### PR TITLE
chore(alerts): remove apdex from alert presets

### DIFF
--- a/static/app/views/alerts/rules/metric/wizardField.tsx
+++ b/static/app/views/alerts/rules/metric/wizardField.tsx
@@ -101,10 +101,6 @@ export default function WizardField({
       value: 'trace_item_duration',
     },
     {
-      label: AlertWizardAlertNames.trace_item_apdex,
-      value: 'trace_item_apdex',
-    },
-    {
       label: AlertWizardAlertNames.trace_item_failure_rate,
       value: 'trace_item_failure_rate',
     },

--- a/static/app/views/alerts/rules/utils.tsx
+++ b/static/app/views/alerts/rules/utils.tsx
@@ -223,7 +223,6 @@ export function isEapAlertType(alertType?: AlertType) {
     'eap_metrics',
     'trace_item_throughput',
     'trace_item_duration',
-    'trace_item_apdex',
     'trace_item_failure_rate',
     'trace_item_lcp',
     'trace_item_logs',

--- a/static/app/views/alerts/wizard/options.tsx
+++ b/static/app/views/alerts/wizard/options.tsx
@@ -48,7 +48,6 @@ export type AlertType =
   | 'eap_metrics'
   | 'trace_item_throughput'
   | 'trace_item_duration'
-  | 'trace_item_apdex'
   | 'trace_item_failure_rate'
   | 'trace_item_lcp'
   | 'trace_item_logs';
@@ -102,7 +101,6 @@ export const AlertWizardAlertNames: Record<AlertType, string> = {
   uptime_monitor: t('Uptime Monitor'),
   trace_item_throughput: t('Throughput'),
   trace_item_duration: t('Duration'),
-  trace_item_apdex: t('Apdex'),
   trace_item_failure_rate: t('Failure Rate'),
   trace_item_lcp: t('Largest Contentful Paint'),
   eap_metrics: t('Spans'),
@@ -151,7 +149,6 @@ export const getAlertWizardCategories = (org: Organization) => {
     const traceItemAggregationOptions: AlertType[] = [
       'trace_item_throughput',
       'trace_item_duration',
-      'trace_item_apdex',
       'trace_item_failure_rate',
       'trace_item_lcp',
     ];
@@ -276,11 +273,6 @@ export const AlertWizardRuleTemplates: Record<
   },
   trace_item_duration: {
     aggregate: 'p95(span.duration)',
-    dataset: Dataset.EVENTS_ANALYTICS_PLATFORM,
-    eventTypes: EventTypes.TRACE_ITEM_SPAN,
-  },
-  trace_item_apdex: {
-    aggregate: 'apdex(300)',
     dataset: Dataset.EVENTS_ANALYTICS_PLATFORM,
     eventTypes: EventTypes.TRACE_ITEM_SPAN,
   },

--- a/static/app/views/alerts/wizard/panelContent.tsx
+++ b/static/app/views/alerts/wizard/panelContent.tsx
@@ -199,14 +199,6 @@ export const AlertWizardPanelContent: Record<AlertType, PanelContent> = {
     ],
     illustration: diagramTransactionDuration,
   },
-  trace_item_apdex: {
-    description: t(
-      'Apdex is a metric used to track and measure user satisfaction based on your application response times. The Apdex score provides the ratio of satisfactory, tolerable, and frustrated requests in a specific endpoint.'
-    ),
-    examples: [t('When apdex is below 300.')],
-    docsLink: 'https://docs.sentry.io/product/performance/metrics/#apdex',
-    illustration: diagramApdex,
-  },
   trace_item_failure_rate: {
     description: t(
       'Failure rate is the percentage of unsuccessful spans. Sentry treats spans with a status other than “ok,” “canceled,” and “unknown” as failures.'

--- a/static/app/views/alerts/wizard/utils.tsx
+++ b/static/app/views/alerts/wizard/utils.tsx
@@ -47,7 +47,6 @@ const alertTypeIdentifiers: Record<
   [Dataset.EVENTS_ANALYTICS_PLATFORM]: {
     trace_item_throughput: 'count(span.duration)',
     trace_item_duration: 'span.duration',
-    trace_item_apdex: 'apdex',
     trace_item_failure_rate: 'failure_rate()',
     trace_item_lcp: 'measurements.lcp',
   },


### PR DESCRIPTION
We don't want to expose apdex as part of the EAP alerts set.

[ENG-4639](https://linear.app/getsentry/issue/ENG-4639/apdex-alerts)