### PR TITLE
feat(spans-migration): Deprecate transactions dataset in discover post endpoint

### DIFF
--- a/src/sentry/discover/endpoints/serializers.py
+++ b/src/sentry/discover/endpoints/serializers.py
@@ -190,7 +190,7 @@ class DiscoverSavedQuerySerializer(serializers.Serializer):
             and dataset == DiscoverSavedQueryTypes.TRANSACTION_LIKE
         ):
             raise serializers.ValidationError(
-                "The Transactions dataset is being deprecated. Please use `Traces` to save new transaction queries."
+                f"The Transactions dataset is being deprecated. Please append the `is_transaction:true` filter in the Trace Explorer product in Sentry or use the `/organizations/{self.context['organization'].slug}/explore/saved/` endpoint with the filter to save new transaction queries."
             )
 
         return dataset

--- a/tests/snuba/api/endpoints/test_discover_saved_queries.py
+++ b/tests/snuba/api/endpoints/test_discover_saved_queries.py
@@ -736,8 +736,9 @@ class DiscoverSavedQueriesVersion2Test(DiscoverSavedQueryBase):
         assert data["version"] == 2
 
     def test_post_transactions_query_with_deprecation_flag(self):
-        with self.feature(self.feature_name) and self.feature(
-            "organizations:discover-saved-queries-deprecation"
+        with (
+            self.feature(self.feature_name),
+            self.feature("organizations:discover-saved-queries-deprecation"),
         ):
             response = self.client.post(
                 self.url,

--- a/tests/snuba/api/endpoints/test_discover_saved_queries.py
+++ b/tests/snuba/api/endpoints/test_discover_saved_queries.py
@@ -756,6 +756,6 @@ class DiscoverSavedQueriesVersion2Test(DiscoverSavedQueryBase):
         assert response.status_code == 400, response.content
         response_data = response.json()
         assert (
-            "The Transactions dataset is being deprecated. Please use `Traces` to save new transaction queries."
+            f"The Transactions dataset is being deprecated. Please append the `is_transaction:true` filter in the Trace Explorer product in Sentry or use the `/organizations/{self.org.slug}/explore/saved/` endpoint with the filter to save new transaction queries."
             in response_data["queryDataset"][0]
         )


### PR DESCRIPTION
As part of the transactions dataset deprecation across sentry we're deprecating the discover saved queries transactions dataset for post requests. It's under the same feature flag as the rest of the deprecation logic in the frontend so it will be rolled out together.

[ENG-4634](https://linear.app/getsentry/issue/ENG-4634/lock-api-for-saved-queries-to-prevent-transaction-queries)