### PR TITLE
feat: create endpoint that fetches test suite list data

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -71,6 +71,7 @@ from sentry.codecov.endpoints.TestResults.test_results import TestResultsEndpoin
 from sentry.codecov.endpoints.TestResultsAggregates.test_results_aggregates import (
     TestResultsAggregatesEndpoint,
 )
+from sentry.codecov.endpoints.TestSuites.test_suites import TestSuitesEndpoint
 from sentry.data_export.endpoints.data_export import DataExportEndpoint
 from sentry.data_export.endpoints.data_export_details import DataExportDetailsEndpoint
 from sentry.discover.endpoints.discover_homepage_query import DiscoverHomepageQueryEndpoint
@@ -1058,6 +1059,11 @@ PREVENT_URLS = [
         r"^owner/(?P<owner>[^/]+)/repository/(?P<repository>[^/]+)/test-results/$",
         TestResultsEndpoint.as_view(),
         name="sentry-api-0-test-results",
+    ),
+    re_path(
+        r"^owner/(?P<owner>[^/]+)/repository/(?P<repository>[^/]+)/test-suites/$",
+        TestSuitesEndpoint.as_view(),
+        name="sentry-api-0-test-suites",
     ),
     re_path(
         r"^owner/(?P<owner>[^/]+)/repository/(?P<repository>[^/]+)/test-results-aggregates/$",

--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -1147,5 +1147,6 @@ Available fields are:
         location="query",
         required=False,
         type=str,
+        many=True,
         description="""A list of test suites belonging to a repository's test results.""",
     )

--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -1142,3 +1142,10 @@ Available fields are:
         type=str,
         description="""Whether to get the previous or next page from paginated results. Use `next` for forward pagination after the cursor or `prev` for backward pagination before the cursor. If not specified, defaults to `next`. If no cursor is provided, the cursor is the beginning of the result set.""",
     )
+    TEST_SUITES = OpenApiParameter(
+        name="testSuites",
+        location="query",
+        required=False,
+        type=str,
+        description="""A list of test suites belonging to a repository's test results.""",
+    )

--- a/src/sentry/codecov/endpoints/Branches/query.py
+++ b/src/sentry/codecov/endpoints/Branches/query.py
@@ -11,6 +11,7 @@ query = """query GetBranches(
     repository(name: $repo) {
       __typename
       ... on Repository {
+        defaultBranch
         branches(
           filters: $filters
           first: $first,

--- a/src/sentry/codecov/endpoints/Branches/serializers.py
+++ b/src/sentry/codecov/endpoints/Branches/serializers.py
@@ -21,6 +21,7 @@ class BranchesSerializer(serializers.Serializer):
     Serializer for repository branches response
     """
 
+    defaultBranch = serializers.CharField()
     results = BranchNodeSerializer(many=True)
     pageInfo = PageInfoSerializer()
     totalCount = serializers.IntegerField()
