### PR TITLE
feat(stats): Add client discard count

### DIFF
--- a/static/app/views/organizationStats/mapSeriesToChart.spec.ts
+++ b/static/app/views/organizationStats/mapSeriesToChart.spec.ts
@@ -220,6 +220,38 @@ describe('mapSeriesToChart func', function () {
     expect(mappedSeries.cardStats.rateLimited).toBe('11');
   });
 
+  it('should correctly format client discard data', function () {
+    const mappedSeries = mapSeriesToChart({
+      orgStats: {
+        start: '2021-01-01T00:00:00Z',
+        end: '2021-01-07T00:00:00Z',
+        intervals: ['2021-01-01T00:00:00Z', '2021-01-02T00:00:00Z'],
+        groups: [
+          {
+            by: {
+              outcome: 'client_discard',
+              reason: 'queue_overflow',
+              category: 'error',
+            },
+            totals: {
+              'sum(quantity)': 1500,
+            },
+            series: {
+              'sum(quantity)': [750, 750],
+            },
+          },
+        ],
+      },
+      chartDateInterval: '1h',
+      chartDateUtc: true,
+      dataCategory: DataCategory.ERRORS,
+      endpointQuery: {},
+    });
+
+    // should format client discard data correctly
+    expect(mappedSeries.cardStats.clientDiscard).toBe('1.5K');
+  });
+
   it('should correctly sum up the profile chunks', function () {
     const mappedSeries = mapSeriesToChart({
       orgStats: {

--- a/static/app/views/organizationStats/mapSeriesToChart.ts
+++ b/static/app/views/organizationStats/mapSeriesToChart.ts
@@ -50,6 +50,7 @@ export function mapSeriesToChart({
   cardStats: {
     accepted?: string;
     accepted_stored?: string;
+    clientDiscard?: string;
     filtered?: string;
     invalid?: string;
     rateLimited?: string;
@@ -66,6 +67,7 @@ export function mapSeriesToChart({
     filtered: undefined,
     invalid: undefined,
     rateLimited: undefined,
+    clientDiscard: undefined,
   };
   const chartStats: ChartStats = {
     accepted: [],
@@ -282,6 +284,11 @@ export function mapSeriesToChart({
         ),
         rateLimited: formatUsageWithUnits(
           count[Outcome.RATE_LIMITED],
+          dataCategory,
+          getFormatUsageOptions(dataCategory)
+        ),
+        clientDiscard: formatUsageWithUnits(
+          count[Outcome.CLIENT_DISCARD],
           dataCategory,
           getFormatUsageOptions(dataCategory)
         ),

--- a/static/app/views/organizationStats/usageStatsOrg.tsx
+++ b/static/app/views/organizationStats/usageStatsOrg.tsx
@@ -57,6 +57,7 @@ type ChartData = {
   cardStats: {
     accepted?: string;
     accepted_stored?: string;
+    clientDiscard?: string;
     filtered?: string;
     invalid?: string;
     rateLimited?: string;
@@ -149,6 +150,7 @@ export function getChartProps({
     | 'chartDateTimezoneDisplay'
     | 'chartDateEndDisplay'
     | 'chartStats'
+    | 'cardStats'
   >;
   dataCategory: DataCategory;
   error: RequestError | null;
@@ -227,7 +229,13 @@ export function getChartProps({
         <InlineContainer>
           {(chartData.chartStats.clientDiscard ?? []).length > 0 && (
             <Flex align="center" gap="md">
-              <strong>{t('Show client-discarded data:')}</strong>
+              <strong>
+                {chartData.cardStats.clientDiscard
+                  ? tct('Show client-discarded data ([count]):', {
+                      count: chartData.cardStats.clientDiscard,
+                    })
+                  : t('Show client-discarded data:')}
+              </strong>
               <Switch
                 onChange={() => {
                   handleChangeState({clientDiscard: !clientDiscard});
@@ -482,6 +490,7 @@ function UsageStatsOrganization({
     cardStats: {
       accepted?: string;
       accepted_stored?: string;
+      clientDiscard?: string;
       filtered?: string;
       invalid?: string;
       rateLimited?: string;


### PR DESCRIPTION
## Before
<img width="2546" height="1506" alt="CleanShot 2025-07-22 at 13 15 38@2x" src="https://github.com/user-attachments/assets/84a92b17-542d-479a-af60-806ea8a89788" />


## After
<img width="2542" height="1398" alt="CleanShot 2025-07-22 at 13 14 45@2x" src="https://github.com/user-attachments/assets/5ef374c0-3262-407d-9552-5fed68845e40" />

Closes https://linear.app/getsentry/issue/TET-933/show-client-discards-count-in-stats