### PR TITLE
feat(mcp-insights): Add tables for tools, resources and prompts

### DIFF
--- a/static/app/views/insights/mcp/components/mcpPromptsTable.tsx
+++ b/static/app/views/insights/mcp/components/mcpPromptsTable.tsx
@@ -12,50 +12,47 @@ import usePageFilters from 'sentry/utils/usePageFilters';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {getExploreUrl} from 'sentry/views/explore/utils';
 import {HeadSortCell} from 'sentry/views/insights/agentMonitoring/components/headSortCell';
+import {useCombinedQuery} from 'sentry/views/insights/agentMonitoring/hooks/useCombinedQuery';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
-import {TimeSpentCell} from 'sentry/views/insights/common/components/tableCells/timeSpentCell';
 import {Referrer} from 'sentry/views/insights/pages/platform/laravel/referrers';
 import {PlatformInsightsTable} from 'sentry/views/insights/pages/platform/shared/table';
 import {DurationCell} from 'sentry/views/insights/pages/platform/shared/table/DurationCell';
-import {
-  ErrorRateCell,
-  getErrorCellIssuesLink,
-} from 'sentry/views/insights/pages/platform/shared/table/ErrorRateCell';
+import {ErrorRateCell} from 'sentry/views/insights/pages/platform/shared/table/ErrorRateCell';
 import {NumberCell} from 'sentry/views/insights/pages/platform/shared/table/NumberCell';
 import {useSpanTableData} from 'sentry/views/insights/pages/platform/shared/table/useTableData';
-import {useTransactionNameQuery} from 'sentry/views/insights/pages/platform/shared/useTransactionNameQuery';
+import {SpanFields} from 'sentry/views/insights/types';
+
+const AVG_DURATION = `avg(${SpanFields.SPAN_DURATION})`;
+const P95_DURATION = `p95(${SpanFields.SPAN_DURATION})`;
 
 const defaultColumnOrder: Array<GridColumnOrder<string>> = [
-  {key: 'command', name: t('Command Name'), width: COL_WIDTH_UNDEFINED},
-  {key: 'count()', name: t('Invocations'), width: 136},
+  {key: SpanFields.MCP_PROMPT_NAME, name: t('Tool Name'), width: COL_WIDTH_UNDEFINED},
+  {key: 'count()', name: t('Requests'), width: 136},
   {key: 'failure_rate()', name: t('Error Rate'), width: 124},
-  {key: 'avg(span.duration)', name: t('AVG'), width: 90},
-  {key: 'p95(span.duration)', name: t('P95'), width: 90},
-  {key: 'sum(span.duration)', name: t('Time Spent'), width: 120},
+  {key: AVG_DURATION, name: t('AVG'), width: 90},
+  {key: P95_DURATION, name: t('P95'), width: 90},
 ];
 
 const rightAlignColumns = new Set([
   'count()',
   'failure_rate()',
-  'sum(span.duration)',
-  'avg(span.duration)',
-  'p95(span.duration)',
+  AVG_DURATION,
+  P95_DURATION,
 ]);
 
