### PR TITLE
ref(ui2): fix "Release Created" readability

### DIFF
--- a/static/app/views/releases/detail/utils.tsx
+++ b/static/app/views/releases/detail/utils.tsx
@@ -178,11 +178,10 @@ function generateReleaseMarkLine(
       label: {
         position: 'insideEndBottom',
         formatter: hideLabel ? '' : title,
-        // @ts-expect-error TS(2322): Type '{ position: "insideEndBottom"; formatter: st... Remove this comment to see the full error message
-        font: 'Rubik',
+        fontFamily: 'Rubik',
         fontSize: 14,
-        color: theme.chartLabel,
-        backgroundColor: theme.chartOther,
+        color: theme.tokens.content.muted,
+        backgroundColor: theme.tokens.background.secondary,
       },
       data: [
         {


### PR DESCRIPTION
`Release Created` is now well visible in all 4 variants:

<img width="472" height="444" alt="Screenshot 2025-07-29 at 14 59 46" src="https://github.com/user-attachments/assets/b3c4d7a2-4169-43dd-8394-9f211c09c814" />
<img width="472" height="444" alt="Screenshot 2025-07-29 at 14 59 49" src="https://github.com/user-attachments/assets/0621a9e6-1757-435e-a6a9-a306281c951d" />
<img width="472" height="444" alt="Screenshot 2025-07-29 at 14 59 52" src="https://github.com/user-attachments/assets/44b8c67d-036a-4a23-b601-12508dff1f86" />
<img width="472" height="444" alt="Screenshot 2025-07-29 at 15 00 27" src="https://github.com/user-attachments/assets/bd647ed1-ea57-4105-a692-ea93a0c0292e" />
