### PR TITLE
feat(onboarding): re-arrange onboarding order for products

### DIFF
--- a/static/app/components/onboarding/productSelection.tsx
+++ b/static/app/components/onboarding/productSelection.tsx
@@ -403,6 +403,30 @@ export function ProductSelection({
         disabled={{reason: t("Let's admit it, we all have errors.")}}
         checked
       />
+      {products.includes(ProductSolution.LOGS) && (
+        <Product
+          label={t('Logs')}
+          description={t(
+            'Structured application logs for debugging and troubleshooting. Automatically gets associated with errors and traces.'
+          )}
+          docLink="https://docs.sentry.io/product/explore/logs/"
+          onClick={() => handleClickProduct(ProductSolution.LOGS)}
+          disabled={disabledProducts[ProductSolution.LOGS]}
+          checked={urlProducts.includes(ProductSolution.LOGS)}
+        />
+      )}
+      {products.includes(ProductSolution.SESSION_REPLAY) && (
+        <Product
+          label={t('Session Replay')}
+          description={t(
+            'Video-like reproductions of user sessions with debugging context to help you confirm issue impact and troubleshoot faster.'
+          )}
+          docLink="https://docs.sentry.io/product/explore/session-replay/"
+          onClick={() => handleClickProduct(ProductSolution.SESSION_REPLAY)}
+          disabled={disabledProducts[ProductSolution.SESSION_REPLAY]}
+          checked={urlProducts.includes(ProductSolution.SESSION_REPLAY)}
+        />
+      )}
       {products.includes(ProductSolution.PERFORMANCE_MONITORING) && (
         <Product
           label={t('Tracing')}
@@ -428,30 +452,6 @@ export function ProductSelection({
           onClick={() => handleClickProduct(ProductSolution.PROFILING)}
           disabled={disabledProducts[ProductSolution.PROFILING]}
           checked={urlProducts.includes(ProductSolution.PROFILING)}
-        />
-      )}
-      {products.includes(ProductSolution.SESSION_REPLAY) && (
-        <Product
-          label={t('Session Replay')}
-          description={t(
-            'Video-like reproductions of user sessions with debugging context to help you confirm issue impact and troubleshoot faster.'
-          )}
-          docLink="https://docs.sentry.io/product/explore/session-replay/"
-          onClick={() => handleClickProduct(ProductSolution.SESSION_REPLAY)}
-          disabled={disabledProducts[ProductSolution.SESSION_REPLAY]}
-          checked={urlProducts.includes(ProductSolution.SESSION_REPLAY)}
-        />
-      )}
-      {products.includes(ProductSolution.LOGS) && (
-        <Product
-          label={t('Logs')}
-          description={t(
-            'Structured application logs for debugging and troubleshooting. Automatically gets associated with errors and traces.'
-          )}
-          docLink="https://docs.sentry.io/product/explore/logs/"
-          onClick={() => handleClickProduct(ProductSolution.LOGS)}
-          disabled={disabledProducts[ProductSolution.LOGS]}
-          checked={urlProducts.includes(ProductSolution.LOGS)}
         />
       )}
     </Products>


### PR DESCRIPTION
Now that we are shipping logs, this re-arranges the onboarding order.

From what I can see there are no backend sdks with session replay. Generally everything follows this order:

1. Errors
2. Logs
3. Replays
4. Tracing
5. Profiling