### PR TITLE
chore(uptime): Move `_get_columns_for_trace_item_type` to a shared file

### DIFF
--- a/src/sentry/search/eap/common_columns.py
+++ b/src/sentry/search/eap/common_columns.py
@@ -5,6 +5,7 @@ COMMON_COLUMNS = [
     ResolvedAttribute(
         public_alias="organization.id",
         internal_name="sentry.organization_id",
+        internal_type=constants.INT,
         search_type="string",
     ),
     ResolvedAttribute(

--- a/src/sentry/search/eap/uptime_results/attributes.py
+++ b/src/sentry/search/eap/uptime_results/attributes.py
@@ -12,6 +12,11 @@ UPTIME_ATTRIBUTE_DEFINITIONS = {
             search_type="string",
         ),
         ResolvedAttribute(
+            public_alias="environment",
+            internal_name="environment",
+            search_type="string",
+        ),
+        ResolvedAttribute(
             public_alias="guid",
             internal_name="guid",
             search_type="string",

--- a/src/sentry/search/eap/uptime_results/attributes.py
+++ b/src/sentry/search/eap/uptime_results/attributes.py
@@ -173,5 +173,10 @@ UPTIME_ATTRIBUTE_DEFINITIONS = {
             internal_name="receive_response_duration_us",
             search_type="integer",
         ),
+        ResolvedAttribute(
+            public_alias="incident_status",
+            internal_name="incident_status",
+            search_type="integer",
+        ),
     ]
 }

--- a/src/sentry/uptime/eap_utils.py
+++ b/src/sentry/uptime/eap_utils.py
@@ -1,0 +1,72 @@
+from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import Column
+from sentry_protos.snuba.v1.request_common_pb2 import TraceItemType
+from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey
+
+from sentry.search.eap.uptime_results.attributes import UPTIME_ATTRIBUTE_DEFINITIONS
+
+
+def get_columns_for_uptime_trace_item_type(
+    trace_item_type: TraceItemType.ValueType = TraceItemType.TRACE_ITEM_TYPE_UPTIME_RESULT,
+) -> list[Column]:
+    if trace_item_type == TraceItemType.TRACE_ITEM_TYPE_UPTIME_RESULT:
+        renames = {"status_reason_type": "check_status_reason"}
+        return [
+            Column(
+                label=renames.get(col.internal_name, col.internal_name), key=col.proto_definition
+            )
+            for col in UPTIME_ATTRIBUTE_DEFINITIONS.values()
+        ]
+    else:
+        return [
+            Column(
+                label="environment",
+                key=AttributeKey(name="environment", type=AttributeKey.Type.TYPE_STRING),
+            ),
+            Column(
+                label="region",
+                key=AttributeKey(name="region", type=AttributeKey.Type.TYPE_STRING),
+            ),
+            Column(
+                label="check_status",
+                key=AttributeKey(name="check_status", type=AttributeKey.Type.TYPE_STRING),
+            ),
+            Column(
+                label="http_status_code",
+                key=AttributeKey(name="http_status_code", type=AttributeKey.Type.TYPE_INT),
+            ),
+            Column(
+                label="incident_status",
+                key=AttributeKey(name="incident_status", type=AttributeKey.Type.TYPE_INT),
+            ),
+            Column(
+                label="trace_id",
+                key=AttributeKey(name="trace_id", type=AttributeKey.Type.TYPE_STRING),
+            ),
+            Column(
+                label="timestamp",
+                key=AttributeKey(
+                    name="timestamp",
+                    type=AttributeKey.Type.TYPE_DOUBLE,
+                ),
+            ),
+            Column(
+                label="uptime_subscription_id",
+                key=AttributeKey(name="uptime_subscription_id", type=AttributeKey.Type.TYPE_STRING),
+            ),
+            Column(
+                label="uptime_check_id",
+                key=AttributeKey(name="uptime_check_id", type=AttributeKey.Type.TYPE_STRING),
+            ),
+            Column(
+                label="scheduled_check_time",
+                key=AttributeKey(name="scheduled_check_time", type=AttributeKey.Type.TYPE_DOUBLE),
+            ),
+            Column(
+                label="duration_ms",
+                key=AttributeKey(name="duration_ms", type=AttributeKey.Type.TYPE_INT),
+            ),
+            Column(
+                label="check_status_reason",
+                key=AttributeKey(name="check_status_reason", type=AttributeKey.Type.TYPE_STRING),
+            ),
+        ]

--- a/src/sentry/uptime/endpoints/project_uptime_alert_checks_index.py
+++ b/src/sentry/uptime/endpoints/project_uptime_alert_checks_index.py
@@ -32,6 +32,7 @@ from sentry.api.paginator import GenericOffsetPaginator
 from sentry.api.serializers.base import serialize
 from sentry.api.utils import get_date_range_from_params, handle_query_errors
 from sentry.models.project import Project
+from sentry.uptime.eap_utils import get_columns_for_uptime_trace_item_type
 from sentry.uptime.endpoints.bases import ProjectUptimeAlertEndpoint
 from sentry.uptime.endpoints.serializers import EapCheckEntrySerializerResponse
 from sentry.uptime.models import ProjectUptimeSubscription
@@ -175,11 +176,15 @@ class ProjectUptimeAlertCheckIndexEndpoint(ProjectUptimeAlertEndpoint):
                 ),
             ),
             filter=query_filter,
