### PR TITLE
fix(profiling): handle android profiles optional AndroidMethod fields

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -84,7 +84,7 @@ typing-extensions>=4.9.0
 ua-parser>=0.10.0
 unidiff>=0.7.4
 urllib3[brotli]>=2.2.2
-vroomrs==0.1.13
+vroomrs==0.1.14
 pyuwsgi==2.0.28.post1
 zstandard>=0.18.0
 sentry-usage-accountant==0.0.10

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -241,7 +241,7 @@ uritemplate==4.1.1
 urllib3==2.2.2
 vine==5.1.0
 virtualenv==20.26.6
-vroomrs==0.1.13
+vroomrs==0.1.14
 wcwidth==0.2.13
 werkzeug==3.0.6
 wheel==0.38.4

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -152,7 +152,7 @@ unidiff==0.7.4
 uritemplate==4.1.1
 urllib3==2.2.2
 vine==5.1.0
-vroomrs==0.1.13
+vroomrs==0.1.14
 wcwidth==0.2.13
 xmlsec==1.3.14
 zstandard==0.18.0


### PR DESCRIPTION
This handle all those android profiles with missing fields in the `AndrtoidMethod` such as `source_file`, `signature`, etc.
