### PR TITLE
feat(aci): Reset interval when switching dataset or detector type

### DIFF
--- a/static/app/views/detectors/components/forms/metric/metric.tsx
+++ b/static/app/views/detectors/components/forms/metric/metric.tsx
@@ -206,13 +206,13 @@ function IntervalPicker() {
   const interval = useMetricDetectorFormField(METRIC_DETECTOR_FORM_FIELDS.interval);
 
   useEffect(() => {
-    if (interval && !intervalChoices.some(choice => choice[0] === interval)) {
+    if (!intervalChoices.some(choice => choice[0] === interval)) {
       formContext.form?.setValue(
         METRIC_DETECTOR_FORM_FIELDS.interval,
         intervalChoices[0]![0]
       );
     }
-  }, [interval, intervalChoices, formContext]);
+  }, [intervalChoices, formContext.form, interval, dataset]);
 
   return (
     <IntervalField

--- a/static/app/views/detectors/components/forms/metric/useIntervalChoices.tsx
+++ b/static/app/views/detectors/components/forms/metric/useIntervalChoices.tsx
@@ -41,12 +41,8 @@ export function useIntervalChoices({dataset, detectionType}: UseIntervalChoicesP
     // 2. Dynamic detection → Only 15min, 30min, 1hour
     // 3. Spans/Logs → No 1-minute intervals (EAP dataset behavior)
     // 4. Everything else → All intervals allowed
-
     const shouldExcludeSubHour = dataset === DetectorDataset.RELEASES;
-
-    // Dynamic detection should match alert system: only 15min, 30min, 1hour
     const isDynamicDetection = detectionType === 'dynamic';
-
     // EAP-derived datasets (spans, logs) exclude 1-minute intervals
     const isEAPDerivedDataset =
       dataset === DetectorDataset.SPANS || dataset === DetectorDataset.LOGS;

--- a/static/app/views/detectors/components/forms/metric/useIntervalChoices.tsx
+++ b/static/app/views/detectors/components/forms/metric/useIntervalChoices.tsx
@@ -1,0 +1,75 @@
+import {useMemo} from 'react';
+
+import getDuration from 'sentry/utils/duration/getDuration';
+import {TimeWindow} from 'sentry/views/alerts/rules/metric/types';
+import {
+  DetectorDataset,
+  type MetricDetectorFormData,
+} from 'sentry/views/detectors/components/forms/metric/metricFormData';
+
+const baseIntervals: TimeWindow[] = [
+  TimeWindow.ONE_MINUTE,
+  TimeWindow.FIVE_MINUTES,
+  TimeWindow.TEN_MINUTES,
+  TimeWindow.FIFTEEN_MINUTES,
+  TimeWindow.THIRTY_MINUTES,
+  TimeWindow.ONE_HOUR,
+  TimeWindow.TWO_HOURS,
+  TimeWindow.FOUR_HOURS,
+  TimeWindow.ONE_DAY,
+];
+
+const dynamicIntervalChoices: TimeWindow[] = [
+  TimeWindow.FIFTEEN_MINUTES,
+  TimeWindow.THIRTY_MINUTES,
+  TimeWindow.ONE_HOUR,
+];
+
+interface UseIntervalChoicesParams {
+  dataset: DetectorDataset;
+  detectionType: MetricDetectorFormData['detectionType'];
+}
+
+export function useIntervalChoices({dataset, detectionType}: UseIntervalChoicesParams) {
+  const intervalChoices = useMemo((): Array<[seconds: number, label: string]> => {
+    if (!dataset) {
+      return [];
+    }
+
+    // Interval filtering rules:
+    // 1. Releases → No sub-hour intervals (crash-free alert behavior)
+    // 2. Dynamic detection → Only 15min, 30min, 1hour
+    // 3. Spans/Logs → No 1-minute intervals (EAP dataset behavior)
+    // 4. Everything else → All intervals allowed
+
+    const shouldExcludeSubHour = dataset === DetectorDataset.RELEASES;
+
+    // Dynamic detection should match alert system: only 15min, 30min, 1hour
+    const isDynamicDetection = detectionType === 'dynamic';
+
+    // EAP-derived datasets (spans, logs) exclude 1-minute intervals
+    const isEAPDerivedDataset =
+      dataset === DetectorDataset.SPANS || dataset === DetectorDataset.LOGS;
+
+    const filteredIntervals = baseIntervals.filter(timeWindow => {
+      if (shouldExcludeSubHour) {
+        return timeWindow >= TimeWindow.ONE_HOUR;
+      }
+      if (isDynamicDetection) {
+        // Match alert system dynamic detection: only 15min, 30min, 1hour
+        return dynamicIntervalChoices.includes(timeWindow);
+      }
+      if (isEAPDerivedDataset) {
+        return timeWindow !== TimeWindow.ONE_MINUTE;
+      }
+      return true;
+    });
+
+    return filteredIntervals.map(timeWindow => {
+      const seconds = timeWindow * 60;
+      return [seconds, getDuration(seconds)];
+    });
+  }, [dataset, detectionType]);
+
+  return intervalChoices;
+}

--- a/static/app/views/detectors/components/forms/metric/useIntervalChoices.tsx
+++ b/static/app/views/detectors/components/forms/metric/useIntervalChoices.tsx
@@ -56,7 +56,6 @@ export function useIntervalChoices({dataset, detectionType}: UseIntervalChoicesP
         return timeWindow >= TimeWindow.ONE_HOUR;
       }
       if (isDynamicDetection) {
-        // Match alert system dynamic detection: only 15min, 30min, 1hour
         return dynamicIntervalChoices.includes(timeWindow);
       }
       if (isEAPDerivedDataset) {

--- a/static/app/views/detectors/edit.spec.tsx
+++ b/static/app/views/detectors/edit.spec.tsx
@@ -396,5 +396,30 @@ describe('DetectorEdit', () => {
       expect(screen.queryByText('Change')).not.toBeInTheDocument();
       expect(screen.queryByText('Dynamic')).not.toBeInTheDocument();
     });
+
+    it('resets 1 day interval to 15 minutes when switching to dynamic detection', async () => {
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/detectors/${mockDetector.id}/`,
+        body: mockDetector,
+      });
+
+      render(<DetectorEdit />, {
+        organization,
+        initialRouterConfig,
+      });
+
+      expect(await screen.findByRole('link', {name})).toBeInTheDocument();
+
+      // Set interval to 1 day
+      const intervalField = screen.getByLabelText('Interval');
+      await userEvent.click(intervalField);
+      await userEvent.click(screen.getByRole('menuitemradio', {name: '1 day'}));
+
+      // Switch to dynamic detection
+      await userEvent.click(screen.getByRole('radio', {name: 'Dynamic'}));
+
+      // Verify interval changed to 15 minutes
+      expect(await screen.findByText('15 minutes')).toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
Dynamic / anomaly alerts have a different set of available thresholds and we should enforce that one of the available choices is selected.

Fixes the choices available for anomalies.
