### PR TITLE
feat(logs): Add pause functionality to auto-refresh

### DIFF
--- a/static/app/views/explore/contexts/logs/logsAutoRefreshContext.tsx
+++ b/static/app/views/explore/contexts/logs/logsAutoRefreshContext.tsx
@@ -11,7 +11,7 @@ import {useLogsQueryKeyWithInfinite} from 'sentry/views/explore/logs/useLogsQuer
 export const LOGS_AUTO_REFRESH_KEY = 'live';
 export const LOGS_REFRESH_INTERVAL_KEY = 'refreshEvery';
 const LOGS_REFRESH_INTERVAL_DEFAULT = 5000;
-export const MAX_AUTO_REFRESH_PAUSED_TIME_MS = 60 * 1000; // 60 seconds
+const MAX_AUTO_REFRESH_PAUSED_TIME_MS = 60 * 1000; // 60 seconds
 
 export const ABSOLUTE_MAX_AUTO_REFRESH_TIME_MS = 10 * 60 * 1000; // 10 minutes
 export const CONSECUTIVE_PAGES_WITH_MORE_DATA = 5;

--- a/static/app/views/explore/contexts/logs/logsAutoRefreshContext.tsx
+++ b/static/app/views/explore/contexts/logs/logsAutoRefreshContext.tsx
@@ -119,7 +119,7 @@ function withinPauseWindow(autoRefresh: AutoRefreshState, pausedAt: number | und
   return (
     (autoRefresh === 'paused' || autoRefresh === 'enabled') &&
     pausedAt &&
-    MAX_AUTO_REFRESH_PAUSED_TIME_MS - (Date.now() - pausedAt) > 0
+    Date.now() - pausedAt < MAX_AUTO_REFRESH_PAUSED_TIME_MS
   );
 }
 

--- a/static/app/views/explore/hooks/useAnalytics.tsx
+++ b/static/app/views/explore/hooks/useAnalytics.tsx
@@ -8,6 +8,7 @@ import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useOrganization from 'sentry/utils/useOrganization';
 import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
