### PR TITLE
chore(github): add date added to rpcorgintegration

### DIFF
--- a/src/sentry/integrations/services/integration/model.py
+++ b/src/sentry/integrations/services/integration/model.py
@@ -58,6 +58,7 @@ class RpcOrganizationIntegration(RpcModel):
     config: dict[str, Any]
     status: int  # As ObjectStatus
     grace_period_end: datetime | None
+    date_added: datetime | None
 
     def __hash__(self) -> int:
         return hash(self.id)


### PR DESCRIPTION
Part 1 of downgrading organizations that upgrade to biz trial to get multi org feature and then downgrade

We need to add `date_added` to the RPC model because when starting grace period for the affected `OrganizationIntegrations` we should keep the original/oldest `OrganizationIntegration` that wasn't added via multi-org but because the plan change logic lives in region and uses the `RpcOrganizationIntegration` object we need to be able to sort by oldest to most recent added.