### PR TITLE
chore: Just wrap the entire widget in a disabled state

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.spec.tsx
@@ -587,6 +587,8 @@ describe('WidgetBuilderSlideout', () => {
         /You may have limited functionality due to the ongoing migration of transactions to spans/i
       )
     ).toBeInTheDocument();
+
+    expect(screen.getByTestId('transaction-widget-disabled-wrapper')).toBeInTheDocument();
   });
 
   it('should not show deprecation alert when flag enabled', async () => {
@@ -628,5 +630,8 @@ describe('WidgetBuilderSlideout', () => {
         )
       ).not.toBeInTheDocument();
     });
+    expect(
+      screen.queryByTestId('transaction-widget-disabled-wrapper')
+    ).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.spec.tsx
@@ -584,7 +584,7 @@ describe('WidgetBuilderSlideout', () => {
 
     expect(
       await screen.findByText(
-        'Transaction widgets are being deprecated. Please use the spans dataset moving forward.'
+        /You may have limited functionality due to the ongoing migration of transactions to spans/i
       )
     ).toBeInTheDocument();
   });
@@ -624,7 +624,7 @@ describe('WidgetBuilderSlideout', () => {
     await waitFor(() => {
       expect(
         screen.queryByText(
-          'Transaction widgets are being deprecated. Please use the spans dataset moving forward.'
+          /You may have limited functionality due to the ongoing migration of transactions to spans/i
         )
       ).not.toBeInTheDocument();
     });

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -211,6 +211,15 @@ function WidgetBuilderSlideout({
         </CloseButton>
       </SlideoutHeaderWrapper>
       <SlideoutBodyWrapper>
+        {disableTransactionWidget && isEditing && (
+          <Section>
+            <Alert type="warning" showIcon>
+              {t(
+                'You may have limited functionality due to the ongoing migration of transactions to spans. To expedite and re-enable edit functionality, switch to the spans dataset below.'
+              )}
+            </Alert>
+          </Section>
+        )}
         {openWidgetTemplates ? (
           <Fragment>
             <div ref={templatesPreviewRef}>
@@ -265,15 +274,6 @@ function WidgetBuilderSlideout({
             {isSmallScreen && (
               <Section>
                 <WidgetBuilderFilterBar releases={dashboard.filters?.release ?? []} />
-              </Section>
-            )}
-            {disableTransactionWidget && isEditing && (
-              <Section>
-                <Alert type="info" showIcon>
-                  {t(
-                    'Transaction widgets are being deprecated. Please use the spans dataset moving forward.'
-                  )}
-                </Alert>
               </Section>
             )}
             <Section>

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -7,7 +7,6 @@ import {Breadcrumbs} from 'sentry/components/breadcrumbs';
 import {openConfirmModal} from 'sentry/components/confirm';
 import {Alert} from 'sentry/components/core/alert';
 import {Button} from 'sentry/components/core/button';
-import {Tooltip} from 'sentry/components/core/tooltip';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import SlideOverPanel from 'sentry/components/slideOverPanel';
 import {IconClose} from 'sentry/icons';
@@ -345,28 +344,21 @@ function DisableTransactionWidget({children}: DisableModeProps) {
   }
 
   return (
-    <Tooltip
-      title={t(
-        'Transaction widgets are being deprecated. Please use the spans dataset moving forward.'
-      )}
-      delay={500}
+    <div
+      data-test-id="demo-mode-disabled-wrapper"
+      style={{
+        opacity: 0.6,
+        cursor: 'not-allowed',
+      }}
     >
       <div
-        data-test-id="demo-mode-disabled-wrapper"
         style={{
-          opacity: 0.6,
-          cursor: 'not-allowed',
+          pointerEvents: 'none',
         }}
       >
-        <div
-          style={{
-            pointerEvents: 'none',
-          }}
-        >
-          {children}
-        </div>
+        {children}
       </div>
-    </Tooltip>
+    </div>
   );
 }
 

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -345,7 +345,7 @@ function DisableTransactionWidget({children}: DisableModeProps) {
 
   return (
     <div
-      data-test-id="demo-mode-disabled-wrapper"
+      data-test-id="transaction-widget-disabled-wrapper"
       style={{
         opacity: 0.6,
         cursor: 'not-allowed',

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -7,6 +7,7 @@ import {Breadcrumbs} from 'sentry/components/breadcrumbs';
 import {openConfirmModal} from 'sentry/components/confirm';
 import {Alert} from 'sentry/components/core/alert';
 import {Button} from 'sentry/components/core/button';
+import {Tooltip} from 'sentry/components/core/tooltip';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import SlideOverPanel from 'sentry/components/slideOverPanel';
 import {IconClose} from 'sentry/icons';
@@ -255,58 +256,60 @@ function WidgetBuilderSlideout({
             <Section>
               <WidgetBuilderDatasetSelector />
             </Section>
-            <Section>
-              <WidgetBuilderTypeSelector error={error} setError={setError} />
-            </Section>
-            <div ref={customPreviewRef}>
+            <DisableTransactionWidget>
+              <Section>
+                <WidgetBuilderTypeSelector error={error} setError={setError} />
+              </Section>
+              <div ref={customPreviewRef}>
+                {isSmallScreen && (
+                  <Section>
+                    <WidgetPreviewContainer
+                      dashboard={dashboard}
+                      dashboardFilters={dashboardFilters}
+                      isWidgetInvalid={isWidgetInvalid}
+                      onDataFetched={onDataFetched}
+                      openWidgetTemplates={openWidgetTemplates}
+                    />
+                  </Section>
+                )}
+              </div>
               {isSmallScreen && (
                 <Section>
-                  <WidgetPreviewContainer
-                    dashboard={dashboard}
-                    dashboardFilters={dashboardFilters}
-                    isWidgetInvalid={isWidgetInvalid}
-                    onDataFetched={onDataFetched}
-                    openWidgetTemplates={openWidgetTemplates}
-                  />
+                  <WidgetBuilderFilterBar releases={dashboard.filters?.release ?? []} />
                 </Section>
               )}
-            </div>
-            {isSmallScreen && (
               <Section>
-                <WidgetBuilderFilterBar releases={dashboard.filters?.release ?? []} />
+                <Visualize error={error} setError={setError} />
               </Section>
-            )}
-            <Section>
-              <Visualize error={error} setError={setError} />
-            </Section>
-            <Section>
-              <WidgetBuilderQueryFilterBuilder
-                onQueryConditionChange={onQueryConditionChange}
-                validatedWidgetResponse={validatedWidgetResponse}
-              />
-            </Section>
-            {state.displayType === DisplayType.BIG_NUMBER && (
               <Section>
-                <ThresholdsSection
-                  dataType={thresholdMetaState?.dataType}
-                  dataUnit={thresholdMetaState?.dataUnit}
-                  error={error}
-                  setError={setError}
-                />
-              </Section>
-            )}
-            {isChartWidget && (
-              <Section>
-                <WidgetBuilderGroupBySelector
+                <WidgetBuilderQueryFilterBuilder
+                  onQueryConditionChange={onQueryConditionChange}
                   validatedWidgetResponse={validatedWidgetResponse}
                 />
               </Section>
-            )}
-            {showSortByStep && (
-              <Section>
-                <WidgetBuilderSortBySelector />
-              </Section>
-            )}
+              {state.displayType === DisplayType.BIG_NUMBER && (
+                <Section>
+                  <ThresholdsSection
+                    dataType={thresholdMetaState?.dataType}
+                    dataUnit={thresholdMetaState?.dataUnit}
+                    error={error}
+                    setError={setError}
+                  />
+                </Section>
+              )}
+              {isChartWidget && (
+                <Section>
+                  <WidgetBuilderGroupBySelector
+                    validatedWidgetResponse={validatedWidgetResponse}
+                  />
+                </Section>
+              )}
+              {showSortByStep && (
+                <Section>
+                  <WidgetBuilderSortBySelector />
+                </Section>
+              )}
+            </DisableTransactionWidget>
             <SaveButtonGroup
               isEditing={isEditing}
               onSave={onSave}
@@ -327,6 +330,43 @@ function Section({children}: {children: React.ReactNode}) {
     <SectionWrapper>
       <ErrorBoundary mini>{children}</ErrorBoundary>
     </SectionWrapper>
+  );
+}
+
+type DisableModeProps = {
+  children: React.ReactNode;
+};
+
+function DisableTransactionWidget({children}: DisableModeProps) {
+  const disableTransactionWidget = useDisableTransactionWidget();
+
+  if (!disableTransactionWidget) {
+    return children;
+  }
+
+  return (
+    <Tooltip
+      title={t(
+        'Transaction widgets are being deprecated. Please use the spans dataset moving forward.'
+      )}
+      delay={500}
+    >
+      <div
+        data-test-id="demo-mode-disabled-wrapper"
+        style={{
+          opacity: 0.6,
+          cursor: 'not-allowed',
+        }}
+      >
+        <div
+          style={{
+            pointerEvents: 'none',
+          }}
+        >
+          {children}
+        </div>
+      </div>
+    </Tooltip>
   );
 }
 


### PR DESCRIPTION
Make the entire editable part of a txn widget disabled.
Update banner copy and positioning.