### PR TITLE
ref(aci): Rename metric detector "kind" to detectionType

### DIFF
--- a/static/app/components/workflowEngine/form/control/priorityControl.tsx
+++ b/static/app/components/workflowEngine/form/control/priorityControl.tsx
@@ -88,7 +88,9 @@ interface PriorityControlProps {
 }
 
 export default function PriorityControl({minimumPriority}: PriorityControlProps) {
-  const detectorKind = useMetricDetectorFormField(METRIC_DETECTOR_FORM_FIELDS.kind);
+  const detectionType = useMetricDetectorFormField(
+    METRIC_DETECTOR_FORM_FIELDS.detectionType
+  );
   const initialPriorityLevel = useMetricDetectorFormField(
     METRIC_DETECTOR_FORM_FIELDS.initialPriorityLevel
   );
@@ -100,7 +102,7 @@ export default function PriorityControl({minimumPriority}: PriorityControlProps)
   );
   const thresholdSuffix = getStaticDetectorThresholdSuffix(aggregate);
 
-  if (detectorKind === 'dynamic') {
+  if (detectionType === 'dynamic') {
     return null;
   }
 
@@ -109,11 +111,7 @@ export default function PriorityControl({minimumPriority}: PriorityControlProps)
       <PrioritizeRow
         left={
           <Flex align="center" direction="column">
-            {!detectorKind || detectorKind === 'static' ? (
-              <ThresholdPriority />
-            ) : (
-              <ChangePriority />
-            )}
+            {detectionType === 'static' ? <ThresholdPriority /> : <ChangePriority />}
             <SecondaryLabel>({t('issue created')})</SecondaryLabel>
           </Flex>
         }
@@ -134,7 +132,7 @@ export default function PriorityControl({minimumPriority}: PriorityControlProps)
                 name={METRIC_DETECTOR_FORM_FIELDS.mediumThreshold}
                 aria-label={t('Medium threshold')}
               />
-              <div>{conditionKindAndTypeToLabel[detectorKind][conditionType!]}</div>
+              <div>{conditionKindAndTypeToLabel[detectionType][conditionType!]}</div>
             </Flex>
           }
           right={<GroupPriorityBadge showLabel priority={PriorityLevel.MEDIUM} />}
@@ -155,7 +153,7 @@ export default function PriorityControl({minimumPriority}: PriorityControlProps)
                 name={METRIC_DETECTOR_FORM_FIELDS.highThreshold}
                 aria-label={t('High threshold')}
               />
-              <div>{conditionKindAndTypeToLabel[detectorKind][conditionType!]}</div>
+              <div>{conditionKindAndTypeToLabel[detectionType][conditionType!]}</div>
             </Flex>
           }
           right={<GroupPriorityBadge showLabel priority={PriorityLevel.HIGH} />}

