### PR TITLE
feat(deletions): New groups deletion task

### DIFF
--- a/src/sentry/api/helpers/group_index/delete.py
+++ b/src/sentry/api/helpers/group_index/delete.py
@@ -87,8 +87,6 @@ def delete_group_list(
         status__in=[GroupStatus.PENDING_DELETION, GroupStatus.DELETION_IN_PROGRESS]
     ).update(status=GroupStatus.PENDING_DELETION, substatus=None)
 
-    eventstream_state = eventstream.backend.start_delete_groups(project.id, group_ids)
-
     # The moment groups are marked as pending deletion, we create audit entries
     # so that we can see who requested the deletion. Even if anything after this point
     # fails, we will still have a record of who requested the deletion.
@@ -113,6 +111,7 @@ def delete_group_list(
                 }
             )
     else:
+        eventstream_state = eventstream.backend.start_delete_groups(project.id, group_ids)
         delete_groups_task.apply_async(
             kwargs={
                 "object_ids": group_ids,

--- a/src/sentry/api/helpers/group_index/delete.py
+++ b/src/sentry/api/helpers/group_index/delete.py
@@ -12,7 +12,7 @@ from rest_framework.response import Response
 
 from sentry import audit_log
 from sentry.api.base import audit_logger
-from sentry.deletions.tasks.groups import delete_groups_for_project_task
+from sentry.deletions.tasks.groups import delete_groups_for_project
 from sentry.issues.grouptype import GroupCategory
 from sentry.models.group import Group, GroupStatus
 from sentry.models.grouphash import GroupHash
@@ -93,7 +93,7 @@ def delete_group_list(
     # `Group` instances that are pending deletion
     GroupInbox.objects.filter(project_id=project.id, group__id__in=group_ids).delete()
 
-    delete_groups_for_project_task.apply_async(
+    delete_groups_for_project.apply_async(
         kwargs={
             "project_id": project.id,
             "object_ids": group_ids,

--- a/src/sentry/api/helpers/group_index/delete.py
+++ b/src/sentry/api/helpers/group_index/delete.py
@@ -13,7 +13,8 @@ from rest_framework.response import Response
 from sentry import audit_log, eventstream, options
 from sentry.api.base import audit_logger
 from sentry.deletions.defaults.group import GROUP_CHUNK_SIZE
-from sentry.deletions.tasks.groups import delete_groups, delete_groups_for_project
+from sentry.deletions.tasks.groups import delete_groups as delete_groups_task
+from sentry.deletions.tasks.groups import delete_groups_for_project
 from sentry.issues.grouptype import GroupCategory
 from sentry.models.group import Group, GroupStatus
 from sentry.models.grouphash import GroupHash
@@ -112,7 +113,7 @@ def delete_group_list(
                 }
             )
     else:
-        delete_groups.apply_async(
+        delete_groups_task.apply_async(
             kwargs={
                 "object_ids": group_ids,
                 "transaction_id": str(transaction_id),

--- a/src/sentry/deletions/tasks/groups.py
+++ b/src/sentry/deletions/tasks/groups.py
@@ -146,16 +146,16 @@ def delete_groups_for_project(
     eventstream_state = eventstream.backend.start_delete_groups(project_id, object_ids)
 
     # These can be used for debugging
-    extra = {"object_ids": object_ids, "project_id": project_id, "transaction_id": transaction_id}
+    extra = {"project_id": project_id, "transaction_id": transaction_id}
     sentry_sdk.set_tags(extra)
     logger.info("delete_groups.started", extra={"object_ids": object_ids, **extra})
 
-    task = deletions.get(model=Group, query={"id__in": object_ids})
+    task = deletions.get(model=Group, query={"id__in": object_ids}, transaction_id=transaction_id)
     has_more = task.chunk()
 
     # XXX: Delete this block once I'm convince this is not happening
     if has_more:
-        metrics.incr("deletions.groups.delete_groups_old.chunked", 1, sample_rate=1)
+        metrics.incr("deletions.groups.delete_groups_for_project.chunked", 1, sample_rate=1)
         sentry_sdk.capture_message(
             "This should not be happening",
             level="info",

--- a/src/sentry/deletions/tasks/groups.py
+++ b/src/sentry/deletions/tasks/groups.py
@@ -162,13 +162,6 @@ def delete_groups_for_project(
             # Use this to query the logs
             tags={"transaction_id": transaction_id},
         )
-        delete_groups_for_project.apply_async(
-            kwargs={
-                "object_ids": object_ids,
-                "project_id": project_id,
-                "transaction_id": transaction_id,
-            },
-        )
 
     # This will delete all Snuba events for all deleted groups
     eventstream.backend.end_delete_groups(eventstream_state)

--- a/src/sentry/deletions/tasks/groups.py
+++ b/src/sentry/deletions/tasks/groups.py
@@ -3,6 +3,7 @@ from typing import Any
 
 import sentry_sdk
 
+from sentry import deletions, eventstream
 from sentry.deletions.defaults.group import GROUP_CHUNK_SIZE
 from sentry.deletions.tasks.scheduled import MAX_RETRIES, logger
 from sentry.exceptions import DeleteAborted
@@ -32,24 +33,18 @@ from sentry.utils import metrics
 )
 @retry(exclude=(DeleteAborted,))
 @track_group_async_operation
-def delete_groups_old(
+def delete_groups(
     object_ids: Sequence[int],
     transaction_id: str,
     eventstream_state: Mapping[str, Any] | None = None,
     **kwargs: Any,
 ) -> None:
-    from sentry import deletions, eventstream
-    from sentry.models.group import Group
-
     current_batch, rest = object_ids[:GROUP_CHUNK_SIZE], object_ids[GROUP_CHUNK_SIZE:]
 
     # Select first_group from current_batch to ensure project_id tag reflects the current batch
     first_group = Group.objects.filter(id__in=current_batch).order_by("id").first()
     if not first_group:
         raise DeleteAborted("delete_groups.no_group_found")
-
-    # This is a no-op on the Snuba side, however, one day it may not be.
-    eventstream_state = eventstream.backend.start_delete_groups(first_group.project_id, object_ids)
 
     # The tags can be used if we want to find errors for when a task fails
     sentry_sdk.set_tags(
@@ -77,16 +72,7 @@ def delete_groups_old(
     )
     has_more = task.chunk()
     if has_more or rest:
-        # I want confirmation that this is not happening since the deletion task
-        # uses the same chunking logic.
-        metrics.incr("deletions.groups.delete_groups_old.chunked", 1, sample_rate=1)
-        sentry_sdk.capture_message(
-            "This should not be happening",
-            level="info",
-            # Use this to query the logs
-            tags={"transaction_id": transaction_id},
-        )
-        delete_groups_old.apply_async(
+        delete_groups.apply_async(
             kwargs={
                 "object_ids": object_ids if has_more else rest,
                 "project_id": first_group.project_id,
@@ -116,10 +102,9 @@ def delete_groups_old(
 @retry(exclude=(DeleteAborted,))
 @track_group_async_operation
 def delete_groups_for_project(
+    project_id: int,
     object_ids: Sequence[int],
     transaction_id: str,
-    project_id: int | None = None,  # XXX: Make it mandatory later
-    eventstream_state: Mapping[str, Any] | None = None,  # XXX: We will remove it later
     **kwargs: Any,
 ) -> None:
     """
@@ -156,10 +141,48 @@ def delete_groups_for_project(
             f"don't belong to project {project_id}"
         )
 
-    delete_groups_old(
-        object_ids=object_ids,
-        transaction_id=transaction_id,
-        eventstream_state=eventstream_state,
-        project_id=project_id,
-        **kwargs,
+    current_batch, rest = object_ids[:GROUP_CHUNK_SIZE], object_ids[GROUP_CHUNK_SIZE:]
+
+    # This is a no-op on the Snuba side, however, one day it may not be.
+    eventstream_state = eventstream.backend.start_delete_groups(project_id, object_ids)
+
+    # The tags can be used if we want to find errors for when a task fails
+    sentry_sdk.set_tags({"project_id": project_id, "transaction_id": transaction_id})
+
+    logger.info(
+        "delete_groups.started",
+        extra={
+            "object_ids_count": len(object_ids),
+            "object_ids_current_batch": current_batch,
+            "first_id": groups.first().id,
+            # These can be used when looking for logs in GCP
+            "project_id": project_id,
+            # All tasks initiated by the same request will have the same transaction_id
+            "transaction_id": transaction_id,
+        },
     )
+
+    task = deletions.get(
+        model=Group, query={"id__in": current_batch}, transaction_id=transaction_id
+    )
+    has_more = task.chunk()
+    if has_more or rest:
+        # I want confirmation that this is not happening since the deletion task
+        # uses the same chunking logic.
+        metrics.incr("deletions.groups.delete_groups_old.chunked", 1, sample_rate=1)
+        sentry_sdk.capture_message(
+            "This should not be happening",
+            level="info",
+            # Use this to query the logs
+            tags={"transaction_id": transaction_id},
+        )
+        delete_groups_for_project.apply_async(
+            kwargs={
+                "object_ids": object_ids if has_more else rest,
+                "project_id": project_id,
+                "transaction_id": transaction_id,
+            },
+        )
+    else:
+        # This will delete all Snuba events for all deleted groups
+        eventstream.backend.end_delete_groups(eventstream_state)

--- a/src/sentry/deletions/tasks/groups.py
+++ b/src/sentry/deletions/tasks/groups.py
@@ -75,13 +75,13 @@ def delete_groups(
         delete_groups.apply_async(
             kwargs={
                 "object_ids": object_ids if has_more else rest,
-                "project_id": first_group.project_id,
                 "transaction_id": transaction_id,
+                "eventstream_state": eventstream_state,
             },
         )
     else:
+        # all groups have been deleted
         if eventstream_state:
-            # This will delete all Snuba events for all deleted groups
             eventstream.backend.end_delete_groups(eventstream_state)
 
 

--- a/src/sentry/deletions/tasks/groups.py
+++ b/src/sentry/deletions/tasks/groups.py
@@ -115,11 +115,9 @@ def delete_groups_for_project(
     constraints. It will eventually replace delete_groups_old.
 
     Args:
+        project_id:         Project ID that all groups must belong to.
         object_ids:         List of group IDs to delete
-        transaction_id:     Unique identifier for this deletion operation
-        project_id:         Project ID that all groups must belong to. If None,
-                            will be inferred from the first group.
-        kwargs:             Additional arguments to pass to the task.
+        transaction_id:     Unique identifier to help debug deletion tasks
     """
     if not object_ids:
         raise DeleteAborted("delete_groups.empty_object_ids")

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -850,6 +850,12 @@ register(
 )
 
 register(
+    "deletions.groups.use-new-task",
+    type=Bool,
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
     "issues.severity.first-event-severity-calculation-projects-allowlist",
     type=Sequence,
     default=[],

--- a/tests/sentry/deletions/tasks/test_groups.py
+++ b/tests/sentry/deletions/tasks/test_groups.py
@@ -117,7 +117,9 @@ class DeleteGroupTest(TestCase):
 
     def test_scheduled_tasks_with_too_many_groups(self) -> None:
         NEW_CHUNK_SIZE = 2
-        group_ids = [123] * (NEW_CHUNK_SIZE + 1)
+        groups = self.create_n_groups_with_hashes(NEW_CHUNK_SIZE + 1, self.project)
+        group_ids = [group.id for group in groups]
+
         with (
             patch("sentry.deletions.tasks.groups.GROUP_CHUNK_SIZE", NEW_CHUNK_SIZE),
             self.tasks(),

--- a/tests/sentry/deletions/tasks/test_groups.py
+++ b/tests/sentry/deletions/tasks/test_groups.py
@@ -117,8 +117,7 @@ class DeleteGroupTest(TestCase):
 
     def test_scheduled_tasks_with_too_many_groups(self) -> None:
         NEW_CHUNK_SIZE = 2
-        group = self.create_group()
-        group_ids = [group.id] * (NEW_CHUNK_SIZE + 1)
+        group_ids = [123] * (NEW_CHUNK_SIZE + 1)
         with (
             patch("sentry.deletions.tasks.groups.GROUP_CHUNK_SIZE", NEW_CHUNK_SIZE),
             self.tasks(),

--- a/tests/sentry/deletions/tasks/test_groups.py
+++ b/tests/sentry/deletions/tasks/test_groups.py
@@ -118,6 +118,7 @@ class DeleteGroupTest(TestCase):
     def test_scheduled_tasks_with_too_many_groups(self) -> None:
         NEW_CHUNK_SIZE = 2
         groups = self.create_n_groups_with_hashes(NEW_CHUNK_SIZE + 1, self.project)
+        assert len(groups) > NEW_CHUNK_SIZE
         group_ids = [group.id for group in groups]
 
         with (

--- a/tests/sentry/deletions/tasks/test_groups.py
+++ b/tests/sentry/deletions/tasks/test_groups.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 import pytest
 
 from sentry import nodestore
-from sentry.deletions.tasks.groups import delete_groups_for_project_task
+from sentry.deletions.tasks.groups import delete_groups_for_project
 from sentry.eventstore.models import Event
 from sentry.exceptions import DeleteAborted
 from sentry.models.group import Group, GroupStatus
@@ -60,7 +60,7 @@ class DeleteGroupTest(TestCase):
         assert nodestore.backend.get(node_id_2)
 
         with self.tasks():
-            delete_groups_for_project_task(object_ids=[group.id], transaction_id=uuid4().hex)
+            delete_groups_for_project(object_ids=[group.id], transaction_id=uuid4().hex)
 
         assert not GroupRedirect.objects.filter(group_id=group.id).exists()
         assert not GroupHash.objects.filter(group_id=group.id).exists()
@@ -76,7 +76,7 @@ class DeleteGroupTest(TestCase):
         group.delete()
 
         with self.tasks():
-            delete_groups_for_project_task(object_ids=group_ids, transaction_id=uuid4().hex)
+            delete_groups_for_project(object_ids=group_ids, transaction_id=uuid4().hex)
 
         assert Group.objects.count() == 0
 
@@ -86,7 +86,7 @@ class DeleteGroupTest(TestCase):
         group.delete()
 
         with self.tasks(), pytest.raises(DeleteAborted):
-            delete_groups_for_project_task(object_ids=group_ids, transaction_id=uuid4().hex)
+            delete_groups_for_project(object_ids=group_ids, transaction_id=uuid4().hex)
 
     def test_prevent_project_groups_mismatch(self) -> None:
         group = self.create_group()
@@ -95,7 +95,7 @@ class DeleteGroupTest(TestCase):
         group_ids = [group.id, group2.id]
 
         with self.tasks(), pytest.raises(DeleteAborted):
-            delete_groups_for_project_task(
+            delete_groups_for_project(
                 object_ids=group_ids,
                 transaction_id=uuid4().hex,
                 project_id=group.project_id,

--- a/tests/sentry/deletions/test_group.py
+++ b/tests/sentry/deletions/test_group.py
@@ -9,7 +9,7 @@ from snuba_sdk import Column, Condition, Entity, Function, Op, Query, Request
 
 from sentry import nodestore
 from sentry.deletions.defaults.group import ErrorEventsDeletionTask, IssuePlatformEventsDeletionTask
-from sentry.deletions.tasks.groups import delete_groups
+from sentry.deletions.tasks.groups import delete_groups_for_project_task
 from sentry.event_manager import GroupInfo
 from sentry.eventstore.models import Event
 from sentry.issues.grouptype import FeedbackGroup, GroupCategory
@@ -75,7 +75,9 @@ class DeleteGroupTest(TestCase, SnubaTestCase):
         assert nodestore.backend.get(self.keep_node_id)
 
         with self.tasks():
-            delete_groups(object_ids=[group.id], transaction_id=uuid4().hex)
+            delete_groups_for_project_task(
+                object_ids=[group.id], transaction_id=uuid4().hex, project_id=self.project.id
+            )
 
         assert not UserReport.objects.filter(group_id=group.id).exists()
         assert not UserReport.objects.filter(event_id=self.event.event_id).exists()
@@ -98,7 +100,11 @@ class DeleteGroupTest(TestCase, SnubaTestCase):
 
         group = self.event.group
         with self.tasks():
-            delete_groups(object_ids=[group.id, other_event.group_id], transaction_id=uuid4().hex)
+            delete_groups_for_project_task(
+                object_ids=[group.id, other_event.group_id],
+                transaction_id=uuid4().hex,
+                project_id=self.project.id,
+            )
 
         assert not Group.objects.filter(id=group.id).exists()
         assert not Group.objects.filter(id=other_event.group_id).exists()
@@ -130,7 +136,11 @@ class DeleteGroupTest(TestCase, SnubaTestCase):
             prev_history=other_history_one,
         )
         with self.tasks():
-            delete_groups(object_ids=[group.id, other_group.id], transaction_id=uuid4().hex)
+            delete_groups_for_project_task(
+                object_ids=[group.id, other_group.id],
+                transaction_id=uuid4().hex,
+                project_id=self.project.id,
+            )
 
         assert GroupHistory.objects.filter(id=history_one.id).exists() is False
         assert GroupHistory.objects.filter(id=history_two.id).exists() is False
@@ -144,7 +154,11 @@ class DeleteGroupTest(TestCase, SnubaTestCase):
             group = self.event.group
 
             with self.tasks():
-                delete_groups(object_ids=[group.id], transaction_id=uuid4().hex)
+                delete_groups_for_project_task(
+                    object_ids=[group.id],
+                    transaction_id=uuid4().hex,
+                    project_id=self.project.id,
+                )
 
             assert nodestore_delete_multi.call_count == 0
         finally:
@@ -174,7 +188,11 @@ class DeleteGroupTest(TestCase, SnubaTestCase):
         ]
         group = self.event.group
         with self.tasks():
-            delete_groups(object_ids=[group.id, other_event.group_id], transaction_id=uuid4().hex)
+            delete_groups_for_project_task(
+                object_ids=[group.id, other_event.group_id],
+                transaction_id=uuid4().hex,
+                project_id=self.project.id,
+            )
 
         assert not Group.objects.filter(id=group.id).exists()
         assert not Group.objects.filter(id=other_event.group_id).exists()
@@ -222,7 +240,11 @@ class DeleteGroupTest(TestCase, SnubaTestCase):
         ]
 
         with self.tasks():
-            delete_groups(object_ids=[error_group.id, invalid_group.id], transaction_id=uuid4().hex)
+            delete_groups_for_project_task(
+                object_ids=[error_group.id, invalid_group.id],
+                transaction_id=uuid4().hex,
+                project_id=self.project.id,
+            )
 
         assert not Group.objects.filter(id__in=[error_group.id, invalid_group.id]).exists()
         assert Group.objects.filter(id=keep_group.id).exists()
@@ -310,7 +332,11 @@ class DeleteIssuePlatformTest(TestCase, SnubaTestCase, OccurrenceTestMixin):
 
         # This will delete the group and the events from the node store and Snuba
         with self.tasks():
-            delete_groups(object_ids=[issue_platform_group.id], transaction_id=uuid4().hex)
+            delete_groups_for_project_task(
+                object_ids=[issue_platform_group.id],
+                transaction_id=uuid4().hex,
+                project_id=self.project.id,
+            )
 
         # The original event and group still exist
         assert Group.objects.filter(id=event.group_id).exists()
@@ -343,7 +369,7 @@ class DeleteIssuePlatformTest(TestCase, SnubaTestCase, OccurrenceTestMixin):
 
             # This will delete the group and the events from the node store and Snuba
             with self.tasks():
-                delete_groups(
+                delete_groups_for_project_task(
                     object_ids=[group1.id, group2.id, group3.id, group4.id],
                     transaction_id=uuid4().hex,
                 )

--- a/tests/sentry/deletions/test_group.py
+++ b/tests/sentry/deletions/test_group.py
@@ -9,7 +9,7 @@ from snuba_sdk import Column, Condition, Entity, Function, Op, Query, Request
 
 from sentry import nodestore
 from sentry.deletions.defaults.group import ErrorEventsDeletionTask, IssuePlatformEventsDeletionTask
-from sentry.deletions.tasks.groups import delete_groups_for_project_task
+from sentry.deletions.tasks.groups import delete_groups_for_project
 from sentry.event_manager import GroupInfo
 from sentry.eventstore.models import Event
 from sentry.issues.grouptype import FeedbackGroup, GroupCategory
@@ -75,7 +75,7 @@ class DeleteGroupTest(TestCase, SnubaTestCase):
         assert nodestore.backend.get(self.keep_node_id)
 
         with self.tasks():
-            delete_groups_for_project_task(
+            delete_groups_for_project(
                 object_ids=[group.id], transaction_id=uuid4().hex, project_id=self.project.id
             )
 
@@ -100,7 +100,7 @@ class DeleteGroupTest(TestCase, SnubaTestCase):
 
         group = self.event.group
         with self.tasks():
-            delete_groups_for_project_task(
+            delete_groups_for_project(
                 object_ids=[group.id, other_event.group_id],
                 transaction_id=uuid4().hex,
                 project_id=self.project.id,
@@ -136,7 +136,7 @@ class DeleteGroupTest(TestCase, SnubaTestCase):
             prev_history=other_history_one,
         )
         with self.tasks():
-            delete_groups_for_project_task(
+            delete_groups_for_project(
                 object_ids=[group.id, other_group.id],
                 transaction_id=uuid4().hex,
                 project_id=self.project.id,
@@ -154,7 +154,7 @@ class DeleteGroupTest(TestCase, SnubaTestCase):
             group = self.event.group
 
             with self.tasks():
-                delete_groups_for_project_task(
+                delete_groups_for_project(
                     object_ids=[group.id],
                     transaction_id=uuid4().hex,
                     project_id=self.project.id,
@@ -188,7 +188,7 @@ class DeleteGroupTest(TestCase, SnubaTestCase):
         ]
         group = self.event.group
         with self.tasks():
-            delete_groups_for_project_task(
+            delete_groups_for_project(
                 object_ids=[group.id, other_event.group_id],
                 transaction_id=uuid4().hex,
                 project_id=self.project.id,
@@ -240,7 +240,7 @@ class DeleteGroupTest(TestCase, SnubaTestCase):
         ]
 
         with self.tasks():
-            delete_groups_for_project_task(
+            delete_groups_for_project(
                 object_ids=[error_group.id, invalid_group.id],
                 transaction_id=uuid4().hex,
                 project_id=self.project.id,
@@ -332,7 +332,7 @@ class DeleteIssuePlatformTest(TestCase, SnubaTestCase, OccurrenceTestMixin):
 
         # This will delete the group and the events from the node store and Snuba
         with self.tasks():
-            delete_groups_for_project_task(
+            delete_groups_for_project(
                 object_ids=[issue_platform_group.id],
                 transaction_id=uuid4().hex,
                 project_id=self.project.id,
@@ -369,7 +369,7 @@ class DeleteIssuePlatformTest(TestCase, SnubaTestCase, OccurrenceTestMixin):
 
             # This will delete the group and the events from the node store and Snuba
             with self.tasks():
-                delete_groups_for_project_task(
+                delete_groups_for_project(
                     object_ids=[group1.id, group2.id, group3.id, group4.id],
                     transaction_id=uuid4().hex,
                 )

--- a/tests/sentry/deletions/test_group.py
+++ b/tests/sentry/deletions/test_group.py
@@ -372,6 +372,7 @@ class DeleteIssuePlatformTest(TestCase, SnubaTestCase, OccurrenceTestMixin):
                 delete_groups_for_project(
                     object_ids=[group1.id, group2.id, group3.id, group4.id],
                     transaction_id=uuid4().hex,
+                    project_id=self.project.id,
                 )
 
             # There should be two batches: [group3, group1] (2+3=5 > 5, so group2 starts new batch), [group2]

--- a/tests/sentry/deletions/test_grouphash.py
+++ b/tests/sentry/deletions/test_grouphash.py
@@ -1,7 +1,7 @@
 from unittest.mock import patch
 from uuid import uuid4
 
-from sentry.deletions.tasks.groups import delete_groups
+from sentry.deletions.tasks.groups import delete_groups_for_project_task
 from sentry.models.group import Group
 from sentry.models.grouphash import GroupHash
 from sentry.models.grouphashmetadata import GroupHashMetadata
@@ -25,7 +25,7 @@ class DeleteGroupHashTest(TestCase):
         assert grouphash_metadata
 
         with self.tasks():
-            delete_groups(object_ids=[group_id], transaction_id=uuid4().hex)
+            delete_groups_for_project_task(object_ids=[group_id], transaction_id=uuid4().hex)
 
         assert not Group.objects.filter(id=group_id).exists()
         assert not GroupHash.objects.filter(group_id=group_id).exists()
@@ -59,7 +59,9 @@ class DeleteGroupHashTest(TestCase):
             assert new_grouphash.metadata.seer_matched_grouphash == existing_grouphash
 
         with self.tasks():
-            delete_groups(object_ids=[existing_group_id], transaction_id=uuid4().hex)
+            delete_groups_for_project_task(
+                object_ids=[existing_group_id], transaction_id=uuid4().hex
+            )
 
         assert not Group.objects.filter(id=existing_group_id).exists()
         assert not GroupHash.objects.filter(group_id=existing_group_id).exists()
@@ -123,7 +125,9 @@ class DeleteGroupHashTest(TestCase):
         )
 
         with self.tasks():
-            delete_groups(object_ids=[existing_event.group.id], transaction_id=uuid4().hex)
+            delete_groups_for_project_task(
+                object_ids=[existing_event.group.id], transaction_id=uuid4().hex
+            )
 
         assert not Group.objects.filter(id=existing_event.group.id).exists()
         assert not GroupHash.objects.filter(group_id=existing_event.group.id).exists()

--- a/tests/sentry/deletions/test_grouphash.py
+++ b/tests/sentry/deletions/test_grouphash.py
@@ -1,7 +1,7 @@
 from unittest.mock import patch
 from uuid import uuid4
 
-from sentry.deletions.tasks.groups import delete_groups_for_project_task
+from sentry.deletions.tasks.groups import delete_groups_for_project
 from sentry.models.group import Group
 from sentry.models.grouphash import GroupHash
 from sentry.models.grouphashmetadata import GroupHashMetadata
@@ -25,7 +25,7 @@ class DeleteGroupHashTest(TestCase):
         assert grouphash_metadata
 
         with self.tasks():
-            delete_groups_for_project_task(object_ids=[group_id], transaction_id=uuid4().hex)
+            delete_groups_for_project(object_ids=[group_id], transaction_id=uuid4().hex)
 
         assert not Group.objects.filter(id=group_id).exists()
         assert not GroupHash.objects.filter(group_id=group_id).exists()
@@ -59,9 +59,7 @@ class DeleteGroupHashTest(TestCase):
             assert new_grouphash.metadata.seer_matched_grouphash == existing_grouphash
 
         with self.tasks():
-            delete_groups_for_project_task(
-                object_ids=[existing_group_id], transaction_id=uuid4().hex
-            )
+            delete_groups_for_project(object_ids=[existing_group_id], transaction_id=uuid4().hex)
 
         assert not Group.objects.filter(id=existing_group_id).exists()
         assert not GroupHash.objects.filter(group_id=existing_group_id).exists()
@@ -125,7 +123,7 @@ class DeleteGroupHashTest(TestCase):
         )
 
         with self.tasks():
-            delete_groups_for_project_task(
+            delete_groups_for_project(
                 object_ids=[existing_event.group.id], transaction_id=uuid4().hex
             )
 

--- a/tests/sentry/deletions/test_grouphash.py
+++ b/tests/sentry/deletions/test_grouphash.py
@@ -25,7 +25,9 @@ class DeleteGroupHashTest(TestCase):
         assert grouphash_metadata
 
         with self.tasks():
-            delete_groups_for_project(object_ids=[group_id], transaction_id=uuid4().hex)
+            delete_groups_for_project(
+                object_ids=[group_id], transaction_id=uuid4().hex, project_id=self.project.id
+            )
 
         assert not Group.objects.filter(id=group_id).exists()
         assert not GroupHash.objects.filter(group_id=group_id).exists()
@@ -59,7 +61,11 @@ class DeleteGroupHashTest(TestCase):
             assert new_grouphash.metadata.seer_matched_grouphash == existing_grouphash
 
         with self.tasks():
-            delete_groups_for_project(object_ids=[existing_group_id], transaction_id=uuid4().hex)
+            delete_groups_for_project(
+                object_ids=[existing_group_id],
+                transaction_id=uuid4().hex,
+                project_id=self.project.id,
+            )
 
         assert not Group.objects.filter(id=existing_group_id).exists()
         assert not GroupHash.objects.filter(group_id=existing_group_id).exists()
@@ -124,7 +130,9 @@ class DeleteGroupHashTest(TestCase):
 
         with self.tasks():
             delete_groups_for_project(
-                object_ids=[existing_event.group.id], transaction_id=uuid4().hex
+                object_ids=[existing_event.group.id],
+                transaction_id=uuid4().hex,
+                project_id=self.project.id,
             )
 
         assert not Group.objects.filter(id=existing_event.group.id).exists()

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -4405,9 +4405,79 @@ class GroupDeleteTest(APITestCase, SnubaTestCase):
 
         self.assert_deleted_groups([group1, group2])
 
-    def test_bulk_delete_for_many_projects(self) -> None:
+    def test_bulk_delete_for_many_projects_with_option(self) -> None:
         NEW_CHUNK_SIZE = 2
+        with (
+            self.options({"deletions.groups.use-new-task": True}),
+            self.feature("organizations:global-views"),
+        ):
+            project_2 = self.create_project(slug="baz", organization=self.organization)
+            groups_1 = self.create_n_groups_with_hashes(2, project=self.project)
+            groups_2 = self.create_n_groups_with_hashes(5, project=project_2)
 
+            with (
+                self.tasks(),
+                patch("sentry.api.helpers.group_index.delete.GROUP_CHUNK_SIZE", NEW_CHUNK_SIZE),
+                patch("sentry.deletions.tasks.groups.logger") as mock_logger,
+                patch(
+                    "sentry.api.helpers.group_index.delete.uuid4",
+                    side_effect=[self.get_mock_uuid("foo"), self.get_mock_uuid("bar")],
+                ),
+            ):
+                self.login_as(user=self.user)
+                response = self.get_success_response(qs_params={"query": ""})
+                assert response.status_code == 204
+                batch_1 = [g.id for g in groups_2[0:2]]
+                batch_2 = [g.id for g in groups_2[2:4]]
+                batch_3 = [g.id for g in groups_2[4:]]
+                assert batch_1 + batch_2 + batch_3 == [g.id for g in groups_2]
+
+                calls_by_project: dict[int, list[tuple[str, dict[str, Any]]]] = defaultdict(list)
+                for log_call in mock_logger.info.call_args_list:
+                    calls_by_project[log_call[1]["extra"]["project_id"]].append(log_call)
+
+                assert len(calls_by_project) == 2
+                assert calls_by_project[self.project.id] == [
+                    call(
+                        "delete_groups.started",
+                        extra={
+                            "object_ids": [g.id for g in groups_1],
+                            "project_id": self.project.id,
+                            "transaction_id": "bar",
+                        },
+                    ),
+                ]
+                assert calls_by_project[project_2.id] == [
+                    call(
+                        "delete_groups.started",
+                        extra={
+                            "object_ids": batch_1,
+                            "project_id": project_2.id,
+                            "transaction_id": "foo",
+                        },
+                    ),
+                    call(
+                        "delete_groups.started",
+                        extra={
+                            "object_ids": batch_2,
+                            "project_id": project_2.id,
+                            "transaction_id": "foo",
+                        },
+                    ),
+                    call(
+                        "delete_groups.started",
+                        extra={
+                            "object_ids": batch_3,
+                            "project_id": project_2.id,
+                            "transaction_id": "foo",
+                        },
+                    ),
+                ]
+
+            self.assert_deleted_groups(groups_1 + groups_2)
+
+    def test_bulk_delete_for_many_projects_without_option(self) -> None:
+        NEW_CHUNK_SIZE = 2
         with self.feature("organizations:global-views"):
             project_2 = self.create_project(slug="baz", organization=self.organization)
             groups_1 = self.create_n_groups_with_hashes(2, project=self.project)


### PR DESCRIPTION
The new `delete_groups_for_project_task` does not schedule more tasks of itself. The API will schedule all required tasks in one go.

There's an option to control enabling the new task.