### PR TITLE
chore(eco): Adds additional logging to help debug missing token install issues

### DIFF
--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -267,9 +267,10 @@ class OAuthLoginView:
 
         pipeline.bind_state("request_token", request_token)
         if not request_token.get("oauth_token"):
+            data_keys = list(request_token.keys())
             logger.info(
                 "identity.jira-server.oauth-token",
-                extra={"url": config.get("url")},
+                extra={"url": config.get("url"), "data_keys": data_keys},
             )
             return pipeline.error("Missing oauth_token")
 


### PR DESCRIPTION
In some select cases, customers are experiencing errors stating "Missing OAuth Token" in the response they receive when attempting to install Jira Server.

This will log out the response body keys we receive when this error occurs.
