### PR TITLE
feat(tasks) Start to create a new namespace for post_process_group

### DIFF
--- a/src/sentry/eventstream/base.py
+++ b/src/sentry/eventstream/base.py
@@ -6,8 +6,9 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any, Optional, TypedDict, cast
 
 from sentry.issues.issue_occurrence import IssueOccurrence
+from sentry.options.rollout import in_random_rollout
 from sentry.queue.routers import SplitQueueRouter
-from sentry.tasks.post_process import post_process_group
+from sentry.tasks.post_process import post_process_group, post_process_group_shim
 from sentry.utils.cache import cache_key_for_event
 from sentry.utils.services import Service
 
@@ -78,21 +79,38 @@ class EventStream(Service):
         else:
             cache_key = cache_key_for_event({"project": project_id, "event_id": event_id})
 
-            post_process_group.apply_async(
-                kwargs={
-                    "is_new": is_new,
-                    "is_regression": is_regression,
-                    "is_new_group_environment": is_new_group_environment,
-                    "primary_hash": primary_hash,
-                    "cache_key": cache_key,
-                    "group_id": group_id,
-                    "group_states": group_states,
-                    "occurrence_id": occurrence_id,
-                    "project_id": project_id,
-                    "eventstream_type": eventstream_type,
-                },
-                queue=queue,
-            )
+            if in_random_rollout("taskworker.postprocess.namespace.rollout"):
+                post_process_group_shim.apply_async(
+                    kwargs={
+                        "is_new": is_new,
+                        "is_regression": is_regression,
+                        "is_new_group_environment": is_new_group_environment,
+                        "primary_hash": primary_hash,
+                        "cache_key": cache_key,
+                        "group_id": group_id,
+                        "group_states": group_states,
+                        "occurrence_id": occurrence_id,
+                        "project_id": project_id,
+                        "eventstream_type": eventstream_type,
+                    },
+                    queue=queue,
+                )
+            else:
+                post_process_group.apply_async(
+                    kwargs={
+                        "is_new": is_new,
+                        "is_regression": is_regression,
+                        "is_new_group_environment": is_new_group_environment,
+                        "primary_hash": primary_hash,
+                        "cache_key": cache_key,
+                        "group_id": group_id,
+                        "group_states": group_states,
+                        "occurrence_id": occurrence_id,
+                        "project_id": project_id,
+                        "eventstream_type": eventstream_type,
+                    },
+                    queue=queue,
+                )
 
     def _get_queue_for_post_process(self, event: Event | GroupEvent) -> str:
         event_type = self._get_event_type(event)

--- a/src/sentry/eventstream/kafka/dispatch.py
+++ b/src/sentry/eventstream/kafka/dispatch.py
@@ -13,8 +13,9 @@ from sentry.eventstream.kafka.protocol import (
     get_task_kwargs_for_message,
     get_task_kwargs_for_message_from_headers,
 )
+from sentry.options.rollout import in_random_rollout
 from sentry.post_process_forwarder.post_process_forwarder import PostProcessForwarderStrategyFactory
-from sentry.tasks.post_process import post_process_group
+from sentry.tasks.post_process import post_process_group, post_process_group_shim
 from sentry.utils import metrics
 from sentry.utils.cache import cache_key_for_event
 
