### PR TITLE
ref(analytics): refactor integrations analytics events to use new analytics event type

### DIFF
--- a/src/sentry/analytics/events/integration_commit_context_all_frames.py
+++ b/src/sentry/analytics/events/integration_commit_context_all_frames.py
@@ -5,7 +5,7 @@ from sentry import analytics
 class IntegrationsFailedToFetchCommitContextAllFrames(analytics.Event):
     organization_id: int
     project_id: int
-    group_id: str
+    group_id: int
     event_id: str
     num_frames: int
     num_successfully_mapped_frames: int
@@ -16,7 +16,7 @@ class IntegrationsFailedToFetchCommitContextAllFrames(analytics.Event):
 class IntegrationsSuccessfullyFetchedCommitContextAllFrames(analytics.Event):
     organization_id: int
     project_id: int
-    group_id: str
+    group_id: int
     event_id: str
     num_frames: int
     num_unique_commits: int

--- a/src/sentry/analytics/events/integration_commit_context_all_frames.py
+++ b/src/sentry/analytics/events/integration_commit_context_all_frames.py
@@ -1,36 +1,30 @@
 from sentry import analytics
 
 
+@analytics.eventclass("integrations.failed_to_fetch_commit_context_all_frames")
 class IntegrationsFailedToFetchCommitContextAllFrames(analytics.Event):
-    type = "integrations.failed_to_fetch_commit_context_all_frames"
-
-    attributes = (
-        analytics.Attribute("organization_id"),
-        analytics.Attribute("project_id"),
-        analytics.Attribute("group_id"),
-        analytics.Attribute("event_id"),
-        analytics.Attribute("num_frames", type=int),
-        analytics.Attribute("num_successfully_mapped_frames", type=int),
-        analytics.Attribute("reason"),
-    )
+    organization_id: int
+    project_id: int
+    group_id: str
+    event_id: str
+    num_frames: int
+    num_successfully_mapped_frames: int
+    reason: str
 
 
+@analytics.eventclass("integrations.successfully_fetched_commit_context_all_frames")
 class IntegrationsSuccessfullyFetchedCommitContextAllFrames(analytics.Event):
-    type = "integrations.successfully_fetched_commit_context_all_frames"
-
-    attributes = (
-        analytics.Attribute("organization_id"),
-        analytics.Attribute("project_id"),
-        analytics.Attribute("group_id"),
-        analytics.Attribute("event_id"),
-        analytics.Attribute("num_frames", type=int),
-        analytics.Attribute("num_unique_commits", type=int),
-        analytics.Attribute("num_unique_commit_authors", type=int),
-        analytics.Attribute("num_successfully_mapped_frames", type=int),
-        analytics.Attribute("selected_frame_index", type=int),
-        analytics.Attribute("selected_provider", type=str),
-        analytics.Attribute("selected_code_mapping_id"),
-    )
+    organization_id: int
+    project_id: int
+    group_id: str
+    event_id: str
+    num_frames: int
+    num_unique_commits: int
+    num_unique_commit_authors: int
+    num_successfully_mapped_frames: int
+    selected_frame_index: int | None
+    selected_provider: str | None
+    selected_code_mapping_id: int
 
 
 analytics.register(IntegrationsSuccessfullyFetchedCommitContextAllFrames)

--- a/src/sentry/analytics/events/integration_serverless_setup.py
+++ b/src/sentry/analytics/events/integration_serverless_setup.py
@@ -1,16 +1,13 @@
 from sentry import analytics
 
 
+@analytics.eventclass("integrations.serverless_setup")
 class IntegrationServerlessSetup(analytics.Event):
-    type = "integrations.serverless_setup"
-
-    attributes = (
-        analytics.Attribute("user_id"),
-        analytics.Attribute("organization_id"),
-        analytics.Attribute("integration"),
-        analytics.Attribute("success_count"),
-        analytics.Attribute("failure_count"),
-    )
+    user_id: int | None
+    organization_id: int
+    integration: str
+    success_count: int
+    failure_count: int
 
 
 analytics.register(IntegrationServerlessSetup)

--- a/src/sentry/analytics/events/open_pr_comment.py
+++ b/src/sentry/analytics/events/open_pr_comment.py
@@ -1,15 +1,12 @@
 from sentry import analytics
 
 
+@analytics.eventclass("open_pr_comment.created")
 class OpenPRCommentCreatedEvent(analytics.Event):
-    type = "open_pr_comment.created"
-
-    attributes = (
-        analytics.Attribute("comment_id"),
-        analytics.Attribute("org_id"),
-        analytics.Attribute("pr_id"),
-        analytics.Attribute("language"),
-    )
+    comment_id: int
+    org_id: str
+    pr_id: int
+    language: str
 
 
 analytics.register(OpenPRCommentCreatedEvent)

--- a/src/sentry/analytics/events/open_pr_comment.py
+++ b/src/sentry/analytics/events/open_pr_comment.py
@@ -4,7 +4,7 @@ from sentry import analytics
 @analytics.eventclass("open_pr_comment.created")
 class OpenPRCommentCreatedEvent(analytics.Event):
     comment_id: int
-    org_id: str
+    org_id: int
     pr_id: int
     language: str
 

--- a/src/sentry/analytics/events/webhook_repository_created.py
+++ b/src/sentry/analytics/events/webhook_repository_created.py
@@ -4,7 +4,7 @@ from sentry import analytics
 @analytics.eventclass("webhook.repository_created")
 class WebHookRepositoryCreatedEvent(analytics.Event):
     organization_id: int
-    repository_id: str
+    repository_id: int
     integration: str
 
 

--- a/src/sentry/analytics/events/webhook_repository_created.py
+++ b/src/sentry/analytics/events/webhook_repository_created.py
@@ -1,14 +1,11 @@
 from sentry import analytics
 
 
+@analytics.eventclass("webhook.repository_created")
 class WebHookRepositoryCreatedEvent(analytics.Event):
