### PR TITLE
feat(aci): add bulk update detectors endpoint

### DIFF
--- a/src/sentry/workflow_engine/endpoints/organization_detector_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_index.py
@@ -399,8 +399,9 @@ class OrganizationDetectorIndexEndpoint(OrganizationEndpoint):
             raise PermissionDenied
 
         # We update detectors individually to ensure post_save signals are called
-        for detector in queryset:
-            detector.update(enabled=enabled)
+        with transaction.atomic(router.db_for_write(Detector)):
+            for detector in queryset:
+                detector.update(enabled=enabled)
 
         return self.paginate(
             request=request,

--- a/src/sentry/workflow_engine/endpoints/organization_detector_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_index.py
@@ -42,9 +42,6 @@ from sentry.uptime.grouptype import UptimeDomainCheckFailure
 from sentry.users.models.user import User
 from sentry.users.services.user import RpcUser
 from sentry.utils.audit import create_audit_entry
-from sentry.workflow_engine.endpoints.organization_workflow_index import (
-    DetectorWorkflowMutationValidator,
-)
 from sentry.workflow_engine.endpoints.serializers import DetectorSerializer
 from sentry.workflow_engine.endpoints.utils.filters import apply_filter
 from sentry.workflow_engine.endpoints.utils.sortby import SortByParam
@@ -52,6 +49,9 @@ from sentry.workflow_engine.endpoints.validators.base import BaseDetectorTypeVal
 from sentry.workflow_engine.endpoints.validators.detector_workflow import (
     BulkDetectorWorkflowsValidator,
     can_edit_detectors,
+)
+from sentry.workflow_engine.endpoints.validators.detector_workflow_mutation import (
+    DetectorWorkflowMutationValidator,
 )
 from sentry.workflow_engine.endpoints.validators.utils import get_unknown_detector_type_error
 from sentry.workflow_engine.models import Detector

--- a/src/sentry/workflow_engine/endpoints/organization_detector_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_index.py
@@ -126,6 +126,7 @@ class OrganizationDetectorIndexEndpoint(OrganizationEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.EXPERIMENTAL,
         "POST": ApiPublishStatus.EXPERIMENTAL,
+        "PUT": ApiPublishStatus.EXPERIMENTAL,
         "DELETE": ApiPublishStatus.EXPERIMENTAL,
     }
     owner = ApiOwner.ISSUES

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
@@ -510,7 +510,7 @@ class OrganizationDetectorIndexGetTest(OrganizationDetectorIndexBaseTest):
         )
         self.login_as(user=owner)
 
-        # Verify that the owner can see detectors across all projects
+        # Verify that the owner can see detectors for projects that they are not a member of
         response = self.get_success_response(
             self.organization.slug,
             qs_params={"project": new_project.id},
@@ -538,7 +538,7 @@ class OrganizationDetectorIndexGetTest(OrganizationDetectorIndexBaseTest):
         )
         self.login_as(user=owner)
 
