### PR TITLE
ref(stories): rename sections (to core + product)

### DIFF
--- a/static/app/stories/view/storySearch.tsx
+++ b/static/app/stories/view/storySearch.tsx
@@ -65,7 +65,7 @@ export function StorySearch() {
     if (core.length > 0) {
       sections.push({
         key: 'components',
-        label: 'Core Components',
+        label: 'Components',
         options: core,
       });
     }
@@ -73,7 +73,7 @@ export function StorySearch() {
     if (shared.length > 0) {
       sections.push({
         key: 'shared',
-        label: 'Product Components',
+        label: 'Product',
         options: shared,
       });
     }

--- a/static/app/stories/view/storySearch.tsx
+++ b/static/app/stories/view/storySearch.tsx
@@ -65,7 +65,7 @@ export function StorySearch() {
     if (core.length > 0) {
       sections.push({
         key: 'components',
-        label: 'Components',
+        label: 'Core Components',
         options: core,
       });
     }
@@ -73,7 +73,7 @@ export function StorySearch() {
     if (shared.length > 0) {
       sections.push({
         key: 'shared',
-        label: 'Shared',
+        label: 'Product Components',
         options: shared,
       });
     }

--- a/static/app/stories/view/storySearch.tsx
+++ b/static/app/stories/view/storySearch.tsx
@@ -169,7 +169,7 @@ function SearchComboBox<T extends StoryTreeNode>(props: SearchComboBoxProps<T>) 
     inputValue,
     onInputChange: setInputValue,
     defaultFilter: filter,
-    shouldCloseOnBlur: false,
+    shouldCloseOnBlur: true,
     allowsEmptyCollection: false,
     onSelectionChange: handleSelectionChange,
   });

--- a/static/app/stories/view/storySidebar.tsx
+++ b/static/app/stories/view/storySidebar.tsx
@@ -18,11 +18,11 @@ export function StorySidebar() {
           <StoryTree nodes={foundations} />
         </li>
         <li>
-          <h3>Core Components</h3>
+          <h3>Components</h3>
           <StoryTree nodes={core} />
         </li>
         <li>
-          <h3>Product Components</h3>
+          <h3>Product</h3>
           <StoryTree nodes={shared} />
         </li>
       </ul>

--- a/static/app/stories/view/storySidebar.tsx
+++ b/static/app/stories/view/storySidebar.tsx
@@ -18,11 +18,11 @@ export function StorySidebar() {
           <StoryTree nodes={foundations} />
         </li>
         <li>
-          <h3>Components</h3>
+          <h3>Core Components</h3>
           <StoryTree nodes={core} />
         </li>
         <li>
-          <h3>Shared</h3>
+          <h3>Product Components</h3>
           <StoryTree nodes={shared} />
         </li>
       </ul>


### PR DESCRIPTION
- For clarity: renames sidebar and search sections to "core components" and "product components"
- Bug fix: close story search on blur