### PR TITLE
feat(tags): Add rate limiting to GroupTag endpoints

### DIFF
--- a/src/sentry/api/endpoints/group_tagkey_details.py
+++ b/src/sentry/api/endpoints/group_tagkey_details.py
@@ -31,8 +31,8 @@ class GroupTagKeyDetailsEndpoint(GroupEndpoint):
         "GET": ApiPublishStatus.PUBLIC,
     }
     owner = ApiOwner.ISSUES
-    enforce_rate_limit = True
 
+    enforce_rate_limit = True
     rate_limits = {
         "GET": {
             RateLimitCategory.IP: RateLimit(limit=10, window=1, concurrent_limit=10),

--- a/src/sentry/api/endpoints/group_tagkey_values.py
+++ b/src/sentry/api/endpoints/group_tagkey_values.py
@@ -32,8 +32,8 @@ class GroupTagKeyValuesEndpoint(GroupEndpoint):
         "GET": ApiPublishStatus.PUBLIC,
     }
     owner = ApiOwner.ISSUES
-    enforce_rate_limit = True
 
+    enforce_rate_limit = True
     rate_limits = {
         "GET": {
             RateLimitCategory.IP: RateLimit(limit=10, window=1, concurrent_limit=10),

--- a/src/sentry/api/endpoints/group_tags.py
+++ b/src/sentry/api/endpoints/group_tags.py
@@ -13,6 +13,7 @@ from sentry.api.helpers.environments import get_environments
 from sentry.api.helpers.mobile import get_readable_device_name
 from sentry.api.serializers import serialize
 from sentry.search.utils import DEVICE_CLASS
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 if TYPE_CHECKING:
     from sentry.models.group import Group
@@ -22,6 +23,15 @@ if TYPE_CHECKING:
 class GroupTagsEndpoint(GroupEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.UNKNOWN,
+    }
+
+    enforce_rate_limit = True
+    rate_limits = {
+        "GET": {
+            RateLimitCategory.IP: RateLimit(limit=10, window=1, concurrent_limit=10),
+            RateLimitCategory.USER: RateLimit(limit=10, window=1, concurrent_limit=10),
+            RateLimitCategory.ORGANIZATION: RateLimit(limit=20, window=1, concurrent_limit=5),
+        }
     }
 
     def get(self, request: Request, group: Group) -> Response:

--- a/src/sentry/api/endpoints/project_tagkey_details.py
+++ b/src/sentry/api/endpoints/project_tagkey_details.py
@@ -21,12 +21,18 @@ class ProjectTagKeyDetailsEndpoint(ProjectEndpoint):
         "DELETE": ApiPublishStatus.UNKNOWN,
         "GET": ApiPublishStatus.UNKNOWN,
     }
+
     enforce_rate_limit = True
     rate_limits = {
         "DELETE": {
             RateLimitCategory.IP: RateLimit(limit=1, window=1),
             RateLimitCategory.USER: RateLimit(limit=1, window=1),
             RateLimitCategory.ORGANIZATION: RateLimit(limit=1, window=1),
+        },
+        "GET": {
+            RateLimitCategory.IP: RateLimit(limit=10, window=1, concurrent_limit=10),
+            RateLimitCategory.USER: RateLimit(limit=10, window=1, concurrent_limit=10),
+            RateLimitCategory.ORGANIZATION: RateLimit(limit=20, window=1, concurrent_limit=5),
         },
     }
 

--- a/src/sentry/api/endpoints/project_tagkey_values.py
+++ b/src/sentry/api/endpoints/project_tagkey_values.py
@@ -11,6 +11,7 @@ from sentry.api.helpers.environments import get_environment_id
 from sentry.api.serializers import serialize
 from sentry.api.utils import get_date_range_from_params
 from sentry.models.environment import Environment
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 
 @region_silo_endpoint
@@ -18,6 +19,15 @@ class ProjectTagKeyValuesEndpoint(ProjectEndpoint):
     owner = ApiOwner.UNOWNED
     publish_status = {
         "GET": ApiPublishStatus.UNKNOWN,
+    }
+
+    enforce_rate_limit = True
+    rate_limits = {
+        "GET": {
+            RateLimitCategory.IP: RateLimit(limit=10, window=1, concurrent_limit=10),
+            RateLimitCategory.USER: RateLimit(limit=10, window=1, concurrent_limit=10),
+            RateLimitCategory.ORGANIZATION: RateLimit(limit=20, window=1, concurrent_limit=5),
+        }
     }
 
     def get(self, request: Request, project, key) -> Response:


### PR DESCRIPTION
## Problem
We want consistent rate limiting across GroupTag endpoints

## Solution
**Rate Limit Configuration (standardized across all endpoints):**
- IP/USER: 10 requests/second with 10 concurrent limit
- ORGANIZATION: 20 requests/second with 5 concurrent limit

**These limits have been applied to:**
- GroupTagsEndpoint
- GroupTagKeyDetailsEndpoint
- GroupTagKeyValuesEndpoint
- ProjectTagKeyDetailsEndpoint
- ProjectTagKeyValuesEndpoint
- GroupTagExportView