### PR TITLE
feat(charts): format currency

### DIFF
--- a/static/app/utils/formatters.spec.tsx
+++ b/static/app/utils/formatters.spec.tsx
@@ -2,6 +2,7 @@ import {RateUnit} from 'sentry/utils/discover/fields';
 import {
   formatAbbreviatedNumber,
   formatAbbreviatedNumberWithDynamicPrecision,
+  formatCurrency,
   formatPercentRate,
   formatRate,
   formatSpanOperation,
@@ -264,5 +265,25 @@ describe('formatTimeDuration', () => {
     it('formats 1 day', () => {
       expect(formatTimeDuration(86400000)).toBe('1d 0h 0m 0s');
     });
+  });
+});
+
+describe('formatCurrency()', function () {
+  it.each([
+    [0, '$0'],
+    [1, '$1'],
+    [0.01, '$0.01'],
+    [17.1238, '$17.12'],
+    [1249.99, '$1.25k'],
+    [999999, '$1,000k'],
+    [1000000, '$1m'],
+    [1772313.1, '$1.77m'],
+    [1000000000, '$1b'],
+    [1000000000000, '$1,000b'],
+    [-100, '$-100'],
+    [-1500, '$-1.5k'],
+    [-1000000, '$-1m'],
+  ])('formats %s as %s', (value, expected) => {
+    expect(formatCurrency(value)).toBe(expected);
   });
 });

--- a/static/app/utils/formatters.spec.tsx
+++ b/static/app/utils/formatters.spec.tsx
@@ -2,7 +2,7 @@ import {RateUnit} from 'sentry/utils/discover/fields';
 import {
   formatAbbreviatedNumber,
   formatAbbreviatedNumberWithDynamicPrecision,
-  formatCurrency,
+  formatDollars,
   formatPercentRate,
   formatRate,
   formatSpanOperation,
@@ -268,7 +268,7 @@ describe('formatTimeDuration', () => {
   });
 });
 
-describe('formatCurrency()', function () {
+describe('formatDollars', function () {
   it.each([
     [0, '$0'],
     [1, '$1'],
@@ -284,6 +284,6 @@ describe('formatCurrency()', function () {
     [-1500, '$-1.5k'],
     [-1000000, '$-1m'],
   ])('formats %s as %s', (value, expected) => {
-    expect(formatCurrency(value)).toBe(expected);
+    expect(formatDollars(value)).toBe(expected);
   });
 });

--- a/static/app/utils/formatters.tsx
+++ b/static/app/utils/formatters.tsx
@@ -295,6 +295,6 @@ export function formatTimeDuration(duration?: number, numLargestUnitsToShow?: nu
   return parts.join(' ');
 }
 
-export function formatCurrency(value: number) {
+export function formatDollars(value: number) {
   return `$${formatAbbreviatedNumberWithDynamicPrecision(value)}`;
 }

--- a/static/app/utils/formatters.tsx
+++ b/static/app/utils/formatters.tsx
@@ -294,3 +294,7 @@ export function formatTimeDuration(duration?: number, numLargestUnitsToShow?: nu
 
   return parts.join(' ');
 }
+
+export function formatCurrency(value: number) {
+  return `$${formatAbbreviatedNumberWithDynamicPrecision(value)}`;
+}

--- a/static/app/views/dashboards/widgets/common/settings.tsx
+++ b/static/app/views/dashboards/widgets/common/settings.tsx
@@ -12,6 +12,7 @@ export const PLOTTABLE_TIME_SERIES_VALUE_TYPES = [
   'size',
   'rate',
   'score',
+  'currency',
 ] as const;
 
 export const MIN_WIDTH = 110;

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatTooltipValue.spec.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatTooltipValue.spec.tsx
@@ -73,4 +73,17 @@ describe('formatTooltipValue', () => {
       expect(formatTooltipValue(value, 'score', unit)).toEqual(formattedValue);
     });
   });
+
+  describe('currency', () => {
+    it.each([
+      [0, '$0'],
+      [17, '$17'],
+      [171, '$171'],
+      [17111, '$17.11k'],
+      [17_000_110, '$17m'],
+      [1_000_110_000, '$1b'],
+    ])('Formats %s as %s', (value, formattedValue) => {
+      expect(formatTooltipValue(value, 'currency')).toEqual(formattedValue);
+    });
+  });
 });

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatTooltipValue.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatTooltipValue.tsx
@@ -3,7 +3,7 @@ import {formatBytesBase10} from 'sentry/utils/bytes/formatBytesBase10';
 import {ABYTE_UNITS} from 'sentry/utils/discover/fieldRenderers';
 import {DurationUnit, type RateUnit, SizeUnit} from 'sentry/utils/discover/fields';
 import getDuration from 'sentry/utils/duration/getDuration';
-import {formatRate} from 'sentry/utils/formatters';
+import {formatCurrency, formatRate} from 'sentry/utils/formatters';
 import {formatPercentage} from 'sentry/utils/number/formatPercentage';
 import {ECHARTS_MISSING_DATA_VALUE} from 'sentry/utils/timeSeries/timeSeriesItemToEChartsDataPoint';
 import {convertDuration} from 'sentry/utils/unitConversion/convertDuration';
@@ -53,6 +53,8 @@ export function formatTooltipValue(
     case 'score':
       // Scores are always integers, no half-marks.
       return value.toFixed(0);
+    case 'currency':
+      return formatCurrency(value);
     default:
       return value.toString();
   }

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatTooltipValue.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatTooltipValue.tsx
@@ -3,7 +3,7 @@ import {formatBytesBase10} from 'sentry/utils/bytes/formatBytesBase10';
 import {ABYTE_UNITS} from 'sentry/utils/discover/fieldRenderers';
 import {DurationUnit, type RateUnit, SizeUnit} from 'sentry/utils/discover/fields';
 import getDuration from 'sentry/utils/duration/getDuration';
-import {formatCurrency, formatRate} from 'sentry/utils/formatters';
+import {formatDollars, formatRate} from 'sentry/utils/formatters';
 import {formatPercentage} from 'sentry/utils/number/formatPercentage';
 import {ECHARTS_MISSING_DATA_VALUE} from 'sentry/utils/timeSeries/timeSeriesItemToEChartsDataPoint';
 import {convertDuration} from 'sentry/utils/unitConversion/convertDuration';
@@ -54,7 +54,7 @@ export function formatTooltipValue(
       // Scores are always integers, no half-marks.
       return value.toFixed(0);
     case 'currency':
-      return formatCurrency(value);
+      return formatDollars(value);
     default:
       return value.toString();
   }

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatYAxisValue.spec.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatYAxisValue.spec.tsx
@@ -74,4 +74,17 @@ describe('formatYAxisValue', () => {
       expect(formatYAxisValue(value, 'rate', unit)).toEqual(formattedValue);
     });
   });
