### PR TITLE
fix(typing): Codemod `None` return to top-level tests

### DIFF
--- a/tests/sentry/api/endpoints/test_custom_rules.py
+++ b/tests/sentry/api/endpoints/test_custom_rules.py
@@ -348,7 +348,7 @@ def test_custom_rule_serializer(what, value, valid):
     assert serializer.is_valid() == valid
 
 
-def test_custom_rule_serializer_creates_org_rule_when_no_projects_given():
+def test_custom_rule_serializer_creates_org_rule_when_no_projects_given() -> None:
     """
     Test that the serializer creates an org level rule when no projects are given
     """

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -1825,7 +1825,7 @@ class OrganizationSettings2FATest(TwoFactorAPITestCase):
         self.get_success_response(self.org_2fa.slug)
 
 
-def test_trusted_relays_option_serialization():
+def test_trusted_relays_option_serialization() -> None:
     # incoming raw data
     data = {
         "publicKey": _VALID_RELAY_KEYS[0],
@@ -1884,7 +1884,7 @@ def test_trusted_relay_serializer_validation(invalid_data):
     assert not serializer.is_valid()
 
 
-def test_trusted_relays_option_deserialization():
+def test_trusted_relays_option_deserialization() -> None:
     # internal data
     instance = {
         "public_key": "key1",

--- a/tests/sentry/api/endpoints/test_organization_profiling_functions.py
+++ b/tests/sentry/api/endpoints/test_organization_profiling_functions.py
@@ -314,7 +314,7 @@ class OrganizationProfilingFunctionTrendsEndpointTest(ProfilesSnubaTestCase):
             assert isinstance(data["examples"], list)
 
 
-def test_get_rollup_from_range_max_buckets():
+def test_get_rollup_from_range_max_buckets() -> None:
     max_buckets = int(MAX_ROLLUP_POINTS / TOP_FUNCTIONS_LIMIT)
 
     for days in range(90):

--- a/tests/sentry/api/endpoints/test_project_release_file_details.py
+++ b/tests/sentry/api/endpoints/test_project_release_file_details.py
@@ -16,7 +16,7 @@ from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.response import close_streaming_response
 
 
-def test_closes_depnedent_files_is_iterable():
+def test_closes_depnedent_files_is_iterable() -> None:
     # django (but not django.test) requires a file response to be iterable
     f = ClosesDependentFiles(io.BytesIO(b"hello\nworld\n"))
     assert list(f) == [b"hello\n", b"world\n"]

--- a/tests/sentry/api/endpoints/test_relay_globalconfig_v3.py
+++ b/tests/sentry/api/endpoints/test_relay_globalconfig_v3.py
@@ -58,7 +58,7 @@ def call_endpoint(client, relay, private_key):
         },
     }
 )
-def test_global_config():
+def test_global_config() -> None:
     config = get_global_config()
 
     normalized = normalize_global_config(config)
@@ -123,7 +123,7 @@ def test_return_global_config_on_right_version(
     },
 )
 @patch("sentry.relay.globalconfig.RELAY_OPTIONS", [])
-def test_global_config_valid_with_generic_filters():
+def test_global_config_valid_with_generic_filters() -> None:
     config = get_global_config()
     assert config == normalize_global_config(config)
 

--- a/tests/sentry/api/endpoints/test_relay_healthcheck.py
+++ b/tests/sentry/api/endpoints/test_relay_healthcheck.py
@@ -2,7 +2,7 @@ from django.test import Client
 from django.urls import reverse
 
 
-def test_healthcheck_endpoint():
+def test_healthcheck_endpoint() -> None:
     c = Client()
     url = reverse("sentry-api-0-relays-healthcheck")
     response = c.get(url)

--- a/tests/sentry/api/serializers/rest_framework/test_base.py
+++ b/tests/sentry/api/serializers/rest_framework/test_base.py
@@ -60,7 +60,7 @@ class CamelSnakeModelSerializerTest(TestCase):
         }
 
 
-def test_convert_dict_key_case():
+def test_convert_dict_key_case() -> None:
     camelData = {
         "appLabel": "hello",
         "model": "Something",

--- a/tests/sentry/api/test_paginator.py
+++ b/tests/sentry/api/test_paginator.py
@@ -382,7 +382,7 @@ class DateTimePaginatorTest(TestCase):
         assert result7[0] == res4
 
 
-def test_reverse_bisect_left():
+def test_reverse_bisect_left() -> None:
     assert reverse_bisect_left([], 0) == 0
 
     assert reverse_bisect_left([1], -1) == 1

--- a/tests/sentry/apidocs/test_extensions.py
+++ b/tests/sentry/apidocs/test_extensions.py
@@ -50,7 +50,7 @@ class FailSerializer(Serializer):
         raise NotImplementedError
 
 
-def test_sentry_response_serializer_extension():
+def test_sentry_response_serializer_extension() -> None:
     seralizer_extension = SentryResponseSerializerExtension(BasicSerializer)
     schema = seralizer_extension.map_serializer(AutoSchema(), "response")
     assert schema == {
@@ -81,7 +81,7 @@ def test_sentry_response_serializer_extension():
     }
 
 
-def test_sentry_inline_response_serializer_extension():
+def test_sentry_inline_response_serializer_extension() -> None:
     inline_serializer = inline_sentry_response_serializer(
         "BasicStuff", list[BasicSerializerResponse]
     )
@@ -123,13 +123,13 @@ def test_sentry_inline_response_serializer_extension():
     }
 
 
-def test_sentry_fails_when_serializer_not_typed():
+def test_sentry_fails_when_serializer_not_typed() -> None:
     seralizer_extension = SentryResponseSerializerExtension(FailSerializer)
     with pytest.raises(TypeError):
         seralizer_extension.map_serializer(AutoSchema(), "response")
 
 
-def test_sentry_restricted_json_field_extension():
+def test_sentry_restricted_json_field_extension() -> None:
     seralizer_extension = RestrictedJsonFieldExtension(serializers.JSONField)
     schema = seralizer_extension.map_serializer_field(AutoSchema(), "response")
     assert schema == {"type": "object", "additionalProperties": {}}

--- a/tests/sentry/apidocs/test_schema.py
+++ b/tests/sentry/apidocs/test_schema.py
@@ -4,7 +4,7 @@ from sentry.api.base import Endpoint
 from tests.sentry.apidocs import generate_schema
 
 
-def test_simple():
+def test_simple() -> None:
 
     op_id = "This is a test"
 
@@ -19,7 +19,7 @@ def test_simple():
     assert schema["paths"]["/foo"]["get"]["operationId"] == op_id
 
 
-def test_description():
+def test_description() -> None:
     class ExampleEndpoint(Endpoint):
         permission_classes = ()
 

--- a/tests/sentry/attachments/test_base.py
+++ b/tests/sentry/attachments/test_base.py
@@ -29,7 +29,7 @@ class InMemoryCache:
         del self.data[key]
 
 
-def test_meta_basic():
+def test_meta_basic() -> None:
     att = CachedAttachment(key="c:foo", id=123, name="lol.txt", content_type="text/plain", chunks=3)
 
     # Regression test to verify that we do not add additional attributes. Note
@@ -43,7 +43,7 @@ def test_meta_basic():
     }
 
 
-def test_meta_rate_limited():
+def test_meta_rate_limited() -> None:
     att = CachedAttachment(
         key="c:foo", id=123, name="lol.txt", content_type="text/plain", chunks=3, rate_limited=True
     )
@@ -58,7 +58,7 @@ def test_meta_rate_limited():
     }
 
 
-def test_basic_chunked():
+def test_basic_chunked() -> None:
     data = InMemoryCache()
     cache = BaseAttachmentCache(data)
 
@@ -79,7 +79,7 @@ def test_basic_chunked():
     assert not list(cache.get("c:foo"))
 
 
-def test_basic_unchunked():
+def test_basic_unchunked() -> None:
     data = InMemoryCache()
     cache = BaseAttachmentCache(data)
 
@@ -96,7 +96,7 @@ def test_basic_unchunked():
     assert not list(cache.get("c:foo"))
 
 
-def test_zstd_chunks():
+def test_zstd_chunks() -> None:
     data = InMemoryCache()
     cache = BaseAttachmentCache(data)
 
@@ -114,7 +114,7 @@ def test_zstd_chunks():
     assert not_chunked.data == b"Hello World! Bye."
 
 
-def test_basic_rate_limited():
+def test_basic_rate_limited() -> None:
     data = InMemoryCache()
     cache = BaseAttachmentCache(data)
 

--- a/tests/sentry/auth/test_system.py
+++ b/tests/sentry/auth/test_system.py
@@ -14,7 +14,7 @@ class TestSystemAuth(TestCase):
 
 @django_db_all
 @control_silo_test
-def test_system_token_option():
+def test_system_token_option() -> None:
     from sentry import options
 
     options.delete("sentry:system-token")

--- a/tests/sentry/backup/test_comparators.py
+++ b/tests/sentry/backup/test_comparators.py
@@ -23,7 +23,7 @@ from sentry.backup.dependencies import ImportKind, NormalizedModelName, PrimaryK
 from sentry.backup.findings import ComparatorFindingKind, InstanceID
 
 
