### PR TITLE
ref(issues): set default for related-issues feature to true

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -320,7 +320,7 @@ def register_temporary_features(manager: FeatureManager):
     # Enable the new Related Events feature
     manager.add("organizations:related-events", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enable related issues feature
-    manager.add("organizations:related-issues", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    manager.add("organizations:related-issues", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, default=True, api_expose=True)
     # Enable the release details performance section
     manager.add("organizations:release-comparison-performance", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable replay AI summaries

--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -91,6 +91,7 @@ class OrganizationSerializerTest(TestCase):
             "new-page-filter",
             "open-membership",
             "performance-tracing-without-performance",
+            "related-issues",
             "relay",
             "session-replay-ui",
             "shared-issues",


### PR DESCRIPTION
Set default of organizations:related-issues to True, as a part of work to remove it entirely, since it is already rolled out to everyone through [flagpole](https://github.com/getsentry/sentry-options-automator/blob/d9ae6c5433dac0cf70d2495fef29ee11edba8d85/options/default/flagpole.yml#L1379)