### PR TITLE
ref(analytics): move alerts analytics to typed event

### DIFF
--- a/src/sentry/analytics/events/alert_rule_ui_component_webhook_sent.py
+++ b/src/sentry/analytics/events/alert_rule_ui_component_webhook_sent.py
@@ -1,15 +1,12 @@
 from sentry import analytics
 
 
+@analytics.eventclass("alert_rule_ui_component_webhook.sent")
 class AlertRuleUiComponentWebhookSentEvent(analytics.Event):
-    type = "alert_rule_ui_component_webhook.sent"
-
-    attributes = (
-        # organization_id refers to the organization that installed the sentryapp
-        analytics.Attribute("organization_id"),
-        analytics.Attribute("sentry_app_id"),
-        analytics.Attribute("event"),
-    )
+    # organization_id refers to the organization that installed the sentryapp
+    organization_id: int
+    sentry_app_id: int
+    event: str
 
 
 analytics.register(AlertRuleUiComponentWebhookSentEvent)

--- a/src/sentry/analytics/events/alert_sent.py
+++ b/src/sentry/analytics/events/alert_sent.py
@@ -1,22 +1,19 @@
 from sentry import analytics
 
 
+@analytics.eventclass("alert.sent")
 class AlertSentEvent(analytics.Event):
-    type = "alert.sent"
-
-    attributes = (
-        analytics.Attribute("organization_id"),
-        analytics.Attribute("project_id"),
-        # The id of the Alert or AlertRule
-        analytics.Attribute("alert_id"),
-        # "issue_alert" or "metric_alert"
-        analytics.Attribute("alert_type"),
-        # Slack, msteams, email, etc.
-        analytics.Attribute("provider"),
-        # User_id if sent via email, channel id if sent via slack, etc.
-        analytics.Attribute("external_id", type=str, required=False),
-        analytics.Attribute("notification_uuid", required=False),
-    )
+    organization_id: int
+    project_id: int
+    # The id of the Alert or AlertRule
+    alert_id: int | str
+    # "issue_alert" or "metric_alert"
+    alert_type: str
+    # Slack, msteams, email, etc.
+    provider: str
+    # User_id if sent via email, channel id if sent via slack, etc.
+    external_id: str | None = None
+    notification_uuid: str | None = None
 
 
 analytics.register(AlertSentEvent)

--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -12,6 +12,7 @@ from django.template.defaultfilters import pluralize
 from django.urls import reverse
 
 from sentry import analytics, features
+from sentry.analytics.events.alert_sent import AlertSentEvent
 from sentry.api.serializers import serialize
 from sentry.charts.types import ChartSize
 from sentry.constants import CRASH_RATE_ALERT_AGGREGATE_ALIAS
@@ -104,14 +105,15 @@ class ActionHandler(metaclass=abc.ABCMeta):
         notification_uuid: str | None = None,
     ) -> None:
         analytics.record(
-            "alert.sent",
-            organization_id=organization_id,
-            project_id=project_id,
-            provider=self.provider,
-            alert_id=alert_id,
-            alert_type="metric_alert",
-            external_id=str(external_id) if external_id is not None else "",
-            notification_uuid=notification_uuid or "",
+            AlertSentEvent(
+                organization_id=organization_id,
+                project_id=project_id,
+                provider=self.provider,
+                alert_id=alert_id,
+                alert_type="metric_alert",
+                external_id=str(external_id) if external_id is not None else "",
+                notification_uuid=notification_uuid or "",
+            )
         )
 
 

--- a/src/sentry/integrations/services/integration/impl.py
+++ b/src/sentry/integrations/services/integration/impl.py
@@ -8,6 +8,9 @@ import sentry_sdk
 from django.utils import timezone
 
 from sentry import analytics
+from sentry.analytics.events.alert_rule_ui_component_webhook_sent import (
+    AlertRuleUiComponentWebhookSentEvent,
+)
 from sentry.api.paginator import OffsetPaginator
 from sentry.constants import SentryAppInstallationStatus
 from sentry.hybridcloud.rpc.pagination import RpcPaginationArgs, RpcPaginationResult
@@ -422,10 +425,11 @@ class DatabaseBackedIntegrationService(IntegrationService):
 
         if alert_rule_action_ui_component:
             analytics.record(
-                "alert_rule_ui_component_webhook.sent",
-                organization_id=organization_id,
-                sentry_app_id=sentry_app.id,
-                event=f"{app_platform_event.resource}.{app_platform_event.action}",
+                AlertRuleUiComponentWebhookSentEvent(
+                    organization_id=organization_id,
+                    sentry_app_id=sentry_app.id,
+                    event=f"{app_platform_event.resource}.{app_platform_event.action}",
+                )
             )
         return alert_rule_action_ui_component
 

--- a/src/sentry/integrations/services/integration/impl.py
+++ b/src/sentry/integrations/services/integration/impl.py
@@ -424,13 +424,16 @@ class DatabaseBackedIntegrationService(IntegrationService):
         alert_rule_action_ui_component = find_alert_rule_action_ui_component(app_platform_event)
 
         if alert_rule_action_ui_component:
