### PR TITLE
fix(ui): Ensure grid-lines are behind check-in timeline

### DIFF
--- a/static/app/components/checkInTimeline/checkInTimeline.tsx
+++ b/static/app/components/checkInTimeline/checkInTimeline.tsx
@@ -152,8 +152,6 @@ const TimelineContainer = styled('div')`
   height: 14px;
   width: 100%;
   overflow: hidden;
-  /* TimelineContainer should be above the GridLineContainer */
-  z-index: 2;
 `;
 
 const JobTick = styled('div')<{

--- a/static/app/components/checkInTimeline/gridLines.tsx
+++ b/static/app/components/checkInTimeline/gridLines.tsx
@@ -125,7 +125,35 @@ export function GridLineLabels({
           <TimeLabel date={date} {...dateTimeProps} />
         </TimeLabelContainer>
       ))}
+      {labelPosition && (
+        <GridLines timeWindowConfig={timeWindowConfig} labelPosition={labelPosition} />
+      )}
     </LabelsContainer>
+  );
+}
+
+interface GridLinesProps {
+  labelPosition: LabelPosition;
+  timeWindowConfig: TimeWindowConfig;
+}
+
+function GridLines({timeWindowConfig, labelPosition}: GridLinesProps) {
+  const {timelineUnderscanWidth} = timeWindowConfig.rollupConfig;
+
+  const gridLine = getTimeMarkersFromConfig(timeWindowConfig);
+
+  // Skip rendering of the first grid line marker when the underscan width is
+  // below the threshold to be displayed
+  if (timelineUnderscanWidth < UNDERSCAN_MARKER_LINE_THRESHOLD) {
+    gridLine.shift();
+  }
+
+  return (
+    <GridLineContainer>
+      {gridLine.map(({date, position}) => (
+        <Gridline key={date.getTime()} left={position} labelPosition={labelPosition} />
+      ))}
+    </GridLineContainer>
   );
 }
 
@@ -234,24 +262,13 @@ export function GridLineOverlay({
   });
 
   const overlayRef = mergeRefs(cursorContainerRef, selectionContainerRef);
-  const gridLine = getTimeMarkersFromConfig(timeWindowConfig);
-
-  // Skip rendering of the first grid line marker when the underscan width is
-  // below the threshold to be displayed
-  if (timelineUnderscanWidth < UNDERSCAN_MARKER_LINE_THRESHOLD) {
-    gridLine.shift();
-  }
 
   return (
     <Overlay aria-hidden ref={overlayRef} className={className}>
       {timelineCursor}
       {timelineSelector}
       {additionalUi}
-      <GridLineContainer>
-        {gridLine.map(({date, position}) => (
-          <Gridline key={date.getTime()} left={position} labelPosition={labelPosition} />
-        ))}
-      </GridLineContainer>
+      <GridLines timeWindowConfig={timeWindowConfig} labelPosition={labelPosition} />
     </Overlay>
   );
 }
@@ -266,7 +283,6 @@ const GridLineContainer = styled('div')`
   position: relative;
   overflow: hidden;
   height: 100%;
-  z-index: 1;
   pointer-events: none;
 `;
 
@@ -277,7 +293,7 @@ const LabelsContainer = styled('div')<{labelPosition: LabelPosition}>`
   ${p =>
     p.labelPosition === 'left-top' &&
     css`
-      height: 50px;
+      min-height: 50px;
     `}
   ${p =>
     p.labelPosition === 'center-bottom' &&


### PR DESCRIPTION
This fixes a stacking problem where the uptiem and cron grid-lines for the checkInTimeline would be above the timelines themselves.

Unfortunately this isn't a simple z-index fix since the grid-lines are also displayed in the header, which is sticky above the check timelines. So if we put the grid-lines behind the timeliens then the grid-lines end up behind the header, and if we move the timelines above the grid-lines then the timelines are above the header.

The solution is to render two gridlines, one set that exist behind the header and timelines, another that _only_ exist in the header.