### PR TITLE
feat(trace): Show span links

### DIFF
--- a/static/app/views/explore/hooks/useTraceItemDetails.tsx
+++ b/static/app/views/explore/hooks/useTraceItemDetails.tsx
@@ -49,7 +49,17 @@ export interface TraceItemDetailsResponse {
   attributes: TraceItemResponseAttribute[];
   itemId: string;
   timestamp: string;
+  links?: TraceItemResponseLink[];
 }
+
+// Span links are stored as JSON-encoded attributes in EAP for now. The backend
+// decodes the JSON for us. Since links are so structurally similar to spans, the types are similar as well.
+export type TraceItemResponseLink = {
+  itemId: string;
+  sampled: boolean;
+  traceId: string;
+  attributes?: TraceItemResponseAttribute[];
+};
 
 type TraceItemDetailsUrlParams = {
   organizationSlug: string;

--- a/static/app/views/issueDetails/streamline/context.tsx
+++ b/static/app/views/issueDetails/streamline/context.tsx
@@ -88,6 +88,8 @@ export const enum SectionKey {
 
   MCP_INPUT = 'mcp-input',
   MCP_OUTPUT = 'mcp-output',
+
+  SPAN_LINKS = 'span-links',
 }
 
 /**

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/traceSpanLinks.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/traceSpanLinks.tsx
@@ -1,0 +1,100 @@
+import styled from '@emotion/styled';
+import type {Location} from 'history';
+
+import {t} from 'sentry/locale';
+import type {Organization} from 'sentry/types/organization';
+import type {Theme} from 'sentry/utils/theme';
+import {AttributesTree} from 'sentry/views/explore/components/traceItemAttributes/attributesTree';
+import {
+  type TraceItemResponseAttribute,
+  type TraceItemResponseLink,
+} from 'sentry/views/explore/hooks/useTraceItemDetails';
+import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
+import {FoldSection} from 'sentry/views/issueDetails/streamline/foldSection';
+import {TraceDrawerComponents} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/styles';
+import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
+import type {TraceTreeNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode';
+
+interface TraceSpanLinksProps {
+  links: TraceItemResponseLink[];
+  location: Location;
+  node: TraceTreeNode<TraceTree.EAPSpan>;
+  organization: Organization;
+  theme: Theme;
+}
+
+export function TraceSpanLinks({
+  links,
+  organization,
+  location,
+  theme,
+}: TraceSpanLinksProps) {
+  // Render the links as a tree of attributes. This visual treatment requires
+  // that we format the trace ID and span ID as attributes, even though they are
+  // top level fields. I think we should convince Design to reconsider this
+  // treatment, but for now we'll need to create synthetic attributes for the
+  // span ID and trace ID, and prefix the actual attributes with a special key.
+  const linksAsAttributes: TraceItemResponseAttribute[] = links.flatMap(
+    (link, linkIndex) => {
+      const prefix = `span_link_${linkIndex + 1}`;
+
+      return [
+        {
+          name: `${prefix}.trace_id`,
+          type: 'str',
+          value: link.traceId,
+        },
+        {
+          name: `${prefix}.span_id`,
+          type: 'str',
+          value: link.itemId,
+        },
+        ...(link.attributes || []).map(attribute => ({
+          ...attribute,
+          name: `${prefix}.attributes.${attribute.name}`,
+        })),
+      ];
+    }
+  );
+
+  return (
+    <FoldSection
+      sectionKey={SectionKey.SPAN_LINKS}
+      initialCollapse
+      title={
+        <TraceDrawerComponents.SectionTitleWithQuestionTooltip
+          title={t('Links')}
+          tooltipText={t(
+            'Span links are used to describe relationships between spans beyond parent-child relationships.'
+          )}
+        />
+      }
+    >
+      {linksAsAttributes?.length ? (
+        <AttributesTree
+          attributes={linksAsAttributes}
+          columnCount={1}
+          config={{
+            disableActions: true,
+            disableRichValue: true,
+          }}
+          rendererExtra={{
+            theme,
+            location,
+            organization,
+          }}
+        />
+      ) : (
+        <NoLinksMessage>{t('No links found')}</NoLinksMessage>
+      )}
+    </FoldSection>
+  );
+}
+
+const NoLinksMessage = styled('div')`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-top: ${p => p.theme.space['2xl']};
+  color: ${p => p.theme.subText};
+`;

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/traceSpanLinks.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/traceSpanLinks.tsx
@@ -1,4 +1,3 @@
-import styled from '@emotion/styled';
 import type {Location} from 'history';
 
 import {t} from 'sentry/locale';
@@ -70,31 +69,19 @@ export function TraceSpanLinks({
         />
       }
     >
-      {linksAsAttributes?.length ? (
-        <AttributesTree
-          attributes={linksAsAttributes}
-          columnCount={1}
-          config={{
-            disableActions: true,
-            disableRichValue: true,
-          }}
-          rendererExtra={{
-            theme,
-            location,
-            organization,
-          }}
-        />
-      ) : (
-        <NoLinksMessage>{t('No links found')}</NoLinksMessage>
-      )}
+      <AttributesTree
+        attributes={linksAsAttributes}
+        columnCount={1}
+        config={{
+          disableActions: true,
+          disableRichValue: true,
+        }}
+        rendererExtra={{
+          theme,
+          location,
+          organization,
+        }}
+      />
     </FoldSection>
   );
 }
-
-const NoLinksMessage = styled('div')`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  margin-top: ${p => p.theme.space['2xl']};
-  color: ${p => p.theme.subText};
-`;

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
@@ -475,8 +475,8 @@ function EAPSpanNodeDetails({
 
                     <LogDetails />
 
-                    {organization.features.includes('trace-view-span-links') &&
-                      links?.length && (
+                    {(organization.features.includes('trace-view-span-links') &&
+                      links?.length) ? (
                         <TraceSpanLinks
                           node={node}
                           links={links}
@@ -484,7 +484,7 @@ function EAPSpanNodeDetails({
                           location={location}
                           organization={organization}
                         />
-                      )}
+                      ) : null}
 
                     {eventTransaction && organization.features.includes('profiling') ? (
                       <ProfileDetails

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
@@ -475,16 +475,16 @@ function EAPSpanNodeDetails({
 
                     <LogDetails />
 
-                    {(organization.features.includes('trace-view-span-links') &&
-                      links?.length) ? (
-                        <TraceSpanLinks
-                          node={node}
-                          links={links}
-                          theme={theme}
-                          location={location}
-                          organization={organization}
-                        />
-                      ) : null}
+                    {organization.features.includes('trace-view-span-links') &&
+                    links?.length ? (
+                      <TraceSpanLinks
+                        node={node}
+                        links={links}
+                        theme={theme}
+                        location={location}
+                        organization={organization}
+                      />
+                    ) : null}
 
                     {eventTransaction && organization.features.includes('profiling') ? (
                       <ProfileDetails

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
@@ -62,6 +62,7 @@ import {ProfileGroupProvider} from 'sentry/views/profiling/profileGroupProvider'
 import {ProfileContext, ProfilesProvider} from 'sentry/views/profiling/profilesProvider';
 
 import {SpanDescription as EAPSpanDescription} from './eapSections/description';
+import {TraceSpanLinks} from './eapSections/traceSpanLinks';
 import Alerts from './sections/alerts';
 import {SpanDescription} from './sections/description';
 import {GeneralInfo} from './sections/generalInfo';
@@ -406,6 +407,7 @@ function EAPSpanNodeDetails({
   }
 
   const attributes = traceItemData?.attributes;
+  const links = traceItemData?.links;
   const isTransaction = isEAPTransactionNode(node) && !!eventTransaction;
   const profileMeta = eventTransaction ? getProfileMeta(eventTransaction) || '' : '';
   const profileId =
@@ -472,6 +474,17 @@ function EAPSpanNodeDetails({
                     {isTransaction ? <Contexts event={eventTransaction} /> : null}
 
                     <LogDetails />
+
+                    {organization.features.includes('trace-view-span-links') &&
+                      links?.length && (
+                        <TraceSpanLinks
+                          node={node}
+                          links={links}
+                          theme={theme}
+                          location={location}
+                          organization={organization}
+                        />
+                      )}
 
                     {eventTransaction && organization.features.includes('profiling') ? (
                       <ProfileDetails


### PR DESCRIPTION
If the span has links (as returned by the trace item details endpoint), add a section called "Links", and show the links as a tree of attributes (as requested by Design).

**e.g.,**
<img width="693" height="312" alt="Screenshot 2025-07-22 at 4 37 27 PM" src="https://github.com/user-attachments/assets/adc3d0d6-a002-496c-8d87-e9c3855af94b" />
