### PR TITLE
feat(aci): Add basic cron detector details page

### DIFF
--- a/static/app/types/workflowEngine/detectors.tsx
+++ b/static/app/types/workflowEngine/detectors.tsx
@@ -32,7 +32,7 @@ interface BaseDataSource {
   id: string;
   organizationId: string;
   sourceId: string;
-  type: 'snuba_query_subscription' | 'uptime_subscription';
+  type: 'snuba_query_subscription' | 'uptime_subscription' | 'cron_subscription';
 }
 
 export interface SnubaQueryDataSource extends BaseDataSource {
@@ -62,6 +62,21 @@ export interface UptimeSubscriptionDataSource extends BaseDataSource {
     url: string;
   };
   type: 'uptime_subscription';
+}
+
+export interface CronSubscriptionDataSource extends BaseDataSource {
+  /* TODO: Make this match the actual properties when implemented in backend */
+  queryObj: {
+    checkinMargin: number | null;
+    failureIssueThreshold: number | null;
+    maxRuntime: number | null;
+    recoveryThreshold: number | null;
+    schedule: string;
+    scheduleType: 'crontab' | 'interval';
+    timezone: string;
+  };
+  // TODO: Change this to the actual type when implemented in backend
+  type: 'cron_subscription';
 }
 
 export type DetectorType =
@@ -108,6 +123,10 @@ interface UptimeDetectorConfig {
   environment: string;
 }
 
