### PR TITLE
fix(dashboards): Filter out current dashboard from add to dashboard options

### DIFF
--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.spec.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.spec.tsx
@@ -79,7 +79,15 @@ describe('add to dashboard modal', () => {
 
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/dashboards/',
-      body: [{...testDashboardListItem, widgetDisplay: [DisplayType.AREA]}],
+      body: [
+        {...testDashboardListItem, widgetDisplay: [DisplayType.AREA]},
+        {
+          ...testDashboardListItem,
+          title: 'Other Dashboard',
+          id: '2',
+          widgetDisplay: [DisplayType.AREA],
+        },
+      ],
     });
 
     MockApiClient.addMockResponse({
@@ -589,5 +597,38 @@ describe('add to dashboard modal', () => {
 
     expect(screen.getByRole('button', {name: 'Add + Stay on this Page'})).toBeDisabled();
     expect(screen.getByRole('button', {name: 'Open in Widget Builder'})).toBeEnabled();
+  });
+
+  it('does not show the current dashboard in the list of options', async () => {
+    render(
+      <AddToDashboardModal
+        Header={stubEl}
+        Footer={stubEl as ModalRenderProps['Footer']}
+        Body={stubEl as ModalRenderProps['Body']}
+        CloseButton={stubEl}
+        closeModal={() => undefined}
+        organization={initialData.organization}
+        widget={widget}
+        selection={defaultSelection}
+        router={initialData.router}
+        location={LocationFixture({pathname: '/organizations/org-slug/dashboard/1/'})}
+      />,
+      {
+        initialRouterConfig: {
+          route: '/organizations/:orgId/dashboard/:dashboardId/',
+          location: {
+            pathname: '/organizations/org-slug/dashboard/1/',
+          },
+        },
+      }
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Select Dashboard')).toBeEnabled();
+    });
+
+    await userEvent.click(screen.getByText('Select Dashboard'));
+    expect(screen.getByText('Other Dashboard')).toBeInTheDocument();
+    expect(screen.queryByText('Test Dashboard')).not.toBeInTheDocument();
   });
 });

--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
@@ -26,6 +26,7 @@ import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhan
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import useApi from 'sentry/utils/useApi';
 import {useNavigate} from 'sentry/utils/useNavigate';
+import {useParams} from 'sentry/utils/useParams';
 import {IndexedEventsSelectionAlert} from 'sentry/views/dashboards/indexedEventsSelectionAlert';
 import type {
   DashboardDetails,
@@ -115,6 +116,8 @@ function AddToDashboardModal({
   );
   const [orderBy, setOrderBy] = useState<string>();
   const [tableWidths, setTableWidths] = useState<number[]>();
+
+  const {dashboardId: currentDashboardId} = useParams<{dashboardId: string}>();
 
   const handleWidgetTableSort = (sort: Sort) => {
     const newOrderBy = `${sort.kind === 'desc' ? '-' : ''}${sort.field}`;
@@ -256,19 +259,24 @@ function AddToDashboardModal({
         label: t('+ Create New Dashboard'),
         value: 'new',
       },
-      ...dashboards.map(({title, id, widgetDisplay}) => ({
-        label: title,
-        value: id,
-        disabled: widgetDisplay.length >= MAX_WIDGETS,
-        tooltip:
-          widgetDisplay.length >= MAX_WIDGETS &&
-          tct('Max widgets ([maxWidgets]) per dashboard reached.', {
-            maxWidgets: MAX_WIDGETS,
-          }),
-        tooltipOptions: {position: 'right'},
-      })),
+      ...dashboards
+        .filter(dashboard =>
+          // if adding from a dashboard, currentDashboardId will be set and we'll remove it from the list of options
+          currentDashboardId ? dashboard.id !== currentDashboardId : true
+        )
+        .map(({title, id, widgetDisplay}) => ({
+          label: title,
+          value: id,
+          disabled: widgetDisplay.length >= MAX_WIDGETS,
+          tooltip:
+            widgetDisplay.length >= MAX_WIDGETS &&
+            tct('Max widgets ([maxWidgets]) per dashboard reached.', {
+              maxWidgets: MAX_WIDGETS,
+            }),
+          tooltipOptions: {position: 'right'},
+        })),
     ].filter(Boolean) as Array<SelectValue<string>>;
-  }, [allowCreateNewDashboard, dashboards]);
+  }, [allowCreateNewDashboard, currentDashboardId, dashboards]);
 
   const widgetLegendState = new WidgetLegendSelectionState({
     location,


### PR DESCRIPTION
Added logic in the add to dashboard modal that looks for a `dashboardId` in the URL params and will filter out the dashboard accordingly. I've done it this way so we don't have to pass any more props in but if that's preferred I can implement it that way. 

Addresses DAIN-777
