### PR TITLE
Add testsuites hook

### DIFF
--- a/static/app/components/codecov/container/codecovParamsProvider.tsx
+++ b/static/app/components/codecov/container/codecovParamsProvider.tsx
@@ -15,8 +15,8 @@ type CodecovQueryParamsProviderProps = {
 };
 
 const VALUES_TO_RESET_MAP = {
-  integratedOrgId: ['repository', 'branch'],
-  repository: ['branch'],
+  integratedOrgId: ['repository', 'branch', 'testSuites'],
+  repository: ['branch', 'testSuites'],
   branch: [],
   codecovPeriod: [],
 };

--- a/static/app/components/codecov/testSuiteDropdown/testSuiteDropdown.tsx
+++ b/static/app/components/codecov/testSuiteDropdown/testSuiteDropdown.tsx
@@ -100,7 +100,7 @@ export function TestSuiteDropdown() {
         const totalLength =
           (value[0]?.length ?? 0) + (value[1]?.length ?? 0) + (value[1] ? 2 : 0);
         const suitesToShow =
-          totalLength < MAX_SUITE_UI_LENGTH ? value.slice(0, 2) : value.slice(0, 1);
+          totalLength <= MAX_SUITE_UI_LENGTH ? value.slice(0, 2) : value.slice(0, 1);
         const enumeratedLabel = suitesToShow
           .map(env => trimSlug(env, MAX_SUITE_UI_LENGTH))
           .join(', ');

--- a/static/app/components/codecov/testSuiteDropdown/testSuiteDropdown.tsx
+++ b/static/app/components/codecov/testSuiteDropdown/testSuiteDropdown.tsx
@@ -1,6 +1,8 @@
-import {useCallback, useMemo} from 'react';
+import {useCallback, useEffect, useMemo, useState} from 'react';
 import {useSearchParams} from 'react-router-dom';
 import styled from '@emotion/styled';
+import debounce from 'lodash/debounce';
+import sortBy from 'lodash/sortBy';
 
 import {useTestSuites} from 'sentry/components/codecov/testSuiteDropdown/useTestSuites';
 import {Badge} from 'sentry/components/core/badge';
@@ -11,41 +13,71 @@ import {space} from 'sentry/styles/space';
 import {trimSlug} from 'sentry/utils/string/trimSlug';
 
 const TEST_SUITES = 'testSuites';
-const MAX_SUITE_UI_LENGTH = 22;
+const MAX_SUITE_UI_LENGTH = 50;
+const MAX_RECORD_LENGTH = 40;
 
 export function TestSuiteDropdown() {
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [dropdownSearch, setDropdownSearch] = useState<string>('');
+  const [urlSearchParams, setUrlSearchParams] = useSearchParams();
   const {data: testSuites} = useTestSuites();
 
   const handleChange = useCallback(
     (newTestSuites: string[]) => {
-      searchParams.delete(TEST_SUITES);
+      urlSearchParams.delete(TEST_SUITES);
 
       newTestSuites.forEach(suite => {
-        searchParams.append(TEST_SUITES, suite);
+        urlSearchParams.append(TEST_SUITES, suite);
       });
 
-      setSearchParams(searchParams);
+      setUrlSearchParams(urlSearchParams);
+      setDropdownSearch('');
     },
-    [searchParams, setSearchParams]
+    [urlSearchParams, setUrlSearchParams]
   );
 
-  const options = useMemo(
+  const options = useMemo(() => {
+    const selectedNames = urlSearchParams.getAll(TEST_SUITES);
+    const selectedSet = new Set(selectedNames.map(name => name.toLowerCase()));
+
+    const filtered = testSuites.filter(suite => {
+      const matchesSearch =
+        !dropdownSearch || suite.toLowerCase().includes(dropdownSearch.toLowerCase());
+      return matchesSearch || selectedSet.has(suite.toLowerCase());
+    });
+
+    const mapped = filtered.map(suite => ({
+      label: suite,
+      value: suite,
+      isSelected: selectedSet.has(suite.toLowerCase()),
+    }));
+
+    const sorted = sortBy(mapped, [option => !option.isSelected]);
+
+    return sorted.slice(0, MAX_RECORD_LENGTH);
+  }, [testSuites, dropdownSearch, urlSearchParams]);
+
+  const handleOnSearch = useMemo(
     () =>
-      testSuites?.map(suite => ({
-        value: suite,
-        label: suite,
-      })),
-    [testSuites]
+      debounce((value: string) => {
+        setDropdownSearch(value);
+      }, 500),
+    [setDropdownSearch]
   );
+
+  useEffect(() => {
+    // Create a use effect to cancel handleOnSearch fn on unmount to avoid memory leaks
+    return () => {
+      handleOnSearch.cancel();
+    };
+  }, [handleOnSearch]);
 
   /**
    * Validated values that only includes the currently available test suites
    */
   const value = useMemo(() => {
-    const urlTestSuites = searchParams.getAll(TEST_SUITES);
+    const urlTestSuites = urlSearchParams.getAll(TEST_SUITES);
     return urlTestSuites.filter(suite => testSuites?.includes(suite));
-  }, [searchParams, testSuites]);
+  }, [urlSearchParams, testSuites]);
 
   return (
     <HybridFilter
@@ -56,13 +88,14 @@ export function TestSuiteDropdown() {
       value={value}
       defaultValue={[]}
       onChange={handleChange}
+      onSearch={handleOnSearch}
       // TODO: Add the disabled and emptyMessage when connected to backend hook
       menuTitle={t('Filter Test Suites')}
       menuWidth={`${MAX_SUITE_UI_LENGTH}em`}
       trigger={triggerProps => {
         const areAllSuitesSelected =
           value.length === 0 || testSuites?.every(suite => value.includes(suite));
-        // Show 2 suites only if the combined string's length does not exceed 22.
+        // Show 2 suites only if the combined string's length does not exceed MAX_SUITE_UI_LENGTH.
         // Otherwise show only 1 test suite.
         const totalLength =
           (value[0]?.length ?? 0) + (value[1]?.length ?? 0) + (value[1] ? 2 : 0);

--- a/static/app/components/codecov/testSuiteDropdown/testSuiteDropdown.tsx
+++ b/static/app/components/codecov/testSuiteDropdown/testSuiteDropdown.tsx
@@ -2,6 +2,7 @@ import {useCallback, useMemo} from 'react';
 import {useSearchParams} from 'react-router-dom';
 import styled from '@emotion/styled';
 
+import {useTestSuites} from 'sentry/components/codecov/testSuiteDropdown/useTestSuites';
 import {Badge} from 'sentry/components/core/badge';
 import DropdownButton from 'sentry/components/dropdownButton';
 import {HybridFilter} from 'sentry/components/organizations/hybridFilter';
@@ -9,26 +10,19 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trimSlug} from 'sentry/utils/string/trimSlug';
 
-// TODO: have these come from the API
-const PLACEHOLDER_TEST_SUITES = [
-  'option 1',
-  'option 2',
-  'option 3',
-  'super-long-option-4',
-];
-
-const TEST_SUITE = 'testSuite';
+const TEST_SUITES = 'testSuites';
 const MAX_SUITE_UI_LENGTH = 22;
 
 export function TestSuiteDropdown() {
   const [searchParams, setSearchParams] = useSearchParams();
+  const {data: testSuites} = useTestSuites();
 
   const handleChange = useCallback(
     (newTestSuites: string[]) => {
-      searchParams.delete(TEST_SUITE);
+      searchParams.delete(TEST_SUITES);
 
       newTestSuites.forEach(suite => {
-        searchParams.append(TEST_SUITE, suite);
+        searchParams.append(TEST_SUITES, suite);
       });
 
       setSearchParams(searchParams);
@@ -38,20 +32,20 @@ export function TestSuiteDropdown() {
 
   const options = useMemo(
     () =>
-      PLACEHOLDER_TEST_SUITES.map(suite => ({
+      testSuites?.map(suite => ({
         value: suite,
         label: suite,
       })),
-    []
+    [testSuites]
   );
 
   /**
    * Validated values that only includes the currently available test suites
    */
   const value = useMemo(() => {
-    const urlTestSuites = searchParams.getAll(TEST_SUITE);
-    return urlTestSuites.filter(suite => PLACEHOLDER_TEST_SUITES.includes(suite));
-  }, [searchParams]);
+    const urlTestSuites = searchParams.getAll(TEST_SUITES);
+    return urlTestSuites.filter(suite => testSuites?.includes(suite));
+  }, [searchParams, testSuites]);
 
   return (
     <HybridFilter
@@ -67,8 +61,7 @@ export function TestSuiteDropdown() {
       menuWidth={`${MAX_SUITE_UI_LENGTH}em`}
       trigger={triggerProps => {
         const areAllSuitesSelected =
-          value.length === 0 ||
-          PLACEHOLDER_TEST_SUITES.every(suite => value.includes(suite));
+          value.length === 0 || testSuites?.every(suite => value.includes(suite));
         // Show 2 suites only if the combined string's length does not exceed 22.
         // Otherwise show only 1 test suite.
         const totalLength =

--- a/static/app/components/codecov/testSuiteDropdown/useTestSuites.tsx
+++ b/static/app/components/codecov/testSuiteDropdown/useTestSuites.tsx
@@ -1,0 +1,46 @@
+import {useMemo} from 'react';
+
+import {useCodecovContext} from 'sentry/components/codecov/context/codecovContext';
+import type {QueryKeyEndpointOptions} from 'sentry/utils/queryClient';
+import {useQuery} from 'sentry/utils/queryClient';
+import useApi from 'sentry/utils/useApi';
+import useOrganization from 'sentry/utils/useOrganization';
+
+type TestSuite = {
+  testSuites: string[];
+};
+
+type QueryKey = [url: string, endpointOptions: QueryKeyEndpointOptions];
+
+// export function useTestSuites({term}: {term?: string[] | null}) {
+export function useTestSuites() {
+  const api = useApi();
+  const organization = useOrganization();
+  const {integratedOrgId, repository} = useCodecovContext();
+  const term = null;
+
+  const {data, ...rest} = useQuery<TestSuite, Error, TestSuite, QueryKey>({
+    queryKey: [
+      `/organizations/${organization.slug}/prevent/owner/${integratedOrgId}/repository/${repository}/test-suites/`,
+      {query: {term}},
+    ],
+    queryFn: async ({queryKey: [url]}): Promise<TestSuite> => {
+      const result = await api.requestPromise(url, {
+        method: 'GET',
+        query: {},
+      });
+
+      return result as TestSuite;
+    },
+  });
+
+  const memoizedData = useMemo(() => {
+    return data?.testSuites || [];
+  }, [data]);
+
+  return {
+    data: memoizedData,
+    // TODO: only provide the values that we're interested in
+    ...rest,
+  };
+}

--- a/static/app/components/codecov/testSuiteDropdown/useTestSuites.tsx
+++ b/static/app/components/codecov/testSuiteDropdown/useTestSuites.tsx
@@ -12,17 +12,15 @@ type TestSuite = {
 
 type QueryKey = [url: string, endpointOptions: QueryKeyEndpointOptions];
 
-// export function useTestSuites({term}: {term?: string[] | null}) {
 export function useTestSuites() {
   const api = useApi();
   const organization = useOrganization();
   const {integratedOrgId, repository} = useCodecovContext();
-  const term = null;
 
   const {data, ...rest} = useQuery<TestSuite, Error, TestSuite, QueryKey>({
     queryKey: [
       `/organizations/${organization.slug}/prevent/owner/${integratedOrgId}/repository/${repository}/test-suites/`,
-      {query: {term}},
+      {query: {}},
     ],
     queryFn: async ({queryKey: [url]}): Promise<TestSuite> => {
       const result = await api.requestPromise(url, {
@@ -32,6 +30,7 @@ export function useTestSuites() {
 
       return result as TestSuite;
     },
+    enabled: !!(integratedOrgId && repository),
   });
 
   const memoizedData = useMemo(() => {

--- a/static/app/views/codecov/tests/queries/useGetTestResults.spec.tsx
+++ b/static/app/views/codecov/tests/queries/useGetTestResults.spec.tsx
@@ -16,6 +16,7 @@ const mockTestResultsResponse = {
     hasPreviousPage: false,
     startCursor: 'cursor000',
   },
+  defaultBranch: 'main',
   results: [
     {
       name: 'test_example_function',
@@ -48,6 +49,7 @@ const mockTestResultsResponse = {
 };
 
 const emptyTestResultsResponse = {
+  defaultBranch: 'another',
   pageInfo: {
     endCursor: null,
     hasNextPage: false,
@@ -113,13 +115,14 @@ describe('useInfiniteTestResults', () => {
       expect(result.current.isSuccess).toBe(true);
     });
 
-    expect(result.current.data).toHaveLength(2);
+    expect(result.current.data.testResults).toHaveLength(2);
     expect(result.current.totalCount).toBe(150);
     expect(result.current.startCursor).toBe('cursor000');
     expect(result.current.endCursor).toBe('cursor123');
 
     // Verifies that the data is transformed correctly
-    expect(result.current.data[0]).toEqual({
+    expect(result.current.data.defaultBranch).toBe('main');
+    expect(result.current.data.testResults[0]).toEqual({
       testName: 'test_example_function',
       averageDurationMs: 45, // avgDuration * 1000
       commitsFailed: 5,
@@ -173,7 +176,7 @@ describe('useInfiniteTestResults', () => {
       expect(result.current.isSuccess).toBe(true);
     });
 
-    expect(result.current.data).toHaveLength(2);
+    expect(result.current.data.testResults).toHaveLength(2);
     expect(result.current.totalCount).toBe(150);
     expect(result.current.hasNextPage).toBe(true);
   });
@@ -211,7 +214,7 @@ describe('useInfiniteTestResults', () => {
       expect(result.current.isSuccess).toBe(true);
     });
 
-    expect(result.current.data).toHaveLength(0);
+    expect(result.current.data.testResults).toHaveLength(0);
     expect(result.current.totalCount).toBe(0);
     expect(result.current.startCursor).toBeNull();
     expect(result.current.endCursor).toBeNull();
@@ -247,7 +250,7 @@ describe('useInfiniteTestResults', () => {
     });
 
     expect(result.current.error).toBeDefined();
-    expect(result.current.data).toHaveLength(0);
+    expect(result.current.data.testResults).toHaveLength(0);
     expect(result.current.totalCount).toBe(0);
   });
 
@@ -300,7 +303,7 @@ describe('useInfiniteTestResults', () => {
       expect(result.current.isSuccess).toBe(true);
     });
 
-    expect(result.current.data).toHaveLength(2);
+    expect(result.current.data.testResults).toHaveLength(2);
     expect(result.current.totalCount).toBe(150);
   });
 });

--- a/static/app/views/codecov/tests/queries/useGetTestResults.ts
+++ b/static/app/views/codecov/tests/queries/useGetTestResults.ts
@@ -77,6 +77,7 @@ export function useInfiniteTestResults({
   const signedSortBy = sortValueToSortKey(sortBy);
 
   const term = searchParams.get('term') || '';
+  const testSuites = searchParams.get('testSuites') || null;
 
   const filterBy = searchParams.get('filterBy') as SummaryFilterKey;
   let mappedFilterBy = null;
@@ -101,6 +102,7 @@ export function useInfiniteTestResults({
           term,
           cursor,
           navigation,
+          testSuites,
         },
       },
     ],
@@ -123,6 +125,7 @@ export function useInfiniteTestResults({
               branch,
               term,
               ...(mappedFilterBy ? {filterBy: mappedFilterBy} : {}),
+              ...(testSuites ? {testSuites} : {}),
               ...(cursor ? {cursor} : {}),
               ...(navigation ? {navigation} : {}),
             },

--- a/static/app/views/codecov/tests/queries/useGetTestResults.ts
+++ b/static/app/views/codecov/tests/queries/useGetTestResults.ts
@@ -78,7 +78,9 @@ export function useInfiniteTestResults({
   const signedSortBy = sortValueToSortKey(sortBy);
 
   const term = searchParams.get('term') || '';
-  const testSuites = searchParams.getAll('testSuites') || null;
+  const testSuites = searchParams.has('testSuites')
+    ? searchParams.getAll('testSuites')
+    : null;
 
   const filterBy = searchParams.get('filterBy') as SummaryFilterKey;
   let mappedFilterBy = null;
@@ -185,7 +187,7 @@ export function useInfiniteTestResults({
   return {
     data: {
       testResults: memoizedData,
-      defaultBranch: data?.pages?.[0]?.[0].defaultBranch,
+      defaultBranch: data?.pages?.[0]?.[0]?.defaultBranch,
     },
     totalCount: data?.pages?.[0]?.[0]?.totalCount ?? 0,
     startCursor: data?.pages?.[0]?.[0]?.pageInfo?.startCursor,

--- a/static/app/views/codecov/tests/queries/useGetTestResults.ts
+++ b/static/app/views/codecov/tests/queries/useGetTestResults.ts
@@ -50,6 +50,7 @@ type TestResultItem = {
 };
 
 interface TestResults {
+  defaultBranch: string;
   pageInfo: {
     endCursor: string;
     hasNextPage: boolean;
@@ -77,7 +78,7 @@ export function useInfiniteTestResults({
   const signedSortBy = sortValueToSortKey(sortBy);
 
   const term = searchParams.get('term') || '';
-  const testSuites = searchParams.get('testSuites') || null;
+  const testSuites = searchParams.getAll('testSuites') || null;
 
   const filterBy = searchParams.get('filterBy') as SummaryFilterKey;
   let mappedFilterBy = null;
@@ -147,6 +148,7 @@ export function useInfiniteTestResults({
         : undefined;
     },
     initialPageParam: null,
+    enabled: !!(integratedOrgId && repository && branch && codecovPeriod),
   });
 
   const memoizedData = useMemo(
@@ -181,7 +183,10 @@ export function useInfiniteTestResults({
   );
 
   return {
-    data: memoizedData,
+    data: {
+      testResults: memoizedData,
+      defaultBranch: data?.pages?.[0]?.[0].defaultBranch,
+    },
     totalCount: data?.pages?.[0]?.[0]?.totalCount ?? 0,
     startCursor: data?.pages?.[0]?.[0]?.pageInfo?.startCursor,
     endCursor: data?.pages?.[0]?.[0]?.pageInfo?.endCursor,
@@ -189,3 +194,5 @@ export function useInfiniteTestResults({
     ...rest,
   };
 }
+
+export type UseInfiniteTestResultsResult = ReturnType<typeof useInfiniteTestResults>;

--- a/static/app/views/codecov/tests/testAnalyticsTable/testAnalyticsTable.tsx
+++ b/static/app/views/codecov/tests/testAnalyticsTable/testAnalyticsTable.tsx
@@ -71,7 +71,9 @@ export function isAValidSort(sort: Sort): sort is ValidSort {
 
 interface Props {
   response: {
-    data: Row[];
+    data: {
+      testResults: Row[];
+    };
     isLoading: boolean;
   };
   sort: ValidSort;
@@ -81,6 +83,7 @@ export default function TestAnalyticsTable({response, sort}: Props) {
   const {data, isLoading} = response;
   const [searchParams] = useSearchParams();
   const wrapToggleValue = searchParams.get('wrap') === 'true';
+  const testResults = data.testResults;
 
   const selectorEmptyMessage = (
     <MessageContainer>
@@ -98,7 +101,7 @@ export default function TestAnalyticsTable({response, sort}: Props) {
     <GridEditable
       aria-label={t('Test Analytics')}
       isLoading={isLoading}
-      data={data ?? []}
+      data={testResults ?? []}
       emptyMessage={selectorEmptyMessage}
       columnOrder={COLUMNS_ORDER}
       // TODO: This isn't used as per the docs but is still required. Test if

--- a/static/app/views/codecov/tests/tests.tsx
+++ b/static/app/views/codecov/tests/tests.tsx
@@ -60,7 +60,9 @@ export default function TestsPage() {
           <BranchSelector />
           <DateSelector />
         </PageFilterBar>
-        {(branch === null || branch === defaultBranch) && <TestSuiteDropdown />}
+        {(branch === undefined || branch === null || branch === defaultBranch) && (
+          <TestSuiteDropdown />
+        )}
       </ControlsContainer>
       {shouldDisplayContent ? <Content response={response} /> : <EmptySelectorsMessage />}
     </LayoutGap>
@@ -116,7 +118,9 @@ function Content({response}: TestResultsContentData) {
 
   return (
     <Fragment>
-      {(selectedBranch === null || selectedBranch === defaultBranch) && <Summaries />}
+      {(selectedBranch === undefined ||
+        selectedBranch === null ||
+        selectedBranch === defaultBranch) && <Summaries />}
       <TestSearchBar testCount={response.totalCount} />
       <TestAnalyticsTable response={response} sort={sorts[0]} />
       {/* We don't need to use the pageLinks prop because Codecov handles pagination using our own cursor implementation. But we need to

--- a/static/app/views/codecov/tests/tests.tsx
+++ b/static/app/views/codecov/tests/tests.tsx
@@ -47,7 +47,7 @@ export default function TestsPage() {
     cursor: location.query?.cursor as string | undefined,
     navigation: location.query?.navigation as 'next' | 'prev' | undefined,
   });
-  const defaultBranch = response.data.defaultBranch;
+  const defaultBranch = response.data?.defaultBranch;
 
   const shouldDisplayContent = integratedOrgId && repository && branch && codecovPeriod;
 
@@ -84,7 +84,7 @@ function Content({response}: TestResultsContentData) {
   const sorts: [ValidSort] = [
     decodeSorts(location.query?.sort).find(isAValidSort) ?? DEFAULT_SORT,
   ];
-  const defaultBranch = response.data.defaultBranch;
+  const defaultBranch = response.data?.defaultBranch;
 
   const handleCursor = useCallback(
     (

--- a/static/app/views/codecov/tests/tests.tsx
+++ b/static/app/views/codecov/tests/tests.tsx
@@ -60,9 +60,7 @@ export default function TestsPage() {
           <BranchSelector />
           <DateSelector />
         </PageFilterBar>
-        {(branch === undefined || branch === null || branch === defaultBranch) && (
-          <TestSuiteDropdown />
-        )}
+        {(!branch || branch === defaultBranch) && <TestSuiteDropdown />}
       </ControlsContainer>
       {shouldDisplayContent ? <Content response={response} /> : <EmptySelectorsMessage />}
     </LayoutGap>
@@ -118,9 +116,7 @@ function Content({response}: TestResultsContentData) {
 
   return (
     <Fragment>
-      {(selectedBranch === undefined ||
-        selectedBranch === null ||
-        selectedBranch === defaultBranch) && <Summaries />}
+      {(!selectedBranch || selectedBranch === defaultBranch) && <Summaries />}
       <TestSearchBar testCount={response.totalCount} />
       <TestAnalyticsTable response={response} sort={sorts[0]} />
       {/* We don't need to use the pageLinks prop because Codecov handles pagination using our own cursor implementation. But we need to

--- a/static/app/views/codecov/tests/tests.tsx
+++ b/static/app/views/codecov/tests/tests.tsx
@@ -15,7 +15,10 @@ import {space} from 'sentry/styles/space';
 import {decodeSorts} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
-import {useInfiniteTestResults} from 'sentry/views/codecov/tests/queries/useGetTestResults';
+import {
+  useInfiniteTestResults,
+  type UseInfiniteTestResultsResult,
+} from 'sentry/views/codecov/tests/queries/useGetTestResults';
 import {DEFAULT_SORT} from 'sentry/views/codecov/tests/settings';
 import {Summaries} from 'sentry/views/codecov/tests/summaries/summaries';
 import type {ValidSort} from 'sentry/views/codecov/tests/testAnalyticsTable/testAnalyticsTable';
@@ -38,6 +41,13 @@ function EmptySelectorsMessage() {
 
 export default function TestsPage() {
   const {integratedOrgId, repository, branch, codecovPeriod} = useCodecovContext();
+  const location = useLocation();
+
+  const response = useInfiniteTestResults({
+    cursor: location.query?.cursor as string | undefined,
+    navigation: location.query?.navigation as 'next' | 'prev' | undefined,
+  });
+  const defaultBranch = response.data.defaultBranch;
 
   const shouldDisplayContent = integratedOrgId && repository && branch && codecovPeriod;
 
@@ -50,9 +60,9 @@ export default function TestsPage() {
           <BranchSelector />
           <DateSelector />
         </PageFilterBar>
-        <TestSuiteDropdown />
+        {(branch === null || branch === defaultBranch) && <TestSuiteDropdown />}
       </ControlsContainer>
-      {shouldDisplayContent ? <Content /> : <EmptySelectorsMessage />}
+      {shouldDisplayContent ? <Content response={response} /> : <EmptySelectorsMessage />}
     </LayoutGap>
   );
 }
@@ -62,16 +72,19 @@ const LayoutGap = styled('div')`
   gap: ${space(2)};
 `;
 
-function Content() {
+interface TestResultsContentData {
+  response: UseInfiniteTestResultsResult;
+}
+
+function Content({response}: TestResultsContentData) {
   const location = useLocation();
   const navigate = useNavigate();
+  const {branch: selectedBranch} = useCodecovContext();
+
   const sorts: [ValidSort] = [
     decodeSorts(location.query?.sort).find(isAValidSort) ?? DEFAULT_SORT,
   ];
-  const response = useInfiniteTestResults({
-    cursor: location.query?.cursor as string | undefined,
-    navigation: location.query?.navigation as 'next' | 'prev' | undefined,
-  });
+  const defaultBranch = response.data.defaultBranch;
 
   const handleCursor = useCallback(
     (
@@ -103,8 +116,7 @@ function Content() {
 
   return (
     <Fragment>
-      {/* TODO: Conditionally show these if the branch we're in is the main branch */}
-      <Summaries />
+      {(selectedBranch === null || selectedBranch === defaultBranch) && <Summaries />}
       <TestSearchBar testCount={response.totalCount} />
       <TestAnalyticsTable response={response} sort={sorts[0]} />
       {/* We don't need to use the pageLinks prop because Codecov handles pagination using our own cursor implementation. But we need to


### PR DESCRIPTION
This PR adds the test suite FE hook to fetch test suite related information.

Closes https://linear.app/getsentry/issue/CCMRG-1428/hideshow-summaries-based-on-branch-selection and https://linear.app/getsentry/issue/CCMRG-1426/ta-test-suite-dropdown

Notes
-
- Adds an API call to get test suites in the `TestSuiteDropdown` component
- Adds the `useTestSuites` hook
- Adjusts `useGetTestResults` hook to further filter by `testSuites` if selected
- Lift `useInfinitedTestResults` hook to it's parent component to leverage defaultBranch field - hook is only enabled when all orgId, repo, branch and date are selected, so this avoids unnecessary, preemptive calls
- Conditionally renders summary + test suites components 
- Adjusts context value to reset URL params for `testSuites` when repo + org are changed