### PR TITLE
chore(grouping): Remove unused `grouping_enhancements_base` project option

### DIFF
--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -940,7 +940,6 @@ class DetailedProjectResponse(ProjectWithTeamResponseDict):
     groupingConfig: str
     derivedGroupingEnhancements: str
     groupingEnhancements: str
-    groupingEnhancementsBase: str | None
     secondaryGroupingExpiry: int
     secondaryGroupingConfig: str | None
     fingerprintingRules: str
@@ -1066,9 +1065,6 @@ class DetailedProjectSerializer(ProjectWithTeamSerializer):
             "groupingConfig": self.get_value_with_default(attrs, "sentry:grouping_config"),
             "groupingEnhancements": self.get_value_with_default(
                 attrs, "sentry:grouping_enhancements"
-            ),
-            "groupingEnhancementsBase": self.get_value_with_default(
-                attrs, "sentry:grouping_enhancements_base"
             ),
             "derivedGroupingEnhancements": self.get_value_with_default(
                 attrs, "sentry:derived_grouping_enhancements"

--- a/src/sentry/apidocs/examples/project_examples.py
+++ b/src/sentry/apidocs/examples/project_examples.py
@@ -170,7 +170,6 @@ DETAILED_PROJECT = {
     "scrapeJavaScript": True,
     "groupingConfig": "newstyle:2012-12-31",
     "groupingEnhancements": "",
-    "groupingEnhancementsBase": None,
     "derivedGroupingEnhancements": "",
     "secondaryGroupingExpiry": 1687010243,
     "secondaryGroupingConfig": "newstyle:2012-11-21",

--- a/src/sentry/models/options/project_option.py
+++ b/src/sentry/models/options/project_option.py
@@ -50,7 +50,6 @@ OPTION_KEYS = frozenset(
         "sentry:scrub_ip_address",
         "sentry:grouping_config",
         "sentry:grouping_enhancements",
-        "sentry:grouping_enhancements_base",
         "sentry:derived_grouping_enhancements",
         "sentry:secondary_grouping_config",
         "sentry:secondary_grouping_expiry",


### PR DESCRIPTION
We stopped using the `sentry:grouping_enhancements_base` project option [4 years ago](https://github.com/getsentry/sentry/pull/24854). The script added in https://github.com/getsentry/getsentry/pull/17932 (which has now been run) removed all references to it in our database. We can therefore now remove it from the codebase entirely.