### PR TITLE
fix(replay): Parse dates and format them with timezones before requesting bulk-delete

### DIFF
--- a/static/app/components/organizations/pageFilters/parse.tsx
+++ b/static/app/components/organizations/pageFilters/parse.tsx
@@ -115,7 +115,7 @@ function parseUtcValue(utc: boolean | SingleParamValue) {
  *
  * Undefined and null inputs are returned as undefined.
  */
-function getUtcValue(maybe: boolean | ParamValue) {
+export function getUtcValue(maybe: boolean | ParamValue) {
   const result = Array.isArray(maybe)
     ? maybe.find(needle => !!parseUtcValue(needle))
     : maybe;

--- a/static/app/components/replays/bulkDelete/replayBulkDeleteAuditLogTable.tsx
+++ b/static/app/components/replays/bulkDelete/replayBulkDeleteAuditLogTable.tsx
@@ -54,14 +54,9 @@ export default function ReplayBulkDeleteAuditLogTable({
                 </dd>
                 <dt>{t('Date Range')}</dt>
                 <dd>
-                  <code>
-                    <DateTime date={row.rangeStart} />
-                  </code>
+                  <code>{row.rangeStart}</code>
                   <br />
-
-                  <code>
-                    <DateTime date={row.rangeEnd} />
-                  </code>
+                  <code>{row.rangeEnd}</code>
                 </dd>
                 <dt>{t('Environments')}</dt>
                 <dd>

--- a/static/app/components/replays/table/deleteReplays.tsx
+++ b/static/app/components/replays/table/deleteReplays.tsx
@@ -9,6 +9,7 @@ import {UserAvatar} from 'sentry/components/core/avatar/userAvatar';
 import {Button} from 'sentry/components/core/button';
 import {Flex} from 'sentry/components/core/layout/flex';
 import {Link} from 'sentry/components/core/link';
+import {Text} from 'sentry/components/core/text';
 import {Tooltip} from 'sentry/components/core/tooltip';
 import Duration from 'sentry/components/duration/duration';
 import ErrorBoundary from 'sentry/components/errorBoundary';
@@ -153,6 +154,9 @@ function ReplayQueryPreview({
         {t('Replays matching the following query will be deleted')}
       </Title>
       <KeyValueData.Card contentItems={contentItems} />
+      <Text size="sm" color="subText">
+        All dates and times are in UTC.
+      </Text>
     </Fragment>
   );
 }

--- a/static/app/components/replays/table/deleteReplays.tsx
+++ b/static/app/components/replays/table/deleteReplays.tsx
@@ -31,7 +31,9 @@ import useProjectFromId from 'sentry/utils/useProjectFromId';
 import type {ReplayListRecord} from 'sentry/views/replays/types';
 
 interface Props {
-  queryOptions: QueryKeyEndpointOptions | undefined;
+  queryOptions:
+    | QueryKeyEndpointOptions<unknown, Record<string, string>, unknown>
+    | undefined;
   replays: ReplayListRecord[];
   selectedIds: 'all' | string[];
 }

--- a/static/app/utils/replays/hooks/useDeleteReplays.tsx
+++ b/static/app/utils/replays/hooks/useDeleteReplays.tsx
@@ -15,10 +15,10 @@ interface Props {
 }
 
 export type ReplayBulkDeletePayload = {
-  environments: string[];
+  environments: string | string[] | undefined;
   query: string;
-  rangeEnd: string;
-  rangeStart: string;
+  rangeEnd: string | undefined;
+  rangeStart: string | undefined;
 };
 
 type Vars = [ReplayBulkDeletePayload];
@@ -52,7 +52,10 @@ export default function useDeleteReplays({projectSlug}: Props) {
   });
 
   const queryOptionsToPayload = useCallback(
-    (selectedIds: 'all' | string[], queryOptions: QueryKeyEndpointOptions) => {
+    (
+      selectedIds: 'all' | string[],
+      queryOptions: QueryKeyEndpointOptions<unknown, Record<string, string>, unknown>
+    ): ReplayBulkDeletePayload => {
       const environments = queryOptions?.query?.environment ?? [];
       const {start, end} = queryOptions?.query?.statsPeriod
         ? parseStatsPeriod(queryOptions?.query?.statsPeriod)

--- a/static/app/utils/replays/hooks/useDeleteReplays.tsx
+++ b/static/app/utils/replays/hooks/useDeleteReplays.tsx
@@ -64,8 +64,8 @@ export default function useDeleteReplays({projectSlug}: Props) {
           selectedIds === 'all'
             ? (queryOptions?.query?.query ?? '')
             : `id:[${selectedIds.join(',')}]`,
-        rangeEnd: new Date(end).toISOString(),
-        rangeStart: new Date(start).toISOString(),
+        rangeStart: start ? new Date(start).toISOString() : start,
+        rangeEnd: end ? new Date(end).toISOString() : end,
       };
     },
     [project?.environments]

--- a/static/app/utils/replays/hooks/useDeleteReplays.tsx
+++ b/static/app/utils/replays/hooks/useDeleteReplays.tsx
@@ -64,8 +64,8 @@ export default function useDeleteReplays({projectSlug}: Props) {
           selectedIds === 'all'
             ? (queryOptions?.query?.query ?? '')
             : `id:[${selectedIds.join(',')}]`,
-        rangeEnd: end,
-        rangeStart: start,
+        rangeEnd: new Date(end).toISOString(),
+        rangeStart: new Date(start).toISOString(),
       };
     },
     [project?.environments]

--- a/static/app/utils/replays/hooks/useDeleteReplays.tsx
+++ b/static/app/utils/replays/hooks/useDeleteReplays.tsx
@@ -80,11 +80,11 @@ export default function useDeleteReplays({projectSlug}: Props) {
             : `id:[${selectedIds.join(',')}]`,
         rangeStart: getDateWithTimezoneInUtc(
           getDateFromTimestamp(start) ?? new Date(),
-          Boolean(getUtcValue(normalizedQuery.utc))
+          getUtcValue(normalizedQuery.utc) === 'true'
         ).toISOString(),
         rangeEnd: getDateWithTimezoneInUtc(
           getDateFromTimestamp(end) ?? new Date(),
-          Boolean(getUtcValue(normalizedQuery.utc))
+          getUtcValue(normalizedQuery.utc) === 'true'
         ).toISOString(),
       };
     },

--- a/static/app/utils/replays/useDeleteReplays.spec.tsx
+++ b/static/app/utils/replays/useDeleteReplays.spec.tsx
@@ -1,0 +1,106 @@
+import type {ReactNode} from 'react';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {makeTestQueryClient} from 'sentry-test/queryClient';
+import {renderHook} from 'sentry-test/reactTestingLibrary';
+
+import ConfigStore from 'sentry/stores/configStore';
+import ProjectsStore from 'sentry/stores/projectsStore';
+import {QueryClientProvider} from 'sentry/utils/queryClient';
+import useDeleteReplays from 'sentry/utils/replays/hooks/useDeleteReplays';
+import {OrganizationContext} from 'sentry/views/organizationContext';
+
+function wrapper({children}: {children?: ReactNode}) {
+  const org = OrganizationFixture();
+  return (
+    <QueryClientProvider client={makeTestQueryClient()}>
+      <OrganizationContext value={org}>{children}</OrganizationContext>
+    </QueryClientProvider>
+  );
+}
+
+describe('useDeleteReplays', () => {
+  describe('queryOptionsToPayload', () => {
+    const project = ProjectFixture();
+    const projectSlug = project.slug;
+
+    beforeEach(() => {
+      const configstate = ConfigStore.getState();
+      ConfigStore.loadInitialData({
+        ...configstate,
+        user: {
+          ...configstate.user,
+          options: {
+            ...configstate.user?.options,
+            timezone: 'America/New_York',
+          },
+        },
+      });
+
+      ProjectsStore.loadInitialData([project]);
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/projects/',
+        body: [project],
+      });
+    });
+
+    it('should parse a statsPeriod into rangeStart & rangeEnd', () => {
+      const {result} = renderHook(useDeleteReplays, {
+        wrapper,
+        initialProps: {projectSlug},
+      });
+
+      expect(
+        result.current.queryOptionsToPayload(['1', '2'], {
+          query: {
+            statsPeriod: '1d',
+          },
+        })
+      ).toEqual({
+        rangeStart: '2017-10-16T02:41:20.000Z',
+        rangeEnd: '2017-10-17T02:41:20.000Z',
+        environments: [],
+        query: 'id:[1,2]',
+      });
+    });
+
+    it('should parse a start & end into rangeStart & rangeEnd', () => {
+      const {result} = renderHook(useDeleteReplays, {
+        wrapper,
+        initialProps: {projectSlug},
+      });
+
+      // Users timezone: 2:41 becomes 6:41 UTC
+      expect(
+        result.current.queryOptionsToPayload(['1', '2'], {
+          query: {
+            start: '2017-10-16T02:41:20',
+            end: '2017-10-17T02:41:20',
+          },
+        })
+      ).toEqual({
+        rangeStart: '2017-10-16T06:41:20.000Z',
+        rangeEnd: '2017-10-17T06:41:20.000Z',
+        environments: [],
+        query: 'id:[1,2]',
+      });
+
+      // UTC: 2:41 stays 2:41 UTC
+      expect(
+        result.current.queryOptionsToPayload(['1', '2'], {
+          query: {
+            start: '2017-10-16T02:41:20',
+            end: '2017-10-17T02:41:20',
+            utc: 'true',
+          },
+        })
+      ).toEqual({
+        rangeStart: '2017-10-16T02:41:20.000Z',
+        rangeEnd: '2017-10-17T02:41:20.000Z',
+        environments: [],
+        query: 'id:[1,2]',
+      });
+    });
+  });
+});

--- a/static/app/utils/replays/useDeleteReplays.spec.tsx
+++ b/static/app/utils/replays/useDeleteReplays.spec.tsx
@@ -45,6 +45,20 @@ describe('useDeleteReplays', () => {
       });
     });
 
