### PR TITLE
ref(analytics): refactor onboarding analytics events to use new analytics event type

### DIFF
--- a/src/sentry/analytics/events/first_cron_checkin_sent.py
+++ b/src/sentry/analytics/events/first_cron_checkin_sent.py
@@ -3,9 +3,9 @@ from sentry import analytics
 
 @analytics.eventclass("first_cron_checkin.sent")
 class FirstCronCheckinSent(analytics.Event):
-    organization_id: str
-    project_id: str
-    monitor_id: str
+    organization_id: int
+    project_id: int
+    monitor_id: int
     user_id: int | None = None
 
 

--- a/src/sentry/analytics/events/first_cron_checkin_sent.py
+++ b/src/sentry/analytics/events/first_cron_checkin_sent.py
@@ -1,15 +1,12 @@
 from sentry import analytics
 
 
+@analytics.eventclass("first_cron_checkin.sent")
 class FirstCronCheckinSent(analytics.Event):
-    type = "first_cron_checkin.sent"
-
-    attributes = (
-        analytics.Attribute("organization_id"),
-        analytics.Attribute("project_id"),
-        analytics.Attribute("monitor_id"),
-        analytics.Attribute("user_id", required=False),
-    )
+    organization_id: str
+    project_id: str
+    monitor_id: str
+    user_id: int | None = None
 
 
 analytics.register(FirstCronCheckinSent)

--- a/src/sentry/analytics/events/first_feedback_sent.py
+++ b/src/sentry/analytics/events/first_feedback_sent.py
@@ -1,15 +1,12 @@
 from sentry import analytics
 
 
+@analytics.eventclass("first_feedback.sent")
 class FirstFeedbackSentEvent(analytics.Event):
-    type = "first_feedback.sent"
-
-    attributes = (
-        analytics.Attribute("organization_id"),
-        analytics.Attribute("project_id"),
-        analytics.Attribute("platform", required=False),
-        analytics.Attribute("user_id", required=False),
-    )
+    organization_id: str
+    project_id: str
+    platform: str | None = None
+    user_id: int | None = None
 
 
 analytics.register(FirstFeedbackSentEvent)

--- a/src/sentry/analytics/events/first_feedback_sent.py
+++ b/src/sentry/analytics/events/first_feedback_sent.py
@@ -3,8 +3,8 @@ from sentry import analytics
 
 @analytics.eventclass("first_feedback.sent")
 class FirstFeedbackSentEvent(analytics.Event):
-    organization_id: str
-    project_id: str
+    organization_id: int
+    project_id: int
     platform: str | None = None
     user_id: int | None = None
 

--- a/src/sentry/analytics/events/first_flag_sent.py
+++ b/src/sentry/analytics/events/first_flag_sent.py
@@ -3,7 +3,7 @@ from sentry import analytics
 
 @analytics.eventclass("first_flag.sent")
 class FirstFlagSentEvent(analytics.Event):
-    organization_id: str
+    organization_id: int
     project_id: int
     platform: str | None = None
 

--- a/src/sentry/analytics/events/first_flag_sent.py
+++ b/src/sentry/analytics/events/first_flag_sent.py
@@ -1,14 +1,11 @@
 from sentry import analytics
 
 
+@analytics.eventclass("first_flag.sent")
 class FirstFlagSentEvent(analytics.Event):
-    type = "first_flag.sent"
-
-    attributes = (
-        analytics.Attribute("organization_id"),
-        analytics.Attribute("project_id"),
-        analytics.Attribute("platform", required=False),
-    )
+    organization_id: str
+    project_id: int
+    platform: str | None = None
 
 
 analytics.register(FirstFlagSentEvent)

--- a/src/sentry/analytics/events/first_insight_span_sent.py
+++ b/src/sentry/analytics/events/first_insight_span_sent.py
@@ -1,16 +1,13 @@
 from sentry import analytics
 
 
+@analytics.eventclass("first_insight_span.sent")
 class FirstInsightSpanSentEvent(analytics.Event):
-    type = "first_insight_span.sent"
-
-    attributes = (
-        analytics.Attribute("organization_id"),
-        analytics.Attribute("user_id"),
-        analytics.Attribute("project_id"),
-        analytics.Attribute("module"),
-        analytics.Attribute("platform", required=False),
-    )
+    organization_id: str
+    user_id: int | None
+    project_id: str
+    module: str
+    platform: str | None = None
 
 
 analytics.register(FirstInsightSpanSentEvent)

