### PR TITLE
feat(error-upsampling): Apply upsampling when ANY project is allowlisted

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -18,7 +18,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.base import CURSOR_LINK_HEADER
 from sentry.api.bases import NoProjects
 from sentry.api.bases.organization import FilterParamsDateNotNull, OrganizationEndpoint
-from sentry.api.helpers.error_upsampling import are_all_projects_error_upsampled
+from sentry.api.helpers.error_upsampling import are_any_projects_error_upsampled
 from sentry.api.helpers.mobile import get_readable_device_name
 from sentry.api.helpers.teams import get_teams
 from sentry.api.serializers.snuba import SnubaTSResultSerializer
@@ -431,7 +431,7 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
         and update the meta fields to reflect the new field names. This works around a limitation in
         how aliases are handled in the SnQL parser.
         """
-        if are_all_projects_error_upsampled(project_ids):
+        if are_any_projects_error_upsampled(project_ids):
             data = results.get("data", [])
             fields_meta = results.get("meta", {}).get("fields", {})
 

--- a/src/sentry/api/helpers/error_upsampling.py
+++ b/src/sentry/api/helpers/error_upsampling.py
@@ -19,18 +19,18 @@ def is_errors_query_for_error_upsampled_projects(
 ) -> bool:
     """
     Determine if this query should use error upsampling transformations.
-    Only applies when ALL projects are allowlisted and we're querying error events.
+    Only applies when ANY projects are allowlisted and we're querying error events.
     """
-    if not are_all_projects_error_upsampled(snuba_params.project_ids):
+    if not are_any_projects_error_upsampled(snuba_params.project_ids):
         return False
 
     return _should_apply_sample_weight_transform(dataset, request)
 
 
-def are_all_projects_error_upsampled(project_ids: Sequence[int]) -> bool:
+def are_any_projects_error_upsampled(project_ids: Sequence[int]) -> bool:
     """
