### PR TITLE
fix(dashboards): Use metrics query builder to validate transaction-like widgets

### DIFF
--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -293,7 +293,7 @@ class DashboardWidgetQuerySerializer(CamelSnakeSerializer[Dashboard]):
                 config.has_metrics = use_metrics
                 if use_metrics:
                     QueryBuilder = MetricsUnresolvedQuery
-                    dataset = Dataset.Metrics
+                    dataset = Dataset.PerformanceMetrics
             builder = QueryBuilder(
                 dataset=dataset,
                 params=params,

--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -2121,3 +2121,15 @@ class TopMetricsQueryBuilder(TimeseriesMetricQueryBuilder):
                 "data": list(time_map.values()),
                 "meta": [{"name": key, "type": value} for key, value in meta_dict.items()],
             }
+
+
+class UnresolvedQuery(MetricsQueryBuilder):
+    def resolve_query(
+        self,
+        query: str | None = None,
+        selected_columns: list[str] | None = None,
+        groupby_columns: list[str] | None = None,
+        equations: list[str] | None = None,
+        orderby: list[str] | str | None = None,
+    ) -> None:
+        pass

--- a/tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py
@@ -16,7 +16,7 @@ from sentry.testutils.cases import OrganizationDashboardWidgetTestCase
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.skips import requires_snuba
 
-pytestmark = [requires_snuba]
+pytestmark = [requires_snuba, pytest.mark.sentry_metrics]
 ONDEMAND_FEATURES = [
     "organizations:on-demand-metrics-extraction",
     "organizations:on-demand-metrics-extraction-widgets",
@@ -1350,4 +1350,27 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
             self.url(),
             data=data,
         )
+        assert response.status_code == 200, response.data
+
+    def test_can_save_metrics_enhanced_webvitals_total_score_widget(self):
+        data = {
+            "title": "Metrics Enhanced Web Vitals Total Score",
+            "displayType": "table",
+            "queries": [
+                {
+                    "name": "",
+                    "conditions": "",
+                    "fields": ['performance_score("measurements.score.total")'],
+                    "columns": [],
+                    "aggregates": ["performance_score(measurements.score.total)"],
+                },
+            ],
+            "widgetType": "transaction-like",
+        }
+        with self.feature("organizations:dashboards-mep"):
+            response = self.do_request(
+                "post",
+                self.url(),
+                data=data,
+            )
         assert response.status_code == 200, response.data


### PR DESCRIPTION
Seems like this is missing and throws an error when a user attempts to save a widget