### PR TITLE
TA Onboarding Responsiveness

### DIFF
--- a/static/app/views/codecov/tests/onboarding.tsx
+++ b/static/app/views/codecov/tests/onboarding.tsx
@@ -93,7 +93,7 @@ const OnboardingContainer = styled('div')`
   padding: ${p => p.theme.space.lg} ${p => p.theme.space['3xl']};
   border: 1px solid ${p => p.theme.border};
   border-radius: ${p => p.theme.borderRadius};
-  max-width: 800px;
+  max-width: 1000px;
 `;
 
 const IntroContainer = styled('div')`

--- a/static/app/views/codecov/tests/onboarding.tsx
+++ b/static/app/views/codecov/tests/onboarding.tsx
@@ -32,53 +32,63 @@ export default function TestsOnboardingPage() {
   const [selectedUploadPermission, setSelectedUploadPermission] =
     useState<UploadPermission>('oidc');
 
-  // TODO: modify to designate full scenario for GHAction vs CLI
+  if (searchParams.get('preOnb') !== null) {
+    return (
+      <LayoutGap>
+        <TestPreOnboardingPage />
+      </LayoutGap>
+    );
+  }
 
+  // TODO: modify to designate full scenario for GHAction vs CLI
   return (
     <LayoutGap>
-      <TestPreOnboardingPage />
       <OnboardingContainer>
-        <IntroContainer>
-          <GetStartedHeader>{t('Get Started with Test Analytics')}</GetStartedHeader>
-          <TAValueText>
-            {t(
-              'Test Analytics offers data on test run times, failure rates, and identifies flaky tests to help decrease the risk of deployment failures and make it easier to ship new features quickly.'
-            )}
-          </TAValueText>
-        </IntroContainer>
-        <SelectOptionHeader>{t('Select a setup option')}</SelectOptionHeader>
-        <RadioGroup
-          label="Select a setup option"
-          value={opt === 'cli' ? 'cli' : 'githubAction'}
-          onChange={handleRadioChange}
-          choices={[
-            ['githubAction', t('Use GitHub Actions to run my CI')],
-            ['cli', t("Use Sentry Prevent's CLI to upload testing reports")],
-          ]}
-        />
-        <StepsContainer>
-          <OutputCoverageFileStep step="1" />
-          {/* TODO coming soon: we will conditionally render this based on CLI vs GHAction and OIDC vs Token for CLI */}
-          <ChooseUploadPermissionStep
-            step="2a"
-            selectedUploadPermission={selectedUploadPermission}
-            setSelectedUploadPermission={setSelectedUploadPermission}
+        <OnboardingContent>
+          <IntroContainer>
+            <GetStartedHeader>{t('Get Started with Test Analytics')}</GetStartedHeader>
+            <TAValueText>
+              {t(
+                'Test Analytics offers data on test run times, failure rates, and identifies flaky tests to help decrease the risk of deployment failures and make it easier to ship new features quickly.'
+              )}
+            </TAValueText>
+          </IntroContainer>
+          <SelectOptionHeader>{t('Select a setup option')}</SelectOptionHeader>
+          <RadioGroup
+            label="Select a setup option"
+            value={opt === 'cli' ? 'cli' : 'githubAction'}
+            onChange={handleRadioChange}
+            choices={[
+              ['githubAction', t('Use GitHub Actions to run my CI')],
+              ['cli', t("Use Sentry Prevent's CLI to upload testing reports")],
+            ]}
           />
-          <AddUploadTokenStep step="2b" />
-          <AddScriptToYamlStep step="3" />
-          <InstallPreventCLIStep step="3" />
-          <EditGHAWorkflowStep step="3" />
-          <RunTestSuiteStep step="4" />
-          <UploadFileCLIStep previousStep="3" step="4" />
-          <ViewResultsInsightsStep step="5" />
-          <div>
-            {tct('To learn more about Test Analytics, please visit [ourDocs].', {
-              ourDocs: (
-                <Link to="https://docs.sentry.io/product/test-analytics/">our docs</Link>
-              ),
-            })}
-          </div>
-        </StepsContainer>
+          <StepsContainer>
+            <OutputCoverageFileStep step="1" />
+            {/* TODO coming soon: we will conditionally render this based on CLI vs GHAction and OIDC vs Token for CLI */}
+            <ChooseUploadPermissionStep
+              step="2a"
+              selectedUploadPermission={selectedUploadPermission}
+              setSelectedUploadPermission={setSelectedUploadPermission}
+            />
+            <AddUploadTokenStep step="2b" />
+            <AddScriptToYamlStep step="3" />
+            <InstallPreventCLIStep step="3" />
+            <EditGHAWorkflowStep step="3" />
+            <RunTestSuiteStep step="4" />
+            <UploadFileCLIStep previousStep="3" step="4" />
+            <ViewResultsInsightsStep step="5" />
+            <div>
+              {tct('To learn more about Test Analytics, please visit [ourDocs].', {
+                ourDocs: (
+                  <Link to="https://docs.sentry.io/product/test-analytics/">
+                    our docs
+                  </Link>
+                ),
+              })}
+            </div>
+          </StepsContainer>
+        </OnboardingContent>
       </OnboardingContainer>
     </LayoutGap>
   );
@@ -93,6 +103,9 @@ const OnboardingContainer = styled('div')`
   padding: ${p => p.theme.space.lg} ${p => p.theme.space['3xl']};
   border: 1px solid ${p => p.theme.border};
   border-radius: ${p => p.theme.borderRadius};
