### PR TITLE
fix(feedback): fix patching flakes with test_openai.py

### DIFF
--- a/tests/sentry/feedback/test_create_feedback.py
+++ b/tests/sentry/feedback/test_create_feedback.py
@@ -451,7 +451,6 @@ def test_create_feedback_spam_detection_produce_to_kafka(
     mock_produce_occurrence_to_kafka,
     input_message,
     expected_result,
-    monkeypatch,
     feature_flag,
 ):
     with Feature({"organizations:user-feedback-spam-ingest": feature_flag}):
@@ -491,11 +490,10 @@ def test_create_feedback_spam_detection_produce_to_kafka(
         mock_openai = Mock()
         mock_openai().chat.completions.create = create_dummy_openai_response
 
-        monkeypatch.setattr("sentry.llm.providers.openai.OpenAI", mock_openai)
-
-        create_feedback_issue(
-            event, default_project.id, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE
-        )
+        with patch("sentry.llm.providers.openai.OpenAI", mock_openai):
+            create_feedback_issue(
+                event, default_project.id, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE
+            )
 
         # Check if the 'is_spam' evidence in the Kafka message matches the expected result
         is_spam_evidence = [
@@ -526,7 +524,6 @@ def test_create_feedback_spam_detection_produce_to_kafka(
 def test_create_feedback_spam_detection_project_option_false(
     default_project,
     mock_produce_occurrence_to_kafka,
-    monkeypatch,
 ):
     default_project.update_option("sentry:feedback_ai_spam_detection", False)
 
@@ -567,11 +564,10 @@ def test_create_feedback_spam_detection_project_option_false(
         mock_openai = Mock()
         mock_openai().chat.completions.create = create_dummy_openai_response
 
-        monkeypatch.setattr("sentry.llm.providers.openai.OpenAI", mock_openai)
-
-        create_feedback_issue(
-            event, default_project.id, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE
-        )
+        with patch("sentry.llm.providers.openai.OpenAI", mock_openai):
+            create_feedback_issue(
+                event, default_project.id, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE
+            )
 
         # Check if the 'is_spam' evidence in the Kafka message matches the expected result
         is_spam_evidence = [
@@ -588,7 +584,6 @@ def test_create_feedback_spam_detection_project_option_false(
 @django_db_all
 def test_create_feedback_spam_detection_set_status_ignored(
     default_project,
-    monkeypatch,
 ):
     with Feature(
         {
@@ -632,11 +627,10 @@ def test_create_feedback_spam_detection_set_status_ignored(
         mock_openai = Mock()
         mock_openai().chat.completions.create = create_dummy_openai_response
 
-        monkeypatch.setattr("sentry.llm.providers.openai.OpenAI", mock_openai)
-
-        create_feedback_issue(
-            event, default_project.id, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE
-        )
+        with patch("sentry.llm.providers.openai.OpenAI", mock_openai):
+            create_feedback_issue(
+                event, default_project.id, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE
+            )
 
         group = Group.objects.get()
         assert group.status == GroupStatus.IGNORED


### PR DESCRIPTION
Discovered in https://github.com/getsentry/sentry/pull/95392 the monkeypatching of `OpenAI` class in `test_create_feedback.py` can affect `test_openai.py`, I'm guessing when they are ran in parallel. I haven't seen this flake anywhere else, but don't believe it's related to the changes in #95392. Using the patch context manager should fix this.

"not spam" return value bleeds over to the openai test:
<img width="806" height="476" alt="Screenshot 2025-07-15 at 10 51 22 AM" src="https://github.com/user-attachments/assets/d900d7d1-9138-422f-b354-ac94fad9967a" />

Ref [REPLAY-513: [PR Tracker] refactor backend user feedback code](https://linear.app/getsentry/issue/REPLAY-513/pr-tracker-refactor-backend-user-feedback-code)