### PR TITLE
chore(spans): Remove spansIndexed from events

### DIFF
--- a/src/sentry/snuba/utils.py
+++ b/src/sentry/snuba/utils.py
@@ -11,7 +11,6 @@ from sentry.snuba import (
     metrics_performance,
     ourlogs,
     profiles,
-    spans_indexed,
     spans_metrics,
     spans_rpc,
     transactions,
@@ -34,7 +33,6 @@ DATASET_OPTIONS = {
     "issuePlatform": issue_platform,
     "profileFunctions": functions,
     "spans": spans_rpc,
-    "spansIndexed": spans_indexed,
     "spansMetrics": spans_metrics,
     "transactions": transactions,
 }

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -18,38 +18,13 @@ from tests.snuba.api.endpoints.test_organization_events import OrganizationEvent
 KNOWN_PREFLIGHT_ID = "ca056dd858a24299"
 
 
-class OrganizationEventsSpanIndexedEndpointTest(OrganizationEventsEndpointTestBase):
-    is_eap = False
-    """Test the indexed spans dataset.
-
-    To run this locally you may need to set the ENABLE_SPANS_CONSUMER flag to True in Snuba.
-    A way to do this is
-    1. run: `docker container rm snuba-snuba-1`
-    2. clone snuba locally
-    3. run: `export ENABLE_SPANS_CONSUMER=True`
-    4. run snuba
-    At this point tests should work locally
-
-    Once span ingestion is on by default this will no longer need to be done
-    """
-
-    @property
-    def dataset(self):
-        if self.is_eap:
-            return "spans"
-        else:
-            return "spansIndexed"
-
-    def do_request(self, query, features=None, **kwargs):
-        return super().do_request(query, features, **kwargs)
-
+class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsEndpointTestBase):
     def setUp(self):
         super().setUp()
         self.features = {
             "organizations:starfish-view": True,
         }
 
