### PR TITLE
feat(dashboards): default cell actions for table widgets

### DIFF
--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
@@ -381,6 +381,7 @@ function AddToDashboardModal({
                       disableFullscreen
                       onWidgetTableResizeColumn={handleWidgetTableColumnResize}
                       onWidgetTableSort={handleWidgetTableSort}
+                      isPreview
                     />
                   </WidgetCardWrapper>
                   <IndexedEventsSelectionAlert widget={widget} />

--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -385,6 +385,7 @@ type SpecialFieldRenderFunc = (
 type SpecialField = {
   renderFunc: SpecialFieldRenderFunc;
   sortField: string | null;
+  preventCellActions?: boolean;
 };
 
 const DownloadCount = styled('span')`
@@ -450,6 +451,7 @@ const SPECIAL_FIELDS: Record<string, SpecialField> = {
         </RightAlignedContainer>
       );
     },
+    preventCellActions: true,
   },
   minidump: {
     sortField: null,
@@ -481,6 +483,7 @@ const SPECIAL_FIELDS: Record<string, SpecialField> = {
         </RightAlignedContainer>
       );
     },
+    preventCellActions: true,
   },
   id: {
     sortField: 'id',
@@ -491,6 +494,7 @@ const SPECIAL_FIELDS: Record<string, SpecialField> = {
       }
       return <Container>{getShortEventId(id)}</Container>;
     },
+    preventCellActions: true,
   },
   span_id: {
     sortField: 'span_id',
@@ -502,6 +506,7 @@ const SPECIAL_FIELDS: Record<string, SpecialField> = {
 
       return <Container>{getShortEventId(id)}</Container>;
     },
+    preventCellActions: true,
   },
   'span.description': {
     sortField: 'span.description',
@@ -554,6 +559,7 @@ const SPECIAL_FIELDS: Record<string, SpecialField> = {
 
       return <Container>{getShortEventId(id)}</Container>;
     },
+    preventCellActions: true,
   },
   'issue.id': {
     sortField: 'issue.id',
@@ -570,6 +576,7 @@ const SPECIAL_FIELDS: Record<string, SpecialField> = {
         </Container>
       );
     },
+    preventCellActions: true,
   },
   replayId: {
     sortField: 'replayId',
@@ -592,6 +599,7 @@ const SPECIAL_FIELDS: Record<string, SpecialField> = {
         </Container>
       );
     },
+    preventCellActions: true,
   },
   'profile.id': {
     sortField: 'profile.id',
@@ -635,6 +643,7 @@ const SPECIAL_FIELDS: Record<string, SpecialField> = {
         </Container>
       );
     },
+    preventCellActions: true,
   },
   project: {
     sortField: 'project',
@@ -667,6 +676,7 @@ const SPECIAL_FIELDS: Record<string, SpecialField> = {
         </Container>
       );
     },
+    preventCellActions: true,
   },
   // Two different project ID fields are being used right now. `project_id` is shared between all datasets, but `project.id` is the new one used in spans
   project_id: {
@@ -675,6 +685,7 @@ const SPECIAL_FIELDS: Record<string, SpecialField> = {
       const projectId = data.project_id;
       return getProjectIdLink(projectId, baggage);
     },
+    preventCellActions: true,
   },
   'project.id': {
     sortField: 'project.id',
@@ -682,6 +693,7 @@ const SPECIAL_FIELDS: Record<string, SpecialField> = {
       const projectId = data['project.id'];
       return getProjectIdLink(projectId, baggage);
     },
+    preventCellActions: true,
   },
   user: {
     sortField: 'user',
@@ -781,6 +793,7 @@ const SPECIAL_FIELDS: Record<string, SpecialField> = {
       ) : (
         <Container>{emptyValue}</Container>
       ),
+    preventCellActions: true,
   },
   'error.handled': {
     sortField: 'error.handled',
@@ -1156,6 +1169,18 @@ export function getSortField(
   return null;
 }
 
+/**
+ * Some special fields should not use cell actions (e.g., some fields with internal links).
+ * @param field
+ * @returns true if the no cell actions are permitted, false otherwise
+ */
+export function shouldPreventCellActions(field: string) {
+  if (SPECIAL_FIELDS.hasOwnProperty(field)) {
+    return !!SPECIAL_FIELDS[field]!.preventCellActions;
+  }
+  return false;
+}
+
 const isDurationValue = (data: EventData, field: string): boolean => {
   return field in data && typeof data[field] === 'number';
 };
@@ -1305,8 +1330,7 @@ export function getFieldRenderer(
   isAlias = true
 ): FieldFormatterRenderFunctionPartial {
   if (SPECIAL_FIELDS.hasOwnProperty(field)) {
-    // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-    return SPECIAL_FIELDS[field].renderFunc;
+    return SPECIAL_FIELDS[field]!.renderFunc;
   }
 
   if (isRelativeSpanOperationBreakdownField(field)) {

--- a/static/app/views/dashboards/widgetBuilder/components/widgetPreview.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetPreview.tsx
@@ -137,6 +137,7 @@ function WidgetPreview({
       showLoadingText
       onWidgetTableSort={handleWidgetTableSort}
       onWidgetTableResizeColumn={handleWidgetTableResizeColumn}
+      isPreview
     />
   );
 }

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -97,6 +97,7 @@ type WidgetCardChartProps = Pick<
   disableZoom?: boolean;
   expandNumbers?: boolean;
   isMobile?: boolean;
+  isPreview?: boolean;
   isSampled?: boolean | null;
   legendOptions?: LegendComponentOption;
   minTableColumnWidth?: number;
@@ -158,6 +159,7 @@ class WidgetCardChart extends Component<WidgetCardChartProps> {
       theme,
       onWidgetTableSort,
       onWidgetTableResizeColumn,
+      isPreview,
     } = this.props;
     if (loading || !tableResults?.[0]) {
       // Align height to other charts.
@@ -229,7 +231,7 @@ class WidgetCardChart extends Component<WidgetCardChartProps> {
                 } satisfies RenderFunctionBaggage;
               }}
               onResizeColumn={onWidgetTableResizeColumn}
-              allowedCellActions={[]}
+              allowedCellActions={isPreview ? [] : undefined}
             />
           ) : (
             <StyledSimpleTableChart

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -329,6 +329,7 @@ function WidgetCard(props: Props) {
             showLoadingText={showLoadingText && isLoadingTextVisible}
             onWidgetTableSort={onWidgetTableSort}
             onWidgetTableResizeColumn={onWidgetTableResizeColumn}
+            isPreview={props.isPreview}
           />
         </WidgetFrame>
       </VisuallyCompleteWithData>

--- a/static/app/views/dashboards/widgetCard/issueWidgetCard.tsx
+++ b/static/app/views/dashboards/widgetCard/issueWidgetCard.tsx
@@ -32,6 +32,7 @@ type Props = {
   theme: Theme;
   widget: Widget;
   errorMessage?: string;
+  isPreview?: boolean;
   onWidgetTableResizeColumn?: (columns: TabularColumn[]) => void;
   tableResults?: TableData[];
 };
@@ -46,6 +47,7 @@ export function IssueWidgetCard({
   location,
   theme,
   onWidgetTableResizeColumn,
+  isPreview,
 }: Props) {
   const datasetConfig = getDatasetConfig(WidgetType.ISSUE);
 
@@ -113,7 +115,7 @@ export function IssueWidgetCard({
           } satisfies RenderFunctionBaggage;
         }}
         onResizeColumn={onWidgetTableResizeColumn}
-        allowedCellActions={[]}
+        allowedCellActions={isPreview ? [] : undefined}
       />
     </TableContainer>
   ) : (

--- a/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
@@ -41,6 +41,7 @@ type Props = {
   disableZoom?: boolean;
   expandNumbers?: boolean;
   isMobile?: boolean;
+  isPreview?: boolean;
   legendOptions?: LegendComponentOption;
   minTableColumnWidth?: number;
   noPadding?: boolean;
@@ -95,6 +96,7 @@ export function WidgetCardChartContainer({
   showLoadingText,
   onWidgetTableSort,
   onWidgetTableResizeColumn,
+  isPreview,
 }: Props) {
   const location = useLocation();
   const theme = useTheme();
@@ -177,6 +179,7 @@ export function WidgetCardChartContainer({
                 theme={theme}
                 organization={organization}
                 onWidgetTableResizeColumn={onWidgetTableResizeColumn}
+                isPreview={isPreview}
               />
             </Fragment>
           );
@@ -223,6 +226,7 @@ export function WidgetCardChartContainer({
               theme={theme}
               onWidgetTableSort={onWidgetTableSort}
               onWidgetTableResizeColumn={onWidgetTableResizeColumn}
+              isPreview={isPreview}
             />
           </Fragment>
         );

--- a/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.tsx
@@ -8,7 +8,10 @@ import {defined} from 'sentry/utils';
 import {getSortField} from 'sentry/utils/dashboards/issueFieldRenderers';
 import type {MetaType} from 'sentry/utils/discover/eventView';
 import type {RenderFunctionBaggage} from 'sentry/utils/discover/fieldRenderers';
-import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
+import {
+  getFieldRenderer,
+  shouldPreventCellActions,
+} from 'sentry/utils/discover/fieldRenderers';
 import type {Column, ColumnValueType, Sort} from 'sentry/utils/discover/fields';
 import {
   fieldAlignment,
@@ -294,7 +297,9 @@ export function TableWidgetVisualization(props: TableWidgetVisualizationProps) {
                     break;
                 }
               }}
-              allowActions={allowedCellActions}
+              allowActions={
+                shouldPreventCellActions(column.key) ? [] : allowedCellActions
+              }
             >
               {cell}
             </CellAction>


### PR DESCRIPTION
### Changes

Adds default cell actions (copying text, opening external links) to table widgets. Widget preview and Add to Dashboard table widgets have cell actions disabled.

To enable this change, an additional field was added to `SPECIAL_FIELDS` as fields with internal links should not have cell actions. 

### Images

If the `discover-cell-actions-v2` flag is enabled (only perf team):
<img width="303" height="127" alt="Screenshot 2025-07-29 at 11 58 08 AM" src="https://github.com/user-attachments/assets/071b3d61-a74c-4dda-8c7b-8dc2b5477c32" />

Otherwise:
<img width="443" height="144" alt="Screenshot 2025-07-29 at 11 59 35 AM" src="https://github.com/user-attachments/assets/573f14d8-7631-48fe-9a0c-2e083e39932c" />

