### PR TITLE
chore(ecosystem): add compare_commits SLO

### DIFF
--- a/src/sentry/integrations/source_code_management/metrics.py
+++ b/src/sentry/integrations/source_code_management/metrics.py
@@ -51,6 +51,9 @@ class SCMIntegrationInteractionType(StrEnum):
     SYNC_EXTERNAL_ISSUE_COMMENT_CREATE = "sync_external_issue_comment_create"
     SYNC_EXTERNAL_ISSUE_COMMENT_UPDATE = "sync_external_issue_comment_update"
 
+    # Releases
+    COMPARE_COMMITS = "compare_commits"
+
 
 @dataclass
 class SCMIntegrationInteractionEvent(IntegrationEventLifecycleMetric):

--- a/src/sentry/tasks/commits.py
+++ b/src/sentry/tasks/commits.py
@@ -8,6 +8,10 @@ from sentry_sdk import set_tag
 
 from sentry.constants import ObjectStatus
 from sentry.exceptions import InvalidIdentity, PluginError
+from sentry.integrations.source_code_management.metrics import (
+    SCMIntegrationInteractionEvent,
+    SCMIntegrationInteractionType,
+)
 from sentry.models.deploy import Deploy
 from sentry.models.latestreporeleaseenvironment import LatestRepoReleaseEnvironment
 from sentry.models.organization import Organization
@@ -125,9 +129,10 @@ def fetch_commits(release_id: int, user_id: int, refs, prev_release_id=None, **k
             )
             continue
 
+        is_integration_repo_provider = is_integration_provider(repo.provider)
         binding_key = (
             "integration-repository.provider"
-            if is_integration_provider(repo.provider)
+            if is_integration_repo_provider
             else "repository.provider"
         )
         try:
