### PR TITLE
fix(rate-limits): expand rate limiting window for `GroupTagKeyValues` endpoint

### DIFF
--- a/src/sentry/api/endpoints/group_tagkey_values.py
+++ b/src/sentry/api/endpoints/group_tagkey_values.py
@@ -36,9 +36,9 @@ class GroupTagKeyValuesEndpoint(GroupEndpoint):
     enforce_rate_limit = True
     rate_limits = {
         "GET": {
-            RateLimitCategory.IP: RateLimit(limit=5, window=1, concurrent_limit=5),
-            RateLimitCategory.USER: RateLimit(limit=10, window=1, concurrent_limit=10),
-            RateLimitCategory.ORGANIZATION: RateLimit(limit=20, window=1, concurrent_limit=5),
+            RateLimitCategory.IP: RateLimit(limit=50, window=10, concurrent_limit=5),
+            RateLimitCategory.USER: RateLimit(limit=100, window=10, concurrent_limit=10),
+            RateLimitCategory.ORGANIZATION: RateLimit(limit=200, window=10, concurrent_limit=5),
         }
     }
 

--- a/tests/sentry/api/endpoints/test_group_tagkey_values.py
+++ b/tests/sentry/api/endpoints/test_group_tagkey_values.py
@@ -206,7 +206,7 @@ class GroupTagKeyValuesTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase
         url = f"/api/0/issues/{group.id}/tags/{key}/values/"
 
         with freeze_time(datetime.datetime.now()):
-            for i in range(10):
+            for i in range(100):
                 response = self.client.get(url)
                 assert response.status_code == 200
             response = self.client.get(url)


### PR DESCRIPTION
Expand the rate limiting window for GroupTagKeyValues by 10x, keeping the total number of requests allowed the same. Looking at [this query](https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Alabels.name%3D%22sentry.access.api%22%0AjsonPayload.view%3D%22sentry.api.endpoints.group_tagkey_values.GroupTagKeyValuesEndpoint%22%0AjsonPayload.rate_limited%3D%22True%22;summaryFields=:true:32:beginning;cursorTimestamp=2025-07-31T19:56:21.119798423Z;duration=PT1M?project=internal-sentry&inv=1&invt=Ab4QJw), several IPs are not getting rate limited properly (e.g. 1000+ requests per minute when we should limit at 60s * 5 req/s = 300 requests), and expanding the rate limit window should make it more reliable.

Refs https://linear.app/getsentry/issue/ID-830/adjust-group-tag-rate-limits-to-limit-snuba-abuse

Will be monitoring the [# of snuba queries](https://app.datadoghq.com/notebook/12697226/inc-1228?fullscreen_end_ts=1753819407024&fullscreen_paused=true&fullscreen_refresh_mode=paused&fullscreen_start_ts=1748549007024&fullscreen_widget=2wostwol&range=5270400000&from_ts=1748713375373&start=1748549007024&to_ts=1753983775373&live=false), [any app users affected](https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Alabels.name%3D%22sentry.access.api%22%0AjsonPayload.view%3D%22sentry.api.endpoints.group_tagkey_values.GroupTagKeyValuesEndpoint%22%20OR%20jsonPayload.view%3D%22sentry.api.endpoints.group_tagkey_details.GroupTagKeyDetailsEndpoint%22%0AjsonPayload.rate_limited%3D%22True%22%0AjsonPayload.is_frontend_request%3D%22True%22;summaryFields=:true:32:beginning;cursorTimestamp=2025-07-31T19:18:32.724651390Z;duration=PT1H?project=internal-sentry&rapt=AEjHL4M4gFWDvsaR44QyTFVQfCKKsWt0-Zqx7tpQ3y9pXU0ASV9Rt3PnKEunwN1yIs1Sj96ud5K545s4WvGucYwH-kHi8f39etwXP5ohHlBbqCKbnkkzcac&inv=1&invt=Ab4P6Q), and [total # of rate limits](https://console.cloud.google.com/logs/query;duration=PT1M;query=resource.type%3D%22k8s_container%22%0Alabels.name%3D%22sentry.access.api%22%0AjsonPayload.view%3D%22sentry.api.endpoints.group_tagkey_values.GroupTagKeyValuesEndpoint%22%0AjsonPayload.rate_limited%3D%22True%22;summaryFields=:true:32:beginning?project=internal-sentry&inv=1&invt=Ab4QMA) (see ticket for details)