### PR TITLE
feat(gaming-tab): edit onboarding copy for consoles

### DIFF
--- a/static/app/components/onboarding/consoleModal.tsx
+++ b/static/app/components/onboarding/consoleModal.tsx
@@ -70,24 +70,14 @@ const consoleConfig = {
   xbox: (
     <Fragment>
       <p>
+        {t('Sentry supports Xbox Series X and S, devkits as well as retail devices.')}
+      </p>
+      <p>
         {tct(
           'You can get started with Sentry by [microsoftGameDevelopmentKitLink: requesting access to the Microsoft Game Development Kit (GDK) Middleware]. We will get back to you with the next steps as soon as we receive your request.',
           {
             microsoftGameDevelopmentKitLink: (
               <ExternalLink href="https://developer.microsoft.com/en-us/games/support/request-gdkx-middleware" />
-            ),
-          }
-        )}
-      </p>
-      <p>
-        {tct(
-          "Sentry supports Xbox Series X and S, devkits as well as retail devices. You can also use Sentry's [unityLink:Unity] and [unrealLink:Unreal Engine] SDKs with Xbox.",
-          {
-            unityLink: (
-              <ExternalLink href="https://docs.sentry.io/platforms/unity/game-consoles/" />
-            ),
-            unrealLink: (
-              <ExternalLink href="https://docs.sentry.io/platforms/unreal/game-consoles/" />
             ),
           }
         )}

--- a/static/app/components/onboarding/consoleModal.tsx
+++ b/static/app/components/onboarding/consoleModal.tsx
@@ -70,7 +70,7 @@ const consoleConfig = {
   xbox: (
     <Fragment>
       <p>
-        {t('Sentry supports Xbox Series X and S, devkits as well as retail devices.')}
+        {t('Sentry supports Xbox One and Series X|S, devkits as well as retail devices.')}
       </p>
       <p>
         {tct(

--- a/static/app/components/onboarding/consoleModal.tsx
+++ b/static/app/components/onboarding/consoleModal.tsx
@@ -3,9 +3,9 @@ import {css} from '@emotion/react';
 import {PlatformIcon} from 'platformicons';
 
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
-import {Alert} from 'sentry/components/core/alert';
 import {Button} from 'sentry/components/core/button';
 import {Flex} from 'sentry/components/core/layout';
+import {Heading} from 'sentry/components/core/text';
 import ExternalLink from 'sentry/components/links/externalLink';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -20,13 +20,8 @@ const consoleConfig = {
         )}
       </p>
       <p>
-        {t(
-          'Configuration can be done in your Sentry project settings, on a new page called PlayStation that is made available to you once the middleware verification process is done.'
-        )}
-      </p>
-      <p>
         {tct(
-          "The verification process starts inside the [partnersWebsiteLink:PlayStation Partners website] where you can confirm your developer status by clicking on [italic:Confirm status]. We'll receive your request and get back to you with the next steps.",
+          "Please complete the verification process on the [partnersWebsiteLink:PlayStation Partners website] and confirm your developer status by clicking on [italic:Confirm status]. We'll receive your request and get back to you with the next steps.",
           {
             partnersWebsiteLink: (
               <ExternalLink href="https://game.develop.playstation.net/tm/verify/functionalsw" />
@@ -35,36 +30,13 @@ const consoleConfig = {
           }
         )}
       </p>
-      <p>
-        {tct(
-          "Even though crash dump collection doesn't require a Sentry SDK, if you add it, you can get additional context in your crash dumps, as well as capture non-fatal events. Sentry offers SDK support specifically for PlayStation so you can add context such as [breadcrumbsLink:breadcrumbs] and [tagsLink:tags].",
-          {
-            breadcrumbsLink: (
-              <ExternalLink href="https://docs.sentry.io/product/issues/issue-details/breadcrumbs/" />
-            ),
-            tagsLink: (
-              <ExternalLink href="https://docs.sentry.io/product/issues/issue-details/#tags" />
-            ),
-          }
-        )}
-      </p>
-      <Alert type="info">
-        {t(
-          'PlayStation support is exclusive to our SaaS offering, as it depends on confidential components that cannot be distributed for self-hosted use.'
-        )}
-      </Alert>
     </Fragment>
   ),
   'nintendo-switch': (
     <Fragment>
       <p>
-        {t(
-          'You can get started using Sentry on Nintendo Switch without any changes to your game, on devkits as well as retail devices.'
-        )}
-      </p>
-      <p>
         {tct(
-          "It can be done directly on Nintendo's CRPORTAL. The two environments available are [lp1Link:lp1 for retail devices] and [dd1Link:dd1 for devkits]. In both cases you can configure Nintendo's servers to start forwarding your crashes directly to Sentry.It can be done directly on Nintendo's CRPORTAL. The two environments available are lp1 for retail devices and dd1 for devkits. In both cases you can configure Nintendo's servers to start forwarding your crashes directly to Sentry.",
+          "You can get started using Sentry on Nintendo Switch without any changes to your game, on devkits as well as retail devices. You can configure Nintendo's CRPORTAL to forward crashes to Sentry using [lp1Link:lp1 for retail devices] or [dd1Link:dd1 for devkits].",
           {
             lp1Link: (
               <ExternalLink href="https://crash-report.wc.lp1.er.srv.nintendo.net/sentry/get_started" />
@@ -75,9 +47,10 @@ const consoleConfig = {
           }
         )}
       </p>
+      <Heading as="h4">Nintendo Switch SDK</Heading>
       <p>
         {tct(
-          'If you want to add additional context to your crash dumps, or you want to capture non-fatal events, Sentry offers an SDK specifically for Nintendo Switch. It allows for adding additional context such as [breadcrumbsLink:breadcrumbs] and [tagsLink:tags]. To get access to the SDK, please reach out via the [nintendoDeveloperAuthorizationFormLink:Nintendo Developer Authorization form].',
+          'To add more context to your crash dumps or capture non-fatal events, Sentry provides a dedicated SDK for Nintendo Switch. With this SDK, you can include details like [breadcrumbsLink:breadcrumbs] and [tagsLink:tags]. To request access, please use the [nintendoDeveloperAuthorizationFormLink:Nintendo Developer Authorization form].',
           {
             nintendoDeveloperAuthorizationFormLink: (
               <ExternalLink href="https://developer.nintendo.com/group/development/getting-started/g1kr9vj6/middleware/sentry" />
@@ -91,14 +64,14 @@ const consoleConfig = {
           }
         )}
       </p>
-      <p>{t('Support for Switch 2 as well as the original Switch is available.')}</p>
+      <p>{t('Sentry supports both the original Switch and Switch 2.')}</p>
     </Fragment>
   ),
   xbox: (
     <Fragment>
       <p>
         {tct(
-          "You can get started using Sentry by [microsoftGameDevelopmentKitLink: requesting Microsoft Game Development Kit (GDK) Middleware access]. We'll receive your request and get back to you with the next steps.",
+          'You can get started with Sentry by [microsoftGameDevelopmentKitLink: requesting access to the Microsoft Game Development Kit (GDK) Middleware]. We will get back to you with the next steps as soon as we receive your request.',
           {
             microsoftGameDevelopmentKitLink: (
               <ExternalLink href="https://developer.microsoft.com/en-us/games/support/request-gdkx-middleware" />
@@ -107,13 +80,8 @@ const consoleConfig = {
         )}
       </p>
       <p>
-        {t(
-          'Support is available on Xbox Series X and S, by adding the Sentry SDK to your game. Crash collection as well as non-fatal events can be captured, on devkits as well as retail devices.'
-        )}
-      </p>
-      <p>
         {tct(
-          "You can also use Sentry's [unityLink:Unity] and [unrealLink:Unreal Engine] SDKs with Xbox.",
+          "Sentry supports Xbox Series X and S, devkits as well as retail devices. You can also use Sentry's [unityLink:Unity] and [unrealLink:Unreal Engine] SDKs with Xbox.",
           {
             unityLink: (
               <ExternalLink href="https://docs.sentry.io/platforms/unity/game-consoles/" />
@@ -151,7 +119,7 @@ export function ConsoleModal({
       <Header closeButton>
         <Flex align="center" gap={space(2)}>
           <PlatformIcon size={32} format="lg" platform={selectedPlatform.key} />
-          <h4>{t('Request Access for %s', selectedPlatform.name)}</h4>
+          <Heading as="h5">{t('Request Access for %s', selectedPlatform.name)}</Heading>
         </Flex>
       </Header>
       <Body>{config}</Body>
@@ -165,6 +133,6 @@ export function ConsoleModal({
 }
 
 export const modalCss = css`
-  max-width: 500px;
+  max-width: 600px;
   width: 100%;
 `;


### PR DESCRIPTION
- Simplify the onboarding instructions to only include necessary information
- Remove banner that points out the feature is only available on SaaS
- Increase modal width from 500->600px so the title does not break for Nintendo Switch

| Platform        | Before | After |
|-----------------|--------|-------|
| Xbox            |<img width="499" height="416" alt="image" src="https://github.com/user-attachments/assets/f32a0537-70c3-431c-a5c8-76862d470a5b" />|<img width="602" height="306" alt="image" src="https://github.com/user-attachments/assets/53ce53fd-89f2-4e15-84e9-ee8f0121cad7" />|
| PlayStation     |<img width="482" height="661" alt="image" src="https://github.com/user-attachments/assets/8d1fb276-9d1b-4a45-96e6-bed9b6fcc421" />|<img width="590" height="331" alt="image" src="https://github.com/user-attachments/assets/53c77ec8-6d12-4f06-915a-3a6385872795" />|
| Nintendo Switch |<img width="493" height="616" alt="image" src="https://github.com/user-attachments/assets/5bea7120-fd7c-4433-8d49-6dde80456e0e" />|<img width="592" height="442" alt="image" src="https://github.com/user-attachments/assets/8034cd3d-f694-431c-9744-c4c2431ac1e3" />|
