### PR TITLE
ref(ecosystem): refactor link_all_repos to bulk update repositories

### DIFF
--- a/src/sentry/integrations/bitbucket/repository.py
+++ b/src/sentry/integrations/bitbucket/repository.py
@@ -1,9 +1,12 @@
+from typing import Any
+
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.locks import locks
 from sentry.models.apitoken import generate_token
 from sentry.models.options.organization_option import OrganizationOption
 from sentry.organizations.services.organization.model import RpcOrganization
 from sentry.plugins.providers import IntegrationRepositoryProvider
+from sentry.plugins.providers.integration_repository import RepositoryConfig
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.utils.email import parse_email, parse_user_name
 from sentry.utils.http import absolute_uri
@@ -43,7 +46,9 @@ class BitbucketRepositoryProvider(IntegrationRepositoryProvider):
                 )
         return secret
 
-    def build_repository_config(self, organization: RpcOrganization, data):
+    def build_repository_config(
+        self, organization: RpcOrganization, data: dict[str, Any]
+    ) -> RepositoryConfig:
         installation = self.get_installation(data.get("installation"), organization.id)
         client = installation.get_client()
         try:

--- a/src/sentry/integrations/bitbucket_server/repository.py
+++ b/src/sentry/integrations/bitbucket_server/repository.py
@@ -1,11 +1,15 @@
 from datetime import datetime, timezone
+from typing import Any
 
 from django.core.cache import cache
 from django.urls import reverse
 
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.organizations.services.organization.model import RpcOrganization
-from sentry.plugins.providers.integration_repository import IntegrationRepositoryProvider
+from sentry.plugins.providers.integration_repository import (
+    IntegrationRepositoryProvider,
+    RepositoryConfig,
+)
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.utils.hashlib import md5_text
 from sentry.utils.http import absolute_uri
@@ -30,7 +34,9 @@ class BitbucketServerRepositoryProvider(IntegrationRepositoryProvider):
             config["repo"] = repo["name"]
         return config
 
-    def build_repository_config(self, organization: RpcOrganization, data):
+    def build_repository_config(
+        self, organization: RpcOrganization, data: dict[str, Any]
+    ) -> RepositoryConfig:
         installation = self.get_installation(data.get("installation"), organization.id)
         client = installation.get_client()
 

--- a/src/sentry/integrations/github/repository.py
+++ b/src/sentry/integrations/github/repository.py
@@ -12,6 +12,7 @@ from sentry.models.pullrequest import PullRequest
 from sentry.models.repository import Repository
 from sentry.organizations.services.organization.model import RpcOrganization
 from sentry.plugins.providers import IntegrationRepositoryProvider
+from sentry.plugins.providers.integration_repository import RepositoryConfig
 from sentry.shared_integrations.exceptions import ApiError, IntegrationError
 
 WEBHOOK_EVENTS = ["push", "pull_request"]
@@ -51,8 +52,8 @@ class GitHubRepositoryProvider(IntegrationRepositoryProvider):
         return config
 
     def build_repository_config(
-        self, organization: RpcOrganization, data: Mapping[str, Any]
-    ) -> Mapping[str, Any]:
+        self, organization: RpcOrganization, data: dict[str, Any]
+    ) -> RepositoryConfig:
         return {
             "name": data["identifier"],
             "external_id": data["external_id"],

--- a/src/sentry/integrations/github_enterprise/repository.py
+++ b/src/sentry/integrations/github_enterprise/repository.py
@@ -1,7 +1,10 @@
+from typing import Any
+
 from sentry.integrations.github.repository import GitHubRepositoryProvider
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.organizations.services.organization.model import RpcOrganization
+from sentry.plugins.providers.integration_repository import RepositoryConfig
 from sentry.shared_integrations.exceptions import ApiError, IntegrationError
 
 WEBHOOK_EVENTS = ["push", "pull_request"]
@@ -25,7 +28,9 @@ class GitHubEnterpriseRepositoryProvider(GitHubRepositoryProvider):
 
         return repo_data
 
-    def build_repository_config(self, organization: RpcOrganization, data):
+    def build_repository_config(
+        self, organization: RpcOrganization, data: dict[str, Any]
+    ) -> RepositoryConfig:
         integration = integration_service.get_integration(
             integration_id=data["integration_id"], provider=self.repo_provider
         )

--- a/src/sentry/integrations/gitlab/repository.py
+++ b/src/sentry/integrations/gitlab/repository.py
@@ -1,6 +1,9 @@
+from typing import Any
+
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.organizations.services.organization.model import RpcOrganization
 from sentry.plugins.providers import IntegrationRepositoryProvider
+from sentry.plugins.providers.integration_repository import RepositoryConfig
 from sentry.shared_integrations.exceptions import ApiError
 
 
@@ -31,7 +34,9 @@ class GitlabRepositoryProvider(IntegrationRepositoryProvider):
         )
         return config
 
