### PR TITLE
fix(ui2): retain chonk when inputs / selects get focused

### DIFF
--- a/static/app/components/core/button/styles.chonk.tsx
+++ b/static/app/components/core/button/styles.chonk.tsx
@@ -198,7 +198,7 @@ export function DO_NOT_USE_getChonkButtonStyles(
       },
 
       '&:focus-visible': {
-        ...p.theme.focusRing,
+        ...p.theme.focusRing(),
       },
 
       '> span:last-child': {

--- a/static/app/components/core/checkbox/index.chonk.tsx
+++ b/static/app/components/core/checkbox/index.chonk.tsx
@@ -21,7 +21,7 @@ export const ChonkNativeHiddenCheckbox = chonkStyled('input')`
   }
 
   &:focus-visible + * {
-    ${p => p.theme.focusRing};
+    ${p => p.theme.focusRing()};
   }
 
   &:disabled + *,

--- a/static/app/components/core/input/index.chonk.tsx
+++ b/static/app/components/core/input/index.chonk.tsx
@@ -8,48 +8,52 @@ export const chonkInputStyles = ({
   monospace,
   readOnly,
   size = 'md',
-}: InputStylesProps & {theme: DO_NOT_USE_ChonkTheme}): StrictCSSObject => ({
-  display: 'block',
-  width: '100%',
-  color: theme.tokens.content.primary,
-  background: theme.tokens.background.secondary,
-  boxShadow: `0px 2px 0px 0px ${theme.tokens.border.primary} inset`,
-  border: `1px solid ${theme.tokens.border.primary}`,
-  fontWeight: theme.fontWeight.normal,
-  resize: 'vertical',
-  transition: 'border 0.1s, box-shadow 0.1s',
-  ...(monospace ? {fontFamily: theme.text.familyMono} : {}),
-  ...(readOnly ? {cursor: 'default'} : {}),
+}: InputStylesProps & {theme: DO_NOT_USE_ChonkTheme}): StrictCSSObject => {
+  const boxShadow = `0px 2px 0px 0px ${theme.tokens.border.primary} inset`;
 
-  ...theme.form[size],
-  ...theme.formPadding[size],
-  ...theme.formRadius[size],
+  return {
+    display: 'block',
+    width: '100%',
+    color: theme.tokens.content.primary,
+    background: theme.tokens.background.secondary,
+    boxShadow,
+    border: `1px solid ${theme.tokens.border.primary}`,
+    fontWeight: theme.fontWeight.normal,
+    resize: 'vertical',
+    transition: 'border 0.1s, box-shadow 0.1s',
+    ...(monospace ? {fontFamily: theme.text.familyMono} : {}),
+    ...(readOnly ? {cursor: 'default'} : {}),
 
-  '&::placeholder': {
-    color: theme.tokens.content.muted,
-    opacity: 1,
-  },
-
-  "&[disabled], &[aria-disabled='true']": {
-    color: theme.disabled,
-    cursor: 'not-allowed',
-    opacity: '60%',
+    ...theme.form[size],
+    ...theme.formPadding[size],
+    ...theme.formRadius[size],
 
     '&::placeholder': {
-      color: theme.disabled,
+      color: theme.tokens.content.muted,
+      opacity: 1,
     },
-  },
 
-  '&:focus, &:focus-visible, :focus-within': {
-    ...theme.focusRing,
-  },
-  "&[type='number']": {
-    appearance: 'textfield',
-    MozAppearance: 'textfield',
-    fontVariantNumeric: 'tabular-nums',
-  },
-  '&::-webkit-outer-spin-button, &::-webkit-inner-spin-button': {
-    WebkitAppearance: 'none',
-    margin: 0,
-  },
-});
+    "&[disabled], &[aria-disabled='true']": {
+      color: theme.disabled,
+      cursor: 'not-allowed',
+      opacity: '60%',
+
+      '&::placeholder': {
+        color: theme.disabled,
+      },
+    },
+
+    '&:focus, &:focus-visible, :focus-within': {
+      ...theme.focusRing(boxShadow),
+    },
+    "&[type='number']": {
+      appearance: 'textfield',
+      MozAppearance: 'textfield',
+      fontVariantNumeric: 'tabular-nums',
+    },
+    '&::-webkit-outer-spin-button, &::-webkit-inner-spin-button': {
+      WebkitAppearance: 'none',
+      margin: 0,
+    },
+  };
+};

--- a/static/app/components/core/radio/index.chonk.tsx
+++ b/static/app/components/core/radio/index.chonk.tsx
@@ -45,7 +45,7 @@ export const chonkRadioStyles = (
   },
 
   '&:focus-visible': {
-    ...props.theme.focusRing,
+    ...props.theme.focusRing(),
   },
 
   '&:checked': {

--- a/static/app/components/core/segmentedControl/index.chonk.tsx
+++ b/static/app/components/core/segmentedControl/index.chonk.tsx
@@ -75,7 +75,7 @@ export const ChonkStyledSegmentWrap = chonkStyled('label')<{
   ${p => ({...DO_NOT_USE_getChonkButtonStyles({...p, disabled: p.isDisabled, priority: p.isSelected && p.priority === 'primary' ? 'primary' : 'default'})})}
 
   &:has(input:focus-visible) {
-    ${p => p.theme.focusRing};
+    ${p => p.theme.focusRing()};
 
     /* Hide fallback ring when :has works */
     span {
@@ -85,7 +85,7 @@ export const ChonkStyledSegmentWrap = chonkStyled('label')<{
 
   /* Fallback ring (for Firefox, where :has doesn't work) */
   input:focus-visible + span {
-    ${({theme}) => theme.focusRing};
+    ${({theme}) => theme.focusRing()};
   }
 `;
 

--- a/static/app/components/core/select/index.chonk.tsx
+++ b/static/app/components/core/select/index.chonk.tsx
@@ -61,6 +61,7 @@ export const getChonkStylesConfig = ({
       color: 'currentcolor',
     },
   });