--- a/src/sentry/analytics/events/first_insight_span_sent.py
+++ b/src/sentry/analytics/events/first_insight_span_sent.py
@@ -3,9 +3,9 @@ from sentry import analytics
 
 @analytics.eventclass("first_insight_span.sent")
 class FirstInsightSpanSentEvent(analytics.Event):
-    organization_id: str
+    organization_id: int
     user_id: int | None
-    project_id: str
+    project_id: int
     module: str
     platform: str | None = None
 

--- a/src/sentry/analytics/events/first_release_tag_sent.py
+++ b/src/sentry/analytics/events/first_release_tag_sent.py
@@ -4,8 +4,8 @@ from sentry import analytics
 @analytics.eventclass("first_release_tag.sent")
 class FirstReleaseTagSentEvent(analytics.Event):
     user_id: int
-    organization_id: str
-    project_id: str
+    organization_id: int
+    project_id: int
 
 
 analytics.register(FirstReleaseTagSentEvent)

--- a/src/sentry/analytics/events/first_release_tag_sent.py
+++ b/src/sentry/analytics/events/first_release_tag_sent.py
@@ -1,14 +1,11 @@
 from sentry import analytics
 
 
+@analytics.eventclass("first_release_tag.sent")
 class FirstReleaseTagSentEvent(analytics.Event):
-    type = "first_release_tag.sent"
-
-    attributes = (
-        analytics.Attribute("user_id"),
-        analytics.Attribute("organization_id"),
-        analytics.Attribute("project_id"),
-    )
+    user_id: int
+    organization_id: str
+    project_id: str
 
 
 analytics.register(FirstReleaseTagSentEvent)

--- a/src/sentry/analytics/events/first_replay_sent.py
+++ b/src/sentry/analytics/events/first_replay_sent.py
@@ -1,15 +1,12 @@
 from sentry import analytics
 
 
+@analytics.eventclass("first_replay.sent")
 class FirstReplaySentEvent(analytics.Event):
-    type = "first_replay.sent"
-
-    attributes = (
-        analytics.Attribute("organization_id"),
-        analytics.Attribute("project_id"),
-        analytics.Attribute("platform", required=False),
-        analytics.Attribute("user_id", required=False),
-    )
+    organization_id: str
+    project_id: int
+    platform: str | None = None
+    user_id: int | None = None
 
 
 analytics.register(FirstReplaySentEvent)

--- a/src/sentry/analytics/events/first_replay_sent.py
+++ b/src/sentry/analytics/events/first_replay_sent.py
@@ -3,7 +3,7 @@ from sentry import analytics
 
 @analytics.eventclass("first_replay.sent")
 class FirstReplaySentEvent(analytics.Event):
-    organization_id: str
+    organization_id: int
     project_id: int
     platform: str | None = None
     user_id: int | None = None

--- a/src/sentry/analytics/events/first_transaction_sent.py
+++ b/src/sentry/analytics/events/first_transaction_sent.py
@@ -1,15 +1,12 @@
 from sentry import analytics
 
 
+@analytics.eventclass("first_transaction.sent")
 class FirstTransactionSentEvent(analytics.Event):
-    type = "first_transaction.sent"
-
-    attributes = (
-        analytics.Attribute("organization_id"),
-        analytics.Attribute("project_id"),
-        analytics.Attribute("platform", required=False),
-        analytics.Attribute("default_user_id", required=False),
-    )
+    organization_id: str
+    project_id: int
+    platform: str | None = None
+    default_user_id: int | None = None
 
 
 analytics.register(FirstTransactionSentEvent)

--- a/src/sentry/analytics/events/first_transaction_sent.py
+++ b/src/sentry/analytics/events/first_transaction_sent.py
@@ -3,7 +3,7 @@ from sentry import analytics
 
 @analytics.eventclass("first_transaction.sent")
 class FirstTransactionSentEvent(analytics.Event):
-    organization_id: str
+    organization_id: int
     project_id: int
     platform: str | None = None
     default_user_id: int | None = None

