### PR TITLE
fix(aci): filter for single written entries in WorkflowFireHistory endpoints

### DIFF
--- a/src/sentry/workflow_engine/endpoints/serializers.py
+++ b/src/sentry/workflow_engine/endpoints/serializers.py
@@ -512,6 +512,7 @@ def fetch_workflow_groups_paginated(
         workflow=workflow,
         date_added__gte=start,
         date_added__lt=end,
+        is_single_written=True,
     )
 
     # subquery that retrieves row with the largest date in a group
@@ -543,6 +544,7 @@ def fetch_workflow_hourly_stats(
             workflow=workflow,
             date_added__gte=start,
             date_added__lt=end,
+            is_single_written=True,
         )
         .annotate(bucket=TruncHour("date_added"))
         .order_by("bucket")

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_group_history.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_group_history.py
@@ -28,11 +28,21 @@ class WorkflowGroupHistoryEndpointTest(APITestCase):
         self.workflow = self.create_workflow(organization=self.organization)
         for i in range(3):
             self.history.append(
-                WorkflowFireHistory(workflow=self.workflow, group=self.group, event_id=uuid4().hex)
+                WorkflowFireHistory(
+                    workflow=self.workflow,
+                    group=self.group,
+                    event_id=uuid4().hex,
+                    is_single_written=True,
+                )
             )
         self.group_2 = self.create_group()
         self.history.append(
-            WorkflowFireHistory(workflow=self.workflow, group=self.group_2, event_id=uuid4().hex)
+            WorkflowFireHistory(
+                workflow=self.workflow,
+                group=self.group_2,
+                event_id=uuid4().hex,
+                is_single_written=True,
+            )
         )
         histories: list[WorkflowFireHistory] = WorkflowFireHistory.objects.bulk_create(self.history)
 

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_stats.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_stats.py
@@ -28,6 +28,7 @@ class WorkflowStatsEndpointTest(APITestCase):
                         workflow=self.workflow,
                         group=self.group,
                         date_added=before_now(hours=i + 1),
+                        is_single_written=True,
                     )
                 )
 
@@ -37,6 +38,7 @@ class WorkflowStatsEndpointTest(APITestCase):
                     workflow=self.workflow_2,
                     group=self.group,
                     date_added=before_now(hours=i + 1),
+                    is_single_written=True,
                 )
             )
 

--- a/tests/sentry/workflow_engine/endpoints/test_serializers.py
+++ b/tests/sentry/workflow_engine/endpoints/test_serializers.py
@@ -547,6 +547,7 @@ class WorkflowGroupsPaginatedTest(TestCase):
                     workflow=self.workflow,
                     group=self.group,
                     event_id=uuid4().hex,
+                    is_single_written=True,
                 )
             )
         self.group_2 = self.create_group()
@@ -560,6 +561,7 @@ class WorkflowGroupsPaginatedTest(TestCase):
                 workflow=self.workflow,
                 group=self.group_2,
                 event_id=uuid4().hex,
+                is_single_written=True,
             )
         )
         self.group_3 = self.create_group()
@@ -574,8 +576,17 @@ class WorkflowGroupsPaginatedTest(TestCase):
                     workflow=self.workflow,
                     group=self.group_3,
                     event_id=uuid4().hex,
+                    is_single_written=True,
                 )
             )
+        # dual written WFH is ignored
+        WorkflowFireHistory.objects.create(
+            detector=self.detector_3,
+            workflow=self.workflow,
+            group=self.group_3,
+            event_id=uuid4().hex,
+            is_single_written=False,
+        )
         # this will be ordered after the WFH with self.detector_1
         self.detector_4 = self.create_detector(
             project_id=self.project.id,
@@ -588,6 +599,7 @@ class WorkflowGroupsPaginatedTest(TestCase):
                 workflow=self.workflow_2,
                 group=self.group,
                 event_id=uuid4().hex,
+                is_single_written=True,
             )
         )
 
@@ -759,6 +771,7 @@ class WorkflowHourlyStatsTest(TestCase):
                     WorkflowFireHistory(
                         workflow=self.workflow,
                         group=self.group,
+                        is_single_written=True,
                     )
                 )
 
@@ -768,8 +781,16 @@ class WorkflowHourlyStatsTest(TestCase):
                 WorkflowFireHistory(
                     workflow=self.workflow_2,
                     group=self.group,
+                    is_single_written=True,
                 )
             )
+
+        # dual written WFH is ignored
+        WorkflowFireHistory.objects.create(
+            workflow=self.workflow_2,
+            group=self.group,
+            is_single_written=False,
+        )
 
         histories: list[WorkflowFireHistory] = WorkflowFireHistory.objects.bulk_create(self.history)
 


### PR DESCRIPTION
For the workflow group history and stats endpoints, we should only be showing users information that has actually completely passed through workflow engine, and this is only the case when `is_single_written=True`.