### PR TITLE
Add fields and tests to project events

### DIFF
--- a/src/sentry/issues/endpoints/project_events.py
+++ b/src/sentry/issues/endpoints/project_events.py
@@ -11,14 +11,14 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
+from sentry.api.exceptions import ParseError
 from sentry.api.serializers import EventSerializer, SimpleEventSerializer, serialize
 from sentry.api.serializers.models.event import SimpleEventSerializerResponse
+from sentry.api.utils import InvalidParams, get_date_range_from_params
 from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND, RESPONSE_UNAUTHORIZED
 from sentry.apidocs.examples.event_examples import EventExamples
 from sentry.apidocs.parameters import CursorQueryParam, EventParams, GlobalParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
-from sentry.api.utils import get_date_range_from_params, InvalidParams
-from sentry.api.exceptions import ParseError
 from sentry.models.project import Project
 from sentry.snuba.events import Columns
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
@@ -80,7 +80,7 @@ class ProjectEventsEndpoint(ProjectEndpoint):
             raise ParseError(detail=f"Invalid date range: {e}")
 
         event_filter = eventstore.Filter(conditions=conditions, project_ids=[project.id])
-        
+
         # Apply date filtering based on parameters or feature flag
         if start and end:
             event_filter.start = start

--- a/tests/snuba/api/endpoints/test_project_events.py
+++ b/tests/snuba/api/endpoints/test_project_events.py
@@ -135,15 +135,11 @@ class ProjectEventsTest(APITestCase, SnubaTestCase):
         self.login_as(user=self.user)
 
         project = self.create_project()
-        
+
         # Events outside range
-        self.store_event(
-            data={"timestamp": before_now(days=10).isoformat()}, project_id=project.id
-        )
-        self.store_event(
-            data={"timestamp": before_now(hours=1).isoformat()}, project_id=project.id
-        )
-        
+        self.store_event(data={"timestamp": before_now(days=10).isoformat()}, project_id=project.id)
+        self.store_event(data={"timestamp": before_now(hours=1).isoformat()}, project_id=project.id)
+
         # Events inside range
         event_in_range_1 = self.store_event(
             data={"timestamp": before_now(days=3).isoformat()}, project_id=project.id
@@ -159,10 +155,10 @@ class ProjectEventsTest(APITestCase, SnubaTestCase):
                 "project_id_or_slug": project.slug,
             },
         )
-        
+
         start_time = before_now(days=6).isoformat()
         end_time = before_now(days=2).isoformat()
-        
+
         response = self.client.get(url, {"start": start_time, "end": end_time}, format="json")
 
         assert response.status_code == 200, response.content
@@ -175,12 +171,10 @@ class ProjectEventsTest(APITestCase, SnubaTestCase):
         self.login_as(user=self.user)
 
         project = self.create_project()
-        
+
         # Event outside period
-        self.store_event(
-            data={"timestamp": before_now(days=5).isoformat()}, project_id=project.id
-        )
-        
+        self.store_event(data={"timestamp": before_now(days=5).isoformat()}, project_id=project.id)
+
         # Events inside period
         event_in_period_1 = self.store_event(
             data={"timestamp": before_now(hours=12).isoformat()}, project_id=project.id
@@ -196,7 +190,7 @@ class ProjectEventsTest(APITestCase, SnubaTestCase):
                 "project_id_or_slug": project.slug,
             },
         )
-        
+
         response = self.client.get(url, {"statsPeriod": "1d"}, format="json")
 
         assert response.status_code == 200, response.content
@@ -217,17 +211,17 @@ class ProjectEventsTest(APITestCase, SnubaTestCase):
                 "project_id_or_slug": project.slug,
             },
         )
-        
+
         # Test invalid start parameter only
         response = self.client.get(url, {"start": "invalid-date"}, format="json")
         assert response.status_code == 400
         assert "Invalid date range" in str(response.content)
-        
+
         # Test only providing start without end
         response = self.client.get(url, {"start": before_now(days=1).isoformat()}, format="json")
         assert response.status_code == 400
         assert "start and end are both required" in str(response.content)
-        
+
         # Test only providing end without start
         response = self.client.get(url, {"end": before_now(days=1).isoformat()}, format="json")
         assert response.status_code == 400
@@ -246,7 +240,7 @@ class ProjectEventsTest(APITestCase, SnubaTestCase):
                 "project_id_or_slug": project.slug,
             },
         )
