### PR TITLE
chore(aci milestone 3): remove unnecessary feature flag

### DIFF
--- a/src/sentry/incidents/grouptype.py
+++ b/src/sentry/incidents/grouptype.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import UTC, datetime
 
-from sentry import features
 from sentry.constants import CRASH_RATE_ALERT_AGGREGATE_ALIAS
 from sentry.incidents.handlers.condition import *  # noqa
 from sentry.incidents.metric_issue_detector import MetricIssueDetectorValidator
@@ -13,7 +12,6 @@ from sentry.incidents.utils.metric_issue_poc import QUERY_AGGREGATION_DISPLAY
 from sentry.incidents.utils.types import QuerySubscriptionUpdate
 from sentry.integrations.metric_alerts import TEXT_COMPARISON_DELTA
 from sentry.issues.grouptype import GroupCategory, GroupType
-from sentry.models.organization import Organization
 from sentry.ratelimits.sliding_windows import Quota
 from sentry.snuba.metrics import format_mri_field, is_mri_field
 from sentry.snuba.models import QuerySubscription, SnubaQuery
@@ -198,7 +196,3 @@ class MetricIssue(GroupType):
             },
         },
     )
-
-    @classmethod
-    def allow_post_process_group(cls, organization: Organization) -> bool:
-        return features.has("organizations:workflow-engine-metric-alert-processing", organization)

--- a/tests/sentry/workflow_engine/test_integration.py
+++ b/tests/sentry/workflow_engine/test_integration.py
@@ -143,7 +143,7 @@ class TestWorkflowEngineIntegrationToIssuePlatform(BaseWorkflowIntegrationTest):
 
 
 class TestWorkflowEngineIntegrationFromIssuePlatform(BaseWorkflowIntegrationTest):
-    @with_feature("organizations:workflow-engine-metric-alert-processing")
+    @with_feature("organizations:issue-metric-issue-post-process-group")
     @with_feature("organizations:workflow-engine-process-metric-issue-workflows")
     def test_workflow_engine__workflows(self):
         """
@@ -157,7 +157,7 @@ class TestWorkflowEngineIntegrationFromIssuePlatform(BaseWorkflowIntegrationTest
             self.call_post_process_group(self.group.id)
             mock_process_workflow.assert_called_once()
 
-    @with_feature("organizations:workflow-engine-metric-alert-processing")
+    @with_feature("organizations:issue-metric-issue-post-process-group")
     def test_workflow_engine__workflows__other_events(self):
         """
         Ensure that the workflow engine only supports MetricIssue events for now.


### PR DESCRIPTION
We shouldn't need to check for `"organizations:workflow-engine-metric-alert-processing"` in grouptype, because processing will be gated by `"organizations:issue-metric-issue-post-process-group"`. The first flag gates data entry into the workflow engine and is unrelated to post process.