-    def build_repository_config(self, organization: RpcOrganization, data):
+    def build_repository_config(
+        self, organization: RpcOrganization, data: dict[str, Any]
+    ) -> RepositoryConfig:
 
         installation = self.get_installation(data.get("installation"), organization.id)
         client = installation.get_client()

--- a/src/sentry/integrations/services/repository/impl.py
+++ b/src/sentry/integrations/services/repository/impl.py
@@ -106,7 +106,6 @@ class DatabaseBackedRepositoryService(RepositoryService):
         fields_to_update = set(list(update_mapping.values())[0].keys())
 
         with transaction.atomic(router.db_for_write(Repository)):
-
             repositories = Repository.objects.filter(
                 organization_id=organization_id, id__in=update_mapping.keys()
             )

--- a/src/sentry/integrations/vsts/repository.py
+++ b/src/sentry/integrations/vsts/repository.py
@@ -9,6 +9,7 @@ from sentry.models.organization import Organization
 from sentry.models.repository import Repository
 from sentry.organizations.services.organization.model import RpcOrganization
 from sentry.plugins.providers import IntegrationRepositoryProvider
+from sentry.plugins.providers.integration_repository import RepositoryConfig
 
 MAX_COMMIT_DATA_REQUESTS = 90
 
@@ -46,8 +47,8 @@ class VstsRepositoryProvider(IntegrationRepositoryProvider):
         return config
 
     def build_repository_config(
-        self, organization: RpcOrganization, data: Mapping[str, str]
-    ) -> Mapping[str, Any]:
+        self, organization: RpcOrganization, data: dict[str, Any]
+    ) -> RepositoryConfig:
         return {
             "name": data["name"],
             "external_id": data["external_id"],

--- a/src/sentry/plugins/providers/integration_repository.py
+++ b/src/sentry/plugins/providers/integration_repository.py
@@ -1,23 +1,20 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import MutableMapping
 from datetime import timezone
-from typing import Any, ClassVar
+from typing import Any, ClassVar, TypedDict
 
 from dateutil.parser import parse as parse_date
-from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import analytics
-from sentry.api.exceptions import SentryAPIException
 from sentry.constants import ObjectStatus
 from sentry.integrations.base import IntegrationInstallation
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.services.repository import repository_service
-from sentry.integrations.services.repository.model import RpcCreateRepository
+from sentry.integrations.services.repository.model import RpcCreateRepository, RpcRepository
 from sentry.models.repository import Repository
 from sentry.organizations.services.organization.model import RpcOrganization
 from sentry.shared_integrations.exceptions import IntegrationError
@@ -27,10 +24,22 @@ from sentry.users.services.user.serial import serialize_rpc_user
 from sentry.utils import metrics
 
 
-class RepoExistsError(SentryAPIException):
-    status_code = status.HTTP_400_BAD_REQUEST
-    code = "repo_exists"
-    message = "A repository with that configuration already exists"
+class RepositoryConfig(TypedDict):
+    name: str
+    external_id: str
+    url: str
+    config: dict[str, Any]
+    integration_id: int
+
+
+class RepoExistsError(Exception):
+    def __init__(self, repos: list[RepositoryConfig] | None = None):
+        self.repos = repos
+
+    def __str__(self):
+        if self.repos:
+            return f"Repositories already exist: {', '.join(repo['name'] for repo in self.repos)}"
+        return "Repositories already exist."
 
 
 def get_integration_repository_provider(integration):
@@ -83,15 +92,15 @@ class IntegrationRepositoryProvider:
 
     def create_repository(
         self,
-        repo_config: MutableMapping[str, Any],
+        repo_config: dict[str, Any],
         organization: RpcOrganization,
     ):
         result = self.build_repository_config(organization=organization, data=repo_config)
 
-        integration_id = result.get("integration_id")
-        external_id = result.get("external_id")
-        name = result.get("name")
-        url = result.get("url")
+        integration_id = result["integration_id"]
+        external_id = result["external_id"]
+        name = result["name"]
+        url = result["url"]
 
         # first check if there is an existing hidden repository for the organization and external id
         repositories = repository_service.get_repositories(
@@ -177,9 +186,95 @@ class IntegrationRepositoryProvider:
                         update=repo,
                     )
 
-            raise RepoExistsError
+            raise RepoExistsError(repos=[result])
 
         return result, repo
+
+    def _update_repository(self, repo: RpcRepository, config: RepositoryConfig):
+        repo.status = ObjectStatus.ACTIVE
+
+        for field_name, field_value in config.items():
+            setattr(repo, field_name, field_value)
+        return repo
+
+    def _update_repositories(
+        self,
+        repositories: list[RpcRepository],
+        external_id_to_repo_config: dict[str, RepositoryConfig],
+    ) -> list[RpcRepository]:
+        repos_to_update: list[RpcRepository] = []
+        for repo in repositories:
+            external_id = repo.external_id
+            if external_id and (repo_config := external_id_to_repo_config.get(external_id)):
+                repos_to_update.append(self._update_repository(repo, repo_config))
+                external_id_to_repo_config.pop(external_id, None)
+        return repos_to_update
+
+    def create_repositories(
+        self,
+        configs: list[dict[str, Any]],
+        organization: RpcOrganization,
+    ):
+        external_id_to_repo_config: dict[str, RepositoryConfig] = {}
+        for config in configs:
+            result = self.build_repository_config(organization=organization, data=config)
+            external_id_to_repo_config[result["external_id"]] = result
+
+        repos_to_update: list[RpcRepository] = []
+
+        hidden_repos = repository_service.get_repositories(
+            organization_id=organization.id,
+            status=ObjectStatus.HIDDEN,
+        )
+        repos_to_update.extend(self._update_repositories(hidden_repos, external_id_to_repo_config))
+
+        # then check if there are repositories without an integration that matches
+        repositories = repository_service.get_repositories(
+            organization_id=organization.id,
+            has_integration=False,
+        )
+        repos_to_update.extend(self._update_repositories(repositories, external_id_to_repo_config))
+
+        # create remaining repositories
+        missing_repos: list[RepositoryConfig] = []
+        for external_id, repo_config in external_id_to_repo_config.items():
+            integration_id = repo_config["integration_id"]
+            create_repository = RpcCreateRepository.parse_obj(
+                {**repo_config, "provider": self.id, "status": ObjectStatus.ACTIVE}
+            )
+            new_repository = repository_service.create_repository(
+                organization_id=organization.id, create=create_repository
+            )
+            if new_repository is not None:
+                continue
+
+            missing_repos.append(repo_config)
+            # Try to delete webhook we just created
+            try:
+                self.on_delete_repository(
+                    Repository(organization_id=organization.id, **repo_config)
+                )
+            except IntegrationError:
+                pass
+
+            # if possible update the repo with matching integration
+            repositories = repository_service.get_repositories(
+                organization_id=organization.id,
+                integration_id=integration_id,
+                external_id=external_id,
+            )
+            # We anticipate to only update one repository, but we update any duplicates as well.
+            for repo in repositories:
+                repos_to_update.append(self._update_repository(repo, repo_config))
+
+        if repos_to_update:
+            repository_service.update_repositories(
+                organization_id=organization.id,
+                updates=repos_to_update,
+            )
+
+        if missing_repos:
+            raise RepoExistsError(repos=missing_repos)
 
     def dispatch(self, request: Request, organization, **kwargs):
         try:
@@ -242,7 +337,9 @@ class IntegrationRepositoryProvider:
         """
         return config
 
-    def build_repository_config(self, organization: RpcOrganization, data):
+    def build_repository_config(
+        self, organization: RpcOrganization, data: dict[str, Any]
+    ) -> RepositoryConfig:
         """
         Builds final dict containing all necessary data to create the repository
 

--- a/src/sentry/plugins/providers/integration_repository.py
+++ b/src/sentry/plugins/providers/integration_repository.py
@@ -5,10 +5,12 @@ from datetime import timezone
 from typing import Any, ClassVar, TypedDict
 
 from dateutil.parser import parse as parse_date
+from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import analytics
+from sentry.api.exceptions import SentryAPIException
 from sentry.constants import ObjectStatus
 from sentry.integrations.base import IntegrationInstallation
 from sentry.integrations.models.integration import Integration
@@ -32,8 +34,20 @@ class RepositoryConfig(TypedDict):
     integration_id: int
 
 
-class RepoExistsError(Exception):
-    def __init__(self, repos: list[RepositoryConfig] | None = None):
+class RepoExistsError(SentryAPIException):
+    status_code = status.HTTP_400_BAD_REQUEST
+    code = "repo_exists"
+    message = "A repository with that configuration already exists"
+
+    def __init__(
+        self,
+        code=None,
+        message=None,
+        detail=None,
+        repos: list[RepositoryConfig] | None = None,
+        **kwargs,
+    ):
+        super().__init__(code=code, message=message, detail=detail, **kwargs)
         self.repos = repos
 
     def __str__(self):

--- a/tests/sentry/integrations/github/tasks/test_link_all_repos.py
+++ b/tests/sentry/integrations/github/tasks/test_link_all_repos.py
@@ -45,18 +45,13 @@ class LinkAllReposTestCase(IntegrationTestCase):
         )
 
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
-    @patch("sentry.integrations.github.tasks.link_all_repos.metrics")
-    def test_link_all_repos_inactive_integration(self, mock_metrics, mock_record, _):
+    def test_link_all_repos_inactive_integration(self, mock_record, _):
         self.integration.update(status=ObjectStatus.DISABLED)
 
         link_all_repos(
             integration_key=self.key,
             integration_id=self.integration.id,
             organization_id=self.organization.id,
-        )
-
-        mock_metrics.incr.assert_called_with(
-            "github.link_all_repos.error", tags={"type": "missing_integration"}
         )
 
         assert_slo_metric(mock_record, EventLifecycleOutcome.FAILURE)
