### PR TITLE
test(workflow): Deflake PercentSessionsQueryTest::test_batch_query_percent

### DIFF
--- a/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_query_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_query_handlers.py
@@ -356,8 +356,8 @@ class PercentSessionsQueryTest(BaseEventFrequencyPercentTest, EventFrequencyQuer
         1,
     )
     def test_batch_query_percent(self) -> None:
-        self._make_sessions(60, self.environment2.name)
-        self._make_sessions(60, self.environment.name)
+        self._make_sessions(60, self.environment2.name, received=self.end.timestamp())
+        self._make_sessions(60, self.environment.name, received=self.end.timestamp())
 
         batch_query = self.handler().batch_query(
             groups=self.groups,

--- a/tests/snuba/rules/conditions/test_event_frequency.py
+++ b/tests/snuba/rules/conditions/test_event_frequency.py
@@ -37,9 +37,14 @@ pytestmark = [pytest.mark.sentry_metrics, requires_snuba]
 
 class BaseEventFrequencyPercentTest(BaseMetricsTestCase):
     def _make_sessions(
-        self, num: int, environment_name: str | None = None, project: Project | None = None
+        self,
+        num: int,
+        environment_name: str | None = None,
+        project: Project | None = None,
+        received: float | None = None,
     ):
-        received = time.time()
+        if received is None:
+            received = time.time()
 
         def make_session(i):
             return dict(


### PR DESCRIPTION
Pass received timestamp to _make_sessions to eliminate minute boundary alignment
effects that caused 20%/25% result variation. Now consistently returns 20%.

Fixes ISWF-578