### PR TITLE
fix(dashboards): portal assignee dropdown on top of all widgets

### DIFF
--- a/static/app/components/assigneeSelectorDropdown.tsx
+++ b/static/app/components/assigneeSelectorDropdown.tsx
@@ -582,6 +582,7 @@ export default function AssigneeSelectorDropdown({
         sizeLimit={sizeLimit}
         sizeLimitMessage="Use search to find more users and teams..."
         strategy="fixed"
+        usePortal
       />
     </AssigneeWrapper>
   );


### PR DESCRIPTION
### Changes

Allow for control dropdown to be portalled in to document body to fix an bug with tables stacking over the assignee dropdown in dashboards.

### Before

<img width="1615" height="787" alt="Screenshot 2025-07-22 at 2 39 30 PM" src="https://github.com/user-attachments/assets/3ad28899-f27c-4433-8a84-f4b6c58c9f38" />


### After

<img width="1650" height="930" alt="Screenshot 2025-07-22 at 2 40 04 PM" src="https://github.com/user-attachments/assets/fb6cb1a1-7d51-4f47-a8d9-63e87aa57380" />

