### PR TITLE
feat(detectors): Add additional filters for Laravel to SQL Injection detector

### DIFF
--- a/fixtures/events/performance_problems/sql-injection/sql-injection-laravel-query.json
+++ b/fixtures/events/performance_problems/sql-injection/sql-injection-laravel-query.json
@@ -1,0 +1,177 @@
+{
+  "event_id": "5d6401994d7949d2ac3474f472564370",
+  "platform": "php",
+  "message": "",
+  "datetime": "2025-05-12T22:42:38.642986+00:00",
+  "breakdowns": {
+    "span_ops": {
+      "ops.db": {
+        "value": 65.715075,
+        "unit": "millisecond"
+      },
+      "total.time": {
+        "value": 67.105293,
+        "unit": "millisecond"
+      }
+    }
+  },
+  "request": {
+    "url": "http://localhost:3001/vulnerable-login",
+    "method": "GET",
+    "query_string": [["id", "1000"]]
+  },
+  "modules": {
+    "sequelize": "1.0.0"
+  },
+  "spans": [
+    {
+      "timestamp": 1747089758.567536,
+      "start_timestamp": 1747089758.567,
+      "exclusive_time": 0.536203,
+      "op": "middleware.express",
+      "span_id": "4a06692f4abc8dbe",
+      "parent_span_id": "91fa92ff0205967d",
+      "trace_id": "375a86eca09a4a4e91903838dd771f50",
+      "status": "ok",
+      "description": "corsMiddleware",
+      "origin": "auto.http.otel.express",
+      "data": {
+        "express.name": "corsMiddleware",
+        "express.type": "middleware",
+        "sentry.op": "middleware.express",
+        "sentry.origin": "auto.http.otel.express"
+      },
+      "sentry_tags": {
+        "user": "ip:::1",
+        "user.ip": "::1",
+        "environment": "production",
+        "transaction": "GET /vulnerable-login",
+        "transaction.method": "GET",
+        "transaction.op": "http.server",
+        "browser.name": "Chrome",
+        "sdk.name": "sentry.php.laravel",
+        "sdk.version": "9.17.0",
+        "platform": "php",
+        "os.name": "macOS",
+        "category": "middleware",
+        "op": "middleware.express",
+        "status": "ok",
+        "trace.status": "ok"
+      },
+      "hash": "e6088cf8b370ed60"
+    },
+    {
+      "timestamp": 1747089758.568761,
+      "start_timestamp": 1747089758.568,
+      "exclusive_time": 0.761032,
+      "op": "middleware.express",
+      "span_id": "92553d2584d250b8",
+      "parent_span_id": "91fa92ff0205967d",
+      "trace_id": "375a86eca09a4a4e91903838dd771f50",
+      "status": "ok",
+      "description": "jsonParser",
+      "origin": "auto.http.otel.express",
+      "data": {
+        "express.name": "jsonParser",
+        "express.type": "middleware",
+        "sentry.op": "middleware.express",
+        "sentry.origin": "auto.http.otel.express"
+      },
+      "sentry_tags": {
+        "user": "ip:::1",
+        "user.ip": "::1",
+        "environment": "production",
+        "transaction": "GET /vulnerable-login",
+        "transaction.method": "GET",
+        "transaction.op": "http.server",
+        "browser.name": "Chrome",
+        "sdk.name": "sentry.php.laravel",
+        "sdk.version": "9.17.0",
+        "platform": "php",
+        "os.name": "macOS",
+        "category": "middleware",
+        "op": "middleware.express",
+        "status": "ok",
+        "trace.status": "ok"
+      },
+      "hash": "c81e963dad9ebc6c"
+    },
+    {
+      "timestamp": 1747089758.569093,
+      "start_timestamp": 1747089758.569,
+      "exclusive_time": 0.092983,
+      "op": "request_handler.express",
+      "span_id": "435146ab0909419d",
+      "parent_span_id": "91fa92ff0205967d",
+      "trace_id": "375a86eca09a4a4e91903838dd771f50",
+      "status": "ok",
+      "description": "/vulnerable-login",
+      "origin": "auto.http.otel.express",
+      "data": {
+        "express.name": "/vulnerable-login",
+        "express.type": "request_handler",
+        "http.route": "/vulnerable-login",
+        "sentry.op": "request_handler.express",
+        "sentry.origin": "auto.http.otel.express"
+      },
+      "sentry_tags": {
+        "user": "ip:::1",
+        "user.ip": "::1",
+        "environment": "production",
+        "transaction": "GET /vulnerable-login",
+        "transaction.method": "GET",
+        "transaction.op": "http.server",
+        "browser.name": "Chrome",
+        "sdk.name": "sentry.php.laravel",
+        "sdk.version": "9.17.0",
+        "platform": "php",
+        "os.name": "macOS",
+        "op": "request_handler.express",
+        "status": "ok",
+        "trace.status": "ok"
+      },
+      "hash": "872b0c84a6f1c590"
+    },
+    {
+      "timestamp": 1747089758.637715,
+      "start_timestamp": 1747089758.572,
+      "exclusive_time": 65.715075,
+      "op": "db",
+      "span_id": "4703181ac343f71a",
+      "parent_span_id": "91fa92ff0205967d",
+      "trace_id": "375a86eca09a4a4e91903838dd771f50",
+      "status": "ok",
+      "description": "SELECT * FROM users WHERE id IN (1000)",
+      "origin": "auto.db.otel.mysql2",
+      "data": {
+        "db.system": "mysql",
+        "db.connection_string": "jdbc:mysql://localhost:3306/injection_test",
+        "db.name": "injection_test",
+        "db.statement": "SELECT * FROM users WHERE id IN (1000)",
+        "db.user": "root",
+        "net.peer.name": "localhost",
+        "net.peer.port": 3306,
+        "otel.kind": "CLIENT",
+        "sentry.op": "db",
+        "sentry.origin": "auto.db.otel.mysql2"
+      },
+      "sentry_tags": {
+        "user": "ip:::1",
+        "user.ip": "::1",
+        "environment": "production",
+        "transaction": "GET /vulnerable-login",
+        "transaction.method": "GET",
+        "transaction.op": "http.server",
+        "browser.name": "Chrome",
+        "sdk.name": "sentry.php.laravel",
+        "sdk.version": "9.17.0",
+        "platform": "php",
+        "os.name": "macOS",
+        "op": "request_handler.express",
+        "status": "ok",
+        "trace.status": "ok"
+      },
+      "hash": "45330ba0cafa5997"
+    }
+  ]
+}

