### PR TITLE
chore(taskworker): Remove unused compression param in process_profile

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3203,6 +3203,12 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
+    "taskworker.try_compress.profile_metrics.level",
+    default=6,
+    type=Int,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
     "taskworker.fetch_next.disabled_pools",
     default=[],
     flags=FLAG_AUTOMATOR_MODIFIABLE,
@@ -3458,6 +3464,13 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Taskbroker compression flag
+register(
+    "taskworker.enable_compression.rollout",
+    default=0.0,
+    type=Float,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # Orgs for which compression should be disabled in the chunk upload endpoint.
 # This is intended to circumvent sporadic 503 errors reported by some customers.

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3203,12 +3203,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
-    "taskworker.try_compress.profile_metrics.level",
-    default=6,
-    type=Int,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
     "taskworker.fetch_next.disabled_pools",
     default=[],
     flags=FLAG_AUTOMATOR_MODIFIABLE,
@@ -3464,13 +3458,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Taskbroker compression flag
-register(
-    "taskworker.enable_compression.rollout",
-    default=0.0,
-    type=Float,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 # Orgs for which compression should be disabled in the chunk upload endpoint.
 # This is intended to circumvent sporadic 503 errors reported by some customers.

--- a/src/sentry/profiles/consumers/process/factory.py
+++ b/src/sentry/profiles/consumers/process/factory.py
@@ -17,7 +17,7 @@ def process_message(message: Message[KafkaPayload]) -> None:
 
     if sampled or options.get("profiling.profile_metrics.unsampled_profiles.enabled"):
         b64encoded = b64encode(message.payload.value).decode("utf-8")
-        process_profile_task.delay(payload=b64encoded, sampled=sampled, compressed_profile=False)
+        process_profile_task.delay(payload=b64encoded, sampled=sampled)
 
 
 class ProcessProfileStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):

--- a/tests/sentry/profiles/consumers/test_process.py
+++ b/tests/sentry/profiles/consumers/test_process.py
@@ -56,7 +56,6 @@ class TestProcessProfileConsumerStrategy(TestCase):
         process_profile_task.assert_called_with(
             payload=b64encode(payload).decode("utf-8"),
             sampled=True,
-            compressed_profile=False,
         )
 
 


### PR DESCRIPTION
This parameter is no longer being used to determine whether the process task payload should be zlib decompressed. The taskworker platform handles compression now.