### PR TITLE
ref: Partially migrate JS getting started docs from configurations to content block

### DIFF
--- a/static/app/gettingStartedDocs/javascript/angular.tsx
+++ b/static/app/gettingStartedDocs/javascript/angular.tsx
@@ -4,7 +4,7 @@ import widgetCallout from 'sentry/components/onboarding/gettingStartedDoc/feedba
 import TracePropagationMessage from 'sentry/components/onboarding/gettingStartedDoc/replay/tracePropagationMessage';
 import {
   type BasePlatformOptions,
-  type Configuration,
+  type ContentBlock,
   type Docs,
   type DocsParams,
   type OnboardingConfig,
@@ -223,70 +223,26 @@ public throwTestError(): void {
   throw new Error("Sentry Test Error");
 }`;
 
-function getVerifyConfiguration(): Configuration {
-  return {
-    description: t(
-      'To verify that everything is working as expected, you can trigger a test error in your app. As an example we will add a button that throws an error when being clicked to your main app component.'
-    ),
-    configurations: [
-      {
-        description: tct(
-          'First add the button element to your [code:app.component.html]:',
-          {code: <code />}
-        ),
-        code: [
-          {
-            label: 'HTML',
-            value: 'html',
-            language: 'html',
-            filename: 'app.component.html',
-            code: getVerifySnippetTemplate(),
-          },
-        ],
-      },
-      {
-        description: tct('Then, in your [code:app.component.ts] add the event handler:', {
-          code: <code />,
-        }),
-        code: [
-          {
-            label: 'TypeScript',
-            value: 'typescript',
-            language: 'typescript',
-            filename: 'app.component.ts',
-            code: getVerifySnippetComponent(),
-          },
-        ],
-      },
-    ],
-  };
-}
-
-const getInstallConfig = () => [
-  {
-    language: 'bash',
-    code: [
-      {
-        label: 'npm',
-        value: 'npm',
-        language: 'bash',
-        code: `npm install --save @sentry/angular`,
-      },
-      {
-        label: 'yarn',
-        value: 'yarn',
-        language: 'bash',
-        code: `yarn add @sentry/angular`,
-      },
-      {
-        label: 'pnpm',
-        value: 'pnpm',
-        language: 'bash',
-        code: `pnpm install @sentry/angular`,
-      },
-    ],
-  },
-];
+const installSnippetBlock: ContentBlock = {
+  type: 'code',
+  tabs: [
+    {
+      label: 'npm',
+      language: 'bash',
+      code: 'npm install --save @sentry/angular',
+    },
+    {
+      label: 'yarn',
+      language: 'bash',
+      code: 'yarn add @sentry/angular',
+    },
+    {
+      label: 'pnpm',
+      language: 'bash',
+      code: 'pnpm install @sentry/angular',
+    },
+  ],
+};
 
 const onboarding: OnboardingConfig<PlatformOptions> = {
   introduction: () =>
@@ -299,29 +255,44 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
   install: () => [
     {
       type: StepType.INSTALL,
-      description: tct(
-        'Add the Sentry SDK as a dependency using [code:npm], [code:yarn] or [code:pnpm]:',
-        {code: <code />}
-      ),
-      configurations: getInstallConfig(),
+      content: [
+        {
+          type: 'text',
+          text: tct(
+            'Add the Sentry SDK as a dependency using [code:npm], [code:yarn] or [code:pnpm]:',
+            {code: <code />}
+          ),
+        },
+        installSnippetBlock,
+      ],
     },
   ],
   configure: (params: Params) => [
     {
       type: StepType.CONFIGURE,
-      configurations: [
+      content: [
         {
-          description: tct(
+          type: 'text',
+          text: tct(
             `Initialize the Sentry Angular SDK in your [code:main.ts] file as early as possible, before initializing Angular:`,
             {
               code: <code />,
             }
           ),
-          language: 'javascript',
-          code: getSdkSetupSnippet(params),
         },
         {
-          description: isModuleConfig(params)
+          type: 'code',
+          tabs: [
+            {
+              label: 'JavaScript',
+              language: 'javascript',
+              code: getSdkSetupSnippet(params),
+            },
+          ],
+        },
+        {
+          type: 'text',
+          text: isModuleConfig(params)
             ? tct(
                 "Register the Sentry Angular SDK's ErrorHandler and Tracing providers in your [code:app.module.ts] file:",
                 {code: <code />}
@@ -330,10 +301,18 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
                 "Register the Sentry Angular SDK's ErrorHandler and Tracing providers in your [code:app.config.ts] file:",
                 {code: <code />}
               ),
-          language: 'javascript',
-          code: isModuleConfig(params)
-            ? getConfigureAppModuleSnippet()
-            : getConfigureAppConfigSnippet(),
+        },
+        {
+          type: 'code',
+          tabs: [
+            {
+              label: 'JavaScript',
+              language: 'javascript',
+              code: isModuleConfig(params)
+                ? getConfigureAppModuleSnippet()
+                : getConfigureAppConfigSnippet(),
+            },
+          ],
         },
       ],
     },
@@ -345,10 +324,52 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
   verify: () => [
     {
       type: StepType.VERIFY,
-      configurations: [
-        getVerifyConfiguration(),
+      content: [
         {
-          description: t(
+          type: 'text',
+          text: t(
+            'To verify that everything is working as expected, you can trigger a test error in your app. As an example we will add a button that throws an error when being clicked to your main app component.'
+          ),
+        },
+        {
+          type: 'text',
+          text: tct('First add the button element to your [code:app.component.html]:', {
+            code: <code />,
+          }),
+        },
+        {
+          type: 'code',
+          tabs: [
+            {
+              label: 'HTML',
+              value: 'html',
+              language: 'html',
+              filename: 'app.component.html',
+              code: getVerifySnippetTemplate(),
+            },
+          ],
+        },
+        {
+          type: 'text',
+          text: tct('Then, in your [code:app.component.ts] add the event handler:', {
+            code: <code />,
+          }),
+        },
+        {
+          type: 'code',
+          tabs: [
+            {
+              label: 'TypeScript',
+              value: 'typescript',
+              language: 'typescript',
+              filename: 'app.component.ts',
+              code: getVerifySnippetComponent(),
+            },
+          ],
+        },
+        {
+          type: 'text',
+          text: t(
             "After clicking the button, you should see the error on Sentry's Issues page."
           ),
         },
@@ -371,13 +392,18 @@ const replayOnboarding: OnboardingConfig<PlatformOptions> = {
   install: () => [
     {
       type: StepType.INSTALL,
-      description: tct(
-        'In order to use Session Replay, you will need version 7.27.0 of [code:@sentry/angular] at minimum. You do not need to install any additional packages.',
+      content: [
         {
-          code: <code />,
-        }
-      ),
-      configurations: getInstallConfig(),
+          type: 'text',
+          text: tct(
+            'In order to use Session Replay, you will need version 7.27.0 of [code:@sentry/angular] at minimum. You do not need to install any additional packages.',
+            {
+              code: <code />,
+            }
+          ),
+        },
+        installSnippetBlock,
+      ],
     },
   ],
   configure: (params: Params) => [
@@ -409,13 +435,18 @@ const feedbackOnboarding: OnboardingConfig<PlatformOptions> = {
   install: () => [
     {
       type: StepType.INSTALL,
-      description: tct(
-        'For the User Feedback integration to work, you must have the Sentry browser SDK package, or an equivalent framework SDK (e.g. [code:@sentry/angular]) installed, minimum version 7.85.0.',
+      content: [
         {
-          code: <code />,
-        }
-      ),
-      configurations: getInstallConfig(),
+          type: 'text',
+          text: tct(
+            'For the User Feedback integration to work, you must have the Sentry browser SDK package, or an equivalent framework SDK (e.g. [code:@sentry/angular]) installed, minimum version 7.85.0.',
+            {
+              code: <code />,
+            }
+          ),
+        },
+        installSnippetBlock,
+      ],
     },
   ],
   configure: (params: Params) => [
@@ -467,7 +498,7 @@ const crashReportOnboarding: OnboardingConfig<PlatformOptions> = {
 };
 
 const profilingOnboarding = getJavascriptProfilingOnboarding({
-  getInstallConfig,
+  installSnippetBlock,
   docsLink:
     'https://docs.sentry.io/platforms/javascript/guides/angular/profiling/browser-profiling/',
 });

--- a/static/app/gettingStartedDocs/javascript/angular.tsx
+++ b/static/app/gettingStartedDocs/javascript/angular.tsx
@@ -342,7 +342,6 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
           tabs: [
             {
               label: 'HTML',
-              value: 'html',
               language: 'html',
               filename: 'app.component.html',
               code: getVerifySnippetTemplate(),
@@ -360,7 +359,6 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
           tabs: [
             {
               label: 'TypeScript',
-              value: 'typescript',
               language: 'typescript',
               filename: 'app.component.ts',
               code: getVerifySnippetComponent(),

--- a/static/app/gettingStartedDocs/javascript/astro.tsx
+++ b/static/app/gettingStartedDocs/javascript/astro.tsx
@@ -5,6 +5,7 @@ import crashReportCallout from 'sentry/components/onboarding/gettingStartedDoc/f
 import widgetCallout from 'sentry/components/onboarding/gettingStartedDoc/feedback/widgetCallout';
 import TracePropagationMessage from 'sentry/components/onboarding/gettingStartedDoc/replay/tracePropagationMessage';
 import type {
+  ContentBlock,
   Docs,
   DocsParams,
   OnboardingConfig,
@@ -71,30 +72,16 @@ const getVerifySnippet = () => `
 </script>
 `;
 
-const getInstallConfig = () => [
-  {
-    type: StepType.INSTALL,
-    description: tct(
-      'Install the [code:@sentry/astro] package with the [code:astro] CLI:',
-      {
-        code: <code />,
-      }
-    ),
-    configurations: [
-      {
-        language: 'bash',
-        code: [
-          {
-            label: 'bash',
-            value: 'bash',
-            language: 'bash',
-            code: `npx astro add @sentry/astro`,
-          },
-        ],
-      },
-    ],
-  },
-];
+const installSnippetBlock: ContentBlock = {
+  type: 'code',
+  tabs: [
+    {
+      label: 'bash',
+      language: 'bash',
+      code: 'npx astro add @sentry/astro',
+    },
+  ],
+};
 
 const onboarding: OnboardingConfig = {
   introduction: () => (
@@ -114,19 +101,39 @@ const onboarding: OnboardingConfig = {
       </p>
     </Fragment>
   ),
-  install: () => getInstallConfig(),
+  install: () => [
+    {
+      type: StepType.INSTALL,
+      content: [
+        {
+          type: 'text',
+          text: tct(
+            'Install the [code:@sentry/astro] package with the [code:astro] CLI:',
+            {
+              code: <code />,
+            }
+          ),
+        },
+        installSnippetBlock,
+      ],
+    },
+  ],
   configure: (params: Params) => [
     {
       type: StepType.CONFIGURE,
-      description: tct(
-        'Open up your [astroConfig:astro.config.mjs] file and configure the DSN, and any other settings you need:',
+      content: [
         {
-          astroConfig: <code />,
-        }
-      ),
-      configurations: [
+          type: 'text',
+          text: tct(
+            'Open up your [astroConfig:astro.config.mjs] file and configure the DSN, and any other settings you need:',
+            {
+              astroConfig: <code />,
+            }
+          ),
+        },
         {
-          code: [
+          type: 'code',
+          tabs: [
             {
               label: 'JavaScript',
               value: 'javascript',
@@ -136,24 +143,27 @@ const onboarding: OnboardingConfig = {
           ],
         },
         {
-          description: tct(
+          type: 'text',
+          text: tct(
             'Add your Sentry auth token to the [authTokenEnvVar:SENTRY_AUTH_TOKEN] environment variable:',
             {
               authTokenEnvVar: <code />,
             }
           ),
-          language: 'bash',
-          code: [
+        },
+        {
+          type: 'code',
+          tabs: [
             {
-              value: 'bash',
-              language: 'bash',
               label: 'bash',
-              code: `SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___`,
+              language: 'bash',
+              code: 'SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___',
             },
           ],
         },
         {
-          description: tct(
+          type: 'text',
+          text: tct(
             'You can further customize your SDK by [manualSetupLink:manually initializing the SDK].',
             {
               manualSetupLink: (
@@ -168,12 +178,16 @@ const onboarding: OnboardingConfig = {
   verify: () => [
     {
       type: StepType.VERIFY,
-      description: t(
-        'Then throw a test error anywhere in your app, so you can test that everything is working:'
-      ),
-      configurations: [
+      content: [
         {
-          code: [
+          type: 'text',
+          text: t(
+            'Then throw a test error anywhere in your app, so you can test that everything is working:'
+          ),
+        },
+        {
+          type: 'code',
+          tabs: [
             {
               label: 'Astro',
               value: 'html',
@@ -182,21 +196,19 @@ const onboarding: OnboardingConfig = {
             },
           ],
         },
+        {
+          type: 'text',
+          text: t(
+            "If you're new to Sentry, use the email alert to access your account and complete a product tour."
+          ),
+        },
+        {
+          type: 'text',
+          text: t(
+            "If you're an existing user and have disabled alerts, you won't receive this email."
+          ),
+        },
       ],
-      additionalInfo: (
-        <Fragment>
-          <p>
-            {t(
-              "If you're new to Sentry, use the email alert to access your account and complete a product tour."
-            )}
-          </p>
-          <p>
-            {t(
-              "If you're an existing user and have disabled alerts, you won't receive this email."
-            )}
-          </p>
-        </Fragment>
-      ),
     },
   ],
   nextSteps: () => [
@@ -214,9 +226,23 @@ const onboarding: OnboardingConfig = {
 const replayOnboarding: OnboardingConfig = {
   install: () => [
     {
-      ...getInstallConfig()[0]!,
-      additionalInfo:
-        'Session Replay is enabled by default when you install the Astro SDK!',
+      type: StepType.INSTALL,
+      content: [
+        {
+          type: 'text',
+          text: tct(
+            'Install the [code:@sentry/astro] package with the [code:astro] CLI:',
+            {
+              code: <code />,
+            }
+          ),
+        },
+        installSnippetBlock,
+        {
+          type: 'text',
+          text: t('Session Replay is enabled by default when you install the Astro SDK!'),
+        },
+      ],
     },
   ],
   configure: (params: Params) => [
@@ -311,13 +337,18 @@ const feedbackOnboarding: OnboardingConfig = {
   install: () => [
     {
       type: StepType.INSTALL,
-      description: tct(
-        'For the User Feedback integration to work, you must have the Sentry browser SDK package, or an equivalent framework SDK (e.g. [code:@sentry/astro]) installed, minimum version 7.85.0.',
+      content: [
         {
-          code: <code />,
-        }
-      ),
-      configurations: getInstallConfig(),
+          type: 'text',
+          text: tct(
+            'For the User Feedback integration to work, you must have the Sentry browser SDK package, or an equivalent framework SDK (e.g. [code:@sentry/astro]) installed, minimum version 7.85.0.',
+            {
+              code: <code />,
+            }
+          ),
+        },
+        installSnippetBlock,
+      ],
     },
   ],
   configure: (params: Params) => [

--- a/static/app/gettingStartedDocs/javascript/astro.tsx
+++ b/static/app/gettingStartedDocs/javascript/astro.tsx
@@ -136,7 +136,6 @@ const onboarding: OnboardingConfig = {
           tabs: [
             {
               label: 'JavaScript',
-              value: 'javascript',
               language: 'javascript',
               code: getSdkSetupSnippet(params),
             },
@@ -190,7 +189,6 @@ const onboarding: OnboardingConfig = {
           tabs: [
             {
               label: 'Astro',
-              value: 'html',
               language: 'html',
               code: getVerifySnippet(),
             },

--- a/static/app/gettingStartedDocs/javascript/ember.tsx
+++ b/static/app/gettingStartedDocs/javascript/ember.tsx
@@ -170,7 +170,6 @@ const onboarding: OnboardingConfig = {
           tabs: [
             {
               label: 'JavaScript',
-              value: 'javascript',
               language: 'javascript',
               code: getSdkSetupSnippet(params),
             },
@@ -198,7 +197,6 @@ const onboarding: OnboardingConfig = {
           tabs: [
             {
               label: 'JavaScript',
-              value: 'javascript',
               language: 'javascript',
               code: getVerifyEmberSnippet(),
             },

--- a/static/app/gettingStartedDocs/javascript/ember.tsx
+++ b/static/app/gettingStartedDocs/javascript/ember.tsx
@@ -3,6 +3,7 @@ import crashReportCallout from 'sentry/components/onboarding/gettingStartedDoc/f
 import widgetCallout from 'sentry/components/onboarding/gettingStartedDoc/feedback/widgetCallout';
 import TracePropagationMessage from 'sentry/components/onboarding/gettingStartedDoc/replay/tracePropagationMessage';
 import type {
+  ContentBlock,
   Docs,
   DocsParams,
   OnboardingConfig,
@@ -115,15 +116,16 @@ export default class App extends Application {
 `;
 };
 
