### PR TITLE
text: prevent mdx from injecting paragraphs

### DIFF
--- a/static/app/components/core/text/index.mdx
+++ b/static/app/components/core/text/index.mdx
@@ -178,34 +178,38 @@ Control line height with the `density` prop: `compressed` (1.0), default (1.2), 
   <Storybook.SideBySide vertical>
     <div style={{width: '300px', marginBottom: '16px'}}>
       <Text bold as="p">
-        Compressed density.
+        {`Compressed density.`}
       </Text>
-      <Text density="compressed">
-        {`Compressed density text. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.`}
-      </Text>
+      <Text
+        density="compressed"
+        as="p"
+      >{`Compressed density text. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.`}</Text>
     </div>
     <div style={{width: '300px', marginBottom: '16px'}}>
       <Text bold as="p">
-        Default density.
+        {`Default density.`}
       </Text>
-      <Text>
-        {`Default density text. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.`}
-      </Text>
+      <Text as="p">{`Default density text. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.`}</Text>
     </div>
     <div style={{width: '300px'}}>
       <Text bold as="p">
-        Comfortable density.
+        {`Comfortable density.`}
       </Text>
-      <Text density="comfortable">
-        {`Comfortable density text. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.`}
-      </Text>
+      <Text
+        density="comfortable"
+        as="p"
+      >{`Comfortable density text. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.`}</Text>
     </div>
   </Storybook.SideBySide>
 </Storybook.Demo>
 ```jsx
-<Text density="compressed">Compressed density text...</Text>
-<Text>Default density text...</Text>
-<Text density="comfortable">Comfortable density text...</Text>
+<Text density="compressed" as="p">
+  Compressed density text...
+</Text>
+<Text as="p">Default density text...</Text>
+<Text density="comfortable" as="p">
+  Comfortable density text...
+</Text>
 ```
 
 ### Ellipsis Overflow
@@ -234,13 +238,13 @@ Use `monospace` for fixed-width text.
     >
       <Text>1234567890</Text>
       <Text size="sm" variant="muted">
-        Regular
+        {`Regular`}
       </Text>
     </div>
     <div style={{display: 'flex', alignItems: 'center', gap: '16px'}}>
       <Text monospace>1234567890</Text>
       <Text size="sm" variant="muted">
-        Monospace
+        {`Monospace`}
       </Text>
     </div>
   </Storybook.SideBySide>
@@ -261,7 +265,7 @@ Use `tabular` for consistent number alignment and `fraction` for diagonal fracti
     >
       <Text>1234567890</Text>
       <Text size="sm" variant="muted">
-        Regular numbers
+        {`Regular numbers`}
       </Text>
     </div>
     <div
@@ -269,7 +273,7 @@ Use `tabular` for consistent number alignment and `fraction` for diagonal fracti
     >
       <Text tabular>1234567890</Text>
       <Text size="sm" variant="muted">
-        Tabular numbers
+        {`Tabular numbers`}
       </Text>
     </div>
     <div
@@ -277,13 +281,13 @@ Use `tabular` for consistent number alignment and `fraction` for diagonal fracti
     >
       <Text>1/2 3/4 5/8</Text>
       <Text size="sm" variant="muted">
-        Regular fractions
+        {`Regular fractions`}
       </Text>
     </div>
     <div style={{display: 'flex', alignItems: 'center', gap: '16px'}}>
       <Text fraction>1/2 3/4 5/8</Text>
       <Text size="sm" variant="muted">
-        Diagonal fractions
+        {`Diagonal fractions`}
       </Text>
     </div>
   </Storybook.SideBySide>


### PR DESCRIPTION
MDX parser will inject a paragraph when it detects a block of text, so we need to escape it