### PR TITLE
fix(detectors): Add parameterized keyword filter to sql detection detector 

### DIFF
--- a/src/sentry/performance_issues/detectors/sql_injection_detector.py
+++ b/src/sentry/performance_issues/detectors/sql_injection_detector.py
@@ -56,6 +56,7 @@ EXCLUDED_KEYWORDS = [
 ]
 
 EXCLUDED_PACKAGES = ["github.com/go-sql-driver/mysql", "sequelize"]
+PARAMETERIZED_KEYWORDS = ["?", "$1", "%s"]
 
 
 class SQLInjectionDetector(PerformanceDetector):
@@ -122,7 +123,9 @@ class SQLInjectionDetector(PerformanceDetector):
         spans_involved = [span["span_id"]]
         vulnerable_parameters = []
 
-        if "WHERE" not in description.upper():
+        if "WHERE" not in description.upper() or any(
+            keyword in description for keyword in PARAMETERIZED_KEYWORDS
+        ):
             return
 
         for key, value in self.request_parameters:


### PR DESCRIPTION
this pr adds an additional check to see if the description already contains some common strings that are used when parameterizing SQL queries. If those are present, it's unlikely that the query also contains a vulnerability so we can skip the span. Starting with a relatively small list to assess impact, but can expand in future PRs if necessary. 