### PR TITLE
feat(dashboards): Add release filters as tokens to list view

### DIFF
--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.spec.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.spec.tsx
@@ -33,6 +33,7 @@ describe('add to dashboard modal', () => {
     widgetPreview: [],
     projects: [],
     environment: [],
+    filters: {},
   };
   const testDashboard: DashboardDetails = {
     id: '1',

--- a/static/app/views/dashboards/manage/tableView/table.spec.tsx
+++ b/static/app/views/dashboards/manage/tableView/table.spec.tsx
@@ -91,4 +91,18 @@ describe('DashboardTable', () => {
     const lastVisitedContent = lastVisitedCell.textContent;
     expect(lastVisitedContent).toMatch(/[\d\w]+s ago$/);
   });
+
+  it('renders release filters', () => {
+    render(
+      <DashboardTable
+        dashboards={[DashboardListItemFixture({filters: {release: ['1.0.0']}})]}
+        cursorKey="test"
+        isLoading={false}
+        title={''}
+      />
+    );
+
+    const filterCells = screen.getAllByLabelText('release:[1.0.0]');
+    expect(filterCells[0]).toHaveTextContent('release is 1.0.0');
+  });
 });

--- a/static/app/views/dashboards/manage/tableView/table.tsx
+++ b/static/app/views/dashboards/manage/tableView/table.tsx
@@ -103,8 +103,9 @@ export function DashboardTable({
             <SavedEntityTable.Cell data-column="envs">
               <SavedEntityTable.CellEnvironments environments={dashboard.environment} />
             </SavedEntityTable.Cell>
-            {/* TODO: DAIN-716 Add release filter as tokens */}
-            <SavedEntityTable.Cell data-column="filter">{'\u2014'}</SavedEntityTable.Cell>
+            <SavedEntityTable.Cell data-column="filter">
+              <SavedEntityTable.CellQuery query={getDashboardFiltersQuery(dashboard)} />
+            </SavedEntityTable.Cell>
             <SavedEntityTable.Cell data-column="num-widgets">
               {dashboard.widgetPreview.length}
             </SavedEntityTable.Cell>
@@ -162,6 +163,13 @@ export function DashboardTable({
   );
 }
 
+function getDashboardFiltersQuery(dashboard: DashboardListItem) {
+  // Dashboards only currently support release filters
+  return dashboard.filters?.release
+    ? `release:[${dashboard.filters.release.join(',')}]`
+    : '';
+}
+
 const Container = styled('div')`
   container-type: inline-size;
 `;
@@ -170,8 +178,8 @@ const Container = styled('div')`
 const SavedEntityTableWithColumns = styled(SavedEntityTable)`
   grid-template-areas: 'star name project envs filter num-widgets created-by last-visited created actions';
   grid-template-columns:
-    40px 20% minmax(auto, 120px) minmax(auto, 120px) minmax(auto, 120px)
-    minmax(auto, 120px) auto auto auto 48px;
+    40px 20% minmax(auto, 120px) minmax(auto, 120px) minmax(auto, 200px)
+    minmax(auto, 120px) 80px auto auto 48px;
 `;
 
 const TableHeading = styled('h2')`

--- a/static/app/views/dashboards/types.tsx
+++ b/static/app/views/dashboards/types.tsx
@@ -132,6 +132,7 @@ export type DashboardPermissions = {
  */
 export type DashboardListItem = {
   environment: string[];
+  filters: DashboardFilters;
   id: string;
   projects: number[];
   title: string;

--- a/tests/js/fixtures/dashboard.ts
+++ b/tests/js/fixtures/dashboard.ts
@@ -30,6 +30,7 @@ export function DashboardListItemFixture(
     widgetPreview: [],
     projects: [],
     environment: [],
+    filters: {},
     ...params,
   };
 }


### PR DESCRIPTION
Adds the release filters under the "Filters" header. Since we don't store them as a query string, we construct a query string on the fly by concatenating the filtered releases. Ignore the spacing of the table columns for now, I'll tackle that separately.

<img width="476" height="623" alt="Screenshot 2025-07-21 at 11 46 37 AM" src="https://github.com/user-attachments/assets/b14ede24-973b-4593-bb76-e7c5236003d7" />
