### PR TITLE
chore(hybridcloud) Capture logs when cache keys are invalidated

### DIFF
--- a/src/sentry/hybridcloud/models/cacheversion.py
+++ b/src/sentry/hybridcloud/models/cacheversion.py
@@ -1,9 +1,14 @@
+import logging
+import random
+
 from django.db import models, router, transaction
 from django.db.models import F
 
 from sentry.backup.scopes import RelocationScope
 from sentry.db.models import Model, control_silo_model, region_silo_model
 from sentry.db.postgres.transactions import enforce_constraints
+
+logger = logging.getLogger(__name__)
 
 
 class CacheVersionBase(Model):
@@ -16,6 +21,8 @@ class CacheVersionBase(Model):
     @classmethod
     def incr_version(cls, key: str) -> int:
         with enforce_constraints(transaction.atomic(router.db_for_write(cls))):
+            if random.random() < 0.01:
+                logger.info("cacheversion.incr_version", extra={"key": key})
             cls.objects.create_or_update(
                 key=key, defaults=dict(version=1), values=dict(version=F("version") + 1)
             )


### PR DESCRIPTION
We're seeing a higher than expected key clear rate, and I'd like to understand which pods are doing all these clear operations to better understand the source of these queries.

I've sampled only 1% of operations because of the volume this query gets.