### PR TITLE
ref(nav-v2): removes navigation v2 banner flag

### DIFF
--- a/static/app/components/sidebar/index.spec.tsx
+++ b/static/app/components/sidebar/index.spec.tsx
@@ -417,10 +417,7 @@ describe('Sidebar', function () {
         body: {data: null},
       });
 
-      renderSidebarWithFeatures([
-        'navigation-sidebar-v2',
-        'navigation-sidebar-v2-banner',
-      ]);
+      renderSidebarWithFeatures(['navigation-sidebar-v2']);
 
       expect(await screen.findByText(/New Navigation/)).toBeInTheDocument();
     });
@@ -431,10 +428,7 @@ describe('Sidebar', function () {
         body: {data: null},
       });
 
-      renderSidebarWithFeatures([
-        'navigation-sidebar-v2',
-        'navigation-sidebar-v2-banner',
-      ]);
+      renderSidebarWithFeatures(['navigation-sidebar-v2']);
 
       await userEvent.click(screen.getByTestId('sidebar-collapse'));
 
@@ -455,10 +449,7 @@ describe('Sidebar', function () {
         body: {},
       });
 
-      renderSidebarWithFeatures([
-        'navigation-sidebar-v2',
-        'navigation-sidebar-v2-banner',
-      ]);
+      renderSidebarWithFeatures(['navigation-sidebar-v2']);
 
       await userEvent.click(await screen.findByRole('button', {name: /Dismiss/}));
 

--- a/static/app/views/nav/useNavPrompts.tsx
+++ b/static/app/views/nav/useNavPrompts.tsx
@@ -8,9 +8,7 @@ export function useNavPrompts({
   collapsed: boolean;
   organization: Organization | null;
 }) {
-  const hasNavigationV2Banner =
-    organization?.features.includes('navigation-sidebar-v2') &&
-    organization?.features.includes('navigation-sidebar-v2-banner');
+  const hasNavigationV2Banner = organization?.features.includes('navigation-sidebar-v2');
 
   const {
     isPromptDismissed: isSidebarPromptDismissed,


### PR DESCRIPTION
The nav v2 banner is fully GAed, so we can remove the flag check
https://github.com/getsentry/sentry-options-automator/blob/507cffc82679fc5aee370808a4b084dc6a416d27/options/default/flagpole.yml#L3588