### PR TITLE
chore(deletions): Do not call event stream to start and delete groups 

### DIFF
--- a/src/sentry/deletions/defaults/group.py
+++ b/src/sentry/deletions/defaults/group.py
@@ -9,7 +9,7 @@ from typing import Any
 from sentry_sdk import set_tag
 from snuba_sdk import DeleteQuery, Request
 
-from sentry import eventstore, eventstream, models, nodestore
+from sentry import eventstore, models, nodestore
 from sentry.eventstore.models import Event
 from sentry.issues.grouptype import GroupCategory, InvalidGroupTypeError
 from sentry.models.group import Group, GroupStatus
@@ -173,11 +173,8 @@ class ErrorEventsDeletionTask(EventsBaseDeletionTask):
         ).delete()
 
     def delete_events_from_snuba(self) -> None:
-        # Remove all group events now that their node data has been removed.
-        for project_id, groups in self.project_groups.items():
-            group_ids = [group.id for group in groups]
-            eventstream_state = eventstream.backend.start_delete_groups(project_id, group_ids)
-            eventstream.backend.end_delete_groups(eventstream_state)
+        # TODO: File a ticket to delete events from snuba
+        pass
 
 
 class IssuePlatformEventsDeletionTask(EventsBaseDeletionTask):

--- a/src/sentry/deletions/tasks/groups.py
+++ b/src/sentry/deletions/tasks/groups.py
@@ -34,10 +34,11 @@ from sentry.taskworker.retry import Retry
 def delete_groups(
     object_ids: Sequence[int],
     transaction_id: str | None = None,
+    # TODO: Remove after this PR merges
     eventstream_state: Mapping[str, Any] | None = None,
     **kwargs: Any,
 ) -> None:
-    from sentry import deletions, eventstream
+    from sentry import deletions
     from sentry.models.group import Group
 
     current_batch, rest = object_ids[:GROUP_CHUNK_SIZE], object_ids[GROUP_CHUNK_SIZE:]
@@ -79,10 +80,5 @@ def delete_groups(
             kwargs={
                 "object_ids": object_ids if has_more else rest,
                 "transaction_id": transaction_id,
-                "eventstream_state": eventstream_state,
             },
         )
-    else:
-        # all groups have been deleted
-        if eventstream_state:
-            eventstream.backend.end_delete_groups(eventstream_state)

--- a/src/sentry/eventstream/base.py
+++ b/src/sentry/eventstream/base.py
@@ -40,8 +40,6 @@ GroupStates = Sequence[GroupState]
 class EventStream(Service):
     __all__ = (
         "insert",
-        "start_delete_groups",
-        "end_delete_groups",
         "start_merge",
         "end_merge",
         "start_unmerge",
@@ -140,12 +138,6 @@ class EventStream(Service):
             occurrence_id=event.occurrence_id if isinstance(event, GroupEvent) else None,
             eventstream_type=eventstream_type,
         )
-
-    def start_delete_groups(self, project_id: int, group_ids: Sequence[int]) -> Mapping[str, Any]:
-        raise NotImplementedError
-
-    def end_delete_groups(self, state: Mapping[str, Any]) -> None:
-        pass
 
     def start_merge(
         self, project_id: int, previous_group_ids: Sequence[int], new_group_id: int

--- a/src/sentry/eventstream/kafka/protocol.py
+++ b/src/sentry/eventstream/kafka/protocol.py
@@ -63,8 +63,6 @@ version_handlers = {
     2: basic_protocol_handler(
         unsupported_operations=frozenset(
             [
-                "start_delete_groups",
-                "end_delete_groups",
                 "start_merge",
                 "end_merge",
                 "start_unmerge",
@@ -151,7 +149,7 @@ def decode_optional_list_str(value: str | None) -> Sequence[Any] | None:
 
 
 def get_task_kwargs_for_message_from_headers(
-    headers: Sequence[tuple[str, bytes | None]]
+    headers: Sequence[tuple[str, bytes | None]],
 ) -> dict[str, Any] | None:
     """
     Same as get_task_kwargs_for_message but gets the required information from

--- a/src/sentry/eventstream/snuba.py
+++ b/src/sentry/eventstream/snuba.py
@@ -43,12 +43,6 @@ if TYPE_CHECKING:
 #   }, {
 #       ...state for post-processing...
 #   })
-#   Delete Groups: (2, '(start_delete_groups|end_delete_groups)', {
-#       'transaction_id': uuid,
-#       'project_id': id,
-#       'group_ids': [id2, id2, id3],
-#       'datetime': timestamp,
-#   })
 #   Merge: (2, '(start_merge|end_merge)', {
 #       'transaction_id': uuid,
 #       'project_id': id,
@@ -201,31 +195,6 @@ class SnubaProtocolEventStream(EventStream):
             asynchronous=kwargs.get("asynchronous", True),
             skip_semantic_partitioning=skip_semantic_partitioning,
             event_type=event_type,
-        )
-
-    def start_delete_groups(self, project_id: int, group_ids: Sequence[int]) -> Mapping[str, Any]:
-        if not group_ids:
-            raise ValueError("expected groups to delete!")
-
-        state = {
-            "transaction_id": str(uuid4().hex),
-            "project_id": project_id,
-            "group_ids": list(group_ids),
-            "datetime": json.datetime_to_str(datetime.now(tz=timezone.utc)),
-        }
-
-        self._send(project_id, "start_delete_groups", extra_data=(state,), asynchronous=False)
-
-        return state
-
-    def end_delete_groups(self, state: Mapping[str, Any]) -> None:
-        state_copy: MutableMapping[str, Any] = {**state}
-        state_copy["datetime"] = json.datetime_to_str(datetime.now(tz=timezone.utc))
-        self._send(
-            state_copy["project_id"],
-            "end_delete_groups",
-            extra_data=(state_copy,),
-            asynchronous=False,
         )
 
     def start_merge(


### PR DESCRIPTION
It's not being used.

See this code: https://github.com/getsentry/snuba/blob/db7ba70631130fa139ecb23921e6daf13c54f698/snuba/replacers/errors_replacer.py#L191-L197