### PR TITLE
fix: Auditlog not displaying data for console platforms editions

### DIFF
--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -753,9 +753,9 @@ def create_console_platform_audit_log(
 
     changes = []
     if enabled:
-        changes.append(f"Enabled Platforms: {', '.join(enabled)}")
+        changes.append(f"Enabled platforms: {', '.join(enabled)}")
     if disabled:
-        changes.append(f"Disabled Platforms: {', '.join(disabled)}")
+        changes.append(f"Disabled platforms: {', '.join(disabled)}")
 
     if changes:
         create_audit_entry(

--- a/src/sentry/audit_log/register.py
+++ b/src/sentry/audit_log/register.py
@@ -675,6 +675,6 @@ default_manager.add(
         event_id=1158,
         name="ORG_CONSOLE_PLATFORM_EDIT",
         api_name="org.console-platform.edit",
-        template="edited console platforms",
+        template="{console_platforms}",
     )
 )

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -1420,11 +1420,11 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
             pass
 
         with assume_test_silo_mode_of(AuditLogEntry):
-            console_log = AuditLogEntry.objects.get(
-                organization_id=self.organization.id,
-                event=audit_log.get_event_id("ORG_CONSOLE_PLATFORM_EDIT"),
+            audit_entry = AuditLogEntry.objects.get(
+                event=audit_log.get_event_id("ORG_CONSOLE_PLATFORM_EDIT")
             )
-            assert console_log.data["console_platforms"] == "Enabled Platforms: PlayStation, Xbox"
+            audit_log_event = audit_log.get(audit_entry.event)
+            assert audit_log_event.render(audit_entry) == "Enabled platforms: PlayStation, Xbox"
 
             # Verify console platforms are NOT in the main ORG_EDIT audit log
             # (Since this test only changes console platforms, there should be no ORG_EDIT log)
@@ -1452,13 +1452,13 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
             pass
 
         with assume_test_silo_mode_of(AuditLogEntry):
-            console_log = AuditLogEntry.objects.get(
-                organization_id=self.organization.id,
-                event=audit_log.get_event_id("ORG_CONSOLE_PLATFORM_EDIT"),
+            audit_entry = AuditLogEntry.objects.get(
+                event=audit_log.get_event_id("ORG_CONSOLE_PLATFORM_EDIT")
             )
+            audit_log_event = audit_log.get(audit_entry.event)
             assert (
-                console_log.data["console_platforms"]
-                == "Disabled Platforms: Nintendo Switch, PlayStation"
+                audit_log_event.render(audit_entry)
+                == "Disabled platforms: Nintendo Switch, PlayStation"
             )
 
     @with_feature({"organizations:project-creation-games-tab": True})
@@ -1476,11 +1476,11 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
             pass
 
         with assume_test_silo_mode_of(AuditLogEntry):
-            console_log = AuditLogEntry.objects.get(
-                organization_id=self.organization.id,
-                event=audit_log.get_event_id("ORG_CONSOLE_PLATFORM_EDIT"),
+            audit_entry = AuditLogEntry.objects.get(
+                event=audit_log.get_event_id("ORG_CONSOLE_PLATFORM_EDIT")
             )
-            assert console_log.data["console_platforms"] == "Enabled Platforms: PlayStation"
+            audit_log_event = audit_log.get(audit_entry.event)
+            assert audit_log_event.render(audit_entry) == "Enabled platforms: PlayStation"
 
     @with_feature({"organizations:project-creation-games-tab": True})
     def test_enabled_and_disabled_console_platforms(self):
@@ -1499,13 +1499,13 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
             pass
 
         with assume_test_silo_mode_of(AuditLogEntry):
-            console_log = AuditLogEntry.objects.get(
-                organization_id=self.organization.id,
-                event=audit_log.get_event_id("ORG_CONSOLE_PLATFORM_EDIT"),
+            audit_entry = AuditLogEntry.objects.get(
+                event=audit_log.get_event_id("ORG_CONSOLE_PLATFORM_EDIT")
             )
+            audit_log_event = audit_log.get(audit_entry.event)
             assert (
-                console_log.data["console_platforms"]
-                == "Enabled Platforms: PlayStation, Xbox; Disabled Platforms: Nintendo Switch"
+                audit_log_event.render(audit_entry)
+                == "Enabled platforms: PlayStation, Xbox; Disabled platforms: Nintendo Switch"
             )
 
     def test_enable_pr_review_test_generation_default_true(self):


### PR DESCRIPTION
<img width="1403" height="94" alt="image" src="https://github.com/user-attachments/assets/5c76e1b1-a39b-4244-84ab-ff20315946c2" />

It should say ^ Enabled platforms: X,Y,Z; Disabled platforms: A,B,C 