### PR TITLE
fix(otlp): Prevent span buffer from erroring if span link attributes are `None`

### DIFF
--- a/src/sentry/spans/consumers/process_segments/convert.py
+++ b/src/sentry/spans/consumers/process_segments/convert.py
@@ -128,14 +128,15 @@ def _sanitize_span_link(link: SpanLink) -> SpanLink:
     prevent unbounded storage, we only support well-known attributes.
     """
     allowed_attributes = {}
+    attributes = link.get("attributes", {}) or {}
 
     # In the future, we want Relay to drop unsupported attributes, so there
     # might be an intermediary state where there is a pre-existing dropped
     # attributes count. Respect that count, if it's present. It should always be
     # an integer.
-    dropped_attributes_count = link.get("attributes", {}).get("sentry.dropped_attributes_count", 0)
+    dropped_attributes_count = attributes.get("sentry.dropped_attributes_count", 0)
 
-    for key, value in link.get("attributes", {}).items():
+    for key, value in attributes.items():
         if key in ALLOWED_LINK_ATTRIBUTE_KEYS:
             allowed_attributes[key] = value
         else:

--- a/tests/sentry/spans/consumers/process_segments/test_convert.py
+++ b/tests/sentry/spans/consumers/process_segments/test_convert.py
@@ -170,6 +170,7 @@ def test_convert_span_links_to_json():
     message = {
         **SPAN_KAFKA_MESSAGE,
         "links": [
+            # A link with all properties
             {
                 "trace_id": "d099bf9ad5a143cf8f83a98081d0ed3b",
                 "span_id": "8873a98879faf06d",
@@ -180,12 +181,14 @@ def test_convert_span_links_to_json():
                     "parent_depth": 17,
                     "confidence": "high",
                 },
-            }
+            },
+            # A link with missing optional properties
+            {"trace_id": "d099bf9ad5a143cf8f83a98081d0ed3b", "span_id": "873a988879faf06d"},
         ],
     }
 
     item = convert_span_to_item(cast(Span, message))
 
     assert item.attributes.get("sentry.links") == AnyValue(
-        string_value='[{"trace_id":"d099bf9ad5a143cf8f83a98081d0ed3b","span_id":"8873a98879faf06d","sampled":true,"attributes":{"sentry.link.type":"parent","sentry.dropped_attributes_count":4}}]'
+        string_value='[{"trace_id":"d099bf9ad5a143cf8f83a98081d0ed3b","span_id":"8873a98879faf06d","sampled":true,"attributes":{"sentry.link.type":"parent","sentry.dropped_attributes_count":4}},{"trace_id":"d099bf9ad5a143cf8f83a98081d0ed3b","span_id":"873a988879faf06d"}]'
     )


### PR DESCRIPTION
This is a rare case. As far as I can tell, it happens occasionally with Prisma interactive transaction spans, which have, mysteriously, links with `null` attributes. This shouldn't really be possible according to the schema, but it's _happening_, and reality is the _real_ schema.

Adding some error handling here, and updating the Kafka schema definitions in https://github.com/getsentry/sentry-kafka-schemas/pull/428

Closes SENTRY-48Q0