### PR TITLE
ref(db): Stop using legacy create_or_update in collect_project_platforms

### DIFF
--- a/src/sentry/tasks/collect_project_platforms.py
+++ b/src/sentry/tasks/collect_project_platforms.py
@@ -55,8 +55,8 @@ def collect_project_platforms(paginate=1000, **kwargs):
             platform = platform.lower()
             if platform not in VALID_PLATFORMS:
                 continue
-            ProjectPlatform.objects.create_or_update(
-                project_id=project_id, platform=platform, values={"last_seen": now}
+            ProjectPlatform.objects.update_or_create(
+                project_id=project_id, platform=platform, defaults={"last_seen": now}
             )
 
     # remove (likely) unused platform associations


### PR DESCRIPTION
On over 40 places we are still using our custom `create_or_update` method. This PR refactors the code in one of them and uses `update_or_create` method provided by Django ORM instead of our custom one.
