### PR TITLE
fix(release-health): Update processing deadline duration of the task

### DIFF
--- a/src/sentry/release_health/tasks.py
+++ b/src/sentry/release_health/tasks.py
@@ -35,7 +35,7 @@ logger = logging.getLogger("sentry.tasks.releasemonitor")
     taskworker_config=TaskworkerConfig(
         namespace=release_health_tasks,
         retry=Retry(times=5, on=(Exception,)),
-        processing_deadline_duration=120,
+        processing_deadline_duration=400,
     ),
 )
 def monitor_release_adoption(**kwargs) -> None:


### PR DESCRIPTION
This fails cause the `fetch_projects_with_recent_sessions` function that is being called in the task will continue fetching projects for 360s before stoppping and returning the results. 

Quick fix currently is to increase the deadline of the task, so that it has enough time to fetch all the data, but this also requires better refactor since it seems that current approach is sub-optimal.

Mark has tried to increase the timer in https://github.com/getsentry/sentry/pull/96456, but it wasn't enough.
