### PR TITLE
chore(ondemand-metrics): create new exception type and log as warning instead of error if metric spec is invalid

### DIFF
--- a/src/sentry/relay/config/metric_extraction.py
+++ b/src/sentry/relay/config/metric_extraction.py
@@ -40,6 +40,7 @@ from sentry.snuba.metrics.extraction import (
     MetricSpec,
     MetricSpecType,
     OnDemandMetricSpec,
+    OnDemandMetricSpecError,
     OnDemandMetricSpecVersioning,
     SpecVersion,
     TagMapping,
@@ -810,6 +811,13 @@ def _convert_aggregate_and_query_to_metrics(
                     "on_demand_metrics.invalid_metric_spec", tags={"prefilling": prefilling}
                 )
                 logger.exception("Invalid on-demand metric spec", extra=extra)
+
+            except OnDemandMetricSpecError:
+                metrics.incr("on_demand_metrics.invalid_metric_spec.other")
+                logger.warning(
+                    "Failed on-demand metric spec creation due to specification error.", extra=extra
+                )
+
             except Exception:
                 # Since prefilling might include several non-ondemand-compatible alerts, we want to not trigger errors in the
                 metrics.incr("on_demand_metrics.invalid_metric_spec.other")

--- a/src/sentry/snuba/metrics/extraction.py
+++ b/src/sentry/snuba/metrics/extraction.py
@@ -1175,6 +1175,10 @@ class MetricSpecType(Enum):
     DYNAMIC_QUERY = "dynamic_query"
 
 
+class OnDemandMetricSpecError(Exception):
+    pass
+
+
 @dataclass
 class OnDemandMetricSpec:
     """
@@ -1460,7 +1464,7 @@ class OnDemandMetricSpec:
             return None
 
         if len(parsed_field.arguments) == 0:
-            raise Exception(f"The operation {op} supports one or more parameters")
+            raise OnDemandMetricSpecError(f"The operation {op} supports one or more parameters")
 
         arguments = parsed_field.arguments
         return [_map_field_name(arguments[0])] if op not in _MULTIPLE_ARGS_METRICS else arguments
@@ -1478,7 +1482,7 @@ class OnDemandMetricSpec:
         if op is not None:
             return op
 
-        raise Exception(f"Unsupported aggregate function {function}")
+        raise OnDemandMetricSpecError(f"Unsupported aggregate function {function}")
 
     @staticmethod
     def _get_metric_type(function: str) -> str:
@@ -1486,7 +1490,7 @@ class OnDemandMetricSpec:
         if metric_type is not None:
             return metric_type
 
-        raise Exception(f"Unsupported aggregate function {function}")
+        raise OnDemandMetricSpecError(f"Unsupported aggregate function {function}")
 
     @staticmethod
     def _parse_field(value: str) -> FieldParsingResult:
@@ -1499,7 +1503,9 @@ class OnDemandMetricSpec:
             column = query_builder.resolve_column(value)
             return column
         except InvalidSearchQuery as e:
-            raise Exception(f"Unable to parse the field '{value}' in on demand spec: {e}")
+            raise OnDemandMetricSpecError(
+                f"Unable to parse the field '{value}' in on demand spec: {e}"
+            )
 
     @staticmethod
     def _parse_query(value: str) -> QueryParsingResult:
@@ -1515,7 +1521,7 @@ class OnDemandMetricSpec:
 
             return QueryParsingResult(conditions=conditions)
         except InvalidSearchQuery as e:
-            raise Exception(f"Invalid search query '{value}' in on demand spec: {e}")
+            raise OnDemandMetricSpecError(f"Invalid search query '{value}' in on demand spec: {e}")
 
 
 def fetch_on_demand_metric_spec(


### PR DESCRIPTION
- Creating a warning for this type of errors, as they have been pretty noisy recently and they happen when users don't specify something correctly. We can't fix anything here, so there is no need to be reminded everytime a spec is invalid. 
- In the future, we could add additional guardrails around the input in the frontend to make sure these errors can't even happen anymore. 
