### PR TITLE
fix(aci): Fix Workflow serializer lastTriggered

### DIFF
--- a/src/sentry/workflow_engine/endpoints/serializers.py
+++ b/src/sentry/workflow_engine/endpoints/serializers.py
@@ -403,6 +403,7 @@ class WorkflowSerializer(Serializer):
             WorkflowFireHistory.objects.filter(
                 workflow__in=item_list,
             )
+            .values("workflow_id")
             .annotate(last_triggered=Max("date_added"))
             .values_list("workflow_id", "last_triggered")
         )

--- a/tests/sentry/workflow_engine/endpoints/test_serializers.py
+++ b/tests/sentry/workflow_engine/endpoints/test_serializers.py
@@ -454,8 +454,14 @@ class TestWorkflowSerializer(TestCase):
             workflow=workflow,
             group=self.group,
             event_id=self.event.event_id,
-            date_added=workflow.date_added + timedelta(seconds=1),
         )
+        WorkflowFireHistory.objects.create(
+            workflow=workflow,
+            group=self.group,
+            event_id=self.event.event_id,
+        )
+        history.date_added = workflow.date_added + timedelta(seconds=1)
+        history.save()
 
         result = serialize(workflow)
 


### PR DESCRIPTION
We need to use `values()` to ensure we're not implicitly grouping by `workflowfirehistory.id` rather than `workflowfirehistory.workflow_id`.

Updates tests to ensure undoing this will fail.
