### PR TITLE
ref(issue-views): remove custom views 

### DIFF
--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -43,8 +43,6 @@ from sentry.models.grouplink import GroupLink
 from sentry.models.groupopenperiod import GroupOpenPeriod, get_latest_open_period
 from sentry.models.groupowner import GROUP_OWNER_TYPE, GroupOwner, GroupOwnerType
 from sentry.models.groupresolution import GroupResolution
-from sentry.models.groupsearchview import GroupSearchView
-from sentry.models.groupsearchviewstarred import GroupSearchViewStarred
 from sentry.models.groupseen import GroupSeen
 from sentry.models.groupshare import GroupShare
 from sentry.models.groupsnooze import GroupSnooze
@@ -2366,118 +2364,6 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
         assert response.status_code == 200
         assert len(response.data) == 1
         assert int(response.data[0]["id"]) == event.group.id
-
-    @with_feature("organizations:issue-stream-custom-views")
-    def test_user_default_custom_view_query(self, _: MagicMock) -> None:
-        SavedSearch.objects.create(
-            name="Saved Search",
-            query="TypeError",
-            organization=self.organization,
-            owner_id=self.user.id,
-            visibility=Visibility.OWNER_PINNED,
-        )
-        default_view = GroupSearchView.objects.create(
-            organization=self.organization,
-            user_id=self.user.id,
-            name="Default View",
-            query="ZeroDivisionError",
-            query_sort="date",
-        )
-        GroupSearchViewStarred.objects.create(
-            organization=self.organization,
-            user_id=self.user.id,
-            position=0,
-            group_search_view=default_view,
-        )
-        event = self.store_event(
-            data={
-                "timestamp": before_now(seconds=500).isoformat(),
-                "fingerprint": ["group-1"],
-                "message": "ZeroDivisionError",
-            },
-            project_id=self.project.id,
-        )
-
-        self.store_event(
-            data={
-                "timestamp": before_now(seconds=500).isoformat(),
-                "fingerprint": ["group-2"],
-                "message": "TypeError",
-            },
-            project_id=self.project.id,
-        )
-
-        self.login_as(user=self.user)
-        response = self.get_response(
-            sort_by="date",
-            limit=10,
-            collapse=["unhandled"],
-            savedSearch=0,
-        )
-        assert response.status_code == 200
-        assert len(response.data) == 1
-        assert int(response.data[0]["id"]) == event.group.id
-
-    @with_feature("organizations:issue-stream-custom-views")
-    def test_non_default_custom_view_query(self, _: MagicMock) -> None:
-        GroupSearchView.objects.create(
-            organization=self.organization,
-            user_id=self.user.id,
-            name="Default View",
-            query="TypeError",
-            query_sort="date",
-        )
-
-        view = GroupSearchView.objects.create(
-            organization=self.organization,
-            user_id=self.user.id,
-            name="Custom View",
-            query="ZeroDivisionError",
-            query_sort="date",
-        )
-
-        event = self.store_event(
-            data={
-                "timestamp": before_now(seconds=500).isoformat(),
-                "fingerprint": ["group-1"],
-                "message": "ZeroDivisionError",
-            },
-            project_id=self.project.id,
-        )
-
-        self.login_as(user=self.user)
-        response = self.get_response(
-            sort_by="date",
-            limit=10,
-            collapse=["unhandled"],
-            viewId=view.id,
-            savedSearch=0,
-        )
-        assert response.status_code == 200
-        assert len(response.data) == 1
-        assert int(response.data[0]["id"]) == event.group.id
-
-    @with_feature("organizations:issue-stream-custom-views")
-    def test_global_default_custom_view_query(self, _: MagicMock) -> None:
-        event = self.store_event(
-            data={
-                "timestamp": before_now(seconds=500).isoformat(),
-                "fingerprint": ["group-1"],
-                "message": "ZeroDivisionError",
-            },
-            project_id=self.project.id,
-        )
-        event.group.priority = PriorityLevel.LOW
-        event.group.save()
-
-        self.login_as(user=self.user)
-        response = self.get_response(sort_by="date", limit=10, collapse=["unhandled"])
-
-        # The request is not populated with a query, or a searchId to extract a query from, so the
-        # query used should be the global default, the Prioritized query. Since the only event is a low priority event,
-        # we should expect no results here.
-        assert response.status_code == 200
-        assert len(response.data) == 0
 
     def test_query_status_and_substatus_overlapping(self, _: MagicMock) -> None:
         event = self.store_event(

--- a/tests/sentry/issues/endpoints/test_organization_group_search_view_starred_order.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_view_starred_order.py
@@ -4,7 +4,6 @@ from rest_framework.exceptions import ErrorDetail
 from sentry.models.groupsearchview import GroupSearchView, GroupSearchViewVisibility
 from sentry.models.groupsearchviewstarred import GroupSearchViewStarred
 from sentry.testutils.cases import APITestCase, TransactionTestCase
-from sentry.testutils.helpers.features import with_feature
 
 
 class OrganizationGroupSearchViewStarredOrderEndpointTest(APITestCase):
@@ -67,7 +66,6 @@ class OrganizationGroupSearchViewStarredOrderEndpointTest(APITestCase):
                 position=idx,
             )
 
