### PR TITLE
ref(replay): add links to console/network tabs on ai summary

### DIFF
--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -99,7 +99,7 @@ interface ReplayPlayerContextProps extends HighlightCallbacks {
   restart: () => void;
 
   /**
-   * Jump the video to a specific time
+   * Jump the video to a specific time. Input is in ms.
    */
   setCurrentTime: (time: number) => void;
 


### PR DESCRIPTION
followup to https://github.com/getsentry/sentry/pull/96049

the link goes to the new tab at the timestamp of the chapter:

https://github.com/user-attachments/assets/1d544c86-6524-4540-810d-353a720fab66

