### PR TITLE
ref(ui): Refactor fetchMutation parameters to object

### DIFF
--- a/static/app/components/feedback/useMutateActivity.tsx
+++ b/static/app/components/feedback/useMutateActivity.tsx
@@ -61,12 +61,12 @@ export default function useMutateActivity({
           ? `/organizations/${organization.slug}/issues/${group.id}/comments/${noteId}/`
           : `/organizations/${organization.slug}/issues/${group.id}/comments/`;
 
-      return fetchMutation([
+      return fetchMutation({
         method,
         url,
-        {},
-        {text: note?.text, mentions: note?.mentions},
-      ]);
+        options: {},
+        data: {text: note?.text, mentions: note?.mentions},
+      });
     },
     onSettled: onSettled ?? undefined,
     gcTime: 0,

--- a/static/app/components/feedback/useMutateFeedback.tsx
+++ b/static/app/components/feedback/useMutateFeedback.tsx
@@ -50,7 +50,7 @@ export default function useMutateFeedback({
         : ids === 'all'
           ? listQueryKey?.[2]!
           : {query: {id: ids, project: projectIds}};
-      return fetchMutation(['PUT', url, options, payload]);
+      return fetchMutation({method: 'PUT', url, options, data: payload});
     },
     onSettled: (_resp, _error, [ids, _payload]) => {
       invalidateCached(ids);

--- a/static/app/utils/queryClient.tsx
+++ b/static/app/utils/queryClient.tsx
@@ -309,19 +309,12 @@ type ApiMutationVariables<
   Headers extends Record<string, unknown> = Record<string, string>,
   Query extends Record<string, unknown> = Record<string, any>,
   Data extends Record<string, unknown> = Record<string, unknown>,
-> =
-  | ['PUT' | 'POST' | 'DELETE', string]
-  | [
-      'PUT' | 'POST' | 'DELETE',
-      string,
-      Pick<QueryKeyEndpointOptions<Headers, Query>, 'query' | 'headers'>,
-    ]
-  | [
-      'PUT' | 'POST' | 'DELETE',
-      string,
-      Pick<QueryKeyEndpointOptions<Headers, Query>, 'query' | 'headers'>,
-      Data,
-    ];
+> = {
+  method: 'PUT' | 'POST' | 'DELETE';
+  url: string;
+  options?: Pick<QueryKeyEndpointOptions<Headers, Query>, 'query' | 'headers'>;
+  data?: Data;
+};
 
 /**
  * This method can be used as a default `mutationFn` with `useMutation` hook.
@@ -331,12 +324,12 @@ type ApiMutationVariables<
 export function fetchMutation<TResponseData = unknown>(
   variables: ApiMutationVariables
 ): Promise<TResponseData> {
-  const [method, url, opts, data] = variables;
+  const {method, url, options, data} = variables;
 
   return QUERY_API_CLIENT.requestPromise(url, {
     method,
-    query: opts?.query,
-    headers: opts?.headers,
+    query: options?.query,
+    headers: options?.headers,
     data,
   });
 }

--- a/static/app/utils/queryClient.tsx
+++ b/static/app/utils/queryClient.tsx
@@ -312,8 +312,8 @@ type ApiMutationVariables<
 > = {
   method: 'PUT' | 'POST' | 'DELETE';
   url: string;
-  options?: Pick<QueryKeyEndpointOptions<Headers, Query>, 'query' | 'headers'>;
   data?: Data;
+  options?: Pick<QueryKeyEndpointOptions<Headers, Query>, 'query' | 'headers'>;
 };
 
 /**

--- a/static/app/utils/replays/hooks/useDeleteReplays.tsx
+++ b/static/app/utils/replays/hooks/useDeleteReplays.tsx
@@ -42,12 +42,12 @@ export default function useDeleteReplays({projectSlug}: Props) {
 
       const options = {};
       const payload = {data};
-      return fetchMutation([
-        'POST',
-        `/projects/${organization.slug}/${projectSlug}/replays/jobs/delete/`,
+      return fetchMutation({
+        method: 'POST',
+        url: `/projects/${organization.slug}/${projectSlug}/replays/jobs/delete/`,
         options,
-        payload,
-      ]);
+        data: payload,
+      });
     },
   });
 

--- a/static/app/utils/replays/hooks/useMarkReplayViewed.tsx
+++ b/static/app/utils/replays/hooks/useMarkReplayViewed.tsx
@@ -14,7 +14,7 @@ export default function useMarkReplayViewed() {
   return useMutation<TData, TError, TVariables, TContext>({
     mutationFn: ({projectSlug, replayId}) => {
       const url = `/projects/${organization.slug}/${projectSlug}/replays/${replayId}/viewed-by/`;
-      return fetchMutation(['POST', url]);
+      return fetchMutation({method: 'POST', url});
     },
     onSuccess(_data, {projectSlug, replayId}) {
       const url = `/projects/${organization.slug}/${projectSlug}/replays/${replayId}/viewed-by/`;

--- a/static/app/views/releases/components/useFinalizeRelease.tsx
+++ b/static/app/views/releases/components/useFinalizeRelease.tsx
@@ -17,12 +17,12 @@ export default function useFinalizeRelease() {
         dateReleased: release.firstEvent ?? release.dateCreated,
       };
 
-      return fetchMutation([
-        'PUT',
-        `/organizations/${organization.slug}/releases/${release.version}/`,
-        {},
-        payload,
-      ]);
+      return fetchMutation({
+        method: 'PUT',
+        url: `/organizations/${organization.slug}/releases/${release.version}/`,
+        options: {},
+        data: payload,
+      });
     },
   });
 }

--- a/static/app/views/settings/account/notifications/notificationSettingsByType.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsByType.tsx
@@ -331,7 +331,7 @@ export function NotificationSettingsByType({notificationType}: Props) {
 
   const removeNotificationMutation = useMutation({
     mutationFn: (id: string) =>
-      fetchMutation(['DELETE', `/users/me/notification-options/${id}/`]),
+      fetchMutation({method: 'DELETE', url: `/users/me/notification-options/${id}/`}),
     onSuccess: (_, id) => {
       setApiQueryData<NotificationOptionsObject[]>(
         queryClient,
@@ -347,12 +347,12 @@ export function NotificationSettingsByType({notificationType}: Props) {
 
   const addNotificationMutation = useMutation({
     mutationFn: (data: Omit<NotificationOptionsObject, 'id'>) =>
-      fetchMutation<NotificationOptionsObject>([
-        'PUT',
-        '/users/me/notification-options/',
-        {},
+      fetchMutation<NotificationOptionsObject>({
+        method: 'PUT',
+        url: '/users/me/notification-options/',
+        options: {},
         data,
-      ]),
+      }),
     onSuccess: notificationOption => {
       setApiQueryData<NotificationOptionsObject[]>(
         queryClient,
@@ -367,12 +367,12 @@ export function NotificationSettingsByType({notificationType}: Props) {
 
   const deleteNotificationMutation = useMutation({
     mutationFn: (data: NotificationOptionsObject) =>
-      fetchMutation<NotificationOptionsObject>([
-        'PUT',
-        '/users/me/notification-options/',
-        {},
+      fetchMutation<NotificationOptionsObject>({
+        method: 'PUT',
+        url: '/users/me/notification-options/',
+        options: {},
         data,
-      ]),
+      }),
     onSuccess: notificationOption => {
       // Replace the item in state
       setApiQueryData<NotificationOptionsObject[]>(

--- a/static/app/views/settings/project/projectOwnership/addCodeOwnerModal.tsx
+++ b/static/app/views/settings/project/projectOwnership/addCodeOwnerModal.tsx
@@ -92,12 +92,12 @@ export default function AddCodeOwnerModal({
     TCodeownersContext
   >({
     mutationFn: ([payload]: TCodeownersVariables) => {
-      return fetchMutation([
-        'POST',
-        `/projects/${organization.slug}/${project.slug}/codeowners/`,
-        {},
-        payload,
-      ]);
+      return fetchMutation({
+        method: 'POST',
+        url: `/projects/${organization.slug}/${project.slug}/codeowners/`,
+        options: {},
+        data: payload,
+      });
     },
     onSuccess: d => {
       const codeMapping = codeMappings?.find(

--- a/static/app/views/settings/project/tempest/PlayStationSettings.tsx
+++ b/static/app/views/settings/project/tempest/PlayStationSettings.tsx
@@ -48,10 +48,10 @@ export default function PlayStationSettings({organization, project}: Props) {
     {id: number}
   >({
     mutationFn: ({id}) =>
-      fetchMutation([
-        'DELETE',
-        `/projects/${organization.slug}/${project.slug}/tempest-credentials/${id}/`,
-      ]),
+      fetchMutation({
+        method: 'DELETE',
+        url: `/projects/${organization.slug}/${project.slug}/tempest-credentials/${id}/`,
+      }),
     onSuccess: () => {
       addSuccessMessage(t('Removed the credentials.'));
       trackAnalytics('tempest.credentials.removed', {


### PR DESCRIPTION
Updates the `fetchMutation` function in `static/app/utils/queryClient.tsx` to accept an object parameter instead of an array.

This change improves readability and maintainability by making the parameters explicit and allowing optional parameters (like `options` or `data`) to be omitted cleanly. All call sites throughout the codebase have been updated to use the new object-based format.