### PR TITLE
fix(test): thread leak: trace meta

### DIFF
--- a/src/sentry/api/endpoints/organization_trace_meta.py
+++ b/src/sentry/api/endpoints/organization_trace_meta.py
@@ -21,9 +21,6 @@ from sentry.snuba.dataset import Dataset
 from sentry.snuba.referrer import Referrer
 from sentry.snuba.rpc_dataset_common import TableQuery, run_bulk_table_queries
 
-# 1 worker for each query
-_query_thread_pool = ThreadPoolExecutor(max_workers=3)
-
 
 class SerializedResponse(TypedDict):
     logs: int
@@ -153,13 +150,19 @@ class OrganizationTraceMetaEndpoint(OrganizationEventsV2EndpointBase):
                 query=f"trace:{trace_id}",
                 limit=1,
             )
-            spans_future = _query_thread_pool.submit(self.query_span_data, trace_id, snuba_params)
-            perf_issues_future = _query_thread_pool.submit(
-                count_performance_issues, trace_id, snuba_params
-            )
-            errors_future = _query_thread_pool.submit(
-                errors_query.run_query, Referrer.API_TRACE_VIEW_GET_EVENTS.value
-            )
+            with ThreadPoolExecutor(
+                thread_name_prefix=__name__,
+                max_workers=3,
+            ) as query_thread_pool:
+                spans_future = query_thread_pool.submit(
+                    self.query_span_data, trace_id, snuba_params
+                )
+                perf_issues_future = query_thread_pool.submit(
+                    count_performance_issues, trace_id, snuba_params
+                )
+                errors_future = query_thread_pool.submit(
+                    errors_query.run_query, Referrer.API_TRACE_VIEW_GET_EVENTS.value
+                )
 
             results = spans_future.result()
             perf_issues = perf_issues_future.result()


### PR DESCRIPTION
Replace module-level ThreadPoolExecutor instances with local instances that are properly closed using context managers. Module-level thread pools cause thread leaks that lead to test flakiness and unhelpful nondeterminism in production. While the production cost of spinning up thread workers is minimal, proper cleanup ensures consistent behavior and prevents resource accumulation over time.