### PR TITLE
perf(aci): Make get_latest_release_for_env cache not-found releases

### DIFF
--- a/src/sentry/workflow_engine/handlers/condition/latest_release_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/latest_release_handler.py
@@ -1,4 +1,5 @@
-from typing import Any
+from abc import abstractmethod
+from typing import Any, Literal
 
 from sentry import tagstore
 from sentry.eventstore.models import GroupEvent
@@ -6,36 +7,76 @@ from sentry.models.environment import Environment
 from sentry.models.release import Release
 from sentry.rules.filters.latest_release import get_project_release_cache_key
 from sentry.search.utils import get_latest_release
+from sentry.utils import metrics
 from sentry.utils.cache import cache
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.registry import condition_handler_registry
 from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
 
 
+class CacheAccess[T]:
+    """
+    Base class for type-safe naive cache access.
+    """
+
+    @abstractmethod
+    def key(self) -> str:
+        raise NotImplementedError
+
+    def get(self) -> T | None:
+        return cache.get(self.key())
+
+    def set(self, value: T, timeout: float | None) -> None:
+        cache.set(self.key(), value, timeout)
+
+
+class _LatestReleaseCacheAccess(CacheAccess[Release | Literal[False]]):
+    def __init__(self, event: GroupEvent, environment: Environment | None):
+        self._key = get_project_release_cache_key(
+            event.group.project_id, environment.id if environment else None
+        )
+
+    def key(self) -> str:
+        return self._key
+
+
 def get_latest_release_for_env(
     environment: Environment | None, event: GroupEvent
 ) -> Release | None:
-    cache_key = get_project_release_cache_key(
-        event.group.project_id, environment.id if environment else None
-    )
-    latest_release = cache.get(cache_key)
+    cache_access = _LatestReleaseCacheAccess(event, environment)
+    latest_release = cache_access.get()
     if latest_release is not None:
+        if latest_release is False:
+            return None
         return latest_release
 
     organization_id = event.group.project.organization_id
     environments = [environment] if environment else None
+
+    def record_get_latest_release_result(result: str) -> None:
+        metrics.incr(
+            "workflow_engine.latest_release.get_latest_release",
+            tags={
+                "has_environment": str(environment is not None),
+                "result": result,
+            },
+        )
+
     try:
         latest_release_version = get_latest_release(
             [event.group.project],
             environments,
             organization_id,
         )[0]
+        record_get_latest_release_result("success")
     except Release.DoesNotExist:
+        record_get_latest_release_result("does_not_exist")
+        cache_access.set(False, 600)
         return None
     latest_release = Release.objects.get(
         version=latest_release_version, organization_id=organization_id
     )
-    cache.set(cache_key, latest_release or False, 600)
+    cache_access.set(latest_release or False, 600)
     return latest_release
 
 

--- a/src/sentry/workflow_engine/handlers/condition/latest_release_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/latest_release_handler.py
@@ -31,6 +31,11 @@ class CacheAccess[T]:
 
 
 class _LatestReleaseCacheAccess(CacheAccess[Release | Literal[False]]):
+    """
+    If we have a release for a project in an environment, we cache it.
+    If we don't, we cache False.
+    """
+
     def __init__(self, event: GroupEvent, environment: Environment | None):
         self._key = get_project_release_cache_key(
             event.group.project_id, environment.id if environment else None


### PR DESCRIPTION
We frequently see slow tasks from repeated latest release condition evaluations.
This may be due to the cache not being used when releases aren't found.
Adds caching and a metric to observe how much value it is adding.

Also adds a typed cache access helper to clarify None vs False, which is a bit overkill for a single use but helpful nonetheless.
