### PR TITLE
feat(agent-insights): add deprecation warning to llm monitoring

### DIFF
--- a/static/app/views/insights/llmMonitoring/views/llmMonitoringLandingPage.tsx
+++ b/static/app/views/insights/llmMonitoring/views/llmMonitoringLandingPage.tsx
@@ -38,11 +38,7 @@ function LLMMonitoringPage() {
                   {tct(
                     'On 4th August 2025, LLM Monitoring will be sunset and replaced by the new AI Agent Monitoring. [link:Switch to the new experience].',
                     {
-                      link: (
-                        <Link onClick={togglePreferedModule} to={''}>
-                          aa
-                        </Link>
-                      ),
+                      link: <Link onClick={togglePreferedModule} to={''} />,
                     }
                   )}
                 </DeprecatedModuleLayout>

--- a/static/app/views/insights/llmMonitoring/views/llmMonitoringLandingPage.tsx
+++ b/static/app/views/insights/llmMonitoring/views/llmMonitoringLandingPage.tsx
@@ -1,7 +1,15 @@
+import styled from '@emotion/styled';
+
+import {Alert} from 'sentry/components/core/alert';
+import {Link} from 'sentry/components/core/link';
 import * as Layout from 'sentry/components/layouts/thirds';
 import Redirect from 'sentry/components/redirect';
+import {tct} from 'sentry/locale';
 import {AiModuleToggleButton} from 'sentry/views/insights/agentMonitoring/components/aiModuleToggleButton';
-import {usePreferedAiModule} from 'sentry/views/insights/agentMonitoring/utils/features';
+import {
+  usePreferedAiModule,
+  useTogglePreferedAiModule,
+} from 'sentry/views/insights/agentMonitoring/utils/features';
 import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
 import {ModulePageFilterBar} from 'sentry/views/insights/common/components/modulePageFilterBar';
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
@@ -17,6 +25,7 @@ import {INSIGHTS_BASE_URL} from 'sentry/views/insights/settings';
 import {ModuleName} from 'sentry/views/insights/types';
 
 function LLMMonitoringPage() {
+  const [, togglePreferedModule] = useTogglePreferedAiModule();
   return (
     <Layout.Page>
       <AiHeader module={ModuleName.AI} headerActions={<AiModuleToggleButton />} />
@@ -25,6 +34,18 @@ function LLMMonitoringPage() {
           <Layout.Main fullWidth>
             <ModuleLayout.Layout>
               <ModuleLayout.Full>
+                <DeprecatedModuleLayout type="error">
+                  {tct(
+                    'On 4th August 2025, LLM Monitoring will be sunset and replaced by the new AI Agent Monitoring. [link:Switch to the new experience].',
+                    {
+                      link: (
+                        <Link onClick={togglePreferedModule} to={''}>
+                          aa
+                        </Link>
+                      ),
+                    }
+                  )}
+                </DeprecatedModuleLayout>
                 <ModulePageFilterBar moduleName={ModuleName.AI} />
               </ModuleLayout.Full>
               <ModulesOnboarding moduleName={ModuleName.AI}>
@@ -62,5 +83,9 @@ function PageWithProviders() {
     </ModulePageProviders>
   );
 }
+
+const DeprecatedModuleLayout = styled(Alert)`
+  margin-bottom: ${p => p.theme.space.xl};
+`;
 
 export default PageWithProviders;


### PR DESCRIPTION
Closes: [TET-935: Put red banner on top of llm monitoring that it will be deleted on X.X](https://linear.app/getsentry/issue/TET-935/put-red-banner-on-top-of-llm-monitoring-that-it-will-be-deleted-on-xx)

<img width="1243" height="793" alt="image" src="https://github.com/user-attachments/assets/2b286a2e-cd16-4068-be7a-eddc2c3a37f0" />
