### PR TITLE
fix(detectors): Add rails filter to query injection detector 

### DIFF
--- a/src/sentry/performance_issues/detectors/sql_injection_detector.py
+++ b/src/sentry/performance_issues/detectors/sql_injection_detector.py
@@ -209,6 +209,7 @@ class SQLInjectionDetector(PerformanceDetector):
         if not op or not op.startswith("db") or op.startswith("db.redis"):
             return False
 
+        # Auto-generated rails queries can contain interpolated values
         if span.get("origin") == "auto.db.rails":
             return False
 

--- a/src/sentry/performance_issues/detectors/sql_injection_detector.py
+++ b/src/sentry/performance_issues/detectors/sql_injection_detector.py
@@ -209,6 +209,9 @@ class SQLInjectionDetector(PerformanceDetector):
         if not op or not op.startswith("db") or op.startswith("db.redis"):
             return False
 
+        if span.get("origin") == "auto.db.rails":
+            return False
+
         description = span.get("description", None)
         if not description:
             return False


### PR DESCRIPTION
got feedback that auto generated queries from rails have interpolated values in them which can cause false positives. filtering out `auto.db.rails` should prevent these false positives, while catching any custom queries that could be vulnerable. 