### PR TITLE
fix(eap): Do not autocomplete timestamp

### DIFF
--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -379,6 +379,7 @@ class TraceItemAttributeValuesAutocompletionExecutor(BaseSpanFieldValuesAutocomp
                 SEMVER_ALIAS: self.semver_autocomplete_function,
                 SEMVER_BUILD_ALIAS: self.semver_build_autocomplete_function,
                 SEMVER_PACKAGE_ALIAS: self.semver_package_autocomplete_function,
+                "timestamp": self.skip_autocomplete,
             }
         )
 
@@ -541,6 +542,9 @@ class TraceItemAttributeValuesAutocompletionExecutor(BaseSpanFieldValuesAutocomp
             )
             for package in packages
         ]
+
+    def skip_autocomplete(self) -> list[TagValue]:
+        return []
 
     def boolean_autocomplete_function(self) -> list[TagValue]:
         return [

--- a/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
@@ -1500,3 +1500,12 @@ class OrganizationTraceItemAttributeValuesEndpointSpansTest(
             }
             for version in ["121", "122"]
         ]
+
+    def test_autocomplete_timestamp(self):
+        self.store_spans(
+            [self.create_span(start_ts=before_now(days=0, minutes=10))],
+            is_eap=True,
+        )
+        response = self.do_request(key="timestamp", query={"substringMatch": "20"})
+        assert response.status_code == 200
+        assert response.data == []


### PR DESCRIPTION
Timestamps aren't realy useful to autocomplete by querying eap. So skip it.