### PR TITLE
chore(projects): Remove auth check on permalink

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -749,12 +749,9 @@ class GroupSerializerBase(Serializer, ABC):
         )
 
     @staticmethod
-    def _get_permalink(attrs, obj: Group):
-        if attrs["authorized"]:
-            with sentry_sdk.start_span(op="GroupSerializerBase.serialize.permalink.build"):
-                return obj.get_absolute_url()
-        else:
-            return None
+    def _get_permalink(attrs, obj: Group) -> str:
+        with sentry_sdk.start_span(op="GroupSerializerBase.serialize.permalink.build"):
+            return obj.get_absolute_url()
 
     @staticmethod
     def _convert_seen_stats(attrs: SeenStats) -> SeenStatsResponse:

--- a/tests/sentry/issues/endpoints/test_shared_group_details.py
+++ b/tests/sentry/issues/endpoints/test_shared_group_details.py
@@ -113,12 +113,4 @@ class SharedGroupDetailsTest(APITestCase):
             response = self.client.get(path, format="json")
 
             assert response.status_code == 200, response.content
-            assert not response.data["permalink"]  # not show permalink when not logged in
-
-        self.login_as(user=self.user)
-        for path_func in self._get_path_functions():
-            path = path_func(share_id)
-            response = self.client.get(path, format="json")
-
-            assert response.status_code == 200, response.content
-            assert response.data["permalink"]  # show permalink when logged in
+            assert response.data["permalink"]

--- a/tests/snuba/api/serializers/test_group.py
+++ b/tests/snuba/api/serializers/test_group.py
@@ -43,12 +43,6 @@ class GroupSerializerSnubaTest(APITestCase, SnubaTestCase):
         assert "http://" in result["permalink"]
         assert f"{group.organization.slug}/issues/{group.id}" in result["permalink"]
 
-    def test_permalink_outside_org(self):
-        outside_user = self.create_user()
-        group = self.create_group()
-        result = serialize(group, outside_user, serializer=GroupSerializerSnuba())
-        assert result["permalink"] is None
-
     def test_priority_high(self):
         outside_user = self.create_user()
         group = self.create_group(priority=PriorityLevel.HIGH)


### PR DESCRIPTION
Removes the auth check for this one line item (and fix the OpenAPI spec) since this is already a privileged endpoint