### PR TITLE
fix(spans-migration): Round off percentiles instead of dropping the field

### DIFF
--- a/src/sentry/discover/translation/mep_to_eap.py
+++ b/src/sentry/discover/translation/mep_to_eap.py
@@ -44,6 +44,7 @@ def format_percentile_term(term):
         numeric_percentile_value = float(percentile_value)
         supported_percentiles = [0.5, 0.75, 0.90, 0.95, 0.99, 1.0]
         smallest_percentile_difference = 1.0
+        nearest_percentile = 0.5
 
         for percentile in supported_percentiles:
             percentile_difference = abs(numeric_percentile_value - percentile)
@@ -53,7 +54,7 @@ def format_percentile_term(term):
                 smallest_percentile_difference = percentile_difference
 
         new_function = percentile_replacement_function.get(nearest_percentile)
-    except (IndexError, ValueError):
+    except (IndexError, ValueError, NameError):
         return term
 
     return f"{new_function}({translated_column})"

--- a/src/sentry/discover/translation/mep_to_eap.py
+++ b/src/sentry/discover/translation/mep_to_eap.py
@@ -23,7 +23,6 @@ COLUMNS_TO_DROP = (
     "count_miserable",
     "count_web_vitals",
     "last_seen",
-    "percentile",
     "total.count",
 )
 
@@ -43,11 +42,18 @@ def format_percentile_term(term):
         translated_column = column_switcheroo(args[0])[0]
         percentile_value = args[1]
         numeric_percentile_value = float(percentile_value)
-        new_function = percentile_replacement_function.get(numeric_percentile_value, function)
-    except (IndexError, ValueError):
-        return term
+        supported_percentiles = [0.5, 0.75, 0.90, 0.95, 0.99, 1.0]
+        smallest_percentile_difference = 1.0
 
-    if new_function == function:
+        for percentile in supported_percentiles:
+            percentile_difference = abs(numeric_percentile_value - percentile)
+            # we're rounding up to the nearest supported percentile if it's the midpoint of two supported percentiles
+            if percentile_difference <= smallest_percentile_difference:
+                nearest_percentile = percentile
+                smallest_percentile_difference = percentile_difference
+
+        new_function = percentile_replacement_function.get(nearest_percentile)
+    except (IndexError, ValueError):
         return term
 
     return f"{new_function}({translated_column})"

--- a/tests/sentry/discover/translation/test_mep_to_eap.py
+++ b/tests/sentry/discover/translation/test_mep_to_eap.py
@@ -52,7 +52,7 @@ from sentry.discover.translation.mep_to_eap import QueryParts, translate_mep_to_
         ),
         pytest.param(
             "percentile(transaction.duration,0.5000):>100 AND percentile(transaction.duration, 0.25):>20",
-            "(p50(span.duration):>100 AND percentile(span.duration, 0.25):>20) AND is_transaction:1",
+            "(p50(span.duration):>100 AND p50(span.duration):>20) AND is_transaction:1",
         ),
         pytest.param(
             "user_misery():>0.5 OR apdex():>0.5",
@@ -102,8 +102,18 @@ def test_mep_to_eap_simple_query(input: str, expected: str):
             ["avgIf(span.duration,greater,300)"],
         ),
         pytest.param(
-            ["percentile(transaction.duration,0.5000)", "percentile(transaction.duration,0.94)"],
-            ["p50(span.duration)"],
+            [
+                "percentile(transaction.duration,0.5000)",
+                "percentile(transaction.duration,0.94)",
+                "percentile(transaction.duration,0.9999)",
+                "percentile(transaction.duration, 0.625)",
+            ],
+            [
+                "p50(span.duration)",
+                "p95(span.duration)",
+                "p100(span.duration)",
+                "p75(span.duration)",
+            ],
         ),
         pytest.param(
             ["user_misery(300)", "apdex(300)"],


### PR DESCRIPTION
Instead of dropping all percentile fields that don't align with supported fields, I'm rounding them off to the closest supported field. For example, `percentile(transaction.duration,0.94)` would map to `p95(span.duration)`. 
intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
