### PR TITLE
gref(logs): Remove useLogsIsTableFrozen hook

### DIFF
--- a/static/app/components/events/ourlogs/ourlogsDrawer.tsx
+++ b/static/app/components/events/ourlogs/ourlogsDrawer.tsx
@@ -90,9 +90,9 @@ export function OurlogsDrawer({event, project, group}: LogIssueDrawerProps) {
         <EventDrawerBody ref={containerRef}>
           <LogsTableContainer>
             {hasInfiniteFeature ? (
-              <LogsInfiniteTable showHeader={false} scrollContainer={containerRef} />
+              <LogsInfiniteTable embedded scrollContainer={containerRef} />
             ) : (
-              <LogsTable showHeader={false} allowPagination />
+              <LogsTable allowPagination embedded />
             )}
           </LogsTableContainer>
         </EventDrawerBody>

--- a/static/app/components/events/ourlogs/ourlogsSection.tsx
+++ b/static/app/components/events/ourlogs/ourlogsSection.tsx
@@ -124,6 +124,7 @@ function OurlogsSectionContent({
                 dataRow={row}
                 meta={tableData.meta}
                 highlightTerms={[]}
+                embedded
                 sharedHoverTimeoutRef={sharedHoverTimeoutRef}
                 key={index}
                 blockRowExpanding

--- a/static/app/views/explore/contexts/logs/logsPageParams.tsx
+++ b/static/app/views/explore/contexts/logs/logsPageParams.tsx
@@ -357,11 +357,6 @@ export function useLogsGroupBy() {
   return groupBy;
 }
 
-export function useLogsIsFrozen() {
-  const {isTableFrozen} = useLogsPageParams();
-  return !!isTableFrozen;
-}
-
 export function useLogsLimitToTraceId() {
   const {limitToTraceId} = useLogsPageParams();
   return limitToTraceId;
@@ -380,11 +375,6 @@ export function useSetLogsCursor() {
     },
     [isTableFrozen, setCursorForFrozenPages, setPageParams]
   );
-}
-
-export function useLogsIsTableFrozen() {
-  const {isTableFrozen} = useLogsPageParams();
-  return !!isTableFrozen;
 }
 
 export function usePersistedLogsPageParams() {

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.spec.tsx
@@ -195,12 +195,11 @@ describe('LogsInfiniteTable', function () {
     });
   });
 
-  const renderWithProviders = (children: React.ReactNode, isTableFrozen = false) => {
+  const renderWithProviders = (children: React.ReactNode) => {
     return render(
       <OrganizationContext.Provider value={organization}>
         <LogsPageParamsProvider
           analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}
-          isTableFrozen={isTableFrozen}
         >
           <LogsPageDataProvider>{children}</LogsPageDataProvider>
         </LogsPageParamsProvider>
@@ -209,7 +208,7 @@ describe('LogsInfiniteTable', function () {
   };
 
   it('should render the table component', async () => {
-    renderWithProviders(<LogsInfiniteTable showHeader />);
+    renderWithProviders(<LogsInfiniteTable />);
 
     await waitFor(() => {
       expect(screen.getByTestId('logs-table')).toBeInTheDocument();
@@ -217,7 +216,7 @@ describe('LogsInfiniteTable', function () {
   });
 
   it('should render with loading state initially', async () => {
-    renderWithProviders(<LogsInfiniteTable showHeader />);
+    renderWithProviders(<LogsInfiniteTable />);
 
     const loadingIndicator = await screen.findByTestId('loading-indicator');
     expect(loadingIndicator).toBeInTheDocument();
@@ -241,7 +240,7 @@ describe('LogsInfiniteTable', function () {
         })
       );
     }
-    renderWithProviders(<LogsInfiniteTable showHeader />);
+    renderWithProviders(<LogsInfiniteTable />);
 
     await waitFor(() => {
       expect(screen.getByTestId('logs-table')).toBeInTheDocument();
@@ -271,7 +270,7 @@ describe('LogsInfiniteTable', function () {
   });
 
   it('should not be interactable on embedded views', async () => {
-    renderWithProviders(<LogsInfiniteTable showHeader />, true);
+    renderWithProviders(<LogsInfiniteTable embedded />);
 
     await waitFor(() => {
       expect(screen.getByTestId('logs-table')).toBeInTheDocument();
@@ -304,7 +303,7 @@ describe('LogsInfiniteTable', function () {
       },
     });
 
-    renderWithProviders(<LogsInfiniteTable showHeader />);
+    renderWithProviders(<LogsInfiniteTable />);
 
     await waitFor(() => {
       expect(emptyApiMock).toHaveBeenCalled();
@@ -319,7 +318,7 @@ describe('LogsInfiniteTable', function () {
       statusCode: 500,
     });
 
-    renderWithProviders(<LogsInfiniteTable showHeader />);
+    renderWithProviders(<LogsInfiniteTable />);
 
     await waitFor(() => {
       expect(mockResponse).toHaveBeenCalled();

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
@@ -243,7 +243,7 @@ export function LogsInfiniteTable({
             onResizeMouseDown={onResizeMouseDown}
           />
         )}
-        <LogTableBody showHeader={embedded} ref={tableBodyRef}>
+        <LogTableBody showHeader={!embedded} ref={tableBodyRef}>
           {paddingTop > 0 && (
             <TableRow>
               {fields.map(field => (

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
@@ -30,7 +30,6 @@ import {
 import {useLogsPageData} from 'sentry/views/explore/contexts/logs/logsPageData';
 import {
   useLogsFields,
-  useLogsIsTableFrozen,
   useLogsSearch,
   useLogsSortBys,
   useSetLogsSortBys,
@@ -56,9 +55,9 @@ import {EmptyStateText} from 'sentry/views/traces/styles';
 
 type LogsTableProps = {
   allowPagination?: boolean;
+  embedded?: boolean;
   numberAttributes?: TagCollection;
   scrollContainer?: React.RefObject<HTMLElement | null>;
-  showHeader?: boolean;
   stringAttributes?: TagCollection;
 };
 
@@ -66,7 +65,7 @@ const LOGS_GRID_SCROLL_PIXEL_REVERSE_THRESHOLD = LOGS_GRID_BODY_ROW_HEIGHT * 2; 
 const LOGS_OVERSCAN_AMOUNT = 50; // How many items to render beyond the visible area.
 
 export function LogsInfiniteTable({
-  showHeader = true,
+  embedded = false,
   numberAttributes,
   stringAttributes,
   scrollContainer,
@@ -74,7 +73,6 @@ export function LogsInfiniteTable({
   const theme = useTheme();
   const fields = useLogsFields();
   const search = useLogsSearch();
-  const isTableFrozen = useLogsIsTableFrozen();
   const autoRefresh = useLogsAutoRefreshEnabled();
   const {infiniteLogsQueryResult} = useLogsPageData();
   const {
@@ -234,17 +232,18 @@ export function LogsInfiniteTable({
         ref={tableRef}
         style={initialTableStyles}
         css={tableStaticCSS}
-        hideBorder={isTableFrozen}
+        hideBorder={embedded}
         data-test-id="logs-table"
       >
-        {showHeader ? (
+        {embedded ? null : (
           <LogsTableHeader
+            isFrozen={embedded}
             numberAttributes={numberAttributes}
             stringAttributes={stringAttributes}
             onResizeMouseDown={onResizeMouseDown}
           />
-        ) : null}
-        <LogTableBody showHeader={showHeader} ref={tableBodyRef}>
+        )}
+        <LogTableBody showHeader={embedded} ref={tableBodyRef}>
           {paddingTop > 0 && (
             <TableRow>
               {fields.map(field => (
@@ -270,6 +269,7 @@ export function LogsInfiniteTable({
                   dataRow={dataRow}
                   meta={meta}
                   highlightTerms={highlightTerms}
+                  embedded={embedded}
                   sharedHoverTimeoutRef={sharedHoverTimeoutRef}
                   key={virtualRow.key}
                   canDeferRenderElements
@@ -308,13 +308,14 @@ export function LogsInfiniteTable({
 }
 
 function LogsTableHeader({
+  isFrozen,
   numberAttributes,
   stringAttributes,
   onResizeMouseDown,
 }: Pick<LogsTableProps, 'numberAttributes' | 'stringAttributes'> & {
+  isFrozen: boolean;
   onResizeMouseDown: (e: React.MouseEvent<HTMLDivElement>, index: number) => void;
 }) {
-  const isTableFrozen = useLogsIsTableFrozen();
   const fields = useLogsFields();
   const sortBys = useLogsSortBys();
   const setSortBys = useSetLogsSortBys();
@@ -349,8 +350,8 @@ function LogsTableHeader({
               isFirst={index === 0}
             >
               <TableHeadCellContent
-                onClick={isTableFrozen ? undefined : () => setSortBys([{field}])}
-                isFrozen={isTableFrozen}
+                onClick={isFrozen ? undefined : () => setSortBys([{field}])}
+                isFrozen={isFrozen}
               >
                 <Tooltip showOnlyOnOverflow title={headerLabel}>
                   {headerLabel}

--- a/static/app/views/explore/logs/tables/logsTable.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsTable.spec.tsx
@@ -142,18 +142,11 @@ describe('LogsTable', function () {
   ];
   const frozenColumnFields = [OurLogKnownFieldKey.TIMESTAMP, OurLogKnownFieldKey.MESSAGE];
 
-  function ProviderWrapper({
-    children,
-    isTableFrozen = false,
-  }: {
-    children: React.ReactNode;
-    isTableFrozen?: boolean;
-  }) {
+  function ProviderWrapper({children}: {children: React.ReactNode}) {
     return (
       <OrganizationContext.Provider value={organization}>
         <LogsPageParamsProvider
           analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}
-          isTableFrozen={isTableFrozen}
         >
           <LogsPageDataProvider>{children}</LogsPageDataProvider>
         </LogsPageParamsProvider>
@@ -207,7 +200,7 @@ describe('LogsTable', function () {
   it('should be interactable', async () => {
     render(
       <ProviderWrapper>
-        <LogsTable showHeader />
+        <LogsTable />
       </ProviderWrapper>
     );
 
@@ -231,8 +224,8 @@ describe('LogsTable', function () {
 
   it('should not be interactable on embedded views', async () => {
     render(
-      <ProviderWrapper isTableFrozen>
-        <LogsTable showHeader />
+      <ProviderWrapper>
+        <LogsTable embedded />
       </ProviderWrapper>
     );
 

--- a/static/app/views/explore/logs/tables/logsTable.tsx
+++ b/static/app/views/explore/logs/tables/logsTable.tsx
@@ -21,7 +21,6 @@ import {
 import {useLogsPageData} from 'sentry/views/explore/contexts/logs/logsPageData';
 import {
   useLogsFields,
-  useLogsIsTableFrozen,
   useLogsSearch,
   useLogsSortBys,
   useSetLogsCursor,
@@ -44,13 +43,13 @@ import {EmptyStateText} from 'sentry/views/traces/styles';
 
 type LogsTableProps = {
   allowPagination?: boolean;
+  embedded?: boolean;
   numberAttributes?: TagCollection;
-  showHeader?: boolean;
   stringAttributes?: TagCollection;
 };
 
 export function LogsTable({
-  showHeader = true,
+  embedded = false,
   allowPagination = true,
   stringAttributes,
   numberAttributes,
@@ -58,7 +57,6 @@ export function LogsTable({
   const fields = useLogsFields();
   const search = useLogsSearch();
   const setCursor = useSetLogsCursor();
-  const isTableFrozen = useLogsIsTableFrozen();
 
   const {data, isError, isPending, pageLinks, meta} = useLogsPageData().logsQueryResult;
 
@@ -83,10 +81,10 @@ export function LogsTable({
         ref={tableRef}
         style={initialTableStyles}
         data-test-id="logs-table"
-        hideBorder={isTableFrozen}
-        showVerticalScrollbar={isTableFrozen}
+        hideBorder={embedded}
+        showVerticalScrollbar={embedded}
       >
-        {showHeader ? (
+        {embedded ? null : (
           <TableHead>
             <LogTableRow>
               <FirstTableHeadCell isFirst align="left">
@@ -113,8 +111,8 @@ export function LogsTable({
                     isFirst={index === 0}
                   >
                     <TableHeadCellContent
-                      onClick={isTableFrozen ? undefined : () => setSortBys([{field}])}
-                      isFrozen={isTableFrozen}
+                      onClick={embedded ? undefined : () => setSortBys([{field}])}
+                      isFrozen={embedded}
                     >
                       <Tooltip showOnlyOnOverflow title={headerLabel}>
                         {headerLabel}
@@ -143,8 +141,8 @@ export function LogsTable({
               })}
             </LogTableRow>
           </TableHead>
-        ) : null}
-        <LogTableBody showHeader={showHeader}>
+        )}
+        <LogTableBody showHeader={!embedded}>
           {isPending && (
             <TableStatus>
               <LoadingIndicator />
@@ -179,6 +177,7 @@ export function LogsTable({
               dataRow={row}
               meta={meta}
               highlightTerms={highlightTerms}
+              embedded={embedded}
               sharedHoverTimeoutRef={sharedHoverTimeoutRef}
               key={index}
             />

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -30,7 +30,6 @@ import {
 import {
   useLogsAnalyticsPageSource,
   useLogsFields,
-  useLogsIsTableFrozen,
   useLogsSearch,
   useSetLogsSearch,
 } from 'sentry/views/explore/contexts/logs/logsPageParams';
@@ -76,6 +75,7 @@ import {
 
 type LogsRowProps = {
   dataRow: OurLogsResponseItem;
+  embedded: boolean;
   highlightTerms: string[];
   meta: EventsMetaType | undefined;
   sharedHoverTimeoutRef: React.MutableRefObject<NodeJS.Timeout | null>;
@@ -110,6 +110,7 @@ function isInsideButton(element: Element | null): boolean {
 
 export const LogRowContent = memo(function LogRowContent({
   dataRow,
+  embedded,
   highlightTerms,
   meta,
   sharedHoverTimeoutRef,
@@ -125,7 +126,6 @@ export const LogRowContent = memo(function LogRowContent({
   const fields = useLogsFields();
   const search = useLogsSearch();
   const setLogsSearch = useSetLogsSearch();
-  const isTableFrozen = useLogsIsTableFrozen();
   const autorefreshEnabled = useLogsAutoRefreshEnabled();
   const setAutorefresh = useSetLogsAutoRefresh();
   const measureRef = useRef<HTMLTableRowElement>(null);
@@ -340,7 +340,7 @@ export const LogRowContent = memo(function LogRowContent({
                     }
                   }}
                   allowActions={
-                    field === OurLogKnownFieldKey.TIMESTAMP || isTableFrozen
+                    field === OurLogKnownFieldKey.TIMESTAMP || embedded
                       ? []
                       : ALLOWED_CELL_ACTIONS
                   }
@@ -359,6 +359,7 @@ export const LogRowContent = memo(function LogRowContent({
         <LogRowDetails
           dataRow={dataRow}
           highlightTerms={highlightTerms}
+          embedded={embedded}
           meta={meta}
           ref={measureRef}
         />
@@ -369,11 +370,13 @@ export const LogRowContent = memo(function LogRowContent({
 
 function LogRowDetails({
   dataRow,
+  embedded,
   highlightTerms,
   meta,
   ref,
 }: {
   dataRow: OurLogsResponseItem;
+  embedded: boolean;
   highlightTerms: string[];
   meta: EventsMetaType | undefined;
   ref: React.RefObject<HTMLTableRowElement | null>;
@@ -385,7 +388,7 @@ function LogRowDetails({
   });
   const projectSlug = project?.slug ?? '';
   const fields = useLogsFields();
-  const getActions = useLogAttributesTreeActions();
+  const getActions = useLogAttributesTreeActions({embedded});
   const severityNumber = dataRow[OurLogKnownFieldKey.SEVERITY_NUMBER];
   const severityText = dataRow[OurLogKnownFieldKey.SEVERITY];
 

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -75,12 +75,12 @@ import {
 
 type LogsRowProps = {
   dataRow: OurLogsResponseItem;
-  embedded: boolean;
   highlightTerms: string[];
   meta: EventsMetaType | undefined;
   sharedHoverTimeoutRef: React.MutableRefObject<NodeJS.Timeout | null>;
   blockRowExpanding?: boolean;
   canDeferRenderElements?: boolean;
+  embedded?: boolean;
   isExpanded?: boolean;
   onCollapse?: (logItemId: string) => void;
   onExpand?: (logItemId: string) => void;

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -110,7 +110,7 @@ function isInsideButton(element: Element | null): boolean {
 
 export const LogRowContent = memo(function LogRowContent({
   dataRow,
-  embedded,
+  embedded = false,
   highlightTerms,
   meta,
   sharedHoverTimeoutRef,

--- a/static/app/views/explore/logs/useLogAttributesTreeActions.tsx
+++ b/static/app/views/explore/logs/useLogAttributesTreeActions.tsx
@@ -5,19 +5,17 @@ import {t} from 'sentry/locale';
 import type {AttributesTreeContent} from 'sentry/views/explore/components/traceItemAttributes/attributesTree';
 import {
   useLogsFields,
-  useLogsIsTableFrozen,
   useLogsSearch,
   useSetLogsFields,
   useSetLogsSearch,
 } from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
 
-export function useLogAttributesTreeActions() {
+export function useLogAttributesTreeActions({embedded}: {embedded: boolean}) {
   const setLogsSearch = useSetLogsSearch();
   const search = useLogsSearch();
   const fields = useLogsFields();
   const setLogFields = useSetLogsFields();
-  const isTableEditingFrozen = useLogsIsTableFrozen();
 
   const addSearchFilter = useCallback(
     (content: AttributesTreeContent, negated?: boolean) => {
@@ -71,7 +69,7 @@ export function useLogAttributesTreeActions() {
       {
         key: 'add-column',
         label: t('Add this as table column'),
-        hidden: isTableEditingFrozen,
+        hidden: embedded,
         disabled: fields.includes(content.originalAttribute.original_attribute_key),
         onAction: () => addColumn(content),
       },

--- a/static/app/views/explore/logs/useLogsQuery.tsx
+++ b/static/app/views/explore/logs/useLogsQuery.tsx
@@ -26,7 +26,6 @@ import {
   useLogsCursor,
   useLogsFields,
   useLogsGroupBy,
-  useLogsIsFrozen,
   useLogsLimitToTraceId,
   useLogsProjectIds,
   useLogsSearch,
@@ -195,7 +194,6 @@ function useLogsQueryKey({limit, referrer}: {referrer: string; limit?: number}) 
   const cursor = useLogsCursor();
   const _fields = useLogsFields();
   const sortBys = useLogsSortBys();
-  const isFrozen = useLogsIsFrozen();
   const limitToTraceId = useLogsLimitToTraceId();
   const {selection, isReady: pageFiltersReady} = usePageFilters();
   const location = useLocation();
@@ -227,7 +225,7 @@ function useLogsQueryKey({limit, referrer}: {referrer: string; limit?: number}) 
   };
 
   const queryKey: ApiQueryKey = [
-    `/organizations/${organization.slug}/${limitToTraceId && isFrozen ? 'trace-logs' : 'events'}/`,
+    `/organizations/${organization.slug}/${limitToTraceId ? 'trace-logs' : 'events'}/`,
     params,
   ];
 

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
@@ -170,9 +170,9 @@ function LogDetails() {
       disableCollapsePersistence
     >
       {hasInfiniteFeature ? (
-        <LogsInfiniteTable showHeader={false} scrollContainer={scrollContainer} />
+        <LogsInfiniteTable embedded scrollContainer={scrollContainer} />
       ) : (
-        <LogsTable showHeader={false} />
+        <LogsTable embedded />
       )}
     </FoldSection>
   );

--- a/static/app/views/performance/newTraceDetails/traceOurlogs.tsx
+++ b/static/app/views/performance/newTraceDetails/traceOurlogs.tsx
@@ -72,9 +72,9 @@ function LogsSectionContent({
       />
       <TableContainer>
         {hasInfiniteFeature ? (
-          <LogsInfiniteTable showHeader={false} scrollContainer={scrollContainer} />
+          <LogsInfiniteTable embedded scrollContainer={scrollContainer} />
         ) : (
-          <LogsTable showHeader={false} />
+          <LogsTable embedded />
         )}
       </TableContainer>
     </Fragment>


### PR DESCRIPTION
This hook is logs only and difficult to merge into an unified context. So work towards removing it entirely.