+`;
+
+const OnboardingContent = styled('div')`
   max-width: 1000px;
 `;
 
@@ -110,6 +123,7 @@ const GetStartedHeader = styled('h2')`
 const TAValueText = styled('p')`
   font-size: ${p => p.theme.fontSize.lg};
   color: ${p => p.theme.tokens.content.primary};
+  margin: 0;
 `;
 
 const SelectOptionHeader = styled('h5')`
@@ -119,5 +133,7 @@ const SelectOptionHeader = styled('h5')`
 `;
 
 const StepsContainer = styled('div')`
-  padding: ${p => p.theme.space['2xl']} ${p => p.theme.space['3xl']};
+  padding-top: ${p => p.theme.space['2xl']};
+  padding-left: ${p => p.theme.space['3xl']};
+  max-width: 1000px;
 `;

--- a/static/app/views/codecov/tests/onboardingSteps/onboardingStep.tsx
+++ b/static/app/views/codecov/tests/onboardingSteps/onboardingStep.tsx
@@ -1,15 +1,13 @@
 import styled from '@emotion/styled';
 
-import {space} from 'sentry/styles/space';
-
 const Container = styled('div')`
   display: flex;
   flex-direction: column;
-  gap: ${space(1)};
+  gap: ${p => p.theme.space.md};
   border: 1px solid ${p => p.theme.border};
   border-radius: ${p => p.theme.borderRadius};
-  padding: ${space(2)} ${space(3)};
-  margin-bottom: ${space(3)};
+  padding: ${p => p.theme.space.xl} ${p => p.theme.space['2xl']};
+  margin-bottom: ${p => p.theme.space['2xl']};
 `;
 
 const Header = styled('h3')`

--- a/static/app/views/codecov/tests/preOnboarding.tsx
+++ b/static/app/views/codecov/tests/preOnboarding.tsx
@@ -157,10 +157,6 @@ export default function TestPreOnboardingPage() {
 const IntroSection = styled('div')`
   padding: 44px;
 
-  @media (min-width: ${p => p.theme.breakpoints.lg}) {
-    gap: 90px;
-  }
-
   @media (min-width: ${p => p.theme.breakpoints.sm}) {
     display: flex;
     flex-direction: row;
@@ -172,12 +168,17 @@ const IntroSection = styled('div')`
     max-width: 1000px;
     margin: 0 auto;
   }
+
+  @media (min-width: ${p => p.theme.breakpoints.lg}) {
+    gap: 90px;
+  }
 `;
 
 const ImgContainer = styled('div')`
   @media (max-width: ${p => p.theme.breakpoints.sm}) {
     text-align: center;
   }
+  width: 1 1 418px;
 `;
 
 const StyledDiv = styled('div')`

--- a/static/app/views/codecov/tests/preOnboarding.tsx
+++ b/static/app/views/codecov/tests/preOnboarding.tsx
@@ -1,4 +1,3 @@
-import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import testsAnalyticsSummary from 'sentry-images/features/test-analytics-summary.svg';
@@ -7,11 +6,10 @@ import testsAnalyticsSummaryDark from 'sentry-images/features/test-analytics-sum
 import {Alert} from 'sentry/components/core/alert';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {Link} from 'sentry/components/core/link';
