### PR TITLE
chore(gitlab): record gitlab exchange token json error with status code

### DIFF
--- a/src/sentry/identity/oauth2.py
+++ b/src/sentry/identity/oauth2.py
@@ -337,7 +337,12 @@ class OAuth2CallbackView:
                 return orjson.loads(body)
             except orjson.JSONDecodeError:
                 lifecycle.record_failure(
-                    "json_error", {"content_type": content_type, "url": self.access_token_url}
+                    "json_error",
+                    {
+                        "content_type": content_type,
+                        "url": self.access_token_url,
+                        "status_code": req.status_code,
+                    },
                 )
                 return {
                     "error": "Could not decode a JSON Response",


### PR DESCRIPTION
While looking into a customer issue, I realized we could tell them exactly what status code we're getting back if we just log it