### PR TITLE
fix(issue details): Align chained exception headers with parent

### DIFF
--- a/static/app/components/events/interfaces/crashContent/exception/content.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/content.tsx
@@ -388,6 +388,7 @@ const ShowRelatedExceptionsButton = styled(Button)`
 
 const StyledFoldSection = styled(FoldSection)`
   margin-bottom: 0;
+  margin-left: -${p => p.theme.space.sm};
 
   & ~ hr {
     margin-left: ${p => p.theme.space.xl};


### PR DESCRIPTION
<img width="720" height="416" alt="image" src="https://github.com/user-attachments/assets/036c123a-8b23-4143-9dfc-ecbbf3c16dde" />

Align the chained exception chevrons with the stack trace header text to typographically align the elements.