### PR TITLE
fix(replays): update ai summary regenerates to skip backend cache

### DIFF
--- a/static/app/views/replays/detail/ai/ai.tsx
+++ b/static/app/views/replays/detail/ai/ai.tsx
@@ -40,11 +40,11 @@ function AiContent() {
   const openForm = useFeedbackForm();
 
   // Until the first regenerate request, we use the prefetched result from aiSummaryContext.
-  const [regenerate, setRegenerate] = useState(false);
+  const [regenerated, setRegenerated] = useState(false);
   const regeneratedResults = useFetchReplaySummaryForceRegenerate({
     staleTime: 0,
     enabled:
-      regenerate &&
+      regenerated &&
       Boolean(
         replayRecord?.id &&
           project?.slug &&
@@ -60,7 +60,7 @@ function AiContent() {
     isError,
     isRefetching,
     refetch,
-  } = !!aiSummaryContext.apiQueryResult && !regenerate
+  } = !!aiSummaryContext.apiQueryResult && !regenerated
     ? aiSummaryContext.apiQueryResult
     : regeneratedResults;
 
@@ -157,10 +157,10 @@ function AiContent() {
               type="button"
               size="xs"
               onClick={() => {
-                if (regenerate) {
+                if (regenerated) {
                   refetch();
                 } else {
-                  setRegenerate(true);
+                  setRegenerated(true);
                 }
               }}
               icon={<IconSync size="xs" />}

--- a/static/app/views/replays/detail/ai/useFetchReplaySummary.tsx
+++ b/static/app/views/replays/detail/ai/useFetchReplaySummary.tsx
@@ -51,6 +51,9 @@ export function useFetchReplaySummary(options?: UseApiQueryOptions<SummaryRespon
   });
 }
 
+/**
+ * Use to force a regenerate of the AI summary, skipping the backend cache.
+ */
 export function useFetchReplaySummaryForceRegenerate(
   options?: UseApiQueryOptions<SummaryResponse>
 ) {

--- a/static/app/views/replays/detail/ai/useFetchReplaySummary.tsx
+++ b/static/app/views/replays/detail/ai/useFetchReplaySummary.tsx
@@ -21,23 +21,42 @@ export interface SummaryResponse {
 function createAISummaryQueryKey(
   orgSlug: string,
   projectSlug: string | undefined,
-  replayId: string
+  replayId: string,
+  query: Record<string, any> = {}
 ): ApiQueryKey {
   return [
     `/projects/${orgSlug}/${projectSlug}/replays/${replayId}/summarize/breadcrumbs/`,
+    {query},
   ];
 }
 
-export function useFetchReplaySummary(options?: UseApiQueryOptions<SummaryResponse>) {
+function useAISummaryQueryKey(query: Record<string, any> = {}): ApiQueryKey {
   const organization = useOrganization();
   const {replay} = useReplayContext();
   const replayRecord = replay?.getReplay();
   const project = useProjectFromId({project_id: replayRecord?.project_id});
-  return useApiQuery<SummaryResponse>(
-    createAISummaryQueryKey(organization.slug, project?.slug, replayRecord?.id ?? ''),
-    {
-      staleTime: 0,
-      ...options,
-    }
+  return createAISummaryQueryKey(
+    organization.slug,
+    project?.slug,
+    replayRecord?.id ?? '',
+    query
   );
+}
+
+export function useFetchReplaySummary(options?: UseApiQueryOptions<SummaryResponse>) {
+  const queryKey = useAISummaryQueryKey();
+  return useApiQuery<SummaryResponse>(queryKey, {
+    staleTime: 0,
+    ...options,
+  });
+}
+
+export function useFetchReplaySummaryForceRegenerate(
+  options?: UseApiQueryOptions<SummaryResponse>
+) {
+  const queryKey = useAISummaryQueryKey({regenerate: 'true'});
+  return useApiQuery<SummaryResponse>(queryKey, {
+    staleTime: 0,
+    ...options,
+  });
 }


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/95761
Depends on https://github.com/getsentry/sentry/pull/95471
Part of [REPLAY-389: Cache the summary](https://linear.app/getsentry/issue/REPLAY-389/cache-the-summary)