### PR TITLE
ref(issues): remove enforce issue views flag usage

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -152,7 +152,7 @@ def register_temporary_features(manager: FeatureManager):
     # Enables lifetime stats on issue details
     manager.add("organizations:issue-details-lifetime-stats", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables streamlined issue details UI for all users of an organization without opt-out
-    manager.add("organizations:issue-details-streamline-enforce", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    manager.add("organizations:issue-details-streamline-enforce", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, default=True, api_expose=True)
     # Enables sorting spans for issue detection
     manager.add("organizations:issue-detection-sort-spans", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Whether to allow issue only search on the issue list

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -152,7 +152,7 @@ def register_temporary_features(manager: FeatureManager):
     # Enables lifetime stats on issue details
     manager.add("organizations:issue-details-lifetime-stats", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables streamlined issue details UI for all users of an organization without opt-out
-    manager.add("organizations:issue-details-streamline-enforce", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, default=True, api_expose=True)
+    manager.add("organizations:issue-details-streamline-enforce", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables sorting spans for issue detection
     manager.add("organizations:issue-detection-sort-spans", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Whether to allow issue only search on the issue list

--- a/static/app/utils/analytics/issueAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/issueAnalyticsEvents.tsx
@@ -197,7 +197,6 @@ export type IssueEventParameters = {
   'issue_details.sourcemap_wizard_dismiss': SourceMapWizardParam;
   'issue_details.sourcemap_wizard_learn_more': SourceMapWizardParam;
   'issue_details.streamline_ui_toggle': {
-    enforced_streamline_ui: boolean;
     isEnabled: boolean;
   };
   'issue_details.tour.reminder': {method: 'dismissed' | 'timeout'};

--- a/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
+++ b/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
@@ -15,7 +15,6 @@ import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import useMutateUserOptions from 'sentry/utils/useMutateUserOptions';
 import useOrganization from 'sentry/utils/useOrganization';
-import {useUser} from 'sentry/utils/useUser';
 import {
   ISSUE_DETAILS_TOUR_GUIDE_KEY,
   useIssueDetailsTour,
@@ -146,8 +145,6 @@ export function NewIssueExperienceButton() {
 
   const hasStreamlinedUI = useHasStreamlinedUI();
   const hasNewUIOnly = Boolean(organization.streamlineOnly);
-  const user = useUser();
-  const userStreamlinePreference = user?.options?.prefersIssueDetailsStreamlinedUI;
 
   const openForm = useFeedbackForm();
   const {mutate: mutateUserOptions} = useMutateUserOptions();
@@ -157,11 +154,8 @@ export function NewIssueExperienceButton() {
     trackAnalytics('issue_details.streamline_ui_toggle', {
       isEnabled: !hasStreamlinedUI,
       organization,
-      enforced_streamline_ui:
-        organization.features.includes('issue-details-streamline-enforce') &&
-        userStreamlinePreference === null,
     });
-  }, [mutateUserOptions, organization, hasStreamlinedUI, userStreamlinePreference]);
+  }, [mutateUserOptions, organization, hasStreamlinedUI]);
 
   if (!hasStreamlinedUI) {
     return (

--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -541,9 +541,6 @@ function useTrackView({
     ref_fallback,
     group_event_type: groupEventType,
     prefers_streamlined_ui: user?.options?.prefersIssueDetailsStreamlinedUI ?? false,
-    enforced_streamlined_ui:
-      organization.features.includes('issue-details-streamline-enforce') &&
-      user?.options?.prefersIssueDetailsStreamlinedUI === null,
     org_streamline_only: organization.streamlineOnly ?? undefined,
     has_streamlined_ui: hasStreamlinedUI,
   });

--- a/static/app/views/issueDetails/groupEventAttachments/groupEventAttachments.spec.tsx
+++ b/static/app/views/issueDetails/groupEventAttachments/groupEventAttachments.spec.tsx
@@ -179,7 +179,7 @@ describe('GroupEventAttachments', function () {
           },
         },
       },
-      organization: {...organization, features: ['issue-details-streamline-enforce']},
+      organization: {...organization},
     });
     expect(getAttachmentsMock).toHaveBeenCalledWith(
       '/organizations/org-slug/issues/group-id/attachments/',

--- a/static/app/views/issueDetails/utils.spec.tsx
+++ b/static/app/views/issueDetails/utils.spec.tsx
@@ -33,23 +33,6 @@ describe('useHasStreamlinedUI', () => {
     expect(userPrefersLegacy.current).toBe(false);
   });
 
-  it('ignores preferences if enforce flag is set and user has not opted out', () => {
-    const enforceOrg = OrganizationFixture({
-      features: ['issue-details-streamline-enforce'],
-      streamlineOnly: null,
-    });
-
-    ConfigStore.init();
-    const user = UserFixture();
-    user.options.prefersIssueDetailsStreamlinedUI = null;
-    act(() => ConfigStore.set('user', user));
-
-    const {result} = renderHook(useHasStreamlinedUI, {
-      wrapper: contextWrapper(enforceOrg),
-    });
-    expect(result.current).toBe(true);
-  });
-
   it('respects preferences if enforce flag is set and user has opted out', () => {
     const enforceOrg = OrganizationFixture({
       features: ['issue-details-streamline-enforce'],

--- a/static/app/views/issueDetails/utils.tsx
+++ b/static/app/views/issueDetails/utils.tsx
@@ -280,14 +280,6 @@ export function useHasStreamlinedUI() {
     return true;
   }
 
-  // If the enforce flag is set for the organization, ignore user preferences and enable the UI
-  if (
-    userStreamlinedUIOption !== false &&
-    organization.features.includes('issue-details-streamline-enforce')
-  ) {
-    return true;
-  }
-
   // Apply the UI based on user preferences
   return userStreamlinedUIOption ?? false;
 }

--- a/static/app/views/issueDetails/utils.tsx
+++ b/static/app/views/issueDetails/utils.tsx
@@ -281,7 +281,7 @@ export function useHasStreamlinedUI() {
   }
 
   // Apply the UI based on user preferences
-  return userStreamlinedUIOption ?? false;
+  return userStreamlinedUIOption !== false;
 }
 
 export function useIsSampleEvent(): boolean {


### PR DESCRIPTION
Remove `organizations:issue-details-streamline-enforce` flag from being checked in the frontend, since it is already GAed for everyone (see [flagpole](https://github.com/getsentry/sentry-options-automator/blob/a7e0418f28f78060a6ec2d7b6e91983d92e0dd26/options/default/flagpole.yml#L471)). Users will still be able to opt out of the new issue view by setting their preferences, but we'll enable it by default now.