### PR TITLE
ref(issues): Fix test util type issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,7 +146,6 @@ module = [
     "sentry.web.frontend.auth_login",
     "sentry_plugins.jira.plugin",
     "tests.sentry.api.helpers.test_group_index",
-    "tests.sentry.issues.test_utils",
 ]
 disable_error_code = [
     "arg-type",
@@ -533,6 +532,7 @@ module = [
     "tests.sentry.issues.test_status_change",
     "tests.sentry.issues.test_status_change_consumer",
     "tests.sentry.issues.test_update_inbox",
+    "tests.sentry.issues.test_utils",
     "tests.sentry.middleware.test_reporting_endpoint",
     "tests.sentry.nodestore.bigtable.test_backend",
     "tests.sentry.organizations.*",

--- a/tests/sentry/issues/test_utils.py
+++ b/tests/sentry/issues/test_utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import uuid
+from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from datetime import datetime, timedelta
 from typing import Any
@@ -58,7 +59,7 @@ class OccurrenceTestMixin:
         }
         kwargs.update(overrides)  # type: ignore[typeddict-item]
 
-        process_occurrence_data(kwargs)
+        process_occurrence_data(dict(kwargs))
         return kwargs
 
     def build_occurrence(self, **overrides: Any) -> IssueOccurrence:
@@ -99,7 +100,7 @@ class StatusChangeTestMixin:
         }
         kwargs.update(overrides)  # type: ignore[typeddict-item]
 
-        process_occurrence_data(kwargs)
+        process_occurrence_data(dict(kwargs))
         return kwargs
 
     def build_statuschange(self, **overrides: Any) -> StatusChangeMessage:
@@ -107,7 +108,12 @@ class StatusChangeTestMixin:
         return StatusChangeMessage(**self.build_statuschange_data(**overrides))
 
 
-class SearchIssueTestMixin(OccurrenceTestMixin):
+class SearchIssueTestMixin(OccurrenceTestMixin, ABC):
+
+    @abstractmethod
+    def store_event(self, data: dict[str, Any], project_id: int) -> Event:
+        raise NotImplementedError
+
     def store_search_issue(
         self,
         project_id: int,


### PR DESCRIPTION
Moving a file from the bad list to the good list.

I understand `cast` calls are a code smell, but genuinely don't think there's a better option here. The core issue is that `dict` and `TypedDict` only overlap via `Mapping`, and `process_occurrence_data` needs to know that the input is mutable.

Alternative solutions:
* Instantiate the data as a raw `dict` and then cast to the `TypedDict` types at the return point. 
* Move the `hash_fingerprint` calls up the stack, since we know the `"fingerprint"` key is present in these cases.

Would love to hear if any reviewers have thoughts / preferences between the potential solutions. (I feel that any of them would be better than leaving the code untyped, but feel free to disagree.)

Test plan: ran `mypy` and observed only pre-existing errors.