### PR TITLE
fix(deletions): If there are any more groups keep chunking

### DIFF
--- a/src/sentry/api/helpers/group_index/delete.py
+++ b/src/sentry/api/helpers/group_index/delete.py
@@ -131,16 +131,6 @@ def create_audit_entries(
             },
         )
 
-        delete_logger.info(
-            "object.delete.queued",
-            extra={
-                "object_id": group.id,
-                "project_id": group.project_id,
-                "transaction_id": transaction_id,
-                "model": type(group).__name__,
-            },
-        )
-
         issue_deleted.send_robust(
             group=group, user=request.user, delete_type=delete_type, sender=delete_group_list
         )

--- a/src/sentry/deletions/base.py
+++ b/src/sentry/deletions/base.py
@@ -215,7 +215,7 @@ class ModelDeletionTask(BaseDeletionTask[ModelT]):
         query_limit = self.query_limit
         remaining = self.chunk_size
 
-        while remaining > 0:
+        while remaining >= 0:
             queryset = getattr(self.model, self.manager_name).filter(**self.query)
             if self.order_by:
                 queryset = queryset.order_by(self.order_by)
@@ -227,17 +227,6 @@ class ModelDeletionTask(BaseDeletionTask[ModelT]):
 
             self.delete_bulk(queryset)
             remaining = remaining - len(queryset)
-            if remaining and self.model.__name__ == "Group":
-                logger.info(
-                    "deletions.group.chunk.remaining",
-                    extra={
-                        "chunk_size": self.chunk_size,
-                        "remaining": remaining,
-                        "query": self.query,
-                        "queryset": queryset,
-                        "transaction_id": self.transaction_id,
-                    },
-                )
 
         # We have more work to do as we didn't run out of rows to delete.
         return True

--- a/src/sentry/deletions/base.py
+++ b/src/sentry/deletions/base.py
@@ -238,6 +238,7 @@ class ModelDeletionTask(BaseDeletionTask[ModelT]):
                         "transaction_id": self.transaction_id,
                     },
                 )
+                raise Exception("This is to help find a test that reaches this point")
 
         # We have more work to do as we didn't run out of rows to delete.
         return True

--- a/src/sentry/deletions/base.py
+++ b/src/sentry/deletions/base.py
@@ -238,7 +238,6 @@ class ModelDeletionTask(BaseDeletionTask[ModelT]):
                         "transaction_id": self.transaction_id,
                     },
                 )
-                raise Exception("This is to help find a test that reaches this point")
 
         # We have more work to do as we didn't run out of rows to delete.
         return True

--- a/src/sentry/deletions/tasks/groups.py
+++ b/src/sentry/deletions/tasks/groups.py
@@ -80,6 +80,3 @@ def delete_groups_for_project(
     has_more = True
     while has_more:
         has_more = task.chunk()
-
-    # This will delete all Snuba events for all deleted groups
-    eventstream.backend.end_delete_groups(eventstream_state)

--- a/src/sentry/deletions/tasks/groups.py
+++ b/src/sentry/deletions/tasks/groups.py
@@ -83,4 +83,4 @@ def delete_groups_for_project(
         has_more = task.chunk()
         if not has_more:
             metrics.incr("deletions.groups.delete_groups_for_project.chunked", 1, sample_rate=1)
-            sentry_sdk.capture_message("This should not be happening")
+            sentry_sdk.capture_message("delete_groups reached a state that should not happen")

--- a/src/sentry/deletions/tasks/groups.py
+++ b/src/sentry/deletions/tasks/groups.py
@@ -13,6 +13,7 @@ from sentry.tasks.base import instrumented_task, retry, track_group_async_operat
 from sentry.taskworker.config import TaskworkerConfig
 from sentry.taskworker.namespaces import deletion_tasks
 from sentry.taskworker.retry import Retry
+from sentry.utils import metrics
 
 
 @instrumented_task(
@@ -80,3 +81,6 @@ def delete_groups_for_project(
     has_more = True
     while has_more:
         has_more = task.chunk()
+        if not has_more:
+            metrics.incr("deletions.groups.delete_groups_for_project.chunked", 1, sample_rate=1)
+            sentry_sdk.capture_message("This should not be happening")

--- a/tests/sentry/deletions/tasks/test_groups.py
+++ b/tests/sentry/deletions/tasks/test_groups.py
@@ -87,11 +87,11 @@ class DeleteGroupTest(TestCase):
             "sentry.deletions.defaults.group.GroupDeletionTask.DEFAULT_CHUNK_SIZE",
             new=CHUNK_SIZE,
         ):
-            groups = self.create_n_groups_with_hashes(CHUNK_SIZE, self.project)
+            groups = self.create_n_groups_with_hashes(CHUNK_SIZE - 1, self.project)
             group_ids = [group.id for group in groups]
 
             task = deletions.get(model=Group, query={"id__in": group_ids})
-            assert task.query_limit == task.chunk_size == CHUNK_SIZE
+            assert task.query_limit == task.chunk_size == CHUNK_SIZE  # type: ignore[attr-defined]
 
             has_more = True
             calls = 0
@@ -113,7 +113,7 @@ class DeleteGroupTest(TestCase):
             group_ids = [group.id for group in groups]
 
             task = deletions.get(model=Group, query={"id__in": group_ids})
-            assert task.query_limit == task.chunk_size == CHUNK_SIZE
+            assert task.query_limit == task.chunk_size == CHUNK_SIZE  # type: ignore[attr-defined]
 
             has_more = True
             calls = 0


### PR DESCRIPTION
The assumption is that we schedule 100 groups for deletion and there should be none left, however, this is not the case.

Instead of raising an error, let's keep deleting and add a bit more logging.

Fixes [SENTRY-48W4](https://sentry.sentry.io/issues/6770253794/)