### PR TITLE
fix(dashboards): Disable the edit state when committing changes

### DIFF
--- a/static/app/views/dashboards/constants.tsx
+++ b/static/app/views/dashboards/constants.tsx
@@ -1,0 +1,3 @@
+import {t} from 'sentry/locale';
+
+export const DASHBOARD_SAVING_MESSAGE = t('Saving changes\u2026');

--- a/static/app/views/dashboards/controls.tsx
+++ b/static/app/views/dashboards/controls.tsx
@@ -11,6 +11,7 @@ import {Tooltip} from 'sentry/components/core/tooltip';
 import {DropdownMenu, type MenuItemProps} from 'sentry/components/dropdownMenu';
 import FeedbackWidgetButton from 'sentry/components/feedback/widget/feedbackWidgetButton';
 import {Hovercard} from 'sentry/components/hovercard';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {IconAdd, IconDownload, IconEdit, IconStar} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -21,6 +22,7 @@ import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useUser} from 'sentry/utils/useUser';
 import {useUserTeams} from 'sentry/utils/useUserTeams';
+import {DASHBOARD_SAVING_MESSAGE} from 'sentry/views/dashboards/constants';
 import EditAccessSelector from 'sentry/views/dashboards/editAccessSelector';
 import {DataSet} from 'sentry/views/dashboards/widgetBuilder/utils';
 
@@ -41,6 +43,7 @@ type Props = {
   organization: Organization;
   widgetLimitReached: boolean;
   hasUnsavedFilters?: boolean;
+  isSaving?: boolean;
   onChangeEditAccess?: (newDashboardPermissions: DashboardPermissions) => void;
 };
 
@@ -56,6 +59,7 @@ function Controls({
   onDelete,
   onCancel,
   onAddWidget,
+  isSaving,
 }: Props) {
   const [isFavorited, setIsFavorited] = useState(dashboard.isFavorited);
   const queryClient = useQueryClient();
@@ -241,12 +245,14 @@ function Controls({
                 e.preventDefault();
                 onEdit();
               }}
-              icon={<IconEdit />}
-              disabled={!hasFeature || hasUnsavedFilters || !hasEditAccess}
+              icon={isSaving ? <LoadingIndicator size={16} /> : <IconEdit />}
+              disabled={!hasFeature || hasUnsavedFilters || !hasEditAccess || isSaving}
               title={
-                hasEditAccess
-                  ? hasUnsavedFilters && UNSAVED_FILTERS_MESSAGE
-                  : t('You do not have permission to edit this dashboard')
+                isSaving
+                  ? DASHBOARD_SAVING_MESSAGE
+                  : hasEditAccess
+                    ? hasUnsavedFilters && UNSAVED_FILTERS_MESSAGE
+                    : t('You do not have permission to edit this dashboard')
               }
               priority="default"
               size="sm"

--- a/static/app/views/dashboards/controls.tsx
+++ b/static/app/views/dashboards/controls.tsx
@@ -245,7 +245,7 @@ function Controls({
                 e.preventDefault();
                 onEdit();
               }}
-              icon={isSaving ? <LoadingIndicator size={16} /> : <IconEdit />}
+              icon={isSaving ? <LoadingIndicator size={14} /> : <IconEdit />}
               disabled={!hasFeature || hasUnsavedFilters || !hasEditAccess || isSaving}
               title={
                 isSaving

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -1111,6 +1111,7 @@ class DashboardDetail extends Component<Props, State> {
       seriesData,
       setData,
       newlyAddedWidget,
+      isCommittingChanges,
     } = this.state;
     const {dashboardId} = params;
 
@@ -1212,6 +1213,7 @@ class DashboardDetail extends Component<Props, State> {
                         onChangeEditAccess={this.onChangeEditAccess}
                         dashboardState={dashboardState}
                         widgetLimitReached={widgetLimitReached}
+                        isSaving={isCommittingChanges}
                       />
                     </Layout.HeaderActions>
                   </Layout.Header>


### PR DESCRIPTION
This is a small workaround for our state management at the moment for dashboards, because saving a dashboard begins a request, our base dashboard state hasn't been updated to reflect the "new" state. When a user adds a widget and immediately goes to edit the dashboard, we show the old state if the save hasn't fully completed yet.

I've only disabled the edit button because all of the other actions that can occur outside of the edit state are okay to continue occuring, they're just new requests to overwrite the state.

We're going with this at the moment because our intention is to remove the edit state fully soon in the future.

Addresses JAVASCRIPT-32DM