### PR TITLE
ref(span-buffer): Do not use DB in tests

### DIFF
--- a/src/sentry/spans/consumers/process/flusher.py
+++ b/src/sentry/spans/consumers/process/flusher.py
@@ -425,3 +425,5 @@ class SpanFlusher(ProcessingStrategy[FilteredPayload | int]):
 
             if isinstance(process, multiprocessing.Process):
                 process.terminate()
+
+            assert not process.is_alive()

--- a/src/sentry/spans/consumers/process/flusher.py
+++ b/src/sentry/spans/consumers/process/flusher.py
@@ -425,5 +425,3 @@ class SpanFlusher(ProcessingStrategy[FilteredPayload | int]):
 
             if isinstance(process, multiprocessing.Process):
                 process.terminate()
-
-            assert not process.is_alive()

--- a/tests/sentry/spans/consumers/process/test_consumer.py
+++ b/tests/sentry/spans/consumers/process/test_consumer.py
@@ -2,14 +2,15 @@ from datetime import datetime
 from time import sleep as real_sleep  # Import before monkeypatch
 
 import orjson
-import pytest
 from arroyo.backends.kafka import KafkaPayload
 from arroyo.types import BrokerValue, Message, Partition, Topic
 
 from sentry.spans.consumers.process.factory import ProcessSpansStrategyFactory
+from sentry.testutils.helpers.options import override_options
+from tests.sentry.spans.test_buffer import DEFAULT_OPTIONS
 
 
-@pytest.mark.django_db(transaction=True)
+@override_options({**DEFAULT_OPTIONS, "spans.drop-in-buffer": []})
 def test_basic(monkeypatch):
     # Flush very aggressively to make test pass instantly
     monkeypatch.setattr("time.sleep", lambda _: None)
@@ -32,61 +33,62 @@ def test_basic(monkeypatch):
 
     step = fac.create_with_partitions(add_commit, {Partition(topic, 0): 0})
 
