### PR TITLE
feat(user feedback): Update Default Replay Tab when Opening From User Feedback Details

### DIFF
--- a/static/app/components/events/eventReplay/replayClipPreview.tsx
+++ b/static/app/components/events/eventReplay/replayClipPreview.tsx
@@ -2,6 +2,7 @@ import {useMemo} from 'react';
 
 import ReplayClipPreviewPlayer from 'sentry/components/events/eventReplay/replayClipPreviewPlayer';
 import {Provider as ReplayContextProvider} from 'sentry/components/replays/replayContext';
+import {TabKey} from 'sentry/utils/replays/hooks/useActiveReplayTab';
 import useLoadReplayReader from 'sentry/utils/replays/hooks/useLoadReplayReader';
 
 interface ReplayClipPreviewProps
@@ -16,6 +17,7 @@ interface ReplayClipPreviewProps
   eventTimestampMs: number;
   orgSlug: string;
   replaySlug: string;
+  focusTab?: TabKey;
   overlayContent?: React.ReactNode;
 }
 
@@ -23,6 +25,7 @@ export default function ReplayClipPreview({
   analyticsContext,
   clipOffsets,
   eventTimestampMs,
+  focusTab,
   fullReplayButtonProps,
   orgSlug,
   replaySlug,
@@ -54,6 +57,8 @@ export default function ReplayClipPreview({
       <ReplayClipPreviewPlayer
         replayReaderResult={readerResult}
         analyticsContext={analyticsContext}
+        eventTimestampMs={eventTimestampMs}
+        focusTab={focusTab}
         overlayContent={overlayContent}
         fullReplayButtonProps={fullReplayButtonProps}
       />


### PR DESCRIPTION
Update the behaviour of the "See Full Replay" button from the User Feedback Details page

**Existing behaviour**
Opens the Replay Details page, on the Errors tab. This is often empty.

**New behaviour**
https://github.com/user-attachments/assets/cb0b874d-dabd-4f1f-83b3-3d9167a478f6

Opens the Replay Details page, on the Breadcrumbs tab, scrubbed to the User Feedback breadcrumb. 
Note that in my testing, the purple line indicating where you are in the replay video, is displayed after the last breadcrumb item belonging to the same timestamp of the User Feedback breadcrumb.

This PR should not impact the behaviour of other "See Full Replay" buttons.

Fixes REPLAY-541