### PR TITLE
chore(analytics): fix casing of codeowners

### DIFF
--- a/src/sentry/analytics/events/codeowners_assignment.py
+++ b/src/sentry/analytics/events/codeowners_assignment.py
@@ -1,7 +1,7 @@
 from sentry import analytics
 
 
-class CodeownersAssignment(analytics.Event):
+class CodeOwnersAssignment(analytics.Event):
     type = "codeowners.assignment"
 
     attributes = (
@@ -12,4 +12,4 @@ class CodeownersAssignment(analytics.Event):
     )
 
 
-analytics.register(CodeownersAssignment)
+analytics.register(CodeOwnersAssignment)

--- a/src/sentry/analytics/events/codeowners_created.py
+++ b/src/sentry/analytics/events/codeowners_created.py
@@ -2,11 +2,11 @@ from sentry import analytics
 
 
 @analytics.eventclass("codeowners.created")
-class CodeownersCreated(analytics.Event):
+class CodeOwnersCreated(analytics.Event):
     user_id: int | None = None
     organization_id: int
     project_id: int
     codeowners_id: int
 
 
-analytics.register(CodeownersCreated)
+analytics.register(CodeOwnersCreated)

--- a/src/sentry/analytics/events/codeowners_max_length_exceeded.py
+++ b/src/sentry/analytics/events/codeowners_max_length_exceeded.py
@@ -2,8 +2,8 @@ from sentry import analytics
 
 
 @analytics.eventclass("codeowners.max_length_exceeded")
-class CodeOwnersMaxLengthExceeded(analytics.Event):
+class CodeownersMaxLengthExceeded(analytics.Event):
     organization_id: int
 
 
-analytics.register(CodeOwnersMaxLengthExceeded)
+analytics.register(CodeownersMaxLengthExceeded)

--- a/src/sentry/analytics/events/codeowners_max_length_exceeded.py
+++ b/src/sentry/analytics/events/codeowners_max_length_exceeded.py
@@ -2,8 +2,8 @@ from sentry import analytics
 
 
 @analytics.eventclass("codeowners.max_length_exceeded")
-class CodeownersMaxLengthExceeded(analytics.Event):
+class CodeOwnersMaxLengthExceeded(analytics.Event):
     organization_id: int
 
 
-analytics.register(CodeownersMaxLengthExceeded)
+analytics.register(CodeOwnersMaxLengthExceeded)

--- a/src/sentry/analytics/events/codeowners_updated.py
+++ b/src/sentry/analytics/events/codeowners_updated.py
@@ -2,11 +2,11 @@ from sentry import analytics
 
 
 @analytics.eventclass("codeowners.updated")
-class CodeownersUpdated(analytics.Event):
+class CodeOwnersUpdated(analytics.Event):
     user_id: int | None = None
     organization_id: int
     project_id: int
     codeowners_id: int
 
 
-analytics.register(CodeownersUpdated)
+analytics.register(CodeOwnersUpdated)

--- a/src/sentry/api/endpoints/codeowners/details.py
+++ b/src/sentry/api/endpoints/codeowners/details.py
@@ -9,7 +9,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import analytics
-from sentry.analytics.events.codeowners_updated import CodeownersUpdated
+from sentry.analytics.events.codeowners_updated import CodeOwnersUpdated
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
@@ -81,7 +81,7 @@ class ProjectCodeOwnersDetailsEndpoint(ProjectEndpoint, ProjectCodeOwnersMixin):
 
             user_id = getattr(request.user, "id", None) or None
             analytics.record(
-                CodeownersUpdated(
+                CodeOwnersUpdated(
                     user_id=user_id,
                     organization_id=project.organization_id,
                     project_id=project.id,

--- a/src/sentry/api/endpoints/codeowners/index.py
+++ b/src/sentry/api/endpoints/codeowners/index.py
@@ -5,7 +5,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import analytics
-from sentry.analytics.events.codeowners_created import CodeownersCreated
+from sentry.analytics.events.codeowners_created import CodeOwnersCreated
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
@@ -111,7 +111,7 @@ class ProjectCodeOwnersEndpoint(ProjectEndpoint, ProjectCodeOwnersMixin):
             user_id = getattr(request.user, "id", None) or None
             try:
                 analytics.record(
-                    CodeownersCreated(
+                    CodeOwnersCreated(
                         user_id=user_id,
                         organization_id=project.organization_id,
                         project_id=project.id,


### PR DESCRIPTION
- Follow-up to https://github.com/getsentry/sentry/pull/96416
- Make spelling of objects containing CodeOwners consistent with the rest of the code (Codeowners -> CodeOwners)