### PR TITLE
fix(replays): Use aggregate search config in bulk delete job

### DIFF
--- a/src/sentry/replays/usecases/delete.py
+++ b/src/sentry/replays/usecases/delete.py
@@ -124,8 +124,10 @@ def fetch_rows_matching_pattern(
 ) -> MatchedRows:
     search_filters = parse_search_query(query, config=replay_url_parser_config)
     having = handle_search_filters(agg_search_config, search_filters)
+
+    where = []
     if environment:
-        having.append(Condition(Column("environment"), Op.IN, environment))
+        where.append(Condition(Column("environment"), Op.IN, environment))
 
     query = Query(
         match=Entity("replays"),
@@ -140,6 +142,7 @@ def fetch_rows_matching_pattern(
             Condition(Column("timestamp"), Op.GTE, start),
             # We only match segment rows because those contain the PII we want to delete.
             Condition(Column("segment_id"), Op.IS_NOT_NULL),
+            *where,
         ],
         having=having,
         groupby=[Column("replay_id")],

--- a/tests/sentry/replays/tasks/test_delete_replays_bulk.py
+++ b/tests/sentry/replays/tasks/test_delete_replays_bulk.py
@@ -5,8 +5,9 @@ import uuid
 from unittest.mock import patch
 
 from sentry.replays.models import DeletionJobStatus, ReplayDeletionJobModel
-from sentry.replays.tasks import fetch_rows_matching_pattern, run_bulk_replay_delete_job
+from sentry.replays.tasks import run_bulk_replay_delete_job
 from sentry.replays.testutils import mock_replay
+from sentry.replays.usecases.delete import fetch_rows_matching_pattern
 from sentry.testutils.cases import APITestCase, ReplaysSnubaTestCase
 from sentry.testutils.helpers import TaskRunner
 


### PR DESCRIPTION
Before aggregate filters were causing the query to fail.