### PR TITLE
feat(nav): Hide what's new button on short screen heights

### DIFF
--- a/static/app/views/nav/primary/components.tsx
+++ b/static/app/views/nav/primary/components.tsx
@@ -55,6 +55,7 @@ interface SidebarButtonProps {
   children: React.ReactNode;
   label: string;
   buttonProps?: Omit<ButtonProps, 'aria-label'>;
+  className?: string;
   onClick?: MouseEventHandler<HTMLButtonElement>;
 }
 
@@ -275,6 +276,7 @@ export function SidebarLink({
 }
 
 export function SidebarButton({
+  className,
   analyticsKey,
   children,
   buttonProps = {},
@@ -287,7 +289,7 @@ export function SidebarButton({
   const showLabel = layout === NavLayout.MOBILE;
 
   return (
-    <SidebarItem label={label} showLabel={showLabel}>
+    <SidebarItem label={label} showLabel={showLabel} className={className}>
       <NavButton
         {...buttonProps}
         isMobile={layout === NavLayout.MOBILE}

--- a/static/app/views/nav/primary/whatsNew.tsx
+++ b/static/app/views/nav/primary/whatsNew.tsx
@@ -1,4 +1,5 @@
 import {Fragment, useEffect, useMemo} from 'react';
+import styled from '@emotion/styled';
 
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {BroadcastPanelItem} from 'sentry/components/sidebar/broadcastPanelItem';
@@ -131,7 +132,7 @@ export function PrimaryNavigationWhatsNew() {
 
   return (
     <Fragment>
-      <SidebarButton
+      <WhatsNewButton
         analyticsKey="broadcasts"
         label={t("What's New")}
         buttonProps={overlayTriggerProps}
@@ -143,7 +144,7 @@ export function PrimaryNavigationWhatsNew() {
             isMobile={layout === NavLayout.MOBILE}
           />
         )}
-      </SidebarButton>
+      </WhatsNewButton>
       {isOpen && (
         <PrimaryButtonOverlay overlayProps={overlayProps}>
           <WhatsNewContent unseenPostIds={unseenPostIds} />
@@ -152,3 +153,11 @@ export function PrimaryNavigationWhatsNew() {
     </Fragment>
   );
 }
+
+const WhatsNewButton = styled(SidebarButton)`
+  display: none;
+
+  @media (min-height: 800px) {
+    display: flex;
+  }
+`;


### PR DESCRIPTION
One user mentioned that there wasn't enough height for everything in the nav, so this is one small improvement for small screens. The what's new button isn't too important so should be fine to hide.

<img width="218"  alt="CleanShot 2025-07-24 at 09 47 30@2x" src="https://github.com/user-attachments/assets/afa7033c-806a-4be6-a689-5f91fcadc20f" />


