### PR TITLE
fix: adjust integrated org default string and avoid CI console warnings

### DIFF
--- a/static/app/components/codecov/integratedOrgSelector/utils.tsx
+++ b/static/app/components/codecov/integratedOrgSelector/utils.tsx
@@ -2,8 +2,8 @@ import type {Integration} from 'sentry/types/integrations';
 
 export const integratedOrgIdToName = (id?: string, integrations?: Integration[]) => {
   if (!id || !integrations) {
-    return '';
+    return 'No Integration';
   }
   const result = integrations.find(item => item.id === id);
-  return result ? result.name : '';
+  return result ? result.name : 'Unknown Integration';
 };


### PR DESCRIPTION
This PR adjusts the default string text from the org selector mapping function to offer a more descriptive string. This in turn silences console warnings in the CI test step.