+import {useLogsAutoRefreshEnabled} from 'sentry/views/explore/contexts/logs/logsAutoRefreshContext';
 import {
   useLogsFields,
   useLogsSearch,
@@ -414,9 +415,11 @@ export function useLogAnalytics({
 
   const tableError = logsTableResult.error?.message ?? '';
   const query_status = tableError ? 'error' : 'success';
+  const autorefreshEnabled = useLogsAutoRefreshEnabled();
 
   useEffect(() => {
-    if (logsTableResult.isPending || isLoadingSubscriptionDetails) {
+    if (logsTableResult.isPending || isLoadingSubscriptionDetails || autorefreshEnabled) {
+      // Auto-refresh causes constant metadata events, so we don't want to track them.
       return;
     }
 
@@ -462,6 +465,7 @@ export function useLogAnalytics({
     logsTableResult.isPending,
     logsTableResult.data?.length,
     search,
+    autorefreshEnabled,
   ]);
 }
 

--- a/static/app/views/explore/hooks/useTraceItemDetails.tsx
+++ b/static/app/views/explore/hooks/useTraceItemDetails.tsx
@@ -15,8 +15,6 @@ import {
   shouldRetryHandler,
 } from 'sentry/views/insights/common/utils/retryHandlers';
 
-export const DEFAULT_TRACE_ITEM_HOVER_TIMEOUT = 200;
-
 interface UseTraceItemDetailsProps {
   /**
    * Every trace item belongs to a project.
@@ -147,12 +145,17 @@ export function usePrefetchTraceItemDetailsOnHover({
   referrer,
   hoverPrefetchDisabled,
   sharedHoverTimeoutRef,
+  timeout,
 }: UseTraceItemDetailsProps & {
   /**
    * A ref to a shared timeout so multiple hover events can be handled
    * without creating multiple timeouts and firing multiple prefetches.
    */
   sharedHoverTimeoutRef: React.MutableRefObject<NodeJS.Timeout | null>;
+  /**
+   * Custom timeout for the prefetched item.
+   */
+  timeout: number;
   /**
    * Whether the hover prefetch should be disabled.
    */
@@ -184,7 +187,7 @@ export function usePrefetchTraceItemDetailsOnHover({
           queryFn: fetchDataQuery,
           staleTime: Infinity, // Prefetched items are never stale as the row is either entirely stored or not stored at all.
         });
-      }, DEFAULT_TRACE_ITEM_HOVER_TIMEOUT);
+      }, timeout);
     },
     onHoverEnd: () => {
       if (sharedHoverTimeoutRef.current) {

--- a/static/app/views/explore/logs/constants.tsx
+++ b/static/app/views/explore/logs/constants.tsx
@@ -17,6 +17,8 @@ export const MAX_LOG_INGEST_DELAY = 40_000;
 export const QUERY_PAGE_LIMIT = 1000; // If this does not equal the limit with auto-refresh, the query keys will diverge and they will have separate caches. We may want to make this change in the future.
 export const QUERY_PAGE_LIMIT_WITH_AUTO_REFRESH = 1000;
 export const LOG_ATTRIBUTE_LAZY_LOAD_HOVER_TIMEOUT = 150;
+export const DEFAULT_TRACE_ITEM_HOVER_TIMEOUT = 150;
+export const DEFAULT_TRACE_ITEM_HOVER_TIMEOUT_WITH_AUTO_REFRESH = 400; // With autorefresh on, a stationary mouse can prefetch multiple rows since virtual time moves rows constantly.
 
 /**
  * These are required fields are always added to the query when fetching the log table.

--- a/static/app/views/explore/logs/logsAutoRefresh.tsx
+++ b/static/app/views/explore/logs/logsAutoRefresh.tsx
@@ -114,7 +114,7 @@ export function AutorefreshToggle({
               if (newChecked) {
                 setAutorefresh('enabled');
               } else {
-                setAutorefresh('idle');
+                setAutorefresh('paused');
               }
             }}
           />

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.spec.tsx
@@ -23,7 +23,7 @@ import {
   LogsPageParamsProvider,
 } from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {LOGS_SORT_BYS_KEY} from 'sentry/views/explore/contexts/logs/sortBys';
-import {DEFAULT_TRACE_ITEM_HOVER_TIMEOUT} from 'sentry/views/explore/hooks/useTraceItemDetails';
+import {DEFAULT_TRACE_ITEM_HOVER_TIMEOUT} from 'sentry/views/explore/logs/constants';
 import {LogsInfiniteTable} from 'sentry/views/explore/logs/tables/logsInfiniteTable';
 import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
 import {OrganizationContext} from 'sentry/views/organizationContext';

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
@@ -23,7 +23,10 @@ import {
   TableStatus,
   useTableStyles,
 } from 'sentry/views/explore/components/table';
-import {useLogsAutoRefreshEnabled} from 'sentry/views/explore/contexts/logs/logsAutoRefreshContext';
+import {
+  useAutorefreshEnabledOrWithinPauseWindow,
+  useLogsAutoRefreshEnabled,
+} from 'sentry/views/explore/contexts/logs/logsAutoRefreshContext';
 import {useLogsPageData} from 'sentry/views/explore/contexts/logs/logsPageData';
 import {
   useLogsFields,
@@ -94,6 +97,10 @@ export function LogsInfiniteTable({
     Record<string, number>
   >({});
   const [isFunctionScrolling, setIsFunctionScrolling] = useState(false);
+  const isAutorefreshEnabledOrWithinPauseWindow =
+    useAutorefreshEnabledOrWithinPauseWindow();
+  const scrollFetchDisabled =
+    isFunctionScrolling || !isAutorefreshEnabledOrWithinPauseWindow;
 
   const sharedHoverTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const {initialTableStyles, onResizeMouseDown} = useTableStyles(fields, tableRef, {
@@ -161,7 +168,7 @@ export function LogsInfiniteTable({
   }, [isFunctionScrolling, isScrolling, scrollOffset]);
 
   useEffect(() => {
-    if (isScrolling && !isFunctionScrolling) {
+    if (isScrolling && !scrollFetchDisabled) {
       if (
         scrollDirection === 'backward' &&
         scrollOffset &&
@@ -187,6 +194,7 @@ export function LogsInfiniteTable({
     lastPageLength,
     scrollOffset,
     isFunctionScrolling,
+    scrollFetchDisabled,
   ]);
 
   const handleExpand = useCallback((logItemId: string) => {

--- a/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
@@ -14,10 +14,8 @@ import {
   LogsPageParamsProvider,
 } from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {LOGS_SORT_BYS_KEY} from 'sentry/views/explore/contexts/logs/sortBys';
-import {
-  DEFAULT_TRACE_ITEM_HOVER_TIMEOUT,
-  type TraceItemResponseAttribute,
-} from 'sentry/views/explore/hooks/useTraceItemDetails';
+import {type TraceItemResponseAttribute} from 'sentry/views/explore/hooks/useTraceItemDetails';
+import {DEFAULT_TRACE_ITEM_HOVER_TIMEOUT} from 'sentry/views/explore/logs/constants';
 import {LogRowContent} from 'sentry/views/explore/logs/tables/logsTableRow';
 import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
 

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -35,7 +35,11 @@ import {
   useLogsSearch,
   useSetLogsSearch,
 } from 'sentry/views/explore/contexts/logs/logsPageParams';
-import {HiddenLogDetailFields} from 'sentry/views/explore/logs/constants';
+import {
+  DEFAULT_TRACE_ITEM_HOVER_TIMEOUT,
+  DEFAULT_TRACE_ITEM_HOVER_TIMEOUT_WITH_AUTO_REFRESH,
+  HiddenLogDetailFields,
+} from 'sentry/views/explore/logs/constants';
 import type {RendererExtra} from 'sentry/views/explore/logs/fieldRenderers';
 import {
   LogAttributesRendererMap,
@@ -163,7 +167,7 @@ export const LogRowContent = memo(function LogRowContent({
       setExpanded(e => !e);
     }
     if (!isExpanded && autorefreshEnabled) {
-      setAutorefresh('idle');
+      setAutorefresh('paused');
     }
 
     trackAnalytics('logs.table.row_expanded', {
@@ -212,11 +216,15 @@ export const LogRowContent = memo(function LogRowContent({
     typeof severityText === 'string' ? severityText : null
   );
   const logColors = getLogColors(level, theme);
+  const prefetchTimeout = autorefreshEnabled
+    ? DEFAULT_TRACE_ITEM_HOVER_TIMEOUT_WITH_AUTO_REFRESH
+    : DEFAULT_TRACE_ITEM_HOVER_TIMEOUT;
   const hoverProps = usePrefetchLogTableRowOnHover({
     logId: String(dataRow[OurLogKnownFieldKey.ID]),
     projectId: String(dataRow[OurLogKnownFieldKey.PROJECT_ID]),
     traceId: String(dataRow[OurLogKnownFieldKey.TRACE_ID]),
     sharedHoverTimeoutRef,
+    timeout: prefetchTimeout,
   });
 
   const rendererExtra = {

--- a/static/app/views/explore/logs/useLogsQuery.tsx
+++ b/static/app/views/explore/logs/useLogsQuery.tsx
@@ -79,10 +79,12 @@ export function usePrefetchLogTableRowOnHover({
   traceId,
   hoverPrefetchDisabled,
   sharedHoverTimeoutRef,
+  timeout,
 }: {
   logId: string | number;
   projectId: string;
   sharedHoverTimeoutRef: React.MutableRefObject<NodeJS.Timeout | null>;
+  timeout: number;
   traceId: string;
   hoverPrefetchDisabled?: boolean;
 }) {
@@ -93,6 +95,7 @@ export function usePrefetchLogTableRowOnHover({
     traceItemType: TraceItemDataset.LOGS,
     hoverPrefetchDisabled,
     sharedHoverTimeoutRef,
+    timeout,
     referrer: 'api.explore.log-item-details',
   });
 }


### PR DESCRIPTION
### Summary
- Add pausedAt timestamp tracking in context using ref
- Update useSetLogsAutoRefresh to handle 'pause' state
- Change toggle and row expansion to use 'pause' instead of 'idle'
- Make useVirtualStreaming jump to pausedAt timestamp when re-enabling
- Fixes analytics firing multiple times because of .length attribute on the useEffect
- fixes prefetching firing too much if you hover rows and autorefresh is on.

