### PR TITLE
chore(dashboards): deprecate transactions dataset on dashboard widgets endpoint

### DIFF
--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -376,6 +376,15 @@ class DashboardWidgetSerializer(CamelSnakeSerializer[Dashboard]):
             raise serializers.ValidationError(
                 "Attribute value `discover` is deprecated. Please use `error-events` or `transaction-like`"
             )
+        if (
+            features.has(
+                "organizations:discover-saved-queries-deprecation", self.context["organization"]
+            )
+            and widget_type == DashboardWidgetTypes.TRANSACTION_LIKE
+        ):
+            raise serializers.ValidationError(
+                "The transactions dataset is being deprecated. Please use the spans dataset with the `is_transaction:true` filter instead."
+            )
         return widget_type
 
     validate_id = validate_id

--- a/tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py
@@ -1351,3 +1351,31 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
             data=data,
         )
         assert response.status_code == 200, response.data
+
+    def test_valid_widget_type_with_transactions_deprecation_flag(self) -> None:
+        with self.feature("organizations:discover-saved-queries-deprecation"):
+            data = {
+                "title": "Test Query",
+                "widgetType": "transaction-like",
+                "displayType": "table",
+                "queries": [
+                    {
+                        "name": "transaction query",
+                        "conditions": "",
+                        "fields": ["count()"],
+                        "columns": [],
+                        "aggregates": ["count()"],
+                    }
+                ],
+            }
+
+            response = self.do_request(
+                "post",
+                self.url(),
+                data=data,
+            )
+            assert response.status_code == 400, response.data
+            assert (
+                response.data["widgetType"][0]
+                == "The transactions dataset is being deprecated. Please use the spans dataset with the `is_transaction:true` filter instead."
+            )


### PR DESCRIPTION
I've deprecated the transactions dataset behind the deprecation flag in the widget validation endpoint. This should prevent transactions widgets to be created via post request.
