### PR TITLE
feat(logs): Add logs query as alert and dashboard

### DIFF
--- a/static/app/views/dashboards/types.tsx
+++ b/static/app/views/dashboards/types.tsx
@@ -189,4 +189,5 @@ export enum DashboardWidgetSource {
   LIBRARY = 'library',
   ISSUE_DETAILS = 'issueDetail',
   TRACE_EXPLORER = 'traceExplorer',
+  LOGS = 'logs',
 }

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -227,6 +227,7 @@ export function LogsTabContent({
 
   const saveAsItems = useSaveAsItems({
     aggregate,
+    groupBy,
     interval,
     mode,
     search: logsSearch,
@@ -355,6 +356,7 @@ export function LogsTabContent({
 
 interface UseSaveAsItemsOptions {
   aggregate: string;
+  groupBy: string | undefined;
   interval: string;
   mode: Mode;
   search: MutableSearch;
@@ -363,6 +365,7 @@ interface UseSaveAsItemsOptions {
 
 function useSaveAsItems({
   aggregate,
+  groupBy,
   interval,
   mode,
   search,
@@ -433,7 +436,12 @@ function useSaveAsItems({
             organization,
           });
 
-          const fields = mode === Mode.SAMPLES ? [] : [].filter(Boolean); // TODO
+          const fields =
+            mode === Mode.SAMPLES
+              ? []
+              : [...new Set([groupBy, yAxis, ...sortBys.map(sort => sort.field)])].filter(
+                  Boolean
+                );
 
           const discoverQuery: NewQuery = {
             name: DEFAULT_WIDGET_NAME,
@@ -481,7 +489,17 @@ function useSaveAsItems({
       disabled: !dashboardsUrls || dashboardsUrls.length === 0,
       isSubmenu: true,
     };
-  }, [aggregates, mode, organization, pageFilters, search, sortBys, location, router]);
+  }, [
+    aggregates,
+    groupBy,
+    mode,
+    organization,
+    pageFilters,
+    search,
+    sortBys,
+    location,
+    router,
+  ]);
 
   return useMemo(() => {
     const saveAs = [];

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -14,6 +14,7 @@ import {SearchQueryBuilderProvider} from 'sentry/components/searchQueryBuilder/c
 import {IconChevron, IconTable} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {NewQuery} from 'sentry/types/organization';
+import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
 import EventView from 'sentry/utils/discover/eventView';
@@ -440,7 +441,7 @@ function useSaveAsItems({
             mode === Mode.SAMPLES
               ? []
               : [...new Set([groupBy, yAxis, ...sortBys.map(sort => sort.field)])].filter(
-                  Boolean
+                  defined
                 );
 
           const discoverQuery: NewQuery = {

--- a/static/app/views/insights/common/utils/getAlertsUrl.tsx
+++ b/static/app/views/insights/common/utils/getAlertsUrl.tsx
@@ -15,12 +15,14 @@ export function getAlertsUrl({
   name,
   interval,
   dataset = Dataset.GENERIC_METRICS,
+  eventTypes = 'transaction',
   referrer,
 }: {
   aggregate: string;
   organization: Organization;
   pageFilters: PageFilters;
   dataset?: Dataset;
+  eventTypes?: string;
   interval?: string;
   name?: string;
   project?: Project;
@@ -34,7 +36,7 @@ export function getAlertsUrl({
     aggregate,
     dataset,
     project: project?.slug,
-    eventTypes: 'transaction',
+    eventTypes,
     query,
     statsPeriod,
     environment,


### PR DESCRIPTION
This adds an save as button by the search bar to allow saving the query as an alert or dashboard. The component is currently not in its own file as we expect to have to refactor this as we unify logs and spans.