### PR TITLE
ref(explore): Lift group by component to shared folder

### DIFF
--- a/static/app/views/explore/components/toolbar/toolbarGroupBy/index.tsx
+++ b/static/app/views/explore/components/toolbar/toolbarGroupBy/index.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useMemo} from 'react';
+import {useMemo} from 'react';
 import {useSortable} from '@dnd-kit/sortable';
 import {CSS} from '@dnd-kit/utilities';
 import styled from '@emotion/styled';
@@ -21,40 +21,28 @@ import {
   ToolbarSection,
 } from 'sentry/views/explore/components/toolbar/styles';
 import {DragNDropContext} from 'sentry/views/explore/contexts/dragNDropContext';
-import {
-  useExploreGroupBys,
-  useSetExploreGroupBys,
-} from 'sentry/views/explore/contexts/pageParamsContext';
-import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
-import {useTraceItemTags} from 'sentry/views/explore/contexts/spanTagsContext';
 import type {Column} from 'sentry/views/explore/hooks/useDragNDropColumns';
-import {useGroupByFields} from 'sentry/views/explore/hooks/useGroupByFields';
 
-interface ToolbarGroupBy {
-  autoSwitchToAggregates: boolean;
+interface ToolbarGroupByProps {
+  allowMultiple: boolean;
+  groupBys: string[];
+  options: Array<SelectOption<string>>;
+  setGroupBys: (
+    groupBys: string[],
+    op: 'insert' | 'update' | 'delete' | 'reorder'
+  ) => void;
 }
 
-export function ToolbarGroupBy({autoSwitchToAggregates}: ToolbarGroupBy) {
-  const {tags} = useTraceItemTags();
-
-  const groupBys = useExploreGroupBys();
-  const setGroupBys = useSetExploreGroupBys();
-
-  const setColumns = useCallback(
-    (columns: string[], op: 'insert' | 'update' | 'delete' | 'reorder') => {
-      if (autoSwitchToAggregates && (op === 'insert' || op === 'update')) {
-        setGroupBys(columns, Mode.AGGREGATE);
-      } else {
-        setGroupBys(columns);
-      }
-    },
-    [autoSwitchToAggregates, setGroupBys]
-  );
-
-  const options: Array<SelectOption<string>> = useGroupByFields({groupBys, tags});
+export function ToolbarGroupBy({
+  allowMultiple,
+  groupBys,
+  options,
+  setGroupBys,
+}: ToolbarGroupByProps) {
+  const hasFooter = allowMultiple;
 
   return (
-    <DragNDropContext columns={groupBys} setColumns={setColumns}>
+    <DragNDropContext columns={groupBys} setColumns={setGroupBys}>
       {({editableColumns, insertColumn, updateColumnAtIndex, deleteColumnAtIndex}) => {
         return (
           <ToolbarSection data-test-id="section-group-by">
@@ -69,27 +57,31 @@ export function ToolbarGroupBy({autoSwitchToAggregates}: ToolbarGroupBy) {
               </Tooltip>
             </ToolbarHeader>
             {editableColumns.map((column, i) => (
-              <ColumnEditorRow
+              <GroupBySelector
                 key={column.id}
                 canDelete={editableColumns.length > 1}
                 column={column}
-                options={options}
                 onColumnChange={c => updateColumnAtIndex(i, c)}
                 onColumnDelete={() => deleteColumnAtIndex(i)}
+                options={options}
               />
             ))}
-            <ToolbarFooter>
-              <ToolbarFooterButton
-                borderless
-                size="zero"
-                icon={<IconAdd />}
-                onClick={() => insertColumn('')}
-                priority="link"
-                aria-label={t('Add Group')}
-              >
-                {t('Add Group')}
-              </ToolbarFooterButton>
-            </ToolbarFooter>
+            {hasFooter && (
+              <ToolbarFooter>
+                {allowMultiple && (
+                  <ToolbarFooterButton
+                    borderless
+                    size="zero"
+                    icon={<IconAdd />}
+                    onClick={() => insertColumn('')}
+                    priority="link"
+                    aria-label={t('Add Group')}
+                  >
+                    {t('Add Group')}
+                  </ToolbarFooterButton>
+                )}
+              </ToolbarFooter>
+            )}
           </ToolbarSection>
         );
       }}
@@ -97,23 +89,21 @@ export function ToolbarGroupBy({autoSwitchToAggregates}: ToolbarGroupBy) {
   );
 }
 
-interface ColumnEditorRowProps {
+interface GroupBySelectorProps {
   canDelete: boolean;
   column: Column<string>;
   onColumnChange: (column: string) => void;
   onColumnDelete: () => void;
   options: Array<SelectOption<string>>;
-  disabled?: boolean;
 }
 
-function ColumnEditorRow({
+function GroupBySelector({
   canDelete,
   column,
-  options,
   onColumnChange,
   onColumnDelete,
-  disabled = false,
-}: ColumnEditorRowProps) {
+  options,
+}: GroupBySelectorProps) {
   const {attributes, listeners, setNodeRef, transform, transition} = useSortable({
     id: column.id,
   });
@@ -141,7 +131,6 @@ function ColumnEditorRow({
           aria-label={t('Drag to reorder')}
           borderless
           size="zero"
-          disabled={disabled}
           icon={<IconGrabbable size="sm" />}
           {...listeners}
         />
@@ -150,7 +139,6 @@ function ColumnEditorRow({
         data-test-id="editor-column"
         options={options}
         triggerLabel={label}
-        disabled={disabled}
         value={column.column ?? ''}
         onChange={handleColumnChange}
         searchable

--- a/static/app/views/explore/toolbar/index.tsx
+++ b/static/app/views/explore/toolbar/index.tsx
@@ -1,12 +1,19 @@
+import {useCallback} from 'react';
 import styled from '@emotion/styled';
 
+import type {SelectOption} from 'sentry/components/core/compactSelect';
 import {defined} from 'sentry/utils';
+import {ToolbarGroupBy} from 'sentry/views/explore/components/toolbar/toolbarGroupBy';
 import {ToolbarVisualize} from 'sentry/views/explore/components/toolbar/toolbarVisualize';
 import {
+  useExploreGroupBys,
   useExploreVisualizes,
+  useSetExploreGroupBys,
   useSetExploreVisualizes,
 } from 'sentry/views/explore/contexts/pageParamsContext';
-import {ToolbarGroupBy} from 'sentry/views/explore/toolbar/toolbarGroupBy';
+import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
+import {useTraceItemTags} from 'sentry/views/explore/contexts/spanTagsContext';
+import {useGroupByFields} from 'sentry/views/explore/hooks/useGroupByFields';
 import {ToolbarSaveAs} from 'sentry/views/explore/toolbar/toolbarSaveAs';
 import {ToolbarSortBy} from 'sentry/views/explore/toolbar/toolbarSortBy';
 
@@ -18,8 +25,25 @@ interface ExploreToolbarProps {
 }
 
 export function ExploreToolbar({extras, width}: ExploreToolbarProps) {
+  const {tags} = useTraceItemTags('string');
+
   const visualizes = useExploreVisualizes();
   const setVisualizes = useSetExploreVisualizes();
+
+  const groupBys = useExploreGroupBys();
+  const _setGroupBys = useSetExploreGroupBys();
+  const setGroupBys = useCallback(
+    (columns: string[], op: 'insert' | 'update' | 'delete' | 'reorder') => {
+      // automatically switch to aggregates mode when a group by is inserted/updated
+      if (op === 'insert' || op === 'update') {
+        _setGroupBys(columns, Mode.AGGREGATE);
+      } else {
+        _setGroupBys(columns);
+      }
+    },
+    [_setGroupBys]
+  );
+  const options: Array<SelectOption<string>> = useGroupByFields({groupBys, tags});
 
   return (
     <Container width={width}>
@@ -28,7 +52,12 @@ export function ExploreToolbar({extras, width}: ExploreToolbarProps) {
         setVisualizes={setVisualizes}
         allowEquations={extras?.includes('equations') || false}
       />
-      <ToolbarGroupBy autoSwitchToAggregates />
+      <ToolbarGroupBy
+        allowMultiple
+        groupBys={groupBys}
+        setGroupBys={setGroupBys}
+        options={options}
+      />
       <ToolbarSortBy />
       <ToolbarSaveAs />
     </Container>


### PR DESCRIPTION
This lifts the group by component to a shared folder in preparation for use with logs.