### PR TITLE
ref(explore): Require traceItemType in useGroupByFields

### DIFF
--- a/static/app/views/explore/components/attributeDetails.tsx
+++ b/static/app/views/explore/components/attributeDetails.tsx
@@ -5,15 +5,22 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {FieldKind} from 'sentry/utils/fields';
 import {getFieldDefinition} from 'sentry/utils/fields';
+import {TraceItemDataset} from 'sentry/views/explore/types';
 
 interface AttributeDetailsProps {
   column: string;
   kind: FieldKind;
   label: ReactNode;
-  type: 'span';
+  traceItemType: TraceItemDataset;
 }
 
-export function AttributeDetails({column, kind, label, type}: AttributeDetailsProps) {
+export function AttributeDetails({
+  column,
+  kind,
+  label,
+  traceItemType,
+}: AttributeDetailsProps) {
+  const type = traceItemTypeToType(traceItemType);
   const definition = getFieldDefinition(column, type, kind);
   const description = definition?.desc ?? t('An attribute sent with one or more events');
   return (
@@ -22,6 +29,18 @@ export function AttributeDetails({column, kind, label, type}: AttributeDetailsPr
       <DetailsDescription>{description}</DetailsDescription>
     </Details>
   );
+}
+
+function traceItemTypeToType(traceItemType: TraceItemDataset): 'span' | 'log' {
+  if (traceItemType === TraceItemDataset.SPANS) {
+    return 'span' as const;
+  }
+
+  if (traceItemType === TraceItemDataset.LOGS) {
+    return 'log' as const;
+  }
+
+  throw new Error('Cannot convert unknown trace item type to type');
 }
 
 const Details = styled('div')`

--- a/static/app/views/explore/hooks/useGroupByFields.tsx
+++ b/static/app/views/explore/hooks/useGroupByFields.tsx
@@ -8,6 +8,7 @@ import {FieldKind} from 'sentry/utils/fields';
 import {AttributeDetails} from 'sentry/views/explore/components/attributeDetails';
 import {TypeBadge} from 'sentry/views/explore/components/typeBadge';
 import {UNGROUPED} from 'sentry/views/explore/contexts/pageParamsContext/groupBys';
+import {TraceItemDataset} from 'sentry/views/explore/types';
 
 interface UseGroupByFieldsProps {
   /**
@@ -16,12 +17,14 @@ interface UseGroupByFieldsProps {
    */
   groupBys: string[];
   tags: TagCollection;
+  traceItemType: TraceItemDataset;
   hideEmptyOption?: boolean;
 }
 
 export function useGroupByFields({
   tags,
   groupBys,
+  traceItemType,
   hideEmptyOption,
 }: UseGroupByFieldsProps) {
   const options: Array<SelectOption<string>> = useMemo(() => {
@@ -56,11 +59,18 @@ export function useGroupByFields({
           textValue: key,
           trailingItems: <TypeBadge kind={kind} />,
           showDetailsInOverlay: true,
-          details: <AttributeDetails column={key} kind={kind} label={key} type="span" />,
+          details: (
+            <AttributeDetails
+              column={key}
+              kind={kind}
+              label={key}
+              traceItemType={traceItemType}
+            />
+          ),
         };
       }),
     ];
-  }, [tags, groupBys, hideEmptyOption]);
+  }, [tags, groupBys, hideEmptyOption, traceItemType]);
 
   return options;
 }

--- a/static/app/views/explore/hooks/useVisualizeFields.tsx
+++ b/static/app/views/explore/hooks/useVisualizeFields.tsx
@@ -13,6 +13,7 @@ import {
 } from 'sentry/utils/fields';
 import {AttributeDetails} from 'sentry/views/explore/components/attributeDetails';
 import {TypeBadge} from 'sentry/views/explore/components/typeBadge';
+import {TraceItemDataset} from 'sentry/views/explore/types';
 import {SpanFields} from 'sentry/views/insights/types';
 
 interface UseVisualizeFieldsProps {
@@ -71,7 +72,12 @@ export function useVisualizeFields({
           trailingItems: <TypeBadge kind={kind} />,
           showDetailsInOverlay: true,
           details: (
-            <AttributeDetails column={option} kind={kind} label={label} type="span" />
+            <AttributeDetails
+              column={option}
+              kind={kind}
+              label={label}
+              traceItemType={TraceItemDataset.SPANS}
+            />
           ),
         };
       }),
@@ -83,7 +89,12 @@ export function useVisualizeFields({
           trailingItems: <TypeBadge kind={kind} />,
           showDetailsInOverlay: true,
           details: (
-            <AttributeDetails column={tag.key} kind={kind} label={tag.name} type="span" />
+            <AttributeDetails
+              column={tag.key}
+              kind={kind}
+              label={tag.name}
+              traceItemType={TraceItemDataset.SPANS}
+            />
           ),
         };
       }),

--- a/static/app/views/explore/multiQueryMode/queryConstructors/groupBy.tsx
+++ b/static/app/views/explore/multiQueryMode/queryConstructors/groupBy.tsx
@@ -14,6 +14,7 @@ import {
   SectionHeader,
   SectionLabel,
 } from 'sentry/views/explore/multiQueryMode/queryConstructors/styles';
+import {TraceItemDataset} from 'sentry/views/explore/types';
 
 type Props = {index: number; query: ReadableExploreQueryParts};
 
@@ -25,6 +26,7 @@ export function GroupBySection({query, index}: Props) {
   const enabledOptions: Array<SelectOption<string>> = useGroupByFields({
     groupBys: [],
     tags,
+    traceItemType: TraceItemDataset.SPANS,
     hideEmptyOption: true,
   });
 

--- a/static/app/views/explore/tables/aggregateColumnEditorModal.tsx
+++ b/static/app/views/explore/tables/aggregateColumnEditorModal.tsx
@@ -51,6 +51,7 @@ import type {Column} from 'sentry/views/explore/hooks/useDragNDropColumns';
 import {useExploreSuggestedAttribute} from 'sentry/views/explore/hooks/useExploreSuggestedAttribute';
 import {useGroupByFields} from 'sentry/views/explore/hooks/useGroupByFields';
 import {useVisualizeFields} from 'sentry/views/explore/hooks/useVisualizeFields';
+import {TraceItemDataset} from 'sentry/views/explore/types';
 
 interface AggregateColumnEditorModalProps extends ModalRenderProps {
   columns: AggregateField[];
@@ -255,6 +256,7 @@ function GroupBySelector({
   const options: Array<SelectOption<string>> = useGroupByFields({
     groupBys,
     tags: stringTags,
+    traceItemType: TraceItemDataset.SPANS,
   });
 
   const label = useMemo(() => {

--- a/static/app/views/explore/tables/columnEditorModal.tsx
+++ b/static/app/views/explore/tables/columnEditorModal.tsx
@@ -22,6 +22,7 @@ import {AttributeDetails} from 'sentry/views/explore/components/attributeDetails
 import {TypeBadge} from 'sentry/views/explore/components/typeBadge';
 import {DragNDropContext} from 'sentry/views/explore/contexts/dragNDropContext';
 import type {Column} from 'sentry/views/explore/hooks/useDragNDropColumns';
+import {TraceItemDataset} from 'sentry/views/explore/types';
 
 interface ColumnEditorModalProps extends ModalRenderProps {
   columns: string[];
@@ -64,7 +65,12 @@ export function ColumnEditorModal({
             key: `${column}-${classifyTagKey(column)}`,
             showDetailsInOverlay: true,
             details: (
-              <AttributeDetails column={column} kind={kind} label={label} type="span" />
+              <AttributeDetails
+                column={column}
+                kind={kind}
+                label={label}
+                traceItemType={TraceItemDataset.SPANS}
+              />
             ),
           };
         }),
@@ -81,7 +87,7 @@ export function ColumnEditorModal({
               column={tag.key}
               kind={FieldKind.TAG}
               label={tag.name}
-              type="span"
+              traceItemType={TraceItemDataset.SPANS}
             />
           ),
         };
@@ -99,7 +105,7 @@ export function ColumnEditorModal({
               column={tag.key}
               kind={FieldKind.TAG}
               label={tag.name}
-              type="span"
+              traceItemType={TraceItemDataset.SPANS}
             />
           ),
         };

--- a/static/app/views/explore/toolbar/index.tsx
+++ b/static/app/views/explore/toolbar/index.tsx
@@ -16,6 +16,7 @@ import {useTraceItemTags} from 'sentry/views/explore/contexts/spanTagsContext';
 import {useGroupByFields} from 'sentry/views/explore/hooks/useGroupByFields';
 import {ToolbarSaveAs} from 'sentry/views/explore/toolbar/toolbarSaveAs';
 import {ToolbarSortBy} from 'sentry/views/explore/toolbar/toolbarSortBy';
+import {TraceItemDataset} from 'sentry/views/explore/types';
 
 type Extras = 'equations';
 
@@ -43,7 +44,11 @@ export function ExploreToolbar({extras, width}: ExploreToolbarProps) {
     },
     [_setGroupBys]
   );
-  const options: Array<SelectOption<string>> = useGroupByFields({groupBys, tags});
+  const options: Array<SelectOption<string>> = useGroupByFields({
+    groupBys,
+    tags,
+    traceItemType: TraceItemDataset.SPANS,
+  });
 
   return (
     <Container width={width}>


### PR DESCRIPTION
This will be used by logs soon so it needs to be able to switch between spans and logs.