-import {IconGithub} from 'sentry/icons';
+import Panel from 'sentry/components/panels/panel';
 import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
-import {space} from 'sentry/styles/space';
 import {getRegionDataFromOrganization} from 'sentry/utils/regions';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -61,144 +59,159 @@ export default function TestPreOnboardingPage() {
           </Alert>
         </Alert.Container>
       )}
-      <IntroSection>
-        <img src={isDarkMode ? testsAnalyticsSummaryDark : testsAnalyticsSummary} />
-        <div>
-          <h2>{t('Prevent testing issues from slowing you down')}</h2>
-          <p
-            css={css`
-              margin-bottom: ${space(1)};
-            `}
-          >
-            {t('Get testing data that keeps your CI running smoothly.')}
-          </p>
-          <ul>
-            <li>{t('See which lines of code failed which tests.')}</li>
-            <li>
-              {t('Get confirmation of flaky tests and confidently skip or re-run them.')}
-            </li>
-            <li>
-              {t('Identify the most problematic tests and prioritize fixes.')}{' '}
-              <Link to="https://docs.codecov.com/docs/test-analytics">
-                {t('Learn more')}
-              </Link>
-            </li>
-          </ul>
-        </div>
-      </IntroSection>
+      <Panel>
+        <IntroSection>
+          <ImgContainer>
+            <img src={isDarkMode ? testsAnalyticsSummaryDark : testsAnalyticsSummary} />
+          </ImgContainer>
+          <StyledDiv>
+            <h2>{t('Keep test problems from slowing you down')}</h2>
+            <SpacedParagraph>
+              {t('Get testing data that keeps your CI running smoothly')}
+            </SpacedParagraph>
+            <ul>
+              <li>{t('See which lines of code failed which tests')}</li>
+              <li>
+                {t('Get confirmation of flaky tests and confidently skip or re-run them')}
+              </li>
+              <li>
+                {t('Identify the most problematic tests and prioritize fixes.')}{' '}
+                <Link to="https://docs.codecov.com/docs/test-analytics">
+                  {t('Learn more')}
+                </Link>
+              </li>
+            </ul>
+          </StyledDiv>
+        </IntroSection>
+      </Panel>
       {isUSStorage && (
-        <InstructionsSection>
-          <h2>{instructionSet.header}</h2>
-          <p>{instructionSet.subtext}</p>
-          <ButtonBar>
-            <LinkButton priority="primary" href={instructionSet.mainCTA}>
-              {instructionSet.mainCTA}
-            </LinkButton>
-            <LinkButton priority="default" href="/settings/integrations/github">
-              Learn more
-            </LinkButton>
-          </ButtonBar>
-          <PrerequisitesSection>
-            <PrerequisitesTitle>
-              {t('Prerequisites to connect your GitHub organization:')}
-            </PrerequisitesTitle>
-            <Prerequisites>
-              <Prereq>
-                <PrereqMainText>{t('Enable GitHub as an Auth Provider')}</PrereqMainText>
-                <PrereqSubText>
-                  {t(
-                    "Sentry Prevent analyzes your code through your Git provider. You'll need to authenticate to access data from your organizations."
-                  )}
-                </PrereqSubText>
-              </Prereq>
-              <Prereq>
-                <LinkButton
-                  priority="default"
-                  icon={<IconGithub />}
-                  href="https://github.com"
-                >
-                  {t('Sign in with GitHub')}
-                </LinkButton>
-              </Prereq>
-              <Prereq>
-                <PrereqMainText>{t('Install the GitHub Sentry App')}</PrereqMainText>
-                <PrereqSubText>
-                  <Link to="https://github.com/apps/sentry-io">
-                    {t('Install the app')}
-                  </Link>
-                  {t(
-                    " on your GitHub org in your Sentry org. You will need to be an Owner of your GitHub organization to fully configure the integration. Note: Once linked, a GitHub org/account can't be connected to another Sentry org."
-                  )}
-                </PrereqSubText>
-              </Prereq>
-              <Prereq>
-                <PrereqMainText>
-                  {t('Connect your GitHub identities in Sentry')}
-                </PrereqMainText>
-                <PrereqSubText>
-                  {t('In your Sentry ')}
-                  <Link to="https://sentry.io/settings/account/identities">
-                    {t('identities')}
-                  </Link>
-                  {t(
-                    " settings, link your GitHub account to your profile. If you're having trouble adding the integration, "
-                  )}
-                  <Link to="https://sentry.io/settings/account/identities">
-                    {t('disconnect')}
-                  </Link>
-                  {t(' then ')}
-                  {/* TODO: figma file links to https://sentry.io/auth/login/?next=/auth/sso/account/settings/social/associate/co[…]D6ee6a67e71b4459e8e4c%26state%3D7nJAqWF3l4bkczXAPzTcfo8EKIvSHyiB
-                      but not sure how to get the link to that currently */}
-                  <Link to="">{t('reconnect')}</Link>
-                  {t(' your GitHub identity.')}
-                </PrereqSubText>
-              </Prereq>
-            </Prerequisites>
-          </PrerequisitesSection>
-        </InstructionsSection>
+        <Panel>
+          <InstructionsSection>
+            <h2>{instructionSet.header}</h2>
+            <SubtextParagraph>{instructionSet.subtext}</SubtextParagraph>
+            <ButtonBar>
+              <LinkButton priority="primary" href={instructionSet.mainCTA}>
+                {instructionSet.mainCTA}
+              </LinkButton>
+              <LinkButton priority="default" href="/settings/integrations/github">
+                Learn more
+              </LinkButton>
+            </ButtonBar>
+            <PrerequisitesSection>
+              <PrerequisitesTitle>
+                {t('Prerequisites to connect your GitHub organization:')}
+              </PrerequisitesTitle>
+              <Prerequisites>
+                <Prereq>
+                  <PrereqMainText>
+                    {t('Enable GitHub as an Auth Provider')}
+                  </PrereqMainText>
+                  <PrereqSubText>
+                    {t(
+                      "Sentry Prevent analyzes your code through your Git provider. You'll need to authenticate to access data from your organizations."
+                    )}
+                  </PrereqSubText>
+                </Prereq>
+                <Prereq>
+                  <PrereqMainText>{t('Install the GitHub Sentry App')}</PrereqMainText>
+                  <PrereqSubText>
+                    <Link to="https://github.com/apps/sentry-io">
+                      {t('Install the app')}
+                    </Link>
+                    {t(
+                      " on your GitHub org in your Sentry org. You will need to be an Owner of your GitHub organization to fully configure the integration. Note: Once linked, a GitHub org/account can't be connected to another Sentry org."
+                    )}
+                  </PrereqSubText>
+                </Prereq>
+                <Prereq>
+                  <PrereqMainText>
+                    {t('Connect your GitHub identities in Sentry')}
+                  </PrereqMainText>
+                  <PrereqSubText>
+                    {t('In your Sentry ')}
+                    <Link to="https://sentry.io/settings/account/identities">
+                      {t('identities')}
+                    </Link>
+                    {t(
+                      " settings, link your GitHub account to your profile. If you're having trouble adding the integration, "
+                    )}
+                    <Link to="https://sentry.io/settings/account/identities">
+                      {t('disconnect')}
+                    </Link>
+                    {t(' then ')}
+                    {/* TODO: figma file links to https://sentry.io/auth/login/?next=/auth/sso/account/settings/social/associate/co[…]D6ee6a67e71b4459e8e4c%26state%3D7nJAqWF3l4bkczXAPzTcfo8EKIvSHyiB
+                        but not sure how to get the link to that currently */}
+                    <Link to="">{t('reconnect')}</Link>
+                    {t(' your GitHub identity.')}
+                  </PrereqSubText>
+                </Prereq>
+              </Prerequisites>
+            </PrerequisitesSection>
+          </InstructionsSection>
+        </Panel>
       )}
     </LayoutGap>
   );
 }
 
