### PR TITLE
chore(performance): remove related issues table flag from registration

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -387,8 +387,6 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:insights-chart-actions", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable access to insights metrics alerts
     manager.add("organizations:insights-alerts", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable Related Issues table in Insights modules
-    manager.add("organizations:insights-related-issues-table", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable access to Mobile Screens insights module
     manager.add("organizations:insights-mobile-screens-module", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Removes performance landing page from sidebar and updates transaction summary breadcrumbs for insights


### PR DESCRIPTION
Cleanup from https://github.com/getsentry/sentry-options-automator/pull/4629 and https://github.com/getsentry/sentry/pull/96169

Flag is no longer used anywhere and the feature is fully rolled out, so cleaning up the flag registration.