### PR TITLE
fix(auto-resolve): dont propagate traces from main task

### DIFF
--- a/src/sentry/tasks/auto_resolve_issues.py
+++ b/src/sentry/tasks/auto_resolve_issues.py
@@ -60,7 +60,10 @@ def schedule_auto_resolution():
         if int(options.get("sentry:_last_auto_resolve", 0)) > cutoff:
             continue
 
-        auto_resolve_project_issues.delay(project_id=project_id, expires=ONE_HOUR)
+        auto_resolve_project_issues.apply_async(
+            kwargs={"project_id": project_id, "expires": ONE_HOUR},
+            headers={"sentry-propagate-traces": False},
+        )
 
 
 @instrumented_task(

--- a/src/sentry/tasks/auto_resolve_issues.py
+++ b/src/sentry/tasks/auto_resolve_issues.py
@@ -61,7 +61,8 @@ def schedule_auto_resolution():
             continue
 
         auto_resolve_project_issues.apply_async(
-            kwargs={"project_id": project_id, "expires": ONE_HOUR},
+            args=[project_id],
+            expires=ONE_HOUR,
             headers={"sentry-propagate-traces": False},
         )
 
@@ -161,6 +162,9 @@ def auto_resolve_project_issues(project_id, cutoff=None, chunk_size=1000, **kwar
             )
 
     if might_have_more:
-        auto_resolve_project_issues.delay(
-            project_id=project_id, cutoff=int(cutoff.strftime("%s")), chunk_size=chunk_size
+        auto_resolve_project_issues.apply_async(
+            args=[project_id],
+            kwargs={"cutoff": int(cutoff.strftime("%s")), "chunk_size": chunk_size},
+            expires=ONE_HOUR,
+            headers={"sentry-propagate-traces": False},
         )


### PR DESCRIPTION
right now traces from this task have way too many spans in them to be able to load. don't propagate trace_id here so our telemetry is more useful.