### PR TITLE
ref(grouping): Pass loaded config to `get_grouping_info`

### DIFF
--- a/src/sentry/api/endpoints/event_grouping_info.py
+++ b/src/sentry/api/endpoints/event_grouping_info.py
@@ -7,6 +7,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.grouping.api import load_grouping_config
 from sentry.grouping.grouping_info import get_grouping_info
 
 
@@ -29,8 +30,8 @@ class EventGroupingInfoEndpoint(ProjectEndpoint):
         if event is None:
             raise ResourceDoesNotExist
 
-        grouping_config_id = event.get_grouping_config()["id"]
-        _grouping_info = get_grouping_info(grouping_config_id, project, event)
+        grouping_config = load_grouping_config(event.get_grouping_config())
+        _grouping_info = get_grouping_info(grouping_config, project, event)
 
         # TODO: All of the below is a temporary hack to preserve compatibility between the BE and FE as
         # we transition from using dashes in the keys/variant types to using underscores. For now, until

--- a/src/sentry/grouping/grouping_info.py
+++ b/src/sentry/grouping/grouping_info.py
@@ -2,6 +2,7 @@ import logging
 from typing import Any
 
 from sentry.eventstore.models import Event, GroupEvent
+from sentry.grouping.strategies.base import StrategyConfiguration
 from sentry.grouping.variants import BaseVariant, PerformanceProblemVariant
 from sentry.models.project import Project
 from sentry.performance_issues.performance_detection import EventPerformanceProblem
@@ -11,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 
 def get_grouping_info(
-    config_name: str | None, project: Project, event: Event | GroupEvent
+    grouping_config: StrategyConfiguration, project: Project, event: Event | GroupEvent
 ) -> dict[str, dict[str, Any]]:
     # We always fetch the stored hashes here. The reason for this is
     # that we want to show in the UI if the forced grouping algorithm
@@ -34,7 +35,7 @@ def get_grouping_info(
             if problem
         }
     else:
-        variants = event.get_grouping_variants(force_config=config_name, normalize_stacktraces=True)
+        variants = event.get_grouping_variants(grouping_config, normalize_stacktraces=True)
 
     grouping_info = get_grouping_info_from_variants(variants)
 

--- a/tests/sentry/grouping/test_grouping_info.py
+++ b/tests/sentry/grouping/test_grouping_info.py
@@ -1,4 +1,5 @@
 from sentry.conf.server import DEFAULT_GROUPING_CONFIG
+from sentry.grouping.api import _load_default_grouping_config
 from sentry.grouping.grouping_info import get_grouping_info
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.eventprocessing import save_new_event
@@ -6,9 +7,10 @@ from sentry.testutils.helpers.eventprocessing import save_new_event
 
 class GroupingInfoTest(TestCase):
     def test_get_grouping_info_error_event(self) -> None:
+        default_grouping_config = _load_default_grouping_config()
         event = save_new_event({"message": "Dogs are great!"}, self.project)
 
-        grouping_info = get_grouping_info(DEFAULT_GROUPING_CONFIG, self.project, event)
+        grouping_info = get_grouping_info(default_grouping_config, self.project, event)
 
         assert grouping_info["default"]["type"] == "component"
         assert grouping_info["default"]["description"] == "message"


### PR DESCRIPTION
This is a small refactor to of the way the grouping info endpoint uses its helper function `get_grouping_info`. Where currently it just passes `get_grouping_info` the name of a grouping config, it will now pass a fully loaded `StrategyConfig` object, so that in an upcoming PR we'll be able to add grouping context data directly from within in the endpoint.