### PR TITLE
feat(errors): Support error upsampling on Number of Errors alert

### DIFF
--- a/src/sentry/incidents/endpoints/serializers/alert_rule.py
+++ b/src/sentry/incidents/endpoints/serializers/alert_rule.py
@@ -269,6 +269,11 @@ class AlertRuleSerializer(Serializer):
             allow_eap=obj.snuba_query.dataset == Dataset.EventsAnalyticsPlatform.value,
         )
 
+        # Apply transparency: Convert upsampled_count() back to count() for user-facing responses
+        # This hides the internal upsampling implementation from users
+        if aggregate == "upsampled_count()":
+            aggregate = "count()"
+
         data: AlertRuleSerializerResponse = {
             "id": str(obj.id),
             "name": obj.name,

--- a/src/sentry/incidents/serializers/alert_rule.py
+++ b/src/sentry/incidents/serializers/alert_rule.py
@@ -13,6 +13,7 @@ from urllib3.exceptions import MaxRetryError, TimeoutError
 from sentry import features
 from sentry.api.exceptions import BadRequest, RequestTimeout
 from sentry.api.fields.actor import ActorField
+from sentry.api.helpers.error_upsampling import are_any_projects_error_upsampled
 from sentry.api.serializers.rest_framework.base import CamelSnakeModelSerializer
 from sentry.api.serializers.rest_framework.environment import EnvironmentField
 from sentry.api.serializers.rest_framework.project import ProjectField
@@ -30,6 +31,7 @@ from sentry.incidents.models.alert_rule import (
     AlertRuleThresholdType,
     AlertRuleTrigger,
 )
+from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import QuerySubscription
 from sentry.snuba.snuba_query_validator import SnubaQueryValidator
 from sentry.workflow_engine.migration_helpers.alert_rule import (
@@ -124,6 +126,20 @@ class AlertRuleSerializer(SnubaQueryValidator, CamelSnakeModelSerializer[AlertRu
                 "Invalid threshold type, valid values are %s"
                 % [item.value for item in AlertRuleThresholdType]
             )
+
+    def validate_aggregate(self, aggregate):
+        """
+        Validate aggregate field and reject upsampled_count() from user input.
+
+        upsampled_count() is reserved for internal use only and gets set automatically
+        by the backend when error upsampling is detected. Users should use count() instead.
+        """
+        if aggregate == "upsampled_count()":
+            raise serializers.ValidationError(
+                "upsampled_count() is not allowed as user input. Use count() instead - "
+                "it will be automatically converted to upsampled_count() when appropriate."
+            )
+        return aggregate
 
     def validate(self, data):
         """
@@ -249,6 +265,9 @@ class AlertRuleSerializer(SnubaQueryValidator, CamelSnakeModelSerializer[AlertRu
         with transaction.atomic(router.db_for_write(AlertRule)):
             triggers = validated_data.pop("triggers")
             user = self.context.get("user", None)
+
+            self._apply_error_upsampling_if_needed(validated_data)
+
             try:
                 alert_rule = create_alert_rule(
                     user=user,
@@ -282,6 +301,20 @@ class AlertRuleSerializer(SnubaQueryValidator, CamelSnakeModelSerializer[AlertRu
                     sentry_sdk.capture_exception()
                     raise BadRequest(message="Error when creating alert rule")
             return alert_rule
+
+    def _apply_error_upsampling_if_needed(self, validated_data):
+        """
+        Automatically convert count() to upsampled_count() for error alerts on upsampled projects.
+        """
+        # Only apply to count() aggregates on Events dataset (error alerts)
+        if (
+            validated_data.get("aggregate") == "count()"
+            and validated_data.get("dataset") == Dataset.Events
+            and validated_data.get("projects")
+        ):
+            project_ids = [project.id for project in validated_data["projects"]]
+            if are_any_projects_error_upsampled(project_ids):
+                validated_data["aggregate"] = "upsampled_count()"
 
     def update(self, instance, validated_data):
         triggers = validated_data.pop("triggers")

--- a/src/sentry/incidents/serializers/alert_rule.py
+++ b/src/sentry/incidents/serializers/alert_rule.py
@@ -321,7 +321,7 @@ class AlertRuleSerializer(SnubaQueryValidator, CamelSnakeModelSerializer[AlertRu
         if "id" in validated_data:
             validated_data.pop("id")
 
-        # Apply error upsampling conversion if needed (missing from original update method)
+        # Apply error upsampling conversion if needed
         self._apply_error_upsampling_if_needed(validated_data)
 
         with transaction.atomic(router.db_for_write(AlertRule)):

--- a/src/sentry/incidents/serializers/alert_rule.py
+++ b/src/sentry/incidents/serializers/alert_rule.py
@@ -320,6 +320,10 @@ class AlertRuleSerializer(SnubaQueryValidator, CamelSnakeModelSerializer[AlertRu
         triggers = validated_data.pop("triggers")
         if "id" in validated_data:
             validated_data.pop("id")
+
+        # Apply error upsampling conversion if needed (missing from original update method)
+        self._apply_error_upsampling_if_needed(validated_data)
+
         with transaction.atomic(router.db_for_write(AlertRule)):
             try:
                 alert_rule = update_alert_rule(

--- a/src/sentry/search/events/fields.py
+++ b/src/sentry/search/events/fields.py
@@ -1844,6 +1844,12 @@ FUNCTIONS = {
             default_result_type="integer",
         ),
         DiscoverFunction(
+            "upsampled_count",
+            optional_args=[NullColumn("column")],
+            aggregate=["toInt64(sum(ifNull(sample_weight, 1)))", None, None],
+            default_result_type="integer",
+        ),
+        DiscoverFunction(
             "count_at_least",
             required_args=[NumericColumn("column"), NumberRange("threshold", 0, None)],
             aggregate=[

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -672,10 +672,7 @@ class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase):
     def test_get_shows_count_when_stored_as_upsampled_count(
         self, mock_are_any_projects_error_upsampled
     ) -> None:
-        """Test GET returns count() to user even when stored as upsampled_count() internally
-
-        This test should FAIL because GET doesn't convert upsampled_count() back to count() for the user.
-        """
+        """Test GET returns count() to user even when stored as upsampled_count() internally"""
         mock_are_any_projects_error_upsampled.return_value = True
 
         # Set up user membership FIRST before accessing self.alert_rule
@@ -734,10 +731,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
     def test_update_to_count_converts_internally_but_shows_count_on_upsampled_project(
         self, mock_are_any_projects_error_upsampled
     ) -> None:
-        """Test updating to count() converts to upsampled_count() internally but shows count() to user
-
-        This test should FAIL because update() method is missing the upsampling conversion logic.
-        """
+        """Test updating to count() converts to upsampled_count() internally but shows count() to user"""
         self.create_member(
             user=self.user, organization=self.organization, role="owner", teams=[self.team]
         )

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -668,6 +668,32 @@ class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase):
         assert response.data["snooze"]
         assert response.data["snoozeCreatedBy"] == user2.get_display_name()
 
+    @patch("sentry.incidents.serializers.alert_rule.are_any_projects_error_upsampled")
+    def test_get_shows_count_when_stored_as_upsampled_count(
+        self, mock_are_any_projects_error_upsampled
+    ) -> None:
+        """Test GET returns count() to user even when stored as upsampled_count() internally
+
+        This test should FAIL because GET doesn't convert upsampled_count() back to count() for the user.
+        """
+        mock_are_any_projects_error_upsampled.return_value = True
+
+        # Set up user membership FIRST before accessing self.alert_rule
+        self.create_team(organization=self.organization, members=[self.user])
+        self.login_as(self.user)
+
+        # Now access and modify the alert rule to have upsampled_count() internally
+        # (simulating what would happen if it was created with count() on upsampled project)
+        self.alert_rule.snuba_query.aggregate = "upsampled_count()"
+        self.alert_rule.snuba_query.save()
+
+        with self.feature("organizations:incidents"):
+            resp = self.get_success_response(self.organization.slug, self.alert_rule.id)
+
+        assert (
+            resp.data["aggregate"] == "count()"
+        ), "GET should return count() to user, hiding internal upsampled_count() storage"
+
 
 class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
     method = "put"
@@ -703,6 +729,82 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
             resp.renderer_context["request"].META["REMOTE_ADDR"]
             == list(audit_log_entry)[0].ip_address
         )
+
+    @patch("sentry.incidents.serializers.alert_rule.are_any_projects_error_upsampled")
+    def test_update_to_count_converts_internally_but_shows_count_on_upsampled_project(
+        self, mock_are_any_projects_error_upsampled
+    ) -> None:
+        """Test updating to count() converts to upsampled_count() internally but shows count() to user
+
+        This test should FAIL because update() method is missing the upsampling conversion logic.
+        """
+        self.create_member(
+            user=self.user, organization=self.organization, role="owner", teams=[self.team]
+        )
+        self.login_as(self.user)
+
+        # Mock that projects are upsampled
+        mock_are_any_projects_error_upsampled.return_value = True
+
+        alert_rule = self.alert_rule
+        serialized_alert_rule = self.get_serialized_alert_rule()
+
+        # Update to count() aggregate - should convert internally but return count() to user
+        serialized_alert_rule["aggregate"] = "count()"
+        serialized_alert_rule["dataset"] = "events"
+        serialized_alert_rule["name"] = "Updated to Count Rule"
+
+        with self.feature("organizations:incidents"), outbox_runner():
+            resp = self.get_success_response(
+                self.organization.slug, alert_rule.id, **serialized_alert_rule
+            )
+
+        # User should see count() in response
+        assert resp.data["aggregate"] == "count()"
+
+        # But internally it should be stored as upsampled_count()
+        alert_rule.refresh_from_db()
+        assert (
+            alert_rule.snuba_query.aggregate == "upsampled_count()"
+        ), "UPDATE should convert count() to upsampled_count() internally for upsampled projects"
+
+    @patch("sentry.incidents.serializers.alert_rule.are_any_projects_error_upsampled")
+    def test_update_non_aggregate_field_preserves_transparency_on_upsampled_project(
+        self, mock_are_any_projects_error_upsampled
+    ) -> None:
+        """Test updating non-aggregate fields maintains transparency of upsampled_count()"""
+        self.create_member(
+            user=self.user, organization=self.organization, role="owner", teams=[self.team]
+        )
+        self.login_as(self.user)
+
+        mock_are_any_projects_error_upsampled.return_value = True
+
+        # Manually set the existing alert rule to have upsampled_count() internally
+        self.alert_rule.snuba_query.aggregate = "upsampled_count()"
+        self.alert_rule.snuba_query.save()
+        original_aggregate = self.alert_rule.snuba_query.aggregate
+
+        alert_rule = self.alert_rule
+        serialized_alert_rule = self.get_serialized_alert_rule()
+
+        # Update only the name, not the aggregate
+        serialized_alert_rule["name"] = "Updated Name Only"
+
+        with self.feature("organizations:incidents"), outbox_runner():
+            resp = self.get_success_response(
+                self.organization.slug, alert_rule.id, **serialized_alert_rule
+            )
+
+        # User should see count() even though it's stored as upsampled_count()
+        assert (
+            resp.data["aggregate"] == "count()"
+        ), "UPDATE response should show count() to user, hiding internal upsampled_count() storage"
+        assert resp.data["name"] == "Updated Name Only"
+
+        # Internal storage should be unchanged
+        alert_rule.refresh_from_db()
+        assert alert_rule.snuba_query.aggregate == original_aggregate  # Still upsampled_count()
 
     def test_workflow_engine_serializer(self) -> None:
         self.create_team(organization=self.organization, members=[self.user])

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -232,10 +232,7 @@ class AlertRuleListEndpointTest(AlertRuleIndexBase, TestWorkflowEngineSerializer
     def test_list_shows_count_when_stored_as_upsampled_count(
         self, mock_are_any_projects_error_upsampled
     ) -> None:
-        """Test LIST returns count() to user even when stored as upsampled_count() internally
-
-        This test should FAIL because LIST doesn't convert upsampled_count() back to count() for the user.
-        """
+        """Test LIST returns count() to user even when stored as upsampled_count() internally"""
         mock_are_any_projects_error_upsampled.return_value = True
 
         team = self.create_team(organization=self.organization, members=[self.user])

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -266,6 +266,86 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
             == list(audit_log_entry)[0].ip_address
         )
 
+    @patch("sentry.incidents.serializers.alert_rule.are_any_projects_error_upsampled")
+    def test_count_automatically_converted_to_upsampled_count_for_upsampled_projects(
+        self, mock_are_any_projects_error_upsampled
+    ) -> None:
+        """Test end-to-end: count() gets auto-converted to upsampled_count() for upsampled projects"""
+        mock_are_any_projects_error_upsampled.return_value = True
+
+        # Start with regular count() aggregate
+        count_alert_rule = self.alert_rule_dict.copy()
+        count_alert_rule["aggregate"] = "count()"
+        count_alert_rule["name"] = "AutoConvertedUpsampledCountRule"
+
+        with (
+            outbox_runner(),
+            self.feature(["organizations:incidents", "organizations:performance-view"]),
+        ):
+            resp = self.get_success_response(
+                self.organization.slug,
+                status_code=201,
+                **count_alert_rule,
+            )
+        assert "id" in resp.data
+        alert_rule = AlertRule.objects.get(id=resp.data["id"])
+
+        # Verify count() was automatically converted to upsampled_count()
+        assert alert_rule.snuba_query.aggregate == "upsampled_count()"
+
+        # Verify the mock was called with the project ID
+        mock_are_any_projects_error_upsampled.assert_called_once_with([self.project.id])
+
+    @patch("sentry.incidents.serializers.alert_rule.are_any_projects_error_upsampled")
+    def test_count_not_converted_for_non_upsampled_projects(
+        self, mock_are_any_projects_error_upsampled
+    ) -> None:
+        """Test end-to-end: count() stays count() for non-upsampled projects"""
+        mock_are_any_projects_error_upsampled.return_value = False
+
+        # Start with regular count() aggregate
+        count_alert_rule = self.alert_rule_dict.copy()
+        count_alert_rule["aggregate"] = "count()"
+        count_alert_rule["name"] = "RegularCountRule"
+
+        with (
+            outbox_runner(),
+            self.feature(["organizations:incidents", "organizations:performance-view"]),
+        ):
+            resp = self.get_success_response(
+                self.organization.slug,
+                status_code=201,
+                **count_alert_rule,
+            )
+        assert "id" in resp.data
+        alert_rule = AlertRule.objects.get(id=resp.data["id"])
+
+        # Verify count() was NOT converted
+        assert alert_rule.snuba_query.aggregate == "count()"
+
+        # Verify the mock was called with the project ID
+        mock_are_any_projects_error_upsampled.assert_called_once_with([self.project.id])
+
+    def test_upsampled_count_rejected_when_sent_directly_by_user(self) -> None:
+        """Test that users cannot send upsampled_count() directly - it gets rejected"""
+        upsampled_alert_rule = self.alert_rule_dict.copy()
+        upsampled_alert_rule["aggregate"] = "upsampled_count()"  # User tries to send this directly
+        upsampled_alert_rule["name"] = "DirectUpsampledCountRule"
+
+        with (
+            outbox_runner(),
+            self.feature(["organizations:incidents", "organizations:performance-view"]),
+        ):
+            resp = self.get_error_response(
+                self.organization.slug,
+                status_code=400,
+                **upsampled_alert_rule,
+            )
+
+        # Verify it was rejected with proper error message
+        assert "upsampled_count() is not allowed as user input" in str(resp.data)
+        assert "Use count() instead" in str(resp.data)
+
     def test_workflow_engine_serializer(self) -> None:
         team = self.create_team(organization=self.organization, members=[self.user])
         ProjectTeam.objects.create(project=self.project, team=team)

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -226,19 +226,6 @@ class TestAlertRuleSerializer(TestAlertRuleSerializerBase):
             assert alert_rule.snuba_query.type == SnubaQuery.Type.PERFORMANCE.value
             assert alert_rule.snuba_query.dataset == Dataset.PerformanceMetrics.value
 
-    def test_upsampled_count_validation_path(self) -> None:
-        """Test to see if upsampled_count() hits the legacy DiscoverFunction validation path"""
-        # This should be rejected by the serializer before it gets to the legacy path
-        self.run_fail_validation_test(
-            {"aggregate": "upsampled_count()"},
-            {
-                "aggregate": [
-                    "upsampled_count() is not allowed as user input. Use count() instead - "
-                    "it will be automatically converted to upsampled_count() when appropriate."
-                ]
-            },
-        )
-
     def test_aggregate(self) -> None:
         self.run_fail_validation_test(
             {"aggregate": "what()"},

--- a/tests/sentry/incidents/subscription_processor/test_subscription_processor.py
+++ b/tests/sentry/incidents/subscription_processor/test_subscription_processor.py
@@ -4599,6 +4599,155 @@ class TestGetAlertRuleStats(TestCase):
         assert resolve_counts == {3: 2, 4: 4}
 
 
+@freeze_time()
+class ProcessUpdateUpsampledCountTest(ProcessUpdateBaseClass):
+    """Test that upsampled_count() aggregate works correctly with sample weight data"""
+
+    @cached_property
+    def upsampled_rule(self):
+        """Create an alert rule that uses upsampled_count() aggregate function"""
+        rule = self.create_alert_rule(
+            projects=[self.project],
+            name="upsampled count rule",
+            query="",
+            aggregate="upsampled_count()",  # Test upsampled_count aggregate function
+            time_window=1,
+            threshold_type=AlertRuleThresholdType.ABOVE,
+            resolve_threshold=10,
+            threshold_period=1,
+            event_types=[
+                SnubaQueryEventType.EventType.ERROR,
+                SnubaQueryEventType.EventType.DEFAULT,
+            ],
+        )
+        # Create trigger that fires when value > 20
+        trigger = create_alert_rule_trigger(rule, CRITICAL_TRIGGER_LABEL, 20)
+        create_alert_rule_trigger_action(
+            trigger,
+            AlertRuleTriggerAction.Type.EMAIL,
+            AlertRuleTriggerAction.TargetType.USER,
+            str(self.user.id),
+        )
+        return rule
+
+    @cached_property
+    def upsampled_sub(self):
+        return self.upsampled_rule.snuba_query.subscriptions.filter(project=self.project).get()
+
+    @cached_property
+    def sub(self):
+        return self.upsampled_sub
+
+    @cached_property
+    def upsampled_trigger(self):
+        return self.upsampled_rule.alertruletrigger_set.get()
+
+    def build_upsampled_subscription_update(
+        self, subscription, upsampled_count=1.0, time_delta=None
+    ):
+        """Build a subscription update that simulates upsampled_count() query results"""
+        if time_delta is not None:
+            timestamp = timezone.now() + time_delta
+        else:
+            timestamp = timezone.now()
+        timestamp = timestamp.replace(microsecond=0)
+
+        # Create subscription update with the aggregation value
+        data = {"upsampled_count": upsampled_count}
+        values = {"data": [data]}
+        return {
+            "subscription_id": subscription.subscription_id if subscription else uuid4().hex,
+            "values": values,
+            "timestamp": timestamp,
+            "interval": 1,
+            "partition": 1,
+            "offset": 1,
+        }
+
+    def send_upsampled_update(self, rule, upsampled_count, time_delta=None, subscription=None):
+        """Send a subscription update simulating upsampled_count() query results"""
+        if time_delta is None:
+            time_delta = timedelta()
+        if subscription is None:
+            subscription = self.upsampled_sub
+        processor = SubscriptionProcessor(subscription)
+        message = self.build_upsampled_subscription_update(
+            subscription, upsampled_count=upsampled_count, time_delta=time_delta
+        )
+        with (
+            self.feature("organizations:incidents"),
+            self.feature("organizations:performance-view"),
+        ):
+            processor.process_update(message)
+        return processor
+
+    def test_upsampled_count_no_alert_below_threshold(self) -> None:
+        """Test that no alert is triggered when upsampled count is below threshold"""
+        # Send update with upsampled_count below threshold (1 < 20)
+        processor = self.send_upsampled_update(self.upsampled_rule, upsampled_count=1.0)
+
+        # Verify no incident was created (1 < 20 threshold)
+        self.assert_trigger_counts(processor, self.upsampled_trigger, 0, 0)
+        self.assert_no_active_incident(self.upsampled_rule)
+
+    def test_upsampled_count_alert_above_threshold(self) -> None:
+        """Test that alert is triggered when upsampled count exceeds threshold"""
+        # Send update with upsampled_count above threshold (30 > 20)
+        self.send_upsampled_update(self.upsampled_rule, upsampled_count=30.0)
+
+        # Verify incident was created (30 > 20 threshold)
+        incident = self.assert_active_incident(self.upsampled_rule)
+        self.assert_trigger_exists_with_status(
+            incident, self.upsampled_trigger, TriggerStatus.ACTIVE
+        )
+
+    def test_upsampled_count_alert_and_resolve(self) -> None:
+        """Test alert triggering and resolving with upsampled count"""
+        # First, trigger the alert with high upsampled_count
+        self.send_upsampled_update(self.upsampled_rule, upsampled_count=30.0)
+        incident = self.assert_active_incident(self.upsampled_rule)
+
+        # Then resolve it with low upsampled_count (below resolve threshold of 10)
+        self.send_upsampled_update(
+            self.upsampled_rule, upsampled_count=5.0, time_delta=timedelta(minutes=1)
+        )
+
+        # Refresh incident from database
+        incident.refresh_from_db()
+
+        # Verify the incident is now resolved
+        assert incident.status == IncidentStatus.CLOSED.value
+
+    def test_upsampled_count_multiple_updates(self) -> None:
+        """Test that multiple updates with upsampled counts accumulate correctly"""
+        rule = self.upsampled_rule
+        trigger = self.upsampled_trigger
+
+        # Set threshold period to 2, requiring 2 consecutive updates above threshold
+        rule.update(threshold_period=2)
+
+        # First update: upsampled_count=15 (below threshold of 20)
+        processor = self.send_upsampled_update(
+            rule, upsampled_count=15.0, time_delta=timedelta(minutes=-2)
+        )
+        self.assert_trigger_counts(processor, trigger, 0, 0)
+        self.assert_no_active_incident(rule)
+
+        # Second update: upsampled_count=25 (above threshold)
+        processor = self.send_upsampled_update(
+            rule, upsampled_count=25.0, time_delta=timedelta(minutes=-1)
+        )
+        self.assert_trigger_counts(processor, trigger, 1, 0)
+        self.assert_no_active_incident(rule)  # Still no incident (need 2 consecutive)
+
+        # Third update: upsampled_count=30 (above threshold again)
+        processor = self.send_upsampled_update(rule, upsampled_count=30.0)
+
+        # Now we should have an active incident
+        incident = self.assert_active_incident(rule)
+        self.assert_trigger_exists_with_status(incident, trigger, TriggerStatus.ACTIVE)
+
+
 class TestUpdateAlertRuleStats(TestCase):
     def test(self) -> None:
         alert_rule = AlertRule(id=1)


### PR DESCRIPTION
- Implemented logic to automatically convert Number of Errors query from count() to upsampled_count() for projects with error upsampling enabled
- Added upsampled_count() as a possible aggregate, but added safeguards so it can't be passed as function to the API, only converted to it internally on allowed projects.
- Updated tests to cover new behavior for count() conversion and validation.
- Introduced new DiscoverFunction for upsampled_count() in event search fields as its used for validation of Alert aggregate function.