### PR TITLE
chore(billing): remove spans abuse quota in sentry

### DIFF
--- a/src/sentry/quotas/base.py
+++ b/src/sentry/quotas/base.py
@@ -472,12 +472,6 @@ class Quota(Service):
                 scope=QuotaScope.PROJECT,
             ),
             AbuseQuota(
-                id="paspi",
-                option="project-abuse-quota.span-limit",
-                categories=[DataCategory.SPAN_INDEXED],
-                scope=QuotaScope.PROJECT,
-            ),
-            AbuseQuota(
                 id="pal",
                 option="project-abuse-quota.log-limit",
                 categories=[DataCategory.LOG_ITEM],

--- a/tests/sentry/quotas/test_redis.py
+++ b/tests/sentry/quotas/test_redis.py
@@ -162,21 +162,13 @@ class RedisQuotaTest(TestCase):
         assert quotas[4].window == 10
         assert quotas[4].reason_code == "project_abuse_limit"
 
-        assert quotas[5].id == "paspi"
+        assert quotas[5].id == "pal"
         assert quotas[5].scope == QuotaScope.PROJECT
         assert quotas[5].scope_id is None
-        assert quotas[5].categories == {DataCategory.SPAN_INDEXED}
-        assert quotas[5].limit == 6050
+        assert quotas[5].categories == {DataCategory.LOG_ITEM}
+        assert quotas[5].limit == 6060
         assert quotas[5].window == 10
         assert quotas[5].reason_code == "project_abuse_limit"
-
-        assert quotas[6].id == "pal"
-        assert quotas[6].scope == QuotaScope.PROJECT
-        assert quotas[6].scope_id is None
-        assert quotas[6].categories == {DataCategory.LOG_ITEM}
-        assert quotas[6].limit == 6060
-        assert quotas[6].window == 10
-        assert quotas[6].reason_code == "project_abuse_limit"
 
         expected_quotas: dict[tuple[QuotaScope, UseCaseID | None], str] = dict()
         for scope, prefix in [


### PR DESCRIPTION
This is being added in `getsentry`
See:
https://github.com/getsentry/getsentry/pull/17973
https://github.com/getsentry/sentry-options-automator/pull/4596
