### PR TITLE
ref: avoid silently corrupting bytes parameters with particular bytes

### DIFF
--- a/src/sentry/db/postgres/base.py
+++ b/src/sentry/db/postgres/base.py
@@ -1,4 +1,6 @@
-import psycopg2 as Database
+from collections.abc import Iterable
+
+import psycopg2
 
 # Some of these imports are unused, but they are inherited from other engines
 # and should be available as part of the backend ``base.py`` namespace.
@@ -13,45 +15,33 @@ from .schema import DatabaseSchemaEditorProxy
 __all__ = ("DatabaseWrapper",)
 
 
-def remove_null(value):
+def remove_null(value: str) -> str:
     # In psycopg2 2.7+, behavior was introduced where a
-    # NULL byte in a parameter would start raising a ValueError.
+    # NULL character in a parameter would start raising a ValueError.
     # psycopg2 chose to do this rather than let Postgres silently
-    # truncate the data, which is it's behavior when it sees a
-    # NULL byte. But for us, we'd rather remove the null value so it's
+    # truncate the data, which is its behavior when it sees a
+    # NULL character. But for us, we'd rather remove the null value so it's
     # somewhat legible rather than error. Considering this is better
     # behavior than the database truncating, seems good to do this
     # rather than attempting to sanitize all data inputs now manually.
-    if type(value) is bytes:
-        return value.replace(b"\x00", b"")
     return value.replace("\x00", "")
 
 
-def remove_surrogates(value):
-    # Another hack.  postgres does not accept lone surrogates
-    # in utf-8 mode.  If we encounter any lone surrogates in
-    # our string we need to remove it.
-    if type(value) is bytes:
-        try:
-            return strip_lone_surrogates(value.decode("utf-8")).encode("utf-8")
-        except UnicodeError:
-            return value
-    return strip_lone_surrogates(value)
-
-
-def clean_bad_params(params):
+def clean_bad_params(
+    params: dict[str, object] | Iterable[object]
+) -> dict[str, object] | list[object]:
     # Support dictionary of parameters for %(key)s placeholders
     # in raw SQL queries.
     if isinstance(params, dict):
         for key, param in params.items():
-            if isinstance(param, (str, bytes)):
-                params[key] = remove_null(remove_surrogates(param))
+            if isinstance(param, str):
+                params[key] = remove_null(strip_lone_surrogates(param))
         return params
 
     params = list(params)
     for idx, param in enumerate(params):
-        if isinstance(param, (str, bytes)):
-            params[idx] = remove_null(remove_surrogates(param))
+        if isinstance(param, str):
+            params[idx] = remove_null(strip_lone_surrogates(param))
     return params
 
 
@@ -113,7 +103,7 @@ class DatabaseWrapper(DjangoDatabaseWrapper):
             if not self.connection.closed:
                 try:
                     self.connection.close()
-                except Database.InterfaceError:
+                except psycopg2.InterfaceError:
                     # connection was already closed by something
                     # like pgbouncer idle timeout.
                     pass

--- a/tests/sentry/db/postgres/test_base.py
+++ b/tests/sentry/db/postgres/test_base.py
@@ -1,64 +1,55 @@
+from django.db import connection
+
 from sentry.constants import MAX_CULPRIT_LENGTH
 from sentry.testutils.cases import TestCase
 
 
 class CursorWrapperTestCase(TestCase):
-    def test_null_bytes(self) -> None:
-        from django.db import connection
-
+    def test_null_byte(self) -> None:
         cursor = connection.cursor()
         cursor.execute("SELECT %s", [b"Ma\x00tt"])
-        assert bytes(cursor.fetchone()[0]) == b"Matt"
+        assert bytes(cursor.fetchone()[0]) == b"Ma\x00tt"
+
+        cursor = connection.cursor()
+        cursor.execute("SELECT %(name)s", {"name": b"Ma\x00tt"})
+        assert bytes(cursor.fetchone()[0]) == b"Ma\x00tt"
+
+    def test_null_character(self) -> None:
+        cursor = connection.cursor()
 
         cursor.execute("SELECT %s", ["Ma\x00tt"])
         assert cursor.fetchone()[0] == "Matt"
 
-        cursor = connection.cursor()
-        cursor.execute("SELECT %(name)s", {"name": b"Ma\x00tt"})
-        assert bytes(cursor.fetchone()[0]) == b"Matt"
-
         cursor.execute("SELECT %(name)s", {"name": "Ma\x00tt"})
         assert cursor.fetchone()[0] == "Matt"
 
-    def test_null_bytes_at_max_len_bytes(self) -> None:
-        from django.db import connection
-
+    def test_null_byte_at_max_len_bytes(self) -> None:
         cursor = connection.cursor()
 
-        long_str = (b"a" * (MAX_CULPRIT_LENGTH - 1)) + b"\x00"
-        assert len(long_str) <= MAX_CULPRIT_LENGTH
+        long_bytes = (b"a" * (MAX_CULPRIT_LENGTH - 1)) + b"\x00"
 
-        cursor.execute("SELECT %s", [long_str])
-        long_str_from_db = bytes(cursor.fetchone()[0])
-        assert long_str_from_db == (b"a" * (MAX_CULPRIT_LENGTH - 1))
-        assert len(long_str_from_db) <= MAX_CULPRIT_LENGTH
+        cursor.execute("SELECT %s", [long_bytes])
+        long_bytes_from_db = bytes(cursor.fetchone()[0])
+        assert long_bytes_from_db == long_bytes
 
-        cursor.execute("SELECT %(long_str)s", {"long_str": long_str})
-        long_str_from_db = bytes(cursor.fetchone()[0])
-        assert long_str_from_db == (b"a" * (MAX_CULPRIT_LENGTH - 1))
-        assert len(long_str_from_db) <= MAX_CULPRIT_LENGTH
+        cursor.execute("SELECT %(long_bytes)s", {"long_bytes": long_bytes})
+        long_bytes_from_db = bytes(cursor.fetchone()[0])
+        assert long_bytes_from_db == long_bytes
 
-    def test_null_bytes_at_max_len_unicode(self) -> None:
-        from django.db import connection
-
+    def test_null_character_at_max_len_str(self) -> None:
         cursor = connection.cursor()
 
         long_str = ("a" * (MAX_CULPRIT_LENGTH - 1)) + "\x00"
-        assert len(long_str) <= MAX_CULPRIT_LENGTH
 
         cursor.execute("SELECT %s", [long_str])
         long_str_from_db = cursor.fetchone()[0]
         assert long_str_from_db == ("a" * (MAX_CULPRIT_LENGTH - 1))
-        assert len(long_str_from_db) <= MAX_CULPRIT_LENGTH
 
         cursor.execute("SELECT %(long_str)s", {"long_str": long_str})
         long_str_from_db = cursor.fetchone()[0]
         assert long_str_from_db == ("a" * (MAX_CULPRIT_LENGTH - 1))
-        assert len(long_str_from_db) <= MAX_CULPRIT_LENGTH
 
     def test_lone_surrogates(self) -> None:
-        from django.db import connection
-
         cursor = connection.cursor()
 
         bad_str = "Hello\ud83dWorld🇦🇹!"


### PR DESCRIPTION
noticed this while refactoring cursors -- the existing code can lead to data loss in any binary columns (I don't think we have any fortunately? so this code is probably just dead anyway)

<!-- Describe your PR here. -->