-            analytics.record(
-                AlertRuleUiComponentWebhookSentEvent(
-                    organization_id=organization_id,
-                    sentry_app_id=sentry_app.id,
-                    event=f"{app_platform_event.resource}.{app_platform_event.action}",
+            try:
+                analytics.record(
+                    AlertRuleUiComponentWebhookSentEvent(
+                        organization_id=organization_id,
+                        sentry_app_id=sentry_app.id,
+                        event=f"{app_platform_event.resource}.{app_platform_event.action}",
+                    )
                 )
-            )
+            except Exception as e:
+                sentry_sdk.capture_exception(e)
         return alert_rule_action_ui_component
 
     def send_msteams_incident_alert_notification(

--- a/src/sentry/notifications/notifications/digest.py
+++ b/src/sentry/notifications/notifications/digest.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any
 from urllib.parse import urlencode
 
 from sentry import analytics, features
+from sentry.analytics.events.alert_sent import AlertSentEvent
 from sentry.db.models import Model
 from sentry.digests.notifications import DigestInfo
 from sentry.digests.utils import (
@@ -259,12 +260,13 @@ class DigestNotification(ProjectNotification):
         super().record_notification_sent(recipient, provider)
         log_params = self.get_log_params(recipient)
         analytics.record(
-            "alert.sent",
-            organization_id=self.organization.id,
-            project_id=self.project.id,
-            provider=provider.name,
-            alert_id=log_params["alert_id"] if log_params["alert_id"] else "",
-            alert_type="issue_alert",
-            external_id=str(recipient.id),
-            notification_uuid=self.notification_uuid,
+            AlertSentEvent(
+                organization_id=self.organization.id,
+                project_id=self.project.id,
+                provider=provider.name,
+                alert_id=log_params["alert_id"] if log_params["alert_id"] else "",
+                alert_type="issue_alert",
+                external_id=str(recipient.id),
+                notification_uuid=self.notification_uuid,
+            )
         )

--- a/src/sentry/notifications/notifications/rules.py
+++ b/src/sentry/notifications/notifications/rules.py
@@ -7,6 +7,7 @@ from datetime import UTC, tzinfo
 from typing import Any
 
 from sentry import analytics, features
+from sentry.analytics.events.alert_sent import AlertSentEvent
 from sentry.db.models import Model
 from sentry.eventstore.models import GroupEvent
 from sentry.integrations.issue_alert_image_builder import IssueAlertImageBuilder
@@ -364,12 +365,13 @@ class AlertRuleNotification(ProjectNotification):
         super().record_notification_sent(recipient, provider)
         log_params = self.get_log_params(recipient)
         analytics.record(
-            "alert.sent",
-            organization_id=self.organization.id,
-            project_id=self.project.id,
-            provider=provider.name,
-            alert_id=log_params["alert_id"] if log_params["alert_id"] else "",
-            alert_type="issue_alert",
-            external_id=str(recipient.id),
-            notification_uuid=self.notification_uuid,
+            AlertSentEvent(
+                organization_id=self.organization.id,
+                project_id=self.project.id,
+                provider=provider.name,
+                alert_id=log_params["alert_id"] if log_params["alert_id"] else "",
+                alert_type="issue_alert",
+                external_id=str(recipient.id),
+                notification_uuid=self.notification_uuid,
+            )
         )

--- a/src/sentry/notifications/notifications/rules.py
+++ b/src/sentry/notifications/notifications/rules.py
@@ -6,6 +6,8 @@ from collections.abc import Iterable, Mapping, MutableMapping
 from datetime import UTC, tzinfo
 from typing import Any
 
+import sentry_sdk
+
 from sentry import analytics, features
 from sentry.analytics.events.alert_sent import AlertSentEvent
 from sentry.db.models import Model
@@ -364,14 +366,17 @@ class AlertRuleNotification(ProjectNotification):
     def record_notification_sent(self, recipient: Actor, provider: ExternalProviders) -> None:
         super().record_notification_sent(recipient, provider)
         log_params = self.get_log_params(recipient)
-        analytics.record(
-            AlertSentEvent(
-                organization_id=self.organization.id,
-                project_id=self.project.id,
-                provider=provider.name,
-                alert_id=log_params["alert_id"] if log_params["alert_id"] else "",
-                alert_type="issue_alert",
-                external_id=str(recipient.id),
-                notification_uuid=self.notification_uuid,
+        try:
+            analytics.record(
+                AlertSentEvent(
+                    organization_id=self.organization.id,
+                    project_id=self.project.id,
+                    provider=provider.name,
+                    alert_id=log_params["alert_id"] if log_params["alert_id"] else "",
+                    alert_type="issue_alert",
+                    external_id=str(recipient.id),
+                    notification_uuid=self.notification_uuid,
+                )
             )
-        )
+        except Exception as e:
+            sentry_sdk.capture_exception(e)

--- a/src/sentry/rules/actions/integrations/base.py
+++ b/src/sentry/rules/actions/integrations/base.py
@@ -7,6 +7,7 @@ from typing import Any, override
 import sentry_sdk
 
 from sentry import analytics
+from sentry.analytics.events.alert_sent import AlertSentEvent
 from sentry.eventstore.models import GroupEvent
 from sentry.integrations.services.integration import (
     RpcIntegration,
@@ -121,12 +122,13 @@ class IntegrationEventAction(EventAction, abc.ABC):
             alert_id=rule.id if rule else None,
         )
         analytics.record(
-            "alert.sent",
-            provider=self.provider,
-            alert_id=rule.id if rule else "",
-            alert_type="issue_alert",
-            organization_id=event.organization.id,
-            project_id=event.project_id,
-            external_id=external_id,
-            notification_uuid=notification_uuid if notification_uuid else "",
+            AlertSentEvent(
+                provider=self.provider,
+                alert_id=rule.id if rule else "",
+                alert_type="issue_alert",
+                organization_id=event.organization.id,
+                project_id=event.project_id,
+                external_id=external_id,
+                notification_uuid=notification_uuid if notification_uuid else "",
+            )
         )

--- a/src/sentry/rules/actions/integrations/base.py
+++ b/src/sentry/rules/actions/integrations/base.py
@@ -121,14 +121,18 @@ class IntegrationEventAction(EventAction, abc.ABC):
             notification_uuid=notification_uuid if notification_uuid else "",
             alert_id=rule.id if rule else None,
         )
-        analytics.record(
-            AlertSentEvent(
-                provider=self.provider,
-                alert_id=rule.id if rule else "",
-                alert_type="issue_alert",
-                organization_id=event.organization.id,
-                project_id=event.project_id,
-                external_id=external_id,
-                notification_uuid=notification_uuid if notification_uuid else "",
+
+        try:
+            analytics.record(
+                AlertSentEvent(
+                    provider=self.provider,
+                    alert_id=rule.id if rule else "",
+                    alert_type="issue_alert",
+                    organization_id=event.organization.id,
+                    project_id=event.project_id,
+                    external_id=external_id,
+                    notification_uuid=notification_uuid if notification_uuid else "",
+                )
             )
-        )
+        except Exception as e:
+            sentry_sdk.capture_exception(e)

--- a/src/sentry/sentry_apps/tasks/sentry_apps.py
+++ b/src/sentry/sentry_apps/tasks/sentry_apps.py
@@ -11,6 +11,9 @@ from requests import HTTPError, Timeout
 from requests.exceptions import ChunkedEncodingError, ConnectionError, RequestException
 
 from sentry import analytics, features, nodestore
+from sentry.analytics.events.alert_rule_ui_component_webhook_sent import (
+    AlertRuleUiComponentWebhookSentEvent,
+)
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.group import BaseGroupSerializerResponse
 from sentry.constants import SentryAppInstallationStatus
@@ -260,10 +263,11 @@ def send_alert_webhook_v2(
     # On success, record analytic event for Alert Rule UI Component
     if request_data.data.get("issue_alert"):
         analytics.record(
-            "alert_rule_ui_component_webhook.sent",
-            organization_id=organization.id,
-            sentry_app_id=sentry_app_id,
-            event=SentryAppEventType.EVENT_ALERT_TRIGGERED,
+            AlertRuleUiComponentWebhookSentEvent(
+                organization_id=organization.id,
+                sentry_app_id=sentry_app_id,
+                event=SentryAppEventType.EVENT_ALERT_TRIGGERED,
+            )
         )
 
 

--- a/tests/sentry/incidents/action_handlers/test_email.py
+++ b/tests/sentry/incidents/action_handlers/test_email.py
@@ -10,6 +10,7 @@ from django.urls import reverse
 from django.utils import timezone
 from urllib3.response import HTTPResponse
 
+from sentry.analytics.events.alert_sent import AlertSentEvent
 from sentry.api.serializers import serialize
 from sentry.incidents.action_handlers import (
     EmailActionHandler,
@@ -46,6 +47,7 @@ from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import SnubaQuery
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.analytics import assert_last_analytics_event
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import assume_test_silo_mode_of
@@ -89,15 +91,17 @@ class EmailActionHandlerTest(FireTest):
     @patch("sentry.analytics.record")
     def test_alert_sent_recorded(self, mock_record):
         self.run_fire_test()
-        mock_record.assert_called_with(
-            "alert.sent",
-            organization_id=self.organization.id,
-            project_id=self.project.id,
-            provider="email",
-            alert_id=self.alert_rule.id,
-            alert_type="metric_alert",
-            external_id=str(self.user.id),
-            notification_uuid="",
+        assert_last_analytics_event(
+            mock_record,
+            AlertSentEvent(
+                organization_id=self.organization.id,
+                project_id=self.project.id,
+                provider="email",
+                alert_id=str(self.alert_rule.id),
+                alert_type="metric_alert",
+                external_id=str(self.user.id),
+                notification_uuid="",
+            ),
         )
 
 

--- a/tests/sentry/incidents/action_handlers/test_msteams.py
+++ b/tests/sentry/incidents/action_handlers/test_msteams.py
@@ -6,6 +6,7 @@ import orjson
 import responses
 from urllib3.response import HTTPResponse
 
+from sentry.analytics.events.alert_sent import AlertSentEvent
 from sentry.incidents.logic import update_incident_status
 from sentry.incidents.models.alert_rule import (
     AlertRuleDetectionType,
@@ -28,6 +29,7 @@ from sentry.integrations.types import EventLifecycleOutcome
 from sentry.seer.anomaly_detection.types import StoreDataResponse
 from sentry.silo.base import SiloMode
 from sentry.testutils.asserts import assert_slo_metric
+from sentry.testutils.helpers.analytics import assert_last_analytics_event
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import assume_test_silo_mode
@@ -210,15 +212,17 @@ class MsTeamsActionHandlerTest(FireTest):
     @patch("sentry.analytics.record")
     def test_alert_sent_recorded(self, mock_record):
         self.run_fire_test()
-        mock_record.assert_called_with(
-            "alert.sent",
-            organization_id=self.organization.id,
-            project_id=self.project.id,
-            provider="msteams",
-            alert_id=self.alert_rule.id,
-            alert_type="metric_alert",
-            external_id=str(self.action.target_identifier),
-            notification_uuid="",
+        assert_last_analytics_event(
+            mock_record,
+            AlertSentEvent(
+                organization_id=self.organization.id,
+                project_id=self.project.id,
+                provider="msteams",
+                alert_id=str(self.alert_rule.id),
+                alert_type="metric_alert",
+                external_id=str(self.action.target_identifier),
+                notification_uuid="",
+            ),
         )
 
     @responses.activate

--- a/tests/sentry/incidents/action_handlers/test_opsgenie.py
+++ b/tests/sentry/incidents/action_handlers/test_opsgenie.py
@@ -4,6 +4,7 @@ import orjson
 import responses
 from urllib3.response import HTTPResponse
 
+from sentry.analytics.events.alert_sent import AlertSentEvent
 from sentry.incidents.action_handlers import OpsgenieActionHandler
 from sentry.incidents.logic import update_incident_status
 from sentry.incidents.models.alert_rule import (
@@ -17,6 +18,7 @@ from sentry.incidents.typings.metric_detector import AlertContext, MetricIssueCo
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.seer.anomaly_detection.types import StoreDataResponse
+from sentry.testutils.helpers.analytics import assert_last_analytics_event
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import assume_test_silo_mode_of
@@ -317,15 +319,17 @@ class OpsgenieActionHandlerTest(FireTest):
     @patch("sentry.analytics.record")
     def test_alert_sent_recorded(self, mock_record):
         self.run_fire_test()
-        mock_record.assert_called_with(
-            "alert.sent",
-            organization_id=self.organization.id,
-            project_id=self.project.id,
-            provider="opsgenie",
-            alert_id=self.alert_rule.id,
-            alert_type="metric_alert",
-            external_id=str(self.action.target_identifier),
-            notification_uuid="",
+        assert_last_analytics_event(
+            mock_record,
+            AlertSentEvent(
+                organization_id=self.organization.id,
+                project_id=self.project.id,
+                provider="opsgenie",
+                alert_id=str(self.alert_rule.id),
+                alert_type="metric_alert",
+                external_id=str(self.action.target_identifier),
+                notification_uuid="",
+            ),
         )
 
     @responses.activate

--- a/tests/sentry/incidents/action_handlers/test_pagerduty.py
+++ b/tests/sentry/incidents/action_handlers/test_pagerduty.py
@@ -7,6 +7,7 @@ import responses
 from django.http import Http404
 from urllib3.response import HTTPResponse
 
+from sentry.analytics.events.alert_sent import AlertSentEvent
 from sentry.incidents.action_handlers import PagerDutyActionHandler
 from sentry.incidents.logic import update_incident_status
 from sentry.incidents.models.alert_rule import (
@@ -20,6 +21,7 @@ from sentry.incidents.typings.metric_detector import AlertContext, MetricIssueCo
 from sentry.integrations.pagerduty.utils import add_service
 from sentry.seer.anomaly_detection.types import StoreDataResponse
 from sentry.silo.base import SiloMode
+from sentry.testutils.helpers.analytics import assert_last_analytics_event
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import assume_test_silo_mode
@@ -262,15 +264,17 @@ class PagerDutyActionHandlerTest(FireTest):
     @patch("sentry.analytics.record")
     def test_alert_sent_recorded(self, mock_record):
         self.run_fire_test()
-        mock_record.assert_called_with(
-            "alert.sent",
-            organization_id=self.organization.id,
-            project_id=self.project.id,
-            provider="pagerduty",
-            alert_id=self.alert_rule.id,
-            alert_type="metric_alert",
-            external_id=str(self.action.target_identifier),
-            notification_uuid="",
+        assert_last_analytics_event(
+            mock_record,
+            AlertSentEvent(
+                organization_id=self.organization.id,
+                project_id=self.project.id,
+                provider="pagerduty",
+                alert_id=str(self.alert_rule.id),
+                alert_type="metric_alert",
+                external_id=str(self.action.target_identifier),
+                notification_uuid="",
+            ),
         )
 
     @responses.activate

--- a/tests/sentry/incidents/action_handlers/test_sentry_app.py
+++ b/tests/sentry/incidents/action_handlers/test_sentry_app.py
@@ -2,6 +2,7 @@ from unittest.mock import patch
 
 import responses
 
+from sentry.analytics.events.alert_sent import AlertSentEvent
 from sentry.api.serializers import serialize
 from sentry.incidents.action_handlers import SentryAppActionHandler
 from sentry.incidents.endpoints.serializers.incident import IncidentSerializer
@@ -15,6 +16,7 @@ from sentry.testutils.asserts import (
     assert_halt_metric,
     assert_success_metric,
 )
+from sentry.testutils.helpers.analytics import assert_last_analytics_event
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.utils import json
 
@@ -303,15 +305,17 @@ class SentryAppAlertRuleUIComponentActionHandlerTest(FireTest):
     @patch("sentry.analytics.record")
     def test_alert_sent_recorded(self, mock_record, mock_record_event):
         self.run_fire_test()
-        mock_record.assert_called_with(
-            "alert.sent",
-            organization_id=self.organization.id,
-            project_id=self.project.id,
-            provider="sentry_app",
-            alert_id=self.alert_rule.id,
-            alert_type="metric_alert",
-            external_id=str(self.action.sentry_app_id),
-            notification_uuid="",
+        assert_last_analytics_event(
+            mock_record,
+            AlertSentEvent(
+                organization_id=self.organization.id,
+                project_id=self.project.id,
+                provider="sentry_app",
+                alert_id=str(self.alert_rule.id),
+                alert_type="metric_alert",
+                external_id=str(self.action.sentry_app_id),
+                notification_uuid="",
+            ),
         )
 
         # SLO asserts

--- a/tests/sentry/incidents/action_handlers/test_slack.py
+++ b/tests/sentry/incidents/action_handlers/test_slack.py
@@ -6,6 +6,7 @@ import responses
 from slack_sdk.errors import SlackApiError
 from slack_sdk.web import SlackResponse
 
+from sentry.analytics.events.alert_sent import AlertSentEvent
 from sentry.constants import ObjectStatus
 from sentry.incidents.logic import update_incident_status
 from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
@@ -18,6 +19,7 @@ from sentry.integrations.types import EventLifecycleOutcome
 from sentry.models.options.organization_option import OrganizationOption
 from sentry.notifications.models.notificationmessage import NotificationMessage
 from sentry.testutils.asserts import assert_failure_metric
+from sentry.testutils.helpers.analytics import assert_last_analytics_event
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.helpers.features import apply_feature_flag_on_cls
 from sentry.utils import json
@@ -316,15 +318,17 @@ class SlackActionHandlerTest(FireTest):
             "status": 200,
         }
         self.run_fire_test()
-        mock_record.assert_called_with(
-            "alert.sent",
-            organization_id=self.organization.id,
-            project_id=self.project.id,
-            provider="slack",
-            alert_id=self.alert_rule.id,
-            alert_type="metric_alert",
-            external_id=str(self.action.target_identifier),
-            notification_uuid="",
+        assert_last_analytics_event(
+            mock_record,
+            AlertSentEvent(
+                organization_id=self.organization.id,
+                project_id=self.project.id,
+                provider="slack",
+                alert_id=str(self.alert_rule.id),
+                alert_type="metric_alert",
+                external_id=str(self.action.target_identifier),
+                notification_uuid="",
+            ),
         )
 
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")

--- a/tests/sentry/integrations/msteams/test_notify_action.py
+++ b/tests/sentry/integrations/msteams/test_notify_action.py
@@ -6,11 +6,13 @@ from unittest.mock import patch
 import orjson
 import responses
 
+from sentry.analytics.events.alert_sent import AlertSentEvent
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.msteams import MsTeamsNotifyServiceAction
 from sentry.integrations.types import EventLifecycleOutcome
 from sentry.testutils.asserts import assert_slo_metric
 from sentry.testutils.cases import PerformanceIssueTestCase, RuleTestCase
+from sentry.testutils.helpers.analytics import assert_last_analytics_event
 from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE, TEST_PERF_ISSUE_OCCURRENCE
 from sentry.testutils.silo import assume_test_silo_mode_of
 from sentry.testutils.skips import requires_snuba
@@ -76,15 +78,17 @@ class MsTeamsNotifyActionTest(RuleTestCase, PerformanceIssueTestCase):
         title_card = attachments[0]["content"]["body"][0]
         title_pattern = r"\[%s\](.*)" % event.title
         assert re.match(title_pattern, title_card["text"])
-        mock_record.assert_called_with(
-            "alert.sent",
-            provider="msteams",
-            alert_id="",
-            alert_type="issue_alert",
-            organization_id=self.organization.id,
-            project_id=self.project.id,
-            external_id="nb",
-            notification_uuid=notification_uuid,
+        assert_last_analytics_event(
+            mock_record,
+            AlertSentEvent(
+                provider="msteams",
+                alert_id="",
+                alert_type="issue_alert",
+                organization_id=self.organization.id,
+                project_id=self.project.id,
+                external_id="nb",
+                notification_uuid=notification_uuid,
+            ),
         )
         mock_record.assert_any_call(
             "integrations.msteams.notification_sent",
@@ -132,15 +136,17 @@ class MsTeamsNotifyActionTest(RuleTestCase, PerformanceIssueTestCase):
         title_card = attachments[0]["content"]["body"][0]
         title_pattern = r"\[%s\](.*)" % event.title
         assert re.match(title_pattern, title_card["text"])
-        mock_record.assert_called_with(
-            "alert.sent",
-            provider="msteams",
-            alert_id="",
-            alert_type="issue_alert",
-            organization_id=self.organization.id,
-            project_id=self.project.id,
-            external_id="nb",
-            notification_uuid=notification_uuid,
+        assert_last_analytics_event(
+            mock_record,
+            AlertSentEvent(
+                provider="msteams",
+                alert_id="",
+                alert_type="issue_alert",
+                organization_id=self.organization.id,
+                project_id=self.project.id,
+                external_id="nb",
+                notification_uuid=notification_uuid,
+            ),
         )
         mock_record.assert_any_call(
             "integrations.msteams.notification_sent",
@@ -193,15 +199,17 @@ class MsTeamsNotifyActionTest(RuleTestCase, PerformanceIssueTestCase):
         title_card = attachments[0]["content"]["body"][0]
         title_pattern = r"\[%s\](.*)" % event.title
         assert re.match(title_pattern, title_card["text"])
-        mock_record.assert_called_with(
-            "alert.sent",
-            provider="msteams",
-            alert_id="",
-            alert_type="issue_alert",
-            organization_id=self.organization.id,
-            project_id=self.project.id,
-            external_id="nb",
-            notification_uuid=notification_uuid,
+        assert_last_analytics_event(
+            mock_record,
+            AlertSentEvent(
+                provider="msteams",
+                alert_id="",
+                alert_type="issue_alert",
+                organization_id=self.organization.id,
+                project_id=self.project.id,
+                external_id="nb",
+                notification_uuid=notification_uuid,
+            ),
         )
         mock_record.assert_any_call(
             "integrations.msteams.notification_sent",

--- a/tests/sentry/integrations/opsgenie/test_notify_action.py
+++ b/tests/sentry/integrations/opsgenie/test_notify_action.py
@@ -4,6 +4,7 @@ import orjson
 import pytest
 import responses
 
+from sentry.analytics.events.alert_sent import AlertSentEvent
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.opsgenie.actions import OpsgenieNotifyTeamAction
 from sentry.integrations.types import EventLifecycleOutcome
@@ -11,6 +12,7 @@ from sentry.shared_integrations.exceptions import ApiError
 from sentry.silo.base import SiloMode
 from sentry.testutils.asserts import assert_slo_metric
 from sentry.testutils.cases import PerformanceIssueTestCase, RuleTestCase
+from sentry.testutils.helpers.analytics import assert_last_analytics_event
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
 
@@ -76,15 +78,17 @@ class OpsgenieNotifyTeamTest(RuleTestCase, PerformanceIssueTestCase):
         assert event.group is not None
         assert data["message"] == event.message
         assert data["details"]["Sentry ID"] == str(event.group.id)
-        mock_record.assert_called_with(
-            "alert.sent",
-            provider="opsgenie",
-            alert_id="",
-            alert_type="issue_alert",
-            organization_id=self.organization.id,
-            project_id=self.project.id,
-            external_id=self.team1["id"],
-            notification_uuid=notification_uuid,
+        assert_last_analytics_event(
+            mock_record,
+            AlertSentEvent(
+                provider="opsgenie",
+                alert_id="",
+                alert_type="issue_alert",
+                organization_id=self.organization.id,
+                project_id=self.project.id,
+                external_id=self.team1["id"],
+                notification_uuid=notification_uuid,
+            ),
         )
         mock_record.assert_any_call(
             "integrations.opsgenie.notification_sent",

--- a/tests/sentry/integrations/pagerduty/test_notification.py
+++ b/tests/sentry/integrations/pagerduty/test_notification.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 import orjson
 import responses
 
+from sentry.analytics.events.alert_sent import AlertSentEvent
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.on_call.metrics import OnCallIntegrationsHaltReason
 from sentry.integrations.pagerduty.actions.notification import PagerDutyNotifyServiceAction
@@ -12,6 +13,7 @@ from sentry.integrations.types import EventLifecycleOutcome
 from sentry.silo.base import SiloMode
 from sentry.testutils.asserts import assert_halt_metric, assert_slo_metric
 from sentry.testutils.cases import PerformanceIssueTestCase, RuleTestCase
+from sentry.testutils.helpers.analytics import assert_last_analytics_event
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE
 from sentry.testutils.silo import assume_test_silo_mode
@@ -106,16 +108,17 @@ class PagerDutyNotifyActionTest(RuleTestCase, PerformanceIssueTestCase):
         assert data["links"][0]["href"] == event.group.get_absolute_url(
             params={"referrer": "pagerduty_integration", "notification_uuid": notification_uuid}
         )
-
-        mock_record.assert_called_with(
-            "alert.sent",
-            provider="pagerduty",
-            alert_id=self.project_rule.id,
-            alert_type="issue_alert",
-            organization_id=self.organization.id,
-            project_id=event.project_id,
-            external_id=str(self.service["id"]),
-            notification_uuid=notification_uuid,
+        assert_last_analytics_event(
+            mock_record,
+            AlertSentEvent(
+                provider="pagerduty",
+                alert_id=self.project_rule.id,
+                alert_type="issue_alert",
+                organization_id=self.organization.id,
+                project_id=event.project_id,
+                external_id=str(self.service["id"]),
+                notification_uuid=notification_uuid,
+            ),
         )
         mock_record.assert_any_call(
             "integrations.pagerduty.notification_sent",

--- a/tests/sentry/integrations/slack/test_notify_action.py
+++ b/tests/sentry/integrations/slack/test_notify_action.py
@@ -6,6 +6,7 @@ import responses
 from slack_sdk.errors import SlackApiError
 from slack_sdk.web.slack_response import SlackResponse
 
+from sentry.analytics.events.alert_sent import AlertSentEvent
 from sentry.constants import ObjectStatus
 from sentry.integrations.slack import SlackNotifyServiceAction
 from sentry.integrations.slack.utils.constants import SLACK_RATE_LIMITED_MESSAGE
@@ -13,6 +14,7 @@ from sentry.integrations.types import ExternalProviders
 from sentry.notifications.additional_attachment_manager import manager
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import RuleTestCase
+from sentry.testutils.helpers.analytics import assert_last_analytics_event
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
 from tests.sentry.integrations.slack.test_notifications import (
@@ -366,15 +368,17 @@ class SlackNotifyActionTest(RuleTestCase):
             assert event.title in blocks[0]["elements"][0]["elements"][-1]["text"]
             assert blocks[5]["text"]["text"] == self.organization.slug
             assert blocks[6]["text"]["text"] == self.integration.id
-            mock_record.assert_called_with(
-                "alert.sent",
-                provider="slack",
-                alert_id="",
-                alert_type="issue_alert",
-                organization_id=self.organization.id,
-                project_id=event.project_id,
-                external_id="123",
-                notification_uuid=notification_uuid,
+            assert_last_analytics_event(
+                mock_record,
+                AlertSentEvent(
+                    provider="slack",
+                    alert_id="",
+                    alert_type="issue_alert",
+                    organization_id=self.organization.id,
+                    project_id=event.project_id,
+                    external_id="123",
+                    notification_uuid=notification_uuid,
+                ),
             )
             mock_record.assert_any_call(
                 "integrations.slack.notification_sent",

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -13,6 +13,7 @@ from django.core.mail.message import EmailMultiAlternatives
 from django.db.models import F
 from django.utils import timezone
 
+from sentry.analytics.events.alert_sent import AlertSentEvent
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.userreport import UserReportWithGroupSerializer
 from sentry.digests.notifications import build_digest, event_to_record
@@ -42,6 +43,7 @@ from sentry.plugins.base import Notification
 from sentry.replays.testutils import mock_replay
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import PerformanceIssueTestCase, ReplaysSnubaTestCase, TestCase
+from sentry.testutils.helpers.analytics import assert_last_analytics_event
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import assume_test_silo_mode
@@ -193,15 +195,18 @@ class MailAdapterNotifyTest(BaseMailAdapterTest):
             notification_uuid=ANY,
             alert_id=rule.id,
         )
-        mock_record.assert_called_with(
-            "alert.sent",
-            organization_id=self.organization.id,
-            project_id=self.project.id,
-            provider="email",
-            alert_id=rule.id,
-            alert_type="issue_alert",
-            external_id=ANY,
-            notification_uuid=ANY,
+        assert_last_analytics_event(
+            mock_record,
+            AlertSentEvent(
+                organization_id=self.organization.id,
+                project_id=self.project.id,
+                provider="email",
+                alert_id=str(rule.id),
+                alert_type="issue_alert",
+                external_id="ANY",
+                notification_uuid="ANY",
+            ),
+            exclude_fields=["external_id", "notification_uuid"],
         )
 
     @mock.patch("sentry.mail.notifications.get_context")
@@ -1559,7 +1564,7 @@ class MailAdapterNotifyDigestTest(BaseMailAdapterTest, ReplaysSnubaTestCase):
         )
 
         rule = project.rule_set.all()[0]
-        rule2 = self.create_project_rule(project=project)
+        rule2 = Rule.objects.create(project=project, label="my rule")
         # mute the first rule only for self.user, not user2
         self.snooze_rule(user_id=self.user.id, owner_id=self.user.id, rule=rule)
 
@@ -1608,7 +1613,7 @@ class MailAdapterNotifyDigestTest(BaseMailAdapterTest, ReplaysSnubaTestCase):
         )
 
         rule = project.rule_set.all()[0]
-        rule2 = self.create_project_rule(project=project)
+        rule2 = Rule.objects.create(project=project, label="my rule")
         # mute the rules for self.user, not user2
         self.snooze_rule(user_id=self.user.id, owner_id=self.user.id, rule=rule)
         self.snooze_rule(user_id=self.user.id, owner_id=self.user.id, rule=rule2)
@@ -1651,7 +1656,7 @@ class MailAdapterNotifyDigestTest(BaseMailAdapterTest, ReplaysSnubaTestCase):
         )
 
         rule = project.rule_set.all()[0]
-        rule2 = self.create_project_rule(project=project)
+        rule2 = Rule.objects.create(project=project, label="my rule")
         # mute the first rule for self.user, not user2
         self.snooze_rule(user_id=self.user.id, owner_id=self.user.id, rule=rule)
         # mute the 2nd rule for both

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -1564,8 +1564,9 @@ class MailAdapterNotifyDigestTest(BaseMailAdapterTest, ReplaysSnubaTestCase):
         )
 
         rule = project.rule_set.all()[0]
-        rule2 = Rule.objects.create(project=project, label="my rule")
-        # mute the first rule only for self.user, not user2
+        rule2 = self.create_project_rule(
+            project=project
+        )  # mute the first rule only for self.user, not user2
         self.snooze_rule(user_id=self.user.id, owner_id=self.user.id, rule=rule)
 
         ProjectOwnership.objects.create(project_id=project.id, fallthrough=True)
@@ -1613,7 +1614,7 @@ class MailAdapterNotifyDigestTest(BaseMailAdapterTest, ReplaysSnubaTestCase):
         )
 
         rule = project.rule_set.all()[0]
-        rule2 = Rule.objects.create(project=project, label="my rule")
+        rule2 = self.create_project_rule(project=project)
         # mute the rules for self.user, not user2
         self.snooze_rule(user_id=self.user.id, owner_id=self.user.id, rule=rule)
         self.snooze_rule(user_id=self.user.id, owner_id=self.user.id, rule=rule2)
@@ -1656,7 +1657,7 @@ class MailAdapterNotifyDigestTest(BaseMailAdapterTest, ReplaysSnubaTestCase):
         )
 
         rule = project.rule_set.all()[0]
-        rule2 = Rule.objects.create(project=project, label="my rule")
+        rule2 = self.create_project_rule(project=project)
         # mute the first rule for self.user, not user2
         self.snooze_rule(user_id=self.user.id, owner_id=self.user.id, rule=rule)
         # mute the 2nd rule for both

--- a/tests/sentry/notifications/notifications/test_digests.py
+++ b/tests/sentry/notifications/notifications/test_digests.py
@@ -7,12 +7,15 @@ from django.core import mail
 from django.core.mail.message import EmailMultiAlternatives
 
 import sentry
+from sentry.analytics.events.alert_sent import AlertSentEvent
 from sentry.digests.backends.base import Backend
 from sentry.digests.backends.redis import RedisBackend
 from sentry.digests.notifications import event_to_record
 from sentry.models.projectownership import ProjectOwnership
+from sentry.models.rule import Rule
 from sentry.tasks.digests import deliver_digest
 from sentry.testutils.cases import PerformanceIssueTestCase, SlackActivityNotificationTest, TestCase
+from sentry.testutils.helpers.analytics import assert_last_analytics_event
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.skips import requires_snuba
 from tests.sentry.issues.test_utils import OccurrenceTestMixin
@@ -78,7 +81,7 @@ class DigestNotificationTest(TestCase, OccurrenceTestMixin, PerformanceIssueTest
 
     def setUp(self):
         super().setUp()
-        self.rule = self.create_project_rule(project=self.project)
+        self.rule = Rule.objects.create(project=self.project, label="Test Rule", data={})
         self.key = f"mail:p:{self.project.id}:IssueOwners::AllMembers"
         ProjectOwnership.objects.create(project_id=self.project.id, fallthrough=True)
         for i in range(USER_COUNT - 1):
@@ -117,15 +120,18 @@ class DigestNotificationTest(TestCase, OccurrenceTestMixin, PerformanceIssueTest
             group_id=None,
             user_id=ANY,
         )
-        mock_record.assert_called_with(
-            "alert.sent",
-            organization_id=self.organization.id,
-            project_id=self.project.id,
-            provider="email",
-            alert_id=self.rule.id,
-            alert_type="issue_alert",
-            external_id=ANY,
-            notification_uuid=ANY,
+        assert_last_analytics_event(
+            mock_record,
+            AlertSentEvent(
+                organization_id=self.organization.id,
+                project_id=self.project.id,
+                provider="email",
+                alert_id=str(self.rule.id),
+                alert_type="issue_alert",
+                external_id="ANY",
+                notification_uuid="ANY",
+            ),
+            exclude_fields=["external_id", "notification_uuid"],
         )
         mock_logger.info.assert_called_with(
             "mail.adapter.notify_digest",
@@ -168,7 +174,7 @@ class DigestSlackNotification(SlackActivityNotificationTest):
         timestamp_secs = int(timestamp_raw.timestamp())
         timestamp = timestamp_raw.isoformat()
         key = f"slack:p:{self.project.id}:IssueOwners::AllMembers"
-        rule = self.create_project_rule(project=self.project)
+        rule = Rule.objects.create(project=self.project, label="my rule")
         event1 = self.store_event(
             data={
                 "timestamp": timestamp,

--- a/tests/sentry/notifications/notifications/test_digests.py
+++ b/tests/sentry/notifications/notifications/test_digests.py
@@ -12,7 +12,6 @@ from sentry.digests.backends.base import Backend
 from sentry.digests.backends.redis import RedisBackend
 from sentry.digests.notifications import event_to_record
 from sentry.models.projectownership import ProjectOwnership
-from sentry.models.rule import Rule
 from sentry.tasks.digests import deliver_digest
 from sentry.testutils.cases import PerformanceIssueTestCase, SlackActivityNotificationTest, TestCase
 from sentry.testutils.helpers.analytics import assert_last_analytics_event
@@ -81,7 +80,7 @@ class DigestNotificationTest(TestCase, OccurrenceTestMixin, PerformanceIssueTest
 
     def setUp(self):
         super().setUp()
-        self.rule = Rule.objects.create(project=self.project, label="Test Rule", data={})
+        self.rule = self.create_project_rule(project=self.project)
         self.key = f"mail:p:{self.project.id}:IssueOwners::AllMembers"
         ProjectOwnership.objects.create(project_id=self.project.id, fallthrough=True)
         for i in range(USER_COUNT - 1):
@@ -174,7 +173,7 @@ class DigestSlackNotification(SlackActivityNotificationTest):
         timestamp_secs = int(timestamp_raw.timestamp())
         timestamp = timestamp_raw.isoformat()
         key = f"slack:p:{self.project.id}:IssueOwners::AllMembers"
-        rule = Rule.objects.create(project=self.project, label="my rule")
+        rule = self.create_project_rule(project=self.project)
         event1 = self.store_event(
             data={
                 "timestamp": timestamp,


### PR DESCRIPTION
- This is part of https://github.com/getsentry/sentry/pull/95210 which I decided to split up to reduce splash radius in case something goes wrong and to make it easier to review in chunks
- Transform event classes to use @analytics.eventclass decorator
- Transform analytics.record calls to use event class instances
- Update imports as needed
Contributes to TET-830