### PR TITLE
feat(codecov): Use navigation and limit query params for test results pagination

### DIFF
--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -1099,27 +1099,19 @@ Available fields are:
 - `UPDATED_AT`
         """,
     )
-    FIRST = OpenApiParameter(
-        name="first",
+    LIMIT = OpenApiParameter(
+        name="limit",
         location="query",
         required=False,
         type=int,
-        default=20,
-        description="""The number of results to return from the start of the list.""",
-    )
-    LAST = OpenApiParameter(
-        name="last",
-        location="query",
-        required=False,
-        type=int,
-        description="""The number of results to return from the end of the list.""",
+        description="""The number of results to return. If not specified, defaults to 20. Maximum allowed is 100.""",
     )
     CURSOR = OpenApiParameter(
         name="cursor",
         location="query",
         required=False,
         type=str,
-        description="""The cursor to start the query from. Will return results after the cursor if used with `first` or before the cursor if used with `last`.""",
+        description="""The cursor pointing to a specific position in the result set to start the query from. Will return results after the cursor if used with `after` or before the cursor if used with `before` for `direction`.""",
     )
     TERM = OpenApiParameter(
         name="term",
@@ -1127,4 +1119,11 @@ Available fields are:
         required=False,
         type=str,
         description="""The term substring to filter test name strings by using the `contains` operator.""",
+    )
+    DIRECTION = OpenApiParameter(
+        name="direction",
+        location="query",
+        required=False,
+        type=str,
+        description="""The direction to paginate in. Use `after` for forward pagination (get results after the cursor) or `before` for backward pagination (get results before the cursor). If not specified, defaults to `after`.""",
     )

--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -1104,14 +1104,29 @@ Available fields are:
         location="query",
         required=False,
         type=int,
-        description="""The number of results to return. If not specified, defaults to 20. Maximum allowed is 100.""",
+        description="""The number of results to return. If not specified, defaults to 20.""",
+    )
+    FIRST = OpenApiParameter(
+        name="first",
+        location="query",
+        required=False,
+        type=int,
+        default=20,
+        description="""The number of results to return from the start of the list.""",
+    )
+    LAST = OpenApiParameter(
+        name="last",
+        location="query",
+        required=False,
+        type=int,
+        description="""The number of results to return from the end of the list.""",
     )
     CURSOR = OpenApiParameter(
         name="cursor",
         location="query",
         required=False,
         type=str,
-        description="""The cursor pointing to a specific position in the result set to start the query from. Will return results after the cursor if used with `after` or before the cursor if used with `before` for `direction`.""",
+        description="""The cursor pointing to a specific position in the result set to start the query from. Results after the cursor will be returned if used with `next` or before the cursor if used with `prev` for `navigation`.""",
     )
     TERM = OpenApiParameter(
         name="term",
@@ -1120,10 +1135,10 @@ Available fields are:
         type=str,
         description="""The term substring to filter test name strings by using the `contains` operator.""",
     )
-    DIRECTION = OpenApiParameter(
-        name="direction",
+    NAVIGATION = OpenApiParameter(
+        name="navigation",
         location="query",
         required=False,
         type=str,
-        description="""The direction to paginate in. Use `after` for forward pagination (get results after the cursor) or `before` for backward pagination (get results before the cursor). If not specified, defaults to `after`.""",
+        description="""Whether to get the previous or next page from paginated results. Use `next` for forward pagination after the cursor or `prev` for backward pagination before the cursor. If not specified, defaults to `next`. If no cursor is provided, the cursor is the beginning of the result set.""",
     )

--- a/src/sentry/codecov/endpoints/Repositories/serializers.py
+++ b/src/sentry/codecov/endpoints/Repositories/serializers.py
@@ -3,6 +3,8 @@ import logging
 import sentry_sdk
 from rest_framework import serializers
 
+from sentry.codecov.endpoints.TestResults.serializers import PageInfoSerializer
+
 logger = logging.getLogger(__name__)
 
 
@@ -19,17 +21,6 @@ class RepositoryNodeSerializer(serializers.Serializer):
     defaultBranch = serializers.CharField()
 
 
-class PageInfoTempSerializer(serializers.Serializer):
-    """
-    Serializer for pagination information
-    """
-
-    startCursor = serializers.CharField(allow_null=True)
-    endCursor = serializers.CharField(allow_null=True)
-    hasNextPage = serializers.BooleanField()
-    hasPreviousPage = serializers.BooleanField()
-
-
 class RepositoriesSerializer(serializers.Serializer):
     """
     Serializer for repositories response
