### PR TITLE
feat: Remove nintendo switch 2

### DIFF
--- a/static/app/components/events/traceEventDataSection.tsx
+++ b/static/app/components/events/traceEventDataSection.tsx
@@ -239,7 +239,6 @@ export function TraceEventDataSection({
       platform === 'native' ||
       platform === 'cocoa' ||
       platform === 'nintendo-switch' ||
-      platform === 'nintendo-switch-2' ||
       platform === 'playstation' ||
       platform === 'xbox'
     ) {

--- a/static/app/components/modals/privateGamingSdkAccessModal.tsx
+++ b/static/app/components/modals/privateGamingSdkAccessModal.tsx
@@ -16,7 +16,6 @@ const PRIVATE_GAMING_SDK_OPTIONS = [
   {value: 'playstation', label: 'PlayStation'},
   {value: 'xbox', label: 'Xbox'},
   {value: 'nintendo-switch', label: 'Nintendo Switch'},
-  {value: 'nintendo-switch-2', label: 'Nintendo Switch 2'},
 ] as const;
 
 type GamingPlatform = (typeof PRIVATE_GAMING_SDK_OPTIONS)[number]['value'];

--- a/static/app/components/onboarding/consoleModal.tsx
+++ b/static/app/components/onboarding/consoleModal.tsx
@@ -100,10 +100,7 @@ export function ConsoleModal({
   closeModal,
   organization,
 }: ConsoleModalProps & ModalRenderProps) {
-  const platformKey =
-    selectedPlatform.key === 'nintendo-switch-2'
-      ? 'nintendo-switch'
-      : selectedPlatform.key;
+  const platformKey = selectedPlatform.key;
   const config = consoleConfig[platformKey as keyof typeof consoleConfig];
 
   useEffect(() => {

--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -171,7 +171,6 @@ export const gaming: PlatformKey[] = [
   'godot',
   'native',
   'nintendo-switch',
-  'nintendo-switch-2',
   'playstation',
   'unity',
   'unreal',
@@ -301,7 +300,6 @@ export const withoutPerformanceSupport: Set<PlatformKey> = new Set([
   'elixir',
   'minidump',
   'nintendo-switch',
-  'nintendo-switch-2',
   'playstation',
   'xbox',
 ]);

--- a/static/app/data/platformPickerCategories.tsx
+++ b/static/app/data/platformPickerCategories.tsx
@@ -164,7 +164,6 @@ const gaming: Set<PlatformKey> = new Set([
   'godot',
   'native',
   'nintendo-switch',
-  'nintendo-switch-2',
   'playstation',
   'unity',
   'unreal',

--- a/static/app/data/platforms.tsx
+++ b/static/app/data/platforms.tsx
@@ -421,16 +421,6 @@ export const platforms: PlatformIntegration[] = [
     },
   },
   {
-    id: 'nintendo-switch-2',
-    name: 'Nintendo Switch 2',
-    type: 'console',
-    language: 'console',
-    link: 'https://docs.sentry.io/platforms/nintendo-switch/',
-    iconConfig: {
-      withLanguageIcon: false,
-    },
-  },
-  {
     id: 'node',
     name: 'Node.js',
     type: 'language',

--- a/static/app/types/project.tsx
+++ b/static/app/types/project.tsx
@@ -244,7 +244,6 @@ export type PlatformKey =
   | 'native-minidump'
   | 'native-qt'
   | 'nintendo-switch'
-  | 'nintendo-switch-2'
   | 'node'
   | 'node-awslambda'
   | 'node-azurefunctions'

--- a/static/app/utils/gettingStartedDocs/getPlatformPath.ts
+++ b/static/app/utils/gettingStartedDocs/getPlatformPath.ts
@@ -3,7 +3,7 @@ import type {PlatformIntegration} from 'sentry/types/project';
 export function getPlatformPath(platform: PlatformIntegration) {
   // handle console platforms (xbox, playstation, nintendo-switch, etc.)
   if (platform.type === 'console') {
-    return `console/${platform.id === 'nintendo-switch-2' ? 'nintendo-switch' : platform.id}`;
+    return `console/${platform.id}`;
   }
 
   // some platforms use a naming convention that combines 'language' and 'id' with a hyphen in between. For example, 'react-native'.

--- a/static/app/utils/platform.tsx
+++ b/static/app/utils/platform.tsx
@@ -47,7 +47,6 @@ export function isNativePlatform(platform: string | undefined) {
     case 'swift':
     case 'c':
     case 'nintendo-switch':
-    case 'nintendo-switch-2':
     case 'playstation':
     case 'xbox':
       return true;
@@ -75,10 +74,5 @@ export function isDisabledGamingPlatform({
   platform: Platform;
   enabledConsolePlatforms?: string[];
 }) {
-  return (
-    platform.type === 'console' &&
-    !enabledConsolePlatforms?.includes(
-      platform.id === 'nintendo-switch-2' ? 'nintendo-switch' : platform.id
-    )
-  );
+  return platform.type === 'console' && !enabledConsolePlatforms?.includes(platform.id);
 }

--- a/static/app/views/releases/utils/sessionTerm.tsx
+++ b/static/app/views/releases/utils/sessionTerm.tsx
@@ -152,7 +152,6 @@ function getTermDescriptions(platform: PlatformKey | null) {
     case 'minidump':
     case 'native':
     case 'nintendo-switch':
-    case 'nintendo-switch-2':
     case 'playstation':
     case 'xbox':
       return {

--- a/static/gsAdmin/components/toggleConsolePlatformsModal.tsx
+++ b/static/gsAdmin/components/toggleConsolePlatformsModal.tsx
@@ -103,8 +103,8 @@ function ToggleConsolePlatformsModal({
             field={{
               name: 'nintendo-switch',
               type: 'boolean',
-              label: 'Nintendo Switch 1 and 2',
-              help: 'Toggle Nintendo Switch 1 and 2 console platforms for this organization.',
+              label: 'Nintendo Switch',
+              help: 'Toggle Nintendo Switch console platformfor this organization.',
             }}
             flexibleControlStateSize
             inline

--- a/static/gsAdmin/components/toggleConsolePlatformsModal.tsx
+++ b/static/gsAdmin/components/toggleConsolePlatformsModal.tsx
@@ -104,7 +104,7 @@ function ToggleConsolePlatformsModal({
               name: 'nintendo-switch',
               type: 'boolean',
               label: 'Nintendo Switch',
-              help: 'Toggle Nintendo Switch console platformfor this organization.',
+              help: 'Toggle Nintendo Switch console platform for this organization.',
             }}
             flexibleControlStateSize
             inline


### PR DESCRIPTION
@bruno-garcia  mentioned that it's better not to list both Switch 1 and Switch 2 in the platform picker, as it could be confusing. similar to having separate options for Windows 10 and 11. So, we’ve decided to remove it.

contributes to https://linear.app/getsentry/issue/TET-976/remove-nintendo-switch-2