### PR TITLE
fix(grouping): Make grouping info stacktrace order match main stacktrace

### DIFF
--- a/src/sentry/api/endpoints/event_grouping_info.py
+++ b/src/sentry/api/endpoints/event_grouping_info.py
@@ -9,6 +9,9 @@ from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.grouping.api import load_grouping_config
 from sentry.grouping.grouping_info import get_grouping_info
+from sentry.interfaces.stacktrace import StacktraceOrder
+from sentry.users.services.user_option import user_option_service
+from sentry.users.services.user_option.service import get_option_from_list
 
 
 @region_silo_endpoint
@@ -31,6 +34,20 @@ class EventGroupingInfoEndpoint(ProjectEndpoint):
             raise ResourceDoesNotExist
 
         grouping_config = load_grouping_config(event.get_grouping_config())
+
+        # We want the stacktraces in the grouping info to match the issue details page's main
+        # stacktrace, which by default is upside down compared to the event JSON. Therefore, unless
+        # user has set a preference to prevent it, we want to flip the grouping info stacktraces,
+        # too.
+        should_reverse_stacktraces = (
+            get_option_from_list(
+                user_option_service.get_many(filter={"user_ids": [request.user.id]}),
+                key="stacktrace_order",
+            )
+            != StacktraceOrder.MOST_RECENT_LAST
+        )
+        grouping_config.initial_context["reverse_stacktraces"] = should_reverse_stacktraces
+
         _grouping_info = get_grouping_info(grouping_config, project, event)
 
         # TODO: All of the below is a temporary hack to preserve compatibility between the BE and FE as

--- a/src/sentry/grouping/component.py
+++ b/src/sentry/grouping/component.py
@@ -286,6 +286,7 @@ class MessageGroupingComponent(BaseGroupingComponent[str]):
 class StacktraceGroupingComponent(BaseGroupingComponent[FrameGroupingComponent]):
     id: str = "stacktrace"
     frame_counts: Counter[str]
+    reverse_when_serializing: bool = False
 
     def __init__(
         self,
@@ -296,6 +297,14 @@ class StacktraceGroupingComponent(BaseGroupingComponent[FrameGroupingComponent])
     ):
         super().__init__(hint=hint, contributes=contributes, values=values)
         self.frame_counts = frame_counts or Counter()