@@ -123,7 +118,10 @@ class LinkAllReposTestCase(IntegrationTestCase):
 
         assert repos[0].name == "getsentry/snuba"
 
-        assert_slo_metric(mock_record, EventLifecycleOutcome.SUCCESS)
+        assert_slo_metric(mock_record, EventLifecycleOutcome.HALTED)
+        assert_halt_metric(
+            mock_record, LinkAllReposHaltReason.REPOSITORY_NOT_CREATED.value
+        )  # should be halt because it didn't complete successfully
 
     @responses.activate
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
@@ -157,39 +155,30 @@ class LinkAllReposTestCase(IntegrationTestCase):
         assert_halt_metric(mock_record, LinkAllReposHaltReason.REPOSITORY_NOT_CREATED.value)
 
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
-    @patch("sentry.integrations.github.tasks.link_all_repos.metrics")
-    def test_link_all_repos_missing_integration(self, mock_metrics, mock_record, _):
+    def test_link_all_repos_missing_integration(self, mock_record, _):
         link_all_repos(
             integration_key=self.key,
             integration_id=0,
             organization_id=self.organization.id,
-        )
-        mock_metrics.incr.assert_called_with(
-            "github.link_all_repos.error", tags={"type": "missing_integration"}
         )
 
         assert_slo_metric(mock_record, EventLifecycleOutcome.FAILURE)
         assert_failure_metric(mock_record, LinkAllReposHaltReason.MISSING_INTEGRATION.value)
 
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
-    @patch("sentry.integrations.github.tasks.link_all_repos.metrics")
-    def test_link_all_repos_missing_organization(self, mock_metrics, mock_record, _):
+    def test_link_all_repos_missing_organization(self, mock_record, _):
         link_all_repos(
             integration_key=self.key,
             integration_id=self.integration.id,
             organization_id=0,
-        )
-        mock_metrics.incr.assert_called_with(
-            "github.link_all_repos.error", tags={"type": "missing_organization"}
         )
 
         assert_slo_metric(mock_record, EventLifecycleOutcome.FAILURE)
         assert_failure_metric(mock_record, LinkAllReposHaltReason.MISSING_ORGANIZATION.value)
 
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
-    @patch("sentry.integrations.github.tasks.link_all_repos.metrics")
     @responses.activate
