### PR TITLE
feat(onboarding): Add product selection to cloudflare

### DIFF
--- a/static/app/components/onboarding/productSelection.tsx
+++ b/static/app/components/onboarding/productSelection.tsx
@@ -228,6 +228,11 @@ export const platformProductAvailability = {
     ProductSolution.PROFILING,
     ProductSolution.LOGS,
   ],
+  'node-cloudflare-workers': [
+    ProductSolution.PERFORMANCE_MONITORING,
+    ProductSolution.LOGS,
+  ],
+  'node-cloudflare-pages': [ProductSolution.PERFORMANCE_MONITORING, ProductSolution.LOGS],
   php: [ProductSolution.PERFORMANCE_MONITORING, ProductSolution.PROFILING],
   'php-laravel': [ProductSolution.PERFORMANCE_MONITORING, ProductSolution.PROFILING],
   'php-symfony': [ProductSolution.PERFORMANCE_MONITORING, ProductSolution.PROFILING],

--- a/static/app/gettingStartedDocs/node/cloudflare-pages.spec.tsx
+++ b/static/app/gettingStartedDocs/node/cloudflare-pages.spec.tsx
@@ -39,4 +39,46 @@ describe('express onboarding docs', function () {
       screen.getByText(textWithMarkupMatcher(/tracesSampleRate/))
     ).toBeInTheDocument();
   });
+
+  it('displays logs configuration when logs are selected', () => {
+    renderWithOnboardingLayout(docs, {
+      selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.LOGS],
+    });
+
+    expect(
+      screen.getByText(textWithMarkupMatcher(/enableLogs: true/))
+    ).toBeInTheDocument();
+  });
+
+  it('shows Logging Integrations in next steps when logs is selected', () => {
+    renderWithOnboardingLayout(docs, {
+      selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.LOGS],
+    });
+
+    expect(screen.getByText('Logging Integrations')).toBeInTheDocument();
+  });
+
+  it('does not display logs configuration when logs are not selected', () => {
+    renderWithOnboardingLayout(docs, {
+      selectedProducts: [
+        ProductSolution.ERROR_MONITORING,
+        ProductSolution.PERFORMANCE_MONITORING,
+      ],
+    });
+
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/enableLogs: true/))
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not show Logging Integrations in next steps when logs is not selected', () => {
+    renderWithOnboardingLayout(docs, {
+      selectedProducts: [
+        ProductSolution.ERROR_MONITORING,
+        ProductSolution.PERFORMANCE_MONITORING,
+      ],
+    });
+
+    expect(screen.queryByText('Logging Integrations')).not.toBeInTheDocument();
+  });
 });

