### PR TITLE
fix(debug-image): Query by debug id and code id

### DIFF
--- a/static/app/components/events/interfaces/debugMeta/debugImageDetails/index.spec.tsx
+++ b/static/app/components/events/interfaces/debugMeta/debugImageDetails/index.spec.tsx
@@ -18,7 +18,7 @@ describe('Debug Meta - Image Details', function () {
   beforeEach(function () {
     MockApiClient.clearMockResponses();
     MockApiClient.addMockResponse({
-      url: `/projects/${organization.slug}/${project.slug}/files/dsyms/?debug_id=${image.debug_id}&code_id=${image.code_id}`,
+      url: `/projects/${organization.slug}/${project.slug}/files/dsyms/`,
       method: 'GET',
       body: [],
     });

--- a/static/app/components/events/interfaces/debugMeta/debugImageDetails/index.spec.tsx
+++ b/static/app/components/events/interfaces/debugMeta/debugImageDetails/index.spec.tsx
@@ -18,7 +18,7 @@ describe('Debug Meta - Image Details', function () {
   beforeEach(function () {
     MockApiClient.clearMockResponses();
     MockApiClient.addMockResponse({
-      url: `/projects/${organization.slug}/${project.slug}/files/dsyms/?debug_id=${image.debug_id}`,
+      url: `/projects/${organization.slug}/${project.slug}/files/dsyms/?debug_id=${image.debug_id}&code_id=${image.code_id}`,
       method: 'GET',
       body: [],
     });

--- a/static/app/components/events/interfaces/debugMeta/debugImageDetails/index.spec.tsx
+++ b/static/app/components/events/interfaces/debugMeta/debugImageDetails/index.spec.tsx
@@ -21,6 +21,9 @@ describe('Debug Meta - Image Details', function () {
       url: `/projects/${organization.slug}/${project.slug}/files/dsyms/`,
       method: 'GET',
       body: [],
+      match: [
+        MockApiClient.matchQuery({debug_id: image?.debug_id, code_id: image?.code_id}),
+      ],
     });
 
     MockApiClient.addMockResponse({

--- a/static/app/components/events/interfaces/debugMeta/debugImageDetails/index.tsx
+++ b/static/app/components/events/interfaces/debugMeta/debugImageDetails/index.tsx
@@ -219,9 +219,11 @@ export function DebugImageDetails({
     refetch,
   } = useApiQuery<DebugFile[]>(
     [
-      `/projects/${organization.slug}/${projSlug}/files/dsyms/?debug_id=${image?.debug_id}&code_id=${image?.code_id}`,
+      `/projects/${organization.slug}/${projSlug}/files/dsyms/`,
       {
         query: {
+          debug_id: image?.debug_id,
+          code_id: image?.code_id,
           // FIXME(swatinem): Ideally we should not filter here at all,
           // though Symbolicator does not currently report `bcsymbolmap` and `il2cpp`
           // candidates, and we would thus show bogus "unapplied" entries for those,

--- a/static/app/components/events/interfaces/debugMeta/debugImageDetails/index.tsx
+++ b/static/app/components/events/interfaces/debugMeta/debugImageDetails/index.tsx
@@ -219,7 +219,7 @@ export function DebugImageDetails({
     refetch,
   } = useApiQuery<DebugFile[]>(
     [
-      `/projects/${organization.slug}/${projSlug}/files/dsyms/?debug_id=${image?.debug_id}`,
+      `/projects/${organization.slug}/${projSlug}/files/dsyms/?debug_id=${image?.debug_id}&code_id=${image?.code_id}`,
       {
         query: {
           // FIXME(swatinem): Ideally we should not filter here at all,

--- a/static/app/components/events/interfaces/debugMeta/index.spec.tsx
+++ b/static/app/components/events/interfaces/debugMeta/index.spec.tsx
@@ -31,6 +31,9 @@ describe('DebugMeta', function () {
       url: `/projects/${organization.slug}/${project.slug}/files/dsyms/`,
       method: 'GET',
       body: [],
+      match: [
+        MockApiClient.matchQuery({debug_id: image?.debug_id, code_id: image?.code_id}),
+      ],
     });
 
     render(

--- a/static/app/components/events/interfaces/debugMeta/index.spec.tsx
+++ b/static/app/components/events/interfaces/debugMeta/index.spec.tsx
@@ -28,7 +28,7 @@ describe('DebugMeta', function () {
     const event = EventFixture({entries: [eventEntryDebugMeta]});
     const image = eventEntryDebugMeta.data.images![0];
     const mockGetDebug = MockApiClient.addMockResponse({
-      url: `/projects/${organization.slug}/${project.slug}/files/dsyms/?debug_id=${image?.debug_id}`,
+      url: `/projects/${organization.slug}/${project.slug}/files/dsyms/?debug_id=${image!.debug_id}&code_id=${image!.code_id}`,
       method: 'GET',
       body: [],
     });

--- a/static/app/components/events/interfaces/debugMeta/index.spec.tsx
+++ b/static/app/components/events/interfaces/debugMeta/index.spec.tsx
@@ -28,7 +28,7 @@ describe('DebugMeta', function () {
     const event = EventFixture({entries: [eventEntryDebugMeta]});
     const image = eventEntryDebugMeta.data.images![0];
     const mockGetDebug = MockApiClient.addMockResponse({
-      url: `/projects/${organization.slug}/${project.slug}/files/dsyms/?debug_id=${image!.debug_id}&code_id=${image!.code_id}`,
+      url: `/projects/${organization.slug}/${project.slug}/files/dsyms/`,
       method: 'GET',
       body: [],
     });


### PR DESCRIPTION
Align the frontend with #95651

Refs: https://github.com/getsentry/symbolicator/issues/1731