### PR TITLE
feat(uptime): Add uptime percentage to details page

### DIFF
--- a/static/app/views/alerts/rules/uptime/details.spec.tsx
+++ b/static/app/views/alerts/rules/uptime/details.spec.tsx
@@ -1,4 +1,5 @@
 import {UptimeRuleFixture} from 'sentry-fixture/uptimeRule';
+import {UptimeSummaryFixture} from 'sentry-fixture/uptimeSummary';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
@@ -24,6 +25,12 @@ describe('UptimeAlertDetails', function () {
     MockApiClient.addMockResponse({
       url: `/projects/${organization.slug}/${project.slug}/uptime/1/checks/`,
       body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/uptime-summary/',
+      body: {
+        '1': UptimeSummaryFixture(),
+      },
     });
   });
 

--- a/static/app/views/alerts/rules/uptime/details.tsx
+++ b/static/app/views/alerts/rules/uptime/details.tsx
@@ -24,6 +24,7 @@ import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 import {makeAlertsPathname} from 'sentry/views/alerts/pathnames';
+import {useUptimeMonitorSummaries} from 'sentry/views/insights/uptime/utils/useUptimeMonitorSummary';
 import {
   setUptimeRuleData,
   useUptimeRule,
@@ -54,6 +55,9 @@ export default function UptimeAlertDetails({params}: UptimeAlertDetailsProps) {
     isPending,
     isError,
   } = useUptimeRule({projectSlug: projectId, uptimeRuleId});
+
+  const {data: uptimeSummaries} = useUptimeMonitorSummaries({ruleIds: [uptimeRuleId]});
+  const summary = uptimeSummaries?.[uptimeRuleId];
 
   // Only display the missed window legend when there are visible missed window
   // check-ins in the timeline
@@ -191,6 +195,7 @@ export default function UptimeAlertDetails({params}: UptimeAlertDetailsProps) {
         </Layout.Main>
         <Layout.Side>
           <UptimeDetailsSidebar
+            summary={summary}
             uptimeRule={uptimeRule}
             showMissedLegend={showMissedLegend}
           />

--- a/static/app/views/alerts/rules/uptime/detailsSidebar.tsx
+++ b/static/app/views/alerts/rules/uptime/detailsSidebar.tsx
@@ -4,23 +4,32 @@ import styled from '@emotion/styled';
 import {SectionHeading} from 'sentry/components/charts/styles';
 import {CodeSnippet} from 'sentry/components/codeSnippet';
 import {ActorAvatar} from 'sentry/components/core/avatar/actorAvatar';
+import {Grid} from 'sentry/components/core/layout';
 import {ExternalLink} from 'sentry/components/core/link';
+import {Text} from 'sentry/components/core/text';
 import {KeyValueTable, KeyValueTableRow} from 'sentry/components/keyValueTable';
+import Placeholder from 'sentry/components/placeholder';
 import QuestionTooltip from 'sentry/components/questionTooltip';
-import Text from 'sentry/components/text';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import getDuration from 'sentry/utils/duration/getDuration';
 import {CheckIndicator} from 'sentry/views/alerts/rules/uptime/checkIndicator';
-import {CheckStatus, type UptimeRule} from 'sentry/views/alerts/rules/uptime/types';
+import {
+  CheckStatus,
+  type UptimeRule,
+  type UptimeSummary,
+} from 'sentry/views/alerts/rules/uptime/types';
+import {UptimePercentile} from 'sentry/views/insights/uptime/components/percentile';
 import {statusToText} from 'sentry/views/insights/uptime/timelineConfig';
 
 interface UptimeDetailsSidebarProps {
   showMissedLegend: boolean;
   uptimeRule: UptimeRule;
+  summary?: UptimeSummary;
 }
 
 export function UptimeDetailsSidebar({
+  summary,
   uptimeRule,
   showMissedLegend,
 }: UptimeDetailsSidebarProps) {
@@ -32,83 +41,105 @@ export function UptimeDetailsSidebar({
           hideCopyButton
         >{`${uptimeRule.method} ${uptimeRule.url}`}</CodeSnippet>
       </MonitorUrlContainer>
-      <SectionHeading>{t('Legend')}</SectionHeading>
-      <CheckLegend>
-        <CheckLegendItem>
-          <CheckIndicator status={CheckStatus.SUCCESS} />
-          <LegendText>
-            {statusToText[CheckStatus.SUCCESS]}
-            <QuestionTooltip
-              isHoverable
-              size="sm"
-              title={tct(
-                'A check status is considered uptime when it meets the uptime check criteria. [link:Learn more].',
-                {
-                  link: (
-                    <ExternalLink href="https://docs.sentry.io/product/alerts/uptime-monitoring/#uptime-check-criteria" />
-                  ),
-                }
-              )}
-            />
-          </LegendText>
-        </CheckLegendItem>
-        <CheckLegendItem>
-          <CheckIndicator status={CheckStatus.FAILURE} />
-          <LegendText>
-            {statusToText[CheckStatus.FAILURE]}
-            <QuestionTooltip
-              isHoverable
-              size="sm"
-              title={tct(
-                'A check status is considered as a failure when a check fails but hasn’t recorded three consecutive failures needed for Downtime. [link:Learn more].',
-                {
-                  link: (
-                    <ExternalLink href="https://docs.sentry.io/product/alerts/uptime-monitoring/#uptime-check-failures" />
-                  ),
-                }
-              )}
-            />
-          </LegendText>
-        </CheckLegendItem>
-        <CheckLegendItem>
-          <CheckIndicator status={CheckStatus.FAILURE_INCIDENT} />
-          <LegendText>
-            {statusToText[CheckStatus.FAILURE_INCIDENT]}
-            <QuestionTooltip
-              isHoverable
-              size="sm"
-              title={tct(
-                'A check status is considered downtime when it fails 3 consecutive times, meeting the Downtime threshold. [link:Learn more].',
-                {
-                  link: (
-                    <ExternalLink href="https://docs.sentry.io/product/alerts/uptime-monitoring/#uptime-check-failures" />
-                  ),
-                }
-              )}
-            />
-          </LegendText>
-        </CheckLegendItem>
-        {showMissedLegend && (
-          <CheckLegendItem>
-            <CheckIndicator status={CheckStatus.MISSED_WINDOW} />
-            <LegendText>
-              {statusToText[CheckStatus.MISSED_WINDOW]}
-              <QuestionTooltip
-                isHoverable
-                size="sm"
-                title={tct(
-                  'A check status is unknown when Sentry is unable to execute an uptime check at the scheduled time. [link:Learn more].',
-                  {
-                    link: (
-                      <ExternalLink href="https://docs.sentry.io/product/alerts/uptime-monitoring/#uptime-check-failures" />
-                    ),
-                  }
+      <Grid columns="1fr 1fr" gap="md">
+        <div>
+          <SectionHeading>{t('Legend')}</SectionHeading>
+          <CheckLegend>
+            <CheckLegendItem>
+              <CheckIndicator status={CheckStatus.SUCCESS} />
+              <LegendText>
+                {statusToText[CheckStatus.SUCCESS]}
+                <QuestionTooltip
+                  isHoverable
+                  size="sm"
+                  title={tct(
+                    'A check status is considered uptime when it meets the uptime check criteria. [link:Learn more].',
+                    {
+                      link: (
+                        <ExternalLink href="https://docs.sentry.io/product/alerts/uptime-monitoring/#uptime-check-criteria" />
+                      ),
+                    }
+                  )}
+                />
+              </LegendText>
+            </CheckLegendItem>
+            <CheckLegendItem>
+              <CheckIndicator status={CheckStatus.FAILURE} />
+              <LegendText>
+                {statusToText[CheckStatus.FAILURE]}
+                <QuestionTooltip
+                  isHoverable
+                  size="sm"
+                  title={tct(
+                    'A check status is considered as a failure when a check fails but hasn’t recorded three consecutive failures needed for Downtime. [link:Learn more].',
+                    {
+                      link: (
+                        <ExternalLink href="https://docs.sentry.io/product/alerts/uptime-monitoring/#uptime-check-failures" />
+                      ),
+                    }
+                  )}
+                />
+              </LegendText>
+            </CheckLegendItem>
+            <CheckLegendItem>
+              <CheckIndicator status={CheckStatus.FAILURE_INCIDENT} />
+              <LegendText>
+                {statusToText[CheckStatus.FAILURE_INCIDENT]}
+                <QuestionTooltip
+                  isHoverable
+                  size="sm"
+                  title={tct(
+                    'A check status is considered downtime when it fails 3 consecutive times, meeting the Downtime threshold. [link:Learn more].',
+                    {
+                      link: (
+                        <ExternalLink href="https://docs.sentry.io/product/alerts/uptime-monitoring/#uptime-check-failures" />
+                      ),
+                    }
+                  )}
+                />
+              </LegendText>
+            </CheckLegendItem>
+            {showMissedLegend && (
+              <CheckLegendItem>
+                <CheckIndicator status={CheckStatus.MISSED_WINDOW} />
+                <LegendText>
+                  {statusToText[CheckStatus.MISSED_WINDOW]}
+                  <QuestionTooltip
+                    isHoverable
+                    size="sm"
+                    title={tct(
+                      'A check status is unknown when Sentry is unable to execute an uptime check at the scheduled time. [link:Learn more].',
+                      {
+                        link: (
+                          <ExternalLink href="https://docs.sentry.io/product/alerts/uptime-monitoring/#uptime-check-failures" />
+                        ),
+                      }
+                    )}
+                  />
+                </LegendText>
+              </CheckLegendItem>
+            )}
+          </CheckLegend>
+        </div>
+        <div>
+          <SectionHeading>{t('Monitor Uptime')}</SectionHeading>
+          <UptimeContainer>
+            {summary ? (
+              <UptimePercentile
+                size="xl"
+                summary={summary}
+                note={t(
+                  'The total calculated uptime of this monitors over the last 90 days.'
                 )}
               />
-            </LegendText>
-          </CheckLegendItem>
-        )}
-      </CheckLegend>
+            ) : (
+              <Text size="xl">
+                <Placeholder width="60px" height="1lh" />
+              </Text>
+            )}
+          </UptimeContainer>
+        </div>
+      </Grid>
       <SectionHeading>{t('Configuration')}</SectionHeading>
       <KeyValueTable>
         <KeyValueTableRow
@@ -146,7 +177,7 @@ const CheckLegendItem = styled('li')`
   grid-column: 1 / -1;
 `;
 
-const LegendText = styled(Text)`
+const LegendText = styled('div')`
   display: flex;
   gap: ${space(1)};
   align-items: center;
@@ -158,4 +189,8 @@ const MonitorUrlContainer = styled('div')`
   h4 {
     margin-top: 0;
   }
+`;
+
+const UptimeContainer = styled('div')`
+  margin-bottom: ${space(2)};
 `;

--- a/static/app/views/insights/uptime/components/overviewTimeline/index.tsx
+++ b/static/app/views/insights/uptime/components/overviewTimeline/index.tsx
@@ -31,7 +31,8 @@ export function OverviewTimeline({uptimeRules}: Props) {
   const dateNavigation = useDateNavigation();
 
   const {data: summaries} = useUptimeMonitorSummaries({
-    timeWindowConfig,
+    start: timeWindowConfig.start,
+    end: timeWindowConfig.end,
     ruleIds: uptimeRules.map(rule => rule.id),
   });
 

--- a/static/app/views/insights/uptime/components/overviewTimeline/overviewRow.tsx
+++ b/static/app/views/insights/uptime/components/overviewTimeline/overviewRow.tsx
@@ -101,7 +101,13 @@ export function OverviewRow({
             ) : (
               <Flex gap="xs" align="center">
                 <IconStats color="subText" size="xs" />
-                <UptimePercentile size="xs" summary={summary} />
+                <UptimePercentile
+                  size="xs"
+                  summary={summary}
+                  note={t(
+                    'The percent uptime of this monitor in the selected time period.'
+                  )}
+                />
               </Flex>
             )}
           </Flex>

--- a/static/app/views/insights/uptime/components/percentile.spec.tsx
+++ b/static/app/views/insights/uptime/components/percentile.spec.tsx
@@ -81,12 +81,12 @@ describe('UptimePercentile', () => {
   });
 
   it('shows tooltip with detailed breakdown on hover', async () => {
-    render(<UptimePercentile summary={mockSummary} />);
+    render(<UptimePercentile summary={mockSummary} note="This is a test" />);
 
     const percentageText = screen.getByText('94.897%');
     await userEvent.hover(percentageText);
 
-    expect(await screen.findByText(/uptime/i)).toBeInTheDocument();
+    expect(await screen.findByText('This is a test')).toBeInTheDocument();
     expect(screen.getByText('Up Checks')).toBeInTheDocument();
     expect(screen.getByText('Failed Checks')).toBeInTheDocument();
     expect(screen.getByText('Down Checks')).toBeInTheDocument();

--- a/static/app/views/insights/uptime/components/percentile.tsx
+++ b/static/app/views/insights/uptime/components/percentile.tsx
@@ -9,10 +9,14 @@ import {CheckStatus, type UptimeSummary} from 'sentry/views/alerts/rules/uptime/
 
 type UptimePercentileProps = {
   summary: UptimeSummary;
+  /**
+   * Text to display at the top of the uptime percentile text tooltip
+   */
+  note?: React.ReactNode;
   size?: BaseTextProps['size'];
 };
 
-export function UptimePercentile({summary, size}: UptimePercentileProps) {
+export function UptimePercentile({summary, note, size}: UptimePercentileProps) {
   const knownChecks = summary.totalChecks - summary.missedWindowChecks;
 
   if (knownChecks === 0) {
@@ -27,7 +31,7 @@ export function UptimePercentile({summary, size}: UptimePercentileProps) {
 
   const tooltip = (
     <Flex direction="column" gap="md" style={{textAlign: 'left'}}>
-      {t('The percent uptime of this monitor in the selected time period.')}
+      {note}
       <Grid columns={'max-content max-content max-content'} gap="xs md">
         <span>
           <CheckIndicator status={CheckStatus.SUCCESS} width={8} />

--- a/static/app/views/insights/uptime/utils/useUptimeMonitorSummary.tsx
+++ b/static/app/views/insights/uptime/utils/useUptimeMonitorSummary.tsx
@@ -1,4 +1,3 @@
-import type {TimeWindowConfig} from 'sentry/components/checkInTimeline/types';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import type {UptimeSummary} from 'sentry/views/alerts/rules/uptime/types';
@@ -10,21 +9,27 @@ interface Options {
    */
   ruleIds: string[];
   /**
-   * The window configuration object
+   * Optional end time for calculating the summary
    */
-  timeWindowConfig: TimeWindowConfig;
+  end?: Date;
+  /**
+   * Optional start time for calculating the summary
+   */
+  start?: Date;
 }
 
 /**
  * Fetches Uptime Monitor summaries
  */
-export function useUptimeMonitorSummaries({ruleIds, timeWindowConfig}: Options) {
-  const {start, end} = timeWindowConfig;
+export function useUptimeMonitorSummaries({ruleIds, start, end}: Options) {
+  const selectionQuery: Record<string, any> = {};
 
-  const selectionQuery = {
-    start: Math.floor(start.getTime() / 1000),
-    end: Math.floor(end.getTime() / 1000),
-  };
+  if (start) {
+    selectionQuery.start = Math.floor(start.getTime() / 1000);
+  }
+  if (end) {
+    selectionQuery.end = Math.floor(end.getTime() / 1000);
+  }
 
   const organization = useOrganization();
   const monitorStatsQueryKey = `/organizations/${organization.slug}/uptime-summary/`;


### PR DESCRIPTION
Looks like this
<img width="1283" height="476" alt="image" src="https://github.com/user-attachments/assets/fb4c295f-c571-4ded-a504-565785b933b9" />
