### PR TITLE
feat(ai): Emit Sentry warning event when model for cost calculation is unknown

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.spec.tsx
@@ -1,0 +1,112 @@
+import * as Sentry from '@sentry/react';
+
+import {getHighlightedSpanAttributes} from './highlightedAttributes';
+
+// Mock Sentry
+jest.mock('@sentry/react', () => ({
+  captureMessage: jest.fn(),
+}));
+
+// Mock organization
+const mockOrganization = {
+  features: ['insights-agent-monitoring'],
+} as any;
+
+// Mock the features utility
+jest.mock('sentry/views/insights/agentMonitoring/utils/features', () => ({
+  hasAgentInsightsFeature: jest.fn(() => true),
+  hasMCPInsightsFeature: jest.fn(() => false),
+}));
+
+// Mock the query utility
+jest.mock('sentry/views/insights/agentMonitoring/utils/query', () => ({
+  getIsAiSpan: jest.fn(({op}) => op?.startsWith('gen_ai.')),
+}));
+
+// Mock the aiTraceNodes utility
+jest.mock('sentry/views/insights/agentMonitoring/utils/aiTraceNodes', () => ({
+  getAIAttribute: jest.fn((attributes, key) => attributes[key]),
+}));
+
+describe('getHighlightedSpanAttributes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should emit Sentry error when gen_ai span has model but no cost', () => {
+    const attributes = {
+      'gen_ai.request.model': 'gpt-4',
+      'gen_ai.usage.total_cost': '0',
+    };
+
+    getHighlightedSpanAttributes({
+      op: 'gen_ai.chat',
+      organization: mockOrganization,
+      attributes,
+    });
+
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      'Gen AI span missing cost calculation',
+      {
+        level: 'warning',
+        tags: {
+          feature: 'agent-monitoring',
+          span_type: 'gen_ai',
+          has_model: 'true',
+          has_cost: 'false',
+          span_operation: 'gen_ai.chat',
+        },
+        extra: {
+          model: 'gpt-4',
+          total_costs: '0',
+          span_operation: 'gen_ai.chat',
+          attributes,
+        },
+      }
+    );
+  });
+
+  it('should not emit Sentry error when gen_ai span has model and cost', () => {
+    const attributes = {
+      'gen_ai.request.model': 'gpt-4',
+      'gen_ai.usage.total_cost': '0.05',
+    };
+
+    getHighlightedSpanAttributes({
+      op: 'gen_ai.chat',
+      organization: mockOrganization,
+      attributes,
+    });
+
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
+  });
+
+  it('should not emit Sentry error when gen_ai span has no model', () => {
+    const attributes = {
+      'gen_ai.usage.total_cost': '0',
+    };
+
+    getHighlightedSpanAttributes({
+      op: 'gen_ai.chat',
+      organization: mockOrganization,
+      attributes,
+    });
+
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
+  });
+
+  it('should not emit Sentry error for non-gen_ai spans', () => {
+    const attributes = {
+      'gen_ai.request.model': 'gpt-4',
+      'gen_ai.usage.total_cost': '0',
+    };
+
+    getHighlightedSpanAttributes({
+      op: 'http.request',
+      organization: mockOrganization,
+      attributes,
+    });
+
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
+  });
+});

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import * as Sentry from '@sentry/react';
 
 import {Tooltip} from 'sentry/components/core/tooltip';
 import Count from 'sentry/components/count';
@@ -32,7 +33,7 @@ export function getHighlightedSpanAttributes({
   const attributeObject = ensureAttributeObject(attributes);
 
   if (hasAgentInsightsFeature(organization) && getIsAiSpan({op})) {
-    return getAISpanAttributes(attributeObject);
+    return getAISpanAttributes(attributeObject, op);
   }
 
   if (hasMCPInsightsFeature(organization) && op?.startsWith('mcp.')) {
@@ -60,7 +61,10 @@ function ensureAttributeObject(
   return attributes;
 }
 
-function getAISpanAttributes(attributes: Record<string, string | number | boolean>) {
+function getAISpanAttributes(
+  attributes: Record<string, string | number | boolean>,
+  op?: string
+) {
   const highlightedAttributes = [];
 
   const model =
@@ -99,6 +103,26 @@ function getAISpanAttributes(attributes: Record<string, string | number | boolea
     highlightedAttributes.push({
       name: t('Cost'),
       value: <LLMCosts cost={totalCosts.toString()} />,
+    });
+  }
+
+  // Check for missing cost calculation and emit Sentry error
+  if (model && (!totalCosts || Number(totalCosts) === 0)) {
+    Sentry.captureMessage('Gen AI span missing cost calculation', {
+      level: 'warning',
+      tags: {
+        feature: 'agent-monitoring',
+        span_type: 'gen_ai',
+        has_model: 'true',
+        has_cost: 'false',
+        span_operation: op || 'unknown',
+      },
+      extra: {
+        model: model.toString(),
+        total_costs: totalCosts,
+        span_operation: op,
+        attributes,
+      },
     });
   }
 


### PR DESCRIPTION
There are still some models we don't support, so we want to emit a warning everytime there is a case in UI when we render span, which has model attached to it, but no cost caluclation.

Closes [TET-738: Emit Sentry warning event when model for cost calculation is unknown](https://linear.app/getsentry/issue/TET-738/emit-sentry-warning-event-when-model-for-cost-calculation-is-unknown)