### PR TITLE
ref(alerts): Refactor escalating issue alerts to use `has_escalated`

### DIFF
--- a/src/sentry/rules/conditions/existing_high_priority_issue.py
+++ b/src/sentry/rules/conditions/existing_high_priority_issue.py
@@ -18,8 +18,7 @@ class ExistingHighPriorityIssueCondition(EventCondition):
         if state.is_new:
             return False
 
-        is_escalating = state.has_reappeared or state.has_escalated
-        return is_escalating and event.group.priority == PriorityLevel.HIGH
+        return state.has_escalated and event.group.priority == PriorityLevel.HIGH
 
     def get_activity(
         self, start: datetime, end: datetime, limit: int

--- a/src/sentry/rules/conditions/reappeared_event.py
+++ b/src/sentry/rules/conditions/reappeared_event.py
@@ -11,22 +11,21 @@ from sentry.types.condition_activity import ConditionActivity, ConditionActivity
 
 class ReappearedEventCondition(EventCondition):
     id = "sentry.rules.conditions.reappeared_event.ReappearedEventCondition"
-    label = "The issue changes state from ignored to unresolved"
+    label = "The issue changes state from archived to escalating"
 
     def passes(self, event: GroupEvent, state: EventState) -> bool:
-        return state.has_reappeared
+        return state.has_escalated
 
     def get_activity(
         self, start: datetime, end: datetime, limit: int
     ) -> Sequence[ConditionActivity]:
-        # reappearances are recorded as SET_UNRESOLVED with no user
+        # escalations are recorded as SET_ESCALATING
         activities = (
             Activity.objects.filter(
                 project=self.project,
                 datetime__gte=start,
                 datetime__lt=end,
-                type=ActivityType.SET_UNRESOLVED.value,
-                user_id=None,
+                type=ActivityType.SET_ESCALATING.value,
             )
             .order_by("-datetime")[:limit]
             .values_list("group", "datetime", "data")

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -833,8 +833,7 @@ def process_snoozes(job: PostProcessJob) -> None:
             manage_issue_states(
                 group, GroupInboxReason.ESCALATING, event, activity_data={"forecast": forecast}
             )
-
-            job["has_reappeared"] = True
+            job["has_escalated"] = True
         return
 
     with metrics.timer("post_process.process_snoozes.duration"):

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -624,7 +624,7 @@ def post_process_group(
                     "is_reprocessed": is_reprocessed,
                     "has_reappeared": bool(not group_state["is_new"]),
                     "has_alert": False,
-                    "has_escalated": False,
+                    "has_escalated": kwargs.get("has_escalated", False),
                 }
             )
             metric_tags["occurrence_type"] = group_event.group.issue_type.slug
@@ -794,7 +794,8 @@ def process_inbox_adds(job: PostProcessJob) -> None:
 
 def process_snoozes(job: PostProcessJob) -> None:
     """
-    Set has_reappeared to True if the group is transitioning from "resolved" to "unresolved",
+    Set has_reappeared to True if the group is transitioning from "resolved" to "unresolved" and
+    set has_escalated to True if the group is transitioning from "archived until escalating" to "unresolved"
     otherwise set to False.
     """
     # we process snoozes before rules as it might create a regression

--- a/src/sentry/workflow_engine/handlers/condition/existing_high_priority_issue_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/existing_high_priority_issue_handler.py
@@ -17,5 +17,4 @@ class ExistingHighPriorityIssueConditionHandler(DataConditionHandler[WorkflowEve
         if state is None or state["is_new"]:
             return False
 
-        is_escalating = bool(event_data.has_reappeared or event_data.has_escalated)
-        return is_escalating and event_data.group.priority == PriorityLevel.HIGH
+        return event_data.has_escalated and event_data.group.priority == PriorityLevel.HIGH

--- a/src/sentry/workflow_engine/handlers/condition/existing_high_priority_issue_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/existing_high_priority_issue_handler.py
@@ -17,4 +17,4 @@ class ExistingHighPriorityIssueConditionHandler(DataConditionHandler[WorkflowEve
         if state is None or state["is_new"]:
             return False
 
-        return event_data.has_escalated and event_data.group.priority == PriorityLevel.HIGH
+        return bool(event_data.has_escalated) and event_data.group.priority == PriorityLevel.HIGH

--- a/src/sentry/workflow_engine/handlers/condition/reappeared_event_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/reappeared_event_handler.py
@@ -12,8 +12,8 @@ class ReappearedEventConditionHandler(DataConditionHandler[WorkflowEventData]):
 
     @staticmethod
     def evaluate_value(event_data: WorkflowEventData, comparison: Any) -> bool:
-        has_reappeared = event_data.has_reappeared
-        if has_reappeared is None:
+        has_escalated = event_data.has_escalated
+        if has_escalated is None:
             return False
 
-        return has_reappeared == comparison
+        return has_escalated == comparison

--- a/src/sentry/workflow_engine/migration_helpers/issue_alert_conditions.py
+++ b/src/sentry/workflow_engine/migration_helpers/issue_alert_conditions.py
@@ -29,7 +29,7 @@ def create_every_event_data_condition(
     )
 
 
-def create_reappeared_event_data_condition(
+def create_escalating_event_data_condition(
     data: dict[str, Any], dcg: DataConditionGroup
 ) -> DataConditionKwargs:
     return DataConditionKwargs(
@@ -360,7 +360,7 @@ data_condition_translator_mapping: dict[
     str, Callable[[dict[str, Any], Any], DataConditionKwargs]
 ] = {
     "sentry.rules.conditions.every_event.EveryEventCondition": create_every_event_data_condition,
-    "sentry.rules.conditions.reappeared_event.ReappearedEventCondition": create_reappeared_event_data_condition,
+    "sentry.rules.conditions.reappeared_event.ReappearedEventCondition": create_escalating_event_data_condition,
     "sentry.rules.conditions.regression_event.RegressionEventCondition": create_regression_event_data_condition,
     "sentry.rules.conditions.high_priority_issue.ExistingHighPriorityIssueCondition": create_existing_high_priority_issue_data_condition,
     "sentry.rules.conditions.event_attribute.EventAttributeCondition": create_event_attribute_data_condition,

--- a/src/sentry/workflow_engine/migration_helpers/rule_conditions.py
+++ b/src/sentry/workflow_engine/migration_helpers/rule_conditions.py
@@ -6,7 +6,7 @@ from sentry.workflow_engine.models.data_condition import Condition, DataConditio
 ConditionAndFilters = tuple[dict[str, Any], list[dict[str, Any]]]
 
 
-def create_reappeared_event_condition(
+def create_escalating_event_condition(
     data_condition: DataCondition,
     is_filter: bool = False,
 ) -> ConditionAndFilters:
@@ -266,7 +266,7 @@ def create_event_unique_user_frequency_condition(
 
 
 data_condition_to_rule_condition_mapping = {
-    Condition.REAPPEARED_EVENT: create_reappeared_event_condition,
+    Condition.REAPPEARED_EVENT: create_escalating_event_condition,
     Condition.REGRESSION_EVENT: create_regression_event_condition,
     Condition.EXISTING_HIGH_PRIORITY_ISSUE: create_existing_high_priority_issue_condition,
     Condition.NEW_HIGH_PRIORITY_ISSUE: create_new_high_priority_issue_condition,

--- a/tests/sentry/rules/conditions/test_existing_high_priority_issue.py
+++ b/tests/sentry/rules/conditions/test_existing_high_priority_issue.py
@@ -18,11 +18,11 @@ class ExistingHighPriorityIssueConditionTest(RuleTestCase):
 
         # This will never pass for non-new or non-escalating issuesalways pass
         self.event.group.update(priority=PriorityLevel.HIGH)
-        self.assertPasses(rule, is_new=False, has_reappeared=True, has_escalated=False)
+        self.assertPasses(rule, is_new=False, has_reappeared=True, has_escalated=True)
         self.assertPasses(rule, is_new=False, has_reappeared=False, has_escalated=True)
 
         # This will never pass
-        self.assertDoesNotPass(rule, is_new=True, has_reappeared=False, has_escalated=True)
+        self.assertDoesNotPass(rule, is_new=True, has_reappeared=False, has_escalated=False)
         self.assertDoesNotPass(rule, is_new=True, has_reappeared=True, has_escalated=False)
 
         self.event.group.update(priority=PriorityLevel.LOW)

--- a/tests/sentry/rules/conditions/test_reappeared_event.py
+++ b/tests/sentry/rules/conditions/test_reappeared_event.py
@@ -11,6 +11,6 @@ class ReappearedEventConditionTest(RuleTestCase):
     def test_applies_correctly(self):
         rule = self.get_rule()
 
-        self.assertPasses(rule, self.event, has_reappeared=True)
+        self.assertPasses(rule, self.event, has_escalated=True)
 
-        self.assertDoesNotPass(rule, self.event, has_reappeared=False)
+        self.assertDoesNotPass(rule, self.event, has_escalated=False)

--- a/tests/sentry/rules/history/test_preview.py
+++ b/tests/sentry/rules/history/test_preview.py
@@ -98,7 +98,7 @@ class ProjectRulePreviewTest(TestCase, SnubaTestCase, PerformanceIssueTestCase):
             hours,
         )
 
-    def test_reappeared(self):
+    def test_escalating(self):
         hours = self._set_up_activity(ActivityType.SET_UNRESOLVED)
         self._test_preview(
             "sentry.rules.conditions.reappeared_event.ReappearedEventCondition",
@@ -399,6 +399,8 @@ class ProjectRulePreviewTest(TestCase, SnubaTestCase, PerformanceIssueTestCase):
         assert len(result) == hours
 
     def test_multiple_projects(self):
+        from sentry.types.group import GroupSubStatus
+
         other_project = Project.objects.create(organization=self.organization)
         prev_hour = timezone.now() - timedelta(hours=1)
         groups = []
@@ -406,6 +408,7 @@ class ProjectRulePreviewTest(TestCase, SnubaTestCase, PerformanceIssueTestCase):
             first_seen = Group.objects.create(project=project, first_seen=prev_hour)
             regression = Group.objects.create(project=project)
             reappearance = Group.objects.create(project=project)
+            reappearance.update(substatus=GroupSubStatus.ESCALATING)
             groups.append((first_seen, regression, reappearance))
             Activity.objects.create(
                 project=project,
@@ -416,7 +419,7 @@ class ProjectRulePreviewTest(TestCase, SnubaTestCase, PerformanceIssueTestCase):
             Activity.objects.create(
                 project=project,
                 group=reappearance,
-                type=ActivityType.SET_UNRESOLVED.value,
+                type=ActivityType.SET_ESCALATING.value,
                 user_id=None,
                 datetime=prev_hour,
             )

--- a/tests/sentry/rules/history/test_preview.py
+++ b/tests/sentry/rules/history/test_preview.py
@@ -99,7 +99,7 @@ class ProjectRulePreviewTest(TestCase, SnubaTestCase, PerformanceIssueTestCase):
         )
 
     def test_escalating(self):
-        hours = self._set_up_activity(ActivityType.SET_UNRESOLVED)
+        hours = self._set_up_activity(ActivityType.SET_ESCALATING)
         self._test_preview(
             "sentry.rules.conditions.reappeared_event.ReappearedEventCondition",
             hours,

--- a/tests/sentry/workflow_engine/handlers/condition/test_existing_high_priority_issue_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_existing_high_priority_issue_handler.py
@@ -77,10 +77,13 @@ class TestExistingHighPriorityIssueCondition(ConditionTestCase):
         self.event_data = replace(self.event_data, has_reappeared=False, has_escalated=True)
         self.assert_passes(self.dc, self.event_data)
 
-        self.event_data = replace(self.event_data, has_reappeared=True, has_escalated=False)
+        self.event_data = replace(self.event_data, has_reappeared=True, has_escalated=True)
         self.assert_passes(self.dc, self.event_data)
 
         self.event_data = replace(self.event_data, has_reappeared=False, has_escalated=False)
+        self.assert_does_not_pass(self.dc, self.event_data)
+
+        self.event_data = replace(self.event_data, has_reappeared=True, has_escalated=False)
         self.assert_does_not_pass(self.dc, self.event_data)
 
     def test_priority(self):

--- a/tests/sentry/workflow_engine/handlers/condition/test_reappeared_event_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_reappeared_event_handler.py
@@ -42,7 +42,10 @@ class TestReappearedEventCondition(ConditionTestCase):
 
     def test(self):
         job = WorkflowEventData(
-            event=self.group_event, group=self.group_event.group, has_reappeared=True
+            event=self.group_event,
+            group=self.group_event.group,
+            has_reappeared=False,
+            has_escalated=True,
         )
         dc = self.create_data_condition(
             type=self.condition,
@@ -52,5 +55,5 @@ class TestReappearedEventCondition(ConditionTestCase):
 
         self.assert_passes(dc, job)
 
-        job = replace(job, has_reappeared=False)
+        job = replace(job, has_escalated=False)
         self.assert_does_not_pass(dc, job)

--- a/tests/sentry/workflow_engine/migration_helpers/test_rule_conditions.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_rule_conditions.py
@@ -25,7 +25,7 @@ class RuleConditionTranslationTest(ConditionTestCase):
         assert condition == {}
         assert filters == [payload]
 
-    def test_reappeared_event(self):
+    def test_escalating_event(self):
         payload = {"id": "sentry.rules.conditions.reappeared_event.ReappearedEventCondition"}
         self.assert_basic_condition_translated(payload)
 

--- a/tests/sentry/workflow_engine/test_integration.py
+++ b/tests/sentry/workflow_engine/test_integration.py
@@ -306,6 +306,7 @@ class TestWorkflowEngineIntegrationFromErrorPostProcess(BaseWorkflowIntegrationT
             )
 
             # Verify the group is in the correct state
+            assert high_priority_event_2.group is not None
             assert high_priority_event_2.group.status == GroupStatus.IGNORED
             assert high_priority_event_2.group.substatus == GroupSubStatus.UNTIL_ESCALATING
 

--- a/tests/sentry/workflow_engine/test_integration.py
+++ b/tests/sentry/workflow_engine/test_integration.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta
 from unittest import mock
+from unittest.mock import patch
 
 import pytest
 from django.utils import timezone
@@ -11,7 +12,6 @@ from sentry.eventstream.types import EventStreamEventType
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.incidents.grouptype import MetricIssue
 from sentry.incidents.utils.types import DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION
-from sentry.issues.ignored import handle_ignored
 from sentry.issues.ingest import save_issue_occurrence
 from sentry.models.group import Group
 from sentry.rules.match import MatchType
@@ -236,6 +236,7 @@ class TestWorkflowEngineIntegrationFromErrorPostProcess(BaseWorkflowIntegrationT
         fingerprint=None,
         level="error",
         tags: list[list[str]] | None = None,
+        group=None,
     ) -> Event:
         if project is None:
             project = self.project
@@ -251,6 +252,9 @@ class TestWorkflowEngineIntegrationFromErrorPostProcess(BaseWorkflowIntegrationT
             level=level,
             tags=tags,
         )
+        if group:
+            event.group = group
+            event.group_id = group.id
         event_processing_store.store({**event.data, "project": project.id})
         return event
 
@@ -268,6 +272,9 @@ class TestWorkflowEngineIntegrationFromErrorPostProcess(BaseWorkflowIntegrationT
 
     @with_feature("organizations:workflow-engine-issue-alert-dual-write")
     def test_default_workflow(self, mock_trigger):
+        from sentry.models.group import GroupStatus
+        from sentry.types.group import GroupSubStatus
+
         project = self.create_project(fire_project_created=True)
         project.flags.has_high_priority_alerts = True
         project.save()
@@ -280,18 +287,35 @@ class TestWorkflowEngineIntegrationFromErrorPostProcess(BaseWorkflowIntegrationT
         self.post_process_error(high_priority_event, is_new=True)
         mock_trigger.assert_called_once()
 
-        # fires for existing high priority issue (has_reappeared or is_escalating)
+        # fires for existing high priority issue (is_escalating)
+        now = timezone.now()
         mock_trigger.reset_mock()
-        high_priority_event_2 = self.create_error_event(project=project, detector=detector)
-        # ignore the issue to get has_reappeared
-        assert high_priority_event_2.group
-        handle_ignored(
-            group_list=[high_priority_event_2.group],
-            status_details={"ignoreDuration": -1},
-            acting_user=self.user,
-        )
-        self.post_process_error(high_priority_event_2)
-        mock_trigger.assert_called_once()
+
+        with freeze_time(now + timedelta(days=8)):
+            # Create a group that's already in the IGNORED state with substatus UNTIL_ESCALATING
+            ignored_group = self.create_group(
+                project=project,
+                status=GroupStatus.IGNORED,
+                substatus=GroupSubStatus.UNTIL_ESCALATING,
+                first_seen=now - timedelta(days=10),
+            )
+
+            # Create an event that uses this group
+            high_priority_event_2 = self.create_error_event(
+                project=project, detector=detector, group=ignored_group
+            )
+
+            # Verify the group is in the correct state
+            assert high_priority_event_2.group.status == GroupStatus.IGNORED
+            assert high_priority_event_2.group.substatus == GroupSubStatus.UNTIL_ESCALATING
+
+            with patch(
+                "sentry.issues.escalating.escalating.is_escalating", return_value=(True, 1)
+            ) as mock_is_escalating:
+                self.post_process_error(high_priority_event_2)
+                mock_is_escalating.assert_called_once()
+
+            mock_trigger.assert_called_once()
 
         # does not fire for low priority issue
         mock_trigger.reset_mock()


### PR DESCRIPTION
Historically, escalating issue alerts were build using `has_reappeared` which was an existing condition intended to alert users on an issue changing from ignored -> unresolved. We no longer support alerts for that state change, and the `has_reappeared` field has been used for escalating issues instead. 

This PR changes the ReappearedEventCondition to use `has_escalated` instead, which helps with readability and cleanliness here. I believe we should be able to remove the `has_reappeared` field in a followup since it won't be used anywhere. I'm opting to not rename the alert condition to avoid having to run a migration and change the alert label in our db, so the underlying condition name remains unchanged.