### PR TITLE
chore(launchpad): Ensure sentry secret is picked up from the environment

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -715,7 +715,9 @@ SEER_RPC_SHARED_SECRET: list[str] | None = None
 SEER_API_SHARED_SECRET: str = ""
 
 # Shared secret used to sign cross-region RPC requests from the launchpad microservice.
-LAUNCHPAD_RPC_SHARED_SECRET: list[str] | None = os.environ.get("LAUNCHPAD_RPC_SHARED_SECRET", None)
+LAUNCHPAD_RPC_SHARED_SECRET: list[str] | None = None
+if (val := os.environ.get("LAUNCHPAD_RPC_SHARED_SECRET")) is not None:
+    LAUNCHPAD_RPC_SHARED_SECRET = [val]
 
 # The protocol, host and port for control silo
 # Usecases include sending requests to the Integration Proxy Endpoint and RPC requests.

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -715,7 +715,7 @@ SEER_RPC_SHARED_SECRET: list[str] | None = None
 SEER_API_SHARED_SECRET: str = ""
 
 # Shared secret used to sign cross-region RPC requests from the launchpad microservice.
-LAUNCHPAD_RPC_SHARED_SECRET: list[str] | None = None
+LAUNCHPAD_RPC_SHARED_SECRET: list[str] | None = os.environ.get("LAUNCHPAD_RPC_SHARED_SECRET", None)
 
 # The protocol, host and port for control silo
 # Usecases include sending requests to the Integration Proxy Endpoint and RPC requests.


### PR DESCRIPTION
<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
