### PR TITLE
ref(insights): remove `spansIndexed` and `spansMetrics` from `DiscoverDatasets`

### DIFF
--- a/static/app/components/events/searchBar.tsx
+++ b/static/app/components/events/searchBar.tsx
@@ -2,7 +2,7 @@ import {useEffect, useMemo} from 'react';
 import memoize from 'lodash/memoize';
 import omit from 'lodash/omit';
 
-import {fetchSpanFieldValues, fetchTagValues} from 'sentry/actionCreators/tags';
+import {fetchTagValues} from 'sentry/actionCreators/tags';
 import SmartSearchBar from 'sentry/components/deprecatedSmartSearchBar';
 import type {SearchConfig} from 'sentry/components/searchSyntax/parser';
 import {defaultConfig} from 'sentry/components/searchSyntax/parser';
@@ -207,30 +207,20 @@ export default function SearchBar(props: SearchBarProps) {
         return Promise.resolve(DEVICE_CLASS_TAG_VALUES);
       }
 
-      const fetchPromise =
-        dataset === DiscoverDatasets.SPANS_INDEXED
-          ? fetchSpanFieldValues({
-              api,
-              orgSlug: organization.slug,
-              fieldKey: tag.key,
-              search: query,
-              projectIds: projectIdStrings,
-              endpointParams,
-            })
-          : fetchTagValues({
-              api,
-              orgSlug: organization.slug,
-              tagKey: tag.key,
-              search: query,
-              projectIds: projectIdStrings,
-              endpointParams,
-              // allows searching for tags on transactions as well
-              includeTransactions,
-              // allows searching for tags on sessions as well
-              includeSessions: includeSessionTagsValues,
-              // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-              dataset: dataset ? DiscoverDatasetsToDatasetMap[dataset] : undefined,
-            });
+      const fetchPromise = fetchTagValues({
+        api,
+        orgSlug: organization.slug,
+        tagKey: tag.key,
+        search: query,
+        projectIds: projectIdStrings,
+        endpointParams,
+        // allows searching for tags on transactions as well
+        includeTransactions,
+        // allows searching for tags on sessions as well
+        includeSessions: includeSessionTagsValues,
+        // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
+        dataset: dataset ? DiscoverDatasetsToDatasetMap[dataset] : undefined,
+      });
 
       return fetchPromise.then(
         results => results.filter(({name}) => defined(name)).map(({name}) => name),

--- a/static/app/utils/discover/eventView.tsx
+++ b/static/app/utils/discover/eventView.tsx
@@ -1222,9 +1222,7 @@ class EventView {
         per_page: DEFAULT_PER_PAGE,
         query: queryString,
         dataset:
-          this.dataset === DiscoverDatasets.SPANS_EAP_RPC
-            ? DiscoverDatasets.SPANS_EAP
-            : this.dataset,
+          this.dataset === DiscoverDatasets.SPANS ? DiscoverDatasets.SPANS : this.dataset,
       }
     ) as EventQuery & LocationQuery;
 

--- a/static/app/utils/discover/types.tsx
+++ b/static/app/utils/discover/types.tsx
@@ -21,7 +21,6 @@ export enum DiscoverDatasets {
   ISSUE_PLATFORM = 'issuePlatform',
   OURLOGS = 'ourlogs',
   SPANS = 'spans',
-  SPANS_METRICS = 'spansMetrics',
   TRANSACTIONS = 'transactions',
 }
 

--- a/static/app/utils/discover/types.tsx
+++ b/static/app/utils/discover/types.tsx
@@ -20,9 +20,7 @@ export enum DiscoverDatasets {
   METRICS_ENHANCED = 'metricsEnhanced',
   ISSUE_PLATFORM = 'issuePlatform',
   OURLOGS = 'ourlogs',
-  SPANS_EAP = 'spans',
-  SPANS_EAP_RPC = 'spansRpc',
-  SPANS_INDEXED = 'spansIndexed',
+  SPANS = 'spans',
   SPANS_METRICS = 'spansMetrics',
   TRANSACTIONS = 'transactions',
 }

