### PR TITLE
feat(emerge): Wireup size_info from buildDetails endpoint to build details sidebar

### DIFF
--- a/static/app/views/preprod/sidebar/buildDetailsSidebarAppInfo.tsx
+++ b/static/app/views/preprod/sidebar/buildDetailsSidebarAppInfo.tsx
@@ -6,7 +6,10 @@ import {IconClock, IconFile, IconJson, IconLink} from 'sentry/icons';
 import {formatBytesBase10} from 'sentry/utils/bytes/formatBytesBase10';
 import {getFormattedDate} from 'sentry/utils/dates';
 import {openInstallModal} from 'sentry/views/preprod/components/installModal';
-import {type BuildDetailsAppInfo} from 'sentry/views/preprod/types/buildDetailsTypes';
+import {
+  type BuildDetailsAppInfo,
+  type BuildDetailsSizeInfo,
+} from 'sentry/views/preprod/types/buildDetailsTypes';
 import {
   getPlatformIconFromPlatform,
   getReadableArtifactTypeLabel,
@@ -16,11 +19,8 @@ import {
 interface BuildDetailsSidebarAppInfoProps {
   appInfo: BuildDetailsAppInfo;
   artifactId: string;
-  // TODO: Optional
-  downloadSizeBytes: number;
-  // TODO: Optional
-  installSizeBytes: number;
   projectId: string;
+  sizeInfo?: BuildDetailsSizeInfo;
 }
 
 export function BuildDetailsSidebarAppInfo(props: BuildDetailsSidebarAppInfoProps) {
@@ -37,19 +37,24 @@ export function BuildDetailsSidebarAppInfo(props: BuildDetailsSidebarAppInfoProp
         <Heading as="h3">{props.appInfo.name}</Heading>
       </AppNameHeader>
 
-      {/* TODO: Optional */}
-      <SizeSection>
-        <SizeRow>
-          <SizeItem>
-            <Heading as="h4">Install Size</Heading>
-            <SizeValue>{formatBytesBase10(props.installSizeBytes)}</SizeValue>
-          </SizeItem>
-          <SizeItem>
-            <Heading as="h4">Download Size</Heading>
-            <SizeValue>{formatBytesBase10(props.downloadSizeBytes)}</SizeValue>
-          </SizeItem>
-        </SizeRow>
-      </SizeSection>
+      {props.sizeInfo && (
+        <SizeSection>
+          <SizeRow>
+            <SizeItem>
+              <Heading as="h4">Install Size</Heading>
+              <SizeValue>
+                {formatBytesBase10(props.sizeInfo.install_size_bytes)}
+              </SizeValue>
+            </SizeItem>
+            <SizeItem>
+              <Heading as="h4">Download Size</Heading>
+              <SizeValue>
+                {formatBytesBase10(props.sizeInfo.download_size_bytes)}
+              </SizeValue>
+            </SizeItem>
+          </SizeRow>
+        </SizeSection>
+      )}
 
       <InfoSection>
         <InfoItem>

--- a/static/app/views/preprod/sidebar/buildDetailsSidebarContent.tsx
+++ b/static/app/views/preprod/sidebar/buildDetailsSidebarContent.tsx
@@ -50,11 +50,9 @@ export function BuildDetailsSidebarContent(props: BuildDetailsSidebarContentProp
       {/* App info */}
       <BuildDetailsSidebarAppInfo
         appInfo={buildDetailsData.app_info}
+        sizeInfo={buildDetailsData.size_info}
         projectId={props.projectId}
         artifactId={props.artifactId}
-        // TODO: Get from size data when available
-        installSizeBytes={1000000}
-        downloadSizeBytes={1000000}
       />
 
       {/* TODO: VCS info */}

--- a/static/app/views/preprod/types/buildDetailsTypes.ts
+++ b/static/app/views/preprod/types/buildDetailsTypes.ts
@@ -4,6 +4,7 @@ export interface BuildDetailsApiResponse {
   app_info: BuildDetailsAppInfo;
   state: BuildDetailsState;
   vcs_info: BuildDetailsVcsInfo;
+  size_info?: BuildDetailsSizeInfo;
 }
 
 export interface BuildDetailsAppInfo {
@@ -25,6 +26,11 @@ interface BuildDetailsVcsInfo {
   // repo?: string; // Uncomment when available
   // provider?: string; // Uncomment when available
   // branch?: string; // Uncomment when available
+}
+
+export interface BuildDetailsSizeInfo {
+  download_size_bytes: number;
+  install_size_bytes: number;
 }
 
 enum BuildDetailsState {


### PR DESCRIPTION
Wires up new `size_info` from the `build-details` API response from #96397.

Frontend with working data for install/download size:
<img width="1076" height="691" alt="Screenshot 2025-07-24 at 6 06 09 PM" src="https://github.com/user-attachments/assets/f523620e-44ac-4262-8b3f-9feae14144e8" />