-        
+
         response = self.client.get(url, {"statsPeriod": "invalid-period"}, format="json")
         assert response.status_code == 400
         assert "Invalid date range" in str(response.content)
@@ -256,7 +250,7 @@ class ProjectEventsTest(APITestCase, SnubaTestCase):
         self.login_as(user=self.user)
 
         project = self.create_project()
-        
+
         # Event older than 7 days (feature flag limit) but within statsPeriod
         event_old = self.store_event(
             data={"timestamp": before_now(days=10).isoformat()}, project_id=project.id
@@ -275,7 +269,7 @@ class ProjectEventsTest(APITestCase, SnubaTestCase):
             response = self.client.get(url, format="json")
             assert response.status_code == 200, response.content
             assert len(response.data) == 0
-            
+
             # With statsPeriod parameter, should return old event
             response = self.client.get(url, {"statsPeriod": "14d"}, format="json")
             assert response.status_code == 200, response.content
@@ -287,7 +281,7 @@ class ProjectEventsTest(APITestCase, SnubaTestCase):
         self.login_as(user=self.user)
 
         project = self.create_project()
-        
+
         # Event older than 7 days (feature flag limit) but within start/end range
         event_old = self.store_event(
             data={"timestamp": before_now(days=10).isoformat()}, project_id=project.id
@@ -306,7 +300,7 @@ class ProjectEventsTest(APITestCase, SnubaTestCase):
             response = self.client.get(url, format="json")
             assert response.status_code == 200, response.content
             assert len(response.data) == 0
-            
+
             # With start/end parameters, should return old event
             start_time = before_now(days=15).isoformat()
             end_time = before_now(days=5).isoformat()

--- a/tests/snuba/api/endpoints/test_project_events.py
+++ b/tests/snuba/api/endpoints/test_project_events.py
@@ -129,3 +129,188 @@ class ProjectEventsTest(APITestCase, SnubaTestCase):
         assert [event["eventID"] for event in response.data] == sorted(
             [event_1.event_id, event_2.event_id]
         )
+
+    def test_start_end_parameters(self):
+        """Test filtering events with start and end parameters"""
+        self.login_as(user=self.user)
+
+        project = self.create_project()
+        
+        # Events outside range
+        self.store_event(
+            data={"timestamp": before_now(days=10).isoformat()}, project_id=project.id
+        )
+        self.store_event(
+            data={"timestamp": before_now(hours=1).isoformat()}, project_id=project.id
+        )
+        
+        # Events inside range
+        event_in_range_1 = self.store_event(
+            data={"timestamp": before_now(days=3).isoformat()}, project_id=project.id
+        )
+        event_in_range_2 = self.store_event(
+            data={"timestamp": before_now(days=5).isoformat()}, project_id=project.id
+        )
+
+        url = reverse(
+            "sentry-api-0-project-events",
+            kwargs={
+                "organization_id_or_slug": project.organization.slug,
+                "project_id_or_slug": project.slug,
+            },
+        )
+        
+        start_time = before_now(days=6).isoformat()
+        end_time = before_now(days=2).isoformat()
+        
+        response = self.client.get(url, {"start": start_time, "end": end_time}, format="json")
+
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 2
+        event_ids = {event["eventID"] for event in response.data}
+        assert event_ids == {event_in_range_1.event_id, event_in_range_2.event_id}
+
+    def test_stats_period_parameter(self):
+        """Test filtering events with statsPeriod parameter"""
+        self.login_as(user=self.user)
+
+        project = self.create_project()
+        
+        # Event outside period
+        self.store_event(
+            data={"timestamp": before_now(days=5).isoformat()}, project_id=project.id
+        )
+        
+        # Events inside period
+        event_in_period_1 = self.store_event(
+            data={"timestamp": before_now(hours=12).isoformat()}, project_id=project.id
+        )
+        event_in_period_2 = self.store_event(
+            data={"timestamp": before_now(hours=6).isoformat()}, project_id=project.id
+        )
+
+        url = reverse(
+            "sentry-api-0-project-events",
+            kwargs={
+                "organization_id_or_slug": project.organization.slug,
+                "project_id_or_slug": project.slug,
+            },
+        )
+        
+        response = self.client.get(url, {"statsPeriod": "1d"}, format="json")
+
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 2
+        event_ids = {event["eventID"] for event in response.data}
+        assert event_ids == {event_in_period_1.event_id, event_in_period_2.event_id}
+
+    def test_invalid_start_end_parameters(self):
+        """Test error handling for invalid start/end parameters"""
+        self.login_as(user=self.user)
+
+        project = self.create_project()
+
+        url = reverse(
+            "sentry-api-0-project-events",
+            kwargs={
+                "organization_id_or_slug": project.organization.slug,
+                "project_id_or_slug": project.slug,
+            },
+        )
+        
+        # Test invalid start parameter only
+        response = self.client.get(url, {"start": "invalid-date"}, format="json")
+        assert response.status_code == 400
+        assert "Invalid date range" in str(response.content)
+        
+        # Test only providing start without end
+        response = self.client.get(url, {"start": before_now(days=1).isoformat()}, format="json")
+        assert response.status_code == 400
+        assert "start and end are both required" in str(response.content)
+        
+        # Test only providing end without start
+        response = self.client.get(url, {"end": before_now(days=1).isoformat()}, format="json")
+        assert response.status_code == 400
+        assert "start and end are both required" in str(response.content)
+
+    def test_invalid_stats_period_parameter(self):
+        """Test error handling for invalid statsPeriod parameter"""
+        self.login_as(user=self.user)
+
+        project = self.create_project()
+
+        url = reverse(
+            "sentry-api-0-project-events",
+            kwargs={
+                "organization_id_or_slug": project.organization.slug,
+                "project_id_or_slug": project.slug,
+            },
+        )
+        
+        response = self.client.get(url, {"statsPeriod": "invalid-period"}, format="json")
+        assert response.status_code == 400
+        assert "Invalid date range" in str(response.content)
+
+    def test_stats_period_overrides_feature_flag(self):
+        """Test that statsPeriod parameter overrides the feature flag date limit"""
+        self.login_as(user=self.user)
+
+        project = self.create_project()
+        
+        # Event older than 7 days (feature flag limit) but within statsPeriod
+        event_old = self.store_event(
+            data={"timestamp": before_now(days=10).isoformat()}, project_id=project.id
+        )
+
+        url = reverse(
+            "sentry-api-0-project-events",
+            kwargs={
+                "organization_id_or_slug": project.organization.slug,
+                "project_id_or_slug": project.slug,
+            },
+        )
+
+        with self.feature("organizations:project-event-date-limit"):
+            # With feature flag but no statsPeriod, should not return old event
+            response = self.client.get(url, format="json")
+            assert response.status_code == 200, response.content
+            assert len(response.data) == 0
+            
+            # With statsPeriod parameter, should return old event
+            response = self.client.get(url, {"statsPeriod": "14d"}, format="json")
+            assert response.status_code == 200, response.content
+            assert len(response.data) == 1
+            assert response.data[0]["eventID"] == event_old.event_id
+
+    def test_start_end_overrides_feature_flag(self):
+        """Test that start/end parameters override the feature flag date limit"""
+        self.login_as(user=self.user)
+
+        project = self.create_project()
+        
+        # Event older than 7 days (feature flag limit) but within start/end range
+        event_old = self.store_event(
+            data={"timestamp": before_now(days=10).isoformat()}, project_id=project.id
+        )
+
+        url = reverse(
+            "sentry-api-0-project-events",
+            kwargs={
+                "organization_id_or_slug": project.organization.slug,
+                "project_id_or_slug": project.slug,
+            },
+        )
+
+        with self.feature("organizations:project-event-date-limit"):
+            # With feature flag but no date parameters, should not return old event
+            response = self.client.get(url, format="json")
+            assert response.status_code == 200, response.content
+            assert len(response.data) == 0
+            
+            # With start/end parameters, should return old event
+            start_time = before_now(days=15).isoformat()
+            end_time = before_now(days=5).isoformat()
+            response = self.client.get(url, {"start": start_time, "end": end_time}, format="json")
+            assert response.status_code == 200, response.content
+            assert len(response.data) == 1
+            assert response.data[0]["eventID"] == event_old.event_id


### PR DESCRIPTION
Adds `start`, `end`, and `statsPeriod` query parameters to the Project Events endpoint (`/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/events/`).

This allows users to filter events by a specific date range. The new parameters take precedence over the existing 7-day feature flag limit. Comprehensive tests have been added to cover valid usage, invalid parameters, and precedence.