### PR TITLE
fix(spans-migration): Maintain widget builder state with spans dataset switch

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/datasetSelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/datasetSelector.tsx
@@ -13,6 +13,7 @@ import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {WidgetBuilderVersion} from 'sentry/utils/analytics/dashboardsAnalyticsEvents';
+import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {WidgetType} from 'sentry/views/dashboards/types';
 import {SectionHeader} from 'sentry/views/dashboards/widgetBuilder/components/common/sectionHeader';
@@ -24,6 +25,7 @@ import {useSegmentSpanWidgetState} from 'sentry/views/dashboards/widgetBuilder/h
 
 function WidgetBuilderDatasetSelector() {
   const organization = useOrganization();
+  const location = useLocation();
   const {state} = useWidgetBuilderContext();
   const source = useDashboardWidgetSource();
   const isEditing = useIsEditingWidget();
@@ -39,7 +41,18 @@ function WidgetBuilderDatasetSelector() {
       tct('This dataset is is no longer supported. Please use the [spans] dataset.', {
         spans: (
           <Link
-            to=""
+            // We need to do this otherwise the dashboard filters will change
+            to={{
+              pathname: location.pathname,
+              query: {
+                project: location.query.project,
+                start: location.query.start,
+                end: location.query.end,
+                statsPeriod: location.query.statsPeriod,
+                environment: location.query.environment,
+                utc: location.query.utc,
+              },
+            }}
             onClick={() => {
               cacheBuilderState(state.dataset ?? WidgetType.ERRORS);
               setSegmentSpanBuilderState();

--- a/static/app/views/dashboards/widgetBuilder/hooks/useSegmentSpanWidgetState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useSegmentSpanWidgetState.tsx
@@ -3,17 +3,21 @@ import {useCallback} from 'react';
 import {WidgetType} from 'sentry/views/dashboards/types';
 import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
 import {BuilderStateAction} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
+import {convertBuilderStateToWidget} from 'sentry/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget';
+import {convertWidgetToBuilderStateParams} from 'sentry/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams';
 
 export function useSegmentSpanWidgetState() {
-  const {dispatch} = useWidgetBuilderContext();
+  const {dispatch, state} = useWidgetBuilderContext();
 
   const setSegmentSpanBuilderState = useCallback(() => {
     const nextDataset = WidgetType.SPANS;
+    const widget = convertBuilderStateToWidget(state);
+    const stateParams = convertWidgetToBuilderStateParams(widget);
     dispatch({
       type: BuilderStateAction.SET_STATE,
-      payload: {dataset: nextDataset, query: ['is_transaction:true']},
+      payload: {...stateParams, dataset: nextDataset, query: ['is_transaction:true']},
     });
-  }, [dispatch]);
+  }, [dispatch, state]);
 
   return {
     setSegmentSpanBuilderState,

--- a/static/app/views/dashboards/widgetBuilder/hooks/useSegmentSpanWidgetState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useSegmentSpanWidgetState.tsx
@@ -15,7 +15,11 @@ export function useSegmentSpanWidgetState() {
     const stateParams = convertWidgetToBuilderStateParams(widget);
     dispatch({
       type: BuilderStateAction.SET_STATE,
-      payload: {...stateParams, dataset: nextDataset, query: ['is_transaction:true']},
+      payload: {
+        ...stateParams,
+        dataset: nextDataset,
+        query: ['is_transaction:true'],
+      },
     });
   }, [dispatch, state]);
 

--- a/static/app/views/dashboards/widgetBuilder/hooks/useSegmentSpanWidgetState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useSegmentSpanWidgetState.tsx
@@ -3,16 +3,14 @@ import {useCallback} from 'react';
 import {WidgetType} from 'sentry/views/dashboards/types';
 import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
 import {BuilderStateAction} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
-import {convertBuilderStateToWidget} from 'sentry/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget';
-import {convertWidgetToBuilderStateParams} from 'sentry/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams';
+import {convertBuilderStateToStateQueryParams} from 'sentry/views/dashboards/widgetBuilder/utils/convertBuilderStateToStateQueryParams';
 
 export function useSegmentSpanWidgetState() {
   const {dispatch, state} = useWidgetBuilderContext();
 
   const setSegmentSpanBuilderState = useCallback(() => {
     const nextDataset = WidgetType.SPANS;
-    const widget = convertBuilderStateToWidget(state);
-    const stateParams = convertWidgetToBuilderStateParams(widget);
+    const stateParams = convertBuilderStateToStateQueryParams(state);
     dispatch({
       type: BuilderStateAction.SET_STATE,
       payload: {

--- a/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToStateQueryParams.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToStateQueryParams.spec.tsx
@@ -1,0 +1,75 @@
+import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
+import type {WidgetBuilderState} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
+import {convertBuilderStateToStateQueryParams} from 'sentry/views/dashboards/widgetBuilder/utils/convertBuilderStateToStateQueryParams';
+import {FieldValueKind} from 'sentry/views/discover/table/types';
+
+describe('convertBuilderStateToStateQueryParams', function () {
+  it('returns the query params with the provided widget queries state', function () {
+    const mockState: WidgetBuilderState = {
+      title: 'Test Widget',
+      description: 'Test Description',
+      dataset: WidgetType.ERRORS,
+      displayType: DisplayType.LINE,
+      limit: 5,
+      fields: [{kind: 'field', field: 'geo.country'}],
+      yAxis: [{kind: 'function', function: ['count', '', undefined, undefined]}],
+      sort: [{field: 'geo.country', kind: 'desc'}],
+    };
+
+    const queryParams = convertBuilderStateToStateQueryParams(mockState);
+
+    expect(queryParams).toEqual({
+      title: 'Test Widget',
+      description: 'Test Description',
+      dataset: WidgetType.ERRORS,
+      displayType: DisplayType.LINE,
+      limit: 5,
+      field: ['geo.country'],
+      yAxis: ['count()'],
+      sort: ['-geo.country'],
+      thresholds: undefined,
+    });
+  });
+
+  it('adds aliases to the query params', function () {
+    const mockState: WidgetBuilderState = {
+      fields: [
+        {field: 'geo.country', alias: 'test', kind: FieldValueKind.FIELD},
+        {field: 'geo.country', alias: undefined, kind: FieldValueKind.FIELD},
+        {field: 'geo.country', alias: 'another one', kind: FieldValueKind.FIELD},
+      ],
+      legendAlias: ['test', '', 'another one'],
+    };
+    const queryParams = convertBuilderStateToStateQueryParams(mockState);
+
+    expect(queryParams.legendAlias).toEqual(['test', '', 'another one']);
+  });
+
+  it('propagates the selected aggregate to the query params', () => {
+    const mockState: WidgetBuilderState = {
+      selectedAggregate: 0,
+      query: ['transaction.duration:>100'],
+    };
+
+    const queryParams = convertBuilderStateToStateQueryParams(mockState);
+
+    expect(queryParams.selectedAggregate).toBe(0);
+  });
+
+  it('applies the thresholds to the query params', () => {
+    const mockState: WidgetBuilderState = {
+      query: ['transaction.duration:>100'],
+      thresholds: {
+        max_values: {
+          max1: 200,
+          max2: 300,
+        },
+        unit: 'milliseconds',
+      },
+    };
+
+    const queryParams = convertBuilderStateToStateQueryParams(mockState);
+
+    expect(queryParams.thresholds).toEqual(JSON.stringify(mockState.thresholds));
+  });
+});

--- a/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToStateQueryParams.ts
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToStateQueryParams.ts
@@ -1,0 +1,21 @@
+import {WidgetType} from 'sentry/views/dashboards/types';
+import {
+  serializeFields,
+  serializeSorts,
+  serializeThresholds,
+  type WidgetBuilderState,
+  type WidgetBuilderStateQueryParams,
+} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
+
+export function convertBuilderStateToStateQueryParams(
+  state: WidgetBuilderState
+): WidgetBuilderStateQueryParams {
+  const {fields, yAxis, sort, thresholds, ...rest} = state;
+  return {
+    ...rest,
+    field: serializeFields(fields ?? []),
+    yAxis: serializeFields(yAxis ?? []),
+    sort: serializeSorts(WidgetType.SPANS)(sort ?? []),
+    thresholds: thresholds ? serializeThresholds(thresholds) : undefined,
+  };
+}


### PR DESCRIPTION
Initially clicking on the "Spans" dataset in the deprecated transactions tooltip would wipe the widget viewer url and only populate the `dataset` and `query` params. This would also wipe the dashboard filters. I've ensured that all of the fields are still populated so that we don't run into state issues.

<img width="637" height="240" alt="image" src="https://github.com/user-attachments/assets/a9b09983-248b-47a8-8313-ce8dbc5049f3" />


