### PR TITLE
Create event lifecycle decorator with halt exceptions

### DIFF
--- a/src/sentry/integrations/utils/metrics.py
+++ b/src/sentry/integrations/utils/metrics.py
@@ -423,3 +423,44 @@ class IntegrationWebhookEvent(IntegrationEventLifecycleMetric):
 
     def get_interaction_type(self) -> str:
         return str(self.interaction_type)
+
+
+def event_lifecycle_decorator(
+    metric: EventLifecycleMetric,
+    assume_success: bool = True,
+    sample_log_rate: float = 1.0,
+    halt_on_exceptions: list[type[BaseException]] | None = None
+):
+    """Decorator that wraps a function with event lifecycle tracking.
+    
+    This decorator provides the same functionality as using the EventLifecycle
+    context manager manually, but in a more convenient decorator form.
+    
+    Args:
+        metric: The EventLifecycleMetric instance to use for tracking
+        assume_success: Whether to assume success if no explicit outcome is recorded
+        sample_log_rate: Rate at which to sample logs (0.0-1.0)
+        halt_on_exceptions: List of exception types that should be treated as halts instead of failures
+        
+    Example:
+        @event_lifecycle_decorator(
+            my_metric, 
+            halt_on_exceptions=[requests.RequestException, ValueError]
+        )
+        def my_integration_function():
+            # Function implementation
+            pass
+    """
+    def decorator(func):
+        def wrapper(*args, **kwargs):
+            with metric.capture(assume_success=assume_success, sample_log_rate=sample_log_rate) as lifecycle:
+                try:
+                    result = func(*args, **kwargs)
+                    return result
+                except BaseException as e:
+                    if halt_on_exceptions and any(isinstance(e, exc_type) for exc_type in halt_on_exceptions):
+                        lifecycle.record_halt(e)
+                    # Let the exception bubble up naturally - the context manager will handle it
+                    raise
+        return wrapper
+    return decorator

--- a/src/sentry/integrations/utils/metrics.py
+++ b/src/sentry/integrations/utils/metrics.py
@@ -429,38 +429,45 @@ def event_lifecycle_decorator(
     metric: EventLifecycleMetric,
     assume_success: bool = True,
     sample_log_rate: float = 1.0,
-    halt_on_exceptions: list[type[BaseException]] | None = None
+    halt_on_exceptions: list[type[BaseException]] | None = None,
 ):
     """Decorator that wraps a function with event lifecycle tracking.
-    
+
     This decorator provides the same functionality as using the EventLifecycle
     context manager manually, but in a more convenient decorator form.
-    
+
     Args:
         metric: The EventLifecycleMetric instance to use for tracking
         assume_success: Whether to assume success if no explicit outcome is recorded
         sample_log_rate: Rate at which to sample logs (0.0-1.0)
         halt_on_exceptions: List of exception types that should be treated as halts instead of failures
-        
+
     Example:
         @event_lifecycle_decorator(
-            my_metric, 
+            my_metric,
             halt_on_exceptions=[requests.RequestException, ValueError]
         )
         def my_integration_function():
             # Function implementation
             pass
     """
+
     def decorator(func):
         def wrapper(*args, **kwargs):
-            with metric.capture(assume_success=assume_success, sample_log_rate=sample_log_rate) as lifecycle:
+            with metric.capture(
+                assume_success=assume_success, sample_log_rate=sample_log_rate
+            ) as lifecycle:
                 try:
                     result = func(*args, **kwargs)
                     return result
                 except BaseException as e:
-                    if halt_on_exceptions and any(isinstance(e, exc_type) for exc_type in halt_on_exceptions):
+                    if halt_on_exceptions and any(
+                        isinstance(e, exc_type) for exc_type in halt_on_exceptions
+                    ):
                         lifecycle.record_halt(e)
                     # Let the exception bubble up naturally - the context manager will handle it
                     raise
+
         return wrapper
+
     return decorator

--- a/tests/sentry/integrations/utils/test_lifecycle_metrics.py
+++ b/tests/sentry/integrations/utils/test_lifecycle_metrics.py
@@ -474,3 +474,206 @@ class IntegrationEventLifecycleMetricTest(TestCase):
 
         # Should log since default is 1.0
         mock_logger.info.assert_called_once()