--- a/static/app/views/detectors/components/forms/metric/metric.tsx
+++ b/static/app/views/detectors/components/forms/metric/metric.tsx
@@ -78,7 +78,7 @@ export function NewMetricDetectorForm() {
 }
 
 function MonitorKind() {
-  const options: Array<[MetricDetectorFormData['kind'], string, string]> = [
+  const options: Array<[MetricDetectorFormData['detectionType'], string, string]> = [
     ['static', t('Threshold'), t('Absolute-valued thresholds, for non-seasonal data.')],
     ['percent', t('Change'), t('Percentage changes over defined time windows.')],
     [
@@ -93,7 +93,7 @@ function MonitorKind() {
       label={t('\u2026and monitor for changes in the following way:')}
       flexibleControlStateSize
       inline={false}
-      name={METRIC_DETECTOR_FORM_FIELDS.kind}
+      name={METRIC_DETECTOR_FORM_FIELDS.detectionType}
       defaultValue="threshold"
       choices={options}
     />
@@ -101,7 +101,9 @@ function MonitorKind() {
 }
 
 function ResolveSection() {
-  const kind = useMetricDetectorFormField(METRIC_DETECTOR_FORM_FIELDS.kind);
+  const detectionType = useMetricDetectorFormField(
+    METRIC_DETECTOR_FORM_FIELDS.detectionType
+  );
   const conditionValue = useMetricDetectorFormField(
     METRIC_DETECTOR_FORM_FIELDS.conditionValue
   );
@@ -117,7 +119,7 @@ function ResolveSection() {
   const thresholdSuffix = getStaticDetectorThresholdSuffix(aggregate);
 
   const description = getResolutionDescription(
-    kind === 'percent'
+    detectionType === 'percent'
       ? {
           detectionType: 'percent',
           conditionType,
@@ -125,7 +127,7 @@ function ResolveSection() {
           comparisonDelta: conditionComparisonAgo ?? 3600, // Default to 1 hour if not set
           thresholdSuffix,
         }
-      : kind === 'static'
+      : detectionType === 'static'
         ? {
             detectionType: 'static',
             conditionType,
@@ -158,18 +160,20 @@ function AssignSection() {
 }
 
 function PrioritizeSection() {
-  const kind = useMetricDetectorFormField(METRIC_DETECTOR_FORM_FIELDS.kind);
+  const detectionType = useMetricDetectorFormField(
+    METRIC_DETECTOR_FORM_FIELDS.detectionType
+  );
   return (
     <Container>
       <Section
         title={t('Prioritize')}
         description={
-          kind === 'dynamic'
+          detectionType === 'dynamic'
             ? t('Sentry will automatically update priority.')
             : t('Update issue priority when the following thresholds are met:')
         }
       >
-        {kind !== 'dynamic' && (
+        {detectionType !== 'dynamic' && (
           <PriorityControl minimumPriority={DetectorPriorityLevel.MEDIUM} />
         )}
       </Section>
@@ -210,7 +214,9 @@ function useDatasetChoices() {
 }
 
 function DetectSection() {
-  const kind = useMetricDetectorFormField(METRIC_DETECTOR_FORM_FIELDS.kind);
+  const detectionType = useMetricDetectorFormField(
+    METRIC_DETECTOR_FORM_FIELDS.detectionType
+  );
   const datasetChoices = useDatasetChoices();
   const formContext = useContext(FormContext);
   const aggregate = useMetricDetectorFormField(
@@ -277,7 +283,7 @@ function DetectSection() {
         <Visualize />
         <MonitorKind />
         <Flex direction="column">
-          {(!kind || kind === 'static') && (
+          {(!detectionType || detectionType === 'static') && (
             <Flex direction="column">
               <MutedText>{t('An issue will be created when query value is:')}</MutedText>
               <Flex align="center" gap={space(1)}>
@@ -308,7 +314,7 @@ function DetectSection() {
               </Flex>
             </Flex>
           )}
-          {kind === 'percent' && (
+          {detectionType === 'percent' && (
             <Flex direction="column">
               <MutedText>{t('An issue will be created when query value is:')}</MutedText>
               <Flex align="center" gap={space(1)}>
@@ -359,7 +365,7 @@ function DetectSection() {
               </Flex>
             </Flex>
           )}
-          {kind === 'dynamic' && (
+          {detectionType === 'dynamic' && (
             <Flex direction="column">
               <SelectField
                 required

--- a/static/app/views/detectors/components/forms/metric/previewChart.tsx
+++ b/static/app/views/detectors/components/forms/metric/previewChart.tsx
@@ -32,12 +32,14 @@ export function MetricDetectorPreviewChart() {
   const initialPriorityLevel = useMetricDetectorFormField(
     METRIC_DETECTOR_FORM_FIELDS.initialPriorityLevel
   );
-  const kind = useMetricDetectorFormField(METRIC_DETECTOR_FORM_FIELDS.kind);
+  const detectionType = useMetricDetectorFormField(
+    METRIC_DETECTOR_FORM_FIELDS.detectionType
+  );
 
   // Create condition group from form data using the helper function
   const conditions = useMemo(() => {
     // Wait for a condition value to be defined
-    if (kind === 'static' && !conditionValue) {
+    if (detectionType === 'static' && !conditionValue) {
       return [];
     }
 
@@ -47,7 +49,7 @@ export function MetricDetectorPreviewChart() {
       initialPriorityLevel,
       highThreshold,
     });
-  }, [conditionType, conditionValue, initialPriorityLevel, highThreshold, kind]);
+  }, [conditionType, conditionValue, initialPriorityLevel, highThreshold, detectionType]);
 
   return (
     <ChartContainer>
@@ -59,7 +61,7 @@ export function MetricDetectorPreviewChart() {
         environment={environment}
         projectId={projectId}
         conditions={conditions}
-        detectionType={kind}
+        detectionType={detectionType}
       />
     </ChartContainer>
   );


### PR DESCRIPTION
Instead of making a new term, use the same word the backend uses. Use shared defaults