+    it('should parse a an empty queryOptions into default 14d rangeStart & rangeEnd', () => {
+      const {result} = renderHook(useDeleteReplays, {
+        wrapper,
+        initialProps: {projectSlug},
+      });
+
+      expect(result.current.queryOptionsToPayload(['1', '2'], {})).toEqual({
+        rangeStart: '2017-10-03T02:41:20.000Z',
+        rangeEnd: '2017-10-17T02:41:20.000Z',
+        environments: [],
+        query: 'id:[1,2]',
+      });
+    });
+
     it('should parse a statsPeriod into rangeStart & rangeEnd', () => {
       const {result} = renderHook(useDeleteReplays, {
         wrapper,
@@ -53,9 +67,7 @@ describe('useDeleteReplays', () => {
 
       expect(
         result.current.queryOptionsToPayload(['1', '2'], {
-          query: {
-            statsPeriod: '1d',
-          },
+          query: {statsPeriod: '1d'},
         })
       ).toEqual({
         rangeStart: '2017-10-16T02:41:20.000Z',


### PR DESCRIPTION
This is converting to a string format that includes the timezone:

**Before**
<img width="638" height="328" alt="SCR-20250723-ltyl" src="https://github.com/user-attachments/assets/dbf5f7cc-4567-4bae-aa96-ff4d331f1942" />


**After**
<img width="632" height="358" alt="SCR-20250725-ngzm" src="https://github.com/user-attachments/assets/cf620da8-a8f7-4bab-ad92-3c5c8f6a0be2" />

Note that i'm not trying to be fancy when i render the values inside this modal or audit log. I like that they're as raw as possible to match what's being passed into the backend.

The audit log removed `<DateTime>` to keep things accurate:
<img width="638" height="193" alt="SCR-20250725-nhbt" src="https://github.com/user-attachments/assets/ea335cca-a3cd-489c-9d3c-9125fcc15630" />
