### PR TITLE
fix(grouping): Use real values for grouping config in example

### DIFF
--- a/src/sentry/apidocs/examples/project_examples.py
+++ b/src/sentry/apidocs/examples/project_examples.py
@@ -1,7 +1,5 @@
 from drf_spectacular.utils import OpenApiExample
 
-from sentry.projectoptions.defaults import DEFAULT_GROUPING_CONFIG, LEGACY_GROUPING_CONFIG
-
 KEY_RATE_LIMIT = {
     "id": "60120449b6b1d5e45f75561e6dabd80b",
     "name": "Liked Pegasus",
@@ -133,11 +131,11 @@ DETAILED_PROJECT = {
         "sentry:scrub_data": False,
         "sentry:token": "e84c8c0fb1c121e988558785885f9cde",
         "sentry:resolve_age": 168,
-        "sentry:grouping_config": DEFAULT_GROUPING_CONFIG,
+        "sentry:grouping_config": "newstyle:2012-12-31",
         "quotas:spike-protection-disabled": False,
         "sentry:store_crash_reports": 5,
         "digests:mail:minimum_delay": 180,
-        "sentry:secondary_grouping_config": LEGACY_GROUPING_CONFIG,
+        "sentry:secondary_grouping_config": "newstyle:2012-11-21",
         "sentry:secondary_grouping_expiry": 147555024,
         "sentry:builtin_symbol_sources": ["ios", "android", "chromium"],
         "sentry:origins": ["getsentry.com", "app.getsentry.com", "www.getsentry.com", "sentry.io"],
@@ -170,12 +168,12 @@ DETAILED_PROJECT = {
     "verifySSL": True,
     "scrubIPAddresses": False,
     "scrapeJavaScript": True,
-    "groupingConfig": DEFAULT_GROUPING_CONFIG,
+    "groupingConfig": "newstyle:2012-12-31",
     "groupingEnhancements": "",
     "groupingEnhancementsBase": None,
     "derivedGroupingEnhancements": "",
     "secondaryGroupingExpiry": 1687010243,
-    "secondaryGroupingConfig": LEGACY_GROUPING_CONFIG,
+    "secondaryGroupingConfig": "newstyle:2012-11-21",
     "fingerprintingRules": "",
     "organization": {
         "id": "1",


### PR DESCRIPTION
This switches from using constants to using actual values in our example project API response, since the idea is to have concrete example data there.