### PR TITLE
ref(grouping): Always use default config when loading unknown config

### DIFF
--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -227,7 +227,8 @@ def load_grouping_config(config_dict: GroupingConfig | None = None) -> StrategyC
         raise ValueError("Malformed configuration dictionary")
     config_id = config_dict["id"]
     if config_id not in CONFIGURATIONS:
-        raise GroupingConfigNotFound(config_id)
+        config_dict = get_default_grouping_config_dict()
+        config_id = config_dict["id"]
     return CONFIGURATIONS[config_id](enhancements=config_dict["enhancements"])
 
 

--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -68,10 +68,6 @@ NULL_GROUPING_CONFIG: GroupingConfig = {"id": "", "enhancements": ""}
 NULL_GROUPHASH_INFO = GroupHashInfo(NULL_GROUPING_CONFIG, {}, [], [], None)
 
 
-class GroupingConfigNotFound(LookupError):
-    pass
-
-
 class GroupingConfig(TypedDict):
     id: str
     enhancements: str

--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -220,7 +220,10 @@ def get_default_grouping_config_dict(config_id: str | None = None) -> GroupingCo
 
 
 def load_grouping_config(config_dict: GroupingConfig | None = None) -> StrategyConfiguration:
-    """Loads the given grouping config."""
+    """
+    Load the given grouping config, or the default config if none is provided or if the given
+    config is not recognized.
+    """
     if config_dict is None:
         config_dict = get_default_grouping_config_dict()
     elif "id" not in config_dict:

--- a/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
+++ b/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
@@ -5,7 +5,6 @@ import sentry_sdk
 
 from sentry import options
 from sentry.api.exceptions import ResourceDoesNotExist
-from sentry.grouping.api import GroupingConfigNotFound
 from sentry.grouping.enhancer.exceptions import InvalidEnhancerConfig
 from sentry.models.project import Project
 from sentry.seer.similarity.utils import (
@@ -35,7 +34,7 @@ from sentry.taskworker.retry import Retry
 from sentry.utils import metrics
 
 SEER_ACCEPTABLE_FAILURE_REASONS = ["Gateway Timeout", "Service Unavailable"]
-EVENT_INFO_EXCEPTIONS = (GroupingConfigNotFound, ResourceDoesNotExist, InvalidEnhancerConfig)
+EVENT_INFO_EXCEPTIONS = (ResourceDoesNotExist, InvalidEnhancerConfig)
 
 logger = logging.getLogger(__name__)
 

--- a/tests/sentry/tasks/test_backfill_seer_grouping_records.py
+++ b/tests/sentry/tasks/test_backfill_seer_grouping_records.py
@@ -19,7 +19,6 @@ from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.conf.server import SEER_SIMILARITY_MODEL_VERSION
 from sentry.db.models.manager.base_query_set import BaseQuerySet
 from sentry.eventstore.models import Event
-from sentry.grouping.api import GroupingConfigNotFound
 from sentry.grouping.enhancer.exceptions import InvalidEnhancerConfig
 from sentry.models.group import Group, GroupStatus
 from sentry.models.grouphash import GroupHash
@@ -1150,7 +1149,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
     def test_nodestore_grouping_config_not_found(
         self, mock_call_next_backfill, mock_lookup_group_data_stacktrace_bulk
     ):
-        exceptions = (GroupingConfigNotFound(), ResourceDoesNotExist(), InvalidEnhancerConfig())
+        exceptions = (ResourceDoesNotExist(), InvalidEnhancerConfig())
 
         for exception in exceptions:
             mock_lookup_group_data_stacktrace_bulk.side_effect = exception


### PR DESCRIPTION
Currently, we have inconsistent behavior when loading a grouping config with an id we don't recognize. If the config id comes from the project, and we've therefore gotten it by using `ProjectGroupingConfigLoader._get_config_id`, it's guaranteed to be one we've heard of, because if it's not, `_get_config_id` will instead [return the id of the default config](https://github.com/getsentry/sentry/blob/65fa0a9af7d186bc5142cf85e6fdb9a59e08a406/src/sentry/grouping/api.py#L147-L148). If instead the config id comes from an event's `grouping_config` entry (which we grab [with no validation](https://github.com/getsentry/sentry/blob/65fa0a9af7d186bc5142cf85e6fdb9a59e08a406/src/sentry/grouping/api.py#L190)), trying to load the grouping config will [raise a `GroupingConfigNotFound` error](https://github.com/getsentry/sentry/blob/65fa0a9af7d186bc5142cf85e6fdb9a59e08a406/src/sentry/grouping/api.py#L229-L230).

To make the behavior consistent, this switches from raising the error in the latter case to just returning the default config. Since this was the only place we were raising `GroupingConfigNotFound`, this also lets us remove all of our handling of it, as well as the error class itself.