### PR TITLE
feat(explore-sus-attrs): Bumping virtualization overscan to 10

### DIFF
--- a/static/app/views/explore/components/suspectTags/charts.tsx
+++ b/static/app/views/explore/components/suspectTags/charts.tsx
@@ -31,7 +31,7 @@ export function Charts({rankedAttributes, searchQuery}: Props) {
     count: rankedAttributes.length,
     getScrollElement: () => scrollContainerRef.current,
     estimateSize: () => 200,
-    overscan: 5,
+    overscan: 10,
   });
 
   const virtualItems = virtualizer.getVirtualItems();


### PR DESCRIPTION
- Each row is tall, at 200px. When a row is blank (happens with virtualization as it mounts and unmounts rows) it covers alot of the vertical real-estate. 
- Increasing over-scan helps mitigate blank rows when the user speed scrolls.