### PR TITLE
Also measure per-upload throughput

### DIFF
--- a/src/sentry/nodestore/base.py
+++ b/src/sentry/nodestore/base.py
@@ -12,6 +12,7 @@ from django.utils.functional import cached_property
 from sentry import options
 from sentry.utils import json, metrics
 from sentry.utils.services import Service
+from sentry.utils.storage import measure_storage_put
 
 # Cache an instance of the encoder we want to use
 json_dumps = json.JSONEncoder(
@@ -226,13 +227,13 @@ class NodeStorage(local, Service):
 
         return b"\n".join(lines)
 
-    @metrics.wraps("storage.put.latency", tags={"usecase": "nodestore"})
     def set_bytes(self, item_id: str, data: bytes, ttl: timedelta | None = None) -> None:
         """
         >>> nodestore.set_bytes('key1', b"{'foo': 'bar'}")
         """
         metrics.distribution("nodestore.set_bytes", len(data))
-        return self._set_bytes(item_id, data, ttl)
+        with measure_storage_put(len(data), "nodestore"):
+            return self._set_bytes(item_id, data, ttl)
 
     def _set_bytes(self, item_id: str, data: bytes, ttl: timedelta | None = None) -> None:
         raise NotImplementedError

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -57,6 +57,7 @@ from sentry.utils.locking import UnableToAcquireLock
 from sentry.utils.outcomes import Outcome, track_outcome
 from sentry.utils.projectflags import set_project_flag_and_signal
 from sentry.utils.sdk import set_span_attribute
+from sentry.utils.storage import measure_storage_put
 
 REVERSE_DEVICE_CLASS = {next(iter(tags)): label for label, tags in DEVICE_CLASS.items()}
 
@@ -1418,14 +1419,7 @@ def _process_vroomrs_chunk_profile(profile: Profile) -> bool:
             with sentry_sdk.start_span(op="gcs.write", name="compress and write"):
                 storage = get_profiles_storage()
                 compressed_chunk = chunk.compress()
-
-                metrics.distribution(
-                    "storage.put.size",
-                    len(compressed_chunk),
-                    tags={"usecase": "profiling", "compression": "lz4"},
-                    unit="byte",
-                )
-                with metrics.timer("storage.put.latency", tags={"usecase": "profiling"}):
+                with measure_storage_put(len(compressed_chunk), "profiling", "lz4"):
                     storage.save(chunk.storage_path(), io.BytesIO(compressed_chunk))
             with sentry_sdk.start_span(op="processing", name="send chunk to kafka"):
                 payload = build_chunk_kafka_message(chunk)

--- a/src/sentry/replays/lib/storage.py
+++ b/src/sentry/replays/lib/storage.py
@@ -20,6 +20,7 @@ from sentry.models.files.file import File
 from sentry.models.files.utils import get_storage
 from sentry.replays.models import ReplayRecordingSegment
 from sentry.utils import metrics
+from sentry.utils.storage import measure_storage_put
 
 logger = logging.getLogger()
 
@@ -206,13 +207,7 @@ class SimpleStorageBlob:
     def set(self, key: str, value: bytes) -> None:
         storage = get_storage(self._make_storage_options())
         try:
-            metrics.distribution(
-                "storage.put.size",
-                len(value),
-                tags={"usecase": "replays", "compression": "gzip"},
-                unit="byte",
-            )
-            with metrics.timer("storage.put.latency", tags={"usecase": "replays"}):
+            with measure_storage_put(len(value), "replays", "gzip"):
                 storage.save(key, BytesIO(value))
         except TooManyRequests:
             # if we 429 because of a dupe segment problem, ignore it

--- a/src/sentry/utils/kvstore/bigtable.py
+++ b/src/sentry/utils/kvstore/bigtable.py
@@ -236,12 +236,6 @@ class BigtableKVStorage(KVStorage[str, bytes]):
         # tracking now is whether compression is on or not for the data column.
         flags = self.Flags(0)
 
-        metrics.distribution(
-            "storage.put.size",
-            len(value),
-            tags={"usecase": "nodestore", "compression": "none"},
-            unit="byte",
-        )
         if self.compression:
             compression_flag, strategy = self.compression_strategies[self.compression]
             flags |= compression_flag

--- a/src/sentry/utils/storage.py
+++ b/src/sentry/utils/storage.py
@@ -1,0 +1,26 @@
+import time
+from collections.abc import Generator
+from contextlib import contextmanager
+
+from sentry.utils import metrics
+
+
+@contextmanager
+def measure_storage_put(
+    upload_size: int, usecase: str, compression: str | None = None
+) -> Generator[None]:
+    metrics.distribution(
+        "storage.put.size",
+        upload_size,
+        tags={"usecase": usecase, "compression": compression or "none"},
+        unit="byte",
+    )
+    start = time.monotonic()
+    try:
+        yield
+    finally:
+        elapsed = time.monotonic() - start
+        metrics.timing("storage.put.latency", elapsed, tags={"usecase": usecase})
+        metrics.distribution(
+            "storage.put.throughput", upload_size / elapsed, tags={"usecase": usecase}
+        )

--- a/src/sentry/utils/storage.py
+++ b/src/sentry/utils/storage.py
@@ -21,6 +21,7 @@ def measure_storage_put(
     finally:
         elapsed = time.monotonic() - start
         metrics.timing("storage.put.latency", elapsed, tags={"usecase": usecase})
-        metrics.distribution(
-            "storage.put.throughput", upload_size / elapsed, tags={"usecase": usecase}
-        )
+        if elapsed > 0:
+            metrics.distribution(
+                "storage.put.throughput", upload_size / elapsed, tags={"usecase": usecase}
+            )


### PR DESCRIPTION
In order to better judge the fixed overhead of storage uploads, we would like to measure the throughput per-upload.