--- a/static/app/gettingStartedDocs/node/cloudflare-pages.tsx
+++ b/static/app/gettingStartedDocs/node/cloudflare-pages.tsx
@@ -39,11 +39,22 @@ import * as Sentry from "@sentry/cloudflare";
 export const onRequest = [
   // Make sure Sentry is the first middleware
   Sentry.sentryPagesPlugin((context) => ({
-    dsn: "${params.dsn.public}",
+    dsn: "${params.dsn.public}",${
+      params.isPerformanceSelected
+        ? `
     // Set tracesSampleRate to 1.0 to capture 100% of spans for tracing.
     // Learn more at
     // https://docs.sentry.io/platforms/javascript/configuration/options/#traces-sample-rate
-    tracesSampleRate: 1.0,
+    tracesSampleRate: 1.0,`
+        : ''
+    }${
+      params.isLogsSelected
+        ? `
+
+    // Send structured logs to Sentry
+    enableLogs: true,`
+        : ''
+    }
 
     // Setting this option to true will send default PII data to Sentry.
     // For example, automatic IP address collection on events
@@ -153,6 +164,31 @@ const onboarding: OnboardingConfig = {
       ],
     },
   ],
+  nextSteps: (params: Params) => {
+    const steps = [
+      {
+        id: 'cloudflare-features',
+        name: t('Cloudflare Features'),
+        description: t(
+          'Learn about our first class integration with the Cloudflare Pages platform.'
+        ),
+        link: 'https://docs.sentry.io/platforms/javascript/guides/cloudflare/features/',
+      },
+    ];
+
+    if (params.isLogsSelected) {
+      steps.push({
+        id: 'logs',
+        name: t('Logging Integrations'),
+        description: t(
+          'Add logging integrations to automatically capture logs from your application.'
+        ),
+        link: 'https://docs.sentry.io/platforms/javascript/guides/cloudflare/logs/#integrations',
+      });
+    }
+
+    return steps;
+  },
 };
 
 const crashReportOnboarding: OnboardingConfig = {

--- a/static/app/gettingStartedDocs/node/cloudflare-workers.spec.tsx
+++ b/static/app/gettingStartedDocs/node/cloudflare-workers.spec.tsx
@@ -52,4 +52,46 @@ describe('express onboarding docs', function () {
       screen.getByText(textWithMarkupMatcher(/tracesSampleRate: 1\.0/))
     ).toBeInTheDocument();
   });
+
+  it('displays logs configuration when logs are selected', () => {
+    renderWithOnboardingLayout(docs, {
+      selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.LOGS],
+    });
+
+    expect(
+      screen.getByText(textWithMarkupMatcher(/enableLogs: true/))
+    ).toBeInTheDocument();
+  });
+
+  it('shows Logging Integrations in next steps when logs is selected', () => {
+    renderWithOnboardingLayout(docs, {
+      selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.LOGS],
+    });
+
+    expect(screen.getByText('Logging Integrations')).toBeInTheDocument();
+  });
+
+  it('does not display logs configuration when logs are not selected', () => {
+    renderWithOnboardingLayout(docs, {
+      selectedProducts: [
+        ProductSolution.ERROR_MONITORING,
+        ProductSolution.PERFORMANCE_MONITORING,
+      ],
+    });
+
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/enableLogs: true/))
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not show Logging Integrations in next steps when logs is not selected', () => {
+    renderWithOnboardingLayout(docs, {
+      selectedProducts: [
+        ProductSolution.ERROR_MONITORING,
+        ProductSolution.PERFORMANCE_MONITORING,
+      ],
+    });
+
+    expect(screen.queryByText('Logging Integrations')).not.toBeInTheDocument();
+  });
 });

--- a/static/app/gettingStartedDocs/node/cloudflare-workers.tsx
+++ b/static/app/gettingStartedDocs/node/cloudflare-workers.tsx
@@ -37,11 +37,22 @@ import * as Sentry from "@sentry/cloudflare";
 
 export default Sentry.withSentry(
   env => ({
-    dsn: "${params.dsn.public}",
+    dsn: "${params.dsn.public}",${
+      params.isPerformanceSelected
+        ? `
     // Set tracesSampleRate to 1.0 to capture 100% of spans for tracing.
     // Learn more at
     // https://docs.sentry.io/platforms/javascript/configuration/options/#traces-sample-rate
-    tracesSampleRate: 1.0,
+    tracesSampleRate: 1.0,`
+        : ''
+    }${
+      params.isLogsSelected
+        ? `
+
+    // Send structured logs to Sentry
+    enableLogs: true,`
+        : ''
+    }
 
     // Setting this option to true will send default PII data to Sentry.
     // For example, automatic IP address collection on events
@@ -145,6 +156,31 @@ const onboarding: OnboardingConfig = {
       ],
     },
   ],
+  nextSteps: (params: Params) => {
+    const steps = [
+      {
+        id: 'cloudflare-features',
+        name: t('Cloudflare Features'),
+        description: t(
+          'Learn about our first class integration with the Cloudflare Workers platform.'
+        ),
+        link: 'https://docs.sentry.io/platforms/javascript/guides/cloudflare/features/',
+      },
+    ];
+
+    if (params.isLogsSelected) {
+      steps.push({
+        id: 'logs',
+        name: t('Logging Integrations'),
+        description: t(
+          'Add logging integrations to automatically capture logs from your application.'
+        ),
+        link: 'https://docs.sentry.io/platforms/javascript/guides/cloudflare/logs/#integrations',
+      });
+    }
+
+    return steps;
+  },
 };
 
 const crashReportOnboarding: OnboardingConfig = {


### PR DESCRIPTION
Updates the cloudflare sdk onboarding to add product selection, and then adds logs accordingly.

<img width="1216" height="808" alt="image" src="https://github.com/user-attachments/assets/975228e1-cdab-4cb3-8603-99bb912b89ab" />
