### PR TITLE
feat(encryption): EncryptedField base class

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1488,6 +1488,18 @@ BGTASKS: dict[str, BgTaskConfig] = {
     },
 }
 
+# Fernet keys for database encryption.
+# First key in the dict is used as a primary key, and if
+# encryption method options is "fernet", the first key will be
+# used to decrypt the data.
+#
+# Other keys are used only for data decryption. This structure
+# is used to allow easier key rotation when "fernet" is used
+# as an encryption method.
+DATABASE_ENCRYPTION_FERNET_KEYS = {
+    os.getenv("DATABASE_ENCRYPTION_KEY_ID_1"): os.getenv("DATABASE_ENCRYPTION_FERNET_KEY_1"),
+}
+
 #######################
 # Taskworker settings #
 #######################

--- a/src/sentry/db/models/fields/__init__.py
+++ b/src/sentry/db/models/fields/__init__.py
@@ -1,5 +1,6 @@
 from .bounded import *  # NOQA
 from .citext import *  # NOQA
+from .encryption import *  # NOQA
 from .foreignkey import *  # NOQA
 from .gzippeddict import *  # NOQA
 from .jsonfield import *  # NOQA

--- a/src/sentry/db/models/fields/encryption.py
+++ b/src/sentry/db/models/fields/encryption.py
@@ -114,6 +114,9 @@ class EncryptedField(Field):
         handler = self._encryption_handlers[encryption_method]
         return handler["encrypt"](value)
 
+    def from_db_value(self, value: Any, expression: Any, connection: Any) -> Any:
+        return self.to_python(value)
+
     def to_python(self, value: Any) -> Any:
         """Decrypt the value when loading from database."""
         if value is None:

