### PR TITLE
fix: SENTRY-454M

### DIFF
--- a/src/sentry/snuba/tasks.py
+++ b/src/sentry/snuba/tasks.py
@@ -72,9 +72,14 @@ def create_subscription_in_snuba(query_subscription_id, **kwargs):
         # into this state. Just attempt to delete the existing subscription and then
         # create a new one.
         query_dataset = Dataset(subscription.snuba_query.dataset)
-        entity_key = get_entity_key_from_snuba_query(
-            subscription.snuba_query, subscription.project.organization_id, subscription.project_id
-        )
+        try:
+            entity_key = get_entity_key_from_snuba_query(
+                subscription.snuba_query,
+                subscription.project.organization_id,
+                subscription.project_id,
+            )
+        except (InvalidSearchQuery, IncompatibleMetricsQuery) as e:
+            raise SubscriptionError(e)
         try:
             _delete_from_snuba(
                 query_dataset,
@@ -211,12 +216,15 @@ def delete_subscription_from_snuba(query_subscription_id, **kwargs):
 
     if subscription.subscription_id is not None and subscription.snuba_query is not None:
         query_dataset = Dataset(subscription.snuba_query.dataset)
-        entity_key = get_entity_key_from_snuba_query(
-            subscription.snuba_query,
-            subscription.project.organization_id,
-            subscription.project_id,
-            skip_field_validation_for_entity_subscription_deletion=True,
-        )
+        try:
+            entity_key = get_entity_key_from_snuba_query(
+                subscription.snuba_query,
+                subscription.project.organization_id,
+                subscription.project_id,
+                skip_field_validation_for_entity_subscription_deletion=True,
+            )
+        except (InvalidSearchQuery, IncompatibleMetricsQuery) as e:
+            raise SubscriptionError(e)
         _delete_from_snuba(
             query_dataset,
             subscription.subscription_id,


### PR DESCRIPTION
- Handle InvalidSearchQuery as SubscriptionError
- I've also updated our rules in sentry so these get assigned to Alerts & Notifications