### PR TITLE
feat(groupowner): Add SuspectCommitStrategy to distinguish detection flows

### DIFF
--- a/src/sentry/models/groupowner.py
+++ b/src/sentry/models/groupowner.py
@@ -72,6 +72,8 @@ class GroupOwnerManager(BaseManager["GroupOwner"]):
         use lookup_kwargs to perform the .get()
         if found: update the object with defaults and the context with context_defaults
         if not found: create the object with the values in lookup_kwargs, defaults, and context_defaults
+
+        Note: lookup_kwargs is modified if the GroupOwner is created, do not reuse it for other purposes!
         """
         try:
             group_owner = GroupOwner.objects.get(**lookup_kwargs)

--- a/src/sentry/models/groupowner.py
+++ b/src/sentry/models/groupowner.py
@@ -4,7 +4,7 @@ import itertools
 from collections import defaultdict
 from collections.abc import Sequence
 from datetime import datetime, timedelta
-from enum import Enum
+from enum import Enum, StrEnum
 from typing import Any, TypedDict
 
 from django.conf import settings
@@ -48,9 +48,9 @@ GROUP_OWNER_TYPE = {
 }
 
 
-class SuspectCommitStrategy(Enum):
-    LEGACY = 0
-    CURRENT = 1
+class SuspectCommitStrategy(StrEnum):
+    RELEASE_BASED = "release_based"  # legacy strategy, used as fallback if scm_based fails
+    SCM_BASED = "scm_based"
 
 
 class OwnersSerialized(TypedDict):

--- a/src/sentry/models/groupowner.py
+++ b/src/sentry/models/groupowner.py
@@ -48,6 +48,11 @@ GROUP_OWNER_TYPE = {
 }
 
 
+class SuspectCommitStrategy(Enum):
+    LEGACY = 0
+    CURRENT = 1
+
+
 class OwnersSerialized(TypedDict):
     type: str
     owner: str

--- a/src/sentry/models/groupowner.py
+++ b/src/sentry/models/groupowner.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from collections.abc import Sequence
 from datetime import datetime, timedelta
 from enum import Enum, StrEnum
-from typing import Any, TypedDict
+from typing import Any, ClassVar, TypedDict
 
 from django.conf import settings
 from django.db import models
@@ -19,6 +19,7 @@ from sentry.backup.scopes import RelocationScope
 from sentry.db.models import FlexibleForeignKey, Model, region_silo_model
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
 from sentry.db.models.fields.jsonfield import JSONField
+from sentry.db.models.manager.base import BaseManager
 from sentry.models.group import Group
 from sentry.utils.cache import cache
 
@@ -59,6 +60,46 @@ class OwnersSerialized(TypedDict):
     date_added: datetime
 
 
+class GroupOwnerManager(BaseManager["GroupOwner"]):
+    def update_or_create_and_preserve_context(
+        self, lookup_kwargs: dict, defaults: dict, context_defaults: dict
+    ) -> tuple[GroupOwner, bool]:
+        """
+        update_or_create doesn't have great support for json fields like context.
+        To preserve the existing content and update only the keys we specify,
+        we have to handle the operation this way.
+
+        use lookup_kwargs to perform the .get()
+        if found: update the object with defaults and the context with context_defaults
+        if not found: create the object with the values in lookup_kwargs, defaults, and context_defaults
+        """
+        try:
+            group_owner = GroupOwner.objects.get(**lookup_kwargs)
+
+            for k, v in defaults.items():
+                setattr(group_owner, k, v)
+
+            existing_context = group_owner.context or {}
+            existing_context.update(context_defaults)
+            group_owner.context = existing_context
+
+            group_owner.save()
+            created = False
+        except GroupOwner.DoesNotExist:
+            # modify lookup_kwargs so they can be used to create the GroupOwner
+            keys_to_delete = [k for k in lookup_kwargs.keys() if "__" in k]
+            for k in keys_to_delete:
+                del lookup_kwargs[k]
+
+            lookup_kwargs.update(defaults)
+            lookup_kwargs["context"] = context_defaults
+
+            group_owner = GroupOwner.objects.create(**lookup_kwargs)
+            created = True
+
+        return group_owner, created
+
+
 @region_silo_model
 class GroupOwner(Model):
     """
@@ -81,6 +122,8 @@ class GroupOwner(Model):
     user_id = HybridCloudForeignKey(settings.AUTH_USER_MODEL, on_delete="CASCADE", null=True)
     team = FlexibleForeignKey("sentry.Team", null=True)
     date_added = models.DateTimeField(default=timezone.now)
