### PR TITLE
fix(aci): Move environment fallback to correct location

### DIFF
--- a/static/app/views/detectors/components/details/common/extraDetails.tsx
+++ b/static/app/views/detectors/components/details/common/extraDetails.tsx
@@ -99,13 +99,14 @@ DetectorExtraDetails.Environment = function DetectorExtraDetailsEnvironment({
   detector: Detector;
 }) {
   const environment = getDetectorEnvironment(detector);
+  const environmentLabel = environment ?? t('All environments');
 
   return (
     <KeyValueTableRow
       keyName={t('Environment')}
       value={
-        <Tooltip title={environment} showOnlyOnOverflow>
-          <TextOverflow>{environment}</TextOverflow>
+        <Tooltip title={environmentLabel} showOnlyOnOverflow>
+          <TextOverflow>{environmentLabel}</TextOverflow>
         </Tooltip>
       }
     />

--- a/static/app/views/detectors/components/forms/uptime/fields.tsx
+++ b/static/app/views/detectors/components/forms/uptime/fields.tsx
@@ -82,7 +82,7 @@ export function uptimeSavedDetectorToFormData(
   }
 
   const dataSource = detector.dataSources?.[0];
-  const environment = getDetectorEnvironment(detector);
+  const environment = getDetectorEnvironment(detector) ?? '';
 
   const common = {
     name: detector.name,

--- a/static/app/views/detectors/utils/getDetectorEnvironment.tsx
+++ b/static/app/views/detectors/utils/getDetectorEnvironment.tsx
@@ -1,26 +1,23 @@
-import {t} from 'sentry/locale';
 import type {Detector} from 'sentry/types/workflowEngine/detectors';
 import {unreachable} from 'sentry/utils/unreachable';
 
-const ALL_ENVIRONMENTS = t('All environments');
-
-export function getDetectorEnvironment(detector: Detector) {
+export function getDetectorEnvironment(detector: Detector): string | null {
   const detectorType = detector.type;
   switch (detectorType) {
     case 'metric_issue':
       return (
         detector.dataSources?.find(ds => ds.type === 'snuba_query_subscription')?.queryObj
-          ?.snubaQuery.environment ?? ALL_ENVIRONMENTS
+          ?.snubaQuery.environment ?? null
       );
     case 'uptime_domain_failure':
-      return detector.config.environment ?? ALL_ENVIRONMENTS;
+      return detector.config.environment ?? null;
     case 'uptime_subscription':
       // TODO: Implement this when we know the shape of object
-      return ALL_ENVIRONMENTS;
+      return null;
     case 'error':
-      return ALL_ENVIRONMENTS;
+      return null;
     default:
       unreachable(detectorType);
-      return ALL_ENVIRONMENTS;
+      return null;
   }
 }


### PR DESCRIPTION
When this got extracted into a common function, the 'all environments' fallback shouldn't have been moved there (because this is used for things like the form and chart as well)