### PR TITLE
layout: implement border on Container

### DIFF
--- a/static/app/components/core/layout/container.mdx
+++ b/static/app/components/core/layout/container.mdx
@@ -6,7 +6,7 @@ resources:
   js: https://github.com/getsentry/sentry/blob/master/static/app/components/core/layout/container.tsx
 ---
 
-import {Container} from 'sentry/components/core/layout/container';
+import {Container, Flex} from 'sentry/components/core/layout';
 import * as Storybook from 'sentry/stories';
 
 import APIReference from '!!type-loader!sentry/components/core/layout/container';
@@ -32,9 +32,9 @@ The simplest usage renders a `div` element with enhanced layout properties:
 The `padding` prop uses the theme's spacing system with shorthand support:
 
 <Storybook.Demo>
-  <Container display="flex" direction="column" gap="md">
+  <Flex gap="md">
     {['xs', 'sm', 'md', 'lg', 'xl', '2xl'].map(size => (
-      <Container key={size} background="tertiary" padding={size}>
+      <Container key={size} background="tertiary" padding={size} border="primary">
         <strong>{size} padding</strong> -{' '}
         {size === 'xs'
           ? '4px'
@@ -49,7 +49,7 @@ The `padding` prop uses the theme's spacing system with shorthand support:
                   : '24px'}
       </Container>
     ))}
-  </Container>
+  </Flex>
 </Storybook.Demo>
 ```jsx
 <Container padding="md">8px padding on all sides</Container>
@@ -62,17 +62,17 @@ The `padding` prop uses the theme's spacing system with shorthand support:
 Apply rounded corners using theme radius values:
 
 <Storybook.Demo>
-  <Container display="flex" gap="md">
-    <Container background="secondary" padding="md" radius="sm">
+  <Flex gap="md">
+    <Container background="secondary" padding="md" radius="sm" border="primary">
       Small radius
     </Container>
-    <Container background="secondary" padding="md" radius="md">
+    <Container background="secondary" padding="md" radius="md" border="primary">
       Medium radius
     </Container>
-    <Container background="secondary" padding="md" radius="lg">
+    <Container background="secondary" padding="md" radius="lg" border="primary">
       Large radius
     </Container>
-  </Container>
+  </Flex>
 </Storybook.Demo>
 ```jsx
 <Container background="secondary" padding="md" radius="md">
@@ -85,12 +85,13 @@ Apply rounded corners using theme radius values:
 Set positioning for absolute/relative layouts:
 
 <Storybook.Demo>
-  <Container position="relative" height="100px" background="secondary">
+  <Container position="relative" height="100px" background="primary" border="primary">
     <Container
       position="absolute"
       padding="xs"
       background="tertiary"
       style={{top: '12px', right: '8px'}}
+      border="primary"
     >
       Absolute positioned
     </Container>
@@ -98,7 +99,7 @@ Set positioning for absolute/relative layouts:
   </Container>
 </Storybook.Demo>
 ```jsx
-<Container position="relative" height="100px" background="secondary">
+<Container position="relative" height="100px" background="primary">
   <Container
     position="absolute"
     padding="xs"
@@ -114,29 +115,27 @@ Set positioning for absolute/relative layouts:
 ## Responsive Example
 
 <Storybook.Demo>
-  <Container
-    display={{xs: 'block', sm: 'flex'}}
+  <Flex
     padding={{xs: 'sm', lg: 'xl'}}
     background={{xs: 'primary', sm: 'secondary', lg: 'tertiary'}}
     radius={{xs: '0', sm: 'md'}}
+    border="primary"
   >
-    <Container padding="sm" background="primary" style={{flex: 1}}>
+    <Container padding="sm" background="primary" style={{flex: 1}} border="primary">
       Item 1
     </Container>
-    <Container padding="sm" background="secondary" style={{flex: 1}}>
+    <Container padding="sm" background="secondary" style={{flex: 1}} border="primary">
       Item 2
     </Container>
-  </Container>
+  </Flex>
 </Storybook.Demo>
 ```jsx
 <Container
