### PR TITLE
feat(agents-insights): add tooltip for tokens

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
@@ -1,5 +1,7 @@
+import styled from '@emotion/styled';
+
+import {Tooltip} from 'sentry/components/core/tooltip';
 import Count from 'sentry/components/count';
-import {IconArrow} from 'sentry/icons/iconArrow';
 import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import {prettifyAttributeName} from 'sentry/views/explore/components/traceItemAttributes/utils';
@@ -71,20 +73,23 @@ function getAISpanAttributes(attributes: Record<string, string | number | boolea
     });
   }
 
-  const promptTokens = getAIAttribute(attributes, 'gen_ai.usage.input_tokens');
-  const completionTokens = getAIAttribute(attributes, 'gen_ai.usage.output_tokens');
+  const inputTokens = getAIAttribute(attributes, 'gen_ai.usage.input_tokens');
+  const cachedTokens = getAIAttribute(attributes, 'gen_ai.usage.cached_tokens');
+  const outputTokens = getAIAttribute(attributes, 'gen_ai.usage.output_tokens');
+  const reasoningTokens = getAIAttribute(attributes, 'gen_ai.usage.reasoning_tokens');
   const totalTokens = getAIAttribute(attributes, 'gen_ai.usage.total_tokens');
-  if (promptTokens && completionTokens && totalTokens && Number(totalTokens) > 0) {
+
+  if (inputTokens && outputTokens && totalTokens && Number(totalTokens) > 0) {
     highlightedAttributes.push({
       name: t('Tokens'),
       value: (
-        <span>
-          <Count value={promptTokens.toString()} />{' '}
-          <IconArrow direction="right" size="xs" />{' '}
-          <Count value={completionTokens.toString()} /> {' (Σ '}
-          <Count value={totalTokens.toString()} />
-          {')'}
-        </span>
+        <HighlightedTokenAttributes
+          inputTokens={Number(inputTokens)}
+          cachedTokens={Number(cachedTokens)}
+          outputTokens={Number(outputTokens)}
+          reasoningTokens={Number(reasoningTokens)}
+          totalTokens={Number(totalTokens)}
+        />
       ),
     });
   }
@@ -145,3 +150,76 @@ function getMCPAttributes(attributes: Record<string, string | number | boolean>)
 
   return highlightedAttributes;
 }
+
+function HighlightedTokenAttributes({
+  inputTokens,
+  cachedTokens,
+  outputTokens,
+  reasoningTokens,
+  totalTokens,
+}: {
+  cachedTokens: number;
+  inputTokens: number;
+  outputTokens: number;
+  reasoningTokens: number;
+  totalTokens: number;
+}) {
+  return (
+    <Tooltip
+      title={
+        <TokensTooltipTitle>
+          <span>{t('Input')}</span>
+          <span>{inputTokens.toString()}</span>
+          <SubTextCell>{t('Cached')}</SubTextCell>
+          <SubTextCell>{isNaN(cachedTokens) ? '0' : cachedTokens.toString()}</SubTextCell>
+          <span>{t('Output')}</span>
+          <span>{outputTokens.toString()}</span>
+          <SubTextCell>{t('Reasoning')}</SubTextCell>
+          <SubTextCell>
+            {isNaN(reasoningTokens) ? '0' : reasoningTokens.toString()}
+          </SubTextCell>
+          <span>{t('Total')}</span>
+          <span>{totalTokens.toString()}</span>
+        </TokensTooltipTitle>
+      }
+    >
+      <TokensSpan>
+        <span>
+          <Count value={inputTokens.toString()} /> {t('in')}
+        </span>
+        <span>+</span>
+        <span>
+          <Count value={outputTokens.toString()} /> {t('out')}
+        </span>
+        <span>=</span>
+        <span>
+          <Count value={totalTokens.toString()} /> {t('total')}
+        </span>
+      </TokensSpan>
+    </Tooltip>
+  );
+}
+
+const TokensTooltipTitle = styled('div')`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  > *:nth-child(odd) {
+    text-align: left;
+  }
+  > *:nth-child(even) {
+    text-align: right;
+  }
+  gap: ${p => p.theme.space.xs};
+`;
+
+const SubTextCell = styled('span')`
+  margin-left: ${p => p.theme.space.md};
+  color: ${p => p.theme.subText};
+`;
+
+const TokensSpan = styled('span')`
+  display: flex;
+  align-items: center;
+  gap: ${p => p.theme.space.xs};
+  border-bottom: 1px dashed ${p => p.theme.border};
+`;


### PR DESCRIPTION
Simplifies token attribute in span details, adds a tooltip with raw values.
Closes [TET-941: Tokens tooltip](https://linear.app/getsentry/issue/TET-941/tokens-tooltip)

<img width="279" height="238" alt="image" src="https://github.com/user-attachments/assets/bea552a6-55f2-41f1-9d32-53dbec102add" />
