### PR TITLE
ref(replay): improve tracing for new summary endpoint

### DIFF
--- a/src/sentry/replays/lib/summarize.py
+++ b/src/sentry/replays/lib/summarize.py
@@ -33,6 +33,7 @@ class EventDict(TypedDict):
     category: str
 
 
+@sentry_sdk.trace
 def fetch_error_details(project_id: int, error_ids: list[str]) -> list[EventDict]:
     """Fetch error details given error IDs and return a list of EventDict objects."""
     try:
@@ -75,6 +76,7 @@ def parse_timestamp(timestamp_value: Any, unit: str) -> float:
     return 0.0
 
 
+@sentry_sdk.trace
 def fetch_trace_connected_errors(
     project: Project,
     trace_ids: list[str],

--- a/src/sentry/replays/post_process.py
+++ b/src/sentry/replays/post_process.py
@@ -5,6 +5,7 @@ from collections.abc import Generator, Iterable, Iterator, MutableMapping
 from itertools import zip_longest
 from typing import Any, TypedDict
 
+import sentry_sdk
 from drf_spectacular.utils import extend_schema_serializer
 
 
@@ -89,6 +90,7 @@ class ReplayDetailsResponse(TypedDict, total=False):
     has_viewed: bool
 
 
+@sentry_sdk.trace
 def process_raw_response(
     response: list[dict[str, Any]], fields: list[str]
 ) -> list[ReplayDetailsResponse]:

--- a/src/sentry/replays/usecases/reader.py
+++ b/src/sentry/replays/usecases/reader.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import uuid
 import zlib
-from collections.abc import Iterator
+from collections.abc import Generator, Iterator
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta
 from typing import Any
@@ -264,7 +264,7 @@ def download_segments(segments: list[RecordingSegmentStorageMeta]) -> Iterator[b
 
 def iter_segment_data(
     segments: list[RecordingSegmentStorageMeta],
-) -> Iterator[tuple[int, memoryview]]:
+) -> Generator[tuple[int, memoryview]]:
     with ThreadPoolExecutor(max_workers=10) as pool:
         segment_data = pool.map(_download_segment, segments)
 


### PR DESCRIPTION
Follow up on https://github.com/getsentry/sentry/pull/96280
[REPLAY-545: Async replay summaries: new Sentry endpoints for starting task and polling](https://linear.app/getsentry/issue/REPLAY-545/async-replay-summaries-new-sentry-endpoints-for-starting-task-and)