### PR TITLE
fix(tokenizing): Stop MutableSearch stripping quotes and brackets

### DIFF
--- a/static/app/utils/tokenizeSearch.spec.tsx
+++ b/static/app/utils/tokenizeSearch.spec.tsx
@@ -528,6 +528,16 @@ describe('utils/tokenizeSearch', function () {
         object: new MutableSearch(['transaction:["this has a space",thisdoesnot]']),
         string: 'transaction:["this has a space",thisdoesnot]',
       },
+      {
+        name: 'should not remove quotes or brackets from literal values',
+        object: new MutableSearch(['transaction:"[beta]"']),
+        string: 'transaction:"[beta]"',
+      },
+      {
+        name: 'should not remove quotes or brackets from literal values in array',
+        object: new MutableSearch(['transaction:["[beta]", alpha]']),
+        string: 'transaction:["[beta]", alpha]',
+      },
     ];
 
     for (const {name, string, object} of cases) {

--- a/static/app/utils/tokenizeSearch.tsx
+++ b/static/app/utils/tokenizeSearch.tsx
@@ -160,14 +160,15 @@ export class MutableSearch {
             formattedTokens.push(`${token.key}:""`);
           } else if (
             // Don't quote if it's already a properly formatted bracket expression
-            /^\[.*\]$/.test(token.value) ||
-            // Don't quote if it's already properly quoted
-            /^".*"$/.test(token.value)
+            // This should only match actual bracket expressions like [value1,value2] or ["value1","value2"]
+            // Not literal strings that happen to start and end with brackets like [Filtered]
+            /^\[.*\]$/.test(token.value) &&
+            (token.value.includes(',') || token.value.includes('"'))
           ) {
             formattedTokens.push(`${token.key}:${token.value}`);
           } else if (
-            // Quote if contains spaces, parens, or quotes
-            /[\s\(\)\\"]/g.test(token.value)
+            // Quote if contains spaces, parens, quotes, or brackets
+            /[\s\(\)\\"\[\]]/g.test(token.value)
           ) {
             formattedTokens.push(`${token.key}:"${escapeDoubleQuotes(token.value)}"`);
           } else {
@@ -175,7 +176,7 @@ export class MutableSearch {
           }
           break;
         case TokenType.FREE_TEXT:
-          if (/[\s\(\)\\"]/g.test(token.value)) {
+          if (/[\s\(\)\\"\[\]]/g.test(token.value)) {
             formattedTokens.push(`"${escapeDoubleQuotes(token.value)}"`);
           } else {
             formattedTokens.push(token.value);


### PR DESCRIPTION
I've poked around, and played around with this, and everything seems to still be working a-okay.

_From Cursor:_
**Summary**
The issue was in the `formatString()` function in `tokenizeSearch.tsx`. When the value `"[Filtered]"` was being processed, it was being treated as if it was already properly quoted because it matched the regex `/^".*"$/.test(token.value)`.
However, `"[Filtered]"` is actually a literal string value that should be quoted, not an already-quoted value. The problem was that the parsing logic was removing the outer quotes during the `parseFilter` function, leaving `[Filtered]` as the token value.

**The Fix**
I fixed this by:
1. Removing the problematic condition that checked for already-quoted values using `/^".*"$/.test(token.value)`
2. Adding bracket characters to the regex pattern that triggers quoting: `/[\s\(\)\\"\[\]]/g.test(token.value)`
3. Restoring a more specific bracket expression check that only matches actual bracket expressions (like `[value1,value2]` or `["value1","value2"]`) and not literal strings that happen to start and end with brackets (like `[Filtered]`)

The key insight was that:
- `[Filtered]` is a literal string that should be quoted → `message:"[Filtered]"`
- `[alpha,beta]` is an actual bracket expression that should not be quoted → `transaction:[alpha,beta]`

The fix distinguishes between these two cases by checking if the bracket expression contains commas or quotes, which are typical characteristics of actual bracket expressions used for filtering.
Now `message:"[Filtered]"` will be properly formatted as `message:"[Filtered]"` instead of incorrectly becoming `message:[Filtered]`.

Ticket: LOGS-277
