### PR TITLE
ref: remove _set_isolation_level

### DIFF
--- a/src/sentry/db/postgres/base.py
+++ b/src/sentry/db/postgres/base.py
@@ -100,10 +100,6 @@ class DatabaseWrapper(DjangoDatabaseWrapper):
         self.ops = DatabaseOperations(self)
 
     @auto_reconnect_connection
-    def _set_isolation_level(self, level):
-        return super()._set_isolation_level(level)
-
-    @auto_reconnect_connection
     def _cursor(self, *args, **kwargs):
         return super()._cursor()
 


### PR DESCRIPTION
_set_isolation_level was removed in django/django@64a899dc815f1a070dc7a7c22276e8bb41e46ea6 released in django 1.9

<!-- Describe your PR here. -->