### PR TITLE
fix(workflow_engine): Refactor to simplify data packet processing, and improve query

### DIFF
--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -63,7 +63,7 @@ from sentry.snuba.subscriptions import delete_snuba_subscription
 from sentry.utils import metrics, redis
 from sentry.utils.dates import to_datetime
 from sentry.workflow_engine.models import DataPacket, Detector
-from sentry.workflow_engine.processors.data_packet import process_data_packets
+from sentry.workflow_engine.processors.data_packet import process_data_packet
 
 logger = logging.getLogger(__name__)
 REDIS_TTL = int(timedelta(days=7).total_seconds())
@@ -390,8 +390,8 @@ class SubscriptionProcessor:
                     anomaly_detection_data_packet = DataPacket[AnomalyDetectionUpdate](
                         source_id=str(self.subscription.id), packet=anomaly_detection_packet
                     )
-                    results = process_data_packets(
-                        [anomaly_detection_data_packet], DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION
+                    results = process_data_packet(
+                        anomaly_detection_data_packet, DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION
                     )
                 else:
                     metric_packet = ProcessedSubscriptionUpdate(
@@ -403,8 +403,8 @@ class SubscriptionProcessor:
                     metric_data_packet = DataPacket[ProcessedSubscriptionUpdate](
                         source_id=str(self.subscription.id), packet=metric_packet
                     )
-                    results = process_data_packets(
-                        [metric_data_packet], DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION
+                    results = process_data_packet(
+                        metric_data_packet, DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION
                     )
 
                 if features.has(

--- a/src/sentry/uptime/consumers/results_consumer.py
+++ b/src/sentry/uptime/consumers/results_consumer.py
@@ -51,7 +51,7 @@ from sentry.utils.arroyo_producer import SingletonProducer
 from sentry.utils.kafka_config import get_kafka_producer_cluster_options, get_topic_definition
 from sentry.workflow_engine.models.data_source import DataPacket
 from sentry.workflow_engine.models.detector import Detector
-from sentry.workflow_engine.processors.data_packet import process_data_packets
+from sentry.workflow_engine.processors.data_packet import process_data_packet
 
 logger = logging.getLogger(__name__)
 
@@ -312,8 +312,8 @@ def handle_active_result(
             subscription=uptime_subscription,
             metric_tags=metric_tags,
         )
-        process_data_packets(
-            [DataPacket(source_id=str(uptime_subscription.id), packet=packet)],
+        process_data_packet(
+            DataPacket(source_id=str(uptime_subscription.id), packet=packet),
             DATA_SOURCE_UPTIME_SUBSCRIPTION,
         )
 

--- a/src/sentry/workflow_engine/processors/__init__.py
+++ b/src/sentry/workflow_engine/processors/__init__.py
@@ -1,5 +1,5 @@
 __all__ = [
-    "process_data_sources",
+    "process_data_source",
     "process_detectors",
     "process_workflows",
     "process_data_packet",
@@ -8,7 +8,7 @@ __all__ = [
     "DelayedWorkflow",
 ]
 
-from .data_source import process_data_sources
+from .data_source import process_data_source
 from .delayed_workflow import DelayedWorkflow, process_delayed_workflows
 from .detector import process_detectors
 from .workflow import process_workflows

--- a/src/sentry/workflow_engine/processors/data_packet.py
+++ b/src/sentry/workflow_engine/processors/data_packet.py
@@ -1,12 +1,12 @@
 from sentry.workflow_engine.models import DataPacket, Detector
-from sentry.workflow_engine.processors.data_source import process_data_sources
+from sentry.workflow_engine.processors.data_source import process_data_source
 from sentry.workflow_engine.processors.detector import process_detectors
 from sentry.workflow_engine.types import DetectorEvaluationResult, DetectorGroupKey
 
 
-def process_data_packets[
+def process_data_packet[
     T
-](data_packets: list[DataPacket[T]], query_type: str) -> list[
+](data_packet: DataPacket[T], query_type: str) -> list[
     tuple[Detector, dict[DetectorGroupKey, DetectorEvaluationResult]]
 ]:
     """
@@ -28,13 +28,5 @@ def process_data_packets[
     TODO - saponifi3d - Create a monitoring dashboard for the workflow engine and link it here
          - the dashboard should show the funnel as we process data.
     """
-    processed_sources = process_data_sources(data_packets, query_type)
-
-    results: list[tuple[Detector, dict[DetectorGroupKey, DetectorEvaluationResult]]] = []
-    for data_packet, detectors in processed_sources:
-        detector_results = process_detectors(data_packet, detectors)
-
-        for detector, detector_state in detector_results:
-            results.append((detector, detector_state))
-
-    return results
+    data_packet, detectors = process_data_source(data_packet, query_type)
+    return process_detectors(data_packet, detectors)

--- a/src/sentry/workflow_engine/processors/data_source.py
+++ b/src/sentry/workflow_engine/processors/data_source.py
@@ -1,86 +1,60 @@
 import logging
 
 import sentry_sdk
-from django.db.models import Prefetch
 
 from sentry.utils import metrics
-from sentry.workflow_engine.models import DataPacket, DataSource, Detector
+from sentry.workflow_engine.models import DataPacket, Detector
 
 logger = logging.getLogger("sentry.workflow_engine.process_data_source")
 
 
-def bulk_fetch_enabled_detectors(
-    source_ids: set[str], query_type: str
-) -> dict[str, list[Detector]]:
+def bulk_fetch_enabled_detectors(source_id: str, query_type: str) -> list[Detector]:
     """
     Get all of the enabled detectors for a list of detector source ids and types.
     This will also prefetch all the subsequent data models for evaluating the detector.
     """
-    data_sources = (
-        DataSource.objects.filter(
-            source_id__in=source_ids,
-            type=query_type,
-            detectors__enabled=True,
+    return list(
+        Detector.objects.filter(
+            enabled=True, data_sources__source_id=source_id, data_sources__type=query_type
         )
-        .prefetch_related(
-            Prefetch(
-                "detectors",
-                queryset=Detector.objects.filter(enabled=True)
-                .select_related("workflow_condition_group")
-                .prefetch_related("workflow_condition_group__conditions"),
-            )
-        )
+        .select_related("workflow_condition_group")
+        .prefetch_related("workflow_condition_group__conditions")
         .distinct()
+        .order_by("id")
     )
-
-    result: dict[str, list[Detector]] = {}
-    for data_source in data_sources:
-        result[data_source.source_id] = list(data_source.detectors.all())
-
-    return result
 
 
 # TODO - @saponifi3d - make query_type optional override, otherwise infer from the data packet.
-def process_data_sources[
+def process_data_source[
     T
-](data_packets: list[DataPacket[T]], query_type: str) -> list[tuple[DataPacket[T], list[Detector]]]:
+](data_packet: DataPacket[T], query_type: str) -> tuple[DataPacket[T], list[Detector]]:
     metrics.incr("workflow_engine.process_data_sources", tags={"query_type": query_type})
 
     with sentry_sdk.start_span(op="workflow_engine.process_data_sources.get_enabled_detectors"):
-        packet_source_ids = {packet.source_id for packet in data_packets}
-        source_to_detector = bulk_fetch_enabled_detectors(packet_source_ids, query_type)
+        detectors = bulk_fetch_enabled_detectors(data_packet.source_id, query_type)
 
-    # Create the result tuples
-    result = []
-    for packet in data_packets:
-        detectors: list[Detector] = source_to_detector.get(packet.source_id, [])
+    if detectors:
+        metrics.incr(
+            "workflow_engine.process_data_sources.detectors",
+            len(detectors),
+            tags={"query_type": query_type},
+        )
+        logger.info(
+            "workflow_engine.process_data_sources detectors",
+            extra={
+                "detectors": [detector.id for detector in detectors],
+                "source_id": data_packet.source_id,
+            },
+        )
+    else:
+        # XXX: this likely means the rule is muted / detector is disabled
+        logger.warning(
+            "workflow_engine.process_data_sources no detectors",
+            extra={"source_id": data_packet.source_id, "query_type": query_type},
+        )
+        metrics.incr(
+            "workflow_engine.process_data_sources.no_detectors",
+            tags={"query_type": query_type},
+        )
 
-        if detectors:
-            data_packet_tuple = (packet, detectors)
-            result.append(data_packet_tuple)
-
-            metrics.incr(
-                "workflow_engine.process_data_sources.detectors",
-                len(detectors),
-                tags={"query_type": query_type},
-            )
-
-            logger.info(
-                "workflow_engine.process_data_sources detectors",
-                extra={
-                    "detectors": [detector.id for detector in detectors],
-                    "source_id": packet.source_id,
-                },
-            )
-        else:
-            # XXX: this likely means the rule is muted / detector is disabled
-            logger.warning(
-                "workflow_engine.process_data_sources no detectors",
-                extra={"source_id": packet.source_id, "query_type": query_type},
-            )
-            metrics.incr(
-                "workflow_engine.process_data_sources.no_detectors",
-                tags={"query_type": query_type},
-            )
-
-    return result
+    return data_packet, detectors

--- a/tests/sentry/incidents/subscription_processor/test_subscription_processor_workflow_engine.py
+++ b/tests/sentry/incidents/subscription_processor/test_subscription_processor_workflow_engine.py
@@ -212,27 +212,26 @@ class ProcessUpdateWorkflowEngineTest(ProcessUpdateComparisonAlertTest):
         )
 
     @with_feature("organizations:workflow-engine-metric-alert-processing")
-    @patch("sentry.incidents.subscription_processor.process_data_packets")
-    def test_process_data_packets_called(self, mock_process_data_packets):
+    @patch("sentry.incidents.subscription_processor.process_data_packet")
+    def test_process_data_packet_called(self, mock_process_data_packet):
         rule = self.rule
         detector = self.create_detector(name="hojicha", type=MetricIssue.slug)
         data_source = self.create_data_source(source_id=str(self.sub.id))
         data_source.detectors.set([detector])
         self.send_update(rule, 10)
-        assert mock_process_data_packets.call_count == 1
+        assert mock_process_data_packet.call_count == 1
         assert (
-            mock_process_data_packets.call_args_list[0][0][1]
-            == DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION
+            mock_process_data_packet.call_args_list[0][0][1] == DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION
         )
-        data_packet_list = mock_process_data_packets.call_args_list[0][0][0]
-        assert data_packet_list[0].source_id == str(self.sub.id)
-        assert data_packet_list[0].packet.values == {"value": 10}
+        data_packet = mock_process_data_packet.call_args_list[0][0][0]
+        assert data_packet.source_id == str(self.sub.id)
+        assert data_packet.packet.values == {"value": 10}
 
     @with_feature("organizations:workflow-engine-metric-alert-processing")
-    @patch("sentry.incidents.subscription_processor.process_data_packets")
+    @patch("sentry.incidents.subscription_processor.process_data_packet")
     @patch("sentry.incidents.subscription_processor.get_comparison_aggregation_value")
-    def test_process_data_packets_not_called(
-        self, mock_get_comparison_aggregation_value, mock_process_data_packets
+    def test_process_data_packet_not_called(
+        self, mock_get_comparison_aggregation_value, mock_process_data_packet
     ):
         rule = self.comparison_rule_above
         trigger = self.trigger
@@ -245,7 +244,7 @@ class ProcessUpdateWorkflowEngineTest(ProcessUpdateComparisonAlertTest):
         self.send_update(
             rule, trigger.alert_threshold + 1, timedelta(minutes=-10), subscription=self.sub
         )
-        assert mock_process_data_packets.call_count == 0
+        assert mock_process_data_packet.call_count == 0
 
 
 @freeze_time()

--- a/tests/sentry/incidents/utils/test_metric_issue_base.py
+++ b/tests/sentry/incidents/utils/test_metric_issue_base.py
@@ -14,7 +14,7 @@ from sentry.snuba.subscriptions import create_snuba_query, create_snuba_subscrip
 from sentry.testutils.cases import TestCase
 from sentry.workflow_engine.models import DataPacket
 from sentry.workflow_engine.models.data_condition import Condition
-from sentry.workflow_engine.processors.data_packet import process_data_packets
+from sentry.workflow_engine.processors.data_packet import process_data_packet
 from sentry.workflow_engine.types import DetectorEvaluationResult, DetectorPriorityLevel
 
 
@@ -91,7 +91,7 @@ class BaseMetricIssueTest(TestCase):
     def process_packet_and_return_result(
         self, data_packet: DataPacket
     ) -> IssueOccurrence | StatusChangeMessage | None:
-        results = process_data_packets([data_packet], DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION)
+        results = process_data_packet(data_packet, DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION)
         if not results:
             # alert did not trigger
             return None

--- a/tests/sentry/workflow_engine/processors/test_data_packet.py
+++ b/tests/sentry/workflow_engine/processors/test_data_packet.py
@@ -1,5 +1,5 @@
 from sentry.incidents.utils.types import DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION
-from sentry.workflow_engine.processors.data_packet import process_data_packets
+from sentry.workflow_engine.processors.data_packet import process_data_packet
 from sentry.workflow_engine.types import DetectorPriorityLevel
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 
@@ -15,7 +15,7 @@ class TestProcessDataPacket(BaseWorkflowTest):
         self.data_source, self.data_packet = self.create_test_query_data_source(self.detector)
 
     def test_single_data_packet(self):
-        results = process_data_packets([self.data_packet], DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION)
+        results = process_data_packet(self.data_packet, DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION)
         assert len(results) == 1
 
         detector, detector_evaluation_result = results[0]

--- a/tests/sentry/workflow_engine/processors/test_data_sources.py
+++ b/tests/sentry/workflow_engine/processors/test_data_sources.py
@@ -2,7 +2,7 @@ from unittest import mock
 
 from sentry.snuba.models import SnubaQuery
 from sentry.workflow_engine.models import DataPacket
-from sentry.workflow_engine.processors import process_data_sources
+from sentry.workflow_engine.processors import process_data_source
 from sentry.workflow_engine.registry import data_source_type_registry
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 
@@ -40,102 +40,64 @@ class TestProcessDataSources(BaseWorkflowTest):
         )
         self.detector_one.save()
 
-        self.ds1 = self.create_data_source(source_id=self.query.id, type="test")
+        source_id_1 = "12345-test-source-1"
+        self.ds1 = self.create_data_source(source_id=source_id_1, type="test")
         self.ds1.detectors.set([self.detector_one])
 
-        self.ds2 = self.create_data_source(source_id=self.query_two.id, type="test")
-        self.ds2.detectors.set([self.detector_two])
+        source_id_2 = "56789-test-source-2"
+        self.ds2 = self.create_data_source(source_id=source_id_2, type="test")
+        self.ds2.detectors.set([self.detector_one, self.detector_two])
 
-        self.packet = DataPacket[dict](
-            str(self.query.id), {"source_id": self.query.id, "foo": "bar"}
+        self.packet = DataPacket[dict](source_id_1, {"source_id": source_id_1, "foo": "bar"})
+        self.two_detector_packet = DataPacket[dict](
+            source_id_2, {"source_id": source_id_2, "foo": "baz"}
         )
-        self.packet_two = DataPacket[dict](
-            str(self.query_two.id), {"source_id": self.query_two.id, "foo": "baz"}
-        )
-
-        self.data_packets = [self.packet, self.packet_two]
 
     def test_single_data_packet(self):
-        assert process_data_sources([self.packet], "test") == [(self.packet, [self.detector_one])]
-
-    def test_multiple_data_packets(self):
-        assert process_data_sources(self.data_packets, "test") == [
-            (self.packet, [self.detector_one]),
-            (self.packet_two, [self.detector_two]),
-        ]
+        assert process_data_source(self.packet, "test") == (self.packet, [self.detector_one])
 
     def test_disabled_detector(self):
         self.detector_one.enabled = False
         self.detector_one.save()
 
-        assert process_data_sources(self.data_packets, "test") == [
-            (self.packet_two, [self.detector_two])
-        ]
+        assert process_data_source(self.two_detector_packet, "test") == (
+            self.two_detector_packet,
+            [self.detector_two],
+        )
 
     def test_multiple_detectors(self):
         self.detector_three = self.create_detector(name="test_detector3")
         self.detector_four = self.create_detector(name="test_detector4")
-        self.detector_five = self.create_detector(name="test_detector5")
-        self.detector_five = self.create_detector(name="test_detector5")
 
         self.ds2.detectors.add(self.detector_three)
         self.ds2.detectors.add(self.detector_four)
-        self.ds2.detectors.add(self.detector_five)
 
-        assert process_data_sources(self.data_packets, "test") == [
-            (self.packet, [self.detector_one]),
-            (
-                self.packet_two,
-                [self.detector_two, self.detector_three, self.detector_four, self.detector_five],
-            ),
-        ]
+        assert process_data_source(self.two_detector_packet, "test") == (
+            self.two_detector_packet,
+            [self.detector_one, self.detector_two, self.detector_three, self.detector_four],
+        )
 
     def test_no_results(self):
-        self.ds1.detectors.clear()
         self.ds2.detectors.clear()
-
-        assert process_data_sources(self.data_packets, "test") == []
+        assert process_data_source(self.two_detector_packet, "test") == (
+            self.two_detector_packet,
+            [],
+        )
 
     def test_different_data_packet_type__no_results(self):
-        assert process_data_sources(self.data_packets, "test2") == []
-
-    def test_different_data_packet_type__with_results(self):
-        self.ds1.type = "test"
-        self.ds1.save()
-
-        self.ds2.type = "test"
-        self.ds2.save()
-
-        assert process_data_sources(
-            self.data_packets,
-            "test",
-        ) == [
-            (self.packet, [self.detector_one]),
-            (self.packet_two, [self.detector_two]),
-        ]
+        assert process_data_source(self.packet, "test2") == (self.packet, [])
 
     def test_metrics_are_sent_for_data_sources(self):
         with mock.patch("sentry.utils.metrics.incr") as mock_incr:
-            process_data_sources(self.data_packets, "test")
+            process_data_source(self.packet, "test")
 
             mock_incr.assert_any_call(
                 "workflow_engine.process_data_sources", tags={"query_type": "test"}
             )
 
-    def test_metrics_are_sent_for_data_types(self):
-        with mock.patch("sentry.utils.metrics.incr") as mock_incr:
-            process_data_sources(self.data_packets, "test")
-
-            mock_incr.assert_any_call(
-                "workflow_engine.process_data_sources.detectors",
-                1,
-                tags={"query_type": "test"},
-            )
-
     def test_metrics_are_sent_for_no_detectors(self):
         with mock.patch("sentry.utils.metrics.incr") as mock_incr:
-            process_data_sources(self.data_packets, "test3")
-
+            process_data_source(self.packet, "test3")
             mock_incr.assert_any_call(
                 "workflow_engine.process_data_sources.no_detectors",
                 tags={"query_type": "test3"},
@@ -146,7 +108,7 @@ class TestProcessDataSources(BaseWorkflowTest):
         self.ds1.detectors.add(self.detector_three)
 
         with mock.patch("sentry.utils.metrics.incr") as mock_incr:
-            process_data_sources(self.data_packets, "test")
+            process_data_source(self.packet, "test")
 
             mock_incr.assert_any_call(
                 "workflow_engine.process_data_sources.detectors",
@@ -155,24 +117,21 @@ class TestProcessDataSources(BaseWorkflowTest):
             )
 
     def test_sql_cascades(self):
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(2):
             """
-            There should be 3 total SQL queries for `bulk_fetch_enabled_detectors`:
-            - Get all the detectors
-            - Get all the data condition groups for those detectors
-            - Get all the data conditions for those groups
+            There should be 2 total SQL queries for `bulk_fetch_enabled_detectors`:
+            - Get the detector and data condition group associated with it
+            - Get all the data conditions for the group
             """
-            results = process_data_sources(self.data_packets, "test")
+            _, detectors = process_data_source(self.two_detector_packet, "test")
+            # If the detector is not prefetched this will increase the query count
+            assert all(detector.enabled for detector in detectors)
 
-            for packet, detectors in results:
-                # If the detector is not prefetched this will increase the query count
-                assert all(detector.enabled for detector in detectors)
+            for detector in detectors:
+                if detector.workflow_condition_group:
+                    # Trigger a SQL query if not prefetched, and fail the assertion
+                    assert detector.workflow_condition_group.id is not None
 
-                for detector in detectors:
-                    if detector.workflow_condition_group:
+                    for condition in detector.workflow_condition_group.conditions.all():
                         # Trigger a SQL query if not prefetched, and fail the assertion
-                        assert detector.workflow_condition_group.id is not None
-
-                        for condition in detector.workflow_condition_group.conditions.all():
-                            # Trigger a SQL query if not prefetched, and fail the assertion
-                            assert condition.id is not None
+                        assert condition.id is not None

--- a/tests/sentry/workflow_engine/test_integration.py
+++ b/tests/sentry/workflow_engine/test_integration.py
@@ -22,7 +22,7 @@ from sentry.testutils.helpers.redis import mock_redis_buffer
 from sentry.utils.cache import cache_key_for_event
 from sentry.workflow_engine.models import Detector, DetectorWorkflow
 from sentry.workflow_engine.models.data_condition import Condition
-from sentry.workflow_engine.processors import process_data_sources, process_detectors
+from sentry.workflow_engine.processors import process_data_source, process_detectors
 from sentry.workflow_engine.processors.delayed_workflow import process_delayed_workflows
 from sentry.workflow_engine.processors.workflow import WORKFLOW_ENGINE_BUFFER_LIST_KEY
 from sentry.workflow_engine.types import DetectorPriorityLevel
@@ -103,13 +103,12 @@ class TestWorkflowEngineIntegrationToIssuePlatform(BaseWorkflowIntegrationTest):
         with mock.patch(
             "sentry.workflow_engine.processors.detector.produce_occurrence_to_kafka"
         ) as mock_producer:
-            processed_packets = process_data_sources(
-                [self.data_packet], DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION
+            packet, detectors = process_data_source(
+                self.data_packet, DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION
             )
 
-            for packet, detectors in processed_packets:
-                results = process_detectors(packet, detectors)
-                assert len(results) == 1
+            results = process_detectors(packet, detectors)
+            assert len(results) == 1
 
             mock_producer.assert_called_once()
 
@@ -121,9 +120,10 @@ class TestWorkflowEngineIntegrationToIssuePlatform(BaseWorkflowIntegrationTest):
             "sentry.workflow_engine.processors.detector.produce_occurrence_to_kafka"
         ) as mock_producer:
             # Change the type to mismatch from the packet. This should not find any detectors and return.
-            processed_packets = process_data_sources([self.data_packet], "snuba_query")
+            packet, detectors = process_data_source(self.data_packet, "snuba_query")
 
-            assert processed_packets == []
+            assert packet == self.data_packet
+            assert detectors == []
             mock_producer.assert_not_called()
 
     @with_feature("organizations:workflow-engine-metric-alert-processing")
@@ -134,11 +134,12 @@ class TestWorkflowEngineIntegrationToIssuePlatform(BaseWorkflowIntegrationTest):
         with mock.patch(
             "sentry.workflow_engine.processors.detector.produce_occurrence_to_kafka"
         ) as mock_producer:
-            processed_packets = process_data_sources(
-                [self.data_packet], DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION
+            packet, detectors = process_data_source(
+                self.data_packet, DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION
             )
 
-            assert processed_packets == []
+            assert packet == self.data_packet
+            assert detectors == []
             mock_producer.assert_not_called()
 
 


### PR DESCRIPTION
This converts `process_data_packets` -> `process_data_packet` and `process_data_sources` -> `process_data_source`. Right now, we're not using any bulk functionality here, and it makes query optimization, caching, etc more complicated.

This also reworks `bulk_fetch_enabled_detectors` to use 2 queries instead of 3. The simplifications here should also make it easier to cache later.
