### PR TITLE
fix(security): Simplify permissions check for notification actions

### DIFF
--- a/src/sentry/notifications/api/endpoints/notification_actions_details.py
+++ b/src/sentry/notifications/api/endpoints/notification_actions_details.py
@@ -61,23 +61,24 @@ class NotificationActionsDetailsEndpoint(OrganizationEndpoint):
             raise ResourceDoesNotExist
 
         parsed_kwargs["action"] = action
+        action_projects = action.projects.all()
 
         # If the action has no projects, skip the project access check
-        if not action.projects.exists():
+        if not action_projects:
             return (parsed_args, parsed_kwargs)
 
         if request.method == "GET":
             # If we're reading the action, the user must have access to one of the associated projects
             if not any(
                 request.access.has_project_scope(project, "project:read")
-                for project in action.projects.all()
+                for project in action_projects
             ):
                 raise PermissionDenied
         else:
             # If we're modifying the action, the user must have access to all associated projects
             if not all(
                 request.access.has_project_scope(project, "project:write")
-                for project in action.projects.all()
+                for project in action_projects
             ):
                 raise PermissionDenied(
                     detail="You don't have sufficient permissions to all the projects associated with this action."

--- a/src/sentry/notifications/api/endpoints/notification_actions_index.py
+++ b/src/sentry/notifications/api/endpoints/notification_actions_index.py
@@ -32,21 +32,9 @@ logger = logging.getLogger(__name__)
 class NotificationActionsPermission(OrganizationPermission):
     scope_map = {
         "GET": ["org:read", "org:write", "org:admin"],
-        "POST": [
-            "org:read",
-            "org:write",
-            "org:admin",
-        ],
-        "PUT": [
-            "org:read",
-            "org:write",
-            "org:admin",
-        ],
-        "DELETE": [
-            "org:read",
-            "org:write",
-            "org:admin",
-        ],
+        "POST": ["org:read", "org:write", "org:admin"],
+        "PUT": ["org:read", "org:write", "org:admin"],
+        "DELETE": ["org:read", "org:write", "org:admin"],
     }
 
 

--- a/src/sentry/notifications/api/serializers/notification_action_request.py
+++ b/src/sentry/notifications/api/serializers/notification_action_request.py
@@ -87,7 +87,7 @@ Required if **service_type** is `slack` or `opsgenie`.
     )
     projects = serializers.ListField(
         help_text="""List of projects slugs that the Notification Action is created for.""",
-        child=ProjectField(scope="project:read"),
+        child=ProjectField(scope="project:write"),
         required=False,
     )
     # Optional and not needed for spike protection so not documenting

--- a/tests/sentry/notifications/api/endpoints/test_notification_actions_details.py
+++ b/tests/sentry/notifications/api/endpoints/test_notification_actions_details.py
@@ -471,7 +471,7 @@ class NotificationActionsDetailsEndpointTest(APITestCase):
 
         self.test_delete_simple()
 
-    def test_bonus_get_respects_multiple_project_access(self):
+    def test_get_respects_multiple_project_access(self):
         # Disable open membership
         self.organization.flags.allow_joinleave = False
         self.organization.save()
@@ -500,7 +500,7 @@ class NotificationActionsDetailsEndpointTest(APITestCase):
             method="GET",
         )
 
-    def test_bonus_delete_respects_multiple_project_access(self):
+    def test_delete_respects_multiple_project_access(self):
         # Disable open membership
         self.organization.flags.allow_joinleave = False
         self.organization.save()
@@ -508,6 +508,8 @@ class NotificationActionsDetailsEndpointTest(APITestCase):
         user = self.create_user()
         member = self.create_member(user=user, organization=self.organization)
         team = self.create_team(name="mobile", organization=self.organization)
+        # Unrelated team, shouldn't affect anything
+        self.create_team(name="desktop", organization=self.organization, members=[user])
         team_membership = OrganizationMemberTeam.objects.create(
             team=team, organizationmember=member, role="contributor"
         )


### PR DESCRIPTION
Simplifies the permission checks for notification action updates. Rather than filtering the notification action by project, just retrieve it and ensure the user has access to the associated projects.

Adds a few tests to ensure that to write to or delete an action with multiple projects, you need write permissions to all projects. For retrieval, you only need read permissions one of them.