### PR TITLE
fix(aci): Re-add changes to write to DetectorGroup

### DIFF
--- a/src/sentry/issues/ingest.py
+++ b/src/sentry/issues/ingest.py
@@ -34,6 +34,7 @@ from sentry.types.group import PriorityLevel
 from sentry.utils import json, metrics, redis
 from sentry.utils.strings import truncatechars
 from sentry.utils.tag_normalization import normalized_sdk_tag_from_event
+from sentry.workflow_engine.models.detector_group import DetectorGroup
 
 issue_rate_limiter = RedisSlidingWindowRateLimiter(
     **settings.SENTRY_ISSUE_PLATFORM_RATE_LIMITER_OPTIONS
@@ -232,6 +233,12 @@ def save_issue_from_occurrence(
             group, is_new, primary_grouphash = save_grouphash_and_group(
                 project, event, primary_hash, **issue_kwargs
             )
+            if is_new and occurrence.evidence_data and "detector_id" in occurrence.evidence_data:
+                DetectorGroup.objects.get_or_create(
+                    detector_id=occurrence.evidence_data["detector_id"],
+                    group_id=group.id,
+                )
+
             open_period = get_latest_open_period(group)
             if open_period is not None:
                 highest_seen_priority = group.priority

--- a/tests/sentry/issues/test_ingest.py
+++ b/tests/sentry/issues/test_ingest.py
@@ -11,7 +11,7 @@ from sentry.api.helpers.group_index.update import handle_priority
 from sentry.constants import LOG_LEVELS_MAP, MAX_CULPRIT_LENGTH
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.incidents.grouptype import MetricIssueDetectorHandler
-from sentry.incidents.utils.types import QuerySubscriptionUpdate
+from sentry.incidents.utils.types import ProcessedSubscriptionUpdate
 from sentry.issues.grouptype import (
     FeedbackGroup,
     GroupCategory,
@@ -265,12 +265,12 @@ class SaveIssueOccurrenceTest(OccurrenceTestMixin, TestCase):
         # Create event
         event = self.store_event(data={}, project_id=self.project.id)
 
-        query_subscription_update: QuerySubscriptionUpdate = {
-            "entity": "events",
-            "subscription_id": str(query_subscription.id),
-            "values": {"value": 15},
-            "timestamp": datetime.now(UTC),
-        }
+        query_subscription_update: ProcessedSubscriptionUpdate = ProcessedSubscriptionUpdate(
+            entity="events",
+            subscription_id=str(query_subscription.id),
+            values={"value": 15},
+            timestamp=datetime.now(UTC),
+        )
 
         handler = MetricIssueDetectorHandler(detector)
         data_packet = DataPacket(str(query_subscription.id), query_subscription_update)

--- a/tests/sentry/issues/test_ingest.py
+++ b/tests/sentry/issues/test_ingest.py
@@ -11,7 +11,7 @@ from sentry.api.helpers.group_index.update import handle_priority
 from sentry.constants import LOG_LEVELS_MAP, MAX_CULPRIT_LENGTH
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.incidents.grouptype import MetricIssueDetectorHandler
-from sentry.incidents.utils.types import ProcessedSubscriptionUpdate
+from sentry.incidents.utils.types import AnomalyDetectionUpdate, ProcessedSubscriptionUpdate
 from sentry.issues.grouptype import (
     FeedbackGroup,
     GroupCategory,
@@ -273,7 +273,9 @@ class SaveIssueOccurrenceTest(OccurrenceTestMixin, TestCase):
         )
 
         handler = MetricIssueDetectorHandler(detector)
-        data_packet = DataPacket(str(query_subscription.id), query_subscription_update)
+        data_packet: DataPacket[ProcessedSubscriptionUpdate | AnomalyDetectionUpdate] = DataPacket(
+            str(query_subscription.id), query_subscription_update
+        )
         eval_result = handler.evaluate(data_packet)
 
         occurrence = None


### PR DESCRIPTION
Undo the revert of https://github.com/getsentry/sentry/pull/95357

> Once we create a group, we can add the group + detector info to DetectorGroup to allow lookups by detector id for the monitors page. Since detector groups are ingested via IssuePlatform, this logic can live inside save_issue_occurrence.