### PR TITLE
feat(dashboards): Add Duplicate and Delete actions from the context menu on each dashboard row

### DIFF
--- a/static/app/views/dashboards/hooks/useDeleteDashboard.tsx
+++ b/static/app/views/dashboards/hooks/useDeleteDashboard.tsx
@@ -1,0 +1,39 @@
+import {useCallback} from 'react';
+
+import {deleteDashboard as deleteDashboardAction} from 'sentry/actionCreators/dashboards';
+import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
+import {t} from 'sentry/locale';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import useApi from 'sentry/utils/useApi';
+import useOrganization from 'sentry/utils/useOrganization';
+import type {DashboardListItem} from 'sentry/views/dashboards/types';
+
+interface UseDeleteDashboardProps {
+  onSuccess: () => void;
+}
+
+export function useDeleteDashboard({onSuccess}: UseDeleteDashboardProps) {
+  const api = useApi();
+  const organization = useOrganization();
+
+  const deleteDashboard = useCallback(
+    (dashboard: DashboardListItem, viewType: 'table' | 'grid') => {
+      deleteDashboardAction(api, organization.slug, dashboard.id)
+        .then(() => {
+          trackAnalytics('dashboards_manage.delete', {
+            organization,
+            dashboard_id: parseInt(dashboard.id, 10),
+            view_type: viewType,
+          });
+          onSuccess();
+          addSuccessMessage(t('Dashboard deleted'));
+        })
+        .catch(() => {
+          addErrorMessage(t('Error deleting Dashboard'));
+        });
+    },
+    [api, organization, onSuccess]
+  );
+
+  return deleteDashboard;
+}

--- a/static/app/views/dashboards/hooks/useDuplicateDashboard.tsx
+++ b/static/app/views/dashboards/hooks/useDuplicateDashboard.tsx
@@ -1,0 +1,46 @@
+import {useCallback} from 'react';
+
+import {createDashboard, fetchDashboard} from 'sentry/actionCreators/dashboards';
+import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
+import {t} from 'sentry/locale';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import useApi from 'sentry/utils/useApi';
+import useOrganization from 'sentry/utils/useOrganization';
+import type {DashboardListItem} from 'sentry/views/dashboards/types';
+import {cloneDashboard} from 'sentry/views/dashboards/utils';
+
+interface UseDuplicateDashboardProps {
+  onSuccess: () => void;
+}
+
+export function useDuplicateDashboard({onSuccess}: UseDuplicateDashboardProps) {
+  const api = useApi();
+  const organization = useOrganization();
+
+  const duplicateDashboard = useCallback(
+    async (dashboard: DashboardListItem, viewType: 'table' | 'grid') => {
+      try {
+        const dashboardDetail = await fetchDashboard(
+          api,
+          organization.slug,
+          dashboard.id
+        );
+        const newDashboard = cloneDashboard(dashboardDetail);
+        newDashboard.widgets.map(widget => (widget.id = undefined));
+        await createDashboard(api, organization.slug, newDashboard, true);
+        trackAnalytics('dashboards_manage.duplicate', {
+          organization,
+          dashboard_id: parseInt(dashboard.id, 10),
+          view_type: viewType,
+        });
+        onSuccess();
+        addSuccessMessage(t('Dashboard duplicated'));
+      } catch (e) {
+        addErrorMessage(t('Error duplicating Dashboard'));
+      }
+    },
+    [api, organization, onSuccess]
+  );
+
+  return duplicateDashboard;
+}

--- a/static/app/views/dashboards/manage/tableView/table.tsx
+++ b/static/app/views/dashboards/manage/tableView/table.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 
 import {updateDashboardFavorite} from 'sentry/actionCreators/dashboards';
 import {ActivityAvatar} from 'sentry/components/activity/item/avatar';
+import {openConfirmModal} from 'sentry/components/confirm';
 import {UserAvatar} from 'sentry/components/core/avatar/userAvatar';
 import {Tooltip} from 'sentry/components/core/tooltip';
 import type {CursorHandler} from 'sentry/components/pagination';
@@ -13,6 +14,7 @@ import {useQueryClient} from 'sentry/utils/queryClient';
 import useApi from 'sentry/utils/useApi';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
+import {useDeleteDashboard} from 'sentry/views/dashboards/hooks/useDeleteDashboard';
 import {useDuplicateDashboard} from 'sentry/views/dashboards/hooks/useDuplicateDashboard';
 import {useResetDashboardLists} from 'sentry/views/dashboards/hooks/useResetDashboardLists';
 import type {DashboardListItem} from 'sentry/views/dashboards/types';
@@ -38,9 +40,10 @@ export function DashboardTable({
   const navigate = useNavigate();
   const resetDashboardLists = useResetDashboardLists();
   const handleDuplicateDashboard = useDuplicateDashboard({
-    onSuccess: () => {
-      resetDashboardLists();
-    },
+    onSuccess: resetDashboardLists,
+  });
+  const handleDeleteDashboard = useDeleteDashboard({
+    onSuccess: resetDashboardLists,
   });
 
   const handleCursor: CursorHandler = (_cursor, pathname, query) => {
@@ -160,7 +163,15 @@ export function DashboardTable({
                           key: 'delete',
                           label: t('Delete'),
                           priority: 'danger' as const,
-                          onAction: () => {},
+                          onAction: () => {
+                            openConfirmModal({
+                              message: t(
+                                'Are you sure you want to delete this dashboard?'
+                              ),
+                              priority: 'danger',
+                              onConfirm: () => handleDeleteDashboard(dashboard, 'table'),
+                            });
+                          },
                         },
                       ]),
                 ]}

--- a/static/app/views/dashboards/manage/tableView/table.tsx
+++ b/static/app/views/dashboards/manage/tableView/table.tsx
@@ -13,6 +13,7 @@ import {useQueryClient} from 'sentry/utils/queryClient';
 import useApi from 'sentry/utils/useApi';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
+import {useDuplicateDashboard} from 'sentry/views/dashboards/hooks/useDuplicateDashboard';
 import {useResetDashboardLists} from 'sentry/views/dashboards/hooks/useResetDashboardLists';
 import type {DashboardListItem} from 'sentry/views/dashboards/types';
 
@@ -36,6 +37,11 @@ export function DashboardTable({
   const organization = useOrganization();
   const navigate = useNavigate();
   const resetDashboardLists = useResetDashboardLists();
+  const handleDuplicateDashboard = useDuplicateDashboard({
+    onSuccess: () => {
+      resetDashboardLists();
+    },
+  });
 
   const handleCursor: CursorHandler = (_cursor, pathname, query) => {
     navigate({
@@ -141,21 +147,11 @@ export function DashboardTable({
             </SavedEntityTable.Cell>
             <SavedEntityTable.Cell data-column="actions" hasButton>
               <SavedEntityTable.CellActions
-                // TODO: DAIN-717 Add action handlers
                 items={[
-                  ...(dashboard.createdBy === null
-                    ? []
-                    : [
-                        {
-                          key: 'rename',
-                          label: t('Rename'),
-                          onAction: () => {},
-                        },
-                      ]),
                   {
                     key: 'duplicate',
                     label: t('Duplicate'),
-                    onAction: () => {},
+                    onAction: () => handleDuplicateDashboard(dashboard, 'table'),
                   },
                   ...(dashboard.createdBy === null
                     ? []


### PR DESCRIPTION
Adds the handlers for duplicate and delete requests from the overview page. The logic for the dropdowns was repeated so I created hooks to encapsulate that endpoint logic.