### PR TITLE
fix(slack): Allow team linking to specific organization

### DIFF
--- a/src/sentry/integrations/middleware/hybrid_cloud/parser.py
+++ b/src/sentry/integrations/middleware/hybrid_cloud/parser.py
@@ -279,17 +279,6 @@ class BaseRequestParser(ABC):
         """
         return None
 
-    def get_organization_from_request(
-        self,
-        integration: Integration | RpcIntegration,
-        organization_integrations: list[OrganizationIntegration],
-    ) -> RpcOrganizationMapping | None:
-        """
-        Parse the request to retrieve the organization to forward the request to.
-        Should be overwritten by implementation.
-        """
-        return None
-
     # Optional Overrides
 
     def get_organizations_from_integration(
@@ -335,13 +324,18 @@ class BaseRequestParser(ABC):
             if not sample_modulo("hybrid_cloud.integration_region_targeting_rate", integration.id):
                 return all_organizations
 
-            # (TARGET_RATE)% of integrations will attempt to target a specific organization...
-            target_organization = self.get_organization_from_request(
-                integration=integration,
-                organization_integrations=list(organization_integrations),
-            )
-            # ... but fallback to all organizations if they don't find one
-            return [target_organization] if target_organization else all_organizations
+            # (TARGET_RATE)% of integrations will attempt to target a specific organization
+            return self.filter_organizations_from_request(organizations=all_organizations)
+
+    def filter_organizations_from_request(
+        self,
+        organizations: list[RpcOrganizationMapping],
+    ) -> list[RpcOrganizationMapping]:
+        """
+        Parse the request to retrieve the organization to forward the request to.
+        Should be overwritten by implementation.
+        """
+        return organizations
 
     def get_regions_from_organizations(
         self, organizations: list[RpcOrganizationMapping] | None = None

--- a/src/sentry/integrations/middleware/hybrid_cloud/parser.py
+++ b/src/sentry/integrations/middleware/hybrid_cloud/parser.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 from abc import ABC
-from collections.abc import Mapping, Sequence
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import TYPE_CHECKING, Any, ClassVar
 
@@ -17,6 +16,7 @@ from sentry.constants import ObjectStatus
 from sentry.hybridcloud.models.webhookpayload import WebhookPayload
 from sentry.hybridcloud.outbox.category import WebhookProviderIdentifier
 from sentry.hybridcloud.services.organization_mapping import organization_mapping_service
+from sentry.hybridcloud.services.organization_mapping.model import RpcOrganizationMapping
 from sentry.integrations.middleware.metrics import (
     MiddlewareHaltReason,
     MiddlewareOperationEvent,
@@ -25,12 +25,12 @@ from sentry.integrations.middleware.metrics import (
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.services.integration.model import RpcIntegration
-from sentry.organizations.services.organization import RpcOrganizationSummary
 from sentry.ratelimits import backend as ratelimiter
 from sentry.silo.base import SiloLimit, SiloMode
 from sentry.silo.client import RegionSiloClient, SiloClientError
 from sentry.types.region import Region, find_regions_for_orgs, get_region_by_name
 from sentry.utils import metrics
+from sentry.utils.options import sample_modulo
 
 logger = logging.getLogger(__name__)
 if TYPE_CHECKING:
@@ -135,12 +135,10 @@ class BaseRequestParser(ABC):
                 http_response = region_client.proxy_request(incoming_request=self.request)
                 return http_response
 
-    def get_responses_from_region_silos(
-        self, regions: Sequence[Region]
-    ) -> Mapping[str, RegionResult]:
+    def get_responses_from_region_silos(self, regions: list[Region]) -> dict[str, RegionResult]:
         """
         Used to handle the requests on a given list of regions (synchronously).
