### PR TITLE
fix(aci milestone 3): return an int for anomaly detection action context

### DIFF
--- a/src/sentry/incidents/typings/metric_detector.py
+++ b/src/sentry/incidents/typings/metric_detector.py
@@ -46,7 +46,7 @@ def fetch_threshold_type(condition: dict[str, Any]) -> AlertRuleThresholdType:
 def fetch_alert_threshold(condition: dict[str, Any], group_status: GroupStatus) -> float | None:
     condition_type = condition["type"]
     if condition_type == Condition.ANOMALY_DETECTION:
-        return None
+        return 0
     comparison_value = condition["comparison"]
     if group_status == GroupStatus.RESOLVED or group_status == GroupStatus.IGNORED:
         return None
@@ -61,7 +61,7 @@ def fetch_resolve_threshold(condition: dict[str, Any], group_status: GroupStatus
     """
     condition_type = condition["type"]
     if condition_type == Condition.ANOMALY_DETECTION:
-        return None
+        return 0
     comparison_value = condition["comparison"]
     if group_status == GroupStatus.RESOLVED or group_status == GroupStatus.IGNORED:
         return comparison_value

--- a/src/sentry/incidents/typings/metric_detector.py
+++ b/src/sentry/incidents/typings/metric_detector.py
@@ -93,8 +93,8 @@ class AlertContext:
         resolve_threshold = alert_rule.resolve_threshold
 
         if alert_rule.detection_type == AlertRuleDetectionType.DYNAMIC:
-            alert_rule_threshold = None
-            resolve_threshold = None
+            alert_rule_threshold = 0
+            resolve_threshold = 0
 
         return cls(
             name=alert_rule.name,


### PR DESCRIPTION
This was breaking. Since the threshold won't be revealed in the email, return an arbitrary integer.