### PR TITLE
fix(ecosystem): Always display external modal title

### DIFF
--- a/static/app/components/externalIssues/externalIssueForm.tsx
+++ b/static/app/components/externalIssues/externalIssueForm.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useMemo, useState} from 'react';
+import {Fragment, useCallback, useEffect, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import type {Span} from '@sentry/core';
 import * as Sentry from '@sentry/react';
@@ -310,7 +310,16 @@ export default function ExternalIssueForm({
   }, [formFields]);
 
   if (isPending) {
-    return <LoadingIndicator />;
+    return (
+      <Fragment>
+        <Header closeButton>
+          <h4>{title}</h4>
+        </Header>
+        <Body>
+          <LoadingIndicator />
+        </Body>
+      </Fragment>
+    );
   }
 
   if (isError) {
@@ -319,7 +328,16 @@ export default function ExternalIssueForm({
       typeof errorDetail === 'string'
         ? errorDetail
         : t('An error occurred loading the issue form');
-    return <LoadingError message={errorMessage} />;
+    return (
+      <Fragment>
+        <Header closeButton>
+          <h4>{title}</h4>
+        </Header>
+        <Body>
+          <LoadingError message={errorMessage} />
+        </Body>
+      </Fragment>
+    );
   }
 
   return (


### PR DESCRIPTION
Previously it did not display a title in the error or loading state making it hard to close.

before

<img width="621" height="155" alt="image" src="https://github.com/user-attachments/assets/949037ad-a3b8-4418-b62f-cc409f5e0a16" />


after

<img width="618" height="213" alt="image" src="https://github.com/user-attachments/assets/61f8a691-4ec2-46a3-8c3c-0cf16f81fca7" />
