### PR TITLE
:sparkles: feat(testing): make `with_features` work with classes

### DIFF
--- a/src/sentry/testutils/helpers/features.py
+++ b/src/sentry/testutils/helpers/features.py
@@ -1,6 +1,7 @@
 import logging
 from collections.abc import Generator, Iterable, Mapping, Sequence
 from contextlib import contextmanager
+from functools import wraps
 from unittest.mock import patch
 
 import pytest
@@ -187,13 +188,11 @@ def with_feature(names: str | Iterable[str] | dict[str, bool]):
                         if callable(original_method):
 
                             def create_wrapped_method(method):
+                                @wraps(method)
                                 def wrapped_method(*args, **kwargs):
                                     with Feature(feature_names):
                                         return method(*args, **kwargs)
 
-                                # Preserve method metadata
-                                wrapped_method.__name__ = method.__name__
-                                wrapped_method.__doc__ = method.__doc__
                                 return wrapped_method
 
                             wrapped = create_wrapped_method(original_method)
@@ -202,13 +201,11 @@ def with_feature(names: str | Iterable[str] | dict[str, bool]):
                 return func_or_cls
 
             # Decorating a function - wrap it with the feature context
+            @wraps(func_or_cls)
             def wrapper(*args, **kwargs):
                 with Feature(self.feature_names):
                     return func_or_cls(*args, **kwargs)
 
-            # Preserve function metadata
-            wrapper.__name__ = getattr(func_or_cls, "__name__", "wrapped_function")
-            wrapper.__doc__ = getattr(func_or_cls, "__doc__", None)
             return wrapper
 
     return FeatureContextManagerOrDecorator(names)

--- a/src/sentry/testutils/helpers/features.py
+++ b/src/sentry/testutils/helpers/features.py
@@ -175,8 +175,10 @@ class FeatureContextManagerOrDecorator:
             for attr_name in dir(func_or_cls):
                 if (
                     attr_name.startswith("test_")
-                    or attr_name.startswith("setup_")
-                    or attr_name.startswith("teardown_")
+                    or attr_name.startswith("setUp")
+                    or attr_name.startswith("tearDown")
+                    or attr_name.startswith("setUpClass")
+                    or attr_name.startswith("tearDownClass")
                 ):
                     original_method = getattr(func_or_cls, attr_name)
                     if callable(original_method):

--- a/src/sentry/testutils/helpers/features.py
+++ b/src/sentry/testutils/helpers/features.py
@@ -197,7 +197,7 @@ class FeatureContextManagerOrDecorator:
                                     return method(*args, **kwargs)
 
                             # Mark as wrapped by our feature decorator
-                            wrapped_method._feature_wrapped = True
+                            wrapped_method._feature_wrapped = True  # type: ignore[attr-defined]
                             return wrapped_method
 
                         wrapped = create_wrapped_method(attr)

--- a/tests/sentry/testutils/helpers/test_features.py
+++ b/tests/sentry/testutils/helpers/test_features.py
@@ -57,8 +57,6 @@ class TestTestUtilsFeatureHelper(TestCase):
 
             assert features.has("system:multi-region")
 
-            assert features.has("system:multi-region")
-
 
 class TestWithFeatureClassDecorator(TestCase):
     """Test that with_feature works correctly when used as a class decorator."""

--- a/tests/sentry/testutils/helpers/test_features.py
+++ b/tests/sentry/testutils/helpers/test_features.py
@@ -92,3 +92,160 @@ class TestWithFeatureClassDecorator(TestCase):
         test_instance.setUp()
         test_instance.test_method_1()
         test_instance.test_method_2()