--- a/src/sentry/analytics/events/member_invited.py
+++ b/src/sentry/analytics/events/member_invited.py
@@ -1,15 +1,12 @@
 from sentry import analytics
 
 
+@analytics.eventclass("member.invited")
 class MemberInvitedEvent(analytics.Event):
-    type = "member.invited"
-
-    attributes = (
-        analytics.Attribute("inviter_user_id"),
-        analytics.Attribute("invited_member_id"),
-        analytics.Attribute("organization_id"),
-        analytics.Attribute("referrer", required=False),
-    )
+    inviter_user_id: int | None
+    invited_member_id: int
+    organization_id: str
+    referrer: str | None = None
 
 
 analytics.register(MemberInvitedEvent)

--- a/src/sentry/analytics/events/member_invited.py
+++ b/src/sentry/analytics/events/member_invited.py
@@ -5,7 +5,7 @@ from sentry import analytics
 class MemberInvitedEvent(analytics.Event):
     inviter_user_id: int | None
     invited_member_id: int
-    organization_id: str
+    organization_id: int
     referrer: str | None = None
 
 

--- a/src/sentry/analytics/events/onboarding_continuation_sent.py
+++ b/src/sentry/analytics/events/onboarding_continuation_sent.py
@@ -1,14 +1,11 @@
 from sentry import analytics
 
 
+@analytics.eventclass("onboarding_continuation.sent")
 class OnboardingContinuationSent(analytics.Event):
-    type = "onboarding_continuation.sent"
-
-    attributes = (
-        analytics.Attribute("user_id"),
-        analytics.Attribute("organization_id"),
-        analytics.Attribute("providers"),
-    )
+    user_id: int
+    organization_id: int
+    providers: str
 
 
 analytics.register(OnboardingContinuationSent)

--- a/src/sentry/analytics/events/project_transferred.py
+++ b/src/sentry/analytics/events/project_transferred.py
@@ -1,15 +1,12 @@
 from sentry import analytics
 
 
+@analytics.eventclass("project.transferred")
 class ProjectTransferredEvent(analytics.Event):
-    type = "project.transferred"
-
-    attributes = (
-        analytics.Attribute("old_organization_id"),
-        analytics.Attribute("new_organization_id"),
-        analytics.Attribute("project_id"),
-        analytics.Attribute("platform", required=False),
-    )
+    old_organization_id: int
+    new_organization_id: int
+    project_id: int
+    platform: str | None = None
 
 
 analytics.register(ProjectTransferredEvent)

--- a/src/sentry/analytics/events/second_platform_added.py
+++ b/src/sentry/analytics/events/second_platform_added.py
@@ -1,15 +1,12 @@
 from sentry import analytics
 
 
+@analytics.eventclass("second_platform.added")
 class SecondPlatformAddedEvent(analytics.Event):
-    type = "second_platform.added"
-
-    attributes = (
-        analytics.Attribute("user_id"),
-        analytics.Attribute("organization_id"),
-        analytics.Attribute("project_id"),
-        analytics.Attribute("platform", required=False),
-    )
+    user_id: str
+    organization_id: str
+    project_id: str
+    platform: str | None = None
 
 
 analytics.register(SecondPlatformAddedEvent)

--- a/src/sentry/analytics/events/second_platform_added.py
+++ b/src/sentry/analytics/events/second_platform_added.py
@@ -3,9 +3,9 @@ from sentry import analytics
 
 @analytics.eventclass("second_platform.added")
 class SecondPlatformAddedEvent(analytics.Event):
-    user_id: str
-    organization_id: str
-    project_id: str
+    user_id: int
+    organization_id: int
+    project_id: int
     platform: str | None = None
 
 

--- a/src/sentry/api/endpoints/organization_onboarding_continuation_email.py
+++ b/src/sentry/api/endpoints/organization_onboarding_continuation_email.py
@@ -3,6 +3,7 @@ from rest_framework import serializers
 from rest_framework.request import Request
 
 from sentry import analytics
+from sentry.analytics.events.onboarding_continuation_sent import OnboardingContinuationSent
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
@@ -64,9 +65,10 @@ class OrganizationOnboardingContinuationEmail(OrganizationEndpoint):
         )
         msg.send_async([request.user.email])
         analytics.record(
-            "onboarding_continuation.sent",
-            organization_id=organization.id,
-            user_id=request.user.id,
-            providers="email",
+            OnboardingContinuationSent(
+                organization_id=organization.id,
+                user_id=request.user.id,
+                providers="email",
+            )
         )
         return self.respond(status=202)

