### PR TITLE
fix(api): include lastTriggered correctly in List Rules endpoint

### DIFF
--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -120,6 +120,21 @@ class GetMaxAlertsTest(ProjectRuleBaseTestCase):
         assert result == 1
 
 
+class GetProjectRulesTest(ProjectRuleBaseTestCase):
+    method = "get"
+
+    def test_simple(self):
+        # attaches lastTriggered by default
+        response = self.get_success_response(
+            self.organization.slug,
+            self.project.slug,
+            status_code=status.HTTP_200_OK,
+        )
+        assert len(response.data) == Rule.objects.filter(project=self.project).count()
+        for rule in response.data:
+            assert "lastTriggered" in rule
+
+
 class CreateProjectRuleTest(ProjectRuleBaseTestCase):
     method = "post"
 


### PR DESCRIPTION
The documentation lists `lastTriggered` as expected as part of the response without passing any additional query params, which is not the case at the moment

https://docs.sentry.io/api/alerts/list-a-projects-issue-alert-rules/