--- a/fixtures/events/performance_problems/sql-injection/sql-injection-query-with-bindings.json
+++ b/fixtures/events/performance_problems/sql-injection/sql-injection-query-with-bindings.json
@@ -1,0 +1,178 @@
+{
+  "event_id": "5d6401994d7949d2ac3474f472564370",
+  "platform": "php",
+  "message": "",
+  "datetime": "2025-05-12T22:42:38.642986+00:00",
+  "breakdowns": {
+    "span_ops": {
+      "ops.db": {
+        "value": 65.715075,
+        "unit": "millisecond"
+      },
+      "total.time": {
+        "value": 67.105293,
+        "unit": "millisecond"
+      }
+    }
+  },
+  "request": {
+    "url": "http://localhost:3001/vulnerable-login",
+    "method": "GET",
+    "query_string": [["id", "1000"]]
+  },
+  "modules": {
+    "sequelize": "1.0.0"
+  },
+  "spans": [
+    {
+      "timestamp": 1747089758.567536,
+      "start_timestamp": 1747089758.567,
+      "exclusive_time": 0.536203,
+      "op": "middleware.express",
+      "span_id": "4a06692f4abc8dbe",
+      "parent_span_id": "91fa92ff0205967d",
+      "trace_id": "375a86eca09a4a4e91903838dd771f50",
+      "status": "ok",
+      "description": "corsMiddleware",
+      "origin": "auto.http.otel.express",
+      "data": {
+        "express.name": "corsMiddleware",
+        "express.type": "middleware",
+        "sentry.op": "middleware.express",
+        "sentry.origin": "auto.http.otel.express"
+      },
+      "sentry_tags": {
+        "user": "ip:::1",
+        "user.ip": "::1",
+        "environment": "production",
+        "transaction": "GET /vulnerable-login",
+        "transaction.method": "GET",
+        "transaction.op": "http.server",
+        "browser.name": "Chrome",
+        "sdk.name": "sentry.php.laravel",
+        "sdk.version": "9.17.0",
+        "platform": "php",
+        "os.name": "macOS",
+        "category": "middleware",
+        "op": "middleware.express",
+        "status": "ok",
+        "trace.status": "ok"
+      },
+      "hash": "e6088cf8b370ed60"
+    },
+    {
+      "timestamp": 1747089758.568761,
+      "start_timestamp": 1747089758.568,
+      "exclusive_time": 0.761032,
+      "op": "middleware.express",
+      "span_id": "92553d2584d250b8",
+      "parent_span_id": "91fa92ff0205967d",
+      "trace_id": "375a86eca09a4a4e91903838dd771f50",
+      "status": "ok",
+      "description": "jsonParser",
+      "origin": "auto.http.otel.express",
+      "data": {
+        "express.name": "jsonParser",
+        "express.type": "middleware",
+        "sentry.op": "middleware.express",
+        "sentry.origin": "auto.http.otel.express"
+      },
+      "sentry_tags": {
+        "user": "ip:::1",
+        "user.ip": "::1",
+        "environment": "production",
+        "transaction": "GET /vulnerable-login",
+        "transaction.method": "GET",
+        "transaction.op": "http.server",
+        "browser.name": "Chrome",
+        "sdk.name": "sentry.php.laravel",
+        "sdk.version": "9.17.0",
+        "platform": "php",
+        "os.name": "macOS",
+        "category": "middleware",
+        "op": "middleware.express",
+        "status": "ok",
+        "trace.status": "ok"
+      },
+      "hash": "c81e963dad9ebc6c"
+    },
+    {
+      "timestamp": 1747089758.569093,
+      "start_timestamp": 1747089758.569,
+      "exclusive_time": 0.092983,
+      "op": "request_handler.express",
+      "span_id": "435146ab0909419d",
+      "parent_span_id": "91fa92ff0205967d",
+      "trace_id": "375a86eca09a4a4e91903838dd771f50",
+      "status": "ok",
+      "description": "/vulnerable-login",
+      "origin": "auto.http.otel.express",
+      "data": {
+        "express.name": "/vulnerable-login",
+        "express.type": "request_handler",
+        "http.route": "/vulnerable-login",
+        "sentry.op": "request_handler.express",
+        "sentry.origin": "auto.http.otel.express"
+      },
+      "sentry_tags": {
+        "user": "ip:::1",
+        "user.ip": "::1",
+        "environment": "production",
+        "transaction": "GET /vulnerable-login",
+        "transaction.method": "GET",
+        "transaction.op": "http.server",
+        "browser.name": "Chrome",
+        "sdk.name": "sentry.php.laravel",
+        "sdk.version": "9.17.0",
+        "platform": "php",
+        "os.name": "macOS",
+        "op": "request_handler.express",
+        "status": "ok",
+        "trace.status": "ok"
+      },
+      "hash": "872b0c84a6f1c590"
+    },
+    {
+      "timestamp": 1747089758.637715,
+      "start_timestamp": 1747089758.572,
+      "exclusive_time": 65.715075,
+      "op": "db",
+      "span_id": "4703181ac343f71a",
+      "parent_span_id": "91fa92ff0205967d",
+      "trace_id": "375a86eca09a4a4e91903838dd771f50",
+      "status": "ok",
+      "description": "SELECT * FROM users WHERE id = ?",
+      "origin": "auto.db.otel.mysql2",
+      "data": {
+        "db.system": "mysql",
+        "db.connection_string": "jdbc:mysql://localhost:3306/injection_test",
+        "db.name": "injection_test",
+        "db.statement": "SELECT * FROM users WHERE id = ?",
+        "db.user": "root",
+        "net.peer.name": "localhost",
+        "net.peer.port": 3306,
+        "otel.kind": "CLIENT",
+        "sentry.op": "db",
+        "sentry.origin": "auto.db.otel.mysql2",
+        "db.sql.bindings": [1000]
+      },
+      "sentry_tags": {
+        "user": "ip:::1",
+        "user.ip": "::1",
+        "environment": "production",
+        "transaction": "GET /vulnerable-login",
+        "transaction.method": "GET",
+        "transaction.op": "http.server",
+        "browser.name": "Chrome",
+        "sdk.name": "sentry.php.laravel",
+        "sdk.version": "9.17.0",
+        "platform": "php",
+        "os.name": "macOS",
+        "op": "request_handler.express",
+        "status": "ok",
+        "trace.status": "ok"
+      },
+      "hash": "45330ba0cafa5997"
+    }
+  ]
+}

