### PR TITLE
fix(teamStats): Fix timeouts on Unresolved Issues graph

### DIFF
--- a/src/sentry/api/endpoints/team_all_unresolved_issues.py
+++ b/src/sentry/api/endpoints/team_all_unresolved_issues.py
@@ -90,9 +90,11 @@ def calculate_unresolved_counts(
         .values("project", "group_id", "bucket", "state")
     )
 
-    most_recent_group_state = defaultdict(lambda: "other")
+    most_recent_group_state: defaultdict[str, str] = defaultdict(lambda: "other")
     # Project => Bucket => State => Count
-    deduping_map = defaultdict(lambda: defaultdict(lambda: defaultdict(int)))
+    deduping_map: defaultdict[str, defaultdict[str, defaultdict[str, int]]] = defaultdict(
+        lambda: defaultdict(lambda: defaultdict(int))
+    )
     for r in bucketed_issues:
         # Don't process the row if it doesn't set the group to open or closed.
         if r["state"] == "other":

--- a/src/sentry/api/endpoints/team_all_unresolved_issues.py
+++ b/src/sentry/api/endpoints/team_all_unresolved_issues.py
@@ -86,6 +86,7 @@ def calculate_unresolved_counts(
         .order_by(
             "group_id",
             "bucket",
+            "id",
         )
         .values("project", "group_id", "bucket", "state")
     )

--- a/src/sentry/api/endpoints/team_all_unresolved_issues.py
+++ b/src/sentry/api/endpoints/team_all_unresolved_issues.py
@@ -88,7 +88,7 @@ def calculate_unresolved_counts(
             "bucket",
             "id",
         )
-        .values("project", "group_id", "bucket", "state")
+        .values("project", "group_id", "bucket", "state")[:200_000]
     )
 
     most_recent_group_state: defaultdict[str, str] = defaultdict(lambda: "other")

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1936,7 +1936,6 @@ SENTRY_EARLY_FEATURES = {
 SENTRY_FEATURES: dict[str, bool | None] = {
     # NOTE: Don't add feature defaults down here! Please add a default to
     # the manager.add() call that defines the feature.
-    "organizations:team-insights": True,
 }
 
 # Default time zone for localization in the UI.

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1936,6 +1936,7 @@ SENTRY_EARLY_FEATURES = {
 SENTRY_FEATURES: dict[str, bool | None] = {
     # NOTE: Don't add feature defaults down here! Please add a default to
     # the manager.add() call that defines the feature.
+    "organizations:team-insights": True,
 }
 
 # Default time zone for localization in the UI.

--- a/tests/sentry/api/endpoints/test_team_all_unresolved_issues.py
+++ b/tests/sentry/api/endpoints/test_team_all_unresolved_issues.py
@@ -1,6 +1,5 @@
 from datetime import datetime, timedelta, timezone
 
-import pytest
 from django.utils.timezone import now
 
 from sentry.models.group import GroupStatus
@@ -15,7 +14,6 @@ from sentry.testutils.helpers.datetime import before_now, freeze_time
 class TeamIssueBreakdownTest(APITestCase):
     endpoint = "sentry-api-0-team-all-unresolved-issues"
 
-    @pytest.mark.xfail(reason="flakey")
     def test_status_format(self):
         project1 = self.create_project(teams=[self.team])
         group1_1 = self.create_group(project=project1, first_seen=before_now(days=40))


### PR DESCRIPTION
The Unresolved Issues graph is currently hanging, then eventually erroring out. Investigating, it seems like it's the DB query timing out. Signs point to that coming from the large number of subqueries involved in the `GroupHistory` query.

Those subqueries exist because `GroupHistory` may contain multiple rows with the same `status` for any given `group_id` (or with different `status` in our same "state" category), so we need to deduplicate to only rows that change between an open or closed state.

The current solution (subqueries) is inefficient on large # of group_ids, which can lead to timeouts.

Another option would be to use `DISTINCT ON` queries to ensure we only get one row per each `(group_id, open/closed state)` pair. Unfortunately Django does not currently support `annotate()` and `distinct(fields)` together.

Instead, what we do here is pull additional data and do the deduplication logic in Python.

Test plan: loads without error in my sandbox.
