### PR TITLE
fix(aci): Limit lastTriggered to single-written history

### DIFF
--- a/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
@@ -160,7 +160,11 @@ class OrganizationWorkflowIndexEndpoint(OrganizationEndpoint):
                 # the annotated value isn't returned in the results.
                 long_ago = ensure_aware(datetime(1970, 1, 1))
                 queryset = queryset.annotate(
-                    last_triggered=Max(Coalesce("workflowfirehistory__date_added", long_ago)),
+                    last_triggered=Max(
+                        Coalesce("workflowfirehistory__date_added", long_ago),
+                        filter=Q(workflowfirehistory__is_single_written=True)
+                        | Q(workflowfirehistory__isnull=True),
+                    ),
                 )
 
         queryset = queryset.order_by(*sort_by.db_order_by)

--- a/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
@@ -160,10 +160,12 @@ class OrganizationWorkflowIndexEndpoint(OrganizationEndpoint):
                 # the annotated value isn't returned in the results.
                 long_ago = ensure_aware(datetime(1970, 1, 1))
                 queryset = queryset.annotate(
-                    last_triggered=Max(
-                        Coalesce("workflowfirehistory__date_added", long_ago),
-                        filter=Q(workflowfirehistory__is_single_written=True)
-                        | Q(workflowfirehistory__isnull=True),
+                    last_triggered=Coalesce(
+                        Max(
+                            "workflowfirehistory__date_added",
+                            filter=Q(workflowfirehistory__is_single_written=True),
+                        ),
+                        long_ago,
                     ),
                 )
 

--- a/src/sentry/workflow_engine/endpoints/serializers.py
+++ b/src/sentry/workflow_engine/endpoints/serializers.py
@@ -402,6 +402,7 @@ class WorkflowSerializer(Serializer):
         last_triggered_map: dict[int, datetime] = dict(
             WorkflowFireHistory.objects.filter(
                 workflow__in=item_list,
+                is_single_written=True,
             )
             .values("workflow_id")
             .annotate(last_triggered=Max("date_added"))

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
@@ -337,6 +337,53 @@ class OrganizationWorkflowIndexBaseTest(OrganizationWorkflowAPITestCase):
         assert len(response3.data) == 2
         assert {self.workflow.name, self.workflow_two.name} == {w["name"] for w in response3.data}
 
+    def test_sort_by_last_triggered_with_non_single_written_only(self) -> None:
+        workflow_never_fired = self.create_workflow(
+            organization_id=self.organization.id, name="Never Fired"
+        )
+
+        workflow_non_single_written_only = self.create_workflow(
+            organization_id=self.organization.id, name="Non Single Written Only"
+        )
+        WorkflowFireHistory.objects.create(
+            workflow=workflow_non_single_written_only,
+            group=self.group,
+            event_id=self.event.event_id,
+            is_single_written=False,
+        )
+
+        # Test ascending order (lastTriggered)
+        response = self.get_success_response(
+            self.organization.slug, qs_params={"sortBy": "lastTriggered"}
+        )
+
+        # Workflows without single-written history should come first, then those with it
+        expected_ascending_order = [
+            self.workflow_three.name,
+            workflow_never_fired.name,
+            workflow_non_single_written_only.name,
+            self.workflow.name,
+            self.workflow_two.name,
+        ]
+
+        assert [w["name"] for w in response.data] == expected_ascending_order
+
+        # Test descending order (-lastTriggered)
+        response_desc = self.get_success_response(
+            self.organization.slug, qs_params={"sortBy": "-lastTriggered"}
+        )
+
+        # In descending order, workflows with single-written history should come first
+        expected_descending_order = [
+            self.workflow_two.name,
+            self.workflow.name,
+            workflow_non_single_written_only.name,
+            workflow_never_fired.name,
+            self.workflow_three.name,
+        ]
+
+        assert [w["name"] for w in response_desc.data] == expected_descending_order
+
     def test_compound_query(self) -> None:
         self.create_detector_workflow(
             workflow=self.workflow, detector=self.create_detector(project=self.project)

--- a/tests/sentry/workflow_engine/endpoints/test_serializers.py
+++ b/tests/sentry/workflow_engine/endpoints/test_serializers.py
@@ -462,6 +462,7 @@ class TestWorkflowSerializer(TestCase):
             workflow=workflow,
             group=self.group,
             event_id=self.event.event_id,
+            is_single_written=True,
         )
         history.date_added = workflow.date_added + timedelta(seconds=1)
         history.save()

--- a/tests/sentry/workflow_engine/endpoints/test_serializers.py
+++ b/tests/sentry/workflow_engine/endpoints/test_serializers.py
@@ -450,11 +450,14 @@ class TestWorkflowSerializer(TestCase):
             detector=detector,
             workflow=workflow,
         )
+
         history = WorkflowFireHistory.objects.create(
             workflow=workflow,
             group=self.group,
             event_id=self.event.event_id,
+            is_single_written=True,
         )
+        # Too old, shouldn't be used.
         WorkflowFireHistory.objects.create(
             workflow=workflow,
             group=self.group,
@@ -462,6 +465,15 @@ class TestWorkflowSerializer(TestCase):
         )
         history.date_added = workflow.date_added + timedelta(seconds=1)
         history.save()
+        # Dual written, shouldn't be used.
+        dual_written_history = WorkflowFireHistory.objects.create(
+            workflow=workflow,
+            group=self.group,
+            event_id=self.event.event_id,
+            is_single_written=False,
+        )
+        dual_written_history.date_added = workflow.date_added + timedelta(seconds=2)
+        dual_written_history.save()
 
         result = serialize(workflow)
 


### PR DESCRIPTION
Dual-written WorkflowActionHistory records are non-canonical, and shouldn't be included in results.

