### PR TITLE
feat(uptime): Allow uptime spans to be fetched from the `organiation_trace` endpoint.

### DIFF
--- a/src/sentry/api/endpoints/organization_trace.py
+++ b/src/sentry/api/endpoints/organization_trace.py
@@ -55,8 +55,11 @@ class OrganizationTraceEndpoint(OrganizationEventsV2EndpointBase):
         trace_id: str,
         error_id: str | None = None,
         additional_attributes: list[str] | None = None,
+        include_uptime: bool = False,
     ) -> list[SerializedEvent]:
-        return query_trace_data(snuba_params, trace_id, error_id, additional_attributes)
+        return query_trace_data(
+            snuba_params, trace_id, error_id, additional_attributes, include_uptime
+        )
 
     def has_feature(self, organization: Organization, request: Request) -> bool:
         return bool(
@@ -74,6 +77,7 @@ class OrganizationTraceEndpoint(OrganizationEventsV2EndpointBase):
             return Response(status=404)
 
         additional_attributes = request.GET.getlist("additional_attributes", [])
+        include_uptime = request.GET.get("include_uptime", "0") == "1"
 
         error_id = request.GET.get("errorId")
         if error_id is not None and not is_event_id(error_id):
@@ -85,7 +89,7 @@ class OrganizationTraceEndpoint(OrganizationEventsV2EndpointBase):
                 update_snuba_params_with_timestamp(request, snuba_params)
 
                 spans = self.query_trace_data(
-                    snuba_params, trace_id, error_id, additional_attributes
+                    snuba_params, trace_id, error_id, additional_attributes, include_uptime
                 )
             return spans
 

--- a/src/sentry/search/eap/uptime_results/attributes.py
+++ b/src/sentry/search/eap/uptime_results/attributes.py
@@ -7,8 +7,8 @@ UPTIME_ATTRIBUTE_DEFINITIONS = {
     for column in COMMON_COLUMNS
     + [
         ResolvedAttribute(
-            public_alias="trace_id",
-            internal_name="trace_id",
+            public_alias="trace",
+            internal_name="sentry.trace_id",
             search_type="string",
         ),
         ResolvedAttribute(

--- a/src/sentry/snuba/trace.py
+++ b/src/sentry/snuba/trace.py
@@ -1,20 +1,38 @@
+import logging
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from typing import Any, NotRequired, TypedDict
 
+logger = logging.getLogger(__name__)
+
 import sentry_sdk
-from snuba_sdk import Column, Function
+from google.protobuf.timestamp_pb2 import Timestamp
+from sentry_protos.snuba.v1.downsampled_storage_pb2 import DownsampledStorageConfig
+from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import (
+    TraceItemTableRequest,
+    TraceItemTableResponse,
+)
+from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta, TraceItemType
+from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey, AttributeValue
+from sentry_protos.snuba.v1.trace_item_filter_pb2 import ComparisonFilter, TraceItemFilter
+from snuba_sdk import Column as SnubaColumn
+from snuba_sdk import Function
 
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.models.group import Group
+from sentry.models.project import Project
+from sentry.search.eap.common_columns import COMMON_COLUMNS
 from sentry.search.eap.types import SearchResolverConfig
+from sentry.search.eap.uptime_results.attributes import UPTIME_ATTRIBUTE_DEFINITIONS
 from sentry.search.events.builder.discover import DiscoverQueryBuilder
 from sentry.search.events.types import QueryBuilderConfig, SnubaParams
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.referrer import Referrer
 from sentry.snuba.spans_rpc import Spans
+from sentry.uptime.eap_utils import get_columns_for_uptime_trace_item_type
 from sentry.utils.numbers import base32_encode
+from sentry.utils.snuba_rpc import table_rpc
 
 # Mostly here for testing
 ERROR_LIMIT = 10_000
@@ -127,21 +145,33 @@ def _serialize_rpc_event(
     group_cache: dict[int, Group],
     additional_attributes: list[str] | None = None,
 ) -> SerializedEvent | SerializedIssue:
-    if event.get("event_type") == "span":
+    if event.get("event_type") in ("span", "uptime"):
         attribute_dict = {
             attribute: event[attribute]
             for attribute in additional_attributes or []
             if attribute in event
         }
+        children = [
+            _serialize_rpc_event(child, group_cache, additional_attributes)
+            for child in event["children"]
+        ]
+        errors = [_serialize_rpc_issue(error, group_cache) for error in event["errors"]]
+        occurrences = [_serialize_rpc_issue(error, group_cache) for error in event["occurrences"]]
+
+        if event.get("event_type") == "uptime":
+            return SerializedSpan(
+                **{
+                    k: v for k, v in event.items() if k not in ["children", "errors", "occurrences"]
+                },
+                children=children,
+                errors=errors,
+                occurrences=occurrences,
+            )
+
         return SerializedSpan(
-            children=[
-                _serialize_rpc_event(child, group_cache, additional_attributes)
-                for child in event["children"]
-            ],
-            errors=[_serialize_rpc_issue(error, group_cache) for error in event["errors"]],
-            occurrences=[
-                _serialize_rpc_issue(error, group_cache) for error in event["occurrences"]
-            ],
+            children=children,
+            errors=errors,
+            occurrences=occurrences,
             event_id=event["id"],
             transaction_id=event["transaction.event_id"],
             project_id=event["project.id"],
@@ -233,13 +263,13 @@ def _perf_issues_query(snuba_params: SnubaParams, trace_id: str) -> DiscoverQuer
     )
     occurrence_query.columns.extend(
         [
-            Function("groupArray", parameters=[Column("group_id")], alias="issue.ids"),
+            Function("groupArray", parameters=[SnubaColumn("group_id")], alias="issue.ids"),
         ]
     )
     occurrence_query.groupby = [
-        Column("event_id"),
-        Column("occurrence_id"),
-        Column("project_id"),
+        SnubaColumn("event_id"),
+        SnubaColumn("occurrence_id"),
+        SnubaColumn("project_id"),
     ]
     return occurrence_query
 
@@ -272,11 +302,138 @@ def _run_perf_issues_query(occurrence_query: DiscoverQueryBuilder):
     return result
 
 
+def _uptime_results_query(
+    snuba_params: SnubaParams,
+    trace_id: str,
+) -> TraceItemTableRequest:
+    """Build a TraceItemTableRequest to query uptime results for a given trace"""
+    start_timestamp = Timestamp()
+    if snuba_params.start:
+        start_timestamp.FromDatetime(snuba_params.start)
+    end_timestamp = Timestamp()
+    if snuba_params.end:
+        end_timestamp.FromDatetime(snuba_params.end)
+
+    return TraceItemTableRequest(
+        meta=RequestMeta(
+            organization_id=snuba_params.organization.id,
+            project_ids=snuba_params.project_ids,
+            trace_item_type=TraceItemType.TRACE_ITEM_TYPE_UPTIME_RESULT,
+            start_timestamp=start_timestamp,
+            end_timestamp=end_timestamp,
+            referrer="api.trace-view.get-uptime-results",
+            downsampled_storage_config=DownsampledStorageConfig(
+                mode=DownsampledStorageConfig.MODE_HIGHEST_ACCURACY
+            ),
+        ),
+        columns=get_columns_for_uptime_trace_item_type(TraceItemType.TRACE_ITEM_TYPE_UPTIME_RESULT),
+        filter=TraceItemFilter(
+            comparison_filter=ComparisonFilter(
+                key=AttributeKey(
+                    name="sentry.trace_id",
+                    type=AttributeKey.Type.TYPE_STRING,
+                ),
+                op=ComparisonFilter.OP_EQUALS,
+                value=AttributeValue(val_str=trace_id),
+            )
+        ),
+    )
+
+
+def _run_uptime_results_query(uptime_query: TraceItemTableRequest) -> list[TraceItemTableResponse]:
+    """Execute the uptime results query"""
+    try:
+        return table_rpc([uptime_query])
+    except Exception:
+        logger.exception("Failed to execute uptime results query")
+        raise
+
+
+def _serialize_columnar_uptime_item(
+    row_dict: dict[str, AttributeValue],
+    project_slugs: dict[int, str],
+) -> dict[str, Any]:
+    """Convert a columnar uptime row to a serialized span format"""
+    columns_by_name = {col.internal_name: col for col in UPTIME_ATTRIBUTE_DEFINITIONS.values()}
+    common_column_names = {col.internal_name for col in COMMON_COLUMNS}
+
+    guid = row_dict["guid"].val_str
+    trace_id = row_dict["sentry.trace_id"].val_str
+    check_status = row_dict["check_status"].val_str
+    http_status_code = (
+        row_dict["http_status_code"].val_int if "http_status_code" in row_dict else None
+    )
+    request_url = row_dict["request_url"].val_str
+    scheduled_check_time_us = row_dict["scheduled_check_time_us"].val_int
+    check_duration_us = (
+        row_dict["check_duration_us"].val_int if "check_duration_us" in row_dict else 0
+    )
+    project_id = row_dict["sentry.project_id"].val_int
+    project_slug = project_slugs[project_id]
+
+    span = {
+        "event_id": guid,
+        "project_id": project_id,
+        "project_slug": project_slug,
+        "transaction_id": trace_id,
+        "transaction": "uptime.check",
+        "event_type": "uptime",
+        "children": [],
+        "errors": [],
+        "occurrences": [],
+        "measurements": {},
+        "op": "uptime.request",
+        "parent_span_id": None,
+        "profile_id": "",
+        "profiler_id": "",
+        "sdk_name": "uptime-monitor",
+        "is_transaction": False,
+    }
+
+    def get_value(attr_name: str, attr_value: AttributeValue):
+        if attr_value.is_null:
+            return None
+        resolved_column = columns_by_name[attr_name]
+        if resolved_column.search_type == "integer":
+            return attr_value.val_int
+        elif resolved_column.search_type == "string":
+            return attr_value.val_str
+        elif resolved_column.search_type == "number":
+            return attr_value.val_double
+        elif resolved_column.search_type == "boolean":
+            return attr_value.val_bool
+        elif resolved_column.search_type == "byte":
+            return attr_value.val_int
+        raise ValueError("Unknown column type")
+
+    additional_attrs = {}
+    for attr_name, attr_value in row_dict.items():
+        if attr_name in columns_by_name and attr_name not in common_column_names:
+            resolved_column = columns_by_name[attr_name]
+            resolved_val = get_value(attr_name, attr_value)
+            if resolved_val is not None:
+                additional_attrs[resolved_column.public_alias] = resolved_val
+
+    span["start_timestamp"] = datetime.fromtimestamp(scheduled_check_time_us / 1_000_000)
+    span["end_timestamp"] = datetime.fromtimestamp(
+        (scheduled_check_time_us + check_duration_us) / 1_000_000
+    )
+    span["duration"] = check_duration_us / 1_000.0
+    span["description"] = f"Uptime Check [{check_status}] - {request_url}"
+    if http_status_code:
+        span["description"] += f" ({http_status_code})"
+
+    span["name"] = request_url
+    span["additional_attributes"] = additional_attrs
+    return span
+
+
 def query_trace_data(
     snuba_params: SnubaParams,
     trace_id: str,
     error_id: str | None = None,
     additional_attributes: list[str] | None = None,
+    include_uptime: bool = False,
 ) -> list[SerializedEvent]:
     """Queries span/error data for a given trace"""
     # This is a hack, long term EAP will store both errors and performance_issues eventually but is not ready
@@ -289,9 +446,11 @@ def query_trace_data(
     # to the database preventing a DROP.
     errors_query = _errors_query(snuba_params, trace_id, error_id)
     occurrence_query = _perf_issues_query(snuba_params, trace_id)
+    uptime_query = _uptime_results_query(snuba_params, trace_id) if include_uptime else None
 
-    # 1 worker each for spans, errors, performance issues
-    query_thread_pool = ThreadPoolExecutor(thread_name_prefix=__name__, max_workers=3)
+    # 1 worker each for spans, errors, performance issues, and optionally uptime
+    max_workers = 4 if include_uptime else 3
+    query_thread_pool = ThreadPoolExecutor(thread_name_prefix=__name__, max_workers=max_workers)
     with query_thread_pool:
         spans_future = query_thread_pool.submit(
             Spans.run_trace_query,
@@ -309,12 +468,47 @@ def query_trace_data(
             _run_perf_issues_query,
             occurrence_query,
         )
+        uptime_future = None
+        if include_uptime and uptime_query:
+            uptime_future = query_thread_pool.submit(_run_uptime_results_query, uptime_query)
 
     spans_data = spans_future.result()
     errors_data = errors_future.result()
     occurrence_data = occurrence_future.result()
-
+    uptime_data = uptime_future.result() if uptime_future else []
     result = []
+    root_span = None
+    if uptime_data:
+        trace_items = []
+        for response in uptime_data:
+            column_values = response.column_values
+            if not column_values:
+                continue
+            column_names = [cv.attribute_name for cv in column_values]
+            num_rows = len(column_values[0].results)
+            for row_idx in range(num_rows):
+                row_dict = {}
+                for col_idx, col_name in enumerate(column_names):
+                    attr_value = column_values[col_idx].results[row_idx]
+                    row_dict[col_name] = attr_value
+                trace_items.append(row_dict)
+
+        if trace_items:
+            project_slugs = {
+                p["id"]: p["slug"]
+                for p in Project.objects.filter(id__in=snuba_params.project_ids).values(
+                    "id", "slug"
+                )
+            }
+            uptime_spans = [
+                _serialize_columnar_uptime_item(item, project_slugs) for item in trace_items
+            ]
+            uptime_spans.sort(
+                key=lambda s: s.get("additional_attributes", {}).get("request_sequence", 0)
+            )
+            root_span = uptime_spans[-1]
+            result.extend(uptime_spans)
+
     id_to_span = {event["id"]: event for event in spans_data}
     id_to_error: dict[str, Any] = {}
     for event in errors_data:
@@ -331,6 +525,10 @@ def query_trace_data(
         if span["parent_span"] in id_to_span:
             parent = id_to_span[span["parent_span"]]
             parent["children"].append(span)
+        elif root_span:
+            # Update parent_span to point to the root span when reassigning orphans
+            span["parent_span"] = root_span.get("event_id", root_span.get("id"))
+            root_span["children"].append(span)
         else:
             result.append(span)
         if span["id"] in id_to_error:

--- a/src/sentry/snuba/trace.py
+++ b/src/sentry/snuba/trace.py
@@ -343,12 +343,7 @@ def _uptime_results_query(
 
 
 def _run_uptime_results_query(uptime_query: TraceItemTableRequest) -> list[TraceItemTableResponse]:
-    """Execute the uptime results query"""
-    try:
-        return table_rpc([uptime_query])
-    except Exception:
-        logger.exception("Failed to execute uptime results query")
-        raise
+    return table_rpc([uptime_query])
 
 
 def _serialize_columnar_uptime_item(
@@ -529,7 +524,6 @@ def query_trace_data(
             parent = id_to_span[span["parent_span"]]
             parent["children"].append(span)
         elif root_span:
-            # Update parent_span to point to the root span when reassigning orphans
             span["parent_span"] = root_span.get("event_id", root_span.get("id"))
             root_span["children"].append(span)
         else:

--- a/src/sentry/uptime/endpoints/project_uptime_alert_checks_index.py
+++ b/src/sentry/uptime/endpoints/project_uptime_alert_checks_index.py
@@ -248,12 +248,14 @@ class ProjectUptimeAlertCheckIndexEndpoint(ProjectUptimeAlertEndpoint):
             duration_ms = (
                 (duration_val.val_int // 1000) if duration_val and not duration_val.is_null else 0
             )
+            trace_id = row_dict["sentry.trace_id"].val_str
         else:
             uptime_check_id = row_dict["uptime_check_id"].val_str
             scheduled_check_time = datetime.fromtimestamp(
                 row_dict["scheduled_check_time"].val_double
             )
             duration_ms = row_dict["duration_ms"].val_int
+            trace_id = row_dict["trace_id"].val_str
 
         return EapCheckEntry(
             uptime_check_id=uptime_check_id,
@@ -278,7 +280,7 @@ class ProjectUptimeAlertCheckIndexEndpoint(ProjectUptimeAlertEndpoint):
                 else row_dict["http_status_code"].val_int
             ),
             duration_ms=duration_ms,
-            trace_id=row_dict["trace_id"].val_str,
+            trace_id=trace_id,
             incident_status=IncidentStatus(row_dict["incident_status"].val_int),
             environment=row_dict.get("environment", AttributeValue(val_str="")).val_str,
             region=row_dict["region"].val_str,

--- a/tests/sentry/uptime/endpoints/test_base.py
+++ b/tests/sentry/uptime/endpoints/test_base.py
@@ -102,7 +102,6 @@ class UptimeResultEAPTestCase(BaseTestCase):
         if incident_status is not None:
             attributes_data["incident_status"] = incident_status.value
 
-        # Always set original_url
         if original_url is None:
             original_url = request_url
         attributes_data["original_url"] = original_url

--- a/tests/sentry/uptime/endpoints/test_base.py
+++ b/tests/sentry/uptime/endpoints/test_base.py
@@ -36,6 +36,7 @@ class UptimeResultEAPTestCase(BaseTestCase):
         http_status_code=200,
         request_type="GET",
         request_url="https://example.com",
+        original_url=None,
         request_sequence=0,
         check_duration_us=150000,
         request_duration_us=125000,
@@ -45,8 +46,8 @@ class UptimeResultEAPTestCase(BaseTestCase):
         time_to_first_byte_duration_us=None,
         send_request_duration_us=None,
         receive_response_duration_us=None,
-        request_body_size_bytes=0,
-        response_body_size_bytes=1024,
+        request_body_size_bytes=None,
+        response_body_size_bytes=None,
         status_reason_type=None,
         status_reason_description=None,
     ) -> TraceItem:
@@ -74,22 +75,22 @@ class UptimeResultEAPTestCase(BaseTestCase):
             "request_sequence": request_sequence,
             "check_duration_us": check_duration_us,
             "request_duration_us": request_duration_us,
-            "request_body_size_bytes": request_body_size_bytes,
-            "response_body_size_bytes": response_body_size_bytes,
         }
 
         if check_id is not None:
             attributes_data["check_id"] = check_id
 
-        timing_fields = {
+        optional_fields = {
             "dns_lookup_duration_us": dns_lookup_duration_us,
             "tcp_connection_duration_us": tcp_connection_duration_us,
             "tls_handshake_duration_us": tls_handshake_duration_us,
             "time_to_first_byte_duration_us": time_to_first_byte_duration_us,
             "send_request_duration_us": send_request_duration_us,
             "receive_response_duration_us": receive_response_duration_us,
+            "request_body_size_bytes": request_body_size_bytes,
+            "response_body_size_bytes": response_body_size_bytes,
         }
-        for field, value in timing_fields.items():
+        for field, value in optional_fields.items():
             if value is not None:
                 attributes_data[field] = value
 
@@ -100,6 +101,11 @@ class UptimeResultEAPTestCase(BaseTestCase):
 
         if incident_status is not None:
             attributes_data["incident_status"] = incident_status.value
+
+        # Always set original_url
+        if original_url is None:
+            original_url = request_url
+        attributes_data["original_url"] = original_url
 
         attributes_proto = {}
         for k, v in attributes_data.items():

--- a/tests/snuba/api/endpoints/test_organization_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_trace.py
@@ -452,7 +452,6 @@ class OrganizationEventsTraceEndpointTest(
         if original_url is None:
             original_url = kwargs.get("request_url", "https://example.com")
         kwargs["original_url"] = original_url
-        # Don't include default body size fields if not specified
         kwargs.setdefault("request_body_size_bytes", None)
         kwargs.setdefault("response_body_size_bytes", None)
         return self.create_eap_uptime_result(**kwargs)

--- a/tests/snuba/api/endpoints/test_organization_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_trace.py
@@ -1,19 +1,132 @@
 import logging
+from datetime import datetime
 from unittest import mock
 from uuid import uuid4
 
 from django.urls import reverse
+from sentry_protos.snuba.v1.trace_item_pb2 import TraceItem
 
+from sentry.search.events.types import SnubaParams
 from sentry.testutils.helpers.datetime import before_now
 from sentry.utils.samples import load_data
+from tests.sentry.uptime.endpoints.test_base import UptimeResultEAPTestCase
 from tests.snuba.api.endpoints.test_organization_events_trace import (
     OrganizationEventsTraceEndpointBase,
 )
 
 logger = logging.getLogger(__name__)
 
+from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeValue as ProtoAttributeValue
 
-class OrganizationEventsTraceEndpointTest(OrganizationEventsTraceEndpointBase):
+from sentry.snuba.trace import _serialize_columnar_uptime_item
+from sentry.testutils.cases import TestCase
+
+
+class TestSerializeColumnarUptimeItem(TestCase):
+    """Test serialization of columnar uptime data to span format."""
+
+    def setUp(self):
+        super().setUp()
+        self.project_slugs = {1: "test-project", 2: "another-project"}
+        self.snuba_params = mock.MagicMock(spec=SnubaParams)
+        self.snuba_params.project_ids = [1]
+
+    def test_basic_uptime_item_serialization(self):
+        """Test basic serialization with all required fields."""
+        row_dict = {
+            "sentry.project_id": ProtoAttributeValue(val_int=1),
+            "guid": ProtoAttributeValue(val_str="check-123"),
+            "sentry.trace_id": ProtoAttributeValue(val_str="a" * 32),
+            "check_status": ProtoAttributeValue(val_str="success"),
+            "http_status_code": ProtoAttributeValue(val_int=200),
+            "request_url": ProtoAttributeValue(val_str="https://example.com"),
+            "original_url": ProtoAttributeValue(val_str="https://example.com"),
+            "scheduled_check_time_us": ProtoAttributeValue(val_int=1700000000000000),
+            "check_duration_us": ProtoAttributeValue(val_int=500000),
+            "subscription_id": ProtoAttributeValue(val_str="sub-456"),
+            "region": ProtoAttributeValue(val_str="us-east-1"),
+            "request_sequence": ProtoAttributeValue(val_int=0),
+        }
+
+        result = _serialize_columnar_uptime_item(row_dict, self.project_slugs)
+
+        assert result["event_id"] == "check-123"
+        assert result["project_id"] == 1
+        assert result["project_slug"] == "test-project"
+        assert result["transaction_id"] == "a" * 32
+        assert result["transaction"] == "uptime.check"
+        assert result["event_type"] == "uptime"
+        assert result["op"] == "uptime.request"
+        assert result["duration"] == 500.0
+        assert result["name"] == "https://example.com"
+        assert result["description"] == "Uptime Check [success] - https://example.com (200)"
+        assert result["start_timestamp"] == datetime.fromtimestamp(1700000000)
+        assert result["end_timestamp"] == datetime.fromtimestamp(1700000000.5)
+        attrs = result["additional_attributes"]
+        assert attrs["guid"] == "check-123"
+        assert attrs["check_status"] == "success"
+        assert attrs["http_status_code"] == 200
+        assert attrs["request_url"] == "https://example.com"
+        assert attrs["original_url"] == "https://example.com"
+        assert attrs["subscription_id"] == "sub-456"
+        assert attrs["region"] == "us-east-1"
+        assert attrs["request_sequence"] == 0
+        assert "project_id" not in attrs
+        assert "organization.id" not in attrs
+        assert "timestamp" not in attrs
+
+    def test_redirect_chain_serialization(self):
+        """Test serialization of redirect chain with different URLs."""
+        row_dict = {
+            "sentry.project_id": ProtoAttributeValue(val_int=1),
+            "guid": ProtoAttributeValue(val_str="check-789"),
+            "sentry.trace_id": ProtoAttributeValue(val_str="b" * 32),
+            "check_status": ProtoAttributeValue(val_str="success"),
+            "http_status_code": ProtoAttributeValue(val_int=301),
+            "request_url": ProtoAttributeValue(val_str="https://www.example.com"),
+            "original_url": ProtoAttributeValue(val_str="https://example.com"),
+            "scheduled_check_time_us": ProtoAttributeValue(val_int=1700000000000000),
+            "check_duration_us": ProtoAttributeValue(val_int=300000),
+            "request_sequence": ProtoAttributeValue(val_int=1),
+        }
+
+        result = _serialize_columnar_uptime_item(row_dict, self.project_slugs)
+
+        assert result["description"] == "Uptime Check [success] - https://www.example.com (301)"
+        assert result["name"] == "https://www.example.com"
+        assert result["additional_attributes"]["request_url"] == "https://www.example.com"
+        assert result["additional_attributes"]["original_url"] == "https://example.com"
+        assert result["additional_attributes"]["request_sequence"] == 1
+
+    def test_null_and_missing_fields(self):
+        """Test handling of null and missing optional fields."""
+        row_dict = {
+            "sentry.project_id": ProtoAttributeValue(val_int=1),
+            "guid": ProtoAttributeValue(val_str="check-null"),
+            "sentry.trace_id": ProtoAttributeValue(val_str="c" * 32),
+            "check_status": ProtoAttributeValue(val_str="failure"),
+            "http_status_code": ProtoAttributeValue(is_null=True),
+            "request_url": ProtoAttributeValue(val_str="https://test.com"),
+            "scheduled_check_time_us": ProtoAttributeValue(val_int=1700000000000000),
+            "dns_lookup_duration_us": ProtoAttributeValue(val_int=50000),
+            "tcp_connection_duration_us": ProtoAttributeValue(is_null=True),
+        }
+
+        result = _serialize_columnar_uptime_item(row_dict, self.project_slugs)
+
+        assert result["duration"] == 0.0
+        assert result["name"] == "https://test.com"
+        assert result["description"] == "Uptime Check [failure] - https://test.com"
+        attrs = result["additional_attributes"]
+        assert "http_status_code" not in attrs
+        assert "original_url" not in attrs
+        assert attrs["dns_lookup_duration_us"] == 50000
+        assert "tcp_connection_duration_us" not in attrs
+
+
+class OrganizationEventsTraceEndpointTest(
+    OrganizationEventsTraceEndpointBase, UptimeResultEAPTestCase
+):
     url_name = "sentry-api-0-organization-trace"
     FEATURES = ["organizations:trace-spans-format"]
 
@@ -325,3 +438,341 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsTraceEndpointBase):
         else:
             orphan = data[1]
         self.assert_event(orphan, orphan_event, "orphan")
+
+    def _find_uptime_spans(self, data):
+        """Helper to find all uptime spans in the response data"""
+        uptime_spans = []
+        for item in data:
+            if item.get("event_type") == "uptime":
+                uptime_spans.append(item)
+        return uptime_spans
+
+    def _create_uptime_result_with_original_url(self, original_url=None, **kwargs):
+        """Helper to create uptime result with original_url attribute"""
+        if original_url is None:
+            original_url = kwargs.get("request_url", "https://example.com")
+        kwargs["original_url"] = original_url
+        # Don't include default body size fields if not specified
+        kwargs.setdefault("request_body_size_bytes", None)
+        kwargs.setdefault("response_body_size_bytes", None)
+        return self.create_eap_uptime_result(**kwargs)
+
+    def assert_expected_results(self, response_data, input_trace_items, expected_children_ids=None):
+        """Assert that API response matches expected results from input trace items."""
+        uptime_spans = [item for item in response_data if item.get("event_type") == "uptime"]
+
+        def sort_key(item):
+            guid = (
+                item.attributes.get("guid", ProtoAttributeValue(val_str="")).string_value
+                if hasattr(item, "attributes")
+                else item.get("event_id", "")
+            )
+            seq = (
+                item.attributes.get("request_sequence", ProtoAttributeValue(val_int=0)).int_value
+                if hasattr(item, "attributes")
+                else item.get("additional_attributes", {}).get("request_sequence", 0)
+            )
+            return guid, seq
+
+        sorted_items = sorted(input_trace_items, key=sort_key)
+        uptime_spans.sort(key=lambda s: sort_key(s))
+
+        for i, (actual, expected_item) in enumerate(zip(uptime_spans, sorted_items)):
+            expected = self._trace_item_to_api_span(expected_item)
+            actual_without_children = {k: v for k, v in actual.items() if k != "children"}
+            expected_without_children = {k: v for k, v in expected.items() if k != "children"}
+            assert (
+                actual_without_children == expected_without_children
+            ), f"Span {i} differs (excluding children)"
+
+        if expected_children_ids:
+            final_span = max(
+                uptime_spans,
+                key=lambda s: s.get("additional_attributes", {}).get("request_sequence", -1),
+            )
+            actual_children = final_span.get("children", [])
+            assert len(actual_children) == len(
+                expected_children_ids
+            ), f"Expected {len(expected_children_ids)} children, got {len(actual_children)}"
+
+            actual_child_txns = {child.get("transaction") for child in actual_children}
+            for expected_id in expected_children_ids:
+                assert (
+                    expected_id in actual_child_txns
+                ), f"Expected '{expected_id}' transaction in children"
+
+    def _trace_item_to_api_span(self, trace_item: TraceItem, children=None) -> dict:
+        """Convert a TraceItem to the exact format returned by the API."""
+        attrs = trace_item.attributes
+        row_dict = {}
+        for attr_name, attr_value in attrs.items():
+            if attr_value.HasField("string_value"):
+                row_dict[attr_name] = ProtoAttributeValue(val_str=attr_value.string_value)
+            elif attr_value.HasField("int_value"):
+                row_dict[attr_name] = ProtoAttributeValue(val_int=attr_value.int_value)
+            elif attr_value.HasField("double_value"):
+                row_dict[attr_name] = ProtoAttributeValue(val_double=attr_value.double_value)
+            elif attr_value.HasField("bool_value"):
+                row_dict[attr_name] = ProtoAttributeValue(val_bool=attr_value.bool_value)
+
+        row_dict["sentry.project_id"] = ProtoAttributeValue(val_int=trace_item.project_id)
+        row_dict["sentry.organization_id"] = ProtoAttributeValue(val_int=trace_item.organization_id)
+        row_dict["sentry.trace_id"] = ProtoAttributeValue(val_str=trace_item.trace_id)
+        row_dict["sentry.timestamp"] = ProtoAttributeValue(
+            val_double=trace_item.timestamp.ToSeconds()
+        )
+        row_dict["sentry.item_type"] = ProtoAttributeValue(val_int=trace_item.item_type)
+        project_slugs = {trace_item.project_id: self.project.slug}
+        span = _serialize_columnar_uptime_item(row_dict, project_slugs)
+
+        if children:
+            span["children"] = children
+
+        return span
+
+    def test_with_uptime_results(self):
+        """Test that uptime results are included when include_uptime=1"""
+        self.load_trace(is_eap=True)
+
+        features = self.FEATURES + [
+            "organizations:uptime-eap-enabled",
+            "organizations:uptime-eap-uptime-results-query",
+        ]
+        redirect_result = self._create_uptime_result_with_original_url(
+            organization=self.organization,
+            project=self.project,
+            trace_id=self.trace_id,
+            guid="check-123",
+            subscription_id="sub-456",
+            check_status="success",
+            http_status_code=301,
+            request_sequence=0,
+            request_url="https://example.com",
+            scheduled_check_time=self.day_ago,
+            check_duration_us=300000,
+        )
+        final_result = self._create_uptime_result_with_original_url(
+            organization=self.organization,
+            project=self.project,
+            trace_id=self.trace_id,
+            guid="check-123",
+            subscription_id="sub-456",
+            check_status="success",
+            http_status_code=200,
+            request_sequence=1,
+            request_url="https://www.example.com",
+            original_url="https://example.com",
+            scheduled_check_time=self.day_ago,
+            check_duration_us=500000,
+        )
+
+        self.store_uptime_results([redirect_result, final_result])
+
+        with self.feature(features):
+            response = self.client_get(
+                data={"timestamp": self.day_ago, "include_uptime": "1"},
+            )
+
+        assert response.status_code == 200, response.content
+        data = response.data
+
+        self.assert_expected_results(
+            data, [redirect_result, final_result], expected_children_ids=["root"]
+        )
+
+    def test_without_uptime_results(self):
+        """Test that uptime results are not queried when include_uptime is not set"""
+        self.load_trace(is_eap=True)
+        uptime_result = self._create_uptime_result_with_original_url(
+            organization=self.organization,
+            project=self.project,
+            trace_id=self.trace_id,
+            guid="check-456",
+            subscription_id="sub-789",
+            check_status="success",
+            http_status_code=200,
+            request_sequence=0,
+            request_url="https://test.com",
+            scheduled_check_time=self.day_ago,
+        )
+
+        self.store_uptime_results([uptime_result])
+
+        with self.feature(self.FEATURES):
+            response = self.client_get(
+                data={"timestamp": self.day_ago},
+            )
+
+        assert response.status_code == 200, response.content
+        data = response.data
+        assert len(data) == 1
+        self.assert_trace_data(data[0])
+
+        uptime_spans = self._find_uptime_spans(data)
+        assert len(uptime_spans) == 0
+
+    def test_uptime_root_tree_with_orphaned_spans(self):
+        """Test that orphaned spans are parented to the final uptime request"""
+        self.load_trace(is_eap=True)
+
+        self.create_event(
+            trace_id=self.trace_id,
+            transaction="/transaction/orphan",
+            spans=[],
+            project_id=self.project.id,
+            parent_span_id=uuid4().hex[:16],
+            milliseconds=500,
+            is_eap=True,
+        )
+        redirect_result = self._create_uptime_result_with_original_url(
+            organization=self.organization,
+            project=self.project,
+            trace_id=self.trace_id,
+            guid="check-123",
+            check_status="success",
+            http_status_code=301,
+            request_sequence=0,
+            request_url="https://example.com",
+            scheduled_check_time=self.day_ago,
+            check_duration_us=300000,
+        )
+
+        final_result = self._create_uptime_result_with_original_url(
+            organization=self.organization,
+            project=self.project,
+            trace_id=self.trace_id,
+            guid="check-123",
+            check_status="success",
+            http_status_code=200,
+            request_sequence=1,
+            request_url="https://www.example.com",
+            scheduled_check_time=self.day_ago,
+        )
+
+        features = self.FEATURES + [
+            "organizations:uptime-eap-enabled",
+            "organizations:uptime-eap-uptime-results-query",
+        ]
+
+        self.store_uptime_results([redirect_result, final_result])
+
+        with self.feature(features):
+            response = self.client_get(
+                data={"timestamp": self.day_ago, "include_uptime": "1"},
+            )
+
+        assert response.status_code == 200, response.content
+        data = response.data
+
+        self.assert_expected_results(
+            data,
+            [redirect_result, final_result],
+            expected_children_ids=["root", "/transaction/orphan"],
+        )
+
+    def test_uptime_root_tree_without_orphans(self):
+        """Test uptime results when there are no orphaned spans"""
+        self.load_trace(is_eap=True)
+
+        uptime_result = self._create_uptime_result_with_original_url(
+            organization=self.organization,
+            project=self.project,
+            trace_id=self.trace_id,
+            guid="check-456",
+            check_status="success",
+            http_status_code=200,
+            request_sequence=0,
+            request_url="https://test.com",
+            scheduled_check_time=self.day_ago,
+            check_duration_us=200000,
+        )
+
+        features = self.FEATURES + [
+            "organizations:uptime-eap-enabled",
+            "organizations:uptime-eap-uptime-results-query",
+        ]
+
+        self.store_uptime_results([uptime_result])
+
+        with self.feature(features):
+            response = self.client_get(
+                data={"timestamp": self.day_ago, "include_uptime": "1"},
+            )
+
+        assert response.status_code == 200, response.content
+        data = response.data
+
+        self.assert_expected_results(data, [uptime_result], expected_children_ids=["root"])
+
+    def test_uptime_root_tree_multiple_checks(self):
+        """Test handling of multiple uptime checks with only the last one becoming parent"""
+        self.load_trace(is_eap=True)
+
+        self.create_event(
+            trace_id=self.trace_id,
+            transaction="/transaction/orphan",
+            spans=[],
+            project_id=self.project.id,
+            parent_span_id=uuid4().hex[:16],
+            milliseconds=500,
+            is_eap=True,
+        )
+        check1_result = self._create_uptime_result_with_original_url(
+            organization=self.organization,
+            project=self.project,
+            trace_id=self.trace_id,
+            guid="check-111",
+            check_status="success",
+            http_status_code=200,
+            request_sequence=0,
+            request_url="https://first.com",
+            scheduled_check_time=self.day_ago,
+            check_duration_us=100000,
+        )
+
+        check2_redirect = self._create_uptime_result_with_original_url(
+            organization=self.organization,
+            project=self.project,
+            trace_id=self.trace_id,
+            guid="check-222",
+            check_status="success",
+            http_status_code=301,
+            request_sequence=0,
+            request_url="https://second.com",
+            scheduled_check_time=self.day_ago,
+            check_duration_us=200000,
+        )
+
+        check2_final = self._create_uptime_result_with_original_url(
+            organization=self.organization,
+            project=self.project,
+            trace_id=self.trace_id,
+            guid="check-222",
+            check_status="success",
+            http_status_code=200,
+            request_sequence=1,
+            request_url="https://www.second.com",
+            scheduled_check_time=self.day_ago,
+            check_duration_us=300000,
+        )
+
+        features = self.FEATURES + [
+            "organizations:uptime-eap-enabled",
+            "organizations:uptime-eap-uptime-results-query",
+        ]
+
+        self.store_uptime_results([check1_result, check2_redirect, check2_final])
+
+        with self.feature(features):
+            response = self.client_get(
+                data={"timestamp": self.day_ago, "include_uptime": "1"},
+            )
+
+        assert response.status_code == 200, response.content
+        data = response.data
+
+        self.assert_expected_results(
+            data,
+            [check1_result, check2_redirect, check2_final],
+            expected_children_ids=["/transaction/orphan", "root"],
+        )


### PR DESCRIPTION
This adds the `include_uptime` param to this endpoint. When this is passed, we'll fetch uptime results and make the main request the root span for all other items in the trace.

<!-- Describe your PR here. -->