### PR TITLE
fix(search): Fix added extra characters after search

### DIFF
--- a/static/app/components/searchQueryBuilder/tokens/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/combobox.tsx
@@ -499,7 +499,10 @@ export function SearchQueryBuilderCombobox<
     isKeyboardDismissDisabled: true,
     shouldCloseOnBlur: true,
     shouldCloseOnInteractOutside: el => {
-      if (popoverRef.current?.contains(el)) {
+      if (
+        popoverRef.current?.contains(el) ||
+        el.closest('[data-test-id="search-query-builder"]')
+      ) {
         return false;
       }
 

--- a/static/app/components/searchQueryBuilder/tokens/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/combobox.tsx
@@ -370,7 +370,7 @@ export function SearchQueryBuilderCombobox<
   ['data-test-id']: dataTestId,
   ref,
 }: SearchQueryBuilderComboboxProps<T>) {
-  const {disabled, portalTarget, enableAISearch} = useSearchQueryBuilder();
+  const {disabled, portalTarget, enableAISearch, wrapperRef} = useSearchQueryBuilder();
   const listBoxRef = useRef<HTMLUListElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const popoverRef = useRef<HTMLDivElement>(null);
@@ -499,10 +499,7 @@ export function SearchQueryBuilderCombobox<
     isKeyboardDismissDisabled: true,
     shouldCloseOnBlur: true,
     shouldCloseOnInteractOutside: el => {
-      if (
-        popoverRef.current?.contains(el) ||
-        el.closest('[data-test-id="search-query-builder"]')
-      ) {
+      if (popoverRef.current?.contains(el) || wrapperRef.current?.contains(el)) {
         return false;
       }
 


### PR DESCRIPTION
this pr fixes an issue where after you click in the search bar, it searched but also added a few additional characters (the last ones you typed) to the search. now it'll perform the correct search and show you the search menu (which also wasn't working before) 
Fixes https://linear.app/getsentry/issue/RTC-1077/bug-extra-character-added-when-clicking-search-bar-and-hitting-enter