### PR TITLE
fix(test): thread leak: organization trace thread pool

### DIFF
--- a/src/sentry/api/endpoints/organization_trace.py
+++ b/src/sentry/api/endpoints/organization_trace.py
@@ -334,8 +334,7 @@ class OrganizationTraceEndpoint(OrganizationEventsV2EndpointBase):
         occurrence_query = self.perf_issues_query(snuba_params, trace_id)
 
         # 1 worker each for spans, errors, performance issues
-        query_thread_pool = ThreadPoolExecutor(thread_name_prefix=__name__, max_workers=3)
-        with query_thread_pool:
+        with ThreadPoolExecutor(thread_name_prefix=__name__, max_workers=3) as query_thread_pool:
             spans_future = query_thread_pool.submit(
                 run_trace_query,
                 trace_id,


### PR DESCRIPTION
Replace module-level ThreadPoolExecutor instances with local instances
that are properly closed using context managers. Module-level thread
pools cause thread leaks that lead to test flakiness and unhelpful
nondeterminism in production. While the production cost of spinning up
thread workers is minimal, proper cleanup ensures consistent behavior
and prevents resource accumulation over time.
