### PR TITLE
fix(nav): Remove the current organization from the switch menu

### DIFF
--- a/static/app/views/nav/orgDropdown.tsx
+++ b/static/app/views/nav/orgDropdown.tsx
@@ -173,7 +173,9 @@ export function OrgDropdown({
               children: [
                 {
                   key: 'active-orgs',
-                  children: orderBy(activeOrgs, ['name']).map(makeOrganizationMenuItem),
+                  children: orderBy(activeOrgs, ['name'])
+                    .filter(org => org.slug !== organization.slug)
+                    .map(makeOrganizationMenuItem),
                 },
                 ...(inactiveOrgs.length === 0
                   ? []

--- a/static/app/views/nav/orgDropdown.tsx
+++ b/static/app/views/nav/orgDropdown.tsx
@@ -71,7 +71,7 @@ export function OrgDropdown({
 
   const {organizations} = useLegacyStore(OrganizationsStore);
   const [activeOrgs, inactiveOrgs] = partition(
-    organizations,
+    organizations.filter(org => org.slug !== organization.slug),
     org => org.status.id === 'active'
   );
 
@@ -173,9 +173,7 @@ export function OrgDropdown({
               children: [
                 {
                   key: 'active-orgs',
-                  children: orderBy(activeOrgs, ['name'])
-                    .filter(org => org.slug !== organization.slug)
-                    .map(makeOrganizationMenuItem),
+                  children: orderBy(activeOrgs, ['name']).map(makeOrganizationMenuItem),
                 },
                 ...(inactiveOrgs.length === 0
                   ? []


### PR DESCRIPTION
There is no need to switch to the org you're already in, so removing it from the switch menu.