### PR TITLE
chore(fields): Break up EVENT_FIELD_DEFINITIONS

### DIFF
--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -140,6 +140,142 @@ export enum FieldKey {
   OTA_UPDATES_UPDATE_ID = 'ota_updates.update_id',
 }
 
+type SharedFieldKey =
+  | FieldKey.DIST
+  | FieldKey.ENVIRONMENT
+  | FieldKey.EVENT_TIMESTAMP
+  | FieldKey.HAS
+  | FieldKey.HTTP_METHOD
+  | FieldKey.HTTP_REFERER
+  | FieldKey.HTTP_STATUS_CODE
+  | FieldKey.HTTP_URL
+  | FieldKey.ID
+  | FieldKey.MESSAGE
+  | FieldKey.PLATFORM
+  | FieldKey.PLATFORM_NAME
+  | FieldKey.PROFILE_ID
+  | FieldKey.PROJECT
+  | FieldKey.REPLAY_ID
+  | FieldKey.TIMESTAMP
+  | FieldKey.TITLE
+  | FieldKey.TRACE
+  | FieldKey.TRACE_PARENT_SPAN
+  | FieldKey.TRACE_SPAN
+  | FieldKey.TRANSACTION
+  | FieldKey.APP_IN_FOREGROUND;
+
+type ErrorFieldKey =
+  | FieldKey.AGE
+  | FieldKey.ASSIGNED
+  | FieldKey.ASSIGNED_OR_SUGGESTED
+  | FieldKey.BOOKMARKS
+  | FieldKey.CULPRIT
+  | FieldKey.ERROR_HANDLED
+  | FieldKey.ERROR_MECHANISM
+  | FieldKey.ERROR_TYPE
+  | FieldKey.ERROR_UNHANDLED
+  | FieldKey.ERROR_VALUE
+  | FieldKey.ERROR_RECEIVED
+  | FieldKey.ERROR_MAIN_THREAD
+  | FieldKey.EVENT_TYPE
+  | FieldKey.FIRST_RELEASE
+  | FieldKey.FIRST_SEEN
+  | FieldKey.IS
+  | FieldKey.ISSUE
+  | FieldKey.ISSUE_CATEGORY
+  | FieldKey.ISSUE_PRIORITY
+  | FieldKey.ISSUE_SEER_ACTIONABILITY
+  | FieldKey.ISSUE_SEER_LAST_RUN
+  | FieldKey.ISSUE_TYPE
+  | FieldKey.LAST_SEEN
+  | FieldKey.LEVEL
+  | FieldKey.LOCATION
+  | FieldKey.STACK_ABS_PATH
+  | FieldKey.STACK_COLNO
+  | FieldKey.STACK_FILENAME
+  | FieldKey.STACK_FUNCTION
+  | FieldKey.STACK_IN_APP
+  | FieldKey.STACK_LINENO
+  | FieldKey.STACK_MODULE
+  | FieldKey.STACK_PACKAGE
+  | FieldKey.STACK_RESOURCE
+  | FieldKey.STACK_STACK_LEVEL
+  | FieldKey.STATUS
+  | FieldKey.SYMBOLICATED_IN_APP
+  | FieldKey.TIMES_SEEN
+  | FieldKey.TYPE
+  | FieldKey.UNREAL_CRASH_TYPE;
+
+type BrowserFieldKey = FieldKey.BROWSER_NAME;
+
+type DeviceFieldKey =
+  | FieldKey.DEVICE
+  | FieldKey.DEVICE_ARCH
+  | FieldKey.DEVICE_BATTERY_LEVEL
+  | FieldKey.DEVICE_BRAND
+  | FieldKey.DEVICE_CHARGING
+  | FieldKey.DEVICE_CLASS
+  | FieldKey.DEVICE_FAMILY
+  | FieldKey.DEVICE_LOCALE
+  | FieldKey.DEVICE_MODEL_ID
+  | FieldKey.DEVICE_NAME
+  | FieldKey.DEVICE_ONLINE
+  | FieldKey.DEVICE_ORIENTATION
+  | FieldKey.DEVICE_SCREEN_DENSITY
+  | FieldKey.DEVICE_SCREEN_DPI
+  | FieldKey.DEVICE_SCREEN_HEIGHT_PIXELS
+  | FieldKey.DEVICE_SCREEN_WIDTH_PIXELS
+  | FieldKey.DEVICE_SIMULATOR
+  | FieldKey.DEVICE_UUID;
+
+type GeoFieldKey =
+  | FieldKey.GEO_CITY
+  | FieldKey.GEO_COUNTRY_CODE
+  | FieldKey.GEO_REGION
+  | FieldKey.GEO_SUBDIVISION;
+
+type OsFieldKey =
+  | FieldKey.OS
+  | FieldKey.OS_BUILD
+  | FieldKey.OS_KERNEL_VERSION
+  | FieldKey.OS_NAME
+  | FieldKey.OS_DISTRIBUTION_NAME
+  | FieldKey.OS_DISTRIBUTION_VERSION;
+
+type ReleaseFieldKey =
+  | FieldKey.RELEASE
+  | FieldKey.RELEASE_BUILD
+  | FieldKey.RELEASE_PACKAGE
+  | FieldKey.RELEASE_STAGE
+  | FieldKey.RELEASE_VERSION;
+
+type SDKFieldKey = FieldKey.SDK_NAME | FieldKey.SDK_VERSION;
+
+type TransactionFieldKey =
+  | FieldKey.TIMESTAMP_TO_DAY
+  | FieldKey.TIMESTAMP_TO_HOUR
+  | FieldKey.TOTAL_COUNT
+  | FieldKey.TRACE_CLIENT_SAMPLE_RATE
+  | FieldKey.TRANSACTION_DURATION
+  | FieldKey.TRANSACTION_OP
+  | FieldKey.TRANSACTION_STATUS;
+
+type UserFieldKey =
+  | FieldKey.USER
+  | FieldKey.USER_DISPLAY
+  | FieldKey.USER_EMAIL
+  | FieldKey.USER_ID
+  | FieldKey.USER_IP
+  | FieldKey.USER_USERNAME
+  | FieldKey.USER_SEGMENT;
+
+type ProfileFieldKey = FieldKey.FUNCTION_DURATION;
+
+type OTAFieldKey =
+  | FieldKey.OTA_UPDATES_CHANNEL
+  | FieldKey.OTA_UPDATES_RUNTIME_VERSION
+  | FieldKey.OTA_UPDATES_UPDATE_ID;
+
 export enum FieldValueType {
   BOOLEAN = 'boolean',
   DATE = 'date',
@@ -1284,18 +1420,119 @@ const TRACE_FIELD_DEFINITIONS: Record<TraceFields, FieldDefinition> = {
   },
 };
 
