### PR TITLE
fix(admin): Prevent stats error on empty assignment

### DIFF
--- a/static/gsAdmin/components/customers/customerStats.tsx
+++ b/static/gsAdmin/components/customers/customerStats.tsx
@@ -265,7 +265,9 @@ export function populateChartData(
     totalDropped!.subSeries.push({seriesName: data.seriesName, data: data.data});
 
     for (const [dataIndex, dataPoint] of data.data.entries()) {
-      totalDropped!.data[dataIndex]!.value += dataPoint.value;
+      if (totalDropped?.data[dataIndex]) {
+        totalDropped.data[dataIndex].value += dataPoint.value;
+      }
     }
   }
 


### PR DESCRIPTION
fixes JAVASCRIPT-329P

could error when a chart only has partial data for a period