### PR TITLE
:sparkles: feat(aci): trigger resolved activity for metric issues

### DIFF
--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -511,10 +511,14 @@ def generate_incident_trigger_email_context(
     notification_uuid: str | None = None,
 ):
     from sentry.notifications.notification_action.utils import should_fire_workflow_actions
+    from sentry.seer.anomaly_detection.types import AnomalyDetectionThresholdType
 
     snuba_query = metric_issue_context.snuba_query
     is_active = trigger_status == TriggerStatus.ACTIVE
-    is_threshold_type_above = alert_context.threshold_type == AlertRuleThresholdType.ABOVE
+    is_threshold_type_above = (
+        alert_context.threshold_type == AlertRuleThresholdType.ABOVE
+        or alert_context.threshold_type == AnomalyDetectionThresholdType.ABOVE
+    )
     subscription = metric_issue_context.subscription
     alert_link_params = {
         "referrer": "metric_alert_email",

--- a/src/sentry/incidents/typings/metric_detector.py
+++ b/src/sentry/incidents/typings/metric_detector.py
@@ -20,6 +20,7 @@ from sentry.workflow_engine.types import DetectorPriorityLevel
 
 if TYPE_CHECKING:
     from sentry.incidents.grouptype import MetricIssueEvidenceData
+    from sentry.seer.anomaly_detection.types import AnomalyDetectionThresholdType
 
 CONDITION_TO_ALERT_RULE_THRESHOLD_TYPE = {
     Condition.GREATER_OR_EQUAL: AlertRuleThresholdType.ABOVE,
@@ -29,7 +30,9 @@ CONDITION_TO_ALERT_RULE_THRESHOLD_TYPE = {
 }
 
 
-def fetch_threshold_type(condition: dict[str, Any]) -> AlertRuleThresholdType:
+def fetch_threshold_type(
+    condition: dict[str, Any],
+) -> AlertRuleThresholdType | AnomalyDetectionThresholdType:
     condition_type = condition["type"]
     if condition_type == Condition.ANOMALY_DETECTION:
         return condition["comparison"]["threshold_type"]
@@ -72,7 +75,7 @@ def fetch_sensitivity(condition: dict[str, Any]) -> str | None:
 class AlertContext:
     name: str
     action_identifier_id: int
-    threshold_type: AlertRuleThresholdType | None
+    threshold_type: AlertRuleThresholdType | None | AnomalyDetectionThresholdType
     detection_type: AlertRuleDetectionType
     comparison_delta: int | None
     sensitivity: str | None

--- a/src/sentry/incidents/typings/metric_detector.py
+++ b/src/sentry/incidents/typings/metric_detector.py
@@ -15,7 +15,6 @@ from sentry.models.group import Group, GroupStatus
 from sentry.models.groupopenperiod import get_latest_open_period
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.snuba.models import QuerySubscription, SnubaQuery
-from sentry.types.group import PriorityLevel
 from sentry.workflow_engine.models import Action, Condition, Detector
 from sentry.workflow_engine.types import DetectorPriorityLevel
 
@@ -27,12 +26,6 @@ CONDITION_TO_ALERT_RULE_THRESHOLD_TYPE = {
     Condition.GREATER: AlertRuleThresholdType.ABOVE,
     Condition.LESS_OR_EQUAL: AlertRuleThresholdType.BELOW,
     Condition.LESS: AlertRuleThresholdType.BELOW,
-}
-
-PRIORITY_LEVEL_TO_DETECTOR_PRIORITY_LEVEL = {
-    PriorityLevel.LOW: DetectorPriorityLevel.LOW,
-    PriorityLevel.MEDIUM: DetectorPriorityLevel.MEDIUM,
-    PriorityLevel.HIGH: DetectorPriorityLevel.HIGH,
 }
 
 
@@ -113,18 +106,15 @@ class AlertContext:
         detector: Detector,
         evidence_data: MetricIssueEvidenceData,
         group_status: GroupStatus,
-        priority_level: int | None,
+        detector_priority_level: DetectorPriorityLevel,
     ) -> AlertContext:
-        # This should never happen, but we need to handle it for now
-        if priority_level is None:
-            raise ValueError("Priority level is required for metric issues")
-
-        target_priority = PRIORITY_LEVEL_TO_DETECTOR_PRIORITY_LEVEL[PriorityLevel(priority_level)]
         try:
             condition = next(
                 cond
                 for cond in evidence_data.conditions
-                if cond["condition_result"] == target_priority
+                if cond["condition_result"] == detector_priority_level
+                # If the condition is an anomaly detection condition, the condition_result is just a placeholder, but that is the condition we want to use
+                or cond["type"] == Condition.ANOMALY_DETECTION
             )
             threshold_type = fetch_threshold_type(condition)
             resolve_threshold = fetch_resolve_threshold(condition, group_status)
@@ -219,11 +209,15 @@ class MetricIssueContext:
     group: Group | None
 
     @classmethod
-    def _get_new_status(cls, group: Group, priority_level: PriorityLevel) -> IncidentStatus:
+    def _get_new_status(
+        cls, group: Group, detector_priority_level: DetectorPriorityLevel
+    ) -> IncidentStatus:
         if group.status == GroupStatus.RESOLVED:
             return IncidentStatus.CLOSED
-        elif priority_level == PriorityLevel.MEDIUM:
+        elif detector_priority_level == DetectorPriorityLevel.MEDIUM:
             return IncidentStatus.WARNING
+        elif detector_priority_level == DetectorPriorityLevel.OK:
+            return IncidentStatus.CLOSED
         else:
             return IncidentStatus.CRITICAL
 
@@ -234,11 +228,11 @@ class MetricIssueContext:
 
     @classmethod
     def from_group_event(
-        cls, group: Group, evidence_data: MetricIssueEvidenceData, priority_level: int | None
+        cls,
+        group: Group,
+        evidence_data: MetricIssueEvidenceData,
+        detector_priority_level: DetectorPriorityLevel,
     ) -> MetricIssueContext:
-        if priority_level is None:
-            raise ValueError("Priority level is required for metric issues")
-
         open_period = get_latest_open_period(group)
         if open_period is None:
             raise ValueError("No open periods found for group")
@@ -247,14 +241,11 @@ class MetricIssueContext:
         snuba_query = subscription.snuba_query
 
         return cls(
-            # TODO(iamrajjoshi): Replace with something once we know how we want to build the link
-            # If we store open periods in the database, we can use the id from that
-            # Otherwise, we can use the issue id
             id=group.id,
             open_period_identifier=open_period.id,
             snuba_query=snuba_query,
             subscription=subscription,
-            new_status=cls._get_new_status(group, PriorityLevel(priority_level)),
+            new_status=cls._get_new_status(group, detector_priority_level),
             metric_value=evidence_data.value,
             group=group,
             title=group.title,

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_discord_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_discord_metric_alert_handler.py
@@ -10,7 +10,7 @@ from sentry.incidents.typings.metric_detector import (
     NotificationContext,
     OpenPeriodContext,
 )
-from sentry.models.activity import Activity, ActivityType
+from sentry.models.activity import Activity
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.notifications.notification_action.metric_alert_registry import DiscordMetricAlertHandler
 from sentry.notifications.notification_action.metric_alert_registry.handlers.utils import (
@@ -18,6 +18,7 @@ from sentry.notifications.notification_action.metric_alert_registry.handlers.uti
     get_detailed_incident_serializer,
 )
 from sentry.testutils.helpers.datetime import freeze_time
+from sentry.types.activity import ActivityType
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.types import DetectorPriorityLevel, WorkflowEventData
 from tests.sentry.notifications.notification_action.test_metric_alert_registry_handlers import (

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_discord_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_discord_metric_alert_handler.py
@@ -1,4 +1,5 @@
 import uuid
+from dataclasses import asdict
 from unittest import mock
 
 from sentry.incidents.models.alert_rule import AlertRuleDetectionType, AlertRuleThresholdType
@@ -9,6 +10,7 @@ from sentry.incidents.typings.metric_detector import (
     NotificationContext,
     OpenPeriodContext,
 )
+from sentry.models.activity import Activity
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.notifications.notification_action.metric_alert_registry import DiscordMetricAlertHandler
 from sentry.notifications.notification_action.metric_alert_registry.handlers.utils import (
@@ -16,7 +18,9 @@ from sentry.notifications.notification_action.metric_alert_registry.handlers.uti
     get_detailed_incident_serializer,
 )
 from sentry.testutils.helpers.datetime import freeze_time
+from sentry.types.group import PriorityLevel
 from sentry.workflow_engine.models import Action
+from sentry.workflow_engine.types import WorkflowEventData
 from tests.sentry.notifications.notification_action.test_metric_alert_registry_handlers import (
     MetricAlertHandlerBase,
 )
@@ -126,6 +130,83 @@ class TestDiscordMetricAlertHandler(MetricAlertHandlerBase):
             open_period_context,
             id=self.open_period.id,
             date_started=self.group_event.group.first_seen,
+            date_closed=None,
+        )
+
+        assert organization == self.detector.project.organization
+        assert isinstance(notification_uuid, str)
+
+    @mock.patch(
+        "sentry.notifications.notification_action.metric_alert_registry.DiscordMetricAlertHandler.send_alert"
+    )
+    @freeze_time("2021-01-01 00:00:00")
+    def test_invoke_legacy_registry_with_activity(self, mock_send_alert: mock.MagicMock) -> None:
+        # Create an Activity instance with evidence data and priority
+        activity_data = asdict(self.evidence_data)
+        activity_data["priority"] = PriorityLevel.HIGH.value  # Add priority to data
+
+        activity = Activity(
+            project=self.project,
+            group=self.group,
+            type=1,  # ActivityType value
+            data=activity_data,
+        )
+        activity.save()
+
+        # Create event data with Activity instead of GroupEvent
+        event_data_with_activity = WorkflowEventData(
+            event=activity,
+            workflow_env=self.workflow.environment,
+            group=self.group,
+        )
+
+        self.handler.invoke_legacy_registry(event_data_with_activity, self.action, self.detector)
+
+        assert mock_send_alert.call_count == 1
+        (
+            notification_context,
+            alert_context,
+            metric_issue_context,
+            open_period_context,
+            organization,
+            notification_uuid,
+        ) = self.unpack_kwargs(mock_send_alert)
+
+        # Verify that the same data is extracted from Activity.data as from GroupEvent.occurrence.evidence_data
+        self.assert_notification_context(
+            notification_context,
+            integration_id=1234567890,
+            target_identifier="channel123",
+            target_display=None,
+            sentry_app_config=None,
+            sentry_app_id=None,
+        )
+
+        self.assert_alert_context(
+            alert_context,
+            name=self.detector.name,
+            action_identifier_id=self.detector.id,
+            threshold_type=AlertRuleThresholdType.ABOVE,
+            detection_type=AlertRuleDetectionType.STATIC,
+            comparison_delta=None,
+            alert_threshold=self.evidence_data.conditions[0]["comparison"],
+        )
+
+        self.assert_metric_issue_context(
+            metric_issue_context,
+            open_period_identifier=self.open_period.id,
+            snuba_query=self.snuba_query,
+            new_status=IncidentStatus.CRITICAL,
+            metric_value=123.45,
+            group=self.group,
+            title=self.group.title,
+            subscription=self.subscription,
+        )
+
+        self.assert_open_period_context(
+            open_period_context,
+            id=self.open_period.id,
+            date_started=self.group.first_seen,
             date_closed=None,
         )
 

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_discord_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_discord_metric_alert_handler.py
@@ -18,9 +18,8 @@ from sentry.notifications.notification_action.metric_alert_registry.handlers.uti
     get_detailed_incident_serializer,
 )
 from sentry.testutils.helpers.datetime import freeze_time
-from sentry.types.group import PriorityLevel
 from sentry.workflow_engine.models import Action
-from sentry.workflow_engine.types import WorkflowEventData
+from sentry.workflow_engine.types import DetectorPriorityLevel, WorkflowEventData
 from tests.sentry.notifications.notification_action.test_metric_alert_registry_handlers import (
     MetricAlertHandlerBase,
 )
@@ -45,14 +44,17 @@ class TestDiscordMetricAlertHandler(MetricAlertHandlerBase):
     def test_send_alert(self, mock_send_incident_alert_notification: mock.MagicMock) -> None:
         notification_context = NotificationContext.from_action_model(self.action)
         assert self.group_event.occurrence is not None
+        assert self.group_event.occurrence.priority is not None
         alert_context = AlertContext.from_workflow_engine_models(
             self.detector,
             self.evidence_data,
             self.group_event.group.status,
-            self.group_event.occurrence.priority,
+            DetectorPriorityLevel(self.group_event.occurrence.priority),
         )
         metric_issue_context = MetricIssueContext.from_group_event(
-            self.group, self.evidence_data, self.group_event.occurrence.priority
+            self.group,
+            self.evidence_data,
+            DetectorPriorityLevel(self.group_event.occurrence.priority),
         )
         open_period_context = OpenPeriodContext.from_group(self.group)
         notification_uuid = str(uuid.uuid4())
@@ -143,7 +145,6 @@ class TestDiscordMetricAlertHandler(MetricAlertHandlerBase):
     def test_invoke_legacy_registry_with_activity(self, mock_send_alert: mock.MagicMock) -> None:
         # Create an Activity instance with evidence data and priority
         activity_data = asdict(self.evidence_data)
-        activity_data["priority"] = PriorityLevel.HIGH.value  # Add priority to data
 
         activity = Activity(
             project=self.project,
@@ -186,17 +187,17 @@ class TestDiscordMetricAlertHandler(MetricAlertHandlerBase):
             alert_context,
             name=self.detector.name,
             action_identifier_id=self.detector.id,
-            threshold_type=AlertRuleThresholdType.ABOVE,
+            threshold_type=AlertRuleThresholdType.BELOW,
             detection_type=AlertRuleDetectionType.STATIC,
             comparison_delta=None,
-            alert_threshold=self.evidence_data.conditions[0]["comparison"],
+            alert_threshold=self.evidence_data.conditions[2]["comparison"],
         )
 
         self.assert_metric_issue_context(
             metric_issue_context,
             open_period_identifier=self.open_period.id,
             snuba_query=self.snuba_query,
-            new_status=IncidentStatus.CRITICAL,
+            new_status=IncidentStatus.CLOSED,
             metric_value=123.45,
             group=self.group,
             title=self.group.title,

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_discord_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_discord_metric_alert_handler.py
@@ -10,7 +10,7 @@ from sentry.incidents.typings.metric_detector import (
     NotificationContext,
     OpenPeriodContext,
 )
-from sentry.models.activity import Activity
+from sentry.models.activity import Activity, ActivityType
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.notifications.notification_action.metric_alert_registry import DiscordMetricAlertHandler
 from sentry.notifications.notification_action.metric_alert_registry.handlers.utils import (
@@ -149,7 +149,7 @@ class TestDiscordMetricAlertHandler(MetricAlertHandlerBase):
         activity = Activity(
             project=self.project,
             group=self.group,
-            type=1,  # ActivityType value
+            type=ActivityType.SET_RESOLVED.value,
             data=activity_data,
         )
         activity.save()

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_email_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_email_metric_alert_handler.py
@@ -18,9 +18,8 @@ from sentry.notifications.notification_action.metric_alert_registry.handlers.uti
     get_detailed_incident_serializer,
 )
 from sentry.testutils.helpers.datetime import freeze_time
-from sentry.types.group import PriorityLevel
 from sentry.workflow_engine.models import Action
-from sentry.workflow_engine.types import WorkflowEventData
+from sentry.workflow_engine.types import DetectorPriorityLevel, WorkflowEventData
 from tests.sentry.notifications.notification_action.test_metric_alert_registry_handlers import (
     MetricAlertHandlerBase,
 )
@@ -47,14 +46,17 @@ class TestEmailMetricAlertHandler(MetricAlertHandlerBase):
     def test_send_alert(self, mock_email_users: mock.MagicMock) -> None:
         notification_context = NotificationContext.from_action_model(self.action)
         assert self.group_event.occurrence is not None
+        assert self.group_event.occurrence.priority is not None
         alert_context = AlertContext.from_workflow_engine_models(
             self.detector,
             self.evidence_data,
             self.group_event.group.status,
-            self.group_event.occurrence.priority,
+            DetectorPriorityLevel(self.group_event.occurrence.priority),
         )
         metric_issue_context = MetricIssueContext.from_group_event(
-            self.group, self.evidence_data, self.group_event.occurrence.priority
+            self.group,
+            self.evidence_data,
+            DetectorPriorityLevel(self.group_event.occurrence.priority),
         )
         open_period_context = OpenPeriodContext.from_group(self.group)
         notification_uuid = str(uuid.uuid4())
@@ -147,7 +149,6 @@ class TestEmailMetricAlertHandler(MetricAlertHandlerBase):
     def test_invoke_legacy_registry_with_activity(self, mock_send_alert: mock.MagicMock) -> None:
         # Create an Activity instance with evidence data and priority
         activity_data = asdict(self.evidence_data)
-        activity_data["priority"] = PriorityLevel.HIGH.value  # Add priority to data
 
         activity = Activity(
             project=self.project,
@@ -191,17 +192,17 @@ class TestEmailMetricAlertHandler(MetricAlertHandlerBase):
             alert_context,
             name=self.detector.name,
             action_identifier_id=self.detector.id,
-            threshold_type=AlertRuleThresholdType.ABOVE,
+            threshold_type=AlertRuleThresholdType.BELOW,
             detection_type=AlertRuleDetectionType.STATIC,
             comparison_delta=None,
-            alert_threshold=self.evidence_data.conditions[0]["comparison"],
+            alert_threshold=self.evidence_data.conditions[2]["comparison"],
         )
 
         self.assert_metric_issue_context(
             metric_issue_context,
             open_period_identifier=self.open_period.id,
             snuba_query=self.snuba_query,
-            new_status=IncidentStatus.CRITICAL,
+            new_status=IncidentStatus.CLOSED,
             metric_value=123.45,
             group=self.group,
             title=self.group.title,

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_email_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_email_metric_alert_handler.py
@@ -10,7 +10,7 @@ from sentry.incidents.typings.metric_detector import (
     NotificationContext,
     OpenPeriodContext,
 )
-from sentry.models.activity import Activity, ActivityType
+from sentry.models.activity import Activity
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.notifications.notification_action.metric_alert_registry import EmailMetricAlertHandler
 from sentry.notifications.notification_action.metric_alert_registry.handlers.utils import (
@@ -18,6 +18,7 @@ from sentry.notifications.notification_action.metric_alert_registry.handlers.uti
     get_detailed_incident_serializer,
 )
 from sentry.testutils.helpers.datetime import freeze_time
+from sentry.types.activity import ActivityType
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.types import DetectorPriorityLevel, WorkflowEventData
 from tests.sentry.notifications.notification_action.test_metric_alert_registry_handlers import (

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_email_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_email_metric_alert_handler.py
@@ -10,7 +10,7 @@ from sentry.incidents.typings.metric_detector import (
     NotificationContext,
     OpenPeriodContext,
 )
-from sentry.models.activity import Activity
+from sentry.models.activity import Activity, ActivityType
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.notifications.notification_action.metric_alert_registry import EmailMetricAlertHandler
 from sentry.notifications.notification_action.metric_alert_registry.handlers.utils import (
@@ -153,7 +153,7 @@ class TestEmailMetricAlertHandler(MetricAlertHandlerBase):
         activity = Activity(
             project=self.project,
             group=self.group,
-            type=1,  # ActivityType value
+            type=ActivityType.SET_RESOLVED.value,
             data=activity_data,
         )
         activity.save()

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_email_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_email_metric_alert_handler.py
@@ -1,4 +1,5 @@
 import uuid
+from dataclasses import asdict
 from unittest import mock
 
 from sentry.incidents.models.alert_rule import AlertRuleDetectionType, AlertRuleThresholdType
@@ -9,6 +10,7 @@ from sentry.incidents.typings.metric_detector import (
     NotificationContext,
     OpenPeriodContext,
 )
+from sentry.models.activity import Activity
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.notifications.notification_action.metric_alert_registry import EmailMetricAlertHandler
 from sentry.notifications.notification_action.metric_alert_registry.handlers.utils import (
@@ -16,7 +18,9 @@ from sentry.notifications.notification_action.metric_alert_registry.handlers.uti
     get_detailed_incident_serializer,
 )
 from sentry.testutils.helpers.datetime import freeze_time
+from sentry.types.group import PriorityLevel
 from sentry.workflow_engine.models import Action
+from sentry.workflow_engine.types import WorkflowEventData
 from tests.sentry.notifications.notification_action.test_metric_alert_registry_handlers import (
     MetricAlertHandlerBase,
 )
@@ -130,6 +134,84 @@ class TestEmailMetricAlertHandler(MetricAlertHandlerBase):
             open_period_context,
             id=self.open_period.id,
             date_started=self.group_event.group.first_seen,
+            date_closed=None,
+        )
+
+        assert organization == self.detector.project.organization
+        assert isinstance(notification_uuid, str)
+
+    @mock.patch(
+        "sentry.notifications.notification_action.metric_alert_registry.EmailMetricAlertHandler.send_alert"
+    )
+    @freeze_time("2021-01-01 00:00:00")
+    def test_invoke_legacy_registry_with_activity(self, mock_send_alert: mock.MagicMock) -> None:
+        # Create an Activity instance with evidence data and priority
+        activity_data = asdict(self.evidence_data)
+        activity_data["priority"] = PriorityLevel.HIGH.value  # Add priority to data
+
+        activity = Activity(
+            project=self.project,
+            group=self.group,
+            type=1,  # ActivityType value
+            data=activity_data,
+        )
+        activity.save()
+
+        # Create event data with Activity instead of GroupEvent
+        event_data_with_activity = WorkflowEventData(
+            event=activity,
+            workflow_env=self.workflow.environment,
+            group=self.group,
+        )
+
+        self.handler.invoke_legacy_registry(event_data_with_activity, self.action, self.detector)
+
+        assert mock_send_alert.call_count == 1
+        (
+            notification_context,
+            alert_context,
+            metric_issue_context,
+            open_period_context,
+            organization,
+            notification_uuid,
+        ) = self.unpack_kwargs(mock_send_alert)
+
+        # Verify that the same data is extracted from Activity.data as from GroupEvent.occurrence.evidence_data
+        self.assert_notification_context(
+            notification_context,
+            integration_id=None,
+            target_identifier=str(self.user.id),
+            target_display=None,
+            target_type=ActionTarget.USER,
+            sentry_app_config=None,
+            sentry_app_id=None,
+        )
+
+        self.assert_alert_context(
+            alert_context,
+            name=self.detector.name,
+            action_identifier_id=self.detector.id,
+            threshold_type=AlertRuleThresholdType.ABOVE,
+            detection_type=AlertRuleDetectionType.STATIC,
+            comparison_delta=None,
+            alert_threshold=self.evidence_data.conditions[0]["comparison"],
+        )
+
+        self.assert_metric_issue_context(
+            metric_issue_context,
+            open_period_identifier=self.open_period.id,
+            snuba_query=self.snuba_query,
+            new_status=IncidentStatus.CRITICAL,
+            metric_value=123.45,
+            group=self.group,
+            title=self.group.title,
+            subscription=self.subscription,
+        )
+
+        self.assert_open_period_context(
+            open_period_context,
+            id=self.open_period.id,
+            date_started=self.group.first_seen,
             date_closed=None,
         )
 

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_msteams_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_msteams_metric_alert_handler.py
@@ -10,7 +10,7 @@ from sentry.incidents.typings.metric_detector import (
     NotificationContext,
     OpenPeriodContext,
 )
-from sentry.models.activity import Activity
+from sentry.models.activity import Activity, ActivityType
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.notifications.notification_action.metric_alert_registry import MSTeamsMetricAlertHandler
 from sentry.notifications.notification_action.metric_alert_registry.handlers.utils import (
@@ -150,7 +150,7 @@ class TestMsteamsMetricAlertHandler(MetricAlertHandlerBase):
         activity = Activity(
             project=self.project,
             group=self.group,
-            type=1,  # ActivityType value
+            type=ActivityType.SET_RESOLVED.value,
             data=activity_data,
         )
         activity.save()

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_msteams_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_msteams_metric_alert_handler.py
@@ -18,9 +18,8 @@ from sentry.notifications.notification_action.metric_alert_registry.handlers.uti
     get_detailed_incident_serializer,
 )
 from sentry.testutils.helpers.datetime import freeze_time
-from sentry.types.group import PriorityLevel
 from sentry.workflow_engine.models import Action
-from sentry.workflow_engine.types import WorkflowEventData
+from sentry.workflow_engine.types import DetectorPriorityLevel, WorkflowEventData
 from tests.sentry.notifications.notification_action.test_metric_alert_registry_handlers import (
     MetricAlertHandlerBase,
 )
@@ -46,14 +45,17 @@ class TestMsteamsMetricAlertHandler(MetricAlertHandlerBase):
     def test_send_alert(self, mock_send_incident_alert_notification: mock.MagicMock) -> None:
         notification_context = NotificationContext.from_action_model(self.action)
         assert self.group_event.occurrence is not None
+        assert self.group_event.occurrence.priority is not None
         alert_context = AlertContext.from_workflow_engine_models(
             self.detector,
             self.evidence_data,
             self.group_event.group.status,
-            self.group_event.occurrence.priority,
+            DetectorPriorityLevel(self.group_event.occurrence.priority),
         )
         metric_issue_context = MetricIssueContext.from_group_event(
-            self.group, self.evidence_data, self.group_event.occurrence.priority
+            self.group,
+            self.evidence_data,
+            DetectorPriorityLevel(self.group_event.occurrence.priority),
         )
         open_period_context = OpenPeriodContext.from_group(self.group)
         notification_uuid = str(uuid.uuid4())
@@ -144,7 +146,6 @@ class TestMsteamsMetricAlertHandler(MetricAlertHandlerBase):
     def test_invoke_legacy_registry_with_activity(self, mock_send_alert: mock.MagicMock) -> None:
         # Create an Activity instance with evidence data and priority
         activity_data = asdict(self.evidence_data)
-        activity_data["priority"] = PriorityLevel.HIGH.value  # Add priority to data
 
         activity = Activity(
             project=self.project,
@@ -187,17 +188,17 @@ class TestMsteamsMetricAlertHandler(MetricAlertHandlerBase):
             alert_context,
             name=self.detector.name,
             action_identifier_id=self.detector.id,
-            threshold_type=AlertRuleThresholdType.ABOVE,
+            threshold_type=AlertRuleThresholdType.BELOW,
             detection_type=AlertRuleDetectionType.STATIC,
             comparison_delta=None,
-            alert_threshold=self.evidence_data.conditions[0]["comparison"],
+            alert_threshold=self.evidence_data.conditions[2]["comparison"],
         )
 
         self.assert_metric_issue_context(
             metric_issue_context,
             open_period_identifier=self.open_period.id,
             snuba_query=self.snuba_query,
-            new_status=IncidentStatus.CRITICAL,
+            new_status=IncidentStatus.CLOSED,
             metric_value=123.45,
             group=self.group,
             title=self.group.title,

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_msteams_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_msteams_metric_alert_handler.py
@@ -10,7 +10,7 @@ from sentry.incidents.typings.metric_detector import (
     NotificationContext,
     OpenPeriodContext,
 )
-from sentry.models.activity import Activity, ActivityType
+from sentry.models.activity import Activity
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.notifications.notification_action.metric_alert_registry import MSTeamsMetricAlertHandler
 from sentry.notifications.notification_action.metric_alert_registry.handlers.utils import (
@@ -18,6 +18,7 @@ from sentry.notifications.notification_action.metric_alert_registry.handlers.uti
     get_detailed_incident_serializer,
 )
 from sentry.testutils.helpers.datetime import freeze_time
+from sentry.types.activity import ActivityType
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.types import DetectorPriorityLevel, WorkflowEventData
 from tests.sentry.notifications.notification_action.test_metric_alert_registry_handlers import (

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_opsgenie_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_opsgenie_metric_alert_handler.py
@@ -10,12 +10,13 @@ from sentry.incidents.typings.metric_detector import (
     NotificationContext,
     OpenPeriodContext,
 )
-from sentry.models.activity import Activity, ActivityType
+from sentry.models.activity import Activity
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.notifications.notification_action.metric_alert_registry import (
     OpsgenieMetricAlertHandler,
 )
 from sentry.testutils.helpers.features import with_feature
+from sentry.types.activity import ActivityType
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.types import DetectorPriorityLevel, WorkflowEventData
 from tests.sentry.notifications.notification_action.test_metric_alert_registry_handlers import (

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_opsgenie_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_opsgenie_metric_alert_handler.py
@@ -16,9 +16,8 @@ from sentry.notifications.notification_action.metric_alert_registry import (
     OpsgenieMetricAlertHandler,
 )
 from sentry.testutils.helpers.features import with_feature
-from sentry.types.group import PriorityLevel
 from sentry.workflow_engine.models import Action
-from sentry.workflow_engine.types import WorkflowEventData
+from sentry.workflow_engine.types import DetectorPriorityLevel, WorkflowEventData
 from tests.sentry.notifications.notification_action.test_metric_alert_registry_handlers import (
     MetricAlertHandlerBase,
 )
@@ -43,14 +42,17 @@ class TestOpsgenieMetricAlertHandler(MetricAlertHandlerBase):
     def test_send_alert(self, mock_send_incident_alert_notification: mock.MagicMock) -> None:
         notification_context = NotificationContext.from_action_model(self.action)
         assert self.group_event.occurrence is not None
+        assert self.group_event.occurrence.priority is not None
         alert_context = AlertContext.from_workflow_engine_models(
             self.detector,
             self.evidence_data,
             self.group_event.group.status,
-            self.group_event.occurrence.priority,
+            DetectorPriorityLevel(self.group_event.occurrence.priority),
         )
         metric_issue_context = MetricIssueContext.from_group_event(
-            self.group, self.evidence_data, self.group_event.occurrence.priority
+            self.group,
+            self.evidence_data,
+            DetectorPriorityLevel(self.group_event.occurrence.priority),
         )
         open_period_context = OpenPeriodContext.from_group(self.group)
         notification_uuid = str(uuid.uuid4())
@@ -139,7 +141,6 @@ class TestOpsgenieMetricAlertHandler(MetricAlertHandlerBase):
     def test_invoke_legacy_registry_with_activity(self, mock_send_alert: mock.MagicMock) -> None:
         # Create an Activity instance with evidence data and priority
         activity_data = asdict(self.evidence_data)
-        activity_data["priority"] = PriorityLevel.HIGH.value  # Add priority to data
 
         activity = Activity(
             project=self.project,
@@ -182,17 +183,17 @@ class TestOpsgenieMetricAlertHandler(MetricAlertHandlerBase):
             alert_context,
             name=self.detector.name,
             action_identifier_id=self.detector.id,
-            threshold_type=AlertRuleThresholdType.ABOVE,
+            threshold_type=AlertRuleThresholdType.BELOW,
             detection_type=AlertRuleDetectionType.STATIC,
             comparison_delta=None,
-            alert_threshold=self.evidence_data.conditions[0]["comparison"],
+            alert_threshold=self.evidence_data.conditions[2]["comparison"],
         )
 
         self.assert_metric_issue_context(
             metric_issue_context,
             open_period_identifier=self.open_period.id,
             snuba_query=self.snuba_query,
-            new_status=IncidentStatus.CRITICAL,
+            new_status=IncidentStatus.CLOSED,
             metric_value=123.45,
             group=self.group,
             title=self.group.title,

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_opsgenie_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_opsgenie_metric_alert_handler.py
@@ -10,7 +10,7 @@ from sentry.incidents.typings.metric_detector import (
     NotificationContext,
     OpenPeriodContext,
 )
-from sentry.models.activity import Activity
+from sentry.models.activity import Activity, ActivityType
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.notifications.notification_action.metric_alert_registry import (
     OpsgenieMetricAlertHandler,
@@ -145,7 +145,7 @@ class TestOpsgenieMetricAlertHandler(MetricAlertHandlerBase):
         activity = Activity(
             project=self.project,
             group=self.group,
-            type=1,  # ActivityType value
+            type=ActivityType.SET_RESOLVED.value,
             data=activity_data,
         )
         activity.save()

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_opsgenie_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_opsgenie_metric_alert_handler.py
@@ -1,4 +1,5 @@
 import uuid
+from dataclasses import asdict
 from unittest import mock
 
 from sentry.incidents.models.alert_rule import AlertRuleDetectionType, AlertRuleThresholdType
@@ -9,12 +10,15 @@ from sentry.incidents.typings.metric_detector import (
     NotificationContext,
     OpenPeriodContext,
 )
+from sentry.models.activity import Activity
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.notifications.notification_action.metric_alert_registry import (
     OpsgenieMetricAlertHandler,
 )
 from sentry.testutils.helpers.features import with_feature
+from sentry.types.group import PriorityLevel
 from sentry.workflow_engine.models import Action
+from sentry.workflow_engine.types import WorkflowEventData
 from tests.sentry.notifications.notification_action.test_metric_alert_registry_handlers import (
     MetricAlertHandlerBase,
 )
@@ -123,6 +127,82 @@ class TestOpsgenieMetricAlertHandler(MetricAlertHandlerBase):
             open_period_context,
             id=self.open_period.id,
             date_started=self.group_event.group.first_seen,
+            date_closed=None,
+        )
+
+        assert organization == self.detector.project.organization
+        assert isinstance(notification_uuid, str)
+
+    @mock.patch(
+        "sentry.notifications.notification_action.metric_alert_registry.OpsgenieMetricAlertHandler.send_alert"
+    )
+    def test_invoke_legacy_registry_with_activity(self, mock_send_alert: mock.MagicMock) -> None:
+        # Create an Activity instance with evidence data and priority
+        activity_data = asdict(self.evidence_data)
+        activity_data["priority"] = PriorityLevel.HIGH.value  # Add priority to data
+
+        activity = Activity(
+            project=self.project,
+            group=self.group,
+            type=1,  # ActivityType value
+            data=activity_data,
+        )
+        activity.save()
+
+        # Create event data with Activity instead of GroupEvent
+        event_data_with_activity = WorkflowEventData(
+            event=activity,
+            workflow_env=self.workflow.environment,
+            group=self.group,
+        )
+
+        self.handler.invoke_legacy_registry(event_data_with_activity, self.action, self.detector)
+
+        assert mock_send_alert.call_count == 1
+        (
+            notification_context,
+            alert_context,
+            metric_issue_context,
+            open_period_context,
+            organization,
+            notification_uuid,
+        ) = self.unpack_kwargs(mock_send_alert)
+
+        # Verify that the same data is extracted from Activity.data as from GroupEvent.occurrence.evidence_data
+        self.assert_notification_context(
+            notification_context,
+            integration_id=1234567890,
+            target_identifier="team123",
+            target_display=None,
+            sentry_app_config={"priority": "P1"},
+            sentry_app_id=None,
+        )
+
+        self.assert_alert_context(
+            alert_context,
+            name=self.detector.name,
+            action_identifier_id=self.detector.id,
+            threshold_type=AlertRuleThresholdType.ABOVE,
+            detection_type=AlertRuleDetectionType.STATIC,
+            comparison_delta=None,
+            alert_threshold=self.evidence_data.conditions[0]["comparison"],
+        )
+
+        self.assert_metric_issue_context(
+            metric_issue_context,
+            open_period_identifier=self.open_period.id,
+            snuba_query=self.snuba_query,
+            new_status=IncidentStatus.CRITICAL,
+            metric_value=123.45,
+            group=self.group,
+            title=self.group.title,
+            subscription=self.subscription,
+        )
+
+        self.assert_open_period_context(
+            open_period_context,
+            id=self.open_period.id,
+            date_started=self.group.first_seen,
             date_closed=None,
         )
 

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_pagerduty_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_pagerduty_metric_alert_handler.py
@@ -10,7 +10,7 @@ from sentry.incidents.typings.metric_detector import (
     NotificationContext,
     OpenPeriodContext,
 )
-from sentry.models.activity import Activity
+from sentry.models.activity import Activity, ActivityType
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.notifications.notification_action.metric_alert_registry import (
     PagerDutyMetricAlertHandler,
@@ -143,7 +143,7 @@ class TestPagerDutyMetricAlertHandler(MetricAlertHandlerBase):
         activity = Activity(
             project=self.project,
             group=self.group,
-            type=1,  # ActivityType value
+            type=ActivityType.SET_RESOLVED.value,
             data=activity_data,
         )
         activity.save()

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_pagerduty_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_pagerduty_metric_alert_handler.py
@@ -10,12 +10,13 @@ from sentry.incidents.typings.metric_detector import (
     NotificationContext,
     OpenPeriodContext,
 )
-from sentry.models.activity import Activity, ActivityType
+from sentry.models.activity import Activity
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.notifications.notification_action.metric_alert_registry import (
     PagerDutyMetricAlertHandler,
 )
 from sentry.testutils.helpers.features import with_feature
+from sentry.types.activity import ActivityType
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.types import DetectorPriorityLevel, WorkflowEventData
 from tests.sentry.notifications.notification_action.test_metric_alert_registry_handlers import (

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_pagerduty_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_pagerduty_metric_alert_handler.py
@@ -1,4 +1,5 @@
 import uuid
+from dataclasses import asdict
 from unittest import mock
 
 from sentry.incidents.models.alert_rule import AlertRuleDetectionType, AlertRuleThresholdType
@@ -9,12 +10,15 @@ from sentry.incidents.typings.metric_detector import (
     NotificationContext,
     OpenPeriodContext,
 )
+from sentry.models.activity import Activity
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.notifications.notification_action.metric_alert_registry import (
     PagerDutyMetricAlertHandler,
 )
 from sentry.testutils.helpers.features import with_feature
+from sentry.types.group import PriorityLevel
 from sentry.workflow_engine.models import Action
+from sentry.workflow_engine.types import WorkflowEventData
 from tests.sentry.notifications.notification_action.test_metric_alert_registry_handlers import (
     MetricAlertHandlerBase,
 )
@@ -121,6 +125,82 @@ class TestPagerDutyMetricAlertHandler(MetricAlertHandlerBase):
             open_period_context,
             id=self.open_period.id,
             date_started=self.group_event.group.first_seen,
+            date_closed=None,
+        )
+
+        assert organization == self.detector.project.organization
+        assert isinstance(notification_uuid, str)
+
+    @mock.patch(
+        "sentry.notifications.notification_action.metric_alert_registry.PagerDutyMetricAlertHandler.send_alert"
+    )
+    def test_invoke_legacy_registry_with_activity(self, mock_send_alert: mock.MagicMock) -> None:
+        # Create an Activity instance with evidence data and priority
+        activity_data = asdict(self.evidence_data)
+        activity_data["priority"] = PriorityLevel.HIGH.value  # Add priority to data
+
+        activity = Activity(
+            project=self.project,
+            group=self.group,
+            type=1,  # ActivityType value
+            data=activity_data,
+        )
+        activity.save()
+
+        # Create event data with Activity instead of GroupEvent
+        event_data_with_activity = WorkflowEventData(
+            event=activity,
+            workflow_env=self.workflow.environment,
+            group=self.group,
+        )
+
+        self.handler.invoke_legacy_registry(event_data_with_activity, self.action, self.detector)
+
+        assert mock_send_alert.call_count == 1
+        (
+            notification_context,
+            alert_context,
+            metric_issue_context,
+            open_period_context,
+            organization,
+            notification_uuid,
+        ) = self.unpack_kwargs(mock_send_alert)
+
+        # Verify that the same data is extracted from Activity.data as from GroupEvent.occurrence.evidence_data
+        self.assert_notification_context(
+            notification_context,
+            integration_id=1234567890,
+            target_identifier="service123",
+            target_display=None,
+            sentry_app_config={"priority": "default"},
+            sentry_app_id=None,
+        )
+
+        self.assert_alert_context(
+            alert_context,
+            name=self.detector.name,
+            action_identifier_id=self.detector.id,
+            threshold_type=AlertRuleThresholdType.ABOVE,
+            detection_type=AlertRuleDetectionType.STATIC,
+            comparison_delta=None,
+            alert_threshold=self.evidence_data.conditions[0]["comparison"],
+        )
+
+        self.assert_metric_issue_context(
+            metric_issue_context,
+            open_period_identifier=self.open_period.id,
+            snuba_query=self.snuba_query,
+            new_status=IncidentStatus.CRITICAL,
+            metric_value=123.45,
+            group=self.group,
+            title=self.group.title,
+            subscription=self.subscription,
+        )
+
+        self.assert_open_period_context(
+            open_period_context,
+            id=self.open_period.id,
+            date_started=self.group.first_seen,
             date_closed=None,
         )
 

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_sentry_app_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_sentry_app_metric_alert_handler.py
@@ -10,7 +10,7 @@ from sentry.incidents.typings.metric_detector import (
     NotificationContext,
     OpenPeriodContext,
 )
-from sentry.models.activity import Activity
+from sentry.models.activity import Activity, ActivityType
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.notifications.notification_action.metric_alert_registry.handlers.sentry_app_metric_alert_handler import (
     SentryAppMetricAlertHandler,
@@ -157,7 +157,7 @@ class TestSentryAppMetricAlertHandler(MetricAlertHandlerBase):
         activity = Activity(
             project=self.project,
             group=self.group,
-            type=1,  # ActivityType value
+            type=ActivityType.SET_RESOLVED.value,
             data=activity_data,
         )
         activity.save()

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_sentry_app_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_sentry_app_metric_alert_handler.py
@@ -19,9 +19,8 @@ from sentry.notifications.notification_action.metric_alert_registry.handlers.uti
     get_incident_serializer,
 )
 from sentry.testutils.helpers.datetime import freeze_time
-from sentry.types.group import PriorityLevel
 from sentry.workflow_engine.models import Action
-from sentry.workflow_engine.types import WorkflowEventData
+from sentry.workflow_engine.types import DetectorPriorityLevel, WorkflowEventData
 from sentry.workflow_engine.typings.notification_action import SentryAppIdentifier
 from tests.sentry.notifications.notification_action.test_metric_alert_registry_handlers import (
     MetricAlertHandlerBase,
@@ -56,14 +55,17 @@ class TestSentryAppMetricAlertHandler(MetricAlertHandlerBase):
     def test_send_alert(self, mock_send_incident_alert_notification: mock.MagicMock) -> None:
         notification_context = NotificationContext.from_action_model(self.action)
         assert self.group_event.occurrence is not None
+        assert self.group_event.occurrence.priority is not None
         alert_context = AlertContext.from_workflow_engine_models(
             self.detector,
             self.evidence_data,
             self.group_event.group.status,
-            self.group_event.occurrence.priority,
+            DetectorPriorityLevel(self.group_event.occurrence.priority),
         )
         metric_issue_context = MetricIssueContext.from_group_event(
-            self.group, self.evidence_data, self.group_event.occurrence.priority
+            self.group,
+            self.evidence_data,
+            DetectorPriorityLevel(self.group_event.occurrence.priority),
         )
         open_period_context = OpenPeriodContext.from_group(self.group)
         notification_uuid = str(uuid.uuid4())
@@ -151,7 +153,6 @@ class TestSentryAppMetricAlertHandler(MetricAlertHandlerBase):
     def test_invoke_legacy_registry_with_activity(self, mock_send_alert: mock.MagicMock) -> None:
         # Create an Activity instance with evidence data and priority
         activity_data = asdict(self.evidence_data)
-        activity_data["priority"] = PriorityLevel.HIGH.value  # Add priority to data
 
         activity = Activity(
             project=self.project,
@@ -194,17 +195,17 @@ class TestSentryAppMetricAlertHandler(MetricAlertHandlerBase):
             alert_context,
             name=self.detector.name,
             action_identifier_id=self.detector.id,
-            threshold_type=AlertRuleThresholdType.ABOVE,
+            threshold_type=AlertRuleThresholdType.BELOW,
             detection_type=AlertRuleDetectionType.STATIC,
             comparison_delta=None,
-            alert_threshold=self.evidence_data.conditions[0]["comparison"],
+            alert_threshold=self.evidence_data.conditions[2]["comparison"],
         )
 
         self.assert_metric_issue_context(
             metric_issue_context,
             open_period_identifier=self.open_period.id,
             snuba_query=self.snuba_query,
-            new_status=IncidentStatus.CRITICAL,
+            new_status=IncidentStatus.CLOSED,
             metric_value=123.45,
             group=self.group,
             title=self.group.title,

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_sentry_app_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_sentry_app_metric_alert_handler.py
@@ -1,4 +1,5 @@
 import uuid
+from dataclasses import asdict
 from unittest import mock
 
 from sentry.incidents.models.alert_rule import AlertRuleDetectionType, AlertRuleThresholdType
@@ -9,6 +10,7 @@ from sentry.incidents.typings.metric_detector import (
     NotificationContext,
     OpenPeriodContext,
 )
+from sentry.models.activity import Activity
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.notifications.notification_action.metric_alert_registry.handlers.sentry_app_metric_alert_handler import (
     SentryAppMetricAlertHandler,
@@ -17,7 +19,9 @@ from sentry.notifications.notification_action.metric_alert_registry.handlers.uti
     get_incident_serializer,
 )
 from sentry.testutils.helpers.datetime import freeze_time
+from sentry.types.group import PriorityLevel
 from sentry.workflow_engine.models import Action
+from sentry.workflow_engine.types import WorkflowEventData
 from sentry.workflow_engine.typings.notification_action import SentryAppIdentifier
 from tests.sentry.notifications.notification_action.test_metric_alert_registry_handlers import (
     MetricAlertHandlerBase,
@@ -134,6 +138,83 @@ class TestSentryAppMetricAlertHandler(MetricAlertHandlerBase):
             open_period_context,
             id=self.open_period.id,
             date_started=self.group_event.group.first_seen,
+            date_closed=None,
+        )
+
+        assert organization == self.detector.project.organization
+        assert isinstance(notification_uuid, str)
+
+    @mock.patch(
+        "sentry.notifications.notification_action.metric_alert_registry.handlers.sentry_app_metric_alert_handler.SentryAppMetricAlertHandler.send_alert"
+    )
+    @freeze_time("2021-01-01 00:00:00")
+    def test_invoke_legacy_registry_with_activity(self, mock_send_alert: mock.MagicMock) -> None:
+        # Create an Activity instance with evidence data and priority
+        activity_data = asdict(self.evidence_data)
+        activity_data["priority"] = PriorityLevel.HIGH.value  # Add priority to data
+
+        activity = Activity(
+            project=self.project,
+            group=self.group,
+            type=1,  # ActivityType value
+            data=activity_data,
+        )
+        activity.save()
+
+        # Create event data with Activity instead of GroupEvent
+        event_data_with_activity = WorkflowEventData(
+            event=activity,
+            workflow_env=self.workflow.environment,
+            group=self.group,
+        )
+
+        self.handler.invoke_legacy_registry(event_data_with_activity, self.action, self.detector)
+
+        assert mock_send_alert.call_count == 1
+        (
+            notification_context,
+            alert_context,
+            metric_issue_context,
+            open_period_context,
+            organization,
+            notification_uuid,
+        ) = self.unpack_kwargs(mock_send_alert)
+
+        # Verify that the same data is extracted from Activity.data as from GroupEvent.occurrence.evidence_data
+        self.assert_notification_context(
+            notification_context,
+            integration_id=None,
+            target_identifier=None,
+            target_display=None,
+            sentry_app_config=None,
+            sentry_app_id=str(self.sentry_app.id),
+        )
+
+        self.assert_alert_context(
+            alert_context,
+            name=self.detector.name,
+            action_identifier_id=self.detector.id,
+            threshold_type=AlertRuleThresholdType.ABOVE,
+            detection_type=AlertRuleDetectionType.STATIC,
+            comparison_delta=None,
+            alert_threshold=self.evidence_data.conditions[0]["comparison"],
+        )
+
+        self.assert_metric_issue_context(
+            metric_issue_context,
+            open_period_identifier=self.open_period.id,
+            snuba_query=self.snuba_query,
+            new_status=IncidentStatus.CRITICAL,
+            metric_value=123.45,
+            group=self.group,
+            title=self.group.title,
+            subscription=self.subscription,
+        )
+
+        self.assert_open_period_context(
+            open_period_context,
+            id=self.open_period.id,
+            date_started=self.group.first_seen,
             date_closed=None,
         )
 

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_sentry_app_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_sentry_app_metric_alert_handler.py
@@ -10,7 +10,7 @@ from sentry.incidents.typings.metric_detector import (
     NotificationContext,
     OpenPeriodContext,
 )
-from sentry.models.activity import Activity, ActivityType
+from sentry.models.activity import Activity
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.notifications.notification_action.metric_alert_registry.handlers.sentry_app_metric_alert_handler import (
     SentryAppMetricAlertHandler,
@@ -19,6 +19,7 @@ from sentry.notifications.notification_action.metric_alert_registry.handlers.uti
     get_incident_serializer,
 )
 from sentry.testutils.helpers.datetime import freeze_time
+from sentry.types.activity import ActivityType
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.types import DetectorPriorityLevel, WorkflowEventData
 from sentry.workflow_engine.typings.notification_action import SentryAppIdentifier

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_slack_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_slack_metric_alert_handler.py
@@ -10,7 +10,7 @@ from sentry.incidents.typings.metric_detector import (
     NotificationContext,
     OpenPeriodContext,
 )
-from sentry.models.activity import Activity
+from sentry.models.activity import Activity, ActivityType
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.notifications.notification_action.metric_alert_registry import SlackMetricAlertHandler
 from sentry.notifications.notification_action.metric_alert_registry.handlers.utils import (
@@ -152,7 +152,7 @@ class TestSlackMetricAlertHandler(MetricAlertHandlerBase):
         activity = Activity(
             project=self.project,
             group=self.group,
-            type=1,  # ActivityType value
+            type=ActivityType.SET_RESOLVED.value,
             data=activity_data,
         )
         activity.save()

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_slack_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_slack_metric_alert_handler.py
@@ -1,4 +1,5 @@
 import uuid
+from dataclasses import asdict
 from unittest import mock
 
 from sentry.incidents.models.alert_rule import AlertRuleDetectionType, AlertRuleThresholdType
@@ -9,6 +10,7 @@ from sentry.incidents.typings.metric_detector import (
     NotificationContext,
     OpenPeriodContext,
 )
+from sentry.models.activity import Activity
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.notifications.notification_action.metric_alert_registry import SlackMetricAlertHandler
 from sentry.notifications.notification_action.metric_alert_registry.handlers.utils import (
@@ -16,7 +18,9 @@ from sentry.notifications.notification_action.metric_alert_registry.handlers.uti
     get_detailed_incident_serializer,
 )
 from sentry.testutils.helpers.datetime import freeze_time
+from sentry.types.group import PriorityLevel
 from sentry.workflow_engine.models import Action
+from sentry.workflow_engine.types import WorkflowEventData
 from tests.sentry.notifications.notification_action.test_metric_alert_registry_handlers import (
     MetricAlertHandlerBase,
 )
@@ -129,6 +133,83 @@ class TestSlackMetricAlertHandler(MetricAlertHandlerBase):
             open_period_context,
             id=self.open_period.id,
             date_started=self.group_event.group.first_seen,
+            date_closed=None,
+        )
+
+        assert organization == self.detector.project.organization
+        assert isinstance(notification_uuid, str)
+
+    @mock.patch(
+        "sentry.notifications.notification_action.metric_alert_registry.SlackMetricAlertHandler.send_alert"
+    )
+    @freeze_time("2021-01-01 00:00:00")
+    def test_invoke_legacy_registry_with_activity(self, mock_send_alert: mock.MagicMock) -> None:
+        # Create an Activity instance with evidence data and priority
+        activity_data = asdict(self.evidence_data)
+        activity_data["priority"] = PriorityLevel.HIGH.value  # Add priority to data
+
+        activity = Activity(
+            project=self.project,
+            group=self.group,
+            type=1,  # ActivityType value
+            data=activity_data,
+        )
+        activity.save()
+
+        # Create event data with Activity instead of GroupEvent
+        event_data_with_activity = WorkflowEventData(
+            event=activity,
+            workflow_env=self.workflow.environment,
+            group=self.group,
+        )
+
+        self.handler.invoke_legacy_registry(event_data_with_activity, self.action, self.detector)
+
+        assert mock_send_alert.call_count == 1
+        (
+            notification_context,
+            alert_context,
+            metric_issue_context,
+            open_period_context,
+            organization,
+            notification_uuid,
+        ) = self.unpack_kwargs(mock_send_alert)
+
+        # Verify that the same data is extracted from Activity.data as from GroupEvent.occurrence.evidence_data
+        self.assert_notification_context(
+            notification_context,
+            integration_id=1234567890,
+            target_identifier="channel123",
+            target_display="Channel 123",
+            sentry_app_config=None,
+            sentry_app_id=None,
+        )
+
+        self.assert_alert_context(
+            alert_context,
+            name=self.detector.name,
+            action_identifier_id=self.detector.id,
+            threshold_type=AlertRuleThresholdType.ABOVE,
+            detection_type=AlertRuleDetectionType.STATIC,
+            comparison_delta=None,
+            alert_threshold=self.evidence_data.conditions[0]["comparison"],
+        )
+
+        self.assert_metric_issue_context(
+            metric_issue_context,
+            open_period_identifier=self.open_period.id,
+            snuba_query=self.snuba_query,
+            new_status=IncidentStatus.CRITICAL,
+            metric_value=123.45,
+            group=self.group,
+            title=self.group.title,
+            subscription=self.subscription,
+        )
+
+        self.assert_open_period_context(
+            open_period_context,
+            id=self.open_period.id,
+            date_started=self.group.first_seen,
             date_closed=None,
         )
 

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_slack_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_slack_metric_alert_handler.py
@@ -18,9 +18,8 @@ from sentry.notifications.notification_action.metric_alert_registry.handlers.uti
     get_detailed_incident_serializer,
 )
 from sentry.testutils.helpers.datetime import freeze_time
-from sentry.types.group import PriorityLevel
 from sentry.workflow_engine.models import Action
-from sentry.workflow_engine.types import WorkflowEventData
+from sentry.workflow_engine.types import DetectorPriorityLevel, WorkflowEventData
 from tests.sentry.notifications.notification_action.test_metric_alert_registry_handlers import (
     MetricAlertHandlerBase,
 )
@@ -48,14 +47,17 @@ class TestSlackMetricAlertHandler(MetricAlertHandlerBase):
     def test_send_alert(self, mock_send_incident_alert_notification: mock.MagicMock) -> None:
         notification_context = NotificationContext.from_action_model(self.action)
         assert self.group_event.occurrence is not None
+        assert self.group_event.occurrence.priority is not None
         alert_context = AlertContext.from_workflow_engine_models(
             self.detector,
             self.evidence_data,
             self.group_event.group.status,
-            self.group_event.occurrence.priority,
+            DetectorPriorityLevel(self.group_event.occurrence.priority),
         )
         metric_issue_context = MetricIssueContext.from_group_event(
-            self.group, self.evidence_data, self.group_event.occurrence.priority
+            self.group,
+            self.evidence_data,
+            DetectorPriorityLevel(self.group_event.occurrence.priority),
         )
         open_period_context = OpenPeriodContext.from_group(self.group)
         notification_uuid = str(uuid.uuid4())
@@ -146,7 +148,6 @@ class TestSlackMetricAlertHandler(MetricAlertHandlerBase):
     def test_invoke_legacy_registry_with_activity(self, mock_send_alert: mock.MagicMock) -> None:
         # Create an Activity instance with evidence data and priority
         activity_data = asdict(self.evidence_data)
-        activity_data["priority"] = PriorityLevel.HIGH.value  # Add priority to data
 
         activity = Activity(
             project=self.project,
@@ -189,17 +190,17 @@ class TestSlackMetricAlertHandler(MetricAlertHandlerBase):
             alert_context,
             name=self.detector.name,
             action_identifier_id=self.detector.id,
-            threshold_type=AlertRuleThresholdType.ABOVE,
+            threshold_type=AlertRuleThresholdType.BELOW,
             detection_type=AlertRuleDetectionType.STATIC,
             comparison_delta=None,
-            alert_threshold=self.evidence_data.conditions[0]["comparison"],
+            alert_threshold=self.evidence_data.conditions[2]["comparison"],
         )
 
         self.assert_metric_issue_context(
             metric_issue_context,
             open_period_identifier=self.open_period.id,
             snuba_query=self.snuba_query,
-            new_status=IncidentStatus.CRITICAL,
+            new_status=IncidentStatus.CLOSED,
             metric_value=123.45,
             group=self.group,
             title=self.group.title,

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_slack_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_slack_metric_alert_handler.py
@@ -10,7 +10,7 @@ from sentry.incidents.typings.metric_detector import (
     NotificationContext,
     OpenPeriodContext,
 )
-from sentry.models.activity import Activity, ActivityType
+from sentry.models.activity import Activity
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.notifications.notification_action.metric_alert_registry import SlackMetricAlertHandler
 from sentry.notifications.notification_action.metric_alert_registry.handlers.utils import (
@@ -18,6 +18,7 @@ from sentry.notifications.notification_action.metric_alert_registry.handlers.uti
     get_detailed_incident_serializer,
 )
 from sentry.testutils.helpers.datetime import freeze_time
+from sentry.types.activity import ActivityType
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.types import DetectorPriorityLevel, WorkflowEventData
 from tests.sentry.notifications.notification_action.test_metric_alert_registry_handlers import (

--- a/tests/sentry/notifications/notification_action/test_metric_alert_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_metric_alert_registry_handlers.py
@@ -25,7 +25,7 @@ from sentry.incidents.typings.metric_detector import (
 )
 from sentry.incidents.utils.constants import INCIDENTS_SNUBA_SUBSCRIPTION_TYPE
 from sentry.issues.issue_occurrence import IssueOccurrence
-from sentry.models.activity import Activity, ActivityType
+from sentry.models.activity import Activity
 from sentry.models.group import Group, GroupStatus
 from sentry.models.groupopenperiod import GroupOpenPeriod
 from sentry.models.organization import Organization
@@ -42,6 +42,7 @@ from sentry.snuba.models import QuerySubscription, SnubaQuery, SnubaQueryEventTy
 from sentry.snuba.subscriptions import create_snuba_query, create_snuba_subscription
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.skips import requires_snuba
+from sentry.types.activity import ActivityType
 from sentry.types.group import PriorityLevel
 from sentry.workflow_engine.models import Action, Condition
 from sentry.workflow_engine.types import DetectorPriorityLevel, WorkflowEventData

--- a/tests/sentry/notifications/notification_action/test_metric_alert_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_metric_alert_registry_handlers.py
@@ -232,10 +232,10 @@ class MetricAlertHandlerBase(BaseWorkflowTest):
         alert_context: AlertContext,
         name: str,
         action_identifier_id: int,
-        threshold_type: AlertRuleThresholdType | None = None,
+        threshold_type: AlertRuleThresholdType | AnomalyDetectionThresholdType | None = None,
         detection_type: AlertRuleDetectionType | None = None,
         comparison_delta: int | None = None,
-        sensitivity: AlertRuleSensitivity | None = None,
+        sensitivity: AlertRuleSensitivity | AnomalyDetectionSensitivity | None = None,
         resolve_threshold: float | None = None,
         alert_threshold: float | None = None,
     ):

--- a/tests/sentry/notifications/notification_action/test_metric_alert_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_metric_alert_registry_handlers.py
@@ -25,7 +25,7 @@ from sentry.incidents.typings.metric_detector import (
 )
 from sentry.incidents.utils.constants import INCIDENTS_SNUBA_SUBSCRIPTION_TYPE
 from sentry.issues.issue_occurrence import IssueOccurrence
-from sentry.models.activity import Activity
+from sentry.models.activity import Activity, ActivityType
 from sentry.models.group import Group, GroupStatus
 from sentry.models.groupopenperiod import GroupOpenPeriod
 from sentry.models.organization import Organization
@@ -507,7 +507,7 @@ class TestBaseMetricAlertHandler(MetricAlertHandlerBase):
         activity = Activity(
             project=self.project,
             group=self.group,
-            type=1,  # ActivityType value
+            type=ActivityType.SET_RESOLVED.value,
             data=activity_data,
         )
         activity.save()
@@ -574,7 +574,7 @@ class TestBaseMetricAlertHandler(MetricAlertHandlerBase):
         activity = Activity(
             project=self.project,
             group=self.group,
-            type=1,  # ActivityType value
+            type=ActivityType.SET_RESOLVED.value,
             data=activity_data,
         )
         activity.save()


### PR DESCRIPTION
this pr adds the the ability for metric issue resolutions to trigger actions via the legacy metric alert registry.


- Convert `PriorityLevel` to `DetectorPriorityLevel` at the beginning of the translation logic, eliminating mid-stream conversions and simplifying the dataclass conversion.
- Updated type signatures throughout the codebase to use `DetectorPriorityLevel` instead of raw integer priority levels
- Added `convert_priority_to_detector_priority_level()` utility function for consistent priority conversion
- Added proper handling for `AnomalyDetectionThresholdType` alongside existing `AlertRuleThresholdType` in threshold comparisons and status text generation.
- Extended metric alert handlers to process both GroupEvent and Activity events, enabling resolution notifications to work properly.
- Implemented logic to map priority level 0 (OK) to IncidentStatus.CLOSED for resolved incidents.
- Enhanced threshold type checks to support both alert rule and anomaly detection threshold types
- Refactored condition matching logic for anomaly detection to handle placeholder condition results
