### PR TITLE
fix(js-sdk): Use correct `enableLogs` flag

### DIFF
--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -191,9 +191,7 @@ export function initializeSdk(config: Config) {
 
       return event;
     },
-    _experiments: {
-      enableLogs: true,
-    },
+    enableLogs: true,
   });
 
   // Track timeOrigin Selection by the SDK to see if it improves transaction durations


### PR DESCRIPTION
We are dogfooding the v10 alpha:

https://github.com/getsentry/sentry/blob/82f640be370f447b29539928c904cafadba981a9/package.json#L71

but forgot to change the `enableLogs` flag.

See https://github.com/getsentry/sentry-javascript/blob/develop/MIGRATION.md#2-removed-apis