### PR TITLE
bug(stories): Clarify graph icon names

### DIFF
--- a/static/app/icons/icons.stories.tsx
+++ b/static/app/icons/icons.stories.tsx
@@ -1136,28 +1136,28 @@ const SECTIONS: TSection[] = [
       },
       {
         id: 'graph-type-circle',
-        name: 'Graph',
+        name: 'GraphCircle',
         defaultProps: {
           type: 'circle',
         },
       },
       {
         id: 'graph-type-bar',
-        name: 'Graph',
+        name: 'GraphBar',
         defaultProps: {
           type: 'bar',
         },
       },
       {
         id: 'graph-type-area',
-        name: 'Graph',
+        name: 'GraphArea',
         defaultProps: {
           type: 'area',
         },
       },
       {
         id: 'graph-type-scatter',
-        name: 'Graph',
+        name: 'GraphScatter',
         defaultProps: {
           type: 'scatter',
         },


### PR DESCRIPTION
Was working on some new UI and using stories, noticed the naming for the IconGraph was duplicated for all other graph icon types (`IconGraphCircle`, `IconGraphBar`, etc).

<img width="743" height="152" alt="Screenshot 2025-07-25 at 5 27 16 PM" src="https://github.com/user-attachments/assets/9e4ae01d-a787-4038-b332-9a713c105113" />

This correctly names each now.