-        Returns a mapping of region name to response/exception.
+        Returns a dict of region name to response/exception.
         """
         self.ensure_control_silo()
 
@@ -164,7 +162,7 @@ class BaseRequestParser(ABC):
 
     def get_response_from_webhookpayload(
         self,
-        regions: Sequence[Region],
+        regions: list[Region],
         identifier: int | str | None = None,
         integration_id: int | None = None,
     ):
@@ -188,7 +186,7 @@ class BaseRequestParser(ABC):
         return HttpResponse(status=status.HTTP_202_ACCEPTED)
 
     def get_mailbox_identifier(
-        self, integration: RpcIntegration | Integration, data: Mapping[str, Any]
+        self, integration: RpcIntegration | Integration, data: dict[str, Any]
     ) -> str:
         """
         Used by integrations with higher hook volumes to create smaller mailboxes
@@ -220,7 +218,7 @@ class BaseRequestParser(ABC):
 
         return f"{integration.id}:{bucket_number}"
 
-    def mailbox_bucket_id(self, data: Mapping[str, Any]) -> int | None:
+    def mailbox_bucket_id(self, data: dict[str, Any]) -> int | None:
         raise NotImplementedError(
             "You must implement mailbox_bucket_id to use bucketed identifiers"
         )
@@ -276,7 +274,18 @@ class BaseRequestParser(ABC):
 
     def get_integration_from_request(self) -> Integration | None:
         """
-        Parse the request to retreive organizations to forward the request to.
+        Parse the request to retrieve integration the request pertains to.
+        Should be overwritten by implementation.
+        """
+        return None
+
+    def get_organization_from_request(
+        self,
+        integration: Integration | RpcIntegration,
+        organization_integrations: list[OrganizationIntegration],
+    ) -> RpcOrganizationMapping | None:
+        """
+        Parse the request to retrieve the organization to forward the request to.
         Should be overwritten by implementation.
         """
         return None
