### PR TITLE
ref(grouping): Add `with_grouping_configs` test helper

### DIFF
--- a/tests/sentry/grouping/test_grouphash_metadata.py
+++ b/tests/sentry/grouping/test_grouphash_metadata.py
@@ -43,7 +43,7 @@ dummy_project = Mock(id=11211231)
     set(CONFIGURATIONS.keys()) - {DEFAULT_GROUPING_CONFIG, NO_MSG_PARAM_CONFIG},
     ids=lambda config_name: config_name.replace("-", "_"),
 )
-def test_hash_basis_with_older_configs(
+def test_variants_with_manual_save(
     config_name: str,
     grouping_input: GroupingInput,
     insta_snapshot: InstaSnapshotter,

--- a/tests/sentry/grouping/test_grouphash_metadata.py
+++ b/tests/sentry/grouping/test_grouphash_metadata.py
@@ -3,9 +3,6 @@ from __future__ import annotations
 from typing import Any
 from unittest.mock import Mock, patch
 
-import pytest
-
-from sentry.conf.server import DEFAULT_GROUPING_CONFIG
 from sentry.eventstore.models import Event
 from sentry.grouping.component import DefaultGroupingComponent, MessageGroupingComponent
 from sentry.grouping.ingest.grouphash_metadata import (
@@ -23,12 +20,15 @@ from sentry.testutils.cases import TestCase
 from sentry.testutils.pytest.fixtures import InstaSnapshotter, django_db_all
 from sentry.utils import json
 from tests.sentry.grouping import (
+    FULL_PIPELINE_CONFIGS,
     GROUPING_INPUTS_DIR,
+    MANUAL_SAVE_CONFIGS,
     NO_MSG_PARAM_CONFIG,
     GroupingInput,
     dump_variant,
     get_snapshot_path,
     to_json,
+    with_grouping_configs,
     with_grouping_inputs,
 )
 
@@ -37,12 +37,7 @@ dummy_project = Mock(id=11211231)
 
 @django_db_all
 @with_grouping_inputs("grouping_input", GROUPING_INPUTS_DIR)
-@pytest.mark.parametrize(
-    "config_name",
-    # The default config is tested below, and NO_MSG_PARAM_CONFIG is only meant for use in unit tests
-    set(CONFIGURATIONS.keys()) - {DEFAULT_GROUPING_CONFIG, NO_MSG_PARAM_CONFIG},
-    ids=lambda config_name: config_name.replace("-", "_"),
-)
+@with_grouping_configs(MANUAL_SAVE_CONFIGS)
 def test_variants_with_manual_save(
     config_name: str,
     grouping_input: GroupingInput,
@@ -66,14 +61,7 @@ def test_variants_with_manual_save(
 
 @django_db_all
 @with_grouping_inputs("grouping_input", GROUPING_INPUTS_DIR)
-@pytest.mark.parametrize(
-    "config_name",
-    # Technically we don't need to parameterize this since there's only one option, but doing it
-    # this way makes snapshots from this test organize themselves neatly alongside snapshots from
-    # the test of the older configs above
-    {DEFAULT_GROUPING_CONFIG},
-    ids=lambda config_name: config_name.replace("-", "_"),
-)
+@with_grouping_configs(FULL_PIPELINE_CONFIGS)
 def test_variants_with_full_pipeline(
     config_name: str,
     grouping_input: GroupingInput,
@@ -97,12 +85,8 @@ def test_variants_with_full_pipeline(
 
 
 @django_db_all
-@pytest.mark.parametrize(
-    "config_name",
-    # NO_MSG_PARAM_CONFIG is only meant for use in unit tests
-    set(CONFIGURATIONS.keys()) - {NO_MSG_PARAM_CONFIG},
-    ids=lambda config_name: config_name.replace("-", "_"),
-)
+# NO_MSG_PARAM_CONFIG is only meant for use in unit tests
+@with_grouping_configs(set(CONFIGURATIONS.keys()) - {NO_MSG_PARAM_CONFIG})
 def test_unknown_hash_basis(
     config_name: str,
     insta_snapshot: InstaSnapshotter,

--- a/tests/sentry/grouping/test_grouphash_metadata.py
+++ b/tests/sentry/grouping/test_grouphash_metadata.py
@@ -74,7 +74,7 @@ def test_variants_with_manual_save(
     {DEFAULT_GROUPING_CONFIG},
     ids=lambda config_name: config_name.replace("-", "_"),
 )
-def test_hash_basis_with_current_default_config(
+def test_variants_with_full_pipeline(
     config_name: str,
     grouping_input: GroupingInput,
     insta_snapshot: InstaSnapshotter,

--- a/tests/sentry/grouping/test_variants.py
+++ b/tests/sentry/grouping/test_variants.py
@@ -32,7 +32,7 @@ from tests.sentry.grouping import (
     ids=lambda config_name: config_name.replace("-", "_"),
 )
 @patch("sentry.grouping.strategies.newstyle.logging.exception")
-def test_variants_with_older_configs(
+def test_variants_with_manual_save(
     mock_exception_logger: MagicMock,
     config_name: str,
     grouping_input: GroupingInput,

--- a/tests/sentry/grouping/test_variants.py
+++ b/tests/sentry/grouping/test_variants.py
@@ -66,7 +66,7 @@ def test_variants_with_manual_save(
     ids=lambda config_name: config_name.replace("-", "_"),
 )
 @patch("sentry.grouping.strategies.newstyle.logging.exception")
-def test_variants_with_current_default_config(
+def test_variants_with_full_pipeline(
     mock_exception_logger: MagicMock,
     config_name: str,
     grouping_input: GroupingInput,


### PR DESCRIPTION
This adds a new helper, `with_grouping_configs`, to our grouping snapshot tests. Soon, the `newstyle:2019-05-08` grouping config will be gone, and the default grouping config will be the only one. As it stands, when that happens the `test_variants_with_older_configs` tests in `test_variants.py` and `test_grouphash_metadata.py` will throw an error, because they'll be parameterizing over an empty set of older configs. 

To fix that, this adds the aforementioned helper, which will return a `pytest.mark.skip` rather than a `pytest.mark.parametrize` if the set of grouping configs it's given is empty.

