### PR TITLE
feat(search-bar): Add contains option for raw search replacement

### DIFF
--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -4389,21 +4389,60 @@ describe('SearchQueryBuilder', function () {
           initialQuery=""
           replaceRawSearchKeys={['span.description']}
         />,
-        {organization: {features: ['search-query-builder-raw-search-replacement']}}
+        {
+          organization: {
+            features: [
+              'search-query-builder-raw-search-replacement',
+              'search-query-builder-wildcard-operators',
+            ],
+          },
+        }
       );
 
       await userEvent.type(screen.getByRole('textbox'), 'randomValue');
 
       expect(
-        within(screen.getByRole('listbox')).getByText('span.description')
-      ).toBeInTheDocument();
+        within(screen.getByRole('listbox')).getAllByText('span.description')
+      ).toHaveLength(2);
 
       await userEvent.click(
-        within(screen.getByRole('listbox')).getByText('span.description')
+        within(screen.getByRole('listbox')).getAllByText('span.description')[0]!
       );
 
       expect(
         screen.getByRole('row', {name: 'span.description:randomValue'})
+      ).toBeInTheDocument();
+    });
+
+    it('should replace raw search keys with defined key:*value*', async function () {
+      render(
+        <SearchQueryBuilder
+          {...defaultProps}
+          initialQuery=""
+          replaceRawSearchKeys={['span.description']}
+        />,
+        {
+          organization: {
+            features: [
+              'search-query-builder-raw-search-replacement',
+              'search-query-builder-wildcard-operators',
+            ],
+          },
+        }
+      );
+
+      await userEvent.type(screen.getByRole('textbox'), 'randomValue');
+
+      expect(
+        within(screen.getByRole('listbox')).getAllByText('span.description')
+      ).toHaveLength(2);
+
+      await userEvent.click(
+        within(screen.getByRole('listbox')).getAllByText('span.description')[1]!
+      );
+
+      expect(
+        screen.getByRole('row', {name: 'span.description:*randomValue*'})
       ).toBeInTheDocument();
     });
 
