### PR TITLE
ref(db): Stop using legacy create_or_update in repair_group_environment_data

### DIFF
--- a/src/sentry/tasks/unmerge.py
+++ b/src/sentry/tasks/unmerge.py
@@ -328,11 +328,10 @@ def repair_group_environment_data(caches, project, events):
         if first_release:
             fields["first_release"] = caches["Release"](project.organization_id, first_release)
 
-        GroupEnvironment.objects.create_or_update(
+        GroupEnvironment.objects.update_or_create(
             environment_id=caches["Environment"](project.organization_id, env_name).id,
             group_id=group_id,
             defaults=fields,
-            values=fields,
         )
 
 


### PR DESCRIPTION
On over 40 places we are still using our custom `create_or_update` method. This PR refactors the code in one of them and uses `update_or_create` method provided by Django ORM instead of our custom one.
