### PR TITLE
Fix create_event event_id None bug

### DIFF
--- a/src/sentry/eventstore/base.py
+++ b/src/sentry/eventstore/base.py
@@ -307,13 +307,13 @@ class EventStorage(Service):
     ) -> Event:
         """
         Returns an Event from processed data.
-        
+
         Args:
             project_id: The project ID for the event
             event_id: The event ID. If None, will be converted to an empty string.
             group_id: The group ID for the event
             data: The event data
-            
+
         Returns:
             Event: An Event object with a string event_id (never None)
         """

--- a/src/sentry/eventstore/base.py
+++ b/src/sentry/eventstore/base.py
@@ -306,7 +306,16 @@ class EventStorage(Service):
         data: Mapping[str, Any] | None = None,
     ) -> Event:
         """
-        Returns an Event from processed data
+        Returns an Event from processed data.
+        
+        Args:
+            project_id: The project ID for the event
+            event_id: The event ID. If None, will be converted to an empty string.
+            group_id: The group ID for the event
+            data: The event data
+            
+        Returns:
+            Event: An Event object with a string event_id (never None)
         """
         return Event(project_id=project_id, event_id=event_id or "", group_id=group_id, data=data)
 


### PR DESCRIPTION
<!-- Describe your PR here. -->
Clarifies the behavior of `event_id` in `create_event` method.

The `event_id` parameter was type-hinted as `str | None`, but its implementation converted `None` to an empty string (`""`). This PR updates the docstring to explicitly state that `None` values for `event_id` will be converted to an empty string, ensuring consistency between the type hint, documentation, and actual behavior. The `Event` object's `event_id` will always be a string.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-7823648b-3c15-4123-b578-7dd5786cfda0) · [Cursor](https://cursor.com/background-agent?bcId=bc-7823648b-3c15-4123-b578-7dd5786cfda0)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)