### PR TITLE
feat(trace-eap-waterfall): Using spans count from tree

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceHeader/meta.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/meta.tsx
@@ -13,6 +13,7 @@ import type {RepresentativeTraceEvent} from 'sentry/views/performance/newTraceDe
 import {TraceDrawerComponents} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/styles';
 import {
   isEAPError,
+  isEAPTraceNode,
   isTraceError,
 } from 'sentry/views/performance/newTraceDetails/traceGuards';
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
@@ -71,7 +72,7 @@ function getRootDuration(event: TraceTree.TraceEvent | null) {
 }
 
 export function Meta(props: MetaProps) {
-  const traceNode = props.tree.root.children[0]!;
+  const traceNode = props.tree.root.children[0];
   const {timestamp} = useTraceQueryParams();
 
   const uniqueErrorIssues = useMemo(() => {
@@ -112,6 +113,14 @@ export function Meta(props: MetaProps) {
     return unique;
   }, [traceNode]);
 
+  if (!traceNode) {
+    return null;
+  }
+
+  const spansCount = isEAPTraceNode(traceNode)
+    ? props.tree.eap_spans_count
+    : (props.meta?.span_count ?? 0);
+
   const uniqueIssuesCount = uniqueErrorIssues.length + uniquePerformanceIssues.length;
 
   // If there is no trace data, use the timestamp from the query params as an approximation for
@@ -119,7 +128,7 @@ export function Meta(props: MetaProps) {
   const ageStartTimestamp =
     traceNode?.space[0] ?? (timestamp ? timestamp * 1000 : undefined);
 
-  const hasSpans = (props.meta?.span_count ?? 0) > 0;
+  const hasSpans = spansCount > 0;
   const hasLogs = (props.logs?.length ?? 0) > 0;
 
   return (
@@ -138,9 +147,7 @@ export function Meta(props: MetaProps) {
           )
         }
       />
-      {hasSpans ? (
-        <MetaSection headingText={t('Spans')} bodyText={props.meta?.span_count} />
-      ) : null}
+      {hasSpans ? <MetaSection headingText={t('Spans')} bodyText={spansCount} /> : null}
       {ageStartTimestamp ? (
         <MetaSection
           headingText={t('Age')}

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
@@ -335,6 +335,7 @@ function fetchTrace(
 
 export class TraceTree extends TraceTreeEventDispatcher {
   transactions_count = 0;
+  eap_spans_count = 0;
   projects = new Map<number, TraceTree.Project>();
 
   type: 'loading' | 'empty' | 'error' | 'trace' = 'trace';
@@ -443,6 +444,10 @@ export class TraceTree extends TraceTreeEventDispatcher {
 
       if (isTransactionNode(node) || isEAPTransactionNode(node)) {
         tree.transactions_count++;
+      }
+
+      if (isEAPSpanNode(node)) {
+        tree.eap_spans_count++;
       }
 
       if (isTransactionNode(node)) {

--- a/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
+++ b/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
@@ -524,6 +524,21 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
         action_source: 'load',
       });
     });
+
+    // TODO Abdullah Khan: Remove this once /trace-meta/ starts responding
+    // with the correct spans count for EAP traces.
+    if (
+      traceNode &&
+      isEAPTraceNode(traceNode) &&
+      props.tree.eap_spans_count !== props.meta?.data?.span_count
+    ) {
+      Sentry.withScope(scope => {
+        scope.setFingerprint(['trace-eap-spans-count-mismatch']);
+        scope.captureMessage(
+          'EAP spans count from /trace/ and /trace-meta/ are not equal'
+        );
+      });
+    }
   }, [
     setRowAsFocused,
     traceDispatch,
@@ -535,6 +550,7 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
     props.organization,
     isLoadingSubscriptionDetails,
     hasExceededPerformanceUsageLimit,
+    props.meta?.data?.span_count,
     source,
     timestamp,
   ]);

--- a/static/app/views/performance/newTraceDetails/useTraceOnLoad.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceOnLoad.tsx
@@ -29,10 +29,20 @@ async function maybeAutoExpandTrace(
   },
   meta: TraceMetaQueryResults
 ): Promise<TraceTree> {
+  const traceNode = tree.root.children[0];
+
+  if (!traceNode) {
+    return tree;
+  }
+
+  const spansCount = isEAPTransactionNode(traceNode)
+    ? tree.eap_spans_count
+    : (meta.data?.span_count ?? 0);
+
   if (
     !(
       tree.transactions_count < AUTO_EXPAND_TRANSACTIONS_THRESHOLD ||
-      (meta.data?.span_count ?? 0) < AUTO_EXPAND_SPANS_THRESHOLD
+      (spansCount ?? 0) < AUTO_EXPAND_SPANS_THRESHOLD
     )
   ) {
     return tree;

--- a/static/app/views/performance/newTraceDetails/useTraceOnLoad.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceOnLoad.tsx
@@ -12,7 +12,7 @@ import {IssuesTraceTree} from 'sentry/views/performance/newTraceDetails/traceMod
 import {TraceTree} from './traceModels/traceTree';
 import type {TracePreferencesState} from './traceState/tracePreferences';
 import {useTraceState} from './traceState/traceStateProvider';
-import {isEAPTransactionNode, isTransactionNode} from './traceGuards';
+import {isEAPTraceNode, isEAPTransactionNode, isTransactionNode} from './traceGuards';
 import type {TraceReducerState} from './traceState';
 import type {useTraceScrollToPath} from './useTraceScrollToPath';
 
@@ -35,7 +35,7 @@ async function maybeAutoExpandTrace(
     return tree;
   }
 
-  const spansCount = isEAPTransactionNode(traceNode)
+  const spansCount = isEAPTraceNode(traceNode)
     ? tree.eap_spans_count
     : (meta.data?.span_count ?? 0);
 


### PR DESCRIPTION
For EAP traces, there is a mismatch between spans count in `/trace` vs `/trace-meta`. The prior is accurate so we are resorting to it for now. 

Will stack a PR, to capture a sentry event for when the mismatch occurs. 