### PR TITLE
chore: add organization types in endpoints 🧼 

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,7 +188,7 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
         "PUT": ApiPublishStatus.PUBLIC,
     }
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """Get organization details."""
         return Response(
             serialize(

--- a/src/sentry/api/endpoints/chunk.py
+++ b/src/sentry/api/endpoints/chunk.py
@@ -17,6 +17,7 @@ from sentry.api.bases.organization import OrganizationEndpoint, OrganizationRele
 from sentry.api.utils import generate_region_url
 from sentry.models.files.fileblob import FileBlob
 from sentry.models.files.utils import MAX_FILE_SIZE
+from sentry.models.organization import Organization
 from sentry.preprod.authentication import LaunchpadRpcSignatureAuthentication
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.utils.http import absolute_uri
@@ -93,7 +94,7 @@ class ChunkUploadEndpoint(OrganizationEndpoint):
     permission_classes = (ChunkUploadPermission,)
     rate_limits = RateLimitConfig(group="CLI")
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         Return chunk upload parameters
         ``````````````````````````````

--- a/src/sentry/api/endpoints/data_scrubbing_selector_suggestions.py
+++ b/src/sentry/api/endpoints/data_scrubbing_selector_suggestions.py
@@ -11,6 +11,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.eventstore.models import Event
+from sentry.models.organization import Organization
 
 
 @region_silo_endpoint
@@ -20,7 +21,7 @@ class DataScrubbingSelectorSuggestionsEndpoint(OrganizationEndpoint):
     }
     owner = ApiOwner.TELEMETRY_EXPERIENCE
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         Generate a list of data scrubbing selectors from existing event data.
 

--- a/src/sentry/api/endpoints/organization_access_request_details.py
+++ b/src/sentry/api/endpoints/organization_access_request_details.py
@@ -12,6 +12,7 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
+from sentry.models.organization import Organization
 from sentry.models.organizationaccessrequest import OrganizationAccessRequest
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
@@ -74,7 +75,7 @@ class OrganizationAccessRequestDetailsEndpoint(OrganizationEndpoint):
             return True
         return False
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         Get a list of requests to join org/team.
         If any requests are redundant (user already joined the team), they are not returned.
@@ -112,7 +113,7 @@ class OrganizationAccessRequestDetailsEndpoint(OrganizationEndpoint):
 
         return Response(serialize(valid_access_requests, request.user))
 
-    def put(self, request: Request, organization, request_id) -> Response:
+    def put(self, request: Request, organization: Organization, request_id: int) -> Response:
         """
         Approve or deny a request
 

--- a/src/sentry/api/endpoints/organization_auth_providers.py
+++ b/src/sentry/api/endpoints/organization_auth_providers.py
@@ -8,6 +8,7 @@ from sentry.api.bases.organization import OrganizationAuthProviderPermission, Or
 from sentry.api.serializers import serialize
 from sentry.auth import manager
 from sentry.auth.partnership_configs import ChannelName
+from sentry.models.organization import Organization
 
 
 @region_silo_endpoint
@@ -18,7 +19,7 @@ class OrganizationAuthProvidersEndpoint(OrganizationEndpoint):
     owner = ApiOwner.ENTERPRISE
     permission_classes = (OrganizationAuthProviderPermission,)
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         List available auth providers that are available to use for an Organization
         ```````````````````````````````````````````````````````````````````````````

--- a/src/sentry/api/endpoints/organization_config_repositories.py
+++ b/src/sentry/api/endpoints/organization_config_repositories.py
@@ -5,6 +5,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.models.organization import Organization
 from sentry.plugins.base import bindings
 
 
@@ -15,7 +16,7 @@ class OrganizationConfigRepositoriesEndpoint(OrganizationEndpoint):
         "GET": ApiPublishStatus.PRIVATE,
     }
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         provider_bindings = bindings.get("repository.provider")
         providers = []
         for provider_id in provider_bindings:

--- a/src/sentry/api/endpoints/organization_dashboard_details.py
+++ b/src/sentry/api/endpoints/organization_dashboard_details.py
@@ -30,6 +30,7 @@ from sentry.models.dashboard import (
     DashboardLastVisited,
     DashboardTombstone,
 )
+from sentry.models.organization import Organization
 from sentry.models.organizationmember import OrganizationMember
 
 EDIT_FEATURE = "organizations:dashboards-edit"
@@ -139,7 +140,7 @@ class OrganizationDashboardDetailsEndpoint(OrganizationDashboardBase):
         },
         examples=DashboardExamples.DASHBOARD_PUT_RESPONSE,
     )
-    def put(self, request: Request, organization, dashboard) -> Response:
+    def put(self, request: Request, organization: Organization, dashboard) -> Response:
         """
         Edit an organization's custom dashboard as well as any bulk
         edits on widgets that may have been made. (For example, widgets
@@ -227,7 +228,7 @@ class OrganizationDashboardFavoriteEndpoint(OrganizationDashboardBase):
         "PUT": ApiPublishStatus.PRIVATE,
     }
 
-    def put(self, request: Request, organization, dashboard) -> Response:
+    def put(self, request: Request, organization: Organization, dashboard) -> Response:
         """
         Toggle favorite status for current user by adding or removing
         current user from dashboard favorites

--- a/src/sentry/api/endpoints/organization_dashboards.py
+++ b/src/sentry/api/endpoints/organization_dashboards.py
@@ -105,7 +105,7 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
         },
         examples=DashboardExamples.DASHBOARDS_QUERY_RESPONSE,
     )
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         Retrieve a list of custom dashboards that are associated with the given organization.
         """

--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -1010,7 +1010,7 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
         },
         examples=OrganizationExamples.RETRIEVE_ORGANIZATION,
     )
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         Return details on an individual organization, including various details
         such as membership access and teams.

--- a/src/sentry/api/endpoints/organization_environments.py
+++ b/src/sentry/api/endpoints/organization_environments.py
@@ -14,6 +14,7 @@ from sentry.apidocs.examples.environment_examples import EnvironmentExamples
 from sentry.apidocs.parameters import EnvironmentParams, GlobalParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.models.environment import Environment, EnvironmentProject
+from sentry.models.organization import Organization
 
 
 @extend_schema(tags=["Environments"])
