### PR TITLE
chore(otlp): Bump `sentry-kafka-schemas` to 1.3.17

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -64,7 +64,7 @@ rfc3339-validator>=0.1.2
 rfc3986-validator>=0.1.1
 # [end] jsonschema format validators
 sentry-arroyo>=2.28.0
-sentry-kafka-schemas>=1.3.14
+sentry-kafka-schemas>=1.3.17
 sentry-ophio>=1.1.3
 sentry-protos==0.3.1
 sentry-redis-tools>=0.5.0

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -186,7 +186,7 @@ sentry-devenv==1.21.0
 sentry-forked-django-stubs==5.2.1.post3
 sentry-forked-djangorestframework-stubs==3.16.0.post1
 sentry-forked-email-reply-parser==0.5.12.post1
-sentry-kafka-schemas==1.3.14
+sentry-kafka-schemas==1.3.17
 sentry-ophio==1.1.3
 sentry-protos==0.3.1
 sentry-redis-tools==0.5.0

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -123,7 +123,7 @@ rsa==4.8
 s3transfer==0.10.0
 sentry-arroyo==2.28.0
 sentry-forked-email-reply-parser==0.5.12.post1
-sentry-kafka-schemas==1.3.14
+sentry-kafka-schemas==1.3.17
 sentry-ophio==1.1.3
 sentry-protos==0.3.1
 sentry-redis-tools==0.5.0


### PR DESCRIPTION
This version includes definitions for segment span links: https://github.com/getsentry/sentry-kafka-schemas/releases/tag/1.3.17
