### PR TITLE
:wrench: chore(aci): invoke metric alert noa handlers for metric issue resolutions

### DIFF
--- a/src/sentry/notifications/notification_action/types.py
+++ b/src/sentry/notifications/notification_action/types.py
@@ -24,6 +24,7 @@ from sentry.models.project import Project
 from sentry.models.rule import Rule, RuleSource
 from sentry.notifications.types import TEST_NOTIFICATION_ID
 from sentry.rules.processing.processor import activate_downstream_actions
+from sentry.types.activity import ActivityType
 from sentry.types.rules import RuleFuture
 from sentry.utils.safe import safe_execute
 from sentry.workflow_engine.models import Action, AlertRuleWorkflow, Detector
@@ -336,6 +337,8 @@ class TicketingIssueAlertHandler(BaseIssueAlertHandler):
 
 
 class BaseMetricAlertHandler(ABC):
+    ACTIVITIES_TO_INVOKE_ON = [ActivityType.SET_RESOLVED.value]
+
     @classmethod
     def build_notification_context(cls, action: Action) -> NotificationContext:
         return NotificationContext.from_action_model(action)

--- a/src/sentry/notifications/notification_action/utils.py
+++ b/src/sentry/notifications/notification_action/utils.py
@@ -65,7 +65,7 @@ def execute_via_group_type_registry(
             event_data.event.type in SUPPORTED_ACTIVITIES
             and event_data.group.type == MetricIssue.type_id
         ):
-            execute_via_metric_alert_handler(event_data, action, detector)
+            return execute_via_metric_alert_handler(event_data, action, detector)
         return event_data.event.send_notification()
 
     try:

--- a/src/sentry/notifications/notification_action/utils.py
+++ b/src/sentry/notifications/notification_action/utils.py
@@ -9,9 +9,9 @@ from sentry.notifications.notification_action.registry import (
     issue_alert_handler_registry,
     metric_alert_handler_registry,
 )
+from sentry.notifications.notification_action.types import BaseMetricAlertHandler
 from sentry.utils.registry import NoRegistrationExistsError
 from sentry.workflow_engine.models import Action, Detector
-from sentry.workflow_engine.tasks.workflows import SUPPORTED_ACTIVITIES
 from sentry.workflow_engine.types import WorkflowEventData
 
 logger = logging.getLogger(__name__)
@@ -62,7 +62,7 @@ def execute_via_group_type_registry(
         # If it is a metric issue resolution, we need to execute the metric alert handler
         # Else we can use the activity.send_notification() method to send the notification.
         if (
-            event_data.event.type in SUPPORTED_ACTIVITIES
+            event_data.event.type in BaseMetricAlertHandler.ACTIVITIES_TO_INVOKE_ON
             and event_data.group.type == MetricIssue.type_id
         ):
             return execute_via_metric_alert_handler(event_data, action, detector)
@@ -129,7 +129,7 @@ def execute_via_metric_alert_handler(
         raise
     except Exception:
         logger.exception(
-            "Error executing via issue alert handler",
+            "Error executing via metric alert handler in legacy registry",
             extra={"action_id": action.id, "detector_id": detector.id},
         )
         raise

--- a/src/sentry/notifications/notification_action/utils.py
+++ b/src/sentry/notifications/notification_action/utils.py
@@ -7,9 +7,11 @@ from sentry.models.organization import Organization
 from sentry.notifications.notification_action.registry import (
     group_type_notification_registry,
     issue_alert_handler_registry,
+    metric_alert_handler_registry,
 )
 from sentry.utils.registry import NoRegistrationExistsError
 from sentry.workflow_engine.models import Action, Detector
+from sentry.workflow_engine.tasks.workflows import SUPPORTED_ACTIVITIES
 from sentry.workflow_engine.types import WorkflowEventData
 
 logger = logging.getLogger(__name__)
@@ -57,6 +59,13 @@ def execute_via_group_type_registry(
         # We'll need to update this in the future to read the notification configuration
         # from the Action, then get the template for the activity, and send it to that
         # integration.
+        # If it is a metric issue resolution, we need to execute the metric alert handler
+        # Else we can use the activity.send_notification() method to send the notification.
+        if (
+            event_data.event.type in SUPPORTED_ACTIVITIES
+            and event_data.group.type == MetricIssue.type_id
+        ):
+            execute_via_metric_alert_handler(event_data, action, detector)
         return event_data.event.send_notification()
 
     try:
@@ -86,6 +95,30 @@ def execute_via_issue_alert_handler(
     """
     try:
         handler = issue_alert_handler_registry.get(action.type)
+        handler.invoke_legacy_registry(job, action, detector)
+    except NoRegistrationExistsError:
+        logger.exception(
+            "No notification handler found for action type: %s",
+            action.type,
+            extra={"action_id": action.id, "detector_id": detector.id},
+        )
+        raise
+    except Exception:
+        logger.exception(
+            "Error executing via issue alert handler",
+            extra={"action_id": action.id, "detector_id": detector.id},
+        )
+        raise
+
+
+def execute_via_metric_alert_handler(
+    job: WorkflowEventData, action: Action, detector: Detector
+) -> None:
+    """
+    This exists so that all metric alert resolution actions can use the same handler as metric alerts
+    """
+    try:
+        handler = metric_alert_handler_registry.get(action.type)
         handler.invoke_legacy_registry(job, action, detector)
     except NoRegistrationExistsError:
         logger.exception(

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -1118,6 +1118,11 @@ class Factories:
 
     @staticmethod
     @assume_test_silo_mode(SiloMode.REGION)
+    def create_group_activity(group, *args, **kwargs):
+        return Activity.objects.create(group=group, project=group.project, *args, **kwargs)
+
+    @staticmethod
+    @assume_test_silo_mode(SiloMode.REGION)
     def create_file(**kwargs):
         return File.objects.create(**kwargs)
 

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -315,6 +315,11 @@ class Fixtures:
             project = self.project
         return Factories.create_group(project, *args, **kwargs)
 
+    def create_group_activity(self, group=None, *args, **kwargs):
+        if group is None:
+            group = self.group
+        return Factories.create_group_activity(group, *args, **kwargs)
+
     def create_n_groups_with_hashes(
         self, number_of_groups: int, project: Project, group_type: int | None = None
     ) -> list[Group]:

--- a/tests/sentry/notifications/notification_action/test_group_type_notification_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_group_type_notification_registry_handlers.py
@@ -71,6 +71,7 @@ class TestMetricAlertRegistryInvoker(BaseWorkflowTest):
     def test_handle_metric_issue_resolution(self, mock_execute_metric_alert_handler):
         group = self.create_group(type=MetricIssue.type_id)
         activity = self.create_group_activity(
+            group=group,
             type=ActivityType.SET_RESOLVED.value,
         )
         self.event_data = WorkflowEventData(event=activity, group=group)


### PR DESCRIPTION
next step in triggering actions for resolutions is invoking the metric alert handler for metric issues RESOLVED activities.