### PR TITLE
fix(billing): Change display name to Logs

### DIFF
--- a/static/gsAdmin/components/addGiftEventsAction.spec.tsx
+++ b/static/gsAdmin/components/addGiftEventsAction.spec.tsx
@@ -343,7 +343,7 @@ describe('Gift', function () {
 
     function getLogBytesInput() {
       return screen.getByRole('textbox', {
-        name: 'How many log bytes in GB?',
+        name: 'How many logs in GB?',
       });
     }
 

--- a/static/gsApp/utils/dataCategory.tsx
+++ b/static/gsApp/utils/dataCategory.tsx
@@ -69,7 +69,7 @@ export function getPlanCategoryName({
   const displayNames = plan?.categoryDisplayNames?.[category];
   const categoryName =
     category === DataCategory.LOG_BYTE
-      ? 'log bytes'
+      ? 'logs'
       : category === DataCategory.SPANS && hadCustomDynamicSampling
         ? 'accepted spans'
         : displayNames

--- a/static/gsApp/views/subscriptionPage/recurringCredits.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/recurringCredits.spec.tsx
@@ -229,7 +229,7 @@ describe('Recurring Credits', function () {
 
     await screen.findByRole('heading', {name: /recurring credits/i});
 
-    expect(screen.getByText('log bytes')).toBeInTheDocument();
+    expect(screen.getByText('logs')).toBeInTheDocument();
     expect(screen.getByTestId('amount')).toHaveTextContent('+2.5 GB/mo');
   });
 


### PR DESCRIPTION
Closes: https://linear.app/getsentry/issue/BIL-1178/logs-product-should-display-in-the-ui-as-logs-not-log-bytes

Changes the display name for the Logs product. Affects the subscription card (shown below) as well as other labels in the application.

<img width="1178" height="343" alt="Screenshot 2025-07-29 at 9 53 02 AM" src="https://github.com/user-attachments/assets/557821cd-998a-48f1-be60-c3ca6c13e102" />
