### PR TITLE
fix(replay): Improve spacing/rendering of the bulk-delete replay log

### DIFF
--- a/static/app/components/replays/bulkDelete/replayBulkDeleteAuditLogTable.tsx
+++ b/static/app/components/replays/bulkDelete/replayBulkDeleteAuditLogTable.tsx
@@ -6,6 +6,7 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import type {ReplayBulkDeleteAuditLog} from 'sentry/components/replays/bulkDelete/types';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import {ERROR_MAP} from 'sentry/utils/requestError/requestError';
 
@@ -46,16 +47,27 @@ export default function ReplayBulkDeleteAuditLogTable({
               <DateTime date={row.dateCreated} />
             </SimpleTable.RowCell>
             <SimpleTable.RowCell>
-              <dl>
+              <Query>
                 <dt>Query</dt>
-                <dd>{row.query}</dd>
-                <dt>Range</dt>
                 <dd>
-                  <DateTime date={row.rangeStart} /> - <DateTime date={row.rangeEnd} />
+                  <code>{row.query}</code>
+                </dd>
+                <dt>Date Range</dt>
+                <dd>
+                  <code>
+                    <DateTime date={row.rangeStart} />
+                  </code>
+                  <br />
+
+                  <code>
+                    <DateTime date={row.rangeEnd} />
+                  </code>
                 </dd>
                 <dt>Environments</dt>
-                <dd>{row.environments.join(', ')}</dd>
-              </dl>
+                <dd>
+                  <code>{row.environments.join(', ')}</code>
+                </dd>
+              </Query>
             </SimpleTable.RowCell>
             <SimpleTable.RowCell>{row.countDeleted}</SimpleTable.RowCell>
             <SimpleTable.RowCell>{row.status}</SimpleTable.RowCell>
@@ -69,7 +81,7 @@ export default function ReplayBulkDeleteAuditLogTable({
 }
 
 const SimpleTableWithColumns = styled(SimpleTable)`
-  grid-template-columns: repeat(5, 1fr);
+  grid-template-columns: max-content max-content 1fr max-content max-content;
 `;
 
 function getErrorMessage(fetchError: RequestError) {
@@ -89,3 +101,9 @@ function getErrorMessage(fetchError: RequestError) {
     'This could be due to invalid search parameters or an internal systems error.'
   );
 }
+
+const Query = styled('dl')`
+  max-width: 100%;
+  overflow: scroll;
+  padding-bottom: ${space(1)};
+`;

--- a/static/app/components/replays/bulkDelete/replayBulkDeleteAuditLogTable.tsx
+++ b/static/app/components/replays/bulkDelete/replayBulkDeleteAuditLogTable.tsx
@@ -48,11 +48,11 @@ export default function ReplayBulkDeleteAuditLogTable({
             </SimpleTable.RowCell>
             <SimpleTable.RowCell>
               <Query>
-                <dt>Query</dt>
+                <dt>{t('Query')}</dt>
                 <dd>
                   <code>{row.query}</code>
                 </dd>
-                <dt>Date Range</dt>
+                <dt>{t('Date Range')}</dt>
                 <dd>
                   <code>
                     <DateTime date={row.rangeStart} />
@@ -63,7 +63,7 @@ export default function ReplayBulkDeleteAuditLogTable({
                     <DateTime date={row.rangeEnd} />
                   </code>
                 </dd>
-                <dt>Environments</dt>
+                <dt>{t('Environments')}</dt>
                 <dd>
                   <code>{row.environments.join(', ')}</code>
                 </dd>

--- a/static/app/components/replays/bulkDelete/replayBulkDeleteAuditLogTable.tsx
+++ b/static/app/components/replays/bulkDelete/replayBulkDeleteAuditLogTable.tsx
@@ -22,7 +22,7 @@ export default function ReplayBulkDeleteAuditLogTable({
   return (
     <SimpleTableWithColumns>
       <SimpleTable.Header>
-        <SimpleTable.HeaderCell>{t('id')}</SimpleTable.HeaderCell>
+        <SimpleTable.HeaderCell>{t('ID')}</SimpleTable.HeaderCell>
         <SimpleTable.HeaderCell>{t('Date Created')}</SimpleTable.HeaderCell>
         <SimpleTable.HeaderCell>{t('Query')}</SimpleTable.HeaderCell>
         <SimpleTable.HeaderCell>{t('Count Deleted')}</SimpleTable.HeaderCell>


### PR DESCRIPTION
We've adjusted column widths to better match the content. And made it possible to scroll when the query get long.

**Before**
<img width="921" height="395" alt="SCR-20250721-jsyv" src="https://github.com/user-attachments/assets/f98c3210-fd3b-4073-b69a-d56b52ceaea5" />



**After**
<img width="907" height="449" alt="SCR-20250721-jsin" src="https://github.com/user-attachments/assets/a0abfd20-017b-4750-9646-55bebb4d5556" />
