### PR TITLE
ref: remove unused warning ignores

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,9 +28,6 @@ filterwarnings = [
   # Consider all warnings to be errors other than the ignored ones.
   "error",
 
-  # this warning in protobuf causes a segfault in 3.12+ protocolbuffers/protobuf#15077
-  "ignore:Type google\\._upb.*",
-
   # TODO: we should fix these, but for now there's a lot
   "ignore:datetime.datetime.utcfromtimestamp\\(\\) is deprecated.*",
   "ignore:datetime.datetime.utcnow\\(\\) is deprecated.*",


### PR DESCRIPTION
protobuf is >= 5.27.0 which includes https://github.com/protocolbuffers/protobuf/commit/5b32936822e64b796fa18fcff53df2305c6b7686

<!-- Describe your PR here. -->