### PR TITLE
chore(emerge): Leverage new Flex, Text & Heading components for Emerge build details page

### DIFF
--- a/static/app/views/preprod/components/installModal.tsx
+++ b/static/app/views/preprod/components/installModal.tsx
@@ -6,6 +6,7 @@ import {QRCodeCanvas} from 'qrcode.react';
 import {openModal} from 'sentry/actionCreators/modal';
 import {Button} from 'sentry/components/core/button';
 import {Flex} from 'sentry/components/core/layout';
+import {Heading, Text} from 'sentry/components/core/text';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -41,7 +42,7 @@ function InstallModal({projectId, artifactId, closeModal}: InstallModalProps) {
     return (
       <Flex direction="column" align="center" gap="md" style={{padding: space(4)}}>
         <LoadingIndicator />
-        <div>{t('Loading install details...')}</div>
+        <Text>{t('Loading install details...')}</Text>
       </Flex>
     );
   }
@@ -49,7 +50,7 @@ function InstallModal({projectId, artifactId, closeModal}: InstallModalProps) {
   if (isError) {
     return (
       <Flex direction="column" align="center" gap="md" style={{padding: space(4)}}>
-        <div>{t('Error: %s', error?.message || 'Failed to fetch install details')}</div>
+        <Text>{t('Error: %s', error?.message || 'Failed to fetch install details')}</Text>
         <Button onClick={() => refetch()}>{t('Retry')}</Button>
         <Button onClick={closeModal}>{t('Close')}</Button>
       </Flex>
@@ -59,7 +60,7 @@ function InstallModal({projectId, artifactId, closeModal}: InstallModalProps) {
   if (!installDetails) {
     return (
       <Flex direction="column" align="center" gap="md" style={{padding: space(4)}}>
-        <div>{t('No install details available')}</div>
+        <Text>{t('No install details available')}</Text>
         <Button onClick={closeModal}>{t('Close')}</Button>
       </Flex>
     );
@@ -68,14 +69,14 @@ function InstallModal({projectId, artifactId, closeModal}: InstallModalProps) {
   const details = installDetails.is_code_signature_valid !== undefined && (
     <CodeSignatureInfo>
       {installDetails.profile_name && (
-        <CodeSignatureValue>
+        <Text size="sm" variant="muted" style={{marginBottom: space(0.5)}}>
           {t('Profile: %s', installDetails.profile_name)}
-        </CodeSignatureValue>
+        </Text>
       )}
       {installDetails.codesigning_type && (
-        <CodeSignatureValue>
+        <Text size="sm" variant="muted" style={{marginBottom: space(0.5)}}>
           {t('Type: %s', installDetails.codesigning_type)}
-        </CodeSignatureValue>
+        </Text>
       )}
     </CodeSignatureInfo>
   );
@@ -83,7 +84,7 @@ function InstallModal({projectId, artifactId, closeModal}: InstallModalProps) {
   return (
     <Fragment>
       <Flex direction="column" align="center" gap="lg" style={{padding: space(4)}}>
-        <Title>{t('Install App')}</Title>
+        <Heading as="h3">{t('Install App')}</Heading>
 
         {installDetails.install_url && (
           <Fragment>
@@ -97,14 +98,16 @@ function InstallModal({projectId, artifactId, closeModal}: InstallModalProps) {
 
             {details}
 
-            <Instructions>
-              <InstructionTitle>{t('Instructions:')}</InstructionTitle>
+            <Flex direction="column" style={{textAlign: 'left', maxWidth: '300px'}}>
+              <Text bold style={{marginBottom: space(1)}}>
+                {t('Instructions:')}
+              </Text>
               <InstructionList>
                 <li>{t('Scan the QR code with your device')}</li>
                 <li>{t('Follow the installation prompts')}</li>
                 <li>{t('The install link will expire in 12 hours')}</li>
               </InstructionList>
-            </Instructions>
+            </Flex>
           </Fragment>
         )}
 
@@ -115,12 +118,6 @@ function InstallModal({projectId, artifactId, closeModal}: InstallModalProps) {
     </Fragment>
   );
 }
-
-const Title = styled('h3')`
-  margin: 0;
-  font-size: 18px;
-  font-weight: 600;
-`;
 
 const QRCodeContainer = styled('div')`
   background: white;
@@ -139,22 +136,6 @@ const CodeSignatureInfo = styled('div')`
   background: ${p => p.theme.backgroundSecondary};
   border-radius: ${space(1)};
   border: 1px solid ${p => p.theme.border};
-`;
-
-const CodeSignatureValue = styled('div')`
-  font-size: 14px;
-  color: ${p => p.theme.subText};
-  margin-bottom: ${space(0.5)};
-`;
-
-const Instructions = styled('div')`
-  text-align: left;
-  max-width: 300px;
-`;
-
-const InstructionTitle = styled('div')`
-  font-weight: 600;
-  margin-bottom: ${space(1)};
 `;
 
 const InstructionList = styled('ul')`

--- a/static/app/views/preprod/header/buildDetailsHeaderContent.tsx
+++ b/static/app/views/preprod/header/buildDetailsHeaderContent.tsx
@@ -1,9 +1,8 @@
-import styled from '@emotion/styled';
-
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {Breadcrumbs, type Crumb} from 'sentry/components/breadcrumbs';
 import {Alert} from 'sentry/components/core/alert';
 import {Button} from 'sentry/components/core/button';
+import {Flex} from 'sentry/components/core/layout';
 import {Heading} from 'sentry/components/core/text';
 import Placeholder from 'sentry/components/placeholder';
 import {IconEllipsis, IconTelescope} from 'sentry/icons';
@@ -28,35 +27,27 @@ export function BuildDetailsHeaderContent(props: BuildDetailsHeaderContentProps)
 
   if (isBuildDetailsPending) {
     return (
-      <HeaderContainer>
+      <Flex direction="column" style={{padding: `0 0 ${space(2)} 0`}}>
         <Placeholder height="20px" width="200px" style={{marginBottom: space(2)}} />
-        <HeaderContent>
+        <Flex align="center" justify="between" gap="md">
           <Heading as="h1">
             <Placeholder height="32px" width="300px" />
           </Heading>
-          <Actions>
+          <Flex align="center" gap="sm" style={{flexShrink: 0}}>
             <Placeholder height="32px" width="120px" style={{marginRight: space(1)}} />
             <Placeholder height="32px" width="40px" />
-          </Actions>
-        </HeaderContent>
-      </HeaderContainer>
+          </Flex>
+        </Flex>
+      </Flex>
     );
   }
 
   if (isBuildDetailsError) {
-    return (
-      <HeaderContainer>
-        <Alert type="error">{buildDetailsError?.message}</Alert>
-      </HeaderContainer>
-    );
+    return <Alert type="error">{buildDetailsError?.message}</Alert>;
   }
 
   if (!buildDetailsData) {
-    return (
-      <HeaderContainer>
-        <Alert type="error">No build details found</Alert>
-      </HeaderContainer>
-    );
+    return <Alert type="error">No build details found</Alert>;
   }
 
   // TODO: Implement proper breadcrumbs once release connection is implemented
@@ -85,13 +76,13 @@ export function BuildDetailsHeaderContent(props: BuildDetailsHeaderContentProps)
   };
 
   return (
-    <HeaderContainer>
+    <Flex direction="column" style={{padding: `0 0 ${space(2)} 0`}}>
       <Breadcrumbs crumbs={breadcrumbs} />
-      <HeaderContent>
+      <Flex align="center" justify="between" gap="md">
         <Heading as="h1">
           v{buildDetailsData.app_info.version} ({buildDetailsData.app_info.build_number})
         </Heading>
-        <Actions>
+        <Flex align="center" gap="sm" style={{flexShrink: 0}}>
           <Button
             size="sm"
             priority="default"
@@ -108,26 +99,8 @@ export function BuildDetailsHeaderContent(props: BuildDetailsHeaderContentProps)
             onClick={handleMoreActions}
             aria-label={'More actions'}
           />
-        </Actions>
-      </HeaderContent>
-    </HeaderContainer>
+        </Flex>
+      </Flex>
+    </Flex>
   );
 }
-
-const HeaderContainer = styled('div')`
-  padding: 0 0 ${space(2)} 0;
-`;
-
-const HeaderContent = styled('div')`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: ${space(2)};
-`;
-
-const Actions = styled('div')`
-  display: flex;
-  align-items: center;
-  gap: ${space(1)};
-  flex-shrink: 0;
-`;

--- a/static/app/views/preprod/sidebar/buildDetailsSidebarAppInfo.tsx
+++ b/static/app/views/preprod/sidebar/buildDetailsSidebarAppInfo.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 import {PlatformIcon} from 'platformicons';
 
+import {Flex} from 'sentry/components/core/layout';
 import {Heading, Text} from 'sentry/components/core/text';
 import {IconClock, IconFile, IconJson, IconLink} from 'sentry/icons';
 import {formatBytesBase10} from 'sentry/utils/bytes/formatBytesBase10';
@@ -29,63 +30,57 @@ export function BuildDetailsSidebarAppInfo(props: BuildDetailsSidebarAppInfoProp
   };
 
   return (
-    <AppInfoContainer>
-      <AppNameHeader>
+    <Flex direction="column" gap="xl">
+      <Flex align="center" gap="sm">
         <AppIcon>
           <AppIconPlaceholder>{props.appInfo.name?.charAt(0) || ''}</AppIconPlaceholder>
         </AppIcon>
         <Heading as="h3">{props.appInfo.name}</Heading>
-      </AppNameHeader>
+      </Flex>
 
       {props.sizeInfo && (
-        <SizeSection>
-          <SizeRow>
-            <SizeItem>
-              <Heading as="h4">Install Size</Heading>
-              <SizeValue>
-                {formatBytesBase10(props.sizeInfo.install_size_bytes)}
-              </SizeValue>
-            </SizeItem>
-            <SizeItem>
-              <Heading as="h4">Download Size</Heading>
-              <SizeValue>
-                {formatBytesBase10(props.sizeInfo.download_size_bytes)}
-              </SizeValue>
-            </SizeItem>
-          </SizeRow>
-        </SizeSection>
+        <Flex gap="sm">
+          <Flex direction="column" gap="xs" style={{flex: 1}}>
+            <Heading as="h4">Install Size</Heading>
+            <Text size="md">{formatBytesBase10(props.sizeInfo.install_size_bytes)}</Text>
+          </Flex>
+          <Flex direction="column" gap="xs" style={{flex: 1}}>
+            <Heading as="h4">Download Size</Heading>
+            <Text size="md">{formatBytesBase10(props.sizeInfo.download_size_bytes)}</Text>
+          </Flex>
+        </Flex>
       )}
 
-      <InfoSection>
-        <InfoItem>
+      <Flex wrap="wrap" gap="md">
+        <Flex gap="2xs" align="center">
           <InfoIcon>
             <PlatformIcon
               platform={getPlatformIconFromPlatform(props.appInfo.platform)}
             />
           </InfoIcon>
           <Text>{getReadablePlatformLabel(props.appInfo.platform)}</Text>
-        </InfoItem>
-        <InfoItem>
+        </Flex>
+        <Flex gap="2xs" align="center">
           <InfoIcon>
             <IconJson />
           </InfoIcon>
           <Text>{props.appInfo.app_id}</Text>
-        </InfoItem>
-        <InfoItem>
+        </Flex>
+        <Flex gap="2xs" align="center">
           <InfoIcon>
             <IconClock />
           </InfoIcon>
           <Text>
             {getFormattedDate(props.appInfo.date_added, 'MM/DD/YYYY [at] hh:mm A')}
           </Text>
-        </InfoItem>
-        <InfoItem>
+        </Flex>
+        <Flex gap="2xs" align="center">
           <InfoIcon>
             <IconFile />
           </InfoIcon>
           <Text>{getReadableArtifactTypeLabel(props.appInfo.artifact_type)}</Text>
-        </InfoItem>
-        <InfoItem>
+        </Flex>
+        <Flex gap="2xs" align="center">
           <InfoIcon>
             <IconLink />
           </InfoIcon>
@@ -96,23 +91,11 @@ export function BuildDetailsSidebarAppInfo(props: BuildDetailsSidebarAppInfoProp
               'Not Installable'
             )}
           </Text>
-        </InfoItem>
-      </InfoSection>
-    </AppInfoContainer>
+        </Flex>
+      </Flex>
+    </Flex>
   );
 }
-
-const AppInfoContainer = styled('div')`
-  display: flex;
-  flex-direction: column;
-  gap: ${p => p.theme.space.xl};
-`;
-
-const AppNameHeader = styled('div')`
-  display: flex;
-  align-items: center;
-  gap: ${p => p.theme.space.sm};
-`;
 
 const AppIcon = styled('div')`
   width: 24px;
@@ -131,46 +114,12 @@ const AppIconPlaceholder = styled('div')`
   font-size: ${p => p.theme.fontSize.sm};
 `;
 
-const InfoSection = styled('div')`
-  display: flex;
-  flex-wrap: wrap;
-  gap: ${p => p.theme.space.md};
-`;
-
-const InfoItem = styled('div')`
-  display: flex;
-  gap: ${p => p.theme.space['2xs']};
-  align-items: center;
-`;
-
 const InfoIcon = styled('div')`
   width: 24px;
   height: 24px;
   display: flex;
   align-items: center;
   justify-content: center;
-`;
-
-const SizeSection = styled('div')`
-  display: flex;
-  flex-direction: column;
-  gap: ${p => p.theme.space.sm};
-`;
-
-const SizeRow = styled('div')`
-  display: flex;
-`;
-
-const SizeItem = styled('div')`
-  display: flex;
-  flex-direction: column;
-  gap: ${p => p.theme.space.xs};
-  flex: 1;
-`;
-
-const SizeValue = styled('div')`
-  font-size: ${p => p.theme.fontSize.md};
-  color: ${p => p.theme.textColor};
 `;
 
 const InstallableLink = styled('button')`

--- a/static/app/views/preprod/sidebar/buildDetailsSidebarContent.tsx
+++ b/static/app/views/preprod/sidebar/buildDetailsSidebarContent.tsx
@@ -1,6 +1,5 @@
-import styled from '@emotion/styled';
-
 import {Alert} from 'sentry/components/core/alert';
+import {Flex} from 'sentry/components/core/layout';
 import {
   KeyValueData,
   type KeyValueDataContentProps,
@@ -26,27 +25,15 @@ export function BuildDetailsSidebarContent(props: BuildDetailsSidebarContentProp
   } = props.buildDetailsQuery;
 
   if (isBuildDetailsPending) {
-    return (
-      <SidebarContainer>
-        <LoadingIndicator />
-      </SidebarContainer>
-    );
+    return <LoadingIndicator />;
   }
 
   if (isBuildDetailsError) {
-    return (
-      <SidebarContainer>
-        <Alert type="error">{buildDetailsError?.message}</Alert>
-      </SidebarContainer>
-    );
+    return <Alert type="error">{buildDetailsError?.message}</Alert>;
   }
 
   if (!buildDetailsData) {
-    return (
-      <SidebarContainer>
-        <Alert type="error">No build details found</Alert>
-      </SidebarContainer>
-    );
+    return <Alert type="error">No build details found</Alert>;
   }
 
   const vcsInfoContentItems: KeyValueDataContentProps[] = [
@@ -95,7 +82,7 @@ export function BuildDetailsSidebarContent(props: BuildDetailsSidebarContentProp
   ];
 
   return (
-    <SidebarContainer>
+    <Flex direction="column" gap="2xl">
       {/* App info */}
       <BuildDetailsSidebarAppInfo
         appInfo={buildDetailsData.app_info}
@@ -106,12 +93,6 @@ export function BuildDetailsSidebarContent(props: BuildDetailsSidebarContentProp
 
       {/* VCS info */}
       <KeyValueData.Card title="Git details" contentItems={vcsInfoContentItems} />
-    </SidebarContainer>
+    </Flex>
   );
 }
-
-const SidebarContainer = styled('div')`
-  display: flex;
-  flex-direction: column;
-  gap: ${p => p.theme.space['2xl']};
-`;


### PR DESCRIPTION
Leverages new Flex, Text & Heading components on the Emerge build details page:

Before:
<img width="1492" height="666" alt="Screenshot 2025-07-28 at 1 03 56 PM" src="https://github.com/user-attachments/assets/7c76e854-71ce-43d5-8be1-3e8501f7335a" />

After (no change as expected):
<img width="1490" height="643" alt="Screenshot 2025-07-28 at 1 01 50 PM" src="https://github.com/user-attachments/assets/63c00429-99dc-4a90-a21e-1aaf57477f99" />
