### PR TITLE
ci(jest): Fix importing of BALANCE_RESULTS_PATH

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -219,7 +219,7 @@ if (
     'jest-balance.json'
   );
   try {
-    balance = await import(BALANCE_RESULTS_PATH, {with: {type: 'json'}});
+    balance = (await import(BALANCE_RESULTS_PATH, {with: {type: 'json'}})).default;
   } catch (err) {
     // Just ignore if balance results doesn't exist
   }

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -219,7 +219,7 @@ if (
     'jest-balance.json'
   );
   try {
-    balance = require(BALANCE_RESULTS_PATH);
+    balance = await import(BALANCE_RESULTS_PATH, {with: {type: 'json'}});
   } catch (err) {
     // Just ignore if balance results doesn't exist
   }


### PR DESCRIPTION
This `require()` call wasn't working since we added `--experimental-transform-types` in https://github.com/getsentry/sentry/pull/93303

We can see our balancer_strategy logging stopped logging `by_path` as often, instead showing 'other':
<img width="530" height="196" alt="SCR-20250726-mgai" src="https://github.com/user-attachments/assets/b449b7a7-f750-47c1-9b4c-1e602fe55fbd" />


And this impacted at test worker runtimes too:
<img width="531" height="203" alt="SCR-20250726-mfyl" src="https://github.com/user-attachments/assets/98e4b294-1b16-4b3e-b487-c443132e7d3e" />


Without the balancer stats js tests got more than a minute slower, because the shards are unbalanced and slowest one is taking longer now.
What we learned though is that the jest-balance.json sharing is pretty good and keeps all the shards at about the same runtime!


I made a new dashboard to see all the CI worker runtimes for frontend.yaml: https://sentry.sentry.io/dashboard/141271/?project=5899451&statsPeriod=30d. The critical path is usually jest, but eslint is taking almost the same amount of time too running in parallel. If we speedup jest then we'll save wall-time in CI. 
There's also a dashboard to see the slowest test suites and test cases. It's got the balancer_strategy chart added too: https://sentry.sentry.io/dashboard/141273/?project=4857230&statsPeriod=30d