### PR TITLE
fix(dynamic-sampling): display minimum sample rate rules correctly in admin

### DIFF
--- a/static/gsAdmin/views/dynamicSamplingPanel.tsx
+++ b/static/gsAdmin/views/dynamicSamplingPanel.tsx
@@ -322,7 +322,10 @@ function DynamicSamplingRulesTable({
   const round = (value: number) => Math.round(value * 10000) / 10000;
 
   const formatSamplingRateValue = (samplingValue: any) => {
-    if (samplingValue.type === 'sampleRate') {
+    if (
+      samplingValue.type === 'sampleRate' ||
+      samplingValue.type === 'minimumSampleRate'
+    ) {
       return `${round(samplingValue.value * 100)}%`;
     }
     if (samplingValue.type === 'reservoir') {

--- a/static/gsAdmin/views/dynamicSamplingPanel.tsx
+++ b/static/gsAdmin/views/dynamicSamplingPanel.tsx
@@ -72,6 +72,7 @@ enum RuleType {
   REBALANCE_TRANSACTIONS = 'Rebalance Transactions', // Boost Low Volume Transactions
   BOOST_REPLAY_ID = 'Boost Replay ID',
   INVESTIGATION_RULE = 'Investigation Rule',
+  MINIMUM_SAMPLE_RATE_TARGET = 'Minimum Sample Rate',
 }
 
 const getRuleType = ({id}: RuleV2): RuleType | undefined => {
@@ -82,6 +83,7 @@ const getRuleType = ({id}: RuleV2): RuleType | undefined => {
     1003: RuleType.BOOST_KEY_TRANSACTIONS,
     1004: RuleType.RECALIBRATION_RULE,
     1005: RuleType.BOOST_REPLAY_ID,
+    1006: RuleType.MINIMUM_SAMPLE_RATE_TARGET,
   };
 
   if (id in RESERVED_IDS) {


### PR DESCRIPTION
- Display the minimumSampleRate rule in the same way as a sampleRate rule - in percent. Currently it shows `* 1` - which is not the correct way to think about it.
Before:
<img width="1241" height="158" alt="Screenshot 2025-07-18 at 13 33 49" src="https://github.com/user-attachments/assets/f83533ad-f7f6-438e-a869-627175e032f0" />

After:
<img width="726" height="161" alt="Screenshot 2025-07-18 at 13 33 36" src="https://github.com/user-attachments/assets/119437d1-f80d-4fb5-b9b2-af539935a9a5" />
