### PR TITLE
fix(dashboards): better viewer modal renderers

### DIFF
--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -1319,7 +1319,9 @@ function ViewerTableV2({
   const aliases = decodeColumnAliases(
     tableColumns,
     tableWidget.queries[0]?.fieldAliases ?? [],
-    tableWidget.widgetType === WidgetType.ISSUE ? datasetConfig.getFieldHeaderMap?.() : {}
+    tableWidget.widgetType === WidgetType.ISSUE
+      ? datasetConfig?.getFieldHeaderMap?.()
+      : {}
   );
 
   if (loading) {
@@ -1372,7 +1374,7 @@ function ViewerTableV2({
         sort={tableSort}
         onChangeSort={onChangeSort}
         getRenderer={(field, _dataRow, meta) => {
-          const customRenderer = datasetConfig.getCustomFieldRenderer?.(
+          const customRenderer = datasetConfig?.getCustomFieldRenderer?.(
             field,
             meta as MetaType,
             widget,

--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -37,6 +37,8 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {getUtcDateString} from 'sentry/utils/dates';
 import type {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 import type EventView from 'sentry/utils/discover/eventView';
+import type {MetaType} from 'sentry/utils/discover/eventView';
+import type {RenderFunctionBaggage} from 'sentry/utils/discover/fieldRenderers';
 import type {AggregationOutputType, Sort} from 'sentry/utils/discover/fields';
 import {
   getAggregateAlias,
@@ -57,6 +59,7 @@ import {
   decodeScalar,
   decodeSorts,
 } from 'sentry/utils/queryString';
+import type {Theme} from 'sentry/utils/theme';
 import useApi from 'sentry/utils/useApi';
 import {useLocation} from 'sentry/utils/useLocation';
 import type {ReactRouter3Navigate} from 'sentry/utils/useNavigate';
@@ -108,7 +111,6 @@ import {
   convertTableDataToTabularData,
   decodeColumnAliases,
 } from 'sentry/views/dashboards/widgets/tableWidget/utils';
-import type {TableColumn} from 'sentry/views/discover/table/types';
 import {decodeColumnOrder} from 'sentry/views/discover/utils';
 import {MetricsDataSwitcher} from 'sentry/views/performance/landing/metricsDataSwitcher';
 
@@ -502,7 +504,7 @@ function WidgetViewerModal(props: Props) {
         tableResults,
         loading,
         pageLinks,
-        columnOrder,
+        fields,
         widget,
         tableWidget,
         setChartUnmodified,
@@ -510,6 +512,8 @@ function WidgetViewerModal(props: Props) {
         location,
         organization,
         navigate,
+        eventView,
+        theme,
       });
     }
 
@@ -594,7 +598,7 @@ function WidgetViewerModal(props: Props) {
         tableResults,
         loading,
         pageLinks,
-        columnOrder,
+        fields,
         widget,
         tableWidget,
         setChartUnmodified,
@@ -602,6 +606,8 @@ function WidgetViewerModal(props: Props) {
         location,
         organization,
         navigate,
+        eventView,
+        theme,
       });
     }
     const links = parseLinkHeader(pageLinks ?? null);
@@ -685,7 +691,7 @@ function WidgetViewerModal(props: Props) {
         tableResults,
         loading,
         pageLinks,
-        columnOrder,
+        fields,
         widget,
         tableWidget,
         setChartUnmodified,
@@ -693,6 +699,8 @@ function WidgetViewerModal(props: Props) {
         location,
         organization,
         navigate,
+        eventView,
+        theme,
       });
     }
     const links = parseLinkHeader(pageLinks ?? null);
@@ -1251,13 +1259,15 @@ function renderTotalResults(totalResults?: string, widgetType?: WidgetType) {
 }
 
 interface ViewerTableV2Props {
-  columnOrder: Array<TableColumn<string>>;
+  eventView: EventView;
+  fields: string[];
   loading: boolean;
   location: Location;
   navigate: ReactRouter3Navigate;
   organization: Organization;
   setChartUnmodified: React.Dispatch<React.SetStateAction<boolean>>;
   tableWidget: Widget;
+  theme: Theme;
   widget: Widget;
   widths: string[];
   pageLinks?: string;
@@ -1269,13 +1279,15 @@ function ViewerTableV2({
   tableResults,
   loading,
   pageLinks,
-  columnOrder,
+  fields,
   widths,
   setChartUnmodified,
   tableWidget,
   location,
   organization,
   navigate,
+  eventView,
+  theme,
 }: ViewerTableV2Props) {
   const page = decodeInteger(location.query[WidgetViewerQueryField.PAGE]) ?? 0;
   const links = parseLinkHeader(pageLinks ?? null);
@@ -1290,18 +1302,24 @@ function ViewerTableV2({
     return true;
   }
 
+  const columnOrder = decodeColumnOrder(
+    fields.map(field => ({
+      field,
+    })),
+    tableResults?.[0]?.meta
+  );
+
   const tableColumns = columnOrder.map((column, index) => ({
     key: column.key,
     type: column.type === 'never' ? null : column.type,
     sortable: sortable(column.key),
     width: widths[index] ? parseInt(widths[index], 10) || -1 : -1,
   }));
+  const datasetConfig = getDatasetConfig(widget.widgetType);
   const aliases = decodeColumnAliases(
     tableColumns,
     tableWidget.queries[0]?.fieldAliases ?? [],
-    tableWidget.widgetType === WidgetType.ISSUE
-      ? getDatasetConfig(tableWidget.widgetType).getFieldHeaderMap?.()
-      : {}
+    tableWidget.widgetType === WidgetType.ISSUE ? datasetConfig.getFieldHeaderMap?.() : {}
   );
 
   if (loading) {
@@ -1353,6 +1371,27 @@ function ViewerTableV2({
         aliases={aliases}
         sort={tableSort}
         onChangeSort={onChangeSort}
+        getRenderer={(field, _dataRow, meta) => {
+          const customRenderer = datasetConfig.getCustomFieldRenderer?.(
+            field,
+            meta as MetaType,
+            widget,
+            organization
+          )!;
+
+          return customRenderer;
+        }}
+        makeBaggage={(field, _dataRow, meta) => {
+          const unit = meta.units?.[field] as string | undefined;
+
+          return {
+            location,
+            organization,
+            theme,
+            unit,
+            eventView,
+          } satisfies RenderFunctionBaggage;
+        }}
       />
       {!(
         tableWidget.queries[0]!.orderby.match(/^-?release$/) &&

--- a/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.tsx
@@ -10,7 +10,11 @@ import type {MetaType} from 'sentry/utils/discover/eventView';
 import type {RenderFunctionBaggage} from 'sentry/utils/discover/fieldRenderers';
 import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
 import type {ColumnValueType, Sort} from 'sentry/utils/discover/fields';
-import {fieldAlignment} from 'sentry/utils/discover/fields';
+import {
+  fieldAlignment,
+  isEquation,
+  stripEquationPrefix,
+} from 'sentry/utils/discover/fields';
 import {decodeSorts} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
@@ -197,7 +201,8 @@ export function TableWidgetVisualization(props: TableWidgetVisualizationProps) {
         renderHeadCell: (_tableColumn, columnIndex) => {
           const column = columnOrder[columnIndex]!;
           const align = fieldAlignment(column.key, column.type as ColumnValueType);
-          const name = aliases?.[column.key] || column.key;
+          let name = aliases?.[column.key] || column.key;
+          if (isEquation(column.key)) name = stripEquationPrefix(name);
           const sortColumn = getSortField(column.key) ?? column.key;
 
           let direction = undefined;


### PR DESCRIPTION
### Changes

Adds the new renderers in dashboard widgets to apply to widget viewer modal. Also fixs rendering of equation column headers (parse out `equation|`) and use the table meta when parsing out column types.

### Before

<img width="1172" height="510" alt="Screenshot 2025-07-23 at 12 53 33 PM" src="https://github.com/user-attachments/assets/d8a95c27-90ef-4c85-a3aa-88670cc00a2c" />

### After
<img width="1171" height="547" alt="Screenshot 2025-07-23 at 12 52 56 PM" src="https://github.com/user-attachments/assets/04b8417f-d8c5-4499-ad5d-d3fea828df66" />



