### PR TITLE
fix(ui2): reduces button cholnk

### DIFF
--- a/static/app/components/core/button/styles.chonk.tsx
+++ b/static/app/components/core/button/styles.chonk.tsx
@@ -4,8 +4,6 @@ import type {DO_NOT_USE_ButtonProps as ButtonProps} from 'sentry/components/core
 import {chonkFor} from 'sentry/components/core/chonk';
 // eslint-disable-next-line boundaries/element-types
 import type {StrictCSSObject} from 'sentry/utils/theme';
-// eslint-disable-next-line boundaries/element-types
-import {unreachable} from 'sentry/utils/unreachable';
 
 // @TODO: remove Link type in the future
 type ChonkButtonType =
@@ -35,21 +33,12 @@ function chonkPriorityToType(priority: ButtonProps['priority']): ChonkButtonType
   }
 }
 
-function chonkElevation(size: NonNullable<ButtonProps['size']>): string {
-  switch (size) {
-    case 'md':
-      return '3px';
-    case 'sm':
-      return '2px';
-    case 'xs':
-      return '1px';
-    case 'zero':
-      return '0px';
-    default:
-      unreachable(size);
-      throw new Error(`Unknown button size: ${size}`);
-  }
-}
+const chonkElevation = {
+  md: '3px',
+  sm: '2px',
+  xs: '1px',
+  zero: '0px',
+} satisfies Record<NonNullable<ButtonProps['size']>, string>;
 
 export function DO_NOT_USE_getChonkButtonStyles(
   p: Pick<ButtonProps, 'priority' | 'busy' | 'disabled' | 'borderless'> & {
@@ -70,6 +59,7 @@ export function DO_NOT_USE_getChonkButtonStyles(
   } as const;
 
   const chonkButtonTheme = getChonkButtonTheme(type, p.theme);
+  const elevation = chonkElevation[p.size];
 
   return {
     position: 'relative',
@@ -96,10 +86,10 @@ export function DO_NOT_USE_getChonkButtonStyles(
       display: 'block',
       position: 'absolute',
       inset: '0',
-      height: `calc(100% - ${chonkElevation(p.size)})`,
-      top: `${chonkElevation(p.size)}`,
-      transform: `translateY(-${chonkElevation(p.size)})`,
-      boxShadow: `0 ${chonkElevation(p.size)} 0 0px ${chonkButtonTheme.background}`,
+      height: `calc(100% - ${elevation})`,
+      top: `${elevation}`,
+      transform: `translateY(-${elevation})`,
+      boxShadow: `0 ${elevation} 0 0px ${chonkButtonTheme.background}`,
       background: chonkButtonTheme.background,
       borderRadius: 'inherit',
     },
@@ -112,7 +102,7 @@ export function DO_NOT_USE_getChonkButtonStyles(
       background: chonkButtonTheme.surface,
       borderRadius: 'inherit',
       border: `1px solid ${chonkButtonTheme.background}`,
-      transform: `translateY(-${chonkElevation(p.size)})`,
+      transform: `translateY(-${elevation})`,
       transition: 'transform 0.06s ease-in-out',
     },
 
@@ -138,7 +128,7 @@ export function DO_NOT_USE_getChonkButtonStyles(
       overflow: 'hidden',
 
       whiteSpace: 'nowrap',
-      transform: `translateY(-${chonkElevation(p.size)})`,
+      transform: `translateY(-${elevation})`,
       transition: 'transform 0.06s ease-in-out',
     },
 
@@ -146,10 +136,10 @@ export function DO_NOT_USE_getChonkButtonStyles(
       color: p.disabled || p.busy ? undefined : chonkButtonTheme.color,
 
       '&::after': {
-        transform: `translateY(calc(-${chonkElevation(p.size)} - 2px))`,
+        transform: `translateY(calc(-${elevation} - 2px))`,
       },
       '> span:last-child': {
-        transform: `translateY(calc(-${chonkElevation(p.size)} - 2px))`,
+        transform: `translateY(calc(-${elevation} - 2px))`,
       },
     },
 

--- a/static/app/components/core/button/styles.chonk.tsx
+++ b/static/app/components/core/button/styles.chonk.tsx
@@ -40,6 +40,8 @@ const chonkElevation = {
   zero: '0px',
 } satisfies Record<NonNullable<ButtonProps['size']>, string>;
 
+const chonkHoverElevation = '1px';
+
 export function DO_NOT_USE_getChonkButtonStyles(
   p: Pick<ButtonProps, 'priority' | 'busy' | 'disabled' | 'borderless'> & {
     size: NonNullable<ButtonProps['size']>;
@@ -136,10 +138,10 @@ export function DO_NOT_USE_getChonkButtonStyles(
       color: p.disabled || p.busy ? undefined : chonkButtonTheme.color,
 
       '&::after': {
-        transform: `translateY(calc(-${elevation} - 2px))`,
+        transform: `translateY(calc(-${elevation} - ${chonkHoverElevation}))`,
       },
       '> span:last-child': {
-        transform: `translateY(calc(-${elevation} - 2px))`,
+        transform: `translateY(calc(-${elevation} - ${chonkHoverElevation}))`,
       },
     },
 

--- a/static/app/components/core/button/styles.chonk.tsx
+++ b/static/app/components/core/button/styles.chonk.tsx
@@ -34,7 +34,7 @@ function chonkPriorityToType(priority: ButtonProps['priority']): ChonkButtonType
 }
 
 const chonkElevation = {
-  md: '3px',
+  md: '2px',
   sm: '2px',
   xs: '1px',
   zero: '0px',


### PR DESCRIPTION
- hover chonk was reduced from +2px to +1px
- regular chonk for `md` was reduced from 3px to 2px

final chonk values are:

| size | chonk | hover |
|--------|--------|--------|
| md | 2px | 3px |
| sm | 2px | 3px |
| xs | 1px | 2px |
| zero | 0px | 1px | 

regular state:

| before | after |
|--------|--------|
| <img width="1167" height="253" alt="Screenshot 2025-07-17 at 12 13 48" src="https://github.com/user-attachments/assets/d425831c-7cb7-4f25-85f0-62a9bfa11feb" /> | <img width="1167" height="253" alt="Screenshot 2025-07-17 at 12 15 12" src="https://github.com/user-attachments/assets/d4d8a246-7c1f-4991-9b94-a145d98e8cd3" /> |

hover state:

| before | after |
|--------|--------|
| <img width="1167" height="253" alt="Screenshot 2025-07-17 at 12 14 38" src="https://github.com/user-attachments/assets/07da3d10-b6fa-47df-907c-48355e7b82f6" /> | <img width="1167" height="253" alt="Screenshot 2025-07-17 at 12 15 29" src="https://github.com/user-attachments/assets/537d6e28-cec3-4bf9-b606-c74f34528d60" /> |