--- a/src/sentry/receivers/onboarding.py
+++ b/src/sentry/receivers/onboarding.py
@@ -13,6 +13,7 @@ from sentry.analytics.events.first_event_sent import (
     FirstEventSentForProjectEvent,
 )
 from sentry.analytics.events.first_insight_span_sent import FirstInsightSpanSentEvent
+from sentry.analytics.events.first_profile_sent import FirstProfileSentEvent
 from sentry.analytics.events.first_replay_sent import FirstReplaySentEvent
 from sentry.analytics.events.first_transaction_sent import FirstTransactionSentEvent
 from sentry.analytics.events.member_invited import MemberInvitedEvent
@@ -197,11 +198,12 @@ def record_first_transaction(project, event, **kwargs):
 @first_profile_received.connect(weak=False, dispatch_uid="onboarding.record_first_profile")
 def record_first_profile(project, **kwargs):
     analytics.record(
-        "first_profile.sent",
-        user_id=get_owner_id(project),
-        organization_id=project.organization_id,
-        project_id=project.id,
-        platform=project.platform,
+        FirstProfileSentEvent(
+            user_id=get_owner_id(project),
+            organization_id=project.organization_id,
+            project_id=project.id,
+            platform=project.platform,
+        )
     )
 
 

--- a/src/sentry/receivers/onboarding.py
+++ b/src/sentry/receivers/onboarding.py
@@ -7,11 +7,17 @@ import sentry_sdk
 from django.db.models import F
 
 from sentry import analytics
+from sentry.analytics.events.first_cron_checkin_sent import FirstCronCheckinSent
 from sentry.analytics.events.first_event_sent import (
     FirstEventSentEvent,
     FirstEventSentForProjectEvent,
 )
-from sentry.analytics.events.first_profile_sent import FirstProfileSentEvent
+from sentry.analytics.events.first_insight_span_sent import FirstInsightSpanSentEvent
+from sentry.analytics.events.first_replay_sent import FirstReplaySentEvent
+from sentry.analytics.events.first_transaction_sent import FirstTransactionSentEvent
+from sentry.analytics.events.member_invited import MemberInvitedEvent
+from sentry.analytics.events.project_transferred import ProjectTransferredEvent
+from sentry.analytics.events.second_platform_added import SecondPlatformAddedEvent
 from sentry.integrations.base import IntegrationDomain, get_integration_types
 from sentry.integrations.services.integration import RpcIntegration, integration_service
 from sentry.models.organization import Organization
@@ -119,10 +125,11 @@ def record_new_project(project, user=None, user_id=None, origin=None, **kwargs):
             project_id=project.id,
         )
         analytics.record(
-            "second_platform.added",
-            user_id=default_user_id,
-            organization_id=project.organization_id,
-            project_id=project.id,
+            SecondPlatformAddedEvent(
+                user_id=default_user_id,
+                organization_id=project.organization_id,
+                project_id=project.id,
+            )
         )
 
 
@@ -178,23 +185,23 @@ def record_first_transaction(project, event, **kwargs):
         date_completed=event.datetime,
     )
     analytics.record(
-        "first_transaction.sent",
-        default_user_id=get_owner_id(project),
-        organization_id=project.organization_id,
-        project_id=project.id,
-        platform=project.platform,
+        FirstTransactionSentEvent(
+            default_user_id=get_owner_id(project),
+            organization_id=project.organization_id,
+            project_id=project.id,
+            platform=project.platform,
+        )
     )
 
 
 @first_profile_received.connect(weak=False, dispatch_uid="onboarding.record_first_profile")
 def record_first_profile(project, **kwargs):
     analytics.record(
-        FirstProfileSentEvent(
-            user_id=get_owner_id(project),
-            organization_id=project.organization_id,
-            project_id=project.id,
-            platform=project.platform,
-        )
+        "first_profile.sent",
+        user_id=get_owner_id(project),
+        organization_id=project.organization_id,
+        project_id=project.id,
+        platform=project.platform,
     )
 
 