-    def test_link_all_repos_api_error(self, mock_metrics, mock_record, _):
+    def test_link_all_repos_api_error(self, mock_record, _):
 
         responses.add(
             responses.GET,
@@ -203,14 +192,12 @@ class LinkAllReposTestCase(IntegrationTestCase):
                 integration_id=self.integration.id,
                 organization_id=self.organization.id,
             )
-        mock_metrics.incr.assert_called_with("github.link_all_repos.api_error")
 
         assert_slo_metric(mock_record, EventLifecycleOutcome.FAILURE)
 
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
-    @patch("sentry.integrations.github.integration.metrics")
     @responses.activate
-    def test_link_all_repos_api_error_rate_limited(self, mock_metrics, mock_record, _):
+    def test_link_all_repos_api_error_rate_limited(self, mock_record, _):
 
         responses.add(
             responses.GET,
@@ -227,16 +214,14 @@ class LinkAllReposTestCase(IntegrationTestCase):
             integration_id=self.integration.id,
             organization_id=self.organization.id,
         )
-        mock_metrics.incr.assert_called_with("github.link_all_repos.rate_limited_error")
 
         assert_slo_metric(mock_record, EventLifecycleOutcome.HALTED)
         assert_halt_metric(mock_record, LinkAllReposHaltReason.RATE_LIMITED.value)
 
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     @patch("sentry.models.Repository.objects.create")
-    @patch("sentry.integrations.github.tasks.link_all_repos.metrics")
     @responses.activate
