### PR TITLE
feat(taskworker): Automatically compression taskworker paramters greater than 3MB

### DIFF
--- a/src/sentry/taskworker/constants.py
+++ b/src/sentry/taskworker/constants.py
@@ -36,6 +36,12 @@ before being restarted.
 """
 
 
+MAX_PARAMETER_BYTES_BEFORE_COMPRESSION = 3000000  # 3MB
+"""
+The maximum number of bytes before a task parameter is compressed.
+"""
+
+
 class CompressionType(Enum):
     """
     The type of compression used for task parameters.


### PR DESCRIPTION
If a task payload is greater than 3MB, the taskworker platform should automatically compress the payload using ZSTD