### PR TITLE
feat(performance): Web Vitals Seer Suggestions frontend

### DIFF
--- a/static/app/views/insights/browser/webVitals/components/pageOverviewSidebar.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/components/pageOverviewSidebar.spec.tsx
@@ -1,0 +1,63 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {PageOverviewSidebar} from 'sentry/views/insights/browser/webVitals/components/pageOverviewSidebar';
+
+const TRANSACTION_NAME = 'transaction';
+
+describe('PageOverviewSidebar', () => {
+  const organization = OrganizationFixture({
+    features: ['performance-web-vitals-seer-suggestions'],
+  });
+
+  beforeEach(() => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events-stats/`,
+      body: {
+        data: [],
+      },
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      body: {
+        data: [],
+      },
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/page-web-vitals-summary/`,
+      body: {
+        suggestedInvestigations: [
+          {
+            explanation: 'Seer Suggestion 1',
+            referenceUrl: 'https://example.com/seer-suggestion-1',
+            spanId: '123',
+            spanOp: 'ui.interaction.click',
+            suggestions: ['Suggestion 1', 'Suggestion 2'],
+          },
+        ],
+      },
+      method: 'POST',
+    });
+  });
+
+  it('should render', () => {
+    render(<PageOverviewSidebar transaction={TRANSACTION_NAME} />);
+
+    expect(screen.getByText('Performance Score')).toBeInTheDocument();
+    expect(screen.getByText('Page Loads')).toBeInTheDocument();
+    expect(screen.getByText('Interactions')).toBeInTheDocument();
+  });
+
+  it('should render seer suggestions', async () => {
+    render(<PageOverviewSidebar transaction={TRANSACTION_NAME} />, {organization});
+
+    expect(screen.getByText('Seer Suggestions')).toBeInTheDocument();
+    expect(await screen.findByText('- Seer Suggestion 1')).toBeInTheDocument();
+    expect(screen.getByText('ui.interaction.click')).toBeInTheDocument();
+    expect(screen.getByText('Suggestion 1')).toBeInTheDocument();
+    expect(screen.getByText('Suggestion 2')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/insights/browser/webVitals/components/pageOverviewSidebar.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/components/pageOverviewSidebar.spec.tsx
@@ -55,7 +55,7 @@ describe('PageOverviewSidebar', () => {
     render(<PageOverviewSidebar transaction={TRANSACTION_NAME} />, {organization});
 
     expect(screen.getByText('Seer Suggestions')).toBeInTheDocument();
-    expect(await screen.findByText('- Seer Suggestion 1')).toBeInTheDocument();
+    expect(await screen.findByText('— Seer Suggestion 1')).toBeInTheDocument();
     expect(screen.getByText('ui.interaction.click')).toBeInTheDocument();
     expect(screen.getByText('Suggestion 1')).toBeInTheDocument();
     expect(screen.getByText('Suggestion 2')).toBeInTheDocument();

--- a/static/app/views/insights/browser/webVitals/components/pageOverviewSidebar.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/components/pageOverviewSidebar.spec.tsx
@@ -1,8 +1,15 @@
+import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
+import {useLocation} from 'sentry/utils/useLocation';
+import usePageFilters from 'sentry/utils/usePageFilters';
 import {PageOverviewSidebar} from 'sentry/views/insights/browser/webVitals/components/pageOverviewSidebar';
+
+jest.mock('sentry/utils/useLocation');
+jest.mock('sentry/utils/usePageFilters');
 
 const TRANSACTION_NAME = 'transaction';
 
@@ -12,6 +19,10 @@ describe('PageOverviewSidebar', () => {
   });
 
   beforeEach(() => {
+    jest.mocked(useLocation).mockReturnValue(LocationFixture());
+
+    jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture());
+
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events-stats/`,
       body: {
@@ -22,7 +33,7 @@ describe('PageOverviewSidebar', () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/`,
       body: {
-        data: [],
+        data: [{trace: '123'}],
       },
     });
 
@@ -43,8 +54,12 @@ describe('PageOverviewSidebar', () => {
     });
   });
 
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('should render', () => {
-    render(<PageOverviewSidebar transaction={TRANSACTION_NAME} />);
+    render(<PageOverviewSidebar transaction={TRANSACTION_NAME} />, {organization});
 
     expect(screen.getByText('Performance Score')).toBeInTheDocument();
     expect(screen.getByText('Page Loads')).toBeInTheDocument();

--- a/static/app/views/insights/browser/webVitals/components/pageOverviewSidebar.tsx
+++ b/static/app/views/insights/browser/webVitals/components/pageOverviewSidebar.tsx
@@ -5,19 +5,25 @@ import styled from '@emotion/styled';
 import ChartZoom from 'sentry/components/charts/chartZoom';
 import type {LineChartSeries} from 'sentry/components/charts/lineChart';
 import {LineChart} from 'sentry/components/charts/lineChart';
-import {ExternalLink} from 'sentry/components/core/link';
+import {ExternalLink, Link} from 'sentry/components/core/link';
+import Placeholder from 'sentry/components/placeholder';
 import QuestionTooltip from 'sentry/components/questionTooltip';
+import {IconFocus, IconSeer} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {PageFilters} from 'sentry/types/core';
 import type {SeriesDataUnit} from 'sentry/types/echarts';
 import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
+import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import PerformanceScoreRingWithTooltips from 'sentry/views/insights/browser/webVitals/components/performanceScoreRingWithTooltips';
 import {useProjectRawWebVitalsValuesTimeseriesQuery} from 'sentry/views/insights/browser/webVitals/queries/rawWebVitalsQueries/useProjectRawWebVitalsValuesTimeseriesQuery';
+import {usePageSummary} from 'sentry/views/insights/browser/webVitals/queries/usePageSummary';
+import {useSpanSamplesWebVitalsQuery} from 'sentry/views/insights/browser/webVitals/queries/useSpanSamplesWebVitalsQuery';
 import {MODULE_DOC_LINK} from 'sentry/views/insights/browser/webVitals/settings';
 import type {ProjectScore} from 'sentry/views/insights/browser/webVitals/types';
 import type {BrowserType} from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
+import {useHasSeerWebVitalsSuggestions} from 'sentry/views/insights/browser/webVitals/utils/useHasSeerWebVitalsSuggestions';
 import type {SubregionCode} from 'sentry/views/insights/types';
 import {SidebarSpacer} from 'sentry/views/performance/transactionSummary/utils';
 
@@ -39,6 +45,8 @@ export function PageOverviewSidebar({
   browserTypes,
   subregions,
 }: Props) {
+  const hasSeerWebVitalsSuggestions = useHasSeerWebVitalsSuggestions();
+  const organization = useOrganization();
   const theme = useTheme();
   const pageFilters = usePageFilters();
   const {period, start, end, utc} = pageFilters.selection.datetime;
@@ -106,6 +114,30 @@ export function PageOverviewSidebar({
   const ringSegmentColors = theme.chart.getColorPalette(4);
   const ringBackgroundColors = ringSegmentColors.map(color => `${color}50`);
 
+  // Query for 3 trace samples, targetting pageloads
+  const {data: traceSamples, isLoading: isLoadingTraceSamples} =
+    useSpanSamplesWebVitalsQuery({
+      transaction,
+      limit: 3,
+      webVital: 'ttfb', // Using TTFB as a proxy for pageloads
+      enabled: hasSeerWebVitalsSuggestions,
+    });
+
+  const traceIds = traceSamples?.map(sample => sample.trace);
+
+  const {data: pageSummary, isLoading: isLoadingPageSummary} = usePageSummary(traceIds, {
+    enabled: hasSeerWebVitalsSuggestions && !isLoadingTraceSamples,
+  });
+
+  const insightCards = [
+    {
+      id: 'suggestions',
+      title: t('Suggestions'),
+      insight: pageSummary?.suggestedInvestigations,
+      icon: <IconFocus size="sm" />,
+    },
+  ];
+
   return (
     <Fragment>
       <SectionHeading>
@@ -137,6 +169,65 @@ export function PageOverviewSidebar({
         )}
         {projectScoreIsLoading && <ProjectScoreEmptyLoadingElement />}
       </SidebarPerformanceScoreRingContainer>
+      <SidebarSpacer />
+      {hasSeerWebVitalsSuggestions && (
+        <Fragment>
+          <SectionHeading>{t('Seer Suggestions')}</SectionHeading>
+          <Content>
+            <InsightGrid>
+              {isLoadingPageSummary && <Placeholder height="1.5rem" />}
+              {insightCards.map(card => {
+                if (!card.insight) {
+                  return null;
+                }
+                if (!card.insight || typeof card.insight !== 'object') {
+                  return null;
+                }
+                return card.insight.map(insight => (
+                  <InsightCard key={card.id}>
+                    <CardTitle>
+                      <CardTitleIcon>
+                        <StyledIconSeer size="md" />
+                      </CardTitleIcon>
+                      <div>
+                        <SpanOp>{insight.spanOp}</SpanOp>
+                        <Summary>
+                          {' - '}
+                          {insight.explanation}
+                        </Summary>
+                      </div>
+                    </CardTitle>
+                    <CardContentContainer>
+                      <CardLineDecorationWrapper>
+                        <CardLineDecoration />
+                      </CardLineDecorationWrapper>
+                      <CardContent>
+                        <SuggestionsList>
+                          {insight.suggestions.map((suggestion, i) => (
+                            <li key={i}>{suggestion}</li>
+                          ))}
+                        </SuggestionsList>
+                        <SuggestionLinks>
+                          <Link
+                            to={`/organizations/${organization.slug}/insights/frontend/trace/${insight.traceId}/?node=span-${insight.spanId}`}
+                          >
+                            {t('Example')}
+                          </Link>
+                          {insight.referenceUrl && (
+                            <ExternalLink href={insight.referenceUrl}>
+                              {t('Reference')}
+                            </ExternalLink>
+                          )}
+                        </SuggestionLinks>
+                      </CardContent>
+                    </CardContentContainer>
+                  </InsightCard>
+                ));
+              })}
+            </InsightGrid>
+          </Content>
+        </Fragment>
+      )}
       <SidebarSpacer />
       <SectionHeading>
         {t('Page Loads')}
@@ -313,4 +404,104 @@ const SectionHeading = styled('h4')`
 const ProjectScoreEmptyLoadingElement = styled('div')`
   width: 220px;
   height: 160px;
+`;
+
+const Content = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: ${space(1)};
+  position: relative;
+  margin: ${space(1)} 0;
+`;
+
+const InsightGrid = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: ${space(1)};
+`;
+
+const InsightCard = styled('div')`
+  display: flex;
+  flex-direction: column;
+  border-radius: ${p => p.theme.borderRadius};
+  width: 100%;
+  min-height: 0;
+`;
+
+const CardTitle = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${space(1)};
+  padding-bottom: ${space(0.5)};
+`;
+
+const SpanOp = styled('p')`
+  margin: 0;
+  font-size: ${p => p.theme.fontSize.md};
+  font-weight: ${p => p.theme.fontWeight.bold};
+  display: inline;
+`;
+const Summary = styled('p')`
+  margin: 0;
+  font-size: ${p => p.theme.fontSize.md};
+  display: inline;
+`;
+
+const CardTitleIcon = styled('div')`
+  display: flex;
+  align-items: center;
+  color: ${p => p.theme.subText};
+`;
+
+const CardContentContainer = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${space(1)};
+`;
+
+const CardLineDecorationWrapper = styled('div')`
+  display: flex;
+  width: 14px;
+  align-self: stretch;
+  justify-content: center;
+  flex-shrink: 0;
+  padding: 0.275rem 0;
+`;
+
+const CardLineDecoration = styled('div')`
+  width: 1px;
+  align-self: stretch;
+  background-color: ${p => p.theme.border};
+`;
+
+const CardContent = styled('div')`
+  overflow-wrap: break-word;
+  word-break: break-word;
+  p {
+    margin: 0;
+    white-space: pre-wrap;
+  }
+  code {
+    word-break: break-all;
+  }
+  flex: 1;
+`;
+
+const SuggestionsList = styled('ul')`
+  margin: ${space(0.5)} 0;
+`;
+
+const SuggestionLinks = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${space(1)};
+
+  > *:not(:last-child) {
+    border-right: 1px solid ${p => p.theme.border};
+    padding-right: ${space(1)};
+  }
+`;
+
+const StyledIconSeer = styled(IconSeer)`
+  color: ${p => p.theme.blue400};
 `;

--- a/static/app/views/insights/browser/webVitals/components/pageOverviewSidebar.tsx
+++ b/static/app/views/insights/browser/webVitals/components/pageOverviewSidebar.tsx
@@ -177,9 +177,6 @@ export function PageOverviewSidebar({
             <InsightGrid>
               {isLoadingPageSummary && <Placeholder height="1.5rem" />}
               {insightCards.map(card => {
-                if (!card.insight) {
-                  return null;
-                }
                 if (!card.insight || typeof card.insight !== 'object') {
                   return null;
                 }

--- a/static/app/views/insights/browser/webVitals/components/pageOverviewSidebar.tsx
+++ b/static/app/views/insights/browser/webVitals/components/pageOverviewSidebar.tsx
@@ -126,7 +126,11 @@ export function PageOverviewSidebar({
   const traceIds = traceSamples?.map(sample => sample.trace);
 
   const {data: pageSummary, isLoading: isLoadingPageSummary} = usePageSummary(traceIds, {
-    enabled: hasSeerWebVitalsSuggestions && !isLoadingTraceSamples,
+    enabled:
+      traceIds &&
+      traceIds.length > 0 &&
+      hasSeerWebVitalsSuggestions &&
+      !isLoadingTraceSamples,
   });
 
   const insightCards = [

--- a/static/app/views/insights/browser/webVitals/components/pageOverviewSidebar.tsx
+++ b/static/app/views/insights/browser/webVitals/components/pageOverviewSidebar.tsx
@@ -115,22 +115,17 @@ export function PageOverviewSidebar({
   const ringBackgroundColors = ringSegmentColors.map(color => `${color}50`);
 
   // Query for 3 trace samples, targetting pageloads
-  const {data: traceSamples, isLoading: isLoadingTraceSamples} =
-    useSpanSamplesWebVitalsQuery({
-      transaction,
-      limit: 3,
-      webVital: 'ttfb', // Using TTFB as a proxy for pageloads
-      enabled: hasSeerWebVitalsSuggestions,
-    });
+  const {data: traceSamples} = useSpanSamplesWebVitalsQuery({
+    transaction,
+    limit: 3,
+    webVital: 'ttfb', // Using TTFB as a proxy for pageloads
+    enabled: hasSeerWebVitalsSuggestions,
+  });
 
   const traceIds = traceSamples?.map(sample => sample.trace);
 
   const {data: pageSummary, isLoading: isLoadingPageSummary} = usePageSummary(traceIds, {
-    enabled:
-      traceIds &&
-      traceIds.length > 0 &&
-      hasSeerWebVitalsSuggestions &&
-      !isLoadingTraceSamples,
+    enabled: hasSeerWebVitalsSuggestions && traceIds && traceIds.length > 0,
   });
 
   const insightCards = [

--- a/static/app/views/insights/browser/webVitals/components/pageOverviewSidebar.tsx
+++ b/static/app/views/insights/browser/webVitals/components/pageOverviewSidebar.tsx
@@ -192,7 +192,7 @@ export function PageOverviewSidebar({
                       <div>
                         <SpanOp>{insight.spanOp}</SpanOp>
                         <Summary>
-                          {' - '}
+                          {' \u2014 '}
                           {insight.explanation}
                         </Summary>
                       </div>

--- a/static/app/views/insights/browser/webVitals/queries/usePageSummary.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/usePageSummary.tsx
@@ -1,0 +1,42 @@
+import type {UseApiQueryOptions} from 'sentry/utils/queryClient';
+import {useApiQuery} from 'sentry/utils/queryClient';
+import useOrganization from 'sentry/utils/useOrganization';
+
+type PageSummary = {
+  keyObservations: string;
+  performanceCharacteristics: string;
+  suggestedInvestigations: SuggestedInvestigation[];
+  summary: string;
+};
+
+type SuggestedInvestigation = {
+  explanation: string;
+  referenceUrl: string | null;
+  spanId: string;
+  spanOp: string;
+  suggestions: string[];
+  traceId: string;
+};
+
+export function usePageSummary(
+  traceSlugs: string[],
+  options: Partial<UseApiQueryOptions<PageSummary>> = {}
+) {
+  const organization = useOrganization();
+  return useApiQuery<PageSummary>(
+    [
+      `/organizations/${organization.slug}/page-web-vitals-summary/`,
+      {
+        data: {
+          traceSlugs,
+        },
+        method: 'POST',
+      },
+    ],
+    {
+      staleTime: 0,
+      retry: false,
+      ...options,
+    }
+  );
+}

--- a/static/app/views/insights/browser/webVitals/utils/useHasSeerWebVitalsSuggestions.tsx
+++ b/static/app/views/insights/browser/webVitals/utils/useHasSeerWebVitalsSuggestions.tsx
@@ -1,0 +1,7 @@
+import useOrganization from 'sentry/utils/useOrganization';
+
+export function useHasSeerWebVitalsSuggestions() {
+  const organization = useOrganization();
+
+  return organization.features.includes('performance-web-vitals-seer-suggestions');
+}


### PR DESCRIPTION
Updates the Web Vitals Page overview page to display seer suggestions on the side nav if `performance-web-vitals-seer-suggestions` is enabled. Up to 3 pageload traces are queried before passing them to the `/page-web-vitals-summary/` endpoint to fetch data for seer suggestions.

<img width="753" height="789" alt="Screenshot 2025-07-21 at 12 25 53 PM" src="https://github.com/user-attachments/assets/7acb338a-2178-457a-a8cf-72ccc396da4e" />