@@ -36,7 +37,7 @@ class OrganizationEnvironmentsEndpoint(OrganizationEndpoint):
         },
         examples=EnvironmentExamples.GET_ORGANIZATION_ENVIRONMENTS,
     )
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         Lists an organization's environments.
         """

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -221,7 +221,7 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
         },
         examples=DiscoverAndPerformanceExamples.QUERY_DISCOVER_EVENTS,
     )
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         Retrieves discover (also known as events) data for a given organization.
 

--- a/src/sentry/api/endpoints/organization_events_facets.py
+++ b/src/sentry/api/endpoints/organization_events_facets.py
@@ -11,6 +11,7 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
 from sentry.api.paginator import GenericOffsetPaginator
 from sentry.api.utils import handle_query_errors, update_snuba_params_with_timestamp
+from sentry.models.organization import Organization
 from sentry.search.utils import DEVICE_CLASS
 
 
@@ -31,7 +32,7 @@ class OrganizationEventsFacetsEndpoint(OrganizationEventsV2EndpointBase):
         "GET": ApiPublishStatus.PRIVATE,
     }
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         if not self.has_feature(organization, request):
             return Response(status=404)
 

--- a/src/sentry/api/endpoints/organization_events_facets_performance.py
+++ b/src/sentry/api/endpoints/organization_events_facets_performance.py
@@ -15,6 +15,7 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
 from sentry.api.paginator import GenericOffsetPaginator
 from sentry.api.utils import handle_query_errors
+from sentry.models.organization import Organization
 from sentry.search.events.builder.discover import DiscoverQueryBuilder
 from sentry.search.events.types import EventsResponse, SnubaParams
 from sentry.snuba import discover
@@ -72,7 +73,7 @@ class OrganizationEventsFacetsPerformanceEndpointBase(OrganizationEventsV2Endpoi
 
 @region_silo_endpoint
 class OrganizationEventsFacetsPerformanceEndpoint(OrganizationEventsFacetsPerformanceEndpointBase):
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         try:
             snuba_params, aggregate_column, filter_query = self._setup(request, organization)
         except NoProjects:
@@ -138,7 +139,7 @@ class OrganizationEventsFacetsPerformanceHistogramEndpoint(
         "GET": ApiPublishStatus.PRIVATE,
     }
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         try:
             snuba_params, aggregate_column, filter_query = self._setup(request, organization)
         except NoProjects:

--- a/src/sentry/api/endpoints/organization_events_has_measurements.py
+++ b/src/sentry/api/endpoints/organization_events_has_measurements.py
@@ -11,6 +11,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
 from sentry.api.utils import handle_query_errors
+from sentry.models.organization import Organization
 from sentry.snuba import discover
 from sentry.utils.hashlib import md5_text
 
@@ -54,7 +55,7 @@ class OrganizationEventsHasMeasurementsEndpoint(OrganizationEventsV2EndpointBase
         "GET": ApiPublishStatus.PRIVATE,
     }
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         if not self.has_feature(organization, request):
             return Response(status=404)
 

--- a/src/sentry/api/endpoints/organization_events_histogram.py
+++ b/src/sentry/api/endpoints/organization_events_histogram.py
@@ -9,6 +9,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
 from sentry.api.utils import handle_query_errors
+from sentry.models.organization import Organization
 from sentry.snuba import discover
 
 # The maximum number of array columns allowed to be queried at at time
@@ -52,7 +53,7 @@ class OrganizationEventsHistogramEndpoint(OrganizationEventsV2EndpointBase):
     def has_feature(self, organization, request):
         return features.has("organizations:performance-view", organization, actor=request.user)
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         if not self.has_feature(organization, request):
             return Response(status=404)
 

--- a/src/sentry/api/endpoints/organization_events_meta.py
+++ b/src/sentry/api/endpoints/organization_events_meta.py
@@ -65,7 +65,7 @@ class OrganizationEventsMetaEndpoint(OrganizationEventsEndpointBase):
 
         return all_features
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         try:
             snuba_params = self.get_snuba_params(request, organization)
         except NoProjects:
@@ -125,7 +125,7 @@ class OrganizationEventsRelatedIssuesEndpoint(OrganizationEventsEndpointBase):
         "GET": ApiPublishStatus.PRIVATE,
     }
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         try:
             # events-meta is still used by events v1 which doesn't require global views
             snuba_params = self.get_snuba_params(request, organization, check_global_views=False)
@@ -186,7 +186,7 @@ class OrganizationSpansSamplesEndpoint(OrganizationEventsV2EndpointBase):
         "GET": ApiPublishStatus.PRIVATE,
     }
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
 
         try:
             snuba_params = self.get_snuba_params(request, organization)

--- a/src/sentry/api/endpoints/organization_events_spans_histogram.py
+++ b/src/sentry/api/endpoints/organization_events_spans_histogram.py
@@ -8,6 +8,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
 from sentry.api.utils import handle_query_errors
+from sentry.models.organization import Organization
 from sentry.search.events.types import Span
 from sentry.snuba import discover
 
@@ -46,7 +47,7 @@ class OrganizationEventsSpansHistogramEndpoint(OrganizationEventsV2EndpointBase)
             "organizations:performance-span-histogram-view", organization, actor=request.user
         )
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         if not self.has_feature(organization, request):
             return Response(status=404)
 

--- a/src/sentry/api/endpoints/organization_events_trends.py
+++ b/src/sentry/api/endpoints/organization_events_trends.py
@@ -18,6 +18,7 @@ from sentry.api.event_search import AggregateFilter
 from sentry.api.paginator import GenericOffsetPaginator
 from sentry.api.utils import handle_query_errors
 from sentry.exceptions import InvalidSearchQuery
+from sentry.models.organization import Organization
 from sentry.search.events.builder.discover import DiscoverQueryBuilder
 from sentry.search.events.datasets import function_aliases
 from sentry.search.events.fields import DateArg, parse_function
@@ -301,7 +302,7 @@ class OrganizationEventsTrendsEndpointBase(OrganizationEventsV2EndpointBase):
     def has_feature(self, organization, request):
         return features.has("organizations:performance-view", organization, actor=request.user)
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         if not self.has_feature(organization, request):
             return Response(status=404)
 

--- a/src/sentry/api/endpoints/organization_events_trends_v2.py
+++ b/src/sentry/api/endpoints/organization_events_trends_v2.py
@@ -13,6 +13,7 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
 from sentry.api.paginator import GenericOffsetPaginator
 from sentry.api.utils import handle_query_errors
+from sentry.models.organization import Organization
 from sentry.performance_issues.detectors.utils import escape_transaction
 from sentry.search.events.constants import METRICS_GRANULARITIES
 from sentry.seer.breakpoints import detect_breakpoints
@@ -68,7 +69,7 @@ class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsV2EndpointBase)
             "organizations:performance-new-trends", organization, actor=request.user
         )
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         if not self.has_feature(organization, request):
             return Response(status=404)
 

--- a/src/sentry/api/endpoints/organization_events_vitals.py
+++ b/src/sentry/api/endpoints/organization_events_vitals.py
@@ -8,6 +8,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
 from sentry.api.utils import handle_query_errors
+from sentry.models.organization import Organization
 from sentry.search.events.fields import get_function_alias
 from sentry.snuba import discover
 
@@ -25,7 +26,7 @@ class OrganizationEventsVitalsEndpoint(OrganizationEventsV2EndpointBase):
         "measurements.fp": {"thresholds": [0, 1000, 3000]},
     }
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         if not self.has_feature(organization, request):
             return Response(status=404)
 

--- a/src/sentry/api/endpoints/organization_insights_tree.py
+++ b/src/sentry/api/endpoints/organization_insights_tree.py
@@ -7,6 +7,7 @@ from rest_framework.response import Response
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.endpoints.organization_events import OrganizationEventsEndpoint
+from sentry.models.organization import Organization
 
 logger = logging.getLogger(__name__)
 
@@ -30,7 +31,7 @@ class OrganizationInsightsTreeEndpoint(OrganizationEventsEndpoint):
         "GET": ApiPublishStatus.EXPERIMENTAL,
     }
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         if not self.has_feature(organization, request):
             return Response(status=404)
 

--- a/src/sentry/api/endpoints/organization_member/index.py
+++ b/src/sentry/api/endpoints/organization_member/index.py
@@ -27,6 +27,7 @@ from sentry.apidocs.parameters import GlobalParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.auth.authenticators import available_authenticators
 from sentry.integrations.models.external_actor import ExternalActor
+from sentry.models.organization import Organization
 from sentry.models.organizationmember import InviteStatus, OrganizationMember
 from sentry.models.organizationmemberinvite import OrganizationMemberInvite
 from sentry.models.team import Team, TeamStatus
@@ -196,7 +197,7 @@ class OrganizationMemberIndexEndpoint(OrganizationEndpoint):
         },
         examples=OrganizationMemberExamples.LIST_ORG_MEMBERS,
     )
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         List all organization members.
 

--- a/src/sentry/api/endpoints/organization_member/requests/invite/index.py
+++ b/src/sentry/api/endpoints/organization_member/requests/invite/index.py
@@ -12,6 +12,7 @@ from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.organization_member import OrganizationMemberWithTeamsSerializer
 from sentry.hybridcloud.models.outbox import outbox_context
+from sentry.models.organization import Organization
 from sentry.models.organizationmember import InviteStatus, OrganizationMember
 from sentry.notifications.notifications.organization_request import InviteRequestNotification
 from sentry.notifications.utils.tasks import async_send_notification
@@ -34,7 +35,7 @@ class OrganizationInviteRequestIndexEndpoint(OrganizationEndpoint):
     }
     permission_classes = (InviteRequestPermissions,)
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         queryset = OrganizationMember.objects.filter(
             Q(user_id__isnull=True),
             Q(invite_status=InviteStatus.REQUESTED_TO_BE_INVITED.value)

--- a/src/sentry/api/endpoints/organization_member_invite/index.py
+++ b/src/sentry/api/endpoints/organization_member_invite/index.py
@@ -184,7 +184,7 @@ class OrganizationMemberInviteIndexEndpoint(OrganizationEndpoint):
         async_send_notification(InviteRequestNotification, omi, request.user)
         return Response(serialize(omi), status=201)
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         List all organization member invites.
         """

