### PR TITLE
fix(grouping): Stop repeated flipping of grouping info stacktraces

### DIFF
--- a/static/app/components/events/groupingInfo/groupingComponentStacktrace.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponentStacktrace.tsx
@@ -1,6 +1,5 @@
 import {Fragment} from 'react';
 
-import {isStacktraceNewestFirst} from 'sentry/components/events/interfaces/utils';
 import type {EventGroupComponent} from 'sentry/types/event';
 
 import GroupingComponent from './groupingComponent';
@@ -21,10 +20,7 @@ function GroupingComponentStacktrace({component, showNonContributing}: Props) {
   const getFrameGroups = () => {
     const frameGroups: FrameGroup[] = [];
 
-    const frames = isStacktraceNewestFirst()
-      ? component.values.reverse()
-      : component.values;
-    (frames as EventGroupComponent[])
+    (component.values as EventGroupComponent[])
       .filter(value => groupingComponentFilter(value, showNonContributing))
       .forEach(value => {
         const key = (value.values as EventGroupComponent[])


### PR DESCRIPTION
This is a follow-up PR to https://github.com/getsentry/sentry/pull/96913, which fixed the problem of grouping info stacktraces being upside down compared to the main stacktrace on the issue details page. Now that grouping info stacktraces are ordered correctly in the API response, we can remove the previous (buggy) front end fix we've had in place, which has been causing grouping info stacktraces to repeatedly flip their ordering after the page has loaded.

Fixes https://github.com/getsentry/sentry/issues/90839