@@ -30,7 +31,9 @@ class BranchesSerializer(serializers.Serializer):
         Transform the GraphQL response to the serialized format
         """
         try:
-            branch_data = graphql_response["data"]["owner"]["repository"]["branches"]
+            repository_data = graphql_response["data"]["owner"]["repository"]
+            default_branch = repository_data["defaultBranch"]
+            branch_data = repository_data["branches"]
             branches = branch_data["edges"]
             page_info = branch_data.get("pageInfo", {})
 
@@ -40,6 +43,7 @@ class BranchesSerializer(serializers.Serializer):
                 nodes.append(node)
 
             response_data = {
+                "defaultBranch": default_branch,
                 "results": nodes,
                 "pageInfo": branch_data.get(
                     "pageInfo",

--- a/src/sentry/codecov/endpoints/TestResults/test_results.py
+++ b/src/sentry/codecov/endpoints/TestResults/test_results.py
@@ -104,7 +104,9 @@ class TestResultsEndpoint(CodecovEndpoint):
                 ),
                 "flags": None,
                 "term": request.query_params.get("term"),
-                "test_suites": request.GET.getlist("testSuites"),
+                "test_suites": (
+                    request.GET.getlist("testSuites") if "testSuites" in request.GET else None
+                ),
             },
             "ordering": {
                 "direction": ordering_direction,

--- a/src/sentry/codecov/endpoints/TestResults/test_results.py
+++ b/src/sentry/codecov/endpoints/TestResults/test_results.py
@@ -104,7 +104,7 @@ class TestResultsEndpoint(CodecovEndpoint):
                 ),
                 "flags": None,
                 "term": request.query_params.get("term"),
-                "test_suites": None,
+                "test_suites": request.GET.getlist("testSuites"),
             },
             "ordering": {
                 "direction": ordering_direction,

--- a/src/sentry/codecov/endpoints/TestSuites/query.py
+++ b/src/sentry/codecov/endpoints/TestSuites/query.py
@@ -1,0 +1,20 @@
+query = """query GetTestResultsTestSuites(
+    $owner: String!
+    $repo: String!
+    $term: String
+  ) {
+    owner(username: $owner) {
+        repository: repository(name: $repo) {
+            __typename
+            ... on Repository {
+                defaultBranch
+                testAnalytics {
+                    testSuites(term: $term)
+                }
+            }
+            ... on NotFoundError {
+                message
+            }
+        }
+    }
+}"""

--- a/src/sentry/codecov/endpoints/TestSuites/serializers.py
+++ b/src/sentry/codecov/endpoints/TestSuites/serializers.py
@@ -13,7 +13,6 @@ class TestSuiteSerializer(serializers.Serializer):
 
     __test__ = False
 
-    defaultBranch = serializers.CharField()
     testSuites = serializers.ListField(child=serializers.CharField())
 
     def to_representation(self, instance):
@@ -21,12 +20,7 @@ class TestSuiteSerializer(serializers.Serializer):
         Transform the GraphQL response to the serialized format
         """
         try:
-            repository_data = instance["data"]["owner"]["repository"]
-            response_data = {
-                "testSuites": repository_data["testAnalytics"]["testSuites"],
-                "defaultBranch": repository_data["defaultBranch"],
-            }
-
+            response_data = instance["data"]["owner"]["repository"]["testAnalytics"]
             return super().to_representation(response_data)
 
         except (KeyError, TypeError) as e:

--- a/src/sentry/codecov/endpoints/TestSuites/serializers.py
+++ b/src/sentry/codecov/endpoints/TestSuites/serializers.py
@@ -1,0 +1,44 @@
+import logging
+
+import sentry_sdk
+from rest_framework import serializers
+
+logger = logging.getLogger(__name__)
+
+
+class TestSuiteSerializer(serializers.Serializer):
+    """
+    Serializer for test suites belonging to a repository's test results
+    """
+
+    __test__ = False
+
+    defaultBranch = serializers.CharField()
+    testSuites = serializers.ListField(child=serializers.CharField())
+
+    def to_representation(self, instance):
+        """
+        Transform the GraphQL response to the serialized format
+        """
+        try:
+            repository_data = instance["data"]["owner"]["repository"]
+            response_data = {
+                "testSuites": repository_data["testAnalytics"]["testSuites"],
+                "defaultBranch": repository_data["defaultBranch"],
+            }
+
+            return super().to_representation(response_data)
+
+        except (KeyError, TypeError) as e:
+            sentry_sdk.capture_exception(e)
+            logger.exception(
+                "Error parsing GraphQL response",
+                extra={
+                    "error": str(e),
+                    "endpoint": "test-suites",
+                    "response_keys": (
+                        list(instance.keys()) if isinstance(instance, dict) else None
+                    ),
+                },
+            )
+            raise

