### PR TITLE
fix: Remove N near icon of nintendo switch

### DIFF
--- a/static/app/components/platformPicker.tsx
+++ b/static/app/components/platformPicker.tsx
@@ -332,7 +332,7 @@ const PlatformCard = styled(
         platform={platform.id}
         size={56}
         radius={5}
-        withLanguageIcon
+        withLanguageIcon={platform.iconConfig?.withLanguageIcon ?? true}
         format="lg"
       />
       <h3>{platform.name}</h3>

--- a/static/app/data/platforms.tsx
+++ b/static/app/data/platforms.tsx
@@ -416,6 +416,9 @@ export const platforms: PlatformIntegration[] = [
     type: 'console',
     language: 'console',
     link: 'https://docs.sentry.io/platforms/nintendo-switch/',
+    iconConfig: {
+      withLanguageIcon: false,
+    },
   },
   {
     id: 'node',

--- a/static/app/types/project.tsx
+++ b/static/app/types/project.tsx
@@ -316,4 +316,7 @@ export type PlatformIntegration = {
   link: string | null;
   name: string;
   type: string;
+  iconConfig?: {
+    withLanguageIcon: boolean;
+  };
 };


### PR DESCRIPTION
**Before**

<img width="161" height="161" alt="image" src="https://github.com/user-attachments/assets/3e2d83d9-b1c1-477f-a083-774aa9d5c090" />


**After**

<img width="120" height="144" alt="image" src="https://github.com/user-attachments/assets/2ee920fe-f934-46be-a60c-d62af0221de8" />

closes https://linear.app/getsentry/issue/TET-947/remove-the-little-n-rendered-near-the-nintendo-switch-icon