### PR TITLE
:wrench: chore: use IntegrationProviderSlug instead of magic str

### DIFF
--- a/src/sentry/identity/bitbucket/provider.py
+++ b/src/sentry/identity/bitbucket/provider.py
@@ -3,12 +3,13 @@ from django.http.response import HttpResponseBase, HttpResponseRedirect
 
 from sentry.identity.base import Provider
 from sentry.identity.pipeline import IdentityPipeline
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.pipeline.views.base import PipelineView
 from sentry.utils.http import absolute_uri
 
 
 class BitbucketIdentityProvider(Provider):
-    key = "bitbucket"
+    key = IntegrationProviderSlug.BITBUCKET.value
     name = "Bitbucket"
 
     def get_pipeline_views(self) -> list[PipelineView[IdentityPipeline]]:

--- a/src/sentry/identity/pipeline.py
+++ b/src/sentry/identity/pipeline.py
@@ -11,6 +11,7 @@ from django.utils.translation import gettext_lazy as _
 from sentry import features, options
 from sentry.identity.base import Provider
 from sentry.integrations.base import IntegrationDomain
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.integrations.utils.metrics import (
     IntegrationPipelineViewEvent,
     IntegrationPipelineViewType,
@@ -33,7 +34,7 @@ class IdentityPipeline(Pipeline[IdentityProvider, PipelineSessionStore]):
 
     # TODO(iamrajjoshi): Delete this after Azure DevOps migration is complete
     def _get_provider(self, provider_key: str, organization: RpcOrganization | None) -> Provider:
-        if provider_key == "vsts" and features.has(
+        if provider_key == IntegrationProviderSlug.AZURE_DEVOPS.value and features.has(
             "organizations:migrate-azure-devops-integration", organization
         ):
             provider_key = "vsts_new"

--- a/src/sentry/identity/vsts/provider.py
+++ b/src/sentry/identity/vsts/provider.py
@@ -9,6 +9,7 @@ from sentry import http, options
 from sentry.http import safe_urlopen
 from sentry.identity.oauth2 import OAuth2CallbackView, OAuth2LoginView, OAuth2Provider
 from sentry.identity.pipeline import IdentityPipeline
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.pipeline.views.base import PipelineView
 from sentry.users.models.identity import Identity
 from sentry.utils.http import absolute_uri
@@ -45,7 +46,7 @@ def get_user_info(access_token):
 
 
 class VSTSIdentityProvider(OAuth2Provider):
-    key = "vsts"
+    key = IntegrationProviderSlug.AZURE_DEVOPS.value
     name = "Azure DevOps"
 
     oauth_access_token_url = "https://app.vssps.visualstudio.com/oauth2/token"
@@ -111,7 +112,7 @@ class VSTSIdentityProvider(OAuth2Provider):
         user = get_user_info(access_token)
 
         return {
-            "type": "vsts",
+            "type": IntegrationProviderSlug.AZURE_DEVOPS.value,
             "id": user["id"],
             "email": user["emailAddress"],
             "email_verified": True,
@@ -204,7 +205,7 @@ class VSTSNewIdentityProvider(OAuth2Provider):
         user = get_user_info(access_token)
 
         return {
-            "type": "vsts",
+            "type": IntegrationProviderSlug.AZURE_DEVOPS.value,
             "id": user["id"],
             "email": user["emailAddress"],
             "email_verified": True,

--- a/src/sentry/integrations/bitbucket/client.py
+++ b/src/sentry/integrations/bitbucket/client.py
@@ -11,6 +11,7 @@ from sentry.integrations.client import ApiClient
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.integrations.source_code_management.repository import RepositoryClient
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.integrations.utils.atlassian_connect import get_query_hash
 from sentry.models.repository import Repository
 from sentry.utils import jwt
@@ -53,7 +54,7 @@ class BitbucketApiClient(ApiClient, RepositoryClient):
     NOTE: repo is the fully qualified slug containing 'username/repo_slug'
     """
 
-    integration_name = "bitbucket"
+    integration_name = IntegrationProviderSlug.BITBUCKET.value
 
     def __init__(self, integration: RpcIntegration | Integration):
         self.base_url = integration.metadata["base_url"]

--- a/src/sentry/integrations/bitbucket/installed.py
+++ b/src/sentry/integrations/bitbucket/installed.py
@@ -8,6 +8,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, control_silo_endpoint
 from sentry.integrations.pipeline import ensure_integration
+from sentry.integrations.types import IntegrationProviderSlug
 
 from .integration import BitbucketIntegrationProvider
 
@@ -28,6 +29,6 @@ class BitbucketInstalledEndpoint(Endpoint):
     def post(self, request: Request, *args, **kwargs) -> Response:
         state = request.data
         data = BitbucketIntegrationProvider().build_integration(state)
-        ensure_integration("bitbucket", data)
+        ensure_integration(IntegrationProviderSlug.BITBUCKET.value, data)
 
         return self.respond()

--- a/src/sentry/integrations/bitbucket/integration.py
+++ b/src/sentry/integrations/bitbucket/integration.py
@@ -22,6 +22,7 @@ from sentry.integrations.pipeline import IntegrationPipeline
 from sentry.integrations.services.repository import RpcRepository, repository_service
 from sentry.integrations.source_code_management.repository import RepositoryIntegration
 from sentry.integrations.tasks.migrate_repo import migrate_repo
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.integrations.utils.atlassian_connect import (
     AtlassianConnectValidationError,
     get_integration_from_request,
@@ -106,7 +107,7 @@ class BitbucketIntegration(RepositoryIntegration, BitbucketIssuesSpec):
 
     @property
     def integration_name(self) -> str:
-        return "bitbucket"
+        return IntegrationProviderSlug.BITBUCKET.value
 
     def get_client(self):
         return BitbucketApiClient(integration=self.model)
@@ -152,7 +153,8 @@ class BitbucketIntegration(RepositoryIntegration, BitbucketIssuesSpec):
 
     def get_unmigratable_repositories(self) -> list[RpcRepository]:
         repos = repository_service.get_repositories(
-            organization_id=self.organization_id, providers=["bitbucket"]
+            organization_id=self.organization_id,
+            providers=[IntegrationProviderSlug.BITBUCKET.value],
         )
 
         accessible_repos = [r["identifier"] for r in self.get_repositories()]
@@ -185,7 +187,7 @@ class BitbucketIntegration(RepositoryIntegration, BitbucketIssuesSpec):
 
 
 class BitbucketIntegrationProvider(IntegrationProvider):
-    key = "bitbucket"
+    key = IntegrationProviderSlug.BITBUCKET.value
     name = "Bitbucket"
     metadata = metadata
     scopes = scopes
@@ -203,7 +205,7 @@ class BitbucketIntegrationProvider(IntegrationProvider):
         return [
             NestedPipelineView(
                 bind_key="identity",
-                provider_key="bitbucket",
+                provider_key=IntegrationProviderSlug.BITBUCKET.value,
                 pipeline_cls=IdentityPipeline,
                 config={"redirect_url": absolute_uri("/extensions/bitbucket/setup/")},
             ),
@@ -219,7 +221,7 @@ class BitbucketIntegrationProvider(IntegrationProvider):
     ) -> None:
         repos = repository_service.get_repositories(
             organization_id=organization.id,
-            providers=["bitbucket", "integrations:bitbucket"],
+            providers=[IntegrationProviderSlug.BITBUCKET.value, "integrations:bitbucket"],
             has_integration=False,
         )
 

--- a/src/sentry/integrations/bitbucket/repository.py
+++ b/src/sentry/integrations/bitbucket/repository.py
@@ -1,3 +1,4 @@
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.locks import locks
 from sentry.models.apitoken import generate_token
 from sentry.models.options.organization_option import OrganizationOption
@@ -10,7 +11,7 @@ from sentry.utils.http import absolute_uri
 
 class BitbucketRepositoryProvider(IntegrationRepositoryProvider):
     name = "Bitbucket"
-    repo_provider = "bitbucket"
+    repo_provider = IntegrationProviderSlug.BITBUCKET.value
 
     def get_repository_data(self, organization, config):
         installation = self.get_installation(config.get("installation"), organization.id)

--- a/src/sentry/integrations/bitbucket/search.py
+++ b/src/sentry/integrations/bitbucket/search.py
@@ -14,6 +14,7 @@ from sentry.integrations.source_code_management.metrics import (
     SourceCodeSearchEndpointHaltReason,
 )
 from sentry.integrations.source_code_management.search import SourceCodeSearchEndpoint
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.shared_integrations.exceptions import ApiError
 
 logger = logging.getLogger("sentry.integrations.bitbucket")
@@ -34,7 +35,7 @@ class BitbucketSearchEndpoint(SourceCodeSearchEndpoint):
 
     @property
     def integration_provider(self):
-        return "bitbucket"
+        return IntegrationProviderSlug.BITBUCKET.value
 
     @property
     def installation_class(self):

--- a/src/sentry/integrations/bitbucket/uninstalled.py
+++ b/src/sentry/integrations/bitbucket/uninstalled.py
@@ -11,6 +11,7 @@ from sentry.constants import ObjectStatus
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.services.repository import repository_service
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.integrations.utils.atlassian_connect import (
     AtlassianConnectValidationError,
     get_integration_from_jwt,
@@ -38,7 +39,11 @@ class BitbucketUninstalledEndpoint(Endpoint):
 
         try:
             rpc_integration = get_integration_from_jwt(
-                token, request.path, "bitbucket", request.GET, method="POST"
+                token,
+                request.path,
+                IntegrationProviderSlug.BITBUCKET.value,
+                request.GET,
+                method="POST",
             )
         except AtlassianConnectValidationError:
             return self.respond(status=400)

--- a/src/sentry/integrations/bitbucket/webhook.py
+++ b/src/sentry/integrations/bitbucket/webhook.py
@@ -22,6 +22,7 @@ from sentry.integrations.base import IntegrationDomain
 from sentry.integrations.bitbucket.constants import BITBUCKET_IP_RANGES, BITBUCKET_IPS
 from sentry.integrations.services.integration.service import integration_service
 from sentry.integrations.source_code_management.webhook import SCMWebhook
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.integrations.utils.metrics import IntegrationWebhookEvent, IntegrationWebhookEventType
 from sentry.models.commit import Commit
 from sentry.models.commitauthor import CommitAuthor
@@ -74,7 +75,7 @@ class WebhookInvalidSignatureException(SentryAPIException):
 class BitbucketWebhook(SCMWebhook, ABC):
     @property
     def provider(self) -> str:
-        return "bitbucket"
+        return IntegrationProviderSlug.BITBUCKET.value
 
     def update_repo_data(self, repo: Repository, event: Mapping[str, Any]) -> None:
         """

--- a/src/sentry/integrations/bitbucket_server/integration.py
+++ b/src/sentry/integrations/bitbucket_server/integration.py
@@ -369,7 +369,7 @@ class BitbucketServerIntegration(RepositoryIntegration):
 
 
 class BitbucketServerIntegrationProvider(IntegrationProvider):
-    key = "bitbucket_server"
+    key = IntegrationProviderSlug.BITBUCKET_SERVER.value
     name = "Bitbucket Server"
     metadata = metadata
     integration_cls = BitbucketServerIntegration

--- a/src/sentry/integrations/jira/actions/create_ticket.py
+++ b/src/sentry/integrations/jira/actions/create_ticket.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from sentry.integrations.jira.actions.form import JiraNotifyServiceForm
 from sentry.integrations.services.integration import RpcIntegration
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.rules.actions import TicketEventAction
 from sentry.utils.http import absolute_uri
 
@@ -13,7 +14,7 @@ class JiraCreateTicketAction(TicketEventAction):
     label = "Create a Jira issue in {integration} with these "
     ticket_type = "a Jira issue"
     link = "https://docs.sentry.io/product/integrations/issue-tracking/jira/#issue-sync"
-    provider = "jira"
+    provider = IntegrationProviderSlug.JIRA.value
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)

--- a/src/sentry/integrations/jira/actions/form.py
+++ b/src/sentry/integrations/jira/actions/form.py
@@ -6,11 +6,12 @@ from django import forms
 from django.utils.translation import gettext_lazy as _
 
 from sentry.integrations.services.integration.service import integration_service
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.rules.actions import IntegrationNotifyServiceForm
 
 
 class JiraNotifyServiceForm(IntegrationNotifyServiceForm):
-    provider = "jira"
+    provider = IntegrationProviderSlug.JIRA.value
 
     def clean(self) -> dict[str, Any] | None:
         cleaned_data = super().clean()

--- a/src/sentry/integrations/jira/client.py
+++ b/src/sentry/integrations/jira/client.py
@@ -9,6 +9,7 @@ from requests import PreparedRequest
 from sentry.integrations.client import ApiClient
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.services.integration.model import RpcIntegration
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.integrations.utils.atlassian_connect import get_query_hash
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.utils import jwt
@@ -44,7 +45,7 @@ class JiraCloudClient(ApiClient):
     AUTOCOMPLETE_URL = "/rest/api/2/jql/autocompletedata/suggestions"
     PROPERTIES_URL = "/rest/api/3/issue/%s/properties/%s"
 
-    integration_name = "jira"
+    integration_name = IntegrationProviderSlug.JIRA.value
 
     # This timeout is completely arbitrary. Jira doesn't give us any
     # caching headers to work with. Ideally we want a duration that

--- a/src/sentry/integrations/jira/endpoints/search.py
+++ b/src/sentry/integrations/jira/endpoints/search.py
@@ -12,6 +12,7 @@ from sentry.api.base import control_silo_endpoint
 from sentry.integrations.api.bases.integration import IntegrationEndpoint
 from sentry.integrations.jira.integration import JiraProjectMapping
 from sentry.integrations.models.integration import Integration
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.organizations.services.organization import RpcOrganization
 from sentry.shared_integrations.exceptions import ApiError, ApiUnauthorized, IntegrationError
 
@@ -29,7 +30,7 @@ class JiraSearchEndpoint(IntegrationEndpoint):
     Called by our front end when it needs to make requests to Jira's API for data.
     """
 
-    provider = "jira"
+    provider = IntegrationProviderSlug.JIRA.value
 
     def _get_integration(self, organization: RpcOrganization, integration_id: int) -> Integration:
         return Integration.objects.get(

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -1149,9 +1149,9 @@ class JiraIntegrationProvider(IntegrationProvider):
         # yet, we can't make API calls for more details like the server name or
         # Icon.
         # two ways build_integration can be called
-        if state.get("jira"):
-            metadata = state["jira"]["metadata"]
-            external_id = state["jira"]["external_id"]
+        if state.get(IntegrationProviderSlug.JIRA.value):
+            metadata = state[IntegrationProviderSlug.JIRA.value]["metadata"]
+            external_id = state[IntegrationProviderSlug.JIRA.value]["external_id"]
         else:
             external_id = state["clientKey"]
             metadata = {
@@ -1164,7 +1164,7 @@ class JiraIntegrationProvider(IntegrationProvider):
             }
         return {
             "external_id": external_id,
-            "provider": "jira",
+            "provider": IntegrationProviderSlug.JIRA.value,
             "name": "JIRA",
             "metadata": metadata,
         }

--- a/src/sentry/integrations/jira/views/extension_configuration.py
+++ b/src/sentry/integrations/jira/views/extension_configuration.py
@@ -1,5 +1,6 @@
 import orjson
 
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.integrations.web.integration_extension_configuration import (
     IntegrationExtensionConfigurationView,
 )
@@ -18,8 +19,8 @@ class JiraExtensionConfigurationView(IntegrationExtensionConfigurationView):
     Handle the UI for adding the Jira integration to a Sentry org.
     """
 
-    provider = "jira"
-    external_provider_key = "jira"
+    provider = IntegrationProviderSlug.JIRA.value
+    external_provider_key = IntegrationProviderSlug.JIRA.value
 
     def map_params_to_state(self, original_params):
         # decode the signed params and add them to whatever params we have

--- a/src/sentry/integrations/jira/views/sentry_installation.py
+++ b/src/sentry/integrations/jira/views/sentry_installation.py
@@ -3,6 +3,7 @@ from jwt import ExpiredSignatureError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.integrations.utils.atlassian_connect import (
     AtlassianConnectValidationError,
     get_integration_from_request,
@@ -26,7 +27,7 @@ class JiraSentryInstallationView(JiraSentryUIBaseView):
 
     def get(self, request: Request, *args, **kwargs) -> Response:
         try:
-            integration = get_integration_from_request(request, "jira")
+            integration = get_integration_from_request(request, IntegrationProviderSlug.JIRA.value)
         except AtlassianConnectValidationError:
             return self.get_response({"error_message": UNABLE_TO_VERIFY_INSTALLATION})
         except ExpiredSignatureError:

--- a/src/sentry/integrations/jira/webhooks/base.py
+++ b/src/sentry/integrations/jira/webhooks/base.py
@@ -16,6 +16,7 @@ from rest_framework.response import Response
 from sentry_sdk import Scope
 
 from sentry.api.base import Endpoint
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.integrations.utils.atlassian_connect import AtlassianConnectValidationError, get_token
 from sentry.shared_integrations.exceptions import ApiError
 
@@ -33,7 +34,7 @@ class JiraWebhookBase(Endpoint, abc.ABC):
 
     authentication_classes = ()
     permission_classes = ()
-    provider = "jira"
+    provider = IntegrationProviderSlug.JIRA.value
 
     @csrf_exempt
     def dispatch(self, request: HttpRequest, *args, **kwargs) -> HttpResponseBase:

--- a/src/sentry/integrations/jira_server/actions/create_ticket.py
+++ b/src/sentry/integrations/jira_server/actions/create_ticket.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from sentry.integrations.jira_server.actions.form import JiraServerNotifyServiceForm
 from sentry.integrations.services.integration import RpcIntegration
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.rules.actions import TicketEventAction
 from sentry.utils.http import absolute_uri
 
@@ -13,7 +14,7 @@ class JiraServerCreateTicketAction(TicketEventAction):
     label = "Create a Jira Server issue in {integration} with these "
     ticket_type = "a Jira Server issue"
     link = "https://docs.sentry.io/product/integrations/issue-tracking/jira/#issue-sync"
-    provider = "jira_server"
+    provider = IntegrationProviderSlug.JIRA_SERVER.value
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)

--- a/src/sentry/integrations/jira_server/actions/form.py
+++ b/src/sentry/integrations/jira_server/actions/form.py
@@ -6,11 +6,12 @@ from django import forms
 from django.utils.translation import gettext_lazy as _
 
 from sentry.integrations.services.integration.service import integration_service
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.rules.actions import IntegrationNotifyServiceForm
 
 
 class JiraServerNotifyServiceForm(IntegrationNotifyServiceForm):
-    provider = "jira_server"
+    provider = IntegrationProviderSlug.JIRA_SERVER.value
 
     def clean(self) -> dict[str, Any] | None:
         cleaned_data = super().clean() or {}

--- a/src/sentry/integrations/jira_server/client.py
+++ b/src/sentry/integrations/jira_server/client.py
@@ -15,6 +15,7 @@ from sentry.integrations.base import IntegrationDomain
 from sentry.integrations.client import ApiClient
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.services.integration.model import RpcIntegration
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.integrations.utils.metrics import (
     IntegrationPipelineViewEvent,
     IntegrationPipelineViewType,
@@ -51,7 +52,7 @@ class JiraServerClient(ApiClient):
     AUTOCOMPLETE_URL = "/rest/api/2/jql/autocompletedata/suggestions"
     PROPERTIES_URL = "/rest/api/3/issue/%s/properties/%s"
 
-    integration_name = "jira_server"
+    integration_name = IntegrationProviderSlug.JIRA_SERVER.value
 
     # This timeout is completely arbitrary. Jira doesn't give us any
     # caching headers to work with. Ideally we want a duration that

--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -563,7 +563,11 @@ class JiraServerIntegration(IssueSyncIntegration):
 
         default_comment = "Linked Sentry Issue: [{}|{}]".format(
             group.qualified_short_id,
-            absolute_uri(group.get_absolute_url(params={"referrer": "jira_server"})),
+            absolute_uri(
+                group.get_absolute_url(
+                    params={"referrer": IntegrationProviderSlug.JIRA_SERVER.value}
+                )
+            ),
         )
         fields.append(
             {
@@ -1414,7 +1418,7 @@ class JiraServerIntegrationProvider(IntegrationProvider):
 
         return {
             "name": install["consumer_key"],
-            "provider": "jira_server",
+            "provider": IntegrationProviderSlug.JIRA_SERVER.value,
             "external_id": external_id,
             "metadata": {
                 "base_url": install["url"],
@@ -1423,7 +1427,7 @@ class JiraServerIntegrationProvider(IntegrationProvider):
                 "webhook_secret": webhook_secret,
             },
             "user_identity": {
-                "type": "jira_server",
+                "type": IntegrationProviderSlug.JIRA_SERVER.value,
                 "external_id": external_id,
                 "scopes": [],
                 "data": credentials,

--- a/src/sentry/integrations/jira_server/search.py
+++ b/src/sentry/integrations/jira_server/search.py
@@ -10,6 +10,7 @@ from sentry.api.base import control_silo_endpoint
 from sentry.integrations.api.bases.integration import IntegrationEndpoint
 from sentry.integrations.jira_server.integration import JiraServerIntegration
 from sentry.integrations.models.integration import Integration
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.organizations.services.organization import RpcOrganization
 from sentry.shared_integrations.exceptions import ApiError, ApiUnauthorized, IntegrationError
 
@@ -22,7 +23,7 @@ class JiraServerSearchEndpoint(IntegrationEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }
-    provider = "jira_server"
+    provider = IntegrationProviderSlug.JIRA_SERVER.value
 
     def _get_integration(self, organization, integration_id) -> Integration:
         return Integration.objects.get(

--- a/src/sentry/integrations/msteams/card_builder/base.py
+++ b/src/sentry/integrations/msteams/card_builder/base.py
@@ -9,7 +9,6 @@ from sentry.integrations.msteams.card_builder.block import (
     Block,
     create_text_block,
 )
-from sentry.integrations.types import IntegrationProviderSlug
 
 
 class MSTeamsMessageBuilder:
@@ -50,5 +49,5 @@ class MSTeamsMessageBuilder:
             "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
             "version": "1.2",
             "actions": actions or [],
-            IntegrationProviderSlug.MSTEAMS.value: {"width": "Full"},
+            "msteams": {"width": "Full"},
         }

--- a/src/sentry/integrations/msteams/card_builder/base.py
+++ b/src/sentry/integrations/msteams/card_builder/base.py
@@ -9,6 +9,7 @@ from sentry.integrations.msteams.card_builder.block import (
     Block,
     create_text_block,
 )
+from sentry.integrations.types import IntegrationProviderSlug
 
 
 class MSTeamsMessageBuilder:
@@ -49,5 +50,5 @@ class MSTeamsMessageBuilder:
             "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
             "version": "1.2",
             "actions": actions or [],
-            "msteams": {"width": "Full"},
+            IntegrationProviderSlug.MSTEAMS.value: {"width": "Full"},
         }

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -321,7 +321,7 @@ def get_suspect_commit_text(group: Group) -> str | None:
         repo_base = repo.url
         provider = repo.provider
         if repo_base and provider in SUPPORTED_COMMIT_PROVIDERS:
-            if "bitbucket" in provider:
+            if IntegrationProviderSlug.BITBUCKET.value in provider:
                 commit_link = f"<{repo_base}/commits/{commit_id}"
             else:
                 commit_link = f"<{repo_base}/commit/{commit_id}"

--- a/src/sentry/integrations/vsts/actions/create_ticket.py
+++ b/src/sentry/integrations/vsts/actions/create_ticket.py
@@ -1,5 +1,6 @@
 import logging
 
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.rules.actions import TicketEventAction
 from sentry.utils.http import absolute_uri
 
@@ -11,7 +12,7 @@ class AzureDevopsCreateTicketAction(TicketEventAction):
     label = "Create an Azure DevOps work item in {integration} with these "
     ticket_type = "an Azure DevOps work item"
     link = "https://docs.sentry.io/product/integrations/source-code-mgmt/azure-devops/#issue-sync"
-    provider = "vsts"
+    provider = IntegrationProviderSlug.AZURE_DEVOPS.value
 
     def generate_footer(self, rule_url: str) -> str:
         return "\nThis work item was automatically created by Sentry via [{}]({})".format(

--- a/src/sentry/integrations/vsts/client.py
+++ b/src/sentry/integrations/vsts/client.py
@@ -13,6 +13,7 @@ from sentry.exceptions import InvalidIdentity
 from sentry.integrations.client import ApiClient
 from sentry.integrations.services.integration.service import integration_service
 from sentry.integrations.source_code_management.repository import RepositoryClient
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.repository import Repository
 from sentry.shared_integrations.client.proxy import IntegrationProxyClient
 from sentry.silo.base import control_silo_function
@@ -118,7 +119,7 @@ def _create_subscription_data(shared_secret: str) -> dict[str, Any]:
 
 
 class VstsSetupApiClient(ApiClient):
-    integration_name = "vsts"
+    integration_name = IntegrationProviderSlug.AZURE_DEVOPS.value
     api_version = "4.1"  # TODO: update api version
     api_version_preview = "-preview.1"
 
@@ -145,7 +146,7 @@ class VstsSetupApiClient(ApiClient):
 
 
 class VstsApiClient(IntegrationProxyClient, RepositoryClient):
-    integration_name = "vsts"
+    integration_name = IntegrationProviderSlug.AZURE_DEVOPS.value
     api_version = "4.1"  # TODO: update api version
     api_version_preview = "-preview.1"
     _identity: Identity | None = None

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -144,7 +144,7 @@ class VstsIntegration(RepositoryIntegration, VstsIssuesSpec):
 
     @property
     def integration_name(self) -> str:
-        return "vsts"
+        return IntegrationProviderSlug.AZURE_DEVOPS.value
 
     def get_client(self) -> VstsApiClient:
         base_url = self.instance
@@ -502,7 +502,7 @@ class VstsIntegrationProvider(IntegrationProvider):
             "external_id": account["accountId"],
             "metadata": {"domain_name": base_url, "scopes": scopes},
             "user_identity": {
-                "type": "vsts",
+                "type": IntegrationProviderSlug.AZURE_DEVOPS.value,
                 "external_id": user["id"],
                 "scopes": scopes,
                 "data": oauth_data,
@@ -512,7 +512,9 @@ class VstsIntegrationProvider(IntegrationProvider):
         # TODO(iamrajjoshi): Clean this up this after Azure DevOps migration is complete
         try:
             integration_model = IntegrationModel.objects.get(
-                provider="vsts", external_id=account["accountId"], status=ObjectStatus.ACTIVE
+                provider=IntegrationProviderSlug.AZURE_DEVOPS.value,
+                external_id=account["accountId"],
+                status=ObjectStatus.ACTIVE,
             )
 
             # Get Integration Metadata

--- a/src/sentry/integrations/vsts/issues.py
+++ b/src/sentry/integrations/vsts/issues.py
@@ -14,6 +14,7 @@ from sentry.integrations.mixins import ResolveSyncAction
 from sentry.integrations.mixins.issues import IssueSyncIntegration
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.source_code_management.issues import SourceCodeIssueIntegration
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.activity import Activity
 from sentry.shared_integrations.exceptions import (
     ApiError,
@@ -46,7 +47,7 @@ VSTS_INTEGRATION_FORM_ERROR_CODES_SUBSTRINGS = ["TF401320"]
 
 class VstsIssuesSpec(IssueSyncIntegration, SourceCodeIssueIntegration, ABC):
     description = "Integrate Azure DevOps work items by linking a project."
-    slug = "vsts"
+    slug = IntegrationProviderSlug.AZURE_DEVOPS.value
     conf_key = slug
 
     issue_fields = frozenset(["id", "title", "url"])

--- a/src/sentry/integrations/vsts/repository.py
+++ b/src/sentry/integrations/vsts/repository.py
@@ -4,6 +4,7 @@ import logging
 from collections.abc import Mapping, MutableMapping, Sequence
 from typing import Any
 
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.organization import Organization
 from sentry.models.repository import Repository
 from sentry.organizations.services.organization.model import RpcOrganization
@@ -16,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 class VstsRepositoryProvider(IntegrationRepositoryProvider):
     name = "Azure DevOps"
-    repo_provider = "vsts"
+    repo_provider = IntegrationProviderSlug.AZURE_DEVOPS.value
 
     def get_repository_data(
         self, organization: Organization, config: MutableMapping[str, Any]

--- a/src/sentry/integrations/vsts/search.py
+++ b/src/sentry/integrations/vsts/search.py
@@ -6,6 +6,7 @@ from sentry.api.base import control_silo_endpoint
 from sentry.integrations.source_code_management.issues import SourceCodeIssueIntegration
 from sentry.integrations.source_code_management.metrics import SCMIntegrationInteractionType
 from sentry.integrations.source_code_management.search import SourceCodeSearchEndpoint
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.integrations.vsts.integration import VstsIntegration
 
 T = TypeVar("T", bound=SourceCodeIssueIntegration)
@@ -15,7 +16,7 @@ T = TypeVar("T", bound=SourceCodeIssueIntegration)
 class VstsSearchEndpoint(SourceCodeSearchEndpoint):
     @property
     def integration_provider(self):
-        return "vsts"
+        return IntegrationProviderSlug.AZURE_DEVOPS.value
 
     @property
     def installation_class(self):

--- a/src/sentry/integrations/vsts/tasks/kickoff_subscription_check.py
+++ b/src/sentry/integrations/vsts/tasks/kickoff_subscription_check.py
@@ -3,6 +3,7 @@ from time import time
 
 from sentry.constants import ObjectStatus
 from sentry.integrations.models.organization_integration import OrganizationIntegration
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task, retry
 from sentry.taskworker.config import TaskworkerConfig
@@ -29,7 +30,7 @@ def kickoff_vsts_subscription_check() -> None:
     from sentry.integrations.vsts.tasks import vsts_subscription_check
 
     organization_integrations = OrganizationIntegration.objects.filter(
-        integration__provider="vsts",
+        integration__provider=IntegrationProviderSlug.AZURE_DEVOPS.value,
         integration__status=ObjectStatus.ACTIVE,
         status=ObjectStatus.ACTIVE,
     ).select_related("integration")

--- a/src/sentry/integrations/vsts/webhooks.py
+++ b/src/sentry/integrations/vsts/webhooks.py
@@ -21,6 +21,7 @@ from sentry.integrations.project_management.metrics import (
     ProjectManagementHaltReason,
 )
 from sentry.integrations.services.integration import integration_service
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.integrations.utils.metrics import IntegrationWebhookEvent, IntegrationWebhookEventType
 from sentry.integrations.utils.sync import sync_group_assignee_inbound
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
@@ -32,7 +33,6 @@ if TYPE_CHECKING:
 
 UNSET = object()
 logger = logging.getLogger("sentry.integrations")
-PROVIDER_KEY = "vsts"
 
 
 def get_vsts_external_id(data: Mapping[str, Any]) -> str:
@@ -70,7 +70,9 @@ class WorkItemWebhook(Endpoint):
         # https://docs.microsoft.com/en-us/azure/devops/service-hooks/events?view=azure-devops#workitem.updated
         if event_type == "workitem.updated":
             integration = integration_service.get_integration(
-                provider=PROVIDER_KEY, external_id=external_id, status=ObjectStatus.ACTIVE
+                provider=IntegrationProviderSlug.AZURE_DEVOPS.value,
+                external_id=external_id,
+                status=ObjectStatus.ACTIVE,
             )
             if integration is None:
                 logger.info(
@@ -87,7 +89,7 @@ class WorkItemWebhook(Endpoint):
             with IntegrationWebhookEvent(
                 interaction_type=IntegrationWebhookEventType.INBOUND_SYNC,
                 domain=IntegrationDomain.SOURCE_CODE_MANAGEMENT,
-                provider_key="vsts",
+                provider_key=IntegrationProviderSlug.AZURE_DEVOPS.value,
             ).capture():
                 handle_updated_workitem(data, integration)
 

--- a/src/sentry/integrations/vsts_extension/integration.py
+++ b/src/sentry/integrations/vsts_extension/integration.py
@@ -8,6 +8,7 @@ from django.http.response import HttpResponseBase
 
 from sentry.integrations.base import IntegrationData
 from sentry.integrations.pipeline import IntegrationPipeline
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.integrations.vsts.integration import AccountConfigView, VstsIntegrationProvider
 from sentry.pipeline.views.base import PipelineView
 from sentry.utils.http import absolute_uri
@@ -15,7 +16,7 @@ from sentry.utils.http import absolute_uri
 
 class VstsExtensionIntegrationProvider(VstsIntegrationProvider):
     key = "vsts-extension"
-    integration_key = "vsts"
+    integration_key = IntegrationProviderSlug.AZURE_DEVOPS.value
 
     # This is only to enable the VSTS -> Sentry installation flow, so we don't
     # want it to actually appear of the Integrations page.
@@ -32,8 +33,8 @@ class VstsExtensionIntegrationProvider(VstsIntegrationProvider):
             {
                 **state,
                 "account": {
-                    "accountId": state["vsts"]["accountId"],
-                    "accountName": state["vsts"]["accountName"],
+                    "accountId": state[IntegrationProviderSlug.AZURE_DEVOPS.value]["accountId"],
+                    "accountName": state[IntegrationProviderSlug.AZURE_DEVOPS.value]["accountName"],
                 },
             }
         )

--- a/src/sentry/integrations/web/vsts_extension_configuration.py
+++ b/src/sentry/integrations/web/vsts_extension_configuration.py
@@ -1,5 +1,6 @@
 import re
 
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.web.frontend.base import control_silo_view
 
 from .integration_extension_configuration import IntegrationExtensionConfigurationView
@@ -7,7 +8,7 @@ from .integration_extension_configuration import IntegrationExtensionConfigurati
 
 @control_silo_view
 class VstsExtensionConfigurationView(IntegrationExtensionConfigurationView):
-    provider = "vsts"
+    provider = IntegrationProviderSlug.AZURE_DEVOPS.value
     external_provider_key = "vsts-extension"
 
     def _is_valid_account_name(self, account_name: str) -> bool:

--- a/src/sentry/middleware/integrations/parsers/bitbucket.py
+++ b/src/sentry/middleware/integrations/parsers/bitbucket.py
@@ -6,6 +6,7 @@ from typing import Any
 from sentry.hybridcloud.outbox.category import WebhookProviderIdentifier
 from sentry.integrations.bitbucket.webhook import BitbucketWebhookEndpoint
 from sentry.integrations.middleware.hybrid_cloud.parser import BaseRequestParser
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.types.region import RegionResolutionError, get_region_by_name
 
@@ -13,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 class BitbucketRequestParser(BaseRequestParser):
-    provider = "bitbucket"
+    provider = IntegrationProviderSlug.BITBUCKET.value
     webhook_identifier = WebhookProviderIdentifier.BITBUCKET
 
     def get_bitbucket_webhook_response(self):

--- a/src/sentry/middleware/integrations/parsers/jira.py
+++ b/src/sentry/middleware/integrations/parsers/jira.py
@@ -18,6 +18,7 @@ from sentry.integrations.jira.webhooks import (
 )
 from sentry.integrations.middleware.hybrid_cloud.parser import BaseRequestParser
 from sentry.integrations.models.integration import Integration
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.integrations.utils.atlassian_connect import (
     AtlassianConnectValidationError,
     parse_integration_from_request,
@@ -28,7 +29,7 @@ logger = logging.getLogger(__name__)
 
 
 class JiraRequestParser(BaseRequestParser):
-    provider = "jira"
+    provider = IntegrationProviderSlug.JIRA.value
     webhook_identifier = WebhookProviderIdentifier.JIRA
 
     control_classes = [

--- a/src/sentry/middleware/integrations/parsers/jira_server.py
+++ b/src/sentry/middleware/integrations/parsers/jira_server.py
@@ -14,12 +14,13 @@ from sentry.integrations.jira_server.webhooks import (
     get_integration_from_token,
 )
 from sentry.integrations.middleware.hybrid_cloud.parser import BaseRequestParser
+from sentry.integrations.types import IntegrationProviderSlug
 
 logger = logging.getLogger(__name__)
 
 
 class JiraServerRequestParser(BaseRequestParser):
-    provider = "jira_server"
+    provider = IntegrationProviderSlug.JIRA_SERVER.value
     webhook_identifier = WebhookProviderIdentifier.JIRA_SERVER
 
     def get_response_from_issue_update_webhook(self):

--- a/src/sentry/middleware/integrations/parsers/vsts.py
+++ b/src/sentry/middleware/integrations/parsers/vsts.py
@@ -9,6 +9,7 @@ from django.http.response import HttpResponseBase
 from sentry.hybridcloud.outbox.category import WebhookProviderIdentifier
 from sentry.integrations.middleware.hybrid_cloud.parser import BaseRequestParser
 from sentry.integrations.models.integration import Integration
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.integrations.vsts.webhooks import WorkItemWebhook, get_vsts_external_id
 from sentry.silo.base import control_silo_function
 
@@ -16,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 class VstsRequestParser(BaseRequestParser):
-    provider = "vsts"
+    provider = IntegrationProviderSlug.AZURE_DEVOPS.value
     webhook_identifier = WebhookProviderIdentifier.VSTS
 
     region_view_classes = [WorkItemWebhook]

--- a/src/social_auth/backends/bitbucket.py
+++ b/src/social_auth/backends/bitbucket.py
@@ -11,6 +11,7 @@ stored in extra_data field, check OAuthBackend class for details on how to
 extend it.
 """
 
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.utils import json
 from social_auth.backends import BaseOAuth1, OAuthBackend
 from social_auth.utils import dsa_urlopen
@@ -27,7 +28,7 @@ BITBUCKET_USER_DATA_URL = "https://%s/users/" % BITBUCKET_SERVER
 class BitbucketBackend(OAuthBackend):
     """Bitbucket OAuth authentication backend"""
 
-    name = "bitbucket"
+    name = IntegrationProviderSlug.BITBUCKET.value
     EXTRA_DATA = [
         ("username", "username"),
         ("expires", "expires"),
@@ -109,4 +110,4 @@ class BitbucketAuth(BaseOAuth1):
 
 
 # Backend definition
-BACKENDS = {"bitbucket": BitbucketAuth}
+BACKENDS = {IntegrationProviderSlug.BITBUCKET.value: BitbucketAuth}


### PR DESCRIPTION
Finally removed all use cases of constants for integration name from our codebase. Now we just have to make sure we are mindful of this during PR reviews


closes ECO-541