### PR TITLE
fix(ui2): cut-off buttons

### DIFF
--- a/static/app/views/settings/organizationIntegrations/repositoryProjectPathConfigRow.tsx
+++ b/static/app/views/settings/organizationIntegrations/repositoryProjectPathConfigRow.tsx
@@ -116,7 +116,7 @@ export const InputPathColumn = styled(Column)`
   grid-area: input-path;
 `;
 
-export const ButtonWrapper = styled(Column)`
+export const ButtonWrapper = styled('span')`
   display: flex;
   gap: ${space(1)};
 `;


### PR DESCRIPTION
`overflow:hidden` breaks our chonky buttons, but it’s not needed here as we have no text in this “Column”.

| before | after |
|--------|--------|
| <img width="368" height="474" alt="Screenshot 2025-07-24 at 14 53 26" src="https://github.com/user-attachments/assets/c533fba3-fbea-4da4-8b6c-5b255e62cca7" /> | <img width="368" height="474" alt="Screenshot 2025-07-24 at 14 53 54" src="https://github.com/user-attachments/assets/2d9a22d1-cebb-4aef-a5aa-263f4fc0b12e" /> | 