### PR TITLE
feat: Remove nintendo switch 2

### DIFF
--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -119,7 +119,6 @@ GETTING_STARTED_DOCS_PLATFORMS = [
     "native",
     "native-qt",
     "nintendo-switch",
-    "nintendo-switch-2",
     "node",
     "node-awslambda",
     "node-azurefunctions",

--- a/src/sentry/utils/platform_categories.py
+++ b/src/sentry/utils/platform_categories.py
@@ -162,7 +162,6 @@ GAMING = {
     "godot",
     "native",
     "nintendo-switch",
-    "nintendo-switch-2",
     "playstation",
     "unity",
     "unreal",


### PR DESCRIPTION
@bruno-garcia  mentioned that it's better not to list both Switch 1 and Switch 2 in the platform picker, as it could be confusing. similar to having separate options for Windows 10 and 11. So, we’ve decided to remove it.

contributes to https://linear.app/getsentry/issue/TET-976/remove-nintendo-switch-2