### PR TITLE
ref(analytics): move issues related analytics to typed events

### DIFF
--- a/src/sentry/analytics/events/codeowners_updated.py
+++ b/src/sentry/analytics/events/codeowners_updated.py
@@ -1,15 +1,12 @@
 from sentry import analytics
 
 
+@analytics.eventclass("codeowners.updated")
 class CodeownersUpdated(analytics.Event):
-    type = "codeowners.updated"
-
-    attributes = (
-        analytics.Attribute("user_id", required=False),
-        analytics.Attribute("organization_id"),
-        analytics.Attribute("project_id"),
-        analytics.Attribute("codeowners_id"),
-    )
+    user_id: int | None = None
+    organization_id: int
+    project_id: int
+    codeowners_id: int
 
 
 analytics.register(CodeownersUpdated)

--- a/src/sentry/analytics/events/project_issue_searched.py
+++ b/src/sentry/analytics/events/project_issue_searched.py
@@ -1,15 +1,12 @@
 from sentry import analytics
 
 
+@analytics.eventclass("project_issue.searched")
 class ProjectIssueSearchEvent(analytics.Event):
-    type = "project_issue.searched"
-
-    attributes = (
-        analytics.Attribute("user_id", required=False),
-        analytics.Attribute("organization_id"),
-        analytics.Attribute("project_id"),
-        analytics.Attribute("query"),
-    )
+    user_id: int | None = None
+    organization_id: int
+    project_id: int
+    query: str
 
 
 analytics.register(ProjectIssueSearchEvent)

--- a/src/sentry/api/analytics.py
+++ b/src/sentry/api/analytics.py
@@ -20,6 +20,7 @@ class GroupSimilarIssuesEmbeddingsCountEvent(analytics.Event):
     organization_id: int
     project_id: int
     group_id: int
+    hash: str
     user_id: int | None
     count_over_threshold: int | None = None
 

--- a/src/sentry/api/analytics.py
+++ b/src/sentry/api/analytics.py
@@ -1,54 +1,42 @@
 from sentry import analytics
 
 
+@analytics.eventclass("organization_saved_search.created")
 class OrganizationSavedSearchCreatedEvent(analytics.Event):
-    type = "organization_saved_search.created"
-
-    attributes = (
-        analytics.Attribute("org_id"),
-        analytics.Attribute("search_type"),
-        analytics.Attribute("query"),
-    )
+    org_id: int
+    search_type: str
+    query: str
 
 
+@analytics.eventclass("organization_saved_search.deleted")
 class OrganizationSavedSearchDeletedEvent(analytics.Event):
-    type = "organization_saved_search.deleted"
-
-    attributes = (
-        analytics.Attribute("org_id"),
-        analytics.Attribute("search_type"),
-        analytics.Attribute("query"),
-    )
+    org_id: int
+    search_type: str
+    query: str
 
 
+@analytics.eventclass("group_similar_issues_embeddings.count")
 class GroupSimilarIssuesEmbeddingsCountEvent(analytics.Event):
-    type = "group_similar_issues_embeddings.count"
-
-    attributes = (
-        analytics.Attribute("organization_id"),
-        analytics.Attribute("project_id"),
-        analytics.Attribute("group_id"),
-        analytics.Attribute("user_id"),
-        analytics.Attribute("count_over_threshold", required=False),
-    )
+    organization_id: int
+    project_id: int
+    group_id: int
+    user_id: int | None
+    count_over_threshold: int | None = None
 
 
+@analytics.eventclass("devtoolbar.api_request")
 class DevToolbarApiRequestEvent(analytics.Event):
-    type = "devtoolbar.api_request"
-
-    attributes = (
-        analytics.Attribute("view_name"),
-        analytics.Attribute("route"),
-        analytics.Attribute("query_string", required=False),
-        analytics.Attribute("origin", required=False),
-        analytics.Attribute("method"),
-        analytics.Attribute("status_code", type=int),
-        analytics.Attribute("organization_id", type=int, required=False),
-        analytics.Attribute("organization_slug", required=False),
-        analytics.Attribute("project_id", type=int, required=False),
-        analytics.Attribute("project_slug", required=False),
-        analytics.Attribute("user_id", type=int, required=False),
-    )
+    view_name: str
+    route: str
+    query_string: str | None = None
+    origin: str | None = None
+    method: str | None
+    status_code: int
+    organization_id: int | None = None
+    organization_slug: str | None = None
+    project_id: int | None = None
+    project_slug: str | None = None
+    user_id: int | None = None
 
 
 analytics.register(OrganizationSavedSearchCreatedEvent)

