### PR TITLE
core: initial text version

### DIFF
--- a/static/app/components/text.tsx
+++ b/static/app/components/text.tsx
@@ -4,6 +4,9 @@ import Panel from 'sentry/components/panels/panel';
 import {space} from 'sentry/styles/space';
 import textStyles from 'sentry/styles/text';
 
+/**
+ * @deprecated Use `Text` from `sentry/components/core/text` instead.
+ */
 const Text = styled('div')`
   ${textStyles};
 

--- a/static/app/styles/text.tsx
+++ b/static/app/styles/text.tsx
@@ -1,5 +1,8 @@
 import {css} from '@emotion/react';
 
+/**
+ * @deprecated Use `Text` from `sentry/components/core/text` instead.
+ */
 const textStyles = () => css`
   /* stylelint-disable no-descending-specificity */
   h1,


### PR DESCRIPTION
Deprecate `textStyles` and `components/text` in favor of core/text component.