### PR TITLE
fix(API): Fix error message in code mappings endpoint

### DIFF
--- a/src/sentry/integrations/api/endpoints/organization_code_mappings.py
+++ b/src/sentry/integrations/api/endpoints/organization_code_mappings.py
@@ -192,7 +192,7 @@ class OrganizationCodeMappingsEndpoint(OrganizationEndpoint, OrganizationIntegra
         integration_id = request.data.get("integrationId")
 
         if not integration_id:
-            return self.respond("Missing param: integration_id", status=status.HTTP_400_BAD_REQUEST)
+            return self.respond("Missing param: integrationId", status=status.HTTP_400_BAD_REQUEST)
 
         try:
             project = Project.objects.get(id=request.data.get("projectId"))

--- a/tests/sentry/integrations/api/endpoints/test_organization_code_mappings.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_code_mappings.py
@@ -255,7 +255,7 @@ class OrganizationCodeMappingsTest(APITestCase):
     def test_basic_post_with_no_integrationId(self):
         response = self.make_post({"integrationId": None})
         assert response.status_code == 400, response.content
-        assert response.data == "Missing param: integration_id"
+        assert response.data == "Missing param: integrationId"
 
     def test_empty_roots_post(self):
         response = self.make_post({"stackRoot": "", "sourceRoot": ""})


### PR DESCRIPTION
This fixes an error message returned by the code mappings endpoint to list the name of the missing parameter accurately (`integration_id` is the local variable, but the API parameter is `integrationId`).