### PR TITLE
chore(ui): Reduce legacy react router types, deprecate RouterFixture

### DIFF
--- a/static/app/types/legacyReactRouter.tsx
+++ b/static/app/types/legacyReactRouter.tsx
@@ -3,80 +3,22 @@
  *
  * Once we've fully migrated to react-router 6 we can drop these types
  */
-import type {
-  Href,
-  Location,
-  LocationDescriptor,
-  LocationState,
-  Path,
-  Pathname,
-  Query,
-} from 'history';
+import type {Location, LocationDescriptor} from 'history';
 
-type Params = Record<string, string>;
-
-type RoutePattern = string;
 export type RouteComponent = React.ComponentClass<any> | React.FunctionComponent<any>;
-
-type RouteComponents = Record<string, RouteComponent>;
-
-interface RouterState<Q = any> {
-  components: RouteComponent[];
-  location: Location<Q>;
-  params: Params;
-  routes: PlainRoute[];
-}
-
-interface RedirectFunction {
-  (location: LocationDescriptor): void;
-  (state: LocationState, pathname: Pathname | Path, query?: Query): void;
-}
-
-type AnyFunction = (...args: any[]) => any;
-
-type EnterHook = (
-  nextState: RouterState,
-  replace: RedirectFunction,
-  callback?: AnyFunction
-) => any;
-
-type LeaveHook = (prevState: RouterState) => any;
-
-type ChangeHook = (
-  prevState: RouterState,
-  nextState: RouterState,
-  replace: RedirectFunction,
-  callback?: AnyFunction
-) => any;
-
-type RouteHook = (nextLocation?: Location) => any;
-
-type ComponentCallback = (err: any, component: RouteComponent) => any;
-type ComponentsCallback = (err: any, components: RouteComponents) => any;
 
 interface IndexRouteProps<Props = any> {
   component?: RouteComponent | undefined;
-  components?: RouteComponents | undefined;
-  getComponent?(nextState: RouterState, callback: ComponentCallback): void;
-  getComponents?(nextState: RouterState, callback: ComponentsCallback): void;
-  onChange?: ChangeHook | undefined;
-  onEnter?: EnterHook | undefined;
-  onLeave?: LeaveHook | undefined;
   props?: Props | undefined;
 }
 
 export interface RouteProps<Props = any> extends IndexRouteProps<Props> {
   children?: React.ReactNode;
-  path?: RoutePattern | undefined;
+  path?: string | undefined;
 }
-
-type RouteCallback = (err: any, route: PlainRoute) => void;
-type RoutesCallback = (err: any, routesArray: PlainRoute[]) => void;
 
 export interface PlainRoute<Props = any> extends RouteProps<Props> {
   childRoutes?: PlainRoute[] | undefined;
-  getChildRoutes?(partialNextState: LocationState, callback: RoutesCallback): void;
-  getIndexRoute?(partialNextState: LocationState, callback: RouteCallback): void;
   indexRoute?: PlainRoute | undefined;
 }
 
@@ -98,12 +40,8 @@ type LocationFunction = (location: LocationDescriptor) => void;
 type GoFunction = (n: number) => void;
 type NavigateFunction = () => void;
 type ActiveFunction = (location: LocationDescriptor, indexOnly?: boolean) => boolean;
-type LeaveHookFunction = (route: any, callback: RouteHook) => () => void;
-type CreatePartFunction<Part> = (pathOrLoc: LocationDescriptor, query?: any) => Part;
 
 export interface InjectedRouter<P = Record<string, string | undefined>, Q = any> {
-  createHref: CreatePartFunction<Href>;
-  createPath: CreatePartFunction<Path>;
   go: GoFunction;
   goBack: NavigateFunction;
   goForward: NavigateFunction;
@@ -113,7 +51,6 @@ export interface InjectedRouter<P = Record<string, string | undefined>, Q = any>
   push: LocationFunction;
   replace: LocationFunction;
   routes: PlainRoute[];
-  setRouteLeaveHook: LeaveHookFunction;
 }
 
 export interface WithRouterProps<P = Record<string, string | undefined>, Q = any> {

--- a/static/app/utils/browserHistory.tsx
+++ b/static/app/utils/browserHistory.tsx
@@ -17,8 +17,6 @@ const historyMethods: Array<keyof History> = [
   'goBack',
   'goForward',
   'createKey',
-  'createPath',
-  'createHref',
   'createLocation',
   'getCurrentLocation',
 ];

--- a/static/app/utils/useRouter.tsx
+++ b/static/app/utils/useRouter.tsx
@@ -53,17 +53,6 @@ function useRouter(): InjectedRouter<any, any> {
           console.error('isActive not implemented for react-router 6 migration');
           return false;
         },
-        createPath: (_pathOrLoc: LocationDescriptor, _query?: any) => {
-          throw new Error('createpath not implemented for react-router 6 migration');
-        },
-        createHref: (_pathOrLoc: LocationDescriptor, _query?: any) => {
-          throw new Error('createHref not implemented for react-router 6 migration');
-        },
-        setRouteLeaveHook: (_route: any, _callback: any) => () => {
-          throw new Error(
-            'setRouteLeave hook not implemented for react-router6 migration'
-          );
-        },
       }) satisfies InjectedRouter,
     [location, navigate, params, routes]
   );

--- a/tests/js/fixtures/routerFixture.ts
+++ b/tests/js/fixtures/routerFixture.ts
@@ -2,6 +2,10 @@ import {LocationFixture} from 'sentry-fixture/locationFixture';
 
 import type {InjectedRouter} from 'sentry/types/legacyReactRouter';
 
+/**
+ * @deprecated Use `initialRouterConfig` and the real react-router instead.
+ * https://develop.sentry.dev/frontend/using-rtl/#testing-route-changes
+ */
 export function RouterFixture(params = {}): InjectedRouter {
   return {
     push: jest.fn(),

--- a/tests/js/fixtures/routerFixture.ts
+++ b/tests/js/fixtures/routerFixture.ts
@@ -1,4 +1,3 @@
-import {stringify} from 'query-string';
 import {LocationFixture} from 'sentry-fixture/locationFixture';
 
 import type {InjectedRouter} from 'sentry/types/legacyReactRouter';
@@ -10,25 +9,8 @@ export function RouterFixture(params = {}): InjectedRouter {
     go: jest.fn(),
     goBack: jest.fn(),
     goForward: jest.fn(),
-    setRouteLeaveHook: jest.fn(),
     isActive: jest.fn(),
-    createHref: jest.fn().mockImplementation(to => {
-      if (typeof to === 'string') {
-        return to;
-      }
-
-      if (typeof to === 'object') {
-        if (!to.query) {
-          return to.pathname;
-        }
-
-        return `${to.pathname}?${stringify(to.query)}`;
-      }
-
-      return '';
-    }),
     location: LocationFixture(),
-    createPath: jest.fn(),
     routes: [],
     params: {},
     ...params,


### PR DESCRIPTION
remove some types for some of the unused functions. makes the file a bit easier to manage.

mark RouterFixture as deprecated
