### PR TITLE
fix(aci): don't connect migrated cron workflows to error detector

### DIFF
--- a/src/sentry/monitors/utils.py
+++ b/src/sentry/monitors/utils.py
@@ -257,8 +257,8 @@ def create_issue_alert_rule(
         environment=data.get("environment"),
         filter_match=data.get("filterMatch"),
         request=request,
+        source=RuleSource.CRON_MONITOR,
     ).run()
-    rule.update(source=RuleSource.CRON_MONITOR)
     RuleActivity.objects.create(
         rule=rule, user_id=request.user.id, type=RuleActivityType.CREATED.value
     )

--- a/src/sentry/projects/project_rules/creator.py
+++ b/src/sentry/projects/project_rules/creator.py
@@ -8,7 +8,7 @@ from rest_framework.request import Request
 
 from sentry import features
 from sentry.models.project import Project
-from sentry.models.rule import Rule
+from sentry.models.rule import Rule, RuleSource
 from sentry.types.actor import Actor
 from sentry.workflow_engine.migration_helpers.issue_alert_migration import (
     IssueAlertMigrator,
@@ -29,6 +29,7 @@ class ProjectRuleCreator:
     environment: int | None = None
     owner: Actor | None = None
     filter_match: str | None = None
+    source: RuleSource | None = RuleSource.ISSUE
     request: Request | None = None
 
     def run(self) -> Rule:
@@ -75,5 +76,6 @@ class ProjectRuleCreator:
             "project": self.project,
             "data": data,
             "owner": self.owner,
+            "source": self.source,
         }
         return _kwargs

--- a/tests/sentry/projects/project_rules/test_creator.py
+++ b/tests/sentry/projects/project_rules/test_creator.py
@@ -2,7 +2,7 @@ import pytest
 
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.locks import locks
-from sentry.models.rule import Rule
+from sentry.models.rule import Rule, RuleSource
 from sentry.projects.project_rules.creator import ProjectRuleCreator
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.features import with_feature
@@ -49,6 +49,7 @@ class TestProjectRuleCreator(TestCase):
                 }
             ],
             frequency=5,
+            source=RuleSource.ISSUE,
         )
 
     def test_creates_rule(self):


### PR DESCRIPTION
There are cron "rules" that we migrated and automatically connected to the error detector. We should actually just be creating these as orphaned workflows because cron detectors have yet to be created and migrated.

Don't automatically connect Rules with `source=RuleSource.CRON_MONITOR` to the error detector for the project.

A follow up migration will disconnect existing cron rules from error detectors. It should be okay because the default cron workflows check for a specific tag as a condition, but we can address to be safe.