### PR TITLE
feat(explore-suspect-attrs): Making scroll smoother

### DIFF
--- a/static/app/components/charts/baseChart.tsx
+++ b/static/app/components/charts/baseChart.tsx
@@ -500,7 +500,7 @@ function BaseChart({
 
     const bucketSize = seriesData ? seriesData[1][0] - seriesData[0][0] : undefined;
     const tooltipOrNone =
-      tooltip === null
+      tooltip === undefined
         ? undefined
         : computeChartTooltip(
             {

--- a/static/app/components/charts/baseChart.tsx
+++ b/static/app/components/charts/baseChart.tsx
@@ -97,7 +97,7 @@ type Truncateable = {
   truncate?: number | boolean;
 };
 
-interface TooltipOption
+export interface TooltipOption
   extends Omit<TooltipComponentOption, 'valueFormatter'>,
     Truncateable {
   filter?: (value: number, seriesParam: TooltipComponentOption['formatter']) => boolean;


### PR DESCRIPTION
- `appendToBody:true` is expensive
- It slows down scroll, when triggered unnecessarily 
- In this PR I delay setting the tooltip option a little, so that charts that are quickly scrolled past and unmounted by the virtualizer -> don't trigger appendToBody.