### PR TITLE
fix(logs): Change meta type for count() from string to integer

### DIFF
--- a/src/sentry/search/eap/spans/aggregates.py
+++ b/src/sentry/search/eap/spans/aggregates.py
@@ -624,7 +624,7 @@ LOG_AGGREGATE_DEFINITIONS = {
         internal_function=Function.FUNCTION_COUNT,
         infer_search_type_from_arguments=False,
         processor=count_processor,
-        default_search_type="string",
+        default_search_type="integer",
         arguments=[
             AttributeArgumentDefinition(
                 attribute_types={

--- a/tests/snuba/api/endpoints/test_organization_events_ourlogs.py
+++ b/tests/snuba/api/endpoints/test_organization_events_ourlogs.py
@@ -268,3 +268,28 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase):
         )
         assert response.status_code == 200, response.content
         assert response.data["data"] == [{"message": "bar"}]
+
+    def test_count_meta_type_is_integer(self):
+        one_day_ago = before_now(days=1).replace(microsecond=0)
+
+        log1 = self.create_ourlog(
+            {"body": "foo"},
+            timestamp=one_day_ago,
+        )
+        self.store_ourlogs([log1])
+
+        request = {
+            "field": ["message", "count()"],
+            "project": self.project.id,
+            "dataset": self.dataset,
+        }
+
+        response = self.do_request(
+            {
+                **request,
+                "query": "timestamp:-2d",
+            }
+        )
+        assert response.status_code == 200, response.content
+        assert response.data["data"] == [{"message": "foo", "count()": 1}]
+        assert response.data["meta"]["fields"]["count()"] == "integer"

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries_logs.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries_logs.py
@@ -81,7 +81,7 @@ class OrganizationEventsStatsOurlogsMetricsEndpointTest(OrganizationEventsEndpoi
             confidence=[any_confidence if val else None for val in event_counts],
         )
         assert timeseries["meta"] == {
-            "valueType": "string",
+            "valueType": "integer",
             "interval": 3_600_000,
         }
 


### PR DESCRIPTION
Defining this as a `string` causes the aggregate not to render properly on the frontend.