### PR TITLE
feat(cell-action): add external linking as action

### DIFF
--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -500,7 +500,7 @@ const SPECIAL_FIELDS: Record<string, SpecialField> = {
   },
   'span.description': {
     sortField: 'span.description',
-    renderFunc: data => {
+    renderFunc: (data, {organization}) => {
       const value = data[SpanFields.SPAN_DESCRIPTION];
       const op: string = data[SpanFields.SPAN_OP];
       const projectId =
@@ -527,7 +527,14 @@ const SPECIAL_FIELDS: Record<string, SpecialField> = {
           showOnlyOnOverflow
           maxWidth={400}
         >
-          <Container>{nullableValue(value)}</Container>
+          <Container>
+            {!organization.features.includes('discover-cell-actions-v2') &&
+            isUrl(value) ? (
+              <ExternalLink href={value}>{value}</ExternalLink>
+            ) : (
+              nullableValue(value)
+            )}
+          </Container>
         </Tooltip>
       );
     },

--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -322,7 +322,7 @@ export const FIELD_FORMATTERS: FieldFormatters = {
   },
   string: {
     isSortable: true,
-    renderFunc: (field, data) => {
+    renderFunc: (field, data, baggage) => {
       // Some fields have long arrays in them, only show the tail of the data.
       const value = Array.isArray(data[field])
         ? data[field].slice(-1)
@@ -330,7 +330,11 @@ export const FIELD_FORMATTERS: FieldFormatters = {
           ? data[field]
           : emptyValue;
 
-      if (isUrl(value)) {
+      // In the future, external linking will be done through CellAction component instead of the default renderer
+      if (
+        !baggage?.organization.features.includes('discover-cell-actions-v2') &&
+        isUrl(value)
+      ) {
         return (
           <Tooltip title={value} containerDisplayMode="block" showOnlyOnOverflow>
             <Container>
@@ -523,13 +527,7 @@ const SPECIAL_FIELDS: Record<string, SpecialField> = {
           showOnlyOnOverflow
           maxWidth={400}
         >
-          <Container>
-            {isUrl(value) ? (
-              <ExternalLink href={value}>{value}</ExternalLink>
-            ) : (
-              nullableValue(value)
-            )}
-          </Container>
+          <Container>{nullableValue(value)}</Container>
         </Tooltip>
       );
     },

--- a/static/app/views/discover/table/cellAction.tsx
+++ b/static/app/views/discover/table/cellAction.tsx
@@ -295,16 +295,25 @@ type Props = React.PropsWithoutRef<CellActionsOpts> & {
   triggerType?: ActionTriggerType;
 };
 
-function CellAction({triggerType = ActionTriggerType.BOLD_HOVER, ...props}: Props) {
+function CellAction({
+  triggerType = ActionTriggerType.BOLD_HOVER,
+  allowActions,
+  ...props
+}: Props) {
   const organization = useOrganization();
   const {children, column} = props;
-  const cellActions = makeCellActions(props);
+
+  const useCellActionsV2 = organization.features.includes('discover-cell-actions-v2');
+  let filteredActions = allowActions;
+  if (!useCellActionsV2)
+    filteredActions = filteredActions?.filter(
+      action => action !== Actions.OPEN_EXTERNAL_LINK
+    );
+
+  const cellActions = makeCellActions({...props, allowActions: filteredActions});
   const align = fieldAlignment(column.key as string, column.type);
 
-  if (
-    organization.features.includes('discover-cell-actions-v2') &&
-    triggerType === ActionTriggerType.BOLD_HOVER
-  )
+  if (useCellActionsV2 && triggerType === ActionTriggerType.BOLD_HOVER)
     return (
       <Container
         data-test-id={cellActions === null ? undefined : 'cell-action-container'}

--- a/static/app/views/discover/table/cellAction.tsx
+++ b/static/app/views/discover/table/cellAction.tsx
@@ -32,19 +32,6 @@ export enum Actions {
   OPEN_EXTERNAL_LINK = 'open_external_link',
 }
 
-export function copyToClipBoard(data: any) {
-  function stringifyValue(value: any): string {
-    if (!value) return '';
-    if (typeof value !== 'object') {
-      return value.toString();
-    }
-    return JSON.stringify(value) ?? value.toString();
-  }
-  navigator.clipboard.writeText(stringifyValue(data)).catch(_ => {
-    addErrorMessage('Error copying to clipboard');
-  });
-}
-
 export function updateQuery(
   results: MutableSearch,
   action: Actions,
@@ -343,7 +330,7 @@ function CellAction(props: Props) {
 }
 
 /**
- * A fallback that has default operations for some actions. E.g., copying to clipboard by default copies raw text, opening link by default opens it in a new link
+ * A fallback that has default operations for some actions. E.g., copying to clipboard by default copies raw text, opening external link opens a new tab
  * @param action
  * @param value
  * @returns true if a default action was executed, false otherwise
@@ -353,9 +340,19 @@ export function handleCellActionFallback(
   value: string | number | string[]
 ): boolean {
   switch (action) {
-    case Actions.COPY_TO_CLIPBOARD:
-      copyToClipBoard(value);
+    case Actions.COPY_TO_CLIPBOARD: {
+      function stringifyValue(val: any): string {
+        if (!val) return '';
+        if (typeof val !== 'object') {
+          return val.toString();
+        }
+        return JSON.stringify(val) ?? val.toString();
+      }
+      navigator.clipboard.writeText(stringifyValue(value)).catch(_ => {
+        addErrorMessage('Error copying to clipboard');
+      });
       return true;
+    }
     case Actions.OPEN_EXTERNAL_LINK:
       if (typeof value === 'string' && isUrl(value)) {
         window.open(value, '_blank', 'noopener,noreferrer');

--- a/static/app/views/discover/table/cellAction.tsx
+++ b/static/app/views/discover/table/cellAction.tsx
@@ -282,15 +282,29 @@ function makeCellActions({
   return actions;
 }
 
-type Props = React.PropsWithoutRef<CellActionsOpts>;
+/**
+ * Potentially temporary as design and product need more time to determine how logs table should trigger the dropdown.
+ * Currently, the agreed default for every table should be bold hover. Logs is the only table to use the ellipsis trigger.
+ */
+export enum ActionTriggerType {
+  ELLIPSIS = 'ellipsis',
+  BOLD_HOVER = 'bold_hover',
+}
 
-function CellAction(props: Props) {
+type Props = React.PropsWithoutRef<CellActionsOpts> & {
+  triggerType?: ActionTriggerType;
+};
+
+function CellAction({triggerType = ActionTriggerType.BOLD_HOVER, ...props}: Props) {
   const organization = useOrganization();
   const {children, column} = props;
   const cellActions = makeCellActions(props);
   const align = fieldAlignment(column.key as string, column.type);
 
-  if (organization.features.includes('discover-cell-actions-v2'))
+  if (
+    organization.features.includes('discover-cell-actions-v2') &&
+    triggerType === ActionTriggerType.BOLD_HOVER
+  )
     return (
       <Container
         data-test-id={cellActions === null ? undefined : 'cell-action-container'}

--- a/static/app/views/discover/table/cellAction.tsx
+++ b/static/app/views/discover/table/cellAction.tsx
@@ -341,7 +341,7 @@ export function handleCellActionFallback(
 ): boolean {
   switch (action) {
     case Actions.COPY_TO_CLIPBOARD: {
-      function stringifyValue(val: any): string {
+      function stringifyValue(val: string | number | string[]): string {
         if (!val) return '';
         if (typeof val !== 'object') {
           return val.toString();

--- a/static/app/views/discover/table/tableView.tsx
+++ b/static/app/views/discover/table/tableView.tsx
@@ -66,7 +66,7 @@ import {makeReleasesPathname} from 'sentry/views/releases/utils/pathnames';
 
 import {QuickContextHoverWrapper} from './quickContext/quickContextWrapper';
 import {ContextType} from './quickContext/utils';
-import CellAction, {Actions, copyToClipBoard, updateQuery} from './cellAction';
+import CellAction, {Actions, updateQuery} from './cellAction';
 import ColumnEditModal, {modalCss} from './columnEditModal';
 import TableActions from './tableActions';
 import {TopResultsIndicator} from './topResultsIndicator';
@@ -608,10 +608,6 @@ function TableView(props: TableViewProps) {
           );
 
           return;
-        }
-        case Actions.COPY_TO_CLIPBOARD: {
-          copyToClipBoard(value);
-          break;
         }
         default: {
           // Some custom perf metrics have units.

--- a/static/app/views/explore/components/table.tsx
+++ b/static/app/views/explore/components/table.tsx
@@ -54,6 +54,7 @@ export const ALLOWED_CELL_ACTIONS: Actions[] = [
   Actions.SHOW_GREATER_THAN,
   Actions.SHOW_LESS_THAN,
   Actions.COPY_TO_CLIPBOARD,
+  Actions.OPEN_EXTERNAL_LINK,
 ];
 
 const MINIMUM_COLUMN_WIDTH = COL_WIDTH_MINIMUM;

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -17,6 +17,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import useProjectFromId from 'sentry/utils/useProjectFromId';
 import CellAction, {
   Actions,
+  ActionTriggerType,
   copyToClipboard,
   openExternalLink,
 } from 'sentry/views/discover/table/cellAction';
@@ -320,6 +321,7 @@ export const LogRowContent = memo(function LogRowContent({
                       ? []
                       : ALLOWED_CELL_ACTIONS
                   }
+                  triggerType={ActionTriggerType.ELLIPSIS}
                 >
                   {renderedField}
                 </CellAction>

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -17,7 +17,8 @@ import useOrganization from 'sentry/utils/useOrganization';
 import useProjectFromId from 'sentry/utils/useProjectFromId';
 import CellAction, {
   Actions,
-  handleCellActionFallback,
+  copyToClipboard,
+  openExternalLink,
 } from 'sentry/views/discover/table/cellAction';
 import type {TableColumn} from 'sentry/views/discover/table/types';
 import {AttributesTree} from 'sentry/views/explore/components/traceItemAttributes/attributesTree';
@@ -304,8 +305,13 @@ export const LogRowContent = memo(function LogRowContent({
                           negated: true,
                         });
                         break;
+                      case Actions.COPY_TO_CLIPBOARD:
+                        copyToClipboard(value);
+                        break;
+                      case Actions.OPEN_EXTERNAL_LINK:
+                        openExternalLink(value);
+                        break;
                       default:
-                        handleCellActionFallback(actions, cellValue);
                         break;
                     }
                   }}

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -17,7 +17,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import useProjectFromId from 'sentry/utils/useProjectFromId';
 import CellAction, {
   Actions,
-  copyToClipBoard,
+  handleCellActionFallback,
 } from 'sentry/views/discover/table/cellAction';
 import type {TableColumn} from 'sentry/views/discover/table/types';
 import {AttributesTree} from 'sentry/views/explore/components/traceItemAttributes/attributesTree';
@@ -304,10 +304,8 @@ export const LogRowContent = memo(function LogRowContent({
                           negated: true,
                         });
                         break;
-                      case Actions.COPY_TO_CLIPBOARD:
-                        copyToClipBoard(cellValue);
-                        break;
                       default:
+                        handleCellActionFallback(actions, cellValue);
                         break;
                     }
                   }}

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -306,10 +306,10 @@ export const LogRowContent = memo(function LogRowContent({
                         });
                         break;
                       case Actions.COPY_TO_CLIPBOARD:
-                        copyToClipboard(value);
+                        copyToClipboard(cellValue);
                         break;
                       case Actions.OPEN_EXTERNAL_LINK:
-                        openExternalLink(value);
+                        openExternalLink(cellValue);
                         break;
                       default:
                         break;

--- a/static/app/views/explore/tables/fieldRenderer.tsx
+++ b/static/app/views/explore/tables/fieldRenderer.tsx
@@ -5,7 +5,6 @@ import styled from '@emotion/styled';
 import {Link} from 'sentry/components/core/link';
 import {Tooltip} from 'sentry/components/core/tooltip';
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
-import ExternalLink from 'sentry/components/links/externalLink';
 import TimeSince from 'sentry/components/timeSince';
 import {space} from 'sentry/styles/space';
 import type {Project} from 'sentry/types/project';
@@ -18,7 +17,6 @@ import {Container} from 'sentry/utils/discover/styles';
 import {generateLinkToEventInTraceView} from 'sentry/utils/discover/urls';
 import {getShortEventId} from 'sentry/utils/events';
 import {generateProfileFlamechartRouteWithQuery} from 'sentry/utils/profiling/routes';
-import {isUrl} from 'sentry/utils/string/isUrl';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -146,7 +144,7 @@ function BaseExploreFieldRenderer({
       source: TraceViewSources.TRACES,
     });
 
-    rendered = <Link to={target}>{rendered}</Link>;
+    return <Link to={target}>{rendered}</Link>;
   }
 
   if (['id', 'span_id', 'transaction.id'].includes(field)) {
@@ -162,7 +160,7 @@ function BaseExploreFieldRenderer({
       source: TraceViewSources.TRACES,
     });
 
-    rendered = <Link to={target}>{rendered}</Link>;
+    return <Link to={target}>{rendered}</Link>;
   }
 
   if (field === 'profile.id') {
@@ -171,7 +169,7 @@ function BaseExploreFieldRenderer({
       projectSlug: data.project,
       profileId: data['profile.id'],
     });
-    rendered = <Link to={target}>{rendered}</Link>;
+    return <Link to={target}>{rendered}</Link>;
   }
 
   return (
@@ -238,13 +236,7 @@ function spanDescriptionRenderFunc(projects: Record<string, Project>) {
                 hideName
               />
             )}
-            <WrappingText>
-              {isUrl(value) ? (
-                <ExternalLink href={value}>{value}</ExternalLink>
-              ) : (
-                nullableValue(value)
-              )}
-            </WrappingText>
+            <WrappingText>{nullableValue(value)}</WrappingText>
           </Description>
         </Tooltip>
       </span>

--- a/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.tsx
@@ -220,6 +220,7 @@ function EventsTable({
         Actions.EXCLUDE,
         Actions.SHOW_GREATER_THAN,
         Actions.SHOW_LESS_THAN,
+        Actions.OPEN_EXTERNAL_LINK,
       ];
 
       if (['attachments', 'minidump'].includes(field)) {


### PR DESCRIPTION
### Changes

Have external linking as a dropdown menu option for `CellAction`. Removed cell actions for some ID linked fields (since it conflicts with the dropdown & should just directly open the link)

### Video


https://github.com/user-attachments/assets/d86c4b1f-f33f-4f0f-8c82-ea14ed62b410

