### PR TITLE
fix(feedback): Fix a case where duplicate items can be rendered in the list

### DIFF
--- a/static/app/components/feedback/list/feedbackList.tsx
+++ b/static/app/components/feedback/list/feedbackList.tsx
@@ -35,8 +35,9 @@ export default function FeedbackList() {
     enabled: Boolean(listQueryKey),
   });
 
+  // Deduplicated issues. In case one page overlaps with another.
   const issues = useMemo(
-    () => uniqBy(queryResult.data?.pages.flatMap(([pageData]) => pageData) ?? [], 'id'),
+    () => uniqBy(queryResult.data?.pages.flatMap(result => result[0]) ?? [], 'id'),
     [queryResult.data?.pages]
   );
   const checkboxState = useListItemCheckboxContext({
@@ -57,6 +58,7 @@ export default function FeedbackList() {
           loadingMessage={() => <LoadingIndicator />}
         >
           <InfiniteListItems<FeedbackIssueListItem>
+            deduplicateItems={items => uniqBy(items, 'id')}
             estimateSize={() => 24}
             queryResult={queryResult}
             itemRenderer={({item}) => (

--- a/static/app/components/infiniteList/infiniteListItems.tsx
+++ b/static/app/components/infiniteList/infiniteListItems.tsx
@@ -24,6 +24,7 @@ interface Props<Data> {
     >,
     {fetchNextPage: () => Promise<unknown>}
   >;
+  deduplicateItems?: (items: Data[]) => Data[];
   emptyMessage?: () => React.ReactNode;
   estimateSize?: () => number;
   loadingCompleteMessage?: () => React.ReactNode;
@@ -32,16 +33,19 @@ interface Props<Data> {
 }
 
 export default function InfiniteListItems<Data>({
+  deduplicateItems = _ => _,
+  emptyMessage = EmptyMessage,
   estimateSize,
   itemRenderer,
-  emptyMessage = EmptyMessage,
   loadingCompleteMessage = LoadingCompleteMessage,
   loadingMoreMessage = LoadingMoreMessage,
   overscan,
   queryResult,
 }: Props<Data>) {
   const {data, hasNextPage, isFetchingNextPage, fetchNextPage} = queryResult;
-  const loadedRows = data ? data.pages.flatMap(d => d[0]) : [];
+  const loadedRows = deduplicateItems(
+    data ? data.pages.flatMap(result => result[0]) : []
+  );
   const parentRef = useRef<HTMLDivElement>(null);
 
   const rowVirtualizer = useVirtualizer({


### PR DESCRIPTION
The robots made a comment: https://github.com/getsentry/sentry/pull/95398#pullrequestreview-3021569372
It points out that we're not de-duplicating result items inside an infinite list when we go to render things.

How could we get duplicate items? If the pagination params are based on offsets (which ours mostly are) then:
- You fetch the first 10 results (items with `id:1`, `id:2`, ... `id:10`) in the first page
- In the 2nd page we'll ask for 10 items, starting at the item 10th from the start
    - So we'd expect to get `id:11`, `id:12` and so on

But "start" depends on the sort order, and usually we're showing the most recent stuff first. 

- When sorting newest->oldest our first page of data would actually be something like `id: 89`, `id:88`, `id:87`, etc.
- The second page we'd expect to be `id:79`, id:78`, etc.
    - But if a new item appears, and becomes `id:90` then everything else shifts down one.
    - So our 2nd page of data actually returns `id: 80`, `id:79`, etc. 

The end result is that `id:80` is double-fetched. This is what we need to filter out of the data.