### PR TITLE
fix(utils): make slugify replace all whitespace

### DIFF
--- a/static/app/utils/slugify.spec.tsx
+++ b/static/app/utils/slugify.spec.tsx
@@ -26,12 +26,6 @@ describe('slugify', function () {
   });
 
   it('keeps hyphens and underscores', function () {
-    expect(slugify('_some-chars__should-stay')).toBe('some-chars__should-stay');
-  });
-
-  it('removes leading and trailing whitespace/hyphens/underscores', function () {
-    expect(slugify(' _-leading-and-trailing_characters-_ ')).toBe(
-      'leading-and-trailing_characters'
-    );
+    expect(slugify('_some-chars__should-stay')).toBe('_some-chars__should-stay');
   });
 });

--- a/static/app/utils/slugify.spec.tsx
+++ b/static/app/utils/slugify.spec.tsx
@@ -26,6 +26,12 @@ describe('slugify', function () {
   });
 
   it('keeps hyphens and underscores', function () {
-    expect(slugify('_some-chars__should-stay')).toBe('_some-chars__should-stay');
+    expect(slugify('_some-chars__should-stay')).toBe('some-chars__should-stay');
+  });
+
+  it('removes leading and trailing whitespace/hyphens/underscores', function () {
+    expect(slugify(' _-leading-and-trailing_characters-_ ')).toBe(
+      'leading-and-trailing_characters'
+    );
   });
 });

--- a/static/app/utils/slugify.spec.tsx
+++ b/static/app/utils/slugify.spec.tsx
@@ -5,8 +5,12 @@ describe('slugify', function () {
     expect(slugify('STOPYELLING')).toBe('stopyelling');
   });
 
-  it('replaces spaces with a hyphen', function () {
+  it('replaces space with a hyphen', function () {
     expect(slugify('STOP YELLING')).toBe('stop-yelling');
+  });
+
+  it('replaces all spaces with a hyphen', function () {
+    expect(slugify('STOP YELLING AT ME')).toBe('stop-yelling-at-me');
   });
 
   it('replaces accented characters', function () {

--- a/static/app/utils/slugify.tsx
+++ b/static/app/utils/slugify.tsx
@@ -10,6 +10,5 @@ export default function slugify(str: string): string {
     .normalize('NFKD') // Converts accents/ligatures/etc to latin alphabet
     .toLowerCase()
     .replace(/[^a-z0-9_\s-]/g, '') // Remove all invalid characters
-    .replace(/[-\s]+/g, '-') // Replace multiple spaces or hyphens with a single hyphen
-    .replace(/^[-_]+|[-_]+$/g, ''); // Trim leading/trailing hyphens or underscores
+    .replace(/[-\s]+/g, '-'); // Replace multiple spaces or hyphens with a single hyphen
 }

--- a/static/app/utils/slugify.tsx
+++ b/static/app/utils/slugify.tsx
@@ -9,6 +9,6 @@ export default function slugify(str: string): string {
   return str
     .normalize('NFKD') // Converts accents/ligatures/etc to latin alphabet
     .toLowerCase()
-    .replace(' ', '-')
+    .replace(/\s+/g, '-')
     .replace(/[^a-z0-9-_]/g, ''); // Remove all invalid characters
 }

--- a/static/app/utils/slugify.tsx
+++ b/static/app/utils/slugify.tsx
@@ -9,6 +9,7 @@ export default function slugify(str: string): string {
   return str
     .normalize('NFKD') // Converts accents/ligatures/etc to latin alphabet
     .toLowerCase()
-    .replace(/\s+/g, '-')
-    .replace(/[^a-z0-9-_]/g, ''); // Remove all invalid characters
+    .replace(/[^a-z0-9-_-\s]/g, '') // Remove all invalid characters
+    .replace(/[-\s]+/g, '-') // Replace multiple spaces or hyphens with a single hyphen
+    .replace(/^[-_]+|[-_]+$/g, ''); // Trim leading/trailing hyphens or underscores
 }

--- a/static/app/utils/slugify.tsx
+++ b/static/app/utils/slugify.tsx
@@ -9,7 +9,7 @@ export default function slugify(str: string): string {
   return str
     .normalize('NFKD') // Converts accents/ligatures/etc to latin alphabet
     .toLowerCase()
-    .replace(/[^a-z0-9-_-\s]/g, '') // Remove all invalid characters
+    .replace(/[^a-z0-9_\s-]/g, '') // Remove all invalid characters
     .replace(/[-\s]+/g, '-') // Replace multiple spaces or hyphens with a single hyphen
     .replace(/^[-_]+|[-_]+$/g, ''); // Trim leading/trailing hyphens or underscores
 }


### PR DESCRIPTION
When attempting to use our `slugify` util, I realized that it only ever replaced the first whitespace character with `-`.

This PR adjusts `slugify` so it more closely matches the built-in Django `slugify` function. Thankfully this is really only used in forms for creating new orgs/projects/teams/monitors, so the impact is minimal.

Pinging @malwilley as the most recent person to modify this function (albeit years ago)