### PR TITLE
chore(issues): remove option registration from inferring project platform

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3653,14 +3653,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Rollout for inferring project platform from events received
-register(
-    "sentry:infer_project_platform",
-    type=Float,
-    default=0.0,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-
 register(
     "sentry.hybridcloud.cacheversion.rollout",
     type=Float,


### PR DESCRIPTION
Follow up from https://github.com/getsentry/sentry-options-automator/pull/4702, cleaning up leftover option from rolling out inferring project platforms from https://github.com/getsentry/sentry/pull/95402