### PR TITLE
ref(grouping): remove unused grouping-configs endpoint from backend

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -2395,12 +2395,6 @@ ORGANIZATION_URLS: list[URLPattern | URLResolver] = [
         BuiltinSymbolSourcesEndpoint.as_view(),
         name="sentry-api-0-organization-builtin-symbol-sources",
     ),
-    # Grouping configs
-    re_path(
-        r"^(?P<organization_id_or_slug>[^/]+)/grouping-configs/$",
-        GroupingConfigsEndpoint.as_view(),
-        name="sentry-api-0-organization-grouping-configs",
-    ),
     # Unsubscribe from organization notifications
     re_path(
         r"^(?P<organization_id_or_slug>[^/]+)/unsubscribe/project/(?P<id>\d+)/$",

--- a/tests/sentry/api/endpoints/test_grouping_configs.py
+++ b/tests/sentry/api/endpoints/test_grouping_configs.py
@@ -22,7 +22,7 @@ class GroupingConfigsNoSlugTest(APITestCase):
 
 
 class GroupingConfigsWithSlugTest(APITestCase):
-    endpoint = "sentry-api-0-organization-grouping-configs"
+    endpoint = "sentry-api-0-grouping-configs"
 
     def setUp(self) -> None:
         super().setUp()
@@ -30,7 +30,7 @@ class GroupingConfigsWithSlugTest(APITestCase):
         self.login_as(user=self.user)
 
     def test_with_slug(self) -> None:
-        resp = self.get_response(self.organization.slug)
+        resp = self.get_response()
         assert resp.status_code == 200
 
         body = resp.data


### PR DESCRIPTION
 Remove unused grouping-configs endpoint from backend. The `GroupingConfigsEndpoint` class isn't getting deleted because it is still being used in the non-scoped grouping configs endpoint. 