### PR TITLE
feat: Pass repo integration_id to Seer

### DIFF
--- a/src/sentry/seer/models.py
+++ b/src/sentry/seer/models.py
@@ -19,6 +19,7 @@ class SummarizeIssueResponse(BaseModel):
 
 
 class SeerRepoDefinition(BaseModel):
+    integration_id: str | None = None  # TODO(jianyuan): Make this required
     provider: str
     owner: str
     name: str

--- a/tests/sentry/seer/endpoints/test_project_seer_preferences.py
+++ b/tests/sentry/seer/endpoints/test_project_seer_preferences.py
@@ -29,6 +29,7 @@ class ProjectSeerPreferencesEndpointTest(APITestCase):
             },
         )
         self.repo_definition = SeerRepoDefinition(
+            integration_id="111",
             provider="github",
             owner="getsentry",
             name="sentry",
@@ -48,6 +49,7 @@ class ProjectSeerPreferencesEndpointTest(APITestCase):
         "sentry.seer.endpoints.project_seer_preferences.get_autofix_repos_from_project_code_mappings",
         return_value=[
             {
+                "integration_id": "111",
                 "provider": "github",
                 "owner": "getsentry",
                 "name": "sentry",
@@ -98,6 +100,7 @@ class ProjectSeerPreferencesEndpointTest(APITestCase):
         request_data = {
             "repositories": [
                 {
+                    "integration_id": "111",
                     "provider": "github",
                     "owner": "getsentry",
                     "name": "sentry",
@@ -128,6 +131,7 @@ class ProjectSeerPreferencesEndpointTest(APITestCase):
         assert preference["organization_id"] == self.org.id
         assert preference["project_id"] == self.project.id
         assert len(preference["repositories"]) == 1
+        assert preference["repositories"][0]["integration_id"] == "111"
         assert preference["repositories"][0]["provider"] == "github"
         assert preference["repositories"][0]["owner"] == "getsentry"
         assert preference["repositories"][0]["name"] == "sentry"


### PR DESCRIPTION
[The frontend now passes the `integration_id` of the repository](https://github.com/getsentry/sentry/blame/af3ab6f3c83e444c0142af6236e1360131447871/static/app/views/settings/projectSeer/autofixRepositories.tsx#L121). We should capture this on the backend and forward it to Seer. The upcoming GitHub Enterprise integration requires the integration_id so that we can look up the correct integration.