### PR TITLE
feat(issue stream): initial skeleton loading state

### DIFF
--- a/static/app/components/count.tsx
+++ b/static/app/components/count.tsx
@@ -7,7 +7,7 @@ type Props = {
 
 function Count({value, className}: Props) {
   return (
-    <span className={className} title={value?.toLocaleString()}>
+    <span className={className} title={value.toLocaleString()}>
       {formatAbbreviatedNumber(value)}
     </span>
   );

--- a/static/app/components/eventOrGroupExtraDetails.tsx
+++ b/static/app/components/eventOrGroupExtraDetails.tsx
@@ -28,6 +28,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 
 type Props = {
   data: Event | Group;
+  replayCount?: number;
   showAssignee?: boolean;
   showLifetime?: boolean;
 };
@@ -53,7 +54,12 @@ function Lifetime({
   );
 }
 
-function EventOrGroupExtraDetails({data, showAssignee, showLifetime = true}: Props) {
+function EventOrGroupExtraDetails({
+  data,
+  showAssignee,
+  showLifetime = true,
+  replayCount,
+}: Props) {
   const {
     id,
     lastSeen,
@@ -72,12 +78,16 @@ function EventOrGroupExtraDetails({data, showAssignee, showLifetime = true}: Pro
 
   const issuesPath = `/organizations/${organization.slug}/issues/`;
   const {getReplayCountForIssue} = useReplayCountForIssues();
+  const finalReplayCount = defined(replayCount)
+    ? replayCount
+    : data.issueCategory
+      ? getReplayCountForIssue(data.id, data.issueCategory)
+      : undefined;
 
   const showReplayCount =
     organization.features.includes('session-replay') &&
     projectCanLinkToReplay(organization, project) &&
-    data.issueCategory &&
-    !!getReplayCountForIssue(data.id, data.issueCategory);
+    !!finalReplayCount;
 
   const autofixRunExists = getAutofixRunExists(data as Group);
   const seerFixable = isIssueQuickFixable(data as Group);

--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -180,6 +180,88 @@ function GroupFirstSeen({group}: {group: Group}) {
   );
 }
 
+export function LoadingStreamGroup({
+  displayReprocessingLayout,
+  withChart = true,
+  withColumns = ['graph', 'event', 'users', 'priority', 'assignee', 'lastTriggered'],
+  showLastTriggered = false,
+}: Pick<
+  Props,
+  'displayReprocessingLayout' | 'withChart' | 'withColumns' | 'showLastTriggered'
+>) {
+  return (
+    <Wrapper data-test-id="group" useTintRow={false} reviewed={false}>
+      <GroupSummary canSelect={false}>
+        <Placeholder height="58px" />
+      </GroupSummary>
+      {withColumns.includes('lastSeen') && (
+        <LastSeenWrapper breakpoint={COLUMN_BREAKPOINTS.LAST_SEEN}>
+          <Placeholder height="18px" width="70px" />
+        </LastSeenWrapper>
+      )}
+      {withColumns.includes('firstSeen') && (
+        <FirstSeenWrapper breakpoint={COLUMN_BREAKPOINTS.FIRST_SEEN}>
+          <Placeholder height="18px" width="30px" />
+        </FirstSeenWrapper>
+      )}
+      {withChart && !displayReprocessingLayout && (
+        <ChartWrapper breakpoint={COLUMN_BREAKPOINTS.TREND}>
+          <GroupStatusChart
+            hideZeros
+            loading
+            stats={[]}
+            secondaryStats={[]}
+            showSecondaryPoints={false}
+            groupStatus={'Loading'}
+            showMarkLine
+          />
+        </ChartWrapper>
+      )}
+      {displayReprocessingLayout ? (
+        <Fragment>
+          <StartedColumn>
+            <Placeholder height="17px" />
+          </StartedColumn>
+          <EventsReprocessedColumn>
+            <Placeholder height="17px" />
+          </EventsReprocessedColumn>
+          <ProgressColumn>
+            <Placeholder height="17px" />
+          </ProgressColumn>
+        </Fragment>
+      ) : (
+        <Fragment>
+          {showLastTriggered && (
+            <LastTriggeredWrapper>
+              <Placeholder height="18px" />
+            </LastTriggeredWrapper>
+          )}
+          {withColumns.includes('event') && (
+            <NarrowEventsOrUsersCountsWrapper breakpoint={COLUMN_BREAKPOINTS.EVENTS}>
+              <Placeholder height="18px" width="40px" />
+            </NarrowEventsOrUsersCountsWrapper>
+          )}
+          {withColumns.includes('users') && (
+            <NarrowEventsOrUsersCountsWrapper breakpoint={COLUMN_BREAKPOINTS.USERS}>
+              <Placeholder height="18px" width="40px" />
+            </NarrowEventsOrUsersCountsWrapper>
+          )}
+          {withColumns.includes('priority') && (
+            <PriorityWrapper breakpoint={COLUMN_BREAKPOINTS.PRIORITY}>
+              <Placeholder height="24px" />
+            </PriorityWrapper>
+          )}
+          {withColumns.includes('assignee') && (
+            <AssigneeWrapper breakpoint={COLUMN_BREAKPOINTS.ASSIGNEE}>
+              <Placeholder height="24px" />
+            </AssigneeWrapper>
+          )}
+        </Fragment>
+      )}
+    </Wrapper>
+  );
+}
+
 function StreamGroup({
   id,
   customStatsPeriod,

--- a/static/app/views/issueList/groupListBody.tsx
+++ b/static/app/views/issueList/groupListBody.tsx
@@ -68,7 +68,6 @@ function GroupListBody({
 }: GroupListBodyProps) {
   const api = useApi();
   const organization = useOrganization();
-  // const [initialLoadComplete, setInitialLoadComplete] = useState(false);
 
   // initial loading state
   if (!issuesSuccessfullyLoaded && loading) {

--- a/static/app/views/issueList/groupListBody.tsx
+++ b/static/app/views/issueList/groupListBody.tsx
@@ -3,6 +3,7 @@ import {useTheme} from '@emotion/react';
 import type {IndexedMembersByProject} from 'sentry/actionCreators/members';
 import type {GroupListColumn} from 'sentry/components/issues/groupList';
 import LoadingError from 'sentry/components/loadingError';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
 import PanelBody from 'sentry/components/panels/panelBody';
 import StreamGroup, {LoadingStreamGroup} from 'sentry/components/stream/group';
 import GroupStore from 'sentry/stores/groupStore';
@@ -32,6 +33,7 @@ type GroupListBodyProps = {
   error: string | null;
   groupIds: string[];
   groupStatsPeriod: string;
+  issuesSuccessfullyLoaded: boolean;
   loading: boolean;
   memberList: IndexedMembersByProject;
   onActionTaken: (itemIds: string[], data: IssueUpdateData) => void;
@@ -62,17 +64,24 @@ function GroupListBody({
   selectedProjectIds,
   onActionTaken,
   pageSize,
+  issuesSuccessfullyLoaded,
 }: GroupListBodyProps) {
   const api = useApi();
   const organization = useOrganization();
 
-  if (loading) {
+  // initial loading state
+  if (!issuesSuccessfullyLoaded && loading) {
     return (
       <LoadingSkeleton
         displayReprocessingLayout={displayReprocessingLayout}
         pageSize={pageSize}
       />
     );
+  }
+
+  // search loading state
+  if (loading) {
+    return <LoadingIndicator />;
   }
 
   if (error) {

--- a/static/app/views/issueList/groupListBody.tsx
+++ b/static/app/views/issueList/groupListBody.tsx
@@ -68,6 +68,7 @@ function GroupListBody({
 }: GroupListBodyProps) {
   const api = useApi();
   const organization = useOrganization();
+  // const [initialLoadComplete, setInitialLoadComplete] = useState(false);
 
   // initial loading state
   if (!issuesSuccessfullyLoaded && loading) {

--- a/static/app/views/issueList/groupListBody.tsx
+++ b/static/app/views/issueList/groupListBody.tsx
@@ -114,7 +114,7 @@ function LoadingSkeleton({
     <PanelBody>
       {Array.from({length: pageSize}).map((_, index) => (
         <LoadingStreamGroup
-          key={index}
+          key={`loading-group-${index}`}
           displayReprocessingLayout={displayReprocessingLayout}
           withColumns={COLUMNS}
         />

--- a/static/app/views/issueList/issueListTable.tsx
+++ b/static/app/views/issueList/issueListTable.tsx
@@ -29,6 +29,7 @@ interface IssueListTableProps {
   onDelete: () => void;
   onSelectStatsPeriod: (period: string) => void;
   pageLinks: string;
+  pageSize: number;
   paginationAnalyticsEvent: (direction: string) => void;
   paginationCaption: React.ReactNode;
   query: string;
@@ -59,6 +60,7 @@ function IssueListTable({
   onCursor,
   paginationAnalyticsEvent,
   issuesSuccessfullyLoaded,
+  pageSize,
 }: IssueListTableProps) {
   const location = useLocation();
 
@@ -83,7 +85,7 @@ function IssueListTable({
         disabled={issuesLoading}
       >
         <ContainerPanel>
-          {groupIds.length !== 0 && (
+          {(groupIds.length !== 0 || issuesLoading) && (
             <IssueListActions
               selection={selection}
               query={query}
@@ -114,6 +116,7 @@ function IssueListTable({
                 error={error}
                 refetchGroups={refetchGroups}
                 onActionTaken={onActionTaken}
+                pageSize={pageSize}
               />
             </VisuallyCompleteWithData>
           </PanelBody>

--- a/static/app/views/issueList/issueListTable.tsx
+++ b/static/app/views/issueList/issueListTable.tsx
@@ -113,6 +113,7 @@ function IssueListTable({
                 query={query}
                 selectedProjectIds={selection.projects}
                 loading={issuesLoading}
+                issuesSuccessfullyLoaded={issuesSuccessfullyLoaded}
                 error={error}
                 refetchGroups={refetchGroups}
                 onActionTaken={onActionTaken}

--- a/static/app/views/issueList/overview.polling.spec.tsx
+++ b/static/app/views/issueList/overview.polling.spec.tsx
@@ -9,14 +9,17 @@ import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
-import StreamGroup from 'sentry/components/stream/group';
 import TagStore from 'sentry/stores/tagStore';
 import IssueList from 'sentry/views/issueList/overview';
 
 jest.mock('sentry/views/issueList/filters', () => jest.fn(() => null));
-jest.mock('sentry/components/stream/group', () =>
-  jest.fn(({id}) => <div data-test-id={id} />)
-);
+jest.mock('sentry/components/stream/group', () => ({
+  __esModule: true,
+  default: jest.fn(({id}: {id: string}) => <div data-test-id={id} />),
+  LoadingStreamGroup: jest.fn(({id}: {id: string}) => <div data-test-id={id} />),
+}));
+
+import StreamGroup, {LoadingStreamGroup} from 'sentry/components/stream/group';
 
 jest.mock('js-cookie', () => ({
   get: jest.fn(),
@@ -152,6 +155,7 @@ describe('IssueList -> Polling', function () {
     });
 
     jest.mocked(StreamGroup).mockClear();
+    jest.mocked(LoadingStreamGroup).mockClear();
     TagStore.init();
   });
 

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -1151,6 +1151,7 @@ function IssueListOverview({
             onCursor={onCursorChange}
             paginationAnalyticsEvent={paginationAnalyticsEvent}
             issuesSuccessfullyLoaded={issuesSuccessfullyLoaded}
+            pageSize={MAX_ITEMS}
           />
         </StyledMain>
         <SavedIssueSearches


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/RTC-1094/issue-stream-initial-loading-state


https://github.com/user-attachments/assets/066138e2-f425-4d1b-b384-e9fd906d5687



TODO:
- Cleanup the last of the placeholders in `static/app/components/stream/group.tsx` and subcomponents that are outside of `LoadingStreamGroup`
- Make it so `LoadingStreamGroup` is only used on initial load (searches just use the existing loading components in prod as loading for this hasn't been decided on; see https://linear.app/getsentry/issue/RTC-1095/issue-stream-search-loading-state)
- Fix tests (missing replay count mock)