### PR TITLE
feat(snuba): Add group_by field validation to SnubaQueryValidator

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -507,6 +507,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:workflow-engine-metric-alert-dual-write", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable Processing for Metric Alerts in the workflow_engine
     manager.add("organizations:workflow-engine-metric-alert-processing", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Enable Creation of Metric Alerts that use the `group_by` field in the workflow_engine
+    manager.add("organizations:workflow-engine-metric-alert-group-by-creation", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable ingestion through trusted relays only
     manager.add("organizations:ingest-through-trusted-relays-only", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable new workflow_engine UI (see: alerts create issues)

--- a/src/sentry/snuba/snuba_query_validator.py
+++ b/src/sentry/snuba/snuba_query_validator.py
@@ -80,6 +80,11 @@ class SnubaQueryValidator(BaseDataSourceValidator[QuerySubscription]):
     event_types = serializers.ListField(
         child=serializers.CharField(),
     )
+    group_by = serializers.ListField(
+        child=serializers.CharField(allow_blank=False, max_length=200),
+        required=False,
+        allow_empty=False,
+    )
 
     class Meta:
         model = QuerySubscription
@@ -91,6 +96,7 @@ class SnubaQueryValidator(BaseDataSourceValidator[QuerySubscription]):
             "time_window",
             "environment",
             "event_types",
+            "group_by",
         ]
 
     data_source_type_handler = QuerySubscriptionDataSourceHandler
@@ -151,6 +157,8 @@ class SnubaQueryValidator(BaseDataSourceValidator[QuerySubscription]):
         data = super().validate(data)
         self._validate_aggregate(data)
         self._validate_query(data)
+
+        data["group_by"] = self._validate_group_by(data.get("group_by"))
 
         query_type = data["query_type"]
         if query_type == SnubaQuery.Type.CRASH_RATE:
@@ -351,6 +359,31 @@ class SnubaQueryValidator(BaseDataSourceValidator[QuerySubscription]):
 
         return dataset
 
+    def _validate_group_by(self, value: Sequence[str] | None) -> Sequence[str] | None:
+        if value is None:
+            return None
+
+        if not features.has(
+            "organizations:workflow-engine-metric-alert-group-by-creation",
+            self.context["organization"],
+            actor=self.context.get("user", None),
+        ):
+            raise serializers.ValidationError(
+                "Group by Metric Alerts feature must be enabled to use this field"
+            )
+
+        if len(value) > 100:
+            raise serializers.ValidationError("Group by must be 100 or fewer items")
+
+        # group by has to be unique list of strings
+        if len(value) != len(set(value)):
+            raise serializers.ValidationError("Group by must be a unique list of strings")
+
+        # TODO:
+        # validate that group by is a valid snql / EAP column?
+
+        return value
+
     @override
     def create_source(self, validated_data) -> QuerySubscription:
         snuba_query = create_snuba_query(
@@ -362,6 +395,7 @@ class SnubaQueryValidator(BaseDataSourceValidator[QuerySubscription]):
             resolution=timedelta(minutes=1),
             environment=validated_data["environment"],
             event_types=validated_data["event_types"],
+            group_by=validated_data.get("group_by"),
         )
         return create_snuba_subscription(
             project=self.context["project"],

--- a/src/sentry/snuba/subscriptions.py
+++ b/src/sentry/snuba/subscriptions.py
@@ -1,5 +1,5 @@
 import logging
-from collections.abc import Collection, Iterable
+from collections.abc import Collection, Iterable, Sequence
 from datetime import timedelta
 
 from django.db import router, transaction
@@ -26,6 +26,7 @@ def create_snuba_query(
     resolution: timedelta,
     environment: Environment | None,
     event_types: Collection[SnubaQueryEventType.EventType] = (),
+    group_by: Sequence[str] | None = None,
 ):
     """
     Constructs a SnubaQuery which is the postgres representation of a query in snuba
@@ -50,6 +51,7 @@ def create_snuba_query(
         time_window=int(time_window.total_seconds()),
         resolution=int(resolution.total_seconds()),
         environment=environment,
+        group_by=group_by,
     )
     if not event_types:
         if dataset == Dataset.Events:

--- a/tests/sentry/snuba/test_validators.py
+++ b/tests/sentry/snuba/test_validators.py
@@ -6,6 +6,7 @@ from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import SnubaQuery, SnubaQueryEventType
 from sentry.snuba.snuba_query_validator import SnubaQueryValidator
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.features import with_feature
 from sentry.workflow_engine.endpoints.validators.base import DataSourceCreator
 
 
@@ -74,3 +75,175 @@ class SnubaQueryValidatorTest(TestCase):
                     code="invalid",
                 )
             ]
+
+    @with_feature("organizations:workflow-engine-metric-alert-group-by-creation")
+    def test_valid_group_by(self) -> None:
+        """Test that valid group_by data is accepted."""
+        self.valid_data["group_by"] = ["project", "environment"]
+
+        validator = SnubaQueryValidator(data=self.valid_data, context=self.context)
+
+        assert validator.is_valid()
+        assert validator.validated_data["group_by"] == ["project", "environment"]
+
+    @with_feature("organizations:workflow-engine-metric-alert-group-by-creation")
+    def test_empty_group_by(self) -> None:
+        """Test that empty group_by list is rejected."""
+        self.valid_data["group_by"] = []
+
+        validator = SnubaQueryValidator(data=self.valid_data, context=self.context)
+        assert not validator.is_valid()
+
+        # The serializer catches this before our custom validation
+        assert "groupBy" in validator.errors
+
+    @with_feature("organizations:workflow-engine-metric-alert-group-by-creation")
+    def test_empty_group_by_string(self) -> None:
+        """Test that empty group_by list is rejected."""
+        self.valid_data["group_by"] = [""]
+
+        validator = SnubaQueryValidator(data=self.valid_data, context=self.context)
+
+        assert not validator.is_valid()
+        assert "groupBy" in validator.errors
+
+    @with_feature("organizations:workflow-engine-metric-alert-group-by-creation")
+    def test_none_group_by(self) -> None:
+        """Test that None group_by is handled correctly."""
+        self.valid_data["group_by"] = None
+
+        validator = SnubaQueryValidator(data=self.valid_data, context=self.context)
+
+        assert not validator.is_valid()
+        assert "groupBy" in validator.errors
+
+    @with_feature("organizations:workflow-engine-metric-alert-group-by-creation")
+    def test_invalid_group_by_not_list(self) -> None:
+        """Test that non-list group_by raises validation error."""
+
+        self.valid_data["group_by"] = "not_a_list"
+
+        validator = SnubaQueryValidator(data=self.valid_data, context=self.context)
+        assert not validator.is_valid()
+
+        assert "groupBy" in validator.errors
+
+    @with_feature("organizations:workflow-engine-metric-alert-group-by-creation")
+    def test_group_by_too_many_items(self) -> None:
+        """Test that group_by with more than 100 items raises validation error."""
+
+        self.valid_data["group_by"] = [f"field_{i}" for i in range(101)]
+
+        validator = SnubaQueryValidator(data=self.valid_data, context=self.context)
+
+        assert not validator.is_valid()
+        assert validator.errors.get("nonFieldErrors") == [
+            ErrorDetail(string="Group by must be 100 or fewer items", code="invalid")
+        ]
+
+    @with_feature("organizations:workflow-engine-metric-alert-group-by-creation")
+    def test_group_by_duplicate_items(self) -> None:
+        """Test that group_by with duplicate items raises validation error."""
+
+        self.valid_data["group_by"] = ["project", "environment", "project"]
+
+        validator = SnubaQueryValidator(data=self.valid_data, context=self.context)
+
+        assert not validator.is_valid()
+        assert validator.errors.get("nonFieldErrors") == [
+            ErrorDetail(string="Group by must be a unique list of strings", code="invalid")
+        ]
+
+    def test_group_by_no_feature(self) -> None:
+        """Test group_by with performance dataset."""
+        self.valid_data.update(
+            {
+                "queryType": SnubaQuery.Type.ERROR.value,
+                "dataset": Dataset.Events.value,
+                "eventTypes": [SnubaQueryEventType.EventType.ERROR.name.lower()],
+                "group_by": ["project", "environment"],
+            }
+        )
+
+        validator = SnubaQueryValidator(data=self.valid_data, context=self.context)
+
+        assert not validator.is_valid()
+        assert validator.errors.get("nonFieldErrors") == [
+            ErrorDetail(
+                string="Group by Metric Alerts feature must be enabled to use this field",
+                code="invalid",
+            )
+        ]
+
+    @with_feature("organizations:workflow-engine-metric-alert-group-by-creation")
+    def test_group_by_string_too_long(self) -> None:
+        """Test that group_by with strings longer than 200 characters is rejected."""
+
+        self.valid_data["group_by"] = ["project", "a" * 201, "environment"]
+
+        validator = SnubaQueryValidator(data=self.valid_data, context=self.context)
+
+        assert not validator.is_valid()
+        assert "groupBy" in validator.errors
+
+    @with_feature("organizations:workflow-engine-metric-alert-group-by-creation")
+    def test_group_by_mixed_types(self) -> None:
+        """Test that group_by with non-string items is converted to strings."""
+
+        self.valid_data["group_by"] = ["project", 123, "environment"]
+
+        validator = SnubaQueryValidator(data=self.valid_data, context=self.context)
+
+        assert validator.is_valid()
+        assert validator.validated_data["group_by"] == ["project", "123", "environment"]
+
+    @with_feature("organizations:workflow-engine-metric-alert-group-by-creation")
+    def test_group_by_with_valid_fields(self) -> None:
+        """Test that common valid group_by fields are accepted."""
+
+        valid_group_by_fields = [
+            "project",
+            "environment",
+            "release",
+            "user",
+            "transaction",
+            "message",
+            "level",
+            "type",
+            "mechanism",
+            "handled",
+            "unhandled",
+            "culprit",
+            "title",
+            "location",
+            "function",
+            "package",
+            "sdk_name",
+            "sdk_version",
+            "device_name",
+            "device_family",
+            "device_model",
+            "os_name",
+            "os_version",
+            "browser_name",
+            "browser_version",
+            "geo_country_code",
+            "geo_region",
+            "geo_city",
+        ]
+
+        for field in valid_group_by_fields:
+            self.valid_data["group_by"] = [field]
+            validator = SnubaQueryValidator(data=self.valid_data, context=self.context)
+            assert validator.is_valid(), f"Failed for field: {field}"
+            assert validator.validated_data["group_by"] == [field]
+
+    @with_feature("organizations:workflow-engine-metric-alert-group-by-creation")
+    def test_group_by_multiple_valid_fields(self) -> None:
+
+        self.valid_data["group_by"] = ["project", "environment", "release", "user"]
+
+        validator = SnubaQueryValidator(data=self.valid_data, context=self.context)
+
+        assert validator.is_valid()
+        assert validator.validated_data["group_by"] == ["project", "environment", "release", "user"]


### PR DESCRIPTION
- Add group_by field to SnubaQueryValidator with validation
- field can only be set if the feature flag mentioned in the PR is turned on, 
- defaults to `None`
- Prevent empty lists (allow_empty=False)
- Validate list length (max 100 items)
- Ensure unique items in group_by list

We'll likely want to do better validation of individual group by fields, and i'll create a follow up PR to handle that.


refs ID-833


Previous: https://github.com/getsentry/sentry/pull/96227



