### PR TITLE
fix: remove custom styles

### DIFF
--- a/static/app/views/organizationStats/teamInsights/controls.tsx
+++ b/static/app/views/organizationStats/teamInsights/controls.tsx
@@ -189,36 +189,6 @@ function TeamStatsControls({
           ]}
           value={currentEnvironment ?? ''}
           onChange={handleEnvironmentChange}
-          styles={{
-            input: (provided: any) => ({
-              ...provided,
-              display: 'grid',
-              gridTemplateColumns: 'max-content 1fr',
-              alignItems: 'center',
-              gridGap: space(1),
-              ':before': {
-                height: 24,
-                width: 90,
-                borderRadius: 3,
-                content: '""',
-                display: 'block',
-              },
-            }),
-            control: (base: any) => ({
-              ...base,
-              boxShadow: 'none',
-            }),
-            singleValue: (base: any) => ({
-              ...base,
-              fontSize: theme.fontSize.md,
-              display: 'flex',
-              ':before': {
-                ...base[':before'],
-                color: theme.textColor,
-                marginRight: space(1.5),
-              },
-            }),
-          }}
           inFieldLabel={t('Environment:')}
         />
       )}


### PR DESCRIPTION
this is just a normal single select, and the style overrides mess with UI2

| before | after |
|--------|--------|
| <img width="1238" height="374" alt="Screenshot 2025-07-21 at 18 25 44" src="https://github.com/user-attachments/assets/0012ff9f-f5e3-4471-a777-778b2ef12bc6" /> | <img width="1238" height="374" alt="Screenshot 2025-07-21 at 18 21 05" src="https://github.com/user-attachments/assets/852b1ed1-3867-4b09-a45f-c5587c314df1" /> | 