### PR TITLE
:wrench: chore(plugins): don't create sentry issues for all plugin errors

### DIFF
--- a/src/sentry/plugins/bases/notify.py
+++ b/src/sentry/plugins/bases/notify.py
@@ -79,8 +79,11 @@ class NotificationPlugin(Plugin):
         project = event.group.project
         extra["project_id"] = project.id
         notification = Notification(event=event, rules=rules)
-        self.notify(notification)
-        self.logger.info("notification.dispatched", extra=extra)
+        try:
+            self.notify(notification)
+        # Because plugins are deprecated, we want to ignore any errors that occur
+        except Exception:
+            pass
 
     def notify_users(self, group, event, triggering_rules) -> None:
         raise NotImplementedError


### PR DESCRIPTION
when looking at SENTRY-49TK, i realized if we swallowed all exceptions at the `rule_notify` level in the `NotificationPlugin` class, we can effectively eliminate a lot of different errors at once.

in any case, the errors aren't relevant since we are deprecating this anyway.