### PR TITLE
ref(grouping): Remove `with_context_line_file_origin_bug` behavior

### DIFF
--- a/src/sentry/grouping/strategies/configurations.py
+++ b/src/sentry/grouping/strategies/configurations.py
@@ -44,8 +44,6 @@ BASE_STRATEGY = create_strategy_configuration_class(
         "contextline_platforms": ("javascript", "node", "python", "php", "ruby"),
         # This detects anonymous classes in PHP code.
         "php_detect_anonymous_classes": True,
-        # Turns on a bug that was present in some variants
-        "with_context_line_file_origin_bug": False,
         # Turns on falling back to exception values when there
         # is no stacktrace.
         "with_exception_value_fallback": True,

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -392,16 +392,14 @@ def get_contextline_component(
     if line:
         if len(frame.context_line) > 120:
             context_line_component.update(hint="discarded because line too long", contributes=False)
-        elif get_behavior_family_for_platform(platform) == "javascript":
-            if context["with_context_line_file_origin_bug"]:
-                if has_url_origin(frame.abs_path, allow_file_origin=True):
-                    context_line_component.update(
-                        hint="discarded because from URL origin", contributes=False
-                    )
-            elif not function and has_url_origin(frame.abs_path):
-                context_line_component.update(
-                    hint="discarded because from URL origin and no function", contributes=False
-                )
+        elif (
+            get_behavior_family_for_platform(platform) == "javascript"
+            and not function
+            and has_url_origin(frame.abs_path)
+        ):
+            context_line_component.update(
+                hint="discarded because from URL origin and no function", contributes=False
+            )
 
     return context_line_component
 


### PR DESCRIPTION
A few years ago, we discovered a bug in our grouping code, having to do with whether or not to consider the context line in certain javascript frames. In order to not create new groups by fixing it, we made a new config with the fix, and added a `with_context_line_file_origin_bug` switch to turn the fix off in the existing config and on in all future configs.

But as they say, the future is now. We have since migrated all projects off of the buggy config, which means we can remove the switch and the buggy behavior it was preserving.