### PR TITLE
ref: Move unity doc to content blocks

### DIFF
--- a/static/app/gettingStartedDocs/unity/unity.tsx
+++ b/static/app/gettingStartedDocs/unity/unity.tsx
@@ -1,6 +1,3 @@
-import {Fragment} from 'react';
-
-import {Alert} from 'sentry/components/core/alert';
 import {ExternalLink} from 'sentry/components/core/link';
 import {StoreCrashReportsConfig} from 'sentry/components/onboarding/gettingStartedDoc/storeCrashReportsConfig';
 import type {
@@ -20,27 +17,31 @@ using Sentry; // On the top of the script
 SentrySdk.CaptureMessage("Test event");`;
 
 const onboarding: OnboardingConfig = {
-  install: params => [
+  install: () => [
     {
       type: StepType.INSTALL,
-      description: tct(
-        "Install the package via the [link:Unity Package Manager] using a Git URL to Sentry's SDK repository:",
+      content: [
         {
-          link: (
-            <ExternalLink href="https://docs.unity3d.com/Manual/upm-ui-giturl.html" />
+          type: 'text',
+          text: tct(
+            "Install the package via the [link:Unity Package Manager] using a Git URL to Sentry's SDK repository:",
+            {
+              link: (
+                <ExternalLink href="https://docs.unity3d.com/Manual/upm-ui-giturl.html" />
+              ),
+            }
           ),
-        }
-      ),
-      configurations: [
+        },
         {
+          type: 'code',
           language: 'url',
-          partialLoading: params.sourcePackageRegistries.isLoading,
           code: 'https://github.com/getsentry/unity.git',
         },
-      ],
-      additionalInfo: (
-        <Alert type="info" showIcon={false}>
-          {tct(
+        {
+          type: 'alert',
+          alertType: 'info',
+          showIcon: false,
+          text: tct(
             'The Unity SDK now supports line numbers for IL2CPP. The feature is currently in beta, but you can enable it at [code:Tools -> Sentry -> Advanced -> IL2CPP] line numbers. To learn more check out our [link:docs].',
             {
               code: <code />,
@@ -48,44 +49,57 @@ const onboarding: OnboardingConfig = {
                 <ExternalLink href="https://docs.sentry.io/platforms/unity/configuration/il2cpp/" />
               ),
             }
-          )}
-        </Alert>
-      ),
+          ),
+        },
+      ],
     },
   ],
   configure: params => [
     {
       type: StepType.CONFIGURE,
-      description: tct(
-        "Access the Sentry configuration window by going to Unity's top menu: [code:Tools] > [code:Sentry] and enter the following DSN:",
-        {code: <code />}
-      ),
-      configurations: [
+      content: [
         {
+          type: 'text',
+          text: tct(
+            "Access the Sentry configuration window by going to Unity's top menu: [code:Tools] > [code:Sentry] and enter the following DSN:",
+            {code: <code />}
+          ),
+        },
+        {
+          type: 'code',
           language: 'url',
           code: params.dsn.public,
         },
+        {
+          type: 'text',
+          text: t("And that's it! Now Sentry can capture errors automatically."),
+        },
+        {
+          type: 'text',
+          text: tct(
+            'If you like additional contexts you could enable [link:Screenshots].',
+            {
+              link: (
+                <ExternalLink href="https://docs.sentry.io/platforms/unity/enriching-events/screenshots/" />
+              ),
+            }
+          ),
+        },
       ],
-      additionalInfo: (
-        <Fragment>
-          <p>{t("And that's it! Now Sentry can capture errors automatically.")}</p>
-          {tct('If you like additional contexts you could enable [link:Screenshots].', {
-            link: (
-              <ExternalLink href="https://docs.sentry.io/platforms/unity/enriching-events/screenshots/" />
-            ),
-          })}
-        </Fragment>
-      ),
     },
   ],
   verify: params => [
     {
       type: StepType.VERIFY,
-      description: t(
-        'Once it is configured with the DSN you can call the SDK from anywhere:'
-      ),
-      configurations: [
+      content: [
         {
+          type: 'text',
+          text: t(
+            'Once it is configured with the DSN you can call the SDK from anywhere:'
+          ),
+        },
+        {
+          type: 'code',
           language: 'csharp',
           code: getVerifySnippet(),
         },
@@ -93,14 +107,16 @@ const onboarding: OnboardingConfig = {
     },
     {
       title: t('Troubleshooting'),
-      description: (
-        <Fragment>
-          <p>
-            {t(
-              "Confirm the URL doesn't have a trailing whitespace at the end. The Unity Package Manager will fail to find the package if a trailing whitespace is appended."
-            )}
-          </p>
-          {tct(
+      content: [
+        {
+          type: 'text',
+          text: t(
+            "Confirm the URL doesn't have a trailing whitespace at the end. The Unity Package Manager will fail to find the package if a trailing whitespace is appended."
+          ),
+        },
+        {
+          type: 'text',
+          text: tct(
             "If you're running into any kind of issue please check out our [troubleshootingLink:troubleshooting page] or [raiseAnIssueLink:raise an issue].",
             {
               troubleshootingLink: (
@@ -110,18 +126,23 @@ const onboarding: OnboardingConfig = {
                 <ExternalLink href="https://github.com/getsentry/sentry-unity/issues/new?assignees=&labels=Platform%3A+Unity%2CType%3A+Bug&template=bug.md" />
               ),
             }
-          )}
-        </Fragment>
-      ),
+          ),
+        },
+      ],
     },
     {
       title: t('Further Settings'),
-      description: (
-        <StoreCrashReportsConfig
-          organization={params.organization}
-          projectSlug={params.projectSlug}
-        />
-      ),
+      content: [
+        {
+          type: 'custom',
+          content: (
+            <StoreCrashReportsConfig
+              organization={params.organization}
+              projectSlug={params.projectSlug}
+            />
+          ),
+        },
+      ],
     },
   ],
 };


### PR DESCRIPTION
contributes to https://linear.app/getsentry/issue/TET-761/docs-move-from-configuration-objects-to-content-blocks