### PR TITLE
style(replay): fix spacing in short summaries

### DIFF
--- a/static/app/views/replays/detail/ai/ai.tsx
+++ b/static/app/views/replays/detail/ai/ai.tsx
@@ -224,6 +224,7 @@ const Summary = styled('div')`
   padding: ${space(1)} ${space(1.5)};
   border-bottom: 1px solid ${p => p.theme.border};
   gap: ${space(4)};
+  justify-content: space-between;
 `;
 
 const SummaryLeft = styled('div')`


### PR DESCRIPTION

before
<img width="714" height="243" alt="SCR-20250721-nbya" src="https://github.com/user-attachments/assets/3544063e-a606-4fed-8db9-c1fa3a1a2e61" />

after
<img width="721" height="267" alt="SCR-20250721-nbwx" src="https://github.com/user-attachments/assets/0b14a2f4-783b-4a2b-90ca-68f99c86bd16" />
