### PR TITLE
chore(aci milestone 3): remove unnecessary fields from detector config

### DIFF
--- a/src/sentry/incidents/grouptype.py
+++ b/src/sentry/incidents/grouptype.py
@@ -184,7 +184,6 @@ class MetricIssue(GroupType):
             "type": "object",
             "required": ["threshold_period", "detection_type"],
             "properties": {
-                "threshold_period": {"type": "integer", "minimum": 1, "maximum": 20},
                 "comparison_delta": {
                     "type": ["integer", "null"],
                     "enum": COMPARISON_DELTA_CHOICES,
@@ -193,8 +192,6 @@ class MetricIssue(GroupType):
                     "type": "string",
                     "enum": [detection_type.value for detection_type in AlertRuleDetectionType],
                 },
-                "sensitivity": {"type": ["string", "null"]},
-                "seasonality": {"type": ["string", "null"]},
             },
         },
     )

--- a/src/sentry/incidents/grouptype.py
+++ b/src/sentry/incidents/grouptype.py
@@ -182,8 +182,13 @@ class MetricIssue(GroupType):
             "$schema": "https://json-schema.org/draft/2020-12/schema",
             "description": "A representation of a metric alert firing",
             "type": "object",
-            "required": ["threshold_period", "detection_type"],
+            "required": ["detection_type"],
             "properties": {
+                "threshold_period": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 20,
+                },  # remove after we complete backfill
                 "comparison_delta": {
                     "type": ["integer", "null"],
                     "enum": COMPARISON_DELTA_CHOICES,
@@ -192,6 +197,8 @@ class MetricIssue(GroupType):
                     "type": "string",
                     "enum": [detection_type.value for detection_type in AlertRuleDetectionType],
                 },
+                "sensitivity": {"type": ["string", "null"]},  # remove after we complete backfill
+                "seasonality": {"type": ["string", "null"]},  # remove after we complete backfill
             },
         },
     )

--- a/src/sentry/workflow_engine/migration_helpers/alert_rule.py
+++ b/src/sentry/workflow_engine/migration_helpers/alert_rule.py
@@ -480,9 +480,6 @@ def get_detector_field_values(
         "owner_user_id": alert_rule.user_id,
         "owner_team": alert_rule.team,
         "config": {
-            "threshold_period": alert_rule.threshold_period,
-            "sensitivity": alert_rule.sensitivity,
-            "seasonality": alert_rule.seasonality,
             "comparison_delta": alert_rule.comparison_delta,
             "detection_type": alert_rule.detection_type,
         },

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
@@ -725,9 +725,6 @@ class DualUpdateAlertRuleTest(BaseMetricAlertMigrationTest):
         updated_fields: dict[str, Any] = {}
         updated_fields = {
             "detection_type": "percent",
-            "threshold_period": 1,
-            "sensitivity": None,
-            "seasonality": None,
             "comparison_delta": 3600,
         }
 
@@ -1526,8 +1523,6 @@ class SinglePointOfEntryTest(BaseMetricAlertMigrationTest):
 
         # check detector
         detector = AlertRuleDetector.objects.get(alert_rule_id=self.dual_written_alert.id).detector
-        assert detector.config["sensitivity"] == self.dual_written_alert.sensitivity
-        assert detector.config["seasonality"] == self.dual_written_alert.seasonality
         assert detector.config["detection_type"] == AlertRuleDetectionType.DYNAMIC
 
         # check detector trigger
@@ -1563,8 +1558,6 @@ class SinglePointOfEntryTest(BaseMetricAlertMigrationTest):
         detector = AlertRuleDetector.objects.get(
             alert_rule_id=self.anomaly_detection_alert.id
         ).detector
-        assert detector.config["sensitivity"] is None
-        assert detector.config["seasonality"] is None
         assert detector.config["detection_type"] == AlertRuleDetectionType.STATIC
 
         # check detector trigger
@@ -1588,8 +1581,6 @@ class SinglePointOfEntryTest(BaseMetricAlertMigrationTest):
         self.anomaly_detection_alert.update(
             detection_type=AlertRuleDetectionType.PERCENT,
             comparison_delta=90,
-            sensitivity=None,
-            seasonality=None,
         )
         self.anomaly_detection_alert_trigger.update(alert_threshold=150)
         self.anomaly_detection_alert.refresh_from_db()
@@ -1601,8 +1592,6 @@ class SinglePointOfEntryTest(BaseMetricAlertMigrationTest):
         detector = AlertRuleDetector.objects.get(
             alert_rule_id=self.anomaly_detection_alert.id
         ).detector
-        assert detector.config["sensitivity"] is None
-        assert detector.config["seasonality"] is None
         assert detector.config["detection_type"] == AlertRuleDetectionType.PERCENT
         assert detector.config["comparison_delta"] == 90
 
@@ -1631,7 +1620,6 @@ class SinglePointOfEntryTest(BaseMetricAlertMigrationTest):
         detector = AlertRuleDetector.objects.get(
             alert_rule_id=self.anomaly_detection_alert.id
         ).detector
-        assert detector.config["sensitivity"] == AlertRuleSensitivity.LOW
 
         detector_trigger = DataCondition.objects.get(
             condition_group=detector.workflow_condition_group,

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
@@ -93,9 +93,6 @@ def assert_alert_rule_migrated(alert_rule, project_id):
     assert detector.owner_team == alert_rule.team
     assert detector.type == MetricIssue.slug
     assert detector.config == {
-        "threshold_period": alert_rule.threshold_period,
-        "sensitivity": alert_rule.sensitivity,
-        "seasonality": alert_rule.seasonality,
         "comparison_delta": alert_rule.comparison_delta,
         "detection_type": alert_rule.detection_type,
     }


### PR DESCRIPTION
`sensitivity` and `seasonality` are never read from the detector config, only from the data conditions. `threshold_period` is only used by internal sentry alerts and was never rolled out to customers. Because it will behave differently in the workflow engine, we can drop the field from the config as well.

Backfill migration incoming. We need to make the config fields optional on the config schema while we're switching over, then remove after we've finished the migration.