### PR TITLE
ref(trace_item_stats): Change tests to look at specific attributes

### DIFF
--- a/tests/sentry/api/endpoints/test_organization_spans_fields_stats.py
+++ b/tests/sentry/api/endpoints/test_organization_spans_fields_stats.py
@@ -119,18 +119,18 @@ class OrganizationSpansFieldsStatsEndpointTest(BaseSpansTestCase, APITestCase):
         response = self.do_request(query={"max_buckets": max_buckets - 1})
 
         assert response.status_code == 200, response.data
-        distributions = response.data["results"][0]["attributeDistributions"]["attributes"][0][
-            "buckets"
-        ]
-        assert len(distributions) == max_buckets - 1
+        distributions = response.data["results"][0]["attributeDistributions"]["attributes"]
+        attribute = next(a for a in distributions if a["attributeName"] == "test_tag")
+        assert attribute
+        assert len(attribute["buckets"]) == max_buckets - 1
 
     def test_distribution_values(self):
         tags = [
-            {"broswer": "chrome", "device": "desktop"},
-            {"broswer": "chrome", "device": "mobile"},
-            {"broswer": "chrome", "device": "desktop"},
-            {"broswer": "safari", "device": "mobile"},
-            {"broswer": "chrome", "device": "desktop"},
+            {"browser": "chrome", "device": "desktop"},
+            {"browser": "chrome", "device": "mobile"},
+            {"browser": "chrome", "device": "desktop"},
+            {"browser": "safari", "device": "mobile"},
+            {"browser": "chrome", "device": "desktop"},
         ]
 
         for tag in tags:
@@ -139,13 +139,15 @@ class OrganizationSpansFieldsStatsEndpointTest(BaseSpansTestCase, APITestCase):
         response = self.do_request(query={"dataset": "spans"})
         assert response.status_code == 200, response.data
         distributions = response.data["results"][0]["attributeDistributions"]["attributes"]
-        assert distributions[0]["attributeName"] == "broswer"
-        assert distributions[0]["buckets"] == [
+        attribute = next(a for a in distributions if a["attributeName"] == "browser")
+        assert attribute
+        assert attribute["buckets"] == [
             {"label": "chrome", "value": 4.0},
             {"label": "safari", "value": 1.0},
         ]
-        assert distributions[1]["attributeName"] == "device"
-        assert distributions[1]["buckets"] == [
+        attribute = next(a for a in distributions if a["attributeName"] == "device")
+        assert attribute
+        assert attribute["buckets"] == [
             {"label": "desktop", "value": 3.0},
             {"label": "mobile", "value": 2.0},
         ]


### PR DESCRIPTION
In order to allow https://github.com/getsentry/snuba/pull/7291, we need to make the tests look at a specific attribute in the response.