### PR TITLE
feat(ui2): chonky inputs

### DIFF
--- a/static/app/components/core/input/index.chonk.tsx
+++ b/static/app/components/core/input/index.chonk.tsx
@@ -11,9 +11,10 @@ export const chonkInputStyles = ({
 }: InputStylesProps & {theme: DO_NOT_USE_ChonkTheme}): StrictCSSObject => ({
   display: 'block',
   width: '100%',
-  color: theme.textColor,
-  background: theme.background,
-  border: `1px solid ${theme.border}`,
+  color: theme.tokens.content.primary,
+  background: theme.tokens.background.secondary,
+  boxShadow: `0px 2px 0px 0px ${theme.tokens.border.primary} inset`,
+  border: `1px solid ${theme.tokens.border.primary}`,
   fontWeight: theme.fontWeight.normal,
   resize: 'vertical',
   transition: 'border 0.1s, box-shadow 0.1s',
@@ -25,7 +26,7 @@ export const chonkInputStyles = ({
   ...theme.formRadius[size],
 
   '&::placeholder': {
-    color: theme.subText,
+    color: theme.tokens.content.muted,
     opacity: 1,
   },
 

--- a/static/app/components/core/select/index.chonk.tsx
+++ b/static/app/components/core/select/index.chonk.tsx
@@ -28,6 +28,8 @@ const multiValueSizeMapping = {
   },
 } satisfies Record<FormSize, {height: string; spacing: string}>;
 
+const chonk = '2px';
+
 export const getChonkStylesConfig = ({
   theme,
   size = 'md',
@@ -64,10 +66,10 @@ export const getChonkStylesConfig = ({
     control: (_, state) => ({
       display: 'flex',
       color: state.isDisabled ? theme.disabled : theme.textColor,
-      background: theme.background,
+      background: theme.tokens.background.secondary,
       border: `1px solid ${theme.border}`,
-      boxShadow: 'none',
-      borderRadius: theme.formRadius[size].borderRadius,
+      boxShadow: `0px ${chonk} 0px 0px ${theme.tokens.border.primary} inset`,
+      ...theme.formRadius[size],
       transition: 'border 0.1s, box-shadow 0.1s',
       alignItems: 'center',
       ...(state.isFocused && theme.focusRing),
@@ -159,9 +161,10 @@ export const getChonkStylesConfig = ({
       backgroundColor: theme.background,
       borderRadius: '4px',
       border: `1px solid ${theme.border}`,
+      boxShadow: `0px 1px 0px 0px ${theme.tokens.border.primary}`,
       display: 'flex',
       margin: 0,
-      marginTop: multiValueSizeMapping[size].spacing,
+      marginTop: `calc(${multiValueSizeMapping[size].spacing} + ${chonk})`,
       marginBottom: multiValueSizeMapping[size].spacing,
       marginRight: multiValueSizeMapping[size].spacing,
     }),
@@ -177,7 +180,7 @@ export const getChonkStylesConfig = ({
     multiValueRemove: () => ({
       alignItems: 'center',
       display: 'flex',
-      padding: '0 4px',
+      margin: '4px 4px',
 
       ...(isDisabled
         ? {
@@ -185,6 +188,7 @@ export const getChonkStylesConfig = ({
           }
         : {
             '&:hover': {
+              cursor: 'pointer',
               background: theme.hover,
             },
           }),

--- a/static/app/components/forms/fields/numberField.tsx
+++ b/static/app/components/forms/fields/numberField.tsx
@@ -106,4 +106,7 @@ const HiddenValue = styled('span')`
 const Suffix = styled('span')`
   color: ${p => p.theme.subText};
   margin-left: ${space(0.5)};
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
 `;


### PR DESCRIPTION
Add chonk to input, select, multi-select and textArea

<img width="1266" height="614" alt="Screenshot 2025-07-17 at 14 03 08" src="https://github.com/user-attachments/assets/6515dab6-123b-4f35-b645-5c07190b7718" />
<img width="1503" height="464" alt="Screenshot 2025-07-17 at 14 03 36" src="https://github.com/user-attachments/assets/38ddb89e-fe28-4f59-8c2c-740d19e5afed" />
<img width="1503" height="382" alt="Screenshot 2025-07-17 at 14 03 59" src="https://github.com/user-attachments/assets/36c5b0a7-ddeb-4736-ac67-9b64de8290df" />
<img width="1329" height="355" alt="Screenshot 2025-07-17 at 14 04 22" src="https://github.com/user-attachments/assets/f28d7d3a-7334-49cb-a59f-2b60250ba88b" />
<img width="1419" height="432" alt="Screenshot 2025-07-17 at 14 04 48" src="https://github.com/user-attachments/assets/9764e199-3da9-4e5f-8ac7-280738dd0165" />
