### PR TITLE
🐛 fix(aci): correctly handle group status update handler

### DIFF
--- a/src/sentry/issues/status_change_consumer.py
+++ b/src/sentry/issues/status_change_consumer.py
@@ -162,13 +162,6 @@ def update_status(group: Group, status_change: StatusChangeMessageData) -> None:
                 amount=len(group_status_update_registry.registrations.keys()),
                 tags={"activity_type": activity_type.value},
             )
-            logger.info(
-                "group.status_change.activity_created",
-                extra={
-                    "group_id": group.id,
-                    "activity_type": activity_type,
-                },
-            )
             for handler in group_status_update_registry.registrations.values():
                 logger.info(
                     "group.status_change.activity_created.handler",

--- a/src/sentry/issues/status_change_consumer.py
+++ b/src/sentry/issues/status_change_consumer.py
@@ -161,6 +161,7 @@ def update_status(group: Group, status_change: StatusChangeMessageData) -> None:
                 "workflow_engine.issue_platform.status_change_handler",
                 amount=len(group_status_update_registry.registrations.keys()),
                 tags={"activity_type": activity_type.value},
+                sample_rate=1.0,
             )
             for handler in group_status_update_registry.registrations.values():
                 logger.info(

--- a/src/sentry/workflow_engine/handlers/__init__.py
+++ b/src/sentry/workflow_engine/handlers/__init__.py
@@ -2,6 +2,8 @@
 __all__ = [
     "EventCreatedByDetectorConditionHandler",
     "EventSeenCountConditionHandler",
+    "workflow_status_update_handler",
 ]
 
 from .condition import EventCreatedByDetectorConditionHandler, EventSeenCountConditionHandler
+from .workflow import workflow_status_update_handler

--- a/src/sentry/workflow_engine/handlers/workflow/__init__.py
+++ b/src/sentry/workflow_engine/handlers/workflow/__init__.py
@@ -1,0 +1,3 @@
+from .workflow_status_update_handler import workflow_status_update_handler
+
+__all__ = ["workflow_status_update_handler"]

--- a/src/sentry/workflow_engine/handlers/workflow/workflow_status_update_handler.py
+++ b/src/sentry/workflow_engine/handlers/workflow/workflow_status_update_handler.py
@@ -1,0 +1,44 @@
+from sentry import features
+from sentry.issues.status_change_consumer import group_status_update_registry
+from sentry.issues.status_change_message import StatusChangeMessageData
+from sentry.models.activity import Activity
+from sentry.models.group import Group
+from sentry.types.activity import ActivityType
+from sentry.utils import metrics
+from sentry.workflow_engine.tasks.workflows import process_workflow_activity
+
+SUPPORTED_ACTIVITIES = [ActivityType.SET_RESOLVED.value]
+
+
+@group_status_update_registry.register("workflow_status_update")
+def workflow_status_update_handler(
+    group: Group, status_change_message: StatusChangeMessageData, activity: Activity
+) -> None:
+    """
+    Hook the process_workflow_task into the activity creation registry.
+
+    Since this handler is called in process for the activity, we want
+    to queue a task to process workflows asynchronously.
+    """
+    metrics.incr(
+        "workflow_engine.tasks.process_workflows.activity_update",
+        tags={"activity_type": activity.type},
+    )
+    if activity.type not in SUPPORTED_ACTIVITIES:
+        # If the activity type is not supported, we do not need to process it.
+        return
+
+    detector_id = status_change_message.get("detector_id")
+
+    if detector_id is None:
+        # We should not hit this case, it's should only occur if there is a bug
+        # passing it from the workflow_engine to the issue platform.
+        metrics.incr("workflow_engine.tasks.error.no_detector_id")
+        return
+
+    if features.has("organizations:workflow-engine-metric-alert-processing", group.organization):
+        process_workflow_activity.delay(
+            activity_id=activity.id,
+            group_id=group.id,
+            detector_id=detector_id,
+        )

--- a/src/sentry/workflow_engine/tasks/__init__.py
+++ b/src/sentry/workflow_engine/tasks/__init__.py
@@ -1,0 +1,1 @@
+from .workflows import *  # noqa

--- a/src/sentry/workflow_engine/tasks/workflows.py
+++ b/src/sentry/workflow_engine/tasks/workflows.py
@@ -1,25 +1,19 @@
 from django.db import router, transaction
 from google.api_core.exceptions import RetryError
 
-from sentry import features
 from sentry.eventstream.base import GroupState
-from sentry.issues.status_change_consumer import group_status_update_registry
-from sentry.issues.status_change_message import StatusChangeMessageData
 from sentry.models.activity import Activity
 from sentry.models.group import Group
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task, retry
 from sentry.taskworker import config, namespaces
 from sentry.taskworker.retry import Retry, retry_task
-from sentry.types.activity import ActivityType
 from sentry.utils import metrics
 from sentry.workflow_engine.models import Detector
 from sentry.workflow_engine.processors.workflow import process_workflows
 from sentry.workflow_engine.tasks.utils import build_workflow_event_data_from_event, retry_timeouts
 from sentry.workflow_engine.types import WorkflowEventData
 from sentry.workflow_engine.utils import log_context
-
-SUPPORTED_ACTIVITIES = [ActivityType.SET_RESOLVED.value]
 
 logger = log_context.get_logger(__name__)
 
@@ -76,40 +70,6 @@ def process_workflow_activity(activity_id: int, group_id: int, detector_id: int)
         "workflow_engine.tasks.process_workflows.activity_update.executed",
         tags={"activity_type": activity.type},
     )
