### PR TITLE
fix(grid-editable): only apply cell body style if column is prepended

### DIFF
--- a/static/app/components/tables/gridEditable/index.tsx
+++ b/static/app/components/tables/gridEditable/index.tsx
@@ -412,7 +412,7 @@ class GridEditable<
         <InteractionStateLayer isHovered={row === highlightedRowKey} as="td" />
 
         {prependColumns?.map((item, i) => (
-          <GridBodyCell data-test-id="grid-body-cell" key={`prepend-${i}`}>
+          <GridBodyCell data-test-id="grid-body-cell" key={`prepend-${i}`} isPrepended>
             {item}
           </GridBodyCell>
         ))}

--- a/static/app/components/tables/gridEditable/index.tsx
+++ b/static/app/components/tables/gridEditable/index.tsx
@@ -13,6 +13,7 @@ import {
   Grid,
   GridBody,
   GridBodyCell,
+  GridBodyCellStatic,
   GridBodyCellStatus,
   GridHead,
   GridHeadCell,
@@ -412,9 +413,9 @@ class GridEditable<
         <InteractionStateLayer isHovered={row === highlightedRowKey} as="td" />
 
         {prependColumns?.map((item, i) => (
-          <GridBodyCell data-test-id="grid-body-cell" key={`prepend-${i}`} isPrepended>
+          <GridBodyCellStatic data-test-id="grid-body-cell" key={`prepend-${i}`}>
             {item}
-          </GridBodyCell>
+          </GridBodyCellStatic>
         ))}
         {columnOrder.map((col, i) => (
           <GridBodyCell data-test-id="grid-body-cell" key={`${col.key}${i}`}>

--- a/static/app/components/tables/gridEditable/styles.tsx
+++ b/static/app/components/tables/gridEditable/styles.tsx
@@ -229,10 +229,6 @@ export const GridBodyCell = styled('td')`
   justify-content: center;
 
   font-size: ${p => p.theme.fontSize.md};
-
-  &:last-child {
-    padding: ${p => p.theme.space.md} ${p => p.theme.space.xl};
-  }
 `;
 
 export const GridBodyCellStatic = styled(GridBodyCell)`

--- a/static/app/components/tables/gridEditable/styles.tsx
+++ b/static/app/components/tables/gridEditable/styles.tsx
@@ -214,7 +214,7 @@ export const GridRow = styled('tr')`
   }
 `;
 
-export const GridBodyCell = styled('td')`
+export const GridBodyCell = styled('td')<{isPrepended?: boolean}>`
   /* By default, a grid item cannot be smaller than the size of its content.
      We override this by setting min-width to be 0. */
   min-width: 0;
@@ -232,9 +232,10 @@ export const GridBodyCell = styled('td')`
 
   /* Need to select the 2nd child to select the first cell
      as the first child is the interaction state layer */
-  &:nth-child(2) {
-    padding: ${space(1)} 0 ${space(1)} ${space(3)};
-  }
+  ${p =>
+    p.isPrepended
+      ? `&:nth-child(2) { padding: ${space(1)} 0 ${space(1)} ${space(3)}; }`
+      : ''}
 
   &:last-child {
     padding: ${space(1)} ${space(2)};

--- a/static/app/components/tables/gridEditable/styles.tsx
+++ b/static/app/components/tables/gridEditable/styles.tsx
@@ -4,7 +4,6 @@ import styled from '@emotion/styled';
 
 import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
-import {space} from 'sentry/styles/space';
 
 const GRID_HEAD_ROW_HEIGHT = 45;
 export const GRID_BODY_ROW_HEIGHT = 42;
@@ -23,7 +22,7 @@ export const Header = styled('div')`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: ${space(1)};
+  margin-bottom: ${p => p.theme.space.md};
 `;
 
 export const HeaderTitle = styled('h4')`
@@ -34,7 +33,7 @@ export const HeaderTitle = styled('h4')`
 
 export const HeaderButtonContainer = styled('div')`
   display: grid;
-  gap: ${space(1)};
+  gap: ${p => p.theme.space.md};
   grid-auto-flow: column;
   grid-auto-columns: auto;
   justify-items: end;
@@ -141,7 +140,7 @@ export const GridHeadCell = styled('th')<{isFirst: boolean}>`
   display: flex;
   align-items: center;
   min-width: 24px;
-  padding: 0 ${space(2)};
+  padding: 0 ${p => p.theme.space.xl};
 
   border-right: 1px solid transparent;
   border-left: 1px solid transparent;
@@ -174,13 +173,14 @@ export const GridHeadCellStatic = styled('th')`
   height: ${GRID_HEAD_ROW_HEIGHT}px;
   display: flex;
   align-items: center;
-  padding: 0 ${space(2)};
+  padding: 0 ${p => p.theme.space.xl};
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
 
   &:first-child {
-    padding: ${space(1)} 0 ${space(1)} ${space(3)};
+    padding: ${p => p.theme.space.md} 0 ${p => p.theme.space.md}
+      ${p => p.theme.space['2xl']};
   }
 `;
 
@@ -222,7 +222,7 @@ export const GridBodyCell = styled('td')`
      min-height is used to allow a cell to expand and this is used to display
      feedback during empty/error state */
   min-height: ${GRID_BODY_ROW_HEIGHT}px;
-  padding: ${space(1)} ${space(2)};
+  padding: ${p => p.theme.space.md} ${p => p.theme.space.xl};
 
   display: flex;
   flex-direction: column;
@@ -231,7 +231,7 @@ export const GridBodyCell = styled('td')`
   font-size: ${p => p.theme.fontSize.md};
 
   &:last-child {
-    padding: ${space(1)} ${space(2)};
+    padding: ${p => p.theme.space.md} ${p => p.theme.space.xl};
   }
 `;
 
@@ -239,7 +239,8 @@ export const GridBodyCellStatic = styled(GridBodyCell)`
   /* Need to select the 2nd child to select the first cell
      as the first child is the interaction state layer */
   &:nth-child(2) {
-    padding: ${space(1)} 0 ${space(1)} ${space(3)};
+    padding: ${p => p.theme.space.md} 0 ${p => p.theme.space.md}
+      ${p => p.theme.space['2xl']};
   }
 `;
 

--- a/static/app/components/tables/gridEditable/styles.tsx
+++ b/static/app/components/tables/gridEditable/styles.tsx
@@ -214,7 +214,7 @@ export const GridRow = styled('tr')`
   }
 `;
 
-export const GridBodyCell = styled('td')<{isPrepended?: boolean}>`
+export const GridBodyCell = styled('td')`
   /* By default, a grid item cannot be smaller than the size of its content.
      We override this by setting min-width to be 0. */
   min-width: 0;
@@ -230,15 +230,16 @@ export const GridBodyCell = styled('td')<{isPrepended?: boolean}>`
 
   font-size: ${p => p.theme.fontSize.md};
 
-  /* Need to select the 2nd child to select the first cell
-     as the first child is the interaction state layer */
-  ${p =>
-    p.isPrepended
-      ? `&:nth-child(2) { padding: ${space(1)} 0 ${space(1)} ${space(3)}; }`
-      : ''}
-
   &:last-child {
     padding: ${space(1)} ${space(2)};
+  }
+`;
+
+export const GridBodyCellStatic = styled(GridBodyCell)`
+  /* Need to select the 2nd child to select the first cell
+     as the first child is the interaction state layer */
+  &:nth-child(2) {
+    padding: ${space(1)} 0 ${space(1)} ${space(3)};
   }
 `;
 


### PR DESCRIPTION
### Changes

Adds `GridBodyCellStatic` styled component and move the custom padding from `GridBodyCell`

The style is for prepended static columns to remove the right padding to bring the icons closer to the second column (e.g., the star column in this table: https://sentry.sentry.io/dashboards/) However, the style also gets applied to the body cells regardless if the first column is prepended or not, causing incorrect padding for right-aligned resizable columns.

### Before
<img width="210" height="89" alt="Screenshot 2025-07-24 at 3 09 40 PM" src="https://github.com/user-attachments/assets/102f5e51-05c9-4379-aaba-9beb9b123c31" />

### After
<img width="199" height="89" alt="Screenshot 2025-07-24 at 3 10 01 PM" src="https://github.com/user-attachments/assets/0d407254-8795-4056-890a-21ad9e17a4ca" />


