### PR TITLE
fix(seer): Bump concurrency for settings endpoint

### DIFF
--- a/src/sentry/api/endpoints/project_seer_preferences.py
+++ b/src/sentry/api/endpoints/project_seer_preferences.py
@@ -52,9 +52,9 @@ class ProjectSeerPreferencesEndpoint(ProjectEndpoint):
             RateLimitCategory.ORGANIZATION: RateLimit(limit=60, window=60),
         },
         "GET": {
-            RateLimitCategory.IP: RateLimit(limit=500, window=60),
-            RateLimitCategory.USER: RateLimit(limit=500, window=60),
-            RateLimitCategory.ORGANIZATION: RateLimit(limit=5000, window=60),
+            RateLimitCategory.IP: RateLimit(limit=1000, window=60, concurrent_limit=500),
+            RateLimitCategory.USER: RateLimit(limit=1000, window=60, concurrent_limit=500),
+            RateLimitCategory.ORGANIZATION: RateLimit(limit=5000, window=60, concurrent_limit=1000),
         },
     }
 


### PR DESCRIPTION
So we can load a lot of prefs at once