### PR TITLE
perf(aci): Generate GroupEvents with a shared Project to avoid N+1 querying

### DIFF
--- a/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
@@ -837,12 +837,14 @@ class TestFireActionsForGroups(TestDelayedWorkflowBase):
             self.group2: self.event2.for_group(self.group2),
         }
 
-    def test_bulk_fetch_events(self):
+    def test_bulk_fetch_events(self) -> None:
         event_ids = [self.event1.event_id, self.event2.event_id]
-        events = bulk_fetch_events(event_ids, self.project.id)
+        events = bulk_fetch_events(event_ids, self.project)
 
         for event in list(events.values()):
             assert event.event_id in event_ids
+            # For perf reasons, we want to be sure the events have the project cached.
+            assert event._project_cache == self.project
 
     def test_get_group_to_groupevent(self):
         self._push_base_events()
@@ -851,7 +853,7 @@ class TestFireActionsForGroups(TestDelayedWorkflowBase):
         group_to_groupevent = get_group_to_groupevent(
             event_data,
             self.groups_to_dcgs,
-            self.project.id,
+            self.project,
         )
         assert group_to_groupevent == self.group_to_groupevent
 


### PR DESCRIPTION
In some cases, this has the potential to save us 10s of seconds and hundreds of queries.

By default, Event instances get a project ID, and use it to fetch and cache a Project as needed.
It's common for Condition code to do `event.project.environment` which results in two queries, and the results of both are cached, but that's of no use for the next of potentially hundreds of Events we process.
By seeding our Events with a shared Project, we avoid the need to fetch it later, and we get caching of any other fields derived from it across our groups.

Fixes #95681.