### PR TITLE
fit(replay): Fix "select all" replay bulk selection

### DIFF
--- a/static/app/components/replays/table/replayTableColumns.tsx
+++ b/static/app/components/replays/table/replayTableColumns.tsx
@@ -422,7 +422,13 @@ export const ReplayPlayPauseColumn: ReplayTableColumn = {
 
 export const ReplaySelectColumn: ReplayTableColumn = {
   Header: ({
-    listItemCheckboxState: {isAllSelected, deselectAll, knownIds, toggleSelected},
+    listItemCheckboxState: {
+      deselectAll,
+      isAllSelected,
+      knownIds,
+      selectedIds,
+      toggleSelected,
+    },
     replays,
   }) => {
     const organization = useOrganization();
@@ -436,13 +442,17 @@ export const ReplaySelectColumn: ReplayTableColumn = {
           checked={isAllSelected}
           disabled={knownIds.length === 0}
           onChange={() => {
-            if (isAllSelected === true) {
+            // If the replay is archived, don't include it in the selection
+            const eligibleIds = knownIds.filter(
+              id => !replays.find(r => r.id === id)?.is_archived
+            );
+
+            if (isAllSelected === true || selectedIds.length === eligibleIds.length) {
               deselectAll();
             } else {
-              // If the replay is archived, don't include it in the selection
-              toggleSelected(
-                knownIds.filter(id => !replays.find(r => r.id === id)?.is_archived)
-              );
+              // Make everything visible selected
+              const unselectedIds = eligibleIds.filter(id => !selectedIds.includes(id));
+              toggleSelected(unselectedIds);
             }
           }}
         />


### PR DESCRIPTION
When a partial list of checkboxes is selected we want to be able to click the 'select all' button and have everything turn on. Previously everything was being toggled.
Then when everything is selected: clicking 'select all' will turn it all off.

Therefore, if you have part of the list selected you can double-click the 'select all' checkbox at the top to deselect everything.

Fixes REPLAY-532