### PR TITLE
chore(aci): format anomaly detection issue aggregate str

### DIFF
--- a/src/sentry/incidents/grouptype.py
+++ b/src/sentry/incidents/grouptype.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
+from enum import StrEnum
 
+from sentry import features
 from sentry.constants import CRASH_RATE_ALERT_AGGREGATE_ALIAS
 from sentry.incidents.handlers.condition import *  # noqa
 from sentry.incidents.metric_issue_detector import MetricIssueDetectorValidator
@@ -10,11 +13,13 @@ from sentry.incidents.utils.format_duration import format_duration_idiomatic
 from sentry.incidents.utils.types import AnomalyDetectionUpdate, ProcessedSubscriptionUpdate
 from sentry.integrations.metric_alerts import TEXT_COMPARISON_DELTA
 from sentry.issues.grouptype import GroupCategory, GroupType
+from sentry.models.organization import Organization
 from sentry.ratelimits.sliding_windows import Quota
 from sentry.snuba.metrics import format_mri_field, is_mri_field
 from sentry.snuba.models import QuerySubscription, SnubaQuery
 from sentry.types.actor import parse_and_validate_actor
 from sentry.types.group import PriorityLevel
+from sentry.utils.snuba import Dataset
 from sentry.workflow_engine.handlers.detector import DetectorOccurrence, StatefulDetectorHandler
 from sentry.workflow_engine.handlers.detector.base import EventData, EvidenceData
 from sentry.workflow_engine.models.alertrule_detector import AlertRuleDetector
@@ -22,6 +27,8 @@ from sentry.workflow_engine.models.data_condition import Condition, DataConditio
 from sentry.workflow_engine.models.data_source import DataPacket
 from sentry.workflow_engine.processors.data_condition_group import ProcessedDataConditionGroup
 from sentry.workflow_engine.types import DetectorException, DetectorPriorityLevel, DetectorSettings
+
+logger = logging.getLogger(__name__)
 
 COMPARISON_DELTA_CHOICES: list[None | int] = [choice.value for choice in ComparisonDeltaChoices]
 COMPARISON_DELTA_CHOICES.append(None)
@@ -43,6 +50,79 @@ class MetricIssueEvidenceData(EvidenceData[float]):
 
 MetricUpdate = ProcessedSubscriptionUpdate | AnomalyDetectionUpdate
 MetricResult = int | dict
