### PR TITLE
ref(logs): Remove blockRowExpanding from logs page params

### DIFF
--- a/static/app/components/events/ourlogs/ourlogsSection.tsx
+++ b/static/app/components/events/ourlogs/ourlogsSection.tsx
@@ -40,7 +40,6 @@ export function OurlogsSection({
     <LogsPageParamsProvider
       analyticsPageSource={LogsAnalyticsPageSource.ISSUE_DETAILS}
       isTableFrozen
-      blockRowExpanding
       limitToTraceId={event.contexts?.trace?.trace_id}
     >
       <LogsPageDataProvider>
@@ -127,6 +126,7 @@ function OurlogsSectionContent({
                 highlightTerms={[]}
                 sharedHoverTimeoutRef={sharedHoverTimeoutRef}
                 key={index}
+                blockRowExpanding
               />
             ))}
           </TableBody>

--- a/static/app/views/explore/contexts/logs/logsPageParams.tsx
+++ b/static/app/views/explore/contexts/logs/logsPageParams.tsx
@@ -51,7 +51,6 @@ interface LogsPageParams {
   /** In the 'aggregates' table, if you GROUP BY, there can be many rows. This is the 'sort by' for that table. */
   readonly aggregateSortBys: Sort[];
   readonly analyticsPageSource: LogsAnalyticsPageSource;
-  readonly blockRowExpanding: boolean | undefined;
   readonly cursor: string;
   readonly fields: string[];
   readonly isTableFrozen: boolean | undefined;
@@ -120,7 +119,6 @@ interface LogsPageParamsProviderProps {
     autoRefresh?: AutoRefreshState;
     refreshInterval?: number;
   };
-  blockRowExpanding?: boolean;
   isTableFrozen?: boolean;
   limitToProjectIds?: number[];
   limitToSpanId?: string;
@@ -132,7 +130,6 @@ export function LogsPageParamsProvider({
   limitToTraceId,
   limitToSpanId,
   limitToProjectIds,
-  blockRowExpanding,
   isTableFrozen,
   analyticsPageSource,
   _testContext,
@@ -200,7 +197,6 @@ export function LogsPageParamsProvider({
         cursor,
         setCursorForFrozenPages,
         isTableFrozen,
-        blockRowExpanding,
         baseSearch,
         projectIds,
         analyticsPageSource,
@@ -389,11 +385,6 @@ export function useSetLogsCursor() {
 export function useLogsIsTableFrozen() {
   const {isTableFrozen} = useLogsPageParams();
   return !!isTableFrozen;
-}
-
-export function useLogsBlockRowExpanding() {
-  const {blockRowExpanding} = useLogsPageParams();
-  return !!blockRowExpanding;
 }
 
 export function usePersistedLogsPageParams() {

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -29,7 +29,6 @@ import {
 } from 'sentry/views/explore/contexts/logs/logsAutoRefreshContext';
 import {
   useLogsAnalyticsPageSource,
-  useLogsBlockRowExpanding,
   useLogsFields,
   useLogsIsTableFrozen,
   useLogsSearch,
@@ -80,6 +79,7 @@ type LogsRowProps = {
   highlightTerms: string[];
   meta: EventsMetaType | undefined;
   sharedHoverTimeoutRef: React.MutableRefObject<NodeJS.Timeout | null>;
+  blockRowExpanding?: boolean;
   canDeferRenderElements?: boolean;
   isExpanded?: boolean;
   onCollapse?: (logItemId: string) => void;
@@ -117,6 +117,7 @@ export const LogRowContent = memo(function LogRowContent({
   onExpand,
   onCollapse,
   onExpandHeight,
+  blockRowExpanding,
   canDeferRenderElements,
 }: LogsRowProps) {
   const location = useLocation();
@@ -125,7 +126,6 @@ export const LogRowContent = memo(function LogRowContent({
   const search = useLogsSearch();
   const setLogsSearch = useSetLogsSearch();
   const isTableFrozen = useLogsIsTableFrozen();
-  const blockRowExpanding = useLogsBlockRowExpanding();
   const autorefreshEnabled = useLogsAutoRefreshEnabled();
   const setAutorefresh = useSetLogsAutoRefresh();
   const measureRef = useRef<HTMLTableRowElement>(null);


### PR DESCRIPTION
There's no reason for `blockRowExpanding` to be in the page params when it can be directly passed the `LogRowContent`.