### PR TITLE
ref(feedback): gate user feedback summary behind gen AI flag (#95534)

### DIFF
--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -379,6 +379,7 @@ class TraceItemAttributeValuesAutocompletionExecutor(BaseSpanFieldValuesAutocomp
                 SEMVER_ALIAS: self.semver_autocomplete_function,
                 SEMVER_BUILD_ALIAS: self.semver_build_autocomplete_function,
                 SEMVER_PACKAGE_ALIAS: self.semver_package_autocomplete_function,
+                "timestamp": self.skip_autocomplete,
             }
         )
 
@@ -541,6 +542,9 @@ class TraceItemAttributeValuesAutocompletionExecutor(BaseSpanFieldValuesAutocomp
             )
             for package in packages
         ]
+
+    def skip_autocomplete(self) -> list[TagValue]:
+        return []
 
     def boolean_autocomplete_function(self) -> list[TagValue]:
         return [

--- a/static/app/components/feedback/feedbackSummary.tsx
+++ b/static/app/components/feedback/feedbackSummary.tsx
@@ -19,7 +19,10 @@ export default function FeedbackSummary() {
 
   const openForm = useFeedbackForm();
 
-  if (!organization.features.includes('user-feedback-ai-summaries')) {
+  if (
+    !organization.features.includes('user-feedback-ai-summaries') ||
+    !organization.features.includes('gen-ai-features')
+  ) {
     return null;
   }
 

--- a/static/app/components/feedback/list/useFeedbackSummary.tsx
+++ b/static/app/components/feedback/list/useFeedbackSummary.tsx
@@ -36,7 +36,8 @@ export default function useFeedbackSummary(): {
       staleTime: 5000,
       enabled:
         Boolean(normalizedDateRange) &&
-        organization.features.includes('user-feedback-ai-summaries'),
+        organization.features.includes('user-feedback-ai-summaries') &&
+        organization.features.includes('gen-ai-features'),
       retry: 1,
     }
   );

--- a/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
@@ -1500,3 +1500,12 @@ class OrganizationTraceItemAttributeValuesEndpointSpansTest(
             }
             for version in ["121", "122"]
         ]
+
+    def test_autocomplete_timestamp(self):
+        self.store_spans(
+            [self.create_span(start_ts=before_now(days=0, minutes=10))],
+            is_eap=True,
+        )
+        response = self.do_request(key="timestamp", query={"substringMatch": "20"})
+        assert response.status_code == 200
+        assert response.data == []


### PR DESCRIPTION
Autocompleting timestamps don't make a lot of sense so skip it entirely.