### PR TITLE
chore(auth): add cache key check and logs for idp verification flow

### DIFF
--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -505,7 +505,7 @@ class AuthIdentityHandler:
                 },
             )
 
-        has_verified_email = cache.get(f"{SSO_VERIFICATION_KEY}:{self.user.id}")
+        has_verified_email = self.user.id and cache.get(f"{SSO_VERIFICATION_KEY}:{self.user.id}")
         if has_verified_email and not verification_key:
             logger.info(
                 "sso.login-pipeline.verified-email-missing-session-key",

--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -27,6 +27,7 @@ from sentry.audit_log.services.log import AuditLogEvent, log_service
 from sentry.auth.email import AmbiguousUserFromEmail, resolve_email_to_user
 from sentry.auth.exceptions import IdentityNotValid
 from sentry.auth.idpmigration import (
+    SSO_VERIFICATION_KEY,
     get_verification_value_from_key,
     send_one_time_account_confirm_link,
 )
@@ -54,6 +55,7 @@ from sentry.tasks.auth.auth import email_missing_links_control
 from sentry.users.models.user import User
 from sentry.utils import auth, metrics
 from sentry.utils.audit import create_audit_entry
+from sentry.utils.cache import cache
 from sentry.utils.hashlib import md5_text
 from sentry.utils.http import absolute_uri
 from sentry.utils.retries import TimedRetryPolicy
@@ -489,28 +491,29 @@ class AuthIdentityHandler:
 
         # we don't trust all IDP email verification, so users can also confirm via one time email link
         is_account_verified = False
-        if self.request.session.get("confirm_account_verification_key"):
-            verification_key = self.request.session["confirm_account_verification_key"]
+        if verification_key := self.request.session.get(SSO_VERIFICATION_KEY):
             verification_value = get_verification_value_from_key(verification_key)
             if verification_value:
                 is_account_verified = self.has_verified_account(verification_value)
-                if not is_account_verified:
-                    logger.info(
-                        "sso.login-pipeline.verification-mismatch",
-                        extra={
-                            "verification_user_id": verification_value["user_id"],
-                            "user_id": self.user.id,
-                            "request_user_id": self.request.user.id,
-                        },
-                    )
-            else:
-                logger.info(
-                    "sso.login-pipeline.missing-verification",
-                    extra={
-                        "user_id": self.user.id,
-                        "request_user_id": self.request.user.id,
-                    },
-                )
+
+            logger.info(
+                "sso.login-pipeline.verified-email-existing-session-key",
+                extra={
+                    "user_id": self.user.id,
+                    "organization_id": self.organization.id,
+                    "has_verification_value": bool(verification_value),
+                },
+            )
+
+        has_verified_email = cache.get(f"{SSO_VERIFICATION_KEY}:{self.user.id}")
+        if has_verified_email and not verification_key:
+            logger.info(
+                "sso.login-pipeline.verified-email-missing-session-key",
+                extra={
+                    "user_id": self.user.id,
+                    "organization_id": self.organization.id,
+                },
+            )
 
         is_new_account = not self.user.is_authenticated  # stateful
         if self._app_user and (self.identity.get("email_verified") or is_account_verified):


### PR DESCRIPTION
We expect `SSO_VERIFICATION_KEY` to be set on` request.session` after a user without a password verifies their email. This session key is then checked in the login flow and we should be prompting them to attach their identity. However, after viewing somebody go through this flow and NOT hit the attach identity screen, this clearly sometimes doesn't happen (possibly when being redirected to an IDP such as Okta to complete login?).

My current hunch is that a cache would solve this problem, but I will add logs in this area + store in cache whether a user confirms their email to inform the logs.