### PR TITLE
ref(replays): rm error fetch param from breadcrumbs endpoint and improve parse_timestamp typing

### DIFF
--- a/src/sentry/replays/endpoints/project_replay_summarize_breadcrumbs.py
+++ b/src/sentry/replays/endpoints/project_replay_summarize_breadcrumbs.py
@@ -173,12 +173,10 @@ def fetch_error_details(project_id: int, error_ids: list[str]) -> list[GroupEven
         return []
 
 
-def parse_timestamp(
-    value: str | float | None, float_input_unit: Literal["s", "ms"] = "ms"
-) -> float:
+def parse_timestamp(value: str | float | None, float_input_unit: Literal["s", "ms"]) -> float:
     """
     Parse a timestamp input to float milliseconds. None and parse errors default to 0.0.
-    `float_input_unit` is the value's expected unit, only applicable when it's a float.
+    `float_input_unit` is the value's expected unit and ignored when it's a not a number.
     """
     if value is None:
         return 0.0
@@ -254,9 +252,9 @@ def fetch_trace_connected_errors(
             error_data = query.process_results(result)["data"]
 
             for event in error_data:
-                timestamp = parse_timestamp(
-                    event.get("timestamp_ms"), float_input_unit="ms"
-                ) or parse_timestamp(event.get("timestamp"), float_input_unit="s")
+                timestamp = parse_timestamp(event.get("timestamp_ms"), "ms") or parse_timestamp(
+                    event.get("timestamp"), float_input_unit="s"
+                )
 
                 if timestamp:
                     error_events.append(

--- a/src/sentry/replays/endpoints/project_replay_summarize_breadcrumbs.py
+++ b/src/sentry/replays/endpoints/project_replay_summarize_breadcrumbs.py
@@ -100,7 +100,9 @@ class ProjectReplaySummarizeBreadcrumbsEndpoint(ProjectEndpoint):
         cache_key = f"replay_summarize_breadcrumbs:{project.id}:{replay_id}:{per_page}:{cursor}"
 
         if not request.query_params.get(REFRESH_CACHE_QPARAM, "false").lower() == "true":
-            cache_lookup_result: tuple[dict[str, Any], int] | None = cache.get(cache_key)
+            cache_lookup_result: tuple[dict[str, Any], dict[str, Any], int] | None = cache.get(
+                cache_key
+            )
             if cache_lookup_result:
                 cached_response, cached_headers, prev_num_segments = cache_lookup_result
                 if num_segments == prev_num_segments:

--- a/src/sentry/replays/endpoints/project_replay_summarize_breadcrumbs.py
+++ b/src/sentry/replays/endpoints/project_replay_summarize_breadcrumbs.py
@@ -97,7 +97,7 @@ class ProjectReplaySummarizeBreadcrumbsEndpoint(ProjectEndpoint):
 
         per_page = self.get_per_page(request)
         cursor = request.GET.get(self.cursor_name, "")
-        cache_key = f"replay_summarize_breadcrumbs:{project.id}:{replay_id}:{per_page}:{cursor}:{disable_error_fetching}"
+        cache_key = f"replay_summarize_breadcrumbs:{project.id}:{replay_id}:{per_page}:{cursor}"
 
         if not request.query_params.get(REFRESH_CACHE_QPARAM, "false").lower() == "true":
             cache_lookup_result: tuple[dict[str, Any], dict[str, Any], int] | None = cache.get(


### PR DESCRIPTION
Followup from https://github.com/getsentry/sentry/pull/95471#discussion_r2208627943