### PR TITLE
ref(replays): add metadata fields to seer summary request

### DIFF
--- a/src/sentry/replays/endpoints/project_replay_summarize_breadcrumbs.py
+++ b/src/sentry/replays/endpoints/project_replay_summarize_breadcrumbs.py
@@ -49,6 +49,15 @@ class GroupEvent(TypedDict):
     category: str
 
 
+class SeerRequest(TypedDict):
+    """Corresponds to SummarizeReplayBreadcrumbsRequest in Seer."""
+
+    logs: list[str]
+    replay_id: str
+    organization_id: int
+    project_id: int
+
+
 @region_silo_endpoint
 @extend_schema(tags=["Replays"])
 class ProjectReplaySummarizeBreadcrumbsEndpoint(ProjectEndpoint):
@@ -117,7 +126,11 @@ class ProjectReplaySummarizeBreadcrumbsEndpoint(ProjectEndpoint):
             paginator_cls=GenericOffsetPaginator,
             data_fn=functools.partial(fetch_segments_metadata, project.id, replay_id),
             on_results=functools.partial(
-                analyze_recording_segments, error_events, replay_id, project.id
+                analyze_recording_segments,
+                error_events,
+                replay_id,
+                project.organization.id,
+                project.id,
             ),
         )
 
@@ -342,24 +355,22 @@ def gen_request_data(
 def analyze_recording_segments(
     error_events: list[GroupEvent],
     replay_id: str,
+    organization_id: int,
     project_id: int,
     segments: list[RecordingSegmentStorageMeta],
 ) -> dict[str, Any]:
     # Combine breadcrumbs and error details
-    request_data = json.dumps(
-        {"logs": get_request_data(iter_segment_data(segments), error_events, project_id)}
+    logs = get_request_data(iter_segment_data(segments), error_events, project_id)
+    request = SeerRequest(
+        logs=logs,
+        replay_id=replay_id,
+        organization_id=organization_id,
+        project_id=project_id,
     )
 
-    # Log when the input string is too large. This is potential for timeout.
-    if len(request_data) > 100000:
-        logger.info(
-            "Replay AI summary: input length exceeds 100k.",
-            extra={"request_len": len(request_data), "replay_id": replay_id},
-        )
-
-    # XXX: I have to deserialize this request so it can be "automatically" reserialized by the
+    # XXX: I have to deserialize this response so it can be "automatically" reserialized by the
     # paginate method. This is less than ideal.
-    return json.loads(make_seer_request(request_data).decode("utf-8"))
+    return json.loads(make_seer_request(request).decode("utf-8"))
 
 
 def as_log_message(event: dict[str, Any]) -> str | None:
@@ -456,15 +467,24 @@ def as_log_message(event: dict[str, Any]) -> str | None:
         return None
 
 
-def make_seer_request(request_data: str) -> bytes:
+def make_seer_request(request: SeerRequest) -> bytes:
+    serialized_request = json.dumps(request)
+
+    # Log when the input string is too large. This is potential for timeout.
+    if len(serialized_request) > 100000:
+        logger.info(
+            "Replay AI summary: input length exceeds 100k.",
+            extra={"request_len": len(serialized_request), "replay_id": request.replay_id},
+        )
+
     # XXX: Request isn't streaming. Limitation of Seer authentication. Would be much faster if we
     # could stream the request data since the GCS download will (likely) dominate latency.
     response = requests.post(
         f"{settings.SEER_AUTOFIX_URL}/v1/automation/summarize/replay/breadcrumbs",
-        data=request_data,
+        data=serialized_request,
         headers={
             "content-type": "application/json;charset=utf-8",
-            **sign_with_seer_secret(request_data.encode()),
+            **sign_with_seer_secret(serialized_request.encode()),
         },
     )
 

--- a/src/sentry/replays/endpoints/project_replay_summarize_breadcrumbs.py
+++ b/src/sentry/replays/endpoints/project_replay_summarize_breadcrumbs.py
@@ -471,10 +471,17 @@ def make_seer_request(request: SeerRequest) -> bytes:
     serialized_request = json.dumps(request)
 
     # Log when the input string is too large. This is potential for timeout.
-    if len(serialized_request) > 100000:
+    request_len_threshold = 1e5
+    if len(serialized_request) > request_len_threshold:
         logger.info(
-            "Replay AI summary: input length exceeds 100k.",
-            extra={"request_len": len(serialized_request), "replay_id": request.replay_id},
+            "Replay AI summary: input length exceeds threshold.",
+            extra={
+                "request_len": len(serialized_request),
+                "request_len_threshold": request_len_threshold,
+                "replay_id": request["replay_id"],
+                "organization_id": request["organization_id"],
+                "project_id": request["project_id"],
+            },
         )
 
     # XXX: Request isn't streaming. Limitation of Seer authentication. Would be much faster if we

--- a/tests/sentry/replays/endpoints/test_project_replay_summarize_breadcrumbs.py
+++ b/tests/sentry/replays/endpoints/test_project_replay_summarize_breadcrumbs.py
@@ -95,7 +95,7 @@ class ProjectReplaySummarizeBreadcrumbsTestCase(
         )
 
     @patch("sentry.replays.endpoints.project_replay_summarize_breadcrumbs.make_seer_request")
-    def test_get(self, make_seer_request):
+    def test_get_simple(self, make_seer_request):
         return_value = json.dumps({"hello": "world"}).encode()
         make_seer_request.return_value = return_value
 
@@ -131,6 +131,12 @@ class ProjectReplaySummarizeBreadcrumbsTestCase(
         assert response.status_code == 200
         assert response.get("Content-Type") == "application/json"
         assert response.content == return_value
+
+        make_seer_request.assert_called_once()
+        seer_request = make_seer_request.call_args[0][0]
+        assert "logs" in seer_request
+        assert seer_request["organization_id"] == self.organization.id
+        assert seer_request["replay_id"] == self.replay_id
 
     def test_get_feature_flag_disabled(self):
         self.save_recording_segment(0, json.dumps([]).encode())
@@ -243,10 +249,10 @@ class ProjectReplaySummarizeBreadcrumbsTestCase(
             response = self.client.get(self.url)
 
         make_seer_request.assert_called_once()
-        call_args = json.loads(make_seer_request.call_args[0][0])
-        assert "logs" in call_args
-        assert any("ZeroDivisionError" in log for log in call_args["logs"])
-        assert any("division by zero" in log for log in call_args["logs"])
+        seer_request = make_seer_request.call_args[0][0]
+        assert "logs" in seer_request
+        assert any("ZeroDivisionError" in log for log in seer_request["logs"])
+        assert any("division by zero" in log for log in seer_request["logs"])
 
         assert response.status_code == 200
         assert response.get("Content-Type") == "application/json"
@@ -310,10 +316,10 @@ class ProjectReplaySummarizeBreadcrumbsTestCase(
             response = self.client.get(self.url, {"enable_error_context": "false"})
 
         make_seer_request.assert_called_once()
-        call_args = json.loads(make_seer_request.call_args[0][0])
-        assert "logs" in call_args
-        assert not any("ZeroDivisionError" in log for log in call_args["logs"])
-        assert not any("division by zero" in log for log in call_args["logs"])
+        seer_request = make_seer_request.call_args[0][0]
+        assert "logs" in seer_request
+        assert not any("ZeroDivisionError" in log for log in seer_request["logs"])
+        assert not any("division by zero" in log for log in seer_request["logs"])
 
         assert response.status_code == 200
         assert response.get("Content-Type") == "application/json"
@@ -330,10 +336,10 @@ class ProjectReplaySummarizeBreadcrumbsTestCase(
             response = self.client.get(self.url, {"enable_error_context": "true"})
 
         assert make_seer_request.call_count == 2
-        call_args = json.loads(make_seer_request.call_args[0][0])
-        assert "logs" in call_args
-        assert any("ZeroDivisionError" in log for log in call_args["logs"])
-        assert any("division by zero" in log for log in call_args["logs"])
+        seer_request = make_seer_request.call_args[0][0]
+        assert "logs" in seer_request
+        assert any("ZeroDivisionError" in log for log in seer_request["logs"])
+        assert any("division by zero" in log for log in seer_request["logs"])
 
         assert response.status_code == 200
         assert response.get("Content-Type") == "application/json"
@@ -407,10 +413,10 @@ class ProjectReplaySummarizeBreadcrumbsTestCase(
             response = self.client.get(self.url)
 
         make_seer_request.assert_called_once()
-        call_args = json.loads(make_seer_request.call_args[0][0])
-        assert "logs" in call_args
-        assert any("ConnectionError" in log for log in call_args["logs"])
-        assert any("Failed to connect to database" in log for log in call_args["logs"])
+        seer_request = make_seer_request.call_args[0][0]
+        assert "logs" in seer_request
+        assert any("ConnectionError" in log for log in seer_request["logs"])
+        assert any("Failed to connect to database" in log for log in seer_request["logs"])
 
         assert response.status_code == 200
         assert response.get("Content-Type") == "application/json"
@@ -506,12 +512,12 @@ class ProjectReplaySummarizeBreadcrumbsTestCase(
             response = self.client.get(self.url)
 
         make_seer_request.assert_called_once()
-        call_args = json.loads(make_seer_request.call_args[0][0])
-        assert "logs" in call_args
-        assert any("ZeroDivisionError" in log for log in call_args["logs"])
-        assert any("division by zero" in log for log in call_args["logs"])
-        assert any("ConnectionError" in log for log in call_args["logs"])
-        assert any("Failed to connect to database" in log for log in call_args["logs"])
+        seer_request = make_seer_request.call_args[0][0]
+        assert "logs" in seer_request
+        assert any("ZeroDivisionError" in log for log in seer_request["logs"])
+        assert any("division by zero" in log for log in seer_request["logs"])
+        assert any("ConnectionError" in log for log in seer_request["logs"])
+        assert any("Failed to connect to database" in log for log in seer_request["logs"])
 
         assert response.status_code == 200
         assert response.get("Content-Type") == "application/json"
@@ -568,10 +574,10 @@ class ProjectReplaySummarizeBreadcrumbsTestCase(
             response = self.client.get(self.url)
 
         make_seer_request.assert_called_once()
-        call_args = json.loads(make_seer_request.call_args[0][0])
-        assert "logs" in call_args
-        assert any("Great website!" in log for log in call_args["logs"])
-        assert any("User submitted feedback" in log for log in call_args["logs"])
+        seer_request = make_seer_request.call_args[0][0]
+        assert "logs" in seer_request
+        assert any("Great website!" in log for log in seer_request["logs"])
+        assert any("User submitted feedback" in log for log in seer_request["logs"])
 
         assert response.status_code == 200
         assert response.get("Content-Type") == "application/json"


### PR DESCRIPTION
org id is needed in seer for https://github.com/getsentry/seer/pull/2961. Replay and project id may come in handy later.
Also updates our logs for large request sizes to include these fields, and not include threshold in the msg