### PR TITLE
:bug: fix(integrations): catch halted exception for ticketing integrations when firing test notifications

### DIFF
--- a/src/sentry/api/endpoints/project_rule_actions.py
+++ b/src/sentry/api/endpoints/project_rule_actions.py
@@ -14,6 +14,7 @@ from sentry.eventstore.models import GroupEvent
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.models.rule import Rule
 from sentry.notifications.notification_action.utils import should_fire_workflow_actions
+from sentry.notifications.types import TEST_NOTIFICATION_ID
 from sentry.rules.processing.processor import activate_downstream_actions
 from sentry.shared_integrations.exceptions import IntegrationFormError
 from sentry.utils.samples import create_sample_event
@@ -69,7 +70,7 @@ class ProjectRuleActionsEndpoint(ProjectEndpoint):
                 "frequency": 30,
             }
         )
-        rule = Rule(id=-1, project=project, data=data, label=data.get("name"))
+        rule = Rule(id=TEST_NOTIFICATION_ID, project=project, data=data, label=data.get("name"))
 
         # Cast to GroupEvent rather than Event to match expected types
         test_event = create_sample_event(
@@ -150,13 +151,13 @@ class ProjectRuleActionsEndpoint(ProjectEndpoint):
         actions = rule.data.get("actions", [])
 
         workflow = Workflow(
-            id=-1,
+            id=TEST_NOTIFICATION_ID,
             name="Test Workflow",
             organization=rule.project.organization,
         )
 
         detector = Detector(
-            id=-1,
+            id=TEST_NOTIFICATION_ID,
             project=rule.project,
             name=rule.label,
             enabled=True,
@@ -173,7 +174,7 @@ class ProjectRuleActionsEndpoint(ProjectEndpoint):
                 action = translate_rule_data_actions_to_notification_actions(
                     [action_blob], skip_failures=False
                 )[0]
-                action.id = -1
+                action.id = TEST_NOTIFICATION_ID
                 # Annotate the action with the workflow id
                 setattr(action, "workflow_id", workflow.id)
             except Exception as e:

--- a/src/sentry/notifications/notification_action/types.py
+++ b/src/sentry/notifications/notification_action/types.py
@@ -22,6 +22,7 @@ from sentry.models.group import Group, GroupStatus
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.rule import Rule, RuleSource
+from sentry.notifications.types import TEST_NOTIFICATION_ID
 from sentry.rules.processing.processor import activate_downstream_actions
 from sentry.types.rules import RuleFuture
 from sentry.utils.safe import safe_execute
@@ -149,8 +150,8 @@ class BaseIssueAlertHandler(ABC):
                 raise ValueError("Workflow ID is required when triggering an action")
 
             # If test event, just set the legacy rule id to -1
-            if workflow_id == -1:
-                data["actions"][0]["legacy_rule_id"] = -1
+            if workflow_id == TEST_NOTIFICATION_ID:
+                data["actions"][0]["legacy_rule_id"] = TEST_NOTIFICATION_ID
             else:
                 try:
                     alert_rule_workflow = AlertRuleWorkflow.objects.get(
@@ -301,7 +302,7 @@ class BaseIssueAlertHandler(ABC):
 
             # Execute the futures
             # If the rule id is -1, we are sending a test notification
-            if rule.id == -1:
+            if rule.id == TEST_NOTIFICATION_ID:
                 cls.send_test_notification(event_data, futures)
             else:
                 cls.execute_futures(event_data, futures)

--- a/src/sentry/notifications/types.py
+++ b/src/sentry/notifications/types.py
@@ -264,3 +264,13 @@ class UnsubscribeContext:
     resource_id: int
     key: str
     referrer: str | None = None
+
+
+"""
+This is a special identifier that is used to indicate that the notification is a test notification.
+It is used to set the ID of models that are required in order to send a test notification.
+
+Note: This should eventually be deleted the test notification logic should instead utilize a notification platform
+which should provide an API for sending test notifications without "hacking" the notification system.
+"""
+TEST_NOTIFICATION_ID = -1

--- a/src/sentry/rules/actions/integrations/create_ticket/utils.py
+++ b/src/sentry/rules/actions/integrations/create_ticket/utils.py
@@ -19,6 +19,7 @@ from sentry.integrations.project_management.metrics import (
 from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.integrations.services.integration.service import integration_service
 from sentry.models.grouplink import GroupLink
+from sentry.notifications.types import TEST_NOTIFICATION_ID
 from sentry.notifications.utils.links import create_link_to_workflow
 from sentry.shared_integrations.exceptions import (
     ApiUnauthorized,
@@ -186,6 +187,9 @@ def create_issue(event: GroupEvent, futures: Sequence[RuleFuture]) -> None:
             ) as e:
                 # Most of the time, these aren't explicit failures, they're
                 # some misconfiguration of an issue field - typically Jira.
+                # We only want to raise if the rule_id is -1 because that means we're testing the action
                 lifecycle.record_halt(e)
+                if rule_id == TEST_NOTIFICATION_ID:
+                    raise
 
         create_link(integration, installation, event, response)

--- a/src/sentry/rules/actions/integrations/create_ticket/utils.py
+++ b/src/sentry/rules/actions/integrations/create_ticket/utils.py
@@ -187,6 +187,5 @@ def create_issue(event: GroupEvent, futures: Sequence[RuleFuture]) -> None:
                 # Most of the time, these aren't explicit failures, they're
                 # some misconfiguration of an issue field - typically Jira.
                 lifecycle.record_halt(e)
-                raise
 
         create_link(integration, installation, event, response)

--- a/src/sentry/rules/actions/integrations/create_ticket/utils.py
+++ b/src/sentry/rules/actions/integrations/create_ticket/utils.py
@@ -191,5 +191,6 @@ def create_issue(event: GroupEvent, futures: Sequence[RuleFuture]) -> None:
                 lifecycle.record_halt(e)
                 if rule_id == TEST_NOTIFICATION_ID:
                     raise
-
-        create_link(integration, installation, event, response)
+            # If we successfully created the issue, we want to create the link
+            else:
+                create_link(integration, installation, event, response)

--- a/src/sentry/workflow_engine/endpoints/organization_test_fire_action.py
+++ b/src/sentry/workflow_engine/endpoints/organization_test_fire_action.py
@@ -17,6 +17,7 @@ from sentry.apidocs.parameters import GlobalParams
 from sentry.constants import ObjectStatus
 from sentry.models.project import Project
 from sentry.notifications.notification_action.grouptype import get_test_notification_event_data
+from sentry.notifications.types import TEST_NOTIFICATION_ID
 from sentry.workflow_engine.endpoints.utils.test_fire_action import test_fire_action
 from sentry.workflow_engine.endpoints.validators.base.action import BaseActionValidator
 from sentry.workflow_engine.models import Action, Detector
@@ -104,14 +105,14 @@ def test_fire_actions(actions: list[dict[str, Any]], project: Project):
         # This can happen if the user is rate limited
         return HTTP_400_BAD_REQUEST, {"detail": "No test event was generated"}
 
-    workflow_id = -1
+    workflow_id = TEST_NOTIFICATION_ID
     workflow_event_data = WorkflowEventData(
         event=test_event,
         group=test_event.group,
     )
 
     detector = Detector(
-        id=-1,
+        id=TEST_NOTIFICATION_ID,
         project=project,
         name="Test Detector",
         enabled=True,
@@ -121,7 +122,7 @@ def test_fire_actions(actions: list[dict[str, Any]], project: Project):
     for action_data in actions:
         # Create a temporary Action object (not saved to database)
         action = Action(
-            id=-1,
+            id=TEST_NOTIFICATION_ID,
             type=action_data["type"],
             integration_id=action_data.get("integration_id"),
             data=action_data.get("data", {}),

--- a/tests/sentry/integrations/jira/test_ticket_action.py
+++ b/tests/sentry/integrations/jira/test_ticket_action.py
@@ -207,10 +207,7 @@ class JiraTicketRulesTestCase(RuleTestCase, BaseAPITestCase):
             rule_object = Rule.objects.get(id=response.data["id"])
             event = self.get_event()
 
-            with pytest.raises(IntegrationFormError):
-                # Trigger its `after`, but with a broken client which should raise
-                # an ApiInvalidRequestError, which is reraised as an IntegrationError.
-                self.trigger(event, rule_object)
+            self.trigger(event, rule_object)
 
             assert mock_record_event.call_count == 2
             start, halt = mock_record_event.call_args_list
@@ -232,8 +229,7 @@ class JiraTicketRulesTestCase(RuleTestCase, BaseAPITestCase):
             rule_object = Rule.objects.get(id=response.data["id"])
             event = self.get_event()
 
-            with pytest.raises(IntegrationInstallationConfigurationError):
-                self.trigger(event, rule_object)
+            self.trigger(event, rule_object)
 
             assert mock_record_event.call_count == 2
             start, halt = mock_record_event.call_args_list


### PR DESCRIPTION
playing around with the sentry mcp server!

should resolve 
* SENTRY-2PCT
* SENTRY-3Y84
* SENTRY-3YEB
* SENTRY-3Z02
* SENTRY-3Y9Y
* SENTRY-3Z06
* SENTRY-43M9
* SENTRY-3ZNC
* SENTRY-3YRD
* SENTRY-3ZNF
* SENTRY-44F7
* SENTRY-3YFF
* SENTRY-470Q
* SENTRY-3Y8V
* SENTRY-470M
* SENTRY-475Y
* SENTRY-3YA2
* SENTRY-3YGH
* SENTRY-3ZZG

We need to swallow these errors so we don't create sentry issues out of them. 

In reality this tiny bug probably has introduced _tons_ of new Ecosystem Issues since the exceptions were bubbling up to `safe_execute` which would then report a sentry issue.

The problem we have is that we use this `raise` so that we can propagate the errors in the frontend for "Send Test Notification." In order for this to work with `post_process` as well, I opt to check for the `rule_id` since it will _always_ be -1 for test notifications.

While this isn't the most ideal solution, I think the benefits of not created many (my estimates about a 1/6 of all ecosystem issues) outweigh this "-1" check.
