### PR TITLE
layout: add stack component

### DIFF
--- a/static/app/components/core/layout/index.tsx
+++ b/static/app/components/core/layout/index.tsx
@@ -1,3 +1,4 @@
 export {Container} from './container';
 export {Flex} from './flex';
 export {Grid} from './grid';
+export {Stack} from './stack';

--- a/static/app/components/core/layout/stack.mdx
+++ b/static/app/components/core/layout/stack.mdx
@@ -1,0 +1,209 @@
+---
+title: Stack
+description: A simplified layout component built on Flex that provides easy vertical stacking with responsive props and spacing controls.
+source: 'sentry/components/core/layout/stack'
+resources:
+  js: https://github.com/getsentry/sentry/blob/master/static/app/components/core/layout/stack.tsx
+---
+
+import {Container, Stack} from 'sentry/components/core/layout';
+import * as Storybook from 'sentry/stories';
+
+import APIReference from '!!type-loader!sentry/components/core/layout/stack';
+
+export const types = {Stack: APIReference.Stack};
+
+The `Stack` component is a simplified layout component built on top of the `Flex` component. It provides a focused API for common stacking layouts with only the essential props: `direction`, `align`, `justify`, and `gap`. By default, Stack uses column direction making it perfect for vertical layouts.
+
+## Basic Usage
+
+To create a basic vertical stack, wrap elements in `<Stack>` and they will be laid out vertically using flexbox.
+
+```jsx
+<Stack>
+  <div>Item 1</div>
+  <div>Item 2</div>
+  <div>Item 3</div>
+</Stack>
+```
+
+### When to Use Stack vs Flex
+
+Use `Stack` when you need a simple, focused layout component for common stacking patterns. It's perfect for:
+
+- Vertical lists or forms
+- Simple horizontal arrangements
+- Basic responsive layouts
+
+Use `Flex` when you need the full power of flexbox with properties like `wrap`, `flex`, `inline`, or complex alignment scenarios.
+
+### Composition
+
+The `Stack` implements composition via <a href="/stories/layout/composition">render prop</a> pattern.
+
+<Storybook.Demo>
+  <Stack
+    border="primary"
+    radius="md"
+    padding="md"
+    justify="between"
+    background="primary"
+    width="80%"
+    gap="md"
+  >
+    {props => (
+      <div {...props}>
+        <Container padding="sm" border="primary" radius="sm" background="surface">
+          First Item
+        </Container>
+        <Container padding="sm" border="primary" radius="sm" background="surface">
+          Second Item
+        </Container>
+        <Container padding="sm" border="primary" radius="sm" background="surface">
+          Third Item
+        </Container>
+      </div>
+    )}
+  </Stack>
+</Storybook.Demo>
+```jsx
+<Stack width="80%" justify="between" gap="md">
+  {props => (
+    <div {...props}>
+      <div>First Item</div>
+      <div>Second Item</div>
+      <div>Third Item</div>
+    </div>
+  )}
+</Stack>
+```
+
+### Specifying the DOM Node via `as` prop
+
+The `Stack` component renders a `div` element by default, but you can specify the DOM node to render by passing a `as` prop.
+
+```tsx
+<Stack as="section" padding="md" background="primary">
+  Basic stack content
+</Stack>
+```
+
+### Stack Properties
+
+Stack provides a focused set of layout properties: `direction` (defaults to 'column'), `gap`, `justify`, and `align`. These properties influence the layout of its children while maintaining simplicity.
+
+Like other layout components, `Stack` inherits all spacing props like `m`, `p`, `mt`, `mb`, `ml`, `mr`, `pt`, `pb`, `pl`, `pr` and implements responsive props so that the layout can be changed per breakpoint.
+
+#### Column Direction (Default)
+
+<Storybook.Demo>
+  <Stack gap="md" justify="center" align="center" padding="md">
+    <Container padding="md" border="primary" radius="md" background="primary">
+      Item 1
+    </Container>
+    <Container padding="md" border="primary" radius="md" background="primary">
+      Item 2
+    </Container>
+    <Container padding="md" border="primary" radius="md" background="primary">
+      Item 3
+    </Container>
+  </Stack>
+</Storybook.Demo>
+```jsx
+<Stack gap="md" justify="center" align="center" padding="md">
+  <div>Item 1</div>
+  <div>Item 2</div>
+  <div>Item 3</div>
+</Stack>
+```
+
+#### Row Direction
+
+<Storybook.Demo>
+  <Stack direction="row" gap="md" justify="between" align="center" padding="md">
+    <Container padding="md" border="primary" radius="md" background="primary">
+      Item 1
+    </Container>
+    <Container padding="md" border="primary" radius="md" background="primary">
+      Item 2
+    </Container>
+    <Container padding="md" border="primary" radius="md" background="primary">
+      Item 3
+    </Container>
+  </Stack>
+</Storybook.Demo>
+```jsx
+<Stack direction="row" gap="md" justify="between" align="center" padding="md">
+  <div>Item 1</div>
+  <div>Item 2</div>
+  <div>Item 3</div>
+</Stack>
+```
+
+### Spacing
+
+The `Stack` `gap` property follows the same spacing system as other layout components.
+
+<Storybook.Demo>
+  {['xs', 'sm', 'md', 'lg', 'xl', '2xl'].map(size => (
+    <Stack direction="column" gap="sm" key={size}>
+      <strong>{size} gap</strong>
+      <Stack m="md" gap={size} align="center">
+        <Container padding="md" border="primary" radius="md" background="primary">
+          Item 1
+        </Container>
+        <Container padding="md" border="primary" radius="md" background="primary">
+          Item 2
+        </Container>
+        <Container padding="md" border="primary" radius="md" background="primary">
+          Item 3
+        </Container>
+      </Stack>
+    </Stack>
+  ))}
+</Storybook.Demo>
+```jsx
+<Stack m="md" gap="xs">
+  <div>Item 1</div>
+  <div>Item 2</div>
+  <div>Item 3</div>
+</Stack>
+```
+
+### Responsive Props
+
+All props support responsive values using breakpoint objects. Breakpoints are: `xs`, `sm`, `md`, `lg`, `xl`, `2xl`.
+
+Example of a responsive stack that uses a static gap, but changes direction based on the breakpoint.
+
+<Storybook.Demo>
+  <Stack direction={{xs: 'column', sm: 'row', md: 'column'}} gap="md" p="md">
+    <Container padding="md" border="primary" radius="md" background="primary">
+      Responsive
+    </Container>
+    <Container padding="md" border="primary" radius="md" background="primary">
+      Stack
+    </Container>
+    <Container padding="md" border="primary" radius="md" background="primary">
+      Layout
+    </Container>
+    <Container padding="md" border="primary" radius="md" background="primary">
+      🔥
+    </Container>
+  </Stack>
+</Storybook.Demo>
+```jsx
+<Stack
+  // Direction = column on xs, row on sm, column on md
+  direction={{xs: 'column', sm: 'row', md: 'column'}}
+  // Gap = md on all sizes
+  gap="md"
+>
+  <div>Responsive</div>
+  <div>Stack</div>
+  <div>Layout</div>
+  <div>🔥</div>
+</Stack>
+```
+
+If a prop is not specified for a breakpoint, the value will **not** be inherited from the previous breakpoint.

