### PR TITLE
Fix thread-queue-parallel consumer to handle Kafka rebalances correctly

### DIFF
--- a/tests/sentry/remote_subscriptions/consumers/test_queue_consumer.py
+++ b/tests/sentry/remote_subscriptions/consumers/test_queue_consumer.py
@@ -3,6 +3,7 @@ Tests for the thread-queue-parallel result consumer implementation.
 """
 
 import threading
+import time
 from datetime import datetime
 from typing import Any
 from unittest import mock
@@ -10,20 +11,27 @@ from unittest import mock
 from arroyo.backends.kafka import KafkaPayload
 from arroyo.types import BrokerValue, FilteredPayload, Message, Partition, Topic
 
+from sentry.conf.types.kafka_definition import Topic as SentryTopic
 from sentry.remote_subscriptions.consumers.queue_consumer import (
     FixedQueuePool,
     OffsetTracker,
     SimpleQueueProcessingStrategy,
     WorkItem,
 )
+from sentry.remote_subscriptions.consumers.result_consumer import (
+    ResultProcessor,
+    ResultsStrategyFactory,
+)
 from sentry.testutils.cases import TestCase
+from sentry.utils import json
 
 
 class TestOffsetTracker(TestCase):
     def setUp(self):
-        self.tracker = OffsetTracker()
         self.partition1 = Partition(Topic("test"), 0)
         self.partition2 = Partition(Topic("test"), 1)
+        self.tracker = OffsetTracker()
+        self.tracker.update_assignments({self.partition1, self.partition2})
 
     def test_simple_tracking(self):
         """Test basic offset tracking and committing."""
@@ -83,6 +91,14 @@ class TestFixedQueuePool(TestCase):
             num_queues=3,
         )
 
+        self.commits: list[dict[Partition, int]] = []
+
+        def commit_function(offsets: dict[Partition, int]) -> None:
+            self.commits.append(offsets.copy())
+
+        test_partitions = {Partition(Topic("test"), i) for i in range(3)}
+        self.pool.update_assignments(test_partitions, commit_function)
+
     def tearDown(self):
         self.pool.shutdown()
 
@@ -129,7 +145,7 @@ class TestFixedQueuePool(TestCase):
             )
             self.pool.submit(group_key, work_item)
 
-        assert self.process_complete_event.wait(timeout=5.0), "Processing did not complete in time"
+        assert self.process_complete_event.wait(timeout=2.0), "Processing did not complete in time"
 
         group_items = [item for _, item in self.processed_items if item.startswith("item_")]
         assert group_items == ["item_0", "item_1", "item_2", "item_3", "item_4"]
@@ -158,7 +174,7 @@ class TestFixedQueuePool(TestCase):
             )
             self.pool.submit(group_key, work_item)
 
-        assert self.process_complete_event.wait(timeout=5.0), "Processing did not complete in time"
+        assert self.process_complete_event.wait(timeout=2.0), "Processing did not complete in time"
         assert len(self.processed_items) == 6
 
         groups_seen = set()
@@ -200,7 +216,7 @@ class TestFixedQueuePool(TestCase):
         assert stats["total_items"] > 0
         assert "queue_depths" in stats
         assert len(stats["queue_depths"]) == 3
-        assert self.process_complete_event.wait(timeout=5.0), "Processing did not complete in time"
+        assert self.process_complete_event.wait(timeout=2.0), "Processing did not complete in time"
 
         stats = self.pool.get_stats()
         assert stats["total_items"] == 0
@@ -242,18 +258,20 @@ class TestSimpleQueueProcessingStrategy(TestCase):
         def grouping_fn(result: dict) -> str:
             return result["subscription_id"]
 
+        self.test_partitions = {Partition(Topic("test"), i) for i in range(3)}
+
         self.strategy = SimpleQueueProcessingStrategy(
             queue_pool=self.queue_pool,
             decoder=decoder,
             grouping_fn=grouping_fn,
             commit_function=commit_function,
+            partitions=self.test_partitions,
         )
 
     def tearDown(self):
         self.strategy.close()
 
     def create_message(self, subscription_id: str, partition: int, offset: int) -> Message:
-        """Helper to create a test message."""
         payload = KafkaPayload(
             key=None,
             value=subscription_id.encode(),
@@ -278,7 +296,7 @@ class TestSimpleQueueProcessingStrategy(TestCase):
 
         self.strategy.submit(message)
 
-        assert self.process_complete_event.wait(timeout=5.0), "Processing did not complete in time"
+        assert self.process_complete_event.wait(timeout=2.0), "Processing did not complete in time"
         assert len(self.processed_results) == 1
         assert self.processed_results[0]["subscription_id"] == "sub1"
 
@@ -293,7 +311,7 @@ class TestSimpleQueueProcessingStrategy(TestCase):
             message = self.create_message("sub1", 0, 100 + i)
             self.strategy.submit(message)
 
-        assert self.process_complete_event.wait(timeout=5.0), "Processing did not complete in time"
+        assert self.process_complete_event.wait(timeout=2.0), "Processing did not complete in time"
         assert self.commit_event.wait(timeout=2.0), "Commit did not happen in time"
 
         assert partition in self.committed_offsets
@@ -308,7 +326,7 @@ class TestSimpleQueueProcessingStrategy(TestCase):
             message = self.create_message("sub1", 0, 100 + i)
             self.strategy.submit(message)
 
-        assert self.process_complete_event.wait(timeout=5.0), "Processing did not complete in time"
+        assert self.process_complete_event.wait(timeout=2.0), "Processing did not complete in time"
         assert len(self.processed_results) == 5
 
     def test_concurrent_processing_different_groups(self):
@@ -320,7 +338,7 @@ class TestSimpleQueueProcessingStrategy(TestCase):
             message = self.create_message(f"sub{i % 2}", 0, 100 + i)
             self.strategy.submit(message)
 
-        assert self.process_complete_event.wait(timeout=5.0), "Processing did not complete in time"
+        assert self.process_complete_event.wait(timeout=2.0), "Processing did not complete in time"
 
         assert len(self.processed_results) == 4
 
@@ -344,7 +362,7 @@ class TestSimpleQueueProcessingStrategy(TestCase):
         self.strategy.submit(invalid_message)
         self.strategy.submit(self.create_message("sub1", 0, 101))
 
-        assert self.process_complete_event.wait(timeout=5.0), "Processing did not complete in time"
+        assert self.process_complete_event.wait(timeout=2.0), "Processing did not complete in time"
         assert self.commit_event.wait(timeout=2.0), "Commit did not happen in time"
         assert self.committed_offsets.get(partition) == 101
 
@@ -360,7 +378,7 @@ class TestSimpleQueueProcessingStrategy(TestCase):
         self.strategy.submit(self.create_message("sub1", 0, 102))
         self.strategy.submit(self.create_message("sub1", 0, 103))
 
-        assert self.process_complete_event.wait(timeout=5.0), "Processing did not complete in time"
+        assert self.process_complete_event.wait(timeout=2.0), "Processing did not complete in time"
         assert self.commit_event.wait(timeout=2.0), "Commit did not happen in time"
         assert self.committed_offsets.get(partition) == 100
 
@@ -396,7 +414,7 @@ class TestThreadQueueParallelIntegration(TestCase):
         class MockFactory(ResultsStrategyFactory):
             @property
             def topic_for_codec(self):
-                return Topic("test")
+                return SentryTopic.SHARED_RESOURCES_USAGE
 
             @property
             def result_processor_cls(self):
@@ -418,4 +436,271 @@ class TestThreadQueueParallelIntegration(TestCase):
         assert factory.queue_pool is not None
         assert factory.queue_pool.num_queues == 5
 
+        factory.shutdown()
+
+
+class TestRebalancing(TestCase):
+    """Test rebalancing scenarios for thread-queue-parallel consumer."""
+
+    def setUp(self):
+        self.processed_results: list[tuple[str, dict]] = []
+        self.process_lock = threading.Lock()
+        self.process_condition = threading.Condition(self.process_lock)
+        self.commit_calls: list[dict[Partition, int]] = []
+        self.commit_lock = threading.Lock()
+        self.commit_condition = threading.Condition(self.commit_lock)
+
+        test_case = self
+
+        class MockResultProcessor(ResultProcessor):
+            @property
+            def subscription_model(self):
+                return mock.Mock()
+
+            def get_subscription_id(self, result):
+                return result.get("subscription_id", "unknown")
+
+            def handle_result(self, subscription, result):
+                pass
+
+            def __call__(self, identifier: str, result: dict):
+                with test_case.process_lock:
+                    test_case.processed_results.append((identifier, result))
+
+        self.mock_processor_cls = MockResultProcessor
+
+    def _wait_for_processed_count(self, expected_count: int, timeout: float = 2.0) -> bool:
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            with self.process_lock:
+                if len(self.processed_results) >= expected_count:
+                    return True
+            threading.Event().wait(0.01)
+        return False
+
+    def _wait_for_commits(self, timeout: float = 1.0) -> bool:
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            with self.commit_lock:
+                if len(self.commit_calls) > 0:
+                    return True
+            threading.Event().wait(0.01)
+        return False
+
+    def create_factory(self):
+        mock_processor_cls = self.mock_processor_cls
+
+        class TestFactory(ResultsStrategyFactory):
+            @property
+            def topic_for_codec(self):
+                return SentryTopic.SHARED_RESOURCES_USAGE
+
+            @property
+            def result_processor_cls(self):
+                return mock_processor_cls
+
+            def build_payload_grouping_key(self, result):
+                return result.get("subscription_id", "unknown")
+
+            @property
+            def identifier(self):
+                return "test-rebalance"
+
+            def decode_payload(self, topic_for_codec, payload):
+                return json.loads(payload.value)
+
+        return TestFactory(mode="thread-queue-parallel", max_workers=3, commit_interval=0.01)
+
+    def create_commit_function(self):
+        def commit(offsets: dict[Partition, int]):
+            with self.commit_lock:
+                self.commit_calls.append(offsets.copy())
+
+        return commit
+
+    def create_message(self, subscription_id: str, partition: int, offset: int) -> Message:
+        payload = KafkaPayload(
+            key=None,
+            value=f'{{"subscription_id": "{subscription_id}", "data": "test"}}'.encode(),
+            headers=[],
+        )
+        return Message(
+            BrokerValue(
+                payload,
+                Partition(Topic("test"), partition),
+                offset,
+                datetime.now(),
+            )
+        )
+
+    def test_initial_assignment(self):
+        """Test initial partition assignment."""
+        factory = self.create_factory()
+        commit = self.create_commit_function()
+
+        partitions = {
+            Partition(Topic("test"), 0): 100,
+            Partition(Topic("test"), 1): 200,
+        }
+
+        strategy = factory.create_with_partitions(commit, partitions)
+        assert isinstance(strategy, SimpleQueueProcessingStrategy)
+
+        strategy.submit(self.create_message("sub1", 0, 100))
+        strategy.submit(self.create_message("sub2", 1, 200))
+
+        assert self._wait_for_processed_count(2, timeout=2.0)
+
+        strategy.close()
+        strategy.join(timeout=1.0)
+        factory.shutdown()
+
+    def test_partition_revocation_and_reassignment(self):
+        """Test revoking partitions and reassigning new ones."""
+        factory = self.create_factory()
+        commit = self.create_commit_function()
+
+        initial_partitions = {
+            Partition(Topic("test"), 0): 100,
+            Partition(Topic("test"), 1): 200,
+        }
+
+        strategy = factory.create_with_partitions(commit, initial_partitions)
+
+        strategy.submit(self.create_message("sub1", 0, 100))
+        strategy.submit(self.create_message("sub2", 1, 200))
+
+        assert self._wait_for_processed_count(2, timeout=2.0)
+        initial_processed = len(self.processed_results)
+
+        strategy.close()
+        strategy.join(timeout=1.0)
+
+        new_partitions = {
+            Partition(Topic("test"), 1): 201,
+            Partition(Topic("test"), 2): 300,
+        }
+
+        new_strategy = factory.create_with_partitions(commit, new_partitions)
+
+        new_strategy.submit(self.create_message("sub3", 1, 201))
+        new_strategy.submit(self.create_message("sub4", 2, 300))
+
+        new_strategy.submit(self.create_message("sub5", 0, 101))
+
+        assert self._wait_for_processed_count(initial_processed + 2, timeout=2.0)
+
+        new_strategy.close()
+        new_strategy.join(timeout=1.0)
+        factory.shutdown()
+
+    def test_multiple_rebalances(self):
+        """Test multiple rebalances in succession."""
+        factory = self.create_factory()
+
+        partitions_1 = {Partition(Topic("test"), 0): 100}
+        strategy_1 = factory.create_with_partitions(self.create_commit_function(), partitions_1)
+        strategy_1.submit(self.create_message("sub1", 0, 100))
+        assert self._wait_for_processed_count(1, timeout=1.0)
+        strategy_1.close()
+        strategy_1.join(timeout=1.0)
+
+        partitions_2 = {Partition(Topic("test"), 1): 200}
+        strategy_2 = factory.create_with_partitions(self.create_commit_function(), partitions_2)
+        strategy_2.submit(self.create_message("sub2", 1, 200))
+        assert self._wait_for_processed_count(2, timeout=1.0)
+        strategy_2.close()
+        strategy_2.join(timeout=1.0)
+
+        partitions_3 = {
+            Partition(Topic("test"), 0): 101,
+            Partition(Topic("test"), 1): 201,
+            Partition(Topic("test"), 2): 300,
+        }
+        strategy_3 = factory.create_with_partitions(self.create_commit_function(), partitions_3)
+        strategy_3.submit(self.create_message("sub3", 0, 101))
+        strategy_3.submit(self.create_message("sub4", 1, 201))
+        strategy_3.submit(self.create_message("sub5", 2, 300))
+        assert self._wait_for_processed_count(5, timeout=1.0)
+        strategy_3.close()
+        strategy_3.join(timeout=1.0)
+
+        factory.shutdown()
+
+    def test_rebalance_with_pending_messages(self):
+        """Test rebalancing while messages are still being processed."""
+        factory = self.create_factory()
+        commit = self.create_commit_function()
+
+        partitions = {Partition(Topic("test"), 0): 100}
+        strategy = factory.create_with_partitions(commit, partitions)
+
+        for i in range(10):
+            strategy.submit(self.create_message(f"sub{i}", 0, 100 + i))
+
+        assert self._wait_for_processed_count(1, timeout=1.0)
+
+        strategy.close()
+        strategy.join(timeout=2.0)
+
+        initial_count = len(self.processed_results)
+        assert initial_count > 0
+
+        new_partitions = {Partition(Topic("test"), 1): 200}
+        new_strategy = factory.create_with_partitions(commit, new_partitions)
+
+        new_strategy.submit(self.create_message("new_sub", 1, 200))
+        assert self._wait_for_processed_count(initial_count + 1, timeout=1.0)
+
+        new_strategy.close()
+        new_strategy.join(timeout=1.0)
+        factory.shutdown()
+
+    def test_commit_behavior_during_rebalance(self):
+        """Test that commits work correctly during rebalances."""
+        factory = self.create_factory()
+
+        commit_1 = self.create_commit_function()
+        partitions_1 = {
+            Partition(Topic("test"), 0): 100,
+            Partition(Topic("test"), 1): 200,
+        }
+
+        strategy_1 = factory.create_with_partitions(commit_1, partitions_1)
+
+        for i in range(3):
+            strategy_1.submit(self.create_message("sub1", 0, 100 + i))
+            strategy_1.submit(self.create_message("sub2", 1, 200 + i))
+
+        assert self._wait_for_commits(timeout=1.0)
+
+        assert len(self.commit_calls) > 0
+        committed_partitions: set[Partition] = set()
+        for commit_call in self.commit_calls:
+            committed_partitions.update(commit_call.keys())
+        assert Partition(Topic("test"), 0) in committed_partitions
+        assert Partition(Topic("test"), 1) in committed_partitions
+
+        self.commit_calls.clear()
+
+        strategy_1.close()
+        strategy_1.join(timeout=1.0)
+
+        commit_2 = self.create_commit_function()
+        partitions_2 = {Partition(Topic("test"), 1): 203}
+
+        strategy_2 = factory.create_with_partitions(commit_2, partitions_2)
+
+        for i in range(3):
+            strategy_2.submit(self.create_message("sub3", 1, 203 + i))
+
+        assert self._wait_for_commits(timeout=1.0)
+
+        assert len(self.commit_calls) > 0
+        for commit_call in self.commit_calls:
+            assert Partition(Topic("test"), 0) not in commit_call
+            assert Partition(Topic("test"), 1) in commit_call
+
+        strategy_2.close()
+        strategy_2.join(timeout=1.0)
         factory.shutdown()

--- a/tests/sentry/uptime/consumers/test_results_consumer.py
+++ b/tests/sentry/uptime/consumers/test_results_consumer.py
@@ -95,7 +95,7 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
         message = Message(
             BrokerValue(
                 KafkaPayload(None, codec.encode(result), []),
-                Partition(Topic("test"), 1),
+                self.partition,
                 1,
                 datetime.now(),
             )


### PR DESCRIPTION
The thread-queue-parallel consumer was encountering errors during Kafka rebalances. This was caused by the commit thread continuing to run after partition revocation and attempting to commit offsets for partitions no longer owned by the consumer.

I also noticed a few other problems with the structure of things and improve those as well.

  - Move commit thread ownership from individual strategies to FixedQueuePool to survive rebalances
  - Add partition assignment validation to reject messages from unassigned partitions
  - Implement OffsetTracker.clear() to reset state during partition revocation
  - Add update_assignments() to atomically update partitions and commit function

<!-- Describe your PR here. -->