### PR TITLE
ref(replay): clarify that empty chapters may contain context from console logs or network requests

### DIFF
--- a/static/app/views/replays/detail/ai/chapterList.tsx
+++ b/static/app/views/replays/detail/ai/chapterList.tsx
@@ -173,7 +173,11 @@ function ChapterRow({
       </Chapter>
       <div>
         {!breadcrumbs.length && (
-          <EmptyMessage>{t('No breadcrumbs for this chapter')}</EmptyMessage>
+          <EmptyMessage>
+            {t(
+              'No breadcrumbs for this chapter, but there may be console logs or network requests that occurred during this window.'
+            )}
+          </EmptyMessage>
         )}
         {breadcrumbs.map((breadcrumb, j) => (
           <ChapterBreadcrumbRow


### PR DESCRIPTION
in parallel, i'll work to discourage chapters that only contain context from network & console logs, to reduce the number of empty chapters

<img width="682" height="269" alt="SCR-20250721-oiil" src="https://github.com/user-attachments/assets/3e7c0f5b-0b26-47a2-98f3-e27a81621302" />
