### PR TITLE
feat(grouping): Add ability to do fast snapshots locally

### DIFF
--- a/tests/sentry/grouping/__init__.py
+++ b/tests/sentry/grouping/__init__.py
@@ -36,6 +36,13 @@ FINGERPRINT_INPUTS_DIR = path.join(path.dirname(__file__), "fingerprint_inputs")
 MANUAL_SAVE_CONFIGS = set(CONFIGURATIONS.keys()) - {DEFAULT_GROUPING_CONFIG}
 FULL_PIPELINE_CONFIGS = {DEFAULT_GROUPING_CONFIG}
 
+# When regenerating snapshots locally, you can set `SENTRY_SNAPSHOTS_WRITEBACK=1` and
+# `SENTRY_FAST_GROUPING_SNAPSHOTS=1` in the environment to update snapshots automatically and run
+# all snapshots through the faster, non-DB-involving process.
+if os.environ.get("SENTRY_FAST_GROUPING_SNAPSHOTS") and not os.environ.get("GITHUB_ACTIONS"):
+    FULL_PIPELINE_CONFIGS.remove(DEFAULT_GROUPING_CONFIG)
+    MANUAL_SAVE_CONFIGS.add(DEFAULT_GROUPING_CONFIG)
+
 # Create a grouping config to be used only in tests, in which message parameterization is turned
 # off. This lets us easily force an event to have different hashes for different configs. (We use a
 # purposefully old date so that it can be used as a secondary config.)

--- a/tests/sentry/grouping/test_grouphash_metadata.py
+++ b/tests/sentry/grouping/test_grouphash_metadata.py
@@ -48,8 +48,9 @@ def test_variants_with_manual_save(
     process.
 
     Because manually cherry-picking only certain parts of the save process to run makes us much more
-    likely to fall out of sync with reality, for safety we only do this when testing older
-    grouping configs.
+    likely to fall out of sync with reality, when we're in CI, for safety we only do this when
+    testing older grouping configs. Locally, if `SENTRY_FAST_GROUPING_SNAPSHOTS` is set in the
+    environment, this is used for the default confing, too.
     """
     event = grouping_input.create_event(config_name, use_full_ingest_pipeline=False)
 
@@ -73,8 +74,9 @@ def test_variants_with_full_pipeline(
 
     This is the most realistic way to test, but it's also slow, because it requires the overhead of
     set-up/tear-down/general interaction with our full postgres database. We therefore only do it
-    when testing the current grouping config, and rely on a much faster manual test (above) for
-    previous grouping configs.
+    when testing the current grouping config in CI, and rely on a much faster manual test (above)
+    when testing previous grouping configs. (When testing locally, the faster test can be used for
+    the default config as well if `SENTRY_FAST_GROUPING_SNAPSHOTS` is set in the environment.)
     """
 
     event = grouping_input.create_event(

--- a/tests/sentry/grouping/test_variants.py
+++ b/tests/sentry/grouping/test_variants.py
@@ -35,8 +35,9 @@ def test_variants_with_manual_save(
     Run the variant snapshot tests using a minimal (and much more performant) save process.
 
     Because manually cherry-picking only certain parts of the save process to run makes us much more
-    likely to fall out of sync with reality, for safety we only do this when testing older grouping
-    configs.
+    likely to fall out of sync with reality, when we're in CI, for safety we only do this when
+    testing older grouping configs. Locally, if `SENTRY_FAST_GROUPING_SNAPSHOTS` is set in the
+    environment, this is used for the default confing, too.
     """
     event = grouping_input.create_event(config_name, use_full_ingest_pipeline=False)
 
@@ -64,8 +65,9 @@ def test_variants_with_full_pipeline(
 
     This is the most realistic way to test, but it's also slow, because it requires the overhead of
     set-up/tear-down/general interaction with our full postgres database. We therefore only do it
-    when testing the current grouping config, and rely on a much faster manual test (below) for
-    previous grouping configs.
+    when testing the current grouping config in CI, and rely on a much faster manual test (above)
+    when testing previous grouping configs. (When testing locally, the faster test can be used for
+    the default config as well if `SENTRY_FAST_GROUPING_SNAPSHOTS` is set in the environment.)
     """
 
     event = grouping_input.create_event(


### PR DESCRIPTION
When creating snapshots for our grouping tests, we have two ways we do it: cherry-picking parts of the save pipeline in such a way as to not touch the database, and using the full pipeline, which does. The advantage of the former method is that it's quite fast. The advantage of the latter method is that it better mimics what happens in prod. To try to get the best of both worlds, we use the slower/safer method when testing the current default config, and the faster method when testing older configs.

This is all well and good, but it makes regenerating snapshots for the default config locally kind of a pain, because it really is a lot slower than for the other configs. For longer than I care to admit, I've therefore been commenting out the slow test, and adding the default config to the list of configs that use the fast test every single time I want to run them which is... a lot. (It's an easy way to just run the grouping code to check stuff, and it's a useful gut check to know that a bunch of different inputs work with whatever change I'm working on before I actually write unit tests for it.)

However, [a recent PR](https://github.com/getsentry/sentry/pull/96054) pulled the sets of grouping configs used for the fast and slow versions of the tests into variables, and solved the problem of snapshot tests running against an empty set of configs (which the slow test does if the default config is moved to the fast test list). It's therefore now really easy to do automatically what I've been doing manually, based on an environment variable, which this PR does.