### PR TITLE
feat(search): added subtitle to metric_issue in issue.type

### DIFF
--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -209,6 +209,9 @@ export enum IssueTitle {
   REPLAY_RAGE_CLICK = 'Rage Click Detected',
   REPLAY_HYDRATION_ERROR = 'Hydration Error Detected',
 
+  // Metric Issues
+  METRIC_ISSUE = 'Issue Detected by Metric Monitor',
+
   QUERY_INJECTION_VULNERABILITY = 'Potential Query Injection Vulnerability',
 }
 
@@ -240,6 +243,8 @@ export const ISSUE_TYPE_TO_ISSUE_TITLE = {
 
   replay_click_rage: IssueTitle.REPLAY_RAGE_CLICK,
   replay_hydration_error: IssueTitle.REPLAY_HYDRATION_ERROR,
+
+  metric_issue: IssueTitle.METRIC_ISSUE,
 };
 
 export function getIssueTitleFromType(issueType: string): IssueTitle | undefined {


### PR DESCRIPTION
Added "Issue Detected by Metric Monitor" to `metric_issue` suggestion for `Issue.type`.

<img width="471" height="395" alt="image" src="https://github.com/user-attachments/assets/f0ee1d4e-5474-42a8-8a51-215920828e12" />

