### PR TITLE
fix: Typo and breadcrumbs on log alerts

### DIFF
--- a/static/app/views/alerts/rules/metric/details/header.tsx
+++ b/static/app/views/alerts/rules/metric/details/header.tsx
@@ -67,6 +67,7 @@ function DetailsHeader({
       aggregate: rule.aggregate,
       dataset: rule.dataset,
       eventTypes: rule.eventTypes,
+      organization,
     });
 
   return (

--- a/static/app/views/alerts/wizard/panelContent.tsx
+++ b/static/app/views/alerts/wizard/panelContent.tsx
@@ -243,7 +243,7 @@ export const AlertWizardPanelContent: Record<AlertType, PanelContent> = {
   },
   trace_item_logs: {
     description: t(
-      'Alert on logs counts and log attributes such as severity, message and log level.'
+      'Alert on log counts and log attributes such as severity, message and log level.'
     ),
     examples: [t('When the number of error level logs exceeds 10 in 5 minutes.')],
     illustration: diagramThroughput,


### PR DESCRIPTION
<img width="345" height="86" alt="Screenshot 2025-07-16 at 3 57 11 PM" src="https://github.com/user-attachments/assets/6e1a2371-f6db-42bd-b42d-6c7724e10050" />
