### PR TITLE
chore(auth-v2): record analytics for rotating csrf token

### DIFF
--- a/src/sentry/analytics/events/__init__.py
+++ b/src/sentry/analytics/events/__init__.py
@@ -6,6 +6,7 @@ from .alert_rule_ui_component_webhook_sent import *  # noqa: F401,F403
 from .alert_sent import *  # noqa: F401,F403
 from .api_token_created import *  # noqa: F401,F403
 from .api_token_deleted import *  # noqa: F401,F403
+from .auth_v2 import *  # noqa: F401,F403
 from .checkin_processing_error_stored import *  # noqa: F401,F403
 from .codeowners_assignment import *  # noqa: F401,F403
 from .codeowners_created import *  # noqa: F401,F403

--- a/src/sentry/analytics/events/auth_v2.py
+++ b/src/sentry/analytics/events/auth_v2.py
@@ -1,0 +1,16 @@
+from sentry import analytics
+from sentry.analytics import Event, eventclass
+
+
+@eventclass("auth_v2.csrf_token.rotated")
+class AuthV2CsrfTokenRotated(Event):
+    event: str
+
+
+@eventclass("auth_v2.csrf_token.delete_login")
+class AuthV2DeleteLogin(Event):
+    event: str
+
+
+analytics.register(AuthV2CsrfTokenRotated)
+analytics.register(AuthV2DeleteLogin)


### PR DESCRIPTION
We hit the API directly to logout + rotate the CSRF token. We want to record when this happens specifically from `403-csrf-failure-script.html`