### PR TITLE
ref: Revert "Don't write unchanged clusterer rules (#95550)"

### DIFF
--- a/src/sentry/ingest/transaction_clusterer/rules.py
+++ b/src/sentry/ingest/transaction_clusterer/rules.py
@@ -105,11 +105,7 @@ class ProjectOptionRuleStore:
         # Track the number of rules per project.
         metrics.distribution(self._tracker, len(converted_rules))
 
-        # Check if the rules have changed compared to what is stored
-        # to prevent a needless project option update and project config
-        # invalidation.
-        if converted_rules != project.get_option(self._storage, default=[]):
-            project.update_option(self._storage, converted_rules)
+        project.update_option(self._storage, converted_rules)
 
 
 class CompositeRuleStore:


### PR DESCRIPTION
PR #95550 removed unnecessary invalidations of project clusterer rules by manually checking if they had changed before updating them. However, as of #95765 and #96519 this check is built into the project option manager, so this workaround is now unnecessary.

Closes INGEST-450.