### PR TITLE
feat(sdk-crash-detection): add additional frame detection rules for Dart/Flutter

### DIFF
--- a/src/sentry/utils/sdk_crashes/sdk_crash_detection_config.py
+++ b/src/sentry/utils/sdk_crashes/sdk_crash_detection_config.py
@@ -379,6 +379,7 @@ def build_sdk_crash_detection_configs() -> Sequence[SDKCrashDetectionConfig]:
             sdk_frame_config=SDKFrameConfig(
                 function_patterns=set(),
                 path_patterns={
+                    # non-obfuscated builds
                     r"package:sentry/**",  # sentry-dart
                     r"package:sentry_flutter/**",  # sentry-dart-flutter
                     # sentry-dart packages
@@ -389,6 +390,10 @@ def build_sdk_crash_detection_configs() -> Sequence[SDKCrashDetectionConfig]:
                     r"package:sentry_drift/**",
                     r"package:sentry_hive/**",
                     r"package:sentry_isar/**",
+                    r"package:sentry_link/**",
+                    r"package:sentry_firebase_remote_config/**",
+                    # obfuscated builds
+                    r"package:/**/.pub-cache/**/sentry**",
                 },
                 path_replacer=KeepFieldPathReplacer(fields={"package", "filename", "abs_path"}),
             ),

--- a/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection_dart.py
+++ b/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection_dart.py
@@ -122,6 +122,61 @@ def configs() -> Sequence[SDKCrashDetectionConfig]:
             "dart:core-patch/growable_array.dart",
             True,
         ),
+        (
+            "package:/some/directory/.pub-cache/hosted/pub.dev/sentry-9.5.0/lib/src/sentry.dart",
+            "dart:core-patch/growable_array.dart",
+            True,
+        ),
+        (
+            "package:/some/directory/.pub-cache/hosted/pub.dev/sentry_flutter-9.5.0/lib/src/sentry.dart",
+            "dart:core-patch/growable_array.dart",
+            True,
+        ),
+        (
+            "package:/some/directory/.pub-cache/hosted/pub.dev/sentry_logging-9.5.0/lib/src/sentry.dart",
+            "dart:core-patch/growable_array.dart",
+            True,
+        ),
+        (
+            "package:/some/directory/.pub-cache/hosted/pub.dev/sentry_dio-9.5.0/lib/src/sentry.dart",
+            "dart:core-patch/growable_array.dart",
+            True,
+        ),
+        (
+            "package:/some/directory/.pub-cache/hosted/pub.dev/sentry_file-9.5.0/lib/src/sentry.dart",
+            "dart:core-patch/growable_array.dart",
+            True,
+        ),
+        (
+            "package:/some/directory/.pub-cache/hosted/pub.dev/sentry_sqflite-9.5.0/lib/src/sentry.dart",
+            "dart:core-patch/growable_array.dart",
+            True,
+        ),
+        (
+            "package:/some/directory/.pub-cache/hosted/pub.dev/sentry_drift-9.5.0/lib/src/sentry.dart",
+            "dart:core-patch/growable_array.dart",
+            True,
+        ),
+        (
+            "package:/some/directory/.pub-cache/hosted/pub.dev/sentry_hive-9.5.0/lib/src/sentry.dart",
+            "dart:core-patch/growable_array.dart",
+            True,
+        ),
+        (
+            "package:/some/directory/.pub-cache/hosted/pub.dev/sentry_isar-9.5.0/lib/src/sentry.dart",
+            "dart:core-patch/growable_array.dart",
+            True,
+        ),
+        (
+            "package:/some/directory/.pub-cache/hosted/pub.dev/sentry_link-9.5.0/lib/src/sentry.dart",
+            "dart:core-patch/growable_array.dart",
+            True,
+        ),
+        (
+            "package:/some/directory/.pub-cache/hosted/pub.dev/sentry_firebase_remote_config-9.5.0/lib/src/sentry.dart",
+            "dart:core-patch/growable_array.dart",
+            True,
+        ),
     ],
 )
 @decorators


### PR DESCRIPTION
Adds additional rule to detect crashes in Dart/Flutter events