### PR TITLE
fix(uptime): Emit `arroyo.consumer.latency` when using `thread-queue-parallel` mode

### DIFF
--- a/src/sentry/conf/types/kafka_definition.py
+++ b/src/sentry/conf/types/kafka_definition.py
@@ -126,6 +126,9 @@ class ConsumerDefinition(TypedDict, total=False):
     # Hardcoded additional kwargs for strategy_factory
     static_args: Mapping[str, Any]
 
+    # Pass the consumer group ID to the strategy factory as 'consumer_group' kwarg
+    pass_consumer_group: bool
+
     require_synchronization: bool
     synchronize_commit_group_default: str
     synchronize_commit_log_topic_default: str

--- a/src/sentry/remote_subscriptions/consumers/result_consumer.py
+++ b/src/sentry/remote_subscriptions/consumers/result_consumer.py
@@ -105,6 +105,7 @@ class ResultsStrategyFactory(ProcessingStrategyFactory[KafkaPayload], Generic[T,
 
     def __init__(
         self,
+        consumer_group: str,
         mode: Literal["batched-parallel", "parallel", "serial", "thread-queue-parallel"] = "serial",
         max_batch_size: int | None = None,
         max_batch_time: int | None = None,
@@ -115,6 +116,7 @@ class ResultsStrategyFactory(ProcessingStrategyFactory[KafkaPayload], Generic[T,
         commit_interval: float | None = None,
     ) -> None:
         self.mode = mode
+        self.consumer_group = consumer_group
         metric_tags = {"identifier": self.identifier, "mode": self.mode}
         self.result_processor = self.result_processor_cls()
         if mode == "batched-parallel":
@@ -134,6 +136,7 @@ class ResultsStrategyFactory(ProcessingStrategyFactory[KafkaPayload], Generic[T,
             self.queue_pool = FixedQueuePool(
                 result_processor=self.result_processor,
                 identifier=self.identifier,
+                consumer_group=consumer_group,
                 num_queues=max_workers or 20,
                 commit_interval=commit_interval or 1.0,
             )

--- a/tests/sentry/uptime/consumers/test_results_consumer.py
+++ b/tests/sentry/uptime/consumers/test_results_consumer.py
@@ -102,7 +102,9 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
         )
         with self.feature(UptimeDomainCheckFailure.build_ingest_feature_name()):
             if consumer is None:
-                factory = UptimeResultsStrategyFactory(mode=self.strategy_processing_mode)
+                factory = UptimeResultsStrategyFactory(
+                    consumer_group="test", mode=self.strategy_processing_mode
+                )
                 commit = mock.Mock()
                 consumer = factory.create_with_partitions(commit, {self.partition: 0})
 
@@ -1106,6 +1108,7 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
         """
 
         factory = UptimeResultsStrategyFactory(
+            consumer_group="test",
             mode="batched-parallel",
             max_batch_size=3,
             max_workers=1,
@@ -1160,6 +1163,7 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
         """
 
         factory = UptimeResultsStrategyFactory(
+            consumer_group="test",
             mode="batched-parallel",
             max_batch_size=3,
             max_workers=1,
@@ -1593,6 +1597,7 @@ class ProcessResultSerialTest(ProcessResultTest):
         """
 
         factory = UptimeResultsStrategyFactory(
+            consumer_group="test",
             mode="batched-parallel",
             max_batch_size=3,
             max_workers=1,
@@ -1648,6 +1653,7 @@ class ProcessResultSerialTest(ProcessResultTest):
         """
 
         factory = UptimeResultsStrategyFactory(
+            consumer_group="test",
             mode="batched-parallel",
             max_batch_size=3,
             max_workers=1,
@@ -1691,6 +1697,7 @@ class ProcessResultSerialTest(ProcessResultTest):
         Validates that the consumer in thread-queue-parallel mode processes messages correctly
         """
         factory = UptimeResultsStrategyFactory(
+            consumer_group="test",
             mode="thread-queue-parallel",
             max_workers=2,
         )
@@ -1735,6 +1742,7 @@ class ProcessResultSerialTest(ProcessResultTest):
         Test that thread-queue-parallel mode preserves order within subscriptions.
         """
         factory = UptimeResultsStrategyFactory(
+            consumer_group="test",
             mode="thread-queue-parallel",
             max_workers=3,
         )
@@ -1782,6 +1790,7 @@ class ProcessResultSerialTest(ProcessResultTest):
         Test that different subscriptions are processed concurrently in thread-queue-parallel mode.
         """
         factory = UptimeResultsStrategyFactory(
+            consumer_group="test",
             mode="thread-queue-parallel",
             max_workers=2,
         )
@@ -1831,6 +1840,7 @@ class ProcessResultSerialTest(ProcessResultTest):
             committed_offsets.update(offsets)
 
         factory = UptimeResultsStrategyFactory(
+            consumer_group="test",
             mode="thread-queue-parallel",
             max_workers=2,
         )
@@ -1881,6 +1891,7 @@ class ProcessResultSerialTest(ProcessResultTest):
             committed_offsets.update(offsets)
 
         factory = UptimeResultsStrategyFactory(
+            consumer_group="test",
             mode="thread-queue-parallel",
             max_workers=2,
         )
@@ -1933,6 +1944,7 @@ class ProcessResultSerialTest(ProcessResultTest):
             all_commits.append(dict(offsets))
 
         factory = UptimeResultsStrategyFactory(
+            consumer_group="test",
             mode="thread-queue-parallel",
             max_workers=1,
         )
@@ -1989,6 +2001,7 @@ class ProcessResultSerialTest(ProcessResultTest):
         Test that the thread-queue-parallel consumer shuts down gracefully.
         """
         factory = UptimeResultsStrategyFactory(
+            consumer_group="test",
             mode="thread-queue-parallel",
             max_workers=3,
         )
@@ -2054,6 +2067,7 @@ class ProcessResultThreadQueueParallelKafkaTest(UptimeTestCase):
             producer.flush()
 
             factory = UptimeResultsStrategyFactory(
+                consumer_group="test",
                 mode="thread-queue-parallel",
                 max_workers=2,
             )


### PR DESCRIPTION
We need to emit this standard metric since we have our own custom offset committing strategy. Without this, a bunch of datadog alerts fire.

<!-- Describe your PR here. -->