### PR TITLE
ref(relay): Raise project config Redis ttl to 2 hours (from 1 hour)

### DIFF
--- a/src/sentry/relay/projectconfig_cache/redis.py
+++ b/src/sentry/relay/projectconfig_cache/redis.py
@@ -8,7 +8,7 @@ from sentry.relay.projectconfig_cache.base import ProjectConfigCache
 from sentry.utils import json, metrics, redis
 from sentry.utils.redis import validate_dynamic_cluster
 
-REDIS_CACHE_TIMEOUT = 3600  # 1 hr
+REDIS_CACHE_TIMEOUT = 8400  # 2 hr, 20 minutes
 COMPRESSION_LEVEL = 3  # 3 is the default level of compression
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Raises the TTL (double) to reduce recomputations, but also adds a small offset (20 minutes) to avoid expiries colliding with hourly tasks.