### PR TITLE
test(relay): add tests for trusted relay signature verification

### DIFF
--- a/src/sentry/testutils/pytest/template/config.yml
+++ b/src/sentry/testutils/pytest/template/config.yml
@@ -21,3 +21,5 @@ aggregator:
   bucket_interval: 1 # Use shortest possible interval to speed up tests
   initial_delay: 0
   debounce_delay: 0
+auth:
+  signature_max_age: 300

--- a/src/sentry/testutils/relay.py
+++ b/src/sentry/testutils/relay.py
@@ -35,12 +35,14 @@ class RelayStoreHelper(RequiredBaseclass):
     get_relay_minidump_url: Any
     get_relay_unreal_url: Any
 
-    def post_and_retrieve_event(self, data):
+    def post_and_retrieve_event(self, data, headers=None):
+        if headers is None:
+            headers = {"x-sentry-auth": self.auth_header, "content-type": "application/json"}
         url = self.get_relay_store_url(self.project.id)
         responses.add_passthru(url)
         resp = requests.post(
             url,
-            headers={"x-sentry-auth": self.auth_header, "content-type": "application/json"},
+            headers=headers,
             json=data,
         )
 
@@ -89,9 +91,9 @@ class RelayStoreHelper(RequiredBaseclass):
         assert event
         return event
 
-    def post_and_try_retrieve_event(self, data):
+    def post_and_try_retrieve_event(self, data, headers=None):
         try:
-            return self.post_and_retrieve_event(data)
+            return self.post_and_retrieve_event(data, headers)
         except AssertionError:
             return None
 

--- a/tests/relay_integration/test_integration.py
+++ b/tests/relay_integration/test_integration.py
@@ -500,7 +500,7 @@ class SentryRemoteTest(RelayStoreHelper, TransactionTestCase):
             headers={
                 "x-sentry-auth": self.auth_header,
                 "content-type": "application/json",
-                "x-sentry-relay-signature": b"\xff\xff\xff\xff",
+                "x-sentry-relay-signature": "\xff\xff\xff\xff",
             },
             json={"message": "hello"},
         )


### PR DESCRIPTION
This PR adds tests into sentry to make sure the trusted relay signature works properly.

These tests are supposed to introduce additional safety and prevent regression, even if something changes on the Relay side.
Similar tests in Relay can be found here: https://github.com/getsentry/relay/blob/master/tests/integration/test_trusted_relay.py

closes INGEST-435