### PR TITLE
fix(dashboards): add check for updating transaction widget vs creating new one

### DIFF
--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -376,15 +376,6 @@ class DashboardWidgetSerializer(CamelSnakeSerializer[Dashboard]):
             raise serializers.ValidationError(
                 "Attribute value `discover` is deprecated. Please use `error-events` or `transaction-like`"
             )
-        if (
-            features.has(
-                "organizations:discover-saved-queries-deprecation", self.context["organization"]
-            )
-            and widget_type == DashboardWidgetTypes.TRANSACTION_LIKE
-        ):
-            raise serializers.ValidationError(
-                "The transactions dataset is being deprecated. Please use the spans dataset with the `is_transaction:true` filter instead."
-            )
         return widget_type
 
     validate_id = validate_id
@@ -423,6 +414,21 @@ class DashboardWidgetSerializer(CamelSnakeSerializer[Dashboard]):
         ondemand_feature = features.has(
             "organizations:on-demand-metrics-extraction-widgets", organization
         )
+
+        if (
+            features.has(
+                "organizations:discover-saved-queries-deprecation",
+                self.context["organization"],
+                actor=self.context["request"].user,
+            )
+            and not data.get("id")
+            and data.get("widget_type") == DashboardWidgetTypes.TRANSACTION_LIKE
+        ):
+            raise serializers.ValidationError(
+                {
+                    "widget_type": "The transactions dataset is being deprecated. Please use the spans dataset with the `is_transaction:true` filter instead."
+                }
+            )
 
         if data.get("queries"):
             # Check each query to see if they have an issue or discover error depending on the type of the widget

--- a/tests/sentry/api/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_details.py
@@ -2693,6 +2693,55 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
                 == "The transactions dataset is being deprecated. Please use the spans dataset with the `is_transaction:true` filter instead."
             )
 
+    def test_dashboard_exisiting_transaction_widget_deprecation_with_flag(self) -> None:
+        with self.feature("organizations:discover-saved-queries-deprecation"):
+            data = {
+                "title": "Test Dashboard",
+                "widgets": [
+                    {
+                        "id": self.widget_1.id,
+                        "title": "Transaction Widget",
+                        "displayType": "table",
+                        "widgetType": DashboardWidgetTypes.get_type_name(
+                            DashboardWidgetTypes.TRANSACTION_LIKE
+                        ),
+                        "queries": [
+                            {
+                                "name": "Transaction Widget",
+                                "fields": ["count()"],
+                                "aggregates": ["count()"],
+                                "conditions": "",
+                                "orderby": "-count()",
+                                "columns": [],
+                                "fieldAliases": [],
+                            }
+                        ],
+                    },
+                    {
+                        "title": "Error Widget",
+                        "displayType": "table",
+                        "widgetType": DashboardWidgetTypes.get_type_name(
+                            DashboardWidgetTypes.ERROR_EVENTS
+                        ),
+                        "queries": [
+                            {
+                                "name": "Error Widget",
+                                "fields": ["count()"],
+                                "aggregates": ["count()"],
+                                "conditions": "",
+                                "orderby": "-count()",
+                                "columns": [],
+                                "fieldAliases": [],
+                            }
+                        ],
+                    },
+                ],
+            }
+            # should be able to add widget to dashboard with existing transaction widgets
+
+            response = self.do_request("put", self.url(self.dashboard.id), data=data)
+            assert response.status_code == 200
+
 
 class OrganizationDashboardDetailsOnDemandTest(OrganizationDashboardDetailsTestCase):
     widget_type = DashboardWidgetTypes.TRANSACTION_LIKE

--- a/tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py
@@ -1352,7 +1352,7 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
         )
         assert response.status_code == 200, response.data
 
-    def test_valid_widget_type_with_transactions_deprecation_flag(self) -> None:
+    def test_new_transactions_widget_with_transactions_deprecation_flag(self) -> None:
         with self.feature("organizations:discover-saved-queries-deprecation"):
             data = {
                 "title": "Test Query",
@@ -1379,3 +1379,29 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
                 response.data["widgetType"][0]
                 == "The transactions dataset is being deprecated. Please use the spans dataset with the `is_transaction:true` filter instead."
             )
+
+    def test_update_transaction_widget_type_with_transactions_deprecation_flag(self) -> None:
+        with self.feature("organizations:discover-saved-queries-deprecation"):
+            data = {
+                "id": "1234",
+                "title": "Test Query",
+                "widgetType": "transaction-like",
+                "displayType": "table",
+                "queries": [
+                    {
+                        "name": "transaction query",
+                        "conditions": "",
+                        "fields": ["count()"],
+                        "columns": [],
+                        "aggregates": ["count()"],
+                    }
+                ],
+            }
+
+            response = self.do_request(
+                "post",
+                self.url(),
+                data=data,
+            )
+            # we need to allow updates to the title of existing transaction widgets
+            assert response.status_code == 200, response.data


### PR DESCRIPTION
If you were adding a widget with a dashboard with a transaction widget, the deprecation flag would not allow you to because there was a transaction widget on the dashboard. I've updated it to look for an ID when spewing the validation error so that existing transaction widgets could be updated (like the title) and new widgets could be added on a dashboard successfully. 