-    @pytest.mark.querybuilder
     def test_simple(self):
         self.store_spans(
             [
@@ -65,7 +40,7 @@ class OrganizationEventsSpanIndexedEndpointTest(OrganizationEventsEndpointTestBa
                     start_ts=self.ten_mins_ago,
                 ),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
         response = self.do_request(
             {
@@ -73,1323 +48,7 @@ class OrganizationEventsSpanIndexedEndpointTest(OrganizationEventsEndpointTestBa
                 "query": "",
                 "orderby": "description",
                 "project": self.project.id,
-                "dataset": self.dataset,
-            }
-        )
-
-        assert response.status_code == 200, response.content
-        data = response.data["data"]
-        meta = response.data["meta"]
-        assert len(data) == 2
-        assert data == [
-            {
-                "span.status": "invalid_argument",
-                "description": "bar",
-                "count()": 1,
-            },
-            {
-                "span.status": "ok",
-                "description": "foo",
-                "count()": 1,
-            },
-        ]
-        assert meta["dataset"] == self.dataset
-
-    def test_spm(self):
-        self.store_spans(
-            [
-                self.create_span(
-                    {"description": "foo", "sentry_tags": {"status": "success"}},
-                    start_ts=self.ten_mins_ago,
-                ),
-            ],
-            is_eap=self.is_eap,
-        )
-        response = self.do_request(
-            {
-                "field": ["description", "spm()"],
-                "query": "",
-                "orderby": "description",
-                "project": self.project.id,
-                "dataset": self.dataset,
-            }
-        )
-
-        assert response.status_code == 200, response.content
-        data = response.data["data"]
-        meta = response.data["meta"]
-        assert len(data) == 1
-        assert data == [
-            {
-                "description": "foo",
-                "spm()": 1 / (90 * 24 * 60),
-            },
-        ]
-        assert meta["dataset"] == self.dataset
-
-    def test_id_fields(self):
-        self.store_spans(
-            [
-                self.create_span(
-                    {"description": "foo", "sentry_tags": {"status": "success"}},
-                    start_ts=self.ten_mins_ago,
-                ),
-                self.create_span(
-                    {
-                        "description": "bar",
-                        "sentry_tags": {"status": "invalid_argument"},
-                    },
-                    start_ts=self.ten_mins_ago,
-                ),
-            ],
-            is_eap=self.is_eap,
-        )
-        response = self.do_request(
-            {
-                "field": ["id", "span_id"],
-                "query": "",
-                "orderby": "id",
-                "project": self.project.id,
-                "dataset": self.dataset,
-            }
-        )
-
-        assert response.status_code == 200, response.content
-        data = response.data["data"]
-        meta = response.data["meta"]
-        assert len(data) == 2
-        for obj in data:
-            assert obj["id"] == obj["span_id"]
-        assert meta["dataset"] == self.dataset
-
-    def test_sentry_tags_vs_tags(self):
-        self.store_spans(
-            [
-                self.create_span(
-                    {"sentry_tags": {"transaction.method": "foo"}},
-                    start_ts=self.ten_mins_ago,
-                ),
-            ],
-            is_eap=self.is_eap,
-        )
-        response = self.do_request(
-            {
-                "field": ["transaction.method", "count()"],
-                "query": "",
-                "orderby": "count()",
-                "project": self.project.id,
-                "dataset": self.dataset,
-            }
-        )
-
-        assert response.status_code == 200, response.content
-        data = response.data["data"]
-        meta = response.data["meta"]
-        assert len(data) == 1
-        assert data[0]["transaction.method"] == "foo"
-        assert meta["dataset"] == self.dataset
-
-    def test_sentry_tags_syntax(self):
-        self.store_spans(
-            [
-                self.create_span(
-                    {"sentry_tags": {"transaction.method": "foo"}},
-                    start_ts=self.ten_mins_ago,
-                ),
-            ],
-            is_eap=self.is_eap,
-        )
-        response = self.do_request(
-            {
-                "field": ["sentry_tags[transaction.method]", "count()"],
-                "query": "",
-                "orderby": "count()",
-                "project": self.project.id,
-                "dataset": self.dataset,
-            }
-        )
-
-        assert response.status_code == 200, response.content
-        data = response.data["data"]
-        meta = response.data["meta"]
-        assert len(data) == 1
-        assert data[0]["sentry_tags[transaction.method]"] == "foo"
-        assert meta["dataset"] == self.dataset
-
-    def test_module_alias(self):
-        # Delegates `span.module` to `sentry_tags[category]`. Maps `"db.redis"` spans to the `"cache"` module
-        self.store_spans(
-            [
-                self.create_span(
-                    {
-                        "op": "db.redis",
-                        "description": "EXEC *",
-                        "sentry_tags": {
-                            "description": "EXEC *",
-                            "category": "db",
-                            "op": "db.redis",
-                            "transaction": "/app/index",
-                        },
-                    },
-                    start_ts=self.ten_mins_ago,
-                ),
-            ],
-            is_eap=self.is_eap,
-        )
-
-        response = self.do_request(
-            {
-                "field": ["span.module", "span.description"],
-                "query": "span.module:cache",
-                "project": self.project.id,
-                "dataset": self.dataset,
-            }
-        )
-
-        assert response.status_code == 200, response.content
-        data = response.data["data"]
-        meta = response.data["meta"]
-        assert len(data) == 1
-        assert data[0]["span.module"] == "cache"
-        assert data[0]["span.description"] == "EXEC *"
-        assert meta["dataset"] == self.dataset
-
-    def test_device_class_filter_unknown(self):
-        self.store_spans(
-            [
-                self.create_span({"sentry_tags": {"device.class": ""}}, start_ts=self.ten_mins_ago),
-            ],
-            is_eap=self.is_eap,
-        )
-        response = self.do_request(
-            {
-                "field": ["device.class", "count()"],
-                "query": "device.class:Unknown",
-                "orderby": "count()",
-                "project": self.project.id,
-                "dataset": self.dataset,
-            }
-        )
-
-        assert response.status_code == 200, response.content
-        data = response.data["data"]
-        meta = response.data["meta"]
-        assert len(data) == 1
-        assert data[0]["device.class"] == "Unknown"
-        assert meta["dataset"] == self.dataset
-
-    def test_span_module(self):
-        self.store_spans(
-            [
-                self.create_span(
-                    {
-                        "sentry_tags": {
-                            "op": "http",
-                            "category": "http",
-                        }
-                    },
-                    start_ts=self.ten_mins_ago,
-                ),
-                self.create_span(
-                    {
-                        "sentry_tags": {
-                            "op": "alternative",
-                            "category": "other",
-                        }
-                    },
-                    start_ts=self.ten_mins_ago,
-                ),
-                self.create_span(
-                    {
-                        "sentry_tags": {
-                            "op": "alternative",
-                            "category": "other",
-                        }
-                    },
-                    start_ts=self.ten_mins_ago,
-                ),
-            ],
-            is_eap=self.is_eap,
-        )
-
-        response = self.do_request(
-            {
-                "field": ["span.module", "count()"],
-                "query": "",
-                "orderby": "-count()",
-                "project": self.project.id,
-                "dataset": self.dataset,
-            }
-        )
-
-        assert response.status_code == 200, response.content
-        data = response.data["data"]
-        meta = response.data["meta"]
-        assert len(data) == 2
-        assert data[0]["span.module"] == "other"
-        assert data[1]["span.module"] == "http"
-        assert meta["dataset"] == self.dataset
-
-    def test_network_span(self):
-        self.store_spans(
-            [
-                self.create_span(
-                    {
-                        "sentry_tags": {
-                            "action": "GET",
-                            "category": "http",
-                            "description": "GET https://*.resource.com",
-                            "domain": "*.resource.com",
-                            "op": "http.client",
-                            "status_code": "200",
-                            "transaction": "/api/0/data/",
-                            "transaction.method": "GET",
-                            "transaction.op": "http.server",
-                        }
-                    },
-                    start_ts=self.ten_mins_ago,
-                ),
-            ],
-            is_eap=self.is_eap,
-        )
-
-        response = self.do_request(
-            {
-                "field": ["span.op", "span.status_code"],
-                "query": "span.status_code:200",
-                "project": self.project.id,
-                "dataset": self.dataset,
-            }
-        )
-
-        assert response.status_code == 200, response.content
-        data = response.data["data"]
-        meta = response.data["meta"]
-        assert len(data) == 1
-        assert data[0]["span.op"] == "http.client"
-        assert data[0]["span.status_code"] == "200"
-        assert meta["dataset"] == self.dataset
-
-    def test_other_category_span(self):
-        self.store_spans(
-            [
-                self.create_span(
-                    {
-                        "sentry_tags": {
-                            "action": "GET",
-                            "category": "alternative",
-                            "description": "GET https://*.resource.com",
-                            "domain": "*.resource.com",
-                            "op": "alternative",
-                            "status_code": "200",
-                            "transaction": "/api/0/data/",
-                            "transaction.method": "GET",
-                            "transaction.op": "http.server",
-                        }
-                    },
-                    start_ts=self.ten_mins_ago,
-                ),
-            ],
-            is_eap=self.is_eap,
-        )
-
-        response = self.do_request(
-            {
-                "field": ["span.op", "span.status_code"],
-                "query": "span.module:other span.status_code:200",
-                "project": self.project.id,
-                "dataset": self.dataset,
-            }
-        )
-
-        assert response.status_code == 200, response.content
-        data = response.data["data"]
-        meta = response.data["meta"]
-        assert len(data) == 1
-        assert data[0]["span.op"] == "alternative"
-        assert data[0]["span.status_code"] == "200"
-        assert meta["dataset"] == self.dataset
-
-    def test_inp_span(self):
-        replay_id = uuid.uuid4().hex
-        self.store_spans(
-            [
-                self.create_span(
-                    {
-                        "sentry_tags": {
-                            "replay_id": replay_id,
-                            "browser.name": "Chrome",
-                            "transaction": "/pageloads/",
-                        }
-                    },
-                    start_ts=self.ten_mins_ago,
-                ),
-            ],
-            is_eap=self.is_eap,
-        )
-        response = self.do_request(
-            {
-                "field": ["replay.id", "browser.name", "origin.transaction", "count()"],
-                "query": f"replay.id:{replay_id} AND browser.name:Chrome AND origin.transaction:/pageloads/",
-                "orderby": "count()",
-                "project": self.project.id,
-                "dataset": self.dataset,
-            }
-        )
-
-        assert response.status_code == 200, response.content
-        data = response.data["data"]
-        meta = response.data["meta"]
-        assert len(data) == 1
-        assert data[0]["replay.id"] == replay_id
-        assert data[0]["browser.name"] == "Chrome"
-        assert data[0]["origin.transaction"] == "/pageloads/"
-        assert meta["dataset"] == self.dataset
-
-    def test_id_filtering(self):
-        span = self.create_span({"description": "foo"}, start_ts=self.ten_mins_ago)
-        self.store_span(span, is_eap=self.is_eap)
-        response = self.do_request(
-            {
-                "field": ["description", "count()"],
-                "query": f"id:{span['span_id']}",
-                "orderby": "description",
-                "project": self.project.id,
-                "dataset": self.dataset,
-            }
-        )
-
-        assert response.status_code == 200, response.content
-        data = response.data["data"]
-        meta = response.data["meta"]
-        assert len(data) == 1
-        assert data[0]["description"] == "foo"
-        assert meta["dataset"] == self.dataset
-
-        response = self.do_request(
-            {
-                "field": ["description", "count()"],
-                "query": f"transaction.id:{span['event_id']}",
-                "orderby": "description",
-                "project": self.project.id,
-                "dataset": self.dataset,
-            }
-        )
-
-        assert response.status_code == 200, response.content
-        data = response.data["data"]
-        meta = response.data["meta"]
-        assert len(data) == 1
-        assert data[0]["description"] == "foo"
-        assert meta["dataset"] == self.dataset
-
-    def test_span_op_casing(self):
-        self.store_spans(
-            [
-                self.create_span(
-                    {
-                        "sentry_tags": {
-                            "replay_id": "abc123",
-                            "browser.name": "Chrome",
-                            "transaction": "/pageloads/",
-                            "op": "this is a transaction",
-                        }
-                    },
-                    start_ts=self.ten_mins_ago,
-                ),
-            ],
-            is_eap=self.is_eap,
-        )
-        response = self.do_request(
-            {
-                "field": ["span.op", "count()"],
-                "query": 'span.op:"ThIs Is a TraNSActiON"',
-                "orderby": "count()",
-                "project": self.project.id,
-                "dataset": self.dataset,
-            }
-        )
-
-        assert response.status_code == 200, response.content
-        data = response.data["data"]
-        meta = response.data["meta"]
-        assert len(data) == 1
-        assert data[0]["span.op"] == "this is a transaction"
-        assert meta["dataset"] == self.dataset
-
-    def test_queue_span(self):
-        self.store_spans(
-            [
-                self.create_span(
-                    {
-                        "measurements": {
-                            "messaging.message.body.size": {
-                                "value": 1024,
-                                "unit": "byte",
-                            },
-                            "messaging.message.receive.latency": {
-                                "value": 1000,
-                                "unit": "millisecond",
-                            },
-                            "messaging.message.retry.count": {
-                                "value": 2,
-                                "unit": "none",
-                            },
-                        },
-                        "sentry_tags": {
-                            "transaction": "queue-processor",
-                            "messaging.destination.name": "events",
-                            "messaging.message.id": "abc123",
-                            "trace.status": "ok",
-                        },
-                    },
-                    start_ts=self.ten_mins_ago,
-                ),
-            ],
-            is_eap=self.is_eap,
-        )
-        response = self.do_request(
-            {
-                "field": [
-                    "transaction",
-                    "messaging.destination.name",
-                    "messaging.message.id",
-                    "measurements.messaging.message.receive.latency",
-                    "measurements.messaging.message.body.size",
-                    "measurements.messaging.message.retry.count",
-                    "trace.status",
-                    "count()",
-                ],
-                "query": 'messaging.destination.name:"events"',
-                "orderby": "count()",
-                "project": self.project.id,
-                "dataset": self.dataset,
-            }
-        )
-
-        assert response.status_code == 200, response.content
-        data = response.data["data"]
-        meta = response.data["meta"]
-        assert len(data) == 1
-        assert data[0]["transaction"] == "queue-processor"
-        assert data[0]["messaging.destination.name"] == "events"
-        assert data[0]["messaging.message.id"] == "abc123"
-        assert data[0]["trace.status"] == "ok"
-        assert data[0]["measurements.messaging.message.receive.latency"] == 1000
-        assert data[0]["measurements.messaging.message.body.size"] == 1024
-        assert data[0]["measurements.messaging.message.retry.count"] == 2
-        assert meta["dataset"] == self.dataset
-
-    def test_tag_wildcards(self):
-        self.store_spans(
-            [
-                self.create_span(
-                    {"description": "foo", "tags": {"foo": "BaR"}},
-                    start_ts=self.ten_mins_ago,
-                ),
-                self.create_span(
-                    {"description": "qux", "tags": {"foo": "QuX"}},
-                    start_ts=self.ten_mins_ago,
-                ),
-            ],
-            is_eap=self.is_eap,
-        )
-
-        for query in [
-            "foo:b*",
-            "foo:*r",
-            "foo:*a*",
-            "foo:b*r",
-        ]:
-            response = self.do_request(
-                {
-                    "field": ["foo", "count()"],
-                    "query": query,
-                    "project": self.project.id,
-                    "dataset": self.dataset,
-                }
-            )
-            assert response.status_code == 200, response.content
-            assert response.data["data"] == [{"foo": "BaR", "count()": 1}]
-
-    def test_query_for_missing_tag(self):
-        self.store_spans(
-            [
-                self.create_span(
-                    {"description": "foo"},
-                    start_ts=self.ten_mins_ago,
-                ),
-                self.create_span(
-                    {"description": "qux", "tags": {"foo": "bar"}},
-                    start_ts=self.ten_mins_ago,
-                ),
-            ],
-            is_eap=self.is_eap,
-        )
-
-        response = self.do_request(
-            {
-                "field": ["foo", "count()"],
-                "query": 'foo:""',
-                "project": self.project.id,
-                "dataset": self.dataset,
-            }
-        )
-        assert response.status_code == 200, response.content
-        assert response.data["data"] == [{"foo": "", "count()": 1}]
-
-    def test_count_field_type(self):
-        response = self.do_request(
-            {
-                "field": ["count()"],
-                "project": self.project.id,
-                "dataset": self.dataset,
-            }
-        )
-        assert response.status_code == 200, response.content
-        assert response.data["meta"]["fields"] == {"count()": "integer"}
-        assert response.data["meta"]["units"] == {"count()": None}
-        assert response.data["data"] == [{"count()": 0}]
-
-    def _test_simple_measurements(self, keys):
-        self.store_spans(
-            [
-                self.create_span(
-                    {
-                        "description": "foo",
-                        "sentry_tags": {"status": "success"},
-                        "tags": {"bar": "bar2"},
-                    },
-                    measurements={k: {"value": (i + 1) / 10} for i, (k, _, _) in enumerate(keys)},
-                    start_ts=self.ten_mins_ago,
-                ),
-            ],
-            is_eap=self.is_eap,
-        )
-
-        for i, (k, type, unit) in enumerate(keys):
-            key = f"measurements.{k}"
-            response = self.do_request(
-                {
-                    "field": [key],
-                    "query": "description:foo",
-                    "project": self.project.id,
-                    "dataset": self.dataset,
-                }
-            )
-            assert response.status_code == 200, response.content
-            expected = {
-                "dataScanned": "full",
-                "dataset": mock.ANY,
-                "datasetReason": "unchanged",
-                "fields": {
-                    key: type,
-                    "id": "string",
-                    "project.name": "string",
-                },
-                "isMetricsData": False,
-                "isMetricsExtractedData": False,
-                "tips": {},
-                "units": {
-                    key: unit,
-                    "id": None,
-                    "project.name": None,
-                },
-            }
-            if self.is_eap:
-                expected["accuracy"] = {
-                    "confidence": [{}],
-                }
-            assert response.data["meta"] == expected
-            assert response.data["data"] == [
-                {
-                    key: pytest.approx((i + 1) / 10),
-                    "id": mock.ANY,
-                    "project.name": self.project.slug,
-                }
-            ]
-
-    def test_simple_measurements(self):
-        keys = [
-            ("app_start_cold", "duration", "millisecond"),
-            ("app_start_warm", "duration", "millisecond"),
-            (
-                "frames_frozen",
-                "number",
-                None,
-            ),  # should be integer but keeping it consistent
-            ("frames_frozen_rate", "percentage", None),
-            (
-                "frames_slow",
-                "number",
-                None,
-            ),  # should be integer but keeping it consistent
-            ("frames_slow_rate", "percentage", None),
-            (
-                "frames_total",
-                "number",
-                None,
-            ),  # should be integer but keeping it consistent
-            ("time_to_initial_display", "duration", "millisecond"),
-            ("time_to_full_display", "duration", "millisecond"),
-            (
-                "stall_count",
-                "number",
-                None,
-            ),  # should be integer but keeping it consistent
-            ("stall_percentage", "percentage", None),
-            ("stall_stall_longest_time", "number", None),
-            ("stall_stall_total_time", "number", None),
-            ("cls", "number", None),
-            ("fcp", "duration", "millisecond"),
-            ("fid", "duration", "millisecond"),
-            ("fp", "duration", "millisecond"),
-            ("inp", "duration", "millisecond"),
-            ("lcp", "duration", "millisecond"),
-            ("ttfb", "duration", "millisecond"),
-            ("ttfb.requesttime", "duration", "millisecond"),
-            ("score.cls", "number", None),
-            ("score.fcp", "number", None),
-            ("score.fid", "number", None),
-            ("score.inp", "number", None),
-            ("score.lcp", "number", None),
-            ("score.ttfb", "number", None),
-            ("score.total", "number", None),
-            ("score.weight.cls", "number", None),
-            ("score.weight.fcp", "number", None),
-            ("score.weight.fid", "number", None),
-            ("score.weight.inp", "number", None),
-            ("score.weight.lcp", "number", None),
-            ("score.weight.ttfb", "number", None),
-            ("messaging.message.receive.latency", "duration", "millisecond"),
-            ("messaging.message.retry.count", "number", None),
-            # size fields aren't property support pre-RPC
-            ("cache.item_size", "number", None),
-            ("messaging.message.body.size", "number", None),
-        ]
-
-        self._test_simple_measurements(keys)
-
-    def test_environment(self):
-        self.create_environment(self.project, name="prod")
-        self.create_environment(self.project, name="test")
-        self.store_spans(
-            [
-                self.create_span(
-                    {"description": "foo", "sentry_tags": {"environment": "prod"}},
-                    start_ts=self.ten_mins_ago,
-                ),
-                self.create_span(
-                    {"description": "foo", "sentry_tags": {"environment": "test"}},
-                    start_ts=self.ten_mins_ago,
-                ),
-            ],
-            is_eap=self.is_eap,
-        )
-        response = self.do_request(
-            {
-                "field": ["environment", "count()"],
-                "project": self.project.id,
-                "environment": "prod",
-                "orderby": "environment",
-                "dataset": self.dataset,
-            }
-        )
-        assert response.status_code == 200, response.content
-        assert response.data["data"] == [
-            {"environment": "prod", "count()": 1},
-        ]
-
-        response = self.do_request(
-            {
-                "field": ["environment", "count()"],
-                "project": self.project.id,
-                "environment": ["prod", "test"],
-                "orderby": "environment",
-                "dataset": self.dataset,
-            }
-        )
-        assert response.status_code == 200, response.content
-        assert response.data["data"] == [
-            {"environment": "prod", "count()": 1},
-            {"environment": "test", "count()": 1},
-        ]
-
-    def test_transaction(self):
-        self.store_spans(
-            [
-                self.create_span(
-                    {"description": "foo", "sentry_tags": {"transaction": "bar"}},
-                    start_ts=self.ten_mins_ago,
-                ),
-            ],
-            is_eap=self.is_eap,
-        )
-        response = self.do_request(
-            {
-                "field": ["description", "count()"],
-                "query": "transaction:bar",
-                "orderby": "description",
-                "project": self.project.id,
-                "dataset": self.dataset,
-            }
-        )
-
-        assert response.status_code == 200, response.content
-        data = response.data["data"]
-        meta = response.data["meta"]
-        assert len(data) == 1
-        assert data == [
-            {
-                "description": "foo",
-                "count()": 1,
-            },
-        ]
-        assert meta["dataset"] == self.dataset
-
-    def test_orderby_alias(self):
-        self.store_spans(
-            [
-                self.create_span(
-                    {"description": "foo", "sentry_tags": {"status": "success"}},
-                    start_ts=self.ten_mins_ago,
-                ),
-                self.create_span(
-                    {
-                        "description": "bar",
-                        "sentry_tags": {"status": "invalid_argument"},
-                    },
-                    duration=2000,
-                    start_ts=self.ten_mins_ago,
-                ),
-            ],
-            is_eap=self.is_eap,
-        )
-        response = self.do_request(
-            {
-                "field": ["span.description", "sum(span.self_time)"],
-                "query": "",
-                "orderby": "sum_span_self_time",
-                "project": self.project.id,
-                "dataset": self.dataset,
-            }
-        )
-        assert response.status_code == 200, response.content
-        data = response.data["data"]
-        meta = response.data["meta"]
-        assert len(data) == 2
-        assert data == [
-            {
-                "span.description": "foo",
-                "sum(span.self_time)": 1000,
-            },
-            {
-                "span.description": "bar",
-                "sum(span.self_time)": 2000,
-            },
-        ]
-        assert meta["dataset"] == self.dataset
-
-    @pytest.mark.querybuilder
-    def test_explore_sample_query(self):
-        spans = [
-            self.create_span(
-                {"description": "foo", "sentry_tags": {"status": "success"}},
-                start_ts=self.ten_mins_ago,
-            ),
-            self.create_span(
-                {"description": "bar", "sentry_tags": {"status": "invalid_argument"}},
-                start_ts=self.nine_mins_ago,
-            ),
-        ]
-        self.store_spans(
-            spans,
-            is_eap=self.is_eap,
-        )
-        response = self.do_request(
-            {
-                "field": [
-                    "id",
-                    "project",
-                    "span.op",
-                    "span.description",
-                    "span.duration",
-                    "timestamp",
-                    "trace",
-                    "transaction.span_id",
-                ],
-                "orderby": "timestamp",
-                "statsPeriod": "1h",
-                "project": self.project.id,
-                "dataset": self.dataset,
-            }
-        )
-        assert response.status_code == 200, response.content
-        data = response.data["data"]
-        meta = response.data["meta"]
-        assert len(data) == 2
-        for source, result in zip(spans, data):
-            assert result["id"] == source["span_id"], "id"
-            assert result["span.duration"] == 1000.0, "duration"
-            assert result["span.op"] == "", "op"
-            assert result["span.description"] == source["description"], "description"
-            ts = datetime.fromisoformat(result["timestamp"])
-            assert ts.tzinfo == timezone.utc
-            assert ts.timestamp() == pytest.approx(
-                source["end_timestamp_precise"], abs=5
-            ), "timestamp"
-            assert result["transaction.span_id"] == source["segment_id"], "transaction.span_id"
-            assert result["project"] == result["project.name"] == self.project.slug, "project"
-        assert meta["dataset"] == self.dataset
-
-    def test_span_status(self):
-        self.store_spans(
-            [
-                self.create_span(
-                    {"description": "foo", "sentry_tags": {"status": "internal_error"}},
-                    start_ts=self.ten_mins_ago,
-                ),
-            ],
-            is_eap=self.is_eap,
-        )
-        response = self.do_request(
-            {
-                "field": ["description", "count()"],
-                "query": "span.status:internal_error",
-                "orderby": "description",
-                "project": self.project.id,
-                "dataset": self.dataset,
-            }
-        )
-
-        assert response.status_code == 200, response.content
-        data = response.data["data"]
-        meta = response.data["meta"]
-        assert len(data) == 1
-        assert data == [
-            {
-                "description": "foo",
-                "count()": 1,
-            },
-        ]
-        assert meta["dataset"] == self.dataset
-
-    def test_handle_nans_from_snuba(self):
-        self.store_spans(
-            [self.create_span({"description": "foo"}, start_ts=self.ten_mins_ago)],
-            is_eap=self.is_eap,
-        )
-
-        response = self.do_request(
-            {
-                "field": ["description", "count()"],
-                "query": "span.status:internal_error",
-                "orderby": "description",
-                "project": self.project.id,
-                "dataset": self.dataset,
-            }
-        )
-        assert response.status_code == 200, response.content
-
-    def test_in_filter(self):
-        self.store_spans(
-            [
-                self.create_span(
-                    {"description": "foo", "sentry_tags": {"transaction": "bar"}},
-                    start_ts=self.ten_mins_ago,
-                ),
-                self.create_span(
-                    {"description": "foo", "sentry_tags": {"transaction": "baz"}},
-                    start_ts=self.ten_mins_ago,
-                ),
-                self.create_span(
-                    {"description": "foo", "sentry_tags": {"transaction": "bat"}},
-                    start_ts=self.ten_mins_ago,
-                ),
-            ],
-            is_eap=self.is_eap,
-        )
-        response = self.do_request(
-            {
-                "field": ["transaction", "count()"],
-                "query": "transaction:[bar, baz]",
-                "orderby": "transaction",
-                "project": self.project.id,
-                "dataset": self.dataset,
-            }
-        )
-
-        assert response.status_code == 200, response.content
-        data = response.data["data"]
-        meta = response.data["meta"]
-        assert len(data) == 2
-        assert data == [
-            {
-                "transaction": "bar",
-                "count()": 1,
-            },
-            {
-                "transaction": "baz",
-                "count()": 1,
-            },
-        ]
-        assert meta["dataset"] == self.dataset
-
-    def _test_aggregate_filter(self, queries):
-        self.store_spans(
-            [
-                self.create_span(
-                    {"sentry_tags": {"transaction": "foo"}},
-                    measurements={
-                        "lcp": {"value": 5000},
-                        "http.response_content_length": {"value": 5000},
-                    },
-                    start_ts=self.ten_mins_ago,
-                ),
-                self.create_span(
-                    {"sentry_tags": {"transaction": "foo"}},
-                    measurements={
-                        "lcp": {"value": 5000},
-                        "http.response_content_length": {"value": 5000},
-                    },
-                    start_ts=self.ten_mins_ago,
-                ),
-                self.create_span(
-                    {"sentry_tags": {"transaction": "bar"}},
-                    measurements={
-                        "lcp": {"value": 1000},
-                        "http.response_content_length": {"value": 1000},
-                    },
-                    start_ts=self.ten_mins_ago,
-                ),
-            ],
-            is_eap=self.is_eap,
-        )
-
-        for query in queries:
-            response = self.do_request(
-                {
-                    "field": ["transaction", "count()"],
-                    "query": query,
-                    "orderby": "transaction",
-                    "project": self.project.id,
-                    "dataset": self.dataset,
-                }
-            )
-            assert response.status_code == 200, response.content
-            data = response.data["data"]
-            meta = response.data["meta"]
-            assert len(data) == 1
-            assert data[0]["transaction"] == "foo"
-            assert data[0]["count()"] == 2
-            assert meta["dataset"] == self.dataset
-
-    def test_aggregate_filter(self):
-        self._test_aggregate_filter(
-            [
-                "count():2",
-                "count():>1",
-                "avg(measurements.lcp):>3000",
-                "avg(measurements.lcp):>3s",
-                "count():>1 avg(measurements.lcp):>3000",
-                "count():>1 AND avg(measurements.lcp):>3000",
-                "count():>1 OR avg(measurements.lcp):>3000",
-            ]
-        )
-
-    def test_pagination_samples(self):
-        self.store_spans(
-            [
-                self.create_span(
-                    {"description": "a"},
-                    start_ts=self.ten_mins_ago,
-                ),
-                self.create_span(
-                    {"description": "b"},
-                    start_ts=self.ten_mins_ago,
-                ),
-            ],
-            is_eap=self.is_eap,
-        )
-        response = self.do_request(
-            {
-                "field": ["description"],
-                "query": "",
-                "orderby": "description",
-                "project": self.project.id,
-                "dataset": self.dataset,
-                "per_page": 1,
-            }
-        )
-        assert response.status_code == 200, response.content
-        assert response.data["data"] == [
-            {
-                "id": mock.ANY,
-                "project.name": self.project.slug,
-                "description": "a",
-            },
-        ]
-
-        links = {}
-        for url, attrs in parse_link_header(response["Link"]).items():
-            links[attrs["rel"]] = attrs
-            attrs["href"] = url
-
-        assert links["previous"]["results"] == "false"
-        assert links["next"]["results"] == "true"
-
-        assert links["next"]["href"] is not None
-        response = self.client.get(links["next"]["href"], format="json")
-        assert response.status_code == 200, response.content
-        assert response.data["data"] == [
-            {
-                "id": mock.ANY,
-                "project.name": self.project.slug,
-                "description": "b",
-            },
-        ]
-
-        links = {}
-        for url, attrs in parse_link_header(response["Link"]).items():
-            links[attrs["rel"]] = attrs
-            attrs["href"] = url
-
-        assert links["previous"]["results"] == "true"
-        assert links["next"]["results"] == "false"
-
-        assert links["previous"]["href"] is not None
-        response = self.client.get(links["previous"]["href"], format="json")
-        assert response.status_code == 200, response.content
-        assert response.data["data"] == [
-            {
-                "id": mock.ANY,
-                "project.name": self.project.slug,
-                "description": "a",
-            },
-        ]
-
-        links = {}
-        for url, attrs in parse_link_header(response["Link"]).items():
-            links[attrs["rel"]] = attrs
-            attrs["href"] = url
-
-        assert links["previous"]["results"] == "false"
-        assert links["next"]["results"] == "true"
-
-    def test_precise_timestamps(self):
-        self.store_spans(
-            [
-                self.create_span(
-                    {"description": "foo", "sentry_tags": {"status": "success"}},
-                    start_ts=self.ten_mins_ago,
-                ),
-            ],
-            is_eap=self.is_eap,
-        )
-        response = self.do_request(
-            {
-                "field": ["precise.start_ts", "precise.finish_ts"],
-                "project": self.project.id,
-                "dataset": self.dataset,
-                "statsPeriod": "1h",
-            }
-        )
-        start = self.ten_mins_ago.timestamp()
-        finish = start + 1
-        assert response.status_code == 200, response.content
-        assert response.data["data"] == [
-            {
-                "id": mock.ANY,
-                "project.name": self.project.slug,
-                "precise.start_ts": start,
-                "precise.finish_ts": finish,
-            },
-        ]
-
-    def test_replay_id(self):
-        self.store_spans(
-            [
-                self.create_span(
-                    {"description": "foo", "sentry_tags": {"replay_id": "123"}},
-                    start_ts=self.ten_mins_ago,
-                ),
-                self.create_span(
-                    {"description": "foo", "tags": {"replayId": "321"}},
-                    start_ts=self.ten_mins_ago,
-                ),
-            ],
-            is_eap=self.is_eap,
-        )
-        response = self.do_request(
-            {
-                "field": ["replay"],
-                "project": self.project.id,
-                "dataset": self.dataset,
-                "orderby": "replay",
-            }
-        )
-        assert response.status_code == 200, response.content
-        assert response.data["data"] == [
-            {
-                "id": mock.ANY,
-                "project.name": self.project.slug,
-                "replay": "123",
-            },
-            {
-                "id": mock.ANY,
-                "project.name": self.project.slug,
-                "replay": "321",
-            },
-        ]
-
-    def test_user_display(self):
-        self.store_spans(
-            [
-                self.create_span(
-                    {
-                        "description": "foo",
-                        "sentry_tags": {"user.email": "test@test.com"},
-                    },
-                    start_ts=self.ten_mins_ago,
-                ),
-                self.create_span(
-                    {"description": "foo", "sentry_tags": {"user.username": "test"}},
-                    start_ts=self.ten_mins_ago,
-                ),
-            ],
-            is_eap=self.is_eap,
-        )
-        response = self.do_request(
-            {
-                "field": ["user.display"],
-                "project": self.project.id,
-                "dataset": self.dataset,
-                "orderby": "user.display",
-            }
-        )
-        assert response.status_code == 200, response.content
-        assert response.data["data"] == [
-            {
-                "id": mock.ANY,
-                "project.name": self.project.slug,
-                "user.display": "test",
-            },
-            {
-                "id": mock.ANY,
-                "project.name": self.project.slug,
-                "user.display": "test@test.com",
-            },
-        ]
-
-    def test_query_with_asterisk(self):
-        self.store_spans(
-            [
-                self.create_span(
-                    {"description": "select * from database"},
-                    start_ts=self.ten_mins_ago,
-                ),
-            ],
-            is_eap=self.is_eap,
-        )
-        response = self.do_request(
-            {
-                "field": ["span.description"],
-                "query": 'span.description:"select \\* from database"',
-                "project": self.project.id,
-                "dataset": self.dataset,
-            }
-        )
-        assert response.status_code == 200, response.content
-        assert len(response.data["data"]) == 1
-        assert response.data["data"][0]["span.description"] == "select * from database"
-
-    def test_wildcard_queries_with_asterisk_literals(self):
-        self.store_spans(
-            [
-                self.create_span(
-                    {"description": "select * from database"},
-                    start_ts=self.ten_mins_ago,
-                ),
-            ],
-            is_eap=self.is_eap,
-        )
-        response = self.do_request(
-            {
-                "field": ["span.description"],
-                "query": 'span.description:"select \\* * database"',
-                "project": self.project.id,
-                "dataset": self.dataset,
-            }
-        )
-        assert response.status_code == 200, response.content
-        assert len(response.data["data"]) == 1
-        assert response.data["data"][0]["span.description"] == "select * from database"
-
-    def test_free_text_wildcard_filter(self):
-        spans = [
-            self.create_span(
-                {
-                    "description": "barbarbar",
-                    "sentry_tags": {"status": "invalid_argument"},
-                },
-                start_ts=self.ten_mins_ago,
-            ),
-            self.create_span(
-                {"description": "foofoofoo", "sentry_tags": {"status": "success"}},
-                start_ts=self.ten_mins_ago,
-            ),
-        ]
-        self.store_spans(spans, is_eap=self.is_eap)
-        response = self.do_request(
-            {
-                "field": ["count()", "description"],
-                "query": "oof",
-                "orderby": "-count()",
-                "project": self.project.id,
-                "dataset": self.dataset,
-            }
-        )
-
-        assert response.status_code == 200, response.content
-        data = response.data["data"]
-        meta = response.data["meta"]
-        assert len(data) == 1
-        assert data == [
-            {
-                "count()": 1,
-                "description": "foofoofoo",
-            },
-        ]
-        assert meta["dataset"] == self.dataset
-
-
-class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndpointTest):
-    is_eap = True
-
-    def test_simple(self):
-        self.store_spans(
-            [
-                self.create_span(
-                    {"description": "foo", "sentry_tags": {"status": "success"}},
-                    start_ts=self.ten_mins_ago,
-                ),
-                self.create_span(
-                    {
-                        "description": "bar",
-                        "sentry_tags": {"status": "invalid_argument"},
-                    },
-                    start_ts=self.ten_mins_ago,
-                ),
-            ],
-            is_eap=self.is_eap,
-        )
-        response = self.do_request(
-            {
-                "field": ["span.status", "description", "count()"],
-                "query": "",
-                "orderby": "description",
-                "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -1409,11 +68,45 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "count()": 1,
             },
         ]
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
 
     @pytest.mark.xfail(reason="event_id isn't being written to the new table")
     def test_id_filtering(self):
-        super().test_id_filtering()
+        span = self.create_span({"description": "foo"}, start_ts=self.ten_mins_ago)
+        self.store_span(span, is_eap=True)
+        response = self.do_request(
+            {
+                "field": ["description", "count()"],
+                "query": f"id:{span['span_id']}",
+                "orderby": "description",
+                "project": self.project.id,
+                "dataset": "spans",
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert len(data) == 1
+        assert data[0]["description"] == "foo"
+        assert meta["dataset"] == "spans"
+
+        response = self.do_request(
+            {
+                "field": ["description", "count()"],
+                "query": f"transaction.id:{span['event_id']}",
+                "orderby": "description",
+                "project": self.project.id,
+                "dataset": "spans",
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert len(data) == 1
+        assert data[0]["description"] == "foo"
+        assert meta["dataset"] == "spans"
 
     def test_numeric_attr_without_space(self):
         self.store_spans(
@@ -1427,7 +120,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     start_ts=self.ten_mins_ago,
                 ),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
 
         response = self.do_request(
@@ -1439,7 +132,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "query": "",
                 "orderby": "description",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -1468,7 +161,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     start_ts=self.ten_mins_ago,
                 ),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
 
         response = self.do_request(
@@ -1482,7 +175,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "query": "",
                 "orderby": "description",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -1510,7 +203,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     start_ts=self.ten_mins_ago,
                 ),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
 
         response = self.do_request(
@@ -1522,7 +215,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "query": "",
                 "orderby": "description",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -1551,7 +244,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     start_ts=self.ten_mins_ago,
                 ),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
 
         response = self.do_request(
@@ -1560,7 +253,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "query": "tags[foo,number]:5",
                 "orderby": "description",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -1577,7 +270,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "query": "",
                 "orderby": "description",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -1615,7 +308,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     start_ts=self.ten_mins_ago,
                 ),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
 
         response = self.do_request(
@@ -1624,7 +317,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "query": "",
                 "orderby": ["tags[foo,number]"],
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -1649,7 +342,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
         )
         self.store_spans(
             [span_1, span_2],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
         response = self.do_request(
             {
@@ -1657,7 +350,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "query": "description:foo count():>1",
                 "orderby": "description",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
                 "allowAggregateConditions": "0",
             }
         )
@@ -1673,7 +366,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "id": span_1["span_id"],
             },
         ]
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
 
     def test_span_data_fields_http_resource(self):
         self.store_spans(
@@ -1691,7 +384,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     start_ts=self.ten_mins_ago,
                 ),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
 
         response = self.do_request(
@@ -1703,7 +396,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 ],
                 "query": "http.decoded_response_content_length:>0 http.response_content_length:>0 http.response_transfer_size:>0",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
                 "allowAggregateConditions": "0",
             }
         )
@@ -1739,7 +432,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "project.name": None,
             },
         }
-        if self.is_eap:
+        if True:
             expected["accuracy"] = {
                 "confidence": [{}],
             }
@@ -1756,14 +449,14 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
             measurements={"foo": {"value": 10}},
             start_ts=self.ten_mins_ago,
         )
