### PR TITLE
ref(grid-editable): remove z-index for body panel

### DIFF
--- a/static/app/components/tables/gridEditable/styles.tsx
+++ b/static/app/components/tables/gridEditable/styles.tsx
@@ -14,8 +14,7 @@ const GRID_STATUS_MESSAGE_HEIGHT = GRID_BODY_ROW_HEIGHT * 4;
  * Local z-index stacking context
  * https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context
  */
-// Parent context is Panel
-const Z_INDEX_GRID = 5;
+const Z_INDEX_STICKY_HEADER = 1;
 
 // Parent context is GridHeadCell
 const Z_INDEX_GRID_RESIZER = 1;
@@ -131,7 +130,7 @@ export const GridHead = styled('thead')<{sticky?: boolean}>`
   border-top-left-radius: ${p => p.theme.borderRadius};
   border-top-right-radius: ${p => p.theme.borderRadius};
 
-  ${p => (p.sticky ? `position: sticky; top: 0; z-index: ${Z_INDEX_GRID + 1}` : '')}
+  ${p => (p.sticky ? `position: sticky; top: 0; z-index: ${Z_INDEX_STICKY_HEADER}` : '')}
 `;
 
 export const GridHeadCell = styled('th')<{isFirst: boolean}>`

--- a/static/app/components/tables/gridEditable/styles.tsx
+++ b/static/app/components/tables/gridEditable/styles.tsx
@@ -15,7 +15,6 @@ const GRID_STATUS_MESSAGE_HEIGHT = GRID_BODY_ROW_HEIGHT * 4;
  * https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context
  */
 // Parent context is Panel
-const Z_INDEX_PANEL = 1;
 const Z_INDEX_GRID = 5;
 
 // Parent context is GridHeadCell
@@ -64,7 +63,6 @@ export const Body = styled(
 )`
   overflow-x: auto;
   overflow-y: ${({showVerticalScrollbar}) => (showVerticalScrollbar ? 'auto' : 'hidden')};
-  z-index: ${Z_INDEX_PANEL};
 `;
 
 /**
@@ -94,7 +92,6 @@ export const Grid = styled('table')<{
   border-collapse: collapse;
   margin: 0;
 
-  z-index: ${Z_INDEX_GRID};
   ${p =>
     p.scrollable &&
     css`


### PR DESCRIPTION
### Changes

Removes `z-index` from the `GridEditable` `Body` and `Grid` styles, because it causes conflicts with tables being stacked over dropdowns and isn't necessary to properly stack the column resizer and sticky headers.

### Before

**Note:** these new widget tables are hidden behind the `dashboards-use-widget-table-visualization` flag

<img width="842" height="617" alt="Screenshot 2025-07-23 at 9 46 38 AM" src="https://github.com/user-attachments/assets/1b1162b7-92e2-4bd5-a2e6-f230e3a736ae" />

### After

<img width="1019" height="622" alt="Screenshot 2025-07-23 at 9 47 38 AM" src="https://github.com/user-attachments/assets/92212890-8d02-4d03-85a3-a4951542fecd" />



