### PR TITLE
feat(eco): Adds new RPC method for surfacing externally linked issue summaries

### DIFF
--- a/src/sentry/issues/services/issue/impl.py
+++ b/src/sentry/issues/services/issue/impl.py
@@ -48,7 +48,7 @@ class DatabaseBackedIssueService(IssueService):
         # correctly should this fail.
         process_inbound_email(from_email, group_id, text)
 
-    def get_linked_issues(
+    def get_integration_linked_issue_summaries(
         self,
         *,
         region_name: str,

--- a/src/sentry/issues/services/issue/impl.py
+++ b/src/sentry/issues/services/issue/impl.py
@@ -6,6 +6,7 @@
 
 from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.issues.services.issue.model import RpcGroupShareMetadata, RpcLinkedIssueSummary
+from sentry.issues.services.issue.serial import serialize_linked_issue_summary
 from sentry.issues.services.issue.service import IssueService
 from sentry.models.group import Group
 from sentry.models.organization import Organization
@@ -65,6 +66,5 @@ class DatabaseBackedIssueService(IssueService):
         ).order_by("date_added")
 
         return [
-            RpcLinkedIssueSummary.from_external_issue(external_issue)
-            for external_issue in external_issues
+            serialize_linked_issue_summary(external_issue) for external_issue in external_issues
         ]

--- a/src/sentry/issues/services/issue/model.py
+++ b/src/sentry/issues/services/issue/model.py
@@ -1,6 +1,30 @@
+from __future__ import annotations
+
 from sentry.hybridcloud.rpc import RpcModel
+from sentry.integrations.models.external_issue import ExternalIssue
+from sentry.models.grouplink import GroupLink
 
 
 class RpcGroupShareMetadata(RpcModel):
     title: str
     message: str
+
+
+class RpcLinkedIssueSummary(RpcModel):
+    title: str
+    issue_link: str
+
+    @classmethod
+    def from_external_issue(cls, external_issue: ExternalIssue) -> RpcLinkedIssueSummary:
+        group_link = GroupLink.objects.get(
+            linked_id=external_issue.id,
+            linked_type=GroupLink.LinkedType.issue,
+            relationship=GroupLink.Relationship.references,
+        )
+
+        group_url = group_link.group.get_absolute_url()
+
+        return RpcLinkedIssueSummary(
+            title=external_issue.title or "",
+            issue_link=group_url,
+        )

--- a/src/sentry/issues/services/issue/model.py
+++ b/src/sentry/issues/services/issue/model.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+from datetime import datetime
+
 from sentry.hybridcloud.rpc import RpcModel
-from sentry.integrations.models.external_issue import ExternalIssue
-from sentry.models.grouplink import GroupLink
 
 
 class RpcGroupShareMetadata(RpcModel):
@@ -11,20 +11,5 @@ class RpcGroupShareMetadata(RpcModel):
 
 
 class RpcLinkedIssueSummary(RpcModel):
-    title: str
     issue_link: str
-
-    @classmethod
-    def from_external_issue(cls, external_issue: ExternalIssue) -> RpcLinkedIssueSummary:
-        group_link = GroupLink.objects.get(
-            linked_id=external_issue.id,
-            linked_type=GroupLink.LinkedType.issue,
-            relationship=GroupLink.Relationship.references,
-        )
-
-        group_url = group_link.group.get_absolute_url()
-
-        return RpcLinkedIssueSummary(
-            title=external_issue.title or "",
-            issue_link=group_url,
-        )
+    date_added: datetime

--- a/src/sentry/issues/services/issue/serial.py
+++ b/src/sentry/issues/services/issue/serial.py
@@ -1,0 +1,18 @@
+from sentry.integrations.models.external_issue import ExternalIssue
+from sentry.issues.services.issue.model import RpcLinkedIssueSummary
+from sentry.models.grouplink import GroupLink
+
+
+def serialize_linked_issue_summary(external_issue: ExternalIssue) -> RpcLinkedIssueSummary:
+    group_link = GroupLink.objects.get(
+        linked_id=external_issue.id,
+        linked_type=GroupLink.LinkedType.issue,
+        relationship=GroupLink.Relationship.references,
+    )
+
+    group_url = group_link.group.get_absolute_url()
+
+    return RpcLinkedIssueSummary(
+        issue_link=group_url,
+        date_added=external_issue.date_added,
+    )

--- a/src/sentry/issues/services/issue/service.py
+++ b/src/sentry/issues/services/issue/service.py
@@ -8,7 +8,7 @@ from abc import abstractmethod
 
 from sentry.hybridcloud.rpc.resolvers import ByOrganizationId, ByOrganizationSlug, ByRegionName
 from sentry.hybridcloud.rpc.service import RpcService, regional_rpc_method
-from sentry.issues.services.issue.model import RpcGroupShareMetadata
+from sentry.issues.services.issue.model import RpcGroupShareMetadata, RpcLinkedIssueSummary
 from sentry.silo.base import SiloMode
 
 
@@ -52,6 +52,30 @@ class IssueService(RpcService):
     def upsert_issue_email_reply(
         self, *, organization_id: int, group_id: int, from_email: str, text: str
     ) -> None:
+        pass
+
+    @regional_rpc_method(resolve=ByRegionName(), return_none_if_mapping_not_found=True)
+    @abstractmethod
+    def get_linked_issues(
+        self,
+        *,
+        region_name: str,
+        integration_id: int,
+        organization_ids: list[int],
+        external_issue_key: str,
+    ) -> list[RpcLinkedIssueSummary]:
+        """
+        Returns a list of linked issue summaries for a given integration ID +
+        org ID combination.
+
+        This is intended to be used for control to fan out to individual regions
+        in order to surface linked issue data related to a given set of
+        integration installations.
+
+        `organization_ids` may be a little superfluous here, but allows us to
+        filter, if necessary, and validate that the issue data we're surfacing
+        _does_ belong to the integration installation.
+        """
         pass
 
 

--- a/src/sentry/issues/services/issue/service.py
+++ b/src/sentry/issues/services/issue/service.py
@@ -56,7 +56,7 @@ class IssueService(RpcService):
 
     @regional_rpc_method(resolve=ByRegionName(), return_none_if_mapping_not_found=True)
     @abstractmethod
-    def get_linked_issues(
+    def get_integration_linked_issue_summaries(
         self,
         *,
         region_name: str,

--- a/tests/sentry/issues/services/test_issue_service.py
+++ b/tests/sentry/issues/services/test_issue_service.py
@@ -1,0 +1,223 @@
+from dataclasses import dataclass
+
+from sentry.integrations.models.external_issue import ExternalIssue
+from sentry.integrations.models.integration import Integration
+from sentry.integrations.types import IntegrationProviderSlug
+from sentry.interfaces.user import User
+from sentry.issues.services.issue.model import RpcLinkedIssueSummary
+from sentry.issues.services.issue.service import issue_service
+from sentry.models.group import Group
+from sentry.models.organization import Organization
+from sentry.models.project import Project
+from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import all_silo_test, create_test_regions
+
+
+@dataclass
+class HcExternalIssueContext:
+    org_owner: User
+    region_name: str
+    organization: Organization
+    project: Project
+
+
+@all_silo_test(regions=create_test_regions("de", "us"))
+class TestIssueService(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.default_jira_integration = self.create_integration(
+            provider=IntegrationProviderSlug.JIRA.value,
+            organization=self.organization,
+            external_id="jira-123",
+            name="Jira",
+        )
+        self.us_region_context = self.create_region_context(
+            "us",
+            org_owner=self.create_user(email="us_test@example.com"),
+            integration=self.default_jira_integration,
+        )
+        self.de_region_context = self.create_region_context(
+            "de",
+            org_owner=self.create_user(email="de_test@example.com"),
+            integration=self.default_jira_integration,
+        )
+
+    def create_region_context(
+        self,
+        region_name: str,
+        org_owner: User | None = None,
+        integration: Integration | None = None,
+    ) -> HcExternalIssueContext:
+        organization = self.create_organization(
+            name="test_org",
+            slug="test",
+            owner=org_owner,
+            region=region_name,
+        )
+
+        project = self.create_project(organization=organization)
+
+        return HcExternalIssueContext(
+            region_name=region_name,
+            organization=organization,
+            project=project,
+            org_owner=org_owner,
+        )
+
+    def create_linked_issue(
+        self,
+        key: str,
+        region_context: HcExternalIssueContext,
+        group: Group,
+        integration: Integration,
+        title: str | None = None,
+    ) -> ExternalIssue:
+
+        external_issue = self.create_integration_external_issue(
+            organization=region_context.organization,
+            group=group,
+            integration=integration,
+            key=key,
+            title=title,
+        )
+
+        return external_issue
+
+    def test_get_linked_issues(self):
+        group = self.create_group(project=self.us_region_context.project)
+        self.create_linked_issue(
+            key="TEST-123",
+            region_context=self.us_region_context,
+            group=group,
+            integration=self.default_jira_integration,
+            title="US Group Link",
+        )
+
+        response = issue_service.get_linked_issues(
+            region_name=self.us_region_context.region_name,
+            integration_id=self.default_jira_integration.id,
+            organization_ids=[self.us_region_context.organization.id],
+            external_issue_key="TEST-123",
+        )
+
+        assert response == [
+            RpcLinkedIssueSummary(
+                issue_link=group.get_absolute_url(),
+                title=group.title,
+            )
+        ]
+
+    def test_get_linked_issues_with_multiple_organizations_in_multiple_regions(self):
+        us_group = self.create_group(project=self.us_region_context.project)
+        us_linked_issue = self.create_linked_issue(
+            key="TEST-123",
+            region_context=self.us_region_context,
+            group=us_group,
+            integration=self.default_jira_integration,
+            title="US Group Link",
+        )
+
+        de_group = self.create_group(project=self.de_region_context.project)
+        de_linked_issue = self.create_linked_issue(
+            key="TEST-123",
+            region_context=self.de_region_context,
+            group=de_group,
+            integration=self.default_jira_integration,
+            title="DE Group Link",
+        )
+
+        response = issue_service.get_linked_issues(
+            region_name=self.us_region_context.region_name,
+            integration_id=self.default_jira_integration.id,
+            organization_ids=[
+                self.us_region_context.organization.id,
+                self.de_region_context.organization.id,
+            ],
+            external_issue_key="TEST-123",
+        )
+
+        assert response == [
+            RpcLinkedIssueSummary(
+                issue_link=us_group.get_absolute_url(),
+                title=us_linked_issue.title,
+            ),
+            RpcLinkedIssueSummary(
+                issue_link=de_group.get_absolute_url(),
+                title=de_linked_issue.title,
+            ),
+        ]
+
+    def test_get_empty_response_when_no_linked_issues(self):
+        response = issue_service.get_linked_issues(
+            region_name=self.us_region_context.region_name,
+            integration_id=self.default_jira_integration.id,
+            organization_ids=[self.us_region_context.organization.id],
+            external_issue_key="TEST-123",
+        )
+
+        assert response == []
+
+    def test_get_single_linked_issue_when_multiple_organizations_share_integration(self):
+        us_group = self.create_group(project=self.us_region_context.project)
+        us_linked_issue = self.create_linked_issue(
+            key="TEST-123",
+            region_context=self.us_region_context,
+            group=us_group,
+            integration=self.default_jira_integration,
+            title="US Group Link",
+        )
+
+        response = issue_service.get_linked_issues(
+            region_name=self.us_region_context.region_name,
+            integration_id=self.default_jira_integration.id,
+            organization_ids=[self.us_region_context.organization.id],
+            external_issue_key="TEST-123",
+        )
+
+        assert response == [
+            RpcLinkedIssueSummary(
+                issue_link=us_group.get_absolute_url(),
+                title=us_linked_issue.title,
+            )
+        ]
+
+    def test_filters_out_issues_from_other_organizations(self):
+        us_group = self.create_group(project=self.us_region_context.project)
+        us_linked_issue = self.create_linked_issue(
+            key="TEST-123",
+            region_context=self.us_region_context,
+            group=us_group,
+            integration=self.default_jira_integration,
+            title="US Group Link",
+        )
+
+        other_integration = self.create_integration(
+            provider=IntegrationProviderSlug.JIRA.value,
+            organization=self.organization,
+            external_id="jira-456",
+            name="Other Jira",
+        )
+
+        unrelated_us_group = self.create_group(project=self.us_region_context.project)
+        # Create another linked issue with the same key but different integration.
+        self.create_linked_issue(
+            key="TEST-123",
+            region_context=self.us_region_context,
+            group=unrelated_us_group,
+            integration=other_integration,
+            title="Unrelated US Group Link",
+        )
+
+        response = issue_service.get_linked_issues(
+            region_name=self.us_region_context.region_name,
+            integration_id=self.default_jira_integration.id,
+            organization_ids=[self.us_region_context.organization.id],
+            external_issue_key="TEST-123",
+        )
+
+        assert response == [
+            RpcLinkedIssueSummary(
+                issue_link=us_group.get_absolute_url(),
+                title=us_linked_issue.title,
+            )
+        ]

--- a/tests/sentry/issues/services/test_issue_service.py
+++ b/tests/sentry/issues/services/test_issue_service.py
@@ -85,12 +85,11 @@ class TestIssueService(TestCase):
 
     def test_get_linked_issues(self):
         group = self.create_group(project=self.us_region_context.project)
-        self.create_linked_issue(
+        linked_issue = self.create_linked_issue(
             key="TEST-123",
             region_context=self.us_region_context,
             group=group,
             integration=self.default_jira_integration,
-            title="US Group Link",
         )
 
         response = issue_service.get_linked_issues(
@@ -103,7 +102,7 @@ class TestIssueService(TestCase):
         assert response == [
             RpcLinkedIssueSummary(
                 issue_link=group.get_absolute_url(),
-                title=group.title,
+                date_added=linked_issue.date_added,
             )
         ]
 
@@ -114,7 +113,6 @@ class TestIssueService(TestCase):
             region_context=self.us_region_context,
             group=us_group,
             integration=self.default_jira_integration,
-            title="US Group Link",
         )
 
         de_group = self.create_group(project=self.de_region_context.project)
@@ -123,7 +121,6 @@ class TestIssueService(TestCase):
             region_context=self.de_region_context,
             group=de_group,
             integration=self.default_jira_integration,
-            title="DE Group Link",
         )
 
         response = issue_service.get_linked_issues(
@@ -139,11 +136,11 @@ class TestIssueService(TestCase):
         assert response == [
             RpcLinkedIssueSummary(
                 issue_link=us_group.get_absolute_url(),
-                title=us_linked_issue.title,
+                date_added=us_linked_issue.date_added,
             ),
             RpcLinkedIssueSummary(
                 issue_link=de_group.get_absolute_url(),
-                title=de_linked_issue.title,
+                date_added=de_linked_issue.date_added,
             ),
         ]
 
@@ -159,12 +156,11 @@ class TestIssueService(TestCase):
 
     def test_get_single_linked_issue_when_multiple_organizations_share_integration(self):
         us_group = self.create_group(project=self.us_region_context.project)
-        us_linked_issue = self.create_linked_issue(
+        linked_issue = self.create_linked_issue(
             key="TEST-123",
             region_context=self.us_region_context,
             group=us_group,
             integration=self.default_jira_integration,
-            title="US Group Link",
         )
 
         response = issue_service.get_linked_issues(
@@ -177,7 +173,7 @@ class TestIssueService(TestCase):
         assert response == [
             RpcLinkedIssueSummary(
                 issue_link=us_group.get_absolute_url(),
-                title=us_linked_issue.title,
+                date_added=linked_issue.date_added,
             )
         ]
 
@@ -188,7 +184,6 @@ class TestIssueService(TestCase):
             region_context=self.us_region_context,
             group=us_group,
             integration=self.default_jira_integration,
-            title="US Group Link",
         )
 
         other_integration = self.create_integration(
@@ -205,7 +200,6 @@ class TestIssueService(TestCase):
             region_context=self.us_region_context,
             group=unrelated_us_group,
             integration=other_integration,
-            title="Unrelated US Group Link",
         )
 
         response = issue_service.get_linked_issues(
@@ -218,6 +212,6 @@ class TestIssueService(TestCase):
         assert response == [
             RpcLinkedIssueSummary(
                 issue_link=us_group.get_absolute_url(),
-                title=us_linked_issue.title,
+                date_added=us_linked_issue.date_added,
             )
         ]

--- a/tests/sentry/issues/services/test_issue_service.py
+++ b/tests/sentry/issues/services/test_issue_service.py
@@ -92,7 +92,7 @@ class TestIssueService(TestCase):
             integration=self.default_jira_integration,
         )
 
-        response = issue_service.get_linked_issues(
+        response = issue_service.get_integration_linked_issue_summaries(
             region_name=self.us_region_context.region_name,
             integration_id=self.default_jira_integration.id,
             organization_ids=[self.us_region_context.organization.id],
@@ -123,7 +123,7 @@ class TestIssueService(TestCase):
             integration=self.default_jira_integration,
         )
 
-        response = issue_service.get_linked_issues(
+        response = issue_service.get_integration_linked_issue_summaries(
             region_name=self.us_region_context.region_name,
             integration_id=self.default_jira_integration.id,
             organization_ids=[
@@ -145,7 +145,7 @@ class TestIssueService(TestCase):
         ]
 
     def test_get_empty_response_when_no_linked_issues(self):
-        response = issue_service.get_linked_issues(
+        response = issue_service.get_integration_linked_issue_summaries(
             region_name=self.us_region_context.region_name,
             integration_id=self.default_jira_integration.id,
             organization_ids=[self.us_region_context.organization.id],
@@ -163,7 +163,7 @@ class TestIssueService(TestCase):
             integration=self.default_jira_integration,
         )
 
-        response = issue_service.get_linked_issues(
+        response = issue_service.get_integration_linked_issue_summaries(
             region_name=self.us_region_context.region_name,
             integration_id=self.default_jira_integration.id,
             organization_ids=[self.us_region_context.organization.id],
@@ -202,7 +202,7 @@ class TestIssueService(TestCase):
             integration=other_integration,
         )
 
-        response = issue_service.get_linked_issues(
+        response = issue_service.get_integration_linked_issue_summaries(
             region_name=self.us_region_context.region_name,
             integration_id=self.default_jira_integration.id,
             organization_ids=[self.us_region_context.organization.id],

--- a/tests/sentry/issues/services/test_issue_service.py
+++ b/tests/sentry/issues/services/test_issue_service.py
@@ -3,7 +3,6 @@ from dataclasses import dataclass
 from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.types import IntegrationProviderSlug
-from sentry.interfaces.user import User
 from sentry.issues.services.issue.model import RpcLinkedIssueSummary
 from sentry.issues.services.issue.service import issue_service
 from sentry.models.group import Group
@@ -11,11 +10,12 @@ from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import all_silo_test, create_test_regions
+from sentry.users.models import User
 
 
 @dataclass
 class HcExternalIssueContext:
-    org_owner: User
+    org_owner: User | None
     region_name: str
     organization: Organization
     project: Project
@@ -34,19 +34,16 @@ class TestIssueService(TestCase):
         self.us_region_context = self.create_region_context(
             "us",
             org_owner=self.create_user(email="us_test@example.com"),
-            integration=self.default_jira_integration,
         )
         self.de_region_context = self.create_region_context(
             "de",
             org_owner=self.create_user(email="de_test@example.com"),
-            integration=self.default_jira_integration,
         )
 
     def create_region_context(
         self,
         region_name: str,
         org_owner: User | None = None,
-        integration: Integration | None = None,
     ) -> HcExternalIssueContext:
         organization = self.create_organization(
             name="test_org",


### PR DESCRIPTION
## Backstory
We've wanted to enable Jira multi-region support for a while (#80381), but have been blocked on a couple of different fronts:
1. Webhooks only dispatch to a single region for simplicity.
2. There's a context pane in our Jira configuration which surfaces issue data that is region-only, and therefore relies on proxy behavior. This can only be done safely when all integration installs are colocated within a single region.

### Jira Context Pane
This is the pane we're populating in Jira with requests to the `/issue/<external-issue-key/` URL in control:

<img width="650" height="526" alt="image" src="https://github.com/user-attachments/assets/36e3299e-3a1f-4c35-87fb-70947a418574" />

[Atlassian Docs](https://developer.atlassian.com/cloud/jira/platform/modules/issue-context/)

## Why this change?
This is the first step, of many, to enable Jira multi-region support.

This new RPC is meant to back a new multi-region version of the Jira Issue Context pane, which will now:
- Dispatch an RPC to each region containing an installation of the Jira integration identified in the request JWT.
- Surface a combined list of issue link summaries, containing a title, date linked, and Issue link specific to the region.

The current pane, as-is, is rather cluttered, and will only get worse once we allow multiple issues from multiple organizations in multiple regions to link to the same ticket. This is meant to back an abbreviated version of the existing preview pane with links to the corresponding issue links.


## Checklist for Jira Multi-Region Support (subject to change):
- [ ] Add new RPC method to surface issue summaries. [We are here]
- [ ] Implement a new Control-Silo endpoint for Jira to use which will perform region fanouts for issue data.
- [ ] Change Jira Connect Metadata to use this new endpoint when populating the issue context pane, update the Jira Parser to disallow requests to the region for this.
- [ ] Update the [Jira parser](https://github.com/getsentry/sentry/blob/d8504c6ac15f7ccdbc8a2c3161ef616fe3f0c918/src/sentry/middleware/integrations/parsers/jira.py#L73) to allow for multi-region installations, gated behind a user feature-flag
- [ ] Test multi-region installations, ensure that everything is working as expected
- [ ] Inevitable bug fixes for issue creation, linking
- [ ] GA multi-region Jira feature flag
- [ ] Deprecate the old region issue context endpoint and delete it.
