### PR TITLE
fix(onboarding): Show logs in gatsby onboarding docs

### DIFF
--- a/static/app/components/onboarding/productSelection.tsx
+++ b/static/app/components/onboarding/productSelection.tsx
@@ -153,6 +153,7 @@ export const platformProductAvailability = {
   'javascript-gatsby': [
     ProductSolution.PERFORMANCE_MONITORING,
     ProductSolution.SESSION_REPLAY,
+    ProductSolution.LOGS,
   ],
   'javascript-solid': [
     ProductSolution.PERFORMANCE_MONITORING,


### PR DESCRIPTION
Missed this during https://github.com/getsentry/sentry/pull/96425