-    type = "webhook.repository_created"
-
-    attributes = (
-        analytics.Attribute("organization_id"),
-        analytics.Attribute("repository_id"),
-        analytics.Attribute("integration"),
-    )
+    organization_id: int
+    repository_id: str
+    integration: str
 
 
 analytics.register(WebHookRepositoryCreatedEvent)

--- a/src/sentry/integrations/analytics.py
+++ b/src/sentry/integrations/analytics.py
@@ -22,7 +22,7 @@ class IntegrationDisabledNotified(analytics.Event):
 @analytics.eventclass("integration.issue.created")
 class IntegrationIssueCreatedEvent(analytics.Event):
     provider: str
-    id: str
+    id: int
     organization_id: int
     user_id: int | None = None
     default_user_id: int
@@ -31,7 +31,7 @@ class IntegrationIssueCreatedEvent(analytics.Event):
 @analytics.eventclass("integration.issue.linked")
 class IntegrationIssueLinkedEvent(analytics.Event):
     provider: str
-    id: str
+    id: int
     organization_id: int
     user_id: int | None = None
     default_user_id: int
@@ -54,35 +54,35 @@ class IntegrationIssueAssigneeSyncedEvent(analytics.Event):
 @analytics.eventclass("integration.issue.comments.synced")
 class IntegrationIssueCommentsSyncedEvent(analytics.Event):
     provider: str
-    id: str
+    id: int
     organization_id: int
 
 
 @analytics.eventclass("integration.repo.added")
 class IntegrationRepoAddedEvent(analytics.Event):
     provider: str
-    id: str
+    id: int
     organization_id: int
 
 
 @analytics.eventclass("integration.resolve.commit")
 class IntegrationResolveCommitEvent(analytics.Event):
     provider: str | None
-    id: str
+    id: int
     organization_id: int
 
 
 @analytics.eventclass("integration.resolve.pr")
 class IntegrationResolvePREvent(analytics.Event):
     provider: str | None
-    id: str
+    id: int
     organization_id: int
 
 
 @analytics.eventclass("integration.stacktrace.linked")
 class IntegrationStacktraceLinkEvent(analytics.Event):
     provider: str
-    config_id: str
+    config_id: int
     project_id: int
     organization_id: int
     filepath: str

--- a/src/sentry/integrations/analytics.py
+++ b/src/sentry/integrations/analytics.py
@@ -61,7 +61,7 @@ class IntegrationIssueCommentsSyncedEvent(analytics.Event):
 @analytics.eventclass("integration.repo.added")
 class IntegrationRepoAddedEvent(analytics.Event):
     provider: str
-    id: int
+    id: int | None = None
     organization_id: int
 
 

--- a/src/sentry/integrations/analytics.py
+++ b/src/sentry/integrations/analytics.py
@@ -1,127 +1,94 @@
 from sentry import analytics
 
 
+@analytics.eventclass("integration.added")
 class IntegrationAddedEvent(analytics.Event):
-    type = "integration.added"
-
-    attributes = (
-        analytics.Attribute("provider"),
-        analytics.Attribute("id"),
-        analytics.Attribute("organization_id"),
-        analytics.Attribute("user_id", required=False),
-        analytics.Attribute("default_user_id"),
-    )
+    provider: str
+    id: int
+    organization_id: int
+    user_id: int | None = None
+    default_user_id: int
 
 
+@analytics.eventclass("integration.disabled.notified")
 class IntegrationDisabledNotified(analytics.Event):
-    type = "integration.disabled.notified"
-
-    attributes = (
-        analytics.Attribute("organization_id"),
-        analytics.Attribute("provider"),
-        analytics.Attribute("integration_type"),
-        analytics.Attribute("integration_id"),
-        analytics.Attribute("user_id", required=False),
-    )
+    organization_id: str
+    provider: str
+    integration_type: str
+    integration_id: str
+    user_id: str | None = None
 
 
+@analytics.eventclass("integration.issue.created")
 class IntegrationIssueCreatedEvent(analytics.Event):
-    type = "integration.issue.created"
-
-    attributes = (
-        analytics.Attribute("provider"),
-        analytics.Attribute("id"),
-        analytics.Attribute("organization_id"),
-        analytics.Attribute("user_id", required=False),
-        analytics.Attribute("default_user_id"),
-    )
+    provider: str
+    id: str
+    organization_id: str
+    user_id: str | None = None
+    default_user_id: str
 
 
+@analytics.eventclass("integration.issue.linked")
 class IntegrationIssueLinkedEvent(analytics.Event):
-    type = "integration.issue.linked"
-
-    attributes = (
-        analytics.Attribute("provider"),
-        analytics.Attribute("id"),
-        analytics.Attribute("organization_id"),
-        analytics.Attribute("user_id", required=False),
-        analytics.Attribute("default_user_id"),
-    )
+    provider: str
+    id: str
+    organization_id: str
+    user_id: str | None = None
+    default_user_id: str
 
 
+@analytics.eventclass("integration.issue.status.synced")
 class IntegrationIssueStatusSyncedEvent(analytics.Event):
-    type = "integration.issue.status.synced"
-
-    attributes = (
-        analytics.Attribute("provider"),
-        analytics.Attribute("id"),
-        analytics.Attribute("organization_id"),
-    )
+    provider: str
+    id: int
+    organization_id: str
 
 
+@analytics.eventclass("integration.issue.assignee.synced")
 class IntegrationIssueAssigneeSyncedEvent(analytics.Event):
-    type = "integration.issue.assignee.synced"
-
-    attributes = (
-        analytics.Attribute("provider"),
-        analytics.Attribute("id"),
-        analytics.Attribute("organization_id"),
-    )
+    provider: str
+    id: int
+    organization_id: str
 
 
+@analytics.eventclass("integration.issue.comments.synced")
 class IntegrationIssueCommentsSyncedEvent(analytics.Event):
