### PR TITLE
chore(eco): Refactors organization report building

### DIFF
--- a/src/sentry/tasks/summaries/metrics.py
+++ b/src/sentry/tasks/summaries/metrics.py
@@ -46,5 +46,5 @@ class WeeklyReportSLO(EventLifecycleMetric):
     def get_metric_tags(self) -> Mapping[str, str]:
         return {
             "operation_type": self.operation_type,
-            "dry_run": int(self.dry_run),
+            "dry_run": str(self.dry_run).lower(),
         }

--- a/src/sentry/tasks/summaries/metrics.py
+++ b/src/sentry/tasks/summaries/metrics.py
@@ -6,8 +6,22 @@ from sentry.integrations.types import EventLifecycleOutcome
 from sentry.integrations.utils.metrics import EventLifecycleMetric
 
 
-class WeeklyReportFailureType(StrEnum):
+class WeeklyReportFailureReason(StrEnum):
+    """
+    The reason for a failure in the weekly reporting pipeline.
+    """
+
     TIMEOUT = "timeout"
+
+
+class WeeklyReportHaltReason(StrEnum):
+    """
+    The reason for a halt in the weekly reporting pipeline.
+    """
+
+    EMPTY_REPORT = "empty_report"
+    DRY_RUN = "dry_run"
+    DUPLICATE_DELIVERY = "duplicate_delivery"
 
 
 class WeeklyReportOperationType(StrEnum):
