### PR TITLE
ref(stories): adjust heading levels

### DIFF
--- a/static/app/components/core/alert/alertLink.mdx
+++ b/static/app/components/core/alert/alertLink.mdx
@@ -31,7 +31,7 @@ To create a basic alert link, wrap content in an `<AlertLink>` and provide navig
 <AlertLink to="/settings">Go to Settings</AlertLink>
 ```
 
-### Alert Types
+## Alert Types
 
 AlertLink supports all alert types: `info` (default), `success`, `warning`, `error`, and `muted`.
 
@@ -72,11 +72,11 @@ AlertLink supports all alert types: `info` (default), `success`, `warning`, `err
 </AlertLink>
 ```
 
-### Link Types
+## Link Types
 
 AlertLink supports three types of navigation: internal routing, external URLs, and custom click handlers.
 
-#### Internal Links
+### Internal Links
 
 Use the `to` prop for internal navigation within the application.
 
@@ -87,7 +87,7 @@ Use the `to` prop for internal navigation within the application.
 <AlertLink to="/settings">Go to Settings</AlertLink>
 ```
 
-#### External Links
+### External Links
 
 Use the `href` prop for external URLs. The `openInNewTab` prop controls whether the link opens in a new tab.
 
@@ -102,7 +102,7 @@ Use the `href` prop for external URLs. The `openInNewTab` prop controls whether 
 </AlertLink>
 ```
 
-#### Custom Click Handlers
+### Custom Click Handlers
 
 Use the `onClick` prop for custom actions that don't involve navigation.
 
@@ -118,7 +118,7 @@ Use the `onClick` prop for custom actions that don't involve navigation.
 </AlertLink>
 ```
 
-### Trailing Items
+## Trailing Items
 
 By default, AlertLink includes a right-pointing chevron icon. You can customize this with the `trailingItems` prop.
 
@@ -143,7 +143,7 @@ By default, AlertLink includes a right-pointing chevron icon. You can customize 
 </AlertLink>
 ```
 
-### Container
+## Container
 
 When displaying multiple AlertLinks, use `AlertLink.Container` to manage consistent spacing.
 
@@ -175,7 +175,7 @@ When displaying multiple AlertLinks, use `AlertLink.Container` to manage consist
 </AlertLink.Container>
 ```
 
