### PR TITLE
ref(issues): remove related-issues flag check from frontend

### DIFF
--- a/static/app/views/issueDetails/groupSimilarIssues/similarIssues.spec.tsx
+++ b/static/app/views/issueDetails/groupSimilarIssues/similarIssues.spec.tsx
@@ -56,6 +56,10 @@ describe('Issues Similar View', function () {
       url: `/projects/org-slug/project-slug/`,
       body: {features: ['similarity-view']},
     });
+    MockApiClient.addMockResponse({
+      url: `/issues/${group.id}/related-issues/`,
+      body: {data: [], type: 'same_root_cause'},
+    });
     ProjectsStore.init();
     ProjectsStore.loadInitialData([project]);
   });
@@ -199,6 +203,10 @@ describe('Issues Similar Embeddings View', function () {
     MockApiClient.addMockResponse({
       url: `/projects/org-slug/project-slug/`,
       body: {features: ['similarity-embeddings']},
+    });
+    MockApiClient.addMockResponse({
+      url: `/issues/${group.id}/related-issues/`,
+      body: {data: [], type: 'same_root_cause'},
     });
     ProjectsStore.init();
     ProjectsStore.loadInitialData([project]);

--- a/static/app/views/issueDetails/groupSimilarIssues/similarIssues.tsx
+++ b/static/app/views/issueDetails/groupSimilarIssues/similarIssues.tsx
@@ -38,9 +38,7 @@ function GroupSimilarIssues() {
       <Feature features="similarity-view" project={project}>
         <SimilarStackTrace project={project} />
       </Feature>
-      <Feature features="related-issues">
-        <GroupRelatedIssues group={group} />
-      </Feature>
+      <GroupRelatedIssues group={group} />
     </Fragment>
   );
 }

--- a/static/app/views/issueDetails/groupSimilarIssues/similarIssuesDrawer.spec.tsx
+++ b/static/app/views/issueDetails/groupSimilarIssues/similarIssuesDrawer.spec.tsx
@@ -36,6 +36,10 @@ describe('SimilarIssuesDrawer', function () {
       url: `/projects/${organization.slug}/${project.slug}/`,
       body: {features: []},
     });
+    MockApiClient.addMockResponse({
+      url: `/issues/${group.id}/related-issues/`,
+      body: {data: [], type: 'same_root_cause'},
+    });
   });
 
   it('renders the content as expected', async function () {


### PR DESCRIPTION
Removes `related-issues` flag check gating on frontend, since it is rolled out to everyone through [flagpole](https://github.com/getsentry/sentry-options-automator/blob/d9ae6c5433dac0cf70d2495fef29ee11edba8d85/options/default/flagpole.yml#L1379). 

Related: https://github.com/getsentry/sentry/pull/95600