### PR TITLE
chore(uptime): Remove query function for run_table

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -36,6 +36,7 @@ from sentry.snuba import (
     ourlogs,
     spans_rpc,
     transactions,
+    uptime_results,
 )
 from sentry.snuba.metrics.extraction import MetricSpecType
 from sentry.snuba.referrer import Referrer, is_valid_referrer
@@ -582,10 +583,15 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
                         config = SearchResolverConfig(
                             use_aggregate_conditions=False,
                         )
+                    elif scoped_dataset == uptime_results:
+                        config = SearchResolverConfig(
+                            use_aggregate_conditions=use_aggregate_conditions, auto_fields=True
+                        )
                     else:
                         config = SearchResolverConfig(
                             use_aggregate_conditions=use_aggregate_conditions,
                         )
+
                     return scoped_dataset.run_table_query(
                         params=snuba_params,
                         query_string=scoped_query or "",

--- a/src/sentry/snuba/uptime_checks.py
+++ b/src/sentry/snuba/uptime_checks.py
@@ -1,15 +1,12 @@
 import logging
 
-from snuba_sdk import Column, Condition
+import sentry_sdk
 
 from sentry.search.eap.resolver import SearchResolver
-from sentry.search.eap.types import SearchResolverConfig
+from sentry.search.eap.types import EAPResponse, SearchResolverConfig
 from sentry.search.eap.uptime_checks.definitions import UPTIME_CHECK_DEFINITIONS
-from sentry.search.events.types import EventsResponse, SnubaParams
-from sentry.snuba.dataset import Dataset
-from sentry.snuba.metrics.extraction import MetricSpecType
-from sentry.snuba.query_sources import QuerySource
-from sentry.snuba.rpc_dataset_common import TableQuery, run_table_query
+from sentry.search.events.types import SAMPLING_MODES, SnubaParams
+from sentry.snuba import rpc_dataset_common
 
 logger = logging.getLogger("sentry.snuba.uptime_checks")
 
@@ -22,51 +19,32 @@ def get_resolver(params: SnubaParams, config: SearchResolverConfig) -> SearchRes
     )
 
 
