### PR TITLE
fix(replays): Make as_trace_item_context safe from KeyErrors

### DIFF
--- a/src/sentry/replays/usecases/ingest/event_parser.py
+++ b/src/sentry/replays/usecases/ingest/event_parser.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import random
 import uuid
-from collections.abc import Iterator, MutableMapping
+from collections.abc import Callable, Iterator, MutableMapping
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, TypedDict
@@ -317,8 +317,6 @@ def as_trace_item_context(event_type: EventType, event: dict[str, Any]) -> Trace
             if not isinstance(current, dict):
                 return {}
             current = current.get(key, {})
-            if current is None:
-                return {}
         return current
 
     def _get_timestamp(dictionary: dict[str, Any], key: str = "timestamp") -> float | None:
@@ -332,7 +330,7 @@ def as_trace_item_context(event_type: EventType, event: dict[str, Any]) -> Trace
             return None
 
     def _map_attr(
-        target_dict: dict[str, Any], key: str, value: Any, converter: callable | None = None
+        target_dict: dict[str, Any], key: str, value: Any, converter: Callable | None = None
     ) -> None:
         """Add an attribute to the target dictionary if the value is not None."""
         if value is not None:
@@ -344,7 +342,7 @@ def as_trace_item_context(event_type: EventType, event: dict[str, Any]) -> Trace
     def _map_attrs(
         target_dict: dict[str, Any],
         source_dict: dict[str, Any],
-        **mappings: str | tuple[str, callable],
+        **mappings: str | tuple[str, Callable],
     ) -> None:
         """Map attributes from source_dict to target_dict using keyword arguments.
 
@@ -490,8 +488,8 @@ def as_trace_item_context(event_type: EventType, event: dict[str, Any]) -> Trace
             _map_attrs(
                 resource_attributes,
                 payload_data,
-                method=("method", as_string_strict),
-                status_code=("statusCode", int),
+                method=("method", str),
+                statusCode=("statusCode", int),
             )
             _map_attrs(
                 resource_attributes,

--- a/src/sentry/replays/usecases/ingest/event_parser.py
+++ b/src/sentry/replays/usecases/ingest/event_parser.py
@@ -489,18 +489,11 @@ def as_trace_item_context(event_type: EventType, event: dict[str, Any]) -> Trace
                 payload_data,
                 method=("method", as_string_strict),
                 status_code=("statusCode", int),
-                duration=("endTimestamp", float),
             )
             map_attrs(
                 resource_attributes,
                 payload,
                 url=("description", as_string_strict),
-            )
-            map_attrs(
-                resource_attributes,
-                payload_data,
-                method=("method", as_string_strict),
-                status_code=("statusCode", int),
             )
             if "endTimestamp" in payload and "startTimestamp" in payload:
                 map_attr(
@@ -570,14 +563,6 @@ def as_trace_item_context(event_type: EventType, event: dict[str, Any]) -> Trace
                 "category": category,
             }
 
-            map_attrs(
-                web_vital_attributes,
-                payload_data,
-                size=("size", float),
-                value=("value", float),
-                rating=("rating", as_string_strict),
-                duration=("endTimestamp", float),
-            )
             map_attrs(
                 web_vital_attributes,
                 payload_data,

--- a/tests/sentry/replays/unit/test_event_parser.py
+++ b/tests/sentry/replays/unit/test_event_parser.py
@@ -1663,3 +1663,33 @@ def test_as_trace_item_context_memory_minimal() -> None:
     assert result is not None
     assert result["attributes"]["category"] == "memory"
     assert len(result["attributes"]) == 1
+
+
+def test_as_trace_item_context_click_missing_timestamp() -> None:
+    click_event = {"data": {"payload": {"data": {"node": {}}}}}
+    result = as_trace_item_context(EventType.CLICK, click_event)
+    assert result is None
+
+
+def test_as_trace_item_context_navigation_missing_timestamp() -> None:
+    navigation_event = {"data": {"payload": {"data": {}}}}
+    result = as_trace_item_context(EventType.NAVIGATION, navigation_event)
+    assert result is None
+
+
+def test_as_trace_item_context_resource_fetch_missing_timestamp() -> None:
+    resource_fetch_event = {"data": {"payload": {"data": {}}}}
+    result = as_trace_item_context(EventType.RESOURCE_FETCH, resource_fetch_event)
+    assert result is None
+
+
+def test_as_trace_item_context_lcp_missing_timestamp() -> None:
+    lcp_event = {"data": {"payload": {"data": {}}}}
+    result = as_trace_item_context(EventType.LCP, lcp_event)
+    assert result is None
+
+
+def test_as_trace_item_context_memory_missing_timestamp() -> None:
+    memory_event = {"data": {"payload": {"data": {}}}}
+    result = as_trace_item_context(EventType.MEMORY, memory_event)
+    assert result is None


### PR DESCRIPTION
fixes REPLAY-568

- Add safe dictionary access using .get() with defaults
- Handle missing optional fields gracefully without KeyErrors