### PR TITLE
fix(logs): Hide save as button when flags are off

### DIFF
--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -250,24 +250,26 @@ export function LogsTabContent({
               />
             </StyledPageFilterBar>
             <TraceItemSearchQueryBuilder {...tracesItemSearchQueryBuilderProps} />
-            <DropdownMenu
-              items={saveAsItems}
-              trigger={triggerProps => (
-                <Button
-                  {...triggerProps}
-                  priority="primary"
-                  aria-label={t('Save as')}
-                  onClick={e => {
-                    e.stopPropagation();
-                    e.preventDefault();
+            {saveAsItems.length > 0 && (
+              <DropdownMenu
+                items={saveAsItems}
+                trigger={triggerProps => (
+                  <Button
+                    {...triggerProps}
+                    priority="primary"
+                    aria-label={t('Save as')}
+                    onClick={e => {
+                      e.stopPropagation();
+                      e.preventDefault();
 
-                    triggerProps.onClick?.(e);
-                  }}
-                >
-                  {t('Save as')}
-                </Button>
-              )}
-            />
+                      triggerProps.onClick?.(e);
+                    }}
+                  >
+                    {t('Save as')}
+                  </Button>
+                )}
+              />
+            )}
           </FilterBarContainer>
           <SchemaHintsSection>
             <SchemaHintsList


### PR DESCRIPTION
When the flags are off, this used to render a button with no options.