### PR TITLE
fix: button tracking events

### DIFF
--- a/static/gsApp/hooks/useButtonTracking.spec.tsx
+++ b/static/gsApp/hooks/useButtonTracking.spec.tsx
@@ -6,7 +6,7 @@ import {ProjectFixture} from 'getsentry-test/fixtures/project';
 import {renderHook} from 'sentry-test/reactTestingLibrary';
 
 import type {ButtonProps} from 'sentry/components/core/button';
-import {OrganizationContext} from 'sentry/views/organizationContext';
+import OrganizationStore from 'sentry/stores/organizationStore';
 import {TestRouteContext} from 'sentry/views/routeContext';
 
 import useButtonTracking from 'getsentry/hooks/useButtonTracking';
@@ -34,10 +34,13 @@ describe('buttonTracking', function () {
   };
 
   const wrapper = ({children}: ButtonProps) => (
-    <OrganizationContext value={organization}>
-      <TestRouteContext value={router}>{children}</TestRouteContext>
-    </OrganizationContext>
+    <TestRouteContext value={router}>{children}</TestRouteContext>
   );
+
+  beforeEach(function () {
+    OrganizationStore.init();
+    OrganizationStore.onUpdate(organization);
+  });
 
   afterEach(function () {
     (rawTrackAnalyticsEvent as jest.Mock).mockClear();

--- a/static/gsApp/hooks/useButtonTracking.tsx
+++ b/static/gsApp/hooks/useButtonTracking.tsx
@@ -1,7 +1,8 @@
 import {useCallback} from 'react';
 
 import type {ButtonProps} from 'sentry/components/core/button';
-import useOrganization from 'sentry/utils/useOrganization';
+import OrganizationStore from 'sentry/stores/organizationStore';
+import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import {useRoutes} from 'sentry/utils/useRoutes';
 
 import rawTrackAnalyticsEvent from 'getsentry/utils/rawTrackAnalyticsEvent';
@@ -10,7 +11,7 @@ import {convertToReloadPath, getEventPath} from 'getsentry/utils/routeAnalytics'
 type Props = ButtonProps;
 
 export default function useButtonTracking() {
-  const organization = useOrganization({allowNull: true});
+  const {organization} = useLegacyStore(OrganizationStore);
   const routes = useRoutes();
 
   const trackButton = useCallback(


### PR DESCRIPTION
read organization from legacy store; the change for button tracking to a react context made the organization `null`, because the OrganizationProvider gets added further down the tree
