### PR TITLE
Fix quote removal in search entries

### DIFF
--- a/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
@@ -21,7 +21,7 @@ import {
   getFieldDefinition,
 } from 'sentry/utils/fields';
 
-const SHOULD_ESCAPE_REGEX = /[\s"(),]/;
+const SHOULD_ESCAPE_REGEX = /[\s"(),\[\]]/;
 
 export const OP_LABELS = {
   [TermOperator.DEFAULT]: 'is',

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
@@ -115,10 +115,9 @@ function prepareInputValueForSaving(valueType: FieldValueType, inputValue: strin
         if (item.value?.quoted) {
           // For quoted values, use the inner content and escape it properly
           return escapeTagValue(item.value?.value ?? '');
-        } else {
-          // For unquoted values, clean them
-          return cleanFilterValue({valueType, value: item.value?.text ?? ''});
         }
+        // For unquoted values, clean them
+        return cleanFilterValue({valueType, value: item.value?.text ?? ''});
       })
       .filter(text => text?.length) ?? [];
 

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
@@ -111,11 +111,15 @@ function prepareInputValueForSaving(valueType: FieldValueType, inputValue: strin
 
   const values =
     parsed.items
-      .map(item =>
-        item.value?.quoted
-          ? (item.value?.text ?? '')
-          : cleanFilterValue({valueType, value: item.value?.text ?? ''})
-      )
+      .map(item => {
+        if (item.value?.quoted) {
+          // For quoted values, use the inner content and escape it properly
+          return escapeTagValue(item.value?.value ?? '');
+        } else {
+          // For unquoted values, clean them
+          return cleanFilterValue({valueType, value: item.value?.text ?? ''});
+        }
+      })
       .filter(text => text?.length) ?? [];
 
   const uniqueValues = uniq(values);


### PR DESCRIPTION
<!-- Describe your PR here. -->
Fixes an issue where quotes were incorrectly removed from search values containing square brackets (e.g., `message:"[Filtered]"`).

The `SHOULD_ESCAPE_REGEX` in `utils.tsx` was updated to include `[` and `]` as characters that require a value to be quoted. This ensures that values like `[Filtered]` are properly escaped as `"[Filtered]"`, preventing them from being misinterpreted by the search grammar, where square brackets have special meaning (e.g., for lists or tags).

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
<a href="https://cursor.com/background-agent?bcId=bc-942de24e-6f9c-4fea-81f1-385c5c98b17b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-942de24e-6f9c-4fea-81f1-385c5c98b17b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>