### PR TITLE
feat(search): added subtitles to monitor_check_in_failure and uptime_…

### DIFF
--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -212,6 +212,12 @@ export enum IssueTitle {
   // Metric Issues
   METRIC_ISSUE = 'Issue Detected by Metric Monitor',
 
+  // Monitors
+  MONITOR_CHECK_IN_FAILURE = 'Crons Monitor Failure',
+
+  // Uptime
+  UPTIME_DOMAIN_FAILURE = 'Uptime Domain Monitor Failure',
+
   QUERY_INJECTION_VULNERABILITY = 'Potential Query Injection Vulnerability',
 }
 
@@ -245,6 +251,9 @@ export const ISSUE_TYPE_TO_ISSUE_TITLE = {
   replay_hydration_error: IssueTitle.REPLAY_HYDRATION_ERROR,
 
   metric_issue: IssueTitle.METRIC_ISSUE,
+
+  monitor_check_in_failure: IssueTitle.MONITOR_CHECK_IN_FAILURE,
+  uptime_domain_failure: IssueTitle.UPTIME_DOMAIN_FAILURE,
 };
 
 export function getIssueTitleFromType(issueType: string): IssueTitle | undefined {

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -213,10 +213,10 @@ export enum IssueTitle {
   METRIC_ISSUE = 'Issue Detected by Metric Monitor',
 
   // Monitors
-  MONITOR_CHECK_IN_FAILURE = 'Crons Monitor Failure',
+  MONITOR_CHECK_IN_FAILURE = 'Missed or Failed Cron Check-In',
 
   // Uptime
-  UPTIME_DOMAIN_FAILURE = 'Uptime Domain Monitor Failure',
+  UPTIME_DOMAIN_FAILURE = 'Uptime Monitor Detected Downtime',
 
   QUERY_INJECTION_VULNERABILITY = 'Potential Query Injection Vulnerability',
 }


### PR DESCRIPTION
Added subtitles to the `monitor_check_in_failure` and `uptime_domain_failure` suggestions for `issue.type`.

<img width="465" height="408" alt="image" src="https://github.com/user-attachments/assets/47b2ca22-3ef2-472c-bf79-64ad3f86f58a" />

