### PR TITLE
fix(dashboards): ui tweaks to table widget visualization

### DIFF
--- a/static/app/components/events/contexts/contextIcon.tsx
+++ b/static/app/components/events/contexts/contextIcon.tsx
@@ -53,18 +53,17 @@ import type {IconSize} from 'sentry/utils/theme';
 const LOGO_MAPPING = {
   'android-phone': logoAndroidPhone,
   'android-tablet': logoAndroidTablet,
-  'chrome-mobile-ios': logoChrome,
   'google-chrome': logoChrome,
   'internet-explorer': logoIe,
   'legacy-edge': logoEdgeOld,
   'mac-os-x': logoApple,
-  'chrome-os': logoChrome,
   'mobile-safari': logoSafari,
   'nintendo-switch': logoNintendoSwitch,
   'net-core': logoNetcore,
   'net-framework': logoNetframework,
   'qq-browser': logoQq,
   'nintendo-os': logoNintendo,
+  'microsoft-edge': logoEdgeNew,
   amazon: logoAmazon,
   amd: logoAmd,
   android: logoAndroid,
@@ -139,6 +138,14 @@ export function getLogoImage(name: string) {
 
   if (name.startsWith('nvidia-')) {
     return logoNvidia;
+  }
+
+  if (name.startsWith('chrome-')) {
+    return logoChrome;
+  }
+
+  if (name.startsWith('opera-')) {
+    return logoOpera;
   }
 
   // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message

--- a/static/app/components/events/contexts/contextIcon.tsx
+++ b/static/app/components/events/contexts/contextIcon.tsx
@@ -53,17 +53,18 @@ import type {IconSize} from 'sentry/utils/theme';
 const LOGO_MAPPING = {
   'android-phone': logoAndroidPhone,
   'android-tablet': logoAndroidTablet,
+  'chrome-mobile-ios': logoChrome,
   'google-chrome': logoChrome,
   'internet-explorer': logoIe,
   'legacy-edge': logoEdgeOld,
   'mac-os-x': logoApple,
+  'chrome-os': logoChrome,
   'mobile-safari': logoSafari,
   'nintendo-switch': logoNintendoSwitch,
   'net-core': logoNetcore,
   'net-framework': logoNetframework,
   'qq-browser': logoQq,
   'nintendo-os': logoNintendo,
-  'microsoft-edge': logoEdgeNew,
   amazon: logoAmazon,
   amd: logoAmd,
   android: logoAndroid,
@@ -138,14 +139,6 @@ export function getLogoImage(name: string) {
 
   if (name.startsWith('nvidia-')) {
     return logoNvidia;
-  }
-
-  if (name.startsWith('chrome-')) {
-    return logoChrome;
-  }
-
-  if (name.startsWith('opera-')) {
-    return logoOpera;
   }
 
   // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message

--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -969,13 +969,14 @@ const getContextIcon = (value: string) => {
 };
 
 /**
- * Drops the last part of an operating system or browser string that contains version appended at the end
+ * Drops the last part of an operating system or browser string that contains version appended at the end.
+ * If the value string has no spaces, the original string will be returned.
  * @param value The string that contains the version to be dropped. E.g., 'Safari 9.1.2'
- * @returns E.g., 'Safari 9.1.2' -> 'Safari'
+ * @returns E.g., 'Safari 9.1.2' -> 'Safari', 'Linux' -> 'Linux'
  */
 const dropVersion = (value: string) => {
   const valueArray = value.split(' ');
-  valueArray.pop();
+  if (valueArray.length > 1) valueArray.pop();
   return valueArray.join(' ');
 };
 

--- a/static/app/views/dashboards/datasetConfig/errorsAndTransactions.tsx
+++ b/static/app/views/dashboards/datasetConfig/errorsAndTransactions.tsx
@@ -1,3 +1,4 @@
+import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 import trimStart from 'lodash/trimStart';
 
@@ -377,11 +378,11 @@ export function renderEventIdAsLinkable(
   });
 
   return (
-    <Tooltip title={t('View Event')}>
+    <StyledTooltip title={t('View Event')}>
       <Link data-test-id="view-event" to={target}>
         <Container>{getShortEventId(id)}</Container>
       </Link>
-    </Tooltip>
+    </StyledTooltip>
   );
 }
 
@@ -414,11 +415,11 @@ export function renderTraceAsLinkable(widget?: Widget) {
     });
 
     return (
-      <Tooltip title={t('View Trace')}>
+      <StyledTooltip title={t('View Trace')}>
         <Link data-test-id="view-trace" to={target}>
           <Container>{getShortEventId(id)}</Container>
         </Link>
-      </Tooltip>
+      </StyledTooltip>
     );
   };
 }
