### PR TITLE
feat(loader): Make js loader v10 available from backend and make v9 default

### DIFF
--- a/src/sentry/loader/browsersdkversion.py
+++ b/src/sentry/loader/browsersdkversion.py
@@ -37,7 +37,7 @@ def get_highest_browser_sdk_version(versions):
 
 
 def get_all_browser_sdk_version_versions():
-    return ["latest", "9.x", "8.x", "7.x", "6.x", "5.x", "4.x"]
+    return ["latest", "10.x", "9.x", "8.x", "7.x", "6.x", "5.x", "4.x"]
 
 
 def get_all_browser_sdk_version_choices():

--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -30,7 +30,7 @@ register(key="sentry:similarity_backfill_completed", default=None)
 # version is set on a project's DSN.
 register(
     key="sentry:default_loader_version",
-    # TODO(lforst): Make v10 loader default
+    # TODO(andreiborza): Make v10 loader default
     epoch_defaults={1: "4.x", 2: "5.x", 7: "6.x", 8: "7.x", 9: "8.x", 13: "9.x"},
 )
 

--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -30,8 +30,8 @@ register(key="sentry:similarity_backfill_completed", default=None)
 # version is set on a project's DSN.
 register(
     key="sentry:default_loader_version",
-    # TODO(lforst): Make v9 loader default
-    epoch_defaults={1: "4.x", 2: "5.x", 7: "6.x", 8: "7.x", 13: "8.x"},
+    # TODO(lforst): Make v10 loader default
+    epoch_defaults={1: "4.x", 2: "5.x", 7: "6.x", 8: "7.x", 9: "8.x", 13: "9.x"},
 )
 
 # Default symbol sources.  The ios source does not exist by default and
@@ -162,7 +162,10 @@ register(
 # The available loader SDK versions
 register(
     key="sentry:loader_available_sdk_versions",
-    epoch_defaults={1: ["9.x", "8.x", "7.x", "6.x", "5.x", "4.x"], 11: ["9.x", "8.x", "7.x"]},
+    epoch_defaults={
+        1: ["10.x", "9.x", "8.x", "7.x", "6.x", "5.x", "4.x"],
+        11: ["10.x", "9.x", "8.x", "7.x"],
+    },
 )
 
 # Dynamic sampling rate in project-level "manual" configuration mode

--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -5,7 +5,7 @@ from sentry.seer.autofix.constants import AutofixAutomationTuningSettings
 
 # This controls what sentry:option-epoch value is given to a project when it is created
 # The epoch of a project will determine what options are valid options for that specific project
-LATEST_EPOCH = 13
+LATEST_EPOCH = 14
 
 register(key="sentry:grouping_config", default=DEFAULT_GROUPING_CONFIG)
 register(key="sentry:grouping_enhancements", default="")
@@ -31,7 +31,7 @@ register(key="sentry:similarity_backfill_completed", default=None)
 register(
     key="sentry:default_loader_version",
     # TODO(andreiborza): Make v10 loader default
-    epoch_defaults={1: "4.x", 2: "5.x", 7: "6.x", 8: "7.x", 9: "8.x", 13: "9.x"},
+    epoch_defaults={1: "4.x", 2: "5.x", 7: "6.x", 8: "7.x", 13: "8.x", 14: "9.x"},
 )
 
 # Default symbol sources.  The ios source does not exist by default and

--- a/tests/sentry/loader/test_browsersdkversion.py
+++ b/tests/sentry/loader/test_browsersdkversion.py
@@ -19,6 +19,7 @@ MOCK_VERSIONS = [
     "5.10.1",
     "8.0.1-beta2",
     "8.1.1",
+    "10.2.3",
 ]
 
 
@@ -33,7 +34,7 @@ class BrowserSdkVersionTestCase(TestCase):
     def test_get_highest_browser_sdk_version_from_versions(
         self, load_version_from_file: mock.MagicMock
     ) -> None:
-        assert str(get_highest_browser_sdk_version(load_version_from_file())) == "8.1.1"
+        assert str(get_highest_browser_sdk_version(load_version_from_file())) == "10.2.3"
 
     @mock.patch(
         "sentry.loader.browsersdkversion.load_version_from_file", return_value=MOCK_VERSIONS
@@ -41,6 +42,7 @@ class BrowserSdkVersionTestCase(TestCase):
     def test_get_highest_selected_version(self, load_version_from_file: mock.MagicMock) -> None:
         assert str(match_selected_version_to_browser_sdk_version("4.x")) == "4.6.4"
         assert str(match_selected_version_to_browser_sdk_version("5.x")) == "5.10.1"
+        assert str(match_selected_version_to_browser_sdk_version("10.x")) == "10.2.3"
         assert (
             str(match_selected_version_to_browser_sdk_version("latest")) == "5.10.1"
         )  # Should not select version 8, since v8 is the first version that doesn't support latest


### PR DESCRIPTION
Should be merged after https://github.com/getsentry/sentry/pull/96841 was deployed.