### PR TITLE
ref(ourlogs): Refactor the code file path renderer to avoid n+1

### DIFF
--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -95,6 +95,13 @@ export type RenderFunctionBaggage = {
   location: Location;
   organization: Organization;
   theme: Theme;
+  /**
+   * If true, all fields that are not needed immediately will not be rendered lazily.
+   * This is useful for fields that require api calls or other side effects to render.
+   *
+   * eg. the code path field in logs requires a call to the stacktrace link api to render.
+   */
+  disableLazyLoad?: boolean;
   eventView?: EventView;
   projectSlug?: string;
   unit?: string;

--- a/static/app/views/explore/hooks/useTraceItemDetails.tsx
+++ b/static/app/views/explore/hooks/useTraceItemDetails.tsx
@@ -15,7 +15,7 @@ import {
   shouldRetryHandler,
 } from 'sentry/views/insights/common/utils/retryHandlers';
 
-const DEFAULT_HOVER_TIMEOUT = 200;
+export const DEFAULT_TRACE_ITEM_HOVER_TIMEOUT = 200;
 
 interface UseTraceItemDetailsProps {
   /**
@@ -182,9 +182,9 @@ export function usePrefetchTraceItemDetailsOnHover({
             },
           }),
           queryFn: fetchDataQuery,
-          staleTime: 30_000,
+          staleTime: Infinity, // Prefetched items are never stale as the row is either entirely stored or not stored at all.
         });
-      }, DEFAULT_HOVER_TIMEOUT);
+      }, DEFAULT_TRACE_ITEM_HOVER_TIMEOUT);
     },
     onHoverEnd: () => {
       if (sharedHoverTimeoutRef.current) {

--- a/static/app/views/explore/logs/constants.tsx
+++ b/static/app/views/explore/logs/constants.tsx
@@ -16,6 +16,7 @@ export const LogAttributesHumanLabel: Partial<Record<OurLogFieldKey, string>> = 
 export const MAX_LOG_INGEST_DELAY = 40_000;
 export const QUERY_PAGE_LIMIT = 1000; // If this does not equal the limit with auto-refresh, the query keys will diverge and they will have separate caches. We may want to make this change in the future.
 export const QUERY_PAGE_LIMIT_WITH_AUTO_REFRESH = 1000;
+export const LOG_ATTRIBUTE_LAZY_LOAD_HOVER_TIMEOUT = 150;
 
 /**
  * These are required fields are always added to the query when fetching the log table.

--- a/static/app/views/explore/logs/fieldRenderers.tsx
+++ b/static/app/views/explore/logs/fieldRenderers.tsx
@@ -206,12 +206,12 @@ function useLazyLoadAttributeOnHover(hoverTimeout: number, props: LogFieldRender
   const hoverTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   const handleMouseEnter = useCallback(() => {
-    if (shouldLoad) {
-      return;
-    }
-
     if (hoverTimeoutRef.current) {
       clearTimeout(hoverTimeoutRef.current);
+    }
+
+    if (shouldLoad) {
+      return;
     }
 
     hoverTimeoutRef.current = setTimeout(() => {

--- a/static/app/views/explore/logs/fieldRenderers.tsx
+++ b/static/app/views/explore/logs/fieldRenderers.tsx
@@ -207,7 +207,7 @@ function useLazyLoadAttributeOnHover(hoverTimeout: number, props: LogFieldRender
 
   const handleMouseEnter = useCallback(() => {
     if (shouldLoad) {
-      return () => {};
+      return;
     }
 
     if (hoverTimeoutRef.current) {
@@ -217,24 +217,14 @@ function useLazyLoadAttributeOnHover(hoverTimeout: number, props: LogFieldRender
     hoverTimeoutRef.current = setTimeout(() => {
       setShouldLoad(true);
     }, hoverTimeout);
-
-    return () => {
-      if (hoverTimeoutRef.current) {
-        clearTimeout(hoverTimeoutRef.current);
-      }
-    };
   }, [hoverTimeout, shouldLoad]);
 
   const handleMouseLeave = useCallback(() => {
-    if (shouldLoad) {
-      return;
-    }
-
     if (hoverTimeoutRef.current) {
       clearTimeout(hoverTimeoutRef.current);
       hoverTimeoutRef.current = null;
     }
-  }, [shouldLoad]);
+  }, []);
 
   useEffect(() => {
     return () => {

--- a/static/app/views/explore/logs/styles.tsx
+++ b/static/app/views/explore/logs/styles.tsx
@@ -165,11 +165,10 @@ export const LogsHighlight = styled(HighlightComponent)`
   margin-left: 2px;
 `;
 
-export const WrappingText = styled('div')<{wrap?: boolean}>`
-  white-space: ${p => (p.wrap ? 'pre-wrap' : 'nowrap')};
+export const WrappingText = styled('div')<{wrapText?: boolean}>`
+  white-space: ${p => (p.wrapText ? 'pre-wrap' : 'nowrap')};
   overflow: hidden;
   text-overflow: ellipsis;
-  ${p => (p.wrap ? '' : '')}
 `;
 
 export const AlignedCellContent = styled('div')<{

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.spec.tsx
@@ -41,18 +41,6 @@ jest.mock('sentry/utils/useRelease', () => ({
   }),
 }));
 
-jest.mock('sentry/components/events/interfaces/frame/useStacktraceLink', () => ({
-  __esModule: true,
-  default: jest.fn().mockReturnValue({
-    data: {
-      sourceUrl: 'https://some-stacktrace-link',
-      integrations: [],
-    },
-    error: null,
-    isPending: false,
-  }),
-}));
-
 jest.mock('@tanstack/react-virtual', () => {
   return {
     useWindowVirtualizer: jest.fn().mockReturnValue({
@@ -101,6 +89,9 @@ describe('LogsInfiniteTable', function () {
       [OurLogKnownFieldKey.RELEASE]: '1.0.0',
       [OurLogKnownFieldKey.CODE_FILE_PATH]:
         '/usr/local/lib/python3.11/dist-packages/gunicorn/glogging.py',
+      [OurLogKnownFieldKey.CODE_LINE_NUMBER]: 123,
+      [OurLogKnownFieldKey.SDK_NAME]: 'sentry.python',
+      [OurLogKnownFieldKey.SDK_VERSION]: '1.0.0',
     }),
     LogFixture({
       [OurLogKnownFieldKey.ORGANIZATION_ID]: Number(organization.id),
@@ -110,6 +101,9 @@ describe('LogsInfiniteTable', function () {
       [OurLogKnownFieldKey.RELEASE]: '1.0.0',
       [OurLogKnownFieldKey.CODE_FILE_PATH]:
         '/usr/local/lib/python3.11/dist-packages/gunicorn/glogging.py',
+      [OurLogKnownFieldKey.CODE_LINE_NUMBER]: 123,
+      [OurLogKnownFieldKey.SDK_NAME]: 'sentry.python',
+      [OurLogKnownFieldKey.SDK_VERSION]: '1.0.0',
     }),
     LogFixture({
       [OurLogKnownFieldKey.ORGANIZATION_ID]: Number(organization.id),
@@ -119,6 +113,9 @@ describe('LogsInfiniteTable', function () {
       [OurLogKnownFieldKey.RELEASE]: '1.0.0',
       [OurLogKnownFieldKey.CODE_FILE_PATH]:
         '/usr/local/lib/python3.11/dist-packages/gunicorn/glogging.py',
+      [OurLogKnownFieldKey.CODE_LINE_NUMBER]: 123,
+      [OurLogKnownFieldKey.SDK_NAME]: 'sentry.python',
+      [OurLogKnownFieldKey.SDK_VERSION]: '1.0.0',
     }),
   ];
 

--- a/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
@@ -1,66 +1,52 @@
-import {LogFixture} from 'sentry-fixture/log';
+import {LogFixture, LogFixtureMeta} from 'sentry-fixture/log';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
+import {ReleaseFixture} from 'sentry-fixture/release';
+import {UserFixture} from 'sentry-fixture/user';
 
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import useStacktraceLink from 'sentry/components/events/interfaces/frame/useStacktraceLink';
+import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
-import {LogsPageParamsProvider} from 'sentry/views/explore/contexts/logs/logsPageParams';
-import type {TraceItemResponseAttribute} from 'sentry/views/explore/hooks/useTraceItemDetails';
+import {
+  LOGS_FIELDS_KEY,
+  LogsPageParamsProvider,
+} from 'sentry/views/explore/contexts/logs/logsPageParams';
+import {LOGS_SORT_BYS_KEY} from 'sentry/views/explore/contexts/logs/sortBys';
+import {
+  DEFAULT_TRACE_ITEM_HOVER_TIMEOUT,
+  type TraceItemResponseAttribute,
+} from 'sentry/views/explore/hooks/useTraceItemDetails';
 import {LogRowContent} from 'sentry/views/explore/logs/tables/logsTableRow';
 import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
-import {useExploreLogsTableRow} from 'sentry/views/explore/logs/useLogsQuery';
-
-jest.mock('sentry/views/explore/logs/useLogsQuery', () => ({
-  useExploreLogsTableRow: jest.fn(),
-  usePrefetchLogTableRowOnHover: jest.fn().mockReturnValue({}),
-  useLogsQueryKeyWithInfinite: jest.fn().mockReturnValue({}),
-}));
-
-jest.mock('sentry/components/events/interfaces/frame/useStacktraceLink', () => ({
-  __esModule: true,
-  default: jest.fn(),
-}));
-
-const mockedUseStacktraceLink = jest.mocked(useStacktraceLink);
-
-jest.mock('sentry/utils/useRelease', () => ({
-  useRelease: jest.fn().mockReturnValue({
-    data: {
-      id: 10,
-      lastCommit: {
-        id: '1e5a9462e6ac23908299b218e18377837297bda1',
-      },
-    },
-  }),
-}));
-const mockedUseExploreLogsTableRow = jest.mocked(useExploreLogsTableRow);
 
 function ProviderWrapper({children}: {children?: React.ReactNode}) {
   return (
     <LogsPageParamsProvider analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}>
-      {children}
+      <table>
+        <tbody>{children}</tbody>
+      </table>
     </LogsPageParamsProvider>
   );
 }
 
 describe('logsTableRow', () => {
+  let stacktraceLinkMock: jest.Mock;
+  let releaseMock: jest.Mock;
+  let rowDetailsMock: jest.Mock;
   const organization = OrganizationFixture({
     features: ['ourlogs-enabled', 'ourlogs-infinite-scroll'],
   });
-
-  const projects = [ProjectFixture()];
+  const project = ProjectFixture();
+  const projects = [project];
+  const release = ReleaseFixture({authors: [UserFixture()]});
   ProjectsStore.loadInitialData(projects);
 
   // These are the values in the actual row - e.g., the ones loaded before you click the row
   const rowData = LogFixture({
-    [OurLogKnownFieldKey.ID]: '1',
-    [OurLogKnownFieldKey.PROJECT_ID]: String(projects[0]!.id),
+    [OurLogKnownFieldKey.PROJECT_ID]: project.id,
     [OurLogKnownFieldKey.ORGANIZATION_ID]: Number(organization.id),
-    [OurLogKnownFieldKey.MESSAGE]: 'test log body',
-    [OurLogKnownFieldKey.SEVERITY]: 'error',
     [OurLogKnownFieldKey.TRACE_ID]: '7b91699f',
   });
 
@@ -72,6 +58,7 @@ describe('logsTableRow', () => {
       [OurLogKnownFieldKey.CODE_FUNCTION_NAME]: 'derp',
       [OurLogKnownFieldKey.CODE_LINE_NUMBER]: '10',
       [OurLogKnownFieldKey.CODE_FILE_PATH]: 'herp/merp/derp.py',
+      [OurLogKnownFieldKey.RELEASE]: release.version, // Needed otherwise stacktrace link will also not load
       [OurLogKnownFieldKey.SDK_NAME]: 'sentry.python',
       [OurLogKnownFieldKey.SDK_VERSION]: '2.27.0',
     }),
@@ -84,44 +71,141 @@ describe('logsTableRow', () => {
       }) as TraceItemResponseAttribute
   );
 
-  it('renders row details', async () => {
-    jest.spyOn(console, 'error').mockImplementation(() => {});
+  const rowDataWithCodeFilePath = LogFixture({
+    [OurLogKnownFieldKey.PROJECT_ID]: project.id,
+    [OurLogKnownFieldKey.ORGANIZATION_ID]: Number(organization.id),
+    // Code file path fields
+    [OurLogKnownFieldKey.CODE_FUNCTION_NAME]: 'derp',
+    [OurLogKnownFieldKey.CODE_LINE_NUMBER]: '10',
+    [OurLogKnownFieldKey.CODE_FILE_PATH]: 'herp/merp/derp.py',
+    [OurLogKnownFieldKey.RELEASE]: release.version, // Needed otherwise stacktrace link will also not load
+  });
 
-    mockedUseExploreLogsTableRow.mockReturnValue({
-      data: {
-        attributes: rowDetails,
+  const initialRouterConfig = {
+    location: {
+      pathname: `/organizations/${organization.slug}/explore/logs/`,
+      query: {
+        [LOGS_FIELDS_KEY]: ['timestamp', 'message'],
+        [LOGS_SORT_BYS_KEY]: '-timestamp',
       },
-      isPending: false,
-    } as unknown as ReturnType<typeof useExploreLogsTableRow>);
+    },
+    route: `/organizations/:orgId/explore/logs/`,
+  };
 
-    mockedUseStacktraceLink.mockReturnValue({
-      data: {
-        sourceUrl: 'https://some-stacktrace-link',
+  const initialRouterConfigWithCodeFilePath = {
+    ...initialRouterConfig,
+    location: {
+      ...initialRouterConfig.location,
+      query: {
+        [LOGS_FIELDS_KEY]: ['timestamp', 'message', OurLogKnownFieldKey.CODE_FILE_PATH],
+        [LOGS_SORT_BYS_KEY]: '-timestamp',
+      },
+    },
+  };
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    MockApiClient.clearMockResponses();
+
+    ProjectsStore.loadInitialData([project]);
+
+    PageFiltersStore.init();
+    PageFiltersStore.onInitializeUrlState(
+      {
+        projects: [parseInt(project.id, 10)],
+        environments: [],
+        datetime: {
+          period: '14d',
+          start: null,
+          end: null,
+          utc: null,
+        },
+      },
+      new Set()
+    );
+
+    stacktraceLinkMock = MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${projects[0]!.slug}/stacktrace-link/`,
+      method: 'GET',
+      body: {
+        sourceUrl: 'https://github.com/example/repo/blob/main/file.py',
         integrations: [],
       },
-      error: null,
-      isPending: false,
-    } as unknown as ReturnType<typeof useStacktraceLink>);
+    });
 
+    releaseMock = MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/releases/${encodeURIComponent(release.version)}/`,
+      body: [release],
+    });
+
+    rowDetailsMock = MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/trace-items/${rowData[OurLogKnownFieldKey.ID]}/`,
+      method: 'GET',
+      body: {
+        itemId: rowData[OurLogKnownFieldKey.ID],
+        links: null,
+        meta: {},
+        timestamp: rowData[OurLogKnownFieldKey.TIMESTAMP],
+        attributes: rowDetails,
+      },
+    });
+  });
+
+  it('hovering the row causes prefetching of the row details', async () => {
+    jest.useFakeTimers();
+    expect(rowDetailsMock).toHaveBeenCalledTimes(0);
     render(
       <ProviderWrapper>
         <LogRowContent
           dataRow={rowData}
           highlightTerms={[]}
-          meta={undefined}
+          meta={LogFixtureMeta(rowData)}
+          sharedHoverTimeoutRef={
+            {current: null} as React.MutableRefObject<NodeJS.Timeout | null>
+          }
+          canDeferRenderElements
+        />
+      </ProviderWrapper>,
+      {organization, initialRouterConfig}
+    );
+
+    expect(screen.queryByLabelText('Toggle trace details')).not.toBeInTheDocument(); // Fake button
+    const row = screen.getByTestId('log-table-row');
+    await userEvent.hover(row, {delay: null});
+
+    expect(rowDetailsMock).toHaveBeenCalledTimes(0);
+    expect(screen.getByLabelText('Toggle trace details')).toBeInTheDocument(); // Real button immediately rendered
+
+    jest.advanceTimersByTime(DEFAULT_TRACE_ITEM_HOVER_TIMEOUT + 1);
+
+    await waitFor(() => {
+      // Prefetching is triggered after the hover timeout
+      expect(rowDetailsMock).toHaveBeenCalledTimes(1);
+    });
+    jest.useRealTimers();
+  });
+
+  it('renders row details', async () => {
+    render(
+      <ProviderWrapper>
+        <LogRowContent
+          dataRow={rowData}
+          highlightTerms={[]}
+          meta={LogFixtureMeta(rowData)}
           sharedHoverTimeoutRef={
             {
               current: null,
             } as React.MutableRefObject<NodeJS.Timeout | null>
           }
+          canDeferRenderElements={false}
         />
       </ProviderWrapper>,
-      {organization}
+      {organization, initialRouterConfig}
     );
 
     // Check that the log body and timestamp are rendered
     expect(screen.getByText('test log body')).toBeInTheDocument();
-    expect(screen.getByText('2025-04-03T15:50:10+00:00')).toBeInTheDocument();
+    expect(screen.getByText('Apr 10, 2025 7:21:10.049 PM')).toBeInTheDocument(); // This is using precise timestamp on log fixture, which overrides passed regular timestamp.
 
     // Check that the span ID is not rendered
     expect(screen.queryByText('span_id')).not.toBeInTheDocument();
@@ -129,6 +213,21 @@ describe('logsTableRow', () => {
     // Expand the row to show the attributes
     const logTableRow = await screen.findByTestId('log-table-row');
     expect(logTableRow).toBeInTheDocument();
+
+    // At this point, useStacktraceLink should not have been called with enabled: true
+    expect(stacktraceLinkMock).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({enabled: true})
+    );
+    expect(releaseMock).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({enabled: true})
+    );
+
+    expect(rowDetailsMock).toHaveBeenCalledTimes(0);
+    expect(stacktraceLinkMock).toHaveBeenCalledTimes(0);
+    expect(releaseMock).toHaveBeenCalledTimes(0);
+
     await userEvent.click(logTableRow);
 
     // Check that there is nothing overflowing in the table row
@@ -146,6 +245,22 @@ describe('logsTableRow', () => {
     }
     expect(hasNoWrapRecursive(logTableRow)).toBe(false);
 
+    await waitFor(() => {
+      expect(rowDetailsMock).toHaveBeenCalledTimes(1);
+    });
+
+    // Even after clicking, useStacktraceLink should be called with enabled: true since the details have disableLazyLoad: true
+    expect(stacktraceLinkMock).toHaveBeenCalledWith(
+      `/projects/${organization.slug}/${project.slug}/stacktrace-link/`,
+      expect.objectContaining({
+        query: expect.objectContaining({
+          lineNo: 10,
+          file: 'herp/merp/derp.py',
+          sdkName: 'sentry.python',
+        }),
+      })
+    );
+
     // Check that the attribute values are rendered
     expect(screen.queryByText(projects[0]!.id)).not.toBeInTheDocument();
     expect(screen.getByText('error')).toBeInTheDocument();
@@ -160,26 +275,89 @@ describe('logsTableRow', () => {
     const traceLink = screen.getByRole('link', {name: '7b91699f'});
     expect(traceLink).toHaveAttribute(
       'href',
-      '/organizations/org-slug/explore/logs/trace/7b91699f/?source=logs&timestamp=1743695410'
+      '/organizations/org-slug/explore/logs/trace/7b91699f/?logsSortBys=-timestamp&source=logs&timestamp=1743695410'
     );
 
-    // Check that stack trace links work
-    expect(mockedUseStacktraceLink).toHaveBeenCalledWith(
-      expect.objectContaining({
-        event: {
-          release: {id: 10, lastCommit: {id: '1e5a9462e6ac23908299b218e18377837297bda1'}},
-          sdk: {name: 'sentry.python', version: '2.27.0'},
-        },
-        frame: {
-          filename: 'herp/merp/derp.py',
-          function: 'derp',
-          lineNo: 10,
-        },
-        orgSlug: 'org-slug',
-        projectSlug: projects[0]!.slug,
-      })
+    // The code file path should be rendered but not as a link until hover
+    expect(screen.getByText('herp/merp/derp.py')).toBeInTheDocument();
+
+    // Verify that useStacktraceLink was not called with enabled: true
+    expect(stacktraceLinkMock).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({enabled: true})
     );
-    const codeLink = screen.getByText('herp/merp/derp.py').closest('a');
-    expect(codeLink).toHaveAttribute('href', 'https://some-stacktrace-link');
+  });
+
+  it('shows a link when hovering over code file path in the table', async () => {
+    render(
+      <ProviderWrapper>
+        <LogRowContent
+          dataRow={rowDataWithCodeFilePath}
+          highlightTerms={[]}
+          meta={LogFixtureMeta(rowDataWithCodeFilePath)}
+          sharedHoverTimeoutRef={
+            {
+              current: null,
+            } as React.MutableRefObject<NodeJS.Timeout | null>
+          }
+          canDeferRenderElements={false}
+        />
+      </ProviderWrapper>,
+      {organization, initialRouterConfig: initialRouterConfigWithCodeFilePath}
+    );
+
+    // Expand the row to show the attributes
+    const logTableRow = await screen.findByTestId('log-table-row');
+    expect(logTableRow).toBeInTheDocument();
+
+    // At this point, useStacktraceLink should not have been called with enabled: true
+    expect(stacktraceLinkMock).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({enabled: true})
+    );
+    expect(releaseMock).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({enabled: true})
+    );
+
+    expect(rowDetailsMock).toHaveBeenCalledTimes(0);
+    expect(stacktraceLinkMock).toHaveBeenCalledTimes(0);
+    expect(releaseMock).toHaveBeenCalledTimes(0);
+
+    // Find the hoverable code path element
+    const codePathElement = await screen.findByTestId('hoverable-code-path');
+    expect(codePathElement).toBeInTheDocument();
+
+    // Verify the file path is displayed
+    const filePath = 'herp/merp/derp.py';
+    expect(screen.getByText(filePath)).toBeInTheDocument();
+
+    // Initially, useStacktraceLink should not have been called with enabled: true
+    expect(stacktraceLinkMock).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({enabled: true})
+    );
+
+    // Hover over the code path
+    await userEvent.hover(codePathElement);
+
+    await waitFor(() => {
+      expect(stacktraceLinkMock).toHaveBeenCalledWith(
+        `/projects/${organization.slug}/${project.slug}/stacktrace-link/`,
+        expect.objectContaining({
+          query: expect.objectContaining({
+            lineNo: 10,
+            file: 'herp/merp/derp.py',
+          }),
+        })
+      );
+    });
+
+    const link = await screen.findByTestId('hoverable-code-path-link');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute(
+      'href',
+      'https://github.com/example/repo/blob/main/file.py'
+    );
   });
 });

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -250,7 +250,12 @@ export const LogRowContent = memo(function LogRowContent({
       <LogTableRow
         data-test-id="log-table-row"
         {...rowInteractProps}
-        onMouseEnter={() => setShouldRenderHoverElements(true)}
+        onMouseEnter={e => {
+          setShouldRenderHoverElements(true);
+          if (rowInteractProps.onMouseEnter) {
+            rowInteractProps.onMouseEnter(e);
+          }
+        }}
       >
         <LogsTableBodyFirstCell key={'first'}>
           <LogFirstCellContent>
@@ -445,6 +450,7 @@ function LogRowDetails({
                     projectSlug,
                     attributes,
                     theme,
+                    disableLazyLoad: true, // We disable lazy loading in the log details view since a user has to open it first.
                   }}
                 />
               </LogAttributeTreeWrapper>

--- a/static/app/views/explore/logs/types.tsx
+++ b/static/app/views/explore/logs/types.tsx
@@ -46,7 +46,7 @@ export enum OurLogKnownFieldKey {
 
 export type OurLogFieldKey = OurLogCustomFieldKey | OurLogKnownFieldKey;
 
-type OurLogsKnownFieldResponseMap = Record<
+export type OurLogsKnownFieldResponseMap = Record<
   (typeof AlwaysPresentLogFields)[number],
   string | number
 > & {

--- a/static/app/views/explore/logs/types.tsx
+++ b/static/app/views/explore/logs/types.tsx
@@ -46,7 +46,7 @@ export enum OurLogKnownFieldKey {
 
 export type OurLogFieldKey = OurLogCustomFieldKey | OurLogKnownFieldKey;
 
-export type OurLogsKnownFieldResponseMap = Record<
+type OurLogsKnownFieldResponseMap = Record<
   (typeof AlwaysPresentLogFields)[number],
   string | number
 > & {

--- a/tests/js/fixtures/log.ts
+++ b/tests/js/fixtures/log.ts
@@ -1,3 +1,4 @@
+import type {EventsMetaType} from 'sentry/utils/discover/eventView';
 import type {OurLogsResponseItem} from 'sentry/views/explore/logs/types';
 import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
 
@@ -24,5 +25,22 @@ export function LogFixture({
     [OurLogKnownFieldKey.TRACE_ID]: traceId,
     [OurLogKnownFieldKey.TIMESTAMP_PRECISE]: timestampPrecise,
     ...rest,
+  };
+}
+
+// Incomplete, only provides type of field if it's a string or number.
+export function LogFixtureMeta(fixture: Partial<OurLogsResponseItem>): EventsMetaType {
+  return {
+    fields: Object.fromEntries(
+      Object.entries(fixture).map(([key, value]) => {
+        const valueType = typeof value;
+        if (!['string', 'number'].includes(valueType)) {
+          throw new Error(`Invalid value type: ${valueType}`);
+        }
+        const type = valueType === 'string' ? 'string' : 'number';
+        return [key, type];
+      })
+    ),
+    units: {},
   };
 }


### PR DESCRIPTION
### Summary
Adding this as a column would cause a lot of headaches for our integration that fetches code links. This PR also cleans up and adds more tests to the log table row spec.


