### PR TITLE
feat(sdk-crashes): Cocoa ignore crash exception

### DIFF
--- a/src/sentry/utils/sdk_crashes/sdk_crash_detection_config.py
+++ b/src/sentry/utils/sdk_crashes/sdk_crash_detection_config.py
@@ -132,12 +132,17 @@ def build_sdk_crash_detection_configs() -> Sequence[SDKCrashDetectionConfig]:
                 path_patterns={"Sentry**"},
                 path_replacer=FixedPathReplacer(path="Sentry.framework"),
             ),
-            # [SentrySDK crash] is a testing function causing a crash.
-            # Therefore, we don't want to mark it a as a SDK crash.
             sdk_crash_ignore_matchers={
+                # [SentrySDK crash] is a testing function causing a crash.
+                # Therefore, we don't want to mark it a as a SDK crash.
                 FunctionAndModulePattern(
                     module_pattern="*",
                     function_pattern="**SentrySDK crash**",
+                ),
+                # SentryCrashExceptionApplicationHelper._crashOnException calls abort() intentionally, which would cause false positives.
+                FunctionAndModulePattern(
+                    module_pattern="*",
+                    function_pattern="**SentryCrashExceptionApplicationHelper _crashOnException**",
                 ),
             },
         )

--- a/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection_cocoa.py
+++ b/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection_cocoa.py
@@ -620,6 +620,14 @@ class CococaSDKFunctionTestMixin(BaseSDKCrashDetectionMixin):
             mock_sdk_crash_reporter,
         )
 
+    # "SentryCrashExceptionApplicationHelper _crashOnException" calls abort() intentionally, so we must ignore it.
+    def test_sentrycrash_exception_application_helper_not_reported(self, mock_sdk_crash_reporter):
+        self.execute_test(
+            get_crash_event(function="+[SentryCrashExceptionApplicationHelper _crashOnException:]"),
+            False,
+            mock_sdk_crash_reporter,
+        )
+
 
 class SDKCrashDetectionCocoaTest(
     TestCase, CococaSDKFilenameTestMixin, CococaSDKFramesTestMixin, CococaSDKFunctionTestMixin


### PR DESCRIPTION
Ignore SentryCrashExceptionApplicationHelper _crashOnException because it causes false positives.
