### PR TITLE
chore(performance): remove flag check for related issues table

### DIFF
--- a/static/app/views/insights/database/views/databaseSpanSummaryPage.spec.tsx
+++ b/static/app/views/insights/database/views/databaseSpanSummaryPage.spec.tsx
@@ -21,7 +21,7 @@ jest.mock('sentry/utils/useReleaseStats');
 
 describe('DatabaseSpanSummaryPage', function () {
   const organization = OrganizationFixture({
-    features: ['insights-related-issues-table', 'insights-initial-modules'],
+    features: ['insights-initial-modules'],
   });
   const group = GroupFixture();
   const groupId = '1756baf8fd19c116';

--- a/static/app/views/insights/database/views/databaseSpanSummaryPage.tsx
+++ b/static/app/views/insights/database/views/databaseSpanSummaryPage.tsx
@@ -1,7 +1,6 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
-import Feature from 'sentry/components/acl/feature';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -224,19 +223,17 @@ export function DatabaseSpanSummaryPage({params}: Props) {
                 </DescriptionContainer>
               )}
 
-              <Feature features="insights-related-issues-table">
-                {!areIndexedSpansByGroupIdLoading && (
-                  <ModuleLayout.Full>
-                    <InsightIssuesList
-                      issueTypes={[
-                        'performance_slow_db_query',
-                        'performance_n_plus_one_db_queries',
-                      ]}
-                      message={indexedSpansByGroupId[0]?.['span.description']}
-                    />
-                  </ModuleLayout.Full>
-                )}
-              </Feature>
+              {!areIndexedSpansByGroupIdLoading && (
+                <ModuleLayout.Full>
+                  <InsightIssuesList
+                    issueTypes={[
+                      'performance_slow_db_query',
+                      'performance_n_plus_one_db_queries',
+                    ]}
+                    message={indexedSpansByGroupId[0]?.['span.description']}
+                  />
+                </ModuleLayout.Full>
+              )}
 
               <ModuleLayout.Full>
                 <ChartContainer>


### PR DESCRIPTION
The related issue insights table is now [fully rolled out](https://github.com/getsentry/sentry-options-automator/blob/b206af42bddb4030e7e1c46b19ac5236b6c012f6/options/default/flagpole.yml#L3324), so we can remove the feature flag check from the frontend

Relevant slack thread: https://sentry.slack.com/archives/CTZCE4WBZ/p1752705000211399