@@ -692,3 +693,7 @@ const getQueryExtraForSplittingDiscover = (
 
   return {};
 };
+
+const StyledTooltip = styled(Tooltip)`
+  vertical-align: middle;
+`;

--- a/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.tsx
@@ -247,7 +247,14 @@ export function TableWidgetVisualization(props: TableWidgetVisualizationProps) {
 
           const cell = valueRenderer(dataRow, baggage);
 
-          return <div key={`${rowIndex}-${columnIndex}:${tableColumn.name}`}>{cell}</div>;
+          return (
+            <StyledBodyCell
+              columnIndex={columnIndex}
+              key={`${rowIndex}-${columnIndex}:${tableColumn.name}`}
+            >
+              {cell}
+            </StyledBodyCell>
+          );
         },
         onResizeColumn: (columnIndex: number, nextColumn: TabularColumn) => {
           widths[columnIndex] = defined(nextColumn.width)
@@ -323,4 +330,10 @@ TableWidgetVisualization.LoadingPlaceholder = function ({
 
 const StyledTooltip = styled(Tooltip)`
   display: initial;
+  vertical-align: middle;
+`;
+
+// GridEditable sets the first child to have right padding 0 which doesn't work for this table
+const StyledBodyCell = styled('div')<{columnIndex: number}>`
+  ${p => (p.columnIndex === 0 ? `padding-right: ${p.theme.space.xl}` : '')}
 `;

--- a/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.tsx
@@ -247,14 +247,7 @@ export function TableWidgetVisualization(props: TableWidgetVisualizationProps) {
 
           const cell = valueRenderer(dataRow, baggage);
 
-          return (
-            <StyledBodyCell
-              columnIndex={columnIndex}
-              key={`${rowIndex}-${columnIndex}:${tableColumn.name}`}
-            >
-              {cell}
-            </StyledBodyCell>
-          );
+          return <div key={`${rowIndex}-${columnIndex}:${tableColumn.name}`}>{cell}</div>;
         },
         onResizeColumn: (columnIndex: number, nextColumn: TabularColumn) => {
           widths[columnIndex] = defined(nextColumn.width)
@@ -331,9 +324,4 @@ TableWidgetVisualization.LoadingPlaceholder = function ({
 const StyledTooltip = styled(Tooltip)`
   display: initial;
   vertical-align: middle;
-`;
-
-// GridEditable sets the first child to have right padding 0 which doesn't work for this table
-const StyledBodyCell = styled('div')<{columnIndex: number}>`
-  ${p => (p.columnIndex === 0 ? `padding-right: ${p.theme.space.xl}` : '')}
 `;


### PR DESCRIPTION
### Changes

This PR address alignment issues with the new widget tables.

1. Trace and id field being slightly misaligned vertically because of the tooltip being inline-block
2. Column headers being slightly misaligned vertically because of the tooltip being inline-block

Also modified the dropVersion helper function to return the original string if there are no spaces, as some OSes don't always attach version (e.g., Linux and Ubuntu)

### Before 

Misaligned column headers and trace field
<img width="328" height="99" alt="Screenshot 2025-07-24 at 12 13 45 PM" src="https://github.com/user-attachments/assets/abf0b859-9f35-45e8-ad9b-ffa09c479a8f" />

Missing icon for Linux
<img width="199" height="87" alt="Screenshot 2025-07-24 at 12 16 31 PM" src="https://github.com/user-attachments/assets/740ee088-10f3-4d01-93f3-3a72381149ca" />

### After

Realigned column headers and trace field
<img width="364" height="95" alt="Screenshot 2025-07-24 at 12 14 26 PM" src="https://github.com/user-attachments/assets/a88896e9-7699-4329-82c9-37230a83e13b" />

Icon appears for Linux
<img width="197" height="91" alt="Screenshot 2025-07-24 at 12 16 45 PM" src="https://github.com/user-attachments/assets/bb3f2bc8-48c1-4468-95d0-7e387be04e68" />

