### PR TITLE
feat(emerge): Add size info to build details response

### DIFF
--- a/src/sentry/preprod/api/endpoints/project_preprod_build_details.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_build_details.py
@@ -81,9 +81,17 @@ class ProjectPreprodBuildDetailsEndpoint(ProjectEndpoint):
                 size_info = None
             else:
                 size_metrics = main_artifact_size_metrics.first()
-                if size_metrics.max_install_size is None or size_metrics.max_download_size is None:
-                    logger.info(
-                        "Size analysis results found for preprod artifact %s but no min install or download size",
+
+                if size_metrics is None:
+                    logger.error(
+                        "No size analysis results found for preprod artifact %s", artifact_id
+                    )
+                    size_info = None
+                elif (
+                    size_metrics.max_install_size is None or size_metrics.max_download_size is None
+                ):
+                    logger.error(
+                        "Size analysis results found for preprod artifact %s but no max install or download size",
                         artifact_id,
                     )
                     size_info = None

--- a/src/sentry/preprod/api/endpoints/project_preprod_build_details.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_build_details.py
@@ -84,14 +84,6 @@ class ProjectPreprodBuildDetailsEndpoint(ProjectEndpoint):
                 size_info = None
             else:
                 size_metrics = size_metrics_qs.first()
-                logger.info(
-                    "Size analysis results found for preprod artifact %s: %s, %s, %s, %s",
-                    artifact_id,
-                    size_metrics.min_install_size,
-                    size_metrics.min_download_size,
-                    size_metrics.max_install_size,
-                    size_metrics.max_download_size,
-                )
                 if size_metrics.min_install_size is None or size_metrics.min_download_size is None:
                     logger.info(
                         "Size analysis results found for preprod artifact %s but no min install or download size",

--- a/src/sentry/preprod/api/models/project_preprod_build_details_models.py
+++ b/src/sentry/preprod/api/models/project_preprod_build_details_models.py
@@ -32,10 +32,16 @@ class BuildDetailsVcsInfo(BaseModel):
     # branch: Optional[str] = None  # Uncomment when available
 
 
+class BuildDetailsSizeInfo(BaseModel):
+    install_size_bytes: int
+    download_size_bytes: int
+
+
 class BuildDetailsApiResponse(BaseModel):
     state: PreprodArtifact.ArtifactState
     app_info: BuildDetailsAppInfo
     vcs_info: BuildDetailsVcsInfo
+    size_info: BuildDetailsSizeInfo | None = None
 
 
 def platform_from_artifact_type(artifact_type: PreprodArtifact.ArtifactType) -> Platform:


### PR DESCRIPTION
We need the size info for the sidebar per the designs. I'd prefer to not parse the treemap on the frontend and mix size-analysis/build-details API responses, and since the data is available in `PreprodArtifactSizeMetrics`, we should pull from there and add to a `size_info` item in the `build-details` API response.