@@ -16,12 +30,14 @@ class WeeklyReportOperationType(StrEnum):
     """
 
     SCHEDULE_ORGANIZATION_REPORTS = "schedule_organization_reports"
-    PREPARE_ORGANIZATION_REPORTS = "prepare_organization_reports"
+    PREPARE_ORGANIZATION_REPORT = "prepare_organization_report"
+    SEND_EMAIL = "send_email"
 
 
 @dataclass
 class WeeklyReportSLO(EventLifecycleMetric):
     operation_type: WeeklyReportOperationType
+    dry_run: bool
 
     def get_metric_key(self, outcome: EventLifecycleOutcome) -> str:
         tokens = ("weekly_report", self.operation_type, str(outcome))
@@ -30,4 +46,5 @@ class WeeklyReportSLO(EventLifecycleMetric):
     def get_metric_tags(self) -> Mapping[str, str]:
         return {
             "operation_type": self.operation_type,
+            "dry_run": int(self.dry_run),
         }

--- a/src/sentry/tasks/summaries/organization_report_context_factory.py
+++ b/src/sentry/tasks/summaries/organization_report_context_factory.py
@@ -1,0 +1,170 @@
+import sentry_sdk
+
+from sentry.constants import DataCategory
+from sentry.models.organization import Organization
+from sentry.models.organizationmember import OrganizationMember
+from sentry.models.team import TeamStatus
+from sentry.snuba.referrer import Referrer
+from sentry.tasks.summaries.utils import (
+    OrganizationReportContext,
+    ProjectContext,
+    fetch_key_error_groups,
+    fetch_key_performance_issue_groups,
+    organization_project_issue_substatus_summaries,
+    project_event_counts_for_organization,
+    project_key_errors,
+    project_key_performance_issues,
+    project_key_transactions_last_week,
+    project_key_transactions_this_week,
+)
+from sentry.utils.outcomes import Outcome
+from sentry.utils.snuba import parse_snuba_datetime
+
+
+class OrganizationReportContextFactory:
+    timestamp: float
+    duration: int
+    organization: Organization
+
+    def __init__(self, timestamp: float, duration: int, organization: Organization):
+        self.timestamp = timestamp
+        self.duration = duration
+        self.organization = organization
+
+    def _append_user_project_ownership(self, ctx: OrganizationReportContext) -> None:
+        """Find the projects associated with each user.
+        Populates context.project_ownership which is { user_id: set<project_id> }
+        """
+        with sentry_sdk.start_span(op="weekly_reports.user_project_ownership"):
+            for project_id, user_id in OrganizationMember.objects.filter(
+                organization_id=ctx.organization.id,
+                teams__projectteam__project__isnull=False,
+                teams__status=TeamStatus.ACTIVE,
+            ).values_list("teams__projectteam__project_id", "user_id"):
+                if user_id is not None:
+                    ctx.project_ownership.setdefault(user_id, set()).add(project_id)
+
+    def _append_project_event_counts(self, ctx: OrganizationReportContext) -> None:
+        with sentry_sdk.start_span(op="weekly_reports.project_event_counts_for_organization"):
+            event_counts = project_event_counts_for_organization(
+                start=ctx.start, end=ctx.end, ctx=ctx, referrer=Referrer.REPORTS_OUTCOMES.value
+            )
+            for data in event_counts:
+                project_id = data["project_id"]
+                # Project no longer in organization, but events still exist
+                if project_id not in ctx.projects_context_map:
+                    continue
+                project_ctx = ctx.projects_context_map[project_id]
+
+                assert isinstance(
+                    project_ctx, ProjectContext
+                ), f"Expected a ProjectContext, received {type(project_ctx)}"
+                total = data["total"]
+                timestamp = int(parse_snuba_datetime(data["time"]).timestamp())
+                if data["category"] == DataCategory.TRANSACTION:
+                    # Transaction outcome
+                    if (
+                        data["outcome"] == Outcome.RATE_LIMITED
+                        or data["outcome"] == Outcome.FILTERED
+                    ):
+                        project_ctx.dropped_transaction_count += total
+                    else:
+                        project_ctx.accepted_transaction_count += total
+                        project_ctx.transaction_count_by_day[timestamp] = total
+                elif data["category"] == DataCategory.REPLAY:
+                    # Replay outcome
+                    if (
+                        data["outcome"] == Outcome.RATE_LIMITED
+                        or data["outcome"] == Outcome.FILTERED
+                    ):
+                        project_ctx.dropped_replay_count += total
+                    else:
+                        project_ctx.accepted_replay_count += total
+                        project_ctx.replay_count_by_day[timestamp] = total
+                else:
+                    # Error outcome
+                    if (
+                        data["outcome"] == Outcome.RATE_LIMITED
+                        or data["outcome"] == Outcome.FILTERED
+                    ):
+                        project_ctx.dropped_error_count += total
+                    else:
+                        project_ctx.accepted_error_count += total
+                        project_ctx.error_count_by_day[timestamp] = (
+                            project_ctx.error_count_by_day.get(timestamp, 0) + total
+                        )
+
+    def _append_organization_project_issue_substatus_summaries(
+        self, ctx: OrganizationReportContext
+    ) -> None:
+        with sentry_sdk.start_span(
+            op="weekly_reports.organization_project_issue_substatus_summaries"
+        ):
+            organization_project_issue_substatus_summaries(ctx)
+
+    def _append_project_key_errors(self, ctx: OrganizationReportContext) -> None:
+        with sentry_sdk.start_span(op="weekly_reports.project_passes"):
+            organization = ctx.organization
+            # Run project passes
+            for project in organization.project_set.all():
+                key_errors = project_key_errors(
+                    ctx, project, referrer=Referrer.REPORTS_KEY_ERRORS.value
+                )
+                if project.id not in ctx.projects_context_map:
+                    continue
+
+                project_ctx = ctx.projects_context_map[project.id]
+                assert isinstance(
+                    project_ctx, ProjectContext
+                ), f"Expected a ProjectContext, received {type(project_ctx)}"
+
+                if key_errors:
+                    project_ctx.key_errors_by_id = [
+                        (e["events.group_id"], e["count()"]) for e in key_errors
+                    ]
+
+                key_transactions_this_week = project_key_transactions_this_week(ctx, project)
+                if key_transactions_this_week:
+                    project_ctx.key_transactions = [
+                        (i["transaction_name"], i["count"], i["p95"])
+                        for i in key_transactions_this_week
+                    ]
+                    query_result = project_key_transactions_last_week(
+                        ctx, project, key_transactions_this_week
+                    )
+                    # Join this week with last week
+                    last_week_data = {
+                        i["transaction_name"]: (i["count"], i["p95"]) for i in query_result["data"]
+                    }
+
+                    project_ctx.key_transactions = [
+                        (i["transaction_name"], i["count"], i["p95"])
+                        + last_week_data.get(i["transaction_name"], (0, 0))
+                        for i in key_transactions_this_week
+                    ]
+
+                key_performance_issues = project_key_performance_issues(
+                    ctx, project, referrer=Referrer.REPORTS_KEY_PERFORMANCE_ISSUES.value
+                )
+                if key_performance_issues:
+                    ctx.projects_context_map[project.id].key_performance_issues = (
+                        key_performance_issues
+                    )
+
+    def _hydrate_key_error_groups(self, ctx: OrganizationReportContext) -> None:
+        with sentry_sdk.start_span(op="weekly_reports.fetch_key_error_groups"):
+            fetch_key_error_groups(ctx)
+
+    def _hydrate_key_performance_issue_groups(self, ctx: OrganizationReportContext) -> None:
+        with sentry_sdk.start_span(op="weekly_reports.fetch_key_performance_issue_groups"):
+            fetch_key_performance_issue_groups(ctx)
+
+    def create_context(self) -> OrganizationReportContext:
+        ctx = OrganizationReportContext(self.timestamp, self.duration, self.organization)
+        self._append_user_project_ownership(ctx)
+        self._append_project_event_counts(ctx)
+        self._append_organization_project_issue_substatus_summaries(ctx)
+        self._append_project_key_errors(ctx)
+        self._hydrate_key_error_groups(ctx)
+        self._hydrate_key_performance_issue_groups(ctx)
+        return ctx

--- a/src/sentry/tasks/summaries/utils.py
+++ b/src/sentry/tasks/summaries/utils.py
@@ -57,6 +57,15 @@ class OrganizationReportContext:
     def __repr__(self) -> str:
         return self.projects_context_map.__repr__()
 
+    def is_empty(self):
+        """
+        Returns True if every project context is empty.
+        """
+        return all(
+            project_ctx.check_if_project_is_empty()
+            for project_ctx in self.projects_context_map.values()
+        )
+
 
 class ProjectContext:
     accepted_error_count = 0


### PR DESCRIPTION
Continuation of #96869, merge that first

Includes the following refactors:
- Adds a new `OrganizationReportContextFactory` to clean up the `prepare_organization_report` task.
- Moves `is_empty` check logic to `OrganizationReportContext` class, from the dedicated util where it lived before.
- Adds stronger typing for `ProjectContext` checks when building org contexts.


## Why these changes?
This change allows us to more easily wrap our report building steps in SLOs. It also allows us to break down individual report building steps with metrics on a per-organization basis, should we choose to.
