### PR TITLE
ref(ourlogs): Remove meta feature flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -527,8 +527,6 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:ourlogs-enabled", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable our logs product to be ingested via Relay.
     manager.add("organizations:ourlogs-ingestion", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable extraction of meta attributes for logs.
-    manager.add("organizations:ourlogs-meta-attributes", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable our logs stats to be displayed in the UI.
     manager.add("organizations:ourlogs-stats", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the visualize sidebar in the logs UI.

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -66,7 +66,6 @@ EXPOSABLE_FEATURES = [
     "organizations:indexed-spans-extraction",
     "projects:relay-otel-endpoint",
     "organizations:ourlogs-ingestion",
-    "organizations:ourlogs-meta-attributes",
     "organizations:view-hierarchy-scrubbing",
     "organizations:performance-issues-spans",
     "organizations:relay-playstation-ingestion",


### PR DESCRIPTION
This is now always enabled.

Options Automator: https://github.com/getsentry/sentry-options-automator/pull/4748
Relay: https://github.com/getsentry/relay/pull/5006