### PR TITLE
feat(issues): Remove legacy props from issue details

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -2653,7 +2653,6 @@ function buildRoutes(): RouteObject[] {
     {
       path: ':groupId/',
       component: make(() => import('sentry/views/issueDetails/groupDetails')),
-      deprecatedRouteProps: true,
       children: [
         ...issueTabs,
         {

--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -1,4 +1,5 @@
 import {Fragment, useCallback, useEffect, useMemo, useState} from 'react';
+import {Outlet} from 'react-router-dom';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 import isEqual from 'lodash/isEqual';
@@ -82,10 +83,6 @@ import {
 
 type Error = (typeof ERROR_TYPES)[keyof typeof ERROR_TYPES] | null;
 
-interface GroupDetailsProps {
-  children: React.ReactNode;
-}
-
 type FetchGroupDetailsState = {
   error: boolean;
   errorType: Error;
@@ -96,7 +93,8 @@ type FetchGroupDetailsState = {
   refetchGroup: () => void;
 };
 
-interface GroupDetailsContentProps extends GroupDetailsProps {
+interface GroupDetailsContentProps {
+  children: React.ReactNode;
   event: Event | null;
   group: Group;
   project: Project;
@@ -744,7 +742,11 @@ function GroupDetailsContent({
   );
 }
 
-function GroupDetailsPageContent(props: GroupDetailsProps & FetchGroupDetailsState) {
+interface GroupDetailsPageContentProps extends FetchGroupDetailsState {
+  children: React.ReactNode;
+}
+
+function GroupDetailsPageContent(props: GroupDetailsPageContentProps) {
   const projectSlug = props.group?.project?.slug;
   const api = useApi();
   const organization = useOrganization();
@@ -857,7 +859,7 @@ function GroupDetailsPageContent(props: GroupDetailsProps & FetchGroupDetailsSta
   );
 }
 
-function GroupDetails(props: GroupDetailsProps) {
+function GroupDetails() {
   const organization = useOrganization();
   const {group, ...fetchGroupDetailsProps} = useFetchGroupDetails();
   const isSampleError = useIsSampleEvent();
@@ -895,7 +897,9 @@ function GroupDetails(props: GroupDetailsProps) {
           shouldForceProject
         >
           {config?.showFeedbackWidget && <FloatingFeedbackWidget />}
-          <GroupDetailsPageContent {...props} {...fetchGroupDetailsProps} group={group} />
+          <GroupDetailsPageContent {...fetchGroupDetailsProps} group={group}>
+            <Outlet />
+          </GroupDetailsPageContent>
         </PageFiltersContainer>
       </SentryDocumentTitle>
     </Fragment>


### PR DESCRIPTION
Finishes the migration away from legacy router props for all issue details pages
