### PR TITLE
grid: fix areas prop mistake

### DIFF
--- a/static/app/components/core/layout/grid.mdx
+++ b/static/app/components/core/layout/grid.mdx
@@ -169,10 +169,10 @@ The `Grid` component renders a `div` element by default, but you can specify the
 </Storybook.Demo>
 ```jsx
 <Grid
-  areas="
-    header header
-    sidebar main
-    footer footer"
+  areas={`
+    "header header"
+    "sidebar main"
+    "footer footer"`}
   columns="200px 1fr"
   rows="60px 1fr 60px"
   gap="md"


### PR DESCRIPTION
Areas needs to be a string with quoted sections