--- a/src/sentry/db/models/fields/encryption.py
+++ b/src/sentry/db/models/fields/encryption.py
@@ -1,0 +1,316 @@
+from __future__ import annotations
+
+import base64
+import logging
+from collections.abc import Callable
+from typing import Any, Literal, TypedDict
+
+import sentry_sdk
+from cryptography.fernet import Fernet, InvalidToken
+from django.conf import settings
+from django.db.models import Field
+
+from sentry import options
+
+logger = logging.getLogger(__name__)
+
+
+# Encryption method markers
+MARKER_PLAIN_TEXT = "00"
+MARKER_FERNET = "01"
+MARKER_TINK_KEYSETS = "02"  # Future implementation
+
+KNOWN_MARKERS = {MARKER_PLAIN_TEXT, MARKER_FERNET, MARKER_TINK_KEYSETS}
+
+
+class _EncryptionHandler(TypedDict):
+    marker: str
+    encrypt: Callable[[Any], str]
+    decrypt: Callable[[bytes], bytes]
+
+
+type _EncryptionMethod = Literal["plain_text"] | Literal["fernet"] | Literal["keysets"]
+
+
+class EncryptedField(Field):
+    """
+    A mixin that adds encryption functionality to Django fields.
+
+    Encryption method is controlled via the 'database.encryption.method' option.
+    Supported methods:
+    - 'plain_text': No encryption (default for development)
+    - 'fernet': Fernet symmetric encryption
+    - 'keysets': (Future) Google Tink keysets for key rotation
+
+    Decryption will be done based on the marker, and not on the current active
+    encryption method option. Current active encryption method option is only
+    relevant when encrypting and storing the data.
+
+    Uses base64 encoding for storing encrypted binary data as text.
+
+    For Fernet encryption, the format is: {marker}:{key_id}:{encrypted_data}
+    This allows for easier key rotation by storing which key was used for encryption.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self._encryption_handlers: dict[_EncryptionMethod, _EncryptionHandler] = {
+            "plain_text": {
+                "marker": MARKER_PLAIN_TEXT,
+                "encrypt": self._encrypt_plain_text,
+                "decrypt": self._decrypt_plain_text,
+            },
+            "fernet": {
+                "marker": MARKER_FERNET,
+                "encrypt": self._encrypt_fernet,
+                "decrypt": self._decrypt_fernet,
+            },
+            "keysets": {
+                "marker": MARKER_TINK_KEYSETS,
+                "encrypt": self._encrypt_keysets,
+                "decrypt": self._decrypt_keysets,
+            },
+        }
+
+    def _format_encrypted_value(
+        self, encrypted_data: bytes, marker: str, key_id: str | None = None
+    ) -> str:
+        """Format encrypted data with marker and optional key_id for storage.
+
+        Args:
+            encrypted_data: The raw encrypted bytes
+            marker: The encryption method marker
+            key_id: Optional key identifier for key rotation support
+
+        Returns:
+            Formatted string for database storage
+        """
+        encoded_data = base64.b64encode(encrypted_data).decode("ascii")
+        if key_id is not None:
+            return f"{marker}:{key_id}:{encoded_data}"
+        else:
+            return f"{marker}:{encoded_data}"
+
+    def get_prep_value(self, value: Any) -> str | None:
+        """Encrypt the value before saving to database."""
+        value = super().get_prep_value(value)
+        if value is None:
+            return value
+
+        encryption_method = options.get("database.encryption.method")
+
+        # Default to plain_text if method is not recognized
+        if encryption_method not in self._encryption_handlers:
+            logger.error(
+                "Unknown encryption method '%s', defaulting to plain_text", encryption_method
+            )
+            encryption_method = "plain_text"
+
+        handler = self._encryption_handlers[encryption_method]
+        return handler["encrypt"](value)
+
+    def to_python(self, value: Any) -> Any:
+        """Decrypt the value when loading from database."""
+        if value is None:
+            return value
+
+        # it's already a string and doesn't look encrypted, return it
+        if isinstance(value, str) and not self._is_encrypted_format(value):
+            return value
+
+        # it's encrypted format, decrypt it
+        if isinstance(value, str) and self._is_encrypted_format(value):
+            return self._decrypt_with_fallback(value)
+
+        # fallback
+        return super().to_python(value)
+
+    def _is_encrypted_format(self, value: str) -> bool:
+        """Check if the value is in encrypted format (marker:base64data or marker:key_id:base64data)."""
+        parts = value.split(":")
+        return len(parts) >= 2 and len(parts[0]) == 2 and parts[0] in KNOWN_MARKERS
+
+    def _get_value_in_bytes(self, value: Any) -> bytes:
+        if isinstance(value, str):
+            return value.encode("utf-8")
+        elif isinstance(value, bytes):
+            return value
+        else:
+            return str(value).encode("utf-8")
+
+    def _encrypt_plain_text(self, value: Any) -> str:
+        """Store value as plain text (UTF-8 encoded)."""
+        value_bytes = self._get_value_in_bytes(value)
+        return self._format_encrypted_value(value_bytes, MARKER_PLAIN_TEXT)
+
+    def _decrypt_plain_text(self, value: bytes) -> bytes:
+        """Decrypt plain text."""
+        return value
+
+    def _encrypt_fernet(self, value: Any) -> str:
+        """Encrypt using Fernet symmetric encryption.
+
+        Returns formatted string with key_id for key rotation support.
+        """
+        key_id, key = self._get_fernet_key_for_encryption()
+        if not key:
+            raise ValueError(
+                "Fernet encryption key is required but not found. "
+                "Please set DATABASE_ENCRYPTION_FERNET_KEYS in your settings."
+            )
+
+        try:
+            f = Fernet(key)
+            value_bytes = self._get_value_in_bytes(value)
+            encrypted_data = f.encrypt(value_bytes)
+            return self._format_encrypted_value(encrypted_data, MARKER_FERNET, key_id)
+        except Exception as e:
+            # TODO: decide what to do with this error
+            sentry_sdk.capture_exception(e)
+            raise
+
+    def _decrypt_fernet(self, value: bytes, key_id: str | None = None) -> bytes:
+        """Decrypt using Fernet."""
+        key = self._get_fernet_key(key_id)
+        if not key:
+            if key_id:
+                logger.warning("No decryption key found for key_id '%s'", key_id)
+            else:
+                logger.warning("No decryption key found")
+            raise ValueError("Cannot decrypt without key")
+
+        try:
+            f = Fernet(key)
+            decrypted = f.decrypt(value)
+            return decrypted
+        except InvalidToken:  # noqa
+            # Decryption failed—this may occur if the value is actually plain text that happens to match
+            # the Fernet-encrypted format (e.g., during a migration or data corruption). We intentionally
+            # let the caller handle this error so that fallback logic (such as returning the original value)
+            # can be applied at a higher level.
+            raise
+
+    def _encrypt_keysets(self, value: Any) -> str:
+        """Encrypt using Google Tink keysets (future implementation)."""
+        raise NotImplementedError("Keysets encryption not yet implemented")
+
+    def _decrypt_keysets(self, value: bytes) -> bytes:
+        """Decrypt using Google Tink keysets (future implementation)."""
+        raise NotImplementedError("Keysets decryption not yet implemented")
+
+    def _decrypt_with_fallback(self, value: str) -> bytes | str:
+        """
+        Attempt to decrypt with multiple methods.
+        This handles cases where the encryption method was changed.
+        """
+        parts = value.split(":")
+        if len(parts) < 2:
+            return value
+
+        marker = parts[0]
+
+        # Handle Fernet format with key_id: marker:key_id:data
+        if marker == MARKER_FERNET and len(parts) == 3:
+            key_id, encoded_data = parts[1], parts[2]
+            try:
+                encrypted_data = base64.b64decode(encoded_data)
+                return self._decrypt_fernet(encrypted_data, key_id)
+            except InvalidToken:
+                # Data might be plain text that happens to accidentally match the Fernet format
+                # Treating this as plain text is the best fallback.
+                return value
+            except Exception as e:
+                sentry_sdk.capture_exception(e)
+                logger.exception("Failed to decrypt with Fernet using key_id '%s'", key_id)
+
+        # Handle plain text format: marker:data
+        elif len(parts) == 2:
+            encoded_data = parts[1]
+            try:
+                encrypted_data = base64.b64decode(encoded_data)
+            except Exception:
+                # If base64 decode fails, treat as plain text
+                return value
+
+            # Find handler by marker
+            for method_name, handler in self._encryption_handlers.items():
+                if handler["marker"] == marker:
+                    try:
+                        return handler["decrypt"](encrypted_data)
+                    except Exception as e:
+                        sentry_sdk.capture_exception(e)
+                        logger.exception("Failed to decrypt with %s", method_name)
+                        continue
+
+        return value
+
+    def _get_fernet_key_for_encryption(self) -> tuple[str, bytes]:
+        """Get the first Fernet key for encryption along with its key_id."""
+        keys = getattr(settings, "DATABASE_ENCRYPTION_FERNET_KEYS", None)
+        if keys is None:
+            raise ValueError("DATABASE_ENCRYPTION_FERNET_KEYS is not configured")
+
+        if not isinstance(keys, dict):
+            logger.error("DATABASE_ENCRYPTION_FERNET_KEYS must be a dict, got %s", type(keys))
+            raise ValueError("DATABASE_ENCRYPTION_FERNET_KEYS must be a dictionary")
+
+        if not keys:
+            raise ValueError("DATABASE_ENCRYPTION_FERNET_KEYS is empty")
+
+        # Use the first key for encryption
+        key_id = next(iter(keys.keys()))
+        key = keys[key_id]
+
+        if not key_id or not key:
+            raise ValueError(
+                f"DATABASE_ENCRYPTION_FERNET_KEYS has invalid key_id or key ({key_id}, {key})"
+            )
+
+        if isinstance(key, str):
+            key = key.encode("utf-8")
+
+        # Validate key
+        try:
+            Fernet(key)
+            return (key_id, key)
+        except Exception as e:
+            sentry_sdk.capture_exception(e)
+            logger.exception("Invalid Fernet key for key_id '%s'", key_id)
+            raise ValueError(f"Invalid Fernet key for key_id '{key_id}'")
+
+    def _get_fernet_key(self, key_id: str | None = None) -> bytes | None:
+        """Get the Fernet key from Django settings."""
+        keys = getattr(settings, "DATABASE_ENCRYPTION_FERNET_KEYS", None)
+        if keys is None:
+            return None
+
+        if not isinstance(keys, dict):
+            logger.error("DATABASE_ENCRYPTION_FERNET_KEYS must be a dict, got %s", type(keys))
+            return None
+
+        if key_id is None:
+            # Return first/default key if no key_id specified
+            if not keys:
+                return None
+            key = next(iter(keys.values()))
+        else:
+            # Return specific key by key_id
+            if key_id not in keys:
+                logger.warning("Fernet key with id '%s' not found, cannot decrypt data", key_id)
+                return None
+            key = keys[key_id]
+
+        if isinstance(key, str):
+            # If key is a string, encode it
+            key = key.encode("utf-8")
+
+        # Validate key length (Fernet requires 32 bytes base64 encoded)
+        try:
+            Fernet(key)
+            return key
+        except Exception as e:
+            sentry_sdk.capture_exception(e)
+            logger.exception("Invalid Fernet key")
+
+        return None

--- a/src/sentry/db/models/fields/encryption.py
+++ b/src/sentry/db/models/fields/encryption.py
@@ -189,7 +189,6 @@ class EncryptedField(Field):
             encrypted_data = f.encrypt(value_bytes)
             return self._format_encrypted_value(encrypted_data, MARKER_FERNET, key_id)
         except Exception as e:
-            # TODO: decide what to do with this error
             sentry_sdk.capture_exception(e)
             raise
 

--- a/src/sentry/db/models/fields/encryption.py
+++ b/src/sentry/db/models/fields/encryption.py
@@ -16,11 +16,11 @@ logger = logging.getLogger(__name__)
 
 
 # Encryption method markers
-MARKER_PLAIN_TEXT = "00"
+MARKER_PLAINTEXT = "00"
 MARKER_FERNET = "01"
 MARKER_TINK_KEYSETS = "02"  # Future implementation
 
-KNOWN_MARKERS = {MARKER_PLAIN_TEXT, MARKER_FERNET, MARKER_TINK_KEYSETS}
+KNOWN_MARKERS = {MARKER_PLAINTEXT, MARKER_FERNET, MARKER_TINK_KEYSETS}
 
 
 class _EncryptionHandler(TypedDict):
@@ -29,7 +29,7 @@ class _EncryptionHandler(TypedDict):
     decrypt: Callable[[bytes], bytes]
 
 
-type _EncryptionMethod = Literal["plain_text"] | Literal["fernet"] | Literal["keysets"]
+type _EncryptionMethod = Literal["plaintext"] | Literal["fernet"] | Literal["keysets"]
 
 
 class EncryptedField(Field):
@@ -38,7 +38,7 @@ class EncryptedField(Field):
 
     Encryption method is controlled via the 'database.encryption.method' option.
     Supported methods:
-    - 'plain_text': No encryption (default for development)
+    - 'plaintext': No encryption (default for development)
     - 'fernet': Fernet symmetric encryption
     - 'keysets': (Future) Google Tink keysets for key rotation
 
@@ -56,10 +56,10 @@ class EncryptedField(Field):
         super().__init__(*args, **kwargs)
 
         self._encryption_handlers: dict[_EncryptionMethod, _EncryptionHandler] = {
-            "plain_text": {
-                "marker": MARKER_PLAIN_TEXT,
-                "encrypt": self._encrypt_plain_text,
-                "decrypt": self._decrypt_plain_text,
+            "plaintext": {
+                "marker": MARKER_PLAINTEXT,
+                "encrypt": self._encrypt_plaintext,
+                "decrypt": self._decrypt_plaintext,
             },
             "fernet": {
                 "marker": MARKER_FERNET,
@@ -100,12 +100,12 @@ class EncryptedField(Field):
 
         encryption_method = options.get("database.encryption.method")
 
-        # Default to plain_text if method is not recognized
+        # Default to plaintext if method is not recognized
         if encryption_method not in self._encryption_handlers:
             logger.error(
-                "Unknown encryption method '%s', defaulting to plain_text", encryption_method
+                "Unknown encryption method '%s', defaulting to plaintext", encryption_method
             )
-            encryption_method = "plain_text"
+            encryption_method = "plaintext"
 
         handler = self._encryption_handlers[encryption_method]
         return handler["encrypt"](value)
@@ -139,12 +139,12 @@ class EncryptedField(Field):
         else:
             return str(value).encode("utf-8")
 
-    def _encrypt_plain_text(self, value: Any) -> str:
+    def _encrypt_plaintext(self, value: Any) -> str:
         """Store value as plain text (UTF-8 encoded)."""
         value_bytes = self._get_value_in_bytes(value)
-        return self._format_encrypted_value(value_bytes, MARKER_PLAIN_TEXT)
+        return self._format_encrypted_value(value_bytes, MARKER_PLAINTEXT)
 
-    def _decrypt_plain_text(self, value: bytes) -> bytes:
+    def _decrypt_plaintext(self, value: bytes) -> bytes:
         """Decrypt plain text."""
         return value
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3504,12 +3504,12 @@ register(
 
 # Database field encryption method
 # Supported values:
-# - 'plain_text': No encryption (default)
+# - 'plaintext': No encryption (default)
 # - 'fernet': Fernet symmetric encryption
 # - 'keysets': (Future) Google Tink keysets for key rotation
 register(
     "database.encryption.method",
     type=String,
-    default="plain_text",
+    default="plaintext",
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3501,3 +3501,15 @@ register(
     default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+# Database field encryption method
+# Supported values:
+# - 'plain_text': No encryption (default)
+# - 'fernet': Fernet symmetric encryption
+# - 'keysets': (Future) Google Tink keysets for key rotation
+register(
+    "database.encryption.method",
+    type=String,
+    default="plain_text",
+    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
+)

--- a/tests/sentry/db/models/fields/test_encryption.py
+++ b/tests/sentry/db/models/fields/test_encryption.py
@@ -1,0 +1,472 @@
+import base64
+
+import pytest
+from cryptography.fernet import Fernet
+from django.test import override_settings
+
+from sentry.db.models.fields.encryption import MARKER_FERNET, MARKER_PLAIN_TEXT, EncryptedField
+from sentry.testutils.helpers.options import override_options
+
+ENCRYPTION_METHODS = ("plain_text", "fernet")
+
+
+@pytest.fixture
+def fernet_key():
+    return Fernet.generate_key()
+
+
+@pytest.fixture
+def fernet_instance(fernet_key):
+    return Fernet(fernet_key)
+
+
+@pytest.fixture
+def fernet_keys_value(fernet_key):
+    return {"key_id_1": fernet_key.decode()}
+
+
+@pytest.fixture
+def multi_fernet_keys_value():
+    """Multiple keys for testing key rotation."""
+    key1 = Fernet.generate_key()
+    key2 = Fernet.generate_key()
+    return {
+        "key_primary": key1.decode(),
+        "key_secondary": key2.decode(),
+    }
+
+
+def test_plain_text_encryption():
+    with override_options({"database.encryption.method": "plain_text"}):
+        field = EncryptedField()
+
+        # Test encryption (should return marker:base64 encoded string)
+        encrypted = field.get_prep_value("test value")
+        assert encrypted == f"{MARKER_PLAIN_TEXT}:{base64.b64encode(b'test value').decode('ascii')}"
+        assert isinstance(encrypted, str)
+
+        # Test decryption (should return string)
+        decrypted = field.to_python(
+            f"{MARKER_PLAIN_TEXT}:{base64.b64encode(b'test value').decode('ascii')}"
+        )
+        assert decrypted == b"test value"
+        assert isinstance(decrypted, bytes)
+
+
+@override_settings(DATABASE_ENCRYPTION_FERNET_KEYS=None)
+def test_fernet_encryption_without_key():
+    """Test that Fernet encryption raises an error without key."""
+    with override_options({"database.encryption.method": "fernet"}):
+        field = EncryptedField()
+
+        with pytest.raises(ValueError, match="DATABASE_ENCRYPTION_FERNET_KEYS is not configured"):
+            field.get_prep_value("test value")
+
+
+def test_fernet_encryption_with_key(multi_fernet_keys_value):
+    """Test Fernet encryption with a valid key using new format."""
+    with override_options({"database.encryption.method": "fernet"}):
+        with override_settings(DATABASE_ENCRYPTION_FERNET_KEYS=multi_fernet_keys_value):
+            field = EncryptedField()
+
+            # Test encryption
+            encrypted = field.get_prep_value("test value")
+            assert isinstance(encrypted, str)
+            assert encrypted is not None
+
+            # Should have the new format: marker:key_id:data
+            parts = encrypted.split(":")
+            assert len(parts) == 3
+            marker, key_id, encoded_data = parts
+
+            # Should start with fernet marker
+            assert marker == MARKER_FERNET
+
+            # Should use the first key (key_primary)
+            assert key_id == "key_primary"
+
+            # Verify the rest is valid fernet encrypted data
+            fernet_data = base64.b64decode(encoded_data)
+            # Should be able to decrypt with the correct key
+            first_key = list(multi_fernet_keys_value.values())[0]
+            fernet_instance = Fernet(first_key.encode())
+            decrypted_bytes = fernet_instance.decrypt(fernet_data)
+            assert decrypted_bytes == b"test value"
+
+            # Test decryption through field
+            decrypted = field.to_python(encrypted)
+            assert decrypted == b"test value"
+
+
+def test_fernet_key_rotation(multi_fernet_keys_value):
+    """Test that data encrypted with different keys can be decrypted."""
+    with override_options({"database.encryption.method": "fernet"}):
+        with override_settings(DATABASE_ENCRYPTION_FERNET_KEYS=multi_fernet_keys_value):
+            field = EncryptedField()
+
+            # Encrypt some data
+            encrypted_value = field.get_prep_value("test data")
+
+            # Should be able to decrypt it
+            decrypted_value = field.to_python(encrypted_value)
+            assert decrypted_value == b"test data"
+
+            # Manually create encrypted data with the second key
+            second_key_id = list(multi_fernet_keys_value.keys())[1]
+            second_key = multi_fernet_keys_value[second_key_id]
+            fernet_instance = Fernet(second_key.encode())
+            manual_encrypted = fernet_instance.encrypt(b"second key data")
+            manual_encoded = base64.b64encode(manual_encrypted).decode("ascii")
+            manual_formatted = f"{MARKER_FERNET}:{second_key_id}:{manual_encoded}"
+
+            # Should be able to decrypt data encrypted with the second key
+            decrypted_manual = field.to_python(manual_formatted)
+            assert decrypted_manual == b"second key data"
+
+
+def test_fernet_plain_text_format_compatibility(fernet_keys_value):
+    """Test that plain text format (without key_id) works."""
+    with override_options({"database.encryption.method": "fernet"}):
+        with override_settings(DATABASE_ENCRYPTION_FERNET_KEYS=fernet_keys_value):
+            field = EncryptedField()
+
+            # Create plain text format manually (marker:data without key_id)
+            key = list(fernet_keys_value.values())[0]
+            fernet_instance = Fernet(key.encode())
+            encrypted_data = fernet_instance.encrypt(b"plain text data")
+            encoded_data = base64.b64encode(encrypted_data).decode("ascii")
+            plain_text_format = f"{MARKER_FERNET}:{encoded_data}"
+
+            # Should be able to decrypt plain text format
+            decrypted = field.to_python(plain_text_format)
+            assert decrypted == b"plain text data"
+
+
+def test_encryption_method_switching(fernet_keys_value):
+    """Test that values can be decrypted after switching encryption methods."""
+    # encrypt with Fernet
+    with (
+        override_options({"database.encryption.method": "fernet"}),
+        override_settings(DATABASE_ENCRYPTION_FERNET_KEYS=fernet_keys_value),
+    ):
+        field = EncryptedField()
+        encrypted_fernet = field.get_prep_value("fernet encrypted")
+
+    # encrypt with plain text
+    with override_options({"database.encryption.method": "plain_text"}):
+        field = EncryptedField()
+        encrypted_plain = field.get_prep_value("plain text value")
+
+    # assert that both can be decrypted independently of the encryption method
+    for encryption_method in ENCRYPTION_METHODS:
+        with (
+            override_options({"database.encryption.method": encryption_method}),
+            override_settings(DATABASE_ENCRYPTION_FERNET_KEYS=fernet_keys_value),
+        ):
+            field = EncryptedField()
+
+            # Should decrypt fernet value
+            decrypted_fernet = field.to_python(encrypted_fernet)
+            assert decrypted_fernet == b"fernet encrypted"
+
+            # Should also handle plain text (fallback)
+            decrypted_plain = field.to_python(encrypted_plain)
+            assert decrypted_plain == b"plain text value"
+
+
+def test_invalid_fernet_key():
+    """Test handling of invalid Fernet keys."""
+    with override_options({"database.encryption.method": "fernet"}):
+        with override_settings(DATABASE_ENCRYPTION_FERNET_KEYS={"key1": "invalid-key"}):
+            field = EncryptedField()
+
+            # Should raise an error due to invalid key
+            with pytest.raises(ValueError, match="Invalid Fernet key for key_id 'key1'"):
+                field.get_prep_value("test value")
+
+
+def test_fernet_key_dict_format():
+    """Test that fernet key dictionary format works correctly."""
+    key1 = Fernet.generate_key()
+    key2 = Fernet.generate_key()
+    keys_dict = {
+        "key1": key1.decode(),
+        "key2": key2.decode(),
+    }
+
+    with override_options({"database.encryption.method": "fernet"}):
+        with override_settings(DATABASE_ENCRYPTION_FERNET_KEYS=keys_dict):
+            field = EncryptedField()
+
+            # Should use first key by default and include key_id
+            encrypted = field.get_prep_value("test value")
+            assert isinstance(encrypted, str)
+
+            # Should have new format with key_id
+            parts = encrypted.split(":")
+            assert len(parts) == 3
+            marker, key_id, encoded_data = parts
+            assert marker == MARKER_FERNET
+            assert key_id == "key1"  # First key in dict
+
+            # Should be able to decrypt
+            decrypted = field.to_python(encrypted)
+            assert decrypted == b"test value"
+
+
+def test_fernet_key_dict_must_be_dict():
+    """Test that DATABASE_ENCRYPTION_FERNET_KEYS must be a dictionary."""
+    with override_options({"database.encryption.method": "fernet"}):
+        # Test with string instead of dict
+        with override_settings(DATABASE_ENCRYPTION_FERNET_KEYS="not-a-dict"):
+            field = EncryptedField()
+
+            with pytest.raises(
+                ValueError, match="DATABASE_ENCRYPTION_FERNET_KEYS must be a dictionary"
+            ):
+                field.get_prep_value("test value")
+
+        # Test with list instead of dict
+        with override_settings(DATABASE_ENCRYPTION_FERNET_KEYS=["key1", "key2"]):
+            field = EncryptedField()
+
+            with pytest.raises(
+                ValueError, match="DATABASE_ENCRYPTION_FERNET_KEYS must be a dictionary"
+            ):
+                field.get_prep_value("test value")
+
+
+def test_fernet_empty_keys_dict():
+    """Test handling of empty keys dictionary."""
+    with (
+        override_options({"database.encryption.method": "fernet"}),
+        override_settings(DATABASE_ENCRYPTION_FERNET_KEYS={}),
+    ):
+        field = EncryptedField()
+
+        with pytest.raises(ValueError, match="DATABASE_ENCRYPTION_FERNET_KEYS is empty"):
+            field.get_prep_value("test value")
+
+
+@pytest.mark.parametrize(
+    "key_id,key_value,expected_error_match",
+    [
+        (
+            "",
+            "valid_key",
+            r"DATABASE_ENCRYPTION_FERNET_KEYS has invalid key_id or key \(, valid_key\)",
+        ),
+        (
+            None,
+            "valid_key",
+            r"DATABASE_ENCRYPTION_FERNET_KEYS has invalid key_id or key \(None, valid_key\)",
+        ),
+        (
+            "valid_key_id",
+            "",
+            r"DATABASE_ENCRYPTION_FERNET_KEYS has invalid key_id or key \(valid_key_id, \)",
+        ),
+        (
+            "valid_key_id",
+            None,
+            r"DATABASE_ENCRYPTION_FERNET_KEYS has invalid key_id or key \(valid_key_id, None\)",
+        ),
+    ],
+)
+def test_fernet_invalid_key_id_or_key_values(key_id, key_value, expected_error_match):
+    """Test handling of None or empty key_id or key values in the keys dictionary."""
+    with override_options({"database.encryption.method": "fernet"}):
+        field = EncryptedField()
+
+        with override_settings(DATABASE_ENCRYPTION_FERNET_KEYS={key_id: key_value}):
+            with pytest.raises(ValueError, match=expected_error_match):
+                field.get_prep_value("test value")
+
+
+def test_fernet_non_utf_8_chars(fernet_keys_value):
+    """Test that different encrypted field types work correctly."""
+    with (
+        override_options({"database.encryption.method": "fernet"}),
+        override_settings(DATABASE_ENCRYPTION_FERNET_KEYS=fernet_keys_value),
+    ):
+        text_field = EncryptedField()
+        invalid_utf_8 = b"\xc0"
+        encrypted_text = text_field.get_prep_value(invalid_utf_8)
+        assert isinstance(encrypted_text, str)
+
+        # Should have new format with key_id
+        parts = encrypted_text.split(":")
+        assert len(parts) == 3
+
+        decrypted_text = text_field.to_python(encrypted_text)
+        # The field now preserves the original data type
+        # When bytes can't be decoded as UTF-8, they are returned as bytes, not converted to string
+        assert decrypted_text == invalid_utf_8
+
+
+def test_keysets_not_implemented():
+    """Test that keysets method raises NotImplementedError."""
+    with override_options({"database.encryption.method": "keysets"}):
+        field = EncryptedField()
+
+        with pytest.raises(NotImplementedError, match="Keysets encryption not yet implemented"):
+            field.get_prep_value("test value")
+
+
+def test_fernet_marker_handling(fernet_keys_value):
+    """Test that the fernet marker is handled correctly."""
+    with override_options({"database.encryption.method": "fernet"}):
+        with override_settings(DATABASE_ENCRYPTION_FERNET_KEYS=fernet_keys_value):
+            field = EncryptedField()
+
+            # Create a value with fernet encryption
+            test_value = "test value"
+            encrypted = field.get_prep_value(test_value)
+            assert encrypted is not None
+
+            # Verify it has the new format: marker:key_id:data
+            parts = encrypted.split(":")
+            assert len(parts) == 3
+            assert parts[0] == MARKER_FERNET
+
+            # Test that decryption works with marker and key_id
+            decrypted = field.to_python(encrypted)
+            assert decrypted == test_value.encode("utf-8")
+
+
+def test_data_without_marker():
+    """Test handling of unencrypted data without method marker."""
+    with override_options({"database.encryption.method": "plain_text"}):
+        field = EncryptedField()
+
+        # Simulate unencrypted plain text data (no marker)
+        plain_value = "unencrypted plain text"
+        decrypted = field.to_python(plain_value)
+        assert decrypted == plain_value
+
+
+def test_to_python_conversion():
+    """Test the to_python method."""
+    field = EncryptedField()
+
+    # Test string
+    assert field.to_python("test") == "test"
+
+    # Test None
+    assert field.to_python(None) is None
+
+    # Test encrypted format
+    with override_options({"database.encryption.method": "plain_text"}):
+        encrypted = f"{MARKER_PLAIN_TEXT}:{base64.b64encode(b'test bytes').decode('ascii')}"
+        assert field.to_python(encrypted) == b"test bytes"
+
+
+def test_non_utf8_data_handling(fernet_keys_value):
+    """Test handling of non-UTF8 data."""
+
+    invalid_value = b"\xc0"  # invalid UTF-8 char
+
+    for encryption_method in ENCRYPTION_METHODS:
+        with override_options({"database.encryption.method": encryption_method}):
+            settings_override = {}
+            if encryption_method == "fernet":
+                settings_override["DATABASE_ENCRYPTION_FERNET_KEYS"] = fernet_keys_value
+
+            with override_settings(**settings_override):
+                field = EncryptedField()
+                result = field.to_python(invalid_value)
+                assert result == invalid_value
+
+
+@pytest.mark.parametrize("encryption_method", ENCRYPTION_METHODS)
+@pytest.mark.parametrize(
+    "test_value",
+    [
+        "simple text",
+        "text with unicode: 你好",
+        "text with special chars: !@#$%^&*()",
+        "",
+        None,
+        "a" * 1000,
+        b"bytes data",
+        b"invalid utf-8: \xc0",
+    ],
+)
+def test_encryption_decryption_roundtrip(encryption_method, test_value, fernet_keys_value):
+    """Test that encryption and decryption work correctly in roundtrip."""
+    with override_options({"database.encryption.method": encryption_method}):
+        settings_override = {}
+        if encryption_method == "fernet":
+            settings_override["DATABASE_ENCRYPTION_FERNET_KEYS"] = fernet_keys_value
+
+        with override_settings(**settings_override):
+            field = EncryptedField()
+
+            encrypted = field.get_prep_value(test_value)
+            decrypted = field.to_python(encrypted)
+
+            if test_value is None:
+                assert decrypted is None
+            elif isinstance(test_value, str):
+                assert decrypted == test_value.encode("utf-8")
+            else:
+                assert decrypted == test_value
+
+
+def test_marker_format_consistency(fernet_keys_value):
+    """Test that the marker format is consistent across methods."""
+    field = EncryptedField()
+
+    with override_options({"database.encryption.method": "plain_text"}):
+        encrypted = field.get_prep_value("test")
+        assert encrypted is not None
+        assert encrypted.startswith(f"{MARKER_PLAIN_TEXT}:")
+
+    with override_options({"database.encryption.method": "fernet"}):
+        with override_settings(DATABASE_ENCRYPTION_FERNET_KEYS=fernet_keys_value):
+            encrypted = field.get_prep_value("test")
+            assert encrypted is not None
+            assert encrypted.startswith(f"{MARKER_FERNET}:")
+
+
+def test_fernet_missing_key_decryption():
+    """Test that decryption fails gracefully when key_id is not found."""
+    keys_dict = {
+        "key1": Fernet.generate_key().decode(),
+    }
+
+    with override_options({"database.encryption.method": "fernet"}):
+        with override_settings(DATABASE_ENCRYPTION_FERNET_KEYS=keys_dict):
+            field = EncryptedField()
+
+            # Try to decrypt data that was "encrypted" with a missing key
+            fake_encrypted_data = base64.b64encode(b"fake data").decode("ascii")
+            formatted_value = f"{MARKER_FERNET}:missing_key:{fake_encrypted_data}"
+
+            # Should fall back to returning the original value when key is missing
+            result = field.to_python(formatted_value)
+            assert result == formatted_value  # Should return the original encrypted string
+
+
+def test_fernet_format_with_plain_text_data(fernet_keys_value):
+    """Test that data in fernet format but containing plain text (not encrypted) falls back correctly."""
+    with override_options({"database.encryption.method": "fernet"}):
+        with override_settings(DATABASE_ENCRYPTION_FERNET_KEYS=fernet_keys_value):
+            field = EncryptedField()
+
+            # Create data that looks like fernet format but contains plain text instead of encrypted data
+            # This could happen during migration from plain text to encrypted storage
+            plain_text_content = "this is just plain text, not encrypted"
+            fake_fernet_data = f"{MARKER_FERNET}:key_id_1:{plain_text_content}"
+
+            # Should fall back to returning the original string since it's not valid encrypted data
+            result = field.to_python(fake_fernet_data)
+            assert result == fake_fernet_data  # Should return the original string as-is
+
+            # Test with a format that has valid base64 but invalid fernet data
+            fake_base64_data = base64.b64encode(b"not fernet encrypted").decode("ascii")
+            fake_fernet_with_base64 = f"{MARKER_FERNET}:key_id_1:{fake_base64_data}"
+
+            result = field.to_python(fake_fernet_with_base64)
+            # This should also fall back to the original string since it's not valid Fernet data
+            assert result == fake_fernet_with_base64

--- a/tests/sentry/db/models/fields/test_encryption.py
+++ b/tests/sentry/db/models/fields/test_encryption.py
@@ -5,7 +5,12 @@ from cryptography.fernet import Fernet
 from django.db import connection, models
 from django.test import override_settings
 
-from sentry.db.models.fields.encryption import MARKER_FERNET, MARKER_PLAINTEXT, EncryptedField
+from sentry.db.models.fields.encryption import (
+    MARKER_FERNET,
+    MARKER_PLAINTEXT,
+    EncryptedCharField,
+    EncryptedField,
+)
 from sentry.testutils.helpers.options import override_options
 
 ENCRYPTION_METHODS = ("plaintext", "fernet")
@@ -475,14 +480,14 @@ def test_fernet_format_with_plaintext_data(fernet_keys_value):
 
 class EncryptedFieldModel(models.Model):
     id = models.AutoField(primary_key=True)
-    data = EncryptedField(null=True, blank=True)
+    data = EncryptedCharField(null=True, blank=True)
 
     class Meta:
         app_label = "fixtures"
 
 
 @pytest.mark.django_db
-def test_encrypted_field_end_to_end(fernet_key, fernet_keys_value):
+def test_encrypted_char_field_fernet_end_to_end(fernet_keys_value):
     """Test complete save/retrieve cycle with EncryptedField."""
 
     with (
@@ -496,7 +501,7 @@ def test_encrypted_field_end_to_end(fernet_key, fernet_keys_value):
 
         # Verify the data was correctly encrypted and decrypted
         retrieved_instance = EncryptedFieldModel.objects.get(id=model_instance.id)
-        assert retrieved_instance.data == test_data.encode()
+        assert retrieved_instance.data == test_data
 
         with connection.cursor() as cursor:
             cursor.execute(
@@ -508,3 +513,43 @@ def test_encrypted_field_end_to_end(fernet_key, fernet_keys_value):
             # Should be in fernet format: enc:fernet:key_id:base64data
             assert raw_value.startswith(f"{MARKER_FERNET}:")
             assert test_data not in raw_value
+
+
+@pytest.mark.django_db
+def test_encrypted_char_field_plaintext_end_to_end():
+    """Test complete save/retrieve cycle with EncryptedCharField."""
+    test_data = "This is plain text data"
+
+    model_instance = EncryptedFieldModel.objects.create(data=test_data)
+    assert model_instance.id is not None
+
+    # Verify the data was correctly encrypted and decrypted
+    retrieved_instance = EncryptedFieldModel.objects.get(id=model_instance.id)
+    assert retrieved_instance.data == test_data
+
+    with connection.cursor() as cursor:
+        cursor.execute(
+            "SELECT data FROM fixtures_encryptedfieldmodel WHERE id = %s",
+            [model_instance.id],
+        )
+        # Should be in a format enc:plaintext:base64data
+        raw_value = cursor.fetchone()[0]
+        assert raw_value.startswith(f"{MARKER_PLAINTEXT}:")
+        assert test_data not in raw_value
+
+
+@pytest.mark.django_db
+def test_encrypted_char_field_null_value():
+    model_instance = EncryptedFieldModel.objects.create(data=None)
+    assert model_instance.id is not None
+
+    retrieved_instance = EncryptedFieldModel.objects.get(id=model_instance.id)
+    assert retrieved_instance.data is None
+
+    with connection.cursor() as cursor:
+        cursor.execute(
+            "SELECT data FROM fixtures_encryptedfieldmodel WHERE id = %s",
+            [model_instance.id],
+        )
+        raw_value = cursor.fetchone()[0]
+        assert raw_value is None


### PR DESCRIPTION
Introduces new base encryption field which can use multiple methods to encrypt/decrypt the data.

Currently it supports (controlled via option) an encryption method (decryption is always "automatic" based on the marker which marks how was the value encrypted):
- plain text - default
- fernet

It is easily extendable with another encryption/decryption methods.

Closes [TET-723: Start with Fernet as encryption algorithm for a simple iteration on this](https://linear.app/getsentry/issue/TET-723/start-with-fernet-as-encryption-algorithm-for-a-simple-iteration-on)