### PR TITLE
chore(issues): log rate limit type as `NOT_LIMITED` rather than `DNE`

### DIFF
--- a/src/sentry/middleware/ratelimit.py
+++ b/src/sentry/middleware/ratelimit.py
@@ -57,19 +57,8 @@ class RatelimitMiddleware:
             try:
                 # TODO: put these fields into their own object
                 request.will_be_rate_limited = False
-                if settings.SENTRY_SELF_HOSTED:
-                    request.rate_limit_metadata = RateLimitMeta(
-                        rate_limit_type=RateLimitType.NOT_LIMITED,
-                        current=0,
-                        remaining=0,
-                        limit=0,
-                        window=0,
-                        group="self-hosted",
-                        reset_time=0,
-                        concurrent_limit=None,
-                        concurrent_requests=None,
-                    )
-                    return None
+                # if settings.SENTRY_SELF_HOSTED:
+                #     return None
                 request.rate_limit_category = None
                 request.rate_limit_uid = uuid.uuid4().hex
                 view_class = getattr(view_func, "view_class", None)
@@ -112,7 +101,6 @@ class RatelimitMiddleware:
                     rate_limit_config=rate_limit_config,
                 )
                 if rate_limit is None:
-                    # Even if rate limit lookup fails, set metadata to indicate this was a rate-limited endpoint
                     request.rate_limit_metadata = RateLimitMeta(
                         rate_limit_type=RateLimitType.NOT_LIMITED,
                         current=0,

--- a/tests/sentry/middleware/test_access_log_middleware.py
+++ b/tests/sentry/middleware/test_access_log_middleware.py
@@ -306,6 +306,7 @@ class TestOrganizationIdPresentForControl(LogCaptureAPITestCase):
 
 
 @all_silo_test
+@override_settings(SENTRY_SELF_HOSTED=False)
 class TestAccessLogRateLimitTypeConsistency(LogCaptureAPITestCase):
     endpoint = "concurrent-ratelimit-endpoint"
 

--- a/tests/sentry/middleware/test_access_log_middleware.py
+++ b/tests/sentry/middleware/test_access_log_middleware.py
@@ -303,3 +303,18 @@ class TestOrganizationIdPresentForControl(LogCaptureAPITestCase):
 
         tested_log = self.get_tested_log(args=[self.organization.slug])
         assert tested_log.organization_id == str(self.organization.id)
+
+
+@all_silo_test
+class TestAccessLogRateLimitTypeConsistency(LogCaptureAPITestCase):
+    endpoint = "concurrent-ratelimit-endpoint"
+
+    def test_rate_limit_type_uses_enum_not_dne_string(self):
+        self._caplog.set_level(logging.INFO, logger="sentry")
+        self.login_as(user=self.user)
+        self.get_success_response()
+
+        self.assert_access_log_recorded()
+        tested_log = self.get_tested_log()
+
+        assert tested_log.rate_limit_type == "RateLimitType.NOT_LIMITED"


### PR DESCRIPTION
There are a number of cases where we log an API request as `rate_limit_type: 'DNE'`, even when we know that the endpoint was rate limited, but just was not limited.

[GCP Query](https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Alabels.name%3D~%22sentry%22%0AjsonPayload.event%3D%22api.access%22%0A--%20jsonPayload.rate_limit_type%3D%22RateLimitType.NOT_LIMITED%22;summaryFields=:true:32:beginning;cursorTimestamp=2025-07-20T17:27:49.522593608Z;duration=PT3H?project=internal-sentry&inv=1&invt=Ab3Rlw&rapt=AEjHL4Nomc9DSm3ZfcUsOniwdoLW25Wt2ct-EzIWhXKmA3Afb6g4uJy-_LENnYrScXRvC47-Kr4zDQayEFQMoWbj-kvL9d8YDZxS9IEq__2z4q9W_VcOUhI)