### PR TITLE
fix(spans-migration): Lock down discover transactions tab completely

### DIFF
--- a/static/app/components/core/tabs/item.tsx
+++ b/static/app/components/core/tabs/item.tsx
@@ -2,11 +2,14 @@ import {Item as _Item} from '@react-stately/collections';
 import type {ItemProps} from '@react-types/shared';
 import type {LocationDescriptor} from 'history';
 
+import type {TooltipProps} from 'sentry/components/core/tooltip';
+
 export interface TabListItemProps extends ItemProps<any> {
   key: string | number;
   disabled?: boolean;
   hidden?: boolean;
   to?: LocationDescriptor;
+  tooltip?: TooltipProps;
 }
 
 export const TabListItem = _Item as (props: TabListItemProps) => React.JSX.Element;

--- a/static/app/components/core/tabs/tab.tsx
+++ b/static/app/components/core/tabs/tab.tsx
@@ -9,6 +9,7 @@ import type {Node, Orientation} from '@react-types/shared';
 
 import InteractionStateLayer from 'sentry/components/core/interactionStateLayer';
 import {Link} from 'sentry/components/core/link';
+import {Tooltip, type TooltipProps} from 'sentry/components/core/tooltip';
 import {space} from 'sentry/styles/space';
 import {isChonkTheme, withChonk} from 'sentry/utils/theme/withChonk';
 
@@ -33,6 +34,7 @@ interface TabProps extends AriaTabProps {
   state: TabListState<any>;
   as?: React.ElementType;
   ref?: React.Ref<HTMLLIElement>;
+  tooltipProps?: TooltipProps;
   variant?: BaseTabProps['variant'];
 }
 
