### PR TITLE
ref(analytics): move weekly reports analytics events to typed events

### DIFF
--- a/src/sentry/analytics/events/weekly_report.py
+++ b/src/sentry/analytics/events/weekly_report.py
@@ -4,7 +4,7 @@ from sentry import analytics
 @analytics.eventclass("weekly_report.sent")
 class WeeklyReportSent(analytics.Event):
     organization_id: int
-    user_id: int
+    user_id: int | None = None
     notification_uuid: str
     user_project_count: int
 

--- a/src/sentry/analytics/events/weekly_report.py
+++ b/src/sentry/analytics/events/weekly_report.py
@@ -1,15 +1,12 @@
 from sentry import analytics
 
 
+@analytics.eventclass("weekly_report.sent")
 class WeeklyReportSent(analytics.Event):
-    type = "weekly_report.sent"
-
-    attributes = (
-        analytics.Attribute("organization_id"),
-        analytics.Attribute("user_id"),
-        analytics.Attribute("notification_uuid"),
-        analytics.Attribute("user_project_count", type=int),
-    )
+    organization_id: int
+    user_id: int
+    notification_uuid: str
+    user_project_count: int
 
 
 analytics.register(WeeklyReportSent)

--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -16,6 +16,7 @@ from rb.clients import LocalClient
 from sentry_sdk import set_tag
 
 from sentry import analytics
+from sentry.analytics.events.weekly_report import WeeklyReportSent
 from sentry.constants import DataCategory
 from sentry.models.group import Group, GroupStatus
 from sentry.models.grouphistory import GroupHistoryStatus
@@ -339,11 +340,12 @@ class OrganizationReportBatch:
             message.send(to=(self.email_override,))
         else:
             analytics.record(
-                "weekly_report.sent",
-                user_id=user_id,
-                organization_id=self.ctx.organization.id,
-                notification_uuid=template_ctx["notification_uuid"],
-                user_project_count=template_ctx["user_project_count"],
+                WeeklyReportSent(
+                    user_id=user_id,
+                    organization_id=self.ctx.organization.id,
+                    notification_uuid=template_ctx["notification_uuid"],
+                    user_project_count=template_ctx["user_project_count"],
+                )
             )
 
             # TODO: see if we can use the UUID to track if the email was sent or not

--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -339,14 +339,17 @@ class OrganizationReportBatch:
         if self.email_override:
             message.send(to=(self.email_override,))
         else:
-            analytics.record(
-                WeeklyReportSent(
-                    user_id=user_id,
-                    organization_id=self.ctx.organization.id,
-                    notification_uuid=template_ctx["notification_uuid"],
-                    user_project_count=template_ctx["user_project_count"],
+            try:
+                analytics.record(
+                    WeeklyReportSent(
+                        user_id=user_id,
+                        organization_id=self.ctx.organization.id,
+                        notification_uuid=template_ctx["notification_uuid"],
+                        user_project_count=template_ctx["user_project_count"],
+                    )
                 )
-            )
+            except Exception as e:
+                sentry_sdk.capture_exception(e)
 
             # TODO: see if we can use the UUID to track if the email was sent or not
             logger.info(

--- a/tests/sentry/tasks/test_weekly_reports.py
+++ b/tests/sentry/tasks/test_weekly_reports.py
@@ -443,9 +443,10 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
             WeeklyReportSent(
                 user_id=user.id,
                 organization_id=self.organization.id,
-                notification_uuid=mock.ANY,
+                notification_uuid="mock.ANY",
                 user_project_count=1,
             ),
+            exclude_fields=["notification_uuid"],
         )
 
     @mock.patch("sentry.analytics.record")
@@ -523,9 +524,10 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
             WeeklyReportSent(
                 user_id=user.id,
                 organization_id=self.organization.id,
-                notification_uuid=mock.ANY,
+                notification_uuid="mock.ANY",
                 user_project_count=1,
             ),
+            exclude_fields=["notification_uuid"],
         )
 
     @mock.patch("sentry.tasks.summaries.weekly_reports.MessageBuilder")
@@ -687,18 +689,20 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
             WeeklyReportSent(
                 user_id=user.id,
                 organization_id=self.organization.id,
-                notification_uuid=mock.ANY,
+                notification_uuid="mock.ANY",
                 user_project_count=1,
             ),
+            exclude_fields=["notification_uuid"],
         )
         assert_any_analytics_event(
             record,
             WeeklyReportSent(
                 user_id=user2.id,
                 organization_id=self.organization.id,
-                notification_uuid=mock.ANY,
+                notification_uuid="mock.ANY",
                 user_project_count=1,
             ),
+            exclude_fields=["notification_uuid"],
         )
 
     @mock.patch("sentry.tasks.summaries.weekly_reports.MessageBuilder")
@@ -931,7 +935,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
                 WeeklyReportSent(
                     user_id=user.id,
                     organization_id=self.organization.id,
-                    notification_uuid=mock.ANY,
+                    notification_uuid="mock.ANY",
                     user_project_count=1,
                 ),
             )
@@ -1002,7 +1006,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
                 WeeklyReportSent(
                     user_id=None,
                     organization_id=self.organization.id,
-                    notification_uuid=mock.ANY,
+                    notification_uuid="mock.ANY",
                     user_project_count=1,
                 ),
             )
@@ -1061,7 +1065,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
                 WeeklyReportSent(
                     user_id=None,
                     organization_id=self.organization.id,
-                    notification_uuid=mock.ANY,
+                    notification_uuid="mock.ANY",
                     user_project_count=1,
                 ),
             )

