### PR TITLE
fix(tasks) Provide custom sampling context for taskworker

### DIFF
--- a/src/sentry/taskworker/workerchild.py
+++ b/src/sentry/taskworker/workerchild.py
@@ -344,13 +344,18 @@ def child_process(
             name=activation.taskname,
             origin="taskworker",
         )
+        sampling_context = {
+            "taskworker": {
+                "task": activation.taskname,
+            }
+        }
         with (
             track_memory_usage(
                 "taskworker.worker.memory_change",
                 tags={"namespace": activation.namespace, "taskname": activation.taskname},
             ),
             sentry_sdk.isolation_scope(),
-            sentry_sdk.start_transaction(transaction),
+            sentry_sdk.start_transaction(transaction, custom_sampling_context=sampling_context),
         ):
             transaction.set_data(
                 "taskworker-task", {"args": args, "kwargs": kwargs, "id": activation.id}

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -198,6 +198,12 @@ def traces_sampler(sampling_context):
         if task_name in SAMPLED_TASKS:
             return SAMPLED_TASKS[task_name]
 
+    if "taskworker" in sampling_context:
+        task_name = sampling_context["taskworker"].get("task")
+
+        if task_name in SAMPLED_TASKS:
+            return SAMPLED_TASKS[task_name]
+
     # Default to the sampling rate in settings
     return float(settings.SENTRY_BACKEND_APM_SAMPLING or 0)
 


### PR DESCRIPTION
When reading through our SDK configuration code, I noticed that we had implemented custom sampling rates for tasks. This change should make the same sampling rates apply to taskworker tasks.
