### PR TITLE
fix(dashboards): don't persist widget sort into widget builder

### DIFF
--- a/static/app/views/dashboards/dashboard.tsx
+++ b/static/app/views/dashboards/dashboard.tsx
@@ -25,12 +25,10 @@ import type {PageFilters} from 'sentry/types/core';
 import type {InjectedRouter} from 'sentry/types/legacyReactRouter';
 import type {Organization} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import type {Sort} from 'sentry/utils/discover/fields';
 import {DatasetSource} from 'sentry/utils/discover/types';
 import withApi from 'sentry/utils/withApi';
 import withPageFilters from 'sentry/utils/withPageFilters';
 import type {DataSet} from 'sentry/views/dashboards/widgetBuilder/utils';
-import type {TabularColumn} from 'sentry/views/dashboards/widgets/common/types';
 
 import AddWidget, {ADD_WIDGET_BUTTON_DRAG_ID} from './addWidget';
 import type {Position} from './layoutUtils';
@@ -353,38 +351,6 @@ class Dashboard extends Component<Props, State> {
     ];
   }
 
-  handleWidgetTableSort(index: number) {
-    const {dashboard, onUpdate} = this.props;
-    return function (sort: Sort) {
-      const widget = dashboard.widgets[index]!;
-      const widgetCopy = cloneDeep(widget);
-      if (widgetCopy.queries[0]) {
-        const direction = sort.kind === 'desc' ? '-' : '';
-        widgetCopy.queries[0].orderby = `${direction}${sort.field}`;
-      }
-
-      const nextList = [...dashboard.widgets];
-      nextList[index] = widgetCopy;
-
-      onUpdate(nextList);
-    };
-  }
-
-  handleWidgetColumnTableResize(index: number) {
-    const {dashboard, onUpdate} = this.props;
-    return function (columns: TabularColumn[]) {
-      const widths = columns.map(column => column.width as number);
-      const widget = dashboard.widgets[index]!;
-      const widgetCopy = cloneDeep(widget);
-      widgetCopy.tableWidths = widths;
-
-      const nextList = [...dashboard.widgets];
-      nextList[index] = widgetCopy;
-
-      onUpdate(nextList);
-    };
-  }
-
   renderWidget(widget: Widget, index: number) {
     const {isMobile, windowWidth} = this.state;
     const {
@@ -425,8 +391,6 @@ class Dashboard extends Component<Props, State> {
           index={String(index)}
           newlyAddedWidget={newlyAddedWidget}
           onNewWidgetScrollComplete={onNewWidgetScrollComplete}
-          onWidgetTableSort={this.handleWidgetTableSort(index)}
-          onWidgetTableResizeColumn={this.handleWidgetColumnTableResize(index)}
         />
       </div>
     );

--- a/static/app/views/dashboards/sortableWidget.tsx
+++ b/static/app/views/dashboards/sortableWidget.tsx
@@ -93,6 +93,9 @@ function SortableWidget(props: Props) {
       widgetRef.current.scrollIntoView({behavior: 'smooth', block: 'center'});
       onNewWidgetScrollComplete?.();
     }
+    if (isMatchingWidget) {
+      setDisplayWidget(cloneDeep(widget));
+    }
   }, [newlyAddedWidget, widget, isEditingDashboard, onNewWidgetScrollComplete]);
 
   const onWidgetTableSort = (sort: Sort) => {

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -226,7 +226,13 @@ function WidgetCard(props: Props) {
           pathname: `${location.pathname}${
             location.pathname.endsWith('/') ? '' : '/'
           }widget/${props.index}/`,
-          query: location.query,
+          query: {
+            ...location.query,
+            sort:
+              widget.displayType === DisplayType.TABLE
+                ? widget.queries[0]?.orderby
+                : location.query.sort,
+          },
         },
         {preventScrollReset: true}
       );


### PR DESCRIPTION
### Changes

Refactors the table widget handlers for temporary actions (sorting, column resizing) to be handled in `SortableWidget` instead of the `Dashboard` component. This fixes the temporary sort being set on a widget, then persisting when the user edits the widget, which might lead them to unintentionally save the temporary sort.

Also added a location query update if the widget is a table, so that the temporary sort persists into the viewer widget modal.

### Before

Note that `timestamp` is the default sort saved to the widget for both before/after

https://github.com/user-attachments/assets/43deb4a7-ef9f-4f1c-ba9a-1de14a9cbd5e

### After

https://github.com/user-attachments/assets/976e0f99-70b7-4922-9588-ccc99c84f110

