### PR TITLE
Make log text wrapping configurable with white-space prop

### DIFF
--- a/static/app/views/explore/logs/styles.tsx
+++ b/static/app/views/explore/logs/styles.tsx
@@ -166,10 +166,10 @@ export const LogsHighlight = styled(HighlightComponent)`
 `;
 
 export const WrappingText = styled('div')<{wrap?: boolean}>`
-  white-space: nowrap;
+  white-space: ${p => (p.wrap ? 'pre-wrap' : 'nowrap')};
   overflow: hidden;
   text-overflow: ellipsis;
-  ${p => (p.wrap ? 'text-wrap: auto;' : '')}
+  ${p => (p.wrap ? '' : '')}
 `;
 
 export const AlignedCellContent = styled('div')<{


### PR DESCRIPTION
resolves JAVASCRIPT-32A9

render line breaks (new lines) in log messages when a user expands the log item to view log item details.

<img width="1692" height="610" alt="image" src="https://github.com/user-attachments/assets/457d2b3f-31bf-4616-9c26-8d1b78fe030f" />