### PR TITLE
ref(explore): Start splitting visualize toolbar into reusable components

### DIFF
--- a/static/app/views/explore/components/attributeDetails.tsx
+++ b/static/app/views/explore/components/attributeDetails.tsx
@@ -9,9 +9,9 @@ import {TraceItemDataset} from 'sentry/views/explore/types';
 
 interface AttributeDetailsProps {
   column: string;
-  kind: FieldKind;
   label: ReactNode;
   traceItemType: TraceItemDataset;
+  kind?: FieldKind;
 }
 
 export function AttributeDetails({

--- a/static/app/views/explore/components/toolbar/toolbarVisualize/index.tsx
+++ b/static/app/views/explore/components/toolbar/toolbarVisualize/index.tsx
@@ -1,138 +1,60 @@
-import {useCallback} from 'react';
-
 import {Tooltip} from 'sentry/components/core/tooltip';
 import {IconAdd} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {EQUATION_PREFIX} from 'sentry/utils/discover/fields';
 import {
-  ToolbarFooter,
   ToolbarFooterButton,
   ToolbarHeader,
   ToolbarLabel,
-  ToolbarSection,
 } from 'sentry/views/explore/components/toolbar/styles';
-import {VisualizeDropdown} from 'sentry/views/explore/components/toolbar/toolbarVisualize/visualizeDropdown';
-import {VisualizeEquation} from 'sentry/views/explore/components/toolbar/toolbarVisualize/visualizeEquation';
-import type {BaseVisualize} from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
-import {
-  DEFAULT_VISUALIZATION,
-  MAX_VISUALIZES,
-  Visualize,
-} from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
-import {TraceItemDataset} from 'sentry/views/explore/types';
 
-interface ToolbarVisualizeProps {
-  setVisualizes: (visualizes: BaseVisualize[]) => void;
-  traceItemType: TraceItemDataset;
-  visualizes: Visualize[];
-  allowEquations?: boolean;
+export function ToolbarVisualizeHeader() {
+  return (
+    <ToolbarHeader>
+      <Tooltip
+        position="right"
+        title={t(
+          'Primary metric that appears in your chart. You can also overlay a series onto an existing chart or add an equation.'
+        )}
+      >
+        <ToolbarLabel>{t('Visualize')}</ToolbarLabel>
+      </Tooltip>
+    </ToolbarHeader>
+  );
 }
 
-export function ToolbarVisualize({
-  setVisualizes,
-  traceItemType,
-  visualizes,
-  allowEquations = false,
-}: ToolbarVisualizeProps) {
-  const addAggregate = useCallback(() => {
-    const newVisualizes = [...visualizes, new Visualize(DEFAULT_VISUALIZATION)].map(
-      visualize => visualize.toJSON()
-    );
-    setVisualizes(newVisualizes);
-  }, [setVisualizes, visualizes]);
+interface ToolbarVisualizeAddProps {
+  add: () => void;
+  disabled: boolean;
+}
 
-  const addEquation = useCallback(() => {
-    const newVisualizes = [...visualizes, new Visualize(EQUATION_PREFIX)].map(visualize =>
-      visualize.toJSON()
-    );
-    setVisualizes(newVisualizes);
-  }, [setVisualizes, visualizes]);
-
-  const replaceOverlay = useCallback(
-    (group: number, newVisualize: BaseVisualize) => {
-      const newVisualizes = visualizes.map((visualize, i) => {
-        if (i === group) {
-          return newVisualize;
-        }
-        return visualize.toJSON();
-      });
-      setVisualizes(newVisualizes);
-    },
-    [setVisualizes, visualizes]
-  );
-
-  const onDelete = useCallback(
-    (group: number) => {
-      const newVisualizes = visualizes
-        .toSpliced(group, 1)
-        .map(visualize => visualize.toJSON());
-      setVisualizes(newVisualizes);
-    },
-    [setVisualizes, visualizes]
-  );
-
-  const canDelete = visualizes.filter(visualize => !visualize.isEquation).length > 1;
-
+export function ToolbarVisualizeAddChart({add, disabled}: ToolbarVisualizeAddProps) {
   return (
-    <ToolbarSection data-test-id="section-visualizes">
-      <ToolbarHeader>
-        <Tooltip
-          position="right"
-          title={t(
-            'Primary metric that appears in your chart. You can also overlay a series onto an existing chart or add an equation.'
-          )}
-        >
-          <ToolbarLabel>{t('Visualize')}</ToolbarLabel>
-        </Tooltip>
-      </ToolbarHeader>
-      {visualizes.map((visualize, group) => {
-        if (visualize.isEquation) {
-          return (
-            <VisualizeEquation
-              key={group}
-              onDelete={() => onDelete(group)}
-              onReplace={newVisualize => replaceOverlay(group, newVisualize)}
-              visualize={visualize}
-            />
-          );
-        }
-        return (
-          <VisualizeDropdown
-            key={group}
-            canDelete={canDelete}
-            onDelete={() => onDelete(group)}
-            onReplace={newVisualize => replaceOverlay(group, newVisualize)}
-            visualize={visualize}
-            traceItemType={traceItemType}
-          />
-        );
-      })}
-      <ToolbarFooter>
-        <ToolbarFooterButton
-          borderless
-          size="zero"
-          icon={<IconAdd />}
-          onClick={addAggregate}
-          priority="link"
-          aria-label={t('Add Chart')}
-          disabled={visualizes.length >= MAX_VISUALIZES}
-        >
-          {t('Add Chart')}
-        </ToolbarFooterButton>
-        {allowEquations && (
-          <ToolbarFooterButton
-            borderless
-            size="zero"
-            icon={<IconAdd />}
-            onClick={addEquation}
-            priority="link"
-            aria-label={t('Add Equation')}
-            disabled={visualizes.length >= MAX_VISUALIZES}
-          >
-            {t('Add Equation')}
-          </ToolbarFooterButton>
-        )}
-      </ToolbarFooter>
-    </ToolbarSection>
+    <ToolbarFooterButton
+      borderless
+      size="zero"
+      icon={<IconAdd />}
+      onClick={add}
+      priority="link"
+      aria-label={t('Add Chart')}
+      disabled={disabled}
+    >
+      {t('Add Chart')}
+    </ToolbarFooterButton>
+  );
+}
+
+export function ToolbarVisualizeAddEquation({add, disabled}: ToolbarVisualizeAddProps) {
+  return (
+    <ToolbarFooterButton
+      borderless
+      size="zero"
+      icon={<IconAdd />}
+      onClick={add}
+      priority="link"
+      aria-label={t('Add Equation')}
+      disabled={disabled}
+    >
+      {t('Add Equation')}
+    </ToolbarFooterButton>
   );
 }

--- a/static/app/views/explore/components/toolbar/toolbarVisualize/visualizeEquation.tsx
+++ b/static/app/views/explore/components/toolbar/toolbarVisualize/visualizeEquation.tsx
@@ -13,14 +13,13 @@ import {
   getFieldDefinition,
 } from 'sentry/utils/fields';
 import {ToolbarRow} from 'sentry/views/explore/components/toolbar/styles';
-import type {BaseVisualize} from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
 import {Visualize} from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
 import {useTraceItemTags} from 'sentry/views/explore/contexts/spanTagsContext';
 import {useExploreSuggestedAttribute} from 'sentry/views/explore/hooks/useExploreSuggestedAttribute';
 
 interface VisualizeEquationProps {
   onDelete: () => void;
-  onReplace: (visualize: BaseVisualize) => void;
+  onReplace: (visualize: Visualize) => void;
   visualize: Visualize;
 }
 
@@ -66,7 +65,7 @@ export function VisualizeEquation({
       const newVisualize = visualize.replace({
         yAxis: `${EQUATION_PREFIX}${newExpression.text}`,
       });
-      onReplace(newVisualize.toJSON());
+      onReplace(newVisualize);
     },
     [onReplace, visualize]
   );

--- a/static/app/views/explore/hooks/useVisualizeFields.tsx
+++ b/static/app/views/explore/hooks/useVisualizeFields.tsx
@@ -29,7 +29,7 @@ export function useVisualizeFields({
   stringTags,
   traceItemType,
 }: UseVisualizeFieldsProps) {
-  const [kind, tags]: [FieldKind, TagCollection] = useMemo(() => {
+  const tags: TagCollection = useMemo(() => {
     return getSupportedAttributes({
       functionName: parsedFunction?.name || '',
       numberTags,
@@ -52,12 +52,10 @@ export function useVisualizeFields({
           label,
           value: option,
           textValue: option,
-          trailingItems: <TypeBadge kind={kind} />,
           showDetailsInOverlay: true,
           details: (
             <AttributeDetails
               column={option}
-              kind={kind}
               label={label}
               traceItemType={traceItemType}
             />
@@ -69,12 +67,12 @@ export function useVisualizeFields({
           label: tag.name,
           value: tag.key,
           textValue: tag.name,
-          trailingItems: <TypeBadge kind={kind} />,
+          trailingItems: <TypeBadge kind={tag.kind} />,
           showDetailsInOverlay: true,
           details: (
             <AttributeDetails
               column={tag.key}
-              kind={kind}
+              kind={tag.kind}
               label={tag.name}
               traceItemType={traceItemType}
             />
@@ -96,7 +94,7 @@ export function useVisualizeFields({
     });
 
     return options;
-  }, [kind, tags, unknownField, traceItemType]);
+  }, [tags, unknownField, traceItemType]);
 
   return fieldOptions;
 }
@@ -111,33 +109,33 @@ function getSupportedAttributes({
   stringTags: TagCollection;
   traceItemType: TraceItemDataset;
   functionName?: string;
-}): [FieldKind, TagCollection] {
+}): TagCollection {
   if (traceItemType === TraceItemDataset.SPANS) {
     if (functionName === AggregationKey.COUNT) {
       const countTags: TagCollection = {
         [SpanFields.SPAN_DURATION]: {
           name: t('spans'),
           key: SpanFields.SPAN_DURATION,
+          kind: FieldKind.MEASUREMENT,
         },
       };
-      return [FieldKind.MEASUREMENT, countTags];
+      return countTags;
     }
 
     if (NO_ARGUMENT_SPAN_AGGREGATES.includes(functionName as AggregationKey)) {
-      const countTags: TagCollection = {
+      return {
         '': {
           name: t('spans'),
           key: '',
         },
       };
-      return [FieldKind.MEASUREMENT, countTags];
     }
 
     if (functionName === AggregationKey.COUNT_UNIQUE) {
-      return [FieldKind.TAG, stringTags];
+      return stringTags;
     }
 
-    return [FieldKind.MEASUREMENT, numberTags];
+    return numberTags;
   }
 
   throw new Error('Cannot get support attributes for unknown trace item type');

--- a/static/app/views/explore/toolbar/index.tsx
+++ b/static/app/views/explore/toolbar/index.tsx
@@ -4,7 +4,6 @@ import styled from '@emotion/styled';
 import type {SelectOption} from 'sentry/components/core/compactSelect';
 import {defined} from 'sentry/utils';
 import {ToolbarGroupBy} from 'sentry/views/explore/components/toolbar/toolbarGroupBy';
-import {ToolbarVisualize} from 'sentry/views/explore/components/toolbar/toolbarVisualize';
 import {
   useExploreGroupBys,
   useExploreVisualizes,
@@ -16,6 +15,7 @@ import {useTraceItemTags} from 'sentry/views/explore/contexts/spanTagsContext';
 import {useGroupByFields} from 'sentry/views/explore/hooks/useGroupByFields';
 import {ToolbarSaveAs} from 'sentry/views/explore/toolbar/toolbarSaveAs';
 import {ToolbarSortBy} from 'sentry/views/explore/toolbar/toolbarSortBy';
+import {ToolbarVisualize} from 'sentry/views/explore/toolbar/toolbarVisualize';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 
 type Extras = 'equations';
@@ -55,7 +55,6 @@ export function ExploreToolbar({extras, width}: ExploreToolbarProps) {
       <ToolbarVisualize
         visualizes={visualizes}
         setVisualizes={setVisualizes}
-        traceItemType={TraceItemDataset.SPANS}
         allowEquations={extras?.includes('equations') || false}
       />
       <ToolbarGroupBy

--- a/static/app/views/explore/toolbar/toolbarVisualize.tsx
+++ b/static/app/views/explore/toolbar/toolbarVisualize.tsx
@@ -1,0 +1,115 @@
+import {useCallback} from 'react';
+
+import {EQUATION_PREFIX} from 'sentry/utils/discover/fields';
+import {
+  ToolbarFooter,
+  ToolbarSection,
+} from 'sentry/views/explore/components/toolbar/styles';
+import {
+  ToolbarVisualizeAddChart,
+  ToolbarVisualizeAddEquation,
+  ToolbarVisualizeHeader,
+} from 'sentry/views/explore/components/toolbar/toolbarVisualize';
+import {VisualizeDropdown} from 'sentry/views/explore/components/toolbar/toolbarVisualize/visualizeDropdown';
+import {VisualizeEquation} from 'sentry/views/explore/components/toolbar/toolbarVisualize/visualizeEquation';
+import type {BaseVisualize} from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
+import {
+  DEFAULT_VISUALIZATION,
+  MAX_VISUALIZES,
+  Visualize,
+} from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
+import {TraceItemDataset} from 'sentry/views/explore/types';
+
+interface ToolbarVisualizeProps {
+  allowEquations: boolean;
+  setVisualizes: (visualizes: BaseVisualize[]) => void;
+  visualizes: Visualize[];
+}
+
+export function ToolbarVisualize({
+  allowEquations,
+  setVisualizes,
+  visualizes,
+}: ToolbarVisualizeProps) {
+  const addChart = useCallback(() => {
+    const newVisualizes = [...visualizes, new Visualize(DEFAULT_VISUALIZATION)].map(
+      visualize => visualize.toJSON()
+    );
+    setVisualizes(newVisualizes);
+  }, [setVisualizes, visualizes]);
+
+  const addEquation = useCallback(() => {
+    const newVisualizes = [...visualizes, new Visualize(EQUATION_PREFIX)].map(visualize =>
+      visualize.toJSON()
+    );
+    setVisualizes(newVisualizes);
+  }, [setVisualizes, visualizes]);
+
+  const replaceOverlay = useCallback(
+    (group: number, newVisualize: Visualize) => {
+      const newVisualizes = visualizes.map((visualize, i) => {
+        if (i === group) {
+          return newVisualize.toJSON();
+        }
+        return visualize.toJSON();
+      });
+      setVisualizes(newVisualizes);
+    },
+    [setVisualizes, visualizes]
+  );
+
+  const onDelete = useCallback(
+    (group: number) => {
+      const newVisualizes = visualizes
+        .toSpliced(group, 1)
+        .map(visualize => visualize.toJSON());
+      setVisualizes(newVisualizes);
+    },
+    [setVisualizes, visualizes]
+  );
+
+  const canDelete = visualizes.filter(visualize => !visualize.isEquation).length > 1;
+
+  return (
+    <ToolbarSection data-test-id="section-visualizes">
+      <ToolbarVisualizeHeader />
+      {visualizes.map((visualize, group) => {
+        if (visualize.isEquation) {
+          return (
+            <VisualizeEquation
+              key={group}
+              onDelete={() => onDelete(group)}
+              onReplace={newVisualize => replaceOverlay(group, newVisualize)}
+              visualize={visualize}
+            />
+          );
+        }
+
+        return (
+          <VisualizeDropdown
+            key={group}
+            canDelete={canDelete}
+            onDelete={() => onDelete(group)}
+            onReplace={newYAxis =>
+              replaceOverlay(group, visualize.replace({yAxis: newYAxis}))
+            }
+            yAxis={visualize.yAxis}
+            traceItemType={TraceItemDataset.SPANS}
+          />
+        );
+      })}
+      <ToolbarFooter>
+        <ToolbarVisualizeAddChart
+          add={addChart}
+          disabled={visualizes.length >= MAX_VISUALIZES}
+        />
+        {allowEquations && (
+          <ToolbarVisualizeAddEquation
+            add={addEquation}
+            disabled={visualizes.length >= MAX_VISUALIZES}
+          />
+        )}
+      </ToolbarFooter>
+    </ToolbarSection>
+  );
+}


### PR DESCRIPTION
Previously lifted the entire visualize toolbar into a shared folder but there are things in there that are custom to spans, so this starts to bring the spans only parts back into the spans folders.

Next step is to make the following 3 things configurable
- aggregate options
- field options
- update rules when changing aggregates

And additionally, remove `traceItemType` from the props to avoid the `if traceItemType === ...` pattern everywhere.