### PR TITLE
fix(issues): Prevent logs section from crashing event details

### DIFF
--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -368,9 +368,11 @@ export function EventDetailsContent({
         </EntryErrorBoundary>
       )}
       <BreadcrumbsDataSection event={event} group={group} project={project} />
-      <Feature features="ourlogs-enabled" organization={organization}>
-        <OurlogsSection event={event} group={group} project={project} />
-      </Feature>
+      <ErrorBoundary mini message={t('There was a problem loading logs.')}>
+        <Feature features="ourlogs-enabled" organization={organization}>
+          <OurlogsSection event={event} group={group} project={project} />
+        </Feature>
+      </ErrorBoundary>
       {hasStreamlinedUI &&
         event.contexts.trace?.trace_id &&
         organization.features.includes('performance-view') && (


### PR DESCRIPTION
Logs can throw an error and it goes up to the next highest error boundary which is the entire event details page.

will now look like this

<img width="894" height="190" alt="image" src="https://github.com/user-attachments/assets/aad92881-418e-4492-be9e-7d49673ca334" />

seen in JAVASCRIPT-32NE
