### PR TITLE
chore(detectors): Add LaunchDarkly filtering to N+1 API Call detectors

### DIFF
--- a/src/sentry/performance_issues/detectors/experiments/n_plus_one_api_calls_detector.py
+++ b/src/sentry/performance_issues/detectors/experiments/n_plus_one_api_calls_detector.py
@@ -122,6 +122,10 @@ class NPlusOneAPICallsExperimentalDetector(PerformanceDetector):
         if "__nextjs_original-stack-frame" in url:
             return False
 
+        # LaunchDarkly SDK calls are not useful
+        if "https://app.launchdarkly.com/sdk/" in url:
+            return False
+
         if not url:
             return False
 

--- a/src/sentry/performance_issues/detectors/n_plus_one_api_calls_detector.py
+++ b/src/sentry/performance_issues/detectors/n_plus_one_api_calls_detector.py
@@ -122,6 +122,10 @@ class NPlusOneAPICallsDetector(PerformanceDetector):
         if "__nextjs_original-stack-frame" in url:
             return False
 
+        # LaunchDarkly SDK calls are not useful
+        if "https://app.launchdarkly.com/sdk/" in url:
+            return False
+
         if not url:
             return False
 


### PR DESCRIPTION
LaunchDarkly N+1 API Calls aren't useful to show and be very noisy so we should not mark these spans as eligible