### PR TITLE
:wrench: chore(aci): gate actions task so it doesn't fire for metric issues

### DIFF
--- a/src/sentry/digests/notifications.py
+++ b/src/sentry/digests/notifications.py
@@ -235,7 +235,6 @@ def get_rules_from_workflows(project: Project, workflow_ids: set[int]) -> dict[i
                     Exception(f"Rule {rule.id} does not have a legacy_rule_id"),
                     level="warning",
                 )
-                raise
 
             rules[workflow_id] = rule
     return rules
@@ -278,7 +277,6 @@ def build_digest(project: Project, records: Sequence[Record]) -> DigestInfo:
                 Exception(f"Rule {rule.id} does not have a legacy_rule_id"),
                 level="warning",
             )
-            raise
 
     rules.update(get_rules_from_workflows(project, workflow_ids))
 

--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -25,6 +25,7 @@ from sentry.incidents.endpoints.serializers.incident import (
     DetailedIncidentSerializerResponse,
     IncidentSerializer,
 )
+from sentry.incidents.grouptype import MetricIssue
 from sentry.incidents.models.alert_rule import (
     AlertRuleDetectionType,
     AlertRuleThresholdType,
@@ -581,7 +582,7 @@ def generate_incident_trigger_email_context(
             ),
             query=urlencode(alert_link_params),
         )