-export function CommandsTable() {
-  const {query} = useTransactionNameQuery();
+export function McpPromptsTable() {
+  const query = useCombinedQuery(`span.op:mcp.server has:${SpanFields.MCP_PROMPT_NAME}`);
   const tableDataRequest = useSpanTableData({
-    query: `span.op:console.command* ${query ?? ''}`.trim(),
+    query,
     fields: [
-      'command',
-      'project.id',
+      SpanFields.MCP_PROMPT_NAME,
+      SpanFields.PROJECT_ID,
       'count()',
       'failure_rate()',
-      'avg(span.duration)',
-      'p95(span.duration)',
-      'sum(span.duration)',
+      AVG_DURATION,
+      P95_DURATION,
     ],
-    cursorParamName: 'jobsCursor',
+    cursorParamName: 'tableCursor',
     referrer: Referrer.PATHS_TABLE,
   });
 
@@ -64,8 +61,8 @@ export function CommandsTable() {
       <HeadSortCell
         sortKey={column.key}
         align={rightAlignColumns.has(column.key) ? 'right' : 'left'}
-        forceCellGrow={column.key === 'command'}
-        cursorParamName="commandsCursor"
+        forceCellGrow={column.key === SpanFields.MCP_PROMPT_NAME}
+        cursorParamName="tableCursor"
       >
         {column.name}
       </HeadSortCell>
@@ -78,26 +75,20 @@ export function CommandsTable() {
       dataRow: (typeof tableDataRequest.data)[number]
     ) => {
       switch (column.key) {
-        case 'command':
-          return <CommandCell command={dataRow.command} />;
+        case SpanFields.MCP_PROMPT_NAME:
+          return <McpPromptCell prompt={dataRow[SpanFields.MCP_PROMPT_NAME]} />;
         case 'failure_rate()':
           return (
             <ErrorRateCell
               errorRate={dataRow['failure_rate()']}
               total={dataRow['count()']}
-              issuesLink={getErrorCellIssuesLink({
-                projectId: dataRow['project.id'],
-                query: `command:"${dataRow.command}"`,
-              })}
             />
           );
-        case 'avg(span.duration)':
-        case 'p95(span.duration)':
-          return <DurationCell milliseconds={dataRow[column.key]} />;
         case 'count()':
           return <NumberCell value={dataRow['count()']} />;
-        case 'sum(span.duration)':
-          return <TimeSpentCell total={dataRow['sum(span.duration)']} />;
+        case AVG_DURATION:
+        case P95_DURATION:
+          return <DurationCell milliseconds={dataRow[column.key]} />;
         default:
           return <div />;
       }
@@ -116,14 +107,14 @@ export function CommandsTable() {
         renderBodyCell,
         renderHeadCell,
       }}
-      cursorParamName="commandsCursor"
+      cursorParamName="tableCursor"
       pageLinks={tableDataRequest.pageLinks}
       isPlaceholderData={tableDataRequest.isPlaceholderData}
     />
   );
 }
 
-function CommandCell({command}: {command: string}) {
+function McpPromptCell({prompt}: {prompt: string}) {
   const organization = useOrganization();
   const {selection} = usePageFilters();
 
@@ -137,8 +128,8 @@ function CommandCell({command}: {command: string}) {
         yAxes: ['count(span.duration)'],
       },
     ],
-    query: `span.op:console.command* command:${command}`,
+    query: `span.op:mcp.server ${SpanFields.MCP_PROMPT_NAME}:"${prompt}"`,
     sort: `-count(span.duration)`,
   });
-  return <Link to={link}>{command}</Link>;
+  return <Link to={link}>{prompt}</Link>;
 }

