### PR TITLE
fix(ui2): make sure disabled LinkButtons don't get hover styles applied

### DIFF
--- a/static/app/components/core/button/styles.chonk.tsx
+++ b/static/app/components/core/button/styles.chonk.tsx
@@ -135,7 +135,7 @@ export function DO_NOT_USE_getChonkButtonStyles(
     },
 
     '&:hover': {
-      color: p.disabled || p.busy ? undefined : chonkButtonTheme.color,
+      color: p.disabled || p.busy ? 'inherit' : chonkButtonTheme.color,
 
       '&::after': {
         transform: `translateY(calc(-${elevation} - ${chonkHoverElevation}))`,


### PR DESCRIPTION
before:

https://github.com/user-attachments/assets/3bce4f66-f86c-4daf-b572-cbb02d947714

after:

https://github.com/user-attachments/assets/bb574fa6-efa6-4261-857b-07396dc5b060