+
+
+class TestNestedFeatureOverrides(TestCase):
+    """Test that nested with_feature contexts work correctly with proper precedence."""
+
+    def setUp(self) -> None:
+        self.org = self.create_organization()
+
+    def test_nested_context_managers_override(self):
+        """Test that nested context managers properly override outer contexts."""
+        # Initially disabled
+        assert not features.has("organizations:global-views", self.org)
+        assert not features.has("organizations:codecov-integration", self.org)
+
+        # Enable feature in outer context
+        with self.feature("organizations:global-views"):
+            assert features.has("organizations:global-views", self.org)
+
+            # Override to disable in inner context
+            with self.feature({"organizations:global-views": False}):
+                assert not features.has("organizations:global-views", self.org)
+
+                # Enable different feature in inner context
+                with self.feature("organizations:codecov-integration"):
+                    assert not features.has(
+                        "organizations:global-views", self.org
+                    )  # Still disabled
+                    assert features.has("organizations:codecov-integration", self.org)  # Enabled
+
+            # Back to outer context - should be enabled again
+            assert features.has("organizations:global-views", self.org)
+
+    def test_multiple_features_nested_contexts(self):
+        """Test multiple features being enabled/disabled in nested contexts."""
+        with self.feature(
+            {"organizations:global-views": True, "organizations:codecov-integration": False}
+        ):
+            assert features.has("organizations:global-views", self.org)
+            assert not features.has("organizations:codecov-integration", self.org)
+
+            # Override both in nested context
+            with self.feature(
+                {"organizations:global-views": False, "organizations:codecov-integration": True}
+            ):
+                assert not features.has("organizations:global-views", self.org)
+                assert features.has("organizations:codecov-integration", self.org)
+
+            # Back to original state
+            assert features.has("organizations:global-views", self.org)
+            assert not features.has("organizations:codecov-integration", self.org)
+
+    @with_feature("organizations:global-views")
+    def test_method_decorator_with_context_override(self):
+        """Test that context managers can override method-level decorators."""
+        # Method decorator enables the feature
+        assert features.has("organizations:global-views", self.org)
+
+        # Context manager overrides to disable
+        with self.feature({"organizations:global-views": False}):
+            assert not features.has("organizations:global-views", self.org)
+
+        # Back to method decorator state
+        assert features.has("organizations:global-views", self.org)
+
+    @with_feature({"organizations:global-views": True, "organizations:codecov-integration": False})
+    def test_method_decorator_multiple_features_with_context_override(self):
+        """Test context manager overriding specific features from method decorator."""
+        # Method decorator state
+        assert features.has("organizations:global-views", self.org)
+        assert not features.has("organizations:codecov-integration", self.org)
+
+        # Override only one feature in context
+        with self.feature({"organizations:codecov-integration": True}):
+            assert features.has("organizations:global-views", self.org)  # Still from decorator
+            assert features.has("organizations:codecov-integration", self.org)  # Overridden
+
+        # Back to decorator state
+        assert features.has("organizations:global-views", self.org)
+        assert not features.has("organizations:codecov-integration", self.org)
+
+
+@with_feature("organizations:global-views")
+class TestClassDecoratorWithNestedOverrides(TestCase):
+    """Test nested overrides when the class itself has a feature decorator."""
+
+    def setUp(self) -> None:
+        self.org = self.create_organization()
+
+    def test_class_decorator_baseline(self):
+        """Verify the class decorator is working."""
+        assert features.has("organizations:global-views", self.org)
+
+    def test_context_manager_override_class_decorator(self):
+        """Test that context managers can override class-level decorators."""
+        # Class decorator enables the feature
+        assert features.has("organizations:global-views", self.org)
+
+        # Context manager overrides to disable
+        with self.feature({"organizations:global-views": False}):
+            assert not features.has("organizations:global-views", self.org)
+
+            # Nested context enables it again
+            with self.feature("organizations:global-views"):
+                assert features.has("organizations:global-views", self.org)
+
+            # Back to first override
+            assert not features.has("organizations:global-views", self.org)
+
+        # Back to class decorator state
+        assert features.has("organizations:global-views", self.org)
+
+    @with_feature("organizations:codecov-integration")
+    def test_method_and_class_decorators_with_context_override(self):
+        """Test interaction of class decorator + method decorator + context manager."""
+        # Both class and method decorators should be active
+        assert features.has("organizations:global-views", self.org)  # From class
+        assert features.has("organizations:codecov-integration", self.org)  # From method
+
+        # Override both with context manager
+        with self.feature(
+            {"organizations:global-views": False, "organizations:codecov-integration": False}
+        ):
+            assert not features.has("organizations:global-views", self.org)
+            assert not features.has("organizations:codecov-integration", self.org)
+
+        # Back to decorator states
+        assert features.has("organizations:global-views", self.org)
+        assert features.has("organizations:codecov-integration", self.org)
+
+    def test_deeply_nested_context_managers(self):
+        """Test deeply nested context managers with alternating states."""
+        # Start with class decorator enabled
+        assert features.has("organizations:global-views", self.org)
+
+        with self.feature({"organizations:global-views": False}):  # Level 1: Disabled
+            assert not features.has("organizations:global-views", self.org)
+
+            with self.feature("organizations:global-views"):  # Level 2: Enabled
+                assert features.has("organizations:global-views", self.org)
+
+                with self.feature({"organizations:global-views": False}):  # Level 3: Disabled
+                    assert not features.has("organizations:global-views", self.org)
+
+                    with self.feature("organizations:global-views"):  # Level 4: Enabled
+                        assert features.has("organizations:global-views", self.org)
+
+                    # Back to level 3
+                    assert not features.has("organizations:global-views", self.org)
+
+                # Back to level 2
+                assert features.has("organizations:global-views", self.org)
+
+            # Back to level 1
+            assert not features.has("organizations:global-views", self.org)
+
+        # Back to class decorator
+        assert features.has("organizations:global-views", self.org)

