### PR TITLE
ref(insights): replace `useTopNMetricsSeries` with `useTopNSpanSeries`

### DIFF
--- a/static/app/components/charts/chartWidgetLoader-unmocked-imports.spec.tsx
+++ b/static/app/components/charts/chartWidgetLoader-unmocked-imports.spec.tsx
@@ -175,12 +175,7 @@ jest.mock('sentry/views/insights/common/queries/useDiscover', () => ({
   })),
 }));
 jest.mock('sentry/views/insights/common/queries/useTopNDiscoverSeries', () => ({
-  useTopNSpanEAPSeries: jest.fn(() => ({
-    data: [mockDiscoverSeries('transaction_a,abc123')],
-    isPending: false,
-    error: null,
-  })),
-  useTopNSpanMetricsSeries: jest.fn(() => ({
+  useTopNSpanSeries: jest.fn(() => ({
     data: [mockDiscoverSeries('transaction_a,abc123')],
     isPending: false,
     error: null,

--- a/static/app/views/insights/agentMonitoring/components/llmGenerationsWidget.tsx
+++ b/static/app/views/insights/agentMonitoring/components/llmGenerationsWidget.tsx
@@ -20,7 +20,7 @@ import {
 import {Referrer} from 'sentry/views/insights/agentMonitoring/utils/referrers';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
-import {useTopNSpanEAPSeries} from 'sentry/views/insights/common/queries/useTopNDiscoverSeries';
+import {useTopNSpanSeries} from 'sentry/views/insights/common/queries/useTopNDiscoverSeries';
 import {convertSeriesToTimeseries} from 'sentry/views/insights/common/utils/convertSeriesToTimeseries';
 import {usePageFilterChartParams} from 'sentry/views/insights/pages/platform/laravel/utils';
 import {WidgetVisualizationStates} from 'sentry/views/insights/pages/platform/laravel/widgetVisualizationStates';
@@ -52,7 +52,7 @@ export default function LLMGenerationsWidget() {
     Referrer.LLM_GENERATIONS_WIDGET
   );
 
-  const timeSeriesRequest = useTopNSpanEAPSeries(
+  const timeSeriesRequest = useTopNSpanSeries(
     {
       ...pageFilterChartParams,
       search: fullQuery,

--- a/static/app/views/insights/agentMonitoring/components/tokenUsageWidget.tsx
+++ b/static/app/views/insights/agentMonitoring/components/tokenUsageWidget.tsx
@@ -21,7 +21,7 @@ import {
 import {Referrer} from 'sentry/views/insights/agentMonitoring/utils/referrers';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
-import {useTopNSpanEAPSeries} from 'sentry/views/insights/common/queries/useTopNDiscoverSeries';
+import {useTopNSpanSeries} from 'sentry/views/insights/common/queries/useTopNDiscoverSeries';
 import {convertSeriesToTimeseries} from 'sentry/views/insights/common/utils/convertSeriesToTimeseries';
 import {usePageFilterChartParams} from 'sentry/views/insights/pages/platform/laravel/utils';
 import {WidgetVisualizationStates} from 'sentry/views/insights/pages/platform/laravel/widgetVisualizationStates';
@@ -53,7 +53,7 @@ export default function TokenUsageWidget() {
     Referrer.TOKEN_USAGE_WIDGET
   );
 
-  const timeSeriesRequest = useTopNSpanEAPSeries(
+  const timeSeriesRequest = useTopNSpanSeries(
     {
       ...pageFilterChartParams,
       search: fullQuery,

--- a/static/app/views/insights/agentMonitoring/components/toolUsageWidget.tsx
+++ b/static/app/views/insights/agentMonitoring/components/toolUsageWidget.tsx
@@ -19,7 +19,7 @@ import {
 import {Referrer} from 'sentry/views/insights/agentMonitoring/utils/referrers';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
-import {useTopNSpanEAPSeries} from 'sentry/views/insights/common/queries/useTopNDiscoverSeries';
+import {useTopNSpanSeries} from 'sentry/views/insights/common/queries/useTopNDiscoverSeries';
 import {convertSeriesToTimeseries} from 'sentry/views/insights/common/utils/convertSeriesToTimeseries';
 import {usePageFilterChartParams} from 'sentry/views/insights/pages/platform/laravel/utils';
 import {WidgetVisualizationStates} from 'sentry/views/insights/pages/platform/laravel/widgetVisualizationStates';
@@ -52,7 +52,7 @@ export default function ToolUsageWidget() {
     Referrer.TOOL_USAGE_WIDGET
   );
 
-  const timeSeriesRequest = useTopNSpanEAPSeries(
+  const timeSeriesRequest = useTopNSpanSeries(
     {
       ...pageFilterChartParams,
       search: fullQuery,

--- a/static/app/views/insights/common/components/widgets/overviewCacheMissChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/overviewCacheMissChartWidget.tsx
@@ -13,7 +13,7 @@ import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/tim
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/components/widgets/types';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
-import {useTopNSpanEAPSeries} from 'sentry/views/insights/common/queries/useTopNDiscoverSeries';
+import {useTopNSpanSeries} from 'sentry/views/insights/common/queries/useTopNDiscoverSeries';
 import {convertSeriesToTimeseries} from 'sentry/views/insights/common/utils/convertSeriesToTimeseries';
 import {Referrer} from 'sentry/views/insights/pages/platform/laravel/referrers';
 import {usePageFilterChartParams} from 'sentry/views/insights/pages/platform/laravel/utils';
@@ -57,7 +57,7 @@ export default function OverviewCacheMissChartWidget(props: LoadableChartWidgetP
     cachesRequest.data.map(item => `"${item.transaction}"`)
   );
 
-  const timeSeriesRequest = useTopNSpanEAPSeries(
+  const timeSeriesRequest = useTopNSpanSeries(
     {
       ...pageFilterChartParams,
       search,

--- a/static/app/views/insights/common/components/widgets/overviewSlowNextjsSSRWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/overviewSlowNextjsSSRWidget.tsx
@@ -15,7 +15,7 @@ import {getExploreUrl} from 'sentry/views/explore/utils';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
 import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/components/widgets/types';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
-import {useTopNSpanEAPSeries} from 'sentry/views/insights/common/queries/useTopNDiscoverSeries';
+import {useTopNSpanSeries} from 'sentry/views/insights/common/queries/useTopNDiscoverSeries';
 import {convertSeriesToTimeseries} from 'sentry/views/insights/common/utils/convertSeriesToTimeseries';
 import {Referrer} from 'sentry/views/insights/pages/platform/laravel/referrers';
 import {usePageFilterChartParams} from 'sentry/views/insights/pages/platform/laravel/utils';
@@ -51,7 +51,7 @@ export default function OverviewSlowNextjsSSRWidget(props: LoadableChartWidgetPr
     Referrer.SLOW_SSR_CHART
   );
 
-  const timeSeriesRequest = useTopNSpanEAPSeries(
+  const timeSeriesRequest = useTopNSpanSeries(
     {
       ...pageFilterChartParams,
       search: `span.group:[${spansRequest.data?.map(item => `"${item['span.group']}"`).join(',')}]`,

--- a/static/app/views/insights/common/components/widgets/overviewSlowQueriesChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/overviewSlowQueriesChartWidget.tsx
@@ -14,7 +14,7 @@ import {ChartType} from 'sentry/views/insights/common/components/chart';
 import {SpanDescriptionCell} from 'sentry/views/insights/common/components/tableCells/spanDescriptionCell';
 import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/components/widgets/types';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
-import {useTopNSpanEAPSeries} from 'sentry/views/insights/common/queries/useTopNDiscoverSeries';
+import {useTopNSpanSeries} from 'sentry/views/insights/common/queries/useTopNDiscoverSeries';
 import {convertSeriesToTimeseries} from 'sentry/views/insights/common/utils/convertSeriesToTimeseries';
 import {Referrer} from 'sentry/views/insights/pages/platform/laravel/referrers';
 import {usePageFilterChartParams} from 'sentry/views/insights/pages/platform/laravel/utils';
@@ -62,7 +62,7 @@ export default function OverviewSlowQueriesChartWidget(props: LoadableChartWidge
     Referrer.QUERIES_CHART
   );
 
-  const timeSeriesRequest = useTopNSpanEAPSeries(
+  const timeSeriesRequest = useTopNSpanSeries(
     {
       ...pageFilterChartParams,
       search: `span.group:[${queriesRequest.data?.map(item => `"${item['span.group']}"`).join(',')}]`,

--- a/static/app/views/insights/common/queries/useTopNDiscoverMultiSeries.ts
+++ b/static/app/views/insights/common/queries/useTopNDiscoverMultiSeries.ts
@@ -18,7 +18,6 @@ import {
   getRetryDelay,
   shouldRetryHandler,
 } from 'sentry/views/insights/common/utils/retryHandlers';
-import {useInsightsEap} from 'sentry/views/insights/common/utils/useEap';
 import type {EAPSpanProperty} from 'sentry/views/insights/types';
 
 import {convertDiscoverTimeseriesResponse} from './convertDiscoverTimeseriesResponse';
@@ -37,7 +36,7 @@ interface UseMetricsSeriesOptions<YAxisFields, Fields> {
   transformAliasToInputFormat?: boolean;
 }
 
-export const useTopNMetricsMultiSeries = <
+export const useTopNSpanMultiSeries = <
   YAxisFields extends EAPSpanProperty[],
   Fields extends EAPSpanProperty[],
 >(
@@ -45,10 +44,9 @@ export const useTopNMetricsMultiSeries = <
   referrer: string,
   pageFilters?: PageFilters
 ) => {
-  const useEap = useInsightsEap();
   return useTopNDiscoverMultiSeries<YAxisFields, Fields>(
     options,
-    useEap ? DiscoverDatasets.SPANS_EAP_RPC : DiscoverDatasets.METRICS,
+    DiscoverDatasets.SPANS_EAP_RPC,
     referrer,
     pageFilters
   );

--- a/static/app/views/insights/common/queries/useTopNDiscoverSeries.ts
+++ b/static/app/views/insights/common/queries/useTopNDiscoverSeries.ts
@@ -19,7 +19,6 @@ import {
   getRetryDelay,
   shouldRetryHandler,
 } from 'sentry/views/insights/common/utils/retryHandlers';
-import {useInsightsEap} from 'sentry/views/insights/common/utils/useEap';
 import type {
   EAPSpanProperty,
   SpanFields,
@@ -44,21 +43,7 @@ interface UseMetricsSeriesOptions<Fields> {
   transformAliasToInputFormat?: boolean;
 }
 
-export const useTopNSpanMetricsSeries = <Fields extends SpanMetricsProperty[]>(
-  options: UseMetricsSeriesOptions<Fields>,
-  referrer: string,
-  pageFilters?: PageFilters
-) => {
-  const useEap = useInsightsEap();
-  return useTopNDiscoverSeries<Fields>(
-    options,
-    useEap ? DiscoverDatasets.SPANS_EAP_RPC : DiscoverDatasets.SPANS_METRICS,
-    referrer,
-    pageFilters
-  );
-};
-
-export const useTopNSpanEAPSeries = <
+export const useTopNSpanSeries = <
   Fields extends
     | EAPSpanProperty[]
     | SpanMetricsProperty[]

--- a/static/app/views/insights/http/components/httpSamplesPanel.spec.tsx
+++ b/static/app/views/insights/http/components/httpSamplesPanel.spec.tsx
@@ -232,7 +232,8 @@ describe('HTTPSamplesPanel', () => {
         expect.objectContaining({
           method: 'GET',
           query: {
-            dataset: 'spansMetrics',
+            dataset: 'spans',
+            sampling: SAMPLING_MODE.NORMAL,
             environment: [],
             excludeOther: 0,
             field: ['span.status_code', 'count()'],

--- a/static/app/views/insights/http/components/httpSamplesPanel.tsx
+++ b/static/app/views/insights/http/components/httpSamplesPanel.tsx
@@ -37,7 +37,7 @@ import {SampleDrawerBody} from 'sentry/views/insights/common/components/sampleDr
 import {SampleDrawerHeaderTransaction} from 'sentry/views/insights/common/components/sampleDrawerHeaderTransaction';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {useSpanMetricsSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
-import {useTopNSpanMetricsSeries} from 'sentry/views/insights/common/queries/useTopNDiscoverSeries';
+import {useTopNSpanSeries} from 'sentry/views/insights/common/queries/useTopNDiscoverSeries';
 import {
   DataTitles,
   getDurationChartTitle,
@@ -203,7 +203,7 @@ export function HTTPSamplesPanel() {
     isFetching: isResponseCodeDataLoading,
     data: responseCodeData,
     error: responseCodeError,
-  } = useTopNSpanMetricsSeries(
+  } = useTopNSpanSeries(
     {
       search,
       fields: [SpanFields.SPAN_STATUS_CODE, 'count()'],

--- a/static/app/views/insights/mcp/components/groupedDurationWidget.tsx
+++ b/static/app/views/insights/mcp/components/groupedDurationWidget.tsx
@@ -13,7 +13,7 @@ import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {useCombinedQuery} from 'sentry/views/insights/agentMonitoring/hooks/useCombinedQuery';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
-import {useTopNSpanEAPSeries} from 'sentry/views/insights/common/queries/useTopNDiscoverSeries';
+import {useTopNSpanSeries} from 'sentry/views/insights/common/queries/useTopNDiscoverSeries';
 import {convertSeriesToTimeseries} from 'sentry/views/insights/common/utils/convertSeriesToTimeseries';
 import {usePageFilterChartParams} from 'sentry/views/insights/pages/platform/laravel/utils';
 import {WidgetVisualizationStates} from 'sentry/views/insights/pages/platform/laravel/widgetVisualizationStates';
@@ -53,7 +53,7 @@ export default function GroupedDurationWidget(props: GroupedDurationWidgetProps)
     props.referrer
   );
 
-  const timeSeriesRequest = useTopNSpanEAPSeries(
+  const timeSeriesRequest = useTopNSpanSeries(
     {
       ...pageFilterChartParams,
       search: fullQuery,

--- a/static/app/views/insights/mcp/components/groupedErrorRateWidget.tsx
+++ b/static/app/views/insights/mcp/components/groupedErrorRateWidget.tsx
@@ -13,7 +13,7 @@ import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {useCombinedQuery} from 'sentry/views/insights/agentMonitoring/hooks/useCombinedQuery';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
-import {useTopNSpanEAPSeries} from 'sentry/views/insights/common/queries/useTopNDiscoverSeries';
+import {useTopNSpanSeries} from 'sentry/views/insights/common/queries/useTopNDiscoverSeries';
 import {convertSeriesToTimeseries} from 'sentry/views/insights/common/utils/convertSeriesToTimeseries';
 import {usePageFilterChartParams} from 'sentry/views/insights/pages/platform/laravel/utils';
 import {WidgetVisualizationStates} from 'sentry/views/insights/pages/platform/laravel/widgetVisualizationStates';
@@ -53,7 +53,7 @@ export default function GroupedErrorRateWidget(props: GroupedErrorRateWidgetProp
     props.referrer
   );
 
-  const timeSeriesRequest = useTopNSpanEAPSeries(
+  const timeSeriesRequest = useTopNSpanSeries(
     {
       ...pageFilterChartParams,
       search: fullQuery,

--- a/static/app/views/insights/mcp/components/groupedTrafficWidget.tsx
+++ b/static/app/views/insights/mcp/components/groupedTrafficWidget.tsx
@@ -13,7 +13,7 @@ import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {useCombinedQuery} from 'sentry/views/insights/agentMonitoring/hooks/useCombinedQuery';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
-import {useTopNSpanEAPSeries} from 'sentry/views/insights/common/queries/useTopNDiscoverSeries';
+import {useTopNSpanSeries} from 'sentry/views/insights/common/queries/useTopNDiscoverSeries';
 import {convertSeriesToTimeseries} from 'sentry/views/insights/common/utils/convertSeriesToTimeseries';
 import {usePageFilterChartParams} from 'sentry/views/insights/pages/platform/laravel/utils';
 import {WidgetVisualizationStates} from 'sentry/views/insights/pages/platform/laravel/widgetVisualizationStates';
@@ -53,7 +53,7 @@ export default function GroupedTrafficWidget(props: GroupedTrafficWidgetProps) {
     props.referrer
   );
 
-  const timeSeriesRequest = useTopNSpanEAPSeries(
+  const timeSeriesRequest = useTopNSpanSeries(
     {
       ...pageFilterChartParams,
       search: fullQuery,

--- a/static/app/views/insights/mobile/appStarts/components/startDurationWidget.tsx
+++ b/static/app/views/insights/mobile/appStarts/components/startDurationWidget.tsx
@@ -13,7 +13,7 @@ import {
 // eslint-disable-next-line no-restricted-imports
 import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/insightsLineChartWidget';
 import {useReleaseSelection} from 'sentry/views/insights/common/queries/useReleases';
-import {useTopNSpanMetricsSeries} from 'sentry/views/insights/common/queries/useTopNDiscoverSeries';
+import {useTopNSpanSeries} from 'sentry/views/insights/common/queries/useTopNDiscoverSeries';
 import {appendReleaseFilters} from 'sentry/views/insights/common/utils/releaseComparison';
 import {COLD_START_TYPE} from 'sentry/views/insights/mobile/appStarts/components/startTypeSelector';
 import {Referrer} from 'sentry/views/insights/mobile/appStarts/referrers';
@@ -91,7 +91,7 @@ function StartDurationWidget({additionalFilters}: Props) {
     data,
     isPending: isSeriesLoading,
     error: seriesError,
-  } = useTopNSpanMetricsSeries(
+  } = useTopNSpanSeries(
     {
       yAxis: [yAxis],
       fields: [groupBy, 'avg(span.duration)'],

--- a/static/app/views/insights/mobile/screenload/components/charts/screenCharts.tsx
+++ b/static/app/views/insights/mobile/screenload/components/charts/screenCharts.tsx
@@ -17,7 +17,7 @@ import {formatVersion} from 'sentry/utils/versions/formatVersion';
 import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/insightsLineChartWidget';
 import {type DiscoverSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {useReleaseSelection} from 'sentry/views/insights/common/queries/useReleases';
-import {useTopNMetricsMultiSeries} from 'sentry/views/insights/common/queries/useTopNDiscoverMultiSeries';
+import {useTopNSpanMultiSeries} from 'sentry/views/insights/common/queries/useTopNDiscoverMultiSeries';
 import {appendReleaseFilters} from 'sentry/views/insights/common/utils/releaseComparison';
 import useCrossPlatformProject from 'sentry/views/insights/mobile/common/queries/useCrossPlatformProject';
 import {ScreensBarChart} from 'sentry/views/insights/mobile/screenload/components/charts/screenBarChart';
@@ -86,7 +86,7 @@ export function ScreenCharts({additionalFilters}: Props) {
     data: releaseSeriesArray,
     isPending: isSeriesLoading,
     error: seriesError,
-  } = useTopNMetricsMultiSeries(
+  } = useTopNSpanMultiSeries(
     {
       fields: [groupBy],
       topN: 2,

--- a/static/app/views/insights/queues/charts/throughputChart.tsx
+++ b/static/app/views/insights/queues/charts/throughputChart.tsx
@@ -14,7 +14,7 @@ import {BaseChartActionDropdown} from 'sentry/views/insights/common/components/c
 // eslint-disable-next-line no-restricted-imports
 import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/insightsLineChartWidget';
 import type {DiscoverSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
-import {useTopNSpanMetricsSeries} from 'sentry/views/insights/common/queries/useTopNDiscoverSeries';
+import {useTopNSpanSeries} from 'sentry/views/insights/common/queries/useTopNDiscoverSeries';
 import {getAlertsUrl} from 'sentry/views/insights/common/utils/getAlertsUrl';
 import {renameDiscoverSeries} from 'sentry/views/insights/common/utils/renameDiscoverSeries';
 import {useAlertsProject} from 'sentry/views/insights/common/utils/useAlertsProject';
@@ -52,7 +52,7 @@ export function ThroughputChart({id, error, destination, pageFilters, referrer}:
     data,
     error: topNError,
     isLoading,
-  } = useTopNSpanMetricsSeries(
+  } = useTopNSpanSeries(
     {
       search,
       yAxis: [yAxis],


### PR DESCRIPTION
Span metrics is no more, so we can replace all the hooks with the span one