### PR TITLE
fix(aci): Simplify metric detector snuba query types

### DIFF
--- a/static/app/types/workflowEngine/detectors.tsx
+++ b/static/app/types/workflowEngine/detectors.tsx
@@ -125,7 +125,7 @@ type BaseDetector = Readonly<{
 export interface MetricDetector extends BaseDetector {
   readonly conditionGroup: DataConditionGroup | null;
   readonly config: MetricDetectorConfig;
-  readonly dataSources: SnubaQueryDataSource[];
+  readonly dataSources: [SnubaQueryDataSource];
   readonly type: 'metric_issue';
 }
 

--- a/static/app/views/detectors/components/details/metric/chart.tsx
+++ b/static/app/views/detectors/components/details/metric/chart.tsx
@@ -10,10 +10,7 @@ interface MetricDetectorDetailsChartProps {
 
 export function MetricDetectorDetailsChart({detector}: MetricDetectorDetailsChartProps) {
   const dataSource = detector.dataSources[0];
-  const snubaQuery =
-    dataSource?.type === 'snuba_query_subscription'
-      ? dataSource.queryObj?.snubaQuery
-      : undefined;
+  const snubaQuery = dataSource.queryObj?.snubaQuery;
 
   if (!snubaQuery) {
     // Unlikely, helps narrow types

--- a/static/app/views/detectors/components/details/metric/detect.tsx
+++ b/static/app/views/detectors/components/details/metric/detect.tsx
@@ -45,22 +45,7 @@ function SnubaQueryDetails({dataSource}: {dataSource: SnubaQueryDataSource}) {
 
 export function MetricDetectorDetailsDetect({detector}: MetricDetectorDetectProps) {
   const dataSource = detector.dataSources?.[0];
-  if (dataSource?.type === 'snuba_query_subscription') {
-    return <SnubaQueryDetails dataSource={dataSource} />;
-  }
-
-  return (
-    <Container>
-      <Flex direction="column" gap={space(0.5)}>
-        <Heading>{t('Query:')}</Heading>
-        <Query>
-          <Label>{t('visualize:')}</Label> <Value>placeholder</Value>
-          <Label>{t('where:')}</Label> <Value>placeholder</Value>
-        </Query>
-      </Flex>
-      <Heading>{t('Threshold:')}</Heading>
-    </Container>
-  );
+  return <SnubaQueryDetails dataSource={dataSource} />;
 }
 
 const Heading = styled('h4')`

--- a/static/app/views/detectors/components/forms/metric/metricDetectorChart.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricDetectorChart.tsx
@@ -134,6 +134,8 @@ export function MetricDetectorChart({
           // Hide the maximum y-axis label to avoid showing arbitrary threshold values
           showMaxLabel: false,
         },
+        // Disable the y-axis grid lines
+        splitLine: {show: false},
       }}
       grid={{
         left: space(0.25),

--- a/static/app/views/detectors/components/forms/metric/metricFormData.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricFormData.tsx
@@ -462,7 +462,7 @@ export function metricSavedDetectorToFormData(
     query: snubaQuery?.query || '',
     aggregateFunction,
     dataset,
-    interval: 60 * 60, // Default to 1 hour
+    interval: snubaQuery?.timeWindow ?? DEFAULT_THRESHOLD_METRIC_FORM_DATA.interval,
 
     // Priority level and condition fields from processed conditions
     ...conditionData,


### PR DESCRIPTION
Now that we're splitting detectors into metric detectors we can simplify the amount of type checking. Further simplify by making dataSources a tuple instead of an array.

Snuck in a small graph fix.