@@ -210,11 +217,12 @@ def record_first_replay(project, **kwargs):
     if completed:
         logger.info("record_first_replay_analytics_start")
         analytics.record(
-            "first_replay.sent",
-            user_id=get_owner_id(project),
-            organization_id=project.organization_id,
-            project_id=project.id,
-            platform=project.platform,
+            FirstReplaySentEvent(
+                user_id=get_owner_id(project),
+                organization_id=project.organization_id,
+                project_id=project.id,
+                platform=project.platform,
+            )
         )
         logger.info("record_first_replay_analytics_end")
 
@@ -280,11 +288,12 @@ def record_cron_monitor_created(project, user, from_upsert, **kwargs):
 )
 def record_first_cron_checkin(project, monitor_id, **kwargs):
     analytics.record(
-        "first_cron_checkin.sent",
-        user_id=get_owner_id(project),
-        organization_id=project.organization_id,
-        project_id=project.id,
-        monitor_id=monitor_id,
+        FirstCronCheckinSent(
+            user_id=get_owner_id(project),
+            organization_id=project.organization_id,
+            project_id=project.id,
+            monitor_id=monitor_id,
+        )
     )
 
 
@@ -293,12 +302,13 @@ def record_first_cron_checkin(project, monitor_id, **kwargs):
 )
 def record_first_insight_span(project, module, **kwargs):
     analytics.record(
-        "first_insight_span.sent",
-        user_id=get_owner_id(project),
-        organization_id=project.organization_id,
-        project_id=project.id,
-        platform=project.platform,
-        module=module,
+        FirstInsightSpanSentEvent(
+            user_id=get_owner_id(project),
+            organization_id=project.organization_id,
+            project_id=project.id,
+            platform=project.platform,
+            module=module,
+        )
     )
 
 
@@ -311,11 +321,12 @@ def record_member_invited(member, user, **kwargs):
     )
 
     analytics.record(
-        "member.invited",
-        invited_member_id=member.id,
-        inviter_user_id=user.id if user else None,
-        organization_id=member.organization_id,
-        referrer=kwargs.get("referrer"),
+        MemberInvitedEvent(
+            invited_member_id=member.id,
+            inviter_user_id=user.id if user else None,
+            organization_id=member.organization_id,
+            referrer=kwargs.get("referrer"),
+        )
     )
 
 
