### PR TITLE
fix(tasks) Disallow tasks having multiple schedules

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1702,10 +1702,6 @@ TASKWORKER_REGION_SCHEDULES: ScheduleConfigMap = {
         "task": "ai_agent_monitoring:sentry.tasks.ai_agent_monitoring.fetch_ai_model_costs",
         "schedule": task_crontab("*/30", "*", "*", "*", "*"),
     },
-    "sync_options_trial": {
-        "schedule": timedelta(minutes=5),
-        "task": "options:sentry.tasks.options.sync_options",
-    },
 }
 
 TASKWORKER_CONTROL_SCHEDULES: ScheduleConfigMap = {

--- a/tests/sentry/taskworker/test_config.py
+++ b/tests/sentry/taskworker/test_config.py
@@ -18,6 +18,17 @@ def test_import_paths():
             raise AssertionError(f"Unable to import {path} from TASKWORKER_IMPORTS")
 
 
+def test_taskworker_schedule_unique() -> None:
+    visited = {}
+    for key, entry in settings.TASKWORKER_SCHEDULES.items():
+        if entry["task"] in visited:
+            msg = f"Schedule {key} references a task that is already scheduled: {entry['task']}"
+            raise AssertionError(msg)
+
+        if entry["task"] not in visited:
+            visited[entry["task"]] = key
+
+
 @pytest.mark.parametrize("name,config", list(settings.TASKWORKER_SCHEDULES.items()))
 def test_taskworker_schedule_type(name: str, config: dict[str, Any]) -> None:
     assert config["task"], f"schedule {name} is missing a task name"

--- a/tests/sentry/taskworker/test_config.py
+++ b/tests/sentry/taskworker/test_config.py
@@ -22,8 +22,13 @@ def test_taskworker_schedule_unique() -> None:
     visited = {}
     for key, entry in settings.TASKWORKER_SCHEDULES.items():
         if entry["task"] in visited:
-            msg = f"Schedule {key} references a task that is already scheduled: {entry['task']}"
+            msg = (
+                f"Schedule {key} references a task ({entry['task']}) "
+                f"that is already scheduled under key {visited[entry['task']]}."
+            )
             raise AssertionError(msg)
+
+        visited[entry["task"]] = key
 
 
 @pytest.mark.parametrize("name,config", list(settings.TASKWORKER_SCHEDULES.items()))

--- a/tests/sentry/taskworker/test_config.py
+++ b/tests/sentry/taskworker/test_config.py
@@ -25,9 +25,6 @@ def test_taskworker_schedule_unique() -> None:
             msg = f"Schedule {key} references a task that is already scheduled: {entry['task']}"
             raise AssertionError(msg)
 
-        if entry["task"] not in visited:
-            visited[entry["task"]] = key
-
 
 @pytest.mark.parametrize("name,config", list(settings.TASKWORKER_SCHEDULES.items()))
 def test_taskworker_schedule_type(name: str, config: dict[str, Any]) -> None:

--- a/tests/sentry/taskworker/test_config.py
+++ b/tests/sentry/taskworker/test_config.py
@@ -19,7 +19,7 @@ def test_import_paths():
 
 
 def test_taskworker_schedule_unique() -> None:
-    visited = {}
+    visited: dict[str, str] = {}
     for key, entry in settings.TASKWORKER_SCHEDULES.items():
         if entry["task"] in visited:
             msg = (


### PR DESCRIPTION
Having multiple schedules for a task is generally a mistake and something we shouldn't do. Add a test to prevent it from happening.
