### PR TITLE
fix(dashboards): fix tooltip in certain fields not aligned to cell text

### DIFF
--- a/static/app/views/dashboards/datasetConfig/errorsAndTransactions.tsx
+++ b/static/app/views/dashboards/datasetConfig/errorsAndTransactions.tsx
@@ -378,11 +378,11 @@ export function renderEventIdAsLinkable(
   });
 
   return (
-    <StyledTooltip title={t('View Event')}>
-      <Link data-test-id="view-event" to={target}>
+    <Link data-test-id="view-event" to={target}>
+      <StyledTooltip title={t('View Event')}>
         <Container>{getShortEventId(id)}</Container>
-      </Link>
-    </StyledTooltip>
+      </StyledTooltip>
+    </Link>
   );
 }
 
@@ -415,11 +415,11 @@ export function renderTraceAsLinkable(widget?: Widget) {
     });
 
     return (
-      <StyledTooltip title={t('View Trace')}>
-        <Link data-test-id="view-trace" to={target}>
+      <Link data-test-id="view-trace" to={target}>
+        <StyledTooltip title={t('View Trace')}>
           <Container>{getShortEventId(id)}</Container>
-        </Link>
-      </StyledTooltip>
+        </StyledTooltip>
+      </Link>
     );
   };
 }


### PR DESCRIPTION
### Changes

[Merged a PR](https://github.com/getsentry/sentry/pull/96323) a few days ago that fixed the vertical alignment the cells, but it messed up the alignment of the tooltip. This is to fix that while still persisting the fix for the vertical alignment

### Before
<img width="324" height="145" alt="Screenshot 2025-07-29 at 11 48 08 AM" src="https://github.com/user-attachments/assets/b6e1e080-90b1-4244-a4e3-9f8bfaf91e16" />


### After
<img width="356" height="137" alt="Screenshot 2025-07-29 at 11 48 19 AM" src="https://github.com/user-attachments/assets/ee2c5cc3-2b24-4090-a918-112f9e9bd322" />
