### PR TITLE
fix(ourlogs): Guard against missing precise timestamps

### DIFF
--- a/static/app/views/explore/logs/useLogsQuery.tsx
+++ b/static/app/views/explore/logs/useLogsQuery.tsx
@@ -331,8 +331,10 @@ function getPageParam(
         timestamp: firstRow[OurLogKnownFieldKey.TIMESTAMP],
         timestampPrecise: firstRow[OurLogKnownFieldKey.TIMESTAMP_PRECISE],
       });
-      firstTimestamp = BigInt(firstRow[OurLogKnownFieldKey.TIMESTAMP]) * 1_000_000n;
-      lastTimestamp = BigInt(lastRow[OurLogKnownFieldKey.TIMESTAMP]) * 1_000_000n;
+      firstTimestamp =
+        BigInt(new Date(firstRow[OurLogKnownFieldKey.TIMESTAMP]).getTime()) * 1_000_000n;
+      lastTimestamp =
+        BigInt(new Date(lastRow[OurLogKnownFieldKey.TIMESTAMP]).getTime()) * 1_000_000n;
     }
 
     const logId = isGetPreviousPage

--- a/static/app/views/explore/logs/useLogsQuery.tsx
+++ b/static/app/views/explore/logs/useLogsQuery.tsx
@@ -320,10 +320,12 @@ function getPageParam(
       return pageParam;
     }
 
-    let firstTimestamp = BigInt(firstRow[OurLogKnownFieldKey.TIMESTAMP_PRECISE]);
-    let lastTimestamp = BigInt(lastRow[OurLogKnownFieldKey.TIMESTAMP_PRECISE]);
-
-    if (!firstTimestamp || !lastTimestamp) {
+    let firstTimestamp: bigint;
+    let lastTimestamp: bigint;
+    try {
+      firstTimestamp = BigInt(firstRow[OurLogKnownFieldKey.TIMESTAMP_PRECISE]);
+      lastTimestamp = BigInt(lastRow[OurLogKnownFieldKey.TIMESTAMP_PRECISE]);
+    } catch {
       logger.warn(`No timestamp precise found for log row, using timestamp instead`, {
         logId: firstRow[OurLogKnownFieldKey.ID],
         timestamp: firstRow[OurLogKnownFieldKey.TIMESTAMP],


### PR DESCRIPTION
Possibly related to https://github.com/getsentry/relay/commit/a23fbd0f8346f00d3d97e38bd48a76c96026c290, timestamp precise is `null` sometimes. 