@@ -38,7 +29,7 @@ class RepositoriesSerializer(serializers.Serializer):
     __test__ = False
 
     results = RepositoryNodeSerializer(many=True)
-    pageInfo = PageInfoTempSerializer()
+    pageInfo = PageInfoSerializer()
     totalCount = serializers.IntegerField()
 
     def to_representation(self, graphql_response):

--- a/src/sentry/codecov/endpoints/Repositories/serializers.py
+++ b/src/sentry/codecov/endpoints/Repositories/serializers.py
@@ -3,7 +3,7 @@ import logging
 import sentry_sdk
 from rest_framework import serializers
 
-from sentry.codecov.endpoints.TestResults.serializers import PageInfoSerializer
+from sentry.codecov.endpoints.serializers import PageInfoSerializer
 
 logger = logging.getLogger(__name__)
 

--- a/src/sentry/codecov/endpoints/TestResults/query.py
+++ b/src/sentry/codecov/endpoints/TestResults/query.py
@@ -40,6 +40,8 @@ query = """query GetTestResults(
             pageInfo {
               endCursor
               hasNextPage
+              hasPreviousPage
+              startCursor
             }
             totalCount
           }

--- a/src/sentry/codecov/endpoints/TestResults/serializers.py
+++ b/src/sentry/codecov/endpoints/TestResults/serializers.py
@@ -3,6 +3,8 @@ import logging
 import sentry_sdk
 from rest_framework import serializers
 
+from sentry.codecov.endpoints.serializers import PageInfoSerializer
+
 logger = logging.getLogger(__name__)
 
 
@@ -25,17 +27,6 @@ class TestResultNodeSerializer(serializers.Serializer):
     totalSkipCount = serializers.IntegerField()
     totalPassCount = serializers.IntegerField()
     lastDuration = serializers.FloatField()
-
-
-class PageInfoSerializer(serializers.Serializer):
-    """
-    Serializer for pagination information
-    """
-
-    endCursor = serializers.CharField(allow_null=True)
-    startCursor = serializers.CharField(allow_null=True)
-    hasPreviousPage = serializers.BooleanField()
-    hasNextPage = serializers.BooleanField()
 
 
 class TestResultSerializer(serializers.Serializer):

--- a/src/sentry/codecov/endpoints/TestResults/serializers.py
+++ b/src/sentry/codecov/endpoints/TestResults/serializers.py
@@ -33,6 +33,8 @@ class PageInfoSerializer(serializers.Serializer):
     """
 
     endCursor = serializers.CharField(allow_null=True)
+    startCursor = serializers.CharField(allow_null=True)
+    hasPreviousPage = serializers.BooleanField()
     hasNextPage = serializers.BooleanField()
 
 
@@ -65,7 +67,13 @@ class TestResultSerializer(serializers.Serializer):
             response_data = {
                 "results": nodes,
                 "pageInfo": test_results_data.get(
-                    "pageInfo", {"endCursor": None, "hasNextPage": False}
+                    "pageInfo",
+                    {
+                        "endCursor": None,
+                        "hasNextPage": False,
+                        "startCursor": None,
+                        "hasPreviousPage": False,
+                    },
                 ),
                 "totalCount": test_results_data.get("totalCount", len(nodes)),
             }

--- a/src/sentry/codecov/endpoints/TestResults/test_results.py
+++ b/src/sentry/codecov/endpoints/TestResults/test_results.py
@@ -38,8 +38,8 @@ class TestResultsEndpoint(CodecovEndpoint):
             PreventParams.TEST_RESULTS_FILTER_BY,
             PreventParams.INTERVAL,
             PreventParams.BRANCH,
-            PreventParams.FIRST,
-            PreventParams.LAST,
+            PreventParams.LIMIT,
+            PreventParams.DIRECTION,
             PreventParams.CURSOR,
             PreventParams.TERM,
         ],
@@ -62,29 +62,29 @@ class TestResultsEndpoint(CodecovEndpoint):
 
         if sort_by.startswith("-"):
             sort_by = sort_by[1:]
-            direction = OrderingDirection.DESC.value
+            ordering_direction = OrderingDirection.DESC.value
         else:
-            direction = OrderingDirection.ASC.value
+            ordering_direction = OrderingDirection.ASC.value
 
-        first_param = request.query_params.get("first")
-        last_param = request.query_params.get("last")
         cursor = request.query_params.get("cursor")
