### PR TITLE
feat(replay): show placeholder message if the replay has no summary/breadcrumbs

### DIFF
--- a/static/app/views/replays/detail/ai/ai.tsx
+++ b/static/app/views/replays/detail/ai/ai.tsx
@@ -12,10 +12,12 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useReplayReader} from 'sentry/utils/replays/playback/providers/replayReaderProvider';
+import {isSpanFrame} from 'sentry/utils/replays/types';
 import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjectFromId from 'sentry/utils/useProjectFromId';
 import {ChapterList} from 'sentry/views/replays/detail/ai/chapterList';
+import {NO_REPLAY_SUMMARY_MESSAGES} from 'sentry/views/replays/detail/ai/utils';
 import TabItemContainer from 'sentry/views/replays/detail/tabItemContainer';
 
 import {useFetchReplaySummary} from './useFetchReplaySummary';
@@ -108,7 +110,7 @@ export default function Ai() {
     return (
       <Wrapper data-test-id="replay-details-ai-summary-tab">
         <EmptySummaryContainer>
-          <Alert type="error">{t('Failed to load replay summary')}</Alert>
+          <Alert type="error">{t('Failed to load replay summary.')}</Alert>
         </EmptySummaryContainer>
       </Wrapper>
     );
@@ -124,6 +126,29 @@ export default function Ai() {
         </EmptySummaryContainer>
       </Wrapper>
     );
+  }
+
+  if (summaryData.data.time_ranges.length <= 1) {
+    if (
+      replay
+        ?.getChapterFrames()
+        ?.filter(frame => isSpanFrame(frame) || frame.category !== 'replay.init')
+        .length === 0
+    ) {
+      return (
+        <Wrapper data-test-id="replay-details-ai-summary-tab">
+          <EmptySummaryContainer>
+            <Alert type="info" showIcon={false}>
+              {
+                NO_REPLAY_SUMMARY_MESSAGES[
+                  Math.floor(Math.random() * NO_REPLAY_SUMMARY_MESSAGES.length)
+                ]
+              }
+            </Alert>
+          </EmptySummaryContainer>
+        </Wrapper>
+      );
+    }
   }
 
   return (

--- a/static/app/views/replays/detail/ai/utils.tsx
+++ b/static/app/views/replays/detail/ai/utils.tsx
@@ -1,0 +1,10 @@
+import {t} from 'sentry/locale';
+
+export const NO_REPLAY_SUMMARY_MESSAGES = [
+  t('Quiet moment here — nothing too wild happening in this replay.'),
+  t('Looks like a peaceful little replay!'),
+  t('Just a calm moment in the timeline.'),
+  t('This replay is taking it easy.'),
+  t('Not a lot happening here — maybe a coffee break?'),
+  t('All quiet on the replay front.'),
+];


### PR DESCRIPTION
for now, this determination is done on the frontend, but we could eventually move it to the backend so that we skip the extra LLM call if the input data is sparse.

https://github.com/user-attachments/assets/1f535679-2e1c-4bf4-be5c-811728ec69f8

closes https://linear.app/getsentry/issue/REPLAY-491/decide-whether-short-replays-should-have-a-summary