### PR TITLE
chore(hybrid-cloud): Setup option to control new integration code paths

### DIFF
--- a/src/sentry/hybridcloud/options.py
+++ b/src/sentry/hybridcloud/options.py
@@ -161,3 +161,11 @@ register(
     default=[],
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+# Controls whether or not the pathway to target regions via integration request contents is enabled for the system.
+register(
+    "hybrid_cloud.integration_region_targeting_rate",
+    type=Int,
+    default=0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)

--- a/src/sentry/hybridcloud/options.py
+++ b/src/sentry/hybridcloud/options.py
@@ -165,7 +165,6 @@ register(
 # Controls whether or not the pathway to target regions via integration request contents is enabled for the system.
 register(
     "hybrid_cloud.integration_region_targeting_rate",
-    type=Int,
-    default=0,
+    default=0.0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )


### PR DESCRIPTION
As a part of my rotation efforts, I'll be looking at fixing some of the integration code paths to remove the random organization selection and minimize the cross-region integration failures. This is the culprit behind some bugs like not being able to find the correct teams when a slack integration is used in two regions.

To reduce the risk a bad code change breaking all integrations in SaaS, introducing a new system option to control how the rate of requests that opt into these new code paths