### PR TITLE
feat(dashboards): Add environment to table

### DIFF
--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.spec.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.spec.tsx
@@ -32,6 +32,7 @@ describe('add to dashboard modal', () => {
     widgetDisplay: [DisplayType.AREA],
     widgetPreview: [],
     projects: [],
+    environment: [],
   };
   const testDashboard: DashboardDetails = {
     id: '1',

--- a/static/app/views/dashboards/manage/tableView/table.spec.tsx
+++ b/static/app/views/dashboards/manage/tableView/table.spec.tsx
@@ -37,4 +37,21 @@ describe('DashboardTable', () => {
     // The dashboard is starred, so the button should prompt "Unstar"
     expect(screen.getByLabelText('Unstar')).toBeInTheDocument();
   });
+
+  it('renders environments', () => {
+    render(
+      <DashboardTable
+        dashboards={[
+          DashboardListItemFixture({
+            environment: ['production', 'staging'],
+          }),
+        ]}
+        cursorKey="test"
+        isLoading={false}
+        title={''}
+      />
+    );
+
+    expect(screen.getByText('production, staging')).toBeInTheDocument();
+  });
 });

--- a/static/app/views/dashboards/manage/tableView/table.tsx
+++ b/static/app/views/dashboards/manage/tableView/table.tsx
@@ -101,8 +101,7 @@ export function DashboardTable({
               <SavedEntityTable.CellProjects projects={dashboard.projects} />
             </SavedEntityTable.Cell>
             <SavedEntityTable.Cell data-column="envs">
-              {/* TODO: DAIN-712 Add environments after they are exposed in the API */}
-              <SavedEntityTable.CellEnvironments environments={[]} />
+              <SavedEntityTable.CellEnvironments environments={dashboard.environment} />
             </SavedEntityTable.Cell>
             {/* TODO: DAIN-716 Add release filter as tokens */}
             <SavedEntityTable.Cell data-column="filter">{'\u2014'}</SavedEntityTable.Cell>

--- a/static/app/views/dashboards/types.tsx
+++ b/static/app/views/dashboards/types.tsx
@@ -131,6 +131,7 @@ export type DashboardPermissions = {
  * The response shape from dashboard list endpoint
  */
 export type DashboardListItem = {
+  environment: string[];
   id: string;
   projects: number[];
   title: string;

--- a/tests/js/fixtures/dashboard.ts
+++ b/tests/js/fixtures/dashboard.ts
@@ -29,6 +29,7 @@ export function DashboardListItemFixture(
     widgetDisplay: [],
     widgetPreview: [],
     projects: [],
+    environment: [],
     ...params,
   };
 }


### PR DESCRIPTION
Uses the environment filter in the dashboard list payload to render the saved environments.