### PR TITLE
fix(aci): Limit the LatestAdoptedReleaseHandler to adopted releases

### DIFF
--- a/src/sentry/rules/filters/latest_adopted_release_filter.py
+++ b/src/sentry/rules/filters/latest_adopted_release_filter.py
@@ -150,7 +150,7 @@ class LatestAdoptedReleaseFilter(EventFilter):
 
 def is_newer_release(
     release: Release, comparison_release: Release, order_type: LatestReleaseOrders
-):
+) -> bool:
     if (
         order_type == LatestReleaseOrders.SEMVER
         and release.is_semver_release

--- a/src/sentry/workflow_engine/handlers/condition/latest_adopted_release_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/latest_adopted_release_handler.py
@@ -10,7 +10,7 @@ from sentry.rules.filters.latest_adopted_release_filter import (
 )
 from sentry.search.utils import LatestReleaseOrders
 from sentry.workflow_engine.handlers.condition.latest_release_handler import (
-    get_latest_release_for_env,
+    get_latest_adopted_release_for_env,
 )
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.registry import condition_handler_registry
@@ -56,7 +56,7 @@ class LatestAdoptedReleaseConditionHandler(DataConditionHandler[WorkflowEventDat
         except Environment.DoesNotExist:
             return False
 
-        latest_project_release = get_latest_release_for_env(environment, event)
+        latest_project_release = get_latest_adopted_release_for_env(environment, event)
         if not latest_project_release:
             return False
 

--- a/src/sentry/workflow_engine/handlers/condition/latest_release_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/latest_release_handler.py
@@ -5,7 +5,12 @@ from sentry import tagstore
 from sentry.eventstore.models import GroupEvent
 from sentry.models.environment import Environment
 from sentry.models.release import Release
-from sentry.rules.filters.latest_release import get_project_release_cache_key
+from sentry.rules.filters.latest_adopted_release_filter import (
+    get_project_release_cache_key as latest_adopted_release_cache_key,
+)
+from sentry.rules.filters.latest_release import (
+    get_project_release_cache_key as latest_release_cache_key,
+)
 from sentry.search.utils import get_latest_release
 from sentry.utils import metrics
 from sentry.utils.cache import cache
@@ -37,7 +42,7 @@ class _LatestReleaseCacheAccess(CacheAccess[Release | Literal[False]]):
     """
 
     def __init__(self, event: GroupEvent, environment: Environment | None):
-        self._key = get_project_release_cache_key(
+        self._key = latest_release_cache_key(
             event.group.project_id, environment.id if environment else None
         )
 
@@ -45,10 +50,55 @@ class _LatestReleaseCacheAccess(CacheAccess[Release | Literal[False]]):
         return self._key
 
 
-def get_latest_release_for_env(
-    environment: Environment | None, event: GroupEvent
+class _LatestAdoptedReleaseCacheAccess(CacheAccess[Release | Literal[False]]):
+    """
+    If we have a latest adopted release for a project in an environment, we cache it.
+    If we don't, we cache False.
+    """
+
+    def __init__(self, event: GroupEvent, environment: Environment):
+        self._key = latest_adopted_release_cache_key(event.group.project_id, environment.id)
+
+    def key(self) -> str:
+        return self._key
+
+
+def get_latest_adopted_release_for_env(
+    environment: Environment, event: GroupEvent
 ) -> Release | None:
-    cache_access = _LatestReleaseCacheAccess(event, environment)
+    """
+    Get the latest adopted release for a project in an environment.
+    """
+    return _get_latest_release_for_env_impl(
+        environment,
+        event,
+        only_adopted=True,
+        cache_access=_LatestAdoptedReleaseCacheAccess(event, environment),
+    )
+
+
+def get_latest_release_for_env(
+    environment: Environment | None,
+    event: GroupEvent,
+) -> Release | None:
+    """
+    Get the latest release for a project in an environment.
+    NOTE: This is independent of whether it has been adopted or not.
+    """
+    return _get_latest_release_for_env_impl(
+        environment,
+        event,
+        only_adopted=False,
+        cache_access=_LatestReleaseCacheAccess(event, environment),
+    )
+
+
+def _get_latest_release_for_env_impl(
+    environment: Environment | None,
+    event: GroupEvent,
+    only_adopted: bool,
+    cache_access: CacheAccess[Release | Literal[False]],
+) -> Release | None:
     latest_release = cache_access.get()
     if latest_release is not None:
         if latest_release is False:
@@ -64,6 +114,7 @@ def get_latest_release_for_env(
             tags={
                 "has_environment": str(environment is not None),
                 "result": result,
+                "only_adopted": str(only_adopted),
             },
         )
 
@@ -72,6 +123,7 @@ def get_latest_release_for_env(
             [event.group.project],
             environments,
             organization_id,
+            adopted=only_adopted,
         )[0]
         record_get_latest_release_result("success")
     except Release.DoesNotExist:

--- a/tests/sentry/workflow_engine/handlers/condition/test_latest_adopted_release_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_latest_adopted_release_handler.py
@@ -258,13 +258,14 @@ class TestLatestAdoptedReleaseCondition(ConditionTestCase):
         self.assert_does_not_pass(self.dc, self.event_data)
 
     @patch(
-        "sentry.workflow_engine.handlers.condition.latest_release_handler.get_latest_release_for_env",
+        "sentry.workflow_engine.handlers.condition.latest_adopted_release_handler.get_latest_adopted_release_for_env",
         return_value=None,
     )
     def test_latest_release_for_env_does_not_exist(
-        self, mock_get_latest_release_for_env: MagicMock
+        self, mock_get_latest_adopted_release_for_env: MagicMock
     ) -> None:
         self.assert_does_not_pass(self.dc, self.event_data)
+        mock_get_latest_adopted_release_for_env.assert_called()
 
     @patch(
         "sentry.workflow_engine.handlers.condition.latest_adopted_release_handler.get_first_last_release_for_event",

--- a/tests/sentry/workflow_engine/handlers/condition/test_latest_adopted_release_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_latest_adopted_release_handler.py
@@ -282,3 +282,32 @@ class TestLatestAdoptedReleaseCondition(ConditionTestCase):
     )
     def test_environment_does_not_exist(self, mock_get_env: MagicMock) -> None:
         self.assert_does_not_pass(self.dc, self.event_data)
+
+    def test_ignores_unadopted_releases(self) -> None:
+        # Create unadopted release (newer) - should be ignored when finding newest adopted release
+        self.create_release(
+            project=self.project,
+            version="test@3.0",
+            date_added=self.now + timedelta(hours=1),
+            environments=[self.prod_env],
+            adopted=None,
+        )
+
+        # Condition: Is newest adopted release older than group's release?
+        dc = self.create_data_condition(
+            type=self.condition,
+            comparison={
+                "release_age_type": "newest",
+                "age_comparison": "older",
+                "environment": self.prod_env.name,
+            },
+            condition_result=True,
+        )
+
+        # Group has middle_release
+        group, group_event = self.create_new_group_event("test")
+        self.create_group_release(group=group, release=self.middle_release)
+
+        # Should NOT pass: newest adopted (middle_release) is NOT older than group's (middle_release)
+        # Would fail if test@3.0 (unadopted) was considered as newest, since 3.0 > 1.5
+        self.assert_does_not_pass(dc, WorkflowEventData(event=group_event, group=group))


### PR DESCRIPTION
Making the distinction between adopted and not resolves an inconsistency with the existing implementation.
