### PR TITLE
fix(issues): Display `>99%` instead of `100%`

### DIFF
--- a/static/app/views/issueDetails/groupTags/tagDetailsDrawerContent.spec.tsx
+++ b/static/app/views/issueDetails/groupTags/tagDetailsDrawerContent.spec.tsx
@@ -236,7 +236,7 @@ describe('TagDetailsDrawerContent', () => {
 
     // Value and percent columns
     expect(screen.getByText('David Cramer 0')).toBeInTheDocument();
-    expect(screen.getByText('100%')).toBeInTheDocument();
+    expect(screen.getByText('>99%')).toBeInTheDocument(); // 996/1000 = 99.6% rounds to 100%, should show >99%
     expect(screen.getByText('David Cramer 1')).toBeInTheDocument();
     expect(screen.getByText('<1%')).toBeInTheDocument();
 
@@ -294,16 +294,48 @@ describe('TagDetailsDrawerContent', () => {
     });
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
 
-    // Percents will be overcounted in this edge case.
+    // Fixed: No longer overcounts percentages - shows >99% instead of 100%
     // Value and percent columns
     expect(screen.getByText('David Cramer 0')).toBeInTheDocument();
-    expect(screen.getByText('100%')).toBeInTheDocument();
+    expect(screen.getByText('>99%')).toBeInTheDocument(); // Should be >99%, not 100%
     expect(screen.getByText('David Cramer 1')).toBeInTheDocument();
     expect(screen.getByText('1%')).toBeInTheDocument();
 
     // Count column
     expect(screen.getByText('995')).toBeInTheDocument();
     expect(screen.getByText('5')).toBeInTheDocument();
+  });
+
+  it('never displays 100% when there are multiple tag values', async () => {
+    const {router} = init('user');
+
+    // Create a case where first item would round to 100% (997/1000 = 99.7%)
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues/1/tags/user/',
+      body: VariableTagFixture([997, 3], 1000),
+    });
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues/1/tags/user/values/',
+      body: VariableTagValueFixture([997, 3]),
+    });
+
+    render(<TagDetailsDrawerContent group={group} />, {
+      router,
+      deprecatedRouterMocks: true,
+    });
+    await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
+
+    // Should show >99% instead of 100%
+    expect(screen.getByText('David Cramer 0')).toBeInTheDocument();
+    expect(screen.getByText('>99%')).toBeInTheDocument();
+    expect(screen.getByText('David Cramer 1')).toBeInTheDocument();
+    expect(screen.getByText('<1%')).toBeInTheDocument();
+    expect(screen.queryByText('100%')).not.toBeInTheDocument(); // Should never show 100%
+
+    // Count column
+    expect(screen.getByText('997')).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument();
   });
 });
 

--- a/static/app/views/issueDetails/groupTags/tagDetailsDrawerContent.spec.tsx
+++ b/static/app/views/issueDetails/groupTags/tagDetailsDrawerContent.spec.tsx
@@ -294,10 +294,9 @@ describe('TagDetailsDrawerContent', () => {
     });
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
 
-    // Fixed: No longer overcounts percentages - shows >99% instead of 100%
     // Value and percent columns
     expect(screen.getByText('David Cramer 0')).toBeInTheDocument();
-    expect(screen.getByText('>99%')).toBeInTheDocument(); // Should be >99%, not 100%
+    expect(screen.getByText('>99%')).toBeInTheDocument();
     expect(screen.getByText('David Cramer 1')).toBeInTheDocument();
     expect(screen.getByText('1%')).toBeInTheDocument();
 

--- a/static/app/views/issueDetails/groupTags/tagDetailsDrawerContent.tsx
+++ b/static/app/views/issueDetails/groupTags/tagDetailsDrawerContent.tsx
@@ -178,7 +178,15 @@ function TagDetailsRow({
     },
   };
   const percentage = Math.round(percent(tagValue.count ?? 0, tag.totalValues ?? 0));
