### PR TITLE
feat(deletions): Task for deleting nodestore events

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -488,6 +488,7 @@ module = [
     "tests.sentry.data_secrecy.*",
     "tests.sentry.debug.*",
     "tests.sentry.deletions.tasks.test_groups",
+    "tests.sentry.deletions.tasks.test_nodestore",
     "tests.sentry.deletions.test_group",
     "tests.sentry.digests.backends.*",
     "tests.sentry.dynamic_sampling.rules.biases.snapshots.*",

--- a/src/sentry/deletions/defaults/group.py
+++ b/src/sentry/deletions/defaults/group.py
@@ -9,7 +9,8 @@ from typing import Any
 from sentry_sdk import set_tag
 from snuba_sdk import DeleteQuery, Request
 
-from sentry import eventstore, eventstream, models, nodestore
+from sentry import eventstream, models
+from sentry.deletions.tasks.nodestore import delete_events_for_groups_from_nodestore
 from sentry.eventstore.models import Event
 from sentry.issues.grouptype import GroupCategory, InvalidGroupTypeError
 from sentry.models.group import Group, GroupStatus
@@ -93,32 +94,6 @@ class EventsBaseDeletionTask(BaseDeletionTask[Group]):
         self.group_ids = group_ids
         self.project_ids = list(self.project_groups.keys())
 
-    def get_unfetched_events(self) -> list[Event]:
-        conditions = []
-        if self.last_event is not None:
-            conditions.extend(
-                [
-                    ["timestamp", "<=", self.last_event.timestamp],
-                    [
-                        ["timestamp", "<", self.last_event.timestamp],
-                        ["event_id", "<", self.last_event.event_id],
-                    ],
-                ]
-            )
-
-        logger.info("Fetching %s events for deletion.", self.DEFAULT_CHUNK_SIZE)
-        events = eventstore.backend.get_unfetched_events(
-            filter=eventstore.Filter(
-                conditions=conditions, project_ids=self.project_ids, group_ids=self.group_ids
-            ),
-            limit=self.DEFAULT_CHUNK_SIZE,
-            referrer=self.referrer,
-            orderby=["-timestamp", "-event_id"],
-            tenant_ids=self.tenant_ids,
-            dataset=self.dataset,
-        )
-        return events
-
     @property
     def tenant_ids(self) -> Mapping[str, Any]:
         result = {"referrer": self.referrer}
@@ -126,44 +101,27 @@ class EventsBaseDeletionTask(BaseDeletionTask[Group]):
             result["organization_id"] = self.groups[0].project.organization_id
         return result
 
-    def chunk(self) -> bool:
-        """This method is called to delete chunks of data. It returns a boolean to say
-        if the deletion has completed and if it needs to be called again."""
-        events = self.get_unfetched_events()
-        if events:
-            # Adding this variable to see the values in stack traces
-            last_event = events[-1]
-            self.delete_events_from_nodestore(events)
-            # This value will be used in the next call to chunk
-            self.last_event = last_event
-            # As long as it returns True the task will keep iterating
-            return True
-        else:
-            # Now that all events have been deleted from the eventstore, we can delete the events from snuba
-            self.delete_events_from_snuba()
-            return False
+    def delete_events_from_nodestore(self) -> None:
+        """Schedule asynchronous deletion of events from the nodestore for all groups."""
+        if not self.group_ids:
+            return
 
-    def delete_events_from_nodestore(self, events: Sequence[Event]) -> None:
-        # We delete by the occurrence_id instead of the event_id
-        node_ids = [
-            Event.generate_node_id(
-                event.project_id,
-                (
-                    event._snuba_data["occurrence_id"]
-                    if self.dataset == Dataset.IssuePlatform
-                    else event.event_id
-                ),
+        # Get organization_id from the first group
+        organization_id = self.groups[0].project.organization_id
+
+        # Schedule nodestore deletion task for each project
+        for project_id, groups in self.project_groups.items():
+            group_ids = [group.id for group in groups]
+            delete_events_for_groups_from_nodestore.apply_async(
+                kwargs={
+                    "organization_id": organization_id,
+                    "project_id": project_id,
+                    "group_ids": group_ids,
+                    "transaction_id": self.transaction_id,
+                    "dataset_str": self.dataset.value,
+                    "referrer": self.referrer,
+                },
             )
-            for event in events
-        ]
-        nodestore.backend.delete_multi(node_ids)
-        self.post_delete_events_from_nodestore(events)
-
-    def post_delete_events_from_nodestore(self, events: Sequence[Event]) -> None:
-        pass
-
-    def delete_events_from_snuba(self) -> None:
-        raise NotImplementedError
 
 
 class ErrorEventsDeletionTask(EventsBaseDeletionTask):
@@ -175,20 +133,12 @@ class ErrorEventsDeletionTask(EventsBaseDeletionTask):
 
     dataset = Dataset.Events
 
-    def post_delete_events_from_nodestore(self, events: Sequence[Event]) -> None:
-        self.delete_dangling_attachments_and_user_reports(events)
-
-    def delete_dangling_attachments_and_user_reports(self, events: Sequence[Event]) -> None:
-        # Remove EventAttachment and UserReport *again* as those may not have a
-        # group ID, therefore there may be dangling ones after "regular" model
-        # deletion.
-        event_ids = [event.event_id for event in events]
-        models.EventAttachment.objects.filter(
-            event_id__in=event_ids, project_id__in=self.project_ids
-        ).delete()
-        models.UserReport.objects.filter(
-            event_id__in=event_ids, project_id__in=self.project_ids
-        ).delete()
+    def chunk(self) -> bool:
+        """This method is called to delete chunks of data. It returns a boolean to say
+        if the deletion has completed and if it needs to be called again."""
+        self.delete_events_from_nodestore()
+        self.delete_events_from_snuba()
+        return False
 
     def delete_events_from_snuba(self) -> None:
         # Remove all group events now that their node data has been removed.
@@ -205,6 +155,13 @@ class IssuePlatformEventsDeletionTask(EventsBaseDeletionTask):
 
     dataset = Dataset.IssuePlatform
     max_rows_to_delete = ISSUE_PLATFORM_MAX_ROWS_TO_DELETE
+
+    def chunk(self) -> bool:
+        """This method is called to delete chunks of data. It returns a boolean to say
+        if the deletion has completed and if it needs to be called again."""
+        self.delete_events_from_nodestore()
+        self.delete_events_from_snuba()
+        return False
 
     def delete_events_from_snuba(self) -> None:
         requests = []

--- a/src/sentry/deletions/tasks/nodestore.py
+++ b/src/sentry/deletions/tasks/nodestore.py
@@ -118,6 +118,8 @@ def delete_events_for_groups_from_nodestore(
 
 
 class NodestoreDeletionTask:
+    DEFAULT_CHUNK_SIZE = EVENT_CHUNK_SIZE
+
     def __init__(
         self,
         organization_id: int,
@@ -158,21 +160,24 @@ class NodestoreDeletionTask:
             referrer=self.referrer,
             dataset=self.dataset,
             tenant_ids=self.tenant_ids,
+            limit=self.DEFAULT_CHUNK_SIZE,
             last_event_id=last_event_id,
             last_event_timestamp=last_event_timestamp,
         )
 
 
 def _fetch_events(
+    *,
     group_ids: Sequence[int],
     project_id: int,
     referrer: str,
     dataset: Dataset,
     tenant_ids: Mapping[str, Any],
+    limit: int = EVENT_CHUNK_SIZE,
     last_event_id: str | None = None,
     last_event_timestamp: str | None = None,
 ) -> list[Event]:
-    logger.info("Fetching %s events for deletion.", EVENT_CHUNK_SIZE)
+    logger.info("Fetching %s events for deletion.", limit)
     conditions = []
     if last_event_id and last_event_timestamp:
         conditions.extend(
@@ -188,7 +193,7 @@ def _fetch_events(
             project_ids=[project_id],
             group_ids=group_ids,
         ),
-        limit=EVENT_CHUNK_SIZE,
+        limit=limit,
         referrer=referrer,
         orderby=["-timestamp", "-event_id"],
         tenant_ids=tenant_ids,

--- a/src/sentry/deletions/tasks/nodestore.py
+++ b/src/sentry/deletions/tasks/nodestore.py
@@ -76,7 +76,7 @@ def delete_events_for_groups_from_nodestore(
         "project_id": project_id,
         "group_ids": group_ids,
         "transaction_id": transaction_id,
-        "dataset": Dataset(dataset_str),
+        "dataset_str": dataset_str,
         "referrer": referrer,
     }
 
@@ -90,7 +90,10 @@ def delete_events_for_groups_from_nodestore(
     try:
         # Fetch events for deletion
         events = fetch_events(
-            **kwargs_to_schedule_next_task,
+            project_id=project_id,
+            group_ids=group_ids,
+            dataset=Dataset(dataset_str),
+            referrer=referrer,
             tenant_ids={"referrer": referrer, "organization_id": organization_id},
             limit=EVENT_CHUNK_SIZE,
             last_event_id=last_event_id,

--- a/src/sentry/deletions/tasks/nodestore.py
+++ b/src/sentry/deletions/tasks/nodestore.py
@@ -70,15 +70,14 @@ def delete_events_for_groups_from_nodestore(
     if not group_ids:
         raise DeleteAborted("delete_events_from_nodestore.empty_group_ids")
 
-    args_to_schedule_next_task = [
-        organization_id,
-        project_id,
-        group_ids,
-        transaction_id,
-        dataset_str,
-        referrer,
-    ]
-    dataset = Dataset(dataset_str)
+    kwargs_to_schedule_next_task = {
+        "organization_id": organization_id,
+        "project_id": project_id,
+        "group_ids": group_ids,
+        "transaction_id": transaction_id,
+        "dataset": Dataset(dataset_str),
+        "referrer": referrer,
+    }
 
     # These can be used for debugging
     extra = {"project_id": project_id, "transaction_id": transaction_id}
@@ -86,24 +85,23 @@ def delete_events_for_groups_from_nodestore(
     logger.info("deletions.nodestore.started", extra=extra)
     project = Project.objects.get(id=project_id)
     assert project.organization_id == organization_id
-    task = NodestoreDeletionTask(
-        organization_id=organization_id,
-        project_id=project_id,
-        group_ids=group_ids,
-        dataset=dataset,
-        referrer=referrer,
-    )
 
     try:
         # Fetch events for deletion
-        events = task.fetch_events(last_event_id, last_event_timestamp)
+        events = fetch_events(
+            **kwargs_to_schedule_next_task,
+            tenant_ids={"referrer": referrer, "organization_id": organization_id},
+            limit=EVENT_CHUNK_SIZE,
+            last_event_id=last_event_id,
+            last_event_timestamp=last_event_timestamp,
+        )
         if len(events) > 0:
             last_event = events[-1]
-            _delete_events_from_nodestore(events=events, extra=extra)
-            _delete_dangling_attachments_and_user_reports(events, [project_id])
+            delete_events_from_nodestore(events=events, extra=extra)
+            delete_dangling_attachments_and_user_reports(events, [project_id])
             delete_events_for_groups_from_nodestore.apply_async(
-                args=args_to_schedule_next_task,
                 kwargs={
+                    **kwargs_to_schedule_next_task,
                     "last_event_id": last_event.event_id,
                     "last_event_timestamp": last_event.timestamp,
                 },
@@ -117,65 +115,17 @@ def delete_events_for_groups_from_nodestore(
         raise
 
 
-class NodestoreDeletionTask:
-    DEFAULT_CHUNK_SIZE = EVENT_CHUNK_SIZE
-
-    def __init__(
-        self,
-        organization_id: int,
-        project_id: int,
-        group_ids: Sequence[int],
-        dataset: Dataset,
-        referrer: str,
-    ):
-        """
-        Initialize the NodestoreDeletionTask.
-
-        Args:
-            organization_id: Organization ID for tenant context
-            project_id: Project ID that all groups belong to
-            group_ids: List of group IDs to delete events for
-            dataset: Dataset to delete events from
-            referrer: Referrer for the task
-        """
-        self.organization_id = organization_id
-        self.project_id = project_id
-        self.group_ids = group_ids
-        self.dataset = dataset
-        self.referrer = referrer
-
-    @property
-    def tenant_ids(self) -> Mapping[str, Any]:
-        return {"referrer": self.referrer, "organization_id": self.organization_id}
-
-    def fetch_events(
-        self,
-        last_event_id: str | None = None,
-        last_event_timestamp: str | None = None,
-    ) -> list[Event]:
-        """Fetch error events for the given groups."""
-        return _fetch_events(
-            group_ids=self.group_ids,
-            project_id=self.project_id,
-            referrer=self.referrer,
-            dataset=self.dataset,
-            tenant_ids=self.tenant_ids,
-            limit=self.DEFAULT_CHUNK_SIZE,
-            last_event_id=last_event_id,
-            last_event_timestamp=last_event_timestamp,
-        )
-
-
-def _fetch_events(
+def fetch_events(
     *,
-    group_ids: Sequence[int],
     project_id: int,
-    referrer: str,
+    group_ids: Sequence[int],
     dataset: Dataset,
+    referrer: str,
     tenant_ids: Mapping[str, Any],
     limit: int = EVENT_CHUNK_SIZE,
     last_event_id: str | None = None,
     last_event_timestamp: str | None = None,
+    **kwargs: Any,
 ) -> list[Event]:
     logger.info("Fetching %s events for deletion.", limit)
     conditions = []
@@ -202,18 +152,20 @@ def _fetch_events(
     return events
 
 
-def _delete_events_from_nodestore(events: Sequence[Event], extra: dict[str, Any]) -> None:
+def delete_events_from_nodestore(events: Sequence[Event], extra: dict[str, Any]) -> None:
     node_ids = [Event.generate_node_id(event.project_id, event.event_id) for event in events]
-    nodestore.backend.delete_multi(node_ids)
-    logger.info("deletions.nodestore.chunk_completed", extra=extra)
-    metrics.incr(
-        "deletions.nodestore.delete_events_from_nodestore.chunk_success",
-        len(node_ids),
-        sample_rate=1,
-    )
+    prefix = "deletions.nodestore"
+    outcome = "success"
+    try:
+        nodestore.backend.delete_multi(node_ids)
+    except Exception:
+        outcome = "error"
+        logger.warning(f"{prefix}.error", extra=extra, exc_info=True)
+    logger.info(f"{prefix}.outcome", extra=extra)
+    metrics.incr(f"{prefix}.outcome", tags={"outcome": outcome}, sample_rate=1)
 
 
-def _delete_dangling_attachments_and_user_reports(
+def delete_dangling_attachments_and_user_reports(
     events: Sequence[Event], project_ids: Sequence[int]
 ) -> None:
     """

--- a/src/sentry/deletions/tasks/nodestore.py
+++ b/src/sentry/deletions/tasks/nodestore.py
@@ -119,7 +119,7 @@ def delete_events_for_groups_from_nodestore_and_eventstore(
             )
         else:
             logger.info(f"{prefix}.completed", extra=extra)
-            groups = Group.objects.filter(id__in=group_ids)
+            groups = list(Group.objects.filter(id__in=group_ids))
             # The fetch request for the nodestore uses the eventstore to determine what IDs to delete
             # from the nodestore. This is why we only delete from the eventstore once we've deleted
             # from the nodestore.

--- a/src/sentry/deletions/tasks/nodestore.py
+++ b/src/sentry/deletions/tasks/nodestore.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import sentry_sdk
+
+from sentry import eventstore, nodestore
+from sentry.deletions.tasks.scheduled import MAX_RETRIES, logger
+from sentry.eventstore.models import Event
+from sentry.exceptions import DeleteAborted
+from sentry.models.eventattachment import EventAttachment
+from sentry.models.project import Project
+from sentry.models.userreport import UserReport
+from sentry.silo.base import SiloMode
+from sentry.snuba.dataset import Dataset
+from sentry.tasks.base import instrumented_task, retry, track_group_async_operation
+from sentry.taskworker.config import TaskworkerConfig
+from sentry.taskworker.namespaces import deletion_tasks
+from sentry.taskworker.retry import Retry
+from sentry.utils import metrics
+
+# Chunk size for fetching events
+EVENT_CHUNK_SIZE = 10000
+
+
+@instrumented_task(
+    name="sentry.deletions.tasks.nodestore.delete_events_from_nodestore",
+    queue="cleanup",
+    default_retry_delay=60 * 5,
+    max_retries=MAX_RETRIES,
+    acks_late=True,
+    silo_mode=SiloMode.REGION,
+    taskworker_config=TaskworkerConfig(
+        namespace=deletion_tasks,
+        retry=Retry(
+            times=MAX_RETRIES,
+            delay=60 * 5,
+        ),
+    ),
+)
+@retry(exclude=(DeleteAborted,))
+@track_group_async_operation
+def delete_events_for_groups_from_nodestore(
+    organization_id: int,
+    project_id: int,
+    group_ids: Sequence[int],
+    transaction_id: str,
+    dataset_str: str,
+    referrer: str,
+    last_event_id: str | None = None,
+    last_event_timestamp: str | None = None,
+    **kwargs: Any,
+) -> None:
+    """
+    Delete error events from nodestore by fetching and processing events in chunks.
+
+    This task fetches events for the given groups and deletes them from nodestore.
+    It processes events in chunks and can be called recursively to handle large numbers of events.
+
+    Args:
+        organization_id:        Organization ID for tenant context
+        project_id:             Project ID that all groups belong to
+        group_ids:              List of group IDs to delete events for
+        transaction_id:         Unique identifier to help debug deletion tasks
+        dataset:                Dataset to delete events from
+        referrer:               Referrer for the task
+        last_event_id:          Event ID of the last processed event (for pagination)
+        last_event_timestamp:   Timestamp of the last processed event (for pagination)
+    """
+    if not group_ids:
+        raise DeleteAborted("delete_events_from_nodestore.empty_group_ids")
+
+    args_to_schedule_next_task = [
+        organization_id,
+        project_id,
+        group_ids,
+        transaction_id,
+        dataset_str,
+        referrer,
+    ]
+    dataset = Dataset(dataset_str)
+
+    # These can be used for debugging
+    extra = {"project_id": project_id, "transaction_id": transaction_id}
+    sentry_sdk.set_tags(extra)
+    logger.info("deletions.nodestore.started", extra=extra)
+    project = Project.objects.get(id=project_id)
+    assert project.organization_id == organization_id
+    task = NodestoreDeletionTask(
+        organization_id=organization_id,
+        project_id=project_id,
+        group_ids=group_ids,
+        dataset=dataset,
+        referrer=referrer,
+    )
+
+    try:
+        # Fetch events for deletion
+        events = task.fetch_events(last_event_id, last_event_timestamp)
+        if len(events) > 0:
+            last_event = events[-1]
+            _delete_events_from_nodestore(events=events, extra=extra)
+            _delete_dangling_attachments_and_user_reports(events, [project_id])
+            delete_events_for_groups_from_nodestore.apply_async(
+                args=args_to_schedule_next_task,
+                kwargs={
+                    "last_event_id": last_event.event_id,
+                    "last_event_timestamp": last_event.timestamp,
+                },
+            )
+        else:
+            logger.info("deletions.nodestore.completed", extra=extra)
+
+    except Exception:
+        metrics.incr("deletions.nodestore.delete_events_from_nodestore.error", 1, sample_rate=1)
+        logger.warning("deletions.nodestore.failed", extra=extra)
+        raise
+
+
+class NodestoreDeletionTask:
+    def __init__(
+        self,
+        organization_id: int,
+        project_id: int,
+        group_ids: Sequence[int],
+        dataset: Dataset,
+        referrer: str,
+    ):
+        """
+        Initialize the NodestoreDeletionTask.
+
+        Args:
+            organization_id: Organization ID for tenant context
+            project_id: Project ID that all groups belong to
+            group_ids: List of group IDs to delete events for
+            dataset: Dataset to delete events from
+            referrer: Referrer for the task
+        """
+        self.organization_id = organization_id
+        self.project_id = project_id
+        self.group_ids = group_ids
+        self.dataset = dataset
+        self.referrer = referrer
+
+    @property
+    def tenant_ids(self) -> Mapping[str, Any]:
+        return {"referrer": self.referrer, "organization_id": self.organization_id}
+
+    def fetch_events(
+        self,
+        last_event_id: str | None = None,
+        last_event_timestamp: str | None = None,
+    ) -> list[Event]:
+        """Fetch error events for the given groups."""
+        return _fetch_events(
+            group_ids=self.group_ids,
+            project_id=self.project_id,
+            referrer=self.referrer,
+            dataset=self.dataset,
+            tenant_ids=self.tenant_ids,
+            last_event_id=last_event_id,
+            last_event_timestamp=last_event_timestamp,
+        )
+
+
+def _fetch_events(
+    group_ids: Sequence[int],
+    project_id: int,
+    referrer: str,
+    dataset: Dataset,
+    tenant_ids: Mapping[str, Any],
+    last_event_id: str | None = None,
+    last_event_timestamp: str | None = None,
+) -> list[Event]:
+    conditions = []
+    if last_event_id and last_event_timestamp:
+        conditions.extend(
+            [
+                ["timestamp", "<=", last_event_timestamp],
+                [["timestamp", "<", last_event_timestamp], ["event_id", "<", last_event_id]],
+            ]
+        )
+
+    events = eventstore.backend.get_unfetched_events(
+        filter=eventstore.Filter(
+            conditions=conditions,
+            project_ids=[project_id],
+            group_ids=group_ids,
+        ),
+        limit=EVENT_CHUNK_SIZE,
+        referrer=referrer,
+        orderby=["-timestamp", "-event_id"],
+        tenant_ids=tenant_ids,
+        dataset=dataset,
+    )
+    return events
+
+
+def _delete_events_from_nodestore(events: Sequence[Event], extra: dict[str, Any]) -> None:
+    node_ids = [Event.generate_node_id(event.project_id, event.event_id) for event in events]
+    nodestore.backend.delete_multi(node_ids)
+    logger.info("deletions.nodestore.chunk_completed", extra=extra)
+    metrics.incr(
+        "deletions.nodestore.delete_events_from_nodestore.chunk_success",
+        len(node_ids),
+        sample_rate=1,
+    )
+
+
+def _delete_dangling_attachments_and_user_reports(
+    events: Sequence[Event], project_ids: Sequence[int]
+) -> None:
+    """
+    Remove EventAttachment and UserReport *again* as those may not have a
+    group ID, therefore there may be dangling ones after "regular" model
+    deletion.
+    """
+    event_ids = [event.event_id for event in events]
+    EventAttachment.objects.filter(event_id__in=event_ids, project_id__in=project_ids).delete()
+    UserReport.objects.filter(event_id__in=event_ids, project_id__in=project_ids).delete()

--- a/src/sentry/deletions/tasks/nodestore.py
+++ b/src/sentry/deletions/tasks/nodestore.py
@@ -6,7 +6,6 @@ from typing import Any
 import sentry_sdk
 
 from sentry import eventstore, nodestore
-from sentry.deletions.defaults.group import EVENT_CHUNK_SIZE
 from sentry.deletions.tasks.scheduled import MAX_RETRIES, logger
 from sentry.eventstore.models import Event
 from sentry.exceptions import DeleteAborted
@@ -20,6 +19,8 @@ from sentry.taskworker.config import TaskworkerConfig
 from sentry.taskworker.namespaces import deletion_tasks
 from sentry.taskworker.retry import Retry
 from sentry.utils import metrics
+
+EVENT_CHUNK_SIZE = 10000
 
 
 @instrumented_task(

--- a/src/sentry/deletions/tasks/nodestore.py
+++ b/src/sentry/deletions/tasks/nodestore.py
@@ -96,7 +96,7 @@ def delete_events_for_groups_from_nodestore_and_eventstore(
 
     try:
         # Fetch events for deletion
-        events = fetch_events(
+        events = fetch_events_from_eventstore(
             project_id=project_id,
             group_ids=group_ids,
             dataset=Dataset(dataset_str),
@@ -133,7 +133,7 @@ def delete_events_for_groups_from_nodestore_and_eventstore(
         raise DeleteAborted("Failed to delete events from nodestore. We won't retry this task.")
 
 
-def fetch_events(
+def fetch_events_from_eventstore(
     *,
     project_id: int,
     group_ids: Sequence[int],

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -892,6 +892,13 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Enable sequential deletion of events from nodestore
+register(
+    "deletions.nodestore.parallelization-task-enabled",
+    default=False,
+    type=Bool,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 register(
     "issues.severity.first-event-severity-calculation-projects-allowlist",

--- a/tests/sentry/deletions/tasks/test_groups.py
+++ b/tests/sentry/deletions/tasks/test_groups.py
@@ -81,6 +81,10 @@ class DeleteGroupTest(TestCase):
         events = eventstore.backend.get_events(conditions, tenant_ids=tenant_ids)
         assert len(events) == 0
 
+    def test_simple_with_new_task(self) -> None:
+        with self.options({"deletions.nodestore.parallelization-task-enabled": True}):
+            self.test_simple()
+
     def test_max_chunk_size_calls_once(self) -> None:
         CHUNK_SIZE = 5
         with patch(
@@ -101,6 +105,10 @@ class DeleteGroupTest(TestCase):
 
             assert calls == 1
             assert not Group.objects.filter(id__in=group_ids).exists()
+
+    def test_max_chunk_size_calls_once_with_new_task(self) -> None:
+        with self.options({"deletions.nodestore.parallelization-task-enabled": True}):
+            self.test_max_chunk_size_calls_once()
 
     def test_max_chunk_size_plus_one_calls_twice(self) -> None:
         CHUNK_SIZE = 5
@@ -124,12 +132,20 @@ class DeleteGroupTest(TestCase):
             assert calls == 2
             assert not Group.objects.filter(id__in=group_ids).exists()
 
+    def test_max_chunk_size_plus_one_calls_twice_with_new_task(self) -> None:
+        with self.options({"deletions.nodestore.parallelization-task-enabled": True}):
+            self.test_max_chunk_size_plus_one_calls_twice()
+
     def test_no_object_ids(self) -> None:
         with self.tasks(), pytest.raises(DeleteAborted) as excinfo:
             delete_groups_for_project(
                 object_ids=[], transaction_id=uuid4().hex, project_id=self.project.id
             )
         assert str(excinfo.value) == "delete_groups.empty_object_ids"
+
+    def test_no_object_ids_with_new_task(self) -> None:
+        with self.options({"deletions.nodestore.parallelization-task-enabled": True}):
+            self.test_no_object_ids()
 
     def test_groups_are_already_deleted(self) -> None:
         group = self.create_group()
@@ -140,6 +156,10 @@ class DeleteGroupTest(TestCase):
                 object_ids=[group.id], transaction_id=uuid4().hex, project_id=self.project.id
             )
         assert str(excinfo.value) == "delete_groups.no_groups_found"
+
+    def test_groups_are_already_deleted_with_new_task(self) -> None:
+        with self.options({"deletions.nodestore.parallelization-task-enabled": True}):
+            self.test_groups_are_already_deleted()
 
     def test_prevent_project_groups_mismatch(self) -> None:
         group = self.create_group()
@@ -157,6 +177,10 @@ class DeleteGroupTest(TestCase):
             str(excinfo.value)
             == f"delete_groups.project_id_mismatch: 1 groups don't belong to project {group.project_id}"
         )
+
+    def test_prevent_project_groups_mismatch_with_new_task(self) -> None:
+        with self.options({"deletions.nodestore.parallelization-task-enabled": True}):
+            self.test_prevent_project_groups_mismatch()
 
     def test_scheduled_tasks_with_too_many_groups(self) -> None:
         NEW_CHUNK_SIZE = 2
@@ -176,3 +200,7 @@ class DeleteGroupTest(TestCase):
             str(excinfo.value)
             == f"delete_groups.object_ids_too_large: {len(group_ids)} groups is greater than GROUP_CHUNK_SIZE"
         )
+
+    def test_scheduled_tasks_with_too_many_groups_with_new_task(self) -> None:
+        with self.options({"deletions.nodestore.parallelization-task-enabled": True}):
+            self.test_scheduled_tasks_with_too_many_groups()

--- a/tests/sentry/deletions/tasks/test_nodestore.py
+++ b/tests/sentry/deletions/tasks/test_nodestore.py
@@ -1,6 +1,9 @@
 from uuid import uuid4
 
-from sentry.deletions.tasks.nodestore import delete_events_for_groups_from_nodestore, fetch_events
+from sentry.deletions.tasks.nodestore import (
+    delete_events_for_groups_from_nodestore_and_eventstore,
+    fetch_events,
+)
 from sentry.eventstore.models import Event
 from sentry.snuba.dataset import Dataset
 from sentry.testutils.cases import TestCase
@@ -40,7 +43,7 @@ class NodestoreDeletionTaskTest(TestCase):
         assert len(events) == 5
 
         with self.tasks():
-            delete_events_for_groups_from_nodestore.apply_async(
+            delete_events_for_groups_from_nodestore_and_eventstore.apply_async(
                 kwargs={
                     "organization_id": self.project.organization_id,
                     "project_id": self.project.id,

--- a/tests/sentry/deletions/tasks/test_nodestore.py
+++ b/tests/sentry/deletions/tasks/test_nodestore.py
@@ -1,0 +1,56 @@
+from uuid import uuid4
+
+from sentry.deletions.tasks.nodestore import _fetch_events, delete_events_for_groups_from_nodestore
+from sentry.eventstore.models import Event
+from sentry.snuba.dataset import Dataset
+from sentry.testutils.cases import TestCase
+
+
+class NodestoreDeletionTaskTest(TestCase):
+
+    def create_n_events_with_group(self, n_events: int) -> list[Event]:
+        events = []
+        for _ in range(n_events):
+            event = self.store_event(
+                data={"fingerprint": [uuid4().hex]},
+                project_id=self.project.id,
+            )
+            events.append(event)
+        return events
+
+    def fetch_events(self, group_ids: list[int], dataset: Dataset) -> list[Event]:
+        return _fetch_events(
+            group_ids=group_ids,
+            project_id=self.project.id,
+            referrer="deletions.groups",
+            dataset=dataset,
+            tenant_ids={
+                "referrer": "deletions.groups",
+                "organization_id": self.project.organization_id,
+            },
+        )
+
+    def test_simple_deletion_with_events(self) -> None:
+        """Test nodestore deletion when events are found."""
+        events = self.create_n_events_with_group(n_events=5)
+        group_ids = [event.group_id for event in events if event.group_id is not None]
+
+        # Verify events exist in both eventstore and nodestore before deletion
+        events = self.fetch_events(group_ids, dataset=Dataset.Events)
+        assert len(events) == 5
+
+        with self.tasks():
+            delete_events_for_groups_from_nodestore.apply_async(
+                kwargs={
+                    "organization_id": self.project.organization_id,
+                    "project_id": self.project.id,
+                    "group_ids": group_ids,
+                    "transaction_id": uuid4().hex,
+                    "dataset_str": Dataset.Events.value,
+                    "referrer": "deletions.groups",
+                },
+            )
+
+        # Events should still exist in eventstore/snuba (that's handled by a different task)
+        events_after = self.fetch_events(group_ids, dataset=Dataset.Events)
+        assert len(events_after) == 5

--- a/tests/sentry/deletions/tasks/test_nodestore.py
+++ b/tests/sentry/deletions/tasks/test_nodestore.py
@@ -1,6 +1,6 @@
 from uuid import uuid4
 
-from sentry.deletions.tasks.nodestore import _fetch_events, delete_events_for_groups_from_nodestore
+from sentry.deletions.tasks.nodestore import delete_events_for_groups_from_nodestore, fetch_events
 from sentry.eventstore.models import Event
 from sentry.snuba.dataset import Dataset
 from sentry.testutils.cases import TestCase
@@ -19,7 +19,7 @@ class NodestoreDeletionTaskTest(TestCase):
         return events
 
     def fetch_events(self, group_ids: list[int], dataset: Dataset) -> list[Event]:
-        return _fetch_events(
+        return fetch_events(
             group_ids=group_ids,
             project_id=self.project.id,
             referrer="deletions.groups",

--- a/tests/sentry/deletions/test_group.py
+++ b/tests/sentry/deletions/test_group.py
@@ -254,13 +254,11 @@ class DeleteGroupTest(TestCase, SnubaTestCase):
 class DeleteIssuePlatformTest(TestCase, SnubaTestCase, OccurrenceTestMixin):
     referrer = Referrer.TESTING_TEST.value
 
-    def create_occurrence(self, event: Event, type_id: int) -> tuple[IssueOccurrence, Group]:
+    def create_occurrence(self, type_id: int) -> tuple[IssueOccurrence, Group]:
         occurrence, group_info = self.process_occurrence(
             project_id=self.project.id,
-            event_id=event.event_id,
             type=type_id,
-            # XXX: Is event.data correct?
-            event_data=dict(event.data),
+            event_data={"level": "info"},
         )
         assert group_info is not None
         return occurrence, group_info.group
@@ -310,9 +308,7 @@ class DeleteIssuePlatformTest(TestCase, SnubaTestCase, OccurrenceTestMixin):
         # Create initial error event and occurrence related to it; two different groups will exist
         event = self.store_event(data={}, project_id=self.project.id)
         # XXX: We need a different way of creating occurrences which will insert into the nodestore
-        occurrence_event, issue_platform_group = self.create_occurrence(
-            event, type_id=FeedbackGroup.type_id
-        )
+        occurrence_event, issue_platform_group = self.create_occurrence(FeedbackGroup.type_id)
 
         # Assertions after creation
         assert occurrence_event.id != event.event_id

--- a/tests/sentry/deletions/test_group.py
+++ b/tests/sentry/deletions/test_group.py
@@ -91,6 +91,10 @@ class DeleteGroupTest(TestCase, SnubaTestCase):
         assert nodestore.backend.get(self.keep_node_id), "Does not remove from second group"
         assert Group.objects.filter(id=self.keep_event.group_id).exists()
 
+    def test_simple_with_new_task(self) -> None:
+        with self.options({"deletions.nodestore.parallelization-task-enabled": True}):
+            self.test_simple()
+
     def test_simple_multiple_groups(self) -> None:
         other_event = self.store_event(
             data={"timestamp": before_now(minutes=1).isoformat(), "fingerprint": ["group3"]},
@@ -114,23 +118,9 @@ class DeleteGroupTest(TestCase, SnubaTestCase):
         assert Group.objects.filter(id=self.keep_event.group_id).exists()
         assert nodestore.backend.get(self.keep_node_id)
 
-    def test_simple_multiple_groups_parallel(self) -> None:
+    def test_simple_multiple_groups_with_new_task(self) -> None:
         with self.options({"deletions.nodestore.parallelization-task-enabled": True}):
-            group_ids = [self.event.group.id, self.event2.group.id]
-            with self.tasks():
-                delete_groups_for_project.apply_async(
-                    kwargs={
-                        "object_ids": group_ids,
-                        "transaction_id": uuid4().hex,
-                        "project_id": self.project.id,
-                    },
-                )
-
-            assert not Group.objects.filter(id__in=group_ids).exists()
-            assert not nodestore.backend.get_multi([self.node_id, self.node_id2])
-
-            assert Group.objects.filter(id=self.keep_event.group_id).exists()
-            assert nodestore.backend.get(self.keep_node_id)
+            self.test_simple_multiple_groups()
 
     def test_grouphistory_relation(self) -> None:
         other_event = self.store_event(
@@ -165,6 +155,10 @@ class DeleteGroupTest(TestCase, SnubaTestCase):
         assert GroupHistory.objects.filter(id=other_history_one.id).exists() is False
         assert GroupHistory.objects.filter(id=other_history_two.id).exists() is False
 
+    def test_grouphistory_relation_with_new_task(self) -> None:
+        with self.options({"deletions.nodestore.parallelization-task-enabled": True}):
+            self.test_grouphistory_relation()
+
     @mock.patch("sentry.nodestore.delete_multi")
     def test_cleanup(self, nodestore_delete_multi: mock.Mock) -> None:
         os.environ["_SENTRY_CLEANUP"] = "1"
@@ -181,6 +175,10 @@ class DeleteGroupTest(TestCase, SnubaTestCase):
             assert nodestore_delete_multi.call_count == 0
         finally:
             del os.environ["_SENTRY_CLEANUP"]
+
+    def test_cleanup_with_new_task(self) -> None:
+        with self.options({"deletions.nodestore.parallelization-task-enabled": True}):
+            self.test_cleanup()
 
     @mock.patch(
         "sentry.tasks.delete_seer_grouping_records.delete_seer_grouping_records_by_hash.apply_async"
@@ -223,6 +221,10 @@ class DeleteGroupTest(TestCase, SnubaTestCase):
         assert mock_delete_seer_grouping_records_by_hash_apply_async.call_args[1] == {
             "args": [group.project.id, hashes, 0]
         }
+
+    def test_delete_groups_delete_grouping_records_by_hash_with_new_task(self) -> None:
+        with self.options({"deletions.nodestore.parallelization-task-enabled": True}):
+            self.test_delete_groups_delete_grouping_records_by_hash()
 
     @mock.patch(
         "sentry.tasks.delete_seer_grouping_records.delete_seer_grouping_records_by_hash.apply_async"
@@ -271,6 +273,10 @@ class DeleteGroupTest(TestCase, SnubaTestCase):
             assert mock_delete_seer_grouping_records_by_hash_apply_async.call_args[1] == {
                 "args": [self.project.id, error_group_hashes, 0]
             }
+
+    def test_invalid_group_type_handling_with_new_task(self) -> None:
+        with self.options({"deletions.nodestore.parallelization-task-enabled": True}):
+            self.test_invalid_group_type_handling()
 
 
 class DeleteIssuePlatformTest(TestCase, SnubaTestCase, OccurrenceTestMixin):
@@ -379,11 +385,60 @@ class DeleteIssuePlatformTest(TestCase, SnubaTestCase, OccurrenceTestMixin):
         # assert not nodestore.backend.get(occurrence_node_id)
         assert self.select_issue_platform_events(self.project.id) is None
 
+    def test_simple_issue_platform_with_new_task(self) -> None:
+        with self.options({"deletions.nodestore.parallelization-task-enabled": True}):
+            self.test_simple_issue_platform()
+
     @mock.patch("sentry.deletions.defaults.group.bulk_snuba_queries")
     def test_issue_platform_batching(self, mock_bulk_snuba_queries: mock.Mock) -> None:
         # Patch max_rows_to_delete to a small value for testing
         with mock.patch.object(IssuePlatformEventsDeletionTask, "max_rows_to_delete", 6):
             # Create three groups with times_seen such that batching is required
+            group1 = self.create_group(project=self.project)
+            group2 = self.create_group(project=self.project)
+            group3 = self.create_group(project=self.project)
+            group4 = self.create_group(project=self.project)
+
+            # Set times_seen for each group
+            Group.objects.filter(id=group1.id).update(times_seen=3, type=GroupCategory.FEEDBACK)
+            Group.objects.filter(id=group2.id).update(times_seen=1, type=GroupCategory.FEEDBACK)
+            Group.objects.filter(id=group3.id).update(times_seen=3, type=GroupCategory.FEEDBACK)
+            Group.objects.filter(id=group4.id).update(times_seen=3, type=GroupCategory.FEEDBACK)
+
+            # This will delete the group and the events from the node store and Snuba
+            with self.tasks():
+                delete_groups_for_project(
+                    object_ids=[group1.id, group2.id, group3.id, group4.id],
+                    transaction_id=uuid4().hex,
+                    project_id=self.project.id,
+                )
+
+            # There should be two batches: [group3, group1] (2+3=5 > 5, so group2 starts new batch), [group2]
+            assert mock_bulk_snuba_queries.call_count == 1
+            requests = mock_bulk_snuba_queries.call_args[0][0]
+            assert len(requests) == 2
+
+            first_batch = requests[0].query.column_conditions["group_id"]
+            second_batch = requests[1].query.column_conditions["group_id"]
+
+            # Since we sort by times_seen, the first batch will be [group2, group1]
+            # and the second batch will be [group3, group4]
+            assert first_batch == [group2.id, group1.id]  # group2 has less times_seen than group1
+            # group3 and group4 have the same times_seen, thus sorted by id
+            assert second_batch == [group3.id, group4.id]
+
+    @mock.patch("sentry.deletions.tasks.nodestore.bulk_snuba_queries")
+    def test_issue_platform_batching_with_new_task(
+        self, mock_bulk_snuba_queries: mock.Mock
+    ) -> None:
+        # Patch max_rows_to_delete to a small value for testing
+        with (
+            mock.patch("sentry.deletions.tasks.nodestore.ISSUE_PLATFORM_MAX_ROWS_TO_DELETE", 6),
+            self.options({"deletions.nodestore.parallelization-task-enabled": True}),
+        ):
+            # Create three groups with times_seen such that batching is required
+            # XXX: Deleting from the nodestore is not working; the test needs to be fixed
+            # XXX: Use store_event to create the groups
             group1 = self.create_group(project=self.project)
             group2 = self.create_group(project=self.project)
             group3 = self.create_group(project=self.project)

--- a/tests/sentry/deletions/test_group.py
+++ b/tests/sentry/deletions/test_group.py
@@ -43,8 +43,8 @@ class DeleteGroupTest(TestCase, SnubaTestCase):
         self.event_id = self.event.event_id
         self.node_id = Event.generate_node_id(self.project.id, self.event_id)
         group = self.event.group
-        self.event_id2 = self.store_event(data=group1_data, project_id=self.project.id).event_id
-        self.node_id2 = Event.generate_node_id(self.project.id, self.event_id2)
+        self.event2 = self.store_event(data=group1_data, project_id=self.project.id)
+        self.node_id2 = Event.generate_node_id(self.project.id, self.event2.event_id)
 
         # Group 2 event
         self.keep_event = self.store_event(data=group2_data, project_id=self.project.id)
@@ -116,7 +116,7 @@ class DeleteGroupTest(TestCase, SnubaTestCase):
 
     def test_simple_multiple_groups_parallel(self) -> None:
         with self.options({"deletions.nodestore.parallelization-task-enabled": True}):
-            group_ids = [self.event.group.id, self.event_id2.group.id]
+            group_ids = [self.event.group.id, self.event2.group.id]
             with self.tasks():
                 delete_groups_for_project.apply_async(
                     kwargs={

--- a/tests/sentry/deletions/test_group.py
+++ b/tests/sentry/deletions/test_group.py
@@ -127,7 +127,7 @@ class DeleteGroupTest(TestCase, SnubaTestCase):
                 )
 
             assert not Group.objects.filter(id__in=group_ids).exists()
-            assert not nodestore.backend.get_multi([self.event_node_id, self.node_id2])
+            assert not nodestore.backend.get_multi([self.node_id, self.node_id2])
 
             assert Group.objects.filter(id=self.keep_event.group_id).exists()
             assert nodestore.backend.get(self.keep_node_id)


### PR DESCRIPTION
Groups with millions of events fail to be deleted because the nodestore deletions fail.

This creates a new task to handle the deletions in parallel.

An option is to be added to control switching to this new task.

Fixes [ID-821](https://linear.app/getsentry/issue/ID-821/)

Fixes [SENTRY-41GE](https://sentry.sentry.io/issues/6683627821/)
Fixes [SENTRY-48X9](https://sentry.sentry.io/issues/6770482833/)