### PR TITLE
fix(issues): Adjust feature flags section on mobile

### DIFF
--- a/static/app/components/events/featureFlags/eventFeatureFlagSection.tsx
+++ b/static/app/components/events/featureFlags/eventFeatureFlagSection.tsx
@@ -66,25 +66,25 @@ function BaseEventFeatureFlagList({event, group, project}: EventFeatureFlagSecti
   const isXsScreen = useMedia(`(max-width: ${theme.breakpoints.xs})`);
 
   const openForm = useFeedbackForm();
-  const feedbackButton = openForm ? (
-    <Button
-      className="hidden-xs"
-      aria-label={t('Give feedback on the feature flag section')}
-      icon={<IconMegaphone />}
-      size={'xs'}
-      onClick={() =>
-        openForm({
-          messagePlaceholder: t('How can we make feature flags work better for you?'),
-          tags: {
-            ['feedback.source']: 'issue_details_feature_flags',
-            ['feedback.owner']: 'replay',
-          },
-        })
-      }
-    >
-      {t('Give Feedback')}
-    </Button>
-  ) : null;
+  const feedbackButton =
+    openForm && !isXsScreen ? (
+      <Button
+        aria-label={t('Give feedback on the feature flag section')}
+        icon={<IconMegaphone />}
+        size={'xs'}
+        onClick={() =>
+          openForm({
+            messagePlaceholder: t('How can we make feature flags work better for you?'),
+            tags: {
+              ['feedback.source']: 'issue_details_feature_flags',
+              ['feedback.owner']: 'replay',
+            },
+          })
+        }
+      >
+        {t('Give Feedback')}
+      </Button>
+    ) : null;
 
   // If we're showing the suspect section at all
   const enableSuspectFlags = organization.features.includes('feature-flag-suspect-flags');

--- a/static/app/components/events/featureFlags/eventFeatureFlagSection.tsx
+++ b/static/app/components/events/featureFlags/eventFeatureFlagSection.tsx
@@ -186,7 +186,7 @@ function BaseEventFeatureFlagList({event, group, project}: EventFeatureFlagSecti
           value: (
             <ValueWrapper>
               {f.result.toString()}
-              {!suspectFlagNames.has(f.flag) && (
+              {suspectFlagNames.has(f.flag) && (
                 <SuspectLabel>{t('Suspect')}</SuspectLabel>
               )}
               <FlagActionDropdown


### PR DESCRIPTION
- Disables 2 column layout
- Hides feedback button
- Moves "Suspect" text to its own line

before

<img width="415" height="535" alt="image" src="https://github.com/user-attachments/assets/e2868606-cf7d-4786-8fb1-a835f07aaeca" />


after

<img width="419" height="350" alt="image" src="https://github.com/user-attachments/assets/b9ead107-194c-440c-b0c4-c6364070e419" />

Fixes REPLAY-219