### PR TITLE
fix(autofix): Batch PUT requests in settings to stay under concurrency limit

### DIFF
--- a/static/gsApp/views/seerAutomation/onboarding.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding.tsx
@@ -443,17 +443,22 @@ function AutoTriggerFixesButton({
     setIsLoading(true);
 
     try {
-      await Promise.all(
-        projectsWithRepos.map(project =>
-          api.requestPromise(`/projects/${organization.slug}/${project.slug}/`, {
-            method: 'PUT',
-            data: {
-              autofixAutomationTuning: selectedThreshold,
-              seerScannerAutomation: true,
-            },
-          })
-        )
-      );
+      // Process projects in batches of 15 to avoid concurrency limit
+      const batchSize = 15;
+      for (let i = 0; i < projectsWithRepos.length; i += batchSize) {
+        const batch = projectsWithRepos.slice(i, i + batchSize);
+        await Promise.all(
+          batch.map(project =>
+            api.requestPromise(`/projects/${organization.slug}/${project.slug}/`, {
+              method: 'PUT',
+              data: {
+                autofixAutomationTuning: selectedThreshold,
+                seerScannerAutomation: true,
+              },
+            })
+          )
+        );
+      }
 
       addSuccessMessage(
         t(
@@ -526,14 +531,19 @@ function EnableIssueScansButton({
     setIsLoading(true);
 
     try {
-      await Promise.all(
-        projectsWithoutRepos.map(project =>
-          api.requestPromise(`/projects/${organization.slug}/${project.slug}/`, {
-            method: 'PUT',
-            data: {seerScannerAutomation: true},
-          })
-        )
-      );
+      // Process projects in batches of 15 to avoid concurrency limit
+      const batchSize = 15;
+      for (let i = 0; i < projectsWithoutRepos.length; i += batchSize) {
+        const batch = projectsWithoutRepos.slice(i, i + batchSize);
+        await Promise.all(
+          batch.map(project =>
+            api.requestPromise(`/projects/${organization.slug}/${project.slug}/`, {
+              method: 'PUT',
+              data: {seerScannerAutomation: true},
+            })
+          )
+        );
+      }
 
       addSuccessMessage(
         t('Issue scans enabled for %s remaining project(s)', projectsWithoutRepos.length)

--- a/static/gsApp/views/seerAutomation/onboarding.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding.tsx
@@ -438,13 +438,13 @@ function AutoTriggerFixesButton({
     }
 
     addLoadingMessage(t('Enabling automation for projects with repositories...'), {
-      duration: 30000,
+      duration: 60000,
     });
     setIsLoading(true);
 
     try {
-      // Process projects in batches of 15 to avoid concurrency limit
-      const batchSize = 15;
+      // Process projects in batches to avoid concurrency limit
+      const batchSize = 20;
       for (let i = 0; i < projectsWithRepos.length; i += batchSize) {
         const batch = projectsWithRepos.slice(i, i + batchSize);
         await Promise.all(
@@ -526,13 +526,13 @@ function EnableIssueScansButton({
     }
 
     addLoadingMessage(t('Enabling issue scans for remaining projects...'), {
-      duration: 30000,
+      duration: 60000,
     });
     setIsLoading(true);
 
     try {
-      // Process projects in batches of 15 to avoid concurrency limit
-      const batchSize = 15;
+      // Process projects in batches to avoid concurrency limit
+      const batchSize = 20;
       for (let i = 0; i < projectsWithoutRepos.length; i += batchSize) {
         const batch = projectsWithoutRepos.slice(i, i + batchSize);
         await Promise.all(

--- a/static/gsApp/views/seerAutomation/seerAutomationProjectList.tsx
+++ b/static/gsApp/views/seerAutomation/seerAutomationProjectList.tsx
@@ -229,26 +229,33 @@ export function SeerAutomationProjectList() {
   };
 
   async function updateProjectsSeerValue(value: string) {
-    addLoadingMessage('Updating projects...', {duration: 30000});
+    addLoadingMessage('Updating projects...', {duration: 60000});
     try {
-      await Promise.all(
-        Array.from(selected).map(projectId => {
-          const project = projects.find(p => p.id === projectId);
-          if (!project) return Promise.resolve();
+      // Process projects in batches to avoid concurrency limit
+      const batchSize = 20;
+      const selectedProjects = Array.from(selected);
 
-          const updateData: any = {autofixAutomationTuning: value};
+      for (let i = 0; i < selectedProjects.length; i += batchSize) {
+        const batch = selectedProjects.slice(i, i + batchSize);
+        await Promise.all(
+          batch.map(projectId => {
+            const project = projects.find(p => p.id === projectId);
+            if (!project) return Promise.resolve();
 
-          // If setting fixes to anything other than "off", also enable scanner
-          if (value !== 'off') {
-            updateData.seerScannerAutomation = true;
-          }
+            const updateData: any = {autofixAutomationTuning: value};
 
-          return api.requestPromise(`/projects/${organization.slug}/${project.slug}/`, {
-            method: 'PUT',
-            data: updateData,
-          });
-        })
-      );
+            // If setting fixes to anything other than "off", also enable scanner
+            if (value !== 'off') {
+              updateData.seerScannerAutomation = true;
+            }
+
+            return api.requestPromise(`/projects/${organization.slug}/${project.slug}/`, {
+              method: 'PUT',
+              data: updateData,
+            });
+          })
+        );
+      }
       addSuccessMessage('Projects updated successfully');
     } catch (err) {
       addErrorMessage('Failed to update some projects');
@@ -267,18 +274,25 @@ export function SeerAutomationProjectList() {
   }
 
   async function updateProjectsSeerScanner(value: boolean) {
-    addLoadingMessage('Updating projects...', {duration: 30000});
+    addLoadingMessage('Updating projects...', {duration: 60000});
     try {
-      await Promise.all(
-        Array.from(selected).map(projectId => {
-          const project = projects.find(p => p.id === projectId);
-          if (!project) return Promise.resolve();
-          return api.requestPromise(`/projects/${organization.slug}/${project.slug}/`, {
-            method: 'PUT',
-            data: {seerScannerAutomation: value},
-          });
-        })
-      );
+      // Process projects in batches to avoid concurrency limit
+      const batchSize = 20;
+      const selectedProjects = Array.from(selected);
+
+      for (let i = 0; i < selectedProjects.length; i += batchSize) {
+        const batch = selectedProjects.slice(i, i + batchSize);
+        await Promise.all(
+          batch.map(projectId => {
+            const project = projects.find(p => p.id === projectId);
+            if (!project) return Promise.resolve();
+            return api.requestPromise(`/projects/${organization.slug}/${project.slug}/`, {
+              method: 'PUT',
+              data: {seerScannerAutomation: value},
+            });
+          })
+        );
+      }
       addSuccessMessage('Projects updated successfully');
     } catch (err) {
       addErrorMessage('Failed to update some projects');


### PR DESCRIPTION
Bulk project settings updates were hitting concurrency limits or rate limits in the API intermittently. Batching requests 20 at a time alleviates that in my testing