### PR TITLE
fix(preprod): Only display path if present

### DIFF
--- a/static/app/views/preprod/main/appSizeTreemap.tsx
+++ b/static/app/views/preprod/main/appSizeTreemap.tsx
@@ -2,6 +2,7 @@ import {useTheme} from '@emotion/react';
 import type {TreemapSeriesOption, VisualMapComponentOption} from 'echarts';
 
 import BaseChart, {type TooltipOption} from 'sentry/components/charts/baseChart';
+import {space} from 'sentry/styles/space';
 import {formatBytesBase10} from 'sentry/utils/bytes/formatBytesBase10';
 import {type TreemapResults, TreemapType} from 'sentry/views/preprod/types/appSizeTypes';
 
@@ -223,11 +224,11 @@ export function AppSizeTreemap(props: AppSizeTreemapProps) {
 
       return `
             <div style="font-family: Rubik;">
-              <div style="display: flex; align-items: center; font-size: 12px; font-weight: bold; line-height: 1; margin-bottom: 8px; gap: 8px">
+              <div style="display: flex; align-items: center; font-size: 12px; font-weight: bold; line-height: 1; margin-bottom: ${space(1)}; gap: ${space(1)}">
                 <div style="flex: initial; width: 8px !important; height: 8px !important; border-radius: 50%; background-color: ${params.data?.itemStyle?.borderColor || theme.border};"></div>
                 <span style="color: ${theme.textColor}">${params.data?.category || 'Other'}</span>
               </div>
-              <div style="display: flex; flex-direction: column; line-height: 1; gap: 4px">
+              <div style="display: flex; flex-direction: column; line-height: 1; gap: ${space(0.5)}">
                 <p style="font-size: 14px; font-weight: bold; margin-bottom: -2px;">${params.name}</p>
                 ${pathElement || ''}
                 <p style="font-size: 12px; margin-bottom: -4px;">${formatBytesBase10(value)} (${percent}%)</p>

--- a/static/app/views/preprod/main/appSizeTreemap.tsx
+++ b/static/app/views/preprod/main/appSizeTreemap.tsx
@@ -2,7 +2,6 @@ import {useTheme} from '@emotion/react';
 import type {TreemapSeriesOption, VisualMapComponentOption} from 'echarts';
 
 import BaseChart, {type TooltipOption} from 'sentry/components/charts/baseChart';
-import {space} from 'sentry/styles/space';
 import {formatBytesBase10} from 'sentry/utils/bytes/formatBytesBase10';
 import {type TreemapResults, TreemapType} from 'sentry/views/preprod/types/appSizeTypes';
 
@@ -218,19 +217,23 @@ export function AppSizeTreemap(props: AppSizeTreemapProps) {
     formatter: function (params: any) {
       const value = typeof params.value === 'number' ? params.value : 0;
       const percent = ((value / totalSize) * 100).toFixed(2);
+      const pathElement = params.data?.path
+        ? `<p style="font-size: 12px; margin-bottom: -4px;">${params.data.path}</p>`
+        : null;
+
       return `
             <div style="font-family: Rubik;">
-              <div style="display: flex; align-items: center; font-size: 12px; font-weight: bold; line-height: 1; margin-bottom: ${space(1)}; gap: ${space(1)}">
+              <div style="display: flex; align-items: center; font-size: 12px; font-weight: bold; line-height: 1; margin-bottom: 8px; gap: 8px">
                 <div style="flex: initial; width: 8px !important; height: 8px !important; border-radius: 50%; background-color: ${params.data?.itemStyle?.borderColor || theme.border};"></div>
                 <span style="color: ${theme.textColor}">${params.data?.category || 'Other'}</span>
               </div>
-              <div style="display: flex; flex-direction: column; line-height: 1; gap: ${space(0.5)}">
+              <div style="display: flex; flex-direction: column; line-height: 1; gap: 4px">
                 <p style="font-size: 14px; font-weight: bold; margin-bottom: -2px;">${params.name}</p>
-                <p style="font-size: 12px; margin-bottom: -4px;">${params.data?.path}</p>
+                ${pathElement || ''}
                 <p style="font-size: 12px; margin-bottom: -4px;">${formatBytesBase10(value)} (${percent}%)</p>
               </div>
             </div>
-          `;
+          `.trim();
     },
   };
 


### PR DESCRIPTION
Previously we were displaying `null` in the tooltip when a treemap node didn't have the `path` set. This field is optional since we can't always attribute a node exactly to a file, so I've fixed the display handling to account for that.

with:
<img width="265" height="129" alt="Screenshot 2025-07-30 at 4 30 05 PM" src="https://github.com/user-attachments/assets/ddeee97e-a386-42a9-9353-fc4cbc2c8e73" />

without:
<img width="167" height="115" alt="Screenshot 2025-07-30 at 4 30 02 PM" src="https://github.com/user-attachments/assets/6cc9602e-712c-4471-bc33-8d99c4c802d0" />
