### PR TITLE
fix(grouping): Remove system-specific error type component

### DIFF
--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -511,7 +511,6 @@ def single_exception(
     type_component = ErrorTypeGroupingComponent(
         values=[exception.type] if exception.type else [],
     )
-    system_type_component = type_component.shallow_copy()
 
     ns_error_component = None
 
@@ -521,9 +520,7 @@ def single_exception(
             # actually carry any meaning with respect to what went wrong. (Synthetic exceptions
             # are dummy excepttions created by the SDK in order to harvest a stacktrace.)
             type_component.update(contributes=False, hint="ignored because exception is synthetic")
-            system_type_component.update(
-                contributes=False, hint="ignored because exception is synthetic"
-            )
+
         if exception.mechanism.meta and "ns_error" in exception.mechanism.meta:
             ns_error_component = NSErrorGroupingComponent(
                 values=[
@@ -553,10 +550,7 @@ def single_exception(
             | ErrorValueGroupingComponent
             | NSErrorGroupingComponent
             | StacktraceGroupingComponent
-        ] = [
-            stacktrace_component,
-            system_type_component if variant_name == "system" else type_component,
-        ]
+        ] = [stacktrace_component, type_component]
 
         if ns_error_component is not None:
             values.append(ns_error_component)


### PR DESCRIPTION
As part of the (now defunct) [mobile grouping strategy](https://github.com/getsentry/sentry/blob/dc56543bcff45c7ef98d526e17be4bda8f85f171/src/sentry/grouping/strategies/configurations.py#L156-L178), we used a regex to detect that certain exceptions were synthetic, i.e., created by the SDK rather than the underlying system. (SDKs do this in order to try to get a stacktrace to use when they haven't been given one.)

So that we could iterate on the regex without creating a new config every time, we only applied the results of this detection to the app variant, while the system variant continued to be calculated [with no detection](https://github.com/getsentry/sentry/blob/dc56543bcff45c7ef98d526e17be4bda8f85f171/src/sentry/grouping/strategies/newstyle.py#L560-L562). That way, even if the detection regex changed, the system variant would provide grouping continuity. This split in behavior was accomplished by having two copies of the error type grouping component, one for the app variant and one for the system variant.

When we removed the mobile config, we removed the split in behavior, but we didn't then merge the two copies of the type component back into one. This fixes that by getting rid of the system-variant-specific type component and using the base type component for both variants.