### PR TITLE
chore(issues): remove option check for inferring project platform

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -140,7 +140,6 @@ from sentry.utils.dates import to_datetime
 from sentry.utils.event import has_event_minified_stack_trace, has_stacktrace, is_handled
 from sentry.utils.eventuser import EventUser
 from sentry.utils.metrics import MutableTags
-from sentry.utils.options import sample_modulo
 from sentry.utils.outcomes import Outcome, track_outcome
 from sentry.utils.projectflags import set_project_flag_and_signal
 from sentry.utils.safe import get_path, safe_execute, setdefault_path, trim
@@ -470,8 +469,7 @@ class EventManager:
 
         # Sometimes projects get created without a platform (e.g. through the API), in which case we
         # attempt to set it based on the first event
-        if sample_modulo("sentry:infer_project_platform", project.id):
-            _set_project_platform_if_needed(project, job["event"])
+        _set_project_platform_if_needed(project, job["event"])
 
         event_type = self._data.get("type")
         if event_type == "transaction":

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -3717,7 +3717,7 @@ class DSLatestReleaseBoostTest(TestCase):
         ts = timezone.now().timestamp()
 
         # We want to test with multiple platforms.
-        for platform in ("python", "java", None):
+        for platform in ("python", "java"):
             project = self.create_project(platform=platform)
 
             for index, (release_version, environment) in enumerate(

--- a/tests/sentry/event_manager/test_event_manager_grouping.py
+++ b/tests/sentry/event_manager/test_event_manager_grouping.py
@@ -149,6 +149,9 @@ class EventManagerGroupingTest(TestCase):
 
     def test_auto_updates_grouping_config(self) -> None:
         self.project.update_option("sentry:grouping_config", NO_MSG_PARAM_CONFIG)
+        # Set platform to prevent additional audit log entry from platform inference
+        self.project.platform = "python"
+        self.project.save()
 
         save_new_event({"message": "Adopt don't shop"}, self.project)
         assert self.project.get_option("sentry:grouping_config") == DEFAULT_GROUPING_CONFIG

--- a/tests/sentry/event_manager/test_project_platform_infer.py
+++ b/tests/sentry/event_manager/test_project_platform_infer.py
@@ -1,10 +1,8 @@
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers import override_options
 from sentry.testutils.helpers.eventprocessing import save_new_event
 
 
 class ProjectPlatformInferTest(TestCase):
-    @override_options({"sentry:infer_project_platform": 1.0})
     def test_platform_inferred_on_event(self) -> None:
         project = self.create_project()
 
@@ -13,7 +11,6 @@ class ProjectPlatformInferTest(TestCase):
         project.refresh_from_db()
         assert project.platform == "javascript"
 
-    @override_options({"sentry:infer_project_platform": 1.0})
     def test_platform_does_not_override_existing_platform(self) -> None:
         project = self.create_project(platform="python")
 

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -2200,7 +2200,7 @@ class DetectBaseUrlsForUptimeTestMixin(BasePostProgressGroupMixin):
 @patch("sentry.utils.metrics.distribution")
 class CheckIfFlagsSentTestMixin(BasePostProgressGroupMixin):
     def test_set_has_flags(self, mock_dist, mock_incr, mock_record):
-        project = self.create_project()
+        project = self.create_project(platform="other")
         event_id = "a" * 32
         event = self.create_event(
             data={


### PR DESCRIPTION
Inferring project platform is fully rolled out (see [automator](https://github.com/getsentry/sentry-options-automator/blob/4f93bbbbcb12630347bc7c6ef2fa27b6b55f739e/options/default/app.yaml#L282)), this removes the option check from the `event_manager`.

Rollout looks very stable, ~13k / 26k projects have now been assigned a platform ([datadog chart](https://app.datadoghq.com/metric/explorer?fromUser=false&graph_layout=multi&start=1752620302092&end=1753225102092&paused=false#N4Ig7glgJg5gpgFxALlAGwIYE8D2BXJVEADxQEYAaELcqyKBAC1pEbghkcLIF8qo4AMwgA7CAgg4RKUAiwAHOChASAtnADOcAE4RNIKtrgBHPJoQaUAbVBGN8qVoD6gnNtUZCKiOq279VKY6epbINiAiGOrKQdpYZAYgUJ4YThr42gDGSsgg6gi6mZaBZnHKGniqyFoiBVgAdBAaFZqNIoI6TvLaOABWcJkIXZgIru71FZnZzcAAVDz1GBpOmfi1ABQAlCA8ALpUY6p4mKHhh8cYMaXxO-sgGnJoOaDyGE8ICDlJODArJxoQTKJNwCbROABGNFyCAwMGKIDQojgTjkinKOERUESiJEyPoTGUIjcHjQO34TXkmCwKIUXxxSj2PD490p4gAwlJhDAUCJjmgeEA), [redash query](https://redash.getsentry.net/queries/9252)), so this option is safe to remove.