### PR TITLE
fix(slack): Encode the `organization_id` into the `action_id`

### DIFF
--- a/src/sentry/integrations/slack/message_builder/base/block.py
+++ b/src/sentry/integrations/slack/message_builder/base/block.py
@@ -106,7 +106,7 @@ class BlockSlackMessageBuilder(SlackMessageBuilder, ABC):
         action = {
             "type": "external_select",
             "placeholder": {"type": "plain_text", "text": action.label, "emoji": True},
-            "action_id": action.name,
+            "action_id": action.action_id if action.action_id else action.name,
         }
         if initial_option:
             action["initial_option"] = initial_option

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -383,8 +383,8 @@ def build_actions(
                 value="unresolved:ongoing",
                 action_id=encode_action_id(
                     action=SlackAction.UNRESOLVED_ONGOING,
-                    organization_slug=group.organization.slug,
-                    project_slug=group.project.slug,
+                    organization_id=group.organization.id,
+                    project_id=group.project.id,
                 ),
             )
 
@@ -394,8 +394,8 @@ def build_actions(
             value="archive_dialog",
             action_id=encode_action_id(
                 action=SlackAction.ARCHIVE_DIALOG,
-                organization_slug=group.organization.slug,
-                project_slug=group.project.slug,
+                organization_id=group.organization.id,
+                project_id=group.project.id,
             ),
         )
 
@@ -407,8 +407,8 @@ def build_actions(
                 value="unresolved:ongoing",
                 action_id=encode_action_id(
                     action=SlackAction.UNRESOLVED_ONGOING,
-                    organization_slug=group.organization.slug,
-                    project_slug=group.project.slug,
+                    organization_id=group.organization.id,
+                    project_id=group.project.id,
                 ),
             )
         if not project.flags.has_releases:
@@ -418,8 +418,8 @@ def build_actions(
                 value="resolved",
                 action_id=encode_action_id(
                     action=SlackAction.STATUS,
-                    organization_slug=group.organization.slug,
-                    project_slug=group.project.slug,
+                    organization_id=group.organization.id,
+                    project_id=group.project.id,
                 ),
             )
 
@@ -429,8 +429,8 @@ def build_actions(
             value="resolve_dialog",
             action_id=encode_action_id(
                 action=SlackAction.RESOLVE_DIALOG,
-                organization_slug=group.organization.slug,
-                project_slug=group.project.slug,
+                organization_id=group.organization.id,
+                project_id=group.project.id,
             ),
         )
 
@@ -443,8 +443,8 @@ def build_actions(
             selected_options=format_actor_options_slack([assignee]) if assignee else [],
             action_id=encode_action_id(
                 action=SlackAction.ASSIGN,
-                organization_slug=group.organization.slug,
-                project_slug=group.project.slug,
+                organization_id=group.organization.id,
+                project_id=group.project.id,
             ),
         )
         return assign_button

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -25,12 +25,14 @@ from sentry.integrations.messaging.message_builder import (
 )
 from sentry.integrations.slack.message_builder.base.block import BlockSlackMessageBuilder
 from sentry.integrations.slack.message_builder.image_block_builder import ImageBlockBuilder
+from sentry.integrations.slack.message_builder.routing import encode_action_id
 from sentry.integrations.slack.message_builder.types import (
     ACTION_EMOJI,
     ACTIONED_CATEGORY_TO_EMOJI,
     CATEGORY_TO_EMOJI,
     LEVEL_TO_EMOJI,
     SLACK_URL_FORMAT,
+    SlackAction,
     SlackBlock,
 )
 from sentry.integrations.slack.message_builder.util import build_slack_footer
