### PR TITLE
fix(ui2): adjust secondary nav styles to match tab component

### DIFF
--- a/static/app/views/nav/secondary/secondary.tsx
+++ b/static/app/views/nav/secondary/secondary.tsx
@@ -370,7 +370,7 @@ const ChonkItem = chonkStyled(Link)<ItemProps>`
   justify-content: center;
   align-items: center;
   position: relative;
-  color: ${p => p.theme.tokens.content.muted};
+  color: ${p => p.theme.tokens.component.link.muted.default};
   padding: ${p => (p.layout === NavLayout.MOBILE ? `${space(0.75)} ${space(1.5)} ${space(0.75)} 48px` : `${space(0.75)} ${space(1.5)}`)};
   border-radius: ${p => p.theme.radius[p.layout === NavLayout.MOBILE ? 'none' : 'md']};
 
@@ -395,12 +395,12 @@ const ChonkItem = chonkStyled(Link)<ItemProps>`
   }
 
   &:hover {
-    color: ${p => p.theme.tokens.content.muted};
+    color: ${p => p.theme.tokens.component.link.muted.default};
     background-color: ${p => p.theme.colors.gray100};
   }
 
   &[aria-selected='true'] {
-    color: ${p => p.theme.colors.blue400};
+    color: ${p => p.theme.tokens.component.link.accent.default};
     background-color: ${p => p.theme.colors.blue100};
 
     &::before {
@@ -408,7 +408,7 @@ const ChonkItem = chonkStyled(Link)<ItemProps>`
     }
     /* Override the default hover styles */
     &:hover {
-      background-color: ${p => p.theme.colors.blue100};
+      background-color: ${p => p.theme.colors.blue200};
     }
   }
 `;


### PR DESCRIPTION
| before | after |
|--------|--------|
| <img width="910" height="400" alt="Screenshot 2025-07-24 at 13 56 30" src="https://github.com/user-attachments/assets/2eb6fb58-9017-482d-b3d2-e8cc9db9d4e1" /> |<img width="910" height="400" alt="Screenshot 2025-07-24 at 13 56 10" src="https://github.com/user-attachments/assets/15d8ed33-425d-4fa9-bfe2-31dc4394a64b" /> | 

in case you don’t spot the difference - the color of the text `Frontend` in the sidebar is now the same as the color of `Overview` in the tab.