### PR TITLE
feat: add integration orgs hook

### DIFF
--- a/static/app/components/codecov/container/codecovParamsProvider.tsx
+++ b/static/app/components/codecov/container/codecovParamsProvider.tsx
@@ -15,7 +15,7 @@ type CodecovQueryParamsProviderProps = {
 };
 
 const VALUES_TO_RESET_MAP = {
-  integratedOrg: ['repository', 'branch'],
+  integratedOrgId: ['repository', 'branch'],
   repository: ['branch'],
   branch: [],
   codecovPeriod: [],
@@ -80,7 +80,7 @@ export default function CodecovQueryParamsProvider({
   useEffect(() => {
     const entries = {
       repository: searchParams.get('repository'),
-      integratedOrg: searchParams.get('integratedOrg'),
+      integratedOrgId: searchParams.get('integratedOrgId'),
       branch: searchParams.get('branch'),
       codecovPeriod: searchParams.get('codecovPeriod'),
     };
@@ -98,13 +98,13 @@ export default function CodecovQueryParamsProvider({
   }, [setLocalStorageState, searchParams]);
 
   const repository = _defineParam('repository');
-  const integratedOrg = _defineParam('integratedOrg');
+  const integratedOrgId = _defineParam('integratedOrgId');
   const branch = _defineParam('branch');
   const codecovPeriod = _defineParam('codecovPeriod', '24h') as CodecovPeriodOptions;
 
   const params: CodecovContextData = {
     ...(repository ? {repository} : {}),
-    ...(integratedOrg ? {integratedOrg} : {}),
+    ...(integratedOrgId ? {integratedOrgId} : {}),
     ...(branch ? {branch} : {}),
     codecovPeriod,
     changeContextValue,

--- a/static/app/components/codecov/context/codecovContext.tsx
+++ b/static/app/components/codecov/context/codecovContext.tsx
@@ -4,7 +4,7 @@ export type CodecovContextData = {
   changeContextValue: (value: Partial<CodecovContextDataParams>) => void;
   codecovPeriod: string;
   branch?: string;
-  integratedOrg?: string;
+  integratedOrgId?: string;
   repository?: string;
 };
 

--- a/static/app/components/codecov/dateSelector/dateSelector.spec.tsx
+++ b/static/app/components/codecov/dateSelector/dateSelector.spec.tsx
@@ -15,7 +15,7 @@ describe('DateSelector', function () {
             pathname: '/codecov/tests',
             query: {
               codecovPeriod: '7d',
-              integratedOrg: 'some-org-name',
+              integratedOrgId: '123',
               repository: 'some-repository',
             },
           },
@@ -36,7 +36,7 @@ describe('DateSelector', function () {
             pathname: '/codecov/tests',
             query: {
               codecovPeriod: '1y',
-              integratedOrg: 'some-org-name',
+              integratedOrgId: '123',
               repository: 'some-repository',
             },
           },

--- a/static/app/components/codecov/integratedOrgSelector/integratedOrgSelector.spec.tsx
+++ b/static/app/components/codecov/integratedOrgSelector/integratedOrgSelector.spec.tsx
@@ -3,8 +3,22 @@ import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import CodecovQueryParamsProvider from 'sentry/components/codecov/container/codecovParamsProvider';
 import {IntegratedOrgSelector} from 'sentry/components/codecov/integratedOrgSelector/integratedOrgSelector';
 
+const mockIntegrations = [
+  {name: 'my-other-org-with-a-super-long-name', id: '1'},
+  {name: 'my-other-org-with-a-super-long-name', id: '2'},
+];
+
+const mockApiCall = () => {
+  MockApiClient.addMockResponse({
+    url: `/organizations/org-slug/integrations/`,
+    method: 'GET',
+    body: mockIntegrations,
+  });
+};
+
 describe('IntegratedOrgSelector', function () {
   it('renders when given integrated org', async function () {
+    mockApiCall();
     render(
       <CodecovQueryParamsProvider>
         <IntegratedOrgSelector />
@@ -13,7 +27,7 @@ describe('IntegratedOrgSelector', function () {
         initialRouterConfig: {
           location: {
             pathname: '/',
-            query: {integratedOrg: 'my-other-org-with-a-super-long-name'},
+            query: {integratedOrgId: '1'},
           },
         },
       }
@@ -24,6 +38,7 @@ describe('IntegratedOrgSelector', function () {
   });
 
   it('renders the chosen org as the first option', async function () {
+    mockApiCall();
     render(
       <CodecovQueryParamsProvider>
         <IntegratedOrgSelector />
@@ -32,7 +47,7 @@ describe('IntegratedOrgSelector', function () {
         initialRouterConfig: {
           location: {
             pathname: '/',
-            query: {integratedOrg: 'my-other-org-with-a-super-long-name'},
+            query: {integratedOrgId: '2'},
           },
         },
       }

--- a/static/app/components/codecov/integratedOrgSelector/utils.tsx
+++ b/static/app/components/codecov/integratedOrgSelector/utils.tsx
@@ -1,0 +1,9 @@
+import type {Integration} from 'sentry/types/integrations';
+
+export const integratedOrgIdToName = (id?: string, integrations?: Integration[]) => {
+  if (!id || !integrations) {
+    return '';
+  }
+  const result = integrations.find(item => item.id === id);
+  return result ? result.name : '';
+};

--- a/static/app/components/codecov/repoSelector/repoSelector.tsx
+++ b/static/app/components/codecov/repoSelector/repoSelector.tsx
@@ -55,11 +55,11 @@ function MenuFooter({repoAccessLink}: MenuFooterProps) {
 }
 
 export function RepoSelector() {
-  const {repository, integratedOrg, changeContextValue} = useCodecovContext();
+  const {repository, integratedOrgId, changeContextValue} = useCodecovContext();
   const [searchValue, setSearchValue] = useState<string | undefined>();
   const {data: repositories} = useInfiniteRepositories({term: searchValue});
 
-  const disabled = !integratedOrg;
+  const disabled = !integratedOrgId;
 
   const handleChange = useCallback(
     (selectedOption: SelectOption<string>) => {

--- a/static/app/components/codecov/repoSelector/useInfiniteRepositories.tsx
+++ b/static/app/components/codecov/repoSelector/useInfiniteRepositories.tsx
@@ -35,7 +35,7 @@ type Props = {
 };
 
 export function useInfiniteRepositories({term}: Props) {
-  const {integratedOrg} = useCodecovContext();
+  const {integratedOrgId} = useCodecovContext();
   const organization = useOrganization();
 
   const {data, ...rest} = useInfiniteQuery<
@@ -45,7 +45,7 @@ export function useInfiniteRepositories({term}: Props) {
     QueryKey
   >({
     queryKey: [
-      `/organizations/${organization.slug}/prevent/owner/${integratedOrg}/repositories/`,
+      `/organizations/${organization.slug}/prevent/owner/${integratedOrgId}/repositories/`,
       {query: {term}},
     ],
     queryFn: async ({
@@ -81,7 +81,7 @@ export function useInfiniteRepositories({term}: Props) {
         : undefined;
     },
     initialPageParam: undefined,
-    enabled: Boolean(integratedOrg),
+    enabled: Boolean(integratedOrgId),
   });
 
   const memoizedData = useMemo(

--- a/static/app/views/codecov/tests/queries/useGetTestResults.ts
+++ b/static/app/views/codecov/tests/queries/useGetTestResults.ts
@@ -61,7 +61,7 @@ interface TestResults {
 type QueryKey = [url: string, endpointOptions: QueryKeyEndpointOptions];
 
 export function useInfiniteTestResults() {
-  const {integratedOrg, repository, branch, codecovPeriod} = useCodecovContext();
+  const {integratedOrgId, repository, branch, codecovPeriod} = useCodecovContext();
   const organization = useOrganization();
   const [searchParams] = useSearchParams();
 
@@ -83,7 +83,7 @@ export function useInfiniteTestResults() {
     QueryKey
   >({
     queryKey: [
-      `/organizations/${organization.slug}/prevent/owner/${integratedOrg}/repository/${repository}/test-results/`,
+      `/organizations/${organization.slug}/prevent/owner/${integratedOrgId}/repository/${repository}/test-results/`,
       {query: {branch, codecovPeriod, signedSortBy, mappedFilterBy, term}},
     ],
     queryFn: async ({

--- a/static/app/views/codecov/tests/queries/useTestResultsAggregates.ts
+++ b/static/app/views/codecov/tests/queries/useTestResultsAggregates.ts
@@ -29,7 +29,7 @@ type QueryKey = [url: string, endpointOptions: QueryKeyEndpointOptions];
 export function useTestResultsAggregates() {
   const api = useApi();
   const organization = useOrganization();
-  const {integratedOrg, repository, codecovPeriod} = useCodecovContext();
+  const {integratedOrgId, repository, codecovPeriod} = useCodecovContext();
 
   const {data, ...rest} = useQuery<
     TestResultAggregate,
@@ -38,7 +38,7 @@ export function useTestResultsAggregates() {
     QueryKey
   >({
     queryKey: [
-      `/organizations/${organization.slug}/prevent/owner/${integratedOrg}/repository/${repository}/test-results-aggregates/`,
+      `/organizations/${organization.slug}/prevent/owner/${integratedOrgId}/repository/${repository}/test-results-aggregates/`,
       {query: {codecovPeriod}},
     ],
     queryFn: async ({queryKey: [url]}): Promise<TestResultAggregate> => {

--- a/static/app/views/codecov/tests/summaries/summaries.spec.tsx
+++ b/static/app/views/codecov/tests/summaries/summaries.spec.tsx
@@ -25,7 +25,7 @@ const mockTestResultAggregates = [
 
 const mockApiCall = () =>
   MockApiClient.addMockResponse({
-    url: `/organizations/org-slug/prevent/owner/some-org-name/repository/some-repository/test-results-aggregates/`,
+    url: `/organizations/org-slug/prevent/owner/123/repository/some-repository/test-results-aggregates/`,
     method: 'GET',
     body: {
       results: mockTestResultAggregates,
@@ -45,7 +45,7 @@ describe('Summaries', () => {
             pathname: '/codecov/tests',
             query: {
               codecovPeriod: '7d',
-              integratedOrg: 'some-org-name',
+              integratedOrgId: '123',
               repository: 'some-repository',
             },
           },

--- a/static/app/views/codecov/tests/tests.spec.tsx
+++ b/static/app/views/codecov/tests/tests.spec.tsx
@@ -54,9 +54,14 @@ const mockRepositories = [
   },
 ];
 
+const mockIntegrations = [
+  {name: 'integration-1', id: '1'},
+  {name: 'integration-2', id: '2'},
+];
+
 const mockApiCall = () => {
   MockApiClient.addMockResponse({
-    url: `/organizations/org-slug/prevent/owner/some-org-name/repository/some-repository/test-results/`,
+    url: `/organizations/org-slug/prevent/owner/123/repository/some-repository/test-results/`,
     method: 'GET',
     body: {
       results: mockTestResultsData,
@@ -69,7 +74,7 @@ const mockApiCall = () => {
   });
 
   MockApiClient.addMockResponse({
-    url: `/organizations/org-slug/prevent/owner/some-org-name/repository/some-repository/test-results-aggregates/`,
+    url: `/organizations/org-slug/prevent/owner/123/repository/some-repository/test-results-aggregates/`,
     method: 'GET',
     body: {
       results: mockTestResultAggregates,
@@ -77,11 +82,16 @@ const mockApiCall = () => {
   });
 
   MockApiClient.addMockResponse({
-    url: `/organizations/org-slug/prevent/owner/some-org-name/repositories/`,
+    url: `/organizations/org-slug/prevent/owner/123/repositories/`,
     method: 'GET',
     body: {
       results: mockRepositories,
     },
+  });
+  MockApiClient.addMockResponse({
+    url: `/organizations/org-slug/integrations/`,
+    method: 'GET',
+    body: mockIntegrations,
   });
 };
 
@@ -99,7 +109,7 @@ describe('CoveragePageWrapper', () => {
               pathname: '/codecov/tests',
               query: {
                 codecovPeriod: '7d',
-                integratedOrg: 'some-org-name',
+                integratedOrgId: '123',
                 repository: 'some-repository',
                 branch: 'some-branch',
               },

--- a/static/app/views/codecov/tests/tests.tsx
+++ b/static/app/views/codecov/tests/tests.tsx
@@ -35,9 +35,9 @@ function EmptySelectorsMessage() {
 }
 
 export default function TestsPage() {
-  const {integratedOrg, repository, branch, codecovPeriod} = useCodecovContext();
+  const {integratedOrgId, repository, branch, codecovPeriod} = useCodecovContext();
 
-  const shouldDisplayContent = integratedOrg && repository && branch && codecovPeriod;
+  const shouldDisplayContent = integratedOrgId && repository && branch && codecovPeriod;
 
   return (
     <LayoutGap>

--- a/static/app/views/codecov/tokens/tokens.spec.tsx
+++ b/static/app/views/codecov/tokens/tokens.spec.tsx
@@ -9,9 +9,23 @@ import {
 import CodecovQueryParamsProvider from 'sentry/components/codecov/container/codecovParamsProvider';
 import TokensPage from 'sentry/views/codecov/tokens/tokens';
 
+const mockIntegrations = [
+  {name: 'some-org-name', id: '1'},
+  {name: 'test-org', id: '2'},
+];
+
+const mockApiCall = () => {
+  MockApiClient.addMockResponse({
+    url: `/organizations/org-slug/integrations/`,
+    method: 'GET',
+    body: mockIntegrations,
+  });
+};
+
 describe('TokensPage', () => {
   describe('when the wrapper is used', () => {
     it('renders the header', async () => {
+      mockApiCall();
       render(
         <CodecovQueryParamsProvider>
           <TokensPage />
@@ -21,7 +35,7 @@ describe('TokensPage', () => {
             location: {
               pathname: '/codecov/tokens/',
               query: {
-                integratedOrg: 'some-org-name',
+                integratedOrgId: '1',
               },
             },
           },
@@ -31,6 +45,7 @@ describe('TokensPage', () => {
     });
 
     it('displays the integrated organization name in the description', async () => {
+      mockApiCall();
       render(
         <CodecovQueryParamsProvider>
           <TokensPage />
@@ -40,7 +55,7 @@ describe('TokensPage', () => {
             location: {
               pathname: '/codecov/tokens/',
               query: {
-                integratedOrg: 'test-org',
+                integratedOrgId: '2',
               },
             },
           },
@@ -65,6 +80,7 @@ describe('TokensPage', () => {
     });
 
     it('renders a table component', async () => {
+      mockApiCall();
       render(
         <CodecovQueryParamsProvider>
           <TokensPage />
@@ -74,7 +90,7 @@ describe('TokensPage', () => {
             location: {
               pathname: '/codecov/tokens/',
               query: {
-                integratedOrg: 'some-org-name',
+                integratedOrgId: '1',
               },
             },
           },
@@ -87,6 +103,7 @@ describe('TokensPage', () => {
     });
 
     it('renders repository tokens and related data', async () => {
+      mockApiCall();
       render(
         <CodecovQueryParamsProvider>
           <TokensPage />
@@ -96,7 +113,7 @@ describe('TokensPage', () => {
             location: {
               pathname: '/codecov/tokens/',
               query: {
-                integratedOrg: 'some-org-name',
+                integratedOrgId: '1',
               },
             },
           },
@@ -113,6 +130,7 @@ describe('TokensPage', () => {
     });
 
     it('Creates new token when regenerate token button is clicked after opening the modal and clicking the Generate new token button', async () => {
+      mockApiCall();
       render(
         <CodecovQueryParamsProvider>
           <TokensPage />
@@ -122,7 +140,7 @@ describe('TokensPage', () => {
             location: {
               pathname: '/codecov/tokens/',
               query: {
-                integratedOrg: 'some-org-name',
+                integratedOrgId: '1',
               },
             },
           },

--- a/static/app/views/codecov/tokens/tokens.tsx
+++ b/static/app/views/codecov/tokens/tokens.tsx
@@ -2,11 +2,15 @@ import styled from '@emotion/styled';
 
 import {useCodecovContext} from 'sentry/components/codecov/context/codecovContext';
 import {IntegratedOrgSelector} from 'sentry/components/codecov/integratedOrgSelector/integratedOrgSelector';
+import {integratedOrgIdToName} from 'sentry/components/codecov/integratedOrgSelector/utils';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import type {Integration} from 'sentry/types/integrations';
+import {useApiQuery} from 'sentry/utils/queryClient';
 import {decodeSorts} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
 
 import type {ValidSort} from './repoTokenTable/repoTokenTable';
 import RepoTokenTable, {
@@ -15,7 +19,15 @@ import RepoTokenTable, {
 } from './repoTokenTable/repoTokenTable';
 
 export default function TokensPage() {
-  const {integratedOrg} = useCodecovContext();
+  const {integratedOrgId} = useCodecovContext();
+  const organization = useOrganization();
+  const {data: integrations = []} = useApiQuery<Integration[]>(
+    [
+      `/organizations/${organization.slug}/integrations/`,
+      {query: {includeConfig: 0, provider_key: 'github'}},
+    ],
+    {staleTime: 0}
+  );
   const location = useLocation();
 
   const sorts: [ValidSort] = [
@@ -47,7 +59,7 @@ export default function TokensPage() {
       <HeaderValue>{t('Repository tokens')}</HeaderValue>
       <p>
         {t('View the list of tokens created for your repositories in')}{' '}
-        <strong>{integratedOrg}</strong>.{' '}
+        <strong>{integratedOrgIdToName(integratedOrgId, integrations)}</strong>.{' '}
         {t("Use them for uploading reports to all Sentry Prevent's features.")}
       </p>
       <RepoTokenTable response={response} sort={sorts[0]} />


### PR DESCRIPTION
This PR adds the integratedOrg hook. It as well renames/repurposes the `integratedOrg` to now be `integratedOrgId`, reflected in many files. Additionally adjust tests and required files.

Closes https://linear.app/getsentry/issue/CCMRG-1401/test-analytics-add-integrated-orgs-fe-hook and https://linear.app/getsentry/issue/CCMRG-1307/create-endpoint-to-fetch-repositories-for-an-organization