### PR TITLE
fix(uptime): Fix bug where uptime seats are not properly unassigned after project deletion

### DIFF
--- a/src/sentry/deletions/__init__.py
+++ b/src/sentry/deletions/__init__.py
@@ -35,6 +35,7 @@ def load_defaults(manager: DeletionTaskManager) -> None:
     from sentry.monitors import models as monitors
     from sentry.sentry_apps import models as sentry_apps
     from sentry.snuba import models as snuba
+    from sentry.uptime import models as uptime
     from sentry.workflow_engine import models as workflow_engine
 
     from . import defaults
@@ -111,6 +112,7 @@ def load_defaults(manager: DeletionTaskManager) -> None:
     manager.register(workflow_engine.DataSource, defaults.DataSourceDeletionTask)
     manager.register(workflow_engine.Detector, defaults.DetectorDeletionTask)
     manager.register(workflow_engine.Workflow, defaults.WorkflowDeletionTask)
+    manager.register(uptime.UptimeSubscription, defaults.UptimeSubscriptionDeletionTask)
     # fmt: on
 
 

--- a/src/sentry/deletions/defaults/__init__.py
+++ b/src/sentry/deletions/defaults/__init__.py
@@ -31,4 +31,5 @@ from .sentry_app_installation import *  # noqa: F401,F403
 from .sentry_app_installation_token import *  # noqa: F401,F403
 from .service_hook import *  # noqa: F401,F403
 from .team import *  # noqa: F401,F403
+from .uptime_subscription import *  # noqa: F401,F403
 from .workflow import *  # noqa: F401,F403

--- a/src/sentry/deletions/defaults/project.py
+++ b/src/sentry/deletions/defaults/project.py
@@ -109,6 +109,13 @@ class ProjectDeletionTask(ModelDeletionTask[Project]):
             )
         )
         relations.append(ModelRelation(Detector, {"project_id": instance.id}))
+        # The `ProjectUptimeSubscription` should be removed when deleting the related `Detector`,
+        # but keep there here as a fallback
+        relations.append(
+            ModelRelation(
+                ProjectUptimeSubscription, {"project_id": instance.id}, BulkModelDeletionTask
+            )
+        )
 
         # Release needs to handle deletes after Group is cleaned up as the foreign
         # key is protected

--- a/src/sentry/deletions/defaults/project.py
+++ b/src/sentry/deletions/defaults/project.py
@@ -109,13 +109,6 @@ class ProjectDeletionTask(ModelDeletionTask[Project]):
             )
         )
         relations.append(ModelRelation(Detector, {"project_id": instance.id}))
-        # The `ProjectUptimeSubscription` should be removed when deleting the related `Detector`,
-        # but keep there here as a fallback
-        relations.append(
-            ModelRelation(
-                ProjectUptimeSubscription, {"project_id": instance.id}, BulkModelDeletionTask
-            )
-        )
 
         # Release needs to handle deletes after Group is cleaned up as the foreign
         # key is protected

--- a/src/sentry/deletions/defaults/uptime_subscription.py
+++ b/src/sentry/deletions/defaults/uptime_subscription.py
@@ -1,9 +1,10 @@
 from sentry.deletions.base import ModelDeletionTask
-from sentry.uptime.models import UptimeSubscription, get_detector
+from sentry.uptime.models import ProjectUptimeSubscription, UptimeSubscription
 
 
 class UptimeSubscriptionDeletionTask(ModelDeletionTask[UptimeSubscription]):
     def delete_instance(self, instance: UptimeSubscription) -> None:
-        from sentry.uptime.subscriptions.subscriptions import delete_uptime_detector
+        from sentry.uptime.subscriptions.subscriptions import delete_project_uptime_subscription
 
-        delete_uptime_detector(get_detector(instance), delete_detector=False)
+        uptime_monitor = ProjectUptimeSubscription.objects.get(uptime_subscription_id=instance.id)
+        delete_project_uptime_subscription(uptime_monitor)

--- a/src/sentry/deletions/defaults/uptime_subscription.py
+++ b/src/sentry/deletions/defaults/uptime_subscription.py
@@ -6,4 +6,4 @@ class UptimeSubscriptionDeletionTask(ModelDeletionTask[UptimeSubscription]):
     def delete_instance(self, instance: UptimeSubscription) -> None:
         from sentry.uptime.subscriptions.subscriptions import delete_uptime_detector
 
