### PR TITLE
fix(project config): Don't write unchanged clusterer rules

### DIFF
--- a/src/sentry/ingest/transaction_clusterer/rules.py
+++ b/src/sentry/ingest/transaction_clusterer/rules.py
@@ -105,7 +105,11 @@ class ProjectOptionRuleStore:
         # Track the number of rules per project.
         metrics.distribution(self._tracker, len(converted_rules))
 
-        project.update_option(self._storage, converted_rules)
+        # Check if the rules have changed compared to what is stored
+        # to prevent a needless project option update and project config
+        # invalidation.
+        if converted_rules != self.read_sorted(project):
+            project.update_option(self._storage, converted_rules)
 
 
 class CompositeRuleStore:

--- a/src/sentry/ingest/transaction_clusterer/rules.py
+++ b/src/sentry/ingest/transaction_clusterer/rules.py
@@ -108,7 +108,7 @@ class ProjectOptionRuleStore:
         # Check if the rules have changed compared to what is stored
         # to prevent a needless project option update and project config
         # invalidation.
-        if converted_rules != self.read_sorted(project):
+        if converted_rules != project.get_option(self._storage, default=[]):
             project.update_option(self._storage, converted_rules)
 
 


### PR DESCRIPTION
Follow-up to https://github.com/getsentry/sentry/pull/95521. We definitely need to invalidate a project config if clusterer rules change, but only if they _actually_ change. Most of these writes are probably idempotent and hence don't require a project config invalidation.

ref: INGEST-444.