--- a/src/sentry/api/endpoints/organization_onboarding_tasks.py
+++ b/src/sentry/api/endpoints/organization_onboarding_tasks.py
@@ -9,6 +9,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.api.serializers import serialize
+from sentry.models.organization import Organization
 from sentry.models.organizationonboardingtask import OnboardingTask, OnboardingTaskStatus
 
 
@@ -76,7 +77,7 @@ class OrganizationOnboardingTaskEndpoint(OrganizationEndpoint):
 
         return Response(status=204)
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         tasks_to_serialize = list(
             onboarding_tasks.fetch_onboarding_tasks(organization, request.user)
         )

--- a/src/sentry/api/endpoints/organization_pinned_searches.py
+++ b/src/sentry/api/endpoints/organization_pinned_searches.py
@@ -9,6 +9,7 @@ from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPinn
 from sentry.api.serializers import serialize
 from sentry.models.groupsearchview import GroupSearchView, GroupSearchViewVisibility
 from sentry.models.groupsearchviewstarred import GroupSearchViewStarred
+from sentry.models.organization import Organization
 from sentry.models.savedsearch import SavedSearch, SortOptions, Visibility
 from sentry.models.search_common import SearchType
 
@@ -39,7 +40,7 @@ class OrganizationPinnedSearchEndpoint(OrganizationEndpoint):
     }
     permission_classes = (OrganizationPinnedSearchPermission,)
 
-    def put(self, request: Request, organization) -> Response:
+    def put(self, request: Request, organization: Organization) -> Response:
         if not request.user.is_authenticated:
             return Response(status=400)
 

--- a/src/sentry/api/endpoints/organization_plugins_configs.py
+++ b/src/sentry/api/endpoints/organization_plugins_configs.py
@@ -12,6 +12,7 @@ from sentry.api.serializers import serialize
 from sentry.api.serializers.models.plugin import PluginSerializer
 from sentry.constants import ObjectStatus
 from sentry.models.options.project_option import ProjectOption
+from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.plugins.base import plugins
 
