### PR TITLE
fix(ui2): vertically center TabListOverflow indicator

### DIFF
--- a/static/app/components/core/tabs/tabList.chonk.tsx
+++ b/static/app/components/core/tabs/tabList.chonk.tsx
@@ -34,3 +34,11 @@ export const ChonkStyledTabListWrap = chonkStyled('ul', {
           padding-right: ${space(0.5)};
         `};
 `;
+
+export const ChonkStyledTabListOverflowWrap = chonkStyled('div')`
+  position: absolute;
+  right: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: ${p => p.theme.zIndex.dropdown};
+`;

--- a/static/app/components/core/tabs/tabList.tsx
+++ b/static/app/components/core/tabs/tabList.tsx
@@ -23,7 +23,7 @@ import type {TabListItemProps} from './item';
 import {TabListItem} from './item';
 import {Tab} from './tab';
 import type {BaseTabProps} from './tab.chonk';
-import {ChonkStyledTabListWrap} from './tabList.chonk';
+import {ChonkStyledTabListOverflowWrap, ChonkStyledTabListWrap} from './tabList.chonk';
 import {tabsShouldForwardProp} from './utils';
 
 /**
@@ -342,11 +342,15 @@ const TabListWrap = withChonk(
   ChonkStyledTabListWrap
 );
 
-const TabListOverflowWrap = styled('div')`
-  position: absolute;
-  right: 0;
-  bottom: ${space(0.75)};
-`;
+const TabListOverflowWrap = withChonk(
+  styled('div')`
+    position: absolute;
+    right: 0;
+    bottom: ${space(0.75)};
+  `,
+  ChonkStyledTabListOverflowWrap
+);
+
 const OverflowMenuTrigger = styled(DropdownButton)`
   padding-left: ${space(1)};
   padding-right: ${space(1)};


### PR DESCRIPTION
the overflow indicator (`...`) wasn’t always vertically centered:

| before | after |
|--------|--------|
| <img width="603" height="157" alt="Screenshot 2025-07-24 at 12 48 42" src="https://github.com/user-attachments/assets/79026b3f-1630-47f5-9695-60a65b3aad7a" /> | <img width="603" height="157" alt="Screenshot 2025-07-24 at 12 47 15" src="https://github.com/user-attachments/assets/4e1ab2cb-425c-4edd-bd67-36bc26b106ed" /> | 