### PR TITLE
chore(logs): Deprecate ourlogs from the public facing APIs

### DIFF
--- a/src/sentry/explore/models.py
+++ b/src/sentry/explore/models.py
@@ -25,7 +25,7 @@ class ExploreSavedQueryDataset(TypesClass):
 
     TYPES = [
         (SPANS, "spans"),
-        (OURLOGS, "ourlogs"),
+        (OURLOGS, "logs"),
         (SEGMENT_SPANS, "segment_spans"),
     ]
     TYPE_NAMES = [t[1] for t in TYPES]

--- a/src/sentry/incidents/charts.py
+++ b/src/sentry/incidents/charts.py
@@ -257,7 +257,7 @@ def build_metric_alert_chart(
             and dataset == Dataset.EventsAnalyticsPlatform
             and snuba_query.event_types == [SnubaQueryEventType.EventType.TRACE_ITEM_LOG]
         ):
-            query_params["dataset"] = "ourlogs"
+            query_params["dataset"] = "logs"
         elif (
             query_type == SnubaQuery.Type.PERFORMANCE and dataset == Dataset.EventsAnalyticsPlatform
         ):

--- a/src/sentry/seer/anomaly_detection/utils.py
+++ b/src/sentry/seer/anomaly_detection/utils.py
@@ -239,7 +239,7 @@ def get_dataset_from_label_and_event_types(
         dataset_label = "errors"
     elif dataset_label == "events_analytics_platform":
         if event_types and SnubaQueryEventType.EventType.TRACE_ITEM_LOG in event_types:
-            dataset_label = "ourlogs"
+            dataset_label = "logs"
         else:
             dataset_label = "spans"
     elif dataset_label in ["generic_metrics", "transactions"]:

--- a/src/sentry/snuba/utils.py
+++ b/src/sentry/snuba/utils.py
@@ -1,3 +1,4 @@
+import logging
 from dataclasses import dataclass
 from typing import Any
 
@@ -20,6 +21,8 @@ from sentry.snuba.spans_rpc import Spans
 from sentry.snuba.uptime_checks import UptimeChecks
 from sentry.snuba.uptime_results import UptimeResults
 
+logger = logging.getLogger(__name__)
+
 # Doesn't map 1:1 with real datasets, but rather what we present to users
 # ie. metricsEnhanced is not a real dataset
 DATASET_OPTIONS = {
@@ -27,7 +30,9 @@ DATASET_OPTIONS = {
     "errors": errors,
     "metricsEnhanced": metrics_enhanced_performance,
     "metrics": metrics_performance,
+    # ourlogs is deprecated, please use logs instead
     "ourlogs": OurLogs,
+    "logs": OurLogs,
     "uptimeChecks": UptimeChecks,
     "uptime_results": UptimeResults,
     "profiles": profiles,
@@ -38,6 +43,7 @@ DATASET_OPTIONS = {
     "spansMetrics": spans_metrics,
     "transactions": transactions,
 }
+DEPRECATED_LABELS = {"ourlogs"}
 RPC_DATASETS = {
     Spans,
     OurLogs,
@@ -102,6 +108,8 @@ ERROR_ONLY_FIELDS = [
 
 
 def get_dataset(dataset_label: str) -> Any | None:
+    if dataset_label in DEPRECATED_LABELS:
+        logger.warning("query.deprecated_dataset.%s", dataset_label)
     return DATASET_OPTIONS.get(dataset_label)
 
 

--- a/src/sentry/snuba/utils.py
+++ b/src/sentry/snuba/utils.py
@@ -50,7 +50,9 @@ RPC_DATASETS = {
     UptimeResults,
     UptimeChecks,
 }
-DATASET_LABELS = {value: key for key, value in DATASET_OPTIONS.items()}
+DATASET_LABELS = {
+    value: key for key, value in DATASET_OPTIONS.items() if key not in DEPRECATED_LABELS
+}
 
 
 TRANSACTION_ONLY_FIELDS = [

--- a/tests/snuba/api/endpoints/test_organization_events_meta.py
+++ b/tests/snuba/api/endpoints/test_organization_events_meta.py
@@ -73,7 +73,7 @@ class OrganizationEventsMetaEndpoint(
         )
 
         with self.feature(self.features):
-            response = self.client.get(self.url, format="json", data={"dataset": "ourlogs"})
+            response = self.client.get(self.url, format="json", data={"dataset": "logs"})
 
         assert response.status_code == 200, response.content
         assert response.data["count"] == 2

--- a/tests/snuba/api/endpoints/test_organization_events_ourlogs.py
+++ b/tests/snuba/api/endpoints/test_organization_events_ourlogs.py
@@ -9,7 +9,7 @@ from tests.snuba.api.endpoints.test_organization_events import OrganizationEvent
 
 
 class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase):
-    dataset = "ourlogs"
+    dataset = "logs"
 
     def do_request(self, query, features=None, **kwargs):
         return super().do_request(query, features, **kwargs)
@@ -350,7 +350,7 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase):
         response = self.do_request(
             {
                 "cursor": "",
-                "dataset": "ourlogs",
+                "dataset": "logs",
                 "field": [
                     "sentry.item_id",
                     "project.id",

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -3087,7 +3087,7 @@ class OrganizationEventsStatsTopNEventsLogs(APITestCase, SnubaTestCase, OurLogTe
                 data={
                     "start": self.day_ago.isoformat(),
                     "end": (self.day_ago + timedelta(hours=2)).isoformat(),
-                    "dataset": "ourlogs",
+                    "dataset": "logs",
                     "interval": "1h",
                     "yAxis": "count()",
                     "orderby": ["-count()"],

--- a/tests/snuba/api/endpoints/test_organization_events_stats_ourlogs.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_ourlogs.py
@@ -53,7 +53,7 @@ class OrganizationEventsStatsOurlogsEndpointTest(OrganizationEventsEndpointTestB
                 "interval": "1h",
                 "yAxis": "count()",
                 "project": self.project.id,
-                "dataset": "ourlogs",
+                "dataset": "logs",
             },
         )
         assert response.status_code == 200, response.content
@@ -69,7 +69,7 @@ class OrganizationEventsStatsOurlogsEndpointTest(OrganizationEventsEndpointTestB
                 "interval": "1h",
                 "yAxis": "count()",
                 "project": self.project.id,
-                "dataset": "ourlogs",
+                "dataset": "logs",
             },
         )
         assert response.status_code == 200, response.content
@@ -80,7 +80,7 @@ class OrganizationEventsStatsOurlogsEndpointTest(OrganizationEventsEndpointTestB
         for the initial load"""
         response = self._do_request(
             data={
-                "dataset": "ourlogs",
+                "dataset": "logs",
                 "excludeOther": 0,
                 "field": ["count(message)"],
                 "interval": "1h",

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries_logs.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries_logs.py
@@ -59,12 +59,12 @@ class OrganizationEventsStatsOurlogsMetricsEndpointTest(OrganizationEventsEndpoi
                 "interval": "1h",
                 "yAxis": "count()",
                 "project": self.project.id,
-                "dataset": "ourlogs",
+                "dataset": "logs",
             },
         )
         assert response.status_code == 200, response.content
         assert response.data["meta"] == {
-            "dataset": "ourlogs",
+            "dataset": "logs",
             "start": self.start.timestamp() * 1000,
             "end": self.end.timestamp() * 1000,
         }
@@ -93,12 +93,12 @@ class OrganizationEventsStatsOurlogsMetricsEndpointTest(OrganizationEventsEndpoi
                 "interval": "1h",
                 "yAxis": "count()",
                 "project": self.project.id,
-                "dataset": "ourlogs",
+                "dataset": "logs",
             },
         )
         assert response.status_code == 200, response.content
         assert response.data["meta"] == {
-            "dataset": "ourlogs",
+            "dataset": "logs",
             "start": self.start.timestamp() * 1000,
             "end": self.end.timestamp() * 1000,
         }


### PR DESCRIPTION
- We want users to interact with logs via "logs", but we still like ourlogs internally for easier code grepping