### PR TITLE
feat(trace-eap-waterfall): Checking for valid event uuid

### DIFF
--- a/static/app/components/events/interfaces/performance/eventTraceView.tsx
+++ b/static/app/components/events/interfaces/performance/eventTraceView.tsx
@@ -66,6 +66,7 @@ function EventTraceViewInner({event, organization, traceId}: EventTraceViewInner
     timestamp,
     traceSlug: traceId,
     limit: 10000,
+    targetEventId: event.id,
   });
   const params = useTraceQueryParams({
     timestamp,

--- a/static/app/components/events/interfaces/performance/spanEvidenceTraceView.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceTraceView.tsx
@@ -81,6 +81,7 @@ function SpanEvidenceTraceViewImpl({
     timestamp,
     traceSlug: traceId,
     limit: 10000,
+    targetEventId: event.id,
   });
   const tree = useIssuesTraceTree({trace, replay: null});
 

--- a/static/app/views/performance/newTraceDetails/traceApi/useTrace.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTrace.spec.tsx
@@ -1,0 +1,171 @@
+import {QueryClientProvider} from '@tanstack/react-query';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {makeTestQueryClient} from 'sentry-test/queryClient';
+import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {OrganizationContext} from 'sentry/views/organizationContext';
+
+import {useTrace} from './useTrace';
+
+jest.mock('sentry/views/performance/newTraceDetails/useIsEAPTraceEnabled', () => ({
+  useIsEAPTraceEnabled: jest.fn(),
+}));
+
+const {useIsEAPTraceEnabled} = jest.requireMock(
+  'sentry/views/performance/newTraceDetails/useIsEAPTraceEnabled'
+);
+
+const organization = OrganizationFixture();
+const queryClient = makeTestQueryClient();
+
+describe('useTrace', () => {
+  beforeEach(() => {
+    queryClient.clear();
+    jest.clearAllMocks();
+    MockApiClient.clearMockResponses();
+  });
+
+  const wrapper = ({children}: {children: React.ReactNode}) => (
+    <QueryClientProvider client={queryClient}>
+      <OrganizationContext value={organization}>{children}</OrganizationContext>
+    </QueryClientProvider>
+  );
+
+  describe('tracing endpoint query params', () => {
+    const validUUid = '550e8400e29b41d4a716446655440000';
+    const invalidUUid = 'notAuuid';
+
+    it.each([
+      [`?targetId=${invalidUUid}`],
+      ['?targetId='],
+      ['?someOtherParam=foo'],
+      [`?eventId=${invalidUUid}`],
+      [`?node=txn-${invalidUUid}`],
+      [`?node=span-${invalidUUid}`],
+      [`?node=error-${invalidUUid}`],
+    ])('does NOT call EAP endpoint with errorId when URL has %s', async search => {
+      // Set up mocked URL before hook runs
+      window.history.pushState({}, '', `/some-path${search}`);
+
+      // Set up EAP enabled
+      useIsEAPTraceEnabled.mockReturnValue(true);
+
+      const eapTraceMock = MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/trace/test-trace-id/`,
+        method: 'GET',
+        body: [],
+      });
+
+      renderHook(
+        () =>
+          useTrace({
+            traceSlug: 'test-trace-id',
+          }),
+        {wrapper}
+      );
+
+      // Wait for the hook to make the API call
+      await waitFor(() => {
+        expect(eapTraceMock).toHaveBeenCalled();
+      });
+
+      // Verify the API was called without errorId in the query params
+      expect(eapTraceMock).toHaveBeenCalledWith(
+        `/organizations/${organization.slug}/trace/test-trace-id/`,
+        expect.objectContaining({
+          query: expect.not.objectContaining({
+            errorId: expect.anything(),
+          }),
+        })
+      );
+    });
+
+    it.each([
+      {
+        search: `?targetId=${validUUid}`, // EAP endpoint
+        mockEapEnabled: true,
+        endpoint: 'trace',
+        expectedParamKey: 'errorId',
+      },
+      {
+        search: `?eventId=${validUUid}`, // EAP endpoint
+        mockEapEnabled: true,
+        endpoint: 'trace',
+        expectedParamKey: 'errorId',
+      },
+      {
+        search: `?node=error-${validUUid}`, // EAP endpoint
+        mockEapEnabled: true,
+        endpoint: 'trace',
+        expectedParamKey: 'errorId',
+      },
+      {
+        search: `?node=txn-${validUUid}`, // EAP endpoint
+        mockEapEnabled: true,
+        endpoint: 'trace',
+        expectedParamKey: 'errorId',
+      },
+      {
+        search: `?targetId=${validUUid}`, // non-EAP endpoint
+        mockEapEnabled: false,
+        endpoint: 'events-trace',
+        expectedParamKey: 'targetId',
+      },
+      {
+        search: `?eventId=${validUUid}`, // non-EAP endpoint
+        mockEapEnabled: false,
+        endpoint: 'events-trace',
+        expectedParamKey: 'targetId',
+      },
+      {
+        search: `?node=error-${validUUid}`, // non-EAP endpoint
+        mockEapEnabled: false,
+        endpoint: 'events-trace',
+        expectedParamKey: 'targetId',
+      },
+      {
+        search: `?node=txn-${validUUid}`, // non-EAP endpoint
+        mockEapEnabled: false,
+        endpoint: 'events-trace',
+        expectedParamKey: 'targetId',
+      },
+    ])(
+      'calls tracing endpoint with query param options %s',
+      async ({search, mockEapEnabled, endpoint, expectedParamKey}) => {
+        // Mock URL before hook runs
+        window.history.pushState({}, '', `/some-path${search}`);
+
+        // Mock EAP toggle
+        useIsEAPTraceEnabled.mockReturnValue(mockEapEnabled);
+
+        const eapTraceMock = MockApiClient.addMockResponse({
+          url: `/organizations/${organization.slug}/${endpoint}/trace-test-id/`,
+          method: 'GET',
+          body: [],
+        });
+
+        renderHook(
+          () =>
+            useTrace({
+              traceSlug: 'trace-test-id',
+            }),
+          {wrapper}
+        );
+
+        await waitFor(() => {
+          expect(eapTraceMock).toHaveBeenCalled();
+        });
+
+        expect(eapTraceMock).toHaveBeenCalledWith(
+          `/organizations/${organization.slug}/${endpoint}/trace-test-id/`,
+          expect.objectContaining({
+            query: expect.objectContaining({
+              [expectedParamKey]: validUUid,
+            }),
+          })
+        );
+      }
+    );
+  });
+});

--- a/static/app/views/performance/newTraceDetails/traceApi/useTrace.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTrace.tsx
@@ -20,39 +20,39 @@ import {useIsEAPTraceEnabled} from 'sentry/views/performance/newTraceDetails/use
 const DEFAULT_TIMESTAMP_LIMIT = 10_000;
 const DEFAULT_LIMIT = 1_000;
 
-export function getTraceQueryParams(
-  query: Location['query'],
-  filters?: Partial<PageFilters>,
-  options: {limit?: number; timestamp?: number} = {}
-): {
+type TraceQueryParams = {
   limit: number;
-  targetId: string | undefined;
-  timestamp: string | undefined;
   demo?: string;
   pageEnd?: string;
   pageStart?: string;
   statsPeriod?: string;
-} {
+  timestamp?: string;
+} & ({targetId: string | undefined} | {errorId: string | undefined});
+
+export function getTraceQueryParams(
+  traceType: 'eap' | 'non-eap',
+  query: Location['query'],
+  filters?: Partial<PageFilters>,
+  options: {limit?: number; targetId?: string; timestamp?: number} = {}
+): TraceQueryParams {
   const normalizedParams = normalizeDateTimeParams(query, {
     allowAbsolutePageDatetime: true,
   });
   const statsPeriod = decodeScalar(normalizedParams.statsPeriod);
   const demo = decodeScalar(normalizedParams.demo);
+
   const timestamp = options.timestamp ?? decodeScalar(normalizedParams.timestamp);
   let limit = options.limit ?? decodeScalar(normalizedParams.limit);
   if (typeof limit === 'string') {
     limit = parseInt(limit, 10);
   }
-
-  const targetId = decodeScalar(normalizedParams.targetId ?? normalizedParams.eventId);
-
   if (timestamp) {
     limit = limit ?? DEFAULT_TIMESTAMP_LIMIT;
   } else {
     limit = limit ?? DEFAULT_LIMIT;
   }
 
-  const otherParams: Record<string, string | string[] | undefined | null> = {
+  const timeRangeParams: Record<string, string | string[] | undefined | null> = {
     end: normalizedParams.pageEnd,
     start: normalizedParams.pageStart,
     statsPeriod: statsPeriod || filters?.datetime?.period,
@@ -61,16 +61,39 @@ export function getTraceQueryParams(
   // We prioritize timestamp over statsPeriod as it makes the query more specific, faster
   // and not prone to time drift issues.
   if (timestamp) {
-    delete otherParams.statsPeriod;
+    delete timeRangeParams.statsPeriod;
   }
 
+  // Node params occur in the format `${event-type}-${eventId}`, where the most relevant event is the last one in the array.
+  // If not an array, it is a string with the same format.
+  const nodeParams = normalizedParams.node;
+  const targetIdFromNodeParams = Array.isArray(nodeParams)
+    ? nodeParams[nodeParams.length - 1]?.split('-')[1]
+    : typeof nodeParams === 'string'
+      ? nodeParams.split('-')[1]
+      : undefined;
+
+  // We try our best to pass a target event id to the trace query.
+  // We first check if targetId is passed in the options, then we check for
+  // targetId/eventId in the query params, lastly we check for the node params.
+  const targetId =
+    options.targetId ??
+    decodeScalar(normalizedParams.targetId ?? normalizedParams.eventId) ??
+    targetIdFromNodeParams;
+
+  const targetEventParams:
+    | {targetId: string | undefined}
+    | {errorId: string | undefined} =
+    traceType === 'eap' ? {errorId: targetId} : {targetId};
+
   const queryParams = {
-    ...otherParams,
+    ...timeRangeParams,
+    ...targetEventParams,
     demo,
     limit,
     timestamp: timestamp?.toString(),
-    targetId,
   };
+
   for (const key in queryParams) {
     if (
       queryParams[key as keyof typeof queryParams] === '' ||
@@ -169,24 +192,39 @@ function useDemoTrace(
   >;
 }
 
-type UseTraceParams = {
+type UseTraceOptions = {
   additionalAttributes?: string[];
   limit?: number;
+  /**
+   * When passed we make sure that the corresponding event is a part of the trace (if it exists)
+   * irrespective of the trace query count limit.
+   */
+  targetEventId?: string;
   timestamp?: number;
   traceSlug?: string;
 };
 
 export function useTrace(
-  options: UseTraceParams
+  options: UseTraceOptions
 ): UseApiQueryResult<TraceTree.Trace, RequestError> {
   const filters = usePageFilters();
   const organization = useOrganization();
   const query = qs.parse(location.search);
+
+  const isEAPEnabled = useIsEAPTraceEnabled();
+  const hasValidTrace = Boolean(options.traceSlug && organization.slug);
+
   const queryParams = useMemo(() => {
-    return getTraceQueryParams(query, filters.selection, {
-      limit: options.limit,
-      timestamp: options.timestamp,
-    });
+    return getTraceQueryParams(
+      isEAPEnabled ? 'eap' : 'non-eap',
+      query,
+      filters.selection,
+      {
+        limit: options.limit,
+        timestamp: options.timestamp,
+        targetId: options.targetEventId,
+      }
+    );
 
     // Only re-run this if the view query param changes, otherwise if we pass location.search
     // as a dependency, the query will re-run every time we perform actions on the trace view; like
@@ -195,9 +233,6 @@ export function useTrace(
   }, [options.limit, options.timestamp, query.trace_format]);
 
   const isDemoMode = Boolean(queryParams.demo);
-  const isEAPEnabled = useIsEAPTraceEnabled();
-  const hasValidTrace = Boolean(options.traceSlug && organization.slug);
-
   const demoTrace = useDemoTrace(queryParams.demo, organization);
 
   const traceQuery = useApiQuery<TraceSplitResults<TraceTree.Transaction>>(

--- a/static/app/views/performance/newTraceDetails/traceApi/useTrace.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTrace.tsx
@@ -230,7 +230,13 @@ export function useTrace(
     // as a dependency, the query will re-run every time we perform actions on the trace view; like
     // clicking on a span, that updates the url.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [options.limit, options.timestamp, query.trace_format]);
+  }, [
+    options.limit,
+    options.timestamp,
+    options.targetEventId,
+    isEAPEnabled,
+    filters.selection,
+  ]);
 
   const isDemoMode = Boolean(queryParams.demo);
   const demoTrace = useDemoTrace(queryParams.demo, organization);

--- a/static/app/views/performance/newTraceDetails/traceApi/utils.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/utils.tsx
@@ -106,3 +106,9 @@ export const isTraceItemDetailsResponse = (
 ): data is TraceItemDetailsResponse => {
   return data !== undefined && 'attributes' in data;
 };
+
+export const isValidEventUUID = (id: string): boolean => {
+  const uuidRegex =
+    /^[0-9a-f]{8}[0-9a-f]{4}[1-5][0-9a-f]{3}[89ab][0-9a-f]{3}[0-9a-f]{12}$/i;
+  return uuidRegex.test(id);
+};

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
@@ -2215,7 +2215,7 @@ export class TraceTree extends TraceTreeEventDispatcher {
               {
                 orgSlug: organization.slug,
                 query: qs.stringify(
-                  getTraceQueryParams(urlParams, filters.selection, {
+                  getTraceQueryParams(options.type, urlParams, filters.selection, {
                     timestamp: batchTraceData.timestamp,
                   })
                 ),


### PR DESCRIPTION
Duplicate of recently reverted PR: https://github.com/getsentry/sentry/pull/96501

Change: When passing target `errorId` to the new /trace/ endpoint we check for a valid uuid. If it's invalid we refrain from passing and targetting params on. 

Made sure that the the non eap /events-trace/ endpoint has no target id format constraint

Depends on: https://github.com/getsentry/sentry/pull/96827