-const LayoutGap = styled('div')`
-  display: grid;
-  gap: ${space(2)};
-`;
-
 const IntroSection = styled('div')`
-  display: flex;
-  border: 1px solid rgba(224, 220, 229, 1);
-  border-radius: 10px;
-  justify-content: space-around;
-  gap: 90px;
   padding: 44px;
-  max-width: 800px;
 
-  @media (max-width: ${p => p.theme.breakpoints.md}) {
-    flex-direction: column;
+  @media (min-width: ${p => p.theme.breakpoints.lg}) {
+    gap: 90px;
+  }
+
+  @media (min-width: ${p => p.theme.breakpoints.sm}) {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
     align-items: center;
-    gap: ${space(3)};
+    flex-wrap: wrap;
+    gap: 0;
+    min-height: 300px;
+    max-width: 1000px;
+    margin: 0 auto;
   }
 `;
 
-const InstructionsSection = styled('div')`
+const ImgContainer = styled('div')`
+  @media (max-width: ${p => p.theme.breakpoints.sm}) {
+    text-align: center;
+  }
+`;
+
+const StyledDiv = styled('div')`
+  flex: 1;
+`;
+
+const SpacedParagraph = styled('p')`
+  margin-bottom: ${p => p.theme.space.md};
+`;
+
+const LayoutGap = styled('div')`
   display: grid;
