### PR TITLE
ref(workflow_engine): Use the metric alert feature flag

### DIFF
--- a/src/sentry/issues/status_change_consumer.py
+++ b/src/sentry/issues/status_change_consumer.py
@@ -157,11 +157,12 @@ def update_status(group: Group, status_change: StatusChangeMessageData) -> None:
             .first()
         )
         if latest_activity is not None:
+            metrics.incr(
+                "workflow_engine.issue_platform.status_change_handler",
+                amount=len(metrics),
+                tags={"activity_type": activity_type.value},
+            )
             for handler in group_status_update_registry.registrations.values():
-                metrics.incr(
-                    "workflow_engine.issue_platform.status_change_handler",
-                    tags={"activity_type": activity_type.value},
-                )
                 handler(group, status_change, latest_activity)
 
 

--- a/src/sentry/issues/status_change_consumer.py
+++ b/src/sentry/issues/status_change_consumer.py
@@ -144,6 +144,13 @@ def update_status(group: Group, status_change: StatusChangeMessageData) -> None:
             f"Unsupported status: {status_change['new_status']} {status_change['new_substatus']}"
         )
 
+    if status_change.get("detector_id"):
+        # issue platform received an object from the detector
+        metrics.incr(
+            "workflow_engine.issue_platform.status_change",
+            tags={"activity_type": activity_type.value if activity_type else "none"},
+        )
+
     if activity_type is not None:
         """
         If we have set created an activity, then we'll also notify any registered handlers
@@ -158,6 +165,10 @@ def update_status(group: Group, status_change: StatusChangeMessageData) -> None:
         )
         if latest_activity is not None:
             for handler in group_status_update_registry.registrations.values():
+                metrics.incr(
+                    "workflow_engine.issue_platform.status_change_handler",
+                    tags={"activity_type": activity_type.value},
+                )
                 handler(group, status_change, latest_activity)
 
 

--- a/src/sentry/issues/status_change_consumer.py
+++ b/src/sentry/issues/status_change_consumer.py
@@ -159,7 +159,7 @@ def update_status(group: Group, status_change: StatusChangeMessageData) -> None:
         if latest_activity is not None:
             metrics.incr(
                 "workflow_engine.issue_platform.status_change_handler",
-                amount=len(metrics),
+                amount=len(group_status_update_registry.registrations.keys()),
                 tags={"activity_type": activity_type.value},
             )
             for handler in group_status_update_registry.registrations.values():

--- a/src/sentry/issues/status_change_consumer.py
+++ b/src/sentry/issues/status_change_consumer.py
@@ -144,13 +144,6 @@ def update_status(group: Group, status_change: StatusChangeMessageData) -> None:
             f"Unsupported status: {status_change['new_status']} {status_change['new_substatus']}"
         )
 
-    if status_change.get("detector_id"):
-        # issue platform received an object from the detector
-        metrics.incr(
-            "workflow_engine.issue_platform.status_change",
-            tags={"activity_type": activity_type.value if activity_type else "none"},
-        )
-
     if activity_type is not None:
         """
         If we have set created an activity, then we'll also notify any registered handlers

