### PR TITLE
feat: Remove platform selection behaviour on back

### DIFF
--- a/static/app/views/onboarding/platformSelection.tsx
+++ b/static/app/views/onboarding/platformSelection.tsx
@@ -2,7 +2,6 @@ import styled from '@emotion/styled';
 import {motion} from 'framer-motion';
 import omit from 'lodash/omit';
 
-import {useOnboardingContext} from 'sentry/components/onboarding/onboardingContext';
 import PlatformPicker from 'sentry/components/platformPicker';
 import {t} from 'sentry/locale';
 import testableTransition from 'sentry/utils/testableTransition';
@@ -15,7 +14,6 @@ import type {StepProps} from './types';
 
 export function PlatformSelection(props: StepProps) {
   const organization = useOrganization();
-  const onboardingContext = useOnboardingContext();
 
   const {configureSdk, isLoadingData} = useConfigureSdk({
     onComplete: props.onComplete,
@@ -44,8 +42,6 @@ export function PlatformSelection(props: StepProps) {
           noAutoFilter
           visibleSelection={false}
           source="targeted-onboarding"
-          platform={onboardingContext.selectedPlatform?.key}
-          defaultCategory={onboardingContext.selectedPlatform?.category}
           setPlatform={platform => {
             const selectedPlatform = platform
               ? {...omit(platform, 'id'), key: platform.id}


### PR DESCRIPTION
**Problem**
In the main onboarding flow, when navigating back, if the project has been deleted, the session storage containing the platform data is cleared. As a result, the platform tab is not re-selected.

This behaviour differs from the case where the project is not deleted....leading to two inconsistent experiences in the flow.

**What Changed**
Since platform selection is already hidden by default (visibleSelection=false) and the tab selection logic only applies to non-deleted projects, we removed the tab selection entirely. This simplifies the logic and makes things consistent.