### PR TITLE
fix(replay): add tooltips in replay full screen view

### DIFF
--- a/static/app/components/events/eventReplay/replayPreviewPlayer.tsx
+++ b/static/app/components/events/eventReplay/replayPreviewPlayer.tsx
@@ -5,6 +5,7 @@ import styled from '@emotion/styled';
 import {Alert} from 'sentry/components/core/alert';
 import {Button} from 'sentry/components/core/button';
 import {LinkButton, type LinkButtonProps} from 'sentry/components/core/button/linkButton';
+import {TooltipContext} from 'sentry/components/core/tooltip';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import ReplayCurrentScreen from 'sentry/components/replays/replayCurrentScreen';
@@ -119,63 +120,65 @@ export default function ReplayPreviewPlayer({
         </LinkButton>
       </HeaderWrapper>
       <PreviewPlayerContainer ref={fullscreenRef} isSidebarOpen={isSidebarOpen}>
-        <PlayerBreadcrumbContainer>
-          <PlayerContextContainer>
-            {isFullscreen ? (
-              <ContextContainer>
-                {isVideoReplay ? <ReplayCurrentScreen /> : <ReplayCurrentUrl />}
-                <BrowserOSIcons />
-                <ReplaySidebarToggleButton
-                  isOpen={isSidebarOpen}
-                  setIsOpen={setIsSidebarOpen}
+        <TooltipContext value={{container: fullscreenRef.current}}>
+          <PlayerBreadcrumbContainer>
+            <PlayerContextContainer>
+              {isFullscreen ? (
+                <ContextContainer>
+                  {isVideoReplay ? <ReplayCurrentScreen /> : <ReplayCurrentUrl />}
+                  <BrowserOSIcons />
+                  <ReplaySidebarToggleButton
+                    isOpen={isSidebarOpen}
+                    setIsOpen={setIsSidebarOpen}
+                  />
+                </ContextContainer>
+              ) : null}
+              <StaticPanel>
+                <ReplayPlayer overlayContent={overlayContent} isPreview />
+              </StaticPanel>
+            </PlayerContextContainer>
+            {isFullscreen && isSidebarOpen ? <Breadcrumbs /> : null}
+          </PlayerBreadcrumbContainer>
+          <ErrorBoundary mini>
+            <ButtonGrid>
+              {showNextAndPrevious && (
+                <Button
+                  size="sm"
+                  title={t('Previous Clip')}
+                  icon={<IconPrevious />}
+                  onClick={() => handleBackClick?.()}
+                  aria-label={t('Previous Clip')}
+                  disabled={!handleBackClick}
+                  analyticsEventName="Replay Preview Player: Clicked Previous Clip"
+                  analyticsEventKey="replay_preview_player.clicked_previous_clip"
                 />
-              </ContextContainer>
-            ) : null}
-            <StaticPanel>
-              <ReplayPlayer overlayContent={overlayContent} isPreview />
-            </StaticPanel>
-          </PlayerContextContainer>
-          {isFullscreen && isSidebarOpen ? <Breadcrumbs /> : null}
-        </PlayerBreadcrumbContainer>
-        <ErrorBoundary mini>
-          <ButtonGrid>
-            {showNextAndPrevious && (
-              <Button
-                size="sm"
-                title={t('Previous Clip')}
-                icon={<IconPrevious />}
-                onClick={() => handleBackClick?.()}
-                aria-label={t('Previous Clip')}
-                disabled={!handleBackClick}
-                analyticsEventName="Replay Preview Player: Clicked Previous Clip"
-                analyticsEventKey="replay_preview_player.clicked_previous_clip"
+              )}
+              <ReplayPlayPauseButton
+                analyticsEventName="Replay Preview Player: Clicked Play/Plause Clip"
+                analyticsEventKey="replay_preview_player.clicked_play_pause_clip"
+                priority={
+                  playPausePriority ?? (isFinished || isPlaying ? 'primary' : 'default')
+                }
               />
-            )}
-            <ReplayPlayPauseButton
-              analyticsEventName="Replay Preview Player: Clicked Play/Plause Clip"
-              analyticsEventKey="replay_preview_player.clicked_play_pause_clip"
-              priority={
-                playPausePriority ?? (isFinished || isPlaying ? 'primary' : 'default')
-              }
-            />
-            {showNextAndPrevious && (
-              <Button
-                size="sm"
-                title={t('Next Clip')}
-                icon={<IconNext />}
-                onClick={() => handleForwardClick?.()}
-                aria-label={t('Next Clip')}
-                disabled={!handleForwardClick}
-                analyticsEventName="Replay Preview Player: Clicked Next Clip"
-                analyticsEventKey="replay_preview_player.clicked_next_clip"
-              />
-            )}
-            <Container>
-              <TimeAndScrubberGrid />
-            </Container>
-            <ReplayFullscreenButton toggleFullscreen={toggleFullscreen} />
-          </ButtonGrid>
-        </ErrorBoundary>
+              {showNextAndPrevious && (
+                <Button
+                  size="sm"
+                  title={t('Next Clip')}
+                  icon={<IconNext />}
+                  onClick={() => handleForwardClick?.()}
+                  aria-label={t('Next Clip')}
+                  disabled={!handleForwardClick}
+                  analyticsEventName="Replay Preview Player: Clicked Next Clip"
+                  analyticsEventKey="replay_preview_player.clicked_next_clip"
+                />
+              )}
+              <Container>
+                <TimeAndScrubberGrid />
+              </Container>
+              <ReplayFullscreenButton toggleFullscreen={toggleFullscreen} />
+            </ButtonGrid>
+          </ErrorBoundary>
+        </TooltipContext>
       </PreviewPlayerContainer>
     </PlayerPanel>
   );

--- a/static/app/components/replays/replayView.tsx
+++ b/static/app/components/replays/replayView.tsx
@@ -137,7 +137,6 @@ function ReplayView({toggleFullscreen, isLoading}: Props) {
     return (
       <TooltipContext
         value={{
-          // When in fullscreen mode, tooltips must be rendered within the fullscreen
           // container instead of document.body to avoid being clipped. This ensures
           // that browser/OS icons and size information tooltips remain visible.
           // See: https://developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API#things_to_keep_in_mind

--- a/static/app/components/replays/replayView.tsx
+++ b/static/app/components/replays/replayView.tsx
@@ -2,7 +2,7 @@ import {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 
 import NegativeSpaceContainer from 'sentry/components/container/negativeSpaceContainer';
-import {Tooltip, TooltipContext} from 'sentry/components/core/tooltip';
+import {Tooltip} from 'sentry/components/core/tooltip';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import ExternalLink from 'sentry/components/links/externalLink';
 import QuestionTooltip from 'sentry/components/questionTooltip';
@@ -51,7 +51,7 @@ function ReplayView({toggleFullscreen, isLoading}: Props) {
     replays: replay ? [replay.getReplay()] : [],
   });
 
-  const content = (
+  return (
     <Fragment>
       <PlayerBreadcrumbContainer>
         <PlayerContainer>
@@ -132,20 +132,6 @@ function ReplayView({toggleFullscreen, isLoading}: Props) {
       ) : null}
     </Fragment>
   );
-
-  if (isFullscreen) {
-    return (
-      <TooltipContext
-        value={{
-          container: document.fullscreenElement,
-        }}
-      >
-        {content}
-      </TooltipContext>
-    );
-  }
-
-  return content;
 }
 
 const Panel = styled(FluidHeight)`

--- a/static/app/components/replays/replayView.tsx
+++ b/static/app/components/replays/replayView.tsx
@@ -137,7 +137,6 @@ function ReplayView({toggleFullscreen, isLoading}: Props) {
     return (
       <TooltipContext
         value={{
-          // that browser/OS icons and size information tooltips remain visible.
           container: document.fullscreenElement,
         }}
       >

--- a/static/app/components/replays/replayView.tsx
+++ b/static/app/components/replays/replayView.tsx
@@ -138,7 +138,6 @@ function ReplayView({toggleFullscreen, isLoading}: Props) {
       <TooltipContext
         value={{
           // that browser/OS icons and size information tooltips remain visible.
-          // See: https://developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API#things_to_keep_in_mind
           container: document.fullscreenElement,
         }}
       >

--- a/static/app/components/replays/replayView.tsx
+++ b/static/app/components/replays/replayView.tsx
@@ -137,7 +137,6 @@ function ReplayView({toggleFullscreen, isLoading}: Props) {
     return (
       <TooltipContext
         value={{
-          // container instead of document.body to avoid being clipped. This ensures
           // that browser/OS icons and size information tooltips remain visible.
           // See: https://developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API#things_to_keep_in_mind
           container: document.fullscreenElement,

--- a/static/app/components/replays/replayView.tsx
+++ b/static/app/components/replays/replayView.tsx
@@ -133,7 +133,6 @@ function ReplayView({toggleFullscreen, isLoading}: Props) {
     </Fragment>
   );
 
-  // In fullscreen mode, ensure tooltips are rendered within the fullscreen container
   // to prevent them from being clipped by the fullscreen boundary
   if (isFullscreen) {
     return (

--- a/static/app/components/replays/replayView.tsx
+++ b/static/app/components/replays/replayView.tsx
@@ -133,7 +133,6 @@ function ReplayView({toggleFullscreen, isLoading}: Props) {
     </Fragment>
   );
 
-  // to prevent them from being clipped by the fullscreen boundary
   if (isFullscreen) {
     return (
       <TooltipContext

--- a/static/app/components/replays/replayView.tsx
+++ b/static/app/components/replays/replayView.tsx
@@ -2,7 +2,7 @@ import {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 
 import NegativeSpaceContainer from 'sentry/components/container/negativeSpaceContainer';
-import {Tooltip} from 'sentry/components/core/tooltip';
+import {Tooltip, TooltipContext} from 'sentry/components/core/tooltip';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import ExternalLink from 'sentry/components/links/externalLink';
 import QuestionTooltip from 'sentry/components/questionTooltip';
@@ -51,7 +51,7 @@ function ReplayView({toggleFullscreen, isLoading}: Props) {
     replays: replay ? [replay.getReplay()] : [],
   });
 
-  return (
+  const content = (
     <Fragment>
       <PlayerBreadcrumbContainer>
         <PlayerContainer>
@@ -132,6 +132,26 @@ function ReplayView({toggleFullscreen, isLoading}: Props) {
       ) : null}
     </Fragment>
   );
+
+  // In fullscreen mode, ensure tooltips are rendered within the fullscreen container
+  // to prevent them from being clipped by the fullscreen boundary
+  if (isFullscreen) {
+    return (
+      <TooltipContext
+        value={{
+          // When in fullscreen mode, tooltips must be rendered within the fullscreen
+          // container instead of document.body to avoid being clipped. This ensures
+          // that browser/OS icons and size information tooltips remain visible.
+          // See: https://developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API#things_to_keep_in_mind
+          container: document.fullscreenElement,
+        }}
+      >
+        {content}
+      </TooltipContext>
+    );
+  }
+
+  return content;
 }
 
 const Panel = styled(FluidHeight)`

--- a/static/app/views/replays/detail/layout/replayLayout.tsx
+++ b/static/app/views/replays/detail/layout/replayLayout.tsx
@@ -1,6 +1,7 @@
 import {useRef} from 'react';
 import styled from '@emotion/styled';
 
+import {TooltipContext} from 'sentry/components/core/tooltip';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import Placeholder from 'sentry/components/placeholder';
 import ReplayController from 'sentry/components/replays/replayController';
@@ -44,9 +45,11 @@ export default function ReplayLayout({
 
   const video = (
     <VideoSection ref={fullscreenRef}>
-      <ErrorBoundary mini>
-        <ReplayView toggleFullscreen={toggleFullscreen} isLoading={isLoading} />
-      </ErrorBoundary>
+      <TooltipContext value={{container: fullscreenRef.current}}>
+        <ErrorBoundary mini>
+          <ReplayView toggleFullscreen={toggleFullscreen} isLoading={isLoading} />
+        </ErrorBoundary>
+      </TooltipContext>
     </VideoSection>
   );
 


### PR DESCRIPTION
In the Replay full screen view, the tooltips for browser, OS and resolution were missing.

This PR adds them to the full screen view.

<img width="1696" height="272" alt="Screenshot 2025-07-15 at 3 53 05 PM" src="https://github.com/user-attachments/assets/76c791f1-0d37-4f09-aad9-1dda0f8a6801" />

<img width="2010" height="324" alt="Screenshot 2025-07-15 at 3 52 59 PM" src="https://github.com/user-attachments/assets/056e759f-09f5-4ab3-9254-4ceb03bc09da" />