-    type = "integration.issue.comments.synced"
-
-    attributes = (
-        analytics.Attribute("provider"),
-        analytics.Attribute("id"),
-        analytics.Attribute("organization_id"),
-    )
+    provider: str
+    id: str
+    organization_id: str
 
 
+@analytics.eventclass("integration.repo.added")
 class IntegrationRepoAddedEvent(analytics.Event):
-    type = "integration.repo.added"
-
-    attributes = (
-        analytics.Attribute("provider"),
-        analytics.Attribute("id"),
-        analytics.Attribute("organization_id"),
-    )
+    provider: str
+    id: str
+    organization_id: str
 
 
+@analytics.eventclass("integration.resolve.commit")
 class IntegrationResolveCommitEvent(analytics.Event):
-    type = "integration.resolve.commit"
-
-    attributes = (
-        analytics.Attribute("provider"),
-        analytics.Attribute("id"),
-        analytics.Attribute("organization_id"),
-    )
+    provider: str | None
+    id: str
+    organization_id: str
 
 
+@analytics.eventclass("integration.resolve.pr")
 class IntegrationResolvePREvent(analytics.Event):
-    type = "integration.resolve.pr"
-
-    attributes = (
-        analytics.Attribute("provider"),
-        analytics.Attribute("id"),
-        analytics.Attribute("organization_id"),
-    )
+    provider: str | None
+    id: str
+    organization_id: str
 
 
+@analytics.eventclass("integration.stacktrace.linked")
 class IntegrationStacktraceLinkEvent(analytics.Event):
-    type = "integration.stacktrace.linked"
-
-    attributes = (
-        analytics.Attribute("provider"),
-        analytics.Attribute("config_id"),
-        analytics.Attribute("project_id"),
-        analytics.Attribute("organization_id"),
-        analytics.Attribute("filepath"),
-        analytics.Attribute("status"),
-        analytics.Attribute("link_fetch_iterations"),
-        analytics.Attribute("platform", required=False),
-    )
+    provider: str
+    config_id: str
+    project_id: int
+    organization_id: str
+    filepath: str
+    status: str
+    link_fetch_iterations: int
+    platform: str | None = None
 
 
 def register_analytics() -> None:

--- a/src/sentry/integrations/analytics.py
+++ b/src/sentry/integrations/analytics.py
@@ -12,71 +12,71 @@ class IntegrationAddedEvent(analytics.Event):
 
 @analytics.eventclass("integration.disabled.notified")
 class IntegrationDisabledNotified(analytics.Event):
-    organization_id: str
+    organization_id: int
     provider: str
     integration_type: str
-    integration_id: str
-    user_id: str | None = None
+    integration_id: int
+    user_id: int | None = None
 
 
 @analytics.eventclass("integration.issue.created")
 class IntegrationIssueCreatedEvent(analytics.Event):
     provider: str
     id: str
-    organization_id: str
-    user_id: str | None = None
-    default_user_id: str
+    organization_id: int
+    user_id: int | None = None
+    default_user_id: int
 
 
 @analytics.eventclass("integration.issue.linked")
 class IntegrationIssueLinkedEvent(analytics.Event):
     provider: str
     id: str
-    organization_id: str
-    user_id: str | None = None
-    default_user_id: str
+    organization_id: int
+    user_id: int | None = None
+    default_user_id: int
 
 
 @analytics.eventclass("integration.issue.status.synced")
 class IntegrationIssueStatusSyncedEvent(analytics.Event):
     provider: str
     id: int
-    organization_id: str
+    organization_id: int
 
 
 @analytics.eventclass("integration.issue.assignee.synced")
 class IntegrationIssueAssigneeSyncedEvent(analytics.Event):
     provider: str
     id: int
-    organization_id: str
+    organization_id: int
 
 
 @analytics.eventclass("integration.issue.comments.synced")
 class IntegrationIssueCommentsSyncedEvent(analytics.Event):
     provider: str
     id: str
-    organization_id: str
+    organization_id: int
 
 
 @analytics.eventclass("integration.repo.added")
 class IntegrationRepoAddedEvent(analytics.Event):
     provider: str
     id: str
-    organization_id: str
+    organization_id: int
 
 
 @analytics.eventclass("integration.resolve.commit")
 class IntegrationResolveCommitEvent(analytics.Event):
     provider: str | None
     id: str
-    organization_id: str
+    organization_id: int
 
 
 @analytics.eventclass("integration.resolve.pr")
 class IntegrationResolvePREvent(analytics.Event):
     provider: str | None
     id: str
-    organization_id: str
+    organization_id: int
 
 
 @analytics.eventclass("integration.stacktrace.linked")
@@ -84,7 +84,7 @@ class IntegrationStacktraceLinkEvent(analytics.Event):
     provider: str
     config_id: str
     project_id: int
-    organization_id: str
+    organization_id: int
     filepath: str
     status: str
     link_fetch_iterations: int

--- a/src/sentry/integrations/aws_lambda/integration.py
+++ b/src/sentry/integrations/aws_lambda/integration.py
@@ -11,6 +11,7 @@ from django.http.response import HttpResponseBase
 from django.utils.translation import gettext_lazy as _
 
 from sentry import analytics, options
+from sentry.analytics.events.integration_serverless_setup import IntegrationServerlessSetup
 from sentry.integrations.base import (
     FeatureDescription,
     IntegrationData,
@@ -452,12 +453,13 @@ class AwsLambdaSetupLayerPipelineView:
                     )
 
         analytics.record(
-            "integrations.serverless_setup",
-            user_id=request.user.id,
-            organization_id=organization.id,
-            integration="aws_lambda",
-            success_count=success_count,
-            failure_count=len(failures),
+            IntegrationServerlessSetup(
+                user_id=request.user.id,
+                organization_id=organization.id,
+                integration="aws_lambda",
+                success_count=success_count,
+                failure_count=len(failures),
+            )
         )
 
         # if we have failures, show them to the user

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -17,6 +17,7 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 
 from sentry import analytics, options
