### PR TITLE
ref(db): Stop usign legacy create_or_update in GitHubAppsRepositoryProvider

### DIFF
--- a/src/sentry_plugins/github/plugin.py
+++ b/src/sentry_plugins/github/plugin.py
@@ -470,12 +470,12 @@ class GitHubAppsRepositoryProvider(GitHubRepositoryProvider):
 
         for repo in self.get_repositories(integration):
             # TODO(jess): figure out way to migrate from github --> github apps
-            Repository.objects.create_or_update(
+            Repository.objects.update_or_create(
                 organization_id=organization.id,
                 name=repo["name"],
                 external_id=repo["external_id"],
                 provider="github_apps",
-                values={
+                defaults={
                     "integration_id": integration.id,
                     "url": repo["url"],
                     "config": repo["config"],


### PR DESCRIPTION
On over 40 places we are still using our custom `create_or_update` method. This PR refactors the code in one of them and uses `update_or_create` method provided by Django ORM instead of our custom one.
