### PR TITLE
ref(grouping): Simplify enhancements helpers post legacy config removal

### DIFF
--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -356,8 +356,6 @@ class Enhancements:
         self.version = version or DEFAULT_ENHANCEMENTS_VERSION
         self.bases = bases or []
 
-        self.rust_enhancements = _merge_rust_enhancements(self.bases, rust_enhancements)
-
         classifier_config, contributes_config = split_enhancement_configs or _split_rules(rules)
 
         self.classifier_rules = classifier_config.rules

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -73,7 +73,7 @@ def EmptyRustFrame() -> RustFrame:  # noqa
 def _merge_rust_enhancements(
     bases: list[str],
     rust_enhancements: RustEnhancements,
-    type: Literal["classifier", "contributes"] | None = None,
+    type: Literal["classifier", "contributes"],
 ) -> RustEnhancements:
     """
     This will merge the parsed enhancements together with the `bases`.
@@ -85,13 +85,9 @@ def _merge_rust_enhancements(
         base = ENHANCEMENT_BASES.get(base_id)
         if base:
             base_rust_enhancements = (
-                base.rust_enhancements
-                if type is None
-                else (
-                    base.classifier_rust_enhancements
-                    if type == "classifier"
-                    else base.contributes_rust_enhancements
-                )
+                base.classifier_rust_enhancements
+                if type == "classifier"
+                else base.contributes_rust_enhancements
             )
             merged_rust_enhancements.extend_from(base_rust_enhancements)
     merged_rust_enhancements.extend_from(rust_enhancements)

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -142,7 +142,7 @@ def _can_use_hint(
     variant_name: str,
     frame_component: FrameGroupingComponent,
     hint: str | None,
-    desired_hint_type: Literal["in-app", "contributes"] | None = None,
+    desired_hint_type: Literal["in-app", "contributes"],
 ) -> bool:
     # Prevent clobbering an existing hint with no hint
     if hint is None:
@@ -152,7 +152,7 @@ def _can_use_hint(
     hint_type = "contributes" if "ignored" in hint else "in-app"
 
     # Don't use the hint if we've specifically asked for something different
-    if desired_hint_type and hint_type != desired_hint_type:
+    if hint_type != desired_hint_type:
         return False
 
     # System frames can't contribute to the app variant, no matter what +/-group rules say, so we
@@ -173,7 +173,7 @@ def _get_hint_for_frame(
     frame: dict[str, Any],
     frame_component: FrameGroupingComponent,
     rust_frame: RustFrame,
-    desired_hint_type: Literal["in-app", "contributes"] | None = None,
+    desired_hint_type: Literal["in-app", "contributes"],
 ) -> str | None:
     """
     Determine a hint to use for the frame, handling special-casing and precedence.
@@ -186,10 +186,7 @@ def _get_hint_for_frame(
     )
     incoming_hint = frame_component.hint
 