+interface CronDetectorConfig {
+  environment: string;
+}
+
 type BaseDetector = Readonly<{
   createdBy: string | null;
   dateCreated: string;
@@ -136,8 +155,9 @@ export interface UptimeDetector extends BaseDetector {
   readonly type: 'uptime_domain_failure';
 }
 
-interface CronDetector extends BaseDetector {
-  // TODO: Add cron detector type fields
+export interface CronDetector extends BaseDetector {
+  readonly config: CronDetectorConfig;
+  readonly dataSources: [CronSubscriptionDataSource];
   readonly type: 'uptime_subscription';
 }
 

--- a/static/app/views/detectors/components/details/cron/index.tsx
+++ b/static/app/views/detectors/components/details/cron/index.tsx
@@ -1,0 +1,63 @@
+import {KeyValueTableRow} from 'sentry/components/keyValueTable';
+import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
+import DetailLayout from 'sentry/components/workflowEngine/layout/detail';
+import Section from 'sentry/components/workflowEngine/ui/section';
+import {t, tn} from 'sentry/locale';
+import type {Project} from 'sentry/types/project';
+import type {CronDetector} from 'sentry/types/workflowEngine/detectors';
+import {DetectorDetailsAssignee} from 'sentry/views/detectors/components/details/common/assignee';
+import {DetectorDetailsAutomations} from 'sentry/views/detectors/components/details/common/automations';
+import {DetectorExtraDetails} from 'sentry/views/detectors/components/details/common/extraDetails';
+import {DetectorDetailsHeader} from 'sentry/views/detectors/components/details/common/header';
+import {DetectorDetailsOngoingIssues} from 'sentry/views/detectors/components/details/common/ongoingIssues';
+
+type CronDetectorDetailsProps = {
+  detector: CronDetector;
+  project: Project;
+};
+
+export function CronDetectorDetails({detector, project}: CronDetectorDetailsProps) {
+  const dataSource = detector.dataSources[0];
+
+  const {failureIssueThreshold, recoveryThreshold} = dataSource.queryObj;
+
+  return (
+    <DetailLayout>
+      <DetectorDetailsHeader detector={detector} project={project} />
+      <DetailLayout.Body>
+        <DetailLayout.Main>
+          <DatePageFilter />
+          {/* TODO: Add check-in chart */}
+          <DetectorDetailsOngoingIssues detectorId={detector.id} />
+          <DetectorDetailsAutomations detector={detector} />
+          {/* TODO: Add recent check-ins table */}
+        </DetailLayout.Main>
+        <DetailLayout.Sidebar>
+          <Section title={t('Detect')}>
+            {tn(
+              'One failed check-in.',
+              '%s consecutive failed check-ins.',
+              failureIssueThreshold
+            )}
+          </Section>
+          <Section title={t('Resolve')}>
+            {tn(
+              'One successful check-in.',
+              '%s consecutive successful check-ins.',
+              recoveryThreshold
+            )}
+          </Section>
+          <DetectorDetailsAssignee owner={detector.owner} />
+          <DetectorExtraDetails>
+            <KeyValueTableRow keyName={t('Next check-in')} value="TODO" />
+            <KeyValueTableRow keyName={t('Last check-in')} value="TODO" />
+            <DetectorExtraDetails.Environment detector={detector} />
+            <DetectorExtraDetails.DateCreated detector={detector} />
+            <DetectorExtraDetails.CreatedBy detector={detector} />
+            <DetectorExtraDetails.LastModified detector={detector} />
+          </DetectorExtraDetails>
+        </DetailLayout.Sidebar>
+      </DetailLayout.Body>
+    </DetailLayout>
+  );
+}

--- a/static/app/views/detectors/components/details/index.tsx
+++ b/static/app/views/detectors/components/details/index.tsx
@@ -1,6 +1,7 @@
 import type {Project} from 'sentry/types/project';
 import type {Detector} from 'sentry/types/workflowEngine/detectors';
 import {unreachable} from 'sentry/utils/unreachable';
+import {CronDetectorDetails} from 'sentry/views/detectors/components/details/cron';
 import {ErrorDetectorDetails} from 'sentry/views/detectors/components/details/error';
 import {FallbackDetectorDetails} from 'sentry/views/detectors/components/details/fallback';
 import {MetricDetectorDetails} from 'sentry/views/detectors/components/details/metric';
@@ -21,7 +22,7 @@ export function DetectorDetailsContent({detector, project}: DetectorDetailsConte
     case 'error':
       return <ErrorDetectorDetails detector={detector} project={project} />;
     case 'uptime_subscription':
-      return <FallbackDetectorDetails detector={detector} project={project} />;
+      return <CronDetectorDetails detector={detector} project={project} />;
     default:
       unreachable(detectorType);
       return <FallbackDetectorDetails detector={detector} project={project} />;

--- a/static/app/views/detectors/detail.spec.tsx
+++ b/static/app/views/detectors/detail.spec.tsx
@@ -1,5 +1,6 @@
 import {AutomationFixture} from 'sentry-fixture/automations';
 import {
+  CronDetectorFixture,
   MetricDetectorFixture,
   SnubaQueryDataSourceFixture,
   UptimeDetectorFixture,
@@ -250,6 +251,43 @@ describe('DetectorDetails', function () {
         'href',
         '/organizations/org-slug/issues/monitors/1/edit/'
       );
+    });
+  });
+
+  describe('cron detectors', function () {
+    const cronDetector = CronDetectorFixture({
+      id: '1',
+      projectId: project.id,
+      owner: `team:${ownerTeam.id}`,
+      workflowIds: ['1', '2'],
+    });
+
+    beforeEach(() => {
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/detectors/${cronDetector.id}/`,
+        body: cronDetector,
+      });
+    });
+
+    it('displays correct detector details', async function () {
+      render(<DetectorDetails />, {
+        organization,
+        initialRouterConfig,
+      });
+
+      expect(
+        await screen.findByRole('heading', {name: cronDetector.name})
+      ).toBeInTheDocument();
+
+      // Failure threshold: 1
+      expect(screen.getByText('One failed check-in.')).toBeInTheDocument();
+      // Recovery threshold: 2
+      expect(screen.getByText('2 consecutive successful check-ins.')).toBeInTheDocument();
+      // Environment: production
+      expect(screen.getByText('production')).toBeInTheDocument();
+
+      // Connected automation
+      expect(await screen.findByText('Automation 1')).toBeInTheDocument();
     });
   });
 });

--- a/static/app/views/detectors/utils/getDetectorEnvironment.tsx
+++ b/static/app/views/detectors/utils/getDetectorEnvironment.tsx
@@ -12,8 +12,7 @@ export function getDetectorEnvironment(detector: Detector): string | null {
     case 'uptime_domain_failure':
       return detector.config.environment ?? null;
     case 'uptime_subscription':
-      // TODO: Implement this when we know the shape of object
-      return null;
+      return detector.config.environment ?? null;
     case 'error':
       return null;
     default:

--- a/tests/js/fixtures/detectors.ts
+++ b/tests/js/fixtures/detectors.ts
@@ -3,6 +3,8 @@ import {DataConditionGroupFixture} from 'sentry-fixture/dataConditions';
 import {UserFixture} from 'sentry-fixture/user';
 
 import type {
+  CronDetector,
+  CronSubscriptionDataSource,
   ErrorDetector,
   MetricDetector,
   SnubaQueryDataSource,
@@ -118,6 +120,48 @@ export function SnubaQueryDataSourceFixture(
         timeWindow: 60,
         eventTypes: [EventTypes.ERROR],
       },
+    },
+    ...params,
+  };
+}
+
+export function CronDetectorFixture(params: Partial<CronDetector> = {}): CronDetector {
+  return {
+    name: 'Cron Detector',
+    createdBy: null,
+    dateCreated: '2025-01-01T00:00:00.000Z',
+    dateUpdated: '2025-01-01T00:00:00.000Z',
+    disabled: false,
+    id: '3',
+    lastTriggered: '2025-01-01T00:00:00.000Z',
+    owner: null,
+    projectId: '1',
+    workflowIds: [AutomationFixture().id],
+    type: 'uptime_subscription',
+    config: {
+      environment: 'production',
+    },
+    dataSources: [CronSubscriptionDataSourceFixture()],
+    ...params,
+  };
+}
+
+function CronSubscriptionDataSourceFixture(
+  params: Partial<CronSubscriptionDataSource> = {}
+): CronSubscriptionDataSource {
+  return {
+    id: '1',
+    organizationId: '1',
+    sourceId: '1',
+    type: 'cron_subscription',
+    queryObj: {
+      checkinMargin: null,
+      failureIssueThreshold: 1,
+      recoveryThreshold: 2,
+      maxRuntime: null,
+      schedule: '0 0 * * *',
+      scheduleType: 'crontab',
+      timezone: 'UTC',
     },
     ...params,
   };


### PR DESCRIPTION
Just laying this out for later when cron detectors are actually in the detector ecosystem. Can't view anything in prod, but I wrote a test