### PR TITLE
ref(db): Stop usign legacy create_or_update in BaseScheduledDeletion

### DIFF
--- a/src/sentry/deletions/models/scheduleddeletion.py
+++ b/src/sentry/deletions/models/scheduleddeletion.py
@@ -77,22 +77,16 @@ class BaseScheduledDeletion(Model):
             )
 
         model_name = model.__name__
-        record, created = cls.objects.create_or_update(
+        record, created = cls.objects.update_or_create(
             app_label=instance._meta.app_label,
             model_name=model_name,
             object_id=instance.pk,
-            values={
+            defaults={
                 "date_scheduled": timezone.now() + timedelta(days=days, hours=hours),
                 "data": data or {},
                 "actor_id": actor.id if actor else None,
             },
         )
-        if not created:
-            record = cls.objects.get(
-                app_label=instance._meta.app_label,
-                model_name=model_name,
-                object_id=instance.pk,
-            )
 
         delete_logger.info(
             "object.delete.queued",


### PR DESCRIPTION
On over 40 places we are still using our custom `create_or_update` method. This PR refactors the code in one of them and uses `update_or_create` method provided by Django ORM instead of our custom one.
