### PR TITLE
feat(profiling): add utility to split a datetime in exponentailly growing ranges

### DIFF
--- a/src/sentry/profiles/flamegraph.py
+++ b/src/sentry/profiles/flamegraph.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from collections.abc import Mapping
+from collections.abc import Iterator, Mapping
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Any, Literal, NotRequired, TypedDict
@@ -614,7 +614,9 @@ class FlamegraphExecutor:
         )
 
 
-def split_datetime_range_exponential(start_datetime, end_datetime, initial_chunk_delta, max_delta):
+def split_datetime_range_exponential(
+    start_datetime, end_datetime, initial_chunk_delta, max_delta
+) -> Iterator[tuple[datetime, datetime]]:
     """
     Splits a datetime range into exponentially increasing chunks, yielded by a generator.
 

--- a/src/sentry/profiles/flamegraph.py
+++ b/src/sentry/profiles/flamegraph.py
@@ -615,7 +615,10 @@ class FlamegraphExecutor:
 
 
 def split_datetime_range_exponential(
-    start_datetime, end_datetime, initial_chunk_delta, max_delta
+    start_datetime: datetime,
+    end_datetime: datetime,
+    initial_chunk_delta: timedelta,
+    max_delta: timedelta,
 ) -> Iterator[tuple[datetime, datetime]]:
     """
     Splits a datetime range into exponentially increasing chunks, yielded by a generator.

--- a/tests/sentry/profiles/test_flamegraph.py
+++ b/tests/sentry/profiles/test_flamegraph.py
@@ -1,0 +1,44 @@
+from datetime import datetime, timedelta
+
+from sentry.profiles.flamegraph import split_datetime_range_exponential
+
+
+def test_split_datetime_range_exponential_with_days():
+    start = datetime(2023, 1, 1)
+    end = datetime(2023, 1, 31)
+    initial_delta = timedelta(days=1)
+    max_chunk_delta = timedelta(days=8)
+
+    result = list(split_datetime_range_exponential(start, end, initial_delta, max_chunk_delta))
+
+    expected_chunks = [
+        (datetime(2023, 1, 1), datetime(2023, 1, 2)),  # Delta: 1 day
+        (datetime(2023, 1, 2), datetime(2023, 1, 4)),  # Delta: 2 days
+        (datetime(2023, 1, 4), datetime(2023, 1, 8)),  # Delta: 4 days
+        (datetime(2023, 1, 8), datetime(2023, 1, 16)),  # Delta: 8 days (max reached)
+        (datetime(2023, 1, 16), datetime(2023, 1, 24)),  # Delta: 8 days
+        (datetime(2023, 1, 24), datetime(2023, 1, 31)),  # Final chunk trimmed to end
+    ]
+
+    assert result == expected_chunks
+
+
+def test_split_datetime_range_exponential_with_hours():
+    start_time = datetime(2024, 5, 1, 6, 0, 0)
+    end_time = datetime(2024, 5, 2, 12, 0, 0)
+    initial_h_delta = timedelta(hours=2)
+    max_h_delta = timedelta(hours=8)
+
+    result = list(
+        split_datetime_range_exponential(start_time, end_time, initial_h_delta, max_h_delta)
+    )
+
+    expected_chunks = [
+        (datetime(2024, 5, 1, 6, 0), datetime(2024, 5, 1, 8, 0)),  # Delta: 2 hours
+        (datetime(2024, 5, 1, 8, 0), datetime(2024, 5, 1, 12, 0)),  # Delta: 4 hours
+        (datetime(2024, 5, 1, 12, 0), datetime(2024, 5, 1, 20, 0)),  # Delta: 8 hours (max reached)
+        (datetime(2024, 5, 1, 20, 0), datetime(2024, 5, 2, 4, 0)),  # Delta: 8 hours
+        (datetime(2024, 5, 2, 4, 0), datetime(2024, 5, 2, 12, 0)),  # Final chunk fits perfectly
+    ]
+
+    assert result == expected_chunks


### PR DESCRIPTION
This PR introduces a new utility function, `split_datetime_range_exponential`, to help with dividing a given datetime range into exponentially increasing chunks.


This utility will be beneficial for scenarios where a large time range needs to be processed in smaller, progressively larger segments. 
This approach can help in efficiently handling large datasets by preventing overly large initial queries while still leveraging larger chunks for older data.