### PR TITLE
ref(nav-v2): removes nav v2 flag 

### DIFF
--- a/static/app/components/performanceOnboarding/sidebar.spec.tsx
+++ b/static/app/components/performanceOnboarding/sidebar.spec.tsx
@@ -62,6 +62,11 @@ describe('Sidebar > Performance Onboarding Checklist', function () {
     });
 
     MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/prompts-activity/`,
+      body: {data: null},
+    });
+
+    MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/onboarding-tasks/`,
       method: 'GET',
       body: {

--- a/static/app/components/sidebar/help.tsx
+++ b/static/app/components/sidebar/help.tsx
@@ -98,21 +98,19 @@ function SidebarHelp({orientation, collapsed, hidePanel, organization}: Props) {
                   {t('Give Feedback')}
                 </SidebarMenuItem>
               ) : null}
-              {organization?.features?.includes('navigation-sidebar-v2') && (
-                <SidebarMenuItem
-                  onClick={() => {
-                    mutateUserOptions({prefersStackedNavigation: true});
-                    trackAnalytics(
-                      'navigation.help_menu_opt_in_stacked_navigation_clicked',
-                      {
-                        organization,
-                      }
-                    );
-                  }}
-                >
-                  {t('Try New Navigation')} <FeatureBadge type="new" />
-                </SidebarMenuItem>
-              )}
+              <SidebarMenuItem
+                onClick={() => {
+                  mutateUserOptions({prefersStackedNavigation: true});
+                  trackAnalytics(
+                    'navigation.help_menu_opt_in_stacked_navigation_clicked',
+                    {
+                      organization,
+                    }
+                  );
+                }}
+              >
+                {t('Try New Navigation')} <FeatureBadge type="new" />
+              </SidebarMenuItem>
               {organization?.features?.includes('chonk-ui') ? (
                 user.options.prefersChonkUI ? (
                   <SidebarMenuItem

--- a/static/app/components/sidebar/index.spec.tsx
+++ b/static/app/components/sidebar/index.spec.tsx
@@ -59,6 +59,12 @@ describe('Sidebar', function () {
   const renderSidebar = ({organization: org}: {organization: Organization | null}) =>
     render(getElement(), {organization: org});
 
+  const renderSidebarWithFeatures = (features: string[] = []) => {
+    return renderSidebar({
+      organization: {...organization, features: [...organization.features, ...features]},
+    });
+  };
+
   beforeEach(function () {
     ConfigStore.set('user', user);
     mockUseLocation.mockReturnValue(LocationFixture());

--- a/static/app/components/sidebar/index.spec.tsx
+++ b/static/app/components/sidebar/index.spec.tsx
@@ -596,7 +596,7 @@ describe('Sidebar', function () {
 
       // Find the dismiss button within the chonk UI banner
       await userEvent.click(
-        within(screen.getByTestId('chonk-opt-in-banner')).getByRole('button', {
+        within(screen.getByRole('complementary')).getByRole('button', {
           name: /Dismiss/,
         })
       );

--- a/static/app/components/sidebar/index.spec.tsx
+++ b/static/app/components/sidebar/index.spec.tsx
@@ -59,12 +59,6 @@ describe('Sidebar', function () {
   const renderSidebar = ({organization: org}: {organization: Organization | null}) =>
     render(getElement(), {organization: org});
 
-  const renderSidebarWithFeatures = (features: string[] = []) => {
-    return renderSidebar({
-      organization: {...organization, features: [...organization.features, ...features]},
-    });
-  };
-
   beforeEach(function () {
     ConfigStore.set('user', user);
     mockUseLocation.mockReturnValue(LocationFixture());
@@ -417,7 +411,7 @@ describe('Sidebar', function () {
         body: {data: null},
       });
 
-      renderSidebarWithFeatures(['navigation-sidebar-v2']);
+      renderSidebar({organization});
 
       expect(await screen.findByText(/New Navigation/)).toBeInTheDocument();
     });
@@ -428,7 +422,7 @@ describe('Sidebar', function () {
         body: {data: null},
       });
 
-      renderSidebarWithFeatures(['navigation-sidebar-v2']);
+      renderSidebar({organization});
 
       await userEvent.click(screen.getByTestId('sidebar-collapse'));
 
@@ -449,7 +443,7 @@ describe('Sidebar', function () {
         body: {},
       });
 
-      renderSidebarWithFeatures(['navigation-sidebar-v2']);
+      renderSidebar({organization});
 
       await userEvent.click(await screen.findByRole('button', {name: /Dismiss/}));
 

--- a/static/app/components/sidebar/index.spec.tsx
+++ b/static/app/components/sidebar/index.spec.tsx
@@ -595,10 +595,10 @@ describe('Sidebar', function () {
       expect(chonkBanner).toBeInTheDocument();
 
       // Find the dismiss button within the chonk UI banner
-      const bannerContainer =
-        chonkBanner.closest('[class*="Panel"]') || chonkBanner.parentElement;
       await userEvent.click(
-        within(bannerContainer! as HTMLElement).getByRole('button', {name: /Dismiss/})
+        within(screen.getByTestId('chonk-opt-in-banner')).getByRole('button', {
+          name: /Dismiss/,
+        })
       );
 
       expect(optionsRequest).not.toHaveBeenCalled();

--- a/static/app/utils/theme/ChonkOptInBanner.tsx
+++ b/static/app/utils/theme/ChonkOptInBanner.tsx
@@ -27,6 +27,7 @@ export function ChonkOptInBanner(props: {collapsed: boolean | 'never'}) {
     <TranslucentBackgroundPanel
       isDarkMode={config.theme === 'dark'}
       position={props.collapsed === 'never' ? 'absolute' : 'relative'}
+      data-test-id="chonk-opt-in-banner"
     >
       <Title>{t('Sentry has a new look')}</Title>
       <Description>

--- a/static/app/utils/theme/ChonkOptInBanner.tsx
+++ b/static/app/utils/theme/ChonkOptInBanner.tsx
@@ -32,7 +32,7 @@ export function ChonkOptInBanner(props: {collapsed: boolean | 'never'}) {
       isDarkMode={config.theme === 'dark'}
       position={props.collapsed === 'never' ? 'absolute' : 'relative'}
     >
-      <Title>{t('Sentry has a new look')}</Title>
+      <Title id={id}>{t('Sentry has a new look')}</Title>
       <Description>
         {t(`We've updated Sentry with a fresh new look, try it out by opting in below.`)}
       </Description>

--- a/static/app/utils/theme/ChonkOptInBanner.tsx
+++ b/static/app/utils/theme/ChonkOptInBanner.tsx
@@ -1,3 +1,4 @@
+import {useId} from 'react';
 import type {Theme} from '@emotion/react';
 import {ThemeProvider} from '@emotion/react';
 import styled from '@emotion/styled';
@@ -18,6 +19,7 @@ export function ChonkOptInBanner(props: {collapsed: boolean | 'never'}) {
   const chonkPrompt = useChonkPrompt();
   const config = useLegacyStore(ConfigStore);
   const {mutate: mutateUserOptions} = useMutateUserOptions();
+  const id = useId();
 
   if (props.collapsed === true || !chonkPrompt.showbannerPrompt) {
     return null;
@@ -25,9 +27,10 @@ export function ChonkOptInBanner(props: {collapsed: boolean | 'never'}) {
 
   return (
     <TranslucentBackgroundPanel
+      role="complementary"
+      aria-labelledby={id}
       isDarkMode={config.theme === 'dark'}
       position={props.collapsed === 'never' ? 'absolute' : 'relative'}
-      data-test-id="chonk-opt-in-banner"
     >
       <Title>{t('Sentry has a new look')}</Title>
       <Description>

--- a/static/app/views/nav/useNavPrompts.tsx
+++ b/static/app/views/nav/useNavPrompts.tsx
@@ -14,7 +14,6 @@ export function useNavPrompts({
   } = usePrompt({
     feature: 'stacked_navigation_banner',
     organization,
-    options: {enabled: true},
   });
 
   const {
@@ -23,7 +22,6 @@ export function useNavPrompts({
   } = usePrompt({
     feature: 'stacked_navigation_help_menu',
     organization,
-    options: {enabled: true},
   });
 
   const shouldShowHelpMenuDot =

--- a/static/app/views/nav/useNavPrompts.tsx
+++ b/static/app/views/nav/useNavPrompts.tsx
@@ -8,15 +8,13 @@ export function useNavPrompts({
   collapsed: boolean;
   organization: Organization | null;
 }) {
-  const hasNavigationV2Banner = organization?.features.includes('navigation-sidebar-v2');
-
   const {
     isPromptDismissed: isSidebarPromptDismissed,
     dismissPrompt: dismissSidebarPrompt,
   } = usePrompt({
     feature: 'stacked_navigation_banner',
     organization,
-    options: {enabled: hasNavigationV2Banner},
+    options: {enabled: true},
   });
 
   const {
@@ -25,17 +23,14 @@ export function useNavPrompts({
   } = usePrompt({
     feature: 'stacked_navigation_help_menu',
     organization,
-    options: {enabled: hasNavigationV2Banner},
+    options: {enabled: true},
   });
 
   const shouldShowHelpMenuDot =
-    hasNavigationV2Banner &&
-    isDropdownPromptDismissed === false &&
-    (collapsed || isSidebarPromptDismissed);
+    isDropdownPromptDismissed === false && (collapsed || isSidebarPromptDismissed);
 
   return {
-    shouldShowSidebarBanner:
-      hasNavigationV2Banner && !collapsed && isSidebarPromptDismissed === false,
+    shouldShowSidebarBanner: !collapsed && isSidebarPromptDismissed === false,
     shouldShowHelpMenuDot,
     onOpenHelpMenu: () => {
       if (shouldShowHelpMenuDot) {


### PR DESCRIPTION
Nav V2 is GAed and available for everyone (see [automator](https://github.com/getsentry/sentry-options-automator/blob/507cffc82679fc5aee370808a4b084dc6a416d27/options/default/flagpole.yml#L3538)), so we don't need the flag. Follow up to https://github.com/getsentry/sentry/pull/95951.