+
+    objects: ClassVar[GroupOwnerManager] = GroupOwnerManager()
 
     class Meta:
         app_label = "sentry"

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3441,3 +3441,11 @@ register(
     default=True,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+# Enables saving the suspectCommitStrategy on GroupOwner
+register(
+    "issues.suspect-commit-strategy",
+    type=Bool,
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)

--- a/src/sentry/tasks/commit_context.py
+++ b/src/sentry/tasks/commit_context.py
@@ -25,7 +25,7 @@ from sentry.issues.auto_source_code_config.code_mapping import get_sorted_code_m
 from sentry.locks import locks
 from sentry.models.commit import Commit
 from sentry.models.commitauthor import CommitAuthor
-from sentry.models.groupowner import GroupOwner, GroupOwnerType
+from sentry.models.groupowner import GroupOwner, GroupOwnerType, SuspectCommitStrategy
 from sentry.models.project import Project
 from sentry.models.projectownership import ProjectOwnership
 from sentry.shared_integrations.exceptions import ApiError
@@ -191,8 +191,12 @@ def process_commit_context(
                 organization_id=project.organization_id,
                 context={"commitId": commit.id},
                 defaults={
-                    "date_added": django_timezone.now()
-                },  # Updates date of an existing owner, since we just matched them with this new event
+                    "date_added": django_timezone.now(),
+                    "context": {
+                        "commitId": commit.id,
+                        "suspectCommitStrategy": SuspectCommitStrategy.CURRENT.value,
+                    },
+                },
             )
 
             if installation and isinstance(installation, CommitContextIntegration):

--- a/src/sentry/tasks/commit_context.py
+++ b/src/sentry/tasks/commit_context.py
@@ -10,7 +10,7 @@ from celery.exceptions import MaxRetriesExceededError
 from django.utils import timezone as django_timezone
 from sentry_sdk import set_tag
 
