### PR TITLE
chore(spans-migration): add transaction deprecation banners

### DIFF
--- a/static/app/views/alerts/rules/metric/details/body.tsx
+++ b/static/app/views/alerts/rules/metric/details/body.tsx
@@ -196,7 +196,7 @@ export default function MetricDetailsBody({
                 }
               >
                 {tctCode(
-                  'Transaction based alerts are going to be deprecated soon. Please use Span alerts instead. You can isolate transactions by using the [code:is_transaction:true] filter.'
+                  'The transaction dataset is being deprecated. Please use Span alerts instead. Spans are a superset of transactions, you can isolate transactions by using the [code:is_transaction:true] filter.'
                 )}
               </Alert>
             </Alert.Container>

--- a/static/app/views/alerts/rules/metric/details/body.tsx
+++ b/static/app/views/alerts/rules/metric/details/body.tsx
@@ -71,7 +71,9 @@ export default function MetricDetailsBody({
   const location = useLocation();
   const navigate = useNavigate();
   const [showTransactionsDeprecationAlert, setShowTransactionsDeprecationAlert] =
-    useState(true);
+    useState(
+      organization.features.includes('performance-transaction-deprecation-banner')
+    );
 
   const handleTimePeriodChange = (datetime: ChangeData) => {
     const {start, end, relative} = datetime;
@@ -146,9 +148,7 @@ export default function MetricDetailsBody({
     });
 
   const deprecateTransactionsAlertsWarning =
-    organization.features.includes('performance-transaction-deprecation-banner') &&
-    ruleType &&
-    DEPRECATED_TRANSACTION_ALERTS.includes(ruleType);
+    ruleType && DEPRECATED_TRANSACTION_ALERTS.includes(ruleType);
 
   return (
     <Fragment>

--- a/static/app/views/alerts/rules/metric/details/body.tsx
+++ b/static/app/views/alerts/rules/metric/details/body.tsx
@@ -1,9 +1,10 @@
-import {Fragment} from 'react';
+import {Fragment, useState} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import moment from 'moment-timezone';
 
 import {Alert} from 'sentry/components/core/alert';
+import {Button} from 'sentry/components/core/button';
 import {Link} from 'sentry/components/core/link';
 import {Tooltip} from 'sentry/components/core/tooltip';
 import * as Layout from 'sentry/components/layouts/thirds';
@@ -12,7 +13,8 @@ import PanelBody from 'sentry/components/panels/panelBody';
 import Placeholder from 'sentry/components/placeholder';
 import type {ChangeData} from 'sentry/components/timeRangeSelector';
 import {TimeRangeSelector} from 'sentry/components/timeRangeSelector';
-import {t, tct} from 'sentry/locale';
+import {IconClose} from 'sentry/icons';
+import {t, tct, tctCode} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {RuleActionsCategories} from 'sentry/types/alerts';
 import type {Project} from 'sentry/types/project';
@@ -36,6 +38,8 @@ import {getAlertRuleActionCategory} from 'sentry/views/alerts/rules/utils';
 import type {Anomaly, Incident} from 'sentry/views/alerts/types';
 import {AlertRuleStatus} from 'sentry/views/alerts/types';
 import {alertDetailsLink} from 'sentry/views/alerts/utils';
+import {DEPRECATED_TRANSACTION_ALERTS} from 'sentry/views/alerts/wizard/options';
+import {getAlertTypeFromAggregateDataset} from 'sentry/views/alerts/wizard/utils';
 
 import type {TimePeriodType} from './constants';
 import {SELECTOR_RELATIVE_PERIODS} from './constants';
@@ -66,6 +70,8 @@ export default function MetricDetailsBody({
   const organization = useOrganization();
   const location = useLocation();
   const navigate = useNavigate();
+  const [showTransactionsDeprecationAlert, setShowTransactionsDeprecationAlert] =
+    useState(true);
 
   const handleTimePeriodChange = (datetime: ChangeData) => {
     const {start, end, relative} = datetime;
@@ -130,6 +136,18 @@ export default function MetricDetailsBody({
 
   const formattedAggregate = aggregate;
 
+  const ruleType =
+    rule &&
+    getAlertTypeFromAggregateDataset({
+      aggregate: rule.aggregate,
+      dataset: rule.dataset,
+      eventTypes: rule.eventTypes,
+      organization,
+    });
+
+  const deprecateTransactionsAlertsWarning =
+    ruleType && DEPRECATED_TRANSACTION_ALERTS.includes(ruleType);
+
   return (
     <Fragment>
       {selectedIncident?.alertRule.status === AlertRuleStatus.SNAPSHOT && (
@@ -156,6 +174,28 @@ export default function MetricDetailsBody({
                         forEveryone: rule.snoozeForEveryone ? ' for everyone ' : ' ',
                       }
                     )}
+              </Alert>
+            </Alert.Container>
+          )}
+          {deprecateTransactionsAlertsWarning && showTransactionsDeprecationAlert && (
+            <Alert.Container>
+              <Alert
+                type="warning"
+                trailingItems={
+                  <StyledCloseButton
+                    icon={<IconClose size="sm" />}
+                    aria-label={t('Close')}
+                    onClick={() => {
+                      setShowTransactionsDeprecationAlert(false);
+                    }}
+                    size="zero"
+                    borderless
+                  />
+                }
+              >
+                {tctCode(
+                  'Transaction based alerts are going to be deprecated soon. Please use Span alerts instead. You can isolate transactions by using the [code:is_transaction:true] filter.'
+                )}
               </Alert>
             </Alert.Container>
           )}
@@ -296,4 +336,15 @@ const StyledSubHeader = styled('div')`
 
 const StyledTimeRangeSelector = styled(TimeRangeSelector)`
   margin-right: ${space(1)};
+`;
+
+const StyledCloseButton = styled(Button)`
+  background-color: transparent;
+  transition: opacity 0.1s linear;
+
+  &:hover,
+  &:focus {
+    background-color: transparent;
+    opacity: 1;
+  }
 `;

--- a/static/app/views/alerts/rules/metric/details/body.tsx
+++ b/static/app/views/alerts/rules/metric/details/body.tsx
@@ -146,7 +146,9 @@ export default function MetricDetailsBody({
     });
 
   const deprecateTransactionsAlertsWarning =
-    ruleType && DEPRECATED_TRANSACTION_ALERTS.includes(ruleType);
+    organization.features.includes('performance-transaction-deprecation-banner') &&
+    ruleType &&
+    DEPRECATED_TRANSACTION_ALERTS.includes(ruleType);
 
   return (
     <Fragment>

--- a/static/app/views/alerts/rules/metric/details/index.tsx
+++ b/static/app/views/alerts/rules/metric/details/index.tsx
@@ -1,5 +1,4 @@
 import {Component, Fragment} from 'react';
-import styled from '@emotion/styled';
 import type {Location} from 'history';
 import isEqual from 'lodash/isEqual';
 import pick from 'lodash/pick';
@@ -8,12 +7,10 @@ import moment from 'moment-timezone';
 import {fetchOrgMembers} from 'sentry/actionCreators/members';
 import type {Client, ResponseMeta} from 'sentry/api';
 import {Alert} from 'sentry/components/core/alert';
-import {Button} from 'sentry/components/core/button';
 import {DateTime} from 'sentry/components/dateTime';
 import * as Layout from 'sentry/components/layouts/thirds';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
-import {IconClose} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import type {Organization} from 'sentry/types/organization';
@@ -33,8 +30,6 @@ import {
   fetchIncident,
   fetchIncidentsForRule,
 } from 'sentry/views/alerts/utils/apiCalls';
-import {DEPRECATED_TRANSACTION_ALERTS} from 'sentry/views/alerts/wizard/options';
-import {getAlertTypeFromAggregateDataset} from 'sentry/views/alerts/wizard/utils';
 
 import MetricDetailsBody from './body';
 import type {TimePeriodType} from './constants';
@@ -57,12 +52,16 @@ interface State {
   selectedIncident: Incident | null;
   incidents?: Incident[];
   rule?: MetricRule;
-  showTransactionsDeprecationAlert?: boolean;
   warning?: string;
 }
 
 class MetricAlertDetails extends Component<Props, State> {
-  state: State = {isLoading: false, hasError: false, error: null, selectedIncident: null};
+  state: State = {
+    isLoading: false,
+    hasError: false,
+    error: null,
+    selectedIncident: null,
+  };
 
   componentDidMount() {
     const {api, organization} = this.props;
@@ -70,7 +69,6 @@ class MetricAlertDetails extends Component<Props, State> {
     fetchOrgMembers(api, organization.slug);
     this.fetchData();
     this.trackView();
-    this.setState({showTransactionsDeprecationAlert: true});
   }
 
   componentDidUpdate(prevProps: Props) {
@@ -261,14 +259,7 @@ class MetricAlertDetails extends Component<Props, State> {
   }
 
   render() {
-    const {
-      rule,
-      incidents,
-      hasError,
-      selectedIncident,
-      warning,
-      showTransactionsDeprecationAlert,
-    } = this.state;
+    const {rule, incidents, hasError, selectedIncident, warning} = this.state;
     const {organization, projects, loadingProjects} = this.props;
     const timePeriod = this.getTimePeriod(selectedIncident);
 
@@ -278,18 +269,6 @@ class MetricAlertDetails extends Component<Props, State> {
 
     const project = projects.find(({slug}) => slug === rule?.projects[0]);
     const isGlobalSelectionReady = project !== undefined && !loadingProjects;
-
-    const ruleType =
-      rule &&
-      getAlertTypeFromAggregateDataset({
-        aggregate: rule.aggregate,
-        dataset: rule.dataset,
-        eventTypes: rule.eventTypes,
-        organization,
-      });
-
-    const deprecateTransactionsAlertsWarning =
-      ruleType && DEPRECATED_TRANSACTION_ALERTS.includes(ruleType);
 
     return (
       <PageFiltersContainer
@@ -312,29 +291,6 @@ class MetricAlertDetails extends Component<Props, State> {
           project={project}
           onSnooze={this.onSnooze}
         />
-        {showTransactionsDeprecationAlert && deprecateTransactionsAlertsWarning && (
-          <Alert.Container>
-            <Alert
-              type="warning"
-              style={{marginBottom: 0}}
-              trailingItems={
-                <StyledCloseButton
-                  icon={<IconClose size="sm" />}
-                  aria-label={t('Close')}
-                  onClick={() => {
-                    this.setState({showTransactionsDeprecationAlert: false});
-                  }}
-                  size="zero"
-                  borderless
-                />
-              }
-            >
-              {t(
-                'Transaction based alerts are going to be deprecated soon. Please use Span alerts instead.'
-              )}
-            </Alert>
-          </Alert.Container>
-        )}
         <MetricDetailsBody
           rule={rule}
           project={project}
@@ -348,14 +304,3 @@ class MetricAlertDetails extends Component<Props, State> {
 }
 
 export default withApi(withProjects(MetricAlertDetails));
-
-const StyledCloseButton = styled(Button)`
-  background-color: transparent;
-  transition: opacity 0.1s linear;
-
-  &:hover,
-  &:focus {
-    background-color: transparent;
-    opacity: 1;
-  }
-`;

--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
@@ -551,8 +551,20 @@ class RuleConditionsForm extends PureComponent<Props, State> {
 
     const traceItemType = getTraceItemTypeForDatasetAndEventType(dataset, eventTypes);
 
+    const deprecateTransactionsAlertsWarning =
+      DEPRECATED_TRANSACTION_ALERTS.includes(alertType);
+
     return (
       <Fragment>
+        {deprecateTransactionsAlertsWarning && (
+          <Alert.Container>
+            <Alert type="warning">
+              {t(
+                'Transaction based alerts are going to be deprecated soon. Please use Span alerts instead.'
+              )}
+            </Alert>
+          </Alert.Container>
+        )}
         <ChartPanel>
           <StyledPanelBody>{this.props.thresholdChart}</StyledPanelBody>
         </ChartPanel>

--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
@@ -561,7 +561,7 @@ class RuleConditionsForm extends PureComponent<Props, State> {
           <Alert.Container>
             <Alert type="warning">
               {tctCode(
-                'Transaction based alerts are going to be deprecated soon. Please use Span alerts instead. You can isolate transactions by using the [code:is_transaction:true] filter.'
+                'The transaction dataset is being deprecated. Please use Span alerts instead. Spans are a superset of transactions, you can isolate transactions by using the [code:is_transaction:true] filter.'
               )}
             </Alert>
           </Alert.Container>

--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
@@ -552,6 +552,7 @@ class RuleConditionsForm extends PureComponent<Props, State> {
     const traceItemType = getTraceItemTypeForDatasetAndEventType(dataset, eventTypes);
 
     const deprecateTransactionsAlertsWarning =
+      organization.features.includes('performance-transaction-deprecation-banner') &&
       DEPRECATED_TRANSACTION_ALERTS.includes(alertType);
 
     return (

--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
@@ -33,7 +33,7 @@ import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
 import {SearchQueryBuilder} from 'sentry/components/searchQueryBuilder';
 import {InvalidReason} from 'sentry/components/searchSyntax/parser';
-import {t, tct} from 'sentry/locale';
+import {t, tct, tctCode} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {SelectValue} from 'sentry/types/core';
 import type {Tag, TagCollection} from 'sentry/types/group';
@@ -559,8 +559,8 @@ class RuleConditionsForm extends PureComponent<Props, State> {
         {deprecateTransactionsAlertsWarning && (
           <Alert.Container>
             <Alert type="warning">
-              {t(
-                'Transaction based alerts are going to be deprecated soon. Please use Span alerts instead.'
+              {tctCode(
+                'Transaction based alerts are going to be deprecated soon. Please use Span alerts instead. You can isolate transactions by using the [code:is_transaction:true] filter.'
               )}
             </Alert>
           </Alert.Container>

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.spec.tsx
@@ -589,7 +589,7 @@ describe('WidgetBuilderSlideout', () => {
 
     expect(
       await screen.findByText(
-        /You may have limited functionality due to the ongoing migration of transactions to spans/i
+        /Editing of transaction-based widgets is disabled, as we migrate to the span dataset/i
       )
     ).toBeInTheDocument();
 

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.spec.tsx
@@ -551,7 +551,10 @@ describe('WidgetBuilderSlideout', () => {
 
   it('should show deprecation alert when flag enabled', async () => {
     const organizationWithFeature = OrganizationFixture({
-      features: ['discover-saved-queries-deprecation'],
+      features: [
+        'discover-saved-queries-deprecation',
+        'performance-transaction-deprecation-banner',
+      ],
     });
     jest.mocked(useParams).mockReturnValue({widgetIndex: '1'});
     render(

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -235,10 +235,10 @@ function WidgetBuilderSlideout({
             >
               {disableTransactionWidget && isEditing
                 ? t(
-                    'You may have limited functionality due to the ongoing migration of transactions to spans. To expedite and re-enable edit functionality, switch to the spans dataset below.'
+                    'Editing of transaction-based alerts is disabled, as we migrate to the span dataset. To expedite and re-enable edit functionality, switch to the spans dataset below.'
                   )
                 : tctCode(
-                    'The transactions dataset is going to be deprecated soon. Please use the Spans dataset with the [code:is_transaction:true] filter instead.'
+                    'The transactions dataset is being deprecated. Please use the Spans dataset with the [code:is_transaction:true] filter instead.'
                   )}
             </Alert>
           </Section>

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -23,6 +23,7 @@ import {
   type DashboardFilters,
   DisplayType,
   type Widget,
+  WidgetType,
 } from 'sentry/views/dashboards/types';
 import {animationTransitionSettings} from 'sentry/views/dashboards/widgetBuilder/components/common/animationSettings';
 import WidgetBuilderDatasetSelector from 'sentry/views/dashboards/widgetBuilder/components/datasetSelector';
@@ -86,6 +87,9 @@ function WidgetBuilderSlideout({
   const isEditing = useIsEditingWidget();
   const source = useDashboardWidgetSource();
   const disableTransactionWidget = useDisableTransactionWidget();
+  const isTransactionsWidget = state.dataset === WidgetType.TRANSACTIONS;
+  const [showTransactionsDeprecationAlert, setShowTransactionsDeprecationAlert] =
+    useState(true);
   const validatedWidgetResponse = useValidateWidgetQuery(
     convertBuilderStateToWidget(state)
   );
@@ -211,12 +215,29 @@ function WidgetBuilderSlideout({
         </CloseButton>
       </SlideoutHeaderWrapper>
       <SlideoutBodyWrapper>
-        {disableTransactionWidget && isEditing && (
+        {isTransactionsWidget && showTransactionsDeprecationAlert && (
           <Section>
-            <Alert type="warning">
-              {t(
-                'You may have limited functionality due to the ongoing migration of transactions to spans. To expedite and re-enable edit functionality, switch to the spans dataset below.'
-              )}
+            <Alert
+              type="warning"
+              trailingItems={
+                <StyledCloseButton
+                  icon={<IconClose size="sm" />}
+                  aria-label={t('Close')}
+                  onClick={() => {
+                    setShowTransactionsDeprecationAlert(false);
+                  }}
+                  size="zero"
+                  borderless
+                />
+              }
+            >
+              {disableTransactionWidget && isEditing
+                ? t(
+                    'You may have limited functionality due to the ongoing migration of transactions to spans. To expedite and re-enable edit functionality, switch to the spans dataset below.'
+                  )
+                : t(
+                    'The transactions dataset is going to be deprecated soon. Please use the Spans dataset with the `is_transaction:true` filter instead.'
+                  )}
             </Alert>
           </Section>
         )}
@@ -389,4 +410,15 @@ const SlideoutBodyWrapper = styled('div')`
 
 const SectionWrapper = styled('div')`
   margin-bottom: 24px;
+`;
+
+const StyledCloseButton = styled(Button)`
+  background-color: transparent;
+  transition: opacity 0.1s linear;
+
+  &:hover,
+  &:focus {
+    background-color: transparent;
+    opacity: 1;
+  }
 `;

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -89,7 +89,9 @@ function WidgetBuilderSlideout({
   const disableTransactionWidget = useDisableTransactionWidget();
   const isTransactionsWidget = state.dataset === WidgetType.TRANSACTIONS;
   const [showTransactionsDeprecationAlert, setShowTransactionsDeprecationAlert] =
-    useState(true);
+    useState(
+      organization.features.includes('performance-transaction-deprecation-banner')
+    );
   const validatedWidgetResponse = useValidateWidgetQuery(
     convertBuilderStateToWidget(state)
   );

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -235,7 +235,7 @@ function WidgetBuilderSlideout({
             >
               {disableTransactionWidget && isEditing
                 ? t(
-                    'Editing of transaction-based alerts is disabled, as we migrate to the span dataset. To expedite and re-enable edit functionality, switch to the spans dataset below.'
+                    'Editing of transaction-based widgets is disabled, as we migrate to the span dataset. To expedite and re-enable edit functionality, switch to the spans dataset below.'
                   )
                 : tctCode(
                     'The transactions dataset is being deprecated. Please use the Spans dataset with the [code:is_transaction:true] filter instead.'

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -10,7 +10,7 @@ import {Button} from 'sentry/components/core/button';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import SlideOverPanel from 'sentry/components/slideOverPanel';
 import {IconClose} from 'sentry/icons';
-import {t} from 'sentry/locale';
+import {t, tctCode} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {WidgetBuilderVersion} from 'sentry/utils/analytics/dashboardsAnalyticsEvents';
@@ -235,8 +235,8 @@ function WidgetBuilderSlideout({
                 ? t(
                     'You may have limited functionality due to the ongoing migration of transactions to spans. To expedite and re-enable edit functionality, switch to the spans dataset below.'
                   )
-                : t(
-                    'The transactions dataset is going to be deprecated soon. Please use the Spans dataset with the `is_transaction:true` filter instead.'
+                : tctCode(
+                    'The transactions dataset is going to be deprecated soon. Please use the Spans dataset with the [code:is_transaction:true] filter instead.'
                   )}
             </Alert>
           </Section>

--- a/static/app/views/discover/results.tsx
+++ b/static/app/views/discover/results.tsx
@@ -13,7 +13,7 @@ import {Client} from 'sentry/api';
 import Confirm from 'sentry/components/confirm';
 import {Alert} from 'sentry/components/core/alert';
 import {Button} from 'sentry/components/core/button';
-import {ExternalLink} from 'sentry/components/core/link';
+import {ExternalLink, Link} from 'sentry/components/core/link';
 import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
@@ -721,7 +721,10 @@ export class Results extends Component<Props, State> {
             }
           >
             {tctCode(
-              'The transactions dataset is going to be deprecated soon. Please use Explore->Traces with the [code:is_transaction:true] filter instead.'
+              'The transactions dataset is being deprecated. Please use [traceLink:Explore / Traces] with the [code:is_transaction:true] filter instead.',
+              {
+                traceLink: <Link to="/explore/traces/?query=is_transaction:true" />,
+              }
             )}
           </Alert>
         </Alert.Container>

--- a/static/app/views/discover/results.tsx
+++ b/static/app/views/discover/results.tsx
@@ -29,7 +29,7 @@ import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilt
 import type {CursorHandler} from 'sentry/components/pagination';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {IconClose} from 'sentry/icons/iconClose';
-import {t, tct} from 'sentry/locale';
+import {t, tct, tctCode} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {PageFilters} from 'sentry/types/core';
 import {SavedSearchType} from 'sentry/types/group';
@@ -719,8 +719,8 @@ export class Results extends Component<Props, State> {
               />
             }
           >
-            {t(
-              'The transactions dataset is going to be deprecated soon. Please use Explore->Traces with the `is_transaction:true` filter instead.'
+            {tctCode(
+              'The transactions dataset is going to be deprecated soon. Please use Explore->Traces with the [code:is_transaction:true] filter instead.'
             )}
           </Alert>
         </Alert.Container>

--- a/static/app/views/discover/results.tsx
+++ b/static/app/views/discover/results.tsx
@@ -107,6 +107,7 @@ type State = {
   showForcedDatasetAlert?: boolean;
   showMetricsAlert?: boolean;
   showQueryIncompatibleWithDataset?: boolean;
+  showTransactionsDeprecationAlert?: boolean;
   showUnparameterizedBanner?: boolean;
   splitDecision?: SavedQueryDatasets;
 };
@@ -190,6 +191,7 @@ export class Results extends Component<Props, State> {
         query: {...location.query, [SHOW_UNPARAM_BANNER]: undefined},
       });
     }
+    this.setState({showTransactionsDeprecationAlert: true});
     loadOrganizationTags(this.tagsApi, organization.slug, selection);
     addRoutePerformanceContext(selection);
     this.checkEventView();
@@ -690,6 +692,43 @@ export class Results extends Component<Props, State> {
     return null;
   }
 
+  renderTransactionsDatasetDeprecationBanner() {
+    const {savedQueryDataset} = this.state;
+    const {location} = this.props;
+    const dataset = getDatasetFromLocationOrSavedQueryDataset(
+      location,
+      savedQueryDataset
+    );
+    if (
+      this.state.showTransactionsDeprecationAlert &&
+      dataset === DiscoverDatasets.TRANSACTIONS
+    ) {
+      return (
+        <Alert.Container>
+          <Alert
+            type="warning"
+            trailingItems={
+              <StyledCloseButton
+                icon={<IconClose size="sm" />}
+                aria-label={t('Close')}
+                onClick={() => {
+                  this.setState({showTransactionsDeprecationAlert: false});
+                }}
+                size="zero"
+                borderless
+              />
+            }
+          >
+            {t(
+              'The transactions dataset is going to be deprecated soon. Please use Explore->Traces with the `is_transaction:true` filter instead.'
+            )}
+          </Alert>
+        </Alert.Container>
+      );
+    }
+    return null;
+  }
+
   renderTips() {
     const {tips} = this.state;
     if (tips) {
@@ -802,6 +841,7 @@ export class Results extends Component<Props, State> {
                 {this.renderTips()}
                 {this.renderForcedDatasetBanner()}
                 {this.renderQueryIncompatibleWithDatasetBanner()}
+                {this.renderTransactionsDatasetDeprecationBanner()}
                 {!hasDatasetSelectorFeature && <SampleDataAlert query={query} />}
 
                 <Wrapper>

--- a/static/app/views/discover/results.tsx
+++ b/static/app/views/discover/results.tsx
@@ -173,6 +173,7 @@ export class Results extends Component<Props, State> {
     tips: [],
     showForcedDatasetAlert: true,
     showQueryIncompatibleWithDataset: false,
+    showTransactionsDeprecationAlert: true,
   };
 
   componentDidMount() {
@@ -191,7 +192,6 @@ export class Results extends Component<Props, State> {
         query: {...location.query, [SHOW_UNPARAM_BANNER]: undefined},
       });
     }
-    this.setState({showTransactionsDeprecationAlert: true});
     loadOrganizationTags(this.tagsApi, organization.slug, selection);
     addRoutePerformanceContext(selection);
     this.checkEventView();

--- a/static/app/views/discover/results.tsx
+++ b/static/app/views/discover/results.tsx
@@ -694,13 +694,14 @@ export class Results extends Component<Props, State> {
 
   renderTransactionsDatasetDeprecationBanner() {
     const {savedQueryDataset} = this.state;
-    const {location} = this.props;
+    const {location, organization} = this.props;
     const dataset = getDatasetFromLocationOrSavedQueryDataset(
       location,
       savedQueryDataset
     );
     if (
       this.state.showTransactionsDeprecationAlert &&
+      organization.features.includes('performance-transaction-deprecation-banner') &&
       dataset === DiscoverDatasets.TRANSACTIONS
     ) {
       return (


### PR DESCRIPTION
Adds a banner to widget builder, discover, alerts, and alert details, to inform users that the transactions dataset will be deprecated soon.

Note: the text copy has changed.

<img width="614" height="416" alt="Screenshot 2025-08-05 at 5 41 24 PM" src="https://github.com/user-attachments/assets/d4e84c30-5e54-40e3-a0e7-d3b7d68c41b6" />
<img width="1235" height="249" alt="Screenshot 2025-08-05 at 5 41 38 PM" src="https://github.com/user-attachments/assets/de277d29-08e8-4b36-93e6-ecfaf62d4b58" />
<img width="1248" height="312" alt="Screenshot 2025-08-05 at 5 41 54 PM" src="https://github.com/user-attachments/assets/fe243ea9-4bbe-4026-933e-2159b42fb438" />
<img width="1088" height="343" alt="Screenshot 2025-08-05 at 5 42 07 PM" src="https://github.com/user-attachments/assets/56771509-a2e8-4da0-a51c-679bfa75fd93" />