@@ -375,22 +377,61 @@ def build_actions(
         if group.issue_category == GroupCategory.FEEDBACK:
             return None
         if status == GroupStatus.IGNORED:
-            return MessageAction(name="status", label="Mark as Ongoing", value="unresolved:ongoing")
+            return MessageAction(
+                name="status",
+                label="Mark as Ongoing",
+                value="unresolved:ongoing",
+                action_id=encode_action_id(
+                    action=SlackAction.UNRESOLVED_ONGOING,
+                    organization_slug=group.organization.slug,
+                    project_slug=group.project.slug,
+                ),
+            )
 
-        return MessageAction(name="status", label="Archive", value="archive_dialog")
+        return MessageAction(
+            name="status",
+            label="Archive",
+            value="archive_dialog",
+            action_id=encode_action_id(
+                action=SlackAction.ARCHIVE_DIALOG,
+                organization_slug=group.organization.slug,
+                project_slug=group.project.slug,
+            ),
+        )
 
     def _resolve_button() -> MessageAction:
         if status == GroupStatus.RESOLVED:
             return MessageAction(
-                name="unresolved:ongoing", label="Unresolve", value="unresolved:ongoing"
+                name="unresolved:ongoing",
+                label="Unresolve",
+                value="unresolved:ongoing",
+                action_id=encode_action_id(
+                    action=SlackAction.UNRESOLVED_ONGOING,
+                    organization_slug=group.organization.slug,
+                    project_slug=group.project.slug,
+                ),
             )
         if not project.flags.has_releases:
-            return MessageAction(name="status", label="Resolve", value="resolved")
+            return MessageAction(
+                name="status",
+                label="Resolve",
+                value="resolved",
+                action_id=encode_action_id(
+                    action=SlackAction.STATUS,
+                    organization_slug=group.organization.slug,
+                    project_slug=group.project.slug,
+                ),
+            )
 
         return MessageAction(
             name="status",
             label="Resolve",
             value="resolve_dialog",
+            action_id=encode_action_id(
+                action=SlackAction.RESOLVE_DIALOG,
+                organization_slug=group.organization.slug,
+                project_slug=group.project.slug,
+            ),
         )
 
     def _assign_button() -> MessageAction:
@@ -400,6 +441,11 @@ def build_actions(
             label="Select Assignee...",
             type="select",
             selected_options=format_actor_options_slack([assignee]) if assignee else [],
+            action_id=encode_action_id(
+                action=SlackAction.ASSIGN,
+                organization_slug=group.organization.slug,
+                project_slug=group.project.slug,
+            ),
         )
         return assign_button
 

--- a/src/sentry/integrations/slack/message_builder/routing.py
+++ b/src/sentry/integrations/slack/message_builder/routing.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass
 
+from sentry.utils.options import sample_modulo
+
 
 @dataclass
 class SlackRoutingData:
@@ -15,8 +17,13 @@ class SlackRoutingData:
     project_slug: str | None = None
 
 
-def encode_action_id(*, action: str, organization_slug: str, project_slug: str) -> str:
+def encode_action_id(
+    *, action: str, organization_slug: str, project_slug: str, integration_id: int
+) -> str:
     """Used to encode routing data into the outbound action_id for a Slack block."""
+    if not sample_modulo("hybrid_cloud.integration_region_targeting_rate", integration_id):
+        return action
+
     return f"{action}::{organization_slug}::{project_slug}"
 
 

--- a/src/sentry/integrations/slack/message_builder/routing.py
+++ b/src/sentry/integrations/slack/message_builder/routing.py
@@ -1,7 +1,5 @@
 from dataclasses import dataclass
 
-from sentry.utils.options import sample_modulo
-
 
 @dataclass
 class SlackRoutingData:
@@ -17,13 +15,8 @@ class SlackRoutingData:
     project_slug: str | None = None
 
 
-def encode_action_id(
-    *, action: str, organization_slug: str, project_slug: str, integration_id: int
-) -> str:
+def encode_action_id(*, action: str, organization_slug: str, project_slug: str) -> str:
     """Used to encode routing data into the outbound action_id for a Slack block."""
-    if not sample_modulo("hybrid_cloud.integration_region_targeting_rate", integration_id):
-        return action
-
     return f"{action}::{organization_slug}::{project_slug}"
 
 

--- a/src/sentry/integrations/slack/message_builder/routing.py
+++ b/src/sentry/integrations/slack/message_builder/routing.py
@@ -1,4 +1,7 @@
+import logging
 from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -35,7 +38,8 @@ def decode_action_id(encoded_action_id: str) -> SlackRoutingData:
                 action=action_target_values[0],
                 organization_id=int(action_target_values[1]),
             )
-    except ValueError:
+    except ValueError as e:
         # If we can't parse the IDs as integers, fail silently since this is just routing
