### PR TITLE
ref(rr6): Migrate insights / discover / performance routes

### DIFF
--- a/static/app/components/route.tsx
+++ b/static/app/components/route.tsx
@@ -1,9 +1,16 @@
+import {useEffect} from 'react';
+import {Navigate, type NavigateProps} from 'react-router-dom';
+import * as Sentry from '@sentry/react';
+
 import type {
   IndexRedirectProps,
   IndexRouteProps,
   RedirectProps,
   RouteProps,
 } from 'sentry/types/legacyReactRouter';
+import replaceRouterParams from 'sentry/utils/replaceRouterParams';
+import {useParams} from 'sentry/utils/useParams';
+import {useRoutes} from 'sentry/utils/useRoutes';
 
 // This module contains the "fake" react components that are used as we migrade
 // off of react-router 3 to 6. The shims in the utils/reactRouter6Compat module
@@ -88,3 +95,41 @@ export function IndexRedirect(_props: IndexRedirectProps) {
   return null;
 }
 IndexRedirect.displayName = 'IndexRedirect';
+
+interface WorkingRedirectProps extends Omit<NavigateProps, 'to'> {
+  /**
+   * Our compat redirect only supports string to
+   */
+  to: string;
+}
+
+/**
+ * Working Redirect component for use in route objects
+ * Wraps a declarative `Navigate` component to interpolate the params of `to`
+ */
+export function WorkingRedirect({to, ...rest}: WorkingRedirectProps) {
+  const params = useParams();
+  const routes = useRoutes();
+
+  // Capture sentry span for this redirect. This will help us understand if we
+  // have redirects that are unused or used too much.
+  useEffect(() => {
+    const routePath = routes
+      .map(route => route.path ?? '')
+      .filter(path => path !== '')
+      .join('/');
+
+    Sentry.startSpan(
+      {
+        name: 'Redirect route used',
+        op: 'navigation.redirect',
+        attributes: {routePath},
+      },
+      () => {
+        // End span automatically
+      }
+    );
+  }, [routes]);
+
+  return <Navigate to={replaceRouterParams(to, params)} {...rest} />;
+}

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1789,7 +1789,10 @@ function buildRoutes() {
       index: true,
       component: make(() => import('sentry/views/insights/index')),
     },
-    ...transactionSummaryChildRoutes,
+    {
+      path: 'summary/',
+      children: transactionSummaryChildRoutes,
+    },
     {
       path: `${FRONTEND_LANDING_SUB_PATH}/`,
       children: [
@@ -1799,7 +1802,10 @@ function buildRoutes() {
             () => import('sentry/views/insights/pages/frontend/frontendOverviewPage')
           ),
         },
-        ...transactionSummaryChildRoutes,
+        {
+          path: 'summary/',
+          children: transactionSummaryChildRoutes,
+        },
         traceViewRouteObject,
         ...moduleRoutes,
       ],
@@ -1813,7 +1819,10 @@ function buildRoutes() {
             () => import('sentry/views/insights/pages/backend/backendOverviewPage')
           ),
         },
-        ...transactionSummaryChildRoutes,
+        {
+          path: 'summary/',
+          children: transactionSummaryChildRoutes,
+        },
         traceViewRouteObject,
         ...moduleRoutes,
       ],
@@ -1827,7 +1836,10 @@ function buildRoutes() {
             () => import('sentry/views/insights/pages/mobile/mobileOverviewPage')
           ),
         },
-        ...transactionSummaryChildRoutes,
+        {
+          path: 'summary/',
+          children: transactionSummaryChildRoutes,
+        },
         traceViewRouteObject,
         ...moduleRoutes,
       ],
@@ -1843,7 +1855,10 @@ function buildRoutes() {
           index: true,
           component: make(() => import('sentry/views/insights/pages/agents/redirect')),
         },
-        ...transactionSummaryChildRoutes,
+        {
+          path: 'summary/',
+          children: transactionSummaryChildRoutes,
+        },
         traceViewRouteObject,
         ...moduleRoutes,
       ],
@@ -1898,7 +1913,10 @@ function buildRoutes() {
       index: true,
       component: () => <WorkingRedirect to="/insights/frontend/" replace />,
     },
-    ...transactionSummaryChildRoutes,
+    {
+      path: 'summary/',
+      children: transactionSummaryChildRoutes,
+    },
     {
       path: 'vitaldetail/',
       component: make(() => import('sentry/views/performance/vitalDetail')),


### PR DESCRIPTION
These are all somewhat interdependent

Replaces #96363, #96365 