### PR TITLE
fix(explore): Pass `AttributeTree` config to subtree rows

### DIFF
--- a/static/app/views/explore/components/traceItemAttributes/attributesTree.tsx
+++ b/static/app/views/explore/components/traceItemAttributes/attributesTree.tsx
@@ -184,6 +184,7 @@ function getAttributesTreeRows<RendererExtra extends RenderFunctionBaggage>({
         isLast: i === subtreeAttributes.length - 1,
         uniqueKey: `${uniqueKey}-${i}`,
         renderers,
+        config,
         rendererExtra,
         getCustomActions,
       });


### PR DESCRIPTION
Right now only the top-level tree rows get the config, it's not passed to the children. This mean I can turn off actions for an attribute tree, but they'll still appear on sub-tree nodes.

This change passes the config through, so it applies to all rows.
