### PR TITLE
fix(dashboards): disable name and description fields for transaction deprecation

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/saveButton.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/saveButton.tsx
@@ -28,7 +28,7 @@ function SaveButton({isEditing, onSave, setError}: SaveButtonProps) {
   const api = useApi();
   const organization = useOrganization();
   const [isSaving, setIsSaving] = useState(false);
-  const disableTransactionWidget = useDisableTransactionWidget() && !isEditing;
+  const disableTransactionWidget = useDisableTransactionWidget();
 
   const handleSave = useCallback(async () => {
     trackAnalytics('dashboards_views.widget_builder.save', {

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.spec.tsx
@@ -590,7 +590,7 @@ describe('WidgetBuilderSlideout', () => {
       )
     ).toBeInTheDocument();
 
-    expect(screen.getByTestId('transaction-widget-disabled-wrapper')).toBeInTheDocument();
+    expect(screen.getAllByTestId('transaction-widget-disabled-wrapper')).toHaveLength(2);
   });
 
   it('should not show deprecation alert when flag enabled', async () => {

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -249,9 +249,11 @@ function WidgetBuilderSlideout({
           </Fragment>
         ) : (
           <Fragment>
-            <Section>
-              <WidgetBuilderNameAndDescription error={error} setError={setError} />
-            </Section>
+            <DisableTransactionWidget>
+              <Section>
+                <WidgetBuilderNameAndDescription error={error} setError={setError} />
+              </Section>
+            </DisableTransactionWidget>
             <Section>
               <WidgetBuilderDatasetSelector />
             </Section>


### PR DESCRIPTION
We didn't disable name and description fields initially but it was causing issues with the validation because of the way we pass in parameters to the endpoint. So I've just decided to disable it. 
