### PR TITLE
ref(ourlogs): Bump refresh interval in tests

### DIFF
--- a/static/app/views/explore/logs/logsAutoRefresh.spec.tsx
+++ b/static/app/views/explore/logs/logsAutoRefresh.spec.tsx
@@ -34,7 +34,7 @@ describe('LogsAutoRefresh Integration Tests', () => {
       query: {
         // Toggle is disabled if sort is not a timestamp
         [LOGS_SORT_BYS_KEY]: '-timestamp',
-        [LOGS_REFRESH_INTERVAL_KEY]: '10', // Fast refresh for testing
+        [LOGS_REFRESH_INTERVAL_KEY]: '200', // Fast refresh for testing
       },
     },
     route: '/organizations/:orgId/explore/logs/',


### PR DESCRIPTION
### Summary
This should stop the timer being called before the jest assertion gets made.
