### PR TITLE
feat(seer): New settings onboarding

### DIFF
--- a/static/app/components/events/autofix/preferences/hooks/useProjectSeerPreferences.ts
+++ b/static/app/components/events/autofix/preferences/hooks/useProjectSeerPreferences.ts
@@ -11,7 +11,7 @@ export interface SeerPreferencesResponse {
   preference?: ProjectSeerPreferences | null;
 }
 
-export function makeProjectSeerPreferencesQueryKey(orgSlug: string, projectSlug: string) {
+function makeProjectSeerPreferencesQueryKey(orgSlug: string, projectSlug: string) {
   return `/projects/${orgSlug}/${projectSlug}/seer/preferences/`;
 }
 

--- a/static/app/views/settings/organization/navigationConfiguration.tsx
+++ b/static/app/views/settings/organization/navigationConfiguration.tsx
@@ -140,6 +140,18 @@ export function getOrganizationNavigationConfiguration({
           description: t('Set up feature flag integrations'),
         },
         {
+          path: `${organizationSettingsPathPrefix}/seer/`,
+          title: t('Seer Automation'),
+          description: t(
+            "Manage settings for Seer's automated analysis across your organization"
+          ),
+          show: ({organization}) =>
+            !!organization &&
+            organization.features.includes('trigger-autofix-on-issue-summary') &&
+            !organization.hideAiFeatures,
+          id: 'seer',
+        },
+        {
           path: `${organizationSettingsPathPrefix}/stats/`,
           title: t('Stats & Usage'),
           description: t('View organization stats and usage'),

--- a/static/app/views/settings/organization/userOrgNavigationConfiguration.tsx
+++ b/static/app/views/settings/organization/userOrgNavigationConfiguration.tsx
@@ -176,6 +176,18 @@ export function getUserOrgNavigationConfiguration(): NavigationSection[] {
           title: t('Feature Flags'),
           description: t('Set up feature flag integrations'),
         },
+        {
+          path: `${organizationSettingsPathPrefix}/seer/`,
+          title: t('Seer Automation'),
+          description: t(
+            "Manage settings for Seer's automated analysis across your organization"
+          ),
+          show: ({organization}) =>
+            !!organization &&
+            organization.features.includes('trigger-autofix-on-issue-summary') &&
+            !organization.hideAiFeatures,
+          id: 'seer',
+        },
       ],
     },
     {

--- a/static/app/views/settings/projectSeer/index.tsx
+++ b/static/app/views/settings/projectSeer/index.tsx
@@ -12,6 +12,7 @@ import Form from 'sentry/components/forms/form';
 import JsonForm from 'sentry/components/forms/jsonForm';
 import type {FieldObject, JsonFormObject} from 'sentry/components/forms/types';
 import HookOrDefault from 'sentry/components/hookOrDefault';
+import ExternalLink from 'sentry/components/links/externalLink';
 import {NoAccess} from 'sentry/components/noAccess';
 import Placeholder from 'sentry/components/placeholder';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
@@ -153,12 +154,14 @@ function ProjectSeerGeneralForm({project}: ProjectSeerProps) {
           {t('Automation')}
           <Subheading>
             {tct(
-              "Choose how Seer automatically triages and root-causes incoming issues, before you even notice them. This analysis is billed at the [link:standard rates] for Seer's Issue Scan and Issue Fix. See [spendlink:docs] on how to manage your Seer spend. You can also [bulklink:configure automation for other projects].",
+              "Choose how Seer automatically triages and diagnoses incoming issues, before you even notice them. This analysis is billed at the [link:standard rates] for Seer's Issue Scan and Issue Fix. See [spendlink:docs] on how to manage your Seer spend. You can also [bulklink:configure automation for other projects].",
               {
-                link: <Link to={'https://docs.sentry.io/pricing/#seer-pricing'} />,
+                link: (
+                  <ExternalLink href={'https://docs.sentry.io/pricing/#seer-pricing'} />
+                ),
                 spendlink: (
-                  <Link
-                    to={getPricingDocsLinkForEventType(DataCategoryExact.SEER_AUTOFIX)}
+                  <ExternalLink
+                    href={getPricingDocsLinkForEventType(DataCategoryExact.SEER_AUTOFIX)}
                   />
                 ),
                 bulklink: <Link to={`/settings/${organization.slug}/seer/`} />,

--- a/static/gsApp/components/gsBillingNavigationConfig.tsx
+++ b/static/gsApp/components/gsBillingNavigationConfig.tsx
@@ -58,14 +58,6 @@ class GSBillingNavigationConfig extends Component<Props> {
         id: 'spike',
       },
       {
-        path: `${prefix}/seer/`,
-        title: t('Seer Automation'),
-        show: () =>
-          organization.features.includes('trigger-autofix-on-issue-summary') &&
-          !organization.hideAiFeatures,
-        id: 'seer',
-      },
-      {
         path: `${prefix}/subscription/redeem-code/`,
         title: t('Redeem Promo Code'),
         id: 'promo',

--- a/static/gsApp/hooks/settingsRoutes.tsx
+++ b/static/gsApp/hooks/settingsRoutes.tsx
@@ -68,11 +68,14 @@ const settingsRoutes = () =>
         name="Spike Protection"
         component={make(() => import('../views/spikeProtection'))}
       />
-      <Route
-        path="seer/"
-        name="Seer Automation"
-        component={make(() => import('../views/seerAutomation'))}
-      />
+      <Route path="seer/" name="Seer Automation">
+        <IndexRoute component={make(() => import('../views/seerAutomation'))} />
+        <Route
+          path="onboarding/"
+          name="Configure Seer for All Projects"
+          component={make(() => import('../views/seerAutomation/onboarding'))}
+        />
+      </Route>
 
       <Route
         path="subscription/spend-allocations/"

--- a/static/gsApp/views/seerAutomation/index.tsx
+++ b/static/gsApp/views/seerAutomation/index.tsx
@@ -1,7 +1,8 @@
 import {Fragment} from 'react';
 
-import {Link} from 'sentry/components/core/link';
+import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {useOrganizationSeerSetup} from 'sentry/components/events/autofix/useOrganizationSeerSetup';
+import ExternalLink from 'sentry/components/links/externalLink';
 import {NoAccess} from 'sentry/components/noAccess';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
 import Placeholder from 'sentry/components/placeholder';
@@ -66,14 +67,24 @@ function SeerAutomationRoot() {
       <SettingsPageHeader
         title={t('Seer Automation')}
         subtitle={tct(
-          "Choose how Seer automatically triages and root-causes incoming issues, before you even notice them. This analysis is billed at the [link:standard rates] for Seer's Issue Scan and Issue Fix. See [spendlink:docs] on how to manage your Seer spend.",
+          "Choose how Seer automatically triages and diagnoses incoming issues, before you even notice them. This analysis is billed at the [link:standard rates] for Seer's Issue Scan and Issue Fix. See [spendlink:docs] on how to manage your Seer spend.",
           {
-            link: <Link to={'https://docs.sentry.io/pricing/#seer-pricing'} />,
+            link: <ExternalLink href={'https://docs.sentry.io/pricing/#seer-pricing'} />,
             spendlink: (
-              <Link to={getPricingDocsLinkForEventType(DataCategoryExact.SEER_AUTOFIX)} />
+              <ExternalLink
+                href={getPricingDocsLinkForEventType(DataCategoryExact.SEER_AUTOFIX)}
+              />
             ),
           }
         )}
+        action={
+          <LinkButton
+            href={'https://docs.sentry.io/product/ai-in-sentry/seer/#seer-capabilities'}
+            external
+          >
+            {t('Read the docs')}
+          </LinkButton>
+        }
       />
 
       <NoProjectMessage organization={organization}>

--- a/static/gsApp/views/seerAutomation/onboarding.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding.tsx
@@ -1,0 +1,719 @@
+import {Fragment, useCallback, useEffect, useMemo, useState} from 'react';
+import styled from '@emotion/styled';
+
+import {
+  addErrorMessage,
+  addLoadingMessage,
+  addSuccessMessage,
+} from 'sentry/actionCreators/indicator';
+import {openModal} from 'sentry/actionCreators/modal';
+import {hasEveryAccess} from 'sentry/components/acl/access';
+import ClippedBox from 'sentry/components/clippedBox';
+import {ProjectAvatar} from 'sentry/components/core/avatar/projectAvatar';
+import {Button} from 'sentry/components/core/button';
+import {CompactSelect} from 'sentry/components/core/compactSelect';
+import {Flex} from 'sentry/components/core/layout';
+import {useOrganizationRepositories} from 'sentry/components/events/autofix/preferences/hooks/useOrganizationRepositories';
+import {useProjectSeerPreferences} from 'sentry/components/events/autofix/preferences/hooks/useProjectSeerPreferences';
+import {useUpdateProjectSeerPreferences} from 'sentry/components/events/autofix/preferences/hooks/useUpdateProjectSeerPreferences';
+import {GuidedSteps} from 'sentry/components/guidedSteps/guidedSteps';
+import ExternalLink from 'sentry/components/links/externalLink';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import NoProjectMessage from 'sentry/components/noProjectMessage';
+import Panel from 'sentry/components/panels/panel';
+import PanelBody from 'sentry/components/panels/panelBody';
+import PanelHeader from 'sentry/components/panels/panelHeader';
+import PanelItem from 'sentry/components/panels/panelItem';
+import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
+import {IconChevron} from 'sentry/icons';
+import {t, tct} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import type {Project} from 'sentry/types/project';
+import {useQueryClient} from 'sentry/utils/queryClient';
+import useApi from 'sentry/utils/useApi';
+import {makeDetailedProjectQueryKey} from 'sentry/utils/useDetailedProject';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import useOrganization from 'sentry/utils/useOrganization';
+import useProjects from 'sentry/utils/useProjects';
+import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
+import {AddAutofixRepoModalContent} from 'sentry/views/settings/projectSeer/addAutofixRepoModal';
+import {
+  MAX_REPOS_LIMIT,
+  SEER_THRESHOLD_OPTIONS,
+} from 'sentry/views/settings/projectSeer/constants';
+
+type ProjectState = {
+  isPending: boolean;
+  preference: any;
+};
+
+type ProjectStateMap = Record<string, ProjectState>;
+
+// Helper function to transform repositories data
+function transformRepositoriesToApiFormat(repositories: any[], repoIds: string[]) {
+  const selectedRepos = repositories.filter(repo => repoIds.includes(repo.externalId));
+
+  return selectedRepos.map(repo => {
+    const [owner, name] = (repo.name || '/').split('/');
+    return {
+      provider: repo.provider?.name?.toLowerCase() || '',
+      owner: owner || '',
+      name: name || repo.name || '',
+      external_id: repo.externalId,
+      branch_name: '',
+      instructions: '',
+    };
+  });
+}
+
+// Helper function to filter projects with access
+function filterProjectsWithAccess(projects: Project[], organization: any) {
+  return projects.filter(project =>
+    hasEveryAccess(['project:read'], {organization, project})
+  );
+}
+
+function ProjectRow({onClick, project}: {onClick: () => void; project: Project}) {
+  return (
+    <ClickablePanelItem onClick={onClick}>
+      <Flex align="center" gap={space(1)} justify="space-between" flex={1}>
+        <Flex align="center" gap={space(1)}>
+          <ProjectAvatar project={project} title={project.slug} />
+          <ProjectName>{project.slug}</ProjectName>
+        </Flex>
+        <IconChevron direction="right" size="sm" color="gray300" />
+      </Flex>
+    </ClickablePanelItem>
+  );
+}
+
+function ProjectRowWithUpdate({
+  isFetchingRepositories,
+  onSuccess,
+  onUpdateProjectState,
+  project,
+  projectStates,
+  repositories,
+}: {
+  isFetchingRepositories: boolean;
+  onSuccess: (projectId: string) => void;
+  onUpdateProjectState: (projectId: string, preference: any) => void;
+  project: Project;
+  projectStates: ProjectStateMap;
+  repositories: any[];
+}) {
+  const {mutate: updateProjectSeerPreferences} = useUpdateProjectSeerPreferences(project);
+
+  const handleProjectClick = useCallback(() => {
+    if (!repositories) return;
+
+    const currentPreference = projectStates[project.id]?.preference;
+    const currentRepoIds =
+      currentPreference?.repositories?.map((r: any) => r.external_id) || [];
+
+    openModal(deps => (
+      <AddAutofixRepoModalContent
+        {...deps}
+        repositories={repositories}
+        selectedRepoIds={currentRepoIds}
+        onSave={(repoIds: string[]) => {
+          const reposData = transformRepositoriesToApiFormat(repositories, repoIds);
+
+          updateProjectSeerPreferences({repositories: reposData});
+
+          if (reposData.length > 0) {
+            addSuccessMessage(
+              t('%s repo(s) connected to %s', reposData.length, project.slug)
+            );
+            onSuccess(project.id);
+            onUpdateProjectState(project.id, {
+              ...currentPreference,
+              repositories: reposData,
+            });
+          }
+        }}
+        isFetchingRepositories={isFetchingRepositories}
+        maxReposLimit={MAX_REPOS_LIMIT}
+      />
+    ));
+  }, [
+    repositories,
+    projectStates,
+    isFetchingRepositories,
+    updateProjectSeerPreferences,
+    project.id,
+    project.slug,
+    onSuccess,
+    onUpdateProjectState,
+  ]);
+
+  return <ProjectRow onClick={handleProjectClick} project={project} />;
+}
+
+function ProjectPreferenceLoader({
+  project,
+  onUpdate,
+}: {
+  onUpdate: (project: Project, preference: any, isPending: boolean) => void;
+  project: Project;
+}) {
+  const {preference, isPending} = useProjectSeerPreferences(project);
+
+  useEffect(() => {
+    onUpdate(project, preference, isPending);
+  }, [project, preference, isPending, onUpdate]);
+
+  return null;
+}
+
+function ProjectsWithoutRepos({
+  onProjectSuccess,
+  onProjectStateUpdate,
+  projects,
+}: {
+  onProjectStateUpdate: (project: Project, preference: any, isPending: boolean) => void;
+  onProjectSuccess: (projectId: string) => void;
+  projects: Project[];
+}) {
+  const {data: repositories, isFetching: isFetchingRepositories} =
+    useOrganizationRepositories();
+
+  const [projectStates, setProjectStates] = useState<ProjectStateMap>({});
+  const [successfullyConnectedProjects, setSuccessfullyConnectedProjects] = useState(
+    new Set<string>()
+  );
+
+  const handleProjectUpdate = useCallback(
+    (project: Project, preference: any, isPending: boolean) => {
+      setProjectStates(prev => ({
+        ...prev,
+        [project.id]: {preference, isPending},
+      }));
+      onProjectStateUpdate(project, preference, isPending);
+    },
+    [onProjectStateUpdate]
+  );
+
+  const handleProjectSuccess = useCallback(
+    (projectId: string) => {
+      setSuccessfullyConnectedProjects(prev => new Set([...prev, projectId]));
+      onProjectSuccess(projectId);
+    },
+    [onProjectSuccess]
+  );
+
+  const handleUpdateProjectState = useCallback(
+    (projectId: string, preference: any) => {
+      setProjectStates(prev => ({
+        ...prev,
+        [projectId]: {preference, isPending: false},
+      }));
+      const project = projects.find(p => p.id === projectId);
+      if (project) {
+        onProjectStateUpdate(project, preference, false);
+      }
+    },
+    [projects, onProjectStateUpdate]
+  );
+
+  const isLoading = useMemo(() => {
+    return (
+      projects.length === 0 ||
+      projects.some(project => projectStates[project.id]?.isPending !== false)
+    );
+  }, [projects, projectStates]);
+
+  const projectsWithoutRepos = useMemo(() => {
+    if (isLoading) return [];
+
+    return projects.filter(project => {
+      if (successfullyConnectedProjects.has(project.id)) return false;
+
+      const state = projectStates[project.id];
+      if (!state || state.isPending) return false;
+
+      const repoCount = state.preference?.repositories?.length || 0;
+      return repoCount === 0;
+    });
+  }, [projects, projectStates, isLoading, successfullyConnectedProjects]);
+
+  if (isLoading) {
+    return (
+      <Panel>
+        <PanelHeader>
+          <HeaderText>{t('Projects missing repositories')}</HeaderText>
+        </PanelHeader>
+        <PanelBody>
+          <LoadingState>
+            <LoadingIndicator />
+          </LoadingState>
+        </PanelBody>
+        {projects.map(project => (
+          <ProjectPreferenceLoader
+            key={project.id}
+            project={project}
+            onUpdate={handleProjectUpdate}
+          />
+        ))}
+      </Panel>
+    );
+  }
+
+  return (
+    <ClippedBox clipHeight={512}>
+      <Panel>
+        <PanelHeader>
+          <HeaderText>{t('Projects missing repositories')}</HeaderText>
+        </PanelHeader>
+        <PanelBody>
+          {projectsWithoutRepos.map(project => (
+            <ProjectRowWithUpdate
+              key={project.id}
+              project={project}
+              repositories={repositories || []}
+              isFetchingRepositories={isFetchingRepositories}
+              projectStates={projectStates}
+              onSuccess={handleProjectSuccess}
+              onUpdateProjectState={handleUpdateProjectState}
+            />
+          ))}
+          {projectsWithoutRepos.length === 0 && (
+            <EmptyState>{t('All your projects have repositories connected!')}</EmptyState>
+          )}
+        </PanelBody>
+      </Panel>
+    </ClippedBox>
+  );
+}
+
+function ProjectsWithReposTracker({
+  projectStates,
+  successfullyConnectedProjects,
+  onUpdate,
+}: {
+  onUpdate: (projectsWithRepos: Project[]) => void;
+  projectStates: ProjectStateMap;
+  successfullyConnectedProjects: Set<string>;
+}) {
+  const {projects} = useProjects();
+  const organization = useOrganization();
+
+  const projectsWithRepos = useMemo(() => {
+    const filteredProjects = filterProjectsWithAccess(projects, organization);
+
+    return filteredProjects.filter(project => {
+      // Check if project has repositories (either connected this session or previously)
+      if (successfullyConnectedProjects.has(project.id)) {
+        return true;
+      }
+
+      const state = projectStates[project.id];
+      if (state && !state.isPending) {
+        const repoCount = state.preference?.repositories?.length || 0;
+        return repoCount > 0;
+      }
+
+      return false;
+    });
+  }, [projects, projectStates, successfullyConnectedProjects, organization]);
+
+  useEffect(() => {
+    onUpdate(projectsWithRepos);
+  }, [projectsWithRepos, onUpdate]);
+
+  return null;
+}
+
+function SeerAutomationOnboarding() {
+  const organization = useOrganization();
+  const {projects, fetching} = useProjects();
+  const api = useApi();
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+  const [selectedThreshold, setSelectedThreshold] = useState('low');
+  const [projectsWithRepos, setProjectsWithRepos] = useState<Project[]>([]);
+  const [projectStates, setProjectStates] = useState<ProjectStateMap>({});
+  const [successfullyConnectedProjects, setSuccessfullyConnectedProjects] = useState(
+    new Set<string>()
+  );
+
+  const filteredProjects = useMemo(() => {
+    return filterProjectsWithAccess(projects, organization);
+  }, [projects, organization]);
+
+  const projectsWithoutRepos = useMemo(() => {
+    return filteredProjects.filter(project => {
+      // Exclude projects that have been successfully connected this session
+      if (successfullyConnectedProjects.has(project.id)) return false;
+
+      // Exclude projects that already have repositories
+      const state = projectStates[project.id];
+      if (state && !state.isPending) {
+        const repoCount = state.preference?.repositories?.length || 0;
+        return repoCount === 0;
+      }
+
+      // Include projects that are still loading (we don't know their repo status yet)
+      return true;
+    });
+  }, [filteredProjects, successfullyConnectedProjects, projectStates]);
+
+  const handleEnableIssueScans = useCallback(async () => {
+    if (projectsWithoutRepos.length === 0) {
+      addErrorMessage(t('No remaining projects found to update'));
+      return;
+    }
+
+    addLoadingMessage(t('Enabling issue scans for remaining projects...'), {
+      duration: 30000,
+    });
+
+    try {
+      await Promise.all(
+        projectsWithoutRepos.map(project =>
+          api.requestPromise(`/projects/${organization.slug}/${project.slug}/`, {
+            method: 'PUT',
+            data: {seerScannerAutomation: true},
+          })
+        )
+      );
+
+      addSuccessMessage(
+        t('Issue scans enabled for %s remaining project(s)', projectsWithoutRepos.length)
+      );
+
+      projectsWithoutRepos.forEach(project => {
+        queryClient.invalidateQueries({
+          queryKey: makeDetailedProjectQueryKey({
+            orgSlug: organization.slug,
+            projectSlug: project.slug,
+          }),
+        });
+      });
+    } catch (err) {
+      addErrorMessage(t('Failed to enable issue scans for some projects'));
+    }
+  }, [api, organization.slug, projectsWithoutRepos, queryClient]);
+
+  const handleEnableAutoTriggerFixes = useCallback(async () => {
+    if (projectsWithRepos.length === 0) {
+      addErrorMessage(t('No projects with repositories found to update'));
+      return;
+    }
+
+    addLoadingMessage(t('Enabling automation for projects with repositories...'), {
+      duration: 30000,
+    });
+
+    try {
+      await Promise.all(
+        projectsWithRepos.map(project =>
+          api.requestPromise(`/projects/${organization.slug}/${project.slug}/`, {
+            method: 'PUT',
+            data: {
+              autofixAutomationTuning: selectedThreshold,
+              seerScannerAutomation: true,
+            },
+          })
+        )
+      );
+
+      addSuccessMessage(
+        t(
+          'Automation enabled for %s project(s) with repositories',
+          projectsWithRepos.length
+        )
+      );
+
+      projectsWithRepos.forEach(project => {
+        queryClient.invalidateQueries({
+          queryKey: makeDetailedProjectQueryKey({
+            orgSlug: organization.slug,
+            projectSlug: project.slug,
+          }),
+        });
+      });
+    } catch (err) {
+      addErrorMessage(t('Failed to enable automation for some projects'));
+    }
+  }, [api, organization.slug, projectsWithRepos, selectedThreshold, queryClient]);
+
+  const handleProjectStatesUpdate = useCallback(
+    (project: Project, preference: any, isPending: boolean) => {
+      setProjectStates(prev => ({
+        ...prev,
+        [project.id]: {preference, isPending},
+      }));
+    },
+    []
+  );
+
+  const handleProjectSuccess = useCallback((projectId: string) => {
+    setSuccessfullyConnectedProjects(prev => new Set([...prev, projectId]));
+  }, []);
+
+  return (
+    <Fragment>
+      <SentryDocumentTitle
+        title={t('Seer Automation Onboarding')}
+        orgSlug={organization.slug}
+      />
+      <SettingsPageHeader
+        title={t('Set Up Seer')}
+        subtitle={t(
+          'Follow these steps to get the most out of Seer across your organization.'
+        )}
+      />
+
+      <NoProjectMessage organization={organization}>
+        <StyledGuidedSteps>
+          <GuidedSteps.Step
+            stepKey="connect-repos"
+            title={t('Connect Your Code')}
+            isCompleted={false}
+          >
+            <StepDescription>
+              {t(
+                'Give Seer access to the relevant repos for the following projects to enable deeper, more accurate analysis.'
+              )}
+            </StepDescription>
+
+            {fetching ? (
+              <LoadingIndicator />
+            ) : (
+              <ProjectsWithoutRepos
+                projects={filteredProjects.filter(
+                  project => !successfullyConnectedProjects.has(project.id)
+                )}
+                onProjectSuccess={handleProjectSuccess}
+                onProjectStateUpdate={handleProjectStatesUpdate}
+              />
+            )}
+
+            <GuidedSteps.StepButtons />
+          </GuidedSteps.Step>
+
+          <GuidedSteps.Step
+            stepKey="auto-trigger-fixes"
+            title={t('Auto-Trigger Fixes')}
+            isCompleted={false}
+          >
+            <StepDescription>
+              {tct(
+                "Once Seer scans for the most actionable issues, Seer can trigger a root cause analysis and plan out a solution. This runs in the background, so by the time you get to debugging, the answer is already there. [link:Learn more about Seer automation.][break][break]This setting is only recommended once you've connected repos to a project.",
+                {
+                  link: (
+                    <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/seer/#automation" />
+                  ),
+                  break: <br />,
+                }
+              )}
+            </StepDescription>
+
+            <AutoFixActionWrapper>
+              {projectsWithRepos.length > 0 && (
+                <ThresholdSelectorWrapper>
+                  <Flex gap={space(1)} align="center">
+                    <SelectorLabel>
+                      {t('Automatically diagnose issues that are...')}
+                    </SelectorLabel>
+                    <CompactSelect
+                      value={selectedThreshold}
+                      onChange={opt => setSelectedThreshold(opt.value)}
+                      options={SEER_THRESHOLD_OPTIONS.map(option => ({
+                        value: option.value,
+                        label: option.label,
+                        details: option.details,
+                      }))}
+                      strategy="fixed"
+                    />
+                  </Flex>
+                  <Button
+                    priority="primary"
+                    onClick={handleEnableAutoTriggerFixes}
+                    disabled={fetching || projectsWithRepos.length === 0}
+                  >
+                    {t('Enable for %s recommended project(s)', projectsWithRepos.length)}
+                  </Button>
+                </ThresholdSelectorWrapper>
+              )}
+
+              {projectsWithRepos.length === 0 && !fetching && (
+                <EmptyProjectsMessage>
+                  {t('No projects recommended for auto-triggered fixes')}
+                </EmptyProjectsMessage>
+              )}
+            </AutoFixActionWrapper>
+
+            <GuidedSteps.StepButtons />
+          </GuidedSteps.Step>
+
+          <GuidedSteps.Step
+            stepKey="enable-issue-scans"
+            title={t('Enable Issue Scans')}
+            isCompleted={false}
+          >
+            <StepDescription>
+              {tct(
+                'For your remaining projects without connected codebases, you can still enable Issue Scans. Seer will scan all new and ongoing issues, flagging the most actionable issues and giving more context in Slack alerts. [link:Learn more about issue scans.]',
+                {
+                  link: (
+                    <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/seer/#issue-scan" />
+                  ),
+                }
+              )}
+            </StepDescription>
+
+            <ScanActionWrapper>
+              <Button
+                priority="primary"
+                onClick={handleEnableIssueScans}
+                disabled={fetching || projectsWithoutRepos.length === 0}
+              >
+                {t('Enable for %s remaining projects', projectsWithoutRepos.length)}
+              </Button>
+              {projectsWithoutRepos.length === 0 && !fetching && (
+                <EmptyProjectsMessage>
+                  {t('All projects are set up with Seer!')}
+                </EmptyProjectsMessage>
+              )}
+            </ScanActionWrapper>
+
+            <GuidedSteps.StepButtons />
+          </GuidedSteps.Step>
+
+          <GuidedSteps.Step
+            stepKey="review-customize"
+            title={t('Review and Customize')}
+            isCompleted={false}
+          >
+            <StepDescription>
+              {t(
+                'You can now visit each project individually to customize Seer more granularly:'
+              )}
+            </StepDescription>
+            <CustomizationList>
+              <li>{t('Choose automation thresholds per-project')}</li>
+              <li>{t('Set working branches for each repository')}</li>
+              <li>{t('Provide context and instructions specific to your codebase')}</li>
+              <li>
+                {t(
+                  'Configure Seer to automatically open pull requests when fixes are ready'
+                )}
+              </li>
+              <li>{t('And more...')}</li>
+            </CustomizationList>
+
+            <GuidedSteps.StepButtons>
+              <Button
+                priority="primary"
+                onClick={() => navigate(`/settings/${organization.slug}/seer/`)}
+                size="sm"
+              >
+                {t('Done')}
+              </Button>
+            </GuidedSteps.StepButtons>
+          </GuidedSteps.Step>
+        </StyledGuidedSteps>
+
+        {filteredProjects.map(project => (
+          <ProjectPreferenceLoader
+            key={project.id}
+            project={project}
+            onUpdate={handleProjectStatesUpdate}
+          />
+        ))}
+        <ProjectsWithReposTracker
+          projectStates={projectStates}
+          successfullyConnectedProjects={successfullyConnectedProjects}
+          onUpdate={setProjectsWithRepos}
+        />
+      </NoProjectMessage>
+    </Fragment>
+  );
+}
+
+const ProjectName = styled('span')`
+  font-weight: ${p => p.theme.fontWeight.normal};
+`;
+
+const StepDescription = styled('div')`
+  margin-bottom: ${space(2)};
+  color: ${p => p.theme.subText};
+`;
+
+const HeaderText = styled('div')`
+  font-weight: ${p => p.theme.fontWeight.bold};
+`;
+
+const EmptyState = styled('div')`
+  padding: ${space(2)};
+  text-align: center;
+  color: ${p => p.theme.subText};
+`;
+
+const LoadingState = styled('div')`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: ${space(1)};
+  padding: ${space(3)};
+  color: ${p => p.theme.subText};
+`;
+
+const StyledGuidedSteps = styled(GuidedSteps)`
+  background: none;
+`;
+
+const ClickablePanelItem = styled(PanelItem)`
+  cursor: pointer;
+  transition: background-color 0.1s;
+
+  &:hover {
+    background-color: ${p => p.theme.backgroundSecondary};
+  }
+`;
+
+const ScanActionWrapper = styled('div')`
+  margin-bottom: ${space(3)};
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: ${space(1)};
+`;
+
+const EmptyProjectsMessage = styled('div')`
+  color: ${p => p.theme.subText};
+  font-weight: ${p => p.theme.fontWeight.bold};
+`;
+
+const AutoFixActionWrapper = styled('div')`
+  margin-bottom: ${space(3)};
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: ${space(2)};
+`;
+
+const ThresholdSelectorWrapper = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${space(2)};
+  width: 100%;
+`;
+
+const SelectorLabel = styled('div')`
+  font-weight: ${p => p.theme.fontWeight.bold};
+`;
+
+const CustomizationList = styled('ul')`
+  margin: ${space(2)} 0;
+  padding-left: ${space(3)};
+
+  li {
+    margin-bottom: ${space(1)};
+    color: ${p => p.theme.subText};
+  }
+`;
+
+export default SeerAutomationOnboarding;

--- a/static/gsApp/views/seerAutomation/seerAutomationProjectList.tsx
+++ b/static/gsApp/views/seerAutomation/seerAutomationProjectList.tsx
@@ -324,7 +324,7 @@ export function SeerAutomationProjectList() {
           priority="primary"
           onClick={() => navigate('/settings/seer/onboarding')}
         >
-          {t('Configure for All Projects')}
+          {t('Open Setup Wizard')}
         </Button>
       </SearchWrapper>
       <Panel>

--- a/static/gsApp/views/seerAutomation/seerAutomationProjectList.tsx
+++ b/static/gsApp/views/seerAutomation/seerAutomationProjectList.tsx
@@ -13,10 +13,7 @@ import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import {Checkbox} from 'sentry/components/core/checkbox';
 import {Flex} from 'sentry/components/core/layout';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
-import {
-  makeProjectSeerPreferencesQueryKey,
-  useProjectSeerPreferences,
-} from 'sentry/components/events/autofix/preferences/hooks/useProjectSeerPreferences';
+import {useProjectSeerPreferences} from 'sentry/components/events/autofix/preferences/hooks/useProjectSeerPreferences';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Panel from 'sentry/components/panels/panel';
@@ -293,97 +290,6 @@ export function SeerAutomationProjectList() {
     }
   }
 
-  async function setAllToRecommended() {
-    addLoadingMessage('Setting all projects to recommended settings...', {
-      duration: 30000,
-    });
-    try {
-      // Get preferences for all filtered projects to check repo counts
-      const projectPreferences = await Promise.all(
-        filteredProjects.map(async project => {
-          try {
-            const response = await queryClient.fetchQuery({
-              queryKey: [
-                makeProjectSeerPreferencesQueryKey(organization.slug, project.slug),
-              ],
-              queryFn: () =>
-                api.requestPromise(
-                  makeProjectSeerPreferencesQueryKey(organization.slug, project.slug)
-                ),
-              staleTime: 60000,
-            });
-            return {
-              project,
-              repoCount: response[0].preference?.repositories?.length || 0,
-            };
-          } catch (err) {
-            // If we can't get preferences, assume no repos
-            return {
-              project,
-              repoCount: 0,
-            };
-          }
-        })
-      );
-
-      // Update all projects
-      await Promise.all(
-        projectPreferences.map(({project, repoCount}) => {
-          const updateData: any = {};
-
-          if (!project.seerScannerAutomation) {
-            updateData.seerScannerAutomation = true; // Set scanner to on for all projects
-          }
-
-          // Sets fixes to highly actionable if repos are connected and no automation already set
-          if (
-            (!project.autofixAutomationTuning ||
-              project.autofixAutomationTuning === 'off') &&
-            repoCount > 0
-          ) {
-            updateData.autofixAutomationTuning = 'low';
-          }
-
-          // no updates, so don't make a request
-          if (Object.keys(updateData).length === 0) {
-            return Promise.resolve();
-          }
-
-          // make the request
-          return api.requestPromise(`/projects/${organization.slug}/${project.slug}/`, {
-            method: 'PUT',
-            data: updateData,
-          });
-        })
-      );
-
-      const projectsWithNoRepos = projectPreferences.filter(
-        ({repoCount}) => repoCount === 0
-      ).length;
-      const updatedProjectsCount = projectPreferences.length;
-
-      if (projectsWithNoRepos > 0) {
-        addSuccessMessage(
-          `Settings applied to ${updatedProjectsCount} project(s). ${projectsWithNoRepos} project(s) have no repos connected and were skipped.`
-        );
-      } else {
-        addSuccessMessage(`Settings applied to ${updatedProjectsCount} projects.`);
-      }
-    } catch (err) {
-      addErrorMessage('Failed to update some projects');
-    } finally {
-      // Invalidate queries for all filtered projects
-      filteredProjects.forEach(project => {
-        queryClient.invalidateQueries({
-          queryKey: makeDetailedProjectQueryKey({
-            orgSlug: organization.slug,
-            projectSlug: project.slug,
-          }),
-        });
-      });
-    }
-  }
-
   const actionMenuItems = SEER_THRESHOLD_MAP.map(key => ({
     key,
     label: getSeerDropdownLabel(key),
@@ -414,15 +320,11 @@ export function SeerAutomationProjectList() {
           />
         </SearchBarWrapper>
         <Button
-          size="sm"
+          size="md"
           priority="primary"
-          onClick={setAllToRecommended}
-          disabled={filteredProjects.length === 0}
-          title={t(
-            'For all projects, turns Issue Scans on, and if repos are connected, sets Issue Fixes to run automatically.'
-          )}
+          onClick={() => navigate('/settings/seer/onboarding')}
         >
-          {t('Turn On for Recommended Projects')}
+          {t('Configure for All Projects')}
         </Button>
       </SearchWrapper>
       <Panel>


### PR DESCRIPTION
Removes the recommended settings button in favor of a button that begins an onboarding flow to configure all of your projects

<img width="1245" height="642" alt="Screenshot 2025-07-15 at 3 18 12 PM" src="https://github.com/user-attachments/assets/e630b323-8a73-430c-b840-aa5513408f1e" />
<img width="1229" height="552" alt="Screenshot 2025-07-15 at 3 18 16 PM" src="https://github.com/user-attachments/assets/af75d063-4905-4eee-aa37-b39f00ed1a82" />
<img width="1003" height="663" alt="Screenshot 2025-07-15 at 3 18 19 PM" src="https://github.com/user-attachments/assets/94f61ab8-8584-4905-99d9-90a3066dc47e" />

<img width="1449" height="778" alt="Screenshot 2025-07-15 at 2 39 57 PM" src="https://github.com/user-attachments/assets/8e3ec5c9-96ab-4e14-9968-67979ef1bdf4" />
<img width="1239" height="888" alt="Screenshot 2025-07-15 at 3 18 09 PM" src="https://github.com/user-attachments/assets/b6b5754a-6060-4e05-825c-aa8ad44eaab1" />
<img width="1477" height="897" alt="Screenshot 2025-07-15 at 2 39 43 PM" src="https://github.com/user-attachments/assets/c5e3bf65-e96f-4a0d-83fc-7cdf9845fb71" />
