### PR TITLE
fix(agent-insights): tweak generation span query

### DIFF
--- a/static/app/views/insights/agentMonitoring/components/tracesTable.tsx
+++ b/static/app/views/insights/agentMonitoring/components/tracesTable.tsx
@@ -82,6 +82,7 @@ const rightAlignColumns = new Set([
   'timestamp',
 ]);
 
+// FIXME: This is potentially not correct, we need to find a way for it to work with the new filter
 const GENERATION_COUNTS = AI_GENERATION_OPS.map(op => `count_if(span.op,${op})` as const);
 
 const AI_AGENT_SUB_OPS = [...AI_GENERATION_OPS, ...AI_TOOL_CALL_OPS].map(

--- a/static/app/views/insights/agentMonitoring/utils/query.tsx
+++ b/static/app/views/insights/agentMonitoring/utils/query.tsx
@@ -60,7 +60,7 @@ export function extendWithLegacyAttributeKeys(attributeKeys: string[]) {
 }
 
 export function getIsAiSpan({op = 'default'}: {op?: string}) {
-  return op.startsWith('gen_ai.');
+  return op.startsWith('gen_ai.') || getIsAiRunSpan({op});
 }
 
 export function getIsAiRunSpan({op = 'default'}: {op?: string}) {

--- a/static/app/views/insights/agentMonitoring/utils/query.tsx
+++ b/static/app/views/insights/agentMonitoring/utils/query.tsx
@@ -14,6 +14,23 @@ const AI_RUN_OPS = [
   'ai.pipeline.stream_object',
 ];
 
+// AI Generations - equivalent to OTEL Inference span
+// https://github.com/open-telemetry/semantic-conventions/blob/main/docs/gen-ai/gen-ai-spans.md#inference
+export const AI_GENERATION_OPS = [
+  'ai.run.doGenerate',
+  'gen_ai.chat',
+  'gen_ai.generate_content',
+  'gen_ai.generate_text',
+  'gen_ai.generate_object',
+  'gen_ai.stream_text',
+  'gen_ai.stream_object',
+  'gen_ai.embed', // AI SDK
+  'gen_ai.embed_many', // AI SDK
+  'gen_ai.embeddings', // Python OpenAI
+  'gen_ai.text_completion',
+  'gen_ai.responses',
+];
+
 // AI Tool Calls - equivalent to OTEL Execute tool span
 // https://github.com/open-telemetry/semantic-conventions/blob/main/docs/gen-ai/gen-ai-spans.md#execute-tool-span
 export const AI_TOOL_CALL_OPS = ['gen_ai.execute_tool'];
@@ -60,7 +77,7 @@ export function extendWithLegacyAttributeKeys(attributeKeys: string[]) {
 }
 
 export function getIsAiSpan({op = 'default'}: {op?: string}) {
-  return op.startsWith('gen_ai.') || getIsAiRunSpan({op});
+  return op.startsWith('gen_ai.');
 }
 
 export function getIsAiRunSpan({op = 'default'}: {op?: string}) {

--- a/static/app/views/insights/agentMonitoring/utils/query.tsx
+++ b/static/app/views/insights/agentMonitoring/utils/query.tsx
@@ -44,6 +44,8 @@ const AI_OPS = [
   ...AI_HANDOFF_OPS,
 ];
 
+const AI_KNOWN_OPS = [...AI_RUN_OPS, ...AI_TOOL_CALL_OPS, ...AI_HANDOFF_OPS];
+
 export const AI_MODEL_ID_ATTRIBUTE = SpanFields.GEN_AI_REQUEST_MODEL;
 export const AI_MODEL_NAME_FALLBACK_ATTRIBUTE = SpanFields.GEN_AI_RESPONSE_MODEL;
 export const AI_TOOL_NAME_ATTRIBUTE = SpanFields.GEN_AI_TOOL_NAME;
@@ -89,8 +91,9 @@ export function getIsAiRunSpan({op = 'default'}: {op?: string}) {
   return AI_RUN_OPS.includes(op);
 }
 
+// All of the gen_ai.* spans that are not agent invocations, handoffs, or tool calls are considered generation spans
 export function getIsAiGenerationSpan({op = 'default'}: {op?: string}) {
-  return AI_GENERATION_OPS.includes(op);
+  return op.startsWith('gen_ai.') && !AI_KNOWN_OPS.includes(op);
 }
 
 export function getIsAiToolCallSpan({op = 'default'}: {op?: string}) {
@@ -109,8 +112,9 @@ export const getAgentRunsFilter = ({negated = false}: {negated?: boolean} = {}) 
   return `${negated ? '!' : ''}span.op:[${joinValues(AI_RUN_OPS)}]`;
 };
 
+// All of the gen_ai.* spans that are not agent invocations, handoffs, or tool calls are considered generation spans
 export const getAIGenerationsFilter = () => {
-  return `span.op:[${joinValues(AI_GENERATION_OPS)}]`;
+  return `span.op:gen_ai.* !span.op:[${joinValues(AI_KNOWN_OPS)}]`;
 };
 
 export const getAIToolCallsFilter = () => {

--- a/static/app/views/insights/agentMonitoring/utils/query.tsx
+++ b/static/app/views/insights/agentMonitoring/utils/query.tsx
@@ -14,23 +14,6 @@ const AI_RUN_OPS = [
   'ai.pipeline.stream_object',
 ];
 
-// AI Generations - equivalent to OTEL Inference span
-// https://github.com/open-telemetry/semantic-conventions/blob/main/docs/gen-ai/gen-ai-spans.md#inference
-export const AI_GENERATION_OPS = [
-  'ai.run.doGenerate',
-  'gen_ai.chat',
-  'gen_ai.generate_content',
-  'gen_ai.generate_text',
-  'gen_ai.generate_object',
-  'gen_ai.stream_text',
-  'gen_ai.stream_object',
-  'gen_ai.embed', // AI SDK
-  'gen_ai.embed_many', // AI SDK
-  'gen_ai.embeddings', // Python OpenAI
-  'gen_ai.text_completion',
-  'gen_ai.responses',
-];
-
 // AI Tool Calls - equivalent to OTEL Execute tool span
 // https://github.com/open-telemetry/semantic-conventions/blob/main/docs/gen-ai/gen-ai-spans.md#execute-tool-span
 export const AI_TOOL_CALL_OPS = ['gen_ai.execute_tool'];

--- a/static/app/views/insights/agentMonitoring/utils/query.tsx
+++ b/static/app/views/insights/agentMonitoring/utils/query.tsx
@@ -37,14 +37,7 @@ export const AI_TOOL_CALL_OPS = ['gen_ai.execute_tool'];
 
 const AI_HANDOFF_OPS = ['gen_ai.handoff'];
 
-const AI_OPS = [
-  ...AI_RUN_OPS,
-  ...AI_GENERATION_OPS,
-  ...AI_TOOL_CALL_OPS,
-  ...AI_HANDOFF_OPS,
-];
-
-const AI_KNOWN_OPS = [...AI_RUN_OPS, ...AI_TOOL_CALL_OPS, ...AI_HANDOFF_OPS];
+const NON_GENERATION_OPS = [...AI_RUN_OPS, ...AI_TOOL_CALL_OPS, ...AI_HANDOFF_OPS];
 
 export const AI_MODEL_ID_ATTRIBUTE = SpanFields.GEN_AI_REQUEST_MODEL;
 export const AI_MODEL_NAME_FALLBACK_ATTRIBUTE = SpanFields.GEN_AI_RESPONSE_MODEL;
@@ -84,7 +77,7 @@ export function extendWithLegacyAttributeKeys(attributeKeys: string[]) {
 }
 
 export function getIsAiSpan({op = 'default'}: {op?: string}) {
-  return AI_OPS.includes(op) || op.startsWith('gen_ai.');
+  return op.startsWith('gen_ai.');
 }
 
 export function getIsAiRunSpan({op = 'default'}: {op?: string}) {
@@ -93,7 +86,7 @@ export function getIsAiRunSpan({op = 'default'}: {op?: string}) {
 
 // All of the gen_ai.* spans that are not agent invocations, handoffs, or tool calls are considered generation spans
 export function getIsAiGenerationSpan({op = 'default'}: {op?: string}) {
-  return op.startsWith('gen_ai.') && !AI_KNOWN_OPS.includes(op);
+  return op.startsWith('gen_ai.') && !NON_GENERATION_OPS.includes(op);
 }
 
 export function getIsAiToolCallSpan({op = 'default'}: {op?: string}) {
@@ -114,7 +107,7 @@ export const getAgentRunsFilter = ({negated = false}: {negated?: boolean} = {}) 
 
 // All of the gen_ai.* spans that are not agent invocations, handoffs, or tool calls are considered generation spans
 export const getAIGenerationsFilter = () => {
-  return `span.op:gen_ai.* !span.op:[${joinValues(AI_KNOWN_OPS)}]`;
+  return `span.op:gen_ai.* !span.op:[${joinValues(NON_GENERATION_OPS)}]`;
 };
 
 export const getAIToolCallsFilter = () => {


### PR DESCRIPTION
Part of [TET-981: Improve seer manual instrumentation](https://linear.app/getsentry/issue/TET-981/improve-seer-manual-instrumentation)

So far we had a finite list of span ops that were interpreted as generation spans, which was not fully OTEL compatible.
This PR changes that to be more in line with the [spec](https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/) and presumes that all `gen_ai.*` spans that are not tool calls, agent invocations and handoffs are generations