### PR TITLE
feat(seer): Seer webhooks

### DIFF
--- a/src/sentry/api/endpoints/seer_rpc.py
+++ b/src/sentry/api/endpoints/seer_rpc.py
@@ -43,14 +43,9 @@ from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.api.endpoints.organization_trace_item_attributes import as_attribute_key
 from sentry.constants import ENABLE_PR_REVIEW_TEST_GENERATION_DEFAULT, ObjectStatus
 from sentry.exceptions import InvalidSearchQuery
-from sentry.hybridcloud.rpc.service import (
-    RpcAuthenticationSetupException,
-    RpcResolutionException,
-)
+from sentry.hybridcloud.rpc.service import RpcAuthenticationSetupException, RpcResolutionException
 from sentry.hybridcloud.rpc.sig import SerializableFunctionValueException
-from sentry.integrations.github_enterprise.integration import (
-    GitHubEnterpriseIntegration,
-)
+from sentry.integrations.github_enterprise.integration import GitHubEnterpriseIntegration
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.group import Group

--- a/src/sentry/api/endpoints/seer_rpc.py
+++ b/src/sentry/api/endpoints/seer_rpc.py
@@ -43,14 +43,9 @@ from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.api.endpoints.organization_trace_item_attributes import as_attribute_key
 from sentry.constants import ENABLE_PR_REVIEW_TEST_GENERATION_DEFAULT, ObjectStatus
 from sentry.exceptions import InvalidSearchQuery
-from sentry.hybridcloud.rpc.service import (
-    RpcAuthenticationSetupException,
-    RpcResolutionException,
-)
+from sentry.hybridcloud.rpc.service import RpcAuthenticationSetupException, RpcResolutionException
 from sentry.hybridcloud.rpc.sig import SerializableFunctionValueException
-from sentry.integrations.github_enterprise.integration import (
-    GitHubEnterpriseIntegration,
-)
+from sentry.integrations.github_enterprise.integration import GitHubEnterpriseIntegration
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.group import Group
@@ -550,6 +545,7 @@ def get_github_enterprise_integration_config(
         "verify_ssl": installation.model.metadata["installation"]["verify_ssl"],
         "encrypted_access_token": encrypted_access_token,
     }