--- a/src/sentry/performance_issues/detectors/sql_injection_detector.py
+++ b/src/sentry/performance_issues/detectors/sql_injection_detector.py
@@ -217,7 +217,8 @@ class SQLInjectionDetector(PerformanceDetector):
             return False
 
         # If bindings are present, we can assume the query is safe
-        if span.get("data", {}).get("db.sql.bindings"):
+        span_data = span.get("data", {})
+        if span_data and span_data.get("db.sql.bindings"):
             return False
 
         description = span.get("description", None)

--- a/src/sentry/performance_issues/detectors/sql_injection_detector.py
+++ b/src/sentry/performance_issues/detectors/sql_injection_detector.py
@@ -227,6 +227,15 @@ class SQLInjectionDetector(PerformanceDetector):
             or any(keyword in description for keyword in PARAMETERIZED_KEYWORDS)
         ):
             return False
+
+        if span.get("sentry_tags", {}).get("sdk.name") == "sentry.php.laravel" and re.search(
+            r"IN\s*\(\s*(\d+\s*,\s*)*\d+\s*\)", description
+        ):
+            return False
+
+        if span.get("data", {}).get("db.sql.bindings"):
+            return False
+
         return True
 
     @classmethod

--- a/src/sentry/performance_issues/detectors/sql_injection_detector.py
+++ b/src/sentry/performance_issues/detectors/sql_injection_detector.py
@@ -235,7 +235,7 @@ class SQLInjectionDetector(PerformanceDetector):
 
         # Laravel queries with this pattern can contain interpolated values
         if span.get("sentry_tags", {}).get("sdk.name") == "sentry.php.laravel" and re.search(
-            r"IN\s*\(\s*(\d+\s*,\s*)*\d+\s*\)", description
+            r"IN\s*\(\s*(\d+\s*,\s*)*\d+\s*\)", description.upper()
         ):
             return False
 

--- a/tests/sentry/performance_issues/test_sql_injection_detector.py
+++ b/tests/sentry/performance_issues/test_sql_injection_detector.py
@@ -79,6 +79,10 @@ class SQLInjectionDetectorTest(TestCase):
         injection_event = get_event("sql-injection/sql-injection-event-non-vulnerable")
         assert len(self.find_problems(injection_event)) == 0
 
-    def test_sql_injection_on_invalid_package(self) -> None:
-        injection_event = get_event("sql-injection/sql-injection-event-invalid-package")
+    def test_sql_injection_on_laravel_query(self) -> None:
+        injection_event = get_event("sql-injection/sql-injection-laravel-query")
+        assert len(self.find_problems(injection_event)) == 0
+
+    def test_sql_injection_on_query_with_bindings(self) -> None:
+        injection_event = get_event("sql-injection/sql-injection-query-with-bindings")
         assert len(self.find_problems(injection_event)) == 0


### PR DESCRIPTION
this pr adds 2 more filters to sql injection detection :
1) it checks if the event is from a Laravel project and sees if it contains something like `IN (1,2,3)` which can cause false positives
2) adds an additional check to see if `db.sql.bindings` exists - if it does, it is unlikely that span has a vulnerable query 