### PR TITLE
ref(profiling): implement chunked profile candidate query for flamegraph

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -88,6 +88,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("projects:continuous-profiling-vroomrs-processing", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable transaction profiles processing with vroomrs
     manager.add("projects:transaction-profiling-vroomrs-processing", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Enable querying profile candidates with exponentially growing datetime range chunks
+    manager.add("organizations:profiling-flamegraph-use-increased-chunks-query-strategy", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable daily summary
     manager.add("organizations:daily-summary", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enables import/export functionality for dashboards

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -89,7 +89,7 @@ def register_temporary_features(manager: FeatureManager):
     # Enable transaction profiles processing with vroomrs
     manager.add("projects:transaction-profiling-vroomrs-processing", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable querying profile candidates with exponentially growing datetime range chunks
-    manager.add("organizations:profiling-flamegraph-use-increased-chunks-query-strategy", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    manager.add("organizations:profiling-flamegraph-use-increased-chunks-query-strategy", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable daily summary
     manager.add("organizations:daily-summary", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enables import/export functionality for dashboards

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2556,6 +2556,24 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# the duration of the first datetime chunk of data queried
+# expressed in hours.
+register(
+    "profiling.flamegraph.query.initial_chunk_delta.hours",
+    type=Int,
+    default=12,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
+# the max duration of any datetime chunk of data queried
+# expressed in hours.
+register(
+    "profiling.flamegraph.query.max_delta.hours",
+    type=Int,
+    default=48,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # list of platform names for which we allow using unsampled profiles for the purpose
 # of improving profile (function) metrics
 register(

--- a/src/sentry/profiles/flamegraph.py
+++ b/src/sentry/profiles/flamegraph.py
@@ -21,7 +21,6 @@ from snuba_sdk import (
 )
 
 from sentry import features, options
-from sentry.models.organization import Organization
 from sentry.search.eap.types import EAPResponse, SearchResolverConfig
 from sentry.search.events.builder.discover import DiscoverQueryBuilder
 from sentry.search.events.builder.profile_functions import ProfileFunctionsQueryBuilder
@@ -103,18 +102,16 @@ class FlamegraphExecutor:
         if self.data_source == "functions":
             return self.get_profile_candidates_from_functions()
         elif self.data_source == "transactions":
-            organization = Organization.objects.get_from_cache(id=self.snuba_params.organization_id)
             if features.has(
                 "organizations:profiling-flamegraph-use-increased-chunks-query-strategy",
-                organization,
+                self.snuba_params.organization,
             ):
                 return self.get_profile_candidates_from_transactions_v2()
             return self.get_profile_candidates_from_transactions()
         elif self.data_source == "profiles":
-            organization = Organization.objects.get_from_cache(id=self.snuba_params.organization_id)
             if features.has(
                 "organizations:profiling-flamegraph-use-increased-chunks-query-strategy",
-                organization,
+                self.snuba_params.organization,
             ):
                 return self.get_profile_candidates_from_profiles_v2()
             return self.get_profile_candidates_from_profiles()

--- a/src/sentry/profiles/flamegraph.py
+++ b/src/sentry/profiles/flamegraph.py
@@ -249,9 +249,10 @@ class FlamegraphExecutor:
         profiler_metas: list[ProfilerMeta] = []
 
         assert self.snuba_params.start is not None and self.snuba_params.end is not None
+        original_start, original_end = self.snuba_params.start, self.snuba_params.end
 
         for chunk_start, chunk_end in split_datetime_range_exponential(
-            self.snuba_params.start, self.snuba_params.end, initial_chunk_delta, max_chunk_delta
+            original_start, original_end, initial_chunk_delta, max_chunk_delta
         ):
             self.snuba_params.start = chunk_start
             self.snuba_params.end = chunk_end
@@ -650,7 +651,7 @@ class FlamegraphExecutor:
         original_start, original_end = self.snuba_params.start, self.snuba_params.end
 
         for chunk_start, chunk_end in split_datetime_range_exponential(
-            self.snuba_params.start, self.snuba_params.end, initial_chunk_delta, max_chunk_delta
+            original_start, original_end, initial_chunk_delta, max_chunk_delta
         ):
             self.snuba_params.start = chunk_start
             self.snuba_params.end = chunk_end

--- a/src/sentry/profiles/flamegraph.py
+++ b/src/sentry/profiles/flamegraph.py
@@ -765,13 +765,9 @@ class FlamegraphExecutor:
                 total_duration += end - start
 
                 # can set max duration to negative to skip this check
-                if (
-                    max_duration >= 0
-                    and total_duration >= max_duration
-                    or (
-                        len(continuous_profile_candidates) + len(transaction_profile_candidates)
-                        >= max_profiles
-                    )
+                if (max_duration >= 0 and total_duration >= max_duration) or (
+                    len(continuous_profile_candidates) + len(transaction_profile_candidates)
+                    >= max_profiles
                 ):
                     break
 


### PR DESCRIPTION
This PR introduces an optimized chunked querying strategy for profile flamegraphs that improves performance when querying large time ranges. Instead of querying the entire datetime range at once, the new approach splits queries into exponentially growing chunks, starting with smaller intervals and potentially finding sufficient data without needing to query the full range.

Key Changes:

* Added feature flag `organizations:profiling-flamegraph-use-increased-chunks-query-strategy` for gradual rollout
* Added configurable options for initial chunk size (12h default) and maximum chunk size (48h default)
* Implemented `get_profile_candidates_from_transactions_v2()` and `get_profile_candidates_from_profiles_v2()` methods with chunked querying logic
* Early termination when sufficient profile candidates are found, reducing unnecessary queries