-        self.store_spans([span_1, span_2], is_eap=self.is_eap)
+        self.store_spans([span_1, span_2], is_eap=True)
 
         response = self.do_request(
             {
                 "field": ["tags[foo,number]"],
                 "query": "span.duration:>=0 tags[foo,number]:>20",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -1801,7 +494,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "query": "",
                 "orderby": "description",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -1830,14 +523,14 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 start_ts=self.ten_mins_ago,
             )
         )
-        self.store_spans(spans, is_eap=self.is_eap)
+        self.store_spans(spans, is_eap=True)
         response = self.do_request(
             {
                 "field": ["description", "count()"],
                 "orderby": "-count()",
                 "query": "",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -1863,14 +556,14 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 start_ts=self.ten_mins_ago,
             ),
         ]
-        self.store_spans(spans, is_eap=self.is_eap)
+        self.store_spans(spans, is_eap=True)
         response = self.do_request(
             {
                 "field": ["span.duration", "description"],
                 "query": "",
                 "orderby": "description",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -1892,7 +585,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "id": spans[1]["span_id"],
             },
         ]
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
 
     def test_aggregate_numeric_attr(self):
         self.store_spans(
@@ -1915,7 +608,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     start_ts=self.ten_mins_ago,
                 ),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
 
         response = self.do_request(
@@ -1941,7 +634,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "query": "",
                 "orderby": "description",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -1969,13 +662,97 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
 
     @pytest.mark.skip(reason="module not migrated over")
     def test_module_alias(self):
-        super().test_module_alias()
+        # Delegates `span.module` to `sentry_tags[category]`. Maps `"db.redis"` spans to the `"cache"` module
+        self.store_spans(
+            [
+                self.create_span(
+                    {
+                        "op": "db.redis",
+                        "description": "EXEC *",
+                        "sentry_tags": {
+                            "description": "EXEC *",
+                            "category": "db",
+                            "op": "db.redis",
+                            "transaction": "/app/index",
+                        },
+                    },
+                    start_ts=self.ten_mins_ago,
+                ),
+            ],
+            is_eap=True,
+        )
+
+        response = self.do_request(
+            {
+                "field": ["span.module", "span.description"],
+                "query": "span.module:cache",
+                "project": self.project.id,
+                "dataset": "spans",
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert len(data) == 1
+        assert data[0]["span.module"] == "cache"
+        assert data[0]["span.description"] == "EXEC *"
+        assert meta["dataset"] == "spans"
 
     @pytest.mark.xfail(
         reason="wip: depends on rpc having a way to set a different default in virtual contexts"
     )
     def test_span_module(self):
-        super().test_span_module()
+        self.store_spans(
+            [
+                self.create_span(
+                    {
+                        "sentry_tags": {
+                            "op": "http",
+                            "category": "http",
+                        }
+                    },
+                    start_ts=self.ten_mins_ago,
+                ),
+                self.create_span(
+                    {
+                        "sentry_tags": {
+                            "op": "alternative",
+                            "category": "other",
+                        }
+                    },
+                    start_ts=self.ten_mins_ago,
+                ),
+                self.create_span(
+                    {
+                        "sentry_tags": {
+                            "op": "alternative",
+                            "category": "other",
+                        }
+                    },
+                    start_ts=self.ten_mins_ago,
+                ),
+            ],
+            is_eap=True,
+        )
+
+        response = self.do_request(
+            {
+                "field": ["span.module", "count()"],
+                "query": "",
+                "orderby": "-count()",
+                "project": self.project.id,
+                "dataset": "spans",
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert len(data) == 2
+        assert data[0]["span.module"] == "other"
+        assert data[1]["span.module"] == "http"
+        assert meta["dataset"] == "spans"
 
     def test_inp_span(self):
         replay_id = uuid.uuid4().hex
@@ -1992,7 +769,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     start_ts=self.ten_mins_ago,
                 ),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
         response = self.do_request(
             {
@@ -2002,7 +779,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "query": f"replay.id:{replay_id} AND browser.name:Chrome AND transaction:/pageloads/",
                 "orderby": "count()",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -2013,21 +790,89 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
         assert data[0]["replay.id"] == replay_id
         assert data[0]["browser.name"] == "Chrome"
         assert data[0]["transaction"] == "/pageloads/"
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
 
     @pytest.mark.xfail(
         reason="wip: depends on rpc having a way to set a different default in virtual contexts"
     )
     # https://github.com/getsentry/projects/issues/215?issue=getsentry%7Cprojects%7C488
     def test_other_category_span(self):
-        super().test_other_category_span()
+        self.store_spans(
+            [
+                self.create_span(
+                    {
+                        "sentry_tags": {
+                            "action": "GET",
+                            "category": "alternative",
+                            "description": "GET https://*.resource.com",
+                            "domain": "*.resource.com",
+                            "op": "alternative",
+                            "status_code": "200",
+                            "transaction": "/api/0/data/",
+                            "transaction.method": "GET",
+                            "transaction.op": "http.server",
+                        }
+                    },
+                    start_ts=self.ten_mins_ago,
+                ),
+            ],
+            is_eap=True,
+        )
+
+        response = self.do_request(
+            {
+                "field": ["span.op", "span.status_code"],
+                "query": "span.module:other span.status_code:200",
+                "project": self.project.id,
+                "dataset": "spans",
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert len(data) == 1
+        assert data[0]["span.op"] == "alternative"
+        assert data[0]["span.status_code"] == "200"
+        assert meta["dataset"] == "spans"
 
     @pytest.mark.xfail(
         reason="wip: not implemented yet, depends on rpc having a way to filter based on casing"
     )
     # https://github.com/getsentry/projects/issues/215?issue=getsentry%7Cprojects%7C489
     def test_span_op_casing(self):
-        super().test_span_op_casing()
+        self.store_spans(
+            [
+                self.create_span(
+                    {
+                        "sentry_tags": {
+                            "replay_id": "abc123",
+                            "browser.name": "Chrome",
+                            "transaction": "/pageloads/",
+                            "op": "this is a transaction",
+                        }
+                    },
+                    start_ts=self.ten_mins_ago,
+                ),
+            ],
+            is_eap=True,
+        )
+        response = self.do_request(
+            {
+                "field": ["span.op", "count()"],
+                "query": 'span.op:"ThIs Is a TraNSActiON"',
+                "orderby": "count()",
+                "project": self.project.id,
+                "dataset": "spans",
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert len(data) == 1
+        assert data[0]["span.op"] == "this is a transaction"
+        assert meta["dataset"] == "spans"
 
     def test_tag_wildcards(self):
         self.store_spans(
@@ -2041,7 +886,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     start_ts=self.ten_mins_ago,
                 ),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
 
         for query in [
@@ -2055,7 +900,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     "field": ["foo", "count()"],
                     "query": query,
                     "project": self.project.id,
-                    "dataset": self.dataset,
+                    "dataset": "spans",
                 }
             )
             assert response.status_code == 200, response.content
@@ -2063,7 +908,36 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
 
     @pytest.mark.xfail(reason="spm is not implemented, as spm will be replaced with spm")
     def test_spm(self):
-        super().test_spm()
+        self.store_spans(
+            [
+                self.create_span(
+                    {"description": "foo", "sentry_tags": {"status": "success"}},
+                    start_ts=self.ten_mins_ago,
+                ),
+            ],
+            is_eap=True,
+        )
+        response = self.do_request(
+            {
+                "field": ["description", "spm()"],
+                "query": "",
+                "orderby": "description",
+                "project": self.project.id,
+                "dataset": "spans",
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert len(data) == 1
+        assert data == [
+            {
+                "description": "foo",
+                "spm()": 1 / (90 * 24 * 60),
+            },
+        ]
+        assert meta["dataset"] == "spans"
 
     def test_epm(self):
         self.store_spans(
@@ -2073,7 +947,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     start_ts=self.ten_mins_ago,
                 ),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
         response = self.do_request(
             {
@@ -2081,7 +955,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "query": "",
                 "orderby": "description",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -2095,7 +969,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "epm()": 1 / (90 * 24 * 60),
             },
         ]
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
         assert meta["units"] == {"description": None, "epm()": "1/minute"}
         assert meta["fields"] == {"description": "string", "epm()": "rate"}
 
@@ -2115,7 +989,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     start_ts=self.ten_mins_ago,
                 ),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
 
         response = self.do_request(
@@ -2124,7 +998,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "query": "",
                 "orderby": "description",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -2141,7 +1015,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "tpm()": segment_span_count / total_time,
             },
         ]
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
         assert meta["units"] == {"description": None, "tpm()": "1/minute"}
         assert meta["fields"] == {"description": "string", "tpm()": "rate"}
 
@@ -2161,7 +1035,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 self.create_span({"is_segment": False}, start_ts=self.ten_mins_ago, duration=5000),
                 self.create_span({"is_segment": False}, start_ts=self.ten_mins_ago, duration=5000),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
 
         response = self.do_request(
@@ -2169,7 +1043,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "field": ["p75_if(span.duration, is_transaction, true)"],
                 "query": "",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -2182,7 +1056,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "p75_if(span.duration, is_transaction, true)": 3000,
             },
         ]
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
         assert meta["units"] == {"p75_if(span.duration, is_transaction, true)": "millisecond"}
         assert meta["fields"] == {"p75_if(span.duration, is_transaction, true)": "duration"}
 
@@ -2206,7 +1080,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     start_ts=self.ten_mins_ago,
                 ),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
         response = self.do_request(
             {
@@ -2214,7 +1088,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "query": "is_transaction:true",
                 "orderby": "description",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -2230,7 +1104,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "count()": 1,
             },
         ]
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
 
     def test_is_not_transaction(self):
         self.store_spans(
@@ -2252,7 +1126,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     start_ts=self.ten_mins_ago,
                 ),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
         response = self.do_request(
             {
@@ -2260,7 +1134,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "query": "is_transaction:0",
                 "orderby": "description",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -2276,7 +1150,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "count()": 1,
             },
         ]
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
 
     def test_byte_fields(self):
         self.store_spans(
@@ -2292,7 +1166,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     start_ts=self.ten_mins_ago,
                 ),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
 
         response = self.do_request(
@@ -2304,7 +1178,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     "measurements.messaging.message.body.size",
                 ],
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -2410,7 +1284,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
         ]
         self.store_spans(
             spans,
-            is_eap=self.is_eap,
+            is_eap=True,
         )
         response = self.do_request(
             {
@@ -2427,7 +1301,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "orderby": "timestamp",
                 "statsPeriod": "1h",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
         assert response.status_code == 200, response.content
@@ -2447,7 +1321,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
             ), "timestamp"
             assert result["transaction.span_id"] == source["segment_id"], "transaction.span_id"
             assert result["project"] == result["project.name"] == self.project.slug, "project"
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
 
     def test_query_for_missing_tag(self):
         self.store_spans(
@@ -2461,7 +1335,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     start_ts=self.ten_mins_ago,
                 ),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
 
         response = self.do_request(
@@ -2469,7 +1343,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "field": ["foo", "count()"],
                 "query": "has:foo",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
         assert response.status_code == 200, response.content
@@ -2487,7 +1361,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     start_ts=self.ten_mins_ago,
                 ),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
 
         response = self.do_request(
@@ -2495,7 +1369,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "field": ["foo", "count()"],
                 "query": "!has:foo",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
         assert response.status_code == 200, response.content
@@ -2509,7 +1383,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
             [
                 self.create_span({"sentry_tags": {"device.class": ""}}, start_ts=self.ten_mins_ago),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
         response = self.do_request(
             {
@@ -2517,7 +1391,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "query": "device.class:Unknown",
                 "orderby": "count()",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -2526,7 +1400,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
         meta = response.data["meta"]
         assert len(data) == 1
         assert data[0]["device.class"] == "Unknown"
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
 
     def test_device_class_column(self):
         self.store_spans(
@@ -2535,7 +1409,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     {"sentry_tags": {"device.class": "1"}}, start_ts=self.ten_mins_ago
                 ),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
         response = self.do_request(
             {
@@ -2543,7 +1417,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "query": "",
                 "orderby": "count()",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -2552,7 +1426,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
         meta = response.data["meta"]
         assert len(data) == 1
         assert data[0]["device.class"] == "low"
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
 
     def test_http_response_count(self):
         self.store_spans(
@@ -2561,7 +1435,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     {"sentry_tags": {"status_code": "500"}}, start_ts=self.ten_mins_ago
                 ),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
         self.store_spans(
             [
@@ -2569,7 +1443,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     {"sentry_tags": {"status_code": "500"}}, start_ts=self.ten_mins_ago
                 ),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
         self.store_spans(
             [
@@ -2577,7 +1451,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     {"sentry_tags": {"status_code": "404"}}, start_ts=self.ten_mins_ago
                 ),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
         self.store_spans(
             [
@@ -2585,7 +1459,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     {"sentry_tags": {"status_code": "200"}}, start_ts=self.ten_mins_ago
                 ),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
         response = self.do_request(
             {
@@ -2595,7 +1469,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     "http_response_count(2)",
                 ],
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -2606,7 +1480,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
         assert data[0]["http_response_count(5)"] == 2
         assert data[0]["http_response_count(4)"] == 1
         assert data[0]["http_response_count(2)"] == 1
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
 
     def test_http_response_rate(self):
         self.store_spans(
@@ -2615,7 +1489,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     {"sentry_tags": {"status_code": "500"}}, start_ts=self.ten_mins_ago
                 ),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
         self.store_spans(
             [
@@ -2623,7 +1497,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     {"sentry_tags": {"status_code": "500"}}, start_ts=self.ten_mins_ago
                 ),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
         self.store_spans(
             [
@@ -2631,7 +1505,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     {"sentry_tags": {"status_code": "404"}}, start_ts=self.ten_mins_ago
                 ),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
         self.store_spans(
             [
@@ -2639,7 +1513,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     {"sentry_tags": {"status_code": "200"}}, start_ts=self.ten_mins_ago
                 ),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
         response = self.do_request(
             {
@@ -2649,7 +1523,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     "http_response_rate(2)",
                 ],
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -2660,7 +1534,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
         assert data[0]["http_response_rate(5)"] == 0.5
         assert data[0]["http_response_rate(4)"] == 0.25
         assert data[0]["http_response_rate(2)"] == 0.25
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
         assert meta["fields"] == {
             "http_response_rate(5)": "percentage",
             "http_response_rate(4)": "percentage",
@@ -2677,7 +1551,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
             [
                 self.create_span({"sentry_tags": {}}, start_ts=self.ten_mins_ago),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
         response = self.do_request(
             {
@@ -2685,7 +1559,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     "http_response_rate(5)",
                 ],
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
         assert response.status_code == 200, response.content
@@ -2693,7 +1567,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
         meta = response.data["meta"]
         assert len(data) == 1
         assert data[0]["http_response_rate(5)"] is None
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
 
     def test_http_response_rate_invalid_param(self):
         self.store_spans(
@@ -2702,7 +1576,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     {"sentry_tags": {"status_code": "500"}}, start_ts=self.ten_mins_ago
                 ),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
         response = self.do_request(
             {
@@ -2710,7 +1584,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     "http_response_rate(a)",
                 ],
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -2731,7 +1605,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     start_ts=self.ten_mins_ago,
                 ),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
         self.store_spans(
             [
@@ -2743,7 +1617,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     start_ts=self.ten_mins_ago,
                 ),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
         self.store_spans(
             [
@@ -2755,7 +1629,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     start_ts=self.ten_mins_ago,
                 ),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
         self.store_spans(
             [
@@ -2767,13 +1641,13 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     start_ts=self.ten_mins_ago,
                 ),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
         response = self.do_request(
             {
                 "field": ["http_response_rate(5)", "description"],
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
                 "orderby": "description",
             }
         )
@@ -2786,7 +1660,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
         assert data[0]["description"] == "description 1"
         assert data[1]["http_response_rate(5)"] == 1.0
         assert data[1]["description"] == "description 2"
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
 
     def test_cache_miss_rate(self):
         self.store_spans(
@@ -2816,14 +1690,14 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     start_ts=self.ten_mins_ago,
                 ),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
 
         response = self.do_request(
             {
                 "field": ["cache_miss_rate()"],
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -2832,7 +1706,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
         meta = response.data["meta"]
         assert len(data) == 1
         assert data[0]["cache_miss_rate()"] == 0.25
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
 
     def test_cache_hit(self):
         self.store_spans(
@@ -2852,14 +1726,14 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     start_ts=self.ten_mins_ago,
                 ),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
 
         response = self.do_request(
             {
                 "field": ["cache.hit", "description"],
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
                 "orderby": "description",
             }
         )
@@ -2870,7 +1744,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
         assert len(data) == 2
         assert data[0]["cache.hit"] is False
         assert data[1]["cache.hit"] is True
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
 
     def test_searchable_contexts(self):
         self.store_spans(
@@ -2884,14 +1758,14 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     start_ts=self.ten_mins_ago,
                 ),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
 
         response = self.do_request(
             {
                 "field": ["device.model", "request.url"],
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
                 "orderby": "device.model",
             }
         )
@@ -2902,7 +1776,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
         assert len(data) == 2
         assert data[0]["device.model"] == "Apple"
         assert data[1]["request.url"] == "https://sentry/api/0/foo"
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
 
     def test_trace_status_rate(self):
         statuses = ["unknown", "internal_error", "unauthenticated", "ok", "ok"]
@@ -2914,7 +1788,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 )
                 for status in statuses
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
 
         response = self.do_request(
@@ -2926,7 +1800,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     "trace_status_rate(unauthenticated)",
                 ],
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -2940,7 +1814,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
         assert data[0]["trace_status_rate(internal_error)"] == 0.2
         assert data[0]["trace_status_rate(unauthenticated)"] == 0.2
 
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
 
     def test_failure_rate(self):
         trace_statuses = ["ok", "cancelled", "unknown", "failure"]
@@ -2952,14 +1826,14 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 )
                 for status in trace_statuses
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
 
         response = self.do_request(
             {
                 "field": ["failure_rate()"],
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -2968,7 +1842,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
         meta = response.data["meta"]
         assert len(data) == 1
         assert data[0]["failure_rate()"] == 0.25
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
 
     def test_failure_rate_if(self):
         trace_statuses = ["ok", "cancelled", "unknown", "failure"]
@@ -2994,13 +1868,13 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
             )
         )
 
-        self.store_spans(spans, is_eap=self.is_eap)
+        self.store_spans(spans, is_eap=True)
 
         response = self.do_request(
             {
                 "field": ["failure_rate_if(is_transaction, true)"],
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -3009,7 +1883,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
         meta = response.data["meta"]
         assert len(data) == 1
         assert data[0]["failure_rate_if(is_transaction, true)"] == 0.25
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
         assert meta["fields"] == {
             "failure_rate_if(is_transaction, true)": "percentage",
         }
@@ -3033,7 +1907,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     start_ts=self.ten_mins_ago,
                 ),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
 
         response = self.do_request(
@@ -3043,7 +1917,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     "count_op(queue.publish)",
                 ],
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -3055,7 +1929,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
         assert data[0]["count_op(queue.process)"] == 2
         assert data[0]["count_op(queue.publish)"] == 1
 
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
 
     def test_avg_if(self):
         self.store_spans(
@@ -3076,7 +1950,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     start_ts=self.ten_mins_ago,
                 ),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
 
         response = self.do_request(
@@ -3086,7 +1960,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     "avg_if(span.duration, span.op, queue.publish)",
                 ],
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -3096,7 +1970,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
         assert len(data) == 1
         assert data[0]["avg_if(span.duration, span.op, queue.process)"] == 1500.0
         assert data[0]["avg_if(span.duration, span.op, queue.publish)"] == 3000.0
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
 
     def test_avg_compare(self):
         self.store_spans(
@@ -3112,14 +1986,14 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     start_ts=self.ten_mins_ago,
                 ),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
 
         response = self.do_request(
             {
                 "field": ["avg_compare(span.self_time, release, foo, bar)"],
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -3128,7 +2002,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
         meta = response.data["meta"]
         assert len(data) == 1
         assert data[0]["avg_compare(span.self_time, release, foo, bar)"] == -0.9
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
         assert meta["fields"] == {
             "avg_compare(span.self_time, release, foo, bar)": "percentage",
         }
@@ -3153,7 +2027,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     "avg_if(span.duration, span.duration, queue.process)",
                 ],
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -3170,7 +2044,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     "count_if(span.description, equals, queue.process)",
                 ],
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -3203,7 +2077,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
             ]
         )
 
-        self.store_spans(spans, is_eap=self.is_eap)
+        self.store_spans(spans, is_eap=True)
 
         response = self.do_request(
             {
@@ -3212,7 +2086,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     "ttfd_contribution_rate()",
                 ],
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -3223,7 +2097,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
         assert len(data) == 1
         assert data[0]["ttid_contribution_rate()"] == 0.8
         assert data[0]["ttfd_contribution_rate()"] == 0.9
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
 
     def test_count_scores(self):
         self.store_spans(
@@ -3254,7 +2128,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     start_ts=self.ten_mins_ago,
                 ),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
 
         response = self.do_request(
@@ -3264,7 +2138,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     "count_scores(measurements.score.total)",
                 ],
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -3274,7 +2148,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
         assert len(data) == 1
         assert data[0]["count_scores(measurements.score.lcp)"] == 1
         assert data[0]["count_scores(measurements.score.total)"] == 3
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
 
     def test_count_scores_filter(self):
         self.store_spans(
@@ -3310,7 +2184,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     start_ts=self.ten_mins_ago,
                 ),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
 
         response = self.do_request(
@@ -3318,7 +2192,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "field": ["count_scores(measurements.score.lcp)", "transaction"],
                 "query": "count_scores(measurements.score.lcp):>1",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -3328,7 +2202,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
         assert len(data) == 1
         assert data[0]["count_scores(measurements.score.lcp)"] == 2
         assert data[0]["transaction"] == "foo_transaction"
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
 
     def test_time_spent_percentage(self):
         spans = []
@@ -3339,7 +2213,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
         spans.append(
             self.create_span({"sentry_tags": {"transaction": "bar_transaction"}}, duration=1)
         )
-        self.store_spans(spans, is_eap=self.is_eap)
+        self.store_spans(spans, is_eap=True)
 
         response = self.do_request(
             {
@@ -3347,7 +2221,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "query": "",
                 "orderby": ["-time_spent_percentage()"],
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -3359,7 +2233,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
         assert data[0]["transaction"] == "foo_transaction"
         assert data[1]["time_spent_percentage()"] == 0.2
         assert data[1]["transaction"] == "bar_transaction"
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
 
     def test_performance_score(self):
         self.store_spans(
@@ -3389,7 +2263,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     start_ts=self.ten_mins_ago,
                 ),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
 
         response = self.do_request(
@@ -3398,7 +2272,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     "performance_score(measurements.score.lcp)",
                 ],
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -3407,7 +2281,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
         meta = response.data["meta"]
         assert len(data) == 1
         assert data[0]["performance_score(measurements.score.lcp)"] == 0.06
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
 
     def test_division_if(self):
         self.store_spans(
@@ -3443,7 +2317,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     "division_if(mobile.slow_frames,mobile.total_frames,browser.name,Firefox)",
                 ],
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -3459,7 +2333,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
             data[0]["division_if(mobile.slow_frames,mobile.total_frames,browser.name,Firefox)"]
             == 50 / 100
         )
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
         assert meta["fields"] == {
             "division_if(mobile.slow_frames,mobile.total_frames,browser.name,Chrome)": "percentage",
             "division_if(mobile.slow_frames,mobile.total_frames,browser.name,Firefox)": "percentage",
@@ -3539,7 +2413,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     "performance_score(measurements.score.total)",
                 ],
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -3554,7 +2428,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
         assert data[0]["performance_score(measurements.score.inp)"] == 0.5
         self.assertAlmostEqual(data[0]["performance_score(measurements.score.total)"], 0.23)
 
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
 
     def test_total_performance_score_missing_vital(self):
         self.store_spans(
@@ -3622,7 +2496,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     "performance_score(measurements.score.total)",
                 ],
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -3637,7 +2511,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
         assert data[0]["performance_score(measurements.score.inp)"] == 0.5
         self.assertAlmostEqual(data[0]["performance_score(measurements.score.total)"], 0.20)
 
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
 
     def test_total_performance_score_multiple_transactions(self):
         self.store_spans(
@@ -3678,7 +2552,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     "opportunity_score(measurements.score.fcp)",
                 ],
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
                 "orderby": "-transaction",
             }
         )
@@ -3708,7 +2582,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
         self.assertAlmostEqual(data[1]["opportunity_score(measurements.score.cls)"], 0.3)
         assert data[1]["opportunity_score(measurements.score.fcp)"] == 0.0
 
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
 
     def test_division(self):
         self.store_spans(
@@ -3733,7 +2607,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     "division(mobile.frozen_frames,mobile.total_frames)",
                 ],
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -3743,7 +2617,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
         assert len(data) == 1
         assert data[0]["division(mobile.slow_frames,mobile.total_frames)"] == 10 / 100
         assert data[0]["division(mobile.frozen_frames,mobile.total_frames)"] == 20 / 100
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
         assert meta["fields"] == {
             "division(mobile.slow_frames,mobile.total_frames)": "percentage",
             "division(mobile.frozen_frames,mobile.total_frames)": "percentage",
@@ -3774,7 +2648,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     "division(mobile.frozen_frames,mobile.total_frames)",
                 ],
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -3785,7 +2659,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
         assert data[0]["division(mobile.slow_frames,mobile.total_frames)"] == 10 / 100
         assert data[0]["division(mobile.frozen_frames,mobile.total_frames)"] == 20 / 100
         assert data[0]["transaction"] == "foo_transaction"
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
 
     def test_opportunity_score_zero_scores(self):
         self.store_spans(
@@ -3830,7 +2704,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     "opportunity_score(measurements.score.fcp)",
                 ],
                 "orderby": "transaction",
-                "dataset": self.dataset,
+                "dataset": "spans",
                 "project": self.project.id,
             }
         )
@@ -3893,7 +2767,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     "opportunity_score(measurements.score.total)",
                 ],
                 "orderby": "transaction",
-                "dataset": self.dataset,
+                "dataset": "spans",
                 "project": self.project.id,
             }
         )
@@ -3951,7 +2825,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     "opportunity_score(measurements.score.total)",
                 ],
                 "orderby": "transaction",
-                "dataset": self.dataset,
+                "dataset": "spans",
                 "project": self.project.id,
             }
         )
@@ -4039,7 +2913,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 ],
                 "query": "browser.name:Chrome",
                 "orderby": "transaction",
-                "dataset": self.dataset,
+                "dataset": "spans",
                 "project": self.project.id,
             }
         )
@@ -4092,7 +2966,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 ],
                 "query": 'transaction.op:foo_transaction span.op:foo_transaction !transaction:"<< unparameterized >>" avg(measurements.score.total):>=0',
                 "orderby": "transaction",
-                "dataset": self.dataset,
+                "dataset": "spans",
                 "project": self.project.id,
             }
         )
@@ -4141,7 +3015,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "field": [
                     "opportunity_score(measurements.score.total)",
                 ],
-                "dataset": self.dataset,
+                "dataset": "spans",
                 "project": self.project.id,
             }
         )
@@ -4184,7 +3058,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     "count_starts(measurements.app_start_cold)",
                 ],
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -4194,15 +3068,84 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
         assert len(data) == 1
         assert data[0]["count_starts(measurements.app_start_warm)"] == 2
         assert data[0]["count_starts(measurements.app_start_cold)"] == 1
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
 
     @pytest.mark.skip(reason="replay id alias not migrated over")
     def test_replay_id(self):
-        super().test_replay_id()
+        self.store_spans(
+            [
+                self.create_span(
+                    {"description": "foo", "sentry_tags": {"replay_id": "123"}},
+                    start_ts=self.ten_mins_ago,
+                ),
+                self.create_span(
+                    {"description": "foo", "tags": {"replayId": "321"}},
+                    start_ts=self.ten_mins_ago,
+                ),
+            ],
+            is_eap=True,
+        )
+        response = self.do_request(
+            {
+                "field": ["replay"],
+                "project": self.project.id,
+                "dataset": "spans",
+                "orderby": "replay",
+            }
+        )
+        assert response.status_code == 200, response.content
+        assert response.data["data"] == [
+            {
+                "id": mock.ANY,
+                "project.name": self.project.slug,
+                "replay": "123",
+            },
+            {
+                "id": mock.ANY,
+                "project.name": self.project.slug,
+                "replay": "321",
+            },
+        ]
 
     @pytest.mark.skip(reason="user display alias not migrated over")
     def test_user_display(self):
-        super().test_user_display()
+        self.store_spans(
+            [
+                self.create_span(
+                    {
+                        "description": "foo",
+                        "sentry_tags": {"user.email": "test@test.com"},
+                    },
+                    start_ts=self.ten_mins_ago,
+                ),
+                self.create_span(
+                    {"description": "foo", "sentry_tags": {"user.username": "test"}},
+                    start_ts=self.ten_mins_ago,
+                ),
+            ],
+            is_eap=True,
+        )
+        response = self.do_request(
+            {
+                "field": ["user.display"],
+                "project": self.project.id,
+                "dataset": "spans",
+                "orderby": "user.display",
+            }
+        )
+        assert response.status_code == 200, response.content
+        assert response.data["data"] == [
+            {
+                "id": mock.ANY,
+                "project.name": self.project.slug,
+                "user.display": "test",
+            },
+            {
+                "id": mock.ANY,
+                "project.name": self.project.slug,
+                "user.display": "test@test.com",
+            },
+        ]
 
     def test_unit_aggregate_filtering(self):
         spans = [
@@ -4215,14 +3158,14 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 start_ts=self.ten_mins_ago,
             ),
         ]
-        self.store_spans(spans, is_eap=self.is_eap)
+        self.store_spans(spans, is_eap=True)
         response = self.do_request(
             {
                 "field": ["avg(span.duration)", "description"],
                 "query": "avg(span.duration):>0.5s",
                 "orderby": "description",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -4240,7 +3183,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "description": "foo",
             },
         ]
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
 
     def test_trace_id_in_filter(self):
         spans = [
@@ -4253,14 +3196,14 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 start_ts=self.ten_mins_ago,
             ),
         ]
-        self.store_spans(spans, is_eap=self.is_eap)
+        self.store_spans(spans, is_eap=True)
         response = self.do_request(
             {
                 "field": ["description"],
                 "query": f"trace:[{'1' * 32}, {'2' * 32}]",
                 "orderby": "description",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -4280,7 +3223,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "project.name": self.project.slug,
             },
         ]
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
 
     def test_filtering_null_numeric_attr(self):
         spans = [
@@ -4298,7 +3241,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 start_ts=self.ten_mins_ago,
             ),
         ]
-        self.store_spans(spans, is_eap=self.is_eap)
+        self.store_spans(spans, is_eap=True)
         response = self.do_request(
             {
                 "field": [
@@ -4309,7 +3252,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "query": "!tags[http.response.status_code,number]:200",
                 "orderby": "description",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -4324,7 +3267,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "count()": 1,
             },
         ]
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
 
     def test_internal_fields(self):
         self.store_spans(
@@ -4338,7 +3281,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     start_ts=self.ten_mins_ago,
                 ),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
         for private_field in [
             "sentry.organization_id",
@@ -4350,7 +3293,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     "query": "",
                     "orderby": private_field,
                     "project": self.project.id,
-                    "dataset": self.dataset,
+                    "dataset": "spans",
                     "statsPeriod": "1h",
                 }
             )
@@ -4364,7 +3307,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
         )
         self.store_spans(
             [span_with_profile, span_without_profile],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
 
         response = self.do_request(
@@ -4373,7 +3316,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "query": "",
                 "orderby": "-timestamp",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
                 "statsPeriod": "1h",
             }
         )
@@ -4399,7 +3342,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "query": "has:profile.id",
                 "orderby": "-timestamp",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
                 "statsPeriod": "1h",
             }
         )
@@ -4430,7 +3373,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
         )
         self.store_spans(
             [span_with_profile, span_without_profile],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
 
         response = self.do_request(
@@ -4439,7 +3382,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "query": "",
                 "orderby": "-timestamp",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
                 "statsPeriod": "1h",
             }
         )
@@ -4469,7 +3412,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "query": "has:profiler.id",
                 "orderby": "-timestamp",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
                 "statsPeriod": "1h",
             }
         )
@@ -4498,14 +3441,14 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
             },
             start_ts=before_now(minutes=10),
         )
