### PR TITLE
feat(search-bar): Allow key value matching from regexp

### DIFF
--- a/static/app/components/searchQueryBuilder/context.tsx
+++ b/static/app/components/searchQueryBuilder/context.tsx
@@ -53,6 +53,7 @@ interface SearchQueryBuilderContextData {
   size: 'small' | 'normal';
   wrapperRef: React.RefObject<HTMLDivElement | null>;
   filterKeyAliases?: TagCollection;
+  matchKeySuggestions?: Array<{key: string; valuePattern: RegExp}>;
   placeholder?: string;
   /**
    * The element to render the combobox popovers into.
@@ -98,6 +99,7 @@ export function SearchQueryBuilderProvider({
   getFilterTokenWarning,
   portalTarget,
   replaceRawSearchKeys,
+  matchKeySuggestions,
   filterKeyAliases,
 }: SearchQueryBuilderProps & {children: React.ReactNode}) {
   const wrapperRef = useRef<HTMLDivElement>(null);
@@ -192,6 +194,7 @@ export function SearchQueryBuilderProvider({
       displaySeerResults,
       setDisplaySeerResults,
       replaceRawSearchKeys,
+      matchKeySuggestions,
       filterKeyAliases,
       gaveSeerConsent: setupAcknowledgement.orgHasAcknowledged,
     };
@@ -213,6 +216,7 @@ export function SearchQueryBuilderProvider({
     portalTarget,
     recentSearches,
     replaceRawSearchKeys,
+    matchKeySuggestions,
     searchSource,
     setupAcknowledgement.orgHasAcknowledged,
     size,

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -4389,14 +4389,7 @@ describe('SearchQueryBuilder', function () {
           initialQuery=""
           replaceRawSearchKeys={['span.description']}
         />,
-        {
-          organization: {
-            features: [
-              'search-query-builder-raw-search-replacement',
-              'search-query-builder-wildcard-operators',
-            ],
-          },
-        }
+        {organization: {features: ['search-query-builder-wildcard-operators']}}
       );
 
       await userEvent.type(screen.getByRole('textbox'), 'randomValue');
@@ -4421,14 +4414,7 @@ describe('SearchQueryBuilder', function () {
           initialQuery=""
           replaceRawSearchKeys={['span.description']}
         />,
-        {
-          organization: {
-            features: [
-              'search-query-builder-raw-search-replacement',
-              'search-query-builder-wildcard-operators',
-            ],
-          },
-        }
+        {organization: {features: ['search-query-builder-wildcard-operators']}}
       );
 
       await userEvent.type(screen.getByRole('textbox'), 'randomValue');
@@ -4453,14 +4439,7 @@ describe('SearchQueryBuilder', function () {
           initialQuery=""
           replaceRawSearchKeys={['span.description']}
         />,
-        {
-          organization: {
-            features: [
-              'search-query-builder-raw-search-replacement',
-              'search-query-builder-wildcard-operators',
-            ],
-          },
-        }
+        {organization: {features: ['search-query-builder-wildcard-operators']}}
       );
 
       await userEvent.type(screen.getByRole('textbox'), 'random value');
@@ -4485,8 +4464,7 @@ describe('SearchQueryBuilder', function () {
         <SearchQueryBuilder
           {...defaultProps}
           matchKeySuggestions={[{key: 'trace', valuePattern: /^[0-9a-fA-F]{32}$/}]}
-        />,
-        {organization: {features: ['search-query-builder-match-key-suggestions']}}
+        />
       );
 
       await userEvent.type(

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -4479,6 +4479,32 @@ describe('SearchQueryBuilder', function () {
     });
   });
 
+  describe('matchKeySuggestions', () => {
+    it('renders the matched key suggestions when the value matches the pattern', async () => {
+      render(
+        <SearchQueryBuilder
+          {...defaultProps}
+          matchKeySuggestions={[{key: 'trace', valuePattern: /^[0-9a-fA-F]{32}$/}]}
+        />,
+        {organization: {features: ['search-query-builder-match-key-suggestions']}}
+      );
+
+      await userEvent.type(
+        screen.getByRole('textbox'),
+        '12345678901234567890123456789012'
+      );
+
+      const listbox = screen.getByRole('listbox');
+      expect(within(listbox).getByText('trace')).toBeInTheDocument();
+
+      await userEvent.click(within(listbox).getByText('trace'));
+
+      expect(
+        screen.getByRole('row', {name: 'trace:12345678901234567890123456789012'})
+      ).toBeInTheDocument();
+    });
+  });
+
   describe('ask seer', function () {
     it('renders ask seer button when user has given consent', async () => {
       MockApiClient.addMockResponse({

--- a/static/app/components/searchQueryBuilder/index.stories.tsx
+++ b/static/app/components/searchQueryBuilder/index.stories.tsx
@@ -715,6 +715,83 @@ export default Storybook.story('SearchQueryBuilder', story => {
     );
   });
 
+  story('Match key suggestions', () => {
+    return (
+      <Fragment>
+        <p>
+          If you would like to show suggestions for keys when the user types a value, you
+          can do so by passing the <code>matchKeySuggestions</code> prop, which requires a
+          key and a value regex pattern.
+        </p>
+        <p>
+          The suggestions will be the values for the provided keys. The following example,
+          will show suggestions for the <code>id</code> key when the user types a value
+          that matches the regex pattern <code>{`/^[0-9]{3}$/`}</code>.
+        </p>
+        <SearchQueryBuilder
+          initialQuery=""
+          filterKeySections={FILTER_KEY_SECTIONS}
+          filterKeys={FILTER_KEYS}
+          getTagValues={getTagValues}
+          searchSource="storybook"
+          matchKeySuggestions={[{key: 'id', valuePattern: /^[0-9]{3}$/}]}
+        />
+        <p>
+          You can also pass multiple values in the prop to show suggestions for multiple
+          keys.
+        </p>
+        <SearchQueryBuilder
+          initialQuery=""
+          filterKeySections={FILTER_KEY_SECTIONS}
+          filterKeys={FILTER_KEYS}
+          getTagValues={getTagValues}
+          searchSource="storybook"
+          matchKeySuggestions={[
+            {key: 'test-1.id', valuePattern: /^[0-9]{3}$/},
+            {key: 'test-2.id', valuePattern: /^[0-9]{3}$/},
+          ]}
+        />
+      </Fragment>
+    );
+  });
+
+  story('Raw search replacement', () => {
+    return (
+      <Fragment>
+        <p>
+          If you would like to replace raw search for your{' '}
+          <Storybook.JSXNode name="SearchQueryBuilder" /> component, you can do so by
+          passing the <code>replaceRawSearchKeys</code> prop.
+        </p>
+        <p>
+          The raw search will be replaced with option(s) in the dropdown. The options will
+          be the values for the provided keys. The following example shows the prop set as{' '}
+          <code>{`replaceRawSearchKeys={['span.description']}`}</code>.
+        </p>
+        <SearchQueryBuilder
+          initialQuery=""
+          filterKeySections={FILTER_KEY_SECTIONS}
+          filterKeys={FILTER_KEYS}
+          getTagValues={getTagValues}
+          searchSource="storybook"
+          replaceRawSearchKeys={['span.description']}
+        />
+        <p>
+          You can also pass multiple values in the prop to replace multiple keys.{' '}
+          <code>{`replaceRawSearchKeys={['span.op', 'span.description']}`}</code>.
+        </p>
+        <SearchQueryBuilder
+          initialQuery=""
+          filterKeySections={FILTER_KEY_SECTIONS}
+          filterKeys={FILTER_KEYS}
+          getTagValues={getTagValues}
+          searchSource="storybook"
+          replaceRawSearchKeys={['span.op', 'span.description']}
+        />
+      </Fragment>
+    );
+  });
+
   story('SearchQueryBuilderProvider', () => {
     function OpenDropdownButton() {
       const {dispatch} = useSearchQueryBuilder();

--- a/static/app/components/searchQueryBuilder/index.tsx
+++ b/static/app/components/searchQueryBuilder/index.tsx
@@ -103,6 +103,19 @@ export interface SearchQueryBuilderProps {
    */
   invalidMessages?: SearchConfig['invalidMessages'];
   label?: string;
+  /**
+   * Allows for key suggestions to be rendered when the value matches the pattern.
+   * This is useful for keys that have a specific format, such as trace IDs or IDs.
+   *
+   * @example
+   * ```tsx
+   * <SearchQueryBuilder
+   *   // ...
+   *   matchKeySuggestions={[{key: 'trace', valuePattern: /^[0-9a-fA-F]{32}$/}]}
+   * />
+   * ```
+   */
+  matchKeySuggestions?: Array<{key: string; valuePattern: RegExp}>;
   onBlur?: (query: string, state: CallbackSearchState) => void;
   /**
    * Called when the query value changes
@@ -125,6 +138,7 @@ export interface SearchQueryBuilderProps {
    * If provided, saves and displays recent searches of the given type.
    */
   recentSearches?: SavedSearchType;
+
   /**
    * When set, provided keys will override default raw search capabilities, while
    * replacing it with options that include the provided keys, and the user's input

--- a/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
@@ -147,12 +147,6 @@ export function useSortedFilterKeyItems({
   const hasWildcardSearch = organization.features.includes(
     'search-query-builder-wildcard-operators'
   );
-  const hasRawSearchReplacement = organization.features.includes(
-    'search-query-builder-raw-search-replacement'
-  );
-  const hasMatchKeySuggestions = organization.features.includes(
-    'search-query-builder-match-key-suggestions'
-  );
 
   const flatKeys = useMemo(() => Object.values(filterKeys), [filterKeys]);
 
@@ -222,7 +216,7 @@ export function useSortedFilterKeyItems({
         inputValue &&
         !isQuoted(inputValue) &&
         (!keyItems.length || inputValue.trim().includes(' ')) &&
-        (!replaceRawSearchKeys?.length || !hasRawSearchReplacement);
+        !replaceRawSearchKeys?.length;
 
       let rawSearchFilterHasValueItems: RawSearchFilterHasValueItem[] = [];
       if (hasWildcardSearch) {
@@ -254,8 +248,7 @@ export function useSortedFilterKeyItems({
         inputValue &&
         !isQuoted(inputValue) &&
         (!keyItems.length || inputValue.trim().includes(' ')) &&
-        !!replaceRawSearchKeys?.length &&
-        hasRawSearchReplacement;
+        !!replaceRawSearchKeys?.length;
 
       const keyItemsSection: KeySectionItem = {
         key: 'key-items',
@@ -271,10 +264,7 @@ export function useSortedFilterKeyItems({
         !isQuoted(inputValue) &&
         (!keyItems.length || inputValue.trim().includes(' ')) &&
         !!matchKeySuggestions?.length &&
-        matchKeySuggestions.some(suggestion =>
-          suggestion.valuePattern.test(inputValue)
-        ) &&
-        hasMatchKeySuggestions;
+        matchKeySuggestions.some(suggestion => suggestion.valuePattern.test(inputValue));
 
       let matchKeySuggestionsOptions: SearchKeyItem[] = [];
       if (shouldShowMatchKeySuggestions && matchKeySuggestions) {
@@ -322,8 +312,6 @@ export function useSortedFilterKeyItems({
     flatKeys,
     gaveSeerConsent,
     getFieldDefinition,
-    hasMatchKeySuggestions,
-    hasRawSearchReplacement,
     hasWildcardSearch,
     includeSuggestions,
     inputValue,

--- a/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
+++ b/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
@@ -19,6 +19,7 @@ type TraceItemSearchQueryBuilderProps = {
   numberSecondaryAliases: TagCollection;
   stringAttributes: TagCollection;
   stringSecondaryAliases: TagCollection;
+  matchKeySuggestions?: Array<{key: string; valuePattern: RegExp}>;
   replaceRawSearchKeys?: string[];
 } & Omit<EAPSpanSearchQueryBuilderProps, 'numberTags' | 'stringTags'>;
 
@@ -67,6 +68,7 @@ export function useSearchQueryBuilderProps({
   projects,
   supportedAggregates = [],
   replaceRawSearchKeys,
+  matchKeySuggestions,
 }: TraceItemSearchQueryBuilderProps) {
   const placeholderText = itemTypeToDefaultPlaceholder(itemType);
   const functionTags = useFunctionTags(itemType, supportedAggregates);
@@ -102,6 +104,7 @@ export function useSearchQueryBuilderProps({
     showUnsubmittedIndicator: true,
     portalTarget,
     replaceRawSearchKeys,
+    matchKeySuggestions,
     filterKeyAliases: {...numberSecondaryAliases, ...stringSecondaryAliases},
   };
 }

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -206,6 +206,13 @@ function SpanTabSearchSection({datePageFilterProps}: SpanTabSearchSectionProps) 
   const search = useMemo(() => new MutableSearch(query), [query]);
   const oldSearch = usePrevious(search);
 
+  const hasRawSearchReplacement = organization.features.includes(
+    'search-query-builder-raw-search-replacement'
+  );
+  const hasMatchKeySuggestions = organization.features.includes(
+    'search-query-builder-match-key-suggestions'
+  );
+
   const eapSpanSearchQueryBuilderProps = useMemo(
     () => ({
       initialQuery: query,
@@ -240,24 +247,28 @@ function SpanTabSearchSection({datePageFilterProps}: SpanTabSearchSectionProps) 
         mode === Mode.SAMPLES ? [] : ALLOWED_EXPLORE_VISUALIZE_AGGREGATES,
       numberTags,
       stringTags,
-      replaceRawSearchKeys: ['span.description'],
-      matchKeySuggestions: [
-        {key: 'trace', valuePattern: /^[0-9a-fA-F]{32}$/},
-        {key: 'id', valuePattern: /^[0-9a-fA-F]{16}$/},
-      ],
+      replaceRawSearchKeys: hasRawSearchReplacement ? ['span.description'] : undefined,
+      matchKeySuggestions: hasMatchKeySuggestions
+        ? [
+            {key: 'trace', valuePattern: /^[0-9a-fA-F]{32}$/},
+            {key: 'id', valuePattern: /^[0-9a-fA-F]{16}$/},
+          ]
+        : undefined,
       numberSecondaryAliases,
       stringSecondaryAliases,
     }),
     [
-      query,
-      mode,
-      numberTags,
-      numberSecondaryAliases,
-      stringTags,
-      stringSecondaryAliases,
-      oldSearch,
       fields,
+      hasMatchKeySuggestions,
+      hasRawSearchReplacement,
+      mode,
+      numberSecondaryAliases,
+      numberTags,
+      oldSearch,
+      query,
       setExplorePageParams,
+      stringSecondaryAliases,
+      stringTags,
     ]
   );
 

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -241,6 +241,10 @@ function SpanTabSearchSection({datePageFilterProps}: SpanTabSearchSectionProps) 
       numberTags,
       stringTags,
       replaceRawSearchKeys: ['span.description'],
+      matchKeySuggestions: [
+        {key: 'trace', valuePattern: /^[0-9a-fA-F]{32}$/},
+        {key: 'id', valuePattern: /^[0-9a-fA-F]{16}$/},
+      ],
       numberSecondaryAliases,
       stringSecondaryAliases,
     }),

--- a/static/app/views/insights/agentMonitoring/views/agentsOverviewPage.tsx
+++ b/static/app/views/insights/agentMonitoring/views/agentsOverviewPage.tsx
@@ -125,6 +125,13 @@ function AgentsMonitoringPage() {
   const {tags: stringTags, secondaryAliases: stringSecondaryAliases} =
     useTraceItemTags('string');
 
+  const hasRawSearchReplacement = organization.features.includes(
+    'search-query-builder-raw-search-replacement'
+  );
+  const hasMatchKeySuggestions = organization.features.includes(
+    'search-query-builder-match-key-suggestions'
+  );
+
   const eapSpanSearchQueryBuilderProps = useMemo(
     () => ({
       initialQuery: searchQuery ?? '',
@@ -136,13 +143,17 @@ function AgentsMonitoringPage() {
       stringTags,
       numberSecondaryAliases,
       stringSecondaryAliases,
-      replaceRawSearchKeys: ['span.description'],
-      matchKeySuggestions: [
-        {key: 'trace', valuePattern: /^[0-9a-fA-F]{32}$/},
-        {key: 'id', valuePattern: /^[0-9a-fA-F]{16}$/},
-      ],
+      replaceRawSearchKeys: hasRawSearchReplacement ? ['span.description'] : undefined,
+      matchKeySuggestions: hasMatchKeySuggestions
+        ? [
+            {key: 'trace', valuePattern: /^[0-9a-fA-F]{32}$/},
+            {key: 'id', valuePattern: /^[0-9a-fA-F]{16}$/},
+          ]
+        : undefined,
     }),
     [
+      hasMatchKeySuggestions,
+      hasRawSearchReplacement,
       numberSecondaryAliases,
       numberTags,
       searchQuery,

--- a/static/app/views/insights/agentMonitoring/views/agentsOverviewPage.tsx
+++ b/static/app/views/insights/agentMonitoring/views/agentsOverviewPage.tsx
@@ -137,6 +137,10 @@ function AgentsMonitoringPage() {
       numberSecondaryAliases,
       stringSecondaryAliases,
       replaceRawSearchKeys: ['span.description'],
+      matchKeySuggestions: [
+        {key: 'trace', valuePattern: /^[0-9a-fA-F]{32}$/},
+        {key: 'id', valuePattern: /^[0-9a-fA-F]{16}$/},
+      ],
     }),
     [
       numberSecondaryAliases,

--- a/static/app/views/insights/mcp/views/overview.tsx
+++ b/static/app/views/insights/mcp/views/overview.tsx
@@ -167,6 +167,10 @@ function McpOverviewPage() {
       numberSecondaryAliases,
       stringSecondaryAliases,
       replaceRawSearchKeys: ['span.description'],
+      matchKeySuggestions: [
+        {key: 'trace', valuePattern: /^[0-9a-fA-F]{32}$/},
+        {key: 'id', valuePattern: /^[0-9a-fA-F]{16}$/},
+      ],
     }),
     [
       numberSecondaryAliases,

--- a/static/app/views/insights/mcp/views/overview.tsx
+++ b/static/app/views/insights/mcp/views/overview.tsx
@@ -155,6 +155,13 @@ function McpOverviewPage() {
   const {tags: stringTags, secondaryAliases: stringSecondaryAliases} =
     useTraceItemTags('string');
 
+  const hasRawSearchReplacement = organization.features.includes(
+    'search-query-builder-raw-search-replacement'
+  );
+  const hasMatchKeySuggestions = organization.features.includes(
+    'search-query-builder-match-key-suggestions'
+  );
+
   const eapSpanSearchQueryBuilderProps = useMemo(
     () => ({
       initialQuery: searchQuery ?? '',
@@ -166,13 +173,17 @@ function McpOverviewPage() {
       stringTags,
       numberSecondaryAliases,
       stringSecondaryAliases,
-      replaceRawSearchKeys: ['span.description'],
-      matchKeySuggestions: [
-        {key: 'trace', valuePattern: /^[0-9a-fA-F]{32}$/},
-        {key: 'id', valuePattern: /^[0-9a-fA-F]{16}$/},
-      ],
+      replaceRawSearchKeys: hasRawSearchReplacement ? ['span.description'] : undefined,
+      matchKeySuggestions: hasMatchKeySuggestions
+        ? [
+            {key: 'trace', valuePattern: /^[0-9a-fA-F]{32}$/},
+            {key: 'id', valuePattern: /^[0-9a-fA-F]{16}$/},
+          ]
+        : undefined,
     }),
     [
+      hasMatchKeySuggestions,
+      hasRawSearchReplacement,
       numberSecondaryAliases,
       numberTags,
       searchQuery,


### PR DESCRIPTION
This PR adds in a new prop to the search query builder context, that allows devs to pass in an array of objects, containing a key, and a regexp value matcher, so that we can provide key value suggestions based off of the raw input. This has been done for span id's and trace id's for all of the EAP Span search query builders.

Ticket: EXP-376

Span id's:
<img width="389" height="235" alt="Screenshot 2025-07-28 at 13 28 25" src="https://github.com/user-attachments/assets/1d35bc91-3031-49f3-b8b8-65d5a06ac173" />

Trace id's:
<img width="511" height="233" alt="Screenshot 2025-07-28 at 13 28 43" src="https://github.com/user-attachments/assets/ff41ed2d-d6a8-446f-8f7e-cdc749003ea8" />