### PR TITLE
fix(dashboards): Invalidate the sidebar on favorite action

### DIFF
--- a/static/app/actionCreators/dashboards.tsx
+++ b/static/app/actionCreators/dashboards.tsx
@@ -6,9 +6,11 @@ import {ALL_ACCESS_PROJECTS} from 'sentry/constants/pageFilters';
 import {t} from 'sentry/locale';
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import type {PageFilters} from 'sentry/types/core';
+import type {Organization} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
 import {TOP_N} from 'sentry/utils/discover/types';
 import type {QueryClient} from 'sentry/utils/queryClient';
+import {getQueryKey} from 'sentry/views/dashboards/hooks/useGetStarredDashboards';
 import {
   type DashboardDetails,
   type DashboardListItem,
@@ -105,13 +107,13 @@ export function updateDashboardVisit(
 export async function updateDashboardFavorite(
   api: Client,
   queryClient: QueryClient,
-  orgId: string,
+  organization: Organization,
   dashboardId: string | string[],
   isFavorited: boolean
 ): Promise<void> {
   try {
     await api.requestPromise(
-      `/organizations/${orgId}/dashboards/${dashboardId}/favorite/`,
+      `/organizations/${organization.slug}/dashboards/${dashboardId}/favorite/`,
       {
         method: 'PUT',
         data: {
@@ -120,10 +122,7 @@ export async function updateDashboardFavorite(
       }
     );
     queryClient.invalidateQueries({
-      queryKey: [
-        `/organizations/${orgId}/dashboards/`,
-        {query: {filter: 'onlyFavorites'}},
-      ],
+      queryKey: getQueryKey(organization),
     });
     addSuccessMessage(isFavorited ? t('Added as favorite') : t('Removed as favorite'));
   } catch (response) {

--- a/static/app/views/dashboards/controls.tsx
+++ b/static/app/views/dashboards/controls.tsx
@@ -217,7 +217,7 @@ function Controls({
                     await updateDashboardFavorite(
                       api,
                       queryClient,
-                      organization.slug,
+                      organization,
                       dashboard.id,
                       !isFavorited
                     );

--- a/static/app/views/dashboards/manage/dashboardGrid.tsx
+++ b/static/app/views/dashboards/manage/dashboardGrid.tsx
@@ -74,7 +74,7 @@ function DashboardGrid({
     await updateDashboardFavorite(
       api,
       queryClient,
-      organization.slug,
+      organization,
       dashboard.id,
       isFavorited
     );

--- a/static/app/views/dashboards/manage/dashboardTable.tsx
+++ b/static/app/views/dashboards/manage/dashboardTable.tsx
@@ -98,7 +98,7 @@ function FavoriteButton({
           await updateDashboardFavorite(
             api,
             queryClient,
-            organization.slug,
+            organization,
             dashboardId,
             !favorited
           );

--- a/static/app/views/dashboards/manage/tableView/table.tsx
+++ b/static/app/views/dashboards/manage/tableView/table.tsx
@@ -106,7 +106,7 @@ export function DashboardTable({
                   await updateDashboardFavorite(
                     api,
                     queryClient,
-                    organization.slug,
+                    organization,
                     dashboard.id,
                     !dashboard.isFavorited
                   );


### PR DESCRIPTION
When favoriting from the dashboard specifically, we aren't invalidating the sidebar cache so it wasn't updating. Previously this hardcoded the old endpoint, but now that I have a helper that gives the starred dashboard key, I've imported it and changed the helper to pass along `organization` to do the feature flag check and invalidate the query for the sidebar.

There's probably a refactor available that reduces the other places where we also invalidate the dashboard list query key (i.e. for the overview page) but I'll revisit that as cleanup.