### PR TITLE
ref(issues): remove resolve upcoming release frontend

### DIFF
--- a/static/app/components/actions/resolve.spec.tsx
+++ b/static/app/components/actions/resolve.spec.tsx
@@ -229,4 +229,19 @@ describe('ResolveActions', function () {
     );
     expect(screen.queryByLabelText('More resolve options')).not.toBeInTheDocument();
   });
+
+  it('does render next release option with subtitle', async function () {
+    const onUpdate = jest.fn();
+    MockApiClient.addMockResponse({
+      url: '/projects/org-slug/project-slug/releases/',
+      body: [ReleaseFixture()],
+    });
+    render(<ResolveActions hasRelease projectSlug="project-slug" onUpdate={onUpdate} />);
+
+    await userEvent.click(screen.getByLabelText('More resolve options'));
+    expect(await screen.findByText('The next release')).toBeInTheDocument();
+    expect(
+      await screen.findByText('The next release after the current one')
+    ).toBeInTheDocument();
+  });
 });

--- a/static/app/components/actions/resolve.spec.tsx
+++ b/static/app/components/actions/resolve.spec.tsx
@@ -1,4 +1,3 @@
-import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ReleaseFixture} from 'sentry-fixture/release';
 
 import {
@@ -229,40 +228,5 @@ describe('ResolveActions', function () {
       />
     );
     expect(screen.queryByLabelText('More resolve options')).not.toBeInTheDocument();
-  });
-
-  it('does render next release option with subtitle', async function () {
-    const onUpdate = jest.fn();
-    MockApiClient.addMockResponse({
-      url: '/projects/org-slug/project-slug/releases/',
-      body: [ReleaseFixture()],
-    });
-    render(<ResolveActions hasRelease projectSlug="project-slug" onUpdate={onUpdate} />);
-
-    await userEvent.click(screen.getByLabelText('More resolve options'));
-    expect(await screen.findByText('The next release')).toBeInTheDocument();
-    expect(
-      await screen.findByText('The next release after the current one')
-    ).toBeInTheDocument();
-  });
-
-  it('does render in upcoming release', async function () {
-    const organization = OrganizationFixture({
-      features: ['resolve-in-upcoming-release'],
-    });
-    const onUpdate = jest.fn();
-    MockApiClient.addMockResponse({
-      url: '/projects/org-slug/project-slug/releases/',
-      body: [ReleaseFixture()],
-    });
-    render(<ResolveActions hasRelease projectSlug="project-slug" onUpdate={onUpdate} />, {
-      organization,
-    });
-
-    await userEvent.click(screen.getByLabelText('More resolve options'));
-    expect(await screen.findByText('The upcoming release')).toBeInTheDocument();
-    expect(
-      await screen.findByText('The next release that is not yet released')
-    ).toBeInTheDocument();
   });
 });

--- a/static/app/components/actions/resolve.tsx
+++ b/static/app/components/actions/resolve.tsx
@@ -196,7 +196,7 @@ function ResolveActions({
       {
         key: 'next-release',
         label: t('The next release'),
-        details: actionTitle,
+        details: actionTitle ? actionTitle : t('The next release after the current one'),
         onAction: () => onActionOrConfirm(handleNextReleaseResolution),
       },
       {

--- a/static/app/components/actions/resolve.tsx
+++ b/static/app/components/actions/resolve.tsx
@@ -127,23 +127,6 @@ function ResolveActions({
     });
   }
 
-  function handleUpcomingReleaseResolution() {
-    if (hasRelease) {
-      onUpdate({
-        status: GroupStatus.RESOLVED,
-        statusDetails: {
-          inUpcomingRelease: true,
-        },
-        substatus: null,
-      });
-    }
-
-    trackAnalytics('resolve_issue', {
-      organization,
-      release: 'upcoming',
-    });
-  }
-
   function handleNextReleaseResolution() {
     if (hasRelease) {
       onUpdate({
@@ -208,25 +191,12 @@ function ResolveActions({
       });
     };
 
-    const hasUpcomingRelease = organization.features.includes(
-      'resolve-in-upcoming-release'
-    );
-
     const isSemver = latestRelease ? isSemverRelease(latestRelease.version) : false;
     const items: MenuItemProps[] = [
       {
-        key: 'upcoming-release',
-        label: t('The upcoming release'),
-        details: actionTitle
-          ? actionTitle
-          : t('The next release that is not yet released'),
-        onAction: () => onActionOrConfirm(handleUpcomingReleaseResolution),
-        hidden: !hasUpcomingRelease,
-      },
-      {
         key: 'next-release',
         label: t('The next release'),
-        details: actionTitle ? actionTitle : t('The next release after the current one'),
+        details: actionTitle,
         onAction: () => onActionOrConfirm(handleNextReleaseResolution),
       },
       {
@@ -280,15 +250,9 @@ function ResolveActions({
         )}
         disabledKeys={
           multipleProjectsSelected
-            ? [
-                'next-release',
-                'current-release',
-                'another-release',
-                'a-commit',
-                'upcoming-release',
-              ]
+            ? ['next-release', 'current-release', 'another-release', 'a-commit']
             : disabled || !hasRelease
-              ? ['next-release', 'current-release', 'another-release', 'upcoming-release']
+              ? ['next-release', 'current-release', 'another-release']
               : []
         }
         menuTitle={shouldDisplayCta ? <SetupReleasesPrompt /> : t('Resolved In')}

--- a/static/app/components/resolutionBox.spec.tsx
+++ b/static/app/components/resolutionBox.spec.tsx
@@ -159,26 +159,4 @@ describe('ResolutionBox', function () {
       'This issue has been marked as resolved by f7f395din'
     );
   });
-
-  it('handles inUpcomingRelease', function () {
-    const {container} = render(
-      <ResolutionBox
-        statusDetails={{
-          inUpcomingRelease: true,
-          actor: {
-            id: '111',
-            name: 'David Cramer',
-            username: 'dcramer',
-            ip_address: '127.0.0.1',
-            email: 'david@sentry.io',
-          },
-        }}
-        project={project}
-        organization={organization}
-      />
-    );
-    expect(container).toHaveTextContent(
-      'David Cramer marked this issue as resolved in the upcoming release.'
-    );
-  });
 });

--- a/static/app/components/resolutionBox.tsx
+++ b/static/app/components/resolutionBox.tsx
@@ -84,15 +84,6 @@ export function renderResolutionReason({
         })
       : t('This issue has been marked as resolved in the upcoming release.');
   }
-
-  if (statusDetails.inUpcomingRelease) {
-    return actor
-      ? tct('[actor] marked this issue as resolved in the upcoming release.', {
-          actor,
-        })
-      : t('This issue has been marked as resolved in the upcoming release.');
-  }
-
   if (statusDetails.inRelease) {
     const version = (
       <VersionHoverCard

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -806,7 +806,6 @@ export interface ResolvedStatusDetails {
   };
   inNextRelease?: boolean;
   inRelease?: string;
-  inUpcomingRelease?: boolean;
   repository?: string;
 }
 interface ReprocessingStatusDetails {


### PR DESCRIPTION
Remove old resolve issue from upcoming release from frontend — hasn't been used in ~a year.