### PR TITLE
fix(discover): Top N queries do not support grouping by array fields

### DIFF
--- a/src/sentry/search/events/builder/discover.py
+++ b/src/sentry/search/events/builder/discover.py
@@ -459,10 +459,13 @@ class TopEventsQueryBuilder(TimeseriesQueryBuilder):
                         list_conditions.append(
                             Condition(resolved_field, Op.IN if not other else Op.NOT_IN, value)
                         )
-                    if not other:
-                        conditions.append(Or(conditions=list_conditions))
+                    if len(list_conditions) > 1:
+                        if not other:
+                            conditions.append(Or(conditions=list_conditions))
+                        else:
+                            conditions.append(And(conditions=list_conditions))
                     else:
-                        conditions.append(And(conditions=list_conditions))
+                        conditions.extend(list_conditions)
                 else:
                     conditions.append(
                         Condition(resolved_field, Op.IN if not other else Op.NOT_IN, values_list)

--- a/src/sentry/search/events/builder/discover.py
+++ b/src/sentry/search/events/builder/discover.py
@@ -456,6 +456,8 @@ class TopEventsQueryBuilder(TimeseriesQueryBuilder):
                 elif any(isinstance(value, list) for value in values_list):
                     list_conditions = []
                     for values in values_list:
+                        # This depends on a weird clickhouse behaviour where the best way to compare arrays is to do
+                        # array("foo", "bar") IN array("foo", "bar") == 1
                         list_conditions.append(
                             Condition(resolved_field, Op.IN if not other else Op.NOT_IN, values)
                         )

--- a/src/sentry/search/events/builder/discover.py
+++ b/src/sentry/search/events/builder/discover.py
@@ -401,6 +401,7 @@ class TopEventsQueryBuilder(TimeseriesQueryBuilder):
             resolved_field = self.resolve_column(self.prefixed_to_tag_map.get(field, field))
 
             values: set[Any] = set()
+            array_values: list[Any] = []
             for event in top_events:
                 if field in event:
                     alias = field
@@ -410,11 +411,12 @@ class TopEventsQueryBuilder(TimeseriesQueryBuilder):
                     continue
 
                 # Note that because orderby shouldn't be an array field its not included in the values
-                if isinstance(event.get(alias), list):
-                    continue
+                event_value = event.get(alias)
+                if isinstance(event_value, list) and event_value not in array_values:
+                    array_values.append(event_value)
                 else:
-                    values.add(event.get(alias))
-            values_list = list(values)
+                    values.add(event_value)
+            values_list = list(values) + array_values
 
             if values_list:
                 if field == "timestamp" or field.startswith("timestamp.to_"):
@@ -451,6 +453,16 @@ class TopEventsQueryBuilder(TimeseriesQueryBuilder):
                             conditions.append(And(conditions=[null_condition, non_none_condition]))
                     else:
                         conditions.append(null_condition)
+                elif any(isinstance(value, list) for value in values_list):
+                    list_conditions = []
+                    for value in values_list:
+                        list_conditions.append(
+                            Condition(resolved_field, Op.IN if not other else Op.NOT_IN, value)
+                        )
+                    if not other:
+                        conditions.append(Or(conditions=list_conditions))
+                    else:
+                        conditions.append(And(conditions=list_conditions))
                 else:
                     conditions.append(
                         Condition(resolved_field, Op.IN if not other else Op.NOT_IN, values_list)

--- a/src/sentry/search/events/builder/discover.py
+++ b/src/sentry/search/events/builder/discover.py
@@ -455,9 +455,9 @@ class TopEventsQueryBuilder(TimeseriesQueryBuilder):
                         conditions.append(null_condition)
                 elif any(isinstance(value, list) for value in values_list):
                     list_conditions = []
-                    for value in values_list:
+                    for values in values_list:
                         list_conditions.append(
-                            Condition(resolved_field, Op.IN if not other else Op.NOT_IN, value)
+                            Condition(resolved_field, Op.IN if not other else Op.NOT_IN, values)
                         )
                     if len(list_conditions) > 1:
                         if not other:

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -427,7 +427,10 @@ def create_groupby_dict(
             value = result_row.get(field)
             if isinstance(value, list):
                 if len(value) > 0:
-                    value = value[-1]
+                    # Even though frontend renders only the last element, this can cause key overlaps
+                    # For now lets just render this as a list to avoid that problem
+                    # TODO: timeseries can handle this correctly since this value isn't used as a dict key
+                    value = f"[{','.join(value)}]"
                 else:
                     value = ""
             values.append({"key": field, "value": str(value)})

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -3137,7 +3137,7 @@ class OrganizationEventsStatsTopNEventsErrors(APITestCase, SnubaTestCase):
                     "timestamp": (self.day_ago + timedelta(minutes=2)).isoformat(),
                     "user": {"email": self.user.email},
                     "tags": {"shared-tag": "yup", "env": "prod"},
-                    "exception": {"values": [{"type": "NameError"}]},
+                    "exception": {"values": [{"type": "NameError"}, {"type": "FooError"}]},
                     "fingerprint": ["group1"],
                 },
                 "project": self.project2,
@@ -3150,7 +3150,7 @@ class OrganizationEventsStatsTopNEventsErrors(APITestCase, SnubaTestCase):
                     "fingerprint": ["group2"],
                     "user": {"email": self.user2.email},
                     "tags": {"shared-tag": "yup", "env": "prod"},
-                    "exception": {"values": [{"type": "NameError"}]},
+                    "exception": {"values": [{"type": "NameError"}, {"type": "FooError"}]},
                 },
                 "project": self.project2,
                 "count": 6,
@@ -3162,7 +3162,7 @@ class OrganizationEventsStatsTopNEventsErrors(APITestCase, SnubaTestCase):
                     "fingerprint": ["group3"],
                     "user": {"email": "foo@example.com"},
                     "tags": {"shared-tag": "yup", "env": "prod"},
-                    "exception": {"values": [{"type": "NameError"}]},
+                    "exception": {"values": [{"type": "NameError"}, {"type": "FooError"}]},
                 },
                 "project": self.project,
                 "count": 5,