-type AllEventFieldKeys =
-  | keyof typeof AGGREGATION_FIELDS
-  | keyof typeof MEASUREMENT_FIELDS
-  | keyof typeof SPAN_OP_FIELDS
-  | keyof typeof TRACE_FIELD_DEFINITIONS
-  | FieldKey;
+const SHARED_FIELD_KEY: Record<SharedFieldKey, FieldDefinition> = {
+  [FieldKey.DIST]: {
+    desc: t(
+      'Distinguishes between build or deployment variants of the same release of an application.'
+    ),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  [FieldKey.ENVIRONMENT]: {
+    desc: t('The environment the event was seen in'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  [FieldKey.EVENT_TIMESTAMP]: {
+    desc: t('Date and time of the event'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.DATE,
+  },
+  [FieldKey.HTTP_METHOD]: {
+    desc: t('Method of the request that created the event'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  [FieldKey.HTTP_REFERER]: {
+    desc: t('The web page the resource was requested from'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  [FieldKey.HTTP_STATUS_CODE]: {
+    desc: t('Type of response (i.e., 200, 404)'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  [FieldKey.HTTP_URL]: {
+    desc: t('Full URL of the request without parameters'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  [FieldKey.ID]: {
+    desc: t('The event identification number'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  [FieldKey.MESSAGE]: {
+    desc: t('Error message or transaction name'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  [FieldKey.PLATFORM]: {
+    desc: t('Name of the platform'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  [FieldKey.PLATFORM_NAME]: {
+    desc: t('Name of the platform'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  [FieldKey.PROFILE_ID]: {
+    desc: t('The ID of an associated profile'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  [FieldKey.PROJECT]: {kind: FieldKind.FIELD, valueType: FieldValueType.STRING},
+  [FieldKey.HAS]: {
+    desc: t('Determines if a tag or field exists in an event'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+    allowWildcard: false,
+  },
+  [FieldKey.REPLAY_ID]: {
+    desc: t('The ID of an associated Session Replay'),
+    kind: FieldKind.TAG,
+    valueType: FieldValueType.STRING,
+  },
+  [FieldKey.TIMESTAMP]: {
+    desc: t('The time an event finishes'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.DATE,
+  },
+  [FieldKey.TITLE]: {
+    desc: t('Error or transaction name identifier'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  [FieldKey.TRACE]: {
+    desc: t('The trace identification number'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  [FieldKey.TRACE_PARENT_SPAN]: {
+    desc: t('Span identification number of the parent to the event'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  [FieldKey.TRACE_SPAN]: {
+    desc: t('Span identification number of the root span'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  [FieldKey.TRANSACTION]: {
+    desc: t('Error or transaction name identifier'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  [FieldKey.APP_IN_FOREGROUND]: {
+    desc: t('Indicates if the app is in the foreground or background'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.BOOLEAN,
+  },
+};
 
-const EVENT_FIELD_DEFINITIONS: Record<AllEventFieldKeys, FieldDefinition> = {
-  ...AGGREGATION_FIELDS,
-  ...MEASUREMENT_FIELDS,
-  ...SPAN_OP_FIELDS,
-  ...TRACE_FIELD_DEFINITIONS,
+const ERROR_FIELD_DEFINITION: Record<ErrorFieldKey, FieldDefinition> = {
   [FieldKey.AGE]: {
     desc: t('The age of the issue in relative time'),
     kind: FieldKind.FIELD,
@@ -1313,22 +1550,212 @@ const EVENT_FIELD_DEFINITIONS: Record<AllEventFieldKeys, FieldDefinition> = {
     valueType: FieldValueType.STRING,
     allowWildcard: false,
   },
-  [FieldKey.CULPRIT]: {
-    deprecated: true,
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.STRING,
-  },
   [FieldKey.BOOKMARKS]: {
     desc: t('The issues bookmarked by a user ID'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
     allowWildcard: false,
   },
+  [FieldKey.CULPRIT]: {
+    deprecated: true,
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  [FieldKey.ERROR_HANDLED]: {
+    desc: t('Determines handling status of the error'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.BOOLEAN,
+  },
+  [FieldKey.ERROR_MECHANISM]: {
+    desc: t('The mechanism that created the error'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  [FieldKey.ERROR_TYPE]: {
+    desc: t('The type of exception'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  [FieldKey.ERROR_UNHANDLED]: {
+    desc: t('Determines unhandling status of the error'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.BOOLEAN,
+  },
+  [FieldKey.ERROR_VALUE]: {
+    desc: t('Original value that exhibits error'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  [FieldKey.ERROR_RECEIVED]: {
+    desc: t('The datetime that the error was received'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.DATE,
+  },
+  [FieldKey.ERROR_MAIN_THREAD]: {
+    desc: t('Indicates if the error occurred on the main thread'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.BOOLEAN,
+  },
+  [FieldKey.EVENT_TYPE]: {
+    desc: t('Type of event (Errors, transactions, csp and default)'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  [FieldKey.FIRST_RELEASE]: {
+    desc: t('Issues first seen in a given release'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  [FieldKey.FIRST_SEEN]: {
+    desc: t('Issues first seen at a given time'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.DATE,
+  },
+  [FieldKey.IS]: {
+    desc: t('The properties of an issue (i.e. Resolved, unresolved)'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+    defaultValue: 'unresolved',
+    allowWildcard: false,
+  },
+  [FieldKey.ISSUE]: {
+    desc: t('The issue identification short code'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+    allowWildcard: false,
+  },
+  [FieldKey.ISSUE_CATEGORY]: {
+    desc: t('Category of issue (error or performance)'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+    allowWildcard: false,
+  },
+  [FieldKey.ISSUE_PRIORITY]: {
+    desc: t('The priority of the issue'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+    allowWildcard: false,
+  },
+  [FieldKey.ISSUE_SEER_ACTIONABILITY]: {
+    desc: t('How easily you can fix the issue with a code change, estimated by Seer'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+    allowWildcard: false,
+  },
+  [FieldKey.ISSUE_SEER_LAST_RUN]: {
+    desc: t('The last time Seer attempted to auto-fix the issue'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.DATE,
+    allowWildcard: false,
+  },
+  [FieldKey.ISSUE_TYPE]: {
+    desc: t('Type of problem the issue represents (i.e. N+1 Query)'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+    allowWildcard: false,
+  },
+  [FieldKey.LAST_SEEN]: {
+    desc: t('Issues last seen at a given time'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.DATE,
+  },
+  [FieldKey.LEVEL]: {
+    kind: FieldKind.FIELD,
+    desc: t('Severity of the event (i.e., fatal, error, warning)'),
+    valueType: FieldValueType.STRING,
+  },
+  [FieldKey.LOCATION]: {
+    desc: t('Location of error'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  [FieldKey.STACK_ABS_PATH]: {
+    desc: t('Absolute path to the source file'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  [FieldKey.STACK_COLNO]: {
+    desc: t('Column number of the call starting at 1'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.NUMBER,
+  },
+  [FieldKey.STACK_FILENAME]: {
+    desc: t('Relative path to the source file from the root directory'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  [FieldKey.STACK_FUNCTION]: {
+    desc: t('Name of function being called'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  [FieldKey.STACK_IN_APP]: {
+    desc: t('Indicates if frame is related to relevant code in stack trace'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.BOOLEAN,
+  },
+  [FieldKey.STACK_LINENO]: {
+    desc: t('Line number of the call starting at 1'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.NUMBER,
+  },
+  [FieldKey.STACK_MODULE]: {
+    desc: t('Platform specific module path'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  [FieldKey.STACK_PACKAGE]: {
+    desc: t('The package the frame is from'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  [FieldKey.STACK_RESOURCE]: {
+    desc: t('The package the frame is from'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  [FieldKey.STACK_STACK_LEVEL]: {
+    desc: t('Number of frames per stacktrace'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.NUMBER,
+  },
+  [FieldKey.SYMBOLICATED_IN_APP]: {
+    desc: t('Indicates if all in-app frames are symbolicated'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.BOOLEAN,
+  },
+  [FieldKey.STATUS]: {
+    desc: t('Status of the issue'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  [FieldKey.TIMES_SEEN]: {
+    desc: t('Total number of events'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.NUMBER,
+    keywords: ['count'],
+  },
+  [FieldKey.TYPE]: {
+    desc: t('Type of event (Errors, transactions, csp and default)'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  [FieldKey.UNREAL_CRASH_TYPE]: {
+    desc: t('Crash type of an Unreal event'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+};
+
+const BROWSER_FIELD_DEFINITION: Record<BrowserFieldKey, FieldDefinition> = {
   [FieldKey.BROWSER_NAME]: {
     desc: t('Name of the browser'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },
+};
+
+const DEVICE_FIELD_DEFINITION: Record<DeviceFieldKey, FieldDefinition> = {
   [FieldKey.DEVICE]: {
     desc: t('The device that the event was seen on'),
     kind: FieldKind.FIELD,
@@ -1419,63 +1846,9 @@ const EVENT_FIELD_DEFINITIONS: Record<AllEventFieldKeys, FieldDefinition> = {
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },
-  [FieldKey.DIST]: {
-    desc: t(
-      'Distinguishes between build or deployment variants of the same release of an application.'
-    ),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.STRING,
-  },
-  [FieldKey.ENVIRONMENT]: {
-    desc: t('The environment the event was seen in'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.STRING,
-  },
-  [FieldKey.ERROR_HANDLED]: {
-    desc: t('Determines handling status of the error'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.BOOLEAN,
-  },
-  [FieldKey.ERROR_MECHANISM]: {
-    desc: t('The mechanism that created the error'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.STRING,
-  },
-  [FieldKey.ERROR_TYPE]: {
-    desc: t('The type of exception'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.STRING,
-  },
-  [FieldKey.ERROR_UNHANDLED]: {
-    desc: t('Determines unhandling status of the error'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.BOOLEAN,
-  },
-  [FieldKey.ERROR_VALUE]: {
-    desc: t('Original value that exhibits error'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.STRING,
-  },
-  [FieldKey.ERROR_RECEIVED]: {
-    desc: t('The datetime that the error was received'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.DATE,
-  },
-  [FieldKey.ERROR_MAIN_THREAD]: {
-    desc: t('Indicates if the error occurred on the main thread'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.BOOLEAN,
-  },
-  [FieldKey.EVENT_TIMESTAMP]: {
-    desc: t('Date and time of the event'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.DATE,
-  },
-  [FieldKey.EVENT_TYPE]: {
-    desc: t('Type of event (Errors, transactions, csp and default)'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.STRING,
-  },
+};
+
+const GEO_FIELD_DEFINITIONS: Record<GeoFieldKey, FieldDefinition> = {
   [FieldKey.GEO_CITY]: {
     desc: t('Full name of the city'),
     kind: FieldKind.FIELD,
@@ -1496,94 +1869,9 @@ const EVENT_FIELD_DEFINITIONS: Record<AllEventFieldKeys, FieldDefinition> = {
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },
-  [FieldKey.HTTP_METHOD]: {
-    desc: t('Method of the request that created the event'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.STRING,
-  },
-  [FieldKey.HTTP_REFERER]: {
-    desc: t('The web page the resource was requested from'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.STRING,
-  },
-  [FieldKey.HTTP_STATUS_CODE]: {
-    desc: t('Type of response (i.e., 200, 404)'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.STRING,
-  },
-  [FieldKey.HTTP_URL]: {
-    desc: t('Full URL of the request without parameters'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.STRING,
-  },
-  [FieldKey.ID]: {
-    desc: t('The event identification number'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.STRING,
-  },
-  [FieldKey.IS]: {
-    desc: t('The properties of an issue (i.e. Resolved, unresolved)'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.STRING,
-    defaultValue: 'unresolved',
-    allowWildcard: false,
-  },
-  [FieldKey.ISSUE]: {
-    desc: t('The issue identification short code'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.STRING,
-    allowWildcard: false,
-  },
-  [FieldKey.ISSUE_CATEGORY]: {
-    desc: t('Category of issue (error or performance)'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.STRING,
-    allowWildcard: false,
-  },
-  [FieldKey.ISSUE_PRIORITY]: {
-    desc: t('The priority of the issue'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.STRING,
-    allowWildcard: false,
-  },
-  [FieldKey.ISSUE_SEER_ACTIONABILITY]: {
-    desc: t('How easily you can fix the issue with a code change, estimated by Seer'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.STRING,
-    allowWildcard: false,
-  },
-  [FieldKey.ISSUE_SEER_LAST_RUN]: {
-    desc: t('The last time Seer attempted to auto-fix the issue'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.DATE,
-    allowWildcard: false,
-  },
-  [FieldKey.ISSUE_TYPE]: {
-    desc: t('Type of problem the issue represents (i.e. N+1 Query)'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.STRING,
-    allowWildcard: false,
-  },
-  [FieldKey.LAST_SEEN]: {
-    desc: t('Issues last seen at a given time'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.DATE,
-  },
-  [FieldKey.LEVEL]: {
-    kind: FieldKind.FIELD,
-    desc: t('Severity of the event (i.e., fatal, error, warning)'),
-    valueType: FieldValueType.STRING,
-  },
-  [FieldKey.LOCATION]: {
-    desc: t('Location of error'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.STRING,
-  },
-  [FieldKey.MESSAGE]: {
-    desc: t('Error message or transaction name'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.STRING,
-  },
+};
+
+const OS_FIELD_DEFINITIONS: Record<OsFieldKey, FieldDefinition> = {
   [FieldKey.OS]: {
     desc: t('Build and kernel version'),
     kind: FieldKind.FIELD,
@@ -1591,11 +1879,6 @@ const EVENT_FIELD_DEFINITIONS: Record<AllEventFieldKeys, FieldDefinition> = {
   },
   [FieldKey.OS_BUILD]: {
     desc: t('Name of the build'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.STRING,
-  },
-  [FieldKey.OS_KERNEL_VERSION]: {
-    desc: t('Version number'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },
@@ -1609,43 +1892,19 @@ const EVENT_FIELD_DEFINITIONS: Record<AllEventFieldKeys, FieldDefinition> = {
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },
-  [FieldKey.PLATFORM]: {
-    desc: t('Name of the platform'),
+  [FieldKey.OS_KERNEL_VERSION]: {
+    desc: t('Version number'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
-  },
-  [FieldKey.PLATFORM_NAME]: {
-    desc: t('Name of the platform'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.STRING,
-  },
-  [FieldKey.PROFILE_ID]: {
-    desc: t('The ID of an associated profile'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.STRING,
-  },
-  [FieldKey.PROJECT]: {kind: FieldKind.FIELD, valueType: FieldValueType.STRING},
-  [FieldKey.FIRST_RELEASE]: {
-    desc: t('Issues first seen in a given release'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.STRING,
-  },
-  [FieldKey.FIRST_SEEN]: {
-    desc: t('Issues first seen at a given time'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.DATE,
-  },
-  [FieldKey.HAS]: {
-    desc: t('Determines if a tag or field exists in an event'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.STRING,
-    allowWildcard: false,
   },
   [FieldKey.OS_NAME]: {
     desc: t('Name of the Operating System'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },
+};
+
+const RELEASE_FIELD_DEFINITION: Record<ReleaseFieldKey, FieldDefinition> = {
   [FieldKey.RELEASE]: {
     desc: t('The version of your code deployed to an environment'),
     kind: FieldKind.FIELD,
@@ -1675,11 +1934,9 @@ const EVENT_FIELD_DEFINITIONS: Record<AllEventFieldKeys, FieldDefinition> = {
     valueType: FieldValueType.STRING,
     allowComparisonOperators: true,
   },
-  [FieldKey.REPLAY_ID]: {
-    desc: t('The ID of an associated Session Replay'),
-    kind: FieldKind.TAG,
-    valueType: FieldValueType.STRING,
-  },
+};
+
+const SDK_FIELD_DEFINITIONS: Record<SDKFieldKey, FieldDefinition> = {
   [FieldKey.SDK_NAME]: {
     desc: t('Name of the platform that sent the event'),
     kind: FieldKind.FIELD,
@@ -1690,77 +1947,9 @@ const EVENT_FIELD_DEFINITIONS: Record<AllEventFieldKeys, FieldDefinition> = {
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },
-  [FieldKey.STACK_ABS_PATH]: {
-    desc: t('Absolute path to the source file'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.STRING,
-  },
-  [FieldKey.STACK_COLNO]: {
-    desc: t('Column number of the call starting at 1'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.NUMBER,
-  },
-  [FieldKey.STACK_FILENAME]: {
-    desc: t('Relative path to the source file from the root directory'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.STRING,
-  },
-  [FieldKey.STACK_FUNCTION]: {
-    desc: t('Name of function being called'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.STRING,
-  },
-  [FieldKey.STACK_IN_APP]: {
-    desc: t('Indicates if frame is related to relevant code in stack trace'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.BOOLEAN,
-  },
-  [FieldKey.STACK_LINENO]: {
-    desc: t('Line number of the call starting at 1'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.NUMBER,
-  },
-  [FieldKey.STACK_MODULE]: {
-    desc: t('Platform specific module path'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.STRING,
-  },
-  [FieldKey.STACK_PACKAGE]: {
-    desc: t('The package the frame is from'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.STRING,
-  },
-  [FieldKey.STACK_RESOURCE]: {
-    desc: t('The package the frame is from'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.STRING,
-  },
-  [FieldKey.STACK_STACK_LEVEL]: {
-    desc: t('Number of frames per stacktrace'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.NUMBER,
-  },
-  [FieldKey.SYMBOLICATED_IN_APP]: {
-    desc: t('Indicates if all in-app frames are symbolicated'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.BOOLEAN,
-  },
-  [FieldKey.STATUS]: {
-    desc: t('Status of the issue'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.STRING,
-  },
-  [FieldKey.TIMES_SEEN]: {
-    desc: t('Total number of events'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.NUMBER,
-    keywords: ['count'],
-  },
-  [FieldKey.TIMESTAMP]: {
-    desc: t('The time an event finishes'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.DATE,
-  },
+};
+
+const TRANSACTION_FIELD_DEFINITIONS: Record<TransactionFieldKey, FieldDefinition> = {
   [FieldKey.TIMESTAMP_TO_HOUR]: {
     desc: t('Rounded down to the nearest hour'),
     kind: FieldKind.FIELD,
@@ -1771,43 +1960,13 @@ const EVENT_FIELD_DEFINITIONS: Record<AllEventFieldKeys, FieldDefinition> = {
     kind: FieldKind.FIELD,
     valueType: FieldValueType.DATE,
   },
-  [FieldKey.TITLE]: {
-    desc: t('Error or transaction name identifier'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.STRING,
-  },
-  [FieldKey.TRACE]: {
-    desc: t('The trace identification number'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.STRING,
-  },
   [FieldKey.TOTAL_COUNT]: {
     desc: t('The total number of events for the current query'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.NUMBER,
   },
-  [FieldKey.TRACE_PARENT_SPAN]: {
-    desc: t('Span identification number of the parent to the event'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.STRING,
-  },
-  [FieldKey.TRACE_SPAN]: {
-    desc: t('Span identification number of the root span'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.STRING,
-  },
   [FieldKey.TRACE_CLIENT_SAMPLE_RATE]: {
     desc: t('Sample rate of the trace in the SDK between 0 and 1'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.STRING,
-  },
-  [FieldKey.TRANSACTION]: {
-    desc: t('Error or transaction name identifier'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.STRING,
-  },
-  [FieldKey.TRANSACTION_OP]: {
-    desc: t('Short code identifying the type of operation the span is measuring'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },
@@ -1816,21 +1975,19 @@ const EVENT_FIELD_DEFINITIONS: Record<AllEventFieldKeys, FieldDefinition> = {
     kind: FieldKind.FIELD,
     valueType: FieldValueType.DURATION,
   },
+  [FieldKey.TRANSACTION_OP]: {
+    desc: t('Short code identifying the type of operation the span is measuring'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
   [FieldKey.TRANSACTION_STATUS]: {
     desc: t('Describes the status of the span/transaction'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },
-  [FieldKey.TYPE]: {
-    desc: t('Type of event (Errors, transactions, csp and default)'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.STRING,
-  },
-  [FieldKey.UNREAL_CRASH_TYPE]: {
-    desc: t('Crash type of an Unreal event'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.STRING,
-  },
+};
+
+const USER_FIELD_DEFINITIONS: Record<UserFieldKey, FieldDefinition> = {
   [FieldKey.USER]: {
     desc: t('User identification value'),
     kind: FieldKind.FIELD,
@@ -1866,16 +2023,17 @@ const EVENT_FIELD_DEFINITIONS: Record<AllEventFieldKeys, FieldDefinition> = {
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },
-  [FieldKey.APP_IN_FOREGROUND]: {
-    desc: t('Indicates if the app is in the foreground or background'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.BOOLEAN,
-  },
+};
+
+const PROFILE_FIELD_DEFINITIONS: Record<ProfileFieldKey, FieldDefinition> = {
   [FieldKey.FUNCTION_DURATION]: {
     desc: t('Duration of the function'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.DURATION,
   },
+};
+
+const OTA_FIELD_DEFINITIONS: Record<OTAFieldKey, FieldDefinition> = {
   [FieldKey.OTA_UPDATES_CHANNEL]: {
     desc: t('The channel name of the build from EAS Update'),
     kind: FieldKind.FIELD,
@@ -1891,6 +2049,32 @@ const EVENT_FIELD_DEFINITIONS: Record<AllEventFieldKeys, FieldDefinition> = {
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },
+};
+
+type AllEventFieldKeys =
+  | keyof typeof AGGREGATION_FIELDS
+  | keyof typeof MEASUREMENT_FIELDS
+  | keyof typeof SPAN_OP_FIELDS
+  | keyof typeof TRACE_FIELD_DEFINITIONS
+  | FieldKey;
+
+const EVENT_FIELD_DEFINITIONS: Record<AllEventFieldKeys, FieldDefinition> = {
+  ...AGGREGATION_FIELDS,
+  ...MEASUREMENT_FIELDS,
+  ...SPAN_OP_FIELDS,
+  ...TRACE_FIELD_DEFINITIONS,
+  ...SHARED_FIELD_KEY,
+  ...ERROR_FIELD_DEFINITION,
+  ...BROWSER_FIELD_DEFINITION,
+  ...DEVICE_FIELD_DEFINITION,
+  ...GEO_FIELD_DEFINITIONS,
+  ...OS_FIELD_DEFINITIONS,
+  ...RELEASE_FIELD_DEFINITION,
+  ...SDK_FIELD_DEFINITIONS,
+  ...TRANSACTION_FIELD_DEFINITIONS,
+  ...USER_FIELD_DEFINITIONS,
+  ...PROFILE_FIELD_DEFINITIONS,
+  ...OTA_FIELD_DEFINITIONS,
 };
 
 const SPAN_HTTP_FIELD_DEFINITIONS: Record<SpanHttpField, FieldDefinition> = {


### PR DESCRIPTION
`EVENT_FIELD_DEFINITIONS` contain a lot of definitions for various fields. It actually contains definitions for fields on different event types. Because of this, the definitions are bleeding into other datasets. For example, in the search bar in explore, if the user tries to use the key `status`, it pulls in the definition of the status field in errors mistakenly.

To remedy this, this PR starts by breaking `EVENT_FIELD_DEFINITIONS` into smaller logical groups of field definitions. And I'll follow up by properly assigning the right fields to the right event types.