+
+  describe('currency', () => {
+    it.each([
+      [0, '0'],
+      [17, '$17'],
+      [171, '$171'],
+      [17111, '$17.11k'],
+      [17_000_110, '$17m'],
+      [1_000_110_000, '$1b'],
+    ])('Formats %s as %s', (value, formattedValue) => {
+      expect(formatYAxisValue(value, 'currency')).toEqual(formattedValue);
+    });
+  });
 });

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatYAxisValue.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatYAxisValue.tsx
@@ -7,7 +7,7 @@ import {
   RateUnit,
   SizeUnit,
 } from 'sentry/utils/discover/fields';
-import {formatAbbreviatedNumber, formatCurrency} from 'sentry/utils/formatters';
+import {formatAbbreviatedNumber, formatDollars} from 'sentry/utils/formatters';
 import {formatPercentage} from 'sentry/utils/number/formatPercentage';
 import {convertDuration} from 'sentry/utils/unitConversion/convertDuration';
 import {convertSize} from 'sentry/utils/unitConversion/convertSize';
@@ -62,7 +62,7 @@ export function formatYAxisValue(value: number, type: string, unit?: string): st
       })}${RATE_UNIT_LABELS[rateUnit]}`;
     }
     case 'currency': {
-      return formatCurrency(value);
+      return formatDollars(value);
     }
     default:
       return value.toString();

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatYAxisValue.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatYAxisValue.tsx
@@ -7,7 +7,7 @@ import {
   RateUnit,
   SizeUnit,
 } from 'sentry/utils/discover/fields';
-import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
+import {formatAbbreviatedNumber, formatCurrency} from 'sentry/utils/formatters';
 import {formatPercentage} from 'sentry/utils/number/formatPercentage';
 import {convertDuration} from 'sentry/utils/unitConversion/convertDuration';
 import {convertSize} from 'sentry/utils/unitConversion/convertSize';
@@ -60,6 +60,9 @@ export function formatYAxisValue(value: number, type: string, unit?: string): st
         notation: 'compact',
         maximumSignificantDigits: 6,
       })}${RATE_UNIT_LABELS[rateUnit]}`;
+    }
+    case 'currency': {
+      return formatCurrency(value);
     }
     default:
       return value.toString();

--- a/static/app/views/insights/agentMonitoring/utils/formatLLMCosts.tsx
+++ b/static/app/views/insights/agentMonitoring/utils/formatLLMCosts.tsx
@@ -1,4 +1,4 @@
-import {formatAbbreviatedNumberWithDynamicPrecision} from 'sentry/utils/formatters';
+import {formatCurrency} from 'sentry/utils/formatters';
 
 export function formatLLMCosts(cost: string | number) {
   let number = Number(cost);
@@ -9,5 +9,5 @@ export function formatLLMCosts(cost: string | number) {
   if (number < 0.01) {
     return `<$${(0.01).toLocaleString()}`;
   }
-  return `$${formatAbbreviatedNumberWithDynamicPrecision(number)}`;
+  return formatCurrency(number);
 }

--- a/static/app/views/insights/agentMonitoring/utils/formatLLMCosts.tsx
+++ b/static/app/views/insights/agentMonitoring/utils/formatLLMCosts.tsx
@@ -1,4 +1,4 @@
-import {formatCurrency} from 'sentry/utils/formatters';
+import {formatDollars} from 'sentry/utils/formatters';
 
 export function formatLLMCosts(cost: string | number) {
   let number = Number(cost);
@@ -9,5 +9,5 @@ export function formatLLMCosts(cost: string | number) {
   if (number < 0.01) {
     return `<$${(0.01).toLocaleString()}`;
   }
-  return formatCurrency(number);
+  return formatDollars(number);
 }


### PR DESCRIPTION
Adds formatting for currency data in chart Y axes and tooltips
Required for [TET-938: Format dollars](https://linear.app/getsentry/issue/TET-938/format-dollars)