-from sentry import analytics
+from sentry import analytics, options
 from sentry.analytics.events.groupowner_assignment import GroupOwnerAssignment
 from sentry.analytics.events.integration_commit_context_all_frames import (
     IntegrationsFailedToFetchCommitContextAllFrames,
@@ -183,23 +183,34 @@ def process_commit_context(
             author_to_user = get_users_for_authors(commit.organization_id, authors)
             user_dct: Mapping[str, Any] = author_to_user.get(str(commit.author_id), {})
 
-            group_owner, created = GroupOwner.objects.update_or_create_and_preserve_context(
-                lookup_kwargs={
-                    "group_id": group_id,
-                    "type": GroupOwnerType.SUSPECT_COMMIT.value,
-                    "user_id": user_dct.get("id"),
-                    "project_id": project.id,
-                    "organization_id": project.organization_id,
-                    "context__contains": f'"commitId":{commit.id}',
-                },
-                defaults={
-                    "date_added": django_timezone.now(),
-                },
-                context_defaults={
-                    "commitId": commit.id,
-                    "suspectCommitStrategy": SuspectCommitStrategy.SCM_BASED.value,
-                },
-            )
+            if options.get("issues.suspect-commit-strategy"):
+                group_owner, created = GroupOwner.objects.update_or_create_and_preserve_context(
+                    lookup_kwargs={
+                        "group_id": group_id,
+                        "type": GroupOwnerType.SUSPECT_COMMIT.value,
+                        "user_id": user_dct.get("id"),
+                        "project_id": project.id,
+                        "organization_id": project.organization_id,
+                        "context__contains": f'"commitId":{commit.id}',
+                    },
+                    defaults={
+                        "date_added": django_timezone.now(),
+                    },
+                    context_defaults={
+                        "commitId": commit.id,
+                        "suspectCommitStrategy": SuspectCommitStrategy.SCM_BASED,
+                    },
+                )
+            else:
+                group_owner, created = GroupOwner.objects.update_or_create(
+                    group_id=group_id,
+                    type=GroupOwnerType.SUSPECT_COMMIT.value,
+                    user_id=user_dct.get("id"),
+                    project=project,
+                    organization_id=project.organization_id,
+                    context={"commitId": commit.id},
+                    defaults={"date_added": django_timezone.now()},
+                )
 
             if installation and isinstance(installation, CommitContextIntegration):
                 installation.queue_pr_comment_task_if_needed(project, commit, group_owner, group_id)

--- a/src/sentry/tasks/commit_context.py
+++ b/src/sentry/tasks/commit_context.py
@@ -183,42 +183,23 @@ def process_commit_context(
             author_to_user = get_users_for_authors(commit.organization_id, authors)
             user_dct: Mapping[str, Any] = author_to_user.get(str(commit.author_id), {})
 
-            # update_or_create but handled this way to preserve other `context` content
-            try:
-                group_owner = GroupOwner.objects.get(
-                    group_id=group_id,
-                    type=GroupOwnerType.SUSPECT_COMMIT.value,
-                    user_id=user_dct.get("id"),
-                    project=project,
-                    organization_id=project.organization_id,
-                    context__contains=f'"commitId":{commit.id}',
-                )
-                # Update existing fields: context and date_added
-                existing_context = group_owner.context or {}
-                existing_context.update(
-                    {
-                        "suspectCommitStrategy": SuspectCommitStrategy.SCM_BASED.value,
-                    }
-                )
-                group_owner.context = existing_context
-                group_owner.date_added = django_timezone.now()
-                group_owner.save()
-                created = False
-            except GroupOwner.DoesNotExist:
-                # Create new record
-                group_owner = GroupOwner.objects.create(
-                    group_id=group_id,
-                    type=GroupOwnerType.SUSPECT_COMMIT.value,
-                    user_id=user_dct.get("id"),
-                    project=project,
-                    organization_id=project.organization_id,
-                    date_added=django_timezone.now(),
-                    context={
-                        "commitId": commit.id,
-                        "suspectCommitStrategy": SuspectCommitStrategy.SCM_BASED.value,
-                    },
-                )
-                created = True
+            group_owner, created = GroupOwner.objects.update_or_create_and_preserve_context(
+                lookup_kwargs={
+                    "group_id": group_id,
+                    "type": GroupOwnerType.SUSPECT_COMMIT.value,
+                    "user_id": user_dct.get("id"),
+                    "project_id": project.id,
+                    "organization_id": project.organization_id,
+                    "context__contains": f'"commitId":{commit.id}',
+                },
+                defaults={
+                    "date_added": django_timezone.now(),
+                },
+                context_defaults={
+                    "commitId": commit.id,
+                    "suspectCommitStrategy": SuspectCommitStrategy.SCM_BASED.value,
+                },
+            )
 
             if installation and isinstance(installation, CommitContextIntegration):
                 installation.queue_pr_comment_task_if_needed(project, commit, group_owner, group_id)

--- a/src/sentry/tasks/groupowner.py
+++ b/src/sentry/tasks/groupowner.py
@@ -5,7 +5,7 @@ from typing import cast
 import sentry_sdk
 from django.utils import timezone
 
-from sentry import analytics
+from sentry import analytics, options
 from sentry.analytics.events.groupowner_assignment import GroupOwnerAssignment
 from sentry.locks import locks
 from sentry.models.commit import Commit
@@ -81,23 +81,34 @@ def _process_suspect_commits(
                     sorted(owner_scores.items(), reverse=True, key=lambda item: item[1])
                 )[:PREFERRED_GROUP_OWNERS]:
                     try:
-                        group_owner, created = (
-                            GroupOwner.objects.update_or_create_and_preserve_context(
-                                lookup_kwargs={
-                                    "group_id": group_id,
-                                    "type": GroupOwnerType.SUSPECT_COMMIT.value,
-                                    "user_id": owner_id,
-                                    "project_id": project.id,
-                                    "organization_id": project.organization_id,
-                                },
-                                defaults={
-                                    "date_added": timezone.now(),
-                                },
-                                context_defaults={
-                                    "suspectCommitStrategy": SuspectCommitStrategy.RELEASE_BASED.value,
-                                },
+                        if options.get("issues.suspect-commit-strategy"):
+                            group_owner, created = (
+                                GroupOwner.objects.update_or_create_and_preserve_context(
+                                    lookup_kwargs={
+                                        "group_id": group_id,
+                                        "type": GroupOwnerType.SUSPECT_COMMIT.value,
+                                        "user_id": owner_id,
+                                        "project_id": project.id,
+                                        "organization_id": project.organization_id,
+                                    },
+                                    defaults={
+                                        "date_added": timezone.now(),
+                                    },
+                                    context_defaults={
+                                        "suspectCommitStrategy": SuspectCommitStrategy.RELEASE_BASED,
+                                    },
+                                )
                             )
-                        )
+                        else:
+                            group_owner, created = GroupOwner.objects.update_or_create(
+                                group_id=group_id,
+                                type=GroupOwnerType.SUSPECT_COMMIT.value,
+                                user_id=owner_id,
+                                project=project,
+                                organization_id=project.organization_id,
+                                defaults={"date_added": timezone.now()},
+                            )
+
                         if created:
                             owner_count += 1
                             if owner_count > PREFERRED_GROUP_OWNERS:

--- a/src/sentry/tasks/groupowner.py
+++ b/src/sentry/tasks/groupowner.py
@@ -9,7 +9,7 @@ from sentry import analytics
 from sentry.analytics.events.groupowner_assignment import GroupOwnerAssignment
 from sentry.locks import locks
 from sentry.models.commit import Commit
-from sentry.models.groupowner import GroupOwner, GroupOwnerType
+from sentry.models.groupowner import GroupOwner, GroupOwnerType, SuspectCommitStrategy
 from sentry.models.project import Project
 from sentry.models.release import Release
 from sentry.silo.base import SiloMode
@@ -88,7 +88,10 @@ def _process_suspect_commits(
                             project=project,
                             organization_id=project.organization_id,
                             defaults={
-                                "date_added": timezone.now()
+                                "date_added": timezone.now(),
+                                "context": {
+                                    "suspectCommitStrategy": SuspectCommitStrategy.LEGACY.value,
+                                },
                             },  # Updates date of an existing owner, since we just matched them with this new event
                         )
                         if created:

--- a/tests/sentry/models/test_groupowner.py
+++ b/tests/sentry/models/test_groupowner.py
@@ -1,0 +1,152 @@
+from django.utils import timezone
+
+from sentry.models.groupowner import GroupOwner, GroupOwnerType, SuspectCommitStrategy
+from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.datetime import before_now
+
+
+class GroupOwnerTest(TestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.timestamp = before_now(minutes=10)
+        self.c = self.create_commit(
+            project=self.project,
+            repo=self.create_repo(self.project),
+        )
+
+        self.lookup_kwargs = {
+            "group_id": self.group.id,
+            "type": GroupOwnerType.SUSPECT_COMMIT.value,
+            "user_id": self.user.id,
+            "project_id": self.project.id,
+            "organization_id": self.organization.id,
+        }
+        self.scm_extra_lookup = {"context__contains": f'"commitId":{self.c.id}'}
+
+        self.defaults = {
+            "date_added": self.timestamp,
+        }
+
+        self.scm_context_defaults = {
+            "commitId": self.c.id,
+            "suspectCommitStrategy": SuspectCommitStrategy.SCM_BASED.value,
+        }
+
+        self.rb_context_defaults = {
+            "suspectCommitStrategy": SuspectCommitStrategy.RELEASE_BASED.value,
+        }
+
+    def _make_scm_lookup_kwargs(self):
+        """
+        scm_based lookup_kwargs include an additional filter: context__contains,
+        release_based group owners don't have this field in context.
+        """
+        self.lookup_kwargs.update(self.scm_extra_lookup)
+
+    def test_update_or_create_and_preserve_context_create_then_update_scm(self):
+        assert GroupOwner.objects.filter(**self.lookup_kwargs).exists() is False
+
+        self._make_scm_lookup_kwargs()
+
+        obj, created = GroupOwner.objects.update_or_create_and_preserve_context(
+            lookup_kwargs=self.lookup_kwargs,
+            defaults=self.defaults,
+            context_defaults=self.scm_context_defaults,
+        )
+
+        assert GroupOwner.objects.filter(**self.lookup_kwargs).exists() is True
+        assert created is True
+        assert obj.group_id == self.group.id
+        assert obj.type == GroupOwnerType.SUSPECT_COMMIT.value
+        assert obj.user_id == self.user.id
+        assert obj.project_id == self.project.id
+        assert obj.organization_id == self.organization.id
+        assert obj.date_added == self.timestamp
+        assert obj.context == self.scm_context_defaults
+
+        now = timezone.now()
+        obj, created = GroupOwner.objects.update_or_create_and_preserve_context(
+            lookup_kwargs=self.lookup_kwargs,
+            defaults={
+                "date_added": now,
+            },
+            context_defaults=self.scm_context_defaults,
+        )
+
+        assert created is False
+        assert obj.group_id == self.group.id
+        assert obj.type == GroupOwnerType.SUSPECT_COMMIT.value
+        assert obj.user_id == self.user.id
+        assert obj.project_id == self.project.id
+        assert obj.organization_id == self.organization.id
+        assert obj.date_added == now
+        assert obj.context == self.scm_context_defaults
+
+    def test_update_or_create_and_preserve_context_update_scm(self):
+        original_obj = GroupOwner.objects.create(
+            context={
+                "commitId": self.c.id,
+                "something": "else",
+            },
+            **self.lookup_kwargs,
+            **self.defaults,
+        )
+
+        self._make_scm_lookup_kwargs()
+        obj, created = GroupOwner.objects.update_or_create_and_preserve_context(
+            lookup_kwargs=self.lookup_kwargs,
+            defaults=self.defaults,
+            context_defaults=self.scm_context_defaults,
+        )
+
+        assert created is False
+        assert original_obj.id == obj.id
+        assert obj.group_id == self.group.id
+        assert obj.type == GroupOwnerType.SUSPECT_COMMIT.value
+        assert obj.user_id == self.user.id
+        assert obj.project_id == self.project.id
+        assert obj.organization_id == self.organization.id
+        assert obj.date_added == self.timestamp
+        assert obj.context == {
+            "commitId": self.c.id,
+            "something": "else",
+            "suspectCommitStrategy": SuspectCommitStrategy.SCM_BASED.value,
+        }
+
+    def test_update_or_create_and_preserve_context_create_then_update_rb(self):
+        assert GroupOwner.objects.filter(**self.lookup_kwargs).exists() is False
+
+        obj, created = GroupOwner.objects.update_or_create_and_preserve_context(
+            lookup_kwargs=self.lookup_kwargs,
+            defaults=self.defaults,
+            context_defaults=self.rb_context_defaults,
+        )
+
+        assert GroupOwner.objects.filter(**self.lookup_kwargs).exists() is True
+        assert created is True
+        assert obj.group_id == self.group.id
+        assert obj.type == GroupOwnerType.SUSPECT_COMMIT.value
+        assert obj.user_id == self.user.id
+        assert obj.project_id == self.project.id
+        assert obj.organization_id == self.organization.id
+        assert obj.date_added == self.timestamp
+        assert obj.context == self.rb_context_defaults
+
+        now = timezone.now()
+        obj, created = GroupOwner.objects.update_or_create_and_preserve_context(
+            lookup_kwargs=self.lookup_kwargs,
+            defaults={
+                "date_added": now,
+            },
+            context_defaults=self.rb_context_defaults,
+        )
+
+        assert created is False
+        assert obj.group_id == self.group.id
+        assert obj.type == GroupOwnerType.SUSPECT_COMMIT.value
+        assert obj.user_id == self.user.id
+        assert obj.project_id == self.project.id
+        assert obj.organization_id == self.organization.id
+        assert obj.date_added == now
+        assert obj.context == self.rb_context_defaults

--- a/tests/sentry/models/test_groupowner.py
+++ b/tests/sentry/models/test_groupowner.py
@@ -30,11 +30,11 @@ class GroupOwnerTest(TestCase):
 
         self.scm_context_defaults = {
             "commitId": self.c.id,
-            "suspectCommitStrategy": SuspectCommitStrategy.SCM_BASED.value,
+            "suspectCommitStrategy": SuspectCommitStrategy.SCM_BASED,
         }
 
         self.rb_context_defaults = {
-            "suspectCommitStrategy": SuspectCommitStrategy.RELEASE_BASED.value,
+            "suspectCommitStrategy": SuspectCommitStrategy.RELEASE_BASED,
         }
 
     def _make_scm_lookup_kwargs(self):
@@ -111,7 +111,7 @@ class GroupOwnerTest(TestCase):
         assert obj.context == {
             "commitId": self.c.id,
             "something": "else",
-            "suspectCommitStrategy": SuspectCommitStrategy.SCM_BASED.value,
+            "suspectCommitStrategy": SuspectCommitStrategy.SCM_BASED,
         }
 
     def test_update_or_create_and_preserve_context_create_then_update_rb(self):

--- a/tests/sentry/tasks/test_commit_context.py
+++ b/tests/sentry/tasks/test_commit_context.py
@@ -25,7 +25,7 @@ from sentry.integrations.source_code_management.metrics import CommitContextHalt
 from sentry.integrations.types import EventLifecycleOutcome
 from sentry.models.commit import Commit
 from sentry.models.commitauthor import CommitAuthor
-from sentry.models.groupowner import GroupOwner, GroupOwnerType
+from sentry.models.groupowner import GroupOwner, GroupOwnerType, SuspectCommitStrategy
 from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.pullrequest import (
     CommentType,
@@ -245,7 +245,10 @@ class TestCommitContextAllFrames(TestCommitContextIntegration):
         assert commit.message == "placeholder commit message"
 
         assert created_group_owner
-        assert created_group_owner.context == {"commitId": existing_commit.id}
+        assert created_group_owner.context == {
+            "commitId": existing_commit.id,
+            "suspectCommitStrategy": SuspectCommitStrategy.CURRENT.value,
+        }
 
         assert_any_analytics_event(
             mock_record,
@@ -310,7 +313,10 @@ class TestCommitContextAllFrames(TestCommitContextIntegration):
             project=self.event.project,
             organization=self.event.project.organization,
             type=GroupOwnerType.SUSPECT_COMMIT.value,
-        ).context == {"commitId": created_commit.id}
+        ).context == {
+            "commitId": created_commit.id,
+            "suspectCommitStrategy": SuspectCommitStrategy.CURRENT.value,
+        }
 
     @patch("sentry.analytics.record")
     @patch(
@@ -348,7 +354,10 @@ class TestCommitContextAllFrames(TestCommitContextIntegration):
 
         created_commit = Commit.objects.get(key="commit-id-recent")
 
-        assert created_group_owner.context == {"commitId": created_commit.id}
+        assert created_group_owner.context == {
+            "commitId": created_commit.id,
+            "suspectCommitStrategy": SuspectCommitStrategy.CURRENT.value,
+        }
 
     @patch("sentry.analytics.record")
     @patch(
@@ -1250,7 +1259,10 @@ class TestGHCommentQueuing(IntegrationTestCase, TestCommitContextIntegration):
             user_id=1,
             project_id=self.event.project_id,
             organization_id=self.project.organization_id,
-            context={"commitId": self.commit.id},
+            context={
+                "commitId": self.commit.id,
+                "suspectCommitStrategy": SuspectCommitStrategy.CURRENT.value,
+            },
             date_added=timezone.now(),
         )
 
@@ -1300,7 +1312,10 @@ class TestGHCommentQueuing(IntegrationTestCase, TestCommitContextIntegration):
             user_id=1,
             project_id=self.event.project_id,
             organization_id=self.project.organization_id,
-            context={"commitId": self.commit.id},
+            context={
+                "commitId": self.commit.id,
+                "suspectCommitStrategy": SuspectCommitStrategy.CURRENT.value,
+            },
             date_added=timezone.now(),
         )
 

--- a/tests/sentry/tasks/test_commit_context.py
+++ b/tests/sentry/tasks/test_commit_context.py
@@ -222,13 +222,14 @@ class TestCommitContextAllFrames(TestCommitContextIntegration):
             existing_commit.update(message="")
             assert Commit.objects.count() == 2
             event_frames = get_frame_paths(self.event)
-            process_commit_context(
-                event_id=self.event.event_id,
-                event_platform=self.event.platform,
-                event_frames=event_frames,
-                group_id=self.event.group_id,
-                project_id=self.event.project_id,
-            )
+            with self.options({"issues.suspect-commit-strategy": True}):
+                process_commit_context(
+                    event_id=self.event.event_id,
+                    event_platform=self.event.platform,
+                    event_frames=event_frames,
+                    group_id=self.event.group_id,
+                    project_id=self.event.project_id,
+                )
 
         created_group_owner = GroupOwner.objects.get(
             group=self.event.group,
@@ -247,7 +248,7 @@ class TestCommitContextAllFrames(TestCommitContextIntegration):
         assert created_group_owner
         assert created_group_owner.context == {
             "commitId": existing_commit.id,
-            "suspectCommitStrategy": SuspectCommitStrategy.SCM_BASED.value,
+            "suspectCommitStrategy": SuspectCommitStrategy.SCM_BASED,
         }
 
         assert_any_analytics_event(
@@ -288,13 +289,14 @@ class TestCommitContextAllFrames(TestCommitContextIntegration):
             existing_commit.update(message="")
             assert Commit.objects.count() == 2
             event_frames = get_frame_paths(self.event)
-            process_commit_context(
-                event_id=self.event.event_id,
-                event_platform=self.event.platform,
-                event_frames=event_frames,
-                group_id=self.event.group_id,
-                project_id=self.event.project_id,
-            )
+            with self.options({"issues.suspect-commit-strategy": True}):
+                process_commit_context(
+                    event_id=self.event.event_id,
+                    event_platform=self.event.platform,
+                    event_frames=event_frames,
+                    group_id=self.event.group_id,
+                    project_id=self.event.project_id,
+                )
 
         created_group_owner = GroupOwner.objects.get(
             group=self.event.group,
@@ -313,19 +315,20 @@ class TestCommitContextAllFrames(TestCommitContextIntegration):
         assert created_group_owner
         assert created_group_owner.context == {
             "commitId": existing_commit.id,
-            "suspectCommitStrategy": SuspectCommitStrategy.SCM_BASED.value,
+            "suspectCommitStrategy": SuspectCommitStrategy.SCM_BASED,
         }
 
         with self.tasks():
             assert GroupOwner.objects.filter(group=self.event.group).count() == 1
             event_frames = get_frame_paths(self.event)
-            process_commit_context(
-                event_id=self.event.event_id,
-                event_platform=self.event.platform,
-                event_frames=event_frames,
-                group_id=self.event.group_id,
-                project_id=self.event.project_id,
-            )
+            with self.options({"issues.suspect-commit-strategy": True}):
+                process_commit_context(
+                    event_id=self.event.event_id,
+                    event_platform=self.event.platform,
+                    event_frames=event_frames,
+                    group_id=self.event.group_id,
+                    project_id=self.event.project_id,
+                )
 
         assert GroupOwner.objects.filter(group=self.event.group).count() == 1
 
@@ -346,7 +349,7 @@ class TestCommitContextAllFrames(TestCommitContextIntegration):
         assert updated_group_owner
         assert updated_group_owner.context == {
             "commitId": existing_commit.id,
-            "suspectCommitStrategy": SuspectCommitStrategy.SCM_BASED.value,
+            "suspectCommitStrategy": SuspectCommitStrategy.SCM_BASED,
         }
 
     @patch("sentry.analytics.record")
@@ -363,13 +366,14 @@ class TestCommitContextAllFrames(TestCommitContextIntegration):
         with self.tasks():
             assert not GroupOwner.objects.filter(group=self.event.group).exists()
             event_frames = get_frame_paths(self.event)
-            process_commit_context(
-                event_id=self.event.event_id,
-                event_platform=self.event.platform,
-                event_frames=event_frames,
-                group_id=self.event.group_id,
-                project_id=self.event.project_id,
-            )
+            with self.options({"issues.suspect-commit-strategy": True}):
+                process_commit_context(
+                    event_id=self.event.event_id,
+                    event_platform=self.event.platform,
+                    event_frames=event_frames,
+                    group_id=self.event.group_id,
+                    project_id=self.event.project_id,
+                )
 
         created_commit_author = CommitAuthor.objects.get(
             organization_id=self.organization.id, email="admin2@localhost"
@@ -397,7 +401,7 @@ class TestCommitContextAllFrames(TestCommitContextIntegration):
             type=GroupOwnerType.SUSPECT_COMMIT.value,
         ).context == {
             "commitId": created_commit.id,
-            "suspectCommitStrategy": SuspectCommitStrategy.SCM_BASED.value,
+            "suspectCommitStrategy": SuspectCommitStrategy.SCM_BASED,
         }
 
     @patch("sentry.analytics.record")
@@ -419,13 +423,14 @@ class TestCommitContextAllFrames(TestCommitContextIntegration):
         with self.tasks():
             assert not GroupOwner.objects.filter(group=self.event.group).exists()
             event_frames = get_frame_paths(self.event)
-            process_commit_context(
-                event_id=self.event.event_id,
-                event_platform=self.event.platform,
-                event_frames=event_frames,
-                group_id=self.event.group_id,
-                project_id=self.event.project_id,
-            )
+            with self.options({"issues.suspect-commit-strategy": True}):
+                process_commit_context(
+                    event_id=self.event.event_id,
+                    event_platform=self.event.platform,
+                    event_frames=event_frames,
+                    group_id=self.event.group_id,
+                    project_id=self.event.project_id,
+                )
 
         created_group_owner = GroupOwner.objects.get(
             group=self.event.group,
@@ -438,7 +443,7 @@ class TestCommitContextAllFrames(TestCommitContextIntegration):
 
         assert created_group_owner.context == {
             "commitId": created_commit.id,
-            "suspectCommitStrategy": SuspectCommitStrategy.SCM_BASED.value,
+            "suspectCommitStrategy": SuspectCommitStrategy.SCM_BASED,
         }
 
     @patch("sentry.analytics.record")
@@ -1343,7 +1348,7 @@ class TestGHCommentQueuing(IntegrationTestCase, TestCommitContextIntegration):
             organization_id=self.project.organization_id,
             context={
                 "commitId": self.commit.id,
-                "suspectCommitStrategy": SuspectCommitStrategy.SCM_BASED.value,
+                "suspectCommitStrategy": SuspectCommitStrategy.SCM_BASED,
             },
             date_added=timezone.now(),
         )

--- a/tests/sentry/tasks/test_groupowner.py
+++ b/tests/sentry/tasks/test_groupowner.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 from django.utils import timezone
 
 from sentry.deletions.tasks.hybrid_cloud import schedule_hybrid_cloud_foreign_key_jobs
-from sentry.models.groupowner import GroupOwner, GroupOwnerType
+from sentry.models.groupowner import GroupOwner, GroupOwnerType, SuspectCommitStrategy
 from sentry.models.grouprelease import GroupRelease
 from sentry.models.repository import Repository
 from sentry.silo.base import SiloMode
@@ -306,6 +306,8 @@ class TestGroupOwners(TestCase):
         )
 
         date_added_before_update = go.date_added
+        assert go.context == {"suspectCommitStrategy": SuspectCommitStrategy.RELEASE_BASED.value}
+
         process_suspect_commits(
             event_id=self.event.event_id,
             event_platform=self.event.platform,
@@ -315,6 +317,7 @@ class TestGroupOwners(TestCase):
         )
         go.refresh_from_db()
         assert go.date_added > date_added_before_update
+        assert go.context == {"suspectCommitStrategy": SuspectCommitStrategy.RELEASE_BASED.value}
         assert GroupOwner.objects.filter(group=self.event.group).count() == 1
         assert GroupOwner.objects.get(
             group=self.event.group,

--- a/tests/sentry/tasks/test_groupowner.py
+++ b/tests/sentry/tasks/test_groupowner.py
@@ -291,13 +291,14 @@ class TestGroupOwners(TestCase):
         # As new events come in associated with existing owners, we should update the date_added of that owner.
         self.set_release_commits(self.user.email)
         event_frames = get_frame_paths(self.event)
-        process_suspect_commits(
-            event_id=self.event.event_id,
-            event_platform=self.event.platform,
-            event_frames=event_frames,
-            group_id=self.event.group_id,
-            project_id=self.event.project_id,
-        )
+        with self.options({"issues.suspect-commit-strategy": True}):
+            process_suspect_commits(
+                event_id=self.event.event_id,
+                event_platform=self.event.platform,
+                event_frames=event_frames,
+                group_id=self.event.group_id,
+                project_id=self.event.project_id,
+            )
         go = GroupOwner.objects.get(
             group=self.event.group,
             project=self.event.project,
@@ -306,18 +307,19 @@ class TestGroupOwners(TestCase):
         )
 
         date_added_before_update = go.date_added
-        assert go.context == {"suspectCommitStrategy": SuspectCommitStrategy.RELEASE_BASED.value}
+        assert go.context == {"suspectCommitStrategy": SuspectCommitStrategy.RELEASE_BASED}
 
-        process_suspect_commits(
-            event_id=self.event.event_id,
-            event_platform=self.event.platform,
-            event_frames=event_frames,
-            group_id=self.event.group_id,
-            project_id=self.event.project_id,
-        )
+        with self.options({"issues.suspect-commit-strategy": True}):
+            process_suspect_commits(
+                event_id=self.event.event_id,
+                event_platform=self.event.platform,
+                event_frames=event_frames,
+                group_id=self.event.group_id,
+                project_id=self.event.project_id,
+            )
         go.refresh_from_db()
         assert go.date_added > date_added_before_update
-        assert go.context == {"suspectCommitStrategy": SuspectCommitStrategy.RELEASE_BASED.value}
+        assert go.context == {"suspectCommitStrategy": SuspectCommitStrategy.RELEASE_BASED}
         assert GroupOwner.objects.filter(group=self.event.group).count() == 1
         assert GroupOwner.objects.get(
             group=self.event.group,


### PR DESCRIPTION
## Problem
We have two different suspect commit detection flows but no way to distinguish which flow created a GroupOwner record:
- **Legacy flow**: `process_suspect_commits` (release-based, stores only user_id)  
- **Modern flow**: `process_commit_context` (SCM integration-based, stores commitId)

This makes it difficult to analyze the effectiveness of each approach or debug issues.

## Solution
Add a `SuspectCommitStrategy` StrEnum and store it in the GroupOwner `context` field:

- **`RELEASE_BASED = "release_based"`**: Set by `process_suspect_commits` 
- **`SCM_BASED = "scm_based"`**: Set by `process_commit_context`

## Changes
- Add `SuspectCommitStrategy` enum to `groupowner.py`
- Modify both suspect commit tasks to include strategy in context
- Update tests to verify new context structure

## Impact
- Enables tracking which detection method is more effective
- Allows filtering GroupOwner queries by detection strategy
- No breaking changes - existing records without strategy still work
- Facilitates future analytics and debugging

[ticket](https://linear.app/getsentry/issue/ID-857/add-suspectcommitstrategy-to-context-on-groupowner)