### PR TITLE
ref(explore): Remove default column from drag n drop context

### DIFF
--- a/static/app/views/explore/contexts/dragNDropContext.tsx
+++ b/static/app/views/explore/contexts/dragNDropContext.tsx
@@ -21,17 +21,15 @@ interface DragNDropContextProps<T> {
   children: (props: {
     deleteColumnAtIndex: (i: number) => void;
     editableColumns: Array<Column<T>>;
-    insertColumn: (column?: T) => void;
+    insertColumn: (column: T) => void;
     updateColumnAtIndex: (i: number, column: T) => void;
   }) => React.ReactNode;
   columns: T[];
-  defaultColumn: () => T;
   setColumns: (columns: T[], op: 'insert' | 'update' | 'delete' | 'reorder') => void;
 }
 
 export function DragNDropContext<T>({
   columns,
-  defaultColumn,
   setColumns,
   children,
 }: DragNDropContextProps<T>) {
@@ -43,7 +41,6 @@ export function DragNDropContext<T>({
     onDragEnd,
   } = useDragNDropColumns({
     columns,
-    defaultColumn,
     setColumns,
   });
 

--- a/static/app/views/explore/hooks/useDragNDropColumns.spec.tsx
+++ b/static/app/views/explore/hooks/useDragNDropColumns.spec.tsx
@@ -7,31 +7,23 @@ import {useDragNDropColumns} from './useDragNDropColumns';
 describe('useDragNDropColumns', () => {
   const initialColumns = ['span.op', 'span_id', 'timestamp'];
 
-  function defaultColumn(): string {
-    return '';
-  }
-
   it('should insert a column', () => {
     let columns!: string[];
     let setColumns: (columns: string[]) => void;
-    let insertColumn: (column?: string) => void;
+    let insertColumn: (column: string) => void;
 
     function TestPage() {
       [columns, setColumns] = useState(initialColumns);
-      ({insertColumn} = useDragNDropColumns({columns, defaultColumn, setColumns}));
+      ({insertColumn} = useDragNDropColumns({columns, setColumns}));
       return null;
     }
 
     render(<TestPage />);
 
-    act(() => {
-      insertColumn();
-    });
+    act(() => insertColumn(''));
     expect(columns).toEqual(['span.op', 'span_id', 'timestamp', '']);
 
-    act(() => {
-      insertColumn('span.description');
-    });
+    act(() => insertColumn('span.description'));
     expect(columns).toEqual(['span.op', 'span_id', 'timestamp', '', 'span.description']);
   });
 
@@ -42,15 +34,13 @@ describe('useDragNDropColumns', () => {
 
     function TestPage() {
       [columns, setColumns] = useState(initialColumns);
-      ({updateColumnAtIndex} = useDragNDropColumns({columns, defaultColumn, setColumns}));
+      ({updateColumnAtIndex} = useDragNDropColumns({columns, setColumns}));
       return null;
     }
 
     render(<TestPage />);
 
-    act(() => {
-      updateColumnAtIndex(0, 'span.description');
-    });
+    act(() => updateColumnAtIndex(0, 'span.description'));
 
     expect(columns).toEqual(['span.description', 'span_id', 'timestamp']);
   });
@@ -62,15 +52,13 @@ describe('useDragNDropColumns', () => {
 
     function TestPage() {
       [columns, setColumns] = useState(initialColumns);
-      ({deleteColumnAtIndex} = useDragNDropColumns({columns, defaultColumn, setColumns}));
+      ({deleteColumnAtIndex} = useDragNDropColumns({columns, setColumns}));
       return null;
     }
 
     render(<TestPage />);
 
-    act(() => {
-      deleteColumnAtIndex(0);
-    });
+    act(() => deleteColumnAtIndex(0));
 
     expect(columns).toEqual(['span_id', 'timestamp']);
   });
@@ -82,18 +70,18 @@ describe('useDragNDropColumns', () => {
 
     function TestPage() {
       [columns, setColumns] = useState(initialColumns);
-      ({onDragEnd} = useDragNDropColumns({columns, defaultColumn, setColumns}));
+      ({onDragEnd} = useDragNDropColumns({columns, setColumns}));
       return null;
     }
 
     render(<TestPage />);
 
-    act(() => {
+    act(() =>
       onDragEnd({
         active: {id: 1},
         over: {id: 3},
-      });
-    });
+      })
+    );
 
     expect(columns).toEqual(['span_id', 'timestamp', 'span.op']);
   });

--- a/static/app/views/explore/hooks/useDragNDropColumns.tsx
+++ b/static/app/views/explore/hooks/useDragNDropColumns.tsx
@@ -9,21 +9,19 @@ export type Column<T> = {
 
 interface UseDragAndDropColumnsProps<T> {
   columns: T[];
-  defaultColumn: () => T;
   setColumns: (columns: T[], op: 'insert' | 'update' | 'delete' | 'reorder') => void;
 }
 
 export function useDragNDropColumns<T>({
   columns,
-  defaultColumn,
   setColumns,
 }: UseDragAndDropColumnsProps<T>) {
   const editableColumns = useMemo(() => {
     return columns.map((column, i) => ({id: i + 1, column}));
   }, [columns]);
 
-  function insertColumn(column?: T) {
-    setColumns([...columns, column ?? defaultColumn()], 'insert');
+  function insertColumn(column: T) {
+    setColumns([...columns, column], 'insert');
   }
 
   function updateColumnAtIndex(i: number, column: T) {
@@ -35,9 +33,7 @@ export function useDragNDropColumns<T>({
 
   function deleteColumnAtIndex(i: number) {
     setColumns(
-      columns.length === 1
-        ? [defaultColumn()]
-        : columns.filter((_: T, j: number) => i !== j),
+      columns.filter((_: T, j: number) => i !== j),
       'delete'
     );
   }

--- a/static/app/views/explore/tables/aggregateColumnEditorModal.tsx
+++ b/static/app/views/explore/tables/aggregateColumnEditorModal.tsx
@@ -88,11 +88,7 @@ export function AggregateColumnEditorModal({
   const canDeleteVisualize = tempColumns.filter(isVisualize).length > 1;
 
   return (
-    <DragNDropContext
-      columns={tempColumns}
-      setColumns={setTempColumns}
-      defaultColumn={() => ({groupBy: ''})}
-    >
+    <DragNDropContext columns={tempColumns} setColumns={setTempColumns}>
       {({insertColumn, updateColumnAtIndex, deleteColumnAtIndex, editableColumns}) => (
         <Fragment>
           <Header closeButton data-test-id="editor-header">

--- a/static/app/views/explore/tables/columnEditorModal.tsx
+++ b/static/app/views/explore/tables/columnEditorModal.tsx
@@ -131,11 +131,7 @@ export function ColumnEditorModal({
   }
 
   return (
-    <DragNDropContext
-      columns={tempColumns}
-      setColumns={setTempColumns}
-      defaultColumn={() => ''}
-    >
+    <DragNDropContext columns={tempColumns} setColumns={setTempColumns}>
       {({insertColumn, updateColumnAtIndex, deleteColumnAtIndex, editableColumns}) => (
         <Fragment>
           <Header closeButton data-test-id="editor-header">
@@ -159,7 +155,7 @@ export function ColumnEditorModal({
                 <Button
                   size="sm"
                   aria-label={t('Add a Column')}
-                  onClick={() => insertColumn()}
+                  onClick={() => insertColumn('')}
                   icon={<IconAdd isCircled />}
                 >
                   {t('Add a Column')}

--- a/static/app/views/explore/toolbar/toolbarGroupBy.tsx
+++ b/static/app/views/explore/toolbar/toolbarGroupBy.tsx
@@ -54,7 +54,7 @@ export function ToolbarGroupBy({autoSwitchToAggregates}: ToolbarGroupBy) {
   const options: Array<SelectOption<string>> = useGroupByFields({groupBys, tags});
 
   return (
-    <DragNDropContext columns={groupBys} setColumns={setColumns} defaultColumn={() => ''}>
+    <DragNDropContext columns={groupBys} setColumns={setColumns}>
       {({editableColumns, insertColumn, updateColumnAtIndex, deleteColumnAtIndex}) => {
         return (
           <ToolbarSection data-test-id="section-group-by">
@@ -83,7 +83,7 @@ export function ToolbarGroupBy({autoSwitchToAggregates}: ToolbarGroupBy) {
                 borderless
                 size="zero"
                 icon={<IconAdd />}
-                onClick={() => insertColumn()}
+                onClick={() => insertColumn('')}
                 priority="link"
                 aria-label={t('Add Group')}
               >


### PR DESCRIPTION
Forcing a default when inserting is more ergonomic and flexible.