### PR TITLE
fix(aci): replace snake case with camel case in automation builder

### DIFF
--- a/static/app/types/workflowEngine/actions.tsx
+++ b/static/app/types/workflowEngine/actions.tsx
@@ -18,10 +18,10 @@ export interface TicketCreationAction extends Action {
 }
 
 export interface ActionConfig {
-  target_type: ActionTarget | null;
-  sentry_app_identifier?: SentryAppIdentifier;
-  target_display?: string;
-  target_identifier?: string;
+  targetType: ActionTarget | null;
+  sentryAppIdentifier?: SentryAppIdentifier;
+  targetDisplay?: string;
+  targetIdentifier?: string;
 }
 
 export enum ActionTarget {

--- a/static/app/views/automations/components/actionFilters/ageComparison.tsx
+++ b/static/app/views/automations/components/actionFilters/ageComparison.tsx
@@ -27,8 +27,8 @@ export function AgeComparisonDetails({condition}: AgeComparisonDetailsProps) {
   return tct('The issue is [comparisonType] [value] [time]', {
     comparisonType:
       AGE_COMPARISON_CHOICES.find(
-        choice => choice.value === condition.comparison.comparison_type
-      )?.label || condition.comparison.comparison_type,
+        choice => choice.value === condition.comparison.comparisonType
+      )?.label || condition.comparison.comparisonType,
     value: condition.comparison.value,
     time:
       TIME_CHOICES.find(choice => choice.value[0] === condition.comparison.time)?.label ||

--- a/static/app/views/automations/components/actionFilters/ageComparison.tsx
+++ b/static/app/views/automations/components/actionFilters/ageComparison.tsx
@@ -50,12 +50,12 @@ function ComparisonField() {
 
   return (
     <AutomationBuilderSelect
-      name={`${condition_id}.comparison.comparison_type`}
+      name={`${condition_id}.comparison.comparisonType`}
       aria-label={t('Comparison')}
-      value={condition.comparison.comparison_type}
+      value={condition.comparison.comparisonType}
       options={AGE_COMPARISON_CHOICES}
       onChange={(option: SelectValue<AgeComparison>) => {
-        onUpdate({comparison: {...condition.comparison, comparison_type: option.value}});
+        onUpdate({comparison: {...condition.comparison, comparisonType: option.value}});
         removeError(condition.id);
       }}
     />
@@ -103,7 +103,7 @@ export function validateAgeComparisonCondition({
   condition,
 }: ValidateDataConditionProps): string | undefined {
   if (
-    !condition.comparison.comparison_type ||
+    !condition.comparison.comparisonType ||
     condition.comparison.value === undefined ||
     !condition.comparison.time
   ) {

--- a/static/app/views/automations/components/actionFilters/assignedTo.tsx
+++ b/static/app/views/automations/components/actionFilters/assignedTo.tsx
@@ -24,13 +24,13 @@ const TARGET_TYPE_CHOICES = [
 ];
 
 export function AssignedToDetails({condition}: {condition: DataCondition}) {
-  const {target_type, target_identifier} = condition.comparison;
+  const {targetType, targetIdentifier} = condition.comparison;
 
-  if (target_type === TargetType.TEAM) {
-    return <AssignedToTeam teamId={String(target_identifier)} />;
+  if (targetType === TargetType.TEAM) {
+    return <AssignedToTeam teamId={String(targetIdentifier)} />;
   }
-  if (target_type === TargetType.MEMBER) {
-    return <AssignedToMember memberId={target_identifier} />;
+  if (targetType === TargetType.MEMBER) {
+    return <AssignedToMember memberId={targetIdentifier} />;
   }
   return tct('Issue is unassigned', {});
 }

--- a/static/app/views/automations/components/actionFilters/comparisonBranches.tsx
+++ b/static/app/views/automations/components/actionFilters/comparisonBranches.tsx
@@ -67,13 +67,13 @@ function ComparisonIntervalField() {
 
   return (
     <AutomationBuilderSelect
-      name={`${condition_id}.comparison.comparison_interval`}
+      name={`${condition_id}.comparison.comparisonInterval`}
       aria-label={t('Comparison interval')}
-      value={condition.comparison.comparison_interval}
+      value={condition.comparison.comparisonInterval}
       options={COMPARISON_INTERVAL_CHOICES}
       onChange={(option: SelectValue<string>) => {
         onUpdate({
-          comparison: {...condition.comparison, comparison_interval: option.value},
+          comparison: {...condition.comparison, comparisonInterval: option.value},
         });
         removeError(condition.id);
       }}

--- a/static/app/views/automations/components/actionFilters/eventFrequency.tsx
+++ b/static/app/views/automations/components/actionFilters/eventFrequency.tsx
@@ -136,7 +136,7 @@ export function validateEventFrequencyCondition({
     !condition.comparison.value ||
     !condition.comparison.interval ||
     (condition.type === DataConditionType.EVENT_FREQUENCY_PERCENT &&
-      !condition.comparison.comparison_interval)
+      !condition.comparison.comparisonInterval)
   ) {
     return t('Ensure all fields are filled in.');
   }

--- a/static/app/views/automations/components/actionFilters/eventFrequency.tsx
+++ b/static/app/views/automations/components/actionFilters/eventFrequency.tsx
@@ -48,17 +48,17 @@ export function EventFrequencyPercentDetails({condition}: {condition: DataCondit
   return (
     <div>
       {tct(
-        'Number of events in an issue is [value]% higher [interval] compared to [comparison_interval] [where]',
+        'Number of events in an issue is [value]% higher [interval] compared to [comparisonInterval] [where]',
         {
           value: condition.comparison.value,
           interval:
             INTERVAL_CHOICES.find(
               choice => choice.value === condition.comparison.interval
             )?.label || condition.comparison.interval,
-          comparison_interval:
+          comparisonInterval:
             COMPARISON_INTERVAL_CHOICES.find(
-              choice => choice.value === condition.comparison.comparison_interval
-            )?.label || condition.comparison.comparison_interval,
+              choice => choice.value === condition.comparison.comparisonInterval
+            )?.label || condition.comparison.comparisonInterval,
           where: hasSubfilters ? t('where') : null,
         }
       )}

--- a/static/app/views/automations/components/actionFilters/eventUniqueUserFrequency.tsx
+++ b/static/app/views/automations/components/actionFilters/eventUniqueUserFrequency.tsx
@@ -148,7 +148,7 @@ export function validateEventUniqueUserFrequencyCondition({
     !condition.comparison.value ||
     !condition.comparison.interval ||
     (condition.type === DataConditionType.EVENT_UNIQUE_USER_FREQUENCY_PERCENT &&
-      !condition.comparison.comparison_interval)
+      !condition.comparison.comparisonInterval)
   ) {
     return t('Ensure all fields are filled in.');
   }

--- a/static/app/views/automations/components/actionFilters/eventUniqueUserFrequency.tsx
+++ b/static/app/views/automations/components/actionFilters/eventUniqueUserFrequency.tsx
@@ -60,17 +60,17 @@ export function EventUniqueUserFrequencyPercentDetails({
   return (
     <div>
       {tct(
-        'Number of users affected by an issue is [value]% higher [interval] compared to [comparison_interval] [where]',
+        'Number of users affected by an issue is [value]% higher [interval] compared to [comparisonInterval] [where]',
         {
           value: condition.comparison.value,
           interval:
             INTERVAL_CHOICES.find(
               choice => choice.value === condition.comparison.interval
             )?.label || condition.comparison.interval,
-          comparison_interval:
+          comparisonInterval:
             COMPARISON_INTERVAL_CHOICES.find(
-              choice => choice.value === condition.comparison.comparison_interval
-            )?.label || condition.comparison.comparison_interval,
+              choice => choice.value === condition.comparison.comparisonInterval
+            )?.label || condition.comparison.comparisonInterval,
           where: hasSubfilters ? t('where') : null,
         }
       )}

--- a/static/app/views/automations/components/actionFilters/issuePriority.tsx
+++ b/static/app/views/automations/components/actionFilters/issuePriority.tsx
@@ -11,8 +11,8 @@ import type {ValidateDataConditionProps} from 'sentry/views/automations/componen
 import {useDataConditionNodeContext} from 'sentry/views/automations/components/dataConditionNodes';
 
 export function IssuePriorityDetails({condition}: {condition: DataCondition}) {
-  return tct('Current issue priority is greater than or equal to [level]', {
-    level:
+  return tct('Current issue priority is greater than or equal to [priority]', {
+    priority:
       PRIORITY_CHOICES.find(choice => choice.value === condition.comparison)?.label ||
       condition.comparison,
   });

--- a/static/app/views/automations/components/actionFilters/latestAdoptedRelease.tsx
+++ b/static/app/views/automations/components/actionFilters/latestAdoptedRelease.tsx
@@ -118,8 +118,8 @@ export function validateLatestAdoptedReleaseCondition({
   condition,
 }: ValidateDataConditionProps): string | undefined {
   if (
-    !condition.comparison.release_age_type ||
-    !condition.comparison.age_comparison ||
+    !condition.comparison.releaseAgeType ||
+    !condition.comparison.ageComparison ||
     !condition.comparison.environment
   ) {
     return t('Ensure all fields are filled in.');

--- a/static/app/views/automations/components/actionFilters/latestAdoptedRelease.tsx
+++ b/static/app/views/automations/components/actionFilters/latestAdoptedRelease.tsx
@@ -21,12 +21,12 @@ export function LatestAdoptedReleaseDetails({condition}: {condition: DataConditi
     {
       releaseAgeType:
         MODEL_AGE_CHOICES.find(
-          choice => choice.value === condition.comparison.release_age_type
-        )?.label || condition.comparison.release_age_type,
+          choice => choice.value === condition.comparison.releaseAgeType
+        )?.label || condition.comparison.releaseAgeType,
       ageComparison:
         AGE_COMPARISON_CHOICES.find(
-          choice => choice.value === condition.comparison.age_comparison
-        )?.label || condition.comparison.age_comparison,
+          choice => choice.value === condition.comparison.ageComparison
+        )?.label || condition.comparison.ageComparison,
       environment: condition.comparison.environment,
     }
   );
@@ -47,12 +47,12 @@ function ReleaseAgeTypeField() {
   const {condition, condition_id, onUpdate} = useDataConditionNodeContext();
   return (
     <AutomationBuilderSelect
-      name={`${condition_id}.comparison.release_age_type`}
+      name={`${condition_id}.comparison.releaseAgeType`}
       aria-label={t('Release age type')}
-      value={condition.comparison.release_age_type}
+      value={condition.comparison.releaseAgeType}
       options={MODEL_AGE_CHOICES}
       onChange={(option: SelectValue<ModelAge>) => {
-        onUpdate({comparison: {...condition.comparison, release_age_type: option.value}});
+        onUpdate({comparison: {...condition.comparison, releaseAgeType: option.value}});
       }}
     />
   );
@@ -62,12 +62,12 @@ function AgeComparisonField() {
   const {condition, condition_id, onUpdate} = useDataConditionNodeContext();
   return (
     <AutomationBuilderSelect
-      name={`${condition_id}.comparison.age_comparison`}
+      name={`${condition_id}.comparison.ageComparison`}
       aria-label={t('Age comparison')}
-      value={condition.comparison.age_comparison}
+      value={condition.comparison.ageComparison}
       options={AGE_COMPARISON_CHOICES}
       onChange={(option: SelectValue<AgeComparison>) => {
-        onUpdate({comparison: {...condition.comparison, age_comparison: option.value}});
+        onUpdate({comparison: {...condition.comparison, ageComparison: option.value}});
       }}
     />
   );

--- a/static/app/views/automations/components/actionFilters/percentSessions.tsx
+++ b/static/app/views/automations/components/actionFilters/percentSessions.tsx
@@ -52,17 +52,17 @@ export function PercentSessionsPercentDetails({condition}: {condition: DataCondi
   return (
     <div>
       {tct(
-        'Percentage of sessions affected by an issue is [value]% higher [interval] compared to [comparison_interval] [where]',
+        'Percentage of sessions affected by an issue is [value]% higher [interval] compared to [comparisonInterval] [where]',
         {
           value: condition.comparison.value,
           interval:
             INTERVAL_CHOICES.find(
               choice => choice.value === condition.comparison.interval
             )?.label || condition.comparison.interval,
-          comparison_interval:
+          comparisonInterval:
             COMPARISON_INTERVAL_CHOICES.find(
-              choice => choice.value === condition.comparison.comparison_interval
-            )?.label || condition.comparison.comparison_interval,
+              choice => choice.value === condition.comparison.comparisonInterval
+            )?.label || condition.comparison.comparisonInterval,
           where: hasSubfilters ? t('where') : null,
         }
       )}
@@ -139,7 +139,7 @@ export function validatePercentSessionsCondition({
     !condition.comparison.value ||
     !condition.comparison.interval ||
     (condition.type === DataConditionType.PERCENT_SESSIONS_PERCENT &&
-      !condition.comparison.comparison_interval)
+      !condition.comparison.comparisonInterval)
   ) {
     return t('Ensure all fields are filled in.');
   }

--- a/static/app/views/automations/components/actionNodeList.tsx
+++ b/static/app/views/automations/components/actionNodeList.tsx
@@ -43,15 +43,15 @@ function getActionHandler(
       if (handler.type !== ActionType.SENTRY_APP) {
         return false;
       }
-      const {sentry_app_identifier, target_identifier} = action.config;
+      const {sentryAppIdentifier, targetIdentifier} = action.config;
       const sentryApp = handler.sentryApp;
 
       const isMatchingAppId =
-        sentry_app_identifier === SentryAppIdentifier.SENTRY_APP_ID &&
-        target_identifier === sentryApp?.id;
+        sentryAppIdentifier === SentryAppIdentifier.SENTRY_APP_ID &&
+        targetIdentifier === sentryApp?.id;
       const isMatchingInstallationUuid =
-        sentry_app_identifier === SentryAppIdentifier.SENTRY_APP_INSTALLATION_UUID &&
-        target_identifier === sentryApp?.installationUuid;
+        sentryAppIdentifier === SentryAppIdentifier.SENTRY_APP_INSTALLATION_UUID &&
+        targetIdentifier === sentryApp?.installationUuid;
       return isMatchingAppId || isMatchingInstallationUuid;
     });
   }

--- a/static/app/views/automations/components/actions/discord.tsx
+++ b/static/app/views/automations/components/actions/discord.tsx
@@ -33,7 +33,7 @@ export function DiscordDetails({
     {
       logo: ActionMetadata[ActionType.DISCORD]?.icon,
       server: integrationName,
-      channel: String(action.config.target_identifier),
+      channel: String(action.config.targetIdentifier),
       tags: action.data.tags ? `, and in the message show tags [${tags}]` : null,
     }
   );
@@ -70,7 +70,7 @@ export function validateDiscordAction(action: Action): string | undefined {
   if (!action.integrationId) {
     return t('You must specify a Discord server.');
   }
-  if (!action.config.target_display) {
+  if (!action.config.targetDisplay) {
     return t('You must specify a channel ID or URL.');
   }
   return undefined;

--- a/static/app/views/automations/components/actions/email.tsx
+++ b/static/app/views/automations/components/actions/email.tsx
@@ -35,9 +35,9 @@ const FALLTHROUGH_CHOICES = [
 ];
 
 export function EmailDetails({action}: {action: Action}) {
-  const {target_type, target_identifier} = action.config;
+  const {targetType, targetIdentifier} = action.config;
 
-  if (target_type === ActionTarget.ISSUE_OWNERS) {
+  if (targetType === ActionTarget.ISSUE_OWNERS) {
     return tct('Notify Suggested Assignees and, if none found, notify [fallthrough]', {
       fallthrough:
         FALLTHROUGH_CHOICES.find(choice => choice.value === action.data.fallthroughType)
@@ -45,11 +45,11 @@ export function EmailDetails({action}: {action: Action}) {
     });
   }
 
-  if (target_type === ActionTarget.TEAM && target_identifier) {
-    return <AssignedToTeam teamId={target_identifier} />;
+  if (targetType === ActionTarget.TEAM && targetIdentifier) {
+    return <AssignedToTeam teamId={targetIdentifier} />;
   }
-  if (target_type === ActionTarget.USER && target_identifier) {
-    return <AssignedToMember memberId={parseInt(target_identifier, 10)} />;
+  if (targetType === ActionTarget.USER && targetIdentifier) {
+    return <AssignedToMember memberId={parseInt(targetIdentifier, 10)} />;
   }
 
   return t('Notify on preferred channel');
@@ -78,15 +78,15 @@ function TargetTypeField() {
   return (
     <AutomationBuilderSelect
       aria-label={t('Notification target type')}
-      name={`${actionId}.config.target_type`}
-      value={action.config.target_type}
+      name={`${actionId}.config.targetType`}
+      value={action.config.targetType}
       options={TARGET_TYPE_CHOICES}
       onChange={(option: SelectValue<ActionTarget>) => {
         onUpdate({
           config: {
             ...action.config,
-            target_type: option.value,
-            target_identifier: undefined,
+            targetType: option.value,
+            targetIdentifier: undefined,
           },
           ...(option.value === ActionTarget.ISSUE_OWNERS
             ? {data: {fallthroughType: FallthroughChoiceType.ACTIVE_MEMBERS}}
@@ -102,16 +102,16 @@ function IdentifierField() {
   const {removeError} = useAutomationBuilderErrorContext();
   const organization = useOrganization();
 
-  if (action.config.target_type === ActionTarget.TEAM) {
+  if (action.config.targetType === ActionTarget.TEAM) {
     return (
       <SelectWrapper>
         <TeamSelector
           aria-label={t('Team')}
-          name={`${actionId}.config.target_identifier`}
-          value={action.config.target_identifier}
+          name={`${actionId}.config.targetIdentifier`}
+          value={action.config.targetIdentifier}
           onChange={(value: any) => {
             onUpdate({
-              config: {...action.config, target_identifier: value.actor.id},
+              config: {...action.config, targetIdentifier: value.actor.id},
               data: {},
             });
             removeError(action.id);
@@ -122,17 +122,17 @@ function IdentifierField() {
       </SelectWrapper>
     );
   }
-  if (action.config.target_type === ActionTarget.USER) {
+  if (action.config.targetType === ActionTarget.USER) {
     return (
       <SelectWrapper>
         <SelectMembers
           aria-label={t('User')}
           organization={organization}
-          key={`${actionId}.config.target_identifier`}
-          value={action.config.target_identifier}
+          key={`${actionId}.config.targetIdentifier`}
+          value={action.config.targetIdentifier}
           onChange={(value: any) => {
             onUpdate({
-              config: {...action.config, target_identifier: value.actor.id},
+              config: {...action.config, targetIdentifier: value.actor.id},
               data: {},
             });
             removeError(action.id);
@@ -163,25 +163,19 @@ function FallthroughField() {
 }
 
 export function validateEmailAction(action: Action): string | undefined {
-  if (!action.config.target_type) {
+  if (!action.config.targetType) {
     return t('You must notification target type.');
   }
   if (
-    action.config.target_type === ActionTarget.ISSUE_OWNERS &&
+    action.config.targetType === ActionTarget.ISSUE_OWNERS &&
     !action.data.fallthroughType
   ) {
     return t('You must specify a fallthrough type.');
   }
-  if (
-    action.config.target_type === ActionTarget.TEAM &&
-    !action.config.target_identifier
-  ) {
+  if (action.config.targetType === ActionTarget.TEAM && !action.config.targetIdentifier) {
     return t('You must specify a team.');
   }
-  if (
-    action.config.target_type === ActionTarget.USER &&
-    !action.config.target_identifier
-  ) {
+  if (action.config.targetType === ActionTarget.USER && !action.config.targetIdentifier) {
     return t('You must specify a member.');
   }
   return undefined;

--- a/static/app/views/automations/components/actions/integrationField.tsx
+++ b/static/app/views/automations/components/actions/integrationField.tsx
@@ -22,7 +22,7 @@ export function IntegrationField() {
         onUpdate({
           integrationId: option.value,
           ...(defaultService && {
-            config: {...action.config, target_identifier: defaultService},
+            config: {...action.config, targetIdentifier: defaultService},
           }),
         });
       }}

--- a/static/app/views/automations/components/actions/msTeams.tsx
+++ b/static/app/views/automations/components/actions/msTeams.tsx
@@ -22,7 +22,7 @@ export function MSTeamsDetails({
   return tct('Send a [logo] Microsoft Teams notification to [team] team, to [channel]', {
     logo: ActionMetadata[ActionType.MSTEAMS]?.icon,
     team: integrationName,
-    channel: String(action.config.target_identifier),
+    channel: String(action.config.targetIdentifier),
   });
 }
 
@@ -38,7 +38,7 @@ export function validateMSTeamsAction(action: Action): string | undefined {
   if (!action.integrationId) {
     return t('You must specify a Microsoft Teams team.');
   }
-  if (!action.config.target_display) {
+  if (!action.config.targetDisplay) {
     return t('You must specify a channel.');
   }
   return undefined;

--- a/static/app/views/automations/components/actions/opsgenie.tsx
+++ b/static/app/views/automations/components/actions/opsgenie.tsx
@@ -19,7 +19,7 @@ export function OpsgenieDetails({
 }) {
   const integration = handler.integrations?.find(i => i.id === action.integrationId);
   const service = integration?.services?.find(
-    s => s.id === action.config.target_identifier
+    s => s.id === action.config.targetIdentifier
   );
 
   return tct(
@@ -27,7 +27,7 @@ export function OpsgenieDetails({
     {
       logo: ActionMetadata[ActionType.OPSGENIE]?.icon,
       account: integration?.name || action.integrationId,
-      team: service?.name || action.config.target_identifier,
+      team: service?.name || action.config.targetIdentifier,
       priority: String(action.data.priority),
     }
   );
@@ -69,7 +69,7 @@ export function validateOpsgenieAction(action: Action): string | undefined {
   if (!action.integrationId) {
     return t('You must specify an Opsgenie configuration.');
   }
-  if (!action.config.target_identifier) {
+  if (!action.config.targetIdentifier) {
     return t('You must specify a team.');
   }
   if (!action.data.priority) {

--- a/static/app/views/automations/components/actions/pagerduty.tsx
+++ b/static/app/views/automations/components/actions/pagerduty.tsx
@@ -19,7 +19,7 @@ export function PagerdutyDetails({
 }) {
   const integration = handler.integrations?.find(i => i.id === action.integrationId);
   const service = integration?.services?.find(
-    s => s.id === action.config.target_identifier
+    s => s.id === action.config.targetIdentifier
   );
 
   return tct(
@@ -27,7 +27,7 @@ export function PagerdutyDetails({
     {
       logo: ActionMetadata[ActionType.PAGERDUTY]?.icon,
       account: integration?.name || action.integrationId,
-      service: service?.name || action.config.target_identifier,
+      service: service?.name || action.config.targetIdentifier,
       severity: String(action.data.priority),
     }
   );
@@ -69,7 +69,7 @@ export function validatePagerdutyAction(action: Action): string | undefined {
   if (!action.integrationId) {
     return t('You must specify a PagerDuty integration.');
   }
-  if (!action.config.target_identifier) {
+  if (!action.config.targetIdentifier) {
     return t('You must specify a service.');
   }
   if (!action.data.priority) {

--- a/static/app/views/automations/components/actions/serviceField.tsx
+++ b/static/app/views/automations/components/actions/serviceField.tsx
@@ -14,16 +14,16 @@ export function ServiceField() {
 
   return (
     <AutomationBuilderSelect
-      name={`${actionId}.config.target_identifier`}
+      name={`${actionId}.config.targetIdentifier`}
       aria-label={t('Service')}
-      value={action.config.target_identifier}
+      value={action.config.targetIdentifier}
       options={integration.services?.map(service => ({
         label: service.name,
         value: service.id,
       }))}
       onChange={(option: SelectValue<string>) => {
         onUpdate({
-          config: {...action.config, target_identifier: option.value},
+          config: {...action.config, targetIdentifier: option.value},
         });
       }}
     />

--- a/static/app/views/automations/components/actions/slack.tsx
+++ b/static/app/views/automations/components/actions/slack.tsx
@@ -31,17 +31,15 @@ export function SlackDetails({
     {
       logo: ActionMetadata[ActionType.SLACK]?.icon,
       workspace: integrationName,
-      channel: action.config.target_display
-        ? `${action.config.target_display}`
-        : action.config.target_identifier,
+      channel: action.config.targetDisplay || action.config.targetIdentifier,
       tagsAndNotes: SlackTagsAndNotes(action),
     }
   );
 }
 
 function SlackTagsAndNotes(action: Action) {
-  const notes = String(action.data.notes);
-  const tags = String(action.data.tags);
+  const notes = action.data.notes;
+  const tags = action.data.tags;
 
   if (notes && tags) {
     return tct(', and in the message show tags [tags] and notes [notes]', {tags, notes});
@@ -106,7 +104,7 @@ export function validateSlackAction(action: Action): string | undefined {
   if (!action.integrationId) {
     return t('You must specify a Slack workspace.');
   }
-  if (!action.config.target_display) {
+  if (!action.config.targetDisplay) {
     return t('You must specify a channel name or ID.');
   }
   return undefined;

--- a/static/app/views/automations/components/actions/targetDisplayField.tsx
+++ b/static/app/views/automations/components/actions/targetDisplayField.tsx
@@ -9,13 +9,13 @@ export function TargetDisplayField({placeholder}: {placeholder?: string}) {
 
   return (
     <AutomationBuilderInput
-      name={`${actionId}.config.target_display`}
+      name={`${actionId}.config.targetDisplay`}
       aria-label={t('Target')}
       placeholder={placeholder ? placeholder : t('channel name or ID')}
-      value={action.config.target_display}
+      value={action.config.targetDisplay}
       onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
         onUpdate({
-          config: {...action.config, target_display: e.target.value},
+          config: {...action.config, targetDisplay: e.target.value},
         });
         removeError(action.id);
       }}

--- a/static/app/views/automations/components/actions/webhook.tsx
+++ b/static/app/views/automations/components/actions/webhook.tsx
@@ -12,8 +12,8 @@ export function WebhookDetails({
   handler: ActionHandler;
 }) {
   const service =
-    handler.services?.find(s => s.slug === action.config.target_identifier)?.name ||
-    action.config.target_identifier;
+    handler.services?.find(s => s.slug === action.config.targetIdentifier)?.name ||
+    action.config.targetIdentifier;
 
   return tct('Send a notification via [service]', {
     service: String(service),
@@ -32,9 +32,9 @@ function ServicesField() {
 
   return (
     <AutomationBuilderSelect
-      name={`${actionId}.config.target_identifier`}
+      name={`${actionId}.config.targetIdentifier`}
       aria-label={t('Webhook')}
-      value={action.config.target_identifier}
+      value={action.config.targetIdentifier}
       options={services?.map(service => ({
         label: service.name,
         value: service.slug,
@@ -43,7 +43,7 @@ function ServicesField() {
         onUpdate({
           config: {
             ...action.config,
-            target_identifier: option.value,
+            targetIdentifier: option.value,
           },
         });
       }}
@@ -52,7 +52,7 @@ function ServicesField() {
 }
 
 export function validateWebhookAction(action: Action): string | undefined {
-  if (!action.config.target_identifier) {
+  if (!action.config.targetIdentifier) {
     return t('You must specify an integration.');
   }
   return undefined;

--- a/static/app/views/automations/components/automationBuilderContext.tsx
+++ b/static/app/views/automations/components/automationBuilderContext.tsx
@@ -481,10 +481,10 @@ function getDefaultConfig(actionHandler: ActionHandler): ActionConfig {
     undefined;
 
   return {
-    target_type: targetType,
-    ...(targetIdentifier && {target_identifier: targetIdentifier}),
+    targetType,
+    ...(targetIdentifier && {targetIdentifier}),
     ...(actionHandler.sentryApp?.id && {
-      sentry_app_identifier: SentryAppIdentifier.SENTRY_APP_ID,
+      sentryAppIdentifier: SentryAppIdentifier.SENTRY_APP_ID,
     }),
   };
 }

--- a/static/app/views/automations/components/conditionsPanel.tsx
+++ b/static/app/views/automations/components/conditionsPanel.tsx
@@ -1,7 +1,7 @@
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import LoadingIndicator from 'sentry/components/loadingIndicator';
+import Placeholder from 'sentry/components/placeholder';
 import {ConditionBadge} from 'sentry/components/workflowEngine/ui/conditionBadge';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -60,13 +60,13 @@ function findActionHandler(
   availableActions: ActionHandler[]
 ): ActionHandler | undefined {
   if (action.type === ActionType.SENTRY_APP) {
-    if (action.config.sentry_app_identifier === SentryAppIdentifier.SENTRY_APP_ID) {
+    if (action.config.sentryAppIdentifier === SentryAppIdentifier.SENTRY_APP_ID) {
       return availableActions.find(
-        handler => handler.sentryApp?.id === action.config.target_identifier
+        handler => handler.sentryApp?.id === action.config.targetIdentifier
       );
     }
     return availableActions.find(
-      handler => handler.sentryApp?.installationUuid === action.config.target_identifier
+      handler => handler.sentryApp?.installationUuid === action.config.targetIdentifier
     );
   }
   return availableActions.find(handler => handler.type === action.type);
@@ -80,9 +80,9 @@ interface ActionFilterProps {
 function ActionFilter({actionFilter, totalFilters}: ActionFilterProps) {
   const {data: availableActions = [], isLoading} = useAvailableActionsQuery();
 
-  if (isLoading) {
-    return <LoadingIndicator />;
-  }
+  // if (isLoading) {
+  //   return <LoadingIndicator />;
+  // }
 
   return (
     <ConditionGroupWrapper showDivider={totalFilters > 1}>
@@ -106,14 +106,18 @@ function ActionFilter({actionFilter, totalFilters}: ActionFilterProps) {
           then: <ConditionBadge />,
         })}
       </ConditionGroupHeader>
-      {actionFilter.actions?.map((action, index) => (
-        <div key={index}>
-          <ActionDetails
-            action={action}
-            handler={findActionHandler(action, availableActions)}
-          />
-        </div>
-      ))}
+      {isLoading
+        ? actionFilter.actions?.map((_, index) => (
+            <Placeholder key={index} height="10px" />
+          ))
+        : actionFilter.actions?.map((action, index) => (
+            <div key={index}>
+              <ActionDetails
+                action={action}
+                handler={findActionHandler(action, availableActions)}
+              />
+            </div>
+          ))}
     </ConditionGroupWrapper>
   );
 }

--- a/tests/js/fixtures/automations.ts
+++ b/tests/js/fixtures/automations.ts
@@ -63,7 +63,7 @@ export function ActionFixture(params: Partial<Action> = {}): Action {
     id: '1000',
     type: ActionType.SLACK,
     config: {
-      target_type: ActionTarget.SPECIFIC,
+      targetType: ActionTarget.SPECIFIC,
     },
     data: {},
     ...params,


### PR DESCRIPTION
since the workflow serializer response has been fixed to return camelCase, we can now update all of the data condition and action nodes to use camelCase

also updated the conditions panel on the automation details sidebar to use skeletons instead of a loading spinner when the available actions are being fetched to display actions