### PR TITLE
fix(workflow-engine): Fix caching for `workflow_condition_group`.

### DIFF
--- a/src/sentry/workflow_engine/handlers/detector/base.py
+++ b/src/sentry/workflow_engine/handlers/detector/base.py
@@ -83,10 +83,7 @@ class DetectorHandler(abc.ABC, Generic[DataPacketType, DataPacketEvaluationType]
         if detector.workflow_condition_group_id is not None:
             try:
                 # Check if workflow_condition_group is already prefetched
-                if (
-                    hasattr(detector, "_prefetched_objects_cache")
-                    and "workflow_condition_group" in detector._prefetched_objects_cache
-                ):
+                if Detector.workflow_condition_group.is_cached(detector):
                     group = detector.workflow_condition_group
                 else:
                     group = DataConditionGroup.objects.get_from_cache(


### PR DESCRIPTION
`select_related` doesn't use `_prefetched_objects_cache`, and so this code didn't work. Fixed and added a test

<!-- Describe your PR here. -->