### PR TITLE
fix(grouping): Remove grouping config from `block_invoke` grouping input

### DIFF
--- a/tests/sentry/grouping/grouping_inputs/block_invoke.json
+++ b/tests/sentry/grouping/grouping_inputs/block_invoke.json
@@ -1,10 +1,6 @@
 {
   "platform": "cocoa",
   "message": "Foo",
-  "grouping_config": {
-    "enhancements": "eJybzDRxc15qeXFJZU6qlZGBkbGugaGuoeHsSRNXp_nkp6enFunl5KdPOcvCcJaZ4SwL41lmxkkTN6a5OAElQxKB8imuRUX5RWgK1kIUOJb4pJal5qBJLoNIooluAYo6FhenFpXgNnYnUI1zRmpyNiGFNxVwqvRNLS5OTE9F07Abm-0UK92S5paZk-qcmJyRijMsl6SlJFVMOcsKFmMFiQEAtd-T3A",
-    "id": "newstyle:2023-01-11"
-  },
   "threads": {
     "values": [
       {


### PR DESCRIPTION
The grouping inputs we use for snapshot tests are supposed to mimic data as it comes into our grouping algorithm, and therefore shouldn't contain metadata added during ingest like the `grouping_config` dict. This removes that data from the one input which for some reason contained it.