### PR TITLE
fix(tasks) Improve scheduler metrics and fix an error

### DIFF
--- a/src/sentry/taskworker/scheduler/runner.py
+++ b/src/sentry/taskworker/scheduler/runner.py
@@ -46,7 +46,8 @@ class RunStorage:
         Returns False when the key is set and a task should not be spawned.
         """
         now = timezone.now()
-        duration = next_runtime - now
+        # next_runtime & now could be the same second, and redis gets sad if ex=0
+        duration = min(int((next_runtime - now).total_seconds()), 1)
 
         result = self._redis.set(self._make_key(taskname), now.isoformat(), ex=duration, nx=True)
         return bool(result)

--- a/src/sentry/taskworker/scheduler/runner.py
+++ b/src/sentry/taskworker/scheduler/runner.py
@@ -59,6 +59,8 @@ class RunStorage:
         result = self._redis.get(self._make_key(taskname))
         if result:
             return datetime.fromisoformat(result)
+
+        metrics.incr("taskworker.scheduler.run_storage.read.miss", tags={"taskname": taskname})
         return None
 
     def read_many(self, tasknames: list[str]) -> Mapping[str, datetime | None]:
@@ -203,6 +205,7 @@ class ScheduleRunner:
         self._update_heap()
 
         if not self._heap:
+            logger.warning("taskworker.scheduler.no_heap")
             return 60
 
         while True:
@@ -239,13 +242,22 @@ class ScheduleRunner:
                 },
             )
         else:
-            # sync with last_run state in storage
-            entry.set_last_run(self._run_storage.read(entry.fullname))
+            # We were not able to set a key, load last run from storage.
+            run_state = self._run_storage.read(entry.fullname)
+            entry.set_last_run(run_state)
 
-            logger.debug(
-                "taskworker.scheduler.sync_with_storage", extra={"fullname": entry.fullname}
+            logger.info(
+                "taskworker.scheduler.sync_with_storage",
+                extra={
+                    "taskname": entry.taskname,
+                    "namespace": entry.namespace,
+                    "last_runtime": run_state.isoformat() if run_state else None,
+                },
             )
-            metrics.incr("taskworker.scheduler.sync_with_storage")
+            metrics.incr(
+                "taskworker.scheduler.sync_with_storage",
+                tags={"taskname": entry.taskname, "namespace": entry.namespace},
+            )
 
     def _update_heap(self) -> None:
         """update the heap to reflect current remaining time"""
@@ -267,3 +279,10 @@ class ScheduleRunner:
         for item in self._entries:
             last_run = last_run_times.get(item.fullname, None)
             item.set_last_run(last_run)
+        logger.info(
+            "taskworker.scheduler.load_last_run",
+            extra={
+                "entry_count": len(self._entries),
+                "loaded_count": len(last_run_times),
+            },
+        )

--- a/src/sentry/taskworker/scheduler/runner.py
+++ b/src/sentry/taskworker/scheduler/runner.py
@@ -47,7 +47,7 @@ class RunStorage:
         """
         now = timezone.now()
         # next_runtime & now could be the same second, and redis gets sad if ex=0
-        duration = min(int((next_runtime - now).total_seconds()), 1)
+        duration = max(int((next_runtime - now).total_seconds()), 1)
 
         result = self._redis.set(self._make_key(taskname), now.isoformat(), ex=duration, nx=True)
         return bool(result)

--- a/tests/sentry/taskworker/scheduler/test_runner.py
+++ b/tests/sentry/taskworker/scheduler/test_runner.py
@@ -34,6 +34,23 @@ def run_storage() -> RunStorage:
     return RunStorage(redis)
 
 
+def test_runstorage_zero_duration(run_storage: RunStorage) -> None:
+    with freeze_time("2025-07-19 14:25:00"):
+        now = timezone.now()
+        result = run_storage.set("test:do_stuff", now)
+        assert result is True
+
+
+def test_runstorage_double_set(run_storage: RunStorage) -> None:
+    with freeze_time("2025-07-19 14:25:00"):
+        now = timezone.now()
+        first = run_storage.set("test:do_stuff", now)
+        second = run_storage.set("test:do_stuff", now)
+
+        assert first is True, "initial set should return true"
+        assert second is False, "writing a key that exists should fail"
+
+
 @pytest.mark.django_db
 def test_schedulerunner_add_invalid(taskregistry) -> None:
     run_storage = Mock(spec=RunStorage)


### PR DESCRIPTION
In debugging why the scheduler in s4s occasionally stops scheduling tasks, I found some gaps in our metrics and logging that would have helped solve the problem, and also a sentry error that occurs when the 'next' runtime for task is `now`. Redis doesn't allow `ex=0`. 

Fixes SENTRY-FOR-SENTRY-B8D