+  const boxShadow = `0px ${chonk} 0px 0px ${theme.tokens.border.primary} inset`;
 
   return {
     control: (_, state) => ({
@@ -68,11 +69,11 @@ export const getChonkStylesConfig = ({
       color: state.isDisabled ? theme.disabled : theme.textColor,
       background: theme.tokens.background.secondary,
       border: `1px solid ${theme.border}`,
-      boxShadow: `0px ${chonk} 0px 0px ${theme.tokens.border.primary} inset`,
+      boxShadow,
       ...theme.formRadius[size],
       transition: 'border 0.1s, box-shadow 0.1s',
       alignItems: 'center',
-      ...(state.isFocused && theme.focusRing),
+      ...(state.isFocused && theme.focusRing(boxShadow)),
       ...(state.isDisabled && {
         background: theme.background,
         color: theme.disabled,

--- a/static/app/components/core/slider/index.chonk.tsx
+++ b/static/app/components/core/slider/index.chonk.tsx
@@ -132,7 +132,7 @@ const StyledSlider = chonkStyled('input')`
       0 0 0 10px transparent;
 
     &:focus-visible {
-      ${p => p.theme.focusRing};
+      ${p => p.theme.focusRing()};
     }
 
     &[disabled] {

--- a/static/app/components/core/switch/index.chonk.tsx
+++ b/static/app/components/core/switch/index.chonk.tsx
@@ -29,7 +29,7 @@ export const ChonkNativeHiddenCheckbox = chonkStyled('input')<{
   cursor: pointer;
 
   &:focus-visible + div {
-    ${p => p.theme.focusRing};
+    ${p => p.theme.focusRing()};
   }
 
   + div {

--- a/static/app/utils/theme/theme.chonk.tsx
+++ b/static/app/utils/theme/theme.chonk.tsx
@@ -1096,7 +1096,7 @@ interface ChonkTheme extends Omit<SentryTheme, 'isChonk' | 'chart'> {
     border: ReturnType<typeof generateChonkTokens>['border'];
     content: ReturnType<typeof generateChonkTokens>['content'];
   };
-  focusRing: {
+  focusRing: (existingShadow?: React.CSSProperties['boxShadow']) => {
     boxShadow: React.CSSProperties['boxShadow'];
     outline: React.CSSProperties['outline'];
   };
@@ -1126,10 +1126,10 @@ export const DO_NOT_USE_lightChonkTheme: ChonkTheme = {
     tokens: darkTokens,
   },
   radius,
-  focusRing: {
+  focusRing: (baseShadow = `0 0 0 0 ${lightAliases.background}`) => ({
     outline: 'none',
-    boxShadow: `0 0 0 0 ${lightAliases.background}, 0 0 0 2px ${lightAliases.focusBorder}`,
-  },
+    boxShadow: `${baseShadow}, 0 0 0 2px ${lightAliases.focusBorder}`,
+  }),
 
   // @TODO: these colors need to be ported
   ...generateThemeUtils(chonkLightColorMapping, lightAliases),
@@ -1194,10 +1194,10 @@ export const DO_NOT_USE_darkChonkTheme: ChonkTheme = {
   },
 
   radius,
-  focusRing: {
+  focusRing: (baseShadow = `0 0 0 0 ${darkAliases.background}`) => ({
     outline: 'none',
-    boxShadow: `0 0 0 0 ${darkAliases.background}, 0 0 0 2px ${darkAliases.focusBorder}`,
-  },
+    boxShadow: `${baseShadow}, 0 0 0 2px ${darkAliases.focusBorder}`,
+  }),
 
   // @TODO: these colors need to be ported
   ...generateThemeUtils(chonkDarkColorMapping, darkAliases),


### PR DESCRIPTION
both the inset chonk, as well as the focus border are done with `boxShadow`, so the focus style was overwriting the chonk:

| before | after |
|--------|--------|
| <img width="1480" height="325" alt="Screenshot 2025-07-25 at 13 43 01" src="https://github.com/user-attachments/assets/9219a4bf-97f1-45d2-abf6-1b3b37315558" /> | <img width="1480" height="325" alt="Screenshot 2025-07-25 at 13 42 28" src="https://github.com/user-attachments/assets/c685b9aa-5510-4a2d-8066-247250d573ce" /> |
| <img width="1480" height="325" alt="Screenshot 2025-07-25 at 13 44 23" src="https://github.com/user-attachments/assets/5b7990d1-222d-4e9b-be01-0d40d8c3841d" /> | <img width="1480" height="325" alt="Screenshot 2025-07-25 at 13 44 16" src="https://github.com/user-attachments/assets/69cd914b-359e-4f0b-a276-89e256a1dff6" /> | 