### PR TITLE
fix(admin): Persist region selection on search from `home` 

### DIFF
--- a/static/gsAdmin/components/resultGrid.tsx
+++ b/static/gsAdmin/components/resultGrid.tsx
@@ -247,7 +247,7 @@ class ResultGrid extends Component<ResultGridProps, State> {
       query: extractQuery(query),
       region: this.props.isRegional
         ? regionUrl
-          ? ConfigStore.get('regions').find((r: any) => r.url === regionUrl)
+          ? ConfigStore.get('regions').find((r: any) => r.url === extractQuery(regionUrl))
           : ConfigStore.get('regions')[0]
         : undefined,
       sortBy: extractQuery(sortBy, this.props.defaultSort),

--- a/static/gsAdmin/components/resultGrid.tsx
+++ b/static/gsAdmin/components/resultGrid.tsx
@@ -236,7 +236,7 @@ class ResultGrid extends Component<ResultGridProps, State> {
   constructor(props: any) {
     super(props);
     const queryParams = this.props.location?.query ?? {};
-    const {cursor, query, sortBy} = queryParams;
+    const {cursor, query, sortBy, regionUrl} = queryParams;
 
     this.state = {
       rows: [],
@@ -245,7 +245,11 @@ class ResultGrid extends Component<ResultGridProps, State> {
       pageLinks: null,
       cursor: extractQuery(cursor),
       query: extractQuery(query),
-      region: this.props.isRegional ? ConfigStore.get('regions')[0] : undefined,
+      region: this.props.isRegional
+        ? regionUrl
+          ? ConfigStore.get('regions').find((r: any) => r.url === regionUrl)
+          : ConfigStore.get('regions')[0]
+        : undefined,
       sortBy: extractQuery(sortBy, this.props.defaultSort),
       filters: Object.assign({}, queryParams),
     };
@@ -253,6 +257,14 @@ class ResultGrid extends Component<ResultGridProps, State> {
 
   componentDidMount() {
     this.fetchData();
+
+    // Remove regionalUrl after setting state
+    if (this.props.isRegional && this.props.location?.query?.regionUrl) {
+      browserHistory.replace({
+        pathname: this.props.location.pathname,
+        query: {...this.props.location.query, regionUrl: undefined},
+      });
+    }
   }
 
   componentDidUpdate(prevProps: ResultGridProps) {

--- a/static/gsAdmin/views/home.tsx
+++ b/static/gsAdmin/views/home.tsx
@@ -30,6 +30,7 @@ function HomePage(props: Props) {
       pathname: '/_admin/customers/',
       query: {
         query,
+        regionUrl,
       },
     });
   };
@@ -116,7 +117,9 @@ function HomePage(props: Props) {
             label: r.name,
             value: r.url,
           }))}
-          onChange={opt => setRegionUrl(opt.value)}
+          onChange={opt => {
+            setRegionUrl(opt.value);
+          }}
         />
 
         <SearchLabel>Organizations</SearchLabel>


### PR DESCRIPTION
right now searching from the homepage will reset any region selected - now the region will be persisted
fixes https://linear.app/getsentry/issue/RTC-1100/de-region-reverts-to-us-on-httpssentryio-admin