### PR TITLE
chore: bump to protobuf 5.29.5

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -41,7 +41,7 @@ parsimonious>=0.10.0
 petname>=2.6
 phonenumberslite>=8.12.32
 Pillow>=11.0.0
-protobuf>=5.27.3
+protobuf==5.29.5
 proto-plus>=1.25.0
 python-rapidjson>=1.4
 psutil>=5.9.2

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -132,7 +132,7 @@ pluggy==1.5.0
 pre-commit==4.2.0
 prompt-toolkit==3.0.51
 proto-plus==1.25.0
-protobuf==5.27.3
+protobuf==5.29.5
 psutil==5.9.7
 psycopg2-binary==2.9.10
 pyasn1==0.4.5

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -90,7 +90,7 @@ phonenumberslite==8.12.55
 pillow==11.0.0
 prompt-toolkit==3.0.51
 proto-plus==1.25.0
-protobuf==5.27.3
+protobuf==5.29.5
 psutil==5.9.7
 psycopg2-binary==2.9.10
 pyasn1==0.4.5


### PR DESCRIPTION
edit: oh i see this is a dupe of https://github.com/getsentry/sentry/pull/95772 - @mdtro you actively working on fixing this? if not - is it ok or even possible to ignore for now to unblock uv?

fixes https://github.com/advisories/GHSA-8qvm-5x2c-j2w7

this was detected by switching over to uv (still WIP) in https://github.com/getsentry/sentry/pull/96782, i suppose because it actually recognizes pyproject.toml deps vs. our bespoke requirements files