### PR TITLE
fix(dashboards): do not persist sort into builder preview

### DIFF
--- a/static/app/views/dashboards/dashboard.tsx
+++ b/static/app/views/dashboards/dashboard.tsx
@@ -25,12 +25,10 @@ import type {PageFilters} from 'sentry/types/core';
 import type {InjectedRouter} from 'sentry/types/legacyReactRouter';
 import type {Organization} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import type {Sort} from 'sentry/utils/discover/fields';
 import {DatasetSource} from 'sentry/utils/discover/types';
 import withApi from 'sentry/utils/withApi';
 import withPageFilters from 'sentry/utils/withPageFilters';
 import type {DataSet} from 'sentry/views/dashboards/widgetBuilder/utils';
-import type {TabularColumn} from 'sentry/views/dashboards/widgets/common/types';
 
 import AddWidget, {ADD_WIDGET_BUTTON_DRAG_ID} from './addWidget';
 import type {Position} from './layoutUtils';
@@ -353,38 +351,6 @@ class Dashboard extends Component<Props, State> {
     ];
   }
 
-  handleWidgetTableSort(index: number) {
-    const {dashboard, onUpdate} = this.props;
-    return function (sort: Sort) {
-      const widget = dashboard.widgets[index]!;
-      const widgetCopy = cloneDeep(widget);
-      if (widgetCopy.queries[0]) {
-        const direction = sort.kind === 'desc' ? '-' : '';
-        widgetCopy.queries[0].orderby = `${direction}${sort.field}`;
-      }
-
-      const nextList = [...dashboard.widgets];
-      nextList[index] = widgetCopy;
-
-      onUpdate(nextList);
-    };
-  }
-
-  handleWidgetColumnTableResize(index: number) {
-    const {dashboard, onUpdate} = this.props;
-    return function (columns: TabularColumn[]) {
-      const widths = columns.map(column => column.width as number);
-      const widget = dashboard.widgets[index]!;
-      const widgetCopy = cloneDeep(widget);
-      widgetCopy.tableWidths = widths;
-
-      const nextList = [...dashboard.widgets];
-      nextList[index] = widgetCopy;
-
-      onUpdate(nextList);
-    };
-  }
-
   renderWidget(widget: Widget, index: number) {
     const {isMobile, windowWidth} = this.state;
     const {
@@ -425,8 +391,6 @@ class Dashboard extends Component<Props, State> {
           index={String(index)}
           newlyAddedWidget={newlyAddedWidget}
           onNewWidgetScrollComplete={onNewWidgetScrollComplete}
-          onWidgetTableSort={this.handleWidgetTableSort(index)}
-          onWidgetTableResizeColumn={this.handleWidgetColumnTableResize(index)}
         />
       </div>
     );

--- a/static/app/views/dashboards/sortableWidget.tsx
+++ b/static/app/views/dashboards/sortableWidget.tsx
@@ -1,5 +1,6 @@
-import {type ComponentProps, useEffect, useRef} from 'react';
+import {type ComponentProps, useEffect, useRef, useState} from 'react';
 import styled from '@emotion/styled';
+import cloneDeep from 'lodash/cloneDeep';
 
 import {LazyRender} from 'sentry/components/lazyRender';
 import PanelAlert from 'sentry/components/panels/panelAlert';
@@ -19,6 +20,7 @@ import {
   type DashboardFilters,
   type DashboardPermissions,
   type Widget,
+  type WidgetQuery,
   WidgetType,
 } from './types';
 import type WidgetLegendSelectionState from './widgetLegendSelectionState';
@@ -42,13 +44,13 @@ type Props = {
   isPreview?: boolean;
   newlyAddedWidget?: Widget;
   onNewWidgetScrollComplete?: () => void;
-  onWidgetTableResizeColumn?: (columns: TabularColumn[]) => void;
-  onWidgetTableSort?: (sort: Sort) => void;
   windowWidth?: number;
 };
 
 function SortableWidget(props: Props) {
   const widgetRef = useRef<HTMLDivElement>(null);
+  const [tableWidths, setTableWidths] = useState<number[]>();
+  const [queries, setQueries] = useState<WidgetQuery[]>();
   const {
     widget,
     isEditingDashboard,
@@ -67,8 +69,6 @@ function SortableWidget(props: Props) {
     dashboardCreator,
     newlyAddedWidget,
     onNewWidgetScrollComplete,
-    onWidgetTableSort,
-    onWidgetTableResizeColumn,
   } = props;
 
   const organization = useOrganization();
@@ -96,8 +96,20 @@ function SortableWidget(props: Props) {
     }
   }, [newlyAddedWidget, widget, isEditingDashboard, onNewWidgetScrollComplete]);
 
+  const onWidgetTableSort = (sort: Sort) => {
+    const newOrderBy = `${sort.kind === 'desc' ? '-' : ''}${sort.field}`;
+    const widgetQueries = cloneDeep(widget.queries);
+    if (widgetQueries[0]) widgetQueries[0].orderby = newOrderBy;
+    setQueries(widgetQueries);
+  };
+
+  const onWidgetTableResizeColumn = (columns: TabularColumn[]) => {
+    const widths = columns.map(column => column.width as number);
+    setTableWidths(widths);
+  };
+
   const widgetProps: ComponentProps<typeof WidgetCard> = {
-    widget,
+    widget: {...widget, queries: queries ?? widget.queries, tableWidths},
     isEditingDashboard,
     widgetLimitReached,
     hasEditAccess,

--- a/static/app/views/dashboards/sortableWidget.tsx
+++ b/static/app/views/dashboards/sortableWidget.tsx
@@ -98,6 +98,7 @@ function SortableWidget(props: Props) {
 
   const onWidgetTableSort = (sort: Sort) => {
     const newOrderBy = `${sort.kind === 'desc' ? '-' : ''}${sort.field}`;
+    // Override the widget queries to pass the temporary sort to the widget and expanded modal
     const widgetQueries = cloneDeep(widget.queries);
     if (widgetQueries[0]) widgetQueries[0].orderby = newOrderBy;
     setQueries(widgetQueries);

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -226,7 +226,13 @@ function WidgetCard(props: Props) {
           pathname: `${location.pathname}${
             location.pathname.endsWith('/') ? '' : '/'
           }widget/${props.index}/`,
-          query: location.query,
+          query: {
+            ...location.query,
+            sort:
+              widget.displayType === DisplayType.TABLE
+                ? widget.queries[0]?.orderby
+                : location.query.sort,
+          },
         },
         {preventScrollReset: true}
       );


### PR DESCRIPTION
### Changes

Fix an issue where a temporary sort would persist into the editor instead of displaying the default sort. But the temporary sort should persist in the viewer modal. Also simplifies the handling of column resizing and sorting. 

### Before

https://github.com/user-attachments/assets/a30ea9e0-32cb-476c-9cd9-a52fb2352ed9

### After

https://github.com/user-attachments/assets/dbcce415-0a2f-492a-be90-4bfffa489665


