### PR TITLE
feat(tasks): Add flag to @retry to auto-retry timed out tasks

### DIFF
--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -65,7 +65,6 @@ from sentry.workflow_engine.processors.workflow import (
 )
 from sentry.workflow_engine.processors.workflow_fire_history import create_workflow_fire_histories
 from sentry.workflow_engine.tasks.actions import build_trigger_action_task_params, trigger_action
-from sentry.workflow_engine.tasks.utils import retry_timeouts
 from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
 from sentry.workflow_engine.utils import log_context
 
@@ -833,8 +832,7 @@ def _summarize_by_first[T1, T2: int | str](
         ),
     ),
 )
-@retry
-@retry_timeouts
+@retry(timeouts=True)
 @log_context.root()
 def process_delayed_workflows(
     project_id: int, batch_key: str | None = None, *args: Any, **kwargs: Any

--- a/tests/sentry/tasks/test_base.py
+++ b/tests/sentry/tasks/test_base.py
@@ -206,7 +206,7 @@ class ExpectedException(Exception):
 
 @patch("sentry.taskworker.retry.current_task")
 @patch("sentry_sdk.capture_exception")
-def test_retry_timeout_enabled_taskbroker(capture_exception, current_task):
+def test_retry_timeout_enabled_taskbroker(capture_exception, current_task) -> None:
     current_task.retry.side_effect = ExpectedException("retry called")
 
     @retry(timeouts=True)
@@ -222,7 +222,7 @@ def test_retry_timeout_enabled_taskbroker(capture_exception, current_task):
 
 @patch("sentry.taskworker.retry.current_task")
 @patch("sentry_sdk.capture_exception")
-def test_retry_timeout_disabled_taskbroker(capture_exception, current_task):
+def test_retry_timeout_disabled_taskbroker(capture_exception, current_task) -> None:
 
     @retry(timeouts=False)
     def timeout_no_retry_task():
@@ -237,7 +237,7 @@ def test_retry_timeout_disabled_taskbroker(capture_exception, current_task):
 
 @patch("sentry.taskworker.retry.current_task")
 @patch("sentry_sdk.capture_exception")
-def test_retry_soft_timeout_enabled(capture_exception, current_task):
+def test_retry_soft_timeout_enabled(capture_exception, current_task) -> None:
     current_task.retry.side_effect = ExpectedException("retry called")
 
     @retry(timeouts=True)
@@ -253,7 +253,7 @@ def test_retry_soft_timeout_enabled(capture_exception, current_task):
 
 @patch("sentry.taskworker.retry.current_task")
 @patch("sentry_sdk.capture_exception")
-def test_retry_soft_timeout_disabled(capture_exception, current_task):
+def test_retry_soft_timeout_disabled(capture_exception, current_task) -> None:
     current_task.retry.side_effect = ExpectedException("retry called")
 
     @retry(on=(ValueError,), timeouts=False)
@@ -269,7 +269,7 @@ def test_retry_soft_timeout_disabled(capture_exception, current_task):
 
 @patch("sentry.taskworker.retry.current_task")
 @patch("sentry_sdk.capture_exception")
-def test_retry_soft_timeouts_by_default(capture_exception, current_task):
+def test_retry_soft_timeouts_by_default(capture_exception, current_task) -> None:
     current_task.retry.side_effect = ExpectedException("retry called")
 
     @retry


### PR DESCRIPTION
Rather than requiring another decorator for what is behavior we'll need in a few places, support it in `@retry`.
