### PR TITLE
fix(IssueStats): Stop double-counting groups with groupHistory

### DIFF
--- a/tests/sentry/api/endpoints/test_team_all_unresolved_issues.py
+++ b/tests/sentry/api/endpoints/test_team_all_unresolved_issues.py
@@ -155,6 +155,24 @@ class TeamIssueBreakdownTest(APITestCase):
             group=group3_1, date_added=before_now(days=4), status=GroupHistoryStatus.RESOLVED
         )
 
+        # Test that we don't double-count creation if first GroupHistory row is "open"
+        # If error, should see index 0 incorrectly report 0 open issues
+        project4 = self.create_project(teams=[self.team])
+        group4_1 = self.create_group(
+            project=project4, first_seen=before_now(days=40), status=GroupStatus.UNRESOLVED
+        )
+        GroupAssignee.objects.assign(group4_1, self.user)
+        group4_2 = self.create_group(
+            project=project4, first_seen=before_now(days=5), status=GroupStatus.RESOLVED
+        )
+        GroupAssignee.objects.assign(group4_2, self.user)
+        self.create_group_history(
+            group=group4_2, date_added=before_now(days=3), status=GroupHistoryStatus.UNRESOLVED
+        )
+        self.create_group_history(
+            group=group4_2, date_added=before_now(days=1), status=GroupHistoryStatus.RESOLVED
+        )
+
         self.login_as(user=self.user)
         response = self.get_success_response(
             self.team.organization.slug, self.team.slug, statsPeriod="7d"
@@ -173,6 +191,7 @@ class TeamIssueBreakdownTest(APITestCase):
         compare_response(response, project1, [3, 3, 3, 4, 4, 5, 5])
         compare_response(response, project2, [0, 1, 0, 1, 0, 1, 0])
         compare_response(response, project3, [0, 1, 0, 0, 0, 0, 0])
+        compare_response(response, project4, [1, 2, 2, 2, 2, 1, 1])
 
     def test_status_format_with_environment(self):
         project1 = self.create_project(teams=[self.team])


### PR DESCRIPTION
The way the `calculate_unresolved_counts` block works:
1. Starts with the current number of `UNRESOLVED` groups, per project.
2. Gathers the history of the groups — through both the `GroupHistory` table and the `first_seen` column of the `Group` table.
3. Step forward through time to understand how many "group open" or "group close" state change happen per day.
4. Step backwards through time, from the initial # of `UNRESOLVED` groups, with the status-change info from (3), to generate a number for how many issues are unresolved at midnight of each day.

Note that in step (3), we're already doing some deduplication logic with the `GroupHistory` data to make sure we aren't counting the same state change twice.

It appears that we may be double-counting state changes between the `Group` and `GroupHistory` data — i.e. we may be reading the `first_seen` of a `Group` and an  `open` `GroupHistory` back-to-back _for the same group_id`. This would cause the data to drop leftwards to zero faster than it should, which matches with the problem we are seeing today of graphs that are oddly zeroed out further back in time.

This PR pulls individual rows with `group_id` with the `Group` data so that we can dedupe between that data & the `GroupHistory` data.

Fixes ISWF-573.

Tested through additions to `tests/sentry/api/endpoints/test_team_all_unresolved_issues.py::TeamIssueBreakdownTest::test_status_format`, which do indeed fail on master.

Risks: this is pulling more raw data from the DB & making python process more data. It should be fine at our scale but might be something to watch out for if we ever see an OOM here.