### PR TITLE
:wrench: chore(cursor): add cursor rule to use pytest instead of unittest

### DIFF
--- a/.cursor/rules/python_tests.mdc
+++ b/.cursor/rules/python_tests.mdc
@@ -6,7 +6,6 @@ alwaysApply: false
 
 # Python tests
 
-
 ## Use factories instead of directly calling `Model.objects.create`
 
 In Sentry Python tests, prefer using factory methods from `sentry.testutils.factories.Factories` @factories.py or fixture methods (e.g., `self.create_model`) provided by base classes like `sentry.testutils.fixtures.Fixtures` @fixtures.py  instead of directly calling `Model.objects.create`. This promotes consistency, reduces boilerplate, and leverages shared test setup logic defined in the factories.
@@ -24,4 +23,16 @@ For example, a diff that uses a fixture instead of the directly calling `Model.o
     +            name="Directly Created",
     +            slug="directly-created" # Note: Ensure factory args match
     +        )
+```
+
+## Use `pytest` instead of `unittest`
+
+In Sentry Python tests, prefer using `pytest` instead of `unittest`. This promotes consistency, reduces boilerplate, and leverages shared test setup logic defined in the factories.
+
+For example, a diff that uses `pytest` instead of `unittest` would look like:
+
+```diff
+    -        self.assertRaises(ValueError, EffectiveGrantStatus.from_cache, None)
+    +        with pytest.raises(ValueError):
+    +            EffectiveGrantStatus.from_cache(None)
 ```


### PR DESCRIPTION
common mistake cursor makes when writing tests is use the `unittest` library for assertions instead of `pytest`. This causes precommit errors, so lets try to encourage cursor to use it from the onset.