### PR TITLE
ref: add a `ui/*` path alias for core/components

### DIFF
--- a/config/tsconfig.base.json
+++ b/config/tsconfig.base.json
@@ -104,7 +104,8 @@
       "sentry-fonts/*": ["../static/fonts/*"],
       "getsentry/*": ["../static/gsApp/*"],
       "getsentry-images/*": ["../static/images/*"],
-      "admin/*": ["../static/gsAdmin/*"]
+      "admin/*": ["../static/gsAdmin/*"],
+      "ui/*": ["../static/app/components/core/*"],
     },
 
     "plugins": [

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -625,6 +625,8 @@ export default typescript.config([
             // Internal packages.
             ['^(sentry-locale|sentry-images)(/.*|$)'],
 
+            ['^ui(/.*|$)'],
+
             ['^(app|sentry)(/.*|$)'],
 
             // Getsentry packages.


### PR DESCRIPTION
This will allow us to change all core component imports to /ui, which will then allow us to move those core components out of static/app while not having to change imports