+        limit = int(request.query_params.get("limit", 20))
+        direction = request.query_params.get("direction", "after")
 
         # When calling request.query_params, the URL is decoded so + is replaced with spaces. We need to change them back so Codecov can properly fetch the next page.
         if cursor:
             cursor = cursor.replace(" ", "+")
 
-        first = int(first_param) if first_param else None
-        last = int(last_param) if last_param else None
-
-        if first and last:
+        MAX_LIMIT = 100
+        if limit <= 0:
             return Response(
                 status=status.HTTP_400_BAD_REQUEST,
-                data={"details": "Cannot specify both `first` and `last`"},
+                data={"details": "`limit` parameter must be a positive integer"},
             )
-
-        if not first and not last:
-            first = 20
+        elif limit > MAX_LIMIT:
+            return Response(
+                status=status.HTTP_400_BAD_REQUEST,
+                data={"details": f"`limit` parameter cannot exceed {MAX_LIMIT}"},
+            )
 
         variables = {
             "owner": owner,
@@ -100,13 +100,13 @@ class TestResultsEndpoint(CodecovEndpoint):
                 "test_suites": None,
             },
             "ordering": {
-                "direction": direction,
+                "direction": ordering_direction,
                 "parameter": sort_by,
             },
-            "first": first,
-            "last": last,
-            "before": cursor if cursor and last else None,
-            "after": cursor if cursor and first else None,
+            "first": limit if direction == "after" else None,
+            "last": limit if direction == "before" else None,
+            "before": cursor if cursor and direction == "before" else None,
+            "after": cursor if cursor and direction == "after" else None,
         }
 
         client = CodecovApiClient(git_provider_org=owner)

--- a/src/sentry/codecov/endpoints/TestResults/test_results.py
+++ b/src/sentry/codecov/endpoints/TestResults/test_results.py
@@ -72,7 +72,14 @@ class TestResultsEndpoint(CodecovEndpoint):
             ordering_direction = OrderingDirection.ASC.value
 
         cursor = request.query_params.get("cursor")
-        limit = int(request.query_params.get("limit", 20))
+        limit_param = request.query_params.get("limit", "20")
+        try:
+            limit = int(limit_param)
+        except (ValueError, TypeError):
+            return Response(
+                status=status.HTTP_400_BAD_REQUEST,
+                data={"details": "provided `limit` parameter must be a positive integer"},
+            )
         navigation = request.query_params.get("navigation", NavigationParameter.NEXT.value)
 
         # When calling request.query_params, the URL is decoded so + is replaced with spaces. We need to change them back so Codecov can properly fetch the next page.

--- a/src/sentry/codecov/endpoints/TestResults/test_results.py
+++ b/src/sentry/codecov/endpoints/TestResults/test_results.py
@@ -109,7 +109,7 @@ class TestResultsEndpoint(CodecovEndpoint):
                 "direction": ordering_direction,
                 "parameter": sort_by,
             },
-            "first": limit if navigation == NavigationParameter.NEXT.value else None,
+            "first": limit if navigation != NavigationParameter.PREV.value else None,
             "last": limit if navigation == NavigationParameter.PREV.value else None,
             "before": cursor if cursor and navigation == NavigationParameter.PREV.value else None,
             "after": cursor if cursor and navigation == NavigationParameter.NEXT.value else None,

--- a/src/sentry/codecov/endpoints/serializers.py
+++ b/src/sentry/codecov/endpoints/serializers.py
@@ -1,0 +1,12 @@
+from rest_framework import serializers
+
+
+class PageInfoSerializer(serializers.Serializer):
+    """
+    Serializer for pagination information
+    """
+
+    endCursor = serializers.CharField(allow_null=True)
+    startCursor = serializers.CharField(allow_null=True)
+    hasPreviousPage = serializers.BooleanField()
+    hasNextPage = serializers.BooleanField()

--- a/src/sentry/codecov/enums.py
+++ b/src/sentry/codecov/enums.py
@@ -25,3 +25,8 @@ class MeasurementInterval(Enum):
     INTERVAL_30_DAY = "INTERVAL_30_DAY"
     INTERVAL_7_DAY = "INTERVAL_7_DAY"
     INTERVAL_1_DAY = "INTERVAL_1_DAY"
+
+
+class NavigationParameter(Enum):
+    NEXT = "next"
+    PREV = "prev"