+
 
 def send_seer_issue_ready_to_fix_webhook(*, group_id: int, user_id: int | None = None) -> dict:
     """

--- a/src/sentry/sentry_apps/metrics.py
+++ b/src/sentry/sentry_apps/metrics.py
@@ -135,4 +135,10 @@ class SentryAppEventType(StrEnum):
     INSTALLATION_CREATE = "install_create"
 
     # seer webhooks
-    SEER_ISSUE_READY_TO_FIX = "seer.issue.ready_to_fix"
+    SEER_ROOT_CAUSE_STARTED = "seer.root_cause_started"
+    SEER_ROOT_CAUSE_COMPLETED = "seer.root_cause_completed"
+    SEER_SOLUTION_STARTED = "seer.solution_started"
+    SEER_SOLUTION_COMPLETED = "seer.solution_completed"
+    SEER_CODING_STARTED = "seer.coding_started"
+    SEER_CODING_COMPLETED = "seer.coding_completed"
+    SEER_PR_CREATED = "seer.pr_created"

--- a/src/sentry/sentry_apps/metrics.py
+++ b/src/sentry/sentry_apps/metrics.py
@@ -133,3 +133,6 @@ class SentryAppEventType(StrEnum):
     REQUESTS = "requests"
     WEBHOOK_UPDATE = "webhook_update"
     INSTALLATION_CREATE = "install_create"
+
+    # seer webhooks
+    SEER_ISSUE_READY_TO_FIX = "seer.issue.ready_to_fix"

--- a/src/sentry/sentry_apps/models/sentry_app.py
+++ b/src/sentry/sentry_apps/models/sentry_app.py
@@ -47,6 +47,7 @@ EVENT_EXPANSION = {
     ],
     "error": ["error.created"],
     "comment": ["comment.created", "comment.deleted", "comment.updated"],
+    "seer": ["seer.issue.ready_to_fix"],
 }
 
 # We present Webhook Subscriptions per-resource (Issue, Project, etc.), not

--- a/src/sentry/sentry_apps/models/sentry_app.py
+++ b/src/sentry/sentry_apps/models/sentry_app.py
@@ -47,17 +47,26 @@ EVENT_EXPANSION = {
     ],
     "error": ["error.created"],
     "comment": ["comment.created", "comment.deleted", "comment.updated"],
-    "seer": ["seer.issue.ready_to_fix"],
+    "seer": [
+        "seer.root_cause_started",
+        "seer.root_cause_completed",
+        "seer.solution_started",
+        "seer.solution_completed",
+        "seer.coding_started",
+        "seer.coding_completed",
+        "seer.pr_created",
+    ],
 }
 
 # We present Webhook Subscriptions per-resource (Issue, Project, etc.), not
 # per-event-type (issue.created, project.deleted, etc.). These are valid
 # resources a Sentry App may subscribe to.
-VALID_EVENT_RESOURCES = ("issue", "error", "comment")
+VALID_EVENT_RESOURCES = ("issue", "error", "comment", "seer")
 
 REQUIRED_EVENT_PERMISSIONS = {
     "issue": "event:read",
     "error": "event:read",
+    "seer": "event:read",
     "project": "project:read",
     "member": "member:read",
     "organization": "org:read",

--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -544,7 +544,7 @@ export type AppOrProviderOrPlugin =
 /**
  * Webhooks and servicehooks
  */
-export type WebhookEvent = 'issue' | 'error' | 'comment';
+export type WebhookEvent = 'issue' | 'error' | 'comment' | 'seer';
 
 export type ServiceHook = {
   dateCreated: string;

--- a/static/app/views/settings/organizationDeveloperSettings/constants.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/constants.tsx
@@ -1,7 +1,8 @@
-export const EVENT_CHOICES = ['issue', 'error', 'comment'] as const;
+export const EVENT_CHOICES = ['issue', 'error', 'comment', 'seer'] as const;
 
 export const PERMISSIONS_MAP = {
   issue: 'Event',
   error: 'Event',
   comment: 'Event',
+  seer: 'Event',
 } as const;

--- a/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.tsx
@@ -54,7 +54,7 @@ function SubscriptionBox({
     issue: `created, resolved, assigned, archived, unresolved`,
     error: 'created',
     comment: 'created, edited, deleted',
-    seer: 'issue ready to fix (trigger agents)',
+    seer: 'root cause, solution generation, coding, and PR creation events',
   };
 
   return (

--- a/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.tsx
@@ -54,6 +54,7 @@ function SubscriptionBox({
     issue: `created, resolved, assigned, archived, unresolved`,
     error: 'created',
     comment: 'created, edited, deleted',
+    seer: 'issue ready to fix (trigger agents)',
   };
 
   return (


### PR DESCRIPTION
Instead of making a doc I figured getting a fully working implementation in a draft PR makes the intention much more clear. I'll split up and make actual PRs + refine if this implementation looks good.

We want to implement webhooks to allow people to integrate with Seer Autofix. We'll introduce the below webhook event types:
```
SEER_ROOT_CAUSE_STARTED = "seer.root_cause_started"
SEER_ROOT_CAUSE_COMPLETED = "seer.root_cause_completed"
SEER_SOLUTION_STARTED = "seer.solution_started"
SEER_SOLUTION_COMPLETED = "seer.solution_completed"
SEER_CODING_STARTED = "seer.coding_started"
SEER_CODING_COMPLETED = "seer.coding_completed"
SEER_PR_CREATED = "seer.pr_created"
```

The idea is Seer calls Sentry through `seer_rpc.py` and each of these events have 2 main values in the payload: `group_id` and `run_id`. These should be enough to allow the third party integration to call the Autofix get state api and get the full state accordingly.

Example webhook body:
```
{
  "action": "coding_completed",
  "installation": {
    "uuid": "63d13673-b763-43d3-ad98-55102bb8bfff"
  },
  "data": {
    "group_id": 51,
    "run_id": 52
  },
  "actor": {
    "type": "application",
    "id": "sentry",
    "name": "Sentry"
  }
}
```