### PR TITLE
container: allow border on each edge

### DIFF
--- a/static/app/components/core/layout/container.tsx
+++ b/static/app/components/core/layout/container.tsx
@@ -42,6 +42,10 @@ interface ContainerLayoutProps {
   maxHeight?: Responsive<React.CSSProperties['maxHeight']>;
 
   border?: Responsive<Border>;
+  borderRight?: Responsive<Border>;
+  borderLeft?: Responsive<Border>;
+  borderTop?: Responsive<Border>;
+  borderBottom?: Responsive<Border>;
 
   area?: Responsive<React.CSSProperties['gridArea']>;
   order?: Responsive<React.CSSProperties['order']>;
@@ -155,6 +159,10 @@ export const Container = styled(
   ${p => rc('order', p.order, p.theme)};
 
   ${p => rc('border', p.border, p.theme, getBorder)};
+  ${p => rc('border-right', p.borderRight, p.theme, getBorder)};
+  ${p => rc('border-left', p.borderLeft, p.theme, getBorder)};
+  ${p => rc('border-top', p.borderTop, p.theme, getBorder)};
+  ${p => rc('border-bottom', p.borderBottom, p.theme, getBorder)};
 
   /**
    * This cast is required because styled-components does not preserve the generic signature of the wrapped component.

--- a/static/app/components/core/layout/styles.tsx
+++ b/static/app/components/core/layout/styles.tsx
@@ -60,7 +60,7 @@ const BREAKPOINT_ORDER: readonly Breakpoint[] = ['xs', 'sm', 'md', 'lg', 'xl'];
 // We alias None -> 0 to make it slighly more terse and easier to read.
 export type RadiusSize = keyof DO_NOT_USE_ChonkTheme['radius'];
 export type SpacingSize = keyof Theme['space'];
-export type Border = keyof Theme['tokens']['border'];
+export type Border = keyof Theme['tokens']['border'] | '0';
 type Breakpoint = keyof Theme['breakpoints'];
 
 // @TODO(jonasbadalic): audit for memory usage and linting performance issues.
@@ -105,6 +105,10 @@ export function getBorder(
   _breakpoint: Breakpoint | undefined,
   theme: Theme
 ) {
+  if (border === '0') {
+    return '0';
+  }
+
   return `1px solid ${theme.tokens.border[border]}`;
 }
 


### PR DESCRIPTION
Allow applying borders to a single edge at a time.

I have thought of possibly using a shorthand like we do for padding, but I think that would have become a footgun over time if we ever decide to also modify border thickness per edge.