### PR TITLE
feat(trace-eap-waterfall): Adding missing contexts

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
@@ -471,7 +471,9 @@ function EAPSpanNodeDetails({
                       project={project}
                     />
 
-                    {isTransaction ? <Contexts event={eventTransaction} /> : null}
+                    {isTransaction ? (
+                      <Contexts event={eventTransaction} project={project} />
+                    ) : null}
 
                     <LogDetails />
 


### PR DESCRIPTION
- Customers have reported missing otel attributes and event payload contexts.
- This PR adds them back, and makes sure that we don't introduce duplicates between attributes and context sections in the trace drawer. 
<img width="560" height="131" alt="Screenshot 2025-07-25 at 1 05 02 PM" src="https://github.com/user-attachments/assets/6f32251e-43b1-4480-9b0e-cafeb358de95" />

