### PR TITLE
fix(aci): Retry process_workflows_event timeouts

### DIFF
--- a/src/sentry/workflow_engine/tasks/workflows.py
+++ b/src/sentry/workflow_engine/tasks/workflows.py
@@ -15,7 +15,7 @@ from sentry.types.activity import ActivityType
 from sentry.utils import metrics
 from sentry.workflow_engine.models import Detector
 from sentry.workflow_engine.processors.workflow import process_workflows
-from sentry.workflow_engine.tasks.utils import build_workflow_event_data_from_event
+from sentry.workflow_engine.tasks.utils import build_workflow_event_data_from_event, retry_timeouts
 from sentry.workflow_engine.types import WorkflowEventData
 from sentry.workflow_engine.utils import log_context
 
@@ -128,6 +128,7 @@ def workflow_status_update_handler(
         ),
     ),
 )
+@retry_timeouts
 @retry
 def process_workflows_event(
     project_id: int,


### PR DESCRIPTION
Now that we're on taskbroker, we need this to preserve the old behavior.