-def test_good_comparator_both_sides_existing():
+def test_good_comparator_both_sides_existing() -> None:
     cmp = DateUpdatedComparator("my_date_field")
     id = InstanceID("sentry.test", 0)
     present: Any = {
@@ -37,7 +37,7 @@ def test_good_comparator_both_sides_existing():
     assert not cmp.existence(id, present, present)
 
 
-def test_good_comparator_neither_side_existing():
+def test_good_comparator_neither_side_existing() -> None:
     cmp = DateUpdatedComparator("my_date_field")
     id = InstanceID("sentry.test", 0)
     missing: Any = {
@@ -49,7 +49,7 @@ def test_good_comparator_neither_side_existing():
     assert not cmp.existence(id, missing, missing)
 
 
-def test_bad_comparator_only_one_side_existing():
+def test_bad_comparator_only_one_side_existing() -> None:
     cmp = DateUpdatedComparator("my_date_field")
     id = InstanceID("sentry.test", 0)
     present: Any = {
@@ -91,7 +91,7 @@ def test_bad_comparator_only_one_side_existing():
     assert "my_date_field" in res[0].reason
 
 
-def test_good_comparator_both_sides_null():
+def test_good_comparator_both_sides_null() -> None:
     cmp = DateUpdatedComparator("my_date_field")
     id = InstanceID("sentry.test", 0)
     nulled: Any = {
@@ -105,7 +105,7 @@ def test_good_comparator_both_sides_null():
     assert not cmp.existence(id, nulled, nulled)
 
 
-def test_bad_comparator_only_one_side_null():
+def test_bad_comparator_only_one_side_null() -> None:
     cmp = DateUpdatedComparator("my_date_field")
     id = InstanceID("sentry.test", 0)
     present: Any = {
@@ -149,7 +149,7 @@ def test_bad_comparator_only_one_side_null():
     assert "my_date_field" in res[0].reason
 
 
-def test_good_comparator_one_side_null_other_side_missing():
+def test_good_comparator_one_side_null_other_side_missing() -> None:
     cmp = DateUpdatedComparator("my_date_field")
     id = InstanceID("sentry.test", 0)
     nulled: Any = {
@@ -173,7 +173,7 @@ def test_good_comparator_one_side_null_other_side_missing():
     assert not res
 
 
-def test_good_auto_suffix_comparator():
+def test_good_auto_suffix_comparator() -> None:
     cmp = AutoSuffixComparator("same", "suffixed")
     id = InstanceID("sentry.test", 0)
     left: Any = {
@@ -197,7 +197,7 @@ def test_good_auto_suffix_comparator():
     assert not cmp.compare(id, left, right)
 
 
-def test_bad_auto_suffix_comparator():
+def test_bad_auto_suffix_comparator() -> None:
     cmp = AutoSuffixComparator("same", "suffixed")
     id = InstanceID("sentry.test", 0)
     left: Any = {
@@ -239,7 +239,7 @@ def test_bad_auto_suffix_comparator():
     assert "foo-barbaz" in res[1].reason
 
 
-def test_good_auto_suffix_comparator_existence():
+def test_good_auto_suffix_comparator_existence() -> None:
     cmp = AutoSuffixComparator("auto_suffix_field")
     id = InstanceID("sentry.test", 0)
     present: Any = {
@@ -269,7 +269,7 @@ def test_good_auto_suffix_comparator_existence():
     assert "`auto_suffix_field`" in res[0].reason
 
 
-def test_good_auto_suffix_comparator_scrubbed():
+def test_good_auto_suffix_comparator_scrubbed() -> None:
     cmp = AutoSuffixComparator("same", "suffixed")
     left: Any = {
         "model": "test",
@@ -299,7 +299,7 @@ def test_good_auto_suffix_comparator_scrubbed():
     assert right["scrubbed"]["AutoSuffixComparator::suffixed"] is ScrubbedData.SCRUBBED_DATA
 
 
-def test_good_datetime_equality_comparator():
+def test_good_datetime_equality_comparator() -> None:
     cmp = DatetimeEqualityComparator("my_date_field")
     id = InstanceID("sentry.test", 0)
     left: Any = {
@@ -321,7 +321,7 @@ def test_good_datetime_equality_comparator():
     assert not cmp.compare(id, left, right)
 
 
-def test_bad_datetime_equality_comparator():
+def test_bad_datetime_equality_comparator() -> None:
     cmp = DatetimeEqualityComparator("my_date_field")
     id = InstanceID("sentry.test", 0)
     left: Any = {
@@ -354,7 +354,7 @@ def test_bad_datetime_equality_comparator():
     assert "right value (2023-06-22T00:00:00.123Z)" in res[0].reason
 
 
-def test_good_date_updated_comparator():
+def test_good_date_updated_comparator() -> None:
     cmp = DateUpdatedComparator("my_date_field")
     id = InstanceID("sentry.test", 0)
     left: Any = {
@@ -376,7 +376,7 @@ def test_good_date_updated_comparator():
     assert not cmp.compare(id, left, right)
 
 
-def test_bad_date_updated_comparator():
+def test_bad_date_updated_comparator() -> None:
     cmp = DateUpdatedComparator("my_date_field")
     id = InstanceID("sentry.test", 0)
     left: Any = {
@@ -409,7 +409,7 @@ def test_bad_date_updated_comparator():
     assert "right value (2023-06-22T23:00:00.001Z)" in res[0].reason
 
 
-def test_good_email_obfuscating_comparator():
+def test_good_email_obfuscating_comparator() -> None:
     cmp = EmailObfuscatingComparator("one_email", "many_emails")
     id = InstanceID("sentry.test", 0)
     model = {
@@ -427,7 +427,7 @@ def test_good_email_obfuscating_comparator():
     assert not cmp.compare(id, model, model)
 
 
-def test_bad_email_obfuscating_comparator():
+def test_bad_email_obfuscating_comparator() -> None:
     cmp = EmailObfuscatingComparator("one_email", "many_emails")
     id = InstanceID("sentry.test", 0)
     left: Any = {
@@ -475,7 +475,7 @@ def test_bad_email_obfuscating_comparator():
     assert "a...@...ng.com" in res[1].reason
 
 
-def test_good_email_obfuscating_comparator_existence():
+def test_good_email_obfuscating_comparator_existence() -> None:
     cmp = EmailObfuscatingComparator("email_obfuscating_field")
     id = InstanceID("sentry.test", 0)
     present: Any = {
@@ -505,7 +505,7 @@ def test_good_email_obfuscating_comparator_existence():
     assert "`email_obfuscating_field`" in res[0].reason
 
 
-def test_good_email_obfuscating_comparator_scrubbed():
+def test_good_email_obfuscating_comparator_scrubbed() -> None:
     cmp = EmailObfuscatingComparator("one_email", "many_emails")
     left: Any = {
         "model": "test",
@@ -547,7 +547,7 @@ def test_good_email_obfuscating_comparator_scrubbed():
     ]
 
 
-def test_good_equal_or_removed_comparator_equal():
+def test_good_equal_or_removed_comparator_equal() -> None:
     cmp = EqualOrRemovedComparator("my_field")
     id = InstanceID("sentry.test", 0)
     present: Any = {
@@ -563,7 +563,7 @@ def test_good_equal_or_removed_comparator_equal():
     assert not cmp.compare(id, present, present)
 
 
-def test_good_equal_or_removed_comparator_not_equal():
+def test_good_equal_or_removed_comparator_not_equal() -> None:
     cmp = EqualOrRemovedComparator("my_field")
     id = InstanceID("sentry.test", 0)
     left: Any = {
@@ -599,7 +599,7 @@ def test_good_equal_or_removed_comparator_not_equal():
     assert "bar" in res[0].reason
 
 
-def test_good_equal_or_removed_comparator_neither_side_existing():
+def test_good_equal_or_removed_comparator_neither_side_existing() -> None:
     cmp = EqualOrRemovedComparator("my_field")
     id = InstanceID("sentry.test", 0)
     missing: Any = {
@@ -611,7 +611,7 @@ def test_good_equal_or_removed_comparator_neither_side_existing():
     assert not cmp.existence(id, missing, missing)
 
 
-def test_good_equal_or_removed_comparator_only_right_side_missing():
+def test_good_equal_or_removed_comparator_only_right_side_missing() -> None:
     cmp = EqualOrRemovedComparator("my_field")
     id = InstanceID("sentry.test", 0)
     present: Any = {
@@ -632,7 +632,7 @@ def test_good_equal_or_removed_comparator_only_right_side_missing():
     assert not cmp.compare(id, present, missing)
 
 
-def test_bad_equal_or_removed_comparator_only_left_side_missing():
+def test_bad_equal_or_removed_comparator_only_left_side_missing() -> None:
     cmp = EqualOrRemovedComparator("my_field")
     id = InstanceID("sentry.test", 0)
     present: Any = {
@@ -662,7 +662,7 @@ def test_bad_equal_or_removed_comparator_only_left_side_missing():
     assert "my_field" in res[0].reason
 
 
-def test_good_equal_or_removed_comparator_both_sides_nulled():
+def test_good_equal_or_removed_comparator_both_sides_nulled() -> None:
     cmp = EqualOrRemovedComparator("my_field")
     id = InstanceID("sentry.test", 0)
     nulled: Any = {
@@ -676,7 +676,7 @@ def test_good_equal_or_removed_comparator_both_sides_nulled():
     assert not cmp.existence(id, nulled, nulled)
 
 
-def test_good_equal_or_removed_comparator_only_right_side_nulled():
+def test_good_equal_or_removed_comparator_only_right_side_nulled() -> None:
     cmp = EqualOrRemovedComparator("my_field")
     id = InstanceID("sentry.test", 0)
     present: Any = {
@@ -699,7 +699,7 @@ def test_good_equal_or_removed_comparator_only_right_side_nulled():
     assert not cmp.compare(id, present, missing)
 
 
-def test_bad_equal_or_removed_comparator_only_left_side_nulled():
+def test_bad_equal_or_removed_comparator_only_left_side_nulled() -> None:
     cmp = EqualOrRemovedComparator("my_field")
     id = InstanceID("sentry.test", 0)
     present: Any = {
@@ -731,7 +731,7 @@ def test_bad_equal_or_removed_comparator_only_left_side_nulled():
     assert "my_field" in res[0].reason
 
 
-def test_good_hash_obfuscating_comparator():
+def test_good_hash_obfuscating_comparator() -> None:
     cmp = HashObfuscatingComparator("one_hash", "many_hashes")
     id = InstanceID("sentry.test", 0)
     model: Any = {
@@ -749,7 +749,7 @@ def test_good_hash_obfuscating_comparator():
     assert not cmp.compare(id, model, model)
 
 
-def test_bad_hash_obfuscating_comparator():
+def test_bad_hash_obfuscating_comparator() -> None:
     cmp = HashObfuscatingComparator("one_hash", "many_hashes")
     id = InstanceID("sentry.test", 0)
     left: Any = {
@@ -797,7 +797,7 @@ def test_bad_hash_obfuscating_comparator():
     assert "124...39c" in res[1].reason
 
 
-def test_good_hash_obfuscating_comparator_existence():
+def test_good_hash_obfuscating_comparator_existence() -> None:
     cmp = HashObfuscatingComparator("hash_obfuscating_field")
     id = InstanceID("sentry.test", 0)
     present: Any = {
@@ -827,7 +827,7 @@ def test_good_hash_obfuscating_comparator_existence():
     assert "`hash_obfuscating_field`" in res[0].reason
 
 
-def test_good_hash_obfuscating_comparator_scrubbed():
+def test_good_hash_obfuscating_comparator_scrubbed() -> None:
     cmp = HashObfuscatingComparator("one_hash", "many_hashes")
     left: Any = {
         "model": "test",
@@ -869,7 +869,7 @@ def test_good_hash_obfuscating_comparator_scrubbed():
     ]
 
 
-def test_good_foreign_key_comparator():
+def test_good_foreign_key_comparator() -> None:
     deps = dependencies()
     cmp = ForeignKeyComparator(
         {k: v.model for k, v in deps[NormalizedModelName("sentry.UserEmail")].foreign_keys.items()}
@@ -908,7 +908,7 @@ def test_good_foreign_key_comparator():
     assert not cmp.compare(id, left, right)
 
 
-def test_good_foreign_key_comparator_existence():
+def test_good_foreign_key_comparator_existence() -> None:
     deps = dependencies()
     cmp = ForeignKeyComparator(
         {k: v.model for k, v in deps[NormalizedModelName("sentry.UserEmail")].foreign_keys.items()}
@@ -950,7 +950,7 @@ def test_good_foreign_key_comparator_existence():
     assert "`user`" in res[0].reason
 
 
-def test_good_foreign_key_comparator_scrubbed():
+def test_good_foreign_key_comparator_scrubbed() -> None:
     deps = dependencies()
     cmp = ForeignKeyComparator(
         {k: v.model for k, v in deps[NormalizedModelName("sentry.UserEmail")].foreign_keys.items()}
@@ -976,7 +976,7 @@ def test_good_foreign_key_comparator_scrubbed():
     assert right["scrubbed"]["ForeignKeyComparator::user"] is ScrubbedData.SCRUBBED_DATA
 
 
-def test_bad_foreign_key_comparator_set_primary_key_maps_not_called():
+def test_bad_foreign_key_comparator_set_primary_key_maps_not_called() -> None:
     deps = dependencies()
     cmp = ForeignKeyComparator(
         {k: v.model for k, v in deps[NormalizedModelName("sentry.UserEmail")].foreign_keys.items()}
@@ -1015,7 +1015,7 @@ def test_bad_foreign_key_comparator_set_primary_key_maps_not_called():
         cmp.compare(id, left, right)
 
 
-def test_bad_foreign_key_comparator_unequal_mapping():
+def test_bad_foreign_key_comparator_unequal_mapping() -> None:
     deps = dependencies()
     cmp = ForeignKeyComparator(
         {k: v.model for k, v in deps[NormalizedModelName("sentry.UserEmail")].foreign_keys.items()}
@@ -1065,7 +1065,7 @@ def test_bad_foreign_key_comparator_unequal_mapping():
     assert "right foreign key ordinal (2)" in res[0].reason
 
 
-def test_bad_foreign_key_comparator_missing_mapping():
+def test_bad_foreign_key_comparator_missing_mapping() -> None:
     deps = dependencies()
     cmp = ForeignKeyComparator(
         {k: v.model for k, v in deps[NormalizedModelName("sentry.UserEmail")].foreign_keys.items()}
@@ -1121,7 +1121,7 @@ def test_bad_foreign_key_comparator_missing_mapping():
     assert "pk `34`" in res[1].reason
 
 
-def test_good_ignored_comparator():
+def test_good_ignored_comparator() -> None:
     cmp = IgnoredComparator("ignored_field")
     id = InstanceID("sentry.test", 0)
     model: Any = {
@@ -1136,7 +1136,7 @@ def test_good_ignored_comparator():
     assert not cmp.compare(id, model, model)
 
 
-def test_good_ignored_comparator_existence():
+def test_good_ignored_comparator_existence() -> None:
     cmp = IgnoredComparator("ignored_field")
     id = InstanceID("sentry.test", 0)
     present: Any = {
@@ -1157,7 +1157,7 @@ def test_good_ignored_comparator_existence():
     assert not res
 
 
-def test_good_ignored_comparator_scrubbed():
+def test_good_ignored_comparator_scrubbed() -> None:
     cmp = IgnoredComparator("ignored_field")
     left: Any = {
         "model": "test",
@@ -1179,7 +1179,7 @@ def test_good_ignored_comparator_scrubbed():
     assert right["scrubbed"].get("IgnoredComparator::other_field") is None
 
 
-def test_good_secret_hex_comparator():
+def test_good_secret_hex_comparator() -> None:
     cmp = SecretHexComparator(8, "equal", "unequal")
     id = InstanceID("sentry.test", 0)
     left: Any = {
@@ -1203,7 +1203,7 @@ def test_good_secret_hex_comparator():
     assert not cmp.compare(id, left, right)
 
 
-def test_bad_secret_hex_comparator():
+def test_bad_secret_hex_comparator() -> None:
     cmp = SecretHexComparator(8, "same", "invalid_left", "invalid_right")
     id = InstanceID("sentry.test", 0)
     left: Any = {
@@ -1251,7 +1251,7 @@ def test_bad_secret_hex_comparator():
     assert "bar" in res[1].reason
 
 
-def test_good_secret_hex_comparator_scrubbed():
+def test_good_secret_hex_comparator_scrubbed() -> None:
     cmp = SecretHexComparator(8, "secret_hex_field")
     left: Any = {
         "model": "test",
@@ -1277,7 +1277,7 @@ def test_good_secret_hex_comparator_scrubbed():
     assert right["scrubbed"]["SecretHexComparator::secret_hex_field"] is ScrubbedData.SCRUBBED_DATA
 
 
-def test_good_subscription_id_comparator():
+def test_good_subscription_id_comparator() -> None:
     cmp = SubscriptionIDComparator("subscription_id_field")
     id = InstanceID("sentry.test", 0)
     left: Any = {
@@ -1299,7 +1299,7 @@ def test_good_subscription_id_comparator():
     assert not cmp.compare(id, left, right)
 
 
-def test_bad_subscription_id_comparator():
+def test_bad_subscription_id_comparator() -> None:
     cmp = SubscriptionIDComparator("same", "invalid_left", "invalid_right")
     id = InstanceID("sentry.test", 0)
     left: Any = {
@@ -1356,7 +1356,7 @@ def test_bad_subscription_id_comparator():
     assert "0/foobar" in res[2].reason
 
 
-def test_good_subscription_id_comparator_existence():
+def test_good_subscription_id_comparator_existence() -> None:
     cmp = SubscriptionIDComparator("subscription_id_field")
     id = InstanceID("sentry.test", 0)
     present: Any = {
@@ -1386,7 +1386,7 @@ def test_good_subscription_id_comparator_existence():
     assert "`subscription_id_field`" in res[0].reason
 
 
-def test_good_subscription_id_comparator_scrubbed():
+def test_good_subscription_id_comparator_scrubbed() -> None:
     cmp = SubscriptionIDComparator("subscription_id_field")
     left: Any = {
         "model": "test",
@@ -1418,7 +1418,7 @@ def test_good_subscription_id_comparator_scrubbed():
     )
 
 
-def test_good_unordered_list_comparator():
+def test_good_unordered_list_comparator() -> None:
     cmp = UnorderedListComparator("ordered", "unordered")
     id = InstanceID("sentry.test", 0)
     left: Any = {
@@ -1442,7 +1442,7 @@ def test_good_unordered_list_comparator():
     assert not cmp.compare(id, left, right)
 
 
-def test_bad_unordered_list_comparator():
+def test_bad_unordered_list_comparator() -> None:
     cmp = UnorderedListComparator("unequal")
     id = InstanceID("sentry.test", 0)
     left: Any = {
@@ -1476,7 +1476,7 @@ def test_bad_unordered_list_comparator():
     assert "['a', 'b', 'c']" in res[0].reason
 
 
-def test_good_unordered_list_comparator_existence():
+def test_good_unordered_list_comparator_existence() -> None:
     cmp = UnorderedListComparator("unordered_list_field")
     id = InstanceID("sentry.test", 0)
     present: Any = {
@@ -1506,7 +1506,7 @@ def test_good_unordered_list_comparator_existence():
     assert "`unordered_list_field`" in res[0].reason
 
 
-def test_good_unordered_list_comparator_scrubbed():
+def test_good_unordered_list_comparator_scrubbed() -> None:
     cmp = UnorderedListComparator("unordered_list_field")
     left: Any = {
         "model": "test",
@@ -1538,7 +1538,7 @@ def test_good_unordered_list_comparator_scrubbed():
     )
 
 
-def test_good_uuid4_comparator():
+def test_good_uuid4_comparator() -> None:
     cmp = UUID4Comparator("guid_field")
     id = InstanceID("sentry.test", 0)
     left: Any = {
@@ -1560,7 +1560,7 @@ def test_good_uuid4_comparator():
     assert not cmp.compare(id, left, right)
 
 
-def test_bad_uuid4_comparator():
+def test_bad_uuid4_comparator() -> None:
     cmp = UUID4Comparator("same", "invalid_left", "invalid_right")
     id = InstanceID("sentry.test", 0)
     left: Any = {
@@ -1617,7 +1617,7 @@ def test_bad_uuid4_comparator():
     assert "bar" in res[2].reason
 
 
-def test_good_uuid4_comparator_scrubbed():
+def test_good_uuid4_comparator_scrubbed() -> None:
     cmp = UUID4Comparator("guid_field")
     left: Any = {
         "model": "test",
@@ -1643,7 +1643,7 @@ def test_good_uuid4_comparator_scrubbed():
     assert right["scrubbed"]["UUID4Comparator::guid_field"] is ScrubbedData.SCRUBBED_DATA
 
 
-def test_good_user_password_obfuscating_comparator_claimed_user():
+def test_good_user_password_obfuscating_comparator_claimed_user() -> None:
     cmp = UserPasswordObfuscatingComparator()
     id = InstanceID("sentry.test", 0)
     model: Any = {
@@ -1660,7 +1660,7 @@ def test_good_user_password_obfuscating_comparator_claimed_user():
     assert not cmp.compare(id, model, model)
 
 
-def test_good_user_password_obfuscating_comparator_claimed_user_never_changed_password():
+def test_good_user_password_obfuscating_comparator_claimed_user_never_changed_password() -> None:
     cmp = UserPasswordObfuscatingComparator()
     id = InstanceID("sentry.test", 0)
     missing: Any = {
@@ -1689,7 +1689,7 @@ def test_good_user_password_obfuscating_comparator_claimed_user_never_changed_pa
     assert not cmp.compare(id, missing, nulled)
 
 
-def test_good_user_password_obfuscating_comparator_newly_unclaimed_user():
+def test_good_user_password_obfuscating_comparator_newly_unclaimed_user() -> None:
     cmp = UserPasswordObfuscatingComparator()
     id = InstanceID("sentry.test", 0)
     left: Any = {
@@ -1717,7 +1717,9 @@ def test_good_user_password_obfuscating_comparator_newly_unclaimed_user():
     assert not cmp.compare(id, left, right)
 
 
-def test_good_user_password_obfuscating_comparator_newly_unclaimed_user_never_changed_password():
+def test_good_user_password_obfuscating_comparator_newly_unclaimed_user_never_changed_password() -> (
+    None
+):
     cmp = UserPasswordObfuscatingComparator()
     id = InstanceID("sentry.test", 0)
     left: Any = {
@@ -1745,7 +1747,7 @@ def test_good_user_password_obfuscating_comparator_newly_unclaimed_user_never_ch
     assert not cmp.compare(id, left, right)
 
 
-def test_good_user_password_obfuscating_comparator_already_unclaimed_user():
+def test_good_user_password_obfuscating_comparator_already_unclaimed_user() -> None:
     cmp = UserPasswordObfuscatingComparator()
     id = InstanceID("sentry.test", 0)
     left: Any = {
@@ -1773,7 +1775,7 @@ def test_good_user_password_obfuscating_comparator_already_unclaimed_user():
     assert not cmp.compare(id, left, right)
 
 
-def test_bad_user_password_obfuscating_comparator_claimed_user_password_changed():
+def test_bad_user_password_obfuscating_comparator_claimed_user_password_changed() -> None:
     cmp = UserPasswordObfuscatingComparator()
     id = InstanceID("sentry.test", 0)
     left: Any = {
@@ -1812,7 +1814,7 @@ def test_bad_user_password_obfuscating_comparator_claimed_user_password_changed(
     assert "pbkdf2_sha25...+Qayg=" in res[0].reason
 
 
-def test_bad_user_password_obfuscating_comparator_newly_unclaimed_user_password_unchanged():
+def test_bad_user_password_obfuscating_comparator_newly_unclaimed_user_password_unchanged() -> None:
     cmp = UserPasswordObfuscatingComparator()
     id = InstanceID("sentry.test", 0)
     left: Any = {
@@ -1850,7 +1852,9 @@ def test_bad_user_password_obfuscating_comparator_newly_unclaimed_user_password_
     assert res[0].reason.count("pbkdf2_sha25...OCTiw=") == 2
 
 
-def test_bad_user_password_obfuscating_comparator_already_unclaimed_user_password_unchanged():
+def test_bad_user_password_obfuscating_comparator_already_unclaimed_user_password_unchanged() -> (
+    None
+):
     cmp = UserPasswordObfuscatingComparator()
     id = InstanceID("sentry.test", 0)
     left: Any = {
@@ -1888,7 +1892,7 @@ def test_bad_user_password_obfuscating_comparator_already_unclaimed_user_passwor
     assert res[0].reason.count("pbkdf2_sha25...OCTiw=") == 2
 
 
-def test_bad_user_password_obfuscating_comparator_impossible_newly_claimed_user():
+def test_bad_user_password_obfuscating_comparator_impossible_newly_claimed_user() -> None:
     cmp = UserPasswordObfuscatingComparator()
     id = InstanceID("sentry.test", 0)
     left: Any = {
@@ -1926,7 +1930,9 @@ def test_bad_user_password_obfuscating_comparator_impossible_newly_claimed_user(
     assert "cannot claim" in res[0].reason
 
 
-def test_bad_user_password_obfuscating_comparator_unclaimed_user_last_password_change_nulled():
+def test_bad_user_password_obfuscating_comparator_unclaimed_user_last_password_change_nulled() -> (
+    None
+):
     cmp = UserPasswordObfuscatingComparator()
     id = InstanceID("sentry.test", 0)
     left: Any = {
@@ -1964,7 +1970,9 @@ def test_bad_user_password_obfuscating_comparator_unclaimed_user_last_password_c
     assert "less than" in res[0].reason
 
 
-def test_bad_user_password_obfuscating_comparator_already_unclaimed_user_password_unexpired():
+def test_bad_user_password_obfuscating_comparator_already_unclaimed_user_password_unexpired() -> (
+    None
+):
     cmp = UserPasswordObfuscatingComparator()
     id = InstanceID("sentry.test", 0)
     left: Any = {
@@ -2001,7 +2009,9 @@ def test_bad_user_password_obfuscating_comparator_already_unclaimed_user_passwor
     assert "`is_password_expired`" in res[0].reason
 
 
-def test_bad_user_password_obfuscating_comparator_newly_unclaimed_user_password_still_expired():
+def test_bad_user_password_obfuscating_comparator_newly_unclaimed_user_password_still_expired() -> (
+    None
+):
     cmp = UserPasswordObfuscatingComparator()
     id = InstanceID("sentry.test", 0)
     left: Any = {
@@ -2039,7 +2049,7 @@ def test_bad_user_password_obfuscating_comparator_newly_unclaimed_user_password_
     assert "False" in res[0].reason
 
 
-def test_good_user_password_obfuscating_comparator_existence():
+def test_good_user_password_obfuscating_comparator_existence() -> None:
     cmp = UserPasswordObfuscatingComparator()
     id = InstanceID("sentry.test", 0)
     present: Any = {
@@ -2069,7 +2079,7 @@ def test_good_user_password_obfuscating_comparator_existence():
     assert "`password`" in res[0].reason
 
 
-def test_good_user_password_obfuscating_comparator_scrubbed_long():
+def test_good_user_password_obfuscating_comparator_scrubbed_long() -> None:
     cmp = UserPasswordObfuscatingComparator()
     left: Any = {
         "model": "test",
@@ -2101,7 +2111,7 @@ def test_good_user_password_obfuscating_comparator_scrubbed_long():
     ]
 
 
-def test_good_user_password_obfuscating_comparator_scrubbed_medium():
+def test_good_user_password_obfuscating_comparator_scrubbed_medium() -> None:
     cmp = UserPasswordObfuscatingComparator()
     left: Any = {
         "model": "test",
@@ -2129,7 +2139,7 @@ def test_good_user_password_obfuscating_comparator_scrubbed_medium():
     assert right["scrubbed"]["UserPasswordObfuscatingComparator::password"] == ["sha1$a...4d4d"]
 
 
-def test_good_user_password_obfuscating_comparator_scrubbed_short():
+def test_good_user_password_obfuscating_comparator_scrubbed_short() -> None:
     cmp = UserPasswordObfuscatingComparator()
     left: Any = {
         "model": "test",

--- a/tests/sentry/backup/test_coverage.py
+++ b/tests/sentry/backup/test_coverage.py
@@ -17,7 +17,7 @@ from tests.sentry.users.models.test_user import ORG_MEMBER_MERGE_TESTED
 ALL_EXPORTABLE_MODELS = {get_model_name(c) for c in get_exportable_sentry_models()}
 
 
-def test_exportable_final_derivations_of_sentry_model_are_dynamic_relocation_tested():
+def test_exportable_final_derivations_of_sentry_model_are_dynamic_relocation_tested() -> None:
     models_with_multiple_relocation_scopes = {
         get_model_name(c)
         for c in get_exportable_sentry_models()
@@ -27,7 +27,7 @@ def test_exportable_final_derivations_of_sentry_model_are_dynamic_relocation_tes
     assert not {str(u) for u in untested}
 
 
-def test_exportable_final_derivations_of_sentry_model_are_collision_tested():
+def test_exportable_final_derivations_of_sentry_model_are_collision_tested() -> None:
     deps = dependencies()
 
     # A model must be tested for collisions if it has at least one `uniques` entry that is composed
@@ -81,14 +81,14 @@ def test_exportable_final_derivations_of_sentry_model_are_collision_tested():
     }, "The aforementioned models are not covered in the `COLLISION` backup tests; please go to `tests/sentry/backup/test_exhaustive.py` and make sure at least one test in the suite contains covers each of the missing models."
 
 
-def test_exportable_final_derivations_of_sentry_model_are_exhaustively_tested():
+def test_exportable_final_derivations_of_sentry_model_are_exhaustively_tested() -> None:
     untested = ALL_EXPORTABLE_MODELS - EXHAUSTIVELY_TESTED
     assert not {
         str(u) for u in untested
     }, "The aforementioned models are not covered in the backup tests; please go to `tests/sentry/backup/test_exhaustive.py` and make sure at least one test in the suite contains covers each of the missing models."
 
 
-def test_exportable_final_derivations_of_sentry_model_are_uniqueness_tested():
+def test_exportable_final_derivations_of_sentry_model_are_uniqueness_tested() -> None:
     # No need to uniqueness test global models, since they assume a clean database anyway.
     all_non_global_sentry_models = {
         get_model_name(m)
@@ -104,7 +104,7 @@ def test_exportable_final_derivations_of_sentry_model_are_uniqueness_tested():
     }, "The aforementioned models are not covered in the `UNIQUENESS` backup tests; please go to `tests/sentry/backup/test_exhaustive.py` and make sure at least one test in the suite contains covers each of the missing models."
 
 
-def test_all_eligible_organization_scoped_models_tested_for_user_merge():
+def test_all_eligible_organization_scoped_models_tested_for_user_merge() -> None:
     all_org_scope_models_that_reference_user = set()
     for model in get_exportable_sentry_models():
         model_name = get_model_name(model)

--- a/tests/sentry/backup/test_invariants.py
+++ b/tests/sentry/backup/test_invariants.py
@@ -17,7 +17,7 @@ from sentry.db.models import BaseModel
 
 # Note: this gets checked at runtime, but better to avoid possible runtime errors and catch it early
 # in CI.
-def test_all_final_derivations_of_django_model_set_included_in_export():
+def test_all_final_derivations_of_django_model_set_included_in_export() -> None:
     missing = set(
         filter(
             lambda c: not hasattr(c, "__relocation_scope__"),
@@ -27,7 +27,7 @@ def test_all_final_derivations_of_django_model_set_included_in_export():
     assert not missing
 
 
-def test_all_many_to_many_fields_explicitly_set_through_attribute():
+def test_all_many_to_many_fields_explicitly_set_through_attribute() -> None:
     # Make sure we are visiting the field definitions correctly.
     visited = 0
 
@@ -69,25 +69,25 @@ def validate_dependency_scopes(allowed: set[RelocationScope]):
                 )
 
 
-def test_user_relocation_scope_validity():
+def test_user_relocation_scope_validity() -> None:
     # Models with a `User` relocation scope are only allowed to transitively depend on other
     # similarly-scoped models.
     validate_dependency_scopes({RelocationScope.User})
 
 
-def test_organization_relocation_scope_validity():
+def test_organization_relocation_scope_validity() -> None:
     # Models with an `Organization` or `User` relocation scope are only allowed to transitively
     # depend on other similarly-scoped models.
     validate_dependency_scopes({RelocationScope.Organization, RelocationScope.User})
 
 
-def test_config_relocation_scope_validity():
+def test_config_relocation_scope_validity() -> None:
     # Models with a `Config` or `User` relocation scope are only allowed to transitively depend on
     # other similarly-scoped models.
     validate_dependency_scopes({RelocationScope.Config, RelocationScope.User})
 
 
-def test_all_exported_model_slug_fields_are_unique():
+def test_all_exported_model_slug_fields_are_unique() -> None:
     # The relocation code assumes that any field whose name ends is "slug" is included in at least
     # one "unique set": that is, either the field itself is marked `unique=True`, or the `slug`
     # field is included in at least one `unique_together` declaration.
@@ -108,7 +108,7 @@ def test_all_exported_model_slug_fields_are_unique():
                 )
 
 
-def test_merging_models_only_fk_into_user():
+def test_merging_models_only_fk_into_user() -> None:
     # We have a mode that allows `User`s to be merged. We assume that related `User*` models
     # `UserIP`, `UserEmail`, and `UserPermission` only reference `User` as a dependency when we do
     # this merging.

--- a/tests/sentry/backup/test_validate.py
+++ b/tests/sentry/backup/test_validate.py
@@ -15,7 +15,7 @@ def copy_model(model: Any, new_pk: int) -> Any:
     return new_model
 
 
-def test_good_ignore_differing_pks():
+def test_good_ignore_differing_pks() -> None:
     with open(get_fixture_path("backup", "single-integration.json"), "rb") as backup_file:
         test_integration = orjson.loads(backup_file.read())[0]
     left = [copy_model(test_integration, 2)]
@@ -28,7 +28,7 @@ def test_good_ignore_differing_pks():
     assert not findings
 
 
-def test_bad_duplicate_entry():
+def test_bad_duplicate_entry() -> None:
     with open(get_fixture_path("backup", "single-integration.json"), "rb") as backup_file:
         test_integration = orjson.loads(backup_file.read())[0]
     test_json = [test_integration, deepcopy(test_integration)]
@@ -46,7 +46,7 @@ def test_bad_duplicate_entry():
     assert findings[1].right_pk == 1
 
 
-def test_bad_out_of_order_entry():
+def test_bad_out_of_order_entry() -> None:
     with open(get_fixture_path("backup", "single-integration.json"), "rb") as backup_file:
         test_integration = orjson.loads(backup_file.read())[0]
 
@@ -66,7 +66,7 @@ def test_bad_out_of_order_entry():
     assert findings[1].right_pk == 2
 
 
-def test_bad_extra_left_entry():
+def test_bad_extra_left_entry() -> None:
     with open(get_fixture_path("backup", "single-integration.json"), "rb") as backup_file:
         test_integration = orjson.loads(backup_file.read())[0]
     left = [deepcopy(test_integration), copy_model(test_integration, 2)]
@@ -83,7 +83,7 @@ def test_bad_extra_left_entry():
     assert "1 right" in findings[0].reason
 
 
-def test_bad_extra_right_entry():
+def test_bad_extra_right_entry() -> None:
     with open(get_fixture_path("backup", "single-integration.json"), "rb") as backup_file:
         test_integration = orjson.loads(backup_file.read())[0]
     left = [test_integration]
@@ -100,7 +100,7 @@ def test_bad_extra_right_entry():
     assert "2 right" in findings[0].reason
 
 
-def test_bad_failing_comparator_field():
+def test_bad_failing_comparator_field() -> None:
     with open(get_fixture_path("backup", "single-option.json"), "rb") as backup_file:
         left = orjson.loads(backup_file.read())
     right = deepcopy(left)
@@ -144,7 +144,7 @@ def test_bad_failing_comparator_field():
     assert findings[0].kind == ComparatorFindingKind.DateUpdatedComparator
 
 
-def test_good_both_sides_comparator_field_missing():
+def test_good_both_sides_comparator_field_missing() -> None:
     with open(get_fixture_path("backup", "single-option.json"), "rb") as backup_file:
         test_json = orjson.loads(backup_file.read())
     userrole_without_date_updated = orjson.loads(
@@ -166,7 +166,7 @@ def test_good_both_sides_comparator_field_missing():
     assert out.empty()
 
 
-def test_bad_left_side_comparator_field_missing():
+def test_bad_left_side_comparator_field_missing() -> None:
     with open(get_fixture_path("backup", "single-option.json"), "rb") as backup_file:
         left = orjson.loads(backup_file.read())
     right = deepcopy(left)
@@ -210,7 +210,7 @@ def test_bad_left_side_comparator_field_missing():
     assert "left `date_updated`" in findings[0].reason
 
 
-def test_bad_right_side_comparator_field_missing():
+def test_bad_right_side_comparator_field_missing() -> None:
     with open(get_fixture_path("backup", "single-option.json"), "rb") as backup_file:
         left = orjson.loads(backup_file.read())
     right = deepcopy(left)
@@ -254,7 +254,7 @@ def test_bad_right_side_comparator_field_missing():
     assert "right `date_updated`" in findings[0].reason
 
 
-def test_auto_assign_email_obfuscating_comparator():
+def test_auto_assign_email_obfuscating_comparator() -> None:
     with open(get_fixture_path("backup", "single-option.json"), "rb") as backup_file:
         left = orjson.loads(backup_file.read())
     right = deepcopy(left)
@@ -298,7 +298,7 @@ def test_auto_assign_email_obfuscating_comparator():
     assert """right value ("f...@...e.fake")""" in findings[0].reason
 
 
-def test_auto_assign_date_updated_comparator():
+def test_auto_assign_date_updated_comparator() -> None:
     with open(get_fixture_path("backup", "single-option.json"), "rb") as backup_file:
         left = orjson.loads(backup_file.read())
     right = deepcopy(left)
@@ -340,7 +340,7 @@ def test_auto_assign_date_updated_comparator():
     assert not findings
 
 
-def test_auto_assign_foreign_key_comparator():
+def test_auto_assign_foreign_key_comparator() -> None:
     left = [
         orjson.loads(
             """
@@ -413,7 +413,7 @@ def test_auto_assign_foreign_key_comparator():
     assert not findings
 
 
-def test_auto_assign_ignored_comparator():
+def test_auto_assign_ignored_comparator() -> None:
     left = [
         orjson.loads(
             """
@@ -476,7 +476,7 @@ def test_auto_assign_ignored_comparator():
     assert not findings
 
 
-def test_bad_missing_custom_ordinal():
+def test_bad_missing_custom_ordinal() -> None:
     left = orjson.loads(
         """
             [
@@ -534,7 +534,7 @@ def test_bad_missing_custom_ordinal():
     assert "c...@...le.com" in findings[0].reason
 
 
-def test_bad_unequal_custom_ordinal():
+def test_bad_unequal_custom_ordinal() -> None:
     left = orjson.loads(
         """
             [
@@ -575,7 +575,7 @@ def test_bad_unequal_custom_ordinal():
     assert findings[0].kind == ComparatorFindingKind.UnequalJSON
 
 
-def test_bad_duplicate_custom_ordinal():
+def test_bad_duplicate_custom_ordinal() -> None:
     with open(get_fixture_path("backup", "single-option.json"), "rb") as backup_file:
         test_option = orjson.loads(backup_file.read())[0]
     test_json = [test_option, copy_model(test_option, 2)]
@@ -593,7 +593,7 @@ def test_bad_duplicate_custom_ordinal():
     assert findings[1].right_pk == 2
 
 
-def test_good_option_custom_ordinal():
+def test_good_option_custom_ordinal() -> None:
     left = orjson.loads(
         """
             [
@@ -655,7 +655,7 @@ def test_good_option_custom_ordinal():
     assert len(findings) == 0
 
 
-def test_good_user_custom_ordinal():
+def test_good_user_custom_ordinal() -> None:
     left = orjson.loads(
         """
             [
@@ -796,7 +796,7 @@ def test_good_user_custom_ordinal():
     assert len(findings) == 0
 
 
-def test_good_user_option_custom_ordinal():
+def test_good_user_option_custom_ordinal() -> None:
     left = orjson.loads(
         """
             [
@@ -899,7 +899,7 @@ def test_good_user_option_custom_ordinal():
 
 # This tests for a prod-only check that is not enumerated in Django: that there can only be one copy
 # of a global option (no org_id/project_id) per key per user.
-def test_good_user_option_duplicate_globals():
+def test_good_user_option_duplicate_globals() -> None:
     left = orjson.loads(
         """
             [

--- a/tests/sentry/conf/test_kafka_definition.py
+++ b/tests/sentry/conf/test_kafka_definition.py
@@ -52,7 +52,7 @@ class ConsumersDefinitionTest(TestCase):
             validate_consumer_definition(definition)
 
 
-def test_get_topic_codec():
+def test_get_topic_codec() -> None:
     """Test that get_topic_codec works with Topic enum values."""
     # Test with a known topic
     codec = get_topic_codec(Topic.BUFFERED_SEGMENTS)

--- a/tests/sentry/consumers/test_get_topic_definition.py
+++ b/tests/sentry/consumers/test_get_topic_definition.py
@@ -4,7 +4,7 @@ from sentry.conf.types.kafka_definition import Topic
 from sentry.utils.kafka_config import get_topic_definition
 
 
-def test_get_topic_definition_without_slice_id():
+def test_get_topic_definition_without_slice_id() -> None:
     with override_settings(
         KAFKA_TOPIC_TO_CLUSTER={"events": "default"},
         KAFKA_TOPIC_OVERRIDES={"events": "custom-events-topic"},
@@ -14,7 +14,7 @@ def test_get_topic_definition_without_slice_id():
         assert topic_def["real_topic_name"] == "custom-events-topic"
 
 
-def test_get_topic_definition_no_override():
+def test_get_topic_definition_no_override() -> None:
     with override_settings(
         KAFKA_TOPIC_TO_CLUSTER={"events": "default"},
         KAFKA_TOPIC_OVERRIDES={},
@@ -24,7 +24,7 @@ def test_get_topic_definition_no_override():
         assert topic_def["real_topic_name"] == "events"
 
 
-def test_get_topic_definition_with_slice_id():
+def test_get_topic_definition_with_slice_id() -> None:
     with override_settings(
         KAFKA_TOPIC_TO_CLUSTER={"events": "default"},
         KAFKA_TOPIC_OVERRIDES={"events": "custom-events-topic"},

--- a/tests/sentry/coreapi/test_coreapi.py
+++ b/tests/sentry/coreapi/test_coreapi.py
@@ -3,12 +3,12 @@ import pytest
 from sentry.interfaces.base import get_interface
 
 
-def test_get_interface_does_not_let_through_disallowed_name():
+def test_get_interface_does_not_let_through_disallowed_name() -> None:
     with pytest.raises(ValueError):
         get_interface("subprocess")
 
 
-def test_get_interface_allows_http():
+def test_get_interface_allows_http() -> None:
     from sentry.interfaces.http import Http
 
     result = get_interface("request")

--- a/tests/sentry/db/models/fields/test_bounded.py
+++ b/tests/sentry/db/models/fields/test_bounded.py
@@ -8,7 +8,7 @@ from sentry.db.models.fields.bounded import (
 )
 
 
-def test_norm_int():
+def test_norm_int() -> None:
     field = BoundedIntegerField()
     with pytest.raises(AssertionError):
         field.get_prep_value(9223372036854775807)
@@ -21,7 +21,7 @@ def test_big_int(cls):
         field.get_prep_value(9223372036854775808)
 
 
-def test_u32_wraparound():
+def test_u32_wraparound() -> None:
     field = WrappingU32IntegerField()
 
     assert field.get_prep_value(2**31) == -(2**31)  # I32_MAX + 1 wraps to I32_MIN

--- a/tests/sentry/db/models/fields/test_hybrid_cloud_foreign_key.py
+++ b/tests/sentry/db/models/fields/test_hybrid_cloud_foreign_key.py
@@ -5,7 +5,7 @@ from sentry.testutils.pytest.fixtures import django_db_all
 
 
 @django_db_all
-def test_all_hybrid_cloud_foreign_keys_generate_outboxes():
+def test_all_hybrid_cloud_foreign_keys_generate_outboxes() -> None:
     hcfk_models = set()
     for app_models in apps.all_models.values():
         for model in app_models.values():

--- a/tests/sentry/db/models/fields/test_picklefield.py
+++ b/tests/sentry/db/models/fields/test_picklefield.py
@@ -13,7 +13,7 @@ class JsonWritingPickleModel(models.Model):
 
 
 @pytest.mark.django_db
-def test_json_by_default():
+def test_json_by_default() -> None:
     obj = JsonWritingPickleModel.objects.create(
         data={"foo": "bar2"},
     )
@@ -38,11 +38,11 @@ def test_json_by_default():
     assert obj.data == {"foo": "bar"}
 
 
-def test_to_python_int():
+def test_to_python_int() -> None:
     obj = picklefield.PickledObjectField()
     assert obj.to_python(9) == 9
 
 
-def test_to_python_bool():
+def test_to_python_bool() -> None:
     obj = picklefield.PickledObjectField()
     assert obj.to_python(True) is True

--- a/tests/sentry/db/test_silo_models.py
+++ b/tests/sentry/db/test_silo_models.py
@@ -14,17 +14,17 @@ decorator_exemptions: set[type[Model]] = set()
 fk_exemptions: set[tuple[type[Model], type[Model]]] = set()
 
 
-def test_models_have_silos():
+def test_models_have_silos() -> None:
     validate_models_have_silos(decorator_exemptions)
 
 
-def test_silo_foreign_keys():
+def test_silo_foreign_keys() -> None:
     for unused in fk_exemptions - validate_no_cross_silo_foreign_keys(fk_exemptions):
         raise ValueError(f"fk_exemptions includes non conflicting relation {unused!r}")
 
 
 @django_db_all
-def test_cross_silo_deletions():
+def test_cross_silo_deletions() -> None:
     validate_no_cross_silo_deletions(fk_exemptions)
 
 
@@ -35,7 +35,7 @@ def test_cross_silo_deletions():
 # Secondly, there should never be any custom serialization logic -- all of our hybrid cloud objects will be
 # serialized and deserialized using narrow, very thin protocol logic, which will not be adhoc written per type.
 # If you're unsure how to proceed, ping the project-hybrid-cloud channel to get some assistance.
-def test_no_serializers_for_hybrid_cloud_dataclasses():
+def test_no_serializers_for_hybrid_cloud_dataclasses() -> None:
     for type in registry.keys():
         if "hybrid_cloud" in type.__module__:
             raise AssertionError(

--- a/tests/sentry/demo_mode/test_utils.py
+++ b/tests/sentry/demo_mode/test_utils.py
@@ -8,80 +8,80 @@ from sentry.testutils.pytest.fixtures import django_db_all
 
 @override_options({"demo-mode.enabled": True, "demo-mode.users": [1]})
 @django_db_all
-def test_is_demo_user_demo_mode_enabled_none():
+def test_is_demo_user_demo_mode_enabled_none() -> None:
     assert not is_demo_user(None)
 
 
 @override_options({"demo-mode.enabled": True, "demo-mode.users": [1]})
 @django_db_all
-def test_is_demo_user_demo_mode_enabled_readonly_user():
+def test_is_demo_user_demo_mode_enabled_readonly_user() -> None:
     user = Factories.create_user(id=1)
     assert is_demo_user(user)
 
 
 @override_options({"demo-mode.enabled": True, "demo-mode.users": [1]})
 @django_db_all
-def test_is_demo_user_demo_mode_enabled_non_readonly_user():
+def test_is_demo_user_demo_mode_enabled_non_readonly_user() -> None:
     user = Factories.create_user(id=2)
     assert not is_demo_user(user)
 
 
 @override_options({"demo-mode.enabled": False})
 @django_db_all
-def test_is_demo_user_demo_mode_disabled_none():
+def test_is_demo_user_demo_mode_disabled_none() -> None:
     assert not is_demo_user(None)
 
 
 @override_options({"demo-mode.enabled": False})
 @django_db_all
-def test_is_demo_user_demo_mode_disabled_readonly_user():
+def test_is_demo_user_demo_mode_disabled_readonly_user() -> None:
     user = Factories.create_user(id=1)
     assert not is_demo_user(user)
 
 
 @override_options({"demo-mode.enabled": False})
 @django_db_all
-def test_is_demo_user_demo_mode_disabled_non_readonly_user():
+def test_is_demo_user_demo_mode_disabled_non_readonly_user() -> None:
     user = Factories.create_user(id=2)
     assert not is_demo_user(user)
 
 
 @override_options({"demo-mode.enabled": False})
 @django_db_all
-def test_is_demo_org_demo_mode_disabled():
+def test_is_demo_org_demo_mode_disabled() -> None:
     organization = Factories.create_organization()
     assert not is_demo_org(organization)
 
 
 @override_options({"demo-mode.enabled": True})
 @django_db_all
-def test_is_demo_org_no_organization():
+def test_is_demo_org_no_organization() -> None:
     assert not is_demo_org(None)
 
 
 @override_options({"demo-mode.enabled": True, "demo-mode.orgs": [1, 2, 3]})
 @django_db_all
-def test_is_demo_org_demo_mode_enabled():
+def test_is_demo_org_demo_mode_enabled() -> None:
     organization = Factories.create_organization(id=1)
     assert is_demo_org(organization)
 
 
 @override_options({"demo-mode.enabled": True, "demo-mode.orgs": [1, 2, 3]})
 @django_db_all
-def test_is_demo_org_not_in_demo_orgs():
+def test_is_demo_org_not_in_demo_orgs() -> None:
     organization = Factories.create_organization(id=4)
     assert not is_demo_org(organization)
 
 
 @override_options({"demo-mode.enabled": False})
 @django_db_all
-def test_get_demo_user_demo_mode_disabled():
+def test_get_demo_user_demo_mode_disabled() -> None:
     assert get_demo_user() is None
 
 
 @override_options({"demo-mode.enabled": True, "demo-mode.users": [1]})
 @django_db_all
-def test_get_demo_user_demo_mode_enabled():
+def test_get_demo_user_demo_mode_enabled() -> None:
     user = Factories.create_user(id=1)
     with patch("sentry.demo_mode.utils.User.objects.get", return_value=user) as mock_user_get:
         assert get_demo_user() == user
@@ -90,13 +90,13 @@ def test_get_demo_user_demo_mode_enabled():
 
 @override_options({"demo-mode.enabled": False})
 @django_db_all
-def test_get_demo_org_demo_mode_disabled():
+def test_get_demo_org_demo_mode_disabled() -> None:
     assert get_demo_org() is None
 
 
 @override_options({"demo-mode.enabled": True, "demo-mode.orgs": [1]})
 @django_db_all
-def test_get_demo_org_demo_mode_enabled():
+def test_get_demo_org_demo_mode_enabled() -> None:
     org = Factories.create_organization(id=1)
     with patch("sentry.demo_mode.utils.Organization.objects.get", return_value=org) as mock_org_get:
         assert get_demo_org() == org

--- a/tests/sentry/discover/test_arithmetic.py
+++ b/tests/sentry/discover/test_arithmetic.py
@@ -78,7 +78,7 @@ def test_homogenous_arithmetic(a, op1, b, op2, c):
     assert result.rhs == float(c), equation
 
 
-def test_mixed_arithmetic():
+def test_mixed_arithmetic() -> None:
     result, _, _ = parse_arithmetic("12 + 34 * 56")
     assert result.operator == "plus"
     assert result.lhs == 12.0
@@ -96,7 +96,7 @@ def test_mixed_arithmetic():
     assert result.rhs == 56.0
 
 
-def test_four_terms():
+def test_four_terms() -> None:
     result, _, _ = parse_arithmetic("1 + 2 / 3 * 4")
     assert result.operator == "plus"
     assert result.lhs == 1.0
@@ -109,7 +109,7 @@ def test_four_terms():
     assert result.rhs.rhs == 4.0
 
 
-def test_brackets_with_two_inner_terms():
+def test_brackets_with_two_inner_terms() -> None:
     result, _, _ = parse_arithmetic("(1 + 2) / (3 - 4)")
     assert result.operator == "divide"
     assert isinstance(result.lhs, Operation)
@@ -122,7 +122,7 @@ def test_brackets_with_two_inner_terms():
     assert result.rhs.rhs == 4.0
 
 
-def test_brackets_with_three_inner_terms():
+def test_brackets_with_three_inner_terms() -> None:
     result, _, _ = parse_arithmetic("(1 + 2 + 3) / 4")
     assert result.operator == "divide"
     assert isinstance(result.lhs, Operation)
@@ -134,7 +134,7 @@ def test_brackets_with_three_inner_terms():
     assert result.rhs == 4.0
 
 
-def test_brackets_with_four_inner_terms():
+def test_brackets_with_four_inner_terms() -> None:
     result, _, _ = parse_arithmetic("(1 + 2 / 3 * 4)")
     assert result.operator == "plus"
     assert result.lhs == 1.0
@@ -181,7 +181,7 @@ def test_homogenous_four_terms(a, op1, b, op2, c, op3, d):
     assert result.rhs == float(d), equation
 
 
-def test_max_operators():
+def test_max_operators() -> None:
     with pytest.raises(MaxOperatorError):
         parse_arithmetic("1 + 2 * 3 * 4", 2)
 

--- a/tests/sentry/dynamic_sampling/rules/biases/test_boost_low_volume_transactions_bias.py
+++ b/tests/sentry/dynamic_sampling/rules/biases/test_boost_low_volume_transactions_bias.py
@@ -96,7 +96,7 @@ def test_transaction_boost_known_projects(get_transactions_resampling_rates):
     assert rules == expected
 
 
-def test_transaction_boost_unknown_projects():
+def test_transaction_boost_unknown_projects() -> None:
     """
     Tests that when there is no information available for the project transactions
     it returns an empty set of rules.

--- a/tests/sentry/dynamic_sampling/tasks/helpers/test_boost_low_volume_transactions.py
+++ b/tests/sentry/dynamic_sampling/tasks/helpers/test_boost_low_volume_transactions.py
@@ -5,7 +5,7 @@ from sentry.dynamic_sampling.tasks.helpers.boost_low_volume_transactions import 
 )
 
 
-def test_resampling_rates_in_cache():
+def test_resampling_rates_in_cache() -> None:
     """
     Tests that we can correctly store and retrieve resampling rates without
     key clashes
@@ -58,7 +58,7 @@ def test_resampling_rates_in_cache():
     assert actual_global_rate == expected_global_rate
 
 
-def test_resampling_rates_missing():
+def test_resampling_rates_missing() -> None:
     """
     Tests that if the resampling rates are not in cache the default values are returned
     """

--- a/tests/sentry/dynamic_sampling/tasks/helpers/test_sliding_window.py
+++ b/tests/sentry/dynamic_sampling/tasks/helpers/test_sliding_window.py
@@ -5,7 +5,7 @@ from sentry.testutils.helpers.datetime import freeze_time
 
 
 @freeze_time("2023-02-03 12:00:00")
-def test_extrapolate_monthly_volume_with_28_days():
+def test_extrapolate_monthly_volume_with_28_days() -> None:
     result = extrapolate_monthly_volume(volume=10, hours=24)
     assert result == 280
 
@@ -26,6 +26,6 @@ def test_extrapolate_monthly_volume_with_30_days(volume, hours, expected_result)
 
 
 @freeze_time("2023-05-03 12:00:00")
-def test_extrapolate_monthly_volume_with_31_days():
+def test_extrapolate_monthly_volume_with_31_days() -> None:
     result = extrapolate_monthly_volume(volume=10, hours=24)
     assert result == 310

--- a/tests/sentry/dynamic_sampling/tasks/test_boost_low_volume_transactions.py
+++ b/tests/sentry/dynamic_sampling/tasks/test_boost_low_volume_transactions.py
@@ -140,7 +140,7 @@ class PrioritiseProjectsSnubaQueryTest(BaseMetricsLayerTestCase, TestCase, Snuba
             assert totals["total_num_classes"] == num_classes
 
 
-def test_merge_transactions_full():
+def test_merge_transactions_full() -> None:
     t1: ProjectTransactions = {
         "project_id": 1,
         "org_id": 2,
@@ -174,7 +174,7 @@ def test_merge_transactions_full():
     assert actual == expected
 
 
-def test_merge_transactions_missing_totals():
+def test_merge_transactions_missing_totals() -> None:
     t1: ProjectTransactions = {
         "project_id": 1,
         "org_id": 2,
@@ -203,7 +203,7 @@ def test_merge_transactions_missing_totals():
     assert actual == expected
 
 
-def test_merge_transactions_missing_right():
+def test_merge_transactions_missing_right() -> None:
     t1: ProjectTransactions = {
         "project_id": 1,
         "org_id": 2,
@@ -230,7 +230,7 @@ def test_merge_transactions_missing_right():
     assert actual == expected
 
 
-def test_transactions_zip():
+def test_transactions_zip() -> None:
     high = 1
     low = 2
     both = 3
@@ -280,7 +280,7 @@ def test_transactions_zip():
     assert actual == expected
 
 
-def test_same_project():
+def test_same_project() -> None:
     p1: ProjectIdentity = {"project_id": 1, "org_id": 2}
     p1bis: ProjectIdentity = {"project_id": 1, "org_id": 2}
     p2: ProjectIdentity = {"project_id": 1, "org_id": 3}
@@ -293,7 +293,7 @@ def test_same_project():
     assert not is_same_project(p1, p4)
 
 
-def test_project_before():
+def test_project_before() -> None:
     p1: ProjectIdentity = {"project_id": 1, "org_id": 2}
     p1bis: ProjectIdentity = {"project_id": 1, "org_id": 2}
     p2: ProjectIdentity = {"project_id": 1, "org_id": 3}
@@ -317,7 +317,7 @@ def test_project_before():
     assert not is_project_identity_before(p1, p4)
 
 
-def test_next_totals():
+def test_next_totals() -> None:
     def ct(org_id: int, project_id: int) -> ProjectTransactionsTotals:
         return {
             "project_id": project_id,

--- a/tests/sentry/dynamic_sampling/tasks/test_common.py
+++ b/tests/sentry/dynamic_sampling/tasks/test_common.py
@@ -22,7 +22,7 @@ MOCK_DATETIME = (timezone.now() - timedelta(days=1)).replace(
 )
 
 
-def test_timeout_exception():
+def test_timeout_exception() -> None:
     """
     Test creation of exception
     """
@@ -58,7 +58,7 @@ class FakeContextIterator:
         self.count = state.num_iterations
 
 
-def test_timed_iterator_no_timout():
+def test_timed_iterator_no_timout() -> None:
 
     with freeze_time("2023-07-12 10:00:00") as frozen_time:
         context = TaskContext("my_context", 3)
@@ -86,7 +86,7 @@ def test_timed_iterator_no_timout():
             next(it)
 
 
-def test_timed_iterator_with_timeout():
+def test_timed_iterator_with_timeout() -> None:
     with freeze_time("2023-07-12 10:00:00") as frozen_time:
         context = TaskContext("my_context", 3)
         it = TimedIterator(context, FakeContextIterator(frozen_time, 4), "ti1")
@@ -148,7 +148,7 @@ class TestGetActiveOrgs(BaseMetricsLayerTestCase, TestCase, SnubaTestCase):
         assert total_orgs == 10
 
 
-def test_timed_function_decorator_updates_state():
+def test_timed_function_decorator_updates_state() -> None:
     """
     Tests that the decorator correctly extracts the state
     and passes it to the inner function.
@@ -179,7 +179,7 @@ def test_timed_function_decorator_updates_state():
     assert f2_state.num_iterations == 2
 
 
-def test_timed_function_correctly_times_inner_function():
+def test_timed_function_correctly_times_inner_function() -> None:
     with freeze_time("2023-07-14 10:00:00") as frozen_time:
         context = TaskContext(name="TC", num_seconds=60.0)
 
@@ -197,7 +197,7 @@ def test_timed_function_correctly_times_inner_function():
         assert t.current() == 2.0
 
 
-def test_timed_function_correctly_raises_when_task_expires():
+def test_timed_function_correctly_raises_when_task_expires() -> None:
     with freeze_time("2023-07-14 10:00:00") as frozen_time:
         context = TaskContext(name="TC", num_seconds=2.0)
 

--- a/tests/sentry/dynamic_sampling/tasks/test_task_context.py
+++ b/tests/sentry/dynamic_sampling/tasks/test_task_context.py
@@ -4,7 +4,7 @@ from sentry.dynamic_sampling.tasks.task_context import DynamicSamplingLogState, 
 from sentry.testutils.helpers.datetime import freeze_time
 
 
-def test_task_context_expiration_time():
+def test_task_context_expiration_time() -> None:
     """
     Tests that the TaskContext properly initialises the expiration_time
     """
@@ -14,7 +14,7 @@ def test_task_context_expiration_time():
         assert context.expiration_time == time.monotonic() + 3
 
 
-def test_task_context_data():
+def test_task_context_data() -> None:
     """
     Tests that TaskContext properly handles function contexts
 
@@ -55,7 +55,7 @@ def test_task_context_data():
     )
 
 
-def test_timer_raw():
+def test_timer_raw() -> None:
     """
     Tests the direct functionality of Timer (i.e. not as a context manager)
     """
@@ -125,7 +125,7 @@ def test_timer_raw():
         assert t.current() == 2.0
 
 
-def test_named_timer_raw():
+def test_named_timer_raw() -> None:
     """
     Tests the direct functionality of Timer (i.e. not as a context manager)
     with named timers
@@ -227,7 +227,7 @@ def test_named_timer_raw():
         assert tc.current() == 5.0
 
 
-def test_timer_context_manager():
+def test_timer_context_manager() -> None:
     """
     Tests the context manager functionality of the timer
     """
@@ -246,7 +246,7 @@ def test_timer_context_manager():
         assert t.current("a") == 3
 
 
-def test_named_timer_context_manager():
+def test_named_timer_context_manager() -> None:
     """
     Tests the context manager functionality of the timer
     """
@@ -283,7 +283,7 @@ def test_named_timer_context_manager():
         assert t.current("global") == 3 * 7
 
 
-def test_task_context_serialisation():
+def test_task_context_serialisation() -> None:
     task = TaskContext("my-task", 100)
     with freeze_time("2023-07-12 10:00:00") as frozen_time:
         # a timer without state

--- a/tests/sentry/dynamic_sampling/tasks/test_utils.py
+++ b/tests/sentry/dynamic_sampling/tasks/test_utils.py
@@ -5,7 +5,7 @@ from sentry.dynamic_sampling.tasks.task_context import TaskContext
 from sentry.dynamic_sampling.tasks.utils import dynamic_sampling_task_with_context
 
 
-def test_injection_dynamic_sampling_task_with_context():
+def test_injection_dynamic_sampling_task_with_context() -> None:
     duration = 420
 
     @dynamic_sampling_task_with_context(max_task_execution=duration)
@@ -16,7 +16,7 @@ def test_injection_dynamic_sampling_task_with_context():
     inner()
 
 
-def test_log_dynamic_sampling_task_with_context():
+def test_log_dynamic_sampling_task_with_context() -> None:
     @dynamic_sampling_task_with_context(max_task_execution=100)
     def inner(context: TaskContext):
         pass
@@ -24,7 +24,7 @@ def test_log_dynamic_sampling_task_with_context():
     inner()
 
 
-def test_timeout_dynamic_sampling_task_with_context():
+def test_timeout_dynamic_sampling_task_with_context() -> None:
     @dynamic_sampling_task_with_context(max_task_execution=100)
     def inner(context: TaskContext):
         raise TimeoutException(context)

--- a/tests/sentry/event_manager/interfaces/test_contexts.py
+++ b/tests/sentry/event_manager/interfaces/test_contexts.py
@@ -110,7 +110,7 @@ def test_gpu(make_ctx_snapshot):
     )
 
 
-def test_large_numbers():
+def test_large_numbers() -> None:
     data = {
         "large_numbers": {
             "decimal_number": 123456.789,
@@ -136,7 +136,7 @@ def test_large_numbers():
         assert isinstance(ctx_data[key], str)
 
 
-def test_large_nested_numbers():
+def test_large_nested_numbers() -> None:
     data = {
         "large_numbers": {
             "dictionary": {"key_1": 608548899684111178, "key_2": -123456789123456789},

--- a/tests/sentry/event_manager/interfaces/test_exception.py
+++ b/tests/sentry/event_manager/interfaces/test_exception.py
@@ -261,7 +261,7 @@ def test_context_with_two_exceptions_having_mechanism(make_exception_snapshot):
     )
 
 
-def test_iteration():
+def test_iteration() -> None:
     inst = Exception.to_python({"values": [None, {"type": "ValueError"}, None]})
 
     assert len(inst) == 1

--- a/tests/sentry/event_manager/interfaces/test_mechanism.py
+++ b/tests/sentry/event_manager/interfaces/test_mechanism.py
@@ -92,7 +92,7 @@ def test_full_errno_meta(make_mechanism_snapshot):
     make_mechanism_snapshot(data)
 
 
-def test_upgrade():
+def test_upgrade() -> None:
     data = {
         "posix_signal": {"name": "SIGSEGV", "code_name": "SEGV_NOOP", "signal": 11, "code": 0},
         "relevant_address": "0x1",

--- a/tests/sentry/event_manager/interfaces/test_stacktrace.py
+++ b/tests/sentry/event_manager/interfaces/test_stacktrace.py
@@ -7,7 +7,7 @@ from sentry.event_manager import EventManager
 from sentry.interfaces.stacktrace import get_context, is_url
 
 
-def test_is_url():
+def test_is_url() -> None:
     assert is_url("http://example.org/") is True
     assert is_url("https://example.org/") is True
     assert is_url("file:///tmp/filename") is True
@@ -18,7 +18,7 @@ def test_is_url():
     assert is_url("blob:\x00") is False
 
 
-def test_works_with_empty_filename():
+def test_works_with_empty_filename() -> None:
     result = get_context(0, "hello world")
     assert result == [(0, "hello world")]
 

--- a/tests/sentry/event_manager/test_ensure_has_ip.py
+++ b/tests/sentry/event_manager/test_ensure_has_ip.py
@@ -8,19 +8,19 @@ def validate_and_normalize(report, client_ip=None):
     return manager.get_data()
 
 
-def test_with_remote_addr():
+def test_with_remote_addr() -> None:
     inp = {"request": {"url": "http://example.com/", "env": {"REMOTE_ADDR": "192.168.0.1"}}}
     out = validate_and_normalize(inp, client_ip="127.0.0.1")
     assert out["request"]["env"]["REMOTE_ADDR"] == "192.168.0.1"
 
 
-def test_with_user_ip():
+def test_with_user_ip() -> None:
     inp = {"user": {"ip_address": "192.168.0.1"}}
     out = validate_and_normalize(inp, client_ip="127.0.0.1")
     assert out["user"]["ip_address"] == "192.168.0.1"
 
 
-def test_with_user_auto_ip():
+def test_with_user_auto_ip() -> None:
     inp = {"user": {"ip_address": "{{auto}}"}}
     out = validate_and_normalize(inp, client_ip="127.0.0.1")
     assert out["user"]["ip_address"] == "{{auto}}"
@@ -31,7 +31,7 @@ def test_with_user_auto_ip():
 
 
 @django_db_all
-def test_without_ip_values():
+def test_without_ip_values() -> None:
     inp = {
         "platform": "javascript",
         "user": {},
@@ -41,19 +41,19 @@ def test_without_ip_values():
     assert "user" not in out
 
 
-def test_without_any_values():
+def test_without_any_values() -> None:
     inp = {"platform": "javascript"}
     out = validate_and_normalize(inp, client_ip="127.0.0.1")
     assert "user" not in out
 
 
-def test_with_http_auto_ip():
+def test_with_http_auto_ip() -> None:
     inp = {"request": {"url": "http://example.com/", "env": {"REMOTE_ADDR": "{{auto}}"}}}
     out = validate_and_normalize(inp, client_ip="127.0.0.1")
     assert out["request"]["env"]["REMOTE_ADDR"] == "{{auto}}"
 
 
-def test_with_all_auto_ip():
+def test_with_all_auto_ip() -> None:
     inp = {
         "user": {"ip_address": "{{auto}}"},
         "request": {"url": "http://example.com/", "env": {"REMOTE_ADDR": "{{auto}}"}},

--- a/tests/sentry/event_manager/test_generate_culprit.py
+++ b/tests/sentry/event_manager/test_generate_culprit.py
@@ -7,7 +7,7 @@ from sentry.culprit import generate_culprit
 from sentry.grouping.utils import hash_from_values
 
 
-def test_with_exception_interface():
+def test_with_exception_interface() -> None:
     data = {
         "exception": {
             "values": [
@@ -32,7 +32,7 @@ def test_with_exception_interface():
     assert generate_culprit(data) == "bar.py in ?"
 
 
-def test_with_missing_exception_stacktrace():
+def test_with_missing_exception_stacktrace() -> None:
     data = {
         "exception": {
             "values": [
@@ -46,7 +46,7 @@ def test_with_missing_exception_stacktrace():
     assert generate_culprit(data) == "http://example.com"
 
 
-def test_with_stacktrace_interface():
+def test_with_stacktrace_interface() -> None:
     data = {
         "stacktrace": {
             "frames": [
@@ -59,17 +59,17 @@ def test_with_stacktrace_interface():
     assert generate_culprit(data) == "PLZNOTME.py in ?"
 
 
-def test_with_missing_stacktrace_frames():
+def test_with_missing_stacktrace_frames() -> None:
     data = {"stacktrace": {"frames": None}, "request": {"url": "http://example.com"}}
     assert generate_culprit(data) == "http://example.com"
 
 
-def test_with_empty_stacktrace():
+def test_with_empty_stacktrace() -> None:
     data = {"stacktrace": None, "request": {"url": "http://example.com"}}
     assert generate_culprit(data) == "http://example.com"
 
 
-def test_with_only_http_interface():
+def test_with_only_http_interface() -> None:
     data: dict[str, Any] = {"request": {"url": "http://example.com"}}
     assert generate_culprit(data) == "http://example.com"
 
@@ -83,11 +83,11 @@ def test_with_only_http_interface():
     assert generate_culprit(data) == ""
 
 
-def test_empty_data():
+def test_empty_data() -> None:
     assert generate_culprit({}) == ""
 
 
-def test_truncation():
+def test_truncation() -> None:
     data: dict[str, dict[str, Any]] = {
         "exception": {
             "values": [{"stacktrace": {"frames": [{"filename": "x" * (MAX_CULPRIT_LENGTH + 1)}]}}]
@@ -102,12 +102,12 @@ def test_truncation():
     assert len(generate_culprit(data)) == MAX_CULPRIT_LENGTH
 
 
-def test_hash_from_values():
+def test_hash_from_values() -> None:
     result = hash_from_values(["foo", "bar", "foô"])
     assert result == "6d81588029ed4190110b2779ba952a00"
 
 
-def test_nel_culprit():
+def test_nel_culprit() -> None:
     data = {
         "type": "nel",
         "contexts": {

--- a/tests/sentry/event_manager/test_normalization.py
+++ b/tests/sentry/event_manager/test_normalization.py
@@ -21,7 +21,7 @@ def make_event(**kwargs):
     return result
 
 
-def test_tags_as_list():
+def test_tags_as_list() -> None:
     manager = EventManager(make_event(tags=[("foo", "bar")]))
     manager.normalize()
     data = manager.get_data()
@@ -29,7 +29,7 @@ def test_tags_as_list():
     assert data["tags"] == [["foo", "bar"]]
 
 
-def test_tags_as_dict():
+def test_tags_as_dict() -> None:
     manager = EventManager(make_event(tags={"foo": "bar"}))
     manager.normalize()
     data = manager.get_data()
@@ -37,7 +37,7 @@ def test_tags_as_dict():
     assert data["tags"] == [["foo", "bar"]]
 
 
-def test_interface_is_relabeled():
+def test_interface_is_relabeled() -> None:
     manager = EventManager(make_event(**{"sentry.interfaces.User": {"id": "1"}}))
     manager.normalize()
     data = manager.get_data()
@@ -61,7 +61,7 @@ def test_does_default_ip_address_to_user(user):
     assert data["user"]["ip_address"] == "127.0.0.1"
 
 
-def test_does_default_ip_address_if_present():
+def test_does_default_ip_address_if_present() -> None:
     manager = EventManager(
         make_event(
             **{
@@ -75,21 +75,21 @@ def test_does_default_ip_address_if_present():
     assert data["user"]["ip_address"] == "192.168.0.1"
 
 
-def test_long_culprit():
+def test_long_culprit() -> None:
     manager = EventManager(make_event(culprit="x" * (MAX_CULPRIT_LENGTH + 1)))
     manager.normalize()
     data = manager.get_data()
     assert len(data["culprit"]) == MAX_CULPRIT_LENGTH
 
 
-def test_long_transaction():
+def test_long_transaction() -> None:
     manager = EventManager(make_event(transaction="x" * (MAX_CULPRIT_LENGTH + 1)))
     manager.normalize()
     data = manager.get_data()
     assert len(data["transaction"]) == MAX_CULPRIT_LENGTH
 
 
-def test_long_message():
+def test_long_message() -> None:
     allowance = 200
     manager = EventManager(
         make_event(message="x" * (settings.SENTRY_MAX_MESSAGE_LENGTH + 1 + allowance))
@@ -99,28 +99,28 @@ def test_long_message():
     assert len(data["logentry"]["formatted"]) == settings.SENTRY_MAX_MESSAGE_LENGTH
 
 
-def test_empty_message():
+def test_empty_message() -> None:
     manager = EventManager(make_event(message=""))
     manager.normalize()
     data = manager.get_data()
     assert "logentry" not in data
 
 
-def test_default_version():
+def test_default_version() -> None:
     manager = EventManager(make_event())
     manager.normalize()
     data = manager.get_data()
     assert data["version"] == "5"
 
 
-def test_explicit_version():
+def test_explicit_version() -> None:
     manager = EventManager(make_event(), "6")
     manager.normalize()
     data = manager.get_data()
     assert data["version"] == "6"
 
 
-def test_logger():
+def test_logger() -> None:
     manager = EventManager(make_event(logger="foo\nbar"))
     manager.normalize()
     data = manager.get_data()
@@ -132,7 +132,7 @@ def test_logger():
     assert data["logger"] == DEFAULT_LOGGER_NAME
 
 
-def test_moves_stacktrace_to_exception():
+def test_moves_stacktrace_to_exception() -> None:
     manager = EventManager(
         make_event(
             exception={"type": "MyException"},
@@ -152,7 +152,7 @@ def test_moves_stacktrace_to_exception():
     assert "stacktrace" not in data
 
 
-def test_bad_interfaces_no_exception():
+def test_bad_interfaces_no_exception() -> None:
     manager = EventManager(
         make_event(**{"user": None, "request": None, "sdk": "A string for sdk is not valid"}),
         client_ip="1.2.3.4",
@@ -163,7 +163,7 @@ def test_bad_interfaces_no_exception():
     manager.normalize()
 
 
-def test_event_pii():
+def test_event_pii() -> None:
     manager = EventManager(
         make_event(user={"id": None}, _meta={"user": {"id": {"": {"err": ["invalid"]}}}})
     )
@@ -172,7 +172,7 @@ def test_event_pii():
     assert data["_meta"]["user"]["id"] == {"": {"err": ["invalid"]}}
 
 
-def test_event_id_lowercase():
+def test_event_id_lowercase() -> None:
     manager = EventManager(make_event(event_id="1234ABCD" * 4))
     manager.normalize()
     data = manager.get_data()

--- a/tests/sentry/event_manager/test_validate_data.py
+++ b/tests/sentry/event_manager/test_validate_data.py
@@ -13,7 +13,7 @@ def validate_and_normalize(data):
     return manager.get_data()
 
 
-def test_timestamp():
+def test_timestamp() -> None:
     data = validate_and_normalize({"timestamp": "not-a-timestamp"})
     assert len(data["errors"]) == 1
 
@@ -32,17 +32,17 @@ def test_timestamp():
     assert data["errors"][0]["type"] == "past_timestamp"
 
 
-def test_empty_event_id():
+def test_empty_event_id() -> None:
     data = validate_and_normalize({"event_id": ""})
     assert len(data["event_id"]) == 32
 
 
-def test_missing_event_id():
+def test_missing_event_id() -> None:
     data = validate_and_normalize({})
     assert len(data["event_id"]) == 32
 
 
-def test_invalid_event_id():
+def test_invalid_event_id() -> None:
     data = validate_and_normalize({"event_id": "a" * 33})
     assert len(data["event_id"]) == 32
     assert len(data["errors"]) == 1
@@ -58,7 +58,7 @@ def test_invalid_event_id():
     assert data["errors"][0]["value"] == "xyz"
 
 
-def test_unknown_attribute():
+def test_unknown_attribute() -> None:
     data = validate_and_normalize({"message": "foo", "foo": "bar"})
     assert data["foo"] is None
     assert len(data["errors"]) == 1
@@ -66,7 +66,7 @@ def test_unknown_attribute():
     assert data["errors"][0]["name"] == "foo"
 
 
-def test_invalid_interface_name():
+def test_invalid_interface_name() -> None:
     data = validate_and_normalize({"message": "foo", "foo.baz": "bar"})
     assert data["foo.baz"] is None
     assert len(data["errors"]) == 1
@@ -74,7 +74,7 @@ def test_invalid_interface_name():
     assert data["errors"][0]["name"] == "foo.baz"
 
 
-def test_invalid_interface_import_path():
+def test_invalid_interface_import_path() -> None:
     data = validate_and_normalize({"message": "foo", "exception2": "bar"})
     assert data["exception2"] is None
 
@@ -83,7 +83,7 @@ def test_invalid_interface_import_path():
     assert data["errors"][0]["name"] == "exception2"
 
 
-def test_does_expand_list():
+def test_does_expand_list() -> None:
     data = validate_and_normalize(
         {
             "message": "foo",
@@ -93,17 +93,17 @@ def test_does_expand_list():
     assert "exception" in data
 
 
-def test_log_level_as_string():
+def test_log_level_as_string() -> None:
     data = validate_and_normalize({"message": "foo", "level": "error"})
     assert data["level"] == "error"
 
 
-def test_log_level_as_int():
+def test_log_level_as_int() -> None:
     data = validate_and_normalize({"message": "foo", "level": 40})
     assert data["level"] == "error"
 
 
-def test_invalid_log_level():
+def test_invalid_log_level() -> None:
     data = validate_and_normalize({"message": "foo", "level": "foobar"})
     assert data["level"] == "error"
     assert len(data["errors"]) == 1
@@ -112,17 +112,17 @@ def test_invalid_log_level():
     assert data["errors"][0]["value"] == "foobar"
 
 
-def test_tags_as_string():
+def test_tags_as_string() -> None:
     data = validate_and_normalize({"message": "foo", "tags": "bar"})
     assert data["tags"] == []
 
 
-def test_tags_with_spaces():
+def test_tags_with_spaces() -> None:
     data = validate_and_normalize({"message": "foo", "tags": {"foo bar": "baz bar"}})
     assert data["tags"] == [["foo-bar", "baz bar"]]
 
 
-def test_tags_out_of_bounds():
+def test_tags_out_of_bounds() -> None:
     data = validate_and_normalize(
         {"message": "foo", "tags": {"f" * 201: "value", "foo": "v" * 201, "bar": "value"}}
     )
@@ -130,7 +130,7 @@ def test_tags_out_of_bounds():
     assert len(data["errors"]) == 2
 
 
-def test_tags_as_invalid_pair():
+def test_tags_as_invalid_pair() -> None:
     data = validate_and_normalize(
         {"message": "foo", "tags": [("foo", "bar"), ("biz", "baz", "boz")]}
     )
@@ -140,14 +140,14 @@ def test_tags_as_invalid_pair():
     assert data["errors"][0]["value"] == ["biz", "baz", "boz"]
 
 
-def test_reserved_tags():
+def test_reserved_tags() -> None:
     data = validate_and_normalize(
         {"message": "foo", "tags": [("foo", "bar"), ("release", "abc123")]}
     )
     assert data["tags"] == [["foo", "bar"]]
 
 
-def test_tag_value():
+def test_tag_value() -> None:
     data = validate_and_normalize({"message": "foo", "tags": [("foo", "b\nar"), ("biz", "baz")]})
     assert data["tags"] == [["foo", None], ["biz", "baz"]]
 
@@ -157,12 +157,12 @@ def test_tag_value():
     assert data["errors"][0]["value"] == "b\nar"
 
 
-def test_extra_as_string():
+def test_extra_as_string() -> None:
     data = validate_and_normalize({"message": "foo", "extra": "bar"})
     assert data["extra"] == {}
 
 
-def test_release_tag_max_len():
+def test_release_tag_max_len() -> None:
     release_key = "sentry:release"
     release_value = "a" * MAX_VERSION_LENGTH
     data = validate_and_normalize({"message": "foo", "tags": [[release_key, release_value]]})
@@ -170,21 +170,21 @@ def test_release_tag_max_len():
     assert data["tags"] == [[release_key, release_value]]
 
 
-def test_server_name_too_long():
+def test_server_name_too_long() -> None:
     key = "server_name"
     value = "a" * (MAX_CULPRIT_LENGTH + 1)
     data = validate_and_normalize({key: value})
     assert len(dict(data["tags"])[key]) == MAX_CULPRIT_LENGTH
 
 
-def test_site_too_long():
+def test_site_too_long() -> None:
     key = "site"
     value = "a" * (MAX_CULPRIT_LENGTH + 1)
     data = validate_and_normalize({key: value})
     assert len(dict(data["tags"])[key]) == MAX_CULPRIT_LENGTH
 
 
-def test_release_too_long():
+def test_release_too_long() -> None:
     data = validate_and_normalize({"release": "a" * (MAX_VERSION_LENGTH + 1)})
     assert not data.get("release")
     assert len(data["errors"]) == 1
@@ -193,12 +193,12 @@ def test_release_too_long():
     assert data["errors"][0]["value"] == "a" * (MAX_VERSION_LENGTH + 1)
 
 
-def test_release_as_non_string():
+def test_release_as_non_string() -> None:
     data = validate_and_normalize({"release": 42})
     assert data["release"] == "42"
 
 
-def test_distribution_too_long():
+def test_distribution_too_long() -> None:
     dist_len = 201
     data = validate_and_normalize({"release": "a" * 62, "dist": "b" * dist_len})
     # max dist length since relay-python 0.8.16 = 64 chars, and they started
@@ -210,7 +210,7 @@ def test_distribution_too_long():
     assert data["errors"][0]["value"] == "b" * dist_len
 
 
-def test_distribution_bad_char():
+def test_distribution_bad_char() -> None:
     data = validate_and_normalize({"release": "a" * 62, "dist": "^%"})
     assert not data.get("dist")
     assert len(data["errors"]) == 1
@@ -219,38 +219,38 @@ def test_distribution_bad_char():
     assert data["errors"][0]["value"] == "^%"
 
 
-def test_distribution_strip():
+def test_distribution_strip() -> None:
     data = validate_and_normalize({"release": "a" * 62, "dist": " foo "})
     assert data["dist"] == "foo"
 
 
-def test_distribution_as_non_string():
+def test_distribution_as_non_string() -> None:
     data = validate_and_normalize({"release": "42", "dist": 23})
     assert data["release"] == "42"
     assert data.get("dist") is None
 
 
-def test_distribution_no_release():
+def test_distribution_no_release() -> None:
     data = validate_and_normalize({"dist": 23})
     assert data.get("dist") is None
 
 
-def test_valid_platform():
+def test_valid_platform() -> None:
     data = validate_and_normalize({"platform": "python"})
     assert data["platform"] == "python"
 
 
-def test_no_platform():
+def test_no_platform() -> None:
     data = validate_and_normalize({})
     assert data["platform"] == "other"
 
 
-def test_invalid_platform():
+def test_invalid_platform() -> None:
     data = validate_and_normalize({"platform": "foobar"})
     assert data["platform"] == "other"
 
 
-def test_environment_too_long():
+def test_environment_too_long() -> None:
     data = validate_and_normalize({"environment": "a" * 65})
     assert not data.get("environment")
     (error,) = data["errors"]
@@ -260,7 +260,7 @@ def test_environment_too_long():
     assert error["value"] == "a" * 65
 
 
-def test_environment_invalid():
+def test_environment_invalid() -> None:
     data = validate_and_normalize({"environment": "a/b"})
     assert not data.get("environment")
     (error,) = data["errors"]
@@ -270,17 +270,17 @@ def test_environment_invalid():
     assert error["value"] == "a/b"
 
 
-def test_environment_as_non_string():
+def test_environment_as_non_string() -> None:
     data = validate_and_normalize({"environment": 42})
     assert data.get("environment") is None
 
 
-def test_time_spent_too_large():
+def test_time_spent_too_large() -> None:
     data = validate_and_normalize({"time_spent": 2147483647 + 1})
     assert data.get("time_spent") is None
 
 
-def test_time_spent_invalid():
+def test_time_spent_invalid() -> None:
     data = validate_and_normalize({"time_spent": "lol"})
     assert not data.get("time_spent")
     assert len(data["errors"]) == 1
@@ -289,12 +289,12 @@ def test_time_spent_invalid():
     assert data["errors"][0]["value"] == "lol"
 
 
-def test_time_spent_non_int():
+def test_time_spent_non_int() -> None:
     data = validate_and_normalize({"time_spent": "123"})
     assert data["time_spent"] is None
 
 
-def test_fingerprints():
+def test_fingerprints() -> None:
     data = validate_and_normalize({"fingerprint": "2012-01-01T10:30:45"})
     assert not data.get("fingerprint")
     assert data["errors"][0]["type"] == "invalid_data"
@@ -327,7 +327,7 @@ def test_fingerprints():
     assert "errors" not in data
 
 
-def test_messages():
+def test_messages() -> None:
     # Just 'message': wrap it in interface
     data = validate_and_normalize({"message": "foo is bar"})
     assert data["logentry"] == {"formatted": "foo is bar"}
@@ -354,7 +354,7 @@ def test_messages():
 
 
 @pytest.mark.skip(reason="Message behavior that didn't make a lot of sense.")
-def test_messages_old_behavior():
+def test_messages_old_behavior() -> None:
     # both 'message' and complete valid interface but interface has the same
     # value for both keys so the 'formatted' value is discarded and ends up
     # being replaced with 'message'

--- a/tests/sentry/eventstore/processing/test_redis_cluster.py
+++ b/tests/sentry/eventstore/processing/test_redis_cluster.py
@@ -5,7 +5,7 @@ from sentry.testutils.helpers.redis import use_redis_cluster
 
 
 @use_redis_cluster()
-def test_mark_event_reprocessed():
+def test_mark_event_reprocessed() -> None:
     group_id = 5
     store = RedisReprocessingStore()
     date_created = datetime.now()

--- a/tests/sentry/eventstream/kafka/test_protocol.py
+++ b/tests/sentry/eventstream/kafka/test_protocol.py
@@ -12,19 +12,19 @@ from sentry.utils import json
 
 
 @override_options({"post-process-forwarder:rapidjson": False})
-def test_get_task_kwargs_for_message_invalid_payload():
+def test_get_task_kwargs_for_message_invalid_payload() -> None:
     with pytest.raises(InvalidPayload):
         get_task_kwargs_for_message(b'{"format": "invalid"}')
 
 
 @override_options({"post-process-forwarder:rapidjson": False})
-def test_get_task_kwargs_for_message_invalid_version():
+def test_get_task_kwargs_for_message_invalid_version() -> None:
     with pytest.raises(InvalidVersion):
         get_task_kwargs_for_message(json.dumps([0, "insert", {}]).encode())
 
 
 @pytest.mark.django_db
-def test_get_task_kwargs_for_message_version_1():
+def test_get_task_kwargs_for_message_version_1() -> None:
     event_data = {
         "project_id": 1,
         "group_id": 2,
@@ -67,7 +67,7 @@ def test_get_task_kwargs_for_message_version_1():
 
 
 @override_options({"post-process-forwarder:rapidjson": False})
-def test_get_task_kwargs_for_message_version_1_skip_consume():
+def test_get_task_kwargs_for_message_version_1_skip_consume() -> None:
     assert (
         get_task_kwargs_for_message(json.dumps([1, "insert", {}, {"skip_consume": True}]).encode())
         is None
@@ -75,18 +75,18 @@ def test_get_task_kwargs_for_message_version_1_skip_consume():
 
 
 @override_options({"post-process-forwarder:rapidjson": False})
-def test_get_task_kwargs_for_message_version_1_unsupported_operation():
+def test_get_task_kwargs_for_message_version_1_unsupported_operation() -> None:
     assert get_task_kwargs_for_message(json.dumps([1, "delete", {}]).encode()) is None
 
 
 @override_options({"post-process-forwarder:rapidjson": False})
-def test_get_task_kwargs_for_message_version_1_unexpected_operation():
+def test_get_task_kwargs_for_message_version_1_unexpected_operation() -> None:
     with pytest.raises(UnexpectedOperation):
         get_task_kwargs_for_message(json.dumps([1, "invalid", {}, {}]).encode())
 
 
 @pytest.mark.django_db
-def test_get_task_kwargs_for_message_version_1_kafka_headers():
+def test_get_task_kwargs_for_message_version_1_kafka_headers() -> None:
     kafka_headers = [
         ("Received-Timestamp", b"1626301534.910839"),
         ("event_id", b"00000000000010008080808080808080"),

--- a/tests/sentry/feedback/usecases/ingest/test_create_feedback.py
+++ b/tests/sentry/feedback/usecases/ingest/test_create_feedback.py
@@ -21,7 +21,7 @@ from sentry.types.group import GroupSubStatus
 from tests.sentry.feedback import create_dummy_openai_response, mock_feedback_event
 
 
-def test_fix_for_issue_platform():
+def test_fix_for_issue_platform() -> None:
     event: dict[str, Any] = {
         "project_id": 1,
         "request": {
@@ -117,7 +117,7 @@ def test_fix_for_issue_platform():
     assert fixed_event["user"]["email"] == event["contexts"]["feedback"]["contact_email"]
 
 
-def test_corrected_still_works():
+def test_corrected_still_works() -> None:
     event: dict[str, Any] = {
         "project_id": 1,
         "request": {
@@ -889,7 +889,7 @@ def test_create_feedback_issue_updates_project_flag(default_project):
 
 
 @django_db_all
-def test_get_feedback_title():
+def test_get_feedback_title() -> None:
     """Test the get_feedback_title function with various message types."""
 
     # Test normal short message

--- a/tests/sentry/feedback/usecases/ingest/test_userreport.py
+++ b/tests/sentry/feedback/usecases/ingest/test_userreport.py
@@ -135,7 +135,7 @@ def test_validator_should_not_filter_empty_message_without_option(set_sentry_opt
 
 
 @django_db_all
-def test_validator_should_not_filter_empty_email():
+def test_validator_should_not_filter_empty_email() -> None:
     should_filter, tag, reason = validate_user_report(
         {
             "name": "",
@@ -151,7 +151,7 @@ def test_validator_should_not_filter_empty_email():
 
 
 @django_db_all
-def test_validator_should_filter_invalid_event_id():
+def test_validator_should_filter_invalid_event_id() -> None:
     should_filter, tag, reason = validate_user_report(
         {
             "name": "",
@@ -167,7 +167,7 @@ def test_validator_should_filter_invalid_event_id():
 
 
 @django_db_all
-def test_validator_strips_event_id_dashes():
+def test_validator_strips_event_id_dashes() -> None:
     report: UserReportDict = {
         "name": "",
         "email": "andrew@example.com",
@@ -180,7 +180,7 @@ def test_validator_strips_event_id_dashes():
 
 
 @django_db_all
-def test_validator_strips_comments_whitespace():
+def test_validator_strips_comments_whitespace() -> None:
     report: UserReportDict = {
         "name": "",
         "email": "andrew@example.com",

--- a/tests/sentry/feedback/usecases/test_spam_detection.py
+++ b/tests/sentry/feedback/usecases/test_spam_detection.py
@@ -1,7 +1,7 @@
 from sentry.feedback.usecases.spam_detection import make_input_prompt
 
 
-def test_make_input_prompt_case_insensitive():
+def test_make_input_prompt_case_insensitive() -> None:
     msg = "Hello WorlD! vEjh3476@@$AB@!"
     prompt1 = make_input_prompt(msg)
     prompt2 = make_input_prompt(msg.lower())

--- a/tests/sentry/flags/providers/test_generic.py
+++ b/tests/sentry/flags/providers/test_generic.py
@@ -4,7 +4,7 @@ from sentry.flags.models import PROVIDER_MAP
 from sentry.flags.providers import DeserializationError, GenericProvider
 
 
-def test_handle():
+def test_handle() -> None:
     items = GenericProvider(123, None).handle(
         {
             "data": [
@@ -39,7 +39,7 @@ def test_handle():
     assert items[0]["tags"] == {}
 
 
-def test_handle_dedupe():
+def test_handle_dedupe() -> None:
     items = GenericProvider(123, None).handle(
         {
             "data": [
@@ -73,7 +73,7 @@ def test_handle_dedupe():
     assert items[0]["tags"] == {}
 
 
-def test_blank():
+def test_blank() -> None:
     try:
         GenericProvider(123, None).handle({})
     except DeserializationError as exc:
@@ -82,14 +82,14 @@ def test_blank():
         assert exc.errors["meta"][0].code == "required"
 
 
-def test_partial_fill():
+def test_partial_fill() -> None:
     try:
         GenericProvider(123, None).handle({"data": [], "meta": {}})
     except DeserializationError as exc:
         assert exc.errors["meta"]["version"][0].code == "required"
 
 
-def test_empty_data_item():
+def test_empty_data_item() -> None:
     try:
         GenericProvider(123, None).handle({"data": [{}], "meta": {"version": 1}})
     except DeserializationError as exc:

--- a/tests/sentry/flags/providers/test_launchdarkly.py
+++ b/tests/sentry/flags/providers/test_launchdarkly.py
@@ -12,7 +12,7 @@ from sentry.flags.providers import (
 default_timezone = timezone.get_default_timezone()
 
 
-def test_launchdarkly_create():
+def test_launchdarkly_create() -> None:
     request_data = {
         "_links": {
             "canonical": {
@@ -160,7 +160,7 @@ def test_launchdarkly_create():
     assert flag_row["tags"]["description"] == "flag was created"
 
 
-def test_launchdarkly_update():
+def test_launchdarkly_update() -> None:
     request_data = {
         "_id": "1234",
         "_accountId": "1234",
@@ -352,7 +352,7 @@ def test_launchdarkly_update():
     assert flag_row["action"] == ACTION_MAP["updated"]
 
 
-def test_launchdarkly_create_no_member():
+def test_launchdarkly_create_no_member() -> None:
     request_data = {
         "_links": {
             "canonical": {
@@ -487,7 +487,7 @@ def test_launchdarkly_create_no_member():
     assert flag_row["tags"]["description"] == "flag was created"
 
 
-def test_launchdarkly_delete_and_update():
+def test_launchdarkly_delete_and_update() -> None:
     request_data = {
         "_id": "1234",
         "_accountId": "1234",
@@ -521,7 +521,7 @@ def test_launchdarkly_delete_and_update():
     assert flag_row_delete["action"] == ACTION_MAP["deleted"]
 
 
-def test_launchdarkly_no_valid_action():
+def test_launchdarkly_no_valid_action() -> None:
     request_data = {
         "_id": "1234",
         "_accountId": "1234",
@@ -559,7 +559,7 @@ def test_launchdarkly_no_valid_action():
     assert len(res) == 0
 
 
-def test_bad_launchdarkly_data():
+def test_bad_launchdarkly_data() -> None:
     request_data = {
         "accesses": [],
         "description": {},

--- a/tests/sentry/flags/providers/test_statsig.py
+++ b/tests/sentry/flags/providers/test_statsig.py
@@ -6,7 +6,7 @@ from sentry.flags.models import PROVIDER_MAP
 from sentry.flags.providers import DeserializationError, StatsigProvider
 
 
-def test_handle_batched_all_actions():
+def test_handle_batched_all_actions() -> None:
     org_id = 123
     logs = StatsigProvider(org_id, "abcdefgh", request_timestamp="1739400185400").handle(
         {
@@ -110,7 +110,7 @@ def test_handle_batched_all_actions():
     }
 
 
-def test_handle_no_user():
+def test_handle_no_user() -> None:
     org_id = 123
     logs = StatsigProvider(org_id, "abcdefgh", request_timestamp="1739400185400").handle(
         {
@@ -136,7 +136,7 @@ def test_handle_no_user():
     assert logs[0]["created_by_type"] is None
 
 
-def test_handle_no_project_or_environments():
+def test_handle_no_project_or_environments() -> None:
     org_id = 123
     logs = StatsigProvider(org_id, "abcdefgh", request_timestamp="1739400185400").handle(
         {
@@ -160,7 +160,7 @@ def test_handle_no_project_or_environments():
     assert logs[0]["organization_id"] == org_id
 
 
-def test_handle_additional_fields():
+def test_handle_additional_fields() -> None:
     org_id = 123
     logs = StatsigProvider(org_id, "abcdefgh", request_timestamp="1739400185400").handle(
         {
@@ -191,7 +191,7 @@ def test_handle_additional_fields():
     assert logs[0]["organization_id"] == org_id
 
 
-def test_handle_created_by_id():
+def test_handle_created_by_id() -> None:
     logs = StatsigProvider(123, "abcdefgh", request_timestamp="1739400185400").handle(
         {
             "data": [
@@ -213,7 +213,7 @@ def test_handle_created_by_id():
     assert logs[0]["created_by_type"] == 1
 
 
-def test_handle_created_by_id2():
+def test_handle_created_by_id2() -> None:
     logs = StatsigProvider(123, "abcdefgh", request_timestamp="1739400185400").handle(
         {
             "data": [
@@ -235,7 +235,7 @@ def test_handle_created_by_id2():
     assert logs[0]["created_by_type"] == 1
 
 
-def test_handle_created_by_name():
+def test_handle_created_by_name() -> None:
     logs = StatsigProvider(123, "abcdefgh", request_timestamp="1739400185400").handle(
         {
             "data": [
@@ -258,7 +258,7 @@ def test_handle_created_by_name():
     assert logs[0]["created_by_type"] == 2
 
 
-def test_handle_unsupported_events():
+def test_handle_unsupported_events() -> None:
     logs = StatsigProvider(123, "abcdefgh", request_timestamp="1739400185400").handle(
         {
             "data": [
@@ -295,7 +295,7 @@ def test_handle_unsupported_events():
     assert len(logs) == 0
 
 
-def test_handle_unsupported_config_changes():
+def test_handle_unsupported_config_changes() -> None:
     logs = StatsigProvider(123, "abcdefgh", request_timestamp="1739400185400").handle(
         {
             "data": [
@@ -323,7 +323,7 @@ def test_handle_unsupported_config_changes():
     assert len(logs) == 0
 
 
-def test_handle_unsupported_action():
+def test_handle_unsupported_action() -> None:
     logs = StatsigProvider(123, "abcdefgh", request_timestamp="1739400185400").handle(
         {
             "data": [
@@ -342,12 +342,12 @@ def test_handle_unsupported_action():
     assert len(logs) == 0
 
 
-def test_handle_empty_batch():
+def test_handle_empty_batch() -> None:
     logs = StatsigProvider(123, "abcdefgh", request_timestamp="1739400185400").handle({"data": []})
     assert len(logs) == 0
 
 
-def test_handle_empty_message():
+def test_handle_empty_message() -> None:
     with pytest.raises(DeserializationError) as exc_info:
         StatsigProvider(123, "abcdefgh", request_timestamp="1739400185400").handle({})
 
@@ -356,7 +356,7 @@ def test_handle_empty_message():
     assert errors["data"][0].code == "required"
 
 
-def test_handle_empty_event():
+def test_handle_empty_event() -> None:
     with pytest.raises(DeserializationError) as exc_info:
         StatsigProvider(123, "abcdefgh", request_timestamp="1739400185400").handle({"data": [{}]})
 

--- a/tests/sentry/flags/providers/test_unleash.py
+++ b/tests/sentry/flags/providers/test_unleash.py
@@ -4,7 +4,7 @@ from sentry.flags.models import PROVIDER_MAP
 from sentry.flags.providers import DeserializationError, UnleashProvider
 
 
-def test_handle_update_no_email():
+def test_handle_update_no_email() -> None:
     items = UnleashProvider(123, "abcdefgh").handle(
         {
             "id": 28,
@@ -33,7 +33,7 @@ def test_handle_update_no_email():
     }
 
 
-def test_handle_update_with_email():
+def test_handle_update_with_email() -> None:
     items = UnleashProvider(123, "abcdefgh").handle(
         {
             "id": 28,
@@ -62,7 +62,7 @@ def test_handle_update_with_email():
     }
 
 
-def test_handle_create():
+def test_handle_create() -> None:
     items = UnleashProvider(123, "abcdefgh").handle(
         {
             "id": 28,
@@ -80,7 +80,7 @@ def test_handle_create():
     assert items[0]["action"] == 0
 
 
-def test_handle_junk_action():
+def test_handle_junk_action() -> None:
     items = UnleashProvider(123, "abcdefgh").handle(
         {
             "id": 28,
@@ -97,7 +97,7 @@ def test_handle_junk_action():
     assert len(items) == 0
 
 
-def test_handle_no_tags():
+def test_handle_no_tags() -> None:
     items = UnleashProvider(123, "abcdefgh").handle(
         {
             "id": 28,
@@ -120,7 +120,7 @@ def test_handle_no_tags():
     assert items[0]["tags"] == {}
 
 
-def test_blank():
+def test_blank() -> None:
     try:
         UnleashProvider(123, "abcdefgh").handle({})
     except DeserializationError as exc:
@@ -131,7 +131,7 @@ def test_blank():
         assert exc.errors["createdBy"][0].code == "required"
 
 
-def test_partial_fill():
+def test_partial_fill() -> None:
     try:
         UnleashProvider(123, "abcdefgh").handle(
             {

--- a/tests/sentry/flags/test_audit_log_presenter.py
+++ b/tests/sentry/flags/test_audit_log_presenter.py
@@ -3,7 +3,7 @@ from sentry.runner.commands.presenters.audit_log_presenter import AuditLogPresen
 from sentry.testutils.cases import APITestCase
 
 
-def test_audit_log_item_generation():
+def test_audit_log_item_generation() -> None:
     presenter = AuditLogPresenter("", True)
     presenter.set("a", True)
     presenter.unset("b")

--- a/tests/sentry/ingest/test_slicing.py
+++ b/tests/sentry/ingest/test_slicing.py
@@ -7,13 +7,13 @@ from sentry.ingest.slicing import (
 )
 
 
-def test_is_storage_partitioned():
+def test_is_storage_partitioned() -> None:
     with override_settings(SENTRY_SLICING_CONFIG={"generic_metrics": {(0, 256): 0}}):
         assert is_sliced("generic_metrics")
         assert not is_sliced("errors")
 
 
-def test_map_logical_partition_to_slice():
+def test_map_logical_partition_to_slice() -> None:
     with override_settings(SENTRY_SLICING_CONFIG={"generic_metrics": {(0, 128): 0, (128, 256): 1}}):
         assert map_logical_partition_to_slice("generic_metrics", 0) == 0
         assert map_logical_partition_to_slice("generic_metrics", 127) == 0
@@ -21,7 +21,7 @@ def test_map_logical_partition_to_slice():
         assert map_logical_partition_to_slice("generic_metrics", 255) == 1
 
 
-def test_map_org_id_to_logical_partition():
+def test_map_org_id_to_logical_partition() -> None:
     base_org_id = 256 * 20
 
     assert map_org_id_to_logical_partition(base_org_id + 1) == 1

--- a/tests/sentry/ingest/test_transaction_clusterer.py
+++ b/tests/sentry/ingest/test_transaction_clusterer.py
@@ -36,7 +36,7 @@ from sentry.testutils.helpers.options import override_options
 from sentry.testutils.pytest.fixtures import django_db_all
 
 
-def test_multi_fanout():
+def test_multi_fanout() -> None:
     clusterer = TreeClusterer(merge_threshold=3)
     transaction_names = [
         "/a/b0/c/d0/e",
@@ -54,7 +54,7 @@ def test_multi_fanout():
     assert clusterer.get_rules() == ["/a/*/c/*/**", "/a/*/**"]
 
 
-def test_single_leaf():
+def test_single_leaf() -> None:
     clusterer = TreeClusterer(merge_threshold=2)
     transaction_names = [
         "/a/b1/c/",
@@ -64,7 +64,7 @@ def test_single_leaf():
     assert clusterer.get_rules() == ["/a/*/**"]
 
 
-def test_deep_tree():
+def test_deep_tree() -> None:
     clusterer = TreeClusterer(merge_threshold=1)
     transaction_names = [
         1001 * "/.",
@@ -75,7 +75,7 @@ def test_deep_tree():
     clusterer.get_rules()
 
 
-def test_clusterer_doesnt_generate_invalid_rules():
+def test_clusterer_doesnt_generate_invalid_rules() -> None:
     clusterer = TreeClusterer(merge_threshold=1)
     all_stars = ["/a/b", "/b/c", "/c/d"]
     clusterer.add_input(all_stars)
@@ -88,7 +88,7 @@ def test_clusterer_doesnt_generate_invalid_rules():
 
 
 @mock.patch("sentry.ingest.transaction_clusterer.datasource.redis.MAX_SET_SIZE", 5)
-def test_collection():
+def test_collection() -> None:
     org = Organization(pk=666)
     project1 = Project(id=101, name="p1", organization=org)
     project2 = Project(id=102, name="project2", organization=org)
@@ -111,7 +111,7 @@ def test_collection():
     assert set() == set(get_transaction_names(project3))
 
 
-def test_clear_redis():
+def test_clear_redis() -> None:
     project = Project(id=101, name="p1", organization=Organization(pk=66))
     _record_sample(ClustererNamespace.TRANSACTIONS, project, "foo")
     assert set(get_transaction_names(project)) == {"foo"}
@@ -123,7 +123,7 @@ def test_clear_redis():
     clear_samples(ClustererNamespace.TRANSACTIONS, project2)
 
 
-def test_clear_redis_projects():
+def test_clear_redis_projects() -> None:
     project1 = Project(id=101, name="p1", organization=Organization(pk=66))
     project2 = Project(id=102, name="p2", organization=Organization(pk=66))
     client = get_redis_client()
@@ -159,7 +159,7 @@ def test_clear_redis_projects():
 
 
 @mock.patch("sentry.ingest.transaction_clusterer.datasource.redis.MAX_SET_SIZE", 100)
-def test_distribution():
+def test_distribution() -> None:
     """Make sure that the redis set prefers newer entries"""
     project = Project(id=103, name="", organization=Organization(pk=66))
     for i in range(1000):
@@ -198,7 +198,7 @@ def test_record_transactions(mocked_record, default_organization, source, txname
     assert len(mocked_record.mock_calls) == expected
 
 
-def test_sort_rules():
+def test_sort_rules() -> None:
     rules = {
         ReplacementRule("/a/*/**"): 1,
         ReplacementRule("/a/**"): 2,
@@ -411,7 +411,7 @@ def test_clusterer_skips_deleted_projects(mock_update_rules, default_project):
 
 
 @django_db_all
-def test_get_deleted_project():
+def test_get_deleted_project() -> None:
     deleted_project = Project(pk=666, organization=Organization(pk=666))
     _record_sample(ClustererNamespace.TRANSACTIONS, deleted_project, "foo")
     assert list(get_active_projects(ClustererNamespace.TRANSACTIONS)) == []
@@ -567,7 +567,7 @@ def test_stale_rules_arent_saved(default_project):
     ]
 
 
-def test_bump_last_used():
+def test_bump_last_used() -> None:
     """Redis update works and does not delete other keys in the set."""
     project1 = Project(id=123, name="project1")
     RedisRuleStore(namespace=ClustererNamespace.TRANSACTIONS).write(

--- a/tests/sentry/ingest/test_transaction_rule_validator.py
+++ b/tests/sentry/ingest/test_transaction_rule_validator.py
@@ -2,7 +2,7 @@ from sentry.ingest.transaction_clusterer.base import ReplacementRule
 from sentry.ingest.transaction_clusterer.rule_validator import RuleValidator
 
 
-def test_all_star_rules_invalid():
+def test_all_star_rules_invalid() -> None:
     assert not RuleValidator(ReplacementRule("*/**")).is_valid()
     assert not RuleValidator(ReplacementRule("/*/**")).is_valid()
 
@@ -10,7 +10,7 @@ def test_all_star_rules_invalid():
     assert not RuleValidator(ReplacementRule("/*/*/*/*/**")).is_valid()
 
 
-def test_non_all_star_rules_valid():
+def test_non_all_star_rules_valid() -> None:
     assert RuleValidator(ReplacementRule("a/*/**")).is_valid()
     assert RuleValidator(ReplacementRule("/a/*/**")).is_valid()
 
@@ -24,7 +24,7 @@ def test_non_all_star_rules_valid():
     assert RuleValidator(ReplacementRule("/a/*/b/*/c/**")).is_valid()
 
 
-def test_schema_all_stars_invalid():
+def test_schema_all_stars_invalid() -> None:
     assert not RuleValidator(ReplacementRule("http://*/*/*/**")).is_valid()
     assert not RuleValidator(ReplacementRule("https://*/*/*/**")).is_valid()
     assert RuleValidator(ReplacementRule("http://a/*/*/**")).is_valid()

--- a/tests/sentry/lang/dart/test_utils.py
+++ b/tests/sentry/lang/dart/test_utils.py
@@ -18,7 +18,7 @@ MOCK_DEBUG_MAP = {
 }
 
 
-def test_view_hierarchy_type_regex():
+def test_view_hierarchy_type_regex() -> None:
     matcher = re.match(VIEW_HIERARCHY_TYPE_REGEX, "abc")
     assert matcher
     assert matcher.groups() == ("abc", None)
@@ -32,7 +32,7 @@ def test_view_hierarchy_type_regex():
     assert matcher.groups() == ("_abc", "_xyz@1")
 
 
-def test_generate_dart_symbols_map():
+def test_generate_dart_symbols_map() -> None:
     with tempfile.NamedTemporaryFile() as mocked_debug_file:
         mocked_debug_file.write(MOCK_DEBUG_FILE)
         mocked_debug_file.seek(0)

--- a/tests/sentry/lang/javascript/test_utils.py
+++ b/tests/sentry/lang/javascript/test_utils.py
@@ -7,7 +7,7 @@ from sentry.lang.javascript.utils import generate_module, trim_line
 LONG_LINE = "The public is more familiar with bad design than good design. It is, in effect, conditioned to prefer bad design, because that is what it lives with. The new becomes threatening, the old reassuring."
 
 
-def test_trim_line():
+def test_trim_line() -> None:
     assert trim_line("foo") == "foo"
     assert (
         trim_line(LONG_LINE)
@@ -31,7 +31,7 @@ def test_trim_line():
     )
 
 
-def test_generate_module():
+def test_generate_module() -> None:
     assert generate_module(None) == "<unknown module>"
     assert generate_module("http://example.com/foo.js") == "foo"
     assert generate_module("http://example.com/foo/bar.js") == "foo/bar"
@@ -88,7 +88,7 @@ def test_generate_module():
     )
 
 
-def test_ensure_module_names():
+def test_ensure_module_names() -> None:
     data: dict[str, Any] = {
         "message": "hello",
         "platform": "javascript",
@@ -123,7 +123,7 @@ def test_ensure_module_names():
     assert exc["stacktrace"]["frames"][1]["module"] == "foo/bar"
 
 
-def test_generate_modules_skips_none():
+def test_generate_modules_skips_none() -> None:
     expected = {
         "culprit": "",
         "exception": {

--- a/tests/sentry/lang/native/test_applecrashreport.py
+++ b/tests/sentry/lang/native/test_applecrashreport.py
@@ -2,7 +2,7 @@ from sentry.constants import NATIVE_UNKNOWN_STRING
 from sentry.lang.native.applecrashreport import AppleCrashReport
 
 
-def test_get_threads_apple_string():
+def test_get_threads_apple_string() -> None:
     acr = AppleCrashReport(
         threads=[
             {
@@ -95,7 +95,7 @@ Thread 2 name: com.apple.test\n\
     )
 
 
-def test_get_threads_apple_string_symbolicated():
+def test_get_threads_apple_string_symbolicated() -> None:
     acr = AppleCrashReport(
         symbolicated=True,
         threads=[
@@ -207,7 +207,7 @@ Thread 2 name: com.apple.test
 # 7   SentrySwift                     0x000000010031caa4 0x1002c8000 + 346788
 
 
-def test_get_thread_apple_string():
+def test_get_thread_apple_string() -> None:
     acr = AppleCrashReport()
     thread = acr.get_thread_apple_string(
         {
@@ -330,7 +330,7 @@ def test_get_thread_apple_string():
     )
 
 
-def test__convert_frame_to_apple_string():
+def test__convert_frame_to_apple_string() -> None:
     acr = AppleCrashReport()
     frame = acr._convert_frame_to_apple_string(
         frame={
@@ -369,7 +369,7 @@ def test__convert_frame_to_apple_string():
     )
 
 
-def test_get_binary_images_apple_string():
+def test_get_binary_images_apple_string() -> None:
     acr = AppleCrashReport(
         debug_images=[
             {
@@ -430,7 +430,7 @@ def test_get_binary_images_apple_string():
     )
 
 
-def test_binary_images_without_code_file():
+def test_binary_images_without_code_file() -> None:
     acr = AppleCrashReport(
         debug_images=[
             {
@@ -490,7 +490,7 @@ def test_binary_images_without_code_file():
     )
 
 
-def test__convert_debug_meta_to_binary_image_row():
+def test__convert_debug_meta_to_binary_image_row() -> None:
     acr = AppleCrashReport(
         context={
             "device": {
@@ -533,7 +533,7 @@ def test__convert_debug_meta_to_binary_image_row():
     )
 
 
-def test__get_exception_info():
+def test__get_exception_info() -> None:
     acr = AppleCrashReport(
         exceptions=[
             {
@@ -572,7 +572,7 @@ Attempted to dereference garbage pointer 0x10."
     )
 
 
-def test__get_exception_info_legacy_mechanism():
+def test__get_exception_info_legacy_mechanism() -> None:
     acr = AppleCrashReport(
         exceptions=[
             {
@@ -608,7 +608,7 @@ Attempted to dereference garbage pointer 0x10."
     )
 
 
-def test__get_exception_info_partial():
+def test__get_exception_info_partial() -> None:
     acr = AppleCrashReport(
         exceptions=[
             {
@@ -628,7 +628,7 @@ Attempted to dereference garbage pointer 0x10."
     )
 
 
-def test__get_crashed_thread_registers_no_exception():
+def test__get_crashed_thread_registers_no_exception() -> None:
     acr = AppleCrashReport(
         exceptions=[],
         threads=[{"id": 1, "crashed": True, "stacktrace": {"registers": {}}}],
@@ -637,7 +637,7 @@ def test__get_crashed_thread_registers_no_exception():
     assert acr._get_crashed_thread_registers() == ""
 
 
-def test__get_crashed_thread_registers_no_thread_registers():
+def test__get_crashed_thread_registers_no_thread_registers() -> None:
     acr = AppleCrashReport(
         exceptions=[{"thread_id": 1}],
         threads=[],
@@ -646,7 +646,7 @@ def test__get_crashed_thread_registers_no_thread_registers():
     assert acr._get_crashed_thread_registers() == ""
 
 
-def test__get_crashed_thread_registers_arm64():
+def test__get_crashed_thread_registers_arm64() -> None:
     acr = AppleCrashReport(
         exceptions=[{"thread_id": 1}],
         context={"device": {"arch": "arm64"}},
@@ -711,7 +711,7 @@ def test__get_crashed_thread_registers_arm64():
     )
 
 
-def test__get_crashed_thread_registers_x86():
+def test__get_crashed_thread_registers_x86() -> None:
     acr = AppleCrashReport(
         exceptions=[{"thread_id": 1}],
         context={"device": {"arch": "x86"}},
@@ -740,7 +740,7 @@ def test__get_crashed_thread_registers_x86():
     )
 
 
-def test__get_crashed_thread_registers_unknown_arch():
+def test__get_crashed_thread_registers_unknown_arch() -> None:
     acr = AppleCrashReport(
         exceptions=[{"thread_id": 1}],
         context={"device": {"arch": "ABC"}},

--- a/tests/sentry/lang/native/test_processing.py
+++ b/tests/sentry/lang/native/test_processing.py
@@ -22,13 +22,13 @@ from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.utils.safe import get_path
 
 
-def test_merge_symbolicator_image_empty():
+def test_merge_symbolicator_image_empty() -> None:
     data: dict[str, Any] = {}
     _merge_image({}, {}, None, data)
     assert not data.get("errors")
 
 
-def test_merge_symbolicator_image_basic():
+def test_merge_symbolicator_image_basic() -> None:
     raw_image = {"instruction_addr": 0xFEEBEE, "other": "foo"}
     sdk_info = {"sdk_name": "linux"}
     complete_image = {
@@ -52,7 +52,7 @@ def test_merge_symbolicator_image_basic():
     }
 
 
-def test_merge_symbolicator_image_basic_success():
+def test_merge_symbolicator_image_basic_success() -> None:
     raw_image = {"instruction_addr": 0xFEEBEE, "other": "foo"}
     sdk_info = {"sdk_name": "linux"}
     complete_image = {
@@ -76,7 +76,7 @@ def test_merge_symbolicator_image_basic_success():
     }
 
 
-def test_merge_symbolicator_image_remove_unknown_arch():
+def test_merge_symbolicator_image_remove_unknown_arch() -> None:
     raw_image = {"instruction_addr": 0xFEEBEE}
     sdk_info = {"sdk_name": "linux"}
     complete_image = {"debug_status": "found", "unwind_status": "found", "arch": "unknown"}
@@ -163,7 +163,7 @@ def test_cocoa_function_name(mock_symbolicator, default_project):
     assert function_name == "thunk for closure"
 
 
-def test_filter_frames():
+def test_filter_frames() -> None:
 
     frames = [
         {
@@ -183,7 +183,7 @@ def test_filter_frames():
     assert len(filtered_frames) == 0
 
 
-def test_instruction_addr_adjustment_auto():
+def test_instruction_addr_adjustment_auto() -> None:
     frames = [
         {"instruction_addr": "0xdeadbeef", "platform": "native"},
         {"instruction_addr": "0xbeefdead", "platform": "native"},
@@ -195,7 +195,7 @@ def test_instruction_addr_adjustment_auto():
     assert "adjust_instruction_addr" not in processed_frames[1].keys()
 
 
-def test_instruction_addr_adjustment_all():
+def test_instruction_addr_adjustment_all() -> None:
     frames = [
         {"instruction_addr": "0xdeadbeef", "platform": "native"},
         {"instruction_addr": "0xbeefdead", "platform": "native"},
@@ -207,7 +207,7 @@ def test_instruction_addr_adjustment_all():
     assert "adjust_instruction_addr" not in processed_frames[1].keys()
 
 
-def test_instruction_addr_adjustment_all_but_first():
+def test_instruction_addr_adjustment_all_but_first() -> None:
     frames = [
         {"instruction_addr": "0xdeadbeef", "platform": "native"},
         {"instruction_addr": "0xbeefdead", "platform": "native"},
@@ -219,7 +219,7 @@ def test_instruction_addr_adjustment_all_but_first():
     assert "adjust_instruction_addr" not in processed_frames[1].keys()
 
 
-def test_instruction_addr_adjustment_none():
+def test_instruction_addr_adjustment_none() -> None:
     frames = [
         {"instruction_addr": "0xdeadbeef", "platform": "native"},
         {"instruction_addr": "0xbeefdead", "platform": "native"},
@@ -231,7 +231,7 @@ def test_instruction_addr_adjustment_none():
     assert not processed_frames[1]["adjust_instruction_addr"]
 
 
-def test_rewrite_electron_debug_file():
+def test_rewrite_electron_debug_file() -> None:
     def rewrite(debug_file):
         for rule in ELECTRON_FIRST_MODULE_REWRITE_RULES:
             # Need to patch the regexes and replacement strings here
@@ -282,7 +282,7 @@ def test_il2cpp_symbolication(mock_symbolicator, default_project):
             "values": [
                 {
                     "type": "System.InvalidOperationException",
-                    "value": "Exception from a lady beetle \uD83D\uDC1E",
+                    "value": "Exception from a lady beetle \ud83d\udc1e",
                     "module": "mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                     "thread_id": 1,
                     "stacktrace": {

--- a/tests/sentry/lang/native/test_sources.py
+++ b/tests/sentry/lang/native/test_sources.py
@@ -16,7 +16,7 @@ from sentry.testutils.pytest.fixtures import django_db_all
 
 
 @django_db_all
-def test_validate_builtin_sources():
+def test_validate_builtin_sources() -> None:
     for source in settings.SENTRY_BUILTIN_SOURCES.values():
         jsonschema.validate(source, BUILTIN_SOURCE_SCHEMA)
 

--- a/tests/sentry/lang/native/test_utils.py
+++ b/tests/sentry/lang/native/test_utils.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 from sentry.lang.native.utils import Backoff, get_os_from_event, is_minidump_event
 
 
-def test_get_os_from_event():
+def test_get_os_from_event() -> None:
     os = get_os_from_event(
         {
             "debug_meta": {
@@ -24,7 +24,7 @@ def test_get_os_from_event():
     assert os == "ios"
 
 
-def test_is_minidump():
+def test_is_minidump() -> None:
     assert is_minidump_event({"exception": {"values": [{"mechanism": {"type": "minidump"}}]}})
     assert not is_minidump_event({"exception": {"values": [{"mechanism": {"type": "other"}}]}})
     assert not is_minidump_event({"exception": {"values": [{"mechanism": {"type": None}}]}})

--- a/tests/sentry/logging/test_handler.py
+++ b/tests/sentry/logging/test_handler.py
@@ -161,14 +161,14 @@ def test_emit_invalid_keys_prod(handler):
 
 
 @mock.patch("logging.raiseExceptions", True)
-def test_JSONRenderer_nonprod():
+def test_JSONRenderer_nonprod() -> None:
     renderer = JSONRenderer()
     with pytest.raises(TypeError):
         renderer(None, None, {"foo": {mock.Mock(): "foo"}})
 
 
 @mock.patch("logging.raiseExceptions", False)
-def test_JSONRenderer_prod():
+def test_JSONRenderer_prod() -> None:
     renderer = JSONRenderer()
     renderer(None, None, {"foo": {mock.Mock(): "foo"}})
 

--- a/tests/sentry/metrics/test_middleware.py
+++ b/tests/sentry/metrics/test_middleware.py
@@ -10,7 +10,7 @@ from sentry.metrics.middleware import (
 )
 
 
-def test_filter_tags_dev():
+def test_filter_tags_dev() -> None:
     with override_settings(SENTRY_METRICS_DISALLOW_BAD_TAGS=True):
         _filter_tags("x", {"foo": "bar"})
         with pytest.raises(
@@ -20,7 +20,7 @@ def test_filter_tags_dev():
             _filter_tags("x", {"foo": "bar", "foo_id": 42, "project": 42, "event": 22})
 
 
-def test_filter_tags_prod():
+def test_filter_tags_prod() -> None:
     with override_settings(SENTRY_METRICS_DISALLOW_BAD_TAGS=False):
         assert _filter_tags("x", {"foo": "bar"}) == {"foo": "bar"}
         assert _filter_tags("x", {"foo": "bar", "foo_id": 42, "project": 42, "event": 22}) == {
@@ -28,7 +28,7 @@ def test_filter_tags_prod():
         }
 
 
-def test_global():
+def test_global() -> None:
     assert get_current_global_tags() == {}
 
     with global_tags(tag_a=123):

--- a/tests/sentry/middleware/integrations/test_parsers_defined.py
+++ b/tests/sentry/middleware/integrations/test_parsers_defined.py
@@ -19,7 +19,7 @@ def extract_matching_url_patterns(urlpatterns, base: str = ""):
                 yield url_pattern
 
 
-def test_parsers_for_all_extension_urls():
+def test_parsers_for_all_extension_urls() -> None:
     """
     Ensure that we have a request parser for all defined integrations.
     """

--- a/tests/sentry/models/test_base.py
+++ b/tests/sentry/models/test_base.py
@@ -85,7 +85,7 @@ class AvailableOnTest(TestCase):
         app_config.get_model.assert_called_with("BogusModel")
 
 
-def test_model_index_location():
+def test_model_index_location() -> None:
     """
     Validates that we didn't misconfigure a model such that the index or
     constraints are defined on the model body itself.

--- a/tests/sentry/models/test_eventerror.py
+++ b/tests/sentry/models/test_eventerror.py
@@ -25,7 +25,7 @@ def test_event_error(error, type, message, data):
     assert EventError(error).data == data
 
 
-def test_api_context():
+def test_api_context() -> None:
     error = {"type": "unknown_error", "foo": "bar"}
     assert EventError(error).get_api_context() == {
         "type": "unknown_error",

--- a/tests/sentry/models/test_file.py
+++ b/tests/sentry/models/test_file.py
@@ -190,7 +190,7 @@ class FileTest(TestCase):
 
 
 @django_db_all
-def test_large_files():
+def test_large_files() -> None:
     large_blob = FileBlob.objects.create(size=3_000_000_000, checksum=uuid4().hex)
     zero_blob = FileBlob.objects.create(size=0, checksum=uuid4().hex)
     large_file = File.objects.create(size=3_000_000_000)

--- a/tests/sentry/models/test_projectcounter.py
+++ b/tests/sentry/models/test_projectcounter.py
@@ -334,6 +334,6 @@ def test_preallocation_early_return(default_project):
     )  # Redis values haven't changed
 
 
-def test_calculate_cached_id_block_size():
+def test_calculate_cached_id_block_size() -> None:
     assert calculate_cached_id_block_size(1) == 100
     assert calculate_cached_id_block_size(1000) == 1000

--- a/tests/sentry/monitors/processing_errors/test_errors.py
+++ b/tests/sentry/monitors/processing_errors/test_errors.py
@@ -2,7 +2,7 @@ from sentry.monitors.processing_errors.errors import CheckinProcessingError, Pro
 from sentry.monitors.testutils import build_checkin_item
 
 
-def test_checkin_processing_error():
+def test_checkin_processing_error() -> None:
     item = build_checkin_item()
     error = CheckinProcessingError(
         [{"type": ProcessingErrorType.MONITOR_INVALID_ENVIRONMENT, "reason": "Bad name"}],

--- a/tests/sentry/monitors/test_schedule.py
+++ b/tests/sentry/monitors/test_schedule.py
@@ -9,7 +9,7 @@ def t(hour: int, minute: int):
     return datetime(2019, 1, 1, hour, minute, 0, tzinfo=timezone.utc)
 
 
-def test_get_next_schedule():
+def test_get_next_schedule() -> None:
     # 00 * * * *: 5:30 -> 6:00
     assert get_next_schedule(t(5, 30), CrontabSchedule("0 * * * *")) == t(6, 00)
 
@@ -23,7 +23,7 @@ def test_get_next_schedule():
     assert get_next_schedule(t(5, 42), IntervalSchedule(interval=2, unit="hour")) == t(7, 42)
 
 
-def test_get_next_schedule_cron_dst():
+def test_get_next_schedule_cron_dst() -> None:
     # Minute rollover during DST start
     assert get_next_schedule(
         datetime(2024, 11, 3, 1, 59, 0, tzinfo=ZoneInfo("America/New_York")),
@@ -37,7 +37,7 @@ def test_get_next_schedule_cron_dst():
     ) == datetime(2024, 3, 10, 3, 0, 0, tzinfo=ZoneInfo("America/New_York"))
 
 
-def test_get_next_schedule_cron_dst_bugs():
+def test_get_next_schedule_cron_dst_bugs() -> None:
     """
     XXX(epurkhiser): This is covered by the cronsim library tests, but since
     it's somewhat important for us let's add our own coverage of the DST
@@ -60,7 +60,7 @@ def test_get_next_schedule_cron_dst_bugs():
     ) == datetime(2024, 3, 10, 12, 0, 0, tzinfo=ZoneInfo("America/New_York"))
 
 
-def test_get_prev_schedule():
+def test_get_prev_schedule() -> None:
     start_ts = datetime(2019, 1, 1, 1, 30, 0, tzinfo=timezone.utc)
 
     # 00 * * * *: 5:35 -> 5:00

--- a/tests/sentry/monitors/test_system_incidents.py
+++ b/tests/sentry/monitors/test_system_incidents.py
@@ -79,7 +79,7 @@ def fill_historic_metrics(start: datetime, metrics: Sequence[float | None]):
     redis_client.mset(values)
 
 
-def test_update_check_in_volume():
+def test_update_check_in_volume() -> None:
     redis_client = redis.redis_clusters.get(settings.SENTRY_MONITORS_REDIS_CLUSTER)
 
     now = timezone.now().replace(second=5)
@@ -359,7 +359,7 @@ def test_record_clock_tick_volume_metric_uniform(metrics, logger):
 
 
 @override_options({"crons.system_incidents.collect_metrics": True})
-def test_prune_incident_check_in_volume():
+def test_prune_incident_check_in_volume() -> None:
     now = timezone.now().replace(second=0, microsecond=0)
 
     # Fill in some historic volume data
@@ -393,7 +393,7 @@ def test_prune_incident_check_in_volume():
         "crons.system_incidents.pct_deviation_incident_threshold": -25,
     }
 )
-def test_tick_decision_anomaly_recovery():
+def test_tick_decision_anomaly_recovery() -> None:
     start = timezone.now().replace(minute=0, second=0, microsecond=0)
 
     test_metrics = [
@@ -452,7 +452,7 @@ def test_tick_decision_anomaly_recovery():
         "crons.system_incidents.pct_deviation_incident_threshold": -25,
     }
 )
-def test_tick_decisions_simple_incident():
+def test_tick_decisions_simple_incident() -> None:
     """
     Tests incident detection for an incident that immediately starts and
     immediately stops.
@@ -530,7 +530,7 @@ def test_tick_decisions_simple_incident():
         "crons.system_incidents.pct_deviation_incident_threshold": -25,
     }
 )
-def test_tick_decisions_variable_incident():
+def test_tick_decisions_variable_incident() -> None:
     """
     Tests an incident that slowly starts and slowly recovers.
     """

--- a/tests/sentry/processing/backpressure/test_checking.py
+++ b/tests/sentry/processing/backpressure/test_checking.py
@@ -32,7 +32,7 @@ EVENTS_MSG = json.dumps(
         "backpressure.status_ttl": 60,
     }
 )
-def test_backpressure_unhealthy_profiles():
+def test_backpressure_unhealthy_profiles() -> None:
     record_consumer_health(
         {
             "celery": Exception("Couldn't check celery"),
@@ -55,7 +55,7 @@ def test_backpressure_unhealthy_profiles():
         "backpressure.status_ttl": 60,
     }
 )
-def test_bad_config():
+def test_bad_config() -> None:
     with raises(MessageRejected):
         process_one_message(consumer_type="profiles", topic="profiles", payload=PROFILES_MSG)
 
@@ -93,7 +93,7 @@ def test_backpressure_healthy_profiles(process_profile_task):
         "backpressure.status_ttl": 60,
     }
 )
-def test_backpressure_unhealthy_events():
+def test_backpressure_unhealthy_events() -> None:
     record_consumer_health(
         {
             "celery": Exception("Couldn't check celery"),

--- a/tests/sentry/processing/backpressure/test_redis.py
+++ b/tests/sentry/processing/backpressure/test_redis.py
@@ -42,7 +42,7 @@ def test_redis_cluster_cluster_returns_some_usage() -> None:
 
 
 @use_redis_cluster(high_watermark=100)
-def test_redis_health():
+def test_redis_health() -> None:
     services = load_service_definitions()
     assert isinstance(services["redis"], Redis)
 
@@ -61,7 +61,7 @@ def test_redis_health():
 
 
 @use_redis_cluster(high_watermark=0)
-def test_redis_unhealthy_state():
+def test_redis_unhealthy_state() -> None:
     services = load_service_definitions()
     assert isinstance(services["redis"], Redis)
 

--- a/tests/sentry/processing/eventstore/test_processing.py
+++ b/tests/sentry/processing/eventstore/test_processing.py
@@ -9,7 +9,7 @@ from sentry.utils.services import LazyServiceWrapper
 @override_settings(
     SENTRY_TRANSACTION_PROCESSING_STORE=None, SENTRY_TRANSACTION_PROCESSING_STORE_OPTIONS={}
 )
-def test_transaction_datastore_defaults_to_event_store():
+def test_transaction_datastore_defaults_to_event_store() -> None:
     assert isinstance(transaction_processing_store, LazyServiceWrapper)
 
     assert transaction_processing_store._backend == event_processing_store._backend

--- a/tests/sentry/profiles/consumers/test_process.py
+++ b/tests/sentry/profiles/consumers/test_process.py
@@ -59,7 +59,7 @@ class TestProcessProfileConsumerStrategy(TestCase):
         )
 
 
-def test_adjust_instruction_addr_sample_format():
+def test_adjust_instruction_addr_sample_format() -> None:
     original_frames = [
         {"instruction_addr": "0xdeadbeef"},
         {"instruction_addr": "0xbeefdead"},
@@ -86,7 +86,7 @@ def test_adjust_instruction_addr_sample_format():
     assert frames[4] == {"instruction_addr": "0xdeadbeef", "adjust_instruction_addr": False}
 
 
-def test_adjust_instruction_addr_original_format():
+def test_adjust_instruction_addr_original_format() -> None:
     profile = {
         "platform": "cocoa",
         "sampled_profile": {

--- a/tests/sentry/profiles/test_flamegraph.py
+++ b/tests/sentry/profiles/test_flamegraph.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 from sentry.profiles.flamegraph import split_datetime_range_exponential
 
 
-def test_split_datetime_range_exponential_with_days():
+def test_split_datetime_range_exponential_with_days() -> None:
     start = datetime(2023, 1, 1)
     end = datetime(2023, 1, 31)
     initial_delta = timedelta(days=1)
@@ -26,7 +26,7 @@ def test_split_datetime_range_exponential_with_days():
     assert result == expected_chunks
 
 
-def test_split_datetime_range_exponential_with_hours():
+def test_split_datetime_range_exponential_with_hours() -> None:
     start_time = datetime(2024, 5, 1, 6, 0, 0)
     end_time = datetime(2024, 5, 2, 12, 0, 0)
     initial_h_delta = timedelta(hours=2)
@@ -50,7 +50,7 @@ def test_split_datetime_range_exponential_with_hours():
     assert result == expected_chunks
 
 
-def test_split_datetime_range_exponential_with_days_reverse():
+def test_split_datetime_range_exponential_with_days_reverse() -> None:
     start = datetime(2023, 1, 1)
     end = datetime(2023, 1, 31)
     initial_delta = timedelta(days=1)
@@ -75,7 +75,7 @@ def test_split_datetime_range_exponential_with_days_reverse():
     assert result == expected_chunks
 
 
-def test_split_datetime_range_exponential_with_hours_reverse():
+def test_split_datetime_range_exponential_with_hours_reverse() -> None:
     start_time = datetime(2024, 5, 1, 6, 0, 0)
     end_time = datetime(2024, 5, 2, 12, 0, 0)
     initial_h_delta = timedelta(hours=2)

--- a/tests/sentry/profiles/test_task.py
+++ b/tests/sentry/profiles/test_task.py
@@ -335,7 +335,7 @@ def test_normalize_android_profile(organization, android_profile):
     assert android_profile["device_classification"] == "low"
 
 
-def test_process_symbolicator_results_for_sample():
+def test_process_symbolicator_results_for_sample() -> None:
     profile: dict[str, Any] = {
         "version": 1,
         "platform": "rust",
@@ -426,7 +426,7 @@ def test_process_symbolicator_results_for_sample():
     assert profile["profile"]["stacks"] == [[0, 1, 2, 3, 4, 5]]
 
 
-def test_process_symbolicator_results_for_sample_js():
+def test_process_symbolicator_results_for_sample_js() -> None:
     profile: dict[str, Any] = {
         "version": 1,
         "platform": "javascript",
@@ -807,7 +807,7 @@ class DeobfuscationViaSymbolicator(TransactionTestCase):
         assert js_profile["profile"]["frames"][0].get("data", {}).get("symbolicated", False)
 
 
-def test_set_frames_platform_sample():
+def test_set_frames_platform_sample() -> None:
     js_prof: Profile = {
         "version": "1",
         "platform": "javascript",
@@ -825,7 +825,7 @@ def test_set_frames_platform_sample():
     assert platforms == ["javascript", "cocoa", "javascript"]
 
 
-def test_set_frames_platform_android():
+def test_set_frames_platform_android() -> None:
     android_prof: Profile = {
         "platform": "android",
         "profile": {

--- a/tests/sentry/profiles/test_utils.py
+++ b/tests/sentry/profiles/test_utils.py
@@ -3,7 +3,7 @@ from typing import Any
 from sentry.profiles.utils import apply_stack_trace_rules_to_profile
 
 
-def test_apply_stack_trace_rules_to_profile_sample_format():
+def test_apply_stack_trace_rules_to_profile_sample_format() -> None:
     profile: dict[str, Any] = {
         "version": 1,
         "platform": "python",
@@ -64,7 +64,7 @@ def test_apply_stack_trace_rules_to_profile_sample_format():
     assert profile["profile"]["frames"] == expected_frames
 
 
-def test_apply_stack_trace_rules_to_profile_android():
+def test_apply_stack_trace_rules_to_profile_android() -> None:
     profile: dict[str, Any] = {
         "platform": "android",
         "profile": {

--- a/tests/sentry/projectoptions/test_basic.py
+++ b/tests/sentry/projectoptions/test_basic.py
@@ -36,7 +36,7 @@ def freeze_option(factories, default_team):
         assert project.get_option("sentry:option-epoch", defaults.LATEST_EPOCH)
 
 
-def test_epoch_defaults():
+def test_epoch_defaults() -> None:
     option = WellKnownProjectOption(
         key="__sentry_test:test-option",
         epoch_defaults={1: "whatever", 10: "new-value", 42: "latest-value"},

--- a/tests/sentry/quotas/test_base.py
+++ b/tests/sentry/quotas/test_base.py
@@ -189,7 +189,7 @@ def test_quotas_to_json(obj, json):
     assert obj.to_json() == json
 
 
-def test_seat_assignable_must_have_reason():
+def test_seat_assignable_must_have_reason() -> None:
     with pytest.raises(ValueError):
         SeatAssignmentResult(assignable=False)
     SeatAssignmentResult(assignable=False, reason="because I said so")

--- a/tests/sentry/quotas/test_redis.py
+++ b/tests/sentry/quotas/test_redis.py
@@ -12,7 +12,7 @@ from sentry.testutils.cases import TestCase
 from sentry.utils.redis import clusters
 
 
-def test_is_rate_limited_script():
+def test_is_rate_limited_script() -> None:
     now = int(time.time())
 
     cluster = clusters.get("default")

--- a/tests/sentry/relay/config/test_experimental.py
+++ b/tests/sentry/relay/config/test_experimental.py
@@ -12,14 +12,14 @@ from sentry.relay.config.experimental import (
 )
 
 
-def test_time_checker_throws_on_timeout_hit():
+def test_time_checker_throws_on_timeout_hit() -> None:
     checker = TimeChecker(timedelta(seconds=1))
     sleep(1)
     with pytest.raises(TimeoutException):
         checker.check()
 
 
-def test_time_checker_no_throw_on_timeout_no_hit():
+def test_time_checker_no_throw_on_timeout_no_hit() -> None:
     checker = TimeChecker(timedelta(seconds=5))
     checker.check()
 
@@ -64,7 +64,7 @@ def test_build_safe_config_catches_timeout(mock_logger):
     assert extra == {"hard_timeout": timedelta(seconds=1)}
 
 
-def test_build_safe_config_returns_results_from_function_in_args():
+def test_build_safe_config_returns_results_from_function_in_args() -> None:
     def dummy(*args, **kwargs):
         return 1, 2, 3
 
@@ -92,7 +92,7 @@ def test_build_safe_config_returns_none_on_timeout_exception(mock_logger):
     assert result is None
 
 
-def test_build_safe_config_returns_none_on_non_timeout_exception():
+def test_build_safe_config_returns_none_on_non_timeout_exception() -> None:
     def dummy(*args, **kwargs):
         raise ValueError("foo")
 

--- a/tests/sentry/relay/test_projectconfig_cache.py
+++ b/tests/sentry/relay/test_projectconfig_cache.py
@@ -19,7 +19,7 @@ def test_delete_count(monkeypatch):
 
 
 @django_db_all
-def test_read_write():
+def test_read_write() -> None:
     cache = redis.RedisProjectConfigCache()
 
     dsn1 = "fake-dsn-1"

--- a/tests/sentry/relay/test_projectconfig_debounce_cache.py
+++ b/tests/sentry/relay/test_projectconfig_debounce_cache.py
@@ -1,7 +1,7 @@
 from sentry.relay.projectconfig_debounce_cache.redis import RedisProjectConfigDebounceCache
 
 
-def test_key_lifecycle():
+def test_key_lifecycle() -> None:
     # This lifecycle checks and inserts in one operation.
     cache = RedisProjectConfigDebounceCache()
     kwargs = {
@@ -19,7 +19,7 @@ def test_key_lifecycle():
     assert not cache.is_debounced(**kwargs)
 
 
-def test_split_debounce_lifecycle():
+def test_split_debounce_lifecycle() -> None:
     # The lifecycle where checking and inserting is done separately like in the
     # sentry.tasks.relay.* tasks.
     cache = RedisProjectConfigDebounceCache()
@@ -46,7 +46,7 @@ def test_split_debounce_lifecycle():
     assert not cache.is_debounced(**kwargs)
 
 
-def test_default_prefix():
+def test_default_prefix() -> None:
     cache = RedisProjectConfigDebounceCache()
     kwargs = {
         "public_key": "abc",
@@ -62,7 +62,7 @@ def test_default_prefix():
     assert redis.get(expected_key) == b"1"
 
 
-def test_custom_prefix():
+def test_custom_prefix() -> None:
     cache = RedisProjectConfigDebounceCache(key_prefix="hello:world")
     kwargs = {
         "public_key": "abc",

--- a/tests/sentry/release_health/test_tasks.py
+++ b/tests/sentry/release_health/test_tasks.py
@@ -553,7 +553,7 @@ class TestMetricReleaseMonitor(BaseTestReleaseMonitor, BaseMetricsTestCase):
     backend_class = MetricReleaseMonitorBackend
 
 
-def test_iter_adopted_releases():
+def test_iter_adopted_releases() -> None:
     """Test the totals object is flattened into a list of tuple of values."""
     assert (
         list(iter_adopted_releases({1: {"": {"releases": {"0.1": 1}, "total_sessions": 1}}})) == []
@@ -579,14 +579,14 @@ def test_iter_adopted_releases():
     )
 
 
-def test_valid_environment():
+def test_valid_environment() -> None:
     """A valid environment is one that has at least one session and a non-empty name."""
     assert valid_environment("production", 20)
     assert not valid_environment("", 20)
     assert not valid_environment("production", 0)
 
 
-def test_valid_and_adopted_release():
+def test_valid_and_adopted_release() -> None:
     """A valid release has a valid name and at least 10% of the environment's sessions."""
     assert valid_and_adopted_release("release", 10, 100)
     assert not valid_and_adopted_release("", 10, 100)
@@ -594,7 +594,7 @@ def test_valid_and_adopted_release():
     assert not valid_and_adopted_release("release", 10, 101)
 
 
-def test_has_been_adopted():
+def test_has_been_adopted() -> None:
     """An adopted session has at least 10% of the environment's sessions."""
     assert has_been_adopted(10, 1)
     assert has_been_adopted(100, 10)

--- a/tests/sentry/replays/test_post_process.py
+++ b/tests/sentry/replays/test_post_process.py
@@ -2,7 +2,7 @@ from sentry.replays.post_process import _archived_row
 from sentry.replays.validators import VALID_FIELD_SET
 
 
-def test_archived_row_contains_all_of_valid_field_set():
+def test_archived_row_contains_all_of_valid_field_set() -> None:
     ret = _archived_row("replay_id", 123)
     missing_keys = frozenset(VALID_FIELD_SET) - ret.keys()
     assert not missing_keys

--- a/tests/sentry/replays/unit/consumers/test_recording.py
+++ b/tests/sentry/replays/unit/consumers/test_recording.py
@@ -20,7 +20,7 @@ from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.utils import json
 
 
-def test_decompress_segment_success():
+def test_decompress_segment_success() -> None:
     """Test successful decompression of segment"""
     data = b"[hello, world!]"
     compressed_data = zlib.compress(data)
@@ -34,7 +34,7 @@ def test_decompress_segment_success():
     assert decompressed == data
 
 
-def test_decompress_segment_already_decompressed():
+def test_decompress_segment_already_decompressed() -> None:
     """Test handling of already decompressed JSON data"""
     data = b"[hello, world!]"
     compressed_data = zlib.compress(data)
@@ -44,19 +44,19 @@ def test_decompress_segment_already_decompressed():
     assert decompressed == data
 
 
-def test_decompress_segment_unexpected_start_character():
+def test_decompress_segment_unexpected_start_character() -> None:
     """Test handling of invalid data that can't be decompressed"""
     with pytest.raises(DropSilently):
         decompress_segment(b"hello, world!")
 
 
-def test_decompress_segment_empty_data():
+def test_decompress_segment_empty_data() -> None:
     """Test handling of empty data"""
     with pytest.raises(DropSilently):
         decompress_segment(b"")
 
 
-def test_parse_headers_success():
+def test_parse_headers_success() -> None:
     """Test successful parsing of headers"""
     recording = json.dumps({"segment_id": 42}).encode() + b"\n" + b"hello, world"
 
@@ -65,38 +65,38 @@ def test_parse_headers_success():
     assert payload == b"hello, world"
 
 
-def test_parse_headers_success_invalid_type():
+def test_parse_headers_success_invalid_type() -> None:
     """Test parsing headers with invalid segment-id value"""
     recording = json.dumps({"segment_id": None}).encode() + b"\n" + b"hello, world"
     with pytest.raises(DropSilently):
         parse_headers(recording, "1")
 
 
-def test_parse_headers_no_newline():
+def test_parse_headers_no_newline() -> None:
     """Test parsing headers without newline separator"""
     with pytest.raises(DropSilently):
         parse_headers(b'{"segment_id": 42}', "1")
 
 
-def test_parse_headers_invalid_json():
+def test_parse_headers_invalid_json() -> None:
     """Test parsing headers with invalid JSON"""
     with pytest.raises(DropSilently):
         parse_headers(b"hello\nworld", "1")
 
 
-def test_parse_headers_missing_segment_id():
+def test_parse_headers_missing_segment_id() -> None:
     """Test parsing headers missing segment_id field"""
     with pytest.raises(DropSilently):
         parse_headers(b'{"other_field": "value"}\nworld', "1")
 
 
-def test_parse_headers_empty_recording():
+def test_parse_headers_empty_recording() -> None:
     """Test parsing empty recording"""
     with pytest.raises(DropSilently):
         parse_headers(b"", "1")
 
 
-def test_parse_request_message_success():
+def test_parse_request_message_success() -> None:
     """Test successful parsing of request message"""
     message = {
         "type": "replay_recording_not_chunked",
@@ -113,13 +113,13 @@ def test_parse_request_message_success():
     assert result == message
 
 
-def test_parse_request_message_validation_error():
+def test_parse_request_message_validation_error() -> None:
     """Test ValidationError raises DropSilently"""
     with pytest.raises(DropSilently):
         parse_request_message(msgpack.packb(b"invalid"))
 
 
-def test_parse_recording_event_success():
+def test_parse_recording_event_success() -> None:
     """Test successful parsing of recording event end-to-end"""
     # Create real compressed data
     original_payload = b'[{"type": "test", "data": "some event data"}]'
@@ -165,7 +165,7 @@ def test_parse_recording_event_success():
     assert result == expected
 
 
-def test_parse_recording_event_with_replay_event():
+def test_parse_recording_event_with_replay_event() -> None:
     """Test parsing recording event with replay_event JSON"""
     # Create real compressed data
     original_payload = b'[{"type": "test", "data": "some event data"}]'
@@ -212,7 +212,7 @@ def test_parse_recording_event_with_replay_event():
     assert result == expected
 
 
-def test_parse_recording_event_missing_payload():
+def test_parse_recording_event_missing_payload() -> None:
     """Test that missing payload cause DropSilently"""
     message = {
         "type": "replay_recording_not_chunked",
@@ -228,7 +228,7 @@ def test_parse_recording_event_missing_payload():
         parse_recording_event(msgpack.packb(message))
 
 
-def test_parse_recording_event_invalid_compression():
+def test_parse_recording_event_invalid_compression() -> None:
     """Test that invalid compression in payload causes DropSilently"""
     message = {
         "type": "replay_recording_not_chunked",
@@ -244,7 +244,7 @@ def test_parse_recording_event_invalid_compression():
         parse_recording_event(msgpack.packb(message))
 
 
-def test_parse_recording_event_invalid_headers():
+def test_parse_recording_event_invalid_headers() -> None:
     """Test that invalid headers in payload causes DropSilently"""
     message = {
         "type": "replay_recording_not_chunked",
@@ -261,7 +261,7 @@ def test_parse_recording_event_invalid_headers():
 
 
 @django_db_all
-def test_process_message_compressed():
+def test_process_message_compressed() -> None:
     """Test "process_message" function with compressed payload."""
     # Create real compressed data
     original_payload = b'[{"type": "test", "data": "some event data"}]'
@@ -312,7 +312,7 @@ def test_process_message_compressed():
 
 
 @django_db_all
-def test_process_message_uncompressed():
+def test_process_message_uncompressed() -> None:
     """Test "process_message" function with uncompressed payload."""
     # Create real compressed data
     original_payload = b'[{"type": "test", "data": "some event data"}]'
@@ -363,7 +363,7 @@ def test_process_message_uncompressed():
 
 
 @django_db_all
-def test_process_message_compressed_with_video():
+def test_process_message_compressed_with_video() -> None:
     """Test "process_message" function with compressed payload and a video."""
     # Create real compressed data
     original_payload = b'[{"type": "test", "data": "some event data"}]'
@@ -413,12 +413,12 @@ def test_process_message_compressed_with_video():
     assert expected == processed_result
 
 
-def test_process_message_invalid_message():
+def test_process_message_invalid_message() -> None:
     """Test "process_message" function with invalid message."""
     assert process_message(make_kafka_message(b"")) == FilteredPayload()
 
 
-def test_process_message_invalid_recording_json():
+def test_process_message_invalid_recording_json() -> None:
     """Test "process_message" function with invalid recording json."""
     message = {
         "type": "replay_recording_not_chunked",
@@ -438,7 +438,7 @@ def test_process_message_invalid_recording_json():
     assert process_message(kafka_message) == FilteredPayload()
 
 
-def test_process_message_invalid_headers():
+def test_process_message_invalid_headers() -> None:
     """Test "process_message" function with invalid headers."""
     message = {
         "type": "replay_recording_not_chunked",
@@ -458,7 +458,7 @@ def test_process_message_invalid_headers():
     assert process_message(kafka_message) == FilteredPayload()
 
 
-def test_process_message_malformed_headers():
+def test_process_message_malformed_headers() -> None:
     """Test "process_message" function with malformed headers."""
     message = {
         "type": "replay_recording_not_chunked",
@@ -478,7 +478,7 @@ def test_process_message_malformed_headers():
     assert process_message(kafka_message) == FilteredPayload()
 
 
-def test_process_message_malformed_headers_invalid_unicode_codepoint():
+def test_process_message_malformed_headers_invalid_unicode_codepoint() -> None:
     """Test "process_message" function with malformed unicode codepoint in headers."""
     message = {
         "type": "replay_recording_not_chunked",
@@ -498,7 +498,7 @@ def test_process_message_malformed_headers_invalid_unicode_codepoint():
     assert process_message(kafka_message) == FilteredPayload()
 
 
-def test_process_message_no_headers():
+def test_process_message_no_headers() -> None:
     """Test "process_message" function with no headers."""
     message = {
         "type": "replay_recording_not_chunked",

--- a/tests/sentry/replays/unit/test_event_logger.py
+++ b/tests/sentry/replays/unit/test_event_logger.py
@@ -14,7 +14,7 @@ from sentry.replays.usecases.ingest.event_logger import (
 from sentry.replays.usecases.ingest.event_parser import ClickEvent, ParsedEventMeta
 
 
-def test_gen_rage_clicks():
+def test_gen_rage_clicks() -> None:
     # No clicks.
     meta = ParsedEventMeta([], [], [], [], [], [])
     assert len(list(gen_rage_clicks(meta, 1, "1", {"a": "b"}))) == 0
@@ -40,7 +40,7 @@ def test_gen_rage_clicks():
     assert len(list(gen_rage_clicks(meta, 1, "1", None))) == 0
 
 
-def test_emit_click_events_environment_handling():
+def test_emit_click_events_environment_handling() -> None:
     click_events = [
         ClickEvent(
             timestamp=1,

--- a/tests/sentry/replays/unit/test_event_parser.py
+++ b/tests/sentry/replays/unit/test_event_parser.py
@@ -17,7 +17,7 @@ from sentry.replays.usecases.ingest.event_parser import (
 from sentry.utils import json
 
 
-def test_highlighted_event_builder_canvas_sizes():
+def test_highlighted_event_builder_canvas_sizes() -> None:
     event = {"type": 3, "data": {"source": 9, "id": 2440, "type": 0, "commands": [{"a": "b"}]}}
 
     builder = HighlightedEventsBuilder()
@@ -31,7 +31,7 @@ def test_highlighted_event_builder_canvas_sizes():
     assert len(builder.result.canvas_sizes) == 0
 
 
-def test_parse_highlighted_events_mutation_events():
+def test_parse_highlighted_events_mutation_events() -> None:
     event = {
         "type": 5,
         "data": {
@@ -52,7 +52,7 @@ def test_parse_highlighted_events_mutation_events():
     assert len(result.mutation_events) == 0
 
 
-def test_parse_highlighted_events_options_events():
+def test_parse_highlighted_events_options_events() -> None:
     event = {
         "data": {
             "payload": {
@@ -86,7 +86,7 @@ def test_parse_highlighted_events_options_events():
     assert len(result.options_events) == 0
 
 
-def test_parse_highlighted_events_hydration_errors():
+def test_parse_highlighted_events_hydration_errors() -> None:
     event = {
         "type": 5,
         "data": {
@@ -106,7 +106,7 @@ def test_parse_highlighted_events_hydration_errors():
     assert result.hydration_errors[0].timestamp == event["data"]["payload"]["timestamp"]  # type: ignore[index]
 
 
-def test_parse_highlighted_events_hydration_errors_missing_data_key():
+def test_parse_highlighted_events_hydration_errors_missing_data_key() -> None:
     event = {
         "type": 5,
         "data": {
@@ -125,7 +125,7 @@ def test_parse_highlighted_events_hydration_errors_missing_data_key():
 # Request response body sizes parsing.
 
 
-def test_parse_highlighted_events_payload_sizes_old_format():
+def test_parse_highlighted_events_payload_sizes_old_format() -> None:
     event = {
         "type": 5,
         "data": {
@@ -143,7 +143,7 @@ def test_parse_highlighted_events_payload_sizes_old_format():
     assert result.request_response_sizes[0] == (1002, 8001)
 
 
-def test_parse_highlighted_events_payload_sizes_old_format_no_response():
+def test_parse_highlighted_events_payload_sizes_old_format_no_response() -> None:
     event = {
         "type": 5,
         "data": {
@@ -158,7 +158,7 @@ def test_parse_highlighted_events_payload_sizes_old_format_no_response():
     assert result.request_response_sizes[0] == (1002, None)
 
 
-def test_parse_highlighted_events_payload_sizes_old_format_no_request():
+def test_parse_highlighted_events_payload_sizes_old_format_no_request() -> None:
     event = {
         "type": 5,
         "data": {
@@ -173,7 +173,7 @@ def test_parse_highlighted_events_payload_sizes_old_format_no_request():
     assert result.request_response_sizes[0] == (None, 8001)
 
 
-def test_parse_highlighted_events_payload_sizes_old_format_nothing():
+def test_parse_highlighted_events_payload_sizes_old_format_nothing() -> None:
     event = {
         "type": 5,
         "data": {"tag": "performanceSpan", "payload": {"op": "resource.xhr", "data": {}}},
@@ -184,7 +184,7 @@ def test_parse_highlighted_events_payload_sizes_old_format_nothing():
     assert len(result.request_response_sizes) == 0
 
 
-def test_parse_highlighted_events_payload_sizes_new_format():
+def test_parse_highlighted_events_payload_sizes_new_format() -> None:
     event = {
         "type": 5,
         "data": {
@@ -202,7 +202,7 @@ def test_parse_highlighted_events_payload_sizes_new_format():
     assert result.request_response_sizes[0] == (5, 22)
 
 
-def test_parse_highlighted_events_payload_sizes_new_format_no_response():
+def test_parse_highlighted_events_payload_sizes_new_format_no_response() -> None:
     event = {
         "type": 5,
         "data": {
@@ -217,7 +217,7 @@ def test_parse_highlighted_events_payload_sizes_new_format_no_response():
     assert result.request_response_sizes[0] == (5, None)
 
 
-def test_parse_highlighted_events_payload_sizes_new_format_no_request():
+def test_parse_highlighted_events_payload_sizes_new_format_no_request() -> None:
     event = {
         "type": 5,
         "data": {
@@ -232,7 +232,7 @@ def test_parse_highlighted_events_payload_sizes_new_format_no_request():
     assert result.request_response_sizes[0] == (None, 5)
 
 
-def test_parse_highlighted_events_payload_sizes_new_format_nothing():
+def test_parse_highlighted_events_payload_sizes_new_format_nothing() -> None:
     event = {
         "type": 5,
         "data": {"tag": "performanceSpan", "payload": {"op": "resource.fetch"}},
@@ -243,7 +243,7 @@ def test_parse_highlighted_events_payload_sizes_new_format_nothing():
     assert len(result.request_response_sizes) == 0
 
 
-def test_parse_highlighted_events_payload_sizes_invalid_op():
+def test_parse_highlighted_events_payload_sizes_invalid_op() -> None:
     event = {
         "type": 5,
         "data": {
@@ -260,7 +260,7 @@ def test_parse_highlighted_events_payload_sizes_invalid_op():
 # Click parsing.
 
 
-def test_parse_highlighted_events_click_events():
+def test_parse_highlighted_events_click_events() -> None:
     event = {
         "type": 5,
         "timestamp": 1674298825,
@@ -313,7 +313,7 @@ def test_parse_highlighted_events_click_events():
     assert user_actions.click_events[0].timestamp == 1674298825
 
 
-def test_parse_highlighted_events_click_events_missing_node():
+def test_parse_highlighted_events_click_events_missing_node() -> None:
     event = {
         "type": 5,
         "timestamp": 1674298825,
@@ -334,7 +334,7 @@ def test_parse_highlighted_events_click_events_missing_node():
     assert len(builder.result.click_events) == 0
 
 
-def test_parse_highlighted_events_click_event_str_payload():
+def test_parse_highlighted_events_click_event_str_payload() -> None:
     event = {"type": 5, "data": {"tag": "breadcrumb", "payload": "hello world"}}
     builder = HighlightedEventsBuilder()
     builder.add(which(event), event, sampled=False)
@@ -342,7 +342,7 @@ def test_parse_highlighted_events_click_event_str_payload():
     assert len(result.click_events) == 0
 
 
-def test_parse_highlighted_events_click_event_missing_node():
+def test_parse_highlighted_events_click_event_missing_node() -> None:
     event = {
         "type": 5,
         "data": {
@@ -357,7 +357,7 @@ def test_parse_highlighted_events_click_event_missing_node():
     assert len(result.click_events) == 0
 
 
-def test_parse_highlighted_events_click_event_dead_rage():
+def test_parse_highlighted_events_click_event_dead_rage() -> None:
     time_after_click_ms = 7000.0
     event1 = {
         "type": 5,
@@ -497,7 +497,7 @@ def test_parse_highlighted_events_click_event_dead_rage():
     assert action.is_rage == 1
 
 
-def test_emit_click_negative_node_id():
+def test_emit_click_negative_node_id() -> None:
     event = {
         "type": 5,
         "timestamp": 1674298825,
@@ -539,7 +539,7 @@ def test_emit_click_negative_node_id():
 # Misc helper tests
 
 
-def test_get_testid():
+def test_get_testid() -> None:
     # Assert each test-id permutation is extracted.
     assert _get_testid({"testId": "123"}) == "123"
     assert _get_testid({"data-testid": "123"}) == "123"
@@ -563,7 +563,7 @@ def test_get_testid():
     assert _get_testid({}) == ""
 
 
-def test_parse_classes():
+def test_parse_classes() -> None:
     assert _parse_classes("") == []
     assert _parse_classes("   ") == []
     assert _parse_classes("  a b ") == ["a", "b"]
@@ -571,7 +571,7 @@ def test_parse_classes():
     assert _parse_classes("  a") == ["a"]
 
 
-def test_which():
+def test_which() -> None:
     event = {
         "type": 5,
         "timestamp": 0.0,
@@ -782,7 +782,7 @@ def test_parse_highlighted_events_fault_tolerance(event):
 # Tests for trace item functions
 
 
-def test_as_trace_item_context_click_event():
+def test_as_trace_item_context_click_event() -> None:
     event = {
         "type": 5,
         "data": {
@@ -836,7 +836,7 @@ def test_as_trace_item_context_click_event():
     assert "event_hash" in result and len(result["event_hash"]) == 16
 
 
-def test_as_trace_item_context_click_event_missing_node():
+def test_as_trace_item_context_click_event_missing_node() -> None:
     event = {
         "type": 5,
         "data": {
@@ -856,7 +856,7 @@ def test_as_trace_item_context_click_event_missing_node():
     assert result is None
 
 
-def test_as_trace_item_context_dead_click_event():
+def test_as_trace_item_context_dead_click_event() -> None:
     event = {
         "type": 5,
         "data": {
@@ -888,7 +888,7 @@ def test_as_trace_item_context_dead_click_event():
     assert "event_hash" in result and len(result["event_hash"]) == 16
 
 
-def test_as_trace_item_context_rage_click_event():
+def test_as_trace_item_context_rage_click_event() -> None:
     event = {
         "type": 5,
         "data": {
@@ -920,7 +920,7 @@ def test_as_trace_item_context_rage_click_event():
     assert "event_hash" in result and len(result["event_hash"]) == 16
 
 
-def test_as_trace_item_context_navigation_event():
+def test_as_trace_item_context_navigation_event() -> None:
     event = {
         "type": 5,
         "timestamp": 1753710793872,
@@ -944,7 +944,7 @@ def test_as_trace_item_context_navigation_event():
     assert "event_hash" in result and len(result["event_hash"]) == 16
 
 
-def test_as_trace_item_context_navigation_event_missing_optional_fields():
+def test_as_trace_item_context_navigation_event_missing_optional_fields() -> None:
     event = {
         "type": 5,
         "timestamp": 1753710793872,
@@ -967,7 +967,7 @@ def test_as_trace_item_context_navigation_event_missing_optional_fields():
     assert "event_hash" in result and len(result["event_hash"]) == 16
 
 
-def test_as_trace_item_context_resource_fetch_event():
+def test_as_trace_item_context_resource_fetch_event() -> None:
     event = {
         "type": 5,
         "timestamp": 1753710794.0346,
@@ -998,7 +998,7 @@ def test_as_trace_item_context_resource_fetch_event():
     assert "event_hash" in result and len(result["event_hash"]) == 16
 
 
-def test_as_trace_item_context_resource_xhr_event():
+def test_as_trace_item_context_resource_xhr_event() -> None:
     event = {
         "type": 5,
         "timestamp": 1753710794.0346,
@@ -1028,7 +1028,7 @@ def test_as_trace_item_context_resource_xhr_event():
     assert "event_hash" in result and len(result["event_hash"]) == 16
 
 
-def test_as_trace_item_context_resource_no_sizes():
+def test_as_trace_item_context_resource_no_sizes() -> None:
     event = {
         "data": {
             "payload": {
@@ -1049,7 +1049,7 @@ def test_as_trace_item_context_resource_no_sizes():
     assert "event_hash" in result and len(result["event_hash"]) == 16
 
 
-def test_as_trace_item_context_resource_script_event():
+def test_as_trace_item_context_resource_script_event() -> None:
     event = {
         "type": 5,
         "timestamp": 1753710794.0346,
@@ -1081,7 +1081,7 @@ def test_as_trace_item_context_resource_script_event():
     assert "event_hash" in result and len(result["event_hash"]) == 16
 
 
-def test_as_trace_item_context_resource_image_event():
+def test_as_trace_item_context_resource_image_event() -> None:
     event = {
         "type": 5,
         "timestamp": 1753710794.0346,
@@ -1113,7 +1113,7 @@ def test_as_trace_item_context_resource_image_event():
     assert "event_hash" in result and len(result["event_hash"]) == 16
 
 
-def test_as_trace_item_context_lcp_event():
+def test_as_trace_item_context_lcp_event() -> None:
     event = {
         "type": 5,
         "timestamp": 1753712471.43,
@@ -1140,7 +1140,7 @@ def test_as_trace_item_context_lcp_event():
     assert "event_hash" in result and len(result["event_hash"]) == 16
 
 
-def test_as_trace_item_context_fcp_event():
+def test_as_trace_item_context_fcp_event() -> None:
     event = {
         "type": 5,
         "timestamp": 1753712471.43,
@@ -1166,7 +1166,7 @@ def test_as_trace_item_context_fcp_event():
     assert "event_hash" in result and len(result["event_hash"]) == 16
 
 
-def test_as_trace_item_context_cls_event():
+def test_as_trace_item_context_cls_event() -> None:
     event = {
         "type": 5,
         "timestamp": 1753467516.4146557,
@@ -1199,7 +1199,7 @@ def test_as_trace_item_context_cls_event():
     assert "event_hash" in result and len(result["event_hash"]) == 16
 
 
-def test_as_trace_item_context_hydration_error():
+def test_as_trace_item_context_hydration_error() -> None:
     event = {
         "data": {
             "payload": {"timestamp": 1674298825.0, "data": {"url": "https://example.com/page"}}
@@ -1214,7 +1214,7 @@ def test_as_trace_item_context_hydration_error():
     assert "event_hash" in result and len(result["event_hash"]) == 16
 
 
-def test_as_trace_item_context_mutations():
+def test_as_trace_item_context_mutations() -> None:
     event = {"timestamp": 1674298825000, "data": {"payload": {"data": {"count": 42}}}}
 
     result = as_trace_item_context(EventType.MUTATIONS, event)
@@ -1225,7 +1225,7 @@ def test_as_trace_item_context_mutations():
     assert "event_hash" in result and len(result["event_hash"]) == 16
 
 
-def test_as_trace_item_context_options():
+def test_as_trace_item_context_options() -> None:
     event = {
         "type": 5,
         "timestamp": 1753710752516,
@@ -1267,7 +1267,7 @@ def test_as_trace_item_context_options():
     assert "event_hash" in result and len(result["event_hash"]) == 16
 
 
-def test_as_trace_item_context_memory():
+def test_as_trace_item_context_memory() -> None:
     event = {
         "type": 5,
         "timestamp": 1753467523.594,
@@ -1300,7 +1300,7 @@ def test_as_trace_item_context_memory():
     assert "event_hash" in result and len(result["event_hash"]) == 16
 
 
-def test_as_trace_item_context_returns_none_for_unsupported_events():
+def test_as_trace_item_context_returns_none_for_unsupported_events() -> None:
     event: dict[str, Any] = {"data": {"payload": {}}}
     assert as_trace_item_context(EventType.CONSOLE, event) is None
     assert as_trace_item_context(EventType.UI_BLUR, event) is None
@@ -1310,7 +1310,7 @@ def test_as_trace_item_context_returns_none_for_unsupported_events():
     assert as_trace_item_context(EventType.FEEDBACK, event) is None
 
 
-def test_as_trace_item():
+def test_as_trace_item() -> None:
     context: EventContext = {
         "organization_id": 123,
         "project_id": 456,
@@ -1345,7 +1345,7 @@ def test_as_trace_item():
     assert result.attributes["replay_id"].string_value == "replay-456"  # Should be added
 
 
-def test_as_trace_item_with_no_trace_id():
+def test_as_trace_item_with_no_trace_id() -> None:
     context: EventContext = {
         "organization_id": 123,
         "project_id": 456,
@@ -1371,7 +1371,7 @@ def test_as_trace_item_with_no_trace_id():
     assert result.trace_id == "replay-456"  # Should fall back to replay_id
 
 
-def test_as_trace_item_returns_none_for_unsupported_event():
+def test_as_trace_item_returns_none_for_unsupported_event() -> None:
     context: EventContext = {
         "organization_id": 123,
         "project_id": 456,

--- a/tests/sentry/replays/unit/test_ingest.py
+++ b/tests/sentry/replays/unit/test_ingest.py
@@ -15,7 +15,7 @@ from sentry.testutils.pytest.fixtures import django_db_all
 
 
 @django_db_all
-def test_process_recording_event_without_video():
+def test_process_recording_event_without_video() -> None:
     """Test process_recording_event without replay video data"""
     payload = b'[{"type": "test"}]'
     payload_compressed = zlib.compress(payload)
@@ -49,7 +49,7 @@ def test_process_recording_event_without_video():
 
 
 @django_db_all
-def test_process_recording_event_with_video():
+def test_process_recording_event_with_video() -> None:
     """Test process_recording_event with replay video data"""
     payload = b'[{"type": "test"}]'
     payload_compressed = zlib.compress(payload)
@@ -88,7 +88,7 @@ def test_process_recording_event_with_video():
     assert unpacked_video == video_data
 
 
-def test_parse_replay_events_empty():
+def test_parse_replay_events_empty() -> None:
     (result, trace_items) = parse_replay_events(
         {
             "context": {
@@ -110,7 +110,7 @@ def test_parse_replay_events_empty():
     assert trace_items == []
 
 
-def test_parse_replay_events_invalid_json():
+def test_parse_replay_events_invalid_json() -> None:
     result = parse_replay_events(
         {
             "context": {
@@ -131,7 +131,7 @@ def test_parse_replay_events_invalid_json():
     assert result is None
 
 
-def test_pack_replay_video():
+def test_pack_replay_video() -> None:
     result = pack_replay_video(b"hello", b"world")
     video, rrweb = unpack(zlib.decompress(result))
     assert rrweb == b"hello"

--- a/tests/sentry/replays/unit/test_issue_creation.py
+++ b/tests/sentry/replays/unit/test_issue_creation.py
@@ -221,7 +221,7 @@ def test_report_rage_click_issue_no_component(produce_occurrence_to_kafka):
     assert occurrence.evidence_display[1].important is True
 
 
-def test_make_clicked_element():
+def test_make_clicked_element() -> None:
     node = {
         "tagName": "a",
         "attributes": {

--- a/tests/sentry/replays/unit/test_retry.py
+++ b/tests/sentry/replays/unit/test_retry.py
@@ -1,7 +1,7 @@
 from sentry.utils.retries import sigmoid_delay
 
 
-def test_sigmoid_delay():
+def test_sigmoid_delay() -> None:
     results = [sigmoid_delay()(i) for i in range(125)]
     assert results[0] == 0.0066928509242848554
     assert results[5] == 0.5

--- a/tests/sentry/replays/unit/usecases/test_events.py
+++ b/tests/sentry/replays/unit/usecases/test_events.py
@@ -4,7 +4,7 @@ from sentry.replays.usecases.events import archive_event, viewed_event
 from sentry.utils import json
 
 
-def test_archive_event():
+def test_archive_event() -> None:
     """Test archive event generator."""
     event = archive_event(1, "2")
 
@@ -26,7 +26,7 @@ def test_archive_event():
     assert isinstance(parsed_event["payload"]["timestamp"], float)
 
 
-def test_viewed_event():
+def test_viewed_event() -> None:
     """Test "replay_viewed" event generator."""
     ts = time.time()
     event = viewed_event(1, "2", 3, ts)

--- a/tests/sentry/replays/unit/usecases/test_pack.py
+++ b/tests/sentry/replays/unit/usecases/test_pack.py
@@ -1,13 +1,13 @@
 from sentry.replays.usecases.pack import HEADER_OFFSET, Encoding, pack, unpack
 
 
-def test_pack_rrweb():
+def test_pack_rrweb() -> None:
     result = pack(b"hello", None)
     assert result[0] == Encoding.RRWEB.value
     assert result[1:] == b"hello"
 
 
-def test_pack_rrweb_video():
+def test_pack_rrweb_video() -> None:
     result = pack(b"hello", b"world")
     assert result[0] == Encoding.VIDEO.value
 
@@ -16,11 +16,11 @@ def test_pack_rrweb_video():
     assert result[HEADER_OFFSET + length :] == b"hello"
 
 
-def test_unpack_rrweb():
+def test_unpack_rrweb() -> None:
     assert unpack(pack(b"hello", None)) == (None, b"hello")
 
 
-def test_unpack_rrweb_video():
+def test_unpack_rrweb_video() -> None:
     assert unpack(pack(b"hello", b"world")) == (b"world", b"hello")
 
     x = b"\x00" * 1_000_000

--- a/tests/sentry/replays/unit/usecases/test_query.py
+++ b/tests/sentry/replays/unit/usecases/test_query.py
@@ -1,7 +1,7 @@
 from sentry.replays.usecases.query import _make_ordered
 
 
-def test_make_ordered():
+def test_make_ordered() -> None:
     """Test "_make_ordered" function."""
     # Assert ordered response.
     ordering = _make_ordered(["a", "b"], [{"replay_id": "a"}, {"replay_id": "b"}])

--- a/tests/sentry/rules/processing/test_buffer_processing.py
+++ b/tests/sentry/rules/processing/test_buffer_processing.py
@@ -23,7 +23,7 @@ from tests.snuba.rules.conditions.test_event_frequency import BaseEventFrequency
 FROZEN_TIME = before_now(days=1).replace(hour=1, minute=30, second=0, microsecond=0)
 
 
-def test_bucket_num_groups():
+def test_bucket_num_groups() -> None:
     assert bucket_num_groups(1) == "1"
     assert bucket_num_groups(50) == ">10"
     assert bucket_num_groups(101) == ">100"

--- a/tests/sentry/runner/commands/presenters/test_presenterdelegator.py
+++ b/tests/sentry/runner/commands/presenters/test_presenterdelegator.py
@@ -6,7 +6,7 @@ from sentry.runner.commands.presenters.presenterdelegator import PresenterDelega
 
 @pytest.mark.django_db
 @responses.activate
-def test_contains_attributes():
+def test_contains_attributes() -> None:
     expected_methods = [
         "set",
         "unset",

--- a/tests/sentry/runner/commands/presenters/test_webhookpresenter.py
+++ b/tests/sentry/runner/commands/presenters/test_webhookpresenter.py
@@ -13,7 +13,7 @@ from sentry.utils import json
     OPTIONS_AUTOMATOR_HMAC_SECRET="test-secret-key",
     SENTRY_REGION="test_region",
 )
-def test_is_slack_enabled():
+def test_is_slack_enabled() -> None:
     responses.add(responses.POST, "https://test/", status=200)
 
     presenter = WebhookPresenter("options-automator")
@@ -93,7 +93,7 @@ def test_is_slack_enabled():
     OPTIONS_AUTOMATOR_SLACK_WEBHOOK_URL="https://test/",
     SENTRY_REGION="test_region",
 )
-def test_is_slack_enabled_without_secret_key():
+def test_is_slack_enabled_without_secret_key() -> None:
     responses.add(responses.POST, "https://test/", status=200)
 
     presenter = WebhookPresenter("options-automator")
@@ -171,7 +171,7 @@ def test_is_slack_enabled_without_secret_key():
     OPTIONS_AUTOMATOR_HMAC_SECRET="test-secret-key",
     SENTRY_REGION="test_region",
 )
-def test_slack_presenter_empty():
+def test_slack_presenter_empty() -> None:
     presenter = WebhookPresenter("options-automator")
     assert presenter.is_webhook_enabled()
     presenter.flush()
@@ -186,7 +186,7 @@ def test_slack_presenter_empty():
     OPTIONS_AUTOMATOR_HMAC_SECRET="test-secret-key",
     SENTRY_REGION="test_region",
 )
-def test_slack_presenter_methods_with_different_types():
+def test_slack_presenter_methods_with_different_types() -> None:
     responses.add(responses.POST, "https://test/", status=200)
 
     presenter = WebhookPresenter("options-automator")

--- a/tests/sentry/search/eap/test_ourlogs.py
+++ b/tests/sentry/search/eap/test_ourlogs.py
@@ -234,7 +234,7 @@ class SearchResolverQueryTest(TestCase):
         assert having is None
 
 
-def test_count_default_argument():
+def test_count_default_argument() -> None:
     resolver = SearchResolver(
         params=SnubaParams(), config=SearchResolverConfig(), definitions=OURLOG_DEFINITIONS
     )

--- a/tests/sentry/search/eap/test_spans.py
+++ b/tests/sentry/search/eap/test_spans.py
@@ -701,7 +701,7 @@ class SearchResolverColumnTest(TestCase):
         assert (resolved_column, virtual_context) == (p95_column, p95_context)
 
 
-def test_loads_deprecated_attrs_json():
+def test_loads_deprecated_attrs_json() -> None:
     with open(os.path.join(SENTRY_CONVENTIONS_DIRECTORY, "deprecated_attributes.json"), "rb") as f:
         deprecated_attrs = json.loads(f.read())["attributes"]
 

--- a/tests/sentry/search/test_utils.py
+++ b/tests/sentry/search/test_utils.py
@@ -31,7 +31,7 @@ from sentry.users.services.user.serial import serialize_rpc_user
 from sentry.users.services.user.service import user_service
 
 
-def test_get_numeric_field_value():
+def test_get_numeric_field_value() -> None:
     assert get_numeric_field_value("foo", "10") == {"foo": 10}
 
     assert get_numeric_field_value("foo", ">10") == {"foo_lower": 10, "foo_lower_inclusive": False}
@@ -135,7 +135,7 @@ class TestParseDuration(TestCase):
             assert parse_duration(str((999999999 + 1) * 24 * 60 * 60 * 1000 + 1), "ms")
 
 
-def test_tokenize_query_only_keyed_fields():
+def test_tokenize_query_only_keyed_fields() -> None:
     tests = [
         ("a:a", {"a": ["a"]}),
         ("(a:a AND b:b)", {"a": ["a"], "b": ["b"]}),
@@ -164,7 +164,7 @@ def test_tokenize_query_only_keyed_fields():
         assert tokenize_query(test[0]) == test[1], test[0]
 
 
-def test_get_numeric_field_value_invalid():
+def test_get_numeric_field_value_invalid() -> None:
     with pytest.raises(InvalidQuery):
         get_numeric_field_value("foo", ">=1k")
 
@@ -910,7 +910,7 @@ class ConvertUserTagTest(TestCase):
         assert convert_user_tag_to_query("user", 'fake:123"456') is None
 
 
-def test_valid_device_class_mapping():
+def test_valid_device_class_mapping() -> None:
     assert set(DEVICE_CLASS.keys()) == {"low", "medium", "high"}, "Only 3 possible classes"
 
     # should all be integers

--- a/tests/sentry/seer/fetch_issues/test_fetch_issues.py
+++ b/tests/sentry/seer/fetch_issues/test_fetch_issues.py
@@ -145,7 +145,7 @@ class TestGetIssuesWithEventDetailsForFile(CreateEventTestCase):
         )
 
 
-def test_safe_for_fetching_issues():
+def test_safe_for_fetching_issues() -> None:
     pr_files: list[PrFile] = [
         {"filename": "foo.py", "patch": "a", "changes": 100, "status": "modified"},
         {"filename": "bar.js", "patch": "b", "changes": 100, "status": "modified"},
@@ -181,7 +181,7 @@ def test_safe_for_fetching_issues():
     assert safe_for_fetching_issues(pr_files_with_unsupported_language) == pr_files_safe
 
 
-def test__left_truncated_paths():
+def test__left_truncated_paths() -> None:
     assert _left_truncated_paths("foo.py") == []
     assert _left_truncated_paths("path/foo.py") == ["foo.py"]
     assert _left_truncated_paths("path/to/foo.py") == ["to/foo.py", "foo.py"]

--- a/tests/sentry/seer/test_math.py
+++ b/tests/sentry/seer/test_math.py
@@ -12,7 +12,7 @@ from sentry.seer.math import (
 )
 
 
-def test_laplace_smooth():
+def test_laplace_smooth() -> None:
     assert laplace_smooth([0.5, 0.5]) == [0.5, 0.5]
     assert laplace_smooth([100, 100]) == [0.5, 0.5]
 
@@ -29,7 +29,7 @@ def test_laplace_smooth():
     assert result[1] < 1
 
 
-def test_kl_divergence():
+def test_kl_divergence() -> None:
     result = kl_divergence([0.5, 0.5], [0.8, 0.2])
     assert math.isclose(result, 0.2231, rel_tol=1e-3), result
 
@@ -37,7 +37,7 @@ def test_kl_divergence():
     assert math.isclose(result, 0.0871, rel_tol=1e-3), result
 
 
-def test_relative_entropy():
+def test_relative_entropy() -> None:
     a, b = [0.5, 0.5], [0.8, 0.2]
     rel_entr = relative_entropy(a, b)
     assert len(rel_entr) == 2, rel_entr
@@ -45,7 +45,7 @@ def test_relative_entropy():
     assert math.isclose(rel_entr[1], 0.458, rel_tol=1e-3)
 
 
-def test_entropy():
+def test_entropy() -> None:
     result = entropy([0.8, 0.2])
     assert math.isclose(result, 0.5004, rel_tol=1e-3), result
 
@@ -68,7 +68,7 @@ def test_entropy():
     assert entropy([1, -2]) == -math.inf
 
 
-def test_rrf_score():
+def test_rrf_score() -> None:
     rrf_scores = rrf_score(
         # Entropy of the selection set.
         entropy_scores=[
@@ -89,12 +89,12 @@ def test_rrf_score():
     assert math.isclose(rrf_scores[2], 0.01587, rel_tol=1e-3)  # Rank 3.
 
 
-def test_rank_min():
+def test_rank_min() -> None:
     assert rank_min(xs=[1, 2, 2, 2, 3], ascending=False) == [3, 2, 2, 2, 1]
     assert rank_min(xs=[1, 2, 2, 2, 3], ascending=True) == [1, 2, 2, 2, 3]
 
 
-def test_boxcox_transform():
+def test_boxcox_transform() -> None:
     # Test with lambda = 0 (log transformation)
     values = [1.0, 2.0, 4.0, 8.0]
     transformed, lambda_used = boxcox_transform(values, lambda_param=0.0)
@@ -128,7 +128,7 @@ def test_boxcox_transform():
     assert lambda_used == 0.0
 
 
-def test_calculate_z_scores():
+def test_calculate_z_scores() -> None:
     values = [1.0, 2.0, 3.0, 4.0, 5.0]
     z_scores = calculate_z_scores(values)
 

--- a/tests/sentry/seer/test_signed_seer_api.py
+++ b/tests/sentry/seer/test_signed_seer_api.py
@@ -36,7 +36,7 @@ def run_test_case(
 
 
 @pytest.mark.django_db
-def test_simple():
+def test_simple() -> None:
     mock_url_open = run_test_case()
     mock_url_open.assert_called_once_with(
         "POST",
@@ -47,7 +47,7 @@ def test_simple():
 
 
 @pytest.mark.django_db
-def test_uses_given_timeout():
+def test_uses_given_timeout() -> None:
     mock_url_open = run_test_case(timeout=5)
     mock_url_open.assert_called_once_with(
         "POST",
@@ -59,7 +59,7 @@ def test_uses_given_timeout():
 
 
 @pytest.mark.django_db
-def test_uses_given_retries():
+def test_uses_given_retries() -> None:
     mock_url_open = run_test_case(retries=5)
     mock_url_open.assert_called_once_with(
         "POST",
@@ -71,7 +71,7 @@ def test_uses_given_retries():
 
 
 @pytest.mark.django_db
-def test_uses_shared_secret():
+def test_uses_shared_secret() -> None:
     with override_options({"seer.api.use-shared-secret": 1.0}):
         mock_url_open = run_test_case()
         mock_url_open.assert_called_once_with(
@@ -86,7 +86,7 @@ def test_uses_shared_secret():
 
 
 @pytest.mark.django_db
-def test_uses_shared_secret_missing_secret():
+def test_uses_shared_secret_missing_secret() -> None:
     with override_options({"seer.api.use-shared-secret": 1.0}):
         mock_url_open = run_test_case(shared_secret="")
 

--- a/tests/sentry/seer/workflows/test_compare.py
+++ b/tests/sentry/seer/workflows/test_compare.py
@@ -7,7 +7,7 @@ from sentry.seer.workflows.compare import (
 )
 
 
-def test_keyed_kl_score():
+def test_keyed_kl_score() -> None:
     baseline = [
         ("key", "true", 10),
         ("key", "false", 200),
@@ -42,7 +42,7 @@ def test_keyed_kl_score():
     assert math.isclose(scores[0][1], 8.58, rel_tol=1e-3)
 
 
-def test_keyed_rrf_score():
+def test_keyed_rrf_score() -> None:
     baseline = [
         ("key", "true", 10),
         ("key", "false", 200),
@@ -63,7 +63,7 @@ def test_keyed_rrf_score():
     assert math.isclose(scores[1][1], 0.01612, abs_tol=1e-3)
 
 
-def test_synthetic_baseline_kl():
+def test_synthetic_baseline_kl() -> None:
     """
     This test checks the KL divergence for the synthetic generated baseline, describe in the tech spec.
     There are 4 attributes: country, device, error_code, browser.
@@ -119,7 +119,7 @@ def test_synthetic_baseline_kl():
     assert math.isclose(kl_scores[1], 0.17, abs_tol=1e-3)
 
 
-def test_zero_kl():
+def test_zero_kl() -> None:
     """
     This test checks the if the distirbution of the outliers is more or less the same as the baseline, the KL divergence should be close to 0.
     """
@@ -145,7 +145,7 @@ def test_zero_kl():
     assert math.isclose(scores[0][1], 0.0, abs_tol=1e-4)
 
 
-def test_entropy_only():
+def test_entropy_only() -> None:
     """
     This test ranks the attributes by entropy only.
     'country' has zero entropy, so it will be ranked the highest. 'browser' has the highest entropy, so it will be ranked the lowest.
@@ -181,7 +181,7 @@ def test_entropy_only():
     assert attributes == ["country", "device", "browser"]
 
 
-def test_small_support():
+def test_small_support() -> None:
     """
     This test checkes the that logic for adding unseen values to the distribution works.
     This logic is used to prevent small support attributes from being ranked higher than large support attributes.
@@ -217,7 +217,7 @@ def test_small_support():
     assert attributes == ["country", "browser", "device"]
 
 
-def test_keyed_rrf_score_with_filter_basic():
+def test_keyed_rrf_score_with_filter_basic() -> None:
     """
     Test basic functionality of keyed_rrf_score_with_filter
     """
@@ -246,7 +246,7 @@ def test_keyed_rrf_score_with_filter_basic():
         assert score >= 0
 
 
-def test_keyed_rrf_score_with_filter_threshold_behavior():
+def test_keyed_rrf_score_with_filter_threshold_behavior() -> None:
     """
     Test filtering behavior with different z_threshold values
     """
@@ -271,7 +271,7 @@ def test_keyed_rrf_score_with_filter_threshold_behavior():
         assert not filtered, f"Key {key} should not be filtered with high threshold"
 
 
-def test_keyed_rrf_score_with_filter_empty_inputs():
+def test_keyed_rrf_score_with_filter_empty_inputs() -> None:
     """
     Test with empty inputs
     """
@@ -281,7 +281,7 @@ def test_keyed_rrf_score_with_filter_empty_inputs():
     assert scores == []
 
 
-def test_keyed_rrf_score_with_filter_consistency_with_regular_rrf():
+def test_keyed_rrf_score_with_filter_consistency_with_regular_rrf() -> None:
     """
     Test that the scores are consistent with keyed_rrf_score
     """

--- a/tests/sentry/sentry_metrics/consumers/test_last_seen_updater.py
+++ b/tests/sentry/sentry_metrics/consumers/test_last_seen_updater.py
@@ -66,19 +66,19 @@ def kafka_message(kafka_payload):
     )
 
 
-def test_retrieve_db_read_keys_meta_field_present_with_db_keys():
+def test_retrieve_db_read_keys_meta_field_present_with_db_keys() -> None:
     message = kafka_message(headerless_kafka_payload(mixed_payload()))
     key_set = retrieve_db_read_keys(message)
     assert key_set == {2000, 2001, 2002}
 
 
-def test_retrieve_db_read_keys_meta_field_not_present():
+def test_retrieve_db_read_keys_meta_field_not_present() -> None:
     message = kafka_message(headerless_kafka_payload(empty_payload()))
     key_set = retrieve_db_read_keys(message)
     assert key_set == set()
 
 
-def test_retrieve_db_read_keys_meta_field_bad_json():
+def test_retrieve_db_read_keys_meta_field_bad_json() -> None:
     message = kafka_message(headerless_kafka_payload(bad_payload()))
     key_set = retrieve_db_read_keys(message)
     assert key_set == set()

--- a/tests/sentry/sentry_metrics/limiters/test_writes_limiter.py
+++ b/tests/sentry/sentry_metrics/limiters/test_writes_limiter.py
@@ -42,7 +42,7 @@ MOCK_USE_CASE_ID_WRITES_LIMIT_QUOTA_OPTIONS = {
     "sentry.sentry_metrics.indexer.limiters.writes.USE_CASE_ID_WRITES_LIMIT_QUOTA_OPTIONS",
     MOCK_USE_CASE_ID_WRITES_LIMIT_QUOTA_OPTIONS,
 )
-def test_writes_limiter_no_limits():
+def test_writes_limiter_no_limits() -> None:
     with override_options(
         {
             "sentry-metrics.writes-limiter.limits.transactions.global": [],
@@ -82,7 +82,7 @@ def test_writes_limiter_no_limits():
     "sentry.sentry_metrics.indexer.limiters.writes.USE_CASE_ID_WRITES_LIMIT_QUOTA_OPTIONS",
     MOCK_USE_CASE_ID_WRITES_LIMIT_QUOTA_OPTIONS,
 )
-def test_writes_limiter_doesnt_limit():
+def test_writes_limiter_doesnt_limit() -> None:
     with override_options(
         {
             "sentry-metrics.writes-limiter.limits.transactions.global": [],
@@ -131,7 +131,7 @@ def test_writes_limiter_doesnt_limit():
     "sentry.sentry_metrics.indexer.limiters.writes.USE_CASE_ID_WRITES_LIMIT_QUOTA_OPTIONS",
     MOCK_USE_CASE_ID_WRITES_LIMIT_QUOTA_OPTIONS,
 )
-def test_writes_limiter_org_limit():
+def test_writes_limiter_org_limit() -> None:
     with override_options(
         {
             "sentry-metrics.writes-limiter.limits.transactions.global": [],
@@ -195,7 +195,7 @@ def test_writes_limiter_org_limit():
     "sentry.sentry_metrics.indexer.limiters.writes.USE_CASE_ID_WRITES_LIMIT_QUOTA_OPTIONS",
     MOCK_USE_CASE_ID_WRITES_LIMIT_QUOTA_OPTIONS,
 )
-def test_writes_limiter_global_limit():
+def test_writes_limiter_global_limit() -> None:
     with override_options(
         {
             "sentry-metrics.writes-limiter.limits.transactions.global": [
@@ -245,7 +245,7 @@ def test_writes_limiter_global_limit():
     "sentry.sentry_metrics.indexer.limiters.writes.USE_CASE_ID_WRITES_LIMIT_QUOTA_OPTIONS",
     MOCK_USE_CASE_ID_WRITES_LIMIT_QUOTA_OPTIONS,
 )
-def test_writes_limiter_respects_use_case_id():
+def test_writes_limiter_respects_use_case_id() -> None:
     """
     Here we test that a use_case_id currently exceededing quota results in
     dropping all strings for subsequent calls to check_write_limits

--- a/tests/sentry/sentry_metrics/querying/data/test_query.py
+++ b/tests/sentry/sentry_metrics/querying/data/test_query.py
@@ -28,7 +28,7 @@ def test_compile_mql_query(formula, queries, expected_formula):
     assert compiled_query.mql == expected_formula
 
 
-def test_compile_mql_query_recursive():
+def test_compile_mql_query_recursive() -> None:
     query_1 = MQLQuery("sum(duration)")
     query_2 = MQLQuery("$query_1 * 2", query_1=query_1)
     compiled_query = MQLQuery("$query_2 + 1 / $query_1", query_1=query_1, query_2=query_2).compile()
@@ -36,6 +36,6 @@ def test_compile_mql_query_recursive():
     assert compiled_query.mql == "sum(duration) * 2 + 1 / sum(duration)"
 
 
-def test_compile_mql_query_with_wrong_sub_queries():
+def test_compile_mql_query_with_wrong_sub_queries() -> None:
     with pytest.raises(InvalidMetricsQueryError):
         MQLQuery("$query_1 * 2", query_1="sum(duration)").compile()

--- a/tests/sentry/sentry_metrics/test_batch.py
+++ b/tests/sentry/sentry_metrics/test_batch.py
@@ -261,7 +261,7 @@ def test_extract_strings_with_rollout(should_index_tag_values, expected):
 
 
 @pytest.mark.django_db
-def test_extract_strings_with_multiple_use_case_ids():
+def test_extract_strings_with_multiple_use_case_ids() -> None:
     """
     Verify that the extract string method can handle payloads that has multiple
     (generic) uses cases
@@ -353,7 +353,7 @@ def test_extract_strings_with_multiple_use_case_ids():
 
 @pytest.mark.django_db
 @override_options({"sentry-metrics.indexer.disabled-namespaces": ["escalating_issues"]})
-def test_extract_strings_with_single_use_case_ids_blocked():
+def test_extract_strings_with_single_use_case_ids_blocked() -> None:
     """
     Verify that the extract string method will work normally when a single use case ID is blocked
     """
@@ -431,7 +431,7 @@ def test_extract_strings_with_single_use_case_ids_blocked():
 
 @pytest.mark.django_db
 @override_options({"sentry-metrics.indexer.disabled-namespaces": ["spans", "escalating_issues"]})
-def test_extract_strings_with_multiple_use_case_ids_blocked():
+def test_extract_strings_with_multiple_use_case_ids_blocked() -> None:
     """
     Verify that the extract string method will work normally when multiple use case IDs are blocked
     """
@@ -506,7 +506,7 @@ def test_extract_strings_with_multiple_use_case_ids_blocked():
 
 
 @pytest.mark.django_db
-def test_extract_strings_with_invalid_mri():
+def test_extract_strings_with_invalid_mri() -> None:
     """
     Verify that extract strings will drop payload that has invalid MRI in name field but continue processing the rest
     """
@@ -611,7 +611,7 @@ def test_extract_strings_with_invalid_mri():
 
 
 @pytest.mark.django_db
-def test_extract_strings_with_multiple_use_case_ids_and_org_ids():
+def test_extract_strings_with_multiple_use_case_ids_and_org_ids() -> None:
     """
     Verify that the extract string method can handle payloads that has multiple
     (generic) uses cases and from different orgs
@@ -1798,7 +1798,7 @@ def test_one_org_limited(caplog, settings):
     ]
 
 
-def test_aggregation_options():
+def test_aggregation_options() -> None:
 
     with override_options(
         {

--- a/tests/sentry/sentry_metrics/test_gen_metrics_multiprocess_steps.py
+++ b/tests/sentry/sentry_metrics/test_gen_metrics_multiprocess_steps.py
@@ -604,6 +604,6 @@ def test_valid_metric_name() -> None:
     assert valid_metric_name("invalid" * 200) is False
 
 
-def test_process_messages_is_pickleable():
+def test_process_messages_is_pickleable() -> None:
     # needed so that the parallel transform step starts up properly
     pickle.dumps(MESSAGE_PROCESSOR.process_messages)

--- a/tests/sentry/sentry_metrics/test_indexer.py
+++ b/tests/sentry/sentry_metrics/test_indexer.py
@@ -6,7 +6,7 @@ from sentry.snuba.metrics.naming_layer import SessionMRI
 INDEXER = MockIndexer()
 
 
-def test_resolve():
+def test_resolve() -> None:
     assert INDEXER.resolve(UseCaseID.SESSIONS, 1, "what") is None
     assert (
         INDEXER.resolve(UseCaseID.SESSIONS, 1, SessionMRI.RAW_USER.value)
@@ -19,7 +19,7 @@ def test_resolve():
     )
 
 
-def test_reverse_resolve():
+def test_reverse_resolve() -> None:
     assert INDEXER.reverse_resolve(UseCaseID.SESSIONS, 1, 666) is None
     id = SHARED_STRINGS[SessionMRI.RAW_USER.value]
     assert INDEXER.reverse_resolve(UseCaseID.SESSIONS, 1, id) == SessionMRI.RAW_USER.value

--- a/tests/sentry/sentry_metrics/test_indexer_cache.py
+++ b/tests/sentry/sentry_metrics/test_indexer_cache.py
@@ -94,7 +94,7 @@ def test_cache(use_case_id: str) -> None:
         assert indexer_cache.get(namespace_2, f"{use_case_id}:1:blah:123") is None
 
 
-def test_cache_validate_stale_timestamp():
+def test_cache_validate_stale_timestamp() -> None:
     with override_options(
         {
             "sentry-metrics.indexer.read-new-cache-namespace": True,

--- a/tests/sentry/sentry_metrics/test_prevent_modifications_to_indexer_strings.py
+++ b/tests/sentry/sentry_metrics/test_prevent_modifications_to_indexer_strings.py
@@ -10,7 +10,7 @@ MESSAGE = f"""{LOCKED_FILE} is locked.
 """
 
 
-def test_prevent_indexer_strings_modification():
+def test_prevent_indexer_strings_modification() -> None:
     with open(LOCKED_FILE, "rb") as f:
         digest = sha256(f.read()).hexdigest()
         assert LOCKED_DIGEST == digest, MESSAGE

--- a/tests/sentry/sentry_metrics/test_rh_metrics_multiprocess_steps.py
+++ b/tests/sentry/sentry_metrics/test_rh_metrics_multiprocess_steps.py
@@ -131,7 +131,7 @@ def test_batch_messages() -> None:
     assert batch_messages_step._BatchMessages__batch is None
 
 
-def test_batch_messages_rejected_message():
+def test_batch_messages_rejected_message() -> None:
     next_step = Mock()
     next_step.submit.side_effect = MessageRejected()
 
@@ -155,7 +155,7 @@ def test_batch_messages_rejected_message():
     assert next_step.submit.called
 
 
-def test_batch_messages_join():
+def test_batch_messages_join() -> None:
     next_step = Mock()
 
     batch_messages_step, message1, _ = _batch_message_set_up(next_step)
@@ -169,7 +169,7 @@ def test_batch_messages_join():
     assert not next_step.submit.called
 
 
-def test_metrics_batch_builder():
+def test_metrics_batch_builder() -> None:
     max_batch_time = 3.0  # seconds
     max_batch_size = 2
 
@@ -531,6 +531,6 @@ def test_valid_metric_name() -> None:
     assert valid_metric_name("invalid" * 200) is False
 
 
-def test_process_messages_is_pickleable():
+def test_process_messages_is_pickleable() -> None:
     # needed so that the parallel transform step starts up properly
     pickle.dumps(MESSAGE_PROCESSOR.process_messages)

--- a/tests/sentry/sentry_metrics/test_strings.py
+++ b/tests/sentry/sentry_metrics/test_strings.py
@@ -66,7 +66,7 @@ REINDEXED_INTS = {12345678: "release"}
 
 
 @override_settings(SENTRY_METRICS_INDEXER_REINDEXED_INTS=REINDEXED_INTS)
-def test_reverse_resolve_reindexed():
+def test_reverse_resolve_reindexed() -> None:
     """
     If we have deleted a record accidentally and whose id still lives in
     ClickHouse, then we need to account for the re-indexed id. Since the

--- a/tests/sentry/shared_integrations/client/test_proxy.py
+++ b/tests/sentry/shared_integrations/client/test_proxy.py
@@ -200,7 +200,7 @@ class IntegrationProxyClientTest(TestCase):
         assert mock_session_send.mock_calls[0].kwargs["timeout"] == 10
 
 
-def test_get_control_silo_ip_address():
+def test_get_control_silo_ip_address() -> None:
     with override_settings(SENTRY_CONTROL_ADDRESS=None):
         assert get_control_silo_ip_address() is None
 

--- a/tests/sentry/silo/test_client.py
+++ b/tests/sentry/silo/test_client.py
@@ -382,7 +382,7 @@ class SiloClientTest(TestCase):
             assert mock_validate_region_ip_address.call_count == 1
 
 
-def test_validate_region_ip_address():
+def test_validate_region_ip_address() -> None:
     with (
         patch("sentry_sdk.capture_exception") as mock_capture_exception,
         override_allowed_region_silo_ip_addresses(),
@@ -411,7 +411,7 @@ def test_validate_region_ip_address():
         assert mock_capture_exception.call_count == 0
 
 
-def test_get_region_ip_addresses():
+def test_get_region_ip_addresses() -> None:
     internal_region_address = "http://i.am.an.internal.hostname:9000"
     region = Region("eu", 1, internal_region_address, RegionCategory.MULTI_TENANT)
     region_config = (region,)

--- a/tests/sentry/silo/test_silo_aware_transaction_patch.py
+++ b/tests/sentry/silo/test_silo_aware_transaction_patch.py
@@ -56,7 +56,7 @@ class TestSiloAwareTransactionPatchInSplitDbMode(TestCase):
 
 
 @no_silo_test
-def test_is_in_test_case_body():
+def test_is_in_test_case_body() -> None:
     """Check that we can correctly detect that we are in a test case body.
 
     It is paradoxically impossible to test the negative case (without doing some

--- a/tests/sentry/similarity/test_encoder.py
+++ b/tests/sentry/similarity/test_encoder.py
@@ -3,7 +3,7 @@ import pytest
 from sentry.similarity.encoder import Encoder
 
 
-def test_builtin_types():
+def test_builtin_types() -> None:
     encoder = Encoder()
     values = [
         1,
@@ -26,7 +26,7 @@ def test_builtin_types():
         encoder.dumps(object())
 
 
-def test_custom_types():
+def test_custom_types() -> None:
     class Widget:
         def __init__(self, color):
             self.color = color

--- a/tests/sentry/snuba/metrics/test_query.py
+++ b/tests/sentry/snuba/metrics/test_query.py
@@ -117,14 +117,14 @@ class MetricsQueryBuilder:
         }
 
 
-def test_metric_field_equality_with_equal_fields():
+def test_metric_field_equality_with_equal_fields() -> None:
     ap_dex_with_alias_1 = MetricField(op=None, metric_mri=TransactionMRI.APDEX.value, alias="apdex")
     ap_dex_with_alias_2 = MetricField(op=None, metric_mri=TransactionMRI.APDEX.value, alias="apdex")
 
     assert ap_dex_with_alias_1 == ap_dex_with_alias_2
 
 
-def test_metric_field_equality_with_different_aliases():
+def test_metric_field_equality_with_different_aliases() -> None:
     ap_dex_with_alias_1 = MetricField(op=None, metric_mri=TransactionMRI.APDEX.value, alias="apdex")
     ap_dex_with_alias_2 = MetricField(
         op=None, metric_mri=TransactionMRI.APDEX.value, alias="transaction.apdex"
@@ -133,7 +133,7 @@ def test_metric_field_equality_with_different_aliases():
     assert ap_dex_with_alias_1 == ap_dex_with_alias_2
 
 
-def test_metric_field_equality_with_different_mris():
+def test_metric_field_equality_with_different_mris() -> None:
     ap_dex_with_alias_1 = MetricField(op=None, metric_mri=TransactionMRI.APDEX.value, alias="apdex")
     ap_dex_with_alias_2 = MetricField(
         op=None, metric_mri=TransactionMRI.DURATION.value, alias="duration"
@@ -142,7 +142,7 @@ def test_metric_field_equality_with_different_mris():
     assert not ap_dex_with_alias_1 == ap_dex_with_alias_2
 
 
-def test_validate_select():
+def test_validate_select() -> None:
     with pytest.raises(InvalidParams, match='Request is missing a "field"'):
         DeprecatingMetricsQuery(**MetricsQueryBuilder().with_select([]).to_metrics_query_dict())
 
@@ -172,7 +172,7 @@ def test_validate_select():
         )
 
 
-def test_validate_select_invalid_use_case_ids():
+def test_validate_select_invalid_use_case_ids() -> None:
     with pytest.raises(InvalidParams, match="All select fields should have the same use_case_id"):
         metric_field_1 = MetricField(op=None, metric_mri=SessionMRI.CRASH_FREE_RATE.value)
         metric_field_2 = MetricField(op="p50", metric_mri=TransactionMRI.DURATION.value)
@@ -183,7 +183,7 @@ def test_validate_select_invalid_use_case_ids():
         )
 
 
-def test_validate_order_by():
+def test_validate_order_by() -> None:
     with pytest.raises(
         InvalidParams,
         match=(f"Invalid operation 'foo'. Must be one of {', '.join(OPERATIONS)}"),
@@ -225,7 +225,7 @@ def test_validate_order_by():
 
 
 @django_db_all
-def test_validate_order_by_field_in_select():
+def test_validate_order_by_field_in_select() -> None:
     create_default_projects()
     metric_field_2 = MetricField(op=None, metric_mri=SessionMRI.ALL.value)
     metrics_query_dict = (
@@ -249,7 +249,7 @@ def test_validate_order_by_field_in_select():
 
 
 @django_db_all
-def test_validate_order_by_field_in_select_with_different_alias():
+def test_validate_order_by_field_in_select_with_different_alias() -> None:
     create_default_projects()
     ap_dex_with_alias_1 = MetricField(op=None, metric_mri=TransactionMRI.APDEX.value, alias="apdex")
     ap_dex_with_alias_2 = MetricField(
@@ -272,7 +272,7 @@ def test_validate_order_by_field_in_select_with_different_alias():
 
 
 @django_db_all
-def test_validate_multiple_orderby_columns_not_specified_in_select():
+def test_validate_multiple_orderby_columns_not_specified_in_select() -> None:
     create_default_projects()
     metric_field_1 = MetricField(op=None, metric_mri=SessionMRI.ABNORMAL.value)
     metric_field_2 = MetricField(op=None, metric_mri=SessionMRI.ALL.value)
@@ -295,7 +295,7 @@ def test_validate_multiple_orderby_columns_not_specified_in_select():
 
 
 @django_db_all
-def test_validate_multiple_order_by_fields_from_multiple_entities():
+def test_validate_multiple_order_by_fields_from_multiple_entities() -> None:
     """
     The example should fail because session crash free rate is generated from
     counters entity while p50 of duration will go to distribution
@@ -325,7 +325,7 @@ def test_validate_multiple_order_by_fields_from_multiple_entities():
 
 
 @django_db_all
-def test_validate_multiple_orderby_derived_metrics_from_different_entities():
+def test_validate_multiple_orderby_derived_metrics_from_different_entities() -> None:
     """
     This example should fail because session crash free rate is generated from
     counters while session user crash free rate is generated from sets
@@ -354,7 +354,7 @@ def test_validate_multiple_orderby_derived_metrics_from_different_entities():
 
 
 @django_db_all
-def test_validate_many_order_by_fields_are_in_select():
+def test_validate_many_order_by_fields_are_in_select() -> None:
     """
     Validate no exception is raised when all orderBy fields are presented the select
     """
@@ -407,7 +407,7 @@ def test_validate_many_order_by_fields_are_in_select():
     DeprecatingMetricsQuery(**metrics_query_dict)
 
 
-def test_validate_functions_from_multiple_entities_in_orderby():
+def test_validate_functions_from_multiple_entities_in_orderby() -> None:
     # Validate exception is raised when orderBy fields have function from different snuba groups
     # because:
     # `avg` are in OP_TO_SNUBA_FUNCTION["metrics_distributions"].keys()
@@ -437,7 +437,7 @@ def test_validate_functions_from_multiple_entities_in_orderby():
         DeprecatingMetricsQuery(**metrics_query_dict)
 
 
-def test_validate_distribution_functions_in_orderby():
+def test_validate_distribution_functions_in_orderby() -> None:
     # Validate no exception is raised when all orderBy fields are presented the select
     metric_field_1 = MetricField(op="avg", metric_mri=TransactionMRI.DURATION.value)
     metric_field_2 = MetricField(op="p50", metric_mri=TransactionMRI.DURATION.value)
@@ -457,7 +457,7 @@ def test_validate_distribution_functions_in_orderby():
 
 
 @django_db_all
-def test_validate_where():
+def test_validate_where() -> None:
     query = "session.status:crashed"
     where = parse_conditions(query, [], [])
 
@@ -465,7 +465,7 @@ def test_validate_where():
         DeprecatingMetricsQuery(**MetricsQueryBuilder().with_where(where).to_metrics_query_dict())
 
 
-def test_validate_groupby():
+def test_validate_groupby() -> None:
     with pytest.raises(
         InvalidParams, match="Tag name session.status cannot be used in groupBy query"
     ):
@@ -476,7 +476,7 @@ def test_validate_groupby():
         )
 
 
-def test_validate_limit():
+def test_validate_limit() -> None:
     with pytest.raises(
         InvalidParams,
         match=(
@@ -494,7 +494,7 @@ def test_validate_limit():
         )
 
 
-def test_validate_end():
+def test_validate_end() -> None:
     with pytest.raises(InvalidParams, match="start must be before end"):
         DeprecatingMetricsQuery(
             **MetricsQueryBuilder()
@@ -504,7 +504,7 @@ def test_validate_end():
         )
 
 
-def test_series_and_totals_validation():
+def test_series_and_totals_validation() -> None:
     metrics_query_dict = (
         MetricsQueryBuilder()
         .with_include_series(False)
@@ -562,7 +562,7 @@ def test_granularity_validation(stats_period, interval, error_message):
         DeprecatingMetricsQuery(**metrics_query_dict)
 
 
-def test_validate_metric_field_mri():
+def test_validate_metric_field_mri() -> None:
     with pytest.raises(InvalidParams, match="Invalid Metric MRI: transaction-metric-duration"):
         MetricField(
             op="avg",
@@ -607,7 +607,7 @@ def test_validate_interval(select, interval, series):
         DeprecatingMetricsQuery(**metrics_query_dict)
 
 
-def test_validate_is_alerts_query():
+def test_validate_is_alerts_query() -> None:
     metrics_query = MetricsQueryBuilder()
     metrics_query.start = None
     metrics_query.end = None
@@ -620,7 +620,7 @@ def test_validate_is_alerts_query():
         DeprecatingMetricsQuery(**metrics_query_dict)
 
 
-def test_ensure_interval_set_to_granularity_in_performance_queries():
+def test_ensure_interval_set_to_granularity_in_performance_queries() -> None:
     metrics_query = (
         MetricsQueryBuilder()
         .with_select([MetricField(op="p95", metric_mri=TransactionMRI.DURATION.value)])

--- a/tests/sentry/snuba/metrics/test_query_builder.py
+++ b/tests/sentry/snuba/metrics/test_query_builder.py
@@ -264,7 +264,7 @@ def test_parse_conditions(query_string, expected):
 
 
 @freeze_time("2018-12-11 03:21:00")
-def test_round_range():
+def test_round_range() -> None:
     # since data is not exactly aligned it will return 2d + 1h (+ one interval to cover everything)
     start, end, interval = get_date_range({"statsPeriod": "2d"})
     assert start == datetime(2018, 12, 9, 3, tzinfo=timezone.utc)
@@ -313,7 +313,7 @@ def test_get_date_range(now, interval, parameters, expected):
         assert (start_actual, end_actual) == (start_expected, end_expected)
 
 
-def test_invalid_interval():
+def test_invalid_interval() -> None:
     # get_date_range is now only responsible for parsing start, end and interval,
     # and not responsible for validation so just letting it bubble up the ZeroDivisionError if
     # the requested interval is 0d
@@ -321,7 +321,7 @@ def test_invalid_interval():
         get_date_range({"interval": "0d"})
 
 
-def test_round_exact():
+def test_round_exact() -> None:
     start, end, interval = get_date_range(
         {"start": "2021-01-12T04:06:16", "end": "2021-01-17T08:26:13", "interval": "1d"},
     )
@@ -329,7 +329,7 @@ def test_round_exact():
     assert end == datetime(2021, 1, 18, tzinfo=timezone.utc)
 
 
-def test_exclusive_end():
+def test_exclusive_end() -> None:
     start, end, interval = get_date_range(
         {"start": "2021-02-24T00:00:00", "end": "2021-02-25T00:00:00", "interval": "1h"},
     )
@@ -338,7 +338,7 @@ def test_exclusive_end():
 
 
 @freeze_time("2020-12-18T11:14:17.105Z")
-def test_timestamps():
+def test_timestamps() -> None:
     start, end, interval = get_date_range({"statsPeriod": "1d", "interval": "12h"})
 
     # one day before now aligned downward at 12h
@@ -1147,7 +1147,7 @@ def test_translate_results_missing_slots(_1, _2):
     ]
 
 
-def test_translate_meta_results():
+def test_translate_meta_results() -> None:
     meta = [
         {"name": "p50(d:transactions/measurements.lcp@millisecond)", "type": "Float64"},
         {"name": "team_key_transaction", "type": "UInt8"},
@@ -1194,7 +1194,7 @@ def test_translate_meta_results():
     )
 
 
-def test_translate_meta_results_with_duplicates():
+def test_translate_meta_results_with_duplicates() -> None:
     meta = [
         {"name": "p50(d:transactions/measurements.lcp@millisecond)", "type": "Float64"},
         {"name": "p50(d:transactions/measurements.lcp@millisecond)", "type": "Float64"},

--- a/tests/sentry/snuba/metrics/test_utils.py
+++ b/tests/sentry/snuba/metrics/test_utils.py
@@ -364,7 +364,7 @@ def test_to_intervals(
     assert expected_num_intervals == actual_num_intervals, test_message
 
 
-def test_get_intervals_checks_valid_interval():
+def test_get_intervals_checks_valid_interval() -> None:
     """
     Checks that get_intervals verifies that granularity > 0
     """

--- a/tests/sentry/spans/consumers/process/test_flusher.py
+++ b/tests/sentry/spans/consumers/process/test_flusher.py
@@ -116,7 +116,7 @@ def create_memory_producer_factory():
         ("buffered-segments", 1): {"cluster": "default", "topic": "buffered-segments-2"},
     }
 )
-def test_multi_producer_sliced_integration_with_arroyo_local_producer():
+def test_multi_producer_sliced_integration_with_arroyo_local_producer() -> None:
     from arroyo import Topic as ArroyoTopic
     from arroyo.backends.kafka import KafkaPayload
 

--- a/tests/sentry/spans/consumers/process_segments/test_convert.py
+++ b/tests/sentry/spans/consumers/process_segments/test_convert.py
@@ -87,7 +87,7 @@ SPAN_KAFKA_MESSAGE = {
 }
 
 
-def test_convert_span_to_item():
+def test_convert_span_to_item() -> None:
     # Cast since the above payload does not conform to the strict schema
     item = convert_span_to_item(cast(Span, SPAN_KAFKA_MESSAGE))
 
@@ -157,7 +157,7 @@ def test_convert_span_to_item():
     }
 
 
-def test_convert_falsy_fields():
+def test_convert_falsy_fields() -> None:
     message = {**SPAN_KAFKA_MESSAGE, "duration_ms": 0, "is_segment": False}
 
     item = convert_span_to_item(cast(Span, message))
@@ -166,7 +166,7 @@ def test_convert_falsy_fields():
     assert item.attributes.get("sentry.is_segment") == AnyValue(bool_value=False)
 
 
-def test_convert_span_links_to_json():
+def test_convert_span_links_to_json() -> None:
     message = {
         **SPAN_KAFKA_MESSAGE,
         "links": [

--- a/tests/sentry/spans/consumers/process_segments/test_enrichment.py
+++ b/tests/sentry/spans/consumers/process_segments/test_enrichment.py
@@ -7,7 +7,7 @@ from tests.sentry.spans.consumers.process import build_mock_span
 # Tests ported from Relay
 
 
-def test_childless_spans():
+def test_childless_spans() -> None:
     spans = [
         build_mock_span(
             project_id=1,
@@ -50,7 +50,7 @@ def test_childless_spans():
     }
 
 
-def test_nested_spans():
+def test_nested_spans() -> None:
     spans = [
         build_mock_span(
             project_id=1,
@@ -93,7 +93,7 @@ def test_nested_spans():
     }
 
 
-def test_overlapping_child_spans():
+def test_overlapping_child_spans() -> None:
     spans = [
         build_mock_span(
             project_id=1,
@@ -136,7 +136,7 @@ def test_overlapping_child_spans():
     }
 
 
-def test_child_spans_dont_intersect_parent():
+def test_child_spans_dont_intersect_parent() -> None:
     spans = [
         build_mock_span(
             project_id=1,
@@ -179,7 +179,7 @@ def test_child_spans_dont_intersect_parent():
     }
 
 
-def test_child_spans_extend_beyond_parent():
+def test_child_spans_extend_beyond_parent() -> None:
     spans = [
         build_mock_span(
             project_id=1,
@@ -222,7 +222,7 @@ def test_child_spans_extend_beyond_parent():
     }
 
 
-def test_child_spans_consumes_all_of_parent():
+def test_child_spans_consumes_all_of_parent() -> None:
     spans = [
         build_mock_span(
             project_id=1,
@@ -265,7 +265,7 @@ def test_child_spans_consumes_all_of_parent():
     }
 
 
-def test_only_immediate_child_spans_affect_calculation():
+def test_only_immediate_child_spans_affect_calculation() -> None:
     spans = [
         build_mock_span(
             project_id=1,
@@ -308,7 +308,7 @@ def test_only_immediate_child_spans_affect_calculation():
     }
 
 
-def test_emit_ops_breakdown():
+def test_emit_ops_breakdown() -> None:
     segment_span = build_mock_span(
         project_id=1,
         is_segment=True,

--- a/tests/sentry/stacktraces/test_functions.py
+++ b/tests/sentry/stacktraces/test_functions.py
@@ -219,7 +219,7 @@ def test_split_func_tokens(input, output):
     assert split_func_tokens(input) == output
 
 
-def test_trim_function_name_cocoa():
+def test_trim_function_name_cocoa() -> None:
     assert trim_function_name("+[foo:(bar)]", "objc") == "+[foo:(bar)]"
     assert trim_function_name("[foo:(bar)]", "objc") == "[foo:(bar)]"
     assert trim_function_name("-[foo:(bar)]", "objc") == "-[foo:(bar)]"

--- a/tests/sentry/tasks/test_assemble.py
+++ b/tests/sentry/tasks/test_assemble.py
@@ -961,7 +961,7 @@ class ArtifactBundleIndexingTest(TestCase):
 
 
 @use_redis_cluster()
-def test_redis_assemble_status():
+def test_redis_assemble_status() -> None:
     task = AssembleTask.DIF
     project_id = uuid.uuid4().hex
     checksum = uuid.uuid4().hex

--- a/tests/sentry/tasks/test_base.py
+++ b/tests/sentry/tasks/test_base.py
@@ -71,7 +71,7 @@ def exclude_on_exception_task(param):
 
 
 @override_settings(SILO_MODE=SiloMode.REGION)
-def test_task_silo_limit_call_region():
+def test_task_silo_limit_call_region() -> None:
     result = region_task("hi")
     assert "Region task hi" == result
 
@@ -80,7 +80,7 @@ def test_task_silo_limit_call_region():
 
 
 @override_settings(SILO_MODE=SiloMode.CONTROL)
-def test_task_silo_limit_call_control():
+def test_task_silo_limit_call_control() -> None:
     with pytest.raises(SiloLimit.AvailabilityError):
         region_task("hi")
 
@@ -88,7 +88,7 @@ def test_task_silo_limit_call_control():
 
 
 @override_settings(SILO_MODE=SiloMode.MONOLITH)
-def test_task_silo_limit_call_monolith():
+def test_task_silo_limit_call_monolith() -> None:
     assert "Region task hi" == region_task("hi")
     assert "Control task hi" == control_task("hi")
 
@@ -148,7 +148,7 @@ def test_capture_payload_metrics(mock_distribution):
         "taskworker.route.overrides": {},
     }
 )
-def test_validate_parameters_call():
+def test_validate_parameters_call() -> None:
     with pytest.raises(TypeError) as err:
         region_task.apply_async(args=(datetime.datetime.now(),))
     assert "region_task was called with a parameter that cannot be JSON encoded" in str(err)

--- a/tests/sentry/tasks/test_store.py
+++ b/tests/sentry/tasks/test_store.py
@@ -297,7 +297,7 @@ def test_scrubbing_after_processing(
 
 
 @django_db_all
-def test_killswitch():
+def test_killswitch() -> None:
     assert not is_process_disabled(1, "asdasdasd", "null")
     options.set("store.load-shed-process-event-projects-gradual", {1: 0.0})
     assert not is_process_disabled(1, "asdasdasd", "null")

--- a/tests/sentry/tasks/test_taskworker_rollout.py
+++ b/tests/sentry/tasks/test_taskworker_rollout.py
@@ -39,7 +39,7 @@ class TestTaskworkerRollout(TestCase):
             name="test.test_with_taskworker_rollout",
             taskworker_config=self.config,
         )
-        def test_task() -> None:
+        def test_task() -> str:
             return "done"
 
         assert test_task.name == "test.test_with_taskworker_rollout"
@@ -154,7 +154,7 @@ class TestTaskworkerRollout(TestCase):
             name="test.test_taskworker_no_rollout_configured",
             taskworker_config=self.config,
         )
-        def test_task() -> None:
+        def test_task() -> str:
             return "done"
 
         assert test_task.name == "test.test_taskworker_no_rollout_configured"

--- a/tests/sentry/tasks/test_taskworker_rollout.py
+++ b/tests/sentry/tasks/test_taskworker_rollout.py
@@ -39,7 +39,7 @@ class TestTaskworkerRollout(TestCase):
             name="test.test_with_taskworker_rollout",
             taskworker_config=self.config,
         )
-        def test_task():
+        def test_task() -> None:
             return "done"
 
         assert test_task.name == "test.test_with_taskworker_rollout"
@@ -154,7 +154,7 @@ class TestTaskworkerRollout(TestCase):
             name="test.test_taskworker_no_rollout_configured",
             taskworker_config=self.config,
         )
-        def test_task():
+        def test_task() -> None:
             return "done"
 
         assert test_task.name == "test.test_taskworker_no_rollout_configured"

--- a/tests/sentry/taskworker/test_client.py
+++ b/tests/sentry/taskworker/test_client.py
@@ -106,7 +106,7 @@ class MockGrpcError(grpc.RpcError):
 
 
 @django_db_all
-def test_get_task_ok():
+def test_get_task_ok() -> None:
     channel = MockChannel()
     channel.add_response(
         "/sentry_protos.taskbroker.v1.ConsumerService/GetTask",
@@ -134,7 +134,7 @@ def test_get_task_ok():
 
 @django_db_all
 @override_settings(TASKWORKER_SHARED_SECRET='["a long secret value","notused"]')
-def test_get_task_with_interceptor():
+def test_get_task_with_interceptor() -> None:
     channel = MockChannel()
     channel.add_response(
         "/sentry_protos.taskbroker.v1.ConsumerService/GetTask",
@@ -167,7 +167,7 @@ def test_get_task_with_interceptor():
 
 
 @django_db_all
-def test_get_task_with_namespace():
+def test_get_task_with_namespace() -> None:
     channel = MockChannel()
     channel.add_response(
         "/sentry_protos.taskbroker.v1.ConsumerService/GetTask",
@@ -194,7 +194,7 @@ def test_get_task_with_namespace():
 
 
 @django_db_all
-def test_get_task_not_found():
+def test_get_task_not_found() -> None:
     channel = MockChannel()
     channel.add_response(
         "/sentry_protos.taskbroker.v1.ConsumerService/GetTask",
@@ -209,7 +209,7 @@ def test_get_task_not_found():
 
 
 @django_db_all
-def test_get_task_failure():
+def test_get_task_failure() -> None:
     channel = MockChannel()
     channel.add_response(
         "/sentry_protos.taskbroker.v1.ConsumerService/GetTask",
@@ -223,7 +223,7 @@ def test_get_task_failure():
 
 
 @django_db_all
-def test_update_task_ok_with_next():
+def test_update_task_ok_with_next() -> None:
     channel = MockChannel()
     channel.add_response(
         "/sentry_protos.taskbroker.v1.ConsumerService/SetTaskStatus",
@@ -253,7 +253,7 @@ def test_update_task_ok_with_next():
 
 
 @django_db_all
-def test_update_task_ok_with_next_namespace():
+def test_update_task_ok_with_next_namespace() -> None:
     channel = MockChannel()
     channel.add_response(
         "/sentry_protos.taskbroker.v1.ConsumerService/SetTaskStatus",
@@ -286,7 +286,7 @@ def test_update_task_ok_with_next_namespace():
 
 
 @django_db_all
-def test_update_task_ok_no_next():
+def test_update_task_ok_no_next() -> None:
     channel = MockChannel()
     channel.add_response(
         "/sentry_protos.taskbroker.v1.ConsumerService/SetTaskStatus", SetTaskStatusResponse()
@@ -307,7 +307,7 @@ def test_update_task_ok_no_next():
 
 
 @django_db_all
-def test_update_task_not_found():
+def test_update_task_not_found() -> None:
     channel = MockChannel()
     channel.add_response(
         "/sentry_protos.taskbroker.v1.ConsumerService/SetTaskStatus",
@@ -329,7 +329,7 @@ def test_update_task_not_found():
 
 
 @django_db_all
-def test_update_task_unavailable_retain_task_to_host():
+def test_update_task_unavailable_retain_task_to_host() -> None:
     channel = MockChannel()
     channel.add_response(
         "/sentry_protos.taskbroker.v1.ConsumerService/SetTaskStatus",
@@ -352,7 +352,7 @@ def test_update_task_unavailable_retain_task_to_host():
 
 
 @django_db_all
-def test_client_loadbalance():
+def test_client_loadbalance() -> None:
     channel_0 = MockChannel()
     channel_0.add_response(
         "/sentry_protos.taskbroker.v1.ConsumerService/GetTask",
@@ -474,7 +474,7 @@ def test_client_loadbalance():
 
 
 @django_db_all
-def test_client_loadbalance_on_notfound():
+def test_client_loadbalance_on_notfound() -> None:
     channel_0 = MockChannel()
     channel_0.add_response(
         "/sentry_protos.taskbroker.v1.ConsumerService/GetTask",
@@ -550,7 +550,7 @@ def test_client_loadbalance_on_notfound():
 
 
 @django_db_all
-def test_client_loadbalance_on_unavailable():
+def test_client_loadbalance_on_unavailable() -> None:
     channel_0 = MockChannel()
     channel_0.add_response(
         "/sentry_protos.taskbroker.v1.ConsumerService/GetTask",
@@ -613,7 +613,7 @@ def test_client_loadbalance_on_unavailable():
 
 
 @django_db_all
-def test_client_single_host_unavailable():
+def test_client_single_host_unavailable() -> None:
     channel = MockChannel()
     channel.add_response(
         "/sentry_protos.taskbroker.v1.ConsumerService/GetTask",
@@ -664,7 +664,7 @@ def test_client_single_host_unavailable():
 
 
 @django_db_all
-def test_client_reset_errors_after_success():
+def test_client_reset_errors_after_success() -> None:
     channel = MockChannel()
     channel.add_response(
         "/sentry_protos.taskbroker.v1.ConsumerService/GetTask",
@@ -708,7 +708,7 @@ def test_client_reset_errors_after_success():
 
 
 @django_db_all
-def test_client_update_task_host_unavailable():
+def test_client_update_task_host_unavailable() -> None:
     channel = MockChannel()
     channel.add_response(
         "/sentry_protos.taskbroker.v1.ConsumerService/GetTask",

--- a/tests/sentry/taskworker/test_config.py
+++ b/tests/sentry/taskworker/test_config.py
@@ -10,7 +10,7 @@ from sentry.dynamic_sampling.tasks.task_context import TaskContext
 from sentry.taskworker.registry import taskregistry
 
 
-def test_import_paths():
+def test_import_paths() -> None:
     for path in settings.TASKWORKER_IMPORTS:
         try:
             __import__(path)

--- a/tests/sentry/templatetags/test_sentry_helpers.py
+++ b/tests/sentry/templatetags/test_sentry_helpers.py
@@ -7,7 +7,7 @@ from sentry.models.organization import Organization
 from sentry.testutils.helpers.features import Feature
 
 
-def test_system_origin():
+def test_system_origin() -> None:
     result = (
         engines["django"]
         .from_string(
@@ -121,7 +121,7 @@ def test_org_url_customer_domains(input, output):
         assert result == output
 
 
-def test_querystring():
+def test_querystring() -> None:
     input = """
     {% load sentry_helpers %}
     {% querystring transaction="testing" referrer="weekly_report" space="some thing"%}
@@ -130,7 +130,7 @@ def test_querystring():
     assert result == "transaction=testing&amp;referrer=weekly_report&amp;space=some+thing"
 
 
-def test_date_handle_date_and_datetime():
+def test_date_handle_date_and_datetime() -> None:
     result = (
         engines["django"]
         .from_string(
@@ -166,7 +166,7 @@ def test_get_item(a_dict, key, expected):
     assert result == expected
 
 
-def test_sanitize_periods():
+def test_sanitize_periods() -> None:
     input = '{% load sentry_helpers %} {{ "example.com"|sanitize_periods}}'
     result = engines["django"].from_string(input).render().strip()
     assert result == "example\u2060.com"

--- a/tests/sentry/test_celery.py
+++ b/tests/sentry/test_celery.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 
 
-def test_import_paths():
+def test_import_paths() -> None:
     for path in settings.CELERY_IMPORTS:
         try:
             __import__(path)

--- a/tests/sentry/test_constants.py
+++ b/tests/sentry/test_constants.py
@@ -20,7 +20,7 @@ def mock_integration_ids():
     )
 
 
-def test_marketing_slug_to_integration_id():
+def test_marketing_slug_to_integration_id() -> None:
     with mock_integration_ids():
         assert get_integration_id_for_marketing_slug("java") == "java"
         # kotlin uses the java library, too
@@ -29,7 +29,7 @@ def test_marketing_slug_to_integration_id():
         assert get_integration_id_for_marketing_slug("foobar") is None
 
 
-def test_integration_id_for_event():
+def test_integration_id_for_event() -> None:
     with mock_integration_ids():
         assert get_integration_id_for_event("java", "sentry-java", []) == "java"
         assert get_integration_id_for_event("java", "raven-java", []) == "java"

--- a/tests/sentry/test_culprit.py
+++ b/tests/sentry/test_culprit.py
@@ -8,7 +8,7 @@ def get_culprit(data):
     return get_culprit_impl(mgr.get_data())
 
 
-def test_cocoa_culprit():
+def test_cocoa_culprit() -> None:
     culprit = get_culprit(
         {
             "platform": "cocoa",
@@ -31,7 +31,7 @@ def test_cocoa_culprit():
     assert culprit == "-[CRLCrashAsyncSafeThread crash]"
 
 
-def test_emoji_culprit():
+def test_emoji_culprit() -> None:
     culprit = get_culprit(
         {
             "platform": "native",
@@ -55,7 +55,7 @@ def test_emoji_culprit():
     assert culprit == "\U0001f60d"
 
 
-def test_cocoa_strict_stacktrace():
+def test_cocoa_strict_stacktrace() -> None:
     culprit = get_culprit(
         {
             "platform": "native",
@@ -85,7 +85,7 @@ def test_cocoa_strict_stacktrace():
     assert culprit == "-[CRLCrashAsyncSafeThread crash]"
 
 
-def test_culprit_for_synthetic_event():
+def test_culprit_for_synthetic_event() -> None:
     # Synthetic events do not generate a culprit
     culprit = get_culprit(
         {
@@ -111,7 +111,7 @@ def test_culprit_for_synthetic_event():
     assert culprit == ""
 
 
-def test_culprit_for_javascript_event():
+def test_culprit_for_javascript_event() -> None:
     culprit = get_culprit(
         {
             "platform": "javascript",
@@ -135,7 +135,7 @@ def test_culprit_for_javascript_event():
     assert culprit == "fooBar(foo/baz.js)"
 
 
-def test_culprit_for_python_event():
+def test_culprit_for_python_event() -> None:
     culprit = get_culprit(
         {
             "platform": "python",

--- a/tests/sentry/test_datascrubbing.py
+++ b/tests/sentry/test_datascrubbing.py
@@ -80,7 +80,7 @@ def test_scrub_data(field, default_project):
     )
 
 
-def test_merge_pii_configs_simple():
+def test_merge_pii_configs_simple() -> None:
     assert merge_pii_configs([("p:", {}), ("o:", {})]) == {}
 
     assert merge_pii_configs(
@@ -88,7 +88,7 @@ def test_merge_pii_configs_simple():
     ) == {"applications": {"$string": ["@ip:remove"]}}
 
 
-def test_merge_pii_configs_rule_references():
+def test_merge_pii_configs_rule_references() -> None:
     my_rules = {
         "remove_ips_alias": {
             "type": "alias",

--- a/tests/sentry/test_http.py
+++ b/tests/sentry/test_http.py
@@ -29,7 +29,7 @@ def test_simple(mock_getaddrinfo):
 @override_blocklist("127.0.0.1", "::1", "10.0.0.0/8")
 # XXX(dcramer): we can't use responses here as it hooks Session.send
 # @responses.activate
-def test_ip_blacklist_ipv4():
+def test_ip_blacklist_ipv4() -> None:
     with pytest.raises(SuspiciousOperation):
         http.safe_urlopen("http://127.0.0.1")
     with pytest.raises(SuspiciousOperation):
@@ -41,7 +41,7 @@ def test_ip_blacklist_ipv4():
 
 @pytest.mark.skipif(not HAS_IPV6, reason="needs ipv6")
 @override_blocklist("::1")
-def test_ip_blacklist_ipv6():
+def test_ip_blacklist_ipv6() -> None:
     with pytest.raises(SuspiciousOperation):
         http.safe_urlopen("http://[::1]")
 
@@ -59,14 +59,14 @@ def test_ip_blacklist_ipv6_fallback(mock_getaddrinfo):
     platform.system() == "Darwin", reason="macOS is always broken, see comment in sentry/http.py"
 )
 @override_blocklist("127.0.0.1")
-def test_garbage_ip():
+def test_garbage_ip() -> None:
     with pytest.raises(SuspiciousOperation):
         # '0177.0000.0000.0001' is an octal for '127.0.0.1'
         http.safe_urlopen("http://0177.0000.0000.0001")
 
 
 @responses.activate
-def test_fetch_file():
+def test_fetch_file() -> None:
     responses.add(
         responses.GET, "http://example.com", body="foo bar", content_type="application/json"
     )
@@ -76,7 +76,7 @@ def test_fetch_file():
 
 
 @responses.activate
-def test_fetch_file_brotli():
+def test_fetch_file_brotli() -> None:
     body = brotli.compress(b"foo bar")
     responses.add(
         responses.GET,

--- a/tests/sentry/test_killswitches.py
+++ b/tests/sentry/test_killswitches.py
@@ -5,7 +5,7 @@ import pytest
 from sentry.killswitches import normalize_value, value_matches
 
 
-def test_normalize_value():
+def test_normalize_value() -> None:
     assert normalize_value("store.load-shed-group-creation-projects", [1, 2, 3]) == [
         {"project_id": "1", "platform": None},
         {"project_id": "2", "platform": None},

--- a/tests/sentry/test_sdk_updates.py
+++ b/tests/sentry/test_sdk_updates.py
@@ -7,14 +7,14 @@ PYTHON_INDEX_STATE = SdkIndexState(sdk_versions={"sentry.python": "0.9.1"})
 DOTNET_INDEX_STATE = SdkIndexState(sdk_versions={"sentry.dotnet": "1.2.0"})
 
 
-def test_too_old_django():
+def test_too_old_django() -> None:
     setup = SdkSetupState(
         sdk_name="sentry.python", sdk_version="0.9.1", integrations=[], modules={"django": "1.3"}
     )
     assert list(get_suggested_updates(setup, PYTHON_INDEX_STATE)) == []
 
 
-def test_too_old_sdk():
+def test_too_old_sdk() -> None:
     setup = SdkSetupState(
         sdk_name="sentry.python", sdk_version="0.1.0", integrations=[], modules={"django": "1.8"}
     )
@@ -36,14 +36,14 @@ def test_too_old_sdk():
     ]
 
 
-def test_ignore_patch_version():
+def test_ignore_patch_version() -> None:
     setup = SdkSetupState(
         sdk_name="sentry.python", sdk_version="0.9.0", integrations=[], modules={}
     )
     assert len(list(get_suggested_updates(setup, PYTHON_INDEX_STATE))) == 0
 
 
-def test_ignore_patch_version_explicit():
+def test_ignore_patch_version_explicit() -> None:
     setup = SdkSetupState(
         sdk_name="sentry.python", sdk_version="0.9.0", integrations=[], modules={}
     )
@@ -52,7 +52,7 @@ def test_ignore_patch_version_explicit():
     )
 
 
-def test_enable_django_integration():
+def test_enable_django_integration() -> None:
     setup = SdkSetupState(
         sdk_name="sentry.python", sdk_version="0.9.1", integrations=[], modules={"django": "1.8"}
     )
@@ -66,7 +66,7 @@ def test_enable_django_integration():
     ]
 
 
-def test_update_sdk():
+def test_update_sdk() -> None:
     setup = SdkSetupState(
         sdk_name="sentry.python", sdk_version="0.1.0", integrations=[], modules={}
     )
@@ -81,7 +81,7 @@ def test_update_sdk():
     ]
 
 
-def test_enable_two_integrations():
+def test_enable_two_integrations() -> None:
     setup = SdkSetupState(
         sdk_name="sentry.python",
         sdk_version="0.1.0",

--- a/tests/sentry/test_unmerge.py
+++ b/tests/sentry/test_unmerge.py
@@ -6,7 +6,7 @@ from sentry.unmerge import (
 )
 
 
-def test_argument_parsing_endpoint():
+def test_argument_parsing_endpoint() -> None:
     """
     Tests task invocations done from group_hashes endpoint.
     """
@@ -42,7 +42,7 @@ def test_argument_parsing_endpoint():
     assert UnmergeArgsBase.parse_arguments(**dumped) == args
 
 
-def test_argument_parsing_page2():
+def test_argument_parsing_page2() -> None:
     """
     Tests task invocations done from an older version of the unmerge task.
     This test only exists such that argument parsing is not broken across

--- a/tests/sentry/test_wsgi.py
+++ b/tests/sentry/test_wsgi.py
@@ -36,7 +36,7 @@ for lang, _ in settings.LANGUAGES:
 """
 
 
-def test_wsgi_init():
+def test_wsgi_init() -> None:
     """
     This test ensures that the wsgi.py file correctly pre-loads the application and
     various resources we want to be "warm"

--- a/tests/sentry/testutils/test_abstract.py
+++ b/tests/sentry/testutils/test_abstract.py
@@ -1,7 +1,7 @@
 from sentry.testutils.abstract import Abstract
 
 
-def test_abstract():
+def test_abstract() -> None:
     class C:
         __test__ = Abstract(__module__, __qualname__)
 

--- a/tests/sentry/testutils/test_silo.py
+++ b/tests/sentry/testutils/test_silo.py
@@ -3,11 +3,11 @@ import pytest
 from sentry.testutils.silo import strip_silo_mode_test_suffix, validate_protected_queries
 
 
-def test_validate_protected_queries__no_queries():
+def test_validate_protected_queries__no_queries() -> None:
     validate_protected_queries([])
 
 
-def test_validate_protected_queries__ok():
+def test_validate_protected_queries__ok() -> None:
     queries = [
         {"sql": "SELECT * FROM sentry_organization"},
         {"sql": "UPDATE sentry_project SET slug = 'best-team' WHERE id = 1"},
@@ -15,7 +15,7 @@ def test_validate_protected_queries__ok():
     validate_protected_queries(queries)
 
 
-def test_validate_protected_queries__missing_fences():
+def test_validate_protected_queries__missing_fences() -> None:
     queries = [
         {"sql": 'SAVEPOINT "s123abc"'},
         {"sql": 'UPDATE "sentry_useremail" SET "is_verified" = true WHERE "id" = 1'},
@@ -26,7 +26,7 @@ def test_validate_protected_queries__missing_fences():
         validate_protected_queries(queries)
 
 
-def test_validate_protected_queries__with_single_fence():
+def test_validate_protected_queries__with_single_fence() -> None:
     queries = [
         {"sql": 'SAVEPOINT "s123abc"'},
         {"sql": 'UPDATE "sentry_useremail" SET "is_verified" = true WHERE "id" = 1'},
@@ -38,7 +38,7 @@ def test_validate_protected_queries__with_single_fence():
     validate_protected_queries(queries)
 
 
-def test_validate_protected_queries__multiple_fences():
+def test_validate_protected_queries__multiple_fences() -> None:
     queries = [
         {"sql": 'SAVEPOINT "s123abc"'},
         {"sql": 'UPDATE "sentry_useremail" SET "is_verified" = true WHERE "id" = 1'},
@@ -53,7 +53,7 @@ def test_validate_protected_queries__multiple_fences():
     validate_protected_queries(queries)
 
 
-def test_validate_protected_queries__nested_fences():
+def test_validate_protected_queries__nested_fences() -> None:
     queries = [
         {"sql": 'SAVEPOINT "s123abc"'},
         {"sql": 'UPDATE "sentry_useremail" SET "is_verified" = true WHERE "id" = 1'},
@@ -86,7 +86,7 @@ def test_validate_protected_queries__nested_fences():
         validate_protected_queries(queries)
 
 
-def test_validate_protected_queries__fenced_and_not():
+def test_validate_protected_queries__fenced_and_not() -> None:
     queries = [
         {"sql": 'SAVEPOINT "s123abc"'},
         {"sql": 'UPDATE "sentry_useremail" SET "is_verified" = true WHERE "id" = 1'},
@@ -101,7 +101,7 @@ def test_validate_protected_queries__fenced_and_not():
         validate_protected_queries(queries)
 
 
-def test_strip_silo_mode_test_suffix():
+def test_strip_silo_mode_test_suffix() -> None:
     assert strip_silo_mode_test_suffix("SomeTest") == "SomeTest"
     assert strip_silo_mode_test_suffix("SomeTest__InMonolithMode") == "SomeTest"
     assert strip_silo_mode_test_suffix("SomeTest__InControlMode") == "SomeTest"

--- a/tests/sentry/toolbar/utils/test_url.py
+++ b/tests/sentry/toolbar/utils/test_url.py
@@ -140,19 +140,19 @@ def test_url_matches_with_path_or_query(referrer, target):
     assert url_matches(urlparse(referrer), target)
 
 
-def test_is_origin_allowed_allows_some():
+def test_is_origin_allowed_allows_some() -> None:
     assert is_origin_allowed("http://sentry.io", ["http://abc.net", "http://sentry.io"])
     assert is_origin_allowed("http://localhost:5173/", ["localhost:5173"])
 
 
-def test_is_origin_allowed_rejects_all():
+def test_is_origin_allowed_rejects_all() -> None:
     assert not is_origin_allowed("http://sentry.io", ["http://abc.net", "http://xyz.net"])
 
 
-def test_is_origin_allowed_rejects_empty():
+def test_is_origin_allowed_rejects_empty() -> None:
     assert not is_origin_allowed("", ["http://abc.net", "http://xyz.net"])
 
 
-def test_is_origin_allowed_rejects_bad_input_scheme():
+def test_is_origin_allowed_rejects_bad_input_scheme() -> None:
     assert not is_origin_allowed("sentry.io", ["sentry.io"])
     assert not is_origin_allowed("ftp://sentry.io", ["sentry.io"])

--- a/tests/sentry/tsdb/test_redis.py
+++ b/tests/sentry/tsdb/test_redis.py
@@ -10,7 +10,7 @@ from sentry.tsdb.redis import CountMinScript, RedisTSDB, SuppressionWrapper
 from sentry.utils.dates import to_datetime
 
 
-def test_suppression_wrapper():
+def test_suppression_wrapper() -> None:
     @contextmanager
     def raise_after():
         yield

--- a/tests/sentry/tsdb/test_redissnuba.py
+++ b/tests/sentry/tsdb/test_redissnuba.py
@@ -15,7 +15,7 @@ def get_callargs(model):
     }
 
 
-def test_redissnuba_connects_to_correct_backend():
+def test_redissnuba_connects_to_correct_backend() -> None:
     should_resolve_to_redis = set(list(TSDBModel)) - set(SnubaTSDB.model_query_settings.keys())
     should_resolve_to_snuba = set(SnubaTSDB.model_query_settings.keys())
 

--- a/tests/sentry/uptime/endpoints/test_organization_uptime_stats.py
+++ b/tests/sentry/uptime/endpoints/test_organization_uptime_stats.py
@@ -263,7 +263,7 @@ class OrganizationUptimeCheckIndexEndpointTest(
 
 
 # TODO(jferg): remove after 90 days
-def test_add_extra_buckets_for_epoch_cutoff():
+def test_add_extra_buckets_for_epoch_cutoff() -> None:
     """Test adding extra buckets when there's an epoch cutoff"""
     start = datetime(2025, 1, 1, tzinfo=timezone.utc)
     end = datetime(2025, 1, 2, tzinfo=timezone.utc)

--- a/tests/sentry/users/models/test_authenticator.py
+++ b/tests/sentry/users/models/test_authenticator.py
@@ -43,7 +43,7 @@ class AuthenticatorTest(TestCase):
 
 
 @django_db_all
-def test_authenticator_config_compatibility():
+def test_authenticator_config_compatibility() -> None:
     field_json = AuthenticatorConfig()
 
     value = {

--- a/tests/sentry/utils/email/test_address.py
+++ b/tests/sentry/utils/email/test_address.py
@@ -15,7 +15,7 @@ from sentry.utils.email.address import (
 
 
 @django_db_all
-def test_get_from_email_domain():
+def test_get_from_email_domain() -> None:
     with override_options({"mail.from": "matt@example.com"}):
         assert get_from_email_domain() == "example.com"
 
@@ -26,52 +26,52 @@ def test_get_from_email_domain():
         assert get_from_email_domain() == "garbage"
 
 
-def test_is_valid_email_address_number_at_qqcom():
+def test_is_valid_email_address_number_at_qqcom() -> None:
     assert is_valid_email_address("12345@qq.com") is False
 
 
-def test_is_valid_email_address_normal_human_email_address():
+def test_is_valid_email_address_normal_human_email_address() -> None:
     assert is_valid_email_address("dcramer@gmail.com") is True
 
 
-def test_parse_email_empty():
+def test_parse_email_empty() -> None:
     assert parse_email("") == ""
 
 
-def test_parse_email_no_email():
+def test_parse_email_no_email() -> None:
     assert parse_email("marcos@sentry.io") == ""
 
 
-def test_parse_email_empty_email():
+def test_parse_email_empty_email() -> None:
     assert parse_email("<>") == ""
 
 
-def test_parse_email_two_emails():
+def test_parse_email_two_emails() -> None:
     assert parse_email("<a><b>") == "a"
 
 
-def test_parse_email_simple():
+def test_parse_email_simple() -> None:
     assert parse_email("lauryn <lauryn@sentry.io>") == "lauryn@sentry.io"
 
 
-def test_parse_user_name_empty():
+def test_parse_user_name_empty() -> None:
     assert parse_user_name("") == ""
 
 
-def test_parse_user_name_no_email():
+def test_parse_user_name_no_email() -> None:
     assert parse_user_name("marcos@sentry.io") == "marcos@sentry.io"
 
 
-def test_parse_user_name_empty_email():
+def test_parse_user_name_empty_email() -> None:
     assert parse_user_name("<>") == ""
 
 
-def test_parse_user_name_simple():
+def test_parse_user_name_simple() -> None:
     assert parse_user_name("Max Bittker <max@getsentry.com>") == "Max Bittker"
 
 
 @django_db_all
-def test_group_id_to_email_backwards_compat():
+def test_group_id_to_email_backwards_compat() -> None:
     mailhost = options.get("mail.reply-hostname")
     group_id = 1234567
 
@@ -85,7 +85,7 @@ def test_group_id_to_email_backwards_compat():
 
 
 @django_db_all
-def test_group_id_to_email_with_org_id():
+def test_group_id_to_email_with_org_id() -> None:
     mailhost = options.get("mail.reply-hostname")
     group_id = 1234567
     org_id = 9876543

--- a/tests/sentry/utils/sdk_crashes/test_build_sdk_crash_detection_configs.py
+++ b/tests/sentry/utils/sdk_crashes/test_build_sdk_crash_detection_configs.py
@@ -23,7 +23,7 @@ from sentry.utils.sdk_crashes.sdk_crash_detection_config import (
         "issues.sdk_crash_detection.dart.organization_allowlist": [4],
     }
 )
-def test_build_sdk_crash_detection_configs():
+def test_build_sdk_crash_detection_configs() -> None:
     configs = build_sdk_crash_detection_configs()
 
     assert len(configs) == 5
@@ -77,7 +77,7 @@ def test_build_sdk_crash_detection_configs():
         "issues.sdk_crash_detection.dart.organization_allowlist": [],
     }
 )
-def test_build_sdk_crash_detection_configs_only_react_native():
+def test_build_sdk_crash_detection_configs_only_react_native() -> None:
     configs = build_sdk_crash_detection_configs()
 
     assert len(configs) == 1
@@ -106,7 +106,7 @@ def test_build_sdk_crash_detection_configs_only_react_native():
         "issues.sdk_crash_detection.dart.organization_allowlist": [4],
     }
 )
-def test_build_sdk_crash_detection_configs_no_sample_rate():
+def test_build_sdk_crash_detection_configs_no_sample_rate() -> None:
     configs = build_sdk_crash_detection_configs()
 
     assert len(configs) == 1
@@ -135,5 +135,5 @@ def test_build_sdk_crash_detection_configs_no_sample_rate():
         "issues.sdk_crash_detection.dart.organization_allowlist": [],
     }
 )
-def test_build_sdk_crash_detection_default_configs():
+def test_build_sdk_crash_detection_default_configs() -> None:
     assert len(build_sdk_crash_detection_configs()) == 0

--- a/tests/sentry/utils/test_arroyo_producer.py
+++ b/tests/sentry/utils/test_arroyo_producer.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock
 from sentry.utils.arroyo_producer import SingletonProducer
 
 
-def test_track_futures():
+def test_track_futures() -> None:
     def dummy_producer():
         raise AssertionError("no producer")
 

--- a/tests/sentry/utils/test_auth.py
+++ b/tests/sentry/utils/test_auth.py
@@ -165,18 +165,18 @@ class LoginTest(TestCase):
         assert request.session["_nonce"] == self.user.session_nonce
 
 
-def test_sso_expiry_default():
+def test_sso_expiry_default() -> None:
     value = sentry.utils.auth._sso_expiry_from_env(None)
     # make sure no accidental changes affect sso timeout
     assert value == timedelta(days=7)
 
 
-def test_sso_expiry_from_env():
+def test_sso_expiry_from_env() -> None:
     value = sentry.utils.auth._sso_expiry_from_env("20")
     assert value == timedelta(seconds=20)
 
 
-def test_construct_link_with_query():
+def test_construct_link_with_query() -> None:
     # testing basic query param construction
     path = "foobar"
     query_params = {"biz": "baz"}

--- a/tests/sentry/utils/test_concurrent.py
+++ b/tests/sentry/utils/test_concurrent.py
@@ -16,14 +16,14 @@ from sentry.utils.concurrent import (
 )
 
 
-def test_execute():
+def test_execute() -> None:
     assert execute(_thread.get_ident).result() != _thread.get_ident()
 
     with pytest.raises(Exception):
         assert execute(mock.Mock(side_effect=Exception("Boom!"))).result()
 
 
-def test_future_set_callback_success():
+def test_future_set_callback_success() -> None:
     future_set = FutureSet([Future() for i in range(3)])
 
     callback = mock.Mock()
@@ -43,7 +43,7 @@ def test_future_set_callback_success():
     assert other_callback.call_args == mock.call(future_set)
 
 
-def test_future_set_callback_error():
+def test_future_set_callback_error() -> None:
     future_set = FutureSet([Future() for i in range(3)])
 
     callback = mock.Mock()
@@ -63,7 +63,7 @@ def test_future_set_callback_error():
     assert other_callback.call_args == mock.call(future_set)
 
 
-def test_future_set_callback_empty():
+def test_future_set_callback_empty() -> None:
     future_set = FutureSet([])
 
     callback = mock.Mock()
@@ -73,7 +73,7 @@ def test_future_set_callback_empty():
     assert callback.call_args == mock.call(future_set)
 
 
-def test_future_broken_callback():
+def test_future_broken_callback() -> None:
     future_set = FutureSet([])
 
     callback = mock.Mock(side_effect=Exception("Boom!"))
@@ -91,7 +91,7 @@ def timestamp(t):
         yield
 
 
-def test_timed_future_success():
+def test_timed_future_success() -> None:
     future: TimedFuture[object] = TimedFuture()
     assert future.get_timing() == (None, None)
 
@@ -117,7 +117,7 @@ def test_timed_future_success():
     assert callback_results[0] == (expected_result, expected_timing)
 
 
-def test_time_is_not_overwritten_if_fail_to_set_result():
+def test_time_is_not_overwritten_if_fail_to_set_result() -> None:
     future: TimedFuture[int] = TimedFuture()
 
     with timestamp(1.0):
@@ -136,7 +136,7 @@ def test_time_is_not_overwritten_if_fail_to_set_result():
         assert future.get_timing() == (1.0, 1.0)
 
 
-def test_timed_future_error():
+def test_timed_future_error() -> None:
     future: TimedFuture[None] = TimedFuture()
     assert future.get_timing() == (None, None)
 
@@ -161,7 +161,7 @@ def test_timed_future_error():
     assert callback_timings[0] == expected_timing
 
 
-def test_timed_future_cancel():
+def test_timed_future_cancel() -> None:
     future: TimedFuture[None] = TimedFuture()
     assert future.get_timing() == (None, None)
 
@@ -183,7 +183,7 @@ def test_timed_future_cancel():
     assert future.get_timing() == (2.0, 1.0)
 
 
-def test_synchronous_executor():
+def test_synchronous_executor() -> None:
     executor = SynchronousExecutor()
 
     assert executor.submit(lambda: mock.sentinel.RESULT).result() is mock.sentinel.RESULT
@@ -199,7 +199,7 @@ def test_synchronous_executor():
         future.result()
 
 
-def test_threaded_same_priority_Tasks():
+def test_threaded_same_priority_Tasks() -> None:
     executor = ThreadedExecutor(worker_count=1)
 
     def callable():
@@ -210,7 +210,7 @@ def test_threaded_same_priority_Tasks():
     executor.submit(callable)
 
 
-def test_threaded_executor():
+def test_threaded_executor() -> None:
     executor = ThreadedExecutor(worker_count=1, maxsize=3)
 
     def waiter(ready, waiting, result):

--- a/tests/sentry/utils/test_cursors.py
+++ b/tests/sentry/utils/test_cursors.py
@@ -10,7 +10,7 @@ class CursorKwargs(TypedDict):
     limit: int
 
 
-def test_build_cursor():
+def test_build_cursor() -> None:
     event1 = SimpleNamespace(id=1.1, message="one")
     event2 = SimpleNamespace(id=1.1, message="two")
     event3 = SimpleNamespace(id=2.1, message="three")

--- a/tests/sentry/utils/test_datastructures.py
+++ b/tests/sentry/utils/test_datastructures.py
@@ -3,7 +3,7 @@ import pytest
 from sentry.utils.datastructures import BidirectionalMapping
 
 
-def test_bidirectional_mapping():
+def test_bidirectional_mapping() -> None:
     value = BidirectionalMapping({"a": 1, "b": 2})
 
     assert value["a"] == 1

--- a/tests/sentry/utils/test_dates.py
+++ b/tests/sentry/utils/test_dates.py
@@ -5,7 +5,7 @@ import pytest
 from sentry.utils.dates import date_to_utc_datetime, parse_stats_period, parse_timestamp
 
 
-def test_parse_stats_period():
+def test_parse_stats_period() -> None:
     assert parse_stats_period("3s") == datetime.timedelta(seconds=3)
     assert parse_stats_period("30m") == datetime.timedelta(minutes=30)
     assert parse_stats_period("1h") == datetime.timedelta(hours=1)
@@ -16,13 +16,13 @@ def test_parse_stats_period():
     assert parse_stats_period("900000000000d") is datetime.timedelta.max
 
 
-def test_date_to_utc_datetime():
+def test_date_to_utc_datetime() -> None:
     d = datetime.date(2024, 7, 5)
     dt = date_to_utc_datetime(d)
     assert dt == datetime.datetime(2024, 7, 5, tzinfo=datetime.UTC)
 
 
-def test_parse_timestamp():
+def test_parse_timestamp() -> None:
     assert parse_timestamp("2024-05-20T17:29:00+00:00") == datetime.datetime(
         2024, 5, 20, 17, 29, tzinfo=datetime.UTC
     )
@@ -31,6 +31,6 @@ def test_parse_timestamp():
     )
 
 
-def test_parse_timestamp_error():
+def test_parse_timestamp_error() -> None:
     with pytest.raises(ValueError):
         parse_timestamp("2024-05-20T17:29:00gu")

--- a/tests/sentry/utils/test_iterators.py
+++ b/tests/sentry/utils/test_iterators.py
@@ -3,13 +3,13 @@ import pytest
 from sentry.utils.iterators import advance, chunked, shingle
 
 
-def test_chunked():
+def test_chunked() -> None:
     assert list(chunked(range(5), 5)) == [[0, 1, 2, 3, 4]]
 
     assert list(chunked(range(10), 4)) == [[0, 1, 2, 3], [4, 5, 6, 7], [8, 9]]
 
 
-def test_advance():
+def test_advance() -> None:
     i = iter(range(10))
 
     advance(5, i)  # [0, 1, 2, 3, 4]
@@ -20,6 +20,6 @@ def test_advance():
         next(i)
 
 
-def test_shingle():
+def test_shingle() -> None:
     assert list(shingle(5, "x")) == []
     assert list(shingle(2, ("foo", "bar", "baz"))) == [("foo", "bar"), ("bar", "baz")]

--- a/tests/sentry/utils/test_kafka_config.py
+++ b/tests/sentry/utils/test_kafka_config.py
@@ -15,7 +15,7 @@ settings.KAFKA_CLUSTERS["default"] = {
 }
 
 
-def test_get_kafka_producer_cluster_options():
+def test_get_kafka_producer_cluster_options() -> None:
     cluster_options = get_kafka_producer_cluster_options("default")
     assert (
         cluster_options["bootstrap.servers"]
@@ -42,7 +42,7 @@ def test_get_kafka_producer_cluster_options():
         assert cluster_options["security.protocol"] == "plain"
 
 
-def test_get_kafka_consumer_cluster_options():
+def test_get_kafka_consumer_cluster_options() -> None:
     cluster_options = get_kafka_consumer_cluster_options("default")
     assert (
         cluster_options["bootstrap.servers"]
@@ -70,7 +70,7 @@ def test_get_kafka_consumer_cluster_options():
         assert "security.protocol" not in cluster_options
 
 
-def test_get_kafka_admin_cluster_options():
+def test_get_kafka_admin_cluster_options() -> None:
     cluster_options = get_kafka_admin_cluster_options("default")
     assert (
         cluster_options["bootstrap.servers"]
@@ -78,13 +78,13 @@ def test_get_kafka_admin_cluster_options():
     )
 
 
-def test_get_kafka_consumer_cluster_options_invalid():
+def test_get_kafka_consumer_cluster_options_invalid() -> None:
     with override_settings(KAFKA_CLUSTERS={"default": {"common": {"invalid.setting": "value"}}}):
         with pytest.raises(ValueError):
             get_kafka_consumer_cluster_options("default")
 
 
-def test_bootstrap_format():
+def test_bootstrap_format() -> None:
     with override_settings(
         KAFKA_CLUSTERS={"default": {"common": {"bootstrap.servers": ["I", "am", "a", "list"]}}}
     ):
@@ -102,7 +102,7 @@ def test_bootstrap_format():
         assert cluster_options["bootstrap.servers"] == "I,am,a,list"
 
 
-def test_legacy_custom_mix_customer():
+def test_legacy_custom_mix_customer() -> None:
     with override_settings(
         KAFKA_CLUSTERS={
             "default": {

--- a/tests/sentry/utils/test_letter_avatar.py
+++ b/tests/sentry/utils/test_letter_avatar.py
@@ -1,7 +1,7 @@
 from sentry.utils.avatar import get_letter_avatar
 
 
-def test_letter_avatar():
+def test_letter_avatar() -> None:
     # Test name as display name and email as identifier
     letter_avatar = get_letter_avatar("Jane Bloggs", "janebloggs@example.com")
     assert "JB" in letter_avatar

--- a/tests/sentry/utils/test_metrics.py
+++ b/tests/sentry/utils/test_metrics.py
@@ -5,7 +5,7 @@ import pytest
 from sentry.utils import metrics
 
 
-def test_timer_success():
+def test_timer_success() -> None:
     with mock.patch("sentry.utils.metrics.timing") as timing:
         with metrics.timer("key", tags={"foo": True}) as tags:
             tags["bar"] = False
@@ -20,7 +20,7 @@ class ExpectedError(Exception):
     pass
 
 
-def test_timer_failure():
+def test_timer_failure() -> None:
     with mock.patch("sentry.utils.metrics.timing") as timing:
         with pytest.raises(ExpectedError):
             with metrics.timer("key", tags={"foo": True}):
@@ -32,7 +32,7 @@ def test_timer_failure():
         assert args[3] == {"foo": True, "result": "failure"}
 
 
-def test_wraps():
+def test_wraps() -> None:
     @metrics.wraps("key", tags={"foo": True})
     def thing(a):
         return a

--- a/tests/sentry/utils/test_numbers.py
+++ b/tests/sentry/utils/test_numbers.py
@@ -8,7 +8,7 @@ from sentry.utils.numbers import (
 )
 
 
-def test_base36():
+def test_base36() -> None:
     assert [base36_encode(x) for x in range(128)] == [
         "0",
         "1",
@@ -143,7 +143,7 @@ def test_base36():
     assert [base36_decode(base36_encode(x)) for x in range(128)] == list(range(128))
 
 
-def test_base32():
+def test_base32() -> None:
     assert [base32_encode(x) for x in range(128)] == [
         "0",
         "1",
@@ -278,7 +278,7 @@ def test_base32():
     assert [base32_decode(base32_encode(x)) for x in range(128)] == list(range(128))
 
 
-def test_format_bytes():
+def test_format_bytes() -> None:
     assert format_bytes(50) == "50 B"
     assert format_bytes(1024) == "1.00 KB"
     assert format_bytes(3000) == "2.93 KB"
@@ -290,7 +290,7 @@ def test_format_bytes():
     assert format_bytes(3000000000000, units=("B", "KB", "MB", "GB")) == "2793.97 GB"
 
 
-def test_format_grouped_length():
+def test_format_grouped_length() -> None:
     assert format_grouped_length(0) == "0"
     assert format_grouped_length(1) == "1"
     assert format_grouped_length(2) == "<10"

--- a/tests/sentry/utils/test_outcomes.py
+++ b/tests/sentry/utils/test_outcomes.py
@@ -61,7 +61,7 @@ def test_parse_outcome(name, outcome):
     assert Outcome.parse(name) == outcome
 
 
-def test_outcome_parse_invalid_name():
+def test_outcome_parse_invalid_name() -> None:
     """
     Tests that `Outcome.parse` raises a KeyError for invalid outcome names.
     """
@@ -174,7 +174,7 @@ def test_track_outcome_billing_cluster(settings, setup):
         assert outcomes.outcomes_publisher is None
 
 
-def test_outcome_api_name():
+def test_outcome_api_name() -> None:
     """
     Tests that the `api_name` method returns the lowercase name of the outcome.
     """
@@ -250,7 +250,7 @@ def test_track_outcome_with_category(setup, category):
     assert data["category"] == category.value
 
 
-def test_track_outcome_with_invalid_inputs():
+def test_track_outcome_with_invalid_inputs() -> None:
     """
     Tests that `track_outcome` raises AssertionError when invalid inputs are provided.
     """

--- a/tests/sentry/utils/test_patch_set.py
+++ b/tests/sentry/utils/test_patch_set.py
@@ -8,7 +8,7 @@ from sentry.utils.patch_set import (
 )
 
 
-def test_filename_containing_spaces():
+def test_filename_containing_spaces() -> None:
     # regression test for https://sentry.io/organizations/sentry/issues/3279066697
     patch = """\
 diff --git a/has spaces/t.sql b/has spaces/t.sql

--- a/tests/sentry/utils/test_redis.py
+++ b/tests/sentry/utils/test_redis.py
@@ -66,7 +66,7 @@ class ClusterManagerTestCase(TestCase):
         manager.get("baz")
 
 
-def test_get_cluster_from_options_cluster_provided():
+def test_get_cluster_from_options_cluster_provided() -> None:
     backend = mock.sentinel.backend
     manager = RBClusterManager(_options_manager())
 
@@ -80,7 +80,7 @@ def test_get_cluster_from_options_cluster_provided():
     assert options == {"foo": "bar"}
 
 
-def test_get_cluster_from_options_legacy_hosts_option():
+def test_get_cluster_from_options_legacy_hosts_option() -> None:
     backend = mock.sentinel.backend
     manager = RBClusterManager(_options_manager())
 
@@ -101,7 +101,7 @@ def test_get_cluster_from_options_legacy_hosts_option():
     assert options == {"foo": "bar"}
 
 
-def test_get_cluster_from_options_both_options_invalid():
+def test_get_cluster_from_options_both_options_invalid() -> None:
     backend = mock.sentinel.backend
     manager = RBClusterManager(_options_manager())
 

--- a/tests/sentry/utils/test_rust.py
+++ b/tests/sentry/utils/test_rust.py
@@ -109,7 +109,7 @@ def get_exc_info(rust_info):
     return type(exc), exc, None
 
 
-def test_merge_rust_info():
+def test_merge_rust_info() -> None:
     event = get_event(STACKTRACE)
     exc_info = get_exc_info(STACKTRACE)
 
@@ -142,7 +142,7 @@ def test_merge_rust_info():
     assert frames[6]["lineno"] == 456
 
 
-def test_merge_rust_info_linux():
+def test_merge_rust_info_linux() -> None:
     event = get_event(STACKTRACE_SEMAPHORE_LINUX)
     exc_info = get_exc_info(STACKTRACE_SEMAPHORE_LINUX)
 
@@ -167,13 +167,13 @@ def test_merge_rust_info_linux():
     assert frames[-2]["function"] == "std::panic::catch_unwind"
 
 
-def test_without_exc_info():
+def test_without_exc_info() -> None:
     event = get_event(STACKTRACE)
     merge_rust_info_frames(event, {})
     assert event["platform"] == "python"
 
 
-def test_without_rust_info():
+def test_without_rust_info() -> None:
     event = get_event(STACKTRACE)
     exc_info = get_exc_info(None)
 
@@ -181,7 +181,7 @@ def test_without_rust_info():
     assert event["platform"] == "python"
 
 
-def test_without_stacktrace():
+def test_without_stacktrace() -> None:
     stacktrace = "stacktrace: stack backtrace:\n\n"
     event = get_event(stacktrace)
     exc_info = get_exc_info(stacktrace)
@@ -198,7 +198,7 @@ def test_without_stacktrace():
     assert len(frames) == 1
 
 
-def test_without_exception():
+def test_without_exception() -> None:
     event = get_event(STACKTRACE)
     exc_info = get_exc_info(STACKTRACE)
 
@@ -207,7 +207,7 @@ def test_without_exception():
     assert event["platform"] == "python"
 
 
-def test_starts_with():
+def test_starts_with() -> None:
     # Basic functions
     assert starts_with("__rust_maybe_catch_panic", "__rust")
     assert starts_with("futures::task_impl::std::set", "futures::")
@@ -227,7 +227,7 @@ def test_starts_with():
     assert starts_with("<T as core::convert::Into<U>>::into", "core::")
 
 
-def test_strip_symbol():
+def test_strip_symbol() -> None:
     assert strip_symbol("") == ""
     assert strip_symbol("_ffi_call_unix64") == "_ffi_call_unix64"
     assert (

--- a/tests/sentry/utils/test_samples.py
+++ b/tests/sentry/utils/test_samples.py
@@ -24,7 +24,7 @@ def test_path_traversal_attempt_raises_exception(platform):
     assert msg == "potential path traversal attack detected"
 
 
-def test_missing_sample_returns_none():
+def test_missing_sample_returns_none() -> None:
     platform = "random-platform-that-does-not-exist"
     data = load_data(platform)
 

--- a/tests/sentry/utils/test_sdk.py
+++ b/tests/sentry/utils/test_sdk.py
@@ -505,7 +505,7 @@ class BindAmbiguousOrgContextTest(TestCase):
             assert slug_list_in_org_context[-1] == "... (3 more)"
 
 
-def test_before_send_error_level():
+def test_before_send_error_level() -> None:
     event = {
         "tags": {
             "silo_mode": "REGION",

--- a/tests/sentry/utils/test_snuba.py
+++ b/tests/sentry/utils/test_snuba.py
@@ -421,7 +421,7 @@ class FakeConnectionPool(HTTPConnectionPool):
         return self.connection
 
 
-def test_retries():
+def test_retries() -> None:
     """
     Tests that, even if I set up 5 retries, there is only one request
     made since it times out.

--- a/tests/sentry/utils/test_strings.py
+++ b/tests/sentry/utils/test_strings.py
@@ -46,7 +46,7 @@ def test_unescape_string(s, expected):
     assert unescape_string(s) == expected
 
 
-def test_codec_lookup():
+def test_codec_lookup() -> None:
     assert codec_lookup("utf-8").name == "utf-8"
     assert codec_lookup("utf8").name == "utf-8"
     assert codec_lookup("zlib").name == "utf-8"
@@ -57,7 +57,7 @@ def test_codec_lookup():
     assert codec_lookup("unknowable", default="latin1").name == "iso8859-1"
 
 
-def test_soft_break():
+def test_soft_break() -> None:
     assert soft_break(
         "com.example.package.method(argument).anotherMethod(argument)", 15
     ) == ZWSP.join(
@@ -65,14 +65,14 @@ def test_soft_break():
     )
 
 
-def test_soft_break_and_hyphenate():
+def test_soft_break_and_hyphenate() -> None:
     hyphenate = functools.partial(soft_hyphenate, length=6)
     assert soft_break("com.reallyreallyreally.long.path", 6, hyphenate) == ZWSP.join(
         ["com.", SHY.join(["really"] * 3) + ".", "long.", "path"]
     )
 
 
-def test_is_valid_dot_atom():
+def test_is_valid_dot_atom() -> None:
     assert is_valid_dot_atom("foo")
     assert is_valid_dot_atom("foo.bar")
     assert not is_valid_dot_atom(".foo.bar")
@@ -80,7 +80,7 @@ def test_is_valid_dot_atom():
     assert not is_valid_dot_atom("foo.\x00")
 
 
-def test_truncatechars():
+def test_truncatechars() -> None:
     assert truncatechars("12345", 6) == "12345"
     assert truncatechars("12345", 5) == "12345"
     assert truncatechars("12345", 4) == "1..."
@@ -100,7 +100,7 @@ def test_truncatechars():
     assert truncatechars(None, 1) is None
 
 
-def test_oxfordize_list():
+def test_oxfordize_list() -> None:
     assert oxfordize_list([]) == ""
     assert oxfordize_list(["A"]) == "A"
     assert oxfordize_list(["A", "B"]) == "A and B"

--- a/tests/sentry/utils/test_tag_normalization.py
+++ b/tests/sentry/utils/test_tag_normalization.py
@@ -65,7 +65,7 @@ def test_unknown_sentry_to_other(tag, expected):
     assert normalize_sdk_tag(tag) == expected
 
 
-def test_responses_cached():
+def test_responses_cached() -> None:
     normalize_sdk_tag.cache_clear()
     assert normalize_sdk_tag("sentry.javascript.react") == "sentry.javascript.react"
     assert normalize_sdk_tag("sentry.javascript.react") == "sentry.javascript.react"
@@ -88,6 +88,6 @@ def test_normalized_sdk_tag_from_event(tag: str, expected: str) -> None:
     assert normalized_sdk_tag_from_event({"sdk": {"name": tag}}) == expected
 
 
-def test_normalized_sdk_tag_from_event_exception():
+def test_normalized_sdk_tag_from_event_exception() -> None:
     mock_event = mock.Mock()
     assert normalized_sdk_tag_from_event(mock_event) == "other"

--- a/tests/sentry/utils/test_validators.py
+++ b/tests/sentry/utils/test_validators.py
@@ -1,7 +1,7 @@
 from sentry.utils.validators import is_event_id, is_span_id, normalize_event_id
 
 
-def test_is_event_id():
+def test_is_event_id() -> None:
     assert is_event_id("b802415f7531431caa27f5c0bf923302")
     assert is_event_id("B802415F7531431CAA27F5C0BF923302")
     assert is_event_id("b802415f-7531-431c-aa27-f5c0bf923302")
@@ -16,7 +16,7 @@ def test_is_event_id():
     assert not is_event_id(None)
 
 
-def test_normalize_event_id():
+def test_normalize_event_id() -> None:
     assert (
         normalize_event_id("b802415f7531431caa27f5c0bf923302") == "b802415f7531431caa27f5c0bf923302"
     )
@@ -44,7 +44,7 @@ def test_normalize_event_id():
     assert normalize_event_id(None) is None
 
 
-def test_is_span_id():
+def test_is_span_id() -> None:
     assert is_span_id("202ab439bb9c4f31")
     assert is_span_id("202AB439BB9C4F31")
     assert is_span_id("202AB439bb9c4f31")

--- a/tests/sentry/utils/test_zip.py
+++ b/tests/sentry/utils/test_zip.py
@@ -1,7 +1,7 @@
 from sentry.utils.zip import is_unsafe_path
 
 
-def test_is_unsafe_path():
+def test_is_unsafe_path() -> None:
     assert is_unsafe_path("/foo.txt")
     assert is_unsafe_path("../foo.txt")
     assert is_unsafe_path("aha/../foo.txt")

--- a/tests/sentry/web/forms/test_accounts.py
+++ b/tests/sentry/web/forms/test_accounts.py
@@ -31,7 +31,7 @@ def test_sets_user_timezone_when_present() -> None:
 
 @no_silo_test
 @django_db_all
-def test_registration_form_without_timezone():
+def test_registration_form_without_timezone() -> None:
     form_data = {
         "username": "a@b.com",
         "name": "Test",

--- a/tests/sentry/web/test_client_config.py
+++ b/tests/sentry/web/test_client_config.py
@@ -70,7 +70,7 @@ multiregion_client_config_test = control_silo_test(
 
 @no_silo_test
 @django_db_all
-def test_client_config_default():
+def test_client_config_default() -> None:
     cfg = get_client_config()
     assert cfg["sentryMode"] == "SELF_HOSTED"
 
@@ -117,7 +117,7 @@ def test_client_config_in_silo_modes(request_factory: RequestFactory):
 
 @no_silo_test
 @django_db_all(transaction=True)
-def test_client_config_deleted_user():
+def test_client_config_deleted_user() -> None:
     request, user = make_user_request_from_org()
     request.user = user
 
@@ -130,7 +130,7 @@ def test_client_config_deleted_user():
 
 @no_silo_test
 @django_db_all
-def test_client_config_features():
+def test_client_config_features() -> None:
     request, user = make_user_request_from_org()
     request.user = user
     result = get_client_config(request)
@@ -152,7 +152,7 @@ def test_client_config_features():
 
 @no_silo_test
 @django_db_all
-def test_client_config_default_region_data():
+def test_client_config_default_region_data() -> None:
     request, user = make_user_request_from_org()
     request.user = user
     result = get_client_config(request)
@@ -170,7 +170,7 @@ def test_client_config_default_region_data():
 
 @no_silo_test
 @django_db_all
-def test_client_config_empty_region_data():
+def test_client_config_empty_region_data() -> None:
     region_directory = region.load_from_config([])
 
     # Usually, we would want to use other testutils functions rather than calling
@@ -189,7 +189,7 @@ def test_client_config_empty_region_data():
 
 @multiregion_client_config_test
 @django_db_all
-def test_client_config_with_region_data():
+def test_client_config_with_region_data() -> None:
     request, user = make_user_request_from_org()
     request.user = user
     result = get_client_config(request)
@@ -220,7 +220,7 @@ hidden_regions = [
 
 @control_silo_test(regions=hidden_regions, include_monolith_run=True)
 @django_db_all
-def test_client_config_with_hidden_region_data():
+def test_client_config_with_hidden_region_data() -> None:
     request, user = make_user_request_from_org()
     request.user = user
     result = get_client_config(request)
@@ -233,7 +233,7 @@ def test_client_config_with_hidden_region_data():
 
 @multiregion_client_config_test
 @django_db_all
-def test_client_config_with_multiple_membership():
+def test_client_config_with_multiple_membership() -> None:
     request, user = make_user_request_from_org()
     request.user = user
 
@@ -257,7 +257,7 @@ def test_client_config_with_multiple_membership():
 
 @multiregion_client_config_test
 @django_db_all
-def test_client_config_with_single_tenant_membership():
+def test_client_config_with_single_tenant_membership() -> None:
     request, user = make_user_request_from_org()
     request.user = user
 
@@ -278,7 +278,7 @@ def test_client_config_with_single_tenant_membership():
 
 @multiregion_client_config_test
 @django_db_all
-def test_client_config_links_regionurl():
+def test_client_config_links_regionurl() -> None:
     request, user = make_user_request_from_org()
     request.user = user
 
@@ -303,7 +303,7 @@ def test_client_config_links_regionurl():
     include_monolith_run=True,
 )
 @django_db_all
-def test_client_config_region_display_order():
+def test_client_config_region_display_order() -> None:
     request, user = make_user_request_from_org()
     request.user = user
 
@@ -318,7 +318,7 @@ def test_client_config_region_display_order():
 
 @multiregion_client_config_test
 @django_db_all
-def test_client_config_links_with_priority_org():
+def test_client_config_links_with_priority_org() -> None:
     request, user = make_user_request_from_org()
     request.user = user
 
@@ -346,7 +346,7 @@ def test_client_config_links_with_priority_org():
 
 
 @django_db_all
-def test_project_key_default():
+def test_project_key_default() -> None:
     organization = Factories.create_organization(name="test-org")
     project = Factories.create_project(organization=organization)
     project_key = Factories.create_project_key(project)
@@ -358,7 +358,7 @@ def test_project_key_default():
 
 @no_silo_test
 @django_db_all
-def test_client_config_no_preload_data_if_accept_invitation_view():
+def test_client_config_no_preload_data_if_accept_invitation_view() -> None:
     request, user = make_user_request_from_org()
     request.user = user
 

--- a/tests/sentry/workflow_engine/endpoints/utils/test_sortby.py
+++ b/tests/sentry/workflow_engine/endpoints/utils/test_sortby.py
@@ -4,7 +4,7 @@ from rest_framework.exceptions import ValidationError
 from sentry.workflow_engine.endpoints.utils.sortby import SortByParam
 
 
-def test_sortby_parse():
+def test_sortby_parse() -> None:
     SORT_ATTRS = {
         "id": "id",
         "name": "name",

--- a/tests/sentry/workflow_engine/processors/test_log_util.py
+++ b/tests/sentry/workflow_engine/processors/test_log_util.py
@@ -116,7 +116,7 @@ class TestBatchPerformanceTracker(unittest.TestCase):
         assert len(call_args["extra"]["durations"]) == _MAX_ITERATIONS_LOGGED
 
 
-def test_top_n_slowest():
+def test_top_n_slowest() -> None:
     durations: dict[str, float] = {"item1": 100, "item2": 50, "item3": 200, "item4": 150}
     assert top_n_slowest(durations, 0) == {}
     assert top_n_slowest(durations, 1) == {"item3": 200}

--- a/tests/sentry/workflow_engine/utils/test_log_context.py
+++ b/tests/sentry/workflow_engine/utils/test_log_context.py
@@ -18,7 +18,7 @@ class LogContextTest(TestCase):
     def test_root_decorator(self) -> None:
 
         @log_context.root()
-        def test_func():
+        def test_func() -> None:
             context = log_context._log_context_state.get()
             assert "context_id" in context.extra
             assert isinstance(context.extra["context_id"], str)
@@ -29,7 +29,7 @@ class LogContextTest(TestCase):
         """Test that set_verbose promotes DEBUG logs to INFO."""
 
         @log_context.root(add_context_id=False)
-        def test_func():
+        def test_func() -> None:
             with (
                 log_context.new_context(verbose=True),
                 patch.object(self.logger.logger, "log") as mock_log,
@@ -50,7 +50,7 @@ class LogContextTest(TestCase):
         """Test that add_extras adds data to the log context."""
 
         @log_context.root()
-        def test_func():
+        def test_func() -> None:
             log_context.add_extras(workflow_id=123, rule_id=456)
             context = log_context._log_context_state.get()
             assert context.extra["workflow_id"] == 123
@@ -67,7 +67,7 @@ class LogContextTest(TestCase):
         """Test that extras passed to log calls override context extras."""
 
         @log_context.root(add_context_id=False)
-        def test_func():
+        def test_func() -> None:
             log_context.add_extras(workflow_id=123, rule_id=456)
             with patch.object(self.logger.logger, "log") as mock_log:
                 self.logger.info("test message", extra={"workflow_id": 789})
@@ -83,7 +83,7 @@ class LogContextTest(TestCase):
         """Test that new_context creates a sub-context with inherited and new data."""
 
         @log_context.root()
-        def test_func():
+        def test_func() -> None:
             log_context.add_extras(workflow_id=123)
             with log_context.new_context(rule_id=456):
                 context = log_context._log_context_state.get()
@@ -96,7 +96,7 @@ class LogContextTest(TestCase):
         """Test that new_context inherits verbose setting unless specified."""
 
         @log_context.root()
-        def test_func():
+        def test_func() -> None:
             log_context.set_verbose(True)
             with log_context.new_context():
                 context = log_context._log_context_state.get()


### PR DESCRIPTION
# What
I added return types to a bunch of test methods in #96385. When further typing my team's tests I noticed that I missed top-level tests (i.e. tests outside of a test class).

# How

## Automated
Ran commands:
```
rg -ls 'def test.*\(\):' tests/sentry | xargs sed -E -i '' -e 's/def test(.*)\(\):/def test\1\(\) -> None:/'    
```

## Manual
`mypy` showed two new errors in one file. It was a pair of basic functions for the purpose of testing a decorator. Manually fixed in a second commit. 
