### PR TITLE
fix(seer settings): fix settings page redirect

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -998,6 +998,14 @@ function buildRoutes() {
           />
         </Route>
       </Route>
+      <Route path="seer/" name={t('Seer Automation')}>
+        <IndexRoute component={make(() => import('getsentry/views/seerAutomation'))} />
+        <Route
+          path="onboarding/"
+          name={t('Configure Seer for All Projects')}
+          component={make(() => import('getsentry/views/seerAutomation/onboarding'))}
+        />
+      </Route>
       <Route path="stats/" name={t('Stats')}>
         {statsChildRoutes}
       </Route>


### PR DESCRIPTION
I believe the issue is that the route was not registered in `routes.tsx`, causing visiting the link directly to redirect