### PR TITLE
chore(launchpad): Add rate limiting to artifact upload endpoint

### DIFF
--- a/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
+++ b/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
@@ -78,10 +78,6 @@ class ProjectPreprodArtifactAssembleEndpoint(ProjectEndpoint):
     enforce_rate_limit = True
     rate_limits = {
         "POST": {
-            RateLimitCategory.IP: RateLimit(limit=20, window=60),  # 20 requests per minute per IP
-            RateLimitCategory.USER: RateLimit(
-                limit=20, window=60
-            ),  # 20 requests per minute per user
             RateLimitCategory.ORGANIZATION: RateLimit(
                 limit=100, window=60
             ),  # 100 requests per minute per org


### PR DESCRIPTION
As a requirement of [the launchpad production readiness checklist](https://www.notion.so/sentry/Emerge-Launchpad-Production-Readiness-2168b10e4b5d8061a3cbfa2e30c37a6e)