### PR TITLE
fix(ui): adjust horizontal tooltip arrows in chonkUI

### DIFF
--- a/static/app/components/overlayArrow.tsx
+++ b/static/app/components/overlayArrow.tsx
@@ -72,7 +72,7 @@ const ChonkWrap = chonkStyled('div')<{
   placement?: PopperProps<any>['placement'];
 }>`
   width: ${p => p.dimensions}px;
-  height: ${p => p.dimensions * sizeRatio}px;
+  height: ${p => (p.placement?.startsWith('left') || p.placement?.startsWith('right') ? p.dimensions : p.dimensions * sizeRatio)}px;
   position: absolute;
   transform-origin: center;
 


### PR DESCRIPTION
I broke the left/right aligned arrows in #95655, so repairing them here.

| before | after |
|--------|--------|
| <img width="1500" height="766" alt="Screenshot 2025-07-17 at 10 06 05" src="https://github.com/user-attachments/assets/47a3ca81-8309-4b70-b370-858aff71a55b" /> | <img width="1500" height="766" alt="Screenshot 2025-07-17 at 10 04 49" src="https://github.com/user-attachments/assets/f2bf5e41-7f42-4539-b05d-4f434d5a7320" /> | 