### PR TITLE
fix(profiling-onboarding): Restore arcade URL

### DIFF
--- a/static/app/views/profiling/onboarding.tsx
+++ b/static/app/views/profiling/onboarding.tsx
@@ -199,7 +199,7 @@ function OnboardingPanel({
               <Preview>
                 <BodyTitle>{t('Preview a Sentry Profile')}</BodyTitle>
                 <Arcade
-                  src="https://demo.arcade.software/IebjOcBKpUHBuFpfGO4f?embed"
+                  src="https://demo.arcade.software/BSKubAMPPaF4N5hujNbi?embed"
                   loading="lazy"
                   allowFullScreen
                 />


### PR DESCRIPTION
The original URL was accidentally overwritten. This PR restores it.