### PR TITLE
ref(grouping): Clean up and relocate grouping config constants

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3503,6 +3503,10 @@ SENTRY_SYNTHETIC_MONITORING_PROJECT_ID: int | None = None
 # Similarity-v1: uses hardcoded set of event properties for diffing
 SENTRY_SIMILARITY_INDEX_REDIS_CLUSTER = "default"
 
+LEGACY_GROUPING_CONFIG = "legacy:2019-03-12"
+DEFAULT_GROUPING_CONFIG = "newstyle:2023-01-11"
+BETA_GROUPING_CONFIG = ""
+
 # How long the migration phase for grouping lasts
 SENTRY_GROUPING_CONFIG_TRANSITION_DURATION = 30 * 24 * 3600  # 30 days
 

--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, NotRequired, TypedDict
 import sentry_sdk
 
 from sentry import options
+from sentry.conf.server import DEFAULT_GROUPING_CONFIG
 from sentry.db.models.fields.node import NodeData
 from sentry.grouping.component import (
     AppGroupingComponent,
@@ -199,8 +200,6 @@ def _get_default_fingerprinting_bases_for_project(
     project: Project, config_id: str | None = None
 ) -> Sequence[str] | None:
     """Returns the default built-in fingerprinting bases (i.e. sets of rules) for a project."""
-    from sentry.projectoptions.defaults import DEFAULT_GROUPING_CONFIG
-
     config_id = (
         config_id
         # TODO: add fingerprinting config to GroupingConfigLoader and use that here
@@ -215,8 +214,6 @@ def _get_default_fingerprinting_bases_for_project(
 def get_default_grouping_config_dict(config_id: str | None = None) -> GroupingConfig:
     """Returns the default grouping config."""
     if config_id is None:
-        from sentry.projectoptions.defaults import DEFAULT_GROUPING_CONFIG
-
         config_id = DEFAULT_GROUPING_CONFIG
     return {"id": config_id, "enhancements": _get_default_enhancements(config_id)}
 

--- a/src/sentry/grouping/ingest/config.py
+++ b/src/sentry/grouping/ingest/config.py
@@ -9,11 +9,11 @@ from django.conf import settings
 from django.core.cache import cache
 
 from sentry import audit_log, options
+from sentry.conf.server import BETA_GROUPING_CONFIG, DEFAULT_GROUPING_CONFIG
 from sentry.grouping.strategies.configurations import CONFIGURATIONS
 from sentry.locks import locks
 from sentry.models.options.project_option import ProjectOption
 from sentry.models.project import Project
-from sentry.projectoptions.defaults import BETA_GROUPING_CONFIG, DEFAULT_GROUPING_CONFIG
 from sentry.utils import metrics
 from sentry.utils.audit import create_system_audit_entry
 from sentry.utils.locking import UnableToAcquireLock

--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -1,3 +1,4 @@
+from sentry.conf.server import DEFAULT_GROUPING_CONFIG
 from sentry.constants import TARGET_SAMPLE_RATE_DEFAULT
 from sentry.projectoptions import register
 from sentry.seer.seer_utils import AutofixAutomationTuningSettings
@@ -6,9 +7,6 @@ from sentry.seer.seer_utils import AutofixAutomationTuningSettings
 # The epoch of a project will determine what options are valid options for that specific project
 LATEST_EPOCH = 13
 
-LEGACY_GROUPING_CONFIG = "legacy:2019-03-12"
-DEFAULT_GROUPING_CONFIG = "newstyle:2023-01-11"
-BETA_GROUPING_CONFIG = ""
 register(key="sentry:grouping_config", default=DEFAULT_GROUPING_CONFIG)
 register(key="sentry:grouping_enhancements", default="")
 register(key="sentry:derived_grouping_enhancements", default="")

--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -6,34 +6,18 @@ from sentry.seer.seer_utils import AutofixAutomationTuningSettings
 # The epoch of a project will determine what options are valid options for that specific project
 LATEST_EPOCH = 13
 
-# grouping related configs
-#
-# The default values are hardcoded because some grouping configs might
-# only exists temporarily for testing purposes.  If we delete them from
-# the codebase and a customer still has them set in the options we want to
-# fall back to the oldest config.
-#
-# TODO: we might instead want to fall back to the latest of the project's
-# epoch instead.
 LEGACY_GROUPING_CONFIG = "legacy:2019-03-12"
 DEFAULT_GROUPING_CONFIG = "newstyle:2023-01-11"
-# NOTE: this is empty for now to migrate projects off the deprecated
-# `mobile` strategy via grouping auto-updates.
 BETA_GROUPING_CONFIG = ""
-# This registers the option as a valid project option
 register(key="sentry:grouping_config", default=DEFAULT_GROUPING_CONFIG)
-
 register(key="sentry:grouping_enhancements", default="")
 register(key="sentry:derived_grouping_enhancements", default="")
-
-# server side fingerprinting defaults.
 register(key="sentry:fingerprinting_rules", default="")
 
 # Secondary grouping setup to run in addition for transition phase.
 #
-# To ensure we minimize unnecessary load, we ttl the secondary grouping setup
-# to 90 days, as that's when all groups should have hashes associated with
-# them.
+# To ensure we minimize unnecessary load, we TTL the secondary grouping setup
+# to `SENTRY_GROUPING_UPDATE_MIGRATION_PHASE` days
 register(key="sentry:secondary_grouping_expiry", default=0)
 register(key="sentry:secondary_grouping_config", default=None)
 

--- a/tests/sentry/event_manager/grouping/test_assign_to_group.py
+++ b/tests/sentry/event_manager/grouping/test_assign_to_group.py
@@ -7,6 +7,7 @@ from unittest import mock
 
 import pytest
 
+from sentry.conf.server import DEFAULT_GROUPING_CONFIG, LEGACY_GROUPING_CONFIG
 from sentry.event_manager import _create_group
 from sentry.eventstore.models import Event
 from sentry.grouping.ingest.hashing import (
@@ -17,7 +18,6 @@ from sentry.grouping.ingest.hashing import (
 from sentry.grouping.ingest.metrics import record_hash_calculation_metrics
 from sentry.models.grouphash import GroupHash
 from sentry.models.project import Project
-from sentry.projectoptions.defaults import DEFAULT_GROUPING_CONFIG, LEGACY_GROUPING_CONFIG
 from sentry.testutils.helpers.eventprocessing import save_new_event
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.testutils.pytest.mocking import capture_results

--- a/tests/sentry/event_manager/grouping/test_grouphash_metadata.py
+++ b/tests/sentry/event_manager/grouping/test_grouphash_metadata.py
@@ -4,11 +4,11 @@ from time import time
 from typing import Any
 from unittest.mock import ANY, MagicMock, patch
 
+from sentry.conf.server import DEFAULT_GROUPING_CONFIG, LEGACY_GROUPING_CONFIG
 from sentry.eventstore.models import Event
 from sentry.grouping.ingest.grouphash_metadata import create_or_update_grouphash_metadata_if_needed
 from sentry.models.grouphash import GroupHash
 from sentry.models.grouphashmetadata import GROUPHASH_METADATA_SCHEMA_VERSION, HashBasis
-from sentry.projectoptions.defaults import DEFAULT_GROUPING_CONFIG, LEGACY_GROUPING_CONFIG
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.eventprocessing import save_new_event
 from sentry.testutils.helpers.options import override_options

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -21,6 +21,7 @@ from django.utils import timezone
 
 from sentry import eventstore, nodestore, tsdb
 from sentry.attachments import CachedAttachment, attachment_cache
+from sentry.conf.server import DEFAULT_GROUPING_CONFIG
 from sentry.constants import MAX_VERSION_LENGTH, DataCategory, InsightModules
 from sentry.dynamic_sampling import (
     ExtendedBoostedRelease,
@@ -66,7 +67,6 @@ from sentry.models.pullrequest import PullRequest, PullRequestCommit
 from sentry.models.release import Release
 from sentry.models.releasecommit import ReleaseCommit
 from sentry.models.releaseprojectenvironment import ReleaseProjectEnvironment
-from sentry.projectoptions.defaults import DEFAULT_GROUPING_CONFIG
 from sentry.signals import (
     first_event_with_minified_stack_trace_received,
     first_insight_span_received,

--- a/tests/sentry/event_manager/test_event_manager_grouping.py
+++ b/tests/sentry/event_manager/test_event_manager_grouping.py
@@ -8,7 +8,11 @@ from unittest.mock import ANY, MagicMock, patch
 import pytest
 
 from sentry import audit_log
-from sentry.conf.server import SENTRY_GROUPING_CONFIG_TRANSITION_DURATION
+from sentry.conf.server import (
+    DEFAULT_GROUPING_CONFIG,
+    LEGACY_GROUPING_CONFIG,
+    SENTRY_GROUPING_CONFIG_TRANSITION_DURATION,
+)
 from sentry.event_manager import _get_updated_group_title
 from sentry.eventtypes.base import DefaultEvent
 from sentry.grouping.api import get_grouping_config_dict_for_project
@@ -17,7 +21,6 @@ from sentry.models.auditlogentry import AuditLogEntry
 from sentry.models.group import Group
 from sentry.models.options.project_option import ProjectOption
 from sentry.models.project import Project
-from sentry.projectoptions.defaults import DEFAULT_GROUPING_CONFIG, LEGACY_GROUPING_CONFIG
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.eventprocessing import save_new_event
 from sentry.testutils.pytest.fixtures import django_db_all

--- a/tests/sentry/eventstore/test_models.py
+++ b/tests/sentry/eventstore/test_models.py
@@ -4,6 +4,7 @@ from unittest import mock
 import pytest
 
 from sentry import eventstore, nodestore
+from sentry.conf.server import DEFAULT_GROUPING_CONFIG
 from sentry.db.models.fields.node import NodeData, NodeIntegrityFailure
 from sentry.eventstore.models import Event, GroupEvent
 from sentry.grouping.api import GroupingConfig, get_grouping_variants_for_event
@@ -13,7 +14,6 @@ from sentry.grouping.variants import ComponentVariant
 from sentry.interfaces.user import User
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.models.environment import Environment
-from sentry.projectoptions.defaults import DEFAULT_GROUPING_CONFIG
 from sentry.snuba.dataset import Dataset
 from sentry.testutils.cases import PerformanceIssueTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now

--- a/tests/sentry/grouping/__init__.py
+++ b/tests/sentry/grouping/__init__.py
@@ -10,6 +10,7 @@ import pytest
 from django.utils.functional import cached_property
 
 from sentry import eventstore
+from sentry.conf.server import DEFAULT_GROUPING_CONFIG
 from sentry.event_manager import EventManager, get_event_type, materialize_metadata
 from sentry.eventstore.models import Event
 from sentry.grouping.api import (
@@ -24,7 +25,6 @@ from sentry.grouping.fingerprinting import FingerprintingRules
 from sentry.grouping.strategies.configurations import CONFIGURATIONS
 from sentry.grouping.variants import BaseVariant
 from sentry.models.project import Project
-from sentry.projectoptions.defaults import DEFAULT_GROUPING_CONFIG
 from sentry.stacktraces.processing import normalize_stacktraces_for_grouping
 from sentry.testutils.helpers.eventprocessing import save_new_event
 from sentry.utils import json

--- a/tests/sentry/grouping/seer_similarity/test_get_seer_similar_issues.py
+++ b/tests/sentry/grouping/seer_similarity/test_get_seer_similar_issues.py
@@ -2,6 +2,7 @@ from typing import Any
 from unittest.mock import MagicMock, call, patch
 
 from sentry import options
+from sentry.conf.server import DEFAULT_GROUPING_CONFIG
 from sentry.eventstore.models import Event
 from sentry.grouping.grouping_info import get_grouping_info_from_variants
 from sentry.grouping.ingest.grouphash_metadata import create_or_update_grouphash_metadata_if_needed
@@ -10,7 +11,6 @@ from sentry.grouping.variants import BaseVariant
 from sentry.models.grouphash import GroupHash
 from sentry.models.grouphashmetadata import GroupHashMetadata
 from sentry.models.project import Project
-from sentry.projectoptions.defaults import DEFAULT_GROUPING_CONFIG
 from sentry.seer.similarity.types import SeerSimilarIssueData
 from sentry.seer.similarity.utils import get_stacktrace_string
 from sentry.testutils.cases import TestCase

--- a/tests/sentry/grouping/test_enhancer.py
+++ b/tests/sentry/grouping/test_enhancer.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from sentry.conf.server import DEFAULT_GROUPING_CONFIG
 from sentry.grouping.api import get_grouping_config_dict_for_project, load_grouping_config
 from sentry.grouping.component import FrameGroupingComponent, StacktraceGroupingComponent
 from sentry.grouping.enhancer import (
@@ -23,7 +24,6 @@ from sentry.grouping.enhancer.exceptions import InvalidEnhancerConfig
 from sentry.grouping.enhancer.matchers import ReturnValueCache, _cached, create_match_frame
 from sentry.grouping.enhancer.parser import parse_enhancements
 from sentry.grouping.enhancer.rules import EnhancementRule
-from sentry.projectoptions.defaults import DEFAULT_GROUPING_CONFIG
 from sentry.testutils.cases import TestCase
 
 

--- a/tests/sentry/grouping/test_grouphash_metadata.py
+++ b/tests/sentry/grouping/test_grouphash_metadata.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
+from sentry.conf.server import DEFAULT_GROUPING_CONFIG
 from sentry.eventstore.models import Event
 from sentry.grouping.component import DefaultGroupingComponent, MessageGroupingComponent
 from sentry.grouping.ingest.grouphash_metadata import (
@@ -18,7 +19,6 @@ from sentry.grouping.variants import ComponentVariant
 from sentry.models.grouphash import GroupHash
 from sentry.models.grouphashmetadata import GroupHashMetadata, HashBasis
 from sentry.models.project import Project
-from sentry.projectoptions.defaults import DEFAULT_GROUPING_CONFIG
 from sentry.testutils.cases import TestCase
 from sentry.testutils.pytest.fixtures import InstaSnapshotter, django_db_all
 from sentry.utils import json

--- a/tests/sentry/grouping/test_grouping_info.py
+++ b/tests/sentry/grouping/test_grouping_info.py
@@ -1,5 +1,5 @@
+from sentry.conf.server import DEFAULT_GROUPING_CONFIG
 from sentry.grouping.grouping_info import get_grouping_info
-from sentry.projectoptions.defaults import DEFAULT_GROUPING_CONFIG
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.eventprocessing import save_new_event
 

--- a/tests/sentry/grouping/test_hashing.py
+++ b/tests/sentry/grouping/test_hashing.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from time import time
 from unittest.mock import MagicMock, patch
 
+from sentry.conf.server import DEFAULT_GROUPING_CONFIG, LEGACY_GROUPING_CONFIG
 from sentry.eventstore.models import Event
 from sentry.grouping.api import GroupingConfig
 from sentry.grouping.ingest.hashing import (
@@ -14,7 +15,6 @@ from sentry.grouping.variants import BaseVariant
 from sentry.models.group import Group
 from sentry.models.grouphash import GroupHash
 from sentry.models.project import Project
-from sentry.projectoptions.defaults import DEFAULT_GROUPING_CONFIG, LEGACY_GROUPING_CONFIG
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.eventprocessing import save_new_event
 from sentry.testutils.helpers.options import override_options

--- a/tests/sentry/grouping/test_variants.py
+++ b/tests/sentry/grouping/test_variants.py
@@ -6,12 +6,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from sentry.conf.server import DEFAULT_GROUPING_CONFIG
 from sentry.eventstore.models import Event
 from sentry.grouping.fingerprinting import FingerprintRuleJSON
 from sentry.grouping.strategies.configurations import CONFIGURATIONS
 from sentry.grouping.variants import CustomFingerprintVariant, expose_fingerprint_dict
 from sentry.models.project import Project
-from sentry.projectoptions.defaults import DEFAULT_GROUPING_CONFIG
 from sentry.testutils.pytest.fixtures import InstaSnapshotter, django_db_all
 from tests.sentry.grouping import (
     GROUPING_INPUTS_DIR,

--- a/tests/sentry/tasks/test_reprocessing2.py
+++ b/tests/sentry/tasks/test_reprocessing2.py
@@ -8,6 +8,7 @@ import pytest
 
 from sentry import eventstore
 from sentry.attachments import attachment_cache
+from sentry.conf.server import DEFAULT_GROUPING_CONFIG
 from sentry.event_manager import EventManager
 from sentry.eventstore.models import Event
 from sentry.eventstore.processing import event_processing_store
@@ -20,7 +21,6 @@ from sentry.models.groupassignee import GroupAssignee
 from sentry.models.groupredirect import GroupRedirect
 from sentry.models.userreport import UserReport
 from sentry.plugins.base.v2 import Plugin2
-from sentry.projectoptions.defaults import DEFAULT_GROUPING_CONFIG
 from sentry.reprocessing2 import is_group_finished
 from sentry.tasks.reprocessing2 import finish_reprocessing, reprocess_group
 from sentry.tasks.store import preprocess_event


### PR DESCRIPTION
This is a follow-up to https://github.com/getsentry/sentry/pull/95096, which removed the epoch defaults from the `sentry:grouping_config` project option. In this PR, a number of comments related to those old defaults have been cleaned up, and the constants for the legacy, default, and beta grouping configs have been moved from `projectoptions/defaults.py` to `conf/server.py`, since two of the three are no longer used in project defaults (and it makes sense to keep them all together). This move also means that they and the related `SENTRY_GROUPING_CONFIG_TRANSITION_DURATION` setting live alongside each other.