### PR TITLE
feat(rr6): Add deprecatedRouterProps to route objects

### DIFF
--- a/static/app/components/route.tsx
+++ b/static/app/components/route.tsx
@@ -12,10 +12,10 @@ interface BaseRouteObject {
    * Only enable this route when USING_CUSTOMER_DOMAIN is enabled
    */
   customerDomainOnlyRoute?: true;
-  // XXX(epurkhiser): In the future we can introduce a `requiresLegacyProps`
-  // prop here that will pass in the react-router 3 style routing props. We can
-  // use this as a way to slowly get rid of react router 3 style prosp in favor
-  // of using the route hooks.
+  /**
+   * Injects react router 3 style router props to the component.
+   * Including an `Outlet` component as a child element.
+   */
   deprecatedRouteProps?: never;
   /**
    * Is a index route
@@ -82,7 +82,7 @@ interface DeprecatedPropRoute extends Omit<BaseRouteObject, 'deprecatedRouteProp
 
 interface RouteObject extends BaseRouteObject {
   /**
-   * A react component to render. Components that expect RouteComponentProps are 
+   * A react component to render. Components that expect RouteComponentProps are
    * not allowed here. Use deprecatedRouteProps: true on legacy components. New
    * components should use the `use{Params,Location}` hooks.
    * Components that expect RouteComponentProps are not allowed here - use deprecatedRouteProps: true instead.

--- a/static/app/components/route.tsx
+++ b/static/app/components/route.tsx
@@ -12,6 +12,11 @@ interface BaseRouteObject {
    * Only enable this route when USING_CUSTOMER_DOMAIN is enabled
    */
   customerDomainOnlyRoute?: true;
+  // XXX(epurkhiser): In the future we can introduce a `requiresLegacyProps`
+  // prop here that will pass in the react-router 3 style routing props. We can
+  // use this as a way to slowly get rid of react router 3 style prosp in favor
+  // of using the route hooks.
+  deprecatedRouteProps?: never;
   /**
    * Is a index route
    */
@@ -48,11 +53,6 @@ interface BaseRouteObject {
    * withDomainRedirect respectively.
    */
   withOrgPath?: boolean;
-
-  // XXX(epurkhiser): In the future we can introduce a `requiresLegacyProps`
-  // prop here that will pass in the react-router 3 style routing props. We can
-  // use this as a way to slowly get rid of react router 3 style prosp in favor
-  // of using the route hooks.
 }
 
 /**
@@ -69,7 +69,7 @@ type NoRouteProps = {
   routes?: never;
 };
 
-interface DeprecatedPropRoute extends BaseRouteObject {
+interface DeprecatedPropRoute extends Omit<BaseRouteObject, 'deprecatedRouteProps'> {
   /**
    * A react component that accepts legacy router props (location, params, router, etc.)
    */

--- a/static/app/components/route.tsx
+++ b/static/app/components/route.tsx
@@ -71,13 +71,13 @@ type NoRouteProps = {
 
 interface DeprecatedPropRoute extends BaseRouteObject {
   /**
+   * A react component that accepts legacy router props (location, params, router, etc.)
+   */
+  component: React.ComponentType<any>;
+  /**
    * Passes legacy route props to the component.
    */
   deprecatedRouteProps: true;
-  /**
-   * A react component that accepts legacy router props (location, params, router, etc.)
-   */
-  component?: React.ComponentType<any>;
 }
 
 interface RouteObject extends BaseRouteObject {
@@ -85,11 +85,11 @@ interface RouteObject extends BaseRouteObject {
    * A react component to render or a import promise that will be lazily loaded.
    * Components that expect RouteComponentProps are not allowed here - use deprecatedRouteProps: true instead.
    */
-  component?: React.ComponentType<NoRouteProps>;
-  /**
-   * Passes legacy route props to the component.
-   */
-  deprecatedRouteProps?: never;
+  component: React.ComponentType<NoRouteProps>;
 }
 
-export type SentryRouteObject = RouteObject | DeprecatedPropRoute;
+interface NoComponentRoute extends BaseRouteObject {
+  component?: never;
+}
+
+export type SentryRouteObject = RouteObject | DeprecatedPropRoute | NoComponentRoute;

--- a/static/app/components/route.tsx
+++ b/static/app/components/route.tsx
@@ -82,7 +82,7 @@ interface DeprecatedPropRoute extends Omit<BaseRouteObject, 'deprecatedRouteProp
 
 interface RouteObject extends BaseRouteObject {
   /**
-   * A react component to render. Components that expect RouteComponentProps are 
+   * A react component to render. Components that expect RouteComponentProps are
    * not allowed here. Use deprecatedRouteProps: true on legacy components. New
    * components should use the `use{Params,Location}` hooks.
    * Components that expect RouteComponentProps are not allowed here - use deprecatedRouteProps: true instead.

--- a/static/app/components/route.tsx
+++ b/static/app/components/route.tsx
@@ -82,7 +82,9 @@ interface DeprecatedPropRoute extends Omit<BaseRouteObject, 'deprecatedRouteProp
 
 interface RouteObject extends BaseRouteObject {
   /**
-   * A react component to render or a import promise that will be lazily loaded.
+   * A react component to render. Components that expect RouteComponentProps are 
+   * not allowed here. Use deprecatedRouteProps: true on legacy components. New
+   * components should use the `use{Params,Location}` hooks.
    * Components that expect RouteComponentProps are not allowed here - use deprecatedRouteProps: true instead.
    */
   component: React.ComponentType<NoRouteProps>;

--- a/static/app/components/route.tsx
+++ b/static/app/components/route.tsx
@@ -3,15 +3,11 @@
  * routing object in that it doesn't take a rendered component, but instead a
  * component type and handles the rendering itself.
  */
-export interface SentryRouteObject {
+interface BaseRouteObject {
   /**
    * child components to render under this route
    */
   children?: SentryRouteObject[];
-  /**
-   * A react component to render or a import promise that will be lazily loaded
-   */
-  component?: React.ComponentType<any>;
   /**
    * Only enable this route when USING_CUSTOMER_DOMAIN is enabled
    */
@@ -58,3 +54,42 @@ export interface SentryRouteObject {
   // use this as a way to slowly get rid of react router 3 style prosp in favor
   // of using the route hooks.
 }
+
+/**
+ * Enforces that these props are not expected by the component.
+ */
+type NoRouteProps = {
+  [key: string | number | symbol]: any;
+  children?: never;
+  location?: never;
+  params?: never;
+  route?: never;
+  routeParams?: never;
+  router?: never;
+  routes?: never;
+};
+
+interface DeprecatedPropRoute extends BaseRouteObject {
+  /**
+   * Passes legacy route props to the component.
+   */
+  deprecatedRouteProps: true;
+  /**
+   * A react component that accepts legacy router props (location, params, router, etc.)
+   */
+  component?: React.ComponentType<any>;
+}
+
+interface RouteObject extends BaseRouteObject {
+  /**
+   * A react component to render or a import promise that will be lazily loaded.
+   * Components that expect RouteComponentProps are not allowed here - use deprecatedRouteProps: true instead.
+   */
+  component?: React.ComponentType<NoRouteProps>;
+  /**
+   * Passes legacy route props to the component.
+   */
+  deprecatedRouteProps?: never;
+}
+
+export type SentryRouteObject = RouteObject | DeprecatedPropRoute;

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -41,8 +41,13 @@ import {type SentryRouteObject} from './components/route';
 import {translateSentryRoute} from './utils/reactRouter6Compat/router';
 import {makeLazyloadComponent as make} from './makeLazyloadComponent';
 
-const routeHook = (name: HookName): SentryRouteObject =>
-  HookStore.get(name)?.[0]?.() ?? {};
+const routeHook = (name: HookName): SentryRouteObject => {
+  const route = HookStore.get(name)?.[0]?.() ?? {};
+  return {
+    ...route,
+    deprecatedRouteProps: true,
+  };
+};
 
 function buildRoutes(): RouteObject[] {
   // Read this to understand where to add new routes, how / why the routing
@@ -128,10 +133,12 @@ function buildRoutes(): RouteObject[] {
     {
       index: true,
       component: make(() => import('sentry/views/auth/login')),
+      deprecatedRouteProps: true,
     },
     {
       path: ':orgId/',
       component: make(() => import('sentry/views/auth/login')),
+      deprecatedRouteProps: true,
     },
   ];
   const experimentalSpaRoutes: SentryRouteObject = EXPERIMENTAL_SPA
@@ -162,6 +169,7 @@ function buildRoutes(): RouteObject[] {
     },
     {
       component: errorHandler(OrganizationContainer),
+      deprecatedRouteProps: true,
       children: [
         {
           path: '/extensions/external-install/:integrationSlug/:installationId',
@@ -176,6 +184,7 @@ function buildRoutes(): RouteObject[] {
     {
       path: '/sentry-apps/:sentryAppSlug/external-install/',
       component: make(() => import('sentry/views/sentryAppExternalInstallation')),
+      deprecatedRouteProps: true,
     },
     {
       path: '/account/',
@@ -194,45 +203,55 @@ function buildRoutes(): RouteObject[] {
     {
       path: '/share/issue/:shareId/',
       component: make(() => import('sentry/views/sharedGroupDetails')),
+      deprecatedRouteProps: true,
     },
     {
       path: '/organizations/:orgId/share/issue/:shareId/',
       component: make(() => import('sentry/views/sharedGroupDetails')),
+      deprecatedRouteProps: true,
     },
     {
       path: '/unsubscribe/project/:id/',
       component: make(() => import('sentry/views/unsubscribe/project')),
       customerDomainOnlyRoute: true,
+      deprecatedRouteProps: true,
     },
     {
       path: '/unsubscribe/:orgId/project/:id/',
       component: make(() => import('sentry/views/unsubscribe/project')),
+      deprecatedRouteProps: true,
     },
     {
       path: '/unsubscribe/issue/:id/',
       component: make(() => import('sentry/views/unsubscribe/issue')),
       customerDomainOnlyRoute: true,
+      deprecatedRouteProps: true,
     },
     {
       path: '/unsubscribe/:orgId/issue/:id/',
       component: make(() => import('sentry/views/unsubscribe/issue')),
+      deprecatedRouteProps: true,
     },
     {
       path: '/organizations/new/',
       component: make(() => import('sentry/views/organizationCreate')),
+      deprecatedRouteProps: true,
     },
     {
       path: '/data-export/:dataExportId',
       component: make(() => import('sentry/views/dataExport/dataDownload')),
       withOrgPath: true,
+      deprecatedRouteProps: true,
     },
     {
       component: errorHandler(OrganizationContainer),
+      deprecatedRouteProps: true,
       children: [
         {
           path: '/disabled-member/',
           component: make(() => import('sentry/views/disabledMember')),
           withOrgPath: true,
+          deprecatedRouteProps: true,
         },
       ],
     },
@@ -240,10 +259,12 @@ function buildRoutes(): RouteObject[] {
       path: '/restore/',
       component: make(() => import('sentry/views/organizationRestore')),
       customerDomainOnlyRoute: true,
+      deprecatedRouteProps: true,
     },
     {
       path: '/organizations/:orgId/restore/',
       component: make(() => import('sentry/views/organizationRestore')),
+      deprecatedRouteProps: true,
     },
     {
       path: '/join-request/',
@@ -251,16 +272,19 @@ function buildRoutes(): RouteObject[] {
         make(() => import('sentry/views/organizationJoinRequest'))
       ),
       customerDomainOnlyRoute: true,
+      deprecatedRouteProps: true,
     },
     {
       path: '/join-request/:orgId/',
       component: withDomainRedirect(
         make(() => import('sentry/views/organizationJoinRequest'))
       ),
+      deprecatedRouteProps: true,
     },
     {
       path: '/relocation/',
       component: make(() => import('sentry/views/relocation')),
+      deprecatedRouteProps: true,
       children: [
         {
           index: true,
@@ -269,6 +293,7 @@ function buildRoutes(): RouteObject[] {
         {
           path: ':step/',
           component: make(() => import('sentry/views/relocation')),
+          deprecatedRouteProps: true,
         },
       ],
     },
@@ -281,10 +306,12 @@ function buildRoutes(): RouteObject[] {
       path: '/onboarding/:step/',
       component: errorHandler(withDomainRequired(OrganizationContainer)),
       customerDomainOnlyRoute: true,
+      deprecatedRouteProps: true,
       children: [
         {
           index: true,
           component: make(() => import('sentry/views/onboarding')),
+          deprecatedRouteProps: true,
         },
       ],
     },
@@ -295,10 +322,12 @@ function buildRoutes(): RouteObject[] {
     {
       path: '/onboarding/:orgId/:step/',
       component: withDomainRedirect(errorHandler(OrganizationContainer)),
+      deprecatedRouteProps: true,
       children: [
         {
           index: true,
           component: make(() => import('sentry/views/onboarding')),
+          deprecatedRouteProps: true,
         },
       ],
     },
@@ -311,6 +340,7 @@ function buildRoutes(): RouteObject[] {
   const rootRoutes: SentryRouteObject = {
     component: errorHandler(AppBodyContent),
     children: rootChildren,
+    deprecatedRouteProps: true,
   };
 
   const accountSettingsChildren: SentryRouteObject[] = [
@@ -335,6 +365,7 @@ function buildRoutes(): RouteObject[] {
                 'sentry/views/settings/account/notifications/notificationSettingsController'
               )
           ),
+          deprecatedRouteProps: true,
         },
         {
           path: ':fineTuneType/',
@@ -345,6 +376,7 @@ function buildRoutes(): RouteObject[] {
                 'sentry/views/settings/account/accountNotificationFineTuningController'
               )
           ),
+          deprecatedRouteProps: true,
         },
       ],
     },
@@ -370,12 +402,14 @@ function buildRoutes(): RouteObject[] {
                 'sentry/views/settings/account/accountSecurity/accountSecurityWrapper'
               )
           ),
+          deprecatedRouteProps: true,
           children: [
             {
               index: true,
               component: make(
                 () => import('sentry/views/settings/account/accountSecurity')
               ),
+              deprecatedRouteProps: true,
             },
             {
               path: 'session-history/',
@@ -384,6 +418,7 @@ function buildRoutes(): RouteObject[] {
                 () =>
                   import('sentry/views/settings/account/accountSecurity/sessionHistory')
               ),
+              deprecatedRouteProps: true,
             },
             {
               path: 'mfa/:authId/',
@@ -394,6 +429,7 @@ function buildRoutes(): RouteObject[] {
                     'sentry/views/settings/account/accountSecurity/accountSecurityDetails'
                   )
               ),
+              deprecatedRouteProps: true,
             },
           ],
         },
@@ -446,6 +482,7 @@ function buildRoutes(): RouteObject[] {
               component: make(
                 () => import('sentry/views/settings/account/apiTokenDetails')
               ),
+              deprecatedRouteProps: true,
             },
           ],
         },
@@ -458,6 +495,7 @@ function buildRoutes(): RouteObject[] {
               component: make(
                 () => import('sentry/views/settings/account/apiApplications')
               ),
+              deprecatedRouteProps: true,
             },
             {
               path: ':appId/',
@@ -465,6 +503,7 @@ function buildRoutes(): RouteObject[] {
               component: make(
                 () => import('sentry/views/settings/account/apiApplications/details')
               ),
+              deprecatedRouteProps: true,
             },
           ],
         },
@@ -481,6 +520,7 @@ function buildRoutes(): RouteObject[] {
     name: t('Account'),
     component: make(() => import('sentry/views/settings/account/accountSettingsLayout')),
     children: accountSettingsChildren,
+    deprecatedRouteProps: true,
   };
 
   const projectSettingsChildren: SentryRouteObject[] = [
@@ -497,15 +537,18 @@ function buildRoutes(): RouteObject[] {
       path: 'teams/',
       name: t('Teams'),
       component: make(() => import('sentry/views/settings/project/projectTeams')),
+      deprecatedRouteProps: true,
     },
     {
       path: 'alerts/',
       name: t('Alerts'),
       component: make(() => import('sentry/views/settings/projectAlerts')),
+      deprecatedRouteProps: true,
       children: [
         {
           index: true,
           component: make(() => import('sentry/views/settings/projectAlerts/settings')),
+          deprecatedRouteProps: true,
         },
         {
           path: 'new/',
@@ -537,6 +580,7 @@ function buildRoutes(): RouteObject[] {
       path: 'environments/',
       name: t('Environments'),
       component: make(() => import('sentry/views/settings/project/projectEnvironments')),
+      deprecatedRouteProps: true,
       children: [
         {
           index: true,
@@ -550,6 +594,7 @@ function buildRoutes(): RouteObject[] {
       path: 'tags/',
       name: t('Tags & Context'),
       component: make(() => import('sentry/views/settings/projectTags')),
+      deprecatedRouteProps: true,
     },
     {
       path: 'issue-tracking/',
@@ -561,26 +606,31 @@ function buildRoutes(): RouteObject[] {
       component: make(
         () => import('sentry/views/settings/project/projectReleaseTracking')
       ),
+      deprecatedRouteProps: true,
     },
     {
       path: 'ownership/',
       name: t('Ownership Rules'),
       component: make(() => import('sentry/views/settings/project/projectOwnership')),
+      deprecatedRouteProps: true,
     },
     {
       path: 'data-forwarding/',
       name: t('Data Forwarding'),
       component: make(() => import('sentry/views/settings/projectDataForwarding')),
+      deprecatedRouteProps: true,
     },
     {
       path: 'seer/',
       name: t('Seer'),
       component: make(() => import('sentry/views/settings/projectSeer/index')),
+      deprecatedRouteProps: true,
     },
     {
       path: 'user-feedback/',
       name: t('User Feedback'),
       component: make(() => import('sentry/views/settings/projectUserFeedback')),
+      deprecatedRouteProps: true,
     },
     {
       path: 'security-and-privacy/',
@@ -591,12 +641,14 @@ function buildRoutes(): RouteObject[] {
           component: make(
             () => import('sentry/views/settings/projectSecurityAndPrivacy')
           ),
+          deprecatedRouteProps: true,
         },
         {
           path: 'advanced-data-scrubbing/:scrubbingId/',
           component: make(
             () => import('sentry/views/settings/projectSecurityAndPrivacy')
           ),
+          deprecatedRouteProps: true,
         },
       ],
     },
@@ -604,31 +656,37 @@ function buildRoutes(): RouteObject[] {
       path: 'debug-symbols/',
       name: t('Debug Information Files'),
       component: make(() => import('sentry/views/settings/projectDebugFiles')),
+      deprecatedRouteProps: true,
     },
     {
       path: 'proguard/',
       name: t('ProGuard Mappings'),
       component: make(() => import('sentry/views/settings/projectProguard')),
+      deprecatedRouteProps: true,
     },
     {
       path: 'performance/',
       name: t('Performance'),
       component: make(() => import('sentry/views/settings/projectPerformance')),
+      deprecatedRouteProps: true,
     },
     {
       path: 'playstation/',
       name: t('PlayStation'),
       component: make(() => import('sentry/views/settings/project/tempest')),
+      deprecatedRouteProps: true,
     },
     {
       path: 'replays/',
       name: t('Replays'),
       component: make(() => import('sentry/views/settings/project/projectReplays')),
+      deprecatedRouteProps: true,
     },
     {
       path: 'toolbar/',
       name: t('Developer Toolbar'),
       component: make(() => import('sentry/views/settings/project/projectToolbar')),
+      deprecatedRouteProps: true,
     },
     {
       path: 'source-maps/',
@@ -637,11 +695,13 @@ function buildRoutes(): RouteObject[] {
         {
           index: true,
           component: make(() => import('sentry/views/settings/projectSourceMaps')),
+          deprecatedRouteProps: true,
         },
         {
           path: ':bundleId/',
           name: t('Source Map Uploads'),
           component: make(() => import('sentry/views/settings/projectSourceMaps')),
+          deprecatedRouteProps: true,
         },
         {
           path: 'source-maps/artifact-bundles/',
@@ -657,6 +717,7 @@ function buildRoutes(): RouteObject[] {
       path: 'filters/',
       name: t('Inbound Filters'),
       component: make(() => import('sentry/views/settings/project/projectFilters')),
+      deprecatedRouteProps: true,
       children: [
         {
           index: true,
@@ -675,6 +736,7 @@ function buildRoutes(): RouteObject[] {
       path: 'issue-grouping/',
       name: t('Issue Grouping'),
       component: make(() => import('sentry/views/settings/projectIssueGrouping')),
+      deprecatedRouteProps: true,
     },
     {
       path: 'hooks/',
@@ -687,6 +749,7 @@ function buildRoutes(): RouteObject[] {
       component: make(
         () => import('sentry/views/settings/project/projectCreateServiceHook')
       ),
+      deprecatedRouteProps: true,
     },
     {
       path: 'hooks/:hookId/',
@@ -702,6 +765,7 @@ function buildRoutes(): RouteObject[] {
         {
           index: true,
           component: make(() => import('sentry/views/settings/project/projectKeys/list')),
+          deprecatedRouteProps: true,
         },
         {
           path: ':keyId/',
@@ -709,6 +773,7 @@ function buildRoutes(): RouteObject[] {
           component: make(
             () => import('sentry/views/settings/project/projectKeys/details')
           ),
+          deprecatedRouteProps: true,
         },
       ],
     },
@@ -716,6 +781,7 @@ function buildRoutes(): RouteObject[] {
       path: 'loader-script/',
       name: t('Loader Script'),
       component: make(() => import('sentry/views/settings/project/loaderScript')),
+      deprecatedRouteProps: true,
     },
     {
       path: 'csp/',
@@ -759,11 +825,13 @@ function buildRoutes(): RouteObject[] {
         {
           index: true,
           component: make(() => import('sentry/views/settings/projectPlugins')),
+          deprecatedRouteProps: true,
         },
         {
           path: ':pluginId/',
           name: t('Integration Details'),
           component: make(() => import('sentry/views/settings/projectPlugins/details')),
+          deprecatedRouteProps: true,
         },
       ],
     },
@@ -773,12 +841,14 @@ function buildRoutes(): RouteObject[] {
     name: t('Project'),
     component: make(() => import('sentry/views/settings/project/projectSettingsLayout')),
     children: projectSettingsChildren,
+    deprecatedRouteProps: true,
   };
 
   const statsChildren: SentryRouteObject[] = [
     {
       index: true,
       component: make(() => import('sentry/views/organizationStats')),
+      deprecatedRouteProps: true,
     },
     {
       component: make(() => import('sentry/views/organizationStats/teamInsights')),
@@ -788,12 +858,14 @@ function buildRoutes(): RouteObject[] {
           component: make(
             () => import('sentry/views/organizationStats/teamInsights/issues')
           ),
+          deprecatedRouteProps: true,
         },
         {
           path: 'health/',
           component: make(
             () => import('sentry/views/organizationStats/teamInsights/health')
           ),
+          deprecatedRouteProps: true,
         },
       ],
     },
@@ -805,6 +877,7 @@ function buildRoutes(): RouteObject[] {
         withOrgPath: true,
         component: OrganizationStatsWrapper,
         children: statsChildren,
+        deprecatedRouteProps: true,
       },
       {
         path: '/organizations/:orgId/stats/team/',
@@ -854,6 +927,7 @@ function buildRoutes(): RouteObject[] {
       path: 'audit-log/',
       name: t('Audit Log'),
       component: make(() => import('sentry/views/settings/organizationAuditLog')),
+      deprecatedRouteProps: true,
     },
     {
       path: 'auth/',
@@ -889,6 +963,7 @@ function buildRoutes(): RouteObject[] {
       path: 'rate-limits/',
       name: t('Rate Limits'),
       component: make(() => import('sentry/views/settings/organizationRateLimits')),
+      deprecatedRouteProps: true,
     },
     {
       path: 'relay/',
@@ -929,6 +1004,7 @@ function buildRoutes(): RouteObject[] {
         {
           index: true,
           component: make(() => import('sentry/views/settings/organizationTeams')),
+          deprecatedRouteProps: true,
         },
         {
           path: ':teamId/',
@@ -936,6 +1012,7 @@ function buildRoutes(): RouteObject[] {
           component: make(
             () => import('sentry/views/settings/organizationTeams/teamDetails')
           ),
+          deprecatedRouteProps: true,
           children: [
             {
               index: true,
@@ -947,6 +1024,7 @@ function buildRoutes(): RouteObject[] {
               component: make(
                 () => import('sentry/views/settings/organizationTeams/teamMembers')
               ),
+              deprecatedRouteProps: true,
             },
             {
               path: 'notifications/',
@@ -961,6 +1039,7 @@ function buildRoutes(): RouteObject[] {
               component: make(
                 () => import('sentry/views/settings/organizationTeams/teamProjects')
               ),
+              deprecatedRouteProps: true,
             },
             {
               path: 'settings/',
@@ -968,6 +1047,7 @@ function buildRoutes(): RouteObject[] {
               component: make(
                 () => import('sentry/views/settings/organizationTeams/teamSettings')
               ),
+              deprecatedRouteProps: true,
             },
           ],
         },
@@ -1063,6 +1143,7 @@ function buildRoutes(): RouteObject[] {
                 'sentry/views/settings/organizationIntegrations/configureIntegration'
               )
           ),
+          deprecatedRouteProps: true,
         },
       ],
     },
@@ -1085,6 +1166,7 @@ function buildRoutes(): RouteObject[] {
                 'sentry/views/settings/organizationDeveloperSettings/sentryApplicationDetails'
               )
           ),
+          deprecatedRouteProps: true,
         },
         {
           path: 'new-internal/',
@@ -1095,6 +1177,7 @@ function buildRoutes(): RouteObject[] {
                 'sentry/views/settings/organizationDeveloperSettings/sentryApplicationDetails'
               )
           ),
+          deprecatedRouteProps: true,
         },
         {
           path: ':appSlug/',
@@ -1105,6 +1188,7 @@ function buildRoutes(): RouteObject[] {
                 'sentry/views/settings/organizationDeveloperSettings/sentryApplicationDetails'
               )
           ),
+          deprecatedRouteProps: true,
         },
         {
           path: ':appSlug/dashboard/',
@@ -1139,6 +1223,7 @@ function buildRoutes(): RouteObject[] {
           component: make(
             () => import('sentry/views/settings/organizationAuthTokens/authTokenDetails')
           ),
+          deprecatedRouteProps: true,
         },
       ],
     },
@@ -1146,6 +1231,7 @@ function buildRoutes(): RouteObject[] {
       path: 'early-features/',
       name: t('Early Features'),
       component: make(() => import('sentry/views/settings/earlyFeatures')),
+      deprecatedRouteProps: true,
     },
     {
       path: 'dynamic-sampling/',
@@ -1210,6 +1296,7 @@ function buildRoutes(): RouteObject[] {
       () => import('sentry/views/settings/organization/organizationSettingsLayout')
     ),
     children: orgSettingsChildren,
+    deprecatedRouteProps: true,
   };
 
   const legacySettingsRedirects: SentryRouteObject = {
@@ -1241,6 +1328,7 @@ function buildRoutes(): RouteObject[] {
       {
         index: true,
         component: make(() => import('sentry/views/settings/settingsIndex')),
+        deprecatedRouteProps: true,
       },
       accountSettingsRoutes,
       {
@@ -1248,14 +1336,17 @@ function buildRoutes(): RouteObject[] {
         component: withDomainRequired(NoOp),
         customerDomainOnlyRoute: true,
         children: [orgSettingsRoutes, projectSettingsRoutes],
+        deprecatedRouteProps: true,
       },
       {
         path: ':orgId/',
         name: t('Organization'),
         component: withDomainRedirect(NoOp),
         children: [orgSettingsRoutes, projectSettingsRoutes, legacySettingsRedirects],
+        deprecatedRouteProps: true,
       },
     ],
+    deprecatedRouteProps: true,
   };
 
   const projectsChildren: SentryRouteObject[] = [
@@ -1270,14 +1361,17 @@ function buildRoutes(): RouteObject[] {
     {
       path: ':projectId/',
       component: make(() => import('sentry/views/projectDetail')),
+      deprecatedRouteProps: true,
     },
     {
       path: ':projectId/events/:eventId/',
       component: errorHandler(ProjectEventRedirect),
+      deprecatedRouteProps: true,
     },
     {
       path: ':projectId/getting-started/',
       component: make(() => import('sentry/views/projectInstall/gettingStarted')),
+      deprecatedRouteProps: true,
     },
   ];
   const projectsRoutes: SentryRouteObject = {
@@ -1285,11 +1379,13 @@ function buildRoutes(): RouteObject[] {
     component: make(() => import('sentry/views/projects/')),
     withOrgPath: true,
     children: projectsChildren,
+    deprecatedRouteProps: true,
   };
 
   const traceView: SentryRouteObject = {
     path: 'trace/:traceSlug/',
     component: make(() => import('sentry/views/performance/traceDetails')),
+    deprecatedRouteProps: true,
   };
 
   const dashboardChildren: SentryRouteObject[] = [
@@ -1304,6 +1400,7 @@ function buildRoutes(): RouteObject[] {
         },
         traceView,
       ],
+      deprecatedRouteProps: true,
     },
     {
       path: '/organizations/:orgId/dashboards/',
@@ -1314,6 +1411,7 @@ function buildRoutes(): RouteObject[] {
           component: make(() => import('sentry/views/dashboards/manage')),
         },
       ],
+      deprecatedRouteProps: true,
     },
     {
       path: '/dashboards/new/',
@@ -1324,21 +1422,26 @@ function buildRoutes(): RouteObject[] {
         {
           path: 'widget-builder/widget/:widgetIndex/edit/',
           component: make(() => import('sentry/views/dashboards/view')),
+          deprecatedRouteProps: true,
         },
         {
           path: 'widget-builder/widget/new/',
           component: make(() => import('sentry/views/dashboards/view')),
+          deprecatedRouteProps: true,
         },
         // old widget builder routes
         {
           path: 'widget/:widgetIndex/edit/',
           component: make(() => import('sentry/views/dashboards/widgetBuilder')),
+          deprecatedRouteProps: true,
         },
         {
           path: 'widget/new/',
           component: make(() => import('sentry/views/dashboards/widgetBuilder')),
+          deprecatedRouteProps: true,
         },
       ],
+      deprecatedRouteProps: true,
     },
     {
       path: '/dashboards/new/:templateId',
@@ -1348,8 +1451,10 @@ function buildRoutes(): RouteObject[] {
         {
           path: 'widget/:widgetId/',
           component: make(() => import('sentry/views/dashboards/create')),
+          deprecatedRouteProps: true,
         },
       ],
+      deprecatedRouteProps: true,
     },
     {
       path: '/organizations/:orgId/dashboards/:dashboardId/',
@@ -1368,24 +1473,30 @@ function buildRoutes(): RouteObject[] {
         {
           path: 'widget-builder/widget/:widgetIndex/edit/',
           component: make(() => import('sentry/views/dashboards/view')),
+          deprecatedRouteProps: true,
         },
         {
           path: 'widget-builder/widget/new/',
           component: make(() => import('sentry/views/dashboards/view')),
+          deprecatedRouteProps: true,
         },
         {
           path: 'widget/:widgetIndex/edit/',
           component: make(() => import('sentry/views/dashboards/widgetBuilder')),
+          deprecatedRouteProps: true,
         },
         {
           path: 'widget/new/',
           component: make(() => import('sentry/views/dashboards/widgetBuilder')),
+          deprecatedRouteProps: true,
         },
         {
           path: 'widget/:widgetId/',
           component: make(() => import('sentry/views/dashboards/view')),
+          deprecatedRouteProps: true,
         },
       ],
+      deprecatedRouteProps: true,
     },
   ];
   const dashboardRoutes: SentryRouteObject = {
@@ -1396,6 +1507,7 @@ function buildRoutes(): RouteObject[] {
     {
       index: true,
       component: make(() => import('sentry/views/alerts/list/incidents')),
+      deprecatedRouteProps: true,
     },
     {
       path: 'rules/',
@@ -1403,10 +1515,12 @@ function buildRoutes(): RouteObject[] {
         {
           index: true,
           component: make(() => import('sentry/views/alerts/list/rules/alertRulesList')),
+          deprecatedRouteProps: true,
         },
         {
           path: 'details/:ruleId/',
           component: make(() => import('sentry/views/alerts/rules/metric/details')),
+          deprecatedRouteProps: true,
         },
         {
           path: ':projectId/',
@@ -1421,8 +1535,10 @@ function buildRoutes(): RouteObject[] {
             {
               path: ':ruleId/',
               component: make(() => import('sentry/views/alerts/edit')),
+              deprecatedRouteProps: true,
             },
           ],
+          deprecatedRouteProps: true,
         },
         {
           path: ':projectId/:ruleId/details/',
@@ -1432,6 +1548,7 @@ function buildRoutes(): RouteObject[] {
               component: make(
                 () => import('sentry/views/alerts/rules/issue/details/ruleDetails')
               ),
+              deprecatedRouteProps: true,
             },
           ],
         },
@@ -1442,12 +1559,14 @@ function buildRoutes(): RouteObject[] {
             {
               path: ':projectId/:uptimeRuleId/details/',
               component: make(() => import('sentry/views/alerts/rules/uptime/details')),
+              deprecatedRouteProps: true,
             },
             {
               path: 'existing-or-create/',
               component: make(
                 () => import('sentry/views/alerts/rules/uptime/existingOrCreate')
               ),
+              deprecatedRouteProps: true,
             },
           ],
         },
@@ -1458,6 +1577,7 @@ function buildRoutes(): RouteObject[] {
             {
               path: ':projectId/:monitorSlug/details/',
               component: make(() => import('sentry/views/alerts/rules/crons/details')),
+              deprecatedRouteProps: true,
             },
           ],
         },
@@ -1485,8 +1605,10 @@ function buildRoutes(): RouteObject[] {
             {
               path: ':ruleId/',
               component: make(() => import('sentry/views/alerts/edit')),
+              deprecatedRouteProps: true,
             },
           ],
+          deprecatedRouteProps: true,
         },
       ],
     },
@@ -1500,8 +1622,10 @@ function buildRoutes(): RouteObject[] {
             {
               path: ':ruleId/',
               component: make(() => import('sentry/views/alerts/edit')),
+              deprecatedRouteProps: true,
             },
           ],
+          deprecatedRouteProps: true,
         },
       ],
     },
@@ -1515,8 +1639,10 @@ function buildRoutes(): RouteObject[] {
             {
               path: ':monitorSlug/',
               component: make(() => import('sentry/views/alerts/edit')),
+              deprecatedRouteProps: true,
             },
           ],
+          deprecatedRouteProps: true,
         },
       ],
     },
@@ -1527,8 +1653,10 @@ function buildRoutes(): RouteObject[] {
         {
           index: true,
           component: make(() => import('sentry/views/alerts/wizard')),
+          deprecatedRouteProps: true,
         },
       ],
+      deprecatedRouteProps: true,
     },
     {
       path: 'new/',
@@ -1543,24 +1671,30 @@ function buildRoutes(): RouteObject[] {
         {
           path: ':alertType/',
           component: make(() => import('sentry/views/alerts/create')),
+          deprecatedRouteProps: true,
         },
       ],
+      deprecatedRouteProps: true,
     },
     {
       path: ':alertId/',
       component: make(() => import('sentry/views/alerts/incidentRedirect')),
+      deprecatedRouteProps: true,
     },
     {
       path: ':projectId/',
       component: make(() => import('sentry/views/alerts/builder/projectProvider')),
+      deprecatedRouteProps: true,
       children: [
         {
           path: 'new/',
           component: make(() => import('sentry/views/alerts/create')),
+          deprecatedRouteProps: true,
         },
         {
           path: 'wizard/',
           component: make(() => import('sentry/views/alerts/wizard')),
+          deprecatedRouteProps: true,
         },
       ],
     },
@@ -1572,11 +1706,13 @@ function buildRoutes(): RouteObject[] {
         component: withDomainRequired(make(() => import('sentry/views/alerts'))),
         customerDomainOnlyRoute: true,
         children: alertChildRoutes(true),
+        deprecatedRouteProps: true,
       },
       {
         path: '/organizations/:orgId/alerts/',
         component: withDomainRedirect(make(() => import('sentry/views/alerts'))),
         children: alertChildRoutes(false),
+        deprecatedRouteProps: true,
       },
     ],
   };
@@ -1595,6 +1731,7 @@ function buildRoutes(): RouteObject[] {
     {
       path: ':replaySlug/',
       component: make(() => import('sentry/views/replays/details')),
+      deprecatedRouteProps: true,
     },
   ];
   const replayRoutes: SentryRouteObject = {
@@ -1602,6 +1739,7 @@ function buildRoutes(): RouteObject[] {
     component: make(() => import('sentry/views/replays/index')),
     withOrgPath: true,
     children: replayChildren,
+    deprecatedRouteProps: true,
   };
 
   const releaseChildren: SentryRouteObject[] = [
@@ -1630,6 +1768,7 @@ function buildRoutes(): RouteObject[] {
           ),
         },
       ],
+      deprecatedRouteProps: true,
     },
   ];
   const releasesRoutes: SentryRouteObject = {
@@ -1639,6 +1778,7 @@ function buildRoutes(): RouteObject[] {
         component: make(() => import('sentry/views/releases/index')),
         withOrgPath: true,
         children: releaseChildren,
+        deprecatedRouteProps: true,
       },
       {
         path: '/releases/new-events/',
@@ -1659,6 +1799,7 @@ function buildRoutes(): RouteObject[] {
     {
       path: 'homepage/',
       component: make(() => import('sentry/views/discover/homepage')),
+      deprecatedRouteProps: true,
     },
     traceView,
     {
@@ -1668,10 +1809,12 @@ function buildRoutes(): RouteObject[] {
     {
       path: 'results/',
       component: make(() => import('sentry/views/discover/results')),
+      deprecatedRouteProps: true,
     },
     {
       path: ':eventSlug/',
       component: make(() => import('sentry/views/discover/eventDetails')),
+      deprecatedRouteProps: true,
     },
   ];
   const discoverRoutes: SentryRouteObject = {
@@ -1679,6 +1822,7 @@ function buildRoutes(): RouteObject[] {
     component: make(() => import('sentry/views/discover')),
     withOrgPath: true,
     children: discoverChildren,
+    deprecatedRouteProps: true,
   };
 
   const llmMonitoringRedirects: SentryRouteObject = {
@@ -1716,6 +1860,7 @@ function buildRoutes(): RouteObject[] {
       component: make(
         () => import('sentry/views/performance/transactionSummary/transactionOverview')
       ),
+      deprecatedRouteProps: true,
     },
     traceView,
     {
@@ -1729,18 +1874,21 @@ function buildRoutes(): RouteObject[] {
       component: make(
         () => import('sentry/views/performance/transactionSummary/transactionVitals')
       ),
+      deprecatedRouteProps: true,
     },
     {
       path: 'tags/',
       component: make(
         () => import('sentry/views/performance/transactionSummary/transactionTags')
       ),
+      deprecatedRouteProps: true,
     },
     {
       path: 'events/',
       component: make(
         () => import('sentry/views/performance/transactionSummary/transactionEvents')
       ),
+      deprecatedRouteProps: true,
     },
     {
       path: 'profiles/',
@@ -1756,6 +1904,7 @@ function buildRoutes(): RouteObject[] {
           component: make(
             () => import('sentry/views/performance/transactionSummary/transactionSpans')
           ),
+          deprecatedRouteProps: true,
         },
         {
           path: ':spanSlug/',
@@ -1765,6 +1914,7 @@ function buildRoutes(): RouteObject[] {
                 'sentry/views/performance/transactionSummary/transactionSpans/spanDetails'
               )
           ),
+          deprecatedRouteProps: true,
         },
       ],
     },
@@ -1903,6 +2053,7 @@ function buildRoutes(): RouteObject[] {
             () =>
               import('sentry/views/insights/llmMonitoring/views/llmMonitoringDetailsPage')
           ),
+          deprecatedRouteProps: true,
         },
       ],
     },
@@ -2020,6 +2171,7 @@ function buildRoutes(): RouteObject[] {
       path: 'projects/',
       component: make(() => import('sentry/views/projects/')),
       children: projectsChildren,
+      deprecatedRouteProps: true,
     },
     {
       path: `${FRONTEND_LANDING_SUB_PATH}/uptime/`,
@@ -2071,6 +2223,7 @@ function buildRoutes(): RouteObject[] {
     {
       path: 'vitaldetail/',
       component: make(() => import('sentry/views/performance/vitalDetail')),
+      deprecatedRouteProps: true,
     },
     traceView,
     ...insightsRedirectObjects,
@@ -2089,6 +2242,7 @@ function buildRoutes(): RouteObject[] {
     {
       path: ':eventSlug/',
       component: make(() => import('sentry/views/performance/transactionDetails')),
+      deprecatedRouteProps: true,
     },
   ];
   const performanceRoutes: SentryRouteObject = {
@@ -2096,6 +2250,7 @@ function buildRoutes(): RouteObject[] {
     component: make(() => import('sentry/views/performance')),
     withOrgPath: true,
     children: performanceChildren,
+    deprecatedRouteProps: true,
   };
 
   const tracesChildren: SentryRouteObject[] = [
@@ -2114,6 +2269,7 @@ function buildRoutes(): RouteObject[] {
     component: make(() => import('sentry/views/traces')),
     withOrgPath: true,
     children: tracesChildren,
+    deprecatedRouteProps: true,
   };
 
   const logsChildren: SentryRouteObject[] = [
@@ -2128,10 +2284,12 @@ function buildRoutes(): RouteObject[] {
     {
       index: true,
       component: make(() => import('sentry/views/profiling/content')),
+      deprecatedRouteProps: true,
     },
     {
       path: 'summary/:projectId/',
       component: make(() => import('sentry/views/profiling/profileSummary')),
+      deprecatedRouteProps: true,
     },
     {
       path: 'profile/:projectId/differential-flamegraph/',
@@ -2149,6 +2307,7 @@ function buildRoutes(): RouteObject[] {
           ),
         },
       ],
+      deprecatedRouteProps: true,
     },
     {
       path: 'profile/:projectId/:eventId/',
@@ -2159,6 +2318,7 @@ function buildRoutes(): RouteObject[] {
           component: make(() => import('sentry/views/profiling/profileFlamechart')),
         },
       ],
+      deprecatedRouteProps: true,
     },
   ];
   const profilingRoutes: SentryRouteObject = {
@@ -2166,46 +2326,55 @@ function buildRoutes(): RouteObject[] {
     component: make(() => import('sentry/views/profiling')),
     withOrgPath: true,
     children: profilingChildren,
+    deprecatedRouteProps: true,
   };
 
   const exploreChildren: SentryRouteObject[] = [
     {
       index: true,
       component: make(() => import('sentry/views/explore/indexRedirect')),
+      deprecatedRouteProps: true,
     },
     {
       path: 'profiling/',
       component: make(() => import('sentry/views/profiling')),
       children: profilingChildren,
+      deprecatedRouteProps: true,
     },
     {
       path: 'traces/',
       component: make(() => import('sentry/views/traces')),
       children: tracesChildren,
+      deprecatedRouteProps: true,
     },
     {
       path: 'replays/',
       component: make(() => import('sentry/views/replays/index')),
       children: replayChildren,
+      deprecatedRouteProps: true,
     },
     {
       path: 'discover/',
       component: make(() => import('sentry/views/discover')),
       children: discoverChildren,
+      deprecatedRouteProps: true,
     },
     {
       path: 'releases/',
       component: make(() => import('sentry/views/releases/index')),
       children: releaseChildren,
+      deprecatedRouteProps: true,
     },
     {
       path: 'logs/',
       component: make(() => import('sentry/views/explore/logs')),
       children: logsChildren,
+      deprecatedRouteProps: true,
     },
     {
       path: 'saved-queries/',
       component: make(() => import('sentry/views/explore/savedQueries')),
+      deprecatedRouteProps: true,
     },
   ];
   const exploreRoutes: SentryRouteObject = {
@@ -2333,12 +2502,14 @@ function buildRoutes(): RouteObject[] {
     withOrgPath: true,
     component: make(() => import('sentry/views/codecov/index')),
     children: codecovChildren,
+    deprecatedRouteProps: true,
   };
 
   const preprodChildren: SentryRouteObject[] = [
     {
       index: true,
       component: make(() => import('sentry/views/preprod/buildDetails')),
+      deprecatedRouteProps: true,
     },
   ];
   const preprodRoutes: SentryRouteObject = {
@@ -2346,12 +2517,14 @@ function buildRoutes(): RouteObject[] {
     component: make(() => import('sentry/views/preprod/index')),
     withOrgPath: true,
     children: preprodChildren,
+    deprecatedRouteProps: true,
   };
 
   const feedbackV2Children: SentryRouteObject[] = [
     {
       index: true,
       component: make(() => import('sentry/views/feedback/feedbackListPage')),
+      deprecatedRouteProps: true,
     },
     traceView,
   ];
@@ -2360,6 +2533,7 @@ function buildRoutes(): RouteObject[] {
     component: make(() => import('sentry/views/feedback/index')),
     withOrgPath: true,
     children: feedbackV2Children,
+    deprecatedRouteProps: true,
   };
 
   const issueTabs: SentryRouteObject[] = [
@@ -2428,32 +2602,39 @@ function buildRoutes(): RouteObject[] {
     {
       index: true,
       component: errorHandler(OverviewWrapper),
+      deprecatedRouteProps: true,
     },
     {
       path: `${IssueTaxonomy.ERRORS_AND_OUTAGES}/`,
       component: make(() => import('sentry/views/issueList/pages/errorsOutages')),
+      deprecatedRouteProps: true,
     },
     {
       path: `${IssueTaxonomy.BREACHED_METRICS}/`,
       component: make(() => import('sentry/views/issueList/pages/breachedMetrics')),
+      deprecatedRouteProps: true,
     },
     {
       path: `${IssueTaxonomy.WARNINGS}/`,
       component: make(() => import('sentry/views/issueList/pages/warnings')),
+      deprecatedRouteProps: true,
     },
     {
       path: 'views/',
       component: make(
         () => import('sentry/views/issueList/issueViews/issueViewsList/issueViewsList')
       ),
+      deprecatedRouteProps: true,
     },
     {
       path: 'views/:viewId/',
       component: errorHandler(OverviewWrapper),
+      deprecatedRouteProps: true,
     },
     {
       path: 'searches/:searchId/',
       component: errorHandler(OverviewWrapper),
+      deprecatedRouteProps: true,
     },
     // Redirects for legacy tags route.
     {
@@ -2475,6 +2656,7 @@ function buildRoutes(): RouteObject[] {
     {
       path: ':groupId/',
       component: make(() => import('sentry/views/issueDetails/groupDetails')),
+      deprecatedRouteProps: true,
       children: [
         ...issueTabs,
         {
@@ -2487,11 +2669,13 @@ function buildRoutes(): RouteObject[] {
       path: 'feedback/',
       component: make(() => import('sentry/views/feedback/index')),
       children: feedbackV2Children,
+      deprecatedRouteProps: true,
     },
     {
       path: 'alerts/',
       component: make(() => import('sentry/views/alerts')),
       children: alertChildRoutes(true),
+      deprecatedRouteProps: true,
     },
     traceView,
     automationRoutes,
@@ -2507,34 +2691,42 @@ function buildRoutes(): RouteObject[] {
     {
       index: true,
       component: make(() => import('sentry/views/admin/adminOverview')),
+      deprecatedRouteProps: true,
     },
     {
       path: 'buffer/',
       component: make(() => import('sentry/views/admin/adminBuffer')),
+      deprecatedRouteProps: true,
     },
     {
       path: 'relays/',
       component: make(() => import('sentry/views/admin/adminRelays')),
+      deprecatedRouteProps: true,
     },
     {
       path: 'organizations/',
       component: make(() => import('sentry/views/admin/adminOrganizations')),
+      deprecatedRouteProps: true,
     },
     {
       path: 'projects/',
       component: make(() => import('sentry/views/admin/adminProjects')),
+      deprecatedRouteProps: true,
     },
     {
       path: 'queue/',
       component: make(() => import('sentry/views/admin/adminQueue')),
+      deprecatedRouteProps: true,
     },
     {
       path: 'quotas/',
       component: make(() => import('sentry/views/admin/adminQuotas')),
+      deprecatedRouteProps: true,
     },
     {
       path: 'settings/',
       component: make(() => import('sentry/views/admin/adminSettings')),
+      deprecatedRouteProps: true,
     },
     {
       path: 'users/',
@@ -2542,28 +2734,35 @@ function buildRoutes(): RouteObject[] {
         {
           index: true,
           component: make(() => import('sentry/views/admin/adminUsers')),
+          deprecatedRouteProps: true,
         },
         {
           path: ':id',
           component: make(() => import('sentry/views/admin/adminUserEdit')),
+          deprecatedRouteProps: true,
         },
       ],
+      deprecatedRouteProps: true,
     },
     {
       path: 'status/mail/',
       component: make(() => import('sentry/views/admin/adminMail')),
+      deprecatedRouteProps: true,
     },
     {
       path: 'status/environment/',
       component: make(() => import('sentry/views/admin/adminEnvironment')),
+      deprecatedRouteProps: true,
     },
     {
       path: 'status/packages/',
       component: make(() => import('sentry/views/admin/adminPackages')),
+      deprecatedRouteProps: true,
     },
     {
       path: 'status/warnings/',
       component: make(() => import('sentry/views/admin/adminWarnings')),
+      deprecatedRouteProps: true,
     },
   ];
 
@@ -2573,6 +2772,7 @@ function buildRoutes(): RouteObject[] {
     path: '/manage/',
     component: make(() => import('sentry/views/admin/adminLayout')),
     children: adminManageChildren,
+    deprecatedRouteProps: true,
   };
 
   const legacyOrganizationRootChildren: SentryRouteObject[] = [
@@ -2692,6 +2892,7 @@ function buildRoutes(): RouteObject[] {
           ({orgId, projectId}) => `/organizations/${orgId}/issues/?project=${projectId}`
         )
       ),
+      deprecatedRouteProps: true,
     },
     {
       path: 'issues/',
@@ -2700,6 +2901,7 @@ function buildRoutes(): RouteObject[] {
           ({orgId, projectId}) => `/organizations/${orgId}/issues/?project=${projectId}`
         )
       ),
+      deprecatedRouteProps: true,
     },
     {
       path: 'dashboard/',
@@ -2709,6 +2911,7 @@ function buildRoutes(): RouteObject[] {
             `/organizations/${orgId}/dashboards/?project=${projectId}`
         )
       ),
+      deprecatedRouteProps: true,
     },
     {
       path: 'user-feedback/',
@@ -2717,6 +2920,7 @@ function buildRoutes(): RouteObject[] {
           ({orgId, projectId}) => `/organizations/${orgId}/feedback/?project=${projectId}`
         )
       ),
+      deprecatedRouteProps: true,
     },
     {
       path: 'releases/',
@@ -2725,6 +2929,7 @@ function buildRoutes(): RouteObject[] {
           ({orgId, projectId}) => `/organizations/${orgId}/releases/?project=${projectId}`
         )
       ),
+      deprecatedRouteProps: true,
     },
     {
       path: 'releases/:version/',
@@ -2734,6 +2939,7 @@ function buildRoutes(): RouteObject[] {
             `/organizations/${orgId}/releases/${router.params.version}/?project=${projectId}`
         )
       ),
+      deprecatedRouteProps: true,
     },
     {
       path: 'releases/:version/new-events/',
@@ -2743,6 +2949,7 @@ function buildRoutes(): RouteObject[] {
             `/organizations/${orgId}/releases/${router.params.version}/new-events/?project=${projectId}`
         )
       ),
+      deprecatedRouteProps: true,
     },
     {
       path: 'releases/:version/all-events/',
@@ -2752,6 +2959,7 @@ function buildRoutes(): RouteObject[] {
             `/organizations/${orgId}/releases/${router.params.version}/all-events/?project=${projectId}`
         )
       ),
+      deprecatedRouteProps: true,
     },
     {
       path: 'releases/:version/commits/',
@@ -2761,11 +2969,13 @@ function buildRoutes(): RouteObject[] {
             `/organizations/${orgId}/releases/${router.params.version}/commits/?project=${projectId}`
         )
       ),
+      deprecatedRouteProps: true,
     },
   ];
   const legacyOrgRedirects: SentryRouteObject = {
     path: '/:orgId/:projectId/',
     children: legacyOrgRedirectChildren,
+    deprecatedRouteProps: true,
   };
 
   const organizationRoutes: SentryRouteObject = {
@@ -2794,6 +3004,7 @@ function buildRoutes(): RouteObject[] {
       legacyOrganizationRootRoutes,
       legacyOrgRedirects,
     ],
+    deprecatedRouteProps: true,
   };
 
   const legacyRedirectRoutes: SentryRouteObject = {
@@ -2948,23 +3159,26 @@ function buildRoutes(): RouteObject[] {
       {
         path: ':projectId/events/:eventId/',
         component: errorHandler(ProjectEventRedirect),
+        deprecatedRouteProps: true,
       },
     ],
   };
 
   const appRoutes: SentryRouteObject = {
     component: ProvideAriaRouter,
+    deprecatedRouteProps: true,
     children: [
       experimentalSpaRoutes,
       {
         path: '/',
         component: errorHandler(App),
+        deprecatedRouteProps: true,
         children: [
           rootRoutes,
           authV2Routes,
           organizationRoutes,
           legacyRedirectRoutes,
-          {path: '*', component: errorHandler(RouteNotFound)},
+          {path: '*', component: errorHandler(RouteNotFound), deprecatedRouteProps: true},
         ],
       },
     ],

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1598,6 +1598,7 @@ function buildRoutes(): RouteObject[] {
         {
           path: ':projectId/',
           component: make(() => import('sentry/views/alerts/builder/projectProvider')),
+          deprecatedRouteProps: true,
           children: [
             {
               index: true,
@@ -1611,7 +1612,6 @@ function buildRoutes(): RouteObject[] {
               deprecatedRouteProps: true,
             },
           ],
-          deprecatedRouteProps: true,
         },
       ],
     },
@@ -1621,6 +1621,7 @@ function buildRoutes(): RouteObject[] {
         {
           path: ':projectId/',
           component: make(() => import('sentry/views/alerts/builder/projectProvider')),
+          deprecatedRouteProps: true,
           children: [
             {
               path: ':ruleId/',
@@ -1628,7 +1629,6 @@ function buildRoutes(): RouteObject[] {
               deprecatedRouteProps: true,
             },
           ],
-          deprecatedRouteProps: true,
         },
       ],
     },
@@ -1638,6 +1638,7 @@ function buildRoutes(): RouteObject[] {
         {
           path: ':projectId/',
           component: make(() => import('sentry/views/alerts/builder/projectProvider')),
+          deprecatedRouteProps: true,
           children: [
             {
               path: ':monitorSlug/',
@@ -1645,7 +1646,6 @@ function buildRoutes(): RouteObject[] {
               deprecatedRouteProps: true,
             },
           ],
-          deprecatedRouteProps: true,
         },
       ],
     },
@@ -2302,6 +2302,7 @@ function buildRoutes(): RouteObject[] {
     {
       path: 'profile/:projectId/',
       component: make(() => import('sentry/views/profiling/continuousProfileProvider')),
+      deprecatedRouteProps: true,
       children: [
         {
           path: 'flamegraph/',
@@ -2310,18 +2311,17 @@ function buildRoutes(): RouteObject[] {
           ),
         },
       ],
-      deprecatedRouteProps: true,
     },
     {
       path: 'profile/:projectId/:eventId/',
       component: make(() => import('sentry/views/profiling/transactionProfileProvider')),
+      deprecatedRouteProps: true,
       children: [
         {
           path: 'flamegraph/',
           component: make(() => import('sentry/views/profiling/profileFlamechart')),
         },
       ],
-      deprecatedRouteProps: true,
     },
   ];
   const profilingRoutes: SentryRouteObject = {
@@ -2745,7 +2745,6 @@ function buildRoutes(): RouteObject[] {
           deprecatedRouteProps: true,
         },
       ],
-      deprecatedRouteProps: true,
     },
     {
       path: 'status/mail/',
@@ -2978,7 +2977,6 @@ function buildRoutes(): RouteObject[] {
   const legacyOrgRedirects: SentryRouteObject = {
     path: '/:orgId/:projectId/',
     children: legacyOrgRedirectChildren,
-    deprecatedRouteProps: true,
   };
 
   const organizationRoutes: SentryRouteObject = {

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1417,6 +1417,7 @@ function buildRoutes(): RouteObject[] {
     {
       path: '/dashboards/new/',
       component: make(() => import('sentry/views/dashboards/create')),
+      deprecatedRouteProps: true,
       withOrgPath: true,
       children: [
         // new widget builder routes
@@ -1442,11 +1443,11 @@ function buildRoutes(): RouteObject[] {
           deprecatedRouteProps: true,
         },
       ],
-      deprecatedRouteProps: true,
     },
     {
       path: '/dashboards/new/:templateId',
       component: make(() => import('sentry/views/dashboards/create')),
+      deprecatedRouteProps: true,
       withOrgPath: true,
       children: [
         {
@@ -1455,7 +1456,6 @@ function buildRoutes(): RouteObject[] {
           deprecatedRouteProps: true,
         },
       ],
-      deprecatedRouteProps: true,
     },
     {
       path: '/organizations/:orgId/dashboards/:dashboardId/',
@@ -1469,6 +1469,7 @@ function buildRoutes(): RouteObject[] {
     {
       path: '/dashboard/:dashboardId/',
       component: make(() => import('sentry/views/dashboards/view')),
+      deprecatedRouteProps: true,
       withOrgPath: true,
       children: [
         {
@@ -1497,7 +1498,6 @@ function buildRoutes(): RouteObject[] {
           deprecatedRouteProps: true,
         },
       ],
-      deprecatedRouteProps: true,
     },
   ];
   const dashboardRoutes: SentryRouteObject = {
@@ -1664,6 +1664,7 @@ function buildRoutes(): RouteObject[] {
     {
       path: 'new/',
       component: make(() => import('sentry/views/alerts/builder/projectProvider')),
+      deprecatedRouteProps: true,
       children: [
         {
           index: true,
@@ -1677,7 +1678,6 @@ function buildRoutes(): RouteObject[] {
           deprecatedRouteProps: true,
         },
       ],
-      deprecatedRouteProps: true,
     },
     {
       path: ':alertId/',
@@ -1753,6 +1753,7 @@ function buildRoutes(): RouteObject[] {
     {
       path: ':release/',
       component: make(() => import('sentry/views/releases/detail')),
+      deprecatedRouteProps: true,
       children: [
         {
           index: true,
@@ -1771,7 +1772,6 @@ function buildRoutes(): RouteObject[] {
           ),
         },
       ],
-      deprecatedRouteProps: true,
     },
   ];
   const releasesRoutes: SentryRouteObject = {
@@ -2527,7 +2527,6 @@ function buildRoutes(): RouteObject[] {
     {
       index: true,
       component: make(() => import('sentry/views/feedback/feedbackListPage')),
-      deprecatedRouteProps: true,
     },
     traceView,
   ];

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -852,6 +852,7 @@ function buildRoutes(): RouteObject[] {
     },
     {
       component: make(() => import('sentry/views/organizationStats/teamInsights')),
+      deprecatedRouteProps: true,
       children: [
         {
           path: 'issues/',
@@ -1525,6 +1526,7 @@ function buildRoutes(): RouteObject[] {
         {
           path: ':projectId/',
           component: make(() => import('sentry/views/alerts/builder/projectProvider')),
+          deprecatedRouteProps: true,
           children: [
             {
               index: true,
@@ -1538,7 +1540,6 @@ function buildRoutes(): RouteObject[] {
               deprecatedRouteProps: true,
             },
           ],
-          deprecatedRouteProps: true,
         },
         {
           path: ':projectId/:ruleId/details/',
@@ -1555,6 +1556,7 @@ function buildRoutes(): RouteObject[] {
         {
           path: 'uptime/',
           component: make(() => import('sentry/views/alerts/rules/uptime')),
+          deprecatedRouteProps: true,
           children: [
             {
               path: ':projectId/:uptimeRuleId/details/',
@@ -1573,6 +1575,7 @@ function buildRoutes(): RouteObject[] {
         {
           path: 'crons/',
           component: make(() => import('sentry/views/alerts/rules/crons')),
+          deprecatedRouteProps: true,
           children: [
             {
               path: ':projectId/:monitorSlug/details/',

--- a/static/app/utils/reactRouter6Compat/router.tsx
+++ b/static/app/utils/reactRouter6Compat/router.tsx
@@ -55,10 +55,6 @@ function withReactRouter3Props(Component: React.ComponentType<any>) {
   return WithReactRouter3Props;
 }
 
-function NoOp({children}: {children: React.JSX.Element}) {
-  return children;
-}
-
 interface RedirectProps extends Omit<NavigateProps, 'to'> {
   /**
    * Our Redirect only supports string to
@@ -97,21 +93,36 @@ function Redirect({to, ...rest}: RedirectProps) {
 }
 Redirect.displayName = 'Redirect';
 
-function getElement(Component: React.ComponentType<any> | undefined) {
+function getElement(
+  Component: React.ComponentType<any> | undefined,
+  deprecatedRouteProps = false
+) {
   if (!Component) {
     return undefined;
   }
 
-  const WrappedComponent = withReactRouter3Props(Component);
+  if (deprecatedRouteProps) {
+    const WrappedComponent = withReactRouter3Props(Component);
 
-  return <WrappedComponent />;
+    return <WrappedComponent />;
+  }
+
+  return <Component />;
 }
 
 /**
  * Converts a SentryRouteObject tree into a react-router RouteObject tree.
  */
 export function translateSentryRoute(tree: SentryRouteObject): RouteObject {
-  const {name, path, withOrgPath, redirectTo, customerDomainOnlyRoute, component} = tree;
+  const {
+    name,
+    path,
+    withOrgPath,
+    redirectTo,
+    customerDomainOnlyRoute,
+    component,
+    deprecatedRouteProps,
+  } = tree;
 
   if (customerDomainOnlyRoute && !USING_CUSTOMER_DOMAIN) {
     return {};
@@ -132,7 +143,7 @@ export function translateSentryRoute(tree: SentryRouteObject): RouteObject {
   const handle = {name, path};
 
   if (tree.index) {
-    return {index: true, element: getElement(component), handle};
+    return {index: true, element: getElement(component, deprecatedRouteProps), handle};
   }
 
   const children = tree.children?.map(translateSentryRoute);
@@ -141,15 +152,19 @@ export function translateSentryRoute(tree: SentryRouteObject): RouteObject {
   // we need to generate multiple routes, one including the
   // /organizations/:ogId prefix, and one without
   if (!withOrgPath) {
-    return {path, element: getElement(component), handle, children};
+    return {path, element: getElement(component, deprecatedRouteProps), handle, children};
   }
 
   const dualRoutes: RouteObject[] = [];
 
+  const hasNoComponent = !component;
+
   if (USING_CUSTOMER_DOMAIN) {
     dualRoutes.push({
       path,
-      element: getElement(withDomainRequired(component ?? NoOp)),
+      element: hasNoComponent
+        ? undefined
+        : getElement(withDomainRequired(component), deprecatedRouteProps),
       handle,
       children,
     });
@@ -157,7 +172,9 @@ export function translateSentryRoute(tree: SentryRouteObject): RouteObject {
 
   dualRoutes.push({
     path: `/organizations/:orgId${path}`,
-    element: getElement(withDomainRedirect(component ?? NoOp)),
+    element: hasNoComponent
+      ? undefined
+      : getElement(withDomainRedirect(component), deprecatedRouteProps),
     handle,
     children,
   });

--- a/static/app/utils/reactRouter6Compat/router.tsx
+++ b/static/app/utils/reactRouter6Compat/router.tsx
@@ -157,14 +157,14 @@ export function translateSentryRoute(tree: SentryRouteObject): RouteObject {
 
   const dualRoutes: RouteObject[] = [];
 
-  const hasNoComponent = !component;
+  const hasComponent = !!component;
 
   if (USING_CUSTOMER_DOMAIN) {
     dualRoutes.push({
       path,
-      element: hasNoComponent
-        ? undefined
-        : getElement(withDomainRequired(component), deprecatedRouteProps),
+      element: hasComponent
+        ? getElement(withDomainRequired(component), deprecatedRouteProps)
+        : undefined,
       handle,
       children,
     });
@@ -172,9 +172,9 @@ export function translateSentryRoute(tree: SentryRouteObject): RouteObject {
 
   dualRoutes.push({
     path: `/organizations/:orgId${path}`,
-    element: hasNoComponent
-      ? undefined
-      : getElement(withDomainRedirect(component), deprecatedRouteProps),
+    element: hasComponent
+      ? getElement(withDomainRedirect(component), deprecatedRouteProps)
+      : undefined,
     handle,
     children,
   });

--- a/static/app/views/alerts/builder/projectProvider.tsx
+++ b/static/app/views/alerts/builder/projectProvider.tsx
@@ -14,9 +14,9 @@ import useScrollToTop from 'sentry/utils/useScrollToTop';
 import {makeAlertsPathname} from 'sentry/views/alerts/pathnames';
 
 type Props = RouteComponentProps<RouteParams> & {
+  children: React.ReactNode;
   hasMetricAlerts: boolean;
   organization: Organization;
-  children?: React.ReactNode;
 };
 
 type RouteParams = {

--- a/static/app/views/alerts/rules/crons/index.tsx
+++ b/static/app/views/alerts/rules/crons/index.tsx
@@ -2,7 +2,7 @@ import NoProjectMessage from 'sentry/components/noProjectMessage';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import useOrganization from 'sentry/utils/useOrganization';
 
-export default function CronsContainer({children}: {children?: React.ReactNode}) {
+export default function CronsContainer({children}: {children: React.ReactNode}) {
   const organization = useOrganization();
 
   return (

--- a/static/app/views/alerts/rules/uptime/index.tsx
+++ b/static/app/views/alerts/rules/uptime/index.tsx
@@ -4,7 +4,7 @@ import NoProjectMessage from 'sentry/components/noProjectMessage';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import useOrganization from 'sentry/utils/useOrganization';
 
-export default function UptimeContainer({children}: {children?: React.ReactNode}) {
+export default function UptimeContainer({children}: {children: React.ReactNode}) {
   const organization = useOrganization();
 
   return (

--- a/static/app/views/organizationLayout/body.tsx
+++ b/static/app/views/organizationLayout/body.tsx
@@ -15,7 +15,7 @@ type OrganizationProps = {
 };
 
 type BodyProps = {
-  children?: React.ReactNode;
+  children: React.ReactNode;
 };
 
 function DeletionInProgress({organization}: OrganizationProps) {

--- a/static/app/views/organizationStats/teamInsights/index.spec.tsx
+++ b/static/app/views/organizationStats/teamInsights/index.spec.tsx
@@ -35,7 +35,11 @@ describe('TeamInsightsContainer', () => {
   it('shows message for users with no teams', () => {
     ProjectsStore.loadInitialData([]);
     const organization = OrganizationFixture({features: ['team-insights']});
-    render(<TeamInsightsContainer organization={organization} />);
+    render(
+      <TeamInsightsContainer organization={organization}>
+        <div>test</div>
+      </TeamInsightsContainer>
+    );
 
     expect(
       screen.getByText('You need at least one project to use this view')

--- a/static/app/views/organizationStats/teamInsights/index.tsx
+++ b/static/app/views/organizationStats/teamInsights/index.tsx
@@ -6,8 +6,8 @@ import type {Organization} from 'sentry/types/organization';
 import withOrganization from 'sentry/utils/withOrganization';
 
 type Props = {
+  children: React.ReactNode;
   organization: Organization;
-  children?: React.ReactNode;
 };
 
 function TeamInsightsContainer({children, organization}: Props) {

--- a/static/app/views/routeAnalyticsContextProvider.tsx
+++ b/static/app/views/routeAnalyticsContextProvider.tsx
@@ -34,7 +34,7 @@ export const RouteAnalyticsContext = createContext<{
 }>(DEFAULT_CONTEXT);
 
 interface Props {
-  children?: React.ReactNode;
+  children: React.ReactNode;
 }
 
 export default function RouteAnalyticsContextProvider({children}: Props) {

--- a/static/gsAdmin/routes.tsx
+++ b/static/gsAdmin/routes.tsx
@@ -43,10 +43,12 @@ function buildRoutes() {
   const routes: SentryRouteObject = {
     path: '/_admin/',
     component: Layout,
+    deprecatedRouteProps: true,
     children: [
       {
         index: true,
         component: Home,
+        deprecatedRouteProps: true,
       },
       {
         path: 'beacons/',
@@ -54,10 +56,12 @@ function buildRoutes() {
           {
             index: true,
             component: Beacons,
+            deprecatedRouteProps: true,
           },
           {
             path: ':beaconId/',
             component: BeaconDetails,
+            deprecatedRouteProps: true,
           },
         ],
       },
@@ -67,10 +71,12 @@ function buildRoutes() {
           {
             index: true,
             component: Broadcasts,
+            deprecatedRouteProps: true,
           },
           {
             path: ':broadcastId/',
             component: BroadcastDetails,
+            deprecatedRouteProps: true,
           },
         ],
       },
@@ -80,6 +86,7 @@ function buildRoutes() {
           {
             index: true,
             component: Customers,
+            deprecatedRouteProps: true,
           },
           {
             path: ':orgId/',
@@ -110,6 +117,7 @@ function buildRoutes() {
           {
             index: true,
             component: DocIntegrations,
+            deprecatedRouteProps: true,
           },
           {
             path: ':docIntegrationSlug/',
@@ -132,10 +140,12 @@ function buildRoutes() {
           {
             index: true,
             component: Policies,
+            deprecatedRouteProps: true,
           },
           {
             path: ':policySlug',
             component: PolicyDetails,
+            deprecatedRouteProps: true,
           },
         ],
       },
@@ -154,6 +164,7 @@ function buildRoutes() {
           {
             index: true,
             component: Relocations,
+            deprecatedRouteProps: true,
           },
           {
             path: 'new/',
@@ -175,6 +186,7 @@ function buildRoutes() {
           {
             index: true,
             component: SentryEmployees,
+            deprecatedRouteProps: true,
           },
         ],
       },
@@ -184,6 +196,7 @@ function buildRoutes() {
           {
             index: true,
             component: PromoCodes,
+            deprecatedRouteProps: true,
           },
           {
             path: ':codeId/',
@@ -197,6 +210,7 @@ function buildRoutes() {
           {
             index: true,
             component: SentryApps,
+            deprecatedRouteProps: true,
           },
           {
             path: ':sentryAppSlug/',
@@ -210,6 +224,7 @@ function buildRoutes() {
           {
             index: true,
             component: Users,
+            deprecatedRouteProps: true,
           },
           {
             path: ':userId/',
@@ -223,16 +238,19 @@ function buildRoutes() {
           {
             index: true,
             component: Options,
+            deprecatedRouteProps: true,
           },
         ],
       },
       {
         path: 'data-requests/',
         component: DataRequests,
+        deprecatedRouteProps: true,
       },
       {
         path: 'billingadmins/',
         component: BillingAdmins,
+        deprecatedRouteProps: true,
       },
       {
         path: 'invoices/',
@@ -240,6 +258,7 @@ function buildRoutes() {
           {
             index: true,
             component: Invoices,
+            deprecatedRouteProps: true,
           },
           {
             path: ':invoiceId/',

--- a/static/gsApp/components/subscriptionContext.tsx
+++ b/static/gsApp/components/subscriptionContext.tsx
@@ -5,7 +5,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import ContactBillingMembers from 'getsentry/views/contactBillingMembers';
 
 type Props = {
-  children?: React.ReactNode;
+  children: React.ReactNode;
 };
 
 function SubscriptionContext(props: Props) {

--- a/static/gsApp/hooks/settingsRoutes.tsx
+++ b/static/gsApp/hooks/settingsRoutes.tsx
@@ -26,10 +26,12 @@ const settingsRoutes = (): SentryRouteObject => ({
           path: 'checkout/',
           name: 'Change',
           component: errorHandler(SubscriptionContext),
+          deprecatedRouteProps: true,
           children: [
             {
               index: true,
               component: make(() => import('../views/decideCheckout')),
+              deprecatedRouteProps: true,
             },
           ],
         },
@@ -37,6 +39,7 @@ const settingsRoutes = (): SentryRouteObject => ({
           path: 'cancel/',
           name: 'Cancel',
           component: errorHandler(SubscriptionContext),
+          deprecatedRouteProps: true,
           children: [
             {
               index: true,
@@ -48,40 +51,48 @@ const settingsRoutes = (): SentryRouteObject => ({
           path: 'overview/',
           name: 'Overview',
           component: make(() => import('../views/subscriptionPage/overview')),
+          deprecatedRouteProps: true,
         },
         {
           path: 'usage/',
           name: 'Usage History',
           component: make(() => import('../views/subscriptionPage/usageHistory')),
+          deprecatedRouteProps: true,
         },
         {
           path: 'receipts/',
           name: 'Receipts',
           component: make(() => import('../views/subscriptionPage/paymentHistory')),
+          deprecatedRouteProps: true,
         },
         {
           path: 'notifications/',
           name: 'Notifications',
           component: make(() => import('../views/subscriptionPage/notifications')),
+          deprecatedRouteProps: true,
         },
         {
           path: 'details/',
           name: 'Billing Details',
           component: make(() => import('../views/subscriptionPage/billingDetails')),
+          deprecatedRouteProps: true,
         },
         {
           path: 'usage-log/',
           name: 'Usage Log',
           component: make(() => import('../views/subscriptionPage/usageLog')),
+          deprecatedRouteProps: true,
         },
         {
           path: 'receipts/:invoiceGuid/',
           name: 'Invoice Details',
           component: errorHandler(SubscriptionContext),
+          deprecatedRouteProps: true,
           children: [
             {
               index: true,
               component: make(() => import('../views/invoiceDetails')),
+              deprecatedRouteProps: true,
             },
           ],
         },
@@ -116,11 +127,13 @@ const settingsRoutes = (): SentryRouteObject => ({
       path: 'subscription/redeem-code/',
       name: 'Redeem Promotional Code',
       component: make(() => import('../views/redeemPromoCode')),
+      deprecatedRouteProps: true,
     },
     {
       path: 'legal/',
       name: 'Legal & Compliance',
       component: make(() => import('../views/legalAndCompliance/legalAndCompliance')),
+      deprecatedRouteProps: true,
     },
     {
       name: 'Support',


### PR DESCRIPTION
This uses typescript to enforce that only some routes are injected with the legacy router props. This way we can slowly reduce the components that require this react router 3 style prop.

Removes the "NoOp" route component and renders undefined instead which react router 6 should just render the child?
