### PR TITLE
fix(ourlogs): Fix groupby in toolbar not updating

### DIFF
--- a/static/app/views/explore/logs/content.spec.tsx
+++ b/static/app/views/explore/logs/content.spec.tsx
@@ -145,7 +145,7 @@ describe('LogsPage', function () {
     eventStatsMock.mockClear();
 
     await userEvent.click(screen.getByRole('button', {name: 'Expand sidebar'}));
-    await userEvent.click(screen.getByRole('button', {name: 'None'}));
+    await userEvent.click(screen.getByRole('button', {name: '\u2014'}));
     await userEvent.click(screen.getByRole('option', {name: 'severity'}));
     await userEvent.click(screen.getByRole('tab', {name: 'Aggregates'}));
 

--- a/static/app/views/explore/logs/logsToolbar.tsx
+++ b/static/app/views/explore/logs/logsToolbar.tsx
@@ -144,7 +144,7 @@ export function LogsToolbar({stringTags, numberTags}: LogsToolbarProps) {
           onChange={val =>
             setLogsPageParams({groupBy: val.value ? (val.value as string) : null})
           }
-          value={groupBy}
+          value={groupBy ?? ''}
           searchable
           triggerProps={{style: {width: '100%'}}}
         />


### PR DESCRIPTION
### Summary
Passing 'undefined' to the compact select after it's initialized appears to not update the option properly, leaving stale UI.
