### PR TITLE
fix(seer): add group_id parameter to repo access check

### DIFF
--- a/src/sentry/seer/endpoints/group_autofix_setup_check.py
+++ b/src/sentry/seer/endpoints/group_autofix_setup_check.py
@@ -54,7 +54,7 @@ def get_autofix_integration_setup_problems(
     return "integration_missing"
 
 
-def get_repos_and_access(project: Project) -> list[dict]:
+def get_repos_and_access(project: Project, group_id: int) -> list[dict]:
     """
     Gets the repos that would be indexed for the given project from the code mappings, and checks if we have write access to them.
 
@@ -73,6 +73,7 @@ def get_repos_and_access(project: Project) -> list[dict]:
         body = orjson.dumps(
             {
                 "repo": repo,
+                "group_id": group_id,
             }
         )
 
@@ -126,7 +127,7 @@ class GroupAutofixSetupCheck(GroupAiEndpoint):
 
         write_integration_check = None
         if request.query_params.get("check_write_access", False):
-            repos = get_repos_and_access(group.project)
+            repos = get_repos_and_access(group.project, group.id)
             write_access_ok = len(repos) > 0 and all(repo["ok"] for repo in repos)
             write_integration_check = {
                 "ok": write_access_ok,

--- a/tests/sentry/seer/endpoints/test_group_autofix_setup_check.py
+++ b/tests/sentry/seer/endpoints/test_group_autofix_setup_check.py
@@ -258,7 +258,8 @@ class GroupAIAutofixEndpointFailureTest(APITestCase, SnubaTestCase):
         mock_response = mock_post.return_value
         mock_response.json.return_value = {"has_access": True}
 
-        result = get_repos_and_access(self.project)
+        group = self.create_group()
+        result = get_repos_and_access(self.project, group.id)
 
         # Verify the result
         assert result == [
@@ -295,7 +296,8 @@ class GroupAIAutofixEndpointFailureTest(APITestCase, SnubaTestCase):
         mock_response = mock_post.return_value
         mock_response.json.return_value = {"has_access": False}
 
-        result = get_repos_and_access(self.project)
+        group = self.create_group()
+        result = get_repos_and_access(self.project, group.id)
 
         assert result == [
             {


### PR DESCRIPTION
Pass group_id to Seer when checking repository write access. This is only called from when someone's looking at the write access modal, so we can safely use this to update the write access state.

Read more at https://github.com/getsentry/seer/pull/2986