### PR TITLE
ref(project-config): Do not invalidate config when updating last resolve ts

### DIFF
--- a/src/sentry/tasks/auto_resolve_issues.py
+++ b/src/sentry/tasks/auto_resolve_issues.py
@@ -81,7 +81,7 @@ def auto_resolve_project_issues(project_id, cutoff=None, chunk_size=1000, **kwar
     if not age:
         return
 
-    project.update_option("sentry:_last_auto_resolve", int(time()))
+    project.update_option("sentry:_last_auto_resolve", int(time()), reload_cache=False)
 
     if cutoff:
         cutoff = datetime.fromtimestamp(cutoff, timezone.utc)


### PR DESCRIPTION
Follow-up to #95521.

The option is set periodically for a lot of projects just to the current time of run. We do not need to invalidate (project) caches for this.