### PR TITLE
fix(replay): Fix tooltip when replay bulk-delete is disabled

### DIFF
--- a/static/app/utils/replays/hooks/useDeleteReplays.tsx
+++ b/static/app/utils/replays/hooks/useDeleteReplays.tsx
@@ -29,14 +29,14 @@ export default function useDeleteReplays({projectSlug}: Props) {
   const hasWriteAccess = hasEveryAccess(['project:write'], {organization, project});
   const hasAdminAccess = hasEveryAccess(['project:admin'], {organization, project});
 
-  const canDelete = Boolean(projectSlug) && (hasWriteAccess || hasAdminAccess);
+  const hasAccess = Boolean(projectSlug) && (hasWriteAccess || hasAdminAccess);
 
   const {mutate} = useMutation({
     mutationFn: ([data]: Vars) => {
       if (!projectSlug) {
         throw new Error('Project ID or slug is required');
       }
-      if (!canDelete) {
+      if (!hasAccess) {
         throw new Error('User does not have permission to delete replays');
       }
 
@@ -72,7 +72,7 @@ export default function useDeleteReplays({projectSlug}: Props) {
 
   return {
     bulkDelete: mutate,
-    canDelete,
+    hasAccess,
     queryOptionsToPayload,
   };
 }


### PR DESCRIPTION
If you have two projects selected you get that message first:
<img width="318" height="201" alt="SCR-20250716-jczl" src="https://github.com/user-attachments/assets/03ede8f3-91b2-4990-9477-c0f646b91feb" />

Then we show the permissions message, depending on the project you picked:
<img width="243" height="137" alt="SCR-20250716-jaxu" src="https://github.com/user-attachments/assets/462a69a0-bc36-4d15-a0c1-d661a95e86c6" />

If permissions are set, then you can delete stuff:
<img width="268" height="172" alt="SCR-20250716-jcyc" src="https://github.com/user-attachments/assets/8d6c4968-93c6-4ec2-961a-7d20b7c7325d" />
