### PR TITLE
ref(profiling): improve the handling of profile platform

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -84,7 +84,7 @@ typing-extensions>=4.9.0
 ua-parser>=0.10.0
 unidiff>=0.7.4
 urllib3[brotli]>=2.2.2
-vroomrs==0.1.14
+vroomrs==0.1.15
 pyuwsgi==2.0.28.post1
 zstandard>=0.18.0
 sentry-usage-accountant==0.0.10

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -241,7 +241,7 @@ uritemplate==4.1.1
 urllib3==2.2.2
 vine==5.1.0
 virtualenv==20.26.6
-vroomrs==0.1.14
+vroomrs==0.1.15
 wcwidth==0.2.13
 werkzeug==3.0.6
 wheel==0.38.4

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -152,7 +152,7 @@ unidiff==0.7.4
 uritemplate==4.1.1
 urllib3==2.2.2
 vine==5.1.0
-vroomrs==0.1.14
+vroomrs==0.1.15
 wcwidth==0.2.13
 xmlsec==1.3.14
 zstandard==0.18.0


### PR DESCRIPTION
This bump `vroomrs` to version `0.1.15` which is more kind on the profile platform.

This let us process profiles without having to embed the specific platform we support in the library.

This will let other used easily add support for new platform without us having to release a new `vroomrs` version with the specific platform each time.

see: https://github.com/getsentry/vroomrs/pull/75