### PR TITLE
feat(seer): Allow subscribing to seer webhooks on f/e

### DIFF
--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -544,7 +544,7 @@ export type AppOrProviderOrPlugin =
 /**
  * Webhooks and servicehooks
  */
-export type WebhookEvent = 'issue' | 'error' | 'comment';
+export type WebhookEvent = 'issue' | 'error' | 'comment' | 'seer';
 
 export type ServiceHook = {
   dateCreated: string;

--- a/static/app/views/settings/organizationDeveloperSettings/constants.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/constants.tsx
@@ -1,7 +1,8 @@
-export const EVENT_CHOICES = ['issue', 'error', 'comment'] as const;
+export const EVENT_CHOICES = ['issue', 'error', 'comment', 'seer'] as const;
 
 export const PERMISSIONS_MAP = {
   issue: 'Event',
   error: 'Event',
   comment: 'Event',
+  seer: 'Event',
 } as const;

--- a/static/app/views/settings/organizationDeveloperSettings/resourceSubscriptions.spec.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/resourceSubscriptions.spec.tsx
@@ -23,10 +23,11 @@ describe('Resource Subscriptions', function () {
         </Form>
       );
 
-      expect(screen.getAllByRole('checkbox')).toHaveLength(3);
+      expect(screen.getAllByRole('checkbox')).toHaveLength(4);
       expect(screen.getByRole('checkbox', {name: 'issue'})).toBeDisabled();
       expect(screen.getByRole('checkbox', {name: 'error'})).toBeDisabled();
       expect(screen.getByRole('checkbox', {name: 'comment'})).toBeDisabled();
+      expect(screen.getByRole('checkbox', {name: 'seer'})).toBeDisabled();
     });
 
     it('updates events state when new permissions props is passed', function () {

--- a/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.tsx
@@ -46,9 +46,7 @@ function SubscriptionBox({
     );
   } else if (resource === 'seer' && !features.includes('seer_webhooks')) {
     disabled = true;
-    message = t(
-      'Your organization does not have access to the seer subscription resource.'
-    );
+    message = t("Your organization can't subscribe to seer events just yet.");
   }
 
   if (webhookDisabled) {

--- a/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.tsx
@@ -44,7 +44,7 @@ function SubscriptionBox({
     message = t(
       'Your organization does not have access to the error subscription resource.'
     );
-  } else if (resource === 'seer' && !features.includes('seer_webhooks')) {
+  } else if (resource === 'seer' && !features.includes('seer-webhooks')) {
     disabled = true;
     message = t("Your organization can't subscribe to seer events just yet.");
   }
@@ -57,7 +57,7 @@ function SubscriptionBox({
     issue: `created, resolved, assigned, archived, unresolved`,
     error: 'created',
     comment: 'created, edited, deleted',
-    seer: 'root cause, solution generation, coding, and PR creation events',
+    seer: 'root_cause_started, root_cause_completed, solution_started, solution_completed, coding_started, coding_completed, pr_created',
   };
 
   return (

--- a/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.tsx
@@ -44,6 +44,11 @@ function SubscriptionBox({
     message = t(
       'Your organization does not have access to the error subscription resource.'
     );
+  } else if (resource === 'seer' && !features.includes('seer_webhooks')) {
+    disabled = true;
+    message = t(
+      'Your organization does not have access to the seer subscription resource.'
+    );
   }
 
   if (webhookDisabled) {
@@ -54,6 +59,7 @@ function SubscriptionBox({
     issue: `created, resolved, assigned, archived, unresolved`,
     error: 'created',
     comment: 'created, edited, deleted',
+    seer: 'root cause, solution generation, coding, and PR creation events',
   };
 
   return (


### PR DESCRIPTION
Shows a seer type to subscribe to on the integrations creation page + guards it via feature flag.
<img width="988" height="342" alt="CleanShot 2025-07-31 at 04 01 56@2x" src="https://github.com/user-attachments/assets/3ce135cb-4895-4dd5-97f9-3283ac48b98d" />
<img width="964" height="386" alt="CleanShot 2025-07-31 at 04 02 20@2x" src="https://github.com/user-attachments/assets/011d0b80-b6b3-4118-a6cb-e3bfa4fb04fc" />

