### PR TITLE
ref(grouping): Make current enhancements the default

### DIFF
--- a/src/sentry/grouping/strategies/base.py
+++ b/src/sentry/grouping/strategies/base.py
@@ -34,7 +34,7 @@ Risk = int  # TODO: make enum or union of literals
 ContextValue = Any
 ContextDict = dict[str, ContextValue]
 
-DEFAULT_ENHANCEMENTS_BASE = "common:2019-03-23"
+DEFAULT_ENHANCEMENTS_BASE = "newstyle:2023-01-11"
 DEFAULT_GROUPING_FINGERPRINTING_BASES: list[str] = []
 
 # TODO: Hack to make `ReturnedVariants` (no pun intended) covariant. At some point we should


### PR DESCRIPTION
This switches `DEFAULT_ENHANCEMENTS_BASE` to point to the current default config's enhancements.