-
-
-@group_status_update_registry.register("workflow_status_update")
-def workflow_status_update_handler(
-    group: Group, status_change_message: StatusChangeMessageData, activity: Activity
-) -> None:
-    """
-    Hook the process_workflow_task into the activity creation registry.
-
-    Since this handler is called in process for the activity, we want
-    to queue a task to process workflows asynchronously.
-    """
-    metrics.incr(
-        "workflow_engine.tasks.process_workflows.activity_update",
-        tags={"activity_type": activity.type},
-    )
-    if activity.type not in SUPPORTED_ACTIVITIES:
-        # If the activity type is not supported, we do not need to process it.
-        return
-
-    detector_id = status_change_message.get("detector_id")
-
-    if detector_id is None:
-        # We should not hit this case, it's should only occur if there is a bug
-        # passing it from the workflow_engine to the issue platform.
-        metrics.incr("workflow_engine.tasks.error.no_detector_id")
-        return
-
-    if features.has("organizations:workflow-engine-metric-alert-processing", group.organization):
-        process_workflow_activity.delay(
-            activity_id=activity.id,
-            group_id=group.id,
-            detector_id=detector_id,
-        )
 
 
 @instrumented_task(

--- a/tests/sentry/workflow_engine/test_task.py
+++ b/tests/sentry/workflow_engine/test_task.py
@@ -226,6 +226,7 @@ class TestProcessWorkflowActivity(TestCase):
                 "workflow_engine.issue_platform.status_change_handler",
                 amount=1,
                 tags={"activity_type": self.activity.type},
+                sample_rate=1.0,
             )
 
             # Workflow engine is correctly registered for the activity update

--- a/tests/sentry/workflow_engine/test_task.py
+++ b/tests/sentry/workflow_engine/test_task.py
@@ -9,11 +9,9 @@ from sentry.models.group import GroupStatus
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import with_feature
 from sentry.types.activity import ActivityType
+from sentry.workflow_engine.handlers.workflow import workflow_status_update_handler
 from sentry.workflow_engine.tasks.utils import fetch_event
-from sentry.workflow_engine.tasks.workflows import (
-    process_workflow_activity,
-    workflow_status_update_handler,
-)
+from sentry.workflow_engine.tasks.workflows import process_workflow_activity
 from sentry.workflow_engine.types import WorkflowEventData
 
 


### PR DESCRIPTION
<img width="1489" height="404" alt="image" src="https://github.com/user-attachments/assets/05cb8673-ba98-499c-a96d-897cc2a55d25" />

turns out we weren't registering the function correctly because it wasn't in the `__init__` path. so i added a new `handler` folder and added the method there