### PR TITLE
feat(dashboards): Add "Most Starred" as sort option

### DIFF
--- a/static/app/views/dashboards/manage/index.spec.tsx
+++ b/static/app/views/dashboards/manage/index.spec.tsx
@@ -311,15 +311,12 @@ describe('Dashboards > Detail', function () {
     const mockNavigate = jest.fn();
     mockUseNavigate.mockReturnValue(mockNavigate);
 
-    // mock the view type to table
-    localStorage.setItem(LAYOUT_KEY, `"grid"`);
-
     render(<ManageDashboards />, {
       organization: org,
     });
 
     await selectEvent.openMenu(await screen.findByRole('button', {name: /sort by/i}));
-    await userEvent.click(await screen.findByRole('option', {name: 'Most Favorited'}));
+    await userEvent.click(await screen.findByRole('option', {name: 'Most Starred'}));
 
     expect(mockNavigate).toHaveBeenCalledWith(
       expect.objectContaining({query: {sort: 'mostFavorited'}})

--- a/static/app/views/dashboards/manage/index.spec.tsx
+++ b/static/app/views/dashboards/manage/index.spec.tsx
@@ -303,4 +303,26 @@ describe('Dashboards > Detail', function () {
       );
     });
   });
+
+  it('shows the most favorited sort option for the %s view type', async function () {
+    const org = OrganizationFixture({
+      features: [...FEATURES, 'dashboards-starred-reordering'],
+    });
+    const mockNavigate = jest.fn();
+    mockUseNavigate.mockReturnValue(mockNavigate);
+
+    // mock the view type to table
+    localStorage.setItem(LAYOUT_KEY, `"grid"`);
+
+    render(<ManageDashboards />, {
+      organization: org,
+    });
+
+    await selectEvent.openMenu(await screen.findByRole('button', {name: /sort by/i}));
+    await userEvent.click(await screen.findByRole('option', {name: 'Most Favorited'}));
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      expect.objectContaining({query: {sort: 'mostFavorited'}})
+    );
+  });
 });

--- a/static/app/views/dashboards/manage/index.tsx
+++ b/static/app/views/dashboards/manage/index.tsx
@@ -104,10 +104,10 @@ function getSortOptions({
     {label: t('Dashboard Name (Z-A)'), value: '-title'},
     {label: t('Date Created (Newest)'), value: '-dateCreated'},
     {label: t('Date Created (Oldest)'), value: 'dateCreated'},
-    ...(organization.features.includes('dashboards-starred-reordering')
-      ? [{label: t('Most Favorited'), value: 'mostFavorited'}]
-      : []),
     {label: t('Most Popular'), value: 'mostPopular'},
+    ...(organization.features.includes('dashboards-starred-reordering')
+      ? [{label: t('Most Starred'), value: 'mostFavorited'}]
+      : []),
     {label: t('Recently Viewed'), value: 'recentlyViewed'},
   ];
 }

--- a/static/app/views/dashboards/manage/index.tsx
+++ b/static/app/views/dashboards/manage/index.tsx
@@ -25,7 +25,6 @@ import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {IconAdd, IconGrid, IconList} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {SelectValue} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import localStorage from 'sentry/utils/localStorage';
@@ -64,16 +63,6 @@ import {
 } from './settings';
 import TemplateCard from './templateCard';
 
-const SORT_OPTIONS: Array<SelectValue<string>> = [
-  {label: t('My Dashboards'), value: 'mydashboards'},
-  {label: t('Dashboard Name (A-Z)'), value: 'title'},
-  {label: t('Dashboard Name (Z-A)'), value: '-title'},
-  {label: t('Date Created (Newest)'), value: '-dateCreated'},
-  {label: t('Date Created (Oldest)'), value: 'dateCreated'},
-  {label: t('Most Popular'), value: 'mostPopular'},
-  {label: t('Recently Viewed'), value: 'recentlyViewed'},
-];
-
 const SHOW_TEMPLATES_KEY = 'dashboards-show-templates';
 export const LAYOUT_KEY = 'dashboards-overview-layout';
 
@@ -106,16 +95,21 @@ function getSortOptions({
   dashboardsLayout: DashboardsLayout;
   organization: Organization;
 }) {
-  if (
-    organization.features.includes('dashboards-starred-reordering') &&
-    dashboardsLayout === TABLE
-  ) {
-    // The table layout under this feature flag is split by owned and shared dashboards, so the 'mydashboards'
-    // sort option does not apply
-    return SORT_OPTIONS.filter(option => option.value !== 'mydashboards');
-  }
-
-  return SORT_OPTIONS;
+  return [
+    ...(!organization.features.includes('dashboards-starred-reordering') ||
+    dashboardsLayout === GRID
+      ? [{label: t('My Dashboards'), value: 'mydashboards'}]
+      : []),
+    {label: t('Dashboard Name (A-Z)'), value: 'title'},
+    {label: t('Dashboard Name (Z-A)'), value: '-title'},
+    {label: t('Date Created (Newest)'), value: '-dateCreated'},
+    {label: t('Date Created (Oldest)'), value: 'dateCreated'},
+    ...(organization.features.includes('dashboards-starred-reordering')
+      ? [{label: t('Most Favorited'), value: 'mostFavorited'}]
+      : []),
+    {label: t('Most Popular'), value: 'mostPopular'},
+    {label: t('Recently Viewed'), value: 'recentlyViewed'},
+  ];
 }
 
 function getDefaultSort({


### PR DESCRIPTION
Conditionally adds "Most Starred" as a sort option in the frontend. The backend uses "mostFavorited" which is my tech debt from before we had the "starred" wording. I'll allow the difference for now but I will have to change it in the future in the backend, at least in the endpoint to make it work better.

<img width="327" height="359" alt="Screenshot 2025-07-24 at 2 22 51 PM" src="https://github.com/user-attachments/assets/2c765bf3-ae37-44fc-9dfc-374e7448b0f4" />
