### PR TITLE
fix(test): thread leak: organization trace thread pool

### DIFF
--- a/src/sentry/api/endpoints/organization_trace.py
+++ b/src/sentry/api/endpoints/organization_trace.py
@@ -30,8 +30,6 @@ from sentry.snuba.spans_rpc import run_trace_query
 from sentry.utils.numbers import base32_encode
 from sentry.utils.validators import is_event_id
 
-# 1 worker each for spans, errors, performance issues
-_query_thread_pool = ThreadPoolExecutor(max_workers=3)
 # Mostly here for testing
 ERROR_LIMIT = 10_000
 
@@ -335,22 +333,25 @@ class OrganizationTraceEndpoint(OrganizationEventsV2EndpointBase):
         errors_query = self.errors_query(snuba_params, trace_id, error_id)
         occurrence_query = self.perf_issues_query(snuba_params, trace_id)
 
-        spans_future = _query_thread_pool.submit(
-            run_trace_query,
-            trace_id,
-            snuba_params,
-            Referrer.API_TRACE_VIEW_GET_EVENTS.value,
-            SearchResolverConfig(),
-            additional_attributes,
-        )
-        errors_future = _query_thread_pool.submit(
-            self.run_errors_query,
-            errors_query,
-        )
-        occurrence_future = _query_thread_pool.submit(
-            self.run_perf_issues_query,
-            occurrence_query,
-        )
+        # 1 worker each for spans, errors, performance issues
+        query_thread_pool = ThreadPoolExecutor(thread_name_prefix=__name__, max_workers=3)
+        with query_thread_pool:
+            spans_future = query_thread_pool.submit(
+                run_trace_query,
+                trace_id,
+                snuba_params,
+                Referrer.API_TRACE_VIEW_GET_EVENTS.value,
+                SearchResolverConfig(),
+                additional_attributes,
+            )
+            errors_future = query_thread_pool.submit(
+                self.run_errors_query,
+                errors_query,
+            )
+            occurrence_future = query_thread_pool.submit(
+                self.run_perf_issues_query,
+                occurrence_query,
+            )
 
         spans_data = spans_future.result()
         errors_data = errors_future.result()


### PR DESCRIPTION
Replace module-level ThreadPoolExecutor instances with local instances that are properly closed using context managers. Module-level thread pools cause thread leaks that lead to test flakiness and unhelpful nondeterminism in production. While the production cost of spinning up thread workers is minimal, proper cleanup ensures consistent behavior and prevents resource accumulation over time.