### PR TITLE
ref(hybridcloud): Refactor queries on cacheversion tables

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3535,3 +3535,10 @@ register(
     default=0.0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+register(
+    "sentry.hybridcloud.cacheversion.rollout",
+    type=Float,
+    default=0.0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)

--- a/tests/sentry/hybridcloud/models/test_cacheversion.py
+++ b/tests/sentry/hybridcloud/models/test_cacheversion.py
@@ -1,4 +1,5 @@
 from sentry.hybridcloud.models.cacheversion import RegionCacheVersion
+from sentry.testutils.helpers import override_options
 from sentry.testutils.pytest.fixtures import django_db_all
 
 
@@ -6,3 +7,10 @@ from sentry.testutils.pytest.fixtures import django_db_all
 def test_increment_version() -> None:
     assert RegionCacheVersion.incr_version("hello-world") == 1
     assert RegionCacheVersion.incr_version("hello-world") == 2
+
+
+@django_db_all
+def test_increment_version_rollout() -> None:
+    with override_options({"sentry.hybridcloud.cacheversion.rollout": 1.0}):
+        assert RegionCacheVersion.incr_version("hello-world") == 1
+        assert RegionCacheVersion.incr_version("hello-world") == 2


### PR DESCRIPTION
Lately `hybridcloud_regioncacheversion` has been quite hot, and one of the reasons for it could be inefficient queries performed.

This PR optimizes query executed on the table, from (worst case scenario) total of 4 to 2 queries. Before we were using our custom `create_or_update` method, instead of Django's `update_or_create` which is slightly better and more optimized, and before we used to perform extra SELECT after we have updated the value, which caused additional load on the database without the need, since we already had the object in memory.


Since this is a critical path, the change will be rolled out gradually in 10-50-100 percentages.
