### PR TITLE
fix(issues): Shrink size of drawer resize handle

### DIFF
--- a/static/app/components/globalDrawer/components.tsx
+++ b/static/app/components/globalDrawer/components.tsx
@@ -229,10 +229,10 @@ const DrawerSlidePanel = styled(SlideOverPanel)`
 
 const ResizeHandle = styled('div')`
   position: absolute;
-  left: -4px;
+  left: -2px;
   top: 0;
   bottom: 0;
-  width: 16px;
+  width: 8px;
   cursor: ew-resize;
   z-index: ${p => p.theme.zIndex.drawer + 2};
 
@@ -254,7 +254,7 @@ const ResizeHandle = styled('div')`
   &::after {
     content: '';
     position: absolute;
-    left: 4px;
+    left: 2px;
     top: 0;
     bottom: 0;
     width: 4px;


### PR DESCRIPTION
the width of the handle was blocking the scroll bar from being clicked

before

https://github.com/user-attachments/assets/f29ec64a-efbf-4941-a9fe-4d164de3bab1

after

https://github.com/user-attachments/assets/bbd3325e-0205-4a82-a741-6b386526a8a6

