### PR TITLE
fix(grouping): Handle missing configs better

### DIFF
--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -192,7 +192,7 @@ def get_grouping_config_dict_for_event_data(data: NodeData, project: Project) ->
 
 def _get_default_enhancements(config_id: str | None = None) -> str:
     base: str | None = DEFAULT_ENHANCEMENTS_BASE
-    if config_id is not None:
+    if config_id is not None and config_id in CONFIGURATIONS.keys():
         base = CONFIGURATIONS[config_id].enhancements_base
     return Enhancements.from_rules_text("", bases=[base] if base else []).base64_string
 

--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -145,6 +145,7 @@ class ProjectGroupingConfigLoader(GroupingConfigLoader):
         return project.get_option(
             self.option_name,
             validate=lambda x: isinstance(x, str) and x in CONFIGURATIONS,
+            default=DEFAULT_GROUPING_CONFIG,
         )
 
 

--- a/src/sentry/grouping/ingest/config.py
+++ b/src/sentry/grouping/ingest/config.py
@@ -146,4 +146,8 @@ def is_in_transition(project: Project) -> bool:
     secondary_grouping_config = project.get_option("sentry:secondary_grouping_config")
     secondary_grouping_expiry = project.get_option("sentry:secondary_grouping_expiry")
 
-    return bool(secondary_grouping_config) and (secondary_grouping_expiry or 0) >= time.time()
+    return (
+        bool(secondary_grouping_config)
+        and secondary_grouping_config in CONFIGURATIONS.keys()
+        and (secondary_grouping_expiry or 0) >= time.time()
+    )


### PR DESCRIPTION
This makes a number of small changes to improve the way we handle grouping configs we don't recognize. Once these are in place, we'll be able to delete a config without worrying about whether or not there are still projects which have it listed as the primary or secondary config.

Already, when we load a grouping config (either the primary or the secondary), we [validate the stored config id](https://github.com/getsentry/sentry/blob/e41ff5f479cc39ed0b3335138f6ce1b42323650b/src/sentry/grouping/api.py#L144-L148), and return the option default for that id if what's stored isn't in our canonical list. For the primary grouping config, the default is `DEFAULT_GROUPING_CONFIG`, but for the secondary grouping config, it's `None`. This latter default has the potential to crash grouping, because there are a number of places where we assume we have a valid, non-None id.

To fix this problem (and protect against similar situations in general), this PR does a few things:

- We only run secondary grouping (and therefore only care about the stored option value) if we see that the project is in transition. We now validate the secondary config id as part of that check.
- The config loader's `_get_config_id` method now has a default return value (the default grouping config) for cases in which the stored id is invalid.
- We now only try to load fingerprinting bases for config ids we recognize.

Invalid primary config handling was already tested in `EventManagerGroupingTest.test_loads_default_config_if_stored_config_option_is_invalid` [here](https://github.com/getsentry/sentry/blob/92f300164af5982716023060cc49dda4b11afbfe/tests/sentry/event_manager/test_event_manager_grouping.py#L137-L144). This PR adds a complementary test, `SecondaryGroupingTest.test_no_error_with_unknown_secondary_config`, for invalid secondary configs.