@@ -483,11 +494,12 @@ def record_integration_added(
 def record_project_transferred(old_org_id: int, project: Project, **kwargs):
 
     analytics.record(
-        "project.transferred",
-        old_organization_id=old_org_id,
-        new_organization_id=project.organization.id,
-        project_id=project.id,
-        platform=project.platform,
+        ProjectTransferredEvent(
+            old_organization_id=old_org_id,
+            new_organization_id=project.organization.id,
+            project_id=project.id,
+            platform=project.platform,
+        )
     )
 
     transfer_onboarding_tasks(

--- a/src/sentry/receivers/onboarding.py
+++ b/src/sentry/receivers/onboarding.py
@@ -12,6 +12,8 @@ from sentry.analytics.events.first_event_sent import (
     FirstEventSentEvent,
     FirstEventSentForProjectEvent,
 )
+from sentry.analytics.events.first_feedback_sent import FirstFeedbackSentEvent
+from sentry.analytics.events.first_flag_sent import FirstFlagSentEvent
 from sentry.analytics.events.first_insight_span_sent import FirstInsightSpanSentEvent
 from sentry.analytics.events.first_profile_sent import FirstProfileSentEvent
 from sentry.analytics.events.first_replay_sent import FirstReplaySentEvent
@@ -232,21 +234,23 @@ def record_first_replay(project, **kwargs):
 @first_flag_received.connect(weak=False, dispatch_uid="onboarding.record_first_flag")
 def record_first_flag(project, **kwargs):
     analytics.record(
-        "first_flag.sent",
-        organization_id=project.organization_id,
-        project_id=project.id,
-        platform=project.platform,
+        FirstFlagSentEvent(
+            organization_id=project.organization_id,
+            project_id=project.id,
+            platform=project.platform,
+        )
     )
 
 
 @first_feedback_received.connect(weak=False, dispatch_uid="onboarding.record_first_feedback")
 def record_first_feedback(project, **kwargs):
     analytics.record(
-        "first_feedback.sent",
-        user_id=get_owner_id(project),
-        organization_id=project.organization_id,
-        project_id=project.id,
-        platform=project.platform,
+        FirstFeedbackSentEvent(
+            user_id=get_owner_id(project),
+            organization_id=project.organization_id,
+            project_id=project.id,
+            platform=project.platform,
+        )
     )
 
 

--- a/tests/sentry/receivers/test_onboarding.py
+++ b/tests/sentry/receivers/test_onboarding.py
@@ -14,7 +14,6 @@ from sentry.analytics.events.first_replay_sent import FirstReplaySentEvent
 from sentry.analytics.events.first_transaction_sent import FirstTransactionSentEvent
 from sentry.analytics.events.member_invited import MemberInvitedEvent
 from sentry.analytics.events.project_transferred import ProjectTransferredEvent
-from sentry.integrations.analytics import IntegrationAddedEvent
 from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.organizationonboardingtask import (
     OnboardingTask,
@@ -762,15 +761,13 @@ class OrganizationOnboardingTaskTest(TestCase):
         )
         assert task is not None
 
-        assert_last_analytics_event(
-            record_analytics,
-            IntegrationAddedEvent(
-                user_id=self.user.id,
-                default_user_id=self.organization.default_owner_id,
-                organization_id=self.organization.id,
-                id=integration_id,
-                provider="slack",
-            ),
+        record_analytics.assert_called_with(
+            "integration.added",
+            user_id=self.user.id,
+            default_user_id=self.organization.default_owner_id,
+            organization_id=self.organization.id,
+            id=integration_id,
+            provider="slack",
         )
 
     @patch("sentry.analytics.record", wraps=record)
@@ -789,15 +786,13 @@ class OrganizationOnboardingTaskTest(TestCase):
         )
         assert task is not None
 
-        assert_last_analytics_event(
-            record_analytics,
-            IntegrationAddedEvent(
-                user_id=self.user.id,
-                default_user_id=self.organization.default_owner_id,
-                organization_id=self.organization.id,
-                id=integration_id,
-                provider="github",
-            ),
+        record_analytics.assert_called_with(
+            "integration.added",
+            user_id=self.user.id,
+            default_user_id=self.organization.default_owner_id,
+            organization_id=self.organization.id,
+            id=integration_id,
+            provider="github",
         )
 
     def test_second_platform_complete(self):
@@ -1009,15 +1004,13 @@ class OrganizationOnboardingTaskTest(TestCase):
             )
             is not None
         )
-        assert_last_analytics_event(
-            record_analytics,
-            IntegrationAddedEvent(
-                user_id=self.user.id,
-                default_user_id=self.organization.default_owner_id,
-                organization_id=self.organization.id,
-                provider=github_integration.provider,
-                id=github_integration.id,
-            ),
+        record_analytics.assert_called_with(
+            "integration.added",
+            user_id=self.user.id,
+            default_user_id=self.organization.default_owner_id,
+            organization_id=self.organization.id,
+            provider=github_integration.provider,
+            id=github_integration.id,
         )
 
         # Invite your team
@@ -1092,15 +1085,13 @@ class OrganizationOnboardingTaskTest(TestCase):
             )
             is not None
         )
