### PR TITLE
feat: include defaultBranch resolver where it's actually needed

### DIFF
--- a/src/sentry/codecov/endpoints/TestResults/query.py
+++ b/src/sentry/codecov/endpoints/TestResults/query.py
@@ -12,6 +12,7 @@ query = """query GetTestResults(
     repository: repository(name: $repo) {
       __typename
       ... on Repository {
+        defaultBranch
         testAnalytics {
           testResults(
             filters: $filters

--- a/src/sentry/codecov/endpoints/TestResults/serializers.py
+++ b/src/sentry/codecov/endpoints/TestResults/serializers.py
@@ -36,6 +36,7 @@ class TestResultSerializer(serializers.Serializer):
 
     __test__ = False
 
+    defaultBranch = serializers.CharField()
     results = TestResultNodeSerializer(many=True)
     pageInfo = PageInfoSerializer()
     totalCount = serializers.IntegerField()
@@ -45,9 +46,8 @@ class TestResultSerializer(serializers.Serializer):
         Transform the GraphQL response to the serialized format
         """
         try:
-            test_results_data = graphql_response["data"]["owner"]["repository"]["testAnalytics"][
-                "testResults"
-            ]
+            repository_data = graphql_response["data"]["owner"]["repository"]
+            test_results_data = repository_data["testAnalytics"]["testResults"]
             test_results = test_results_data["edges"]
 
             nodes = []
@@ -56,6 +56,7 @@ class TestResultSerializer(serializers.Serializer):
                 nodes.append(node)
 
             response_data = {
+                "defaultBranch": repository_data["defaultBranch"],
                 "results": nodes,
                 "pageInfo": test_results_data.get(
                     "pageInfo",

--- a/src/sentry/codecov/endpoints/TestSuites/query.py
+++ b/src/sentry/codecov/endpoints/TestSuites/query.py
@@ -7,7 +7,6 @@ query = """query GetTestResultsTestSuites(
         repository: repository(name: $repo) {
             __typename
             ... on Repository {
-                defaultBranch
                 testAnalytics {
                     testSuites(term: $term)
                 }

--- a/tests/sentry/codecov/endpoints/test_test_results.py
+++ b/tests/sentry/codecov/endpoints/test_test_results.py
@@ -12,6 +12,7 @@ mock_graphql_response_empty = {
         "owner": {
             "repository": {
                 "__typename": "Repository",
+                "defaultBranch": "main",
                 "testAnalytics": {
                     "testResults": {
                         "edges": [],
@@ -34,6 +35,7 @@ mock_graphql_response_populated = {
         "owner": {
             "repository": {
                 "__typename": "Repository",
+                "defaultBranch": "another-branch",
                 "testAnalytics": {
                     "testResults": {
                         "edges": [


### PR DESCRIPTION
This PR properly surfaces + serializers the defaultBranch key in the correct endpoint.