### PR TITLE
feat: seer-rpc get_github_enterprise_integration_config now returns permissions

### DIFF
--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Mapping, Sequence
 from datetime import datetime
-from typing import Any
+from typing import Any, TypedDict
 
 import orjson
 import sentry_sdk
@@ -116,6 +116,10 @@ class GithubSetupApiClient(IntegrationProxyClient):
 class GithubProxyClient(IntegrationProxyClient):
     integration: Integration | RpcIntegration  # late init
 
+    class AccessTokenWithMetadata(TypedDict):
+        access_token: str
+        permissions: dict[str, str] | None
+
     def _get_installation_id(self) -> str:
         """
         Returns the Github App installation identifier.
@@ -133,7 +137,7 @@ class GithubProxyClient(IntegrationProxyClient):
         return get_jwt()
 
     @control_silo_function
-    def _refresh_access_token(self) -> str | None:
+    def _refresh_access_token(self) -> AccessTokenWithMetadata | None:
         integration = Integration.objects.filter(id=self.integration.id).first()
         if not integration:
             return None
@@ -167,7 +171,10 @@ class GithubProxyClient(IntegrationProxyClient):
         )
 
         self.integration = integration
-        return access_token
+        return {
+            "access_token": access_token,
+            "permissions": permissions,
+        }
 
     @control_silo_function
     def _get_token(self, prepared_request: PreparedRequest) -> str | None:
@@ -192,10 +199,13 @@ class GithubProxyClient(IntegrationProxyClient):
             return jwt
 
         # The rest should use access tokens...
-        return self.get_access_token()
+        metadata = self.get_access_token()
+        if not metadata:
+            return None
+        return metadata["access_token"]
 
     @control_silo_function
-    def get_access_token(self) -> str | None:
+    def get_access_token(self) -> AccessTokenWithMetadata | None:
         now = datetime.utcnow()
         access_token: str | None = self.integration.metadata.get("access_token")
         expires_at: str | None = self.integration.metadata.get("expires_at")
@@ -205,9 +215,12 @@ class GithubProxyClient(IntegrationProxyClient):
         should_refresh = not access_token or not expires_at or is_expired
 
         if should_refresh:
-            access_token = self._refresh_access_token()
+            return self._refresh_access_token()
 
-        return access_token
+        return {
+            "access_token": access_token,
+            "permissions": self.integration.metadata.get("permissions"),
+        }
 
     @control_silo_function
     def authorize_request(self, prepared_request: PreparedRequest) -> PreparedRequest:

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -548,14 +548,15 @@ def get_github_enterprise_integration_config(
     assert isinstance(installation, GitHubEnterpriseIntegration)
 
     client = installation.get_client()
-    access_token = client.get_access_token()
+    access_token_data = client.get_access_token()
 
-    if not access_token:
+    if not access_token_data:
         logger.error("No access token found for integration %s", integration.id)
         return {"success": False}
 
     try:
         fernet = Fernet(settings.SEER_GHE_ENCRYPT_KEY.encode("utf-8"))
+        access_token = access_token_data["access_token"]
         encrypted_access_token = fernet.encrypt(access_token.encode("utf-8")).decode("utf-8")
     except Exception:
         logger.exception("Failed to encrypt access token")
@@ -566,6 +567,7 @@ def get_github_enterprise_integration_config(
         "base_url": f"https://{installation.model.metadata['domain_name'].split('/')[0]}/api/v3",
         "verify_ssl": installation.model.metadata["installation"]["verify_ssl"],
         "encrypted_access_token": encrypted_access_token,
+        "permissions": access_token_data["permissions"],
     }
 
 

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -538,8 +538,24 @@ class GithubProxyClientTest(TestCase):
     def test_get_access_token(self, _):
         self.gh_client.integration.metadata["access_token"] = "access_token_1"
         self.gh_client.integration.metadata["expires_at"] = "3000-01-01T00:00:00Z"
+        self.gh_client.integration.metadata["permissions"] = {
+            "administration": "read",
+            "contents": "read",
+            "issues": "write",
+            "metadata": "read",
+            "pull_requests": "read",
+        }
 
-        assert self.gh_client.get_access_token() == "access_token_1"
+        assert self.gh_client.get_access_token() == {
+            "access_token": "access_token_1",
+            "permissions": {
+                "administration": "read",
+                "contents": "read",
+                "issues": "write",
+                "metadata": "read",
+                "pull_requests": "read",
+            },
+        }
 
     @responses.activate
     @mock.patch("sentry.integrations.github.client.GithubProxyClient._get_token", return_value=None)

--- a/tests/sentry/seer/endpoints/test_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_seer_rpc.py
@@ -384,7 +384,17 @@ class TestSeerRpcMethods(APITestCase):
         responses.add(
             responses.POST,
             f"https://github.example.org/api/v3/app/installations/{installation_id}/access_tokens",
-            json={"token": access_token, "expires_at": "3000-01-01T00:00:00Z"},
+            json={
+                "token": access_token,
+                "expires_at": "3000-01-01T00:00:00Z",
+                "permissions": {
+                    "administration": "read",
+                    "contents": "read",
+                    "issues": "write",
+                    "metadata": "read",
+                    "pull_requests": "read",
+                },
+            },
         )
 
         # Create a GitHub Enterprise integration
@@ -412,6 +422,13 @@ class TestSeerRpcMethods(APITestCase):
         assert result["base_url"] == "https://github.example.org/api/v3"
         assert result["verify_ssl"]
         assert result["encrypted_access_token"]
+        assert result["permissions"] == {
+            "administration": "read",
+            "contents": "read",
+            "issues": "write",
+            "metadata": "read",
+            "pull_requests": "read",
+        }
 
         # Test that the access token is encrypted correctly
         fernet = Fernet(TEST_FERNET_KEY.encode("utf-8"))


### PR DESCRIPTION
Modify `get_github_enterprise_integration_config` to return permissions. This is to enable Seer to check whether the access token has read/write permissions.