-        # Verify that the owner can see detectors across all projects
+        # Verify that the owner can see detectors for projects that they are not a member of
         response = self.get_success_response(
             self.organization.slug,
             qs_params=[("id", str(self.detector.id)), ("id", str(self.detector_2.id))],
@@ -926,7 +926,6 @@ class OrganizationDetectorIndexPutTest(OrganizationDetectorIndexBaseTest):
 
         self.org_manager_user = self.create_user()
         self.create_member(
-            # team_roles=[(self.team, "contributor")],
             user=self.org_manager_user,
             role="manager",
             organization=self.organization,

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
@@ -496,6 +496,56 @@ class OrganizationDetectorIndexGetTest(OrganizationDetectorIndexBaseTest):
         )
         assert len(response.data) == 0
 
+    def test_query_by_project_owner_user(self) -> None:
+        new_project = self.create_project(organization=self.organization)
+        detector = self.create_detector(
+            project_id=new_project.id, name="Test Detector", type=MetricIssue.slug
+        )
+
+        owner = self.create_user()
+        self.create_member(
+            user=owner,
+            role="owner",
+            organization=self.organization,
+        )
+        self.login_as(user=owner)
+
+        # Verify that the owner can see detectors across all projects
+        response = self.get_success_response(
+            self.organization.slug,
+            qs_params={"project": new_project.id},
+            status_code=200,
+        )
+        assert {d["name"] for d in response.data} == {detector.name}
+
+    def test_query_by_id_owner_user(self) -> None:
+        self.detector = self.create_detector(
+            project_id=self.project.id,
+            name="Detector 1",
+            type=MetricIssue.slug,
+        )
+        self.detector_2 = self.create_detector(
+            project_id=self.project.id,
+            name="Detector 2",
+            type=MetricIssue.slug,
+        )
+
+        owner = self.create_user()
+        self.create_member(
+            user=owner,
+            role="owner",
+            organization=self.organization,
+        )
+        self.login_as(user=owner)
+
+        # Verify that the owner can see detectors across all projects
+        response = self.get_success_response(
+            self.organization.slug,
+            qs_params=[("id", str(self.detector.id)), ("id", str(self.detector_2.id))],
+            status_code=200,
+        )
+        assert {d["name"] for d in response.data} == {self.detector.name, self.detector_2.name}
+
 
 @region_silo_test
 @with_feature("organizations:incidents")
@@ -831,6 +881,281 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
             status_code=400,
         )
         assert "owner" in response.data