+
+
+class SessionsAggregate(StrEnum):
+    CRASH_FREE_SESSIONS = "percentage(sessions_crashed, sessions) AS _crash_rate_alert_aggregate"
+    CRASH_FREE_USERS = "percentage(users_crashed, users) AS _crash_rate_alert_aggregate"
+
+
+ALERT_TYPE_IDENTIFIERS: dict[Dataset, dict[str, str]] = {
+    Dataset.Events: {"num_errors": "count()", "users_experiencing_errors": "count_unique(user)"},
+    Dataset.Transactions: {
+        "throughput": "count()",
+        "trans_duration": "transaction.duration",
+        "apdex": "apdex",
+        "failure_rate": "failure_rate()",
+        "lcp": "measurements.lcp",
+        "fid": "measurements.fid",
+        "cls": "measurements.cls",
+    },
+    Dataset.PerformanceMetrics: {
+        "throughput": "count()",
+        "trans_duration": "transaction.duration",
+        "apdex": "apdex",
+        "failure_rate": "failure_rate()",
+        "lcp": "measurements.lcp",
+        "fid": "measurements.fid",
+        "cls": "measurements.cls",
+    },
+    Dataset.Sessions: {
+        "crash_free_sessions": SessionsAggregate.CRASH_FREE_SESSIONS.value,
+        "crash_free_users": SessionsAggregate.CRASH_FREE_USERS.value,
+    },
+    Dataset.Metrics: {
+        "crash_free_sessions": SessionsAggregate.CRASH_FREE_SESSIONS.value,
+        "crash_free_users": SessionsAggregate.CRASH_FREE_USERS.value,
+    },
+    Dataset.EventsAnalyticsPlatform: {
+        "trace_item_throughput": "count(span.duration)",
+        "trace_item_duration": "span.duration",
+        "trace_item_apdex": "apdex",
+        "trace_item_failure_rate": "failure_rate()",
+        "trace_item_lcp": "measurements.lcp",
+    },
+}
+
+
+def get_alert_type_from_aggregate_dataset(
+    aggregate: str, dataset: Dataset, organization: Organization | None = None
+) -> str:
+    """
+    Given an aggregate and dataset object, will return the corresponding wizard alert type
+    e.g. {'aggregate': 'count()', 'dataset': Dataset.ERRORS} will yield 'num_errors'
+
+    This function is used to format the aggregate value for anomaly detection issues.
+    """
+    identifier_for_dataset = ALERT_TYPE_IDENTIFIERS.get(dataset, {})
+
+    # Find matching alert type entry
+    matching_alert_type: None | str = None
+    for alert_type, identifier in identifier_for_dataset.items():
+        if identifier in aggregate:
+            matching_alert_type = alert_type
+            break
+
+    # Special handling for EventsAnalyticsPlatform dataset
+    if dataset == Dataset.EventsAnalyticsPlatform:
+        if organization and features.has(
+            "organizations:performance-transaction-deprecation-alerts", organization
+        ):
+            return matching_alert_type if matching_alert_type else "eap_metrics"
+
+        return "eap_metrics"
+
+    return matching_alert_type if matching_alert_type else "custom_transactions"
 
 
 class MetricIssueDetectorHandler(StatefulDetectorHandler[MetricUpdate, MetricResult]):
