### PR TITLE
fix(crons): Ensure many in-progress checkins don't suppress timeouts

### DIFF
--- a/src/sentry/monitors/clock_tasks/check_missed.py
+++ b/src/sentry/monitors/clock_tasks/check_missed.py
@@ -9,6 +9,7 @@ from sentry_kafka_schemas.schema_types.monitors_clock_tasks_v1 import MarkMissin
 
 from sentry.constants import ObjectStatus
 from sentry.monitors.logic.mark_failed import mark_failed
+from sentry.monitors.logic.monitor_environment import update_monitor_environment
 from sentry.monitors.models import CheckInStatus, MonitorCheckIn, MonitorEnvironment, MonitorStatus
 from sentry.monitors.schedule import get_prev_schedule
 from sentry.utils import metrics
@@ -158,6 +159,9 @@ def mark_environment_missing(monitor_environment_id: int, ts: datetime):
         monitor.schedule,
     )
 
+    update_monitor_environment(
+        monitor_environment, monitor_environment.last_checkin, most_recent_expected_ts
+    )
     mark_failed(
         checkin,
         failed_at=most_recent_expected_ts,

--- a/src/sentry/monitors/clock_tasks/check_missed.py
+++ b/src/sentry/monitors/clock_tasks/check_missed.py
@@ -159,6 +159,10 @@ def mark_environment_missing(monitor_environment_id: int, ts: datetime):
         monitor.schedule,
     )
 
+    # Pass `monitor_environment.last_checkin` as last_checkin here, so that we don't
+    # change monitor_environment.last_checkin, and therefore do not advance the
+    # last_checkin for this enivronment (since this is a synthetic checkin, we don't
+    # want the UI to reflect that this was an actual checkin.)
     update_monitor_environment(
         monitor_environment, monitor_environment.last_checkin, most_recent_expected_ts
     )

--- a/src/sentry/monitors/consumers/monitor_consumer.py
+++ b/src/sentry/monitors/consumers/monitor_consumer.py
@@ -32,6 +32,10 @@ from sentry.monitors.clock_dispatch import try_monitor_clock_tick
 from sentry.monitors.constants import PermitCheckInStatus
 from sentry.monitors.logic.mark_failed import mark_failed
 from sentry.monitors.logic.mark_ok import mark_ok
