### PR TITLE
feat(trace-eap-waterfall): Adding 1s buffer to start and end params of replay traces query

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceApi/useReplayTraceMeta.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useReplayTraceMeta.tsx
@@ -17,15 +17,23 @@ export function useReplayTraceMeta(
 ): TraceMetaQueryResults {
   const organization = useOrganization();
 
+  // The replay timestamps have seconds precision, while the trace timestamps have milliseconds precision.
+  // We fetch the traces with a 1 second buffer on either side of the replay timestamps to ensure we capture all
+  // associated traces.
+  const start = replayRecord
+    ? getUtcDateString(replayRecord?.started_at.getTime() - 1000)
+    : undefined;
+  const end = replayRecord
+    ? getUtcDateString(replayRecord?.finished_at.getTime() + 1000)
+    : undefined;
+
   // EventView that is used to fetch the list of events for the replay
   const eventView = useMemo(() => {
-    if (!replayRecord) {
+    if (!replayRecord || !start || !end) {
       return null;
     }
     const replayId = replayRecord?.id;
     const projectId = replayRecord?.project_id;
-    const start = getUtcDateString(replayRecord?.started_at.getTime());
-    const end = getUtcDateString(replayRecord?.finished_at.getTime());
 
     return EventView.fromSavedQuery({
       id: undefined,
@@ -38,10 +46,7 @@ export function useReplayTraceMeta(
       start,
       end,
     });
-  }, [replayRecord]);
-
-  const start = getUtcDateString(replayRecord?.started_at.getTime());
-  const end = getUtcDateString(replayRecord?.finished_at.getTime());
+  }, [replayRecord, start, end]);
 
   const {data: eventsData, isPending: eventsIsLoading} = useApiQuery<{
     data: TableDataRow[];


### PR DESCRIPTION
- The replay timestamps have seconds precision, while the trace timestamps have milliseconds precision.
- We fetch the traces with a 1 second buffer on either side of the replay timestamps to ensure we capture all associated traces.