### PR TITLE
ref(workflow_engine): Check model for prefetched data

### DIFF
--- a/src/sentry/workflow_engine/handlers/detector/base.py
+++ b/src/sentry/workflow_engine/handlers/detector/base.py
@@ -80,9 +80,19 @@ class DetectorHandler(abc.ABC, Generic[DataPacketType, DataPacketEvaluationType]
         self.detector = detector
         if detector.workflow_condition_group_id is not None:
             try:
-                group = DataConditionGroup.objects.get_from_cache(
-                    id=detector.workflow_condition_group_id
-                )
+                # Check if workflow_condition_group is already prefetched
+                if (
+                    hasattr(detector, "_prefetched_objects_cache")
+                    and "workflow_condition_group" in detector._prefetched_objects_cache
+                ):
+                    group = detector.workflow_condition_group
+                elif Detector.workflow_condition_group.is_cached(detector):
+                    group = detector.workflow_condition_group
+                else:
+                    group = DataConditionGroup.objects.get_from_cache(
+                        id=detector.workflow_condition_group_id
+                    )
+
                 self.condition_group: DataConditionGroup | None = group
             except DataConditionGroup.DoesNotExist:
                 logger.exception(

--- a/src/sentry/workflow_engine/handlers/detector/base.py
+++ b/src/sentry/workflow_engine/handlers/detector/base.py
@@ -75,6 +75,8 @@ class DetectorOccurrence:
         )
 
 
+# TODO - @saponifi3d - Change this class to be a pure ABC and remove the `__init__` method.
+# TODO - @saponifi3d - Once the change is made, we should introduce a `BaseDetector` class to evaluate simple cases
 class DetectorHandler(abc.ABC, Generic[DataPacketType, DataPacketEvaluationType]):
     def __init__(self, detector: Detector):
         self.detector = detector
@@ -85,8 +87,6 @@ class DetectorHandler(abc.ABC, Generic[DataPacketType, DataPacketEvaluationType]
                     hasattr(detector, "_prefetched_objects_cache")
                     and "workflow_condition_group" in detector._prefetched_objects_cache
                 ):
-                    group = detector.workflow_condition_group
-                elif Detector.workflow_condition_group.is_cached(detector):
                     group = detector.workflow_condition_group
                 else:
                     group = DataConditionGroup.objects.get_from_cache(

--- a/src/sentry/workflow_engine/processors/data_condition_group.py
+++ b/src/sentry/workflow_engine/processors/data_condition_group.py
@@ -174,7 +174,7 @@ def process_data_condition_group(
     if (
         hasattr(group, "_prefetched_objects_cache")
         and "conditions" in group._prefetched_objects_cache
-    ) or DataConditionGroup.conditions.is_cached(group):
+    ):
         conditions = group.conditions
     else:
         conditions = get_data_conditions_for_group(group.id)

--- a/src/sentry/workflow_engine/processors/data_condition_group.py
+++ b/src/sentry/workflow_engine/processors/data_condition_group.py
@@ -171,11 +171,12 @@ def process_data_condition_group(
         return invalid_group_result
 
     # Check if conditions are already prefetched before using cache
+    conditions: list[DataCondition] = []
     if (
         hasattr(group, "_prefetched_objects_cache")
         and "conditions" in group._prefetched_objects_cache
     ):
-        conditions = group.conditions
+        conditions = list(group.conditions.all())
     else:
         conditions = get_data_conditions_for_group(group.id)
 

--- a/src/sentry/workflow_engine/processors/data_condition_group.py
+++ b/src/sentry/workflow_engine/processors/data_condition_group.py
@@ -170,7 +170,14 @@ def process_data_condition_group(
         )
         return invalid_group_result
 
-    conditions = get_data_conditions_for_group(group.id)
+    # Check if conditions are already prefetched before using cache
+    if (
+        hasattr(group, "_prefetched_objects_cache")
+        and "conditions" in group._prefetched_objects_cache
+    ) or DataConditionGroup.conditions.is_cached(group):
+        conditions = group.conditions
+    else:
+        conditions = get_data_conditions_for_group(group.id)
 
     if is_fast:
         conditions, remaining_conditions = split_conditions_by_speed(conditions)


### PR DESCRIPTION
# Description
It was assumed that models wouldn't include all the nested models, so it would always fetch from the cache. After updating `process_data_sources` we can now check the model to see if the data exists before fetching from the cache and assume it _has_ all the nested models from `process_data_sources`

[Trace](https://sentry.sentry.io/explore/traces/trace/704c5a8afd7d4acd8e36cae2f84ed421/?aggregateField=%7B%22groupBy%22%3A%22%22%7D&aggregateField=%7B%22yAxes%22%3A%5B%22avg%28span.duration%29%22%5D%7D&environment=de&fov=0%2C203.051025390625&node=span-bdf219fda5d31f9e&project=1&query=span.op%3Aresult_processor.handle_result&source=traces&statsPeriod=1h&targetId=b56d4af1f66b3514&timestamp=1752706025) shows that this should save about ~50ms per execution