+
+    def as_dict(self) -> dict[str, Any]:
+        result = super().as_dict()
+
+        if self.reverse_when_serializing:
+            result["values"].reverse()
+
+        return result
 
 
 ExceptionGroupingComponentChildren = (
@@ -324,6 +333,7 @@ class ExceptionGroupingComponent(BaseGroupingComponent[ExceptionGroupingComponen
 class ChainedExceptionGroupingComponent(BaseGroupingComponent[ExceptionGroupingComponent]):
     id: str = "chained-exception"
     frame_counts: Counter[str]
+    reverse_when_serializing: bool = False
 
     def __init__(
         self,
@@ -334,6 +344,14 @@ class ChainedExceptionGroupingComponent(BaseGroupingComponent[ExceptionGroupingC
     ):
         super().__init__(hint=hint, contributes=contributes, values=values)
         self.frame_counts = frame_counts or Counter()
+
+    def as_dict(self) -> dict[str, Any]:
+        result = super().as_dict()
+
+        if self.reverse_when_serializing:
+            result["values"].reverse()
+
+        return result
 
 
 class ThreadsGroupingComponent(BaseGroupingComponent[StacktraceGroupingComponent]):

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -469,6 +469,12 @@ def _single_stacktrace_variant(
         exception_data=context["exception_data"],
     )
 
+    # This context value is set by the grouping info endpoint, so that the frame order of the
+    # stacktraces we show in the issue details page's grouping info section matches the frame order
+    # of the main stacktraces on the page.
+    if context.get("reverse_stacktraces"):
+        stacktrace_component.reverse_when_serializing = True
+
     # TODO: Ideally this hint would get set by the rust enhancer. Right now the only stacktrace
     # component hint it sets is one about ignoring stacktraces with contributing frames because the
     # number of contributing frames isn't big enough. In that case it also sets `contributes` to
@@ -651,10 +657,18 @@ def chained_exception(
         for exception_component in variant_exception_components:
             total_frame_counts += exception_component.frame_counts
 
-        chained_exception_components_by_variant[variant_name] = ChainedExceptionGroupingComponent(
+        chained_exception_component = ChainedExceptionGroupingComponent(
             values=variant_exception_components,
             frame_counts=total_frame_counts,
         )
+
+        # This context value is set by the grouping info endpoint, so that the exception order of
+        # the chained exceptions we show in the in the issue details page's grouping info section
+        # matches the exception order of the main stacktraces on the page.
+        if context.get("reverse_stacktraces"):
+            chained_exception_component.reverse_when_serializing = True
+
+        chained_exception_components_by_variant[variant_name] = chained_exception_component
 
     return chained_exception_components_by_variant
 

--- a/tests/sentry/api/endpoints/test_event_grouping_info.py
+++ b/tests/sentry/api/endpoints/test_event_grouping_info.py
@@ -7,8 +7,11 @@ from django.urls import reverse
 from sentry.conf.server import DEFAULT_GROUPING_CONFIG
 from sentry.grouping.api import _load_default_grouping_config, load_grouping_config
 from sentry.grouping.grouping_info import get_grouping_info
+from sentry.interfaces.stacktrace import StacktraceOrder
 from sentry.testutils.cases import APITestCase, PerformanceIssueTestCase
+from sentry.testutils.silo import assume_test_silo_mode_of
 from sentry.testutils.skips import requires_snuba
+from sentry.users.models.user_option import UserOption
 from sentry.utils.samples import load_data
 
 pytestmark = [requires_snuba]
@@ -44,6 +47,109 @@ class EventGroupingInfoEndpointTestCase(APITestCase, PerformanceIssueTestCase):
 
         assert response.status_code == 200
         assert content["system"]["type"] == "component"
+
+    def test_error_event_stacktrace_order(self) -> None:
+        """Test that the response stacktrace order matches the user's stacktrace order preference"""
+        data = load_data(platform="javascript")
+
+        # Grab the context lines, in order, to compare to what we get back from the endpoint
+        frames = data["exception"]["values"][0]["stacktrace"]["frames"]
+        orig_context_lines = [frame["context_line"].strip() for frame in frames]
+
+        event = self.store_event(data=data, project_id=self.project.id)
+
+        for option_value, expect_reversed_frames in [
+            ("", True),  # TODO: We should remove these faulty values from the DB
+            (StacktraceOrder.DEFAULT, True),
+            (StacktraceOrder.MOST_RECENT_LAST, False),
+            (StacktraceOrder.MOST_RECENT_FIRST, True),
+        ]:
+            with assume_test_silo_mode_of(UserOption):
+                UserOption.objects.set_value(
+                    user=self.user, key="stacktrace_order", value=option_value
+                )
+
+            url = reverse(
+                "sentry-api-0-event-grouping-info",
+                kwargs={
+                    "organization_id_or_slug": self.organization.slug,
+                    "project_id_or_slug": self.project.slug,
+                    "event_id": event.event_id,
+                },
+            )
+            response = self.client.get(url, format="json")
+            content = orjson.loads(response.content)
+
+            # Dig into the JSON to grab the context lines, in order
+            response_context_lines = []
+            exception_component = content["app"]["component"]["values"][0]
+            for exception_component_subcomponent in exception_component["values"]:
+                if exception_component_subcomponent["id"] == "stacktrace":
+                    stacktrace_component = exception_component_subcomponent
+                    for frame_component in stacktrace_component["values"]:
+                        for frame_component_subcomponent in frame_component["values"]:
+                            if frame_component_subcomponent["id"] == "context-line":
+                                context_line_component = frame_component_subcomponent
+                                response_context_lines.append(context_line_component["values"][0])
+
+            assert response.status_code == 200
+            if expect_reversed_frames:
+                assert response_context_lines == list(reversed(orig_context_lines))
+            else:
+                assert response_context_lines == orig_context_lines
+
+    def test_error_event_exception_order(self) -> None:
+        """Test that the response exception order matches the user's stacktrace order preference"""
+        data = load_data(platform="javascript")
+
+        # Replace the single exception in `data` with two exceptions
+        exceptions = [
+            {"type": "FetchError", "value": "Charlie didn't bring the ball back!"},
+            {"type": "ShoeError", "value": "Oh, no! Charlie ate the flip-flops!"},
+        ]
+        data["exception"]["values"] = exceptions
+
+        # Grab the error types, in order, to compare to what we get back from the endpoint
+        orig_exception_types = [exception["type"] for exception in exceptions]
+
+        event = self.store_event(data=data, project_id=self.project.id)
+
+        for option_value, expect_reversed_exceptions in [
+            ("", True),  # TODO: We should remove these faulty values from the DB
+            (StacktraceOrder.DEFAULT, True),
+            (StacktraceOrder.MOST_RECENT_LAST, False),
+            (StacktraceOrder.MOST_RECENT_FIRST, True),
+        ]:
+            with assume_test_silo_mode_of(UserOption):
+                UserOption.objects.set_value(
+                    user=self.user, key="stacktrace_order", value=option_value
+                )
+
+            url = reverse(
+                "sentry-api-0-event-grouping-info",
+                kwargs={
+                    "organization_id_or_slug": self.organization.slug,
+                    "project_id_or_slug": self.project.slug,
+                    "event_id": event.event_id,
+                },
+            )
+            response = self.client.get(url, format="json")
+            content = orjson.loads(response.content)
+
+            # Dig into the JSON to grab the error types, in order
+            response_error_types = []
+            chained_exception_component = content["app"]["component"]["values"][0]
+            for exception_component in chained_exception_component["values"]:
+                for exception_component_subcomponent in exception_component["values"]:
+                    if exception_component_subcomponent["id"] == "type":
+                        error_type_component = exception_component_subcomponent
+                        response_error_types.append(error_type_component["values"][0])
+
+            assert response.status_code == 200
+            if expect_reversed_exceptions:
+                assert response_error_types == list(reversed(orig_exception_types))
+            else:
+                assert response_error_types == orig_exception_types
 
     def test_transaction_event(self) -> None:
         data = load_data(platform="transaction")


### PR DESCRIPTION
In https://github.com/getsentry/sentry/pull/82168, we made a change which was meant to solve https://github.com/getsentry/sentry/issues/81933 (stacktraces in grouping info most often being upside down compared to the main stacktrace), but which instead caused https://github.com/getsentry/sentry/issues/90839 (the stacktrace order flip-flopping at random times in a super annoying way). It turns out that for #reactreasons, the stacktrace component rerenders a bunch, and every time it does, the stacktrace flips.

To solve that we're going to undo the original change, but that of course will leave us back where we started, with upside down stacktraces. This PR is a second attempt to solve the problem, this time in the backend.

The reason the grouping info stacktraces are upside down in the first place is that our default behavior is to present the main stacktrace with the most recent frame at the top, even though the event JSON the stacktrace has the most recent frame at the bottom. (Users can turn this main-stacktrace flip off, but of our ~3.7 million users, only about 1600 have chosen to do so.)

Meanwhile, down in the grouping info section, we present the stacktraces as they're stored, with the most recent frame at the bottom. Voila, two stacktraces in opposite orders.

To fix that, this PR brings the same flipping we do for the main stacktrace to the grouping info stacktraces (controlled by the same user option which controls the main stacktrace), To accomplish this, it makes three key changes:

- The `StacktraceGroupingComponent` and `ChainedExceptionGroupingComponent` classes now have the ability to reverse the order of their values based on a new `reverse_when_serializing` flag.

- The grouping info endpoint now checks the user option and sets a `reverse_stacktraces` flag on the grouping config based on what it finds,

- Finally, the two changes are connected by having the `reverse_stacktraces` flag (if set) control the value of the `reverse_when_serializing` flag. Since nowhere other than the endpoint sets `reverse_stacktraces`, this change has no effect on other users of our grouping functions.

Fixes https://github.com/getsentry/sentry/issues/81933