--- a/static/app/views/insights/mcp/components/mcpPromptsTable.tsx
+++ b/static/app/views/insights/mcp/components/mcpPromptsTable.tsx
@@ -26,7 +26,7 @@ const AVG_DURATION = `avg(${SpanFields.SPAN_DURATION})`;
 const P95_DURATION = `p95(${SpanFields.SPAN_DURATION})`;
 
 const defaultColumnOrder: Array<GridColumnOrder<string>> = [
-  {key: SpanFields.MCP_PROMPT_NAME, name: t('Tool Name'), width: COL_WIDTH_UNDEFINED},
+  {key: SpanFields.MCP_PROMPT_NAME, name: t('Prompt Name'), width: COL_WIDTH_UNDEFINED},
   {key: 'count()', name: t('Requests'), width: 136},
   {key: 'failure_rate()', name: t('Error Rate'), width: 124},
   {key: AVG_DURATION, name: t('AVG'), width: 90},

--- a/static/app/views/insights/mcp/components/mcpPromptsTable.tsx
+++ b/static/app/views/insights/mcp/components/mcpPromptsTable.tsx
@@ -14,7 +14,7 @@ import {getExploreUrl} from 'sentry/views/explore/utils';
 import {HeadSortCell} from 'sentry/views/insights/agentMonitoring/components/headSortCell';
 import {useCombinedQuery} from 'sentry/views/insights/agentMonitoring/hooks/useCombinedQuery';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
-import {Referrer} from 'sentry/views/insights/pages/platform/laravel/referrers';
+import {MCPReferrer} from 'sentry/views/insights/mcp/utils/referrer';
 import {PlatformInsightsTable} from 'sentry/views/insights/pages/platform/shared/table';
 import {DurationCell} from 'sentry/views/insights/pages/platform/shared/table/DurationCell';
 import {ErrorRateCell} from 'sentry/views/insights/pages/platform/shared/table/ErrorRateCell';
@@ -53,7 +53,7 @@ export function McpPromptsTable() {
       P95_DURATION,
     ],
     cursorParamName: 'tableCursor',
-    referrer: Referrer.PATHS_TABLE,
+    referrer: MCPReferrer.MCP_PROMPT_TABLE,
   });
 
   const renderHeadCell = useCallback((column: GridColumnHeader<string>) => {

--- a/static/app/views/insights/mcp/components/mcpResourcesTable.tsx
+++ b/static/app/views/insights/mcp/components/mcpResourcesTable.tsx
@@ -26,7 +26,7 @@ const AVG_DURATION = `avg(${SpanFields.SPAN_DURATION})`;
 const P95_DURATION = `p95(${SpanFields.SPAN_DURATION})`;
 
 const defaultColumnOrder: Array<GridColumnOrder<string>> = [
-  {key: SpanFields.MCP_RESOURCE_URI, name: t('Tool Name'), width: COL_WIDTH_UNDEFINED},
+  {key: SpanFields.MCP_RESOURCE_URI, name: t('Resource URI'), width: COL_WIDTH_UNDEFINED},
   {key: 'count()', name: t('Requests'), width: 136},
   {key: 'failure_rate()', name: t('Error Rate'), width: 124},
   {key: AVG_DURATION, name: t('AVG'), width: 90},

--- a/static/app/views/insights/mcp/components/mcpResourcesTable.tsx
+++ b/static/app/views/insights/mcp/components/mcpResourcesTable.tsx
@@ -12,50 +12,47 @@ import usePageFilters from 'sentry/utils/usePageFilters';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {getExploreUrl} from 'sentry/views/explore/utils';
 import {HeadSortCell} from 'sentry/views/insights/agentMonitoring/components/headSortCell';
+import {useCombinedQuery} from 'sentry/views/insights/agentMonitoring/hooks/useCombinedQuery';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
-import {TimeSpentCell} from 'sentry/views/insights/common/components/tableCells/timeSpentCell';
 import {Referrer} from 'sentry/views/insights/pages/platform/laravel/referrers';
 import {PlatformInsightsTable} from 'sentry/views/insights/pages/platform/shared/table';
 import {DurationCell} from 'sentry/views/insights/pages/platform/shared/table/DurationCell';
-import {
-  ErrorRateCell,
-  getErrorCellIssuesLink,
-} from 'sentry/views/insights/pages/platform/shared/table/ErrorRateCell';
+import {ErrorRateCell} from 'sentry/views/insights/pages/platform/shared/table/ErrorRateCell';
 import {NumberCell} from 'sentry/views/insights/pages/platform/shared/table/NumberCell';
 import {useSpanTableData} from 'sentry/views/insights/pages/platform/shared/table/useTableData';
-import {useTransactionNameQuery} from 'sentry/views/insights/pages/platform/shared/useTransactionNameQuery';
+import {SpanFields} from 'sentry/views/insights/types';
+
+const AVG_DURATION = `avg(${SpanFields.SPAN_DURATION})`;
+const P95_DURATION = `p95(${SpanFields.SPAN_DURATION})`;
 
 const defaultColumnOrder: Array<GridColumnOrder<string>> = [
-  {key: 'command', name: t('Command Name'), width: COL_WIDTH_UNDEFINED},
-  {key: 'count()', name: t('Invocations'), width: 136},
+  {key: SpanFields.MCP_RESOURCE_URI, name: t('Tool Name'), width: COL_WIDTH_UNDEFINED},
+  {key: 'count()', name: t('Requests'), width: 136},
   {key: 'failure_rate()', name: t('Error Rate'), width: 124},
-  {key: 'avg(span.duration)', name: t('AVG'), width: 90},
-  {key: 'p95(span.duration)', name: t('P95'), width: 90},
-  {key: 'sum(span.duration)', name: t('Time Spent'), width: 120},
+  {key: AVG_DURATION, name: t('AVG'), width: 90},
+  {key: P95_DURATION, name: t('P95'), width: 90},
 ];
 
 const rightAlignColumns = new Set([
   'count()',
   'failure_rate()',
-  'sum(span.duration)',
-  'avg(span.duration)',
-  'p95(span.duration)',
+  AVG_DURATION,
+  P95_DURATION,
 ]);
 
-export function CommandsTable() {
-  const {query} = useTransactionNameQuery();
+export function McpResourcesTable() {
+  const query = useCombinedQuery(`span.op:mcp.server has:${SpanFields.MCP_RESOURCE_URI}`);
   const tableDataRequest = useSpanTableData({
-    query: `span.op:console.command* ${query ?? ''}`.trim(),
+    query,
     fields: [
-      'command',
-      'project.id',
+      SpanFields.MCP_RESOURCE_URI,
+      SpanFields.PROJECT_ID,
       'count()',
       'failure_rate()',
-      'avg(span.duration)',
-      'p95(span.duration)',
-      'sum(span.duration)',
+      AVG_DURATION,
+      P95_DURATION,
     ],
-    cursorParamName: 'jobsCursor',
+    cursorParamName: 'tableCursor',
     referrer: Referrer.PATHS_TABLE,
   });
 
@@ -64,8 +61,8 @@ export function CommandsTable() {
       <HeadSortCell
         sortKey={column.key}
         align={rightAlignColumns.has(column.key) ? 'right' : 'left'}
-        forceCellGrow={column.key === 'command'}
-        cursorParamName="commandsCursor"
+        forceCellGrow={column.key === SpanFields.MCP_RESOURCE_URI}
+        cursorParamName="tableCursor"
       >
         {column.name}
       </HeadSortCell>
@@ -78,26 +75,20 @@ export function CommandsTable() {
       dataRow: (typeof tableDataRequest.data)[number]
     ) => {
       switch (column.key) {
-        case 'command':
-          return <CommandCell command={dataRow.command} />;
+        case SpanFields.MCP_RESOURCE_URI:
+          return <McpResourceCell resource={dataRow[SpanFields.MCP_RESOURCE_URI]} />;
         case 'failure_rate()':
           return (
             <ErrorRateCell
               errorRate={dataRow['failure_rate()']}
               total={dataRow['count()']}
-              issuesLink={getErrorCellIssuesLink({
-                projectId: dataRow['project.id'],
-                query: `command:"${dataRow.command}"`,
-              })}
             />
           );
-        case 'avg(span.duration)':
-        case 'p95(span.duration)':
-          return <DurationCell milliseconds={dataRow[column.key]} />;
         case 'count()':
           return <NumberCell value={dataRow['count()']} />;
-        case 'sum(span.duration)':
-          return <TimeSpentCell total={dataRow['sum(span.duration)']} />;
+        case AVG_DURATION:
+        case P95_DURATION:
+          return <DurationCell milliseconds={dataRow[column.key]} />;
         default:
           return <div />;
       }
@@ -116,14 +107,14 @@ export function CommandsTable() {
         renderBodyCell,
         renderHeadCell,
       }}
-      cursorParamName="commandsCursor"
+      cursorParamName="tableCursor"
       pageLinks={tableDataRequest.pageLinks}
       isPlaceholderData={tableDataRequest.isPlaceholderData}
     />
   );
 }
 
-function CommandCell({command}: {command: string}) {
+function McpResourceCell({resource}: {resource: string}) {
   const organization = useOrganization();
   const {selection} = usePageFilters();
 
@@ -137,8 +128,8 @@ function CommandCell({command}: {command: string}) {
         yAxes: ['count(span.duration)'],
       },
     ],
-    query: `span.op:console.command* command:${command}`,
+    query: `span.op:mcp.server ${SpanFields.MCP_RESOURCE_URI}:"${resource}"`,
     sort: `-count(span.duration)`,
   });
-  return <Link to={link}>{command}</Link>;
+  return <Link to={link}>{resource}</Link>;
 }

--- a/static/app/views/insights/mcp/components/mcpResourcesTable.tsx
+++ b/static/app/views/insights/mcp/components/mcpResourcesTable.tsx
@@ -14,7 +14,7 @@ import {getExploreUrl} from 'sentry/views/explore/utils';
 import {HeadSortCell} from 'sentry/views/insights/agentMonitoring/components/headSortCell';
 import {useCombinedQuery} from 'sentry/views/insights/agentMonitoring/hooks/useCombinedQuery';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
-import {Referrer} from 'sentry/views/insights/pages/platform/laravel/referrers';
+import {MCPReferrer} from 'sentry/views/insights/mcp/utils/referrer';
 import {PlatformInsightsTable} from 'sentry/views/insights/pages/platform/shared/table';
 import {DurationCell} from 'sentry/views/insights/pages/platform/shared/table/DurationCell';
 import {ErrorRateCell} from 'sentry/views/insights/pages/platform/shared/table/ErrorRateCell';
@@ -53,7 +53,7 @@ export function McpResourcesTable() {
       P95_DURATION,
     ],
     cursorParamName: 'tableCursor',
-    referrer: Referrer.PATHS_TABLE,
+    referrer: MCPReferrer.MCP_RESOURCE_TABLE,
   });
 
   const renderHeadCell = useCallback((column: GridColumnHeader<string>) => {

--- a/static/app/views/insights/mcp/components/mcpToolsTable.tsx
+++ b/static/app/views/insights/mcp/components/mcpToolsTable.tsx
@@ -14,7 +14,7 @@ import {getExploreUrl} from 'sentry/views/explore/utils';
 import {HeadSortCell} from 'sentry/views/insights/agentMonitoring/components/headSortCell';
 import {useCombinedQuery} from 'sentry/views/insights/agentMonitoring/hooks/useCombinedQuery';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
-import {Referrer} from 'sentry/views/insights/pages/platform/laravel/referrers';
+import {MCPReferrer} from 'sentry/views/insights/mcp/utils/referrer';
 import {PlatformInsightsTable} from 'sentry/views/insights/pages/platform/shared/table';
 import {DurationCell} from 'sentry/views/insights/pages/platform/shared/table/DurationCell';
 import {ErrorRateCell} from 'sentry/views/insights/pages/platform/shared/table/ErrorRateCell';
@@ -53,7 +53,7 @@ export function McpToolsTable() {
       P95_DURATION,
     ],
     cursorParamName: 'tableCursor',
-    referrer: Referrer.PATHS_TABLE,
+    referrer: MCPReferrer.MCP_TOOL_TABLE,
   });
 
   const renderHeadCell = useCallback((column: GridColumnHeader<string>) => {

--- a/static/app/views/insights/mcp/components/placeholders.tsx
+++ b/static/app/views/insights/mcp/components/placeholders.tsx
@@ -1,8 +1,6 @@
 import styled from '@emotion/styled';
 
-import Panel from 'sentry/components/panels/panel';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 
 const PlaceholderContent = styled('div')`
@@ -12,16 +10,6 @@ const PlaceholderContent = styled('div')`
   justify-content: center;
   color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSize.md};
-`;
-
-const TableContainer = styled('div')`
-  margin-top: ${space(2)};
-`;
-
-const PlaceholderTable = styled(Panel)`
-  padding: ${space(2)};
-  text-align: center;
-  color: ${p => p.theme.subText};
 `;
 
 function PlaceholderText() {
@@ -34,42 +22,5 @@ export function RequestsBySourceWidget() {
       Title={<Widget.WidgetTitle title={t('Requests by source')} />}
       Visualization={<PlaceholderText />}
     />
-  );
-}
-
-export function ToolsTable() {
-  return (
-    <TableContainer>
-      <PlaceholderTable>
-        <h3>{t('Tools Table')}</h3>
-        <p>
-          {t(
-            'Placeholder for tools table with metrics like requests, error rate, avg, p95'
-          )}
-        </p>
-      </PlaceholderTable>
-    </TableContainer>
-  );
-}
-
-export function ResourcesTable() {
-  return (
-    <TableContainer>
-      <PlaceholderTable>
-        <h3>{t('Resources Table')}</h3>
-        <p>{t('Placeholder for resources table')}</p>
-      </PlaceholderTable>
-    </TableContainer>
-  );
-}
-
-export function PromptsTable() {
-  return (
-    <TableContainer>
-      <PlaceholderTable>
-        <h3>{t('Prompts Table')}</h3>
-        <p>{t('Placeholder for prompts table')}</p>
-      </PlaceholderTable>
-    </TableContainer>
   );
 }

--- a/static/app/views/insights/mcp/components/styles.tsx
+++ b/static/app/views/insights/mcp/components/styles.tsx
@@ -5,6 +5,7 @@ import {space} from 'sentry/styles/space';
 const StyledGrid = styled('div')`
   display: grid;
   gap: ${space(2)};
+  padding-bottom: ${space(2)};
 
   grid-template-columns: minmax(0, 1fr);
   grid-template-rows: 260px 260px 260px;

--- a/static/app/views/insights/mcp/utils/referrer.tsx
+++ b/static/app/views/insights/mcp/utils/referrer.tsx
@@ -1,6 +1,7 @@
 export enum MCPReferrer {
   MCP_TRAFFIC_WIDGET = 'api.performance.mcp.traffic-widget',
   MCP_TRANSPORT_WIDGET = 'api.performance.mcp.transport-widget',
+  MCP_SOURCES_WIDGET = 'api.performance.mcp.sources-widget',
   MCP_TOOL_TRAFFIC_WIDGET = 'api.performance.mcp.tool-traffic-widget',
   MCP_PROMPT_TRAFFIC_WIDGET = 'api.performance.mcp.prompt-traffic-widget',
   MCP_RESOURCE_TRAFFIC_WIDGET = 'api.performance.mcp.resource-traffic-widget',

--- a/static/app/views/insights/mcp/utils/referrer.tsx
+++ b/static/app/views/insights/mcp/utils/referrer.tsx
@@ -10,4 +10,7 @@ export enum MCPReferrer {
   MCP_TOOL_ERROR_RATE_WIDGET = 'api.performance.mcp.tool-error-rate-widget',
   MCP_PROMPT_ERROR_RATE_WIDGET = 'api.performance.mcp.prompt-error-rate-widget',
   MCP_RESOURCE_ERROR_RATE_WIDGET = 'api.performance.mcp.resource-error-rate-widget',
+  MCP_TOOL_TABLE = 'api.performance.mcp.tool-table',
+  MCP_PROMPT_TABLE = 'api.performance.mcp.prompt-table',
+  MCP_RESOURCE_TABLE = 'api.performance.mcp.resource-table',
 }

--- a/static/app/views/insights/mcp/views/overview.tsx
+++ b/static/app/views/insights/mcp/views/overview.tsx
@@ -78,6 +78,12 @@ const viewErrorRateWidgets: Record<ViewType, React.ComponentType> = {
   [ViewType.PROMPT]: McpPromptErrorRateWidget,
 };
 
+const viewTables: Record<ViewType, React.ComponentType> = {
+  [ViewType.TOOL]: McpToolsTable,
+  [ViewType.RESOURCE]: McpResourcesTable,
+  [ViewType.PROMPT]: McpPromptsTable,
+};
+
 function useShowOnboarding() {
   const {projects} = useProjects();
   const pageFilters = usePageFilters();
@@ -137,6 +143,7 @@ function McpOverviewPage() {
   const ViewTrafficWidget = viewTrafficWidgets[activeView];
   const ViewDurationWidget = viewDurationWidgets[activeView];
   const ViewErrorRateWidget = viewErrorRateWidgets[activeView];
+  const ViewTable = viewTables[activeView];
 
   return (
     <SearchQueryBuilderProvider {...eapSpanSearchQueryProviderProps}>
@@ -212,9 +219,7 @@ function McpOverviewPage() {
                         <ViewErrorRateWidget />
                       </WidgetGrid.Position3>
                     </WidgetGrid>
-                    {activeView === ViewType.TOOL && <McpToolsTable />}
-                    {activeView === ViewType.RESOURCE && <McpResourcesTable />}
-                    {activeView === ViewType.PROMPT && <McpPromptsTable />}
+                    <ViewTable />
                   </Fragment>
                 )}
               </ModuleLayout.Full>

--- a/static/app/views/insights/pages/platform/laravel/commandsTable.tsx
+++ b/static/app/views/insights/pages/platform/laravel/commandsTable.tsx
@@ -55,7 +55,7 @@ export function CommandsTable() {
       'p95(span.duration)',
       'sum(span.duration)',
     ],
-    cursorParamName: 'jobsCursor',
+    cursorParamName: 'commandsCursor',
     referrer: Referrer.PATHS_TABLE,
   });
 

--- a/static/app/views/insights/pages/platform/laravel/jobsTable.tsx
+++ b/static/app/views/insights/pages/platform/laravel/jobsTable.tsx
@@ -17,7 +17,8 @@ import {PlatformInsightsTable} from 'sentry/views/insights/pages/platform/shared
 import {DurationCell} from 'sentry/views/insights/pages/platform/shared/table/DurationCell';
 import {ErrorRateCell} from 'sentry/views/insights/pages/platform/shared/table/ErrorRateCell';
 import {NumberCell} from 'sentry/views/insights/pages/platform/shared/table/NumberCell';
-import {useTableData} from 'sentry/views/insights/pages/platform/shared/table/useTableData';
+import {useSpanTableData} from 'sentry/views/insights/pages/platform/shared/table/useTableData';
+import {useTransactionNameQuery} from 'sentry/views/insights/pages/platform/shared/useTransactionNameQuery';
 
 const defaultColumnOrder: Array<GridColumnOrder<string>> = [
   {
@@ -50,8 +51,9 @@ const rightAlignColumns = new Set([
 ]);
 
 export function JobsTable() {
-  const tableDataRequest = useTableData({
-    query: 'span.op:queue.process',
+  const {query} = useTransactionNameQuery();
+  const tableDataRequest = useSpanTableData({
+    query: `span.op:queue.process ${query ?? ''}`.trim(),
     fields: [
       'count()',
       'project.id',

--- a/static/app/views/insights/pages/platform/nextjs/apiTable.tsx
+++ b/static/app/views/insights/pages/platform/nextjs/apiTable.tsx
@@ -17,7 +17,8 @@ import {
 } from 'sentry/views/insights/pages/platform/shared/table/ErrorRateCell';
 import {NumberCell} from 'sentry/views/insights/pages/platform/shared/table/NumberCell';
 import {TransactionCell} from 'sentry/views/insights/pages/platform/shared/table/TransactionCell';
-import {useTableData} from 'sentry/views/insights/pages/platform/shared/table/useTableData';
+import {useSpanTableData} from 'sentry/views/insights/pages/platform/shared/table/useTableData';
+import {useTransactionNameQuery} from 'sentry/views/insights/pages/platform/shared/useTransactionNameQuery';
 
 const getP95Threshold = (avg: number) => {
   return {
@@ -44,8 +45,9 @@ const rightAlignColumns = new Set([
 ]);
 
 export function ApiTable() {
-  const tableDataRequest = useTableData({
-    query: 'transaction.op:http.server is_transaction:True',
+  const {query} = useTransactionNameQuery();
+  const tableDataRequest = useSpanTableData({
+    query: `transaction.op:http.server is_transaction:True ${query ?? ''}`.trim(),
     fields: [
       'project.id',
       'transaction',

--- a/static/app/views/insights/pages/platform/nextjs/clientTable.tsx
+++ b/static/app/views/insights/pages/platform/nextjs/clientTable.tsx
@@ -24,7 +24,8 @@ import {
 } from 'sentry/views/insights/pages/platform/shared/table/ErrorRateCell';
 import {NumberCell} from 'sentry/views/insights/pages/platform/shared/table/NumberCell';
 import {TransactionCell} from 'sentry/views/insights/pages/platform/shared/table/TransactionCell';
-import {useTableData} from 'sentry/views/insights/pages/platform/shared/table/useTableData';
+import {useSpanTableData} from 'sentry/views/insights/pages/platform/shared/table/useTableData';
+import {useTransactionNameQuery} from 'sentry/views/insights/pages/platform/shared/useTransactionNameQuery';
 import {ModuleName} from 'sentry/views/insights/types';
 
 const pageloadColumnOrder: Array<GridColumnOrder<string>> = [
@@ -69,8 +70,9 @@ export function ClientTable() {
   existingQuery.addFilterValue('is_transaction', 'true');
   existingQuery.addFilterValues('!sentry.origin', ['auto.db.*', 'auto'], false);
 
-  const tableDataRequest = useTableData({
-    query: existingQuery.formatString(),
+  const {query} = useTransactionNameQuery();
+  const tableDataRequest = useSpanTableData({
+    query: `${existingQuery.formatString()} ${query ?? ''}`.trim(),
     fields: [
       'transaction',
       'project.id',

--- a/static/app/views/insights/pages/platform/shared/table/useTableData.tsx
+++ b/static/app/views/insights/pages/platform/shared/table/useTableData.tsx
@@ -3,15 +3,14 @@ import {useMemo} from 'react';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useTableSortParams} from 'sentry/views/insights/agentMonitoring/components/headSortCell';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
-import {useTransactionNameQuery} from 'sentry/views/insights/pages/platform/shared/useTransactionNameQuery';
 import type {EAPSpanProperty} from 'sentry/views/insights/types';
 
 const PER_PAGE = 10;
 
-export function useTableData<Fields extends EAPSpanProperty>({
+export function useSpanTableData<Fields extends EAPSpanProperty>({
   fields,
   referrer,
-  query: baseQuery,
+  query,
   cursorParamName,
 }: {
   cursorParamName: string;
@@ -20,13 +19,14 @@ export function useTableData<Fields extends EAPSpanProperty>({
   referrer: string;
 }) {
   const location = useLocation();
-  const {query} = useTransactionNameQuery();
   const {sortField, sortOrder} = useTableSortParams();
+
+  const isValidSortKey = fields.includes(sortField as Fields);
 
   return useSpans(
     {
-      search: `${baseQuery ?? ''} ${query}`.trim(),
-      sorts: [{field: sortField, kind: sortOrder}],
+      search: query,
+      sorts: isValidSortKey ? [{field: sortField, kind: sortOrder}] : undefined,
       fields,
       limit: PER_PAGE,
       keepPreviousData: true,
@@ -50,7 +50,7 @@ export function useTableDataWithController<Fields extends EAPSpanProperty>({
   query: string;
   referrer: string;
 }) {
-  const transactionsRequest = useTableData({
+  const transactionsRequest = useSpanTableData({
     query,
     fields: ['transaction', ...fields],
     cursorParamName,


### PR DESCRIPTION
Add tables for tools, resources and prompts to the MCP insights module.
Move `useTransactionNameQuery` out of table data hook.