### PR TITLE
ref(nodestore): cache error events in nodestore

### DIFF
--- a/src/sentry/db/models/fields/node.py
+++ b/src/sentry/db/models/fields/node.py
@@ -114,7 +114,7 @@ class NodeData(MutableMapping[str, Any]):
             self.data["_ref"] = ref
             self.data["_ref_version"] = self.ref_version
 
-    def save(self, subkeys=None):
+    def save(self, subkeys=None, cache_on_write: bool | None = False):
         """
         Write current data back to nodestore.
 
@@ -137,4 +137,4 @@ class NodeData(MutableMapping[str, Any]):
         subkeys = subkeys or {}
         subkeys[None] = to_write
 
-        nodestore.backend.set_subkeys(self.id, subkeys)
+        nodestore.backend.set_subkeys(self.id, subkeys, cache_on_write=cache_on_write)

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1103,9 +1103,8 @@ def _nodestore_save_many(jobs: Sequence[Job], app_feature: str) -> None:
                 usage_type=UsageUnit.BYTES,
             )
         job["event"].data["nodestore_insert"] = inserted_time
-        cache_on_write = (
-            options.get("nodestore.set-subkeys.enable-errors-caching")
-            and job["event"].get_event_type() == ErrorEvent.key
+        cache_on_write = job["event"].get_event_type() == ErrorEvent.key and options.get(
+            "nodestore.set-subkeys.enable-errors-caching"
         )
         job["event"].data.save(subkeys=subkeys, cache_on_write=cache_on_write)
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2067,6 +2067,9 @@ register("txnames.bump-lifetime-sample-rate", default=0.1, flags=FLAG_AUTOMATOR_
 register(
     "nodestore.set-subkeys.enable-set-cache-item", default=True, flags=FLAG_AUTOMATOR_MODIFIABLE
 )
+register(
+    "nodestore.set-subkeys.enable-errors-caching", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE
+)
 
 # === Backpressure related runtime options ===
 

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -3176,7 +3176,6 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         manager.normalize()
         manager.save(self.project.id)
 
-        # Verify that set_subkeys was called with cache_on_write=True
         mock_set_cache_item.assert_called_once()
 
         # Test that cache_on_write=False is passed to nodestore for non-error events


### PR DESCRIPTION
We frequently fetch from Nodestore in issue alert / workflow processing. Nodestore slowdowns can cause alerts to be processed slower or processing tasks to be retried because they time out (potentially causing inaccuracies because we make queries at a later time).

I added an option to toggle caching for error events. If something blows up I can revert the option