### PR TITLE
feat(dashboards): Use quota to retrieve dashboard limit for plan

### DIFF
--- a/src/sentry/api/endpoints/organization_dashboards.py
+++ b/src/sentry/api/endpoints/organization_dashboards.py
@@ -322,7 +322,7 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
 
             if dashboard_limit is not None and dashboard_count >= dashboard_limit:
                 return Response(
-                    f"You may not exceed {dashboard_limit} dashboards per organization on your current plan.",
+                    f"You may not exceed {dashboard_limit} dashboards on your current plan.",
                     status=400,
                 )
 

--- a/src/sentry/api/endpoints/organization_dashboards.py
+++ b/src/sentry/api/endpoints/organization_dashboards.py
@@ -320,7 +320,7 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
             dashboard_count = Dashboard.objects.filter(organization=organization).count()
             dashboard_limit = quotas.backend.get_dashboard_limit(organization.id)
 
-            if dashboard_limit is not None and dashboard_count >= dashboard_limit:
+            if dashboard_limit >= 0 and dashboard_count >= dashboard_limit:
                 return Response(
                     f"You may not exceed {dashboard_limit} dashboards on your current plan.",
                     status=400,

--- a/src/sentry/api/endpoints/organization_dashboards.py
+++ b/src/sentry/api/endpoints/organization_dashboards.py
@@ -19,7 +19,7 @@ from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features, roles
+from sentry import features, quotas, roles
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
@@ -315,6 +315,15 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
 
         if not features.has("organizations:dashboards-edit", organization, actor=request.user):
             return Response(status=404)
+
+        dashboard_count = Dashboard.objects.filter(organization=organization).count()
+        dashboard_limit = quotas.backend.get_dashboard_limit(organization.id)
+
+        if dashboard_limit is not None and dashboard_count >= dashboard_limit:
+            return Response(
+                f"You may not exceed {dashboard_limit} dashboards per organization on your current plan.",
+                status=400,
+            )
 
         serializer = DashboardSerializer(
             data=request.data,

--- a/src/sentry/api/endpoints/organization_dashboards.py
+++ b/src/sentry/api/endpoints/organization_dashboards.py
@@ -316,14 +316,15 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
         if not features.has("organizations:dashboards-edit", organization, actor=request.user):
             return Response(status=404)
 
-        dashboard_count = Dashboard.objects.filter(organization=organization).count()
-        dashboard_limit = quotas.backend.get_dashboard_limit(organization.id)
+        if features.has("organizations:dashboards-plan-limits", organization, actor=request.user):
+            dashboard_count = Dashboard.objects.filter(organization=organization).count()
+            dashboard_limit = quotas.backend.get_dashboard_limit(organization.id)
 
-        if dashboard_limit is not None and dashboard_count >= dashboard_limit:
-            return Response(
-                f"You may not exceed {dashboard_limit} dashboards per organization on your current plan.",
-                status=400,
-            )
+            if dashboard_limit is not None and dashboard_count >= dashboard_limit:
+                return Response(
+                    f"You may not exceed {dashboard_limit} dashboards per organization on your current plan.",
+                    status=400,
+                )
 
         serializer = DashboardSerializer(
             data=request.data,

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -98,6 +98,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:dashboards-mep", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable metrics enhanced performance for AM2+ customers as they transition from AM2 to AM3
     manager.add("organizations:dashboards-metrics-transition", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable dashboard limits by plan type
+    manager.add("organizations:dashboards-plan-limits", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable starred dashboards with reordering
     manager.add("organizations:dashboards-starred-reordering", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the dashboard widget builder redesign UI

--- a/src/sentry/quotas/base.py
+++ b/src/sentry/quotas/base.py
@@ -763,7 +763,8 @@ class Quota(Service):
         """
         return True
 
-    def get_dashboard_limit(self, org_id: int) -> int | None:
+    def get_dashboard_limit(self, org_id: int) -> int:
         """
         Returns the maximum number of dashboards allowed for the organization's plan type.
         """
+        return -1

--- a/src/sentry/quotas/base.py
+++ b/src/sentry/quotas/base.py
@@ -762,3 +762,8 @@ class Quota(Service):
                   Always False if data category is not a profile duration category.
         """
         return True
+
+    def get_dashboard_limit(self, org_id: int) -> int | None:
+        """
+        Returns the maximum number of dashboards allowed for the organization's plan type.
+        """

--- a/tests/sentry/api/endpoints/test_organization_dashboards.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboards.py
@@ -1887,10 +1887,7 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
         with self.feature("organizations:dashboards-plan-limits"):
             response = self.do_request("post", self.url, data={"title": "New Dashboard w/ Limit"})
         assert response.status_code == 400
-        assert (
-            response.data
-            == "You may not exceed 1 dashboards per organization on your current plan."
-        )
+        assert response.data == "You may not exceed 1 dashboards on your current plan."
 
         mock_get_dashboard_limit.return_value = 5
         with self.feature("organizations:dashboards-plan-limits"):


### PR DESCRIPTION
Adds a stub to the quota object to retrieve the allowed number of dashboards for validation from the quota service. If there is a number returned, then it will be used to compare with the current dashboard count. If the user exceeds it, then we will reject the dashboard request.

Also feature flags the change