### PR TITLE
fix(replay): fix navigation timestamp in log

### DIFF
--- a/src/sentry/replays/lib/summarize.py
+++ b/src/sentry/replays/lib/summarize.py
@@ -272,8 +272,9 @@ def as_log_message(event: dict[str, Any]) -> str | None:
                 message = event["data"]["payload"]["message"]
                 return f"User rage clicked on {message} but the triggered action was slow to complete at {timestamp}"
             case EventType.NAVIGATION_SPAN:
+                timestamp_ms = timestamp * 1000
                 to = event["data"]["payload"]["description"]
-                return f"User navigated to: {to} at {timestamp}"
+                return f"User navigated to: {to} at {timestamp_ms}"
             case EventType.CONSOLE:
                 message = event["data"]["payload"]["message"]
                 return f"Logged: {message} at {timestamp}"


### PR DESCRIPTION
<img width="640" height="20" alt="SCR-20250729-jqrk" src="https://github.com/user-attachments/assets/660428c3-22bb-4dec-912c-4fd14f07baee" />