-const getInstallConfig = () => [
-  {
-    language: 'bash',
-    code: `
-# Using ember-cli
-ember install @sentry/ember
-    `,
-  },
-];
+const installSnippetBlock: ContentBlock = {
+  type: 'code',
+  tabs: [
+    {
+      label: 'ember-cli',
+      language: 'bash',
+      code: 'ember install @sentry/ember',
+    },
+  ],
+};
 
 const getVerifyEmberSnippet = () => `
 myUndefinedFunction();`;
@@ -139,21 +141,33 @@ const onboarding: OnboardingConfig = {
       description: t(
         'Sentry captures data by using an SDK within your application’s runtime.'
       ),
-      configurations: getInstallConfig(),
+      content: [
+        {
+          type: 'text',
+          text: t(
+            'Sentry captures data by using an SDK within your application’s runtime.'
+          ),
+        },
+        installSnippetBlock,
+      ],
     },
   ],
   configure: (params: Params) => [
     {
       type: StepType.CONFIGURE,
-      description: tct(
-        'You should [code:init] the Sentry SDK as soon as possible during your application load up in [code:app.js], before initializing Ember:',
+      content: [
         {
-          code: <code />,
-        }
-      ),
-      configurations: [
+          type: 'text',
+          text: tct(
+            'You should [code:init] the Sentry SDK as soon as possible during your application load up in [code:app.js], before initializing Ember:',
+            {
+              code: <code />,
+            }
+          ),
+        },
         {
-          code: [
+          type: 'code',
+          tabs: [
             {
               label: 'JavaScript',
               value: 'javascript',
@@ -172,12 +186,16 @@ const onboarding: OnboardingConfig = {
   verify: () => [
     {
       type: StepType.VERIFY,
-      description: t(
-        "This snippet contains an intentional error and can be used as a test to make sure that everything's working as expected."
-      ),
-      configurations: [
+      content: [
         {
-          code: [
+          type: 'text',
+          text: t(
+            "This snippet contains an intentional error and can be used as a test to make sure that everything's working as expected."
+          ),
+        },
+        {
+          type: 'code',
+          tabs: [
             {
               label: 'JavaScript',
               value: 'javascript',
@@ -196,13 +214,18 @@ const replayOnboarding: OnboardingConfig = {
   install: () => [
     {
       type: StepType.INSTALL,
-      description: tct(
-        'You need a minimum version 7.27.0 of [code:@sentry/ember] in order to use Session Replay. You do not need to install any additional packages.',
+      content: [
         {
-          code: <code />,
-        }
-      ),
-      configurations: getInstallConfig(),
+          type: 'text',
+          text: tct(
+            'You need a minimum version 7.27.0 of [code:@sentry/ember] in order to use Session Replay. You do not need to install any additional packages.',
+            {
+              code: <code />,
+            }
+          ),
+        },
+        installSnippetBlock,
+      ],
     },
   ],
   configure: (params: Params) => [
@@ -234,13 +257,18 @@ const feedbackOnboarding: OnboardingConfig = {
   install: () => [
     {
       type: StepType.INSTALL,
-      description: tct(
-        'For the User Feedback integration to work, you must have the Sentry browser SDK package, or an equivalent framework SDK (e.g. [code:@sentry/ember]) installed, minimum version 7.85.0.',
+      content: [
         {
-          code: <code />,
-        }
-      ),
-      configurations: getInstallConfig(),
+          type: 'text',
+          text: tct(
+            'For the User Feedback integration to work, you must have the Sentry browser SDK package, or an equivalent framework SDK (e.g. [code:@sentry/ember]) installed, minimum version 7.85.0.',
+            {
+              code: <code />,
+            }
+          ),
+        },
+        installSnippetBlock,
+      ],
     },
   ],
   configure: (params: Params) => [
@@ -292,7 +320,7 @@ const crashReportOnboarding: OnboardingConfig = {
 };
 
 const profilingOnboarding = getJavascriptProfilingOnboarding({
-  getInstallConfig,
+  installSnippetBlock,
   docsLink:
     'https://docs.sentry.io/platforms/javascript/guides/ember/profiling/browser-profiling/',
 });

--- a/static/app/gettingStartedDocs/javascript/gatsby.tsx
+++ b/static/app/gettingStartedDocs/javascript/gatsby.tsx
@@ -231,7 +231,6 @@ const onboarding: OnboardingConfig = {
           tabs: [
             {
               label: 'JavaScript',
-              value: 'javascript',
               language: 'javascript',
               code: getVerifySnippet(),
             },

--- a/static/app/gettingStartedDocs/javascript/gatsby.tsx
+++ b/static/app/gettingStartedDocs/javascript/gatsby.tsx
@@ -5,9 +5,11 @@ import crashReportCallout from 'sentry/components/onboarding/gettingStartedDoc/f
 import widgetCallout from 'sentry/components/onboarding/gettingStartedDoc/feedback/widgetCallout';
 import TracePropagationMessage from 'sentry/components/onboarding/gettingStartedDoc/replay/tracePropagationMessage';
 import type {
+  ContentBlock,
   Docs,
   DocsParams,
   OnboardingConfig,
+  OnboardingStep,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {getUploadSourceMapsStep} from 'sentry/components/onboarding/gettingStartedDoc/utils';
@@ -116,19 +118,22 @@ root.render(<App />);
 const getVerifySnippet = () => `
 myUndefinedFunction();`;
 
-const getConfigureStep = (params: Params) => {
+const getConfigureStep = (params: Params): OnboardingStep => {
   return {
     type: StepType.CONFIGURE,
-    configurations: [
+    content: [
       {
-        description: tct(
+        type: 'text',
+        text: tct(
           'Register the [code:Sentry@sentry/gatsby] plugin in your Gatsby configuration file (typically [code:gatsby-config.js]).',
           {code: <code />}
         ),
-        code: [
+      },
+      {
+        type: 'code',
+        tabs: [
           {
             label: 'JavaScript',
-            value: 'javascript',
             language: 'javascript',
             code: `module.exports = {
             plugins: [{
@@ -139,14 +144,17 @@ const getConfigureStep = (params: Params) => {
         ],
       },
       {
-        description: tct(
+        type: 'text',
+        text: tct(
           'Then, configure your [codeSentry:Sentry.init:]. For this, create a new file called [codeSentry:sentry.config.js] in the root of your project and add the following code:',
           {codeSentry: <code />}
         ),
-        code: [
+      },
+      {
+        type: 'code',
+        tabs: [
           {
             label: 'JavaScript',
-            value: 'javascript',
             language: 'javascript',
             filename: 'sentry.config.js',
             code: getSdkSetupSnippet(params),
@@ -157,21 +165,26 @@ const getConfigureStep = (params: Params) => {
   };
 };
 
-const getInstallConfig = () => [
-  {
-    language: 'bash',
-    code: [
-      {
-        label: 'npm',
-        value: 'npm',
-        language: 'bash',
-        code: 'npm install --save @sentry/gatsby',
-      },
-      {label: 'yarn', value: 'yarn', language: 'bash', code: 'yarn add @sentry/gatsby'},
-      {label: 'pnpm', value: 'pnpm', language: 'bash', code: 'pnpm add @sentry/gatsby'},
-    ],
-  },
-];
+const installSnippetBlock: ContentBlock = {
+  type: 'code',
+  tabs: [
+    {
+      label: 'npm',
+      language: 'bash',
+      code: 'npm install --save @sentry/gatsby',
+    },
+    {
+      label: 'yarn',
+      language: 'bash',
+      code: 'yarn add @sentry/gatsby',
+    },
+    {
+      label: 'pnpm',
+      language: 'bash',
+      code: 'pnpm add @sentry/gatsby',
+    },
+  ],
+};
 
 const onboarding: OnboardingConfig = {
   introduction: () =>
@@ -184,11 +197,16 @@ const onboarding: OnboardingConfig = {
   install: () => [
     {
       type: StepType.INSTALL,
-      description: tct(
-        'Add the Sentry SDK as a dependency using [code:npm], [code:yarn], or [code:pnpm]:',
-        {code: <code />}
-      ),
-      configurations: getInstallConfig(),
+      content: [
+        {
+          type: 'text',
+          text: tct(
+            'Add the Sentry SDK as a dependency using [code:npm], [code:yarn], or [code:pnpm]:',
+            {code: <code />}
+          ),
+        },
+        installSnippetBlock,
+      ],
     },
   ],
   configure: (params: Params) => [
@@ -201,12 +219,16 @@ const onboarding: OnboardingConfig = {
   verify: () => [
     {
       type: StepType.VERIFY,
-      description: t(
-        "This snippet contains an intentional error and can be used as a test to make sure that everything's working as expected."
-      ),
-      configurations: [
+      content: [
         {
-          code: [
+          type: 'text',
+          text: t(
+            "This snippet contains an intentional error and can be used as a test to make sure that everything's working as expected."
+          ),
+        },
+        {
+          type: 'code',
+          tabs: [
             {
               label: 'JavaScript',
               value: 'javascript',
@@ -225,11 +247,16 @@ const replayOnboarding: OnboardingConfig = {
   install: () => [
     {
       type: StepType.INSTALL,
-      description: tct(
-        'You need a minimum version 7.27.0 of [code:@sentry/gatsby] in order to use Session Replay. You do not need to install any additional packages.',
-        {code: <code />}
-      ),
-      configurations: getInstallConfig(),
+      content: [
+        {
+          type: 'text',
+          text: tct(
+            'You need a minimum version 7.27.0 of [code:@sentry/gatsby] in order to use Session Replay. You do not need to install any additional packages.',
+            {code: <code />}
+          ),
+        },
+        installSnippetBlock,
+      ],
     },
   ],
   configure: (params: Params) => [
@@ -258,11 +285,16 @@ const feedbackOnboarding: OnboardingConfig = {
   install: () => [
     {
       type: StepType.INSTALL,
-      description: tct(
-        'For the User Feedback integration to work, you must have the Sentry browser SDK package, or an equivalent framework SDK (e.g. [code:@sentry/gatsby]) installed, minimum version 7.85.0.',
-        {code: <code />}
-      ),
-      configurations: getInstallConfig(),
+      content: [
+        {
+          type: 'text',
+          text: tct(
+            'For the User Feedback integration to work, you must have the Sentry browser SDK package, or an equivalent framework SDK (e.g. [code:@sentry/gatsby]) installed, minimum version 7.85.0.',
+            {code: <code />}
+          ),
+        },
+        installSnippetBlock,
+      ],
     },
   ],
   configure: (params: Params) => [
@@ -314,7 +346,7 @@ const crashReportOnboarding: OnboardingConfig = {
 };
 
 const profilingOnboarding = getJavascriptProfilingOnboarding({
-  getInstallConfig,
+  installSnippetBlock,
   docsLink:
     'https://docs.sentry.io/platforms/javascript/guides/gatsby/profiling/browser-profiling/',
 });

--- a/static/app/gettingStartedDocs/javascript/javascript.tsx
+++ b/static/app/gettingStartedDocs/javascript/javascript.tsx
@@ -8,6 +8,7 @@ import widgetCallout from 'sentry/components/onboarding/gettingStartedDoc/feedba
 import TracePropagationMessage from 'sentry/components/onboarding/gettingStartedDoc/replay/tracePropagationMessage';
 import type {
   BasePlatformOptions,
+  ContentBlock,
   Docs,
   DocsParams,
   OnboardingConfig,
@@ -274,27 +275,41 @@ Sentry.init({
 const getVerifyJSSnippet = () => `
 myUndefinedFunction();`;
 
-const getInstallConfig = () => [
+const installSnippetBlock: ContentBlock = {
+  type: 'code',
+  tabs: [
+    {
+      label: 'npm',
+      language: 'bash',
+      code: 'npm install --save @sentry/browser',
+    },
+    {
+      label: 'yarn',
+      language: 'bash',
+      code: 'yarn add @sentry/browser',
+    },
+    {
+      label: 'pnpm',
+      language: 'bash',
+      code: 'pnpm add @sentry/browser',
+    },
+  ],
+};
+
+const verifySnippetBlock: ContentBlock[] = [
   {
-    language: 'bash',
-    code: [
+    type: 'text',
+    text: t(
+      "This snippet contains an intentional error and can be used as a test to make sure that everything's working as expected."
+    ),
+  },
+  {
+    type: 'code',
+    tabs: [
       {
-        label: 'npm',
-        value: 'npm',
-        language: 'bash',
-        code: 'npm install --save @sentry/browser',
-      },
-      {
-        label: 'yarn',
-        value: 'yarn',
-        language: 'bash',
-        code: 'yarn add @sentry/browser',
-      },
-      {
-        label: 'pnpm',
-        value: 'pnpm',
-        language: 'bash',
-        code: 'pnpm add @sentry/browser',
+        label: 'Javascript',
+        language: 'javascript',
+        code: getVerifyJSSnippet(),
       },
     ],
   },
@@ -303,21 +318,7 @@ const getInstallConfig = () => [
 const getVerifyConfig = () => [
   {
     type: StepType.VERIFY,
-    description: t(
-      "This snippet contains an intentional error and can be used as a test to make sure that everything's working as expected."
-    ),
-    configurations: [
-      {
-        code: [
-          {
-            label: 'Javascript',
-            value: 'javascript',
-            language: 'javascript',
-            code: getVerifyJSSnippet(),
-          },
-        ],
-      },
-    ],
+    content: verifySnippetBlock,
   },
 ];
 
@@ -464,11 +465,14 @@ const loaderScriptOnboarding: OnboardingConfig<PlatformOptions> = {
   install: params => [
     {
       type: StepType.INSTALL,
-      description: t('Add this script tag to the top of the page:'),
-      configurations: [
+      content: [
         {
-          language: 'html',
-          code: [
+          type: 'text',
+          text: t('Add this script tag to the top of the page:'),
+        },
+        {
+          type: 'code',
+          tabs: [
             {
               label: 'HTML',
               value: 'html',
@@ -522,43 +526,46 @@ const loaderScriptOnboarding: OnboardingConfig<PlatformOptions> = {
   configure: params => [
     {
       title: t('Configure SDK (Optional)'),
-      description: t(
-        "Initialize Sentry as early as possible in your application's lifecycle."
-      ),
       collapsible: true,
-      configurations: [
+      content: [
         {
-          language: 'html',
-          code: [
+          type: 'text',
+          text: t(
+            "Initialize Sentry as early as possible in your application's lifecycle."
+          ),
+        },
+        {
+          type: 'code',
+          tabs: [
             {
               label: 'HTML',
               value: 'html',
               language: 'html',
               code: `
-<script>
-  Sentry.onLoad(function() {
-    Sentry.init({${
-      params.isPerformanceSelected || params.isReplaySelected
-        ? ''
-        : `
-        // You can add any additional configuration here`
-    }${
-      params.isPerformanceSelected
-        ? `
-        // Tracing
-        tracesSampleRate: 1.0, // Capture 100% of the transactions`
-        : ''
-    }${
-      params.isReplaySelected
-        ? `
-        // Session Replay
-        replaysSessionSampleRate: 0.1, // This sets the sample rate at 10%. You may want to change it to 100% while in development and then sample at a lower rate in production.
-        replaysOnErrorSampleRate: 1.0, // If you're not already sampling the entire session, change the sample rate to 100% when sampling sessions where errors occur.`
-        : ''
-    }
-      });
-  });
-</script>`,
+              <script>
+                Sentry.onLoad(function() {
+                  Sentry.init({${
+                    params.isPerformanceSelected || params.isReplaySelected
+                      ? ''
+                      : `
+                      // You can add any additional configuration here`
+                  }${
+                    params.isPerformanceSelected
+                      ? `
+                      // Tracing
+                      tracesSampleRate: 1.0, // Capture 100% of the transactions`
+                      : ''
+                  }${
+                    params.isReplaySelected
+                      ? `
+                      // Session Replay
+                      replaysSessionSampleRate: 0.1, // This sets the sample rate at 10%. You may want to change it to 100% while in development and then sample at a lower rate in production.
+                      replaysOnErrorSampleRate: 1.0, // If you're not already sampling the entire session, change the sample rate to 100% when sampling sessions where errors occur.`
+                      : ''
+                  }
+                    });
+                });
+              </script>`,
             },
           ],
         },
@@ -638,24 +645,32 @@ const packageManagerOnboarding: OnboardingConfig<PlatformOptions> = {
   install: () => [
     {
       type: StepType.INSTALL,
-      description: t(
-        "Sentry captures data by using an SDK within your application's runtime."
-      ),
-      configurations: getInstallConfig(),
+      content: [
+        {
+          type: 'text',
+          text: t(
+            "Sentry captures data by using an SDK within your application's runtime."
+          ),
+        },
+        installSnippetBlock,
+      ],
     },
   ],
   configure: params => [
     {
       type: StepType.CONFIGURE,
-      description: t(
-        "Initialize Sentry as early as possible in your application's lifecycle."
-      ),
-      configurations: [
+      content: [
         {
-          code: [
+          type: 'text',
+          text: t(
+            "Initialize Sentry as early as possible in your application's lifecycle."
+          ),
+        },
+        {
+          type: 'code',
+          tabs: [
             {
               label: 'JavaScript',
-              value: 'javascript',
               language: 'javascript',
               code: getSdkSetupSnippet(params),
             },
@@ -756,13 +771,18 @@ const replayOnboarding: OnboardingConfig<PlatformOptions> = {
   install: () => [
     {
       type: StepType.INSTALL,
-      description: tct(
-        'For the Session Replay to work, you must have the Sentry browser SDK package, or an equivalent framework SDK (e.g. [code:@sentry/react]) installed, minimum version 7.27.0.',
+      content: [
         {
-          code: <code />,
-        }
-      ),
-      configurations: getInstallConfig(),
+          type: 'text',
+          text: tct(
+            'For the Session Replay to work, you must have the Sentry browser SDK package, or an equivalent framework SDK (e.g. [code:@sentry/react]) installed, minimum version 7.27.0.',
+            {
+              code: <code />,
+            }
+          ),
+        },
+        installSnippetBlock,
+      ],
     },
   ],
   configure: (params: Params) => [
@@ -794,13 +814,18 @@ const feedbackOnboarding: OnboardingConfig<PlatformOptions> = {
   install: () => [
     {
       type: StepType.INSTALL,
-      description: tct(
-        'For the User Feedback integration to work, you must have the Sentry browser SDK package, or an equivalent framework SDK (e.g. [code:@sentry/react]) installed, minimum version 7.85.0.',
+      content: [
         {
-          code: <code />,
-        }
-      ),
-      configurations: getInstallConfig(),
+          type: 'text',
+          text: tct(
+            'For the User Feedback integration to work, you must have the Sentry browser SDK package, or an equivalent framework SDK (e.g. [code:@sentry/react]) installed, minimum version 7.85.0.',
+            {
+              code: <code />,
+            }
+          ),
+        },
+        installSnippetBlock,
+      ],
     },
   ],
   configure: (params: Params) => [
@@ -859,11 +884,16 @@ const performanceOnboarding: OnboardingConfig<PlatformOptions> = {
   install: () => [
     {
       type: StepType.INSTALL,
-      description: tct(
-        'Install our JavaScript browser SDK using either [code:yarn] or [code:npm]:',
-        {code: <code />}
-      ),
-      configurations: getInstallConfig(),
+      content: [
+        {
+          type: 'text',
+          text: tct(
+            'Install our JavaScript browser SDK using either [code:yarn] or [code:npm]:',
+            {code: <code />}
+          ),
+        },
+        installSnippetBlock,
+      ],
     },
   ],
   configure: params => [
@@ -972,7 +1002,7 @@ Sentry.init({
 };
 
 const profilingOnboarding = getJavascriptProfilingOnboarding({
-  getInstallConfig,
+  installSnippetBlock,
   docsLink: 'https://docs.sentry.io/platforms/javascript/profiling/browser-profiling/',
 });
 

--- a/static/app/gettingStartedDocs/javascript/javascript.tsx
+++ b/static/app/gettingStartedDocs/javascript/javascript.tsx
@@ -475,7 +475,6 @@ const loaderScriptOnboarding: OnboardingConfig<PlatformOptions> = {
           tabs: [
             {
               label: 'HTML',
-              value: 'html',
               language: 'html',
               code: `
 <script
@@ -539,7 +538,6 @@ const loaderScriptOnboarding: OnboardingConfig<PlatformOptions> = {
           tabs: [
             {
               label: 'HTML',
-              value: 'html',
               language: 'html',
               code: `
               <script>

--- a/static/app/gettingStartedDocs/javascript/nuxt.tsx
+++ b/static/app/gettingStartedDocs/javascript/nuxt.tsx
@@ -107,7 +107,6 @@ const onboarding: OnboardingConfig = {
           tabs: [
             {
               label: 'Vue',
-              value: 'vue',
               language: 'html',
               code: getVerifyNuxtSnippet(),
             },
@@ -154,7 +153,6 @@ const replayOnboarding: OnboardingConfig = {
           tabs: [
             {
               label: 'JavaScript',
-              value: 'javascript',
               language: 'javascript',
               code: getReplaySDKSetupSnippet({
                 importStatement: `import * as Sentry from "@sentry/nuxt";`,

--- a/static/app/gettingStartedDocs/javascript/react.tsx
+++ b/static/app/gettingStartedDocs/javascript/react.tsx
@@ -179,7 +179,6 @@ const onboarding: OnboardingConfig = {
           tabs: [
             {
               label: 'JavaScript',
-              value: 'javascript',
               language: 'javascript',
               code: getSdkSetupSnippet(params),
             },
@@ -338,7 +337,6 @@ logger.fatal("Database connection pool exhausted", {
           tabs: [
             {
               label: 'React',
-              value: 'react',
               language: 'javascript',
               code: getVerifySnippet(),
             },

--- a/static/app/gettingStartedDocs/javascript/react.tsx
+++ b/static/app/gettingStartedDocs/javascript/react.tsx
@@ -120,32 +120,6 @@ const getVerifySnippet = () => `
 return <button onClick={() => {throw new Error("This is your first error!");}}>Break the world</button>;
 `;
 
-// TODO: Remove once the other product areas support content blocks
-const getInstallConfig = () => [
-  {
-    code: [
-      {
-        label: 'npm',
-        value: 'npm',
-        language: 'bash',
-        code: 'npm install --save @sentry/react',
-      },
-      {
-        label: 'yarn',
-        value: 'yarn',
-        language: 'bash',
-        code: 'yarn add @sentry/react',
-      },
-      {
-        label: 'pnpm',
-        value: 'pnpm',
-        language: 'bash',
-        code: 'pnpm add @sentry/react',
-      },
-    ],
-  },
-];
-
 const installSnippetBlock: ContentBlock = {
   type: 'code',
   tabs: [
@@ -395,11 +369,16 @@ const replayOnboarding: OnboardingConfig = {
   install: () => [
     {
       type: StepType.INSTALL,
-      description: tct(
-        'Add the Sentry SDK as a dependency using [code:npm], [code:yarn], or [code:pnpm]. You need a minimum version 7.27.0 of [code:@sentry/react] in order to use Session Replay. You do not need to install any additional packages.',
-        {code: <code />}
-      ),
-      configurations: getInstallConfig(),
+      content: [
+        {
+          type: 'text',
+          text: tct(
+            'Add the Sentry SDK as a dependency using [code:npm], [code:yarn], or [code:pnpm]. You need a minimum version 7.27.0 of [code:@sentry/react] in order to use Session Replay. You do not need to install any additional packages.',
+            {code: <code />}
+          ),
+        },
+        installSnippetBlock,
+      ],
     },
   ],
   configure: (params: Params) => [
@@ -430,13 +409,18 @@ const feedbackOnboarding: OnboardingConfig = {
   install: () => [
     {
       type: StepType.INSTALL,
-      description: tct(
-        'For the User Feedback integration to work, you must have the Sentry browser SDK package, or an equivalent framework SDK (e.g. [code:@sentry/react]) installed, minimum version 7.85.0.',
+      content: [
         {
-          code: <code />,
-        }
-      ),
-      configurations: getInstallConfig(),
+          type: 'text',
+          text: tct(
+            'For the User Feedback integration to work, you must have the Sentry browser SDK package, or an equivalent framework SDK (e.g. [code:@sentry/react]) installed, minimum version 7.85.0.',
+            {
+              code: <code />,
+            }
+          ),
+        },
+        installSnippetBlock,
+      ],
     },
   ],
   configure: (params: Params) => [
@@ -601,7 +585,7 @@ Sentry.init({
 };
 
 const profilingOnboarding = getJavascriptProfilingOnboarding({
-  getInstallConfig,
+  installSnippetBlock,
   docsLink:
     'https://docs.sentry.io/platforms/javascript/guides/react/profiling/browser-profiling/',
 });

--- a/static/app/gettingStartedDocs/javascript/remix.tsx
+++ b/static/app/gettingStartedDocs/javascript/remix.tsx
@@ -118,7 +118,6 @@ const onboarding: OnboardingConfig = {
           tabs: [
             {
               label: 'Javascript',
-              value: 'javascript',
               language: 'javascript',
               code: `myUndefinedFunction();`,
             },

--- a/static/app/gettingStartedDocs/javascript/remix.tsx
+++ b/static/app/gettingStartedDocs/javascript/remix.tsx
@@ -6,6 +6,7 @@ import crashReportCallout from 'sentry/components/onboarding/gettingStartedDoc/f
 import widgetCallout from 'sentry/components/onboarding/gettingStartedDoc/feedback/widgetCallout';
 import TracePropagationMessage from 'sentry/components/onboarding/gettingStartedDoc/replay/tracePropagationMessage';
 import type {
+  ContentBlock,
   Docs,
   DocsParams,
   OnboardingConfig,
@@ -30,29 +31,26 @@ import {getNodeAgentMonitoringOnboarding} from 'sentry/utils/gettingStartedDocs/
 
 type Params = DocsParams;
 
-const getConfigStep = ({isSelfHosted, organization, projectSlug}: Params) => {
-  const urlParam = isSelfHosted ? '' : '--saas';
-
-  return [
-    {
-      description: tct(
-        'Configure your app automatically by running the [wizardLink:Sentry wizard] in the root of your project.',
-        {
-          wizardLink: (
-            <ExternalLink href="https://docs.sentry.io/platforms/javascript/guides/remix/#install" />
-          ),
-        }
-      ),
-      language: 'bash',
-      code: `npx @sentry/wizard@latest -i remix ${urlParam}  --org ${organization.slug} --project ${projectSlug}`,
-    },
-  ];
-};
-
-const getInstallConfig = (params: Params) => [
+const getInstallContent = ({
+  isSelfHosted,
+  organization,
+  projectSlug,
+}: Params): ContentBlock[] => [
   {
-    type: StepType.INSTALL,
-    configurations: getConfigStep(params),
+    type: 'text',
+    text: tct(
+      'Configure your app automatically by running the [wizardLink:Sentry wizard] in the root of your project.',
+      {
+        wizardLink: (
+          <ExternalLink href="https://docs.sentry.io/platforms/javascript/guides/remix/#install" />
+        ),
+      }
+    ),
+  },
+  {
+    type: 'code',
+    language: 'bash',
+    code: `npx @sentry/wizard@latest -i remix ${isSelfHosted ? '' : '--saas'}  --org ${organization.slug} --project ${projectSlug}`,
   },
 ];
 
@@ -70,24 +68,28 @@ const onboarding: OnboardingConfig = {
   install: (params: Params) => [
     {
       title: t('Automatic Configuration (Recommended)'),
-      configurations: getConfigStep(params),
+      content: getInstallContent(params),
     },
   ],
   configure: params => [
     {
       collapsible: true,
       title: t('Manual Configuration'),
-      description: tct(
-        'Alternatively, you can also set up the SDK manually, by following the [manualSetupLink:manual setup docs].',
+      content: [
         {
-          manualSetupLink: (
-            <ExternalLink href="https://docs.sentry.io/platforms/javascript/guides/remix/manual-setup/" />
+          type: 'text',
+          text: tct(
+            'Alternatively, you can also set up the SDK manually, by following the [manualSetupLink:manual setup docs].',
+            {
+              manualSetupLink: (
+                <ExternalLink href="https://docs.sentry.io/platforms/javascript/guides/remix/manual-setup/" />
+              ),
+            }
           ),
-        }
-      ),
-      configurations: [
+        },
         {
-          description: <CopyDsnField params={params} />,
+          type: 'custom',
+          content: <CopyDsnField params={params} />,
         },
       ],
     },
@@ -95,26 +97,25 @@ const onboarding: OnboardingConfig = {
   verify: () => [
     {
       type: StepType.VERIFY,
-      description: (
-        <Fragment>
-          <p>
-            {tct(
-              'Start your development server and visit [code:/sentry-example-page] if you have set it up. Click the button to trigger a test error.',
-              {
-                code: <code />,
-              }
-            )}
-          </p>
-          <p>
-            {t(
-              'Or, trigger a sample error by calling a function that does not exist somewhere in your application.'
-            )}
-          </p>
-        </Fragment>
-      ),
-      configurations: [
+      content: [
         {
-          code: [
+          type: 'text',
+          text: tct(
+            'Start your development server and visit [code:/sentry-example-page] if you have set it up. Click the button to trigger a test error.',
+            {
+              code: <code />,
+            }
+          ),
+        },
+        {
+          type: 'text',
+          text: t(
+            'Or, trigger a sample error by calling a function that does not exist somewhere in your application.'
+          ),
+        },
+        {
+          type: 'code',
+          tabs: [
             {
               label: 'Javascript',
               value: 'javascript',
@@ -123,17 +124,25 @@ const onboarding: OnboardingConfig = {
             },
           ],
         },
+        {
+          type: 'text',
+          text: t(
+            'If you see an issue in your Sentry Issues, you have successfully set up Sentry.'
+          ),
+        },
       ],
-      additionalInfo: t(
-        'If you see an issue in your Sentry Issues, you have successfully set up Sentry.'
-      ),
     },
   ],
   nextSteps: () => [],
 };
 
 const replayOnboarding: OnboardingConfig = {
-  install: (params: Params) => getInstallConfig(params),
+  install: (params: Params) => [
+    {
+      type: StepType.INSTALL,
+      content: getInstallContent(params),
+    },
+  ],
   configure: (params: Params) => [
     {
       type: StepType.CONFIGURE,
@@ -176,13 +185,18 @@ const feedbackOnboarding: OnboardingConfig = {
   install: (params: Params) => [
     {
       type: StepType.INSTALL,
-      description: tct(
-        'For the User Feedback integration to work, you must have the Sentry browser SDK package, or an equivalent framework SDK (e.g. [code:@sentry/remix]) installed, minimum version 7.85.0.',
+      content: [
         {
-          code: <code />,
-        }
-      ),
-      configurations: getConfigStep(params),
+          type: 'text',
+          text: tct(
+            'For the User Feedback integration to work, you must have the Sentry browser SDK package, or an equivalent framework SDK (e.g. [code:@sentry/remix]) installed, minimum version 7.85.0.',
+            {
+              code: <code />,
+            }
+          ),
+        },
+        ...getInstallContent(params),
+      ],
     },
   ],
   configure: (params: Params) => [

--- a/static/app/gettingStartedDocs/javascript/solid.tsx
+++ b/static/app/gettingStartedDocs/javascript/solid.tsx
@@ -5,6 +5,7 @@ import crashReportCallout from 'sentry/components/onboarding/gettingStartedDoc/f
 import widgetCallout from 'sentry/components/onboarding/gettingStartedDoc/feedback/widgetCallout';
 import TracePropagationMessage from 'sentry/components/onboarding/gettingStartedDoc/replay/tracePropagationMessage';
 import type {
+  ContentBlock,
   Docs,
   DocsParams,
   OnboardingConfig,
@@ -134,6 +135,7 @@ const getVerifySnippet = () => `
   Throw error
 </button>`;
 
+// TODO: Remove once the other product areas support content blocks
 const getInstallConfig = () => [
   {
     language: 'bash',
@@ -160,6 +162,27 @@ const getInstallConfig = () => [
   },
 ];
 
+const installSnippetBlock: ContentBlock = {
+  type: 'code',
+  tabs: [
+    {
+      label: 'npm',
+      language: 'bash',
+      code: 'npm install --save @sentry/solid',
+    },
+    {
+      label: 'yarn',
+      language: 'bash',
+      code: 'yarn add @sentry/solid',
+    },
+    {
+      label: 'pnpm',
+      language: 'bash',
+      code: 'pnpm add @sentry/solid',
+    },
+  ],
+};
+
 const onboarding: OnboardingConfig = {
   introduction: () => (
     <Fragment>
@@ -176,25 +199,34 @@ const onboarding: OnboardingConfig = {
   install: () => [
     {
       type: StepType.INSTALL,
-      description: tct(
-        'Add the Sentry SDK as a dependency using [code:npm], [code:yarn], or [code:pnpm]:',
+      content: [
         {
-          code: <code />,
-        }
-      ),
-      configurations: getInstallConfig(),
+          type: 'text',
+          text: tct(
+            'Add the Sentry SDK as a dependency using [code:npm], [code:yarn], or [code:pnpm]:',
+            {
+              code: <code />,
+            }
+          ),
+        },
+        installSnippetBlock,
+      ],
     },
   ],
   configure: (params: Params) => [
     {
       type: StepType.CONFIGURE,
-      description: tct(
-        "Initialize Sentry as early as possible in your application's lifecycle, usually your solid app's entry point ([code:main.ts/js]):",
-        {code: <code />}
-      ),
-      configurations: [
+      content: [
         {
-          code: [
+          type: 'text',
+          text: tct(
+            "Initialize Sentry as early as possible in your application's lifecycle, usually your solid app's entry point ([code:main.ts/js]):",
+            {code: <code />}
+          ),
+        },
+        {
+          type: 'code',
+          tabs: [
             {
               label: 'JavaScript',
               value: 'javascript',
@@ -202,7 +234,16 @@ const onboarding: OnboardingConfig = {
               code: getSdkSetupSnippet(params),
             },
           ],
-          additionalInfo: params.isReplaySelected ? <TracePropagationMessage /> : null,
+        },
+        {
+          type: 'conditional',
+          condition: params.isReplaySelected,
+          content: [
+            {
+              type: 'custom',
+              content: <TracePropagationMessage />,
+            },
+          ],
         },
       ],
     },
@@ -214,12 +255,16 @@ const onboarding: OnboardingConfig = {
   verify: () => [
     {
       type: StepType.VERIFY,
-      description: t(
-        "This snippet contains an intentional error and can be used as a test to make sure that everything's working as expected."
-      ),
-      configurations: [
+      content: [
         {
-          code: [
+          type: 'text',
+          text: t(
+            "This snippet contains an intentional error and can be used as a test to make sure that everything's working as expected."
+          ),
+        },
+        {
+          type: 'code',
+          tabs: [
             {
               label: 'JavaScript',
               value: 'javascript',
@@ -340,7 +385,7 @@ const crashReportOnboarding: OnboardingConfig = {
 };
 
 const profilingOnboarding = getJavascriptProfilingOnboarding({
-  getInstallConfig,
+  installSnippetBlock,
   docsLink:
     'https://docs.sentry.io/platforms/javascript/guides/solid/profiling/browser-profiling/',
 });

--- a/static/app/gettingStartedDocs/javascript/solid.tsx
+++ b/static/app/gettingStartedDocs/javascript/solid.tsx
@@ -229,7 +229,6 @@ const onboarding: OnboardingConfig = {
           tabs: [
             {
               label: 'JavaScript',
-              value: 'javascript',
               language: 'javascript',
               code: getSdkSetupSnippet(params),
             },
@@ -267,7 +266,6 @@ const onboarding: OnboardingConfig = {
           tabs: [
             {
               label: 'JavaScript',
-              value: 'javascript',
               language: 'javascript',
               code: getVerifySnippet(),
             },

--- a/static/app/gettingStartedDocs/javascript/solidstart.tsx
+++ b/static/app/gettingStartedDocs/javascript/solidstart.tsx
@@ -4,6 +4,7 @@ import crashReportCallout from 'sentry/components/onboarding/gettingStartedDoc/f
 import widgetCallout from 'sentry/components/onboarding/gettingStartedDoc/feedback/widgetCallout';
 import TracePropagationMessage from 'sentry/components/onboarding/gettingStartedDoc/replay/tracePropagationMessage';
 import type {
+  ContentBlock,
   Docs,
   DocsParams,
   OnboardingConfig,
@@ -202,36 +203,31 @@ const getVerifySnippet = () => `
   Throw error
 </button>`;
 
-const getInstallConfig = () => [
-  {
-    language: 'bash',
-    code: [
-      {
-        label: 'npm',
-        value: 'npm',
-        language: 'bash',
-        code: 'npm install --save @sentry/solidstart',
-      },
-      {
-        label: 'yarn',
-        value: 'yarn',
-        language: 'bash',
-        code: 'yarn add @sentry/solidstart',
-      },
-      {
-        label: 'pnpm',
-        value: 'pnpm',
-        language: 'bash',
-        code: `pnpm add @sentry/solidstart`,
-      },
-    ],
-  },
-];
+const installSnippetBlock: ContentBlock = {
+  type: 'code',
+  tabs: [
+    {
+      label: 'npm',
+      language: 'bash',
+      code: 'npm install --save @sentry/solidstart',
+    },
+    {
+      label: 'yarn',
+      language: 'bash',
+      code: 'yarn add @sentry/solidstart',
+    },
+    {
+      label: 'pnpm',
+      language: 'bash',
+      code: `pnpm add @sentry/solidstart`,
+    },
+  ],
+};
 
 const onboarding: OnboardingConfig = {
   introduction: () =>
     tct(
-      'In this quick guide you’ll use [strong:npm], [strong:yarn] or [strong:pnpm] to set up:',
+      "In this quick guide you'll use [strong:npm], [strong:yarn] or [strong:pnpm] to set up:",
       {
         strong: <strong />,
       }
@@ -239,61 +235,79 @@ const onboarding: OnboardingConfig = {
   install: () => [
     {
       type: StepType.INSTALL,
-      description: tct(
-        'Add the Sentry SDK as a dependency using [code:npm], [code:yarn] or [code:pnpm]:',
+      content: [
         {
-          code: <code />,
-        }
-      ),
-      configurations: getInstallConfig(),
+          type: 'text',
+          text: tct(
+            'Add the Sentry SDK as a dependency using [code:npm], [code:yarn] or [code:pnpm]:',
+            {
+              code: <code />,
+            }
+          ),
+        },
+        installSnippetBlock,
+      ],
     },
   ],
   configure: (params: Params) => [
     {
       type: StepType.CONFIGURE,
-      description: t(
-        "Initialize Sentry as early as possible in your application's lifecycle."
-      ),
-      configurations: [
+      content: [
         {
-          description: tct(
+          type: 'text',
+          text: t(
+            "Initialize Sentry as early as possible in your application's lifecycle."
+          ),
+        },
+        {
+          type: 'text',
+          text: tct(
             'For the client, initialize the Sentry SDK in your [code:src/entry-client.tsx] file',
             {code: <code />}
           ),
-          code: [
+        },
+        {
+          type: 'code',
+          tabs: [
             {
               label: 'TypeScript',
-              // value and language are in JS to get consistent syntax highlighting
+              // language are in JS to get consistent syntax highlighting
               // we aren't using any Typescript specific code in these snippets but
               // want a typescript ending.
-              value: 'javascript',
               language: 'javascript',
               code: getSdkClientSetupSnippet(params),
             },
           ],
         },
         {
-          description: tct(
+          type: 'text',
+          text: tct(
             'For the server, create an instrument file [code:instrument.server.mjs], initialize the Sentry SDK and deploy it alongside your application. For example by placing it in the [code:public] folder.',
             {code: <code />}
           ),
-          code: [
+        },
+        {
+          type: 'code',
+          tabs: [
             {
               label: 'JavaScript',
-              value: 'javascript',
               language: 'javascript',
               code: getSdkServerSetupSnippet(params),
             },
           ],
-          additionalInfo: tct(
+        },
+        {
+          type: 'text',
+          text: tct(
             'Note: Placing [code:instrument.server.mjs] inside the [code:public] folder makes it accessible to the outside world. Consider blocking requests to this file or finding a more appropriate location which your backend can access.',
             {code: <code />}
           ),
         },
-        ...(params.isPerformanceSelected
+        ...((params.isPerformanceSelected
           ? [
               {
-                description: tct(
+                type: 'text',
+                text: tct(
                   'Complete the setup by adding the Sentry [solidStartMiddlewareLink: middleware] to your [code:src/middleware.ts] file',
                   {
                     code: <code />,
@@ -302,33 +316,36 @@ const onboarding: OnboardingConfig = {
                     ),
                   }
                 ),
-                code: [
+              },
+              {
+                type: 'code',
+                tabs: [
                   {
                     label: 'TypeScript',
-                    // value and language are in JS to get consistent syntax highlighting
-                    // we aren't using any Typescript specific code in these snippets but
-                    // want a typescript ending.
-                    value: 'javascript',
                     language: 'javascript',
                     code: getSdkMiddlewareSetup(),
                   },
                 ],
               },
               {
-                description: tct('And including it in the [code:app.config.ts] file', {
+                type: 'text',
+                text: tct('And including it in the [code:app.config.ts] file', {
                   code: <code />,
                 }),
-                code: [
+              },
+              {
+                type: 'code',
+                tabs: [
                   {
                     label: 'TypeScript',
-                    value: 'javascript',
                     language: 'javascript',
                     code: getSdkMiddlewareLinkSetup(),
                   },
                 ],
               },
               {
-                description: tct(
+                type: 'text',
+                text: tct(
                   "If you're using [solidRouterLink:Solid Router], wrap your [code:Router] with [code:withSentryRouterRouting]. This creates a higher order component, which will enable Sentry to collect navigation spans.",
                   {
                     code: <code />,
@@ -337,28 +354,33 @@ const onboarding: OnboardingConfig = {
                     ),
                   }
                 ),
-                code: [
+              },
+              {
+                type: 'code',
+                tabs: [
                   {
                     label: 'TypeScript',
-                    value: 'typescript',
                     language: 'typescript',
                     code: getSdkRouterWrappingSetup(),
                   },
                 ],
               },
             ]
-          : []),
+          : []) as ContentBlock[]),
         {
-          description: tct(
+          type: 'text',
+          text: tct(
             'Add an [code:--import] flag to the [code:NODE_OPTIONS] environment variable wherever you run your application to import [code:public/instrument.server.mjs]. For example, update your [code:scripts] entry in [code:package.json]',
             {
               code: <code />,
             }
           ),
-          code: [
+        },
+        {
+          type: 'code',
+          tabs: [
             {
               label: 'JSON',
-              value: 'json',
               language: 'json',
               code: getSdkRun(),
             },
@@ -381,12 +403,16 @@ const onboarding: OnboardingConfig = {
   verify: () => [
     {
       type: StepType.VERIFY,
-      description: t(
-        "This snippet contains an intentional error and can be used as a test to make sure that everything's working as expected."
-      ),
-      configurations: [
+      content: [
         {
-          code: [
+          type: 'text',
+          text: t(
+            "This snippet contains an intentional error and can be used as a test to make sure that everything's working as expected."
+          ),
+        },
+        {
+          type: 'code',
+          tabs: [
             {
               label: 'JavaScript',
               value: 'javascript',
@@ -412,13 +438,18 @@ const replayOnboarding: OnboardingConfig = {
   install: () => [
     {
       type: StepType.INSTALL,
-      description: tct(
-        'You need a minimum version 8.9.1 of [code:@sentry/solid] in order to use Session Replay. You do not need to install any additional packages.',
+      content: [
         {
-          code: <code />,
-        }
-      ),
-      configurations: getInstallConfig(),
+          type: 'text',
+          text: tct(
+            'You need a minimum version 8.9.1 of [code:@sentry/solid] in order to use Session Replay. You do not need to install any additional packages.',
+            {
+              code: <code />,
+            }
+          ),
+        },
+        installSnippetBlock,
+      ],
     },
   ],
   configure: (params: Params) => [
@@ -450,13 +481,18 @@ const feedbackOnboarding: OnboardingConfig = {
   install: () => [
     {
       type: StepType.INSTALL,
-      description: tct(
-        'For the User Feedback integration to work, you must have the Sentry browser SDK package, or an equivalent framework SDK (e.g. [code:@sentry/solid]) installed, minimum version 7.85.0.',
+      content: [
         {
-          code: <code />,
-        }
-      ),
-      configurations: getInstallConfig(),
+          type: 'text',
+          text: tct(
+            'For the User Feedback integration to work, you must have the Sentry browser SDK package, or an equivalent framework SDK (e.g. [code:@sentry/solid]) installed, minimum version 7.85.0.',
+            {
+              code: <code />,
+            }
+          ),
+        },
+        installSnippetBlock,
+      ],
     },
   ],
   configure: (params: Params) => [
@@ -508,7 +544,7 @@ const crashReportOnboarding: OnboardingConfig = {
 };
 
 const profilingOnboarding = getJavascriptProfilingOnboarding({
-  getInstallConfig,
+  installSnippetBlock,
   docsLink:
     'https://docs.sentry.io/platforms/javascript/guides/solidstart/profiling/browser-profiling/',
 });

--- a/static/app/gettingStartedDocs/javascript/solidstart.tsx
+++ b/static/app/gettingStartedDocs/javascript/solidstart.tsx
@@ -415,7 +415,6 @@ const onboarding: OnboardingConfig = {
           tabs: [
             {
               label: 'JavaScript',
-              value: 'javascript',
               language: 'javascript',
               code: getVerifySnippet(),
             },

--- a/static/app/gettingStartedDocs/javascript/svelte.tsx
+++ b/static/app/gettingStartedDocs/javascript/svelte.tsx
@@ -189,13 +189,11 @@ const onboarding: OnboardingConfig = {
           tabs: [
             {
               label: 'Svelte v5',
-              value: 'svelte v5',
               language: 'javascript',
               code: getSdkSetupSnippet(params, true),
             },
             {
               label: 'Svelte v3/v4',
-              value: 'svelte v3/v4',
               language: 'javascript',
               code: getSdkSetupSnippet(params, false),
             },
@@ -223,13 +221,11 @@ const onboarding: OnboardingConfig = {
           tabs: [
             {
               label: 'Svelte v5',
-              value: 'svelte v5',
               language: 'html',
               code: getVerifySnippet(true),
             },
             {
               label: 'Svelte v3/v4',
-              value: 'svelte v3/v4',
               language: 'html',
               code: getVerifySnippet(false),
             },

--- a/static/app/gettingStartedDocs/javascript/svelte.tsx
+++ b/static/app/gettingStartedDocs/javascript/svelte.tsx
@@ -3,6 +3,7 @@ import crashReportCallout from 'sentry/components/onboarding/gettingStartedDoc/f
 import widgetCallout from 'sentry/components/onboarding/gettingStartedDoc/feedback/widgetCallout';
 import TracePropagationMessage from 'sentry/components/onboarding/gettingStartedDoc/replay/tracePropagationMessage';
 import type {
+  ContentBlock,
   Docs,
   DocsParams,
   OnboardingConfig,
@@ -128,31 +129,26 @@ const getVerifySnippet = (isVersion5: boolean) =>
   Break the world
 </button>`;
 
-const getInstallConfig = () => [
-  {
-    language: 'bash',
-    code: [
-      {
-        label: 'npm',
-        value: 'npm',
-        language: 'bash',
-        code: 'npm install --save @sentry/svelte',
-      },
-      {
-        label: 'yarn',
-        value: 'yarn',
-        language: 'bash',
-        code: 'yarn add @sentry/svelte',
-      },
-      {
-        label: 'pnpm',
-        value: 'pnpm',
-        language: 'bash',
-        code: 'pnpm add @sentry/svelte',
-      },
-    ],
-  },
-];
+const installSnippetBlock: ContentBlock = {
+  type: 'code',
+  tabs: [
+    {
+      label: 'npm',
+      language: 'bash',
+      code: 'npm install --save @sentry/svelte',
+    },
+    {
+      label: 'yarn',
+      language: 'bash',
+      code: 'yarn add @sentry/svelte',
+    },
+    {
+      label: 'pnpm',
+      language: 'bash',
+      code: 'pnpm add @sentry/svelte',
+    },
+  ],
+};
 
 const onboarding: OnboardingConfig = {
   introduction: () =>
@@ -165,23 +161,32 @@ const onboarding: OnboardingConfig = {
   install: () => [
     {
       type: StepType.INSTALL,
-      description: tct(
-        'Add the Sentry SDK as a dependency using [code:npm], [code:yarn], or [code:pnpm]:',
-        {code: <code />}
-      ),
-      configurations: getInstallConfig(),
+      content: [
+        {
+          type: 'text',
+          text: tct(
+            'Add the Sentry SDK as a dependency using [code:npm], [code:yarn], or [code:pnpm]:',
+            {code: <code />}
+          ),
+        },
+        installSnippetBlock,
+      ],
     },
   ],
   configure: (params: Params) => [
     {
       type: StepType.CONFIGURE,
-      description: tct(
-        "Initialize Sentry as early as possible in your application's lifecycle, usually your Svelte app's entry point ([code:main.ts/js]):",
-        {code: <code />}
-      ),
-      configurations: [
+      content: [
         {
-          code: [
+          type: 'text',
+          text: tct(
+            "Initialize Sentry as early as possible in your application's lifecycle, usually your Svelte app's entry point ([code:main.ts/js]):",
+            {code: <code />}
+          ),
+        },
+        {
+          type: 'code',
+          tabs: [
             {
               label: 'Svelte v5',
               value: 'svelte v5',
@@ -206,12 +211,16 @@ const onboarding: OnboardingConfig = {
   verify: () => [
     {
       type: StepType.VERIFY,
-      description: t(
-        "This snippet contains an intentional error and can be used as a test to make sure that everything's working as expected."
-      ),
-      configurations: [
+      content: [
         {
-          code: [
+          type: 'text',
+          text: t(
+            "This snippet contains an intentional error and can be used as a test to make sure that everything's working as expected."
+          ),
+        },
+        {
+          type: 'code',
+          tabs: [
             {
               label: 'Svelte v5',
               value: 'svelte v5',
@@ -245,13 +254,18 @@ const replayOnboarding: OnboardingConfig = {
   install: () => [
     {
       type: StepType.INSTALL,
-      description: tct(
-        'You need a minimum version 7.27.0 of [code:@sentry/svelte] in order to use Session Replay. You do not need to install any additional packages.',
+      content: [
         {
-          code: <code />,
-        }
-      ),
-      configurations: getInstallConfig(),
+          type: 'text',
+          text: tct(
+            'You need a minimum version 7.27.0 of [code:@sentry/svelte] in order to use Session Replay. You do not need to install any additional packages.',
+            {
+              code: <code />,
+            }
+          ),
+        },
+        installSnippetBlock,
+      ],
     },
   ],
   configure: (params: Params) => [
@@ -289,13 +303,18 @@ const feedbackOnboarding: OnboardingConfig = {
   install: () => [
     {
       type: StepType.INSTALL,
-      description: tct(
-        'For the User Feedback integration to work, you must have the Sentry browser SDK package, or an equivalent framework SDK (e.g. [code:@sentry/svelte]) installed, minimum version 7.85.0.',
+      content: [
         {
-          code: <code />,
-        }
-      ),
-      configurations: getInstallConfig(),
+          type: 'text',
+          text: tct(
+            'For the User Feedback integration to work, you must have the Sentry browser SDK package, or an equivalent framework SDK (e.g. [code:@sentry/svelte]) installed, minimum version 7.85.0.',
+            {
+              code: <code />,
+            }
+          ),
+        },
+        installSnippetBlock,
+      ],
     },
   ],
   configure: (params: Params) => [
@@ -353,7 +372,7 @@ const crashReportOnboarding: OnboardingConfig = {
 };
 
 const profilingOnboarding = getJavascriptProfilingOnboarding({
-  getInstallConfig,
+  installSnippetBlock,
   docsLink:
     'https://docs.sentry.io/platforms/javascript/guides/svelte/profiling/browser-profiling/',
 });

--- a/static/app/gettingStartedDocs/javascript/sveltekit.tsx
+++ b/static/app/gettingStartedDocs/javascript/sveltekit.tsx
@@ -1,11 +1,10 @@
-import {Fragment} from 'react';
-
 import {ExternalLink} from 'sentry/components/core/link';
 import {CopyDsnField} from 'sentry/components/onboarding/gettingStartedDoc/copyDsnField';
 import crashReportCallout from 'sentry/components/onboarding/gettingStartedDoc/feedback/crashReportCallout';
 import widgetCallout from 'sentry/components/onboarding/gettingStartedDoc/feedback/widgetCallout';
 import TracePropagationMessage from 'sentry/components/onboarding/gettingStartedDoc/replay/tracePropagationMessage';
 import type {
+  ContentBlock,
   Docs,
   DocsParams,
   OnboardingConfig,
@@ -30,13 +29,17 @@ import {getNodeAgentMonitoringOnboarding} from 'sentry/utils/gettingStartedDocs/
 
 type Params = DocsParams;
 
-const getConfigStep = ({isSelfHosted, organization, projectSlug}: Params) => {
+const getConfigStep = ({
+  isSelfHosted,
+  organization,
+  projectSlug,
+}: Params): ContentBlock[] => {
   const urlParam = isSelfHosted ? '' : '--saas';
 
   return [
     {
-      type: StepType.INSTALL,
-      description: tct(
+      type: 'text',
+      text: tct(
         'Configure your app automatically by running the [wizardLink:Sentry wizard] in the root of your project.',
         {
           wizardLink: (
@@ -44,45 +47,41 @@ const getConfigStep = ({isSelfHosted, organization, projectSlug}: Params) => {
           ),
         }
       ),
-      configurations: [
-        {
-          language: 'bash',
-          code: `npx @sentry/wizard@latest -i sveltekit ${urlParam}  --org ${organization.slug} --project ${projectSlug}`,
-        },
-      ],
+    },
+    {
+      type: 'code',
+      language: 'bash',
+      code: `npx @sentry/wizard@latest -i sveltekit ${urlParam}  --org ${organization.slug} --project ${projectSlug}`,
     },
   ];
 };
-
-const getInstallConfig = (params: Params) => [
-  {
-    type: StepType.INSTALL,
-    configurations: getConfigStep(params),
-  },
-];
 
 const onboarding: OnboardingConfig = {
   install: (params: Params) => [
     {
       title: t('Automatic Configuration (Recommended)'),
-      configurations: getConfigStep(params),
+      content: getConfigStep(params),
     },
   ],
   configure: params => [
     {
       collapsible: true,
       title: t('Manual Configuration'),
-      description: tct(
-        'Alternatively, you can also set up the SDK manually, by following the [manualSetupLink:manual setup docs].',
+      content: [
         {
-          manualSetupLink: (
-            <ExternalLink href="https://docs.sentry.io/platforms/javascript/guides/sveltekit/manual-setup/" />
+          type: 'text',
+          text: tct(
+            'Alternatively, you can also set up the SDK manually, by following the [manualSetupLink:manual setup docs].',
+            {
+              manualSetupLink: (
+                <ExternalLink href="https://docs.sentry.io/platforms/javascript/guides/sveltekit/manual-setup/" />
+              ),
+            }
           ),
-        }
-      ),
-      configurations: [
+        },
         {
-          description: <CopyDsnField params={params} />,
+          type: 'custom',
+          content: <CopyDsnField params={params} />,
         },
       ],
     },
@@ -90,26 +89,25 @@ const onboarding: OnboardingConfig = {
   verify: () => [
     {
       type: StepType.VERIFY,
-      description: (
-        <Fragment>
-          <p>
-            {tct(
-              'Start your development server and visit [code:/sentry-example-page] if you have set it up. Click the button to trigger a test error.',
-              {
-                code: <code />,
-              }
-            )}
-          </p>
-          <p>
-            {t(
-              'Or, trigger a sample error by calling a function that does not exist somewhere in your application.'
-            )}
-          </p>
-        </Fragment>
-      ),
-      configurations: [
+      content: [
         {
-          code: [
+          type: 'text',
+          text: tct(
+            'Start your development server and visit [code:/sentry-example-page] if you have set it up. Click the button to trigger a test error.',
+            {
+              code: <code />,
+            }
+          ),
+        },
+        {
+          type: 'text',
+          text: t(
+            'Or, trigger a sample error by calling a function that does not exist somewhere in your application.'
+          ),
+        },
+        {
+          type: 'code',
+          tabs: [
             {
               label: 'Javascript',
               value: 'javascript',
@@ -118,16 +116,24 @@ const onboarding: OnboardingConfig = {
             },
           ],
         },
+        {
+          type: 'text',
+          text: t(
+            'If you see an issue in your Sentry Issues, you have successfully set up Sentry.'
+          ),
+        },
       ],
-      additionalInfo: t(
-        'If you see an issue in your Sentry Issues, you have successfully set up Sentry.'
-      ),
     },
   ],
 };
 
 const replayOnboarding: OnboardingConfig = {
-  install: (params: Params) => getInstallConfig(params),
+  install: (params: Params) => [
+    {
+      type: StepType.INSTALL,
+      content: getConfigStep(params),
+    },
+  ],
   configure: (params: Params) => [
     {
       type: StepType.CONFIGURE,
@@ -162,13 +168,18 @@ const feedbackOnboarding: OnboardingConfig = {
   install: (params: Params) => [
     {
       type: StepType.INSTALL,
-      description: tct(
-        'For the User Feedback integration to work, you must have the Sentry browser SDK package, or an equivalent framework SDK (e.g. [code:@sentry/sveltekit]) installed, minimum version 7.85.0.',
+      content: [
         {
-          code: <code />,
-        }
-      ),
-      configurations: getInstallConfig(params),
+          type: 'text',
+          text: tct(
+            'For the User Feedback integration to work, you must have the Sentry browser SDK package, or an equivalent framework SDK (e.g. [code:@sentry/sveltekit]) installed, minimum version 7.85.0.',
+            {
+              code: <code />,
+            }
+          ),
+        },
+        ...getConfigStep(params),
+      ],
     },
   ],
   configure: (params: Params) => [

--- a/static/app/gettingStartedDocs/javascript/sveltekit.tsx
+++ b/static/app/gettingStartedDocs/javascript/sveltekit.tsx
@@ -110,7 +110,6 @@ const onboarding: OnboardingConfig = {
           tabs: [
             {
               label: 'Javascript',
-              value: 'javascript',
               language: 'javascript',
               code: `myUndefinedFunction();`,
             },

--- a/static/app/gettingStartedDocs/javascript/tanstackstart-react.tsx
+++ b/static/app/gettingStartedDocs/javascript/tanstackstart-react.tsx
@@ -1,5 +1,3 @@
-import {Fragment} from 'react';
-
 import type {
   Docs,
   DocsParams,
@@ -12,61 +10,65 @@ import {getNodeAgentMonitoringOnboarding} from 'sentry/utils/gettingStartedDocs/
 
 type Params = DocsParams;
 
-const getInstallConfig = () => [
-  {
-    language: 'bash',
-    code: [
-      {
-        label: 'npm',
-        value: 'npm',
-        language: 'bash',
-        code: 'npm install --save @sentry/tanstackstart-react',
-      },
-      {
-        label: 'yarn',
-        value: 'yarn',
-        language: 'bash',
-        code: 'yarn add @sentry/tanstackstart-react',
-      },
-      {
-        label: 'pnpm',
-        value: 'pnpm',
-        language: 'bash',
-        code: 'pnpm add @sentry/tanstackstart-react',
-      },
-    ],
-  },
-];
-
 const onboarding: OnboardingConfig = {
   introduction: () =>
     t("In this guide you'll set up the Sentry TanStack Start React SDK"),
   install: () => [
     {
       type: StepType.INSTALL,
-      description: tct(
-        'Add the Sentry TanStack Start SDK as a dependency using [code:npm], [code:yarn] or [code:pnpm]:',
-        {code: <code />}
-      ),
-      configurations: getInstallConfig(),
+      content: [
+        {
+          type: 'text',
+          text: tct(
+            'Add the Sentry TanStack Start SDK as a dependency using [code:npm], [code:yarn] or [code:pnpm]:',
+            {code: <code />}
+          ),
+        },
+        {
+          type: 'code',
+          tabs: [
+            {
+              label: 'npm',
+              language: 'bash',
+              code: 'npm install --save @sentry/tanstackstart-react',
+            },
+            {
+              label: 'yarn',
+              language: 'bash',
+              code: 'yarn add @sentry/tanstackstart-react',
+            },
+            {
+              label: 'pnpm',
+              language: 'bash',
+              code: 'pnpm add @sentry/tanstackstart-react',
+            },
+          ],
+        },
+      ],
     },
   ],
   configure: (params: Params) => [
     {
       title: t('Set up the SDK'),
-      description: t(
-        'In the following steps we will set up the SDK and instrument various parts of your application.'
-      ),
-      configurations: [
+      content: [
         {
-          description: tct(
+          type: 'text',
+          text: t(
+            'In the following steps we will set up the SDK and instrument various parts of your application.'
+          ),
+        },
+        {
+          type: 'text',
+          text: tct(
             "First, extend your app's default TanStack Start configuration by adding [code:wrapVinxiConfigWithSentry] to your [code:app.config.ts] file:",
             {code: <code />}
           ),
-          code: [
+        },
+        {
+          type: 'code',
+          tabs: [
             {
               label: 'TypeScript',
-              value: 'typescript',
               language: 'typescript',
               filename: 'app.config.ts',
               code: `import { defineConfig } from "@tanstack/react-start/config";
@@ -90,11 +92,15 @@ export default wrapVinxiConfigWithSentry(config, {
           ],
         },
         {
-          description: tct(
+          type: 'text',
+          text: tct(
             'In future versions of this SDK, setting the [code:SENTRY_AUTH_TOKEN] environment variable during your build will upload sourcemaps for you to see unminified errors in Sentry.',
             {code: <code />}
           ),
-          code: [
+        },
+        {
+          type: 'code',
+          tabs: [
             {
               value: 'bash',
               language: 'bash',
@@ -104,13 +110,17 @@ export default wrapVinxiConfigWithSentry(config, {
           ],
         },
         {
-          description: tct(
+          type: 'text',
+          text: tct(
             'Add the following initialization code to your [code:app/client.tsx] file to initialize Sentry on the client:',
             {code: <code />}
           ),
-          code: [
+        },
+        {
+          type: 'code',
+          tabs: [
             {
-              label: 'tsx',
+              label: 'TypeScript',
               value: 'tsx',
               language: 'tsx',
               filename: 'app/client.tsx',
@@ -168,13 +178,17 @@ hydrateRoot(document, <StartClient router={router} />);`,
           ],
         },
         {
-          description: tct(
+          type: 'text',
+          text: tct(
             'Add the following initialization code anywhere in your [code:app/ssr.tsx] file to initialize Sentry on the server:',
             {code: <code />}
           ),
-          code: [
+        },
+        {
+          type: 'code',
+          tabs: [
             {
-              label: 'tsx',
+              label: 'TypeScript',
               value: 'tsx',
               language: 'tsx',
               filename: 'app/ssr.tsx',
@@ -202,13 +216,17 @@ Sentry.init({
           ],
         },
         {
-          description: tct(
+          type: 'text',
+          text: tct(
             "Wrap TanStack Start's [code:createRootRoute] function using [code:wrapCreateRootRouteWithSentry] to apply tracing to Server-Side Rendering (SSR):",
             {code: <code />}
           ),
-          code: [
+        },
+        {
+          type: 'code',
+          tabs: [
             {
-              label: 'tsx',
+              label: 'TypeScript',
               value: 'tsx',
               language: 'tsx',
               filename: 'app/routes/__root.tsx',
@@ -223,13 +241,17 @@ export const Route = wrapCreateRootRouteWithSentry(createRootRoute)({
           ],
         },
         {
-          description: tct(
+          type: 'text',
+          text: tct(
             "Wrap TanStack Start's [code:defaultStreamHandler] function using [code:wrapStreamHandlerWithSentry] to instrument requests to your server:",
             {code: <code />}
           ),
-          code: [
+        },
+        {
+          type: 'code',
+          tabs: [
             {
-              label: 'tsx',
+              label: 'TypeScript',
               value: 'tsx',
               language: 'tsx',
               filename: 'app/ssr.tsx',
@@ -249,11 +271,15 @@ export default createStartHandler({
           ],
         },
         {
-          description: tct(
+          type: 'text',
+          text: tct(
             "Add the [code:sentryGlobalServerMiddlewareHandler] to your global middlewares to instrument your server function invocations. If you haven't done so, create a [code:app/global-middleware.ts] file.",
             {code: <code />}
           ),
-          code: [
+        },
+        {
+          type: 'code',
+          tabs: [
             {
               label: 'TypeScript',
               value: 'typescript',
@@ -274,18 +300,23 @@ registerGlobalMiddleware({
           ],
         },
         {
-          description: t(
+          type: 'text',
+          text: t(
             'The Sentry SDK cannot capture errors that you manually caught yourself with error boundaries.'
           ),
         },
         {
-          description: tct(
+          type: 'text',
+          text: tct(
             'If you have React error boundaries in your app and you want to report errors that these boundaries catch to Sentry, apply the [code:withErrorBoundary] wrapper to your [code:ErrorBoundary]:',
             {code: <code />}
           ),
-          code: [
+        },
+        {
+          type: 'code',
+          tabs: [
             {
-              label: 'tsx',
+              label: 'TypeScript',
               value: 'tsx',
               language: 'tsx',
               code: `import React from "react";
@@ -305,13 +336,17 @@ export const MySentryWrappedErrorBoundary = withErrorBoundary(
           ],
         },
         {
-          description: tct(
+          type: 'text',
+          text: tct(
             'If you defined [code:errorComponents] in your Code-Based TanStack Router routes, capture the [code:error] argument with [code:captureException] inside a [code:useEffect] hook:',
             {code: <code />}
           ),
-          code: [
+        },
+        {
+          type: 'code',
+          tabs: [
             {
-              label: 'tsx',
+              label: 'TypeScript',
               value: 'tsx',
               language: 'tsx',
               code: `import { createRoute } from "@tanstack/react-router";
@@ -337,18 +372,24 @@ const route = createRoute({
   verify: () => [
     {
       type: StepType.VERIFY,
-      description: t(
-        "Let's test your setup and confirm that Sentry is working correctly and sending data to your Sentry project."
-      ),
-      configurations: [
+      content: [
         {
-          description: t(
+          type: 'text',
+          text: t(
+            "Let's test your setup and confirm that Sentry is working correctly and sending data to your Sentry project."
+          ),
+        },
+        {
+          type: 'text',
+          text: t(
             'To verify that Sentry captures errors and creates issues in your Sentry project, add a test button to an existing page or create a new one:'
           ),
-          code: [
+        },
+        {
+          type: 'code',
+          tabs: [
             {
-              label: 'tsx',
-              value: 'tsx',
+              label: 'TypeScript',
               language: 'tsx',
               code: `<button
   type="button"
@@ -363,14 +404,17 @@ const route = createRoute({
           ],
         },
         {
-          description: tct(
+          type: 'text',
+          text: tct(
             'To test tracing, create a test API route like /api/sentry-example-api:',
             {code: <code />}
           ),
-          code: [
+        },
+        {
+          type: 'code',
+          tabs: [
             {
               label: 'TypeScript',
-              value: 'typescript',
               language: 'typescript',
               filename: 'app/routes/api/sentry-example-api.ts',
               code: `import { json } from "@tanstack/react-start";
@@ -387,14 +431,17 @@ export const APIRoute = createAPIFileRoute("/api/sentry-example-api")({
           ],
         },
         {
-          description: tct(
+          type: 'text',
+          text: tct(
             "Next, update your test button to call this route and throw an error if the response isn't [code:ok]:",
             {code: <code />}
           ),
-          code: [
+        },
+        {
+          type: 'code',
+          tabs: [
             {
-              label: 'tsx',
-              value: 'tsx',
+              label: 'TypeScript',
               language: 'tsx',
               code: `<button
   type="button"
@@ -417,20 +464,26 @@ export const APIRoute = createAPIFileRoute("/api/sentry-example-api")({
 </button>`,
             },
           ],
-          additionalInfo: (
-            <Fragment>
-              <p>
-                Open the page in a browser and click the button to trigger two errors:
-              </p>
-              <ul>
-                <li>a frontend error</li>
-                <li>an error within the API route</li>
-              </ul>
-              <p>
-                Additionally, this starts a performance trace to measure the time it takes
-                for the API request to complete.
-              </p>
-            </Fragment>
+        },
+        {
+          type: 'text',
+          text: t(
+            'Open the page in a browser and click the button to trigger two errors:'
+          ),
+        },
+        {
+          type: 'custom',
+          content: (
+            <ul>
+              <li>{t('a frontend error')}</li>
+              <li>{t('an error within the API route')}</li>
+            </ul>
+          ),
+        },
+        {
+          type: 'text',
+          text: t(
+            'Additionally, this starts a performance trace to measure the time it takes for the API request to complete.'
           ),
         },
       ],

--- a/static/app/gettingStartedDocs/javascript/tanstackstart-react.tsx
+++ b/static/app/gettingStartedDocs/javascript/tanstackstart-react.tsx
@@ -102,7 +102,6 @@ export default wrapVinxiConfigWithSentry(config, {
           type: 'code',
           tabs: [
             {
-              value: 'bash',
               language: 'bash',
               label: 'Bash',
               code: `SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___`,
@@ -121,7 +120,6 @@ export default wrapVinxiConfigWithSentry(config, {
           tabs: [
             {
               label: 'TypeScript',
-              value: 'tsx',
               language: 'tsx',
               filename: 'app/client.tsx',
               code: `import { hydrateRoot } from "react-dom/client";
@@ -189,7 +187,6 @@ hydrateRoot(document, <StartClient router={router} />);`,
           tabs: [
             {
               label: 'TypeScript',
-              value: 'tsx',
               language: 'tsx',
               filename: 'app/ssr.tsx',
               code: `import * as Sentry from "@sentry/tanstackstart-react";
@@ -227,7 +224,6 @@ Sentry.init({
           tabs: [
             {
               label: 'TypeScript',
-              value: 'tsx',
               language: 'tsx',
               filename: 'app/routes/__root.tsx',
               code: `import type { ReactNode } from "react";
@@ -252,7 +248,6 @@ export const Route = wrapCreateRootRouteWithSentry(createRootRoute)({
           tabs: [
             {
               label: 'TypeScript',
-              value: 'tsx',
               language: 'tsx',
               filename: 'app/ssr.tsx',
               code: `import {
@@ -282,7 +277,6 @@ export default createStartHandler({
           tabs: [
             {
               label: 'TypeScript',
-              value: 'typescript',
               language: 'typescript',
               filename: 'app/global-middleware.ts',
               code: `import {
@@ -317,7 +311,6 @@ registerGlobalMiddleware({
           tabs: [
             {
               label: 'TypeScript',
-              value: 'tsx',
               language: 'tsx',
               code: `import React from "react";
 import * as Sentry from "@sentry/tanstackstart-react";
@@ -347,7 +340,6 @@ export const MySentryWrappedErrorBoundary = withErrorBoundary(
           tabs: [
             {
               label: 'TypeScript',
-              value: 'tsx',
               language: 'tsx',
               code: `import { createRoute } from "@tanstack/react-router";
 import * as Sentry from "@sentry/tanstackstart-react";

--- a/static/app/gettingStartedDocs/javascript/vue.tsx
+++ b/static/app/gettingStartedDocs/javascript/vue.tsx
@@ -3,6 +3,7 @@ import crashReportCallout from 'sentry/components/onboarding/gettingStartedDoc/f
 import widgetCallout from 'sentry/components/onboarding/gettingStartedDoc/feedback/widgetCallout';
 import TracePropagationMessage from 'sentry/components/onboarding/gettingStartedDoc/replay/tracePropagationMessage';
 import type {
+  ContentBlock,
   Docs,
   DocsParams,
   OnboardingConfig,
@@ -117,31 +118,26 @@ const getSentryInitLayout = (params: Params, siblingOption: string): string => {
   });`;
 };
 
-const getInstallConfig = () => [
-  {
-    language: 'bash',
-    code: [
-      {
-        label: 'npm',
-        value: 'npm',
-        language: 'bash',
-        code: `npm install --save @sentry/vue`,
-      },
-      {
-        label: 'yarn',
-        value: 'yarn',
-        language: 'bash',
-        code: `yarn add @sentry/vue`,
-      },
-      {
-        label: 'pnpm',
-        value: 'pnpm',
-        language: 'bash',
-        code: `pnpm add @sentry/vue`,
-      },
-    ],
-  },
-];
+const installSnippetBlock: ContentBlock = {
+  type: 'code',
+  tabs: [
+    {
+      label: 'npm',
+      language: 'bash',
+      code: 'npm install --save @sentry/vue',
+    },
+    {
+      label: 'yarn',
+      language: 'bash',
+      code: 'yarn add @sentry/vue',
+    },
+    {
+      label: 'pnpm',
+      language: 'bash',
+      code: 'pnpm add @sentry/vue',
+    },
+  ],
+};
 
 const onboarding: OnboardingConfig<PlatformOptions> = {
   introduction: () =>
@@ -154,21 +150,40 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
   install: () => [
     {
       type: StepType.INSTALL,
-      description: tct(
-        'Add the Sentry SDK as a dependency using [code:npm], [code:yarn], or [code:pnpm]:',
-        {code: <code />}
-      ),
-      configurations: getInstallConfig(),
+      content: [
+        {
+          type: 'text',
+          text: tct(
+            'Add the Sentry SDK as a dependency using [code:npm], [code:yarn], or [code:pnpm]:',
+            {code: <code />}
+          ),
+        },
+        installSnippetBlock,
+      ],
     },
   ],
   configure: params => [
     {
       type: StepType.CONFIGURE,
-      description: tct(
-        "Initialize Sentry as early as possible in your application's lifecycle, usually your Vue app's entry point ([code:main.ts/js]).",
-        {code: <code />}
-      ),
-      configurations: getSetupConfiguration(params),
+      content: [
+        {
+          type: 'text',
+          text: tct(
+            "Initialize Sentry as early as possible in your application's lifecycle, usually your Vue app's entry point ([code:main.ts/js]).",
+            {code: <code />}
+          ),
+        },
+        {
+          type: 'code',
+          tabs: [
+            {
+              label: 'JavaScript',
+              language: 'javascript',
+              code: getSetupConfiguration(params)[0]?.code || '',
+            },
+          ],
+        },
+      ],
     },
     getUploadSourceMapsStep({
       guideLink: 'https://docs.sentry.io/platforms/javascript/guides/vue/sourcemaps/',
@@ -178,13 +193,22 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
   verify: () => [
     {
       type: StepType.VERIFY,
-      description: t(
-        "This snippet contains an intentional error and can be used as a test to make sure that everything's working as expected."
-      ),
-      configurations: [
+      content: [
         {
-          language: 'javascript',
-          code: `myUndefinedFunction();`,
+          type: 'text',
+          text: t(
+            "This snippet contains an intentional error and can be used as a test to make sure that everything's working as expected."
+          ),
+        },
+        {
+          type: 'code',
+          tabs: [
+            {
+              label: 'JavaScript',
+              language: 'javascript',
+              code: `myUndefinedFunction();`,
+            },
+          ],
         },
       ],
     },
@@ -270,13 +294,18 @@ const replayOnboarding: OnboardingConfig<PlatformOptions> = {
   install: () => [
     {
       type: StepType.INSTALL,
-      description: tct(
-        'You need a minimum version 7.27.0 of [code:@sentry/vue] in order to use Session Replay. You do not need to install any additional packages.',
+      content: [
         {
-          code: <code />,
-        }
-      ),
-      configurations: getInstallConfig(),
+          type: 'text',
+          text: tct(
+            'You need a minimum version 7.27.0 of [code:@sentry/vue] in order to use Session Replay. You do not need to install any additional packages.',
+            {
+              code: <code />,
+            }
+          ),
+        },
+        installSnippetBlock,
+      ],
     },
   ],
   configure: params => [
@@ -297,13 +326,18 @@ const feedbackOnboarding: OnboardingConfig<PlatformOptions> = {
   install: () => [
     {
       type: StepType.INSTALL,
-      description: tct(
-        'For the User Feedback integration to work, you must have the Sentry browser SDK package, or an equivalent framework SDK (e.g. [code:@sentry/vue]) installed, minimum version 7.85.0.',
+      content: [
         {
-          code: <code />,
-        }
-      ),
-      configurations: getInstallConfig(),
+          type: 'text',
+          text: tct(
+            'For the User Feedback integration to work, you must have the Sentry browser SDK package, or an equivalent framework SDK (e.g. [code:@sentry/vue]) installed, minimum version 7.85.0.',
+            {
+              code: <code />,
+            }
+          ),
+        },
+        installSnippetBlock,
+      ],
     },
   ],
   configure: (params: Params) => [
@@ -359,7 +393,7 @@ const crashReportOnboarding: OnboardingConfig<PlatformOptions> = {
 };
 
 const profilingOnboarding = getJavascriptProfilingOnboarding({
-  getInstallConfig,
+  installSnippetBlock,
   docsLink:
     'https://docs.sentry.io/platforms/javascript/guides/vue/profiling/browser-profiling/',
 });

--- a/static/app/gettingStartedDocs/node/node.tsx
+++ b/static/app/gettingStartedDocs/node/node.tsx
@@ -320,7 +320,6 @@ const performanceOnboarding: OnboardingConfig = {
           tabs: [
             {
               label: 'JavaScript',
-              value: 'javascript',
               filename: 'instrument.(js|mjs)',
               language: 'javascript',
               code: getSdkInitSnippet(params, 'node'),

--- a/static/app/utils/gettingStartedDocs/javascript.tsx
+++ b/static/app/utils/gettingStartedDocs/javascript.tsx
@@ -3,6 +3,7 @@ import {ExternalLink} from 'sentry/components/core/link';
 import {
   type BasePlatformOptions,
   type Configuration,
+  type ContentBlock,
   type DocsParams,
   type OnboardingConfig,
   StepType,
@@ -73,23 +74,28 @@ response.sendFile("index.html");
 export const getJavascriptProfilingOnboarding = <
   PlatformOptions extends BasePlatformOptions = BasePlatformOptions,
 >({
-  getInstallConfig,
+  installSnippetBlock,
   docsLink,
 }: {
   docsLink: string;
-  getInstallConfig: (params: DocsParams<PlatformOptions>) => Configuration[];
+  installSnippetBlock: ContentBlock;
 }): OnboardingConfig<PlatformOptions> => ({
   introduction: () => <BrowserProfilingBetaWarning />,
-  install: params => [
+  install: () => [
     {
       type: StepType.INSTALL,
-      description: tct(
-        'Install our SDK using your preferred package manager, the minimum version that supports profiling is [code:7.60.0].',
+      content: [
         {
-          code: <code />,
-        }
-      ),
-      configurations: getInstallConfig(params),
+          type: 'text',
+          text: tct(
+            'Install our SDK using your preferred package manager, the minimum version that supports profiling is [code:7.60.0].',
+            {
+              code: <code />,
+            }
+          ),
+        },
+        installSnippetBlock,
+      ],
     },
   ],
   configure: params => [


### PR DESCRIPTION
Most of the migrations are related to onboarding configurations. Both replayOnboarding and feedbackOnboarding use codeHeader in their layouts, which injects a toggle component at the top of the last code block. Right now, this isn't working properly with the code blocks.

Once we fix the codeHeader issue (I have a solution in mind), we’ll need to revisit these files and migrate the rest of the onboarding configurations.

contributes to https://linear.app/getsentry/issue/TET-761/docs-move-from-configuration-objects-to-content-blocks