### PR TITLE
ref(ourlogs): Default logs sample rate to 100%

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -567,7 +567,7 @@ register(
 # NOTE: Any value below 1.0 will cause customer data to not appear and can break the product. Do not override in production.
 register(
     "relay.ourlogs-ingestion.sample-rate",
-    default=0.0,
+    default=1.0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 


### PR DESCRIPTION
We have overrides that force the option to 100%, in order to be able to remove the overrides the default needs to be 100% first.

Longterm: Delete the option -> https://github.com/getsentry/relay/pull/5008