### PR TITLE
fix(alerts): Disable 1password autocomplete for slack alert

### DIFF
--- a/static/app/views/alerts/rules/metric/triggers/actionsPanel/actionSpecificTargetSelector.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/actionsPanel/actionSpecificTargetSelector.tsx
@@ -28,6 +28,7 @@ function ActionSpecificTargetSelector({action, disabled, onChange}: Props) {
       value={action.inputChannelId || ''}
       onChange={handleChangeSpecificTargetIdentifier}
       placeholder={t('optional: channel ID or user ID')}
+      // Disable 1Password autocomplete
       data-1p-ignore
     />
   );

--- a/static/app/views/alerts/rules/metric/triggers/actionsPanel/actionSpecificTargetSelector.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/actionsPanel/actionSpecificTargetSelector.tsx
@@ -28,6 +28,7 @@ function ActionSpecificTargetSelector({action, disabled, onChange}: Props) {
       value={action.inputChannelId || ''}
       onChange={handleChangeSpecificTargetIdentifier}
       placeholder={t('optional: channel ID or user ID')}
+      data-1p-ignore
     />
   );
 }

--- a/static/app/views/alerts/rules/metric/triggers/actionsPanel/actionTargetSelector.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/actionsPanel/actionTargetSelector.tsx
@@ -91,6 +91,8 @@ export default function ActionTargetSelector(props: Props) {
           value={action.targetIdentifier || ''}
           onChange={handleChangeSpecificTargetIdentifier}
           placeholder={getPlaceholderForType(action.type)}
+          // Disable 1Password autocomplete
+          data-1p-ignore
         />
       );
 


### PR DESCRIPTION
I tried a few methods from their docs but didn't want to change too much https://developer.1password.com/docs/web/compatible-website-design/

<img width="456" height="117" alt="image" src="https://github.com/user-attachments/assets/1d82f62d-b6d3-4404-8a41-9843c5db5bf2" />
