### PR TITLE
fix(otlp): Add better fallbacks to OTLP-friendly span waterfall rendering

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceRow/traceSpanRow.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceSpanRow.tsx
@@ -78,12 +78,12 @@ export function TraceSpanRow(
           <PlatformIcon
             platform={props.projects[props.node.metadata.project_slug ?? ''] ?? 'default'}
           />
-          {shouldUseOTelFriendlyUI && isEAPSpanNode(props.node) ? (
+          {shouldUseOTelFriendlyUI &&
+          isEAPSpanNode(props.node) &&
+          props.node.value.name ? (
             <React.Fragment>
               <span className="TraceName" title={props.node.value.name}>
-                {props.node.value.name
-                  ? ellipsize(props.node.value.name, 100)
-                  : (spanId ?? 'unknown')}
+                {ellipsize(props.node.value.name, 100)}
               </span>
             </React.Fragment>
           ) : (


### PR DESCRIPTION
Right now, as of https://github.com/getsentry/sentry/pull/94928, if the OTLP-friendly UI flag is on, we render the span waterfall using the `name` attribute, instead of `op` and `description`. This works very badly if the trace is _mixed_ (i.e., contains both OTLP spans and Sentry spans). The longer-term solution for this is to generate useful `name` attributes for Sentry spans, and that's underway. For now though, if the `name` isn't there, attempt to render the `op` and `description`. This is a much better fallback for mixed traces.

**e.g.,**
You can see the "GET" spans are using the name, and spans underneath are using the `op` and `description`.

<img width="478" height="128" alt="Screenshot 2025-07-30 at 4 34 20 PM" src="https://github.com/user-attachments/assets/d4e5c0d2-2fbc-410d-85ed-68c4525e22c5" />
