### PR TITLE
chore: Remove FID and CLS from span alert presets

### DIFF
--- a/static/app/views/alerts/rules/metric/wizardField.tsx
+++ b/static/app/views/alerts/rules/metric/wizardField.tsx
@@ -112,14 +112,6 @@ export default function WizardField({
       label: AlertWizardAlertNames.trace_item_lcp,
       value: 'trace_item_lcp',
     },
-    {
-      label: AlertWizardAlertNames.trace_item_fid,
-      value: 'trace_item_fid',
-    },
-    {
-      label: AlertWizardAlertNames.trace_item_cls,
-      value: 'trace_item_cls',
-    },
   ];
 
   const menuOptions: GroupedMenuOption[] = [

--- a/static/app/views/alerts/rules/utils.tsx
+++ b/static/app/views/alerts/rules/utils.tsx
@@ -225,8 +225,6 @@ export function isEapAlertType(alertType?: AlertType) {
     'trace_item_apdex',
     'trace_item_failure_rate',
     'trace_item_lcp',
-    'trace_item_fid',
-    'trace_item_cls',
     'trace_item_logs',
   ].includes(alertType);
 }

--- a/static/app/views/alerts/wizard/options.tsx
+++ b/static/app/views/alerts/wizard/options.tsx
@@ -51,8 +51,6 @@ export type AlertType =
   | 'trace_item_apdex'
   | 'trace_item_failure_rate'
   | 'trace_item_lcp'
-  | 'trace_item_fid'
-  | 'trace_item_cls'
   | 'trace_item_logs';
 
 export enum MEPAlertsQueryType {
@@ -107,8 +105,6 @@ export const AlertWizardAlertNames: Record<AlertType, string> = {
   trace_item_apdex: t('Apdex'),
   trace_item_failure_rate: t('Failure Rate'),
   trace_item_lcp: t('Largest Contentful Paint'),
-  trace_item_fid: t('First Input Delay'),
-  trace_item_cls: t('Cumulative Layout Shift'),
   eap_metrics: t('Spans'),
   trace_item_logs: t('Logs'),
   crons_monitor: t('Cron Monitor'),
@@ -158,8 +154,6 @@ export const getAlertWizardCategories = (org: Organization) => {
       'trace_item_apdex',
       'trace_item_failure_rate',
       'trace_item_lcp',
-      'trace_item_fid',
-      'trace_item_cls',
     ];
     result.push({
       categoryHeading: t('Performance'),
@@ -297,16 +291,6 @@ export const AlertWizardRuleTemplates: Record<
   },
   trace_item_lcp: {
     aggregate: 'p95(measurements.lcp)',
-    dataset: Dataset.EVENTS_ANALYTICS_PLATFORM,
-    eventTypes: EventTypes.TRACE_ITEM_SPAN,
-  },
-  trace_item_fid: {
-    aggregate: 'p95(measurements.fid)',
-    dataset: Dataset.EVENTS_ANALYTICS_PLATFORM,
-    eventTypes: EventTypes.TRACE_ITEM_SPAN,
-  },
-  trace_item_cls: {
-    aggregate: 'p95(measurements.cls)',
     dataset: Dataset.EVENTS_ANALYTICS_PLATFORM,
     eventTypes: EventTypes.TRACE_ITEM_SPAN,
   },

--- a/static/app/views/alerts/wizard/panelContent.tsx
+++ b/static/app/views/alerts/wizard/panelContent.tsx
@@ -225,22 +225,6 @@ export const AlertWizardPanelContent: Record<AlertType, PanelContent> = {
     docsLink: 'https://docs.sentry.io/product/performance/web-vitals',
     illustration: diagramLCP,
   },
-  trace_item_fid: {
-    description: t(
-      'First Input Delay (FID) measures interactivity as the response time when the user tries to interact with the viewport. A low FID helps ensure that a page is useful, and we recommend a FID of less than 100 milliseconds.'
-    ),
-    examples: [t('When the average FID of a page is longer than 4 seconds.')],
-    docsLink: 'https://docs.sentry.io/product/performance/web-vitals',
-    illustration: diagramFID,
-  },
-  trace_item_cls: {
-    description: t(
-      'Cumulative Layout Shift (CLS) measures visual stability by quantifying unexpected layout shifts that occur during the entire lifespan of the page. A CLS of less than 0.1 is a good user experience, while anything greater than 0.25 is poor.'
-    ),
-    examples: [t('When the CLS of a page is more than 0.5.')],
-    docsLink: 'https://docs.sentry.io/product/performance/web-vitals',
-    illustration: diagramCLS,
-  },
   trace_item_logs: {
     description: t(
       'Alert on log counts and log attributes such as severity, message and log level.'

--- a/static/app/views/alerts/wizard/utils.tsx
+++ b/static/app/views/alerts/wizard/utils.tsx
@@ -50,8 +50,6 @@ const alertTypeIdentifiers: Record<
     trace_item_apdex: 'apdex',
     trace_item_failure_rate: 'failure_rate()',
     trace_item_lcp: 'measurements.lcp',
-    trace_item_fid: 'measurements.fid',
-    trace_item_cls: 'measurements.cls',
   },
 };
 


### PR DESCRIPTION
They are legacy attributes, we don't want to surface them as top level attributes.