### PR TITLE
chore(ecosystem): add SLO for fetching PR diffs for open PR comments

### DIFF
--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -29,7 +29,6 @@ from sentry.integrations.base import (
 )
 from sentry.integrations.github.constants import ISSUE_LOCKED_ERROR_MESSAGE, RATE_LIMITED_MESSAGE
 from sentry.integrations.github.tasks.link_all_repos import link_all_repos
-from sentry.integrations.github.tasks.utils import GithubAPIErrorType
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.pipeline import IntegrationPipeline
@@ -39,13 +38,11 @@ from sentry.integrations.services.repository import RpcRepository, repository_se
 from sentry.integrations.source_code_management.commit_context import (
     OPEN_PR_MAX_FILES_CHANGED,
     OPEN_PR_MAX_LINES_CHANGED,
-    OPEN_PR_METRICS_BASE,
     CommitContextIntegration,
     OpenPRCommentWorkflow,
     PRCommentWorkflow,
     PullRequestFile,
     PullRequestIssue,
-    _open_pr_comment_log,
 )
 from sentry.integrations.source_code_management.language_parsers import (
     get_patch_parsers_for_organization,
@@ -477,48 +474,13 @@ class GitHubOpenPRCommentWorkflow(OpenPRCommentWorkflow):
 
     def safe_for_comment(self, repo: Repository, pr: PullRequest) -> list[dict[str, Any]]:
         client = self.integration.get_client()
-        logger.info(
-            _open_pr_comment_log(
-                integration_name=self.integration.integration_name, suffix="check_safe_for_comment"
-            )
-        )
         try:
             pr_files = client.get_pullrequest_files(repo=repo.name, pull_number=pr.key)
         except ApiError as e:
-            logger.info(
-                _open_pr_comment_log(
-                    integration_name=self.integration.integration_name, suffix="api_error"
-                )
-            )
-            if e.json and RATE_LIMITED_MESSAGE in e.json.get("message", ""):
-                metrics.incr(
-                    OPEN_PR_METRICS_BASE.format(
-                        integration=self.integration.integration_name, key="api_error"
-                    ),
-                    tags={"type": GithubAPIErrorType.RATE_LIMITED.value, "code": e.code},
-                )
-            elif e.code == 404:
-                metrics.incr(
-                    OPEN_PR_METRICS_BASE.format(
-                        integration=self.integration.integration_name, key="api_error"
-                    ),
-                    tags={"type": GithubAPIErrorType.MISSING_PULL_REQUEST.value, "code": e.code},
-                )
+            if (e.json and RATE_LIMITED_MESSAGE in e.json.get("message", "")) or e.code == 404:
+                return []
             else:
-                metrics.incr(
-                    OPEN_PR_METRICS_BASE.format(
-                        integration=self.integration.integration_name, key="api_error"
-                    ),
-                    tags={"type": GithubAPIErrorType.UNKNOWN.value, "code": e.code},
-                )
-                logger.exception(
-                    _open_pr_comment_log(
-                        integration_name=self.integration.integration_name,
-                        suffix="unknown_api_error",
-                    ),
-                    extra={"error": str(e)},
-                )
-            return []
+                raise
 
         changed_file_count = 0
         changed_lines_count = 0
@@ -538,21 +500,10 @@ class GitHubOpenPRCommentWorkflow(OpenPRCommentWorkflow):
             changed_lines_count += file["changes"]
             filtered_pr_files.append(file)
 
-            if changed_file_count > OPEN_PR_MAX_FILES_CHANGED:
-                metrics.incr(
-                    OPEN_PR_METRICS_BASE.format(
-                        integration=self.integration.integration_name, key="rejected_comment"
-                    ),
-                    tags={"reason": "too_many_files"},
-                )
-                return []
-            if changed_lines_count > OPEN_PR_MAX_LINES_CHANGED:
-                metrics.incr(
-                    OPEN_PR_METRICS_BASE.format(
-                        integration=self.integration.integration_name, key="rejected_comment"
-                    ),
-                    tags={"reason": "too_many_lines"},
-                )
+            if (
+                changed_file_count > OPEN_PR_MAX_FILES_CHANGED
+                or changed_lines_count > OPEN_PR_MAX_LINES_CHANGED
+            ):
                 return []
 
         return filtered_pr_files
@@ -566,14 +517,6 @@ class GitHubOpenPRCommentWorkflow(OpenPRCommentWorkflow):
             if "patch" in file
         ]
 
