### PR TITLE
feat(grouping): Add docstring and tests to `GroupingContext` class

### DIFF
--- a/src/sentry/grouping/strategies/base.py
+++ b/src/sentry/grouping/strategies/base.py
@@ -95,6 +95,27 @@ def strategy(
 
 
 class GroupingContext:
+    """
+    A key-value store used for passing state between strategy functions and other helpers used
+    during grouping.
+
+    Has a dictionary-like interface, along with a context manager which allows values to be
+    temporarily overwritten:
+
+        context = GroupingContext()
+        context["some_key"] = "original_value"
+
+        value_at_some_key = context["some_key"] # will be "original_value"
+
+        value_at_another_key = context["another_key"] # will raise a KeyError
+
+        with context:
+            context["some_key"] = "some_other_value"
+            value_at_some_key = context["some_key"] # will be "some_other_value"
+
+        value_at_some_key = context["some_key"] # will be "original_value"
+    """
+
     def __init__(self, strategy_config: StrategyConfiguration, event: Event):
         # The initial context is essentially the grouping config options
         self._stack = [strategy_config.initial_context]

--- a/tests/sentry/grouping/test_strategies.py
+++ b/tests/sentry/grouping/test_strategies.py
@@ -1,7 +1,89 @@
 from typing import Any
 
+import pytest
+
 from sentry.eventstore.models import Event
+from sentry.grouping.strategies.base import GroupingContext, create_strategy_configuration_class
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.eventprocessing import save_new_event
+
+
+class GroupingContextTest(TestCase):
+
+    def _get_new_context(self, initial_context: dict[str, Any] | None = None) -> GroupingContext:
+        strategy_class = create_strategy_configuration_class(
+            id="doggity_dogs_dogs", initial_context=initial_context
+        )
+        strategy_instance = strategy_class()
+        event = save_new_event({"message": "Dogs are great!"}, self.project)
+
+        return GroupingContext(strategy_instance, event)
+
+    def test_initial_context(self) -> None:
+        context = self._get_new_context(initial_context={"adopt": "don't shop"})
+        assert context._stack[0] == {"adopt": "don't shop"}
+
+    def test_get_value(self) -> None:
+        context = self._get_new_context(initial_context={"adopt": "don't shop"})
+
+        # Behavior when key exists
+        assert context["adopt"] == "don't shop"
+
+        # Behavior when key doesn’t exist
+        with pytest.raises(KeyError):
+            context["dogs"]
+
+    def test_set_value(self) -> None:
+        context = self._get_new_context(initial_context={"adopt": "don't shop"})
+        assert context["adopt"] == "don't shop"
+
+        # Change the value, and see that the new value is what's there now
+        context["adopt"] = "really don't shop"
+        assert context["adopt"] == "really don't shop"
+
+    def test_context_manager(self) -> None:
+        """
+        Test that:
+            - The `GroupingContext` context manager adds a new context layer to the stack when
+              entered, and pops it off when the manager exits.
+            - Values in lower layers are still accessible even once the new layer has been added.
+            - Values in lower layers aren't destroyed when setting values in the top layer.
+        """
+        context = self._get_new_context(initial_context={"adopt": "don't shop"})
+        context["dogs"] = "great"
+        context["tricks"] = ["shake", "kangaroo"]
+
+        assert len(context._stack) == 2
+        assert context["adopt"] == "don't shop"  # From initial context layer
+        assert context["dogs"] == "great"  # Set in layer 1, will be set in layer 2
+        assert context["tricks"] == ["shake", "kangaroo"]  # Set in layer 1, won't be set in layer 2
+
+        stack_before_with_context = [*context._stack]
+
+        with context:
+            # A new layer has been added
+            assert len(context._stack) == 3
+            assert context._stack == [*stack_before_with_context, {}]
+
+            # We can set and retrieve values from it, which take precedence over the values which
+            # were already there
+            context["dogs"] = "yay"
+            assert context["dogs"] == "yay"
+
+            # Values from lower levels are still accessible
+            assert context["adopt"] == "don't shop"
+            assert context["tricks"] == ["shake", "kangaroo"]
+
+        # The new layer is now gone
+        assert len(context._stack) == 2
+        assert context._stack == stack_before_with_context
+
+        # The old value is now accessible again
+        assert context["dogs"] == "great"
+
+        # These have been accessible the whole time and are still accessible
+        assert context["adopt"] == "don't shop"
+        assert context["tricks"] == ["shake", "kangaroo"]
 
 
 class ChainedExceptionTest(TestCase):


### PR DESCRIPTION
This adds a docstring and tests for the `GroupingContext` class, as a way to document current behavior and to have a place to add to when a new method is introduced in an upcoming PR.