--- a/src/sentry/api/endpoints/codeowners/details.py
+++ b/src/sentry/api/endpoints/codeowners/details.py
@@ -9,6 +9,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import analytics
+from sentry.analytics.events.codeowners_updated import CodeownersUpdated
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
@@ -80,11 +81,12 @@ class ProjectCodeOwnersDetailsEndpoint(ProjectEndpoint, ProjectCodeOwnersMixin):
 
             user_id = getattr(request.user, "id", None) or None
             analytics.record(
-                "codeowners.updated",
-                user_id=user_id,
-                organization_id=project.organization_id,
-                project_id=project.id,
-                codeowners_id=updated_codeowners.id,
+                CodeownersUpdated(
+                    user_id=user_id,
+                    organization_id=project.organization_id,
+                    project_id=project.id,
+                    codeowners_id=updated_codeowners.id,
+                )
             )
             self.track_response_code("update", status.HTTP_200_OK)
             return Response(

--- a/src/sentry/api/endpoints/organization_search_details.py
+++ b/src/sentry/api/endpoints/organization_search_details.py
@@ -3,6 +3,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import analytics
+from sentry.api.analytics import OrganizationSavedSearchDeletedEvent
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
@@ -103,9 +104,10 @@ class OrganizationSearchDetailsEndpoint(OrganizationEndpoint):
         """
         search.delete()
         analytics.record(
-            "organization_saved_search.deleted",
-            search_type=SearchType(search.type).name,
-            org_id=organization.id,
-            query=search.query,
+            OrganizationSavedSearchDeletedEvent(
+                search_type=SearchType(search.type).name,
+                org_id=organization.id,
+                query=search.query,
+            )
         )
         return Response(status=204)

--- a/src/sentry/issues/analytics.py
+++ b/src/sentry/issues/analytics.py
@@ -1,10 +1,9 @@
 from sentry import analytics
 
 
+@analytics.eventclass("issue_forecasts.saved")
 class IssueForecastSaved(analytics.Event):
-    type = "issue_forecasts.saved"
-
-    attributes = (analytics.Attribute("num_groups"),)
+    num_groups: int
 
 
 analytics.register(IssueForecastSaved)

--- a/src/sentry/issues/endpoints/group_similar_issues_embeddings.py
+++ b/src/sentry/issues/endpoints/group_similar_issues_embeddings.py
@@ -7,6 +7,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import analytics, options
+from sentry.api.analytics import GroupSimilarIssuesEmbeddingsCountEvent
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
@@ -124,19 +125,19 @@ class GroupSimilarIssuesEmbeddingsEndpoint(GroupEndpoint):
         results = get_similarity_data_from_seer(similar_issues_params)
 
         analytics.record(
-            "group_similar_issues_embeddings.count",
-            organization_id=group.organization.id,
-            project_id=group.project.id,
-            group_id=group.id,
-            hash=latest_event.get_primary_hash(),
-            count_over_threshold=len(
-                [
-                    result.stacktrace_distance
-                    for result in results
-                    if result.stacktrace_distance <= 0.01
-                ]
-            ),
-            user_id=request.user.id,
+            GroupSimilarIssuesEmbeddingsCountEvent(
+                organization_id=group.organization.id,
+                project_id=group.project.id,
+                group_id=group.id,
+                count_over_threshold=len(
+                    [
+                        result.stacktrace_distance
+                        for result in results
+                        if result.stacktrace_distance <= 0.01
+                    ]
+                ),
+                user_id=request.user.id,
+            )
         )
 
         if not results:

--- a/src/sentry/issues/endpoints/group_similar_issues_embeddings.py
+++ b/src/sentry/issues/endpoints/group_similar_issues_embeddings.py
@@ -129,6 +129,7 @@ class GroupSimilarIssuesEmbeddingsEndpoint(GroupEndpoint):
                 organization_id=group.organization.id,
                 project_id=group.project.id,
                 group_id=group.id,
+                hash=latest_event.get_primary_hash(),
                 count_over_threshold=len(
                     [
                         result.stacktrace_distance

--- a/src/sentry/issues/endpoints/organization_searches.py
+++ b/src/sentry/issues/endpoints/organization_searches.py
@@ -3,6 +3,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import analytics
+from sentry.api.analytics import OrganizationSavedSearchCreatedEvent
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
@@ -111,9 +112,10 @@ class OrganizationSearchesEndpoint(OrganizationEndpoint):
             visibility=result["visibility"],
         )
         analytics.record(
-            "organization_saved_search.created",
-            search_type=SearchType(saved_search.type).name,
-            org_id=organization.id,
-            query=saved_search.query,
+            OrganizationSavedSearchCreatedEvent(
+                search_type=SearchType(saved_search.type).name,
+                org_id=organization.id,
+                query=saved_search.query,
+            )
         )
         return Response(serialize(saved_search, request.user))

--- a/src/sentry/issues/endpoints/project_group_index.py
+++ b/src/sentry/issues/endpoints/project_group_index.py
@@ -4,7 +4,7 @@ import logging
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import eventstore
+from sentry import analytics, eventstore
 from sentry.analytics.events.project_issue_searched import ProjectIssueSearchEvent
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
@@ -196,11 +196,13 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint):
 
         if results and query:
             advanced_search.send(project=project, sender=request.user)
-            ProjectIssueSearchEvent(
-                user_id=request.user.id,
-                organization_id=project.organization_id,
-                project_id=project.id,
-                query=query,
+            analytics.record(
+                ProjectIssueSearchEvent(
+                    user_id=request.user.id,
+                    organization_id=project.organization_id,
+                    project_id=project.id,
+                    query=query,
+                )
             )
 
         return response

--- a/src/sentry/issues/endpoints/project_group_index.py
+++ b/src/sentry/issues/endpoints/project_group_index.py
@@ -4,7 +4,8 @@ import logging
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import analytics, eventstore
+from sentry import eventstore
+from sentry.analytics.events.project_issue_searched import ProjectIssueSearchEvent
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
@@ -195,8 +196,7 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint):
 
         if results and query:
             advanced_search.send(project=project, sender=request.user)
-            analytics.record(
-                "project_issue.searched",
+            ProjectIssueSearchEvent(
                 user_id=request.user.id,
                 organization_id=project.organization_id,
                 project_id=project.id,

--- a/src/sentry/issues/escalating/forecasts.py
+++ b/src/sentry/issues/escalating/forecasts.py
@@ -6,6 +6,8 @@ import logging
 from collections.abc import Iterable, Sequence
 from datetime import datetime
 
+import sentry_sdk
+
 from sentry import analytics
 from sentry.issues.analytics import IssueForecastSaved
 from sentry.issues.escalating.escalating import (
@@ -50,7 +52,10 @@ def save_forecast_per_group(
                 "save_forecast_per_group",
                 extra={"group_id": group_id, "group_counts": group_count},
             )
-    analytics.record(IssueForecastSaved(num_groups=len(group_counts.keys())))
+    try:
+        analytics.record(IssueForecastSaved(num_groups=len(group_counts.keys())))
+    except Exception as e:
+        sentry_sdk.capture_exception(e)
 
 
 def generate_and_save_forecasts(groups: Iterable[Group]) -> None:

--- a/src/sentry/issues/escalating/forecasts.py
+++ b/src/sentry/issues/escalating/forecasts.py
@@ -50,7 +50,7 @@ def save_forecast_per_group(
                 "save_forecast_per_group",
                 extra={"group_id": group_id, "group_counts": group_count},
             )
-        analytics.record(IssueForecastSaved(num_groups=len(group_counts.keys())))
+    analytics.record(IssueForecastSaved(num_groups=len(group_counts.keys())))
 
 
 def generate_and_save_forecasts(groups: Iterable[Group]) -> None:

--- a/src/sentry/issues/escalating/forecasts.py
+++ b/src/sentry/issues/escalating/forecasts.py
@@ -7,6 +7,7 @@ from collections.abc import Iterable, Sequence
 from datetime import datetime
 
 from sentry import analytics
+from sentry.issues.analytics import IssueForecastSaved
 from sentry.issues.escalating.escalating import (
     ParsedGroupsCount,
     parse_groups_past_counts,
@@ -49,7 +50,7 @@ def save_forecast_per_group(
                 "save_forecast_per_group",
                 extra={"group_id": group_id, "group_counts": group_count},
             )
-    analytics.record("issue_forecasts.saved", num_groups=len(group_counts.keys()))
+        analytics.record(IssueForecastSaved(num_groups=len(group_counts.keys())))
 
 
 def generate_and_save_forecasts(groups: Iterable[Group]) -> None:

--- a/src/sentry/middleware/devtoolbar.py
+++ b/src/sentry/middleware/devtoolbar.py
@@ -3,6 +3,7 @@ import logging
 from django.http import HttpRequest, HttpResponse
 
 from sentry import analytics, options
+from sentry.api.analytics import DevToolbarApiRequestEvent
 from sentry.utils.http import origin_from_request
 from sentry.utils.http import query_string as get_query_string
 from sentry.utils.urls import parse_id_or_slug_param
@@ -48,16 +49,17 @@ def _record_api_request(request: HttpRequest, response: HttpResponse) -> None:
     query_string: str = get_query_string(request)  # starts with ? if non-empty
 
     analytics.record(
-        "devtoolbar.api_request",
-        view_name=view_name,
-        route=route,
-        query_string=query_string,
-        origin=origin,
-        method=request.method,
-        status_code=response.status_code,
-        organization_id=org_id or None,
-        organization_slug=org_slug,
-        project_id=project_id or None,
-        project_slug=project_slug,
-        user_id=request.user.id if hasattr(request, "user") and request.user else None,
+        DevToolbarApiRequestEvent(
+            view_name=view_name,
+            route=route,
+            query_string=query_string,
+            origin=origin,
+            method=request.method,
+            status_code=response.status_code,
+            organization_id=org_id or None,
+            organization_slug=org_slug,
+            project_id=project_id or None,
+            project_slug=project_slug,
+            user_id=request.user.id if hasattr(request, "user") and request.user else None,
+        )
     )

--- a/tests/sentry/issues/endpoints/test_group_similar_issues_embeddings.py
+++ b/tests/sentry/issues/endpoints/test_group_similar_issues_embeddings.py
@@ -275,6 +275,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             GroupSimilarIssuesEmbeddingsCountEvent(
                 organization_id=self.org.id,
                 project_id=self.project.id,
+                hash=self.event.get_primary_hash(),
                 group_id=self.group.id,
                 count_over_threshold=2,
                 user_id=self.user.id,
@@ -508,6 +509,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             GroupSimilarIssuesEmbeddingsCountEvent(
                 organization_id=self.org.id,
                 project_id=self.project.id,
+                hash=self.event.get_primary_hash(),
                 group_id=self.group.id,
                 count_over_threshold=0,
                 user_id=self.user.id,

--- a/tests/sentry/issues/endpoints/test_group_similar_issues_embeddings.py
+++ b/tests/sentry/issues/endpoints/test_group_similar_issues_embeddings.py
@@ -6,6 +6,7 @@ import orjson
 from urllib3.response import HTTPResponse
 
 from sentry import options
+from sentry.api.analytics import GroupSimilarIssuesEmbeddingsCountEvent
 from sentry.api.serializers.base import serialize
 from sentry.conf.server import SEER_SIMILAR_ISSUES_URL
 from sentry.issues.endpoints.group_similar_issues_embeddings import (
@@ -17,6 +18,7 @@ from sentry.models.grouphashmetadata import GroupHashMetadata
 from sentry.seer.similarity.types import SeerSimilarIssueData, SimilarIssuesEmbeddingsResponse
 from sentry.seer.similarity.utils import MAX_FRAME_COUNT
 from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers.analytics import assert_last_analytics_event
 from sentry.testutils.helpers.eventprocessing import save_new_event
 
 EXPECTED_STACKTRACE_STRING = 'ZeroDivisionError: division by zero\n  File "python_onboarding.py", function divide_by_zero\n    divide = 1/0'
@@ -268,14 +270,15 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             ["Yes", "Yes", "No"],
         )
 
-        mock_record.assert_called_with(
-            "group_similar_issues_embeddings.count",
-            organization_id=self.org.id,
-            project_id=self.project.id,
-            group_id=self.group.id,
-            hash=self.event.get_primary_hash(),
-            count_over_threshold=2,
-            user_id=self.user.id,
+        assert_last_analytics_event(
+            mock_record,
+            GroupSimilarIssuesEmbeddingsCountEvent(
+                organization_id=self.org.id,
+                project_id=self.project.id,
+                group_id=self.group.id,
+                count_over_threshold=2,
+                user_id=self.user.id,
+            ),
         )
 
     @mock.patch("sentry.seer.similarity.similar_issues.seer_grouping_connection_pool.urlopen")
@@ -500,14 +503,15 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
         response = self.client.get(self.path)
         assert response.data == []
 
-        mock_record.assert_called_with(
-            "group_similar_issues_embeddings.count",
-            organization_id=self.org.id,
-            project_id=self.project.id,
-            group_id=self.group.id,
-            hash=self.event.get_primary_hash(),
-            count_over_threshold=0,
-            user_id=self.user.id,
+        assert_last_analytics_event(
+            mock_record,
+            GroupSimilarIssuesEmbeddingsCountEvent(
+                organization_id=self.org.id,
+                project_id=self.project.id,
+                group_id=self.group.id,
+                count_over_threshold=0,
+                user_id=self.user.id,
+            ),
         )
 
     def test_no_contributing_exception(self) -> None:

--- a/tests/sentry/middleware/test_devtoolbar.py
+++ b/tests/sentry/middleware/test_devtoolbar.py
@@ -1,4 +1,5 @@
 from functools import cached_property
+from typing import cast
 from unittest.mock import MagicMock, patch
 
 from django.http import HttpResponse
@@ -8,6 +9,7 @@ from sentry.api import DevToolbarApiRequestEvent
 from sentry.middleware.devtoolbar import DevToolbarAnalyticsMiddleware
 from sentry.testutils.cases import APITestCase, SnubaTestCase, TestCase
 from sentry.testutils.helpers import override_options
+from sentry.testutils.helpers.analytics import assert_last_analytics_event, get_last_analytics_event
 from sentry.types.group import GroupSubStatus
 
 
@@ -27,10 +29,13 @@ class DevToolbarAnalyticsMiddlewareUnitTest(TestCase):
     @patch("sentry.analytics.record")
     def test_basic(self, mock_record: MagicMock):
         request = self.factory.get("/?queryReferrer=devtoolbar")
-        request.resolver_match = MagicMock()
+        view_name = "my-endpoint"
+        route = "/issues/(?P<issue_id>)/"
+        request.resolver_match = MagicMock(view_name=view_name, route=route)
         self.middleware(request)
-        mock_record.assert_called()
-        assert mock_record.call_args[0][0] == self.analytics_event_name
+
+        event = get_last_analytics_event(mock_record)
+        assert event.type == self.analytics_event_name
 
     @override_options({"devtoolbar.analytics.enabled": True})
     @patch("sentry.analytics.record")
@@ -70,10 +75,10 @@ class DevToolbarAnalyticsMiddlewareUnitTest(TestCase):
         request.resolver_match = MagicMock(view_name=view_name, route=route)
         self.middleware(request)
 
-        mock_record.assert_called()
-        assert mock_record.call_args[0][0] == self.analytics_event_name
-        assert mock_record.call_args[1].get("view_name") == view_name
-        assert mock_record.call_args[1].get("route") == route
+        event = cast(DevToolbarApiRequestEvent, get_last_analytics_event(mock_record))
+        assert event.type == self.analytics_event_name
+        assert event.view_name == view_name
+        assert event.route == route
 
     @override_options({"devtoolbar.analytics.enabled": True})
     @patch("sentry.analytics.record")
@@ -81,11 +86,13 @@ class DevToolbarAnalyticsMiddlewareUnitTest(TestCase):
         query = "?a=b&statsPeriod=14d&queryReferrer=devtoolbar"
         request = self.factory.get("/" + query)
         request.resolver_match = MagicMock()
+        request.resolver_match.view_name = "my-endpoint"
+        request.resolver_match.route = "/issues/(?P<issue_id>)/"
         self.middleware(request)
 
-        mock_record.assert_called()
-        assert mock_record.call_args[0][0] == self.analytics_event_name
-        assert mock_record.call_args[1].get("query_string") == query
+        event = cast(DevToolbarApiRequestEvent, get_last_analytics_event(mock_record))
+        assert event.type == self.analytics_event_name
+        assert event.query_string == query
 
     @override_options({"devtoolbar.analytics.enabled": True})
     @patch("sentry.analytics.record")
@@ -94,12 +101,12 @@ class DevToolbarAnalyticsMiddlewareUnitTest(TestCase):
         request = self.factory.get(
             f"{origin}/?queryReferrer=devtoolbar", headers={"Origin": origin}
         )
-        request.resolver_match = MagicMock()
+        request.resolver_match = MagicMock(view_name="my-endpoint", route="/issues/(?P<issue_id>)/")
         self.middleware(request)
 
-        mock_record.assert_called()
-        assert mock_record.call_args[0][0] == self.analytics_event_name
-        assert mock_record.call_args[1].get("origin") == origin
+        event = cast(DevToolbarApiRequestEvent, get_last_analytics_event(mock_record))
+        assert event.type == self.analytics_event_name
+        assert event.origin == origin
 
     @override_options({"devtoolbar.analytics.enabled": True})
     @patch("sentry.analytics.record")
@@ -107,36 +114,38 @@ class DevToolbarAnalyticsMiddlewareUnitTest(TestCase):
         origin = "https://potato.com"
         url = origin + "/issues/?a=b&queryReferrer=devtoolbar"
         request = self.factory.get(url, headers={"Referer": url})
-        request.resolver_match = MagicMock()
+        request.resolver_match = MagicMock(view_name="my-endpoint", route="/issues/(?P<issue_id>)/")
         self.middleware(request)
 
-        mock_record.assert_called()
-        assert mock_record.call_args[0][0] == self.analytics_event_name
-        assert mock_record.call_args[1].get("origin") == origin
+        event = cast(DevToolbarApiRequestEvent, get_last_analytics_event(mock_record))
+        assert event.type == self.analytics_event_name
+        assert event.origin == origin
 
     @override_options({"devtoolbar.analytics.enabled": True})
     @patch("sentry.analytics.record")
     def test_response_status_code(self, mock_record: MagicMock):
         request = self.factory.get("/?queryReferrer=devtoolbar")
-        request.resolver_match = MagicMock()
+        request.resolver_match = MagicMock(view_name="my-endpoint", route="/issues/(?P<issue_id>)/")
         self.middleware.get_response.return_value = HttpResponse(status=420)
         self.middleware(request)
 
-        mock_record.assert_called()
-        assert mock_record.call_args[0][0] == self.analytics_event_name
-        assert mock_record.call_args[1].get("status_code") == 420
+        event = cast(DevToolbarApiRequestEvent, get_last_analytics_event(mock_record))
+        assert event.type == self.analytics_event_name
+        assert event.status_code == 420
 
     @override_options({"devtoolbar.analytics.enabled": True})
     @patch("sentry.analytics.record")
     def test_methods(self, mock_record: MagicMock):
         for method in ["GET", "POST", "PUT", "DELETE"]:
             request = getattr(self.factory, method.lower())("/?queryReferrer=devtoolbar")
-            request.resolver_match = MagicMock()
+            request.resolver_match = MagicMock(
+                view_name="my-endpoint", route="/issues/(?P<issue_id>)/"
+            )
             self.middleware(request)
 
-            mock_record.assert_called()
-            assert mock_record.call_args[0][0] == self.analytics_event_name
-            assert mock_record.call_args[1].get("method") == method
+            event = cast(DevToolbarApiRequestEvent, get_last_analytics_event(mock_record))
+            assert event.type == self.analytics_event_name
+            assert event.method == method
 
 
 TEST_MIDDLEWARE = (
@@ -178,19 +187,21 @@ class DevToolbarAnalyticsMiddlewareIntegrationTest(APITestCase, SnubaTestCase):
             },
         )
 
-        mock_record.assert_any_call(
-            "devtoolbar.api_request",
-            view_name=expected_view_name,
-            route=expected_route,
-            query_string=query_string,
-            origin=self.origin,
-            method=method,
-            status_code=response.status_code,
-            organization_id=expected_org_id,
-            organization_slug=expected_org_slug,
-            project_id=expected_proj_id,
-            project_slug=expected_proj_slug,
-            user_id=self.user.id,
+        assert_last_analytics_event(
+            mock_record,
+            DevToolbarApiRequestEvent(
+                view_name=expected_view_name,
+                route=expected_route,
+                query_string=query_string,
+                origin=self.origin,
+                method=method,
+                status_code=response.status_code,
+                organization_id=expected_org_id,
+                organization_slug=expected_org_slug,
+                project_id=expected_proj_id,
+                project_slug=expected_proj_slug,
+                user_id=self.user.id,
+            ),
         )
 
     def test_organization_replays(self) -> None:

--- a/tests/sentry/tasks/test_weekly_escalating_forecast.py
+++ b/tests/sentry/tasks/test_weekly_escalating_forecast.py
@@ -2,6 +2,7 @@ from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
 from sentry.grouping.grouptype import ErrorGroupType
+from sentry.issues.analytics import IssueForecastSaved
 from sentry.issues.escalating.escalating_group_forecast import (
     ONE_EVENT_FORECAST,
     EscalatingGroupForecast,
@@ -10,6 +11,7 @@ from sentry.issues.grouptype import PerformanceP95EndpointRegressionGroupType
 from sentry.models.group import Group, GroupStatus
 from sentry.tasks.weekly_escalating_forecast import run_escalating_forecast
 from sentry.testutils.cases import APITestCase, SnubaTestCase
+from sentry.testutils.helpers.analytics import assert_last_analytics_event
 from sentry.types.group import GroupSubStatus
 from tests.sentry.issues.test_utils import get_mock_groups_past_counts_response
 
@@ -100,7 +102,10 @@ class TestWeeklyEscalatingForecast(APITestCase, SnubaTestCase):
                 second=0, microsecond=0
             ) == approximate_date_added.replace(second=0, microsecond=0)
             assert fetched_forecast.date_added < approximate_date_added
-            record_mock.assert_called_with("issue_forecasts.saved", num_groups=1)
+            assert_last_analytics_event(
+                record_mock,
+                IssueForecastSaved(num_groups=1),
+            )
 
     @patch("sentry.analytics.record")
     @patch("sentry.issues.escalating.forecasts.query_groups_past_counts")
@@ -155,7 +160,10 @@ class TestWeeklyEscalatingForecast(APITestCase, SnubaTestCase):
                     second=0, microsecond=0
                 ) == approximate_date_added.replace(second=0, microsecond=0)
                 assert fetched_forecast.date_added < approximate_date_added
-                record_mock.assert_called_with("issue_forecasts.saved", num_groups=3)
+                assert_last_analytics_event(
+                    record_mock,
+                    IssueForecastSaved(num_groups=3),
+                )
 
     @patch("sentry.analytics.record")
     @patch("sentry.issues.escalating.forecasts.query_groups_past_counts")
@@ -209,7 +217,10 @@ class TestWeeklyEscalatingForecast(APITestCase, SnubaTestCase):
             assert first_fetched_forecast is not None
             assert second_fetched_forecast is not None
             assert first_fetched_forecast.date_added < second_fetched_forecast.date_added
-            record_mock.assert_called_with("issue_forecasts.saved", num_groups=1)
+            assert_last_analytics_event(
+                record_mock,
+                IssueForecastSaved(num_groups=1),
+            )
 
     @patch("sentry.analytics.record")
     @patch("sentry.issues.escalating.forecasts.query_groups_past_counts")


### PR DESCRIPTION
- Was part of https://github.com/getsentry/sentry/pull/95209 - split up because it was too big to usefully review
- Transform event classes to use @analytics.eventclass decorator
- Transform analytics.record calls to use event class instances
- Update imports as needed

Contributes to TET-829