### PR TITLE
fix(dashboards): Add to Dashboard tables can be sorted & column resized

### DIFF
--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
@@ -2,6 +2,7 @@ import {Fragment, useEffect, useMemo, useState} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
+import cloneDeep from 'lodash/cloneDeep';
 
 import {
   fetchDashboard,
@@ -19,6 +20,7 @@ import {space} from 'sentry/styles/space';
 import type {PageFilters, SelectValue} from 'sentry/types/core';
 import type {InjectedRouter} from 'sentry/types/legacyReactRouter';
 import type {Organization} from 'sentry/types/organization';
+import type {Sort} from 'sentry/utils/discover/fields';
 import {MetricsCardinalityProvider} from 'sentry/utils/performance/contexts/metricsCardinality';
 import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
@@ -50,6 +52,7 @@ import WidgetCard from 'sentry/views/dashboards/widgetCard';
 import {DashboardsMEPProvider} from 'sentry/views/dashboards/widgetCard/dashboardsMEPContext';
 import WidgetLegendNameEncoderDecoder from 'sentry/views/dashboards/widgetLegendNameEncoderDecoder';
 import WidgetLegendSelectionState from 'sentry/views/dashboards/widgetLegendSelectionState';
+import type {TabularColumn} from 'sentry/views/dashboards/widgets/common/types';
 import {MetricsDataSwitcher} from 'sentry/views/performance/landing/metricsDataSwitcher';
 
 type AddToDashboardModalActions =
@@ -110,6 +113,18 @@ function AddToDashboardModal({
   const [newWidgetTitle, setNewWidgetTitle] = useState<string>(
     getFallbackWidgetTitle(widget)
   );
+  const [orderBy, setOrderBy] = useState<string>();
+  const [tableWidths, setTableWidths] = useState<number[]>();
+
+  const handleWidgetTableSort = (sort: Sort) => {
+    const newOrderBy = `${sort.kind === 'desc' ? '-' : ''}${sort.field}`;
+    setOrderBy(newOrderBy);
+  };
+
+  const handleWidgetTableColumnResize = (columns: TabularColumn[]) => {
+    const widths = columns.map(column => column.width as number);
+    setTableWidths(widths);
+  };
 
   // Set custom title, or fallback to default title for widget
   const updateWidgetTitle = (newTitle: string) => {
@@ -179,6 +194,7 @@ function AddToDashboardModal({
         query: {
           ...widgetAsQueryParams,
           title: newWidgetTitle,
+          sort: orderBy ?? widgetAsQueryParams.sort,
           source,
           ...(selectedDashboard ? getSavedPageFilters(selectedDashboard) : {}),
         },
@@ -192,13 +208,13 @@ function AddToDashboardModal({
       return;
     }
 
-    let orderby = widget.queries[0]!.orderby;
+    let newOrderBy = orderBy ?? widget.queries[0]!.orderby;
     if (!(DisplayType.AREA && widget.queries[0]!.columns.length)) {
-      orderby = ''; // Clear orderby if its not a top n visualization.
+      newOrderBy = ''; // Clear orderby if its not a top n visualization.
     }
     const queries = widget.queries.map(query => ({
       ...query,
-      orderby,
+      orderby: newOrderBy,
     }));
 
     const newWidget = {
@@ -266,6 +282,17 @@ function AddToDashboardModal({
       false,
   };
 
+  // Used to refresh sort in table widgets
+  const getUpdatedWidgetQueries = () => {
+    if (orderBy && widget.queries[0]?.orderby) {
+      const queries = cloneDeep(widget.queries);
+      queries[0]!.orderby = orderBy;
+      return queries;
+    }
+
+    return widget.queries;
+  };
+
   return (
     <Fragment>
       <Header closeButton>
@@ -329,7 +356,12 @@ function AddToDashboardModal({
                       dashboardFilters={
                         getDashboardFiltersFromURL(location) ?? selectedDashboard?.filters
                       }
-                      widget={{...widget, title: newWidgetTitle}}
+                      widget={{
+                        ...widget,
+                        title: newWidgetTitle,
+                        tableWidths,
+                        queries: getUpdatedWidgetQueries(),
+                      }}
                       shouldResize
                       widgetLegendState={widgetLegendState}
                       onLegendSelectChanged={() => {}}
@@ -339,6 +371,8 @@ function AddToDashboardModal({
                           : undefined
                       }
                       disableFullscreen
+                      onWidgetTableResizeColumn={handleWidgetTableColumnResize}
+                      onWidgetTableSort={handleWidgetTableSort}
                     />
                   </WidgetCardWrapper>
                   <IndexedEventsSelectionAlert widget={widget} />


### PR DESCRIPTION
### Changes

Add handlers for sorting and column resizing when user adds table widget to another dashboard. In addition, the sort that is selected in the widget persists into the editor (Open in Widget Builder) or when saved (Add + Stay on this Page).

### Before

https://github.com/user-attachments/assets/16520f1c-96ce-4432-8177-8907755dbbdd


### After

https://github.com/user-attachments/assets/0bb3069e-4266-48dd-802f-a72cfe604684

