### PR TITLE
fix(explore): revert removing cell actions from linked id fields

### DIFF
--- a/static/app/views/explore/tables/fieldRenderer.tsx
+++ b/static/app/views/explore/tables/fieldRenderer.tsx
@@ -146,7 +146,7 @@ function BaseExploreFieldRenderer({
       source: TraceViewSources.TRACES,
     });
 
-    return <Link to={target}>{rendered}</Link>;
+    rendered = <Link to={target}>{rendered}</Link>;
   }
 
   if (['id', 'span_id', 'transaction.id'].includes(field)) {
@@ -162,7 +162,7 @@ function BaseExploreFieldRenderer({
       source: TraceViewSources.TRACES,
     });
 
-    return <Link to={target}>{rendered}</Link>;
+    rendered = <Link to={target}>{rendered}</Link>;
   }
 
   if (field === 'profile.id') {
@@ -171,7 +171,7 @@ function BaseExploreFieldRenderer({
       projectSlug: data.project,
       profileId: data['profile.id'],
     });
-    return <Link to={target}>{rendered}</Link>;
+    rendered = <Link to={target}>{rendered}</Link>;
   }
 
   return (


### PR DESCRIPTION
### Changes

Reverts removing cell actions from linked fields in explore tables.

### Image
<img width="277" height="227" alt="Screenshot 2025-07-29 at 2 42 32 PM" src="https://github.com/user-attachments/assets/eda650b4-f2f1-4995-8135-45175cd404a3" />