@@ -137,6 +217,21 @@ class MetricIssueDetectorHandler(StatefulDetectorHandler[MetricUpdate, MetricRes
 
         if detection_type == "dynamic":
             alert_type = aggregate
+            try:
+                dataset = Dataset(snuba_query.dataset)
+                alert_type = get_alert_type_from_aggregate_dataset(
+                    aggregate, dataset, self.detector.project.organization
+                )
+            except ValueError:
+                logger.exception(
+                    "Failed to get alert type from aggregate and dataset",
+                    extra={
+                        "aggregate": aggregate,
+                        "dataset": snuba_query.dataset,
+                        "detector_id": self.detector.id,
+                    },
+                )
+
             return f"Detected an anomaly in the query for {alert_type}"
 
         # Determine the higher or lower comparison

--- a/src/sentry/incidents/grouptype.py
+++ b/src/sentry/incidents/grouptype.py
@@ -258,7 +258,7 @@ class MetricIssueDetectorHandler(StatefulDetectorHandler[MetricUpdate, MetricRes
             try:
                 dataset = Dataset(snuba_query.dataset)
                 alert_type = get_alert_type_from_aggregate_dataset(
-                    aggregate, dataset, self.detector.project.organization
+                    agg_display_key, dataset, self.detector.project.organization
                 )
             except ValueError:
                 logger.exception(

--- a/src/sentry/incidents/grouptype.py
+++ b/src/sentry/incidents/grouptype.py
@@ -15,11 +15,11 @@ from sentry.integrations.metric_alerts import TEXT_COMPARISON_DELTA
 from sentry.issues.grouptype import GroupCategory, GroupType
 from sentry.models.organization import Organization
 from sentry.ratelimits.sliding_windows import Quota
+from sentry.snuba.dataset import Dataset
 from sentry.snuba.metrics import format_mri_field, is_mri_field
 from sentry.snuba.models import QuerySubscription, SnubaQuery
 from sentry.types.actor import parse_and_validate_actor
 from sentry.types.group import PriorityLevel
-from sentry.utils.snuba import Dataset
 from sentry.workflow_engine.handlers.detector import DetectorOccurrence, StatefulDetectorHandler
 from sentry.workflow_engine.handlers.detector.base import EventData, EvidenceData
 from sentry.workflow_engine.models.alertrule_detector import AlertRuleDetector

--- a/src/sentry/incidents/grouptype.py
+++ b/src/sentry/incidents/grouptype.py
@@ -145,7 +145,7 @@ def get_alert_type_from_aggregate_dataset(
     identifier_for_dataset = ALERT_TYPE_IDENTIFIERS.get(dataset, {})
 
     # Find matching alert type entry
-    matching_alert_type: MetricAlertType = "custom_transactions"
+    matching_alert_type: MetricAlertType | None = None
     for alert_type, identifier in identifier_for_dataset.items():
         if identifier in aggregate:
             matching_alert_type = alert_type
@@ -160,7 +160,7 @@ def get_alert_type_from_aggregate_dataset(
 
         return "eap_metrics"
 
-    return matching_alert_type
+    return matching_alert_type if matching_alert_type else "custom_transactions"
 
 
 class MetricIssueDetectorHandler(StatefulDetectorHandler[MetricUpdate, MetricResult]):

--- a/tests/sentry/incidents/test_metric_issue_detector_handler.py
+++ b/tests/sentry/incidents/test_metric_issue_detector_handler.py
@@ -4,9 +4,9 @@ from sentry.incidents.grouptype import (
     get_alert_type_from_aggregate_dataset,
 )
 from sentry.issues.issue_occurrence import IssueOccurrence
+from sentry.snuba.dataset import Dataset
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import freeze_time
-from sentry.utils.snuba import Dataset
 from sentry.workflow_engine.models import DataCondition
 from sentry.workflow_engine.models.data_condition import Condition
 from tests.sentry.incidents.utils.test_metric_issue_base import BaseMetricIssueTest

--- a/tests/sentry/incidents/test_metric_issue_detector_handler.py
+++ b/tests/sentry/incidents/test_metric_issue_detector_handler.py
@@ -1,6 +1,12 @@
-from sentry.incidents.grouptype import MetricIssueDetectorHandler
+from sentry.incidents.grouptype import (
+    MetricIssueDetectorHandler,
+    SessionsAggregate,
+    get_alert_type_from_aggregate_dataset,
+)
 from sentry.issues.issue_occurrence import IssueOccurrence
+from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import freeze_time
+from sentry.utils.snuba import Dataset
 from sentry.workflow_engine.models import DataCondition
 from sentry.workflow_engine.models.data_condition import Condition
 from tests.sentry.incidents.utils.test_metric_issue_base import BaseMetricIssueTest
@@ -178,4 +184,127 @@ class TestConstructTitle(TestEvaluateMetricDetector):
         assert (
             title
             == f"Critical: Crash free session rate in the last minute above {self.critical_detector_trigger.comparison}"
+        )
+
+    def test_dynamic_alert_title(self):
+        self.detector.config.update({"detection_type": "dynamic"})
+        self.snuba_query.aggregate = "count_unique(user)"
+        title = self.handler.construct_title(
+            snuba_query=self.snuba_query,
+            detector_trigger=self.critical_detector_trigger,
+            priority=self.critical_detector_trigger.condition_result,
+        )
+        assert title == "Detected an anomaly in the query for users_experiencing_errors"
+
+        self.snuba_query.aggregate = "p95(transaction.duration)"
+        title = self.handler.construct_title(
+            snuba_query=self.snuba_query,
+            detector_trigger=self.critical_detector_trigger,
+            priority=self.critical_detector_trigger.condition_result,
+        )
+        assert title == "Detected an anomaly in the query for custom_transactions"
+
+    def test_dynamic_alert_title_default(self):
+        self.detector.config.update({"detection_type": "dynamic"})
+        self.snuba_query.dataset = "asdf"
+        self.snuba_query.aggregate = "default_aggregate"
+        title = self.handler.construct_title(
+            snuba_query=self.snuba_query,
+            detector_trigger=self.critical_detector_trigger,
+            priority=self.critical_detector_trigger.condition_result,
+        )
+        assert title == "Detected an anomaly in the query for default_aggregate"
+
+
+class TestGetAnomalyDetectionIssueTitle(TestCase):
+    def test_extract_lcp_alert(self):
+        assert (
+            get_alert_type_from_aggregate_dataset("p95(measurements.lcp)", Dataset.Transactions)
+            == "lcp"
+        )
+        assert (
+            get_alert_type_from_aggregate_dataset(
+                "percentile(measurements.lcp,0.7)", Dataset.Transactions
+            )
+            == "lcp"
+        )
+        assert (
+            get_alert_type_from_aggregate_dataset("avg(measurements.lcp)", Dataset.Transactions)
+            == "lcp"
+        )
+
+    def test_extract_duration_alert(self):
+        assert (
+            get_alert_type_from_aggregate_dataset("p95(transaction.duration)", Dataset.Transactions)
+            == "trans_duration"
+        )
+        assert (
+            get_alert_type_from_aggregate_dataset(
+                "percentile(transaction.duration,0.3)", Dataset.Transactions
+            )
+            == "trans_duration"
+        )
+        assert (
+            get_alert_type_from_aggregate_dataset("avg(transaction.duration)", Dataset.Transactions)
+            == "trans_duration"
+        )
+
+    def test_extract_throughput_alert(self):
+        assert (
+            get_alert_type_from_aggregate_dataset("count()", Dataset.Transactions) == "throughput"
+        )
+
+    def test_extract_user_error_alert(self):
+        assert (
+            get_alert_type_from_aggregate_dataset("count_unique(user)", Dataset.Events)
+            == "users_experiencing_errors"
+        )
+
+    def test_extract_error_count_alert(self):
+        assert get_alert_type_from_aggregate_dataset("count()", Dataset.Events) == "num_errors"
+
+    def test_extract_crash_free_sessions_alert(self):
+        assert (
+            get_alert_type_from_aggregate_dataset(
+                SessionsAggregate.CRASH_FREE_SESSIONS, Dataset.Metrics
+            )
+            == "crash_free_sessions"
+        )
+
+    def test_extract_crash_free_users_alert(self):
+        assert (
+            get_alert_type_from_aggregate_dataset(
+                SessionsAggregate.CRASH_FREE_USERS, Dataset.Metrics
+            )
+            == "crash_free_users"
+        )
+
+    def test_defaults_to_custom(self):
+        assert (
+            get_alert_type_from_aggregate_dataset(
+                "count_unique(tags[sentry:user])", Dataset.Transactions
+            )
+            == "custom_transactions"
+        )
+        assert (
+            get_alert_type_from_aggregate_dataset("p95(measurements.fp)", Dataset.Transactions)
+            == "custom_transactions"
+        )
+        assert (
+            get_alert_type_from_aggregate_dataset("p95(measurements.ttfb)", Dataset.Transactions)
+            == "custom_transactions"
+        )
+        assert (
+            get_alert_type_from_aggregate_dataset(
+                "count(d:transaction/measurement@seconds)", Dataset.PerformanceMetrics
+            )
+            == "custom_transactions"
+        )
+
+    def test_extract_eap_metrics_alert(self):
+        assert (
+            get_alert_type_from_aggregate_dataset(
+                "count(span.duration)", Dataset.EventsAnalyticsPlatform
+            )
+            == "eap_metrics"
         )


### PR DESCRIPTION
Closes ACI-424

Move the following function from FE to BE
https://github.com/getsentry/sentry/blob/492a91b2ac7963f90745f3d4d537c0a15db204bc/static/app/views/alerts/wizard/utils.tsx#L61-L93

to use to format the `aggregate` value when creating an anomaly detection metric issue

The tests are also moved from FE to BE from
https://github.com/getsentry/sentry/blob/492a91b2ac7963f90745f3d4d537c0a15db204bc/static/app/views/alerts/wizard/utils.spec.tsx