### PR TITLE
chore(sentry apps): Ignore RestircedIPAddress error

### DIFF
--- a/src/sentry/sentry_apps/metrics.py
+++ b/src/sentry/sentry_apps/metrics.py
@@ -68,6 +68,7 @@ class SentryAppWebhookHaltReason(StrEnum):
     GOT_CLIENT_ERROR = "got_client_error"
     INTEGRATOR_ERROR = "integrator_error"
     MISSING_INSTALLATION = "missing_installation"
+    RESTRICED_IP = "restricted_ip"
 
 
 class SentryAppExternalRequestFailureReason(StrEnum):

--- a/src/sentry/sentry_apps/metrics.py
+++ b/src/sentry/sentry_apps/metrics.py
@@ -68,7 +68,7 @@ class SentryAppWebhookHaltReason(StrEnum):
     GOT_CLIENT_ERROR = "got_client_error"
     INTEGRATOR_ERROR = "integrator_error"
     MISSING_INSTALLATION = "missing_installation"
-    RESTRICED_IP = "restricted_ip"
+    RESTRICTED_IP = "restricted_ip"
 
 
 class SentryAppExternalRequestFailureReason(StrEnum):

--- a/src/sentry/sentry_apps/tasks/sentry_apps.py
+++ b/src/sentry/sentry_apps/tasks/sentry_apps.py
@@ -15,6 +15,7 @@ from sentry.api.serializers.models.group import BaseGroupSerializerResponse
 from sentry.constants import SentryAppInstallationStatus
 from sentry.db.models.base import Model
 from sentry.eventstore.models import BaseEvent, Event, GroupEvent
+from sentry.exceptions import RestrictedIPAddress
 from sentry.hybridcloud.rpc.caching import region_caching_service
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.models.activity import Activity
@@ -48,7 +49,7 @@ from sentry.tasks.base import instrumented_task, retry
 from sentry.taskworker.config import TaskworkerConfig
 from sentry.taskworker.constants import CompressionType
 from sentry.taskworker.namespaces import sentryapp_control_tasks, sentryapp_tasks
-from sentry.taskworker.retry import Retry, retry_task
+from sentry.taskworker.retry import NoRetriesRemainingError, Retry, retry_task
 from sentry.types.rules import RuleFuture
 from sentry.users.services.user.model import RpcUser
 from sentry.users.services.user.service import user_service
@@ -78,7 +79,14 @@ CONTROL_TASK_OPTIONS = {
 
 retry_decorator = retry(
     on=(RequestException, ApiHostError, ApiTimeoutError),
-    ignore=(ClientError, SentryAppSentryError, AssertionError, ValueError),
+    ignore=(
+        ClientError,
+        SentryAppSentryError,
+        AssertionError,
+        ValueError,
+        RestrictedIPAddress,
+        NoRetriesRemainingError,
+    ),
     ignore_and_capture=(),
 )
 

--- a/src/sentry/utils/sentry_apps/webhooks.py
+++ b/src/sentry/utils/sentry_apps/webhooks.py
@@ -9,6 +9,7 @@ from requests.exceptions import ConnectionError, Timeout
 from rest_framework import status
 
 from sentry import options
+from sentry.exceptions import RestrictedIPAddress
 from sentry.http import safe_urlopen
 from sentry.sentry_apps.metrics import (
     SentryAppEventType,
@@ -119,6 +120,11 @@ def send_and_save_webhook_request(
             )
             lifecycle.record_halt(e)
             # Re-raise the exception because some of these tasks might retry on the exception
+            raise
+        except RestrictedIPAddress:
+            lifecycle.record_halt(
+                halt_reason=f"send_and_save_webhook_request.{SentryAppWebhookHaltReason.RESTRICED_IP}"
+            )
             raise
 
         track_response_code(response.status_code, slug, event)

--- a/src/sentry/utils/sentry_apps/webhooks.py
+++ b/src/sentry/utils/sentry_apps/webhooks.py
@@ -123,7 +123,7 @@ def send_and_save_webhook_request(
             raise
         except RestrictedIPAddress:
             lifecycle.record_halt(
-                halt_reason=f"send_and_save_webhook_request.{SentryAppWebhookHaltReason.RESTRICED_IP}"
+                halt_reason=f"send_and_save_webhook_request.{SentryAppWebhookHaltReason.RESTRICTED_IP}"
             )
             raise
 


### PR DESCRIPTION
Ignore[ `RestrictedIPAddress`](https://sentry.sentry.io/issues/6712113522/?query=is%3Aunresolved%20timesSeen%3A%3E10k%20assigned_or_suggested%3Amy_teams&referrer=issue-stream&sort=date&stream_index=1) & [`NoRetriesRemainingError`](https://sentry.sentry.io/issues/6713284206/?project=1&query=is%3Aunresolved%20timesSeen%3A%3E10k%20assigned_or_suggested%3Amy_teams&referrer=issue-stream&sort=date&stream_index=2) for sentry apps tasks. 

`RestrictedIPAddress` isn't something we can control or fix so ignore it.

For `NoRetriesRemainingError`, I'm unsure if adding it to the retry decorator will fix things since it seems to be raised at the taskworker framework level but worth a shot (?)

closes ECO-842
closes ECO-843
