### PR TITLE
fix(analytics): Add distinct analytics event for suspect commit assignments

### DIFF
--- a/src/sentry/analytics/events/__init__.py
+++ b/src/sentry/analytics/events/__init__.py
@@ -97,6 +97,7 @@ from .sentry_app_uninstalled import *  # noqa: F401,F403
 from .sentry_app_updated import *  # noqa: F401,F403
 from .sentryapp_issue_webhooks import *  # noqa: F401,F403
 from .sso_enabled import *  # noqa: F401,F403
+from .suspectcommit_assignment import *  # noqa: F401,F403
 from .team_created import *  # noqa: F401,F403
 from .user_created import *  # noqa: F401,F403
 from .user_signup import *  # noqa: F401,F403

--- a/src/sentry/analytics/events/suspectcommit_assignment.py
+++ b/src/sentry/analytics/events/suspectcommit_assignment.py
@@ -1,0 +1,15 @@
+from sentry import analytics
+
+
+class SuspectCommitAssignment(analytics.Event):
+    type = "suspectcommit.assignment"
+
+    attributes = (
+        analytics.Attribute("organization_id"),
+        analytics.Attribute("project_id"),
+        analytics.Attribute("group_id"),
+        analytics.Attribute("updated_assignment"),
+    )
+
+
+analytics.register(SuspectCommitAssignment)

--- a/src/sentry/models/projectownership.py
+++ b/src/sentry/models/projectownership.py
@@ -350,7 +350,12 @@ class ProjectOwnership(Model):
                         "codeowners.assignment"
                         if activity_details.get("integration")
                         == ActivityIntegration.CODEOWNERS.value
-                        else "issueowners.assignment"
+                        else (
+                            "suspectcommit.assignment"
+                            if activity_details.get("integration")
+                            == ActivityIntegration.SUSPECT_COMMITTER.value
+                            else "issueowners.assignment"
+                        )
                     ),
                     organization_id=organization_id or ownership.project.organization_id,
                     project_id=project_id,


### PR DESCRIPTION
## Problem

The analytics code in `projectownership.py` was only recording 2 events for 3 distinct assignment integration types:

- `codeowners.assignment` - for CODEOWNERS integration
- `issueowners.assignment` - for **both** SUSPECT_COMMITTER and PROJECT_OWNERSHIP integrations

This made it impossible to distinguish between suspect commit assignments and project ownership rule assignments in our analytics, preventing us from measuring the effectiveness of different assignment methods.

## Solution

Add a third distinct analytics event `suspectcommit.assignment` for SUSPECT_COMMITTER integration, following the established naming pattern.

Now we properly track all three integration types:
- `codeowners.assignment` - CODEOWNERS integration  
- `suspectcommit.assignment` - SUSPECT_COMMITTER integration
- `issueowners.assignment` - PROJECT_OWNERSHIP integration