--- a/tests/sentry/testutils/helpers/test_features.py
+++ b/tests/sentry/testutils/helpers/test_features.py
@@ -61,16 +61,16 @@ class TestTestUtilsFeatureHelper(TestCase):
 class TestWithFeatureClassDecorator(TestCase):
     """Test that with_feature works correctly when used as a class decorator."""
 
-    def test_with_feature_on_class_works(self):
+    def test_with_feature_on_class_works(self) -> None:
         """Test that using with_feature as a class decorator enables features for all methods."""
 
         @with_feature("organizations:global-views")
         class TestClassWithFeature(TestCase):
-            def test_method_1(self):
+            def test_method_1(self) -> None:
                 org = self.create_organization()
                 assert features.has("organizations:global-views", org)
 
-            def test_method_2(self):
+            def test_method_2(self) -> None:
                 org = self.create_organization()
                 assert features.has("organizations:global-views", org)
 
@@ -98,7 +98,7 @@ class TestNestedFeatureOverrides(TestCase):
     def setUp(self) -> None:
         self.org = self.create_organization()
 
-    def test_nested_context_managers_override(self):
+    def test_nested_context_managers_override(self) -> None:
         """Test that nested context managers properly override outer contexts."""
         # Initially disabled
         assert not features.has("organizations:global-views", self.org)
@@ -122,7 +122,7 @@ class TestNestedFeatureOverrides(TestCase):
             # Back to outer context - should be enabled again
             assert features.has("organizations:global-views", self.org)
 
