### PR TITLE
test(trace): Increase trace search success timeout

### DIFF
--- a/static/app/views/performance/newTraceDetails/trace.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.spec.tsx
@@ -776,7 +776,7 @@ const VISIBLE_TRACE_ROW_SELECTOR = '.TraceRow:not(.Hidden)';
 const ACTIVE_SEARCH_HIGHLIGHT_ROW = '.TraceRow.SearchResult.Highlight:not(.Hidden)';
 
 const searchToResolve = async (): Promise<void> => {
-  await screen.findByTestId('trace-search-success');
+  await screen.findByTestId('trace-search-success', undefined, {timeout: 10_000});
 };
 
 function printVirtualizedList(container: HTMLElement) {


### PR DESCRIPTION
Default timeout is 1 second. This will probably cause the entire test to timeout, but we'll see.
