### PR TITLE
Implement Attachments on top of the new blobstore Client API

### DIFF
--- a/src/sentry/api/endpoints/event_attachment_details.py
+++ b/src/sentry/api/endpoints/event_attachment_details.py
@@ -60,6 +60,9 @@ class EventAttachmentDetailsEndpoint(ProjectEndpoint):
         name = posixpath.basename(" ".join(attachment.name.split()))
 
         def stream_attachment():
+            # TODO: We should pass along the `Accept-Encoding`, so we can avoid
+            # decompressing on the API side, and just transfer the already
+            # compressed bytes to the client as it indicated it can handle it.
             with attachment.getfile() as fp:
                 while chunk := fp.read(4096):
                     yield chunk
@@ -68,6 +71,9 @@ class EventAttachmentDetailsEndpoint(ProjectEndpoint):
             stream_attachment(),
             content_type=attachment.content_type,
         )
+        # TODO(see above): response["Content-Encoding"] = compression
+        # Also, if we were to directly stream compressed data, the `Content-Length`
+        # has to refer to the compressed size, which we currently don’t save anywhere.
         response["Content-Length"] = attachment.size
         response["Content-Disposition"] = f'attachment; filename="{name}"'
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3449,3 +3449,6 @@ register(
     default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+# Whether the new objectstore implementation is being used for attachments
+register("objectstore.enable_for.attachments", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)


### PR DESCRIPTION
The new blobstore API in theory should offer the possibility to return a compressed stream directly, which we would then forward to clients unmodified.
This is however not properly implemented yet.

---

Builds on top of https://github.com/getsentry/sentry/pull/96076
REF FS-62