### PR TITLE
fix(aci milestone 3): fix detector to action filtering in detector alert rule serializer

### DIFF
--- a/src/sentry/incidents/endpoints/serializers/workflow_engine_detector.py
+++ b/src/sentry/incidents/endpoints/serializers/workflow_engine_detector.py
@@ -276,19 +276,19 @@ class WorkflowEngineDetectorSerializer(Serializer):
 
         if "latestIncident" in self.expand:
             # to get the actions for a detector, we need to go from detector -> workflow -> action filters for that workflow -> actions
-            detector_workflows = DetectorWorkflow.objects.filter(
+            detector_workflow_values = DetectorWorkflow.objects.filter(
                 detector__in=detector_ids
             ).values_list("detector_id", "workflow_id")
             detector_id_to_workflow_ids = defaultdict(list)
-            for detector_id, workflow_id in detector_workflows:
+            for detector_id, workflow_id in detector_workflow_values:
                 detector_id_to_workflow_ids[detector_id].append(workflow_id)
 
-            data_condition_group_actions = dcgas.values_list(
+            workflow_action_values = dcgas.values_list(
                 "condition_group__workflowdataconditiongroup__workflow_id", "action_id"
             )
 
             workflow_id_to_action_ids = defaultdict(list)
-            for workflow_id, action_id in data_condition_group_actions:
+            for workflow_id, action_id in workflow_action_values:
                 workflow_id_to_action_ids[workflow_id].append(action_id)
 
             detector_to_action_ids = defaultdict(list)

--- a/tests/sentry/incidents/serializers/test_workflow_engine_detector.py
+++ b/tests/sentry/incidents/serializers/test_workflow_engine_detector.py
@@ -31,6 +31,20 @@ class TestDetectorSerializer(TestWorkflowEngineSerializer):
         assert serialized_detector == self.expected
 
     def test_latest_incident(self) -> None:
+        # add some other workflow engine objects to ensure that our filtering is working properly
+        other_alert_rule = self.create_alert_rule()
+        critical_trigger = self.create_alert_rule_trigger(
+            alert_rule=other_alert_rule, label="critical"
+        )
+        critical_trigger_action = self.create_alert_rule_trigger_action(
+            alert_rule_trigger=critical_trigger
+        )
+        migrate_alert_rule(other_alert_rule)
+        migrate_metric_data_conditions(critical_trigger)
+
+        migrate_metric_action(critical_trigger_action)
+        migrate_resolve_threshold_data_condition(other_alert_rule)
+
         self.add_incident_data()
         past_incident = self.create_incident(
             alert_rule=self.alert_rule, date_started=self.now - timedelta(days=1)


### PR DESCRIPTION
The previous iteration of this logic had a bug on line 294: we would append any action filter to a detector's list of action filters if its comparison was equal to one of the detector triggers' condition results. While this works if a single detector is serialized, it could break if we try to serialize multiple detectors. 

In addition, triple for loops made the code confusing to understand and somewhat inefficient. 

Correct the filtering logic and reuse existing querysets to make the code easier to understand.
