### PR TITLE
Do not fail migrations when btree_gist extension already exists

### DIFF
--- a/src/sentry/migrations/0001_squashed_0904_onboarding_task_project_id_idx.py
+++ b/src/sentry/migrations/0001_squashed_0904_onboarding_task_project_id_idx.py
@@ -8410,7 +8410,7 @@ class Migration(CheckedMigration):
         # would be nice but it doesn't support hints :(
         # django.contrib.postgres.operations.BtreeGistExtension(),
         SafeRunSQL(
-            sql="CREATE EXTENSION btree_gist;",
+            sql="CREATE EXTENSION IF NOT EXISTS btree_gist;",
             reverse_sql="",
             hints={"tables": ["sentry_groupopenperiod"]},
         ),

--- a/tools/migrations/squash.py
+++ b/tools/migrations/squash.py
@@ -11,7 +11,7 @@ _GIST_EXT = """\
         # would be nice but it doesn't support hints :(
         # django.contrib.postgres.operations.BtreeGistExtension(),
         SafeRunSQL(
-            sql="CREATE EXTENSION btree_gist;",
+            sql="CREATE EXTENSION IF NOT EXISTS btree_gist;",
             reverse_sql="",
             hints={{"tables": [{table!r}]}},
         ),


### PR DESCRIPTION
<!-- Describe your PR here. -->

Add `IF NOT EXISTS` to the `btree_gist` extension creation to avoid failing migrations on databases where the extension was already created.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
