### PR TITLE
test(ui): Switch coverage provider to v8

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -210,7 +210,7 @@ jobs:
           if [ ${{ github.ref }} = 'refs/heads/master' ]; then
             pnpm run test-ci --forceExit --coverage
           else
-            pnpm run test-ci --forceExit
+            pnpm run test-ci --forceExit --coverage
           fi
 
       # We only upload coverage data for FE changes since it conflicts with

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -256,6 +256,7 @@ const ESM_NODE_MODULES = ['screenfull', 'cbor2'];
 
 const config: Config.InitialOptions = {
   verbose: false,
+  coverageProvider: 'v8',
   collectCoverageFrom: [
     'static/app/**/*.{js,jsx,ts,tsx}',
     '!static/app/**/*.spec.{js,jsx,ts,tsx}',


### PR DESCRIPTION
Moves coverage from babel to v8. Ideally we aren't using babel for this and we can migrate the rest of the jest babel build to swc. On jest 29 + node 20 this was hitting a memory crash but it looks okay now.

v8 is also the default for vitest

[some tradeoffs documented here](https://github.com/jestjs/jest/issues/11188)

