### PR TITLE
chore(django): Tidy up `BaseManager` caching and other cruft

### DIFF
--- a/src/sentry/models/groupmeta.py
+++ b/src/sentry/models/groupmeta.py
@@ -56,16 +56,6 @@ class GroupMetaManager(BaseManager["GroupMeta"]):
         for group_id, key, value in results:
             self.__cache[group_id][key] = value
 
-    def get_value_bulk(self, instance_list, key, default=None):
-        results = {}
-        for instance in instance_list:
-            try:
-                inst_cache = self.__cache[instance.id]
-            except KeyError:
-                raise GroupMetaCacheNotPopulated(ERR_CACHE_MISSING % (instance.id,))
-            results[instance] = inst_cache.get(key, default)
-        return results
-
     def get_value(self, instance, key, default=None):
         try:
             inst_cache = self.__cache[instance.id]

--- a/tests/sentry/models/test_groupmeta.py
+++ b/tests/sentry/models/test_groupmeta.py
@@ -26,15 +26,3 @@ class GroupMetaManagerTest(TestCase):
         GroupMeta.objects.create(group=self.group, key="foo", value="bar")
         GroupMeta.objects.unset_value(self.group, "foo")
         assert not GroupMeta.objects.filter(group=self.group, key="foo").exists()
-
-    def test_get_value_bulk(self):
-        with pytest.raises(GroupMetaCacheNotPopulated):
-            GroupMeta.objects.get_value_bulk([self.group], "foo")
-
-        GroupMeta.objects.create(group=self.group, key="foo", value="bar")
-        with pytest.raises(GroupMetaCacheNotPopulated):
-            GroupMeta.objects.get_value_bulk([self.group], "foo")
-
-        GroupMeta.objects.populate_cache([self.group])
-        result = GroupMeta.objects.get_value_bulk([self.group], "foo")
-        assert result == {self.group: "bar"}


### PR DESCRIPTION
Removes `self.__local_cache` and related from `BaseManager`. Note that this is *not* the same as `self.local_cache`, which does not reference `self.__local_cache`, but instead references a module level `_local_cache` variable. This all makes sense.

`self.__local_cache` and related aren't used at all. They seem to keep track of the instance state, but it's not really used in general. The only place that uses it is where we delete keys from the cache in `self.__post_save`, but as far as I can tell that code is also not helpful, because we've just written these fields to the cache, so there's no real reason to go and then just delete them if they've changed.

Also removed a bunch of logic for setting up triggers that fire in various situations. These look like they have never been used, and are cluttering up the class and making it hard to work with, so also removing.

I'm tidying this up in preparation for some improvements to how we use the cache to make it a little faster.