--- a/tests/sentry/tasks/test_weekly_reports.py
+++ b/tests/sentry/tasks/test_weekly_reports.py
@@ -9,6 +9,7 @@ from django.db import router
 from django.db.models import F
 from django.utils import timezone
 
+from sentry.analytics.events.weekly_report import WeeklyReportSent
 from sentry.constants import DataCategory
 from sentry.issues.grouptype import MonitorIncidentType, PerformanceNPlusOneGroupType
 from sentry.models.group import GroupStatus
@@ -38,6 +39,7 @@ from sentry.tasks.summaries.weekly_reports import (
 from sentry.testutils.cases import OutcomesSnubaTest, PerformanceIssueTestCase, SnubaTestCase
 from sentry.testutils.factories import EventType
 from sentry.testutils.helpers import with_feature
+from sentry.testutils.helpers.analytics import assert_any_analytics_event
 from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode
@@ -436,12 +438,14 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
 
             assert isinstance(context["notification_uuid"], str)
 
-        record.assert_any_call(
-            "weekly_report.sent",
-            user_id=user.id,
-            organization_id=self.organization.id,
-            notification_uuid=mock.ANY,
-            user_project_count=1,
+        assert_any_analytics_event(
+            record,
+            WeeklyReportSent(
+                user_id=user.id,
+                organization_id=self.organization.id,
+                notification_uuid=mock.ANY,
+                user_project_count=1,
+            ),
         )
 
     @mock.patch("sentry.analytics.record")
@@ -514,12 +518,14 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
 
             assert isinstance(context["notification_uuid"], str)
 
-        record.assert_any_call(
-            "weekly_report.sent",
-            user_id=user.id,
-            organization_id=self.organization.id,
-            notification_uuid=mock.ANY,
-            user_project_count=1,
+        assert_any_analytics_event(
+            record,
+            WeeklyReportSent(
+                user_id=user.id,
+                organization_id=self.organization.id,
+                notification_uuid=mock.ANY,
+                user_project_count=1,
+            ),
         )
 
     @mock.patch("sentry.tasks.summaries.weekly_reports.MessageBuilder")
@@ -676,19 +682,23 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
 
             assert isinstance(context["notification_uuid"], str)
 
-        record.assert_any_call(
-            "weekly_report.sent",
-            user_id=user.id,
-            organization_id=self.organization.id,
-            notification_uuid=mock.ANY,
-            user_project_count=1,
+        assert_any_analytics_event(
+            record,
+            WeeklyReportSent(
+                user_id=user.id,
+                organization_id=self.organization.id,
+                notification_uuid=mock.ANY,
+                user_project_count=1,
+            ),
         )
-        record.assert_any_call(
-            "weekly_report.sent",
-            user_id=user2.id,
-            organization_id=self.organization.id,
-            notification_uuid=mock.ANY,
-            user_project_count=1,
+        assert_any_analytics_event(
+            record,
+            WeeklyReportSent(
+                user_id=user2.id,
+                organization_id=self.organization.id,
+                notification_uuid=mock.ANY,
+                user_project_count=1,
+            ),
         )
 
     @mock.patch("sentry.tasks.summaries.weekly_reports.MessageBuilder")
@@ -916,12 +926,14 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
             assert f"Weekly Report for {self.organization.name}" in message_params["subject"]
 
         with pytest.raises(AssertionError):
-            record.assert_any_call(
-                "weekly_report.sent",
-                user_id=user.id,
-                organization_id=self.organization.id,
-                notification_uuid=mock.ANY,
-                user_project_count=1,
+            assert_any_analytics_event(
+                record,
+                WeeklyReportSent(
+                    user_id=user.id,
+                    organization_id=self.organization.id,
+                    notification_uuid=mock.ANY,
+                    user_project_count=1,
+                ),
             )
 
         message_builder.return_value.send.assert_called_with(to=("joseph@speedwagon.org",))
@@ -985,12 +997,14 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
             assert context["user_project_count"] == 3
 
         with pytest.raises(AssertionError):
-            record.assert_any_call(
-                "weekly_report.sent",
-                user_id=None,
-                organization_id=self.organization.id,
-                notification_uuid=mock.ANY,
-                user_project_count=1,
+            assert_any_analytics_event(
+                record,
+                WeeklyReportSent(
+                    user_id=None,
+                    organization_id=self.organization.id,
+                    notification_uuid=mock.ANY,
+                    user_project_count=1,
+                ),
             )
 
             message_builder.return_value.send.assert_called_with(to=("jonathan@speedwagon.org",))
@@ -1042,12 +1056,14 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
         )
 
         with pytest.raises(AssertionError):
-            record.assert_any_call(
-                "weekly_report.sent",
-                user_id=None,
-                organization_id=self.organization.id,
-                notification_uuid=mock.ANY,
-                user_project_count=1,
+            assert_any_analytics_event(
+                record,
+                WeeklyReportSent(
+                    user_id=None,
+                    organization_id=self.organization.id,
+                    notification_uuid=mock.ANY,
+                    user_project_count=1,
+                ),
             )
 
         message_builder.return_value.send.assert_not_called()


### PR DESCRIPTION
- Part of the split-up PR https://github.com/getsentry/sentry/pull/95209 to make it easier to review
- Transform event classes to use @analytics.eventclass decorator
- Transform analytics.record calls to use event class instances
- Update imports as needed

Contributes to TET-829