### PR TITLE
feat(crash-detection): Ignore Java GraphQL `instrumentExecutionResultComplete`

### DIFF
--- a/src/sentry/utils/sdk_crashes/sdk_crash_detection_config.py
+++ b/src/sentry/utils/sdk_crashes/sdk_crash_detection_config.py
@@ -289,6 +289,10 @@ def build_sdk_crash_detection_configs() -> Sequence[SDKCrashDetectionConfig]:
                     module_pattern="io.sentry.graphql.SentryInstrumentation",
                     function_pattern="lambda$instrumentExecutionResult$0",
                 ),
+                FunctionAndModulePattern(
+                    module_pattern="io.sentry.graphql.SentryGraphqlInstrumentation",
+                    function_pattern="instrumentExecutionResultComplete",
+                ),
             },
         )
         configs.append(java_config)


### PR DESCRIPTION
<!-- Describe your PR here. -->
Ignore a new false positive SDK crash in our GraphQL module.