### PR TITLE
Remove uptime date cutoff setting

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3182,7 +3182,6 @@ register(
 )
 
 
-
 register(
     "uptime.snuba_uptime_results.enabled",
     type=Bool,
@@ -3643,14 +3642,6 @@ register(
 # Enable experimental message parameterization in grouping.
 register(
     "grouping.experimental_parameterization",
-    type=Float,
-    default=0.0,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-
-# Rollout for inferring project platform from events received
-register(
-    "sentry:infer_project_platform",
     type=Float,
     default=0.0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3181,12 +3181,7 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-register(
-    "uptime.date_cutoff_epoch_seconds",
-    type=Int,
-    default=0,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
+
 
 register(
     "uptime.snuba_uptime_results.enabled",

--- a/src/sentry/uptime/endpoints/organization_uptime_stats.py
+++ b/src/sentry/uptime/endpoints/organization_uptime_stats.py
@@ -329,7 +329,7 @@ def add_missing_buckets(
     first_result = formatted_response[list(formatted_response.keys())[0]]
     if len(first_result) >= total_buckets:
         return formatted_response
-    
+
     num_missing = total_buckets - len(first_result)
 
     # Add missing buckets at the beginning for each subscription
@@ -344,5 +344,3 @@ def add_missing_buckets(
         result[subscription_id] = missing_buckets + data
 
     return result
-
-

--- a/src/sentry/uptime/endpoints/project_uptime_alert_checks_index.py
+++ b/src/sentry/uptime/endpoints/project_uptime_alert_checks_index.py
@@ -373,5 +373,3 @@ class ProjectUptimeAlertCheckIndexEndpoint(ProjectUptimeAlertEndpoint):
             return None
         val_str = check_status_reason_val.val_str
         return cast(CheckStatusReasonType, val_str) if val_str != "" else None
-
-

--- a/src/sentry/uptime/endpoints/project_uptime_alert_checks_index.py
+++ b/src/sentry/uptime/endpoints/project_uptime_alert_checks_index.py
@@ -115,13 +115,6 @@ class ProjectUptimeAlertCheckIndexEndpoint(ProjectUptimeAlertEndpoint):
         subscription_key: str,
         include_request_sequence_filter: bool,
     ) -> list[EapCheckEntrySerializerResponse]:
-        maybe_cutoff = self._get_date_cutoff_epoch_seconds()
-        epoch_cutoff = (
-            datetime.fromtimestamp(maybe_cutoff, tz=timezone.utc) if maybe_cutoff else None
-        )
-        if epoch_cutoff and epoch_cutoff > start:
-            start = epoch_cutoff
-
         start_timestamp = Timestamp()
         start_timestamp.FromDatetime(start)
         end_timestamp = Timestamp()
@@ -381,6 +374,4 @@ class ProjectUptimeAlertCheckIndexEndpoint(ProjectUptimeAlertEndpoint):
         val_str = check_status_reason_val.val_str
         return cast(CheckStatusReasonType, val_str) if val_str != "" else None
 
-    def _get_date_cutoff_epoch_seconds(self) -> float | None:
-        value = float(options.get("uptime.date_cutoff_epoch_seconds"))
-        return None if value == 0 else value
+

--- a/tests/sentry/uptime/endpoints/test_organization_uptime_stats.py
+++ b/tests/sentry/uptime/endpoints/test_organization_uptime_stats.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta, timezone
 from sentry.testutils.cases import APITestCase, UptimeCheckSnubaTestCase
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.helpers.options import override_options
-
+from sentry.uptime.endpoints.organization_uptime_stats import add_missing_buckets
 from sentry.uptime.types import IncidentStatus
 from sentry.utils import json
 from tests.sentry.uptime.endpoints.test_base import UptimeResultEAPTestCase
@@ -150,6 +150,56 @@ class OrganizationUptimeStatsBaseTest(APITestCase):
                 response.json()
                 == "Too many project uptime subscription ids provided. Maximum is 100"
             )
+
+
+def test_add_missing_buckets() -> None:
+    """Test adding missing buckets to ensure full time range coverage"""
+    start = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    end = datetime(2025, 1, 2, tzinfo=timezone.utc)
+    rollup = 3600  # 1 hour
+
+    # Generate 12 hours of data points starting at 12:00 (missing first 12 hours)
+    data_points = []
+    start_data_time = datetime(2025, 1, 1, 12, tzinfo=timezone.utc)
+    for i in range(12):
+        timestamp = int(start_data_time.timestamp()) + (i * 3600)
+        data_points.append(
+            (timestamp, {"failure": i % 3, "success": (3 - i % 3), "missed_window": 0})
+        )
+
+    subscription_id = 1234
+    formatted_response = {subscription_id: data_points}
+
+    result = add_missing_buckets(formatted_response, rollup, start, end)
+
+    # Should have 24 buckets total (24 hours worth)
+    assert len(result[subscription_id]) == 24
+
+    # First bucket should be at start time
+    assert result[subscription_id][0][0] == int(start.timestamp())
+
+    # Last bucket should be the original last bucket
+    assert result[subscription_id][-1] == formatted_response[subscription_id][-1]
+
+    # Added buckets should have zero counts
+    for bucket in result[subscription_id][:12]:
+        assert bucket[1] == {"failure": 0, "failure_incident": 0, "success": 0, "missed_window": 0}
+
+    # Test when response already has full coverage - should return original
+    full_data_points = []
+    for i in range(24):
+        timestamp = int(start.timestamp()) + (i * 3600)
+        full_data_points.append(
+            (timestamp, {"failure": 0, "success": 1, "missed_window": 0})
+        )
+    
+    full_response = {subscription_id: full_data_points}
+    result = add_missing_buckets(full_response, rollup, start, end)
+    assert result == full_response
+
+    # Test with empty response - should return original
+    result = add_missing_buckets({}, rollup, start, end)
+    assert result == {}
 
 
 @freeze_time(MOCK_DATETIME)

--- a/tests/sentry/uptime/endpoints/test_organization_uptime_stats.py
+++ b/tests/sentry/uptime/endpoints/test_organization_uptime_stats.py
@@ -79,8 +79,6 @@ class OrganizationUptimeStatsBaseTest(APITestCase):
                 "missed_window": 0,
             }
 
-
-
     def test_invalid_uptime_subscription_id(self) -> None:
         """
         Test that an invalid uptime_subscription_id produces a 400 response.
@@ -189,10 +187,8 @@ def test_add_missing_buckets() -> None:
     full_data_points = []
     for i in range(24):
         timestamp = int(start.timestamp()) + (i * 3600)
-        full_data_points.append(
-            (timestamp, {"failure": 0, "success": 1, "missed_window": 0})
-        )
-    
+        full_data_points.append((timestamp, {"failure": 0, "success": 1, "missed_window": 0}))
+
     full_response = {subscription_id: full_data_points}
     result = add_missing_buckets(full_response, rollup, start, end)
     assert result == full_response
@@ -221,9 +217,6 @@ class OrganizationUptimeCheckIndexEndpointTest(
             incident_status=incident_status,
             scheduled_check_time=scheduled_check_time,
         )
-
-
-
 
 
 @freeze_time(MOCK_DATETIME)

--- a/tests/sentry/uptime/endpoints/test_project_uptime_alert_check_index.py
+++ b/tests/sentry/uptime/endpoints/test_project_uptime_alert_check_index.py
@@ -165,8 +165,6 @@ class ProjectUptimeAlertCheckIndexBaseTest(UptimeAlertBaseEndpointTest):
             assert response.data is not None
             assert len(response.data) == 0
 
-
-
     def test_get_with_none_subscription_id(self) -> None:
         with self.feature(self.features):
             # Create a subscription with None subscription_id

--- a/tests/sentry/uptime/endpoints/test_project_uptime_alert_check_index.py
+++ b/tests/sentry/uptime/endpoints/test_project_uptime_alert_check_index.py
@@ -165,18 +165,7 @@ class ProjectUptimeAlertCheckIndexBaseTest(UptimeAlertBaseEndpointTest):
             assert response.data is not None
             assert len(response.data) == 0
 
-    @override_options(
-        {"uptime.date_cutoff_epoch_seconds": (MOCK_DATETIME - timedelta(seconds=1)).timestamp()}
-    )
-    def test_get_with_date_cutoff(self) -> None:
-        with self.feature(self.features):
-            response = self.get_success_response(
-                self.organization.slug,
-                self.project.slug,
-                self.project_uptime_subscription.id,
-            )
-            assert response.data is not None
-            assert len(response.data) == 0
+
 
     def test_get_with_none_subscription_id(self) -> None:
         with self.feature(self.features):


### PR DESCRIPTION
This PR removes the `uptime.date_cutoff_epoch_seconds` option and its related code. This option was a temporary measure to handle historical data gaps and is no longer necessary. The essential logic for filling missing time series buckets has been retained and generalized, now decoupled from the removed cutoff.