### PR TITLE
fix(spans): Include the Kafka slice ID in flush queue keys

### DIFF
--- a/src/sentry/conf/types/kafka_definition.py
+++ b/src/sentry/conf/types/kafka_definition.py
@@ -130,8 +130,9 @@ class ConsumerDefinition(TypedDict, total=False):
     # Hardcoded additional kwargs for strategy_factory
     static_args: Mapping[str, Any]
 
-    # Pass the consumer group ID to the strategy factory as 'consumer_group' kwarg
+    # Pass optional kwargs to the strategy factory
     pass_consumer_group: bool
+    pass_kafka_slice_id: bool
 
     require_synchronization: bool
     synchronize_commit_group_default: str

--- a/src/sentry/consumers/__init__.py
+++ b/src/sentry/consumers/__init__.py
@@ -437,6 +437,7 @@ KAFKA_CONSUMERS: Mapping[str, ConsumerDefinition] = {
                 help="Maximum number of processes for the span flusher. Defaults to 1.",
             ),
         ],
+        "pass_kafka_slice_id": True,
     },
     "process-segments": {
         "topic": Topic.BUFFERED_SEGMENTS,
@@ -515,7 +516,7 @@ def get_stream_processor(
     extra_kwargs = {}
     if consumer_definition.get("pass_consumer_group", False):
         extra_kwargs["consumer_group"] = group_id
-    if kafka_slice_id is not None:
+    if consumer_definition.get("pass_kafka_slice_id", False):
         extra_kwargs["kafka_slice_id"] = kafka_slice_id
     strategy_factory = cmd_context.invoke(
         strategy_factory_cls,

--- a/src/sentry/consumers/__init__.py
+++ b/src/sentry/consumers/__init__.py
@@ -515,6 +515,8 @@ def get_stream_processor(
     extra_kwargs = {}
     if consumer_definition.get("pass_consumer_group", False):
         extra_kwargs["consumer_group"] = group_id
+    if kafka_slice_id is not None:
+        extra_kwargs["kafka_slice_id"] = kafka_slice_id
     strategy_factory = cmd_context.invoke(
         strategy_factory_cls,
         **cmd_context.params,

--- a/src/sentry/consumers/__init__.py
+++ b/src/sentry/consumers/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import uuid
 from collections.abc import Mapping, Sequence
+from typing import Any
 
 import click
 from arroyo.backends.abstract import Consumer
@@ -513,7 +514,7 @@ def get_stream_processor(
         name=consumer_name, params=list(consumer_definition.get("click_options") or ())
     )
     cmd_context = cmd.make_context(consumer_name, list(consumer_args))
-    extra_kwargs = {}
+    extra_kwargs: dict[str, Any] = {}
     if consumer_definition.get("pass_consumer_group", False):
         extra_kwargs["consumer_group"] = group_id
     if consumer_definition.get("pass_kafka_slice_id", False):

--- a/src/sentry/spans/consumers/process/factory.py
+++ b/src/sentry/spans/consumers/process/factory.py
@@ -43,6 +43,7 @@ class ProcessSpansStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
         output_block_size: int | None,
         flusher_processes: int | None = None,
         produce_to_pipe: Callable[[KafkaPayload], None] | None = None,
+        kafka_slice_id: int | None = None,
     ):
         super().__init__()
 
@@ -56,6 +57,7 @@ class ProcessSpansStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
         self.num_processes = num_processes
         self.flusher_processes = flusher_processes
         self.produce_to_pipe = produce_to_pipe
+        self.kafka_slice_id = kafka_slice_id
 
         if self.num_processes != 1:
             self.__pool = MultiprocessingPool(num_processes)
@@ -75,7 +77,10 @@ class ProcessSpansStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
 
         committer = CommitOffsets(commit)
 
-        buffer = SpansBuffer(assigned_shards=[p.index for p in partitions])
+        buffer = SpansBuffer(
+            assigned_shards=[p.index for p in partitions],
+            slice_id=self.kafka_slice_id,
+        )
 
         # patch onto self just for testing
         flusher: ProcessingStrategy[FilteredPayload | int]

--- a/src/sentry/spans/consumers/process/flusher.py
+++ b/src/sentry/spans/consumers/process/flusher.py
@@ -131,6 +131,7 @@ class SpanFlusher(ProcessingStrategy[FilteredPayload | int]):
     ):
         self.next_step = next_step
         self.max_processes = max_processes or len(buffer.assigned_shards)
+        self.slice_id = buffer.slice_id
 
         self.mp_context = mp_context = multiprocessing.get_context("spawn")
         self.stopped = mp_context.Value("i", 0)
@@ -192,7 +193,7 @@ class SpanFlusher(ProcessingStrategy[FilteredPayload | int]):
         self.process_healthy_since[process_index].value = 0
 
         # Create a buffer for these specific shards
-        shard_buffer = SpansBuffer(shards)
+        shard_buffer = SpansBuffer(shards, slice_id=self.slice_id)
 
         make_process: Callable[..., multiprocessing.context.SpawnProcess | threading.Thread]
         if self.produce_to_pipe is None:

--- a/src/sentry/spans/consumers/process_segments/factory.py
+++ b/src/sentry/spans/consumers/process_segments/factory.py
@@ -42,7 +42,6 @@ class DetectPerformanceIssuesStrategyFactory(ProcessingStrategyFactory[KafkaPayl
         input_block_size: int | None,
         output_block_size: int | None,
         skip_produce: bool,
-        kafka_slice_id: int | None = None,
     ):
         super().__init__()
         self.max_batch_size = max_batch_size

--- a/src/sentry/spans/consumers/process_segments/factory.py
+++ b/src/sentry/spans/consumers/process_segments/factory.py
@@ -42,6 +42,7 @@ class DetectPerformanceIssuesStrategyFactory(ProcessingStrategyFactory[KafkaPayl
         input_block_size: int | None,
         output_block_size: int | None,
         skip_produce: bool,
+        kafka_slice_id: int | None = None,
     ):
         super().__init__()
         self.max_batch_size = max_batch_size

--- a/tests/sentry/spans/consumers/process/test_consumer.py
+++ b/tests/sentry/spans/consumers/process/test_consumer.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from time import sleep as real_sleep  # Import before monkeypatch
 
 import orjson
+import pytest
 from arroyo.backends.kafka import KafkaPayload
 from arroyo.types import BrokerValue, Message, Partition, Topic
 
@@ -11,7 +12,8 @@ from tests.sentry.spans.test_buffer import DEFAULT_OPTIONS
 
 
 @override_options({**DEFAULT_OPTIONS, "spans.drop-in-buffer": []})
-def test_basic(monkeypatch):
+@pytest.mark.parametrize("kafka_slice_id", [None, 2])
+def test_basic(monkeypatch, kafka_slice_id):
     # Flush very aggressively to make test pass instantly
     monkeypatch.setattr("time.sleep", lambda _: None)
     topic = Topic("test")
@@ -24,6 +26,7 @@ def test_basic(monkeypatch):
         input_block_size=None,
         output_block_size=None,
         produce_to_pipe=messages.append,
+        kafka_slice_id=kafka_slice_id,
     )
 
     commits = []


### PR DESCRIPTION
As we slice `process_spans`, each of the slices have shards starting with index
0, each stored on the same Redis cluster. Since these are separate queues, we
need to include the Kafka slice ID in the queue key to make them unique.