-        assert_last_analytics_event(
-            record_analytics,
-            IntegrationAddedEvent(
-                user_id=self.user.id,
-                default_user_id=self.organization.default_owner_id,
-                organization_id=self.organization.id,
-                provider=slack_integration.provider,
-                id=slack_integration.id,
-            ),
+        record_analytics.assert_called_with(
+            "integration.added",
+            user_id=self.user.id,
+            default_user_id=self.organization.default_owner_id,
+            organization_id=self.organization.id,
+            provider=slack_integration.provider,
+            id=slack_integration.id,
         )
         # Add Sentry to other parts app
         second_project = self.create_project(

--- a/tests/sentry/receivers/test_onboarding.py
+++ b/tests/sentry/receivers/test_onboarding.py
@@ -11,6 +11,9 @@ from sentry.analytics.events.first_event_sent import (
     FirstEventSentForProjectEvent,
 )
 from sentry.analytics.events.first_replay_sent import FirstReplaySentEvent
+from sentry.analytics.events.first_transaction_sent import FirstTransactionSentEvent
+from sentry.analytics.events.member_invited import MemberInvitedEvent
+from sentry.analytics.events.project_transferred import ProjectTransferredEvent
 from sentry.integrations.analytics import IntegrationAddedEvent
 from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.organizationonboardingtask import (
@@ -895,14 +898,15 @@ class OrganizationOnboardingTaskTest(TestCase):
             )
             is not None
         )
-        record_analytics.assert_called_with(
-            "first_transaction.sent",
-            default_user_id=self.organization.default_owner_id,
-            organization_id=self.organization.id,
-            project_id=project.id,
-            platform=project.platform,
+        assert_last_analytics_event(
+            record_analytics,
+            FirstTransactionSentEvent(
+                default_user_id=self.organization.default_owner_id,
+                organization_id=self.organization.id,
+                project_id=project.id,
+                platform=project.platform,
+            ),
         )
-
         #  Capture first error
         error_event = self.store_event(
             data={
@@ -1030,12 +1034,14 @@ class OrganizationOnboardingTaskTest(TestCase):
             )
             is not None
         )
-        record_analytics.assert_called_with(
-            "member.invited",
-            invited_member_id=member.id,
-            inviter_user_id=user.id,
-            organization_id=self.organization.id,
-            referrer=None,
+        assert_last_analytics_event(
+            record_analytics,
+            MemberInvitedEvent(
+                invited_member_id=member.id,
+                inviter_user_id=user.id,
+                organization_id=self.organization.id,
+                referrer=None,
+            ),
         )
 
         # Manually update the completionSeen column of existing tasks
@@ -1360,14 +1366,15 @@ class OrganizationOnboardingTaskTest(TestCase):
             sender=None,
         )
 
-        record_analytics.assert_called_with(
-            "project.transferred",
-            old_organization_id=self.organization.id,
-            new_organization_id=new_organization.id,
-            project_id=project.id,
-            platform=project.platform,
+        assert_last_analytics_event(
+            record_analytics,
+            ProjectTransferredEvent(
+                old_organization_id=self.organization.id,
+                new_organization_id=new_organization.id,
+                project_id=project.id,
+                platform=project.platform,
+            ),
         )
-
         project2 = self.create_project(platform="javascript-react")
         project_created.send(project=project2, user=self.user, default_rules=False, sender=None)
         project2.organization = new_organization
@@ -1377,12 +1384,14 @@ class OrganizationOnboardingTaskTest(TestCase):
             sender=None,
         )
 
-        record_analytics.assert_called_with(
-            "project.transferred",
-            old_organization_id=self.organization.id,
-            new_organization_id=new_organization.id,
-            project_id=project2.id,
-            platform=project2.platform,
+        assert_last_analytics_event(
+            record_analytics,
+            ProjectTransferredEvent(
+                old_organization_id=self.organization.id,
+                new_organization_id=new_organization.id,
+                project_id=project2.id,
+                platform=project2.platform,
+            ),
         )
 
         transferred_tasks = OrganizationOnboardingTask.objects.filter(

--- a/tests/sentry/receivers/test_transactions.py
+++ b/tests/sentry/receivers/test_transactions.py
@@ -3,11 +3,13 @@ from unittest.mock import patch
 
 from django.db import router
 
+from sentry.analytics.events.first_transaction_sent import FirstTransactionSentEvent
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.project import Project
 from sentry.signals import event_processed, transaction_processed
 from sentry.silo.safety import unguarded_write
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.analytics import assert_any_analytics_event
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.skips import requires_snuba
 
@@ -81,12 +83,14 @@ class RecordFirstTransactionTest(TestCase):
         project = Project.objects.get(id=self.project.id)
         assert project.flags.has_transactions
 
-        mock_record.assert_called_with(
-            "first_transaction.sent",
-            default_user_id=self.user.id,
-            organization_id=self.organization.id,
-            project_id=self.project.id,
-            platform=self.project.platform,
+        assert_any_analytics_event(
+            mock_record,
+            FirstTransactionSentEvent(
+                default_user_id=self.user.id,
+                organization_id=self.organization.id,
+                project_id=self.project.id,
+                platform=self.project.platform,
+            ),
         )
 
     def test_analytics_event_no_owner(self):

--- a/tests/sentry/replays/consumers/test_recording.py
+++ b/tests/sentry/replays/consumers/test_recording.py
@@ -11,11 +11,13 @@ from arroyo.backends.kafka import KafkaPayload
 from arroyo.types import BrokerValue, Message, Partition, Topic
 from sentry_kafka_schemas.schema_types.ingest_replay_recordings_v1 import ReplayRecording
 
+from sentry.analytics.events.first_replay_sent import FirstReplaySentEvent
 from sentry.models.organizationonboardingtask import OnboardingTask, OnboardingTaskStatus
 from sentry.replays.consumers.recording import ProcessReplayRecordingStrategyFactory
 from sentry.replays.lib.storage import _make_recording_filename, storage_kv
 from sentry.replays.usecases.pack import unpack
 from sentry.testutils.cases import TransactionTestCase
+from sentry.testutils.helpers.analytics import assert_any_analytics_event
 from sentry.utils import json
 
 
@@ -152,12 +154,14 @@ class RecordingTestCase(TransactionTestCase):
             date_completed=ANY,
         )
 
-        mock_record.assert_called_with(
-            "first_replay.sent",
-            organization_id=self.organization.id,
-            project_id=self.project.id,
-            platform=self.project.platform,
-            user_id=self.organization.default_owner_id,
+        assert_any_analytics_event(
+            mock_record,
+            FirstReplaySentEvent(
+                organization_id=self.organization.id,
+                project_id=self.project.id,
+                platform=self.project.platform,
+                user_id=self.organization.default_owner_id,
+            ),
         )
 
         assert track_outcome.called

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -67,6 +67,7 @@ from sentry.tasks.post_process import (
 )
 from sentry.testutils.cases import BaseTestCase, PerformanceIssueTestCase, SnubaTestCase, TestCase
 from sentry.testutils.helpers import with_feature
+from sentry.testutils.helpers.analytics import assert_last_analytics_event
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.helpers.eventprocessing import write_event_to_cache
 from sentry.testutils.helpers.options import override_options
@@ -2232,7 +2233,7 @@ class CheckIfFlagsSentTestMixin(BasePostProgressGroupMixin):
 
         mock_incr.assert_any_call("feature_flags.event_has_flags_context")
         mock_dist.assert_any_call("feature_flags.num_flags_sent", 2)
-        mock_record.assert_called_with(
+        assert_last_analytics_event(
             FirstFlagSentEvent(
                 organization_id=self.organization.id,
                 project_id=project.id,

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -2234,6 +2234,7 @@ class CheckIfFlagsSentTestMixin(BasePostProgressGroupMixin):
         mock_incr.assert_any_call("feature_flags.event_has_flags_context")
         mock_dist.assert_any_call("feature_flags.num_flags_sent", 2)
         assert_last_analytics_event(
+            mock_record,
             FirstFlagSentEvent(
                 organization_id=self.organization.id,
                 project_id=project.id,

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -15,6 +15,7 @@ from django.test import override_settings
 from django.utils import timezone
 
 from sentry import buffer
+from sentry.analytics.events.first_flag_sent import FirstFlagSentEvent
 from sentry.eventstore.models import Event
 from sentry.eventstore.processing import event_processing_store
 from sentry.eventstream.types import EventStreamEventType
@@ -2232,10 +2233,11 @@ class CheckIfFlagsSentTestMixin(BasePostProgressGroupMixin):
         mock_incr.assert_any_call("feature_flags.event_has_flags_context")
         mock_dist.assert_any_call("feature_flags.num_flags_sent", 2)
         mock_record.assert_called_with(
-            "first_flag.sent",
-            organization_id=self.organization.id,
-            project_id=project.id,
-            platform=project.platform,
+            FirstFlagSentEvent(
+                organization_id=self.organization.id,
+                project_id=project.id,
+                platform=project.platform,
+            ),
         )
 
 


### PR DESCRIPTION
- Part of the split-up PR https://github.com/getsentry/sentry/pull/95209 to make it easier to review
- Transform event classes to use @analytics.eventclass decorator
- Transform analytics.record calls to use event class instances
- Update imports as needed

Contributes to TET-829
Contributes to TET-830