### PR TITLE
ref(grouping): Always use config from event for grouping info

### DIFF
--- a/src/sentry/api/endpoints/event_grouping_info.py
+++ b/src/sentry/api/endpoints/event_grouping_info.py
@@ -29,7 +29,8 @@ class EventGroupingInfoEndpoint(ProjectEndpoint):
         if event is None:
             raise ResourceDoesNotExist
 
-        _grouping_info = get_grouping_info(request.GET.get("config", None), project, event)
+        grouping_config_id = event.get_grouping_config()["id"]
+        _grouping_info = get_grouping_info(grouping_config_id, project, event)
 
         # TODO: All of the below is a temporary hack to preserve compatibility between the BE and FE as
         # we transition from using dashes in the keys/variant types to using underscores. For now, until


### PR DESCRIPTION
We've never let anyone other than staff pick which grouping config is being used to calculate grouping info for the issue details page, and now even that ability is going away. This therefore switches the endpoint from looking in the request for which config to use (potentially overriding the config stored in the event) to looking in the event for the config.