@@ -23,7 +24,7 @@ class OrganizationPluginsConfigsEndpoint(OrganizationEndpoint):
         "GET": ApiPublishStatus.PRIVATE,
     }
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         List one or more plugin configurations, including a `projectList` for each plugin which contains
         all the projects that have that specific plugin both configured and enabled.

--- a/src/sentry/api/endpoints/organization_plugins_index.py
+++ b/src/sentry/api/endpoints/organization_plugins_index.py
@@ -9,6 +9,7 @@ from sentry.api.serializers import serialize
 from sentry.api.serializers.models.organization_plugin import OrganizationPluginSerializer
 from sentry.api.serializers.models.plugin import PluginSerializer
 from sentry.models.options.project_option import ProjectOption
+from sentry.models.organization import Organization
 from sentry.plugins.base import plugins
 
 
@@ -19,7 +20,7 @@ class OrganizationPluginsEndpoint(OrganizationEndpoint):
         "GET": ApiPublishStatus.PRIVATE,
     }
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         all_plugins = {p.slug: p for p in plugins.all()}
 
         if "plugins" in request.GET:

--- a/src/sentry/api/endpoints/organization_projects.py
+++ b/src/sentry/api/endpoints/organization_projects.py
@@ -22,6 +22,7 @@ from sentry.apidocs.examples.organization_examples import OrganizationExamples
 from sentry.apidocs.parameters import CursorQueryParam, GlobalParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import ObjectStatus
+from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.team import Team
 from sentry.search.utils import tokenize_query
@@ -65,7 +66,7 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint):
         },
         examples=OrganizationExamples.LIST_PROJECTS,
     )
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         Return a list of projects bound to a organization.
         """
@@ -204,7 +205,7 @@ class OrganizationProjectsCountEndpoint(OrganizationEndpoint):
         "GET": ApiPublishStatus.PRIVATE,
     }
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         queryset = Project.objects.filter(organization=organization)
 
         all_projects = queryset.count()

--- a/src/sentry/api/endpoints/organization_projects_sent_first_event.py
+++ b/src/sentry/api/endpoints/organization_projects_sent_first_event.py
@@ -6,6 +6,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.serializers import serialize
+from sentry.models.organization import Organization
 
 
 @region_silo_endpoint
@@ -15,7 +16,7 @@ class OrganizationProjectsSentFirstEventEndpoint(OrganizationEndpoint):
         "GET": ApiPublishStatus.PRIVATE,
     }
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         Verify If Any Project Within An Organization Has Received a First Event
         ```````````````````````````````````````````````````````````````````````

--- a/src/sentry/api/endpoints/organization_recent_searches.py
+++ b/src/sentry/api/endpoints/organization_recent_searches.py
@@ -8,7 +8,6 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.api.serializers import serialize
-from sentry.models.organization import Organization
 from sentry.models.recentsearch import RecentSearch, remove_excess_recent_searches
 from sentry.models.search_common import SearchType
 
@@ -34,7 +33,7 @@ class OrganizationRecentSearchesEndpoint(OrganizationEndpoint):
     }
     permission_classes = (OrganizationRecentSearchPermission,)
 
-    def get(self, request: Request, organization: Organization) -> Response:
+    def get(self, request: Request, organization) -> Response:
         """
         List recent searches for a User within an Organization
         ``````````````````````````````````````````````````````

--- a/src/sentry/api/endpoints/organization_recent_searches.py
+++ b/src/sentry/api/endpoints/organization_recent_searches.py
@@ -8,6 +8,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.api.serializers import serialize
+from sentry.models.organization import Organization
 from sentry.models.recentsearch import RecentSearch, remove_excess_recent_searches
 from sentry.models.search_common import SearchType
 
@@ -33,7 +34,7 @@ class OrganizationRecentSearchesEndpoint(OrganizationEndpoint):
     }
     permission_classes = (OrganizationRecentSearchPermission,)
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         List recent searches for a User within an Organization
         ``````````````````````````````````````````````````````

--- a/src/sentry/api/endpoints/organization_relay_usage.py
+++ b/src/sentry/api/endpoints/organization_relay_usage.py
@@ -13,6 +13,7 @@ from sentry.apidocs.constants import RESPONSE_NOT_FOUND
 from sentry.apidocs.examples.organization_examples import OrganizationExamples
 from sentry.apidocs.parameters import GlobalParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
+from sentry.models.organization import Organization
 from sentry.models.relay import RelayUsage
 
 
@@ -37,7 +38,7 @@ class OrganizationRelayUsage(OrganizationEndpoint):
         },
         examples=OrganizationExamples.LIST_RELAYS,
     )
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         Return a list of trusted relays bound to an organization.
 

--- a/src/sentry/api/endpoints/organization_release_details.py
+++ b/src/sentry/api/endpoints/organization_release_details.py
@@ -34,6 +34,7 @@ from sentry.apidocs.examples.organization_examples import OrganizationExamples
 from sentry.apidocs.parameters import GlobalParams, ReleaseParams, VisibilityParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.models.activity import Activity
+from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.release import Release, ReleaseStatus
 from sentry.models.releases.exceptions import ReleaseCommitError, UnsafeReleaseDeletion
@@ -428,7 +429,7 @@ class OrganizationReleaseDetailsEndpoint(
         },
         examples=OrganizationExamples.RELEASE_DETAILS,
     )
