### PR TITLE
feat(devserver): Filter Relay API calls on devserver

### DIFF
--- a/src/sentry/data/config/sentry.conf.py.default
+++ b/src/sentry/data/config/sentry.conf.py.default
@@ -121,3 +121,11 @@ SENTRY_WEB_OPTIONS = {
     # 'workers': 1,  # the number of web workers
     # 'protocol': 'uwsgi',  # Enable uwsgi protocol instead of http
 }
+
+##############
+# Devserver #
+##############
+
+# Exclude logs caused by Relay polling every 100ms.
+# Makes it rather hard to use Python debugger
+DEVSERVER_REQUEST_LOG_EXCLUDES = ["/api/0/relays/projectconfigs/"]


### PR DESCRIPTION
Can't use the debugger when I'm getting spammed. This change sets it on `sentry.conf.py.default`.

<img width="1296" height="934" alt="Screenshot 2025-07-16 at 5 44 48 PM" src="https://github.com/user-attachments/assets/76f2b3cb-37a1-4765-81c4-c6e0060f5c2d" />