+
+
+@region_silo_test
+@with_feature("organizations:incidents")
+class OrganizationDetectorIndexPutTest(OrganizationDetectorIndexBaseTest):
+    method = "PUT"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.detector = self.create_detector(
+            project_id=self.project.id, name="Test Detector", type=MetricIssue.slug, enabled=True
+        )
+        self.detector_two = self.create_detector(
+            project_id=self.project.id, name="Another Detector", type=MetricIssue.slug, enabled=True
+        )
+        self.detector_three = self.create_detector(
+            project_id=self.project.id, name="Third Detector", type=MetricIssue.slug, enabled=True
+        )
+
+        self.user_detector = self.create_detector(
+            project=self.project,
+            name="User Created Detector",
+            type=MetricIssue.slug,
+            enabled=True,
+            created_by_id=self.user.id,
+        )
+
+        self.member_user = self.create_user()
+        self.create_member(
+            team_roles=[(self.team, "contributor")],
+            user=self.member_user,
+            role="member",
+            organization=self.organization,
+        )
+
+        self.team_admin_user = self.create_user()
+        self.create_member(
+            team_roles=[(self.team, "admin")],
+            user=self.team_admin_user,
+            role="member",
+            organization=self.organization,
+        )
+
+        self.org_manager_user = self.create_user()
+        self.create_member(
+            # team_roles=[(self.team, "contributor")],
+            user=self.org_manager_user,
+            role="manager",
+            organization=self.organization,
+        )
+
+    def test_update_detectors_by_ids_success(self) -> None:
+        response = self.get_success_response(
+            self.organization.slug,
+            qs_params=[("id", str(self.detector.id)), ("id", str(self.detector_two.id))],
+            enabled=False,
+            status_code=200,
+        )
+
+        # Verify detectors were updated
+        self.detector.refresh_from_db()
+        self.detector_two.refresh_from_db()
+        assert self.detector.enabled is False
+        assert self.detector_two.enabled is False
+
+        # Verify third detector was not affected
+        self.detector_three.refresh_from_db()
+        assert self.detector_three.enabled is True
+
+        # Verify response data
+        assert len(response.data) == 2
+        detector_ids = {d["id"] for d in response.data}
+        assert detector_ids == {str(self.detector.id), str(self.detector_two.id)}
+        assert all(d["enabled"] is False for d in response.data)
+
+    def test_update_detectors_by_query_success(self) -> None:
+        response = self.get_success_response(
+            self.organization.slug,
+            qs_params={"query": "test", "project": self.project.id},
+            enabled=False,
+            status_code=200,
+        )
+
+        # Verify detector matching query was updated
+        self.detector.refresh_from_db()
+        assert self.detector.enabled is False
+
+        # Verify other detectors were not affected
+        self.detector_two.refresh_from_db()
+        self.detector_three.refresh_from_db()
+        assert self.detector_two.enabled is True
+        assert self.detector_three.enabled is True
+
+        # Verify response
+        assert len(response.data) == 1
+        assert response.data[0]["id"] == str(self.detector.id)
+        assert response.data[0]["enabled"] is False
+
+    def test_update_detectors_enable_success(self) -> None:
+        self.detector.update(enabled=False)
+        self.detector_two.update(enabled=False)
+        self.detector_three.update(enabled=False)
+
+        response = self.get_success_response(
+            self.organization.slug,
+            qs_params={"id": str(self.detector_three.id)},
+            enabled=True,
+            status_code=200,
+        )
+
+        # Verify detector was enabled
+        self.detector_three.refresh_from_db()
+        assert self.detector_three.enabled is True
+
+        # Verify response
+        assert len(response.data) == 1
+        assert response.data[0]["id"] == str(self.detector_three.id)
+        assert response.data[0]["enabled"] is True
+
+    def test_update_detectors_no_parameters_error(self) -> None:
+        response = self.get_error_response(
+            self.organization.slug,
+            enabled=False,
+            status_code=400,
+        )
+
+        assert "At least one of 'id', 'query', 'project', or 'projectSlug' must be provided" in str(
+            response.data["detail"]
+        )
+
+    def test_update_detectors_missing_enabled_field(self) -> None:
+        response = self.get_error_response(
+            self.organization.slug,
+            qs_params={"id": str(self.detector.id)},
+            status_code=400,
+        )
+
+        assert response.data == {"enabled": "This field is required."}
+
+    def test_update_detectors_invalid_id_format(self) -> None:
+        response = self.get_error_response(
+            self.organization.slug,
+            qs_params={"id": "not-a-number"},
+            enabled=False,
+            status_code=400,
+        )
+
+        assert "Invalid ID format" in str(response.data["id"])
+
+    def test_update_detectors_no_matching_detectors(self) -> None:
+        response = self.get_success_response(
+            self.organization.slug,
+            qs_params={"id": "999999"},
+            enabled=False,
+            status_code=204,
+        )
+
+        assert response.data["detail"] == "No detectors found."
+
+    def test_update_detectors_permission_denied_for_member(self) -> None:
+        self.organization.flags.allow_joinleave = False
+        self.organization.save()
+
+        self.login_as(user=self.member_user)
+
+        self.get_error_response(
+            self.organization.slug,
+            qs_params={"id": str(self.detector.id)},
+            enabled=False,
+            status_code=403,
+        )
+
+        # Verify detector was not modified
+        self.detector.refresh_from_db()
+        assert self.detector.enabled is True
+
+    def test_update_detectors_permission_allowed_for_team_admin(self) -> None:
+        self.login_as(user=self.team_admin_user)
+
+        self.get_success_response(
+            self.organization.slug,
+            qs_params={"id": str(self.detector.id)},
+            enabled=False,
+            status_code=200,
+        )
+
+        # Verify detector was updated
+        self.detector.refresh_from_db()
+        assert self.detector.enabled is False
+
+    def test_update_detectors_member_permission_allowed_for_user_created_detector(self) -> None:
+        self.login_as(user=self.member_user)
+
+        self.get_success_response(
+            self.organization.slug,
+            qs_params={"id": str(self.user_detector.id)},
+            enabled=False,
+            status_code=200,
+        )
+
+        # Verify detector was updated
+        self.user_detector.refresh_from_db()
+        assert self.user_detector.enabled is False
+
+    def test_update_detectors_member_permission_denied_for_non_user_created_detector(self) -> None:
+        self.login_as(user=self.member_user)
+
+        # Try to update a detector not created by a user
+        self.get_error_response(
+            self.organization.slug,
+            qs_params={"id": str(self.detector.id)},
+            enabled=False,
+            status_code=403,
+        )
+
+        # Verify detector was not modified
+        self.detector.refresh_from_db()
+        assert self.detector.enabled is True
+
+    def test_update_detectors_org_manager_permission(self) -> None:
+        self.login_as(user=self.org_manager_user)
+
+        self.get_success_response(
+            self.organization.slug,
+            qs_params=[("id", str(self.detector.id)), ("id", str(self.detector_two.id))],
+            enabled=False,
+            status_code=200,
+        )
+
+        # Verify detectors were updated
+        self.detector.refresh_from_db()
+        self.detector_two.refresh_from_db()
+        assert self.detector.enabled is False
+        assert self.detector_two.enabled is False
+
+    def test_update_owner_query_by_project(self) -> None:
+        new_project = self.create_project(organization=self.organization)
+        detector = self.create_detector(
+            project_id=new_project.id, name="Test Detector", type=MetricIssue.slug, enabled=True
+        )
+
+        owner = self.create_user()
+        self.create_member(
+            user=owner,
+            role="owner",
+            organization=self.organization,
+        )
+        self.login_as(user=owner)
+
+        self.get_success_response(
+            self.organization.slug,
+            qs_params={"project": new_project.id},
+            enabled=False,
+            status_code=200,
+        )
+
+        detector.refresh_from_db()
+        assert detector.enabled is False
+
+    def test_update_detectors_mixed_permissions(self) -> None:
+        self.login_as(user=self.member_user)
+
+        # Try to update both detectors - should fail because of mixed permissions
+        self.get_error_response(
+            self.organization.slug,
+            qs_params=[("id", str(self.user_detector.id)), ("id", str(self.detector.id))],
+            enabled=False,
+            status_code=403,
+        )
+
+        # Verify neither detector was modified
+        self.user_detector.refresh_from_db()
+        self.detector.refresh_from_db()
+        assert self.user_detector.enabled is True
+        assert self.detector.enabled is True
 
 
 @region_silo_test

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
@@ -1018,7 +1018,7 @@ class OrganizationDetectorIndexPutTest(OrganizationDetectorIndexBaseTest):
             status_code=400,
         )
 
