### PR TITLE
fix(invites): error message for emails with pending invites

### DIFF
--- a/src/sentry/api/endpoints/organization_member/index.py
+++ b/src/sentry/api/endpoints/organization_member/index.py
@@ -94,6 +94,8 @@ class OrganizationMemberRequestSerializer(serializers.Serializer):
         )
 
         if queryset.filter(invite_status=InviteStatus.APPROVED.value).exists():
+            if queryset.filter(user_id__isnull=True).exists():
+                raise MemberConflictValidationError("The user %s has already been invited" % email)
             raise MemberConflictValidationError("The user %s is already a member" % email)
 
         if not self.context.get("allow_existing_invite_request"):

--- a/src/sentry/api/endpoints/organization_member/index.py
+++ b/src/sentry/api/endpoints/organization_member/index.py
@@ -92,9 +92,10 @@ class OrganizationMemberRequestSerializer(serializers.Serializer):
             Q(email=email) | Q(user_id__in=[u.id for u in users]),
             organization=self.context["organization"],
         )
+        approved_queryset = queryset.filter(invite_status=InviteStatus.APPROVED.value)
 
-        if queryset.filter(invite_status=InviteStatus.APPROVED.value).exists():
-            if queryset.filter(user_id__isnull=True).exists():
+        if approved_queryset.exists():
+            if approved_queryset.filter(user_id__isnull=True).exists():
                 raise MemberConflictValidationError("The user %s has already been invited" % email)
             raise MemberConflictValidationError("The user %s is already a member" % email)
 

--- a/tests/sentry/api/endpoints/test_organization_member_index.py
+++ b/tests/sentry/api/endpoints/test_organization_member_index.py
@@ -80,7 +80,7 @@ class OrganizationMemberRequestSerializerTest(TestCase):
 
         serializer = OrganizationMemberRequestSerializer(context=context, data=data)
         assert not serializer.is_valid()
-        assert serializer.errors == {"email": [f"The user {user.email} is already a member"]}
+        assert serializer.errors == {"email": [f"The user {user.email} has already been invited"]}
 
         request = self.make_request(user=user)
 


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/RTC-1083/improve-error-message-for-user-with-pendingexpired-invite-in-invite

<img width="444" height="221" alt="Screenshot 2025-07-23 at 1 29 51 PM" src="https://github.com/user-attachments/assets/285009e4-3ecd-4e4c-893e-105b45b1933a" />
