### PR TITLE
fix(ui): alignment of read-the-docs button

### DIFF
--- a/static/app/components/events/featureFlags/onboarding/featureFlagOtherPlatformOnboarding.tsx
+++ b/static/app/components/events/featureFlags/onboarding/featureFlagOtherPlatformOnboarding.tsx
@@ -2,11 +2,9 @@ import styled from '@emotion/styled';
 
 import {Alert} from 'sentry/components/core/alert';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
-import {Flex} from 'sentry/components/core/layout';
 import OnboardingAdditionalFeatures from 'sentry/components/events/featureFlags/onboarding/onboardingAdditionalFeatures';
 import {AuthTokenGeneratorProvider} from 'sentry/components/onboarding/gettingStartedDoc/authTokenGenerator';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import useOrganization from 'sentry/utils/useOrganization';
 
 interface FeatureFlagOtherPlatformOnboardingProps {
@@ -30,13 +28,16 @@ export function FeatureFlagOtherPlatformOnboarding({
       <Wrapper>
         {
           <Alert.Container>
-            <Alert type="info" showIcon>
-              <Flex gap={space(3)}>
-                {t('Read the docs to learn more about setting up evaluation tracking.')}
-                <LinkButton href={docsUrl} external>
+            <Alert
+              type="info"
+              showIcon
+              trailingItems={
+                <LinkButton href={docsUrl} size="xs" external>
                   {t('Read the docs')}
                 </LinkButton>
-              </Flex>
+              }
+            >
+              {t('Read the docs to learn more about setting up evaluation tracking.')}
             </Alert>
           </Alert.Container>
         }


### PR DESCRIPTION
`trailingItems` inside `Alert` is made for actions like this:

| before | after |
|--------|--------|
| <img width="1160" height="135" alt="Screenshot 2025-07-17 at 16 16 02" src="https://github.com/user-attachments/assets/3856c08f-31dd-4a79-ab97-0229e889bfb0" /> | <img width="1160" height="135" alt="Screenshot 2025-07-17 at 16 16 10" src="https://github.com/user-attachments/assets/4f63c1c9-cba9-44e2-970f-3b072f33a247" /> |
| <img width="1160" height="135" alt="Screenshot 2025-07-17 at 16 15 53" src="https://github.com/user-attachments/assets/35a93952-9b79-4a93-a2d4-e1348d3349f1" /> | <img width="1160" height="135" alt="Screenshot 2025-07-17 at 16 15 30" src="https://github.com/user-attachments/assets/0e2bd77c-16f4-4a51-b72c-8c8432a5135e" /> | 