### PR TITLE
fix(tasks) Capture errors on unregistered tasks

### DIFF
--- a/src/sentry/taskworker/workerchild.py
+++ b/src/sentry/taskworker/workerchild.py
@@ -205,7 +205,17 @@ def child_process(
                         "taskname": inflight.activation.taskname,
                         "processing_pool": processing_pool_name,
                     },
+                    sample_rate=1.0,
                 )
+                with sentry_sdk.isolation_scope() as scope:
+                    scope.set_tag("taskname", inflight.activation.taskname)
+                    scope.set_tag("namespace", inflight.activation.namespace)
+                    scope.set_tag("processing_pool", processing_pool_name)
+                    scope.set_extra("activation", str(inflight.activation))
+                    scope.capture_message(
+                        f"Unregistered task {inflight.activation.taskname} was not executed"
+                    )
+
                 processed_tasks.put(
                     ProcessingResult(
                         task_id=inflight.activation.id,


### PR DESCRIPTION
Metrics can get sampled away. Having an error will make mistakes more visible.
