### PR TITLE
fix(issues): add first-seen time from group to event

### DIFF
--- a/src/sentry/eventstream/snuba.py
+++ b/src/sentry/eventstream/snuba.py
@@ -174,6 +174,11 @@ class SnubaProtocolEventStream(EventStream):
                 {
                     "group_id": event.group_id,
                     "group_ids": [group.id for group in getattr(event, "groups", [])],
+                    "group_first_seen": (
+                        json.datetime_to_str(event.group.first_seen)
+                        if event.group is not None
+                        else None
+                    ),
                     "event_id": event.event_id,
                     "organization_id": project.organization_id,
                     "project_id": event.project_id,

--- a/src/sentry/snuba/events.py
+++ b/src/sentry/snuba/events.py
@@ -863,3 +863,12 @@ class Columns(Enum):
         issue_platform_name=None,
         alias="timestamp_ms",
     )
+
+    GROUP_FIRST_SEEN = Column(
+        group_name="events.group_first_seen",
+        event_name="group_first_seen",
+        transaction_name=None,
+        discover_name=None,
+        issue_platform_name="group_first_seen",
+        alias="group_first_seen",
+    )

--- a/tests/sentry/eventstream/test_eventstream.py
+++ b/tests/sentry/eventstream/test_eventstream.py
@@ -253,10 +253,15 @@ class SnubaEventStreamTest(TestCase, SnubaTestCase, OccurrenceTestMixin):
         assert payload1["occurrence_id"] == occurrence_data["id"]
         assert payload1["occurrence_data"] == occurrence_data_no_evidence
         assert payload1["group_id"] == self.group.id
+        assert payload1["group_first_seen"] == json.datetime_to_str(self.group.first_seen)
 
         query = Query(
             match=Entity(EntityKey.IssuePlatform.value),
-            select=[Column("event_id"), Column("group_id"), Column("occurrence_id")],
+            select=[
+                Column("event_id"),
+                Column("group_id"),
+                Column("occurrence_id"),
+            ],
             where=[
                 Condition(Column("timestamp"), Op.GTE, now - timedelta(days=1)),
                 Condition(Column("timestamp"), Op.LT, now + timedelta(days=1)),


### PR DESCRIPTION
This is part of a larger project to fix the Issues search page's sorting by issue age. Currently, the issues page searches by Events — which means that sorting by issue age is actually sorting by which events occurred earliest _within the selected time range_. This looks a bit silly, since we display the actual age in the UI.

First step here is adding the group's first-seen time to the events. 

After this, we'll expose the column to Snuba and then hook it into the search strategy.