### PR TITLE
feat(aci): Add error detector details page

### DIFF
--- a/static/app/components/workflowEngine/ui/section.tsx
+++ b/static/app/components/workflowEngine/ui/section.tsx
@@ -11,13 +11,23 @@ type SectionProps = {
 
 export default function Section({children, title, description}: SectionProps) {
   return (
-    <Flex direction="column" gap={space(1)}>
+    <SectionContainer direction="column" gap={space(1)}>
       <SectionHeading>{title}</SectionHeading>
       {description && <SectionDescription>{description}</SectionDescription>}
       {children}
-    </Flex>
+    </SectionContainer>
   );
 }
+
+const SectionContainer = styled(Flex)`
+  > p {
+    margin-bottom: ${p => p.theme.space.none};
+  }
+
+  p + p {
+    margin-top: ${p => p.theme.space.md};
+  }
+`;
 
 const SectionHeading = styled('h4')`
   font-size: ${p => p.theme.fontSize.lg};

--- a/static/app/views/detectors/components/details/error/index.spec.tsx
+++ b/static/app/views/detectors/components/details/error/index.spec.tsx
@@ -1,0 +1,47 @@
+import {ErrorDetectorFixture} from 'sentry-fixture/detectors';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {ErrorDetectorDetails} from 'sentry/views/detectors/components/details/error';
+
+describe('ErrorDetectorDetails', function () {
+  const defaultProps = {
+    detector: ErrorDetectorFixture(),
+    project: ProjectFixture(),
+  };
+
+  beforeEach(function () {
+    MockApiClient.addMockResponse({
+      url: '/projects/org-slug/project-slug/',
+      method: 'GET',
+      body: ProjectFixture(),
+    });
+  });
+
+  describe('Resolve section', function () {
+    it('displays the auto-resolve time when it is configured', async function () {
+      MockApiClient.addMockResponse({
+        url: '/projects/org-slug/project-slug/',
+        method: 'GET',
+        body: ProjectFixture({
+          resolveAge: 30 * 24,
+        }),
+      });
+
+      render(<ErrorDetectorDetails {...defaultProps} />);
+
+      expect(
+        await screen.findByText('Auto-resolve after 30 days of inactivity')
+      ).toBeInTheDocument();
+    });
+
+    it('displays correct text when auto-resolve is disabled', async function () {
+      const project = ProjectFixture({resolveAge: 0});
+
+      render(<ErrorDetectorDetails {...defaultProps} project={project} />);
+
+      expect(await screen.findByText('Auto-resolution disabled')).toBeInTheDocument();
+    });
+  });
+});

--- a/static/app/views/detectors/components/details/error/index.tsx
+++ b/static/app/views/detectors/components/details/error/index.tsx
@@ -1,0 +1,98 @@
+import ExternalLink from 'sentry/components/links/externalLink';
+import Placeholder from 'sentry/components/placeholder';
+import DetailLayout from 'sentry/components/workflowEngine/layout/detail';
+import Section from 'sentry/components/workflowEngine/ui/section';
+import {t, tct, tn} from 'sentry/locale';
+import type {Project} from 'sentry/types/project';
+import type {Detector} from 'sentry/types/workflowEngine/detectors';
+import {useDetailedProject} from 'sentry/utils/useDetailedProject';
+import useOrganization from 'sentry/utils/useOrganization';
+import {DetectorDetailsAssignee} from 'sentry/views/detectors/components/details/common/assignee';
+import {DetectorDetailsAutomations} from 'sentry/views/detectors/components/details/common/automations';
+import {DetectorExtraDetails} from 'sentry/views/detectors/components/details/common/extraDetails';
+import {DetectorDetailsHeader} from 'sentry/views/detectors/components/details/common/header';
+import {DetectorDetailsOngoingIssues} from 'sentry/views/detectors/components/details/common/ongoingIssues';
+
+type ErrorDetectorDetailsProps = {
+  detector: Detector;
+  project: Project;
+};
+
+const formatResolveAge = (resolveAge: number) => {
+  if (!resolveAge) {
+    return t('Auto-resolution disabled');
+  }
+
+  if (resolveAge < 24 || resolveAge % 24 !== 0) {
+    return tn(
+      'Auto-resolve after %s hour of inactivity',
+      'Auto-resolve after %s hours of inactivity',
+      resolveAge
+    );
+  }
+  return tn(
+    'Auto-resolve after %s day of inactivity',
+    'Auto-resolve after %s days of inactivity',
+    resolveAge / 24
+  );
+};
+
+function ResolveSection({project}: {project: Project}) {
+  const organization = useOrganization();
+  const {data: detailedProject, isPending} = useDetailedProject({
+    orgSlug: organization.slug,
+    projectSlug: project.slug,
+  });
+
+  if (isPending || !detailedProject) {
+    return (
+      <Section title={t('Resolve')}>
+        <Placeholder height="1em" />
+      </Section>
+    );
+  }
+
+  const resolveAgeHours = detailedProject.resolveAge;
+
+  return (
+    <Section title={t('Resolve')}>
+      <p>{formatResolveAge(resolveAgeHours)}</p>
+    </Section>
+  );
+}
+
+export function ErrorDetectorDetails({detector, project}: ErrorDetectorDetailsProps) {
+  return (
+    <DetailLayout>
+      <DetectorDetailsHeader detector={detector} project={project} />
+      <DetailLayout.Body>
+        <DetailLayout.Main>
+          <DetectorDetailsOngoingIssues />
+          <DetectorDetailsAutomations detector={detector} />
+        </DetailLayout.Main>
+        <DetailLayout.Sidebar>
+          <Section title={t('Detect')}>
+            <p>
+              {tct(
+                'All events have a fingerprint. Events with the same fingerprint are grouped together into an issue. To learn more about issue grouping, [link:read the docs].',
+                {
+                  link: (
+                    <ExternalLink href="https://docs.sentry.io/concepts/data-management/event-grouping/" />
+                  ),
+                }
+              )}
+            </p>
+          </Section>
+          <DetectorDetailsAssignee owner={detector.owner} />
+          <ResolveSection project={project} />
+          <DetectorExtraDetails>
+            <DetectorExtraDetails.DateCreated detector={detector} />
+            <DetectorExtraDetails.CreatedBy detector={detector} />
+            <DetectorExtraDetails.LastModified detector={detector} />
+            <DetectorExtraDetails.Environment detector={detector} />
+          </DetectorExtraDetails>
+        </DetailLayout.Sidebar>
+      </DetailLayout.Body>
+    </DetailLayout>
+  );
+}

--- a/static/app/views/detectors/components/details/index.tsx
+++ b/static/app/views/detectors/components/details/index.tsx
@@ -18,9 +18,10 @@ export function DetectorDetailsContent({detector, project}: DetectorDetailsConte
       return <MetricDetectorDetails detector={detector} project={project} />;
     case 'uptime_domain_failure':
       return <UptimeDetectorDetails detector={detector} project={project} />;
-    case 'uptime_subscription':
     case 'error':
       return <ErrorDetectorDetails detector={detector} project={project} />;
+    case 'uptime_subscription':
+      return <FallbackDetectorDetails detector={detector} project={project} />;
     default:
       unreachable(detectorType);
       return <FallbackDetectorDetails detector={detector} project={project} />;

--- a/static/app/views/detectors/components/details/index.tsx
+++ b/static/app/views/detectors/components/details/index.tsx
@@ -1,6 +1,7 @@
 import type {Project} from 'sentry/types/project';
 import type {Detector} from 'sentry/types/workflowEngine/detectors';
 import {unreachable} from 'sentry/utils/unreachable';
+import {ErrorDetectorDetails} from 'sentry/views/detectors/components/details/error';
 import {FallbackDetectorDetails} from 'sentry/views/detectors/components/details/fallback';
 import {MetricDetectorDetails} from 'sentry/views/detectors/components/details/metric';
 import {UptimeDetectorDetails} from 'sentry/views/detectors/components/details/uptime';
@@ -19,7 +20,7 @@ export function DetectorDetailsContent({detector, project}: DetectorDetailsConte
       return <UptimeDetectorDetails detector={detector} project={project} />;
     case 'uptime_subscription':
     case 'error':
-      return <FallbackDetectorDetails detector={detector} project={project} />;
+      return <ErrorDetectorDetails detector={detector} project={project} />;
     default:
       unreachable(detectorType);
       return <FallbackDetectorDetails detector={detector} project={project} />;


### PR DESCRIPTION
Simple addition to support error detector details. The only special bit here is the resolution age which comes from the project settings.

<img width="1818" height="1352" alt="CleanShot 2025-07-16 at 14 25 59@2x" src="https://github.com/user-attachments/assets/2a6c5175-5720-4bef-8a25-3772316e81cc" />
