### PR TITLE
ref: getApiUrl helper

### DIFF
--- a/static/app/api/getApiUrl.spec.ts
+++ b/static/app/api/getApiUrl.spec.ts
@@ -32,14 +32,6 @@ describe('getApiUrl', () => {
     expect(url).toBe('/projects/my-org/my-project/releases/v%201.0.0/');
   });
 
-  test('should not modify already encoded parameters', () => {
-    const url = getApiUrl('/search/$query/', {
-      path: {query: 'test%20query'},
-    });
-
-    expect(url).toBe('/search/test%20query/');
-  });
-
   test('should stringify number path params', () => {
     const url = getApiUrl('/items/$id/', {
       path: {id: 123},

--- a/static/app/api/getApiUrl.spec.ts
+++ b/static/app/api/getApiUrl.spec.ts
@@ -1,0 +1,87 @@
+import {getApiUrl} from './getApiUrl';
+
+describe('getApiUrl', () => {
+  test('should replace path parameters with their values', () => {
+    const url = getApiUrl('/projects/$orgSlug/$projectSlug/', {
+      path: {
+        orgSlug: 'my-org',
+        projectSlug: 'my-project',
+      },
+    });
+
+    expect(url).toBe('/projects/my-org/my-project/');
+  });
+
+  test('should not require path parameters if none are present', () => {
+    const url = getApiUrl('/projects/');
+
+    expect(url).toBe('/projects/');
+  });
+
+  test('should encode path parameters correctly', () => {
+    const url = getApiUrl('/projects/$orgSlug/$projectSlug/releases/$releaseVersion/', {
+      path: {
+        orgSlug: 'my-org',
+        projectSlug: 'my-project',
+        releaseVersion: 'v 1.0.0',
+      },
+    });
+
+    expect(url).toBe('/projects/my-org/my-project/releases/v%201.0.0/');
+  });
+
+  test('should not modify already encoded parameters', () => {
+    const url = getApiUrl('/search/$query/', {
+      path: {query: 'test%20query'},
+    });
+
+    expect(url).toBe('/search/test%20query/');
+  });
+
+  test('should stringify number path params', () => {
+    const url = getApiUrl('/items/$id/', {
+      path: {id: 123},
+    });
+
+    expect(url).toBe('/items/123/');
+  });
+
+  test('should not do accidental replacements', () => {
+    const url = getApiUrl('/projects/$id1/$id', {
+      path: {id: '123', id1: '456'},
+    });
+
+    expect(url).toBe('/projects/456/123');
+  });
+
+  describe('types', () => {
+    test('should not allow invalid path parameters', () => {
+      getApiUrl('/projects/$orgSlug/', {
+        // @ts-expect-error Invalid path parameter
+        path: {orgSlug: 'my-org', invalidParam: 'invalid'},
+      });
+    });
+
+    test('should not allow excess path parameters', () => {
+      getApiUrl('/projects/$orgSlug/', {
+        staleTime: 0,
+        // @ts-expect-error Excess path parameter
+        path: {orgSlug: 'my-org', extraParam: 'extra'},
+      });
+    });
+
+    test('should require path params for paths with parameters', () => {
+      expect(() => {
+        getApiUrl('/projects/$orgSlug/', {
+          // @ts-expect-error Missing required path parameter
+          path: {},
+        });
+      }).toThrow('Missing path param: orgSlug');
+    });
+
+    test('should not allow empty path parameters for paths without parameters', () => {
+      // @ts-expect-error Expected 1 argument, but got 2
+      getApiUrl('/projects/', {path: {}});
+    });
+  });
+});

--- a/static/app/api/getApiUrl.spec.ts
+++ b/static/app/api/getApiUrl.spec.ts
@@ -1,3 +1,5 @@
+import {expectTypeOf} from 'expect-type';
+
 import {getApiUrl} from './getApiUrl';
 
 describe('getApiUrl', () => {
@@ -55,6 +57,13 @@ describe('getApiUrl', () => {
   });
 
   describe('types', () => {
+    test('should return branded string type', () => {
+      const url = getApiUrl('/projects/$orgSlug/', {
+        path: {orgSlug: 'my-org'},
+      });
+
+      expectTypeOf(url).toEqualTypeOf<string & {__apiUrl: true}>();
+    });
     test('should not allow invalid path parameters', () => {
       getApiUrl('/projects/$orgSlug/', {
         // @ts-expect-error Invalid path parameter

--- a/static/app/api/getApiUrl.ts
+++ b/static/app/api/getApiUrl.ts
@@ -29,10 +29,12 @@ type OptionalPathParams<TApiPath extends string> =
 
 const paramRegex = /\$([a-zA-Z0-9_-]+)/g;
 
+type ApiUrl = string & {__apiUrl: true};
+
 export function getApiUrl<TApiPath extends string>(
   path: TApiPath,
   ...[options]: OptionalPathParams<TApiPath>
-): string {
+): ApiUrl {
   let url: string = path;
   const pathParams = options?.path;
   if (pathParams) {
@@ -44,5 +46,5 @@ export function getApiUrl<TApiPath extends string>(
       return safeEncodeURIComponent(String(pathParams[key as keyof typeof pathParams]));
     });
   }
-  return url;
+  return url as ApiUrl;
 }

--- a/static/app/api/getApiUrl.ts
+++ b/static/app/api/getApiUrl.ts
@@ -1,15 +1,3 @@
-function safeEncodeURIComponent(input: string) {
-  try {
-    // If decoding and re-encoding gives the same string, it's already encoded
-    if (encodeURIComponent(decodeURIComponent(input)) === input) {
-      return input;
-    }
-  } catch (e) {
-    // decodeURIComponent threw an error, so it was not encoded
-  }
-  return encodeURIComponent(input);
-}
-
 type ExtractPathParams<TApiPath extends string> =
   TApiPath extends `${string}$${infer Param}/${infer Rest}`
     ? Param | ExtractPathParams<`/${Rest}`>
@@ -43,7 +31,7 @@ export function getApiUrl<TApiPath extends string>(
       if (!(key in pathParams)) {
         throw new Error(`Missing path param: ${key}`);
       }
-      return safeEncodeURIComponent(String(pathParams[key as keyof typeof pathParams]));
+      return encodeURIComponent(String(pathParams[key as keyof typeof pathParams]));
     });
   }
   return url as ApiUrl;

--- a/static/app/api/getApiUrl.ts
+++ b/static/app/api/getApiUrl.ts
@@ -1,0 +1,48 @@
+function safeEncodeURIComponent(input: string) {
+  try {
+    // If decoding and re-encoding gives the same string, it's already encoded
+    if (encodeURIComponent(decodeURIComponent(input)) === input) {
+      return input;
+    }
+  } catch (e) {
+    // decodeURIComponent threw an error, so it was not encoded
+  }
+  return encodeURIComponent(input);
+}
+
+type ExtractPathParams<TApiPath extends string> =
+  TApiPath extends `${string}$${infer Param}/${infer Rest}`
+    ? Param | ExtractPathParams<`/${Rest}`>
+    : TApiPath extends `${string}$${infer Param}`
+      ? Param
+      : never;
+
+type PathParamOptions<TApiPath extends string> =
+  ExtractPathParams<TApiPath> extends never
+    ? {path?: never}
+    : {path: Record<ExtractPathParams<TApiPath>, string | number>};
+
+type OptionalPathParams<TApiPath extends string> =
+  ExtractPathParams<TApiPath> extends never
+    ? [] // eslint-disable-line @typescript-eslint/no-restricted-types
+    : [PathParamOptions<TApiPath>];
+
+const paramRegex = /\$([a-zA-Z0-9_-]+)/g;
+
+export function getApiUrl<TApiPath extends string>(
+  path: TApiPath,
+  ...[options]: OptionalPathParams<TApiPath>
+): string {
+  let url: string = path;
+  const pathParams = options?.path;
+  if (pathParams) {
+    // Replace path parameters in the URL with their corresponding values
+    url = url.replace(paramRegex, (_, key: string) => {
+      if (!(key in pathParams)) {
+        throw new Error(`Missing path param: ${key}`);
+      }
+      return safeEncodeURIComponent(String(pathParams[key as keyof typeof pathParams]));
+    });
+  }
+  return url;
+}

--- a/static/app/utils/useRelease.tsx
+++ b/static/app/utils/useRelease.tsx
@@ -1,19 +1,6 @@
+import {getApiUrl} from 'sentry/api/getApiUrl';
 import type {Release} from 'sentry/types/release';
-import {type ApiQueryKey, useApiQuery} from 'sentry/utils/queryClient';
-
-function getReleaseQueryKey({
-  orgSlug,
-  projectSlug,
-  releaseVersion,
-}: {
-  orgSlug: string;
-  projectSlug: string;
-  releaseVersion: string;
-}): ApiQueryKey {
-  return [
-    `/projects/${orgSlug}/${projectSlug}/releases/${encodeURIComponent(releaseVersion)}/`,
-  ];
-}
+import {useApiQuery} from 'sentry/utils/queryClient';
 
 export function useRelease({
   orgSlug,
@@ -27,7 +14,15 @@ export function useRelease({
   enabled?: boolean;
 }) {
   return useApiQuery<Release>(
-    getReleaseQueryKey({orgSlug, projectSlug, releaseVersion}),
+    [
+      getApiUrl('/projects/$orgSlug/$projectSlug/releases/$releaseVersion/', {
+        path: {
+          orgSlug,
+          projectSlug,
+          releaseVersion,
+        },
+      }),
+    ],
     {
       enabled,
       staleTime: Infinity,


### PR DESCRIPTION
taken partially from:
- https://github.com/getsentry/sentry/pull/96085

the `getApiUrl` helper ensures that:

- we don’t manually build strings, but have placeholders inside known paths that we replace
- the replacement always includes URI encoding, so it can’t be forgotten
- ~the replacement is resilient against already receiving URI encoded values~ dropped this
- returns a branded string type so that we _could_ enforce this being passed to e.g. `useApiQuery`.

we can start building a “known list of API urls” that are valid to be passed towards `getApiUrl` as type hints for auto-completion in a follow-up. This is also a stepping stone towards `apiOptions`, which would use this under the hood.