### PR TITLE
fix(auth-v2): Nonce for CSRF inline-script

### DIFF
--- a/src/sentry/templates/sentry/403-csrf-failure-script.html
+++ b/src/sentry/templates/sentry/403-csrf-failure-script.html
@@ -1,5 +1,6 @@
+{% load sentry_assets %}
+{% script %}
 <script>
-
   const status = document.getElementById('csrf-status');
   const button = document.getElementById('csrf-rotate-btn');
 
@@ -98,3 +99,4 @@
    */
   autoRotateCsrf();
 </script>
+{% endscript %}

--- a/src/sentry/templates/sentry/403-csrf-failure.html
+++ b/src/sentry/templates/sentry/403-csrf-failure.html
@@ -48,7 +48,6 @@
            'same-origin' requests.</p>
         {% endif %}
 
-
         {% include "sentry/403-csrf-failure-script.html" %}
     </section>
 {% endblock %}


### PR DESCRIPTION
Getting this error on production

```
Refused to execute inline script because it violates the following Content 
Security Policy directive: "script-src 'self''unsafe-inline' 'report-sample' 
s1.sentry-cdn.com js.sentry-cdn.com browser.sentry-cdn.com 
<... CDN domains ...> 'nonce-<... hash ...>=='". Note that 'unsafe-inline' 
is ignored if either a hash or nonce value is present in the source list.
```

This is the way we set the nonce on the inline script.