-        self.store_spans([span], is_eap=self.is_eap)
+        self.store_spans([span], is_eap=True)
         response = self.do_request(
             {
                 "field": ["sentry.sampling_weight"],
                 "query": "",
                 "orderby": "sentry.sampling_weight",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -4515,7 +3458,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
         assert len(data) == 1
         # Sampling weight is 1 / client_sample_rate
         assert data[0]["sentry.sampling_weight"] == 2.0
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
 
     def test_sampling_factor_does_not_fail(self):
         span = self.create_span(
@@ -4530,14 +3473,14 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
             },
             start_ts=before_now(minutes=10),
         )
-        self.store_spans([span], is_eap=self.is_eap)
+        self.store_spans([span], is_eap=True)
         response = self.do_request(
             {
                 "field": ["sentry.sampling_factor"],
                 "query": "",
                 "orderby": "sentry.sampling_factor",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -4546,7 +3489,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
         meta = response.data["meta"]
         assert len(data) == 1
         assert data[0]["sentry.sampling_factor"] == 0.01
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
 
     def test_is_starred_transaction(self):
         InsightsStarredSegment.objects.create(
@@ -4575,7 +3518,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     start_ts=self.ten_mins_ago,
                 ),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
 
         response = self.do_request(
@@ -4583,7 +3526,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "field": ["is_starred_transaction", "transaction"],
                 "query": "",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
                 "orderby": "-is_starred_transaction",
             }
         )
@@ -4607,7 +3550,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "field": ["count()"],
                 "query": "",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -4629,7 +3572,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     start_ts=self.ten_mins_ago,
                 ),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
         response = self.do_request(
             {
@@ -4637,7 +3580,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "query": '!user.email:""',
                 "orderby": "description",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -4652,7 +3595,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "count()": 1,
             },
         ]
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
 
     def test_empty_string_negation(self):
         self.store_spans(
@@ -4669,7 +3612,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     start_ts=self.ten_mins_ago,
                 ),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
         response = self.do_request(
             {
@@ -4677,7 +3620,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "query": 'user.email:""',
                 "orderby": "description",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -4692,7 +3635,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "count()": 1,
             },
         ]
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
 
     def test_has_parent_span_filter(self):
         spans = [
@@ -4705,14 +3648,14 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 start_ts=self.ten_mins_ago,
             ),
         ]
