### PR TITLE
Add feature flags settings files to the replay-frontend codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -317,6 +317,7 @@ tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py     @ge
 /static/app/views/issueDetails/groupDistributionsDrawer.tsx     @getsentry/replay-frontend
 /static/app/views/issueDetails/groupFeatureFlags/               @getsentry/replay-frontend
 /static/app/views/issueDetails/groupTags/                       @getsentry/replay-frontend
+/static/app/views/settings/featureFlags/                        @getsentry/replay-frontend
 ## End of Flags
 
 


### PR DESCRIPTION
Adds missing files (feature flags settings) to @getsentry/replay-frontend in CODEOWNERS.