### PR TITLE
fix(aci): treat issue priority deescalating as its own condition in automation builder

### DIFF
--- a/static/app/views/automations/components/actionFilters/issuePriority.tsx
+++ b/static/app/views/automations/components/actionFilters/issuePriority.tsx
@@ -11,7 +11,7 @@ import type {ValidateDataConditionProps} from 'sentry/views/automations/componen
 import {useDataConditionNodeContext} from 'sentry/views/automations/components/dataConditionNodes';
 
 export function IssuePriorityDetails({condition}: {condition: DataCondition}) {
-  return tct('Current issue priority is [level]', {
+  return tct('Current issue priority is greater than or equal to [level]', {
     level:
       PRIORITY_CHOICES.find(choice => choice.value === condition.comparison)?.label ||
       condition.comparison,
@@ -22,7 +22,7 @@ export function IssuePriorityNode() {
   const {condition, condition_id, onUpdate} = useDataConditionNodeContext();
   const {removeError} = useAutomationBuilderErrorContext();
 
-  return tct('Current issue priority is [priority]', {
+  return tct('Current issue priority is greater than or equal to [priority]', {
     priority: (
       <AutomationBuilderSelect
         name={`${condition_id}.comparison`}

--- a/static/app/views/automations/components/actionFilters/issuePriorityDeescalating.tsx
+++ b/static/app/views/automations/components/actionFilters/issuePriorityDeescalating.tsx
@@ -1,0 +1,5 @@
+import {t} from 'sentry/locale';
+
+export function IssuePriorityDeescalating() {
+  return t('The issue priority de-escalates');
+}

--- a/static/app/views/automations/components/dataConditionNodeList.spec.tsx
+++ b/static/app/views/automations/components/dataConditionNodeList.spec.tsx
@@ -80,8 +80,7 @@ describe('DataConditionNodeList', function () {
     );
     await userEvent.click(screen.getByRole('textbox', {name: 'Add condition'}));
 
-    // Deescalating condition should not be shown in the dropdown
-    expect(screen.getAllByRole('menuitemradio')).toHaveLength(3);
+    expect(screen.getAllByRole('menuitemradio')).toHaveLength(4);
     expect(screen.getByRole('menuitemradio', {name: 'Issue age'})).toBeInTheDocument();
     expect(
       screen.getByRole('menuitemradio', {name: 'Issue priority'})
@@ -143,66 +142,6 @@ describe('DataConditionNodeList', function () {
 
     await userEvent.click(screen.getByRole('button', {name: 'Delete row'}));
     expect(mockOnDeleteRow).toHaveBeenCalledWith('1');
-  });
-
-  it('handles adding issue priority deescalating condition', async function () {
-    render(
-      <AutomationBuilderErrorContext.Provider value={defaultErrorContextProps}>
-        <AutomationBuilderConflictContext.Provider value={defaultConflictContextProps}>
-          <DataConditionNodeList
-            {...defaultProps}
-            conditions={[
-              DataConditionFixture({
-                type: DataConditionType.ISSUE_PRIORITY_GREATER_OR_EQUAL,
-              }),
-            ]}
-          />
-        </AutomationBuilderConflictContext.Provider>
-      </AutomationBuilderErrorContext.Provider>,
-      {
-        organization,
-      }
-    );
-
-    await userEvent.click(screen.getByRole('checkbox', {name: 'Notify on deescalation'}));
-    expect(mockOnAddRow).toHaveBeenCalledWith(
-      DataConditionType.ISSUE_PRIORITY_DEESCALATING
-    );
-  });
-
-  it('handles deleting issue priority deescalating condition', async function () {
-    render(
-      <AutomationBuilderErrorContext.Provider value={defaultErrorContextProps}>
-        <AutomationBuilderConflictContext.Provider value={defaultConflictContextProps}>
-          <DataConditionNodeList
-            {...defaultProps}
-            conditions={[
-              DataConditionFixture({
-                id: 'issue-priority',
-                type: DataConditionType.ISSUE_PRIORITY_GREATER_OR_EQUAL,
-              }),
-              DataConditionFixture({
-                id: 'deescalating',
-                type: DataConditionType.ISSUE_PRIORITY_DEESCALATING,
-              }),
-            ]}
-          />
-        </AutomationBuilderConflictContext.Provider>
-      </AutomationBuilderErrorContext.Provider>,
-      {
-        organization,
-      }
-    );
-
-    await userEvent.click(screen.getByRole('checkbox', {name: 'Notify on deescalation'}));
-    expect(mockOnDeleteRow).toHaveBeenCalledWith('deescalating');
-    mockOnDeleteRow.mockClear();
-
-    // Deleting the issue priority condition should also delete the deescalating condition
-    await userEvent.click(screen.getByRole('button', {name: 'Delete row'}));
-    expect(mockOnDeleteRow).toHaveBeenCalledTimes(2);
-    expect(mockOnDeleteRow).toHaveBeenCalledWith('issue-priority');
-    expect(mockOnDeleteRow).toHaveBeenCalledWith('deescalating');
   });
 
   it('shows conflicting condition warning for action filters', function () {

--- a/static/app/views/automations/components/dataConditionNodeList.tsx
+++ b/static/app/views/automations/components/dataConditionNodeList.tsx
@@ -2,7 +2,6 @@ import {Fragment, useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import {Alert} from 'sentry/components/core/alert';
-import {Checkbox} from 'sentry/components/core/checkbox';
 import {Select} from 'sentry/components/core/select';
 import {Tooltip} from 'sentry/components/core/tooltip';
 import {IconWarning} from 'sentry/icons';
@@ -73,10 +72,8 @@ export default function DataConditionNodeList({
     ];
 
     dataConditionHandlers.forEach(handler => {
-      if (
-        percentageTypes.includes(handler.type) || // Skip percentage types so that frequency conditions are not duplicated
-        handler.type === DataConditionType.ISSUE_PRIORITY_DEESCALATING // Skip issue priority deescalating condition since it is handled separately
-      ) {
+      // Skip percentage types so that frequency conditions are not duplicated
+      if (percentageTypes.includes(handler.type)) {
         return;
       }
 
@@ -133,50 +130,15 @@ export default function DataConditionNodeList({
     ];
   }, [dataConditionHandlers, handlerGroup]);
 
-  const issuePriorityDeescalatingConditionId: string | undefined = useMemo(() => {
-    return conditions.find(
-      condition => condition.type === DataConditionType.ISSUE_PRIORITY_DEESCALATING
-    )?.id;
-  }, [conditions]);
-
-  const onIssuePriorityDeescalatingChange = () => {
-    if (issuePriorityDeescalatingConditionId) {
-      onDeleteRow(issuePriorityDeescalatingConditionId);
-    } else {
-      onAddRow(DataConditionType.ISSUE_PRIORITY_DEESCALATING);
-    }
-  };
-
-  const onDeleteRowHandler = (condition: DataCondition) => {
-    onDeleteRow(condition.id);
-
-    // Count remaining ISSUE_PRIORITY_GREATER_OR_EQUAL conditions (excluding the one being deleted)
-    const remainingPriorityConditions = conditions.filter(
-      c =>
-        c.type === DataConditionType.ISSUE_PRIORITY_GREATER_OR_EQUAL &&
-        c.id !== condition.id
-    ).length;
-
-    // If no more ISSUE_PRIORITY_GREATER_OR_EQUAL conditions exist, remove the ISSUE_PRIORITY_DEESCALATING condition
-    if (remainingPriorityConditions === 0 && issuePriorityDeescalatingConditionId) {
-      onDeleteRow(issuePriorityDeescalatingConditionId);
-    }
-  };
-
   return (
     <Fragment>
       {conditions.map(condition => {
         const error = errors?.[condition.id];
 
-        // ISSUE_PRIORITY_DEESCALATING condition is a special case attached to the ISSUE_PRIORITY_GREATER_OR_EQUAL condition
-        if (condition.type === DataConditionType.ISSUE_PRIORITY_DEESCALATING) {
-          return null;
-        }
-
         return (
           <AutomationBuilderRow
             key={condition.id}
-            onDelete={() => onDeleteRowHandler(condition)}
+            onDelete={() => onDeleteRow(condition.id)}
             hasError={conflictingConditions?.has(condition.id) || !!error}
             errorMessage={error}
           >
@@ -188,16 +150,6 @@ export default function DataConditionNodeList({
               }}
             >
               <Node />
-              {condition.type === DataConditionType.ISSUE_PRIORITY_GREATER_OR_EQUAL && (
-                <Fragment>
-                  <Checkbox
-                    checked={!!issuePriorityDeescalatingConditionId}
-                    onChange={() => onIssuePriorityDeescalatingChange()}
-                    aria-label={t('Notify on deescalation')}
-                  />
-                  {t('Notify on deescalation')}
-                </Fragment>
-              )}
             </DataConditionNodeContext.Provider>
           </AutomationBuilderRow>
         );

--- a/static/app/views/automations/components/dataConditionNodes.tsx
+++ b/static/app/views/automations/components/dataConditionNodes.tsx
@@ -62,6 +62,7 @@ import {
   IssuePriorityNode,
   validateIssuePriorityCondition,
 } from 'sentry/views/automations/components/actionFilters/issuePriority';
+import {IssuePriorityDeescalating} from 'sentry/views/automations/components/actionFilters/issuePriorityDeescalating';
 import {
   LatestAdoptedReleaseDetails,
   LatestAdoptedReleaseNode,
@@ -202,6 +203,15 @@ export const dataConditionNodesMap = new Map<DataConditionType, DataConditionNod
       details: IssuePriorityDetails,
       defaultComparison: Priority.HIGH,
       validate: validateIssuePriorityCondition,
+    },
+  ],
+  [
+    DataConditionType.ISSUE_PRIORITY_DEESCALATING,
+    {
+      label: t('De-escalation'),
+      dataCondition: IssuePriorityDeescalating,
+      details: IssuePriorityDeescalating,
+      validate: undefined,
     },
   ],
   [

--- a/static/app/views/automations/hooks/utils.spec.tsx
+++ b/static/app/views/automations/hooks/utils.spec.tsx
@@ -351,6 +351,46 @@ describe('findConflictingConditions', () => {
     });
   });
 
+  it('correctly handles conflicting issue priority and priority de-escalating conditions', () => {
+    const triggers: DataConditionGroup = {
+      id: 'triggers',
+      logicType: DataConditionGroupLogicType.ANY_SHORT_CIRCUIT,
+      conditions: [
+        {
+          id: '1',
+          type: DataConditionType.FIRST_SEEN_EVENT,
+          comparison: {comparison_type: 'equals', value: 5},
+        },
+      ],
+    };
+    const actionFilters = [
+      {
+        id: 'actionFilter1',
+        logicType: DataConditionGroupLogicType.ALL,
+        conditions: [
+          {
+            id: '3',
+            type: DataConditionType.ISSUE_PRIORITY_GREATER_OR_EQUAL,
+            comparison: {value: 'high'},
+          },
+          {
+            id: '4',
+            type: DataConditionType.ISSUE_PRIORITY_DEESCALATING,
+            comparison: true,
+          },
+        ],
+      },
+    ];
+
+    const result = findConflictingConditions(triggers, actionFilters);
+    expect(result).toEqual({
+      conflictingConditionGroups: {
+        actionFilter1: new Set(['3', '4']),
+      },
+      conflictReason: 'The issue priority conditions highlighted in red are in conflict.',
+    });
+  });
+
   it('correctly handles duplicate trigger conditions', () => {
     const triggers: DataConditionGroup = {
       id: 'triggers',


### PR DESCRIPTION
instead of having a "notify on de-escalation" checkbox, we're just going to treat issue priority deescalation as it's own condition. this more clear and more accurately reflects what is stored in the backend.

<img width="1299" height="211" alt="Screenshot 2025-07-22 at 12 02 32 PM" src="https://github.com/user-attachments/assets/d4930ce3-305a-41f6-a07f-c248d9cdfefe" />

also added more conflicting condition logic to highlight a conflict when the issue priority and priority deescalating conditions are used together with the ALL logic type

<img width="1299" height="269" alt="Screenshot 2025-07-22 at 12 02 10 PM" src="https://github.com/user-attachments/assets/4b7f44ac-bcdb-4b97-976c-6c4508b6b433" />
