### PR TITLE
chore(anomaly detection): fully remove rollout flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -50,8 +50,6 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:alert-allow-indexed", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Use metrics as the dataset for crash free metric alerts
     manager.add("organizations:alert-crash-free-metrics", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable anomaly detection feature for rollout
-    manager.add("organizations:anomaly-detection-rollout", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, default=True, api_expose=True)
     # Enable anomaly detection feature for EAP spans
     manager.add("organizations:anomaly-detection-eap", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable anr frame analysis

--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -63,7 +63,6 @@ class OrganizationSerializerTest(TestCase):
         assert result["id"] == str(organization.id)
         assert result["features"] == [
             "advanced-search",
-            "anomaly-detection-rollout",
             "change-alerts",
             "crash-rate-alerts",
             "custom-symbol-sources",


### PR DESCRIPTION
After the config has been removed from options automator, we can fully delete the flag from sentry.

Merge/deploy this first: https://github.com/getsentry/sentry-options-automator/pull/4595