-    step.submit(
-        Message(
-            BrokerValue(
-                partition=Partition(topic, 0),
-                offset=1,
-                payload=KafkaPayload(
-                    None,
-                    orjson.dumps(
-                        {
-                            "project_id": 12,
-                            "span_id": "a" * 16,
-                            "trace_id": "b" * 32,
-                            "end_timestamp_precise": 1700000000.0,
-                        }
+    try:
+        step.submit(
+            Message(
+                BrokerValue(
+                    partition=Partition(topic, 0),
+                    offset=1,
+                    payload=KafkaPayload(
+                        None,
+                        orjson.dumps(
+                            {
+                                "project_id": 12,
+                                "span_id": "a" * 16,
+                                "trace_id": "b" * 32,
+                                "end_timestamp_precise": 1700000000.0,
+                            }
+                        ),
+                        [],
                     ),
-                    [],
-                ),
-                timestamp=datetime.now(),
+                    timestamp=datetime.now(),
+                )
             )
         )
-    )
 
-    step.poll()
-    fac._flusher.current_drift.value = 9000  # "advance" our "clock"
-
-    step.poll()
-    # Give flusher threads time to process after drift change
-    for _ in range(20):
-        if messages:
-            break
         step.poll()
-        real_sleep(0.1)
+        fac._flusher.current_drift.value = 9000  # "advance" our "clock"
 
-    step.join()
+        step.poll()
+        # Give flusher threads time to process after drift change
+        for _ in range(20):
+            if messages:
+                break
+            step.poll()
+            real_sleep(0.1)
 
-    (msg,) = messages
+        (msg,) = messages
 
-    assert orjson.loads(msg.value) == {
-        "spans": [
-            {
-                "data": {
-                    "__sentry_internal_span_buffer_outcome": "different",
+        assert orjson.loads(msg.value) == {
+            "spans": [
+                {
+                    "data": {
+                        "__sentry_internal_span_buffer_outcome": "different",
+                    },
+                    "is_segment": True,
+                    "project_id": 12,
+                    "segment_id": "aaaaaaaaaaaaaaaa",
+                    "span_id": "aaaaaaaaaaaaaaaa",
+                    "trace_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                    "end_timestamp_precise": 1700000000.0,
                 },
-                "is_segment": True,
-                "project_id": 12,
-                "segment_id": "aaaaaaaaaaaaaaaa",
-                "span_id": "aaaaaaaaaaaaaaaa",
-                "trace_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-                "end_timestamp_precise": 1700000000.0,
-            },
-        ],
-    }
+            ],
+        }
+    finally:
+        fac._flusher.join()
 
 
-@pytest.mark.django_db(transaction=True)
+@override_options({**DEFAULT_OPTIONS, "spans.drop-in-buffer": []})
 def test_flusher_processes_limit(monkeypatch):
     """Test that flusher respects the max_processes limit"""
     # Flush very aggressively to make test pass instantly
@@ -113,16 +115,18 @@ def test_flusher_processes_limit(monkeypatch):
 
     # Create with 4 partitions/shards to test process sharing
     partitions = {Partition(topic, i): 0 for i in range(4)}
-    step = fac.create_with_partitions(add_commit, partitions)
-
-    # Verify that flusher uses at most 2 processes
+    fac.create_with_partitions(add_commit, partitions)
     flusher = fac._flusher
-    assert len(flusher.processes) == 2
-    assert flusher.max_processes == 2
-    assert flusher.num_processes == 2
 
-    # Verify shards are distributed across processes
-    total_shards = sum(len(shards) for shards in flusher.process_to_shards_map.values())
-    assert total_shards == 4  # All 4 shards should be assigned
+    try:
+        # Verify that flusher uses at most 2 processes
+        assert len(flusher.processes) == 2
+        assert flusher.max_processes == 2
+        assert flusher.num_processes == 2
 
-    step.join()
+        # Verify shards are distributed across processes
+        total_shards = sum(len(shards) for shards in flusher.process_to_shards_map.values())
+        assert total_shards == 4  # All 4 shards should be assigned
+    finally:
+        # shutdown flusher thread
+        fac._flusher.join()

--- a/tests/sentry/spans/consumers/process/test_flusher.py
+++ b/tests/sentry/spans/consumers/process/test_flusher.py
@@ -35,59 +35,62 @@ def test_backpressure(monkeypatch):
         produce_to_pipe=append,
     )
 
-    now = time.time()
+    try:
+        now = time.time()
 
-    for i in range(200):
-        trace_id = f"{i:0>32x}"
+        for i in range(200):
+            trace_id = f"{i:0>32x}"
 
-        spans = [
-            Span(
-                payload=_payload("a" * 16),
-                trace_id=trace_id,
-                span_id="a" * 16,
-                parent_span_id="b" * 16,
-                project_id=1,
-                end_timestamp_precise=now,
-            ),
-            Span(
-                payload=_payload("d" * 16),
-                trace_id=trace_id,
-                span_id="d" * 16,
-                parent_span_id="b" * 16,
-                project_id=1,
-                end_timestamp_precise=now,
-            ),
-            Span(
-                payload=_payload("c" * 16),
-                trace_id=trace_id,
-                span_id="c" * 16,
-                parent_span_id="b" * 16,
-                project_id=1,
-                end_timestamp_precise=now,
-            ),
-            Span(
-                payload=_payload("b" * 16),
-                trace_id=trace_id,
-                span_id="b" * 16,
-                parent_span_id=None,
-                is_segment_span=True,
-                project_id=1,
-                end_timestamp_precise=now,
-            ),
-        ]
+            spans = [
+                Span(
+                    payload=_payload("a" * 16),
+                    trace_id=trace_id,
+                    span_id="a" * 16,
+                    parent_span_id="b" * 16,
+                    project_id=1,
+                    end_timestamp_precise=now,
+                ),
+                Span(
+                    payload=_payload("d" * 16),
+                    trace_id=trace_id,
+                    span_id="d" * 16,
+                    parent_span_id="b" * 16,
+                    project_id=1,
+                    end_timestamp_precise=now,
+                ),
+                Span(
+                    payload=_payload("c" * 16),
+                    trace_id=trace_id,
+                    span_id="c" * 16,
+                    parent_span_id="b" * 16,
+                    project_id=1,
+                    end_timestamp_precise=now,
+                ),
+                Span(
+                    payload=_payload("b" * 16),
+                    trace_id=trace_id,
+                    span_id="b" * 16,
+                    parent_span_id=None,
+                    is_segment_span=True,
+                    project_id=1,
+                    end_timestamp_precise=now,
+                ),
+            ]
 
-        buffer.process_spans(spans, now=int(now))
+            buffer.process_spans(spans, now=int(now))
 
-    # Advance drift to trigger idle timeout of all segments. The flusher should
-    # have way too much to do due to `max_flush_segments=1` and enter
-    # backpressure state.
+        # Advance drift to trigger idle timeout of all segments. The flusher should
+        # have way too much to do due to `max_flush_segments=1` and enter
+        # backpressure state.
 
-    flusher.current_drift.value = 20000
-    sleep(0.1)
+        flusher.current_drift.value = 20000
+        sleep(0.1)
 
-    assert messages
+        assert messages
 
-    assert any(x.value for x in flusher.process_backpressure_since.values())
+        assert any(x.value for x in flusher.process_backpressure_since.values())
+    finally:
+        flusher.join()
 
 
 def create_memory_producer_factory():


### PR DESCRIPTION
There are some test flakes that I can't figure out. Apparently there is
a thread leak coming from test_flusher.py, but when I simply remove
database access the thread leak disappears.

We don't really need DB access, we can mock out all used options
instead.

fix https://github.com/getsentry/sentry/issues/95793
