### PR TITLE
fix(dashboards): Remove My Dashboards from the table view sort

### DIFF
--- a/static/app/views/dashboards/manage/index.spec.tsx
+++ b/static/app/views/dashboards/manage/index.spec.tsx
@@ -1,13 +1,14 @@
 import {DashboardListItemFixture} from 'sentry-fixture/dashboard';
+import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
-import {RouteComponentPropsFixture} from 'sentry-fixture/routeComponentPropsFixture';
 
-import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 import selectEvent from 'sentry-test/selectEvent';
 
 import ProjectsStore from 'sentry/stores/projectsStore';
 import localStorage from 'sentry/utils/localStorage';
+import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import ManageDashboards, {LAYOUT_KEY} from 'sentry/views/dashboards/manage';
 import {getPaginationPageLink} from 'sentry/views/organizationStats/utils';
@@ -25,7 +26,10 @@ jest.mock('sentry/utils/useNavigate', () => ({
   useNavigate: jest.fn(),
 }));
 
+jest.mock('sentry/utils/useLocation');
+
 const mockUseNavigate = jest.mocked(useNavigate);
+const mockUseLocation = jest.mocked(useLocation);
 
 describe('Dashboards > Detail', function () {
   const mockUnauthorizedOrg = OrganizationFixture({
@@ -50,9 +54,16 @@ describe('Dashboards > Detail', function () {
       url: '/organizations/org-slug/dashboards/?sort=name&per_page=9',
       body: [],
     });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/dashboards/starred/',
+      body: [],
+    });
+
+    mockUseLocation.mockReturnValue(LocationFixture());
   });
   afterEach(function () {
     MockApiClient.clearMockResponses();
+    localStorage.clear();
   });
 
   it('renders', async function () {
@@ -62,7 +73,6 @@ describe('Dashboards > Detail', function () {
     });
 
     render(<ManageDashboards />, {
-      ...RouteComponentPropsFixture(),
       organization: mockAuthorizedOrg,
     });
 
@@ -79,7 +89,6 @@ describe('Dashboards > Detail', function () {
       statusCode: 400,
     });
     render(<ManageDashboards />, {
-      ...RouteComponentPropsFixture(),
       organization: mockAuthorizedOrg,
     });
 
@@ -88,7 +97,6 @@ describe('Dashboards > Detail', function () {
 
   it('denies access on missing feature', async function () {
     render(<ManageDashboards />, {
-      ...RouteComponentPropsFixture(),
       organization: mockUnauthorizedOrg,
     });
 
@@ -101,7 +109,6 @@ describe('Dashboards > Detail', function () {
     act(() => ProjectsStore.loadInitialData([]));
 
     render(<ManageDashboards />, {
-      ...RouteComponentPropsFixture(),
       organization: mockAuthorizedOrg,
     });
 
@@ -116,7 +123,6 @@ describe('Dashboards > Detail', function () {
     mockUseNavigate.mockReturnValue(mockNavigate);
 
     render(<ManageDashboards />, {
-      ...RouteComponentPropsFixture(),
       organization: org,
     });
 
@@ -134,7 +140,6 @@ describe('Dashboards > Detail', function () {
     mockUseNavigate.mockReturnValue(mockNavigate);
 
     render(<ManageDashboards />, {
-      ...RouteComponentPropsFixture(),
       organization: org,
     });
 
@@ -154,7 +159,6 @@ describe('Dashboards > Detail', function () {
     mockUseNavigate.mockReturnValue(mockNavigate);
 
     render(<ManageDashboards />, {
-      ...RouteComponentPropsFixture(),
       organization: org,
     });
 
@@ -178,7 +182,6 @@ describe('Dashboards > Detail', function () {
     });
 
     render(<ManageDashboards />, {
-      ...RouteComponentPropsFixture(),
       organization: mockAuthorizedOrg,
     });
 
@@ -205,7 +208,6 @@ describe('Dashboards > Detail', function () {
     });
 
     render(<ManageDashboards />, {
-      ...RouteComponentPropsFixture(),
       organization: mockAuthorizedOrg,
     });
 
@@ -223,7 +225,6 @@ describe('Dashboards > Detail', function () {
     });
 
     render(<ManageDashboards />, {
-      ...RouteComponentPropsFixture(),
       organization: {
         ...mockAuthorizedOrg,
       },
@@ -240,5 +241,66 @@ describe('Dashboards > Detail', function () {
 
     expect(localStorage.setItem).toHaveBeenCalledWith(LAYOUT_KEY, '"grid"');
     expect(await screen.findByTestId('dashboard-grid')).toBeInTheDocument();
+  });
+
+  it('uses recently viewed sort by default on table view', async function () {
+    const org = OrganizationFixture({
+      features: [...FEATURES, 'dashboards-starred-reordering'],
+    });
+    const mockNavigate = jest.fn();
+    mockUseNavigate.mockReturnValue(mockNavigate);
+
+    // mock the view type to table
+    localStorage.setItem(LAYOUT_KEY, '"table"');
+
+    render(<ManageDashboards />, {
+      organization: org,
+    });
+
+    const sortBy = await screen.findByTestId('sort-by-select');
+    expect(sortBy).toBeInTheDocument();
+    // The prefix and the selection are concatenated when using text content
+    expect(sortBy).toHaveTextContent('Sort ByRecently Viewed');
+  });
+
+  it('does not show My Dashboards as a sort option in table view', async function () {
+    const org = OrganizationFixture({
+      features: [...FEATURES, 'dashboards-starred-reordering'],
+    });
+    const mockNavigate = jest.fn();
+    mockUseNavigate.mockReturnValue(mockNavigate);
+
+    // mock the view type to table
+    localStorage.setItem(LAYOUT_KEY, '"table"');
+
+    render(<ManageDashboards />, {
+      organization: org,
+    });
+
+    const sortBy = await screen.findByTestId('sort-by-select');
+    expect(sortBy).toBeInTheDocument();
+    // The prefix and the selection are concatenated when using text content
+    expect(sortBy).toHaveTextContent('Sort ByRecently Viewed');
+    expect(screen.queryByText('My Dashboards')).not.toBeInTheDocument();
+  });
+
+  it('redirects the URL to the default sort option when the sort option is not valid', async function () {
+    const org = OrganizationFixture({
+      features: [...FEATURES, 'dashboards-starred-reordering'],
+    });
+    const mockNavigate = jest.fn();
+    mockUseNavigate.mockReturnValue(mockNavigate);
+    mockUseLocation.mockReturnValue(LocationFixture({query: {sort: 'invalid'}}));
+
+    render(<ManageDashboards />, {
+      organization: org,
+    });
+
+    expect(await screen.findByText('My Dashboards')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(
+        expect.objectContaining({query: {sort: 'mydashboards'}})
+      );
+    });
   });
 });

--- a/static/app/views/dashboards/manage/index.tsx
+++ b/static/app/views/dashboards/manage/index.tsx
@@ -26,6 +26,7 @@ import {IconAdd, IconGrid, IconList} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {SelectValue} from 'sentry/types/core';
+import type {Organization} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import localStorage from 'sentry/utils/localStorage';
 import parseLinkHeader from 'sentry/utils/parseLinkHeader';
@@ -98,6 +99,42 @@ function getDashboardsOverviewLayout(): DashboardsLayout {
     : GRID;
 }
 
+function getSortOptions({
+  organization,
+  dashboardsLayout,
+}: {
+  dashboardsLayout: DashboardsLayout;
+  organization: Organization;
+}) {
+  if (
+    organization.features.includes('dashboards-starred-reordering') &&
+    dashboardsLayout === TABLE
+  ) {
+    // The table layout under this feature flag is split by owned and shared dashboards, so the 'mydashboards'
+    // sort option does not apply
+    return SORT_OPTIONS.filter(option => option.value !== 'mydashboards');
+  }
+
+  return SORT_OPTIONS;
+}
+
+function getDefaultSort({
+  organization,
+  dashboardsLayout,
+}: {
+  dashboardsLayout: DashboardsLayout;
+  organization: Organization;
+}) {
+  if (
+    organization.features.includes('dashboards-starred-reordering') &&
+    dashboardsLayout === TABLE
+  ) {
+    return 'recentlyViewed';
+  }
+
+  return 'mydashboards';
+}
+
 function ManageDashboards() {
   const organization = useOrganization();
   const navigate = useNavigate();
@@ -117,6 +154,11 @@ function ManageDashboards() {
   const [{rowCount, columnCount}, setGridSize] = useState({
     rowCount: DASHBOARD_GRID_DEFAULT_NUM_ROWS,
     columnCount: DASHBOARD_GRID_DEFAULT_NUM_COLUMNS,
+  });
+
+  const sortOptions = getSortOptions({
+    organization,
+    dashboardsLayout,
   });
 
   const {
@@ -216,9 +258,37 @@ function ManageDashboards() {
     };
   }, [columnCount, dashboards?.length, dashboardsPageLinks, refetchDashboards, rowCount]);
 
+  useEffect(() => {
+    const urlSort = decodeScalar(location.query.sort);
+    const defaultSort = getDefaultSort({
+      organization,
+      dashboardsLayout,
+    });
+    if (urlSort && !sortOptions.some(option => option.value === urlSort)) {
+      // The sort option is not valid, so we need to set the default sort
+      // in the URL
+      navigate({
+        pathname: location.pathname,
+        query: {...location.query, sort: defaultSort},
+      });
+    }
+  }, [
+    dashboardsLayout,
+    location.pathname,
+    location.query,
+    navigate,
+    organization,
+    sortOptions,
+  ]);
+
   function getActiveSort() {
-    const urlSort = decodeScalar(location.query.sort, 'mydashboards');
-    return SORT_OPTIONS.find(item => item.value === urlSort) || SORT_OPTIONS[0];
+    const defaultSort = getDefaultSort({
+      organization,
+      dashboardsLayout,
+    });
+    const urlSort = decodeScalar(location.query.sort, defaultSort);
+
+    return sortOptions.find(item => item.value === urlSort) || sortOptions[0];
   }
 
   function handleSearch(query: string) {
@@ -316,9 +386,10 @@ function ManageDashboards() {
         <CompactSelect
           triggerProps={{prefix: t('Sort By')}}
           value={activeSort!.value}
-          options={SORT_OPTIONS}
+          options={sortOptions}
           onChange={opt => handleSortChange(opt.value)}
           position="bottom-end"
+          data-test-id="sort-by-select"
         />
       </StyledActions>
     );

--- a/static/app/views/dashboards/manage/index.tsx
+++ b/static/app/views/dashboards/manage/index.tsx
@@ -288,7 +288,16 @@ function ManageDashboards() {
     });
     const urlSort = decodeScalar(location.query.sort, defaultSort);
 
-    return sortOptions.find(item => item.value === urlSort) || sortOptions[0];
+    if (urlSort) {
+      // Check if the URL sort is valid
+      const foundSort = sortOptions.find(item => item.value === urlSort);
+      if (foundSort) {
+        return foundSort;
+      }
+    }
+
+    // If it is not valid, try the default sort, and only if that is not valid, use the first option
+    return sortOptions.find(item => item.value === defaultSort) || sortOptions[0];
   }
 
   function handleSearch(query: string) {


### PR DESCRIPTION
Since the table view will be split into Created by Me and Created by Others, the "My Dashboards" table sort doesn't make sense. Make the default one for table view to be "Recently Viewed". If an invalid sort is used, instead of choosing the first one, choose "My Dashboards" for the grid view and "Recently Viewed" for table view and update the URL.