-    def test_link_all_repos_repo_creation_error(self, mock_metrics, mock_repo, mock_record, _):
+    def test_link_all_repos_repo_creation_error(self, mock_repo, mock_record, _):
         mock_repo.side_effect = IntegrityError
 
         self._add_responses()
@@ -246,8 +231,6 @@ class LinkAllReposTestCase(IntegrationTestCase):
             integration_id=self.integration.id,
             organization_id=self.organization.id,
         )
-
-        mock_metrics.incr.assert_called_with("sentry.integration_repo_provider.repo_exists")
 
         assert_slo_metric(mock_record, EventLifecycleOutcome.HALTED)
         assert_halt_metric(mock_record, LinkAllReposHaltReason.REPOSITORY_NOT_CREATED.value)


### PR DESCRIPTION
We are hitting the processing deadline of 60 seconds for `link_all_repos`. We can improve the performance by making more bulk queries.

Changes
1. Add `RepositoryConfig` type
2. Make 1 function to create repos for an org. Previously we were repeatedly calling the same function (`IntegrationRepositoryProvider.create_repository`) with possibly many RPC calls inside
3. Make a constant number of queries per integration to link all repos (previously this was not constant) + as many queries as new repos
4. Remove unnecessary metrics now that we are using the context manager

Unchanged
1. We still attempt to create each new `Repository` individually. This is because we may need to take actions for each `Repository` that fails creation. Django's `bulk_create` will fail and rollback all changes if there is an error. Alternatively, we can pass `ignore_conflicts=True` to `bulk_create`, but then we wouldn't be able to see which ones failed.

Fixes ECO-801