### PR TITLE
ref(workflow_engine): Refactor `evaluate_value` and add a metric

### DIFF
--- a/src/sentry/workflow_engine/models/data_condition.py
+++ b/src/sentry/workflow_engine/models/data_condition.py
@@ -248,7 +248,7 @@ class DataCondition(DefaultFieldsModel):
         metrics.incr("workflow_engine.data_condition.evaluation", tags={"type": self.type})
 
         if isinstance(result, bool):
-            # If the result is a boolean, get the result from `.condition_result`
+            # If the result is True, get the result from `.condition_result`
             return self.get_condition_result() if result else None
 
         return result

--- a/src/sentry/workflow_engine/models/data_condition.py
+++ b/src/sentry/workflow_engine/models/data_condition.py
@@ -162,36 +162,26 @@ class DataCondition(DefaultFieldsModel):
 
         return None
 
-    def evaluate_value(self, value: T) -> DataConditionResult:
+    def _evaluate_operator(self, condition_type: Condition, value: T) -> DataConditionResult:
+        # If the condition is a base type, handle it directly
+        op = CONDITION_OPS[condition_type]
+        result = None
         try:
-            condition_type = Condition(self.type)
-        except ValueError:
+            result = op(cast(Any, value), self.comparison)
+        except TypeError:
             logger.exception(
-                "Invalid condition type",
-                extra={"type": self.type, "id": self.id},
+                "Invalid comparison for data condition",
+                extra={
+                    "comparison": self.comparison,
+                    "value": value,
+                    "type": self.type,
+                    "condition_id": self.id,
+                },
             )
-            return None
 
-        if condition_type in CONDITION_OPS:
-            # If the condition is a base type, handle it directly
-            op = CONDITION_OPS[Condition(self.type)]
-            result = None
-            try:
-                result = op(cast(Any, value), self.comparison)
-            except TypeError:
-                logger.exception(
-                    "Invalid comparison for data condition",
-                    extra={
-                        "comparison": self.comparison,
-                        "value": value,
-                        "type": self.type,
-                        "condition_id": self.id,
-                    },
-                )
+        return result
 
-            return self.get_condition_result() if result else None
-
-        # Otherwise, we need to get the handler and evaluate the value
+    def _evaluate_condition(self, condition_type: Condition, value: T) -> DataConditionResult:
         try:
             handler = condition_handler_registry.get(condition_type)
         except registry.NoRegistrationExistsError:
@@ -237,7 +227,28 @@ class DataCondition(DefaultFieldsModel):
                     },
                 )
 
+        return result
+
+    def evaluate_value(self, value: T) -> DataConditionResult:
+        try:
+            condition_type = Condition(self.type)
+        except ValueError:
+            logger.exception(
+                "Invalid condition type",
+                extra={"type": self.type, "id": self.id},
+            )
+            return None
+
+        result: DataConditionResult
+        if condition_type in CONDITION_OPS:
+            result = self._evaluate_operator(condition_type, value)
+        else:
+            result = self._evaluate_condition(condition_type, value)
+
+        metrics.incr("workflow_engine.data_condition.evaluation", tags={"type": self.type})
+
         if isinstance(result, bool):
+            # If the result is a boolean, get the result from `.condition_result`
             return self.get_condition_result() if result else None
 
         return result

--- a/tests/sentry/workflow_engine/models/test_data_condition.py
+++ b/tests/sentry/workflow_engine/models/test_data_condition.py
@@ -69,7 +69,8 @@ class EvaluateValueTest(DataConditionHandlerMixin, BaseWorkflowTest):
         assert dc.evaluate_value(2) == DetectorPriorityLevel.HIGH
 
         dc.update(comparison={"baz": MockDataConditionEnum.FOO})
-        assert dc.evaluate_value(0) == DetectorPriorityLevel.OK
+        result = dc.evaluate_value(0)
+        assert result == DetectorPriorityLevel.OK
         self.teardown_condition_mocks()
 
     def test_bad_condition(self):


### PR DESCRIPTION
# Description
Was adding the metric `workflow_engine.data_condition.evaluation` but couldn't do it cleanly. so quickly refactored the evaluate_value logic to be a little cleaner and have a consistent final return value.