@@ -52,21 +53,38 @@ def dispatch_post_process_group_task(
     else:
         cache_key = cache_key_for_event({"project": project_id, "event_id": event_id})
 
-        post_process_group.apply_async(
-            kwargs={
-                "is_new": is_new,
-                "is_regression": is_regression,
-                "is_new_group_environment": is_new_group_environment,
-                "primary_hash": primary_hash,
-                "cache_key": cache_key,
-                "group_id": group_id,
-                "group_states": group_states,
-                "occurrence_id": occurrence_id,
-                "project_id": project_id,
-                "eventstream_type": eventstream_type,
-            },
-            queue=queue,
-        )
+        if in_random_rollout("taskworker.postprocess.namespace.rollout"):
+            post_process_group_shim.apply_async(
+                kwargs={
+                    "is_new": is_new,
+                    "is_regression": is_regression,
+                    "is_new_group_environment": is_new_group_environment,
+                    "primary_hash": primary_hash,
+                    "cache_key": cache_key,
+                    "group_id": group_id,
+                    "group_states": group_states,
+                    "occurrence_id": occurrence_id,
+                    "project_id": project_id,
+                    "eventstream_type": eventstream_type,
+                },
+                queue=queue,
+            )
+        else:
+            post_process_group.apply_async(
+                kwargs={
+                    "is_new": is_new,
+                    "is_regression": is_regression,
+                    "is_new_group_environment": is_new_group_environment,
+                    "primary_hash": primary_hash,
+                    "cache_key": cache_key,
+                    "group_id": group_id,
+                    "group_states": group_states,
+                    "occurrence_id": occurrence_id,
+                    "project_id": project_id,
+                    "eventstream_type": eventstream_type,
+                },
+                queue=queue,
+            )
 
 
 def _get_task_kwargs(message: Message[KafkaPayload]) -> Mapping[str, Any] | None:

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3482,6 +3482,12 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+register(
+    "taskworker.postprocess.namespace.rollout",
+    default=0.0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 
 # Orgs for which compression should be disabled in the chunk upload endpoint.
 # This is intended to circumvent sporadic 503 errors reported by some customers.

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3460,6 +3460,11 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
+    "taskworker.ingest.errors.postprocess.rollout",
+    default={},
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
     "taskworker.ingest.transactions.rollout",
     default={},
     flags=FLAG_AUTOMATOR_MODIFIABLE,

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -27,7 +27,7 @@ from sentry.signals import event_processed, issue_unignored
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.config import TaskworkerConfig
-from sentry.taskworker.namespaces import ingest_errors_tasks
+from sentry.taskworker.namespaces import ingest_errors_postprocess_tasks, ingest_errors_tasks
 from sentry.types.group import GroupSubStatus
 from sentry.utils import json, metrics
 from sentry.utils.cache import cache
@@ -487,6 +487,25 @@ def should_update_escalating_metrics(event: Event) -> bool:
     silo_mode=SiloMode.REGION,
     taskworker_config=TaskworkerConfig(
         namespace=ingest_errors_tasks,
+        processing_deadline_duration=120,
+    ),
+)
+def post_process_group_compat(*args, **kwargs) -> None:
+    """
+    Deployment shim for post_process_group.
+    We need to move this task to a new taskworker namespace, but don't want to change the
+    celery queue.
+    """
+    post_process_group(*args, **kwargs)
+
+
+@instrumented_task(
+    name="sentry.tasks.post_process.post_process_group",
+    time_limit=120,
+    soft_time_limit=110,
+    silo_mode=SiloMode.REGION,
+    taskworker_config=TaskworkerConfig(
+        namespace=ingest_errors_postprocess_tasks,
         processing_deadline_duration=120,
     ),
 )

--- a/src/sentry/taskworker/namespaces.py
+++ b/src/sentry/taskworker/namespaces.py
@@ -72,6 +72,10 @@ ingest_attachments_tasks = taskregistry.create_namespace(
 
 ingest_errors_tasks = taskregistry.create_namespace("ingest.errors", app_feature="errors")
 
+ingest_errors_postprocess_tasks = taskregistry.create_namespace(
+    "ingest.errors.postprocess", app_feature="errors"
+)
+
 issues_tasks = taskregistry.create_namespace("issues", app_feature="issueplatform")
 
 integrations_tasks = taskregistry.create_namespace("integrations", app_feature="integrations")

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -62,6 +62,7 @@ from sentry.tasks.post_process import (
     feedback_filter_decorator,
     locks,
     post_process_group,
+    post_process_group_shim,
     run_post_process_job,
 )
 from sentry.testutils.cases import BaseTestCase, PerformanceIssueTestCase, SnubaTestCase, TestCase
@@ -208,6 +209,37 @@ class CorePostProcessGroupTestMixin(BasePostProgressGroupMixin):
         assert "tasks.post_process.old_time_to_post_process" not in [
             args[0] for args in logger_mock.warning.call_args_list
         ]
+
+
+class PostProcessGroupShimTest(TestCase, SnubaTestCase, BasePostProgressGroupMixin):
+    def create_event(self, data: dict[str, Any], project_id: int, assert_no_errors=True):
+        return self.store_event(data=data, project_id=project_id, assert_no_errors=assert_no_errors)
+
+    def call_post_process_group(
+        self, is_new, is_regression, is_new_group_environment, event, cache_key=None
+    ):
+        if cache_key is None:
+            cache_key = write_event_to_cache(event)
+        post_process_group_shim(
+            is_new=is_new,
+            is_regression=is_regression,
+            is_new_group_environment=is_new_group_environment,
+            cache_key=cache_key,
+            group_id=event.group_id,
+            project_id=event.project_id,
+            eventstream_type=EventStreamEventType.Error.value,
+        )
+
+    @patch("sentry.signals.event_processed.send_robust")
+    def test_shim_calls_implementation(self, event_processed_signal_mock):
+        event = self.create_event(data={}, project_id=self.project.id)
+        self.call_post_process_group(
+            is_new=True,
+            is_regression=False,
+            is_new_group_environment=True,
+            event=event,
+        )
+        assert event_processed_signal_mock.call_count == 1
 
 
 class DeriveCodeMappingsProcessGroupTestMixin(BasePostProgressGroupMixin):


### PR DESCRIPTION
Because we want to operate `post_process_group` as a separate processing pool in US, we need to re-assign its namespace. In order to do this and *not* drop any inflight work we have to do the change in a few steps:

1. Setup all the existing regions to handle the `ingest.errors.postprocess` namespace in the existing processing pools (see getsentry/ops#16423), and apply the changes to task routing.
2. Introduce the new namespace and a task binding in the new namespace. We also need an option to shift load into the new task post-deploy (this pull request).
3. Deploy this change and use the rollout option to shift load into the new task.
4. With no traffic on the old task binding, we can change the namespace assignment so that `post_process_group` and `post_process_group_shim` are on the `ingest.errors.postprocess` namespace.
5. Use the rollout option to switch traffic back to the original task name.
6. Remove the shim task.

If folks on @getsentry/issues are ok with the new task name - `sentry.issues.tasks.post_process.post_process_group` - being the name we keep long term than steps 4-6 can be replaced with a simpler code removal.