-        self.store_spans(spans, is_eap=self.is_eap)
+        self.store_spans(spans, is_eap=True)
 
         response = self.do_request(
             {
                 "field": ["parent_span"],
                 "query": "!has:parent_span",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
         assert response.status_code == 200, response.content
@@ -4726,14 +3669,14 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "project.name": self.project.slug,
             }
         ]
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
 
         response = self.do_request(
             {
                 "field": ["parent_span"],
                 "query": "has:parent_span",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
         assert response.status_code == 200, response.content
@@ -4747,7 +3690,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "project.name": self.project.slug,
             }
         ]
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
 
     def test_app_start_fields(self):
         self.store_spans(
@@ -4782,7 +3725,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     start_ts=self.ten_mins_ago,
                 ),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
         response = self.do_request(
             {
@@ -4790,7 +3733,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "query": "has:ttid",
                 "orderby": "app_start_type",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -4805,8 +3748,8 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
         assert data[1]["ttid"] == "ttid"
         assert data[1]["os.name"] == "iOS"
 
-        assert meta["dataset"] == self.dataset
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
+        assert meta["dataset"] == "spans"
 
     def test_typed_attributes_with_colons(self):
         span = self.create_span(
@@ -4822,7 +3765,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 self.create_span(start_ts=self.ten_mins_ago),
                 span,
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
 
         response = self.do_request(
@@ -4830,7 +3773,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "field": ["tags[flag.evaluation.feature.organizations:foo,number]"],
                 "query": "has:tags[flag.evaluation.feature.organizations:foo,number] tags[flag.evaluation.feature.organizations:foo,number]:1",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
         assert response.status_code == 200, response.content
@@ -4852,7 +3795,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     start_ts=self.ten_mins_ago,
                 ),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
 
         response = self.do_request(
@@ -4860,7 +3803,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "field": ["count_if(release,foo)"],
                 "query": "",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
         assert response.status_code == 200, response.content
@@ -4869,7 +3812,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
 
         assert len(data) == 1
         assert data[0]["count_if(release,foo)"] == 1
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
 
     def test_span_ops_breakdown(self):
         self.store_spans(
@@ -4880,7 +3823,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     },
                 ),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
 
         response = self.do_request(
@@ -4888,7 +3831,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "field": ["spans.http"],
                 "query": "",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
         assert response.status_code == 200, response.content
@@ -4897,7 +3840,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
 
         assert len(data) == 1
         assert data[0]["spans.http"] == 100
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
 
     def test_special_characters(self):
         characters = "_.-"
@@ -4910,7 +3853,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 span,
                 self.create_span(start_ts=self.ten_mins_ago),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
 
         for c in characters:
@@ -4919,7 +3862,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     "field": [f"tag{c}"],
                     "query": f"tag{c}:{c}",
                     "project": self.project.id,
-                    "dataset": self.dataset,
+                    "dataset": "spans",
                 }
             )
             assert response.status_code == 200, response.content
@@ -4943,7 +3886,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     start_ts=self.ten_mins_ago,
                 ),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
 
         response = self.do_request(
@@ -4951,7 +3894,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "field": ["sum(ai.total_tokens.used)"],
                 "query": "",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
         assert response.status_code == 200, response.content
@@ -4959,7 +3902,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
         data, meta = response.data["data"], response.data["meta"]
         assert len(data) == 1
         assert data[0]["sum(ai.total_tokens.used)"] == 150
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
         assert meta["fields"]["sum(ai.total_tokens.used)"] == "integer"
 
     def test_equation_simple(self):
@@ -4977,7 +3920,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     start_ts=self.ten_mins_ago,
                 ),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
         equation = "equation|count() * 2"
         response = self.do_request(
@@ -4986,7 +3929,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "query": "",
                 "orderby": "description",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -5006,7 +3949,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 equation: 2,
             },
         ]
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
         assert meta["fields"][equation] == "number"
 
     def test_equation_with_orderby_using_same_alias(self):