-    def test_multiple_features_nested_contexts(self):
+    def test_multiple_features_nested_contexts(self) -> None:
         """Test multiple features being enabled/disabled in nested contexts."""
         with self.feature(
             {"organizations:global-views": True, "organizations:codecov-integration": False}
@@ -142,7 +142,7 @@ class TestNestedFeatureOverrides(TestCase):
             assert not features.has("organizations:codecov-integration", self.org)
 
     @with_feature("organizations:global-views")
-    def test_method_decorator_with_context_override(self):
+    def test_method_decorator_with_context_override(self) -> None:
         """Test that context managers can override method-level decorators."""
         # Method decorator enables the feature
         assert features.has("organizations:global-views", self.org)
@@ -155,7 +155,7 @@ class TestNestedFeatureOverrides(TestCase):
         assert features.has("organizations:global-views", self.org)
 
     @with_feature({"organizations:global-views": True, "organizations:codecov-integration": False})
-    def test_method_decorator_multiple_features_with_context_override(self):
+    def test_method_decorator_multiple_features_with_context_override(self) -> None:
         """Test context manager overriding specific features from method decorator."""
         # Method decorator state
         assert features.has("organizations:global-views", self.org)
@@ -178,11 +178,11 @@ class TestClassDecoratorWithNestedOverrides(TestCase):
     def setUp(self) -> None:
         self.org = self.create_organization()
 
-    def test_class_decorator_baseline(self):
+    def test_class_decorator_baseline(self) -> None:
         """Verify the class decorator is working."""
         assert features.has("organizations:global-views", self.org)
 
-    def test_context_manager_override_class_decorator(self):
+    def test_context_manager_override_class_decorator(self) -> None:
         """Test that context managers can override class-level decorators."""
         # Class decorator enables the feature
         assert features.has("organizations:global-views", self.org)
@@ -202,7 +202,7 @@ class TestClassDecoratorWithNestedOverrides(TestCase):
         assert features.has("organizations:global-views", self.org)
 
     @with_feature("organizations:codecov-integration")
-    def test_method_and_class_decorators_with_context_override(self):
+    def test_method_and_class_decorators_with_context_override(self) -> None:
         """Test interaction of class decorator + method decorator + context manager."""
         # Both class and method decorators should be active
         assert features.has("organizations:global-views", self.org)  # From class
@@ -219,7 +219,7 @@ class TestClassDecoratorWithNestedOverrides(TestCase):
         assert features.has("organizations:global-views", self.org)
         assert features.has("organizations:codecov-integration", self.org)
 
-    def test_deeply_nested_context_managers(self):
+    def test_deeply_nested_context_managers(self) -> None:
         """Test deeply nested context managers with alternating states."""
         # Start with class decorator enabled
         assert features.has("organizations:global-views", self.org)

--- a/tests/sentry/testutils/helpers/test_features.py
+++ b/tests/sentry/testutils/helpers/test_features.py
@@ -1,5 +1,7 @@
 from unittest import mock
 
+import pytest
+
 from sentry import features
 from sentry.organizations.services.organization import RpcOrganization, organization_service
 from sentry.testutils.cases import TestCase
@@ -56,3 +58,24 @@ class TestTestUtilsFeatureHelper(TestCase):
             assert isinstance(org_context.organization, RpcOrganization)
 
             assert features.has("system:multi-region")
+
+            assert features.has("system:multi-region")
+
+
+class TestWithFeatureClassDecoratorError(TestCase):
+    """Test that with_feature raises an error when used as a class decorator."""
+
+    def test_with_feature_on_class_raises_error(self):
+        """Test that using with_feature as a class decorator raises ValueError."""
+
+        with pytest.raises(ValueError) as exc_info:
+
+            @with_feature("organizations:test-feature")
+            class TestClass:
+                pass
+
+        error_message = str(exc_info.value)
+        assert "with_feature cannot be used as a class decorator" in error_message
+        assert "Use apply_feature_flag_on_cls instead" in error_message
+        assert "organizations:test-feature" in error_message
+        assert "TestClass" in error_message


### PR DESCRIPTION
## Prevent `@with_feature` misuse as class decorator

### Problem
I often mistakenly use @with_feature as a class decorator, which silently fail ( _doesn't_ run tests) to enable features for test methods. This leads to confusing test failures and wasted debugging time.

with @JoshFerge's suggestion, I made it so that `with_feature` can now be used on classes as well.

In a follow-up PR, can remove the usage of `apply_feature_to_cls` so we only have 1 decorator after this.