### PR TITLE
fix(test) - Remove network calls from test_project_codeowners_details.py

### DIFF
--- a/tests/sentry/api/endpoints/test_project_codeowners_details.py
+++ b/tests/sentry/api/endpoints/test_project_codeowners_details.py
@@ -44,15 +44,16 @@ class ProjectCodeOwnersDetailsEndpointTestCase(APITestCase):
         )
 
         # Mock the external HTTP request to prevent real network calls
-        self.codeowner_mock = patch(
+        self.codeowner_patcher = patch(
             "sentry.integrations.source_code_management.repository.RepositoryIntegration.get_codeowner_file",
             return_value={
                 "html_url": "https://github.com/test/CODEOWNERS",
                 "filepath": "CODEOWNERS",
                 "raw": "test content",
             },
-        ).start()
-        self.addCleanup(patch.stopall)
+        )
+        self.codeowner_mock = self.codeowner_patcher.start()
+        self.addCleanup(self.codeowner_patcher.stop)
 
     def test_basic_delete(self):
         with self.feature({"organizations:integrations-codeowners": True}):


### PR DESCRIPTION
We were  making requests to the external codeowners file link, added a patch to call a mock

closes ID-763