@@ -5024,7 +3967,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     start_ts=self.ten_mins_ago,
                 ),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
         equation = "equation|count(span.duration)"
         response = self.do_request(
@@ -5033,7 +3976,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "query": "",
                 "orderby": "count_span_duration",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -5047,7 +3990,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 equation: 2,
             },
         ]
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
         assert meta["fields"][equation] == "integer"
 
     def test_equation_single_function_term(self):
@@ -5065,7 +4008,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     start_ts=self.ten_mins_ago,
                 ),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
         equation = "equation|count()"
         response = self.do_request(
@@ -5074,7 +4017,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "query": "",
                 "orderby": "description",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -5094,7 +4037,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 equation: 1,
             },
         ]
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
         assert meta["fields"][equation] == "integer"
 
     def test_equation_single_field_term(self):
@@ -5117,7 +4060,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     start_ts=self.ten_mins_ago,
                 ),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
         equation = "equation|measurements.lcp"
         response = self.do_request(
@@ -5126,7 +4069,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "query": "",
                 "orderby": "description",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -5148,7 +4091,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 equation: 1,
             },
         ]
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
         assert meta["fields"][equation] == "duration"
 
     def test_equation_single_literal(self):
@@ -5169,7 +4112,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     start_ts=self.ten_mins_ago,
                 ),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
         equation = "equation|3.14159"
         response = self.do_request(
@@ -5178,7 +4121,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "query": "",
                 "orderby": "description",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -5200,7 +4143,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 equation: 3.14159,
             },
         ]
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
         assert meta["fields"][equation] == "number"
 
     @pytest.mark.xfail(reason="Confidence isn't being returned by the RPC currently")
