### PR TITLE
feat: Instrument parse_addr in Apple crash reports

### DIFF
--- a/src/sentry/lang/native/applecrashreport.py
+++ b/src/sentry/lang/native/applecrashreport.py
@@ -32,6 +32,7 @@ class AppleCrashReport:
 
     @sentry_sdk.trace
     def __str__(self):
+        self.time_spent_parsing_addrs = 0
         rv = []
         rv.append(self._get_meta_header())
         rv.append(self._get_exception_info())

--- a/src/sentry/lang/native/applecrashreport.py
+++ b/src/sentry/lang/native/applecrashreport.py
@@ -1,7 +1,8 @@
 import posixpath
 from collections.abc import Mapping
 
-from symbolic.common import parse_addr
+import sentry_sdk
+import symbolic.common
 
 from sentry.constants import NATIVE_UNKNOWN_STRING
 from sentry.interfaces.exception import upgrade_legacy_mechanism
@@ -15,6 +16,12 @@ from sentry.lang.native.utils import image_name
 from sentry.utils.safe import get_path
 
 REPORT_VERSION = "104"
+
+
+# symbolic.common.parse_addr with instrumentation
+@sentry_sdk.trace
+def parse_addr(x: int | str | None) -> int:
+    return symbolic.common.parse_addr(x)
 
 
 class AppleCrashReport:

--- a/src/sentry/lang/native/applecrashreport.py
+++ b/src/sentry/lang/native/applecrashreport.py
@@ -28,11 +28,11 @@ class AppleCrashReport:
         self.debug_images = debug_images
         self.symbolicated = symbolicated
         self.exceptions = exceptions
-        self.time_spent_parsing_addrs = 0
+        self.time_spent_parsing_addrs = 0.0
 
     @sentry_sdk.trace
     def __str__(self):
-        self.time_spent_parsing_addrs = 0
+        self.time_spent_parsing_addrs = 0.0
         rv = []
         rv.append(self._get_meta_header())
         rv.append(self._get_exception_info())

--- a/src/sentry/lang/native/applecrashreport.py
+++ b/src/sentry/lang/native/applecrashreport.py
@@ -30,6 +30,7 @@ class AppleCrashReport:
         self.exceptions = exceptions
         self.time_spent_parsing_addrs = 0
 
+    @sentry_sdk.trace
     def __str__(self):
         rv = []
         rv.append(self._get_meta_header())
@@ -51,6 +52,7 @@ class AppleCrashReport:
         self.time_spent_parsing_addrs += end - start
         return res
 
+    @sentry_sdk.trace
     def _get_meta_header(self):
         return "OS Version: {} {} ({})\nReport Version: {}".format(
             get_path(self.context, "os", "name"),
@@ -96,6 +98,7 @@ class AppleCrashReport:
         except Exception:
             return value
 
+    @sentry_sdk.trace
     def _get_crashed_thread_registers(self):
         rv = []
         exception = get_path(self.exceptions, 0)
@@ -137,6 +140,7 @@ class AppleCrashReport:
 
         return "\n".join(rv)
 
+    @sentry_sdk.trace
     def _get_exception_info(self):
         rv = []
 
@@ -174,6 +178,7 @@ class AppleCrashReport:
 
         return "\n".join(rv)
 
+    @sentry_sdk.trace
     def get_threads_apple_string(self):
         rv = []
         exception = self.exceptions or []
@@ -256,6 +261,7 @@ class AppleCrashReport:
                     return self._parse_addr(debug_image.get("image_vmaddr", 0))
         return 0
 
+    @sentry_sdk.trace
     def get_binary_images_apple_string(self):
         # We don't need binary images on symbolicated crashreport
         if self.symbolicated or self.debug_images is None:


### PR DESCRIPTION
Local testing revealed that Apple crash report generation spends a significant amount of time in this function. This instruments it to confirm whether this really accounts for the much longer time generating a report takes in the product.

ref: INGEST-454.