### PR TITLE
feat(seer): Add button to open bulk onboarding wizard

### DIFF
--- a/static/app/views/settings/projectSeer/index.tsx
+++ b/static/app/views/settings/projectSeer/index.tsx
@@ -4,6 +4,7 @@ import {useQueryClient} from '@tanstack/react-query';
 
 import {hasEveryAccess} from 'sentry/components/acl/access';
 import FeatureDisabled from 'sentry/components/acl/featureDisabled';
+import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {Link} from 'sentry/components/core/link';
 import {useProjectSeerPreferences} from 'sentry/components/events/autofix/preferences/hooks/useProjectSeerPreferences';
 import {useUpdateProjectSeerPreferences} from 'sentry/components/events/autofix/preferences/hooks/useUpdateProjectSeerPreferences';
@@ -154,7 +155,7 @@ function ProjectSeerGeneralForm({project}: ProjectSeerProps) {
           {t('Automation')}
           <Subheading>
             {tct(
-              "Choose how Seer automatically triages and diagnoses incoming issues, before you even notice them. This analysis is billed at the [link:standard rates] for Seer's Issue Scan and Issue Fix. See [spendlink:docs] on how to manage your Seer spend. You can also [bulklink:configure automation for other projects].",
+              "Choose how Seer automatically triages and diagnoses incoming issues, before you even notice them. This analysis is billed at the [link:standard rates] for Seer's Issue Scan and Issue Fix. See [spendlink:docs] on how to manage your Seer spend.",
               {
                 link: (
                   <ExternalLink href={'https://docs.sentry.io/pricing/#seer-pricing'} />
@@ -270,6 +271,14 @@ function ProjectSeer({project}: ProjectSeerProps) {
         <ProjectSeerGeneralForm project={project} />
       )}
       <AutofixRepositories project={project} />
+      <Center>
+        <LinkButton
+          to={`/settings/${organization.slug}/seer/onboarding/`}
+          priority="primary"
+        >
+          {t('Set Up All Projects')}
+        </LinkButton>
+      </Center>
     </Fragment>
   );
 }
@@ -298,4 +307,10 @@ const Subheading = styled('div')`
   text-transform: none;
   margin-top: ${space(1)};
   line-height: 1.4;
+`;
+
+const Center = styled('div')`
+  display: flex;
+  justify-content: center;
+  margin-top: ${p => p.theme.space.lg};
 `;

--- a/static/app/views/settings/projectSeer/index.tsx
+++ b/static/app/views/settings/projectSeer/index.tsx
@@ -276,7 +276,7 @@ function ProjectSeer({project}: ProjectSeerProps) {
           to={`/settings/${organization.slug}/seer/onboarding/`}
           priority="primary"
         >
-          {t('Set Up All Projects')}
+          {t('Set up my other projects')}
         </LinkButton>
       </Center>
     </Fragment>


### PR DESCRIPTION
As the user works their way down the per-project settings page, they will come across a button that takes them directly to the setup wizard to configure all their projects at once. 

<img width="1209" height="833" alt="Screenshot 2025-07-21 at 3 53 26 PM" src="https://github.com/user-attachments/assets/3e081cef-798e-4aab-b404-cbdc60b3fba1" />
