### PR TITLE
fix(aci): Allow partial updates in detector PUT endpoint

### DIFF
--- a/src/sentry/incidents/metric_issue_detector.py
+++ b/src/sentry/incidents/metric_issue_detector.py
@@ -80,9 +80,12 @@ class MetricIssueDetectorValidator(BaseDetectorTypeValidator):
 
     def validate(self, attrs):
         attrs = super().validate(attrs)
-        conditions = attrs.get("condition_group", {}).get("conditions")
-        if len(conditions) > 2:
-            raise serializers.ValidationError("Too many conditions")
+
+        if "condition_group" in attrs:
+            conditions = attrs.get("condition_group", {}).get("conditions")
+            if len(conditions) > 2:
+                raise serializers.ValidationError("Too many conditions")
+
         return attrs
 
     def update_data_source(self, instance: Detector, data_source: SnubaQueryDataSourceType):
@@ -128,9 +131,10 @@ class MetricIssueDetectorValidator(BaseDetectorTypeValidator):
             if query_subscriptions:
                 enable_disable_subscriptions(query_subscriptions, enabled)
 
-        data_source: SnubaQueryDataSourceType = validated_data.pop("data_source")
-        if data_source:
-            self.update_data_source(instance, data_source)
+        if "data_source" in validated_data:
+            data_source: SnubaQueryDataSourceType = validated_data.pop("data_source")
+            if data_source:
+                self.update_data_source(instance, data_source)
 
         instance.save()
         return instance

--- a/src/sentry/workflow_engine/endpoints/organization_detector_details.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_details.py
@@ -37,7 +37,7 @@ from sentry.workflow_engine.models import Detector
 
 
 def get_detector_validator(
-    request: Request, project: Project, detector_type_slug: str, instance=None
+    request: Request, project: Project, detector_type_slug: str, instance=None, partial=False
 ):
     type = grouptype.registry.get_by_slug(detector_type_slug)
     if type is None:
@@ -56,6 +56,7 @@ def get_detector_validator(
             "access": request.access,
         },
         data=request.data,
+        partial=partial,
     )
 
 
@@ -145,7 +146,9 @@ class OrganizationDetectorDetailsEndpoint(OrganizationEndpoint):
             raise PermissionDenied
 
         group_type = request.data.get("type") or detector.group_type.slug
-        validator = get_detector_validator(request, detector.project, group_type, detector)
+        validator = get_detector_validator(
+            request, detector.project, group_type, detector, partial=True
+        )
 
         if not validator.is_valid():
             return Response(validator.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/src/sentry/workflow_engine/endpoints/validators/base/detector.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/detector.py
@@ -65,8 +65,10 @@ class BaseDetectorTypeValidator(CamelSnakeSerializer):
 
     def update(self, instance: Detector, validated_data: dict[str, Any]):
         with transaction.atomic(router.db_for_write(Detector)):
-            instance.name = validated_data.get("name", instance.name)
-            instance.type = validated_data.get("detector_type", instance.group_type).slug
+            if "name" in validated_data:
+                instance.name = validated_data.get("name", instance.name)
+            if "type" in validated_data:
+                instance.type = validated_data.get("detector_type", instance.group_type).slug
 
             # Handle enable/disable detector
             if "enabled" in validated_data:

--- a/src/sentry/workflow_engine/endpoints/validators/base/detector.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/detector.py
@@ -67,8 +67,6 @@ class BaseDetectorTypeValidator(CamelSnakeSerializer):
         with transaction.atomic(router.db_for_write(Detector)):
             if "name" in validated_data:
                 instance.name = validated_data.get("name", instance.name)
-            if "type" in validated_data:
-                instance.type = validated_data.get("detector_type", instance.group_type).slug
 
             # Handle enable/disable detector
             if "enabled" in validated_data:

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
@@ -277,7 +277,6 @@ class OrganizationDetectorDetailsPutTest(OrganizationDetectorDetailsBaseTest):
         assert self.detector.owner_team_id is None
 
         data = {
-            **self.valid_data,
             "owner": self.user.get_actor_identifier(),
         }
 
@@ -309,7 +308,6 @@ class OrganizationDetectorDetailsPutTest(OrganizationDetectorDetailsBaseTest):
         team = self.create_team(organization=self.organization)
 
         data = {
-            **self.valid_data,
             "owner": f"team:{team.id}",
         }
 
@@ -338,7 +336,6 @@ class OrganizationDetectorDetailsPutTest(OrganizationDetectorDetailsBaseTest):
         self.detector.save()
 
         data = {
-            **self.valid_data,
             "owner": None,
         }
 
@@ -365,7 +362,6 @@ class OrganizationDetectorDetailsPutTest(OrganizationDetectorDetailsBaseTest):
         assert self.detector.status == ObjectStatus.ACTIVE
 
         data = {
-            **self.valid_data,
             "enabled": False,
         }
         with self.tasks():
@@ -385,7 +381,6 @@ class OrganizationDetectorDetailsPutTest(OrganizationDetectorDetailsBaseTest):
         self.detector.update(status=ObjectStatus.DISABLED)
 
         data = {
-            **self.valid_data,
             "enabled": True,
         }
         with self.tasks():
@@ -407,7 +402,6 @@ class OrganizationDetectorDetailsPutTest(OrganizationDetectorDetailsBaseTest):
         assert DetectorWorkflow.objects.filter(detector=self.detector).count() == 0
 
         data = {
-            **self.valid_data,
             "workflowIds": [workflow1.id, workflow2.id],
         }
 
@@ -446,7 +440,6 @@ class OrganizationDetectorDetailsPutTest(OrganizationDetectorDetailsBaseTest):
         assert DetectorWorkflow.objects.filter(detector=self.detector).count() == 1
 
         data = {
-            **self.valid_data,
             "workflowIds": [new_workflow.id],
         }
 


### PR DESCRIPTION
We often want to update just a portion of the detector, like when enabling/disabling it. This updates the PUT endpoint to use `partial=True` and updates the validator `update()` function so that it's compatible with that.