-        delete_uptime_detector(get_detector(instance))
+        delete_uptime_detector(get_detector(instance), delete_detector=False)

--- a/src/sentry/deletions/defaults/uptime_subscription.py
+++ b/src/sentry/deletions/defaults/uptime_subscription.py
@@ -1,0 +1,9 @@
+from sentry.deletions.base import ModelDeletionTask
+from sentry.uptime.models import UptimeSubscription, get_detector
+
+
+class UptimeSubscriptionDeletionTask(ModelDeletionTask[UptimeSubscription]):
+    def delete_instance(self, instance: UptimeSubscription) -> None:
+        from sentry.uptime.subscriptions.subscriptions import delete_uptime_detector
+
+        delete_uptime_detector(get_detector(instance))

--- a/src/sentry/uptime/models.py
+++ b/src/sentry/uptime/models.py
@@ -360,7 +360,7 @@ def get_detector(
             type=DATA_SOURCE_UPTIME_SUBSCRIPTION,
             source_id=str(uptime_subscription.id),
         )
-        qs = Detector.objects.filter(
+        qs = Detector.objects_for_deletion.filter(
             type=GROUP_TYPE_UPTIME_DOMAIN_CHECK_FAILURE, data_sources=data_source[:1]
         )
         select_related = ["project", "project__organization"]

--- a/src/sentry/uptime/subscriptions/subscriptions.py
+++ b/src/sentry/uptime/subscriptions/subscriptions.py
@@ -444,13 +444,16 @@ def enable_uptime_detector(
         create_remote_uptime_subscription.delay(uptime_subscription.id)
 
 
-def delete_uptime_detector(detector: Detector, delete_detector=True):
+def delete_uptime_detector(detector: Detector):
     uptime_monitor = get_project_subscription(detector)
+    delete_project_uptime_subscription(uptime_monitor)
+    RegionScheduledDeletion.schedule(detector, days=0)
+
+
+def delete_project_uptime_subscription(uptime_monitor: ProjectUptimeSubscription):
     uptime_subscription: UptimeSubscription = uptime_monitor.uptime_subscription
     quotas.backend.remove_seat(DataCategory.UPTIME, uptime_monitor)
     uptime_monitor.delete()
-    if delete_detector:
-        RegionScheduledDeletion.schedule(detector, days=0)
     remove_uptime_subscription_if_unused(uptime_subscription)
 
 

--- a/src/sentry/uptime/subscriptions/subscriptions.py
+++ b/src/sentry/uptime/subscriptions/subscriptions.py
@@ -444,12 +444,13 @@ def enable_uptime_detector(
         create_remote_uptime_subscription.delay(uptime_subscription.id)
 
 
-def delete_uptime_detector(detector: Detector):
+def delete_uptime_detector(detector: Detector, delete_detector=True):
     uptime_monitor = get_project_subscription(detector)
     uptime_subscription: UptimeSubscription = uptime_monitor.uptime_subscription
     quotas.backend.remove_seat(DataCategory.UPTIME, uptime_monitor)
     uptime_monitor.delete()
-    RegionScheduledDeletion.schedule(detector, days=0)
+    if delete_detector:
+        RegionScheduledDeletion.schedule(detector, days=0)
     remove_uptime_subscription_if_unused(uptime_subscription)
 
 

--- a/tests/sentry/uptime/detectors/test_tasks.py
+++ b/tests/sentry/uptime/detectors/test_tasks.py
@@ -349,10 +349,12 @@ class TestMonitorUrlForProject(UptimeTestCase):
 
     def test_existing(self):
         url = "http://sentry.io"
-        monitor_url_for_project(self.project, url)
+        with self.tasks():
+            monitor_url_for_project(self.project, url)
         assert is_url_auto_monitored_for_project(self.project, url)
         url_2 = "http://santry.io"
-        monitor_url_for_project(self.project, url_2)
+        with self.tasks():
+            monitor_url_for_project(self.project, url_2)
         # Execute scheduled deletions to ensure the first detector is cleaned
         # up when re-detecting
         with self.tasks():


### PR DESCRIPTION
This fixes a bug where if a project is deleted, the uptime monitor is deleted but the seat is left allocated.