--- a/tests/sentry/codecov/endpoints/test_test_results.py
+++ b/tests/sentry/codecov/endpoints/test_test_results.py
@@ -328,3 +328,11 @@ class TestResultsEndpointTest(APITestCase):
 
         assert response.status_code == 400
         assert response.data == {"details": "provided `limit` parameter must be a positive integer"}
+
+    def test_get_with_limit_as_string_returns_bad_request(self):
+        url = self.reverse_url()
+        query_params = {"limit": "asdf"}
+        response = self.client.get(url, query_params)
+
+        assert response.status_code == 400
+        assert response.data == {"details": "provided `limit` parameter must be a positive integer"}

--- a/tests/sentry/codecov/endpoints/test_test_results.py
+++ b/tests/sentry/codecov/endpoints/test_test_results.py
@@ -15,7 +15,12 @@ mock_graphql_response_empty = {
                 "testAnalytics": {
                     "testResults": {
                         "edges": [],
-                        "pageInfo": {"endCursor": None, "hasNextPage": False},
+                        "pageInfo": {
+                            "endCursor": None,
+                            "hasNextPage": False,
+                            "hasPreviousPage": False,
+                            "startCursor": None,
+                        },
                         "totalCount": 0,
                     }
                 },
@@ -65,7 +70,12 @@ mock_graphql_response_populated = {
                                 }
                             },
                         ],
-                        "pageInfo": {"endCursor": "cursor123", "hasNextPage": False},
+                        "pageInfo": {
+                            "endCursor": "cursor123",
+                            "hasNextPage": False,
+                            "hasPreviousPage": False,
+                            "startCursor": None,
+                        },
                         "totalCount": 2,
                     }
                 },
@@ -136,6 +146,8 @@ class TestResultsEndpointTest(APITestCase):
         assert len(response.data["results"]) == 2
         assert response.data["pageInfo"]["endCursor"] == "cursor123"
         assert response.data["pageInfo"]["hasNextPage"] is False
+        assert response.data["pageInfo"]["hasPreviousPage"] is False
+        assert response.data["pageInfo"]["startCursor"] is None
         assert response.data["totalCount"] == 2
 
         serializer_fields = set(NodeSerializer().fields.keys())
@@ -159,7 +171,7 @@ class TestResultsEndpointTest(APITestCase):
             "filterBy": "FLAKY_TESTS",
             "sortBy": "-AVG_DURATION",
             "interval": "INTERVAL_7_DAY",
-            "first": "10",
+            "limit": "10",
         }
         response = self.client.get(url, query_params)
 
@@ -190,53 +202,6 @@ class TestResultsEndpointTest(APITestCase):
         assert response.status_code == 200
 
     @patch("sentry.codecov.endpoints.TestResults.test_results.CodecovApiClient")
-    def test_get_with_last_parameter(self, mock_codecov_client_class):
-        mock_codecov_client_instance = Mock()
-        mock_response = Mock()
-        mock_response.json.return_value = mock_graphql_response_empty
-        mock_codecov_client_instance.query.return_value = mock_response
-        mock_codecov_client_class.return_value = mock_codecov_client_instance
-
-        url = self.reverse_url()
-        query_params = {"last": "5"}
-        response = self.client.get(url, query_params)
-
-        # Verify the correct variables are passed with last parameter
-        expected_variables = {
-            "owner": "testowner",
-            "repo": "testrepo",
-            "filters": {
-                "branch": "main",
-                "parameter": None,
-                "interval": "INTERVAL_30_DAY",
-                "flags": None,
-                "term": None,
-                "test_suites": None,
-            },
-            "ordering": {
-                "direction": "DESC",
-                "parameter": "COMMITS_WHERE_FAIL",
-            },
-            "first": None,
-            "last": 5,
-            "before": None,
-            "after": None,
-        }
-
-        call_args = mock_codecov_client_instance.query.call_args
-        assert call_args[1]["variables"] == expected_variables
-        assert response.status_code == 200
-
-    def test_get_with_both_first_and_last_returns_bad_request(self):
-        """Test that providing both first and last parameters returns a 400 Bad Request error"""
-        url = self.reverse_url()
-        query_params = {"first": "10", "last": "5"}
-        response = self.client.get(url, query_params)
-
-        assert response.status_code == 400
-        assert response.data == {"details": "Cannot specify both `first` and `last`"}
-
-    @patch("sentry.codecov.endpoints.TestResults.test_results.CodecovApiClient")
     def test_get_with_term_filter(self, mock_codecov_client_class):
         mock_codecov_client_instance = Mock()
         mock_response = Mock()
