### PR TITLE
fix(test): thread leak: trends API thread pool

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trends_v2.py
+++ b/src/sentry/api/endpoints/organization_events_trends_v2.py
@@ -42,8 +42,6 @@ DEFAULT_RATE_LIMIT_WINDOW = 1
 DEFAULT_CONCURRENT_RATE_LIMIT = 15
 ORGANIZATION_RATE_LIMIT = 30
 
-_query_thread_pool = ThreadPoolExecutor()
-
 
 @region_silo_endpoint
 class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsV2EndpointBase):
@@ -278,7 +276,8 @@ class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsV2EndpointBase)
             ]
 
             # send the data to microservice
-            results = list(_query_thread_pool.map(detect_breakpoints, trends_requests))
+            with ThreadPoolExecutor(thread_name_prefix=__name__) as query_thread_pool:
+                results = list(query_thread_pool.map(detect_breakpoints, trends_requests))
             trend_results = []
 
             # append all the results


### PR DESCRIPTION
Replace module-level ThreadPoolExecutor instances with local instances that are properly closed using context managers. Module-level thread pools cause thread leaks that lead to test flakiness and unhelpful nondeterminism in production. While the production cost of spinning up thread workers is minimal, proper cleanup ensures consistent behavior and prevents resource accumulation over time.