### PR TITLE
feat(tempest): Show prospero dumps in crash only view

### DIFF
--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -29,7 +29,7 @@ from sentry.users.services.user.model import RpcUser
 from sentry.utils.json import prune_empty_keys
 from sentry.utils.safe import get_path
 
-CRASH_FILE_TYPES = {"event.minidump"}
+CRASH_FILE_TYPES = {"event.minidump", "event.prosperodump"}
 RESERVED_KEYS = frozenset(["user", "sdk", "device", "contexts"])
 
 FORMATTED_BREADCRUMB_CATEGORIES = frozenset(["query", "sql.query"])

--- a/src/sentry/lang/native/processing.py
+++ b/src/sentry/lang/native/processing.py
@@ -42,6 +42,9 @@ MINIDUMP_ATTACHMENT_TYPE = "event.minidump"
 # Attachment type used for Apple Crash Reports
 APPLECRASHREPORT_ATTACHMENT_TYPE = "event.applecrashreport"
 
+# Attachment type used for prosperodump files
+PROSPERODUMP_ATTACHMENT_TYPE = "event.prosperodump"
+
 # Rules for rewriting the debug file of the first module
 # in an Electron minidump.
 #

--- a/src/sentry/models/eventattachment.py
+++ b/src/sentry/models/eventattachment.py
@@ -21,7 +21,7 @@ from sentry.utils import metrics
 from sentry.utils.storage import measure_storage_put
 
 # Attachment file types that are considered a crash report (PII relevant)
-CRASH_REPORT_TYPES = ("event.minidump", "event.applecrashreport")
+CRASH_REPORT_TYPES = ("event.minidump", "event.applecrashreport", "event.prosperodump")
 
 
 def get_crashreport_key(group_id: int) -> str:

--- a/static/app/views/issueDetails/groupEventAttachments/groupEventAttachmentsTableRow.tsx
+++ b/static/app/views/issueDetails/groupEventAttachments/groupEventAttachmentsTableRow.tsx
@@ -15,6 +15,7 @@ import {InlineEventAttachment} from 'sentry/views/issueDetails/groupEventAttachm
 const friendlyAttachmentType: Record<string, string> = {
   'event.minidump': t('Minidump'),
   'event.applecrashreport': t('Apple Crash Report'),
+  'event.prosperodump': t('Prosperodump'),
   'event.attachment': t('Other'),
 };
 

--- a/static/app/views/issueDetails/groupEventAttachments/useGroupEventAttachments.tsx
+++ b/static/app/views/issueDetails/groupEventAttachments/useGroupEventAttachments.tsx
@@ -38,6 +38,7 @@ interface MakeFetchGroupEventAttachmentsQueryKeyOptions
 type GroupEventAttachmentsTypeFilter =
   | 'event.minidump'
   | 'event.applecrashreport'
+  | 'event.prosperodump'
   | 'event.screenshot';
 
 interface GroupEventAttachmentsQuery {
@@ -94,7 +95,7 @@ export const makeFetchGroupEventAttachmentsQueryKey = ({
   if (activeAttachmentsTab === 'screenshot') {
     query.screenshot = '1';
   } else if (activeAttachmentsTab === 'onlyCrash') {
-    query.types = ['event.minidump', 'event.applecrashreport'];
+    query.types = ['event.minidump', 'event.applecrashreport', 'event.prosperodump'];
   }
 
   return [`/organizations/${orgSlug}/issues/${group.id}/attachments/`, {query}];

--- a/tests/sentry/api/endpoints/test_group_attachments.py
+++ b/tests/sentry/api/endpoints/test_group_attachments.py
@@ -61,6 +61,39 @@ class GroupEventAttachmentsTest(APITestCase):
         assert len(response.data) == 1
         assert response.data[0]["id"] == str(attachment2.id)
 
+    def test_prosperodump_filter(self):
+        self.login_as(user=self.user)
+
+        self.create_attachment(type="event.attachment")
+        attachment2 = self.create_attachment(type="event.prosperodump")
+
+        with self.feature("organizations:event-attachments"):
+            response = self.client.get(self.path(types=["event.prosperodump"]))
+
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 1
+        assert response.data[0]["id"] == str(attachment2.id)
+
+    def test_crash_reports_filter(self):
+        self.login_as(user=self.user)
+
+        self.create_attachment(type="event.attachment")
+        attachment2 = self.create_attachment(type="event.minidump")
+        attachment3 = self.create_attachment(type="event.applecrashreport")
+        attachment4 = self.create_attachment(type="event.prosperodump")
+
+        with self.feature("organizations:event-attachments"):
+            response = self.client.get(
+                self.path(types=["event.minidump", "event.applecrashreport", "event.prosperodump"])
+            )
+
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 3
+        attachment_ids = [attachment["id"] for attachment in response.data]
+        assert str(attachment2.id) in attachment_ids
+        assert str(attachment3.id) in attachment_ids
+        assert str(attachment4.id) in attachment_ids
+
     def test_screenshot_across_groups(self):
         self.login_as(user=self.user)
 


### PR DESCRIPTION
Fixes: https://linear.app/getsentry/issue/TEMPEST-24/show-prosperodump-on-only-crash-reports-tab-on-event-attachments