### PR TITLE
core: add slot component

### DIFF
--- a/static/app/components/slot/index.tsx
+++ b/static/app/components/slot/index.tsx
@@ -1,0 +1,1 @@
+export {Slot} from './slot';

--- a/static/app/components/slot/slot.spec.tsx
+++ b/static/app/components/slot/slot.spec.tsx
@@ -1,0 +1,123 @@
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {Text} from 'sentry/components/core/text';
+
+import {Slot} from './slot';
+
+describe('Slot', () => {
+  describe('production environment', () => {
+    let originalEnv: string | undefined;
+
+    beforeEach(() => {
+      originalEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'production';
+    });
+
+    afterEach(() => {
+      process.env.NODE_ENV = originalEnv;
+    });
+
+    it('renders null for invalid children', () => {
+      render(<Slot>Hello</Slot>);
+      expect(screen.queryByText('Hello')).not.toBeInTheDocument();
+      render(<Slot>{['Hello', 'from', 'production']}</Slot>);
+      expect(screen.queryByText('Hello')).not.toBeInTheDocument();
+    });
+
+    it('renders null if multiple children are provided', () => {
+      render(
+        <Slot>
+          <Text>Hello</Text>
+          <Text>World</Text>
+        </Slot>
+      );
+      expect(screen.queryByText('Hello')).not.toBeInTheDocument();
+      expect(screen.queryByText('World')).not.toBeInTheDocument();
+    });
+
+    it('renders the child if it is a valid element', () => {
+      render(
+        <Slot>
+          <Text>Hello</Text>
+        </Slot>
+      );
+      expect(screen.getByText('Hello')).toBeInTheDocument();
+    });
+  });
+
+  describe('development environment', () => {
+    let originalEnv: string | undefined;
+
+    beforeEach(() => {
+      originalEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'development';
+    });
+
+    afterEach(() => {
+      process.env.NODE_ENV = originalEnv;
+    });
+
+    it('throws an error if children is not a valid element', () => {
+      expect(() => render(<Slot>{['Hello', 'from', 'development']}</Slot>)).toThrow(
+        'React.Children.only expected to receive a single React element child.'
+      );
+    });
+
+    it('throws an error if children count is greater than 1', () => {
+      expect(() =>
+        render(
+          <Slot>
+            <Text>Hello</Text>
+            <Text>World</Text>
+          </Slot>
+        )
+      ).toThrow('React.Children.only expected to receive a single React element child.');
+    });
+
+    it('renders the child if it is a valid element', () => {
+      render(
+        <Slot>
+          <Text>Hello</Text>
+        </Slot>
+      );
+      expect(screen.getByText('Hello')).toBeInTheDocument();
+    });
+  });
+
+  it('merges styles', () => {
+    render(
+      <Slot style={{color: 'red'}}>
+        <Text style={{backgroundColor: 'blue'}}>Hello</Text>
+      </Slot>
+    );
+    expect(screen.getByText('Hello')).toHaveStyle({
+      color: 'red',
+      backgroundColor: 'blue',
+    });
+  });
+
+  it('merges classNames', () => {
+    render(
+      <Slot className="slot">
+        <Text className="child">Hello</Text>
+      </Slot>
+    );
+    expect(screen.getByText('Hello')).toHaveClass('slot', 'child');
+  });
+
+  it('merges handlers', async () => {
+    const handleSlotClick = jest.fn();
+    const handleChildClick = jest.fn();
+
+    render(
+      <Slot onClick={handleSlotClick}>
+        <Text onClick={handleChildClick}>Hello</Text>
+      </Slot>
+    );
+
+    await userEvent.click(screen.getByText('Hello'));
+
+    expect(handleSlotClick).toHaveBeenCalledTimes(1);
+    expect(handleChildClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/static/app/components/slot/slot.tsx
+++ b/static/app/components/slot/slot.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+
+interface SlotProps extends React.ComponentProps<any> {
+  children?: React.ReactNode;
+}
+
+/**
+ * The slot Component is used internally inside the design system to implement the asChild slot pattern.
+ * @internal
+ */
+export function Slot({children, ...props}: SlotProps): React.ReactNode {
+  // Destructure child, or else we'll just end up rendering it as the child prop
+  // and negate the entire slot functionality.
+  if (React.isValidElement(children)) {
+    return React.cloneElement(children, mergeProps(props, children.props));
+  }
+
+  // React.Children.only will throw if there are multiple children.
+  return process.env.NODE_ENV === 'production' ? null : React.Children.only(children);
+}
+
+function mergeProps(slotProps: SlotProps, childProps: React.ComponentProps<any>) {
+  // take all children props and merge them with the slot props
+  const result = {...childProps};
+
+  for (const slotPropKey in slotProps) {
+    if (childProps[slotPropKey] === undefined) continue;
+
+    const childValue = childProps[slotPropKey];
+    const slotValue = slotProps[slotPropKey];
+
+    if (typeof childValue === 'function' && typeof slotValue === 'function') {
+      result[slotPropKey] = (...args: readonly unknown[]) => {
+        // Call the slot function as a side effect of the child invocation and treat the result as the return value.
+
+        // There is a potential issue here where it is currently possible for the child function
+        // to mutate args, causing the slot to receive different arguments than the ones passed in.
+        // I am unsure if this could be mitigated, as it would require a deep clone of args,
+        // which might not be feasible due to unserializable values.
+        const value = childValue(...args);
+        slotValue(...args);
+        return value;
+      };
+      continue;
+    }
+
+    switch (slotPropKey) {
+      case 'style':
+        // Treat the styles from the slot as more of a suggestion than a strict override,
+        // which allows users to opt out of the style override by omitting the child style implementation.
+        result[slotPropKey] = {
+          ...slotValue,
+          ...childValue,
+        };
+        break;
+      case 'className':
+        result[slotPropKey] = [childValue, slotValue].filter(Boolean).join(' ');
+        break;
+      default:
+        // Slot props take precedence over child props.
+        result[slotPropKey] = slotValue;
+        break;
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
Introduce a Slot component to design system.

This component will be used in a followup PR to implement the `asChild` prop on Flex and Grid to implement a composition pattern. 