### PR TITLE
fix(dashboards): add some styles to overflow os and browser fields

### DIFF
--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -24,7 +24,6 @@ import UserMisery from 'sentry/components/userMisery';
 import Version from 'sentry/components/version';
 import {IconDownload} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import type {IssueAttachment} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
 import type {AvatarProject, Project} from 'sentry/types/project';
@@ -382,7 +381,7 @@ type SpecialField = {
 };
 
 const DownloadCount = styled('span')`
-  padding-left: ${space(0.75)};
+  padding-left: ${p => p.theme.space.sm};
 `;
 
 const RightAlignedContainer = styled('span')`
@@ -899,7 +898,7 @@ const SPECIAL_FIELDS: Record<string, SpecialField> = {
       return (
         <IconContainer>
           {getContextIcon(browserName)}
-          {browserName}
+          <Container>{browserName}</Container>
         </IconContainer>
       );
     },
@@ -915,7 +914,7 @@ const SPECIAL_FIELDS: Record<string, SpecialField> = {
       return (
         <IconContainer>
           {getContextIcon(dropVersion(browser))}
-          {browser}
+          <Container>{browser}</Container>
         </IconContainer>
       );
     },
@@ -931,7 +930,7 @@ const SPECIAL_FIELDS: Record<string, SpecialField> = {
       return (
         <IconContainer>
           {getContextIcon(osName)}
-          {osName}
+          <Container>{osName}</Container>
         </IconContainer>
       );
     },
@@ -950,11 +949,11 @@ const SPECIAL_FIELDS: Record<string, SpecialField> = {
         <IconContainer>
           {getContextIcon(dropVersion(os))}
           {hasUserAgentLocking ? (
-            <Tooltip title={userAgentLocking} showUnderline>
-              {os}
-            </Tooltip>
+            <StyledTooltip title={userAgentLocking} showUnderline>
+              <Container>{os}</Container>
+            </StyledTooltip>
           ) : (
-            os
+            <Container>{os}</Container>
           )}
         </IconContainer>
       );
@@ -1279,6 +1278,10 @@ const StyledProjectBadge = styled(ProjectBadge)`
   ${BadgeDisplayName} {
     max-width: 100%;
   }
+`;
+
+const StyledTooltip = styled(Tooltip)`
+  ${p => p.theme.overflowEllipsis}
 `;
 
 /**

--- a/static/app/utils/discover/styles.tsx
+++ b/static/app/utils/discover/styles.tsx
@@ -4,7 +4,6 @@ import {Link} from 'sentry/components/core/link';
 import {DateTime} from 'sentry/components/dateTime';
 import ShortId, {StyledAutoSelectText} from 'sentry/components/shortId';
 import {IconUser} from 'sentry/icons/iconUser';
-import {space} from 'sentry/styles/space';
 
 // Styled components used to render discover result sets.
 
@@ -59,13 +58,11 @@ export const FlexContainer = styled('div')`
 `;
 
 export const UserIcon = styled(IconUser)`
-  margin-left: ${space(1)};
+  margin-left: ${p => p.theme.space.md};
   color: ${p => p.theme.gray400};
 `;
 
 export const IconContainer = styled('div')`
   display: flex;
-  gap: ${space(1)};
-  overflow: hidden;
-  text-overflow: ellipsis;
+  gap: ${p => p.theme.space.md};
 `;


### PR DESCRIPTION
### Changes

Adjusted the os and browser renderers so they correctly use the ellipsis overflow. Also replaces deprecated use cases of `space`

### Before

<img width="785" height="204" alt="Screenshot 2025-07-25 at 1 00 12 PM" src="https://github.com/user-attachments/assets/114f12b0-037c-43f9-8a41-0a41bcf19b5c" />

### After

<img width="792" height="209" alt="Screenshot 2025-07-25 at 1 00 25 PM" src="https://github.com/user-attachments/assets/9b63ddf7-eb33-472e-a760-8c87655b4495" />

