### PR TITLE
feat(discover): Open in discover from issues page doesn't apply sort

### DIFF
--- a/static/app/views/issueDetails/streamline/eventNavigation.spec.tsx
+++ b/static/app/views/issueDetails/streamline/eventNavigation.spec.tsx
@@ -92,6 +92,53 @@ describe('EventNavigation', () => {
         expect.stringContaining(`/organizations/${organization.slug}/issues/${group.id}/`)
       );
     });
+
+    it('supplies the default timestamp sort when no sort is set in the query params', () => {
+      const allEventsRouter = RouterFixture({
+        params: {groupId: group.id},
+        routes: [{path: TabPaths[Tab.EVENTS]}],
+        location: LocationFixture({
+          pathname: `/organizations/${organization.slug}/issues/${group.id}/events/`,
+        }),
+      });
+
+      render(<IssueEventNavigation {...defaultProps} />, {
+        router: allEventsRouter,
+        deprecatedRouterMocks: true,
+      });
+
+      const discoverButton = screen.getByLabelText('Open in Discover');
+      expect(discoverButton).toBeInTheDocument();
+      const url = new URL(
+        discoverButton.getAttribute('href') ?? '',
+        'https://www.example.com'
+      );
+      expect(url.searchParams.get('sort')).toBe('-timestamp');
+    });
+
+    it('supplies the sort when it is set in the query params', () => {
+      const allEventsRouter = RouterFixture({
+        params: {groupId: group.id},
+        routes: [{path: TabPaths[Tab.EVENTS]}],
+        location: LocationFixture({
+          pathname: `/organizations/${organization.slug}/issues/${group.id}/events/`,
+          query: {sort: '-title'},
+        }),
+      });
+
+      render(<IssueEventNavigation {...defaultProps} />, {
+        router: allEventsRouter,
+        deprecatedRouterMocks: true,
+      });
+
+      const discoverButton = screen.getByLabelText('Open in Discover');
+      expect(discoverButton).toBeInTheDocument();
+      const url = new URL(
+        discoverButton.getAttribute('href') ?? '',
+        'https://www.example.com'
+      );
+      expect(url.searchParams.get('sort')).toBe('-title');
+    });
   });
 
   describe('counts', () => {

--- a/static/app/views/issueDetails/streamline/eventNavigation.tsx
+++ b/static/app/views/issueDetails/streamline/eventNavigation.tsx
@@ -271,7 +271,13 @@ export function IssueEventNavigation({event, group}: IssueEventNavigationProps) 
             <ButtonBar>
               {issueTypeConfig.discover.enabled && currentTab === Tab.EVENTS && (
                 <LinkButton
-                  to={discoverUrl}
+                  to={{
+                    pathname: discoverUrl.pathname,
+                    query: {
+                      ...discoverUrl.query,
+                      sort: location.query.sort ?? '-timestamp',
+                    },
+                  }}
                   aria-label={t('Open in Discover')}
                   size="xs"
                   icon={<IconTelescope />}

--- a/static/app/views/issueDetails/streamline/hooks/useIssueDetailsDiscoverQuery.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/useIssueDetailsDiscoverQuery.tsx
@@ -70,7 +70,6 @@ export function useIssueDetailsEventView({
     yAxis: ['count()', 'count_unique(user)'],
     fields: ['title', 'release', 'environment', 'user.display', 'timestamp'],
     name: group.title || group.type,
-    orderby: location.query.sort ?? '-timestamp',
     ...queryProps,
     query,
   };

--- a/static/app/views/issueDetails/streamline/hooks/useIssueDetailsDiscoverQuery.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/useIssueDetailsDiscoverQuery.tsx
@@ -70,6 +70,7 @@ export function useIssueDetailsEventView({
     yAxis: ['count()', 'count_unique(user)'],
     fields: ['title', 'release', 'environment', 'user.display', 'timestamp'],
     name: group.title || group.type,
+    orderby: location.query.sort ?? '-timestamp',
     ...queryProps,
     query,
   };


### PR DESCRIPTION
When on an issue and the user clicks "View More Events", they're presented with an "Open in Discover" button. That button currently doesn't persist the sort param, so I've added it in this PR.

If there is a query param that overrides the default sort, use that. Otherwise, use `-timestamp` which is what the default sort is for the issue events.