### PR TITLE
:wrench: chore(aci): logs in status change consumer

### DIFF
--- a/src/sentry/issues/status_change_consumer.py
+++ b/src/sentry/issues/status_change_consumer.py
@@ -61,6 +61,10 @@ def update_status(group: Group, status_change: StatusChangeMessageData) -> None:
             return
 
     if new_status == GroupStatus.RESOLVED:
+        logger.info(
+            "group.update_status.resolved",
+            extra={**log_extra, "group_id": group.id},
+        )
         activity_type = ActivityType.SET_RESOLVED
         Group.objects.update_group_status(
             groups=[group],
@@ -151,6 +155,10 @@ def update_status(group: Group, status_change: StatusChangeMessageData) -> None:
 
         This is used to trigger the `workflow_engine` processing status changes.
         """
+        logger.info(
+            "group.update_status.activity_type",
+            extra={**log_extra, "activity_type": activity_type.value, "group_id": group.id},
+        )
         latest_activity = (
             Activity.objects.filter(group_id=group.id, type=activity_type.value)
             .order_by("-datetime")


### PR DESCRIPTION
for some reason, we aren't triggering the activity task for resolutions. something is wrong before we invoke the status update handlers since we aren't getting any metrics for `workflow_engine.issue_platform.status_change_handler`