@@ -3185,7 +3185,7 @@ class OrganizationEventsStatsTopNEventsErrors(APITestCase, SnubaTestCase):
                     "timestamp": (self.day_ago + timedelta(minutes=2)).isoformat(),
                     "user": {"email": self.user.email},
                     "tags": {"shared-tag": "yup", "env": "staging"},
-                    "exception": {"values": [{"type": "NameError"}]},
+                    "exception": {"values": [{"type": "NameError"}, {"type": "FooError"}]},
                     "fingerprint": ["group7"],
                 },
                 "project": self.project,
@@ -3305,9 +3305,9 @@ class OrganizationEventsStatsTopNEventsErrors(APITestCase, SnubaTestCase):
 
         data = response.data
         assert len(data) == 2
-        assert "NameError" in data
+        assert "[NameError,FooError]" in data
         assert "ValueError" in data
-        assert [attrs[0]["count"] for _, attrs in data["NameError"]["data"]] == [2, 0]
+        assert [attrs[0]["count"] for _, attrs in data["[NameError,FooError]"]["data"]] == [2, 0]
         assert [attrs[0]["count"] for _, attrs in data["ValueError"]["data"]] == [1, 0]
 
     def test_top_events_with_projects_other(self):

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -3303,9 +3303,9 @@ class OrganizationEventsStatsTopNEventsErrors(APITestCase, SnubaTestCase):
         data = response.data
         assert len(data) == 2
         assert "[NameError,FooError]" in data
-        assert "ValueError" in data
+        assert "[ValueError]" in data
         assert [attrs[0]["count"] for _, attrs in data["[NameError,FooError]"]["data"]] == [2, 0]
-        assert [attrs[0]["count"] for _, attrs in data["ValueError"]["data"]] == [1, 0]
+        assert [attrs[0]["count"] for _, attrs in data["[ValueError]"]["data"]] == [1, 0]
 
     def test_top_events_with_projects_other(self):
         with self.feature(self.enabled_features):

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -3275,12 +3275,9 @@ class OrganizationEventsStatsTopNEventsErrors(APITestCase, SnubaTestCase):
         assert other["order"] == 5
         assert [{"count": 3}] in [attrs for _, attrs in other["data"]]
 
-    def test_top_events_with_query_on_field(self):
+    def test_top_events_with_array_field(self):
         """
-        Test that if there is a query on one of the group by fields, the top
-        events are filtered correctly. In this case, we are asking for the top 2
-        error types, with a query on the `error.type` field. The test data only
-        has two error types, so there should _not_ be an `"Other"` group.
+        Test that when doing a qurey on top events with an array field that its handled correctly
         """
 
         with self.feature(self.enabled_features):

--- a/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
@@ -889,7 +889,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
         assert len(response.data) == 1
 
         # Results are grouped by the error type
-        assert response.data.get("test_error").get("meta").get(
+        assert response.data.get("[test_error]").get("meta").get(
             "discoverSplitDecision"
         ) is DashboardWidgetTypes.get_type_name(DashboardWidgetTypes.ERROR_EVENTS)
 


### PR DESCRIPTION
The `/events-stats` endpoint does not support array fields like `error.type` and omits them from the query conditions when creating `topEvents` queries. This results in strange bugs where the "Other" series is actually _all_ series!

Closes DAIN-770.
