### PR TITLE
fix(ui): only forward allowed props from `Flex`

### DIFF
--- a/static/app/components/core/layout/flex.tsx
+++ b/static/app/components/core/layout/flex.tsx
@@ -1,4 +1,5 @@
 import type {CSSProperties} from 'react';
+import isPropValid from '@emotion/is-prop-valid';
 import styled from '@emotion/styled';
 
 interface FlexProps {
@@ -16,6 +17,7 @@ interface FlexProps {
 
 export const Flex = styled('div', {
   shouldForwardProp: prop =>
+    isPropValid(prop) &&
     !['align', 'direction', 'flex', 'gap', 'inline', 'justify', 'wrap'].includes(prop),
 })<FlexProps>`
   display: ${p => (p.inline ? 'inline-flex' : 'flex')};


### PR DESCRIPTION
This ensures props like `as` don't show up in the DOM, but are processed by emotion instead

---

Found out by accident that this `<Flex as=“section”>` we have in storybook didn’t work:

https://github.com/getsentry/sentry/blob/1aff620999f3bb754a8ab85f4af4e3d2a2e44040/static/app/stories/view/landing/index.tsx#L80

| before | after |
|--------|--------|
| <img width="583" height="107" alt="Screenshot 2025-07-17 at 15 11 39" src="https://github.com/user-attachments/assets/03120e08-feab-4e11-a5c2-f525ff17f5b9" /> | <img width="583" height="107" alt="Screenshot 2025-07-17 at 15 12 29" src="https://github.com/user-attachments/assets/c8d74b50-86e9-4182-85c7-801fd1ad8feb" /> | 
