### PR TITLE
ref(grouping): delete unused query parameter from UseEventGroupin…

### DIFF
--- a/static/app/components/events/groupingInfo/groupingInfo.tsx
+++ b/static/app/components/events/groupingInfo/groupingInfo.tsx
@@ -34,7 +34,6 @@ export default function GroupingInfo({
       event,
       group,
       projectSlug,
-      query: {},
     });
 
   const variants = groupInfo

--- a/static/app/components/events/groupingInfo/groupingSummary.tsx
+++ b/static/app/components/events/groupingInfo/groupingSummary.tsx
@@ -17,7 +17,6 @@ export function GroupInfoSummary({
     event,
     group,
     projectSlug,
-    query: {},
   });
   const groupedBy = groupInfo
     ? Object.values(groupInfo)

--- a/static/app/components/events/groupingInfo/useEventGroupingInfo.tsx
+++ b/static/app/components/events/groupingInfo/useEventGroupingInfo.tsx
@@ -50,22 +50,17 @@ export function useEventGroupingInfo({
   event,
   group,
   projectSlug,
-  query,
 }: {
   event: Event;
   group: Group | undefined;
   projectSlug: string;
-  query: Record<string, string>;
 }) {
   const organization = useOrganization();
 
   const hasPerformanceGrouping = event.occurrence && event.type === 'transaction';
 
   const {data, isPending, isError, isSuccess} = useApiQuery<EventGroupingInfoResponse>(
-    [
-      `/projects/${organization.slug}/${projectSlug}/events/${event.id}/grouping-info/`,
-      {query},
-    ],
+    [`/projects/${organization.slug}/${projectSlug}/events/${event.id}/grouping-info/`],
     {enabled: !hasPerformanceGrouping, staleTime: Infinity}
   );
 


### PR DESCRIPTION
Remove `query` parameter from `useEventGroupingInfo` because neither `groupingInfo` or `groupSummary` use it as of #96655. 