### PR TITLE
ref(ourlogs): Always hide severity_number in the UI

### DIFF
--- a/static/app/views/explore/components/schemaHints/schemaHintsList.tsx
+++ b/static/app/views/explore/components/schemaHints/schemaHintsList.tsx
@@ -30,7 +30,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import SchemaHintsDrawer from 'sentry/views/explore/components/schemaHints/schemaHintsDrawer';
 import {
   getSchemaHintsListOrder,
-  removeHiddenKeys,
+  removeHiddenSchemaHintsKeys,
   SchemaHintsSources,
   USER_IDENTIFIER_KEY,
 } from 'sentry/views/explore/components/schemaHints/schemaHintsUtils';
@@ -162,7 +162,7 @@ function SchemaHintsList({
 
   // sort tags by the order they show up in the query builder
   const filterTagsSorted = useMemo(() => {
-    const filterTags = removeHiddenKeys({
+    const filterTags = removeHiddenSchemaHintsKeys({
       ...functionTags,
       ...numberTags,
       ...stringTags,

--- a/static/app/views/explore/components/schemaHints/schemaHintsUtils.tsx
+++ b/static/app/views/explore/components/schemaHints/schemaHintsUtils.tsx
@@ -1,6 +1,7 @@
 import type {TagCollection} from 'sentry/types/group';
 import {FieldKey} from 'sentry/utils/fields';
 import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
+import {removeHiddenKeys} from 'sentry/views/explore/utils';
 import {SpanFields} from 'sentry/views/insights/types';
 
 export const USER_IDENTIFIER_KEY = 'user.key';
@@ -67,12 +68,8 @@ export const getSchemaHintsListOrder = (source: SchemaHintsSources) => {
   return SCHEMA_HINTS_LIST_ORDER_KEYS_EXPLORE;
 };
 
-export const removeHiddenKeys = (tagCollection: TagCollection): TagCollection => {
-  const result: TagCollection = {};
-  for (const key in tagCollection) {
-    if (key && !SCHEMA_HINTS_HIDDEN_KEYS.includes(key) && tagCollection[key]) {
-      result[key] = tagCollection[key];
-    }
-  }
-  return result;
+export const removeHiddenSchemaHintsKeys = (
+  tagCollection: TagCollection
+): TagCollection => {
+  return removeHiddenKeys(tagCollection, SCHEMA_HINTS_HIDDEN_KEYS);
 };

--- a/static/app/views/explore/contexts/traceItemAttributeContext.tsx
+++ b/static/app/views/explore/contexts/traceItemAttributeContext.tsx
@@ -12,6 +12,7 @@ import {
 } from 'sentry/views/explore/constants';
 import {useTraceItemAttributeKeys} from 'sentry/views/explore/hooks/useTraceItemAttributeKeys';
 import {TraceItemDataset} from 'sentry/views/explore/types';
+import {removeHiddenKeys} from 'sentry/views/explore/utils';
 
 type TypedTraceItemAttributes = {
   number: TagCollection;
@@ -113,7 +114,10 @@ export function TraceItemAttributeProvider({
   );
 }
 
-export function useTraceItemAttributes(type?: 'number' | 'string') {
+export function useTraceItemAttributes(
+  type?: 'number' | 'string',
+  hiddenKeys?: string[]
+) {
   const typedAttributesResult = useContext(TraceItemAttributeContext);
 
   if (typedAttributesResult === undefined) {
@@ -124,14 +128,22 @@ export function useTraceItemAttributes(type?: 'number' | 'string') {
 
   if (type === 'number') {
     return {
-      attributes: typedAttributesResult.number,
-      secondaryAliases: typedAttributesResult.numberSecondaryAliases,
+      attributes: hiddenKeys
+        ? removeHiddenKeys(typedAttributesResult.number, hiddenKeys)
+        : typedAttributesResult.number,
+      secondaryAliases: hiddenKeys
+        ? removeHiddenKeys(typedAttributesResult.numberSecondaryAliases, hiddenKeys)
+        : typedAttributesResult.numberSecondaryAliases,
       isLoading: typedAttributesResult.numberAttributesLoading,
     };
   }
   return {
-    attributes: typedAttributesResult.string,
-    secondaryAliases: typedAttributesResult.stringSecondaryAliases,
+    attributes: hiddenKeys
+      ? removeHiddenKeys(typedAttributesResult.string, hiddenKeys)
+      : typedAttributesResult.string,
+    secondaryAliases: hiddenKeys
+      ? removeHiddenKeys(typedAttributesResult.stringSecondaryAliases, hiddenKeys)
+      : typedAttributesResult.stringSecondaryAliases,
     isLoading: typedAttributesResult.stringAttributesLoading,
   };
 }

--- a/static/app/views/explore/logs/constants.tsx
+++ b/static/app/views/explore/logs/constants.tsx
@@ -34,6 +34,7 @@ export const AlwaysPresentLogFields: OurLogFieldKey[] = [
 const AlwaysHiddenLogFields: OurLogFieldKey[] = [
   OurLogKnownFieldKey.ID,
   OurLogKnownFieldKey.ORGANIZATION_ID,
+  OurLogKnownFieldKey.SEVERITY_NUMBER,
   OurLogKnownFieldKey.ITEM_TYPE,
   OurLogKnownFieldKey.PROJECT,
   OurLogKnownFieldKey.TIMESTAMP_PRECISE,
@@ -56,6 +57,8 @@ export const HiddenLogDetailFields: OurLogFieldKey[] = [
 ];
 
 export const HiddenColumnEditorLogFields: OurLogFieldKey[] = [...AlwaysHiddenLogFields];
+
+export const HiddenLogSearchFields: string[] = [...AlwaysHiddenLogFields];
 
 const LOGS_FILTERS: FilterKeySection = {
   value: 'logs_filters',

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -67,7 +67,10 @@ import {
   ChartIntervalUnspecifiedStrategy,
   useChartInterval,
 } from 'sentry/views/explore/hooks/useChartInterval';
-import {HiddenColumnEditorLogFields} from 'sentry/views/explore/logs/constants';
+import {
+  HiddenColumnEditorLogFields,
+  HiddenLogSearchFields,
+} from 'sentry/views/explore/logs/constants';
 import {AutorefreshToggle} from 'sentry/views/explore/logs/logsAutoRefresh';
 import {LogsGraph} from 'sentry/views/explore/logs/logsGraph';
 import {LogsToolbar} from 'sentry/views/explore/logs/logsToolbar';
@@ -184,12 +187,12 @@ export function LogsTabContent({
     attributes: stringAttributes,
     isLoading: stringAttributesLoading,
     secondaryAliases: stringSecondaryAliases,
-  } = useTraceItemAttributes('string');
+  } = useTraceItemAttributes('string', HiddenLogSearchFields);
   const {
     attributes: numberAttributes,
     isLoading: numberAttributesLoading,
     secondaryAliases: numberSecondaryAliases,
-  } = useTraceItemAttributes('number');
+  } = useTraceItemAttributes('number', HiddenLogSearchFields);
 
   const averageLogsPerSecond = calculateAverageLogsPerSecond(timeseriesResult);
 

--- a/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
@@ -152,10 +152,8 @@ describe('logsTableRow', () => {
     expect(screen.getByText('7b91699f')).toBeInTheDocument();
 
     // Check that the attributes keys are rendered
-    expect(screen.getByTestId('tree-key-severity_number')).toBeInTheDocument();
-    expect(screen.getByTestId('tree-key-severity_number')).toHaveTextContent(
-      'severity_number'
-    );
+    expect(screen.getByTestId('tree-key-severity')).toBeInTheDocument();
+    expect(screen.getByTestId('tree-key-severity')).toHaveTextContent('severity');
 
     // Check that the custom renderer works
     expect(screen.getByTestId('tree-key-trace')).toHaveTextContent('trace');

--- a/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
@@ -60,7 +60,7 @@ describe('logsTableRow', () => {
     [OurLogKnownFieldKey.PROJECT_ID]: String(projects[0]!.id),
     [OurLogKnownFieldKey.ORGANIZATION_ID]: Number(organization.id),
     [OurLogKnownFieldKey.MESSAGE]: 'test log body',
-    [OurLogKnownFieldKey.SEVERITY_NUMBER]: 456,
+    [OurLogKnownFieldKey.SEVERITY]: 'error',
     [OurLogKnownFieldKey.TRACE_ID]: '7b91699f',
   });
 
@@ -148,7 +148,7 @@ describe('logsTableRow', () => {
 
     // Check that the attribute values are rendered
     expect(screen.queryByText(projects[0]!.id)).not.toBeInTheDocument();
-    expect(screen.getByText('456')).toBeInTheDocument();
+    expect(screen.getByText('error')).toBeInTheDocument();
     expect(screen.getByText('7b91699f')).toBeInTheDocument();
 
     // Check that the attributes keys are rendered

--- a/static/app/views/explore/utils.tsx
+++ b/static/app/views/explore/utils.tsx
@@ -691,3 +691,16 @@ export function prettifyAggregation(aggregation: string): string | null {
 
   return null;
 }
+
+export const removeHiddenKeys = (
+  tagCollection: TagCollection,
+  hiddenKeys: string[]
+): TagCollection => {
+  const result: TagCollection = {};
+  for (const key in tagCollection) {
+    if (key && !hiddenKeys.includes(key) && tagCollection[key]) {
+      result[key] = tagCollection[key];
+    }
+  }
+  return result;
+};


### PR DESCRIPTION
### Summary
We are looking to remove sending severity_number in lieu of 'severity' (aliased from sentry.severity_text), this will ensure it is unused before we remove it in Relay.

#### Other
This PR also adds the always hidden log keys as a new passable param to useTraceItemAttributes.

