### PR TITLE
🔧 chore(aci): consolidate actions metric logs and ff checks

### DIFF
--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -436,36 +436,8 @@ def process_workflows(
 
     create_workflow_fire_histories(detector, actions, event_data, should_trigger_actions)
 
-    with sentry_sdk.start_span(op="workflow_engine.process_workflows.trigger_actions"):
-        if should_trigger_actions:
-            for action in actions:
-                task_params = build_trigger_action_task_params(action, detector, event_data)
-                trigger_action.delay(**task_params)
-        else:
-            logger.info(
-                "workflow_engine.triggered_actions",
-                extra={
-                    "action_ids": [action.id for action in actions],
-                    "event_data": asdict(event_data),
-                },
-            )
-            # If the feature flag is not enabled, only send a metric
-            for action in actions:
-                metrics_incr(
-                    "process_workflows.action_triggered",
-                    1,
-                    tags={"action_type": action.type},
-                )
-                logger.debug(
-                    "workflow_engine.action.would-trigger",
-                    extra={
-                        "action_id": action.id,
-                        "event_data": asdict(event_data),
-                    },
-                )
-
-    # in order to check if workflow engine is firing 1:1 with the old system, we must only count once rather than each action
-    if len(actions) > 0:
-        metrics_incr("process_workflows.fired_actions")
+    for action in actions:
+        task_params = build_trigger_action_task_params(action, detector, event_data)
+        trigger_action.delay(**task_params)
 
     return triggered_workflows

--- a/src/sentry/workflow_engine/tasks/actions.py
+++ b/src/sentry/workflow_engine/tasks/actions.py
@@ -92,7 +92,6 @@ def trigger_action(
 
     metrics.incr(
         "workflow_engine.tasks.trigger_action_task_started",
-        1,
         tags={"action_type": action.type, "detector_type": detector.type},
         sample_rate=1.0,
     )
@@ -115,7 +114,6 @@ def trigger_action(
         # Here, we probably build the event data from the activity
         raise NotImplementedError("Activity ID is not supported yet")
 
-    # Check feature flag inside the task
     should_trigger_actions = should_fire_workflow_actions(detector.project.organization)
 
     if should_trigger_actions:

--- a/src/sentry/workflow_engine/tasks/actions.py
+++ b/src/sentry/workflow_engine/tasks/actions.py
@@ -93,7 +93,7 @@ def trigger_action(
     metrics.incr(
         "workflow_engine.tasks.trigger_action_task_started",
         1,
-        tags={"action_type": action.type},
+        tags={"action_type": action.type, "detector_type": detector.type},
         sample_rate=1.0,
     )
 

--- a/src/sentry/workflow_engine/tasks/actions.py
+++ b/src/sentry/workflow_engine/tasks/actions.py
@@ -1,3 +1,5 @@
+from dataclasses import asdict
+
 from django.db.models import Value
 
 from sentry.eventstore.models import GroupEvent
@@ -75,6 +77,7 @@ def trigger_action(
     has_escalated: bool,
     workflow_env_id: int | None,
 ) -> None:
+    from sentry.notifications.notification_action.utils import should_fire_workflow_actions
 
     # XOR check to ensure exactly one of event_id or activity_id is provided
     if (event_id is not None) == (activity_id is not None):
@@ -89,7 +92,8 @@ def trigger_action(
 
     metrics.incr(
         "workflow_engine.tasks.trigger_action_task_started",
-        tags={"action_type": action.type, "detector_type": detector.type},
+        1,
+        tags={"action_type": action.type},
         sample_rate=1.0,
     )
 
@@ -107,18 +111,20 @@ def trigger_action(
             workflow_env_id=workflow_env_id,
         )
 
-        # TODO(iamrajjoshi): remove this once we are sure everything is working as expected
-        logger.info(
-            "workflow_engine.tasks.trigger_action.build_workflow_event_data_from_event",
-            extra={
-                "action_id": action_id,
-                "detector_id": detector_id,
-                "workflow_id": workflow_id,
-            },
-        )
-
     else:
         # Here, we probably build the event data from the activity
         raise NotImplementedError("Activity ID is not supported yet")
 
-    action.trigger(event_data, detector)
+    # Check feature flag inside the task
+    should_trigger_actions = should_fire_workflow_actions(detector.project.organization)
+
+    if should_trigger_actions:
+        action.trigger(event_data, detector)
+    else:
+        logger.info(
+            "workflow_engine.triggered_actions.dry-run",
+            extra={
+                "action_ids": [action_id],
+                "event_data": asdict(event_data),
+            },
+        )

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -567,13 +567,15 @@ class TestEvaluateWorkflowActionFilters(BaseWorkflowTest):
     @with_feature("organizations:workflow-engine-metric-alert-dual-processing-logs")
     @patch("sentry.utils.metrics.incr")
     def test_metrics_issue_dual_processing_metrics(self, mock_incr):
-        process_workflows(self.event_data)
+        with self.tasks():
+            process_workflows(self.event_data)
         mock_incr.assert_any_call(
-            "workflow_engine.process_workflows.fired_actions",
-            1,
+            "workflow_engine.tasks.trigger_action_task_started",
             tags={
                 "detector_type": self.detector.type,
+                "action_type": "slack",
             },
+            sample_rate=1.0,
         )
 
     def test_basic__no_filter(self) -> None:


### PR DESCRIPTION
After the actions task was rolled out, there were a few places where we logged/emitted metrics regarding actions being triggered.

this pr consolidates the metrics and logs &  triggers actions in all scenarios so we can load test.

specifically
- move the ff check to determine if we will dry run or actually fire actions into the task
- create only 1 log for dry run actions
- emit 1 metric in the task

We also have a separate log and metric when an action is actually fired, which are logs and metric that will exist in the system long term

https://github.com/getsentry/sentry/blob/2a01796bc99c7410ceb425e146a55117565cbab9/src/sentry/workflow_engine/models/action.py#L92-L104

the two metrics we now watch are
- `workflow_engine.tasks.trigger_action_task_started`
- `workflow_engine.action.trigger`