### PR TITLE
fix(replay): Disable text wrapping inside CountTooltipContent

### DIFF
--- a/static/app/components/replays/countTooltipContent.tsx
+++ b/static/app/components/replays/countTooltipContent.tsx
@@ -9,6 +9,7 @@ const CountTooltipContent = styled('dl')`
   text-align: left;
   align-items: start;
   margin-bottom: 0;
+  white-space: nowrap;
 `;
 
 export default CountTooltipContent;


### PR DESCRIPTION
**Before**
<img width="259" height="147" alt="SCR-20250723-jqst" src="https://github.com/user-attachments/assets/569b23a4-5d2c-4a11-8be9-e6a192fa933a" />

**After**
<img width="237" height="140" alt="SCR-20250723-jqlm" src="https://github.com/user-attachments/assets/59e8f74a-841d-44a9-8657-78ff1882ce81" />

Something about https://github.com/getsentry/sentry/pull/95614 caused the problem; i'm not sure what.