### PR TITLE
ref(issues): default issue view enforce flag to true

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -152,7 +152,7 @@ def register_temporary_features(manager: FeatureManager):
     # Enables lifetime stats on issue details
     manager.add("organizations:issue-details-lifetime-stats", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables streamlined issue details UI for all users of an organization without opt-out
-    manager.add("organizations:issue-details-streamline-enforce", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    manager.add("organizations:issue-details-streamline-enforce", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, default=True, api_expose=True)
     # Enables sorting spans for issue detection
     manager.add("organizations:issue-detection-sort-spans", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Whether to allow issue only search on the issue list


### PR DESCRIPTION
Set default of `organizations:issue-details-streamline-enforce` to True, as a part of work to remove it entirely, since it is already rolled out to everyone through [flagpole](https://github.com/getsentry/sentry-options-automator/blob/a7e0418f28f78060a6ec2d7b6e91983d92e0dd26/options/default/flagpole.yml#L471).

See https://github.com/getsentry/sentry/pull/95573