### PR TITLE
fix(setup-wizard): Only show teams with admin role for project creation

### DIFF
--- a/static/app/views/setupWizard/wizardProjectSelection.tsx
+++ b/static/app/views/setupWizard/wizardProjectSelection.tsx
@@ -98,9 +98,6 @@ export function WizardProjectSelection({
     if (orgDetailsRequest.data?.access.includes('org:admin')) {
       return teamsRequest.data;
     }
-    if (orgDetailsRequest.data?.allowMemberProjectCreation) {
-      return teamsRequest.data?.filter(team => team.isMember);
-    }
     return teamsRequest.data?.filter(team => team.teamRole === 'admin');
   }, [orgDetailsRequest.data, teamsRequest.data]);
 


### PR DESCRIPTION
This PR fixes a bug where the SDK setup wizard view would show teams in the team selection menu where users didn't have permissions to create a project. 

Specifically, the team selection menu was populated by 3 criteria:
1. User was an admin in the org ✅ 
2. The user's selected org had the "Members can create projects" option turned on and the user had "member" status in the team in question ❌ 
3. The user had "admin" status in the team in question ✅ 

Apparently, criterion 2 is incorrect because even if the "Members can create project" option is turned on for the org, this only applies to org-level members. Within a team, the user still needed "Admin" access.

In the main Sentry UI, we work around this by allowing users who are not part of any team where they're a team admin to simply create a project. Then, Sentry creates a new team for the user where they're a team admin (e.g. `#team-lukasstracke`). Long-term, we likely want the same behaviour in the wizard view. 

For now though, my fix removes criterion 2 from the selector so that users can only create new projects in:
- any team if they're org-level admins
- otherwise, all teams they're team-level admins in