### PR TITLE
fix(feedback): remove browser version and model id search suggestions

### DIFF
--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -2532,7 +2532,6 @@ const REPLAY_CLICK_FIELD_DEFINITIONS: Record<ReplayClickFieldKey, FieldDefinitio
 
 export enum FeedbackFieldKey {
   BROWSER_NAME = 'browser.name',
-  BROWSER_VERSION = 'browser.version',
   LOCALE_LANG = 'locale.lang',
   LOCALE_TIMEZONE = 'locale.timezone',
   MESSAGE = 'message',
@@ -2544,10 +2543,8 @@ export enum FeedbackFieldKey {
 export const FEEDBACK_FIELDS = [
   FieldKey.ASSIGNED,
   FeedbackFieldKey.BROWSER_NAME,
-  FeedbackFieldKey.BROWSER_VERSION,
   FieldKey.DEVICE_BRAND,
   FieldKey.DEVICE_FAMILY,
-  FieldKey.DEVICE_MODEL_ID,
   FieldKey.DEVICE_NAME,
   FieldKey.DIST,
   FieldKey.ENVIRONMENT,
@@ -2582,11 +2579,6 @@ const FEEDBACK_FIELD_DEFINITIONS: Record<FeedbackFieldKey, FieldDefinition> = {
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },
-  [FeedbackFieldKey.BROWSER_VERSION]: {
-    desc: t('Version number of the browser'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.STRING,
-  },
   [FeedbackFieldKey.LOCALE_LANG]: {
     desc: t('Language preference of the user'),
     kind: FieldKind.FIELD,
@@ -2598,7 +2590,9 @@ const FEEDBACK_FIELD_DEFINITIONS: Record<FeedbackFieldKey, FieldDefinition> = {
     valueType: FieldValueType.STRING,
   },
   [FeedbackFieldKey.MESSAGE]: {
-    desc: t('Message written by the user providing feedback.'),
+    desc: t(
+      'Message written by the user providing feedback. Search is case insensitive and supports substrings.'
+    ),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
     allowWildcard: true,


### PR DESCRIPTION
As far as I can tell these searches don't work in sentry javascript project, and we should remove to avoid confusion. If they're added as custom tags they should show in the "Tags" section, but we shouldn't hard-code in "Suggested".
Search behavior is described in https://github.com/getsentry/sentry/issues/88766. Closes https://github.com/getsentry/sentry/issues/88766

<img width="621" height="266" alt="Screenshot 2025-07-15 at 4 17 39 PM" src="https://github.com/user-attachments/assets/ae9bce62-a2b9-457e-a113-3ffee94723e4" />

No suggestions though many feedbacks display a version:
<img width="395" height="266" alt="Screenshot 2025-07-15 at 4 18 08 PM" src="https://github.com/user-attachments/assets/96d68ab1-d88b-42e5-b9fa-4ad8c790b52b" />

Also improves the desc for `message`.
<img width="491" height="201" alt="Screenshot 2025-07-15 at 4 19 04 PM" src="https://github.com/user-attachments/assets/faefb6e5-ef28-41ce-8cc5-46d07785cd5f" />