### PR TITLE
fix(globalselection): Add tooltips to all items in project selector

### DIFF
--- a/static/app/components/organizations/projectPageFilter/index.tsx
+++ b/static/app/components/organizations/projectPageFilter/index.tsx
@@ -281,7 +281,7 @@ export function ProjectPageFilter({
               borderless
               size="zero"
               icon={<IconOpen />}
-              aria-label={t('Project Details')}
+              title={t('Project Details')}
               to={
                 makeProjectsPathname({
                   path: `/${project.slug}/`,
@@ -294,7 +294,7 @@ export function ProjectPageFilter({
               borderless
               size="zero"
               icon={<IconSettings />}
-              aria-label={t('Project Settings')}
+              title={t('Project Settings')}
               to={`/settings/${organization.slug}/projects/${project.slug}/`}
               visible={isFocused}
             />

--- a/static/app/components/organizations/projectPageFilter/index.tsx
+++ b/static/app/components/organizations/projectPageFilter/index.tsx
@@ -282,6 +282,7 @@ export function ProjectPageFilter({
               size="zero"
               icon={<IconOpen />}
               title={t('Project Details')}
+              aria-label={t('Project Details')}
               to={
                 makeProjectsPathname({
                   path: `/${project.slug}/`,
@@ -295,6 +296,7 @@ export function ProjectPageFilter({
               size="zero"
               icon={<IconSettings />}
               title={t('Project Settings')}
+              aria-label={t('Project Settings')}
               to={`/settings/${organization.slug}/projects/${project.slug}/`}
               visible={isFocused}
             />


### PR DESCRIPTION
adds missing tooltips from settings / details link so all items have a tooltip

<img width="420" height="228" alt="image" src="https://github.com/user-attachments/assets/561ec01b-ddff-403c-8981-6501f964e351" />
