### PR TITLE
ref(issues): remove related issues flag from defaults

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -319,8 +319,6 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:project-templates", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enable the new Related Events feature
     manager.add("organizations:related-events", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
-    # Enable related issues feature
-    manager.add("organizations:related-issues", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, default=True, api_expose=True)
     # Enable the release details performance section
     manager.add("organizations:release-comparison-performance", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable replay AI summaries

--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -91,7 +91,6 @@ class OrganizationSerializerTest(TestCase):
             "new-page-filter",
             "open-membership",
             "performance-tracing-without-performance",
-            "related-issues",
             "relay",
             "session-replay-ui",
             "shared-issues",


### PR DESCRIPTION
Fully deprecates `organizations:related-issues` after:
- https://github.com/getsentry/sentry/pull/95600
- https://github.com/getsentry/sentry/pull/95607
- https://github.com/getsentry/sentry-options-automator/pull/4490