### PR TITLE
feat(emerge): Update PreprodArtifactSizeMetrics size fields on launchpad analysis result assemble

### DIFF
--- a/src/sentry/preprod/api/models/project_preprod_size_analysis_models.py
+++ b/src/sentry/preprod/api/models/project_preprod_size_analysis_models.py
@@ -1,0 +1,10 @@
+from pydantic import BaseModel
+
+
+class TreemapResults(BaseModel):
+    total_install_size: int
+    total_download_size: int
+
+
+class SizeAnalysisResults(BaseModel):
+    treemap: TreemapResults | None

--- a/src/sentry/preprod/api/models/project_preprod_size_analysis_models.py
+++ b/src/sentry/preprod/api/models/project_preprod_size_analysis_models.py
@@ -1,10 +1,7 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
-class TreemapResults(BaseModel):
-    total_install_size: int
-    total_download_size: int
-
-
+# Keep in sync with https://github.com/getsentry/launchpad/blob/ff2d2956d062b202206353747af3bdb5bf6062a5/src/launchpad/size/models/common.py#L92
 class SizeAnalysisResults(BaseModel):
-    treemap: TreemapResults | None
+    download_size: int = Field(..., description="Estimated download size in bytes")
+    install_size: int = Field(..., description="Estimated install size in bytes")

--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -279,9 +279,12 @@ def _assemble_preprod_artifact_size_analysis(
         raise Exception(f"PreprodArtifact with id {artifact_id} does not exist")
 
     size_analysis_results = SizeAnalysisResults.parse_raw(assemble_result.bundle_temp_file.read())
-    if size_analysis_results.treemap:
-        install_size = size_analysis_results.treemap.total_install_size
-        download_size = size_analysis_results.treemap.total_download_size
+    install_size = (
+        size_analysis_results.treemap.total_install_size if size_analysis_results.treemap else None
+    )
+    download_size = (
+        size_analysis_results.treemap.total_download_size if size_analysis_results.treemap else None
+    )
 
     # Update size metrics in its own transaction
     with transaction.atomic(router.db_for_write(PreprodArtifactSizeMetrics)):

--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -279,12 +279,6 @@ def _assemble_preprod_artifact_size_analysis(
         raise Exception(f"PreprodArtifact with id {artifact_id} does not exist")
 
     size_analysis_results = SizeAnalysisResults.parse_raw(assemble_result.bundle_temp_file.read())
-    install_size = (
-        size_analysis_results.treemap.total_install_size if size_analysis_results.treemap else None
-    )
-    download_size = (
-        size_analysis_results.treemap.total_download_size if size_analysis_results.treemap else None
-    )
 
     # Update size metrics in its own transaction
     with transaction.atomic(router.db_for_write(PreprodArtifactSizeMetrics)):
@@ -293,10 +287,10 @@ def _assemble_preprod_artifact_size_analysis(
             defaults={
                 "analysis_file_id": assemble_result.bundle.id,
                 "metrics_artifact_type": PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,  # TODO: parse this from the treemap json
-                "min_install_size": install_size,
-                "max_install_size": install_size,
-                "min_download_size": download_size,
-                "max_download_size": download_size,
+                "min_install_size": None,  # No min value at this time
+                "max_install_size": size_analysis_results.install_size,
+                "min_download_size": None,  # No min value at this time
+                "max_download_size": size_analysis_results.download_size,
                 "state": PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
             },
         )

--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -11,6 +11,7 @@ from django.db import router, transaction
 
 from sentry.models.organization import Organization
 from sentry.models.project import Project
+from sentry.preprod.api.models.project_preprod_size_analysis_models import SizeAnalysisResults
 from sentry.preprod.models import PreprodArtifact
 from sentry.preprod.producer import produce_preprod_artifact_to_kafka
 from sentry.silo.base import SiloMode
@@ -277,6 +278,11 @@ def _assemble_preprod_artifact_size_analysis(
             pass  # Ignore cleanup errors
         raise Exception(f"PreprodArtifact with id {artifact_id} does not exist")
 
+    size_analysis_results = SizeAnalysisResults.parse_raw(assemble_result.bundle_temp_file.read())
+    if size_analysis_results.treemap:
+        install_size = size_analysis_results.treemap.total_install_size
+        download_size = size_analysis_results.treemap.total_download_size
+
     # Update size metrics in its own transaction
     with transaction.atomic(router.db_for_write(PreprodArtifactSizeMetrics)):
         size_metrics, created = PreprodArtifactSizeMetrics.objects.update_or_create(
@@ -284,6 +290,10 @@ def _assemble_preprod_artifact_size_analysis(
             defaults={
                 "analysis_file_id": assemble_result.bundle.id,
                 "metrics_artifact_type": PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,  # TODO: parse this from the treemap json
+                "min_install_size": install_size,
+                "max_install_size": install_size,
+                "min_download_size": download_size,
+                "max_download_size": download_size,
                 "state": PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
             },
         )

--- a/tests/sentry/preprod/test_tasks.py
+++ b/tests/sentry/preprod/test_tasks.py
@@ -403,7 +403,9 @@ class AssemblePreprodArtifactSizeAnalysisTest(BaseAssembleTest):
         return status, details
 
     def test_assemble_preprod_artifact_size_analysis_success(self) -> None:
-        status, details = self._run_task_and_verify_status(b"test size analysis content")
+        status, details = self._run_task_and_verify_status(
+            b'{"download_size": 1000, "install_size": 2000}'
+        )
 
         assert status == ChunkFileState.OK
         assert details is None
@@ -432,7 +434,9 @@ class AssemblePreprodArtifactSizeAnalysisTest(BaseAssembleTest):
             state=PreprodArtifactSizeMetrics.SizeAnalysisState.PENDING,
         )
 
-        status, details = self._run_task_and_verify_status(b"test size analysis update content")
+        status, details = self._run_task_and_verify_status(
+            b'{"download_size": 1000, "install_size": 2000}'
+        )
 
         assert status == ChunkFileState.OK
         assert details is None


### PR DESCRIPTION
Based on the result of the launchpad analysis, we need to seed the `min_install_size`,`min_download_size`,`max_install_size`,`max_download_size`. This wires that up from the treemap results.