### PR TITLE
fix(sentry apps): Self-heal/regenereate broken ServiceHooks

### DIFF
--- a/src/sentry/sentry_apps/tasks/sentry_apps.py
+++ b/src/sentry/sentry_apps/tasks/sentry_apps.py
@@ -751,7 +751,6 @@ def send_webhooks(installation: RpcSentryAppInstallation, event: str, **kwargs: 
         servicehook: ServiceHook | None = _load_service_hook(
             installation.organization_id, installation.id
         )
-        lifecycle.add_extra("events", installation.sentry_app.events)
         lifecycle.add_extras(
             {
                 "installation_uuid": installation.uuid,

--- a/src/sentry/sentry_apps/tasks/sentry_apps.py
+++ b/src/sentry/sentry_apps/tasks/sentry_apps.py
@@ -810,6 +810,7 @@ def regenerate_service_hook_for_installation(
     installation_id: int, servicehook_events: list[str] | None
 ) -> None:
     installation = app_service.installation_by_id(id=installation_id)
+    assert installation is not None, "Installation must exist to regenerate service hooks"
     app_events = installation.sentry_app.events
 
     if servicehook_events is None or set(servicehook_events) != set(app_events):

--- a/src/sentry/utils/sentry_apps/service_hook_manager.py
+++ b/src/sentry/utils/sentry_apps/service_hook_manager.py
@@ -1,9 +1,12 @@
 from sentry.sentry_apps.models.sentry_app_installation import SentryAppInstallation
+from sentry.sentry_apps.services.app.model import RpcSentryAppInstallation
 from sentry.sentry_apps.services.hook import hook_service
 
 
 def create_or_update_service_hooks_for_installation(
-    installation: SentryAppInstallation, webhook_url: str | None, events: list[str]
+    installation: SentryAppInstallation | RpcSentryAppInstallation,
+    webhook_url: str | None,
+    events: list[str],
 ) -> None:
     """
     This function creates or updates service hooks for a given Sentry app installation.

--- a/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
+++ b/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
@@ -1681,22 +1681,16 @@ class TestBackfillServiceHooksEvents(TestCase):
             hook.events = ["issue.resolved", "error.created"]
             hook.save()
 
-        servicehook_events = ["issue.created"]
         with self.tasks(), assume_test_silo_mode(SiloMode.REGION):
-            regenerate_service_hook_for_installation(
-                installation_id=self.install.id, servicehook_events=servicehook_events
-            )
+            regenerate_service_hook_for_installation(installation_id=self.install.id)
 
         with assume_test_silo_mode(SiloMode.REGION):
             hook.refresh_from_db()
             assert set(hook.events) == {"issue.created", "issue.resolved", "error.created"}
 
     def test_regenerate_service_hook_for_installation_event_not_in_app_events(self):
-        servicehook_events = ["comment.created"]
         with self.tasks(), assume_test_silo_mode(SiloMode.REGION):
-            regenerate_service_hook_for_installation(
-                installation_id=self.install.id, servicehook_events=servicehook_events
-            )
+            regenerate_service_hook_for_installation(installation_id=self.install.id)
 
         with assume_test_silo_mode(SiloMode.REGION):
             hook = ServiceHook.objects.get(installation_id=self.install.id)
@@ -1711,11 +1705,8 @@ class TestBackfillServiceHooksEvents(TestCase):
             hook = ServiceHook.objects.get(installation_id=self.install.id)
             assert hook.events != []
 
-        servicehook_events = ["comment.created"]
         with self.tasks(), assume_test_silo_mode(SiloMode.REGION):
-            regenerate_service_hook_for_installation(
-                installation_id=self.install.id, servicehook_events=servicehook_events
-            )
+            regenerate_service_hook_for_installation(installation_id=self.install.id)
 
         with assume_test_silo_mode(SiloMode.REGION):
             hook.refresh_from_db()


### PR DESCRIPTION
Finally got around to doing this... In the past some Sentry Apps have been updated and their ServiceHooks(read: webhooks) weren't updated properly for various reasons. Leaving people with broken webhooks. That also caused these Sentry errors to surface to us 
1. https://sentry.sentry.io/issues/6682915846/?project=1&query=is%3Aunresolved%20missing_servicehook&referrer=issue-stream
2. https://sentry.sentry.io/issues/6678511610/?project=1&query=operation_type%3Asend_webhook%20event_type%3Aissue.unresolved&referrer=issue-stream

This PR adds a task that will gradually regenerate the broken webhooks by re-running the `create_or_update_service_hooks_for_installation` function. That function is what should've been run during the initial webhook update but for various reason (timeouts, errors etc.) didn't complete.