### PR TITLE
chore(taskworker): Remove taskworker compression rollout option

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3203,12 +3203,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
-    "taskworker.try_compress.profile_metrics.level",
-    default=6,
-    type=Int,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
     "taskworker.fetch_next.disabled_pools",
     default=[],
     flags=FLAG_AUTOMATOR_MODIFIABLE,
@@ -3464,13 +3458,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Taskbroker compression flag
-register(
-    "taskworker.enable_compression.rollout",
-    default=0.0,
-    type=Float,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 # Orgs for which compression should be disabled in the chunk upload endpoint.
 # This is intended to circumvent sporadic 503 errors reported by some customers.

--- a/src/sentry/taskworker/task.py
+++ b/src/sentry/taskworker/task.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import base64
 import datetime
-import random
 import time
 from collections.abc import Callable, Collection, Mapping, MutableMapping
 from functools import update_wrapper
@@ -21,7 +20,6 @@ from sentry_protos.taskbroker.v1.taskbroker_pb2 import (
     TaskActivation,
 )
 
-from sentry import options
 from sentry.taskworker.constants import DEFAULT_PROCESSING_DEADLINE, CompressionType
 from sentry.taskworker.retry import Retry
 from sentry.utils import metrics
@@ -179,38 +177,30 @@ class Task(Generic[P, R]):
 
         parameters_json = orjson.dumps({"args": args, "kwargs": kwargs})
         if self.compression_type == CompressionType.ZSTD:
-            # TODO(taskworker): Nesting this conditional avoids django_db fixtures in tests.
-            # Once we have rolled out compression safely, we can remove this conditional.
-            compression_rollout_rate = options.get("taskworker.enable_compression.rollout")
-            if compression_rollout_rate and compression_rollout_rate > random.random():
-                # Worker uses this header to determine if the parameters are decompressed
-                headers["compression-type"] = CompressionType.ZSTD.value
-                start_time = time.perf_counter()
-                parameters_data = zstd.compress(parameters_json)
-                # Compressed data is binary and needs base64 encoding for transport
-                parameters_str = base64.b64encode(parameters_data).decode("utf8")
-                end_time = time.perf_counter()
+            # Worker uses this header to determine if the parameters are decompressed
+            headers["compression-type"] = CompressionType.ZSTD.value
+            start_time = time.perf_counter()
+            parameters_str = base64.b64encode(zstd.compress(parameters_json)).decode("utf8")
+            end_time = time.perf_counter()
 
-                metrics.distribution(
-                    "taskworker.producer.compressed_parameters_size",
-                    len(parameters_str),
-                    tags={
-                        "namespace": self._namespace.name,
-                        "taskname": self.name,
-                        "topic": self._namespace.topic.value,
-                    },
-                )
-                metrics.distribution(
-                    "taskworker.producer.compression_time",
-                    end_time - start_time,
-                    tags={
-                        "namespace": self._namespace.name,
-                        "taskname": self.name,
-                        "topic": self._namespace.topic.value,
-                    },
-                )
-            else:
-                parameters_str = parameters_json.decode("utf8")
+            metrics.distribution(
+                "taskworker.producer.compressed_parameters_size",
+                len(parameters_str),
+                tags={
+                    "namespace": self._namespace.name,
+                    "taskname": self.name,
+                    "topic": self._namespace.topic.value,
+                },
+            )
+            metrics.distribution(
+                "taskworker.producer.compression_time",
+                end_time - start_time,
+                tags={
+                    "namespace": self._namespace.name,
+                    "taskname": self.name,
+                    "topic": self._namespace.topic.value,
+                },
+            )
         else:
             parameters_str = parameters_json.decode("utf8")
 

--- a/tests/sentry/processing/backpressure/test_checking.py
+++ b/tests/sentry/processing/backpressure/test_checking.py
@@ -67,7 +67,6 @@ def test_bad_config():
         "backpressure.checking.interval": 5,
         "backpressure.monitoring.enabled": True,
         "backpressure.status_ttl": 60,
-        "taskworker.try_compress.profile_metrics.level": 1,
     }
 )
 def test_backpressure_healthy_profiles(process_profile_task):
@@ -139,7 +138,6 @@ def test_backpressure_healthy_events(preprocess_event):
     {
         "backpressure.checking.enabled": False,
         "backpressure.checking.interval": 5,
-        "taskworker.try_compress.profile_metrics.level": 1,
     }
 )
 def test_backpressure_not_enabled(process_profile_task):


### PR DESCRIPTION
Now that compression has been safely rolled out to taskworker, we can remove the rollout options