### PR TITLE
♻️ : ref(aci): refactor how we build evidence data for stateful detectors

### DIFF
--- a/src/sentry/incidents/grouptype.py
+++ b/src/sentry/incidents/grouptype.py
@@ -170,11 +170,10 @@ class MetricIssueDetectorHandler(StatefulDetectorHandler[MetricUpdate, MetricRes
         data_packet: DataPacket[MetricUpdate],
         priority: DetectorPriorityLevel,
     ) -> dict[str, Any]:
-        evidence_data: dict[str, Any] = {}
 
         try:
             alert_rule_detector = AlertRuleDetector.objects.get(detector=self.detector)
-            evidence_data["alert_id"] = alert_rule_detector.alert_rule_id
+            return {"alert_id": alert_rule_detector.alert_rule_id}
         except AlertRuleDetector.DoesNotExist:
             logger.warning(
                 "No alert rule detector found for detector id %s",
@@ -183,9 +182,7 @@ class MetricIssueDetectorHandler(StatefulDetectorHandler[MetricUpdate, MetricRes
                     "detector_id": self.detector.id,
                 },
             )
-            evidence_data["alert_id"] = None
-
-        return evidence_data
+            return {"alert_id": None}
 
     def create_occurrence(
         self,


### PR DESCRIPTION
when I was working on triggering resolution alerts for metric issues, i needed to pass `alert_id` as well for the resolved messages. as i went to do that, i found that evidence data is very coupled to individual handlers.

To decouple, i refactored how stateful detectors build evidence data by:

  - Extracted reusable method: Added `build_detector_evidence_data()` hook for
  detector-specific evidence data
  - Separated concerns: Split workflow engine evidence data
  (_build_workflow_engine_evidence_data()) from detector-specific data


  This allows detectors to customize their evidence data while maintaining
  consistency in the workflow engine data structure.