### PR TITLE
ref(snuba): remove old side query code path

### DIFF
--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -1,4 +1,3 @@
-import time
 import uuid
 from datetime import UTC, datetime, timedelta
 from typing import Any
@@ -2583,29 +2582,6 @@ class EventsJoinedGroupAttributesSnubaSearchTest(TransactionTestCase, EventsSnub
 
         with mock.patch("sentry.issues.attributes.produce_snapshot_to_kafka", post_insert):
             super().setUp()
-
-    @mock.patch("sentry.utils.metrics.timer")
-    @mock.patch("sentry.utils.metrics.incr")
-    def test_is_unresolved_query_logs_metric(self, metrics_incr, metrics_timer):
-        results = self.make_query(search_filter_query="is:unresolved")
-        assert set(results) == {self.group1}
-
-        # introduce a slight delay so the async future has time to run and log the metric
-        time.sleep(1)
-
-        metrics_incr_called = False
-        for call in metrics_incr.call_args_list:
-            args, kwargs = call
-            if "snuba.search.group_attributes_joined.events_compared" in set(args):
-                metrics_incr_called = True
-        assert metrics_incr_called
-
-        metrics_timer_called = False
-        for call in metrics_timer.call_args_list:
-            args, kwargs = call
-            if "snuba.search.group_attributes_joined.duration" in set(args):
-                metrics_timer_called = True
-        assert metrics_timer_called
 
     def test_issue_priority(self):
         results = self.make_query(search_filter_query="issue.priority:high")

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -33,7 +33,7 @@ from sentry.search.snuba.executors import TrendsSortWeights
 from sentry.seer.seer_utils import FixabilityScoreThresholds
 from sentry.snuba.dataset import Dataset
 from sentry.testutils.cases import SnubaTestCase, TestCase, TransactionTestCase
-from sentry.testutils.helpers import Feature, apply_feature_flag_on_cls
+from sentry.testutils.helpers import Feature
 from sentry.testutils.helpers.datetime import before_now
 from sentry.types.group import GroupSubStatus, PriorityLevel
 from sentry.utils import json
@@ -2568,7 +2568,6 @@ class EventsSnubaSearchTest(TestCase, EventsSnubaSearchTestCases):
     pass
 
 
-@apply_feature_flag_on_cls("organizations:issue-search-group-attributes-side-query")
 class EventsJoinedGroupAttributesSnubaSearchTest(TransactionTestCase, EventsSnubaSearchTestCases):
     def setUp(self):
         def post_insert(snapshot: GroupAttributesSnapshot) -> None:


### PR DESCRIPTION
`organizations:issue-search-group-attributes-side-query` hasn't been enabled for a few months (https://github.com/getsentry/sentry-options-automator/blob/020ef8c90b122b37149599a93c0fa6e3f0938b3f/options/default/flagpole.yml#L2374) - this removes the code path from https://github.com/getsentry/sentry/pull/54519 that introduced it.