### PR TITLE
Mark asynchronous suspension as symbolicated

### DIFF
--- a/src/sentry/interfaces/stacktrace.py
+++ b/src/sentry/interfaces/stacktrace.py
@@ -262,6 +262,12 @@ class Frame(Interface):
 
             if "min_grouping_level" in self.data:
                 data["minGroupingLevel"] = self.data["min_grouping_level"]
+        
+        # Mark <asynchronous suspension> frames as symbolicated since they cannot be symbolicated
+        # and should not show false warnings in the UI
+        if (self.filename == "<asynchronous suspension>" or 
+            self.abs_path == "<asynchronous suspension>"):
+            data["symbolicatorStatus"] = "symbolicated"
 
         return data
 

--- a/src/sentry/interfaces/stacktrace.py
+++ b/src/sentry/interfaces/stacktrace.py
@@ -262,11 +262,13 @@ class Frame(Interface):
 
             if "min_grouping_level" in self.data:
                 data["minGroupingLevel"] = self.data["min_grouping_level"]
-        
+
         # Mark <asynchronous suspension> frames as symbolicated since they cannot be symbolicated
         # and should not show false warnings in the UI
-        if (self.filename == "<asynchronous suspension>" or 
-            self.abs_path == "<asynchronous suspension>"):
+        if (
+            self.filename == "<asynchronous suspension>"
+            or self.abs_path == "<asynchronous suspension>"
+        ):
             data["symbolicatorStatus"] = "symbolicated"
 
         return data

--- a/tests/sentry/event_manager/interfaces/test_frame.py
+++ b/tests/sentry/event_manager/interfaces/test_frame.py
@@ -54,43 +54,51 @@ def test_address_normalization(make_frames_snapshot):
     )
 
 
-@django_db_all  
+@django_db_all
 def test_asynchronous_suspension_frame_symbolicated():
     """Test that asynchronous suspension frames are automatically marked as symbolicated."""
     # Test with filename = <asynchronous suspension>
-    mgr = EventManager(data={
-        "stacktrace": {
-            "frames": [{
-                "filename": "<asynchronous suspension>",
-                "abs_path": "<asynchronous suspension>",
-                "in_app": False,
-                "data": {"orig_in_app": -1}
-            }]
+    mgr = EventManager(
+        data={
+            "stacktrace": {
+                "frames": [
+                    {
+                        "filename": "<asynchronous suspension>",
+                        "abs_path": "<asynchronous suspension>",
+                        "in_app": False,
+                        "data": {"orig_in_app": -1},
+                    }
+                ]
+            }
         }
-    })
+    )
     mgr.normalize()
     evt = eventstore.backend.create_event(project_id=1, data=mgr.get_data())
     frame = evt.interfaces["stacktrace"].frames[0]
-    
+
     # Check that the frame has symbolicatorStatus set to "symbolicated"
     api_context = frame.get_api_context()
     assert api_context["symbolicatorStatus"] == "symbolicated"
-    
+
     # Test with abs_path = <asynchronous suspension> and different filename
-    mgr2 = EventManager(data={
-        "stacktrace": {
-            "frames": [{
-                "filename": "some_file.dart",
-                "abs_path": "<asynchronous suspension>",
-                "in_app": False,
-                "data": {"orig_in_app": -1}
-            }]
+    mgr2 = EventManager(
+        data={
+            "stacktrace": {
+                "frames": [
+                    {
+                        "filename": "some_file.dart",
+                        "abs_path": "<asynchronous suspension>",
+                        "in_app": False,
+                        "data": {"orig_in_app": -1},
+                    }
+                ]
+            }
         }
-    })
+    )
     mgr2.normalize()
     evt2 = eventstore.backend.create_event(project_id=1, data=mgr2.get_data())
     frame2 = evt2.interfaces["stacktrace"].frames[0]
-    
+
     # Check that the frame has symbolicatorStatus set to "symbolicated"
     api_context2 = frame2.get_api_context()
     assert api_context2["symbolicatorStatus"] == "symbolicated"


### PR DESCRIPTION
<!-- Describe your PR here. -->
Fixes false symbolication warnings for `<asynchronous suspension>` frames in Flutter stacktraces.

These frames are not actual code and cannot be symbolicated, but the UI was incorrectly flagging them as unsymbolicated. This PR marks them as `symbolicated` in the backend to prevent misleading warnings.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
<a href="https://cursor.com/background-agent?bcId=bc-2dca90af-49d6-4a6b-b592-c0e90f207e73">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2dca90af-49d6-4a6b-b592-c0e90f207e73">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>