### PR TITLE
feat(stories): add hash links to story headings

### DIFF
--- a/static/app/stories/view/index.tsx
+++ b/static/app/stories/view/index.tsx
@@ -132,7 +132,7 @@ function useScrollToHash() {
       // Exponential backoff with jitter
       const delay = Math.min(baseDelay * Math.pow(1.5, attempts), maxDelay);
       const jitter = Math.random() * 0.1 * delay; // Add up to 10% jitter
-      
+
       setTimeout(tryScroll, delay + jitter);
     };
 

--- a/static/app/stories/view/index.tsx
+++ b/static/app/stories/view/index.tsx
@@ -114,6 +114,7 @@ function scrollToHash() {
 
 function useScrollToHash() {
   useEffect(() => {
+    const timers: NodeJS.Timeout[] = [];
     let attempts = 0;
     const maxAttempts = 20; // Maximum number of attempts
     const baseDelay = 50; // Base delay in ms
@@ -133,13 +134,18 @@ function useScrollToHash() {
       const delay = Math.min(baseDelay * Math.pow(1.5, attempts), maxDelay);
       const jitter = Math.random() * 0.1 * delay; // Add up to 10% jitter
 
-      setTimeout(tryScroll, delay + jitter);
+      timers.push(setTimeout(tryScroll, delay + jitter));
     };
 
     // Start with a small initial delay to allow initial render
     requestAnimationFrame(() => {
-      setTimeout(tryScroll, 100);
+      timers.push(setTimeout(tryScroll, 100));
     });
+    return () => {
+      for (const timer of timers) {
+        clearTimeout(timer);
+      }
+    };
   }, []);
 }
 

--- a/static/app/stories/view/index.tsx
+++ b/static/app/stories/view/index.tsx
@@ -93,26 +93,26 @@ function StoriesLayout(props: PropsWithChildren) {
   );
 }
 