--- a/src/sentry/codecov/endpoints/TestSuites/test_suites.py
+++ b/src/sentry/codecov/endpoints/TestSuites/test_suites.py
@@ -30,7 +30,7 @@ class TestSuitesEndpoint(CodecovEndpoint):
             GlobalParams.ORG_ID_OR_SLUG,
             PreventParams.OWNER,
             PreventParams.REPOSITORY,
-            PreventParams.TEST_SUITES,
+            PreventParams.TERM,
         ],
         request=None,
         responses={

--- a/src/sentry/codecov/endpoints/TestSuites/test_suites.py
+++ b/src/sentry/codecov/endpoints/TestSuites/test_suites.py
@@ -1,0 +1,61 @@
+from drf_spectacular.utils import extend_schema
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.apidocs.constants import RESPONSE_BAD_REQUEST, RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND
+from sentry.apidocs.parameters import GlobalParams, PreventParams
+from sentry.codecov.base import CodecovEndpoint
+from sentry.codecov.client import CodecovApiClient
+from sentry.codecov.endpoints.TestSuites.query import query
+from sentry.codecov.endpoints.TestSuites.serializers import TestSuiteSerializer
+from sentry.integrations.services.integration.model import RpcIntegration
+
+
+@extend_schema(tags=["Prevent"])
+@region_silo_endpoint
+class TestSuitesEndpoint(CodecovEndpoint):
+    __test__ = False
+
+    owner = ApiOwner.CODECOV
+    publish_status = {
+        "GET": ApiPublishStatus.PUBLIC,
+    }
+
+    @extend_schema(
+        operation_id="Retrieve test suites belonging to a repository's test results",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            PreventParams.OWNER,
+            PreventParams.REPOSITORY,
+            PreventParams.TEST_SUITES,
+        ],
+        request=None,
+        responses={
+            200: TestSuiteSerializer,
+            400: RESPONSE_BAD_REQUEST,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
+    def get(self, request: Request, owner: RpcIntegration, repository: str, **kwargs) -> Response:
+        """
+        Retrieves test suites belonging to a repository's test results.
+        It accepts a list of test suites as a query parameter to specify individual test suites.
+        """
+
+        owner_slug = owner.name
+
+        variables = {
+            "owner": owner_slug,
+            "repo": repository,
+            "term": request.query_params.get("term", ""),
+        }
+
+        client = CodecovApiClient(git_provider_org=owner_slug)
+        graphql_response = client.query(query=query, variables=variables)
+        test_suites = TestSuiteSerializer().to_representation(graphql_response.json())
+
+        return Response(test_suites)

--- a/tests/sentry/codecov/endpoints/test_branches.py
+++ b/tests/sentry/codecov/endpoints/test_branches.py
@@ -11,6 +11,7 @@ mock_graphql_response_populated: dict[str, Any] = {
     "data": {
         "owner": {
             "repository": {
+                "defaultBranch": "main",
                 "branches": {
                     "edges": [
                         {
@@ -30,7 +31,7 @@ mock_graphql_response_populated: dict[str, Any] = {
                         "hasPreviousPage": False,
                         "startCursor": None,
                     },
-                }
+                },
             }
         }
     }
@@ -40,9 +41,10 @@ mock_graphql_response_empty: dict[str, Any] = {
     "data": {
         "owner": {
             "repository": {
+                "defaultBranch": "main",
                 "branches": {
                     "edges": [],
-                }
+                },
             }
         }
     }

--- a/tests/sentry/codecov/endpoints/test_test_results.py
+++ b/tests/sentry/codecov/endpoints/test_test_results.py
@@ -179,6 +179,7 @@ class TestResultsEndpointTest(APITestCase):
             "sortBy": "-AVG_DURATION",
             "interval": "INTERVAL_7_DAY",
             "limit": "10",
+            "testSuites": "../usr/local",
         }
         response = self.client.get(url, query_params)
 
@@ -192,7 +193,7 @@ class TestResultsEndpointTest(APITestCase):
                 "interval": "INTERVAL_7_DAY",
                 "flags": None,
                 "term": None,
-                "test_suites": None,
+                "test_suites": ["../usr/local"],
             },
             "ordering": {
                 "direction": "DESC",

--- a/tests/sentry/codecov/endpoints/test_test_results.py
+++ b/tests/sentry/codecov/endpoints/test_test_results.py
@@ -59,7 +59,7 @@ mock_graphql_response_populated = {
                                     "avgDuration": 0.034125877192982455,
                                     "totalDuration": 1.0,
                                     "lastDuration": 0.034125877192982455,
-                                    "name": "../usr/local/lib/python3.13/site-packages/asgiref/sync.py::GetFinalYamlInteractorTest::test_when_commit_has_yaml",
+                                    "name": "../usr/local-2/lib/python3.13/site-packages/asgiref/sync.py::GetFinalYamlInteractorTest::test_when_commit_has_yaml",
                                     "failureRate": 0.0,
                                     "flakeRate": 0.0,
                                     "commitsFailed": 0,
@@ -179,7 +179,7 @@ class TestResultsEndpointTest(APITestCase):
             "sortBy": "-AVG_DURATION",
             "interval": "INTERVAL_7_DAY",
             "limit": "10",
-            "testSuites": "../usr/local",
+            "testSuites": ["../usr/local", "../usr/local-2"],
         }
         response = self.client.get(url, query_params)
 
@@ -193,7 +193,7 @@ class TestResultsEndpointTest(APITestCase):
                 "interval": "INTERVAL_7_DAY",
                 "flags": None,
                 "term": None,
-                "test_suites": ["../usr/local"],
+                "test_suites": ["../usr/local", "../usr/local-2"],
             },
             "ordering": {
                 "direction": "DESC",

--- a/tests/sentry/codecov/endpoints/test_test_suites.py
+++ b/tests/sentry/codecov/endpoints/test_test_suites.py
@@ -9,7 +9,6 @@ mock_graphql_response_populated: dict[str, Any] = {
     "data": {
         "owner": {
             "repository": {
-                "defaultBranch": "main",
                 "testAnalytics": {"testSuites": ["suite-1", "another-2", "suite-3"]},
             }
         }
@@ -17,9 +16,7 @@ mock_graphql_response_populated: dict[str, Any] = {
 }
 
 mock_graphql_response_empty: dict[str, Any] = {
-    "data": {
-        "owner": {"repository": {"defaultBranch": "main-2", "testAnalytics": {"testSuites": []}}}
-    }
+    "data": {"owner": {"repository": {"testAnalytics": {"testSuites": []}}}}
 }
 
 
@@ -65,7 +62,6 @@ class TestSuitesEndpointTest(APITestCase):
         assert mock_codecov_client_instance.query.call_count == 1
         assert response.status_code == 200
 
-        assert response.data["defaultBranch"] == "main"
         assert response.data["testSuites"] == ["suite-1", "another-2", "suite-3"]
 
     @patch("sentry.codecov.endpoints.TestSuites.test_suites.CodecovApiClient")

--- a/tests/sentry/codecov/endpoints/test_test_suites.py
+++ b/tests/sentry/codecov/endpoints/test_test_suites.py
@@ -10,7 +10,7 @@ mock_graphql_response_populated: dict[str, Any] = {
         "owner": {
             "repository": {
                 "defaultBranch": "main",
-                "testResults": {"testSuites": ["suite-1", "another-2", "suite-3"]},
+                "testAnalytics": {"testSuites": ["suite-1", "another-2", "suite-3"]},
             }
         }
     }
@@ -18,7 +18,7 @@ mock_graphql_response_populated: dict[str, Any] = {
 
 mock_graphql_response_empty: dict[str, Any] = {
     "data": {
-        "owner": {"repository": {"defaultBranch": "main-2", "testResults": {"testSuites": []}}}
+        "owner": {"repository": {"defaultBranch": "main-2", "testAnalytics": {"testSuites": []}}}
     }
 }
 

--- a/tests/sentry/codecov/endpoints/test_test_suites.py
+++ b/tests/sentry/codecov/endpoints/test_test_suites.py
@@ -1,0 +1,91 @@
+from typing import Any
+from unittest.mock import ANY, Mock, patch
+
+from django.urls import reverse
+
+from sentry.testutils.cases import APITestCase
+
+mock_graphql_response_populated: dict[str, Any] = {
+    "data": {
+        "owner": {
+            "repository": {
+                "defaultBranch": "main",
+                "testResults": {"testSuites": ["suite-1", "another-2", "suite-3"]},
+            }
+        }
+    }
+}
+
+mock_graphql_response_empty: dict[str, Any] = {
+    "data": {
+        "owner": {"repository": {"defaultBranch": "main-2", "testResults": {"testSuites": []}}}
+    }
+}
+
+
+class TestSuitesEndpointTest(APITestCase):
+    endpoint_name = "sentry-api-0-test-suites"
+
+    def setUp(self):
+        super().setUp()
+        self.user = self.create_user(email="user@example.com")
+        self.organization = self.create_organization(owner=self.user)
+        self.integration = self.create_integration(
+            organization=self.organization,
+            external_id="1234",
+            name="testowner",
+            provider="github",
+        )
+        self.login_as(user=self.user)
+
+    def reverse_url(self, owner="testowner", repository="testrepo"):
+        """Custom reverse URL method to handle required URL parameters"""
+        return reverse(
+            self.endpoint_name,
+            kwargs={
+                "organization_id_or_slug": self.organization.slug,
+                "owner": self.integration.id,
+                "repository": repository,
+            },
+        )
+
+    @patch("sentry.codecov.endpoints.TestSuites.test_suites.CodecovApiClient")
+    def test_get_returns_mock_response(self, mock_codecov_client_class):
+        mock_codecov_client_instance = Mock()
+        mock_response = Mock()
+        mock_response.json.return_value = mock_graphql_response_populated
+        mock_codecov_client_instance.query.return_value = mock_response
+        mock_codecov_client_class.return_value = mock_codecov_client_instance
+
+        url = self.reverse_url()
+        response = self.client.get(url)
+
+        mock_codecov_client_class.assert_called_once_with(git_provider_org="testowner")
+
+        assert mock_codecov_client_instance.query.call_count == 1
+        assert response.status_code == 200
+
+        assert response.data["defaultBranch"] == "main"
+        assert response.data["testSuites"] == ["suite-1", "another-2", "suite-3"]
+
+    @patch("sentry.codecov.endpoints.TestSuites.test_suites.CodecovApiClient")
+    def test_get_with_interval_query_param(self, mock_codecov_client_class):
+        mock_codecov_client_instance = Mock()
+        mock_response = Mock()
+        mock_response.json.return_value = mock_graphql_response_populated
+        mock_codecov_client_instance.query.return_value = mock_response
+        mock_codecov_client_class.return_value = mock_codecov_client_instance
+
+        url = self.reverse_url()
+        response = self.client.get(url, {"term": "suite-1"})
+
+        assert response.status_code == 200
+        mock_codecov_client_class.assert_called_once_with(git_provider_org="testowner")
+        mock_codecov_client_instance.query.assert_called_once_with(
+            query=ANY,
+            variables={
+                "owner": "testowner",
+                "repo": "testrepo",
+                "term": "suite-1",
+            },
+        )


### PR DESCRIPTION
This PR adds an endpoint that returns test-suite data from a repository's test results. Additionally, it modifies the test-results endpoint to account for the testSuite's query parameter, as well as return the defaultBranch for a repository for the branches list endpoint. 
 
Closes https://linear.app/getsentry/issue/CCMRG-1404/test-analytics-backend-endpoint-for-test-suites and https://linear.app/getsentry/issue/CCMRG-1317/create-api-endpoint-that-surfaces-test-suite