### PR TITLE
fix: Remove duplicate words

### DIFF
--- a/src/sentry/api/endpoints/organization_events_facets_performance.py
+++ b/src/sentry/api/endpoints/organization_events_facets_performance.py
@@ -409,7 +409,7 @@ def query_facet_performance(
     # Aggregate (avg) and count of all transactions for this query
     transaction_aggregate = tag_data["aggregate"]
 
-    # Exclude tags that have high cardinality are are generally unrelated to performance
+    # Exclude tags that have high cardinality are generally unrelated to performance
     excluded_tags = Condition(
         Column("tags_key"),
         Op.NOT_IN,

--- a/src/sentry/db/router.py
+++ b/src/sentry/db/router.py
@@ -28,7 +28,7 @@ class SiloRouter:
     - Monolith - all tables reside in the same database.
     - Siloed - tables for control and region are separated.
 
-    Within Siloed there are are two flavours:
+    Within Siloed there are two flavours:
 
     - simulated - If the application is configured with `control` and `default`
       connections, then we are in 'simulated' silo environment (like our testsuite).

--- a/src/sentry/replays/_case_studies/INC_1184_consumer_backlog_from_increased_threads/report.py
+++ b/src/sentry/replays/_case_studies/INC_1184_consumer_backlog_from_increased_threads/report.py
@@ -172,7 +172,7 @@ def test2_insufficient_queue_depth():
 def test3_over_production_hogs_cpu_time_leading_to_starvation():
     """
     Background:
-    "Because every time a MessageRejected is is raised by the commit step, it happens when process
+    "Because every time a MessageRejected is raised by the commit step, it happens when process
     submits to commit. by re-parsing the same message over and over in a tight loop we also steal
     the GIL from everything else."
 

--- a/static/app/utils/profiling/canvasView.spec.tsx
+++ b/static/app/utils/profiling/canvasView.spec.tsx
@@ -179,7 +179,7 @@ describe('CanvasView', () => {
       it('is zoomed in', () => {
         const {view} = makeCanvasAndView(canvas, flamegraph);
 
-        // Duration is is 1000, so we can't go over the end of the profile
+        // Duration is 1000, so we can't go over the end of the profile
         view.setConfigView(new Rect(600, 0, 500, 50));
         expect(view.configView).toEqual(new Rect(500, 0, 500, 50));
       });

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/dataSetStep.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/dataSetStep.tsx
@@ -89,7 +89,7 @@ export function DataSetStep({
     if (organization.features.includes('discover-saved-queries-deprecation')) {
       disabledChoices.push([
         DataSet.TRANSACTIONS,
-        t('This dataset is is no longer supported. Please use the Spans dataset.'),
+        t('This dataset is no longer supported. Please use the Spans dataset.'),
       ]);
     }
     datasetChoices.set(DataSet.TRANSACTIONS, t('Transactions'));

--- a/static/app/views/dashboards/widgetBuilder/components/datasetSelector.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/datasetSelector.spec.tsx
@@ -73,7 +73,7 @@ describe('DatasetSelector', function () {
     await userEvent.hover(transactionsRadio);
 
     expect(
-      await screen.findByText(/This dataset is is no longer supported./i)
+      await screen.findByText(/This dataset is no longer supported./i)
     ).toBeInTheDocument();
 
     // Click on the "Spans" link in the tooltip

--- a/static/app/views/dashboards/widgetBuilder/components/datasetSelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/datasetSelector.tsx
@@ -38,7 +38,7 @@ function WidgetBuilderDatasetSelector() {
   if (organization.features.includes('discover-saved-queries-deprecation')) {
     disabledChoices.push([
       WidgetType.TRANSACTIONS,
-      tct('This dataset is is no longer supported. Please use the [spans] dataset.', {
+      tct('This dataset is no longer supported. Please use the [spans] dataset.', {
         spans: (
           <Link
             // We need to do this otherwise the dashboard filters will change

--- a/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
@@ -403,7 +403,7 @@ export function getMenuOptions(
       label: t('Add to Dashboard'),
       disabled: disableTransactionEdit,
       tooltip: disableTransactionEdit
-        ? t('This dataset is is no longer supported. Please use the Spans dataset.')
+        ? t('This dataset is no longer supported. Please use the Spans dataset.')
         : undefined,
       onAction: () => {
         openAddToDashboardModal({
@@ -428,7 +428,7 @@ export function getMenuOptions(
       label: t('Duplicate Widget'),
       onAction: () => onDuplicate?.(),
       tooltip: disableTransactionEdit
-        ? t('This dataset is is no longer supported. Please use the Spans dataset.')
+        ? t('This dataset is no longer supported. Please use the Spans dataset.')
         : undefined,
       disabled: widgetLimitReached || !hasEditAccess || disableTransactionEdit,
     });

--- a/static/app/views/insights/database/components/noDataMessage.spec.tsx
+++ b/static/app/views/insights/database/components/noDataMessage.spec.tsx
@@ -100,7 +100,7 @@ describe('NoDataMessage', () => {
     );
   });
 
-  it('shows a list of denylisted projects if any are are set even if data is available', async function () {
+  it('shows a list of denylisted projects if any are set even if data is available', async function () {
     ProjectsStore.loadInitialData([
       ProjectFixture({
         name: 'Awful API',

--- a/static/app/views/settings/project/projectToolbar.tsx
+++ b/static/app/views/settings/project/projectToolbar.tsx
@@ -58,7 +58,7 @@ export default function ProjectToolbarSettings({
               {t('Domains where the dev toolbar is allowed to access your data.')}
               <br />
               {t(
-                'Protocol and port are optional; wildcard subdomains (*) are are supported.'
+                'Protocol and port are optional; wildcard subdomains (*) are supported.'
               )}
               <br />
               {tct(


### PR DESCRIPTION
This PR addresses instances of unintentional word duplication (e.g., "are are," "is is") throughout the codebase.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
