### PR TITLE
dev(releases): update test values

### DIFF
--- a/tests/sentry/models/test_release.py
+++ b/tests/sentry/models/test_release.py
@@ -39,12 +39,22 @@ from sentry.utils.strings import truncatechars
 @pytest.mark.parametrize(
     "release_version",
     [
-        "fake_package@1.0.0",
-        "fake_package@1.0.0-alpha",
-        "fake_package@1.0.0-alpha.1",
-        "fake_package@1.0.0-alpha.beta",
-        "fake_package@1.0.0-rc.1+43",
-        "org.example.FooApp@1.0+whatever",
+        "fake_package@1",  # Major version only
+        "fake_package@1.0",  # Major and minor version
+        "fake_package@1.0.0",  # Major, minor, and patch version
+        "fake_package@1.0.0-alpha",  # With prerelease
+        "fake_package@1.0.0-alpha.1",  # With prerelease and number
+        "fake_package@1.0.0-alpha.beta",  # With prerelease and text
+        "fake_package@1.0.0-rc.1+43",  # With prerelease and build
+        "fake_package@1-alpha+43",  # major only with prerelease and build
+        "org.example.FooApp@1.0+whatever",  # With build metadata
+        # Additional valid semver patterns
+        "fake_package@1.0.0.1",  # Four version components with revision (major.minor.patch.revision)
+        "fake_package@1.0.0-alpha.1.2",  # pre-release
+        "fake_package@1.0.0-beta+exp.sha.5114f85",  # pre-release and build
+        "fake_package@1.0.0+20130313144700",  # version and build
+        "fake_package@1.0.0-0.3.7",  # Prerelease starting with number
+        "fake_package@1.0.0.0-beta+exp.sha.5114f85",  # major, minor, patch, revision, pre-release, and build
     ],
 )
 def test_version_is_semver_valid(release_version):
@@ -58,6 +68,20 @@ def test_version_is_semver_valid(release_version):
         "alpha@helloworld",
         "alpha@helloworld-1.0",
         "org.example.FooApp@9223372036854775808.1.2.3-r1+12345",
+        # Additional invalid semver patterns
+        "package@1a",  # Invalid character in version
+        "package@1.0.0.0.0",  # Too many version components
+        "package@1.0.0+",  # Incomplete build
+        "package@1.0.0-+",  # Empty prerelease and build
+        "package@1.0.0-@",  # Invalid character in prerelease
+        "package@1.0.0+@",  # Invalid character in build
+        "package@1.0.0-alpha.01",  # Leading zero in prerelease
+        "package@1.0.0-alpha..1",  # Empty prerelease component
+        "package@1.0.0-alpha.1.",  # Trailing dot in prerelease
+        "package@1.0.0+.1",  # Invalid build
+        "package@1.0.0+1.",  # Trailing dot in build
+        "package@1.0.0-alpha.1+1.",  # Trailing dot in build
+        "package@1.0.0-alpha.1+1..2",  # Empty build component
     ],
 )
 def test_version_is_semver_invalid(release_version):


### PR DESCRIPTION
i was having a hard time groking the various potentially valid/invalid release values so i've updated tests with what I think are more comprehensive values. Also going to update https://docs.sentry.io/platforms/javascript/guides/javascript/configuration/releases/