### PR TITLE
fix(ui2): error colors for traceWaterfallStyles

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceWaterfallStyles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceWaterfallStyles.tsx
@@ -1,11 +1,13 @@
 import type {Theme} from '@emotion/react';
 
+import {isChonkTheme} from 'sentry/utils/theme/withChonk';
+
 export const traceGridCssVariables = ({theme}: {theme: Theme}) => `
   --info: ${theme.purple400};
   --warning: ${theme.yellow300};
   --debug: ${theme.blue300};
-  --error: ${theme.error};
-  --fatal: ${theme.error};
+  --error: ${isChonkTheme(theme) ? theme.tokens.graphics.danger : theme.error};
+  --fatal: ${isChonkTheme(theme) ? theme.tokens.graphics.danger : theme.error};
   --default: ${theme.gray300};
   --unknown: ${theme.gray300};
   --profile: ${theme.purple300};


### PR DESCRIPTION
| before | after |
|--------|--------|
| <img width="510" height="400" alt="Screenshot 2025-07-24 at 14 16 28" src="https://github.com/user-attachments/assets/ee689b3f-3b99-40b2-ba4f-4784c5cccdee" /> | <img width="510" height="400" alt="Screenshot 2025-07-24 at 14 16 15" src="https://github.com/user-attachments/assets/cf9d785a-62a8-42b6-a175-d2c8c2ded7c4" /> | 