### PR TITLE
fix(ui): match height of ChonkOverlayArrow with height of inline svg

### DIFF
--- a/static/app/components/overlayArrow.tsx
+++ b/static/app/components/overlayArrow.tsx
@@ -18,6 +18,9 @@ export interface OverlayArrowProps extends React.ComponentPropsWithRef<'div'> {
 
 export const OverlayArrow = withChonk(LegacyOverlayArrow, ChonkOverlayArrow);
 
+const sizeRatio = 0.5;
+const heightRatio = 0.3;
+
 function ChonkOverlayArrow({
   placement,
   ref,
@@ -30,16 +33,13 @@ function ChonkOverlayArrow({
 
   const offset = placement?.startsWith('top') ? 3 : 1.5;
   const topOffset = placement?.startsWith('top') ? 3 : 1;
-  const sizeRatio = 0.5;
-  const heightRatio = 0.3;
 
   return (
-    <ChonkWrap size={size} ref={ref} placement={placement} {...props}>
+    <ChonkWrap dimensions={size} ref={ref} placement={placement} {...props}>
       <svg
-        width={size * sizeRatio}
-        height={size * sizeRatio}
-        viewBox={`0 0 ${size} ${size}`}
+        viewBox={`0 0 ${size} ${size * sizeRatio}`}
         fill="none"
+        style={{display: 'block'}}
       >
         {placement?.startsWith('left') || placement?.startsWith('right') ? (
           <polygon
@@ -68,11 +68,11 @@ function ChonkOverlayArrow({
 }
 
 const ChonkWrap = chonkStyled('div')<{
-  size: number;
+  dimensions: number;
   placement?: PopperProps<any>['placement'];
 }>`
-  width: ${p => p.size}px;
-  height: ${p => p.size}px;
+  width: ${p => p.dimensions}px;
+  height: ${p => p.dimensions * sizeRatio}px;
   position: absolute;
   transform-origin: center;
 
@@ -83,12 +83,6 @@ const ChonkWrap = chonkStyled('div')<{
   ${p =>
     p.placement?.startsWith('right') &&
     `right: 100%; top: 50%; transform: rotate(90deg);`}
-
-  > svg {
-    width: ${p => p.size}px;
-    height: ${p => p.size}px;
-  }
-
 `;
 
 function LegacyOverlayArrow({size = 16, placement, ref, ...props}: OverlayArrowProps) {


### PR DESCRIPTION
The content of the svg had a height of 8px (half the passed `size`), but we created the svg and the div above with a height of 16px (full size)

This introduced a problem with Tooltips when this element was then Arrow was then overlaying the element that triggered the tooltip, thus making it “non hovered”.

| before | after |
|--------|--------|
| the blue area was overlapping the purple circle (which is the tooltip trigger) | after: no overlap |
| <img width="797" height="320" alt="Screenshot 2025-07-16 at 15 46 14" src="https://github.com/user-attachments/assets/f578f4c7-eed4-43fb-8c7c-a8a21615d647" /> | <img width="797" height="320" alt="Screenshot 2025-07-16 at 15 45 51" src="https://github.com/user-attachments/assets/2d1e701a-a9bf-42b8-a4c6-86465345fc63" /> | 