### PR TITLE
feat(onboarding): Add logs to angular onboarding snippets

### DIFF
--- a/static/app/components/onboarding/productSelection.tsx
+++ b/static/app/components/onboarding/productSelection.tsx
@@ -142,6 +142,7 @@ export const platformProductAvailability = {
   'javascript-angular': [
     ProductSolution.PERFORMANCE_MONITORING,
     ProductSolution.SESSION_REPLAY,
+    ProductSolution.LOGS,
   ],
   'javascript-ember': [
     ProductSolution.PERFORMANCE_MONITORING,

--- a/static/app/gettingStartedDocs/javascript/angular.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript/angular.spec.tsx
@@ -99,4 +99,46 @@ describe('javascript-angular onboarding docs', function () {
       screen.getByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
     ).toBeInTheDocument();
   });
+
+  it('enables logs by setting enableLogs to true', () => {
+    renderWithOnboardingLayout(docs, {
+      selectedOptions: {
+        configType: AngularConfigType.APP,
+      },
+      selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.LOGS],
+    });
+
+    expect(
+      screen.getByText(textWithMarkupMatcher(/enableLogs: true/))
+    ).toBeInTheDocument();
+  });
+
+  it('shows Logging Integrations in next steps when logs is selected', () => {
+    renderWithOnboardingLayout(docs, {
+      selectedOptions: {
+        configType: AngularConfigType.APP,
+      },
+      selectedProducts: [
+        ProductSolution.ERROR_MONITORING,
+        ProductSolution.PERFORMANCE_MONITORING,
+        ProductSolution.LOGS,
+      ],
+    });
+
+    expect(screen.getByText('Logging Integrations')).toBeInTheDocument();
+  });
+
+  it('does not show Logging Integrations in next steps when logs is not selected', () => {
+    renderWithOnboardingLayout(docs, {
+      selectedOptions: {
+        configType: AngularConfigType.APP,
+      },
+      selectedProducts: [
+        ProductSolution.ERROR_MONITORING,
+        ProductSolution.PERFORMANCE_MONITORING,
+      ],
+    });
+
+    expect(screen.queryByText('Logging Integrations')).not.toBeInTheDocument();
+  });
 });

--- a/static/app/gettingStartedDocs/javascript/angular.tsx
+++ b/static/app/gettingStartedDocs/javascript/angular.tsx
@@ -102,6 +102,12 @@ const getDynamicParts = (params: Params): string[] => {
       replaysOnErrorSampleRate: 1.0 // If you're not already sampling the entire session, change the sample rate to 100% when sampling sessions where errors occur.`);
   }
 
+  if (params.isLogsSelected) {
+    dynamicParts.push(`
+      // Logs
+      enableLogs: true`);
+  }
+
   if (params.isProfilingSelected) {
     dynamicParts.push(`
         // Set profilesSampleRate to 1.0 to profile every transaction.
@@ -374,16 +380,31 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
       ],
     },
   ],
-  nextSteps: () => [
-    {
-      id: 'angular-features',
-      name: t('Angular Features'),
-      description: t(
-        'Learn about our first class integration with the Angular framework.'
-      ),
-      link: 'https://docs.sentry.io/platforms/javascript/guides/angular/features/',
-    },
-  ],
+  nextSteps: (params: Params) => {
+    const steps = [
+      {
+        id: 'angular-features',
+        name: t('Angular Features'),
+        description: t(
+          'Learn about our first class integration with the Angular framework.'
+        ),
+        link: 'https://docs.sentry.io/platforms/javascript/guides/angular/features/',
+      },
+    ];
+
+    if (params.isLogsSelected) {
+      steps.push({
+        id: 'logs',
+        name: t('Logging Integrations'),
+        description: t(
+          'Add logging integrations to automatically capture logs from your application.'
+        ),
+        link: 'https://docs.sentry.io/platforms/javascript/guides/angular/logs/#integrations/',
+      });
+    }
+
+    return steps;
+  },
 };
 
 const replayOnboarding: OnboardingConfig<PlatformOptions> = {


### PR DESCRIPTION
resolves https://linear.app/getsentry/issue/LOGS-232/add-logs-to-angular-onboarding

This PR adds support for the Logs product to the Angular onboarding flow.

- When the Logs product is selected, the generated code snippet now includes `enableLogs: true`.
- The "Next Steps" section conditionally displays a link to "Logging Integrations" documentation.
- New tests have been added to `angular.spec.tsx` to verify this functionality, mirroring the existing React onboarding for Logs.