### PR TITLE
feat(profiling): Move function trends widgets behind feature flag

### DIFF
--- a/static/app/views/profiling/content.tsx
+++ b/static/app/views/profiling/content.tsx
@@ -175,7 +175,11 @@ export default function ProfilingContent({location}: ProfilingContentProps) {
                       <LandingWidgetSelector
                         cursorName={RIGHT_WIDGET_CURSOR}
                         widgetHeight="410px"
-                        defaultWidget="regressed functions"
+                        defaultWidget={
+                          organization.features.includes('profiling-function-trends')
+                            ? 'regressed functions'
+                            : 'slowest functions avg'
+                        }
                         storageKey="profiling-landing-widget-1"
                         onDataState={updateWidget2DataState}
                       />

--- a/static/app/views/profiling/landing/landingWidgetSelector.tsx
+++ b/static/app/views/profiling/landing/landingWidgetSelector.tsx
@@ -74,10 +74,14 @@ export function LandingWidgetSelector({
     return conditions.formatString();
   }, []);
 
+  const options = organization.features.includes('profiling-function-trends')
+    ? [...SUSPECT_FUNCTIONS_WIDGET_OPTIONS, ...FUNCTION_TRENDS_WIDGET_OPTIONS]
+    : SUSPECT_FUNCTIONS_WIDGET_OPTIONS;
+
   const header = (
     <StyledCompactSelect
       value={selectedWidget}
-      options={WIDGET_OPTIONS}
+      options={options}
       onChange={onWidgetChange}
       triggerProps={{borderless: true, size: 'zero'}}
       offset={4}
@@ -174,7 +178,7 @@ export function LandingWidgetSelector({
   }
 }
 
-const WIDGET_OPTIONS: Array<SelectOption<WidgetOption>> = [
+const SUSPECT_FUNCTIONS_WIDGET_OPTIONS: Array<SelectOption<WidgetOption>> = [
   {
     label: t('Slowest Functions (breakdown by AVG)'),
     value: 'slowest functions avg' as const,
@@ -195,6 +199,9 @@ const WIDGET_OPTIONS: Array<SelectOption<WidgetOption>> = [
     label: t('Slowest Functions (breakdown by P99)'),
     value: 'slowest functions p99' as const,
   },
+];
+
+const FUNCTION_TRENDS_WIDGET_OPTIONS: Array<SelectOption<WidgetOption>> = [
   {
     label: t('Most Regressed Functions'),
     value: 'regressed functions' as const,

--- a/static/app/views/profiling/landing/landingWidgetSelector.tsx
+++ b/static/app/views/profiling/landing/landingWidgetSelector.tsx
@@ -84,8 +84,8 @@ export function LandingWidgetSelector({
     />
   );
 
-  switch (selectedWidget) {
-    case 'regressed functions':
+  if (organization.features.includes('profiling-function-trends')) {
+    if (selectedWidget === 'regressed functions') {
       return (
         <FunctionTrendsWidget
           cursorName={cursorName}
@@ -97,7 +97,9 @@ export function LandingWidgetSelector({
           onDataState={onDataState}
         />
       );
-    case 'improved functions':
+    }
+
+    if (selectedWidget === 'improved functions') {
       return (
         <FunctionTrendsWidget
           cursorName={cursorName}
@@ -109,6 +111,10 @@ export function LandingWidgetSelector({
           onDataState={onDataState}
         />
       );
+    }
+  }
+
+  switch (selectedWidget) {
     case 'slowest functions avg':
       return (
         <SlowestFunctionsWidget


### PR DESCRIPTION
The function trends widgets are not supported in self hosted. So it's being moved behind a separate feature flag so suspect functions widgets can be enabled independently from the function trends widgets.

Depends on #95987