### PR TITLE
fix(project config): Don't reload cache when updating transaction clusterer meta

### DIFF
--- a/src/sentry/ingest/transaction_clusterer/meta.py
+++ b/src/sentry/ingest/transaction_clusterer/meta.py
@@ -28,6 +28,6 @@ def track_clusterer_run(namespace: ClustererNamespace, project: Project) -> None
     meta["last_run"] = now = int(datetime.now(timezone.utc).timestamp())
     if meta["first_run"] == 0:
         meta["first_run"] = now
-    # This project option only serves a stats purpose and doesn't
-    # require refreshing the cache.
+    # This option is updated very often, but only keeps track of transaction clusterer internal metadata.
+    # To minimize the recomputations the system does, we can skip reloading (project) caches.
     project.update_option(namespace.value.meta_store, meta, reload_cache=False)

--- a/src/sentry/ingest/transaction_clusterer/meta.py
+++ b/src/sentry/ingest/transaction_clusterer/meta.py
@@ -28,4 +28,6 @@ def track_clusterer_run(namespace: ClustererNamespace, project: Project) -> None
     meta["last_run"] = now = int(datetime.now(timezone.utc).timestamp())
     if meta["first_run"] == 0:
         meta["first_run"] = now
-    project.update_option(namespace.value.meta_store, meta)
+    # This project option only serves a stats purpose and doesn't
+    # require refreshing the cache.
+    project.update_option(namespace.value.meta_store, meta, reload_cache=False)

--- a/src/sentry/models/options/project_option.py
+++ b/src/sentry/models/options/project_option.py
@@ -117,7 +117,9 @@ class ProjectOptionManager(OptionManager["ProjectOption"]):
         self.filter(project=project, key=key).delete()
         self.reload_cache(project.id, "projectoption.unset_value", key)
 
-    def set_value(self, project: int | Project, key: str, value: Any) -> bool:
+    def set_value(
+        self, project: int | Project, key: str, value: Any, reload_cache: bool = True
+    ) -> bool:
         if isinstance(project, models.Model):
             project_id = project.id
         else:
@@ -126,7 +128,9 @@ class ProjectOptionManager(OptionManager["ProjectOption"]):
         inst, created = self.create_or_update(
             project_id=project_id, key=key, values={"value": value}
         )
-        self.reload_cache(project_id, "projectoption.set_value", key)
+
+        if reload_cache:
+            self.reload_cache(project_id, "projectoption.set_value", key)
 
         return created or inst > 0
 

--- a/src/sentry/models/options/project_option.py
+++ b/src/sentry/models/options/project_option.py
@@ -120,6 +120,13 @@ class ProjectOptionManager(OptionManager["ProjectOption"]):
     def set_value(
         self, project: int | Project, key: str, value: Any, reload_cache: bool = True
     ) -> bool:
+        """
+        Sets a project option for the given project.
+        :param reload_cache: Invalidate the project config and reload the
+        cache. Do not call this with `False` unless you know for sure that
+        it's fine to keep the cached project config.
+        """
+
         if isinstance(project, models.Model):
             project_id = project.id
         else:

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -445,6 +445,12 @@ class Project(Model):
         return self.option_manager.get_value(self, key, default, validate)
 
     def update_option(self, key: str, value: Any, reload_cache: bool = True) -> bool:
+        """
+        Updates a project option for this project.
+        :param reload_cache: Invalidate the project config and reload the
+        cache. Do not call this with `False` unless you know for sure that
+        it's fine to keep the cached project config.
+        """
         return self.option_manager.set_value(self, key, value, reload_cache=reload_cache)
 
     def delete_option(self, key: str) -> None:

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -444,8 +444,8 @@ class Project(Model):
 
         return self.option_manager.get_value(self, key, default, validate)
 
-    def update_option(self, key: str, value: Any) -> bool:
-        return self.option_manager.set_value(self, key, value)
+    def update_option(self, key: str, value: Any, reload_cache: bool = True) -> bool:
+        return self.option_manager.set_value(self, key, value, reload_cache=reload_cache)
 
     def delete_option(self, key: str) -> None:
         self.option_manager.unset_value(self, key)


### PR DESCRIPTION
Project config invalidations from setting these options cause a periodic spike of activity on project config queues. But these options don't require reloading the cache at all because they're just stats. So we add the ability to skip the reload when setting a project option and do so in this specific case.

ref: INGEST-444