### PR TITLE
fix(aci milestone 3): correct ID for actions in data condition serializer

### DIFF
--- a/src/sentry/incidents/endpoints/serializers/workflow_engine_data_condition.py
+++ b/src/sentry/incidents/endpoints/serializers/workflow_engine_data_condition.py
@@ -60,7 +60,7 @@ class WorkflowEngineDataConditionSerializer(Serializer):
 
         action_filter_data_condition_group_action_ids = DataConditionGroupAction.objects.filter(
             condition_group_id__in=Subquery(action_filter_data_condition_groups)
-        ).values_list("id", flat=True)
+        ).values_list("action_id", flat=True)
 
         actions = Action.objects.filter(
             id__in=Subquery(action_filter_data_condition_group_action_ids)

--- a/tests/sentry/incidents/serializers/test_workflow_engine_base.py
+++ b/tests/sentry/incidents/serializers/test_workflow_engine_base.py
@@ -25,6 +25,10 @@ from sentry.workflow_engine.models.workflow_action_group_status import WorkflowA
 class TestWorkflowEngineSerializer(TestCase):
     @assume_test_silo_mode(SiloMode.REGION)
     def setUp(self) -> None:
+        # XXX: do this so that DCGA and Action IDs aren't one to one
+        other_action = self.create_action()
+        other_action.delete()
+
         self.now = timezone.now()
         self.alert_rule = self.create_alert_rule()
         self.critical_trigger = self.create_alert_rule_trigger(


### PR DESCRIPTION
We were erroneously fetching DCGA IDs instead of Action IDs.