### PR TITLE
fix(discover): Refresh discover saved queries on delete/duplicate

### DIFF
--- a/static/app/views/discover/landing.tsx
+++ b/static/app/views/discover/landing.tsx
@@ -143,6 +143,7 @@ function DiscoverLanding() {
     error,
     data: savedQueries = [],
     getResponseHeader,
+    refetch: refreshSavedQueries,
   } = useDiscoverLandingQuery(renderPrebuilt);
 
   const savedQueriesPageLinks = getResponseHeader?.('Link');
@@ -254,6 +255,7 @@ function DiscoverLanding() {
                   location={location}
                   organization={organization}
                   router={router}
+                  refetchSavedQueries={refreshSavedQueries}
                 />
               )}
             </Layout.Main>

--- a/static/app/views/discover/queryList.spec.tsx
+++ b/static/app/views/discover/queryList.spec.tsx
@@ -26,6 +26,7 @@ describe('Discover > QueryList', function () {
   let duplicateMock: jest.Mock;
   let updateHomepageMock: jest.Mock;
   let eventsStatsMock: jest.Mock;
+  const refetchSavedQueries = jest.fn();
 
   const {router} = initializeOrg();
 
@@ -34,6 +35,7 @@ describe('Discover > QueryList', function () {
   });
 
   beforeEach(function () {
+    jest.resetAllMocks();
     organization = OrganizationFixture({
       features: ['discover-basic', 'discover-query'],
     });
@@ -91,6 +93,7 @@ describe('Discover > QueryList', function () {
         pageLinks=""
         renderPrebuilt={false}
         location={location}
+        refetchSavedQueries={refetchSavedQueries}
       />,
       {
         deprecatedRouterMocks: true,
@@ -110,6 +113,7 @@ describe('Discover > QueryList', function () {
         renderPrebuilt
         pageLinks=""
         location={location}
+        refetchSavedQueries={refetchSavedQueries}
       />,
       {
         deprecatedRouterMocks: true,
@@ -151,6 +155,7 @@ describe('Discover > QueryList', function () {
         renderPrebuilt
         pageLinks=""
         location={location}
+        refetchSavedQueries={refetchSavedQueries}
       />,
       {
         router,
@@ -210,6 +215,7 @@ describe('Discover > QueryList', function () {
         renderPrebuilt
         pageLinks=""
         location={location}
+        refetchSavedQueries={refetchSavedQueries}
       />,
       {
         deprecatedRouterMocks: true,
@@ -248,6 +254,7 @@ describe('Discover > QueryList', function () {
         pageLinks=""
         renderPrebuilt={false}
         location={location}
+        refetchSavedQueries={refetchSavedQueries}
       />,
       {
         router,
@@ -282,6 +289,7 @@ describe('Discover > QueryList', function () {
         savedQueries={savedQueries}
         pageLinks=""
         location={location}
+        refetchSavedQueries={refetchSavedQueries}
       />,
       {
         deprecatedRouterMocks: true,
@@ -295,6 +303,7 @@ describe('Discover > QueryList', function () {
     await userEvent.click(withinCard.getByText('Delete Query'));
 
     expect(deleteMock).toHaveBeenCalled();
+    expect(refetchSavedQueries).toHaveBeenCalled();
   });
 
   it('redirects to Discover on card click', async function () {
@@ -307,6 +316,7 @@ describe('Discover > QueryList', function () {
         pageLinks=""
         renderPrebuilt={false}
         location={location}
+        refetchSavedQueries={refetchSavedQueries}
       />,
       {
         router,
@@ -331,6 +341,7 @@ describe('Discover > QueryList', function () {
         renderPrebuilt={false}
         pageLinks=""
         location={location}
+        refetchSavedQueries={refetchSavedQueries}
       />,
       {
         router,
@@ -368,6 +379,7 @@ describe('Discover > QueryList', function () {
         pageLinks=""
         renderPrebuilt={false}
         location={location}
+        refetchSavedQueries={refetchSavedQueries}
       />,
       {
         deprecatedRouterMocks: true,
@@ -401,6 +413,7 @@ describe('Discover > QueryList', function () {
         pageLinks=""
         renderPrebuilt={false}
         location={location}
+        refetchSavedQueries={refetchSavedQueries}
       />,
       {
         deprecatedRouterMocks: true,
@@ -443,6 +456,7 @@ describe('Discover > QueryList', function () {
         pageLinks=""
         renderPrebuilt={false}
         location={location}
+        refetchSavedQueries={refetchSavedQueries}
       />,
       {
         deprecatedRouterMocks: true,
@@ -471,6 +485,7 @@ describe('Discover > QueryList', function () {
         renderPrebuilt={false}
         pageLinks=""
         location={location}
+        refetchSavedQueries={refetchSavedQueries}
       />,
       {
         deprecatedRouterMocks: true,
@@ -509,6 +524,7 @@ describe('Discover > QueryList', function () {
         pageLinks=""
         renderPrebuilt={false}
         location={location}
+        refetchSavedQueries={refetchSavedQueries}
       />
     );
 
@@ -545,6 +561,7 @@ describe('Discover > QueryList', function () {
         pageLinks=""
         renderPrebuilt={false}
         location={location}
+        refetchSavedQueries={refetchSavedQueries}
       />
     );
 
@@ -580,6 +597,7 @@ describe('Discover > QueryList', function () {
           ]}
           pageLinks=""
           location={location}
+          refetchSavedQueries={refetchSavedQueries}
         />,
         {
           deprecatedRouterMocks: true,
@@ -647,6 +665,7 @@ describe('Discover > QueryList', function () {
           ]}
           pageLinks=""
           location={location}
+          refetchSavedQueries={refetchSavedQueries}
         />,
         {
           deprecatedRouterMocks: true,
@@ -714,6 +733,7 @@ describe('Discover > QueryList', function () {
           ]}
           pageLinks=""
           location={location}
+          refetchSavedQueries={refetchSavedQueries}
         />
       );
 
@@ -750,6 +770,7 @@ describe('Discover > QueryList', function () {
           ]}
           pageLinks=""
           location={location}
+          refetchSavedQueries={refetchSavedQueries}
         />
       );
 
@@ -787,6 +808,7 @@ describe('Discover > QueryList', function () {
         ]}
         pageLinks=""
         location={location}
+        refetchSavedQueries={refetchSavedQueries}
       />,
       {
         deprecatedRouterMocks: true,

--- a/static/app/views/discover/queryList.tsx
+++ b/static/app/views/discover/queryList.tsx
@@ -47,6 +47,7 @@ type Props = {
   location: Location;
   organization: Organization;
   pageLinks: string;
+  refetchSavedQueries: () => void;
   renderPrebuilt: boolean;
   router: InjectedRouter;
   savedQueries: SavedQuery[];
@@ -63,9 +64,10 @@ class QueryList extends Component<Props> {
   }
 
   handleDeleteQuery = (eventView: EventView) => {
-    const {api, organization, location, savedQueries} = this.props;
+    const {api, organization, location, savedQueries, refetchSavedQueries} = this.props;
 
     handleDeleteQuery(api, organization, eventView).then(() => {
+      refetchSavedQueries();
       if (savedQueries.length === 1 && location.query.cursor) {
         browserHistory.push({
           pathname: location.pathname,
@@ -76,12 +78,13 @@ class QueryList extends Component<Props> {
   };
 
   handleDuplicateQuery = (eventView: EventView, yAxis: string[]) => {
-    const {api, location, organization} = this.props;
+    const {api, location, organization, refetchSavedQueries} = this.props;
 
     eventView = eventView.clone();
     eventView.name = `${eventView.name} copy`;
 
     handleCreateQuery(api, organization, eventView, yAxis).then(() => {
+      refetchSavedQueries();
       browserHistory.push({
         pathname: location.pathname,
         query: {},


### PR DESCRIPTION
just refreshes the current query

this acceptance test below is testing this case, however it currently only passes because it attempts to navigate to the saved query directly after deleting (event propagation) therefore the card disappears and it passes.

https://github.com/getsentry/sentry/blob/195d6990b8a694ee733a1483e0b3f7486b53a5f4/tests/acceptance/test_organization_events_v2.py#L447-L472