### PR TITLE
ref(performance): Remove trace wrapper props

### DIFF
--- a/static/app/views/traces/content.tsx
+++ b/static/app/views/traces/content.tsx
@@ -31,7 +31,7 @@ const TRACE_EXPLORER_DOCS_URL = 'https://docs.sentry.io/product/explore/traces/'
 const DEFAULT_STATS_PERIOD = '24h';
 const DEFAULT_PER_PAGE = 50;
 
-export default function Wrapper(props: any) {
+export default function Wrapper() {
   const location = useLocation();
   const organization = useOrganization();
 
@@ -39,10 +39,10 @@ export default function Wrapper(props: any) {
     location.query.view !== 'trace' &&
     organization.features.includes('visibility-explore-view')
   ) {
-    return <ExploreContent {...props} />;
+    return <ExploreContent />;
   }
 
-  return <Content {...props} />;
+  return <Content />;
 }
 
 function Content() {


### PR DESCRIPTION
both `ExploreContent` and `Content` do not take props. Remove "any"