### PR TITLE
fix(kafka): add typing to kafka config util

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -424,6 +424,7 @@ module = [
     "sentry.utils.iterators",
     "sentry.utils.javascript",
     "sentry.utils.kafka",
+    "sentry.utils.kafka_config",
     "sentry.utils.kvstore.*",
     "sentry.utils.lazy_service_wrapper",
     "sentry.utils.linksign",

--- a/src/sentry/utils/kafka_config.py
+++ b/src/sentry/utils/kafka_config.py
@@ -39,7 +39,7 @@ ADMIN_SECTION = "admin"
 KNOWN_SECTIONS = (COMMON_SECTION, PRODUCERS_SECTION, CONSUMERS_SECTION, ADMIN_SECTION)
 
 
-def _get_legacy_kafka_cluster_options(cluster_name):
+def _get_legacy_kafka_cluster_options(cluster_name: str) -> dict[str, Any]:
     options = settings.KAFKA_CLUSTERS[cluster_name]
 
     options = {k: v for k, v in options.items() if k not in KNOWN_SECTIONS}
@@ -50,8 +50,11 @@ def _get_legacy_kafka_cluster_options(cluster_name):
 
 
 def _get_kafka_cluster_options(
-    cluster_name, config_section, only_bootstrap=False, override_params=None
-):
+    cluster_name: str,
+    config_section: str,
+    only_bootstrap: bool = False,
+    override_params: MutableMapping[str, Any] | None = None,
+) -> dict[str, Any]:
     options = {}
     custom_options = settings.KAFKA_CLUSTERS[cluster_name].get(config_section, {})
     common_options = settings.KAFKA_CLUSTERS[cluster_name].get(COMMON_SECTION, {})
@@ -77,13 +80,13 @@ def _get_kafka_cluster_options(
     return options
 
 
-def get_kafka_producer_cluster_options(cluster_name):
+def get_kafka_producer_cluster_options(cluster_name: str) -> dict[str, Any]:
     return _get_kafka_cluster_options(cluster_name, PRODUCERS_SECTION)
 
 
 def get_kafka_consumer_cluster_options(
     cluster_name: str, override_params: MutableMapping[str, Any] | None = None
-) -> MutableMapping[Any, Any]:
+) -> dict[str, Any]:
     return _get_kafka_cluster_options(
         cluster_name, CONSUMERS_SECTION, only_bootstrap=True, override_params=override_params
     )
@@ -91,7 +94,7 @@ def get_kafka_consumer_cluster_options(
 
 def get_kafka_admin_cluster_options(
     cluster_name: str, override_params: MutableMapping[str, Any] | None = None
-) -> MutableMapping[Any, Any]:
+) -> dict[str, Any]:
     return _get_kafka_cluster_options(
         cluster_name, ADMIN_SECTION, only_bootstrap=True, override_params=override_params
     )


### PR DESCRIPTION
Ran mypy; saw only pre-existing failures.

`get_kafka_producer_cluster_options` had to return `dict` instead of `MutableMapping` because it was used to construct `KafkaPublisher`, which takes `dict`. Changed the other similar functions for consistency. (Alternatives: leave those functions alone, change `KafkaPublisher` to accept `MutableMapping`.)