+        logger.info("invalid_identifiers", extra={"action_id": encoded_action_id, "error": e})
         pass
     return SlackRoutingData(action=action_target_values[0])

--- a/src/sentry/integrations/slack/message_builder/routing.py
+++ b/src/sentry/integrations/slack/message_builder/routing.py
@@ -11,28 +11,31 @@ class SlackRoutingData:
     """
 
     action: str  # Should be a member of SlackAction, but we don't care about the value for routing
-    organization_slug: str | None = None
-    project_slug: str | None = None
+    organization_id: int | None = None
+    project_id: int | None = None
 
 
-def encode_action_id(*, action: str, organization_slug: str, project_slug: str) -> str:
+def encode_action_id(*, action: str, organization_id: int, project_id: int) -> str:
     """Used to encode routing data into the outbound action_id for a Slack block."""
-    return f"{action}::{organization_slug}::{project_slug}"
+    return f"{action}::{organization_id}::{project_id}"
 
 
 def decode_action_id(encoded_action_id: str) -> SlackRoutingData:
     """Used to decode the routing data from the inbound action_id on a Slack block."""
     action_target_values = encoded_action_id.split("::")
-
-    if len(action_target_values) == 3:
-        return SlackRoutingData(
-            action=action_target_values[0],
-            organization_slug=action_target_values[1],
-            project_slug=action_target_values[2],
-        )
-    elif len(action_target_values) == 2:
-        return SlackRoutingData(
-            action=action_target_values[0],
-            organization_slug=action_target_values[1],
-        )
+    try:
+        if len(action_target_values) == 3:
+            return SlackRoutingData(
+                action=action_target_values[0],
+                organization_id=int(action_target_values[1]),
+                project_id=int(action_target_values[2]),
+            )
+        elif len(action_target_values) == 2:
+            return SlackRoutingData(
+                action=action_target_values[0],
+                organization_id=int(action_target_values[1]),
+            )
+    except ValueError:
+        # If we can't parse the IDs as integers, fail silently since this is just routing
+        pass
     return SlackRoutingData(action=action_target_values[0])

--- a/src/sentry/integrations/slack/message_builder/routing.py
+++ b/src/sentry/integrations/slack/message_builder/routing.py
@@ -1,0 +1,38 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class SlackRoutingData:
+    """
+    Slack only allows us one key to encode data on our actions, so to better route requests, we
+    need to encode it with enough data to narrow our targeting.
+
+    This type represents the current data we encode for targeting regions or cells.
+    """
+
+    action: str  # Should be a member of SlackAction, but we don't care about the value for routing
+    organization_slug: str | None = None
+    project_slug: str | None = None
+
+
+def encode_action_id(*, action: str, organization_slug: str, project_slug: str) -> str:
+    """Used to encode routing data into the outbound action_id for a Slack block."""
+    return f"{action}::{organization_slug}::{project_slug}"
+
+
+def decode_action_id(encoded_action_id: str) -> SlackRoutingData:
+    """Used to decode the routing data from the inbound action_id on a Slack block."""
+    action_target_values = encoded_action_id.split("::")
+
+    if len(action_target_values) == 3:
+        return SlackRoutingData(
+            action=action_target_values[0],
+            organization_slug=action_target_values[1],
+            project_slug=action_target_values[2],
+        )
+    elif len(action_target_values) == 2:
+        return SlackRoutingData(
+            action=action_target_values[0],
+            organization_slug=action_target_values[1],
+        )
+    return SlackRoutingData(action=action_target_values[0])

--- a/src/sentry/integrations/slack/message_builder/types.py
+++ b/src/sentry/integrations/slack/message_builder/types.py
@@ -1,3 +1,4 @@
+from enum import StrEnum
 from typing import Any, Union
 
 from sentry.issues.grouptype import GroupCategory
@@ -6,6 +7,20 @@ from sentry.issues.grouptype import GroupCategory
 SlackAttachment = dict[str, Any]
 SlackBlock = dict[str, Any]
 SlackBody = Union[SlackAttachment, SlackBlock]
+
+
+class SlackAction(StrEnum):
+    """
+    These are encoded into the action_id of a Slack block (see `encode_action_id` in `routing.py`).
+    Keep in mind that Slack requires each action in a message to have a unique action_id.
+    """
+
+    STATUS = "status"
+    UNRESOLVED_ONGOING = "unresolved:ongoing"
+    RESOLVE_DIALOG = "resolve_dialog"
+    ARCHIVE_DIALOG = "archive_dialog"
+    ASSIGN = "assign"
+
 
 INCIDENT_COLOR_MAPPING = {
     "Resolved": "_incident_resolved",

--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -32,6 +32,7 @@ from sentry.integrations.messaging.metrics import (
 )
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.slack.message_builder.issues import SlackIssuesMessageBuilder
+from sentry.integrations.slack.message_builder.routing import decode_action_id
 from sentry.integrations.slack.requests.action import SlackActionRequest
 from sentry.integrations.slack.requests.base import SlackRequestError
 from sentry.integrations.slack.sdk_client import SlackSdkClient
@@ -390,11 +391,7 @@ class SlackActionEndpoint(Endpoint):
                     lifecycle.record_failure(MessageInteractionFailureReason.MISSING_ACTION)
                     return self.respond()
 
-                lifecycle.add_extra(
-                    "selection",
-                    selection,
-                )
-
+                lifecycle.add_extra("selection", selection)
                 status_action = MessageAction(name="status", value=selection)
 
                 try:
@@ -556,9 +553,12 @@ class SlackActionEndpoint(Endpoint):
 
         action_list = []
         for action_data in action_data:
+
+            routing_data = decode_action_id(action_data["action_id"])
+            action_name = routing_data.action
             if action_data.get("type") in ("static_select", "external_select"):
                 action = BlockKitMessageAction(
-                    name=action_data["action_id"],
+                    name=action_name,
                     label=action_data["selected_option"]["text"]["text"],
                     type=action_data["type"],
                     value=action_data["selected_option"]["value"],
@@ -571,7 +571,7 @@ class SlackActionEndpoint(Endpoint):
                 # TODO: selected_options is kinda ridiculous, I think this is built to handle multi-select?
             else:
                 action = BlockKitMessageAction(
-                    name=action_data["action_id"],
+                    name=action_name,
                     label=action_data["text"]["text"],
                     type=action_data["type"],
                     value=action_data["value"],
@@ -864,7 +864,6 @@ class _ModalDialog(ABC):
         #
         # [1]: https://stackoverflow.com/questions/46629852/update-a-bot-message-after-responding-to-a-slack-dialog#comment80795670_46629852
         org = group.project.organization
-
         callback_id_dict = {
             "issue": group.id,
             "orig_response_url": slack_request.data["response_url"],

--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -544,18 +544,17 @@ class SlackActionEndpoint(Endpoint):
     @classmethod
     def get_action_list(cls, slack_request: SlackActionRequest) -> list[BlockKitMessageAction]:
         action_data = slack_request.data.get("actions")
-        if (
-            not action_data
-            or not isinstance(action_data, list)
-            or not action_data[0].get("action_id")
-        ):
+        if not action_data or not isinstance(action_data, list):
             return []
 
         action_list = []
         for action_data in action_data:
-
-            routing_data = decode_action_id(action_data["action_id"])
+            routing_data = decode_action_id(action_data.get("action_id", ""))
             action_name = routing_data.action
+
+            if not action_name:
+                continue
+
             if action_data.get("type") in ("static_select", "external_select"):
                 action = BlockKitMessageAction(
                     name=action_name,

--- a/src/sentry/notifications/utils/actions.py
+++ b/src/sentry/notifications/utils/actions.py
@@ -20,7 +20,7 @@ class MessageAction:
     # If this is a select type, the selected value.
     value: str | None = None
 
-    # Denotes the type of action
+    # Denotes the type of action, used for routing
     action_id: str | None = None
 
     style: Literal["primary", "danger", "default"] | None = None

--- a/tests/sentry/integrations/slack/message_builder/test_routing.py
+++ b/tests/sentry/integrations/slack/message_builder/test_routing.py
@@ -11,8 +11,8 @@ class SlackRequestRoutingTest(TestCase):
     def test_encode_action_id(self):
         action_id = encode_action_id(
             action=SlackAction.ARCHIVE_DIALOG,
-            organization_slug=self.organization.slug,
-            project_slug=self.project.slug,
+            organization_id=self.organization.id,
+            project_id=self.project.id,
         )
         assert (
             action_id
@@ -24,17 +24,17 @@ class SlackRequestRoutingTest(TestCase):
             f"{SlackAction.ARCHIVE_DIALOG}::{self.organization.slug}::{self.project.slug}"
         )
         assert action_id.action == SlackAction.ARCHIVE_DIALOG
-        assert action_id.organization_slug == self.organization.slug
-        assert action_id.project_slug == self.project.slug
+        assert action_id.organization_id == self.organization.id
+        assert action_id.project_id == self.project.id
 
     def test_decode_action_id_non_project(self):
         action_id = decode_action_id(f"{SlackAction.ARCHIVE_DIALOG}::{self.organization.slug}")
         assert action_id.action == SlackAction.ARCHIVE_DIALOG
-        assert action_id.organization_slug == self.organization.slug
-        assert action_id.project_slug is None
+        assert action_id.organization_id == self.organization.id
+        assert action_id.project_id is None
 
     def test_decode_action_id_non_encoded(self):
         action_id = decode_action_id(f"{SlackAction.ARCHIVE_DIALOG}")
         assert action_id.action == SlackAction.ARCHIVE_DIALOG
-        assert action_id.organization_slug is None
-        assert action_id.project_slug is None
+        assert action_id.organization_id is None
+        assert action_id.project_id is None

--- a/tests/sentry/integrations/slack/message_builder/test_routing.py
+++ b/tests/sentry/integrations/slack/message_builder/test_routing.py
@@ -1,0 +1,62 @@
+from sentry.integrations.slack.message_builder.routing import decode_action_id, encode_action_id
+from sentry.integrations.slack.message_builder.types import SlackAction
+from sentry.integrations.types import ExternalProviders
+from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.options import override_options
+
+
+class SlackRequestRoutingTest(TestCase):
+    def setUp(self):
+        self.organization = self.create_organization()
+        self.project = self.create_project(organization=self.organization)
+        self.integration = self.create_integration(
+            organization=self.organization,
+            provider=ExternalProviders.SLACK.value,
+            external_id="slack:test",
+        )
+        self.encoded_action_id = (
+            f"{SlackAction.ARCHIVE_DIALOG}::{self.organization.slug}::{self.project.slug}"
+        )
+
+    @override_options({"hybrid_cloud.integration_region_targeting_rate": 0.0})
+    def test_encode_action_id_non_targeted(self):
+        action_id = encode_action_id(
+            action=SlackAction.ARCHIVE_DIALOG,
+            organization_slug=self.organization.slug,
+            project_slug=self.project.slug,
+            integration_id=self.integration.id,
+        )
+        assert action_id == SlackAction.ARCHIVE_DIALOG
+
+    @override_options({"hybrid_cloud.integration_region_targeting_rate": 1.0})
+    def test_encode_action_id_targeted(self):
+        action_id = encode_action_id(
+            action=SlackAction.ARCHIVE_DIALOG,
+            organization_slug=self.organization.slug,
+            project_slug=self.project.slug,
+            integration_id=self.integration.id,
+        )
+        assert (
+            action_id
+            == f"{SlackAction.ARCHIVE_DIALOG}::{self.organization.slug}::{self.project.slug}"
+        )
+
+    def test_decode_action_id_full(self):
+        action_id = decode_action_id(
+            f"{SlackAction.ARCHIVE_DIALOG}::{self.organization.slug}::{self.project.slug}"
+        )
+        assert action_id.action == SlackAction.ARCHIVE_DIALOG
+        assert action_id.organization_slug == self.organization.slug
+        assert action_id.project_slug == self.project.slug
+
+    def test_decode_action_id_non_project(self):
+        action_id = decode_action_id(f"{SlackAction.ARCHIVE_DIALOG}::{self.organization.slug}")
+        assert action_id.action == SlackAction.ARCHIVE_DIALOG
+        assert action_id.organization_slug == self.organization.slug
+        assert action_id.project_slug is None
+
+    def test_decode_action_id_non_encoded(self):
+        action_id = decode_action_id(f"{SlackAction.ARCHIVE_DIALOG}")
+        assert action_id.action == SlackAction.ARCHIVE_DIALOG
+        assert action_id.organization_slug is None
+        assert action_id.project_slug is None

--- a/tests/sentry/integrations/slack/message_builder/test_routing.py
+++ b/tests/sentry/integrations/slack/message_builder/test_routing.py
@@ -15,20 +15,19 @@ class SlackRequestRoutingTest(TestCase):
             project_id=self.project.id,
         )
         assert (
-            action_id
-            == f"{SlackAction.ARCHIVE_DIALOG}::{self.organization.slug}::{self.project.slug}"
+            action_id == f"{SlackAction.ARCHIVE_DIALOG}::{self.organization.id}::{self.project.id}"
         )
 
     def test_decode_action_id_full(self):
         action_id = decode_action_id(
-            f"{SlackAction.ARCHIVE_DIALOG}::{self.organization.slug}::{self.project.slug}"
+            f"{SlackAction.ARCHIVE_DIALOG}::{self.organization.id}::{self.project.id}"
         )
         assert action_id.action == SlackAction.ARCHIVE_DIALOG
         assert action_id.organization_id == self.organization.id
         assert action_id.project_id == self.project.id
 
     def test_decode_action_id_non_project(self):
-        action_id = decode_action_id(f"{SlackAction.ARCHIVE_DIALOG}::{self.organization.slug}")
+        action_id = decode_action_id(f"{SlackAction.ARCHIVE_DIALOG}::{self.organization.id}")
         assert action_id.action == SlackAction.ARCHIVE_DIALOG
         assert action_id.organization_id == self.organization.id
         assert action_id.project_id is None

--- a/tests/sentry/integrations/slack/message_builder/test_routing.py
+++ b/tests/sentry/integrations/slack/message_builder/test_routing.py
@@ -1,40 +1,18 @@
 from sentry.integrations.slack.message_builder.routing import decode_action_id, encode_action_id
 from sentry.integrations.slack.message_builder.types import SlackAction
-from sentry.integrations.types import ExternalProviders
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers.options import override_options
 
 
 class SlackRequestRoutingTest(TestCase):
     def setUp(self):
         self.organization = self.create_organization()
         self.project = self.create_project(organization=self.organization)
-        self.integration = self.create_integration(
-            organization=self.organization,
-            provider=ExternalProviders.SLACK.value,
-            external_id="slack:test",
-        )
-        self.encoded_action_id = (
-            f"{SlackAction.ARCHIVE_DIALOG}::{self.organization.slug}::{self.project.slug}"
-        )
 
-    @override_options({"hybrid_cloud.integration_region_targeting_rate": 0.0})
-    def test_encode_action_id_non_targeted(self):
+    def test_encode_action_id(self):
         action_id = encode_action_id(
             action=SlackAction.ARCHIVE_DIALOG,
             organization_slug=self.organization.slug,
             project_slug=self.project.slug,
-            integration_id=self.integration.id,
-        )
-        assert action_id == SlackAction.ARCHIVE_DIALOG
-
-    @override_options({"hybrid_cloud.integration_region_targeting_rate": 1.0})
-    def test_encode_action_id_targeted(self):
-        action_id = encode_action_id(
-            action=SlackAction.ARCHIVE_DIALOG,
-            organization_slug=self.organization.slug,
-            project_slug=self.project.slug,
-            integration_id=self.integration.id,
         )
         assert (
             action_id

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -190,8 +190,8 @@ def build_test_message_blocks(
                 "type": "button",
                 "action_id": encode_action_id(
                     action=SlackAction.RESOLVE_DIALOG,
-                    organization_slug=project.organization.slug,
-                    project_slug=project.slug,
+                    organization_id=project.organization.id,
+                    project_id=project.id,
                 ),
                 "text": {"type": "plain_text", "text": "Resolve"},
                 "value": "resolve_dialog",
@@ -200,8 +200,8 @@ def build_test_message_blocks(
                 "type": "button",
                 "action_id": encode_action_id(
                     action=SlackAction.ARCHIVE_DIALOG,
-                    organization_slug=project.organization.slug,
-                    project_slug=project.slug,
+                    organization_id=project.organization.id,
+                    project_id=project.id,
                 ),
                 "text": {"type": "plain_text", "text": "Archive"},
                 "value": "archive_dialog",
@@ -215,8 +215,8 @@ def build_test_message_blocks(
                 },
                 "action_id": encode_action_id(
                     action=SlackAction.ASSIGN,
-                    organization_slug=project.organization.slug,
-                    project_slug=project.slug,
+                    organization_id=project.organization.id,
+                    project_id=project.id,
                 ),
             },
         ],

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -34,6 +34,8 @@ from sentry.integrations.slack.message_builder.issues import (
     get_tags,
 )
 from sentry.integrations.slack.message_builder.metric_alerts import SlackMetricAlertMessageBuilder
+from sentry.integrations.slack.message_builder.routing import encode_action_id
+from sentry.integrations.slack.message_builder.types import SlackAction
 from sentry.integrations.time_utils import time_since
 from sentry.issues.grouptype import (
     FeedbackGroup,
@@ -186,13 +188,21 @@ def build_test_message_blocks(
         "elements": [
             {
                 "type": "button",
-                "action_id": "resolve_dialog",
+                "action_id": encode_action_id(
+                    action=SlackAction.RESOLVE_DIALOG,
+                    organization_slug=project.organization.slug,
+                    project_slug=project.slug,
+                ),
                 "text": {"type": "plain_text", "text": "Resolve"},
                 "value": "resolve_dialog",
             },
             {
                 "type": "button",
-                "action_id": "archive_dialog",
+                "action_id": encode_action_id(
+                    action=SlackAction.ARCHIVE_DIALOG,
+                    organization_slug=project.organization.slug,
+                    project_slug=project.slug,
+                ),
                 "text": {"type": "plain_text", "text": "Archive"},
                 "value": "archive_dialog",
             },
@@ -203,7 +213,11 @@ def build_test_message_blocks(
                     "text": "Select Assignee...",
                     "emoji": True,
                 },
-                "action_id": "assign",
+                "action_id": encode_action_id(
+                    action=SlackAction.ASSIGN,
+                    organization_slug=project.organization.slug,
+                    project_slug=project.slug,
+                ),
             },
         ],
     }

--- a/tests/sentry/middleware/integrations/parsers/test_slack.py
+++ b/tests/sentry/middleware/integrations/parsers/test_slack.py
@@ -13,6 +13,8 @@ from rest_framework import status
 from sentry.hybridcloud.models.outbox import outbox_context
 from sentry.integrations.middleware.hybrid_cloud.parser import create_async_request_payload
 from sentry.integrations.models.organization_integration import OrganizationIntegration
+from sentry.integrations.slack.message_builder.routing import encode_action_id
+from sentry.integrations.slack.message_builder.types import SlackAction
 from sentry.integrations.slack.utils.auth import _encode_data
 from sentry.integrations.slack.views import SALT
 from sentry.middleware.integrations.parsers.slack import SlackRequestParser
@@ -189,7 +191,7 @@ class SlackRequestParserTest(TestCase):
         other_organization = self.create_organization()
         self.integration.add_organization(other_organization)
 
-        # Without passing an organization, we expect to filter to both.
+        # Case 1: Without passing an organization, we expect to filter to both.
         for cmd in ["link team", "unlink team"]:
             data = urlencode(
                 {
@@ -242,7 +244,7 @@ class SlackRequestParserTest(TestCase):
         # And add another, maybe the user belongs to it, maybe not
         irrelevant_organization = self.create_organization()
 
-        # If the organization slug is irrelevant, ignore it and return all orgs
+        # Case 3: If the organization slug is irrelevant, ignore it and return all orgs
         for cmd in ["link team", "unlink team"]:
             data = urlencode(
                 {
@@ -260,3 +262,90 @@ class SlackRequestParserTest(TestCase):
             organization_ids = {org.id for org in organizations}
             assert len(organization_ids) == 2
             assert irrelevant_organization.id not in organization_ids
+
+    @override_options({"hybrid_cloud.integration_region_targeting_rate": 1.0})
+    def test_targeting_issue_actions(self):
+        # Install the integration on two organizations
+        other_organization = self.create_organization()
+        self.integration.add_organization(other_organization)
+
+        # Case 1:With the default actions (non-encoded), we shouldn't filter the organization
+        data = urlencode(
+            {
+                "payload": json.dumps(
+                    {
+                        "actions": [{"action_id": SlackAction.RESOLVE_DIALOG}],
+                        "team_id": self.integration.external_id,
+                    }
+                ),
+            }
+        ).encode("utf-8")
+        request = self.factory.post(
+            reverse("sentry-integration-slack-action"),
+            data=data,
+            content_type="application/x-www-form-urlencoded",
+        )
+        parser = SlackRequestParser(request, self.get_response)
+        organizations = parser.get_organizations_from_integration(self.integration)
+        organization_ids = {org.id for org in organizations}
+        assert len(organization_ids) == 2
+        assert self.organization.id in organization_ids
+        assert other_organization.id in organization_ids
+
+        # Case 2: With the encoded action, we should filter to a single organization
+        project = self.create_project(organization=other_organization)
+        encoded_action = encode_action_id(
+            action=SlackAction.RESOLVE_DIALOG,
+            organization_slug=other_organization.slug,
+            project_slug=project.slug,
+        )
+        data = urlencode(
+            {
+                "payload": json.dumps(
+                    {
+                        "actions": [{"action_id": encoded_action}],
+                        "team_id": self.integration.external_id,
+                    }
+                ),
+            }
+        ).encode("utf-8")
+        request = self.factory.post(
+            reverse("sentry-integration-slack-action"),
+            data=data,
+            content_type="application/x-www-form-urlencoded",
+        )
+        parser = SlackRequestParser(request, self.get_response)
+        organizations = parser.get_organizations_from_integration(self.integration)
+        organization_ids = {org.id for org in organizations}
+        assert len(organization_ids) == 1
+        assert other_organization.id in organization_ids
+
+        # Case 3: If we see an irrelevant organization, we should ignore it
+        irrelevant_organization = self.create_organization()
+        project = self.create_project(organization=irrelevant_organization)
+        encoded_action = encode_action_id(
+            action=SlackAction.RESOLVE_DIALOG,
+            organization_slug=irrelevant_organization.slug,
+            project_slug=project.slug,
+        )
+        data = urlencode(
+            {
+                "payload": json.dumps(
+                    {
+                        "actions": [{"action_id": encoded_action}],
+                        "team_id": self.integration.external_id,
+                    }
+                ),
+            }
+        ).encode("utf-8")
+        request = self.factory.post(
+            reverse("sentry-integration-slack-action"),
+            data=data,
+            content_type="application/x-www-form-urlencoded",
+        )
+        parser = SlackRequestParser(request, self.get_response)
+        organizations = parser.get_organizations_from_integration(self.integration)
+        organization_ids = {org.id for org in organizations}
+        assert len(organization_ids) == 2
+        assert self.organization.id in organization_ids
+        assert other_organization.id in organization_ids

--- a/tests/sentry/middleware/integrations/parsers/test_slack.py
+++ b/tests/sentry/middleware/integrations/parsers/test_slack.py
@@ -296,8 +296,8 @@ class SlackRequestParserTest(TestCase):
         project = self.create_project(organization=other_organization)
         encoded_action = encode_action_id(
             action=SlackAction.RESOLVE_DIALOG,
-            organization_slug=other_organization.slug,
-            project_slug=project.slug,
+            organization_id=other_organization.id,
+            project_id=project.id,
         )
         data = urlencode(
             {
@@ -325,8 +325,8 @@ class SlackRequestParserTest(TestCase):
         project = self.create_project(organization=irrelevant_organization)
         encoded_action = encode_action_id(
             action=SlackAction.RESOLVE_DIALOG,
-            organization_slug=irrelevant_organization.slug,
-            project_slug=project.slug,
+            organization_id=irrelevant_organization.id,
+            project_id=project.id,
         )
         data = urlencode(
             {


### PR DESCRIPTION

Update2: Done, and updated failing tests
Update: Gonna switch to `organization_id` and update tests

---

This will allow us to route the actions taken for slack messages at the parser level.
This only needs to be done for actions that don't use URLs and should fail silently if the `action_id` is not encoded with routing data (as is the case for many billing notifs in the closed source repo).

I tested it locally with cross region enabled, and it seemed to work fine, filtering to my organization, though I only had one region active.


**todo**
- [x] Add tests for this routing behaviour
- [x] ~~Maybe try to only encode/decode the IDs if the behavior is enabled for the integration?~~ Didn't work out without a big refactor, still have some failing tests to address though