### PR TITLE
ref(deletions): Debug few events being deleted

### DIFF
--- a/src/sentry/deletions/defaults/group.py
+++ b/src/sentry/deletions/defaults/group.py
@@ -143,10 +143,10 @@ class ErrorEventsDeletionTask(EventsBaseDeletionTask):
         if events:
             # Adding this variable to see the values in stack traces
             last_event = events[-1]
-            # This value will be used in the next call to chunk
-            self.last_event = last_event
             self.delete_events_from_nodestore(events)
             self.delete_dangling_attachments_and_user_reports(events)
+            # This value will be used in the next call to chunk
+            self.last_event = last_event
             # As long as it returns True the task will keep iterating
             return True
         else:
@@ -195,13 +195,13 @@ class IssuePlatformEventsDeletionTask(EventsBaseDeletionTask):
         if events:
             # Adding this variable to see the values in stack traces
             last_event = events[-1]
-            # This value will be used in the next call to chunk
-            self.last_event = last_event
             # Ideally, in some cases, we should also delete the associated event from the Nodestore.
             # In the occurrence_consumer [1] we sometimes create a new event but it's hard in post-ingestion to distinguish between
             # a created event and an existing one.
             # https://github.com/getsentry/sentry/blob/a86b9b672709bc9c4558cffb2c825965b8cee0d1/src/sentry/issues/occurrence_consumer.py#L324-L339
             self.delete_events_from_nodestore(events)
+            # This value will be used in the next call to chunk
+            self.last_event = last_event
             # As long as it returns True the task will keep iterating
             return True
         else:

--- a/src/sentry/deletions/defaults/group.py
+++ b/src/sentry/deletions/defaults/group.py
@@ -11,7 +11,6 @@ from snuba_sdk import DeleteQuery, Request
 
 from sentry import eventstore, eventstream, models, nodestore
 from sentry.eventstore.models import Event
-from sentry.eventstore.snuba.backend import get_before_event_condition
 from sentry.issues.grouptype import GroupCategory, InvalidGroupTypeError
 from sentry.models.group import Group, GroupStatus
 from sentry.models.rulefirehistory import RuleFireHistory
@@ -94,10 +93,19 @@ class EventsBaseDeletionTask(BaseDeletionTask[Group]):
         self.group_ids = group_ids
         self.project_ids = list(self.project_groups.keys())
 
+    def get_before_event_condition(self, last_event: Event) -> list[list[Any]]:
+        return [
+            ["timestamp", "<=", last_event.timestamp],
+            [
+                ["timestamp", "<", last_event.timestamp],
+                ["event_id", "<", last_event.event_id],
+            ],
+        ]
+
     def get_unfetched_events(self) -> list[Event]:
         conditions = []
         if self.last_event is not None:
-            conditions.extend(get_before_event_condition(self.last_event))
+            conditions.extend(self.get_before_event_condition(self.last_event))
 
         logger.info("Fetching %s events for deletion.", self.DEFAULT_CHUNK_SIZE)
         events = eventstore.backend.get_unfetched_events(

--- a/src/sentry/deletions/defaults/group.py
+++ b/src/sentry/deletions/defaults/group.py
@@ -140,10 +140,12 @@ class ErrorEventsDeletionTask(EventsBaseDeletionTask):
         if the deletion has completed and if it needs to be called again."""
         events = self.get_unfetched_events()
         if events:
+            # Adding this variable to see the values in stack traces
+            last_event = events[-1]
+            # This value will be used in the next call to chunk
+            self.last_event = last_event
             self.delete_events_from_nodestore(events)
             self.delete_dangling_attachments_and_user_reports(events)
-            # This value will be used in the next call to chunk
-            self.last_event = events[-1]
             # As long as it returns True the task will keep iterating
             return True
         else:
@@ -189,13 +191,15 @@ class IssuePlatformEventsDeletionTask(EventsBaseDeletionTask):
         if the deletion has completed and if it needs to be called again."""
         events = self.get_unfetched_events()
         if events:
+            # Adding this variable to see the values in stack traces
+            last_event = events[-1]
+            # This value will be used in the next call to chunk
+            self.last_event = last_event
             # Ideally, in some cases, we should also delete the associated event from the Nodestore.
             # In the occurrence_consumer [1] we sometimes create a new event but it's hard in post-ingestion to distinguish between
             # a created event and an existing one.
             # https://github.com/getsentry/sentry/blob/a86b9b672709bc9c4558cffb2c825965b8cee0d1/src/sentry/issues/occurrence_consumer.py#L324-L339
             self.delete_events_from_nodestore(events)
-            # This value will be used in the next call to chunk
-            self.last_event = events[-1]
             # As long as it returns True the task will keep iterating
             return True
         else:

--- a/src/sentry/deletions/defaults/group.py
+++ b/src/sentry/deletions/defaults/group.py
@@ -157,6 +157,7 @@ class ErrorEventsDeletionTask(EventsBaseDeletionTask):
     def delete_events_from_nodestore(self, events: Sequence[Event]) -> None:
         # Remove from nodestore
         node_ids = [Event.generate_node_id(event.project_id, event.event_id) for event in events]
+        logger.info("Deleting %s events from nodestore.", len(node_ids))
         nodestore.backend.delete_multi(node_ids)
 
     def delete_dangling_attachments_and_user_reports(self, events: Sequence[Event]) -> None:

--- a/src/sentry/deletions/defaults/group.py
+++ b/src/sentry/deletions/defaults/group.py
@@ -93,19 +93,18 @@ class EventsBaseDeletionTask(BaseDeletionTask[Group]):
         self.group_ids = group_ids
         self.project_ids = list(self.project_groups.keys())
 
-    def get_before_event_condition(self, last_event: Event) -> list[list[Any]]:
-        return [
-            ["timestamp", "<=", last_event.timestamp],
-            [
-                ["timestamp", "<", last_event.timestamp],
-                ["event_id", "<", last_event.event_id],
-            ],
-        ]
-
     def get_unfetched_events(self) -> list[Event]:
         conditions = []
         if self.last_event is not None:
-            conditions.extend(self.get_before_event_condition(self.last_event))
+            conditions.extend(
+                [
+                    ["timestamp", "<=", self.last_event.timestamp],
+                    [
+                        ["timestamp", "<", self.last_event.timestamp],
+                        ["event_id", "<", self.last_event.event_id],
+                    ],
+                ]
+            )
 
         logger.info("Fetching %s events for deletion.", self.DEFAULT_CHUNK_SIZE)
         events = eventstore.backend.get_unfetched_events(


### PR DESCRIPTION
The code says we should be fetching and deleting 10k events at a time, however, I see 10 hashes per fetch from stack traces
in [SENTRY-41FE](https://sentry.sentry.io/issues/6683289583/).

This change will add more debugging.

<img width="796" height="470" alt="image" src="https://github.com/user-attachments/assets/96a78e54-937a-4230-b9e4-ea13903ffac5" />
