### PR TITLE
fix(issues): Remove left chevron alignment on mobile

### DIFF
--- a/static/app/views/issueDetails/streamline/foldSection.tsx
+++ b/static/app/views/issueDetails/streamline/foldSection.tsx
@@ -231,7 +231,9 @@ const Section = styled('section')<{scrollMargin: number}>`
 
 const Content = styled('div')`
   padding: ${space(0.5)} ${space(0.75)};
-  margin-left: ${p => p.theme.space.xl};
+  @media (min-width: ${p => p.theme.breakpoints.xs}) {
+    margin-left: ${p => p.theme.space.xl};
+  }
 `;
 
 const SectionExpander = styled('div')<{preventCollapse: boolean}>`


### PR DESCRIPTION
Makes the indent added in #96173 not apply on mobile widths

before

<img width="451" height="588" alt="image" src="https://github.com/user-attachments/assets/5aa36843-e2d7-4fe5-9117-6619763e0ecd" />


after

<img width="528" height="592" alt="image" src="https://github.com/user-attachments/assets/8a7be876-cdb5-4ecd-afd9-d87f2dd1c4ca" />
