### PR TITLE
feat(aci): Update API to allow filter monitors by assignee

### DIFF
--- a/src/sentry/workflow_engine/endpoints/organization_detector_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_index.py
@@ -145,6 +145,9 @@ class OrganizationDetectorIndexEndpoint(OrganizationEndpoint):
         `````````````````````````````
         Return a list of detectors for a given organization.
         """
+        if not request.user.is_authenticated:
+            return self.respond(status=401)
+
         projects = self.get_projects(request, organization)
         queryset: QuerySet[Detector] = Detector.objects.filter(
             project_id__in=projects,

--- a/src/sentry/workflow_engine/endpoints/organization_detector_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_index.py
@@ -72,7 +72,7 @@ def convert_assignee_values(value: Iterable[str], projects: Sequence[Project], u
         elif actor is None:
             assignee_query |= Q(owner_team_id__isnull=True, owner_user_id__isnull=True)
         else:
-            assert_never()
+            assert_never(actor)
     return assignee_query
 
 
@@ -146,7 +146,7 @@ class OrganizationDetectorIndexEndpoint(OrganizationEndpoint):
         Return a list of detectors for a given organization.
         """
         if not request.user.is_authenticated:
-            return self.respond(status=401)
+            return self.respond(status=status.HTTP_401_UNAUTHORIZED)
 
         projects = self.get_projects(request, organization)
         queryset: QuerySet[Detector] = Detector.objects.filter(

--- a/src/sentry/workflow_engine/endpoints/organization_detector_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_index.py
@@ -1,5 +1,6 @@
 from collections.abc import Iterable, Sequence
 from functools import partial
+from typing import assert_never
 
 from django.db import router, transaction
 from django.db.models import Count, Q
@@ -71,8 +72,7 @@ def convert_assignee_values(value: Iterable[str], projects: Sequence[Project], u
         elif actor is None:
             assignee_query |= Q(owner_team_id__isnull=True, owner_user_id__isnull=True)
         else:
-            # Unknown actor type, return a query that matches nothing
-            assignee_query |= Q(pk__isnull=True)
+            assert_never()
     return assignee_query
 
 

--- a/src/sentry/workflow_engine/endpoints/organization_detector_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_index.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterable, Sequence
 from functools import partial
 
 from django.db import router, transaction
@@ -17,6 +18,7 @@ from sentry.api.bases import OrganizationAlertRulePermission, OrganizationEndpoi
 from sentry.api.event_search import SearchConfig, SearchFilter, SearchKey, default_config
 from sentry.api.event_search import parse_search_query as base_parse_search_query
 from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.api.issue_search import convert_actor_or_none_value
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.apidocs.constants import (
@@ -30,6 +32,9 @@ from sentry.incidents.grouptype import MetricIssue
 from sentry.issues import grouptype
 from sentry.models.organization import Organization
 from sentry.models.project import Project
+from sentry.models.team import Team
+from sentry.users.models.user import User
+from sentry.users.services.user import RpcUser
 from sentry.workflow_engine.endpoints.serializers import DetectorSerializer
 from sentry.workflow_engine.endpoints.utils.filters import apply_filter
 from sentry.workflow_engine.endpoints.utils.sortby import SortByParam
@@ -43,11 +48,33 @@ from sentry.workflow_engine.models import Detector
 detector_search_config = SearchConfig.create_from(
     default_config,
     text_operator_keys={"name", "type"},
-    allowed_keys={"name", "type"},
+    allowed_keys={"name", "type", "assignee"},
     allow_boolean=False,
     free_text_key="query",
 )
 parse_detector_query = partial(base_parse_search_query, config=detector_search_config)
+
+
+def convert_assignee_values(value: Iterable[str], projects: Sequence[Project], user: User) -> Q:
+    """
+    Convert an assignee search value to a Django Q object for filtering detectors.
+    """
+    actors_or_none: list[RpcUser | Team | None] = convert_actor_or_none_value(
+        value, projects, user, None
+    )
+    assignee_query = Q()
+    for actor in actors_or_none:
+        if isinstance(actor, (User, RpcUser)):
+            assignee_query |= Q(owner_user_id=actor.id)
+        elif isinstance(actor, Team):
+            assignee_query |= Q(owner_team_id=actor.id)
+        elif actor is None:
+            assignee_query |= Q(owner_team_id__isnull=True, owner_user_id__isnull=True)
+        else:
+            # Unknown actor type, return a query that matches nothing
+            assignee_query |= Q(pk__isnull=True)
+    return assignee_query
+
 
 # Maps API field name to database field name, with synthetic aggregate fields keeping
 # to our field naming scheme for consistency.
@@ -138,6 +165,19 @@ class OrganizationDetectorIndexEndpoint(OrganizationEndpoint):
                         queryset = apply_filter(queryset, filter, "name")
                     case SearchFilter(key=SearchKey("type"), operator=("=" | "IN" | "!=")):
                         queryset = apply_filter(queryset, filter, "type")
+                    case SearchFilter(key=SearchKey("assignee"), operator=("=" | "IN" | "!=")):
+                        # Filter values can be emails, team slugs, "me", "my_teams", "none"
+                        values = (
+                            filter.value.value
+                            if isinstance(filter.value.value, list)
+                            else [filter.value.value]
+                        )
+                        assignee_q = convert_assignee_values(values, projects, request.user)
+
+                        if filter.operator == "!=":
+                            queryset = queryset.exclude(assignee_q)
+                        else:
+                            queryset = queryset.filter(assignee_q)
                     case SearchFilter(key=SearchKey("query"), operator="="):
                         # 'query' is our free text key; all free text gets returned here
                         # as '=', and we search any relevant fields for it.

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
@@ -780,6 +780,25 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
         )
         assert "owner" in response.data
 
+    def test_owner_not_in_organization(self):
+        # Create a user in another organization
+        other_org = self.create_organization()
+        other_user = self.create_user()
+        self.create_member(organization=other_org, user=other_user)
+
+        # Test with owner not in current organization
+        data_with_invalid_owner = {
+            **self.valid_data,
+            "owner": other_user.get_actor_identifier(),
+        }
+
+        response = self.get_error_response(
+            self.organization.slug,
+            **data_with_invalid_owner,
+            status_code=400,
+        )
+        assert "owner" in response.data
+
 
 @region_silo_test
 class ConvertAssigneeValuesTest(APITestCase):


### PR DESCRIPTION
Allows filtering with assignee: `/api/0/organizations/sentry/detectors/?query=assignee%3A{me|my_teams|none|team_slug|user_email}&...`