### PR TITLE
fix(dsyms): Search for debug and code id when available

### DIFF
--- a/src/sentry/api/endpoints/debug_files.py
+++ b/src/sentry/api/endpoints/debug_files.py
@@ -273,7 +273,7 @@ class DebugFilesEndpoint(ProjectEndpoint):
             # that the debug id does not perfectly match due to 'age' differences, but the code-id
             # will match.
             q = Q(debug_id__exact=debug_id) | Q(code_id__exact=code_id)
-        if debug_id:
+        elif debug_id:
             q = Q(debug_id__exact=debug_id)
         elif code_id:
             q = Q(code_id__exact=code_id)

--- a/src/sentry/api/endpoints/debug_files.py
+++ b/src/sentry/api/endpoints/debug_files.py
@@ -265,10 +265,15 @@ class DebugFilesEndpoint(ProjectEndpoint):
             except SymbolicError:
                 pass
 
+        if debug_id and code_id:
+            # Be lenient when searching for debug files, check either for a matching debug id
+            # or a matching code id, as both of these are unique identifiers for an object.
+            #
+            # Ideally debug- and code-id yield the same files, but especially on Windows it is possible
+            # that the debug id does not perfectly match due to 'age' differences, but the code-id
+            # will match.
+            q = Q(debug_id__exact=debug_id) | Q(code_id__exact=code_id)
         if debug_id:
-            # If a debug ID is specified, do not consider the stored code
-            # identifier and strictly filter by debug identifier. Often there
-            # are mismatches in the code identifier in PEs.
             q = Q(debug_id__exact=debug_id)
         elif code_id:
             q = Q(code_id__exact=code_id)


### PR DESCRIPTION
The plan is also to have symbolicator request both IDs in one query instead of just debug id (if available).

This should solve the customer issue outlined [here](https://github.com/getsentry/symbolicator/issues/1731), where the debug id does not match, depending on whether it is coming from the SDK or a minidump (crashpad), but the code id matches.