### PR TITLE
:wrench: chore: bump processesing deadline for `send_activity_notifications_to_slack_threads`

### DIFF
--- a/src/sentry/integrations/slack/tasks/send_notifications_on_activity.py
+++ b/src/sentry/integrations/slack/tasks/send_notifications_on_activity.py
@@ -25,6 +25,7 @@ _TASK_QUEUED_METRIC = (
     silo_mode=SiloMode.REGION,
     taskworker_config=TaskworkerConfig(
         namespace=integrations_tasks,
+        processing_deadline_duration=30,
     ),
 )
 def send_activity_notifications_to_slack_threads(activity_id) -> None:


### PR DESCRIPTION
bumping the processing deadline for this task since it actually has to query for all threads for a particular slack integration with a `group_id` of x, and fire a slack notification for each thread, making this rather expensive.

i tried figuring out if there was a way to optimize, but unless we break down sending the notification itself into its own task, there isn't much scope. id rather just bump the deadline of this task first to see if this helps.


hopefully resolves SENTRY-416Q