-function useScrollToHash() {
-  const scrollToHash = () => {
-    if (window.location.hash) {
-      const hash = window.location.hash.replace(/^#/, '');
+function scrollToHash() {
+  if (window.location.hash) {
+    const hash = window.location.hash.replace(/^#/, '');
 
-      try {
-        const element = document.querySelector(`#${hash}`);
-        if (element) {
-          element.scrollIntoView({behavior: 'instant', block: 'start'});
-          return true; // Successfully scrolled
-        }
-        return false; // Element not found
-      } catch {
-        // hash might be an invalid querySelector and lead to a DOMException
-        return false;
+    try {
+      const element = document.querySelector(`#${hash}`);
+      if (element) {
+        element.scrollIntoView({behavior: 'instant', block: 'start'});
+        return true; // Successfully scrolled
       }
+      return false; // Element not found
+    } catch {
+      // hash might be an invalid querySelector and lead to a DOMException
+      return false;
     }
-    return true; // No hash to scroll to
-  };
+  }
+  return true; // No hash to scroll to
+}
 
+function useScrollToHash() {
   useEffect(() => {
     let attempts = 0;
     const maxAttempts = 20; // Maximum number of attempts

--- a/static/app/stories/view/index.tsx
+++ b/static/app/stories/view/index.tsx
@@ -1,4 +1,4 @@
-import {Fragment, type PropsWithChildren} from 'react';
+import {Fragment, type PropsWithChildren, useEffect} from 'react';
 import {css, Global, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -38,6 +38,7 @@ function StoriesLanding() {
 
 function StoryDetail() {
   useStoryRedirect();
+  useScrollToHash();
   const location = useLocation<{name: string; query?: string}>();
   const files = [location.state?.storyPath ?? location.query.name];
   const story = useStoriesLoader({files});
@@ -90,6 +91,25 @@ function StoriesLayout(props: PropsWithChildren) {
       </RouteAnalyticsContextProvider>
     </Fragment>
   );
+}
+
+function useScrollToHash() {
+  const scrollToHash = () => {
+    if (window.location.hash) {
+      const hash = window.location.hash.replace(/^#/, '');
+
+      try {
+        const element = document.querySelector(`#${hash}`);
+        element?.scrollIntoView({behavior: 'instant', block: 'start'});
+      } catch {
+        // hash might be an invalid querySelector and lead to a DOMException
+      }
+    }
+  };
+
+  useEffect(() => {
+    setTimeout(() => scrollToHash(), 300);
+  }, []);
 }
 
 function GlobalStoryStyles() {

--- a/static/app/stories/view/index.tsx
+++ b/static/app/stories/view/index.tsx
@@ -113,7 +113,7 @@ function useScrollToHash() {
     return true; // No hash to scroll to
   };
 
-  const attemptScrollWithRetry = () => {
+  useEffect(() => {
     let attempts = 0;
     const maxAttempts = 20; // Maximum number of attempts
     const baseDelay = 50; // Base delay in ms
@@ -140,10 +140,6 @@ function useScrollToHash() {
     requestAnimationFrame(() => {
       setTimeout(tryScroll, 100);
     });
-  };
-
-  useEffect(() => {
-    attemptScrollWithRetry();
   }, []);
 }
 

--- a/static/app/stories/view/index.tsx
+++ b/static/app/stories/view/index.tsx
@@ -74,7 +74,7 @@ function StoryDetail() {
 function StoriesLayout(props: PropsWithChildren) {
   return (
     <Fragment>
-      <GlobalStoryStyles />
+      <GlobalStoryStyles key="global-story-styles" />
       <RouteAnalyticsContextProvider>
         <OrganizationContainer>
           <Layout>
@@ -124,7 +124,7 @@ function GlobalStoryStyles() {
       background: ${theme.tokens.background.primary};
     }
   `;
-  return <Global key="stories" styles={styles} />;
+  return <Global styles={styles} />;
 }
 
 const Layout = styled('div')`

--- a/static/app/stories/view/index.tsx
+++ b/static/app/stories/view/index.tsx
@@ -175,7 +175,7 @@ const StoryMainContainer = styled('div')`
   h4,
   h5,
   h6 {
-    scroll-margin-top: 64px;
+    scroll-margin-top: 80px;
     margin: 0;
   }
 

--- a/static/app/stories/view/storyExports.tsx
+++ b/static/app/stories/view/storyExports.tsx
@@ -6,12 +6,13 @@ import {Alert} from 'sentry/components/core/alert';
 import {TabList, TabPanels, Tabs} from 'sentry/components/core/tabs';
 import {t} from 'sentry/locale';
 import * as Storybook from 'sentry/stories';
-import {StoryFooter} from 'sentry/stories/view/storyFooter';
-import {StoryTableOfContents} from 'sentry/stories/view/storyTableOfContents';
 import {space} from 'sentry/styles/space';
 
+import {StoryFooter} from './storyFooter';
+import {storyMdxComponents} from './storyMdxComponent';
 import {StoryResources} from './storyResources';
 import {StorySourceLinks} from './storySourceLinks';
+import {StoryTableOfContents} from './storyTableOfContents';
 import {isMDXStory, type StoryDescriptor} from './useStoriesLoader';
 import type {StoryExports as StoryExportValues} from './useStory';
 import {StoryContextProvider, useStory} from './useStory';
@@ -122,7 +123,7 @@ function StoryUsage() {
               </Alert>
             }
           >
-            <Story />
+            <Story components={storyMdxComponents} />
           </ErrorBoundary>
         </Storybook.Section>
       )}

--- a/static/app/stories/view/storyHeading.tsx
+++ b/static/app/stories/view/storyHeading.tsx
@@ -15,7 +15,7 @@ export function StoryHeading(props: ComponentProps<typeof Heading>) {
   const {story} = useStory();
   const storyTitle = (story.exports.frontmatter as any)?.title;
   const text = stringifyChildren(props.children);
-  const id = props.id ?? slugify(text.replace(/\s+/g, '-'));
+  const id = props.id ?? slugify(text);
   const {onClick} = useCopyToClipboard({
     text: `${window.location.toString().replace(/#.*$/, '')}#${id}`,
     successMessage: (

--- a/static/app/stories/view/storyHeading.tsx
+++ b/static/app/stories/view/storyHeading.tsx
@@ -3,6 +3,8 @@ import {Fragment} from 'react';
 import {renderToStaticMarkup} from 'react-dom/server';
 import styled from '@emotion/styled';
 
+import {LinkButton} from 'sentry/components/core/button/linkButton';
+import {Flex} from 'sentry/components/core/layout';
 import {Heading} from 'sentry/components/core/text';
 import {IconLink} from 'sentry/icons';
 import {useStory} from 'sentry/stories/view/useStory';
@@ -26,35 +28,39 @@ export function StoryHeading(props: ComponentProps<typeof Heading>) {
       </Fragment>
     ),
   });
+
   return (
-    <HeadingLink href={`#${id}`} onClick={onClick}>
-      <IconLink />
+    <HeadingContainer gap="md" align="center">
       <Heading {...props} id={id} />
-    </HeadingLink>
+      <LinkButton priority="transparent" size="xs" href={`#${id}`} onClick={onClick}>
+        <IconLink />
+      </LinkButton>
+    </HeadingContainer>
   );
 }
 
-const HeadingLink = styled('a')`
-  display: flex;
-  flex-flow: row-reverse;
-  justify-content: flex-end;
-  align-items: center;
-  gap: ${p => p.theme.space.md};
+const HeadingContainer = styled(Flex)`
+  > a {
+    opacity: 0;
+    color: ${p => p.theme.tokens.graphics.muted};
+  }
+
+  &:is(:hover, :focus-within) > a {
+    opacity: 1;
+  }
+
+  a:is(:hover, :focus) {
+    color: ${p => p.theme.tokens.graphics.accent};
+  }
 
   @media (min-width: ${p => p.theme.breakpoints.xl}) {
-    display: grid;
-    justify-content: flex-start;
-    grid-template-columns: ${p => p.theme.space.xl} auto;
-    margin-left: calc((${p => p.theme.space.xl} + ${p => p.theme.space.md}) * -1);
-  }
+    flex-direction: row;
+    margin-left: -40px;
 
-  > :first-child {
-    opacity: 0;
-  }
-
-  &:where(:hover, :focus) {
-    > :first-child {
-      opacity: 1;
+    > a {
+      width: 32px;
+      height: 32px;
+      order: -1;
     }
   }
 `;

--- a/static/app/stories/view/storyHeading.tsx
+++ b/static/app/stories/view/storyHeading.tsx
@@ -12,8 +12,8 @@ import useCopyToClipboard from 'sentry/utils/useCopyToClipboard';
 export function StoryHeading(props: ComponentProps<typeof Heading>) {
   const {story} = useStory();
   const storyTitle = (story.exports.frontmatter as any)?.title;
-  const text = renderToStaticMarkup(props.children);
-  const id = props.id ?? slugify(text);
+  const text = stringifyChildren(props.children);
+  const id = props.id ?? slugify(text.replace(/\s+/, '-'));
   const {onClick} = useCopyToClipboard({
     text: `${window.location.toString().replace(/#.*$/, '')}#${id}`,
     successMessage: (
@@ -58,3 +58,12 @@ const HeadingLink = styled('a')`
     }
   }
 `;
+
+function stringifyChildren(children: React.ReactNode) {
+  const markup = renderToStaticMarkup(children);
+  const p = new DOMParser();
+  const {
+    body: {textContent},
+  } = p.parseFromString(markup, 'text/html');
+  return textContent ?? '';
+}

--- a/static/app/stories/view/storyHeading.tsx
+++ b/static/app/stories/view/storyHeading.tsx
@@ -13,7 +13,7 @@ export function StoryHeading(props: ComponentProps<typeof Heading>) {
   const {story} = useStory();
   const storyTitle = (story.exports.frontmatter as any)?.title;
   const text = stringifyChildren(props.children);
-  const id = props.id ?? slugify(text.replace(/\s+/, '-'));
+  const id = props.id ?? slugify(text.replace(/\s+/g, '-'));
   const {onClick} = useCopyToClipboard({
     text: `${window.location.toString().replace(/#.*$/, '')}#${id}`,
     successMessage: (

--- a/static/app/stories/view/storyHeading.tsx
+++ b/static/app/stories/view/storyHeading.tsx
@@ -1,30 +1,41 @@
 import type {ComponentProps} from 'react';
+import {Fragment} from 'react';
 import {renderToStaticMarkup} from 'react-dom/server';
 import styled from '@emotion/styled';
 
-import {Link} from 'sentry/components/core/link';
 import {Heading} from 'sentry/components/core/text';
 import {IconLink} from 'sentry/icons';
+import {useStory} from 'sentry/stories/view/useStory';
 import slugify from 'sentry/utils/slugify';
 import useCopyToClipboard from 'sentry/utils/useCopyToClipboard';
-import {useLocation} from 'sentry/utils/useLocation';
 
 export function StoryHeading(props: ComponentProps<typeof Heading>) {
-  const id = props.id ?? slugify(renderToStaticMarkup(props.children));
-  const location = useLocation();
+  const {story} = useStory();
+  const storyTitle = (story.exports.frontmatter as any)?.title;
+  const text = renderToStaticMarkup(props.children);
+  const id = props.id ?? slugify(text);
   const {onClick} = useCopyToClipboard({
-    text: `${window.location}#${id}`,
-    successMessage: `Copied \`#${id}\` link to clipboard`,
+    text: `${window.location.toString().replace(/#.*$/, '')}#${id}`,
+    successMessage: (
+      <Fragment>
+        Copied link to{' '}
+        <strong>
+          {storyTitle ? `${storyTitle} > ` : null}
+          {text}
+        </strong>{' '}
+        section
+      </Fragment>
+    ),
   });
   return (
-    <HeadingLink to={{...location, hash: id}} onClick={onClick}>
+    <HeadingLink href={`#${id}`} onClick={onClick}>
       <IconLink />
       <Heading {...props} id={id} />
     </HeadingLink>
   );
 }
 
-const HeadingLink = styled(Link)`
+const HeadingLink = styled('a')`
   display: flex;
   flex-flow: row-reverse;
   justify-content: flex-end;

--- a/static/app/stories/view/storyHeading.tsx
+++ b/static/app/stories/view/storyHeading.tsx
@@ -1,0 +1,50 @@
+import type {ComponentProps} from 'react';
+import {renderToStaticMarkup} from 'react-dom/server';
+import styled from '@emotion/styled';
+
+import {Link} from 'sentry/components/core/link';
+import {Heading} from 'sentry/components/core/text';
+import {IconLink} from 'sentry/icons';
+import slugify from 'sentry/utils/slugify';
+import useCopyToClipboard from 'sentry/utils/useCopyToClipboard';
+import {useLocation} from 'sentry/utils/useLocation';
+
+export function StoryHeading(props: ComponentProps<typeof Heading>) {
+  const id = props.id ?? slugify(renderToStaticMarkup(props.children));
+  const location = useLocation();
+  const {onClick} = useCopyToClipboard({
+    text: `${window.location}#${id}`,
+    successMessage: `Copied \`#${id}\` link to clipboard`,
+  });
+  return (
+    <HeadingLink to={{...location, hash: id}} onClick={onClick}>
+      <IconLink />
+      <Heading {...props} id={id} />
+    </HeadingLink>
+  );
+}
+
+const HeadingLink = styled(Link)`
+  display: flex;
+  flex-flow: row-reverse;
+  justify-content: flex-end;
+  align-items: center;
+  gap: ${p => p.theme.space.md};
+
+  @media (min-width: ${p => p.theme.breakpoints.xl}) {
+    display: grid;
+    justify-content: flex-start;
+    grid-template-columns: ${p => p.theme.space.xl} auto;
+    margin-left: calc((${p => p.theme.space.xl} + ${p => p.theme.space.md}) * -1);
+  }
+
+  > :first-child {
+    opacity: 0;
+  }
+
+  &:where(:hover, :focus) {
+    > :first-child {
+      opacity: 1;
+    }
+  }
+`;

--- a/static/app/stories/view/storyHeading.tsx
+++ b/static/app/stories/view/storyHeading.tsx
@@ -1,6 +1,7 @@
 import type {ComponentProps} from 'react';
 import {Fragment} from 'react';
-import {renderToStaticMarkup} from 'react-dom/server';
+import {flushSync} from 'react-dom';
+import {createRoot} from 'react-dom/client';
 import styled from '@emotion/styled';
 
 import {LinkButton} from 'sentry/components/core/button/linkButton';
@@ -66,10 +67,10 @@ const HeadingContainer = styled(Flex)`
 `;
 
 function stringifyChildren(children: React.ReactNode) {
-  const markup = renderToStaticMarkup(children);
-  const p = new DOMParser();
-  const {
-    body: {textContent},
-  } = p.parseFromString(markup, 'text/html');
-  return textContent ?? '';
+  const container = document.createElement('div');
+  const root = createRoot(container);
+  flushSync(() => {
+    root.render(<Fragment>{children}</Fragment>);
+  });
+  return container.textContent ?? '';
 }

--- a/static/app/stories/view/storyHeading.tsx
+++ b/static/app/stories/view/storyHeading.tsx
@@ -22,8 +22,7 @@ export function StoryHeading(props: ComponentProps<typeof Heading>) {
         <strong>
           {storyTitle ? `${storyTitle} > ` : null}
           {text}
-        </strong>{' '}
-        section
+        </strong>
       </Fragment>
     ),
   });

--- a/static/app/stories/view/storyMdxComponent.tsx
+++ b/static/app/stories/view/storyMdxComponent.tsx
@@ -1,0 +1,14 @@
+import {StoryHeading} from './storyHeading';
+
+type HeadingProps = {
+  children: React.ReactNode;
+};
+
+export const storyMdxComponents = {
+  h1: (props: HeadingProps) => <StoryHeading as="h1" size="2xl" {...props} />,
+  h2: (props: HeadingProps) => <StoryHeading as="h2" size="2xl" {...props} />,
+  h3: (props: HeadingProps) => <StoryHeading as="h3" size="xl" {...props} />,
+  h4: (props: HeadingProps) => <StoryHeading as="h4" size="lg" {...props} />,
+  h5: (props: HeadingProps) => <StoryHeading as="h5" size="md" {...props} />,
+  h6: (props: HeadingProps) => <StoryHeading as="h6" size="sm" {...props} />,
+};

--- a/static/app/stories/view/storySidebar.tsx
+++ b/static/app/stories/view/storySidebar.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useMemo, useRef} from 'react';
+import {useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import {space} from 'sentry/styles/space';
@@ -9,15 +9,14 @@ import {useStoryBookFiles} from './useStoriesLoader';
 
 export function StorySidebar() {
   const {foundations, typography, layout, core, shared} = useStoryBookFilesByCategory();
-  const sidebarEl = useRef<HTMLElement | null>(null);
-  useEffect(() => {
-    sidebarEl.current
+  function scrollIntoView(node: HTMLElement | null) {
+    node
       ?.querySelector('[aria-current="page"]')
       ?.scrollIntoView({behavior: 'instant', block: 'nearest'});
-  }, []);
+  }
 
   return (
-    <SidebarContainer key="sidebar" ref={sidebarEl}>
+    <SidebarContainer key="sidebar" ref={scrollIntoView}>
       <ul>
         <li>
           <h3>Foundations</h3>

--- a/static/app/stories/view/storySidebar.tsx
+++ b/static/app/stories/view/storySidebar.tsx
@@ -1,4 +1,4 @@
-import {useMemo} from 'react';
+import {useLayoutEffect, useMemo, useRef} from 'react';
 import styled from '@emotion/styled';
 
 import {space} from 'sentry/styles/space';
@@ -9,9 +9,17 @@ import {useStoryBookFiles} from './useStoriesLoader';
 
 export function StorySidebar() {
   const {foundations, typography, layout, core, shared} = useStoryBookFilesByCategory();
+  const sidebarEl = useRef<HTMLElement | null>(null);
+  useLayoutEffect(() => {
+    setTimeout(() => {
+      sidebarEl.current
+        ?.querySelector('[aria-current="page"]')
+        ?.scrollIntoView({behavior: 'instant', block: 'nearest'});
+    }, 50);
+  }, []);
 
   return (
-    <SidebarContainer>
+    <SidebarContainer key="sidebar" ref={sidebarEl}>
       <ul>
         <li>
           <h3>Foundations</h3>

--- a/static/app/stories/view/storySidebar.tsx
+++ b/static/app/stories/view/storySidebar.tsx
@@ -1,4 +1,4 @@
-import {useLayoutEffect, useMemo, useRef} from 'react';
+import {useEffect, useMemo, useRef} from 'react';
 import styled from '@emotion/styled';
 
 import {space} from 'sentry/styles/space';
@@ -10,12 +10,10 @@ import {useStoryBookFiles} from './useStoriesLoader';
 export function StorySidebar() {
   const {foundations, typography, layout, core, shared} = useStoryBookFilesByCategory();
   const sidebarEl = useRef<HTMLElement | null>(null);
-  useLayoutEffect(() => {
-    setTimeout(() => {
-      sidebarEl.current
-        ?.querySelector('[aria-current="page"]')
-        ?.scrollIntoView({behavior: 'instant', block: 'nearest'});
-    }, 50);
+  useEffect(() => {
+    sidebarEl.current
+      ?.querySelector('[aria-current="page"]')
+      ?.scrollIntoView({behavior: 'instant', block: 'nearest'});
   }, []);
 
   return (

--- a/static/app/stories/view/storyTree.tsx
+++ b/static/app/stories/view/storyTree.tsx
@@ -499,15 +499,16 @@ function Folder(props: {node: StoryTreeNode}) {
 function File(props: {node: StoryTreeNode}) {
   const location = useLocation();
   const {state, ...to} = props.node.location;
+  const active =
+    props.node.filesystemPath === (location.state?.storyPath ?? location.query.name);
 
   return (
     <li>
       <FolderLink
         to={to}
         state={state}
-        active={
-          props.node.filesystemPath === (location.state?.storyPath ?? location.query.name)
-        }
+        aria-current={active ? 'page' : undefined}
+        active={active}
       >
         {normalizeFilename(props.node.name)}
       </FolderLink>

--- a/static/app/stories/view/useStoryRedirect.tsx
+++ b/static/app/stories/view/useStoryRedirect.tsx
@@ -35,7 +35,10 @@ export function useStoryRedirect() {
       return;
     }
     const {state, ...to} = story.location;
-    navigate({...location, ...to}, {replace: true, state: {...location.state, ...state}});
+    navigate(
+      {pathname: location.pathname, ...to},
+      {replace: true, state: {...location.state, ...state}}
+    );
   }, [location, params, navigate, stories]);
 
   useLayoutEffect(() => {

--- a/static/app/stories/view/useStoryRedirect.tsx
+++ b/static/app/stories/view/useStoryRedirect.tsx
@@ -35,7 +35,7 @@ export function useStoryRedirect() {
       return;
     }
     const {state, ...to} = story.location;
-    navigate(to, {replace: true, state});
+    navigate({...location, ...to}, {replace: true, state: {...location.state, ...state}});
   }, [location, params, navigate, stories]);
 }
 

--- a/static/app/stories/view/useStoryRedirect.tsx
+++ b/static/app/stories/view/useStoryRedirect.tsx
@@ -48,7 +48,7 @@ export function useStoryRedirect() {
 
 function scrollToHash() {
   if (window.location.hash) {
-    const hash = window.location.hash.replace(/\^#/, '');
+    const hash = window.location.hash.replace(/^#/, '');
 
     try {
       const element = document.querySelector(`#${hash}`);

--- a/static/app/stories/view/useStoryRedirect.tsx
+++ b/static/app/stories/view/useStoryRedirect.tsx
@@ -40,23 +40,6 @@ export function useStoryRedirect() {
       {replace: true, state: {...location.state, ...state}}
     );
   }, [location, params, navigate, stories]);
-
-  useLayoutEffect(() => {
-    requestAnimationFrame(() => scrollToHash());
-  }, [location.hash]);
-}
-
-function scrollToHash() {
-  if (window.location.hash) {
-    const hash = window.location.hash.replace(/^#/, '');
-
-    try {
-      const element = document.querySelector(`#${hash}`);
-      element?.scrollIntoView({behavior: 'instant', block: 'start'});
-    } catch {
-      // hash might be an invalid querySelector and lead to a DOMException
-    }
-  }
 }
 
 interface StoryRouteContext {

--- a/static/app/stories/view/useStoryRedirect.tsx
+++ b/static/app/stories/view/useStoryRedirect.tsx
@@ -38,16 +38,22 @@ export function useStoryRedirect() {
     navigate({...location, ...to}, {replace: true, state: {...location.state, ...state}});
   }, [location, params, navigate, stories]);
 
-  // scroll to active section
   useLayoutEffect(() => {
-    if (location.hash) {
-      setTimeout(() => {
-        document
-          .querySelector(location.hash)
-          ?.scrollIntoView({behavior: 'instant', block: 'start'});
-      }, 50);
+    setTimeout(() => scrollToHash(), 100);
+  }, []);
+}
+
+function scrollToHash() {
+  if (window.location.hash) {
+    const [, hash] = window.location.hash.split('#');
+
+    try {
+      const element = document.querySelector(`#${hash}`);
+      element?.scrollIntoView({behavior: 'instant', block: 'start'});
+    } catch {
+      // hash might be an invalid querySelector and lead to a DOMException
     }
-  }, [location.hash]);
+  }
 }
 
 interface StoryRouteContext {

--- a/static/app/stories/view/useStoryRedirect.tsx
+++ b/static/app/stories/view/useStoryRedirect.tsx
@@ -37,6 +37,17 @@ export function useStoryRedirect() {
     const {state, ...to} = story.location;
     navigate({...location, ...to}, {replace: true, state: {...location.state, ...state}});
   }, [location, params, navigate, stories]);
+
+  // scroll to active section
+  useLayoutEffect(() => {
+    if (location.hash) {
+      setTimeout(() => {
+        document
+          .querySelector(location.hash)
+          ?.scrollIntoView({behavior: 'instant', block: 'start'});
+      }, 50);
+    }
+  }, [location.hash]);
 }
 
 interface StoryRouteContext {

--- a/static/app/stories/view/useStoryRedirect.tsx
+++ b/static/app/stories/view/useStoryRedirect.tsx
@@ -36,14 +36,14 @@ export function useStoryRedirect() {
     }
     const {state, ...to} = story.location;
     navigate(
-      {pathname: location.pathname, ...to},
+      {pathname: location.pathname, hash: location.hash, ...to},
       {replace: true, state: {...location.state, ...state}}
     );
   }, [location, params, navigate, stories]);
 
   useLayoutEffect(() => {
     setTimeout(() => scrollToHash(), 100);
-  }, []);
+  }, [location.hash]);
 }
 
 function scrollToHash() {

--- a/static/app/stories/view/useStoryRedirect.tsx
+++ b/static/app/stories/view/useStoryRedirect.tsx
@@ -42,13 +42,13 @@ export function useStoryRedirect() {
   }, [location, params, navigate, stories]);
 
   useLayoutEffect(() => {
-    setTimeout(() => scrollToHash(), 100);
+    requestAnimationFrame(() => scrollToHash());
   }, [location.hash]);
 }
 
 function scrollToHash() {
   if (window.location.hash) {
-    const [, hash] = window.location.hash.split('#');
+    const hash = window.location.hash.replace(/\^#/, '');
 
     try {
       const element = document.querySelector(`#${hash}`);


### PR DESCRIPTION
This PR adds `id` attributes to headings in MDX Stories, wraps headings in `Link`, adds `copyToClipboard` functionality, and automatically scrolls the linked sections on load.

[See Deploy Preview](https://sentry-git-stories-nmheadings.sentry.dev/stories/core/text)

https://github.com/user-attachments/assets/71f559ba-0058-4b4e-9493-f73abeb92a9e


