### PR TITLE
chore(ecosystem): don't double emit exceptions we also raise as IntegrationError

### DIFF
--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -504,7 +504,6 @@ class IntegrationInstallation(abc.ABC):
         elif isinstance(exc, IntegrationError):
             raise
         else:
-            self.logger.exception(str(exc))
             raise IntegrationError(self.message_from_error(exc)).with_traceback(sys.exc_info()[2])
 
     def is_rate_limited_error(self, exc: ApiError) -> bool:


### PR DESCRIPTION
Every time we call `installation.raise_error`, the fallback behavior is to log an exception (which will also create a Sentry issue) AND raise an IntegrationError, which will create a Sentry issue.

Remove the extra logging to halve the number of issues we produce from this area of the code.

The main motivation for this was the number of errors associated with `compare_commits`. We already catch `IntegrationError` in `compare_commits` code and emit a halt for it (although this may need to be revisited).

Resolves too many issues for me to list them all