-    def put(self, request: Request, organization, version) -> Response:
+    def put(self, request: Request, organization: Organization, version) -> Response:
         """
 
         Update a release. This can change some metadata associated with

--- a/src/sentry/api/endpoints/organization_release_file_details.py
+++ b/src/sentry/api/endpoints/organization_release_file_details.py
@@ -7,6 +7,7 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationReleasesBaseEndpoint
 from sentry.api.endpoints.project_release_file_details import ReleaseFileDetailsMixin
 from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.models.organization import Organization
 from sentry.models.release import Release
 
 
@@ -54,7 +55,7 @@ class OrganizationReleaseFileDetailsEndpoint(
             check_permission_fn=lambda: request.access.has_scope("project:write"),
         )
 
-    def put(self, request: Request, organization, version, file_id) -> Response:
+    def put(self, request: Request, organization: Organization, version, file_id) -> Response:
         """
         Update an Organization Release's File
         `````````````````````````````````````

--- a/src/sentry/api/endpoints/organization_release_health_data.py
+++ b/src/sentry/api/endpoints/organization_release_health_data.py
@@ -8,6 +8,7 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import OrganizationAndStaffPermission, OrganizationEndpoint
 from sentry.api.paginator import GenericOffsetPaginator
 from sentry.exceptions import InvalidParams
+from sentry.models.organization import Organization
 from sentry.sentry_metrics.use_case_utils import get_use_case_id
 from sentry.snuba.metrics import DerivedMetricException, QueryDefinition, get_series
 from sentry.snuba.metrics.naming_layer import SessionMetricKey
@@ -77,7 +78,7 @@ class OrganizationReleaseHealthDataEndpoint(OrganizationEndpoint):
             except InvalidParams as exc:
                 raise ParseError(detail=str(exc))
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         projects = self.get_projects(request, organization)
         self._validate_fields(request)
 

--- a/src/sentry/api/endpoints/organization_sdk_deprecations.py
+++ b/src/sentry/api/endpoints/organization_sdk_deprecations.py
@@ -12,6 +12,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.projectsdk import EventType, ProjectSDK, get_minimum_sdk_version
 
@@ -42,7 +43,7 @@ class OrganizationSdkDeprecationsEndpoint(OrganizationEndpoint):
         "GET": ApiPublishStatus.PRIVATE,
     }
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         serializer = SDKDeprecationsSerializer(data=request.GET)
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)

--- a/src/sentry/api/endpoints/organization_sdk_updates.py
+++ b/src/sentry/api/endpoints/organization_sdk_updates.py
@@ -13,6 +13,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.utils import handle_query_errors
+from sentry.models.organization import Organization
 from sentry.sdk_updates import SdkIndexState, SdkSetupState, get_sdk_index, get_suggested_updates
 from sentry.search.events.types import SnubaParams
 from sentry.snuba import discover
@@ -88,7 +89,7 @@ class OrganizationSdkUpdatesEndpoint(OrganizationEndpoint):
         "GET": ApiPublishStatus.PRIVATE,
     }
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         projects = self.get_projects(request, organization)
 
         len_projects = len(projects)
@@ -128,7 +129,7 @@ class OrganizationSdksEndpoint(OrganizationEndpoint):
     }
     owner = ApiOwner.TELEMETRY_EXPERIENCE
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         try:
             sdks = get_sdk_index()
         except Exception as e:

--- a/src/sentry/api/endpoints/organization_sessions.py
+++ b/src/sentry/api/endpoints/organization_sessions.py
@@ -63,7 +63,7 @@ class OrganizationSessionsEndpoint(OrganizationEndpoint):
         },
         examples=SessionExamples.QUERY_SESSIONS,
     )
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         Returns a time series of release health session statistics for projects bound to an organization.
 

--- a/src/sentry/api/endpoints/organization_stats_summary.py
+++ b/src/sentry/api/endpoints/organization_stats_summary.py
@@ -23,6 +23,7 @@ from sentry.apidocs.parameters import GlobalParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import ALL_ACCESS_PROJECTS
 from sentry.exceptions import InvalidParams
+from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.search.utils import InvalidQuery
 from sentry.snuba.outcomes import COLUMN_MAP, QueryDefinition, run_outcomes_query_totals
@@ -136,7 +137,7 @@ class OrganizationStatsSummaryEndpoint(OrganizationEndpoint):
         },
         examples=OrganizationExamples.RETRIEVE_SUMMARY_EVENT_COUNT,
     )
-    def get(self, request: Request, organization) -> HttpResponse:
+    def get(self, request: Request, organization: Organization) -> HttpResponse:
         """
         Query summarized event counts by project for your Organization. Also see https://docs.sentry.io/api/organizations/retrieve-event-counts-for-an-organization-v2/ for reference.
         """

--- a/src/sentry/api/endpoints/organization_stats_v2.py
+++ b/src/sentry/api/endpoints/organization_stats_v2.py
@@ -20,6 +20,7 @@ from sentry.apidocs.parameters import GlobalParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import ALL_ACCESS_PROJECTS
 from sentry.exceptions import InvalidParams
+from sentry.models.organization import Organization
 from sentry.search.utils import InvalidQuery
 from sentry.snuba.outcomes import (
     COLUMN_MAP,
@@ -178,7 +179,7 @@ class OrganizationStatsEndpointV2(OrganizationEndpoint):
         },
         examples=OrganizationExamples.RETRIEVE_EVENT_COUNTS_V2,
     )
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         Query event counts for your Organization.
         Select a field, define a date range, and group or filter by columns.

--- a/src/sentry/api/endpoints/organization_tags.py
+++ b/src/sentry/api/endpoints/organization_tags.py
@@ -13,6 +13,7 @@ from sentry.api.bases import NoProjects
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.serializers import serialize
 from sentry.api.utils import clamp_date_range, handle_query_errors
+from sentry.models.organization import Organization
 from sentry.snuba.dataset import Dataset
 from sentry.utils.numbers import format_grouped_length
 from sentry.utils.sdk import set_span_attribute
@@ -25,7 +26,7 @@ class OrganizationTagsEndpoint(OrganizationEndpoint):
     }
     owner = ApiOwner.PERFORMANCE
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         try:
             filter_params = self.get_filter_params(request, organization)
         except NoProjects:

--- a/src/sentry/api/endpoints/organization_teams.py
+++ b/src/sentry/api/endpoints/organization_teams.py
@@ -20,6 +20,7 @@ from sentry.apidocs.parameters import CursorQueryParam, GlobalParams, TeamParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.db.models.fields.slug import DEFAULT_SLUG_MAX_LENGTH
 from sentry.integrations.models.external_actor import ExternalActor
+from sentry.models.organization import Organization
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.models.team import Team, TeamStatus
@@ -95,7 +96,7 @@ class OrganizationTeamsEndpoint(OrganizationEndpoint):
         },
         examples=TeamExamples.LIST_ORG_TEAMS,
     )
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         Returns a list of teams bound to a organization.
         """

--- a/src/sentry/api/endpoints/organization_user_teams.py
+++ b/src/sentry/api/endpoints/organization_user_teams.py
@@ -13,6 +13,7 @@ from sentry.apidocs.examples.team_examples import TeamExamples
 from sentry.apidocs.parameters import GlobalParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.auth.superuser import is_active_superuser
+from sentry.models.organization import Organization
 from sentry.models.team import Team, TeamStatus
 
 
@@ -37,7 +38,7 @@ class OrganizationUserTeamsEndpoint(OrganizationEndpoint):
         },
         examples=TeamExamples.LIST_ORG_TEAMS,
     )
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         Returns a list of teams the user has access to in the specified organization.
         Note that this endpoint is restricted to [user auth tokens](https://docs.sentry.io/account/auth-tokens/#user-auth-tokens).

--- a/src/sentry/api/endpoints/organization_users.py
+++ b/src/sentry/api/endpoints/organization_users.py
@@ -7,6 +7,7 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models import OrganizationMemberWithProjectsSerializer
+from sentry.models.organization import Organization
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.models.projectteam import ProjectTeam
@@ -19,7 +20,7 @@ class OrganizationUsersEndpoint(OrganizationEndpoint):
         "GET": ApiPublishStatus.PRIVATE,
     }
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         List an Organization's Projects Users
         ````````````````````````````

--- a/src/sentry/api/endpoints/project_transaction_threshold_override.py
+++ b/src/sentry/api/endpoints/project_transaction_threshold_override.py
@@ -9,6 +9,7 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import ProjectTransactionThresholdOverridePermission
 from sentry.api.bases.organization_events import OrganizationEventsV2EndpointBase
 from sentry.api.serializers import serialize
+from sentry.models.organization import Organization
 from sentry.models.transaction_threshold import (
     TRANSACTION_METRICS,
     ProjectTransactionThresholdOverride,
@@ -71,7 +72,7 @@ class ProjectTransactionThresholdOverrideEndpoint(OrganizationEventsV2EndpointBa
 
         return projects[0]
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         if not self.has_feature(organization, request):
             return self.respond(status=status.HTTP_404_NOT_FOUND)
 

--- a/src/sentry/discover/endpoints/discover_homepage_query.py
+++ b/src/sentry/discover/endpoints/discover_homepage_query.py
@@ -14,6 +14,7 @@ from sentry.api.serializers import serialize
 from sentry.discover.endpoints.bases import DiscoverSavedQueryPermission
 from sentry.discover.endpoints.serializers import DiscoverSavedQuerySerializer
 from sentry.discover.models import DatasetSourcesTypes, DiscoverSavedQuery, DiscoverSavedQueryTypes
+from sentry.models.organization import Organization
 
 
 def get_homepage_query(organization, user):
@@ -41,7 +42,7 @@ class DiscoverHomepageQueryEndpoint(OrganizationEndpoint):
             "organizations:discover", organization, actor=request.user
         ) or features.has("organizations:discover-query", organization, actor=request.user)
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         if not self.has_feature(organization, request):
             return self.respond(status=status.HTTP_404_NOT_FOUND)
 
@@ -52,7 +53,7 @@ class DiscoverHomepageQueryEndpoint(OrganizationEndpoint):
 
         return Response(serialize(query), status=status.HTTP_200_OK)
 
-    def put(self, request: Request, organization) -> Response:
+    def put(self, request: Request, organization: Organization) -> Response:
         if not self.has_feature(organization, request):
             return self.respond(status=status.HTTP_404_NOT_FOUND)
 

--- a/src/sentry/discover/endpoints/discover_key_transactions.py
+++ b/src/sentry/discover/endpoints/discover_key_transactions.py
@@ -18,6 +18,7 @@ from sentry.api.serializers import Serializer, register, serialize
 from sentry.discover.endpoints import serializers
 from sentry.discover.models import TeamKeyTransaction
 from sentry.exceptions import InvalidParams
+from sentry.models.organization import Organization
 from sentry.models.projectteam import ProjectTeam
 from sentry.models.team import Team
 
@@ -40,7 +41,7 @@ class KeyTransactionEndpoint(KeyTransactionBase):
     }
     permission_classes = (KeyTransactionPermission,)
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         if not self.has_feature(organization, request):
             return Response(status=404)
 
@@ -150,7 +151,7 @@ class KeyTransactionListEndpoint(KeyTransactionBase):
     }
     permission_classes = (KeyTransactionPermission,)
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         if not self.has_feature(organization, request):
             return Response(status=404)
 

--- a/src/sentry/discover/endpoints/discover_saved_queries.py
+++ b/src/sentry/discover/endpoints/discover_saved_queries.py
@@ -29,6 +29,7 @@ from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.discover.endpoints.bases import DiscoverSavedQueryPermission
 from sentry.discover.endpoints.serializers import DiscoverSavedQuerySerializer
 from sentry.discover.models import DatasetSourcesTypes, DiscoverSavedQuery, DiscoverSavedQueryTypes
+from sentry.models.organization import Organization
 from sentry.search.utils import tokenize_query
 
 
@@ -67,7 +68,7 @@ class DiscoverSavedQueriesEndpoint(OrganizationEndpoint):
         },
         examples=DiscoverExamples.DISCOVER_SAVED_QUERIES_QUERY_RESPONSE,
     )
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         Retrieve a list of saved queries that are associated with the given organization.
         """

--- a/src/sentry/discover/endpoints/discover_saved_query_detail.py
+++ b/src/sentry/discover/endpoints/discover_saved_query_detail.py
@@ -24,6 +24,7 @@ from sentry.apidocs.parameters import DiscoverSavedQueryParams, GlobalParams
 from sentry.discover.endpoints.bases import DiscoverSavedQueryPermission
 from sentry.discover.endpoints.serializers import DiscoverSavedQuerySerializer
 from sentry.discover.models import DatasetSourcesTypes, DiscoverSavedQuery, DiscoverSavedQueryTypes
+from sentry.models.organization import Organization
 
 
 class DiscoverSavedQueryBase(OrganizationEndpoint):
@@ -96,7 +97,7 @@ class DiscoverSavedQueryDetailEndpoint(DiscoverSavedQueryBase):
         },
         examples=DiscoverExamples.DISCOVER_SAVED_QUERY_GET_RESPONSE,
     )
-    def put(self, request: Request, organization, query) -> Response:
+    def put(self, request: Request, organization: Organization, query) -> Response:
         """
         Modify a saved query.
         """

--- a/src/sentry/explore/endpoints/explore_saved_queries.py
+++ b/src/sentry/explore/endpoints/explore_saved_queries.py
@@ -36,6 +36,7 @@ from sentry.explore.models import (
     ExploreSavedQueryStarred,
 )
 from sentry.locks import locks
+from sentry.models.organization import Organization
 from sentry.search.utils import tokenize_query
 from sentry.utils.locking import UnableToAcquireLock
 
@@ -297,7 +298,7 @@ class ExploreSavedQueriesEndpoint(OrganizationEndpoint):
         },
         examples=ExploreExamples.EXPLORE_SAVED_QUERIES_QUERY_RESPONSE,
     )
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         Retrieve a list of saved queries that are associated with the given organization.
         """

--- a/src/sentry/explore/endpoints/explore_saved_query_detail.py
+++ b/src/sentry/explore/endpoints/explore_saved_query_detail.py
@@ -24,6 +24,7 @@ from sentry.apidocs.parameters import ExploreSavedQueryParams, GlobalParams
 from sentry.explore.endpoints.bases import ExploreSavedQueryPermission
 from sentry.explore.endpoints.serializers import ExploreSavedQuerySerializer
 from sentry.explore.models import ExploreSavedQuery, ExploreSavedQueryLastVisited
+from sentry.models.organization import Organization
 
 
 class ExploreSavedQueryBase(OrganizationEndpoint):
@@ -95,7 +96,7 @@ class ExploreSavedQueryDetailEndpoint(ExploreSavedQueryBase):
         },
         examples=ExploreExamples.EXPLORE_SAVED_QUERY_GET_RESPONSE,
     )
-    def put(self, request: Request, organization, query) -> Response:
+    def put(self, request: Request, organization: Organization, query) -> Response:
         """
         Modify a saved query.
         """

--- a/src/sentry/feedback/endpoints/organization_user_reports.py
+++ b/src/sentry/feedback/endpoints/organization_user_reports.py
@@ -14,6 +14,7 @@ from sentry.api.helpers.user_reports import user_reports_filter_to_unresolved
 from sentry.api.paginator import DateTimePaginator
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models import UserReportWithGroupSerializer
+from sentry.models.organization import Organization
 from sentry.models.userreport import UserReport
 from sentry.utils.dates import epoch
 
@@ -30,7 +31,7 @@ class OrganizationUserReportsEndpoint(OrganizationEndpoint):
     }
     permission_classes = (OrganizationUserReportsPermission,)
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         List an Organization's User Feedback
         ``````````````````````````````

--- a/src/sentry/incidents/endpoints/organization_alert_rule_available_action_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_available_action_index.py
@@ -93,7 +93,7 @@ class OrganizationAlertRuleAvailableActionIndexEndpoint(OrganizationEndpoint):
         "GET": ApiPublishStatus.PRIVATE,
     }
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         Fetches actions that an alert rule can perform for an organization
         """

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -226,7 +226,7 @@ class OrganizationCombinedRuleIndexEndpoint(OrganizationEndpoint):
         "GET": ApiPublishStatus.PRIVATE,
     }
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         Fetches metric, issue, crons, and uptime alert rules for an organization
         """

--- a/src/sentry/incidents/endpoints/organization_incident_details.py
+++ b/src/sentry/incidents/endpoints/organization_incident_details.py
@@ -10,6 +10,7 @@ from sentry.api.serializers import serialize
 from sentry.incidents.endpoints.serializers.incident import DetailedIncidentSerializer
 from sentry.incidents.logic import update_incident_status
 from sentry.incidents.models.incident import IncidentStatus, IncidentStatusMethod
+from sentry.models.organization import Organization
 
 
 class IncidentSerializer(serializers.Serializer):
@@ -47,7 +48,7 @@ class OrganizationIncidentDetailsEndpoint(IncidentEndpoint):
 
         return Response(data)
 
-    def put(self, request: Request, organization, incident) -> Response:
+    def put(self, request: Request, organization: Organization, incident) -> Response:
         serializer = IncidentSerializer(data=request.data)
         if serializer.is_valid():
             result = serializer.validated_data

--- a/src/sentry/incidents/endpoints/organization_incident_index.py
+++ b/src/sentry/incidents/endpoints/organization_incident_index.py
@@ -17,6 +17,7 @@ from sentry.exceptions import InvalidParams
 from sentry.incidents.endpoints.serializers.incident import IncidentSerializer
 from sentry.incidents.models.alert_rule import AlertRuleActivity, AlertRuleActivityType
 from sentry.incidents.models.incident import Incident, IncidentStatus
+from sentry.models.organization import Organization
 from sentry.snuba.dataset import Dataset
 from sentry.utils.dates import ensure_aware
 
@@ -31,7 +32,7 @@ class OrganizationIncidentIndexEndpoint(OrganizationEndpoint):
     }
     permission_classes = (IncidentPermission,)
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         List Incidents that a User can access within an Organization
         ````````````````````````````````````````````````````````````

--- a/src/sentry/integrations/api/endpoints/organization_code_mappings.py
+++ b/src/sentry/integrations/api/endpoints/organization_code_mappings.py
@@ -18,6 +18,7 @@ from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework.base import CamelSnakeModelSerializer
 from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
 from sentry.integrations.services.integration import integration_service
+from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.repository import Repository
 
@@ -141,7 +142,7 @@ class OrganizationCodeMappingsEndpoint(OrganizationEndpoint, OrganizationIntegra
     }
     permission_classes = (OrganizationIntegrationsLoosePermission,)
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         Get the list of repository project path configs
 

--- a/src/sentry/integrations/api/endpoints/organization_config_integrations.py
+++ b/src/sentry/integrations/api/endpoints/organization_config_integrations.py
@@ -19,6 +19,7 @@ from sentry.integrations.api.serializers.models.integration import (
     IntegrationProviderSerializer,
 )
 from sentry.integrations.manager import default_manager as integrations
+from sentry.models.organization import Organization
 
 
 class OrganizationConfigIntegrationsEndpointResponse(TypedDict):
@@ -48,7 +49,7 @@ class OrganizationConfigIntegrationsEndpoint(OrganizationEndpoint):
         },
         examples=IntegrationExamples.ORGANIZATION_CONFIG_INTEGRATIONS,
     )
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         Get integration provider information about all available integrations for an organization.
         """

--- a/src/sentry/integrations/api/endpoints/organization_repositories.py
+++ b/src/sentry/integrations/api/endpoints/organization_repositories.py
@@ -16,6 +16,7 @@ from sentry.integrations.services.integration import integration_service
 from sentry.integrations.services.repository.model import RpcRepository
 from sentry.integrations.source_code_management.repository import RepositoryIntegration
 from sentry.integrations.types import IntegrationProviderSlug
+from sentry.models.organization import Organization
 from sentry.models.repository import Repository
 from sentry.plugins.base import bindings
 from sentry.ratelimits.config import SENTRY_RATELIMITER_GROUP_DEFAULTS, RateLimitConfig
@@ -39,7 +40,7 @@ class OrganizationRepositoriesEndpoint(OrganizationEndpoint):
         group="CLI", limit_overrides={"POST": SENTRY_RATELIMITER_GROUP_DEFAULTS["default"]}
     )
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         List an Organization's Repositories
         ```````````````````````````````````

