### PR TITLE
fix(project-configs): Use update ORM method to avoid post save() signals

### DIFF
--- a/src/sentry/models/options/project_option.py
+++ b/src/sentry/models/options/project_option.py
@@ -143,8 +143,9 @@ class ProjectOptionManager(OptionManager["ProjectOption"]):
                 if created:
                     is_value_changed = True
                 elif obj.value != value:
-                    obj.value = value
-                    obj.save(update_fields=["value"])
+                    # update the value via ORM update() to avoid post save signals which
+                    # might cause cache reload when it is not needed (e.g. post_save signal)
+                    self.filter(id=obj.id).update(value=value)
                     is_value_changed = True
 
             if reload_cache and is_value_changed:


### PR DESCRIPTION
Calling `obj.save()` triggers `post_save` signal in Django, and by triggering this signal, it completely bypasses `reload_cache` argument, and reloads the cache always. By using Django ORM `update` method, `post_save` signal won't be emitted, and all the cache reloading logic will only happen in the `set_value` function.