@@ -251,7 +216,7 @@ class TestResultsEndpointTest(APITestCase):
             "filterBy": "FLAKY_TESTS",
             "sortBy": "AVG_DURATION",
             "interval": "INTERVAL_7_DAY",
-            "first": "15",
+            "limit": "15",
         }
         response = self.client.get(url, query_params)
 
@@ -279,3 +244,98 @@ class TestResultsEndpointTest(APITestCase):
         call_args = mock_codecov_client_instance.query.call_args
         assert call_args[1]["variables"] == expected_variables
         assert response.status_code == 200
+
+    @patch("sentry.codecov.endpoints.TestResults.test_results.CodecovApiClient")
+    def test_get_with_cursor_alone_uses_default_limit_and_direction(
+        self, mock_codecov_client_class
+    ):
+        mock_codecov_client_instance = Mock()
+        mock_response = Mock()
+        mock_response.json.return_value = mock_graphql_response_empty
+        mock_codecov_client_instance.query.return_value = mock_response
+        mock_codecov_client_class.return_value = mock_codecov_client_instance
+
+        url = self.reverse_url()
+        query_params = {"cursor": "some-cursor"}
+        response = self.client.get(url, query_params)
+
+        expected_variables = {
+            "owner": "testowner",
+            "repo": "testrepo",
+            "filters": {
+                "branch": "main",
+                "parameter": None,
+                "interval": "INTERVAL_30_DAY",
+                "flags": None,
+                "term": None,
+                "test_suites": None,
+            },
+            "ordering": {
+                "direction": "DESC",
+                "parameter": "COMMITS_WHERE_FAIL",
+            },
+            "first": 20,
+            "last": None,
+            "before": None,
+            "after": "some-cursor",
+        }
+
+        call_args = mock_codecov_client_instance.query.call_args
+        assert call_args[1]["variables"] == expected_variables
+        assert response.status_code == 200
+
+    @patch("sentry.codecov.endpoints.TestResults.test_results.CodecovApiClient")
+    def test_get_with_cursor_with_direction(self, mock_codecov_client_class):
+        """Test that cursor with last parameter works correctly for backward pagination"""
+        mock_codecov_client_instance = Mock()
+        mock_response = Mock()
+        mock_response.json.return_value = mock_graphql_response_empty
+        mock_codecov_client_instance.query.return_value = mock_response
+        mock_codecov_client_class.return_value = mock_codecov_client_instance
+
+        url = self.reverse_url()
+        query_params = {"cursor": "cursor123", "limit": "10", "direction": "before"}
+        response = self.client.get(url, query_params)
+
+        expected_variables = {
+            "owner": "testowner",
+            "repo": "testrepo",
+            "filters": {
+                "branch": "main",
+                "parameter": None,
+                "interval": "INTERVAL_30_DAY",
+                "flags": None,
+                "term": None,
+                "test_suites": None,
+            },
+            "ordering": {
+                "direction": "DESC",
+                "parameter": "COMMITS_WHERE_FAIL",
+            },
+            "first": None,
+            "last": 10,
+            "before": "cursor123",
+            "after": None,
+        }
+
+        call_args = mock_codecov_client_instance.query.call_args
+        assert call_args[1]["variables"] == expected_variables
+        assert response.status_code == 200
+
+    def test_get_with_negative_limit_returns_bad_request(self):
+        """Test that providing negative first parameter returns a 400 Bad Request error"""
+        url = self.reverse_url()
+        query_params = {"limit": "-5"}
+        response = self.client.get(url, query_params)
+
+        assert response.status_code == 400
+        assert response.data == {"details": "`limit` parameter must be a positive integer"}
+
+    def test_get_with_large_first_returns_bad_request(self):
+        """Test that providing first parameter exceeding max limit returns a 400 Bad Request error"""
+        url = self.reverse_url()
+        query_params = {"limit": "150"}
+        response = self.client.get(url, query_params)
+
+        assert response.status_code == 400
+        assert response.data == {"details": "`limit` parameter cannot exceed 100"}


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/CCMRG-1312/identify-and-implement-proper-way-to-query-next-and-previous-page-for

- I've chosen to use `limit` to follow these guidelines https://develop.sentry.dev/backend/api/design/#parameter-design with a more clear designation of `navigation` in favor of passing in `first` and `last` parameters as it is confusing to figure out what exactly that means
- Added `hasPreviousPage` and `startCursor` to the PageInfo returned from the call to allow future FE calls in either forward or backward direction