### PR TITLE
ref: replace monkeypatch with unittest.mock

### DIFF
--- a/tests/sentry/api/endpoints/test_relay_projectconfigs.py
+++ b/tests/sentry/api/endpoints/test_relay_projectconfigs.py
@@ -100,11 +100,12 @@ def add_org_key(default_organization, relay):
 
 
 @pytest.fixture
-def no_internal_networks(monkeypatch):
+def no_internal_networks():
     """
     Disable is_internal_ip functionality (make all requests appear to be from external networks)
     """
-    monkeypatch.setattr("sentry.auth.system.INTERNAL_NETWORKS", ())
+    with patch("sentry.auth.system.INTERNAL_NETWORKS", ()):
+        yield
 
 
 @django_db_all
@@ -205,10 +206,10 @@ def test_untrusted_external_relays_should_not_receive_configs(call_endpoint, no_
 
 
 @pytest.fixture
-def projectconfig_cache_set(monkeypatch):
+def projectconfig_cache_set():
     calls: list[dict[str, Any]] = []
-    monkeypatch.setattr("sentry.relay.projectconfig_cache.backend.set_many", calls.append)
-    return calls
+    with patch("sentry.relay.projectconfig_cache.backend.set_many", calls.append):
+        yield calls
 
 
 @django_db_all

--- a/tests/sentry/api/endpoints/test_relay_projectconfigs_v2.py
+++ b/tests/sentry/api/endpoints/test_relay_projectconfigs_v2.py
@@ -55,11 +55,12 @@ def add_org_key(default_organization, relay):
 
 
 @pytest.fixture
-def no_internal_networks(monkeypatch):
+def no_internal_networks():
     """
     Disable is_internal_ip functionality (make all requests appear to be from external networks)
     """
-    monkeypatch.setattr("sentry.auth.system.INTERNAL_NETWORKS", ())
+    with patch("sentry.auth.system.INTERNAL_NETWORKS", ()):
+        yield
 
 
 @django_db_all
@@ -166,10 +167,10 @@ def test_untrusted_external_relays_should_not_receive_configs(call_endpoint, no_
 
 
 @pytest.fixture
-def projectconfig_cache_set(monkeypatch):
+def projectconfig_cache_set():
     calls: list[dict[str, Any]] = []
-    monkeypatch.setattr("sentry.relay.projectconfig_cache.backend.set_many", calls.append)
-    return calls
+    with patch("sentry.relay.projectconfig_cache.backend.set_many", calls.append):
+        yield calls
 
 
 @django_db_all

--- a/tests/sentry/api/endpoints/test_relay_projectconfigs_v3.py
+++ b/tests/sentry/api/endpoints/test_relay_projectconfigs_v3.py
@@ -45,37 +45,38 @@ def call_endpoint(client, relay, private_key, default_projectkey):
 
 
 @pytest.fixture
-def projectconfig_cache_get_mock_config(monkeypatch):
-    monkeypatch.setattr(
+def projectconfig_cache_get_mock_config():
+    with patch(
         "sentry.relay.projectconfig_cache.backend.get",
-        lambda *args, **kwargs: {"is_mock_config": True},
-    )
+        return_value={"is_mock_config": True},
+    ):
+        yield
 
 
 @pytest.fixture
-def single_mock_proj_cached(monkeypatch):
+def single_mock_proj_cached():
     def cache_get(*args, **kwargs):
         if args[0] == "must_exist":
             return {"is_mock_config": True}
         return None
 
-    monkeypatch.setattr("sentry.relay.projectconfig_cache.backend.get", cache_get)
+    with patch("sentry.relay.projectconfig_cache.backend.get", cache_get):
+        yield
 
 
 @pytest.fixture
-def projectconfig_debounced_cache(monkeypatch):
-    monkeypatch.setattr(
-        "sentry.relay.projectconfig_debounce_cache.backend.is_debounced",
-        lambda *args, **kargs: True,
-    )
+def projectconfig_debounced_cache():
+    with patch("sentry.relay.projectconfig_debounce_cache.backend.is_debounced", return_value=True):
+        yield
 
 
 @pytest.fixture
-def project_config_get_mock(monkeypatch):
-    monkeypatch.setattr(
+def project_config_get_mock():
+    with patch(
         "sentry.relay.config.get_project_config",
-        lambda *args, **kwargs: ProjectConfig(sentinel.mock_project, is_mock_config=True),
-    )
+        return_value=ProjectConfig(sentinel.mock_project, is_mock_config=True),
+    ):
+        yield
 
 
 @django_db_all

--- a/tests/sentry/eventstore/test_models.py
+++ b/tests/sentry/eventstore/test_models.py
@@ -604,7 +604,7 @@ class GroupEventOccurrenceTest(TestCase, OccurrenceTestMixin):
 
 
 @django_db_all
-def test_renormalization(monkeypatch, factories, task_runner, default_project):
+def test_renormalization(factories, task_runner, default_project):
     from sentry_relay.processing import StoreNormalizer
 
     old_normalize = StoreNormalizer.normalize_event
@@ -614,9 +614,10 @@ def test_renormalization(monkeypatch, factories, task_runner, default_project):
         normalize_mock_calls.append(1)
         return old_normalize(*args, **kwargs)
 
-    monkeypatch.setattr("sentry_relay.processing.StoreNormalizer.normalize_event", normalize)
-
-    with task_runner():
+    with (
+        mock.patch("sentry_relay.processing.StoreNormalizer.normalize_event", normalize),
+        task_runner(),
+    ):
         factories.store_event(
             data={"event_id": "a" * 32, "environment": "production"}, project_id=default_project.id
         )

--- a/tests/sentry/feedback/usecases/conftest.py
+++ b/tests/sentry/feedback/usecases/conftest.py
@@ -1,15 +1,14 @@
-from unittest.mock import Mock
+from unittest import mock
 
 import pytest
 
 
 @pytest.fixture
-def mock_produce_occurrence_to_kafka(monkeypatch):
-    mock = Mock()
-    monkeypatch.setattr(
-        "sentry.feedback.usecases.ingest.create_feedback.produce_occurrence_to_kafka", mock
-    )
-    return mock
+def mock_produce_occurrence_to_kafka():
+    with mock.patch(
+        "sentry.feedback.usecases.ingest.create_feedback.produce_occurrence_to_kafka"
+    ) as mck:
+        yield mck
 
 
 @pytest.fixture(autouse=True)

--- a/tests/sentry/feedback/usecases/ingest/test_create_feedback.py
+++ b/tests/sentry/feedback/usecases/ingest/test_create_feedback.py
@@ -453,7 +453,6 @@ def test_create_feedback_spam_detection_produce_to_kafka(
     input_message,
     expected_result,
     feature_flag,
-    monkeypatch,
 ):
     with Feature({"organizations:user-feedback-spam-ingest": feature_flag}):
         event = {
@@ -492,8 +491,10 @@ def test_create_feedback_spam_detection_produce_to_kafka(
         mock_openai = Mock()
         mock_openai().chat.completions.create = create_dummy_openai_response
 
-        monkeypatch.setattr("sentry.llm.providers.openai.OpenAI", mock_openai)
-        create_feedback_issue(event, default_project, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE)
+        with patch("sentry.llm.providers.openai.OpenAI", mock_openai):
+            create_feedback_issue(
+                event, default_project, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE
+            )
 
         # Check if the 'is_spam' evidence in the Kafka message matches the expected result
         is_spam_evidence = [
@@ -524,7 +525,6 @@ def test_create_feedback_spam_detection_produce_to_kafka(
 def test_create_feedback_spam_detection_project_option_false(
     default_project,
     mock_produce_occurrence_to_kafka,
-    monkeypatch,
 ):
     default_project.update_option("sentry:feedback_ai_spam_detection", False)
 
@@ -565,8 +565,10 @@ def test_create_feedback_spam_detection_project_option_false(
         mock_openai = Mock()
         mock_openai().chat.completions.create = create_dummy_openai_response
 
-        monkeypatch.setattr("sentry.llm.providers.openai.OpenAI", mock_openai)
-        create_feedback_issue(event, default_project, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE)
+        with patch("sentry.llm.providers.openai.OpenAI", mock_openai):
+            create_feedback_issue(
+                event, default_project, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE
+            )
 
         # Check if the 'is_spam' evidence in the Kafka message matches the expected result
         is_spam_evidence = [
@@ -581,7 +583,7 @@ def test_create_feedback_spam_detection_project_option_false(
 
 
 @django_db_all
-def test_create_feedback_spam_detection_set_status_ignored(default_project, monkeypatch):
+def test_create_feedback_spam_detection_set_status_ignored(default_project):
     with Feature(
         {
             "organizations:user-feedback-spam-filter-actions": True,
@@ -624,8 +626,10 @@ def test_create_feedback_spam_detection_set_status_ignored(default_project, monk
         mock_openai = Mock()
         mock_openai().chat.completions.create = create_dummy_openai_response
 
-        monkeypatch.setattr("sentry.llm.providers.openai.OpenAI", mock_openai)
-        create_feedback_issue(event, default_project, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE)
+        with patch("sentry.llm.providers.openai.OpenAI", mock_openai):
+            create_feedback_issue(
+                event, default_project, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE
+            )
 
         group = Group.objects.get()
         assert group.status == GroupStatus.IGNORED
@@ -792,7 +796,7 @@ def test_create_feedback_tags_skips_if_empty(default_project, mock_produce_occur
 @django_db_all
 @pytest.mark.parametrize("spam_enabled", (True, False))
 def test_create_feedback_filters_large_message(
-    default_project, mock_produce_occurrence_to_kafka, monkeypatch, set_sentry_option, spam_enabled
+    default_project, mock_produce_occurrence_to_kafka, set_sentry_option, spam_enabled
 ):
     """Large messages are filtered before spam detection and producing to kafka."""
     features = (
@@ -803,10 +807,11 @@ def test_create_feedback_filters_large_message(
         else {}
     )
 
-    mock_complete_prompt = Mock()
-    monkeypatch.setattr("sentry.llm.usecases.complete_prompt", mock_complete_prompt)
-
-    with Feature(features), set_sentry_option("feedback.message.max-size", 4096):
+    with (
+        patch("sentry.llm.usecases.complete_prompt") as mock_complete_prompt,
+        Feature(features),
+        set_sentry_option("feedback.message.max-size", 4096),
+    ):
         event = mock_feedback_event(default_project.id)
         event["contexts"]["feedback"]["message"] = "a" * 7007
         create_feedback_issue(event, default_project, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE)
@@ -828,14 +833,14 @@ def test_create_feedback_evidence_has_source(default_project, mock_produce_occur
 
 
 @django_db_all
-def test_create_feedback_evidence_has_spam(
-    default_project, mock_produce_occurrence_to_kafka, monkeypatch
-):
+def test_create_feedback_evidence_has_spam(default_project, mock_produce_occurrence_to_kafka):
     """We need this evidence field in post process, to determine if we should send alerts."""
-    monkeypatch.setattr("sentry.feedback.usecases.ingest.create_feedback.is_spam", lambda _: True)
     default_project.update_option("sentry:feedback_ai_spam_detection", True)
 
-    with Feature({"organizations:user-feedback-spam-ingest": True}):
+    with (
+        patch("sentry.feedback.usecases.ingest.create_feedback.is_spam", return_value=True),
+        Feature({"organizations:user-feedback-spam-ingest": True}),
+    ):
         event = mock_feedback_event(default_project.id)
         source = FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE
         create_feedback_issue(event, default_project, source)
@@ -939,9 +944,7 @@ def test_create_feedback_issue_title(default_project, mock_produce_occurrence_to
 
 
 @django_db_all
-def test_create_feedback_adds_ai_labels(
-    default_project, mock_produce_occurrence_to_kafka, monkeypatch
-):
+def test_create_feedback_adds_ai_labels(default_project, mock_produce_occurrence_to_kafka):
     """Test that create_feedback_issue adds AI labels to tags when label generation succeeds."""
     with Feature(
         {
@@ -956,12 +959,14 @@ def test_create_feedback_adds_ai_labels(
         def mock_generate_labels(*args, **kwargs):
             return ["User Interface", "Authentication", "Performance"]
 
-        monkeypatch.setattr(
+        with patch(
             "sentry.feedback.usecases.ingest.create_feedback.generate_labels",
             mock_generate_labels,
-        )
+        ):
 
-        create_feedback_issue(event, default_project, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE)
+            create_feedback_issue(
+                event, default_project, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE
+            )
 
         assert mock_produce_occurrence_to_kafka.call_count == 1
         produced_event = mock_produce_occurrence_to_kafka.call_args.kwargs["event_data"]
@@ -974,7 +979,7 @@ def test_create_feedback_adds_ai_labels(
 
 @django_db_all
 def test_create_feedback_handles_label_generation_errors(
-    default_project, mock_produce_occurrence_to_kafka, monkeypatch
+    default_project, mock_produce_occurrence_to_kafka
 ):
     """Test that create_feedback_issue continues to work even when generate_labels raises an error."""
     with Feature(
@@ -990,13 +995,14 @@ def test_create_feedback_handles_label_generation_errors(
         def mock_generate_labels(*args, **kwargs):
             raise Exception("Label generation failed")
 
-        monkeypatch.setattr(
+        with patch(
             "sentry.feedback.usecases.ingest.create_feedback.generate_labels",
             mock_generate_labels,
-        )
-
-        # This should not raise an exception and should still create the feedback
-        create_feedback_issue(event, default_project, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE)
+        ):
+            # This should not raise an exception and should still create the feedback
+            create_feedback_issue(
+                event, default_project, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE
+            )
 
         # Verify that the feedback was still created successfully
         assert mock_produce_occurrence_to_kafka.call_count == 1
@@ -1011,9 +1017,7 @@ def test_create_feedback_handles_label_generation_errors(
 
 
 @django_db_all
-def test_create_feedback_truncates_ai_labels(
-    default_project, mock_produce_occurrence_to_kafka, monkeypatch
-):
+def test_create_feedback_truncates_ai_labels(default_project, mock_produce_occurrence_to_kafka):
     """Test that create_feedback_issue truncates AI labels when more than MAX_AI_LABELS are returned."""
     with Feature(
         {
@@ -1030,12 +1034,13 @@ def test_create_feedback_truncates_ai_labels(
         def mock_generate_labels(*args, **kwargs):
             return [f"Label {i}" for i in range(MAX_AI_LABELS + 5)]
 
-        monkeypatch.setattr(
+        with patch(
             "sentry.feedback.usecases.ingest.create_feedback.generate_labels",
             mock_generate_labels,
-        )
-
-        create_feedback_issue(event, default_project, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE)
+        ):
+            create_feedback_issue(
+                event, default_project, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE
+            )
 
         assert mock_produce_occurrence_to_kafka.call_count == 1
 

--- a/tests/sentry/feedback/usecases/ingest/test_shim_to_feedback.py
+++ b/tests/sentry/feedback/usecases/ingest/test_shim_to_feedback.py
@@ -2,7 +2,7 @@
 shim_to_feedback unit tests. Integration testing is done in test_create_feedback, test_project_user_reports, test_post_process, and test_update_user_reports.
 """
 
-from unittest.mock import Mock
+from unittest import mock
 
 import pytest
 
@@ -107,20 +107,18 @@ def test_shim_to_feedback_no_user_info(default_project, mock_produce_occurrence_
 
 
 @django_db_all
-def test_shim_to_feedback_fails_if_required_fields_missing(default_project, monkeypatch):
+def test_shim_to_feedback_fails_if_required_fields_missing(default_project):
     # Email and comments are required to shim. Tests key errors are handled.
-    mock_create_feedback_issue = Mock()
-    monkeypatch.setattr(
-        "sentry.feedback.usecases.ingest.shim_to_feedback.create_feedback_issue",
-        mock_create_feedback_issue,
-    )
     report_dict = {
         "name": "andrew",
         "event_id": "a" * 32,
         "level": "error",
     }
     event = Event(event_id="a" * 32, project_id=default_project.id)
-    shim_to_feedback(
-        report_dict, event, default_project, FeedbackCreationSource.USER_REPORT_ENVELOPE  # type: ignore[arg-type]
-    )
+    with mock.patch(
+        "sentry.feedback.usecases.ingest.shim_to_feedback.create_feedback_issue"
+    ) as mock_create_feedback_issue:
+        shim_to_feedback(
+            report_dict, event, default_project, FeedbackCreationSource.USER_REPORT_ENVELOPE  # type: ignore[arg-type]
+        )
     assert mock_create_feedback_issue.call_count == 0

--- a/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py
+++ b/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py
@@ -6,7 +6,7 @@ import uuid
 import zipfile
 from io import BytesIO
 from typing import Any
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import orjson
 import pytest
@@ -56,28 +56,26 @@ def get_normalized_event(data, project):
 
 
 @pytest.fixture
-def save_event_transaction(monkeypatch):
-    mock = Mock()
-    monkeypatch.setattr("sentry.ingest.consumer.processors.save_event_transaction", mock)
-    return mock
+def save_event_transaction():
+    with patch("sentry.ingest.consumer.processors.save_event_transaction") as mck:
+        yield mck
 
 
 @pytest.fixture
-def save_event_feedback(monkeypatch):
-    mock = Mock()
-    monkeypatch.setattr("sentry.ingest.consumer.processors.save_event_feedback", mock)
-    return mock
+def save_event_feedback():
+    with patch("sentry.ingest.consumer.processors.save_event_feedback") as mck:
+        yield mck
 
 
 @pytest.fixture
-def preprocess_event(monkeypatch):
+def preprocess_event():
     calls = []
 
     def inner(**kwargs):
         calls.append(kwargs)
 
-    monkeypatch.setattr("sentry.ingest.consumer.processors.preprocess_event", inner)
-    return calls
+    with patch("sentry.ingest.consumer.processors.preprocess_event", inner):
+        yield calls
 
 
 @django_db_all
@@ -219,42 +217,41 @@ def test_accountant_transaction(default_project):
 
 @django_db_all
 def test_feedbacks_spawn_save_event_feedback(
-    default_project, task_runner, preprocess_event, save_event_feedback, monkeypatch
+    default_project, task_runner, preprocess_event, save_event_feedback
 ):
-    monkeypatch.setattr("sentry.features.has", lambda *a, **kw: True)
-
-    project_id = default_project.id
-    now = datetime.datetime.now()
-    event: dict[str, Any] = {
-        "type": "feedback",
-        "timestamp": now.isoformat(),
-        "start_timestamp": now.isoformat(),
-        "spans": [],
-        "contexts": {
-            "feedback": {
-                "contact_email": "test_test.com",
-                "message": "I really like this user-feedback feature!",
-                "replay_id": "ec3b4dc8b79f417596f7a1aa4fcca5d2",
-                "url": "https://docs.sentry.io/platforms/javascript/",
-                "name": "Colton Allen",
-                "type": "feedback",
+    with patch("sentry.features.has", return_value=True):
+        project_id = default_project.id
+        now = datetime.datetime.now()
+        event: dict[str, Any] = {
+            "type": "feedback",
+            "timestamp": now.isoformat(),
+            "start_timestamp": now.isoformat(),
+            "spans": [],
+            "contexts": {
+                "feedback": {
+                    "contact_email": "test_test.com",
+                    "message": "I really like this user-feedback feature!",
+                    "replay_id": "ec3b4dc8b79f417596f7a1aa4fcca5d2",
+                    "url": "https://docs.sentry.io/platforms/javascript/",
+                    "name": "Colton Allen",
+                    "type": "feedback",
+                },
             },
-        },
-    }
-    payload = get_normalized_event(event, default_project)
-    event_id = payload["event_id"]
-    start_time = time.time() - 3600
-    process_event(
-        ConsumerType.Events,
-        {
-            "payload": orjson.dumps(payload).decode(),
-            "start_time": start_time,
-            "event_id": event_id,
-            "project_id": project_id,
-            "remote_addr": "127.0.0.1",
-        },
-        project=default_project,
-    )
+        }
+        payload = get_normalized_event(event, default_project)
+        event_id = payload["event_id"]
+        start_time = time.time() - 3600
+        process_event(
+            ConsumerType.Events,
+            {
+                "payload": orjson.dumps(payload).decode(),
+                "start_time": start_time,
+                "event_id": event_id,
+                "project_id": project_id,
+                "remote_addr": "127.0.0.1",
+            },
+            project=default_project,
+        )
     assert not len(preprocess_event)
     assert save_event_feedback.delay.call_args[0] == ()
     assert (
@@ -266,57 +263,56 @@ def test_feedbacks_spawn_save_event_feedback(
 
 @django_db_all
 @pytest.mark.parametrize("missing_chunks", (True, False))
-def test_with_attachments(default_project, task_runner, missing_chunks, monkeypatch, django_cache):
-    monkeypatch.setattr("sentry.features.has", lambda *a, **kw: True)
+def test_with_attachments(default_project, task_runner, missing_chunks, django_cache):
+    with patch("sentry.features.has", return_value=True):
+        payload = get_normalized_event({"message": "hello world"}, default_project)
+        event_id = payload["event_id"]
+        attachment_id = "ca90fb45-6dd9-40a0-a18f-8693aa621abb"
+        project_id = default_project.id
+        start_time = time.time() - 3600
 
-    payload = get_normalized_event({"message": "hello world"}, default_project)
-    event_id = payload["event_id"]
-    attachment_id = "ca90fb45-6dd9-40a0-a18f-8693aa621abb"
-    project_id = default_project.id
-    start_time = time.time() - 3600
+        if not missing_chunks:
+            process_attachment_chunk(
+                {
+                    "payload": b"Hello ",
+                    "event_id": event_id,
+                    "project_id": project_id,
+                    "id": attachment_id,
+                    "chunk_index": 0,
+                }
+            )
 
-    if not missing_chunks:
-        process_attachment_chunk(
-            {
-                "payload": b"Hello ",
-                "event_id": event_id,
-                "project_id": project_id,
-                "id": attachment_id,
-                "chunk_index": 0,
-            }
-        )
+            process_attachment_chunk(
+                {
+                    "payload": b"World!",
+                    "event_id": event_id,
+                    "project_id": project_id,
+                    "id": attachment_id,
+                    "chunk_index": 1,
+                }
+            )
 
-        process_attachment_chunk(
-            {
-                "payload": b"World!",
-                "event_id": event_id,
-                "project_id": project_id,
-                "id": attachment_id,
-                "chunk_index": 1,
-            }
-        )
-
-    with task_runner():
-        process_event(
-            ConsumerType.Events,
-            {
-                "payload": orjson.dumps(payload).decode(),
-                "start_time": start_time,
-                "event_id": event_id,
-                "project_id": project_id,
-                "remote_addr": "127.0.0.1",
-                "attachments": [
-                    {
-                        "id": attachment_id,
-                        "name": "lol.txt",
-                        "content_type": "text/plain",
-                        "attachment_type": "custom.attachment",
-                        "chunks": 2,
-                    }
-                ],
-            },
-            project=default_project,
-        )
+        with task_runner():
+            process_event(
+                ConsumerType.Events,
+                {
+                    "payload": orjson.dumps(payload).decode(),
+                    "start_time": start_time,
+                    "event_id": event_id,
+                    "project_id": project_id,
+                    "remote_addr": "127.0.0.1",
+                    "attachments": [
+                        {
+                            "id": attachment_id,
+                            "name": "lol.txt",
+                            "content_type": "text/plain",
+                            "attachment_type": "custom.attachment",
+                            "chunks": 2,
+                        }
+                    ],
+                },
+                project=default_project,
+            )
 
     persisted_attachments = list(
         EventAttachment.objects.filter(project_id=project_id, event_id=event_id)
@@ -432,56 +428,55 @@ def test_deobfuscate_view_hierarchy(default_project, task_runner, set_sentry_opt
 )
 @pytest.mark.parametrize("with_group", [True, False], ids=["with_group", "without_group"])
 def test_individual_attachments(
-    default_project, factories, monkeypatch, feature_enabled, attachment, with_group, django_cache
+    default_project, factories, feature_enabled, attachment, with_group, django_cache
 ):
-    monkeypatch.setattr("sentry.features.has", lambda *a, **kw: feature_enabled)
+    with patch("sentry.features.has", return_value=feature_enabled):
+        event_id = uuid.uuid4().hex
+        attachment_id = "ca90fb45-6dd9-40a0-a18f-8693aa621abb"
+        project_id = default_project.id
+        group_id = None
 
-    event_id = uuid.uuid4().hex
-    attachment_id = "ca90fb45-6dd9-40a0-a18f-8693aa621abb"
-    project_id = default_project.id
-    group_id = None
-
-    if with_group:
-        event = factories.store_event(
-            data={"event_id": event_id, "message": "existence is pain"}, project_id=project_id
-        )
-
-        group_id = event.group.id
-        assert group_id, "this test requires a group to work"
-
-    chunks, attachment_type, content_type = attachment
-    attachment_meta = {
-        "attachment_type": attachment_type,
-        "chunks": len(chunks),
-        "content_type": content_type,
-        "id": attachment_id,
-        "name": "foo.txt",
-    }
-    if isinstance(chunks, bytes):
-        attachment_meta["data"] = chunks
-        expected_content = chunks
-    else:
-        for i, chunk in enumerate(chunks):
-            process_attachment_chunk(
-                {
-                    "payload": chunk,
-                    "event_id": event_id,
-                    "project_id": project_id,
-                    "id": attachment_id,
-                    "chunk_index": i,
-                }
+        if with_group:
+            event = factories.store_event(
+                data={"event_id": event_id, "message": "existence is pain"}, project_id=project_id
             )
-        expected_content = b"".join(chunks)
 
-    process_individual_attachment(
-        {
-            "type": "attachment",
-            "attachment": attachment_meta,
-            "event_id": event_id,
-            "project_id": project_id,
-        },
-        project=default_project,
-    )
+            group_id = event.group.id
+            assert group_id, "this test requires a group to work"
+
+        chunks, attachment_type, content_type = attachment
+        attachment_meta = {
+            "attachment_type": attachment_type,
+            "chunks": len(chunks),
+            "content_type": content_type,
+            "id": attachment_id,
+            "name": "foo.txt",
+        }
+        if isinstance(chunks, bytes):
+            attachment_meta["data"] = chunks
+            expected_content = chunks
+        else:
+            for i, chunk in enumerate(chunks):
+                process_attachment_chunk(
+                    {
+                        "payload": chunk,
+                        "event_id": event_id,
+                        "project_id": project_id,
+                        "id": attachment_id,
+                        "chunk_index": i,
+                    }
+                )
+            expected_content = b"".join(chunks)
+
+        process_individual_attachment(
+            {
+                "type": "attachment",
+                "attachment": attachment_meta,
+                "event_id": event_id,
+                "project_id": project_id,
+            },
+            project=default_project,
+        )
 
     attachments = list(EventAttachment.objects.filter(project_id=project_id, event_id=event_id))
 
@@ -498,7 +493,7 @@ def test_individual_attachments(
 
 
 @django_db_all
-def test_userreport(django_cache, default_project, monkeypatch):
+def test_userreport(django_cache, default_project):
     """
     Test that user_report-type kafka messages end up in a user report being
     persisted. We additionally test some logic around upserting data in
@@ -536,7 +531,7 @@ def test_userreport(django_cache, default_project, monkeypatch):
 
 
 @django_db_all
-def test_userreport_reverse_order(django_cache, default_project, monkeypatch):
+def test_userreport_reverse_order(django_cache, default_project):
     """
     Test that ingesting a userreport before the event works. This is relevant
     for unreal crashes where the userreport is processed immediately in the
@@ -579,28 +574,27 @@ def test_userreport_reverse_order(django_cache, default_project, monkeypatch):
 
 
 @django_db_all
-def test_individual_attachments_missing_chunks(default_project, factories, monkeypatch):
-    monkeypatch.setattr("sentry.features.has", lambda *a, **kw: True)
+def test_individual_attachments_missing_chunks(default_project, factories):
+    with patch("sentry.features.has", return_value=True):
+        event_id = "515539018c9b4260a6f999572f1661ee"
+        attachment_id = "ca90fb45-6dd9-40a0-a18f-8693aa621abb"
+        project_id = default_project.id
 
-    event_id = "515539018c9b4260a6f999572f1661ee"
-    attachment_id = "ca90fb45-6dd9-40a0-a18f-8693aa621abb"
-    project_id = default_project.id
-
-    process_individual_attachment(
-        {
-            "type": "attachment",
-            "attachment": {
-                "attachment_type": "event.attachment",
-                "chunks": 123,
-                "content_type": "application/octet-stream",
-                "id": attachment_id,
-                "name": "foo.txt",
+        process_individual_attachment(
+            {
+                "type": "attachment",
+                "attachment": {
+                    "attachment_type": "event.attachment",
+                    "chunks": 123,
+                    "content_type": "application/octet-stream",
+                    "id": attachment_id,
+                    "name": "foo.txt",
+                },
+                "event_id": event_id,
+                "project_id": project_id,
             },
-            "event_id": event_id,
-            "project_id": project_id,
-        },
-        project=default_project,
-    )
+            project=default_project,
+        )
 
     attachments = list(EventAttachment.objects.filter(project_id=project_id, event_id=event_id))
 

--- a/tests/sentry/models/test_projectcounter.py
+++ b/tests/sentry/models/test_projectcounter.py
@@ -27,18 +27,17 @@ def test_increment(default_project):
 
 
 @contextmanager
-def patch_group_creation(monkeypatch):
+def patch_group_creation():
     group_creation_results: list[Group | Exception] = []
     group_creation_spy = MagicMock(
         side_effect=capture_results(Group.objects.create, group_creation_results)
     )
-    monkeypatch.setattr("sentry.event_manager.Group.objects.create", group_creation_spy)
+    with patch.object(Group.objects, "create", group_creation_spy):
+        yield (group_creation_spy, group_creation_results)
 
-    yield (group_creation_spy, group_creation_results)
 
-
-def create_existing_group(project, monkeypatch, message):
-    with patch_group_creation(monkeypatch) as patches:
+def create_existing_group(project, message):
+    with patch_group_creation() as patches:
         group_creation_spy, group_creation_results = patches
 
         event = save_new_event({"message": message}, project)
@@ -55,8 +54,8 @@ def create_existing_group(project, monkeypatch, message):
 
 
 @django_db_all
-def test_group_creation_simple(default_project, monkeypatch):
-    group = create_existing_group(default_project, monkeypatch, "Dogs are great!")
+def test_group_creation_simple(default_project):
+    group = create_existing_group(default_project, "Dogs are great!")
 
     # See `create_existing_group` for more assertions
     assert group
@@ -68,7 +67,7 @@ def test_group_creation_simple(default_project, monkeypatch):
     [1, 2, 3],
     ids=[" discrepancy = 1 ", " discrepancy = 2 ", " discrepancy = 3 "],
 )
-def test_group_creation_with_stuck_project_counter(default_project, monkeypatch, discrepancy):
+def test_group_creation_with_stuck_project_counter(default_project, discrepancy):
     project = default_project
 
     # Create enough groups that a discripancy larger than 1 will still land us on an existing group
@@ -78,9 +77,9 @@ def test_group_creation_with_stuck_project_counter(default_project, monkeypatch,
         "Bodhi is an adventurous dog",
         "Cory is a loyal dog",
     ]
-    existing_groups = [create_existing_group(project, monkeypatch, message) for message in messages]
+    existing_groups = [create_existing_group(project, message) for message in messages]
 
-    with patch_group_creation(monkeypatch) as patches:
+    with patch_group_creation() as patches:
         group_creation_spy, group_creation_results = patches
 
         # Set the counter value such that it will try to create the next group with the same `short_id` as the
@@ -153,7 +152,7 @@ def test_group_creation_with_stuck_project_counter(default_project, monkeypatch,
     redis.delete(redis_key)
 
     # Just to prove that it now works, here we go (new spies just for convenience)
-    with patch_group_creation(monkeypatch) as patches:
+    with patch_group_creation() as patches:
         group_creation_spy, group_creation_results = patches
 
         new_new_message = "Dogs are still great!"

--- a/tests/sentry/relay/test_projectconfig_cache.py
+++ b/tests/sentry/relay/test_projectconfig_cache.py
@@ -5,13 +5,12 @@ from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.utils import metrics
 
 
-def test_delete_count(monkeypatch):
+def test_delete_count():
     cache = redis.RedisProjectConfigCache()
-    incr_mock = mock.Mock()
-    monkeypatch.setattr(metrics, "incr", incr_mock)
-    cache.set_many({"a": {"foo": "bar"}})
+    with mock.patch.object(metrics, "incr") as incr_mock:
+        cache.set_many({"a": {"foo": "bar"}})
 
-    cache.delete_many(["a", "b"])
+        cache.delete_many(["a", "b"])
 
     assert incr_mock.call_args == mock.call(
         "relay.projectconfig_cache.write", amount=1, tags={"action": "delete"}

--- a/tests/sentry/spans/consumers/process/test_consumer.py
+++ b/tests/sentry/spans/consumers/process/test_consumer.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from time import sleep as real_sleep  # Import before monkeypatch
+from unittest import mock
 
 import orjson
 import pytest
@@ -13,123 +14,123 @@ from tests.sentry.spans.test_buffer import DEFAULT_OPTIONS
 
 @override_options({**DEFAULT_OPTIONS, "spans.drop-in-buffer": []})
 @pytest.mark.parametrize("kafka_slice_id", [None, 2])
-def test_basic(monkeypatch, kafka_slice_id):
+def test_basic(kafka_slice_id):
     # Flush very aggressively to make test pass instantly
-    monkeypatch.setattr("time.sleep", lambda _: None)
-    topic = Topic("test")
-    messages: list[KafkaPayload] = []
+    with mock.patch("time.sleep"):
+        topic = Topic("test")
+        messages: list[KafkaPayload] = []
 
-    fac = ProcessSpansStrategyFactory(
-        max_batch_size=1,
-        max_batch_time=10,
-        num_processes=1,
-        input_block_size=None,
-        output_block_size=None,
-        produce_to_pipe=messages.append,
-        kafka_slice_id=kafka_slice_id,
-    )
-
-    commits = []
-
-    def add_commit(offsets, force=False):
-        commits.append(offsets)
-
-    step = fac.create_with_partitions(add_commit, {Partition(topic, 0): 0})
-
-    try:
-        step.submit(
-            Message(
-                BrokerValue(
-                    partition=Partition(topic, 0),
-                    offset=1,
-                    payload=KafkaPayload(
-                        None,
-                        orjson.dumps(
-                            {
-                                "project_id": 12,
-                                "span_id": "a" * 16,
-                                "trace_id": "b" * 32,
-                                "end_timestamp_precise": 1700000000.0,
-                            }
-                        ),
-                        [],
-                    ),
-                    timestamp=datetime.now(),
-                )
-            )
+        fac = ProcessSpansStrategyFactory(
+            max_batch_size=1,
+            max_batch_time=10,
+            num_processes=1,
+            input_block_size=None,
+            output_block_size=None,
+            produce_to_pipe=messages.append,
+            kafka_slice_id=kafka_slice_id,
         )
 
-        step.poll()
-        fac._flusher.current_drift.value = 9000  # "advance" our "clock"
+        commits = []
 
-        step.poll()
-        # Give flusher threads time to process after drift change
-        for _ in range(20):
-            if messages:
-                break
+        def add_commit(offsets, force=False):
+            commits.append(offsets)
+
+        step = fac.create_with_partitions(add_commit, {Partition(topic, 0): 0})
+
+        try:
+            step.submit(
+                Message(
+                    BrokerValue(
+                        partition=Partition(topic, 0),
+                        offset=1,
+                        payload=KafkaPayload(
+                            None,
+                            orjson.dumps(
+                                {
+                                    "project_id": 12,
+                                    "span_id": "a" * 16,
+                                    "trace_id": "b" * 32,
+                                    "end_timestamp_precise": 1700000000.0,
+                                }
+                            ),
+                            [],
+                        ),
+                        timestamp=datetime.now(),
+                    )
+                )
+            )
+
             step.poll()
-            real_sleep(0.1)
+            fac._flusher.current_drift.value = 9000  # "advance" our "clock"
 
-        (msg,) = messages
+            step.poll()
+            # Give flusher threads time to process after drift change
+            for _ in range(20):
+                if messages:
+                    break
+                step.poll()
+                real_sleep(0.1)
 
-        assert orjson.loads(msg.value) == {
-            "spans": [
-                {
-                    "data": {
-                        "__sentry_internal_span_buffer_outcome": "different",
+            (msg,) = messages
+
+            assert orjson.loads(msg.value) == {
+                "spans": [
+                    {
+                        "data": {
+                            "__sentry_internal_span_buffer_outcome": "different",
+                        },
+                        "is_segment": True,
+                        "project_id": 12,
+                        "segment_id": "aaaaaaaaaaaaaaaa",
+                        "span_id": "aaaaaaaaaaaaaaaa",
+                        "trace_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                        "end_timestamp_precise": 1700000000.0,
                     },
-                    "is_segment": True,
-                    "project_id": 12,
-                    "segment_id": "aaaaaaaaaaaaaaaa",
-                    "span_id": "aaaaaaaaaaaaaaaa",
-                    "trace_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-                    "end_timestamp_precise": 1700000000.0,
-                },
-            ],
-        }
-    finally:
-        fac._flusher.join()
+                ],
+            }
+        finally:
+            fac._flusher.join()
 
 
 @override_options({**DEFAULT_OPTIONS, "spans.drop-in-buffer": []})
-def test_flusher_processes_limit(monkeypatch):
+def test_flusher_processes_limit():
     """Test that flusher respects the max_processes limit"""
     # Flush very aggressively to make test pass instantly
-    monkeypatch.setattr("time.sleep", lambda _: None)
+    with mock.patch("time.sleep"):
 
-    topic = Topic("test")
-    messages: list[KafkaPayload] = []
+        topic = Topic("test")
+        messages: list[KafkaPayload] = []
 
-    # Create factory with limited flusher processes
-    fac = ProcessSpansStrategyFactory(
-        max_batch_size=10,
-        max_batch_time=10,
-        num_processes=1,
-        input_block_size=None,
-        output_block_size=None,
-        flusher_processes=2,  # Limit to 2 processes even if more shards
-        produce_to_pipe=messages.append,
-    )
+        # Create factory with limited flusher processes
+        fac = ProcessSpansStrategyFactory(
+            max_batch_size=10,
+            max_batch_time=10,
+            num_processes=1,
+            input_block_size=None,
+            output_block_size=None,
+            flusher_processes=2,  # Limit to 2 processes even if more shards
+            produce_to_pipe=messages.append,
+        )
 
-    commits = []
+        commits = []
 
-    def add_commit(offsets, force=False):
-        commits.append(offsets)
+        def add_commit(offsets, force=False):
+            commits.append(offsets)
 
-    # Create with 4 partitions/shards to test process sharing
-    partitions = {Partition(topic, i): 0 for i in range(4)}
-    fac.create_with_partitions(add_commit, partitions)
-    flusher = fac._flusher
+        # Create with 4 partitions/shards to test process sharing
+        partitions = {Partition(topic, i): 0 for i in range(4)}
+        fac.create_with_partitions(add_commit, partitions)
+        flusher = fac._flusher
 
-    try:
-        # Verify that flusher uses at most 2 processes
-        assert len(flusher.processes) == 2
-        assert flusher.max_processes == 2
-        assert flusher.num_processes == 2
+        try:
+            # Verify that flusher uses at most 2 processes
+            assert len(flusher.processes) == 2
+            assert flusher.max_processes == 2
+            assert flusher.num_processes == 2
 
-        # Verify shards are distributed across processes
-        total_shards = sum(len(shards) for shards in flusher.process_to_shards_map.values())
-        assert total_shards == 4  # All 4 shards should be assigned
-    finally:
-        # shutdown flusher thread
-        fac._flusher.join()
+            # Verify shards are distributed across processes
+            total_shards = sum(len(shards) for shards in flusher.process_to_shards_map.values())
+            assert total_shards == 4  # All 4 shards should be assigned
+        finally:
+            # shutdown flusher thread
+            fac._flusher.join()

--- a/tests/sentry/tasks/conftest.py
+++ b/tests/sentry/tasks/conftest.py
@@ -1,13 +1,17 @@
+import contextlib
+from unittest import mock
+
 import pytest
 
 
 @pytest.fixture
-def register_plugin(request, monkeypatch):
-    def inner(globals, cls):
-        from sentry.plugins.base import plugins
+def register_plugin(request):
+    from sentry.plugins.base import plugins
 
-        monkeypatch.setitem(globals, cls.__name__, cls)
+    def inner(globals, cls):
+        ctx.enter_context(mock.patch.dict(globals, {cls.__name__: cls}))
         plugins.register(cls)
         request.addfinalizer(lambda: plugins.unregister(cls))
 
-    return inner
+    with contextlib.ExitStack() as ctx:
+        yield inner

--- a/tests/sentry/tasks/test_reprocessing2.py
+++ b/tests/sentry/tasks/test_reprocessing2.py
@@ -113,7 +113,6 @@ def test_basic(
     reset_snuba,
     process_and_save,
     register_event_preprocessor,
-    monkeypatch,
     django_cache,
 ):
     from sentry import eventstream
@@ -125,92 +124,94 @@ def test_basic(
         tombstone_calls.append((args, kwargs))
         old_tombstone_fn(*args, **kwargs)
 
-    monkeypatch.setattr("sentry.eventstream.backend.tombstone_events_unsafe", tombstone_called)
+    with mock.patch("sentry.eventstream.backend.tombstone_events_unsafe", tombstone_called):
 
-    abs_count = 0
+        abs_count = 0
 
-    @register_event_preprocessor
-    def event_preprocessor(data):
-        nonlocal abs_count
+        @register_event_preprocessor
+        def event_preprocessor(data):
+            nonlocal abs_count
 
-        tags = data.setdefault("tags", [])
-        assert all(not x or x[0] != "processing_counter" for x in tags)
-        tags.append(("processing_counter", f"x{abs_count}"))
-        abs_count += 1
+            tags = data.setdefault("tags", [])
+            assert all(not x or x[0] != "processing_counter" for x in tags)
+            tags.append(("processing_counter", f"x{abs_count}"))
+            abs_count += 1
+
+            if change_groups:
+                data["fingerprint"] = [uuid.uuid4().hex]
+            else:
+                data["fingerprint"] = ["foo"]
+
+            return data
+
+        event_id = process_and_save({"tags": [["key1", "value"], None, ["key2", "value"]]})
+
+        def get_event_by_processing_counter(n: str) -> list[Event]:
+            return list(
+                eventstore.backend.get_events(
+                    eventstore.Filter(
+                        project_ids=[default_project.id],
+                        conditions=[["tags[processing_counter]", "=", n]],
+                    ),
+                    tenant_ids={"organization_id": 1234, "referrer": "eventstore.get_events"},
+                )
+            )
+
+        event = eventstore.backend.get_event_by_id(
+            default_project.id,
+            event_id,
+            tenant_ids={"organization_id": 1234, "referrer": "eventstore.get_events"},
+        )
+        assert event is not None
+        assert event.get_tag("processing_counter") == "x0"
+        assert not event.data.get("errors")
+
+        assert get_event_by_processing_counter("x0")[0].event_id == event.event_id
+
+        old_event = event
+
+        with BurstTaskRunner() as burst:
+            reprocess_group(default_project.id, event.group_id)
+
+            burst(max_jobs=100)
+
+        (event,) = get_event_by_processing_counter("x1")
+
+        # Assert original data is used
+        assert event.get_tag("processing_counter") == "x1"
+        assert not event.data.get("errors")
 
         if change_groups:
-            data["fingerprint"] = [uuid.uuid4().hex]
+            assert event.get_hashes() != old_event.get_hashes()
         else:
-            data["fingerprint"] = ["foo"]
+            assert event.get_hashes() == old_event.get_hashes()
 
-        return data
+        assert event.group_id != old_event.group_id
 
-    event_id = process_and_save({"tags": [["key1", "value"], None, ["key2", "value"]]})
-
-    def get_event_by_processing_counter(n: str) -> list[Event]:
-        return list(
-            eventstore.backend.get_events(
-                eventstore.Filter(
-                    project_ids=[default_project.id],
-                    conditions=[["tags[processing_counter]", "=", n]],
-                ),
-                tenant_ids={"organization_id": 1234, "referrer": "eventstore.get_events"},
-            )
+        assert event.event_id == old_event.event_id
+        assert (
+            int(event.data["contexts"]["reprocessing"]["original_issue_id"]) == old_event.group_id
         )
 
-    event = eventstore.backend.get_event_by_id(
-        default_project.id,
-        event_id,
-        tenant_ids={"organization_id": 1234, "referrer": "eventstore.get_events"},
-    )
-    assert event is not None
-    assert event.get_tag("processing_counter") == "x0"
-    assert not event.data.get("errors")
+        assert not Group.objects.filter(id=old_event.group_id).exists()
 
-    assert get_event_by_processing_counter("x0")[0].event_id == event.event_id
+        assert is_group_finished(old_event.group_id)
 
-    old_event = event
-
-    with BurstTaskRunner() as burst:
-        reprocess_group(default_project.id, event.group_id)
-
-        burst(max_jobs=100)
-
-    (event,) = get_event_by_processing_counter("x1")
-
-    # Assert original data is used
-    assert event.get_tag("processing_counter") == "x1"
-    assert not event.data.get("errors")
-
-    if change_groups:
-        assert event.get_hashes() != old_event.get_hashes()
-    else:
-        assert event.get_hashes() == old_event.get_hashes()
-
-    assert event.group_id != old_event.group_id
-
-    assert event.event_id == old_event.event_id
-    assert int(event.data["contexts"]["reprocessing"]["original_issue_id"]) == old_event.group_id
-
-    assert not Group.objects.filter(id=old_event.group_id).exists()
-
-    assert is_group_finished(old_event.group_id)
-
-    # Old event is actually getting tombstoned
-    assert not get_event_by_processing_counter("x0")
-    if change_groups:
-        assert tombstone_calls == [
-            (
-                (default_project.id, [old_event.event_id]),
-                {
-                    "from_timestamp": old_event.datetime,
-                    "old_primary_hash": old_event.get_primary_hash(),
-                    "to_timestamp": old_event.datetime,
-                },
-            )
-        ]
-    else:
-        assert not tombstone_calls
+        # Old event is actually getting tombstoned
+        assert not get_event_by_processing_counter("x0")
+        if change_groups:
+            assert tombstone_calls == [
+                (
+                    (default_project.id, [old_event.event_id]),
+                    {
+                        "from_timestamp": old_event.datetime,
+                        "old_primary_hash": old_event.get_primary_hash(),
+                        "to_timestamp": old_event.datetime,
+                    },
+                )
+            ]
+        else:
+            assert not tombstone_calls
 
 
 @django_db_all
@@ -294,7 +295,6 @@ def test_max_events(
     reset_snuba,
     register_event_preprocessor,
     process_and_save,
-    monkeypatch,
     remaining_events,
     max_events,
 ):
@@ -375,7 +375,6 @@ def test_attachments_and_userfeedback(
     reset_snuba,
     register_event_preprocessor,
     process_and_save,
-    monkeypatch,
 ):
     @register_event_preprocessor
     def event_preprocessor(data):
@@ -447,7 +446,6 @@ def test_nodestore_missing(
     default_project,
     reset_snuba,
     process_and_save,
-    monkeypatch,
     remaining_events,
     django_cache,
 ):

--- a/tests/sentry/utils/test_samples.py
+++ b/tests/sentry/utils/test_samples.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 from django.core.exceptions import SuspiciousFileOperation
 
@@ -31,17 +33,16 @@ def test_missing_sample_returns_none() -> None:
     assert data is None
 
 
-def test_sample_as_directory_raises_exception(monkeypatch, tmp_path):
+def test_sample_as_directory_raises_exception(tmp_path):
     # override DATA_ROOT to a tmp directory
-    monkeypatch.setattr("sentry.utils.samples.DATA_ROOT", tmp_path)
+    with mock.patch("sentry.utils.samples.DATA_ROOT", tmp_path):
+        # create a directory ending with `.json`
+        samples_root = tmp_path / "samples" / "a_directory.json"
+        samples_root.mkdir(parents=True)
 
-    # create a directory ending with `.json`
-    samples_root = tmp_path / "samples" / "a_directory.json"
-    samples_root.mkdir(parents=True)
-
-    platform = "a_directory"
-    with pytest.raises(IsADirectoryError) as excinfo:
-        load_data(platform)
+        platform = "a_directory"
+        with pytest.raises(IsADirectoryError) as excinfo:
+            load_data(platform)
 
     (msg,) = excinfo.value.args
     assert msg == "expected file but found a directory instead"

--- a/tests/tools/test_flake8_plugin.py
+++ b/tests/tools/test_flake8_plugin.py
@@ -232,3 +232,11 @@ from sentry.db.models.fields.array import ArrayField
 """
     expected = ["t.py:1:0: S013 Use `django.contrib.postgres.fields.array.ArrayField` instead"]
     assert _run(src) == expected
+
+
+def test_S014():
+    src = """\
+def test(monkeypatch): pass
+"""
+    expected = ["t.py:1:9: S014 Use `unittest.mock` instead"]
+    assert _run(src) == expected

--- a/tools/flake8_plugin.py
+++ b/tools/flake8_plugin.py
@@ -38,6 +38,8 @@ S012_msg = "S012 Use `from sentry.api.permissions import SentryIsAuthenticated` 
 
 S013_msg = "S013 Use `django.contrib.postgres.fields.array.ArrayField` instead"
 
+S014_msg = "S014 Use `unittest.mock` instead"
+
 
 class SentryVisitor(ast.NodeVisitor):
     def __init__(self, filename: str) -> None:
@@ -103,6 +105,12 @@ class SentryVisitor(ast.NodeVisitor):
     def visit_Name(self, node: ast.Name) -> None:
         if node.id == "print":
             self.errors.append((node.lineno, node.col_offset, S002_msg))
+
+        self.generic_visit(node)
+
+    def visit_arg(self, node: ast.arg) -> None:
+        if node.arg == "monkeypatch":
+            self.errors.append((node.lineno, node.col_offset, S014_msg))
 
         self.generic_visit(node)
 


### PR DESCRIPTION
the monkeypatch fixture has not-well-defined scope compared to context managers.  it also can produce unexpected results when repeatedly called on the same target potentially leading to test pollution

getsentry portion: https://github.com/getsentry/getsentry/pull/18043

<!-- Describe your PR here. -->