### PR TITLE
fix(dropdown): Remove z-index from a general Dropdown component

### DIFF
--- a/static/app/components/dropdownButton.tsx
+++ b/static/app/components/dropdownButton.tsx
@@ -76,7 +76,6 @@ interface StyledButtonProps
 const StyledButton = styled(Button)<StyledButtonProps>`
   position: relative;
   max-width: 100%;
-  z-index: 2;
 
   ${p =>
     (p.isOpen || p.disabled) &&


### PR DESCRIPTION
This conflicts with things on the page that assume the dropdown will just be placed normally. That 2` is a magic number doesn't help either.

The only problem is that it has been like this for 7 years :( and lots could be checked to see if its broken

--- 

I discovered this now because when a replay snippet on Issues>Replay is full-screen we show the breadcrumb list to the right side of it. When the replay snippet is finished playing we show an overlay with the name of the next replay:

<img width="327" height="203" alt="SCR-20250717-nieh" src="https://github.com/user-attachments/assets/14b5face-a2ca-4c14-8389-ec9275c507ba" />

While this is happening the dropdown in the top-right will pop on top of the overlay:

<img width="300" height="129" alt="SCR-20250717-nhma" src="https://github.com/user-attachments/assets/5c5faaaf-d946-4c01-b8df-ec0a244eca71" />

--- 

Test plan: 
I clicked around a bunch looking for problems and didn't find anything. through Explore, Insights, Crons and Uptime, Settings, and Dashboards.
I was looking for sticky scrolling, modals, and drawers that contain dropdowns as they're likely to deal with z-index issues. I didn't find any broken instances.