### PR TITLE
feat(agents-insights): get error count from span.status

### DIFF
--- a/static/app/views/insights/agentMonitoring/components/aiSpanList.tsx
+++ b/static/app/views/insights/agentMonitoring/components/aiSpanList.tsx
@@ -143,6 +143,7 @@ const TraceListItem = memo(function TraceListItem({
   onClick: () => void;
   traceBounds: TraceBounds;
 }) {
+  const hasErrors = hasError(node);
   const {icon, title, subtitle, color} = getNodeInfo(node, colors);
   const safeColor = color || colors[0] || '#9ca3af';
   const relativeTiming = calculateRelativeTiming(node, traceBounds);
@@ -150,7 +151,7 @@ const TraceListItem = memo(function TraceListItem({
 
   return (
     <ListItemContainer
-      hasErrors={node.errors.size > 0}
+      hasErrors={hasErrors}
       isSelected={isSelected}
       onClick={onClick}
       indent={indent}
@@ -303,12 +304,25 @@ function getNodeInfo(node: AITraceSpanNode, colors: readonly string[]) {
   }
 
   // Override the color and icon if the node has errors
-  if (node.errors.size > 0) {
+  if (hasError(node)) {
     nodeInfo.icon = <IconFire size="md" color="red300" />;
     nodeInfo.color = colors[6];
   }
 
   return nodeInfo;
+}
+
+function hasError(node: AITraceSpanNode) {
+  if (node.errors.size > 0) {
+    return true;
+  }
+
+  // spans with status unknown are errors
+  if (isEAPSpanNode(node)) {
+    return node.value.additional_attributes?.['span.status'] === 'unknown';
+  }
+
+  return false;
 }
 
 const TraceListContainer = styled('div')`

--- a/static/app/views/insights/agentMonitoring/components/tracesTable.tsx
+++ b/static/app/views/insights/agentMonitoring/components/tracesTable.tsx
@@ -202,9 +202,14 @@ export function TracesTable() {
       totalTokens: spanDataMap[span.trace]?.totalTokens ?? 0,
       totalCost: spanDataMap[span.trace]?.totalCost ?? null,
       timestamp: span.start,
-      isSpanDataLoading: spansRequest.isLoading,
+      isSpanDataLoading: spansRequest.isLoading || traceErrorRequest.isLoading,
     }));
-  }, [tracesRequest.data, spanDataMap, spansRequest.isLoading]);
+  }, [
+    tracesRequest.data,
+    spanDataMap,
+    spansRequest.isLoading,
+    traceErrorRequest.isLoading,
+  ]);
 
   const renderHeadCell = useCallback((column: GridColumnHeader<string>) => {
     return (

--- a/static/app/views/insights/agentMonitoring/components/tracesTable.tsx
+++ b/static/app/views/insights/agentMonitoring/components/tracesTable.tsx
@@ -26,6 +26,7 @@ import {
   AI_COST_ATTRIBUTE_SUM,
   AI_GENERATION_OPS,
   AI_TOKEN_USAGE_ATTRIBUTE_SUM,
+  AI_TOOL_CALL_OPS,
   getAgentRunsFilter,
   getAITracesFilter,
 } from 'sentry/views/insights/agentMonitoring/utils/query';
@@ -77,6 +78,10 @@ const rightAlignColumns = new Set([
 
 const GENERATION_COUNTS = AI_GENERATION_OPS.map(op => `count_if(span.op,${op})` as const);
 
+const AI_AGENT_SUB_OPS = [...AI_GENERATION_OPS, ...AI_TOOL_CALL_OPS].map(
+  op => `count_if(span.op,${op})` as const
+);
+
 export function TracesTable() {
   const navigate = useNavigate();
   const location = useLocation();
@@ -113,10 +118,34 @@ export function TracesTable() {
     Referrer.TRACES_TABLE
   );
 
+  const traceErrorRequest = useSpans(
+    {
+      // Get all generations and tool calls with status unknown
+      search: `span.status:unknown trace:[${tracesRequest.data?.data.map(span => span.trace).join(',')}]`,
+      fields: ['trace', ...AI_AGENT_SUB_OPS],
+      limit: tracesRequest.data?.data.length ?? 0,
+      enabled: Boolean(tracesRequest.data && tracesRequest.data.data.length > 0),
+    },
+    Referrer.TRACES_TABLE
+  );
+
   const spanDataMap = useMemo(() => {
-    if (!spansRequest.data) {
+    if (!spansRequest.data || !traceErrorRequest.data) {
       return {};
     }
+    // sum up the error spans for a trace
+    const errors = traceErrorRequest.data?.reduce(
+      (acc, span) => {
+        const sum = AI_AGENT_SUB_OPS.reduce(
+          (errorSum, key) => errorSum + (span[key] ?? 0),
+          0
+        );
+
+        acc[span.trace] = sum;
+        return acc;
+      },
+      {} as Record<string, number>
+    );
 
     return spansRequest.data.reduce(
       (acc, span) => {
@@ -128,15 +157,22 @@ export function TracesTable() {
           toolCalls: span['count_if(span.op,gen_ai.execute_tool)'] ?? 0,
           totalTokens: Number(span[AI_TOKEN_USAGE_ATTRIBUTE_SUM] ?? 0),
           totalCost: Number(span[AI_COST_ATTRIBUTE_SUM] ?? 0),
+          totalErrors: errors[span.trace] ?? 0,
         };
         return acc;
       },
       {} as Record<
         string,
-        {llmCalls: number; toolCalls: number; totalCost: number; totalTokens: number}
+        {
+          llmCalls: number;
+          toolCalls: number;
+          totalCost: number;
+          totalErrors: number;
+          totalTokens: number;
+        }
       >
     );
-  }, [spansRequest.data]);
+  }, [spansRequest.data, traceErrorRequest.data]);
 
   const handleCursor: CursorHandler = (cursor, pathname, previousQuery) => {
     navigate(
@@ -160,7 +196,7 @@ export function TracesTable() {
       traceId: span.trace,
       transaction: span.name ?? '',
       duration: span.duration,
-      errors: span.numErrors,
+      errors: spanDataMap[span.trace]?.totalErrors ?? 0,
       llmCalls: spanDataMap[span.trace]?.llmCalls ?? 0,
       toolCalls: spanDataMap[span.trace]?.toolCalls ?? 0,
       totalTokens: spanDataMap[span.trace]?.totalTokens ?? 0,
@@ -241,8 +277,8 @@ const BodyCell = memo(function BodyCell({
       );
     case 'duration':
       return <DurationCell milliseconds={dataRow.duration} />;
+    // return <NumberCell value={dataRow.errors} />;
     case 'errors':
-      return <NumberCell value={dataRow.errors} />;
     case 'llmCalls':
     case 'toolCalls':
     case 'totalTokens':

--- a/static/app/views/insights/agentMonitoring/components/tracesTable.tsx
+++ b/static/app/views/insights/agentMonitoring/components/tracesTable.tsx
@@ -277,7 +277,6 @@ const BodyCell = memo(function BodyCell({
       );
     case 'duration':
       return <DurationCell milliseconds={dataRow.duration} />;
-    // return <NumberCell value={dataRow.errors} />;
     case 'errors':
     case 'llmCalls':
     case 'toolCalls':

--- a/static/app/views/insights/agentMonitoring/hooks/useAITrace.tsx
+++ b/static/app/views/insights/agentMonitoring/hooks/useAITrace.tsx
@@ -51,6 +51,7 @@ export function useAITrace(traceSlug: string): UseAITraceResult {
       AI_TOTAL_TOKENS_ATTRIBUTE,
       AI_COST_ATTRIBUTE,
       AI_TOOL_NAME_ATTRIBUTE,
+      'span.status',
     ],
   });
 

--- a/static/app/views/insights/agentMonitoring/utils/query.tsx
+++ b/static/app/views/insights/agentMonitoring/utils/query.tsx
@@ -31,7 +31,7 @@ export const AI_GENERATION_OPS = [
 
 // AI Tool Calls - equivalent to OTEL Execute tool span
 // https://github.com/open-telemetry/semantic-conventions/blob/main/docs/gen-ai/gen-ai-spans.md#execute-tool-span
-const AI_TOOL_CALL_OPS = ['gen_ai.execute_tool'];
+export const AI_TOOL_CALL_OPS = ['gen_ai.execute_tool'];
 
 const AI_HANDOFF_OPS = ['gen_ai.handoff'];
 


### PR DESCRIPTION
Closes [TET-931: Count span.status:unknown as error](https://linear.app/getsentry/issue/TET-931/count-spanstatusunknown-as-error)

- Errors in traces table now show number of gen_ai spans that are not gen_ai.invoke_agent and that have status "unknown"
- Displays fire icon in the AI trace view if the span status is "unknown"
<img width="767" height="573" alt="image" src="https://github.com/user-attachments/assets/daae932a-5038-4ded-8534-f5660d668082" />
