### PR TITLE
feat(aci): add bulk delete workflow endpoint

### DIFF
--- a/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
@@ -282,4 +282,4 @@ class OrganizationWorkflowIndexEndpoint(OrganizationEndpoint):
                 )
             queryset.update(status=ObjectStatus.PENDING_DELETION)
 
-        return Response(status=204)
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
@@ -30,6 +30,7 @@ from sentry.apidocs.constants import (
 from sentry.apidocs.parameters import GlobalParams, OrganizationParams, WorkflowParams
 from sentry.constants import ObjectStatus
 from sentry.deletions.models.scheduleddeletion import RegionScheduledDeletion
+from sentry.models.organization import Organization
 from sentry.utils.audit import create_audit_entry
 from sentry.utils.dates import ensure_aware
 from sentry.workflow_engine.endpoints.serializers import WorkflowSerializer
@@ -85,7 +86,7 @@ class OrganizationWorkflowIndexEndpoint(OrganizationEndpoint):
     }
     owner = ApiOwner.ISSUES
 
-    def filter_workflows(self, request: Request, organization):
+    def filter_workflows(self, request: Request, organization: Organization) -> QuerySet[Workflow]:
         """
         Helper function to filter workflows based on request parameters.
         """
@@ -257,8 +258,8 @@ class OrganizationWorkflowIndexEndpoint(OrganizationEndpoint):
         if not (
             request.GET.getlist("id")
             or request.GET.get("query")
-            or request.GET.get("project")
-            or request.GET.get("projectSlug")
+            or request.GET.getlist("project")
+            or request.GET.getlist("projectSlug")
         ):
             return Response(
                 {

--- a/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
@@ -255,7 +255,7 @@ class OrganizationWorkflowIndexEndpoint(OrganizationEndpoint):
         Deletes workflows for a given org
         """
         projects = self.get_projects(request, organization)
-        if not (request.GET.get("id") or request.GET.get("query") or projects):
+        if not (request.GET.getlist("id") or request.GET.get("query") or projects):
             return Response(
                 {"detail": "At least one of 'id', 'query', or 'project' must be provided."},
                 status=status.HTTP_400_BAD_REQUEST,

--- a/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
@@ -239,7 +239,7 @@ class OrganizationWorkflowIndexEndpoint(OrganizationEndpoint):
         return Response(serialize(workflow, request.user), status=status.HTTP_201_CREATED)
 
     @extend_schema(
-        operation_id="Bulk Delete an Organization's Workflows",
+        operation_id="Delete an Organization's Workflows",
         parameters=[
             GlobalParams.ORG_ID_OR_SLUG,
         ],


### PR DESCRIPTION
this workflow DELETE endpoint deletes all workflows that match the specified query. some sort of filtering is required, to prevent a user from deleting all workflows for an org. if a list of ids is provided, all other filtering is ignored.

moved filtering logic from workflow GET into a helper function that can be shared between GET and DELETE