### PR TITLE
ref(insights): replace `useDiscoverOrEap` with `useSpans`

### DIFF
--- a/static/app/views/insights/browser/webVitals/utils/useProfileExists.tsx
+++ b/static/app/views/insights/browser/webVitals/utils/useProfileExists.tsx
@@ -1,10 +1,10 @@
-import {useDiscoverOrEap} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 
 /**
  * Query results for whether a given replayId exists in the database (not deleted, etc)
  */
 export default function useProfileExists(ids: string[]) {
-  const result = useDiscoverOrEap(
+  const result = useSpans(
     {
       search: `profile.id:[${ids.join(',')}]`,
       fields: ['profile.id'],

--- a/static/app/views/insights/cache/components/samplePanel.tsx
+++ b/static/app/views/insights/cache/components/samplePanel.tsx
@@ -29,11 +29,7 @@ import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLay
 import {ReadoutRibbon} from 'sentry/views/insights/common/components/ribbon';
 import {SampleDrawerBody} from 'sentry/views/insights/common/components/sampleDrawerBody';
 import {SampleDrawerHeaderTransaction} from 'sentry/views/insights/common/components/sampleDrawerHeaderTransaction';
-import {
-  useDiscoverOrEap,
-  useSpanMetrics,
-  useSpans,
-} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpanMetrics, useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {
   DataTitles,
   getThroughputTitle,
@@ -198,7 +194,7 @@ export function CacheSamplePanel() {
     data: transactionData,
     error: transactionError,
     isFetching: isFetchingTransactions,
-  } = useDiscoverOrEap(
+  } = useSpans(
     {
       search: transactionDurationSearch,
       enabled: Boolean(transactionIds.length),

--- a/static/app/views/insights/common/queries/useDiscover.ts
+++ b/static/app/views/insights/common/queries/useDiscover.ts
@@ -8,8 +8,6 @@ import type {SamplingMode} from 'sentry/views/explore/hooks/useProgressiveQuery'
 import {useWrappedDiscoverQuery} from 'sentry/views/insights/common/queries/useSpansQuery';
 import {useInsightsEap} from 'sentry/views/insights/common/utils/useEap';
 import type {
-  DiscoverProperty,
-  DiscoverResponse,
   EAPSpanProperty,
   EAPSpanResponse,
   MetricsProperty,
@@ -75,18 +73,6 @@ export const useMetrics = <Fields extends MetricsProperty[]>(
   return useDiscover<Fields, MetricsResponse>(
     options,
     useEap ? DiscoverDatasets.SPANS_EAP_RPC : DiscoverDatasets.METRICS,
-    referrer
-  );
-};
-
-export const useDiscoverOrEap = <Fields extends DiscoverProperty[]>(
-  options: UseDiscoverOptions<Fields> = {},
-  referrer: string
-) => {
-  const useEap = useInsightsEap();
-  return useDiscover<Fields, DiscoverResponse>(
-    options,
-    useEap ? DiscoverDatasets.SPANS_EAP_RPC : DiscoverDatasets.DISCOVER,
     referrer
   );
 };

--- a/static/app/views/insights/common/views/spanSummaryPage/sampleList/sampleTable/sampleTable.tsx
+++ b/static/app/views/insights/common/views/spanSummaryPage/sampleList/sampleTable/sampleTable.tsx
@@ -11,10 +11,7 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useOrganization from 'sentry/utils/useOrganization';
 import type {SamplesTableColumnHeader} from 'sentry/views/insights/common/components/samplesTable/spanSamplesTable';
 import {SpanSamplesTable} from 'sentry/views/insights/common/components/samplesTable/spanSamplesTable';
-import {
-  useDiscoverOrEap,
-  useSpanMetrics,
-} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpanMetrics, useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import type {
   NonDefaultSpanSampleFields,
   SpanSample,
@@ -129,7 +126,7 @@ function SampleTable({
     isFetching: isFetchingTransactions,
     isPending: isLoadingTransactions,
     error: transactionError,
-  } = useDiscoverOrEap(
+  } = useSpans(
     {
       search,
       enabled: isTransactionsEnabled,

--- a/static/app/views/insights/mobile/screenload/components/eventSamples.tsx
+++ b/static/app/views/insights/mobile/screenload/components/eventSamples.tsx
@@ -13,7 +13,7 @@ import {
   PRIMARY_RELEASE_ALIAS,
   SECONDARY_RELEASE_ALIAS,
 } from 'sentry/views/insights/common/components/releaseSelector';
-import {useDiscoverOrEap} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {useReleaseSelection} from 'sentry/views/insights/common/queries/useReleases';
 import useCrossPlatformProject from 'sentry/views/insights/mobile/common/queries/useCrossPlatformProject';
 import {EventSamplesTable} from 'sentry/views/insights/mobile/screenload/components/tables/eventSamplesTable';
@@ -110,7 +110,7 @@ export function ScreenLoadEventSamples({
   const eventView = EventView.fromNewQueryWithLocation(newQuery, location);
   eventView.sorts = [sort];
 
-  const {data, meta, isPending, pageLinks} = useDiscoverOrEap(
+  const {data, meta, isPending, pageLinks} = useSpans(
     {
       search: searchQuery.formatString(),
       cursor,

--- a/static/app/views/insights/types.tsx
+++ b/static/app/views/insights/types.tsx
@@ -184,8 +184,7 @@ type SpanNumberFields =
   | SpanFields.TOTAL_SCORE
   | SpanFields.SPAN_SELF_TIME
   | SpanFields.CACHE_ITEM_SIZE
-  | SpanFields.CODE_LINENO
-  | DiscoverNumberFields;
+  | SpanFields.CODE_LINENO;
 
 export type SpanStringFields =
   | SpanMetricsField.RESOURCE_RENDER_BLOCKING_STATUS
@@ -698,90 +697,7 @@ type MetricsResponseRaw = {
 };
 export type MetricsResponse = Flatten<MetricsResponseRaw>;
 
-enum DiscoverFields {
-  ID = 'id',
-  TRACE = 'trace',
-  USER_DISPLAY = 'user.display',
-  TRANSACTION = 'transaction',
-  LCP = 'measurements.lcp',
-  FCP = 'measurements.fcp',
-  CLS = 'measurements.cls',
-  TTFB = 'measurements.ttfb',
-  INP = 'measurements.inp',
-  TRANSACTION_DURATION = 'transaction.duration',
-  SPAN_DURATION = 'span.duration',
-  REPLAY_ID = 'replayId',
-  TIMESTAMP = 'timestamp',
-  PROFILE_ID = 'profile.id',
-  PROJECT = 'project',
-  SCORE_TOTAL = 'measurements.score.total',
-  SCORE_LCP = 'measurements.score.lcp',
-  SCORE_FCP = 'measurements.score.fcp',
-  SCORE_CLS = 'measurements.score.cls',
-  SCORE_TTFB = 'measurements.score.ttfb',
-  SCORE_INP = 'measurements.score.inp',
-  SCORE_WEIGHT_LCP = 'measurements.score.weight.lcp',
-  SCORE_WEIGHT_FCP = 'measurements.score.weight.fcp',
-  SCORE_WEIGHT_CLS = 'measurements.score.weight.cls',
-  SCORE_WEIGHT_TTFB = 'measurements.score.weight.ttfb',
-  SCORE_WEIGHT_INP = 'measurements.score.weight.inp',
-  SCORE_RATIO_LCP = 'measurements.score.ratio.lcp',
-  SCORE_RATIO_FCP = 'measurements.score.ratio.fcp',
-  SCORE_RATIO_CLS = 'measurements.score.ratio.cls',
-  SCORE_RATIO_TTFB = 'measurements.score.ratio.ttfb',
-  SCORE_RATIO_INP = 'measurements.score.ratio.inp',
-  MEASUREMENTS_TIME_TO_INITIAL_DISPLAY = 'measurements.time_to_initial_display',
-  MEASUREMENTS_TIME_TO_FULL_DISPLAY = 'measurements.time_to_full_display',
-}
-
 export type MetricsProperty = keyof MetricsResponse;
-
-type DiscoverNumberFields =
-  | DiscoverFields.INP
-  | DiscoverFields.CLS
-  | DiscoverFields.FCP
-  | DiscoverFields.LCP
-  | DiscoverFields.TTFB
-  | DiscoverFields.TRANSACTION_DURATION
-  | DiscoverFields.SPAN_DURATION
-  | DiscoverFields.SCORE_TOTAL
-  | DiscoverFields.SCORE_LCP
-  | DiscoverFields.SCORE_FCP
-  | DiscoverFields.SCORE_CLS
-  | DiscoverFields.SCORE_TTFB
-  | DiscoverFields.SCORE_INP
-  | DiscoverFields.SCORE_WEIGHT_LCP
-  | DiscoverFields.SCORE_WEIGHT_FCP
-  | DiscoverFields.SCORE_WEIGHT_CLS
-  | DiscoverFields.SCORE_WEIGHT_TTFB
-  | DiscoverFields.SCORE_WEIGHT_INP
-  | DiscoverFields.SCORE_RATIO_LCP
-  | DiscoverFields.SCORE_RATIO_FCP
-  | DiscoverFields.SCORE_RATIO_CLS
-  | DiscoverFields.SCORE_RATIO_TTFB
-  | DiscoverFields.SCORE_RATIO_INP
-  | DiscoverFields.MEASUREMENTS_TIME_TO_INITIAL_DISPLAY
-  | DiscoverFields.MEASUREMENTS_TIME_TO_FULL_DISPLAY;
-
-type DiscoverStringFields =
-  | DiscoverFields.ID
-  | DiscoverFields.TRACE
-  | DiscoverFields.USER_DISPLAY
-  | DiscoverFields.TRANSACTION
-  | DiscoverFields.REPLAY_ID
-  | DiscoverFields.TIMESTAMP
-  | DiscoverFields.PROFILE_ID
-  | DiscoverFields.PROJECT;
-
-type DiscoverResponseRaw = {
-  [Property in DiscoverNumberFields as `${Property}`]: number;
-} & {
-  [Property in DiscoverStringFields as `${Property}`]: string;
-};
-
-export type DiscoverResponse = Flatten<DiscoverResponseRaw>;
-
-export type DiscoverProperty = keyof DiscoverResponse;
 
 export type SpanQueryFilters = Partial<Record<SpanStringFields, string>> & {
   is_transaction?: 'true' | 'false';

--- a/static/app/views/insights/types.tsx
+++ b/static/app/views/insights/types.tsx
@@ -90,6 +90,7 @@ export enum SpanFields {
   PROJECT = 'project',
   MEASUREMENT_HTTP_RESPONSE_CONTENT_LENGTH = 'measurements.http.response_content_length',
   MEASUREMENTS_TIME_TO_INITIAL_DISPLAY = 'measurements.time_to_initial_display',
+  MEASUREMENTS_TIME_TO_FILL_DISPLAY = 'measurements.time_to_full_display',
   SPAN_DESCRIPTION = 'span.description',
   SPAN_GROUP = 'span.group',
   SPAN_OP = 'span.op',
@@ -116,19 +117,14 @@ export enum SpanFields {
   MCP_RESOURCE_URI = 'mcp.resource.uri',
   MCP_PROMPT_NAME = 'mcp.prompt.name',
   TRANSACTION_SPAN_ID = 'transaction.span_id',
-  TOTAL_SCORE = 'measurements.score.total',
   SPAN_SELF_TIME = 'span.self_time',
   TRACE = 'trace',
   PROFILE_ID = 'profile_id',
   PROFILEID = 'profile.id',
   REPLAYID = 'replayId',
   REPLAY_ID = 'replay.id',
-  USER_ID = 'user.id',
-  USER_IP = 'user.ip',
   LCP_ELEMENT = 'lcp.element',
   CLS_SOURCE = 'cls.source.1',
-  USER_EMAIL = 'user.email',
-  USER_USERNAME = 'user.username',
   CACHE_ITEM_SIZE = 'measurements.cache.item_size',
   SPAN_ID = 'span_id',
   DB_SYSTEM = 'db.system',
@@ -138,6 +134,36 @@ export enum SpanFields {
   SDK_VERSION = 'sdk.version',
   PLATFORM = 'platform',
   CODE_LINENO = 'code.lineno',
+
+  // User fields
+  USER_ID = 'user.id',
+  USER_IP = 'user.ip',
+  USER_EMAIL = 'user.email',
+  USER_USERNAME = 'user.username',
+  USER_GEO_SUBREGION = 'user.geo.subregion',
+
+  // Web vitals
+  INP = 'measurements.inp',
+  INP_SCORE = 'measurements.score.inp',
+  INP_SCORE_RATIO = 'measurements.score.ratio.inp',
+  INP_SCORE_WEIGHT = 'measurements.score.weight.inp',
+  LCP = 'measurements.lcp',
+  LCP_SCORE = 'measurements.score.lcp',
+  LCP_SCORE_RATIO = 'measurements.score.ratio.lcp',
+  LCP_SCORE_WEIGHT = 'measurements.score.weight.lcp',
+  CLS = 'measurements.cls',
+  CLS_SCORE = 'measurements.score.cls',
+  CLS_SCORE_RATIO = 'measurements.score.ratio.cls',
+  CLS_SCORE_WEIGHT = 'measurements.score.weight.cls',
+  TTFB = 'measurements.ttfb',
+  TTFB_SCORE = 'measurements.score.ttfb',
+  TTFB_SCORE_RATIO = 'measurements.score.ratio.ttfb',
+  TTFB_SCORE_WEIGHT = 'measurements.score.weight.ttfb',
+  FCP = 'measurements.fcp',
+  FCP_SCORE = 'measurements.score.fcp',
+  FCP_SCORE_RATIO = 'measurements.score.ratio.fcp',
+  FCP_SCORE_WEIGHT = 'measurements.score.weight.fcp',
+  TOTAL_SCORE = 'measurements.score.total',
 }
 
 type WebVitalsMeasurements =
@@ -177,11 +203,32 @@ type SpanNumberFields =
   | SpanFields.SLOW_FRAMES_RATE
   | SpanFields.MEASUREMENT_HTTP_RESPONSE_CONTENT_LENGTH
   | SpanFields.MEASUREMENTS_TIME_TO_INITIAL_DISPLAY
+  | SpanFields.MEASUREMENTS_TIME_TO_FILL_DISPLAY
   | SpanFields.GEN_AI_USAGE_INPUT_TOKENS
   | SpanFields.GEN_AI_USAGE_OUTPUT_TOKENS
   | SpanFields.GEN_AI_USAGE_TOTAL_TOKENS
   | SpanFields.GEN_AI_USAGE_TOTAL_COST
   | SpanFields.TOTAL_SCORE
+  | SpanFields.INP
+  | SpanFields.INP_SCORE
+  | SpanFields.INP_SCORE_RATIO
+  | SpanFields.INP_SCORE_WEIGHT
+  | SpanFields.LCP
+  | SpanFields.LCP_SCORE
+  | SpanFields.LCP_SCORE_RATIO
+  | SpanFields.LCP_SCORE_WEIGHT
+  | SpanFields.CLS
+  | SpanFields.CLS_SCORE
+  | SpanFields.CLS_SCORE_RATIO
+  | SpanFields.CLS_SCORE_WEIGHT
+  | SpanFields.TTFB
+  | SpanFields.TTFB_SCORE
+  | SpanFields.TTFB_SCORE_RATIO
+  | SpanFields.TTFB_SCORE_WEIGHT
+  | SpanFields.FCP
+  | SpanFields.FCP_SCORE
+  | SpanFields.FCP_SCORE_RATIO
+  | SpanFields.FCP_SCORE_WEIGHT
   | SpanFields.SPAN_SELF_TIME
   | SpanFields.CACHE_ITEM_SIZE
   | SpanFields.CODE_LINENO;
@@ -388,6 +435,8 @@ type EAPSpanResponseRaw = {
     [SpanMetricsField.USER_GEO_SUBREGION]: SubregionCode;
   } & {
     [SpanFields.PLATFORM]: PlatformKey;
+  } & {
+    [SpanFields.USER_GEO_SUBREGION]: SubregionCode;
   } & {
     [Property in SpanFields as `count_unique(${Property})`]: number;
   } & {


### PR DESCRIPTION
Now that eap is 100% for insights, we can replace `useDiscoverOrEap` with `useSpans`