### PR TITLE
fix(seer scanner): Check budget before checking rate limit

### DIFF
--- a/src/sentry/integrations/utils/issue_summary_for_alerts.py
+++ b/src/sentry/integrations/utils/issue_summary_for_alerts.py
@@ -34,9 +34,6 @@ def fetch_issue_summary(group: Group) -> dict[str, Any] | None:
     if not get_seer_org_acknowledgement(org_id=group.organization.id):
         return None
 
-    if is_seer_scanner_rate_limited(project, group.organization):
-        return None
-
     from sentry import quotas
     from sentry.constants import DataCategory
 
@@ -44,6 +41,9 @@ def fetch_issue_summary(group: Group) -> dict[str, Any] | None:
         org_id=group.organization.id, data_category=DataCategory.SEER_SCANNER
     )
     if not has_budget:
+        return None
+
+    if is_seer_scanner_rate_limited(project, group.organization):
         return None
 
     timeout = options.get("alerts.issue_summary_timeout") or 5


### PR DESCRIPTION
This is to prevent emitting rate limited outcomes for customers with seer inactive