### PR TITLE
feat(onboarding): Add `isLogsSelected` flag

### DIFF
--- a/static/app/components/events/featureFlags/onboarding/featureFlagOnboardingLayout.tsx
+++ b/static/app/components/events/featureFlags/onboarding/featureFlagOnboardingLayout.tsx
@@ -48,6 +48,7 @@ export function FeatureFlagOnboardingLayout({
       platformKey,
       projectId,
       projectSlug,
+      isLogsSelected: false,
       isFeedbackSelected: false,
       isPerformanceSelected: false,
       isProfilingSelected: false,

--- a/static/app/components/feedback/feedbackOnboarding/feedbackOnboardingLayout.tsx
+++ b/static/app/components/feedback/feedbackOnboarding/feedbackOnboardingLayout.tsx
@@ -47,6 +47,7 @@ export function FeedbackOnboardingLayout({
       platformKey,
       projectId,
       projectSlug,
+      isLogsSelected: false,
       isFeedbackSelected: true,
       isPerformanceSelected: false,
       isProfilingSelected: false,

--- a/static/app/components/onboarding/gettingStartedDoc/onboardingLayout.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/onboardingLayout.tsx
@@ -85,6 +85,7 @@ export function OnboardingLayout({
       platformKey,
       projectId,
       projectSlug,
+      isLogsSelected: false,
       isFeedbackSelected: false,
       isPerformanceSelected: activeProductSelection.includes(
         ProductSolution.PERFORMANCE_MONITORING

--- a/static/app/components/onboarding/gettingStartedDoc/types.ts
+++ b/static/app/components/onboarding/gettingStartedDoc/types.ts
@@ -152,6 +152,7 @@ export interface DocsParams<
   api: Client;
   dsn: ProjectKey['dsn'];
   isFeedbackSelected: boolean;
+  isLogsSelected: boolean;
   isPerformanceSelected: boolean;
   isProfilingSelected: boolean;
   isReplaySelected: boolean;

--- a/static/app/components/performanceOnboarding/sidebar.tsx
+++ b/static/app/components/performanceOnboarding/sidebar.tsx
@@ -335,6 +335,7 @@ function OnboardingContent({currentProject}: {currentProject: Project}) {
     projectId: currentProject.id,
     projectSlug: currentProject.slug,
     isFeedbackSelected: false,
+    isLogsSelected: false,
     isPerformanceSelected: true,
     isProfilingSelected: false,
     isReplaySelected: false,

--- a/static/app/components/profiling/profilingOnboardingSidebar.tsx
+++ b/static/app/components/profiling/profilingOnboardingSidebar.tsx
@@ -349,6 +349,7 @@ function ProfilingOnboardingContent(props: ProfilingOnboardingContentProps) {
     platformKey: props.platform.id,
     projectId: props.projectId,
     projectSlug: props.projectSlug,
+    isLogsSelected: false,
     isFeedbackSelected: false,
     isPerformanceSelected: true,
     isProfilingSelected: true,

--- a/static/app/components/replaysOnboarding/replayOnboardingLayout.tsx
+++ b/static/app/components/replaysOnboarding/replayOnboardingLayout.tsx
@@ -46,6 +46,7 @@ export function ReplayOnboardingLayout({
       platformKey,
       projectId,
       projectSlug,
+      isLogsSelected: false,
       isFeedbackSelected: false,
       isPerformanceSelected: false,
       isProfilingSelected: false,

--- a/static/app/components/updatedEmptyState.tsx
+++ b/static/app/components/updatedEmptyState.tsx
@@ -124,6 +124,7 @@ export default function UpdatedEmptyState({project}: {project?: Project}) {
     platformKey: currentPlatformKey,
     projectId: project.id,
     projectSlug: project.slug,
+    isLogsSelected: false,
     isFeedbackSelected: false,
     isPerformanceSelected: false,
     isProfilingSelected: false,

--- a/static/app/views/insights/agentMonitoring/views/onboarding.tsx
+++ b/static/app/views/insights/agentMonitoring/views/onboarding.tsx
@@ -306,6 +306,7 @@ export function Onboarding() {
     platformKey: project.platform || 'other',
     projectId: project.id,
     projectSlug: project.slug,
+    isLogsSelected: false,
     isFeedbackSelected: false,
     isPerformanceSelected: true,
     isProfilingSelected: false,

--- a/static/app/views/performance/onboarding.tsx
+++ b/static/app/views/performance/onboarding.tsx
@@ -585,6 +585,7 @@ export function Onboarding({organization, project}: OnboardingProps) {
     platformKey: project.platform || 'other',
     projectId: project.id,
     projectSlug: project.slug,
+    isLogsSelected: false,
     isFeedbackSelected: false,
     isPerformanceSelected: true,
     isProfilingSelected: false,

--- a/static/app/views/profiling/onboarding.tsx
+++ b/static/app/views/profiling/onboarding.tsx
@@ -298,6 +298,7 @@ export function Onboarding() {
     platformKey: project.platform || 'other',
     projectId: project.id,
     projectSlug: project.slug,
+    isLogsSelected: false,
     isFeedbackSelected: false,
     isPerformanceSelected: true,
     isProfilingSelected: true,


### PR DESCRIPTION
resolves https://linear.app/getsentry/issue/LOGS-230/update-frontend-to-rely-on-islogsselected-option

Once this is added, we can start adding logs onboarding to every SDK.