### PR TITLE
fix(release-health): Update processing deadline duration of the task

### DIFF
--- a/src/sentry/release_health/tasks.py
+++ b/src/sentry/release_health/tasks.py
@@ -33,7 +33,9 @@ logger = logging.getLogger("sentry.tasks.releasemonitor")
     default_retry_delay=5,
     max_retries=5,
     taskworker_config=TaskworkerConfig(
-        namespace=release_health_tasks, retry=Retry(times=5, on=(Exception,))
+        namespace=release_health_tasks,
+        retry=Retry(times=5, on=(Exception,)),
+        processing_deadline_duration=50,
     ),
 )
 def monitor_release_adoption(**kwargs) -> None:


### PR DESCRIPTION
This task is timing out after 10s and causes every project recently to have broken release health experience. Increasing the time should help with it, because this is the only place where `has_sessions` flag is set, and a lot of UI relies on that flag.

Fixes [SENTRY-4039](https://sentry.sentry.io/issues/6673230789/events/71116c0846bc4ce8b66d40288794e081/)