### PR TITLE
fix(ProjectPageFilter): FeatureDisabled link was not clickable

### DIFF
--- a/static/app/components/organizations/projectPageFilter/index.tsx
+++ b/static/app/components/organizations/projectPageFilter/index.tsx
@@ -446,7 +446,9 @@ export function ProjectPageFilter({
 function shouldCloseOnInteractOutside(target: Element) {
   // Don't close select menu when clicking on power hovercard ("Requires Business Plan") or disabled feature hovercard
   const powerHovercard = target.closest('[data-test-id="power-hovercard"]');
-  const disabledFeatureHovercard = target.closest('.disabled-feature-hovercard');
+  const disabledFeatureHovercard = target.closest(
+    '[data-test-id="disabled-feature-hovercard"]'
+  );
   return !powerHovercard && !disabledFeatureHovercard;
 }
 
@@ -466,7 +468,7 @@ function checkboxWrapper(
               featureName={t('Multiple Project Selection')}
             />
           }
-          className="disabled-feature-hovercard"
+          data-test-id="disabled-feature-hovercard"
         >
           {typeof props.children === 'function' ? props.children(props) : props.children}
         </Hovercard>

--- a/static/app/components/organizations/projectPageFilter/index.tsx
+++ b/static/app/components/organizations/projectPageFilter/index.tsx
@@ -444,9 +444,8 @@ export function ProjectPageFilter({
 }
 
 function shouldCloseOnInteractOutside(target: Element) {
-  // Don't close select menu when clicking on power hovercard ("Requires Business Plan") or disabled feature hovercard that includes a link to the configuration documentation
-  const powerHovercard = target.closest('.power-hovercard');
-  // Don't close select menu / tooltip when clicking on disabled feature hovercard that includes a link to the configuration documentation
+  // Don't close select menu when clicking on power hovercard ("Requires Business Plan") or disabled feature hovercard
+  const powerHovercard = target.closest('[data-test-id="power-hovercard"]');
   const disabledFeatureHovercard = target.closest('.disabled-feature-hovercard');
   return !powerHovercard && !disabledFeatureHovercard;
 }

--- a/static/app/components/organizations/projectPageFilter/index.tsx
+++ b/static/app/components/organizations/projectPageFilter/index.tsx
@@ -444,9 +444,11 @@ export function ProjectPageFilter({
 }
 
 function shouldCloseOnInteractOutside(target: Element) {
-  // Don't close select menu when clicking on power hovercard ("Requires Business Plan")
-  const powerHovercard = document.querySelector("[data-test-id='power-hovercard']");
-  return !powerHovercard?.contains(target);
+  // Don't close select menu when clicking on power hovercard ("Requires Business Plan") or disabled feature hovercard that includes a link to the configuration documentation
+  const powerHovercard = target.closest('.power-hovercard');
+  // Don't close select menu / tooltip when clicking on disabled feature hovercard that includes a link to the configuration documentation
+  const disabledFeatureHovercard = target.closest('.disabled-feature-hovercard');
+  return !powerHovercard && !disabledFeatureHovercard;
 }
 
 function checkboxWrapper(
@@ -465,6 +467,7 @@ function checkboxWrapper(
               featureName={t('Multiple Project Selection')}
             />
           }
+          className="disabled-feature-hovercard"
         >
           {typeof props.children === 'function' ? props.children(props) : props.children}
         </Hovercard>


### PR DESCRIPTION
* The dropdown was closing when clicking the link because the outside dropdown event was being called before the link click would register

Enhancement on top of https://github.com/getsentry/sentry/pull/96514