+from sentry.monitors.logic.monitor_environment import (
+    monitor_has_newer_status_affecting_checkins,
+    update_monitor_environment,
+)
 from sentry.monitors.models import (
     CheckInStatus,
     Monitor,
@@ -954,9 +958,13 @@ def _process_checkin(item: CheckinItem, txn: Transaction | Span) -> None:
                 # Note: We use `start_time` for received here since it's the time that this
                 # checkin was received by relay. Potentially, `ts` should be the client
                 # timestamp. If we change that, leave `received` the same.
-                mark_failed(check_in, failed_at=start_time, received=start_time)
+                if not monitor_has_newer_status_affecting_checkins(
+                    monitor_environment, check_in.date_added
+                ):
+                    update_monitor_environment(monitor_environment, check_in.date_added, start_time)
+                    mark_failed(check_in, failed_at=start_time, received=start_time)
             else:
-                mark_ok(check_in, succeeded_at=start_time)
+                mark_ok(check_in, start_time)
 
             # track how much time it took for the message to make it through
             # relay into kafka. This should help us understand when missed

--- a/src/sentry/monitors/logic/mark_failed.py
+++ b/src/sentry/monitors/logic/mark_failed.py
@@ -3,10 +3,8 @@ from __future__ import annotations
 import logging
 from datetime import datetime
 
-from django.db.models import Q
-
 from sentry.monitors.logic.incidents import try_incident_threshold
-from sentry.monitors.models import CheckInStatus, MonitorCheckIn, MonitorEnvironment
+from sentry.monitors.models import MonitorCheckIn
 
 logger = logging.getLogger(__name__)
 
@@ -17,61 +15,8 @@ def mark_failed(
     received: datetime | None = None,
     clock_tick: datetime | None = None,
 ) -> bool:
-    """
-    Given a failing check-in, mark the monitor environment as failed and trigger
-    side effects for creating monitor incidents and issues.
-
-    The provided `failed_at` is the reference time for when the next check-in
-    time is calculated from. This typically would be the failed check-in's
-    `date_added` or completion time. Though for the missed and time-out tasks
-    this may be computed based on the tasks reference time.
-    """
-    monitor_env = failed_checkin.monitor_environment
-
     # Use the failure time as recieved if there is no received time
     if received is None:
         received = failed_at
 
-    # Compute the next check-in time from our reference time
-    next_checkin = monitor_env.monitor.get_next_expected_checkin(failed_at)
-    next_checkin_latest = monitor_env.monitor.get_next_expected_checkin_latest(failed_at)
-
-    # When the failed check-in is a synthetic missed check-in we do not move
-    # the `last_checkin` timestamp forward.
-    if failed_checkin.status == CheckInStatus.MISSED:
-        # When a monitor is MISSED it MUST have already had a `last_checkin`. A
-        # monitor cannot be missed without having checked in.
-        last_checkin = monitor_env.last_checkin
-    else:
-        last_checkin = failed_checkin.date_added
-
-    # Select the MonitorEnvironment for update. We ONLY want to update the
-    # monitor if there have not been newer check-ins.
-    monitors_to_update = MonitorEnvironment.objects.filter(
-        Q(last_checkin__lte=last_checkin) | Q(last_checkin__isnull=True),
-        id=monitor_env.id,
-    )
-
-    field_updates = {
-        "last_checkin": last_checkin,
-        "next_checkin": next_checkin,
-        "next_checkin_latest": next_checkin_latest,
-    }
-
-    affected = monitors_to_update.update(**field_updates)
-
-    # If we did not update the monitor environment it means there was a newer
-    # check-in. We have nothing to do in this case.
-    #
-    # XXX: The `affected` result is the number of rows returned from the
-    # filter. Not the number of rows that had their values modified by the
-    # update.
-    if not affected:
-        return False
-
-    # refresh the object from the database so we have the updated values in our
-    # cached instance
-    monitor_env.refresh_from_db()
-
-    # Create incidents + issues
     return try_incident_threshold(failed_checkin, received, clock_tick)

--- a/src/sentry/monitors/logic/mark_ok.py
+++ b/src/sentry/monitors/logic/mark_ok.py
@@ -22,7 +22,7 @@ def mark_ok(checkin: MonitorCheckIn, succeeded_at: datetime) -> None:
 
     monitor_environment = checkin.monitor_environment
 
-    incident_status = None
+    incident_status: int | None = None
     if try_incident_resolution(checkin):
         incident_status = MonitorStatus.OK
 

--- a/src/sentry/monitors/logic/mark_ok.py
+++ b/src/sentry/monitors/logic/mark_ok.py
@@ -2,19 +2,12 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime
-from typing import NotRequired, TypedDict
 
 from sentry.monitors.logic.incidents import try_incident_resolution
-from sentry.monitors.models import MonitorCheckIn, MonitorEnvironment, MonitorStatus
+from sentry.monitors.logic.monitor_environment import update_monitor_environment
+from sentry.monitors.models import MonitorCheckIn, MonitorStatus
 
 logger = logging.getLogger(__name__)
-
-
-class _Params(TypedDict):
-    last_checkin: datetime
-    next_checkin: datetime
-    next_checkin_latest: datetime
-    status: NotRequired[int]
 
 
 def mark_ok(checkin: MonitorCheckIn, succeeded_at: datetime) -> None:
@@ -26,22 +19,14 @@ def mark_ok(checkin: MonitorCheckIn, succeeded_at: datetime) -> None:
     time is calculated from. This typically would be when the successful
     check-in was received.
     """
-    monitor_env = checkin.monitor_environment
 
-    next_checkin = monitor_env.monitor.get_next_expected_checkin(succeeded_at)
-    next_checkin_latest = monitor_env.monitor.get_next_expected_checkin_latest(succeeded_at)
+    monitor_environment = checkin.monitor_environment
 
-    params: _Params = {
-        "last_checkin": checkin.date_added,
-        "next_checkin": next_checkin,
-        "next_checkin_latest": next_checkin_latest,
-    }
+    incident_status = None
+    if try_incident_resolution(checkin):
+        incident_status = MonitorStatus.OK
 
-    incident_resolved = try_incident_resolution(checkin)
-
-    if incident_resolved:
-        params["status"] = MonitorStatus.OK
-
-    MonitorEnvironment.objects.filter(id=monitor_env.id).exclude(
-        last_checkin__gt=succeeded_at
-    ).update(**params)
+    if monitor_environment.last_checkin is None or monitor_environment.last_checkin <= succeeded_at:
+        update_monitor_environment(
+            monitor_environment, checkin.date_added, succeeded_at, incident_status
+        )

--- a/src/sentry/monitors/logic/monitor_environment.py
+++ b/src/sentry/monitors/logic/monitor_environment.py
@@ -15,9 +15,9 @@ def monitor_has_newer_status_affecting_checkins(
 
 def update_monitor_environment(
     monitor_env: MonitorEnvironment,
-    last_checkin: datetime,
+    last_checkin: datetime | None,
     expected_ts: datetime,
-    monitor_status: CheckInStatus | None = None,
+    monitor_status: int | None = None,
 ):
     # Compute the next check-in time from our reference time
     next_checkin = monitor_env.monitor.get_next_expected_checkin(expected_ts)

--- a/src/sentry/monitors/logic/monitor_environment.py
+++ b/src/sentry/monitors/logic/monitor_environment.py
@@ -1,0 +1,34 @@
+from datetime import datetime
+
+from sentry.monitors.models import CheckInStatus, MonitorCheckIn, MonitorEnvironment
+
+
+def monitor_has_newer_status_affecting_checkins(
+    monitor_env: MonitorEnvironment, timestamp: datetime
+):
+    return MonitorCheckIn.objects.filter(
+        monitor_environment=monitor_env,
+        date_added__gt=timestamp,
+        status__in=[CheckInStatus.OK, CheckInStatus.ERROR],
+    ).exists()
+
+
+def update_monitor_environment(
+    monitor_env: MonitorEnvironment,
+    last_checkin: datetime,
+    expected_ts: datetime,
+    monitor_status: CheckInStatus | None = None,
+):
+    # Compute the next check-in time from our reference time
+    next_checkin = monitor_env.monitor.get_next_expected_checkin(expected_ts)
+    next_checkin_latest = monitor_env.monitor.get_next_expected_checkin_latest(expected_ts)
+
+    monitor_env.last_checkin = last_checkin
+    monitor_env.next_checkin = next_checkin
+    monitor_env.next_checkin_latest = next_checkin_latest
+    if monitor_status is not None:
+        monitor_env.status = monitor_status
+
+    monitor_env.save(
+        update_fields=["last_checkin", "next_checkin", "next_checkin_latest", "status"]
+    )

--- a/tests/sentry/monitors/clock_tasks/test_check_timeout.py
+++ b/tests/sentry/monitors/clock_tasks/test_check_timeout.py
@@ -204,11 +204,9 @@ class MonitorClockTasksCheckTimeoutTest(TestCase):
             id=checkin2.id, status=CheckInStatus.IN_PROGRESS
         ).exists()
 
-        # XXX(epurkhiser): We do NOT update the MonitorStatus, another check-in
-        # has already happened. It may be worth re-visiting this logic later.
         monitor_env = MonitorEnvironment.objects.filter(
             id=monitor_environment.id,
-            status=MonitorStatus.OK,
+            status=MonitorStatus.ERROR,
         )
         assert monitor_env.exists()
 

--- a/tests/sentry/monitors/consumers/test_end_to_end.py
+++ b/tests/sentry/monitors/consumers/test_end_to_end.py
@@ -10,18 +10,15 @@ from arroyo.backends.local.backend import LocalBroker
 from arroyo.backends.local.storages.memory import MemoryMessageStorage
 from arroyo.commit import ONCE_PER_SECOND
 from arroyo.processing.processor import StreamProcessor
-from arroyo.types import Partition, Topic
+from arroyo.types import BrokerValue, Message, Partition, Topic
 from django.test.utils import override_settings
 from django.utils import timezone
+from sentry_kafka_schemas.schema_types.ingest_monitors_v1 import CheckIn
 
 from sentry.monitors.clock_dispatch import try_monitor_clock_tick
 from sentry.monitors.consumers.clock_tasks_consumer import MonitorClockTasksStrategyFactory
 from sentry.monitors.consumers.clock_tick_consumer import MonitorClockTickStrategyFactory
-from sentry.monitors.consumers.monitor_consumer import (
-    BrokerValue,
-    Message,
-    StoreMonitorCheckInStrategyFactory,
-)
+from sentry.monitors.consumers.monitor_consumer import StoreMonitorCheckInStrategyFactory
 from sentry.monitors.models import (
     CheckInStatus,
     Monitor,
@@ -31,7 +28,7 @@ from sentry.monitors.models import (
     ScheduleType,
 )
 from sentry.monitors.processing_errors.errors import ProcessingErrorsException
-from sentry.monitors.types import CheckIn, CheckinItem
+from sentry.monitors.types import CheckinItem
 from sentry.testutils.cases import TestCase
 from sentry.utils import json
 

--- a/tests/sentry/monitors/consumers/test_end_to_end.py
+++ b/tests/sentry/monitors/consumers/test_end_to_end.py
@@ -1,0 +1,307 @@
+import contextlib
+import uuid
+from collections.abc import Generator
+from datetime import datetime, timedelta
+from unittest import mock
+
+import msgpack
+from arroyo.backends.kafka import KafkaPayload
+from arroyo.backends.local.backend import LocalBroker
+from arroyo.backends.local.storages.memory import MemoryMessageStorage
+from arroyo.commit import ONCE_PER_SECOND
+from arroyo.processing.processor import StreamProcessor
+from arroyo.types import Partition, Topic
+from django.test.utils import override_settings
+from django.utils import timezone
+
+from sentry.monitors.clock_dispatch import try_monitor_clock_tick
+from sentry.monitors.consumers.clock_tasks_consumer import MonitorClockTasksStrategyFactory
+from sentry.monitors.consumers.clock_tick_consumer import MonitorClockTickStrategyFactory
+from sentry.monitors.consumers.monitor_consumer import (
+    BrokerValue,
+    Message,
+    StoreMonitorCheckInStrategyFactory,
+)
+from sentry.monitors.models import (
+    CheckInStatus,
+    Monitor,
+    MonitorCheckIn,
+    MonitorEnvironment,
+    MonitorStatus,
+    ScheduleType,
+)
+from sentry.monitors.processing_errors.errors import ProcessingErrorsException
+from sentry.monitors.types import CheckIn, CheckinItem
+from sentry.testutils.cases import TestCase
+from sentry.utils import json
+
+
+class ExpectNoProcessingError:
+    pass
+
+
+partition = Partition(Topic("test"), 0)
+
+
+def create_consumer():
+    factory = StoreMonitorCheckInStrategyFactory()
+    commit = mock.Mock()
+    return factory.create_with_partitions(commit, {partition: 0})
+
+
+class MonitorsClockTickEndToEndTest(TestCase):
+    def send_checkin(
+        self,
+        status: str,
+        guid: str | None = None,
+        ts: datetime | None = None,
+        item_ts: datetime | None = None,
+    ) -> str:
+        if ts is None:
+            ts = self.time.replace(tzinfo=None)
+        if item_ts is None:
+            item_ts = ts
+
+        guid = uuid.uuid4().hex if not guid else guid
+        trace_id = uuid.uuid4().hex
+
+        payload = {
+            "monitor_slug": self.monitor.slug,
+            "status": status,
+            "check_in_id": guid,
+            "environment": "production",
+            "contexts": {"trace": {"trace_id": trace_id}},
+        }
+
+        wrapper: CheckIn = {
+            "message_type": "check_in",
+            "start_time": ts.timestamp(),
+            "project_id": self.project.id,
+            "payload": json.dumps(payload).encode(),
+            "sdk": "test/1.0",
+            "retention_days": 90,
+        }
+
+        with self.check_processing_errors(wrapper, None, None):
+            self.consumer.submit(
+                Message(
+                    BrokerValue(
+                        KafkaPayload(b"fake-key", msgpack.packb(wrapper), []),
+                        self.partition,
+                        1,
+                        item_ts,
+                    )
+                )
+            )
+        return guid
+
+    @contextlib.contextmanager
+    def check_processing_errors(
+        self,
+        expected_checkin: CheckIn,
+        expected_error: ProcessingErrorsException | ExpectNoProcessingError | None,
+        expected_monitor_slug: str | None,
+    ) -> Generator:
+        if expected_error is None:
+            yield None
+            return
+
+        with mock.patch(
+            "sentry.monitors.consumers.monitor_consumer.handle_processing_errors"
+        ) as handle_processing_errors:
+            yield
+
+            args_list = handle_processing_errors.call_args_list
+            if isinstance(expected_error, ExpectNoProcessingError):
+                assert len(args_list) == 0
+                return
+
+            assert len(args_list) == 1
+
+            checkin_item, error = args_list[0][0]
+            expected_checkin_item = CheckinItem(
+                datetime.fromtimestamp(expected_checkin["start_time"]),
+                self.partition.index,
+                expected_checkin,
+                json.loads(expected_checkin["payload"]),
+            )
+            if expected_monitor_slug:
+                expected_error.monitor = Monitor.objects.get(
+                    project_id=expected_checkin["project_id"], slug=expected_monitor_slug
+                )
+            assert checkin_item == expected_checkin_item
+            assert error.monitor == expected_error.monitor
+            assert error.processing_errors == expected_error.processing_errors
+
+    def init(self, checkin_margin=1, max_runtime=1):
+        self.time = timezone.now().replace(second=0, microsecond=0)
+        self.time_delta = timedelta(minutes=1)
+        self.broker: LocalBroker[KafkaPayload] = LocalBroker(MemoryMessageStorage())
+
+        self.clock_tick_topic = Topic("monitors-clock-tick")
+        self.clock_tasks_topic = Topic("monitors-clock-tasks")
+
+        self.broker.create_topic(self.clock_tick_topic, partitions=1)
+        self.broker.create_topic(self.clock_tasks_topic, partitions=1)
+
+        self.consumer = create_consumer()
+        self.partition = partition
+
+        # Setup one monitor which should be marked as missed, and one check-in that
+        # should be marked as timed-out
+        self.monitor = Monitor.objects.create(
+            organization_id=self.organization.id,
+            project_id=self.project.id,
+            config={
+                "schedule": "* * * * *",
+                "schedule_type": ScheduleType.CRONTAB,
+                "checkin_margin": checkin_margin,
+                "max_runtime": max_runtime,
+            },
+        )
+
+        self.monitor_environment = MonitorEnvironment.objects.ensure_environment(
+            self.project, self.monitor, "production"
+        )
+
+        self.monitor_environment.status = MonitorStatus.OK
+        self.monitor_environment.last_checkin = self.time
+        self.monitor_environment.next_checkin = self.time + self.time_delta
+        self.monitor_environment.next_checkin_latest = self.time + self.time_delta * 2
+        self.monitor_environment.save()
+
+        self.producer = self.broker.get_producer()
+        self.tick_consumer = self.broker.get_consumer("monitors-clock-tick")
+        self.tasks_consumer = self.broker.get_consumer("monitors-clock-tasks")
+        self.tick_processor = StreamProcessor(
+            consumer=self.tick_consumer,
+            topic=self.clock_tick_topic,
+            processor_factory=MonitorClockTickStrategyFactory(),
+            commit_policy=ONCE_PER_SECOND,
+        )
+
+        self.task_processor = StreamProcessor(
+            consumer=self.tasks_consumer,
+            topic=self.clock_tasks_topic,
+            processor_factory=MonitorClockTasksStrategyFactory(),
+            commit_policy=ONCE_PER_SECOND,
+        )
+
+    def tick_clock(self, delta: timedelta | None = None):
+        if delta is None:
+            delta = self.time_delta
+        self.time = self.time + delta
+        # Dispatch a clock tick
+        with mock.patch(
+            "sentry.monitors.clock_dispatch._clock_tick_producer",
+            self.producer,
+        ):
+            try_monitor_clock_tick(self.time, 0)
+
+        # Process the tick. This will produce two tasks, one for the missed
+        # check-in and one for the timed-out check-in. This will produce two
+        # tasks, one for the missed check-in and one for the timed-out check-in
+        with mock.patch(
+            "sentry.monitors.clock_tasks.producer._clock_task_producer",
+            self.producer,
+        ):
+            self.tick_processor._run_once()
+
+        # process the two tasks
+        self.task_processor._run_once()
+        self.task_processor._run_once()
+
+    @override_settings(SENTRY_EVENTSTREAM="sentry.eventstream.kafka.KafkaEventStream")
+    def test_two_in_progress_timeout(self):
+        self.init()
+
+        self.send_checkin("in_progress")
+
+        self.tick_clock()
+
+        self.send_checkin("in_progress")
+
+        self.tick_clock(timedelta(seconds=59))
+
+        self.monitor_environment.refresh_from_db()
+
+        checkins = list(MonitorCheckIn.objects.filter(monitor_environment=self.monitor_environment))
+        checkins.sort(key=lambda checkin: checkin.id)
+
+        assert checkins[0].status == CheckInStatus.TIMEOUT
+        assert checkins[1].status == CheckInStatus.IN_PROGRESS
+        assert self.monitor_environment.status == MonitorStatus.ERROR
+
+    @override_settings(SENTRY_EVENTSTREAM="sentry.eventstream.kafka.KafkaEventStream")
+    def test_timeout_followed_by_checkin(self):
+        self.init()
+
+        self.send_checkin("in_progress")
+
+        self.tick_clock()
+
+        guid = self.send_checkin("in_progress")
+
+        self.tick_clock(timedelta(seconds=1))
+
+        self.send_checkin("ok", guid)
+
+        self.tick_clock(timedelta(seconds=59))
+
+        self.monitor_environment.refresh_from_db()
+
+        checkins = list(MonitorCheckIn.objects.filter(monitor_environment=self.monitor_environment))
+        checkins.sort(key=lambda checkin: checkin.id)
+
+        assert len(checkins) == 2
+        assert checkins[0].status == CheckInStatus.TIMEOUT
+        assert checkins[1].status == CheckInStatus.OK
+        assert self.monitor_environment.status == MonitorStatus.OK
+
+    @override_settings(SENTRY_EVENTSTREAM="sentry.eventstream.kafka.KafkaEventStream")
+    def test_late_ok_followed_by_timeout(self):
+        self.init(1, 2)
+
+        first_guid = self.send_checkin("in_progress")
+
+        self.tick_clock()
+
+        self.send_checkin("in_progress")
+
+        self.tick_clock(timedelta(seconds=59))
+
+        self.send_checkin("ok", first_guid)
+
+        self.monitor_environment.refresh_from_db()
+
+        checkins = list(MonitorCheckIn.objects.filter(monitor_environment=self.monitor_environment))
+        checkins.sort(key=lambda checkin: checkin.id)
+
+        assert len(checkins) == 2
+        assert checkins[0].status == CheckInStatus.OK
+        assert checkins[1].status == CheckInStatus.IN_PROGRESS
+        assert self.monitor_environment.status == MonitorStatus.OK
+
+    @override_settings(SENTRY_EVENTSTREAM="sentry.eventstream.kafka.KafkaEventStream")
+    def test_late_ok_followed_by_missed(self):
+        self.init(1, 3)
+
+        first_guid = self.send_checkin("in_progress")
+
+        self.tick_clock()
+
+        self.tick_clock()
+
+        self.tick_clock(timedelta(seconds=59))
+
+        self.send_checkin("ok", first_guid)
+
+        self.monitor_environment.refresh_from_db()
+
+        checkins = list(MonitorCheckIn.objects.filter(monitor_environment=self.monitor_environment))
+        checkins.sort(key=lambda checkin: checkin.id)
+
+        assert len(checkins) == 2
+        assert checkins[0].status == CheckInStatus.OK
+        assert checkins[1].status == CheckInStatus.MISSED
+        assert self.monitor_environment.status == MonitorStatus.OK


### PR DESCRIPTION
This PR disentangles some of the logic around updating crons monitors statuses.  The original code had some overlapping (and even inconsistent/irrelevant) checks around checkin dates that made fixing the actual bug highly confusing and error-prone.  The result is that the mark_ok and mark_failed functions are fairly trivial, and the required time-period checks have been hoisted to the places they are used.

A few things to note:

- within mark_failed, on the MISSED_CHECKIN codepath, the original code would assign "monitor_environment.last_checkin" to the "last_checkin" variable, which would then be used in the query to filter for monitor environments with last_checkin <= last_checkin--i.e., it could not fail.
- this also means that mark_failed was always called on MISSED_CHECKIN; this is now reflected in the code
- removed a number of filters, since the values had already been loaded
- added a couple of new end-to-end tests