### PR TITLE
fix(ui): fix traces toolbar styling in UI2

### DIFF
--- a/static/app/views/explore/toolbar/styles.tsx
+++ b/static/app/views/explore/toolbar/styles.tsx
@@ -3,7 +3,6 @@ import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/core/button';
 import {space} from 'sentry/styles/space';
-import {defined} from 'sentry/utils';
 
 export const ToolbarSection = styled('div')`
   margin-bottom: ${space(3)};
@@ -14,17 +13,15 @@ export const ToolbarHeader = styled('div')`
   flex-direction: row;
   justify-content: space-between;
   align-items: baseline;
-  margin-bottom: ${space(0.5)};
+  margin-bottom: ${p => (p.theme.isChonk ? p.theme.space.sm : p.theme.space.xs)};
 `;
 
-export const ToolbarLabel = styled('h6')<{disabled?: boolean; underlined?: boolean}>`
+export const ToolbarLabel = styled('h6')<{disabled?: boolean}>`
   color: ${p => (p.disabled ? p.theme.disabled : p.theme.gray500)};
   font-size: ${p => p.theme.form.md.fontSize};
   margin: 0;
-  ${p =>
-    !defined(p.underlined) || p.underlined
-      ? `text-decoration: underline dotted ${p.disabled ? p.theme.disabled : p.theme.gray300}`
-      : ''};
+  text-decoration: underline;
+  text-decoration-style: dotted;
 `;
 
 export const ToolbarFooterButton = styled(Button)<{disabled?: boolean}>`


### PR DESCRIPTION
- dotted underlines were barely visible in dark mode; now they have the same color as the text

| before | after |
|--------|--------|
| <img width="506" height="242" alt="Screenshot 2025-07-17 at 11 30 35" src="https://github.com/user-attachments/assets/0204be82-a939-499f-ab7f-75ba5517b206" /> | <img width="506" height="242" alt="Screenshot 2025-07-17 at 11 29 51" src="https://github.com/user-attachments/assets/a73e2204-c44a-4f52-b514-5d74c759cab8" /> | 

- increased spacing in UI2 to avoid buttons colliding with the underlined heading when they get hovered in chonk:

| before | after |
|--------|--------|
| <img width="506" height="242" alt="Screenshot 2025-07-17 at 11 30 39" src="https://github.com/user-attachments/assets/75b1d41b-5e6e-4087-859e-c2bcb392afcd" /> | <img width="506" height="242" alt="Screenshot 2025-07-17 at 11 29 57" src="https://github.com/user-attachments/assets/73dd9517-3cb5-41ef-b06e-f02b0d3274b3" /> | 