### PR TITLE
fix(aci): handle a rule only having fired through workflow engine in RuleSerializer

### DIFF
--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -233,9 +233,9 @@ class RuleSerializer(Serializer):
                     rule_id = workflow_rule_lookup.get(wfh["workflow_id"])
                     if rule_id:
                         # Take the maximum date between RuleFireHistory and WorkflowFireHistory
-                        existing_date = last_triggered_lookup[rule_id]
+                        existing_date = last_triggered_lookup.get(rule_id)
                         new_date = wfh["date_added"]
-                        if new_date > existing_date:
+                        if (existing_date and new_date > existing_date) or not existing_date:
                             last_triggered_lookup[rule_id] = new_date
 
             # Set the results

--- a/tests/sentry/api/serializers/test_rule.py
+++ b/tests/sentry/api/serializers/test_rule.py
@@ -37,6 +37,20 @@ class RuleSerializerTest(TestCase):
         assert result["lastTriggered"] == timezone.now()
 
     @with_feature("organizations:workflow-engine-single-process-workflows")
+    def test_last_triggered_with_workflow_only(self) -> None:
+        rule = self.create_project_rule()
+
+        # Create a workflow for the rule
+        workflow = IssueAlertMigrator(rule).run()
+
+        WorkflowFireHistory.objects.create(
+            workflow=workflow, group=self.group, event_id="test-event-id", is_single_written=True
+        )
+
+        result = serialize(rule, self.user, RuleSerializer(expand=["lastTriggered"]))
+        assert result["lastTriggered"] == timezone.now()
+
+    @with_feature("organizations:workflow-engine-single-process-workflows")
     def test_last_triggered_with_workflow(self) -> None:
         rule = self.create_project_rule()
 


### PR DESCRIPTION
Fixes SENTRY-48X7

A `KeyError` can happen if a Rule only has fired through workflow engine and we expect it to have a lastTriggered value in the lookup (aka `RuleFireHistory`) before comparing with `WorkflowFireHistory` values