### PR TITLE
ref(replay): filter out blur & focus breadcrumbs from replay summary

### DIFF
--- a/src/sentry/replays/endpoints/project_replay_summarize_breadcrumbs.py
+++ b/src/sentry/replays/endpoints/project_replay_summarize_breadcrumbs.py
@@ -392,11 +392,11 @@ def as_log_message(event: dict[str, Any]) -> str | None:
                 message = event["data"]["payload"]["message"]
                 return f"Logged: {message} at {timestamp}"
             case EventType.UI_BLUR:
-                timestamp_ms = timestamp * 1000
-                return f"User looked away from the tab at {timestamp_ms}"
+                # timestamp_ms = timestamp * 1000
+                return None
             case EventType.UI_FOCUS:
-                timestamp_ms = timestamp * 1000
-                return f"User returned to tab at {timestamp_ms}"
+                # timestamp_ms = timestamp * 1000
+                return None
             case EventType.RESOURCE_FETCH:
                 timestamp_ms = timestamp * 1000
                 payload = event["data"]["payload"]

--- a/tests/sentry/replays/endpoints/test_project_replay_summarize_breadcrumbs.py
+++ b/tests/sentry/replays/endpoints/test_project_replay_summarize_breadcrumbs.py
@@ -695,14 +695,14 @@ def test_as_log_message():
         "timestamp": 0.0,
         "data": {"tag": "breadcrumb", "payload": {"category": "ui.blur"}},
     }
-    assert as_log_message(event) is not None
+    assert as_log_message(event) is None
 
     event = {
         "type": 5,
         "timestamp": 0.0,
         "data": {"tag": "breadcrumb", "payload": {"category": "ui.focus"}},
     }
-    assert as_log_message(event) is not None
+    assert as_log_message(event) is None
 
     event = {
         "type": 5,


### PR DESCRIPTION
from experimentation & feedback, it appears that these breadcrumbs (blur/focus) are not important for including in the replay summary or chapters. furthermore, we don't show these in the UI at all in the breadcrumbs tab

relates to https://linear.app/getsentry/issue/REPLAY-488/consider-filtering-out-unimportant-replay-events-phrases