### PR TITLE
fix(aci): Stop requiring condition_group in detector validator updates

### DIFF
--- a/src/sentry/workflow_engine/endpoints/validators/base/detector.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/detector.py
@@ -89,14 +89,15 @@ class BaseDetectorTypeValidator(CamelSnakeSerializer):
                     instance.owner_user_id = None
                     instance.owner_team_id = None
 
-            condition_group = validated_data.pop("condition_group")
-            data_conditions: list[DataConditionType] = condition_group.get("conditions")
+            if "condition_group" in validated_data:
+                condition_group = validated_data.pop("condition_group")
+                data_conditions: list[DataConditionType] = condition_group.get("conditions")
 
-            if data_conditions and instance.workflow_condition_group:
-                group_validator = BaseDataConditionGroupValidator()
-                group_validator.update(instance.workflow_condition_group, condition_group)
+                if data_conditions and instance.workflow_condition_group:
+                    group_validator = BaseDataConditionGroupValidator()
+                    group_validator.update(instance.workflow_condition_group, condition_group)
 
-        instance.save()
+            instance.save()
 
         create_audit_entry(
             request=self.context["request"],

--- a/tests/sentry/workflow_engine/detectors/test_error_detector.py
+++ b/tests/sentry/workflow_engine/detectors/test_error_detector.py
@@ -27,6 +27,9 @@ class TestErrorDetectorValidator(TestCase):
             "fingerprinting_rules": """message:"hello world 1" -> hw1 title="HW1""",
             "resolve_age": 30,
         }
+        self.existing_error_detector = Detector.objects.create(
+            name="Existing Detector", type="error", project_id=self.project.id, config={}
+        )
 
     @patch("sentry.workflow_engine.endpoints.validators.error_detector.create_audit_entry")
     def test_create_with_valid_data(self, mock_audit):
@@ -78,3 +81,16 @@ class TestErrorDetectorValidator(TestCase):
         assert validator.errors.get("resolveAge") == [
             ErrorDetail(string="Resolve age must be a non-negative number", code="invalid")
         ]
+
+    def test_update_existing_with_valid_data(self) -> None:
+        data = {**self.valid_data, "name": "Updated Detector"}
+        validator = ErrorDetectorValidator(
+            data=data, context=self.context, instance=self.existing_error_detector
+        )
+        assert validator.is_valid()
+        with self.tasks():
+            detector = validator.save()
+        assert detector.name == "Updated Detector"
+        assert detector.type == "error"
+        assert detector.project_id == self.project.id
+        assert detector.workflow_condition_group is None


### PR DESCRIPTION
Error monitors do not have anything for `condition_group`, so it shouldn't be required. This is also good for other monitor types like cron and uptime which will never want to modify the condition groups.