### PR TITLE
fix(replay): use navigation span instead of breadcrumb for ai summaries

### DIFF
--- a/src/sentry/replays/lib/summarize.py
+++ b/src/sentry/replays/lib/summarize.py
@@ -272,7 +272,7 @@ def as_log_message(event: dict[str, Any]) -> str | None:
                 message = event["data"]["payload"]["message"]
                 return f"User rage clicked on {message} but the triggered action was slow to complete at {timestamp}"
             case EventType.NAVIGATION:
-                to = event["data"]["payload"]["data"]["to"]
+                to = event["data"]["payload"]["description"]
                 return f"User navigated to: {to} at {timestamp}"
             case EventType.CONSOLE:
                 message = event["data"]["payload"]["message"]

--- a/src/sentry/replays/lib/summarize.py
+++ b/src/sentry/replays/lib/summarize.py
@@ -344,7 +344,7 @@ def as_log_message(event: dict[str, Any]) -> str | None:
             case EventType.CLS:
                 return None
             case EventType.NAVIGATION:
-                return None
+                return None  # we favor NAVIGATION_SPAN since the frontend favors navigation span events in the breadcrumb tab
     except (KeyError, ValueError):
         logger.exception(
             "Error parsing event in replay AI summary",

--- a/src/sentry/replays/lib/summarize.py
+++ b/src/sentry/replays/lib/summarize.py
@@ -271,7 +271,7 @@ def as_log_message(event: dict[str, Any]) -> str | None:
             case EventType.RAGE_CLICK:
                 message = event["data"]["payload"]["message"]
                 return f"User rage clicked on {message} but the triggered action was slow to complete at {timestamp}"
-            case EventType.NAVIGATION:
+            case EventType.NAVIGATION_SPAN:
                 to = event["data"]["payload"]["description"]
                 return f"User navigated to: {to} at {timestamp}"
             case EventType.CONSOLE:
@@ -342,6 +342,8 @@ def as_log_message(event: dict[str, Any]) -> str | None:
             case EventType.RESOURCE_SCRIPT:
                 return None
             case EventType.CLS:
+                return None
+            case EventType.NAVIGATION:
                 return None
     except (KeyError, ValueError):
         logger.exception(

--- a/src/sentry/replays/usecases/ingest/event_parser.py
+++ b/src/sentry/replays/usecases/ingest/event_parser.py
@@ -158,8 +158,6 @@ def which(event: dict[str, Any]) -> EventType:
                             return EventType.DEAD_CLICK
                     else:
                         return EventType.SLOW_CLICK
-                elif category == "navigation":
-                    return EventType.NAVIGATION
                 elif category == "console":
                     return EventType.CONSOLE
                 elif category == "ui.blur":
@@ -177,6 +175,8 @@ def which(event: dict[str, Any]) -> EventType:
             elif event["data"]["tag"] == "performanceSpan":
                 payload = event["data"]["payload"]
                 op = payload["op"]
+                if op.startswith("navigation"):
+                    return EventType.NAVIGATION
                 if op == "resource.fetch":
                     return EventType.RESOURCE_FETCH
                 elif op == "resource.xhr":

--- a/src/sentry/replays/usecases/ingest/event_parser.py
+++ b/src/sentry/replays/usecases/ingest/event_parser.py
@@ -111,6 +111,7 @@ class EventType(Enum):
     UI_FOCUS = 19
     UNKNOWN = 20
     CLS = 21
+    NAVIGATION_SPAN = 22
 
 
 def which(event: dict[str, Any]) -> EventType:
@@ -158,6 +159,8 @@ def which(event: dict[str, Any]) -> EventType:
                             return EventType.DEAD_CLICK
                     else:
                         return EventType.SLOW_CLICK
+                elif category == "navigation":
+                    return EventType.NAVIGATION
                 elif category == "console":
                     return EventType.CONSOLE
                 elif category == "ui.blur":
@@ -176,7 +179,7 @@ def which(event: dict[str, Any]) -> EventType:
                 payload = event["data"]["payload"]
                 op = payload["op"]
                 if op.startswith("navigation"):
-                    return EventType.NAVIGATION
+                    return EventType.NAVIGATION_SPAN
                 if op == "resource.fetch":
                     return EventType.RESOURCE_FETCH
                 elif op == "resource.xhr":

--- a/src/sentry/replays/usecases/ingest/event_parser.py
+++ b/src/sentry/replays/usecases/ingest/event_parser.py
@@ -510,6 +510,8 @@ def as_trace_item_context(event_type: EventType, event: dict[str, Any]) -> Trace
                 "event_hash": uuid.uuid4().bytes,
                 "timestamp": float(payload["startTimestamp"]),
             }
+        case EventType.NAVIGATION_SPAN:
+            return None
 
 
 def as_string_strict(value: Any) -> str:

--- a/tests/sentry/replays/unit/lib/test_summarize.py
+++ b/tests/sentry/replays/unit/lib/test_summarize.py
@@ -112,7 +112,13 @@ def test_as_log_message() -> None:
     event = {
         "type": 5,
         "timestamp": 0.0,
-        "data": {"tag": "breadcrumb", "payload": {"category": "navigation", "data": {"to": "/"}}},
+        "data": {
+            "tag": "performanceSpan",
+            "payload": {
+                "op": "navigation.push",
+                "description": "url",
+            },
+        },
     }
     assert as_log_message(event) is not None
 

--- a/tests/sentry/replays/unit/lib/test_summarize.py
+++ b/tests/sentry/replays/unit/lib/test_summarize.py
@@ -125,6 +125,16 @@ def test_as_log_message() -> None:
     event = {
         "type": 5,
         "timestamp": 0.0,
+        "data": {
+            "tag": "breadcrumb",
+            "payload": {"category": "navigation", "data": {"to": "/"}},
+        },
+    }
+    assert as_log_message(event) is None
+
+    event = {
+        "type": 5,
+        "timestamp": 0.0,
         "data": {"tag": "breadcrumb", "payload": {"category": "console", "message": "t"}},
     }
     assert as_log_message(event) is not None

--- a/tests/sentry/replays/unit/test_event_parser.py
+++ b/tests/sentry/replays/unit/test_event_parser.py
@@ -618,7 +618,16 @@ def test_which():
     event = {
         "type": 5,
         "timestamp": 0.0,
-        "data": {"tag": "breadcrumb", "payload": {"category": "navigation"}},
+        "data": {
+            "tag": "performanceSpan",
+            "payload": {
+                "op": "navigation.push",
+                "description": "url",
+                "startTimestamp": 1752530070.378,
+                "endTimestamp": 1752530070.378,
+                "data": {},
+            },
+        },
     }
     assert which(event) == EventType.NAVIGATION
 

--- a/tests/sentry/replays/unit/test_event_parser.py
+++ b/tests/sentry/replays/unit/test_event_parser.py
@@ -629,6 +629,13 @@ def test_which():
             },
         },
     }
+    assert which(event) == EventType.NAVIGATION_SPAN
+
+    event = {
+        "type": 5,
+        "timestamp": 0.0,
+        "data": {"tag": "breadcrumb", "payload": {"category": "navigation"}},
+    }
     assert which(event) == EventType.NAVIGATION
 
     event = {


### PR DESCRIPTION
fixes https://linear.app/getsentry/issue/REPLAY-543/sometimes-a-breadcrumb-is-not-included-in-the-chapter-ui

navigation span type:
```
{
    "type": 5,
    "timestamp": 1752530070.378,
    "data": {
        "tag": "performanceSpan",
        "payload": {
            "op": "navigation.push",
            "description": "<url>",
            "startTimestamp": 1752530070.378,
            "endTimestamp": 1752530070.378,
            "data": {}
        }
    }
}
```

keeps the original navigation breadcrumb event type since it's being used elsewhere, but introduce a new `NAVIGATION_SPAN` type for summaries use case