### PR TITLE
chore(billing): Clean up category-specific fields for PerCategoryOnDemandBudgetWithSpends

### DIFF
--- a/static/gsApp/components/navBillingStatus.spec.tsx
+++ b/static/gsApp/components/navBillingStatus.spec.tsx
@@ -204,9 +204,6 @@ describe('PrimaryNavigationQuotaExceeded', function () {
       },
       usedSpends: {},
       enabled: true,
-      attachmentSpendUsed: 0,
-      errorSpendUsed: 0,
-      transactionSpendUsed: 0,
     };
     SubscriptionStore.set(organization.slug, subscription);
     render(<PrimaryNavigationQuotaExceeded organization={organization} />);

--- a/static/gsApp/types/index.tsx
+++ b/static/gsApp/types/index.tsx
@@ -242,10 +242,6 @@ export type PerCategoryOnDemandBudget = {
 };
 
 type PerCategoryOnDemandBudgetWithSpends = PerCategoryOnDemandBudget & {
-  attachmentSpendUsed: number;
-  errorSpendUsed: number;
-  transactionSpendUsed: number;
-  // TODO(data categories): BIL-959
   usedSpends: Partial<Record<DataCategory, number>>;
 };
 

--- a/static/gsApp/views/amCheckout/steps/onDemandBudgets.spec.tsx
+++ b/static/gsApp/views/amCheckout/steps/onDemandBudgets.spec.tsx
@@ -320,9 +320,6 @@ describe('OnDemandBudgets AM Checkout', function () {
       onDemandBudgets: {
         enabled: false,
         budgetMode: OnDemandBudgetMode.PER_CATEGORY,
-        attachmentSpendUsed: 0,
-        errorSpendUsed: 0,
-        transactionSpendUsed: 0,
         usedSpends: {errors: 0, transactions: 0, attachments: 0, replays: 0},
         budgets: {errors: 1000, transactions: 2000, attachments: 3000},
       },

--- a/static/gsApp/views/onDemandBudgets/onDemandBudgets.spec.tsx
+++ b/static/gsApp/views/onDemandBudgets/onDemandBudgets.spec.tsx
@@ -235,9 +235,6 @@ describe('OnDemandBudgets', () => {
           replays: 0,
           monitorSeats: 0,
         },
-        attachmentSpendUsed: 0,
-        errorSpendUsed: 0,
-        transactionSpendUsed: 0,
         usedSpends: {},
       },
     });
@@ -380,9 +377,6 @@ describe('OnDemandBudgets', () => {
             attachments: 3000,
             monitorSeats: 4000,
           },
-          errorSpendUsed: 100,
-          transactionSpendUsed: 200,
-          attachmentSpendUsed: 300,
           usedSpends: {
             errors: 100,
             transactions: 200,
@@ -616,9 +610,6 @@ describe('OnDemandBudgets', () => {
           attachments: 3000,
           monitorSeats: 4000,
         },
-        attachmentSpendUsed: 0,
-        errorSpendUsed: 0,
-        transactionSpendUsed: 0,
         usedSpends: {},
       },
     });

--- a/static/gsApp/views/onDemandBudgets/utils.spec.tsx
+++ b/static/gsApp/views/onDemandBudgets/utils.spec.tsx
@@ -149,9 +149,6 @@ describe('parseOnDemandBudgetsFromSubscription', function () {
           profileDurationUI: 0,
           logBytes: 0,
         },
-        attachmentSpendUsed: 0,
-        errorSpendUsed: 0,
-        transactionSpendUsed: 0,
         usedSpends: {
           errors: 0,
           transactions: 0,
@@ -321,9 +318,6 @@ describe('getTotalBudget', function () {
         enabled: true,
         budgetMode: OnDemandBudgetMode.PER_CATEGORY,
         budgets: {errors: 100, transactions: 200, attachments: 300, uptime: 400},
-        attachmentSpendUsed: 0,
-        errorSpendUsed: 0,
-        transactionSpendUsed: 0,
         usedSpends: {errors: 0, transactions: 0, attachments: 0, replays: 0},
       },
     });

--- a/static/gsApp/views/subscriptionPage/onDemandSettings.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/onDemandSettings.spec.tsx
@@ -145,9 +145,6 @@ describe('edit on-demand budget', () => {
             attachments: 3000,
             monitorSeats: 4000,
           },
-          errorSpendUsed: 100,
-          transactionSpendUsed: 200,
-          attachmentSpendUsed: 300,
           usedSpends: {
             errors: 100,
             transactions: 200,
@@ -271,9 +268,6 @@ describe('edit on-demand budget', () => {
             replays: 300,
             monitorSeats: 200,
           },
-          errorSpendUsed: 76,
-          transactionSpendUsed: 0,
-          attachmentSpendUsed: 0,
           usedSpends: {
             errors: 76,
             transactions: 0,
@@ -365,9 +359,6 @@ describe('edit on-demand budget', () => {
           replays: 0,
           monitorSeats: 5000,
         },
-        attachmentSpendUsed: 0,
-        errorSpendUsed: 0,
-        transactionSpendUsed: 0,
         usedSpends: {},
       },
     });
@@ -562,9 +553,6 @@ describe('edit on-demand budget', () => {
           replays: 0,
           monitorSeats: 5000,
         },
-        attachmentSpendUsed: 0,
-        errorSpendUsed: 0,
-        transactionSpendUsed: 0,
         usedSpends: {},
       },
     });

--- a/static/gsApp/views/subscriptionPage/pendingChanges.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/pendingChanges.spec.tsx
@@ -393,9 +393,6 @@ describe('Subscription > PendingChanges', function () {
           transactions: 0,
           attachments: 0,
         },
-        attachmentSpendUsed: 0,
-        errorSpendUsed: 0,
-        transactionSpendUsed: 0,
         usedSpends: {},
       },
       pendingChanges: PendingChangesFixture({

--- a/static/gsApp/views/subscriptionPage/usageTotals.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/usageTotals.spec.tsx
@@ -1498,9 +1498,6 @@ describe('Subscription > CombinedUsageTotals', function () {
           [DataCategory.SEER_AUTOFIX]: 4,
           [DataCategory.SEER_SCANNER]: 5,
         },
-        attachmentSpendUsed: 0,
-        errorSpendUsed: 0,
-        transactionSpendUsed: 0,
         usedSpends: {
           [DataCategory.SEER_AUTOFIX]: 4,
           [DataCategory.SEER_SCANNER]: 5,


### PR DESCRIPTION
This PR just removes a couple fields from an interface and subsequently from some tests. They weren't used at all in the UI otherwise.

Closes https://linear.app/getsentry/issue/BIL-959/clean-up-category-specific-fields-for

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
