### PR TITLE
feat(workflow_engine): Add `has_grouping` flag to Stateful Detectors

### DIFF
--- a/src/sentry/incidents/grouptype.py
+++ b/src/sentry/incidents/grouptype.py
@@ -164,6 +164,8 @@ def get_alert_type_from_aggregate_dataset(
 
 
 class MetricIssueDetectorHandler(StatefulDetectorHandler[MetricUpdate, MetricResult]):
+    has_grouping = False
+
     def build_detector_evidence_data(
         self,
         evaluation_result: ProcessedDataConditionGroup,
@@ -241,10 +243,11 @@ class MetricIssueDetectorHandler(StatefulDetectorHandler[MetricUpdate, MetricRes
         return int(data_packet.packet.timestamp.timestamp())
 
     def extract_value(self, data_packet: DataPacket[MetricUpdate]) -> MetricResult:
-        # this is a bit of a hack - anomaly detection data packets send extra data we need to pass along
         values = data_packet.packet.values
+
         if isinstance(data_packet.packet, AnomalyDetectionUpdate):
-            return {None: values}
+            return values
+
         return values.get("value")
 
     def construct_title(

--- a/src/sentry/workflow_engine/handlers/detector/__init__.py
+++ b/src/sentry/workflow_engine/handlers/detector/__init__.py
@@ -4,8 +4,9 @@ __all__ = [
     "DetectorHandler",
     "DetectorOccurrence",
     "DetectorStateData",
+    "DetectorThresholds",
     "StatefulDetectorHandler",
 ]
 
 from .base import DataPacketEvaluationType, DataPacketType, DetectorHandler, DetectorOccurrence
-from .stateful import DetectorStateData, StatefulDetectorHandler
+from .stateful import DetectorStateData, DetectorThresholds, StatefulDetectorHandler

--- a/src/sentry/workflow_engine/handlers/detector/stateful.py
+++ b/src/sentry/workflow_engine/handlers/detector/stateful.py
@@ -311,7 +311,11 @@ class StatefulDetectorHandler(
     Stateful Detectors are provided as a base class for new detectors that need to track state.
     """
 
-    def __init__(self, detector: Detector, thresholds: DetectorThresholds | None = None):
+    has_grouping: bool
+
+    def __init__(
+        self, detector: Detector, thresholds: DetectorThresholds | None = None, has_grouping=False
+    ):
         super().__init__(detector)
 
         # Default to 1 for all the possible levels on a given detector
@@ -325,6 +329,7 @@ class StatefulDetectorHandler(
         }
 
         self.state_manager = DetectorStateManager(detector, list(self._thresholds.keys()))
+        self.has_grouping = has_grouping
 
     @property
     def thresholds(self) -> DetectorThresholds:
@@ -558,6 +563,9 @@ class StatefulDetectorHandler(
             return False
 
         if not value:  # Empty dict case
+            return False
+
+        if not self.has_grouping:
             return False
 
         # Check if all keys are DetectorGroupKey instances

--- a/tests/sentry/workflow_engine/handlers/detector/test_base.py
+++ b/tests/sentry/workflow_engine/handlers/detector/test_base.py
@@ -62,10 +62,10 @@ class MockDetectorStateHandler(StatefulDetectorHandler[dict, int | None]):
         return data_packet.packet.get("dedupe", 0)
 
     def extract_value(self, data_packet: DataPacket[dict]) -> int:
-        if data_packet.packet.get("value"):
-            return data_packet.packet["value"]
+        if self.has_grouping:
+            return data_packet.packet.get("group_vals", 0)
 
-        return data_packet.packet.get("group_vals", 0)
+        return data_packet.packet["value"]
 
     def create_occurrence(
         self,

--- a/tests/sentry/workflow_engine/handlers/detector/test_base.py
+++ b/tests/sentry/workflow_engine/handlers/detector/test_base.py
@@ -11,6 +11,7 @@ from sentry.workflow_engine.handlers.detector import (
     DataPacketEvaluationType,
     DetectorHandler,
     DetectorOccurrence,
+    DetectorThresholds,
     StatefulDetectorHandler,
 )
 from sentry.workflow_engine.handlers.detector.stateful import DetectorCounters
@@ -55,6 +56,18 @@ def status_change_comparator(self: StatusChangeMessage, other: StatusChangeMessa
 
 
 class MockDetectorStateHandler(StatefulDetectorHandler[dict, int | None]):
+    def __init__(
+        self,
+        detector: Detector,
+        thresholds: DetectorThresholds | None = None,
+        has_grouping: bool = True,
+    ):
+        """
+        Tests have `has_grouping` enabled by default.
+        This is to ensure consistency in tests, when the flag was introduced.
+        """
+        super().__init__(detector, thresholds, has_grouping)
+
     def test_get_empty_counter_state(self):
         return {name: None for name in self.state_manager.counter_names}
 

--- a/tests/sentry/workflow_engine/handlers/detector/test_stateful.py
+++ b/tests/sentry/workflow_engine/handlers/detector/test_stateful.py
@@ -193,6 +193,7 @@ class TestStatefulDetectorHandlerEvaluate(TestCase):
             "id": str(key),
             "dedupe": key,
             "group_vals": {self.group_key: result.name},
+            "value": result.name,
         }
         return DataPacket(source_id=str(key), packet=packet)
 
@@ -390,6 +391,24 @@ class TestStatefulDetectorHandlerEvaluate(TestCase):
         state_data = test_handler.state_manager.get_state_data([self.group_key])[self.group_key]
         assert state_data.is_triggered is True
         assert state_data.status == Level.LOW
+
+    def test_evaluate__with_grouping(self):
+        self.handler.has_grouping = True
+        self.group_key = "test_group"
+
+        self.handler._thresholds[Level.HIGH] = 1
+        result = self.handler.evaluate(self.packet(2, Level.HIGH))
+
+        assert result
+        group_result = result[self.group_key]
+
+        assert group_result
+        assert group_result.result
+        assert group_result.result.evidence_data
+        evidence_data = group_result.result.evidence_data
+
+        assert evidence_data.get("detector_id") == self.detector.id
+        assert evidence_data.get("value") == Level.HIGH.name
 
 
 class TestDetectorStateManagerRedisOptimization(TestCase):

--- a/tests/sentry/workflow_engine/handlers/detector/test_stateful.py
+++ b/tests/sentry/workflow_engine/handlers/detector/test_stateful.py
@@ -404,6 +404,8 @@ class TestStatefulDetectorHandlerEvaluate(TestCase):
 
         assert group_result
         assert group_result.result
+
+        assert isinstance(group_result.result, IssueOccurrence)
         assert group_result.result.evidence_data
         evidence_data = group_result.result.evidence_data
 


### PR DESCRIPTION
# Description
When adding the Anomaly Detection Condition Handler, we ran into a use case where the data packet is a dictionary and needs multiple values from it to be able to invoke seer as expected. We were able to work around the issue by nesting the dictionary in `{ None: original_data }`. This didn't feel like a great fix, so adding a flag `has_grouping` to help determine if we should extract keys or not.

Also update the Mock to be able to support this more easily.