### PR TITLE
fix(ui2): cut-off replay button

### DIFF
--- a/static/app/components/events/eventReplay/replayPreviewPlayer.tsx
+++ b/static/app/components/events/eventReplay/replayPreviewPlayer.tsx
@@ -23,6 +23,8 @@ import getRouteStringFromRoutes from 'sentry/utils/getRouteStringFromRoutes';
 import {TabKey} from 'sentry/utils/replays/hooks/useActiveReplayTab';
 import useMarkReplayViewed from 'sentry/utils/replays/hooks/useMarkReplayViewed';
 import {useReplayReader} from 'sentry/utils/replays/playback/providers/replayReaderProvider';
+import {chonkStyled} from 'sentry/utils/theme/theme.chonk';
+import {withChonk} from 'sentry/utils/theme/withChonk';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {useRoutes} from 'sentry/utils/useRoutes';
@@ -102,7 +104,7 @@ export default function ReplayPreviewPlayer({
           columnIndex={0}
           showDropdownFilters={false}
         />
-        <LinkButton
+        <ContainedLinkButton
           size="sm"
           to={{
             pathname: makeReplaysPathname({
@@ -119,7 +121,7 @@ export default function ReplayPreviewPlayer({
           {...fullReplayButtonProps}
         >
           {t('See Full Replay')}
-        </LinkButton>
+        </ContainedLinkButton>
       </HeaderWrapper>
       <PreviewPlayerContainer ref={fullscreenRef} isSidebarOpen={isSidebarOpen}>
         <TooltipContext value={{container: fullscreenRef.current}}>
@@ -258,3 +260,12 @@ const HeaderWrapper = styled('div')`
 const StyledAlert = styled(Alert)`
   margin: ${space(1)} 0;
 `;
+
+const ContainedLinkButton = withChonk(
+  LinkButton,
+  chonkStyled(LinkButton)`
+    position: absolute;
+    right: 0;
+    top: 3px;
+  `
+);


### PR DESCRIPTION
This is another attempt to fix the “See full Replay” button, which is cut-off because the container has `overflow:hidden`. @ryan953 already tried to remove this with:
- https://github.com/getsentry/sentry/pull/95618

but it had to be reverted because of the  negative impact.

This time, we’re just fixing the button with an absolute positioning. Not a great fix but hopefully less impact.

| before | Header |
|--------|--------|
| <img width="301" height="328" alt="Screenshot 2025-07-24 at 15 23 44" src="https://github.com/user-attachments/assets/07c0593d-990a-4fe0-91c5-d4b60bad0c5a" /> | <img width="368" height="417" alt="Screenshot 2025-07-24 at 15 20 32" src="https://github.com/user-attachments/assets/3b4d01c2-1871-45e1-b788-0a306c919d53" /> |
| <img width="1102" height="214" alt="Screenshot 2025-07-24 at 15 23 31" src="https://github.com/user-attachments/assets/63e2a7ee-708e-4916-8c8b-f9a88100ffa2" /> | <img width="1102" height="214" alt="Screenshot 2025-07-24 at 15 22 24" src="https://github.com/user-attachments/assets/2f064694-9d40-4754-ac24-910d9ed47a32" /> | 