### PR TITLE
fix(event-details): Handle invalid search query

### DIFF
--- a/src/sentry/issues/endpoints/group_event_details.py
+++ b/src/sentry/issues/endpoints/group_event_details.py
@@ -30,7 +30,7 @@ from sentry.apidocs.examples.event_examples import EventExamples
 from sentry.apidocs.parameters import EventParams, GlobalParams, IssueParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.eventstore.models import Event, GroupEvent
-from sentry.exceptions import InvalidParams
+from sentry.exceptions import InvalidParams, InvalidSearchQuery
 from sentry.issues.endpoints.project_event_details import (
     GroupEventDetailsResponse,
     wrap_event_response,
@@ -172,6 +172,9 @@ class GroupEventDetailsEndpoint(GroupEndpoint):
             )
         except ValidationError:
             raise ParseError(detail="Invalid event query")
+        except InvalidSearchQuery as error:
+            message = str(error)
+            raise ParseError(detail=message)
         except Exception:
             logging.exception(
                 "group_event_details.parse_query",

--- a/tests/snuba/api/endpoints/test_group_event_details.py
+++ b/tests/snuba/api/endpoints/test_group_event_details.py
@@ -116,3 +116,9 @@ class GroupEventDetailsTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase
         response = self.client.get(url, format="json")
         assert response.status_code == 200
         assert response.data["eventID"] == event.event_id
+
+    def test_invalid_query(self):
+        event = self.create_performance_issue()
+        url = f"/api/0/issues/{event.group.id}/events/{event.event_id}/"
+        response = self.client.get(url, format="json", data={"query": "release.version:foobar"})
+        assert response.status_code == 400


### PR DESCRIPTION
- Fixes SENTRY-3WA2
- When there's an invalid search query return a parse error with what the user did wrong instead of server erroring