### PR TITLE
ref(performance-onboarding): Remove array index access and render all…

### DIFF
--- a/static/app/gettingStartedDocs/javascript/javascript.tsx
+++ b/static/app/gettingStartedDocs/javascript/javascript.tsx
@@ -870,12 +870,16 @@ const performanceOnboarding: OnboardingConfig<PlatformOptions> = {
   configure: params => [
     {
       type: StepType.CONFIGURE,
-      configurations: [
+      content: [
         {
-          language: 'javascript',
-          description: t(
+          type: 'text',
+          text: t(
             "Configuration should happen as early as possible in your application's lifecycle."
           ),
+        },
+        {
+          type: 'code',
+          language: 'javascript',
           code: `
 import * as Sentry from "@sentry/browser";
 
@@ -894,7 +898,10 @@ Sentry.init({
   sendDefaultPii: true,
 });
 `,
-          additionalInfo: tct(
+        },
+        {
+          type: 'text',
+          text: tct(
             'We recommend adjusting the value of [code:tracesSampleRate] in production. Learn more about tracing [linkTracingOptions:options], how to use the [linkTracesSampler:traces_sampler] function, or how to do [linkSampleTransactions:sampling].',
             {
               code: <code />,
@@ -910,9 +917,14 @@ Sentry.init({
             }
           ),
         },
+      ],
+    },
+    {
+      title: t('Add Distributed Tracing (Optional)'),
+      content: [
         {
-          language: 'javascript',
-          description: tct(
+          type: 'text',
+          text: tct(
             "If you're using the current version of our JavaScript SDK and have enabled the [code: BrowserTracing] integration, distributed tracing will work out of the box. To get around possible [link:Browser CORS] issues, define your [code:tracePropagationTargets].",
             {
               code: <code />,
@@ -921,6 +933,10 @@ Sentry.init({
               ),
             }
           ),
+        },
+        {
+          type: 'code',
+          language: 'javascript',
           code: `
 Sentry.init({
   dsn: "${params.dsn.public}",
@@ -938,14 +954,19 @@ Sentry.init({
   verify: () => [
     {
       type: StepType.VERIFY,
-      description: tct(
-        'Verify that performance monitoring is working correctly with our [link:automatic instrumentation] by simply using your JavaScript application.',
+      content: [
         {
-          link: (
-            <ExternalLink href="https://docs.sentry.io/platforms/javascript/tracing/instrumentation/automatic-instrumentation/" />
+          type: 'text',
+          text: tct(
+            'Verify that performance monitoring is working correctly with our [link:automatic instrumentation] by simply using your JavaScript application.',
+            {
+              link: (
+                <ExternalLink href="https://docs.sentry.io/platforms/javascript/tracing/instrumentation/automatic-instrumentation/" />
+              ),
+            }
           ),
-        }
-      ),
+        },
+      ],
     },
   ],
   nextSteps: () => [],

--- a/static/app/gettingStartedDocs/javascript/nextjs.tsx
+++ b/static/app/gettingStartedDocs/javascript/nextjs.tsx
@@ -403,13 +403,17 @@ const performanceOnboarding: OnboardingConfig = {
   configure: params => [
     {
       type: StepType.CONFIGURE,
-      configurations: [
+      content: [
         {
-          language: 'javascript',
-          description: tct(
+          type: 'text',
+          text: tct(
             'To configure, set [code:tracesSampleRate] in your config files, [code:sentry.server.config.js], [code:sentry.client.config.js], and [code:sentry.edge.config.js]:',
             {code: <code />}
           ),
+        },
+        {
+          type: 'code',
+          language: 'javascript',
           code: `
 import * as Sentry from "@sentry/nextjs";
 
@@ -422,7 +426,10 @@ Sentry.init({
   tracesSampleRate: 1.0,
 });
 `,
-          additionalInfo: tct(
+        },
+        {
+          type: 'text',
+          text: tct(
             'We recommend adjusting the value of [code:tracesSampleRate] in production. Learn more about tracing [linkTracingOptions:options], how to use the [linkTracesSampler:traces_sampler] function, or how to [linkSampleTransactions:sample transactions].',
             {
               code: <code />,
@@ -438,9 +445,14 @@ Sentry.init({
             }
           ),
         },
+      ],
+    },
+    {
+      title: t('Add Distributed Tracing (Optional)'),
+      content: [
         {
-          language: 'javascript',
-          description: tct(
+          type: 'text',
+          text: tct(
             "If you're using the current version of our Next.js SDK, distributed tracing will work out of the box for the client, server, and edge runtimes.[break][break]For client-side you might have to define [code: tracePropagationTargets] to get around possible [link:Browser CORS] issues.",
             {
               break: <br />,
@@ -450,6 +462,10 @@ Sentry.init({
               ),
             }
           ),
+        },
+        {
+          type: 'code',
+          language: 'javascript',
           code: `
 // sentry.client.config.js
 Sentry.init({
@@ -458,7 +474,10 @@ Sentry.init({
   tracePropagationTargets: ["localhost", /^https:\\/\\/yourserver\\.io\\/api/]
 });
 `,
-          additionalInfo: tct(
+        },
+        {
+          type: 'text',
+          text: tct(
             "If you're using version [code:7.57.x] or below, you'll need to have our [link:tracing feature enabled] in order for distributed tracing to work.",
             {
               code: <code />,
@@ -474,14 +493,19 @@ Sentry.init({
   verify: () => [
     {
       type: StepType.VERIFY,
-      description: tct(
-        'Verify that performance monitoring is working correctly with our [link:automatic instrumentation] by simply using your NextJS application.',
+      content: [
         {
-          link: (
-            <ExternalLink href="https://docs.sentry.io/platforms/javascript/guides/nextjs/tracing/instrumentation/automatic-instrumentation/" />
+          type: 'text',
+          text: tct(
+            'Verify that performance monitoring is working correctly with our [link:automatic instrumentation] by simply using your NextJS application.',
+            {
+              link: (
+                <ExternalLink href="https://docs.sentry.io/platforms/javascript/guides/nextjs/tracing/instrumentation/automatic-instrumentation/" />
+              ),
+            }
           ),
-        }
-      ),
+        },
+      ],
     },
   ],
   nextSteps: () => [],

--- a/static/app/gettingStartedDocs/javascript/react-router.tsx
+++ b/static/app/gettingStartedDocs/javascript/react-router.tsx
@@ -452,11 +452,15 @@ const performanceOnboarding: OnboardingConfig = {
   configure: params => [
     {
       type: StepType.CONFIGURE,
-      configurations: [
+      content: [
         {
-          description: t(
+          type: 'text',
+          text: t(
             "Configuration should happen as early as possible in your application's lifecycle."
           ),
+        },
+        {
+          type: 'code',
           language: 'tsx',
           code: getClientSetupSnippet(params),
         },
@@ -466,14 +470,19 @@ const performanceOnboarding: OnboardingConfig = {
   verify: () => [
     {
       type: StepType.VERIFY,
-      description: tct(
-        'Verify that performance monitoring is working correctly with our [link:automatic instrumentation] by simply using your React Router application.',
+      content: [
         {
-          link: (
-            <ExternalLink href="https://docs.sentry.io/platforms/javascript/guides/react-router/tracing/instrumentation/automatic-instrumentation/" />
+          type: 'text',
+          text: tct(
+            'Verify that performance monitoring is working correctly with our [link:automatic instrumentation] by simply using your React Router application.',
+            {
+              link: (
+                <ExternalLink href="https://docs.sentry.io/platforms/javascript/guides/react-router/tracing/instrumentation/automatic-instrumentation/" />
+              ),
+            }
           ),
-        }
-      ),
+        },
+      ],
     },
   ],
   nextSteps: () => [],

--- a/static/app/gettingStartedDocs/javascript/react.tsx
+++ b/static/app/gettingStartedDocs/javascript/react.tsx
@@ -496,12 +496,16 @@ const performanceOnboarding: OnboardingConfig = {
   configure: params => [
     {
       type: StepType.CONFIGURE,
-      configurations: [
+      content: [
         {
-          language: 'javascript',
-          description: t(
+          type: 'text',
+          text: t(
             "Configuration should happen as early as possible in your application's lifecycle."
           ),
+        },
+        {
+          type: 'code',
+          language: 'javascript',
           code: `
 import React from "react";
 import ReactDOM from "react-dom";
@@ -525,7 +529,10 @@ ReactDOM.render(<App />, document.getElementById("root"));
 // Can also use with React Concurrent Mode
 // ReactDOM.createRoot(document.getElementById('root')).render(<App />);
 `,
-          additionalInfo: tct(
+        },
+        {
+          type: 'text',
+          text: tct(
             'We recommend adjusting the value of [code:tracesSampleRate] in production. Learn more about tracing [linkTracingOptions:options], how to use the [linkTracesSampler:traces_sampler] function, or how to do [linkSampleTransactions:sampling].',
             {
               code: <code />,
@@ -541,9 +548,14 @@ ReactDOM.render(<App />, document.getElementById("root"));
             }
           ),
         },
+      ],
+    },
+    {
+      title: t('Add Distributed Tracing (Optional)'),
+      content: [
         {
-          language: 'javascript',
-          description: tct(
+          type: 'text',
+          text: tct(
             "If you're using the current version of our JavaScript SDK and have enabled the [code: BrowserTracing] integration, distributed tracing will work out of the box. To get around possible [link:Browser CORS] issues, define your [code:tracePropagationTargets].",
             {
               code: <code />,
@@ -552,6 +564,10 @@ ReactDOM.render(<App />, document.getElementById("root"));
               ),
             }
           ),
+        },
+        {
+          type: 'code',
+          language: 'javascript',
           code: `
 Sentry.init({
   dsn: "${params.dsn.public}",
@@ -566,14 +582,19 @@ Sentry.init({
   verify: () => [
     {
       type: StepType.VERIFY,
-      description: tct(
-        'Verify that performance monitoring is working correctly with our [link:automatic instrumentation] by simply using your React application.',
+      content: [
         {
-          link: (
-            <ExternalLink href="https://docs.sentry.io/platforms/javascript/guides/react/tracing/instrumentation/automatic-instrumentation/" />
+          type: 'text',
+          text: tct(
+            'Verify that performance monitoring is working correctly with our [link:automatic instrumentation] by simply using your React application.',
+            {
+              link: (
+                <ExternalLink href="https://docs.sentry.io/platforms/javascript/guides/react/tracing/instrumentation/automatic-instrumentation/" />
+              ),
+            }
           ),
-        }
-      ),
+        },
+      ],
     },
   ],
   nextSteps: () => [],

--- a/static/app/gettingStartedDocs/node/node.tsx
+++ b/static/app/gettingStartedDocs/node/node.tsx
@@ -300,17 +300,24 @@ const performanceOnboarding: OnboardingConfig = {
   configure: params => [
     {
       type: StepType.CONFIGURE,
-      description: tct(
-        'Sentry should be initialized as early in your app as possible. It is essential that you call [code:Sentry.init] before you require any other modules in your application—otherwise, auto-instrumentation of these modules will [strong:not] work.',
-        {code: <code />, strong: <strong />}
-      ),
-      configurations: [
+      content: [
         {
-          description: tct(
+          type: 'text',
+          text: tct(
+            'Sentry should be initialized as early in your app as possible. It is essential that you call [code:Sentry.init] before you require any other modules in your application—otherwise, auto-instrumentation of these modules will [strong:not] work.',
+            {code: <code />, strong: <strong />}
+          ),
+        },
+        {
+          type: 'text',
+          text: tct(
             'To initialize the SDK before everything else, create an external file called [code:instrument.js/mjs] and make sure to import it in your apps entrypoint before anything else.',
             {code: <code />}
           ),
-          code: [
+        },
+        {
+          type: 'code',
+          tabs: [
             {
               label: 'JavaScript',
               value: 'javascript',
@@ -319,7 +326,10 @@ const performanceOnboarding: OnboardingConfig = {
               code: getSdkInitSnippet(params, 'node'),
             },
           ],
-          additionalInfo: tct(
+        },
+        {
+          type: 'text',
+          text: tct(
             'We recommend adjusting the value of [code:tracesSampleRate] in production. Learn more about tracing [linkTracingOptions:options], how to use the [linkTracesSampler:traces_sampler] function, or how to [linkSampleTransactions:sample transactions].',
             {
               code: <code />,
@@ -341,22 +351,30 @@ const performanceOnboarding: OnboardingConfig = {
   verify: () => [
     {
       type: StepType.VERIFY,
-      description: tct(
-        'Verify that performance monitoring is working correctly with our [link:automatic instrumentation] by simply using your Node application.',
+      content: [
         {
-          link: (
-            <ExternalLink href="https://docs.sentry.io/platforms/javascript/guides/node/tracing/instrumentation/automatic-instrumentation/" />
+          type: 'text',
+          text: tct(
+            'Verify that performance monitoring is working correctly with our [link:automatic instrumentation] by simply using your Node application.',
+            {
+              link: (
+                <ExternalLink href="https://docs.sentry.io/platforms/javascript/guides/node/tracing/instrumentation/automatic-instrumentation/" />
+              ),
+            }
           ),
-        }
-      ),
-      additionalInfo: tct(
-        'You have the option to manually construct a transaction using [link:custom instrumentation].',
+        },
         {
-          link: (
-            <ExternalLink href="https://docs.sentry.io/platforms/javascript/guides/node/tracing/instrumentation/custom-instrumentation/" />
+          type: 'text',
+          text: tct(
+            'You have the option to manually construct a transaction using [link:custom instrumentation].',
+            {
+              link: (
+                <ExternalLink href="https://docs.sentry.io/platforms/javascript/guides/node/tracing/instrumentation/custom-instrumentation/" />
+              ),
+            }
           ),
-        }
-      ),
+        },
+      ],
     },
   ],
   nextSteps: () => [],

--- a/static/app/gettingStartedDocs/php/php.tsx
+++ b/static/app/gettingStartedDocs/php/php.tsx
@@ -160,15 +160,22 @@ const performanceOnboarding: OnboardingConfig = {
   configure: params => [
     {
       type: StepType.CONFIGURE,
-      description: t(
-        'To capture all errors and transactions, even the one during the startup of your application, you should initialize the Sentry PHP SDK as soon as possible.'
-      ),
-      configurations: [
+      content: [
         {
-          description: tct(
+          type: 'text',
+          text: t(
+            'To capture all errors and transactions, even the one during the startup of your application, you should initialize the Sentry PHP SDK as soon as possible.'
+          ),
+        },
+        {
+          type: 'text',
+          text: tct(
             'To initialize the SDK before everything else, create an external file called [code:instrument.js/mjs] and make sure to import it in your apps entrypoint before anything else.',
             {code: <code />}
           ),
+        },
+        {
+          type: 'code',
           language: 'php',
           code: `
 \\Sentry\\init([
@@ -179,7 +186,10 @@ const performanceOnboarding: OnboardingConfig = {
   'traces_sample_rate' => 1.0,
 ]);
 `,
-          additionalInfo: tct(
+        },
+        {
+          type: 'text',
+          text: tct(
             'We recommend adjusting the value of [code:tracesSampleRate] in production. Learn more about tracing [linkTracingOptions:options], how to use the [linkTracesSampler:traces_sampler] function, or how to do [linkSampleTransactions:sampling].',
             {
               code: <code />,
@@ -201,14 +211,19 @@ const performanceOnboarding: OnboardingConfig = {
   verify: () => [
     {
       type: StepType.VERIFY,
-      description: tct(
-        'Verify that performance monitoring is working correctly with our [link:automatic instrumentation] by simply using your Node application.',
+      content: [
         {
-          link: (
-            <ExternalLink href="https://docs.sentry.io/platforms/php/tracing/instrumentation/automatic-instrumentation/" />
+          type: 'text',
+          text: tct(
+            'Verify that performance monitoring is working correctly with our [link:automatic instrumentation] by simply using your Node application.',
+            {
+              link: (
+                <ExternalLink href="https://docs.sentry.io/platforms/php/tracing/instrumentation/automatic-instrumentation/" />
+              ),
+            }
           ),
-        }
-      ),
+        },
+      ],
     },
   ],
   nextSteps: () => [],

--- a/static/app/gettingStartedDocs/python/django.tsx
+++ b/static/app/gettingStartedDocs/python/django.tsx
@@ -156,13 +156,17 @@ const performanceOnboarding: OnboardingConfig = {
   configure: params => [
     {
       type: StepType.CONFIGURE,
-      configurations: [
+      content: [
         {
-          language: 'python',
-          description: tct(
+          type: 'text',
+          text: tct(
             'To configure the Sentry SDK, initialize it in your [code:settings.py] file:',
             {code: <code />}
           ),
+        },
+        {
+          type: 'code',
+          language: 'python',
           code: `
 import sentry_sdk
 
@@ -173,7 +177,10 @@ sentry_sdk.init(
   // of transactions for performance monitoring.
   traces_sample_rate=1.0,
 )`,
-          additionalInfo: tct(
+        },
+        {
+          type: 'text',
+          text: tct(
             'Learn more about tracing [linkTracingOptions:options], how to use the [linkTracesSampler:traces_sampler] function, or how to do [linkSampleTransactions:sampling].',
             {
               linkTracingOptions: (
@@ -194,14 +201,19 @@ sentry_sdk.init(
   verify: () => [
     {
       type: StepType.VERIFY,
-      description: tct(
-        'Verify that performance monitoring is working correctly with our [link:automatic instrumentation] by simply using your Python application.',
+      content: [
         {
-          link: (
-            <ExternalLink href="https://docs.sentry.io/platforms/python/tracing/instrumentation/automatic-instrumentation/" />
+          type: 'text',
+          text: tct(
+            'Verify that performance monitoring is working correctly with our [link:automatic instrumentation] by simply using your Python application.',
+            {
+              link: (
+                <ExternalLink href="https://docs.sentry.io/platforms/python/tracing/instrumentation/automatic-instrumentation/" />
+              ),
+            }
           ),
-        }
-      ),
+        },
+      ],
     },
   ],
   nextSteps: () => [],

--- a/static/app/gettingStartedDocs/python/flask.tsx
+++ b/static/app/gettingStartedDocs/python/flask.tsx
@@ -164,13 +164,17 @@ const performanceOnboarding: OnboardingConfig = {
   configure: params => [
     {
       type: StepType.CONFIGURE,
-      configurations: [
+      content: [
         {
-          language: 'python',
-          description: tct(
+          type: 'text',
+          text: tct(
             'To configure the Sentry SDK, initialize it in your [code:settings.py] file:',
             {code: <code />}
           ),
+        },
+        {
+          type: 'code',
+          language: 'python',
           code: `
 import sentry-sdk
 
@@ -180,7 +184,10 @@ sentry_sdk.init(
     # of transactions for performance monitoring.
     traces_sample_rate=1.0,
 )`,
-          additionalInfo: tct(
+        },
+        {
+          type: 'text',
+          text: tct(
             'Learn more about tracing [linkTracingOptions:options], how to use the [linkTracesSampler:traces_sampler] function, or how to [linkSampleTransactions:sample transactions].',
             {
               linkTracingOptions: (
@@ -201,14 +208,19 @@ sentry_sdk.init(
   verify: () => [
     {
       type: StepType.VERIFY,
-      description: tct(
-        'Verify that performance monitoring is working correctly with our [link:automatic instrumentation] by simply using your Python application.',
+      content: [
         {
-          link: (
-            <ExternalLink href="https://docs.sentry.io/platforms/python/tracing/instrumentation/automatic-instrumentation/" />
+          type: 'text',
+          text: tct(
+            'Verify that performance monitoring is working correctly with our [link:automatic instrumentation] by simply using your Python application.',
+            {
+              link: (
+                <ExternalLink href="https://docs.sentry.io/platforms/python/tracing/instrumentation/automatic-instrumentation/" />
+              ),
+            }
           ),
-        }
-      ),
+        },
+      ],
     },
   ],
   nextSteps: () => [],

--- a/static/app/gettingStartedDocs/python/python.tsx
+++ b/static/app/gettingStartedDocs/python/python.tsx
@@ -269,15 +269,22 @@ export const performanceOnboarding: OnboardingConfig = {
   configure: params => [
     {
       type: StepType.CONFIGURE,
-      description: t(
-        "Configuration should happen as early as possible in your application's lifecycle."
-      ),
-      configurations: [
+      content: [
         {
-          description: tct(
+          type: 'text',
+          text: t(
+            "Configuration should happen as early as possible in your application's lifecycle."
+          ),
+        },
+        {
+          type: 'text',
+          text: tct(
             "Once this is done, Sentry's Python SDK captures all unhandled exceptions and transactions. To enable tracing, use [code:traces_sample_rate=1.0] in the sentry_sdk.init() call.",
             {code: <code />}
           ),
+        },
+        {
+          type: 'code',
           language: 'python',
           code: `
 import sentry_sdk
@@ -288,7 +295,10 @@ sentry_sdk.init(
     # of transactions for tracing.
     traces_sample_rate=1.0,
 )`,
-          additionalInfo: tct(
+        },
+        {
+          type: 'text',
+          text: tct(
             'Learn more about tracing [linkTracingOptions:options], how to use the [linkTracesSampler:traces_sampler] function, or how to [linkSampleTransactions:sample transactions].',
             {
               linkTracingOptions: (
@@ -309,22 +319,30 @@ sentry_sdk.init(
   verify: () => [
     {
       type: StepType.VERIFY,
-      description: tct(
-        'Verify that performance monitoring is working correctly with our [link:automatic instrumentation] by simply using your Python application.',
+      content: [
         {
-          link: (
-            <ExternalLink href="https://docs.sentry.io/platforms/python/tracing/instrumentation/automatic-instrumentation/" />
+          type: 'text',
+          text: tct(
+            'Verify that performance monitoring is working correctly with our [link:automatic instrumentation] by simply using your Python application.',
+            {
+              link: (
+                <ExternalLink href="https://docs.sentry.io/platforms/python/tracing/instrumentation/automatic-instrumentation/" />
+              ),
+            }
           ),
-        }
-      ),
-      additionalInfo: tct(
-        'You have the option to manually construct a transaction using [link:custom instrumentation].',
+        },
         {
-          link: (
-            <ExternalLink href="https://docs.sentry.io/platforms/python/tracing/instrumentation/custom-instrumentation/" />
+          type: 'text',
+          text: tct(
+            'You have the option to manually construct a transaction using [link:custom instrumentation].',
+            {
+              link: (
+                <ExternalLink href="https://docs.sentry.io/platforms/python/tracing/instrumentation/custom-instrumentation/" />
+              ),
+            }
           ),
-        }
-      ),
+        },
+      ],
     },
   ],
   nextSteps: () => [],

--- a/static/app/views/performance/onboarding.tsx
+++ b/static/app/views/performance/onboarding.tsx
@@ -37,7 +37,10 @@ import type {
   ContentBlock,
   DocsParams,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
-import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {
+  ProductSolution,
+  StepType,
+} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {useSourcePackageRegistries} from 'sentry/components/onboarding/gettingStartedDoc/useSourcePackageRegistries';
 import {useLoadGettingStarted} from 'sentry/components/onboarding/gettingStartedDoc/utils/useLoadGettingStarted';
 import LegacyOnboardingPanel from 'sentry/components/onboardingPanel';
@@ -345,29 +348,29 @@ const ButtonList = styled(ButtonBar)`
   margin-bottom: 16px;
 `;
 
-function WaitingIndicator({
-  api,
-  organization,
-  project,
-}: {
-  api: Client;
-  organization: Organization;
-  project: Project;
-}) {
-  const [received, setReceived] = useState<boolean>(false);
-
+function ConfigurationRenderer({configuration}: {configuration: Configuration}) {
+  const subConfigurations = configuration.configurations ?? [];
   return (
-    <EventWaiter
-      api={api}
-      organization={organization}
-      project={project}
-      eventType="transaction"
-      onIssueReceived={() => {
-        setReceived(true);
-      }}
-    >
-      {() => (received ? <EventReceivedIndicator /> : <EventWaitingIndicator />)}
-    </EventWaiter>
+    <ConfigurationWrapper>
+      {configuration.description && (
+        <DescriptionWrapper>{configuration.description}</DescriptionWrapper>
+      )}
+      {configuration.code ? (
+        Array.isArray(configuration.code) ? (
+          <TabbedCodeSnippet tabs={configuration.code} />
+        ) : (
+          <OnboardingCodeSnippet language={configuration.language}>
+            {configuration.code}
+          </OnboardingCodeSnippet>
+        )
+      ) : null}
+      {subConfigurations.map((subConfiguration, index) => (
+        <ConfigurationRenderer key={index} configuration={subConfiguration} />
+      ))}
+      {configuration.additionalInfo && (
+        <AdditionalInfo>{configuration.additionalInfo}</AdditionalInfo>
+      )}
+    </ConfigurationWrapper>
   );
 }
 
@@ -382,64 +385,6 @@ function RenderBlocksOrFallback({
     return <ContentBlocksRenderer spacing={space(1)} contentBlocks={contentBlocks} />;
   }
   return children;
-}
-
-type ConfigurationStepProps = {
-  api: Client;
-  configuration: Configuration;
-  organization: Organization;
-  project: Project;
-  showWaitingIndicator: boolean;
-  stepKey: string;
-  title: React.ReactNode;
-  contentBlocks?: ContentBlock[];
-};
-
-function ConfigurationStep({
-  stepKey,
-  title,
-  api,
-  organization,
-  project,
-  contentBlocks,
-  configuration,
-  showWaitingIndicator,
-}: ConfigurationStepProps) {
-  return (
-    <GuidedSteps.Step stepKey={stepKey} title={title}>
-      <div>
-        <RenderBlocksOrFallback contentBlocks={contentBlocks}>
-          <DescriptionWrapper>{configuration.description}</DescriptionWrapper>
-          <CodeSnippetWrapper>
-            {configuration.code ? (
-              Array.isArray(configuration.code) ? (
-                <TabbedCodeSnippet tabs={configuration.code} />
-              ) : (
-                <OnboardingCodeSnippet language={configuration.language}>
-                  {configuration.code}
-                </OnboardingCodeSnippet>
-              )
-            ) : null}
-          </CodeSnippetWrapper>
-          <CodeSnippetWrapper>
-            {configuration.configurations && configuration.configurations.length > 0 ? (
-              Array.isArray(configuration.configurations[0]!.code) ? (
-                <TabbedCodeSnippet tabs={configuration.configurations[0]!.code} />
-              ) : null
-            ) : null}
-          </CodeSnippetWrapper>
-          <DescriptionWrapper>{configuration.additionalInfo}</DescriptionWrapper>
-          {showWaitingIndicator ? (
-            <WaitingIndicator api={api} organization={organization} project={project} />
-          ) : null}
-        </RenderBlocksOrFallback>
-        <GuidedSteps.ButtonWrapper>
-          <GuidedSteps.BackButton size="md" />
-          <GuidedSteps.NextButton size="md" />
-        </GuidedSteps.ButtonWrapper>
-      </div>
-    </GuidedSteps.Step>
-  );
 }
 
 function OnboardingPanel({
@@ -500,6 +445,12 @@ function OnboardingPanel({
     </Panel>
   );
 }
+
+const STEP_TITLES: Record<StepType, string> = {
+  [StepType.INSTALL]: t('Install Sentry'),
+  [StepType.CONFIGURE]: t('Configure Sentry'),
+  [StepType.VERIFY]: t('Verify Sentry'),
+};
 
 export function Onboarding({organization, project}: OnboardingProps) {
   const api = useApi();
@@ -649,13 +600,11 @@ export function Onboarding({organization, project}: OnboardingProps) {
     isSelfHosted,
   };
 
-  const installStep = performanceDocs.install(docParams)[0]!;
+  const installSteps = performanceDocs.install(docParams);
+  const configureSteps = performanceDocs.configure(docParams);
+  const verifySteps = performanceDocs.verify(docParams);
 
-  const configureStep = performanceDocs.configure(docParams)[0]!;
-  const [sentryConfiguration, addingDistributedTracing] = configureStep.configurations!;
-
-  const verifyStep = performanceDocs.verify(docParams)[0]!;
-  const hasVerifyStep = !!(verifyStep.configurations || verifyStep.description);
+  const steps = [...installSteps, ...configureSteps, ...verifySteps];
 
   const eventWaitingIndicator = (
     <EventWaiter
@@ -688,116 +637,56 @@ export function Onboarding({organization, project}: OnboardingProps) {
           });
         }}
       >
-        <GuidedSteps.Step stepKey="install-sentry" title={t('Install Sentry')}>
-          <div>
-            <RenderBlocksOrFallback contentBlocks={installStep.content}>
-              <DescriptionWrapper>{installStep.description}</DescriptionWrapper>
-              {installStep.configurations?.map((configuration, index) => (
-                <div key={index}>
-                  <DescriptionWrapper>{configuration.description}</DescriptionWrapper>
-                  <CodeSnippetWrapper>
-                    {configuration.code ? (
-                      Array.isArray(configuration.code) ? (
-                        <TabbedCodeSnippet tabs={configuration.code} />
-                      ) : (
-                        <OnboardingCodeSnippet language={configuration.language}>
-                          {configuration.code}
-                        </OnboardingCodeSnippet>
-                      )
-                    ) : null}
-                  </CodeSnippetWrapper>
-                </div>
-              ))}
-              {!configureStep.configurations && !verifyStep.configurations
-                ? eventWaitingIndicator
-                : null}
-            </RenderBlocksOrFallback>
-            <GuidedSteps.ButtonWrapper>
-              <GuidedSteps.BackButton size="md" />
-              <GuidedSteps.NextButton size="md" />
-            </GuidedSteps.ButtonWrapper>
-          </div>
-        </GuidedSteps.Step>
-        {sentryConfiguration ? (
-          <ConfigurationStep
-            stepKey={'configure-sentry'}
-            title={t('Configure Sentry')}
-            configuration={sentryConfiguration}
-            api={api}
-            organization={organization}
-            project={project}
-            showWaitingIndicator={!hasVerifyStep}
-          />
-        ) : null}
-        {addingDistributedTracing ? (
-          <ConfigurationStep
-            stepKey={'add-distributed-tracing'}
-            title={tct('Add Distributed Tracing [optional:(Optional)]', {
-              optional: <OptionalText />,
-            })}
-            configuration={addingDistributedTracing}
-            api={api}
-            organization={organization}
-            project={project}
-            showWaitingIndicator={!hasVerifyStep}
-          />
-        ) : null}
-        {verifyStep.configurations || verifyStep.description ? (
-          <GuidedSteps.Step stepKey="verify-sentry" title={t('Verify')}>
-            <RenderBlocksOrFallback contentBlocks={verifyStep.content}>
-              <DescriptionWrapper>{verifyStep.description}</DescriptionWrapper>
-              {verifyStep.configurations?.map((configuration, index) => (
-                <div key={index}>
-                  <DescriptionWrapper>{configuration.description}</DescriptionWrapper>
-                  <CodeSnippetWrapper>
-                    {configuration.code ? (
-                      Array.isArray(configuration.code) ? (
-                        <TabbedCodeSnippet tabs={configuration.code} />
-                      ) : (
-                        <OnboardingCodeSnippet language={configuration.language}>
-                          {configuration.code}
-                        </OnboardingCodeSnippet>
-                      )
-                    ) : null}
-                  </CodeSnippetWrapper>
-                </div>
-              ))}
-              {eventWaitingIndicator}
-            </RenderBlocksOrFallback>
-            <GuidedSteps.ButtonWrapper>
-              <GuidedSteps.BackButton size="md" />
-              {received ? (
-                <Button
-                  priority="primary"
-                  busy={!traceId}
-                  title={traceId ? undefined : t('Processing trace\u2026')}
-                  onClick={() => {
-                    const params = new URLSearchParams(window.location.search);
-                    params.set('table', Tab.TRACE);
-                    params.set('query', `trace:${traceId}`);
-                    params.delete('guidedStep');
-                    testableWindowLocation.assign(
-                      `${window.location.pathname}?${params.toString()}`
-                    );
-                  }}
-                >
-                  {t('Take me to my trace')}
-                </Button>
-              ) : isEAPTraceEnabled ? null : (
-                <SampleButton
-                  triggerText={t('Take me to an example')}
-                  loadingMessage={t('Processing sample trace...')}
-                  errorMessage={t('Failed to create sample trace')}
-                  organization={organization}
-                  project={project}
-                  api={api}
-                />
+        {steps.map((step, index) => {
+          const title = step.title ?? STEP_TITLES[step.type];
+          return (
+            <GuidedSteps.Step key={title} stepKey={title} title={title}>
+              <RenderBlocksOrFallback contentBlocks={step.content}>
+                <ConfigurationRenderer configuration={step} />
+              </RenderBlocksOrFallback>
+              {index === steps.length - 1 ? (
+                <Fragment>
+                  {eventWaitingIndicator}
+                  <GuidedSteps.ButtonWrapper>
+                    <GuidedSteps.BackButton size="md" />
+                    {received ? (
+                      <Button
+                        priority="primary"
+                        busy={!traceId}
+                        title={traceId ? undefined : t('Processing trace\u2026')}
+                        onClick={() => {
+                          const params = new URLSearchParams(window.location.search);
+                          params.set('table', Tab.TRACE);
+                          params.set('query', `trace:${traceId}`);
+                          params.delete('guidedStep');
+                          testableWindowLocation.assign(
+                            `${window.location.pathname}?${params.toString()}`
+                          );
+                        }}
+                      >
+                        {t('Take me to my trace')}
+                      </Button>
+                    ) : isEAPTraceEnabled ? null : (
+                      <SampleButton
+                        triggerText={t('Take me to an example')}
+                        loadingMessage={t('Processing sample trace...')}
+                        errorMessage={t('Failed to create sample trace')}
+                        organization={organization}
+                        project={project}
+                        api={api}
+                      />
+                    )}
+                  </GuidedSteps.ButtonWrapper>
+                </Fragment>
+              ) : (
+                <GuidedSteps.ButtonWrapper>
+                  <GuidedSteps.BackButton size="md" />
+                  <GuidedSteps.NextButton size="md" />
+                </GuidedSteps.ButtonWrapper>
               )}
-            </GuidedSteps.ButtonWrapper>
-          </GuidedSteps.Step>
-        ) : (
-          <Fragment />
-        )}
+            </GuidedSteps.Step>
+          );
+        })}
       </GuidedSteps>
     </OnboardingPanel>
   );
@@ -821,11 +710,6 @@ const EventWaitingIndicator = styled((p: React.HTMLAttributes<HTMLDivElement>) =
 const PulsingIndicator = styled('div')`
   ${pulsingIndicatorStyles};
   margin-left: ${space(1)};
-`;
-
-const OptionalText = styled('span')`
-  color: ${p => p.theme.purple300};
-  font-weight: ${p => p.theme.fontWeight.normal};
 `;
 
 const EventReceivedIndicator = styled((p: React.HTMLAttributes<HTMLDivElement>) => (
@@ -932,14 +816,37 @@ const Arcade = styled('iframe')`
   border: 0;
 `;
 
-const CodeSnippetWrapper = styled('div')`
-  margin-bottom: ${space(2)};
+const CONTENT_SPACING = space(1);
+
+const ConfigurationWrapper = styled('div')`
+  margin-bottom: ${CONTENT_SPACING};
 `;
 
 const DescriptionWrapper = styled('div')`
-  margin-bottom: ${space(1)};
-
-  code {
+  code:not([class*='language-']) {
     color: ${p => p.theme.pink400};
   }
+
+  :not(:last-child) {
+    margin-bottom: ${CONTENT_SPACING};
+  }
+
+  && > h4,
+  && > h5,
+  && > h6 {
+    font-size: ${p => p.theme.fontSize.xl};
+    font-weight: ${p => p.theme.fontWeight.bold};
+    line-height: 34px;
+  }
+
+  && > * {
+    margin: 0;
+    &:not(:last-child) {
+      margin-bottom: ${CONTENT_SPACING};
+    }
+  }
+`;
+
+const AdditionalInfo = styled(DescriptionWrapper)`
+  margin-top: ${CONTENT_SPACING};
 `;


### PR DESCRIPTION
Simplify the performance onboarding to just render the defined steps instead of accessing specific array elements.
This allows us to refactor the onboarding structure now and in the future.
Update the profiling onboarding docs to use the new content block structure

- closes [TET-917: Refactor performance onboarding to remove direct array access](https://linear.app/getsentry/issue/TET-917/refactor-performance-onboarding-to-remove-direct-array-access)
- part of [TET-761: Docs: Move from configuration objects to content blocks](https://linear.app/getsentry/issue/TET-761/docs-move-from-configuration-objects-to-content-blocks)