### PR TITLE
fix(trace-item-stats): Look for the specific attribute stats

### DIFF
--- a/tests/sentry/api/endpoints/test_organization_spans_fields_stats.py
+++ b/tests/sentry/api/endpoints/test_organization_spans_fields_stats.py
@@ -152,8 +152,8 @@ class OrganizationSpansFieldsStatsEndpointTest(BaseSpansTestCase, APITestCase):
 
     def test_filter_query(self):
         tags = [
-            {"broswer": "chrome", "device": "desktop"},
-            {"broswer": "chrome", "device": "mobile"},
+            {"browser": "chrome", "device": "desktop"},
+            {"browser": "chrome", "device": "mobile"},
         ]
 
         for tag in tags:
@@ -162,8 +162,9 @@ class OrganizationSpansFieldsStatsEndpointTest(BaseSpansTestCase, APITestCase):
         response = self.do_request(query={"query": "device:desktop"})
         assert response.status_code == 200, response.data
         distributions = response.data["results"][0]["attributeDistributions"]["attributes"]
-        assert distributions[0]["attributeName"] == "broswer"
+        attribute = next(a for a in distributions if a["attributeName"] == "browser")
+        assert attribute
         # the second span has a different device value, so it should not be included in the results
-        assert distributions[0]["buckets"] == [
+        assert attribute["buckets"] == [
             {"label": "chrome", "value": 1.0},
         ]


### PR DESCRIPTION
We want to change the behavior of the TraceItemStats endpoint to not filter any attributes (https://github.com/getsentry/snuba/pull/7291). A query can still filter attributes it's not interested in.

This test fails because it expects only one attribute back. This will fix it to look at the stats for the specific attribute it created.

