### PR TITLE
ref(explore): Require traceItemType in useVisualizeFields

### DIFF
--- a/static/app/views/explore/components/toolbar/toolbarVisualize/index.tsx
+++ b/static/app/views/explore/components/toolbar/toolbarVisualize/index.tsx
@@ -19,15 +19,18 @@ import {
   MAX_VISUALIZES,
   Visualize,
 } from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
+import {TraceItemDataset} from 'sentry/views/explore/types';
 
 interface ToolbarVisualizeProps {
   setVisualizes: (visualizes: BaseVisualize[]) => void;
+  traceItemType: TraceItemDataset;
   visualizes: Visualize[];
   allowEquations?: boolean;
 }
 
 export function ToolbarVisualize({
   setVisualizes,
+  traceItemType,
   visualizes,
   allowEquations = false,
 }: ToolbarVisualizeProps) {
@@ -100,6 +103,7 @@ export function ToolbarVisualize({
             onDelete={() => onDelete(group)}
             onReplace={newVisualize => replaceOverlay(group, newVisualize)}
             visualize={visualize}
+            traceItemType={traceItemType}
           />
         );
       })}

--- a/static/app/views/explore/components/toolbar/toolbarVisualize/visualizeDropdown.tsx
+++ b/static/app/views/explore/components/toolbar/toolbarVisualize/visualizeDropdown.tsx
@@ -16,11 +16,13 @@ import {
 } from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
 import {useTraceItemTags} from 'sentry/views/explore/contexts/spanTagsContext';
 import {useVisualizeFields} from 'sentry/views/explore/hooks/useVisualizeFields';
+import {TraceItemDataset} from 'sentry/views/explore/types';
 
 interface VisualizeDropdownProps {
   canDelete: boolean;
   onDelete: () => void;
   onReplace: (visualize: BaseVisualize) => void;
+  traceItemType: TraceItemDataset;
   visualize: Visualize;
 }
 
@@ -29,6 +31,7 @@ export function VisualizeDropdown({
   onDelete,
   onReplace,
   visualize,
+  traceItemType,
 }: VisualizeDropdownProps) {
   const {tags: stringTags} = useTraceItemTags('string');
   const {tags: numberTags} = useTraceItemTags('number');
@@ -49,6 +52,7 @@ export function VisualizeDropdown({
     numberTags,
     stringTags,
     parsedFunction,
+    traceItemType,
   });
 
   const setYAxis = useCallback(

--- a/static/app/views/explore/hooks/useVisualizeFields.spec.tsx
+++ b/static/app/views/explore/hooks/useVisualizeFields.spec.tsx
@@ -41,6 +41,7 @@ function useWrapper(yAxis: string) {
     numberTags,
     stringTags,
     parsedFunction: parseFunction(yAxis) ?? undefined,
+    traceItemType: TraceItemDataset.SPANS,
   });
 }
 

--- a/static/app/views/explore/multiQueryMode/queryConstructors/visualize.tsx
+++ b/static/app/views/explore/multiQueryMode/queryConstructors/visualize.tsx
@@ -21,6 +21,7 @@ import {
   SectionHeader,
   SectionLabel,
 } from 'sentry/views/explore/multiQueryMode/queryConstructors/styles';
+import {TraceItemDataset} from 'sentry/views/explore/types';
 
 type Props = {
   index: number;
@@ -37,6 +38,7 @@ export function VisualizeSection({query, index}: Props) {
     numberTags,
     stringTags,
     parsedFunction,
+    traceItemType: TraceItemDataset.SPANS,
   });
 
   const updateYAxis = useUpdateQueryAtIndex(index);

--- a/static/app/views/explore/tables/aggregateColumnEditorModal.tsx
+++ b/static/app/views/explore/tables/aggregateColumnEditorModal.tsx
@@ -328,6 +328,7 @@ function AggregateSelector({
     numberTags,
     stringTags,
     parsedFunction,
+    traceItemType: TraceItemDataset.SPANS,
   });
 
   const handleFunctionChange = useCallback(

--- a/static/app/views/explore/toolbar/index.tsx
+++ b/static/app/views/explore/toolbar/index.tsx
@@ -55,6 +55,7 @@ export function ExploreToolbar({extras, width}: ExploreToolbarProps) {
       <ToolbarVisualize
         visualizes={visualizes}
         setVisualizes={setVisualizes}
+        traceItemType={TraceItemDataset.SPANS}
         allowEquations={extras?.includes('equations') || false}
       />
       <ToolbarGroupBy


### PR DESCRIPTION
To support using the visualize component in logs, this requires traceItemType to be provided so it can be used by spans and logs.