### PR TITLE
Record GitHub (Enterprise) App Access Token Permissions During Token Creation

### DIFF
--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -148,12 +148,20 @@ class GithubProxyClient(IntegrationProxyClient):
         data = self.post(f"/app/installations/{self._get_installation_id()}/access_tokens")
         access_token = data["token"]
         expires_at = datetime.strptime(data["expires_at"], "%Y-%m-%dT%H:%M:%SZ").isoformat()
-        integration.metadata.update({"access_token": access_token, "expires_at": expires_at})
+        permissions = data.get("permissions")
+        integration.metadata.update(
+            {
+                "access_token": access_token,
+                "expires_at": expires_at,
+                "permissions": permissions,
+            }
+        )
         integration.save()
         logger.info(
             "token.refresh_end",
             extra={
                 "new_expires_at": integration.metadata.get("expires_at"),
+                "new_permissions": integration.metadata.get("permissions"),
                 "integration_id": integration.id,
             },
         )

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -150,7 +150,18 @@ class GitHubIntegrationTest(IntegrationTestCase):
         responses.add(
             responses.POST,
             self.base_url + f"/app/installations/{self.installation_id}/access_tokens",
-            json={"token": self.access_token, "expires_at": self.expires_at},
+            json={
+                "token": self.access_token,
+                "expires_at": self.expires_at,
+                "permissions": {
+                    "administration": "read",
+                    "contents": "read",
+                    "issues": "write",
+                    "metadata": "read",
+                    "pull_requests": "read",
+                },
+                "repository_selection": "all",
+            },
         )
 
         repositories: dict[str, Any] = {
@@ -403,6 +414,13 @@ class GitHubIntegrationTest(IntegrationTestCase):
             "domain_name": "github.com/Test-Organization",
             "account_type": "Organization",
             "account_id": 60591805,
+            "permissions": {
+                "administration": "read",
+                "contents": "read",
+                "issues": "write",
+                "metadata": "read",
+                "pull_requests": "read",
+            },
         }
         oi = OrganizationIntegration.objects.get(
             integration=integration, organization_id=self.organization.id


### PR DESCRIPTION
We need to verify whether Seer has read and write access. The scopes of an access token are only returned when creating an installation access token for an app. This PR begins capturing those permissions on the next token refresh.

https://docs.github.com/en/enterprise-server@3.17/rest/apps/apps?apiVersion=2022-11-28#create-an-installation-access-token-for-an-app