### PR TITLE
ref(discover): restyle `CellAction` behind a feature flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -114,6 +114,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:discover", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
     # Enable the discover saved queries deprecation warnings
     manager.add("organizations:discover-saved-queries-deprecation", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable new cell actions styling and features for tables that use the component
+    manager.add("organizations:discover-cell-actions-v2", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the org recalibration
     manager.add("organizations:ds-org-recalibration", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enable custom dynamic sampling rates

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -114,8 +114,6 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:discover", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
     # Enable the discover saved queries deprecation warnings
     manager.add("organizations:discover-saved-queries-deprecation", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable new cell actions styling and features for tables that use the component
-    manager.add("organizations:discover-cell-actions-v2", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the org recalibration
     manager.add("organizations:ds-org-recalibration", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enable custom dynamic sampling rates

--- a/static/app/components/dropdownMenu/index.tsx
+++ b/static/app/components/dropdownMenu/index.tsx
@@ -156,6 +156,7 @@ function DropdownMenu({
   flipOptions,
   portalContainerRef,
   shouldApplyMinWidth,
+  menuWidth,
   ...props
 }: DropdownMenuProps) {
   const isDisabled = disabledProp ?? (!items || items.length === 0);
@@ -244,6 +245,7 @@ function DropdownMenu({
         overlayPositionProps={overlayProps}
         overlayState={overlayState}
         items={activeItems}
+        menuWidth={menuWidth}
       >
         {(item: MenuItemProps) => {
           if (item.children && item.children.length > 0 && !item.isSubmenu) {

--- a/static/app/components/dropdownMenu/index.tsx
+++ b/static/app/components/dropdownMenu/index.tsx
@@ -1,4 +1,4 @@
-import {type CSSProperties, useContext, useMemo} from 'react';
+import {useContext, useMemo} from 'react';
 import {createPortal} from 'react-dom';
 import styled from '@emotion/styled';
 import {useButton} from '@react-aria/button';
@@ -85,10 +85,6 @@ export interface DropdownMenuProps
    */
   menuTitle?: React.ReactNode;
   /**
-   * Set the menu width
-   */
-  menuWidth?: CSSProperties['width'];
-  /**
    * Minimum menu width
    */
   minMenuWidth?: number;
@@ -163,7 +159,6 @@ function DropdownMenu({
   flipOptions,
   portalContainerRef,
   shouldApplyMinWidth,
-  menuWidth,
   minMenuWidth,
   ...props
 }: DropdownMenuProps) {
@@ -254,7 +249,6 @@ function DropdownMenu({
           ...overlayProps,
           style: {
             ...overlayProps.style,
-            width: menuWidth ?? overlayProps.style?.width,
             minWidth: minMenuWidth ?? overlayProps.style?.minWidth,
           },
         }}

--- a/static/app/components/dropdownMenu/index.tsx
+++ b/static/app/components/dropdownMenu/index.tsx
@@ -1,4 +1,4 @@
-import {useContext, useMemo} from 'react';
+import {type CSSProperties, useContext, useMemo} from 'react';
 import {createPortal} from 'react-dom';
 import styled from '@emotion/styled';
 import {useButton} from '@react-aria/button';
@@ -85,6 +85,14 @@ export interface DropdownMenuProps
    */
   menuTitle?: React.ReactNode;
   /**
+   * Set the menu width
+   */
+  menuWidth?: CSSProperties['width'];
+  /**
+   * Minimum menu width
+   */
+  minMenuWidth?: number;
+  /**
    * Reference to the container element that the portal should be rendered into.
    */
   portalContainerRef?: React.RefObject<HTMLElement | null>;
@@ -117,7 +125,6 @@ export interface DropdownMenuProps
    * component.
    */
   triggerProps?: DropdownButtonProps;
-
   /**
    * Whether to render the menu inside a React portal (false by default). This should
    * only be enabled if necessary, e.g. when the dropdown menu is inside a small,
@@ -157,6 +164,7 @@ function DropdownMenu({
   portalContainerRef,
   shouldApplyMinWidth,
   menuWidth,
+  minMenuWidth,
   ...props
 }: DropdownMenuProps) {
   const isDisabled = disabledProp ?? (!items || items.length === 0);
@@ -242,10 +250,16 @@ function DropdownMenu({
         {...menuProps}
         size={size}
         disabledKeys={disabledKeys ?? defaultDisabledKeys}
-        overlayPositionProps={overlayProps}
+        overlayPositionProps={{
+          ...overlayProps,
+          style: {
+            ...overlayProps.style,
+            width: menuWidth ?? overlayProps.style?.width,
+            minWidth: minMenuWidth ?? overlayProps.style?.minWidth,
+          },
+        }}
         overlayState={overlayState}
         items={activeItems}
-        menuWidth={menuWidth}
       >
         {(item: MenuItemProps) => {
           if (item.children && item.children.length > 0 && !item.isSubmenu) {

--- a/static/app/components/dropdownMenu/list.tsx
+++ b/static/app/components/dropdownMenu/list.tsx
@@ -1,4 +1,11 @@
-import {createContext, Fragment, useContext, useMemo, useRef} from 'react';
+import {
+  createContext,
+  type CSSProperties,
+  Fragment,
+  useContext,
+  useMemo,
+  useRef,
+} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {FocusScope} from '@react-aria/focus';
@@ -66,6 +73,10 @@ export interface DropdownMenuListProps
    */
   menuTitle?: React.ReactNode;
   /**
+   * Set the menu width
+   */
+  menuWidth?: CSSProperties['width'];
+  /**
    * Minimum menu width
    */
   minMenuWidth?: number;
@@ -81,6 +92,7 @@ function DropdownMenuList({
   menuFooter,
   overlayState,
   overlayPositionProps,
+  menuWidth,
   ...props
 }: DropdownMenuListProps) {
   const {rootOverlayState, parentMenuState} = useContext(DropdownMenuContext);
@@ -91,6 +103,14 @@ function DropdownMenuList({
   const menuRef = useRef(null);
   const {menuProps} = useMenu({...props, selectionMode: 'single'}, state, menuRef);
   const {separatorProps} = useSeparator({elementType: 'li'});
+
+  if (menuWidth) {
+    overlayPositionProps.style = {
+      ...overlayPositionProps.style,
+      width: menuWidth,
+      minWidth: minMenuWidth ?? overlayPositionProps.style?.minWidth,
+    };
+  }
 
   // If this is a submenu, pressing arrow left should close it (but not the
   // root menu).

--- a/static/app/components/dropdownMenu/list.tsx
+++ b/static/app/components/dropdownMenu/list.tsx
@@ -1,11 +1,4 @@
-import {
-  createContext,
-  type CSSProperties,
-  Fragment,
-  useContext,
-  useMemo,
-  useRef,
-} from 'react';
+import {createContext, Fragment, useContext, useMemo, useRef} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {FocusScope} from '@react-aria/focus';
@@ -72,27 +65,17 @@ export interface DropdownMenuListProps
    * Title to display on top of the menu
    */
   menuTitle?: React.ReactNode;
-  /**
-   * Set the menu width
-   */
-  menuWidth?: CSSProperties['width'];
-  /**
-   * Minimum menu width
-   */
-  minMenuWidth?: number;
   size?: MenuItemProps['size'];
 }
 
 function DropdownMenuList({
   closeOnSelect = true,
   onClose,
-  minMenuWidth,
   size,
   menuTitle,
   menuFooter,
   overlayState,
   overlayPositionProps,
-  menuWidth,
   ...props
 }: DropdownMenuListProps) {
   const {rootOverlayState, parentMenuState} = useContext(DropdownMenuContext);
@@ -245,15 +228,7 @@ function DropdownMenuList({
   );
   return (
     <FocusScope restoreFocus autoFocus>
-      <PositionWrapper
-        zIndex={theme.zIndex.dropdown}
-        {...overlayPositionProps}
-        style={{
-          ...overlayPositionProps.style,
-          width: menuWidth ?? overlayPositionProps.style?.width,
-          minWidth: minMenuWidth ?? overlayPositionProps.style?.minWidth,
-        }}
-      >
+      <PositionWrapper zIndex={theme.zIndex.dropdown} {...overlayPositionProps}>
         <DropdownMenuContext value={contextValue}>
           <StyledOverlay>
             {menuTitle && <MenuTitle>{menuTitle}</MenuTitle>}

--- a/static/app/components/dropdownMenu/list.tsx
+++ b/static/app/components/dropdownMenu/list.tsx
@@ -104,14 +104,6 @@ function DropdownMenuList({
   const {menuProps} = useMenu({...props, selectionMode: 'single'}, state, menuRef);
   const {separatorProps} = useSeparator({elementType: 'li'});
 
-  if (menuWidth) {
-    overlayPositionProps.style = {
-      ...overlayPositionProps.style,
-      width: menuWidth,
-      minWidth: minMenuWidth ?? overlayPositionProps.style?.minWidth,
-    };
-  }
-
   // If this is a submenu, pressing arrow left should close it (but not the
   // root menu).
   const {keyboardProps} = useKeyboard({
@@ -253,7 +245,15 @@ function DropdownMenuList({
   );
   return (
     <FocusScope restoreFocus autoFocus>
-      <PositionWrapper zIndex={theme.zIndex.dropdown} {...overlayPositionProps}>
+      <PositionWrapper
+        zIndex={theme.zIndex.dropdown}
+        {...overlayPositionProps}
+        style={{
+          ...overlayPositionProps.style,
+          width: menuWidth ?? overlayPositionProps.style?.width,
+          minWidth: minMenuWidth ?? overlayPositionProps.style?.minWidth,
+        }}
+      >
         <DropdownMenuContext value={contextValue}>
           <StyledOverlay>
             {menuTitle && <MenuTitle>{menuTitle}</MenuTitle>}
@@ -263,7 +263,6 @@ function DropdownMenuList({
               {...mergeProps(modifiedMenuProps, keyboardProps)}
               style={{
                 maxHeight: overlayPositionProps.style?.maxHeight,
-                minWidth: minMenuWidth ?? overlayPositionProps.style?.minWidth,
               }}
             >
               {renderCollection(stateCollection)}

--- a/static/app/views/discover/table/cellAction.tsx
+++ b/static/app/views/discover/table/cellAction.tsx
@@ -294,7 +294,6 @@ function CellAction(props: Props) {
               </ActionMenuTriggerV2>
             )}
             // So the menu doesn't fill the entire row which can lead to extremely wide menus
-            menuWidth={'fit-content'}
             minMenuWidth={0}
           />
         ) : (

--- a/static/app/views/discover/table/cellAction.tsx
+++ b/static/app/views/discover/table/cellAction.tsx
@@ -270,7 +270,7 @@ function CellAction(props: Props) {
       <Container
         data-test-id={cellActions === null ? undefined : 'cell-action-container'}
       >
-        {cellActions?.length && (
+        {cellActions?.length ? (
           <DropdownMenu
             items={cellActions}
             usePortal
@@ -297,6 +297,8 @@ function CellAction(props: Props) {
             menuWidth={'fit-content'}
             minMenuWidth={0}
           />
+        ) : (
+          children
         )}
       </Container>
     );

--- a/static/app/views/discover/table/cellAction.tsx
+++ b/static/app/views/discover/table/cellAction.tsx
@@ -368,11 +368,9 @@ const ActionMenuTrigger = styled(Button)`
   }
 `;
 
-const ActionMenuTriggerV2 = styled('div')<{text?: string}>`
+const ActionMenuTriggerV2 = styled('div')`
   :hover {
     cursor: pointer;
     font-weight: ${p => p.theme.fontWeight.bold};
   }
-  padding: ${p => p.theme.space.md};
-  margin: -${p => p.theme.space.md};
 `;


### PR DESCRIPTION
### Changes

Changed the trigger for `CellAction` to be the field itself rather than the ellipsis button. Hiding this behind a feature flag since it's used in many places and so that upcoming changes can be added behind it (see this [Figma doc](https://www.figma.com/design/mkSbiiywBMdE1iHponwEqa/Explore?node-id=4347-3835&t=1mjFjjFkGVMoTpAA-0) for details) 

### Video

https://github.com/user-attachments/assets/705df18d-3a9b-400f-8fb0-a8f3756a4aae

