### PR TITLE
chore(deletions): Increase task duration for group deletions & some new constants

### DIFF
--- a/src/sentry/deletions/defaults/group.py
+++ b/src/sentry/deletions/defaults/group.py
@@ -24,6 +24,9 @@ from ..manager import DeletionTaskManager
 
 logger = logging.getLogger(__name__)
 
+GROUP_CHUNK_SIZE = 10
+EVENTS_CHUNK_SIZE = 1000
+
 # Group models that relate only to groups and not to events. We assume those to
 # be safe to delete/mutate within a single transaction for user-triggered
 # actions (delete/reprocess/merge/unmerge)
@@ -66,7 +69,7 @@ class EventsBaseDeletionTask(BaseDeletionTask[Group]):
     """
 
     # Number of events fetched from eventstore per chunk() call.
-    DEFAULT_CHUNK_SIZE = 10000
+    DEFAULT_CHUNK_SIZE = EVENTS_CHUNK_SIZE
     referrer = "deletions.group"
     dataset: Dataset
 
@@ -251,9 +254,9 @@ class IssuePlatformEventsDeletionTask(EventsBaseDeletionTask):
 
 
 class GroupDeletionTask(ModelDeletionTask[Group]):
-    # Delete groups in blocks of 1000. Using 1000 aims to
-    # balance the number of snuba replacements with memory limits.
-    DEFAULT_CHUNK_SIZE = 1000
+    # Delete groups in blocks of GROUP_CHUNK_SIZE. Using GROUP_CHUNK_SIZE aims to
+    # balance the number of Snuba replacements with memory limits.
+    DEFAULT_CHUNK_SIZE = GROUP_CHUNK_SIZE
 
     def delete_bulk(self, instance_list: Sequence[Group]) -> bool:
         """

--- a/src/sentry/deletions/defaults/group.py
+++ b/src/sentry/deletions/defaults/group.py
@@ -24,7 +24,7 @@ from ..manager import DeletionTaskManager
 
 logger = logging.getLogger(__name__)
 
-GROUP_CHUNK_SIZE = 1000
+GROUP_CHUNK_SIZE = 100
 EVENT_CHUNK_SIZE = 10000
 # https://github.com/getsentry/snuba/blob/54feb15b7575142d4b3af7f50d2c2c865329f2db/snuba/datasets/configuration/issues/storages/search_issues.yaml#L139
 ISSUE_PLATFORM_MAX_ROWS_TO_DELETE = 2000000

--- a/src/sentry/deletions/defaults/group.py
+++ b/src/sentry/deletions/defaults/group.py
@@ -24,8 +24,8 @@ from ..manager import DeletionTaskManager
 
 logger = logging.getLogger(__name__)
 
-GROUP_CHUNK_SIZE = 10
-EVENTS_CHUNK_SIZE = 1000
+GROUP_CHUNK_SIZE = 1000
+EVENT_CHUNK_SIZE = 10000
 
 # Group models that relate only to groups and not to events. We assume those to
 # be safe to delete/mutate within a single transaction for user-triggered
@@ -69,7 +69,7 @@ class EventsBaseDeletionTask(BaseDeletionTask[Group]):
     """
 
     # Number of events fetched from eventstore per chunk() call.
-    DEFAULT_CHUNK_SIZE = EVENTS_CHUNK_SIZE
+    DEFAULT_CHUNK_SIZE = 10000
     referrer = "deletions.group"
     dataset: Dataset
 
@@ -259,7 +259,7 @@ class IssuePlatformEventsDeletionTask(EventsBaseDeletionTask):
 
 class GroupDeletionTask(ModelDeletionTask[Group]):
     # Delete groups in blocks of GROUP_CHUNK_SIZE. Using GROUP_CHUNK_SIZE aims to
-    # balance the number of Snuba replacements with memory limits.
+    # balance the number of snuba replacements with memory limits.
     DEFAULT_CHUNK_SIZE = GROUP_CHUNK_SIZE
 
     def delete_bulk(self, instance_list: Sequence[Group]) -> bool:

--- a/src/sentry/deletions/tasks/groups.py
+++ b/src/sentry/deletions/tasks/groups.py
@@ -4,6 +4,7 @@ from uuid import uuid4
 
 import sentry_sdk
 
+from sentry.deletions.defaults.group import GROUP_CHUNK_SIZE
 from sentry.deletions.tasks.scheduled import MAX_RETRIES, logger
 from sentry.exceptions import DeleteAborted
 from sentry.silo.base import SiloMode
@@ -39,8 +40,7 @@ def delete_groups(
     from sentry import deletions, eventstream
     from sentry.models.group import Group
 
-    max_batch_size = 100
-    current_batch, rest = object_ids[:max_batch_size], object_ids[max_batch_size:]
+    current_batch, rest = object_ids[:GROUP_CHUNK_SIZE], object_ids[GROUP_CHUNK_SIZE:]
 
     # Select first_group from current_batch to ensure project_id tag reflects the current batch
     first_group = Group.objects.filter(id__in=current_batch).order_by("id").first()

--- a/src/sentry/taskworker/namespaces.py
+++ b/src/sentry/taskworker/namespaces.py
@@ -21,7 +21,7 @@ crons_tasks = taskregistry.create_namespace("crons", app_feature="crons")
 
 deletion_tasks = taskregistry.create_namespace(
     "deletions",
-    processing_deadline_duration=60 * 4,
+    processing_deadline_duration=60 * 6,
     app_feature="shared",
 )
 


### PR DESCRIPTION
Some tasks to delete groups are reaching the four-minute `ProcessingDeadlineExceeded` for the namespace.

Fixes [SENTRY-41FE](https://sentry.sentry.io/issues/6683289583/)