### PR TITLE
ref(grouping): Move default grouping config values to base

### DIFF
--- a/src/sentry/grouping/strategies/configurations.py
+++ b/src/sentry/grouping/strategies/configurations.py
@@ -50,7 +50,7 @@ BASE_STRATEGY = create_strategy_configuration_class(
         "with_context_line_file_origin_bug": True,
         # Turns on falling back to exception values when there
         # is no stacktrace.
-        "with_exception_value_fallback": False,
+        "with_exception_value_fallback": True,
         # Stacktrace is produced in the context of this exception
         "exception_data": None,
         # replaces generated IDs in Java stack frames related to CGLIB and hibernate
@@ -91,7 +91,6 @@ register_strategy_config(
     """,
     initial_context={
         "contextline_platforms": ("javascript", "node", "python", "php", "ruby"),
-        "with_exception_value_fallback": True,
     },
     enhancements_base="common:2019-03-23",
 )

--- a/src/sentry/grouping/strategies/configurations.py
+++ b/src/sentry/grouping/strategies/configurations.py
@@ -40,7 +40,7 @@ BASE_STRATEGY = create_strategy_configuration_class(
         # by the message strategy. (Only still configurable so it can be turned off in tests.)
         "normalize_message": True,
         # Turns on some javascript fuzzing features.
-        "javascript_fuzzing": False,
+        "javascript_fuzzing": True,
         # Platforms for which context line should be taken into
         # account when grouping.
         "contextline_platforms": (),
@@ -90,7 +90,6 @@ register_strategy_config(
         * C/C++ and other native stacktraces are more reliably grouped.
     """,
     initial_context={
-        "javascript_fuzzing": True,
         "contextline_platforms": ("javascript", "node", "python", "php", "ruby"),
         "with_context_line_file_origin_bug": True,
         "with_exception_value_fallback": True,

--- a/src/sentry/grouping/strategies/configurations.py
+++ b/src/sentry/grouping/strategies/configurations.py
@@ -47,7 +47,7 @@ BASE_STRATEGY = create_strategy_configuration_class(
         # This detects anonymous classes in PHP code.
         "php_detect_anonymous_classes": False,
         # Turns on a bug that was present in some variants
-        "with_context_line_file_origin_bug": False,
+        "with_context_line_file_origin_bug": True,
         # Turns on falling back to exception values when there
         # is no stacktrace.
         "with_exception_value_fallback": False,
@@ -91,7 +91,6 @@ register_strategy_config(
     """,
     initial_context={
         "contextline_platforms": ("javascript", "node", "python", "php", "ruby"),
-        "with_context_line_file_origin_bug": True,
         "with_exception_value_fallback": True,
     },
     enhancements_base="common:2019-03-23",

--- a/src/sentry/grouping/strategies/configurations.py
+++ b/src/sentry/grouping/strategies/configurations.py
@@ -37,8 +37,8 @@ BASE_STRATEGY = create_strategy_configuration_class(
         # strategy.
         "is_recursion": False,
         # This turns on the automatic message trimming and parameter substitution
-        # by the message strategy.
-        "normalize_message": False,
+        # by the message strategy. (Only still configurable so it can be turned off in tests.)
+        "normalize_message": True,
         # Turns on some javascript fuzzing features.
         "javascript_fuzzing": False,
         # Platforms for which context line should be taken into
@@ -93,7 +93,6 @@ register_strategy_config(
         "javascript_fuzzing": True,
         "contextline_platforms": ("javascript", "node", "python", "php", "ruby"),
         "with_context_line_file_origin_bug": True,
-        "normalize_message": True,
         "with_exception_value_fallback": True,
     },
     enhancements_base="common:2019-03-23",

--- a/src/sentry/grouping/strategies/configurations.py
+++ b/src/sentry/grouping/strategies/configurations.py
@@ -43,7 +43,7 @@ BASE_STRATEGY = create_strategy_configuration_class(
         "javascript_fuzzing": True,
         # Platforms for which context line should be taken into
         # account when grouping.
-        "contextline_platforms": (),
+        "contextline_platforms": ("javascript", "node", "python", "php", "ruby"),
         # This detects anonymous classes in PHP code.
         "php_detect_anonymous_classes": False,
         # Turns on a bug that was present in some variants
@@ -89,9 +89,7 @@ register_strategy_config(
           better.
         * C/C++ and other native stacktraces are more reliably grouped.
     """,
-    initial_context={
-        "contextline_platforms": ("javascript", "node", "python", "php", "ruby"),
-    },
+    initial_context={},
     enhancements_base="common:2019-03-23",
 )
 


### PR DESCRIPTION
Now that the legacy config is gone, the `newstyle:2019-05-08` option values are effectively the defaults, since it serves as the base for the only other config, the default config. This codifies that, by moving its option values into the actual base config. Once this is done, we'll be able to remove it.