### PR TITLE
chore(nav-v2): remove nav v2 sidebar banner flag registration

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -185,7 +185,6 @@ def register_temporary_features(manager: FeatureManager):
     # Enable higher limit for workflows
     manager.add("organizations:more-workflows", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     manager.add("organizations:navigation-sidebar-v2", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    manager.add("organizations:navigation-sidebar-v2-banner", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:new-page-filter", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, default=True, api_expose=True)
     # Enable AI Agents specific insights
     manager.add("organizations:agents-insights", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)


### PR DESCRIPTION
Follows up https://github.com/getsentry/sentry/pull/95951 (removing references to the flag) and https://github.com/getsentry/sentry-options-automator/pull/4578 (removing the flag from flagpole), fully removes the registration for the navigation sidebar banner.