@@ -4414,17 +4453,24 @@ describe('SearchQueryBuilder', function () {
           initialQuery=""
           replaceRawSearchKeys={['span.description']}
         />,
-        {organization: {features: ['search-query-builder-raw-search-replacement']}}
+        {
+          organization: {
+            features: [
+              'search-query-builder-raw-search-replacement',
+              'search-query-builder-wildcard-operators',
+            ],
+          },
+        }
       );
 
       await userEvent.type(screen.getByRole('textbox'), 'random value');
 
       expect(
-        within(screen.getByRole('listbox')).getByText('span.description')
-      ).toBeInTheDocument();
+        within(screen.getByRole('listbox')).getAllByText('span.description')
+      ).toHaveLength(2);
 
       await userEvent.click(
-        within(screen.getByRole('listbox')).getByText('span.description')
+        within(screen.getByRole('listbox')).getAllByText('span.description')[0]!
       );
 
       expect(

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -4406,7 +4406,7 @@ describe('SearchQueryBuilder', function () {
       ).toHaveLength(2);
 
       await userEvent.click(
-        within(screen.getByRole('listbox')).getAllByText('span.description')[0]!
+        within(screen.getByRole('listbox')).getAllByText('span.description')[1]!
       );
 
       expect(
@@ -4438,7 +4438,7 @@ describe('SearchQueryBuilder', function () {
       ).toHaveLength(2);
 
       await userEvent.click(
-        within(screen.getByRole('listbox')).getAllByText('span.description')[1]!
+        within(screen.getByRole('listbox')).getAllByText('span.description')[0]!
       );
 
       expect(
@@ -4470,7 +4470,7 @@ describe('SearchQueryBuilder', function () {
       ).toHaveLength(2);
 
       await userEvent.click(
-        within(screen.getByRole('listbox')).getAllByText('span.description')[0]!
+        within(screen.getByRole('listbox')).getAllByText('span.description')[1]!
       );
 
       expect(

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/types.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/types.tsx
@@ -31,8 +31,13 @@ export interface FilterValueItem extends SelectOptionWithKey<string> {
   value: string;
 }
 
-export interface RawSearchFilterValueItem extends SelectOptionWithKey<string> {
-  type: 'raw-search-filter-value';
+export interface RawSearchFilterIsValueItem extends SelectOptionWithKey<string> {
+  type: 'raw-search-filter-is-value';
+  value: string;
+}
+
+export interface RawSearchFilterHasValueItem extends SelectOptionWithKey<string> {
+  type: 'raw-search-filter-has-value';
   value: string;
 }
 
@@ -63,7 +68,8 @@ export type SearchKeyItem =
   | KeyItem
   | RawSearchItem
   | FilterValueItem
-  | RawSearchFilterValueItem
+  | RawSearchFilterIsValueItem
+  | RawSearchFilterHasValueItem
   | AskSeerItem
   | AskSeerConsentItem;
 
@@ -74,7 +80,8 @@ export type FilterKeyItem =
   | RecentQueryItem
   | RawSearchItem
   | FilterValueItem
-  | RawSearchFilterValueItem
+  | RawSearchFilterIsValueItem
+  | RawSearchFilterHasValueItem
   | AskSeerItem
   | AskSeerConsentItem;
 

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/utils.tsx
@@ -13,7 +13,8 @@ import type {
   FilterValueItem,
   KeyItem,
   KeySectionItem,
-  RawSearchFilterValueItem,
+  RawSearchFilterHasValueItem,
+  RawSearchFilterIsValueItem,
   RawSearchItem,
   RecentQueryItem,
 } from 'sentry/components/searchQueryBuilder/tokens/filterKeyListBox/types';
@@ -150,10 +151,10 @@ export function createFilterValueItem(key: string, value: string): FilterValueIt
   };
 }
 
-export function createRawSearchFilterValueItem(
+export function createRawSearchFilterIsValueItem(
   key: string,
   value: string
-): RawSearchFilterValueItem {
+): RawSearchFilterIsValueItem {
   const filter = `${key}:${escapeFilterValue(value)}`;
 
   return {
@@ -164,7 +165,29 @@ export function createRawSearchFilterValueItem(
     hideCheck: true,
     showDetailsInOverlay: true,
     details: null,
-    type: 'raw-search-filter-value',
+    type: 'raw-search-filter-is-value',
+  };
+}
+
+export function createRawSearchFilterHasValueItem(
+  key: string,
+  value: string
+): RawSearchFilterHasValueItem {
+  const escapedValue = escapeFilterValue(value);
+  const inputValue = escapedValue?.includes(' ')
+    ? `"*${escapedValue.replace(/"/g, '')}*"`
+    : `*${escapedValue}*`;
+  const filter = `${key}:${inputValue}`;
+
+  return {
+    key: getEscapedKey(`${key}:${inputValue}`),
+    label: <FormattedQuery query={filter} />,
+    value: filter,
+    textValue: filter,
+    hideCheck: true,
+    showDetailsInOverlay: true,
+    details: null,
+    type: 'raw-search-filter-has-value',
   };
 }
 

--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -431,7 +431,11 @@ function SearchQueryBuilderInputInternal({
             return;
           }
 
-          if (option.type === 'raw-search-filter-value' && option.textValue) {
+          if (
+            (option.type === 'raw-search-filter-is-value' ||
+              option.type === 'raw-search-filter-has-value') &&
+            option.textValue
+          ) {
             dispatch({
               type: 'UPDATE_FREE_TEXT',
               tokens: [token],

--- a/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
@@ -145,7 +145,7 @@ export function useSortedFilterKeyItems({
   } = useSearchQueryBuilder();
   const organization = useOrganization();
   const hasWildcardSearch = organization.features.includes(
-    'search-query-builder-wildcard-search'
+    'search-query-builder-wildcard-operators'
   );
   const hasRawSearchReplacement = organization.features.includes(
     'search-query-builder-raw-search-replacement'

--- a/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
@@ -5,7 +5,6 @@ import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/contex
 import type {
   KeySectionItem,
   RawSearchFilterHasValueItem,
-  RawSearchFilterIsValueItem,
   SearchKeyItem,
 } from 'sentry/components/searchQueryBuilder/tokens/filterKeyListBox/types';
 import {
@@ -221,7 +220,15 @@ export function useSortedFilterKeyItems({
         (!keyItems.length || inputValue.trim().includes(' ')) &&
         (!replaceRawSearchKeys?.length || !hasRawSearchReplacement);
 
-      const options: Array<RawSearchFilterIsValueItem | RawSearchFilterHasValueItem> =
+      let rawSearchFilterHasValueItems: RawSearchFilterHasValueItem[] = [];
+      if (hasWildcardSearch) {
+        rawSearchFilterHasValueItems =
+          replaceRawSearchKeys?.map(key => {
+            return createRawSearchFilterHasValueItem(key, inputValue);
+          }) ?? [];
+      }
+
+      const rawSearchFilterIsValueItems =
         replaceRawSearchKeys?.map(key => {
           const value = inputValue?.includes(' ')
             ? `"${inputValue.replace(/"/g, '')}"`
@@ -230,19 +237,11 @@ export function useSortedFilterKeyItems({
           return createRawSearchFilterIsValueItem(key, value);
         }) ?? [];
 
-      if (hasWildcardSearch) {
-        options.push(
-          ...(replaceRawSearchKeys?.map(key => {
-            return createRawSearchFilterHasValueItem(key, inputValue);
-          }) ?? [])
-        );
-      }
-
       const rawSearchReplacements: KeySectionItem = {
         key: 'raw-search-filter-values',
         value: 'raw-search-filter-values',
         label: '',
-        options,
+        options: [...rawSearchFilterHasValueItems, ...rawSearchFilterIsValueItems],
         type: 'section',
       };
 


### PR DESCRIPTION
This PR adds in a second option that wraps the entered value in wildcards giving the option for the user to see if the value they entered is contained in any `span.description` on the traces tab for instance.

Ticket: EXP-20

<img width="308" height="178" alt="Screenshot 2025-07-24 at 13 52 57" src="https://github.com/user-attachments/assets/7dd06adf-f6df-4bf7-968a-e5681464a470" />