### PR TITLE
ref(errors): Use enum for stacktrace order

### DIFF
--- a/static/app/components/events/interfaces/utils.tsx
+++ b/static/app/components/events/interfaces/utils.tsx
@@ -9,7 +9,7 @@ import type {EntryRequest, EntryThreads, Event, Frame, Thread} from 'sentry/type
 import {EntryType} from 'sentry/types/event';
 import type {PlatformKey} from 'sentry/types/project';
 import type {StacktraceType} from 'sentry/types/stacktrace';
-import type {AvatarUser} from 'sentry/types/user';
+import {type AvatarUser, StacktraceOrder} from 'sentry/types/user';
 import {defined} from 'sentry/utils';
 import {fileExtensionToPlatform, getFileExtension} from 'sentry/utils/fileExtension';
 
@@ -382,11 +382,11 @@ export function isStacktraceNewestFirst() {
   }
 
   switch (user.options.stacktraceOrder) {
-    case 2:
+    case StacktraceOrder.MOST_RECENT_FIRST:
       return true;
-    case 1:
+    case StacktraceOrder.MOST_RECENT_LAST:
       return false;
-    case -1:
+    case StacktraceOrder.DEFAULT:
     default:
       return true;
   }

--- a/static/app/data/forms/accountPreferences.tsx
+++ b/static/app/data/forms/accountPreferences.tsx
@@ -2,6 +2,7 @@ import type {JsonFormObject} from 'sentry/components/forms/types';
 import languages from 'sentry/data/languages';
 import {timezoneOptions} from 'sentry/data/timezones';
 import {t} from 'sentry/locale';
+import {StacktraceOrder} from 'sentry/types/user';
 import {removeBodyTheme} from 'sentry/utils/removeBodyTheme';
 
 // Export route to make these forms searchable by label/help
@@ -58,9 +59,9 @@ const formGroups: JsonFormObject[] = [
         type: 'select',
         required: false,
         options: [
-          {value: -1, label: t('Default')},
-          {value: 1, label: t('Oldest')},
-          {value: 2, label: t('Newest')},
+          {value: StacktraceOrder.DEFAULT, label: t('Default')},
+          {value: StacktraceOrder.MOST_RECENT_LAST, label: t('Oldest')},
+          {value: StacktraceOrder.MOST_RECENT_FIRST, label: t('Newest')},
         ],
         label: t('Stack Trace Order'),
         help: t('Choose the default ordering of frames in stack traces'),

--- a/static/app/data/forms/accountPreferences.tsx
+++ b/static/app/data/forms/accountPreferences.tsx
@@ -59,6 +59,9 @@ const formGroups: JsonFormObject[] = [
         type: 'select',
         required: false,
         options: [
+          // TODO: If we eliminate the special-casing as discussed in
+          // https://github.com/getsentry/sentry/pull/96719, consider changing the label here to
+          // `Default (newest first)` and removing the separate `Newest first` option.
           {value: StacktraceOrder.DEFAULT, label: t('Default')},
           {value: StacktraceOrder.MOST_RECENT_LAST, label: t('Oldest first')},
           {value: StacktraceOrder.MOST_RECENT_FIRST, label: t('Newest first')},

--- a/static/app/data/forms/accountPreferences.tsx
+++ b/static/app/data/forms/accountPreferences.tsx
@@ -60,8 +60,8 @@ const formGroups: JsonFormObject[] = [
         required: false,
         options: [
           {value: StacktraceOrder.DEFAULT, label: t('Default')},
-          {value: StacktraceOrder.MOST_RECENT_LAST, label: t('Oldest')},
-          {value: StacktraceOrder.MOST_RECENT_FIRST, label: t('Newest')},
+          {value: StacktraceOrder.MOST_RECENT_LAST, label: t('Oldest first')},
+          {value: StacktraceOrder.MOST_RECENT_FIRST, label: t('Newest first')},
         ],
         label: t('Stack Trace Order'),
         help: t('Choose the default ordering of frames in stack traces'),

--- a/static/app/types/user.tsx
+++ b/static/app/types/user.tsx
@@ -56,7 +56,7 @@ export interface User extends Omit<AvatarUser, 'options'> {
     prefersIssueDetailsStreamlinedUI: boolean | null;
     prefersNextjsInsightsOverview: boolean;
     prefersStackedNavigation: boolean | null;
-    stacktraceOrder: number;
+    stacktraceOrder: StacktraceOrder;
     theme: 'system' | 'light' | 'dark';
     timezone: string;
   };

--- a/static/app/types/user.tsx
+++ b/static/app/types/user.tsx
@@ -21,6 +21,12 @@ export type AvatarUser = {
   };
 };
 
+export enum StacktraceOrder {
+  DEFAULT = -1, // Equivalent to `MOST_RECENT_FIRST`
+  MOST_RECENT_LAST = 1,
+  MOST_RECENT_FIRST = 2,
+}
+
 export interface User extends Omit<AvatarUser, 'options'> {
   canReset2fa: boolean;
   dateJoined: string;


### PR DESCRIPTION
This is a follow-up to https://github.com/getsentry/sentry/pull/96719, which added a backend `StacktraceOrder` enum, doing the same in the front end. It also clarifies the labels for the `Newest` (now `Newest first`) and `Oldest` (now `Oldest first`) options in user preferences.