### PR TITLE
:wrench: chore(aci): increase sample rate for workflow engine task metrics

### DIFF
--- a/src/sentry/workflow_engine/models/action.py
+++ b/src/sentry/workflow_engine/models/action.py
@@ -92,6 +92,7 @@ class Action(DefaultFieldsModel, JSONConfigBase):
         metrics.incr(
             "workflow_engine.action.trigger",
             tags={"action_type": self.type, "detector_type": detector.type},
+            sample_rate=1.0,
         )
 
         logger.info(

--- a/src/sentry/workflow_engine/tasks/workflows.py
+++ b/src/sentry/workflow_engine/tasks/workflows.py
@@ -69,6 +69,7 @@ def process_workflow_activity(activity_id: int, group_id: int, detector_id: int)
     metrics.incr(
         "workflow_engine.tasks.process_workflows.activity_update.executed",
         tags={"activity_type": activity.type},
+        sample_rate=1.0,
     )
 
 

--- a/tests/sentry/incidents/test_metric_issue_post_process.py
+++ b/tests/sentry/incidents/test_metric_issue_post_process.py
@@ -186,6 +186,7 @@ class MetricIssueIntegrationTest(BaseWorkflowTest, BaseMetricIssueTest):
             mock_incr.assert_any_call(
                 "workflow_engine.tasks.process_workflows.activity_update.executed",
                 tags={"activity_type": ActivityType.SET_RESOLVED.value},
+                sample_rate=1.0,
             )
 
     @with_feature("organizations:workflow-engine-metric-alert-processing")
@@ -214,4 +215,5 @@ class MetricIssueIntegrationTest(BaseWorkflowTest, BaseMetricIssueTest):
             mock_incr.assert_any_call(
                 "workflow_engine.tasks.process_workflows.activity_update.executed",
                 tags={"activity_type": ActivityType.SET_RESOLVED.value},
+                sample_rate=1.0,
             )

--- a/tests/sentry/workflow_engine/models/test_action.py
+++ b/tests/sentry/workflow_engine/models/test_action.py
@@ -100,6 +100,7 @@ class TestAction(TestCase):
             mock_incr.assert_called_once_with(
                 "workflow_engine.action.trigger",
                 tags={"action_type": self.action.type, "detector_type": self.mock_detector.type},
+                sample_rate=1.0,
             )
 
     def test_config_schema(self) -> None:

--- a/tests/sentry/workflow_engine/test_task.py
+++ b/tests/sentry/workflow_engine/test_task.py
@@ -239,4 +239,5 @@ class TestProcessWorkflowActivity(TestCase):
             mock_incr.assert_any_call(
                 "workflow_engine.tasks.process_workflows.activity_update.executed",
                 tags={"activity_type": self.activity.type},
+                sample_rate=1.0,
             )


### PR DESCRIPTION
some metrics have a sample rate of 100% while others don't. lets make sure everything in the critical path is sampled at 100%