### PR TITLE
fix(discover): use empty value if browser/os string is empty

### DIFF
--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -888,7 +888,7 @@ const SPECIAL_FIELDS: Record<string, SpecialField> = {
     sortField: 'browser.name',
     renderFunc: data => {
       const browserName = data['browser.name'];
-      if (typeof browserName !== 'string') {
+      if (typeof browserName !== 'string' || !browserName) {
         return <Container>{emptyStringValue}</Container>;
       }
 
@@ -904,7 +904,7 @@ const SPECIAL_FIELDS: Record<string, SpecialField> = {
     sortField: 'browser',
     renderFunc: data => {
       const browser = data.browser;
-      if (typeof browser !== 'string') {
+      if (typeof browser !== 'string' || !browser) {
         return <Container>{emptyStringValue}</Container>;
       }
 
@@ -920,7 +920,7 @@ const SPECIAL_FIELDS: Record<string, SpecialField> = {
     sortField: 'os.name',
     renderFunc: data => {
       const osName = data['os.name'];
-      if (typeof osName !== 'string') {
+      if (typeof osName !== 'string' || !osName) {
         return <Container>{emptyStringValue}</Container>;
       }
 
@@ -936,7 +936,7 @@ const SPECIAL_FIELDS: Record<string, SpecialField> = {
     sortField: 'os',
     renderFunc: data => {
       const os = data.os;
-      if (typeof os !== 'string') {
+      if (typeof os !== 'string' || !os) {
         return <Container>{emptyStringValue}</Container>;
       }
 


### PR DESCRIPTION
### Changes

Seems like browser/os can be an empty string which causes it to render as:

<img width="267" height="174" alt="Screenshot 2025-07-17 at 11 58 39 AM" src="https://github.com/user-attachments/assets/263338bc-b244-409c-9a5d-cd78fec40296" />

So instead render it as an empty string:

<img width="256" height="175" alt="Screenshot 2025-07-17 at 11 59 53 AM" src="https://github.com/user-attachments/assets/d3b75339-8ac6-436d-abb5-a02113d54f85" />
