### PR TITLE
fix(summaries): Make schedule_organizations retry on timeout; increase timeout

### DIFF
--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -51,6 +51,7 @@ from sentry.utils.email import MessageBuilder
 from sentry.utils.outcomes import Outcome
 from sentry.utils.query import RangeQuerySetWrapper
 from sentry.utils.snuba import parse_snuba_datetime
+from sentry.workflow_engine.tasks.utils import retry_timeouts
 
 date_format = partial(dateformat.format, format_string="F jS, Y")
 
@@ -67,9 +68,10 @@ logger = logging.getLogger(__name__)
     taskworker_config=TaskworkerConfig(
         namespace=reports_tasks,
         retry=Retry(times=5),
-        processing_deadline_duration=timedelta(minutes=10),
+        processing_deadline_duration=timedelta(minutes=15),
     ),
 )
+@retry_timeouts
 @retry
 def schedule_organizations(
     dry_run: bool = False, timestamp: float | None = None, duration: int | None = None

--- a/src/sentry/workflow_engine/tasks/utils.py
+++ b/src/sentry/workflow_engine/tasks/utils.py
@@ -93,6 +93,8 @@ def retry_timeouts(func):
     """
     Schedule a task retry if the function raises ProcessingDeadlineExceeded.
     This exists because the standard retry decorator doesn't allow BaseExceptions.
+
+    TODO: This should be part of the standard retry config/decorator.
     """
 
     @wraps(func)


### PR DESCRIPTION
Since the migration to taskbroker, this task has been timing out every week, and taskbroker timeouts aren't covered by `@retry`, so we haven't been retrying and resuming as intended.
This returns to the intended retry model.
This also extends the timeout, because ideally we wouldn't be abruptly forced to retry.