-### Accessibility
+## Accessibility
 
 To meet WCAG 2.2 AA compliance, `<AlertLink>` automatically meets the [WCAG 2.1.1](https://www.w3.org/TR/WCAG22/#keyboard) and [WCAG 2.4.7](https://www.w3.org/TR/WCAG22/#focus-visible) success criteria.
 

--- a/static/app/components/core/alert/index.mdx
+++ b/static/app/components/core/alert/index.mdx
@@ -27,7 +27,7 @@ To create a basic alert, wrap your message in an `<Alert>` component and specify
 <Alert type="info">This is an informational message</Alert>
 ```
 
-### Types
+# Types
 
 Alerts come in five different types to convey different levels of importance and meaning: `muted`, `info`, `warning`, `success`, and `error`.
 
@@ -50,7 +50,7 @@ Alerts come in five different types to convey different levels of importance and
 </Alert.Container>
 ```
 
-### Icons
+# Icons
 
 By default, alerts display appropriate icons based on their type. You can hide icons by setting `showIcon={false}` or provide custom icons.
 
@@ -77,7 +77,7 @@ By default, alerts display appropriate icons based on their type. You can hide i
 </Alert.Container>
 ```
 
-### Expandable Content
+# Expandable Content
 
 Alerts can contain expandable content to provide additional details without overwhelming the initial view.
 
@@ -114,7 +114,7 @@ Alerts can contain expandable content to provide additional details without over
 </Alert>
 ```
 
-### Trailing Items
+# Trailing Items
 
 Add interactive elements like buttons or links to the right side of alerts using the `trailingItems` prop.
 
@@ -177,7 +177,7 @@ Add interactive elements like buttons or links to the right side of alerts using
 </Alert.Container>
 ```
 
-### System Alerts
+# System Alerts
 
 System alerts are full-width variants typically used for application-level notifications or banners.
 
@@ -192,7 +192,7 @@ System alerts are full-width variants typically used for application-level notif
 </Alert>
 ```
 
-### Expanded by Default
+# Expanded by Default
 
 You can control the initial expansion state of alerts with expandable content.
 
@@ -225,7 +225,7 @@ You can control the initial expansion state of alerts with expandable content.
 </Alert>
 ```
 
-### Container
+# Container
 
 Use `Alert.Container` to properly manage spacing between multiple alerts.
 
@@ -244,7 +244,7 @@ Use `Alert.Container` to properly manage spacing between multiple alerts.
 </Alert.Container>
 ```
 
-### Accessibility
+# Accessibility
 
 To meet WCAG 2.2 AA compliance, `<Alert>` automatically meets the [WCAG 1.4.3](https://www.w3.org/TR/WCAG22/#contrast-minimum), [WCAG 2.1.1](https://www.w3.org/TR/WCAG22/#keyboard), and [WCAG 2.4.7](https://www.w3.org/TR/WCAG22/#focus-visible) success criteria.
 

--- a/static/app/components/core/alert/index.mdx
+++ b/static/app/components/core/alert/index.mdx
@@ -27,7 +27,7 @@ To create a basic alert, wrap your message in an `<Alert>` component and specify
 <Alert type="info">This is an informational message</Alert>
 ```
 
-# Types
+## Types
 
 Alerts come in five different types to convey different levels of importance and meaning: `muted`, `info`, `warning`, `success`, and `error`.
 
@@ -50,7 +50,7 @@ Alerts come in five different types to convey different levels of importance and
 </Alert.Container>
 ```
 
-# Icons
+## Icons
 
 By default, alerts display appropriate icons based on their type. You can hide icons by setting `showIcon={false}` or provide custom icons.
 
@@ -77,7 +77,7 @@ By default, alerts display appropriate icons based on their type. You can hide i
 </Alert.Container>
 ```
 
-# Expandable Content
+## Expandable Content
 
 Alerts can contain expandable content to provide additional details without overwhelming the initial view.
 
@@ -114,7 +114,7 @@ Alerts can contain expandable content to provide additional details without over
 </Alert>
 ```
 
-# Trailing Items
+## Trailing Items
 
 Add interactive elements like buttons or links to the right side of alerts using the `trailingItems` prop.
 
@@ -177,7 +177,7 @@ Add interactive elements like buttons or links to the right side of alerts using
 </Alert.Container>
 ```
 
-# System Alerts
+## System Alerts
 
 System alerts are full-width variants typically used for application-level notifications or banners.
 
@@ -192,7 +192,7 @@ System alerts are full-width variants typically used for application-level notif
 </Alert>
 ```
 
-# Expanded by Default
+## Expanded by Default
 
 You can control the initial expansion state of alerts with expandable content.
 
@@ -225,7 +225,7 @@ You can control the initial expansion state of alerts with expandable content.
 </Alert>
 ```
 
-# Container
+## Container
 
 Use `Alert.Container` to properly manage spacing between multiple alerts.
 
@@ -244,7 +244,7 @@ Use `Alert.Container` to properly manage spacing between multiple alerts.
 </Alert.Container>
 ```
 
-# Accessibility
+## Accessibility
 
 To meet WCAG 2.2 AA compliance, `<Alert>` automatically meets the [WCAG 1.4.3](https://www.w3.org/TR/WCAG22/#contrast-minimum), [WCAG 2.1.1](https://www.w3.org/TR/WCAG22/#keyboard), and [WCAG 2.4.7](https://www.w3.org/TR/WCAG22/#focus-visible) success criteria.
 

--- a/static/app/components/core/button/index.mdx
+++ b/static/app/components/core/button/index.mdx
@@ -42,7 +42,7 @@ To create a basic button, wrap text in a `<Button>` and pass an `onClick` callba
 <Button onClick={() => alert('Hello world')}>Click here</Button>
 ```
 
-### Priorities
+## Priorities
 
 Buttons come in a few different styles: `muted` (default), `primary`, `warning`, `danger`, `transparent` and `link`.
 
@@ -65,7 +65,7 @@ Buttons come in a few different styles: `muted` (default), `primary`, `warning`,
 <Button priority="link">Link</Button>
 ```
 
-### Sizes
+## Sizes
 
 Buttons are available in different sizes: `md` (default), `sm`, `xs`, and `zero`.
 
@@ -82,7 +82,7 @@ Buttons are available in different sizes: `md` (default), `sm`, `xs`, and `zero`
 <Button size="zero">Zero</Button>
 ```
 
-### Icons
+## Icons
 
 Buttons support an optional leading icon.
 
@@ -128,7 +128,7 @@ We have standardized call to action copy and specific icon pairings. When creati
 | <IconZoom />                               | `zoom`      | Zoom Out                               | Applies to charts and zooms out (i.e. 200%)               |
 | <IconStar />                               | `star`      | Favorite                               | Hoisting item to primary view                             |
 
-### Icon-only Buttons
+## Icon-only Buttons
 
 In scenarios where high information density is critical, buttons may be displayed without text.
 
@@ -142,7 +142,7 @@ In scenarios where high information density is critical, buttons may be displaye
 <Button icon={<IconAdd />} aria-label="Add" />
 ```
 
-### Accessibility
+## Accessibility
 
 To meet WCAG 2.2 AA compliance, `<Button>` automatically meets the [WCAG 1.4.3](https://www.w3.org/TR/WCAG22/#contrast-minimum), [WCAG 2.1.1](https://www.w3.org/TR/WCAG22/#keyboard), [WCAG 2.4.7](https://www.w3.org/TR/WCAG22/#focus-visible), [WCAG 2.5.8](https://www.w3.org/TR/WCAG22/#target-size-minimum) success criteria.
 

--- a/static/app/components/core/layout/composition.mdx
+++ b/static/app/components/core/layout/composition.mdx
@@ -4,9 +4,9 @@ description: 'Learn how to compose layout components using render props and adva
 layout: document
 ---
 
-# Render Props
+## Render Props
 
-The layout components (`Container`, `Flex`, and `Grid`) support composition via render props - this allows you to apply layout styling to custom elements without creating extra DOM nodes.
+When using the `Container`, `Flex`, and `Grid` elements, use **render props** to apply layout styling to custom elements without creating extra DOM nodes.
 
 ```tsx
 // ✅ Apply layout props to a single element
@@ -82,7 +82,7 @@ You can apply layout props to custom elements by passing a render function to th
 There are multiple ways to apply layout styling to a custom element, each has their tradeoffs. We have picked the render prop pattern becaseu we believe that it is
 the most type-safe and flexible way of applying component props to the child element.
 
-#### Type Safety
+### Type Safety
 
 The render prop system prevents invalid attributes from being passed to HTML elements:
 
@@ -99,7 +99,7 @@ The render prop system prevents invalid attributes from being passed to HTML ele
 // The aria-activedescendant prop is filtered out since it's invalid for <p>
 ```
 
-#### Prop Merging and Prop Selection
+### Prop Merging and Prop Selection
 
 The render prop system allows you to select which props to pass to the child element at runtime, and pick only a subset of the props that you need.
 

--- a/static/app/components/core/layout/composition.mdx
+++ b/static/app/components/core/layout/composition.mdx
@@ -1,6 +1,6 @@
 ---
 title: Layout Composition
-description: 'Learn how to compose layout components using render props and advanced patterns.'
+description: Learn how to compose layout components using render props and advanced patterns.
 layout: document
 ---
 

--- a/static/app/components/core/text/heading.mdx
+++ b/static/app/components/core/text/heading.mdx
@@ -29,7 +29,7 @@ The `<Heading>` component creates semantic heading elements with appropriate def
 <Heading as="h3">Subsection Title</Heading>
 ```
 
-### Semantic Heading Levels
+## Semantic Heading Levels
 
 Use the required `as` prop to specify the semantic heading level. Each level has a default size that follows standard typography hierarchy.
 
@@ -52,7 +52,7 @@ Use the required `as` prop to specify the semantic heading level. Each level has
 <Heading as="h6">Heading 6</Heading>
 ```
 
-### Custom Sizes
+## Custom Sizes
 
 Override the default size with the `size` prop to decouple visual appearance from semantic meaning.
 
@@ -81,7 +81,7 @@ Override the default size with the `size` prop to decouple visual appearance fro
 </Heading>
 ```
 
-### Variants
+## Variants
 
 Headings support various color variants: `primary` (default), `muted`, `accent`, `success`, `warning`, `danger`, and `promotion`.
 
@@ -134,7 +134,7 @@ Headings support various color variants: `primary` (default), `muted`, `accent`,
 </Heading>
 ```
 
-### Typography Features
+## Typography Features
 
 Headings support various typography options including italic, underline, strikethrough, and uppercase.
 
@@ -175,7 +175,7 @@ Headings support various typography options including italic, underline, striket
 </Heading>
 ```
 
-### Text Alignment
+## Text Alignment
 
 Control text alignment with the `align` prop: `left` (default), `center`, `right`, or `justify`.
 
@@ -210,7 +210,7 @@ Control text alignment with the `align` prop: `left` (default), `center`, `right
 </Heading>
 ```
 
-### Ellipsis Overflow
+## Ellipsis Overflow
 
 Handle text overflow with the `ellipsis` prop to truncate long headings with an ellipsis.
 
@@ -229,7 +229,7 @@ Handle text overflow with the `ellipsis` prop to truncate long headings with an 
 </div>
 ```
 
-### Monospace
+## Monospace
 
 Use `monospace` for fixed-width headings, useful for code-related content.
 

--- a/static/app/components/core/text/text.mdx
+++ b/static/app/components/core/text/text.mdx
@@ -27,7 +27,7 @@ To create basic text, wrap content in a `<Text>` component. For semantic heading
 <Heading as="h1">This is a heading</Heading>
 ```
 
-### Sizes
+## Sizes
 
 Text components support different sizes: `xs`, `sm`, `md` (default), `lg`, `xl`, and `2xl`.
 
@@ -50,7 +50,7 @@ Text components support different sizes: `xs`, `sm`, `md` (default), `lg`, `xl`,
 <Text size="xs">Extra small text</Text>
 ```
 
-### Variants
+## Variants
 
 Text components support various color variants: `primary` (default), `muted`, `accent`, `success`, `warning`, `danger`, and `promotion`.
 
@@ -75,7 +75,7 @@ Text components support various color variants: `primary` (default), `muted`, `a
 <Text variant="promotion">Promotion text</Text>
 ```
 
-### Custom Elements with `as` Prop
+## Custom Elements with `as` Prop
 
 The `<Text>` component can be rendered as different HTML elements using the `as` prop. This allows you to maintain semantic meaning while applying the component's styling.
 
@@ -92,7 +92,7 @@ The `<Text>` component can be rendered as different HTML elements using the `as`
 <Text as="div">Text rendered as a div element</Text>
 ```
 
-### Typography Features
+## Typographic Features
 
 Text components support various typography options including bold, italic, underline, and strikethrough.
 
@@ -117,7 +117,7 @@ Text components support various typography options including bold, italic, under
 </Text>
 ```
 
-### Text Alignment
+## Text Alignment
 
 Control text alignment with the `align` prop: `left` (default), `center`, `right`, or `justify`.
 
@@ -148,7 +148,7 @@ Control text alignment with the `align` prop: `left` (default), `center`, `right
 </Text>
 ```
 
-### Density
+## Density
 
 Control line height with the `density` prop: `compressed` (1.0), default (1.2), or `comfortable` (1.4).
 
@@ -183,7 +183,7 @@ Control line height with the `density` prop: `compressed` (1.0), default (1.2), 
 <Text density="comfortable">Comfortable density text...</Text>
 ```
 
-### Ellipsis Overflow
+## Ellipsis Overflow
 
 Handle text overflow with the `ellipsis` prop to truncate long text with an ellipsis.
 
@@ -198,7 +198,7 @@ Handle text overflow with the `ellipsis` prop to truncate long text with an elli
 </div>
 ```
 
-### Monospace
+## Monospace
 
 Use `monospace` for fixed-width text.
 
@@ -223,7 +223,7 @@ Use `monospace` for fixed-width text.
 <Text monospace>1234567890</Text>
 ```
 
-### Font Features
+## Font Features
 
 Use `tabular` for consistent number alignment and `fraction` for diagonal fraction display.
 
@@ -260,6 +260,6 @@ Use `tabular` for consistent number alignment and `fraction` for diagonal fracti
 <Text fraction>1/2 3/4 5/8</Text>
 ```
 
-### Accessibility
+## Accessibility
 
 Text components automatically meet WCAG 2.2 AA compliance for color contrast and text spacing. When using semantic headings, ensure proper heading hierarchy for screen readers.

--- a/static/app/components/core/tooltip/index.mdx
+++ b/static/app/components/core/tooltip/index.mdx
@@ -33,7 +33,7 @@ To create a basic tooltip, wrap any element with `<Tooltip>` and provide the `ti
 </Tooltip>
 ```
 
-### Position
+## Position
 
 Tooltips can be positioned in different directions using the `position` prop. Available positions include `top`, `bottom`, `left`, and `right`.
 
@@ -70,7 +70,7 @@ Tooltips can be positioned in different directions using the `position` prop. Av
 </Tooltip>
 ```
 
-### Hoverable Tooltips
+## Hoverable Tooltips
 
 By default, tooltips hide when you move your cursor toward them. For interactive tooltips that contain clickable content, use the `isHoverable` prop to allow users to hover over the tooltip itself.
 
@@ -93,7 +93,7 @@ By default, tooltips hide when you move your cursor toward them. For interactive
 </Tooltip>
 ```
 
-### Custom Width
+## Custom Width
 
 Control the maximum width of tooltips using the `maxWidth` prop. The default maximum width is 225px.
 
@@ -122,7 +122,7 @@ Control the maximum width of tooltips using the `maxWidth` prop. The default max
 </Tooltip>
 ```
 
-### Rich Content
+## Rich Content
 
 Tooltips can display rich content including formatted text, multiple lines, and React elements.
 
@@ -185,7 +185,7 @@ Tooltips can display rich content including formatted text, multiple lines, and 
 </Tooltip>
 ```
 
-### Disabled State
+## Disabled State
 
 Tooltips can be disabled entirely using the `disabled` prop, which prevents them from showing on hover.
 
@@ -209,7 +209,7 @@ Tooltips can be disabled entirely using the `disabled` prop, which prevents them
 </Tooltip>
 ```
 
-### Show Only on Overflow
+## Show Only on Overflow
 
 For text that may or may not overflow, use the `showOnlyOnOverflow` prop to conditionally show tooltips only when content is truncated.
 
@@ -242,7 +242,7 @@ For text that may or may not overflow, use the `showOnlyOnOverflow` prop to cond
 </Tooltip>
 ```
 
-### Accessibility
+## Accessibility
 
 Tooltips automatically include proper ARIA attributes for screen readers. The component meets WCAG 2.2 AA compliance requirements for contrast and focus visibility.
 

--- a/static/app/stories/view/storyMdxComponent.tsx
+++ b/static/app/stories/view/storyMdxComponent.tsx
@@ -7,10 +7,10 @@ type HeadingProps = {
 };
 
 export const storyMdxComponents = {
-  h1: (props: HeadingProps) => <StoryHeading as="h3" size="xl" {...props} />,
-  h2: (props: HeadingProps) => <StoryHeading as="h4" size="lg" {...props} />,
-  h3: (props: HeadingProps) => <StoryHeading as="h5" size="md" {...props} />,
-  h4: (props: HeadingProps) => <StoryHeading as="h6" size="sm" {...props} />,
-  h5: (props: HeadingProps) => <Text bold as="p" size="md" {...props} />,
+  h1: () => null,
+  h2: (props: HeadingProps) => <StoryHeading as="h3" size="xl" {...props} />,
+  h3: (props: HeadingProps) => <StoryHeading as="h4" size="lg" {...props} />,
+  h4: (props: HeadingProps) => <StoryHeading as="h5" size="md" {...props} />,
+  h5: (props: HeadingProps) => <StoryHeading as="h6" size="sm" {...props} />,
   h6: (props: HeadingProps) => <Text bold as="p" size="sm" {...props} />,
 };

--- a/static/app/stories/view/storyMdxComponent.tsx
+++ b/static/app/stories/view/storyMdxComponent.tsx
@@ -1,5 +1,3 @@
-import {Text} from 'sentry/components/core/text';
-
 import {StoryHeading} from './storyHeading';
 
 type HeadingProps = {
@@ -7,10 +5,10 @@ type HeadingProps = {
 };
 
 export const storyMdxComponents = {
-  h1: () => null,
+  h1: (props: HeadingProps) => <StoryHeading as="h2" size="2xl" {...props} />,
   h2: (props: HeadingProps) => <StoryHeading as="h3" size="xl" {...props} />,
   h3: (props: HeadingProps) => <StoryHeading as="h4" size="lg" {...props} />,
   h4: (props: HeadingProps) => <StoryHeading as="h5" size="md" {...props} />,
   h5: (props: HeadingProps) => <StoryHeading as="h6" size="sm" {...props} />,
-  h6: (props: HeadingProps) => <Text bold as="p" size="sm" {...props} />,
+  h6: (props: HeadingProps) => <StoryHeading as="h6" size="xs" {...props} />,
 };

--- a/static/app/stories/view/storyMdxComponent.tsx
+++ b/static/app/stories/view/storyMdxComponent.tsx
@@ -1,3 +1,5 @@
+import {Text} from 'sentry/components/core/text';
+
 import {StoryHeading} from './storyHeading';
 
 type HeadingProps = {
@@ -5,10 +7,10 @@ type HeadingProps = {
 };
 
 export const storyMdxComponents = {
-  h1: (props: HeadingProps) => <StoryHeading as="h1" size="2xl" {...props} />,
-  h2: (props: HeadingProps) => <StoryHeading as="h2" size="2xl" {...props} />,
-  h3: (props: HeadingProps) => <StoryHeading as="h3" size="xl" {...props} />,
-  h4: (props: HeadingProps) => <StoryHeading as="h4" size="lg" {...props} />,
-  h5: (props: HeadingProps) => <StoryHeading as="h5" size="md" {...props} />,
-  h6: (props: HeadingProps) => <StoryHeading as="h6" size="sm" {...props} />,
+  h1: (props: HeadingProps) => <StoryHeading as="h3" size="xl" {...props} />,
+  h2: (props: HeadingProps) => <StoryHeading as="h4" size="lg" {...props} />,
+  h3: (props: HeadingProps) => <StoryHeading as="h5" size="md" {...props} />,
+  h4: (props: HeadingProps) => <StoryHeading as="h6" size="sm" {...props} />,
+  h5: (props: HeadingProps) => <Text bold as="p" size="md" {...props} />,
+  h6: (props: HeadingProps) => <Text bold as="p" size="sm" {...props} />,
 };

--- a/static/app/stories/view/storyMdxComponent.tsx
+++ b/static/app/stories/view/storyMdxComponent.tsx
@@ -4,6 +4,7 @@ type HeadingProps = {
   children: React.ReactNode;
 };
 
+// Heading levels shifted N+1 for proper semantics on /stories pages
 export const storyMdxComponents = {
   h1: (props: HeadingProps) => <StoryHeading as="h2" size="2xl" {...props} />,
   h2: (props: HeadingProps) => <StoryHeading as="h3" size="xl" {...props} />,


### PR DESCRIPTION
Original stories were written to emit `h3` and `h4` elements, since those were the semantic correct heading levels for the story page markup.

However, by adjusting the [`storyMdxComponent.tsx`](https://github.com/getsentry/sentry/blob/03ff4b882891ea9ab4ebc13fb01cb7ba78a883f1/static/app/stories/view/storyMdxComponent.tsx) levels, we can emit `h3` and `h4` without forcing that constrain onto doc authors.

All stories should now be written with `## title` for sections and `### subtitles` for sub-sections, which will now correctly output `h3` and `h4` elements. `# page` are not rendered.