--- a/src/sentry/integrations/api/endpoints/organization_repository_details.py
+++ b/src/sentry/integrations/api/endpoints/organization_repository_details.py
@@ -19,6 +19,7 @@ from sentry.deletions.models.scheduleddeletion import RegionScheduledDeletion
 from sentry.hybridcloud.rpc import coerce_id_from
 from sentry.integrations.services.integration import integration_service
 from sentry.models.commit import Commit
+from sentry.models.organization import Organization
 from sentry.models.repository import Repository
 from sentry.tasks.repository import repository_cascade_delete_on_hide
 from sentry.tasks.seer import cleanup_seer_repository_preferences
@@ -47,7 +48,7 @@ class OrganizationRepositoryDetailsEndpoint(OrganizationEndpoint):
     }
     permission_classes = (OrganizationIntegrationsPermission,)
 
-    def put(self, request: Request, organization, repo_id) -> Response:
+    def put(self, request: Request, organization: Organization, repo_id) -> Response:
         if not request.user.is_authenticated:
             return Response(status=401)
 

--- a/src/sentry/monitors/endpoints/organization_monitor_index_stats.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_index_stats.py
@@ -15,6 +15,7 @@ from sentry.api.base import StatsMixin, region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.helpers.environments import get_environments
 from sentry.models.environment import Environment
