### PR TITLE
fix(aci): Inline connect monitors in new automation page

### DIFF
--- a/static/app/views/automations/components/editConnectedMonitors.tsx
+++ b/static/app/views/automations/components/editConnectedMonitors.tsx
@@ -55,9 +55,11 @@ function SelectedMonitors({
 function AllMonitors({
   connectedIds,
   toggleConnected,
+  footerContent,
 }: {
   connectedIds: Automation['detectorIds'];
   toggleConnected: (params: {detector: Detector}) => void;
+  footerContent?: React.ReactNode;
 }) {
   const [query, setQuery] = useState('');
   const [cursor, setCursor] = useState<string | undefined>(undefined);
@@ -71,6 +73,7 @@ function AllMonitors({
     cursor,
     limit: 10,
   });
+
   return (
     <Section title={t('All Monitors')}>
       <DetectorSearch initialQuery={query} onSearch={setQuery} />
@@ -84,17 +87,25 @@ function AllMonitors({
         emptyMessage={t('No monitors found')}
         numSkeletons={10}
       />
-      <Pagination onCursor={setCursor} pageLinks={getResponseHeader?.('Link')} />
+      <Flex justify="space-between">
+        <div>{footerContent}</div>
+        <PaginationWithoutMargin
+          onCursor={setCursor}
+          pageLinks={getResponseHeader?.('Link')}
+        />
+      </Flex>
     </Section>
   );
 }
 
-function ConnectMonitorsDrawer({
+export function ConnectMonitorsContent({
   initialIds,
   saveConnectedIds,
+  footerContent,
 }: {
   initialIds: Automation['detectorIds'];
   saveConnectedIds: (ids: Automation['detectorIds']) => void;
+  footerContent?: React.ReactNode;
 }) {
   const organization = useOrganization();
   const queryClient = useQueryClient();
@@ -119,7 +130,7 @@ function ConnectMonitorsDrawer({
         : [...oldDetectorsData, detector]
     )
       // API will return ID ascending, so this avoids re-ordering
-      .toSorted((a, b) => a.id.localeCompare(b.id));
+      .toSorted((a, b) => Number(a.id) - Number(b.id));
     const newDetectorIds = newDetectors.map(d => d.id);
 
     // Update the query cache to prevent the list from being fetched anew
@@ -138,17 +149,18 @@ function ConnectMonitorsDrawer({
 
   return (
     <Fragment>
-      <DrawerHeader hideBar />
-      <DrawerContent>
-        {connectedIds.length > 0 && (
-          <SelectedMonitors
-            data-test-id="drawer-connected-monitors-list"
-            connectedIds={connectedIds}
-            toggleConnected={toggleConnected}
-          />
-        )}
-        <AllMonitors connectedIds={connectedIds} toggleConnected={toggleConnected} />
-      </DrawerContent>
+      {connectedIds.length > 0 && (
+        <SelectedMonitors
+          data-test-id="drawer-connected-monitors-list"
+          connectedIds={connectedIds}
+          toggleConnected={toggleConnected}
+        />
+      )}
+      <AllMonitors
+        connectedIds={connectedIds}
+        toggleConnected={toggleConnected}
+        footerContent={footerContent}
+      />
     </Fragment>
   );
 }
@@ -165,10 +177,15 @@ export default function EditConnectedMonitors({connectedIds, setConnectedIds}: P
 
     openDrawer(
       () => (
-        <ConnectMonitorsDrawer
-          initialIds={connectedIds}
-          saveConnectedIds={setConnectedIds}
-        />
+        <Fragment>
+          <DrawerHeader hideBar />
+          <DrawerContent>
+            <ConnectMonitorsContent
+              initialIds={connectedIds}
+              saveConnectedIds={setConnectedIds}
+            />
+          </DrawerContent>
+        </Fragment>
       ),
       {
         ariaLabel: t('Connect Monitors'),
@@ -227,4 +244,8 @@ const ButtonWrapper = styled(Flex)`
   border-top: 1px solid ${p => p.theme.border};
   padding: ${p => p.theme.space.xl};
   margin: -${p => p.theme.space.xl};
+`;
+
+const PaginationWithoutMargin = styled(Pagination)`
+  margin: ${p => p.theme.space.none};
 `;

--- a/static/app/views/automations/new.tsx
+++ b/static/app/views/automations/new.tsx
@@ -11,13 +11,15 @@ import {
   StickyFooterLabel,
 } from 'sentry/components/workflowEngine/ui/footer';
 import {useWorkflowEngineFeatureGate} from 'sentry/components/workflowEngine/useWorkflowEngineFeatureGate';
+import {IconAdd} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Automation} from 'sentry/types/workflowEngine/automations';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
-import EditConnectedMonitors from 'sentry/views/automations/components/editConnectedMonitors';
+import {ConnectMonitorsContent} from 'sentry/views/automations/components/editConnectedMonitors';
 import {makeAutomationBasePathname} from 'sentry/views/automations/pathnames';
+import {makeMonitorCreatePathname} from 'sentry/views/detectors/pathnames';
 
 function AutomationBreadcrumbs() {
   const organization = useOrganization();
@@ -61,9 +63,18 @@ export default function AutomationNew() {
         </StyledLayoutHeader>
         <Layout.Body>
           <Layout.Main fullWidth>
-            <EditConnectedMonitors
-              connectedIds={connectedIds}
-              setConnectedIds={setConnectedIds}
+            <ConnectMonitorsContent
+              initialIds={connectedIds}
+              saveConnectedIds={setConnectedIds}
+              footerContent={
+                <LinkButton
+                  icon={<IconAdd />}
+                  href={makeMonitorCreatePathname(organization.slug)}
+                  external
+                >
+                  {t('Create New Monitor')}
+                </LinkButton>
+              }
             />
           </Layout.Main>
         </Layout.Body>

--- a/static/app/views/detectors/list.tsx
+++ b/static/app/views/detectors/list.tsx
@@ -22,7 +22,7 @@ import DetectorListTable from 'sentry/views/detectors/components/detectorListTab
 import {DetectorSearch} from 'sentry/views/detectors/components/detectorSearch';
 import {DETECTOR_LIST_PAGE_LIMIT} from 'sentry/views/detectors/constants';
 import {useDetectorsQuery} from 'sentry/views/detectors/hooks';
-import {makeMonitorBasePathname} from 'sentry/views/detectors/pathnames';
+import {makeMonitorCreatePathname} from 'sentry/views/detectors/pathnames';
 
 export default function DetectorsList() {
   useWorkflowEngineFeatureGate({redirect: true});
@@ -123,7 +123,7 @@ function Actions() {
     <Fragment>
       <LinkButton
         to={{
-          pathname: `${makeMonitorBasePathname(organization.slug)}new/`,
+          pathname: makeMonitorCreatePathname(organization.slug),
           query: project ? {project} : undefined,
         }}
         priority="primary"

--- a/static/app/views/detectors/pathnames.tsx
+++ b/static/app/views/detectors/pathnames.tsx
@@ -5,5 +5,9 @@ export const makeMonitorBasePathname = (orgSlug: string) => {
 };
 
 export const makeMonitorDetailsPathname = (orgSlug: string, monitorId: string) => {
-  return normalizeUrl(`/organizations/${orgSlug}/issues/monitors/${monitorId}/`);
+  return normalizeUrl(`${makeMonitorBasePathname(orgSlug)}${monitorId}/`);
+};
+
+export const makeMonitorCreatePathname = (orgSlug: string) => {
+  return normalizeUrl(`${makeMonitorBasePathname(orgSlug)}new/`);
 };


### PR DESCRIPTION
Pretty simple change. Previously this was using the same component as the edit page, which opens this in a drawer. Since the designs want this inline, I'm rendering the content component here instead.

<img width="1038" height="891" alt="CleanShot 2025-07-21 at 16 17 34" src="https://github.com/user-attachments/assets/cafe01fc-b7f6-4c39-8333-aa0975d4a526" />
