### PR TITLE
feat(ourlogs): Disable autorefresh when clicking into a row

### DIFF
--- a/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
@@ -16,6 +16,7 @@ import {useExploreLogsTableRow} from 'sentry/views/explore/logs/useLogsQuery';
 jest.mock('sentry/views/explore/logs/useLogsQuery', () => ({
   useExploreLogsTableRow: jest.fn(),
   usePrefetchLogTableRowOnHover: jest.fn().mockReturnValue({}),
+  useLogsQueryKeyWithInfinite: jest.fn().mockReturnValue({}),
 }));
 
 jest.mock('sentry/components/events/interfaces/frame/useStacktraceLink', () => ({
@@ -46,7 +47,9 @@ function ProviderWrapper({children}: {children?: React.ReactNode}) {
 }
 
 describe('logsTableRow', () => {
-  const organization = OrganizationFixture();
+  const organization = OrganizationFixture({
+    features: ['ourlogs-enabled', 'ourlogs-infinite-scroll'],
+  });
 
   const projects = [ProjectFixture()];
   ProjectsStore.loadInitialData(projects);

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -156,13 +156,14 @@ export const LogRowContent = memo(function LogRowContent({
         onCollapse?.(String(dataRow[OurLogKnownFieldKey.ID]));
       } else {
         onExpand?.(String(dataRow[OurLogKnownFieldKey.ID]));
-        if (autorefreshEnabled) {
-          setAutorefresh('idle');
-        }
       }
     } else {
       setExpanded(e => !e);
     }
+    if (!isExpanded && autorefreshEnabled) {
+      setAutorefresh('idle');
+    }
+
     trackAnalytics('logs.table.row_expanded', {
       log_id: String(dataRow[OurLogKnownFieldKey.ID]),
       page_source: analyticsPageSource,

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -22,6 +22,10 @@ import CellAction, {
 import type {TableColumn} from 'sentry/views/discover/table/types';
 import {AttributesTree} from 'sentry/views/explore/components/traceItemAttributes/attributesTree';
 import {
+  useLogsAutoRefreshEnabled,
+  useSetLogsAutoRefresh,
+} from 'sentry/views/explore/contexts/logs/logsAutoRefreshContext';
+import {
   useLogsAnalyticsPageSource,
   useLogsBlockRowExpanding,
   useLogsFields,
@@ -116,6 +120,8 @@ export const LogRowContent = memo(function LogRowContent({
   const setLogsSearch = useSetLogsSearch();
   const isTableFrozen = useLogsIsTableFrozen();
   const blockRowExpanding = useLogsBlockRowExpanding();
+  const autorefreshEnabled = useLogsAutoRefreshEnabled();
+  const setAutorefresh = useSetLogsAutoRefresh();
   const measureRef = useRef<HTMLTableRowElement>(null);
   const [shouldRenderHoverElements, _setShouldRenderHoverElements] = useState(
     canDeferRenderElements ? false : true
@@ -150,6 +156,9 @@ export const LogRowContent = memo(function LogRowContent({
         onCollapse?.(String(dataRow[OurLogKnownFieldKey.ID]));
       } else {
         onExpand?.(String(dataRow[OurLogKnownFieldKey.ID]));
+        if (autorefreshEnabled) {
+          setAutorefresh('idle');
+        }
       }
     } else {
       setExpanded(e => !e);


### PR DESCRIPTION
### Summary
We will eventually add resume mechanics, but for now, clicking a row should turn autorefresh to idle

