### PR TITLE
chore(deletions): Bump Group deletion task expiration

### DIFF
--- a/src/sentry/taskworker/namespaces.py
+++ b/src/sentry/taskworker/namespaces.py
@@ -21,7 +21,7 @@ crons_tasks = taskregistry.create_namespace("crons", app_feature="crons")
 
 deletion_tasks = taskregistry.create_namespace(
     "deletions",
-    processing_deadline_duration=60 * 6,
+    processing_deadline_duration=60 * 10,
     app_feature="shared",
 )
 


### PR DESCRIPTION
Fixes [SENTRY-48X9](https://sentry.sentry.io/issues/6770482833/)