-    @with_feature("organizations:issue-stream-custom-views")
     def test_simple_reordering(self) -> None:
         self.star_views([self.views[0].id, self.views[1].id, self.views[2].id])
 
@@ -91,7 +89,6 @@ class OrganizationGroupSearchViewStarredOrderEndpointTest(APITestCase):
         assert starred_views[2].group_search_view_id == self.views[1].id
         assert starred_views[2].position == 2
 
-    @with_feature("organizations:issue-stream-custom-views")
     def test_same_order_reordering(self) -> None:
         original_order = [self.views[0].id, self.views[1].id, self.views[2].id]
 
@@ -115,7 +112,6 @@ class OrganizationGroupSearchViewStarredOrderEndpointTest(APITestCase):
         assert starred_views[2].group_search_view_id == self.views[2].id
         assert starred_views[2].position == 2
 
-    @with_feature("organizations:issue-stream-custom-views")
     def reordering_with_shared_views(self) -> None:
         self.star_views([self.views[0].id, self.views[1].id, self.views[2].id, self.shared_view.id])
 
@@ -142,7 +138,6 @@ class OrganizationGroupSearchViewStarredOrderEndpointTest(APITestCase):
         assert starred_views[3].group_search_view_id == self.views[1].id
         assert starred_views[3].position == 3
 
-    @with_feature("organizations:issue-stream-custom-views")
     def test_empty_starred_list(self) -> None:
         response = self.client.put(self.url, data={"view_ids": []}, format="json")
 
@@ -153,7 +148,6 @@ class OrganizationGroupSearchViewStarredOrderEndpointTest(APITestCase):
             user_id=self.user.id,
         ).exists()
 
-    @with_feature("organizations:issue-stream-custom-views")
     def test_error_on_fewer_views_than_starred_views(self) -> None:
         self.star_views([self.views[0].id, self.views[1].id, self.views[2].id])
 
@@ -163,7 +157,6 @@ class OrganizationGroupSearchViewStarredOrderEndpointTest(APITestCase):
 
         assert response.status_code == 400
 
-    @with_feature("organizations:issue-stream-custom-views")
     def test_error_on_more_views_than_starred_views(self) -> None:
         self.star_views([self.views[0].id, self.views[1].id])
 
@@ -175,7 +168,6 @@ class OrganizationGroupSearchViewStarredOrderEndpointTest(APITestCase):
 
         assert response.status_code == 400
 
-    @with_feature("organizations:issue-stream-custom-views")
     def test_error_on_duplicate_view_ids(self) -> None:
         view_ids = [self.views[0].id, self.views[1].id, self.views[1].id]
 
@@ -208,7 +200,6 @@ class OrganizationGroupSearchViewStarredOrderTransactionTest(TransactionTestCase
             query_sort="date",
         )
 
-    @with_feature("organizations:issue-stream-custom-views")
     def test_nonexistent_view_id(self) -> None:
         non_existent_id = 373737
         view_ids = [self.view.id, non_existent_id]

--- a/tests/sentry/issues/endpoints/test_organization_group_search_views.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_views.py
@@ -621,7 +621,6 @@ class OrganizationGroupSearchViewsGetPageFiltersTest(APITestCase):
             kwargs={"organization_id_or_slug": self.organization.slug},
         )
 
-    @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": True})
     def test_basic_get_page_filters_with_global_filters(self) -> None:
         self.login_as(user=self.user)
