### PR TITLE
feat(tasks) Enable providing a host list to `run taskworker`

### DIFF
--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -281,11 +281,16 @@ def taskworker_scheduler(redis_cluster: str, **options: Any) -> None:
 @run.command()
 @click.option(
     "--rpc-host",
-    help="The hostname for the taskworker-rpc. When using num-brokers the hostname will be appended with `-{i}` to connect to individual brokers.",
+    help="The hostname and port for the taskworker-rpc. When using num-brokers the hostname will be appended with `-{i}` to connect to individual brokers.",
     default="127.0.0.1:50051",
 )
 @click.option(
     "--num-brokers", help="Number of brokers available to connect to", default=None, type=int
+)
+@click.option(
+    "--rpc-host-list",
+    help="Provide a comma separated list of broker RPC host:ports. Use when your broker host names are not compatible with `rpc-host`",
+    default=None,
 )
 @click.option(
     "--max-child-task-count",
@@ -330,6 +335,7 @@ def taskworker(**options: Any) -> None:
 def run_taskworker(
     rpc_host: str,
     num_brokers: int | None,
+    rpc_host_list: str | None,
     max_child_task_count: int,
     namespace: str | None,
     concurrency: int,
@@ -342,12 +348,14 @@ def run_taskworker(
     """
     taskworker factory that can be reloaded
     """
+    from sentry.taskworker.client.client import make_broker_hosts
     from sentry.taskworker.worker import TaskWorker
 
     with managed_bgtasks(role="taskworker"):
         worker = TaskWorker(
-            rpc_host=rpc_host,
-            num_brokers=num_brokers,
+            broker_hosts=make_broker_hosts(
+                host_prefix=rpc_host, num_brokers=num_brokers, host_list=rpc_host_list
+            ),
             max_child_task_count=max_child_task_count,
             namespace=namespace,
             concurrency=concurrency,

--- a/src/sentry/taskworker/client/client.py
+++ b/src/sentry/taskworker/client/client.py
@@ -32,6 +32,22 @@ MAX_ACTIVATION_SIZE = 1024 * 1024 * 10
 """Max payload size we will process."""
 
 
+def make_broker_hosts(
+    host_prefix: str,
+    num_brokers: int | None,
+    host_list: str | None = None,
+) -> list[str]:
+    """
+    Handle RPC host CLI options and create a list of broker host:ports
+    """
+    if host_list:
+        return list(host_list.split(","))
+    if not num_brokers:
+        return [host_prefix]
+    domain, port = host_prefix.split(":")
+    return [f"{domain}-{i}:{port}" for i in range(0, num_brokers)]
+
+
 class ClientCallDetails(grpc.ClientCallDetails):
     """
     Subclass of grpc.ClientCallDetails that allows metadata to be updated
@@ -106,22 +122,22 @@ class TaskworkerClient:
 
     def __init__(
         self,
-        host: str,
-        num_brokers: int | None = None,
+        hosts: list[str],
         max_tasks_before_rebalance: int = DEFAULT_REBALANCE_AFTER,
         max_consecutive_unavailable_errors: int = DEFAULT_CONSECUTIVE_UNAVAILABLE_ERRORS,
         temporary_unavailable_host_timeout: int = DEFAULT_TEMPORARY_UNAVAILABLE_HOST_TIMEOUT,
     ) -> None:
-        self._hosts: list[str] = (
-            [host] if not num_brokers else self._get_all_hosts(host, num_brokers)
-        )
-
+        self._hosts = hosts
         grpc_config = options.get("taskworker.grpc_service_config")
         self._grpc_options: list[tuple[str, Any]] = [
             ("grpc.max_receive_message_length", MAX_ACTIVATION_SIZE)
         ]
         if grpc_config:
             self._grpc_options.append(("grpc.service_config", grpc_config))
+
+        logger.info(
+            "taskworker.client.start", extra={"hosts": hosts, "options": self._grpc_options}
+        )
 
         self._cur_host = random.choice(self._hosts)
         self._host_to_stubs: dict[str, ConsumerServiceStub] = {
@@ -138,23 +154,12 @@ class TaskworkerClient:
         self._temporary_unavailable_host_timeout = temporary_unavailable_host_timeout
 
     def _connect_to_host(self, host: str) -> ConsumerServiceStub:
-        logger.info("Connecting to %s with options %s", host, self._grpc_options)
+        logger.info("taskworker.client.connect", extra={"host": host})
         channel = grpc.insecure_channel(host, options=self._grpc_options)
         if settings.TASKWORKER_SHARED_SECRET:
             secrets = json.loads(settings.TASKWORKER_SHARED_SECRET)
             channel = grpc.intercept_channel(channel, RequestSignatureInterceptor(secrets))
         return ConsumerServiceStub(channel)
-
-    def _get_all_hosts(self, pattern: str, num_brokers: int) -> list[str]:
-        """
-        This function is used to determine the individual host names of
-        the broker given their headless service name.
-
-        This assumes that the passed in port is of the form broker:port,
-        where broker corresponds to the headless service of the brokers.
-        """
-        domain, port = pattern.split(":")
-        return [f"{domain}-{i}:{port}" for i in range(0, num_brokers)]
 
     def _check_consecutive_unavailable_errors(self) -> None:
         if self._num_consecutive_unavailable_errors >= self._max_consecutive_unavailable_errors:

--- a/src/sentry/taskworker/client/client.py
+++ b/src/sentry/taskworker/client/client.py
@@ -127,6 +127,8 @@ class TaskworkerClient:
         max_consecutive_unavailable_errors: int = DEFAULT_CONSECUTIVE_UNAVAILABLE_ERRORS,
         temporary_unavailable_host_timeout: int = DEFAULT_TEMPORARY_UNAVAILABLE_HOST_TIMEOUT,
     ) -> None:
+        assert len(hosts) > 0, "You must provide at least one RPC host to connect to"
+
         self._hosts = hosts
         grpc_config = options.get("taskworker.grpc_service_config")
         self._grpc_options: list[tuple[str, Any]] = [

--- a/src/sentry/taskworker/client/client.py
+++ b/src/sentry/taskworker/client/client.py
@@ -41,7 +41,8 @@ def make_broker_hosts(
     Handle RPC host CLI options and create a list of broker host:ports
     """
     if host_list:
-        return list(host_list.split(","))
+        stripped = map(lambda x: x.strip(), host_list.split(","))
+        return list(filter(lambda x: len(x), stripped))
     if not num_brokers:
         return [host_prefix]
     domain, port = host_prefix.split(":")

--- a/src/sentry/taskworker/worker.py
+++ b/src/sentry/taskworker/worker.py
@@ -45,8 +45,7 @@ class TaskWorker:
 
     def __init__(
         self,
-        rpc_host: str,
-        num_brokers: int | None,
+        broker_hosts: list[str],
         max_child_task_count: int | None = None,
         namespace: str | None = None,
         concurrency: int = 1,
@@ -61,7 +60,7 @@ class TaskWorker:
         self._max_child_task_count = max_child_task_count
         self._namespace = namespace
         self._concurrency = concurrency
-        self.client = TaskworkerClient(rpc_host, num_brokers, rebalance_after)
+        self.client = TaskworkerClient(broker_hosts, rebalance_after)
         if process_type == "fork":
             self.mp_context = multiprocessing.get_context("fork")
         elif process_type == "spawn":

--- a/tests/sentry/taskworker/test_client.py
+++ b/tests/sentry/taskworker/test_client.py
@@ -110,6 +110,13 @@ class MockGrpcError(grpc.RpcError):
 
 
 @django_db_all
+def test_init_no_hosts() -> None:
+    with pytest.raises(AssertionError) as err:
+        TaskworkerClient(hosts=[])
+    assert "You must provide at least one RPC host" in str(err)
+
+
+@django_db_all
 def test_get_task_ok() -> None:
     channel = MockChannel()
     channel.add_response(

--- a/tests/sentry/taskworker/test_client.py
+++ b/tests/sentry/taskworker/test_client.py
@@ -109,6 +109,20 @@ class MockGrpcError(grpc.RpcError):
         raise self
 
 
+def test_make_broker_hosts() -> None:
+    hosts = make_broker_hosts(host_prefix="broker:50051", num_brokers=3)
+    assert len(hosts) == 3
+    assert hosts == ["broker-0:50051", "broker-1:50051", "broker-2:50051"]
+
+    hosts = make_broker_hosts(
+        host_prefix="",
+        num_brokers=None,
+        host_list="broker:50051, broker-a:50051 ,  , broker-b:50051",
+    )
+    assert len(hosts) == 3
+    assert hosts == ["broker:50051", "broker-a:50051", "broker-b:50051"]
+
+
 @django_db_all
 def test_init_no_hosts() -> None:
     with pytest.raises(AssertionError) as err:

--- a/tests/sentry/taskworker/test_worker.py
+++ b/tests/sentry/taskworker/test_worker.py
@@ -160,7 +160,7 @@ class TestTaskWorker(TestCase):
 
     def test_fetch_task(self) -> None:
         taskworker = TaskWorker(
-            rpc_host="127.0.0.1:50051", num_brokers=1, max_child_task_count=100, process_type="fork"
+            broker_hosts=["127.0.0.1:50051"], max_child_task_count=100, process_type="fork"
         )
         with mock.patch.object(taskworker.client, "get_task") as mock_get:
             mock_get.return_value = SIMPLE_TASK
@@ -173,7 +173,7 @@ class TestTaskWorker(TestCase):
 
     def test_fetch_no_task(self) -> None:
         taskworker = TaskWorker(
-            rpc_host="127.0.0.1:50051", num_brokers=1, max_child_task_count=100, process_type="fork"
+            broker_hosts=["127.0.0.1:50051"], max_child_task_count=100, process_type="fork"
         )
         with mock.patch.object(taskworker.client, "get_task") as mock_get:
             mock_get.return_value = None
@@ -185,7 +185,7 @@ class TestTaskWorker(TestCase):
     def test_run_once_no_next_task(self) -> None:
         max_runtime = 5
         taskworker = TaskWorker(
-            rpc_host="127.0.0.1:50051", num_brokers=1, max_child_task_count=1, process_type="fork"
+            broker_hosts=["127.0.0.1:50051"], max_child_task_count=1, process_type="fork"
         )
         with mock.patch.object(taskworker, "client") as mock_client:
             mock_client.get_task.return_value = SIMPLE_TASK
@@ -218,7 +218,7 @@ class TestTaskWorker(TestCase):
         # be processed.
         max_runtime = 5
         taskworker = TaskWorker(
-            rpc_host="127.0.0.1:50051", num_brokers=1, max_child_task_count=1, process_type="fork"
+            broker_hosts=["127.0.0.1:50051"], max_child_task_count=1, process_type="fork"
         )
         with mock.patch.object(taskworker, "client") as mock_client:
 
@@ -257,8 +257,7 @@ class TestTaskWorker(TestCase):
         # Cover the scenario where taskworker.fetch_next.disabled_pools is defined
         max_runtime = 5
         taskworker = TaskWorker(
-            rpc_host="127.0.0.1:50051",
-            num_brokers=1,
+            broker_hosts=["127.0.0.1:50051"],
             max_child_task_count=1,
             process_type="fork",
             processing_pool_name="testing",
@@ -294,7 +293,7 @@ class TestTaskWorker(TestCase):
         # We should retain the result until RPC succeeds.
         max_runtime = 5
         taskworker = TaskWorker(
-            rpc_host="127.0.0.1:50051", num_brokers=1, max_child_task_count=1, process_type="fork"
+            broker_hosts=["127.0.0.1:50051"], max_child_task_count=1, process_type="fork"
         )
         with mock.patch.object(taskworker, "client") as mock_client:
 
@@ -337,7 +336,7 @@ class TestTaskWorker(TestCase):
         # to raise and catch a NoRetriesRemainingError
         max_runtime = 5
         taskworker = TaskWorker(
-            rpc_host="127.0.0.1:50051", num_brokers=1, max_child_task_count=1, process_type="fork"
+            broker_hosts=["127.0.0.1:50051"], max_child_task_count=1, process_type="fork"
         )
         with mock.patch.object(taskworker, "client") as mock_client:
 


### PR DESCRIPTION
To accomodate self-hosted usage where brokers may not have host names that follow the pattern we use in saas, we can provide a `--rpc-host-list-` CLI option for providing an explict list of hosts. I've maintained backwards compatibility with `--rpc-host` and `--num-brokers` as we use those in saas currently.

Refs #95403