### PR TITLE
feat(ourlogs): Make table mode stable in url

### DIFF
--- a/static/app/views/explore/contexts/logs/logsPageParams.tsx
+++ b/static/app/views/explore/contexts/logs/logsPageParams.tsx
@@ -41,7 +41,6 @@ export const LOGS_FIELDS_KEY = 'logsFields';
 export const LOGS_AGGREGATE_FN_KEY = 'logsAggregate'; // e.g., p99
 export const LOGS_AGGREGATE_PARAM_KEY = 'logsAggregateParam'; // e.g., message.parameters.0
 export const LOGS_GROUP_BY_KEY = 'logsGroupBy'; // e.g., message.template
-export const LOGS_MODE_KEY = 'mode'; // 'aggregates' or 'table'
 
 const LOGS_AUTO_REFRESH_KEY = 'live';
 const LOGS_REFRESH_INTERVAL_KEY = 'refreshEvery';

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -31,10 +31,13 @@ import {
   useLogsAggregateFunction,
   useLogsFields,
   useLogsGroupBy,
+  useLogsMode,
   useLogsSearch,
   useSetLogsFields,
+  useSetLogsMode,
   useSetLogsPageParams,
 } from 'sentry/views/explore/contexts/logs/logsPageParams';
+import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {useTraceItemAttributes} from 'sentry/views/explore/contexts/traceItemAttributeContext';
 import {useLogAnalytics} from 'sentry/views/explore/hooks/useAnalytics';
 import {
@@ -78,6 +81,8 @@ export function LogsTabContent({
   const logsSearch = useLogsSearch();
   const fields = useLogsFields();
   const groupBy = useLogsGroupBy();
+  const mode = useLogsMode();
+  const setMode = useSetLogsMode();
   const setFields = useSetLogsFields();
   const setLogsPageParams = useSetLogsPageParams();
   const tableData = useLogsPageDataQueryResult();
@@ -105,11 +110,6 @@ export function LogsTabContent({
     },
     'explore.ourlogs.main-chart',
     DiscoverDatasets.OURLOGS
-  );
-  const [tableTab, setTableTab] = useState<'aggregates' | 'logs'>(
-    (aggregateFunction && aggregateFunction !== 'count') || groupBy
-      ? 'aggregates'
-      : 'logs'
   );
 
   const {attributes: stringAttributes, isLoading: stringAttributesLoading} =
@@ -177,6 +177,15 @@ export function LogsTabContent({
       {closeEvents: 'escape-key'}
     );
   }, [fields, setFields, stringAttributes, numberAttributes]);
+
+  const tableTab = mode === Mode.AGGREGATE ? 'aggregates' : 'logs';
+  const setTableTab = useCallback(
+    (tab: 'aggregates' | 'logs') => {
+      setMode(tab === 'aggregates' ? Mode.AGGREGATE : Mode.SAMPLES);
+    },
+    [setMode]
+  );
+
   return (
     <SearchQueryBuilderProvider {...searchQueryBuilderProps}>
       <TopSectionBody noRowGap>


### PR DESCRIPTION
### Summary
This makes table mode stable via url and doesn't switch you to aggregates when you load the the page if you manually switched to aggregate.


