### PR TITLE
fix(aci): cast member/team ids to strings for automation builder selectors

### DIFF
--- a/static/app/views/automations/components/actionFilters/assignedTo.tsx
+++ b/static/app/views/automations/components/actionFilters/assignedTo.tsx
@@ -85,10 +85,14 @@ function IdentifierField() {
         <TeamSelector
           name={`${condition_id}.data.targetIdentifier`}
           aria-label={t('Team')}
-          value={condition.comparison.targetIdentifier}
+          value={String(condition.comparison.targetIdentifier)}
           onChange={(option: SelectValue<string>) => {
             onUpdate({
-              comparison: {...condition.comparison, targetIdentifier: option.value},
+              comparison: {
+                ...condition.comparison,
+                // Backend expects a number
+                targetIdentifier: Number(option.value),
+              },
             });
             removeError(condition.id);
           }}
@@ -106,10 +110,14 @@ function IdentifierField() {
           organization={organization}
           key={`${condition_id}.data.targetIdentifier`}
           aria-label={t('Member')}
-          value={condition.comparison.targetIdentifier}
+          value={String(condition.comparison.targetIdentifier)}
           onChange={(value: any) => {
             onUpdate({
-              comparison: {...condition.comparison, targetIdentifier: value.actor.id},
+              comparison: {
+                ...condition.comparison,
+                // Backend expects a number
+                targetIdentifier: Number(value.actor.id),
+              },
             });
             removeError(condition.id);
           }}


### PR DESCRIPTION
the `<TeamSelector>` and `<SelectMembers>` selectors for the "Issue is assigned to ___" condition expect team/member ids to be strings while the backend returns them as ints, so we need to cast them