### PR TITLE
ref: fix typing for sentry.db.postgres.base

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,6 @@ module = [
     "sentry.api.endpoints.organization_events_spans_performance",
     "sentry.api.endpoints.organization_releases",
     "sentry.api.paginator",
-    "sentry.db.postgres.base",
     "sentry.eventstore.models",
     "sentry.identity.gitlab.provider",
     "sentry.identity.oauth2",

--- a/src/sentry/db/postgres/decorators.py
+++ b/src/sentry/db/postgres/decorators.py
@@ -21,7 +21,7 @@ def auto_reconnect_cursor(func):
                 raise
 
             self.db.close(reconnect=True)
-            self.cursor = self.db._cursor()
+            self.cursor = self.db.cursor()
 
             return func(self, *args, **kwargs)
 


### PR DESCRIPTION
_set_isolation_level was removed in django/django@64a899dc815f1a070dc7a7c22276e8bb41e46ea6 released in django 1.9

<!-- Describe your PR here. -->