-    # TODO: We can switch this to `desired_hint_type == "in-app"` once we're only using split
-    # enhancements. For now, we need to also include the case where `desired_hint_type` is None. (At
-    # that point we can also change the type of the parameter to be a required string.)
-    if variant_name == "app" and desired_hint_type != "contributes":
+    if variant_name == "app" and desired_hint_type == "in-app":
         default_in_app_hint = "non app frame" if not frame_component.in_app else None
         client_in_app_hint = (
             f"marked {"in-app" if client_in_app else "out of app"} by the client"

--- a/tests/sentry/grouping/enhancements/test_hints.py
+++ b/tests/sentry/grouping/enhancements/test_hints.py
@@ -42,7 +42,7 @@ default_system_frame_hint = "non app frame"
     #    client_in_app: None, True, or False
     #    rust_hint: in_app_hint, out_of_app_hint, ignored_hint, unignored_hint, or None
     #    incoming_hint: None or ignored_because_hint (the only kind of hint that gets set ahead of time)
-    #    desired_hint_type: None, in-app, or contributes
+    #    desired_hint_type: In-app or contributes
     #
     # Some of the combos will never happen in real life, and those that won't are marked. They're still
     # in the list because it's much easier to ensure every case is covered that way.
@@ -50,364 +50,244 @@ default_system_frame_hint = "non app frame"
     # No formatting so that we can keep all the cases as single lines
     # fmt: off
     [
-        ("app", True, None, in_app_hint, None, None, in_app_hint),
         ("app", True, None, in_app_hint, None, "in-app", in_app_hint),
         ("app", True, None, in_app_hint, None, "contributes", None),
-        ("app", True, None, in_app_hint, ignored_because_hint, None, in_app_hint),
         ("app", True, None, in_app_hint, ignored_because_hint, "in-app", in_app_hint),
         ("app", True, None, in_app_hint, ignored_because_hint, "contributes", ignored_because_hint),
-        ("app", True, None, out_of_app_hint, None, None, out_of_app_hint),  # impossible - rust can't return out of app hint if it marks frame in-app
         ("app", True, None, out_of_app_hint, None, "in-app", out_of_app_hint),  # impossible - rust can't return out of app hint if it marks frame in-app
         ("app", True, None, out_of_app_hint, None, "contributes", None),  # impossible - rust can't return out of app hint if it marks frame in-app
-        ("app", True, None, out_of_app_hint, ignored_because_hint, None, out_of_app_hint),  # impossible - rust can't return out of app hint if it marks frame in-app
         ("app", True, None, out_of_app_hint, ignored_because_hint, "in-app", out_of_app_hint),  # impossible - rust can't return out of app hint if it marks frame in-app
         ("app", True, None, out_of_app_hint, ignored_because_hint, "contributes", ignored_because_hint),  # impossible - rust can't return out of app hint if it marks frame in-app
-        ("app", True, None, ignored_hint, None, None, ignored_hint),
         ("app", True, None, ignored_hint, None, "in-app", None),
         ("app", True, None, ignored_hint, None, "contributes", ignored_hint),
-        ("app", True, None, ignored_hint, ignored_because_hint, None, ignored_hint),
         ("app", True, None, ignored_hint, ignored_because_hint, "in-app", None),
         ("app", True, None, ignored_hint, ignored_because_hint, "contributes", ignored_hint),
-        ("app", True, None, unignored_hint, None, None, unignored_hint),
         ("app", True, None, unignored_hint, None, "in-app", None),
         ("app", True, None, unignored_hint, None, "contributes", unignored_hint),
-        ("app", True, None, unignored_hint, ignored_because_hint, None, unignored_hint),
         ("app", True, None, unignored_hint, ignored_because_hint, "in-app", None),
         ("app", True, None, unignored_hint, ignored_because_hint, "contributes", unignored_hint),
-        ("app", True, None, None, None, None, None),
         ("app", True, None, None, None, "in-app", None),
         ("app", True, None, None, None, "contributes", None),
-        ("app", True, None, None, ignored_because_hint, None, ignored_because_hint),
         ("app", True, None, None, ignored_because_hint, "in-app", None),
         ("app", True, None, None, ignored_because_hint, "contributes", ignored_because_hint),
-        ("app", True, True, in_app_hint, None, None, client_in_app_hint),
         ("app", True, True, in_app_hint, None, "in-app", client_in_app_hint),
         ("app", True, True, in_app_hint, None, "contributes", None),
-        ("app", True, True, in_app_hint, ignored_because_hint, None, client_in_app_hint),
         ("app", True, True, in_app_hint, ignored_because_hint, "in-app", client_in_app_hint),
         ("app", True, True, in_app_hint, ignored_because_hint, "contributes", ignored_because_hint),
-        ("app", True, True, out_of_app_hint, None, None, client_in_app_hint),  # impossible - rust can't return out of app hint if it marks frame in-app
         ("app", True, True, out_of_app_hint, None, "in-app", client_in_app_hint),  # impossible - rust can't return out of app hint if it marks frame in-app
         ("app", True, True, out_of_app_hint, None, "contributes", None),  # impossible - rust can't return out of app hint if it marks frame in-app
-        ("app", True, True, out_of_app_hint, ignored_because_hint, None, client_in_app_hint),  # impossible - rust can't return out of app hint if it marks frame in-app
         ("app", True, True, out_of_app_hint, ignored_because_hint, "in-app", client_in_app_hint),  # impossible - rust can't return out of app hint if it marks frame in-app
         ("app", True, True, out_of_app_hint, ignored_because_hint, "contributes", ignored_because_hint),  # impossible - rust can't return out of app hint if it marks frame in-app
-        ("app", True, True, ignored_hint, None, None, ignored_hint),
         ("app", True, True, ignored_hint, None, "in-app", client_in_app_hint),
         ("app", True, True, ignored_hint, None, "contributes", ignored_hint),
-        ("app", True, True, ignored_hint, ignored_because_hint, None, ignored_hint),
         ("app", True, True, ignored_hint, ignored_because_hint, "in-app", client_in_app_hint),
         ("app", True, True, ignored_hint, ignored_because_hint, "contributes", ignored_hint),
-        ("app", True, True, unignored_hint, None, None, unignored_hint),
         ("app", True, True, unignored_hint, None, "in-app", client_in_app_hint),
         ("app", True, True, unignored_hint, None, "contributes", unignored_hint),
-        ("app", True, True, unignored_hint, ignored_because_hint, None, unignored_hint),
         ("app", True, True, unignored_hint, ignored_because_hint, "in-app", client_in_app_hint),
         ("app", True, True, unignored_hint, ignored_because_hint, "contributes", unignored_hint),
-        ("app", True, True, None, None, None, client_in_app_hint),
         ("app", True, True, None, None, "in-app", client_in_app_hint),
         ("app", True, True, None, None, "contributes", None),
-        ("app", True, True, None, ignored_because_hint, None, client_in_app_hint),
         ("app", True, True, None, ignored_because_hint, "in-app", client_in_app_hint),
         ("app", True, True, None, ignored_because_hint, "contributes", ignored_because_hint),
-        ("app", True, False, in_app_hint, None, None, in_app_hint),
         ("app", True, False, in_app_hint, None, "in-app", in_app_hint),
         ("app", True, False, in_app_hint, None, "contributes", None),
-        ("app", True, False, in_app_hint, ignored_because_hint, None, in_app_hint),
         ("app", True, False, in_app_hint, ignored_because_hint, "in-app", in_app_hint),
         ("app", True, False, in_app_hint, ignored_because_hint, "contributes", ignored_because_hint),
-        ("app", True, False, out_of_app_hint, None, None, out_of_app_hint),  # impossible - rust can't return out of app hint if it marks frame in-app
         ("app", True, False, out_of_app_hint, None, "in-app", out_of_app_hint),  # impossible - rust can't return out of app hint if it marks frame in-app
         ("app", True, False, out_of_app_hint, None, "contributes", None),  # impossible - rust can't return out of app hint if it marks frame in-app
-        ("app", True, False, out_of_app_hint, ignored_because_hint, None, out_of_app_hint),  # impossible - rust can't return out of app hint if it marks frame in-app
         ("app", True, False, out_of_app_hint, ignored_because_hint, "in-app", out_of_app_hint),  # impossible - rust can't return out of app hint if it marks frame in-app
         ("app", True, False, out_of_app_hint, ignored_because_hint, "contributes", ignored_because_hint),  # impossible - rust can't return out of app hint if it marks frame in-app
-        ("app", True, False, ignored_hint, None, None, ignored_hint),
         ("app", True, False, ignored_hint, None, "in-app", None),
         ("app", True, False, ignored_hint, None, "contributes", ignored_hint),
-        ("app", True, False, ignored_hint, ignored_because_hint, None, ignored_hint),
         ("app", True, False, ignored_hint, ignored_because_hint, "in-app", None),
         ("app", True, False, ignored_hint, ignored_because_hint, "contributes", ignored_hint),
-        ("app", True, False, unignored_hint, None, None, unignored_hint),
         ("app", True, False, unignored_hint, None, "in-app", None),
         ("app", True, False, unignored_hint, None, "contributes", unignored_hint),
-        ("app", True, False, unignored_hint, ignored_because_hint, None, unignored_hint),
         ("app", True, False, unignored_hint, ignored_because_hint, "in-app", None),
         ("app", True, False, unignored_hint, ignored_because_hint, "contributes", unignored_hint),
-        ("app", True, False, None, None, None, None),  # impossible - can't have no rust hint if client in-app is changed
         ("app", True, False, None, None, "in-app", None),  # impossible - can't have no rust hint if client in-app is changed
         ("app", True, False, None, None, "contributes", None),  # impossible - can't have no rust hint if client in-app is changed
-        ("app", True, False, None, ignored_because_hint, None, ignored_because_hint),  # impossible - can't have no rust hint if client in-app is changed
         ("app", True, False, None, ignored_because_hint, "in-app", None),  # impossible - can't have no rust hint if client in-app is changed
         ("app", True, False, None, ignored_because_hint, "contributes", ignored_because_hint),  # impossible - can't have no rust hint if client in-app is changed
-        ("app", False, None, in_app_hint, None, None, in_app_hint),  # impossible - rust can't return in-app hint if it marks frame out of app
         ("app", False, None, in_app_hint, None, "in-app", in_app_hint),  # impossible - rust can't return in-app hint if it marks frame out of app
         ("app", False, None, in_app_hint, None, "contributes", None),  # impossible - rust can't return in-app hint if it marks frame out of app
-        ("app", False, None, in_app_hint, ignored_because_hint, None, in_app_hint),  # impossible - rust can't return in-app hint if it marks frame out of app
         ("app", False, None, in_app_hint, ignored_because_hint, "in-app", in_app_hint),  # impossible - rust can't return in-app hint if it marks frame out of app
         ("app", False, None, in_app_hint, ignored_because_hint, "contributes", None),  # impossible - rust can't return in-app hint if it marks frame out of app
-        ("app", False, None, out_of_app_hint, None, None, out_of_app_hint),
         ("app", False, None, out_of_app_hint, None, "in-app", out_of_app_hint),
         ("app", False, None, out_of_app_hint, None, "contributes", None),
-        ("app", False, None, out_of_app_hint, ignored_because_hint, None, out_of_app_hint),
         ("app", False, None, out_of_app_hint, ignored_because_hint, "in-app", out_of_app_hint),
         ("app", False, None, out_of_app_hint, ignored_because_hint, "contributes", None),
-        ("app", False, None, ignored_hint, None, None, default_system_frame_hint),
         ("app", False, None, ignored_hint, None, "in-app", default_system_frame_hint),
         ("app", False, None, ignored_hint, None, "contributes", None),
-        ("app", False, None, ignored_hint, ignored_because_hint, None, default_system_frame_hint),
         ("app", False, None, ignored_hint, ignored_because_hint, "in-app", default_system_frame_hint),
         ("app", False, None, ignored_hint, ignored_because_hint, "contributes", None),
-        ("app", False, None, unignored_hint, None, None, default_system_frame_hint),
         ("app", False, None, unignored_hint, None, "in-app", default_system_frame_hint),
         ("app", False, None, unignored_hint, None, "contributes", None),
-        ("app", False, None, unignored_hint, ignored_because_hint, None, default_system_frame_hint),
         ("app", False, None, unignored_hint, ignored_because_hint, "in-app", default_system_frame_hint),
         ("app", False, None, unignored_hint, ignored_because_hint, "contributes", None),
-        ("app", False, None, None, None, None, default_system_frame_hint),
         ("app", False, None, None, None, "in-app", default_system_frame_hint),
         ("app", False, None, None, None, "contributes", None),
-        ("app", False, None, None, ignored_because_hint, None, default_system_frame_hint),
         ("app", False, None, None, ignored_because_hint, "in-app", default_system_frame_hint),
         ("app", False, None, None, ignored_because_hint, "contributes", None),
-        ("app", False, True, in_app_hint, None, None, in_app_hint),  # impossible - rust can't return in-app hint if it marks frame out of app
         ("app", False, True, in_app_hint, None, "in-app", in_app_hint),  # impossible - rust can't return in-app hint if it marks frame out of app
         ("app", False, True, in_app_hint, None, "contributes", None),  # impossible - rust can't return in-app hint if it marks frame out of app
-        ("app", False, True, in_app_hint, ignored_because_hint, None, in_app_hint),  # impossible - rust can't return in-app hint if it marks frame out of app
         ("app", False, True, in_app_hint, ignored_because_hint, "in-app", in_app_hint),  # impossible - rust can't return in-app hint if it marks frame out of app
         ("app", False, True, in_app_hint, ignored_because_hint, "contributes", None),  # impossible - rust can't return in-app hint if it marks frame out of app
-        ("app", False, True, out_of_app_hint, None, None, out_of_app_hint),
         ("app", False, True, out_of_app_hint, None, "in-app", out_of_app_hint),
         ("app", False, True, out_of_app_hint, None, "contributes", None),
-        ("app", False, True, out_of_app_hint, ignored_because_hint, None, out_of_app_hint),
         ("app", False, True, out_of_app_hint, ignored_because_hint, "in-app", out_of_app_hint),
         ("app", False, True, out_of_app_hint, ignored_because_hint, "contributes", None),
-        ("app", False, True, ignored_hint, None, None, default_system_frame_hint),
         ("app", False, True, ignored_hint, None, "in-app", default_system_frame_hint),
         ("app", False, True, ignored_hint, None, "contributes", None),
-        ("app", False, True, ignored_hint, ignored_because_hint, None, default_system_frame_hint),
         ("app", False, True, ignored_hint, ignored_because_hint, "in-app", default_system_frame_hint),
         ("app", False, True, ignored_hint, ignored_because_hint, "contributes", None),
-        ("app", False, True, unignored_hint, None, None, default_system_frame_hint),
         ("app", False, True, unignored_hint, None, "in-app", default_system_frame_hint),
         ("app", False, True, unignored_hint, None, "contributes", None),
-        ("app", False, True, unignored_hint, ignored_because_hint, None, default_system_frame_hint),
         ("app", False, True, unignored_hint, ignored_because_hint, "in-app", default_system_frame_hint),
         ("app", False, True, unignored_hint, ignored_because_hint, "contributes", None),
-        ("app", False, True, None, None, None, default_system_frame_hint),  # impossible - can't have no rust hint if client in-app is changed
         ("app", False, True, None, None, "in-app", default_system_frame_hint),  # impossible - can't have no rust hint if client in-app is changed
         ("app", False, True, None, None, "contributes", None),  # impossible - can't have no rust hint if client in-app is changed
-        ("app", False, True, None, ignored_because_hint, None, default_system_frame_hint),  # impossible - can't have no rust hint if client in-app is changed
         ("app", False, True, None, ignored_because_hint, "in-app", default_system_frame_hint),  # impossible - can't have no rust hint if client in-app is changed
         ("app", False, True, None, ignored_because_hint, "contributes", None),  # impossible - can't have no rust hint if client in-app is changed
-        ("app", False, False, in_app_hint, None, None, client_out_of_app_hint),  # impossible - rust can't return in-app hint if it marks frame out of app
         ("app", False, False, in_app_hint, None, "in-app", client_out_of_app_hint),  # impossible - rust can't return in-app hint if it marks frame out of app
         ("app", False, False, in_app_hint, None, "contributes", None),  # impossible - rust can't return in-app hint if it marks frame out of app
-        ("app", False, False, in_app_hint, ignored_because_hint, None, client_out_of_app_hint),  # impossible - rust can't return in-app hint if it marks frame out of app
         ("app", False, False, in_app_hint, ignored_because_hint, "in-app", client_out_of_app_hint),  # impossible - rust can't return in-app hint if it marks frame out of app
         ("app", False, False, in_app_hint, ignored_because_hint, "contributes", None),  # impossible - rust can't return in-app hint if it marks frame out of app
-        ("app", False, False, out_of_app_hint, None, None, client_out_of_app_hint),
         ("app", False, False, out_of_app_hint, None, "in-app", client_out_of_app_hint),
         ("app", False, False, out_of_app_hint, None, "contributes", None),
-        ("app", False, False, out_of_app_hint, ignored_because_hint, None, client_out_of_app_hint),
         ("app", False, False, out_of_app_hint, ignored_because_hint, "in-app", client_out_of_app_hint),
         ("app", False, False, out_of_app_hint, ignored_because_hint, "contributes", None),
-        ("app", False, False, ignored_hint, None, None, client_out_of_app_hint),
         ("app", False, False, ignored_hint, None, "in-app", client_out_of_app_hint),
         ("app", False, False, ignored_hint, None, "contributes", None),
-        ("app", False, False, ignored_hint, ignored_because_hint, None, client_out_of_app_hint),
         ("app", False, False, ignored_hint, ignored_because_hint, "in-app", client_out_of_app_hint),
         ("app", False, False, ignored_hint, ignored_because_hint, "contributes", None),
-        ("app", False, False, unignored_hint, None, None, client_out_of_app_hint),
         ("app", False, False, unignored_hint, None, "in-app", client_out_of_app_hint),
         ("app", False, False, unignored_hint, None, "contributes", None),
-        ("app", False, False, unignored_hint, ignored_because_hint, None, client_out_of_app_hint),
         ("app", False, False, unignored_hint, ignored_because_hint, "in-app", client_out_of_app_hint),
         ("app", False, False, unignored_hint, ignored_because_hint, "contributes", None),
-        ("app", False, False, None, None, None, client_out_of_app_hint),
         ("app", False, False, None, None, "in-app", client_out_of_app_hint),
         ("app", False, False, None, None, "contributes", None),
-        ("app", False, False, None, ignored_because_hint, None, client_out_of_app_hint),
         ("app", False, False, None, ignored_because_hint, "in-app", client_out_of_app_hint),
         ("app", False, False, None, ignored_because_hint, "contributes", None),
-        ("system", True, None, in_app_hint, None, None, None),
         ("system", True, None, in_app_hint, None, "in-app", None),
         ("system", True, None, in_app_hint, None, "contributes", None),
-        ("system", True, None, in_app_hint, ignored_because_hint, None, ignored_because_hint),
         ("system", True, None, in_app_hint, ignored_because_hint, "in-app", None),
         ("system", True, None, in_app_hint, ignored_because_hint, "contributes", ignored_because_hint),
-        ("system", True, None, out_of_app_hint, None, None, None),  # impossible - rust can't return out of app hint if it marks frame in-app
         ("system", True, None, out_of_app_hint, None, "in-app", None),  # impossible - rust can't return out of app hint if it marks frame in-app
         ("system", True, None, out_of_app_hint, None, "contributes", None),  # impossible - rust can't return out of app hint if it marks frame in-app
-        ("system", True, None, out_of_app_hint, ignored_because_hint, None, ignored_because_hint),  # impossible - rust can't return out of app hint if it marks frame in-app
         ("system", True, None, out_of_app_hint, ignored_because_hint, "in-app", None),  # impossible - rust can't return out of app hint if it marks frame in-app
         ("system", True, None, out_of_app_hint, ignored_because_hint, "contributes", ignored_because_hint),  # impossible - rust can't return out of app hint if it marks frame in-app
-        ("system", True, None, ignored_hint, None, None, ignored_hint),
         ("system", True, None, ignored_hint, None, "in-app", None),
         ("system", True, None, ignored_hint, None, "contributes", ignored_hint),
-        ("system", True, None, ignored_hint, ignored_because_hint, None, ignored_hint),
         ("system", True, None, ignored_hint, ignored_because_hint, "in-app", None),
         ("system", True, None, ignored_hint, ignored_because_hint, "contributes", ignored_hint),
-        ("system", True, None, unignored_hint, None, None, unignored_hint),
         ("system", True, None, unignored_hint, None, "in-app", None),
         ("system", True, None, unignored_hint, None, "contributes", unignored_hint),
-        ("system", True, None, unignored_hint, ignored_because_hint, None, unignored_hint),
         ("system", True, None, unignored_hint, ignored_because_hint, "in-app", None),
         ("system", True, None, unignored_hint, ignored_because_hint, "contributes", unignored_hint),
-        ("system", True, None, None, None, None, None),
         ("system", True, None, None, None, "in-app", None),
         ("system", True, None, None, None, "contributes", None),
-        ("system", True, None, None, ignored_because_hint, None, ignored_because_hint),
         ("system", True, None, None, ignored_because_hint, "in-app", None),
         ("system", True, None, None, ignored_because_hint, "contributes", ignored_because_hint),
-        ("system", True, True, in_app_hint, None, None, None),
         ("system", True, True, in_app_hint, None, "in-app", None),
         ("system", True, True, in_app_hint, None, "contributes", None),
-        ("system", True, True, in_app_hint, ignored_because_hint, None, ignored_because_hint),
         ("system", True, True, in_app_hint, ignored_because_hint, "in-app", None),
         ("system", True, True, in_app_hint, ignored_because_hint, "contributes", ignored_because_hint),
-        ("system", True, True, out_of_app_hint, None, None, None),  # impossible - rust can't return out of app hint if it marks frame in-app
         ("system", True, True, out_of_app_hint, None, "in-app", None),  # impossible - rust can't return out of app hint if it marks frame in-app
         ("system", True, True, out_of_app_hint, None, "contributes", None),  # impossible - rust can't return out of app hint if it marks frame in-app
-        ("system", True, True, out_of_app_hint, ignored_because_hint, None, ignored_because_hint),  # impossible - rust can't return out of app hint if it marks frame in-app
         ("system", True, True, out_of_app_hint, ignored_because_hint, "in-app", None),  # impossible - rust can't return out of app hint if it marks frame in-app
         ("system", True, True, out_of_app_hint, ignored_because_hint, "contributes", ignored_because_hint),  # impossible - rust can't return out of app hint if it marks frame in-app
-        ("system", True, True, ignored_hint, None, None, ignored_hint),
         ("system", True, True, ignored_hint, None, "in-app", None),
         ("system", True, True, ignored_hint, None, "contributes", ignored_hint),
-        ("system", True, True, ignored_hint, ignored_because_hint, None, ignored_hint),
         ("system", True, True, ignored_hint, ignored_because_hint, "in-app", None),
         ("system", True, True, ignored_hint, ignored_because_hint, "contributes", ignored_hint),
-        ("system", True, True, unignored_hint, None, None, unignored_hint),
         ("system", True, True, unignored_hint, None, "in-app", None),
         ("system", True, True, unignored_hint, None, "contributes", unignored_hint),
-        ("system", True, True, unignored_hint, ignored_because_hint, None, unignored_hint),
         ("system", True, True, unignored_hint, ignored_because_hint, "in-app", None),
         ("system", True, True, unignored_hint, ignored_because_hint, "contributes", unignored_hint),
-        ("system", True, True, None, None, None, None),
         ("system", True, True, None, None, "in-app", None),
         ("system", True, True, None, None, "contributes", None),
-        ("system", True, True, None, ignored_because_hint, None, ignored_because_hint),
         ("system", True, True, None, ignored_because_hint, "in-app", None),
         ("system", True, True, None, ignored_because_hint, "contributes", ignored_because_hint),
-        ("system", True, False, in_app_hint, None, None, None),
         ("system", True, False, in_app_hint, None, "in-app", None),
         ("system", True, False, in_app_hint, None, "contributes", None),
-        ("system", True, False, in_app_hint, ignored_because_hint, None, ignored_because_hint),
         ("system", True, False, in_app_hint, ignored_because_hint, "in-app", None),
         ("system", True, False, in_app_hint, ignored_because_hint, "contributes", ignored_because_hint),
-        ("system", True, False, out_of_app_hint, None, None, None),  # impossible - rust can't return out of app hint if it marks frame in-app
         ("system", True, False, out_of_app_hint, None, "in-app", None),  # impossible - rust can't return out of app hint if it marks frame in-app
         ("system", True, False, out_of_app_hint, None, "contributes", None),  # impossible - rust can't return out of app hint if it marks frame in-app
-        ("system", True, False, out_of_app_hint, ignored_because_hint, None, ignored_because_hint),  # impossible - rust can't return out of app hint if it marks frame in-app
         ("system", True, False, out_of_app_hint, ignored_because_hint, "in-app", None),  # impossible - rust can't return out of app hint if it marks frame in-app
         ("system", True, False, out_of_app_hint, ignored_because_hint, "contributes", ignored_because_hint),  # impossible - rust can't return out of app hint if it marks frame in-app
-        ("system", True, False, ignored_hint, None, None, ignored_hint),
         ("system", True, False, ignored_hint, None, "in-app", None),
         ("system", True, False, ignored_hint, None, "contributes", ignored_hint),
-        ("system", True, False, ignored_hint, ignored_because_hint, None, ignored_hint),
         ("system", True, False, ignored_hint, ignored_because_hint, "in-app", None),
         ("system", True, False, ignored_hint, ignored_because_hint, "contributes", ignored_hint),
-        ("system", True, False, unignored_hint, None, None, unignored_hint),
         ("system", True, False, unignored_hint, None, "in-app", None),
         ("system", True, False, unignored_hint, None, "contributes", unignored_hint),
-        ("system", True, False, unignored_hint, ignored_because_hint, None, unignored_hint),
         ("system", True, False, unignored_hint, ignored_because_hint, "in-app", None),
         ("system", True, False, unignored_hint, ignored_because_hint, "contributes", unignored_hint),
-        ("system", True, False, None, None, None, None),  # impossible - can't have no rust hint if client in-app is changed
         ("system", True, False, None, None, "in-app", None),  # impossible - can't have no rust hint if client in-app is changed
         ("system", True, False, None, None, "contributes", None),  # impossible - can't have no rust hint if client in-app is changed
-        ("system", True, False, None, ignored_because_hint, None, ignored_because_hint),  # impossible - can't have no rust hint if client in-app is changed
         ("system", True, False, None, ignored_because_hint, "in-app", None),  # impossible - can't have no rust hint if client in-app is changed
         ("system", True, False, None, ignored_because_hint, "contributes", ignored_because_hint),  # impossible - can't have no rust hint if client in-app is changed
-        ("system", False, None, in_app_hint, None, None, None),  # impossible - rust can't return in-app hint if it marks frame out of app
         ("system", False, None, in_app_hint, None, "in-app", None),  # impossible - rust can't return in-app hint if it marks frame out of app
         ("system", False, None, in_app_hint, None, "contributes", None),  # impossible - rust can't return in-app hint if it marks frame out of app
-        ("system", False, None, in_app_hint, ignored_because_hint, None, ignored_because_hint),  # impossible - rust can't return in-app hint if it marks frame out of app
         ("system", False, None, in_app_hint, ignored_because_hint, "in-app", None),  # impossible - rust can't return in-app hint if it marks frame out of app
         ("system", False, None, in_app_hint, ignored_because_hint, "contributes", ignored_because_hint),  # impossible - rust can't return in-app hint if it marks frame out of app
-        ("system", False, None, out_of_app_hint, None, None, None),
         ("system", False, None, out_of_app_hint, None, "in-app", None),
         ("system", False, None, out_of_app_hint, None, "contributes", None),
-        ("system", False, None, out_of_app_hint, ignored_because_hint, None, ignored_because_hint),
         ("system", False, None, out_of_app_hint, ignored_because_hint, "in-app", None),
         ("system", False, None, out_of_app_hint, ignored_because_hint, "contributes", ignored_because_hint),
-        ("system", False, None, ignored_hint, None, None, ignored_hint),
         ("system", False, None, ignored_hint, None, "in-app", None),
         ("system", False, None, ignored_hint, None, "contributes", ignored_hint),
-        ("system", False, None, ignored_hint, ignored_because_hint, None, ignored_hint),
         ("system", False, None, ignored_hint, ignored_because_hint, "in-app", None),
         ("system", False, None, ignored_hint, ignored_because_hint, "contributes", ignored_hint),
-        ("system", False, None, unignored_hint, None, None, unignored_hint),
         ("system", False, None, unignored_hint, None, "in-app", None),
         ("system", False, None, unignored_hint, None, "contributes", unignored_hint),
-        ("system", False, None, unignored_hint, ignored_because_hint, None, unignored_hint),
         ("system", False, None, unignored_hint, ignored_because_hint, "in-app", None),
         ("system", False, None, unignored_hint, ignored_because_hint, "contributes", unignored_hint),
-        ("system", False, None, None, None, None, None),
         ("system", False, None, None, None, "in-app", None),
         ("system", False, None, None, None, "contributes", None),
-        ("system", False, None, None, ignored_because_hint, None, ignored_because_hint),
         ("system", False, None, None, ignored_because_hint, "in-app", None),
         ("system", False, None, None, ignored_because_hint, "contributes", ignored_because_hint),
-        ("system", False, True, in_app_hint, None, None, None),  # impossible - rust can't return in-app hint if it marks frame out of app
         ("system", False, True, in_app_hint, None, "in-app", None),  # impossible - rust can't return in-app hint if it marks frame out of app
         ("system", False, True, in_app_hint, None, "contributes", None),  # impossible - rust can't return in-app hint if it marks frame out of app
-        ("system", False, True, in_app_hint, ignored_because_hint, None, ignored_because_hint),  # impossible - rust can't return in-app hint if it marks frame out of app
         ("system", False, True, in_app_hint, ignored_because_hint, "in-app", None),  # impossible - rust can't return in-app hint if it marks frame out of app
         ("system", False, True, in_app_hint, ignored_because_hint, "contributes", ignored_because_hint),  # impossible - rust can't return in-app hint if it marks frame out of app
-        ("system", False, True, out_of_app_hint, None, None, None),
         ("system", False, True, out_of_app_hint, None, "in-app", None),
         ("system", False, True, out_of_app_hint, None, "contributes", None),
-        ("system", False, True, out_of_app_hint, ignored_because_hint, None, ignored_because_hint),
         ("system", False, True, out_of_app_hint, ignored_because_hint, "in-app", None),
         ("system", False, True, out_of_app_hint, ignored_because_hint, "contributes", ignored_because_hint),
-        ("system", False, True, ignored_hint, None, None, ignored_hint),
         ("system", False, True, ignored_hint, None, "in-app", None),
         ("system", False, True, ignored_hint, None, "contributes", ignored_hint),
-        ("system", False, True, ignored_hint, ignored_because_hint, None, ignored_hint),
         ("system", False, True, ignored_hint, ignored_because_hint, "in-app", None),
         ("system", False, True, ignored_hint, ignored_because_hint, "contributes", ignored_hint),
-        ("system", False, True, unignored_hint, None, None, unignored_hint),
         ("system", False, True, unignored_hint, None, "in-app", None),
         ("system", False, True, unignored_hint, None, "contributes", unignored_hint),
-        ("system", False, True, unignored_hint, ignored_because_hint, None, unignored_hint),
         ("system", False, True, unignored_hint, ignored_because_hint, "in-app", None),
         ("system", False, True, unignored_hint, ignored_because_hint, "contributes", unignored_hint),
-        ("system", False, True, None, None, None, None),  # impossible - can't have no rust hint if client in-app is changed
         ("system", False, True, None, None, "in-app", None),  # impossible - can't have no rust hint if client in-app is changed
         ("system", False, True, None, None, "contributes", None),  # impossible - can't have no rust hint if client in-app is changed
-        ("system", False, True, None, ignored_because_hint, None, ignored_because_hint),  # impossible - can't have no rust hint if client in-app is changed
         ("system", False, True, None, ignored_because_hint, "in-app", None),  # impossible - can't have no rust hint if client in-app is changed
         ("system", False, True, None, ignored_because_hint, "contributes", ignored_because_hint),  # impossible - can't have no rust hint if client in-app is changed
-        ("system", False, False, in_app_hint, None, None, None),  # impossible - rust can't return in-app hint if it marks frame out of app
         ("system", False, False, in_app_hint, None, "in-app", None),  # impossible - rust can't return in-app hint if it marks frame out of app
         ("system", False, False, in_app_hint, None, "contributes", None),  # impossible - rust can't return in-app hint if it marks frame out of app
-        ("system", False, False, in_app_hint, ignored_because_hint, None, ignored_because_hint),  # impossible - rust can't return in-app hint if it marks frame out of app
         ("system", False, False, in_app_hint, ignored_because_hint, "in-app", None),  # impossible - rust can't return in-app hint if it marks frame out of app
         ("system", False, False, in_app_hint, ignored_because_hint, "contributes", ignored_because_hint),  # impossible - rust can't return in-app hint if it marks frame out of app
-        ("system", False, False, out_of_app_hint, None, None, None),
         ("system", False, False, out_of_app_hint, None, "in-app", None),
         ("system", False, False, out_of_app_hint, None, "contributes", None),
-        ("system", False, False, out_of_app_hint, ignored_because_hint, None, ignored_because_hint),
         ("system", False, False, out_of_app_hint, ignored_because_hint, "in-app", None),
         ("system", False, False, out_of_app_hint, ignored_because_hint, "contributes", ignored_because_hint),
-        ("system", False, False, ignored_hint, None, None, ignored_hint),
         ("system", False, False, ignored_hint, None, "in-app", None),
         ("system", False, False, ignored_hint, None, "contributes", ignored_hint),
-        ("system", False, False, ignored_hint, ignored_because_hint, None, ignored_hint),
         ("system", False, False, ignored_hint, ignored_because_hint, "in-app", None),
         ("system", False, False, ignored_hint, ignored_because_hint, "contributes", ignored_hint),
-        ("system", False, False, unignored_hint, None, None, unignored_hint),
         ("system", False, False, unignored_hint, None, "in-app", None),
         ("system", False, False, unignored_hint, None, "contributes", unignored_hint),
-        ("system", False, False, unignored_hint, ignored_because_hint, None, unignored_hint),
         ("system", False, False, unignored_hint, ignored_because_hint, "in-app", None),
         ("system", False, False, unignored_hint, ignored_because_hint, "contributes", unignored_hint),
-        ("system", False, False, None, None, None, None),
         ("system", False, False, None, None, "in-app", None),
         ("system", False, False, None, None, "contributes", None),
-        ("system", False, False, None, ignored_because_hint, None, ignored_because_hint),
         ("system", False, False, None, ignored_because_hint, "in-app", None),
         ("system", False, False, None, ignored_because_hint, "contributes", ignored_because_hint),
     ]
@@ -419,7 +299,7 @@ def test_get_hint_for_frame(
     client_in_app: bool | None,
     rust_hint: str | None,
     incoming_hint: str | None,
-    desired_hint_type: Literal["in-app", "contributes"] | None,
+    desired_hint_type: Literal["in-app", "contributes"],
     expected_result: str | None,
 ) -> None:
 


### PR DESCRIPTION
This includes two small changes made possible by the removal of the legacy grouping config:

- The newstyle config only uses split enhancements, so we no longer need to store unsplit rust enhancements on the `Enhancements` object. This in turn means we're always passing a `type` parameter to `_merge_rust_enhancements`, so it can become required, and the `_merge_rust_enhancements` code can be simplified.

- Similarly, the only places where we were calling either `_can_use_hint` or `_get_hint_for_frame` without a `desired_hint_type` parameter were in `assemble_stacktrace_component_legacy`, so it, too, can now become required, and the code in both functions can be slightly simplified. (We can also now remove the test cases where it wasn't provided.)