### PR TITLE
chore(codeowners): Remove Performance team from performance issues 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -232,8 +232,8 @@ pnpm-lock.yaml                                           @getsentry/owners-js-de
 /src/sentry/search/events/                                                  @getsentry/visibility
 /src/sentry/search/eap/                                                     @getsentry/visibility
 
-/src/sentry/performance_issues/                                             @getsentry/performance @getsentry/issue-detection-backend
-/tests/sentry/performance_issues/                                           @getsentry/performance @getsentry/issue-detection-backend
+/src/sentry/performance_issues/                                             @getsentry/issue-detection-backend
+/tests/sentry/performance_issues/                                           @getsentry/issue-detection-backend
 
 /static/app/components/events/eventStatisticalDetector/                     @getsentry/visibility @getsentry/profiling
 


### PR DESCRIPTION
new version of https://github.com/getsentry/sentry/pull/96862 
Don't merge until we figure out this codeowner/api bug