+from sentry.models.organization import Organization
 from sentry.monitors.models import CheckInStatus, Monitor, MonitorCheckIn, MonitorEnvironment
 
 TRACKED_STATUSES = [
@@ -46,7 +47,7 @@ class OrganizationMonitorIndexStatsEndpoint(OrganizationEndpoint, StatsMixin):
     owner = ApiOwner.CRONS
 
     # TODO(epurkhiser): probably convert to snuba
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         # Do not restrict rollups allowing us to define custom resolutions.
         # Important for this endpoint since we want our buckets to align with
         # the UI's timescale markers.

--- a/src/sentry/replays/endpoints/organization_replay_events_meta.py
+++ b/src/sentry/replays/endpoints/organization_replay_events_meta.py
@@ -51,7 +51,7 @@ class OrganizationReplayEventsMetaEndpoint(OrganizationEventsV2EndpointBase):
 
         return fields
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         if not features.has("organizations:session-replay", organization, actor=request.user):
             return Response(status=404)
 

--- a/src/sentry/scim/endpoints/members.py
+++ b/src/sentry/scim/endpoints/members.py
@@ -43,6 +43,7 @@ from sentry.apidocs.parameters import GlobalParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.auth.providers.saml2.activedirectory.apps import ACTIVE_DIRECTORY_PROVIDER_NAME
 from sentry.auth.services.auth import auth_service
+from sentry.models.organization import Organization
 from sentry.models.organizationmember import InviteStatus, OrganizationMember
 from sentry.roles import organization_roles
 from sentry.signals import member_invited
@@ -346,7 +347,7 @@ class OrganizationSCIMMemberDetails(SCIMEndpoint, OrganizationMemberEndpoint):
         },
         examples=SCIMExamples.UPDATE_USER_ROLE,
     )
