### PR TITLE
fix(aci milestone 3): bug fix metric detector serializers

### DIFF
--- a/src/sentry/incidents/endpoints/serializers/workflow_engine_detector.py
+++ b/src/sentry/incidents/endpoints/serializers/workflow_engine_detector.py
@@ -223,9 +223,6 @@ class WorkflowEngineDetectorSerializer(Serializer):
             condition_group__in=detector_workflow_condition_group_ids,
             condition_result__in=[DetectorPriorityLevel.HIGH, DetectorPriorityLevel.MEDIUM],
         )
-        ###
-        # THIS IS WRONG!!!!!!!!!!
-        ###
         workflow_dcg_ids = DataConditionGroup.objects.filter(
             workflowdataconditiongroup__workflow__in=Subquery(
                 DetectorWorkflow.objects.filter(detector__in=detector_ids).values_list(

--- a/tests/sentry/incidents/serializers/test_workflow_engine_base.py
+++ b/tests/sentry/incidents/serializers/test_workflow_engine_base.py
@@ -40,6 +40,20 @@ class TestWorkflowEngineSerializer(TestCase):
         self.resolve_trigger_data_condition = migrate_resolve_threshold_data_condition(
             self.alert_rule
         )
+
+        # add some other workflow engine objects to ensure that our filtering is working properly
+        other_alert_rule = self.create_alert_rule()
+        critical_trigger = self.create_alert_rule_trigger(
+            alert_rule=other_alert_rule, label="critical"
+        )
+        critical_trigger_action = self.create_alert_rule_trigger_action(
+            alert_rule_trigger=critical_trigger
+        )
+        migrate_alert_rule(other_alert_rule)
+        migrate_metric_data_conditions(critical_trigger)
+
+        migrate_metric_action(critical_trigger_action)
+        migrate_resolve_threshold_data_condition(other_alert_rule)
         self.expected_critical_action = [
             {
                 "id": str(self.critical_trigger_action.id),

--- a/tests/sentry/incidents/serializers/test_workflow_engine_base.py
+++ b/tests/sentry/incidents/serializers/test_workflow_engine_base.py
@@ -41,19 +41,6 @@ class TestWorkflowEngineSerializer(TestCase):
             self.alert_rule
         )
 
-        # add some other workflow engine objects to ensure that our filtering is working properly
-        other_alert_rule = self.create_alert_rule()
-        critical_trigger = self.create_alert_rule_trigger(
-            alert_rule=other_alert_rule, label="critical"
-        )
-        critical_trigger_action = self.create_alert_rule_trigger_action(
-            alert_rule_trigger=critical_trigger
-        )
-        migrate_alert_rule(other_alert_rule)
-        migrate_metric_data_conditions(critical_trigger)
-
-        migrate_metric_action(critical_trigger_action)
-        migrate_resolve_threshold_data_condition(other_alert_rule)
         self.expected_critical_action = [
             {
                 "id": str(self.critical_trigger_action.id),

--- a/tests/sentry/incidents/serializers/test_workflow_engine_detector.py
+++ b/tests/sentry/incidents/serializers/test_workflow_engine_detector.py
@@ -8,7 +8,12 @@ from sentry.incidents.endpoints.serializers.workflow_engine_detector import (
 )
 from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
 from sentry.incidents.models.incident import IncidentTrigger, TriggerStatus
-from sentry.workflow_engine.migration_helpers.alert_rule import migrate_metric_action
+from sentry.workflow_engine.migration_helpers.alert_rule import (
+    migrate_alert_rule,
+    migrate_metric_action,
+    migrate_metric_data_conditions,
+    migrate_resolve_threshold_data_condition,
+)
 from tests.sentry.incidents.serializers.test_workflow_engine_base import (
     TestWorkflowEngineSerializer,
 )
@@ -67,6 +72,43 @@ class TestDetectorSerializer(TestWorkflowEngineSerializer):
             ],
         )
         self.sentry_app_action, _, _ = migrate_metric_action(self.sentry_app_trigger_action)
+
+        other_sentry_app = self.create_sentry_app(
+            organization=self.organization,
+            published=True,
+            verify_install=False,
+            name="Not Awesome App",
+            schema={"elements": [self.create_alert_rule_action_schema()]},
+        )
+        self.create_sentry_app_installation(
+            slug=other_sentry_app.slug, organization=self.organization, user=self.user
+        )
+
+        # add some other workflow engine objects to ensure that our filtering is working properly
+        other_alert_rule = self.create_alert_rule()
+        critical_trigger = self.create_alert_rule_trigger(
+            alert_rule=other_alert_rule, label="critical"
+        )
+        critical_trigger_action = self.create_alert_rule_trigger_action(
+            alert_rule_trigger=critical_trigger
+        )
+        migrate_alert_rule(other_alert_rule)
+        migrate_metric_data_conditions(critical_trigger)
+
+        migrate_metric_action(critical_trigger_action)
+        migrate_resolve_threshold_data_condition(other_alert_rule)
+
+        other_sentry_app_action = self.create_alert_rule_trigger_action(
+            alert_rule_trigger=critical_trigger,
+            type=AlertRuleTriggerAction.Type.SENTRY_APP,
+            target_identifier=other_sentry_app.id,
+            target_type=AlertRuleTriggerAction.TargetType.SENTRY_APP,
+            sentry_app=other_sentry_app,
+            sentry_app_config=[
+                {"name": "title", "value": "An alert"},
+            ],
+        )
+        migrate_metric_action(other_sentry_app_action)
 
         # add a sentry app action and update expected actions
         sentry_app_action_data = {


### PR DESCRIPTION
Due to incorrect querying, we were fetching all action filter data conditions in the database when attempting to serialize a detector :yikes:
Ultimately, the serialized response would be correct, because the data condition serializer had the correct filtering. However, on production data with many data conditions in the DB, the query would time out.