@@ -153,118 +158,132 @@ def fetch_commits(release_id: int, user_id: int, refs, prev_release_id=None, **k
 
         end_sha = ref["commit"]
         provider = provider_cls(id=repo.provider)
-        try:
-            if is_integration_provider(provider.id):
-                repo_commits = provider.compare_commits(repo, start_sha, end_sha)
-            else:
-                repo_commits = provider.compare_commits(repo, start_sha, end_sha, actor=user)
-        except NotImplementedError:
-            pass
-        except IntegrationResourceNotFoundError:
-            pass
-        except Exception as e:
-            logger.info(
-                "fetch_commits.error",
-                extra={
+
+        provider_key = (
+            provider_cls.repo_provider
+            if is_integration_repo_provider
+            else provider_cls.auth_provider
+        )
+
+        with SCMIntegrationInteractionEvent(
+            SCMIntegrationInteractionType.COMPARE_COMMITS,
+            provider_key=provider_key,
+        ).capture() as lifecycle:
+            lifecycle.add_extras(
+                {
                     "organization_id": repo.organization_id,
                     "user_id": user_id,
                     "repository": repo.name,
                     "provider": provider.id,
-                    "error": str(e),
                     "end_sha": end_sha,
                     "start_sha": start_sha,
-                },
+                }
             )
-            span = sentry_sdk.get_current_span()
-            if span is None:
-                raise TypeError("No span is currently active right now")
-            span.set_status("unknown_error")
-            logger.exception(str(e))
-            if isinstance(e, InvalidIdentity) and getattr(e, "identity", None):
-                handle_invalid_identity(identity=e.identity, commit_failure=True)
-            elif isinstance(e, (PluginError, InvalidIdentity, IntegrationError)):
-                msg = generate_fetch_commits_error_email(release, repo, str(e))
-                emails = get_emails_for_user_or_org(user, release.organization_id)
-                msg.send_async(to=emails)
-            else:
-                msg = generate_fetch_commits_error_email(
-                    release, repo, "An internal system error occurred."
-                )
-                emails = get_emails_for_user_or_org(user, release.organization_id)
-                msg.send_async(to=emails)
-        else:
-            logger.info(
-                "fetch_commits.complete",
-                extra={
-                    "organization_id": repo.organization_id,
-                    "user_id": user_id,
-                    "repository": repo.name,
-                    "end_sha": end_sha,
-                    "start_sha": start_sha,
-                    "num_commits": len(repo_commits or []),
-                },
-            )
-            commit_list.extend(repo_commits)
+            try:
+                if is_integration_repo_provider:
+                    repo_commits = provider.compare_commits(repo, start_sha, end_sha)
+                else:
+                    repo_commits = provider.compare_commits(repo, start_sha, end_sha, actor=user)
+            except NotImplementedError:
+                pass
+            except IntegrationResourceNotFoundError:
+                pass
+            except Exception as e:
+                span = sentry_sdk.get_current_span()
+                if span is None:
+                    raise TypeError("No span is currently active right now")
+                span.set_status("unknown_error")
 
-    if commit_list:
-        try:
-            release.set_commits(commit_list)
-        except ReleaseCommitError:
-            # Another task or webworker is currently setting commits on this
-            # release. Return early as that task will do the remaining work.
-            logger.info(
-                "fetch_commits.duplicate",
-                extra={
-                    "release_id": release.id,
-                    "organization_id": release.organization_id,
-                    "user_id": user_id,
-                },
-            )
-            return
-
-        deploys = Deploy.objects.filter(
-            organization_id=release.organization_id, release=release, notified=False
-        ).values_list("id", "environment_id", "date_finished")
-
-        # XXX(dcramer): i don't know why this would have multiple environments, but for
-        # our sanity lets assume it can
-        pending_notifications = []
-        last_deploy_per_environment = {}
-        for deploy_id, environment_id, date_finished in deploys:
-            last_deploy_per_environment[environment_id] = (deploy_id, date_finished)
-            pending_notifications.append(deploy_id)
-
-        repo_queryset = ReleaseHeadCommit.objects.filter(
-            organization_id=release.organization_id, release=release
-        ).values_list("repository_id", "commit")
-
-        # for each repo, update (or create if this is the first one) our records
-        # of the latest commit-associated release in each env
-        # use deploys as a proxy for ReleaseEnvironment, because they contain
-        # a timestamp in addition to release and env data
-        for repository_id, commit_id in repo_queryset:
-            for environment_id, (deploy_id, date_finished) in last_deploy_per_environment.items():
-                # we need to mark LatestRepoReleaseEnvironment, but only if there's not a
-                # deploy in the given environment which has completed *after*
-                # this deploy (given we might process commits out of order)
-                if not Deploy.objects.filter(
-                    id__in=LatestRepoReleaseEnvironment.objects.filter(
-                        repository_id=repository_id, environment_id=environment_id
-                    ).values("deploy_id"),
-                    date_finished__gt=date_finished,
-                ).exists():
-                    LatestRepoReleaseEnvironment.objects.create_or_update(
-                        repository_id=repository_id,
-                        environment_id=environment_id,
-                        values={
-                            "release_id": release.id,
-                            "deploy_id": deploy_id,
-                            "commit_id": commit_id,
-                        },
+                if isinstance(e, InvalidIdentity) and getattr(e, "identity", None):
+                    handle_invalid_identity(identity=e.identity, commit_failure=True)
+                    lifecycle.record_halt(e)
+                elif isinstance(e, (PluginError, InvalidIdentity, IntegrationError)):
+                    msg = generate_fetch_commits_error_email(release, repo, str(e))
+                    emails = get_emails_for_user_or_org(user, release.organization_id)
+                    msg.send_async(to=emails)
+                    lifecycle.record_halt(e)
+                else:
+                    msg = generate_fetch_commits_error_email(
+                        release, repo, "An internal system error occurred."
                     )
+                    emails = get_emails_for_user_or_org(user, release.organization_id)
+                    msg.send_async(to=emails)
+                    lifecycle.record_failure(e)
+            else:
+                logger.info(
+                    "fetch_commits.complete",
+                    extra={
+                        "organization_id": repo.organization_id,
+                        "user_id": user_id,
+                        "repository": repo.name,
+                        "end_sha": end_sha,
+                        "start_sha": start_sha,
+                        "num_commits": len(repo_commits or []),
+                    },
+                )
+                commit_list.extend(repo_commits)
 
-        for deploy_id in pending_notifications:
-            Deploy.notify_if_ready(deploy_id, fetch_complete=True)
+    if not commit_list:
+        return
+
+    try:
+        release.set_commits(commit_list)
+    except ReleaseCommitError:
+        # Another task or webworker is currently setting commits on this
+        # release. Return early as that task will do the remaining work.
+        logger.info(
+            "fetch_commits.duplicate",
+            extra={
+                "release_id": release.id,
+                "organization_id": release.organization_id,
+                "user_id": user_id,
+            },
+        )
+        return
+
+    deploys = Deploy.objects.filter(
+        organization_id=release.organization_id, release=release, notified=False
+    ).values_list("id", "environment_id", "date_finished")
+
+    # XXX(dcramer): i don't know why this would have multiple environments, but for
+    # our sanity lets assume it can
+    pending_notifications = []
+    last_deploy_per_environment = {}
+    for deploy_id, environment_id, date_finished in deploys:
+        last_deploy_per_environment[environment_id] = (deploy_id, date_finished)
+        pending_notifications.append(deploy_id)
+
+    repo_queryset = ReleaseHeadCommit.objects.filter(
+        organization_id=release.organization_id, release=release
+    ).values_list("repository_id", "commit")
+
+    # for each repo, update (or create if this is the first one) our records
+    # of the latest commit-associated release in each env
+    # use deploys as a proxy for ReleaseEnvironment, because they contain
+    # a timestamp in addition to release and env data
+    for repository_id, commit_id in repo_queryset:
+        for environment_id, (deploy_id, date_finished) in last_deploy_per_environment.items():
+            # we need to mark LatestRepoReleaseEnvironment, but only if there's not a
+            # deploy in the given environment which has completed *after*
+            # this deploy (given we might process commits out of order)
+            if not Deploy.objects.filter(
+                id__in=LatestRepoReleaseEnvironment.objects.filter(
+                    repository_id=repository_id, environment_id=environment_id
+                ).values("deploy_id"),
+                date_finished__gt=date_finished,
+            ).exists():
+                LatestRepoReleaseEnvironment.objects.create_or_update(
+                    repository_id=repository_id,
+                    environment_id=environment_id,
+                    values={
+                        "release_id": release.id,
+                        "deploy_id": deploy_id,
+                        "commit_id": commit_id,
+                    },
+                )
+
+    for deploy_id in pending_notifications:
+        Deploy.notify_if_ready(deploy_id, fetch_complete=True)
 
 
 def is_integration_provider(provider):

--- a/tests/sentry/tasks/test_commits.py
+++ b/tests/sentry/tasks/test_commits.py
@@ -4,6 +4,7 @@ from django.core import mail
 
 from sentry.constants import ObjectStatus
 from sentry.exceptions import InvalidIdentity, PluginError
+from sentry.integrations.types import EventLifecycleOutcome
 from sentry.locks import locks
 from sentry.models.commit import Commit
 from sentry.models.deploy import Deploy
@@ -13,11 +14,13 @@ from sentry.models.releaseheadcommit import ReleaseHeadCommit
 from sentry.models.repository import Repository
 from sentry.silo.base import SiloMode
 from sentry.tasks.commits import fetch_commits, handle_invalid_identity
+from sentry.testutils.asserts import assert_slo_metric
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from social_auth.models import UserSocialAuth
 
 
+@patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
 class FetchCommitsTest(TestCase):
     def _test_simple_action(self, user, org):
         repo = Repository.objects.create(name="example", provider="dummy", organization_id=org.id)
@@ -69,12 +72,12 @@ class FetchCommitsTest(TestCase):
         assert latest_repo_release_environment.release_id == release2.id
         assert latest_repo_release_environment.commit_id == commit_list[0].id
 
-    def test_simple(self):
+    def test_simple(self, mock_record):
         self.login_as(user=self.user)
         org = self.create_organization(owner=self.user, name="baz")
         self._test_simple_action(user=self.user, org=org)
 
-    def test_duplicate_repositories(self):
+    def test_duplicate_repositories(self, mock_record):
         self.login_as(user=self.user)
         org = self.create_organization(owner=self.user, name="baz")
         Repository.objects.create(
@@ -83,7 +86,7 @@ class FetchCommitsTest(TestCase):
         Repository.objects.create(name="example", provider="dummy", organization_id=org.id)
         self._test_simple_action(user=self.user, org=org)
 
-    def test_release_locked(self):
+    def test_release_locked(self, mock_record_event):
         self.login_as(user=self.user)
         org = self.create_organization(owner=self.user, name="baz")
         repo = Repository.objects.create(name="example", provider="dummy", organization_id=org.id)
@@ -113,7 +116,9 @@ class FetchCommitsTest(TestCase):
 
     @patch("sentry.tasks.commits.handle_invalid_identity")
     @patch("sentry.plugins.providers.dummy.repository.DummyRepositoryProvider.compare_commits")
-    def test_fetch_error_invalid_identity(self, mock_compare_commits, mock_handle_invalid_identity):
+    def test_fetch_error_invalid_identity(
+        self, mock_compare_commits, mock_handle_invalid_identity, mock_record
+    ):
         self.login_as(user=self.user)
         org = self.create_organization(owner=self.user, name="baz")
 
@@ -141,8 +146,10 @@ class FetchCommitsTest(TestCase):
 
         mock_handle_invalid_identity.assert_called_once_with(identity=usa, commit_failure=True)
 
+        assert_slo_metric(mock_record, EventLifecycleOutcome.HALTED)
+
     @patch("sentry.plugins.providers.dummy.repository.DummyRepositoryProvider.compare_commits")
-    def test_fetch_error_plugin_error(self, mock_compare_commits):
+    def test_fetch_error_plugin_error(self, mock_compare_commits, mock_record):
         self.login_as(user=self.user)
         org = self.create_organization(owner=self.user, name="baz")
 
@@ -177,8 +184,10 @@ class FetchCommitsTest(TestCase):
         assert msg.to == [self.user.email]
         assert "secrets" not in msg.body
 
+        assert_slo_metric(mock_record, EventLifecycleOutcome.FAILURE)
+
     @patch("sentry.plugins.providers.dummy.repository.DummyRepositoryProvider.compare_commits")
-    def test_fetch_error_plugin_error_for_sentry_app(self, mock_compare_commits):
+    def test_fetch_error_plugin_error_for_sentry_app(self, mock_compare_commits, mock_record):
         org = self.create_organization(owner=self.user, name="baz")
         sentry_app = self.create_sentry_app(
             organization=org, published=True, verify_install=False, name="Super Awesome App"
@@ -199,6 +208,8 @@ class FetchCommitsTest(TestCase):
 
         mock_compare_commits.side_effect = Exception("secrets")
 
+        mock_record.reset_mock()
+
         with self.tasks():
             fetch_commits(
                 release_id=release2.id,
@@ -212,8 +223,10 @@ class FetchCommitsTest(TestCase):
         assert msg.to == [self.user.email]
         assert "secrets" not in msg.body
 
+        assert_slo_metric(mock_record, EventLifecycleOutcome.FAILURE)
+
     @patch("sentry.plugins.providers.dummy.repository.DummyRepositoryProvider.compare_commits")
-    def test_fetch_error_random_exception(self, mock_compare_commits):
+    def test_fetch_error_random_exception(self, mock_compare_commits, mock_record):
         self.login_as(user=self.user)
         org = self.create_organization(owner=self.user, name="baz")
 
@@ -248,7 +261,9 @@ class FetchCommitsTest(TestCase):
         assert msg.to == [self.user.email]
         assert "You can read me" in msg.body
 
-    def test_fetch_error_random_exception_integration(self):
+        assert_slo_metric(mock_record, EventLifecycleOutcome.HALTED)
+
+    def test_fetch_error_random_exception_integration(self, mock_record):
         self.login_as(user=self.user)
         org = self.create_organization(owner=self.user, name="baz")
 
@@ -286,6 +301,8 @@ class FetchCommitsTest(TestCase):
         assert msg.subject == "Unable to Fetch Commits"
         assert msg.to == [self.user.email]
         assert "Repository not found" in msg.body
+
+        assert_slo_metric(mock_record, EventLifecycleOutcome.HALTED)
 
 
 @control_silo_test


### PR DESCRIPTION
We make outgoing API calls to compare commits (for releases) but we don't yet have SLOs for this.