### PR TITLE
chore(hybrid-cloud): Clean up options usage in refactored code

### DIFF
--- a/tests/sentry/hybridcloud/models/test_cacheversion.py
+++ b/tests/sentry/hybridcloud/models/test_cacheversion.py
@@ -1,5 +1,4 @@
 from sentry.hybridcloud.models.cacheversion import RegionCacheVersion
-from sentry.testutils.helpers import override_options
 from sentry.testutils.pytest.fixtures import django_db_all
 
 
@@ -7,10 +6,3 @@ from sentry.testutils.pytest.fixtures import django_db_all
 def test_increment_version() -> None:
     assert RegionCacheVersion.incr_version("hello-world") == 1
     assert RegionCacheVersion.incr_version("hello-world") == 2
-
-
-@django_db_all
-def test_increment_version_rollout() -> None:
-    with override_options({"sentry.hybridcloud.cacheversion.rollout": 1.0}):
-        assert RegionCacheVersion.incr_version("hello-world") == 1
-        assert RegionCacheVersion.incr_version("hello-world") == 2


### PR DESCRIPTION
This feature has been fully rolled out know, so we can clean the old code, and option usage.

Next 2 PRs will be:
- clean the option from options automator
- remove registering the option