@@ -5226,7 +4169,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 start_ts=self.ten_mins_ago,
             )
         )
-        self.store_spans(spans, is_eap=self.is_eap)
+        self.store_spans(spans, is_eap=True)
         equation = "equation|count() * (2)"
         response = self.do_request(
             {
@@ -5234,7 +4177,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "orderby": f"-{equation}",
                 "query": "",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
         assert response.status_code == 200, response.content
@@ -5263,7 +4206,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     start_ts=self.ten_mins_ago,
                 ),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
         equation = "equation|count() * 2 + 2 - 2 / 2"
         response = self.do_request(
@@ -5272,7 +4215,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "query": "",
                 "orderby": "description",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -5292,7 +4235,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 equation: 3,
             },
         ]
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
         assert meta["fields"][equation] == "number"
 
     def test_release(self):
@@ -5314,7 +4257,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
             },
             start_ts=self.ten_mins_ago,
         )
-        self.store_spans([span1, span2], is_eap=self.is_eap)
+        self.store_spans([span1, span2], is_eap=True)
 
         response = self.do_request(
             {
@@ -5322,7 +4265,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "query": "release:1.0.8",
                 "project": self.project.id,
                 "environment": self.environment.name,
-                "dataset": self.dataset,
+                "dataset": "spans",
                 "orderby": "release",
             }
         )
@@ -5340,7 +4283,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "field": ["release"],
                 "query": "release:1*",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
                 "orderby": "release",
             }
         )
@@ -5361,14 +4304,14 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
     def test_latest_release_alias(self):
         self.create_release(version="0.8")
         span1 = self.create_span({"sentry_tags": {"release": "0.8"}}, start_ts=self.ten_mins_ago)
-        self.store_spans([span1], is_eap=self.is_eap)
+        self.store_spans([span1], is_eap=True)
 
         response = self.do_request(
             {
                 "field": ["release"],
                 "query": "release:latest",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
         assert response.status_code == 200, response.content
@@ -5382,14 +4325,14 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
 
         self.create_release(version="0.9")
         span2 = self.create_span({"sentry_tags": {"release": "0.9"}}, start_ts=self.ten_mins_ago)
-        self.store_spans([span2], is_eap=self.is_eap)
+        self.store_spans([span2], is_eap=True)
 
         response = self.do_request(
             {
                 "field": ["release"],
                 "query": "release:latest",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
         assert response.status_code == 200, response.content
@@ -5433,12 +4376,12 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
             },
             start_ts=self.ten_mins_ago,
         )
-        self.store_spans([adopted_span, replaced_span], is_eap=self.is_eap)
+        self.store_spans([adopted_span, replaced_span], is_eap=True)
 
         request = {
             "field": ["release"],
             "project": self.project.id,
-            "dataset": self.dataset,
+            "dataset": "spans",
             "orderby": "release",
             "environment": self.environment.name,
         }
@@ -5497,12 +4440,12 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
         span3 = self.create_span(
             {"sentry_tags": {"release": release_3.version}}, start_ts=self.ten_mins_ago
         )
-        self.store_spans([span1, span2, span3], is_eap=self.is_eap)
+        self.store_spans([span1, span2, span3], is_eap=True)
 
         request = {
             "field": ["release"],
             "project": self.project.id,
-            "dataset": self.dataset,
+            "dataset": "spans",
             "orderby": "release",
         }
 
@@ -5602,12 +4545,12 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
         span2 = self.create_span(
             {"sentry_tags": {"release": release_2.version}}, start_ts=self.ten_mins_ago
         )
-        self.store_spans([span1, span2], is_eap=self.is_eap)
+        self.store_spans([span1, span2], is_eap=True)
 
         request = {
             "field": ["release"],
             "project": self.project.id,
-            "dataset": self.dataset,
+            "dataset": "spans",
             "orderby": "release",
         }
 
@@ -5641,12 +4584,12 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
         span2 = self.create_span(
             {"sentry_tags": {"release": release_2.version}}, start_ts=self.ten_mins_ago
         )
-        self.store_spans([span1, span2], is_eap=self.is_eap)
+        self.store_spans([span1, span2], is_eap=True)
 
         request = {
             "field": ["release"],
             "project": self.project.id,
-            "dataset": self.dataset,
+            "dataset": "spans",
             "orderby": "release",
         }
 
@@ -5692,7 +4635,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     start_ts=self.ten_mins_ago,
                 ),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
 
         response = self.do_request(
@@ -5702,7 +4645,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 ],
                 "orderby": "file_extension",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -5712,7 +4655,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
         assert len(data) == 2
         assert data[0]["file_extension"] == "css"
         assert data[1]["file_extension"] == "js"
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
 
     def test_filter_timestamp(self):
         one_day_ago = before_now(days=1).replace(microsecond=0)
@@ -5720,12 +4663,12 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
 
         span1 = self.create_span({}, start_ts=one_day_ago)
         span2 = self.create_span({}, start_ts=three_days_ago)
-        self.store_spans([span1, span2], is_eap=self.is_eap)
+        self.store_spans([span1, span2], is_eap=True)
 
         request = {
             "field": ["timestamp"],
             "project": self.project.id,
-            "dataset": self.dataset,
+            "dataset": "spans",
         }
 
         response = self.do_request(
@@ -5797,14 +4740,14 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 start_ts=self.ten_mins_ago,
             )
         )
-        self.store_spans(spans, is_eap=self.is_eap)
+        self.store_spans(spans, is_eap=True)
         response = self.do_request(
             {
                 "field": ["description", "count()"],
                 "orderby": "-count()",
                 "query": "",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
                 "disableAggregateExtrapolation": 1,
             }
         )
@@ -5830,14 +4773,14 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 )
                 for status in trace_statuses
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
 
         response = self.do_request(
             {
                 "field": ["failure_count()"],
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -5846,7 +4789,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
         meta = response.data["meta"]
         assert len(data) == 1
         assert data[0]["failure_count()"] == 1
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
 
     def test_short_trace_id_filter(self):
         trace_ids = [
@@ -5864,7 +4807,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 )
                 for trace_id in trace_ids
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
 
         for i in range(8, 32):
@@ -5872,7 +4815,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 {
                     "field": ["trace"],
                     "project": self.project.id,
-                    "dataset": self.dataset,
+                    "dataset": "spans",
                     "query": f"trace:{'7' * i}",
                     "orderby": "trace",
                 }
@@ -5895,7 +4838,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     start_ts=self.ten_mins_ago,
                 ),
             ],
-            is_eap=self.is_eap,
+            is_eap=True,
         )
         response = self.do_request(
             {
@@ -5903,7 +4846,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "query": "",
                 "orderby": "description",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -5917,7 +4860,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "eps()": 1 / (90 * 24 * 60 * 60),
             },
         ]
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
         assert meta["units"] == {"description": None, "eps()": "1/second"}
         assert meta["fields"] == {"description": "string", "eps()": "rate"}
 
@@ -5964,14 +4907,14 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 duration=5000,  # 5000ms - frustrated
             ),
         ]
-        self.store_spans(spans, is_eap=self.is_eap)
+        self.store_spans(spans, is_eap=True)
 
         response = self.do_request(
             {
                 "field": ["apdex(span.duration,1000)"],
                 "query": "",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -5989,7 +4932,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
 
         assert len(data) == 1
         assert data[0]["apdex(span.duration,1000)"] == expected_apdex
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
         assert meta["fields"] == {"apdex(span.duration,1000)": "number"}
 
     def test_apdex_function_with_filter(self):
@@ -6047,14 +4990,14 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 duration=100,
             ),
         ]
-        self.store_spans(spans, is_eap=self.is_eap)
+        self.store_spans(spans, is_eap=True)
 
         response = self.do_request(
             {
                 "field": ["apdex(span.duration,1000)"],
                 "query": "description:http.server",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -6138,14 +5081,14 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 duration=5000,  # 5000ms - miserable but not a segment
             ),
         ]
-        self.store_spans(spans, is_eap=self.is_eap)
+        self.store_spans(spans, is_eap=True)
 
         response = self.do_request(
             {
                 "field": ["user_misery(span.duration,1000)"],
                 "query": "",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -6164,7 +5107,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
         assert data[0]["user_misery(span.duration,1000)"] == pytest.approx(
             expected_user_misery, rel=1e-3
         )
-        assert meta["dataset"] == self.dataset
+        assert meta["dataset"] == "spans"
         assert meta["fields"] == {"user_misery(span.duration,1000)": "number"}
 
     def test_user_misery_function_with_filter(self):
@@ -6212,14 +5155,14 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 duration=100,
             ),
         ]
-        self.store_spans(spans, is_eap=self.is_eap)
+        self.store_spans(spans, is_eap=True)
 
         response = self.do_request(
             {
                 "field": ["user_misery(span.duration,1000)"],
                 "query": "description:http.server",
                 "project": self.project.id,
-                "dataset": self.dataset,
+                "dataset": "spans",
             }
         )
 
@@ -6238,3 +5181,718 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
         assert data[0]["user_misery(span.duration,1000)"] == pytest.approx(
             expected_user_misery, rel=1e-3
         )
