### PR TITLE
fix(dashboards): remove extra column in issues widget preview modal

### DIFF
--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -304,6 +304,7 @@ function WidgetViewerModal(props: Props) {
   // include the orderby in the table widget aggregates and columns otherwise
   // eventsv2 will complain about sorting on an unselected field.
   if (
+    widget.displayType === DisplayType.TABLE &&
     orderby &&
     !isEquationAlias(rawOrderby) &&
     // Normalize to the aggregate alias because we may still have widgets

--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -304,7 +304,7 @@ function WidgetViewerModal(props: Props) {
   // include the orderby in the table widget aggregates and columns otherwise
   // eventsv2 will complain about sorting on an unselected field.
   if (
-    widget.displayType === DisplayType.TABLE &&
+    widget.displayType !== DisplayType.TABLE &&
     orderby &&
     !isEquationAlias(rawOrderby) &&
     // Normalize to the aggregate alias because we may still have widgets


### PR DESCRIPTION
### Changes

Fix issues table having additional columns in the widget preview modal

### Before 
Extra date as rightmost column:
<img width="1166" height="693" alt="Screenshot 2025-07-21 at 3 33 06 PM" src="https://github.com/user-attachments/assets/6b516a2a-1e4b-4069-8cdf-cf3084b89ae6" />

### After
<img width="1163" height="557" alt="Screenshot 2025-07-21 at 3 35 55 PM" src="https://github.com/user-attachments/assets/921ef379-4762-4d6c-b0f3-a4d714ae9bd9" />