--- a/static/app/components/core/layout/stack.spec.tsx
+++ b/static/app/components/core/layout/stack.spec.tsx
@@ -1,0 +1,110 @@
+import React, {createRef} from 'react';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {Stack} from 'sentry/components/core/layout/stack';
+
+describe('Stack', () => {
+  it('renders children', () => {
+    render(<Stack>Hello</Stack>);
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+  });
+
+  it('implements render prop', () => {
+    render(
+      <section>
+        <Stack justify="between">{props => <p {...props}>Hello</p>}</Stack>
+      </section>
+    );
+
+    expect(screen.getByText('Hello')?.tagName).toBe('P');
+    expect(screen.getByText('Hello').parentElement?.tagName).toBe('SECTION');
+  });
+
+  it('render prop guards against invalid attributes', () => {
+    render(
+      // @ts-expect-error - aria-activedescendant should be set on the child element
+      <Stack justify="between" aria-activedescendant="what">
+        {/* @ts-expect-error - this should be a React.ElementType */}
+        {props => <p {...props}>Hello</p>}
+      </Stack>
+    );
+
+    expect(screen.getByText('Hello')).not.toHaveAttribute('aria-activedescendant');
+  });
+
+  it('render prop type is correctly inferred', () => {
+    // Incompatible className type - should be string
+    function Child({className}: {className: 'invalid'}) {
+      return <p className={className}>Hello</p>;
+    }
+
+    render(
+      <Stack justify="between" padding="md">
+        {/* @ts-expect-error - className is incompatible */}
+        {props => <Child {...props} />}
+      </Stack>
+    );
+  });
+
+  it('passes attributes to the underlying element', () => {
+    render(<Stack data-test-id="container">Hello</Stack>);
+    expect(screen.getByTestId('container')).toBeInTheDocument();
+  });
+
+  it('renders as a different element if specified', () => {
+    render(<Stack as="section">Hello</Stack>);
+    expect(screen.getByText('Hello').tagName).toBe('SECTION');
+  });
+
+  it('does not bleed attributes to the underlying element', () => {
+    render(<Stack radius="sm">Hello</Stack>);
+    expect(screen.getByText('Hello')).not.toHaveAttribute('radius');
+  });
+
+  it('does not bleed stack attributes to the underlying element', () => {
+    render(
+      <Stack align="center" justify="center" gap="md">
+        Hello
+      </Stack>
+    );
+
+    expect(screen.getByText('Hello')).not.toHaveAttribute('align');
+    expect(screen.getByText('Hello')).not.toHaveAttribute('justify');
+    expect(screen.getByText('Hello')).not.toHaveAttribute('gap');
+    expect(screen.getByText('Hello')).not.toHaveAttribute('direction');
+  });
+
+  it('allows settings native html attributes', () => {
+    render(<Stack style={{color: 'red'}}>Hello</Stack>);
+    expect(screen.getByText('Hello')).toHaveStyle({color: 'red'});
+  });
+
+  it('attaches ref to the underlying element', () => {
+    const ref = createRef<HTMLOListElement>();
+    render(
+      <Stack ref={ref} as="ol">
+        Hello
+      </Stack>
+    );
+    expect(ref.current).toBeInTheDocument();
+    expect(ref.current?.tagName).toBe('OL');
+  });
+
+  it('reuses class names for the same props', () => {
+    render(
+      <React.Fragment>
+        <Stack radius="sm" padding="md">
+          First Stack
+        </Stack>
+        <Stack radius="sm" padding="md">
+          Second Stack
+        </Stack>
+      </React.Fragment>
+    );
+
+    const firstStack = screen.getByText('First Stack').className;
+    const secondStack = screen.getByText('Second Stack').className;
+    expect(firstStack).toEqual(secondStack);
+  });
+});

