### PR TITLE
ref: remove LPQ backend code

### DIFF
--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -644,10 +644,6 @@ class ProjectWithTeamSerializer(ProjectSerializer):
         return {**base, **extra, "teams": attrs["teams"]}
 
 
-class EventProcessingDict(TypedDict):
-    symbolicationDegraded: bool
-
-
 class LatestReleaseDict(TypedDict):
     version: str
 
@@ -662,7 +658,6 @@ class OrganizationProjectResponse(
 ):
     team: TeamResponseDict | None
     teams: list[TeamResponseDict]
-    eventProcessing: EventProcessingDict
     platforms: list[str]
     hasUserReports: bool
     environments: list[str]
@@ -751,11 +746,6 @@ class ProjectSummarySerializer(ProjectWithTeamSerializer):
             attrs[item]["has_user_reports"] = item.id in projects_with_user_reports
             if not self._collapse(LATEST_DEPLOYS_KEY):
                 attrs[item]["deploys"] = deploys_by_project.get(item.id)
-            # TODO: remove this attribute and evenrything connected with it
-            # check if the project is in LPQ for any platform
-            # XXX(joshferge): determine if the frontend needs this flag at all
-            # removing redis call as was causing problematic latency issues
-            attrs[item]["symbolication_degraded"] = False
 
         return attrs
 
@@ -778,9 +768,6 @@ class ProjectSummarySerializer(ProjectWithTeamSerializer):
             hasAccess=attrs["has_access"],
             dateCreated=obj.date_added,
             environments=attrs["environments"],
-            eventProcessing={
-                "symbolicationDegraded": attrs["symbolication_degraded"],
-            },
             features=attrs["features"],
             firstEvent=obj.first_event,
             firstTransactionEvent=bool(obj.flags.has_transactions),
@@ -951,7 +938,6 @@ class DetailedProjectResponse(ProjectWithTeamResponseDict):
     relayPiiConfig: str | None
     builtinSymbolSources: list[str]
     dynamicSamplingBiases: list[dict[str, str | bool]]
-    eventProcessing: dict[str, bool]
     symbolSources: str
     isDynamicallySampled: bool
     tempestFetchScreenshots: NotRequired[bool]
@@ -1098,9 +1084,6 @@ class DetailedProjectSerializer(ProjectWithTeamSerializer):
             "dynamicSamplingBiases": self.get_value_with_default(
                 attrs, "sentry:dynamic_sampling_biases"
             ),
-            "eventProcessing": {
-                "symbolicationDegraded": False,
-            },
             "symbolSources": serialized_sources,
             "isDynamicallySampled": sample_rate is not None and sample_rate < 1.0,
             "autofixAutomationTuning": self.get_value_with_default(

--- a/src/sentry/apidocs/examples/organization_examples.py
+++ b/src/sentry/apidocs/examples/organization_examples.py
@@ -367,7 +367,6 @@ class OrganizationExamples:
                         "hasAccess": True,
                         "dateCreated": "2019-06-17T18:56:25.777769Z",
                         "environments": [],
-                        "eventProcessing": {"symbolicationDegraded": False},
                         "features": ["releases"],
                         "firstEvent": None,
                         "firstTransactionEvent": False,
@@ -432,7 +431,6 @@ class OrganizationExamples:
                         }
                     ],
                     "environments": ["local"],
-                    "eventProcessing": {"symbolicationDegraded": False},
                     "features": ["releases"],
                     "firstTransactionEvent": True,
                     "hasSessions": True,

--- a/src/sentry/apidocs/examples/project_examples.py
+++ b/src/sentry/apidocs/examples/project_examples.py
@@ -257,7 +257,6 @@ DETAILED_PROJECT = {
         {"id": "boostReplayId", "active": True},
         {"id": "recalibrationRule", "active": True},
     ],
-    "eventProcessing": {"symbolicationDegraded": False},
     "symbolSources": "[]",
     "tempestFetchScreenshots": False,
     "tempestFetchDumps": False,
@@ -305,7 +304,6 @@ PROJECT_SUMMARY = {
     "hasAccess": True,
     "dateCreated": "2023-03-29T15:25:21.344565Z",
     "environments": ["production"],
-    "eventProcessing": {"symbolicationDegraded": False},
     "features": [
         "alert-filters",
         "custom-inbound-filters",


### PR DESCRIPTION
Removes remaining backend code that was used for LPQ notification. LPQ was removed some time ago and this code is no longer needed.
Frontend changes have been done in a different PR: https://github.com/getsentry/sentry/pull/94952