### PR TITLE
fix(sentry apps): Make a script to align servicehooks for all sentry apps

### DIFF
--- a/bin/backfill-servicehooks.py
+++ b/bin/backfill-servicehooks.py
@@ -16,9 +16,7 @@ def backfill_servicehooks_for_all_sentry_apps():
     """
     sentry_apps = SentryApp.objects.all()
 
-    for sentry_app in RangeQuerySetWrapper(
-        queryset=sentry_apps, step=1, result_value_getter=lambda item: item.id
-    ):
+    for sentry_app in RangeQuerySetWrapper(queryset=sentry_apps):
         click.echo(f"\nAttempting to backfill servicehooks for {sentry_app.slug}")
 
         create_or_update_service_hooks_for_sentry_app.delay(

--- a/bin/backfill-servicehooks.py
+++ b/bin/backfill-servicehooks.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+import click
+
+from sentry.runner import configure
+
+configure()
+
+from sentry.sentry_apps.models import SentryApp
+from sentry.sentry_apps.tasks.sentry_apps import create_or_update_service_hooks_for_sentry_app
+from sentry.utils.query import RangeQuerySetWrapper
+
+
+def backfill_servicehooks_for_all_sentry_apps():
+    """
+    This script goes through all sentry apps and attempts to create or update servicehooks for each.
+    """
+    sentry_apps = SentryApp.objects.all()
+
+    for sentry_app in RangeQuerySetWrapper(
+        queryset=sentry_apps, step=1, result_value_getter=lambda item: item.id
+    ):
+        click.echo(f"\nAttempting to backfill servicehooks for {sentry_app.slug}")
+
+        create_or_update_service_hooks_for_sentry_app.delay(
+            sentry_app_id=sentry_app.id,
+            webhook_url=sentry_app.webhook_url,
+            events=sentry_app.events,
+        )
+
+
+if __name__ == "__main__":
+    backfill_servicehooks_for_all_sentry_apps()


### PR DESCRIPTION
Instead of a task that runs when there's a failure, create a script that one and dones to align all installation's `ServiceHooks` with their `SentryApp`'s event list. 

The reason we're going through every single sentry app/installation is because there's only like ~150,000 so not too many. And trying to query `ServiceHook` & `SentryAppInstallation` would be a bigger effort because they're in separate silos and we don't currently have a way to get ServiceHooks for an Installation


Also also I don't think we need a test (??) since this script is just calling a tested task multiple times, feel free to flame me tho :hides