### PR TITLE
fix(spans-migration): Disable transaction saved queries context menu options

### DIFF
--- a/static/app/views/discover/queryList.spec.tsx
+++ b/static/app/views/discover/queryList.spec.tsx
@@ -487,6 +487,78 @@ describe('Discover > QueryList', function () {
     );
   });
 
+  it('disabled duplicate for transaction queries with deprecation flag', async function () {
+    const featuredOrganization = OrganizationFixture({
+      features: ['dashboards-edit', 'discover-saved-queries-deprecation'],
+    });
+
+    render(
+      <QueryList
+        savedQuerySearchQuery=""
+        router={RouterFixture()}
+        organization={featuredOrganization}
+        savedQueries={[
+          DiscoverSavedQueryFixture({
+            display: DisplayModes.DEFAULT,
+            orderby: 'count()',
+            fields: ['test', 'count()'],
+            yAxis: ['count()'],
+            queryDataset: SavedQueryDatasets.TRANSACTIONS,
+          }),
+        ]}
+        pageLinks=""
+        renderPrebuilt={false}
+        location={location}
+      />
+    );
+
+    const card = screen.getAllByTestId(/card-*/).at(0)!;
+    const withinCard = within(card);
+
+    await userEvent.click(withinCard.getByTestId('menu-trigger'));
+    const duplicateMenuItem = await screen.findByRole('menuitemradio', {
+      name: 'Duplicate Query',
+    });
+
+    expect(duplicateMenuItem).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('does not disable duplicate for error queries with deprecation flag', async function () {
+    const featuredOrganization = OrganizationFixture({
+      features: ['dashboards-edit', 'discover-saved-queries-deprecation'],
+    });
+
+    render(
+      <QueryList
+        savedQuerySearchQuery=""
+        router={RouterFixture()}
+        organization={featuredOrganization}
+        savedQueries={[
+          DiscoverSavedQueryFixture({
+            display: DisplayModes.DEFAULT,
+            orderby: 'count()',
+            fields: ['test', 'count()'],
+            yAxis: ['count()'],
+            queryDataset: SavedQueryDatasets.ERRORS,
+          }),
+        ]}
+        pageLinks=""
+        renderPrebuilt={false}
+        location={location}
+      />
+    );
+
+    const card = screen.getAllByTestId(/card-*/).at(0)!;
+    const withinCard = within(card);
+
+    await userEvent.click(withinCard.getByTestId('menu-trigger'));
+    const duplicateMenuItem = await screen.findByRole('menuitemradio', {
+      name: 'Duplicate Query',
+    });
+
+    expect(duplicateMenuItem).not.toHaveAttribute('aria-disabled');
+  });
+
   describe('Add to Dashboard modal', () => {
     it('opens a modal with the correct params for Top 5 chart', async function () {
       const featuredOrganization = OrganizationFixture({
@@ -619,6 +691,78 @@ describe('Discover > QueryList', function () {
           })
         );
       });
+    });
+
+    it('disables Add to Dashboard for transaction queries with deprecation flag', async function () {
+      const featuredOrganization = OrganizationFixture({
+        features: ['dashboards-edit', 'discover-saved-queries-deprecation'],
+      });
+      render(
+        <QueryList
+          savedQuerySearchQuery=""
+          router={RouterFixture()}
+          organization={featuredOrganization}
+          renderPrebuilt={false}
+          savedQueries={[
+            DiscoverSavedQueryFixture({
+              display: DisplayModes.DEFAULT,
+              orderby: 'count()',
+              fields: ['test', 'count()'],
+              yAxis: ['count()'],
+              queryDataset: SavedQueryDatasets.TRANSACTIONS,
+            }),
+          ]}
+          pageLinks=""
+          location={location}
+        />
+      );
+
+      const contextMenu = await screen.findByTestId('menu-trigger');
+      expect(contextMenu).toBeInTheDocument();
+
+      await userEvent.click(contextMenu);
+
+      const addToDashboardMenuItem = await screen.findByRole('menuitemradio', {
+        name: 'Add to Dashboard',
+      });
+
+      expect(addToDashboardMenuItem).toHaveAttribute('aria-disabled', 'true');
+    });
+
+    it('does not disable Add to Dashboard for error queries with deprecation flag', async function () {
+      const featuredOrganization = OrganizationFixture({
+        features: ['dashboards-edit', 'discover-saved-queries-deprecation'],
+      });
+      render(
+        <QueryList
+          savedQuerySearchQuery=""
+          router={RouterFixture()}
+          organization={featuredOrganization}
+          renderPrebuilt={false}
+          savedQueries={[
+            DiscoverSavedQueryFixture({
+              display: DisplayModes.DEFAULT,
+              orderby: 'count()',
+              fields: ['test', 'count()'],
+              yAxis: ['count()'],
+              queryDataset: SavedQueryDatasets.ERRORS,
+            }),
+          ]}
+          pageLinks=""
+          location={location}
+        />
+      );
+
+      const contextMenu = await screen.findByTestId('menu-trigger');
+      expect(contextMenu).toBeInTheDocument();
+
+      await userEvent.click(contextMenu);
+
+      const addToDashboardMenuItem = await screen.findByRole('menuitemradio', {
+        name: 'Add to Dashboard',
+      });
+
+      expect(addToDashboardMenuItem).not.toHaveAttribute('aria-disabled');
     });
   });
 

--- a/static/app/views/discover/queryList.tsx
+++ b/static/app/views/discover/queryList.tsx
@@ -20,6 +20,7 @@ import type {NewQuery, Organization, SavedQuery} from 'sentry/types/organization
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {browserHistory} from 'sentry/utils/browserHistory';
 import EventView from 'sentry/utils/discover/eventView';
+import {SavedQueryDatasets} from 'sentry/utils/discover/types';
 import parseLinkHeader from 'sentry/utils/parseLinkHeader';
 import {decodeList} from 'sentry/utils/queryString';
 import withApi from 'sentry/utils/withApi';
@@ -171,7 +172,11 @@ class QueryList extends Component<Props> {
         hasDatasetSelector(organization) ? view.queryDataset : undefined
       );
 
-      const menuItems = [
+      const deprecateTransactionQuery =
+        organization.features.includes('discover-saved-queries-deprecation') &&
+        view.queryDataset === SavedQueryDatasets.TRANSACTIONS;
+
+      const menuItems: MenuItemProps[] = [
         {
           key: 'add-to-dashboard',
           label: t('Add to Dashboard'),
@@ -191,6 +196,7 @@ class QueryList extends Component<Props> {
                 : undefined,
               source: DashboardWidgetSource.DISCOVERV2,
             }),
+          disabled: deprecateTransactionQuery,
         },
         {
           key: 'set-as-default',
@@ -262,6 +268,10 @@ class QueryList extends Component<Props> {
       const dateStatus = <TimeSince date={savedQuery.dateUpdated} />;
       const referrer = `api.discover.${eventView.getDisplayMode()}-chart`;
 
+      const deprecateTransactionQuery =
+        organization.features.includes('discover-saved-queries-deprecation') &&
+        savedQuery.queryDataset === SavedQueryDatasets.TRANSACTIONS;
+
       const menuItems = (canAddToDashboard: boolean): MenuItemProps[] => [
         ...(canAddToDashboard
           ? [
@@ -284,6 +294,7 @@ class QueryList extends Component<Props> {
                       : undefined,
                     source: DashboardWidgetSource.DISCOVERV2,
                   }),
+                disabled: deprecateTransactionQuery,
               },
             ]
           : []),
@@ -304,6 +315,7 @@ class QueryList extends Component<Props> {
           label: t('Duplicate Query'),
           onAction: () =>
             this.handleDuplicateQuery(eventView, decodeList(savedQuery.yAxis)),
+          disabled: deprecateTransactionQuery,
         },
         {
           key: 'delete',


### PR DESCRIPTION
We forgot to disable the context menu options (Add to dashboard and Duplicate query) for transaction saved queries so I've added that in under the feature flag. I haven't put in tooltips because this is a pattern that we use for dashboard widgets. 

<img width="400" height="231" alt="image" src="https://github.com/user-attachments/assets/5af5e5d3-49a1-4a15-bcfe-a64ceea79fbc" />

Closes [ENG-4632](https://linear.app/getsentry/issue/ENG-4632/remove-duplicateadd-to-dashboard-etc-from-saved-queries-context-menu)
