### PR TITLE
:wrench: chore(jira): prevent EventLifecycle flow errors

### DIFF
--- a/src/sentry/integrations/utils/sync.py
+++ b/src/sentry/integrations/utils/sync.py
@@ -117,6 +117,9 @@ def sync_group_assignee_inbound(
         projects_by_user = Project.objects.get_by_users(users)
 
         groups_assigned = []
+
+        assignee_not_found = False
+
         for group in affected_groups:
             user_id = get_user_id(projects_by_user, group)
             user = users_by_id.get(user_id)
@@ -128,10 +131,13 @@ def sync_group_assignee_inbound(
                 )
                 groups_assigned.append(group)
             else:
-                lifecycle.record_halt(
-                    ProjectManagementHaltReason.SYNC_INBOUND_ASSIGNEE_NOT_FOUND, extra=log_context
-                )
-                logger.info("inbound-assignee-not-found", extra=log_context)
+                assignee_not_found = True
+
+        if assignee_not_found:
+            lifecycle.record_halt(
+                ProjectManagementHaltReason.SYNC_INBOUND_ASSIGNEE_NOT_FOUND, extra=log_context
+            )
+
         return groups_assigned
 
 


### PR DESCRIPTION
resolves ECO-883

instead of recording halts multiple times, lets check if we need to record a halt and then do it.