### PR TITLE
feat: Add question-mark tooltip with a link to the docs in processing card

### DIFF
--- a/static/app/components/events/eventProcessingErrors.spec.tsx
+++ b/static/app/components/events/eventProcessingErrors.spec.tsx
@@ -1,0 +1,89 @@
+import {EventFixture} from 'sentry-fixture/event';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {textWithMarkupMatcher} from 'sentry-test/utils';
+
+import {
+  docUrls,
+  EventProcessingErrors,
+} from 'sentry/components/events/eventProcessingErrors';
+import type {ErrorMessage} from 'sentry/components/events/interfaces/crashContent/exception/actionableItems';
+
+jest.mock(
+  'sentry/components/events/interfaces/crashContent/exception/useActionableItems',
+  () => ({
+    useActionableItemsWithProguardErrors: jest.fn(),
+  })
+);
+
+const {useActionableItemsWithProguardErrors} = jest.requireMock(
+  'sentry/components/events/interfaces/crashContent/exception/useActionableItems'
+);
+
+describe('EventProcessingErrors', function () {
+  it.each(['release', 'environment'])(
+    'renders error card with documentation tooltip for known error type: %s',
+    async function (fieldName) {
+      const mockErrors: ErrorMessage[] = [
+        {
+          title: 'Discarded invalid value',
+          desc: null,
+          data: {
+            name: fieldName,
+            value: 'something/invalid',
+          },
+        },
+      ];
+
+      useActionableItemsWithProguardErrors.mockReturnValue(mockErrors);
+
+      render(
+        <EventProcessingErrors
+          event={EventFixture()}
+          project={ProjectFixture()}
+          isShare={false}
+        />
+      );
+
+      expect(screen.getByText(/discarded invalid value/i)).toBeInTheDocument();
+      expect(screen.getByText(fieldName)).toBeInTheDocument();
+
+      await userEvent.hover(screen.getByTestId('more-information'));
+
+      expect(
+        await screen.findByText(
+          textWithMarkupMatcher(/learn more about this error in our documentation/i)
+        )
+      ).toBeInTheDocument();
+
+      expect(screen.getByRole('link')).toHaveAttribute('href', docUrls[fieldName]);
+    }
+  );
+
+  it('renders error card without documentation tooltip for unknown error types', function () {
+    const mockErrors: ErrorMessage[] = [
+      {
+        title: 'Discarded invalid value',
+        desc: null,
+        data: {
+          unknown_field: 'some-value',
+        },
+      },
+    ];
+
+    useActionableItemsWithProguardErrors.mockReturnValue(mockErrors);
+
+    render(
+      <EventProcessingErrors
+        event={EventFixture()}
+        project={ProjectFixture()}
+        isShare={false}
+      />
+    );
+
+    expect(screen.getByText('Discarded invalid value')).toBeInTheDocument();
+    expect(screen.getByText('some-value')).toBeInTheDocument();
+    expect(screen.queryByTestId('more-information')).not.toBeInTheDocument();
+  });
+});

--- a/static/app/components/events/eventProcessingErrors.tsx
+++ b/static/app/components/events/eventProcessingErrors.tsx
@@ -2,10 +2,13 @@ import {useMemo} from 'react';
 import startCase from 'lodash/startCase';
 import moment from 'moment-timezone';
 
+import {Flex} from 'sentry/components/core/layout';
+import {ExternalLink} from 'sentry/components/core/link';
 import type {ErrorMessage} from 'sentry/components/events/interfaces/crashContent/exception/actionableItems';
 import {useActionableItemsWithProguardErrors} from 'sentry/components/events/interfaces/crashContent/exception/useActionableItems';
 import {KeyValueData} from 'sentry/components/keyValueData';
-import {t} from 'sentry/locale';
+import QuestionTooltip from 'sentry/components/questionTooltip';
+import {t, tct} from 'sentry/locale';
 import type {Event} from 'sentry/types/event';
 import type {Project} from 'sentry/types/project';
 import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
@@ -23,6 +26,12 @@ const keyMapping = {
   image_path: 'File Path',
 };
 
+export const docUrls: Record<string, string> = {
+  release: 'https://docs.sentry.io/cli/releases/#creating-releases',
+  environment:
+    'https://docs.sentry.io/concepts/key-terms/environments/#environment-naming-requirements',
+};
+
 function EventErrorCard({
   title,
   data,
@@ -33,7 +42,27 @@ function EventErrorCard({
   const contentItems = data.map(datum => {
     return {item: datum};
   });
-  return <KeyValueData.Card contentItems={contentItems} title={<div>{title}</div>} />;
+
+  const dataWithDocs = data.find(d => docUrls[d.value.toLowerCase()]);
+  const docLink = dataWithDocs ? docUrls[dataWithDocs.value.toLowerCase()] : undefined;
+
+  const titleElement = docLink ? (
+    <Flex gap="md" align="center">
+      {title}
+      <QuestionTooltip
+        title={tct('Learn more about this error in our [docLink:documentation]', {
+          docLink: <ExternalLink href={docLink} />,
+        })}
+        size="sm"
+        position="top"
+        isHoverable
+      />
+    </Flex>
+  ) : (
+    <div>{title}</div>
+  );
+
+  return <KeyValueData.Card contentItems={contentItems} title={titleElement} />;
 }
 
 function EventErrorDescription({error}: {error: ErrorMessage}) {

--- a/static/app/components/events/interfaces/crashContent/exception/actionableItems.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/actionableItems.tsx
@@ -66,6 +66,7 @@ export function getErrorMessage(
 ): ErrorMessage[] {
   const errorData = error.data ?? {};
   const metaData = meta ?? {};
+
   switch (error.type) {
     // Event Errors
     case ProguardProcessingErrors.PROGUARD_MISSING_LINENO:


### PR DESCRIPTION
When users see a processing error card that includes either a release or environment name, we want to help them quickly access relevant documentation. This PR adds a question mark icon next to the title, which opens a tooltip containing a link to the appropriate docs.

**Note:**
I didn’t limit this to just the "Discarded invalid value" error, because there may be other errors involving a release or environment. In those cases, I believe we also want to show the question mark and tooltip to guide users to the docs.

**Preview**

https://github.com/user-attachments/assets/27ffbb4e-c599-4e23-98c9-c53af964fded


closes https://linear.app/getsentry/issue/TET-975/link-releaseandenv-processing-errors-to-docs