### PR TITLE
chore(issues): Disable deletions for some issue types

### DIFF
--- a/static/app/utils/issueTypeConfig/cronConfig.tsx
+++ b/static/app/utils/issueTypeConfig/cronConfig.tsx
@@ -7,7 +7,8 @@ const cronConfig: IssueCategoryConfigMapping = {
     actions: {
       archiveUntilOccurrence: {enabled: true},
       delete: {
-        enabled: true,
+        enabled: false,
+        disabledReason: t('Not yet supported for cron issues'),
       },
       deleteAndDiscard: {
         enabled: false,

--- a/static/app/utils/issueTypeConfig/metricConfig.tsx
+++ b/static/app/utils/issueTypeConfig/metricConfig.tsx
@@ -8,7 +8,8 @@ const metricConfig: IssueCategoryConfigMapping = {
     actions: {
       archiveUntilOccurrence: {enabled: true},
       delete: {
-        enabled: true,
+        enabled: false,
+        disabledReason: t('Not yet supported for regression issues'),
       },
       deleteAndDiscard: {
         enabled: false,

--- a/static/app/utils/issueTypeConfig/metricIssueConfig.tsx
+++ b/static/app/utils/issueTypeConfig/metricIssueConfig.tsx
@@ -6,7 +6,7 @@ const metricIssueConfig: IssueCategoryConfigMapping = {
   _categoryDefaults: {
     actions: {
       archiveUntilOccurrence: {enabled: false},
-      delete: {enabled: true},
+      delete: {enabled: false},
       deleteAndDiscard: {enabled: false},
       merge: {enabled: false},
       ignore: {enabled: true},

--- a/static/app/utils/issueTypeConfig/outageConfig.tsx
+++ b/static/app/utils/issueTypeConfig/outageConfig.tsx
@@ -15,7 +15,8 @@ const outageConfig: IssueCategoryConfigMapping = {
     actions: {
       archiveUntilOccurrence: {enabled: true},
       delete: {
-        enabled: true,
+        enabled: false,
+        disabledReason: t('Not yet supported for cron issues'),
       },
       deleteAndDiscard: {
         enabled: false,

--- a/static/app/utils/issueTypeConfig/uptimeConfig.tsx
+++ b/static/app/utils/issueTypeConfig/uptimeConfig.tsx
@@ -6,7 +6,7 @@ const uptimeConfig: IssueCategoryConfigMapping = {
   _categoryDefaults: {
     actions: {
       archiveUntilOccurrence: {enabled: true},
-      delete: {enabled: true},
+      delete: {enabled: false},
       deleteAndDiscard: {enabled: false},
       merge: {enabled: false},
       ignore: {enabled: true},


### PR DESCRIPTION
This is a follow-up to #96230.

Teams supporting those issue types will have to determine if it would make sense to enable deletion.

Fixes [ID-808](https://linear.app/getsentry/issue/ID-808)