### PR TITLE
feat(otlp): Unroll span links into a friendlier format in trace item details endpoint

### DIFF
--- a/src/sentry/api/endpoints/project_trace_item_details.py
+++ b/src/sentry/api/endpoints/project_trace_item_details.py
@@ -183,7 +183,7 @@ def serialize_link(link: dict) -> dict:
         "traceId": link["trace_id"],
     }
 
-    if sampled := link.get("sampled"):
+    if (sampled := link.get("sampled")) is not None:
         clean_link["sampled"] = sampled
 
     if attributes := link.get("attributes"):

--- a/src/sentry/api/endpoints/project_trace_item_details.py
+++ b/src/sentry/api/endpoints/project_trace_item_details.py
@@ -184,8 +184,8 @@ def serialize_links(attributes: list[dict]) -> list[dict] | None:
             ]
         else:
             return None
-    except json.JSONDecodeError as err:
-        sentry_sdk.capture_exception(err)
+    except Exception as e:
+        sentry_sdk.capture_exception(e)
         return None
 
 

--- a/tests/snuba/api/endpoints/test_project_trace_item_details.py
+++ b/tests/snuba/api/endpoints/test_project_trace_item_details.py
@@ -458,9 +458,12 @@ class ProjectTraceItemDetailsEndpointTest(APITestCase, SnubaTestCase, OurLogTest
         )
         assert trace_details_response.data["links"] == [
             {
-                "trace_id": "d099bf9ad5a143cf8f83a98081d0ed3b",
-                "span_id": "8873a98879faf06d",
+                "traceId": "d099bf9ad5a143cf8f83a98081d0ed3b",
+                "itemId": "8873a98879faf06d",
                 "sampled": True,
-                "attributes": {"sentry.link.type": "parent", "sentry.dropped_attributes_count": 1},
+                "attributes": [
+                    {"name": "sentry.link.type", "value": "parent", "type": "str"},
+                    {"name": "sentry.dropped_attributes_count", "value": 1, "type": "int"},
+                ],
             }
         ]


### PR DESCRIPTION
Supports OPE-50. We store span links as JSON blobs, and we parse the JSON in the trace item details endpoint. The storage format is different from the desired output format right now, this PR updates the code to re-format the span links to more familiar format. This makes it easier to render the span link attributes as an attribute tree on the frontend.
