### PR TITLE
feat(dynamic-sampling): add endpoint for dynamic sampling metrics

### DIFF
--- a/src/sentry/api/endpoints/organization_sampling_admin_metrics.py
+++ b/src/sentry/api/endpoints/organization_sampling_admin_metrics.py
@@ -1,0 +1,106 @@
+from rest_framework.exceptions import ParseError
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases import OrganizationAndStaffPermission, OrganizationEndpoint
+from sentry.api.endpoints.organization_release_health_data import MetricsDataSeriesPaginator
+from sentry.exceptions import InvalidParams
+from sentry.sentry_metrics.use_case_utils import get_use_case_id
+from sentry.snuba.metrics import DerivedMetricException, QueryDefinition, get_series
+from sentry.snuba.metrics.naming_layer import SessionMetricKey
+from sentry.snuba.metrics.query_builder import parse_field
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
+from sentry.utils import metrics
+
+
+@region_silo_endpoint
+class OrganizationReleaseHealthDataEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.PRIVATE,
+    }
+    owner = ApiOwner.TELEMETRY_EXPERIENCE
+    permission_classes = (OrganizationAndStaffPermission,)
+
+    # 60 req/s to allow for metric dashboard loading
+    default_rate_limit = RateLimit(limit=60, window=1)
+
+    rate_limits = {
+        "GET": {
+            RateLimitCategory.IP: default_rate_limit,
+            RateLimitCategory.USER: default_rate_limit,
+            RateLimitCategory.ORGANIZATION: default_rate_limit,
+        },
+    }
+
+    default_per_page = 50
+
+    def _validate_fields(self, request: Request):
+        """
+        Validates fields request parameter.
+        Checks if metric field is public (InvalidParams exception is raised if it is not),
+        and checks if every generic metric that is requested has operation assigned, because
+        it is not possible to query generic metrics without assigned operation.
+
+        NOTE 'd:sessions/duration.exited@second' is a derived metric but for unknown
+        reason entity is not 'e', so we do extra check just for that metric.
+        """
+        fields = request.GET.getlist("field", [])
+        for field in fields:
+            try:
+                metric_field = parse_field(field, allow_mri=True)
+                if (
+                    metric_field.op is None
+                    and not metric_field.metric_mri.startswith("e:")
+                    and metric_field.metric_mri
+                    != "d:sessions/duration.exited@second"  # this is special case, derived metric without 'e' as entity
+                ):
+                    raise ParseError(
+                        detail="You can not use generic metric public field without operation"
+                    )
+            except InvalidParams as exc:
+                raise ParseError(detail=str(exc))
+
+    def get(self, request: Request, organization) -> Response:
+        projects = self.get_projects(request, organization)
+        self._validate_fields(request)
+
+        def data_fn(offset: int, limit: int):
+            try:
+                query = QueryDefinition(
+                    projects,
+                    request.GET,
+                    allow_mri=True,
+                    paginator_kwargs={"limit": limit, "offset": offset},
+                )
+                data = get_series(
+                    projects,
+                    metrics_query=query.to_metrics_query(),
+                    use_case_id=get_use_case_id(request),
+                    tenant_ids={"organization_id": organization.id},
+                )
+                # due to possible data corruption crash free value can be less than 0 or greater than 1,
+                # which is not valid behavior, so those values have to be capped
+                metrics.ensure_crash_rate_in_bounds(
+                    data, request, organization, SessionMetricKey.CRASH_RATE.value
+                )
+                metrics.ensure_crash_rate_in_bounds(
+                    data, request, organization, SessionMetricKey.CRASH_FREE_RATE.value
+                )
+
+                data["query"] = query.query
+            except (
+                InvalidParams,
+                DerivedMetricException,
+            ) as exc:
+                raise (ParseError(detail=str(exc)))
+            return data
+
+        return self.paginate(
+            request,
+            paginator=MetricsDataSeriesPaginator(data_fn=data_fn),
+            default_per_page=self.default_per_page,
+            max_per_page=100,
+        )