-        logger.info(
-            _open_pr_comment_log(
-                integration_name=self.integration.integration_name,
-                suffix="pr_filenames",
-            ),
-            extra={"count": len(pullrequest_files)},
-        )
-
         return pullrequest_files
 
     def get_pr_files_safe_for_comment(
@@ -582,19 +525,6 @@ class GitHubOpenPRCommentWorkflow(OpenPRCommentWorkflow):
         pr_files = self.safe_for_comment(repo=repo, pr=pr)
 
         if len(pr_files) == 0:
-            logger.info(
-                _open_pr_comment_log(
-                    integration_name=self.integration.integration_name,
-                    suffix="not_safe_for_comment",
-                ),
-                extra={"file_count": len(pr_files)},
-            )
-            metrics.incr(
-                OPEN_PR_METRICS_BASE.format(
-                    integration=self.integration.integration_name, key="error"
-                ),
-                tags={"type": "unsafe_for_comment"},
-            )
             return []
 
         return self.get_pr_files(pr_files)

--- a/src/sentry/integrations/source_code_management/metrics.py
+++ b/src/sentry/integrations/source_code_management/metrics.py
@@ -38,6 +38,7 @@ class SCMIntegrationInteractionType(StrEnum):
     CREATE_COMMENT = "create_comment"
     UPDATE_COMMENT = "update_comment"
     QUEUE_COMMENT_TASK = "queue_comment_task"
+    GET_PR_DIFFS = "get_pr_diffs"  # open PR comments
 
     # Tasks
     LINK_ALL_REPOS = "link_all_repos"

--- a/src/sentry/integrations/source_code_management/tasks.py
+++ b/src/sentry/integrations/source_code_management/tasks.py
@@ -16,6 +16,10 @@ from sentry.integrations.source_code_management.commit_context import (
 from sentry.integrations.source_code_management.language_parsers import (
     get_patch_parsers_for_organization,
 )
+from sentry.integrations.source_code_management.metrics import (
+    CommitContextIntegrationInteractionEvent,
+    SCMIntegrationInteractionType,
+)
 from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.organization import Organization
 from sentry.models.project import Project
@@ -236,7 +240,7 @@ def open_pr_comment_workflow(pr_id: int) -> None:
         )
         return
 
-    # check integration exists to hit Github API with client
+    # check integration exists to hit external API with client
     integration = integration_service.get_integration(
         integration_id=repo.integration_id, status=ObjectStatus.ACTIVE
     )
@@ -269,12 +273,16 @@ def open_pr_comment_workflow(pr_id: int) -> None:
         )
         return
 
-    # CREATING THE COMMENT
-
-    # fetch the files in the PR and determine if it is safe to comment
-    pullrequest_files = open_pr_comment_workflow.get_pr_files_safe_for_comment(
-        repo=repo, pr=pull_request
-    )
+    with CommitContextIntegrationInteractionEvent(
+        interaction_type=SCMIntegrationInteractionType.GET_PR_DIFFS,
+        provider_key=integration_name,
+        repository=repo,
+        pull_request_id=pull_request.id,
+    ).capture():
+        # fetch the files in the PR and determine if it is safe to comment
+        pullrequest_files = open_pr_comment_workflow.get_pr_files_safe_for_comment(
+            repo=repo, pr=pull_request
+        )
 
     issue_table_contents = {}
     top_issues_per_file = []

--- a/tests/sentry/integrations/gitlab/tasks/test_open_pr_comment.py
+++ b/tests/sentry/integrations/gitlab/tasks/test_open_pr_comment.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+import pytest
 import responses
 from django.utils import timezone
 
@@ -9,8 +10,11 @@ from sentry.integrations.source_code_management.commit_context import (
     PullRequestFile,
 )
 from sentry.integrations.source_code_management.tasks import open_pr_comment_workflow
+from sentry.integrations.types import EventLifecycleOutcome
 from sentry.models.group import Group
 from sentry.models.pullrequest import CommentType, PullRequestComment
+from sentry.shared_integrations.exceptions import ApiError
+from sentry.testutils.asserts import assert_slo_metric
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.skips import requires_snuba
 from sentry.utils import json
@@ -264,9 +268,6 @@ index 0000001..0000002 100644
         pr_files = self.open_pr_comment_workflow.safe_for_comment(repo=self.repo, pr=self.pr)
 
         assert pr_files == []
-        self.mock_integration_metrics.incr.assert_called_with(
-            "gitlab.open_pr_comment.api_error", tags={"type": "missing_pr", "code": 404}
-        )
 
     @responses.activate
     def test_error__unknown_api_error(self):
@@ -276,12 +277,8 @@ index 0000001..0000002 100644
             status=500,
         )
 
-        pr_files = self.open_pr_comment_workflow.safe_for_comment(repo=self.repo, pr=self.pr)
-
-        assert pr_files == []
-        self.mock_integration_metrics.incr.assert_called_with(
-            "gitlab.open_pr_comment.api_error", tags={"type": "unknown_api_error", "code": 500}
-        )
+        with pytest.raises(ApiError):
+            self.open_pr_comment_workflow.safe_for_comment(repo=self.repo, pr=self.pr)
 
 
 @patch(
@@ -575,3 +572,25 @@ Your merge request is modifying functions with the following pre-existing issues
         mock_task_metrics.incr.assert_called_with("gitlab.open_pr_comment.no_issues")
         assert mock_integration_metrics.mock_calls == []
         assert mock_analytics.mock_calls == []
+
+    @responses.activate
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_comment_workflow_api_error(
+        self,
+        mock_record_event,
+        mock_analytics,
+        mock_commit_context_metrics,
+        mock_task_metrics,
+        mock_integration_metrics,
+        mock_extract_functions_from_patch,
+        mock_get_top_5_issues_by_count_for_file,
+        mock_get_projects_and_filenames_from_source_file,
+        mock_get_pr_files_safe_for_comment,
+    ):
+        # two filenames, the second one has a toggle table
+        mock_get_pr_files_safe_for_comment.side_effect = ApiError("asdf")
+
+        with pytest.raises(ApiError):
+            open_pr_comment_workflow(self.pr.id)
+
+        assert_slo_metric(mock_record_event, EventLifecycleOutcome.FAILURE)


### PR DESCRIPTION
Add a SLO for fetching PR diffs in open PR comments so that we can remove custom logging behavior in open PR comments.

I am seeing quite a few errors for this for Gitlab but I'm not sure what the failure rate is vs success.
Instead of swallowing all ApiErrors, we'll now surface them if they should be causing the SLO to fail.

Contributes to ECO-845