### PR TITLE
ref(replay): show end timestamp on chapter title

### DIFF
--- a/static/app/views/replays/detail/ai/chapterList.tsx
+++ b/static/app/views/replays/detail/ai/chapterList.tsx
@@ -170,8 +170,8 @@ function ChapterRow({
               onClick={event => {
                 onClickChapterTimestamp(event, start);
               }}
-            />{' '}
-            -{' '}
+            />
+            -
             <TimestampButton
               startTimestampMs={replay?.getStartTimestampMs() ?? 0}
               timestampMs={end}

--- a/static/app/views/replays/detail/ai/chapterList.tsx
+++ b/static/app/views/replays/detail/ai/chapterList.tsx
@@ -170,6 +170,14 @@ function ChapterRow({
               onClick={event => {
                 onClickChapterTimestamp(event, start);
               }}
+            />{' '}
+            -{' '}
+            <TimestampButton
+              startTimestampMs={replay?.getStartTimestampMs() ?? 0}
+              timestampMs={end}
+              onClick={event => {
+                onClickChapterTimestamp(event, end);
+              }}
             />
           </ReplayTimestamp>
         </ChapterTitle>
@@ -370,7 +378,9 @@ const ChapterTitle = styled('div')`
 `;
 
 // Copied from breadcrumbItem
-const ReplayTimestamp = styled('div')`
+const ReplayTimestamp = styled('span')`
+  display: flex;
+  gap: ${space(0.5)};
   color: ${p => p.theme.textColor};
   font-size: ${p => p.theme.fontSize.sm};
   font-weight: ${p => p.theme.fontWeight.normal};


### PR DESCRIPTION
closes https://linear.app/getsentry/issue/REPLAY-490/improve-ui-of-chapters-to-include-more-information-about-chapter

<img width="697" height="410" alt="SCR-20250723-lnnn" src="https://github.com/user-attachments/assets/bfd3ab01-713c-4278-b233-ee1cb64c8829" />
