### PR TITLE
fix(error_upsampling) - Fix events-stats API "meta" field regression

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -341,8 +341,6 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
             meta = results.get("meta", {})
             fields_meta = meta.get("fields", {})
 
-            self.handle_error_upsampling(project_ids, results)
-
             if standard_meta:
                 isMetricsData = meta.pop("isMetricsData", False)
                 isMetricsExtractedData = meta.pop("isMetricsExtractedData", False)
@@ -436,25 +434,25 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
             fields_meta = results.get("meta", {}).get("fields", {})
 
             for result in data:
-                if "count" in result:
-                    result["count()"] = result["count"]
-                    del result["count"]
-                if "eps" in result:
-                    result["eps()"] = result["eps"]
-                    del result["eps"]
-                if "epm" in result:
-                    result["epm()"] = result["epm"]
-                    del result["epm"]
+                if "upsampled_count()" in result:
+                    result["count()"] = result["upsampled_count()"]
+                    del result["upsampled_count()"]
+                if "upsampled_eps()" in result:
+                    result["eps()"] = result["upsampled_eps()"]
+                    del result["upsampled_eps()"]
+                if "upsampled_epm()" in result:
+                    result["epm()"] = result["upsampled_epm()"]
+                    del result["upsampled_epm()"]
 
-            if "count" in fields_meta:
-                fields_meta["count()"] = fields_meta["count"]
-                del fields_meta["count"]
-            if "eps" in fields_meta:
-                fields_meta["eps()"] = fields_meta["eps"]
-                del fields_meta["eps"]
-            if "epm" in fields_meta:
-                fields_meta["epm()"] = fields_meta["epm"]
-                del fields_meta["epm"]
+            if "upsampled_count()" in fields_meta:
+                fields_meta["count()"] = fields_meta["upsampled_count()"]
+                del fields_meta["upsampled_count()"]
+            if "upsampled_eps()" in fields_meta:
+                fields_meta["eps()"] = fields_meta["upsampled_eps()"]
+                del fields_meta["upsampled_eps()"]
+            if "upsampled_epm()" in fields_meta:
+                fields_meta["epm()"] = fields_meta["upsampled_epm()"]
+                del fields_meta["upsampled_epm()"]
 
     def handle_issues(
         self, results: Sequence[Any], project_ids: Sequence[int], organization: Organization

--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -426,33 +426,29 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
     def handle_error_upsampling(self, project_ids: Sequence[int], results: dict[str, Any]):
         """
         If the query is for error upsampled projects, we need to rename the fields to include the ()
-        and update the meta fields to reflect the new field names. This works around a limitation in
+        and update the data and meta fields to reflect the new field names. This works around a limitation in
         how aliases are handled in the SnQL parser.
         """
         if are_any_projects_error_upsampled(project_ids):
             data = results.get("data", [])
             fields_meta = results.get("meta", {}).get("fields", {})
 
-            for result in data:
-                if "upsampled_count()" in result:
-                    result["count()"] = result["upsampled_count()"]
-                    del result["upsampled_count()"]
-                if "upsampled_eps()" in result:
-                    result["eps()"] = result["upsampled_eps()"]
-                    del result["upsampled_eps()"]
-                if "upsampled_epm()" in result:
-                    result["epm()"] = result["upsampled_epm()"]
-                    del result["upsampled_epm()"]
+            function_conversions = {
+                "upsampled_count()": "count()",
+                "upsampled_eps()": "eps()",
+                "upsampled_epm()": "epm()",
+            }
 
-            if "upsampled_count()" in fields_meta:
-                fields_meta["count()"] = fields_meta["upsampled_count()"]
-                del fields_meta["upsampled_count()"]
-            if "upsampled_eps()" in fields_meta:
-                fields_meta["eps()"] = fields_meta["upsampled_eps()"]
-                del fields_meta["upsampled_eps()"]
-            if "upsampled_epm()" in fields_meta:
-                fields_meta["epm()"] = fields_meta["upsampled_epm()"]
-                del fields_meta["upsampled_epm()"]
+            # Go over each both data and meta, and convert function names to the non-upsampled version
+            for upsampled_function, count_function in function_conversions.items():
+                for result in data:
+                    if upsampled_function in result:
+                        result[count_function] = result[upsampled_function]
+                        del result[upsampled_function]
+
+                if upsampled_function in fields_meta:
+                    fields_meta[count_function] = fields_meta[upsampled_function]
+                    del fields_meta[upsampled_function]
 
     def handle_issues(
         self, results: Sequence[Any], project_ids: Sequence[int], organization: Organization

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -320,13 +320,13 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
             limit: int,
             query: str | None,
         ):
-            transform_alias_to_input_format = True
             selected_columns = self.get_field_list(organization, request)
             if is_errors_query_for_error_upsampled_projects(
                 snuba_params, organization, dataset, request
             ):
-                selected_columns = transform_query_columns_for_error_upsampling(selected_columns)
-                transform_alias_to_input_format = False
+                selected_columns = transform_query_columns_for_error_upsampling(
+                    selected_columns, False
+                )
             query_source = self.get_request_source(request)
             return dataset_query(
                 selected_columns=selected_columns,
@@ -341,7 +341,7 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
                 auto_aggregations=True,
                 allow_metric_aggregates=allow_metric_aggregates,
                 use_aggregate_conditions=use_aggregate_conditions,
-                transform_alias_to_input_format=transform_alias_to_input_format,
+                transform_alias_to_input_format=True,
                 # Whether the flag is enabled or not, regardless of the referrer
                 has_metrics=use_metrics,
                 use_metrics_layer=batch_features.get("organizations:use-metrics-layer", False),
@@ -624,30 +624,26 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
 
         max_per_page = 9999 if dataset == ourlogs else None
 
+        def _handle_results(results):
+            # Apply error upsampling for regular Events API
+            self.handle_error_upsampling(snuba_params.project_ids, results)
+            return self.handle_results_with_meta(
+                request,
+                organization,
+                snuba_params.project_ids,
+                results,
+                standard_meta=True,
+                dataset=dataset,
+            )
+
         with handle_query_errors():
             # Don't include cursor headers if the client won't be using them
             if request.GET.get("noPagination"):
-                return Response(
-                    self.handle_results_with_meta(
-                        request,
-                        organization,
-                        snuba_params.project_ids,
-                        data_fn(0, self.get_per_page(request)),
-                        standard_meta=True,
-                        dataset=dataset,
-                    )
-                )
+                return Response(_handle_results(data_fn(0, self.get_per_page(request))))
             else:
                 return self.paginate(
                     request=request,
                     paginator=GenericOffsetPaginator(data_fn=data_fn),
-                    on_results=lambda results: self.handle_results_with_meta(
-                        request,
-                        organization,
-                        snuba_params.project_ids,
-                        results,
-                        standard_meta=True,
-                        dataset=dataset,
-                    ),
+                    on_results=_handle_results,
                     max_per_page=max_per_page,
                 )

--- a/src/sentry/api/helpers/error_upsampling.py
+++ b/src/sentry/api/helpers/error_upsampling.py
@@ -44,7 +44,9 @@ def are_any_projects_error_upsampled(project_ids: Sequence[int]) -> bool:
     return result
 
 
-def transform_query_columns_for_error_upsampling(query_columns: Sequence[str]) -> list[str]:
+def transform_query_columns_for_error_upsampling(
+    query_columns: Sequence[str], include_alias: bool = True
+) -> list[str]:
     """
     Transform aggregation functions to use sum(sample_weight) instead of count()
     for error upsampling.
@@ -54,13 +56,20 @@ def transform_query_columns_for_error_upsampling(query_columns: Sequence[str]) -
         column_lower = column.lower().strip()
 
         if column_lower == "count()":
-            transformed_columns.append("upsampled_count() as count")
-
+            transformed = "upsampled_count()"
+            if include_alias:
+                transformed += " as count"
+            transformed_columns.append(transformed)
         elif column_lower == "eps()":
-            transformed_columns.append("upsampled_eps() as eps")
-
+            transformed = "upsampled_eps()"
+            if include_alias:
+                transformed += " as eps"
+            transformed_columns.append(transformed)
         elif column_lower == "epm()":
-            transformed_columns.append("upsampled_epm() as epm")
+            transformed = "upsampled_epm()"
+            if include_alias:
+                transformed += " as epm"
+            transformed_columns.append(transformed)
         else:
             transformed_columns.append(column)
 

--- a/src/sentry/api/helpers/error_upsampling.py
+++ b/src/sentry/api/helpers/error_upsampling.py
@@ -51,24 +51,20 @@ def transform_query_columns_for_error_upsampling(
     Transform aggregation functions to use sum(sample_weight) instead of count()
     for error upsampling.
     """
+    function_conversions = {
+        "count()": "upsampled_count()",
+        "eps()": "upsampled_eps()",
+        "epm()": "upsampled_epm()",
+    }
+
     transformed_columns = []
     for column in query_columns:
         column_lower = column.lower().strip()
 
-        if column_lower == "count()":
-            transformed = "upsampled_count()"
+        if column_lower in function_conversions:
+            transformed = function_conversions[column_lower]
             if include_alias:
-                transformed += " as count"
-            transformed_columns.append(transformed)
-        elif column_lower == "eps()":
-            transformed = "upsampled_eps()"
-            if include_alias:
-                transformed += " as eps"
-            transformed_columns.append(transformed)
-        elif column_lower == "epm()":
-            transformed = "upsampled_epm()"
-            if include_alias:
-                transformed += " as epm"
+                transformed += " as " + column_lower[:-2]
             transformed_columns.append(transformed)
         else:
             transformed_columns.append(column)

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -1681,7 +1681,7 @@ def aliased_query_params(
                     get_upsampled_count_snql_with_alias(
                         aggregation[2]
                         if len(aggregation) > 2 and aggregation[2] is not None
-                        else "upsampled_count"
+                        else UPSAMPLED_ERROR_AGGREGATION
                     )
                 )
             else:

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -3553,9 +3553,17 @@ class OrganizationEventsStatsErrorUpsamplingTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 200, response.content
         data = response.data["data"]
+        meta = response.data["meta"]
+
         assert len(data) == 2  # Two time buckets
         assert data[0][1][0]["count"] == 10  # First bucket has 1 event
         assert data[1][1][0]["count"] == 10  # Second bucket has 1 event
+
+        # Check that meta has the expected field structure
+        assert "count" in meta["fields"], f"Expected 'count' in meta fields, got: {meta['fields']}"
+        assert (
+            meta["fields"]["count"] == "integer"
+        ), f"Expected 'count' to be 'integer' type, got: {meta['fields']['count']}"
 
     @mock.patch("sentry.api.helpers.error_upsampling.options")
     def test_error_upsampling_with_partial_allowlist(self, mock_options):
@@ -3651,3 +3659,78 @@ class OrganizationEventsStatsErrorUpsamplingTest(APITestCase, SnubaTestCase):
         # Should use regular count() since no projects are allowlisted
         assert data[0][1][0]["count"] == 1
         assert data[1][1][0]["count"] == 1
+
+    @mock.patch("sentry.api.helpers.error_upsampling.options")
+    def test_error_upsampling_count_unique_user_with_allowlisted_projects(self, mock_options):
+        """Test that count_unique(user) works correctly with error upsampling for Events Stats API."""
+        # Set up allowlisted projects
+        mock_options.get.return_value = [self.project.id, self.project2.id]
+
+        # Store error events with users and error_sampling context
+        # Use more precise timestamps to ensure clear bucket separation
+        event1_time = self.day_ago.replace(minute=0, second=0, microsecond=0)
+        event2_time = self.day_ago.replace(minute=0, second=0, microsecond=0) + timedelta(hours=1)
+
+        self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "message": "Error event for user1",
+                "type": "error",
+                "exception": [{"type": "ValueError", "value": "Something went wrong"}],
+                "timestamp": event1_time.isoformat(),
+                "fingerprint": ["group1"],
+                "tags": {"sentry:user": self.user.email},
+                "contexts": {"error_sampling": {"client_sample_rate": 0.1}},
+            },
+            project_id=self.project.id,
+        )
+
+        self.store_event(
+            data={
+                "event_id": "b" * 32,
+                "message": "Error event for user2",
+                "type": "error",
+                "exception": [{"type": "ValueError", "value": "Another error"}],
+                "timestamp": event2_time.isoformat(),
+                "fingerprint": ["group2"],
+                "tags": {"sentry:user": self.user2.email},
+                "contexts": {"error_sampling": {"client_sample_rate": 0.1}},
+            },
+            project_id=self.project2.id,
+        )
+
+        # Test with count_unique(user) aggregation
+        query_start = self.day_ago
+        query_end = self.day_ago + timedelta(hours=2)
+
+        response = self.client.get(
+            self.url,
+            data={
+                "start": query_start.isoformat(),
+                "end": query_end.isoformat(),
+                "interval": "1h",
+                "yAxis": "count_unique(user)",
+                "query": "event.type:error",
+                "project": [self.project.id, self.project2.id],
+            },
+            format="json",
+        )
+
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+
+        assert len(data) == 2  # Two time buckets
+
+        # count_unique(user) should NOT be upsampled - each bucket should count its actual unique users
+        # This test verifies that user counts work correctly even with error upsampling enabled
+        assert data[0][1][0]["count"] == 1  # First bucket: 1 user (user1)
+        assert data[1][1][0]["count"] == 1  # Second bucket: 1 user (user2)
+
+        # Check that meta has the expected field structure for count_unique(user)
+        assert (
+            "count_unique_user" in meta["fields"]
+        ), f"Expected 'count_unique_user' in meta fields, got: {meta['fields']}"
+        assert (
+            meta["fields"]["count_unique_user"] == "integer"
+        ), f"Expected 'count_unique_user' to be 'integer' type, got: {meta['fields']['count_unique_user']}"


### PR DESCRIPTION
Fixes event-stats API meta field being altered by recent implementation of error-upsampling in Events API. Split the implementation to be isolated, and added test for "meta" field, as well as test for count_uniq(users) which was also broken by this and had no test.