### PR TITLE
ref(groupingInfo): move feedback button inline with groupInfoSummary

### DIFF
--- a/static/app/components/events/groupingInfo/groupingInfo.tsx
+++ b/static/app/components/events/groupingInfo/groupingInfo.tsx
@@ -57,15 +57,17 @@ export default function GroupingInfo({
         {hasStreamlinedUI && (
           <GroupInfoSummary event={event} group={group} projectSlug={projectSlug} />
         )}
-        <FeatureFeedback
-          featureName="grouping"
-          feedbackTypes={[
-            t('Too eager grouping'),
-            t('Too specific grouping'),
-            t('Other grouping issue'),
-          ]}
-          buttonProps={{size: 'xs'}}
-        />
+        {hasStreamlinedUI && (
+          <FeatureFeedback
+            featureName="grouping"
+            feedbackTypes={[
+              t('Too eager grouping'),
+              t('Too specific grouping'),
+              t('Other grouping issue'),
+            ]}
+            buttonProps={{size: 'xs'}}
+          />
+        )}
       </ConfigHeader>
       {isError ? <LoadingError message={t('Failed to fetch grouping info.')} /> : null}
       {isPending && !hasPerformanceGrouping ? <LoadingIndicator /> : null}
@@ -87,7 +89,6 @@ export default function GroupingInfo({
 
 const ConfigHeader = styled('div')`
   display: flex;
-  align-items: center;
   justify-content: space-between;
   gap: ${space(1)};
   margin-bottom: ${space(2)};

--- a/static/app/components/events/groupingInfo/groupingInfo.tsx
+++ b/static/app/components/events/groupingInfo/groupingInfo.tsx
@@ -51,22 +51,30 @@ export default function GroupingInfo({
       })
     : [];
 
+  const feedbackComponent = (
+    <FeatureFeedback
+      featureName="grouping"
+      feedbackTypes={[
+        t('Too eager grouping'),
+        t('Too specific grouping'),
+        t('Other grouping issue'),
+      ]}
+      buttonProps={{size: hasStreamlinedUI ? 'xs' : 'sm'}}
+    />
+  );
+
   return (
     <Fragment>
       <ConfigHeader>
         {hasStreamlinedUI && (
           <GroupInfoSummary event={event} group={group} projectSlug={projectSlug} />
         )}
-        {hasStreamlinedUI && (
-          <FeatureFeedback
-            featureName="grouping"
-            feedbackTypes={[
-              t('Too eager grouping'),
-              t('Too specific grouping'),
-              t('Other grouping issue'),
-            ]}
-            buttonProps={{size: 'xs'}}
-          />
+        {hasStreamlinedUI ? (
+          feedbackComponent
+        ) : (
+          <div style={{display: 'flex', justifyContent: 'flex-end', width: '100%'}}>
+            {feedbackComponent}
+          </div>
         )}
       </ConfigHeader>
       {isError ? <LoadingError message={t('Failed to fetch grouping info.')} /> : null}

--- a/static/app/components/events/groupingInfo/groupingInfo.tsx
+++ b/static/app/components/events/groupingInfo/groupingInfo.tsx
@@ -64,7 +64,7 @@ export default function GroupingInfo({
             t('Too specific grouping'),
             t('Other grouping issue'),
           ]}
-          buttonProps={{size: 'sm'}}
+          buttonProps={{size: 'xs'}}
         />
       </ConfigHeader>
       {isError ? <LoadingError message={t('Failed to fetch grouping info.')} /> : null}

--- a/static/app/components/events/groupingInfo/groupingInfo.tsx
+++ b/static/app/components/events/groupingInfo/groupingInfo.tsx
@@ -53,10 +53,10 @@ export default function GroupingInfo({
 
   return (
     <Fragment>
-      {hasStreamlinedUI && (
-        <GroupInfoSummary event={event} group={group} projectSlug={projectSlug} />
-      )}
-      <ConfigHeader>
+      <SummaryFeedbackComponent>
+        {hasStreamlinedUI && (
+          <GroupInfoSummary event={event} group={group} projectSlug={projectSlug} />
+        )}
         <FeatureFeedback
           featureName="grouping"
           feedbackTypes={[
@@ -66,7 +66,7 @@ export default function GroupingInfo({
           ]}
           buttonProps={{size: 'sm'}}
         />
-      </ConfigHeader>
+      </SummaryFeedbackComponent>
       {isError ? <LoadingError message={t('Failed to fetch grouping info.')} /> : null}
       {isPending && !hasPerformanceGrouping ? <LoadingIndicator /> : null}
       {hasPerformanceGrouping || isSuccess
@@ -85,10 +85,10 @@ export default function GroupingInfo({
   );
 }
 
-const ConfigHeader = styled('div')`
+const SummaryFeedbackComponent = styled('div')`
   display: flex;
   align-items: center;
-  justify-content: flex-end;
+  justify-content: space-between;
   gap: ${space(1)};
   margin-bottom: ${space(2)};
 `;

--- a/static/app/components/events/groupingInfo/groupingInfo.tsx
+++ b/static/app/components/events/groupingInfo/groupingInfo.tsx
@@ -53,7 +53,7 @@ export default function GroupingInfo({
 
   return (
     <Fragment>
-      <SummaryFeedbackComponent>
+      <ConfigHeader>
         {hasStreamlinedUI && (
           <GroupInfoSummary event={event} group={group} projectSlug={projectSlug} />
         )}
@@ -66,7 +66,7 @@ export default function GroupingInfo({
           ]}
           buttonProps={{size: 'sm'}}
         />
-      </SummaryFeedbackComponent>
+      </ConfigHeader>
       {isError ? <LoadingError message={t('Failed to fetch grouping info.')} /> : null}
       {isPending && !hasPerformanceGrouping ? <LoadingIndicator /> : null}
       {hasPerformanceGrouping || isSuccess
@@ -85,7 +85,7 @@ export default function GroupingInfo({
   );
 }
 
-const SummaryFeedbackComponent = styled('div')`
+const ConfigHeader = styled('div')`
   display: flex;
   align-items: center;
   justify-content: space-between;


### PR DESCRIPTION
Move Give Feedback button to be more inline with the `groupingInfoSummary` component now that `selectGroupingConfig` component is gone(#96655). Changed size to `xs`.

Created `feedbackComponent` for consistency across old and new UI. 


Before:
<img width="937" height="177" alt="image" src="https://github.com/user-attachments/assets/97017f76-0ce1-4887-983f-5e078386fa5c" />

After: 
<img width="939" height="147" alt="image" src="https://github.com/user-attachments/assets/0871759e-8e1c-4f01-aa26-7caf41daf87a" />
