### PR TITLE
chore: Bump `sentry-kafka-schemas` to 2.0.2

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -64,7 +64,7 @@ rfc3339-validator>=0.1.2
 rfc3986-validator>=0.1.1
 # [end] jsonschema format validators
 sentry-arroyo>=2.28.2
-sentry-kafka-schemas>=1.3.18
+sentry-kafka-schemas>=2.0.2
 sentry-ophio>=1.1.3
 sentry-protos==0.3.1
 sentry-redis-tools>=0.5.0

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -186,7 +186,7 @@ sentry-devenv==1.21.0
 sentry-forked-django-stubs==5.2.2.post1
 sentry-forked-djangorestframework-stubs==3.16.1.post1
 sentry-forked-email-reply-parser==0.5.12.post1
-sentry-kafka-schemas==1.3.18
+sentry-kafka-schemas==2.0.2
 sentry-ophio==1.1.3
 sentry-protos==0.3.1
 sentry-redis-tools==0.5.0

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -123,7 +123,7 @@ rsa==4.8
 s3transfer==0.10.0
 sentry-arroyo==2.28.2
 sentry-forked-email-reply-parser==0.5.12.post1
-sentry-kafka-schemas==1.3.18
+sentry-kafka-schemas==2.0.2
 sentry-ophio==1.1.3
 sentry-protos==0.3.1
 sentry-redis-tools==0.5.0


### PR DESCRIPTION
This includes [removal of unused topics, and small update to the segment spans definition](https://github.com/getsentry/sentry-kafka-schemas/compare/1.3.18...2.0.2)
