### PR TITLE
feat(onboarding): Add logs to svelte onboarding snippets

### DIFF
--- a/static/app/components/onboarding/productSelection.tsx
+++ b/static/app/components/onboarding/productSelection.tsx
@@ -162,6 +162,7 @@ export const platformProductAvailability = {
   'javascript-svelte': [
     ProductSolution.PERFORMANCE_MONITORING,
     ProductSolution.SESSION_REPLAY,
+    ProductSolution.LOGS,
   ],
   'javascript-tanstackstart-react': [
     ProductSolution.PERFORMANCE_MONITORING,

--- a/static/app/gettingStartedDocs/javascript/svelte.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript/svelte.spec.tsx
@@ -87,4 +87,37 @@ describe('javascript-svelte onboarding docs', function () {
       screen.getByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
     ).toBeInTheDocument();
   });
+
+  it('enables logs by setting enableLogs to true', () => {
+    renderWithOnboardingLayout(docs, {
+      selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.LOGS],
+    });
+
+    expect(
+      screen.getByText(textWithMarkupMatcher(/enableLogs: true/))
+    ).toBeInTheDocument();
+  });
+
+  it('shows Logging Integrations in next steps when logs is selected', () => {
+    renderWithOnboardingLayout(docs, {
+      selectedProducts: [
+        ProductSolution.ERROR_MONITORING,
+        ProductSolution.PERFORMANCE_MONITORING,
+        ProductSolution.LOGS,
+      ],
+    });
+
+    expect(screen.getByText('Logging Integrations')).toBeInTheDocument();
+  });
+
+  it('does not show Logging Integrations in next steps when logs is not selected', () => {
+    renderWithOnboardingLayout(docs, {
+      selectedProducts: [
+        ProductSolution.ERROR_MONITORING,
+        ProductSolution.PERFORMANCE_MONITORING,
+      ],
+    });
+
+    expect(screen.queryByText('Logging Integrations')).not.toBeInTheDocument();
+  });
 });

--- a/static/app/gettingStartedDocs/javascript/svelte.tsx
+++ b/static/app/gettingStartedDocs/javascript/svelte.tsx
@@ -83,6 +83,12 @@ const getDynamicParts = (params: Params): string[] => {
         profilesSampleRate: 1.0`);
   }
 
+  if (params.isLogsSelected) {
+    dynamicParts.push(`
+      // Logs
+      enableLogs: true`);
+  }
+
   return dynamicParts;
 };
 
@@ -234,16 +240,31 @@ const onboarding: OnboardingConfig = {
       ],
     },
   ],
-  nextSteps: () => [
-    {
-      id: 'svelte-features',
-      name: t('Svelte Features'),
-      description: t(
-        'Learn about our first class integration with the Svelte framework.'
-      ),
-      link: 'https://docs.sentry.io/platforms/javascript/guides/svelte/features/',
-    },
-  ],
+  nextSteps: (params: Params) => {
+    const steps = [
+      {
+        id: 'svelte-features',
+        name: t('Svelte Features'),
+        description: t(
+          'Learn about our first class integration with the Svelte framework.'
+        ),
+        link: 'https://docs.sentry.io/platforms/javascript/guides/svelte/features/',
+      },
+    ];
+
+    if (params.isLogsSelected) {
+      steps.push({
+        id: 'logs',
+        name: t('Logging Integrations'),
+        description: t(
+          'Add logging integrations to automatically capture logs from your application.'
+        ),
+        link: 'https://docs.sentry.io/platforms/javascript/guides/svelte/logs/#integrations/',
+      });
+    }
+
+    return steps;
+  },
 };
 
 const replayOnboarding: OnboardingConfig = {


### PR DESCRIPTION
Adds support for Sentry Logs to the Svelte onboarding documentation.

resolves https://linear.app/getsentry/issue/LOGS-241/add-logs-to-svelte-onboarding

[Open in Web](https://cursor.com/agents?id=bc-3b15599a-8bd9-4a5d-a3e0-612fc8287ce4) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-3b15599a-8bd9-4a5d-a3e0-612fc8287ce4) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)