### PR TITLE
:wrench: chore: add detector type tag to activity task metric

### DIFF
--- a/src/sentry/workflow_engine/tasks/workflows.py
+++ b/src/sentry/workflow_engine/tasks/workflows.py
@@ -68,7 +68,7 @@ def process_workflow_activity(activity_id: int, group_id: int, detector_id: int)
     process_workflows(event_data, detector)
     metrics.incr(
         "workflow_engine.tasks.process_workflows.activity_update.executed",
-        tags={"activity_type": activity.type},
+        tags={"activity_type": activity.type, "detector_type": detector.type},
         sample_rate=1.0,
     )
 

--- a/tests/sentry/incidents/test_metric_issue_post_process.py
+++ b/tests/sentry/incidents/test_metric_issue_post_process.py
@@ -185,7 +185,10 @@ class MetricIssueIntegrationTest(BaseWorkflowTest, BaseMetricIssueTest):
                 update_status(group, message)
             mock_incr.assert_any_call(
                 "workflow_engine.tasks.process_workflows.activity_update.executed",
-                tags={"activity_type": ActivityType.SET_RESOLVED.value},
+                tags={
+                    "activity_type": ActivityType.SET_RESOLVED.value,
+                    "detector_type": self.detector.type,
+                },
                 sample_rate=1.0,
             )
 
@@ -214,6 +217,9 @@ class MetricIssueIntegrationTest(BaseWorkflowTest, BaseMetricIssueTest):
                 update_status(group, message)
             mock_incr.assert_any_call(
                 "workflow_engine.tasks.process_workflows.activity_update.executed",
-                tags={"activity_type": ActivityType.SET_RESOLVED.value},
+                tags={
+                    "activity_type": ActivityType.SET_RESOLVED.value,
+                    "detector_type": self.detector.type,
+                },
                 sample_rate=1.0,
             )

--- a/tests/sentry/workflow_engine/test_task.py
+++ b/tests/sentry/workflow_engine/test_task.py
@@ -238,6 +238,9 @@ class TestProcessWorkflowActivity(TestCase):
             # Workflow engine evaluated activity update in process_workflows
             mock_incr.assert_any_call(
                 "workflow_engine.tasks.process_workflows.activity_update.executed",
-                tags={"activity_type": self.activity.type},
+                tags={
+                    "activity_type": self.activity.type,
+                    "detector_type": self.detector.type,
+                },
                 sample_rate=1.0,
             )


### PR DESCRIPTION
i was looking at the dashboard and realized i missed this