### PR TITLE
chore(sentry apps): Ignore a bunch more client side errors

### DIFF
--- a/src/sentry/sentry_apps/tasks/sentry_apps.py
+++ b/src/sentry/sentry_apps/tasks/sentry_apps.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from typing import Any
 
 from django.urls import reverse
+from requests import HTTPError, Timeout
 from requests.exceptions import ChunkedEncodingError, RequestException
 
 from sentry import analytics, features, nodestore
@@ -78,8 +79,15 @@ CONTROL_TASK_OPTIONS = {
 }
 
 retry_decorator = retry(
-    on=(RequestException, ApiHostError, ApiTimeoutError),
-    on_silent=(ChunkedEncodingError),
+    on=(RequestException),
+    on_silent=(
+        ChunkedEncodingError,
+        Timeout,
+        ApiHostError,
+        ApiTimeoutError,
+        ConnectionError,
+        HTTPError,
+    ),
     ignore=(
         ClientError,
         SentryAppSentryError,

--- a/src/sentry/sentry_apps/tasks/sentry_apps.py
+++ b/src/sentry/sentry_apps/tasks/sentry_apps.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from django.urls import reverse
 from requests import HTTPError, Timeout
-from requests.exceptions import ChunkedEncodingError, RequestException
+from requests.exceptions import ChunkedEncodingError, ConnectionError, RequestException
 
 from sentry import analytics, features, nodestore
 from sentry.api.serializers import serialize

--- a/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
+++ b/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
@@ -4,6 +4,7 @@ from unittest.mock import ANY, patch
 import pytest
 import responses
 from django.urls import reverse
+from requests import HTTPError
 from requests.exceptions import ChunkedEncodingError, ConnectionError, Timeout
 
 from sentry.api.serializers import serialize
@@ -71,6 +72,10 @@ def raiseException():
     raise Exception
 
 
+def raiseHTTPError():
+    raise HTTPError()
+
+
 class RequestMock:
     def __init__(self):
         self.body = "blah blah"
@@ -101,7 +106,7 @@ MockResponseInstance = MockResponse({}, b"{}", "", True, 200, raiseStatusFalse, 
 MockResponse404 = MockResponse({}, b'{"bruh": "bruhhhhhhh"}', "", False, 404, raiseException, None)
 MockResponse504 = MockResponse(headers, json_content, "", False, 504, raiseStatusFalse, None)
 MockResponse503 = MockResponse(headers, json_content, "", False, 503, raiseStatusFalse, None)
-MockResponse502 = MockResponse(headers, json_content, "", False, 502, raiseStatusFalse, None)
+MockResponse502 = MockResponse(headers, json_content, "", False, 502, raiseHTTPError, None)
 
 
 class TestSendAlertEvent(TestCase, OccurrenceTestMixin):

--- a/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
+++ b/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
@@ -4,7 +4,7 @@ from unittest.mock import ANY, patch
 import pytest
 import responses
 from django.urls import reverse
-from requests.exceptions import ChunkedEncodingError
+from requests.exceptions import ChunkedEncodingError, ConnectionError, Timeout
 
 from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework import convert_dict_key_case, snake_to_camel_case
@@ -99,6 +99,9 @@ MockResponseWithHeadersInstance = MockResponse(
 )
 MockResponseInstance = MockResponse({}, b"{}", "", True, 200, raiseStatusFalse, None)
 MockResponse404 = MockResponse({}, b'{"bruh": "bruhhhhhhh"}', "", False, 404, raiseException, None)
+MockResponse504 = MockResponse(headers, json_content, "", False, 504, raiseStatusFalse, None)
+MockResponse503 = MockResponse(headers, json_content, "", False, 503, raiseStatusFalse, None)
+MockResponse502 = MockResponse(headers, json_content, "", False, 502, raiseStatusFalse, None)
 
 
 class TestSendAlertEvent(TestCase, OccurrenceTestMixin):
@@ -591,6 +594,126 @@ class TestProcessResourceChange(TestCase):
             )
 
         # Verify that the exception was not captured by Sentry since it's ignored
+        assert len(capture_exception.mock_calls) == 0
+        assert safe_urlopen.called
+
+    @patch("sentry_sdk.capture_exception")
+    def test_ignores_timeout_error(self, capture_exception, safe_urlopen):
+        safe_urlopen.side_effect = Timeout()
+
+        event = self.store_event(data={}, project_id=self.project.id)
+        assert event.group is not None
+
+        # The task should complete without reporting to sentry when Timeout is raised
+        # because it's in the on_silent list of the retry decorator
+        with self.tasks():
+            post_process_group(
+                is_new=True,
+                is_regression=False,
+                is_new_group_environment=False,
+                cache_key=write_event_to_cache(event),
+                group_id=event.group_id,
+                project_id=self.project.id,
+                eventstream_type=EventStreamEventType.Error.value,
+            )
+
+        # Verify that the exception was not captured by Sentry since it's on_silent
+        assert len(capture_exception.mock_calls) == 0
+        assert safe_urlopen.called
+
+    @patch("sentry_sdk.capture_exception")
+    def test_ignores_api_host_error(self, capture_exception, safe_urlopen):
+        safe_urlopen.return_value = MockResponse503
+
+        event = self.store_event(data={}, project_id=self.project.id)
+        assert event.group is not None
+
+        # The task should complete without reporting to sentry when ApiHostError is raised
+        # because it's in the on_silent list of the retry decorator
+        with self.tasks():
+            post_process_group(
+                is_new=True,
+                is_regression=False,
+                is_new_group_environment=False,
+                cache_key=write_event_to_cache(event),
+                group_id=event.group_id,
+                project_id=self.project.id,
+                eventstream_type=EventStreamEventType.Error.value,
+            )
+
+        # Verify that the exception was not captured by Sentry since it's on_silent
+        assert len(capture_exception.mock_calls) == 0
+        assert safe_urlopen.called
+
+    @patch("sentry_sdk.capture_exception")
+    def test_ignores_api_timeout_error(self, capture_exception, safe_urlopen):
+        safe_urlopen.return_value = MockResponse504
+
+        event = self.store_event(data={}, project_id=self.project.id)
+        assert event.group is not None
+
+        # The task should complete without reporting to sentry when ApiTimeoutError is raised
+        # because it's in the on_silent list of the retry decorator
+        with self.tasks():
+            post_process_group(
+                is_new=True,
+                is_regression=False,
+                is_new_group_environment=False,
+                cache_key=write_event_to_cache(event),
+                group_id=event.group_id,
+                project_id=self.project.id,
+                eventstream_type=EventStreamEventType.Error.value,
+            )
+
+        # Verify that the exception was not captured by Sentry since it's on_silent
+        assert len(capture_exception.mock_calls) == 0
+        assert safe_urlopen.called
+
+    @patch("sentry_sdk.capture_exception")
+    def test_ignores_connection_error(self, capture_exception, safe_urlopen):
+        safe_urlopen.side_effect = ConnectionError()
+
+        event = self.store_event(data={}, project_id=self.project.id)
+        assert event.group is not None
+
+        # The task should complete without reporting to sentry when ConnectionError is raised
+        # because it's in the on_silent list of the retry decorator
+        with self.tasks():
+            post_process_group(
+                is_new=True,
+                is_regression=False,
+                is_new_group_environment=False,
+                cache_key=write_event_to_cache(event),
+                group_id=event.group_id,
+                project_id=self.project.id,
+                eventstream_type=EventStreamEventType.Error.value,
+            )
+
+        # Verify that the exception was not captured by Sentry since it's on_silent
+        assert len(capture_exception.mock_calls) == 0
+        assert safe_urlopen.called
+
+    @patch("sentry_sdk.capture_exception")
+    def test_ignores_http_error(self, capture_exception, safe_urlopen):
+        safe_urlopen.return_value = MockResponse502
+
+        event = self.store_event(data={}, project_id=self.project.id)
+        assert event.group is not None
+
+        # The task should complete without reporting to sentry when HTTPError is raised
+        # because it's in the on_silent list of the retry decorator
+        with self.tasks():
+            post_process_group(
+                is_new=True,
+                is_regression=False,
+                is_new_group_environment=False,
+                cache_key=write_event_to_cache(event),
+                group_id=event.group_id,
+                project_id=self.project.id,
+                eventstream_type=EventStreamEventType.Error.value,
+            )
+
+        # Verify that the exception was not captured by Sentry since it's on_silent
         assert len(capture_exception.mock_calls) == 0
         assert safe_urlopen.called
 


### PR DESCRIPTION
Went through the errors that can get raised from `send_and_save_webhook_request` and moved many of them to the `on_silent` retry category since they aren't actionable. i.e the error is usually the integrators giving us a 50X or timeout which we want to retry but not make a Sentry issue out of

Should address ... and more probably
- https://sentry.sentry.io/issues/6682733538/?query=is%3Aunresolved%20timesSeen%3A%3E10k%20assigned_or_suggested%3Amy_teams%20has%3Aevent_type&referrer=issue-stream&sort=freq
- https://sentry.sentry.io/issues/6672722749/?query=is%3Aunresolved%20timesSeen%3A%3E10k%20assigned_or_suggested%3Amy_teams%20has%3Aevent_type&referrer=issue-stream&sort=freq


resolves ECO-840
resolves ECO-841