### PR TITLE
fix(router): Prevent routing to external links in dropdowns

### DIFF
--- a/static/app/utils/provideAriaRouter.tsx
+++ b/static/app/utils/provideAriaRouter.tsx
@@ -1,7 +1,9 @@
+import {useCallback} from 'react';
 import {useHref} from 'react-router-dom';
 import {RouterProvider as AriaRouterProvider} from '@react-aria/utils';
 
 import {useNavigate} from 'sentry/utils/useNavigate';
+
 /**
  * React aira has its own context for useTabs, useMenuItem, useLink, etc.
  * We need to provide the router instance so it knows how to navigate.
@@ -9,8 +11,27 @@ import {useNavigate} from 'sentry/utils/useNavigate';
  */
 export function ProvideAriaRouter({children}: {children: React.ReactNode}) {
   const navigate = useNavigate();
+
+  const handleNavigate = useCallback<typeof navigate>(
+    path => {
+      if (typeof path === 'number') {
+        navigate(path);
+        return;
+      }
+
+      const pathString = typeof path === 'string' ? path : path.pathname;
+      // Prevent navigation to external links via router
+      if (pathString?.startsWith('http')) {
+        return;
+      }
+
+      navigate(path);
+    },
+    [navigate]
+  );
+
   return (
-    <AriaRouterProvider navigate={navigate} useHref={useHref}>
+    <AriaRouterProvider navigate={handleNavigate} useHref={useHref}>
       {children}
     </AriaRouterProvider>
   );


### PR DESCRIPTION
Prevents calling useNavigate with links that cannot be navigated to because they are outside the app.

fixes part of JAVASCRIPT-2YR9
