### PR TITLE
feat(aci): Add support to search for a detector

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -922,6 +922,7 @@ SKIP_SNUBA_FIELDS = frozenset(
     (
         "status",
         "substatus",
+        "detector",
         "bookmarked_by",
         "assigned_to",
         "for_review",

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -44,6 +44,7 @@ from sentry.sentry_apps.models.platformexternalissue import PlatformExternalIssu
 from sentry.users.models.user import User
 from sentry.utils import metrics
 from sentry.utils.cursors import Cursor, CursorResult
+from sentry.workflow_engine.models.detector_group import DetectorGroup
 
 logger = logging.getLogger(__name__)
 
@@ -771,6 +772,13 @@ class EventsDatasetSnubaSearchBackend(SnubaSearchBackendBase):
             ),
             "regressed_in_release": QCallbackCondition(
                 functools.partial(regressed_in_release_filter, projects=projects)
+            ),
+            "detector": QCallbackCondition(
+                lambda detector_ids: Q(
+                    id__in=DetectorGroup.objects.filter(detector_id__in=detector_ids).values_list(
+                        "group_id", flat=True
+                    )
+                )
             ),
             "issue.category": QCallbackCondition(lambda categories: Q(type__in=categories)),
             "issue.type": QCallbackCondition(lambda types: Q(type__in=types)),

--- a/tests/sentry/search/events/test_filter.py
+++ b/tests/sentry/search/events/test_filter.py
@@ -1475,7 +1475,7 @@ class DetectorFilterTest(TestCase):
             projects=[self.project],
             search_filters=[
                 SearchFilter(SearchKey("detector"), "=", SearchValue([self.detector1.id])),
-                SearchFilter(SearchKey("status"), "=", SearchValue(["unresolved"])),
+                SearchFilter(SearchKey("status"), "=", SearchValue([0])),
             ],
         )
 

--- a/tests/sentry/search/events/test_filter.py
+++ b/tests/sentry/search/events/test_filter.py
@@ -1384,8 +1384,8 @@ class DetectorFilterTest(TestCase):
         )
 
         # Should return groups 1 and 2 (both associated with detector_id_1)
-        assert len(results) == 2
-        group_ids = {group.id for group in results}
+        assert len(results.results) == 2
+        group_ids = {group.id for group in results.results}
         assert group_ids == {self.group1.id, self.group2.id}
 
     def test_detector_filter_multiple_detectors(self):
@@ -1406,8 +1406,8 @@ class DetectorFilterTest(TestCase):
 
         # Should return groups 1 and 2 (associated with detector_id_1)
         # group3 is not associated with any detector
-        assert len(results) == 2
-        group_ids = {group.id for group in results}
+        assert len(results.results) == 2
+        group_ids = {group.id for group in results.results}
         assert group_ids == {self.group1.id, self.group2.id}
 
     def test_detector_filter_no_matches(self):
@@ -1425,7 +1425,7 @@ class DetectorFilterTest(TestCase):
         )
 
         # Should return no groups
-        assert len(results) == 0
+        assert len(results.results) == 0
 
     def test_detector_filter_invalid_detector(self):
         """Test filtering by an invalid detector ID."""
@@ -1444,7 +1444,7 @@ class DetectorFilterTest(TestCase):
         )
 
         # Should return no groups
-        assert len(results) == 0
+        assert len(results.results) == 0
 
     def test_detector_filter_negation(self):
         """Test negated detector filter."""
@@ -1461,8 +1461,8 @@ class DetectorFilterTest(TestCase):
         )
 
         # Should return group3 (not associated with detector_id_1)
-        assert len(results) == 1
-        assert results[0].id == self.group3.id
+        assert len(results.results) == 1
+        assert results.results[0].id == self.group3.id
 
     def test_detector_filter_with_other_filters(self):
         """Test detector filter combined with other filters."""
@@ -1480,8 +1480,8 @@ class DetectorFilterTest(TestCase):
         )
 
         # Should return groups 1 and 2 (both associated with detector1 and unresolved)
-        assert len(results) == 2
-        group_ids = {group.id for group in results}
+        assert len(results.results) == 2
+        group_ids = {group.id for group in results.results}
         assert group_ids == {self.group1.id, self.group2.id}
 
     def test_detector_filter_empty_list(self):
@@ -1497,4 +1497,4 @@ class DetectorFilterTest(TestCase):
         )
 
         # Should return no groups
-        assert len(results) == 0
+        assert len(results.results) == 0


### PR DESCRIPTION
This allows searching for a `detector:` field to find groups created by that detector.