### PR TITLE
feat(aci): Add search bar to connected automations drawer

### DIFF
--- a/static/app/views/automations/components/automationListTable/search.tsx
+++ b/static/app/views/automations/components/automationListTable/search.tsx
@@ -3,9 +3,12 @@ import {t} from 'sentry/locale';
 import type {TagCollection} from 'sentry/types/group';
 import type {FieldDefinition} from 'sentry/utils/fields';
 import {FieldKind} from 'sentry/utils/fields';
-import {useLocation} from 'sentry/utils/useLocation';
-import {useNavigate} from 'sentry/utils/useNavigate';
 import {AUTOMATION_FILTER_KEYS} from 'sentry/views/automations/constants';
+
+type AutomationSearchProps = {
+  initialQuery: string;
+  onSearch: (query: string) => void;
+};
 
 function getAutomationFilterKeyDefinition(filterKey: string): FieldDefinition | null {
   if (
@@ -42,24 +45,12 @@ const FILTER_KEYS: TagCollection = Object.fromEntries(
   })
 );
 
-export function AutomationSearch() {
-  const location = useLocation();
-  const navigate = useNavigate();
-  const query = typeof location.query.query === 'string' ? location.query.query : '';
-
+export function AutomationSearch({initialQuery, onSearch}: AutomationSearchProps) {
   return (
     <SearchQueryBuilder
-      initialQuery={query}
+      initialQuery={initialQuery}
       placeholder={t('Search for automations')}
-      onSearch={searchQuery => {
-        navigate({
-          pathname: location.pathname,
-          query: {
-            ...location.query,
-            query: searchQuery,
-          },
-        });
-      }}
+      onSearch={onSearch}
       filterKeys={FILTER_KEYS}
       getTagValues={() => Promise.resolve([])}
       searchSource="automations-list"

--- a/static/app/views/automations/list.tsx
+++ b/static/app/views/automations/list.tsx
@@ -96,7 +96,7 @@ function TableHeader() {
     (query: string) => {
       navigate({
         pathname: location.pathname,
-        query: {...location.query, query},
+        query: {...location.query, query, cursor: undefined},
       });
     },
     [location.pathname, location.query, navigate]

--- a/static/app/views/automations/list.tsx
+++ b/static/app/views/automations/list.tsx
@@ -1,4 +1,4 @@
-import {Fragment} from 'react';
+import {Fragment, useCallback} from 'react';
 
 import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {Flex} from 'sentry/components/core/layout';
@@ -87,11 +87,26 @@ export default function AutomationsList() {
 }
 
 function TableHeader() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const initialQuery =
+    typeof location.query.query === 'string' ? location.query.query : '';
+
+  const onSearch = useCallback(
+    (query: string) => {
+      navigate({
+        pathname: location.pathname,
+        query: {...location.query, query},
+      });
+    },
+    [location.pathname, location.query, navigate]
+  );
+
   return (
     <Flex gap={space(2)}>
       <ProjectPageFilter size="md" />
       <div style={{flexGrow: 1}}>
-        <AutomationSearch />
+        <AutomationSearch initialQuery={initialQuery} onSearch={onSearch} />
       </div>
     </Flex>
   );

--- a/static/app/views/detectors/components/connectedAutomationList.tsx
+++ b/static/app/views/detectors/components/connectedAutomationList.tsx
@@ -29,6 +29,7 @@ type Props = React.HTMLAttributes<HTMLDivElement> & {
   connectedAutomationIds?: Set<string>;
   emptyMessage?: string;
   limit?: number | null;
+  query?: string;
   toggleConnected?: (params: {automation: Automation}) => void;
 };
 
@@ -65,6 +66,7 @@ export function ConnectedAutomationsList({
   cursor,
   onCursor,
   limit = DEFAULT_AUTOMATIONS_PER_PAGE,
+  query,
   ...props
 }: Props) {
   const canEdit = Boolean(
@@ -82,6 +84,7 @@ export function ConnectedAutomationsList({
       ids: automationIds ?? undefined,
       limit: limit ?? undefined,
       cursor,
+      query,
     },
     {enabled: automationIds === null || automationIds.length > 0}
   );

--- a/static/app/views/detectors/components/forms/automateSection.tsx
+++ b/static/app/views/detectors/components/forms/automateSection.tsx
@@ -15,6 +15,7 @@ import {space} from 'sentry/styles/space';
 import type {Automation} from 'sentry/types/workflowEngine/automations';
 import {getApiQueryData, setApiQueryData, useQueryClient} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
+import {AutomationSearch} from 'sentry/views/automations/components/automationListTable/search';
 import {makeAutomationsQueryKey} from 'sentry/views/automations/hooks';
 import {ConnectedAutomationsList} from 'sentry/views/detectors/components/connectedAutomationList';
 
@@ -49,10 +50,15 @@ function AllAutomations({
   automationIds: string[];
   toggleConnected: (params: {automation: Automation}) => void;
 }) {
+  const [searchQuery, setSearchQuery] = useState('');
   const [cursor, setCursor] = useState<string | undefined>(undefined);
 
   return (
     <Section title={t('All Automations')}>
+      <AutomationSearch
+        initialQuery={searchQuery}
+        onSearch={query => setSearchQuery(query)}
+      />
       <ConnectedAutomationsList
         data-test-id="drawer-all-automations-list"
         automationIds={null}
@@ -61,6 +67,7 @@ function AllAutomations({
         emptyMessage={t('No automations found')}
         cursor={cursor}
         onCursor={setCursor}
+        query={searchQuery}
       />
     </Section>
   );

--- a/static/app/views/detectors/components/forms/automateSection.tsx
+++ b/static/app/views/detectors/components/forms/automateSection.tsx
@@ -52,13 +52,14 @@ function AllAutomations({
 }) {
   const [searchQuery, setSearchQuery] = useState('');
   const [cursor, setCursor] = useState<string | undefined>(undefined);
+  const onSearch = useCallback((query: string) => {
+    setSearchQuery(query);
+    setCursor(undefined);
+  }, []);
 
   return (
     <Section title={t('All Automations')}>
-      <AutomationSearch
-        initialQuery={searchQuery}
-        onSearch={query => setSearchQuery(query)}
-      />
+      <AutomationSearch initialQuery={searchQuery} onSearch={onSearch} />
       <ConnectedAutomationsList
         data-test-id="drawer-all-automations-list"
         automationIds={null}


### PR DESCRIPTION
Allows users to search for automations in the drawer. Had to modify the existing component to support both this and the list view use cases.

<img width="1394" height="470" alt="CleanShot 2025-07-14 at 15 31 46@2x" src="https://github.com/user-attachments/assets/bb6eb987-3f23-498b-86c7-d71e4526686c" />
