### PR TITLE
feat(replay): Be specific about which envs are selected when bulk deleting replays

### DIFF
--- a/static/app/utils/replays/hooks/useDeleteReplays.tsx
+++ b/static/app/utils/replays/hooks/useDeleteReplays.tsx
@@ -53,12 +53,13 @@ export default function useDeleteReplays({projectSlug}: Props) {
 
   const queryOptionsToPayload = useCallback(
     (selectedIds: 'all' | string[], queryOptions: QueryKeyEndpointOptions) => {
+      const environments = queryOptions?.query?.environment ?? [];
       const {start, end} = queryOptions?.query?.statsPeriod
         ? parseStatsPeriod(queryOptions?.query?.statsPeriod)
         : (queryOptions?.query ?? {start: undefined, end: undefined});
 
       return {
-        environments: queryOptions?.query?.environment,
+        environments: environments.length === 0 ? project?.environments : environments,
         query:
           selectedIds === 'all'
             ? queryOptions?.query?.query
@@ -67,7 +68,7 @@ export default function useDeleteReplays({projectSlug}: Props) {
         rangeStart: start,
       };
     },
-    []
+    [project?.environments]
   );
 
   return {


### PR DESCRIPTION
Instead of passing the empty array `[]` to mean "all environments" for bulk-deletes we should be explicit about which envs we want to delete from. This will result in better audit-logs in the case where envs are added or removed from the project... by being explicit we'll have a record of which envs existed at the time when the delete happened.\

<img width="961" height="386" alt="SCR-20250717-kweg" src="https://github.com/user-attachments/assets/cc0c0a0b-f581-4345-9f61-46b9cc52de00" />



Fixes REPLAY-530