### PR TITLE
ref: avoid introducing nullability through parse_timestamp

### DIFF
--- a/src/sentry/issues/escalating/escalating_group_forecast.py
+++ b/src/sentry/issues/escalating/escalating_group_forecast.py
@@ -9,7 +9,7 @@ import hashlib
 import logging
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import TypedDict, cast
+from typing import TypedDict
 
 from sentry import nodestore
 from sentry.models.group import Group
@@ -126,5 +126,5 @@ class EscalatingGroupForecast:
             data["project_id"],
             data["group_id"],
             data["forecast"],
-            cast(datetime, parse_timestamp(data["date_added"])),
+            parse_timestamp(data["date_added"]),
         )

--- a/src/sentry/issues/issue_occurrence.py
+++ b/src/sentry/issues/issue_occurrence.py
@@ -166,7 +166,7 @@ class IssueOccurrence:
                 for evidence in data["evidence_display"]
             ],
             get_group_type_by_type_id(data["type"]),
-            cast(datetime, parse_timestamp(data["detection_time"])),
+            parse_timestamp(data["detection_time"]),
             level,
             culprit,
             priority,

--- a/src/sentry/utils/dates.py
+++ b/src/sentry/utils/dates.py
@@ -4,7 +4,7 @@ import zoneinfo
 from datetime import UTC, date, datetime, timedelta
 from typing import Any, overload
 
-from dateutil.parser import ParserError, parse
+from dateutil.parser import parse
 from django.http.request import HttpRequest
 from django.utils.timezone import is_aware, make_aware
 
@@ -76,6 +76,14 @@ def parse_date(datestr: str, timestr: str) -> datetime | None:
             return None
 
 
+@overload  # TODO: deprecate
+def parse_timestamp(value: None) -> None: ...
+
+
+@overload
+def parse_timestamp(value: datetime | int | float | str | bytes) -> datetime: ...
+
+
 def parse_timestamp(value: datetime | int | float | str | bytes | None) -> datetime | None:
     # TODO(mitsuhiko): merge this code with coreapis date parser
     if not value:
@@ -85,13 +93,9 @@ def parse_timestamp(value: datetime | int | float | str | bytes | None) -> datet
     elif isinstance(value, (int, float)):
         return datetime.fromtimestamp(value, UTC)
 
-    try:
-        if isinstance(value, bytes):
-            value = value.decode()
-        return parse(value, ignoretz=True).replace(tzinfo=UTC)
-    except (ParserError, ValueError):
-        logger.exception("parse_timestamp")
-        return None
+    if isinstance(value, bytes):
+        value = value.decode()
+    return parse(value, ignoretz=True).replace(tzinfo=UTC)
 
 
 def parse_stats_period(period: str) -> timedelta | None:

--- a/tests/sentry/utils/test_dates.py
+++ b/tests/sentry/utils/test_dates.py
@@ -1,5 +1,7 @@
 import datetime
 
+import pytest
+
 from sentry.utils.dates import date_to_utc_datetime, parse_stats_period, parse_timestamp
 
 
@@ -27,4 +29,8 @@ def test_parse_timestamp():
     assert parse_timestamp("2024-05-20T17:29:00") == datetime.datetime(
         2024, 5, 20, 17, 29, tzinfo=datetime.UTC
     )
-    assert parse_timestamp("2024-05-20T17:29:00gu") is None
+
+
+def test_parse_timestamp_error():
+    with pytest.raises(ValueError):
+        parse_timestamp("2024-05-20T17:29:00gu")


### PR DESCRIPTION
searching sentry the last 90 days show no errors for `parse_timestamp`

<!-- Describe your PR here. -->