-    elif should_fire_workflow_actions(organization):
+    elif should_fire_workflow_actions(organization, MetricIssue.type_id):
         # lookup the incident_id from the open_period_identifier
         try:
             incident_group_open_period = IncidentGroupOpenPeriod.objects.get(

--- a/src/sentry/integrations/discord/message_builder/issues.py
+++ b/src/sentry/integrations/discord/message_builder/issues.py
@@ -61,7 +61,7 @@ class DiscordIssuesMessageBuilder(DiscordMessageBuilder):
             rule_environment_id = self.rules[0].environment_id
             if features.has("organizations:workflow-engine-ui-links", self.group.organization):
                 rule_id = int(get_key_from_rule_data(self.rules[0], "workflow_id"))
-            elif should_fire_workflow_actions(self.group.organization):
+            elif should_fire_workflow_actions(self.group.organization, self.group.type):
                 rule_id = int(get_key_from_rule_data(self.rules[0], "legacy_rule_id"))
             else:
                 rule_id = self.rules[0].id

--- a/src/sentry/integrations/messaging/message_builder.py
+++ b/src/sentry/integrations/messaging/message_builder.py
@@ -107,10 +107,10 @@ def fetch_environment_name(rule_env: int) -> str | None:
 
 
 def get_rule_environment_param_from_rule(
-    rule_id: int, rule_environment_id: int | None, organization: Organization
+    rule_id: int, rule_environment_id: int | None, organization: Organization, type_id: int
 ) -> dict[str, str]:
     params = {}
-    if should_fire_workflow_actions(organization):
+    if should_fire_workflow_actions(organization, type_id):
         if (
             rule_environment_id is not None
             and (environment_name := fetch_environment_name(rule_environment_id)) is not None
@@ -147,7 +147,9 @@ def get_title_link(
     # add in rule id if we have it
     if rule_id:
         other_params.update(
-            get_rule_environment_param_from_rule(rule_id, rule_environment_id, group.organization)
+            get_rule_environment_param_from_rule(
+                rule_id, rule_environment_id, group.organization, group.type
+            )
         )
         # hard code for issue alerts
         other_params["alert_rule_id"] = str(rule_id)
@@ -270,7 +272,7 @@ def build_attachment_replay_link(
 def build_rule_url(rule: Any, group: Group, project: Project) -> str:
     org_slug = group.organization.slug
     project_slug = project.slug
-    if should_fire_workflow_actions(group.organization):
+    if should_fire_workflow_actions(group.organization, group.type):
         rule_id = get_key_from_rule_data(rule, "legacy_rule_id")
         rule_url = f"/organizations/{org_slug}/alerts/rules/{project_slug}/{rule_id}/details/"
     else:

--- a/src/sentry/integrations/metric_alerts.py
+++ b/src/sentry/integrations/metric_alerts.py
@@ -222,8 +222,10 @@ def incident_attachment_info(
     if notification_uuid:
         title_link_params["notification_uuid"] = notification_uuid
 
+    from sentry.incidents.grouptype import MetricIssue
+
     # TODO(iamrajjoshi): This will need to be updated once we plan out Metric Alerts rollout
-    if should_fire_workflow_actions(organization, 8001):
+    if should_fire_workflow_actions(organization, MetricIssue.type_id):
         try:
             alert_rule_id = AlertRuleDetector.objects.values_list("alert_rule_id", flat=True).get(
                 detector_id=alert_context.action_identifier_id

--- a/src/sentry/integrations/metric_alerts.py
+++ b/src/sentry/integrations/metric_alerts.py
@@ -222,7 +222,8 @@ def incident_attachment_info(
     if notification_uuid:
         title_link_params["notification_uuid"] = notification_uuid
 
-    if should_fire_workflow_actions(organization):
+    # TODO(iamrajjoshi): This will need to be updated once we plan out Metric Alerts rollout
+    if should_fire_workflow_actions(organization, 8001):
         try:
             alert_rule_id = AlertRuleDetector.objects.values_list("alert_rule_id", flat=True).get(
                 detector_id=alert_context.action_identifier_id

--- a/src/sentry/integrations/opsgenie/client.py
+++ b/src/sentry/integrations/opsgenie/client.py
@@ -59,7 +59,7 @@ class OpsgenieClient(ApiClient):
         rule_urls = []
         for rule in rules:
             rule_id = rule.id
-            if should_fire_workflow_actions(organization):
+            if should_fire_workflow_actions(organization, group.type):
                 rule_id = get_key_from_rule_data(rule, "legacy_rule_id")
 
             path = f"/organizations/{organization.slug}/alerts/rules/{group.project.slug}/{rule_id}/details/"

--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -479,7 +479,7 @@ class SlackNotifyServiceAction(IntegrationEventAction):
             },
             skip_internal=False,
         )
-        if should_fire_workflow_actions(self.project.organization):
+        if should_fire_workflow_actions(self.project.organization, event.group.type):
             yield self.future(send_notification_noa, key=key)
         else:
             yield self.future(send_notification, key=key)

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -616,7 +616,7 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         if self.rules:
             if features.has("organizations:workflow-engine-ui-links", self.group.organization):
                 rule_id = int(get_key_from_rule_data(self.rules[0], "workflow_id"))
-            elif should_fire_workflow_actions(self.group.organization):
+            elif should_fire_workflow_actions(self.group.organization, self.group.type):
                 rule_id = int(get_key_from_rule_data(self.rules[0], "legacy_rule_id"))
             else:
                 rule_id = self.rules[0].id

--- a/src/sentry/integrations/slack/service.py
+++ b/src/sentry/integrations/slack/service.py
@@ -248,7 +248,9 @@ class SlackService:
             parent_notifications: Generator[
                 NotificationActionNotificationMessage | IssueAlertNotificationMessage
             ]
-            will_fire_workflow_actions = should_fire_workflow_actions(group.organization)
+            will_fire_workflow_actions = should_fire_workflow_actions(
+                group.organization, group.type
+            )
             if group.issue_category == GroupCategory.UPTIME:
                 use_open_period_start = True
                 open_period_start = open_period_start_for_group(group)

--- a/src/sentry/integrations/slack/utils/notifications.py
+++ b/src/sentry/integrations/slack/utils/notifications.py
@@ -15,6 +15,7 @@ from sentry.constants import METRIC_ALERTS_THREAD_DEFAULT, ObjectStatus
 from sentry.incidents.charts import build_metric_alert_chart
 from sentry.incidents.endpoints.serializers.alert_rule import AlertRuleSerializerResponse
 from sentry.incidents.endpoints.serializers.incident import DetailedIncidentSerializerResponse
+from sentry.incidents.grouptype import MetricIssue
 from sentry.incidents.models.incident import IncidentStatus
 from sentry.incidents.typings.metric_detector import (
     AlertContext,
@@ -436,7 +437,8 @@ def send_incident_alert_notification(
         notification_uuid=notification_uuid,
     )
 
-    if should_fire_workflow_actions(organization):
+    # TODO(iamrajjoshi): This will need to be updated once we plan out Metric Alerts rollout
+    if should_fire_workflow_actions(organization, MetricIssue.type_id):
         return _handle_workflow_engine_notification(
             organization=organization,
             notification_context=notification_context,

--- a/src/sentry/notifications/notification_action/utils.py
+++ b/src/sentry/notifications/notification_action/utils.py
@@ -1,6 +1,6 @@
 import logging
 
-from sentry import features
+from sentry import features, options
 from sentry.models.activity import Activity
 from sentry.models.organization import Organization
 from sentry.notifications.notification_action.registry import (
@@ -14,10 +14,21 @@ from sentry.workflow_engine.types import WorkflowEventData
 logger = logging.getLogger(__name__)
 
 
-def should_fire_workflow_actions(org: Organization) -> bool:
-    return features.has(
-        "organizations:workflow-engine-single-process-workflows", org
-    ) or features.has("organizations:workflow-engine-trigger-actions", org)
+def should_fire_workflow_actions(org: Organization, type_id: int) -> bool:
+    ga_type_ids = options.get("workflow_engine.issue_alert.group.type_id.ga")
+    rollout_type_ids = options.get("workflow_engine.issue_alert.group.type_id.rollout")
+
+    return (
+        type_id in ga_type_ids  # We have completely rolled out these group types
+        or (
+            type_id
+            in rollout_type_ids  # While we are rolling out these groups & we are single  processing
+            and features.has("organizations:workflow-engine-single-process-workflows", org)
+        )
+        or features.has(
+            "organizations:workflow-engine-trigger-actions", org
+        )  # This is for temporary rollouts
+    )
 
 
 def execute_via_group_type_registry(

--- a/src/sentry/notifications/notifications/digest.py
+++ b/src/sentry/notifications/notifications/digest.py
@@ -106,7 +106,11 @@ class DigestNotification(ProjectNotification):
         return self.project
 
     def get_context(self) -> MutableMapping[str, Any]:
-        rule_details = get_rules(list(self.digest.digest), self.project.organization, self.project)
+        rule_details = get_rules(
+            list(self.digest.digest),
+            self.project.organization,
+            self.project,
+        )
         context = DigestNotification.build_context(
             self.digest,
             self.project,

--- a/src/sentry/notifications/notifications/rules.py
+++ b/src/sentry/notifications/notifications/rules.py
@@ -164,7 +164,7 @@ class AlertRuleNotification(ProjectNotification):
     def get_context(self) -> MutableMapping[str, Any]:
         environment = self.event.get_tag("environment")
         enhanced_privacy = self.organization.flags.enhanced_privacy
-        rule_details = get_rules(self.rules, self.organization, self.project)
+        rule_details = get_rules(self.rules, self.organization, self.project, self.group.type)
         sentry_query_params = self.get_sentry_query_params(ExternalProviders.EMAIL)
         for rule in rule_details:
             rule.url = rule.url + sentry_query_params
@@ -262,7 +262,11 @@ class AlertRuleNotification(ProjectNotification):
             if len(self.rules) > 0:
                 context["snooze_alert"] = True
                 context["snooze_alert_url"] = get_snooze_url(
-                    self.rules[0], self.organization, self.project, sentry_query_params
+                    self.rules[0],
+                    self.organization,
+                    self.project,
+                    sentry_query_params,
+                    self.group.type,
                 )
         else:
             context["snooze_alert"] = False

--- a/src/sentry/notifications/utils/links.py
+++ b/src/sentry/notifications/utils/links.py
@@ -123,12 +123,21 @@ def get_rules(
     ]
 
 
+def _fetch_rule_id(rule: Rule, type_id: int | None = None):
+    # Try to fetch the legacy rule id, if it fails, return the rule id
+    # This allows us to support both legacy and new rule ids
+    try:
+        return int(get_key_from_rule_data(rule, "legacy_rule_id"))
+    except AssertionError:
+        return rule.id
+
+
 def get_rules_with_legacy_ids(
     rules: Sequence[Rule], organization: Organization, project: Project
 ) -> Sequence[NotificationRuleDetails]:
     rules_with_legacy_ids = []
     for rule in rules:
-        rule_id = int(get_key_from_rule_data(rule, "legacy_rule_id"))
+        rule_id = _fetch_rule_id(rule)
         rules_with_legacy_ids.append(
             NotificationRuleDetails(
                 rule_id,

--- a/src/sentry/notifications/utils/links.py
+++ b/src/sentry/notifications/utils/links.py
@@ -104,13 +104,13 @@ def get_issue_replay_link(group: Group, sentry_query_params: str = ""):
 
 
 def get_rules(
-    rules: Sequence[Rule], organization: Organization, project: Project
+    rules: Sequence[Rule], organization: Organization, project: Project, type_id: int | None = None
 ) -> Sequence[NotificationRuleDetails]:
     from sentry.notifications.notification_action.utils import should_fire_workflow_actions
 
     if features.has("organizations:workflow-engine-ui-links", organization):
         return get_workflow_links(rules, organization, project)
-    elif should_fire_workflow_actions(organization):
+    elif type_id is None or should_fire_workflow_actions(organization, type_id):
         return get_rules_with_legacy_ids(rules, organization, project)
     return [
         NotificationRuleDetails(
@@ -163,10 +163,11 @@ def get_snooze_url(
     organization: Organization,
     project: Project,
     sentry_query_params: str,
+    type_id: int,
 ) -> str:
     from sentry.notifications.notification_action.utils import should_fire_workflow_actions
 
-    if should_fire_workflow_actions(organization):
+    if should_fire_workflow_actions(organization, type_id):
         rule_id = int(get_key_from_rule_data(rule, "legacy_rule_id"))
     else:
         rule_id = rule.id

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2969,7 +2969,14 @@ register(
 )
 
 register(
-    "workflow_engine.metric_issue.trigger_actions.issue_type_ids",
+    "workflow_engine.issue_alert.group.type_id.rollout",
+    type=Sequence,
+    default=[],
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
+register(
+    "workflow_engine.issue_alert.group.type_id.ga",
     type=Sequence,
     default=[],
     flags=FLAG_AUTOMATOR_MODIFIABLE,

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2968,6 +2968,12 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+register(
+    "workflow_engine.metric_issue.trigger_actions.issue_type_ids",
+    type=Sequence,
+    default=[],
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # Restrict uptime issue creation for specific host provider identifiers. Items
 # in this list map to the `host_provider_id` column in the UptimeSubscription

--- a/src/sentry/rules/actions/integrations/create_ticket/utils.py
+++ b/src/sentry/rules/actions/integrations/create_ticket/utils.py
@@ -120,7 +120,7 @@ def create_issue(event: GroupEvent, futures: Sequence[RuleFuture]) -> None:
 
         # If we invoked this handler from the notification action, we need to replace the rule_id with the legacy_rule_id, so we link notifications correctly
         action_id = None
-        if should_fire_workflow_actions(organization):
+        if should_fire_workflow_actions(organization, event.group.type):
             # In the Notification Action, we store the rule_id in the action_id field
             action_id = rule_id
             rule_id = data.get("legacy_rule_id")

--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -598,7 +598,7 @@ def fire_rules(
                         is_post_process=False,
                     ).values()
 
-                    if not should_fire_workflow_actions(group.organization):
+                    if not should_fire_workflow_actions(group.organization, group.type):
                         for callback, futures in callback_and_futures:
                             try:
                                 callback(groupevent, futures)

--- a/src/sentry/sentry_apps/tasks/sentry_apps.py
+++ b/src/sentry/sentry_apps/tasks/sentry_apps.py
@@ -710,7 +710,7 @@ def notify_sentry_app(event: GroupEvent, futures: Sequence[RuleFuture]):
         if int(id) != -1:
             if features.has("organizations:workflow-engine-ui-links", event.group.organization):
                 id = get_key_from_rule_data(f.rule, "workflow_id")
-            elif should_fire_workflow_actions(event.group.organization):
+            elif should_fire_workflow_actions(event.group.organization, event.group.type):
                 id = get_key_from_rule_data(f.rule, "legacy_rule_id")
 
         settings = f.kwargs.get("schema_defined_settings")

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1011,10 +1011,11 @@ def process_rules(job: PostProcessJob) -> None:
 
     org = job["event"].project.organization
 
-    if features.has("organizations:workflow-engine-single-process-workflows", org) and (
-        job["event"].group.type in options.get("workflow_engine.issue_alert.group.type_id.rollout")
-        or job["event"].group.type in options.get("workflow_engine.issue_alert.group.type_id.ga")
-    ):
+    if (
+        features.has("organizations:workflow-engine-single-process-workflows", org)
+        and job["event"].group.type
+        in options.get("workflow_engine.issue_alert.group.type_id.rollout")
+    ) or job["event"].group.type in options.get("workflow_engine.issue_alert.group.type_id.ga"):
         # we are only processing through the workflow engine
         return
 

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1011,11 +1011,9 @@ def process_rules(job: PostProcessJob) -> None:
 
     org = job["event"].project.organization
 
-    if (
-        features.has("organizations:workflow-engine-single-process-workflows", org)
-        and job["event"].group.type
-        in options.get("workflow_engine.issue_alert.group.type_id.rollout")
-        or options.get("workflow_engine.issue_alert.group.type_id.ga")
+    if features.has("organizations:workflow-engine-single-process-workflows", org) and (
+        job["event"].group.type in options.get("workflow_engine.issue_alert.group.type_id.rollout")
+        or job["event"].group.type in options.get("workflow_engine.issue_alert.group.type_id.ga")
     ):
         # we are only processing through the workflow engine
         return

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1011,7 +1011,12 @@ def process_rules(job: PostProcessJob) -> None:
 
     org = job["event"].project.organization
 
-    if features.has("organizations:workflow-engine-single-process-workflows", org):
+    if (
+        features.has("organizations:workflow-engine-single-process-workflows", org)
+        and job["event"].group.type
+        in options.get("workflow_engine.issue_alert.group.type_id.rollout")
+        or options.get("workflow_engine.issue_alert.group.type_id.ga")
+    ):
         # we are only processing through the workflow engine
         return
 

--- a/src/sentry/tasks/summaries/utils.py
+++ b/src/sentry/tasks/summaries/utils.py
@@ -441,6 +441,7 @@ def organization_project_issue_substatus_summaries(ctx: OrganizationReportContex
             last_seen__lt=ctx.end,
             status=GroupStatus.UNRESOLVED,
         )
+        .select_related("project")
         .values("project_id", "substatus")
         .annotate(total=Count("substatus"))
     )

--- a/src/sentry/web/frontend/debug/debug_feedback_issue.py
+++ b/src/sentry/web/frontend/debug/debug_feedback_issue.py
@@ -29,11 +29,15 @@ class DebugFeedbackIssueEmailView(View):
             text_template="sentry/emails/feedback.txt",
             context={
                 "rule": rule,
-                "rules": get_rules([rule], org, project),
+                "rules": get_rules([rule], org, project, group.type),
                 "group": group,
                 "event": event,
                 "timezone": settings.SENTRY_DEFAULT_TIME_ZONE,
-                "link": get_group_settings_link(group, None, get_rules([rule], org, project), 1337),
+                "link": get_group_settings_link(
+                    group,
+                    None,
+                    get_rules([rule], org, project, group.type),
+                ),
                 "generic_issue_data": [(section_header, mark_safe(generic_issue_data_html), None)],
                 "tags": event.tags,
                 "project_label": project.slug,

--- a/src/sentry/web/frontend/debug/debug_generic_issue.py
+++ b/src/sentry/web/frontend/debug/debug_generic_issue.py
@@ -31,13 +31,17 @@ class DebugGenericIssueEmailView(View):
             text_template="sentry/emails/generic.txt",
             context={
                 "rule": rule,
-                "rules": get_rules([rule], org, project),
+                "rules": get_rules([rule], org, project, group.type),
                 "group": group,
                 "event": event,
                 "timezone": zoneinfo.ZoneInfo("Europe/Vienna"),
                 # http://testserver/organizations/example/issues/<issue-id>/?referrer=alert_email
                 #       &alert_type=email&alert_timestamp=<ts>&alert_rule_id=1
-                "link": get_group_settings_link(group, None, get_rules([rule], org, project), 1337),
+                "link": get_group_settings_link(
+                    group,
+                    None,
+                    get_rules([rule], org, project, group.type),
+                ),
                 "generic_issue_data": [(section_header, mark_safe(generic_issue_data_html), None)],
                 "tags": event.tags,
                 "project_label": project.slug,

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -275,7 +275,7 @@ def make_feedback_issue(project):
 
 
 def get_shared_context(rule, org, project: Project, group, event):
-    rules = get_rules([rule], org, project)
+    rules = get_rules([rule], org, project, group.type)
     snooze_alert = len(rules) > 0
     snooze_alert_url = rules[0].status_url + urlencode({"mute": "1"}) if snooze_alert else ""
     return {
@@ -593,7 +593,7 @@ def digest(request):
     )
     start, end, counts = get_digest_metadata(digest.digest)
 
-    rule_details = get_rules(list(rules.values()), org, project)
+    rule_details = get_rules(list(rules.values()), org, project, groups[0].type)
     context = DigestNotification.build_context(digest, project, org, rule_details, 1337)
 
     context["show_replay_links"] = True

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -593,7 +593,7 @@ def digest(request):
     )
     start, end, counts = get_digest_metadata(digest.digest)
 
-    rule_details = get_rules(list(rules.values()), org, project, groups[0].type)
+    rule_details = get_rules(list(rules.values()), org, project)
     context = DigestNotification.build_context(digest, project, org, rule_details, 1337)
 
     context["show_replay_links"] = True

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -432,7 +432,7 @@ def process_workflows(
         # If there aren't any actions on the associated workflows, there's nothing to trigger
         return triggered_workflows
 
-    should_trigger_actions = should_fire_workflow_actions(organization)
+    should_trigger_actions = should_fire_workflow_actions(organization, event_data.group.type)
 
     create_workflow_fire_histories(detector, actions, event_data, should_trigger_actions)
 

--- a/src/sentry/workflow_engine/tasks/actions.py
+++ b/src/sentry/workflow_engine/tasks/actions.py
@@ -2,6 +2,7 @@ from dataclasses import asdict
 
 from django.db.models import Value
 
+from sentry import options
 from sentry.eventstore.models import GroupEvent
 from sentry.eventstream.base import GroupState
 from sentry.models.activity import Activity
@@ -9,7 +10,7 @@ from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task, retry
 from sentry.taskworker import config, namespaces
 from sentry.taskworker.retry import Retry
-from sentry.utils import metrics, options
+from sentry.utils import metrics
 from sentry.workflow_engine.models import Action, Detector
 from sentry.workflow_engine.tasks.utils import build_workflow_event_data_from_event
 from sentry.workflow_engine.types import WorkflowEventData

--- a/src/sentry/workflow_engine/tasks/actions.py
+++ b/src/sentry/workflow_engine/tasks/actions.py
@@ -119,7 +119,7 @@ def trigger_action(
 
     issue_type_ids = options.get("workflow_engine.metric_issue.trigger_actions.issue_type_ids")
 
-    if should_trigger_actions and event_data.group.type not in issue_type_ids:
+    if should_trigger_actions and event_data.group.type in issue_type_ids:
         action.trigger(event_data, detector)
     else:
         logger.info(

--- a/src/sentry/workflow_engine/tasks/actions.py
+++ b/src/sentry/workflow_engine/tasks/actions.py
@@ -4,6 +4,7 @@ from django.db.models import Value
 
 from sentry.eventstore.models import GroupEvent
 from sentry.eventstream.base import GroupState
+from sentry.incidents.grouptype import MetricIssue
 from sentry.models.activity import Activity
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task, retry
@@ -116,7 +117,7 @@ def trigger_action(
 
     should_trigger_actions = should_fire_workflow_actions(detector.project.organization)
 
-    if should_trigger_actions:
+    if should_trigger_actions and event_data.group.type != MetricIssue.type_id:
         action.trigger(event_data, detector)
     else:
         logger.info(

--- a/src/sentry/workflow_engine/tasks/actions.py
+++ b/src/sentry/workflow_engine/tasks/actions.py
@@ -2,7 +2,6 @@ from dataclasses import asdict
 
 from django.db.models import Value
 
-from sentry import options
 from sentry.eventstore.models import GroupEvent
 from sentry.eventstream.base import GroupState
 from sentry.models.activity import Activity
@@ -115,11 +114,11 @@ def trigger_action(
         # Here, we probably build the event data from the activity
         raise NotImplementedError("Activity ID is not supported yet")
 
-    should_trigger_actions = should_fire_workflow_actions(detector.project.organization)
+    should_trigger_actions = should_fire_workflow_actions(
+        detector.project.organization, event_data.group.type
+    )
 
-    issue_type_ids = options.get("workflow_engine.metric_issue.trigger_actions.issue_type_ids")
-
-    if should_trigger_actions and event_data.group.type in issue_type_ids:
+    if should_trigger_actions:
         action.trigger(event_data, detector)
     else:
         logger.info(

--- a/tests/sentry/integrations/slack/notifications/test_issue_alert.py
+++ b/tests/sentry/integrations/slack/notifications/test_issue_alert.py
@@ -1026,7 +1026,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         digests.backend.digest = backend.digest
         digests.enabled.return_value = True
 
-        rule = Rule.objects.create(project=self.project, label="my rule")
+        rule = self.create_project_rule(project=self.project)
         ProjectOwnership.objects.create(project_id=self.project.id)
         event = self.store_event(
             data={"message": "Hello world", "level": "error"}, project_id=self.project.id
@@ -1046,7 +1046,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         )
         assert (
             fallback_text
-            == f"Alert triggered <http://testserver/organizations/{event.organization.slug}/alerts/rules/{event.project.slug}/{rule.id}/details/|my rule>"
+            == f"Alert triggered <http://testserver/organizations/{event.organization.slug}/alerts/rules/{event.project.slug}/{rule.id}/details/|Test Alert>"
         )
         assert blocks[0]["text"]["text"] == fallback_text
         assert event.group

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -1559,7 +1559,7 @@ class MailAdapterNotifyDigestTest(BaseMailAdapterTest, ReplaysSnubaTestCase):
         )
 
         rule = project.rule_set.all()[0]
-        rule2 = Rule.objects.create(project=project, label="my rule")
+        rule2 = self.create_project_rule(project=project)
         # mute the first rule only for self.user, not user2
         self.snooze_rule(user_id=self.user.id, owner_id=self.user.id, rule=rule)
 
@@ -1608,7 +1608,7 @@ class MailAdapterNotifyDigestTest(BaseMailAdapterTest, ReplaysSnubaTestCase):
         )
 
         rule = project.rule_set.all()[0]
-        rule2 = Rule.objects.create(project=project, label="my rule")
+        rule2 = self.create_project_rule(project=project)
         # mute the rules for self.user, not user2
         self.snooze_rule(user_id=self.user.id, owner_id=self.user.id, rule=rule)
         self.snooze_rule(user_id=self.user.id, owner_id=self.user.id, rule=rule2)
@@ -1651,7 +1651,7 @@ class MailAdapterNotifyDigestTest(BaseMailAdapterTest, ReplaysSnubaTestCase):
         )
 
         rule = project.rule_set.all()[0]
-        rule2 = Rule.objects.create(project=project, label="my rule")
+        rule2 = self.create_project_rule(project=project)
         # mute the first rule for self.user, not user2
         self.snooze_rule(user_id=self.user.id, owner_id=self.user.id, rule=rule)
         # mute the 2nd rule for both

--- a/tests/sentry/notifications/notifications/test_digests.py
+++ b/tests/sentry/notifications/notifications/test_digests.py
@@ -11,7 +11,6 @@ from sentry.digests.backends.base import Backend
 from sentry.digests.backends.redis import RedisBackend
 from sentry.digests.notifications import event_to_record
 from sentry.models.projectownership import ProjectOwnership
-from sentry.models.rule import Rule
 from sentry.tasks.digests import deliver_digest
 from sentry.testutils.cases import PerformanceIssueTestCase, SlackActivityNotificationTest, TestCase
 from sentry.testutils.helpers.datetime import before_now
@@ -79,7 +78,7 @@ class DigestNotificationTest(TestCase, OccurrenceTestMixin, PerformanceIssueTest
 
     def setUp(self):
         super().setUp()
-        self.rule = Rule.objects.create(project=self.project, label="Test Rule", data={})
+        self.rule = self.create_project_rule(project=self.project)
         self.key = f"mail:p:{self.project.id}:IssueOwners::AllMembers"
         ProjectOwnership.objects.create(project_id=self.project.id, fallthrough=True)
         for i in range(USER_COUNT - 1):
@@ -169,7 +168,7 @@ class DigestSlackNotification(SlackActivityNotificationTest):
         timestamp_secs = int(timestamp_raw.timestamp())
         timestamp = timestamp_raw.isoformat()
         key = f"slack:p:{self.project.id}:IssueOwners::AllMembers"
-        rule = Rule.objects.create(project=self.project, label="my rule")
+        rule = self.create_project_rule(project=self.project)
         event1 = self.store_event(
             data={
                 "timestamp": timestamp,

--- a/tests/sentry/notifications/test_helpers.py
+++ b/tests/sentry/notifications/test_helpers.py
@@ -92,7 +92,7 @@ class NotificationHelpersTest(TestCase):
 
     def test_get_group_settings_link(self):
         rule: Rule = self.create_project_rule(self.project)
-        rule_details = get_rules([rule], self.organization, self.project)
+        rule_details = get_rules([rule], self.organization, self.project, self.group.type)
         link = get_group_settings_link(
             self.group, self.environment.name, rule_details, 1337, extra="123"
         )
@@ -114,7 +114,7 @@ class NotificationHelpersTest(TestCase):
         project2 = self.create_project()
         rule2 = self.create_project_rule(project2)
 
-        rule_details = get_rules([rule, rule2], self.organization, self.project)
+        rule_details = get_rules([rule, rule2], self.organization, self.project, self.group.type)
         extra_params = {
             k: dict(map(lambda x: (x[0], x[1][0]), parse_qs(v.strip("?")).items()))
             for k, v in get_email_link_extra_params(

--- a/tests/sentry/tasks/test_digests.py
+++ b/tests/sentry/tasks/test_digests.py
@@ -8,7 +8,6 @@ import sentry
 from sentry.digests.backends.redis import RedisBackend
 from sentry.digests.notifications import event_to_record
 from sentry.models.projectownership import ProjectOwnership
-from sentry.models.rule import Rule
 from sentry.tasks.digests import deliver_digest
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import before_now
@@ -24,7 +23,7 @@ class DeliverDigestTest(TestCase):
             backend = RedisBackend()
             digests.backend.digest = backend.digest
 
-            rule = Rule.objects.create(project=self.project, label="Test Rule", data={})
+            rule = self.create_project_rule(project=self.project)
             ProjectOwnership.objects.create(project_id=self.project.id, fallthrough=True)
             event = self.store_event(
                 data={"timestamp": before_now(days=1).isoformat(), "fingerprint": ["group-1"]},

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -602,6 +602,7 @@ class ServiceHooksTestMixin(BasePostProgressGroupMixin):
         assert not mock_process_service_hook.delay.mock_calls
 
     @with_feature("organizations:workflow-engine-single-process-workflows")
+    @override_options({"workflow_engine.issue_alert.group.type_id.rollout": [1]})
     @patch("sentry.rules.processing.processor.RuleProcessor")
     @patch("sentry.tasks.post_process.process_workflow_engine")
     def test_workflow_engine_single_processing(self, mock_process_workflow_engine, mock_processor):


### PR DESCRIPTION
while rolling out ACI single processing, we don't want to roll out firing actions for metric issues, so lets gate the task so it doesn't fire for metric issues