### PR TITLE
Fix(taskworker): Increase incremental backoff when broker unavailable

### DIFF
--- a/src/sentry/taskworker/constants.py
+++ b/src/sentry/taskworker/constants.py
@@ -35,6 +35,11 @@ The number of tasks a worker child process will process
 before being restarted.
 """
 
+MAX_BACKOFF_SECONDS_WHEN_HOST_UNAVAILABLE = 20
+"""
+The maximum number of seconds to wait before retrying RPCs when the host is unavailable.
+"""
+
 
 class CompressionType(Enum):
     """

--- a/src/sentry/taskworker/worker.py
+++ b/src/sentry/taskworker/worker.py
@@ -302,6 +302,7 @@ class TaskWorker:
             )
             return None
         except HostTemporarilyUnavailable as e:
+            self._setstatus_backoff_seconds = min(self._setstatus_backoff_seconds + 4, 20)
             logger.info(
                 "taskworker.send_update_task.temporarily_unavailable",
                 extra={"task_id": result.task_id, "error": str(e)},
@@ -353,7 +354,7 @@ class TaskWorker:
                 extra={"error": e, "processing_pool": self._processing_pool_name},
             )
 
-            self._gettask_backoff_seconds = min(self._gettask_backoff_seconds + 1, 5)
+            self._gettask_backoff_seconds = min(self._gettask_backoff_seconds + 4, 20)
             return None
 
         if not activation:


### PR DESCRIPTION
Taskbroker restarts during deploys can take a few minutes. This PR increases the maximum wait time before a worker is allowed to retry hitting the same host that has failed its previous gRPC. Additionally, this PR adds the missing backoff time for the set path. 