@@ -285,7 +294,7 @@ class BaseRequestParser(ABC):
 
     def get_organizations_from_integration(
         self, integration: Integration | RpcIntegration | None = None
-    ) -> Sequence[RpcOrganizationSummary]:
+    ) -> list[RpcOrganizationMapping]:
         """
         Use the get_integration_from_request() method to identify organizations associated with
         the integration request.
@@ -318,11 +327,25 @@ class BaseRequestParser(ABC):
                 return []
 
             organization_ids = [oi.organization_id for oi in organization_integrations]
-            return organization_mapping_service.get_many(organization_ids=organization_ids)
+            all_organizations = organization_mapping_service.get_many(
+                organization_ids=organization_ids
+            )
+
+            # (1-TARGET_RATE)% of integrations will return all the organizations
+            if not sample_modulo("hybrid_cloud.integration_region_targeting_rate", integration.id):
+                return all_organizations
+
+            # (TARGET_RATE)% of integrations will attempt to target a specific organization...
+            target_organization = self.get_organization_from_request(
+                integration=integration,
+                organization_integrations=list(organization_integrations),
+            )
+            # ... but fallback to all organizations if they don't find one
+            return [target_organization] if target_organization else all_organizations
 
     def get_regions_from_organizations(
-        self, organizations: Sequence[RpcOrganizationSummary] | None = None
-    ) -> Sequence[Region]:
+        self, organizations: list[RpcOrganizationMapping] | None = None
+    ) -> list[Region]:
         """
         Use the get_organizations_from_integration() method to identify forwarding regions.
         """

--- a/src/sentry/middleware/integrations/integration_control.py
+++ b/src/sentry/middleware/integrations/integration_control.py
@@ -48,8 +48,8 @@ class IntegrationControlMiddleware:
         cls.classifications += classifications
 
     def __call__(self, request: HttpRequest):
-        if not self._should_operate(request):
-            return self.get_response(request)
+        # if not self._should_operate(request):
+        #     return self.get_response(request)
 
         # Check request against each classification, if a match is found, return early
         for classification in self.classifications:

--- a/src/sentry/middleware/integrations/integration_control.py
+++ b/src/sentry/middleware/integrations/integration_control.py
@@ -48,8 +48,8 @@ class IntegrationControlMiddleware:
         cls.classifications += classifications
 
     def __call__(self, request: HttpRequest):
-        # if not self._should_operate(request):
-        #     return self.get_response(request)
+        if not self._should_operate(request):
+            return self.get_response(request)
 
         # Check request against each classification, if a match is found, return early
         for classification in self.classifications:

--- a/src/sentry/middleware/integrations/parsers/slack.py
+++ b/src/sentry/middleware/integrations/parsers/slack.py
@@ -235,7 +235,7 @@ class SlackRequestParser(BaseRequestParser):
             link_input = None
             if commands.LINK_TEAM.command_slug.does_match(cmd_input):
                 link_input = cmd_input.adjust(commands.LINK_TEAM.command_slug)
-            if commands.UNLINK_TEAM.command_slug.does_match(cmd_input):
+            elif commands.UNLINK_TEAM.command_slug.does_match(cmd_input):
                 link_input = cmd_input.adjust(commands.UNLINK_TEAM.command_slug)
             if not link_input or not link_input.arg_values:
                 return organizations

--- a/src/sentry/middleware/integrations/parsers/slack.py
+++ b/src/sentry/middleware/integrations/parsers/slack.py
@@ -12,6 +12,8 @@ from rest_framework.request import Request
 from slack_sdk.errors import SlackApiError
 
 from sentry.hybridcloud.outbox.category import WebhookProviderIdentifier
+from sentry.hybridcloud.services.organization_mapping.model import RpcOrganizationMapping
+from sentry.integrations.messaging import commands
 from sentry.integrations.middleware.hybrid_cloud.parser import (
     BaseRequestParser,
     create_async_request_payload,
@@ -215,6 +217,38 @@ class SlackRequestParser(BaseRequestParser):
             return Integration.objects.filter(id=params["integration_id"]).first()
 
         return None
+
+    def filter_organizations_from_request(
+        self,
+        organizations: list[RpcOrganizationMapping],
+    ) -> list[RpcOrganizationMapping]:
+        """
+        For linking/unlinking teams, we can target specific organizations if the user provides it
+        as an additional argument. If not, we'll pick from all the organizations, which might fail.
+        """
+        if self.view_class == SlackCommandsEndpoint:
+            drf_request: Request = SlackDMEndpoint().initialize_request(self.request)
+            slack_request = self.view_class.slack_request_class(drf_request)
+            cmd_input = slack_request.get_command_input()
+
+            # For both linking/unlinking teams, the organization slug is found in the same place
+            link_input = None
+            if commands.LINK_TEAM.command_slug.does_match(cmd_input):
+                link_input = cmd_input.adjust(commands.LINK_TEAM.command_slug)
+            if commands.UNLINK_TEAM.command_slug.does_match(cmd_input):
+                link_input = cmd_input.adjust(commands.UNLINK_TEAM.command_slug)
+            if not link_input or not link_input.arg_values:
+                return organizations
+
+            linking_organization_slug = link_input.arg_values[0]
+            linking_organization = next(
+                (org for org in organizations if org.slug == linking_organization_slug), None
+            )
+
+            if linking_organization:
+                return [linking_organization]
+
+        return organizations
 
     def get_response(self):
         """

--- a/tests/sentry/integrations/middleware/hybrid_cloud/test_base.py
+++ b/tests/sentry/integrations/middleware/hybrid_cloud/test_base.py
@@ -32,10 +32,10 @@ class ExampleRequestParser(BaseRequestParser):
 
 class BaseRequestParserTest(TestCase):
     response_handler = MagicMock()
-    region_config = (
+    region_config = [
         Region("us", 1, "https://us.testserver", RegionCategory.MULTI_TENANT),
         Region("eu", 2, "https://eu.testserver", RegionCategory.MULTI_TENANT),
-    )
+    ]
     factory = RequestFactory()
 
     def setUp(self):


### PR DESCRIPTION
Enables the control middleware to read the intended organization to correctly proxy.

I was able to test that this would work for the slash command (`/sentry link team [org-slug]`). Once it's tested in prod a bit more, i can add it to the help function.

Also added tests for this new behaviour across both `link` and `unlink` commands