### PR TITLE
fix(dashboards): Force INP metrics widgets to query spans when compatible

### DIFF
--- a/static/app/views/dashboards/utils/shouldForceQueryToSpans.spec.tsx
+++ b/static/app/views/dashboards/utils/shouldForceQueryToSpans.spec.tsx
@@ -1,0 +1,78 @@
+import {WidgetFixture} from 'sentry-fixture/widget';
+
+import {WidgetType} from 'sentry/views/dashboards/types';
+import {shouldForceQueryToSpans} from 'sentry/views/dashboards/utils/shouldForceQueryToSpans';
+
+describe('shouldForceQueryToSpans', function () {
+  it('return true if the widget is a transactions widget and uses measurements.inp', function () {
+    const widget = WidgetFixture({
+      widgetType: WidgetType.TRANSACTIONS,
+      queries: [
+        {
+          fields: ['p75(measurements.inp)'],
+          aggregates: ['p75(measurements.inp)'],
+          columns: [],
+          conditions: '',
+          name: 'inp widget',
+          orderby: '',
+        },
+      ],
+    });
+
+    expect(shouldForceQueryToSpans(widget)).toBe(true);
+  });
+
+  it('return false if the widget is not a transactions widget', function () {
+    const widget = WidgetFixture({
+      widgetType: WidgetType.TRANSACTIONS,
+      queries: [
+        {
+          fields: ['p75(measurements.lcp)'],
+          aggregates: ['p75(measurements.lcp)'],
+          columns: [],
+          conditions: '',
+          name: 'lcp widget',
+          orderby: '',
+        },
+      ],
+    });
+
+    expect(shouldForceQueryToSpans(widget)).toBe(false);
+  });
+
+  it('return false if the widget is a transactions widget and uses equations', function () {
+    const widget = WidgetFixture({
+      widgetType: WidgetType.TRANSACTIONS,
+      queries: [
+        {
+          fields: ['equation|p75(measurements.inp)'],
+          aggregates: ['equation|p75(measurements.inp)'],
+          columns: [],
+          conditions: '',
+          name: 'equation widget',
+          orderby: '',
+        },
+      ],
+    });
+
+    expect(shouldForceQueryToSpans(widget)).toBe(false);
+  });
+
+  it('return false if the widget is a transactions widget and uses percentile', function () {
+    const widget = WidgetFixture({
+      widgetType: WidgetType.TRANSACTIONS,
+      queries: [
+        {
+          fields: ['percentile(measurements.inp, 0.9)'],
+          aggregates: ['percentile(measurements.inp, 0.9)'],
+          columns: [],
+          conditions: '',
+          name: 'percentile widget',
+          orderby: '',
+        },
+      ],
+    });
+
+    expect(shouldForceQueryToSpans(widget)).toBe(false);
+  });
+});

--- a/static/app/views/dashboards/utils/shouldForceQueryToSpans.tsx
+++ b/static/app/views/dashboards/utils/shouldForceQueryToSpans.tsx
@@ -1,0 +1,31 @@
+import {type Widget, WidgetType} from 'sentry/views/dashboards/types';
+
+// Checks for specific widget conditions that should force a widget to query the spans dataset instead
+// TODO: Deprecate this function when all metric widgets have been migrated to the spans dataset
+export function shouldForceQueryToSpans(widget: Widget) {
+  // If a widget is using measurements.inp in any field, including as an aggregation and is not using equations or percentile
+  if (
+    widget.widgetType === WidgetType.TRANSACTIONS &&
+    widget.queries.some(query =>
+      query.fields?.some(field => field.includes('measurements.inp'))
+    ) &&
+    !widgetUsesEquations(widget) &&
+    !widgetUsesPercentile(widget)
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+function widgetUsesEquations(widget: Widget) {
+  return widget.queries.some(query =>
+    query.fields?.some(field => field.includes('equation|'))
+  );
+}
+
+function widgetUsesPercentile(widget: Widget) {
+  return widget.queries.some(query =>
+    query.fields?.some(field => field.includes('percentile'))
+  );
+}

--- a/static/app/views/dashboards/widgetCard/widgetCardDataLoader.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardDataLoader.tsx
@@ -9,6 +9,7 @@ import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 import type {DashboardFilters, Widget} from 'sentry/views/dashboards/types';
 import {WidgetType} from 'sentry/views/dashboards/types';
+import {shouldForceQueryToSpans} from 'sentry/views/dashboards/utils/shouldForceQueryToSpans';
 import SpansWidgetQueries from 'sentry/views/dashboards/widgetCard/spansWidgetQueries';
 
 import IssueWidgetQueries from './issueWidgetQueries';
@@ -104,7 +105,7 @@ export function WidgetCardDataLoader({
     );
   }
 
-  if (widget.widgetType === WidgetType.SPANS) {
+  if (widget.widgetType === WidgetType.SPANS || shouldForceQueryToSpans(widget)) {
     return (
       <SpansWidgetQueries
         api={api}


### PR DESCRIPTION
Updates widget queries to evaluate if an INP widget on the transactions/metrics dataset is compatible to be run on the spans dataset. A widget is compatible if it:
- is a `Transactions` data type
- contains `measurements.inp` in `fields`, including as an aggregation
- does not use equations
- does not use the `percentile()` function

This check is completely frontend and does not affect backend or databases. When inspecting/editing a widget, the widget configuration remains unchanged, ie will still be set to the `Transactions` data type. The widget also still shows the `Open in Discover` button, but this is also fine because Discover never worked for displaying metrics anyways (we can update to `Open in Explore` in a different pr, or let this be handled by the full migration).

This logic is intended to be removed once we fully migrate all widgets to EAP.