### PR TITLE
ref(rr6): Convert gettingStartedRoutes to route objects

### DIFF
--- a/static/app/components/route.tsx
+++ b/static/app/components/route.tsx
@@ -56,6 +56,10 @@ export interface SentryRouteObject extends CustomProps {
    */
   component?: React.ComponentType<any>;
   /**
+   * Only enable this route when USING_CUSTOMER_DOMAIN is enabled
+   */
+  customerDomainOnlyRoute?: true;
+  /**
    * Is a index route
    */
   index?: boolean;

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -2535,30 +2535,42 @@ function buildRoutes() {
     </Fragment>
   );
 
-  const gettingStartedRoutes = (
-    <Fragment>
-      {USING_CUSTOMER_DOMAIN && (
-        <Fragment>
-          <Redirect
-            from="/getting-started/:projectId/"
-            to="/projects/:projectId/getting-started/"
-          />
-          <Redirect
-            from="/getting-started/:projectId/:platform/"
-            to="/projects/:projectId/getting-started/"
-          />
-        </Fragment>
-      )}
-      <Redirect
-        from="/:orgId/:projectId/getting-started/"
-        to="/organizations/:orgId/projects/:projectId/getting-started/"
-      />
-      <Redirect
-        from="/:orgId/:projectId/getting-started/:platform/"
-        to="/organizations/:orgId/projects/:projectId/getting-started/"
-      />
-    </Fragment>
-  );
+  const gettingStartedChildRoutes: SentryRouteObject[] = [
+    {
+      path: '/getting-started/:projectId/',
+      component: () => (
+        <WorkingRedirect to="/projects/:projectId/getting-started/" replace />
+      ),
+      customerDomainOnlyRoute: true,
+    },
+    {
+      path: '/getting-started/:projectId/:platform/',
+      component: () => (
+        <WorkingRedirect to="/projects/:projectId/getting-started/" replace />
+      ),
+      customerDomainOnlyRoute: true,
+    },
+    {
+      path: '/:orgId/:projectId/getting-started/',
+      component: () => (
+        <WorkingRedirect
+          to="/organizations/:orgId/projects/:projectId/getting-started/"
+          replace
+        />
+      ),
+    },
+    {
+      path: '/:orgId/:projectId/getting-started/:platform/',
+      component: () => (
+        <WorkingRedirect
+          to="/organizations/:orgId/projects/:projectId/getting-started/"
+          replace
+        />
+      ),
+    },
+  ];
+
+  const gettingStartedRoutes = <Route newStyleChildren={gettingStartedChildRoutes} />;
 
   const profilingRoutes = (
     <Route

--- a/static/app/utils/reactRouter6Compat/router.tsx
+++ b/static/app/utils/reactRouter6Compat/router.tsx
@@ -117,7 +117,11 @@ function getElement(Component: React.ComponentType<any> | undefined) {
  * Converts a SentryRouteObject tree into a react-router RouteObject tree.
  */
 function translateSentryRoute(tree: SentryRouteObject): RouteObject {
-  const {name, path, withOrgPath, component} = tree;
+  const {name, path, withOrgPath, customerDomainOnlyRoute, component} = tree;
+
+  if (customerDomainOnlyRoute && !USING_CUSTOMER_DOMAIN) {
+    return {};
+  }
 
   // XXX(epurkhiser)
   //


### PR DESCRIPTION
Adds a new `customerDomainOnlyRoute` to our custom route object that causes the route to only be available when USING_CUSTOMER_DOMAIN is enabled. This will make our route trees simpler without a bunch of conditions in the arrays