-  border: 1px solid rgba(224, 220, 229, 1);
-  border-radius: 10px;
+  gap: ${p => p.theme.space.xl};
+`;
+
+const InstructionsSection = styled('div')`
+  display: flex;
+  flex-direction: column;
   padding: 24px 40px;
-  max-width: 800px;
 `;
 
 const ButtonBar = styled('div')`
   display: flex;
-  gap: ${space(2)};
+  gap: ${p => p.theme.space.xl};
+`;
+
+const SubtextParagraph = styled('p')`
+  max-width: 1000px;
 `;
 
 const PrerequisitesSection = styled('div')`
   border-top: 1px solid ${p => p.theme.border};
   margin-top: 24px;
-  padding-top: ${space(3)};
+  padding-top: ${p => p.theme.space['2xl']};
 `;
 
 const Prerequisites = styled('div')`
@@ -206,12 +219,13 @@ const Prerequisites = styled('div')`
   padding: 24px;
   border: 1px solid ${p => p.theme.border};
   border-radius: 10px;
-  margin-bottom: ${space(1.5)};
-  gap: ${space(1.5)};
+  margin-bottom: ${p => p.theme.space.lg};
+  gap: ${p => p.theme.space.lg};
 `;
 
 const Prereq = styled('div')`
-  margin-bottom: ${space(1.5)};
+  margin-bottom: ${p => p.theme.space.lg};
+  max-width: 1000px;
 `;
 
 const PrerequisitesTitle = styled('p')`

--- a/static/app/views/codecov/tests/preOnboarding.tsx
+++ b/static/app/views/codecov/tests/preOnboarding.tsx
@@ -155,34 +155,42 @@ export default function TestPreOnboardingPage() {
 }
 
 const IntroSection = styled('div')`
-  padding: 44px;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  gap: 90px;
+  min-height: 300px;
+  max-width: 1000px;
+  margin: 0 auto;
+  padding: 44px 40px;
 
-  @media (min-width: ${p => p.theme.breakpoints.sm}) {
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
-    align-items: center;
+  @media (max-width: ${p => p.theme.breakpoints.sm}) {
+    padding: ${p => p.theme.space['2xl']} 40px;
     flex-wrap: wrap;
-    gap: 0;
-    min-height: 300px;
-    max-width: 1000px;
-    margin: 0 auto;
   }
 
-  @media (min-width: ${p => p.theme.breakpoints.lg}) {
-    gap: 90px;
+  @media (max-width: ${p => p.theme.breakpoints.lg}) {
+    gap: 0;
   }
 `;
 
 const ImgContainer = styled('div')`
+  flex: 0 0 418px;
+
   @media (max-width: ${p => p.theme.breakpoints.sm}) {
     text-align: center;
+    flex: 1 0 100%;
   }
-  width: 1 1 418px;
 `;
 
 const StyledDiv = styled('div')`
   flex: 1;
+
+  @media (max-width: ${p => p.theme.breakpoints.sm}) {
+    flex: 1 0 100%;
+    margin-top: ${p => p.theme.space['2xl']};
+  }
 `;
 
 const SpacedParagraph = styled('p')`


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/CCMRG-1416/test-analytics-onboarding-container-responsiveness-updates

- Separated out preonboarding to be rendered separately if the `preOnb` query param is included on the page
- Added a couple of component wrapper tags

Onboarding:
https://github.com/user-attachments/assets/e5624285-c687-46a9-8014-ec0c336f074c

Preonboarding:
https://github.com/user-attachments/assets/8a41c876-2b09-4640-a40c-4d6fd93ba4de


For preview testing, preonboarding needs an extra query param on the `.../new` route of `?preOnb`