--- a/src/sentry/api/endpoints/organization_sampling_admin_metrics.py
+++ b/src/sentry/api/endpoints/organization_sampling_admin_metrics.py
@@ -1,28 +1,42 @@
-from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
-from sentry.api.bases import OrganizationAndStaffPermission, OrganizationEndpoint
-from sentry.api.endpoints.organization_release_health_data import MetricsDataSeriesPaginator
-from sentry.exceptions import InvalidParams
-from sentry.sentry_metrics.use_case_utils import get_use_case_id
-from sentry.snuba.metrics import DerivedMetricException, QueryDefinition, get_series
-from sentry.snuba.metrics.naming_layer import SessionMetricKey
-from sentry.snuba.metrics.query_builder import parse_field
+from sentry.api.bases import OrganizationEndpoint
+from sentry.api.permissions import StaffPermission
+from sentry.api.utils import get_date_range_from_params
+from sentry.constants import ObjectStatus
+from sentry.models.organization import Organization
+from sentry.models.project import Project
+from sentry.sentry_metrics.querying.data import (
+    MetricsAPIQueryResultsTransformer,
+    MQLQuery,
+    run_queries,
+)
+from sentry.sentry_metrics.querying.types import QueryOrder, QueryType
+from sentry.sentry_metrics.use_case_id_registry import UseCaseID
+from sentry.sentry_metrics.utils import STRING_NOT_FOUND, resolve_weak
+from sentry.snuba.metrics import SpanMRI
+from sentry.snuba.referrer import Referrer
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
-from sentry.utils import metrics
+from sentry.utils.dates import parse_stats_period
 
 
 @region_silo_endpoint
-class OrganizationReleaseHealthDataEndpoint(OrganizationEndpoint):
+class OrganizationDynamicSamplingAdminMetricsEndpoint(OrganizationEndpoint):
+    """
+    The purpose of this endpoint is to provide a way to query metrics for
+    dynamic sampling that can be displayed in admin and used to debug
+    dynamic sampling.
+    """
+
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }
     owner = ApiOwner.TELEMETRY_EXPERIENCE
-    permission_classes = (OrganizationAndStaffPermission,)
+    permission_classes = (StaffPermission,)
 
     # 60 req/s to allow for metric dashboard loading
     default_rate_limit = RateLimit(limit=60, window=1)
@@ -37,70 +51,44 @@ class OrganizationReleaseHealthDataEndpoint(OrganizationEndpoint):
 
     default_per_page = 50
 