--- a/static/app/components/core/layout/stack.tsx
+++ b/static/app/components/core/layout/stack.tsx
@@ -1,0 +1,41 @@
+import styled from '@emotion/styled';
+
+import type {ContainerElement, ContainerProps} from './container';
+import {Flex} from './flex';
+import type {Responsive, SpacingSize} from './styles';
+
+interface StackLayoutProps {
+  /**
+   * Aligns flex items along the cross axis of the current line of flex items.
+   * Uses CSS align-items property.
+   */
+  align?: Responsive<'start' | 'end' | 'center' | 'baseline' | 'stretch'>;
+  /**
+   * Sets the stack direction.
+   * @default 'column'
+   */
+  direction?: Responsive<'row' | 'row-reverse' | 'column' | 'column-reverse'>;
+  gap?: Responsive<SpacingSize | `${SpacingSize} ${SpacingSize}`>;
+  /**
+   * Aligns flex items along the block axis of the current line of flex items.
+   * Uses CSS justify-content property.
+   */
+  justify?: Responsive<
+    'start' | 'end' | 'center' | 'between' | 'around' | 'evenly' | 'left' | 'right'
+  >;
+}
+
+type StackProps<T extends ContainerElement = 'div'> = ContainerProps<T> &
+  StackLayoutProps;
+
+export const Stack = styled((props: StackProps<any>) => (
+  <Flex {...props} direction={props.direction ?? 'column'} />
+))<StackProps<any>>`
+  /**
+   * This cast is required because styled-components does not preserve the generic signature of the wrapped component.
+   * By default, the generic type parameter <T> is lost, so we use 'as unknown as' to restore the correct typing.
+   * https://github.com/styled-components/styled-components/issues/1803
+   */
+` as unknown as <T extends ContainerElement = 'div'>(
+  props: StackProps<T>
+) => React.ReactElement;


### PR DESCRIPTION
I'm not entirely sure if this needs to exist, but Claude almost one shot the implementation, so I'm opening this for feedback. 

The main benefit here is better semantics, and the possibility of adding a `<Stack.Divider/>`, otherwise this is just a convenience over `<Flex direction="column"/>`

With a `<Stack.Divider/>` component, this would look something like this, and could be a good foundation for our tab and nav components to build on
```tsx
<Stack gap="md">
   <Item/>
   <Item/>
   <Item/>
   <Stack.Divider/>
   <Item/>
</Stack>
```

