### PR TITLE
core(flex): update flex api and remove gap space instances

### DIFF
--- a/static/app/components/codecov/integratedOrgSelector/integratedOrgSelector.tsx
+++ b/static/app/components/codecov/integratedOrgSelector/integratedOrgSelector.tsx
@@ -36,7 +36,7 @@ function OrgFooterMessage() {
     <Fragment>
       <AddIntegratedOrgButton />
       <MenuFooterDivider />
-      <Flex justify="flex-start" gap="md">
+      <Flex justify="start" gap="md">
         <IconInfo size="sm" style={{margin: '2px 0'}} />
         <div>
           <FooterInfoHeading>
@@ -102,7 +102,7 @@ export function IntegratedOrgSelector() {
             {...triggerProps}
           >
             <TriggerLabelWrap>
-              <Flex justify="flex-start" gap="sm" align="center">
+              <Flex justify="start" gap="sm" align="center">
                 <IconContainer>
                   <IconIntegratedOrg />
                 </IconContainer>

--- a/static/app/components/core/layout/flex.mdx
+++ b/static/app/components/core/layout/flex.mdx
@@ -44,14 +44,14 @@ Simialarly to `Container`, `Flex` inherits all spacing props like `m`, `p`, `mt`
 #### Row Direction
 
 <Storybook.Demo>
-  <Flex direction="row" gap="md" justify="space-between" align="center" padding="md">
+  <Flex direction="row" gap="md" justify="between" align="center" padding="md">
     <Card>Item 1</Card>
     <Card>Item 2</Card>
     <Card>Item 3</Card>
   </Flex>
 </Storybook.Demo>
 ```jsx
-<Flex direction="row" gap="md" justify="space-between" align="center" padding="md">
+<Flex direction="row" gap="md" justify="between" align="center" padding="md">
   <div>Item 1</div>
   <div>Item 2</div>
   <div>Item 3</div>
@@ -61,14 +61,14 @@ Simialarly to `Container`, `Flex` inherits all spacing props like `m`, `p`, `mt`
 #### Column direction
 
 <Storybook.Demo>
-  <Flex direction="column" gap="md" justify="space-between" align="center">
+  <Flex direction="column" gap="md" justify="between" align="center">
     <Card>Item 1</Card>
     <Card>Item 2</Card>
     <Card>Item 3</Card>
   </Flex>
 </Storybook.Demo>
 ```jsx
-<Flex direction="column" gap="md" justify="space-between" align="center">
+<Flex direction="column" gap="md" justify="between" align="center">
   <div>Item 1</div>
   <div>Item 2</div>
   <div>Item 3</div>

--- a/static/app/components/events/interfaces/spans/newTraceDetailsHeader.tsx
+++ b/static/app/components/events/interfaces/spans/newTraceDetailsHeader.tsx
@@ -33,13 +33,13 @@ function ServiceBreakdown({
   if (!displayBreakdown) {
     return (
       <BreakDownWrapper>
-        <Flex align="center" justify="space-between">
+        <Flex align="center" justify="between">
           <div>{t('server side')}</div>
           <Flex>
             <span>{'N/A'}</span>
           </Flex>
         </Flex>
-        <Flex align="center" justify="space-between">
+        <Flex align="center" justify="between">
           <div>{t('client side')}</div>
           <Flex>
             <span>{'N/A'}</span>
@@ -58,14 +58,14 @@ function ServiceBreakdown({
 
   return httpDuration ? (
     <BreakDownWrapper>
-      <Flex align="center" justify="space-between">
+      <Flex align="center" justify="between">
         <div>{t('server side')}</div>
         <Flex>
           <Dur>{getDuration(httpDuration, 2, true)}</Dur>
           <Pct>{serverSidePct}%</Pct>
         </Flex>
       </Flex>
-      <Flex align="center" justify="space-between">
+      <Flex align="center" justify="between">
         <div>{t('client side')}</div>
         <Flex>
           <Dur>{getDuration(totalDuration - httpDuration, 2, true)}</Dur>

--- a/static/app/components/feedback/feedbackItem/feedbackItemHeader.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItemHeader.tsx
@@ -36,7 +36,7 @@ export default function FeedbackItemHeader({eventData, feedbackItem}: Props) {
 
   return (
     <VerticalSpacing ref={wrapperRef}>
-      <Flex wrap="wrap" flex="1 1 auto" gap="md" justify="space-between">
+      <Flex wrap="wrap" flex="1 1 auto" gap="md" justify="between">
         <FeedbackShortId feedbackItem={feedbackItem} />
         <FeedbackActions
           eventData={eventData}
@@ -48,14 +48,14 @@ export default function FeedbackItemHeader({eventData, feedbackItem}: Props) {
 
       {eventData && feedbackItem.project ? (
         <ErrorBoundary mini>
-          <Flex wrap="wrap" justify="space-between" align="center" gap="md">
+          <Flex wrap="wrap" justify="between" align="center" gap="md">
             <StreamlinedExternalIssueList
               group={feedbackItem as unknown as Group}
               project={feedbackItem.project}
               event={eventData}
             />
             {feedbackItem.seenBy.length ? (
-              <Flex justify="flex-end">
+              <Flex justify="end">
                 <Flex gap="md" align="center">
                   <SeenBy>{t('Seen by')}</SeenBy>
                   <FeedbackViewers feedbackItem={feedbackItem} />

--- a/static/app/components/feedback/feedbackItem/messageSection.tsx
+++ b/static/app/components/feedback/feedbackItem/messageSection.tsx
@@ -29,7 +29,7 @@ export default function MessageSection({eventData, feedbackItem}: Props) {
 
   return (
     <Fragment>
-      <Flex wrap="wrap" flex="1 1 auto" gap="md" justify="space-between">
+      <Flex wrap="wrap" flex="1 1 auto" gap="md" justify="between">
         <FeedbackItemUsername feedbackIssue={feedbackItem} />
         <Flex gap="md">
           {isSpam ? (

--- a/static/app/components/feedback/feedbackSummary.tsx
+++ b/static/app/components/feedback/feedbackSummary.tsx
@@ -45,7 +45,7 @@ export default function FeedbackSummary() {
     <SummaryIconContainer>
       <IconSeer size="xs" />
       <SummaryContainer>
-        <Flex justify="space-between" align="center">
+        <Flex justify="between" align="center">
           <SummaryHeader>{t('Summary')}</SummaryHeader>
           <Flex gap="xs">
             {feedbackButton({type: 'positive'})}

--- a/static/app/components/feedback/list/feedbackListBulkSelection.tsx
+++ b/static/app/components/feedback/list/feedbackListBulkSelection.tsx
@@ -44,7 +44,7 @@ export default function FeedbackListBulkSelection({
     mailbox === 'ignored' ? GroupStatus.UNRESOLVED : GroupStatus.IGNORED;
 
   return (
-    <Flex gap="md" align="center" justify="space-between" flex="1 0 auto">
+    <Flex gap="md" align="center" justify="between" flex="1 0 auto">
       <span>
         <strong>
           {tct('[countSelected] Selected', {
@@ -52,7 +52,7 @@ export default function FeedbackListBulkSelection({
           })}
         </strong>
       </span>
-      <Flex gap="md" justify="flex-end">
+      <Flex gap="md" justify="end">
         <ErrorBoundary mini>
           <Button
             size="xs"

--- a/static/app/components/feedback/list/feedbackListItem.tsx
+++ b/static/app/components/feedback/list/feedbackListItem.tsx
@@ -102,8 +102,8 @@ export default function FeedbackListItem({feedbackItem, isSelected, onSelect}: P
         )}
 
         <PreviewRow
-          align="flex-start"
-          justify="flex-start"
+          align="start"
+          justify="start"
           style={{
             gridArea: 'message',
           }}
@@ -112,7 +112,7 @@ export default function FeedbackListItem({feedbackItem, isSelected, onSelect}: P
         </PreviewRow>
 
         <BottomGrid style={{gridArea: 'bottom'}}>
-          <Row justify="flex-start" gap="sm">
+          <Row justify="start" gap="sm">
             {feedbackItem.project ? (
               <StyledProjectBadge
                 disableLink
@@ -125,7 +125,7 @@ export default function FeedbackListItem({feedbackItem, isSelected, onSelect}: P
             <ShortId>{feedbackItem.shortId}</ShortId>
           </Row>
 
-          <Row justify="flex-end" gap="md">
+          <Row justify="end" gap="md">
             <IssueTrackingSignals group={feedbackItem as unknown as Group} />
 
             {hasComments && (

--- a/static/app/components/feedback/list/mailboxPicker.tsx
+++ b/static/app/components/feedback/list/mailboxPicker.tsx
@@ -30,7 +30,7 @@ export default function MailboxPicker({onChange, value}: Props) {
   const filteredMailboxes = MAILBOXES;
 
   return (
-    <Flex justify="flex-end" flex="1 0 auto">
+    <Flex justify="end" flex="1 0 auto">
       <SegmentedControl
         size="xs"
         aria-label={t('Filter feedbacks')}

--- a/static/app/components/onboarding/consoleModal.tsx
+++ b/static/app/components/onboarding/consoleModal.tsx
@@ -8,7 +8,6 @@ import {Button} from 'sentry/components/core/button';
 import {Flex} from 'sentry/components/core/layout';
 import ExternalLink from 'sentry/components/links/externalLink';
 import {t, tct} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
 
 const consoleConfig = {
@@ -149,7 +148,7 @@ export function ConsoleModal({
   return (
     <Fragment>
       <Header closeButton>
-        <Flex align="center" gap={space(2)}>
+        <Flex align="center" gap="xl">
           <PlatformIcon size={32} format="lg" platform={selectedPlatform.key} />
           <h4>{t('Request Access for %s', selectedPlatform.name)}</h4>
         </Flex>

--- a/static/app/components/onboardingWizard/content.tsx
+++ b/static/app/components/onboardingWizard/content.tsx
@@ -135,7 +135,7 @@ function SkipConfirmation({onConfirm, onDismiss}: SkipConfirmationProps) {
     <Alert type="info">
       <Flex direction="column" gap="md">
         {t("Not sure what to do? We're here for you!")}
-        <Flex justify="space-between" gap="xs" flex={1}>
+        <Flex justify="between" gap="xs" flex={1}>
           <LinkButton external href="https://sentry.io/support/" size="xs">
             {t('Contact Support')}
           </LinkButton>

--- a/static/app/components/profiling/flamegraph/flamegraphContextMenu.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphContextMenu.tsx
@@ -608,7 +608,7 @@ function ProfileIdsSubMenu(props: {
           setIsOpen(true);
         }}
       >
-        <FullWidthFlex justify="space-between" align="center">
+        <FullWidthFlex justify="between" align="center">
           <div>{t('Appears in %s profiles', props.profileIds.length)}</div>
           <IconChevron direction="right" size="xs" />
         </FullWidthFlex>

--- a/static/app/components/replays/preferences/replayPreferenceDropdown.tsx
+++ b/static/app/components/replays/preferences/replayPreferenceDropdown.tsx
@@ -74,7 +74,7 @@ export default function ReplayPreferenceDropdown({
             });
             return {
               label: (
-                <Flex justify="space-between">
+                <Flex justify="between">
                   <span>{baseLabel}</span>
                   <DurationDisplay>{durationDisplay}</DurationDisplay>
                 </Flex>

--- a/static/app/components/replays/table/deleteReplays.tsx
+++ b/static/app/components/replays/table/deleteReplays.tsx
@@ -193,7 +193,7 @@ function ReplayPreviewTable({
                   size={24}
                 />
                 <SubText>
-                  <Flex gap="xs" align="flex-start">
+                  <Flex gap="xs" align="start">
                     <DisplayName>
                       {replay.user.display_name || t('Anonymous User')}
                     </DisplayName>
@@ -208,7 +208,7 @@ function ReplayPreviewTable({
                 </SubText>
               </Flex>
             </SimpleTable.RowCell>
-            <SimpleTable.RowCell justify="flex-end">
+            <SimpleTable.RowCell justify="end">
               <Duration
                 duration={[replay.duration.asMilliseconds() ?? 0, 'ms']}
                 precision="sec"

--- a/static/app/components/replays/table/replayTableColumns.tsx
+++ b/static/app/components/replays/table/replayTableColumns.tsx
@@ -560,7 +560,7 @@ export const ReplaySessionColumn: ReplayTableColumn = {
             size={24}
           />
           <SubText>
-            <Flex gap="xs" align="flex-start">
+            <Flex gap="xs" align="start">
               <DisplayName data-underline-on-hover>
                 {replay.user.display_name || t('Anonymous User')}
               </DisplayName>

--- a/static/app/components/tours/tour.stories.tsx
+++ b/static/app/components/tours/tour.stories.tsx
@@ -376,7 +376,7 @@ function TourProvider({
           {...tourProviderProps}
         >
           <Flex gap="xl" align="center">
-            <Flex gap="xl" justify="space-between" direction="column" align="flex-start">
+            <Flex gap="xl" justify="between" direction="column" align="start">
               <StartTourButton />
               {children}
             </Flex>

--- a/static/app/components/versionHoverCard.tsx
+++ b/static/app/components/versionHoverCard.tsx
@@ -100,7 +100,7 @@ function VersionHoverCardBody({organization, releaseVersion, projectSlug}: BodyP
 
     return (
       <Flex direction="column" gap="xl">
-        <Flex gap="xl" justify="space-between">
+        <Flex gap="xl" justify="between">
           <div>
             <h6>{t('New Issues')}</h6>
             <CountSince>{release.newGroups}</CountSince>
@@ -111,7 +111,7 @@ function VersionHoverCardBody({organization, releaseVersion, projectSlug}: BodyP
           </div>
         </Flex>
         {parsedVersion?.package && (
-          <Flex direction="column" gap="xl" justify="space-between">
+          <Flex direction="column" gap="xl" justify="between">
             {parsedVersion.package && (
               <div>
                 <h6>{t('Package')}</h6>
@@ -140,16 +140,11 @@ function VersionHoverCardBody({organization, releaseVersion, projectSlug}: BodyP
         )}
         {release.lastCommit && <LastCommit commit={release.lastCommit} />}
         {deploys.length > 0 && (
-          <Flex direction="column" gap={space(0.5)}>
+          <Flex direction="column" gap="xs">
             <h6>{t('Deploys')}</h6>
             {recentDeploysByEnvironment.map(deploy => {
               return (
-                <Flex
-                  key={deploy.id}
-                  align="center"
-                  gap={space(1)}
-                  justify="space-between"
-                >
+                <Flex key={deploy.id} align="center" gap="md" justify="between">
                   <Tag type="highlight">{deploy.environment}</Tag>
                   {deploy.dateFinished && <StyledTimeSince date={deploy.dateFinished} />}
                 </Flex>

--- a/static/app/stories/view/storyFooter.tsx
+++ b/static/app/stories/view/storyFooter.tsx
@@ -17,7 +17,7 @@ export function StoryFooter() {
   const pagination = findPreviousAndNextStory(story, stories);
 
   return (
-    <Flex align="center" justify="space-between" gap="xl">
+    <Flex align="center" justify="between" gap="xl">
       {pagination?.prev && (
         <Card to={pagination.prev.location} icon={<IconArrow direction="left" />}>
           <Text variant="muted" as="div">

--- a/static/app/stories/view/storyHeader.tsx
+++ b/static/app/stories/view/storyHeader.tsx
@@ -34,7 +34,7 @@ export function StoryHeader() {
     <HeaderGrid>
       <Link to="/stories">
         <Heading as="h1" variant="accent">
-          <Flex align="center" gap={space(1)}>
+          <Flex align="center" gap="md">
             <StyledSentryUiLogo />
             UI
           </Flex>

--- a/static/app/stories/view/storySourceLinks.tsx
+++ b/static/app/stories/view/storySourceLinks.tsx
@@ -30,7 +30,7 @@ export function StorySourceLinks() {
   const committerDate = data?.[0]?.commit.committer.date;
 
   return (
-    <Flex align="center" justify="space-between" gap="md">
+    <Flex align="center" justify="between" gap="md">
       <LinkButton
         priority="transparent"
         href={`https://github.com/getsentry/sentry/edit/master/static/${story.filename}`}

--- a/static/app/styles/typography.stories.tsx
+++ b/static/app/styles/typography.stories.tsx
@@ -198,7 +198,7 @@ export default function TypographyStories() {
         hierarchy. If the element has low importance, use a smaller size.
       </Block>
       <Block>
-        <Flex gap="md" align="flex-start">
+        <Flex gap="md" align="start">
           <PositiveLabel />
           Always define font sizes with the <code>rem</code> unit.
         </Flex>
@@ -297,7 +297,7 @@ export default function TypographyStories() {
           <ul>
             <li>
               <Flex gap="md" align="baseline">
-                <PositiveLabel style={{alignSelf: 'flex-end'}} /> the{' '}
+                <PositiveLabel style={{alignSelf: 'end'}} /> the{' '}
                 <FixedExternalLink onClick={() => {}}>
                   Church of the Flying Spaghetti Monster
                 </FixedExternalLink>
@@ -305,7 +305,7 @@ export default function TypographyStories() {
             </li>
             <li>
               <Flex gap="md" align="baseline">
-                <NegativeLabel style={{alignSelf: 'flex-end'}} />{' '}
+                <NegativeLabel style={{alignSelf: 'end'}} />{' '}
                 <FixedExternalLink onClick={() => {}}>
                   the Church of the Flying Spaghetti Monster
                 </FixedExternalLink>
@@ -392,14 +392,14 @@ export default function TypographyStories() {
         </CodeSnippet>
       </Block>
       <Block>
-        <Flex gap="md" align="flex-start">
+        <Flex gap="md" align="start">
           <PositiveLabel />
           Don't add full stops (.) to the end of each item, unless the item contains
           multiple sentences.
         </Flex>
       </Block>
       <Block>
-        <Flex gap="md" align="flex-start">
+        <Flex gap="md" align="start">
           <PositiveLabel /> Avoid using custom symbols and icons as bullet characters, as
           they usually look out of place and distract from the main text content.
         </Flex>
@@ -430,7 +430,7 @@ export default function TypographyStories() {
         </CodeSnippet>
       </Block>
       <Block>
-        <Flex gap="md" align="flex-start">
+        <Flex gap="md" align="start">
           <PositiveLabel />
           Avoid using custom symbols and icons as counters.
         </Flex>
@@ -486,7 +486,7 @@ export default function TypographyStories() {
         </li>
       </SideBySideList>
       <Block>
-        <Flex gap="md" align="flex-start">
+        <Flex gap="md" align="start">
           <PositiveLabel />
           Use ligatures across the whole user interface.
         </Flex>
@@ -517,7 +517,7 @@ export default function TypographyStories() {
       </SideBySideList>
 
       <Block>
-        <Flex gap="md" align="flex-start">
+        <Flex gap="md" align="start">
           <PositiveLabel />
           Use fractional formatting whenever possible.
         </Flex>

--- a/static/app/views/automations/components/connectedMonitorsList.tsx
+++ b/static/app/views/automations/components/connectedMonitorsList.tsx
@@ -106,7 +106,7 @@ export default function ConnectedMonitorsList({
               <DetectorAssigneeCell assignee={detector.owner} />
             </SimpleTable.RowCell>
             {canEdit && (
-              <SimpleTable.RowCell data-column-name="connected" justify="flex-end">
+              <SimpleTable.RowCell data-column-name="connected" justify="end">
                 <Button onClick={() => toggleConnected?.({detector})} size="sm">
                   {connectedDetectorIds?.includes(detector.id)
                     ? t('Disconnect')

--- a/static/app/views/automations/components/dataConditionNodes.tsx
+++ b/static/app/views/automations/components/dataConditionNodes.tsx
@@ -4,7 +4,6 @@ import styled from '@emotion/styled';
 
 import {Flex} from 'sentry/components/core/layout';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import {
   type DataCondition,
   DataConditionType,
@@ -384,7 +383,7 @@ export const dataConditionNodesMap = new Map<DataConditionType, DataConditionNod
 
 function OccurenceBasedMonitorsWarning() {
   return (
-    <Flex direction="column" gap={space(1)}>
+    <Flex direction="column" gap="md">
       <WarningLine>
         {t('These filters will only apply to some of your monitors and triggers.')}
       </WarningLine>

--- a/static/app/views/automations/components/editConnectedMonitors.tsx
+++ b/static/app/views/automations/components/editConnectedMonitors.tsx
@@ -87,7 +87,7 @@ function AllMonitors({
         emptyMessage={t('No monitors found')}
         numSkeletons={10}
       />
-      <Flex justify="space-between">
+      <Flex justify="between">
         <div>{footerContent}</div>
         <PaginationWithoutMargin
           onCursor={setCursor}
@@ -203,7 +203,7 @@ export default function EditConnectedMonitors({connectedIds, setConnectedIds}: P
     return (
       <Container>
         <SelectedMonitors connectedIds={connectedIds} />
-        <ButtonWrapper justify="space-between">
+        <ButtonWrapper justify="between">
           <Button size="sm" icon={<IconAdd />} onClick={toggleDrawer}>
             {t('Create New Monitor')}
           </Button>

--- a/static/app/views/codecov/tests/onboardingSteps/addUploadToken.tsx
+++ b/static/app/views/codecov/tests/onboardingSteps/addUploadToken.tsx
@@ -72,8 +72,8 @@ export function AddUploadToken({step}: AddUploadTokenProps) {
                   </Alert>
                 </Alert.Container>
               )}
-              <Flex justify="space-between" gap="md">
-                <Flex justify="space-between" gap="md">
+              <Flex justify="between" gap="md">
+                <Flex justify="between" gap="md">
                   <CodeSnippet dark>SENTRY_PREVENT_TOKEN</CodeSnippet>
                   <CodeSnippet dark>{FULL_TOKEN}</CodeSnippet>
                 </Flex>
@@ -83,8 +83,8 @@ export function AddUploadToken({step}: AddUploadTokenProps) {
               </Flex>
             </Fragment>
           ) : (
-            <Flex justify="space-between" gap="md">
-              <Flex justify="space-between" gap="md">
+            <Flex justify="between" gap="md">
+              <Flex justify="between" gap="md">
                 <CodeSnippet dark>SENTRY_PREVENT_TOKEN</CodeSnippet>
                 <CodeSnippet dark>{TRUNCATED_TOKEN}</CodeSnippet>
               </Flex>

--- a/static/app/views/detectors/components/connectedAutomationList.tsx
+++ b/static/app/views/detectors/components/connectedAutomationList.tsx
@@ -135,7 +135,7 @@ export function ConnectedAutomationsList({
                 <ActionCell actions={getAutomationActions(automation)} />
               </SimpleTable.RowCell>
               {canEdit && (
-                <SimpleTable.RowCell data-column-name="connected" justify="flex-end">
+                <SimpleTable.RowCell data-column-name="connected" justify="end">
                   <Button onClick={() => toggleConnected?.({automation})} size="sm">
                     {connectedAutomationIds?.has(automation.id)
                       ? t('Disconnect')

--- a/static/app/views/detectors/components/details/metric/chart.tsx
+++ b/static/app/views/detectors/components/details/metric/chart.tsx
@@ -2,7 +2,6 @@ import styled from '@emotion/styled';
 
 import {CompactSelect} from 'sentry/components/core/compactSelect';
 import {Flex} from 'sentry/components/core/layout';
-import {space} from 'sentry/styles/space';
 import type {MetricDetector} from 'sentry/types/workflowEngine/detectors';
 import {Dataset} from 'sentry/views/alerts/rules/metric/types';
 import {MetricDetectorChart} from 'sentry/views/detectors/components/forms/metric/metricDetectorChart';
@@ -37,7 +36,7 @@ export function MetricDetectorDetailsChart({detector}: MetricDetectorDetailsChar
   const detectionType = detector.config.detectionType;
 
   return (
-    <Flex direction="column" gap={space(2)}>
+    <Flex direction="column" gap="xl">
       <CompactSelect
         size="sm"
         options={timePeriodOptions}

--- a/static/app/views/detectors/components/forms/automateSection.tsx
+++ b/static/app/views/detectors/components/forms/automateSection.tsx
@@ -183,7 +183,7 @@ export function AutomateSection() {
             limit={null}
           />
         </Section>
-        <ButtonWrapper justify="space-between">
+        <ButtonWrapper justify="between">
           {/* TODO: Implement create automation flow */}
           <Button size="sm" icon={<IconAdd />} disabled>
             {t('Create New Automation')}

--- a/static/app/views/detectors/components/forms/editDetectorLayout.tsx
+++ b/static/app/views/detectors/components/forms/editDetectorLayout.tsx
@@ -117,7 +117,7 @@ export function EditDetectorLayout({
         </Layout.Body>
       </Layout.Page>
       <StickyFooter>
-        <Flex gap="md" flex={1} justify="flex-end">
+        <Flex gap="md" flex={1} justify="end">
           <LinkButton
             priority="default"
             to={makeMonitorDetailsPathname(organization.slug, detector.id)}

--- a/static/app/views/detectors/components/forms/metric/visualize.tsx
+++ b/static/app/views/detectors/components/forms/metric/visualize.tsx
@@ -296,7 +296,7 @@ export function Visualize() {
 
   return (
     <AggregateContainer hasParameters={hasVisibleParameters}>
-      <Flex gap="md" align="flex-end">
+      <Flex gap="md" align="end">
         <FieldContainer>
           <div>
             <Tooltip

--- a/static/app/views/insights/pages/platform/shared/table/ErrorRateCell.tsx
+++ b/static/app/views/insights/pages/platform/shared/table/ErrorRateCell.tsx
@@ -45,7 +45,7 @@ export function ErrorRateCell({
 
   return (
     <ThresholdCell value={errorRate}>
-      <Flex align="center" justify="flex-end" gap="xs">
+      <Flex align="center" justify="end" gap="xs">
         {formatPercentage(errorRate, 2, {minimumValue: 0.0001})}
         {defined(errorCount) ? errorCountElement : null}
       </Flex>

--- a/static/app/views/insights/sessions/charts/chartWithIssues.tsx
+++ b/static/app/views/insights/sessions/charts/chartWithIssues.tsx
@@ -127,7 +127,7 @@ export default function ChartWithIssues(props: Props) {
             onClick={() => {
               openInsightChartModal({
                 title: (
-                  <Flex justify="space-between">
+                  <Flex justify="between">
                     {title}
                     {hasData && recentIssues?.length ? (
                       <LinkButton size="xs" to={{pathname: `/issues/`}}>

--- a/static/app/views/issueDetails/groupEventAttachments/groupEventAttachments.tsx
+++ b/static/app/views/issueDetails/groupEventAttachments/groupEventAttachments.tsx
@@ -153,7 +153,7 @@ function GroupEventAttachments({project, group}: GroupEventAttachmentsProps) {
   return (
     <Wrapper>
       {hasStreamlinedUI ? (
-        <Flex justify="space-between">
+        <Flex justify="between">
           <Flex align="center" gap="md">
             <IconFilter size="xs" />
             {t('Results are filtered by the selections above.')}

--- a/static/app/views/issueDetails/streamline/header/header.tsx
+++ b/static/app/views/issueDetails/streamline/header/header.tsx
@@ -116,7 +116,7 @@ export default function StreamlinedGroupHeader({
   return (
     <Fragment>
       <Header>
-        <Flex justify="space-between">
+        <Flex justify="between">
           <Flex align="center">
             <Breadcrumbs
               crumbs={[

--- a/static/app/views/issueDetails/streamline/sidebar/activitySection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/activitySection.tsx
@@ -83,7 +83,7 @@ function TimelineItem({
   return (
     <ActivityTimelineItem
       title={
-        <Flex gap="xs" align="center" justify="flex-start">
+        <Flex gap="xs" align="center" justify="start">
           <TitleTooltip title={title} showOnlyOnOverflow>
             {title}
           </TitleTooltip>
@@ -263,7 +263,7 @@ export default function StreamlinedActivitySection({
   return (
     <div>
       {!isDrawer && (
-        <Flex justify="space-between" align="center" style={{marginBottom: space(1)}}>
+        <Flex justify="between" align="center" style={{marginBottom: space(1)}}>
           <SidebarSectionTitle style={{gap: space(0.75), margin: 0}}>
             {t('Activity')}
             {group.numComments > 0 ? (

--- a/static/app/views/issueDetails/streamline/sidebar/mergedSidebarSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/mergedSidebarSection.tsx
@@ -11,7 +11,7 @@ export function MergedIssuesSidebarSection() {
   const location = useLocation();
 
   return (
-    <Flex justify="space-between" align="center">
+    <Flex justify="between" align="center">
       <SidebarSectionTitle style={{margin: 0}}>{t('Merged Issues')}</SidebarSectionTitle>
       <ViewButton
         aria-label={t('View Merged Issues')}

--- a/static/app/views/issueDetails/streamline/sidebar/similarIssuesSidebarSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/similarIssuesSidebarSection.tsx
@@ -11,7 +11,7 @@ export function SimilarIssuesSidebarSection() {
   const location = useLocation();
 
   return (
-    <Flex justify="space-between" align="center">
+    <Flex justify="between" align="center">
       <SidebarSectionTitle style={{margin: 0}}>{t('Similar Issues')}</SidebarSectionTitle>
       <ViewButton
         aria-label={t('View Similar Issues')}

--- a/static/app/views/performance/newTraceDetails/traceTabsAndVitals.tsx
+++ b/static/app/views/performance/newTraceDetails/traceTabsAndVitals.tsx
@@ -18,7 +18,7 @@ type TraceTabsAndVitalsProps = {
 
 function Placeholder() {
   return (
-    <Flex justify="space-between" align="center" gap="md">
+    <Flex justify="between" align="center" gap="md">
       <Flex align="center" gap="md">
         <StyledPlaceholder _width={75} _height={28} />
         <StyledPlaceholder _width={75} _height={28} />
@@ -90,7 +90,7 @@ export function TraceTabsAndVitals({
   }
 
   return (
-    <Flex ref={setRef} justify="space-between">
+    <Flex ref={setRef} justify="between">
       <Tabs value={currentTab} onChange={onTabChange}>
         <StyledTabsList hideBorder variant="floating">
           {tabOptions.map(tab => (

--- a/static/app/views/settings/featureFlags/changeTracking/index.tsx
+++ b/static/app/views/settings/featureFlags/changeTracking/index.tsx
@@ -162,7 +162,7 @@ function OrganizationFeatureFlagsChangeTracking() {
         )}
       </TextBlock>
 
-      <Flex justify="space-between">
+      <Flex justify="between">
         <h5>{t('Providers')}</h5>
         {addNewProvider(hasAccess)}
       </Flex>

--- a/static/app/views/settings/project/tempest/CredentialRow.tsx
+++ b/static/app/views/settings/project/tempest/CredentialRow.tsx
@@ -39,7 +39,7 @@ export function CredentialRow({
         {credential.createdByEmail ? credential.createdByEmail : '\u2014'}
       </Flex>
 
-      <Flex align="center" justify="flex-end">
+      <Flex align="center" justify="end">
         <Tooltip
           title={t('You must be an organization admin to remove credentials.')}
           disabled={!!removeCredential}

--- a/static/gsApp/views/amCheckout/steps/stepHeader.tsx
+++ b/static/gsApp/views/amCheckout/steps/stepHeader.tsx
@@ -51,7 +51,7 @@ function StepHeader({
       onClick={onEditClick}
       data-test-id={`header-${kebabCase(title)}`}
     >
-      <Flex justify="space-between">
+      <Flex justify="between">
         <StepTitle>
           {isCompleted ? (
             <IconCheckmark isCircled color="green300" />

--- a/static/gsApp/views/seerAutomation/onboarding.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding.tsx
@@ -82,7 +82,7 @@ function filterProjectsWithAccess(projects: Project[], organization: any) {
 function ProjectRow({onClick, project}: {onClick: () => void; project: Project}) {
   return (
     <ClickablePanelItem onClick={onClick}>
-      <Flex align="center" gap="md" justify="space-between" flex={1}>
+      <Flex align="center" gap="md" justify="between" flex={1}>
         <Flex align="center" gap="md">
           <ProjectAvatar project={project} title={project.slug} />
           <ProjectName>{project.slug}</ProjectName>

--- a/static/gsApp/views/seerAutomation/seerAutomationProjectList.tsx
+++ b/static/gsApp/views/seerAutomation/seerAutomationProjectList.tsx
@@ -362,7 +362,7 @@ export function SeerAutomationProjectList() {
           )}
           {paginatedProjects.map(project => (
             <ClickablePanelItem key={project.id} onClick={() => handleRowClick(project)}>
-              <Flex justify="space-between" align="center" gap="xl" flex={1}>
+              <Flex justify="between" align="center" gap="xl" flex={1}>
                 <Flex gap="md" align="center">
                   <StyledCheckbox
                     checked={selected.has(project.id)}
@@ -380,7 +380,7 @@ export function SeerAutomationProjectList() {
         </PanelBody>
       </Panel>
       {totalProjects > PROJECTS_PER_PAGE && (
-        <Flex justify="flex-end">
+        <Flex justify="end">
           <ButtonBar merged gap="none">
             <Button
               icon={<IconChevron direction="left" />}


### PR DESCRIPTION
Align justify with flex and use `start` as opposed to `flex-start` (flex prefix is redundant in the context of a flex component). Also removed a couple instances of `gap={space}` that have been left over. 

Note that this is a stacked PR and isn't getting merged into master as it requires the core flex changes from https://github.com/getsentry/sentry/pull/96206