### PR TITLE
chore(issues): Update Fold Section chevron

### DIFF
--- a/static/app/views/issueDetails/streamline/foldSection.tsx
+++ b/static/app/views/issueDetails/streamline/foldSection.tsx
@@ -185,6 +185,9 @@ export function FoldSection({
             hasSelectedBackground={false}
             hidden={preventCollapse ? preventCollapse : !isLayerEnabled}
           />
+          <IconWrapper preventCollapse={preventCollapse}>
+            <IconChevron direction={isCollapsed ? 'right' : 'down'} size="xs" />
+          </IconWrapper>
           <TitleWithActions preventCollapse={preventCollapse}>
             <TitleWrapper>{title}</TitleWrapper>
             {!isCollapsed && (
@@ -197,9 +200,6 @@ export function FoldSection({
               </div>
             )}
           </TitleWithActions>
-          <IconWrapper preventCollapse={preventCollapse}>
-            <IconChevron direction={isCollapsed ? 'down' : 'up'} size="xs" />
-          </IconWrapper>
         </SectionExpander>
         {isCollapsed ? null : (
           <ErrorBoundary mini>
@@ -235,7 +235,8 @@ const Content = styled('div')`
 
 const SectionExpander = styled('div')<{preventCollapse: boolean}>`
   display: grid;
-  grid-template-columns: 1fr auto;
+  grid-template-columns: auto 1fr;
+  column-gap: ${p => p.theme.space.xs};
   align-items: center;
   padding: ${space(0.5)} ${space(1.5)};
   margin: 0 -${space(0.75)};


### PR DESCRIPTION
this pr updates the fold section to have the chevron at the front instead of at the end 

before: 
<img width="1292" height="102" alt="Screenshot 2025-07-21 at 12 23 33 PM" src="https://github.com/user-attachments/assets/ab435c16-6217-4a55-a487-ac085d06551a" />


after: 
<img width="1143" height="109" alt="Screenshot 2025-07-21 at 12 23 11 PM" src="https://github.com/user-attachments/assets/83140ea9-8070-4f95-8f35-caa53cf18ae2" />
<img width="1136" height="107" alt="Screenshot 2025-07-21 at 12 23 04 PM" src="https://github.com/user-attachments/assets/b3fc9f1f-66e7-47f4-af9d-baa6ffe30ee4" />
