### PR TITLE
fix(billing): only use invoice tax number

### DIFF
--- a/static/gsApp/views/invoiceDetails/index.spec.tsx
+++ b/static/gsApp/views/invoiceDetails/index.spec.tsx
@@ -311,9 +311,9 @@ describe('InvoiceDetails', function () {
       ).toBeInTheDocument();
       expect(screen.getByText('Details:')).toBeInTheDocument();
       expect(screen.getByText(`${billingDetails.displayAddress}`)).toBeInTheDocument();
-      expect(screen.getByText('Tax Number:')).toBeInTheDocument();
-      expect(screen.getByText(`${billingDetails.taxNumber}`)).toBeInTheDocument();
       expect(screen.getByText(`${billingDetails.billingEmail}`)).toBeInTheDocument();
+      expect(screen.queryByText('Tax Number:')).not.toBeInTheDocument();
+      expect(screen.queryByText(`${billingDetails.taxNumber}`)).not.toBeInTheDocument();
       expect(screen.queryByText('Country Id: 1234')).not.toBeInTheDocument();
       expect(screen.queryByText('Regional Tax Id: 5678')).not.toBeInTheDocument();
     });

--- a/static/gsApp/views/invoiceDetails/index.tsx
+++ b/static/gsApp/views/invoiceDetails/index.tsx
@@ -141,7 +141,7 @@ function InvoiceAttributes({invoice, billingDetails}: AttributeProps) {
   const contactInfo = invoice?.displayAddress || billingDetails?.displayAddress;
   const companyName = billingDetails?.companyName;
   const billingEmail = billingDetails?.billingEmail;
-  const taxNumber = invoice?.taxNumber || billingDetails?.taxNumber;
+  const taxNumber = invoice?.taxNumber;
   const countryCode = invoice?.countryCode || billingDetails?.countryCode;
   const taxNumberName = `${getTaxFieldInfo(countryCode).label}:`;
 


### PR DESCRIPTION
closes https://linear.app/getsentry/issue/BIL-1173/remove-vat-id-visibility-on-prior-invoices