### PR TITLE
perf(replays): prefetch ai summary data in ReplayDetailsProviders

### DIFF
--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -31,10 +31,6 @@ type HighlightCallbacks = ReturnType<typeof useReplayHighlighting>;
 // It has state that, when changed, will not trigger a react render.
 // Instead only expose methods that wrap `Replayer` and manage state.
 interface ReplayPlayerContextProps extends HighlightCallbacks {
-  aiSummaryContext: {
-    apiQueryResult?: ReturnType<typeof useApiQuery<SummaryResponse>>;
-  };
-
   /**
    * The context in which the replay is being viewed.
    */
@@ -99,6 +95,10 @@ interface ReplayPlayerContextProps extends HighlightCallbacks {
    */
   replay: ReplayReader | null;
 
+  replaySummary: {
+    apiQueryResult?: ReturnType<typeof useApiQuery<SummaryResponse>>;
+  };
+
   /**
    * Restart the replay
    */
@@ -126,7 +126,7 @@ interface ReplayPlayerContextProps extends HighlightCallbacks {
 }
 
 const ReplayPlayerContext = createContext<ReplayPlayerContextProps>({
-  aiSummaryContext: {},
+  replaySummary: {},
   analyticsContext: '',
   clearAllHighlights: () => {},
   currentTime: 0,
@@ -164,8 +164,6 @@ type Props = {
 
   replay: ReplayReader | null;
 
-  aiSummaryQueryResult?: ReturnType<typeof useApiQuery<SummaryResponse>>;
-
   /**
    * Start the video as soon as it's ready
    */
@@ -175,6 +173,8 @@ type Props = {
    * Time, in seconds, when the video should start
    */
   initialTimeOffsetMs?: ReturnType<typeof useInitialOffsetMs>;
+
+  replaySummaryQueryResult?: ReturnType<typeof useApiQuery<SummaryResponse>>;
 
   /**
    * Override return fields for testing
@@ -195,7 +195,7 @@ export function Provider({
   isFetching,
   replay,
   autoStart,
-  aiSummaryQueryResult,
+  replaySummaryQueryResult,
   value = {},
 }: Props) {
   const user = useUser();
@@ -614,7 +614,7 @@ export function Provider({
     <ReplayCurrentTimeContextProvider>
       <ReplayPlayerContext
         value={{
-          aiSummaryContext: {apiQueryResult: aiSummaryQueryResult},
+          replaySummary: {apiQueryResult: replaySummaryQueryResult},
           analyticsContext,
           clearAllHighlights,
           currentTime,

--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -7,6 +7,7 @@ import useReplayHighlighting from 'sentry/components/replays/useReplayHighlighti
 import {VideoReplayerWithInteractions} from 'sentry/components/replays/videoReplayerWithInteractions';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import clamp from 'sentry/utils/number/clamp';
+import type {useApiQuery} from 'sentry/utils/queryClient';
 import type useInitialOffsetMs from 'sentry/utils/replays/hooks/useInitialTimeOffsetMs';
 import useTouchEventsCheck from 'sentry/utils/replays/playback/hooks/useTouchEventsCheck';
 import {useReplayPrefs} from 'sentry/utils/replays/playback/providers/replayPreferencesContext';
@@ -18,6 +19,7 @@ import usePrevious from 'sentry/utils/usePrevious';
 import useProjectFromId from 'sentry/utils/useProjectFromId';
 import useRAF from 'sentry/utils/useRAF';
 import {useUser} from 'sentry/utils/useUser';
+import type {SummaryResponse} from 'sentry/views/replays/detail/ai/useFetchReplaySummary';
 
 import {CanvasReplayerPlugin} from './canvasReplayerPlugin';
 
@@ -29,6 +31,10 @@ type HighlightCallbacks = ReturnType<typeof useReplayHighlighting>;
 // It has state that, when changed, will not trigger a react render.
 // Instead only expose methods that wrap `Replayer` and manage state.
 interface ReplayPlayerContextProps extends HighlightCallbacks {
+  aiSummaryContext: {
+    apiQueryResult?: ReturnType<typeof useApiQuery<SummaryResponse>>;
+  };
+
   /**
    * The context in which the replay is being viewed.
    */
@@ -120,6 +126,7 @@ interface ReplayPlayerContextProps extends HighlightCallbacks {
 }
 
 const ReplayPlayerContext = createContext<ReplayPlayerContextProps>({
+  aiSummaryContext: {},
   analyticsContext: '',
   clearAllHighlights: () => {},
   currentTime: 0,
@@ -157,6 +164,8 @@ type Props = {
 
   replay: ReplayReader | null;
 
+  aiSummaryQueryResult?: ReturnType<typeof useApiQuery<SummaryResponse>>;
+
   /**
    * Start the video as soon as it's ready
    */
@@ -186,6 +195,7 @@ export function Provider({
   isFetching,
   replay,
   autoStart,
+  aiSummaryQueryResult,
   value = {},
 }: Props) {
   const user = useUser();
@@ -604,6 +614,7 @@ export function Provider({
     <ReplayCurrentTimeContextProvider>
       <ReplayPlayerContext
         value={{
+          aiSummaryContext: {apiQueryResult: aiSummaryQueryResult},
           analyticsContext,
           clearAllHighlights,
           currentTime,

--- a/static/app/views/replays/detail/ai/ai.tsx
+++ b/static/app/views/replays/detail/ai/ai.tsx
@@ -31,7 +31,7 @@ export default function Ai() {
 
 function AiContent() {
   const organization = useOrganization();
-  const {replay, aiSummaryContext} = useReplayContext(); // Data is queried in ReplayDetailsProviders.
+  const {replay, replaySummary} = useReplayContext(); // Data is queried in ReplayDetailsProviders.
   const replayRecord = replay?.getReplay();
   const project = useProjectFromId({project_id: replayRecord?.project_id});
 
@@ -44,7 +44,7 @@ function AiContent() {
     return (
       <SummaryContainer>
         <Alert type="info">
-          {t('Replay AI summary is not available for this organization.')}
+          {t('Replay summary is not available for this organization.')}
         </Alert>
       </SummaryContainer>
     );
@@ -53,15 +53,15 @@ function AiContent() {
   if (replayRecord?.project_id && !project) {
     return (
       <SummaryContainer>
-        <Alert type="error">{t('Project not found. Unable to load AI summary.')}</Alert>
+        <Alert type="error">{t('Project not found. Unable to load summary.')}</Alert>
       </SummaryContainer>
     );
   }
 
-  if (!aiSummaryContext.apiQueryResult) {
+  if (!replaySummary.apiQueryResult) {
     return (
       <SummaryContainer>
-        <Alert type="error">{t('Unable to load AI summary.')}</Alert>
+        <Alert type="error">{t('Unable to load summary.')}</Alert>
       </SummaryContainer>
     );
   }
@@ -72,7 +72,7 @@ function AiContent() {
     isError,
     isRefetching,
     refetch,
-  } = aiSummaryContext.apiQueryResult;
+  } = replaySummary.apiQueryResult;
 
   if (isPending || isRefetching) {
     return (
@@ -85,7 +85,7 @@ function AiContent() {
   if (isError) {
     return (
       <SummaryContainer>
-        <Alert type="error">{t('Failed to load AI summary')}</Alert>
+        <Alert type="error">{t('Failed to load summary')}</Alert>
       </SummaryContainer>
     );
   }
@@ -101,7 +101,7 @@ function AiContent() {
   const feedbackButton = ({type}: {type: 'positive' | 'negative'}) => {
     return openForm ? (
       <Button
-        aria-label={t('Give feedback on the AI summary section')}
+        aria-label={t('Give feedback on the summary section')}
         icon={<IconThumb direction={type === 'positive' ? 'up' : 'down'} />}
         title={type === 'positive' ? t('I like this') : t(`I don't like this`)}
         size={'xs'}
@@ -109,8 +109,10 @@ function AiContent() {
           openForm({
             messagePlaceholder:
               type === 'positive'
-                ? t('What did you like about the AI summary and chapters?')
-                : t('How can we make the AI summary and chapters work better for you?'),
+                ? t('What did you like about the replay summary and chapters?')
+                : t(
+                    'How can we make the replay summary and chapters work better for you?'
+                  ),
             tags: {
               ['feedback.source']: 'replay_ai_summary',
               ['feedback.owner']: 'replay',

--- a/static/app/views/replays/detail/body/replayDetailsProviders.tsx
+++ b/static/app/views/replays/detail/body/replayDetailsProviders.tsx
@@ -12,6 +12,7 @@ import {ReplayPreferencesContextProvider} from 'sentry/utils/replays/playback/pr
 import {ReplayReaderProvider} from 'sentry/utils/replays/playback/providers/replayReaderProvider';
 import type ReplayReader from 'sentry/utils/replays/replayReader';
 import useOrganization from 'sentry/utils/useOrganization';
+import {useFetchReplaySummary} from 'sentry/views/replays/detail/ai/useFetchReplaySummary';
 import ReplayTransactionContext from 'sentry/views/replays/detail/trace/replayTransactionContext';
 
 interface Props {
@@ -40,6 +41,17 @@ export default function ReplayDetailsProviders({children, replay, projectSlug}: 
 
   useLogReplayDataLoaded({projectId: replayRecord.project_id, replay});
 
+  const aiSummaryData = useFetchReplaySummary({
+    staleTime: 0,
+    enabled: Boolean(
+      replayRecord?.id &&
+        projectSlug &&
+        organization.features.includes('replay-ai-summaries') &&
+        organization.features.includes('gen-ai-features')
+    ),
+    retry: false,
+  });
+
   return (
     <ReplayPreferencesContextProvider prefsStrategy={LocalStorageReplayPreferences}>
       <ReplayPlayerPluginsContextProvider>
@@ -51,6 +63,7 @@ export default function ReplayDetailsProviders({children, replay, projectSlug}: 
                 initialTimeOffsetMs={initialTimeOffsetMs}
                 isFetching={false}
                 replay={replay}
+                aiSummaryQueryResult={aiSummaryData}
               >
                 <ReplayTransactionContext replayRecord={replayRecord}>
                   {children}

--- a/static/app/views/replays/detail/body/replayDetailsProviders.tsx
+++ b/static/app/views/replays/detail/body/replayDetailsProviders.tsx
@@ -41,7 +41,7 @@ export default function ReplayDetailsProviders({children, replay, projectSlug}: 
 
   useLogReplayDataLoaded({projectId: replayRecord.project_id, replay});
 
-  const aiSummaryData = useFetchReplaySummary({
+  const replaySummaryQueryResult = useFetchReplaySummary({
     staleTime: 0,
     enabled: Boolean(
       replayRecord?.id &&
@@ -63,7 +63,7 @@ export default function ReplayDetailsProviders({children, replay, projectSlug}: 
                 initialTimeOffsetMs={initialTimeOffsetMs}
                 isFetching={false}
                 replay={replay}
-                aiSummaryQueryResult={aiSummaryData}
+                replaySummaryQueryResult={replaySummaryQueryResult}
               >
                 <ReplayTransactionContext replayRecord={replayRecord}>
                   {children}


### PR DESCRIPTION
Closes [REPLAY-449: Pre-load AI summaries upon loading replay details](https://linear.app/getsentry/issue/REPLAY-449/pre-load-ai-summaries-upon-loading-replay-details)