-  // Changes from block to flex layout at sm breakpoint
-  display={{xs: 'block', sm: 'flex'}}
   // Padding increases at lg breakpoint
   padding={{xs: 'sm', lg: 'xl'}}
   // Background changes at sm and lg breakpoints
   background={{xs: 'primary', sm: 'secondary', lg: 'tertiary'}}
-  // Adds border radius at sm breakpoint
+  // Adds border="primary" radius at sm breakpoint
   radius={{xs: '0', sm: 'md'}}
 >
   <div>Responsive layout content</div>
@@ -158,13 +157,13 @@ The `area` prop supports CSS Grid integration:
       height: '200px',
     }}
   >
-    <Container area="header" background="tertiary" padding="sm">
+    <Container area="header" background="tertiary" padding="sm" border="primary">
       Header
     </Container>
-    <Container area="sidebar" background="secondary" padding="sm">
+    <Container area="sidebar" background="secondary" padding="sm" border="primary">
       Sidebar
     </Container>
-    <Container area="content" background="primary" padding="sm">
+    <Container area="content" background="primary" padding="sm" border="primary">
       Content
     </Container>
   </Container>

--- a/static/app/components/core/layout/container.tsx
+++ b/static/app/components/core/layout/container.tsx
@@ -4,6 +4,8 @@ import styled from '@emotion/styled';
 import type {Theme} from 'sentry/utils/theme';
 
 import {
+  type Border,
+  getBorder,
   getRadius,
   getSpacing,
   type RadiusSize,
@@ -38,6 +40,8 @@ interface BaseContainerProps {
   height?: Responsive<React.CSSProperties['height']>;
   minHeight?: Responsive<React.CSSProperties['minHeight']>;
   maxHeight?: Responsive<React.CSSProperties['maxHeight']>;
+
+  border?: Responsive<Border>;
 
   area?: Responsive<React.CSSProperties['gridArea']>;
 }
@@ -118,6 +122,8 @@ export const Container = styled(
   ${p => rc('max-height', p.maxHeight, p.theme)};
 
   ${p => rc('grid-area', p.area, p.theme)};
+
+  ${p => rc('border', p.border, p.theme, getBorder)};
 
   /**
    * This cast is required because styled-components does not preserve the generic signature of the wrapped component.

--- a/static/app/components/core/layout/container.tsx
+++ b/static/app/components/core/layout/container.tsx
@@ -70,6 +70,7 @@ export type ContainerProps<T extends ContainerElement = 'div'> = BaseContainerPr
 const omitContainerProps = new Set<keyof ContainerProps<any>>([
   'as',
   'area',
+  'border',
   'background',
   'display',
   'padding',

--- a/static/app/components/core/layout/styles.tsx
+++ b/static/app/components/core/layout/styles.tsx
@@ -60,6 +60,7 @@ const BREAKPOINT_ORDER: readonly Breakpoint[] = ['xs', 'sm', 'md', 'lg', 'xl'];
 // We alias None -> 0 to make it slighly more terse and easier to read.
 export type RadiusSize = keyof DO_NOT_USE_ChonkTheme['radius'];
 export type SpacingSize = keyof Theme['space'];
+export type Border = keyof Theme['tokens']['border'];
 type Breakpoint = keyof Theme['breakpoints'];
 
 // @TODO(jonasbadalic): audit for memory usage and linting performance issues.
@@ -97,6 +98,14 @@ function resolveSpacing(sizeComponent: SpacingSize, theme: Theme) {
   }
 
   return theme.space[sizeComponent] ?? theme.space['0'];
+}
+
+export function getBorder(
+  border: Border,
+  _breakpoint: Breakpoint | undefined,
+  theme: Theme
+) {
+  return `1px solid ${theme.tokens.border[border]}`;
 }
 
 export function getRadius(


### PR DESCRIPTION
Add border via `keyof theme.tokens.border` and map it to a single px value. Lets start here and see if we need to allow extending of border thickness.