-            columns=self._get_columns_for_trace_item_type(trace_item_type),
+            columns=get_columns_for_uptime_trace_item_type(trace_item_type),
             order_by=[
                 TraceItemTableRequest.OrderBy(
                     column=Column(
-                        label="timestamp",
+                        label=(
+                            "sentry.timestamp"
+                            if trace_item_type == TraceItemType.TRACE_ITEM_TYPE_UPTIME_RESULT
+                            else "timestamp"
+                        ),
                         key=AttributeKey(
                             name=(
                                 "sentry.timestamp"
@@ -198,107 +203,6 @@ class ProjectUptimeAlertCheckIndexEndpoint(ProjectUptimeAlertEndpoint):
 
         rpc_response = snuba_rpc.table_rpc([rpc_request])[0]
         return self._serialize_response(rpc_response, uptime_subscription, trace_item_type)
-
-    def _get_columns_for_trace_item_type(
-        self, trace_item_type: TraceItemType.ValueType
-    ) -> list[Column]:
-        """Get appropriate columns based on trace item type."""
-        common_columns = [
-            Column(
-                label="environment",
-                key=AttributeKey(name="environment", type=AttributeKey.Type.TYPE_STRING),
-            ),
-            Column(
-                label="timestamp",
-                key=AttributeKey(
-                    name=(
-                        "sentry.timestamp"
-                        if trace_item_type == TraceItemType.TRACE_ITEM_TYPE_UPTIME_RESULT
-                        else "timestamp"
-                    ),
-                    type=AttributeKey.Type.TYPE_DOUBLE,
-                ),
-            ),
-            Column(
-                label="region",
-                key=AttributeKey(name="region", type=AttributeKey.Type.TYPE_STRING),
-            ),
-            Column(
-                label="check_status",
-                key=AttributeKey(name="check_status", type=AttributeKey.Type.TYPE_STRING),
-            ),
-            Column(
-                label="http_status_code",
-                key=AttributeKey(name="http_status_code", type=AttributeKey.Type.TYPE_INT),
-            ),
-            Column(
-                label="incident_status",
-                key=AttributeKey(name="incident_status", type=AttributeKey.Type.TYPE_INT),
-            ),
-            Column(
-                label="trace_id",
-                key=AttributeKey(name="trace_id", type=AttributeKey.Type.TYPE_STRING),
-            ),
-        ]
-
-        if trace_item_type == TraceItemType.TRACE_ITEM_TYPE_UPTIME_RESULT:
-            return common_columns + [
-                Column(
-                    label="subscription_id",
-                    key=AttributeKey(name="subscription_id", type=AttributeKey.Type.TYPE_STRING),
-                ),
-                Column(
-                    label="check_id",
-                    key=AttributeKey(name="check_id", type=AttributeKey.Type.TYPE_STRING),
-                ),
-                Column(
-                    label="scheduled_check_time_us",
-                    key=AttributeKey(
-                        name="scheduled_check_time_us", type=AttributeKey.Type.TYPE_INT
-                    ),
-                ),
-                Column(
-                    label="check_duration_us",
-                    key=AttributeKey(name="check_duration_us", type=AttributeKey.Type.TYPE_INT),
-                ),
-                Column(
-                    label="check_status_reason",
-                    key=AttributeKey(name="status_reason_type", type=AttributeKey.Type.TYPE_STRING),
-                ),
-                Column(
-                    label="guid",
-                    key=AttributeKey(name="guid", type=AttributeKey.Type.TYPE_STRING),
-                ),
-            ]
-        else:
-            return common_columns + [
-                Column(
-                    label="uptime_subscription_id",
-                    key=AttributeKey(
-                        name="uptime_subscription_id", type=AttributeKey.Type.TYPE_STRING
-                    ),
-                ),
-                Column(
-                    label="uptime_check_id",
-                    key=AttributeKey(name="uptime_check_id", type=AttributeKey.Type.TYPE_STRING),
-                ),
-                Column(
-                    label="scheduled_check_time",
-                    key=AttributeKey(
-                        name="scheduled_check_time", type=AttributeKey.Type.TYPE_DOUBLE
-                    ),
-                ),
-                Column(
-                    label="duration_ms",
-                    key=AttributeKey(name="duration_ms", type=AttributeKey.Type.TYPE_INT),
-                ),
-                Column(
-                    label="check_status_reason",
-                    key=AttributeKey(
-                        name="check_status_reason", type=AttributeKey.Type.TYPE_STRING
-                    ),
-                ),
-            ]
 
     def _serialize_response(
         self,
@@ -354,7 +258,15 @@ class ProjectUptimeAlertCheckIndexEndpoint(ProjectUptimeAlertEndpoint):
         return EapCheckEntry(
             uptime_check_id=uptime_check_id,
             uptime_monitor_id=uptime_subscription.id,
-            timestamp=datetime.fromtimestamp(row_dict["timestamp"].val_double),
+            timestamp=datetime.fromtimestamp(
+                row_dict[
+                    (
+                        "sentry.timestamp"
+                        if trace_item_type == TraceItemType.TRACE_ITEM_TYPE_UPTIME_RESULT
+                        else "timestamp"
+                    )
+                ].val_double
+            ),
             scheduled_check_time=scheduled_check_time,
             check_status=cast(CheckStatus, row_dict["check_status"].val_str),
             check_status_reason=self._extract_check_status_reason(


### PR DESCRIPTION
We'll be using this function from multiple endpoints, so moving it to a shared location. Also changed it to fetch all columns rather than needing to manually fetch all of them. A few small fixes to make it all fit together too.

<!-- Describe your PR here. -->