### PR TITLE
ref(grouping): Update language to reflect legacy config removal

### DIFF
--- a/src/sentry/grouping/__init__.py
+++ b/src/sentry/grouping/__init__.py
@@ -104,7 +104,7 @@ stacktrace strategy can produce a component tree for a stacktrace.  Because
 events can have different forms and different strategies for the same interface,
 strategy configurations define which ones are picked.
 
-For instance, there is a `frame:legacy` strategy, which is the legacy
+For instance, there was a `frame:legacy` strategy, which was the legacy
 version of the `frame` strategy.  Then there are the new ones (`frame:v1`,
 `frame:v2`, etc.).  The strategy configuration defines which one is used.
 These are in `sentry.grouping.strategies.configurations`.  A strategy can

--- a/src/sentry/grouping/strategies/configurations.py
+++ b/src/sentry/grouping/strategies/configurations.py
@@ -39,16 +39,16 @@ BASE_STRATEGY = create_strategy_configuration_class(
         # This turns on the automatic message trimming and parameter substitution
         # by the message strategy.
         "normalize_message": False,
-        # newstyle: turns on some javascript fuzzing features.
+        # Turns on some javascript fuzzing features.
         "javascript_fuzzing": False,
-        # newstyle: platforms for which context line should be taken into
+        # Platforms for which context line should be taken into
         # account when grouping.
         "contextline_platforms": (),
-        # newstyle: this detects anonymous classes in PHP code.
+        # This detects anonymous classes in PHP code.
         "php_detect_anonymous_classes": False,
-        # newstyle: turns on a bug that was present in some variants
+        # Turns on a bug that was present in some variants
         "with_context_line_file_origin_bug": False,
-        # newstyle: turns on falling back to exception values when there
+        # Turns on falling back to exception values when there
         # is no stacktrace.
         "with_exception_value_fallback": False,
         # Stacktrace is produced in the context of this exception

--- a/src/sentry/grouping/strategies/message.py
+++ b/src/sentry/grouping/strategies/message.py
@@ -72,6 +72,7 @@ def normalize_message_for_grouping(message: str, event: Event) -> str:
 def message_v1(
     interface: Message, event: Event, context: GroupingContext, **kwargs: Any
 ) -> ReturnedVariants:
+    # This is true for all but our test config
     if context["normalize_message"]:
         raw = interface.message or interface.formatted or ""
         normalized = normalize_message_for_grouping(raw, event)

--- a/tests/sentry/grouping/test_grouphash_metadata.py
+++ b/tests/sentry/grouping/test_grouphash_metadata.py
@@ -43,7 +43,7 @@ dummy_project = Mock(id=11211231)
     set(CONFIGURATIONS.keys()) - {DEFAULT_GROUPING_CONFIG, NO_MSG_PARAM_CONFIG},
     ids=lambda config_name: config_name.replace("-", "_"),
 )
-def test_hash_basis_with_legacy_configs(
+def test_hash_basis_with_older_configs(
     config_name: str,
     grouping_input: GroupingInput,
     insta_snapshot: InstaSnapshotter,
@@ -53,8 +53,8 @@ def test_hash_basis_with_legacy_configs(
     process.
 
     Because manually cherry-picking only certain parts of the save process to run makes us much more
-    likely to fall out of sync with reality, for safety we only do this when testing legacy,
-    inactive grouping configs.
+    likely to fall out of sync with reality, for safety we only do this when testing older
+    grouping configs.
     """
     event = grouping_input.create_event(config_name, use_full_ingest_pipeline=False)
 
@@ -70,7 +70,7 @@ def test_hash_basis_with_legacy_configs(
     "config_name",
     # Technically we don't need to parameterize this since there's only one option, but doing it
     # this way makes snapshots from this test organize themselves neatly alongside snapshots from
-    # the test of the legacy configs above
+    # the test of the older configs above
     {DEFAULT_GROUPING_CONFIG},
     ids=lambda config_name: config_name.replace("-", "_"),
 )

--- a/tests/sentry/grouping/test_variants.py
+++ b/tests/sentry/grouping/test_variants.py
@@ -32,7 +32,7 @@ from tests.sentry.grouping import (
     ids=lambda config_name: config_name.replace("-", "_"),
 )
 @patch("sentry.grouping.strategies.newstyle.logging.exception")
-def test_variants_with_legacy_configs(
+def test_variants_with_older_configs(
     mock_exception_logger: MagicMock,
     config_name: str,
     grouping_input: GroupingInput,
@@ -42,8 +42,8 @@ def test_variants_with_legacy_configs(
     Run the variant snapshot tests using a minimal (and much more performant) save process.
 
     Because manually cherry-picking only certain parts of the save process to run makes us much more
-    likely to fall out of sync with reality, for safety we only do this when testing legacy,
-    inactive grouping configs.
+    likely to fall out of sync with reality, for safety we only do this when testing older grouping
+    configs.
     """
     event = grouping_input.create_event(config_name, use_full_ingest_pipeline=False)
 
@@ -61,7 +61,7 @@ def test_variants_with_legacy_configs(
     "config_name",
     # Technically we don't need to parameterize this since there's only one option, but doing it
     # this way makes snapshots from this test organize themselves neatly alongside snapshots from
-    # the test of the legacy configs above
+    # the test of the older configs above
     {DEFAULT_GROUPING_CONFIG},
     ids=lambda config_name: config_name.replace("-", "_"),
 )


### PR DESCRIPTION
This updates a number of variables names and comments to reflect the fact that the legacy config has now been removed.