@@ -639,7 +638,6 @@ class OrganizationGroupSearchViewsGetPageFiltersTest(APITestCase):
         assert response.data[2]["projects"] == [-1]
         assert response.data[2]["environments"] == ["development"]
 
-    @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": False})
     def test_get_page_filters_without_global_filters(self) -> None:
         self.login_as(user=self.user)
@@ -657,7 +655,6 @@ class OrganizationGroupSearchViewsGetPageFiltersTest(APITestCase):
         assert response.data[2]["projects"] == [self.project3.id]
         assert response.data[2]["environments"] == ["development"]
 
-    @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": False})
     def test_get_page_filters_without_global_filters_user_2(self) -> None:
         self.login_as(user=self.user_2)
@@ -667,7 +664,6 @@ class OrganizationGroupSearchViewsGetPageFiltersTest(APITestCase):
         assert response.data[0]["projects"] == [self.project2.id]
         assert response.data[0]["environments"] == []
 
-    @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": False})
     def test_error_when_no_projects_found(self) -> None:
         self.login_as(user=self.user_4)
@@ -691,7 +687,6 @@ class OrganizationGroupSearchViewsGetSortTest(GroupSearchViewAPITestCase):
         )
 
     @freeze_time("2025-03-07T00:00:00Z")
-    @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": True})
     def test_sort_by_default_last_seen(self) -> None:
         self.login_as(user=self.user_1)
@@ -740,7 +735,6 @@ class OrganizationGroupSearchViewsGetSortTest(GroupSearchViewAPITestCase):
         assert response.data[3]["id"] == str(view_3.id), not response.data[3]["starred"]
         assert response.data[4]["id"] == str(view_2.id), not response.data[4]["starred"]
 
-    @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": True})
     def test_created_by_me_sort_by_name(self) -> None:
         self.login_as(user=self.user_1)
@@ -777,7 +771,6 @@ class OrganizationGroupSearchViewsGetSortTest(GroupSearchViewAPITestCase):
         assert response.status_code == 200
         assert len(response.data) == 0
 
-    @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": True})
     def test_created_by_others_sort_by_last_seen(self) -> None:
         self.login_as(user=self.user_1)
@@ -825,7 +818,6 @@ class OrganizationGroupSearchViewsGetSortTest(GroupSearchViewAPITestCase):
         assert response.status_code == 200
         assert len(response.data) == 0
 
-    @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": True})
     def test_created_by_others_sort_by_name(self) -> None:
         self.login_as(user=self.user_1)
@@ -870,7 +862,6 @@ class OrganizationGroupSearchViewsGetSortTest(GroupSearchViewAPITestCase):
         assert response.status_code == 200
         assert len(response.data) == 0
 
-    @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": True})
     def test_created_by_me_sort_by_popularity(self) -> None:
         self.login_as(user=self.user_1)
@@ -922,7 +913,6 @@ class OrganizationGroupSearchViewsGetSortTest(GroupSearchViewAPITestCase):
         # ============= Non-starred views =============
         # None
 
-    @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": True})
     def test_created_by_me_sort_by_created(self) -> None:
         self.login_as(user=self.user_1)
@@ -945,7 +935,6 @@ class OrganizationGroupSearchViewsGetSortTest(GroupSearchViewAPITestCase):
         assert response.data[1]["id"] == str(view_2.id)
         assert response.data[2]["id"] == str(view_1.id)
 
-    @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": True})
     def test_created_by_me_multiple_sort(self) -> None:
         self.login_as(user=self.user_1)

--- a/tests/sentry/issues/endpoints/test_organization_group_search_views_starred.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_views_starred.py
@@ -50,7 +50,6 @@ class OrganizationGroupSearchViewsStarredEndpointTest(APITestCase):
             view=view,
         )
 
-    @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": True})
     def test_simple_case(self) -> None:
         self.login_as(user=self.user)
@@ -69,7 +68,6 @@ class OrganizationGroupSearchViewsStarredEndpointTest(APITestCase):
         assert response.data[1]["id"] == str(view_2.id)
         assert response.data[2]["id"] == str(view_3.id)
 
-    @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": True})
     def test_views_starred_by_many_users(self) -> None:
         user_1 = self.user


### PR DESCRIPTION
Remove code path for custom views, since it is merged with the new nav UI. Next steps will be to remove it from the automator, then from `temporary.py`.