### PR TITLE
fix(aci milestone 3): updates to data condition -> trigger serializer

### DIFF
--- a/src/sentry/incidents/endpoints/serializers/workflow_engine_data_condition.py
+++ b/src/sentry/incidents/endpoints/serializers/workflow_engine_data_condition.py
@@ -9,7 +9,7 @@ from sentry.api.serializers import Serializer, serialize
 from sentry.incidents.endpoints.serializers.workflow_engine_action import (
     WorkflowEngineActionSerializer,
 )
-from sentry.incidents.endpoints.utils import translate_data_condition_type, translate_threshold
+from sentry.incidents.endpoints.utils import translate_data_condition_type
 from sentry.incidents.models.alert_rule import AlertRuleThresholdType
 from sentry.users.models.user import User
 from sentry.users.services.user.model import RpcUser
@@ -105,7 +105,11 @@ class WorkflowEngineDataConditionSerializer(Serializer):
                 if obj.type == Condition.GREATER
                 else AlertRuleThresholdType.BELOW.value
             )
-            resolve_threshold = translate_threshold(get_resolve_threshold(obj.condition_group))
+            resolve_threshold = translate_data_condition_type(
+                detector.config.get("comparison_delta"),
+                obj.type,
+                get_resolve_threshold(obj.condition_group),
+            )
 
         return {
             "id": str(alert_rule_trigger_id),

--- a/src/sentry/workflow_engine/migration_helpers/utils.py
+++ b/src/sentry/workflow_engine/migration_helpers/utils.py
@@ -3,6 +3,8 @@ from typing import cast
 from sentry.incidents.models.alert_rule import AlertRule, AlertRuleTrigger, AlertRuleTriggerAction
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.team import Team
+from sentry.workflow_engine.models import DataCondition, DataConditionGroup
+from sentry.workflow_engine.types import DetectorPriorityLevel
 
 MAX_ACTIONS = 3
 
@@ -13,6 +15,16 @@ ACTION_TYPE_TO_STRING = {
     AlertRuleTriggerAction.Type.OPSGENIE.value: "Opsgenie",
     AlertRuleTriggerAction.Type.DISCORD.value: "Discord",
 }
+
+
+def get_resolve_threshold(condition_group: DataConditionGroup) -> float:
+    """
+    Returns the resolution threshold for a static or percent-based metric issue
+    """
+    resolve_condition = DataCondition.objects.get(
+        condition_result=DetectorPriorityLevel.OK, condition_group=condition_group
+    )
+    return resolve_condition.comparison
 
 
 def get_action_description(action: AlertRuleTriggerAction) -> str:

--- a/tests/sentry/incidents/serializers/test_workflow_engine_base.py
+++ b/tests/sentry/incidents/serializers/test_workflow_engine_base.py
@@ -67,7 +67,7 @@ class TestWorkflowEngineSerializer(TestCase):
                 "label": "critical",
                 "thresholdType": AlertRuleThresholdType.ABOVE.value,
                 "alertThreshold": self.critical_detector_trigger.comparison,
-                "resolveThreshold": AlertRuleThresholdType.BELOW.value,
+                "resolveThreshold": self.alert_rule.resolve_threshold,
                 "dateCreated": self.critical_trigger.date_added,
                 "actions": self.expected_critical_action,
             },
@@ -123,7 +123,7 @@ class TestWorkflowEngineSerializer(TestCase):
             "label": "warning",
             "thresholdType": AlertRuleThresholdType.ABOVE.value,
             "alertThreshold": self.critical_detector_trigger.comparison,
-            "resolveThreshold": AlertRuleThresholdType.BELOW.value,
+            "resolveThreshold": self.alert_rule.resolve_threshold,
             "dateCreated": self.critical_trigger.date_added,
             "actions": self.expected_warning_action,
         }

--- a/tests/sentry/incidents/serializers/test_workflow_engine_data_condition.py
+++ b/tests/sentry/incidents/serializers/test_workflow_engine_data_condition.py
@@ -126,6 +126,7 @@ class TestDataConditionSerializer(TestWorkflowEngineSerializer):
             comparison_detector_trigger.type,
             comparison_detector_trigger.comparison,
         )
+        expected_trigger["resolveThreshold"] = expected_trigger["alertThreshold"]
         expected_trigger["id"] = str(comparison_delta_trigger.id)
         expected_trigger["alertRuleId"] = str(comparison_delta_rule.id)
         assert serialized_data_condition == expected_trigger


### PR DESCRIPTION
Allow serializing anomaly detection data conditions and update the resolution threshold to be the threshold value instead of threshold type (like the old serializer). 

One problem: the new models must explicitly have resolution detector triggers, but the resolve threshold on the legacy alert rule could be `None` (which means that the threshold is auto-detected). Therefore, we don't have a way of determining whether the resolve threshold should be `None` without looking at the legacy model. I've set all non-dynamic resolution thresholds to be non-null, as I feel this makes the most sense, but this may break some things with the legacy UI. 