### PR TITLE
chore(tasks) Remove autoreload option from taskworker

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -289,7 +289,7 @@ x-programs:
   devserver:
     command: sentry devserver
   taskworker:
-    command: sentry run taskworker --autoreload
+    command: sentry run taskworker
   taskworker-scheduler:
     command: sentry run taskworker-scheduler
   ingest-events:

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -287,7 +287,6 @@ def taskworker_scheduler(redis_cluster: str, **options: Any) -> None:
 @click.option(
     "--num-brokers", help="Number of brokers available to connect to", default=None, type=int
 )
-@click.option("--autoreload", is_flag=True, default=False, help="Enable autoreloading.")
 @click.option(
     "--max-child-task-count",
     help="Number of tasks child processes execute before being restart",
@@ -324,10 +323,8 @@ def taskworker(**options: Any) -> None:
     Run a taskworker worker
     """
     os.environ["GRPC_ENABLE_FORK_SUPPORT"] = "0"
-    if options["autoreload"]:
-        autoreload.run_with_reloader(run_taskworker, **options)
-    else:
-        run_taskworker(**options)
+    # TODO(mark) restore autoreload
+    run_taskworker(**options)
 
 
 def run_taskworker(


### PR DESCRIPTION
Since we implemented signal handlers for SIGTERM/SIGINT --autoreload has not worked as autoreload runs the worker in non-main thread where signals handlers cannot be registered. Removing `--autoreload` lets `devservices foreground taskworker` work again.

I'll revisit autoreload in the future when I figure out how to get it to play nicely with multiprocessing.