+
+    def test_id_fields(self):
+        self.store_spans(
+            [
+                self.create_span(
+                    {"description": "foo", "sentry_tags": {"status": "success"}},
+                    start_ts=self.ten_mins_ago,
+                ),
+                self.create_span(
+                    {
+                        "description": "bar",
+                        "sentry_tags": {"status": "invalid_argument"},
+                    },
+                    start_ts=self.ten_mins_ago,
+                ),
+            ],
+            is_eap=True,
+        )
+        response = self.do_request(
+            {
+                "field": ["id", "span_id"],
+                "query": "",
+                "orderby": "id",
+                "project": self.project.id,
+                "dataset": "spans",
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert len(data) == 2
+        for obj in data:
+            assert obj["id"] == obj["span_id"]
+        assert meta["dataset"] == "spans"
+
+    def test_sentry_tags_vs_tags(self):
+        self.store_spans(
+            [
+                self.create_span(
+                    {"sentry_tags": {"transaction.method": "foo"}},
+                    start_ts=self.ten_mins_ago,
+                ),
+            ],
+            is_eap=True,
+        )
+        response = self.do_request(
+            {
+                "field": ["transaction.method", "count()"],
+                "query": "",
+                "orderby": "count()",
+                "project": self.project.id,
+                "dataset": "spans",
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert len(data) == 1
+        assert data[0]["transaction.method"] == "foo"
+        assert meta["dataset"] == "spans"
+
+    def test_sentry_tags_syntax(self):
+        self.store_spans(
+            [
+                self.create_span(
+                    {"sentry_tags": {"transaction.method": "foo"}},
+                    start_ts=self.ten_mins_ago,
+                ),
+            ],
+            is_eap=True,
+        )
+        response = self.do_request(
+            {
+                "field": ["sentry_tags[transaction.method]", "count()"],
+                "query": "",
+                "orderby": "count()",
+                "project": self.project.id,
+                "dataset": "spans",
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert len(data) == 1
+        assert data[0]["sentry_tags[transaction.method]"] == "foo"
+        assert meta["dataset"] == "spans"
+
+    def test_network_span(self):
+        self.store_spans(
+            [
+                self.create_span(
+                    {
+                        "sentry_tags": {
+                            "action": "GET",
+                            "category": "http",
+                            "description": "GET https://*.resource.com",
+                            "domain": "*.resource.com",
+                            "op": "http.client",
+                            "status_code": "200",
+                            "transaction": "/api/0/data/",
+                            "transaction.method": "GET",
+                            "transaction.op": "http.server",
+                        }
+                    },
+                    start_ts=self.ten_mins_ago,
+                ),
+            ],
+            is_eap=True,
+        )
+
+        response = self.do_request(
+            {
+                "field": ["span.op", "span.status_code"],
+                "query": "span.status_code:200",
+                "project": self.project.id,
+                "dataset": "spans",
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert len(data) == 1
+        assert data[0]["span.op"] == "http.client"
+        assert data[0]["span.status_code"] == "200"
+        assert meta["dataset"] == "spans"
+
+    def test_queue_span(self):
+        self.store_spans(
+            [
+                self.create_span(
+                    {
+                        "measurements": {
+                            "messaging.message.body.size": {
+                                "value": 1024,
+                                "unit": "byte",
+                            },
+                            "messaging.message.receive.latency": {
+                                "value": 1000,
+                                "unit": "millisecond",
+                            },
+                            "messaging.message.retry.count": {
+                                "value": 2,
+                                "unit": "none",
+                            },
+                        },
+                        "sentry_tags": {
+                            "transaction": "queue-processor",
+                            "messaging.destination.name": "events",
+                            "messaging.message.id": "abc123",
+                            "trace.status": "ok",
+                        },
+                    },
+                    start_ts=self.ten_mins_ago,
+                ),
+            ],
+            is_eap=True,
+        )
+        response = self.do_request(
+            {
+                "field": [
+                    "transaction",
+                    "messaging.destination.name",
+                    "messaging.message.id",
+                    "measurements.messaging.message.receive.latency",
+                    "measurements.messaging.message.body.size",
+                    "measurements.messaging.message.retry.count",
+                    "trace.status",
+                    "count()",
+                ],
+                "query": 'messaging.destination.name:"events"',
+                "orderby": "count()",
+                "project": self.project.id,
+                "dataset": "spans",
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert len(data) == 1
+        assert data[0]["transaction"] == "queue-processor"
+        assert data[0]["messaging.destination.name"] == "events"
+        assert data[0]["messaging.message.id"] == "abc123"
+        assert data[0]["trace.status"] == "ok"
+        assert data[0]["measurements.messaging.message.receive.latency"] == 1000
+        assert data[0]["measurements.messaging.message.body.size"] == 1024
+        assert data[0]["measurements.messaging.message.retry.count"] == 2
+        assert meta["dataset"] == "spans"
+
+    def test_count_field_type(self):
+        response = self.do_request(
+            {
+                "field": ["count()"],
+                "project": self.project.id,
+                "dataset": "spans",
+            }
+        )
+        assert response.status_code == 200, response.content
+        assert response.data["meta"]["fields"] == {"count()": "integer"}
+        assert response.data["meta"]["units"] == {"count()": None}
+        assert response.data["data"] == [{"count()": 0}]
+
+    def _test_simple_measurements(self, keys):
+        self.store_spans(
+            [
+                self.create_span(
+                    {
+                        "description": "foo",
+                        "sentry_tags": {"status": "success"},
+                        "tags": {"bar": "bar2"},
+                    },
+                    measurements={k: {"value": (i + 1) / 10} for i, (k, _, _) in enumerate(keys)},
+                    start_ts=self.ten_mins_ago,
+                ),
+            ],
+            is_eap=True,
+        )
+
+        for i, (k, type, unit) in enumerate(keys):
+            key = f"measurements.{k}"
+            response = self.do_request(
+                {
+                    "field": [key],
+                    "query": "description:foo",
+                    "project": self.project.id,
+                    "dataset": "spans",
+                }
+            )
+            assert response.status_code == 200, response.content
+            expected = {
+                "dataScanned": "full",
+                "dataset": mock.ANY,
+                "datasetReason": "unchanged",
+                "fields": {
+                    key: type,
+                    "id": "string",
+                    "project.name": "string",
+                },
+                "isMetricsData": False,
+                "isMetricsExtractedData": False,
+                "tips": {},
+                "units": {
+                    key: unit,
+                    "id": None,
+                    "project.name": None,
+                },
+            }
+            if True:
+                expected["accuracy"] = {
+                    "confidence": [{}],
+                }
+            assert response.data["meta"] == expected
+            assert response.data["data"] == [
+                {
+                    key: pytest.approx((i + 1) / 10),
+                    "id": mock.ANY,
+                    "project.name": self.project.slug,
+                }
+            ]
+
+    def test_environment(self):
+        self.create_environment(self.project, name="prod")
+        self.create_environment(self.project, name="test")
+        self.store_spans(
+            [
+                self.create_span(
+                    {"description": "foo", "sentry_tags": {"environment": "prod"}},
+                    start_ts=self.ten_mins_ago,
+                ),
+                self.create_span(
+                    {"description": "foo", "sentry_tags": {"environment": "test"}},
+                    start_ts=self.ten_mins_ago,
+                ),
+            ],
+            is_eap=True,
+        )
+        response = self.do_request(
+            {
+                "field": ["environment", "count()"],
+                "project": self.project.id,
+                "environment": "prod",
+                "orderby": "environment",
+                "dataset": "spans",
+            }
+        )
+        assert response.status_code == 200, response.content
+        assert response.data["data"] == [
+            {"environment": "prod", "count()": 1},
+        ]
+
+        response = self.do_request(
+            {
+                "field": ["environment", "count()"],
+                "project": self.project.id,
+                "environment": ["prod", "test"],
+                "orderby": "environment",
+                "dataset": "spans",
+            }
+        )
+        assert response.status_code == 200, response.content
+        assert response.data["data"] == [
+            {"environment": "prod", "count()": 1},
+            {"environment": "test", "count()": 1},
+        ]
+
+    def test_transaction(self):
+        self.store_spans(
+            [
+                self.create_span(
+                    {"description": "foo", "sentry_tags": {"transaction": "bar"}},
+                    start_ts=self.ten_mins_ago,
+                ),
+            ],
+            is_eap=True,
+        )
+        response = self.do_request(
+            {
+                "field": ["description", "count()"],
+                "query": "transaction:bar",
+                "orderby": "description",
+                "project": self.project.id,
+                "dataset": "spans",
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert len(data) == 1
+        assert data == [
+            {
+                "description": "foo",
+                "count()": 1,
+            },
+        ]
+        assert meta["dataset"] == "spans"
+
+    def test_orderby_alias(self):
+        self.store_spans(
+            [
+                self.create_span(
+                    {"description": "foo", "sentry_tags": {"status": "success"}},
+                    start_ts=self.ten_mins_ago,
+                ),
+                self.create_span(
+                    {
+                        "description": "bar",
+                        "sentry_tags": {"status": "invalid_argument"},
+                    },
+                    duration=2000,
+                    start_ts=self.ten_mins_ago,
+                ),
+            ],
+            is_eap=True,
+        )
+        response = self.do_request(
+            {
+                "field": ["span.description", "sum(span.self_time)"],
+                "query": "",
+                "orderby": "sum_span_self_time",
+                "project": self.project.id,
+                "dataset": "spans",
+            }
+        )
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert len(data) == 2
+        assert data == [
+            {
+                "span.description": "foo",
+                "sum(span.self_time)": 1000,
+            },
+            {
+                "span.description": "bar",
+                "sum(span.self_time)": 2000,
+            },
+        ]
+        assert meta["dataset"] == "spans"
+
+    def test_span_status(self):
+        self.store_spans(
+            [
+                self.create_span(
+                    {"description": "foo", "sentry_tags": {"status": "internal_error"}},
+                    start_ts=self.ten_mins_ago,
+                ),
+            ],
+            is_eap=True,
+        )
+        response = self.do_request(
+            {
+                "field": ["description", "count()"],
+                "query": "span.status:internal_error",
+                "orderby": "description",
+                "project": self.project.id,
+                "dataset": "spans",
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert len(data) == 1
+        assert data == [
+            {
+                "description": "foo",
+                "count()": 1,
+            },
+        ]
+        assert meta["dataset"] == "spans"
+
+    def test_handle_nans_from_snuba(self):
+        self.store_spans(
+            [self.create_span({"description": "foo"}, start_ts=self.ten_mins_ago)],
+            is_eap=True,
+        )
+
+        response = self.do_request(
+            {
+                "field": ["description", "count()"],
+                "query": "span.status:internal_error",
+                "orderby": "description",
+                "project": self.project.id,
+                "dataset": "spans",
+            }
+        )
+        assert response.status_code == 200, response.content
+
+    def test_in_filter(self):
+        self.store_spans(
+            [
+                self.create_span(
+                    {"description": "foo", "sentry_tags": {"transaction": "bar"}},
+                    start_ts=self.ten_mins_ago,
+                ),
+                self.create_span(
+                    {"description": "foo", "sentry_tags": {"transaction": "baz"}},
+                    start_ts=self.ten_mins_ago,
+                ),
+                self.create_span(
+                    {"description": "foo", "sentry_tags": {"transaction": "bat"}},
+                    start_ts=self.ten_mins_ago,
+                ),
+            ],
+            is_eap=True,
+        )
+        response = self.do_request(
+            {
+                "field": ["transaction", "count()"],
+                "query": "transaction:[bar, baz]",
+                "orderby": "transaction",
+                "project": self.project.id,
+                "dataset": "spans",
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert len(data) == 2
+        assert data == [
+            {
+                "transaction": "bar",
+                "count()": 1,
+            },
+            {
+                "transaction": "baz",
+                "count()": 1,
+            },
+        ]
+        assert meta["dataset"] == "spans"
+
+    def _test_aggregate_filter(self, queries):
+        self.store_spans(
+            [
+                self.create_span(
+                    {"sentry_tags": {"transaction": "foo"}},
+                    measurements={
+                        "lcp": {"value": 5000},
+                        "http.response_content_length": {"value": 5000},
+                    },
+                    start_ts=self.ten_mins_ago,
+                ),
+                self.create_span(
+                    {"sentry_tags": {"transaction": "foo"}},
+                    measurements={
+                        "lcp": {"value": 5000},
+                        "http.response_content_length": {"value": 5000},
+                    },
+                    start_ts=self.ten_mins_ago,
+                ),
+                self.create_span(
+                    {"sentry_tags": {"transaction": "bar"}},
+                    measurements={
+                        "lcp": {"value": 1000},
+                        "http.response_content_length": {"value": 1000},
+                    },
+                    start_ts=self.ten_mins_ago,
+                ),
+            ],
+            is_eap=True,
+        )
+
+        for query in queries:
+            response = self.do_request(
+                {
+                    "field": ["transaction", "count()"],
+                    "query": query,
+                    "orderby": "transaction",
+                    "project": self.project.id,
+                    "dataset": "spans",
+                }
+            )
+            assert response.status_code == 200, response.content
+            data = response.data["data"]
+            meta = response.data["meta"]
+            assert len(data) == 1
+            assert data[0]["transaction"] == "foo"
+            assert data[0]["count()"] == 2
+            assert meta["dataset"] == "spans"
+
+    def test_pagination_samples(self):
+        self.store_spans(
+            [
+                self.create_span(
+                    {"description": "a"},
+                    start_ts=self.ten_mins_ago,
+                ),
+                self.create_span(
+                    {"description": "b"},
+                    start_ts=self.ten_mins_ago,
+                ),
+            ],
+            is_eap=True,
+        )
+        response = self.do_request(
+            {
+                "field": ["description"],
+                "query": "",
+                "orderby": "description",
+                "project": self.project.id,
+                "dataset": "spans",
+                "per_page": 1,
+            }
+        )
+        assert response.status_code == 200, response.content
+        assert response.data["data"] == [
+            {
+                "id": mock.ANY,
+                "project.name": self.project.slug,
+                "description": "a",
+            },
+        ]
+
+        links = {}
+        for url, attrs in parse_link_header(response["Link"]).items():
+            links[attrs["rel"]] = attrs
+            attrs["href"] = url
+
+        assert links["previous"]["results"] == "false"
+        assert links["next"]["results"] == "true"
+
+        assert links["next"]["href"] is not None
+        response = self.client.get(links["next"]["href"], format="json")
+        assert response.status_code == 200, response.content
+        assert response.data["data"] == [
+            {
+                "id": mock.ANY,
+                "project.name": self.project.slug,
+                "description": "b",
+            },
+        ]
+
+        links = {}
+        for url, attrs in parse_link_header(response["Link"]).items():
+            links[attrs["rel"]] = attrs
+            attrs["href"] = url
+
+        assert links["previous"]["results"] == "true"
+        assert links["next"]["results"] == "false"
+
+        assert links["previous"]["href"] is not None
+        response = self.client.get(links["previous"]["href"], format="json")
+        assert response.status_code == 200, response.content
+        assert response.data["data"] == [
+            {
+                "id": mock.ANY,
+                "project.name": self.project.slug,
+                "description": "a",
+            },
+        ]
+
+        links = {}
+        for url, attrs in parse_link_header(response["Link"]).items():
+            links[attrs["rel"]] = attrs
+            attrs["href"] = url
+
+        assert links["previous"]["results"] == "false"
+        assert links["next"]["results"] == "true"
+
+    def test_precise_timestamps(self):
+        self.store_spans(
+            [
+                self.create_span(
+                    {"description": "foo", "sentry_tags": {"status": "success"}},
+                    start_ts=self.ten_mins_ago,
+                ),
+            ],
+            is_eap=True,
+        )
+        response = self.do_request(
+            {
+                "field": ["precise.start_ts", "precise.finish_ts"],
+                "project": self.project.id,
+                "dataset": "spans",
+                "statsPeriod": "1h",
+            }
+        )
+        start = self.ten_mins_ago.timestamp()
+        finish = start + 1
+        assert response.status_code == 200, response.content
+        assert response.data["data"] == [
+            {
+                "id": mock.ANY,
+                "project.name": self.project.slug,
+                "precise.start_ts": start,
+                "precise.finish_ts": finish,
+            },
+        ]
+
+    def test_query_with_asterisk(self):
+        self.store_spans(
+            [
+                self.create_span(
+                    {"description": "select * from database"},
+                    start_ts=self.ten_mins_ago,
+                ),
+            ],
+            is_eap=True,
+        )
+        response = self.do_request(
+            {
+                "field": ["span.description"],
+                "query": 'span.description:"select \\* from database"',
+                "project": self.project.id,
+                "dataset": "spans",
+            }
+        )
+        assert response.status_code == 200, response.content
+        assert len(response.data["data"]) == 1
+        assert response.data["data"][0]["span.description"] == "select * from database"
+
+    def test_wildcard_queries_with_asterisk_literals(self):
+        self.store_spans(
+            [
+                self.create_span(
+                    {"description": "select * from database"},
+                    start_ts=self.ten_mins_ago,
+                ),
+            ],
+            is_eap=True,
+        )
+        response = self.do_request(
+            {
+                "field": ["span.description"],
+                "query": 'span.description:"select \\* * database"',
+                "project": self.project.id,
+                "dataset": "spans",
+            }
+        )
+        assert response.status_code == 200, response.content
+        assert len(response.data["data"]) == 1
+        assert response.data["data"][0]["span.description"] == "select * from database"
+
+    def test_free_text_wildcard_filter(self):
+        spans = [
+            self.create_span(
+                {
+                    "description": "barbarbar",
+                    "sentry_tags": {"status": "invalid_argument"},
+                },
+                start_ts=self.ten_mins_ago,
+            ),
+            self.create_span(
+                {"description": "foofoofoo", "sentry_tags": {"status": "success"}},
+                start_ts=self.ten_mins_ago,
+            ),
+        ]
+        self.store_spans(spans, is_eap=True)
+        response = self.do_request(
+            {
+                "field": ["count()", "description"],
+                "query": "oof",
+                "orderby": "-count()",
+                "project": self.project.id,
+                "dataset": "spans",
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert len(data) == 1
+        assert data == [
+            {
+                "count()": 1,
+                "description": "foofoofoo",
+            },
+        ]
+        assert meta["dataset"] == "spans"


### PR DESCRIPTION
- This removes the option to pass dataset=spansIndexed to the events endpoints and query the deprecated indexed spans dataset