--- a/src/sentry/workflow_engine/tasks/workflows.py
+++ b/src/sentry/workflow_engine/tasks/workflows.py
@@ -104,7 +104,7 @@ def workflow_status_update_handler(
         metrics.incr("workflow_engine.tasks.error.no_detector_id")
         return
 
-    if features.has("organizations:workflow-engine-process-activity", group.organization):
+    if features.has("organizations:workflow-engine-metric-alert-processing", group.organization):
         process_workflow_activity.delay(
             activity_id=activity.id,
             group_id=group.id,

--- a/src/sentry/workflow_engine/tasks/workflows.py
+++ b/src/sentry/workflow_engine/tasks/workflows.py
@@ -73,7 +73,7 @@ def process_workflow_activity(activity_id: int, group_id: int, detector_id: int)
 
     process_workflows(event_data, detector)
     metrics.incr(
-        "workflow_engine.process_workflow.activity_update.executed",
+        "workflow_engine.tasks.process_workflow.activity_update.executed",
         tags={"activity_type": activity.type},
     )
 
@@ -86,9 +86,11 @@ def workflow_status_update_handler(
     Hook the process_workflow_task into the activity creation registry.
 
     Since this handler is called in process for the activity, we want
-    to queue a task to process workflows asynchronously."""
+    to queue a task to process workflows asynchronously.
+    """
     metrics.incr(
-        "workflow_engine.process_workflow.activity_update", tags={"activity_type": activity.type}
+        "workflow_engine.tasks.process_workflows.activity_update",
+        tags={"activity_type": activity.type},
     )
     if activity.type not in SUPPORTED_ACTIVITIES:
         # If the activity type is not supported, we do not need to process it.
@@ -99,7 +101,7 @@ def workflow_status_update_handler(
     if detector_id is None:
         # We should not hit this case, it's should only occur if there is a bug
         # passing it from the workflow_engine to the issue platform.
-        metrics.incr("workflow_engine.error.tasks.no_detector_id")
+        metrics.incr("workflow_engine.tasks.error.no_detector_id")
         return
 
     if features.has("organizations:workflow-engine-process-activity", group.organization):

--- a/src/sentry/workflow_engine/tasks/workflows.py
+++ b/src/sentry/workflow_engine/tasks/workflows.py
@@ -73,7 +73,7 @@ def process_workflow_activity(activity_id: int, group_id: int, detector_id: int)
 
     process_workflows(event_data, detector)
     metrics.incr(
-        "workflow_engine.tasks.process_workflow.activity_update.executed",
+        "workflow_engine.tasks.process_workflows.activity_update.executed",
         tags={"activity_type": activity.type},
     )
 

--- a/tests/sentry/incidents/test_metric_issue_post_process.py
+++ b/tests/sentry/incidents/test_metric_issue_post_process.py
@@ -214,6 +214,6 @@ class MetricIssueIntegrationTest(BaseWorkflowTest, BaseMetricIssueTest):
             with self.tasks():
                 update_status(group, message)
             mock_incr.assert_any_call(
-                "workflow_engine.process_workflow.activity_update.executed",
+                "workflow_engine.tasks.process_workflows.activity_update.executed",
                 tags={"activity_type": ActivityType.SET_RESOLVED.value},
             )

--- a/tests/sentry/incidents/test_metric_issue_post_process.py
+++ b/tests/sentry/incidents/test_metric_issue_post_process.py
@@ -163,7 +163,7 @@ class MetricIssueIntegrationTest(BaseWorkflowTest, BaseMetricIssueTest):
         self.call_post_process_group(occurrence)
         assert mock_trigger.call_count == 2  # both actions
 
-    @with_feature("organizations:workflow-engine-process-activity")
+    @with_feature("organizations:workflow-engine-metric-alert-processing")
     def test_resolution_from_critical(self, mock_trigger):
         value = self.critical_detector_trigger.comparison + 1
         data_packet = self.create_subscription_packet(value)
@@ -186,11 +186,11 @@ class MetricIssueIntegrationTest(BaseWorkflowTest, BaseMetricIssueTest):
             with self.tasks():
                 update_status(group, message)
             mock_incr.assert_any_call(
-                "workflow_engine.process_workflow.activity_update.executed",
+                "workflow_engine.tasks.process_workflows.activity_update.executed",
                 tags={"activity_type": ActivityType.SET_RESOLVED.value},
             )
 
-    @with_feature("organizations:workflow-engine-process-activity")
+    @with_feature("organizations:workflow-engine-metric-alert-processing")
     def test_resolution_from_warning(self, mock_trigger):
         value = self.warning_detector_trigger.comparison + 1
         data_packet = self.create_subscription_packet(value)

--- a/tests/sentry/workflow_engine/test_task.py
+++ b/tests/sentry/workflow_engine/test_task.py
@@ -217,16 +217,11 @@ class TestProcessWorkflowActivity(TestCase):
             new_status=GroupStatus.RESOLVED,
             new_substatus=None,
             detector_id=self.detector.id,
+            activity_data={},
         )
 
         with self.tasks():
             update_status(self.group, self.message)
-
-            # Ensure task is evaluated in issue platform
-            mock_incr.assert_any_call(
-                "workflow_engine.issue_platform.status_change",
-                tags={"activity_type": self.activity.type},
-            )
 
             # Issue platform is forwarding the activity update
             mock_incr.assert_any_call(

--- a/tests/sentry/workflow_engine/test_task.py
+++ b/tests/sentry/workflow_engine/test_task.py
@@ -226,6 +226,7 @@ class TestProcessWorkflowActivity(TestCase):
             # Issue platform is forwarding the activity update
             mock_incr.assert_any_call(
                 "workflow_engine.issue_platform.status_change_handler",
+                amount=1,
                 tags={"activity_type": self.activity.type},
             )
 

--- a/tests/sentry/workflow_engine/test_task.py
+++ b/tests/sentry/workflow_engine/test_task.py
@@ -91,7 +91,7 @@ class WorkflowStatusUpdateHandlerTests(TestCase):
             workflow_status_update_handler(group, message, activity)
             mock_delay.assert_not_called()
 
-    @with_feature("organizations:workflow-engine-process-activity")
+    @with_feature("organizations:workflow-engine-metric-alert-processing")
     def test(self):
         detector = self.create_detector(project=self.project)
         group = self.create_group(project=self.project)
@@ -207,7 +207,7 @@ class TestProcessWorkflowActivity(TestCase):
 
         mock_filter_actions.assert_called_once_with({self.action_group}, expected_event_data)
 
-    @with_feature("organizations:workflow-engine-process-activity")
+    @with_feature("organizations:workflow-engine-metric-alert-processing")
     @mock.patch("sentry.workflow_engine.tasks.workflows.metrics.incr")
     def test__e2e__issue_plat_to_processed(self, mock_incr):
         self.message = StatusChangeMessageData(

--- a/tests/sentry/workflow_engine/test_task.py
+++ b/tests/sentry/workflow_engine/test_task.py
@@ -238,6 +238,6 @@ class TestProcessWorkflowActivity(TestCase):
 
             # Workflow engine evaluated activity update in process_workflows
             mock_incr.assert_any_call(
-                "workflow_engine.tasks.process_workflow.activity_update.executed",
+                "workflow_engine.tasks.process_workflows.activity_update.executed",
                 tags={"activity_type": self.activity.type},
             )

--- a/tests/sentry/workflow_engine/test_task_integration.py
+++ b/tests/sentry/workflow_engine/test_task_integration.py
@@ -45,7 +45,7 @@ class IssuePlatformIntegrationTests(TestCase):
             _process_message(message)
 
             mock_incr.assert_any_call(
-                "workflow_engine.process_workflow.activity_update",
+                "workflow_engine.tasks.process_workflows.activity_update",
                 tags={"activity_type": ActivityType.SET_RESOLVED.value},
             )
 
@@ -68,6 +68,6 @@ class IssuePlatformIntegrationTests(TestCase):
         with mock.patch("sentry.workflow_engine.tasks.workflows.metrics.incr") as mock_incr:
             update_status(self.group, message)
             mock_incr.assert_any_call(
-                "workflow_engine.process_workflow.activity_update",
+                "workflow_engine.tasks.process_workflows.activity_update",
                 tags={"activity_type": ActivityType.SET_RESOLVED.value},
             )


### PR DESCRIPTION
## Description
- Add e2e test to ensure all metrics are triggered as expected through an activity update
- Use the metric processing feature flag to gate these updates, so we only need to maintain one flag
- Normalize task metrics with `workflow_engine.tasks` prefix.