### PR TITLE
:wrench: chore(aci): delete `workflow-engine-test-notifications` FF

### DIFF
--- a/src/sentry/api/endpoints/project_rule_actions.py
+++ b/src/sentry/api/endpoints/project_rule_actions.py
@@ -5,7 +5,6 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
@@ -80,9 +79,6 @@ class ProjectRuleActionsEndpoint(ProjectEndpoint):
             event=test_event,
             group=test_event.group,
         )
-
-        if features.has("organizations:workflow-engine-test-notifications", project.organization):
-            return self.execute_future_on_test_event_workflow_engine(group_event, rule)
 
         return self.execute_future_on_test_event(group_event, rule)
 

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -501,8 +501,6 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:workflow-engine-trigger-actions", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable logs to debug metric alert dual processing
     manager.add("organizations:workflow-engine-metric-alert-dual-processing-logs", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Enable sending test notifications from the workflow_engine
-    manager.add("organizations:workflow-engine-test-notifications", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable dual writing for metric alert issues (see: alerts create issues)
     manager.add("organizations:workflow-engine-metric-alert-dual-write", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable Processing for Metric Alerts in the workflow_engine

--- a/tests/sentry/api/endpoints/test_project_rule_actions.py
+++ b/tests/sentry/api/endpoints/test_project_rule_actions.py
@@ -5,21 +5,12 @@ import sentry_sdk
 from sentry.integrations.jira.integration import JiraIntegration
 from sentry.integrations.pagerduty.client import PagerDutyClient
 from sentry.integrations.pagerduty.utils import PagerDutyServiceDict, add_service
-from sentry.notifications.notification_action.group_type_notification_registry import (
-    IssueAlertRegistryHandler,
-)
-from sentry.notifications.notification_action.issue_alert_registry import (
-    PagerDutyIssueAlertHandler,
-    PluginIssueAlertHandler,
-)
 from sentry.rules.actions.notify_event import NotifyEventAction
 from sentry.shared_integrations.exceptions import IntegrationFormError
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers import apply_feature_flag_on_cls
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
-from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 
 pytestmark = [requires_snuba]
 
@@ -111,172 +102,6 @@ class ProjectRuleActionsEndpointTest(APITestCase):
     @mock.patch.object(JiraIntegration, "create_issue")
     @mock.patch.object(sentry_sdk, "capture_exception")
     def test_sample_event_raises_exceptions(self, mock_sdk_capture, mock_create_issue):
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            self.jira_integration = self.create_provider_integration(
-                provider="jira", name="Jira", external_id="jira:1"
-            )
-            self.jira_integration.add_organization(self.organization, self.user)
-
-        form_errors = {"broken": "something went wrong"}
-        mock_create_issue.side_effect = IntegrationFormError(form_errors)
-        mock_sdk_capture.return_value = "abc-1234"
-        action_data = [
-            {
-                "id": "sentry.integrations.jira.notify_action.JiraCreateTicketAction",
-                "dynamic_form_fields": {
-                    "fake_field": "fake_value",
-                },
-            }
-        ]
-
-        response = self.get_error_response(
-            self.organization.slug, self.project.slug, actions=action_data
-        )
-        assert response.status_code == 400
-        assert mock_create_issue.call_count == 1
-        assert response.data == {"actions": [str(form_errors)]}
-
-        mock_create_issue.side_effect = Exception("Something went wrong")
-        response = self.get_error_response(
-            self.organization.slug, self.project.slug, actions=action_data
-        )
-        actions = response.data.get("actions")
-        assert actions is not None
-        assert actions == ["An unexpected error occurred. Error ID: 'abc-1234'"]
-
-    def test_no_events(self):
-        response = self.get_response(self.organization.slug, self.project.slug)
-        assert response.status_code == 400
-
-
-@apply_feature_flag_on_cls("organizations:workflow-engine-test-notifications")
-class ProjectRuleActionsEndpointWorkflowEngineTest(APITestCase, BaseWorkflowTest):
-    endpoint = "sentry-api-0-project-rule-actions"
-    method = "POST"
-
-    def setUp(self):
-        super().setUp()
-        self.login_as(self.user)
-        self.workflow = self.create_workflow()
-
-    def setup_pd_service(self) -> PagerDutyServiceDict:
-        service_info = {
-            "type": "service",
-            "integration_key": "PND123",
-            "service_name": "Sentry Service",
-        }
-        _integration, org_integration = self.create_provider_integration_for(
-            provider="pagerduty",
-            name="Example PagerDuty",
-            external_id="example-pd",
-            metadata={"services": [service_info]},
-            organization=self.organization,
-            user=self.user,
-        )
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            return add_service(
-                org_integration,
-                service_name=service_info["service_name"],
-                integration_key=service_info["integration_key"],
-            )
-
-    @mock.patch.object(NotifyEventAction, "after")
-    @mock.patch(
-        "sentry.notifications.notification_action.registry.issue_alert_handler_registry.get",
-        return_value=PluginIssueAlertHandler,
-    )
-    def test_actions(self, mock_get_handler, action):
-        action_data = [
-            {
-                "id": "sentry.rules.actions.notify_event.NotifyEventAction",
-            }
-        ]
-
-        self.get_success_response(self.organization.slug, self.project.slug, actions=action_data)
-        assert action.called
-
-    def test_unknown_action_returns_400(self):
-        action_data = [
-            {
-                "id": "sentry.rules.actions.fake_action.FakeAction",
-            }
-        ]
-
-        response = self.get_error_response(
-            self.organization.slug, self.project.slug, actions=action_data
-        )
-        assert response.status_code == 400
-
-    @mock.patch.object(PagerDutyClient, "send_trigger")
-    @mock.patch(
-        "sentry.notifications.notification_action.registry.group_type_notification_registry.get",
-        return_value=IssueAlertRegistryHandler,
-    )
-    @mock.patch(
-        "sentry.notifications.notification_action.registry.issue_alert_handler_registry.get",
-        return_value=PagerDutyIssueAlertHandler,
-    )
-    def test_name_action_default(
-        self, mock_get_issue_alert_handler, mock_get_group_type_handler, mock_send_trigger
-    ):
-        """
-        Tests that label will be used as 'Test Alert' if not present. Uses PagerDuty since those
-        notifications will differ based on the name of the alert.
-        """
-        service_info = self.setup_pd_service()
-        action_data = [
-            {
-                "account": service_info["integration_id"],
-                "service": service_info["id"],
-                "severity": "info",
-                "id": "sentry.integrations.pagerduty.notify_action.PagerDutyNotifyServiceAction",
-            }
-        ]
-        self.get_success_response(self.organization.slug, self.project.slug, actions=action_data)
-
-        assert mock_send_trigger.call_count == 1
-        pagerduty_data = mock_send_trigger.call_args.kwargs.get("data")
-        assert pagerduty_data["payload"]["summary"].startswith("[Test Alert]:")
-
-    @mock.patch.object(PagerDutyClient, "send_trigger")
-    @mock.patch(
-        "sentry.notifications.notification_action.registry.group_type_notification_registry.get",
-        return_value=IssueAlertRegistryHandler,
-    )
-    @mock.patch(
-        "sentry.notifications.notification_action.registry.issue_alert_handler_registry.get",
-        return_value=PagerDutyIssueAlertHandler,
-    )
-    def test_name_action_with_custom_name(
-        self, mock_get_issue_alert_handler, mock_get_group_type_handler, mock_send_trigger
-    ):
-        """
-        Tests that custom names can be provided to the test notification. Uses PagerDuty since those
-        notifications will differ based on the name of the alert.
-        """
-        service_info = self.setup_pd_service()
-        action_data = [
-            {
-                "account": service_info["integration_id"],
-                "service": service_info["id"],
-                "severity": "info",
-                "id": "sentry.integrations.pagerduty.notify_action.PagerDutyNotifyServiceAction",
-            }
-        ]
-        custom_alert_name = "Check #feed-issues"
-
-        self.get_success_response(
-            self.organization.slug, self.project.slug, actions=action_data, name=custom_alert_name
-        )
-        assert mock_send_trigger.call_count == 1
-        pagerduty_data = mock_send_trigger.call_args.kwargs.get("data")
-        assert pagerduty_data["payload"]["summary"].startswith(f"[{custom_alert_name}]:")
-
-    @mock.patch.object(JiraIntegration, "create_issue")
-    @mock.patch.object(sentry_sdk, "capture_exception")
-    def test_sample_event_raises_exceptions_workflow_engine(
-        self, mock_sdk_capture, mock_create_issue
-    ):
         with assume_test_silo_mode(SiloMode.CONTROL):
             self.jira_integration = self.create_provider_integration(
                 provider="jira", name="Jira", external_id="jira:1"

--- a/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
@@ -856,7 +856,6 @@ class TestFireActionsForGroups(TestDelayedWorkflowBase):
         assert group_to_groupevent == self.group_to_groupevent
 
     @patch("sentry.workflow_engine.tasks.actions.trigger_action.delay")
-    @with_feature("organizations:workflow-engine-action-trigger-async")
     @with_feature("organizations:workflow-engine-trigger-actions")
     def test_fire_actions_for_groups__fire_actions(self, mock_trigger):
         self._push_base_events()


### PR DESCRIPTION
i added this FF and logic back when i was testing actions before the system was ready. we don't need to do this now.