### PR TITLE
feat(onboarding): Add logs to node onboarding

### DIFF
--- a/static/app/components/onboarding/productSelection.tsx
+++ b/static/app/components/onboarding/productSelection.tsx
@@ -178,7 +178,11 @@ export const platformProductAvailability = {
     ProductSolution.SESSION_REPLAY,
     ProductSolution.LOGS,
   ],
-  node: [ProductSolution.PERFORMANCE_MONITORING, ProductSolution.PROFILING],
+  node: [
+    ProductSolution.PERFORMANCE_MONITORING,
+    ProductSolution.PROFILING,
+    ProductSolution.LOGS,
+  ],
   'node-azurefunctions': [
     ProductSolution.PERFORMANCE_MONITORING,
     ProductSolution.PROFILING,

--- a/static/app/gettingStartedDocs/node/node.spec.tsx
+++ b/static/app/gettingStartedDocs/node/node.spec.tsx
@@ -110,4 +110,40 @@ describe('node onboarding docs', function () {
       screen.queryByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
     ).not.toBeInTheDocument();
   });
+
+  it('enables logs by setting enableLogs to true', () => {
+    renderWithOnboardingLayout(docs, {
+      selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.LOGS],
+    });
+
+    expect(
+      screen.getByText(textWithMarkupMatcher(/enableLogs: true/))
+    ).toBeInTheDocument();
+  });
+
+  it('does not enable logs when not selected', () => {
+    renderWithOnboardingLayout(docs, {
+      selectedProducts: [ProductSolution.ERROR_MONITORING],
+    });
+
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/enableLogs: true/))
+    ).not.toBeInTheDocument();
+  });
+
+  it('displays logs integration next step when logs are selected', () => {
+    renderWithOnboardingLayout(docs, {
+      selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.LOGS],
+    });
+
+    expect(screen.getByText('Logging Integrations')).toBeInTheDocument();
+  });
+
+  it('does not display logs integration next step when logs are not selected', () => {
+    renderWithOnboardingLayout(docs, {
+      selectedProducts: [ProductSolution.ERROR_MONITORING],
+    });
+
+    expect(screen.queryByText('Logging Integrations')).not.toBeInTheDocument();
+  });
 });

--- a/static/app/gettingStartedDocs/node/node.tsx
+++ b/static/app/gettingStartedDocs/node/node.tsx
@@ -44,7 +44,7 @@ server.listen(3000, "127.0.0.1");
 
 const onboarding: OnboardingConfig = {
   introduction: () =>
-    tct('In this quick guide you’ll use [strong:npm] or [strong:yarn] to set up:', {
+    tct("In this quick guide you'll use [strong:npm] or [strong:yarn] to set up:", {
       strong: <strong />,
     }),
   install: (params: Params) => [
@@ -173,7 +173,7 @@ async function fetchUserData(userId) {
 # Logs
 
 Where logs are used, ensure they are imported using \`import * as Sentry from "@sentry/node"\`
-Enable logging in Sentry using \`Sentry.init({ _experiments: { enableLogs: true } })\`
+Enable logging in Sentry using \`Sentry.init({ enableLogs: true })\`
 Reference the logger using \`const { logger } = Sentry\`
 Sentry offers a consoleLoggingIntegration that can be used to log specific console error types automatically without instrumenting the individual logger calls
 
@@ -189,9 +189,8 @@ import * as Sentry from "@sentry/node";
 Sentry.init({
   dsn: "${params.dsn.public}",
 
-  _experiments: {
-    enableLogs: true,
-  },
+  // Send structured logs to Sentry
+  enableLogs: true,
 });
 \`\`\`
 
@@ -266,6 +265,22 @@ try {
       ],
     },
   ],
+  nextSteps: (params: Params) => {
+    const steps = [];
+
+    if (params.isLogsSelected) {
+      steps.push({
+        id: 'logs',
+        name: t('Logging Integrations'),
+        description: t(
+          'Add logging integrations to automatically capture logs from your application.'
+        ),
+        link: 'https://docs.sentry.io/platforms/javascript/guides/node/logs/#integrations',
+      });
+    }
+
+    return steps;
+  },
 };
 
 const crashReportOnboarding: OnboardingConfig = {

--- a/static/app/utils/gettingStartedDocs/node.tsx
+++ b/static/app/utils/gettingStartedDocs/node.tsx
@@ -197,6 +197,13 @@ Sentry.init({
     // Trace lifecycle automatically enables profiling during active traces
     profileLifecycle: 'trace',`
       : ''
+  }${
+    params.isLogsSelected
+      ? `
+
+  // Send structured logs to Sentry
+  enableLogs: true,`
+      : ''
   }
 
   // Setting this option to true will send default PII data to Sentry.


### PR DESCRIPTION
Once this is merged in, we can update the rest of the node onboarding docs (because they all rely on the utils in `static/app/utils/gettingStartedDocs/node.tsx`)

resolves https://linear.app/getsentry/issue/LOGS-255/add-logs-to-node-onboarding