### PR TITLE
ref(deletions): Simplify groups deletion task

### DIFF
--- a/src/sentry/deletions/tasks/groups.py
+++ b/src/sentry/deletions/tasks/groups.py
@@ -1,10 +1,7 @@
 from collections.abc import Mapping, Sequence
 from typing import Any
-from uuid import uuid4
 
-import sentry_sdk
-
-from sentry.deletions.tasks.scheduled import MAX_RETRIES, logger
+from sentry.deletions.tasks.scheduled import MAX_RETRIES
 from sentry.exceptions import DeleteAborted
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task, retry, track_group_async_operation
@@ -36,53 +33,18 @@ def delete_groups(
     eventstream_state: Mapping[str, Any] | None = None,
     **kwargs: Any,
 ) -> None:
+    """
+    This task is used to delete groups in bulk.
+
+    Pass eventstream_state to the task in order to be notified when the groups have been deleted.
+    """
     from sentry import deletions, eventstream
     from sentry.models.group import Group
 
-    max_batch_size = 100
-    current_batch, rest = object_ids[:max_batch_size], object_ids[max_batch_size:]
+    groups_left = True
+    while groups_left:
+        task = deletions.get(model=Group, query={"id__in": object_ids})
+        groups_left = task.chunk()
 
-    # Select first_group from current_batch to ensure project_id tag reflects the current batch
-    first_group = Group.objects.filter(id__in=current_batch).order_by("id").first()
-    if not first_group:
-        raise DeleteAborted("delete_groups.no_group_found")
-
-    # The tags can be used if we want to find errors for when a task fails
-    sentry_sdk.set_tags(
-        {
-            "project_id": first_group.project_id,
-            "transaction_id": transaction_id,
-        },
-    )
-
-    transaction_id = transaction_id or uuid4().hex
-
-    logger.info(
-        "delete_groups.started",
-        extra={
-            "object_ids_count": len(object_ids),
-            "object_ids_current_batch": current_batch,
-            "first_id": first_group.id,
-            # These can be used when looking for logs in GCP
-            "project_id": first_group.project_id,
-            # All tasks initiated by the same request will have the same transaction_id
-            "transaction_id": transaction_id,
-        },
-    )
-
-    task = deletions.get(
-        model=Group, query={"id__in": current_batch}, transaction_id=transaction_id
-    )
-    has_more = task.chunk()
-    if has_more or rest:
-        delete_groups.apply_async(
-            kwargs={
-                "object_ids": object_ids if has_more else rest,
-                "transaction_id": transaction_id,
-                "eventstream_state": eventstream_state,
-            },
-        )
-    else:
-        # all groups have been deleted
-        if eventstream_state:
-            eventstream.backend.end_delete_groups(eventstream_state)
+    if eventstream_state:
+        eventstream.backend.end_delete_groups(eventstream_state)


### PR DESCRIPTION
Simplify the task by allowing the Group deletion task to manage its own state rather than scheduling a task per chunk of groups.