### PR TITLE
fix(vercel): Stop infinite redirect on multi-org installation

### DIFF
--- a/static/app/views/integrationOrganizationLink/index.tsx
+++ b/static/app/views/integrationOrganizationLink/index.tsx
@@ -156,8 +156,7 @@ export default function IntegrationOrganizationLink() {
   useEffect(() => {
     // If only one organization, select it and redirect
     if (organizations.length === 1) {
-      const urlWithQuery = generateOrgSlugUrl(organizations[0]?.slug) + location.search;
-      testableWindowLocation.assign(urlWithQuery);
+      selectOrganization((organizations[0] as Organization).slug);
     }
     // Now, check the subdomain and use that org slug if it exists
     const customerDomain = ConfigStore.get('customerDomain');


### PR DESCRIPTION
Due to an incorrect port of the existing behavior in https://github.com/getsentry/sentry/pull/88720/files#diff-884157bdc22f32549118219de4f7b3a28515ad26dd4eaf14e72b07348ba445d7L110-L111

Resolves https://github.com/getsentry/sentry/issues/91594