-        assert response.data == {"enabled": "This field is required."}
+        assert "This field is required." in str(response.data["enabled"])
 
     def test_update_detectors_invalid_id_format(self) -> None:
         response = self.get_error_response(
@@ -1035,7 +1035,7 @@ class OrganizationDetectorIndexPutTest(OrganizationDetectorIndexBaseTest):
             self.organization.slug,
             qs_params={"id": "999999"},
             enabled=False,
-            status_code=204,
+            status_code=200,
         )
 
         assert response.data["detail"] == "No detectors found."
@@ -1353,11 +1353,12 @@ class OrganizationDetectorDeleteTest(OrganizationDetectorIndexBaseTest):
 
     def test_delete_no_matching_detectors(self) -> None:
         # Test deleting detectors with non-existent ID
-        self.get_success_response(
+        response = self.get_success_response(
             self.organization.slug,
             qs_params={"id": "999999"},
-            status_code=204,
+            status_code=200,
         )
+        assert response.data["detail"] == "No detectors found."
 
         # Verify no detectors were affected
         self.assert_unaffected_detectors([self.detector, self.detector_two, self.detector_three])
@@ -1366,8 +1367,9 @@ class OrganizationDetectorDeleteTest(OrganizationDetectorIndexBaseTest):
         self.get_success_response(
             self.organization.slug,
             qs_params={"query": "nonexistent-detector-name", "project": self.project.id},
-            status_code=204,
+            status_code=200,
         )
+        assert response.data["detail"] == "No detectors found."
 
         # Verify no detectors were affected
         self.assert_unaffected_detectors([self.detector, self.detector_two, self.detector_three])


### PR DESCRIPTION
- added PUT endpoint to enable/disable detectors
- fixed queries by `id`
    - was originally only returning matching detectors owned by projects that the requesting user was a member of, rather than matching detectors owned by projects that the requesting user has access to
- optimized permission checks for detectors
    - added `can_edit_detectors` helper function that bulk checks detectors by project, since most permissions are project-level
- added so many tests