### PR TITLE
:bug: fix(stateful detector): pass value correctly in stateful evidence data

### DIFF
--- a/src/sentry/incidents/grouptype.py
+++ b/src/sentry/incidents/grouptype.py
@@ -36,13 +36,13 @@ QUERY_AGGREGATION_DISPLAY = {
 }
 
 
-@dataclass
-class MetricIssueEvidenceData(EvidenceData[float]):
-    alert_id: int
-
-
 MetricUpdate = ProcessedSubscriptionUpdate | AnomalyDetectionUpdate
-MetricResult = int | dict
+MetricResult = float | dict
+
+
+@dataclass
+class MetricIssueEvidenceData(EvidenceData[MetricResult]):
+    alert_id: int
 
 
 class MetricIssueDetectorHandler(StatefulDetectorHandler[MetricUpdate, MetricResult]):

--- a/src/sentry/incidents/typings/metric_detector.py
+++ b/src/sentry/incidents/typings/metric_detector.py
@@ -215,7 +215,7 @@ class MetricIssueContext:
     snuba_query: SnubaQuery
     new_status: IncidentStatus
     subscription: QuerySubscription | None
-    metric_value: float | None
+    metric_value: float | dict | None
     group: Group | None
 
     @classmethod

--- a/src/sentry/workflow_engine/handlers/detector/stateful.py
+++ b/src/sentry/workflow_engine/handlers/detector/stateful.py
@@ -385,7 +385,7 @@ class StatefulDetectorHandler(
         self,
         condition_results: ProcessedDataConditionGroup,
         data_packet: DataPacket[DataPacketType],
-        data_value: DataPacketEvaluationType,
+        evaluation_value: DataPacketEvaluationType,
         group_key: DetectorGroupKey = None,
     ) -> StatusChangeMessage:
         fingerprint = [
@@ -396,9 +396,8 @@ class StatefulDetectorHandler(
         evidence_data = self._build_evidence_data(
             detector_occurrence=None,
             evaluation_result=condition_results,
-            new_priority=DetectorPriorityLevel.OK,
             data_packet=data_packet,
-            data_value=data_value,
+            evaluation_value=evaluation_value,
         )
 
         return StatusChangeMessage(
@@ -440,7 +439,7 @@ class StatefulDetectorHandler(
         new_priority: DetectorPriorityLevel,
         condition_results: ProcessedDataConditionGroup,
         data_packet: DataPacket[DataPacketType],
-        data_value: DataPacketEvaluationType,
+        evaluation_value: DataPacketEvaluationType,
     ) -> DetectorEvaluationResult:
         detector_result: IssueOccurrence | StatusChangeMessage
         event_data: EventData | None = None
@@ -450,7 +449,7 @@ class StatefulDetectorHandler(
             detector_result = self._create_resolve_message(
                 condition_results,
                 data_packet,
-                data_value,
+                evaluation_value,
                 group_key,
             )
         else:
@@ -464,7 +463,7 @@ class StatefulDetectorHandler(
                 condition_results,
                 new_priority,
                 group_key,
-                data_value,
+                evaluation_value,
             )
 
             # Set the event data with the necessary fields
@@ -515,9 +514,8 @@ class StatefulDetectorHandler(
         self,
         detector_occurrence: DetectorOccurrence | None,
         evaluation_result: ProcessedDataConditionGroup,
-        new_priority: DetectorPriorityLevel,
         data_packet: DataPacket[DataPacketType],
-        data_value: DataPacketEvaluationType,
+        evaluation_value: DataPacketEvaluationType,
     ) -> dict[str, Any]:
 
         evidence_data: dict[str, Any] = {}
@@ -528,7 +526,7 @@ class StatefulDetectorHandler(
         evidence_data.update(
             {
                 "detector_id": self.detector.id,
-                "value": data_value,
+                "value": evaluation_value,
                 "data_packet_source_id": str(data_packet.source_id),
                 "conditions": [
                     result.condition.get_snapshot()
@@ -554,7 +552,6 @@ class StatefulDetectorHandler(
         evidence_data = self._build_evidence_data(
             detector_occurrence,
             evaluation_result,
-            new_priority,
             data_packet,
             data_value,
         )

--- a/tests/sentry/incidents/test_metric_issue_detector_handler.py
+++ b/tests/sentry/incidents/test_metric_issue_detector_handler.py
@@ -20,7 +20,7 @@ class TestEvaluateMetricDetector(BaseMetricIssueTest):
     ):
         evidence_data = {
             "detector_id": self.detector.id,
-            "value": detector_trigger.condition_result,
+            "value": value,
             "alert_id": self.alert_rule.id,
             "data_packet_source_id": str(self.query_subscription.id),
             "conditions": [

--- a/tests/sentry/incidents/test_metric_issue_detector_handler.py
+++ b/tests/sentry/incidents/test_metric_issue_detector_handler.py
@@ -18,22 +18,18 @@ class TestEvaluateMetricDetector(BaseMetricIssueTest):
         detector_trigger: DataCondition,
         extra_trigger: DataCondition | None = None,
     ):
-        evidence_data = {
-            "detector_id": self.detector.id,
-            "value": value,
-            "alert_id": self.alert_rule.id,
-            "data_packet_source_id": str(self.query_subscription.id),
-            "conditions": [
-                {
-                    "id": detector_trigger.id,
-                    "type": detector_trigger.type,
-                    "comparison": detector_trigger.comparison,
-                    "condition_result": detector_trigger.condition_result.value,
-                },
-            ],
-        }
+
+        conditions = [
+            {
+                "id": detector_trigger.id,
+                "type": detector_trigger.type,
+                "comparison": detector_trigger.comparison,
+                "condition_result": detector_trigger.condition_result.value,
+            },
+        ]
+
         if extra_trigger:
-            evidence_data["conditions"].append(
+            conditions.append(
                 {
                     "id": extra_trigger.id,
                     "type": extra_trigger.type,
@@ -41,6 +37,15 @@ class TestEvaluateMetricDetector(BaseMetricIssueTest):
                     "condition_result": extra_trigger.condition_result.value,
                 }
             )
+
+        evidence_data = {
+            "detector_id": self.detector.id,
+            "value": value,
+            "alert_id": self.alert_rule.id,
+            "data_packet_source_id": str(self.query_subscription.id),
+            "conditions": conditions,
+        }
+
         return evidence_data
 
     def verify_issue_occurrence(

--- a/tests/sentry/notifications/notification_action/test_metric_alert_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_metric_alert_registry_handlers.py
@@ -225,7 +225,7 @@ class MetricAlertHandlerBase(BaseWorkflowTest):
         snuba_query: SnubaQuery,
         new_status: IncidentStatus,
         title: str,
-        metric_value: float | None = None,
+        metric_value: float | dict | None = None,
         subscription: QuerySubscription | None = None,
         group: Group | None = None,
     ):


### PR DESCRIPTION
Instead of passing the `DetectorPriorityLevel` again in the evidence data of the occurrence, we should actually pass the value that the detector evaluates.