### PR TITLE
feat(otlp): Return OTLP info in project key endpoint

### DIFF
--- a/src/sentry/api/serializers/models/project_key.py
+++ b/src/sentry/api/serializers/models/project_key.py
@@ -28,6 +28,7 @@ class DSN(TypedDict):
     crons: str
     cdn: str
     playstation: str
+    otlp_traces: str
 
 
 class BrowserSDK(TypedDict):
@@ -96,6 +97,7 @@ class ProjectKeySerializer(Serializer):
                 "crons": obj.crons_endpoint,
                 "cdn": obj.js_sdk_loader_cdn_url,
                 "playstation": obj.playstation_endpoint,
+                "otlp_traces": obj.otlp_traces_endpoint,
             },
             "browserSdkVersion": get_selected_browser_sdk_version(obj),
             "browserSdk": {"choices": get_browser_sdk_version_choices(obj.project)},

--- a/src/sentry/apidocs/examples/project_examples.py
+++ b/src/sentry/apidocs/examples/project_examples.py
@@ -16,6 +16,7 @@ KEY_RATE_LIMIT = {
         "security": "https://o4504765715316736.ingest.sentry.io/api/4505281256090153/security/?sentry_key=a785682ddda719b7a8a4011110d75598",
         "minidump": "https://o4504765715316736.ingest.sentry.io/api/4505281256090153/minidump/?sentry_key=a785682ddda719b7a8a4011110d75598",
         "playstation": "https://o4504765715316736.ingest.sentry.io/api/4505281256090153/playstation/?sentry_key=a785682ddda719b7a8a4011110d75598",
+        "otlp_traces": "https://o4504765715316736.ingest.sentry.io/api/4505281256090153/otlp/v1/traces",
         "nel": "https://o4504765715316736.ingest.sentry.io/api/4505281256090153/nel/?sentry_key=a785682ddda719b7a8a4011110d75598",
         "unreal": "https://o4504765715316736.ingest.sentry.io/api/4505281256090153/unreal/a785682ddda719b7a8a4011110d75598/",
         "cdn": "https://js.sentry-cdn.com/a785682ddda719b7a8a4011110d75598.min.js",

--- a/src/sentry/models/projectkey.py
+++ b/src/sentry/models/projectkey.py
@@ -266,6 +266,12 @@ class ProjectKey(Model):
         return f"{endpoint}/api/{self.project_id}/playstation/?sentry_key={self.public_key}"
 
     @property
+    def otlp_traces_endpoint(self):
+        endpoint = self.get_endpoint()
+
+        return f"{endpoint}/api/{self.project_id}/otlp/v1/traces"
+
+    @property
     def unreal_endpoint(self):
         return f"{self.get_endpoint()}/api/{self.project_id}/unreal/{self.public_key}/"
 

--- a/tests/sentry/api/endpoints/test_project_keys.py
+++ b/tests/sentry/api/endpoints/test_project_keys.py
@@ -40,6 +40,21 @@ class ListProjectKeysTest(APITestCase):
         assert response.status_code == 200
         assert response.data[0]["dsn"]["playstation"] == key.playstation_endpoint
 
+    def test_otlp_traces_endpoint(self):
+        project = self.create_project()
+        key = ProjectKey.objects.get_or_create(project=project)[0]
+        self.login_as(user=self.user)
+        url = reverse(
+            "sentry-api-0-project-keys",
+            kwargs={
+                "organization_id_or_slug": project.organization.slug,
+                "project_id_or_slug": project.slug,
+            },
+        )
+        response = self.client.get(url)
+        assert response.status_code == 200
+        assert response.data[0]["dsn"]["otlp_traces"] == key.otlp_traces_endpoint
+
     def test_use_case(self):
         """Regular user can access user DSNs but not internal DSNs"""
         project = self.create_project()


### PR DESCRIPTION
Adding OTLP trace endpoint info (OTLP can have multiple endpoints for different kinds of telemetry) as part of a serialized project key response so we can show it in the settings for anyone who's in the OTLP ingestion LA.
