### PR TITLE
feat(aci): Add metric detector chart to details

### DIFF
--- a/static/app/views/detectors/components/details/metric/chart.tsx
+++ b/static/app/views/detectors/components/details/metric/chart.tsx
@@ -1,0 +1,51 @@
+import styled from '@emotion/styled';
+
+import type {MetricDetector} from 'sentry/types/workflowEngine/detectors';
+import {MetricDetectorChart} from 'sentry/views/detectors/components/forms/metric/metricDetectorChart';
+import {getDetectorDataset} from 'sentry/views/detectors/components/forms/metric/metricFormData';
+
+interface MetricDetectorDetailsChartProps {
+  detector: MetricDetector;
+}
+
+export function MetricDetectorDetailsChart({detector}: MetricDetectorDetailsChartProps) {
+  const dataSource = detector.dataSources[0];
+  const snubaQuery =
+    dataSource?.type === 'snuba_query_subscription'
+      ? dataSource.queryObj?.snubaQuery
+      : undefined;
+
+  if (!snubaQuery) {
+    // Unlikely, helps narrow types
+    return null;
+  }
+
+  const dataset = getDetectorDataset(snubaQuery.dataset, snubaQuery.eventTypes);
+  const aggregate = snubaQuery.aggregate;
+  const query = snubaQuery.query;
+  const environment = snubaQuery.environment;
+  const interval = snubaQuery.timeWindow;
+  const conditions = detector.conditionGroup?.conditions || [];
+  const detectionType = detector.config.detectionType;
+
+  return (
+    <ChartContainer>
+      <MetricDetectorChart
+        dataset={dataset}
+        aggregate={aggregate}
+        interval={interval}
+        query={query}
+        environment={environment}
+        projectId={detector.projectId}
+        conditions={conditions}
+        detectionType={detectionType}
+      />
+    </ChartContainer>
+  );
+}
+
+const ChartContainer = styled('div')`
+  padding: ${p => p.theme.space.xs} ${p => p.theme.space.lg} ${p => p.theme.space.md};
+  border: 1px solid ${p => p.theme.border};
+  border-radius: ${p => p.theme.borderRadius};
+`;

--- a/static/app/views/detectors/components/details/metric/index.tsx
+++ b/static/app/views/detectors/components/details/metric/index.tsx
@@ -4,6 +4,7 @@ import type {MetricDetector} from 'sentry/types/workflowEngine/detectors';
 import {DetectorDetailsAutomations} from 'sentry/views/detectors/components/details/common/automations';
 import {DetectorDetailsHeader} from 'sentry/views/detectors/components/details/common/header';
 import {DetectorDetailsOngoingIssues} from 'sentry/views/detectors/components/details/common/ongoingIssues';
