### PR TITLE
Fix guide coordination with pendo

### DIFF
--- a/static/gsApp/hooks/handleGuideUpdate.tsx
+++ b/static/gsApp/hooks/handleGuideUpdate.tsx
@@ -1,16 +1,42 @@
 import type {Guide} from 'sentry/components/assistant/types';
+import GuideStore from 'sentry/stores/guideStore';
 
 export default function handleGuideUpdate(
   nextGuide: Guide | null,
-  {dismissed}: {dismissed?: boolean}
+  {dismissed}: {dismissed?: boolean} = {}
 ) {
-  // if not ready, ignore
+  // Helper that contains the core coordination logic once Pendo *is* ready
+  const run = () => {
+    const {forceHide} = GuideStore.state;
+
+    // Stop guides if:
+    // 1. A Sentry guide is active (nextGuide is truthy)
+    // 2. Guides are force-hidden (e.g. a modal is open)
+    // 3. User dismissed a Sentry guide (to avoid immediate Pendo takeover)
+    if (nextGuide || forceHide || dismissed) {
+      window.pendo?.stopGuides?.();
+    } else {
+      // Only start Pendo guides when no Sentry guides are active *and*
+      // guides are not force-hidden.
+      window.pendo?.startGuides?.();
+    }
+  };
+
+  // If Pendo is not ready yet, poll until it is ready, then execute logic
   if (!window.pendo?.isReady?.()) {
+    const retryInterval = 100; // ms
+    const retry = () => {
+      if (window.pendo?.isReady?.()) {
+        run();
+      } else {
+        setTimeout(retry, retryInterval);
+      }
+    };
+
+    retry();
     return;
   }
-  // only start Pendo if there is no next guide
-  // and the user did not dismiss
-  if (!nextGuide && !dismissed) {
-    window.pendo.startGuides();
-  }
+
+  // Pendo is ready – run coordination logic immediately
+  run();
 }


### PR DESCRIPTION
<!-- Describe your PR here. -->
This PR resolves several issues with guide coordination between Sentry's internal guides and Pendo, improving timing and state management.

*   **Race Condition**: Pendo initialization now waits for Sentry guides to be loaded, ensuring correct initial state.
*   **Complete State Management**: The `handleGuideUpdate` hook now correctly stops Pendo guides when a Sentry guide is active, dismissed, or a modal is open, and starts Pendo otherwise.
*   **Pendo Ready Handling**: Added retry logic to `handleGuideUpdate` to ensure coordination runs only when Pendo is fully ready.
*   **Modal State**: Pendo initialization now considers the `forceHide` state (e.g., when a modal is open) to delay Pendo guides.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---

[Open in Web](https://cursor.com/agents?id=bc-d0252017-6782-4ac3-909e-a168472789f1) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-d0252017-6782-4ac3-909e-a168472789f1) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)