@@ -156,6 +158,7 @@ export function Tab({
   variant,
   size,
   as = 'li',
+  tooltipProps,
 }: TabProps) {
   const objectRef = useObjectRef(ref);
 
@@ -166,6 +169,28 @@ export function Tab({
   } = item;
 
   const {tabProps, isSelected} = useTab({key, isDisabled: hidden}, state, objectRef);
+
+  if (tooltipProps) {
+    return (
+      <Tooltip {...tooltipProps}>
+        <BaseTab
+          tabProps={tabProps}
+          isSelected={isSelected}
+          to={to}
+          hidden={hidden}
+          disabled={disabled}
+          orientation={orientation}
+          overflowing={overflowing}
+          ref={objectRef}
+          variant={variant}
+          as={as}
+          size={size}
+        >
+          {rendered}
+        </BaseTab>
+      </Tooltip>
+    );
+  }
 
   return (
     <BaseTab

--- a/static/app/components/core/tabs/tabList.tsx
+++ b/static/app/components/core/tabs/tabList.tsx
@@ -11,7 +11,6 @@ import type {Node, Orientation} from '@react-types/shared';
 
 import type {SelectOption} from 'sentry/components/core/compactSelect';
 import {CompactSelect} from 'sentry/components/core/compactSelect';
-import {Tooltip} from 'sentry/components/core/tooltip';
 import DropdownButton from 'sentry/components/dropdownButton';
 import {IconEllipsis} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -237,30 +236,21 @@ function BaseTabList({
         ref={tabListRef}
         variant={variant}
       >
-        {[...state.collection].map(item => {
-          const rendered = item.props.tooltip ? (
-            <Tooltip {...item.props.tooltip}>{item.rendered}</Tooltip>
-          ) : (
-            item.rendered
-          );
-
-          return (
-            <Tab
-              key={item.key}
-              item={{...item, rendered}}
-              state={state}
-              orientation={orientation}
-              size={size}
-              overflowing={
-                orientation === 'horizontal' && overflowTabs.includes(item.key)
-              }
-              ref={element => {
-                tabItemsRef.current[item.key] = element;
-              }}
-              variant={variant}
-            />
-          );
-        })}
+        {[...state.collection].map(item => (
+          <Tab
+            key={item.key}
+            item={item}
+            state={state}
+            orientation={orientation}
+            size={size}
+            overflowing={orientation === 'horizontal' && overflowTabs.includes(item.key)}
+            tooltipProps={item.props.tooltip}
+            ref={element => {
+              tabItemsRef.current[item.key] = element;
+            }}
+            variant={variant}
+          />
+        ))}
       </TabListWrap>
 
       {orientation === 'horizontal' && overflowMenuItems.length > 0 && (

--- a/static/app/components/core/tabs/tabList.tsx
+++ b/static/app/components/core/tabs/tabList.tsx
@@ -11,6 +11,7 @@ import type {Node, Orientation} from '@react-types/shared';
 
 import type {SelectOption} from 'sentry/components/core/compactSelect';
 import {CompactSelect} from 'sentry/components/core/compactSelect';
+import {Tooltip} from 'sentry/components/core/tooltip';
 import DropdownButton from 'sentry/components/dropdownButton';
 import {IconEllipsis} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -221,6 +222,7 @@ function BaseTabList({
         value: key,
         label: item.props.children,
         disabled: item.props.disabled,
+        tooltip: item.props.tooltip,
         textValue: item.textValue,
       };
     });
@@ -235,20 +237,30 @@ function BaseTabList({
         ref={tabListRef}
         variant={variant}
       >
-        {[...state.collection].map(item => (
-          <Tab
-            key={item.key}
-            item={item}
-            state={state}
-            orientation={orientation}
-            size={size}
-            overflowing={orientation === 'horizontal' && overflowTabs.includes(item.key)}
-            ref={element => {
-              tabItemsRef.current[item.key] = element;
-            }}
-            variant={variant}
-          />
-        ))}
+        {[...state.collection].map(item => {
+          const rendered = item.props.tooltip ? (
+            <Tooltip {...item.props.tooltip}>{item.rendered}</Tooltip>
+          ) : (
+            item.rendered
+          );
+
+          return (
+            <Tab
+              key={item.key}
+              item={{...item, rendered}}
+              state={state}
+              orientation={orientation}
+              size={size}
+              overflowing={
+                orientation === 'horizontal' && overflowTabs.includes(item.key)
+              }
+              ref={element => {
+                tabItemsRef.current[item.key] = element;
+              }}
+              variant={variant}
+            />
+          );
+        })}
       </TabListWrap>
 
       {orientation === 'horizontal' && overflowMenuItems.length > 0 && (

--- a/static/app/views/discover/savedQuery/datasetSelectorTabs.spec.tsx
+++ b/static/app/views/discover/savedQuery/datasetSelectorTabs.spec.tsx
@@ -23,7 +23,7 @@ const EVENT_VIEW_CONSTRUCTOR_PROPS: EventViewOptions = {
 };
 
 describe('Discover DatasetSelector', function () {
-  const {router} = initializeOrg({
+  const {router, organization} = initializeOrg({
     organization: {features: ['performance-view']},
   });
 
@@ -119,6 +119,37 @@ describe('Discover DatasetSelector', function () {
           queryDataset: 'transaction-like',
         }),
       })
+    );
+  });
+
+  it('disables transactions dataset if org has deprecation feature', function () {
+    const eventView = new EventView({
+      ...EVENT_VIEW_CONSTRUCTOR_PROPS,
+      dataset: DiscoverDatasets.ERRORS,
+      id: '1',
+    });
+
+    const org = {
+      ...organization,
+      features: [...organization.features, 'discover-saved-queries-deprecation'],
+    };
+
+    render(
+      <DatasetSelectorTabs
+        isHomepage={false}
+        savedQuery={undefined}
+        eventView={eventView}
+      />,
+      {
+        router,
+        organization: org,
+        deprecatedRouterMocks: true,
+      }
+    );
+
+    expect(screen.getByRole('tab', {name: 'Transactions'})).toHaveAttribute(
+      'aria-disabled',
+      'true'
     );
   });
 });

--- a/static/app/views/discover/savedQuery/datasetSelectorTabs.tsx
+++ b/static/app/views/discover/savedQuery/datasetSelectorTabs.tsx
@@ -1,7 +1,6 @@
-import {Link} from 'sentry/components/core/link';
 import {TabList} from 'sentry/components/core/tabs';
 import * as Layout from 'sentry/components/layouts/thirds';
-import {t, tct} from 'sentry/locale';
+import {t} from 'sentry/locale';
 import type {SavedQuery} from 'sentry/types/organization';
 import type EventView from 'sentry/utils/discover/eventView';
 import {
@@ -20,6 +19,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {
   getDatasetFromLocationOrSavedQueryDataset,
   getSavedQueryDataset,
+  getTransactionDeprecationMessage,
 } from 'sentry/views/discover/savedQuery/utils';
 import {getExploreUrl} from 'sentry/views/explore/utils';
 
@@ -129,12 +129,7 @@ export function DatasetSelectorTabs(props: Props) {
       disabled: deprecatingTransactionsDataset,
       tooltip: deprecatingTransactionsDataset
         ? {
-            title: tct(
-              'Discover\u2192Transactions is going to be merged into Explore\u2192Traces soon. Please browse and save any transaction related queries from [traces:Explore\u2192Traces]',
-              {
-                traces: <Link to={tracesUrl} />,
-              }
-            ),
+            title: getTransactionDeprecationMessage(tracesUrl),
             isHoverable: true,
           }
         : undefined,

--- a/static/app/views/discover/savedQuery/index.tsx
+++ b/static/app/views/discover/savedQuery/index.tsx
@@ -411,22 +411,23 @@ class SavedQueryButtonGroup extends PureComponent<Props, State> {
 
       return (
         <Fragment>
-          <Button
-            onClick={this.handleUpdateQuery}
-            data-test-id="discover2-savedquery-button-update"
-            disabled={disabled || deprecatingTransactionsDataset}
-            size="sm"
-            tooltipProps={{
-              isHoverable: true,
-            }}
+          <Tooltip
             title={
               deprecatingTransactionsDataset &&
               getTransactionDeprecationMessage(tracesUrl)
             }
+            isHoverable
           >
-            <IconUpdate />
-            {t('Save Changes')}
-          </Button>
+            <Button
+              onClick={this.handleUpdateQuery}
+              data-test-id="discover2-savedquery-button-update"
+              disabled={disabled || deprecatingTransactionsDataset}
+              size="sm"
+            >
+              <IconUpdate />
+              {t('Save Changes')}
+            </Button>
+          </Tooltip>
           {this.renderButtonSaveAs(disabled)}
         </Fragment>
       );

--- a/static/app/views/discover/savedQuery/index.tsx
+++ b/static/app/views/discover/savedQuery/index.tsx
@@ -16,7 +16,6 @@ import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {Input} from 'sentry/components/core/input';
 import {Flex} from 'sentry/components/core/layout';
-import {Link} from 'sentry/components/core/link';
 import {Tooltip} from 'sentry/components/core/tooltip';
 import {CreateAlertFromViewButton} from 'sentry/components/createAlertButton';
 import type {MenuItemProps} from 'sentry/components/dropdownMenu';
@@ -24,7 +23,7 @@ import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {Hovercard} from 'sentry/components/hovercard';
 import {Overlay, PositionWrapper} from 'sentry/components/overlay';
 import {IconBookmark, IconDelete, IconEllipsis, IconStar} from 'sentry/icons';
-import {t, tct} from 'sentry/locale';
+import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {InjectedRouter} from 'sentry/types/legacyReactRouter';
 import type {Organization, SavedQuery} from 'sentry/types/organization';
@@ -52,6 +51,7 @@ import {deprecateTransactionAlerts} from 'sentry/views/insights/common/utils/has
 import {
   getDatasetFromLocationOrSavedQueryDataset,
   getSavedQueryDataset,
+  getTransactionDeprecationMessage,
   handleCreateQuery,
   handleDeleteQuery,
   handleResetHomepageQuery,
@@ -374,12 +374,7 @@ class SavedQueryButtonGroup extends PureComponent<Props, State> {
           !organization.features.includes('discover-saved-queries-deprecation')
         }
         isHoverable
-        title={tct(
-          'Discover\u2192Transactions is going to be merged into Explore\u2192Traces soon. Please save any transaction related queries from [traces:Explore\u2192Traces]',
-          {
-            traces: <Link to={tracesUrl} />,
-          }
-        )}
+        title={getTransactionDeprecationMessage(tracesUrl)}
       >
         <SaveAsDropdown
           queryName={queryName}
@@ -426,12 +421,7 @@ class SavedQueryButtonGroup extends PureComponent<Props, State> {
             }}
             title={
               deprecatingTransactionsDataset &&
-              tct(
-                'Discover\u2192Transactions is going to be merged into Explore\u2192Traces soon. Please save any transaction related queries from [traces:Explore\u2192Traces]',
-                {
-                  traces: <Link to={tracesUrl} />,
-                }
-              )
+              getTransactionDeprecationMessage(tracesUrl)
             }
           >
             <IconUpdate />
@@ -667,13 +657,7 @@ class SavedQueryButtonGroup extends PureComponent<Props, State> {
         disabled: deprecatingTransactionsDataset,
         tooltipOptions: {isHoverable: true},
         tooltip:
-          deprecatingTransactionsDataset &&
-          tct(
-            'Discover\u2192Transactions is going to be merged into Explore\u2192Traces soon. Please save any transaction related queries from [traces:Explore\u2192Traces]',
-            {
-              traces: <Link to={tracesUrl} />,
-            }
-          ),
+          deprecatingTransactionsDataset && getTransactionDeprecationMessage(tracesUrl),
         onAction: () => {
           handleAddQueryToDashboard({
             organization,

--- a/static/app/views/discover/savedQuery/utils.tsx
+++ b/static/app/views/discover/savedQuery/utils.tsx
@@ -11,7 +11,8 @@ import {
 } from 'sentry/actionCreators/discoverSavedQueries';
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import type {Client} from 'sentry/api';
-import {t} from 'sentry/locale';
+import {Link} from 'sentry/components/core/link';
+import {t, tct} from 'sentry/locale';
 import type {NewQuery, Organization, SavedQuery} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import type {SaveQueryEventParameters} from 'sentry/utils/analytics/discoverAnalyticsEvents';
@@ -346,4 +347,13 @@ export function getSavedQueryDatasetFromLocationOrDataset(
     default:
       return undefined;
   }
+}
+
+export function getTransactionDeprecationMessage(tracesUrl: string) {
+  return tct(
+    'Discover\u2192Transactions is going to be merged into Explore\u2192Traces soon. Please save any transaction related queries from [traces:Explore\u2192Traces]',
+    {
+      traces: <Link to={tracesUrl} />,
+    }
+  );
 }


### PR DESCRIPTION
As part of the spans migration, we're locking down the transactions dataset in discover completely. This will not allow users to select the transactions dataset and save changes to existing transaction queries. I had to make changes to the `TabList.Item` component to allow passing in tooltip props so i can display the deprecation message.

Closes [ENG-4633](https://linear.app/getsentry/issue/ENG-4633/lock-existing-discover-query-edit-and-transaction-tab)
