### PR TITLE
chore(project-config): Remove reload_cache_only_on_value_change option'

### DIFF
--- a/src/sentry/models/options/project_option.py
+++ b/src/sentry/models/options/project_option.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 
 from django.db import models, router, transaction
 
-from sentry import options, projectoptions
+from sentry import projectoptions
 from sentry.backup.dependencies import ImportKind
 from sentry.backup.helpers import ImportFlags
 from sentry.backup.scopes import ImportScope, RelocationScope
@@ -133,36 +133,26 @@ class ProjectOptionManager(OptionManager["ProjectOption"]):
         else:
             project_id = project
 
-        if options.get("sentry.project_option.reload_cache_only_on_value_change"):
-            is_value_changed = False
-            with transaction.atomic(router.db_for_write(ProjectOption)):
-                # select_for_update lock rows until the end of the transaction
-                obj, created = self.select_for_update().get_or_create(
-                    project_id=project_id, key=key, defaults={"value": value}
-                )
-                if created:
-                    is_value_changed = True
-                elif obj.value != value:
-                    # update the value via ORM update() to avoid post save signals which
-                    # might cause cache reload when it is not needed (e.g. post_save signal)
-                    self.filter(id=obj.id).update(value=value)
-                    is_value_changed = True
+        is_value_changed = False
+        with transaction.atomic(router.db_for_write(ProjectOption)):
+            # select_for_update lock rows until the end of the transaction
+            obj, created = self.select_for_update().get_or_create(
+                project_id=project_id, key=key, defaults={"value": value}
+            )
+            if created:
+                is_value_changed = True
+            elif obj.value != value:
+                # update the value via ORM update() to avoid post save signals which
+                # might cause cache reload when it is not needed (e.g. post_save signal)
+                self.filter(id=obj.id).update(value=value)
+                is_value_changed = True
 
-            if reload_cache and is_value_changed:
-                # invalidate the cached project config only if the value has changed,
-                # and reload_cache is set to True
-                self.reload_cache(project_id, "projectoption.set_value", key)
-
-            return is_value_changed
-
-        inst, created = self.create_or_update(
-            project_id=project_id, key=key, values={"value": value}
-        )
-
-        if reload_cache:
+        if reload_cache and is_value_changed:
+            # invalidate the cached project config only if the value has changed,
+            # and reload_cache is set to True
             self.reload_cache(project_id, "projectoption.set_value", key)
 
-        return created or inst > 0
+        return is_value_changed
 
     def get_all_values(self, project: Project | int) -> Mapping[str, Any]:
         if isinstance(project, models.Model):

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3535,13 +3535,3 @@ register(
     default=0.0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
-
-# Enables the new project option set_value implementation that only reloads the cache if the
-# value has changed. This is a temporary option to allow for a smooth transition to the new
-# implementation, and acts as a killswitch.
-register(
-    "sentry.project_option.reload_cache_only_on_value_change",
-    type=Bool,
-    default=False,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)

--- a/tests/sentry/models/test_projectoption.py
+++ b/tests/sentry/models/test_projectoption.py
@@ -1,8 +1,5 @@
-from unittest.mock import patch
-
 from sentry.models.options.project_option import ProjectOption
 from sentry.testutils.cases import TransactionTestCase
-from sentry.testutils.helpers.options import override_options
 
 
 class ProjectOptionManagerTest(TransactionTestCase):
@@ -31,84 +28,3 @@ class ProjectOptionManagerTest(TransactionTestCase):
         ProjectOption.objects.create(project=self.project, key="foo", value="bar")
         result = ProjectOption.objects.get_value_bulk([self.project], "foo")
         assert result == {self.project: "bar"}
-
-    def test_set_value_with_new_caching_option_enabled(self) -> None:
-        """Test set_value behavior with reload_cache_only_on_value_change enabled"""
-        with override_options({"sentry.project_option.reload_cache_only_on_value_change": True}):
-            with patch.object(ProjectOption.objects, "reload_cache") as mock_reload:
-                # Test creating new option - should reload cache
-                result = ProjectOption.objects.set_value(self.project, "new_key", "new_value")
-                assert result is True  # Value changed (created)
-                assert mock_reload.called
-                mock_reload.reset_mock()
-
-                # Test setting same value - should NOT reload cache
-                result2 = ProjectOption.objects.set_value(self.project, "new_key", "new_value")
-                assert result2 is False  # Value did not change
-                assert not mock_reload.called
-
-                # Test setting different value - should reload cache
-                result3 = ProjectOption.objects.set_value(  # type: ignore[unreachable]
-                    self.project, "new_key", "updated_value"
-                )
-                assert result3 is True  # Value changed
-                assert mock_reload.called
-                mock_reload.reset_mock()
-
-                # Test setting value with reload_cache=False - should not reload cache even if value changes
-                result4 = ProjectOption.objects.set_value(
-                    self.project, "new_key", "another_value", reload_cache=False
-                )
-                assert result4 is True  # Value changed
-                assert not mock_reload.called
-
-    def test_set_value_with_new_caching_option_disabled(self) -> None:
-        """Test set_value behavior with reload_cache_only_on_value_change disabled (legacy behavior)"""
-        with override_options({"sentry.project_option.reload_cache_only_on_value_change": False}):
-            with patch.object(ProjectOption.objects, "reload_cache") as mock_reload:
-                # Test creating new option - should reload cache
-                result = ProjectOption.objects.set_value(self.project, "new_key", "new_value")
-                assert result is True  # Created
-                assert mock_reload.called
-                mock_reload.reset_mock()
-
-                # Test setting same value - should STILL return True and reload cache (legacy behavior)
-                # This is because create_or_update always returns (1, False) for existing records
-                result = ProjectOption.objects.set_value(self.project, "new_key", "new_value")
-                assert (
-                    result is True
-                )  # Legacy: always True for existing records (created=False, inst=1 > 0)
-                assert mock_reload.called  # Should always reload in legacy mode
-                mock_reload.reset_mock()
-
-                # Test setting different value - should reload cache
-                result = ProjectOption.objects.set_value(self.project, "new_key", "updated_value")
-                assert result is True  # Updated
-                assert mock_reload.called
-                mock_reload.reset_mock()
-
-                # Test setting value with reload_cache=False - should not reload cache
-                result = ProjectOption.objects.set_value(
-                    self.project, "new_key", "another_value", reload_cache=False
-                )
-                assert result is True  # Updated
-                assert not mock_reload.called
-
-    def test_set_value_with_project_id(self) -> None:
-        """Test set_value works with project ID instead of project object"""
-        with override_options({"sentry.project_option.reload_cache_only_on_value_change": True}):
-            result = ProjectOption.objects.set_value(self.project.id, "id_key", "id_value")
-            assert result is True  # Created
-            assert ProjectOption.objects.get(project=self.project, key="id_key").value == "id_value"
-
-            # Test setting same value with project ID
-            result = ProjectOption.objects.set_value(self.project.id, "id_key", "id_value")
-            assert result is False  # No change
-
-            # Test setting different value with project ID
-            result = ProjectOption.objects.set_value(self.project.id, "id_key", "new_id_value")
-            assert result is True  # Changed
-            assert (
-                ProjectOption.objects.get(project=self.project, key="id_key").value
-                == "new_id_value"
-            )


### PR DESCRIPTION
For over a week now this has been running without any problems, so it is safe to remove the old code, and completely swtich to the refactored version.
