### PR TITLE
fix(spans-migration): add `platform.name` to translation layer

### DIFF
--- a/src/sentry/discover/translation/mep_to_eap.py
+++ b/src/sentry/discover/translation/mep_to_eap.py
@@ -101,6 +101,7 @@ def column_switcheroo(term):
         "geo.subregion": "user.geo.subregion",
         "timestamp.to_day": "timestamp",
         "timestamp.to_hour": "timestamp",
+        "platform.name": "platform",
     }
 
     swapped_term = column_swap_map.get(term, term)

--- a/tests/sentry/discover/translation/test_mep_to_eap.py
+++ b/tests/sentry/discover/translation/test_mep_to_eap.py
@@ -62,6 +62,10 @@ from sentry.discover.translation.mep_to_eap import QueryParts, translate_mep_to_
             "apdex(1000):>0.5 OR user_misery(1000):>0.5",
             "(apdex(span.duration,1000):>0.5 OR user_misery(span.duration,1000):>0.5) AND is_transaction:1",
         ),
+        pytest.param(
+            "platform.name:python",
+            "(platform:python) AND is_transaction:1",
+        ),
     ],
 )
 def test_mep_to_eap_simple_query(input: str, expected: str):
@@ -122,6 +126,10 @@ def test_mep_to_eap_simple_query(input: str, expected: str):
         pytest.param(
             ["any(transaction.duration)", "count_miserable(user,300)", "transaction", "count()"],
             ["transaction", "count(span.duration)"],
+        ),
+        pytest.param(
+            ["platform.name", "count()"],
+            ["platform", "count(span.duration)"],
         ),
     ],
 )


### PR DESCRIPTION
EAP doesn't support `platform.name` and `platform` tags like discover does, it only supports `platform`, so we're mapping all instances of `platform.name` to `platform` in EAP. It pretty much has the same functionality so there shouldn't be issues with the mapping.