### PR TITLE
feat(aci): Save connected workflows in the detector POST endpoint

### DIFF
--- a/src/sentry/workflow_engine/endpoints/organization_detector_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_index.py
@@ -34,7 +34,7 @@ from sentry.workflow_engine.endpoints.utils.filters import apply_filter
 from sentry.workflow_engine.endpoints.utils.sortby import SortByParam
 from sentry.workflow_engine.endpoints.validators.base import BaseDetectorTypeValidator
 from sentry.workflow_engine.endpoints.validators.utils import get_unknown_detector_type_error
-from sentry.workflow_engine.models import Detector
+from sentry.workflow_engine.models import Detector, DetectorWorkflow, Workflow
 
 detector_search_config = SearchConfig.create_from(
     default_config,
@@ -194,6 +194,20 @@ class OrganizationDetectorIndexEndpoint(OrganizationEndpoint):
         if not detector_type:
             raise ValidationError({"type": ["This field is required."]})
 
+        workflow_ids = request.data.get("workflowIds", [])
+
+        if workflow_ids:
+            workflows = Workflow.objects.filter(
+                id__in=workflow_ids, organization_id=organization.id
+            )
+            found_workflow_ids = set(workflows.values_list("id", flat=True))
+            missing_workflow_ids = set(workflow_ids) - found_workflow_ids
+
+            if missing_workflow_ids:
+                raise ValidationError(
+                    {"workflowIds": [f"Workflows not found: {list(missing_workflow_ids)}"]}
+                )
+
         # restrict creating metric issue detectors by plan type
         if detector_type == MetricIssue.slug and not features.has(
             "organizations:incidents", organization, actor=request.user
@@ -221,4 +235,8 @@ class OrganizationDetectorIndexEndpoint(OrganizationEndpoint):
             return Response(validator.errors, status=status.HTTP_400_BAD_REQUEST)
 
         detector = validator.save()
+
+        for workflow_id in workflow_ids:
+            DetectorWorkflow.objects.create(detector=detector, workflow_id=workflow_id)
+
         return Response(serialize(detector, request.user), status=status.HTTP_201_CREATED)

--- a/src/sentry/workflow_engine/endpoints/organization_detector_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_index.py
@@ -188,9 +188,11 @@ class OrganizationDetectorIndexEndpoint(OrganizationEndpoint):
         Create a new detector for a project.
 
         :param string name: The name of the detector
-        :param string detector_type: The type of detector to create
-        :param object data_source: Configuration for the data source
-        :param array data_conditions: List of conditions to trigger the detector
+        :param string type: The type of detector to create
+        :param string projectId: The detector project
+        :param object dataSource: Configuration for the data source
+        :param array dataConditions: List of conditions to trigger the detector
+        :param array workflowIds: List of workflow IDs to connect to the detector
         """
         detector_type = request.data.get("type")
         if not detector_type:
@@ -222,7 +224,7 @@ class OrganizationDetectorIndexEndpoint(OrganizationEndpoint):
         if not validator.is_valid():
             return Response(validator.errors, status=status.HTTP_400_BAD_REQUEST)
 
-        workflow_ids = request.data.get("workflowIds", [])
+        workflow_ids = set(request.data.get("workflowIds", []))
         if not workflow_ids:
             detector = validator.save()
         else:
@@ -244,7 +246,7 @@ class OrganizationDetectorIndexEndpoint(OrganizationEndpoint):
                 ]
                 for workflow_validator in workflow_validators:
                     if not workflow_validator.is_valid():
-                        raise ValidationError(workflow_validator.errors)
+                        raise ValidationError({"workflowIds": workflow_validator.errors})
 
                 for workflow_validator in workflow_validators:
                     workflow_validator.save()

--- a/src/sentry/workflow_engine/endpoints/validators/detector_workflow.py
+++ b/src/sentry/workflow_engine/endpoints/validators/detector_workflow.py
@@ -80,7 +80,7 @@ class BulkDetectorWorkflowsValidator(CamelSnakeSerializer):
     """
 
     detector_id = serializers.IntegerField(required=True)
-    workflow_ids = serializers.ListField(required=True)
+    workflow_ids = serializers.ListField(child=serializers.IntegerField(), required=True)
 
     def create(self, validated_data) -> list[DetectorWorkflow]:
         if not validated_data["workflow_ids"]:

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
@@ -462,7 +462,7 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
             **data,
             status_code=400,
         )
-        assert "Workflow matching query does not exist" in str(response.data)
+        assert "Some workflows do not exist" in str(response.data)
 
         # Workflow that exists but is in another org should also fail validation
         other_org = self.create_organization()
@@ -473,7 +473,7 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
             **data,
             status_code=400,
         )
-        assert "Workflow matching query does not exist" in str(response.data)
+        assert "Some workflows do not exist" in str(response.data)
 
     def test_transaction_rollback_on_workflow_validation_failure(self):
         initial_detector_count = Detector.objects.filter(project=self.project).count()
@@ -489,7 +489,7 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
         # Verify that the detector was never created (same number of detectors as before)
         final_detector_count = Detector.objects.filter(project=self.project).count()
         assert final_detector_count == initial_detector_count
-        assert "Workflow matching query does not exist" in str(response.data)
+        assert "Some workflows do not exist" in str(response.data)
 
     def test_missing_required_field(self):
         response = self.get_error_response(

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
@@ -442,6 +442,18 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
             data=detector.get_audit_log_data(),
         )
 
+    def test_valid_creation_with_connected_workflows(self):
+        workflow = self.create_workflow(
+            organization_id=self.organization.id,
+        )
+        data = {**self.valid_data, "workflowIds": [workflow.id]}
+        response = self.get_success_response(
+            self.organization.slug,
+            **data,
+            status_code=201,
+        )
+        assert response.data["workflowIds"] == [str(workflow.id)]
+
     def test_missing_required_field(self):
         response = self.get_error_response(
             self.organization.slug,


### PR DESCRIPTION
The detector creation form asks the user to connect workflows while defining the detector. Because creating a detector and connecting workflows happens at the same time, the best experience would be for the POST endpoint to also handle workflow connections (otherwise, it will require another round trip to the frontend and could potentially cause strange error states if one succeeds and one fails). Because the detector serializer already returns `workflowIds`, this seems like an appropriate place to put this logic, but let me know if there is a better place.