-    def _validate_fields(self, request: Request):
-        """
-        Validates fields request parameter.
-        Checks if metric field is public (InvalidParams exception is raised if it is not),
-        and checks if every generic metric that is requested has operation assigned, because
-        it is not possible to query generic metrics without assigned operation.
-
-        NOTE 'd:sessions/duration.exited@second' is a derived metric but for unknown
-        reason entity is not 'e', so we do extra check just for that metric.
-        """
-        fields = request.GET.getlist("field", [])
-        for field in fields:
-            try:
-                metric_field = parse_field(field, allow_mri=True)
-                if (
-                    metric_field.op is None
-                    and not metric_field.metric_mri.startswith("e:")
-                    and metric_field.metric_mri
-                    != "d:sessions/duration.exited@second"  # this is special case, derived metric without 'e' as entity
-                ):
-                    raise ParseError(
-                        detail="You can not use generic metric public field without operation"
-                    )
-            except InvalidParams as exc:
-                raise ParseError(detail=str(exc))
-
-    def get(self, request: Request, organization) -> Response:
-        projects = self.get_projects(request, organization)
-        self._validate_fields(request)
-
-        def data_fn(offset: int, limit: int):
-            try:
-                query = QueryDefinition(
-                    projects,
-                    request.GET,
-                    allow_mri=True,
-                    paginator_kwargs={"limit": limit, "offset": offset},
-                )
-                data = get_series(
-                    projects,
-                    metrics_query=query.to_metrics_query(),
-                    use_case_id=get_use_case_id(request),
-                    tenant_ids={"organization_id": organization.id},
-                )
-                # due to possible data corruption crash free value can be less than 0 or greater than 1,
-                # which is not valid behavior, so those values have to be capped
-                metrics.ensure_crash_rate_in_bounds(
-                    data, request, organization, SessionMetricKey.CRASH_RATE.value
-                )
-                metrics.ensure_crash_rate_in_bounds(
-                    data, request, organization, SessionMetricKey.CRASH_FREE_RATE.value
-                )
-
-                data["query"] = query.query
-            except (
-                InvalidParams,
-                DerivedMetricException,
-            ) as exc:
-                raise (ParseError(detail=str(exc)))
-            return data
-
-        return self.paginate(
-            request,
-            paginator=MetricsDataSeriesPaginator(data_fn=data_fn),
-            default_per_page=self.default_per_page,
-            max_per_page=100,
+    def get(self, request: Request, organization: Organization) -> Response:
+        start, end = get_date_range_from_params(request.GET)
+        # We are purposely not filtering on team membership, as all users should be able to see the span counts
+        # in order to show the dynamic sampling settings page with all valid data. Please do not remove this
+        # without consulting the owner of the endpoint
+        projects = list(
+            Project.objects.filter(organization=organization, status=ObjectStatus.ACTIVE)
         )
+
+        transformer = MetricsAPIQueryResultsTransformer()
+
+        # Try to resolve the `target_project_id` tag first, as otherwise the query will
+        # fail to resolve the column and raise a validation error.
+        # When the tag is not present, we can simply return with an empty result set, as this
+        # means that there are no spans ingested yet.
+        if resolve_weak(UseCaseID.SPANS, organization.id, "target_project_id") == STRING_NOT_FOUND:
+            results = transformer.transform([])
+            return Response(status=200, data=results)
+
+        mql = f"sum({SpanMRI.COUNT_PER_ROOT_PROJECT.value}) by (project,target_project_id,transaction)"
+        query = MQLQuery(mql=mql, order=QueryOrder.DESC, limit=10000)
+        results = run_queries(
+            mql_queries=[query],
+            start=start,
+            end=end,
+            interval=self._interval_from_request(request),
+            organization=organization,
+            projects=projects,
+            environments=self.get_environments(request, organization),
+            referrer=Referrer.DYNAMIC_SAMPLING_SETTINGS_GET_SPAN_COUNTS.value,
+            query_type=QueryType.TOTALS,
+        ).apply_transformer(transformer)
+
+        return Response(status=200, data=results)
+
+    def _interval_from_request(self, request: Request) -> int:
+        """
+        Extracts the interval of the query from the request payload.
+        """
+        interval = parse_stats_period(request.GET.get("interval", "1h"))
+        return int(3600 if interval is None else interval.total_seconds())

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -30,6 +30,9 @@ from sentry.api.endpoints.organization_plugins_index import OrganizationPluginsE
 from sentry.api.endpoints.organization_projects_experiment import (
     OrganizationProjectsExperimentEndpoint,
 )
+from sentry.api.endpoints.organization_sampling_admin_metrics import (
+    OrganizationDynamicSamplingAdminMetricsEndpoint,
+)
 from sentry.api.endpoints.organization_sampling_project_span_counts import (
     OrganizationSamplingProjectSpanCountsEndpoint,
 )
@@ -1530,6 +1533,11 @@ ORGANIZATION_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_id_or_slug>[^/]+)/sampling/project-root-counts/$",
         OrganizationSamplingProjectSpanCountsEndpoint.as_view(),
         name="sentry-api-0-organization-sampling-root-counts",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/sampling/admin-metrics/$",
+        OrganizationDynamicSamplingAdminMetricsEndpoint.as_view(),
+        name="sentry-api-0-organization-sampling-admin-metrics",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^/]+)/sdk-updates/$",

--- a/tests/sentry/api/endpoints/test_organization_sampling_admin_metrics.py
+++ b/tests/sentry/api/endpoints/test_organization_sampling_admin_metrics.py
@@ -71,6 +71,7 @@ class OrganizationSamplingAdminMetricsTest(MetricsEnhancedPerformanceTestCase):
         response = self.client.get(self.get_url())
 
         assert response.status_code == 200
+        assert hasattr(response, "data")
         data = response.data
 
         # Verify response structure matches MetricsAPIQueryResultsTransformer format
@@ -136,6 +137,7 @@ class OrganizationSamplingAdminMetricsTest(MetricsEnhancedPerformanceTestCase):
         response = self.client.get(self.get_url(self.other_org.slug))
 
         assert response.status_code == 200
+        assert hasattr(response, "data")
         data = response.data
         assert "data" in data
 
@@ -155,6 +157,7 @@ class OrganizationSamplingAdminMetricsTest(MetricsEnhancedPerformanceTestCase):
             response = self.client.get(self.get_url())
 
             assert response.status_code == 200
+            assert hasattr(response, "data")
             data = response.data
 
             # Should return empty data structure
@@ -215,6 +218,7 @@ class OrganizationSamplingAdminMetricsTest(MetricsEnhancedPerformanceTestCase):
         response = self.client.get(self.get_url())
 
         assert response.status_code == 200
+        assert hasattr(response, "data")
         data = response.data
 
         # Verify top-level structure