+from sentry.analytics.events.webhook_repository_created import WebHookRepositoryCreatedEvent
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, all_silo_endpoint
@@ -140,10 +141,11 @@ class GitHubWebhook(SCMWebhook, ABC):
                         continue
 
                     analytics.record(
-                        "webhook.repository_created",
-                        organization_id=org.id,
-                        repository_id=repo.id,
-                        integration=IntegrationProviderSlug.GITHUB.value,
+                        WebHookRepositoryCreatedEvent(
+                            organization_id=org.id,
+                            repository_id=repo.id,
+                            integration=IntegrationProviderSlug.GITHUB.value,
+                        )
                     )
                     metrics.incr("github.webhook.repository_created")
 

--- a/src/sentry/integrations/source_code_management/commit_context.py
+++ b/src/sentry/integrations/source_code_management/commit_context.py
@@ -27,6 +27,7 @@ from snuba_sdk import (
 from snuba_sdk import Request as SnubaRequest
 
 from sentry import analytics
+from sentry.analytics.events.open_pr_comment import OpenPRCommentCreatedEvent
 from sentry.auth.exceptions import IdentityNotValid
 from sentry.integrations.gitlab.constants import GITLAB_CLOUD_BASE_URL
 from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
@@ -409,11 +410,12 @@ class CommitContextIntegration(ABC):
 
                 if comment_type == CommentType.OPEN_PR:
                     analytics.record(
-                        "open_pr_comment.created",
-                        comment_id=comment.id,
-                        org_id=repo.organization_id,
-                        pr_id=pr.id,
-                        language=(language or "not found"),
+                        OpenPRCommentCreatedEvent(
+                            comment_id=comment.id,
+                            org_id=repo.organization_id,
+                            pr_id=pr.id,
+                            language=(language or "not found"),
+                        )
                     )
             else:
                 resp = client.update_pr_comment(

--- a/src/sentry/integrations/tasks/create_comment.py
+++ b/src/sentry/integrations/tasks/create_comment.py
@@ -1,4 +1,5 @@
 from sentry import analytics
+from sentry.integrations.analytics import IntegrationIssueCommentsSyncedEvent
 from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.source_code_management.metrics import (
@@ -68,10 +69,9 @@ def create_comment(external_issue_id: int, user_id: int, group_note_id: int) -> 
         note.data["external_id"] = installation.get_comment_id(comment)
         note.save()
         analytics.record(
-            # TODO(lb): this should be changed and/or specified?
-            "integration.issue.comments.synced",
-            provider=installation.model.provider,
-            id=installation.model.id,
-            organization_id=external_issue.organization_id,
-            user_id=user_id,
+            IntegrationIssueCommentsSyncedEvent(
+                provider=installation.model.provider,
+                id=installation.model.id,
+                organization_id=external_issue.organization_id,
+            )
         )

--- a/src/sentry/integrations/tasks/sync_assignee_outbound.py
+++ b/src/sentry/integrations/tasks/sync_assignee_outbound.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from sentry import analytics, features
 from sentry.constants import ObjectStatus
+from sentry.integrations.analytics import IntegrationIssueAssigneeSyncedEvent
 from sentry.integrations.errors import OrganizationIntegrationNotFound
 from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.integrations.models.integration import Integration
@@ -98,10 +99,11 @@ def sync_assignee_outbound(
                     external_issue, user, assign=assign, assignment_source=parsed_assignment_source
                 )
                 analytics.record(
-                    "integration.issue.assignee.synced",
-                    provider=integration.provider,
-                    id=integration.id,
-                    organization_id=external_issue.organization_id,
+                    IntegrationIssueAssigneeSyncedEvent(
+                        provider=integration.provider,
+                        id=integration.id,
+                        organization_id=external_issue.organization_id,
+                    )
                 )
         except (
             OrganizationIntegrationNotFound,

--- a/src/sentry/integrations/tasks/sync_status_outbound.py
+++ b/src/sentry/integrations/tasks/sync_status_outbound.py
@@ -1,6 +1,7 @@
 from sentry import analytics, features
 from sentry.constants import ObjectStatus
 from sentry.exceptions import InvalidIdentity
+from sentry.integrations.analytics import IntegrationIssueStatusSyncedEvent
 from sentry.integrations.base import IntegrationInstallation
 from sentry.integrations.errors import OrganizationIntegrationNotFound
 from sentry.integrations.models.external_issue import ExternalIssue
@@ -84,10 +85,11 @@ def sync_status_outbound(group_id: int, external_issue_id: int) -> bool | None:
                 )
 
                 analytics.record(
-                    "integration.issue.status.synced",
-                    provider=integration.provider,
-                    id=integration.id,
-                    organization_id=external_issue.organization_id,
+                    IntegrationIssueStatusSyncedEvent(
+                        provider=integration.provider,
+                        id=integration.id,
+                        organization_id=external_issue.organization_id,
+                    )
                 )
         except (
             IntegrationFormError,

--- a/src/sentry/integrations/tasks/update_comment.py
+++ b/src/sentry/integrations/tasks/update_comment.py
@@ -1,4 +1,5 @@
 from sentry import analytics
+from sentry.integrations.analytics import IntegrationIssueCommentsSyncedEvent
 from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.source_code_management.metrics import (
@@ -68,10 +69,9 @@ def update_comment(external_issue_id: int, user_id: int, group_note_id: int) -> 
         )
         installation.update_comment(external_issue.key, user_id, note)
         analytics.record(
-            # TODO(lb): this should be changed and/or specified?
-            "integration.issue.comments.synced",
-            provider=installation.model.provider,
-            id=installation.model.id,
-            organization_id=external_issue.organization_id,
-            user_id=user_id,
+            IntegrationIssueCommentsSyncedEvent(
+                provider=installation.model.provider,
+                id=installation.model.id,
+                organization_id=external_issue.organization_id,
+            )
         )

--- a/src/sentry/integrations/utils/commit_context.py
+++ b/src/sentry/integrations/utils/commit_context.py
@@ -9,6 +9,10 @@ from typing import Any
 from django.utils.datastructures import OrderedSet
 
 from sentry import analytics
+from sentry.analytics.events.integration_commit_context_all_frames import (
+    IntegrationsFailedToFetchCommitContextAllFrames,
+    IntegrationsSuccessfullyFetchedCommitContextAllFrames,
+)
 from sentry.constants import ObjectStatus
 from sentry.integrations.base import IntegrationInstallation
 from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
@@ -362,14 +366,15 @@ def _record_commit_context_all_frames_analytics(
             },
         )
         analytics.record(
-            "integrations.failed_to_fetch_commit_context_all_frames",
-            organization_id=organization_id,
-            project_id=project_id,
-            group_id=extra["group"],
-            event_id=extra["event"],
-            num_frames=len(frames),
-            num_successfully_mapped_frames=num_successfully_mapped_frames,
-            reason=reason,
+            IntegrationsFailedToFetchCommitContextAllFrames(
+                organization_id=organization_id,
+                project_id=project_id,
+                group_id=extra["group"],
+                event_id=extra["event"],
+                num_frames=len(frames),
+                num_successfully_mapped_frames=num_successfully_mapped_frames,
+                reason=reason,
+            )
         )
         return
 
@@ -392,18 +397,19 @@ def _record_commit_context_all_frames_analytics(
     )
 
     analytics.record(
-        "integrations.successfully_fetched_commit_context_all_frames",
-        organization_id=organization_id,
-        project_id=project_id,
-        group_id=extra["group"],
-        event_id=extra["event"],
-        num_frames=len(frames),
-        num_unique_commits=len(unique_commit_ids),
-        num_unique_commit_authors=len(unique_author_emails),
-        num_successfully_mapped_frames=num_successfully_mapped_frames,
-        selected_frame_index=selected_frame_index,
-        selected_provider=selected_provider,
-        selected_code_mapping_id=selected_blame.code_mapping.id,
+        IntegrationsSuccessfullyFetchedCommitContextAllFrames(
+            organization_id=organization_id,
+            project_id=project_id,
+            group_id=extra["group"],
+            event_id=extra["event"],
+            num_frames=len(frames),
+            num_unique_commits=len(unique_commit_ids),
+            num_unique_commit_authors=len(unique_author_emails),
+            num_successfully_mapped_frames=num_successfully_mapped_frames,
+            selected_frame_index=selected_frame_index,
+            selected_provider=selected_provider,
+            selected_code_mapping_id=selected_blame.code_mapping.id,
+        )
     )
 
 

--- a/src/sentry/issues/endpoints/project_stacktrace_link.py
+++ b/src/sentry/issues/endpoints/project_stacktrace_link.py
@@ -14,6 +14,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.serializers import serialize
+from sentry.integrations.analytics import IntegrationStacktraceLinkEvent
 from sentry.integrations.api.serializers.models.integration import IntegrationSerializer
 from sentry.integrations.base import IntegrationFeatures
 from sentry.integrations.services.integration import integration_service
@@ -175,15 +176,16 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):
 
         if result["current_config"] and serialized_config:
             analytics.record(
-                "integration.stacktrace.linked",
-                provider=serialized_config["provider"]["key"],
-                config_id=serialized_config["id"],
-                project_id=project.id,
-                organization_id=project.organization_id,
-                filepath=filepath,
-                status=error or "success",
-                link_fetch_iterations=result["iteration_count"],
-                platform=ctx["platform"],
+                IntegrationStacktraceLinkEvent(
+                    provider=serialized_config["provider"]["key"],
+                    config_id=serialized_config["id"],
+                    project_id=project.id,
+                    organization_id=project.organization_id,
+                    filepath=filepath,
+                    status=error or "success",
+                    link_fetch_iterations=result["iteration_count"],
+                    platform=ctx["platform"],
+                )
             )
             return Response(
                 {

--- a/src/sentry/plugins/providers/integration_repository.py
+++ b/src/sentry/plugins/providers/integration_repository.py
@@ -12,6 +12,7 @@ from rest_framework.response import Response
 from sentry import analytics
 from sentry.api.exceptions import SentryAPIException
 from sentry.constants import ObjectStatus
+from sentry.integrations.analytics import IntegrationRepoAddedEvent
 from sentry.integrations.base import IntegrationInstallation
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.services.integration import integration_service
@@ -307,10 +308,11 @@ class IntegrationRepositoryProvider:
         repo_linked.send_robust(repo=repo, user=request.user, sender=self.__class__)
 
         analytics.record(
-            "integration.repo.added",
-            provider=self.id,
-            id=result.get("integration_id"),
-            organization_id=organization.id,
+            IntegrationRepoAddedEvent(
+                provider=self.id,
+                id=result.get("integration_id"),
+                organization_id=organization.id,
+            )
         )
         return Response(
             repository_service.serialize_repository(

--- a/src/sentry/receivers/features.py
+++ b/src/sentry/receivers/features.py
@@ -4,6 +4,11 @@ from django.db.models.signals import post_save
 
 from sentry import analytics
 from sentry.adoption import manager
+from sentry.integrations.analytics import (
+    IntegrationAddedEvent,
+    IntegrationIssueCreatedEvent,
+    IntegrationIssueLinkedEvent,
+)
 from sentry.integrations.services.integration import integration_service
 from sentry.models.featureadoption import FeatureAdoption
 from sentry.models.group import Group
@@ -643,12 +648,13 @@ def record_integration_added(
         default_user_id = organization.get_default_owner().id
 
     analytics.record(
-        "integration.added",
-        user_id=user_id,
-        default_user_id=default_user_id,
-        organization_id=organization.id,
-        provider=integration.provider,
-        id=integration.id,
+        IntegrationAddedEvent(
+            user_id=user_id,
+            default_user_id=default_user_id,
+            organization_id=organization.id,
+            provider=integration.provider,
+            id=integration.id,
+        )
     )
     metrics.incr(
         "integration.added",
@@ -665,12 +671,13 @@ def record_integration_issue_created(integration, organization, user, **kwargs):
         user_id = None
         default_user_id = organization.get_default_owner().id
     analytics.record(
-        "integration.issue.created",
-        user_id=user_id,
-        default_user_id=default_user_id,
-        organization_id=organization.id,
-        provider=integration.provider,
-        id=integration.id,
+        IntegrationIssueCreatedEvent(
+            user_id=user_id,
+            default_user_id=default_user_id,
+            organization_id=organization.id,
+            provider=integration.provider,
+            id=integration.id,
+        )
     )
 
 
@@ -682,12 +689,13 @@ def record_integration_issue_linked(integration, organization, user, **kwargs):
         user_id = None
         default_user_id = organization.get_default_owner().id
     analytics.record(
-        "integration.issue.linked",
-        user_id=user_id,
-        default_user_id=default_user_id,
-        organization_id=organization.id,
-        provider=integration.provider,
-        id=integration.id,
+        IntegrationIssueLinkedEvent(
+            user_id=user_id,
+            default_user_id=default_user_id,
+            organization_id=organization.id,
+            provider=integration.provider,
+            id=integration.id,
+        )
     )
 
 

--- a/src/sentry/receivers/releases.py
+++ b/src/sentry/receivers/releases.py
@@ -6,6 +6,7 @@ from django.utils import timezone
 
 from sentry import analytics
 from sentry.db.postgres.transactions import in_test_hide_transaction_boundary
+from sentry.integrations.analytics import IntegrationResolveCommitEvent, IntegrationResolvePREvent
 from sentry.models.activity import Activity
 from sentry.models.commit import Commit
 from sentry.models.group import Group, GroupStatus
@@ -176,10 +177,11 @@ def resolved_in_commit(instance: Commit, created, **kwargs):
             if repo is not None:
                 if repo.integration_id is not None:
                     analytics.record(
-                        "integration.resolve.commit",
-                        provider=repo.provider,
-                        id=repo.integration_id,
-                        organization_id=repo.organization_id,
+                        IntegrationResolveCommitEvent(
+                            provider=repo.provider,
+                            id=repo.integration_id,
+                            organization_id=repo.organization_id,
+                        )
                     )
 
                 issue_resolved.send_robust(
@@ -251,10 +253,11 @@ def resolved_in_pull_request(instance: PullRequest, created, **kwargs):
         else:
             if repo is not None and repo.integration_id is not None:
                 analytics.record(
-                    "integration.resolve.pr",
-                    provider=repo.provider,
-                    id=repo.integration_id,
-                    organization_id=repo.organization_id,
+                    IntegrationResolvePREvent(
+                        provider=repo.provider,
+                        id=repo.integration_id,
+                        organization_id=repo.organization_id,
+                    )
                 )
 
 

--- a/src/sentry/tasks/commit_context.py
+++ b/src/sentry/tasks/commit_context.py
@@ -10,6 +10,9 @@ from django.utils import timezone as django_timezone
 from sentry_sdk import set_tag
 
 from sentry import analytics
+from sentry.analytics.events.integration_commit_context_all_frames import (
+    IntegrationsFailedToFetchCommitContextAllFrames,
+)
 from sentry.api.serializers.models.release import get_users_for_authors
 from sentry.integrations.source_code_management.commit_context import CommitContextIntegration
 from sentry.integrations.utils.commit_context import (
@@ -121,14 +124,15 @@ def process_commit_context(
                     sdk_name=sdk_name,
                 )
                 analytics.record(
-                    "integrations.failed_to_fetch_commit_context_all_frames",
-                    organization_id=project.organization_id,
-                    project_id=project_id,
-                    group_id=basic_logging_details["group"],
-                    event_id=basic_logging_details["event"],
-                    num_frames=0,
-                    num_successfully_mapped_frames=0,
-                    reason="could_not_find_in_app_stacktrace_frame",
+                    IntegrationsFailedToFetchCommitContextAllFrames(
+                        organization_id=project.organization_id,
+                        project_id=project_id,
+                        group_id=basic_logging_details["group"],
+                        event_id=basic_logging_details["event"],
+                        num_frames=0,
+                        num_successfully_mapped_frames=0,
+                        reason="could_not_find_in_app_stacktrace_frame",
+                    )
                 )
 
                 return

--- a/tests/sentry/integrations/github/tasks/test_open_pr_comment.py
+++ b/tests/sentry/integrations/github/tasks/test_open_pr_comment.py
@@ -6,6 +6,7 @@ import pytest
 import responses
 from django.utils import timezone
 
+from sentry.analytics.events.open_pr_comment import OpenPRCommentCreatedEvent
 from sentry.constants import ObjectStatus
 from sentry.integrations.github.integration import GitHubIntegration, GitHubIntegrationProvider
 from sentry.integrations.github.tasks.open_pr_comment import open_pr_comment_workflow
@@ -20,6 +21,7 @@ from sentry.models.group import Group, GroupStatus
 from sentry.models.pullrequest import CommentType, PullRequest, PullRequestComment
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.testutils.cases import IntegrationTestCase, TestCase
+from sentry.testutils.helpers.analytics import assert_any_analytics_event
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.integrations import get_installation_of_type
@@ -1036,12 +1038,14 @@ class TestOpenPRCommentWorkflow(IntegrationTestCase, CreateEventTestCase):
         assert comment.comment_type == CommentType.OPEN_PR
 
         mock_metrics.incr.assert_called_with("github.open_pr_comment.comment_created")
-        mock_analytics.assert_any_call(
-            "open_pr_comment.created",
-            comment_id=comment.id,
-            org_id=self.organization.id,
-            pr_id=comment.pull_request.id,
-            language="python",
+        assert_any_analytics_event(
+            mock_analytics,
+            OpenPRCommentCreatedEvent(
+                comment_id=comment.id,
+                org_id=self.organization.id,
+                pr_id=comment.pull_request.id,
+                language="python",
+            ),
         )
 
     @responses.activate

--- a/tests/sentry/integrations/gitlab/tasks/test_open_pr_comment.py
+++ b/tests/sentry/integrations/gitlab/tasks/test_open_pr_comment.py
@@ -4,6 +4,7 @@ import pytest
 import responses
 from django.utils import timezone
 
+from sentry.analytics.events.open_pr_comment import OpenPRCommentCreatedEvent
 from sentry.integrations.source_code_management.commit_context import (
     OPEN_PR_MAX_FILES_CHANGED,
     OPEN_PR_MAX_LINES_CHANGED,
@@ -15,6 +16,7 @@ from sentry.models.group import Group
 from sentry.models.pullrequest import CommentType, PullRequestComment
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.testutils.asserts import assert_slo_metric
+from sentry.testutils.helpers.analytics import assert_any_analytics_event
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.skips import requires_snuba
 from sentry.utils import json
@@ -444,12 +446,14 @@ Your merge request is modifying functions with the following pre-existing issues
         )
         assert mock_task_metrics.mock_calls == []
         assert mock_integration_metrics.mock_calls == []
-        mock_analytics.assert_any_call(
-            "open_pr_comment.created",
-            comment_id=comment.id,
-            org_id=self.organization.id,
-            pr_id=comment.pull_request.id,
-            language="python",
+        assert_any_analytics_event(
+            mock_analytics,
+            OpenPRCommentCreatedEvent(
+                comment_id=comment.id,
+                org_id=self.organization.id,
+                pr_id=comment.pull_request.id,
+                language="python",
+            ),
         )
 
     @responses.activate

--- a/tests/sentry/receivers/test_onboarding.py
+++ b/tests/sentry/receivers/test_onboarding.py
@@ -14,6 +14,7 @@ from sentry.analytics.events.first_replay_sent import FirstReplaySentEvent
 from sentry.analytics.events.first_transaction_sent import FirstTransactionSentEvent
 from sentry.analytics.events.member_invited import MemberInvitedEvent
 from sentry.analytics.events.project_transferred import ProjectTransferredEvent
+from sentry.integrations.analytics import IntegrationAddedEvent
 from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.organizationonboardingtask import (
     OnboardingTask,
@@ -761,13 +762,15 @@ class OrganizationOnboardingTaskTest(TestCase):
         )
         assert task is not None
 
-        record_analytics.assert_called_with(
-            "integration.added",
-            user_id=self.user.id,
-            default_user_id=self.organization.default_owner_id,
-            organization_id=self.organization.id,
-            id=integration_id,
-            provider="slack",
+        assert_last_analytics_event(
+            record_analytics,
+            IntegrationAddedEvent(
+                user_id=self.user.id,
+                default_user_id=self.organization.default_owner_id,
+                organization_id=self.organization.id,
+                id=integration_id,
+                provider="slack",
+            ),
         )
 
     @patch("sentry.analytics.record", wraps=record)
@@ -786,13 +789,15 @@ class OrganizationOnboardingTaskTest(TestCase):
         )
         assert task is not None
 
-        record_analytics.assert_called_with(
-            "integration.added",
-            user_id=self.user.id,
-            default_user_id=self.organization.default_owner_id,
-            organization_id=self.organization.id,
-            id=integration_id,
-            provider="github",
+        assert_last_analytics_event(
+            record_analytics,
+            IntegrationAddedEvent(
+                user_id=self.user.id,
+                default_user_id=self.organization.default_owner_id,
+                organization_id=self.organization.id,
+                id=integration_id,
+                provider="github",
+            ),
         )
 
     def test_second_platform_complete(self):
@@ -1004,13 +1009,15 @@ class OrganizationOnboardingTaskTest(TestCase):
             )
             is not None
         )
-        record_analytics.assert_called_with(
-            "integration.added",
-            user_id=self.user.id,
-            default_user_id=self.organization.default_owner_id,
-            organization_id=self.organization.id,
-            provider=github_integration.provider,
-            id=github_integration.id,
+        assert_last_analytics_event(
+            record_analytics,
+            IntegrationAddedEvent(
+                user_id=self.user.id,
+                default_user_id=self.organization.default_owner_id,
+                organization_id=self.organization.id,
+                provider=github_integration.provider,
+                id=github_integration.id,
+            ),
         )
 
         # Invite your team
@@ -1085,13 +1092,15 @@ class OrganizationOnboardingTaskTest(TestCase):
             )
             is not None
         )
-        record_analytics.assert_called_with(
-            "integration.added",
-            user_id=self.user.id,
-            default_user_id=self.organization.default_owner_id,
-            organization_id=self.organization.id,
-            provider=slack_integration.provider,
-            id=slack_integration.id,
+        assert_last_analytics_event(
+            record_analytics,
+            IntegrationAddedEvent(
+                user_id=self.user.id,
+                default_user_id=self.organization.default_owner_id,
+                organization_id=self.organization.id,
+                provider=slack_integration.provider,
+                id=slack_integration.id,
+            ),
         )
         # Add Sentry to other parts app
         second_project = self.create_project(

--- a/tests/sentry/tasks/test_commit_context.py
+++ b/tests/sentry/tasks/test_commit_context.py
@@ -529,15 +529,17 @@ class TestCommitContextAllFrames(TestCommitContextIntegration):
             sdk_name="sentry.python",
         )
 
-        mock_record.assert_any_call(
-            "integrations.failed_to_fetch_commit_context_all_frames",
-            organization_id=self.organization.id,
-            project_id=self.project.id,
-            group_id=self.event.group_id,
-            event_id=self.event.event_id,
-            num_frames=1,
-            num_successfully_mapped_frames=1,
-            reason="no_commit_found",
+        assert_any_analytics_event(
+            mock_record,
+            IntegrationsFailedToFetchCommitContextAllFrames(
+                organization_id=self.organization.id,
+                project_id=self.project.id,
+                group_id=self.event.group_id,
+                event_id=self.event.event_id,
+                num_frames=1,
+                num_successfully_mapped_frames=1,
+                reason="no_commit_found",
+            ),
         )
 
         mock_logger_info.assert_any_call(
@@ -588,15 +590,17 @@ class TestCommitContextAllFrames(TestCommitContextIntegration):
             sdk_name="sentry.python",
         )
 
-        mock_record.assert_any_call(
-            "integrations.failed_to_fetch_commit_context_all_frames",
-            organization_id=self.organization.id,
-            project_id=self.project.id,
-            group_id=self.event.group_id,
-            event_id=self.event.event_id,
-            num_frames=1,
-            num_successfully_mapped_frames=1,
-            reason="commit_too_old",
+        assert_any_analytics_event(
+            mock_record,
+            IntegrationsFailedToFetchCommitContextAllFrames(
+                organization_id=self.organization.id,
+                project_id=self.project.id,
+                group_id=self.event.group_id,
+                event_id=self.event.event_id,
+                num_frames=1,
+                num_successfully_mapped_frames=1,
+                reason="commit_too_old",
+            ),
         )
 
         mock_logger_info.assert_any_call(

--- a/tests/sentry/tasks/test_commit_context.py
+++ b/tests/sentry/tasks/test_commit_context.py
@@ -8,6 +8,10 @@ import responses
 from celery.exceptions import Retry
 from django.utils import timezone
 
+from sentry.analytics.events.integration_commit_context_all_frames import (
+    IntegrationsFailedToFetchCommitContextAllFrames,
+    IntegrationsSuccessfullyFetchedCommitContextAllFrames,
+)
 from sentry.constants import ObjectStatus
 from sentry.integrations.github.integration import GitHubIntegrationProvider
 from sentry.integrations.services.integration import integration_service
@@ -35,6 +39,7 @@ from sentry.silo.base import SiloMode
 from sentry.tasks.commit_context import PR_COMMENT_WINDOW, process_commit_context
 from sentry.testutils.asserts import assert_halt_metric
 from sentry.testutils.cases import IntegrationTestCase, TestCase
+from sentry.testutils.helpers.analytics import assert_any_analytics_event
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
@@ -240,19 +245,21 @@ class TestCommitContextAllFrames(TestCommitContextIntegration):
         assert created_group_owner
         assert created_group_owner.context == {"commitId": existing_commit.id}
 
-        mock_record.assert_any_call(
-            "integrations.successfully_fetched_commit_context_all_frames",
-            organization_id=self.organization.id,
-            project_id=self.project.id,
-            group_id=self.event.group_id,
-            event_id=self.event.event_id,
-            num_frames=1,
-            num_unique_commits=1,
-            num_unique_commit_authors=1,
-            num_successfully_mapped_frames=1,
-            selected_frame_index=0,
-            selected_provider="github",
-            selected_code_mapping_id=self.code_mapping.id,
+        assert_any_analytics_event(
+            mock_record,
+            IntegrationsSuccessfullyFetchedCommitContextAllFrames(
+                organization_id=self.organization.id,
+                project_id=self.project.id,
+                group_id=self.event.group_id,
+                event_id=self.event.event_id,
+                num_frames=1,
+                num_unique_commits=1,
+                num_unique_commit_authors=1,
+                num_successfully_mapped_frames=1,
+                selected_frame_index=0,
+                selected_provider="github",
+                selected_code_mapping_id=self.code_mapping.id,
+            ),
         )
 
     @patch("sentry.analytics.record")
@@ -473,15 +480,17 @@ class TestCommitContextAllFrames(TestCommitContextIntegration):
             sdk_name="sentry.python",
         )
 
-        mock_record.assert_any_call(
-            "integrations.failed_to_fetch_commit_context_all_frames",
-            organization_id=self.organization.id,
-            project_id=self.project.id,
-            group_id=self.event.group_id,
-            event_id=self.event.event_id,
-            num_frames=0,
-            num_successfully_mapped_frames=0,
-            reason="could_not_find_in_app_stacktrace_frame",
+        assert_any_analytics_event(
+            mock_record,
+            IntegrationsFailedToFetchCommitContextAllFrames(
+                organization_id=self.organization.id,
+                project_id=self.project.id,
+                group_id=self.event.group_id,
+                event_id=self.event.event_id,
+                num_frames=0,
+                num_successfully_mapped_frames=0,
+                reason="could_not_find_in_app_stacktrace_frame",
+            ),
         )
 
     @patch("sentry.integrations.utils.commit_context.logger.info")
@@ -817,21 +826,23 @@ class TestCommitContextAllFrames(TestCommitContextIntegration):
                 "organization": self.organization.id,
             },
         )
-        mock_record.assert_any_call(
-            "integrations.successfully_fetched_commit_context_all_frames",
-            organization_id=self.organization.id,
-            project_id=self.project.id,
-            group_id=self.event.group_id,
-            event_id=self.event.event_id,
-            # 1 was a duplicate, 2 filtered out because of missing properties
-            num_frames=2,
-            num_unique_commits=1,
-            num_unique_commit_authors=1,
-            # Only 1 successfully mapped frame of the 6 total
-            num_successfully_mapped_frames=1,
-            selected_frame_index=0,
-            selected_provider="github",
-            selected_code_mapping_id=self.code_mapping.id,
+        assert_any_analytics_event(
+            mock_record,
+            IntegrationsSuccessfullyFetchedCommitContextAllFrames(
+                organization_id=self.organization.id,
+                project_id=self.project.id,
+                group_id=self.event.group_id,
+                event_id=self.event.event_id,
+                # 1 was a duplicate, 2 filtered out because of missing properties
+                num_frames=2,
+                num_unique_commits=1,
+                num_unique_commit_authors=1,
+                # Only 1 successfully mapped frame of the 6 total
+                num_successfully_mapped_frames=1,
+                selected_frame_index=0,
+                selected_provider="github",
+                selected_code_mapping_id=self.code_mapping.id,
+            ),
         )
 
 


### PR DESCRIPTION
- Part of the split-up PR https://github.com/getsentry/sentry/pull/95209 to make it easier to review
- Transform event classes to use @analytics.eventclass decorator
- Transform analytics.record calls to use event class instances
- Update imports as needed

Contributes to TET-829