### PR TITLE
feat(grouping): Add `get` method to `GroupingContext` class

### DIFF
--- a/src/sentry/grouping/strategies/base.py
+++ b/src/sentry/grouping/strategies/base.py
@@ -134,6 +134,12 @@ class GroupingContext:
                 return d[key]
         raise KeyError(key)
 
+    def get(self, key: str, default: ContextValue | None = None) -> ContextValue | None:
+        try:
+            return self[key]
+        except KeyError:
+            return default
+
     def __enter__(self) -> Self:
         self.push()
         return self

--- a/src/sentry/grouping/strategies/base.py
+++ b/src/sentry/grouping/strategies/base.py
@@ -106,8 +106,11 @@ class GroupingContext:
         context["some_key"] = "original_value"
 
         value_at_some_key = context["some_key"] # will be "original_value"
+        value_at_some_key = context.get("some_key") # will be "original_value"
 
         value_at_another_key = context["another_key"] # will raise a KeyError
+        value_at_another_key = context.get("another_key") # will be None
+        value_at_another_key = context.get("another_key", "some_default") # will be "some_default"
 
         with context:
             context["some_key"] = "some_other_value"

--- a/tests/sentry/grouping/test_strategies.py
+++ b/tests/sentry/grouping/test_strategies.py
@@ -28,10 +28,13 @@ class GroupingContextTest(TestCase):
 
         # Behavior when key exists
         assert context["adopt"] == "don't shop"
+        assert context.get("adopt") == "don't shop"
 
         # Behavior when key doesn’t exist
         with pytest.raises(KeyError):
             context["dogs"]
+        assert context.get("dogs") is None
+        assert context.get("dogs", "great") == "great"
 
     def test_set_value(self) -> None:
         context = self._get_new_context(initial_context={"adopt": "don't shop"})


### PR DESCRIPTION
The `GroupingContext` class we use as a datastore during event grouping has a dictionary-like interface, but doesn't support `.get()` the way actual dictionaries do. This adds the method, which will allow us to stop setting default values at the top level of our grouping configs when they're only needed by certain strategies. (For example, see `variant`, `is_recursion`, and `exception_data` [here](https://github.com/getsentry/sentry/blob/510c723483d6eaed11fb307fc7cd1c17ec451a26/src/sentry/grouping/strategies/configurations.py#L30-L47).)