### PR TITLE
:wrench: chore(sentry apps): silently capture ChunkedEncodingErrors and ignore for unpublished apps

### DIFF
--- a/src/sentry/sentry_apps/metrics.py
+++ b/src/sentry/sentry_apps/metrics.py
@@ -69,6 +69,7 @@ class SentryAppWebhookHaltReason(StrEnum):
     INTEGRATOR_ERROR = "integrator_error"
     MISSING_INSTALLATION = "missing_installation"
     RESTRICTED_IP = "restricted_ip"
+    CONNECTION_RESET = "connection_reset"
 
 
 class SentryAppExternalRequestFailureReason(StrEnum):

--- a/src/sentry/sentry_apps/tasks/sentry_apps.py
+++ b/src/sentry/sentry_apps/tasks/sentry_apps.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from typing import Any
 
 from django.urls import reverse
-from requests.exceptions import RequestException
+from requests.exceptions import ChunkedEncodingError, RequestException
 
 from sentry import analytics, features, nodestore
 from sentry.api.serializers import serialize
@@ -79,6 +79,7 @@ CONTROL_TASK_OPTIONS = {
 
 retry_decorator = retry(
     on=(RequestException, ApiHostError, ApiTimeoutError),
+    on_silent=(ChunkedEncodingError),
     ignore=(
         ClientError,
         SentryAppSentryError,

--- a/src/sentry/tasks/base.py
+++ b/src/sentry/tasks/base.py
@@ -228,6 +228,7 @@ def instrumented_task(
 def retry(
     func: Callable[..., Any] | None = None,
     on: type[Exception] | tuple[type[Exception], ...] = (Exception,),
+    on_silent: type[Exception] | tuple[type[Exception], ...] = (),
     exclude: type[Exception] | tuple[type[Exception], ...] = (),
     ignore: type[Exception] | tuple[type[Exception], ...] = (),
     ignore_and_capture: type[Exception] | tuple[type[Exception], ...] = (),
@@ -257,6 +258,9 @@ def retry(
                 return
             except exclude:
                 raise
+            except on_silent as exc:
+                logger.info("silently retrying %s due to %s", func.__name__, exc)
+                retry_task(exc)
             except on as exc:
                 sentry_sdk.capture_exception()
                 retry_task(exc)

--- a/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
+++ b/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
@@ -4,6 +4,7 @@ from unittest.mock import ANY, patch
 import pytest
 import responses
 from django.urls import reverse
+from requests.exceptions import ChunkedEncodingError
 
 from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework import convert_dict_key_case, snake_to_camel_case
@@ -592,6 +593,80 @@ class TestProcessResourceChange(TestCase):
         # Verify that the exception was not captured by Sentry since it's ignored
         assert len(capture_exception.mock_calls) == 0
         assert safe_urlopen.called
+
+    @patch("sentry_sdk.capture_exception")
+    def test_silently_retries_chunked_encoding_error_unpublished(
+        self, capture_exception, safe_urlopen
+    ):
+        """
+        Test that a chunked encoding error is ignored when the sentry app is unpublished
+        """
+        with assume_test_silo_mode_of(SentryApp):
+            SentryApp.objects.all().delete()
+            SentryAppInstallation.objects.all().delete()
+
+        self.sentry_app = self.create_sentry_app(
+            organization=self.organization, events=["issue.created"]
+        )
+        self.install = self.create_sentry_app_installation(
+            organization=self.organization, slug=self.sentry_app.slug
+        )
+
+        safe_urlopen.side_effect = ChunkedEncodingError("Connection reset by peer")
+
+        event = self.store_event(data={}, project_id=self.project.id)
+        assert event.group is not None
+
+        with self.tasks():
+            post_process_group(
+                is_new=True,
+                is_regression=False,
+                is_new_group_environment=False,
+                cache_key=write_event_to_cache(event),
+                group_id=event.group_id,
+                project_id=self.project.id,
+                eventstream_type=EventStreamEventType.Error.value,
+            )
+
+        assert len(capture_exception.mock_calls) == 0
+        assert safe_urlopen.call_count == 1
+
+    @patch("sentry_sdk.capture_exception")
+    def test_silently_retries_chunked_encoding_error_published(
+        self, capture_exception, safe_urlopen
+    ):
+        """
+        Test that a chunked encoding error raises a retry error
+        """
+        with assume_test_silo_mode_of(SentryApp):
+            SentryApp.objects.all().delete()
+            SentryAppInstallation.objects.all().delete()
+
+        self.sentry_app = self.create_sentry_app(
+            organization=self.organization, published=True, events=["issue.created"]
+        )
+        self.install = self.create_sentry_app_installation(
+            organization=self.organization, slug=self.sentry_app.slug
+        )
+
+        safe_urlopen.side_effect = ChunkedEncodingError("Connection reset by peer")
+
+        event = self.store_event(data={}, project_id=self.project.id)
+        assert event.group is not None
+
+        with self.tasks():
+            post_process_group(
+                is_new=True,
+                is_regression=False,
+                is_new_group_environment=False,
+                cache_key=write_event_to_cache(event),
+                group_id=event.group_id,
+                project_id=self.project.id,
+                eventstream_type=EventStreamEventType.Error.value,
+            )
+
+        # Just 1 from the RetryError
+        assert len(capture_exception.mock_calls) == 1
 
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     def test_does_not_process_no_event(self, mock_record, safe_urlopen):


### PR DESCRIPTION
Resolves SENTRY-3PVS

We fix this in 2 different ways:
1. update the decorator to accept a `on_silent` param which retries without emitting a Error
2. turns out `ChunkedEncodingErrors` inherit from `RequestExceptions` which _does not_ inherit from `Exceptions`, so we need to separately ignore it for unpublished apps.

Closes ECO-852