### PR TITLE
:wrench: chore(aci): record CapabilityOverride as a halt for msteams

### DIFF
--- a/src/sentry/integrations/msteams/metrics.py
+++ b/src/sentry/integrations/msteams/metrics.py
@@ -8,6 +8,7 @@ MSTEAMS_HALT_ERROR_CODES = [
     "ConversationBlockedByUser",
     "ConversationNotFound",
     "TenantNoPermission",
+    "CapabilityOverride",
 ]
 
 


### PR DESCRIPTION
resolves SENTRY-49E0

closes ECO-917