-  const displayPercentage = percentage < 1 ? '<1%' : `${percentage.toFixed(0)}%`;
+  // Ensure no item shows 100% when there are multiple tag values
+  const hasMultipleItems = (tag.uniqueValues ?? 0) > 1;
+  const cappedPercentage = hasMultipleItems && percentage >= 100 ? 99 : percentage;
+  const displayPercentage =
+    cappedPercentage < 1
+      ? '<1%'
+      : hasMultipleItems && percentage >= 100
+        ? '>99%'
+        : `${cappedPercentage.toFixed(0)}%`;
 
   return (
     <Row>

--- a/static/app/views/issueDetails/groupTags/tagDistribution.spec.tsx
+++ b/static/app/views/issueDetails/groupTags/tagDistribution.spec.tsx
@@ -54,6 +54,33 @@ describe('TagDistribution', () => {
     expect(screen.getByText('Other')).toBeInTheDocument();
     expect(screen.getByText('<1%')).toBeInTheDocument();
   });
+
+  it('never displays 100% when there are multiple items', () => {
+    // 997/1000 = 99.7% which would round to 100%, but should be capped at 99%
+    render(<TagDistribution tag={TagFixture([997, 2, 1], 1000)} />);
+
+    expect(screen.getByText('Chrome0')).toBeInTheDocument();
+    expect(screen.getByText('>99%')).toBeInTheDocument(); // Should be >99%, not 100%
+    expect(screen.queryByText('100%')).not.toBeInTheDocument(); // Should never show 100%
+    expect(screen.getByText('Chrome1')).toBeInTheDocument();
+    expect(screen.getAllByText('<1%')).toHaveLength(2); // Chrome1 and Chrome2 both show <1%
+    expect(screen.getByText('Chrome2')).toBeInTheDocument();
+    expect(screen.queryByText('Other')).not.toBeInTheDocument(); // No other items
+  });
+
+  it('other section never displays 100% when there are visible items', () => {
+    // Create a case where visible items have very small percentages that round to 0%
+    // 1 + 1 + 1 = 3 visible (each 0.1% rounds to 0%), 997 other would be 100% but should show >99%
+    render(<TagDistribution tag={TagFixture([1, 1, 1], 1000)} />);
+
+    expect(screen.getByText('Chrome0')).toBeInTheDocument();
+    expect(screen.getAllByText('<1%')).toHaveLength(3); // Chrome0, Chrome1, Chrome2 all show <1%
+    expect(screen.getByText('Chrome1')).toBeInTheDocument();
+    expect(screen.getByText('Chrome2')).toBeInTheDocument();
+    expect(screen.getByText('Other')).toBeInTheDocument();
+    expect(screen.getByText('>99%')).toBeInTheDocument(); // Other should show >99%, not 100%
+    expect(screen.queryByText('100%')).not.toBeInTheDocument(); // Should never show 100%
+  });
 });
 
 function TagFixture(topValues: number[], totalValues: number): GroupTag {

--- a/static/app/views/issueDetails/groupTags/tagDistribution.tsx
+++ b/static/app/views/issueDetails/groupTags/tagDistribution.tsx
@@ -22,7 +22,11 @@ export function TagDistribution({tag}: {tag: GroupTag}) {
       0
     );
   const otherDisplayPercentage =
-    otherPercentage < 1 ? '<1%' : `${otherPercentage.toFixed(0)}%`;
+    otherPercentage < 1
+      ? '<1%'
+      : visibleTagValues.length > 0 && otherPercentage >= 100
+        ? '>99%'
+        : `${otherPercentage.toFixed(0)}%`;
 
   return (
     <TagPanel>
@@ -34,7 +38,16 @@ export function TagDistribution({tag}: {tag: GroupTag}) {
       <TagValueContent>
         {visibleTagValues.map((tagValue, tagValueIdx) => {
           const percentage = Math.round(percent(tagValue.count, tag.totalValues));
-          const displayPercentage = percentage < 1 ? '<1%' : `${percentage.toFixed(0)}%`;
+          // Ensure no item shows 100% when there are multiple items
+          const hasMultipleItems = tag.topValues.length > 1 || hasOther;
+          const cappedPercentage =
+            hasMultipleItems && percentage >= 100 ? 99 : percentage;
+          const displayPercentage =
+            cappedPercentage < 1
+              ? '<1%'
+              : hasMultipleItems && percentage >= 100
+                ? '>99%'
+                : `${cappedPercentage.toFixed(0)}%`;
           return (
             <TagValueRow key={tagValueIdx}>
               <Tooltip delay={300} title={tagValue.name} skipWrapper>


### PR DESCRIPTION
We were incorrectly rounding up to 100% which is impossible / confusing when there is more than one item

before
<img width="608" height="102" alt="image" src="https://github.com/user-attachments/assets/f5de61f2-968d-4b1d-b788-849eed760132" />

after
<img width="613" height="104" alt="image" src="https://github.com/user-attachments/assets/af57cfb5-5411-4ad9-b915-fc576bc2b3f0" />

fixes https://linear.app/getsentry/issue/ID-811/clarify-tag-definition-for-100percent-rounding-distinction