### PR TITLE
feat(taskworker) Remove fetch_next logic from taskworker

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3188,11 +3188,6 @@ register(
     type=Int,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
-register(
-    "taskworker.fetch_next.disabled_pools",
-    default=[],
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 
 # Taskbroker rollout flags

--- a/src/sentry/taskworker/tasks/examples.py
+++ b/src/sentry/taskworker/tasks/examples.py
@@ -87,7 +87,7 @@ def at_most_once_task() -> None:
 @exampletasks.register(name="examples.timed")
 def timed_task(sleep_seconds: float | str, *args: list[Any], **kwargs: dict[str, Any]) -> None:
     sleep(float(sleep_seconds))
-    logger.debug("timed_task complete")
+    logger.info("timed_task complete")
 
 
 @exampletasks.register(name="examples.simple_task", compression_type=CompressionType.ZSTD)

--- a/tests/sentry/taskworker/test_worker.py
+++ b/tests/sentry/taskworker/test_worker.py
@@ -211,7 +211,6 @@ class TestTaskWorker(TestCase):
             assert (
                 mock_client.update_task.call_args.args[0].status == TASK_ACTIVATION_STATUS_COMPLETE
             )
-            assert mock_client.update_task.call_args.args[1] is None
 
     def test_run_once_with_next_task(self) -> None:
         # Cover the scenario where update_task returns the next task which should
@@ -250,11 +249,8 @@ class TestTaskWorker(TestCase):
             assert (
                 mock_client.update_task.call_args.args[0].status == TASK_ACTIVATION_STATUS_COMPLETE
             )
-            assert mock_client.update_task.call_args.args[1] is None
 
-    @override_options({"taskworker.fetch_next.disabled_pools": ["testing"]})
-    def test_run_once_with_fetch_next_disabled(self) -> None:
-        # Cover the scenario where taskworker.fetch_next.disabled_pools is defined
+    def test_run_once_multiple_get_and_update(self) -> None:
         max_runtime = 5
         taskworker = TaskWorker(
             rpc_host="127.0.0.1:50051",
@@ -287,7 +283,6 @@ class TestTaskWorker(TestCase):
             assert (
                 mock_client.update_task.call_args.args[0].status == TASK_ACTIVATION_STATUS_COMPLETE
             )
-            assert mock_client.update_task.call_args.args[1] is None
 
     def test_run_once_with_update_failure(self) -> None:
         # Cover the scenario where update_task fails a few times in a row
@@ -370,7 +365,6 @@ class TestTaskWorker(TestCase):
             assert (
                 mock_client.update_task.call_args.args[0].status == TASK_ACTIVATION_STATUS_COMPLETE
             )
-            assert mock_client.update_task.call_args.args[1] is None
 
             redis = redis_clusters.get("default")
             assert current_task() is None, "should clear current task on completion"


### PR DESCRIPTION
We've disabled fetch_next across all pools in production and have observed improvements in both rpc response time and reduced contention on multiprocessing queues. Since we aren't using fetch_next flows anymore I would like to remove this code to simplify worker logic.
