### PR TITLE
fix(stories): ignore unknown mdx exports

### DIFF
--- a/static/app/stories/view/storyExports.tsx
+++ b/static/app/stories/view/storyExports.tsx
@@ -127,6 +127,9 @@ function StoryUsage() {
         </Storybook.Section>
       )}
       {Object.entries(namedExports).map(([name, MaybeComponent]) => {
+        if (filename.endsWith('.mdx')) {
+          return null;
+        }
         if (EXPECTED_EXPORTS.has(name as keyof StoryExportValues)) {
           return null;
         }


### PR DESCRIPTION
In `.mdx` files, the `export` keyword is required for any local components defined in the file. In some cases, we were treating these exports as if they were stories, but `.mdx` files should only ever render a single story.

Closes [DE-198](https://linear.app/getsentry/issue/DE-198/remove-extra-label-on-colors-page)

[DE-198]: https://getsentry.atlassian.net/browse/DE-198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