### PR TITLE
feat(dashboards): Add starring behavior on POST

### DIFF
--- a/src/sentry/api/endpoints/organization_dashboards.py
+++ b/src/sentry/api/endpoints/organization_dashboards.py
@@ -99,7 +99,7 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
         Retrieve a list of custom dashboards that are associated with the given organization.
         """
         if not request.user.is_authenticated:
-            return Response(status=400)
+            return Response(status=status.HTTP_401_UNAUTHORIZED)
 
         if not features.has("organizations:dashboards-basic", organization, actor=request.user):
             return Response(status=404)
@@ -291,6 +291,9 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
         if not features.has("organizations:dashboards-edit", organization, actor=request.user):
             return Response(status=404)
 
+        if not request.user.is_authenticated:
+            return Response(status=status.HTTP_401_UNAUTHORIZED)
+
         serializer = DashboardSerializer(
             data=request.data,
             context={
@@ -300,9 +303,6 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
                 "environment": self.request.GET.getlist("environment"),
             },
         )
-
-        if not request.user.is_authenticated:
-            return Response(status=status.HTTP_401_UNAUTHORIZED)
 
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)

--- a/src/sentry/api/endpoints/organization_dashboards.py
+++ b/src/sentry/api/endpoints/organization_dashboards.py
@@ -4,6 +4,7 @@ import sentry_sdk
 from django.db import IntegrityError, router, transaction
 from django.db.models import Case, Exists, F, IntegerField, OrderBy, OuterRef, Subquery, Value, When
 from drf_spectacular.utils import extend_schema
+from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -300,6 +301,9 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
             },
         )
 
+        if not request.user.is_authenticated:
+            return Response(status=status.HTTP_401_UNAUTHORIZED)
+
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)
 
@@ -308,7 +312,9 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
                 dashboard = serializer.save()
 
                 if features.has(
-                    "organizations:dashboards-starred-reordering", organization, actor=request.user
+                    "organizations:dashboards-starred-reordering",
+                    organization,
+                    actor=request.user,
                 ):
                     if serializer.validated_data.get("is_favorited"):
                         try:

--- a/src/sentry/api/endpoints/organization_dashboards.py
+++ b/src/sentry/api/endpoints/organization_dashboards.py
@@ -288,11 +288,11 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
         """
         Create a new dashboard for the given Organization
         """
-        if not features.has("organizations:dashboards-edit", organization, actor=request.user):
-            return Response(status=404)
-
         if not request.user.is_authenticated:
             return Response(status=status.HTTP_401_UNAUTHORIZED)
+
+        if not features.has("organizations:dashboards-edit", organization, actor=request.user):
+            return Response(status=404)
 
         serializer = DashboardSerializer(
             data=request.data,

--- a/src/sentry/api/endpoints/organization_dashboards.py
+++ b/src/sentry/api/endpoints/organization_dashboards.py
@@ -310,8 +310,7 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
                 if features.has(
                     "organizations:dashboards-starred-reordering", organization, actor=request.user
                 ):
-                    is_favorited = request.data.get("isFavorited", False)
-                    if is_favorited:
+                    if serializer.validated_data.get("is_favorited"):
                         try:
                             DashboardFavoriteUser.objects.insert_favorite_dashboard(
                                 organization=organization,

--- a/src/sentry/api/endpoints/organization_dashboards.py
+++ b/src/sentry/api/endpoints/organization_dashboards.py
@@ -310,7 +310,7 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
                     "organizations:dashboards-starred-reordering", organization, actor=request.user
                 ):
                     is_favorited = request.data.get("isFavorited", False)
-                    if is_favorited is not False:
+                    if is_favorited:
                         DashboardFavoriteUser.objects.insert_favorite_dashboard(
                             organization=organization,
                             user_id=request.user.id,

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -981,6 +981,7 @@ class DashboardSerializer(DashboardDetailsSerializer):
     title = serializers.CharField(
         required=True, max_length=255, help_text="The user defined title for this dashboard."
     )
+    is_favorited = serializers.BooleanField(required=False, default=False)
 
 
 class DashboardStarredOrderSerializer(serializers.Serializer):

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -981,7 +981,11 @@ class DashboardSerializer(DashboardDetailsSerializer):
     title = serializers.CharField(
         required=True, max_length=255, help_text="The user defined title for this dashboard."
     )
-    is_favorited = serializers.BooleanField(required=False, default=False)
+    is_favorited = serializers.BooleanField(
+        required=False,
+        default=False,
+        help_text="Favorite the dashboard automatically for the request user",
+    )
 
 
 class DashboardStarredOrderSerializer(serializers.Serializer):

--- a/tests/sentry/api/endpoints/test_organization_dashboards.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboards.py
@@ -1805,3 +1805,43 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
 
         starred_dashboard = response.data[2]
         assert starred_dashboard["projects"] == []
+
+    def test_automatically_favorites_dashboard_when_isFavorited_is_true(self):
+        data = {
+            "title": "Dashboard with errors widget",
+            "isFavorited": True,
+        }
+        with self.feature("organizations:dashboards-starred-reordering"):
+            response = self.do_request("post", self.url, data=data)
+        assert response.status_code == 201, response.data
+        dashboard = Dashboard.objects.get(
+            organization=self.organization, title="Dashboard with errors widget"
+        )
+        assert response.data["isFavorited"] is True
+
+        assert (
+            DashboardFavoriteUser.objects.get_favorite_dashboard(
+                organization=self.organization, user_id=self.user.id, dashboard=dashboard
+            )
+            is not None
+        )
+
+    def test_does_not_automatically_favorite_dashboard_when_isFavorited_is_false(self):
+        data = {
+            "title": "Dashboard with errors widget",
+            "isFavorited": False,
+        }
+        with self.feature("organizations:dashboards-starred-reordering"):
+            response = self.do_request("post", self.url, data=data)
+        assert response.status_code == 201, response.data
+        dashboard = Dashboard.objects.get(
+            organization=self.organization, title="Dashboard with errors widget"
+        )
+        assert response.data["isFavorited"] is False
+
+        assert (
+            DashboardFavoriteUser.objects.get_favorite_dashboard(
+                organization=self.organization, user_id=self.user.id, dashboard=dashboard
+            )
+            is None
+        )


### PR DESCRIPTION
Dashboards that are created at the moment do not auto-star themselves. This adds a query param `isFavorited` to tell the backend to create and insert the dashboard as a favorite. The frontend will pass this along in the required requests to favorite a dashboard.