### PR TITLE
feat(aci): Add link to metric alert for super users

### DIFF
--- a/static/app/types/workflowEngine/detectors.tsx
+++ b/static/app/types/workflowEngine/detectors.tsx
@@ -123,6 +123,7 @@ type BaseDetector = Readonly<{
 }>;
 
 export interface MetricDetector extends BaseDetector {
+  readonly alertRuleId: number | null;
   readonly conditionGroup: DataConditionGroup | null;
   readonly config: MetricDetectorConfig;
   readonly dataSources: [SnubaQueryDataSource];

--- a/static/app/views/detectors/components/details/common/extraDetails.tsx
+++ b/static/app/views/detectors/components/details/common/extraDetails.tsx
@@ -26,6 +26,7 @@ export function DetectorExtraDetails({children}: Props) {
 
 const StyledKeyValueTable = styled(KeyValueTable)`
   grid-template-columns: min-content auto;
+  margin-bottom: 0;
 `;
 
 DetectorExtraDetails.DateCreated = function DetectorExtraDetailsDateCreated({

--- a/static/app/views/detectors/components/details/metric/sidebar.tsx
+++ b/static/app/views/detectors/components/details/metric/sidebar.tsx
@@ -139,7 +139,7 @@ export function MetricDetectorDetailsSidebar({detector}: DetectorDetailsSidebarP
         <DetectorExtraDetails.LastModified detector={detector} />
         <DetectorExtraDetails.Environment detector={detector} />
       </DetectorExtraDetails>
-      <GoToMetircAlert detector={detector} />
+      <GoToMetricAlert detector={detector} />
     </Fragment>
   );
 }

--- a/static/app/views/detectors/components/details/metric/sidebar.tsx
+++ b/static/app/views/detectors/components/details/metric/sidebar.tsx
@@ -100,7 +100,7 @@ function DetectorResolve({detector}: {detector: MetricDetector}) {
   return <div>{description}</div>;
 }
 
-function GoToMetircAlert({detector}: {detector: MetricDetector}) {
+function GoToMetricAlert({detector}: {detector: MetricDetector}) {
   const organization = useOrganization();
   const user = useUser();
   if (!user.isSuperuser || !detector.alertRuleId) {

--- a/static/app/views/detectors/components/details/metric/sidebar.tsx
+++ b/static/app/views/detectors/components/details/metric/sidebar.tsx
@@ -1,7 +1,9 @@
 import {Fragment} from 'react';
+import {Link} from 'react-router-dom';
 import styled from '@emotion/styled';
 
 import {GroupPriorityBadge} from 'sentry/components/badge/groupPriority';
+import {Tooltip} from 'sentry/components/core/tooltip';
 import Section from 'sentry/components/workflowEngine/ui/section';
 import {IconArrow} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -12,6 +14,8 @@ import {
   DetectorPriorityLevel,
 } from 'sentry/types/workflowEngine/dataConditions';
 import type {MetricDetector} from 'sentry/types/workflowEngine/detectors';
+import useOrganization from 'sentry/utils/useOrganization';
+import {useUser} from 'sentry/utils/useUser';
 import {DetectorDetailsAssignee} from 'sentry/views/detectors/components/details/common/assignee';
 import {DetectorExtraDetails} from 'sentry/views/detectors/components/details/common/extraDetails';
 import {MetricDetectorDetailsDetect} from 'sentry/views/detectors/components/details/metric/detect';
@@ -96,6 +100,26 @@ function DetectorResolve({detector}: {detector: MetricDetector}) {
   return <div>{description}</div>;
 }
 
+function GoToMetircAlert({detector}: {detector: MetricDetector}) {
+  const organization = useOrganization();
+  const user = useUser();
+  if (!user.isSuperuser || !detector.alertRuleId) {
+    return null;
+  }
+
+  return (
+    <div>
+      <Tooltip title="Superuser only">
+        <Link
+          to={`/organizations/${organization.slug}issues/alerts/rules/details/${detector.alertRuleId}/`}
+        >
+          View Metric Alert
+        </Link>
+      </Tooltip>
+    </div>
+  );
+}
+
 export function MetricDetectorDetailsSidebar({detector}: DetectorDetailsSidebarProps) {
   return (
     <Fragment>
@@ -115,6 +139,7 @@ export function MetricDetectorDetailsSidebar({detector}: DetectorDetailsSidebarP
         <DetectorExtraDetails.LastModified detector={detector} />
         <DetectorExtraDetails.Environment detector={detector} />
       </DetectorExtraDetails>
+      <GoToMetircAlert detector={detector} />
     </Fragment>
   );
 }

--- a/tests/js/fixtures/detectors.ts
+++ b/tests/js/fixtures/detectors.ts
@@ -32,6 +32,7 @@ export function MetricDetectorFixture(
     conditionGroup: params.conditionGroup ?? DataConditionGroupFixture(),
     dataSources: params.dataSources ?? [SnubaQueryDataSourceFixture()],
     owner: null,
+    alertRuleId: null,
     ...params,
   };
 }


### PR DESCRIPTION
adds a little link from metric detectors to metric alerts

<img width="408" height="341" alt="image" src="https://github.com/user-attachments/assets/92beae15-1884-494d-a476-a58e3409825d" />
