### PR TITLE
fix(hybridcloud) Continue to track down write volume from sentryapps

### DIFF
--- a/src/sentry/hybridcloud/models/cacheversion.py
+++ b/src/sentry/hybridcloud/models/cacheversion.py
@@ -1,14 +1,9 @@
-import logging
-import random
-
 from django.db import models, router, transaction
 from django.db.models import F
 
 from sentry.backup.scopes import RelocationScope
 from sentry.db.models import Model, control_silo_model, region_silo_model
 from sentry.db.postgres.transactions import enforce_constraints
-
-logger = logging.getLogger(__name__)
 
 
 class CacheVersionBase(Model):
@@ -21,8 +16,6 @@ class CacheVersionBase(Model):
     @classmethod
     def incr_version(cls, key: str) -> int:
         with enforce_constraints(transaction.atomic(router.db_for_write(cls))):
-            if random.random() < 0.01:
-                logger.info("cacheversion.incr_version", extra={"key": key})
             cls.objects.create_or_update(
                 key=key, defaults=dict(version=1), values=dict(version=F("version") + 1)
             )

--- a/src/sentry/hybridcloud/rpc/caching/service.py
+++ b/src/sentry/hybridcloud/rpc/caching/service.py
@@ -3,10 +3,12 @@
 # in modules such as this one where hybrid cloud data models or service classes are
 # defined, because we want to reflect on type annotations and avoid forward references.
 import abc
+import random
 from collections.abc import Callable, Generator, Mapping
 from typing import TYPE_CHECKING, Generic, TypeVar
 
 import pydantic
+import sentry_sdk
 
 from sentry.hybridcloud.rpc.resolvers import ByRegionName
 from sentry.hybridcloud.rpc.service import RpcService, regional_rpc_method, rpc_method
@@ -162,7 +164,18 @@ class SiloCacheBackedListCallable(Generic[_R]):
             try:
                 metrics.incr("hybridcloud.caching.list.cached", tags={"base_key": self.base_key})
                 return [self.type_(**item) for item in json.loads(value)]
-            except (pydantic.ValidationError, JSONDecodeError, TypeError):
+            except (pydantic.ValidationError, JSONDecodeError, TypeError) as err:
+                metrics.incr(
+                    "hybridcloud.caching.list.failed_read",
+                    tags={
+                        "base_key": self.base_key,
+                        "err": type(err).__name__,
+                    },
+                )
+                if random.random() < 0.001:
+                    with sentry_sdk.isolation_scope() as scope:
+                        scope.set_level("warning")
+                        sentry_sdk.capture_exception(err)
                 version = yield from _delete_cache(key, self.silo_mode)
         else:
             version = value


### PR DESCRIPTION
Continue the work started in #96440 to track down why we're getting higher than expected write volumes to regioncache.

Based on the writes coming from the sentryapp + product workers and not RPC web pods, my next theory is that we're getting invalid/incomplete data back from cache and hitting this delete.