+import {MetricDetectorDetailsChart} from 'sentry/views/detectors/components/details/metric/chart';
 import {MetricDetectorDetailsSidebar} from 'sentry/views/detectors/components/details/metric/sidebar';
 
 type MetricDetectorDetailsProps = {
@@ -17,6 +18,7 @@ export function MetricDetectorDetails({detector, project}: MetricDetectorDetails
       <DetectorDetailsHeader detector={detector} project={project} />
       <DetailLayout.Body>
         <DetailLayout.Main>
+          <MetricDetectorDetailsChart detector={detector} />
           <DetectorDetailsOngoingIssues />
           <DetectorDetailsAutomations detector={detector} />
         </DetailLayout.Main>

--- a/static/app/views/detectors/components/forms/metric/metricDetectorChart.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricDetectorChart.tsx
@@ -1,5 +1,4 @@
 import {useMemo} from 'react';
-import styled from '@emotion/styled';
 
 import {AreaChart} from 'sentry/components/charts/areaChart';
 import ErrorPanel from 'sentry/components/charts/errorPanel';
@@ -14,7 +13,7 @@ import type {DetectorDataset} from 'sentry/views/detectors/components/forms/metr
 import {useMetricDetectorSeries} from 'sentry/views/detectors/hooks/useMetricDetectorSeries';
 import {useMetricDetectorThresholdSeries} from 'sentry/views/detectors/hooks/useMetricDetectorThresholdSeries';
 
-const CHART_HEIGHT = 150;
+const CHART_HEIGHT = 165;
 
 interface MetricDetectorChartProps {
   /**
@@ -104,55 +103,44 @@ export function MetricDetectorChart({
 
   if (isPending) {
     return (
-      <ChartContainer>
-        <Flex style={{height: CHART_HEIGHT}} justify="center" align="center">
-          <Placeholder height={`${CHART_HEIGHT - 20}px`} />
-        </Flex>
-      </ChartContainer>
+      <Flex style={{height: CHART_HEIGHT}} justify="center" align="center">
+        <Placeholder height={`${CHART_HEIGHT - 20}px`} />
+      </Flex>
     );
   }
 
   if (isError) {
     return (
-      <ChartContainer>
-        <Flex style={{height: CHART_HEIGHT}} justify="center" align="center">
-          <ErrorPanel>
-            <IconWarning color="gray300" size="lg" />
-            <div>{t('Error loading chart data')}</div>
-          </ErrorPanel>
-        </Flex>
-      </ChartContainer>
+      <Flex style={{height: CHART_HEIGHT}} justify="center" align="center">
+        <ErrorPanel>
+          <IconWarning color="gray300" size="lg" />
+          <div>{t('Error loading chart data')}</div>
+        </ErrorPanel>
+      </Flex>
     );
   }
 
   return (
-    <ChartContainer>
-      <AreaChart
-        isGroupedByDate
-        showTimeInTooltip
-        height={CHART_HEIGHT}
-        stacked={false}
-        series={mergedSeries}
-        yAxis={{
-          min: yAxisBounds.min,
-          max: yAxisBounds.max,
-          axisLabel: {
-            // Hide the maximum y-axis label to avoid showing arbitrary threshold values
-            showMaxLabel: false,
-          },
-        }}
-        grid={{
-          left: space(0.25),
-          right: space(0.5),
-          top: space(1),
-          bottom: space(1),
-        }}
-      />
-    </ChartContainer>
+    <AreaChart
+      isGroupedByDate
+      showTimeInTooltip
+      height={CHART_HEIGHT}
+      stacked={false}
+      series={mergedSeries}
+      yAxis={{
+        min: yAxisBounds.min,
+        max: yAxisBounds.max,
+        axisLabel: {
+          // Hide the maximum y-axis label to avoid showing arbitrary threshold values
+          showMaxLabel: false,
+        },
+      }}
+      grid={{
+        left: space(0.25),
+        right: space(0.5),
+        top: space(0.5),
+        bottom: space(1),
+      }}
+    />
   );
 }
-
-const ChartContainer = styled('div')`
-  max-width: 1440px;
-  border-top: 1px solid ${p => p.theme.border};
-`;

--- a/static/app/views/detectors/components/forms/metric/metricFormData.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricFormData.tsx
@@ -223,7 +223,7 @@ export function createConditions(
 /**
  * Convert backend dataset to our form dataset
  */
-const getDetectorDataset = (
+export const getDetectorDataset = (
   backendDataset: Dataset,
   eventTypes: EventTypes[]
 ): DetectorDataset => {

--- a/static/app/views/detectors/components/forms/metric/previewChart.tsx
+++ b/static/app/views/detectors/components/forms/metric/previewChart.tsx
@@ -1,4 +1,5 @@
 import {useMemo} from 'react';
+import styled from '@emotion/styled';
 
 import {MetricDetectorChart} from 'sentry/views/detectors/components/forms/metric/metricDetectorChart';
 import {
@@ -49,15 +50,22 @@ export function MetricDetectorPreviewChart() {
   }, [conditionType, conditionValue, initialPriorityLevel, highThreshold, kind]);
 
   return (
-    <MetricDetectorChart
-      dataset={dataset}
-      aggregate={aggregateFunction}
-      interval={interval}
-      query={query}
-      environment={environment}
-      projectId={projectId}
-      conditions={conditions}
-      detectionType={kind}
-    />
+    <ChartContainer>
+      <MetricDetectorChart
+        dataset={dataset}
+        aggregate={aggregateFunction}
+        interval={interval}
+        query={query}
+        environment={environment}
+        projectId={projectId}
+        conditions={conditions}
+        detectionType={kind}
+      />
+    </ChartContainer>
   );
 }
+
+const ChartContainer = styled('div')`
+  max-width: 1440px;
+  border-top: 1px solid ${p => p.theme.border};
+`;

--- a/static/app/views/detectors/detail.spec.tsx
+++ b/static/app/views/detectors/detail.spec.tsx
@@ -61,6 +61,15 @@ describe('DetectorDetails', function () {
       url: `/organizations/${organization.slug}/users/1/`,
       body: UserFixture(),
     });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events-stats/`,
+      body: {
+        data: [
+          [1543449600, [20, 12]],
+          [1543449601, [10, 5]],
+        ],
+      },
+    });
   });
 
   it('renders the detector details and snuba query', async function () {


### PR DESCRIPTION
Adds a metric detector chart to the detector details page

<img width="1392" height="451" alt="image" src="https://github.com/user-attachments/assets/93e1653b-8a1b-4e6a-b094-12ada7b6867e" />
