### PR TITLE
ref(insights): replace `useMetricSeries` with `useSpanSeries`

### DIFF
--- a/static/app/components/charts/chartWidgetLoader-unmocked-imports.spec.tsx
+++ b/static/app/components/charts/chartWidgetLoader-unmocked-imports.spec.tsx
@@ -209,6 +209,24 @@ jest.mock('sentry/views/insights/common/queries/useDiscoverSeries', () => ({
       'trace_status_rate(internal_error)': mockDiscoverSeries(
         'trace_status_rate(internal_error)'
       ),
+      'performance_score(measurements.score.lcp)': {
+        data: [],
+      },
+      'performance_score(measurements.score.fcp)': {
+        data: [],
+      },
+      'performance_score(measurements.score.cls)': {
+        data: [],
+      },
+      'performance_score(measurements.score.inp)': {
+        data: [],
+      },
+      'performance_score(measurements.score.ttfb)': {
+        data: [],
+      },
+      'count()': {
+        data: [],
+      },
     },
     isPending: false,
     error: null,

--- a/static/app/components/charts/chartWidgetLoader-unmocked-imports.spec.tsx
+++ b/static/app/components/charts/chartWidgetLoader-unmocked-imports.spec.tsx
@@ -213,30 +213,6 @@ jest.mock('sentry/views/insights/common/queries/useDiscoverSeries', () => ({
     isPending: false,
     error: null,
   })),
-  useMetricsSeries: jest.fn(() => ({
-    data: {
-      'performance_score(measurements.score.lcp)': {
-        data: [],
-      },
-      'performance_score(measurements.score.fcp)': {
-        data: [],
-      },
-      'performance_score(measurements.score.cls)': {
-        data: [],
-      },
-      'performance_score(measurements.score.inp)': {
-        data: [],
-      },
-      'performance_score(measurements.score.ttfb)': {
-        data: [],
-      },
-      'count()': {
-        data: [],
-      },
-    },
-    isPending: false,
-    error: null,
-  })),
   useSpanMetricsSeries: jest.fn(() => ({
     data: {
       'cache_miss_rate()': {},

--- a/static/app/views/insights/browser/webVitals/components/charts/webVitalStatusLineChart.tsx
+++ b/static/app/views/insights/browser/webVitals/components/charts/webVitalStatusLineChart.tsx
@@ -19,7 +19,7 @@ import {
 // eslint-disable-next-line no-restricted-imports
 import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/insightsLineChartWidget';
 import type {DiscoverSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
-import {useMetricsSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
+import {useSpanSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import type {SubregionCode} from 'sentry/views/insights/types';
 import {SpanFields} from 'sentry/views/insights/types';
 
@@ -56,7 +56,7 @@ export function WebVitalStatusLineChart({
     data: timeseriesData,
     isLoading: isTimeseriesLoading,
     error: timeseriesError,
-  } = useMetricsSeries(
+  } = useSpanSeries(
     {
       search,
       yAxis: webVital ? [`p75(measurements.${webVital})`] : [],

--- a/static/app/views/insights/browser/webVitals/queries/rawWebVitalsQueries/useProjectRawWebVitalsValuesTimeseriesQuery.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/rawWebVitalsQueries/useProjectRawWebVitalsValuesTimeseriesQuery.tsx
@@ -3,7 +3,7 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {DEFAULT_QUERY_FILTER} from 'sentry/views/insights/browser/webVitals/settings';
 import type {BrowserType} from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
-import {useMetricsSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
+import {useSpanSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {SpanFields, type SubregionCode} from 'sentry/views/insights/types';
 
 type Props = {
@@ -30,7 +30,7 @@ export const useProjectRawWebVitalsValuesTimeseriesQuery = ({
     search.addDisjunctionFilterValues(SpanFields.USER_GEO_SUBREGION, subregions);
   }
 
-  const result = useMetricsSeries(
+  const result = useSpanSeries(
     {
       search: [DEFAULT_QUERY_FILTER, search.formatString()].join(' ').trim(),
       interval: getInterval(pageFilters.selection.datetime, 'spans-low'),

--- a/static/app/views/insights/browser/webVitals/queries/storedScoreQueries/useProjectWebVitalsScoresTimeseriesQuery.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/storedScoreQueries/useProjectWebVitalsScoresTimeseriesQuery.tsx
@@ -3,7 +3,7 @@ import type {Tag} from 'sentry/types/group';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {DEFAULT_QUERY_FILTER} from 'sentry/views/insights/browser/webVitals/settings';
 import type {BrowserType} from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
-import {useMetricsSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
+import {useSpanSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {SpanMetricsField, type SubregionCode} from 'sentry/views/insights/types';
 
 type Props = {
@@ -44,7 +44,7 @@ export const useProjectWebVitalsScoresTimeseriesQuery = ({
     search.addDisjunctionFilterValues(SpanMetricsField.BROWSER_NAME, browserTypes);
   }
 
-  const result = useMetricsSeries(
+  const result = useSpanSeries(
     {
       search: [DEFAULT_QUERY_FILTER, search.formatString()].join(' ').trim(),
       yAxis: [

--- a/static/app/views/insights/common/components/widgets/performanceScoreBreakdownChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/performanceScoreBreakdownChartWidget.tsx
@@ -14,7 +14,7 @@ import {InsightsTimeSeriesWidget} from 'sentry/views/insights/common/components/
 import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/components/widgets/types';
 import {
   type DiscoverSeries,
-  useMetricsSeries,
+  useSpanSeries,
 } from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {SpanFields, SpanMetricsField} from 'sentry/views/insights/types';
 
@@ -54,7 +54,7 @@ export default function PerformanceScoreBreakdownChartWidget(
     data: vitalScoresData,
     isLoading: areVitalScoresLoading,
     error: vitalScoresError,
-  } = useMetricsSeries(
+  } = useSpanSeries(
     {
       search,
       yAxis: [

--- a/static/app/views/insights/common/queries/useDiscoverSeries.ts
+++ b/static/app/views/insights/common/queries/useDiscoverSeries.ts
@@ -58,7 +58,7 @@ export const useSpanMetricsSeries = <Fields extends SpanMetricsProperty[]>(
 };
 
 export const useSpanSeries = <
-  Fields extends SpanMetricsProperty[] | SpanFields[] | SpanFunctions[] | string[],
+  Fields extends EAPSpanProperty[] | SpanFields[] | SpanFunctions[] | string[],
 >(
   options: UseMetricsSeriesOptions<Fields> = {},
   referrer: string,
@@ -67,20 +67,6 @@ export const useSpanSeries = <
   return useDiscoverSeries<Fields>(
     options,
     DiscoverDatasets.SPANS_EAP_RPC,
-    referrer,
-    pageFilters
-  );
-};
-
-export const useMetricsSeries = <Fields extends EAPSpanProperty[]>(
-  options: UseMetricsSeriesOptions<Fields> = {},
-  referrer: string,
-  pageFilters?: PageFilters
-) => {
-  const useEap = useInsightsEap();
-  return useDiscoverSeries<Fields>(
-    options,
-    useEap ? DiscoverDatasets.SPANS_EAP_RPC : DiscoverDatasets.METRICS,
     referrer,
     pageFilters
   );


### PR DESCRIPTION
Metrics dataset is no longer use with these hooks, this pr switching the hook to `useSpanSeries`