### PR TITLE
fix(seer): CSS selector specificity

### DIFF
--- a/static/app/components/events/autofix/autofixDiff.tsx
+++ b/static/app/components/events/autofix/autofixDiff.tsx
@@ -122,8 +122,8 @@ const SyntaxHighlightedCode = styled('div')`
   font-family: ${p => p.theme.text.familyMono};
   white-space: pre;
 
-  pre,
-  code {
+  pre[class*='language-'],
+  code[class*='language-'] {
     margin: 0;
     padding: 0;
     background: transparent;

--- a/static/app/components/events/autofix/autofixDiff.tsx
+++ b/static/app/components/events/autofix/autofixDiff.tsx
@@ -123,7 +123,7 @@ const SyntaxHighlightedCode = styled('div')`
   white-space: pre;
 
   pre[class*='language-'],
-  code[class*='language-'] {
+  code {
     margin: 0;
     padding: 0;
     background: transparent;

--- a/static/app/components/events/autofix/autofixDiff.tsx
+++ b/static/app/components/events/autofix/autofixDiff.tsx
@@ -122,8 +122,8 @@ const SyntaxHighlightedCode = styled('div')`
   font-family: ${p => p.theme.text.familyMono};
   white-space: pre;
 
-  pre[class*='language-'],
-  code {
+  && pre,
+  && code {
     margin: 0;
     padding: 0;
     background: transparent;


### PR DESCRIPTION
Increase selector specificity to reliably overwrite global styles.