### PR TITLE
feat(onboarding): Add logs to react onboarding

### DIFF
--- a/static/app/components/onboarding/gettingStartedDoc/onboardingLayout.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/onboardingLayout.tsx
@@ -85,7 +85,7 @@ export function OnboardingLayout({
       platformKey,
       projectId,
       projectSlug,
-      isLogsSelected: false,
+      isLogsSelected: activeProductSelection.includes(ProductSolution.LOGS),
       isFeedbackSelected: false,
       isPerformanceSelected: activeProductSelection.includes(
         ProductSolution.PERFORMANCE_MONITORING

--- a/static/app/components/onboarding/gettingStartedDoc/types.ts
+++ b/static/app/components/onboarding/gettingStartedDoc/types.ts
@@ -144,6 +144,7 @@ export enum ProductSolution {
   PERFORMANCE_MONITORING = 'performance-monitoring',
   SESSION_REPLAY = 'session-replay',
   PROFILING = 'profiling',
+  LOGS = 'logs',
 }
 
 export interface DocsParams<

--- a/static/app/components/onboarding/productSelection.tsx
+++ b/static/app/components/onboarding/productSelection.tsx
@@ -31,6 +31,7 @@ function getDisabledProducts(organization: Organization): DisabledProducts {
   const hasSessionReplay = organization.features.includes('session-replay');
   const hasPerformance = organization.features.includes('performance-view');
   const hasProfiling = organization.features.includes('profiling-view');
+  const hasLogs = organization.features.includes('ourlogs-enabled');
   const isSelfHostedErrorsOnly = ConfigStore.get('isSelfHostedErrorsOnly');
 
   let reason = t('This feature is not enabled on your Sentry installation.');
@@ -66,6 +67,12 @@ function getDisabledProducts(organization: Organization): DisabledProducts {
     disabledProducts[ProductSolution.PROFILING] = {
       reason,
       onClick: createClickHandler('organizations:profiling-view', 'Profiling'),
+    };
+  }
+  if (!hasLogs) {
+    disabledProducts[ProductSolution.LOGS] = {
+      reason,
+      onClick: createClickHandler('organizations:ourlogs-enabled', 'Logs'),
     };
   }
   return disabledProducts;
@@ -122,6 +129,7 @@ export const platformProductAvailability = {
   'javascript-react': [
     ProductSolution.PERFORMANCE_MONITORING,
     ProductSolution.SESSION_REPLAY,
+    ProductSolution.LOGS,
   ],
   'javascript-react-router': [
     ProductSolution.PERFORMANCE_MONITORING,
@@ -430,6 +438,18 @@ export function ProductSelection({
           onClick={() => handleClickProduct(ProductSolution.SESSION_REPLAY)}
           disabled={disabledProducts[ProductSolution.SESSION_REPLAY]}
           checked={urlProducts.includes(ProductSolution.SESSION_REPLAY)}
+        />
+      )}
+      {products.includes(ProductSolution.LOGS) && (
+        <Product
+          label={t('Logs')}
+          description={t(
+            'Structured application logs for debugging and troubleshooting. Automatically gets associated with errors and traces.'
+          )}
+          docLink="https://docs.sentry.io/product/explore/logs/"
+          onClick={() => handleClickProduct(ProductSolution.LOGS)}
+          disabled={disabledProducts[ProductSolution.LOGS]}
+          checked={urlProducts.includes(ProductSolution.LOGS)}
         />
       )}
     </Products>

--- a/static/app/gettingStartedDocs/javascript/react.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript/react.spec.tsx
@@ -85,4 +85,37 @@ describe('javascript-react onboarding docs', function () {
       screen.getByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
     ).toBeInTheDocument();
   });
+
+  it('enables logs by setting enableLogs to true', () => {
+    renderWithOnboardingLayout(docs, {
+      selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.LOGS],
+    });
+
+    expect(
+      screen.getByText(textWithMarkupMatcher(/enableLogs: true/))
+    ).toBeInTheDocument();
+  });
+
+  it('shows Logging Integrations in next steps when logs is selected', () => {
+    renderWithOnboardingLayout(docs, {
+      selectedProducts: [
+        ProductSolution.ERROR_MONITORING,
+        ProductSolution.PERFORMANCE_MONITORING,
+        ProductSolution.LOGS,
+      ],
+    });
+
+    expect(screen.getByText('Logging Integrations')).toBeInTheDocument();
+  });
+
+  it('does not show Logging Integrations in next steps when logs is not selected', () => {
+    renderWithOnboardingLayout(docs, {
+      selectedProducts: [
+        ProductSolution.ERROR_MONITORING,
+        ProductSolution.PERFORMANCE_MONITORING,
+      ],
+    });
+
+    expect(screen.queryByText('Logging Integrations')).not.toBeInTheDocument();
+  });
 });

--- a/static/app/gettingStartedDocs/javascript/react.tsx
+++ b/static/app/gettingStartedDocs/javascript/react.tsx
@@ -50,6 +50,12 @@ const getDynamicParts = (params: Params): string[] => {
       replaysOnErrorSampleRate: 1.0 // If you're not already sampling the entire session, change the sample rate to 100% when sampling sessions where errors occur.`);
   }
 
+  if (params.isLogsSelected) {
+    dynamicParts.push(`
+      // Logs
+      enableLogs: true`);
+  }
+
   if (params.isProfilingSelected) {
     dynamicParts.push(`
         // Set profilesSampleRate to 1.0 to profile every transaction.
@@ -345,22 +351,39 @@ logger.fatal("Database connection pool exhausted", {
       ],
     },
   ],
-  nextSteps: () => [
-    {
-      id: 'react-features',
-      name: t('React Features'),
-      description: t('Learn about our first class integration with the React framework.'),
-      link: 'https://docs.sentry.io/platforms/javascript/guides/react/features/',
-    },
-    {
-      id: 'react-router',
-      name: t('React Router'),
-      description: t(
-        'Configure routing, so Sentry can generate parameterized transaction names for a better overview on the Performance page.'
-      ),
-      link: 'https://docs.sentry.io/platforms/javascript/guides/react/configuration/integrations/react-router/',
-    },
-  ],
+  nextSteps: (params: Params) => {
+    const steps = [
+      {
+        id: 'react-features',
+        name: t('React Features'),
+        description: t(
+          'Learn about our first class integration with the React framework.'
+        ),
+        link: 'https://docs.sentry.io/platforms/javascript/guides/react/features/',
+      },
+      {
+        id: 'react-router',
+        name: t('React Router'),
+        description: t(
+          'Configure routing, so Sentry can generate parameterized transaction names for a better overview on the Performance page.'
+        ),
+        link: 'https://docs.sentry.io/platforms/javascript/guides/react/configuration/integrations/react-router/',
+      },
+    ];
+
+    if (params.isLogsSelected) {
+      steps.push({
+        id: 'logs',
+        name: t('Logging Integrations'),
+        description: t(
+          'Add logging integrations to automatically capture logs from your application.'
+        ),
+        link: 'https://docs.sentry.io/platforms/javascript/guides/react/logs/#integrations/',
+      });
+    }
+
+    return steps;
+  },
 };
 
 const replayOnboarding: OnboardingConfig = {

--- a/static/app/gettingStartedDocs/javascript/react.tsx
+++ b/static/app/gettingStartedDocs/javascript/react.tsx
@@ -272,7 +272,7 @@ async function fetchUserData(userId) {
 # Logs
 
 Where logs are used, ensure Sentry is imported using \`import * as Sentry from "@sentry/react"\`
-Enable logging in Sentry using \`Sentry.init({ _experiments: { enableLogs: true } })\`
+Enable logging in Sentry using \`Sentry.init({ enableLogs: true })\`
 Reference the logger using \`const { logger } = Sentry\`
 Sentry offers a consoleLoggingIntegration that can be used to log specific console error types automatically without instrumenting the individual logger calls
 
@@ -286,9 +286,7 @@ import * as Sentry from "@sentry/react";
 Sentry.init({
   dsn: "${params.dsn.public}",
 
-  _experiments: {
-    enableLogs: true,
-  },
+  enableLogs: true,
 });
 \`\`\`
 


### PR DESCRIPTION
resolves https://linear.app/getsentry/issue/LOGS-231/add-logs-to-react-onboarding

Building off of https://github.com/getsentry/sentry/pull/96409, we update the react onboarding to add logs to the onboarding snippet. We also link docs to logging integrations that people can automatically configure.

<img width="1164" height="1193" alt="image" src="https://github.com/user-attachments/assets/553b6c17-7ee4-401f-8e9e-1c54c8901080" />
