### PR TITLE
chore(settings): Fix team notifications if integration and team don't match

### DIFF
--- a/static/app/views/settings/organizationTeams/teamNotifications.tsx
+++ b/static/app/views/settings/organizationTeams/teamNotifications.tsx
@@ -77,7 +77,29 @@ function TeamNotificationSettingsPanel({
 
   const hasWriteAccess = hasEveryAccess(['team:write'], {organization, team});
 
-  return externalTeams.map(externalTeam => (
+  const hasValidIntegration = externalTeams.some(
+    externalTeam => integrationsById[externalTeam.integrationId]
+  );
+
+  if (!hasValidIntegration) {
+    return (
+      <EmptyMessage>
+        <div>{t('No teams have been linked yet.')}</div>
+        <NotDisabledSubText>
+          {tct('Head over to Slack and type [code] to get started. [link].', {
+            code: <code>/sentry link team</code>,
+            link: <ExternalLink href={DOCS_LINK}>{t('Learn more')}</ExternalLink>,
+          })}
+        </NotDisabledSubText>
+      </EmptyMessage>
+    );
+  }
+
+  const filteredExternalTeams = externalTeams.filter(
+    externalTeam => integrationsById[externalTeam.integrationId]
+  );
+
+  return filteredExternalTeams.map(externalTeam => (
     <FormFieldWrapper key={externalTeam.id}>
       <StyledFormField
         disabled


### PR DESCRIPTION
fixes https://linear.app/getsentry/issue/RTC-1102/error-loading-component-on-team-notifications-settings-page
fixes [JAVASCRIPT-31MF](https://sentry.sentry.io/issues/6675121457/)