### PR TITLE
chore(widget-builder): simplify labels

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/datasetSelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/datasetSelector.tsx
@@ -128,6 +128,7 @@ const FeatureBadgeAlignmentWrapper = styled('div')`
 `;
 
 const DatasetChoices = styled(RadioGroup<WidgetType>)`
+  display: flex;
   flex-direction: row;
   flex-wrap: wrap;
 `;

--- a/static/app/views/dashboards/widgetBuilder/components/datasetSelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/datasetSelector.tsx
@@ -127,7 +127,10 @@ const FeatureBadgeAlignmentWrapper = styled('div')`
   }
 `;
 
-const DatasetChoices = styled(RadioGroup<WidgetType>)``;
+const DatasetChoices = styled(RadioGroup<WidgetType>)`
+  flex-direction: row;
+  flex-wrap: wrap;
+`;
 
 const StyledSectionHeader = styled(SectionHeader)`
   margin-bottom: ${space(1)};

--- a/static/app/views/dashboards/widgetBuilder/components/datasetSelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/datasetSelector.tsx
@@ -51,7 +51,6 @@ function WidgetBuilderDatasetSelector() {
       }),
     ]);
   }
-  datasetChoices.push([WidgetType.TRANSACTIONS, t('Transactions')]);
 
   if (organization.features.includes('visibility-explore-view')) {
     datasetChoices.push([WidgetType.SPANS, t('Spans')]);
@@ -74,6 +73,7 @@ function WidgetBuilderDatasetSelector() {
   }
   datasetChoices.push([WidgetType.ISSUE, t('Issues')]);
   datasetChoices.push([WidgetType.RELEASE, t('Releases')]);
+  datasetChoices.push([WidgetType.TRANSACTIONS, t('Transactions')]);
 
   return (
     <Fragment>
@@ -127,12 +127,7 @@ const FeatureBadgeAlignmentWrapper = styled('div')`
   }
 `;
 
-const DatasetChoices = styled(RadioGroup<WidgetType>)`
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-  gap: ${space(2)};
-`;
+const DatasetChoices = styled(RadioGroup<WidgetType>)``;
 
 const StyledSectionHeader = styled(SectionHeader)`
   margin-bottom: ${space(1)};

--- a/static/app/views/dashboards/widgetBuilder/components/nameAndDescFields.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/nameAndDescFields.tsx
@@ -32,7 +32,10 @@ function WidgetBuilderNameAndDescription({
 
   return (
     <Fragment>
-      <SectionHeader title={t('Display Name')} />
+      <SectionHeader
+        title={t('Display Name')}
+        tooltipText={t('This will appear in the header of your widget.')}
+      />
       <StyledTextField
         name={t('Name')}
         size="md"

--- a/static/app/views/dashboards/widgetBuilder/components/nameAndDescFields.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/nameAndDescFields.tsx
@@ -32,13 +32,13 @@ function WidgetBuilderNameAndDescription({
 
   return (
     <Fragment>
-      <SectionHeader title={t('Widget Name & Description')} />
+      <SectionHeader title={t('Display Name')} />
       <StyledTextField
-        name={t('Widget Name')}
+        name={t('Name')}
         size="md"
         placeholder={t('Name')}
-        title={t('Widget Name')}
-        aria-label={t('Widget Name')}
+        title={t('Name')}
+        aria-label={t('Name')}
         value={state.title}
         onChange={(newTitle: any) => {
           // clear error once user starts typing
@@ -63,19 +63,19 @@ function WidgetBuilderNameAndDescription({
       {!isDescSelected && (
         <Button
           priority="link"
-          aria-label={t('Add Widget Description')}
+          aria-label={t('Add Description')}
           onClick={() => {
             setIsDescSelected(true);
           }}
           data-test-id={'add-description'}
         >
-          {t('+ Add Widget Description')}
+          {t('+ Add Description')}
         </Button>
       )}
       {isDescSelected && (
-        <DescriptionTextArea
+        <TextArea
           placeholder={t('Description')}
-          aria-label={t('Widget Description')}
+          aria-label={t('Description')}
           autosize
           rows={4}
           value={state.description}
@@ -105,8 +105,4 @@ const StyledTextField = styled(TextField)`
   margin-bottom: ${space(1)};
   padding: 0;
   border: none;
-`;
-
-const DescriptionTextArea = styled(TextArea)`
-  margin: ${space(2)} 0;
 `;

--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.spec.tsx
@@ -127,7 +127,7 @@ describe('NewWidgetBuilder', function () {
     expect(await screen.findByRole('button', {name: 'All Releases'})).toBeInTheDocument();
 
     expect(await screen.findByPlaceholderText('Name')).toBeInTheDocument();
-    expect(await screen.findByText('+ Add Widget Description')).toBeInTheDocument();
+    expect(await screen.findByText('+ Add Description')).toBeInTheDocument();
 
     expect(await screen.findByLabelText('Dataset')).toHaveAttribute('role', 'radiogroup');
     expect(screen.getByText('Errors')).toBeInTheDocument();

--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
@@ -370,15 +370,10 @@ export function WidgetPreviewContainer({
                 ref={setNodeRef}
                 id={WIDGET_PREVIEW_DRAG_ID}
                 style={draggableStyle}
-                aria-label={t('Draggable Widget Preview')}
+                aria-label={t('Draggable Preview')}
                 {...attributes}
                 {...listeners}
               >
-                {!isSmallScreen && (
-                  <WidgetPreviewTitle {...animatedProps}>
-                    {t('Widget Preview')}
-                  </WidgetPreviewTitle>
-                )}
                 <SampleWidgetCard
                   {...animatedProps}
                   style={{
@@ -562,13 +557,6 @@ const SurroundingWidgetContainer = styled('div')`
   display: flex;
   justify-content: center;
   align-items: center;
-`;
-
-const WidgetPreviewTitle = styled(motion.h5)`
-  margin-bottom: ${space(1)};
-  margin-left: ${space(1)};
-  color: ${p => p.theme.white};
-  font-weight: ${p => p.theme.fontWeight.bold};
 `;
 
 const FilterBarContainer = styled(motion.div)`

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
@@ -971,6 +971,7 @@ export const FieldExtras = styled('div')<{isChartWidget: boolean}>`
   flex-direction: row;
   gap: ${space(1)};
   flex: ${p => (p.isChartWidget ? '0' : '1')};
+  align-items: center;
 `;
 
 const AddButton = styled(Button)`


### PR DESCRIPTION
- Moved the disabled transactions to be last in the dataset list
- Renamed Widget Name and Description to be shorter and more scannable 
- Removed Widget Preview seeing how obvious that is

**Before:**
<img width="1324" height="962" alt="Screenshot 2025-07-18 at 11 30 42 AM" src="https://github.com/user-attachments/assets/b73be3f8-5edc-488d-8897-5707f1c55e91" />
<img width="535" height="142" alt="Screenshot 2025-07-18 at 11 54 54 AM" src="https://github.com/user-attachments/assets/7495f601-3ce1-483e-b243-8aad8774097d" />

**After:**
<img width="1335" height="965" alt="Screenshot 2025-07-18 at 11 30 32 AM" src="https://github.com/user-attachments/assets/0a48eb0e-bff0-492a-8d93-d5503a80e909" />
<img width="549" height="142" alt="Screenshot 2025-07-18 at 11 54 27 AM" src="https://github.com/user-attachments/assets/06610a91-8ed4-46dc-9a1a-804ad8fd06a7" />