### PR TITLE
fix(replay): Pass `undefiend` to `handleSortClick` when sorting isnt defined

### DIFF
--- a/static/app/components/replays/table/replayTableHeader.tsx
+++ b/static/app/components/replays/table/replayTableHeader.tsx
@@ -26,15 +26,17 @@ export default function ReplayTableHeader({columns, replays, onSortClick, sort}:
 
   return (
     <SimpleTable.Header>
-      {columns.map((column, columnIndex) => (
+      {columns.map(({Header, sortKey}, columnIndex) => (
         <SimpleTable.HeaderCell
-          key={`${column.sortKey}-${columnIndex}`}
-          handleSortClick={() => column.sortKey && onSortClick?.(column.sortKey)}
-          sort={column.sortKey && sort?.field === column.sortKey ? sort.kind : undefined}
+          key={`${sortKey}-${columnIndex}`}
+          handleSortClick={
+            onSortClick && sortKey ? () => onSortClick(sortKey) : undefined
+          }
+          sort={sortKey && sort?.field === sortKey ? sort.kind : undefined}
         >
-          {typeof column.Header === 'function'
-            ? column.Header({columnIndex, listItemCheckboxState, replays})
-            : column.Header}
+          {typeof Header === 'function'
+            ? Header({columnIndex, listItemCheckboxState, replays})
+            : Header}
         </SimpleTable.HeaderCell>
       ))}
     </SimpleTable.Header>


### PR DESCRIPTION
This makes table headers divs instead of buttons when they don't support sorting. 
Sorting could be disabled at all times if a column hasn't defined `sortKey`, or it could be disabled for a whole table-instance if `onSortClick` isn't passed as a prop.

**Before**
Things looked clickable but weren't
<img width="1112" height="69" alt="Screenshot 2025-07-16 at 9 33 38 PM" src="https://github.com/user-attachments/assets/d7fd0bc5-116a-433e-8003-eca1f88ffd04" />

**After**
It's just normal text:
<img width="1105" height="63" alt="SCR-20250716-sqxl" src="https://github.com/user-attachments/assets/155e0660-bcab-47c6-8471-7f2cb0fa8d92" />
