### PR TITLE
chore(trace ai queries): Gate consent UI to flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -134,6 +134,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:gen-ai-features", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the 'generate me a query' functionality on the explore > traces page
     manager.add("organizations:gen-ai-explore-traces", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable GenAI consent UI on the explore > traces page
+    manager.add("organizations:gen-ai-explore-traces-consent-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable GenAI consent
     manager.add("organizations:gen-ai-consent", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable disabling gitlab integrations when broken is detected

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -134,8 +134,6 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:gen-ai-features", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the 'generate me a query' functionality on the explore > traces page
     manager.add("organizations:gen-ai-explore-traces", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable GenAI consent UI on the explore > traces page
-    manager.add("organizations:gen-ai-explore-traces-consent-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable GenAI consent
     manager.add("organizations:gen-ai-consent", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable disabling gitlab integrations when broken is detected

--- a/static/app/components/searchQueryBuilder/askSeer.tsx
+++ b/static/app/components/searchQueryBuilder/askSeer.tsx
@@ -113,7 +113,7 @@ export function AskSeer<T>({state}: {state: ComboBoxState<T>}) {
 
   if (isPendingSetupCheck || isMutating) {
     return (
-      <Feature features="organizations:trace-ai-query-consent">
+      <Feature features="organizations:gen-ai-explore-traces-consent-ui">
         <AskSeerPane>
           <AskSeerListItem>
             <AskSeerLabel width="auto">{t('Loading Seer')}</AskSeerLabel>
@@ -133,7 +133,7 @@ export function AskSeer<T>({state}: {state: ComboBoxState<T>}) {
   }
 
   return (
-    <Feature features="organizations:trace-ai-query-consent">
+    <Feature features="organizations:gen-ai-explore-traces-consent-ui">
       <AskSeerPane>
         <AskSeerConsentOption state={state} />
       </AskSeerPane>

--- a/static/app/components/searchQueryBuilder/askSeer.tsx
+++ b/static/app/components/searchQueryBuilder/askSeer.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import {useOption} from '@react-aria/listbox';
 import type {ComboBoxState} from '@react-stately/combobox';
 
+import Feature from 'sentry/components/acl/feature';
 import {FeatureBadge} from 'sentry/components/core/badge/featureBadge';
 import InteractionStateLayer from 'sentry/components/core/interactionStateLayer';
 import {makeOrganizationSeerSetupQueryKey} from 'sentry/components/events/autofix/useOrganizationSeerSetup';
@@ -112,12 +113,14 @@ export function AskSeer<T>({state}: {state: ComboBoxState<T>}) {
 
   if (isPendingSetupCheck || isMutating) {
     return (
-      <AskSeerPane>
-        <AskSeerListItem>
-          <AskSeerLabel width="auto">{t('Loading Seer')}</AskSeerLabel>
-          <LoadingIndicator size={16} style={{margin: 0}} />
-        </AskSeerListItem>
-      </AskSeerPane>
+      <Feature features="organizations:trace-ai-query-consent">
+        <AskSeerPane>
+          <AskSeerListItem>
+            <AskSeerLabel width="auto">{t('Loading Seer')}</AskSeerLabel>
+            <LoadingIndicator size={16} style={{margin: 0}} />
+          </AskSeerListItem>
+        </AskSeerPane>
+      </Feature>
     );
   }
 
@@ -130,9 +133,11 @@ export function AskSeer<T>({state}: {state: ComboBoxState<T>}) {
   }
 
   return (
-    <AskSeerPane>
-      <AskSeerConsentOption state={state} />
-    </AskSeerPane>
+    <Feature features="organizations:trace-ai-query-consent">
+      <AskSeerPane>
+        <AskSeerConsentOption state={state} />
+      </AskSeerPane>
+    </Feature>
   );
 }
 

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -4446,7 +4446,13 @@ describe('SearchQueryBuilder', function () {
       });
 
       render(<SearchQueryBuilder {...defaultProps} enableAISearch />, {
-        organization: {features: ['gen-ai-features', 'gen-ai-explore-traces']},
+        organization: {
+          features: [
+            'gen-ai-features',
+            'gen-ai-explore-traces',
+            'gen-ai-explore-traces-consent-ui',
+          ],
+        },
       });
 
       await userEvent.click(getLastInput());
@@ -4467,7 +4473,13 @@ describe('SearchQueryBuilder', function () {
       });
 
       render(<SearchQueryBuilder {...defaultProps} enableAISearch />, {
-        organization: {features: ['gen-ai-features', 'gen-ai-explore-traces']},
+        organization: {
+          features: [
+            'gen-ai-features',
+            'gen-ai-explore-traces',
+            'gen-ai-explore-traces-consent-ui',
+          ],
+        },
       });
 
       await userEvent.click(getLastInput());
@@ -4480,7 +4492,11 @@ describe('SearchQueryBuilder', function () {
       it('calls promptsUpdate', async () => {
         const organization = OrganizationFixture({
           slug: 'org-slug',
-          features: ['gen-ai-features', 'gen-ai-explore-traces'],
+          features: [
+            'gen-ai-features',
+            'gen-ai-explore-traces',
+            'gen-ai-explore-traces-consent-ui',
+          ],
         });
         const promptsUpdateMock = MockApiClient.addMockResponse({
           url: `/organizations/${organization.slug}/prompts-activity/`,
@@ -4537,7 +4553,15 @@ describe('SearchQueryBuilder', function () {
 
         render(
           <SearchQueryBuilder {...defaultProps} enableAISearch onSearch={mockOnSearch} />,
-          {organization: {features: ['gen-ai-features', 'gen-ai-explore-traces']}}
+          {
+            organization: {
+              features: [
+                'gen-ai-features',
+                'gen-ai-explore-traces',
+                'gen-ai-explore-traces-consent-ui',
+              ],
+            },
+          }
         );
 
         await userEvent.click(getLastInput());
@@ -4561,7 +4585,15 @@ describe('SearchQueryBuilder', function () {
 
       render(
         <SearchQueryBuilder {...defaultProps} enableAISearch onSearch={mockOnSearch} />,
-        {organization: {features: ['gen-ai-features', 'gen-ai-explore-traces']}}
+        {
+          organization: {
+            features: [
+              'gen-ai-features',
+              'gen-ai-explore-traces',
+              'gen-ai-explore-traces-consent-ui',
+            ],
+          },
+        }
       );
 
       await userEvent.click(getLastInput());


### PR DESCRIPTION
- Only enable consent flow for those with ff so only orgs who have already consented to Seer AND have enabled genAi features can use the query assistant