### PR TITLE
feat(aci): Add alert rule id to detector

### DIFF
--- a/src/sentry/workflow_engine/endpoints/serializers.py
+++ b/src/sentry/workflow_engine/endpoints/serializers.py
@@ -22,6 +22,7 @@ from sentry.sentry_apps.models.sentry_app_installation import prepare_ui_compone
 from sentry.utils.cursors import Cursor, CursorResult
 from sentry.workflow_engine.models import (
     Action,
+    AlertRuleDetector,
     DataCondition,
     DataConditionGroup,
     DataSource,
@@ -310,6 +311,17 @@ class DetectorSerializer(Serializer):
         for detector_id, workflow_id in detector_workflows:
             workflows_map[detector_id].append(str(workflow_id))
 
+        # Fetch alert rule mappings
+        # TODO: Remove alert rule mappings as they're deprecated
+        alert_rule_mappings = list(AlertRuleDetector.objects.filter(detector__in=item_list))
+        alert_rule_map = {
+            mapping.detector_id: {
+                "alert_rule_id": mapping.alert_rule_id,
+                "rule_id": mapping.rule_id,
+            }
+            for mapping in alert_rule_mappings
+        }
+
         filtered_item_list = [item for item in item_list if item.type == ErrorGroupType.slug]
         project_ids = [item.project_id for item in filtered_item_list]
 
@@ -331,6 +343,13 @@ class DetectorSerializer(Serializer):
                 str(item.workflow_condition_group_id)
             )
             attrs[item]["workflow_ids"] = workflows_map[item.id]
+            attrs[item]["alert_rule_mapping"] = alert_rule_map.get(
+                item.id,
+                {
+                    "alert_rule_id": None,
+                    "rule_id": None,
+                },
+            )
             if item.id in configs:
                 attrs[item]["config"] = configs[item.id]
             else:
@@ -342,6 +361,7 @@ class DetectorSerializer(Serializer):
         return attrs
 
     def serialize(self, obj: Detector, attrs: Mapping[str, Any], user, **kwargs) -> dict[str, Any]:
+        alert_rule_mapping = attrs.get("alert_rule_mapping", {})
         return {
             "id": str(obj.id),
             "projectId": str(obj.project_id),
@@ -356,6 +376,8 @@ class DetectorSerializer(Serializer):
             "conditionGroup": attrs.get("condition_group"),
             "config": convert_dict_key_case(attrs.get("config"), snake_to_camel_case),
             "enabled": obj.enabled,
+            "alertRuleId": alert_rule_mapping.get("alert_rule_id"),
+            "ruleId": alert_rule_mapping.get("rule_id"),
         }
 
 

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
@@ -110,28 +110,24 @@ class OrganizationDetectorDetailsGetTest(OrganizationDetectorDetailsBaseTest):
         self.get_error_response(self.organization.slug, detector.id, status_code=404)
 
     def test_with_alert_rule_mapping(self):
-        """Test that alertRuleId and ruleId are included when mapping exists"""
         # Create a metric alert rule mapping
         metric_alert_id = 12345
         AlertRuleDetector.objects.create(alert_rule_id=metric_alert_id, detector=self.detector)
 
         response = self.get_success_response(self.organization.slug, self.detector.id)
 
-        # Verify the mapping fields are included
         assert response.data["alertRuleId"] == metric_alert_id
-        assert response.data["ruleId"] is None  # This is a metric alert, not an issue alert
+        assert response.data["ruleId"] is None
 
     def test_with_issue_rule_mapping(self):
-        """Test that ruleId is included when issue alert mapping exists"""
         # Create an issue alert rule mapping
         issue_rule_id = 67890
         AlertRuleDetector.objects.create(rule_id=issue_rule_id, detector=self.detector)
 
         response = self.get_success_response(self.organization.slug, self.detector.id)
 
-        # Verify the mapping fields are included
         assert response.data["ruleId"] == issue_rule_id
-        assert response.data["alertRuleId"] is None  # This is an issue alert, not a metric alert
+        assert response.data["alertRuleId"] is None
 
     def test_without_alert_rule_mapping(self):
         """Test that alertRuleId and ruleId are null when no mapping exists"""

--- a/tests/sentry/workflow_engine/endpoints/test_serializers.py
+++ b/tests/sentry/workflow_engine/endpoints/test_serializers.py
@@ -50,6 +50,8 @@ class TestDetectorSerializer(TestCase):
             },
             "owner": None,
             "enabled": detector.enabled,
+            "alertRuleId": None,
+            "ruleId": None,
         }
 
     def test_serialize_full(self):
@@ -164,6 +166,8 @@ class TestDetectorSerializer(TestCase):
             },
             "owner": self.user.get_actor_identifier(),
             "enabled": detector.enabled,
+            "alertRuleId": None,
+            "ruleId": None,
         }
 
     def test_serialize_bulk(self):


### PR DESCRIPTION
Going from the detector to the alert rule is very helpful in the ui. "Go to old ui" Ideally removed once we stop mirroring detectors to alert rules.