--- a/tests/sentry/api/endpoints/test_organization_sampling_admin_metrics.py
+++ b/tests/sentry/api/endpoints/test_organization_sampling_admin_metrics.py
@@ -1,0 +1,247 @@
+from datetime import timedelta
+from unittest.mock import patch
+
+import pytest
+from django.urls import reverse
+
+from sentry.snuba.metrics import SpanMRI
+from sentry.testutils.cases import MetricsEnhancedPerformanceTestCase
+from sentry.testutils.helpers.datetime import freeze_time
+from sentry.testutils.pytest.fixtures import django_db_all
+from sentry.testutils.silo import region_silo_test
+
+pytestmark = [pytest.mark.sentry_metrics]
+
+
+@freeze_time(MetricsEnhancedPerformanceTestCase.MOCK_DATETIME)
+@region_silo_test
+class OrganizationSamplingAdminMetricsTest(MetricsEnhancedPerformanceTestCase):
+    endpoint = "sentry-api-0-organization-sampling-admin-metrics"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.org = self.create_organization(owner=self.user)
+        self.project_1 = self.create_project(organization=self.org, name="project_1")
+        self.project_2 = self.create_project(organization=self.org, name="project_2")
+        self.project_3 = self.create_project(organization=self.org, name="project_3")
+
+        # Create a staff user for permission testing
+        self.staff_user = self.create_user(is_staff=True)
+
+        # Create a regular user for negative permission testing
+        self.regular_user = self.create_user()
+        self.create_member(user=self.regular_user, organization=self.org, role="member")
+
+        # Create another organization for cross-org testing
+        self.other_org = self.create_organization()
+        self.other_project = self.create_project(organization=self.other_org)
+
+    def get_url(self, org_slug=None):
+        return reverse(self.endpoint, kwargs={"organization_id_or_slug": org_slug or self.org.slug})
+
+    def store_sample_metrics(self):
+        """Store sample metrics data for testing"""
+        metric_data = [
+            (self.project_1.id, self.project_2.id, "transaction_1", 100),
+            (self.project_1.id, self.project_3.id, "transaction_2", 150),
+            (self.project_2.id, self.project_1.id, "transaction_3", 200),
+        ]
+
+        hour_ago = self.MOCK_DATETIME - timedelta(hours=1)
+
+        for project_source_id, target_project_id, transaction, span_count in metric_data:
+            self.store_metric(
+                org_id=self.org.id,
+                value=span_count,
+                project_id=int(project_source_id),
+                mri=SpanMRI.COUNT_PER_ROOT_PROJECT.value,
+                tags={
+                    "target_project_id": str(target_project_id),
+                    "transaction": transaction,
+                },
+                timestamp=int(hour_ago.timestamp()),
+            )
+
+    @django_db_all
+    def test_staff_user_access_success(self) -> None:
+        """Test that staff users can access the endpoint"""
+        self.login_as(user=self.staff_user, staff=True)
+        self.store_sample_metrics()
+
+        response = self.client.get(self.get_url())
+
+        assert response.status_code == 200
+        data = response.data
+
+        # Verify response structure matches MetricsAPIQueryResultsTransformer format
+        assert "data" in data
+        assert "meta" in data
+        assert "start" in data
+        assert "end" in data
+        assert "intervals" in data
+
+        # Verify we have data
+        assert len(data["data"]) > 0
+        assert len(data["data"][0]) > 0
+
+        # Verify group structure
+        first_group = data["data"][0][0]
+        assert "by" in first_group
+        assert "totals" in first_group
+
+        # Verify group by fields are present
+        group_by_fields = first_group["by"]
+        assert "project" in group_by_fields
+        assert "target_project_id" in group_by_fields
+        assert "transaction" in group_by_fields
+
+    @django_db_all
+    def test_regular_user_access_denied(self) -> None:
+        """Test that regular users cannot access the endpoint"""
+        self.login_as(user=self.regular_user)
+
+        response = self.client.get(self.get_url())
+
+        assert response.status_code == 403
+
+    @django_db_all
+    def test_superuser_access_denied_without_staff(self) -> None:
+        """Test that superusers without staff flag cannot access the endpoint"""
+        superuser = self.create_user(is_superuser=True)
+        self.login_as(user=superuser, superuser=True)
+
+        response = self.client.get(self.get_url())
+
+        assert response.status_code == 403
+
+    @django_db_all
+    def test_staff_access_to_different_organization(self) -> None:
+        """Test that staff can access data from different organizations"""
+        self.login_as(user=self.staff_user, staff=True)
+
+        # Store metrics for the other org
+        hour_ago = self.MOCK_DATETIME - timedelta(hours=1)
+        self.store_metric(
+            org_id=self.other_org.id,
+            value=50,
+            project_id=self.other_project.id,
+            mri=SpanMRI.COUNT_PER_ROOT_PROJECT.value,
+            tags={
+                "target_project_id": str(self.other_project.id),
+                "transaction": "other_transaction",
+            },
+            timestamp=int(hour_ago.timestamp()),
+        )
+
+        response = self.client.get(self.get_url(self.other_org.slug))
+
+        assert response.status_code == 200
+        data = response.data
+        assert "data" in data
+
+    @django_db_all
+    def test_empty_response_when_no_target_project_id_tag(self) -> None:
+        """Test that endpoint returns empty result when target_project_id tag is not found"""
+        self.login_as(user=self.staff_user, staff=True)
+
+        # Mock resolve_weak to return STRING_NOT_FOUND
+        with patch(
+            "sentry.api.endpoints.organization_sampling_admin_metrics.resolve_weak"
+        ) as mock_resolve:
+            from sentry.sentry_metrics.utils import STRING_NOT_FOUND
+
+            mock_resolve.return_value = STRING_NOT_FOUND
+
+            response = self.client.get(self.get_url())
+
+            assert response.status_code == 200
+            data = response.data
+
+            # Should return empty data structure
+            assert data["data"] == []
+            assert data["meta"] == []
+            assert data["start"] is None
+            assert data["end"] is None
+            assert data["intervals"] == []
+
+    @django_db_all
+    def test_query_parameters(self) -> None:
+        """Test endpoint works with various query parameters"""
+        self.login_as(user=self.staff_user, staff=True)
+        self.store_sample_metrics()
+
+        # Test with statsPeriod
+        response = self.client.get(self.get_url(), {"statsPeriod": "24h"})
+        assert response.status_code == 200
+
+        # Test with start and end
+        from sentry.testutils.helpers.datetime import before_now
+
+        start = before_now(hours=2)
+        end = before_now(hours=1)
+
+        response = self.client.get(
+            self.get_url(),
+            {
+                "start": start.isoformat(),
+                "end": end.isoformat(),
+            },
+        )
+        assert response.status_code == 200
+
+    @django_db_all
+    def test_projects_filtering(self) -> None:
+        """Test that only active projects are included in the query"""
+        self.login_as(user=self.staff_user, staff=True)
+
+        # Create an inactive project
+        inactive_project = self.create_project(organization=self.org, name="inactive")
+        inactive_project.status = 1  # PENDING_DELETION
+        inactive_project.save()
+
+        self.store_sample_metrics()
+
+        response = self.client.get(self.get_url())
+
+        assert response.status_code == 200
+        # The inactive project should not be included in the projects list
+
+    @django_db_all
+    def test_response_data_structure_with_real_data(self) -> None:
+        """Test the actual response data structure with real metrics data"""
+        self.login_as(user=self.staff_user, staff=True)
+        self.store_sample_metrics()
+
+        response = self.client.get(self.get_url())
+
+        assert response.status_code == 200
+        data = response.data
+
+        # Verify top-level structure
+        assert isinstance(data["data"], list)
+        assert isinstance(data["meta"], list)
+        assert data["start"] is not None
+        assert data["end"] is not None
+        assert isinstance(data["intervals"], list)
+
+        # Verify data contains our metrics
+        if data["data"] and data["data"][0]:
+            groups = data["data"][0]
+
+            # Should have groups for our stored metrics
+            assert len(groups) > 0
+
+            for group in groups:
+                # Each group should have the correct structure
+                assert "by" in group
+                assert "totals" in group
+
+                # Should have our group by fields
+                by_fields = group["by"]
+                assert "project" in by_fields
+                assert "target_project_id" in by_fields
+                assert "transaction" in by_fields
+
+                # Totals should be numeric
+                if group["totals"] is not None:
+                    assert isinstance(group["totals"], (int, float))


### PR DESCRIPTION
- Add endpoint for dynamic sampling metrics that is accessible only for staff
- Goal is to display dynamic sampling metrics in admin to make it possible to identify issue with dynamic sampling on AM3
- Endpoint is loosely based on OrganizationSamplingProjectSpanCountsEndpoint, but needs to be with staff-only permissions

Contributes to TET-965