### PR TITLE
ref(insights): replace `useSpanMetrics` with `useSpans`

### DIFF
--- a/static/app/components/charts/chartWidgetLoader-unmocked-imports.spec.tsx
+++ b/static/app/components/charts/chartWidgetLoader-unmocked-imports.spec.tsx
@@ -159,20 +159,6 @@ jest.mock('sentry/views/insights/common/queries/useDiscover', () => ({
     isPending: false,
     error: null,
   })),
-  useSpanMetrics: jest.fn(() => ({
-    data: [
-      {
-        'avg(span.duration)': 123,
-        'sum(span.duration)': 456,
-        'span.group': 'abc123',
-        'span.description': 'span1',
-        'sentry.normalized_description': 'span1',
-        transaction: 'transaction_a',
-      },
-    ],
-    isPending: false,
-    error: null,
-  })),
   useSpans: jest.fn(() => ({
     data: [
       {

--- a/static/app/components/events/eventStatisticalDetector/aggregateSpanDiff.tsx
+++ b/static/app/components/events/eventStatisticalDetector/aggregateSpanDiff.tsx
@@ -10,7 +10,7 @@ import {useApiQuery} from 'sentry/utils/queryClient';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
-import {useSpanMetrics} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
 import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSection';
 import {spanDetailsRouteWithQuery} from 'sentry/views/performance/transactionSummary/transactionSpans/spanDetails/utils';
@@ -119,7 +119,7 @@ function AggregateSpanDiff({event, project}: AggregateSpanDiffProps) {
     data: spansData,
     isPending: isSpansDataLoading,
     isError: isSpansDataError,
-  } = useSpanMetrics(
+  } = useSpans(
     {
       search,
       fields: [

--- a/static/app/views/insights/browser/common/queries/useResourcesQuery.ts
+++ b/static/app/views/insights/browser/common/queries/useResourcesQuery.ts
@@ -7,7 +7,7 @@ import {ResourceSpanOps} from 'sentry/views/insights/browser/resources/types';
 import type {ModuleFilters} from 'sentry/views/insights/browser/resources/utils/useResourceFilters';
 import {useResourceModuleFilters} from 'sentry/views/insights/browser/resources/utils/useResourceFilters';
 import type {ValidSort} from 'sentry/views/insights/browser/resources/utils/useResourceSort';
-import {useSpanMetrics} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {SpanMetricsField} from 'sentry/views/insights/types';
 
 const {
@@ -72,7 +72,7 @@ export const useResourcesQuery = ({
     query,
   ];
 
-  return useSpanMetrics(
+  return useSpans(
     {
       sorts: [sort],
       search: queryConditions.join(' '),

--- a/static/app/views/insights/browser/resources/queries/useResourcePageQuery.ts
+++ b/static/app/views/insights/browser/resources/queries/useResourcePageQuery.ts
@@ -1,7 +1,7 @@
 import {defined} from 'sentry/utils';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
-import {useSpanMetrics} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {SpanMetricsField, type SubregionCode} from 'sentry/views/insights/types';
 
 const {HTTP_RESPONSE_CONTENT_LENGTH, RESOURCE_RENDER_BLOCKING_STATUS} = SpanMetricsField;
@@ -54,7 +54,7 @@ export const useResourcePagesQuery = (
     }
   });
 
-  return useSpanMetrics(
+  return useSpans(
     {
       cursor,
       limit: 25,

--- a/static/app/views/insights/browser/resources/queries/useResourcePagesQuery.ts
+++ b/static/app/views/insights/browser/resources/queries/useResourcePagesQuery.ts
@@ -4,7 +4,7 @@ import {
   getResourceTypeFilter,
 } from 'sentry/views/insights/browser/common/queries/useResourcesQuery';
 import {useResourceModuleFilters} from 'sentry/views/insights/browser/resources/utils/useResourceFilters';
-import {useSpanMetrics} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {SpanMetricsField} from 'sentry/views/insights/types';
 
 const {SPAN_DOMAIN, SPAN_OP} = SpanMetricsField;
@@ -28,7 +28,7 @@ export const useResourcePagesQuery = (
       : []),
   ]; // TODO: We will need to consider other ops
 
-  const result = useSpanMetrics(
+  const result = useSpans(
     {
       fields: ['transaction', 'count()'],
       search: queryConditions.join(' '),

--- a/static/app/views/insights/browser/resources/views/resourceSummaryPage.tsx
+++ b/static/app/views/insights/browser/resources/views/resourceSummaryPage.tsx
@@ -20,7 +20,7 @@ import {ModulePageFilterBar} from 'sentry/views/insights/common/components/modul
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
 import {ModuleBodyUpsellHook} from 'sentry/views/insights/common/components/moduleUpsellHookWrapper';
 import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
-import {useSpanMetrics} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {useModuleTitle} from 'sentry/views/insights/common/utils/useModuleTitle';
 import {useModuleURL} from 'sentry/views/insights/common/utils/useModuleURL';
 import {useSamplesDrawer} from 'sentry/views/insights/common/utils/useSamplesDrawer';
@@ -61,7 +61,7 @@ function ResourceSummary() {
     requiredParams: ['transaction'],
   });
 
-  const {data, isPending} = useSpanMetrics(
+  const {data, isPending} = useSpans(
     {
       search: MutableSearch.fromQueryObject({
         'span.group': groupId,

--- a/static/app/views/insights/browser/resources/views/resourcesLandingPage.spec.tsx
+++ b/static/app/views/insights/browser/resources/views/resourcesLandingPage.spec.tsx
@@ -69,7 +69,7 @@ describe('ResourcesLandingPage', function () {
       "error": [Function],
       "method": "GET",
       "query": {
-        "dataset": "spansMetrics",
+        "dataset": "spans",
         "environment": [],
         "field": [
           "span.domain",
@@ -79,6 +79,7 @@ describe('ResourcesLandingPage', function () {
         "project": [],
         "query": "has:sentry.normalized_description span.category:resource !sentry.normalized_description:"browser-extension://*" span.op:[resource.script,resource.css,resource.font,resource.img]",
         "referrer": "api.starfish.get-span-domains",
+        "sampling": "NORMAL",
         "sort": "-count()",
         "statsPeriod": "10d",
       },
@@ -102,7 +103,7 @@ describe('ResourcesLandingPage', function () {
       "error": [Function],
       "method": "GET",
       "query": {
-        "dataset": "spansMetrics",
+        "dataset": "spans",
         "environment": [],
         "field": [
           "sentry.normalized_description",
@@ -119,6 +120,7 @@ describe('ResourcesLandingPage', function () {
         "project": [],
         "query": "!sentry.normalized_description:"browser-extension://*" ( span.op:resource.script OR file_extension:css OR file_extension:[woff,woff2,ttf,otf,eot] OR file_extension:[jpg,jpeg,png,gif,svg,webp,apng,avif] OR span.op:resource.img ) ",
         "referrer": "api.performance.browser.resources.main-table",
+        "sampling": "NORMAL",
         "sort": "-sum(span.self_time)",
         "statsPeriod": "10d",
       },

--- a/static/app/views/insights/cache/components/samplePanel.tsx
+++ b/static/app/views/insights/cache/components/samplePanel.tsx
@@ -29,7 +29,7 @@ import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLay
 import {ReadoutRibbon} from 'sentry/views/insights/common/components/ribbon';
 import {SampleDrawerBody} from 'sentry/views/insights/common/components/sampleDrawerBody';
 import {SampleDrawerHeaderTransaction} from 'sentry/views/insights/common/components/sampleDrawerHeaderTransaction';
-import {useSpanMetrics, useSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {
   DataTitles,
   getThroughputTitle,
@@ -93,7 +93,7 @@ export function CacheSamplePanel() {
   const search = MutableSearch.fromQueryObject(filters);
 
   const {data: cacheTransactionMetrics, isFetching: areCacheTransactionMetricsFetching} =
-    useSpanMetrics(
+    useSpans(
       {
         search,
         fields: [

--- a/static/app/views/insights/cache/views/cacheLandingPage.spec.tsx
+++ b/static/app/views/insights/cache/views/cacheLandingPage.spec.tsx
@@ -120,7 +120,8 @@ describe('CacheLandingPage', function () {
       expect.objectContaining({
         method: 'GET',
         query: {
-          dataset: 'spansMetrics',
+          dataset: 'spans',
+          sampling: SAMPLING_MODE.NORMAL,
           environment: [],
           field: [
             'project',

--- a/static/app/views/insights/cache/views/cacheLandingPage.tsx
+++ b/static/app/views/insights/cache/views/cacheLandingPage.tsx
@@ -28,7 +28,7 @@ import {ModulesOnboarding} from 'sentry/views/insights/common/components/modules
 import {ModuleBodyUpsellHook} from 'sentry/views/insights/common/components/moduleUpsellHookWrapper';
 import CacheMissRateChartWidget from 'sentry/views/insights/common/components/widgets/cacheMissRateChartWidget';
 import CacheThroughputChartWidget from 'sentry/views/insights/common/components/widgets/cacheThroughputChartWidget';
-import {useSpanMetrics, useSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {useSpanMetricsSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {useHasFirstSpan} from 'sentry/views/insights/common/queries/useHasFirstSpan';
 import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
@@ -84,7 +84,7 @@ export function CacheLandingPage() {
     meta: transactionsListMeta,
     error: transactionsListError,
     pageLinks: transactionsListPageLinks,
-  } = useSpanMetrics(
+  } = useSpans(
     {
       search: MutableSearch.fromQueryObject(BASE_FILTERS),
       fields: [

--- a/static/app/views/insights/common/queries/useDiscover.spec.tsx
+++ b/static/app/views/insights/common/queries/useDiscover.spec.tsx
@@ -113,7 +113,7 @@ describe('useDiscover', () => {
         expect.objectContaining({
           method: 'GET',
           query: {
-            dataset: 'spansMetrics',
+            dataset: 'spans',
             environment: [],
             field: ['epm()'],
             per_page: 10,

--- a/static/app/views/insights/common/queries/useDiscover.spec.tsx
+++ b/static/app/views/insights/common/queries/useDiscover.spec.tsx
@@ -11,8 +11,8 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
-import {useSpanMetrics, useSpans} from 'sentry/views/insights/common/queries/useDiscover';
-import type {EAPSpanProperty, SpanMetricsProperty} from 'sentry/views/insights/types';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import type {EAPSpanProperty} from 'sentry/views/insights/types';
 import {SpanFields} from 'sentry/views/insights/types';
 import {OrganizationContext} from 'sentry/views/organizationContext';
 
@@ -28,7 +28,7 @@ function Wrapper({children}: {children?: ReactNode}) {
 }
 
 describe('useDiscover', () => {
-  describe('useSpanMetrics', () => {
+  describe('useSpans', () => {
     const organization = OrganizationFixture();
 
     jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture());
@@ -47,11 +47,11 @@ describe('useDiscover', () => {
       });
 
       const {result} = renderHook(
-        ({fields, enabled}) => useSpanMetrics({fields, enabled}, 'span-metrics-series'),
+        ({fields, enabled}) => useSpans({fields, enabled}, 'span-metrics-series'),
         {
           wrapper: Wrapper,
           initialProps: {
-            fields: ['epm()'] as SpanMetricsProperty[],
+            fields: ['epm()'] as EAPSpanProperty[],
             enabled: false,
           },
         }
@@ -78,7 +78,7 @@ describe('useDiscover', () => {
 
       const {result} = renderHook(
         ({filters, fields, sorts, limit, cursor, referrer}) =>
-          useSpanMetrics(
+          useSpans(
             {
               search: MutableSearch.fromQueryObject(filters),
               fields,
@@ -97,7 +97,7 @@ describe('useDiscover', () => {
               release: '0.0.1',
               environment: undefined,
             },
-            fields: ['epm()'] as SpanMetricsProperty[],
+            fields: ['epm()'] as EAPSpanProperty[],
             sorts: [{field: 'epm()', kind: 'desc' as const}],
             limit: 10,
             referrer: 'api-spec',

--- a/static/app/views/insights/common/queries/useDiscover.spec.tsx
+++ b/static/app/views/insights/common/queries/useDiscover.spec.tsx
@@ -121,6 +121,7 @@ describe('useDiscover', () => {
             sort: '-epm()',
             query: `span.group:221aa7ebd216 transaction:/api/details release:0.0.1`,
             referrer: 'api-spec',
+            sampling: SAMPLING_MODE.NORMAL,
             statsPeriod: '10d',
           },
         })

--- a/static/app/views/insights/common/queries/useDiscover.ts
+++ b/static/app/views/insights/common/queries/useDiscover.ts
@@ -6,13 +6,7 @@ import type {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import type {SamplingMode} from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {useWrappedDiscoverQuery} from 'sentry/views/insights/common/queries/useSpansQuery';
-import {useInsightsEap} from 'sentry/views/insights/common/utils/useEap';
-import type {
-  EAPSpanProperty,
-  EAPSpanResponse,
-  SpanMetricsProperty,
-  SpanMetricsResponse,
-} from 'sentry/views/insights/types';
+import type {EAPSpanProperty, EAPSpanResponse} from 'sentry/views/insights/types';
 
 interface UseDiscoverQueryOptions {
   additonalQueryKey?: string[];
@@ -47,18 +41,6 @@ export const useSpans = <Fields extends EAPSpanProperty[]>(
   return useDiscover<Fields, EAPSpanResponse>(
     options,
     DiscoverDatasets.SPANS_EAP_RPC,
-    referrer
-  );
-};
-
-export const useSpanMetrics = <Fields extends SpanMetricsProperty[]>(
-  options: UseDiscoverOptions<Fields> = {},
-  referrer: string
-) => {
-  const useEap = useInsightsEap();
-  return useDiscover<Fields, SpanMetricsResponse>(
-    options,
-    useEap ? DiscoverDatasets.SPANS_EAP_RPC : DiscoverDatasets.SPANS_METRICS,
     referrer
   );
 };

--- a/static/app/views/insights/common/views/spanSummaryPage/sampleList/durationChart/index.tsx
+++ b/static/app/views/insights/common/views/spanSummaryPage/sampleList/durationChart/index.tsx
@@ -9,7 +9,7 @@ import {Samples} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottabl
 // TODO(release-drawer): Used in spanSummarPage/samplelist and spanSamplesPanelContainer
 // eslint-disable-next-line no-restricted-imports
 import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/insightsLineChartWidget';
-import {useSpanMetrics} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {useSpanMetricsSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import type {
   NonDefaultSpanSampleFields,
@@ -99,7 +99,7 @@ function DurationChart({
     referrer
   );
 
-  const {data, error: spanMetricsError} = useSpanMetrics(
+  const {data, error: spanMetricsError} = useSpans(
     {
       search: MutableSearch.fromQueryObject(filters),
       fields: [`avg(${SPAN_SELF_TIME})`, SPAN_OP],

--- a/static/app/views/insights/common/views/spanSummaryPage/sampleList/sampleInfo/index.tsx
+++ b/static/app/views/insights/common/views/spanSummaryPage/sampleList/sampleInfo/index.tsx
@@ -6,7 +6,7 @@ import {usePageAlert} from 'sentry/utils/performance/contexts/pageAlert';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {MetricReadout} from 'sentry/views/insights/common/components/metricReadout';
 import {ReadoutRibbon} from 'sentry/views/insights/common/components/ribbon';
-import {useSpanMetrics} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {
   DataTitles,
   getThroughputTitle,
@@ -40,7 +40,7 @@ function SampleInfo(props: Props) {
     ribbonFilters[SpanMetricsField.USER_GEO_SUBREGION] = `[${subregions.join(',')}]`;
   }
 
-  const {data, error, isPending} = useSpanMetrics(
+  const {data, error, isPending} = useSpans(
     {
       search: MutableSearch.fromQueryObject(ribbonFilters),
       fields: [

--- a/static/app/views/insights/common/views/spanSummaryPage/sampleList/sampleTable/sampleTable.tsx
+++ b/static/app/views/insights/common/views/spanSummaryPage/sampleList/sampleTable/sampleTable.tsx
@@ -11,7 +11,7 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useOrganization from 'sentry/utils/useOrganization';
 import type {SamplesTableColumnHeader} from 'sentry/views/insights/common/components/samplesTable/spanSamplesTable';
 import {SpanSamplesTable} from 'sentry/views/insights/common/components/samplesTable/spanSamplesTable';
-import {useSpanMetrics, useSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import type {
   NonDefaultSpanSampleFields,
   SpanSample,
@@ -79,7 +79,7 @@ function SampleTable({
     filters[SpanMetricsField.USER_GEO_SUBREGION] = `[${subregions.join(',')}]`;
   }
 
-  const {data, isFetching: isFetchingSpanMetrics} = useSpanMetrics(
+  const {data, isFetching: isFetchingSpanMetrics} = useSpans(
     {
       search: MutableSearch.fromQueryObject({...filters, ...additionalFilters}),
       fields: [`avg(${SPAN_SELF_TIME})`, SPAN_OP],

--- a/static/app/views/insights/common/views/spans/selectors/actionSelector.tsx
+++ b/static/app/views/insights/common/views/spans/selectors/actionSelector.tsx
@@ -8,7 +8,7 @@ import {EMPTY_OPTION_VALUE, MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
-import {useSpanMetrics} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {buildEventViewQuery} from 'sentry/views/insights/common/utils/buildEventViewQuery';
 import {QueryParameterNames} from 'sentry/views/insights/common/views/queryParameters';
 import {EmptyContainer} from 'sentry/views/insights/common/views/spans/selectors/emptyOption';
@@ -45,7 +45,7 @@ export function ActionSelector({value = '', moduleName, spanCategory, filters}: 
 
   const useHTTPActions = moduleName === ModuleName.HTTP;
 
-  const {data: actions} = useSpanMetrics(
+  const {data: actions} = useSpans(
     {
       search,
       fields: [SPAN_ACTION, 'count()'],

--- a/static/app/views/insights/common/views/spans/selectors/domainSelector.tsx
+++ b/static/app/views/insights/common/views/spans/selectors/domainSelector.tsx
@@ -10,7 +10,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import {useSpanMetrics} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {buildEventViewQuery} from 'sentry/views/insights/common/utils/buildEventViewQuery';
 import {useCompactSelectOptionsCache} from 'sentry/views/insights/common/utils/useCompactSelectOptionsCache';
 import {useWasSearchSpaceExhausted} from 'sentry/views/insights/common/utils/useWasSearchSpaceExhausted';
@@ -69,7 +69,7 @@ export function DomainSelector({
     data: domainData,
     isPending,
     pageLinks,
-  } = useSpanMetrics(
+  } = useSpans(
     {
       limit: LIMIT,
       search: query,

--- a/static/app/views/insights/common/views/spans/selectors/subregionSelector.tsx
+++ b/static/app/views/insights/common/views/spans/selectors/subregionSelector.tsx
@@ -15,7 +15,7 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
-import {useSpanMetrics} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {SpanMetricsField, subregionCodeToName} from 'sentry/views/insights/types';
 
 type Props = {
@@ -28,7 +28,7 @@ export default function SubregionSelector({size}: Props) {
   const navigate = useNavigate();
 
   const value = decodeList(location.query[SpanMetricsField.USER_GEO_SUBREGION]);
-  const {data, isPending} = useSpanMetrics(
+  const {data, isPending} = useSpans(
     {
       fields: [SpanMetricsField.USER_GEO_SUBREGION, 'count()'],
       search: new MutableSearch('has:user.geo.subregion'),

--- a/static/app/views/insights/database/components/databaseSystemSelector.spec.tsx
+++ b/static/app/views/insights/database/components/databaseSystemSelector.spec.tsx
@@ -5,7 +5,7 @@ import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
-import {useSpanMetrics} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {DatabaseSystemSelector} from 'sentry/views/insights/database/components/databaseSystemSelector';
 import {SpanMetricsField} from 'sentry/views/insights/types';
 
@@ -26,7 +26,7 @@ jest.mock('sentry/utils/useNavigate', () => ({
 }));
 
 const mockUseLocalStorageState = jest.mocked(useLocalStorageState);
-const mockUseSpanMetrics = jest.mocked(useSpanMetrics);
+const mockUseSpanMetrics = jest.mocked(useSpans);
 const mockUseLocation = jest.mocked(useLocation);
 const mockUseNavigate = jest.mocked(useNavigate);
 

--- a/static/app/views/insights/database/components/databaseSystemSelector.spec.tsx
+++ b/static/app/views/insights/database/components/databaseSystemSelector.spec.tsx
@@ -10,7 +10,7 @@ import {DatabaseSystemSelector} from 'sentry/views/insights/database/components/
 import {SpanMetricsField} from 'sentry/views/insights/types';
 
 jest.mock('sentry/views/insights/common/queries/useDiscover', () => ({
-  useSpanMetrics: jest.fn(),
+  useSpans: jest.fn(),
 }));
 
 jest.mock('sentry/utils/useLocalStorageState', () => ({
@@ -26,7 +26,7 @@ jest.mock('sentry/utils/useNavigate', () => ({
 }));
 
 const mockUseLocalStorageState = jest.mocked(useLocalStorageState);
-const mockUseSpanMetrics = jest.mocked(useSpans);
+const mockUseSpans = jest.mocked(useSpans);
 const mockUseLocation = jest.mocked(useLocation);
 const mockUseNavigate = jest.mocked(useNavigate);
 
@@ -52,7 +52,7 @@ describe('DatabaseSystemSelector', function () {
   it('is disabled and does not select a system if there are none available', async function () {
     const mockSetState = jest.fn();
     mockUseLocalStorageState.mockReturnValue(['', mockSetState]);
-    mockUseSpanMetrics.mockReturnValue({
+    mockUseSpans.mockReturnValue({
       data: [],
       isLoading: false,
       isError: false,
@@ -69,7 +69,7 @@ describe('DatabaseSystemSelector', function () {
   it('is disabled when only one database system is present and shows that system as selected', async function () {
     const mockSetState = jest.fn();
     mockUseLocalStorageState.mockReturnValue(['', mockSetState]);
-    mockUseSpanMetrics.mockReturnValue({
+    mockUseSpans.mockReturnValue({
       data: [
         {
           'span.system': 'postgresql',
@@ -88,7 +88,7 @@ describe('DatabaseSystemSelector', function () {
   });
 
   it('renders all database system options correctly', async function () {
-    mockUseSpanMetrics.mockReturnValue({
+    mockUseSpans.mockReturnValue({
       data: [
         {
           'span.system': 'postgresql',
@@ -111,7 +111,7 @@ describe('DatabaseSystemSelector', function () {
 
     const dropdownSelector = await screen.findByRole('button');
     expect(dropdownSelector).toBeEnabled();
-    expect(mockUseSpanMetrics).toHaveBeenCalled();
+    expect(mockUseSpans).toHaveBeenCalled();
 
     const dropdownButton = await screen.findByRole('button');
     expect(dropdownButton).toBeInTheDocument();
@@ -127,7 +127,7 @@ describe('DatabaseSystemSelector', function () {
 
   it('chooses the currently selected system from localStorage', async function () {
     mockUseLocalStorageState.mockReturnValue(['mongodb', () => {}]);
-    mockUseSpanMetrics.mockReturnValue({
+    mockUseSpans.mockReturnValue({
       data: [
         {
           'span.system': 'postgresql',
@@ -154,7 +154,7 @@ describe('DatabaseSystemSelector', function () {
   it('does not set the value from localStorage if the value is invalid', async function () {
     const mockSetState = jest.fn();
     mockUseLocalStorageState.mockReturnValue(['chungusdb', mockSetState]);
-    mockUseSpanMetrics.mockReturnValue({
+    mockUseSpans.mockReturnValue({
       data: [
         {
           'span.system': 'postgresql',
@@ -187,7 +187,7 @@ describe('DatabaseSystemSelector', function () {
       key: '',
     });
 
-    mockUseSpanMetrics.mockReturnValue({
+    mockUseSpans.mockReturnValue({
       data: [
         {
           'span.system': 'postgresql',

--- a/static/app/views/insights/database/components/useSystemSelectorOptions.tsx
+++ b/static/app/views/insights/database/components/useSystemSelectorOptions.tsx
@@ -1,7 +1,7 @@
 import type {SelectOption} from 'sentry/components/core/compactSelect';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
-import {useSpanMetrics} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {
   DATABASE_SYSTEM_TO_LABEL,
   SupportedDatabaseSystem,
@@ -14,7 +14,7 @@ export function useSystemSelectorOptions() {
     undefined
   );
 
-  const {data, isPending, isError} = useSpanMetrics(
+  const {data, isPending, isError} = useSpans(
     {
       search: MutableSearch.fromQueryObject({'span.op': 'db'}),
 

--- a/static/app/views/insights/database/views/databaseLandingPage.spec.tsx
+++ b/static/app/views/insights/database/views/databaseLandingPage.spec.tsx
@@ -190,7 +190,7 @@ describe('DatabaseLandingPage', function () {
       expect.objectContaining({
         method: 'GET',
         query: {
-          dataset: 'spansMetrics',
+          dataset: 'spans',
           environment: [],
           field: [
             'project.id',
@@ -308,7 +308,7 @@ describe('DatabaseLandingPage', function () {
       expect.objectContaining({
         method: 'GET',
         query: {
-          dataset: 'spansMetrics',
+          dataset: 'spans',
           environment: [],
           field: [
             'project.id',

--- a/static/app/views/insights/database/views/databaseLandingPage.spec.tsx
+++ b/static/app/views/insights/database/views/databaseLandingPage.spec.tsx
@@ -8,6 +8,7 @@ import ProjectsStore from 'sentry/stores/projectsStore';
 import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {useReleaseStats} from 'sentry/utils/useReleaseStats';
+import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {DatabaseLandingPage} from 'sentry/views/insights/database/views/databaseLandingPage';
 
 jest.mock('sentry/utils/useLocation');
@@ -206,6 +207,7 @@ describe('DatabaseLandingPage', function () {
           query:
             'span.category:db !span.op:[db.sql.room,db.redis] has:sentry.normalized_description',
           referrer: 'api.starfish.use-span-list',
+          sampling: SAMPLING_MODE.NORMAL,
           sort: '-sum(span.self_time)',
           statsPeriod: '10d',
         },
@@ -325,6 +327,7 @@ describe('DatabaseLandingPage', function () {
             'span.category:db !span.op:[db.sql.room,db.redis] has:sentry.normalized_description span.action:SELECT span.domain:organizations',
           referrer: 'api.starfish.use-span-list',
           sort: '-sum(span.self_time)',
+          sampling: SAMPLING_MODE.NORMAL,
           statsPeriod: '10d',
         },
       })

--- a/static/app/views/insights/database/views/databaseLandingPage.tsx
+++ b/static/app/views/insights/database/views/databaseLandingPage.tsx
@@ -19,7 +19,7 @@ import DatabaseLandingThroughputChartWidget from 'sentry/views/insights/common/c
 import {useDatabaseLandingChartFilter} from 'sentry/views/insights/common/components/widgets/hooks/useDatabaseLandingChartFilter';
 import {useDatabaseLandingDurationQuery} from 'sentry/views/insights/common/components/widgets/hooks/useDatabaseLandingDurationQuery';
 import {useDatabaseLandingThroughputQuery} from 'sentry/views/insights/common/components/widgets/hooks/useDatabaseLandingThroughputQuery';
-import {useSpanMetrics} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {useHasFirstSpan} from 'sentry/views/insights/common/queries/useHasFirstSpan';
 import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
 import {QueryParameterNames} from 'sentry/views/insights/common/views/queryParameters';
@@ -93,7 +93,7 @@ export function DatabaseLandingPage() {
 
   const cursor = decodeScalar(location.query?.[QueryParameterNames.SPANS_CURSOR]);
 
-  const queryListResponse = useSpanMetrics(
+  const queryListResponse = useSpans(
     {
       search: MutableSearch.fromQueryObject(tableFilters),
       fields: [

--- a/static/app/views/insights/database/views/databaseSpanSummaryPage.spec.tsx
+++ b/static/app/views/insights/database/views/databaseSpanSummaryPage.spec.tsx
@@ -215,6 +215,7 @@ describe('DatabaseSpanSummaryPage', function () {
           project: [],
           query: 'span.group:1756baf8fd19c116',
           referrer: 'api.starfish.span-summary-page-metrics',
+          sampling: SAMPLING_MODE.NORMAL,
           statsPeriod: '10d',
         },
       })
@@ -298,6 +299,7 @@ describe('DatabaseSpanSummaryPage', function () {
           project: [],
           query: 'span.group:1756baf8fd19c116',
           referrer: 'api.insights.database.summary-duration-chart',
+          sampling: undefined,
           statsPeriod: '10d',
           topEvents: undefined,
           yAxis: 'avg(span.self_time)',
@@ -329,6 +331,7 @@ describe('DatabaseSpanSummaryPage', function () {
           query: 'span.group:1756baf8fd19c116',
           sort: '-sum(span.self_time)',
           referrer: 'api.starfish.span-transaction-metrics',
+          sampling: SAMPLING_MODE.NORMAL,
           statsPeriod: '10d',
         },
       })

--- a/static/app/views/insights/database/views/databaseSpanSummaryPage.spec.tsx
+++ b/static/app/views/insights/database/views/databaseSpanSummaryPage.spec.tsx
@@ -198,7 +198,7 @@ describe('DatabaseSpanSummaryPage', function () {
       expect.objectContaining({
         method: 'GET',
         query: {
-          dataset: 'spansMetrics',
+          dataset: 'spans',
           environment: [],
           field: [
             'span.op',
@@ -313,7 +313,7 @@ describe('DatabaseSpanSummaryPage', function () {
       expect.objectContaining({
         method: 'GET',
         query: {
-          dataset: 'spansMetrics',
+          dataset: 'spans',
           environment: [],
           field: [
             'transaction',

--- a/static/app/views/insights/database/views/databaseSpanSummaryPage.tsx
+++ b/static/app/views/insights/database/views/databaseSpanSummaryPage.tsx
@@ -21,7 +21,7 @@ import {ReadoutRibbon, ToolRibbon} from 'sentry/views/insights/common/components
 import {DatabaseSpanDescription} from 'sentry/views/insights/common/components/spanDescription';
 import DatabaseSummaryDurationChartWidget from 'sentry/views/insights/common/components/widgets/databaseSummaryDurationChartWidget';
 import DatabaseSummaryThroughputChartWidget from 'sentry/views/insights/common/components/widgets/databaseSummaryThroughputChartWidget';
-import {useSpanMetrics, useSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {useModuleTitle} from 'sentry/views/insights/common/utils/useModuleTitle';
 import {useModuleURL} from 'sentry/views/insights/common/utils/useModuleURL';
 import {useSamplesDrawer} from 'sentry/views/insights/common/utils/useSamplesDrawer';
@@ -93,7 +93,7 @@ export function DatabaseSpanSummaryPage({params}: Props) {
       'api.starfish.span-description'
     );
 
-  const {data, isPending: areSpanMetricsLoading} = useSpanMetrics(
+  const {data, isPending: areSpanMetricsLoading} = useSpans(
     {
       search: MutableSearch.fromQueryObject(filters),
       fields: [
@@ -120,7 +120,7 @@ export function DatabaseSpanSummaryPage({params}: Props) {
     meta: transactionsListMeta,
     error: transactionsListError,
     pageLinks: transactionsListPageLinks,
-  } = useSpanMetrics(
+  } = useSpans(
     {
       search: MutableSearch.fromQueryObject(filters),
       fields: [

--- a/static/app/views/insights/http/components/httpSamplesPanel.spec.tsx
+++ b/static/app/views/insights/http/components/httpSamplesPanel.spec.tsx
@@ -220,6 +220,7 @@ describe('HTTPSamplesPanel', () => {
             project: [],
             query: 'span.op:http.client !has:span.domain transaction:/api/0/users',
             referrer: 'api.performance.http.samples-panel-metrics-ribbon',
+            sampling: SAMPLING_MODE.NORMAL,
             statsPeriod: '10d',
           },
         })

--- a/static/app/views/insights/http/components/httpSamplesPanel.spec.tsx
+++ b/static/app/views/insights/http/components/httpSamplesPanel.spec.tsx
@@ -206,7 +206,7 @@ describe('HTTPSamplesPanel', () => {
         expect.objectContaining({
           method: 'GET',
           query: {
-            dataset: 'spansMetrics',
+            dataset: 'spans',
             environment: [],
             field: [
               'epm()',

--- a/static/app/views/insights/http/components/httpSamplesPanel.tsx
+++ b/static/app/views/insights/http/components/httpSamplesPanel.tsx
@@ -35,7 +35,7 @@ import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLay
 import {ReadoutRibbon} from 'sentry/views/insights/common/components/ribbon';
 import {SampleDrawerBody} from 'sentry/views/insights/common/components/sampleDrawerBody';
 import {SampleDrawerHeaderTransaction} from 'sentry/views/insights/common/components/sampleDrawerHeaderTransaction';
-import {useSpanMetrics, useSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {useSpanMetricsSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {useTopNSpanMetricsSeries} from 'sentry/views/insights/common/queries/useTopNDiscoverSeries';
 import {
@@ -169,7 +169,7 @@ export function HTTPSamplesPanel() {
   const {
     data: domainTransactionMetrics,
     isFetching: areDomainTransactionMetricsFetching,
-  } = useSpanMetrics(
+  } = useSpans(
     {
       search: MutableSearch.fromQueryObject(ribbonFilters),
       fields: [

--- a/static/app/views/insights/http/views/httpDomainSummaryPage.spec.tsx
+++ b/static/app/views/insights/http/views/httpDomainSummaryPage.spec.tsx
@@ -296,7 +296,7 @@ describe('HTTPDomainSummaryPage', function () {
       expect.objectContaining({
         method: 'GET',
         query: {
-          dataset: 'spansMetrics',
+          dataset: 'spans',
           environment: [],
           field: [
             'epm()',
@@ -321,7 +321,7 @@ describe('HTTPDomainSummaryPage', function () {
       expect.objectContaining({
         method: 'GET',
         query: {
-          dataset: 'spansMetrics',
+          dataset: 'spans',
           environment: [],
           field: [
             'project.id',
@@ -350,7 +350,7 @@ describe('HTTPDomainSummaryPage', function () {
       expect.objectContaining({
         method: 'GET',
         query: {
-          dataset: 'spansMetrics',
+          dataset: 'spans',
           environment: [],
           field: ['user.geo.subregion', 'count()'],
           per_page: 50,

--- a/static/app/views/insights/http/views/httpDomainSummaryPage.spec.tsx
+++ b/static/app/views/insights/http/views/httpDomainSummaryPage.spec.tsx
@@ -16,6 +16,7 @@ jest.mock('sentry/utils/usePageFilters');
 import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 
 import {useReleaseStats} from 'sentry/utils/useReleaseStats';
+import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
 
 jest.mock('sentry/utils/useReleaseStats');
 
@@ -310,6 +311,7 @@ describe('HTTPDomainSummaryPage', function () {
           project: [],
           query: 'span.op:http.client span.domain:"\\*.sentry.dev"',
           referrer: 'api.performance.http.domain-summary-metrics-ribbon',
+          sampling: SAMPLING_MODE.NORMAL,
           statsPeriod: '10d',
         },
       })
@@ -340,6 +342,7 @@ describe('HTTPDomainSummaryPage', function () {
           query: 'span.op:http.client span.domain:"\\*.sentry.dev"',
           sort: '-sum(span.self_time)',
           referrer: 'api.performance.http.domain-summary-transactions-list',
+          sampling: SAMPLING_MODE.NORMAL,
           statsPeriod: '10d',
         },
       })
@@ -358,6 +361,7 @@ describe('HTTPDomainSummaryPage', function () {
           query: 'has:user.geo.subregion',
           sort: '-count()',
           referrer: 'api.insights.user-geo-subregion-selector',
+          sampling: SAMPLING_MODE.NORMAL,
           statsPeriod: '10d',
         },
       })

--- a/static/app/views/insights/http/views/httpDomainSummaryPage.tsx
+++ b/static/app/views/insights/http/views/httpDomainSummaryPage.tsx
@@ -21,7 +21,7 @@ import {useHttpDomainSummaryChartFilter} from 'sentry/views/insights/common/comp
 import HttpDomainSummaryDurationChartWidget from 'sentry/views/insights/common/components/widgets/httpDomainSummaryDurationChartWidget';
 import HttpDomainSummaryResponseCodesChartWidget from 'sentry/views/insights/common/components/widgets/httpDomainSummaryResponseCodesChartWidget';
 import HttpDomainSummaryThroughputChartWidget from 'sentry/views/insights/common/components/widgets/httpDomainSummaryThroughputChartWidget';
-import {useSpanMetrics} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {useModuleTitle} from 'sentry/views/insights/common/utils/useModuleTitle';
 import {useModuleURL} from 'sentry/views/insights/common/utils/useModuleURL';
 import {useSamplesDrawer} from 'sentry/views/insights/common/utils/useSamplesDrawer';
@@ -83,7 +83,7 @@ export function HTTPDomainSummaryPage() {
 
   const project = projects.find(p => projectId === p.id);
 
-  const {data: domainMetrics, isPending: areDomainMetricsLoading} = useSpanMetrics(
+  const {data: domainMetrics, isPending: areDomainMetricsLoading} = useSpans(
     {
       search: MutableSearch.fromQueryObject(filters),
       fields: [
@@ -104,7 +104,7 @@ export function HTTPDomainSummaryPage() {
     meta: transactionsListMeta,
     error: transactionsListError,
     pageLinks: transactionsListPageLinks,
-  } = useSpanMetrics(
+  } = useSpans(
     {
       search: MutableSearch.fromQueryObject(filters),
       fields: [

--- a/static/app/views/insights/http/views/httpLandingPage.spec.tsx
+++ b/static/app/views/insights/http/views/httpLandingPage.spec.tsx
@@ -8,6 +8,7 @@ import ProjectsStore from 'sentry/stores/projectsStore';
 import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {useReleaseStats} from 'sentry/utils/useReleaseStats';
+import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {QueryParameterNames} from 'sentry/views/insights/common/views/queryParameters';
 import {HTTPLandingPage} from 'sentry/views/insights/http/views/httpLandingPage';
 
@@ -299,6 +300,7 @@ describe('HTTPLandingPage', function () {
           query: 'has:user.geo.subregion',
           sort: '-count()',
           referrer: 'api.insights.user-geo-subregion-selector',
+          sampling: SAMPLING_MODE.NORMAL,
           statsPeriod: '10d',
         },
       })
@@ -384,6 +386,7 @@ describe('HTTPLandingPage', function () {
           referrer: 'api.performance.http.landing-domains-list',
           sort: '-sum(span.self_time)',
           statsPeriod: '10d',
+          sampling: SAMPLING_MODE.NORMAL,
         },
       })
     );
@@ -475,6 +478,7 @@ describe('HTTPLandingPage', function () {
           referrer: 'api.performance.http.landing-domains-list',
           sort: '-avg(span.self_time)',
           statsPeriod: '10d',
+          sampling: SAMPLING_MODE.NORMAL,
         },
       })
     );

--- a/static/app/views/insights/http/views/httpLandingPage.spec.tsx
+++ b/static/app/views/insights/http/views/httpLandingPage.spec.tsx
@@ -291,7 +291,7 @@ describe('HTTPLandingPage', function () {
       expect.objectContaining({
         method: 'GET',
         query: {
-          dataset: 'spansMetrics',
+          dataset: 'spans',
           environment: [],
           field: ['user.geo.subregion', 'count()'],
           per_page: 50,
@@ -365,7 +365,7 @@ describe('HTTPLandingPage', function () {
       expect.objectContaining({
         method: 'GET',
         query: {
-          dataset: 'spansMetrics',
+          dataset: 'spans',
           environment: [],
           field: [
             'project',
@@ -456,7 +456,7 @@ describe('HTTPLandingPage', function () {
       expect.objectContaining({
         method: 'GET',
         query: {
-          dataset: 'spansMetrics',
+          dataset: 'spans',
           environment: [],
           field: [
             'project',

--- a/static/app/views/insights/http/views/httpLandingPage.tsx
+++ b/static/app/views/insights/http/views/httpLandingPage.tsx
@@ -20,7 +20,7 @@ import {useHttpLandingChartFilter} from 'sentry/views/insights/common/components
 import HttpDurationChartWidget from 'sentry/views/insights/common/components/widgets/httpDurationChartWidget';
 import HttpResponseCodesChartWidget from 'sentry/views/insights/common/components/widgets/httpResponseCodesChartWidget';
 import HttpThroughputChartWidget from 'sentry/views/insights/common/components/widgets/httpThroughputChartWidget';
-import {useSpanMetrics} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {QueryParameterNames} from 'sentry/views/insights/common/views/queryParameters';
 import SubregionSelector from 'sentry/views/insights/common/views/spans/selectors/subregionSelector';
 import {
@@ -78,7 +78,7 @@ export function HTTPLandingPage() {
     });
   };
 
-  const domainsListResponse = useSpanMetrics(
+  const domainsListResponse = useSpans(
     {
       search: MutableSearch.fromQueryObject(tableFilters),
       fields: [

--- a/static/app/views/insights/llmMonitoring/components/tables/pipelinesTable.tsx
+++ b/static/app/views/insights/llmMonitoring/components/tables/pipelinesTable.tsx
@@ -27,7 +27,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {renderHeadCell} from 'sentry/views/insights/common/components/tableCells/renderHeadCell';
-import {useSpanMetrics} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {combineMeta} from 'sentry/views/insights/common/utils/combineMeta';
 import {useModuleURL} from 'sentry/views/insights/common/utils/useModuleURL';
 import {QueryParameterNames} from 'sentry/views/insights/common/views/queryParameters';
@@ -112,7 +112,7 @@ export function PipelinesTable() {
     meta: baseMeta,
     pageLinks,
     error,
-  } = useSpanMetrics(
+  } = useSpans(
     {
       search: MutableSearch.fromQueryObject({
         'span.category': 'ai.pipeline',
@@ -136,7 +136,7 @@ export function PipelinesTable() {
     data: tokensUsedData,
     meta: tokensUsedMeta,
     isPending: tokensUsedLoading,
-  } = useSpanMetrics(
+  } = useSpans(
     {
       search: new MutableSearch(
         `span.category:ai span.ai.pipeline.group:[${(data as Row[])
@@ -154,7 +154,7 @@ export function PipelinesTable() {
     meta: tokenCostMeta,
     isPending: tokenCostLoading,
     error: tokenCostError,
-  } = useSpanMetrics(
+  } = useSpans(
     {
       search: new MutableSearch(
         `span.category:ai span.ai.pipeline.group:[${(data as Row[])?.map(x => x['span.group']).join(',')}]`

--- a/static/app/views/insights/llmMonitoring/views/llmMonitoringDetailsPage.tsx
+++ b/static/app/views/insights/llmMonitoring/views/llmMonitoringDetailsPage.tsx
@@ -19,7 +19,7 @@ import {ReadoutRibbon, ToolRibbon} from 'sentry/views/insights/common/components
 import LlmGroupNumberOfPipelinesChartWidget from 'sentry/views/insights/common/components/widgets/llmGroupNumberOfPipelinesChartWidget';
 import LlmGroupPipelineDurationChartWidget from 'sentry/views/insights/common/components/widgets/llmGroupPipelineDurationChartWidget';
 import LlmGroupTotalTokensUsedChartWidget from 'sentry/views/insights/common/components/widgets/llmGroupTotalTokensUsedChartWidget';
-import {useSpanMetrics} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {PipelineSpansTable} from 'sentry/views/insights/llmMonitoring/components/tables/pipelineSpansTable';
 import {RELEASE_LEVEL} from 'sentry/views/insights/llmMonitoring/settings';
 import {AiHeader} from 'sentry/views/insights/pages/ai/aiPageHeader';
@@ -53,7 +53,7 @@ function LLMMonitoringPage({params}: Props) {
     'span.category': 'ai.pipeline',
   };
 
-  const {data, isPending: areSpanMetricsLoading} = useSpanMetrics(
+  const {data, isPending: areSpanMetricsLoading} = useSpans(
     {
       search: MutableSearch.fromQueryObject(filters),
       fields: [
@@ -69,7 +69,7 @@ function LLMMonitoringPage({params}: Props) {
 
   const spanMetrics = data[0] ?? {};
 
-  const {data: totalTokenData, isPending: isTotalTokenDataLoading} = useSpanMetrics(
+  const {data: totalTokenData, isPending: isTotalTokenDataLoading} = useSpans(
     {
       search: MutableSearch.fromQueryObject({
         'span.category': 'ai',

--- a/static/app/views/insights/mobile/appStarts/components/spanOpSelector.tsx
+++ b/static/app/views/insights/mobile/appStarts/components/spanOpSelector.tsx
@@ -6,7 +6,7 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
-import {useSpanMetrics} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {appendReleaseFilters} from 'sentry/views/insights/common/utils/releaseComparison';
 import {COLD_START_TYPE} from 'sentry/views/insights/mobile/appStarts/components/startTypeSelector';
 import useCrossPlatformProject from 'sentry/views/insights/mobile/common/queries/useCrossPlatformProject';
@@ -66,7 +66,7 @@ export function SpanOpSelector({transaction, primaryRelease, secondaryRelease}: 
     secondaryRelease
   );
 
-  const {data} = useSpanMetrics(
+  const {data} = useSpans(
     {
       limit: 25,
       search: queryStringPrimary,

--- a/static/app/views/insights/mobile/appStarts/components/startDurationWidget.spec.tsx
+++ b/static/app/views/insights/mobile/appStarts/components/startDurationWidget.spec.tsx
@@ -121,7 +121,7 @@ describe('StartDurationWidget', () => {
             isMetricsExtractedData: false,
             tips: {},
             datasetReason: 'unchanged',
-            dataset: 'spansMetrics',
+            dataset: 'spans',
           },
         },
         'com.example.vu.android@2.10.3+42': {
@@ -146,7 +146,7 @@ describe('StartDurationWidget', () => {
             isMetricsExtractedData: false,
             tips: {},
             datasetReason: 'unchanged',
-            dataset: 'spansMetrics',
+            dataset: 'spans',
           },
         },
       } as MultiSeriesEventsStats;

--- a/static/app/views/insights/mobile/appStarts/components/tables/spanOperationTable.tsx
+++ b/static/app/views/insights/mobile/appStarts/components/tables/spanOperationTable.tsx
@@ -26,7 +26,7 @@ import {
 } from 'sentry/views/insights/common/components/releaseSelector';
 import {PercentChangeCell} from 'sentry/views/insights/common/components/tableCells/percentChangeCell';
 import {OverflowEllipsisTextContainer} from 'sentry/views/insights/common/components/textAlign';
-import {useSpanMetrics} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {appendReleaseFilters} from 'sentry/views/insights/common/utils/releaseComparison';
 import {useModuleURL} from 'sentry/views/insights/common/utils/useModuleURL';
 import {QueryParameterNames} from 'sentry/views/insights/common/views/queryParameters';
@@ -114,7 +114,7 @@ export function SpanOperationTable({
     field: `avg_compare(${SPAN_SELF_TIME},release,${primaryRelease},${secondaryRelease})`,
   };
 
-  const {data, meta, isPending, pageLinks} = useSpanMetrics(
+  const {data, meta, isPending, pageLinks} = useSpans(
     {
       cursor,
       fields: [

--- a/static/app/views/insights/mobile/common/components/spanSamplesPanelContainer.tsx
+++ b/static/app/views/insights/mobile/common/components/spanSamplesPanelContainer.tsx
@@ -18,7 +18,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {MetricReadout} from 'sentry/views/insights/common/components/metricReadout';
 import {ReadoutRibbon} from 'sentry/views/insights/common/components/ribbon';
-import {useSpanMetrics} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import type {SpanSample} from 'sentry/views/insights/common/queries/useSpanSamples';
 import {formatVersionAndCenterTruncate} from 'sentry/views/insights/common/utils/centerTruncate';
 import {DataTitles} from 'sentry/views/insights/common/views/spans/types';
@@ -104,7 +104,7 @@ export function SpanSamplesContainer({
     filters['span.op'] = spanOp;
   }
 
-  const {data, isPending} = useSpanMetrics(
+  const {data, isPending} = useSpans(
     {
       search: MutableSearch.fromQueryObject({...filters, ...additionalFilters}),
       fields: [`avg(${SPAN_SELF_TIME})`, 'count()', SPAN_OP],

--- a/static/app/views/insights/mobile/screenload/components/spanOpSelector.tsx
+++ b/static/app/views/insights/mobile/screenload/components/spanOpSelector.tsx
@@ -9,7 +9,7 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
-import {useSpanMetrics} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {appendReleaseFilters} from 'sentry/views/insights/common/utils/releaseComparison';
 import {MobileCursors} from 'sentry/views/insights/mobile/screenload/constants';
 import {SpanMetricsField} from 'sentry/views/insights/types';
@@ -50,7 +50,7 @@ export function SpanOpSelector({transaction, primaryRelease, secondaryRelease}: 
     secondaryRelease
   );
 
-  const {data} = useSpanMetrics(
+  const {data} = useSpans(
     {
       limit: 25,
       search: queryStringPrimary,

--- a/static/app/views/insights/mobile/screenload/components/tables/screenLoadSpansTable.spec.tsx
+++ b/static/app/views/insights/mobile/screenload/components/tables/screenLoadSpansTable.spec.tsx
@@ -55,7 +55,7 @@ describe('ScreenLoadSpansTable', function () {
       expect.anything(),
       expect.objectContaining({
         query: expect.objectContaining({
-          dataset: 'spansMetrics',
+          dataset: 'spans',
           environment: [],
           field: ['span.op', 'count()'],
           per_page: 25,
@@ -74,7 +74,7 @@ describe('ScreenLoadSpansTable', function () {
       expect.anything(),
       expect.objectContaining({
         query: expect.objectContaining({
-          dataset: 'spansMetrics',
+          dataset: 'spans',
           environment: [],
           field: [
             'project.id',

--- a/static/app/views/insights/mobile/screenload/components/tables/screenLoadSpansTable.tsx
+++ b/static/app/views/insights/mobile/screenload/components/tables/screenLoadSpansTable.tsx
@@ -27,7 +27,7 @@ import {
   SECONDARY_RELEASE_ALIAS,
 } from 'sentry/views/insights/common/components/releaseSelector';
 import {OverflowEllipsisTextContainer} from 'sentry/views/insights/common/components/textAlign';
-import {useSpanMetrics} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {useTTFDConfigured} from 'sentry/views/insights/common/queries/useHasTtfdConfigured';
 import {appendReleaseFilters} from 'sentry/views/insights/common/utils/releaseComparison';
 import {useModuleURL} from 'sentry/views/insights/common/utils/useModuleURL';
@@ -99,7 +99,7 @@ export function ScreenLoadSpansTable({
     field: 'sum(span.self_time)',
   };
 
-  const {data, meta, isPending, pageLinks} = useSpanMetrics(
+  const {data, meta, isPending, pageLinks} = useSpans(
     {
       cursor,
       search: queryStringPrimary,

--- a/static/app/views/insights/mobile/screenload/utils.tsx
+++ b/static/app/views/insights/mobile/screenload/utils.tsx
@@ -66,7 +66,7 @@ export function transformDeviceClassEvents({
           // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
           transformedData[YAXIS_COLUMNS[val]][release].data[index] = {
             name: deviceClass,
-            value: row[YAXIS_COLUMNS[val] as keyof EAPSpanResponse],
+            value: row[YAXIS_COLUMNS[val]],
             itemStyle: {
               color: isPrimary ? colors[0] : colors[1],
             },

--- a/static/app/views/insights/mobile/screens/components/screensOverview.spec.tsx
+++ b/static/app/views/insights/mobile/screens/components/screensOverview.spec.tsx
@@ -154,10 +154,10 @@ describe('ScreensOverview', () => {
           isMetricsExtractedData: false,
           tips: {},
           datasetReason: 'unchanged',
-          dataset: 'spansMetrics',
+          dataset: 'spans',
         },
       },
-      match: [MockApiClient.matchQuery({dataset: 'spansMetrics'})],
+      match: [MockApiClient.matchQuery({dataset: 'spans'})],
     });
 
     render(<ScreensOverview />, {organization});

--- a/static/app/views/insights/mobile/screens/components/screensOverview.spec.tsx
+++ b/static/app/views/insights/mobile/screens/components/screensOverview.spec.tsx
@@ -113,7 +113,11 @@ describe('ScreensOverview', () => {
           dataset: 'spans',
         },
       },
-      match: [MockApiClient.matchQuery({dataset: 'spans'})],
+      match: [
+        MockApiClient.matchQuery({
+          referrer: 'api.starfish.mobile-screens-screen-table-metrics',
+        }),
+      ],
     });
 
     const spanMetricsMock = MockApiClient.addMockResponse({
@@ -157,7 +161,11 @@ describe('ScreensOverview', () => {
           dataset: 'spans',
         },
       },
-      match: [MockApiClient.matchQuery({dataset: 'spans'})],
+      match: [
+        MockApiClient.matchQuery({
+          referrer: 'api.starfish.mobile-screens-screen-table-span-metrics',
+        }),
+      ],
     });
 
     render(<ScreensOverview />, {organization});

--- a/static/app/views/insights/mobile/screens/components/screensOverview.tsx
+++ b/static/app/views/insights/mobile/screens/components/screensOverview.tsx
@@ -15,16 +15,12 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import {useSpanMetrics, useSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import useCrossPlatformProject from 'sentry/views/insights/mobile/common/queries/useCrossPlatformProject';
 import ScreensOverviewTable from 'sentry/views/insights/mobile/screens/components/screensOverviewTable';
 import {Referrer} from 'sentry/views/insights/mobile/screens/referrers';
 import {DEFAULT_SORT} from 'sentry/views/insights/mobile/screens/settings';
-import {
-  type EAPSpanProperty,
-  SpanMetricsField,
-  type SpanMetricsProperty,
-} from 'sentry/views/insights/types';
+import {type EAPSpanProperty, SpanFields} from 'sentry/views/insights/types';
 import {getTransactionSearchQuery} from 'sentry/views/performance/utils';
 
 const getQueryString = (
@@ -54,8 +50,8 @@ const getQueryString = (
 };
 
 const transactionMetricsFields = [
-  SpanMetricsField.PROJECT_ID,
-  SpanMetricsField.TRANSACTION,
+  SpanFields.PROJECT_ID,
+  SpanFields.TRANSACTION,
   `count()`,
   'avg(measurements.app_start_cold)',
   'avg(measurements.app_start_warm)',
@@ -64,12 +60,12 @@ const transactionMetricsFields = [
 ] as const satisfies EAPSpanProperty[];
 
 const spanMetricsFields = [
-  SpanMetricsField.PROJECT_ID,
-  SpanMetricsField.TRANSACTION,
+  SpanFields.PROJECT_ID,
+  SpanFields.TRANSACTION,
   `division(mobile.slow_frames,mobile.total_frames)`,
   `division(mobile.frozen_frames,mobile.total_frames)`,
   `avg(mobile.frames_delay)`,
-] as const satisfies SpanMetricsProperty[];
+] as const satisfies EAPSpanProperty[];
 
 export function ScreensOverview() {
   const navigate = useNavigate();
@@ -116,7 +112,7 @@ export function ScreensOverview() {
   const spanMetricsSorts = isSpanPrimary ? [sort] : [];
   const metricsSorts = isSpanPrimary ? [] : [sort];
 
-  const spanMetricsResult = useSpanMetrics(
+  const spanMetricsResult = useSpans(
     {
       search: spanMetricsQuery,
       fields: spanMetricsFields,

--- a/static/app/views/insights/mobile/screens/components/screensOverview.tsx
+++ b/static/app/views/insights/mobile/screens/components/screensOverview.tsx
@@ -119,7 +119,7 @@ export function ScreensOverview() {
       sorts: spanMetricsSorts,
       enabled: isSpanPrimary || hasVisibleScreens,
     },
-    Referrer.SCREENS_SCREEN_TABLE
+    Referrer.SCREENS_SCREEN_TABLE_SPAN_METRICS
   );
 
   const metricsResult = useSpans(

--- a/static/app/views/insights/mobile/screens/referrers.tsx
+++ b/static/app/views/insights/mobile/screens/referrers.tsx
@@ -1,5 +1,7 @@
 export enum Referrer {
   // based on https://github.com/getsentry/sentry/blob/1dd8b8de9a99672301ee8eb2f852ac42b3a87e62/src/sentry/snuba/referrer.py#L457-L458
+  SCREENS_SPAN_METRICS = 'api.starfish.mobile-screens-span-metrics',
   SCREENS_METRICS = 'api.starfish.mobile-screens-metrics',
-  SCREENS_SCREEN_TABLE = 'api.starfish.mobile-screens-screen-table',
+  SCREENS_SCREEN_TABLE = 'api.starfish.mobile-screens-screen-table-metrics',
+  SCREENS_SCREEN_TABLE_SPAN_METRICS = 'api.starfish.mobile-screens-screen-table-span-metrics',
 }

--- a/static/app/views/insights/mobile/screens/views/screensLandingPage.spec.tsx
+++ b/static/app/views/insights/mobile/screens/views/screensLandingPage.spec.tsx
@@ -128,7 +128,9 @@ describe('Screens Landing Page', function () {
             dataset: 'spans',
           },
         },
-        match: [MockApiClient.matchQuery({dataset: 'spans'})],
+        match: [
+          MockApiClient.matchQuery({referrer: 'api.starfish.mobile-screens-metrics'}),
+        ],
       });
 
       const spanMetricsMock = MockApiClient.addMockResponse({
@@ -159,7 +161,11 @@ describe('Screens Landing Page', function () {
             dataset: 'spans',
           },
         },
-        match: [MockApiClient.matchQuery({dataset: 'spans'})],
+        match: [
+          MockApiClient.matchQuery({
+            referrer: 'api.starfish.mobile-screens-span-metrics',
+          }),
+        ],
       });
 
       render(<ScreensLandingPage />, {organization, deprecatedRouterMocks: true});

--- a/static/app/views/insights/mobile/screens/views/screensLandingPage.spec.tsx
+++ b/static/app/views/insights/mobile/screens/views/screensLandingPage.spec.tsx
@@ -156,10 +156,10 @@ describe('Screens Landing Page', function () {
             isMetricsExtractedData: false,
             tips: {},
             datasetReason: 'unchanged',
-            dataset: 'spansMetrics',
+            dataset: 'spans',
           },
         },
-        match: [MockApiClient.matchQuery({dataset: 'spansMetrics'})],
+        match: [MockApiClient.matchQuery({dataset: 'spans'})],
       });
 
       render(<ScreensLandingPage />, {organization, deprecatedRouterMocks: true});

--- a/static/app/views/insights/mobile/screens/views/screensLandingPage.tsx
+++ b/static/app/views/insights/mobile/screens/views/screensLandingPage.tsx
@@ -20,7 +20,7 @@ import {ModulePageProviders} from 'sentry/views/insights/common/components/modul
 import {ModulesOnboarding} from 'sentry/views/insights/common/components/modulesOnboarding';
 import {ModuleBodyUpsellHook} from 'sentry/views/insights/common/components/moduleUpsellHookWrapper';
 import {InsightsProjectSelector} from 'sentry/views/insights/common/components/projectSelector';
-import {useSpanMetrics, useSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {useMobileVitalsDrawer} from 'sentry/views/insights/common/utils/useMobileVitalsDrawer';
 import useCrossPlatformProject from 'sentry/views/insights/mobile/common/queries/useCrossPlatformProject';
 import {PlatformSelector} from 'sentry/views/insights/mobile/screenload/components/platformSelector';
@@ -223,7 +223,7 @@ function ScreensLandingPage() {
     Referrer.SCREENS_METRICS
   );
 
-  const spanMetricsResult = useSpanMetrics(
+  const spanMetricsResult = useSpans(
     {
       search: query,
       limit: 25,

--- a/static/app/views/insights/mobile/screens/views/screensLandingPage.tsx
+++ b/static/app/views/insights/mobile/screens/views/screensLandingPage.tsx
@@ -229,7 +229,7 @@ function ScreensLandingPage() {
       limit: 25,
       fields: spanMetricsFields,
     },
-    Referrer.SCREENS_METRICS
+    Referrer.SCREENS_SPAN_METRICS
   );
 
   const metricsData = {...metricsResult.data[0], ...spanMetricsResult.data[0]};

--- a/static/app/views/insights/mobile/ui/components/tables/spanOperationTable.tsx
+++ b/static/app/views/insights/mobile/ui/components/tables/spanOperationTable.tsx
@@ -89,7 +89,7 @@ export function SpanOperationTable({
     ],
     query: queryStringPrimary,
     orderby,
-    dataset: DiscoverDatasets.SPANS_METRICS,
+    dataset: DiscoverDatasets.SPANS_EAP_RPC,
     version: 2,
     projects: selection.projects,
     interval: getInterval(selection.datetime, STARFISH_CHART_INTERVAL_FIDELITY),

--- a/static/app/views/insights/mobile/ui/components/tables/spanOperationTable.tsx
+++ b/static/app/views/insights/mobile/ui/components/tables/spanOperationTable.tsx
@@ -17,7 +17,7 @@ import {
   SECONDARY_RELEASE_ALIAS,
 } from 'sentry/views/insights/common/components/releaseSelector';
 import {OverflowEllipsisTextContainer} from 'sentry/views/insights/common/components/textAlign';
-import {useSpanMetrics} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {STARFISH_CHART_INTERVAL_FIDELITY} from 'sentry/views/insights/common/utils/constants';
 import {appendReleaseFilters} from 'sentry/views/insights/common/utils/releaseComparison';
 import {useModuleURL} from 'sentry/views/insights/common/utils/useModuleURL';
@@ -97,7 +97,7 @@ export function SpanOperationTable({
 
   const eventView = EventView.fromNewQueryWithLocation(newQuery, location);
 
-  const {data, meta, isPending, pageLinks} = useSpanMetrics(
+  const {data, meta, isPending, pageLinks} = useSpans(
     {
       cursor,
       search: queryStringPrimary,

--- a/static/app/views/insights/queues/components/messageSpanSamplesPanel.spec.tsx
+++ b/static/app/views/insights/queues/components/messageSpanSamplesPanel.spec.tsx
@@ -176,7 +176,7 @@ describe('messageSpanSamplesPanel', () => {
       expect.objectContaining({
         method: 'GET',
         query: expect.objectContaining({
-          dataset: 'spansMetrics',
+          dataset: 'spans',
           environment: [],
           field: [
             'count()',
@@ -288,7 +288,7 @@ describe('messageSpanSamplesPanel', () => {
       expect.objectContaining({
         method: 'GET',
         query: expect.objectContaining({
-          dataset: 'spansMetrics',
+          dataset: 'spans',
           environment: [],
           field: [
             'count()',

--- a/static/app/views/insights/queues/components/tables/queuesTable.spec.tsx
+++ b/static/app/views/insights/queues/components/tables/queuesTable.spec.tsx
@@ -82,7 +82,7 @@ describe('queuesTable', () => {
             'avg(messaging.message.receive.latency)',
             'trace_status_rate(ok)',
           ],
-          dataset: 'spansMetrics',
+          dataset: 'spans',
         }),
       })
     );
@@ -118,7 +118,7 @@ describe('queuesTable', () => {
             'avg(messaging.message.receive.latency)',
             'trace_status_rate(ok)',
           ],
-          dataset: 'spansMetrics',
+          dataset: 'spans',
           sort: '-messaging.destination.name',
           query:
             'span.op:[queue.process,queue.publish] messaging.destination.name:*events*',

--- a/static/app/views/insights/queues/components/tables/transactionsTable.spec.tsx
+++ b/static/app/views/insights/queues/components/tables/transactionsTable.spec.tsx
@@ -98,7 +98,7 @@ describe('transactionsTable', () => {
             'avg(messaging.message.receive.latency)',
             'trace_status_rate(ok)',
           ],
-          dataset: 'spansMetrics',
+          dataset: 'spans',
         }),
       })
     );
@@ -146,7 +146,7 @@ describe('transactionsTable', () => {
             'avg(messaging.message.receive.latency)',
             'trace_status_rate(ok)',
           ],
-          dataset: 'spansMetrics',
+          dataset: 'spans',
           sort: '-avg_if(span.duration,span.op,queue.process)',
         }),
       })

--- a/static/app/views/insights/queues/queries/useQueuesByDestinationQuery.tsx
+++ b/static/app/views/insights/queues/queries/useQueuesByDestinationQuery.tsx
@@ -2,7 +2,7 @@ import type {Sort} from 'sentry/utils/discover/fields';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
-import {useSpanMetrics} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {QueryParameterNames} from 'sentry/views/insights/common/views/queryParameters';
 import type {Referrer} from 'sentry/views/insights/queues/referrers';
 import {
@@ -30,7 +30,7 @@ export function useQueuesByDestinationQuery({
   if (destination) {
     mutableSearch.addFilterValue('messaging.destination.name', destination, false);
   }
-  return useSpanMetrics(
+  return useSpans(
     {
       search: mutableSearch,
       fields: [

--- a/static/app/views/insights/queues/queries/useQueuesByTransactionQuery.tsx
+++ b/static/app/views/insights/queues/queries/useQueuesByTransactionQuery.tsx
@@ -2,7 +2,7 @@ import type {Sort} from 'sentry/utils/discover/fields';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
-import {useSpanMetrics} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {QueryParameterNames} from 'sentry/views/insights/common/views/queryParameters';
 import type {Referrer} from 'sentry/views/insights/queues/referrers';
 import {
@@ -31,7 +31,7 @@ export function useQueuesByTransactionQuery({
     mutableSearch.addFilterValue('messaging.destination.name', destination);
   }
 
-  return useSpanMetrics(
+  return useSpans(
     {
       search: mutableSearch,
       fields: [

--- a/static/app/views/insights/queues/queries/useQueuesMetricsQuery.tsx
+++ b/static/app/views/insights/queues/queries/useQueuesMetricsQuery.tsx
@@ -1,5 +1,5 @@
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
-import {useSpanMetrics} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import type {Referrer} from 'sentry/views/insights/queues/referrers';
 import {DEFAULT_QUERY_FILTER} from 'sentry/views/insights/queues/settings';
 
@@ -24,7 +24,7 @@ export function useQueuesMetricsQuery({
     mutableSearch.addFilterValue('transaction', transaction);
   }
 
-  return useSpanMetrics(
+  return useSpans(
     {
       search: mutableSearch,
       fields: [

--- a/static/app/views/insights/types.tsx
+++ b/static/app/views/insights/types.tsx
@@ -459,6 +459,19 @@ type EAPSpanResponseRaw = {
       | `${Property}(${string},${string})`
       | `${Property}(${string},${string},${string})`
       | `${Property}(${string},${string},${string},${string})`]: number;
+    // TODO: We should allow a nicer way to define functions with multiple arguments and different arg types
+  } & Record<`division(${SpanNumberFields},${SpanNumberFields})`, number> & {
+    // TODO: This should include all valid HTTP codes or just all integers
+    'http_response_count(2)': number;
+    'http_response_count(3)': number;
+    'http_response_count(4)': number;
+    'http_response_count(5)': number;
+    'http_response_rate(2)': number;
+    'http_response_rate(3)': number;
+    'http_response_rate(4)': number;
+    'http_response_rate(5)': number;
+    'ttfd_contribution_rate()': number;
+    'ttid_contribution_rate()': number;
   } & {
     [SpanMetricsField.USER_GEO_SUBREGION]: SubregionCode;
   } & {

--- a/static/app/views/performance/landing/widgets/components/widgetContainer.spec.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetContainer.spec.tsx
@@ -878,7 +878,7 @@ describe('Performance > Widgets > WidgetContainer', function () {
       expect.anything(),
       expect.objectContaining({
         query: expect.objectContaining({
-          dataset: 'spansMetrics',
+          dataset: 'spans',
           environment: ['prod'],
           field: [
             'span.op',
@@ -925,7 +925,7 @@ describe('Performance > Widgets > WidgetContainer', function () {
       expect.anything(),
       expect.objectContaining({
         query: expect.objectContaining({
-          dataset: 'spansMetrics',
+          dataset: 'spans',
           environment: ['prod'],
           field: [
             'project.id',
@@ -969,7 +969,7 @@ describe('Performance > Widgets > WidgetContainer', function () {
       expect.anything(),
       expect.objectContaining({
         query: expect.objectContaining({
-          dataset: 'spansMetrics',
+          dataset: 'spans',
           environment: ['prod'],
           field: [
             'sentry.normalized_description',
@@ -1040,7 +1040,7 @@ describe('Performance > Widgets > WidgetContainer', function () {
       expect.objectContaining({
         query: expect.objectContaining({
           cursor: '0:0:1',
-          dataset: 'spansMetrics',
+          dataset: 'spans',
           environment: ['prod'],
           field: ['transaction', 'project.id', 'cache_miss_rate()'],
           noPagination: true,

--- a/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
@@ -118,9 +118,7 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
 
   const metricsDataset = useEap ? DiscoverDatasets.SPANS_EAP : DiscoverDatasets.METRICS;
 
-  const spanQueryParams: Record<string, string> = useEap
-    ? {...EAP_QUERY_PARAMS}
-    : {dataset: DiscoverDatasets.SPANS_METRICS};
+  const spanQueryParams: Record<string, string> = {...EAP_QUERY_PARAMS};
 
   const metricsQueryParams: Record<string, string> = useEap
     ? {...EAP_QUERY_PARAMS}

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/index.tsx
@@ -17,7 +17,7 @@ import type {Organization} from 'sentry/types/organization';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useProjects from 'sentry/utils/useProjects';
-import {useSpanMetrics} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import type {
   SpanMetricsQueryFilters,
   SpanMetricsResponse,
@@ -107,7 +107,7 @@ export function TransactionNodeDetails({
     project_slug: node.value.project_slug,
     organization,
   });
-  const {data: cacheMetrics} = useSpanMetrics(
+  const {data: cacheMetrics} = useSpans(
     {
       search: MutableSearch.fromQueryObject({
         transaction: node.value.transaction,

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanMetricsTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanMetricsTable.tsx
@@ -21,7 +21,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {renderHeadCell} from 'sentry/views/insights/common/components/tableCells/renderHeadCell';
-import {useSpanMetrics} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {QueryParameterNames} from 'sentry/views/insights/common/views/queryParameters';
 import {
   type DomainView,
@@ -129,7 +129,7 @@ export default function SpanMetricsTable(props: Props) {
   const mutableSearch = MutableSearch.fromQueryObject(filters);
   mutableSearch.addStringMultiFilter(search);
 
-  const {data, isPending, pageLinks} = useSpanMetrics(
+  const {data, isPending, pageLinks} = useSpans(
     {
       search: mutableSearch,
       fields: [

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanSummary/content.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanSummary/content.spec.tsx
@@ -214,7 +214,7 @@ describe('SpanSummaryPage', function () {
           isMetricsExtractedData: false,
           tips: {},
           datasetReason: 'unchanged',
-          dataset: 'spansMetrics',
+          dataset: 'spans',
         },
       },
     });

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanSummary/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanSummary/content.tsx
@@ -11,7 +11,7 @@ import useRouteAnalyticsParams from 'sentry/utils/routeAnalytics/useRouteAnalyti
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useParams} from 'sentry/utils/useParams';
-import {useSpanMetrics} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {AiHeader} from 'sentry/views/insights/pages/ai/aiPageHeader';
 import {BackendHeader} from 'sentry/views/insights/pages/backend/backendPageHeader';
 import {FrontendHeader} from 'sentry/views/insights/pages/frontend/frontendPageHeader';
@@ -150,7 +150,7 @@ function SpanSummaryContent(props: ContentProps) {
     transaction: transactionName,
   };
 
-  const {data: spanHeaderData} = useSpanMetrics(
+  const {data: spanHeaderData} = useSpans(
     {
       search: MutableSearch.fromQueryObject(filters),
       fields: ['span.description', 'sum(span.duration)', 'count()'],
@@ -160,7 +160,7 @@ function SpanSummaryContent(props: ContentProps) {
   );
 
   // Average span duration must be queried for separately, since it could get broken up into multiple groups if used in the first query
-  const {data: avgDurationData} = useSpanMetrics(
+  const {data: avgDurationData} = useSpans(
     {
       search: MutableSearch.fromQueryObject(filters),
       fields: ['avg(span.duration)'],


### PR DESCRIPTION
Work for DAIN-748

Replacing `useSpanMetrics` with `useSpans` now that span metrics is gone