--- a/static/app/views/alerts/rules/metric/utils/getMetricDatasetQueryExtras.tsx
+++ b/static/app/views/alerts/rules/metric/utils/getMetricDatasetQueryExtras.tsx
@@ -37,7 +37,7 @@ export function getMetricDatasetQueryExtras({
 
   if (dataset === Dataset.EVENTS_ANALYTICS_PLATFORM) {
     return {
-      dataset: DiscoverDatasets.SPANS_EAP,
+      dataset: DiscoverDatasets.SPANS,
     };
   }
 
@@ -53,7 +53,7 @@ export function getMetricDatasetQueryExtras({
     queryExtras.dataset = getDiscoverDataset(dataset, newAlertOrQuery);
   }
   if (location?.query?.aggregate?.includes('ai.total')) {
-    queryExtras.dataset = DiscoverDatasets.SPANS_METRICS;
+    queryExtras.dataset = DiscoverDatasets.SPANS;
     queryExtras.query = '';
   }
 

--- a/static/app/views/dashboards/datasetConfig/spans.spec.tsx
+++ b/static/app/views/dashboards/datasetConfig/spans.spec.tsx
@@ -59,7 +59,7 @@ describe('SpansConfig', () => {
       expect(eventsStatsMock).toHaveBeenCalledWith(
         '/organizations/org-slug/events-stats/',
         expect.objectContaining({
-          query: expect.objectContaining({dataset: DiscoverDatasets.SPANS_EAP}),
+          query: expect.objectContaining({dataset: DiscoverDatasets.SPANS}),
         })
       );
     });

--- a/static/app/views/dashboards/datasetConfig/spans.tsx
+++ b/static/app/views/dashboards/datasetConfig/spans.tsx
@@ -283,7 +283,7 @@ function getEventsRequest(
     per_page: limit,
     cursor,
     referrer,
-    dataset: DiscoverDatasets.SPANS_EAP,
+    dataset: DiscoverDatasets.SPANS,
     ...queryExtras,
   };
 
@@ -345,7 +345,7 @@ function getSeriesRequest(
     queryIndex,
     organization,
     pageFilters,
-    DiscoverDatasets.SPANS_EAP,
+    DiscoverDatasets.SPANS,
     referrer
   );
 

--- a/static/app/views/detectors/datasetConfig/utils/discoverDatasetMap.tsx
+++ b/static/app/views/detectors/datasetConfig/utils/discoverDatasetMap.tsx
@@ -7,7 +7,7 @@ export const DETECTOR_DATASET_TO_DISCOVER_DATASET_MAP: Record<
 > = {
   [DetectorDataset.ERRORS]: DiscoverDatasets.ERRORS,
   [DetectorDataset.TRANSACTIONS]: DiscoverDatasets.TRANSACTIONS,
-  [DetectorDataset.SPANS]: DiscoverDatasets.SPANS_EAP,
+  [DetectorDataset.SPANS]: DiscoverDatasets.SPANS,
   [DetectorDataset.LOGS]: DiscoverDatasets.OURLOGS,
   [DetectorDataset.RELEASES]: DiscoverDatasets.DISCOVER,
 };

--- a/static/app/views/discover/results/resultsSearchQueryBuilder.tsx
+++ b/static/app/views/discover/results/resultsSearchQueryBuilder.tsx
@@ -1,11 +1,7 @@
 import {useCallback, useMemo} from 'react';
 import omit from 'lodash/omit';
 
-import {
-  fetchFeatureFlagValues,
-  fetchSpanFieldValues,
-  fetchTagValues,
-} from 'sentry/actionCreators/tags';
+import {fetchFeatureFlagValues, fetchTagValues} from 'sentry/actionCreators/tags';
 import {makeFeatureFlagSearchKey} from 'sentry/components/events/featureFlags/utils';
 import {
   STATIC_FIELD_TAGS,
@@ -274,30 +270,20 @@ function ResultsSearchQueryBuilder(props: Props) {
       if (isDeviceClass(tag.key)) {
         return Promise.resolve(DEVICE_CLASS_TAG_VALUES);
       }
-      const fetchPromise =
-        dataset === DiscoverDatasets.SPANS_INDEXED
-          ? fetchSpanFieldValues({
-              api,
-              endpointParams: dateTimeParams,
-              orgSlug: organization.slug,
-              fieldKey: tag.key,
-              search: query,
-              projectIds: projectIdStrings,
-            })
-          : fetchTagValues({
-              api,
-              endpointParams: dateTimeParams,
-              orgSlug: organization.slug,
-              tagKey: tag.key,
-              search: query,
-              projectIds: projectIdStrings,
-              // allows searching for tags on transactions as well
-              includeTransactions,
-              // allows searching for tags on sessions as well
-              includeSessions: includeSessionTagsValues,
-              // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-              dataset: dataset ? DiscoverDatasetsToDatasetMap[dataset] : undefined,
-            });
+      const fetchPromise = fetchTagValues({
+        api,
+        endpointParams: dateTimeParams,
+        orgSlug: organization.slug,
+        tagKey: tag.key,
+        search: query,
+        projectIds: projectIdStrings,
+        // allows searching for tags on transactions as well
+        includeTransactions,
+        // allows searching for tags on sessions as well
+        includeSessions: includeSessionTagsValues,
+        // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
+        dataset: dataset ? DiscoverDatasetsToDatasetMap[dataset] : undefined,
+      });
 
       try {
         const results = await fetchPromise;

--- a/static/app/views/explore/contexts/pageParamsContext/dataset.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/dataset.tsx
@@ -14,16 +14,12 @@ export function getDatasetFromLocation(location: Location): DiscoverDatasets | u
 }
 
 function parseDataset(rawDataset: string | undefined) {
-  if (rawDataset === 'spansIndexed') {
-    return DiscoverDatasets.SPANS_INDEXED;
-  }
-
   if (rawDataset === 'spansRpc') {
-    return DiscoverDatasets.SPANS_EAP_RPC;
+    return DiscoverDatasets.SPANS;
   }
 
   if (rawDataset === 'spans') {
-    return DiscoverDatasets.SPANS_EAP;
+    return DiscoverDatasets.SPANS;
   }
 
   return undefined;

--- a/static/app/views/explore/contexts/pageParamsContext/index.spec.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/index.spec.tsx
@@ -74,7 +74,7 @@ describe('PageParamsProvider', function () {
 
     act(() =>
       setPageParams({
-        dataset: DiscoverDatasets.SPANS_EAP_RPC,
+        dataset: DiscoverDatasets.SPANS,
         fields: ['id', 'timestamp'],
         mode: Mode.AGGREGATE,
         query: '',
@@ -126,7 +126,7 @@ describe('PageParamsProvider', function () {
 
     expect(pageParams).toEqual(
       expect.objectContaining({
-        dataset: DiscoverDatasets.SPANS_EAP_RPC,
+        dataset: DiscoverDatasets.SPANS,
         fields: ['id', 'span.op', 'timestamp'],
         mode: Mode.AGGREGATE,
         query: '',
@@ -149,7 +149,7 @@ describe('PageParamsProvider', function () {
 
     expect(pageParams).toEqual(
       expect.objectContaining({
-        dataset: DiscoverDatasets.SPANS_EAP_RPC,
+        dataset: DiscoverDatasets.SPANS,
         fields: ['id', 'timestamp', 'span.self_time'],
         mode: Mode.AGGREGATE,
         query: '',
@@ -173,7 +173,7 @@ describe('PageParamsProvider', function () {
 
     expect(pageParams).toEqual(
       expect.objectContaining({
-        dataset: DiscoverDatasets.SPANS_EAP_RPC,
+        dataset: DiscoverDatasets.SPANS,
         fields: ['id', 'timestamp', 'span.self_time'],
         mode: Mode.AGGREGATE,
         query: '',
@@ -196,7 +196,7 @@ describe('PageParamsProvider', function () {
 
     expect(pageParams).toEqual(
       expect.objectContaining({
-        dataset: DiscoverDatasets.SPANS_EAP_RPC,
+        dataset: DiscoverDatasets.SPANS,
         fields: ['id', 'timestamp', 'span.self_time'],
         mode: Mode.AGGREGATE,
         query: '',
@@ -219,7 +219,7 @@ describe('PageParamsProvider', function () {
 
     expect(pageParams).toEqual(
       expect.objectContaining({
-        dataset: DiscoverDatasets.SPANS_EAP_RPC,
+        dataset: DiscoverDatasets.SPANS,
         fields: ['id', 'timestamp', 'span.self_time'],
         mode: Mode.AGGREGATE,
         query: '',
@@ -253,7 +253,7 @@ describe('PageParamsProvider', function () {
 
     expect(pageParams).toEqual(
       expect.objectContaining({
-        dataset: DiscoverDatasets.SPANS_EAP_RPC,
+        dataset: DiscoverDatasets.SPANS,
         fields: ['id', 'timestamp', 'span.self_time'],
         mode: Mode.SAMPLES,
         query: '',
@@ -291,7 +291,7 @@ describe('PageParamsProvider', function () {
 
     expect(pageParams).toEqual(
       expect.objectContaining({
-        dataset: DiscoverDatasets.SPANS_EAP_RPC,
+        dataset: DiscoverDatasets.SPANS,
         fields: [
           'id',
           'sdk.name',
@@ -324,7 +324,7 @@ describe('PageParamsProvider', function () {
 
     expect(pageParams).toEqual(
       expect.objectContaining({
-        dataset: DiscoverDatasets.SPANS_EAP_RPC,
+        dataset: DiscoverDatasets.SPANS,
         fields: ['id', 'timestamp', 'span.self_time'],
         mode: Mode.AGGREGATE,
         query: 'foo:bar',
@@ -347,7 +347,7 @@ describe('PageParamsProvider', function () {
 
     expect(pageParams).toEqual(
       expect.objectContaining({
-        dataset: DiscoverDatasets.SPANS_EAP_RPC,
+        dataset: DiscoverDatasets.SPANS,
         fields: ['id', 'timestamp', 'span.self_time'],
         mode: Mode.SAMPLES,
         query: '',
@@ -370,7 +370,7 @@ describe('PageParamsProvider', function () {
 
     expect(pageParams).toEqual(
       expect.objectContaining({
-        dataset: DiscoverDatasets.SPANS_EAP_RPC,
+        dataset: DiscoverDatasets.SPANS,
         fields: ['id', 'timestamp', 'span.self_time'],
         mode: Mode.SAMPLES,
         query: '',
@@ -402,7 +402,7 @@ describe('PageParamsProvider', function () {
 
     expect(pageParams).toEqual(
       expect.objectContaining({
-        dataset: DiscoverDatasets.SPANS_EAP_RPC,
+        dataset: DiscoverDatasets.SPANS,
         fields: ['id', 'timestamp', 'span.self_time'],
         mode: Mode.AGGREGATE,
         query: '',
@@ -437,7 +437,7 @@ describe('PageParamsProvider', function () {
 
     expect(pageParams).toEqual(
       expect.objectContaining({
-        dataset: DiscoverDatasets.SPANS_EAP_RPC,
+        dataset: DiscoverDatasets.SPANS,
         fields: ['id', 'timestamp', 'span.self_time'],
         mode: Mode.AGGREGATE,
         query: '',
@@ -472,7 +472,7 @@ describe('PageParamsProvider', function () {
 
     expect(pageParams).toEqual(
       expect.objectContaining({
-        dataset: DiscoverDatasets.SPANS_EAP_RPC,
+        dataset: DiscoverDatasets.SPANS,
         fields: ['id', 'timestamp', 'span.self_time'],
         mode: Mode.AGGREGATE,
         query: '',
@@ -504,7 +504,7 @@ describe('PageParamsProvider', function () {
 
     expect(pageParams).toEqual(
       expect.objectContaining({
-        dataset: DiscoverDatasets.SPANS_EAP_RPC,
+        dataset: DiscoverDatasets.SPANS,
         fields: ['id', 'timestamp', 'span.self_time'],
         mode: Mode.AGGREGATE,
         query: '',
@@ -527,7 +527,7 @@ describe('PageParamsProvider', function () {
 
     expect(pageParams).toEqual(
       expect.objectContaining({
-        dataset: DiscoverDatasets.SPANS_EAP_RPC,
+        dataset: DiscoverDatasets.SPANS,
         fields: ['id', 'timestamp'],
         mode: Mode.AGGREGATE,
         query: '',
@@ -556,7 +556,7 @@ describe('PageParamsProvider', function () {
 
     expect(pageParams).toEqual(
       expect.objectContaining({
-        dataset: DiscoverDatasets.SPANS_EAP_RPC,
+        dataset: DiscoverDatasets.SPANS,
         fields: ['id', 'timestamp', 'span.self_time', 'span.duration'],
         mode: Mode.AGGREGATE,
         query: '',

--- a/static/app/views/explore/contexts/pageParamsContext/index.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/index.tsx
@@ -246,7 +246,7 @@ export function useExplorePageParams(): ReadablePageParams {
 }
 
 export function useExploreDataset(): DiscoverDatasets {
-  return DiscoverDatasets.SPANS_EAP_RPC;
+  return DiscoverDatasets.SPANS;
 }
 
 interface UseExploreAggregateFieldsOptions {

--- a/static/app/views/explore/hooks/useAnalytics.tsx
+++ b/static/app/views/explore/hooks/useAnalytics.tsx
@@ -370,7 +370,7 @@ export function useCompareAnalytics({
 > & {
   query: ReadableExploreQueryParts;
 }) {
-  const dataset = DiscoverDatasets.SPANS_EAP_RPC;
+  const dataset = DiscoverDatasets.SPANS;
   const query = queryParts.query;
   const fields = queryParts.fields;
   const visualizes = queryParts.yAxes.map(

--- a/static/app/views/explore/hooks/useTraceSpans.tsx
+++ b/static/app/views/explore/hooks/useTraceSpans.tsx
@@ -46,8 +46,7 @@ export function useTraceSpans<F extends string>({
       environment: selection.environments,
       ...normalizeDateTimeParams(datetime ?? selection.datetime),
       // RPC not supported here yet, fall back to EAP directly
-      dataset:
-        dataset === DiscoverDatasets.SPANS_EAP_RPC ? DiscoverDatasets.SPANS_EAP : dataset,
+      dataset: dataset === DiscoverDatasets.SPANS ? DiscoverDatasets.SPANS : dataset,
       field: fields,
       query,
       sort,

--- a/static/app/views/explore/hooks/useTraces.tsx
+++ b/static/app/views/explore/hooks/useTraces.tsx
@@ -92,7 +92,7 @@ export function useTraces({
       project: selection.projects,
       environment: selection.environments,
       ...normalizeDateTimeParams(datetime ?? selection.datetime),
-      dataset: DiscoverDatasets.SPANS_EAP,
+      dataset: DiscoverDatasets.SPANS,
       query,
       sort,
       per_page: limit,

--- a/static/app/views/explore/multiQueryMode/hooks/useAddCompareQueryToDashboard.tsx
+++ b/static/app/views/explore/multiQueryMode/hooks/useAddCompareQueryToDashboard.tsx
@@ -54,14 +54,14 @@ export function useAddCompareQueryToDashboard(query: ReadableExploreQueryParts) 
       orderby: sortBys.map(formatSort),
       query: search.formatString(),
       version: 2,
-      dataset: DiscoverDatasets.SPANS_EAP_RPC,
+      dataset: DiscoverDatasets.SPANS,
       yAxis: yAxes,
       display:
         CHART_TYPE_TO_DISPLAY_TYPE[query.chartType || determineDefaultChartType(yAxes)],
     };
 
     const newEventView = EventView.fromNewQueryWithPageFilters(discoverQuery, selection);
-    newEventView.dataset = DiscoverDatasets.SPANS_EAP_RPC;
+    newEventView.dataset = DiscoverDatasets.SPANS;
     return newEventView;
   }, [groupBys, mode, qs, query.chartType, selection, sortBys, yAxes]);
 

--- a/static/app/views/explore/multiQueryMode/hooks/useMultiQueryTable.tsx
+++ b/static/app/views/explore/multiQueryMode/hooks/useMultiQueryTable.tsx
@@ -81,7 +81,7 @@ function useMultiQueryTableAggregateModeImpl({
       orderby: sortBys.map(formatSort),
       query,
       version: 2,
-      dataset: DiscoverDatasets.SPANS_EAP_RPC,
+      dataset: DiscoverDatasets.SPANS,
     };
 
     return EventView.fromNewQueryWithPageFilters(discoverQuery, selection);
@@ -141,7 +141,7 @@ function useMultiQueryTableSampleModeImpl({
       orderby: sortBys.map(formatSort),
       query,
       version: 2,
-      dataset: DiscoverDatasets.SPANS_EAP_RPC,
+      dataset: DiscoverDatasets.SPANS,
     };
 
     return EventView.fromNewQueryWithPageFilters(discoverQuery, selection);

--- a/static/app/views/explore/multiQueryMode/hooks/useMultiQueryTimeseries.tsx
+++ b/static/app/views/explore/multiQueryMode/hooks/useMultiQueryTimeseries.tsx
@@ -150,7 +150,7 @@ function useMultiQueryTimeseriesImpl({
   const timeseriesResult = useSortedTimeSeries(
     options,
     'api.explorer.stats',
-    DiscoverDatasets.SPANS_EAP_RPC
+    DiscoverDatasets.SPANS
   );
 
   return {result: timeseriesResult, canUsePreviousResults};

--- a/static/app/views/insights/common/queries/getSeriesEventView.tsx
+++ b/static/app/views/insights/common/queries/getSeriesEventView.tsx
@@ -40,7 +40,7 @@ export function getSeriesEventView(
       query: typeof search === 'string' ? search : (search?.formatString() ?? ''),
       fields,
       yAxis,
-      dataset: dataset || DiscoverDatasets.SPANS_METRICS,
+      dataset: dataset || DiscoverDatasets.SPANS,
       interval,
       topEvents: topEvents?.toString(),
       version: 2,

--- a/static/app/views/insights/common/queries/useDiscover.ts
+++ b/static/app/views/insights/common/queries/useDiscover.ts
@@ -38,11 +38,7 @@ export const useSpans = <Fields extends SpanProperty[]>(
   options: UseDiscoverOptions<Fields> = {},
   referrer: string
 ) => {
-  return useDiscover<Fields, SpanResponse>(
-    options,
-    DiscoverDatasets.SPANS_EAP_RPC,
-    referrer
-  );
+  return useDiscover<Fields, SpanResponse>(options, DiscoverDatasets.SPANS, referrer);
 };
 
 const useDiscover = <T extends Array<Extract<keyof ResponseType, string>>, ResponseType>(

--- a/static/app/views/insights/common/queries/useDiscoverSeries.ts
+++ b/static/app/views/insights/common/queries/useDiscoverSeries.ts
@@ -44,7 +44,7 @@ export const useSpanSeries = <Fields extends SpanProperty[]>(
 ) => {
   return useDiscoverSeries<Fields>(
     options,
-    DiscoverDatasets.SPANS_EAP_RPC,
+    DiscoverDatasets.SPANS,
     referrer,
     pageFilters
   );

--- a/static/app/views/insights/common/queries/useReleases.tsx
+++ b/static/app/views/insights/common/queries/useReleases.tsx
@@ -56,7 +56,7 @@ export function useReleases(
         query: `transaction.op:[ui.load,navigation] ${escapeFilterValue(
           `release:[${releases.map(r => `"${r.version}"`).join()}]`
         )}`,
-        dataset: DiscoverDatasets.SPANS_EAP_RPC,
+        dataset: DiscoverDatasets.SPANS,
         version: 2,
         projects: selection.projects,
       };

--- a/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
+++ b/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
@@ -78,7 +78,7 @@ export const useSortedTimeSeries = <
     pageFilters.selection,
     yAxis,
     topEvents,
-    dataset ?? DiscoverDatasets.SPANS_INDEXED,
+    dataset ?? DiscoverDatasets.SPANS,
     orderby
   );
 

--- a/static/app/views/insights/common/queries/useSpanSamples.tsx
+++ b/static/app/views/insights/common/queries/useSpanSamples.tsx
@@ -142,7 +142,7 @@ export const useSpanSamples = <Fields extends NonDefaultSpanSampleFields[]>(
             ...additionalFields,
           ],
           sampling: useEap ? SAMPLING_MODE.NORMAL : undefined,
-          dataset: useEap ? DiscoverDatasets.SPANS_EAP : undefined,
+          dataset: useEap ? DiscoverDatasets.SPANS : undefined,
           sort: `-${SPAN_SELF_TIME}`,
         },
       },

--- a/static/app/views/insights/common/queries/useSpansQuery.tsx
+++ b/static/app/views/insights/common/queries/useSpansQuery.tsx
@@ -170,7 +170,7 @@ function useWrappedDiscoverTimeseriesQueryBase<T>({
       interval: eventView.interval,
       cursor,
       sampling:
-        eventView.dataset === DiscoverDatasets.SPANS_EAP_RPC && samplingMode
+        eventView.dataset === DiscoverDatasets.SPANS && samplingMode
           ? samplingMode
           : undefined,
     }),
@@ -256,7 +256,7 @@ function useWrappedDiscoverQueryBase<T>({
   const organization = useOrganization();
 
   const queryExtras: Record<string, string> = {};
-  if (eventView.dataset === DiscoverDatasets.SPANS_EAP_RPC && samplingMode) {
+  if (eventView.dataset === DiscoverDatasets.SPANS && samplingMode) {
     queryExtras.sampling = samplingMode;
   }
 

--- a/static/app/views/insights/common/queries/useTopNDiscoverMultiSeries.ts
+++ b/static/app/views/insights/common/queries/useTopNDiscoverMultiSeries.ts
@@ -46,7 +46,7 @@ export const useTopNSpanMultiSeries = <
 ) => {
   return useTopNDiscoverMultiSeries<YAxisFields, Fields>(
     options,
-    DiscoverDatasets.SPANS_EAP_RPC,
+    DiscoverDatasets.SPANS,
     referrer,
     pageFilters
   );

--- a/static/app/views/insights/common/queries/useTopNDiscoverSeries.ts
+++ b/static/app/views/insights/common/queries/useTopNDiscoverSeries.ts
@@ -45,7 +45,7 @@ export const useTopNSpanSeries = <Fields extends SpanProperty[]>(
 ) => {
   return useTopNDiscoverSeries<Fields>(
     options,
-    DiscoverDatasets.SPANS_EAP_RPC,
+    DiscoverDatasets.SPANS,
     referrer,
     pageFilters
   );

--- a/static/app/views/insights/http/queries/useSpanSamples.tsx
+++ b/static/app/views/insights/http/queries/useSpanSamples.tsx
@@ -70,7 +70,7 @@ export const useSpanSamples = <Fields extends NonDefaultSpanSampleFields[]>(
           additionalFields: [...fields, SpanFields.TRANSACTION_SPAN_ID],
           sort: '-timestamp',
           sampling: SAMPLING_MODE.NORMAL,
-          dataset: DiscoverDatasets.SPANS_EAP,
+          dataset: DiscoverDatasets.SPANS,
           referrer,
         },
       },

--- a/static/app/views/insights/mobile/appStarts/components/eventSamples.tsx
+++ b/static/app/views/insights/mobile/appStarts/components/eventSamples.tsx
@@ -84,7 +84,7 @@ export function EventSamples({
       'span.duration',
     ],
     query: searchQuery.formatString(),
-    dataset: DiscoverDatasets.SPANS_INDEXED,
+    dataset: DiscoverDatasets.SPANS,
     version: 2,
     projects: selection.projects,
   };

--- a/static/app/views/insights/mobile/screens/components/vitalDetailPanel.spec.tsx
+++ b/static/app/views/insights/mobile/screens/components/vitalDetailPanel.spec.tsx
@@ -1,6 +1,5 @@
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {PageAlertProvider} from 'sentry/utils/performance/contexts/pageAlert';
 import {
   PerformanceScore,
@@ -38,7 +37,7 @@ const mockVital: VitalItem = {
     Android: 'https://example.com/sdk-docs',
   },
   field: 'avg(measurements.app_start_cold)',
-  dataset: DiscoverDatasets.METRICS,
+  dataset: 'metrics',
   getStatus: () => mockStatus,
 };
 

--- a/static/app/views/insights/mobile/screens/utils.ts
+++ b/static/app/views/insights/mobile/screens/utils.ts
@@ -1,5 +1,4 @@
 import {DURATION_UNITS} from 'sentry/utils/discover/fieldRenderers';
-import type {DiscoverDatasets} from 'sentry/utils/discover/types';
 import getDuration from 'sentry/utils/duration/getDuration';
 import {formatPercentage} from 'sentry/utils/number/formatPercentage';
 import type {SpanProperty} from 'sentry/views/insights/types';
@@ -50,13 +49,11 @@ export type VitalStatus = {
   value: MetricValue | undefined;
 };
 
-type GenericVitalItem<
-  T extends DiscoverDatasets.SPANS_METRICS | DiscoverDatasets.METRICS,
-> = {
+type GenericVitalItem<T extends 'spansMetrics' | 'metrics'> = {
   dataset: T;
   description: string;
   docs: React.ReactNode;
-  field: T extends DiscoverDatasets.SPANS_METRICS ? SpanProperty : SpanProperty;
+  field: SpanProperty;
   getStatus: (value: MetricValue, field?: string | undefined) => VitalStatus;
   platformDocLinks: Record<string, string>;
   sdkDocLinks: Record<string, string>;
@@ -64,9 +61,7 @@ type GenericVitalItem<
   title: string;
 };
 
-export type VitalItem =
-  | GenericVitalItem<DiscoverDatasets.METRICS>
-  | GenericVitalItem<DiscoverDatasets.SPANS_METRICS>;
+export type VitalItem = GenericVitalItem<'metrics'> | GenericVitalItem<'spansMetrics'>;
 
 export type MetricValue = {
   // the field type if defined, e.g. duration

--- a/static/app/views/insights/mobile/screens/views/screensLandingPage.tsx
+++ b/static/app/views/insights/mobile/screens/views/screensLandingPage.tsx
@@ -11,7 +11,6 @@ import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {PageAlert, PageAlertProvider} from 'sentry/utils/performance/contexts/pageAlert';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -82,7 +81,7 @@ function ScreensLandingPage() {
         iOS: 'https://docs.sentry.io/platforms/apple/guides/ios/tracing/instrumentation/automatic-instrumentation/#app-start-tracing',
       },
       field: 'avg(measurements.app_start_cold)' as const,
-      dataset: DiscoverDatasets.METRICS,
+      dataset: 'metrics',
       getStatus: getColdAppStartPerformance,
     },
     {

--- a/static/app/views/insights/mobile/screens/views/screensLandingPage.tsx
+++ b/static/app/views/insights/mobile/screens/views/screensLandingPage.tsx
@@ -102,7 +102,7 @@ function ScreensLandingPage() {
         iOS: 'https://docs.sentry.io/platforms/apple/guides/ios/tracing/instrumentation/automatic-instrumentation/#app-start-tracing',
       },
       field: 'avg(measurements.app_start_warm)' as const,
-      dataset: DiscoverDatasets.METRICS,
+      dataset: 'metrics',
       getStatus: getWarmAppStartPerformance,
     },
     {
@@ -119,7 +119,7 @@ function ScreensLandingPage() {
         iOS: 'https://docs.sentry.io/platforms/apple/guides/ios/tracing/instrumentation/automatic-instrumentation/#slow-and-frozen-frames',
       },
       field: `division(mobile.slow_frames,mobile.total_frames)` as const,
-      dataset: DiscoverDatasets.SPANS_METRICS,
+      dataset: 'spansMetrics',
       getStatus: getDefaultMetricPerformance,
     },
     {
@@ -136,7 +136,7 @@ function ScreensLandingPage() {
         iOS: 'https://docs.sentry.io/platforms/apple/guides/ios/tracing/instrumentation/automatic-instrumentation/#slow-and-frozen-frames',
       },
       field: `division(mobile.frozen_frames,mobile.total_frames)` as const,
-      dataset: DiscoverDatasets.SPANS_METRICS,
+      dataset: 'spansMetrics',
       getStatus: getDefaultMetricPerformance,
     },
     {
@@ -155,7 +155,7 @@ function ScreensLandingPage() {
         iOS: 'https://docs.sentry.io/platforms/apple/guides/ios/tracing/instrumentation/automatic-instrumentation/#slow-and-frozen-frames',
       },
       field: `avg(mobile.frames_delay)` as const,
-      dataset: DiscoverDatasets.SPANS_METRICS,
+      dataset: 'spansMetrics',
       getStatus: getDefaultMetricPerformance,
     },
     {
@@ -173,7 +173,7 @@ function ScreensLandingPage() {
         iOS: 'https://docs.sentry.io/platforms/apple/features/experimental-features/',
       },
       field: `avg(measurements.time_to_initial_display)` as const,
-      dataset: DiscoverDatasets.METRICS,
+      dataset: 'metrics',
       getStatus: getDefaultMetricPerformance,
     },
     {
@@ -191,17 +191,17 @@ function ScreensLandingPage() {
         iOS: 'https://docs.sentry.io/platforms/apple/features/experimental-features/',
       },
       field: `avg(measurements.time_to_full_display)` as const,
-      dataset: DiscoverDatasets.METRICS,
+      dataset: 'metrics',
       getStatus: getDefaultMetricPerformance,
     },
   ] satisfies VitalItem[];
 
   const metricsFields = vitalItems
-    .filter(item => item.dataset === DiscoverDatasets.METRICS)
+    .filter(item => item.dataset === 'metrics')
     .map(item => item.field);
 
   const spanMetricsFields = vitalItems
-    .filter(item => item.dataset === DiscoverDatasets.SPANS_METRICS)
+    .filter(item => item.dataset === 'spansMetrics')
     .map(item => item.field);
 
   const [state, setState] = useState<{
@@ -214,6 +214,7 @@ function ScreensLandingPage() {
     query.addFilterValue('os.name', selectedPlatform);
   }
 
+  // TODO: combine these two queries into one, see DAIN-780
   const metricsResult = useSpans(
     {
       search: query,

--- a/static/app/views/insights/mobile/ui/components/tables/spanOperationTable.tsx
+++ b/static/app/views/insights/mobile/ui/components/tables/spanOperationTable.tsx
@@ -85,7 +85,7 @@ export function SpanOperationTable({
     ],
     query: queryStringPrimary,
     orderby,
-    dataset: DiscoverDatasets.SPANS_EAP_RPC,
+    dataset: DiscoverDatasets.SPANS,
     version: 2,
     projects: selection.projects,
     interval: getInterval(selection.datetime, STARFISH_CHART_INTERVAL_FIDELITY),

--- a/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
@@ -112,11 +112,9 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
     props.chartSetting
   );
   const useEap = useInsightsEap();
-  const spanDataset = useEap
-    ? DiscoverDatasets.SPANS_EAP_RPC
-    : DiscoverDatasets.SPANS_METRICS;
+  const spanDataset = useEap ? DiscoverDatasets.SPANS : DiscoverDatasets.SPANS_METRICS;
 
-  const metricsDataset = useEap ? DiscoverDatasets.SPANS_EAP : DiscoverDatasets.METRICS;
+  const metricsDataset = useEap ? DiscoverDatasets.SPANS : DiscoverDatasets.METRICS;
 
   const spanQueryParams: Record<string, string> = {...EAP_QUERY_PARAMS};
 
@@ -489,7 +487,7 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
           }
 
           if (useEap) {
-            eventView.dataset = DiscoverDatasets.SPANS_EAP_RPC;
+            eventView.dataset = DiscoverDatasets.SPANS;
             extraQueryParams = {
               ...extraQueryParams,
               ...spanQueryParams,

--- a/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
@@ -112,7 +112,7 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
     props.chartSetting
   );
   const useEap = useInsightsEap();
-  const spanDataset = useEap ? DiscoverDatasets.SPANS : DiscoverDatasets.SPANS_METRICS;
+  const spanDataset = DiscoverDatasets.SPANS;
 
   const metricsDataset = useEap ? DiscoverDatasets.SPANS : DiscoverDatasets.METRICS;
 

--- a/static/app/views/performance/landing/widgets/widgets/mobileReleaseComparisonListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/mobileReleaseComparisonListWidget.tsx
@@ -118,7 +118,7 @@ function MobileReleaseComparisonListWidget(props: PerformanceWidgetProps) {
   const useEap = useInsightsEap();
 
   const dataset = useInsightsEap()
-    ? DiscoverDatasets.SPANS_EAP_RPC
+    ? DiscoverDatasets.SPANS
     : DiscoverDatasets.SPANS_METRICS;
 
   const queryParams: Record<string, string> = useEap

--- a/static/app/views/performance/landing/widgets/widgets/settings.ts
+++ b/static/app/views/performance/landing/widgets/widgets/settings.ts
@@ -2,6 +2,6 @@ import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {DEFAULT_SAMPLING_MODE} from 'sentry/views/insights/common/queries/useDiscover';
 
 export const EAP_QUERY_PARAMS = {
-  dataset: DiscoverDatasets.SPANS_EAP,
+  dataset: DiscoverDatasets.SPANS,
   sampling: DEFAULT_SAMPLING_MODE,
 };

--- a/static/app/views/performance/transactionSummary/transactionOverview/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/index.tsx
@@ -384,7 +384,7 @@ function generateEventView({
       fields,
       query: conditions.formatString(),
       projects: [],
-      dataset: shouldUseOTelFriendlyUI ? DiscoverDatasets.SPANS_EAP_RPC : undefined,
+      dataset: shouldUseOTelFriendlyUI ? DiscoverDatasets.SPANS : undefined,
     },
     location
   );

--- a/static/app/views/performance/utils/useSpanFieldSupportedTags.tsx
+++ b/static/app/views/performance/utils/useSpanFieldSupportedTags.tsx
@@ -3,23 +3,14 @@ import {useMemo} from 'react';
 import {getHasTag} from 'sentry/components/events/searchBar';
 import type {PageFilters} from 'sentry/types/core';
 import type {TagCollection} from 'sentry/types/group';
-import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {type ApiQueryKey, useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {SpanFields} from 'sentry/views/insights/types';
 
-const DATASET_TO_FIELDS = {
-  [DiscoverDatasets.SPANS_INDEXED]: SpanFields,
-  [DiscoverDatasets.SPANS_METRICS]: SpanFields,
-};
-
-function useSpanFieldBaseTags(
-  excludedTags: string[],
-  dataset: DiscoverDatasets.SPANS_INDEXED | DiscoverDatasets.SPANS_METRICS
-) {
+function useSpanFieldBaseTags(excludedTags: string[]) {
   const builtinTags = useMemo(() => {
-    const fields = DATASET_TO_FIELDS[dataset];
+    const fields = SpanFields;
 
     const tags: TagCollection = Object.fromEntries(
       Object.values(fields)
@@ -30,7 +21,7 @@ function useSpanFieldBaseTags(
     tags.has = getHasTag(tags);
 
     return tags;
-  }, [excludedTags, dataset]);
+  }, [excludedTags]);
 
   return builtinTags;
 }
@@ -89,21 +80,15 @@ export function useSpanFieldCustomTags(options?: {
   return {...rest, data: tags};
 }
 
-function useSpanFieldStaticTags(options?: {
-  dataset?: DiscoverDatasets.SPANS_INDEXED | DiscoverDatasets.SPANS_METRICS;
-  excludedTags?: string[];
-}) {
-  const {excludedTags = [], dataset = DiscoverDatasets.SPANS_INDEXED} = options || {};
+function useSpanFieldStaticTags(options?: {excludedTags?: string[]}) {
+  const {excludedTags = []} = options || {};
   // we do not yet support span field search by SPAN_AI_PIPELINE_GROUP and SPAN_CATEGORY should not be surfaced to users
-  const staticTags: TagCollection = useSpanFieldBaseTags(
-    [
-      SpanFields.SPAN_AI_PIPELINE_GROUP,
-      SpanFields.SPAN_CATEGORY,
-      SpanFields.SPAN_GROUP,
-      ...excludedTags,
-    ],
-    dataset
-  );
+  const staticTags: TagCollection = useSpanFieldBaseTags([
+    SpanFields.SPAN_AI_PIPELINE_GROUP,
+    SpanFields.SPAN_CATEGORY,
+    SpanFields.SPAN_GROUP,
+    ...excludedTags,
+  ]);
 
   return staticTags;
 }
@@ -116,7 +101,6 @@ export function useSpanFieldSupportedTags(options?: {
   // we do not yet support span field search by SPAN_AI_PIPELINE_GROUP and SPAN_CATEGORY should not be surfaced to users
   const staticTags: TagCollection = useSpanFieldStaticTags({
     excludedTags,
-    dataset: DiscoverDatasets.SPANS_INDEXED,
   });
 
   const {data: customTags, ...rest} = useSpanFieldCustomTags({projects});

--- a/static/app/views/traces/hooks/useTraces.tsx
+++ b/static/app/views/traces/hooks/useTraces.tsx
@@ -73,7 +73,7 @@ export function useTraces({datetime, enabled, limit, query}: UseTracesOptions) {
       project: selection.projects,
       environment: selection.environments,
       ...normalizeDateTimeParams(datetime ?? selection.datetime),
-      dataset: DiscoverDatasets.SPANS_INDEXED,
+      dataset: DiscoverDatasets.SPANS,
       query,
       per_page: limit,
       breakdownSlices: BREAKDOWN_SLICES,


### PR DESCRIPTION
1. Data for spansIndexed and spansMetrics is no longer being ingested, this PR removes it from the frontend code
2. This Pr also removes some usage of the `metrics` dataset when it's confirmed to be replaced by EAP. There are some Am1 cases which i'm not sure about yet, so i can look into those in a seperate PR.
3. Rename `SPANS_RPC` dataset to `SPANS` (as this is the actual name now)
