### PR TITLE
feat(Codecov): Get rid of main branch default value

### DIFF
--- a/src/sentry/codecov/endpoints/test_results/test_results.py
+++ b/src/sentry/codecov/endpoints/test_results/test_results.py
@@ -97,7 +97,7 @@ class TestResultsEndpoint(CodecovEndpoint):
             "owner": owner_slug,
             "repo": repository,
             "filters": {
-                "branch": request.query_params.get("branch", "main"),
+                "branch": request.query_params.get("branch"),
                 "parameter": request.query_params.get("filterBy"),
                 "interval": (
                     request.query_params.get("interval", MeasurementInterval.INTERVAL_30_DAY.value)

--- a/tests/sentry/codecov/endpoints/test_test_results.py
+++ b/tests/sentry/codecov/endpoints/test_test_results.py
@@ -130,7 +130,7 @@ class TestResultsEndpointTest(APITestCase):
             "owner": "testowner",
             "repo": "testrepo",
             "filters": {
-                "branch": "main",
+                "branch": None,
                 "parameter": None,
                 "interval": "INTERVAL_30_DAY",
                 "flags": None,
@@ -273,7 +273,7 @@ class TestResultsEndpointTest(APITestCase):
             "owner": "testowner",
             "repo": "testrepo",
             "filters": {
-                "branch": "main",
+                "branch": None,
                 "parameter": None,
                 "interval": "INTERVAL_30_DAY",
                 "flags": None,
@@ -310,7 +310,7 @@ class TestResultsEndpointTest(APITestCase):
             "owner": "testowner",
             "repo": "testrepo",
             "filters": {
-                "branch": "main",
+                "branch": None,
                 "parameter": None,
                 "interval": "INTERVAL_30_DAY",
                 "flags": None,


### PR DESCRIPTION
This PR gets rid of the main default value for branch query parameter on the test_results endpoint as a) this endpoint does and can support `None` as a value and b) that was a placeholder value during testing 