### PR TITLE
feat(aci): combine Rule and WorkflowFireHistory to make RuleGroupHistory when single processing

### DIFF
--- a/src/sentry/rules/history/backends/postgres.py
+++ b/src/sentry/rules/history/backends/postgres.py
@@ -1,21 +1,26 @@
 from __future__ import annotations
 
+import logging
 from collections.abc import Sequence
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING, TypedDict, cast
+from typing import TYPE_CHECKING, TypedDict
 
+from django.db import connection
 from django.db.models import Count, Max, OuterRef, Subquery
 from django.db.models.functions import TruncHour
 
+from sentry import features
 from sentry.api.paginator import OffsetPaginator
 from sentry.models.group import Group
 from sentry.models.rulefirehistory import RuleFireHistory
 from sentry.rules.history.base import RuleGroupHistory, RuleHistoryBackend, TimeSeriesValue
-from sentry.utils.cursors import CursorResult
+from sentry.utils.cursors import Cursor, CursorResult
+from sentry.workflow_engine.models import AlertRuleWorkflow
 
 if TYPE_CHECKING:
     from sentry.models.rule import Rule
-    from sentry.utils.cursors import Cursor
+
+logger = logging.getLogger(__name__)
 
 
 class _Result(TypedDict):
@@ -63,31 +68,85 @@ class PostgresRuleHistoryBackend(RuleHistoryBackend):
         end: datetime,
         cursor: Cursor | None = None,
         per_page: int = 25,
-    ) -> CursorResult[Group]:
-        filtered_history = RuleFireHistory.objects.filter(
+    ) -> CursorResult[RuleGroupHistory]:
+        # Check if the workflow engine single process workflows flag is enabled
+        if features.has(
+            "organizations:workflow-engine-single-process-workflows", rule.project.organization
+        ):
+            try:
+                alert_rule_workflow = AlertRuleWorkflow.objects.get(rule_id=rule.id)
+                workflow = alert_rule_workflow.workflow
+
+                # Use raw SQL to combine data from both tables and aggregate
+                with connection.cursor() as db_cursor:
+                    db_cursor.execute(
+                        """
+                        SELECT
+                            group_id as group,
+                            COUNT(*) as count,
+                            MAX(date_added) as last_triggered,
+                            (ARRAY_AGG(event_id ORDER BY date_added DESC))[1] as event_id
+                        FROM (
+                            SELECT group_id, date_added, event_id
+                            FROM sentry_rulefirehistory
+                            WHERE rule_id = %s
+                                AND date_added >= %s
+                                AND date_added < %s
+
+                            UNION ALL
+
+                            SELECT group_id, date_added, event_id
+                            FROM workflow_engine_workflowfirehistory
+                            WHERE workflow_id = %s
+                                AND is_single_written = true
+                                AND date_added >= %s
+                                AND date_added < %s
+                        ) combined_data
+                        GROUP BY group_id
+                        ORDER BY count DESC, last_triggered DESC
+                    """,
+                        [rule.id, start, end, workflow.id, start, end],
+                    )
+
+                    results = db_cursor.fetchall()
+
+                # Convert to expected format (already ordered)
+                final_results = [
+                    _Result(group=row[0], count=row[1], last_triggered=row[2], event_id=row[3])
+                    for row in results
+                ]
+
+                return OffsetPaginator(
+                    final_results,
+                    on_results=convert_results,
+                ).get_result(per_page, cursor)
+
+            except AlertRuleWorkflow.DoesNotExist:
+                # If no workflow is associated with this rule, just use the original behavior
+                logger.exception("No workflow associated with rule", extra={"rule_id": rule.id})
+                pass
+
+        rule_filtered_history = RuleFireHistory.objects.filter(
             rule=rule,
             date_added__gte=start,
             date_added__lt=end,
         )
 
