### PR TITLE
ref(insights): replace `spanIndexedFields` with `spanFields`

### DIFF
--- a/static/app/components/performance/spanSearchQueryBuilder.tsx
+++ b/static/app/components/performance/spanSearchQueryBuilder.tsx
@@ -27,7 +27,7 @@ import {
 import {useTraceItemTags} from 'sentry/views/explore/contexts/spanTagsContext';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 import {SPANS_FILTER_KEY_SECTIONS} from 'sentry/views/insights/constants';
-import {SpanIndexedField} from 'sentry/views/insights/types';
+import {SpanFields} from 'sentry/views/insights/types';
 import {
   useSpanFieldCustomTags,
   useSpanFieldSupportedTags,
@@ -218,7 +218,7 @@ export function useEAPSpanSearchQueryBuilderProps(props: EAPSpanSearchQueryBuild
 
   const numberAttributes = numberTags;
   const stringAttributes = useMemo(() => {
-    if (stringTags.hasOwnProperty(SpanIndexedField.RELEASE)) {
+    if (stringTags.hasOwnProperty(SpanFields.RELEASE)) {
       return {
         ...stringTags,
         ...STATIC_SEMVER_TAGS,

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -1,7 +1,7 @@
 import {t} from 'sentry/locale';
 import type {TagCollection} from 'sentry/types/group';
 import {CONDITIONS_ARGUMENTS, WEB_VITALS_QUALITY} from 'sentry/utils/discover/types';
-import {SpanFields, SpanFields} from 'sentry/views/insights/types';
+import {SpanFields} from 'sentry/views/insights/types';
 // Don't forget to update https://docs.sentry.io/product/sentry-basics/search/searchable-properties/ for any changes made here
 
 export enum FieldKind {

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -1204,6 +1204,7 @@ type TraceFields =
   // TODO: Remove self time field when it is deprecated
   | SpanFields.SPAN_SELF_TIME
   | SpanFields.SPAN_STATUS
+  | SpanFields.SPAN_STATUS_CODE
   | SpanFields.CACHE_HIT;
 
 const TRACE_FIELD_DEFINITIONS: Record<TraceFields, FieldDefinition> = {
@@ -1262,6 +1263,11 @@ const TRACE_FIELD_DEFINITIONS: Record<TraceFields, FieldDefinition> = {
     valueType: FieldValueType.DURATION,
   },
   [SpanFields.SPAN_STATUS]: {
+    desc: t('Status of the operation the span represents'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  [SpanFields.SPAN_STATUS_CODE]: {
     desc: t('The HTTP response status code'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
@@ -1922,7 +1928,7 @@ const SPAN_FIELD_DEFINITIONS: Record<string, FieldDefinition> = {
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },
-  [SpanFields.STATUS]: {
+  [SpanFields.SPAN_STATUS]: {
     desc: t('Span status. Indicates whether the span operation was successful.'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -1,7 +1,7 @@
 import {t} from 'sentry/locale';
 import type {TagCollection} from 'sentry/types/group';
 import {CONDITIONS_ARGUMENTS, WEB_VITALS_QUALITY} from 'sentry/utils/discover/types';
-import {SpanFields, SpanIndexedField} from 'sentry/views/insights/types';
+import {SpanFields, SpanFields} from 'sentry/views/insights/types';
 // Don't forget to update https://docs.sentry.io/product/sentry-basics/search/searchable-properties/ for any changes made here
 
 export enum FieldKind {
@@ -826,9 +826,9 @@ export const AGGREGATION_FIELDS: Record<AggregationKey, FieldDefinition> = {
 };
 
 // TODO: Extend the two lists below with more options upon backend support
-export const ALLOWED_EXPLORE_VISUALIZE_FIELDS: SpanIndexedField[] = [
-  SpanIndexedField.SPAN_DURATION, // DO NOT RE-ORDER: the first element is used as the default
-  SpanIndexedField.SPAN_SELF_TIME,
+export const ALLOWED_EXPLORE_VISUALIZE_FIELDS: SpanFields[] = [
+  SpanFields.SPAN_DURATION, // DO NOT RE-ORDER: the first element is used as the default
+  SpanFields.SPAN_SELF_TIME,
 ];
 
 export const ALLOWED_EXPLORE_VISUALIZE_AGGREGATES: AggregationKey[] = [
@@ -859,7 +859,7 @@ const SPAN_AGGREGATION_FIELDS: Record<AggregationKey, FieldDefinition> = {
         kind: 'column',
         columnTypes: function ({key, valueType}) {
           return (
-            key === SpanIndexedField.SPAN_DURATION &&
+            key === SpanFields.SPAN_DURATION &&
             (valueType === FieldValueType.DURATION || valueType === FieldValueType.NUMBER)
           );
         },
@@ -1192,92 +1192,86 @@ const SPAN_OP_FIELDS: Record<SpanOpBreakdown, FieldDefinition> = {
 };
 
 type TraceFields =
-  | SpanIndexedField.IS_TRANSACTION
-  | SpanIndexedField.SPAN_ACTION
-  | SpanIndexedField.SPAN_DESCRIPTION
-  | SpanIndexedField.SPAN_DOMAIN
-  | SpanIndexedField.SPAN_DURATION
-  | SpanIndexedField.SPAN_GROUP
-  | SpanIndexedField.SPAN_CATEGORY
-  | SpanIndexedField.SPAN_OP
-  | SpanIndexedField.NORMALIZED_DESCRIPTION
+  | SpanFields.IS_TRANSACTION
+  | SpanFields.SPAN_ACTION
+  | SpanFields.SPAN_DESCRIPTION
+  | SpanFields.SPAN_DOMAIN
+  | SpanFields.SPAN_DURATION
+  | SpanFields.SPAN_GROUP
+  | SpanFields.SPAN_CATEGORY
+  | SpanFields.SPAN_OP
+  | SpanFields.NORMALIZED_DESCRIPTION
   // TODO: Remove self time field when it is deprecated
-  | SpanIndexedField.SPAN_SELF_TIME
-  | SpanIndexedField.SPAN_STATUS
-  | SpanIndexedField.RESPONSE_CODE
-  | SpanIndexedField.CACHE_HIT;
+  | SpanFields.SPAN_SELF_TIME
+  | SpanFields.SPAN_STATUS
+  | SpanFields.CACHE_HIT;
 
 const TRACE_FIELD_DEFINITIONS: Record<TraceFields, FieldDefinition> = {
   /** Indexed Fields */
-  [SpanIndexedField.SPAN_ACTION]: {
+  [SpanFields.SPAN_ACTION]: {
     desc: t(
       'The Sentry Insights span action, e.g `SELECT` for a SQL span or `POST` for an HTTP client span'
     ),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },
-  [SpanIndexedField.SPAN_DESCRIPTION]: {
+  [SpanFields.SPAN_DESCRIPTION]: {
     desc: t('Description of the span’s operation'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },
-  [SpanIndexedField.NORMALIZED_DESCRIPTION]: {
+  [SpanFields.NORMALIZED_DESCRIPTION]: {
     desc: t(
       'Parameterized and normalized description of the span, commonly used for grouping within insights'
     ),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },
-  [SpanIndexedField.SPAN_DOMAIN]: {
+  [SpanFields.SPAN_DOMAIN]: {
     desc: t(
       'General scope of the span’s action, i.e. the tables involved in a `db` span or the host name in an `http` span'
     ),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },
-  [SpanIndexedField.SPAN_DURATION]: {
+  [SpanFields.SPAN_DURATION]: {
     desc: t('The total time taken by the span'),
     kind: FieldKind.METRICS,
     valueType: FieldValueType.DURATION,
   },
-  [SpanIndexedField.SPAN_GROUP]: {
+  [SpanFields.SPAN_GROUP]: {
     desc: t('Unique hash of the span’s description'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },
-  [SpanIndexedField.SPAN_CATEGORY]: {
+  [SpanFields.SPAN_CATEGORY]: {
     desc: t(
       'The prefix of the span operation, e.g if `span.op` is `http.client`, then `span.category` is `http`'
     ),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },
-  [SpanIndexedField.SPAN_OP]: {
+  [SpanFields.SPAN_OP]: {
     desc: t('The operation of the span, e.g `http.client`, `middleware`'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },
-  [SpanIndexedField.SPAN_SELF_TIME]: {
+  [SpanFields.SPAN_SELF_TIME]: {
     desc: t('The duration of the span excluding the duration of its child spans'),
     kind: FieldKind.METRICS,
     valueType: FieldValueType.DURATION,
   },
-  [SpanIndexedField.SPAN_STATUS]: {
-    desc: t('Status of the operation the span represents'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.STRING,
-  },
-  [SpanIndexedField.RESPONSE_CODE]: {
+  [SpanFields.SPAN_STATUS]: {
     desc: t('The HTTP response status code'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },
-  [SpanIndexedField.IS_TRANSACTION]: {
+  [SpanFields.IS_TRANSACTION]: {
     desc: t('The span is also a transaction'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.BOOLEAN,
   },
-  [SpanIndexedField.CACHE_HIT]: {
+  [SpanFields.CACHE_HIT]: {
     desc: t('`true` if the  cache was hit, `false` otherwise'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.BOOLEAN,

--- a/static/app/views/dashboards/widgets/common/types.tsx
+++ b/static/app/views/dashboards/widgets/common/types.tsx
@@ -71,7 +71,7 @@ export type TabularMeta<TFields extends string = string> = {
 
 export type TabularRow<TFields extends string = string> = Record<
   TFields,
-  number | string | string[] | null
+  number | string | string[] | boolean | null
 >;
 
 export type TabularData<TFields extends string = string> = {

--- a/static/app/views/explore/components/schemaHints/schemaHintsList.tsx
+++ b/static/app/views/explore/components/schemaHints/schemaHintsList.tsx
@@ -40,7 +40,7 @@ import {
 } from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {LOGS_FILTER_KEY_SECTIONS} from 'sentry/views/explore/logs/constants';
 import {SPANS_FILTER_KEY_SECTIONS} from 'sentry/views/insights/constants';
-import {SpanIndexedField} from 'sentry/views/insights/types';
+import {SpanFields} from 'sentry/views/insights/types';
 
 const SCHEMA_HINTS_DRAWER_WIDTH = '350px';
 
@@ -75,9 +75,9 @@ function getTagsFromKeys(keys: string[], tags: TagCollection): Tag[] {
     .map(key => {
       if (key === USER_IDENTIFIER_KEY) {
         return (
-          tags[SpanIndexedField.USER_EMAIL] ||
-          tags[SpanIndexedField.USER_USERNAME] ||
-          tags[SpanIndexedField.USER_ID]
+          tags[SpanFields.USER_EMAIL] ||
+          tags[SpanFields.USER_USERNAME] ||
+          tags[SpanFields.USER_ID]
         );
       }
       return tags[key];

--- a/static/app/views/explore/components/schemaHints/schemaHintsUtils.tsx
+++ b/static/app/views/explore/components/schemaHints/schemaHintsUtils.tsx
@@ -1,22 +1,22 @@
 import type {TagCollection} from 'sentry/types/group';
 import {FieldKey} from 'sentry/utils/fields';
 import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
-import {SpanIndexedField} from 'sentry/views/insights/types';
+import {SpanFields} from 'sentry/views/insights/types';
 
 export const USER_IDENTIFIER_KEY = 'user.key';
 
-const FRONTEND_HINT_KEYS = [SpanIndexedField.BROWSER_NAME, USER_IDENTIFIER_KEY];
+const FRONTEND_HINT_KEYS = [SpanFields.BROWSER_NAME, USER_IDENTIFIER_KEY];
 
 const MOBILE_HINT_KEYS = [FieldKey.OS_NAME, FieldKey.DEVICE_FAMILY, USER_IDENTIFIER_KEY];
 
 const COMMON_HINT_KEYS = [
-  SpanIndexedField.IS_TRANSACTION,
-  SpanIndexedField.SPAN_OP,
-  SpanIndexedField.SPAN_DESCRIPTION,
-  SpanIndexedField.SPAN_DURATION,
-  SpanIndexedField.TRANSACTION,
+  SpanFields.IS_TRANSACTION,
+  SpanFields.SPAN_OP,
+  SpanFields.SPAN_DESCRIPTION,
+  SpanFields.SPAN_DURATION,
+  SpanFields.TRANSACTION,
   FieldKey.HTTP_STATUS_CODE,
-  SpanIndexedField.RELEASE,
+  SpanFields.RELEASE,
   'url',
 ];
 

--- a/static/app/views/explore/constants.tsx
+++ b/static/app/views/explore/constants.tsx
@@ -1,5 +1,5 @@
 import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
-import {SpanFields, SpanIndexedField} from 'sentry/views/insights/types';
+import {SpanFields, SpanFields} from 'sentry/views/insights/types';
 
 export const SENTRY_SEARCHABLE_SPAN_STRING_TAGS: string[] = [
   // NOTE: intentionally choose to not expose transaction id
@@ -7,53 +7,53 @@ export const SENTRY_SEARCHABLE_SPAN_STRING_TAGS: string[] = [
 
   'id', // SpanIndexedField.SPAN_ID is actually `span_id`
   'profile.id', // SpanIndexedField.PROFILE_ID is actually `profile_id`
-  SpanIndexedField.BROWSER_NAME,
-  SpanIndexedField.ENVIRONMENT,
-  SpanIndexedField.ORIGIN_TRANSACTION,
-  SpanIndexedField.PROJECT,
-  SpanIndexedField.RAW_DOMAIN,
-  SpanIndexedField.RELEASE,
-  SpanIndexedField.SDK_NAME,
-  SpanIndexedField.SDK_VERSION,
-  SpanIndexedField.SPAN_ACTION,
-  SpanIndexedField.SPAN_CATEGORY,
-  SpanIndexedField.SPAN_DESCRIPTION,
-  SpanIndexedField.SPAN_DOMAIN,
-  SpanIndexedField.SPAN_GROUP,
-  SpanIndexedField.SPAN_OP,
-  SpanIndexedField.SPAN_STATUS,
-  SpanIndexedField.TIMESTAMP,
-  SpanIndexedField.TRACE,
-  SpanIndexedField.TRANSACTION,
-  SpanIndexedField.TRANSACTION_METHOD,
-  SpanIndexedField.TRANSACTION_OP,
-  SpanIndexedField.USER,
-  SpanIndexedField.USER_EMAIL,
-  SpanIndexedField.USER_GEO_SUBREGION,
-  SpanIndexedField.USER_ID,
-  SpanIndexedField.USER_IP,
-  SpanIndexedField.USER_USERNAME,
-  SpanIndexedField.IS_TRANSACTION, // boolean field but we can expose it as a string
-  SpanIndexedField.NORMALIZED_DESCRIPTION,
-  SpanIndexedField.CACHE_HIT,
+  SpanFields.BROWSER_NAME,
+  SpanFields.ENVIRONMENT,
+  SpanFields.ORIGIN_TRANSACTION,
+  SpanFields.PROJECT,
+  SpanFields.RAW_DOMAIN,
+  SpanFields.RELEASE,
+  SpanFields.SDK_NAME,
+  SpanFields.SDK_VERSION,
+  SpanFields.SPAN_ACTION,
+  SpanFields.SPAN_CATEGORY,
+  SpanFields.SPAN_DESCRIPTION,
+  SpanFields.SPAN_DOMAIN,
+  SpanFields.SPAN_GROUP,
+  SpanFields.SPAN_OP,
+  SpanFields.SPAN_STATUS,
+  SpanFields.TIMESTAMP,
+  SpanFields.TRACE,
+  SpanFields.TRANSACTION,
+  SpanFields.TRANSACTION_METHOD,
+  SpanFields.TRANSACTION_OP,
+  SpanFields.USER,
+  SpanFields.USER_EMAIL,
+  SpanFields.USER_GEO_SUBREGION,
+  SpanFields.USER_ID,
+  SpanFields.USER_IP,
+  SpanFields.USER_USERNAME,
+  SpanFields.IS_TRANSACTION, // boolean field but we can expose it as a string
+  SpanFields.NORMALIZED_DESCRIPTION,
+  SpanFields.CACHE_HIT,
 ];
 
 export const SENTRY_SEARCHABLE_SPAN_NUMBER_TAGS: string[] = [
-  SpanIndexedField.SPAN_DURATION,
-  SpanIndexedField.SPAN_SELF_TIME,
+  SpanFields.SPAN_DURATION,
+  SpanFields.SPAN_SELF_TIME,
 ];
 
 export const SENTRY_SPAN_STRING_TAGS: string[] = [
   'id', // SpanIndexedField.SPAN_ID is actually `span_id`
-  SpanIndexedField.PROJECT,
-  SpanIndexedField.SPAN_DESCRIPTION,
-  SpanIndexedField.SPAN_OP,
-  SpanIndexedField.TIMESTAMP,
-  SpanIndexedField.TRANSACTION,
-  SpanIndexedField.TRACE,
-  SpanIndexedField.IS_TRANSACTION, // boolean field but we can expose it as a string
-  SpanIndexedField.NORMALIZED_DESCRIPTION,
-  SpanIndexedField.RELEASE, // temporary as orgs with >1k keys still want releases
+  SpanFields.PROJECT,
+  SpanFields.SPAN_DESCRIPTION,
+  SpanFields.SPAN_OP,
+  SpanFields.TIMESTAMP,
+  SpanFields.TRANSACTION,
+  SpanFields.TRACE,
+  SpanFields.IS_TRANSACTION, // boolean field but we can expose it as a string
+  SpanFields.NORMALIZED_DESCRIPTION,
+  SpanFields.RELEASE, // temporary as orgs with >1k keys still want releases
   SpanFields.PROJECT_ID,
   SpanFields.SPAN_SYSTEM,
   SpanFields.SPAN_CATEGORY,

--- a/static/app/views/explore/constants.tsx
+++ b/static/app/views/explore/constants.tsx
@@ -1,5 +1,5 @@
 import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
-import {SpanFields, SpanFields} from 'sentry/views/insights/types';
+import {SpanFields} from 'sentry/views/insights/types';
 
 export const SENTRY_SEARCHABLE_SPAN_STRING_TAGS: string[] = [
   // NOTE: intentionally choose to not expose transaction id

--- a/static/app/views/explore/contexts/pageParamsContext/visualizes.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/visualizes.tsx
@@ -16,7 +16,7 @@ import {
 } from 'sentry/utils/fields';
 import {decodeList} from 'sentry/utils/queryString';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
-import {SpanIndexedField} from 'sentry/views/insights/types';
+import {SpanFields} from 'sentry/views/insights/types';
 
 export const MAX_VISUALIZES = 4;
 
@@ -168,7 +168,7 @@ export function updateVisualizeAggregate({
     // and carry the argument if it's the same type, reset to a default
     // if it's not the same type. Just hard coding it for now for simplicity
     // as `count_unique` is the only aggregate that takes a string.
-    return `${newAggregate}(${SpanIndexedField.SPAN_OP})`;
+    return `${newAggregate}(${SpanFields.SPAN_OP})`;
   }
 
   if (NO_ARGUMENT_SPAN_AGGREGATES.includes(newAggregate as AggregationKey)) {

--- a/static/app/views/explore/hooks/useVisualizeFields.tsx
+++ b/static/app/views/explore/hooks/useVisualizeFields.tsx
@@ -13,7 +13,7 @@ import {
 } from 'sentry/utils/fields';
 import {AttributeDetails} from 'sentry/views/explore/components/attributeDetails';
 import {TypeBadge} from 'sentry/views/explore/components/typeBadge';
-import {SpanIndexedField} from 'sentry/views/insights/types';
+import {SpanFields} from 'sentry/views/insights/types';
 
 interface UseVisualizeFieldsProps {
   numberTags: TagCollection;
@@ -29,9 +29,9 @@ export function useVisualizeFields({
   const [kind, tags]: [FieldKind, TagCollection] = useMemo(() => {
     if (parsedFunction?.name === AggregationKey.COUNT) {
       const countTags: TagCollection = {
-        [SpanIndexedField.SPAN_DURATION]: {
+        [SpanFields.SPAN_DURATION]: {
           name: t('spans'),
-          key: SpanIndexedField.SPAN_DURATION,
+          key: SpanFields.SPAN_DURATION,
         },
       };
       return [FieldKind.MEASUREMENT, countTags];

--- a/static/app/views/explore/tables/tracesTable/fieldRenderers.tsx
+++ b/static/app/views/explore/tables/tracesTable/fieldRenderers.tsx
@@ -505,6 +505,7 @@ const STATUS_TO_TAG_TYPE: Record<SpanStatus, keyof Theme['tag']> = {
 };
 
 function statusToTagType(status: string) {
+  // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
   return STATUS_TO_TAG_TYPE[status];
 }
 

--- a/static/app/views/explore/tables/tracesTable/fieldRenderers.tsx
+++ b/static/app/views/explore/tables/tracesTable/fieldRenderers.tsx
@@ -23,7 +23,7 @@ import useProjects from 'sentry/utils/useProjects';
 import type {TraceResult} from 'sentry/views/explore/hooks/useTraces';
 import {BREAKDOWN_SLICES} from 'sentry/views/explore/hooks/useTraces';
 import type {SpanResult} from 'sentry/views/explore/hooks/useTraceSpans';
-import type {SpanIndexedField, SpanIndexedResponse} from 'sentry/views/insights/types';
+import type {EAPSpanResponse, SpanFields} from 'sentry/views/insights/types';
 import {TraceViewSources} from 'sentry/views/performance/newTraceDetails/traceHeader/breadcrumbs';
 import {getTraceDetailsUrl} from 'sentry/views/performance/traceDetails/utils';
 
@@ -482,7 +482,7 @@ export function SpanTimeRenderer({
   );
 }
 
-type SpanStatus = SpanIndexedResponse[SpanIndexedField.SPAN_STATUS];
+type SpanStatus = EAPSpanResponse[SpanFields.SPAN_STATUS];
 
 const STATUS_TO_TAG_TYPE: Record<SpanStatus, keyof Theme['tag']> = {
   ok: 'success',
@@ -505,7 +505,6 @@ const STATUS_TO_TAG_TYPE: Record<SpanStatus, keyof Theme['tag']> = {
 };
 
 function statusToTagType(status: string) {
-  // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
   return STATUS_TO_TAG_TYPE[status];
 }
 

--- a/static/app/views/insights/browser/resources/components/sampleImages.spec.tsx
+++ b/static/app/views/insights/browser/resources/components/sampleImages.spec.tsx
@@ -9,10 +9,10 @@ import type {Organization} from 'sentry/types/organization';
 import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import SampleImages from 'sentry/views/insights/browser/resources/components/sampleImages';
-import {SpanIndexedField} from 'sentry/views/insights/types';
+import {SpanFields} from 'sentry/views/insights/types';
 
 const {SPAN_GROUP, HTTP_RESPONSE_CONTENT_LENGTH, RAW_DOMAIN, SPAN_DESCRIPTION} =
-  SpanIndexedField;
+  SpanFields;
 
 jest.mock('sentry/utils/useLocation');
 jest.mock('sentry/utils/usePageFilters');

--- a/static/app/views/insights/browser/resources/components/tables/resourceSummaryTable.tsx
+++ b/static/app/views/insights/browser/resources/components/tables/resourceSummaryTable.tsx
@@ -32,7 +32,7 @@ import {
 } from 'sentry/views/insights/common/views/spans/types';
 import {
   ModuleName,
-  SpanIndexedField,
+  SpanFields,
   SpanMetricsField,
   type SpanMetricsResponse,
 } from 'sentry/views/insights/types';
@@ -138,9 +138,9 @@ function ResourceSummaryTable() {
                   group={groupId}
                   moduleName={ModuleName.RESOURCE}
                   filters={{
-                    [SpanIndexedField.RESOURCE_RENDER_BLOCKING_STATUS]:
+                    [SpanFields.RESOURCE_RENDER_BLOCKING_STATUS]:
                       row[RESOURCE_RENDER_BLOCKING_STATUS],
-                    [SpanIndexedField.TRANSACTION]: row[TRANSACTION],
+                    [SpanFields.TRANSACTION]: row[TRANSACTION],
                   }}
                 />
               </Fragment>

--- a/static/app/views/insights/browser/webVitals/components/browserTypeSelector.tsx
+++ b/static/app/views/insights/browser/webVitals/components/browserTypeSelector.tsx
@@ -10,7 +10,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {BrowserType} from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
-import {SpanIndexedField} from 'sentry/views/insights/types';
+import {SpanFields} from 'sentry/views/insights/types';
 
 const LabelContainer = styled('div')`
   display: flex;
@@ -77,7 +77,7 @@ export default function BrowserTypeSelector() {
   const location = useLocation();
   const organization = useOrganization();
 
-  const value = decodeList(location.query[SpanIndexedField.BROWSER_NAME]);
+  const value = decodeList(location.query[SpanFields.BROWSER_NAME]);
 
   return (
     <CompactSelect
@@ -98,7 +98,7 @@ export default function BrowserTypeSelector() {
           ...location,
           query: {
             ...location.query,
-            [SpanIndexedField.BROWSER_NAME]: selectedOptions.map(option => option.value),
+            [SpanFields.BROWSER_NAME]: selectedOptions.map(option => option.value),
           },
         });
       }}

--- a/static/app/views/insights/browser/webVitals/components/charts/webVitalStatusLineChart.tsx
+++ b/static/app/views/insights/browser/webVitals/components/charts/webVitalStatusLineChart.tsx
@@ -21,7 +21,7 @@ import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/i
 import type {DiscoverSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {useMetricsSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import type {SubregionCode} from 'sentry/views/insights/types';
-import {SpanIndexedField} from 'sentry/views/insights/types';
+import {SpanFields} from 'sentry/views/insights/types';
 
 interface Props {
   webVital: WebVitals | null;
@@ -46,10 +46,10 @@ export function WebVitalStatusLineChart({
     search.addFilterValue('transaction', transaction);
   }
   if (browserTypes) {
-    search.addDisjunctionFilterValues(SpanIndexedField.BROWSER_NAME, browserTypes);
+    search.addDisjunctionFilterValues(SpanFields.BROWSER_NAME, browserTypes);
   }
   if (subregions) {
-    search.addDisjunctionFilterValues(SpanIndexedField.USER_GEO_SUBREGION, subregions);
+    search.addDisjunctionFilterValues(SpanFields.USER_GEO_SUBREGION, subregions);
   }
 
   const {

--- a/static/app/views/insights/browser/webVitals/components/pageOverviewWebVitalsDetailPanel.tsx
+++ b/static/app/views/insights/browser/webVitals/components/pageOverviewWebVitalsDetailPanel.tsx
@@ -38,7 +38,7 @@ import decodeBrowserTypes from 'sentry/views/insights/browser/webVitals/utils/qu
 import useProfileExists from 'sentry/views/insights/browser/webVitals/utils/useProfileExists';
 import {SampleDrawerBody} from 'sentry/views/insights/common/components/sampleDrawerBody';
 import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
-import {SpanIndexedField, type SubregionCode} from 'sentry/views/insights/types';
+import {SpanFields, type SubregionCode} from 'sentry/views/insights/types';
 import {TraceViewSources} from 'sentry/views/performance/newTraceDetails/traceHeader/breadcrumbs';
 import {generateReplayLink} from 'sentry/views/performance/transactionSummary/utils';
 
@@ -55,7 +55,7 @@ const PAGELOADS_COLUMN_ORDER: GridColumnOrder[] = [
 const SPANS_SAMPLES_COLUMN_ORDER: GridColumnOrder[] = [
   {key: 'id', width: COL_WIDTH_UNDEFINED, name: t('Trace')},
   {
-    key: SpanIndexedField.SPAN_DESCRIPTION,
+    key: SpanFields.SPAN_DESCRIPTION,
     width: COL_WIDTH_UNDEFINED,
     name: t('Description'),
   },
@@ -84,10 +84,8 @@ export function PageOverviewWebVitalsDetailPanel({
   const {replayExists} = useReplayExists();
   const domainViewFilters = useDomainViewFilters();
 
-  const browserTypes = decodeBrowserTypes(location.query[SpanIndexedField.BROWSER_NAME]);
-  const subregions = location.query[
-    SpanIndexedField.USER_GEO_SUBREGION
-  ] as SubregionCode[];
+  const browserTypes = decodeBrowserTypes(location.query[SpanFields.BROWSER_NAME]);
+  const subregions = location.query[SpanFields.USER_GEO_SUBREGION] as SubregionCode[];
   const isSpansWebVital = defined(webVital) && ['inp', 'cls', 'lcp'].includes(webVital);
   const isInp = webVital === 'inp';
   const useSpansWebVitals = organization.features.includes(
@@ -148,7 +146,7 @@ export function PageOverviewWebVitalsDetailPanel({
       return <AlignCenter>{col.name}</AlignCenter>;
     }
 
-    if (col.key === SpanIndexedField.SPAN_DESCRIPTION) {
+    if (col.key === SpanFields.SPAN_DESCRIPTION) {
       if (webVital === 'lcp') {
         return <span>{t('LCP Element')}</span>;
       }
@@ -206,7 +204,7 @@ export function PageOverviewWebVitalsDetailPanel({
         {
           replayId: row.replayId,
           id: '', // id doesn't actually matter here. Just to satisfy type.
-          'transaction.duration': row[SpanIndexedField.SPAN_SELF_TIME],
+          'transaction.duration': row[SpanFields.SPAN_SELF_TIME],
           timestamp: row.timestamp,
         },
         undefined
@@ -247,12 +245,12 @@ export function PageOverviewWebVitalsDetailPanel({
       );
     }
 
-    if (key === SpanIndexedField.SPAN_DESCRIPTION) {
+    if (key === SpanFields.SPAN_DESCRIPTION) {
       const description =
-        webVital === 'lcp' && row[SpanIndexedField.SPAN_OP] === 'pageload'
-          ? row[SpanIndexedField.LCP_ELEMENT]
-          : webVital === 'cls' && row[SpanIndexedField.SPAN_OP] === 'pageload'
-            ? row[SpanIndexedField.CLS_SOURCE]
+        webVital === 'lcp' && row[SpanFields.SPAN_OP] === 'pageload'
+          ? row[SpanFields.LCP_ELEMENT]
+          : webVital === 'cls' && row[SpanFields.SPAN_OP] === 'pageload'
+            ? row[SpanFields.CLS_SOURCE]
             : row[key];
 
       if (description) {

--- a/static/app/views/insights/browser/webVitals/components/tables/pagePerformanceTable.tsx
+++ b/static/app/views/insights/browser/webVitals/components/tables/pagePerformanceTable.tsx
@@ -36,11 +36,7 @@ import {SORTABLE_FIELDS} from 'sentry/views/insights/browser/webVitals/types';
 import decodeBrowserTypes from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
 import {useWebVitalsSort} from 'sentry/views/insights/browser/webVitals/utils/useWebVitalsSort';
 import {useModuleURL} from 'sentry/views/insights/common/utils/useModuleURL';
-import {
-  ModuleName,
-  SpanIndexedField,
-  type SubregionCode,
-} from 'sentry/views/insights/types';
+import {ModuleName, SpanFields, type SubregionCode} from 'sentry/views/insights/types';
 
 type Column = GridColumnHeader<keyof RowWithScoreAndOpportunity>;
 
@@ -78,9 +74,9 @@ export function PagePerformanceTable() {
   const columnOrder = COLUMN_ORDER;
 
   const query = decodeScalar(location.query.query, '');
-  const browserTypes = decodeBrowserTypes(location.query[SpanIndexedField.BROWSER_NAME]);
+  const browserTypes = decodeBrowserTypes(location.query[SpanFields.BROWSER_NAME]);
   const subregions = decodeList(
-    location.query[SpanIndexedField.USER_GEO_SUBREGION]
+    location.query[SpanFields.USER_GEO_SUBREGION]
   ) as SubregionCode[];
 
   const sort = useWebVitalsSort({defaultSort: DEFAULT_SORT});

--- a/static/app/views/insights/browser/webVitals/components/tables/pageSamplePerformanceTable.tsx
+++ b/static/app/views/insights/browser/webVitals/components/tables/pageSamplePerformanceTable.tsx
@@ -60,7 +60,7 @@ import {useWebVitalsSort} from 'sentry/views/insights/browser/webVitals/utils/us
 import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
 import {
   ModuleName,
-  SpanIndexedField,
+  SpanFields,
   SpanMetricsField,
   type SubregionCode,
 } from 'sentry/views/insights/types';
@@ -88,12 +88,12 @@ const INTERACTION_SAMPLES_COLUMN_ORDER: Array<
   GridColumnOrder<keyof SpanSampleRowWithScore>
 > = [
   {
-    key: SpanIndexedField.SPAN_DESCRIPTION,
+    key: SpanFields.SPAN_DESCRIPTION,
     width: COL_WIDTH_UNDEFINED,
     name: t('Description'),
   },
   {key: 'user.display', width: COL_WIDTH_UNDEFINED, name: t('User')},
-  {key: SpanIndexedField.INP, width: COL_WIDTH_UNDEFINED, name: 'INP'},
+  {key: SpanFields.INP, width: COL_WIDTH_UNDEFINED, name: 'INP'},
   {key: 'profile.id', width: COL_WIDTH_UNDEFINED, name: t('Profile')},
   {key: 'replayId', width: COL_WIDTH_UNDEFINED, name: t('Replay')},
   {key: 'totalScore', width: COL_WIDTH_UNDEFINED, name: t('Score')},
@@ -104,7 +104,7 @@ const SPANS_SAMPLES_WITH_DESCRIPTION_COLUMN_ORDER: Array<
 > = [
   {key: 'id', width: COL_WIDTH_UNDEFINED, name: t('Trace')},
   {
-    key: SpanIndexedField.SPAN_DESCRIPTION,
+    key: SpanFields.SPAN_DESCRIPTION,
     width: COL_WIDTH_UNDEFINED,
     name: t('Description'),
   },
@@ -168,7 +168,7 @@ export function PageSamplePerformanceTable({transaction, search, limit = 9}: Pro
     'performance-vitals-standalone-cls-lcp'
   );
 
-  const browserTypes = decodeBrowserTypes(location.query[SpanIndexedField.BROWSER_NAME]);
+  const browserTypes = decodeBrowserTypes(location.query[SpanFields.BROWSER_NAME]);
   const subregions = decodeList(
     location.query[SpanMetricsField.USER_GEO_SUBREGION]
   ) as SubregionCode[];
@@ -345,7 +345,7 @@ export function PageSamplePerformanceTable({transaction, search, limit = 9}: Pro
       return <AlignRight>{datatype.toUpperCase()}</AlignRight>;
     }
 
-    if (col.key === SpanIndexedField.SPAN_DESCRIPTION) {
+    if (col.key === SpanFields.SPAN_DESCRIPTION) {
       if (datatype === Datatype.LCP) {
         return <span>{t('LCP Element')}</span>;
       }
@@ -458,7 +458,7 @@ export function PageSamplePerformanceTable({transaction, search, limit = 9}: Pro
         // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
         (row['transaction.duration'] !== undefined ||
           // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-          row[SpanIndexedField.SPAN_SELF_TIME] !== undefined) &&
+          row[SpanFields.SPAN_SELF_TIME] !== undefined) &&
         replayLinkGenerator(
           organization,
           {
@@ -467,7 +467,7 @@ export function PageSamplePerformanceTable({transaction, search, limit = 9}: Pro
             'transaction.duration':
               datatype === Datatype.INTERACTIONS
                 ? // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-                  row[SpanIndexedField.SPAN_SELF_TIME]
+                  row[SpanFields.SPAN_SELF_TIME]
                 : // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
                   row['transaction.duration'],
             timestamp: row.timestamp,
@@ -493,7 +493,7 @@ export function PageSamplePerformanceTable({transaction, search, limit = 9}: Pro
       );
     }
 
-    if (key === 'id' || key === SpanIndexedField.SPAN_DESCRIPTION) {
+    if (key === 'id' || key === SpanFields.SPAN_DESCRIPTION) {
       const traceViewLink = generateLinkToEventInTraceView({
         traceSlug: row.trace,
         eventId: row.id,
@@ -514,14 +514,14 @@ export function PageSamplePerformanceTable({transaction, search, limit = 9}: Pro
         );
       }
 
-      if (key === SpanIndexedField.SPAN_DESCRIPTION) {
+      if (key === SpanFields.SPAN_DESCRIPTION) {
         const description =
           datatype === 'lcp' &&
-          (row as SpanSampleRowWithScore)[SpanIndexedField.SPAN_OP] === 'pageload'
-            ? (row as SpanSampleRowWithScore)[SpanIndexedField.LCP_ELEMENT]
+          (row as SpanSampleRowWithScore)[SpanFields.SPAN_OP] === 'pageload'
+            ? (row as SpanSampleRowWithScore)[SpanFields.LCP_ELEMENT]
             : datatype === 'cls' &&
-                (row as SpanSampleRowWithScore)[SpanIndexedField.SPAN_OP] === 'pageload'
-              ? (row as SpanSampleRowWithScore)[SpanIndexedField.CLS_SOURCE]
+                (row as SpanSampleRowWithScore)[SpanFields.SPAN_OP] === 'pageload'
+              ? (row as SpanSampleRowWithScore)[SpanFields.CLS_SOURCE]
               : (row as SpanSampleRowWithScore)[key];
 
         if (description) {

--- a/static/app/views/insights/browser/webVitals/components/webVitalsDetailPanel.tsx
+++ b/static/app/views/insights/browser/webVitals/components/webVitalsDetailPanel.tsx
@@ -35,11 +35,7 @@ import type {
 import decodeBrowserTypes from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
 import {SampleDrawerBody} from 'sentry/views/insights/common/components/sampleDrawerBody';
 import {useModuleURL} from 'sentry/views/insights/common/utils/useModuleURL';
-import {
-  ModuleName,
-  SpanIndexedField,
-  type SubregionCode,
-} from 'sentry/views/insights/types';
+import {ModuleName, SpanFields, type SubregionCode} from 'sentry/views/insights/types';
 
 type Column = GridColumnHeader;
 
@@ -59,9 +55,9 @@ export function WebVitalsDetailPanel({webVital}: {webVital: WebVitals | null}) {
   const location = useLocation();
   const organization = useOrganization();
   const moduleUrl = useModuleURL(ModuleName.VITAL);
-  const browserTypes = decodeBrowserTypes(location.query[SpanIndexedField.BROWSER_NAME]);
+  const browserTypes = decodeBrowserTypes(location.query[SpanFields.BROWSER_NAME]);
   const subregions = decodeList(
-    location.query[SpanIndexedField.USER_GEO_SUBREGION]
+    location.query[SpanFields.USER_GEO_SUBREGION]
   ) as SubregionCode[];
 
   const {data: projectData} = useProjectRawWebVitalsQuery({browserTypes, subregions});

--- a/static/app/views/insights/browser/webVitals/queries/rawWebVitalsQueries/useProjectRawWebVitalsValuesTimeseriesQuery.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/rawWebVitalsQueries/useProjectRawWebVitalsValuesTimeseriesQuery.tsx
@@ -4,7 +4,7 @@ import usePageFilters from 'sentry/utils/usePageFilters';
 import {DEFAULT_QUERY_FILTER} from 'sentry/views/insights/browser/webVitals/settings';
 import type {BrowserType} from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
 import {useMetricsSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
-import {SpanIndexedField, type SubregionCode} from 'sentry/views/insights/types';
+import {SpanFields, type SubregionCode} from 'sentry/views/insights/types';
 
 type Props = {
   browserTypes?: BrowserType[];
@@ -24,10 +24,10 @@ export const useProjectRawWebVitalsValuesTimeseriesQuery = ({
     search.addFilterValue('transaction', transaction);
   }
   if (browserTypes) {
-    search.addDisjunctionFilterValues(SpanIndexedField.BROWSER_NAME, browserTypes);
+    search.addDisjunctionFilterValues(SpanFields.BROWSER_NAME, browserTypes);
   }
   if (subregions) {
-    search.addDisjunctionFilterValues(SpanIndexedField.USER_GEO_SUBREGION, subregions);
+    search.addDisjunctionFilterValues(SpanFields.USER_GEO_SUBREGION, subregions);
   }
 
   const result = useMetricsSeries(

--- a/static/app/views/insights/browser/webVitals/queries/storedScoreQueries/useProjectWebVitalsScoresQuery.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/storedScoreQueries/useProjectWebVitalsScoresQuery.tsx
@@ -5,7 +5,7 @@ import {DEFAULT_QUERY_FILTER} from 'sentry/views/insights/browser/webVitals/sett
 import type {WebVitals} from 'sentry/views/insights/browser/webVitals/types';
 import type {BrowserType} from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
-import {SpanIndexedField, type SubregionCode} from 'sentry/views/insights/types';
+import {SpanFields, type SubregionCode} from 'sentry/views/insights/types';
 
 type Props = {
   browserTypes?: BrowserType[];
@@ -31,10 +31,10 @@ export const useProjectWebVitalsScoresQuery = ({
     search.addFilterValue(tag.key, tag.name);
   }
   if (browserTypes) {
-    search.addDisjunctionFilterValues(SpanIndexedField.BROWSER_NAME, browserTypes);
+    search.addDisjunctionFilterValues(SpanFields.BROWSER_NAME, browserTypes);
   }
   if (subregions) {
-    search.addDisjunctionFilterValues(SpanIndexedField.USER_GEO_SUBREGION, subregions);
+    search.addDisjunctionFilterValues(SpanFields.USER_GEO_SUBREGION, subregions);
   }
 
   const result = useSpans(

--- a/static/app/views/insights/browser/webVitals/queries/storedScoreQueries/useTransactionSamplesWebVitalsScoresQuery.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/storedScoreQueries/useTransactionSamplesWebVitalsScoresQuery.tsx
@@ -8,7 +8,7 @@ import {mapWebVitalToOrderBy} from 'sentry/views/insights/browser/webVitals/util
 import type {BrowserType} from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
 import {useWebVitalsSort} from 'sentry/views/insights/browser/webVitals/utils/useWebVitalsSort';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
-import {SpanIndexedField, type SubregionCode} from 'sentry/views/insights/types';
+import {SpanFields, type SubregionCode} from 'sentry/views/insights/types';
 
 type Props = {
   transaction: string;
@@ -51,13 +51,10 @@ export const useTransactionSamplesWebVitalsScoresQuery = ({
     mutableSearch.addStringMultiFilter(query);
   }
   if (browserTypes) {
-    mutableSearch.addDisjunctionFilterValues(SpanIndexedField.BROWSER_NAME, browserTypes);
+    mutableSearch.addDisjunctionFilterValues(SpanFields.BROWSER_NAME, browserTypes);
   }
   if (subregions) {
-    mutableSearch.addDisjunctionFilterValues(
-      SpanIndexedField.USER_GEO_SUBREGION,
-      subregions
-    );
+    mutableSearch.addDisjunctionFilterValues(SpanFields.USER_GEO_SUBREGION, subregions);
   }
 
   const result = useSpans(

--- a/static/app/views/insights/browser/webVitals/queries/storedScoreQueries/useTransactionWebVitalsScoresQuery.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/storedScoreQueries/useTransactionWebVitalsScoresQuery.tsx
@@ -12,7 +12,7 @@ import {useWebVitalsSort} from 'sentry/views/insights/browser/webVitals/utils/us
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {
   type EAPSpanProperty,
-  SpanIndexedField,
+  SpanFields,
   type SubregionCode,
 } from 'sentry/views/insights/types';
 
@@ -60,10 +60,10 @@ export const useTransactionWebVitalsScoresQuery = ({
     search.addFilterValue('transaction', transaction, shouldEscapeFilters);
   }
   if (browserTypes) {
-    search.addDisjunctionFilterValues(SpanIndexedField.BROWSER_NAME, browserTypes);
+    search.addDisjunctionFilterValues(SpanFields.BROWSER_NAME, browserTypes);
   }
   if (subregions) {
-    search.addDisjunctionFilterValues(SpanIndexedField.USER_GEO_SUBREGION, subregions);
+    search.addDisjunctionFilterValues(SpanFields.USER_GEO_SUBREGION, subregions);
   }
 
   const {data, isPending, ...rest} = useSpans(

--- a/static/app/views/insights/browser/webVitals/queries/useSpanSamplesWebVitalsQuery.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/useSpanSamplesWebVitalsQuery.tsx
@@ -9,11 +9,7 @@ import {
 import type {BrowserType} from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
 import {useWebVitalsSort} from 'sentry/views/insights/browser/webVitals/utils/useWebVitalsSort';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
-import {
-  SpanFields,
-  SpanIndexedField,
-  type SubregionCode,
-} from 'sentry/views/insights/types';
+import {SpanFields, type SubregionCode} from 'sentry/views/insights/types';
 
 export const INTERACTION_SPANS_FILTER =
   'span.op:[ui.interaction.click,ui.interaction.hover,ui.interaction.drag,ui.interaction.press]';
@@ -58,44 +54,41 @@ export function useSpanSamplesWebVitalsQuery({
 
   const mutableSearch = MutableSearch.fromQueryObject({
     has: 'message',
-    [`!${SpanIndexedField.SPAN_DESCRIPTION}`]: '<unknown>',
+    [`!${SpanFields.SPAN_DESCRIPTION}`]: '<unknown>',
   });
   if (transaction !== undefined) {
-    mutableSearch.addFilterValue(SpanIndexedField.TRANSACTION, transaction);
+    mutableSearch.addFilterValue(SpanFields.TRANSACTION, transaction);
   }
   if (browserTypes) {
-    mutableSearch.addDisjunctionFilterValues(SpanIndexedField.BROWSER_NAME, browserTypes);
+    mutableSearch.addDisjunctionFilterValues(SpanFields.BROWSER_NAME, browserTypes);
   }
   if (subregions) {
-    mutableSearch.addDisjunctionFilterValues(
-      SpanIndexedField.USER_GEO_SUBREGION,
-      subregions
-    );
+    mutableSearch.addDisjunctionFilterValues(SpanFields.USER_GEO_SUBREGION, subregions);
   }
 
-  let field: SpanIndexedField | undefined;
-  let ratioField: SpanIndexedField | undefined;
+  let field: SpanFields | undefined;
+  let ratioField: SpanFields | undefined;
   switch (webVital) {
     case 'lcp':
-      field = SpanIndexedField.LCP;
-      ratioField = SpanIndexedField.LCP_SCORE_RATIO;
+      field = SpanFields.LCP;
+      ratioField = SpanFields.LCP_SCORE_RATIO;
       break;
     case 'cls':
-      field = SpanIndexedField.CLS;
-      ratioField = SpanIndexedField.CLS_SCORE_RATIO;
+      field = SpanFields.CLS;
+      ratioField = SpanFields.CLS_SCORE_RATIO;
       break;
     case 'fcp':
-      field = SpanIndexedField.FCP;
-      ratioField = SpanIndexedField.FCP_SCORE_RATIO;
+      field = SpanFields.FCP;
+      ratioField = SpanFields.FCP_SCORE_RATIO;
       break;
     case 'ttfb':
-      field = SpanIndexedField.TTFB;
-      ratioField = SpanIndexedField.TTFB_SCORE_RATIO;
+      field = SpanFields.TTFB;
+      ratioField = SpanFields.TTFB_SCORE_RATIO;
       break;
     case 'inp':
     default:
-      field = SpanIndexedField.INP;
-      ratioField = SpanIndexedField.INP_SCORE_RATIO;
+      field = SpanFields.INP;
+      ratioField = SpanFields.INP_SCORE_RATIO;
       break;
   }
 
@@ -137,20 +130,19 @@ export function useSpanSamplesWebVitalsQuery({
             ...row,
             [`measurements.${webVital}`]: row[ratioField] > 0 ? row[field] : undefined,
             'user.display':
-              row[SpanIndexedField.USER_EMAIL] ??
-              row[SpanIndexedField.USER_USERNAME] ??
-              row[SpanIndexedField.USER_ID] ??
-              row[SpanIndexedField.USER_IP],
-            replayId: row[SpanIndexedField.REPLAY_ID] ?? row[SpanIndexedField.REPLAYID],
-            'profile.id':
-              row[SpanIndexedField.PROFILEID] ?? row[SpanIndexedField.PROFILE_ID],
+              row[SpanFields.USER_EMAIL] ??
+              row[SpanFields.USER_USERNAME] ??
+              row[SpanFields.USER_ID] ??
+              row[SpanFields.USER_IP],
+            replayId: row[SpanFields.REPLAY_ID] ?? row[SpanFields.REPLAYID],
+            'profile.id': row[SpanFields.PROFILEID] ?? row[SpanFields.PROFILE_ID],
             totalScore: Math.round((row[`measurements.score.total`] ?? 0) * 100),
-            inpScore: Math.round((row[SpanIndexedField.INP_SCORE_RATIO] ?? 0) * 100),
-            lcpScore: Math.round((row[SpanIndexedField.LCP_SCORE_RATIO] ?? 0) * 100),
-            clsScore: Math.round((row[SpanIndexedField.CLS_SCORE_RATIO] ?? 0) * 100),
-            fcpScore: Math.round((row[SpanIndexedField.FCP_SCORE_RATIO] ?? 0) * 100),
-            ttfbScore: Math.round((row[SpanIndexedField.TTFB_SCORE_RATIO] ?? 0) * 100),
-            projectSlug: row[SpanIndexedField.PROJECT],
+            inpScore: Math.round((row[SpanFields.INP_SCORE_RATIO] ?? 0) * 100),
+            lcpScore: Math.round((row[SpanFields.LCP_SCORE_RATIO] ?? 0) * 100),
+            clsScore: Math.round((row[SpanFields.CLS_SCORE_RATIO] ?? 0) * 100),
+            fcpScore: Math.round((row[SpanFields.FCP_SCORE_RATIO] ?? 0) * 100),
+            ttfbScore: Math.round((row[SpanFields.TTFB_SCORE_RATIO] ?? 0) * 100),
+            projectSlug: row[SpanFields.PROJECT],
           };
         })
       : [];

--- a/static/app/views/insights/browser/webVitals/types.tsx
+++ b/static/app/views/insights/browser/webVitals/types.tsx
@@ -1,6 +1,6 @@
 import type {ISSUE_TYPE_TO_ISSUE_TITLE} from 'sentry/types/group';
 import type {Sort} from 'sentry/utils/discover/fields';
-import {SpanIndexedField} from 'sentry/views/insights/types';
+import {SpanFields} from 'sentry/views/insights/types';
 
 export type Row = {
   'count()': number;
@@ -46,19 +46,19 @@ type SpanSampleRow = {
   'profile.id': string;
   project: string;
   replayId: string;
-  [SpanIndexedField.SPAN_DESCRIPTION]: string;
-  [SpanIndexedField.SPAN_SELF_TIME]: number;
-  [SpanIndexedField.TIMESTAMP]: string;
-  [SpanIndexedField.TRACE]: string;
+  [SpanFields.SPAN_DESCRIPTION]: string;
+  [SpanFields.SPAN_SELF_TIME]: number;
+  [SpanFields.TIMESTAMP]: string;
+  [SpanFields.TRACE]: string;
   'user.display'?: string;
-  [SpanIndexedField.INP]?: number;
-  [SpanIndexedField.CLS]?: number;
-  [SpanIndexedField.LCP]?: number;
-  [SpanIndexedField.FCP]?: number;
-  [SpanIndexedField.TTFB]?: number;
-  [SpanIndexedField.LCP_ELEMENT]?: string;
-  [SpanIndexedField.SPAN_OP]?: string;
-  [SpanIndexedField.CLS_SOURCE]?: string;
+  [SpanFields.INP]?: number;
+  [SpanFields.CLS]?: number;
+  [SpanFields.LCP]?: number;
+  [SpanFields.FCP]?: number;
+  [SpanFields.TTFB]?: number;
+  [SpanFields.LCP_ELEMENT]?: string;
+  [SpanFields.SPAN_OP]?: string;
+  [SpanFields.CLS_SOURCE]?: string;
 };
 
 export type SpanSampleRowWithScore = SpanSampleRow & Score;
@@ -118,20 +118,20 @@ export const DEFAULT_INDEXED_SORT: Sort = {
 };
 
 export const SORTABLE_INDEXED_INTERACTION_FIELDS = [
-  SpanIndexedField.INP,
-  SpanIndexedField.INP_SCORE,
-  SpanIndexedField.INP_SCORE_WEIGHT,
-  SpanIndexedField.TOTAL_SCORE,
-  SpanIndexedField.SPAN_ID,
-  SpanIndexedField.TIMESTAMP,
-  SpanIndexedField.PROFILE_ID,
-  SpanIndexedField.REPLAY_ID,
-  SpanIndexedField.USER,
-  SpanIndexedField.ORIGIN_TRANSACTION,
-  SpanIndexedField.PROJECT,
-  SpanIndexedField.BROWSER_NAME,
-  SpanIndexedField.SPAN_SELF_TIME,
-  SpanIndexedField.SPAN_DESCRIPTION,
+  SpanFields.INP,
+  SpanFields.INP_SCORE,
+  SpanFields.INP_SCORE_WEIGHT,
+  SpanFields.TOTAL_SCORE,
+  SpanFields.SPAN_ID,
+  SpanFields.TIMESTAMP,
+  SpanFields.PROFILE_ID,
+  SpanFields.REPLAY_ID,
+  SpanFields.USER,
+  SpanFields.ORIGIN_TRANSACTION,
+  SpanFields.PROJECT,
+  SpanFields.BROWSER_NAME,
+  SpanFields.SPAN_SELF_TIME,
+  SpanFields.SPAN_DESCRIPTION,
 ] as const;
 
 export const DEFAULT_INDEXED_SPANS_SORT: Sort = {

--- a/static/app/views/insights/browser/webVitals/views/pageOverview.tsx
+++ b/static/app/views/insights/browser/webVitals/views/pageOverview.tsx
@@ -34,11 +34,7 @@ import {useModuleURL} from 'sentry/views/insights/common/utils/useModuleURL';
 import {useWebVitalsDrawer} from 'sentry/views/insights/common/utils/useWebVitalsDrawer';
 import {FrontendHeader} from 'sentry/views/insights/pages/frontend/frontendPageHeader';
 import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
-import {
-  ModuleName,
-  SpanIndexedField,
-  type SubregionCode,
-} from 'sentry/views/insights/types';
+import {ModuleName, SpanFields, type SubregionCode} from 'sentry/views/insights/types';
 import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
 
 function PageOverview() {
@@ -67,9 +63,9 @@ function PageOverview() {
   });
 
   const query = decodeScalar(location.query.query);
-  const browserTypes = decodeBrowserTypes(location.query[SpanIndexedField.BROWSER_NAME]);
+  const browserTypes = decodeBrowserTypes(location.query[SpanFields.BROWSER_NAME]);
   const subregions = decodeList(
-    location.query[SpanIndexedField.USER_GEO_SUBREGION]
+    location.query[SpanFields.USER_GEO_SUBREGION]
   ) as SubregionCode[];
 
   const {data: pageData, isPending} = useProjectRawWebVitalsQuery({

--- a/static/app/views/insights/cache/components/tables/cacheHitMissCell.tsx
+++ b/static/app/views/insights/cache/components/tables/cacheHitMissCell.tsx
@@ -1,14 +1,12 @@
 import {t} from 'sentry/locale';
-import type {EAPSpanResponse, SpanIndexedResponse} from 'sentry/views/insights/types';
 
-export function CacheHitMissCell(props: {
-  hit: SpanIndexedResponse['cache.hit'] | EAPSpanResponse['cache.hit'];
-}) {
+// TODO: Ideally the hit prop is a boolean (SpanResponse['cache.hit'])
+export function CacheHitMissCell(props: {hit: 'true' | 'false' | ''}) {
   const {hit} = props;
-  if (hit === 'true' || hit === true) {
+  if (hit === 'true') {
     return <span>{t('HIT')}</span>;
   }
-  if (hit === 'false' || hit === false) {
+  if (hit === 'false') {
     return <span>{t('MISS')}</span>;
   }
   return <span>--</span>;

--- a/static/app/views/insights/cache/components/tables/spanSamplesTable.tsx
+++ b/static/app/views/insights/cache/components/tables/spanSamplesTable.tsx
@@ -16,41 +16,41 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {CacheHitMissCell} from 'sentry/views/insights/cache/components/tables/cacheHitMissCell';
 import {renderHeadCell} from 'sentry/views/insights/common/components/tableCells/renderHeadCell';
 import {SpanIdCell} from 'sentry/views/insights/common/components/tableCells/spanIdCell';
-import type {SpanIndexedResponse} from 'sentry/views/insights/types';
-import {ModuleName, SpanIndexedField} from 'sentry/views/insights/types';
+import type {EAPSpanResponse} from 'sentry/views/insights/types';
+import {ModuleName, SpanFields} from 'sentry/views/insights/types';
 import {TraceViewSources} from 'sentry/views/performance/newTraceDetails/traceHeader/breadcrumbs';
 
 type DataRowKeys =
-  | SpanIndexedField.PROJECT
-  | SpanIndexedField.TRANSACTION_SPAN_ID
-  | SpanIndexedField.TRACE
-  | SpanIndexedField.TIMESTAMP
-  | SpanIndexedField.SPAN_ID
-  | SpanIndexedField.SPAN_DESCRIPTION
-  | SpanIndexedField.CACHE_HIT
-  | SpanIndexedField.CACHE_ITEM_SIZE;
+  | SpanFields.PROJECT
+  | SpanFields.TRANSACTION_SPAN_ID
+  | SpanFields.TRACE
+  | SpanFields.TIMESTAMP
+  | SpanFields.SPAN_ID
+  | SpanFields.SPAN_DESCRIPTION
+  | SpanFields.CACHE_ITEM_SIZE;
 
 type ColumnKeys =
-  | SpanIndexedField.SPAN_ID
-  | SpanIndexedField.SPAN_DESCRIPTION
-  | SpanIndexedField.CACHE_HIT
-  | SpanIndexedField.CACHE_ITEM_SIZE
+  | SpanFields.SPAN_ID
+  | SpanFields.SPAN_DESCRIPTION
+  | SpanFields.CACHE_HIT
+  | SpanFields.CACHE_ITEM_SIZE
   | 'transaction.duration';
 
-type DataRow = Pick<SpanIndexedResponse, DataRowKeys> & {
-  'transaction.duration': number;
+type DataRow = Pick<EAPSpanResponse, DataRowKeys> & {
+  'cache.hit': '' | 'true' | 'false';
+  'transaction.duration': number; // TODO: this should be a boolean
 };
 
 type Column = GridColumnHeader<ColumnKeys>;
 
 const COLUMN_ORDER: Column[] = [
   {
-    key: SpanIndexedField.SPAN_ID,
+    key: SpanFields.SPAN_ID,
     name: t('Span ID'),
     width: 150,
   },
   {
-    key: SpanIndexedField.SPAN_DESCRIPTION,
+    key: SpanFields.SPAN_DESCRIPTION,
     name: t('Span Description'),
     width: COL_WIDTH_UNDEFINED,
   },
@@ -60,12 +60,12 @@ const COLUMN_ORDER: Column[] = [
     width: COL_WIDTH_UNDEFINED,
   },
   {
-    key: SpanIndexedField.CACHE_ITEM_SIZE,
+    key: SpanFields.CACHE_ITEM_SIZE,
     name: t('Value Size'),
     width: COL_WIDTH_UNDEFINED,
   },
   {
-    key: SpanIndexedField.CACHE_HIT,
+    key: SpanFields.CACHE_HIT,
     name: t('Status'),
     width: COL_WIDTH_UNDEFINED,
   },
@@ -125,27 +125,25 @@ function renderBodyCell(
   organization: Organization,
   theme: Theme
 ) {
-  if (column.key === SpanIndexedField.SPAN_ID) {
+  if (column.key === SpanFields.SPAN_ID) {
     return (
       <SpanIdCell
         moduleName={ModuleName.CACHE}
         traceId={row.trace}
         timestamp={row.timestamp}
-        transactionSpanId={row[SpanIndexedField.TRANSACTION_SPAN_ID]}
-        spanId={row[SpanIndexedField.SPAN_ID]}
+        transactionSpanId={row[SpanFields.TRANSACTION_SPAN_ID]}
+        spanId={row[SpanFields.SPAN_ID]}
         source={TraceViewSources.CACHES_MODULE}
         location={location}
       />
     );
   }
 
-  if (column.key === SpanIndexedField.SPAN_DESCRIPTION) {
-    return (
-      <SpanDescriptionCell>{row[SpanIndexedField.SPAN_DESCRIPTION]}</SpanDescriptionCell>
-    );
+  if (column.key === SpanFields.SPAN_DESCRIPTION) {
+    return <SpanDescriptionCell>{row[SpanFields.SPAN_DESCRIPTION]}</SpanDescriptionCell>;
   }
 
-  if (column.key === SpanIndexedField.CACHE_HIT) {
+  if (column.key === SpanFields.CACHE_HIT) {
     return <CacheHitMissCell hit={row[column.key]} />;
   }
 

--- a/static/app/views/insights/common/components/samplesTable/spanSamplesTable.tsx
+++ b/static/app/views/insights/common/components/samplesTable/spanSamplesTable.tsx
@@ -25,11 +25,7 @@ import {
 } from 'sentry/views/insights/common/components/textAlign';
 import type {SpanSample} from 'sentry/views/insights/common/queries/useSpanSamples';
 import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
-import {
-  type ModuleName,
-  SpanIndexedField,
-  SpanMetricsField,
-} from 'sentry/views/insights/types';
+import {type ModuleName, SpanFields, SpanMetricsField} from 'sentry/views/insights/types';
 import type {TraceViewSources} from 'sentry/views/performance/newTraceDetails/traceHeader/breadcrumbs';
 
 const {HTTP_RESPONSE_CONTENT_LENGTH, SPAN_DESCRIPTION} = SpanMetricsField;
@@ -74,8 +70,8 @@ type SpanTableRow = {
   };
   'transaction.span_id': string;
 } & SpanSample & {
-    [SpanIndexedField.PROFILER_ID]?: string;
-    [SpanIndexedField.PROFILE_ID]?: string;
+    [SpanFields.PROFILER_ID]?: string;
+    [SpanFields.PROFILE_ID]?: string;
   };
 
 type Props = {
@@ -199,9 +195,8 @@ export function SpanSamplesTable({
     }
 
     if (column.key === 'profile_id') {
-      const profileId =
-        row[SpanIndexedField.PROFILEID] || row[SpanIndexedField.PROFILE_ID];
-      const continuousProfilerId = row[SpanIndexedField.PROFILER_ID];
+      const profileId = row[SpanFields.PROFILEID] || row[SpanFields.PROFILE_ID];
+      const continuousProfilerId = row[SpanFields.PROFILER_ID];
       const link =
         continuousProfilerId && row?.transaction
           ? generateContinuousProfileFlamechartRouteWithQuery({

--- a/static/app/views/insights/common/components/samplesTable/spanSamplesTable.tsx
+++ b/static/app/views/insights/common/components/samplesTable/spanSamplesTable.tsx
@@ -185,7 +185,7 @@ export function SpanSamplesTable({
     }
 
     if (column.key === HTTP_RESPONSE_CONTENT_LENGTH) {
-      const size = parseInt(row[HTTP_RESPONSE_CONTENT_LENGTH], 10);
+      const size = row[HTTP_RESPONSE_CONTENT_LENGTH];
       return <ResourceSizeCell bytes={size} />;
     }
 

--- a/static/app/views/insights/common/components/spanDescription.tsx
+++ b/static/app/views/insights/common/components/spanDescription.tsx
@@ -22,12 +22,12 @@ import {
   isValidJson,
   prettyPrintJsonString,
 } from 'sentry/views/insights/database/utils/jsonUtils';
-import type {SpanIndexedFieldTypes} from 'sentry/views/insights/types';
+import type {EAPSpanResponse} from 'sentry/views/insights/types';
 import {SpanFields} from 'sentry/views/insights/types';
 
 interface Props {
-  groupId: SpanIndexedFieldTypes[SpanFields.SPAN_GROUP];
-  op: SpanIndexedFieldTypes[SpanFields.SPAN_OP];
+  groupId: EAPSpanResponse[SpanFields.SPAN_GROUP];
+  op: EAPSpanResponse[SpanFields.SPAN_OP];
   preliminaryDescription?: string;
 }
 

--- a/static/app/views/insights/common/components/tableCells/renderHeadCell.tsx
+++ b/static/app/views/insights/common/components/tableCells/renderHeadCell.tsx
@@ -12,11 +12,7 @@ import {
   parseFunction,
 } from 'sentry/utils/discover/fields';
 import type {QueryParameterNames} from 'sentry/views/insights/common/views/queryParameters';
-import {
-  SpanFunction,
-  SpanIndexedField,
-  SpanMetricsField,
-} from 'sentry/views/insights/types';
+import {SpanFields, SpanFunction, SpanMetricsField} from 'sentry/views/insights/types';
 
 type Options = {
   column: GridColumnHeader<string>;
@@ -65,10 +61,10 @@ const SORTABLE_FIELDS = new Set([
   `avg(${HTTP_RESPONSE_CONTENT_LENGTH})`,
   `${CACHE_HIT_RATE}()`,
   `${CACHE_MISS_RATE}()`,
-  SpanIndexedField.TIMESTAMP,
-  SpanIndexedField.SPAN_DURATION,
+  SpanFields.TIMESTAMP,
+  SpanFields.SPAN_DURATION,
   `avg(${CACHE_ITEM_SIZE})`,
-  SpanIndexedField.MESSAGING_MESSAGE_DESTINATION_NAME,
+  SpanFields.MESSAGING_MESSAGE_DESTINATION_NAME,
   'count_op(queue.publish)',
   'count_op(queue.process)',
   'avg_if(span.duration,span.op,queue.process)',
@@ -96,11 +92,11 @@ const SORTABLE_FIELDS = new Set([
 const NUMERIC_FIELDS = new Set([
   'transaction.duration',
   SpanMetricsField.CACHE_ITEM_SIZE,
-  SpanIndexedField.SPAN_SELF_TIME,
-  SpanIndexedField.SPAN_DURATION,
-  SpanIndexedField.CACHE_ITEM_SIZE,
-  SpanIndexedField.MESSAGING_MESSAGE_BODY_SIZE,
-  SpanIndexedField.MESSAGING_MESSAGE_RETRY_COUNT,
+  SpanFields.SPAN_SELF_TIME,
+  SpanFields.SPAN_DURATION,
+  SpanFields.CACHE_ITEM_SIZE,
+  SpanFields.MESSAGING_MESSAGE_BODY_SIZE,
+  SpanFields.MESSAGING_MESSAGE_RETRY_COUNT,
 ]);
 
 export const renderHeadCell = ({column, location, sort, sortParameterName}: Options) => {

--- a/static/app/views/insights/common/components/widgets/performanceScoreBreakdownChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/performanceScoreBreakdownChartWidget.tsx
@@ -16,19 +16,19 @@ import {
   type DiscoverSeries,
   useMetricsSeries,
 } from 'sentry/views/insights/common/queries/useDiscoverSeries';
-import {SpanIndexedField, SpanMetricsField} from 'sentry/views/insights/types';
+import {SpanFields, SpanMetricsField} from 'sentry/views/insights/types';
 
 export default function PerformanceScoreBreakdownChartWidget(
   props: LoadableChartWidgetProps
 ) {
   const {
     transaction,
-    [SpanIndexedField.BROWSER_NAME]: browserTypes,
-    [SpanIndexedField.USER_GEO_SUBREGION]: subregions,
+    [SpanFields.BROWSER_NAME]: browserTypes,
+    [SpanFields.USER_GEO_SUBREGION]: subregions,
   } = useLocationQuery({
     fields: {
-      [SpanIndexedField.BROWSER_NAME]: decodeBrowserTypes,
-      [SpanIndexedField.USER_GEO_SUBREGION]: decodeList,
+      [SpanFields.BROWSER_NAME]: decodeBrowserTypes,
+      [SpanFields.USER_GEO_SUBREGION]: decodeList,
       transaction: decodeList,
     },
   });

--- a/static/app/views/insights/common/queries/useDiscoverSeries.ts
+++ b/static/app/views/insights/common/queries/useDiscoverSeries.ts
@@ -20,8 +20,8 @@ import {
 import {useInsightsEap} from 'sentry/views/insights/common/utils/useEap';
 import type {
   EAPSpanProperty,
+  SpanFields,
   SpanFunctions,
-  SpanIndexedField,
   SpanMetricsProperty,
 } from 'sentry/views/insights/types';
 
@@ -58,7 +58,7 @@ export const useSpanMetricsSeries = <Fields extends SpanMetricsProperty[]>(
 };
 
 export const useSpanSeries = <
-  Fields extends SpanMetricsProperty[] | SpanIndexedField[] | SpanFunctions[] | string[],
+  Fields extends SpanMetricsProperty[] | SpanFields[] | SpanFunctions[] | string[],
 >(
   options: UseMetricsSeriesOptions<Fields> = {},
   referrer: string,
@@ -90,7 +90,7 @@ export const useMetricsSeries = <Fields extends EAPSpanProperty[]>(
  * TODO: Remove string type, added to fix types for 'count()'
  */
 export const useSpanIndexedSeries = <
-  Fields extends SpanIndexedField[] | SpanFunctions[] | string[],
+  Fields extends SpanFields[] | SpanFunctions[] | string[],
 >(
   options: UseMetricsSeriesOptions<Fields> = {},
   referrer: string,

--- a/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
+++ b/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
@@ -32,7 +32,7 @@ import {
   getRetryDelay,
   shouldRetryHandler,
 } from 'sentry/views/insights/common/utils/retryHandlers';
-import type {SpanFunctions, SpanIndexedField} from 'sentry/views/insights/types';
+import type {SpanFields, SpanFunctions} from 'sentry/views/insights/types';
 
 type SeriesMap = Record<string, TimeSeries[]>;
 
@@ -50,7 +50,7 @@ interface Options<Fields> {
 }
 
 export const useSortedTimeSeries = <
-  Fields extends SpanIndexedField[] | SpanFunctions[] | string[],
+  Fields extends SpanFields[] | SpanFunctions[] | string[],
 >(
   options: Options<Fields> = {},
   referrer: string,

--- a/static/app/views/insights/common/queries/useSpanSamples.tsx
+++ b/static/app/views/insights/common/queries/useSpanSamples.tsx
@@ -11,15 +11,14 @@ import {useSpanMetricsSeries} from 'sentry/views/insights/common/queries/useDisc
 import {getDateConditions} from 'sentry/views/insights/common/utils/getDateConditions';
 import {useInsightsEap} from 'sentry/views/insights/common/utils/useEap';
 import type {
-  SpanIndexedFieldTypes,
-  SpanIndexedProperty,
-  SpanIndexedResponse,
+  EAPSpanProperty,
+  EAPSpanResponse,
   SpanMetricsQueryFilters,
   SubregionCode,
 } from 'sentry/views/insights/types';
-import {SpanIndexedField, SpanMetricsField} from 'sentry/views/insights/types';
+import {SpanFields, SpanMetricsField} from 'sentry/views/insights/types';
 
-const {SPAN_SELF_TIME, SPAN_GROUP} = SpanIndexedField;
+const {SPAN_SELF_TIME, SPAN_GROUP} = SpanFields;
 
 type Options<Fields extends NonDefaultSpanSampleFields[]> = {
   groupId: string;
@@ -33,27 +32,27 @@ type Options<Fields extends NonDefaultSpanSampleFields[]> = {
 };
 
 export type SpanSample = Pick<
-  SpanIndexedFieldTypes,
-  | SpanIndexedField.SPAN_SELF_TIME
-  | SpanIndexedField.TRANSACTION_SPAN_ID
-  | SpanIndexedField.PROJECT
-  | SpanIndexedField.TIMESTAMP
-  | SpanIndexedField.SPAN_ID
-  | SpanIndexedField.PROFILEID
-  | SpanIndexedField.HTTP_RESPONSE_CONTENT_LENGTH
-  | SpanIndexedField.TRACE
+  EAPSpanResponse,
+  | SpanFields.SPAN_SELF_TIME
+  | SpanFields.TRANSACTION_SPAN_ID
+  | SpanFields.PROJECT
+  | SpanFields.TIMESTAMP
+  | SpanFields.SPAN_ID
+  | SpanFields.PROFILEID
+  | SpanFields.HTTP_RESPONSE_CONTENT_LENGTH
+  | SpanFields.TRACE
 >;
 
 export type DefaultSpanSampleFields =
-  | SpanIndexedField.PROJECT
-  | SpanIndexedField.TRANSACTION_SPAN_ID
-  | SpanIndexedField.TIMESTAMP
-  | SpanIndexedField.SPAN_ID
-  | SpanIndexedField.PROFILEID
-  | SpanIndexedField.SPAN_SELF_TIME;
+  | SpanFields.PROJECT
+  | SpanFields.TRANSACTION_SPAN_ID
+  | SpanFields.TIMESTAMP
+  | SpanFields.SPAN_ID
+  | SpanFields.PROFILEID
+  | SpanFields.SPAN_SELF_TIME;
 
 export type NonDefaultSpanSampleFields = Exclude<
-  SpanIndexedProperty,
+  EAPSpanProperty,
   DefaultSpanSampleFields
 >;
 
@@ -119,7 +118,7 @@ export const useSpanSamples = <Fields extends NonDefaultSpanSampleFields[]>(
   );
 
   type DataRow = Pick<
-    SpanIndexedResponse,
+    EAPSpanResponse,
     Fields[number] | DefaultSpanSampleFields // These fields are returned by default
   >;
 
@@ -141,8 +140,8 @@ export const useSpanSamples = <Fields extends NonDefaultSpanSampleFields[]>(
           secondBound: max * (2 / 3),
           upperBound: max,
           additionalFields: [
-            SpanIndexedField.ID,
-            SpanIndexedField.TRANSACTION_SPAN_ID, // TODO: transaction.span_id should be a default from the backend
+            SpanFields.ID,
+            SpanFields.TRANSACTION_SPAN_ID, // TODO: transaction.span_id should be a default from the backend
             ...additionalFields,
           ],
           sampling: useEap ? SAMPLING_MODE.NORMAL : undefined,

--- a/static/app/views/insights/common/queries/useTopNDiscoverSeries.ts
+++ b/static/app/views/insights/common/queries/useTopNDiscoverSeries.ts
@@ -22,8 +22,8 @@ import {
 import {useInsightsEap} from 'sentry/views/insights/common/utils/useEap';
 import type {
   EAPSpanProperty,
+  SpanFields,
   SpanFunctions,
-  SpanIndexedField,
   SpanMetricsProperty,
 } from 'sentry/views/insights/types';
 
@@ -62,7 +62,7 @@ export const useTopNSpanEAPSeries = <
   Fields extends
     | EAPSpanProperty[]
     | SpanMetricsProperty[]
-    | SpanIndexedField[]
+    | SpanFields[]
     | SpanFunctions[]
     | string[],
 >(

--- a/static/app/views/insights/common/utils/constants.tsx
+++ b/static/app/views/insights/common/utils/constants.tsx
@@ -1,5 +1,5 @@
 import type {AggregationOutputType} from 'sentry/utils/discover/fields';
-import {SpanIndexedField, SpanMetricsField} from 'sentry/views/insights/types';
+import {SpanFields, SpanMetricsField} from 'sentry/views/insights/types';
 
 // This constant is to be used as an arg for `getInterval`.
 // 'metrics' fidelity is intended to match the granularities of stored metrics.
@@ -22,7 +22,7 @@ export const STARFISH_FIELDS: Record<string, {outputType: AggregationOutputType}
   [SpanMetricsField.HTTP_RESPONSE_CONTENT_LENGTH]: {
     outputType: 'size',
   },
-  [SpanIndexedField.CACHE_ITEM_SIZE]: {
+  [SpanFields.CACHE_ITEM_SIZE]: {
     outputType: 'size',
   },
   [SpanMetricsField.CACHE_ITEM_SIZE]: {

--- a/static/app/views/insights/common/views/spanSummaryPage/sampleList/index.tsx
+++ b/static/app/views/insights/common/views/spanSummaryPage/sampleList/index.tsx
@@ -30,11 +30,7 @@ import SampleInfo from 'sentry/views/insights/common/views/spanSummaryPage/sampl
 import SampleTable from 'sentry/views/insights/common/views/spanSummaryPage/sampleList/sampleTable/sampleTable';
 import {InsightsSpanTagProvider} from 'sentry/views/insights/pages/insightsSpanTagProvider';
 import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
-import {
-  ModuleName,
-  SpanIndexedField,
-  SpanMetricsField,
-} from 'sentry/views/insights/types';
+import {ModuleName, SpanFields, SpanMetricsField} from 'sentry/views/insights/types';
 import {getTransactionSummaryBaseUrl} from 'sentry/views/performance/transactionSummary/utils';
 
 const {HTTP_RESPONSE_CONTENT_LENGTH, SPAN_DESCRIPTION} = SpanMetricsField;
@@ -103,11 +99,11 @@ export function SampleList({groupId, moduleName, transactionRoute, referrer}: Pr
 
   let columnOrder = DEFAULT_COLUMN_ORDER;
 
-  const additionalFields: NonDefaultSpanSampleFields[] = [SpanIndexedField.TRACE];
+  const additionalFields: NonDefaultSpanSampleFields[] = [SpanFields.TRACE];
 
   if (moduleName === ModuleName.RESOURCE) {
-    additionalFields?.push(SpanIndexedField.HTTP_RESPONSE_CONTENT_LENGTH);
-    additionalFields?.push(SpanIndexedField.SPAN_DESCRIPTION);
+    additionalFields?.push(SpanFields.HTTP_RESPONSE_CONTENT_LENGTH);
+    additionalFields?.push(SpanFields.SPAN_DESCRIPTION);
 
     columnOrder = [
       ...DEFAULT_COLUMN_ORDER,

--- a/static/app/views/insights/common/views/spanSummaryPage/sampleList/sampleTable/sampleTable.tsx
+++ b/static/app/views/insights/common/views/spanSummaryPage/sampleList/sampleTable/sampleTable.tsx
@@ -22,7 +22,7 @@ import type {
   SpanMetricsQueryFilters,
   SubregionCode,
 } from 'sentry/views/insights/types';
-import {SpanIndexedField, SpanMetricsField} from 'sentry/views/insights/types';
+import {SpanFields, SpanMetricsField} from 'sentry/views/insights/types';
 import {TraceViewSources} from 'sentry/views/performance/newTraceDetails/traceHeader/breadcrumbs';
 
 const {SPAN_SELF_TIME, SPAN_OP} = SpanMetricsField;
@@ -119,7 +119,7 @@ function SampleTable({
 
   const isTransactionsEnabled = Boolean(transactionIds.length);
 
-  const search = `${SpanIndexedField.TRANSACTION_SPAN_ID}:[${transactionIds.join(',')}] is_transaction:true`;
+  const search = `${SpanFields.TRANSACTION_SPAN_ID}:[${transactionIds.join(',')}] is_transaction:true`;
 
   const {
     data: transactions,

--- a/static/app/views/insights/constants.tsx
+++ b/static/app/views/insights/constants.tsx
@@ -2,7 +2,7 @@ import type {FilterKeySection} from 'sentry/components/searchQueryBuilder/types'
 import {t} from 'sentry/locale';
 import type {AggregationOutputType} from 'sentry/utils/discover/fields';
 import {type FieldDefinition, FieldKind, FieldValueType} from 'sentry/utils/fields';
-import {SpanFunction, SpanIndexedField} from 'sentry/views/insights/types';
+import {SpanFields, SpanFunction} from 'sentry/views/insights/types';
 
 export const STARFISH_AGGREGATION_FIELDS: Record<
   SpanFunction,
@@ -85,17 +85,17 @@ export const STARFISH_AGGREGATION_FIELDS: Record<
 const RELEASE_FILTERS: FilterKeySection = {
   value: 'release_filters',
   label: 'Release',
-  children: [SpanIndexedField.RELEASE],
+  children: [SpanFields.RELEASE],
 };
 
 const TRANSACTION_FILTERS: FilterKeySection = {
   value: 'transaction_filters',
   label: 'Transaction',
   children: [
-    SpanIndexedField.TRANSACTION_METHOD,
-    SpanIndexedField.TRANSACTION_OP,
-    SpanIndexedField.TRANSACTION,
-    SpanIndexedField.TRANSACTION_ID,
+    SpanFields.TRANSACTION_METHOD,
+    SpanFields.TRANSACTION_OP,
+    SpanFields.TRANSACTION,
+    SpanFields.TRANSACTION_SPAN_ID,
   ],
 };
 
@@ -103,12 +103,12 @@ const USER_CONTEXT_FILTERS: FilterKeySection = {
   value: 'user_context_filters',
   label: 'User',
   children: [
-    SpanIndexedField.USER,
-    SpanIndexedField.USER_ID,
-    SpanIndexedField.USER_IP,
-    SpanIndexedField.USER_EMAIL,
-    SpanIndexedField.USER_USERNAME,
-    SpanIndexedField.USER_GEO_SUBREGION,
+    SpanFields.USER,
+    SpanFields.USER_ID,
+    SpanFields.USER_IP,
+    SpanFields.USER_EMAIL,
+    SpanFields.USER_USERNAME,
+    SpanFields.USER_GEO_SUBREGION,
   ],
 };
 
@@ -116,14 +116,14 @@ const SPAN_FILTERS: FilterKeySection = {
   value: 'span_filters',
   label: 'Span',
   children: [
-    SpanIndexedField.SPAN_OP,
-    SpanIndexedField.SPAN_DURATION,
-    SpanIndexedField.SPAN_SELF_TIME,
-    SpanIndexedField.SPAN_DESCRIPTION,
-    SpanIndexedField.SPAN_STATUS,
-    SpanIndexedField.SPAN_ACTION,
-    SpanIndexedField.SPAN_DOMAIN,
-    SpanIndexedField.SPAN_CATEGORY,
+    SpanFields.SPAN_OP,
+    SpanFields.SPAN_DURATION,
+    SpanFields.SPAN_SELF_TIME,
+    SpanFields.SPAN_DESCRIPTION,
+    SpanFields.SPAN_STATUS,
+    SpanFields.SPAN_ACTION,
+    SpanFields.SPAN_DOMAIN,
+    SpanFields.SPAN_CATEGORY,
   ],
 };
 

--- a/static/app/views/insights/http/components/charts/responseCodeCountChart.tsx
+++ b/static/app/views/insights/http/components/charts/responseCodeCountChart.tsx
@@ -71,12 +71,12 @@ export function ResponseCodeCountChart({
 
   const queries = topResponseCodes.map(code => ({
     label: code,
-    query: `${stringifiedSearch} ${SpanFields.RESPONSE_CODE}:${code}`,
+    query: `${stringifiedSearch} ${SpanFields.SPAN_STATUS}:${code}`,
   }));
 
   queries.push({
     label: t('Other'),
-    query: `${stringifiedSearch} !${SpanFields.RESPONSE_CODE}:[${topResponseCodes.join(',')}]`,
+    query: `${stringifiedSearch} !${SpanFields.SPAN_STATUS}:[${topResponseCodes.join(',')}]`,
   });
 
   const exploreUrl = getExploreUrl({

--- a/static/app/views/insights/http/components/charts/responseCodeCountChart.tsx
+++ b/static/app/views/insights/http/components/charts/responseCodeCountChart.tsx
@@ -71,12 +71,12 @@ export function ResponseCodeCountChart({
 
   const queries = topResponseCodes.map(code => ({
     label: code,
-    query: `${stringifiedSearch} ${SpanFields.SPAN_STATUS}:${code}`,
+    query: `${stringifiedSearch} ${SpanFields.SPAN_STATUS_CODE}:${code}`,
   }));
 
   queries.push({
     label: t('Other'),
-    query: `${stringifiedSearch} !${SpanFields.SPAN_STATUS}:[${topResponseCodes.join(',')}]`,
+    query: `${stringifiedSearch} !${SpanFields.SPAN_STATUS_CODE}:[${topResponseCodes.join(',')}]`,
   });
 
   const exploreUrl = getExploreUrl({

--- a/static/app/views/insights/http/components/httpSamplesPanel.tsx
+++ b/static/app/views/insights/http/components/httpSamplesPanel.tsx
@@ -206,7 +206,7 @@ export function HTTPSamplesPanel() {
   } = useTopNSpanMetricsSeries(
     {
       search,
-      fields: [SpanFields.SPAN_STATUS, 'count()'],
+      fields: [SpanFields.SPAN_STATUS_CODE, 'count()'],
       yAxis: ['count()'],
       topN: 5,
       sort: {
@@ -231,7 +231,7 @@ export function HTTPSamplesPanel() {
       SpanFields.ID,
       SpanFields.TRACE,
       SpanFields.SPAN_DESCRIPTION,
-      SpanFields.SPAN_STATUS,
+      SpanFields.SPAN_STATUS_CODE,
     ],
     min: 0,
     max: durationAxisMax,
@@ -258,7 +258,7 @@ export function HTTPSamplesPanel() {
         SpanFields.SPAN_ID,
         SpanFields.TIMESTAMP,
         SpanFields.SPAN_DESCRIPTION,
-        SpanFields.SPAN_STATUS,
+        SpanFields.SPAN_STATUS_CODE,
       ],
       sorts: [SPAN_SAMPLES_SORT],
       limit: SPAN_SAMPLE_LIMIT,
@@ -433,7 +433,7 @@ export function HTTPSamplesPanel() {
                   <ResponseCodeCountChart
                     search={search}
                     referrer={Referrer.SAMPLES_PANEL_RESPONSE_CODE_CHART}
-                    groupBy={[SpanFields.SPAN_STATUS]}
+                    groupBy={[SpanFields.SPAN_STATUS_CODE]}
                     series={Object.values(responseCodeData).filter(Boolean)}
                     isLoading={isResponseCodeDataLoading}
                     error={responseCodeError}

--- a/static/app/views/insights/http/components/httpSamplesPanel.tsx
+++ b/static/app/views/insights/http/components/httpSamplesPanel.tsx
@@ -56,7 +56,6 @@ import {
   ModuleName,
   SpanFields,
   SpanFunction,
-  SpanIndexedField,
   SpanMetricsField,
   type SpanMetricsQueryFilters,
 } from 'sentry/views/insights/types';
@@ -207,7 +206,7 @@ export function HTTPSamplesPanel() {
   } = useTopNSpanMetricsSeries(
     {
       search,
-      fields: [SpanFields.RESPONSE_CODE, 'count()'],
+      fields: [SpanFields.SPAN_STATUS, 'count()'],
       yAxis: ['count()'],
       topN: 5,
       sort: {
@@ -229,10 +228,10 @@ export function HTTPSamplesPanel() {
   } = useSpanSamples({
     search,
     fields: [
-      SpanIndexedField.ID,
-      SpanIndexedField.TRACE,
-      SpanIndexedField.SPAN_DESCRIPTION,
-      SpanIndexedField.RESPONSE_CODE,
+      SpanFields.ID,
+      SpanFields.TRACE,
+      SpanFields.SPAN_DESCRIPTION,
+      SpanFields.SPAN_STATUS,
     ],
     min: 0,
     max: durationAxisMax,
@@ -259,7 +258,7 @@ export function HTTPSamplesPanel() {
         SpanFields.SPAN_ID,
         SpanFields.TIMESTAMP,
         SpanFields.SPAN_DESCRIPTION,
-        SpanFields.RESPONSE_CODE,
+        SpanFields.SPAN_STATUS,
       ],
       sorts: [SPAN_SAMPLES_SORT],
       limit: SPAN_SAMPLE_LIMIT,
@@ -434,7 +433,7 @@ export function HTTPSamplesPanel() {
                   <ResponseCodeCountChart
                     search={search}
                     referrer={Referrer.SAMPLES_PANEL_RESPONSE_CODE_CHART}
-                    groupBy={[SpanFields.RESPONSE_CODE]}
+                    groupBy={[SpanFields.SPAN_STATUS]}
                     series={Object.values(responseCodeData).filter(Boolean)}
                     isLoading={isResponseCodeDataLoading}
                     error={responseCodeError}

--- a/static/app/views/insights/http/components/tables/spanSamplesTable.tsx
+++ b/static/app/views/insights/http/components/tables/spanSamplesTable.tsx
@@ -15,41 +15,41 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {renderHeadCell} from 'sentry/views/insights/common/components/tableCells/renderHeadCell';
 import {SpanIdCell} from 'sentry/views/insights/common/components/tableCells/spanIdCell';
-import type {SpanIndexedResponse} from 'sentry/views/insights/types';
-import {ModuleName, SpanIndexedField} from 'sentry/views/insights/types';
+import type {EAPSpanResponse} from 'sentry/views/insights/types';
+import {ModuleName, SpanFields} from 'sentry/views/insights/types';
 import {TraceViewSources} from 'sentry/views/performance/newTraceDetails/traceHeader/breadcrumbs';
 
 type DataRowKeys =
-  | SpanIndexedField.PROJECT
-  | SpanIndexedField.TRANSACTION_SPAN_ID
-  | SpanIndexedField.TRACE
-  | SpanIndexedField.TIMESTAMP
-  | SpanIndexedField.SPAN_ID
-  | SpanIndexedField.SPAN_DESCRIPTION
-  | SpanIndexedField.RESPONSE_CODE;
+  | SpanFields.PROJECT
+  | SpanFields.TRANSACTION_SPAN_ID
+  | SpanFields.TRACE
+  | SpanFields.TIMESTAMP
+  | SpanFields.SPAN_ID
+  | SpanFields.SPAN_DESCRIPTION
+  | SpanFields.SPAN_STATUS;
 
 type ColumnKeys =
-  | SpanIndexedField.SPAN_ID
-  | SpanIndexedField.SPAN_DESCRIPTION
-  | SpanIndexedField.RESPONSE_CODE;
+  | SpanFields.SPAN_ID
+  | SpanFields.SPAN_DESCRIPTION
+  | SpanFields.SPAN_STATUS;
 
-type DataRow = Pick<SpanIndexedResponse, DataRowKeys>;
+type DataRow = Pick<EAPSpanResponse, DataRowKeys>;
 
 type Column = GridColumnHeader<ColumnKeys>;
 
 const COLUMN_ORDER: Column[] = [
   {
-    key: SpanIndexedField.SPAN_ID,
+    key: SpanFields.SPAN_ID,
     name: t('Span ID'),
     width: 150,
   },
   {
-    key: SpanIndexedField.RESPONSE_CODE,
+    key: SpanFields.SPAN_STATUS,
     name: t('Status'),
     width: 50,
   },
   {
-    key: SpanIndexedField.SPAN_DESCRIPTION,
+    key: SpanFields.SPAN_DESCRIPTION,
     name: t('URL'),
     width: COL_WIDTH_UNDEFINED,
   },
@@ -111,21 +111,21 @@ function renderBodyCell(
   organization: Organization,
   theme: Theme
 ) {
-  if (column.key === SpanIndexedField.SPAN_ID) {
+  if (column.key === SpanFields.SPAN_ID) {
     return (
       <SpanIdCell
         moduleName={ModuleName.HTTP}
         traceId={row.trace}
         timestamp={row.timestamp}
-        transactionId={row[SpanIndexedField.TRANSACTION_SPAN_ID]}
-        spanId={row[SpanIndexedField.SPAN_ID]}
+        transactionId={row[SpanFields.TRANSACTION_SPAN_ID]}
+        spanId={row[SpanFields.SPAN_ID]}
         source={TraceViewSources.REQUESTS_MODULE}
         location={location}
       />
     );
   }
 
-  if (column.key === SpanIndexedField.SPAN_DESCRIPTION) {
+  if (column.key === SpanFields.SPAN_DESCRIPTION) {
     return <SpanDescriptionCell>{row[column.key]}</SpanDescriptionCell>;
   }
 

--- a/static/app/views/insights/http/components/tables/spanSamplesTable.tsx
+++ b/static/app/views/insights/http/components/tables/spanSamplesTable.tsx
@@ -26,12 +26,12 @@ type DataRowKeys =
   | SpanFields.TIMESTAMP
   | SpanFields.SPAN_ID
   | SpanFields.SPAN_DESCRIPTION
-  | SpanFields.SPAN_STATUS;
+  | SpanFields.SPAN_STATUS_CODE;
 
 type ColumnKeys =
   | SpanFields.SPAN_ID
   | SpanFields.SPAN_DESCRIPTION
-  | SpanFields.SPAN_STATUS;
+  | SpanFields.SPAN_STATUS_CODE;
 
 type DataRow = Pick<EAPSpanResponse, DataRowKeys>;
 
@@ -44,7 +44,7 @@ const COLUMN_ORDER: Column[] = [
     width: 150,
   },
   {
-    key: SpanFields.SPAN_STATUS,
+    key: SpanFields.SPAN_STATUS_CODE,
     name: t('Status'),
     width: 50,
   },

--- a/static/app/views/insights/http/queries/useSpanSamples.tsx
+++ b/static/app/views/insights/http/queries/useSpanSamples.tsx
@@ -13,7 +13,7 @@ import type {
   NonDefaultSpanSampleFields,
 } from 'sentry/views/insights/common/queries/useSpanSamples';
 import {getDateConditions} from 'sentry/views/insights/common/utils/getDateConditions';
-import {SpanIndexedField, type SpanIndexedResponse} from 'sentry/views/insights/types';
+import {type EAPSpanResponse, SpanFields} from 'sentry/views/insights/types';
 
 interface UseSpanSamplesOptions<Fields> {
   enabled?: boolean;
@@ -50,7 +50,7 @@ export const useSpanSamples = <Fields extends NonDefaultSpanSampleFields[]>(
   const dateConditions = getDateConditions(selection);
 
   return useApiQuery<{
-    data: Array<Pick<SpanIndexedResponse, Fields[number] | DefaultSpanSampleFields>>;
+    data: Array<Pick<EAPSpanResponse, Fields[number] | DefaultSpanSampleFields>>;
     meta: EventsMetaType;
   }>(
     [
@@ -67,7 +67,7 @@ export const useSpanSamples = <Fields extends NonDefaultSpanSampleFields[]>(
           secondBound: max && max * (2 / 3),
           upperBound: max,
           // TODO: transaction.span_id should be a default from the backend
-          additionalFields: [...fields, SpanIndexedField.TRANSACTION_SPAN_ID],
+          additionalFields: [...fields, SpanFields.TRANSACTION_SPAN_ID],
           sort: '-timestamp',
           sampling: SAMPLING_MODE.NORMAL,
           dataset: DiscoverDatasets.SPANS_EAP,

--- a/static/app/views/insights/mobile/common/components/spanSamplesPanelContainer.tsx
+++ b/static/app/views/insights/mobile/common/components/spanSamplesPanelContainer.tsx
@@ -29,7 +29,7 @@ import {InsightsSpanTagProvider} from 'sentry/views/insights/pages/insightsSpanT
 import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
 import {
   type ModuleName,
-  SpanIndexedField,
+  SpanFields,
   SpanMetricsField,
   type SpanMetricsQueryFilters,
 } from 'sentry/views/insights/types';
@@ -246,7 +246,7 @@ export function SpanSamplesContainer({
               width: COL_WIDTH_UNDEFINED,
             },
           ]}
-          additionalFields={[SpanIndexedField.PROFILER_ID]}
+          additionalFields={[SpanFields.PROFILER_ID]}
         />
       </InsightsSpanTagProvider>
     </Fragment>

--- a/static/app/views/insights/queues/components/messageSpanSamplesPanel.tsx
+++ b/static/app/views/insights/queues/components/messageSpanSamplesPanel.tsx
@@ -48,7 +48,7 @@ import decodeRetryCount from 'sentry/views/insights/queues/utils/queryParameterD
 import decodeTraceStatus from 'sentry/views/insights/queues/utils/queryParameterDecoders/traceStatus';
 import {
   ModuleName,
-  SpanIndexedField,
+  SpanFields,
   type SpanMetricsResponse,
 } from 'sentry/views/insights/types';
 
@@ -192,15 +192,15 @@ export function MessageSpanSamplesPanel() {
     max: durationAxisMax,
     enabled: isPanelOpen && durationAxisMax > 0,
     fields: [
-      SpanIndexedField.ID,
-      SpanIndexedField.TRACE,
-      SpanIndexedField.SPAN_DESCRIPTION,
-      SpanIndexedField.MESSAGING_MESSAGE_BODY_SIZE,
-      SpanIndexedField.MESSAGING_MESSAGE_RECEIVE_LATENCY,
-      SpanIndexedField.MESSAGING_MESSAGE_RETRY_COUNT,
-      SpanIndexedField.MESSAGING_MESSAGE_ID,
-      SpanIndexedField.TRACE_STATUS,
-      SpanIndexedField.SPAN_DURATION,
+      SpanFields.ID,
+      SpanFields.TRACE,
+      SpanFields.SPAN_DESCRIPTION,
+      SpanFields.MESSAGING_MESSAGE_BODY_SIZE,
+      SpanFields.MESSAGING_MESSAGE_RECEIVE_LATENCY,
+      SpanFields.MESSAGING_MESSAGE_RETRY_COUNT,
+      SpanFields.MESSAGING_MESSAGE_ID,
+      SpanFields.TRACE_STATUS,
+      SpanFields.SPAN_DURATION,
     ],
   });
 
@@ -342,13 +342,13 @@ export function MessageSpanSamplesPanel() {
                 // Samples endpoint doesn't provide meta data, so we need to provide it here
                 meta={{
                   fields: {
-                    [SpanIndexedField.SPAN_DURATION]: 'duration',
-                    [SpanIndexedField.MESSAGING_MESSAGE_BODY_SIZE]: 'size',
-                    [SpanIndexedField.MESSAGING_MESSAGE_RETRY_COUNT]: 'number',
+                    [SpanFields.SPAN_DURATION]: 'duration',
+                    [SpanFields.MESSAGING_MESSAGE_BODY_SIZE]: 'size',
+                    [SpanFields.MESSAGING_MESSAGE_RETRY_COUNT]: 'number',
                   },
                   units: {
-                    [SpanIndexedField.SPAN_DURATION]: DurationUnit.MILLISECOND,
-                    [SpanIndexedField.MESSAGING_MESSAGE_BODY_SIZE]: SizeUnit.BYTE,
+                    [SpanFields.SPAN_DURATION]: DurationUnit.MILLISECOND,
+                    [SpanFields.MESSAGING_MESSAGE_BODY_SIZE]: SizeUnit.BYTE,
                   },
                 }}
                 type={messageActorType}

--- a/static/app/views/insights/queues/components/tables/messageSpanSamplesTable.tsx
+++ b/static/app/views/insights/queues/components/tables/messageSpanSamplesTable.tsx
@@ -16,59 +16,59 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {renderHeadCell} from 'sentry/views/insights/common/components/tableCells/renderHeadCell';
 import {SpanIdCell} from 'sentry/views/insights/common/components/tableCells/spanIdCell';
 import {MessageActorType} from 'sentry/views/insights/queues/settings';
-import type {SpanIndexedResponse} from 'sentry/views/insights/types';
-import {ModuleName, SpanIndexedField} from 'sentry/views/insights/types';
+import type {EAPSpanResponse} from 'sentry/views/insights/types';
+import {ModuleName, SpanFields} from 'sentry/views/insights/types';
 import {TraceViewSources} from 'sentry/views/performance/newTraceDetails/traceHeader/breadcrumbs';
 
 type DataRowKeys =
-  | SpanIndexedField.PROJECT
-  | SpanIndexedField.TRANSACTION_SPAN_ID
-  | SpanIndexedField.TRACE
-  | SpanIndexedField.TIMESTAMP
-  | SpanIndexedField.SPAN_ID
-  | SpanIndexedField.SPAN_DESCRIPTION
-  | SpanIndexedField.MESSAGING_MESSAGE_BODY_SIZE
-  | SpanIndexedField.MESSAGING_MESSAGE_RECEIVE_LATENCY
-  | SpanIndexedField.MESSAGING_MESSAGE_ID
-  | SpanIndexedField.MESSAGING_MESSAGE_RETRY_COUNT
-  | SpanIndexedField.TRACE_STATUS
-  | SpanIndexedField.SPAN_DURATION;
+  | SpanFields.PROJECT
+  | SpanFields.TRANSACTION_SPAN_ID
+  | SpanFields.TRACE
+  | SpanFields.TIMESTAMP
+  | SpanFields.SPAN_ID
+  | SpanFields.SPAN_DESCRIPTION
+  | SpanFields.MESSAGING_MESSAGE_BODY_SIZE
+  | SpanFields.MESSAGING_MESSAGE_RECEIVE_LATENCY
+  | SpanFields.MESSAGING_MESSAGE_ID
+  | SpanFields.MESSAGING_MESSAGE_RETRY_COUNT
+  | SpanFields.TRACE_STATUS
+  | SpanFields.SPAN_DURATION;
 
 type ColumnKeys =
-  | SpanIndexedField.SPAN_ID
-  | SpanIndexedField.MESSAGING_MESSAGE_ID
-  | SpanIndexedField.MESSAGING_MESSAGE_BODY_SIZE
-  | SpanIndexedField.MESSAGING_MESSAGE_RETRY_COUNT
-  | SpanIndexedField.TRACE_STATUS
-  | SpanIndexedField.SPAN_DURATION;
+  | SpanFields.SPAN_ID
+  | SpanFields.MESSAGING_MESSAGE_ID
+  | SpanFields.MESSAGING_MESSAGE_BODY_SIZE
+  | SpanFields.MESSAGING_MESSAGE_RETRY_COUNT
+  | SpanFields.TRACE_STATUS
+  | SpanFields.SPAN_DURATION;
 
-type DataRow = Pick<SpanIndexedResponse, DataRowKeys>;
+type DataRow = Pick<EAPSpanResponse, DataRowKeys>;
 
 type Column = GridColumnHeader<ColumnKeys>;
 
 const CONSUMER_COLUMN_ORDER: Column[] = [
   {
-    key: SpanIndexedField.SPAN_ID,
+    key: SpanFields.SPAN_ID,
     name: t('Span ID'),
     width: 150,
   },
   {
-    key: SpanIndexedField.MESSAGING_MESSAGE_ID,
+    key: SpanFields.MESSAGING_MESSAGE_ID,
     name: t('Message ID'),
     width: COL_WIDTH_UNDEFINED,
   },
   {
-    key: SpanIndexedField.SPAN_DURATION,
+    key: SpanFields.SPAN_DURATION,
     name: t('Span Duration'),
     width: COL_WIDTH_UNDEFINED,
   },
   {
-    key: SpanIndexedField.MESSAGING_MESSAGE_RETRY_COUNT,
+    key: SpanFields.MESSAGING_MESSAGE_RETRY_COUNT,
     name: t('Retries'),
     width: COL_WIDTH_UNDEFINED,
   },
   {
-    key: SpanIndexedField.TRACE_STATUS,
+    key: SpanFields.TRACE_STATUS,
     name: t('Status'),
     width: COL_WIDTH_UNDEFINED,
   },
@@ -76,22 +76,22 @@ const CONSUMER_COLUMN_ORDER: Column[] = [
 
 const PRODUCER_COLUMN_ORDER: Column[] = [
   {
-    key: SpanIndexedField.SPAN_ID,
+    key: SpanFields.SPAN_ID,
     name: t('Span ID'),
     width: 150,
   },
   {
-    key: SpanIndexedField.MESSAGING_MESSAGE_ID,
+    key: SpanFields.MESSAGING_MESSAGE_ID,
     name: t('Message ID'),
     width: COL_WIDTH_UNDEFINED,
   },
   {
-    key: SpanIndexedField.MESSAGING_MESSAGE_BODY_SIZE,
+    key: SpanFields.MESSAGING_MESSAGE_BODY_SIZE,
     name: t('Message Size'),
     width: COL_WIDTH_UNDEFINED,
   },
   {
-    key: SpanIndexedField.TRACE_STATUS,
+    key: SpanFields.TRACE_STATUS,
     name: t('Status'),
     width: COL_WIDTH_UNDEFINED,
   },
@@ -164,14 +164,14 @@ function renderBodyCell(
     );
   }
 
-  if (key === SpanIndexedField.SPAN_ID) {
+  if (key === SpanFields.SPAN_ID) {
     return (
       <SpanIdCell
         moduleName={ModuleName.QUEUE}
         traceId={row.trace}
         timestamp={row.timestamp}
-        transactionSpanId={row[SpanIndexedField.TRANSACTION_SPAN_ID]}
-        spanId={row[SpanIndexedField.SPAN_ID]}
+        transactionSpanId={row[SpanFields.TRANSACTION_SPAN_ID]}
+        spanId={row[SpanFields.SPAN_ID]}
         source={TraceViewSources.QUEUES_MODULE}
         location={location}
       />

--- a/static/app/views/insights/queues/components/tables/queuesTable.spec.tsx
+++ b/static/app/views/insights/queues/components/tables/queuesTable.spec.tsx
@@ -3,7 +3,7 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {QueuesTable} from 'sentry/views/insights/queues/components/tables/queuesTable';
-import {SpanIndexedField} from 'sentry/views/insights/types';
+import {SpanFields} from 'sentry/views/insights/types';
 
 describe('queuesTable', () => {
   const organization = OrganizationFixture();
@@ -98,7 +98,7 @@ describe('queuesTable', () => {
     render(
       <QueuesTable
         destination="*events*"
-        sort={{field: SpanIndexedField.MESSAGING_MESSAGE_DESTINATION_NAME, kind: 'desc'}}
+        sort={{field: SpanFields.MESSAGING_MESSAGE_DESTINATION_NAME, kind: 'desc'}}
       />,
       {organization}
     );

--- a/static/app/views/insights/queues/components/tables/queuesTable.tsx
+++ b/static/app/views/insights/queues/components/tables/queuesTable.tsx
@@ -29,7 +29,7 @@ import {useQueuesByDestinationQuery} from 'sentry/views/insights/queues/queries/
 import {Referrer} from 'sentry/views/insights/queues/referrers';
 import {
   ModuleName,
-  SpanIndexedField,
+  SpanFields,
   type SpanMetricsResponse,
 } from 'sentry/views/insights/types';
 
@@ -83,7 +83,7 @@ const COLUMN_ORDER: Column[] = [
 ];
 
 const SORTABLE_FIELDS = [
-  SpanIndexedField.MESSAGING_MESSAGE_DESTINATION_NAME,
+  SpanFields.MESSAGING_MESSAGE_DESTINATION_NAME,
   'count_op(queue.publish)',
   'count_op(queue.process)',
   'avg_if(span.duration,span.op,queue.process)',

--- a/static/app/views/insights/types.tsx
+++ b/static/app/views/insights/types.tsx
@@ -96,11 +96,11 @@ export enum SpanFields {
   SPAN_OP = 'span.op',
   NAME = 'span.name',
   KIND = 'span.kind',
-  STATUS = 'span.status',
+  SPAN_STATUS = 'span.status',
   STATUS_MESSAGE = 'span.status_message',
   RELEASE = 'release',
   PROJECT_ID = 'project.id',
-  SPAN_STATUS = 'span.status_code',
+  SPAN_STATUS_CODE = 'span.status_code',
   DEVICE_CLASS = 'device.class',
   SPAN_SYSTEM = 'span.system',
   SPAN_CATEGORY = 'span.category',
@@ -264,7 +264,6 @@ export type SpanStringFields =
   | SpanFields.ID
   | SpanFields.NAME
   | SpanFields.KIND
-  | SpanFields.STATUS
   | SpanFields.STATUS_MESSAGE
   | SpanFields.GEN_AI_AGENT_NAME
   | SpanFields.GEN_AI_REQUEST_MODEL
@@ -468,6 +467,25 @@ type EAPSpanResponseRaw = {
     [SpanFields.USER_GEO_SUBREGION]: SubregionCode;
   } & {
     [SpanFields.DB_SYSTEM]: SupportedDatabaseSystem;
+  } & {
+    [SpanFields.SPAN_STATUS]:
+      | 'ok'
+      | 'cancelled'
+      | 'unknown'
+      | 'invalid_argument'
+      | 'deadline_exceeded'
+      | 'not_found'
+      | 'already_exists'
+      | 'permission_denied'
+      | 'resource_exhausted'
+      | 'failed_precondition'
+      | 'aborted'
+      | 'out_of_range'
+      | 'unimplemented'
+      | 'internal_error'
+      | 'unavailable'
+      | 'data_loss'
+      | 'unauthenticated';
   } & {
     [Property in SpanFields as `count_unique(${Property})`]: number;
   } & {

--- a/static/app/views/insights/types.tsx
+++ b/static/app/views/insights/types.tsx
@@ -100,7 +100,7 @@ export enum SpanFields {
   STATUS_MESSAGE = 'span.status_message',
   RELEASE = 'release',
   PROJECT_ID = 'project.id',
-  RESPONSE_CODE = 'span.status_code',
+  SPAN_STATUS = 'span.status_code',
   DEVICE_CLASS = 'device.class',
   SPAN_SYSTEM = 'span.system',
   SPAN_CATEGORY = 'span.category',
@@ -136,6 +136,26 @@ export enum SpanFields {
   CODE_LINENO = 'code.lineno',
   APP_START_COLD = 'measurements.app_start_cold',
   APP_START_WARM = 'measurements.app_start_warm',
+  SPAN_ACTION = 'span.action',
+  SPAN_DOMAIN = 'span.domain',
+  NORMALIZED_DESCRIPTION = 'sentry.normalized_description',
+  BROWSER_NAME = 'browser.name',
+  ENVIRONMENT = 'environment',
+  ORIGIN_TRANSACTION = 'origin.transaction',
+  TRANSACTION_METHOD = 'transaction.method',
+  TRANSACTION_OP = 'transaction.op',
+  HTTP_RESPONSE_CONTENT_LENGTH = 'http.response_content_length',
+  RESOURCE_RENDER_BLOCKING_STATUS = 'resource.render_blocking_status',
+  PROFILER_ID = 'profiler.id',
+  TRACE_STATUS = 'trace.status',
+  SPAN_AI_PIPELINE_GROUP = 'span.ai.pipeline.group',
+
+  // Messaging fields
+  MESSAGING_MESSAGE_ID = 'messaging.message.id',
+  MESSAGING_MESSAGE_BODY_SIZE = 'measurements.messaging.message.body.size',
+  MESSAGING_MESSAGE_RECEIVE_LATENCY = 'measurements.messaging.message.receive.latency',
+  MESSAGING_MESSAGE_RETRY_COUNT = 'measurements.messaging.message.retry.count',
+  MESSAGING_MESSAGE_DESTINATION_NAME = 'messaging.destination.name',
 
   // User fields
   USER_ID = 'user.id',
@@ -273,10 +293,17 @@ export type SpanStringFields =
   | SpanFields.SDK_NAME
   | SpanFields.SDK_VERSION
   | SpanFields.DEVICE_CLASS
+  | SpanFields.SPAN_ACTION
+  | SpanFields.SPAN_DOMAIN
+  | SpanFields.NORMALIZED_DESCRIPTION
+  | SpanFields.MESSAGING_MESSAGE_BODY_SIZE
+  | SpanFields.MESSAGING_MESSAGE_RECEIVE_LATENCY
+  | SpanFields.MESSAGING_MESSAGE_RETRY_COUNT
+  | SpanFields.MESSAGING_MESSAGE_ID
+  | SpanFields.TRACE_STATUS
   | 'span_id'
   | 'span.op'
   | 'span.description'
-  | 'sentry.normalized_description'
   | 'span.action'
   | 'span.group'
   | 'span.category'
@@ -311,10 +338,6 @@ export type SpanStringFields =
 export type SpanMetricsQueryFilters = Partial<Record<SpanStringFields, string>> & {
   [SpanMetricsField.PROJECT_ID]?: string;
   [SpanMetricsField.SPAN_DOMAIN]?: string;
-};
-
-export type SpanIndexedQueryFilters = Partial<Record<SpanStringFields, string>> & {
-  [SpanIndexedField.PROJECT_ID]?: string;
 };
 
 type SpanStringArrayFields = 'span.domain';
@@ -444,7 +467,11 @@ type EAPSpanResponseRaw = {
   } & {
     [SpanFields.USER_GEO_SUBREGION]: SubregionCode;
   } & {
+    [SpanFields.DB_SYSTEM]: SupportedDatabaseSystem;
+  } & {
     [Property in SpanFields as `count_unique(${Property})`]: number;
+  } & {
+    [SpanFields.RESOURCE_RENDER_BLOCKING_STATUS]: '' | 'non-blocking' | 'blocking';
   } & {
     [Property in SpanNumberFields as `${CounterConditionalAggregate}(${Property},${string},${string})`]: number;
   } & {
@@ -455,192 +482,6 @@ type EAPSpanResponseRaw = {
 
 export type EAPSpanResponse = Flatten<EAPSpanResponseRaw>;
 export type EAPSpanProperty = keyof EAPSpanResponse; // TODO: rename this to `SpanProperty` when we remove `useInsightsEap`
-
-export enum SpanIndexedField {
-  ENVIRONMENT = 'environment',
-  RESOURCE_RENDER_BLOCKING_STATUS = 'resource.render_blocking_status',
-  HTTP_RESPONSE_CONTENT_LENGTH = 'http.response_content_length',
-  SPAN_CATEGORY = 'span.category',
-  SPAN_DURATION = 'span.duration',
-  SPAN_SELF_TIME = 'span.self_time',
-  SPAN_GROUP = 'span.group', // Span group computed from the normalized description. Matches the group in the metrics data set
-  SPAN_DESCRIPTION = 'span.description',
-  SPAN_STATUS = 'span.status',
-  SPAN_OP = 'span.op',
-  ID = 'id',
-  SPAN_ID = 'span_id',
-  SPAN_ACTION = 'span.action',
-  SPAN_AI_PIPELINE_GROUP = 'span.ai.pipeline.group',
-  SDK_NAME = 'sdk.name',
-  SDK_VERSION = 'sdk.version',
-  TRACE = 'trace',
-  TRANSACTION_ID = 'transaction.id', // TODO - remove this with `useInsightsEap`
-  TRANSACTION_SPAN_ID = 'transaction.span_id',
-  TRANSACTION_METHOD = 'transaction.method',
-  TRANSACTION_OP = 'transaction.op',
-  SPAN_DOMAIN = 'span.domain',
-  TIMESTAMP = 'timestamp',
-  RAW_DOMAIN = 'raw_domain',
-  PROJECT = 'project',
-  PROJECT_ID = 'project.id',
-  PROFILE_ID = 'profile_id',
-  PROFILEID = 'profile.id',
-  PROFILER_ID = 'profiler.id',
-  RELEASE = 'release',
-  TRANSACTION = 'transaction',
-  ORIGIN_TRANSACTION = 'origin.transaction',
-  REPLAYID = 'replayId',
-  REPLAY_ID = 'replay.id',
-  REPLAY = 'replay', // Field alias that coalesces `replay.id` and `replayId`
-  BROWSER_NAME = 'browser.name',
-  USER = 'user',
-  USER_ID = 'user.id',
-  USER_IP = 'user.ip',
-  USER_EMAIL = 'user.email',
-  USER_USERNAME = 'user.username',
-  USER_DISPLAY = 'user.display', // Field alias that coalesces `user.id`, `user.email`, `user.username`, `user.ip`, and `user`
-  INP = 'measurements.inp',
-  INP_SCORE = 'measurements.score.inp',
-  INP_SCORE_RATIO = 'measurements.score.ratio.inp',
-  INP_SCORE_WEIGHT = 'measurements.score.weight.inp',
-  LCP = 'measurements.lcp',
-  LCP_SCORE = 'measurements.score.lcp',
-  LCP_SCORE_RATIO = 'measurements.score.ratio.lcp',
-  CLS = 'measurements.cls',
-  CLS_SCORE = 'measurements.score.cls',
-  CLS_SCORE_RATIO = 'measurements.score.ratio.cls',
-  TTFB = 'measurements.ttfb',
-  TTFB_SCORE = 'measurements.score.ttfb',
-  TTFB_SCORE_RATIO = 'measurements.score.ratio.ttfb',
-  FCP = 'measurements.fcp',
-  FCP_SCORE = 'measurements.score.fcp',
-  FCP_SCORE_RATIO = 'measurements.score.ratio.fcp',
-  TOTAL_SCORE = 'measurements.score.total',
-  RESPONSE_CODE = 'span.status_code',
-  CACHE_HIT = 'cache.hit',
-  CACHE_ITEM_SIZE = 'measurements.cache.item_size',
-  TRACE_STATUS = 'trace.status',
-  MESSAGING_MESSAGE_ID = 'messaging.message.id',
-  MESSAGING_MESSAGE_BODY_SIZE = 'measurements.messaging.message.body.size',
-  MESSAGING_MESSAGE_RECEIVE_LATENCY = 'measurements.messaging.message.receive.latency',
-  MESSAGING_MESSAGE_RETRY_COUNT = 'measurements.messaging.message.retry.count',
-  MESSAGING_MESSAGE_DESTINATION_NAME = 'messaging.destination.name',
-  USER_GEO_SUBREGION = 'user.geo.subregion',
-  IS_TRANSACTION = 'is_transaction',
-  LCP_ELEMENT = 'lcp.element',
-  CLS_SOURCE = 'cls.source.1',
-  NORMALIZED_DESCRIPTION = 'sentry.normalized_description',
-  MEASUREMENT_HTTP_RESPONSE_CONTENT_LENGTH = 'measurements.http.response_content_length',
-  DB_SYSTEM = 'db.system',
-  CODE_FILEPATH = 'code.filepath',
-  CODE_LINENO = 'code.lineno',
-  CODE_FUNCTION = 'code.function',
-  PLATFORM = 'platform',
-}
-
-export type SpanIndexedResponse = {
-  [SpanIndexedField.ID]: string;
-  [SpanIndexedField.SPAN_ID]: string;
-  [SpanIndexedField.ENVIRONMENT]: string;
-  [SpanIndexedField.RELEASE]: string;
-  [SpanIndexedField.SDK_NAME]: string;
-  [SpanIndexedField.SDK_VERSION]: string;
-  [SpanIndexedField.SPAN_CATEGORY]: string;
-  [SpanIndexedField.SPAN_DURATION]: number;
-  [SpanIndexedField.SPAN_SELF_TIME]: number;
-  [SpanIndexedField.SPAN_GROUP]: string;
-  [SpanIndexedField.SPAN_DESCRIPTION]: string;
-  [SpanIndexedField.SPAN_OP]: string;
-  [SpanIndexedField.SPAN_AI_PIPELINE_GROUP]: string;
-  [SpanIndexedField.SPAN_STATUS]:
-    | 'ok'
-    | 'cancelled'
-    | 'unknown'
-    | 'invalid_argument'
-    | 'deadline_exceeded'
-    | 'not_found'
-    | 'already_exists'
-    | 'permission_denied'
-    | 'resource_exhausted'
-    | 'failed_precondition'
-    | 'aborted'
-    | 'out_of_range'
-    | 'unimplemented'
-    | 'internal_error'
-    | 'unavailable'
-    | 'data_loss'
-    | 'unauthenticated';
-  [SpanIndexedField.SPAN_ACTION]: string;
-  [SpanIndexedField.TRACE]: string;
-  [SpanIndexedField.TRANSACTION]: string;
-  [SpanIndexedField.TRANSACTION_ID]: string;
-  [SpanIndexedField.TRANSACTION_SPAN_ID]: string;
-  [SpanIndexedField.TRANSACTION_METHOD]: string;
-  [SpanIndexedField.TRANSACTION_OP]: string;
-  [SpanIndexedField.SPAN_DOMAIN]: string[];
-  [SpanIndexedField.RAW_DOMAIN]: string;
-  [SpanIndexedField.TIMESTAMP]: string;
-  [SpanIndexedField.PROJECT]: string;
-  [SpanIndexedField.PROJECT_ID]: number;
-  [SpanIndexedField.PROFILE_ID]: string;
-  [SpanIndexedField.PROFILEID]: string;
-  [SpanIndexedField.PROFILER_ID]: string;
-  [SpanIndexedField.RESOURCE_RENDER_BLOCKING_STATUS]: '' | 'non-blocking' | 'blocking';
-  [SpanIndexedField.HTTP_RESPONSE_CONTENT_LENGTH]: string;
-  [SpanIndexedField.ORIGIN_TRANSACTION]: string;
-  [SpanIndexedField.REPLAY_ID]: string;
-  [SpanIndexedField.REPLAYID]: string;
-  [SpanIndexedField.REPLAY]: string;
-  [SpanIndexedField.BROWSER_NAME]: string;
-  [SpanIndexedField.USER]: string;
-  [SpanIndexedField.USER_ID]: string;
-  [SpanIndexedField.USER_EMAIL]: string;
-  [SpanIndexedField.USER_USERNAME]: string;
-  [SpanIndexedField.USER_IP]: string;
-  [SpanIndexedField.USER_DISPLAY]: string;
-  [SpanIndexedField.IS_TRANSACTION]: number;
-  [SpanIndexedField.INP]: number;
-  [SpanIndexedField.INP_SCORE]: number;
-  [SpanIndexedField.INP_SCORE_WEIGHT]: number;
-  [SpanIndexedField.INP_SCORE_RATIO]: number;
-  [SpanIndexedField.LCP]: number;
-  [SpanIndexedField.LCP_SCORE]: number;
-  [SpanIndexedField.LCP_SCORE_RATIO]: number;
-  [SpanIndexedField.CLS]: number;
-  [SpanIndexedField.CLS_SCORE]: number;
-  [SpanIndexedField.CLS_SCORE_RATIO]: number;
-  [SpanIndexedField.TTFB]: number;
-  [SpanIndexedField.TTFB_SCORE]: number;
-  [SpanIndexedField.TTFB_SCORE_RATIO]: number;
-  [SpanIndexedField.FCP]: number;
-  [SpanIndexedField.FCP_SCORE]: number;
-  [SpanIndexedField.FCP_SCORE_RATIO]: number;
-  [SpanIndexedField.TOTAL_SCORE]: number;
-  [SpanIndexedField.RESPONSE_CODE]: string;
-  [SpanIndexedField.CACHE_HIT]: '' | 'true' | 'false';
-  [SpanIndexedField.CACHE_ITEM_SIZE]: number;
-  [SpanIndexedField.TRACE_STATUS]: string;
-  [SpanIndexedField.MESSAGING_MESSAGE_ID]: string;
-  [SpanIndexedField.MESSAGING_MESSAGE_BODY_SIZE]: number;
-  [SpanIndexedField.MESSAGING_MESSAGE_RECEIVE_LATENCY]: number;
-  [SpanIndexedField.MESSAGING_MESSAGE_RETRY_COUNT]: number;
-  [SpanIndexedField.MESSAGING_MESSAGE_DESTINATION_NAME]: string;
-  [SpanIndexedField.USER_GEO_SUBREGION]: string;
-  [SpanIndexedField.LCP_ELEMENT]: string;
-  [SpanIndexedField.CLS_SOURCE]: string;
-  [SpanIndexedField.MEASUREMENT_HTTP_RESPONSE_CONTENT_LENGTH]: number;
-  'any(id)': string;
-  [SpanIndexedField.DB_SYSTEM]: SupportedDatabaseSystem;
-  [SpanIndexedField.CODE_FILEPATH]: string;
-  [SpanIndexedField.CODE_LINENO]: number;
-  [SpanIndexedField.CODE_FUNCTION]: string;
-  [SpanIndexedField.PLATFORM]: PlatformKey;
-};
-
-export type SpanIndexedProperty = keyof SpanIndexedResponse;
-
-// TODO: When convenient, remove this alias and use `IndexedResponse` everywhere
-export type SpanIndexedFieldTypes = SpanIndexedResponse;
 
 export enum SpanFunction {
   SPS = 'sps',
@@ -659,7 +500,7 @@ export enum SpanFunction {
 
 export type SpanQueryFilters = Partial<Record<SpanStringFields, string>> & {
   is_transaction?: 'true' | 'false';
-  [SpanIndexedField.PROJECT_ID]?: string;
+  [SpanFields.PROJECT_ID]?: string;
 };
 
 // Maps the subregion code to the subregion name according to UN m49 standard

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/description.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/description.tsx
@@ -34,7 +34,7 @@ import {
   isValidJson,
   prettyPrintJsonString,
 } from 'sentry/views/insights/database/utils/jsonUtils';
-import {ModuleName, SpanIndexedField} from 'sentry/views/insights/types';
+import {ModuleName, SpanFields} from 'sentry/views/insights/types';
 import {traceAnalytics} from 'sentry/views/performance/newTraceDetails/traceAnalytics';
 import SpanSummaryLink from 'sentry/views/performance/newTraceDetails/traceDrawer/details/span/components/spanSummaryLink';
 import {TraceDrawerComponents} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/styles';
@@ -116,7 +116,7 @@ export function SpanDescription({
                 organization,
                 location,
                 node.event?.projectID,
-                SpanIndexedField.SPAN_DESCRIPTION,
+                SpanFields.SPAN_DESCRIPTION,
                 span.description,
                 TraceDrawerActionKind.INCLUDE
               )
@@ -132,7 +132,7 @@ export function SpanDescription({
           if (hasExploreEnabled) {
             traceAnalytics.trackExploreSearch(
               organization,
-              SpanIndexedField.SPAN_DESCRIPTION,
+              SpanFields.SPAN_DESCRIPTION,
               span.description!,
               TraceDrawerActionKind.INCLUDE,
               'drawer'

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/ancestry.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/ancestry.tsx
@@ -12,7 +12,7 @@ import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
 import {generateEventSlug} from 'sentry/utils/discover/urls';
-import {SpanIndexedField} from 'sentry/views/insights/types';
+import {SpanFields} from 'sentry/views/insights/types';
 import {
   type SectionCardKeyValueList,
   TraceDrawerComponents,
@@ -171,7 +171,7 @@ export function useSpanAncestryAndGroupingItems({
     subject: t('Span Group'),
     actionButton: (
       <TraceDrawerComponents.KeyValueAction
-        rowKey={SpanIndexedField.SPAN_GROUP}
+        rowKey={SpanFields.SPAN_GROUP}
         rowValue={spanGroup}
         projectIds={
           childTransaction ? String(childTransaction.value.project_id) : undefined

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/description.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/description.tsx
@@ -33,7 +33,7 @@ import {
   isValidJson,
   prettyPrintJsonString,
 } from 'sentry/views/insights/database/utils/jsonUtils';
-import {ModuleName, SpanIndexedField} from 'sentry/views/insights/types';
+import {ModuleName, SpanFields} from 'sentry/views/insights/types';
 import {traceAnalytics} from 'sentry/views/performance/newTraceDetails/traceAnalytics';
 import SpanSummaryLink from 'sentry/views/performance/newTraceDetails/traceDrawer/details/span/components/spanSummaryLink';
 import {TraceDrawerComponents} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/styles';
@@ -121,7 +121,7 @@ export function SpanDescription({
                 organization,
                 location,
                 node.event?.projectID,
-                SpanIndexedField.SPAN_DESCRIPTION,
+                SpanFields.SPAN_DESCRIPTION,
                 span.description!,
                 TraceDrawerActionKind.INCLUDE
               )
@@ -137,7 +137,7 @@ export function SpanDescription({
           if (hasExploreEnabled) {
             traceAnalytics.trackExploreSearch(
               organization,
-              SpanIndexedField.SPAN_DESCRIPTION,
+              SpanFields.SPAN_DESCRIPTION,
               span.description!,
               TraceDrawerActionKind.INCLUDE,
               'drawer'

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/generalInfo.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/generalInfo.tsx
@@ -15,7 +15,7 @@ import {SQLishFormatter} from 'sentry/utils/sqlish/SQLishFormatter';
 import {FullSpanDescription} from 'sentry/views/insights/common/components/fullSpanDescription';
 import {WiderHovercard} from 'sentry/views/insights/common/components/tableCells/spanDescriptionCell';
 import {resolveSpanModule} from 'sentry/views/insights/common/utils/resolveSpanModule';
-import {ModuleName, SpanIndexedField} from 'sentry/views/insights/types';
+import {ModuleName, SpanFields} from 'sentry/views/insights/types';
 import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSection';
 import {
   type SectionCardKeyValueList,
@@ -110,7 +110,7 @@ export function GeneralInfo(props: GeneralnfoProps) {
       value: span.op,
       actionButton: (
         <TraceDrawerComponents.KeyValueAction
-          rowKey={SpanIndexedField.SPAN_OP}
+          rowKey={SpanFields.SPAN_OP}
           rowValue={span.op}
           projectIds={projectIds}
         />
@@ -142,7 +142,7 @@ export function GeneralInfo(props: GeneralnfoProps) {
       ),
       actionButton: (
         <TraceDrawerComponents.KeyValueAction
-          rowKey={SpanIndexedField.SPAN_DESCRIPTION}
+          rowKey={SpanFields.SPAN_DESCRIPTION}
           rowValue={span.description}
           projectIds={projectIds}
         />
@@ -155,7 +155,7 @@ export function GeneralInfo(props: GeneralnfoProps) {
       value: <SpanDuration node={props.node} />,
       actionButton: (
         <TraceDrawerComponents.KeyValueAction
-          rowKey={SpanIndexedField.SPAN_DURATION}
+          rowKey={SpanFields.SPAN_DURATION}
           rowValue={getDuration((endTimestamp - startTimestamp) / 1000, 2, true)}
           projectIds={projectIds}
         />
@@ -189,7 +189,7 @@ export function GeneralInfo(props: GeneralnfoProps) {
       }),
       actionButton: (
         <TraceDrawerComponents.KeyValueAction
-          rowKey={SpanIndexedField.TIMESTAMP}
+          rowKey={SpanFields.TIMESTAMP}
           rowValue={new Date(endTimestamp).toISOString()}
           projectIds={projectIds}
         />
@@ -214,7 +214,7 @@ export function GeneralInfo(props: GeneralnfoProps) {
       value: <SpanSelfTime node={props.node} />,
       actionButton: (
         <TraceDrawerComponents.KeyValueAction
-          rowKey={SpanIndexedField.SPAN_SELF_TIME}
+          rowKey={SpanFields.SPAN_SELF_TIME}
           rowValue={getDuration(span.exclusive_time / 1000, 2, true)}
           projectIds={projectIds}
         />

--- a/static/app/views/performance/newTraceDetails/traceLinksNavigation/useFindNextTrace.ts
+++ b/static/app/views/performance/newTraceDetails/traceLinksNavigation/useFindNextTrace.ts
@@ -6,7 +6,7 @@ import {useApiQueries} from 'sentry/utils/queryClient';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
-import {SpanIndexedField} from 'sentry/views/insights/types';
+import {SpanFields} from 'sentry/views/insights/types';
 import {useIsEAPTraceEnabled} from 'sentry/views/performance/newTraceDetails/useIsEAPTraceEnabled';
 
 import type {ConnectedTraceConnection} from './traceLinkNavigationButton';
@@ -49,11 +49,7 @@ export function useFindNextTrace({
         },
       },
       search: MutableSearch.fromQueryObject({is_transaction: 1}),
-      fields: [
-        SpanIndexedField.TRANSACTION_ID,
-        SpanIndexedField.PROJECT_ID,
-        SpanIndexedField.PROJECT,
-      ],
+      fields: [SpanFields.TRANSACTION_ID, SpanFields.PROJECT_ID, SpanFields.PROJECT],
     },
     'api.trace-view.linked-traces'
   );

--- a/static/app/views/performance/newTraceDetails/traceLinksNavigation/useFindNextTrace.ts
+++ b/static/app/views/performance/newTraceDetails/traceLinksNavigation/useFindNextTrace.ts
@@ -49,14 +49,14 @@ export function useFindNextTrace({
         },
       },
       search: MutableSearch.fromQueryObject({is_transaction: 1}),
-      fields: [SpanFields.TRANSACTION_ID, SpanFields.PROJECT_ID, SpanFields.PROJECT],
+      fields: [SpanFields.TRANSACTION_SPAN_ID, SpanFields.PROJECT_ID, SpanFields.PROJECT],
     },
     'api.trace-view.linked-traces'
   );
 
   const traceData = indexedSpans.map(span => ({
     projectSlug: span.project,
-    eventId: span['transaction.id'],
+    eventId: span['transaction.span_id'],
   }));
 
   const rootEvents = useTraceRootEvents(traceData);

--- a/static/app/views/performance/otlp/serviceEntrySpansTable.tsx
+++ b/static/app/views/performance/otlp/serviceEntrySpansTable.tsx
@@ -25,7 +25,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 import {renderHeadCell} from 'sentry/views/insights/common/components/tableCells/renderHeadCell';
 import {SpanIdCell} from 'sentry/views/insights/common/components/tableCells/spanIdCell';
-import {ModuleName, SpanIndexedField} from 'sentry/views/insights/types';
+import {ModuleName, SpanFields} from 'sentry/views/insights/types';
 import {TraceViewSources} from 'sentry/views/performance/newTraceDetails/traceHeader/breadcrumbs';
 import {
   SERVICE_ENTRY_SPANS_COLUMN_ORDER,
@@ -67,7 +67,7 @@ export function ServiceEntrySpansTable({
 
   const projectSlug = projects.find(p => p.id === `${eventView.project}`)?.slug;
   const cursor = decodeScalar(location.query?.[SERVICE_ENTRY_SPANS_CURSOR]);
-  const spanCategory = decodeScalar(location.query?.[SpanIndexedField.SPAN_CATEGORY]);
+  const spanCategory = decodeScalar(location.query?.[SpanFields.SPAN_CATEGORY]);
   const {selected, options} = getOTelTransactionsListSort(location, spanCategory);
 
   const p95 = totalValues?.['p95()'] ?? 0;

--- a/static/app/views/performance/otlp/useServiceEntrySpansQuery.tsx
+++ b/static/app/views/performance/otlp/useServiceEntrySpansQuery.tsx
@@ -4,7 +4,7 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
-import {type EAPSpanProperty, SpanIndexedField} from 'sentry/views/insights/types';
+import {type EAPSpanProperty, SpanFields} from 'sentry/views/insights/types';
 import {SERVICE_ENTRY_SPANS_CURSOR_NAME} from 'sentry/views/performance/transactionSummary/transactionOverview/content';
 import {TransactionFilterOptions} from 'sentry/views/performance/transactionSummary/utils';
 
@@ -43,9 +43,7 @@ export function useServiceEntrySpansQuery({
   limit = DEFAULT_LIMIT,
 }: Options) {
   const location = useLocation();
-  const spanCategoryUrlParam = decodeScalar(
-    location.query?.[SpanIndexedField.SPAN_CATEGORY]
-  );
+  const spanCategoryUrlParam = decodeScalar(location.query?.[SpanFields.SPAN_CATEGORY]);
   const selectedOption = decodeScalar(location.query?.showTransactions);
 
   const isSingleQueryEnabled =
@@ -163,9 +161,7 @@ function useMultipleQueries(options: UseMultipleQueriesOptions) {
   const cursor = decodeScalar(location.query?.[SERVICE_ENTRY_SPANS_CURSOR_NAME]);
   const selectedOption = decodeScalar(location.query?.showTransactions);
   const {selection} = usePageFilters();
-  const spanCategoryUrlParam = decodeScalar(
-    location.query?.[SpanIndexedField.SPAN_CATEGORY]
-  );
+  const spanCategoryUrlParam = decodeScalar(location.query?.[SpanFields.SPAN_CATEGORY]);
 
   const categorizedSpansQuery = new MutableSearch(
     `transaction:${transactionName} span.category:${spanCategoryUrlParam}`

--- a/static/app/views/performance/transactionSummary/spanCategoryFilter.tsx
+++ b/static/app/views/performance/transactionSummary/spanCategoryFilter.tsx
@@ -15,7 +15,7 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {useCompactSelectOptionsCache} from 'sentry/views/insights/common/utils/useCompactSelectOptionsCache';
-import {SpanIndexedField} from 'sentry/views/insights/types';
+import {SpanFields} from 'sentry/views/insights/types';
 
 type Props = {
   serviceEntrySpanName: string;
@@ -29,9 +29,7 @@ const ALLOWED_CATEGORIES = ['http', 'db', 'browser', 'resource', 'ui'];
 
 export function SpanCategoryFilter({serviceEntrySpanName}: Props) {
   const location = useLocation();
-  const spanCategoryUrlParam = decodeScalar(
-    location.query?.[SpanIndexedField.SPAN_CATEGORY]
-  );
+  const spanCategoryUrlParam = decodeScalar(location.query?.[SpanFields.SPAN_CATEGORY]);
 
   const [selectedCategory, setSelectedCategory] = useState<string | undefined>(
     spanCategoryUrlParam
@@ -47,7 +45,7 @@ export function SpanCategoryFilter({serviceEntrySpanName}: Props) {
   const {data, isError} = useSpans(
     {
       limit: LIMIT,
-      fields: [SpanIndexedField.SPAN_CATEGORY, 'count()'],
+      fields: [SpanFields.SPAN_CATEGORY, 'count()'],
       search: query,
       sorts: [{field: 'count()', kind: 'desc'}],
       pageFilters: selection,
@@ -57,15 +55,15 @@ export function SpanCategoryFilter({serviceEntrySpanName}: Props) {
 
   const {options: categoryOptions} = useCompactSelectOptionsCache(
     data
-      .filter(d => !!d[SpanIndexedField.SPAN_CATEGORY])
-      .filter(d => ALLOWED_CATEGORIES.includes(d[SpanIndexedField.SPAN_CATEGORY]))
+      .filter(d => !!d[SpanFields.SPAN_CATEGORY])
+      .filter(d => ALLOWED_CATEGORIES.includes(d[SpanFields.SPAN_CATEGORY]))
       .map(d => ({
-        value: d[SpanIndexedField.SPAN_CATEGORY],
-        label: d[SpanIndexedField.SPAN_CATEGORY],
-        key: d[SpanIndexedField.SPAN_CATEGORY],
+        value: d[SpanFields.SPAN_CATEGORY],
+        label: d[SpanFields.SPAN_CATEGORY],
+        key: d[SpanFields.SPAN_CATEGORY],
         leadingItems: (
           <OperationDot
-            backgroundColor={pickBarColor(d[SpanIndexedField.SPAN_CATEGORY], theme)}
+            backgroundColor={pickBarColor(d[SpanFields.SPAN_CATEGORY], theme)}
           />
         ),
       }))
@@ -86,7 +84,7 @@ export function SpanCategoryFilter({serviceEntrySpanName}: Props) {
       ...location,
       query: {
         ...location.query,
-        [SpanIndexedField.SPAN_CATEGORY]: selectedOption?.value,
+        [SpanFields.SPAN_CATEGORY]: selectedOption?.value,
       },
     });
   };

--- a/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
@@ -40,7 +40,7 @@ import type {Actions} from 'sentry/views/discover/table/cellAction';
 import {updateQuery} from 'sentry/views/discover/table/cellAction';
 import type {TableColumn} from 'sentry/views/discover/table/types';
 import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
-import {SpanIndexedField} from 'sentry/views/insights/types';
+import {SpanFields} from 'sentry/views/insights/types';
 import {ServiceEntrySpansTable} from 'sentry/views/performance/otlp/serviceEntrySpansTable';
 import Filter, {
   decodeFilterFromLocation,
@@ -107,7 +107,7 @@ function OTelSummaryContentInner({
   const theme = useTheme();
   const navigate = useNavigate();
   const domainViewFilters = useDomainViewFilters();
-  const spanCategory = decodeScalar(location.query?.[SpanIndexedField.SPAN_CATEGORY]);
+  const spanCategory = decodeScalar(location.query?.[SpanFields.SPAN_CATEGORY]);
 
   const handleSearch = useCallback(
     (query: string) => {
@@ -219,7 +219,7 @@ function OTelSummaryContentInner({
   if (spanCategory) {
     eventView = eventView.clone();
     eventView.query =
-      `${eventView.query} ${SpanIndexedField.SPAN_CATEGORY}:${spanCategory}`.trim();
+      `${eventView.query} ${SpanFields.SPAN_CATEGORY}:${spanCategory}`.trim();
     transactionsListEventView = eventView.clone();
   }
 

--- a/static/app/views/performance/transactionSummary/transactionOverview/eapChartsWidget.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/eapChartsWidget.tsx
@@ -7,7 +7,7 @@ import useLocationQuery from 'sentry/utils/url/useLocationQuery';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
-import {SpanIndexedField} from 'sentry/views/insights/types';
+import {SpanFields} from 'sentry/views/insights/types';
 import {useWidgetChartVisualization} from 'sentry/views/performance/transactionSummary/transactionOverview/useWidgetChartVisualization';
 
 export enum EAPWidgetType {
@@ -80,11 +80,11 @@ export function EAPChartsWidget({transactionName, query}: EAPChartsWidgetProps) 
   const navigate = useNavigate();
 
   const {
-    [SpanIndexedField.SPAN_CATEGORY]: spanCategoryUrlParam,
+    [SpanFields.SPAN_CATEGORY]: spanCategoryUrlParam,
     [SELECTED_CHART_QUERY_PARAM]: selectedChartUrlParam,
   } = useLocationQuery({
     fields: {
-      [SpanIndexedField.SPAN_CATEGORY]: decodeScalar,
+      [SpanFields.SPAN_CATEGORY]: decodeScalar,
       [SELECTED_CHART_QUERY_PARAM]: decodeScalar,
     },
   });

--- a/static/app/views/performance/transactionSummary/transactionOverview/useWidgetChartVisualization.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/useWidgetChartVisualization.tsx
@@ -9,7 +9,7 @@ import {Line} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/
 import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {useSpanSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
-import {SpanIndexedField} from 'sentry/views/insights/types';
+import {SpanFields} from 'sentry/views/insights/types';
 import {
   filterToColor,
   type SpanOperationBreakdownFilter,
@@ -74,9 +74,7 @@ function useDurationBreakdownVisualization({
   query,
 }: DurationBreakdownVisualizationOptions) {
   const location = useLocation();
-  const spanCategoryUrlParam = decodeScalar(
-    location.query?.[SpanIndexedField.SPAN_CATEGORY]
-  );
+  const spanCategoryUrlParam = decodeScalar(location.query?.[SpanFields.SPAN_CATEGORY]);
   const {selection} = usePageFilters();
 
   const {releases: releasesWithDate} = useReleaseStats(selection);
@@ -153,9 +151,7 @@ function useDurationPercentilesVisualization({
   const {selection} = usePageFilters();
   const theme = useTheme();
 
-  const spanCategoryUrlParam = decodeScalar(
-    location.query?.[SpanIndexedField.SPAN_CATEGORY]
-  );
+  const spanCategoryUrlParam = decodeScalar(location.query?.[SpanFields.SPAN_CATEGORY]);
 
   const newQuery = new MutableSearch(query);
   newQuery.addFilterValue('transaction', transactionName);

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanSummary/spanSummaryTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanSummary/spanSummaryTable.tsx
@@ -34,9 +34,9 @@ import {SpanIdCell} from 'sentry/views/insights/common/components/tableCells/spa
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {QueryParameterNames} from 'sentry/views/insights/common/views/queryParameters';
 import {
+  type EAPSpanResponse,
   ModuleName,
-  SpanIndexedField,
-  type SpanIndexedResponse,
+  SpanFields,
   type SpanMetricsQueryFilters,
 } from 'sentry/views/insights/types';
 import {TraceViewSources} from 'sentry/views/performance/newTraceDetails/traceHeader/breadcrumbs';
@@ -46,35 +46,32 @@ import {SpanSummaryReferrer} from 'sentry/views/performance/transactionSummary/t
 import {useSpanSummarySort} from 'sentry/views/performance/transactionSummary/transactionSpans/spanSummary/useSpanSummarySort';
 
 type DataRowKeys =
-  | SpanIndexedField.SPAN_ID
-  | SpanIndexedField.TIMESTAMP
-  | SpanIndexedField.SPAN_DURATION
-  | SpanIndexedField.TRANSACTION_ID
-  | SpanIndexedField.TRACE
-  | SpanIndexedField.PROJECT;
+  | SpanFields.SPAN_ID
+  | SpanFields.TIMESTAMP
+  | SpanFields.SPAN_DURATION
+  | SpanFields.TRANSACTION_ID
+  | SpanFields.TRACE
+  | SpanFields.PROJECT;
 
-type ColumnKeys =
-  | SpanIndexedField.SPAN_ID
-  | SpanIndexedField.TIMESTAMP
-  | SpanIndexedField.SPAN_DURATION;
+type ColumnKeys = SpanFields.SPAN_ID | SpanFields.TIMESTAMP | SpanFields.SPAN_DURATION;
 
-type DataRow = Pick<SpanIndexedResponse, DataRowKeys> & {'transaction.duration': number};
+type DataRow = Pick<EAPSpanResponse, DataRowKeys> & {'transaction.duration': number};
 
 type Column = GridColumnHeader<ColumnKeys>;
 
 const COLUMN_ORDER: Column[] = [
   {
-    key: SpanIndexedField.SPAN_ID,
+    key: SpanFields.SPAN_ID,
     name: t('Span ID'),
     width: COL_WIDTH_UNDEFINED,
   },
   {
-    key: SpanIndexedField.TIMESTAMP,
+    key: SpanFields.TIMESTAMP,
     name: t('Timestamp'),
     width: COL_WIDTH_UNDEFINED,
   },
   {
-    key: SpanIndexedField.SPAN_DURATION,
+    key: SpanFields.SPAN_DURATION,
     name: t('Span Duration'),
     width: COL_WIDTH_UNDEFINED,
   },
@@ -125,12 +122,12 @@ export default function SpanSummaryTable(props: Props) {
   } = useSpans(
     {
       fields: [
-        SpanIndexedField.SPAN_ID,
-        SpanIndexedField.TRANSACTION_ID,
-        SpanIndexedField.TIMESTAMP,
-        SpanIndexedField.SPAN_DURATION,
-        SpanIndexedField.TRACE,
-        SpanIndexedField.PROJECT,
+        SpanFields.SPAN_ID,
+        SpanFields.TRANSACTION_ID,
+        SpanFields.TIMESTAMP,
+        SpanFields.SPAN_DURATION,
+        SpanFields.TRACE,
+        SpanFields.PROJECT,
       ],
       search,
       limit: LIMIT,
@@ -140,7 +137,7 @@ export default function SpanSummaryTable(props: Props) {
     SpanSummaryReferrer.SPAN_SUMMARY_TABLE
   );
 
-  const transactionIds = rowData?.map(row => row[SpanIndexedField.TRANSACTION_ID]);
+  const transactionIds = rowData?.map(row => row[SpanFields.TRANSACTION_ID]);
 
   const eventView = EventView.fromNewQueryWithLocation(
     {
@@ -189,8 +186,8 @@ export default function SpanSummaryTable(props: Props) {
   });
 
   const mergedData: DataRow[] =
-    rowData?.map((row: Pick<SpanIndexedResponse, DataRowKeys>) => {
-      const transactionId = row[SpanIndexedField.TRANSACTION_ID];
+    rowData?.map((row: Pick<EAPSpanResponse, DataRowKeys>) => {
+      const transactionId = row[SpanFields.TRANSACTION_ID];
       const newRow = {
         ...row,
         'transaction.duration': transactionDurationMap[transactionId]!,
@@ -277,11 +274,11 @@ function renderBodyCell(
 ) {
   return function (column: Column, dataRow: DataRow): React.ReactNode {
     const {timestamp, span_id, trace} = dataRow;
-    const spanDuration = dataRow[SpanIndexedField.SPAN_DURATION];
-    const transactionId = dataRow[SpanIndexedField.TRANSACTION_ID];
+    const spanDuration = dataRow[SpanFields.SPAN_DURATION];
+    const transactionId = dataRow[SpanFields.TRANSACTION_ID];
     const transactionDuration = dataRow['transaction.duration'];
 
-    if (column.key === SpanIndexedField.SPAN_DURATION) {
+    if (column.key === SpanFields.SPAN_DURATION) {
       if (isTxnDurationDataLoading) {
         return <EmptySpanDurationBar />;
       }
@@ -308,7 +305,7 @@ function renderBodyCell(
       );
     }
 
-    if (column.key === SpanIndexedField.SPAN_ID) {
+    if (column.key === SpanFields.SPAN_ID) {
       if (!defined(span_id)) {
         return null;
       }

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanSummary/spanSummaryTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanSummary/spanSummaryTable.tsx
@@ -49,7 +49,7 @@ type DataRowKeys =
   | SpanFields.SPAN_ID
   | SpanFields.TIMESTAMP
   | SpanFields.SPAN_DURATION
-  | SpanFields.TRANSACTION_ID
+  | SpanFields.TRANSACTION_SPAN_ID
   | SpanFields.TRACE
   | SpanFields.PROJECT;
 
@@ -123,7 +123,7 @@ export default function SpanSummaryTable(props: Props) {
     {
       fields: [
         SpanFields.SPAN_ID,
-        SpanFields.TRANSACTION_ID,
+        SpanFields.TRANSACTION_SPAN_ID,
         SpanFields.TIMESTAMP,
         SpanFields.SPAN_DURATION,
         SpanFields.TRACE,
@@ -137,7 +137,7 @@ export default function SpanSummaryTable(props: Props) {
     SpanSummaryReferrer.SPAN_SUMMARY_TABLE
   );
 
-  const transactionIds = rowData?.map(row => row[SpanFields.TRANSACTION_ID]);
+  const transactionIds = rowData?.map(row => row[SpanFields.TRANSACTION_SPAN_ID]);
 
   const eventView = EventView.fromNewQueryWithLocation(
     {
@@ -187,7 +187,7 @@ export default function SpanSummaryTable(props: Props) {
 
   const mergedData: DataRow[] =
     rowData?.map((row: Pick<EAPSpanResponse, DataRowKeys>) => {
-      const transactionId = row[SpanFields.TRANSACTION_ID];
+      const transactionId = row[SpanFields.TRANSACTION_SPAN_ID];
       const newRow = {
         ...row,
         'transaction.duration': transactionDurationMap[transactionId]!,
@@ -275,7 +275,7 @@ function renderBodyCell(
   return function (column: Column, dataRow: DataRow): React.ReactNode {
     const {timestamp, span_id, trace} = dataRow;
     const spanDuration = dataRow[SpanFields.SPAN_DURATION];
-    const transactionId = dataRow[SpanFields.TRANSACTION_ID];
+    const transactionId = dataRow[SpanFields.TRANSACTION_SPAN_ID];
     const transactionDuration = dataRow['transaction.duration'];
 
     if (column.key === SpanFields.SPAN_DURATION) {

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanSummary/useSpanSummarySort.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanSummary/useSpanSummarySort.tsx
@@ -2,16 +2,13 @@ import type {Sort} from 'sentry/utils/discover/fields';
 import {decodeSorts} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import type {QueryParameterNames} from 'sentry/views/insights/common/views/queryParameters';
-import {SpanIndexedField} from 'sentry/views/insights/types';
+import {SpanFields} from 'sentry/views/insights/types';
 
 type Query = {
   sort?: string;
 };
 
-const SORTABLE_FIELDS = [
-  SpanIndexedField.TIMESTAMP,
-  SpanIndexedField.SPAN_DURATION,
-] as const;
+const SORTABLE_FIELDS = [SpanFields.TIMESTAMP, SpanFields.SPAN_DURATION] as const;
 
 type ValidSort = Sort & {
   field: (typeof SORTABLE_FIELDS)[number];

--- a/static/app/views/performance/utils/useSpanFieldSupportedTags.tsx
+++ b/static/app/views/performance/utils/useSpanFieldSupportedTags.tsx
@@ -7,10 +7,10 @@ import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {type ApiQueryKey, useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import {SpanIndexedField, SpanMetricsField} from 'sentry/views/insights/types';
+import {SpanFields, SpanMetricsField} from 'sentry/views/insights/types';
 
 const DATASET_TO_FIELDS = {
-  [DiscoverDatasets.SPANS_INDEXED]: SpanIndexedField,
+  [DiscoverDatasets.SPANS_INDEXED]: SpanFields,
   [DiscoverDatasets.SPANS_METRICS]: SpanMetricsField,
 };
 
@@ -97,9 +97,9 @@ function useSpanFieldStaticTags(options?: {
   // we do not yet support span field search by SPAN_AI_PIPELINE_GROUP and SPAN_CATEGORY should not be surfaced to users
   const staticTags: TagCollection = useSpanFieldBaseTags(
     [
-      SpanIndexedField.SPAN_AI_PIPELINE_GROUP,
-      SpanIndexedField.SPAN_CATEGORY,
-      SpanIndexedField.SPAN_GROUP,
+      SpanFields.SPAN_AI_PIPELINE_GROUP,
+      SpanFields.SPAN_CATEGORY,
+      SpanFields.SPAN_GROUP,
       ...excludedTags,
     ],
     dataset

--- a/static/app/views/traces/fieldRenderers.tsx
+++ b/static/app/views/traces/fieldRenderers.tsx
@@ -24,7 +24,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
-import type {SpanIndexedField, SpanIndexedResponse} from 'sentry/views/insights/types';
+import type {EAPSpanResponse, SpanFields} from 'sentry/views/insights/types';
 import {TraceViewSources} from 'sentry/views/performance/newTraceDetails/traceHeader/breadcrumbs';
 import {getTraceDetailsUrl} from 'sentry/views/performance/traceDetails/utils';
 import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
@@ -468,7 +468,7 @@ export function SpanTimeRenderer({
   );
 }
 
-type SpanStatus = SpanIndexedResponse[SpanIndexedField.SPAN_STATUS];
+type SpanStatus = EAPSpanResponse[SpanFields.SPAN_STATUS];
 
 const STATUS_TO_TAG_TYPE: Record<SpanStatus, keyof Theme['tag']> = {
   ok: 'success',
@@ -491,7 +491,6 @@ const STATUS_TO_TAG_TYPE: Record<SpanStatus, keyof Theme['tag']> = {
 };
 
 function statusToTagType(status: string) {
-  // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
   return STATUS_TO_TAG_TYPE[status];
 }
 

--- a/static/app/views/traces/fieldRenderers.tsx
+++ b/static/app/views/traces/fieldRenderers.tsx
@@ -491,6 +491,7 @@ const STATUS_TO_TAG_TYPE: Record<SpanStatus, keyof Theme['tag']> = {
 };
 
 function statusToTagType(status: string) {
+  // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
   return STATUS_TO_TAG_TYPE[status];
 }
 


### PR DESCRIPTION
The `spanIndexed` dataset is no more, this PR
1.  replaces all uses of `spanIndexedFields` with `spanFields`
2. Removes `SpanIndexedField`, `SpanIndexedQueryFilters`, etc