### PR TITLE
:wrench: chore: remove alert_context assertion

### DIFF
--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -499,7 +499,7 @@ def generate_incident_trigger_email_context(
     alert_context: AlertContext,
     open_period_context: OpenPeriodContext,
     trigger_status: TriggerStatus,
-    trigger_threshold: float,
+    trigger_threshold: float | None,
     user: User | RpcUser | None = None,
     notification_uuid: str | None = None,
 ):

--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -674,9 +674,6 @@ def email_users(
     sent_to_users = []
     for index, (user_id, email) in enumerate(targets):
         user = users[index]
-        # TODO(iamrajjoshi): Temporarily assert that alert_threshold is not None
-        # This should be removed when we update the typing and fetch the trigger_threshold in the new system
-        assert alert_context.alert_threshold is not None
 
         email_context = generate_incident_trigger_email_context(
             project=project,

--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -528,6 +528,7 @@ def generate_incident_trigger_email_context(
         threshold = f"({alert_context.sensitivity} responsiveness)"
         alert_link_params["type"] = "anomaly_detection"
     else:
+        assert alert_context.alert_threshold is not None
         threshold_prefix_string = ">" if show_greater_than_string else "<"
         threshold = trigger_threshold if is_active else alert_context.resolve_threshold
         if threshold is None:


### PR DESCRIPTION
removing this assertion since Anomaly Detection Alerts will not have an `alert_threshold`