### PR TITLE
Revert "ref(deletions): Remove unnecessary Seer calls in endpoint (#93541)

### DIFF
--- a/src/sentry/api/helpers/group_index/delete.py
+++ b/src/sentry/api/helpers/group_index/delete.py
@@ -13,10 +13,13 @@ from rest_framework.response import Response
 from sentry import audit_log, eventstream
 from sentry.api.base import audit_logger
 from sentry.deletions.tasks.groups import delete_groups as delete_groups_task
+from sentry.issues.grouptype import GroupCategory
 from sentry.models.group import Group, GroupStatus
+from sentry.models.grouphash import GroupHash
 from sentry.models.groupinbox import GroupInbox
 from sentry.models.project import Project
 from sentry.signals import issue_deleted
+from sentry.tasks.delete_seer_grouping_records import may_schedule_task_to_delete_hashes_from_seer
 from sentry.utils.audit import create_audit_entry
 
 from . import BULK_MUTATION_LIMIT, SearchFunction
@@ -44,7 +47,12 @@ def delete_group_list(
     # deterministic sort for sanity, and for very large deletions we'll
     # delete the "smaller" groups first
     group_list.sort(key=lambda g: (g.times_seen, g.id))
-    group_ids = [g.id for g in group_list]
+    group_ids = []
+    error_ids = []
+    for g in group_list:
+        group_ids.append(g.id)
+        if g.issue_category == GroupCategory.ERROR:
+            error_ids.append(g.id)
 
     transaction_id = uuid4().hex
     delete_logger.info(
@@ -75,6 +83,13 @@ def delete_group_list(
     # so that we can see who requested the deletion. Even if anything after this point
     # fails, we will still have a record of who requested the deletion.
     create_audit_entries(request, project, group_list, delete_type, transaction_id)
+
+    # Tell seer to delete grouping records for these groups
+    may_schedule_task_to_delete_hashes_from_seer(error_ids)
+
+    # Removing GroupHash rows prevents new events from associating to the groups
+    # we just deleted.
+    GroupHash.objects.filter(project_id=project.id, group__id__in=group_ids).delete()
 
     # We remove `GroupInbox` rows here so that they don't end up influencing queries for
     # `Group` instances that are pending deletion

--- a/tests/sentry/api/helpers/test_group_index.py
+++ b/tests/sentry/api/helpers/test_group_index.py
@@ -1174,8 +1174,7 @@ class DeleteGroupsTest(TestCase):
             GroupHash.objects.create(project=self.project, group=group, hash=hashes[i])
             add_group_to_inbox(group, GroupInboxReason.NEW)
 
-        with self.tasks():
-            delete_groups(request, [self.project], self.organization.id)
+        delete_groups(request, [self.project], self.organization.id)
 
         assert (
             len(GroupHash.objects.filter(project_id=self.project.id, group_id__in=group_ids).all())
@@ -1206,8 +1205,7 @@ class DeleteGroupsTest(TestCase):
             GroupHash.objects.create(project=self.project, group=group, hash=hashes[i])
             add_group_to_inbox(group, GroupInboxReason.NEW)
 
-        with self.tasks():
-            delete_groups(request, [self.project], self.organization.id)
+        delete_groups(request, [self.project], self.organization.id)
 
         assert (
             len(GroupHash.objects.filter(project_id=self.project.id, group_id__in=group_ids).all())

--- a/tests/sentry/issues/endpoints/test_group_details.py
+++ b/tests/sentry/issues/endpoints/test_group_details.py
@@ -878,7 +878,10 @@ class GroupDeleteTest(APITestCase):
 
         # Deletion was deferred, so it should still exist
         assert Group.objects.get(id=group.id).status == GroupStatus.PENDING_DELETION
-        assert GroupHash.objects.filter(group_id=group.id).exists()
+        # BUT the hash should be gone
+        assert not GroupHash.objects.filter(group_id=group.id).exists()
+
+        Group.objects.filter(id=group.id).update(status=GroupStatus.UNRESOLVED)
 
     def test_delete_and_tasks_run(self) -> None:
         self.login_as(user=self.user)

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -5488,7 +5488,7 @@ class GroupDeleteTest(APITestCase, SnubaTestCase):
     def assert_pending_deletion_groups(self, groups: Sequence[Group]) -> None:
         for group in groups:
             assert Group.objects.get(id=group.id).status == GroupStatus.PENDING_DELETION
-            assert GroupHash.objects.filter(group_id=group.id).exists()
+            assert not GroupHash.objects.filter(group_id=group.id).exists()
 
     def assert_deleted_groups(self, groups: Sequence[Group]) -> None:
         for group in groups:
@@ -5525,7 +5525,12 @@ class GroupDeleteTest(APITestCase, SnubaTestCase):
         )
 
         assert response.status_code == 204
-        self.assert_pending_deletion_groups([group1, group2])
+
+        assert Group.objects.get(id=group1.id).status == GroupStatus.PENDING_DELETION
+        assert not GroupHash.objects.filter(group_id=group1.id).exists()
+
+        assert Group.objects.get(id=group2.id).status == GroupStatus.PENDING_DELETION
+        assert not GroupHash.objects.filter(group_id=group2.id).exists()
 
         assert Group.objects.get(id=group3.id).status != GroupStatus.PENDING_DELETION
         assert GroupHash.objects.filter(group_id=group3.id).exists()

--- a/tests/snuba/api/endpoints/test_project_group_index.py
+++ b/tests/snuba/api/endpoints/test_project_group_index.py
@@ -1505,6 +1505,7 @@ class GroupDeleteTest(APITestCase, SnubaTestCase):
     def assert_groups_being_deleted(self, groups: Sequence[Group]) -> None:
         for g in groups:
             assert Group.objects.get(id=g.id).status == GroupStatus.PENDING_DELETION
+            assert not GroupHash.objects.filter(group_id=g.id).exists()
 
         # This is necessary before calling the delete task
         Group.objects.filter(id__in=[g.id for g in groups]).update(status=GroupStatus.UNRESOLVED)
@@ -1634,3 +1635,25 @@ class GroupDeleteTest(APITestCase, SnubaTestCase):
             response = self.client.delete(url, format="json")
             assert response.status_code == 204
             self.assert_groups_are_gone(groups)
+
+    @patch("sentry.api.helpers.group_index.delete.may_schedule_task_to_delete_hashes_from_seer")
+    @patch("sentry.utils.audit.log_service.record_audit_log")
+    def test_audit_log_even_if_exception_raised(
+        self, mock_record_audit_log: Mock, mock_seer_delete: Mock
+    ):
+        """
+        Test that audit log is created even if an exception is raised after the audit log is created.
+        """
+        # Calling seer happens after creating the audit log entry
+        mock_seer_delete.side_effect = Exception("Seer error!")
+        group1 = self.create_group()
+        self.login_as(user=self.user)
+        url = f"{self.path}?id={group1.id}"
+        with self.tasks():
+            response = self.client.delete(url, format="json")
+            assert response.status_code == 500
+
+        self.assert_audit_log_entry([group1], mock_record_audit_log)
+
+        # They have been marked as pending deletion but the exception prevented their complete deletion
+        assert Group.objects.get(id=group1.id).status == GroupStatus.PENDING_DELETION


### PR DESCRIPTION
This reverts commit e9e09e1307a37bad735e2f4e0411cf81062b90ab.

A customer deleted an issue but new events were being associated with the old group.
I will add a test to document the expected behaviour.