### PR TITLE
feat(dashboards): Add handler for starring dashboard

### DIFF
--- a/static/app/views/dashboards/hooks/useResetDashboardLists.tsx
+++ b/static/app/views/dashboards/hooks/useResetDashboardLists.tsx
@@ -1,0 +1,18 @@
+import {useCallback} from 'react';
+
+import {useQueryClient} from 'sentry/utils/queryClient';
+import useOrganization from 'sentry/utils/useOrganization';
+import {useGetStarredDashboards} from 'sentry/views/dashboards/hooks/useGetStarredDashboards';
+
+export function useResetDashboardLists() {
+  const organization = useOrganization();
+  const queryClient = useQueryClient();
+  const getStarredDashboards = useGetStarredDashboards();
+
+  return useCallback(() => {
+    queryClient.invalidateQueries({
+      queryKey: [`/organizations/${organization.slug}/dashboards/`],
+    });
+    getStarredDashboards.refetch();
+  }, [queryClient, organization, getStarredDashboards]);
+}

--- a/static/app/views/dashboards/manage/tableView/table.spec.tsx
+++ b/static/app/views/dashboards/manage/tableView/table.spec.tsx
@@ -1,11 +1,20 @@
 import {DashboardListItemFixture} from 'sentry-fixture/dashboard';
 import {UserFixture} from 'sentry-fixture/user';
 
-import {render, screen, within} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
 
 import {DashboardTable} from './table';
 
 describe('DashboardTable', () => {
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/dashboards/',
+      method: 'GET',
+      body: {dashboards: []},
+    });
+  });
+
   it('should render', () => {
     render(
       <DashboardTable
@@ -104,5 +113,33 @@ describe('DashboardTable', () => {
 
     const filterCells = screen.getAllByLabelText('release:[1.0.0]');
     expect(filterCells[0]).toHaveTextContent('release is 1.0.0');
+  });
+
+  it('should update the dashboard favorite status', async () => {
+    const mockFavoriteRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/dashboards/1/favorite/',
+      method: 'PUT',
+      body: {isFavorited: true},
+    });
+
+    render(
+      <DashboardTable
+        dashboards={[DashboardListItemFixture({isFavorited: false})]}
+        cursorKey="test"
+        isLoading={false}
+        title="My custom dashboards"
+      />
+    );
+
+    const starButton = screen.getByLabelText('Star');
+    await userEvent.click(starButton);
+
+    expect(mockFavoriteRequest).toHaveBeenCalledWith(
+      '/organizations/org-slug/dashboards/1/favorite/',
+      expect.objectContaining({
+        method: 'PUT',
+        data: {isFavorited: true},
+      })
+    );
   });
 });

--- a/static/app/views/dashboards/manage/tableView/table.tsx
+++ b/static/app/views/dashboards/manage/tableView/table.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 
+import {updateDashboardFavorite} from 'sentry/actionCreators/dashboards';
 import {ActivityAvatar} from 'sentry/components/activity/item/avatar';
 import {UserAvatar} from 'sentry/components/core/avatar/userAvatar';
 import {Tooltip} from 'sentry/components/core/tooltip';
@@ -8,8 +9,11 @@ import Pagination from 'sentry/components/pagination';
 import {SavedEntityTable} from 'sentry/components/savedEntityTable';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {useQueryClient} from 'sentry/utils/queryClient';
+import useApi from 'sentry/utils/useApi';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
+import {useResetDashboardLists} from 'sentry/views/dashboards/hooks/useResetDashboardLists';
 import type {DashboardListItem} from 'sentry/views/dashboards/types';
 
 export interface DashboardTableProps {
@@ -27,8 +31,11 @@ export function DashboardTable({
   pageLinks,
   cursorKey,
 }: DashboardTableProps) {
+  const api = useApi();
+  const queryClient = useQueryClient();
   const organization = useOrganization();
   const navigate = useNavigate();
+  const resetDashboardLists = useResetDashboardLists();
 
   const handleCursor: CursorHandler = (_cursor, pathname, query) => {
     navigate({
@@ -86,8 +93,16 @@ export function DashboardTable({
             <SavedEntityTable.Cell hasButton data-column="star">
               <SavedEntityTable.CellStar
                 isStarred={dashboard.isFavorited ?? false}
-                // TODO: DAIN-718 Add star functionality
-                onClick={() => {}}
+                onClick={async () => {
+                  await updateDashboardFavorite(
+                    api,
+                    queryClient,
+                    organization.slug,
+                    dashboard.id,
+                    !dashboard.isFavorited
+                  );
+                  resetDashboardLists();
+                }}
               />
             </SavedEntityTable.Cell>
             <SavedEntityTable.Cell data-column="name">


### PR DESCRIPTION
When starring a dashboard from the table we should reset and refetch the starred dashboard data for the sidebar as well as invalidate the queries for the list view, so it can be updated.