### PR TITLE
fix(issues): Prevent "Set up code mapping" from closing frame

### DIFF
--- a/static/app/components/events/interfaces/frame/stacktraceLink.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.tsx
@@ -411,6 +411,7 @@ const StacktraceLinkWrapper = styled('div')`
 const FixMappingButton = styled(Button)`
   color: ${p => p.theme.subText};
   font-weight: 400;
+  font-size: ${p => p.theme.fontSize.sm};
   &:hover {
     color: ${p => p.theme.subText};
   }

--- a/static/app/components/events/interfaces/frame/stacktraceLink.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.tsx
@@ -348,13 +348,16 @@ export function StacktraceLink({frame, event, line, disableSetup}: StacktraceLin
     return (
       <StacktraceLinkWrapper>
         <FixMappingButton
+          type="button"
           priority="link"
           icon={
             sourceCodeProviders.length === 1
               ? getIntegrationIcon(sourceCodeProviders[0]!.provider.key, 'sm')
               : undefined
           }
-          onClick={() => {
+          onClick={e => {
+            // Prevent from opening/closing the stack frame
+            e.stopPropagation();
             trackAnalytics(
               'integrations.stacktrace_start_setup',
               {
@@ -407,6 +410,7 @@ const StacktraceLinkWrapper = styled('div')`
 
 const FixMappingButton = styled(Button)`
   color: ${p => p.theme.subText};
+  font-weight: 400;
   &:hover {
     color: ${p => p.theme.subText};
   }


### PR DESCRIPTION
Prevents click from propagating to the stack trace frame. Reduces font weight on ui2.

before + ui2
<img width="422" height="101" alt="image" src="https://github.com/user-attachments/assets/ce7d81c5-8a6c-4c01-a333-df141eaa6792" />

after + ui2
<img width="378" height="120" alt="image" src="https://github.com/user-attachments/assets/023877e9-38c8-411e-b1f2-957826bc518f" />

before + non chonk
<img width="414" height="118" alt="image" src="https://github.com/user-attachments/assets/7d35366e-5bc5-431d-bad4-9e05ff83288d" />