-        # subquery that retrieves row with the largest date in a group
-        group_max_dates = filtered_history.filter(group=OuterRef("group")).order_by("-date_added")[
-            :1
-        ]
+        # subquery that retrieves row with the largest date in a group for RuleFireHistory
+        rule_group_max_dates = rule_filtered_history.filter(group=OuterRef("group")).order_by(
+            "-date_added"
+        )[:1]
         qs = (
-            filtered_history.select_related("group")
+            rule_filtered_history.select_related("group")
             .values("group")
             .annotate(count=Count("group"))
-            .annotate(event_id=NoGroupBySubquery(group_max_dates.values("event_id")))
+            .annotate(event_id=NoGroupBySubquery(rule_group_max_dates.values("event_id")))
             .annotate(last_triggered=Max("date_added"))
         )
-        # TODO: Add types to paginators and remove this
-        return cast(
-            CursorResult[Group],
-            OffsetPaginator(
-                qs, order_by=("-count", "-last_triggered"), on_results=convert_results
-            ).get_result(per_page, cursor),
-        )
+
+        return OffsetPaginator(
+            qs, order_by=("-count", "-last_triggered"), on_results=convert_results
+        ).get_result(per_page, cursor)
 
     def fetch_rule_hourly_stats(
         self, rule: Rule, start: datetime, end: datetime

--- a/src/sentry/rules/history/backends/postgres.py
+++ b/src/sentry/rules/history/backends/postgres.py
@@ -77,7 +77,7 @@ class PostgresRuleHistoryBackend(RuleHistoryBackend):
                 workflow = alert_rule_workflow.workflow
 
                 # Performs the raw SQL query with pagination
-                def data_fn(offset: int, limit: int):
+                def data_fn(offset: int, limit: int) -> list[_Result]:
                     with connection.cursor() as db_cursor:
                         db_cursor.execute(
                             """

--- a/src/sentry/rules/history/backends/postgres.py
+++ b/src/sentry/rules/history/backends/postgres.py
@@ -69,7 +69,6 @@ class PostgresRuleHistoryBackend(RuleHistoryBackend):
         cursor: Cursor | None = None,
         per_page: int = 25,
     ) -> CursorResult[RuleGroupHistory]:
-        # Check if the workflow engine single process workflows flag is enabled
         if features.has(
             "organizations:workflow-engine-single-process-workflows", rule.project.organization
         ):

--- a/src/sentry/rules/history/base.py
+++ b/src/sentry/rules/history/base.py
@@ -50,7 +50,7 @@ class RuleHistoryBackend(Service):
 
     def fetch_rule_groups_paginated(
         self, rule: Rule, start: datetime, end: datetime, cursor: Cursor, per_page: int
-    ) -> CursorResult[Group]:
+    ) -> CursorResult[RuleGroupHistory]:
         """
         Fetches groups that triggered a rule within a given timeframe, ordered by number of
         times each group fired.

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -673,6 +673,9 @@ def fire_actions_for_groups(
     should_trigger_actions_async = features.has(
         "organizations:workflow-engine-action-trigger-async", organization
     )
+    is_single_processing = features.has(
+        "organizations:workflow-engine-single-processing", organization
+    )
 
     total_actions = 0
     with track_batch_performance(

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -673,9 +673,6 @@ def fire_actions_for_groups(
     should_trigger_actions_async = features.has(
         "organizations:workflow-engine-action-trigger-async", organization
     )
-    is_single_processing = features.has(
-        "organizations:workflow-engine-single-processing", organization
-    )
 
     total_actions = 0
     with track_batch_performance(


### PR DESCRIPTION
When the single processing flag is on, we should populate the issue alert table with the `RuleFireHistory` AND `WorkflowFireHistory` info.

Query in SQL (accounting for offset pagination) for all `RuleFireHistory` within the period as well as `WorkflowFireHistory` with `is_single_written=True`. Aggregate these so we have the last triggered date, count, and event_id for each `Group` that was triggered by the `Rule`/`Workflow`. Use `GenericOffsetPaginator` to account for the cursor.