### PR TITLE
feat(emerge): Add installable info row to build details sidebar

### DIFF
--- a/static/app/views/preprod/sidebar/buildDetailsSidebarAppInfo.tsx
+++ b/static/app/views/preprod/sidebar/buildDetailsSidebarAppInfo.tsx
@@ -1,7 +1,14 @@
 import styled from '@emotion/styled';
 import {PlatformIcon} from 'platformicons';
 
-import {IconCheckmark, IconClock, IconFile, IconJson, IconWarning} from 'sentry/icons';
+import {
+  IconCheckmark,
+  IconClock,
+  IconFile,
+  IconJson,
+  IconLink,
+  IconWarning,
+} from 'sentry/icons';
 import {space} from 'sentry/styles/space';
 import {getFormattedDate} from 'sentry/utils/dates';
 import {type BuildDetailsAppInfo, BuildDetailsState} from 'sentry/views/preprod/types';
@@ -60,6 +67,14 @@ export function BuildDetailsSidebarAppInfo(props: BuildDetailsSidebarAppInfoProp
             <IconFile />
           </InfoIcon>
           <InfoValue>{getReadableArtifactTypeLabel(appInfo.artifact_type)}</InfoValue>
+        </InfoRow>
+        <InfoRow>
+          <InfoIcon>
+            <IconLink />
+          </InfoIcon>
+          <InfoValue>
+            {appInfo.is_installable ? 'Installable' : 'Not Installable'}
+          </InfoValue>
         </InfoRow>
       </InfoSection>
 


### PR DESCRIPTION
<img width="371" height="279" alt="Screenshot 2025-07-18 at 1 26 32 PM" src="https://github.com/user-attachments/assets/e6ca43b5-d4b4-4f35-bee2-fe2236493101" />