-def query(
+@sentry_sdk.trace
+def run_table_query(
+    params: SnubaParams,
+    query_string: str,
     selected_columns: list[str],
-    query: str,
-    snuba_params: SnubaParams,
+    orderby: list[str] | None,
+    offset: int,
+    limit: int,
+    referrer: str,
+    config: SearchResolverConfig,
+    sampling_mode: SAMPLING_MODES | None = None,
     equations: list[str] | None = None,
-    orderby: list[str] | None = None,
-    offset: int | None = None,
-    limit: int = 50,
-    referrer: str | None = None,
-    auto_fields: bool = False,
-    auto_aggregations: bool = False,
-    include_equation_fields: bool = False,
-    allow_metric_aggregates: bool = False,
-    use_aggregate_conditions: bool = False,
-    conditions: list[Condition] | None = None,
-    functions_acl: list[str] | None = None,
-    transform_alias_to_input_format: bool = False,
-    sample: float | None = None,
-    has_metrics: bool = False,
-    use_metrics_layer: bool = False,
-    skip_tag_resolution: bool = False,
-    extra_columns: list[Column] | None = None,
-    on_demand_metrics_enabled: bool = False,
-    on_demand_metrics_type: MetricSpecType | None = None,
-    dataset: Dataset = Dataset.Discover,
-    fallback_to_transactions: bool = False,
-    query_source: QuerySource | None = None,
+    search_resolver: SearchResolver | None = None,
     debug: bool = False,
-) -> EventsResponse:
-    return run_table_query(
-        TableQuery(
-            query_string=query or "",
+) -> EAPResponse:
+    return rpc_dataset_common.run_table_query(
+        rpc_dataset_common.TableQuery(
+            query_string=query_string,
             selected_columns=selected_columns,
+            equations=equations,
             orderby=orderby,
-            offset=offset or 0,
+            offset=offset,
             limit=limit,
-            referrer=referrer or "referrer unset",
-            sampling_mode=None,
-            resolver=get_resolver(
-                params=snuba_params,
-                config=SearchResolverConfig(
-                    auto_fields=False,
-                    use_aggregate_conditions=use_aggregate_conditions,
-                ),
-            ),
+            referrer=referrer,
+            sampling_mode=sampling_mode,
+            resolver=search_resolver or get_resolver(params, config),
         ),
-        debug=debug,
+        debug,
     )

--- a/src/sentry/snuba/uptime_results.py
+++ b/src/sentry/snuba/uptime_results.py
@@ -1,15 +1,12 @@
 import logging
 
-from snuba_sdk import Column, Condition
+import sentry_sdk
 
 from sentry.search.eap.resolver import SearchResolver
-from sentry.search.eap.types import SearchResolverConfig
+from sentry.search.eap.types import EAPResponse, SearchResolverConfig
 from sentry.search.eap.uptime_results.definitions import UPTIME_RESULT_DEFINITIONS
-from sentry.search.events.types import EventsResponse, SnubaParams
-from sentry.snuba.dataset import Dataset
-from sentry.snuba.metrics.extraction import MetricSpecType
-from sentry.snuba.query_sources import QuerySource
-from sentry.snuba.rpc_dataset_common import TableQuery, run_table_query
+from sentry.search.events.types import SAMPLING_MODES, SnubaParams
+from sentry.snuba import rpc_dataset_common
 
 logger = logging.getLogger("sentry.snuba.uptime_results")
 
@@ -22,51 +19,32 @@ def get_resolver(params: SnubaParams, config: SearchResolverConfig) -> SearchRes
     )
 
 
-def query(
+@sentry_sdk.trace
+def run_table_query(
+    params: SnubaParams,
+    query_string: str,
     selected_columns: list[str],
-    query: str,
-    snuba_params: SnubaParams,
+    orderby: list[str] | None,
+    offset: int,
+    limit: int,
+    referrer: str,
+    config: SearchResolverConfig,
+    sampling_mode: SAMPLING_MODES | None = None,
     equations: list[str] | None = None,
-    orderby: list[str] | None = None,
-    offset: int | None = None,
-    limit: int = 50,
-    referrer: str | None = None,
-    auto_fields: bool = False,
-    auto_aggregations: bool = False,
-    include_equation_fields: bool = False,
-    allow_metric_aggregates: bool = False,
-    use_aggregate_conditions: bool = False,
-    conditions: list[Condition] | None = None,
-    functions_acl: list[str] | None = None,
-    transform_alias_to_input_format: bool = False,
-    sample: float | None = None,
-    has_metrics: bool = False,
-    use_metrics_layer: bool = False,
-    skip_tag_resolution: bool = False,
-    extra_columns: list[Column] | None = None,
-    on_demand_metrics_enabled: bool = False,
-    on_demand_metrics_type: MetricSpecType | None = None,
-    dataset: Dataset = Dataset.Discover,
-    fallback_to_transactions: bool = False,
-    query_source: QuerySource | None = None,
+    search_resolver: SearchResolver | None = None,
     debug: bool = False,
-) -> EventsResponse:
-    return run_table_query(
-        TableQuery(
-            query_string=query or "",
+) -> EAPResponse:
+    return rpc_dataset_common.run_table_query(
+        rpc_dataset_common.TableQuery(
+            query_string=query_string,
             selected_columns=selected_columns,
-            orderby=orderby or [],
-            offset=offset or 0,
+            equations=equations,
+            orderby=orderby,
+            offset=offset,
             limit=limit,
-            referrer=referrer or "referrer unset",
-            sampling_mode=None,
-            resolver=get_resolver(
-                params=snuba_params,
-                config=SearchResolverConfig(
-                    auto_fields=auto_fields,
-                    use_aggregate_conditions=use_aggregate_conditions,
-                ),
-            ),
+            referrer=referrer,
+            sampling_mode=sampling_mode,
+            resolver=search_resolver or get_resolver(params, config),
         ),
-        debug=debug,
+        debug,
     )

--- a/src/sentry/snuba/utils.py
+++ b/src/sentry/snuba/utils.py
@@ -41,6 +41,8 @@ DATASET_OPTIONS = {
 RPC_DATASETS = {
     spans_rpc,
     ourlogs,
+    uptime_results,
+    uptime_checks,
 }
 DATASET_LABELS = {value: key for key, value in DATASET_OPTIONS.items()}
 


### PR DESCRIPTION
- Follow up to #95719
- Replaces the query function for run_table because i want to move all of these to class based so the parameters etc. can be enforced instead and also because run_table doesn't have the like 400 extra params
- I think auto_fields is being set to True accidentally on uptime results? But I'm not sure