-    def put(self, request: Request, organization, member):
+    def put(self, request: Request, organization: Organization, member):
         """
         Update an organization member
 
@@ -452,7 +453,7 @@ class OrganizationSCIMMemberIndex(SCIMEndpoint):
         },
         examples=SCIMExamples.LIST_ORG_MEMBERS,
     )
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         Returns a paginated list of members bound to a organization with a SCIM Users GET Request.
         """

--- a/src/sentry/scim/endpoints/members.py
+++ b/src/sentry/scim/endpoints/members.py
@@ -419,7 +419,7 @@ class OrganizationSCIMMemberDetails(SCIMEndpoint, OrganizationMemberEndpoint):
             previous_role != organization.default_role
             or previous_restriction != idp_role_restricted
         ):
-            metrics.incr("sentry.scim.member.update_role", tags={"organization": organization})
+            metrics.incr("sentry.scim.member.update_role", tags={"organization": organization.slug})
 
         context = serialize(
             member,

--- a/src/sentry/sentry_apps/api/endpoints/sentry_app_installations.py
+++ b/src/sentry/sentry_apps/api/endpoints/sentry_app_installations.py
@@ -13,6 +13,7 @@ from sentry.auth.superuser import superuser_has_permission
 from sentry.constants import SENTRY_APP_SLUG_MAX_LENGTH, SentryAppStatus
 from sentry.features.exceptions import FeatureNotRegistered
 from sentry.integrations.models.integration_feature import IntegrationFeature, IntegrationTypes
+from sentry.models.organization import Organization
 from sentry.sentry_apps.api.bases.sentryapps import SentryAppInstallationsBaseEndpoint
 from sentry.sentry_apps.api.serializers.sentry_app_installation import (
     SentryAppInstallationSerializer,
@@ -36,7 +37,7 @@ class SentryAppInstallationsEndpoint(SentryAppInstallationsBaseEndpoint):
         "POST": ApiPublishStatus.PRIVATE,
     }
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         queryset = SentryAppInstallation.objects.filter(organization_id=organization.id)
 
         return self.paginate(


### PR DESCRIPTION
- Consistently add type hints for Organization in API endpoints 🧼 