+
+
+    # Decorator tests
+    @mock.patch("sentry.integrations.utils.metrics.logger")
+    @mock.patch("sentry.integrations.utils.metrics.metrics")
+    def test_decorator_success(
+        self, mock_metrics: mock.MagicMock, mock_logger: mock.MagicMock
+    ) -> None:
+        """Test that decorator records success for functions that complete normally"""
+        from sentry.integrations.utils.metrics import event_lifecycle_decorator
+        
+        metric_obj = self.TestLifecycleMetric()
+        
+        @event_lifecycle_decorator(metric_obj)
+        def test_function():
+            return "success"
+        
+        result = test_function()
+        
+        assert result == "success"
+        self._check_metrics_call_args(mock_metrics, "success")
+        mock_logger.error.assert_not_called()
+        mock_logger.warning.assert_not_called()
+
+    @mock.patch("sentry.integrations.utils.metrics.logger")
+    @mock.patch("sentry.integrations.utils.metrics.metrics")
+    def test_decorator_failure(
+        self, mock_metrics: mock.MagicMock, mock_logger: mock.MagicMock
+    ) -> None:
+        """Test that decorator records failure for unhandled exceptions"""
+        from sentry.integrations.utils.metrics import event_lifecycle_decorator
+        
+        metric_obj = self.TestLifecycleMetric()
+        
+        @event_lifecycle_decorator(metric_obj)
+        def test_function():
+            raise ExampleException("test error")
+        
+        with pytest.raises(ExampleException):
+            test_function()
+        
+        self._check_metrics_call_args(mock_metrics, "failure")
+
+    @mock.patch("sentry.integrations.utils.metrics.logger")
+    @mock.patch("sentry.integrations.utils.metrics.metrics")
+    def test_decorator_halt_on_specific_exceptions(
+        self, mock_metrics: mock.MagicMock, mock_logger: mock.MagicMock
+    ) -> None:
+        """Test that decorator records halt for specified exception types"""
+        from sentry.integrations.utils.metrics import event_lifecycle_decorator
+        
+        metric_obj = self.TestLifecycleMetric()
+        
+        @event_lifecycle_decorator(metric_obj, halt_on_exceptions=[ExampleException])
+        def test_function():
+            raise ExampleException("this should be a halt")
+        
+        with pytest.raises(ExampleException):
+            test_function()
+        
+        self._check_metrics_call_args(mock_metrics, "halted")
+        mock_logger.info.assert_called_once_with(
+            "integrations.slo.halted",
+            extra={
+                "integration_domain": "messaging",
+                "integration_name": "my_integration",
+                "interaction_type": "my_interaction",
+                "exception_summary": repr(ExampleException("this should be a halt")),
+            },
+        )
+
+    @mock.patch("sentry.integrations.utils.metrics.logger")
+    @mock.patch("sentry.integrations.utils.metrics.metrics")
+    def test_decorator_halt_vs_failure_exception_types(
+        self, mock_metrics: mock.MagicMock, mock_logger: mock.MagicMock
+    ) -> None:
+        """Test that decorator correctly distinguishes between halt and failure exceptions"""
+        from sentry.integrations.utils.metrics import event_lifecycle_decorator
+        
+        class HaltException(Exception):
+            pass
+            
+        class FailureException(Exception):
+            pass
+        
+        metric_obj = self.TestLifecycleMetric()
+        
+        @event_lifecycle_decorator(metric_obj, halt_on_exceptions=[HaltException])
+        def test_function_halt():
+            raise HaltException("should halt")
+            
+        @event_lifecycle_decorator(metric_obj, halt_on_exceptions=[HaltException])
+        def test_function_failure():
+            raise FailureException("should fail")
+        
+        # Test halt exception
+        with pytest.raises(HaltException):
+            test_function_halt()
+        
+        self._check_metrics_call_args(mock_metrics, "halted")
+        mock_logger.info.assert_called_once()
+        
+        # Reset mocks
+        mock_metrics.reset_mock()
+        mock_logger.reset_mock()
+        
+        # Test failure exception
+        with pytest.raises(FailureException):
+            test_function_failure()
+        
+        self._check_metrics_call_args(mock_metrics, "failure")
+        mock_logger.warning.assert_called_once()
+
+    @mock.patch("sentry.integrations.utils.metrics.logger")
+    @mock.patch("sentry.integrations.utils.metrics.metrics")
+    def test_decorator_assume_success_false(
+        self, mock_metrics: mock.MagicMock, mock_logger: mock.MagicMock
+    ) -> None:
+        """Test that decorator respects assume_success=False"""
+        from sentry.integrations.utils.metrics import event_lifecycle_decorator
+        
+        metric_obj = self.TestLifecycleMetric()
+        
+        @event_lifecycle_decorator(metric_obj, assume_success=False)
+        def test_function():
+            return "completed"
+        
+        result = test_function()
+        
+        assert result == "completed"
+        self._check_metrics_call_args(mock_metrics, "halted")
+
+    @mock.patch("sentry.integrations.utils.metrics.random")
+    @mock.patch("sentry.integrations.utils.metrics.logger")
+    @mock.patch("sentry.integrations.utils.metrics.metrics")
+    def test_decorator_sample_log_rate(
+        self, mock_metrics: mock.MagicMock, mock_logger: mock.MagicMock, mock_random: mock.MagicMock
+    ) -> None:
+        """Test that decorator respects sample_log_rate parameter"""
+        from sentry.integrations.utils.metrics import event_lifecycle_decorator
+        
+        mock_random.random.return_value = 0.15  # Above 0.1 threshold
+        
+        metric_obj = self.TestLifecycleMetric()
+        
+        @event_lifecycle_decorator(metric_obj, sample_log_rate=0.1, halt_on_exceptions=[ExampleException])
+        def test_function():
+            raise ExampleException("test")
+        
+        with pytest.raises(ExampleException):
+            test_function()
+        
+        # Metrics should always be called
+        self._check_metrics_call_args(mock_metrics, "halted")
+        # Logger should NOT be called since 0.15 > 0.1
+        mock_logger.info.assert_not_called()
+        mock_random.random.assert_called_once()
+
+    @mock.patch("sentry.integrations.utils.metrics.logger")
+    @mock.patch("sentry.integrations.utils.metrics.metrics")
+    def test_decorator_inheritance_with_halt_exceptions(
+        self, mock_metrics: mock.MagicMock, mock_logger: mock.MagicMock
+    ) -> None:
+        """Test that decorator handles exception inheritance correctly"""
+        from sentry.integrations.utils.metrics import event_lifecycle_decorator
+        
+        class BaseHaltException(Exception):
+            pass
+            
+        class DerivedHaltException(BaseHaltException):
+            pass
+        
+        metric_obj = self.TestLifecycleMetric()
+        
+        @event_lifecycle_decorator(metric_obj, halt_on_exceptions=[BaseHaltException])
+        def test_function():
+            raise DerivedHaltException("derived exception")
+        
+        with pytest.raises(DerivedHaltException):
+            test_function()
+        
+        # Should be treated as halt since DerivedHaltException inherits from BaseHaltException
+        self._check_metrics_call_args(mock_metrics, "halted")
+        mock_logger.info.assert_called_once()
+
+    @mock.patch("sentry.integrations.utils.metrics.logger")
+    @mock.patch("sentry.integrations.utils.metrics.metrics")
+    def test_decorator_function_arguments_preserved(
+        self, mock_metrics: mock.MagicMock, mock_logger: mock.MagicMock
+    ) -> None:
+        """Test that decorator preserves function arguments and return values"""
+        from sentry.integrations.utils.metrics import event_lifecycle_decorator
+        
+        metric_obj = self.TestLifecycleMetric()
+        
+        @event_lifecycle_decorator(metric_obj)
+        def test_function(arg1, arg2, kwarg1=None, kwarg2=None):
+            return f"{arg1}-{arg2}-{kwarg1}-{kwarg2}"
+        
+        result = test_function("a", "b", kwarg1="c", kwarg2="d")
+        
+        assert result == "a-b-c-d"
+        self._check_metrics_call_args(mock_metrics, "success")


### PR DESCRIPTION
<!-- Describe your PR here. -->
This PR introduces `event_lifecycle_decorator`, a new decorator for event lifecycle tracking.

**Why this change?**
*   **Convenience:** Provides a more ergonomic, decorator-based syntax for integrating event lifecycle metrics into functions, reducing boilerplate compared to the context manager.
*   **Granular Error Handling:** Adds the `halt_on_exceptions` parameter, allowing specific exception types to be explicitly marked as "halts" rather than "failures." This provides finer control over metric outcomes for expected, non-failure scenarios.

The decorator wraps the existing `EventLifecycle` context manager, ensuring compatibility and leveraging existing logic.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
<a href="https://cursor.com/background-agent?bcId=bc-9599f225-e46c-4e28-8edc-855bcabe768e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9599f225-e46c-4e28-8edc-855bcabe768e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>