-    Check if ALL projects in the query are allowlisted for error upsampling.
-    Only returns True if all projects pass the allowlist condition.
+    Check if ANY projects in the query are allowlisted for error upsampling.
+    Only returns True if any project pass the allowlist condition.
     """
     if not project_ids:
         return False
@@ -39,8 +39,8 @@ def are_all_projects_error_upsampled(project_ids: Sequence[int]) -> bool:
     if not allowlist:
         return False
 
-    # All projects must be in the allowlist
-    result = all(project_id in allowlist for project_id in project_ids)
+    # Any project must be in the allowlist
+    result = any(project_id in allowlist for project_id in project_ids)
     return result
 
 

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -14,7 +14,7 @@ from django.contrib.auth.models import AnonymousUser
 from django.db.models import Min, prefetch_related_objects
 
 from sentry import features, tagstore
-from sentry.api.helpers.error_upsampling import are_all_projects_error_upsampled
+from sentry.api.helpers.error_upsampling import are_any_projects_error_upsampled
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.models.actor import ActorSerializer
 from sentry.api.serializers.models.plugin import is_plugin_deprecated
@@ -1074,8 +1074,8 @@ class GroupSerializerSnuba(GroupSerializerBase):
             ["max", "timestamp", "last_seen"],
             ["uniq", "tags[sentry:user]", "count"],
         ]
-        # Check if all projects are allowlisted for error upsampling
-        is_upsampled = are_all_projects_error_upsampled(project_ids)
+        # Check if any projects are allowlisted for error upsampling
+        is_upsampled = are_any_projects_error_upsampled(project_ids)
         if is_upsampled:
             aggregations[0] = ["upsampled_count", "", "times_seen"]
 

--- a/src/sentry/api/serializers/models/group_stream.py
+++ b/src/sentry/api/serializers/models/group_stream.py
@@ -12,7 +12,7 @@ from django.utils import timezone
 from sentry import features, release_health, tsdb
 from sentry.api.helpers.error_upsampling import (
     UPSAMPLED_ERROR_AGGREGATION,
-    are_all_projects_error_upsampled,
+    are_any_projects_error_upsampled,
 )
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.group import (
@@ -395,8 +395,7 @@ class StreamGroupSerializerSnuba(GroupSerializerSnuba, GroupStatsMixin):
         if self.stats_period and not self._collapse("stats"):
             aggregation_override = None
             if self.project_ids:
-                is_upsampled = are_all_projects_error_upsampled(self.project_ids)
-                if is_upsampled:
+                if are_any_projects_error_upsampled(self.project_ids):
                     aggregation_override = UPSAMPLED_ERROR_AGGREGATION
 
             partial_get_stats = functools.partial(

--- a/tests/sentry/api/helpers/test_error_upsampling.py
+++ b/tests/sentry/api/helpers/test_error_upsampling.py
@@ -7,7 +7,7 @@ from rest_framework.request import Request
 from sentry.api.helpers.error_upsampling import (
     _is_error_focused_query,
     _should_apply_sample_weight_transform,
-    are_all_projects_error_upsampled,
+    are_any_projects_error_upsampled,
     transform_query_columns_for_error_upsampling,
 )
 from sentry.models.organization import Organization
@@ -35,21 +35,21 @@ class ErrorUpsamplingTest(TestCase):
         self.request.GET = QueryDict("")
 
     @patch("sentry.api.helpers.error_upsampling.options")
-    def test_are_all_projects_error_upsampled(self, mock_options: Mock) -> None:
+    def test_are_any_projects_error_upsampled(self, mock_options: Mock) -> None:
         # Test when all projects are allowlisted
         mock_options.get.return_value = self.project_ids
-        assert are_all_projects_error_upsampled(self.project_ids) is True
+        assert are_any_projects_error_upsampled(self.project_ids) is True
 
-        # Test when some projects are not allowlisted
+        # Test when some projects are allowlisted
         mock_options.get.return_value = self.project_ids[:-1]
-        assert are_all_projects_error_upsampled(self.project_ids) is False
+        assert are_any_projects_error_upsampled(self.project_ids) is True
 
         # Test when no projects are allowlisted
         mock_options.get.return_value = []
-        assert are_all_projects_error_upsampled(self.project_ids) is False
+        assert are_any_projects_error_upsampled(self.project_ids) is False
 
         # Test when no project IDs provided
-        assert are_all_projects_error_upsampled([]) is False
+        assert are_any_projects_error_upsampled([]) is False
 
     def test_transform_query_columns_for_error_upsampling(self) -> None:
         # Test count() transformation

--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -6776,7 +6776,7 @@ class OrganizationEventsErrorsDatasetEndpointTest(OrganizationEventsEndpointTest
             assert response.data["data"][0]["count()"] == 1
 
     def test_error_upsampling_with_partial_allowlist(self):
-        """Test that count() is not upsampled when only some projects are allowlisted."""
+        """Test that count() is upsampled when any project in the query is allowlisted."""
         # Create a second project
         project2 = self.create_project(organization=self.organization)
 
@@ -6819,8 +6819,8 @@ class OrganizationEventsErrorsDatasetEndpointTest(OrganizationEventsEndpointTest
             features = {"organizations:discover-basic": True, "organizations:global-views": True}
             response = self.do_request(query, features=features)
             assert response.status_code == 200, response.content
-            # Expect no upsampling since not all projects are allowlisted
-            assert response.data["data"][0]["count()"] == 2
+            # Expect upsampling since any project is allowlisted (both events upsampled: 10 + 10 = 20)
+            assert response.data["data"][0]["count()"] == 20
 
     def test_is_status(self):
         self.store_event(

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -3578,9 +3578,9 @@ class OrganizationEventsStatsErrorUpsamplingTest(APITestCase, SnubaTestCase):
         assert response.status_code == 200, response.content
         data = response.data["data"]
         assert len(data) == 2  # Two time buckets
-        # Should use regular count() since not all projects are allowlisted
-        assert data[0][1][0]["count"] == 1
-        assert data[1][1][0]["count"] == 1
+        # Should use upsampled count() since any project is allowlisted
+        assert data[0][1][0]["count"] == 10
+        assert data[1][1][0]["count"] == 10
 
     @mock.patch("sentry.api.helpers.error_upsampling.options")
     def test_error_upsampling_with_transaction_events(self, mock_options):


### PR DESCRIPTION
Changes the error upsampling logic from requiring ALL projects in a query to be allowlisted to requiring only ANY project to be allowlisted. The upsampling returns the same data for non upsampled projects so there is no need to be strict and require all projects.

While that means that we could theoretically always count the upsampled way, there is a performance cost to the upsampled way - `sum(ifNull(sample_weight, 1))`, summing up a field instead of a simple count, and changing the way we count across the board for the very small subset of projects that are going to be using this currently seems off. 