### PR TITLE
fix(replay): redirect feedback replay to breadcrumbs tab

### DIFF
--- a/static/app/components/events/eventReplay/replayPreviewPlayer.tsx
+++ b/static/app/components/events/eventReplay/replayPreviewPlayer.tsx
@@ -68,7 +68,7 @@ export default function ReplayPreviewPlayer({
   const startOffsetMs = replay?.getStartOffsetMs() ?? 0;
 
   const referrer = getRouteStringFromRoutes(routes);
-  const fromFeedback = referrer === '/feedback/';
+  const fromFeedback = referrer === '/issues/feedback/';
 
   const {groupId} = useParams<{groupId: string}>();
 


### PR DESCRIPTION
closes https://linear.app/getsentry/issue/REPLAY-541/change-default-tab-when-opening-full-replay-from-user-feedback-reports