### PR TITLE
feat(replay): Unify the tooltips into one for replay details os/browser

### DIFF
--- a/static/app/views/replays/detail/browserOSIcons.tsx
+++ b/static/app/views/replays/detail/browserOSIcons.tsx
@@ -1,11 +1,15 @@
+import {Fragment} from 'react';
 import styled from '@emotion/styled';
+import {PlatformIcon} from 'platformicons';
 
 import {Flex} from 'sentry/components/core/layout';
 import {Tooltip} from 'sentry/components/core/tooltip';
 import Placeholder from 'sentry/components/placeholder';
+import CountTooltipContent from 'sentry/components/replays/countTooltipContent';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
-import ReplayPlatformIcon from 'sentry/components/replays/replayPlatformIcon';
+import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {generatePlatformIconName} from 'sentry/utils/replays/generatePlatformIconName';
 
 export default function BrowserOSIcons({
   showBrowser = true,
@@ -17,33 +21,56 @@ export default function BrowserOSIcons({
   const {replay} = useReplayContext();
   const replayRecord = replay?.getReplay();
 
-  return isLoading ? (
-    <Placeholder width="50px" height="32px" />
-  ) : (
-    <Flex direction="row-reverse">
-      <Tooltip title={`${replayRecord?.os.name ?? ''} ${replayRecord?.os.version ?? ''}`}>
-        <ReplayPlatformIcon
-          name={replayRecord?.os.name ?? ''}
-          version={replayRecord?.os.version ?? undefined}
-          showVersion
-        />
+  if (isLoading) {
+    return <Placeholder width="34px" height="20px" />;
+  }
+
+  if (!replayRecord) {
+    return (
+      <Tooltip title={t('Unknown Device')}>
+        <PlatformIcon platform="unknown" size="20px" />
       </Tooltip>
-      {showBrowser && (
-        <Overlap>
-          <Tooltip
-            title={`${replayRecord?.browser.name ?? ''} ${
-              replayRecord?.browser.version ?? ''
-            }`}
-          >
-            <ReplayPlatformIcon
-              name={replayRecord?.browser.name ?? ''}
-              version={replayRecord?.browser.version ?? undefined}
-              showVersion
+    );
+  }
+
+  return (
+    <Tooltip
+      title={
+        <CountTooltipContent>
+          {showBrowser && (
+            <Fragment>
+              <dt>{t('Browser:')}</dt>
+              <dd>{`${replayRecord?.browser.name ?? ''} ${replayRecord?.browser.version ?? ''}`}</dd>
+            </Fragment>
+          )}
+          <dt>{t('OS:')}</dt>
+          <dd>
+            {replayRecord?.os.name ?? ''} {replayRecord?.os.version ?? ''}
+          </dd>
+        </CountTooltipContent>
+      }
+    >
+      <Flex>
+        {showBrowser && (
+          <Overlap>
+            <PlatformIcon
+              platform={generatePlatformIconName(
+                replayRecord?.browser.name ?? '',
+                replayRecord?.browser.version ?? undefined
+              )}
+              size="20px"
             />
-          </Tooltip>
-        </Overlap>
-      )}
-    </Flex>
+          </Overlap>
+        )}
+        <PlatformIcon
+          platform={generatePlatformIconName(
+            replayRecord?.os.name ?? '',
+            replayRecord?.os.version ?? undefined
+          )}
+          size="20px"
+        />
+      </Flex>
+    </Tooltip>
   );
 }
 


### PR DESCRIPTION
One tooltip is enough, and some error handling in case `replay` is messed up somehow.

<img width="260" height="112" alt="SCR-20250715-ijrc" src="https://github.com/user-attachments/assets/a5a3ef16-d593-4094-991b-cd50e687b219" />
