### PR TITLE
chore(autofix): Clarify feedback button

### DIFF
--- a/static/app/components/events/autofix/autofixFeedback.tsx
+++ b/static/app/components/events/autofix/autofixFeedback.tsx
@@ -18,6 +18,7 @@ function AutofixFeedback() {
       size="xs"
       onClick={() =>
         openForm({
+          formTitle: t('Give feedback to the devs'),
           messagePlaceholder: t('How can we make Seer better for you?'),
           tags: {
             ['feedback.source']: 'issue_details_ai_autofix',
@@ -26,7 +27,7 @@ function AutofixFeedback() {
         })
       }
     >
-      {t('Contact Us')}
+      {t('Give Us Feedback')}
     </Button>
   );
 }

--- a/static/app/components/events/autofix/autofixFeedback.tsx
+++ b/static/app/components/events/autofix/autofixFeedback.tsx
@@ -26,7 +26,7 @@ function AutofixFeedback() {
         })
       }
     >
-      {t('Give Feedback')}
+      {t('Contact Us')}
     </Button>
   );
 }

--- a/static/app/components/events/autofix/autofixStartBox.tsx
+++ b/static/app/components/events/autofix/autofixStartBox.tsx
@@ -166,6 +166,7 @@ const InputWrapper = styled('form')`
 
 const StyledInput = styled(TextArea)`
   resize: none;
+  background: ${p => p.theme.background};
 
   border-color: ${p => p.theme.innerBorder};
   &:hover {

--- a/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
@@ -208,6 +208,9 @@ export function SeerDrawer({group, project, event}: SeerDrawerProps) {
             {label: t('Seer')},
           ]}
         />
+        <FeedbackWrapper>
+          <AutofixFeedback />
+        </FeedbackWrapper>
       </SeerDrawerHeader>
       {(!showWelcomeScreen || aiConfig.isAutofixSetupLoading) && (
         <SeerDrawerNavigator>
@@ -256,7 +259,6 @@ export function SeerDrawer({group, project, event}: SeerDrawerProps) {
                     icon={<IconSettings />}
                   />
                 </Feature>
-                <AutofixFeedback />
                 {aiConfig.hasAutofix && (
                   <Button
                     size="xs"
@@ -454,4 +456,9 @@ const ShortId = styled('div')`
 
 const ButtonBarWrapper = styled('div')`
   margin-left: auto;
+`;
+
+const FeedbackWrapper = styled('div')`
+  margin-left: auto;
+  margin-right: ${p => p.theme.space.md};
 `;

--- a/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
@@ -208,9 +208,13 @@ export function SeerDrawer({group, project, event}: SeerDrawerProps) {
             {label: t('Seer')},
           ]}
         />
-        <FeedbackWrapper>
-          <AutofixFeedback />
-        </FeedbackWrapper>
+        {!showWelcomeScreen &&
+          !aiConfig.isAutofixSetupLoading &&
+          !aiConfig.orgNeedsGenAiAcknowledgement && (
+            <FeedbackWrapper>
+              <AutofixFeedback />
+            </FeedbackWrapper>
+          )}
       </SeerDrawerHeader>
       {(!showWelcomeScreen || aiConfig.isAutofixSetupLoading) && (
         <SeerDrawerNavigator>


### PR DESCRIPTION
Move and rename feedback button to clarify that it's not for talking to the AI

<img width="774" height="138" alt="Screenshot 2025-07-23 at 11 35 50 AM" src="https://github.com/user-attachments/assets/d32b0636-0786-4717-9108-51d214a758a0" />
