### PR TITLE
fix(issues): Remove `stream_index` analytic query param

### DIFF
--- a/static/app/components/eventOrGroupHeader.tsx
+++ b/static/app/components/eventOrGroupHeader.tsx
@@ -26,7 +26,6 @@ interface EventOrGroupHeaderProps {
   eventId?: string;
   hideIcons?: boolean;
   hideLevel?: boolean;
-  index?: number;
   /** Group link clicked */
   onClick?: () => void;
   query?: string;
@@ -76,7 +75,6 @@ function usePreloadGroupOnHover({
  */
 function EventOrGroupHeader({
   data,
-  index,
   query,
   onClick,
   hideIcons,
@@ -126,7 +124,6 @@ function EventOrGroupHeader({
       data,
       eventId,
       referrer: source,
-      streamIndex: index,
       location,
       query,
     });

--- a/static/app/components/stream/group.spec.tsx
+++ b/static/app/components/stream/group.spec.tsx
@@ -237,7 +237,6 @@ describe('StreamGroup', function () {
           project: '13',
           query: 'is:unresolved is:for_review assigned_or_suggested:[me, none]',
           referrer: 'issue-stream',
-          stream_index: undefined,
         },
       });
     });

--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -71,7 +71,6 @@ type Props = {
   customStatsPeriod?: TimePeriodType;
   displayReprocessingLayout?: boolean;
   hasGuideAnchor?: boolean;
-  index?: number;
   memberList?: User[];
   onPriorityChange?: (newPriority: PriorityLevel) => void;
   query?: string;
@@ -186,7 +185,6 @@ function StreamGroup({
   customStatsPeriod,
   displayReprocessingLayout,
   hasGuideAnchor,
-  index,
   memberList,
   query,
   queryFilterDescription,
@@ -367,7 +365,6 @@ function StreamGroup({
       pathname: `/organizations/${organization.slug}/issues/${group.id}/events/`,
       query: {
         referrer,
-        stream_index: index,
         ...commonQuery,
         query: filteredQuery,
       },
@@ -559,7 +556,6 @@ function StreamGroup({
           data: group,
           organization,
           referrer,
-          streamIndex: index,
           location,
           query,
         })
@@ -583,7 +579,7 @@ function StreamGroup({
         />
       )}
       <GroupSummary canSelect={canSelect}>
-        <EventOrGroupHeader index={index} data={group} query={query} source={referrer} />
+        <EventOrGroupHeader data={group} query={query} source={referrer} />
         <EventOrGroupExtraDetails data={group} showLifetime={false} />
       </GroupSummary>
       {hasGuideAnchor && <GuideAnchor target="issue_stream" />}

--- a/static/app/views/alerts/rules/issue/previewTable.tsx
+++ b/static/app/views/alerts/rules/issue/previewTable.tsx
@@ -56,12 +56,11 @@ function PreviewTable({
       );
     }
     const memberList = indexMembersByProject(members);
-    return previewGroups.map((id, index) => {
+    return previewGroups.map(id => {
       const group = GroupStore.get(id) as Group | undefined;
 
       return (
         <StreamGroup
-          index={index}
           key={id}
           id={id}
           hasGuideAnchor={false}

--- a/static/app/views/insights/sessions/charts/chartWithIssues.tsx
+++ b/static/app/views/insights/sessions/charts/chartWithIssues.tsx
@@ -101,9 +101,9 @@ export default function ChartWithIssues(props: Props) {
 
   const footer = hasData && recentIssues && (
     <FooterIssues>
-      {recentIssues.map((group, index) => (
+      {recentIssues.map(group => (
         <GroupWrapper canSelect key={group.id}>
-          <EventOrGroupHeader index={index} data={group} source={'session-health'} />
+          <EventOrGroupHeader data={group} source={'session-health'} />
           <EventOrGroupExtraDetails data={group} showLifetime={false} />
         </GroupWrapper>
       ))}

--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -519,8 +519,7 @@ function useTrackView({
   project?: Project;
 }) {
   const location = useLocation();
-  const {alert_date, alert_rule_id, alert_type, ref_fallback, stream_index, query} =
-    location.query;
+  const {alert_date, alert_rule_id, alert_type, ref_fallback, query} = location.query;
   const groupEventType = useLoadedEventType();
   const user = useUser();
   const hasStreamlinedUI = useHasStreamlinedUI();
@@ -531,7 +530,6 @@ function useTrackView({
     ...getAnalyticsDataForEvent(event),
     ...getAnalyicsDataForProject(project),
     tab,
-    stream_index: typeof stream_index === 'string' ? Number(stream_index) : undefined,
     query: typeof query === 'string' ? query : undefined,
     // Alert properties track if the user came from email/slack alerts
     alert_date:

--- a/static/app/views/issueList/groupListBody.tsx
+++ b/static/app/views/issueList/groupListBody.tsx
@@ -117,13 +117,12 @@ function GroupList({
 
   return (
     <PanelBody>
-      {groupIds.map((id, index) => {
+      {groupIds.map(id => {
         const hasGuideAnchor = id === topIssue;
         const group = GroupStore.get(id) as Group | undefined;
 
         return (
           <StreamGroup
-            index={index}
             key={id}
             id={id}
             statsPeriod={groupStatsPeriod}

--- a/static/app/views/issueList/utils.tsx
+++ b/static/app/views/issueList/utils.tsx
@@ -233,7 +233,6 @@ export function createIssueLink({
   data,
   eventId,
   referrer,
-  streamIndex,
   location,
   query,
 }: {
@@ -243,7 +242,6 @@ export function createIssueLink({
   eventId?: string;
   query?: string;
   referrer?: string;
-  streamIndex?: number;
 }): LocationDescriptorObject {
   const {id, project} = data as Group;
   const {eventID: latestEventId, groupID} = data as Event;
@@ -257,7 +255,6 @@ export function createIssueLink({
     }/${finalEventId ? `events/${finalEventId}/` : ''}`,
     query: {
       referrer: referrer || 'event-or-group-header',
-      stream_index: streamIndex,
       query,
       // Add environment to the query if it was selected
       ...(location.query.environment === undefined


### PR DESCRIPTION
We were working on adjusting our sorting at the time - tracking how deep the user was in the issues stream. Clean up extra query param
