### PR TITLE
feat(Codecov): expand codecov context to save repos/branches per org

### DIFF
--- a/static/app/components/codecov/branchSelector/branchSelector.tsx
+++ b/static/app/components/codecov/branchSelector/branchSelector.tsx
@@ -17,7 +17,8 @@ import {IconBranch} from './iconBranch';
 export const ALL_BRANCHES = 'All Branches';
 
 export function BranchSelector() {
-  const {branch, integratedOrgId, repository, changeContextValue} = useCodecovContext();
+  const {branch, integratedOrgId, repository, codecovPeriod, changeContextValue} =
+    useCodecovContext();
   const [searchValue, setSearchValue] = useState<string | undefined>();
   const {data} = useInfiniteRepositoryBranches({term: searchValue});
   const branches = data.branches;
@@ -25,9 +26,14 @@ export function BranchSelector() {
 
   const handleChange = useCallback(
     (selectedOption: SelectOption<string>) => {
-      changeContextValue({integratedOrgId, repository, branch: selectedOption.value});
+      changeContextValue({
+        integratedOrgId,
+        repository,
+        codecovPeriod,
+        branch: selectedOption.value,
+      });
     },
-    [changeContextValue, integratedOrgId, repository]
+    [changeContextValue, integratedOrgId, repository, codecovPeriod]
   );
 
   const handleOnSearch = useMemo(

--- a/static/app/components/codecov/branchSelector/branchSelector.tsx
+++ b/static/app/components/codecov/branchSelector/branchSelector.tsx
@@ -17,7 +17,7 @@ import {IconBranch} from './iconBranch';
 export const ALL_BRANCHES = 'All Branches';
 
 export function BranchSelector() {
-  const {branch, repository, changeContextValue} = useCodecovContext();
+  const {branch, integratedOrgId, repository, changeContextValue} = useCodecovContext();
   const [searchValue, setSearchValue] = useState<string | undefined>();
   const {data} = useInfiniteRepositoryBranches({term: searchValue});
   const branches = data.branches;
@@ -25,9 +25,9 @@ export function BranchSelector() {
 
   const handleChange = useCallback(
     (selectedOption: SelectOption<string>) => {
-      changeContextValue({branch: selectedOption.value});
+      changeContextValue({integratedOrgId, repository, branch: selectedOption.value});
     },
-    [changeContextValue]
+    [changeContextValue, integratedOrgId, repository]
   );
 
   const handleOnSearch = useMemo(

--- a/static/app/components/codecov/container/codecovParamsProvider.tsx
+++ b/static/app/components/codecov/container/codecovParamsProvider.tsx
@@ -65,9 +65,7 @@ export default function CodecovQueryParamsProvider({
 
   const changeContextValue = useCallback(
     (input: Partial<CodecovContextDataParams>) => {
-      const currentParams = Object.fromEntries(
-        new URLSearchParams(window.location.search).entries()
-      );
+      const currentParams = Object.fromEntries(searchParams.entries());
       const integratedOrgId = input.integratedOrgId;
 
       setLocalStorageState((prev: LocalStorageState) => {
@@ -101,7 +99,7 @@ export default function CodecovQueryParamsProvider({
 
       setSearchParams(updatedParams);
     },
-    [setLocalStorageState, setSearchParams]
+    [searchParams, setLocalStorageState, setSearchParams]
   );
 
   const {integratedOrgId, repository, branch, codecovPeriod} = _defineParams();

--- a/static/app/components/codecov/container/codecovParamsProvider.tsx
+++ b/static/app/components/codecov/container/codecovParamsProvider.tsx
@@ -79,11 +79,11 @@ export default function CodecovQueryParamsProvider({
 
         if (input.repository) {
           const orgId = input.integratedOrgId;
-          const repository = input.repository;
-          const branch = input.branch ? input.branch : ALL_BRANCHES;
 
           if (orgId) {
-            newState[orgId] = {repository, branch};
+            const branch = input.branch ? input.branch : ALL_BRANCHES;
+            newState[orgId] = {repository: input.repository, branch};
+            newState.lastVisitedOrgId = orgId;
           }
         }
 

--- a/static/app/components/codecov/container/codecovParamsProvider.tsx
+++ b/static/app/components/codecov/container/codecovParamsProvider.tsx
@@ -65,16 +65,18 @@ export default function CodecovQueryParamsProvider({
 
   const changeContextValue = useCallback(
     (input: Partial<CodecovContextDataParams>) => {
-      const currentParams = Object.fromEntries(searchParams.entries());
+      const currentParams = Object.fromEntries(
+        new URLSearchParams(window.location.search).entries()
+      );
       const integratedOrgId = input.integratedOrgId;
 
-      if (integratedOrgId && !localStorageState[integratedOrgId]) {
-        VALUES_TO_RESET.forEach(key => {
-          delete currentParams[key];
-        });
-      }
-
       setLocalStorageState((prev: LocalStorageState) => {
+        if (integratedOrgId && !prev[integratedOrgId]) {
+          VALUES_TO_RESET.forEach(key => {
+            delete currentParams[key];
+          });
+        }
+
         const newState = {...prev};
 
         if (input.repository) {
@@ -99,7 +101,7 @@ export default function CodecovQueryParamsProvider({
 
       setSearchParams(updatedParams);
     },
-    [localStorageState, setLocalStorageState, setSearchParams, searchParams]
+    [setLocalStorageState, setSearchParams]
   );
 
   const {integratedOrgId, repository, branch, codecovPeriod} = _defineParams();

--- a/static/app/components/codecov/container/codecovParamsProvider.tsx
+++ b/static/app/components/codecov/container/codecovParamsProvider.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect} from 'react';
+import {useCallback} from 'react';
 import {useSearchParams} from 'react-router-dom';
 
 import {ALL_BRANCHES} from 'sentry/components/codecov/branchSelector/branchSelector';
@@ -7,7 +7,6 @@ import type {
   CodecovContextDataParams,
 } from 'sentry/components/codecov/context/codecovContext';
 import {CodecovContext} from 'sentry/components/codecov/context/codecovContext';
-import type {CodecovPeriodOptions} from 'sentry/components/codecov/dateSelector/dateSelector';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -15,93 +14,95 @@ type CodecovQueryParamsProviderProps = {
   children?: NonNullable<React.ReactNode>;
 };
 
-const VALUES_TO_RESET_MAP = {
-  integratedOrgId: ['repository', 'branch', 'testSuites'],
-  repository: ['branch', 'testSuites'],
-  branch: [],
-  codecovPeriod: [],
+type Org = {
+  branch: string | null;
+  repository: string;
 };
+
+type LocalStorageState = Record<string, Org> & {
+  codecovPeriod?: string;
+  lastVisitedOrgId?: string;
+};
+
+const VALUES_TO_RESET = ['repository', 'branch', 'testSuites'];
 
 export default function CodecovQueryParamsProvider({
   children,
 }: CodecovQueryParamsProviderProps) {
   const organization = useOrganization();
-  const [searchParams, setSearchParams] = useSearchParams();
+  const initialLocalStorageState: LocalStorageState = {};
   const [localStorageState, setLocalStorageState] = useLocalStorageState(
     `codecov-selection:${organization.slug}`,
-    {}
+    initialLocalStorageState
   );
 
-  function _defineParam(key: string, defaultValue?: string | CodecovPeriodOptions) {
-    const queryValue = searchParams.get(key);
+  const [searchParams, setSearchParams] = useSearchParams();
 
-    if (queryValue) {
-      return decodeURIComponent(queryValue);
-    }
+  function _defineParams(): CodecovContextDataParams {
+    const currentParams = Object.fromEntries(searchParams.entries());
 
-    if (key in localStorageState) {
-      return (localStorageState as Record<string, string>)[key];
-    }
+    const localStorageLastVisitedOrgId = localStorageState?.lastVisitedOrgId;
+    const integratedOrgId =
+      currentParams?.integratedOrgId || localStorageLastVisitedOrgId || undefined;
+    const repository =
+      (integratedOrgId ? localStorageState?.[integratedOrgId]?.repository : null) ||
+      currentParams?.repository ||
+      undefined;
+    const branch =
+      (integratedOrgId ? localStorageState?.[integratedOrgId]?.branch : null) ||
+      currentParams?.branch ||
+      'All Branches';
+    const codecovPeriod =
+      currentParams?.codecovPeriod || localStorageState.codecovPeriod || '24h';
 
-    if (defaultValue) {
-      return defaultValue;
-    }
-
-    return undefined;
+    return {
+      integratedOrgId,
+      repository,
+      branch,
+      codecovPeriod,
+    };
   }
 
   const changeContextValue = useCallback(
-    (value: Partial<CodecovContextDataParams>) => {
+    (input: Partial<CodecovContextDataParams>) => {
       const currentParams = Object.fromEntries(searchParams.entries());
-      const valueKey = Object.keys(value)[0] as keyof typeof value;
-      const valuesToReset = VALUES_TO_RESET_MAP[valueKey];
+      const integratedOrgId = input.integratedOrgId;
 
-      valuesToReset.forEach(key => {
-        delete currentParams[key];
-      });
-
-      setLocalStorageState((prev: Partial<CodecovContextDataParams>) => {
-        const newState = {...prev};
-        valuesToReset.forEach(key => {
-          delete newState[key as keyof CodecovContextDataParams];
+      if (integratedOrgId && !localStorageState[integratedOrgId]) {
+        VALUES_TO_RESET.forEach(key => {
+          delete currentParams[key];
         });
+      }
+
+      setLocalStorageState((prev: LocalStorageState) => {
+        const newState = {...prev};
+
+        if (input.repository) {
+          const orgId = input.integratedOrgId;
+          const repository = input.repository;
+          const branch = input.branch ? input.branch : ALL_BRANCHES;
+
+          if (orgId) {
+            newState[orgId] = {repository, branch};
+          }
+        }
+
+        newState.codecovPeriod = input.codecovPeriod ? input.codecovPeriod : '24h';
+
         return newState;
       });
 
       const updatedParams = {
         ...currentParams,
-        ...value,
+        ...input,
       };
 
       setSearchParams(updatedParams);
     },
-    [searchParams, setLocalStorageState, setSearchParams]
+    [localStorageState, setLocalStorageState, setSearchParams, searchParams]
   );
 
-  useEffect(() => {
-    const entries = {
-      repository: searchParams.get('repository'),
-      integratedOrgId: searchParams.get('integratedOrgId'),
-      branch: searchParams.get('branch'),
-      codecovPeriod: searchParams.get('codecovPeriod'),
-    };
-
-    for (const [key, value] of Object.entries(entries)) {
-      if (!value) {
-        delete entries[key as keyof typeof entries];
-      }
-    }
-
-    setLocalStorageState(prev => ({
-      ...prev,
-      ...entries,
-    }));
-  }, [setLocalStorageState, searchParams]);
-
-  const repository = _defineParam('repository');
-  const integratedOrgId = _defineParam('integratedOrgId');
-  const branch = _defineParam('branch', ALL_BRANCHES);
-  const codecovPeriod = _defineParam('codecovPeriod', '24h') as CodecovPeriodOptions;
+  const {integratedOrgId, repository, branch, codecovPeriod} = _defineParams();
 
   const params: CodecovContextData = {
     ...(repository ? {repository} : {}),

--- a/static/app/components/codecov/context/codecovContext.tsx
+++ b/static/app/components/codecov/context/codecovContext.tsx
@@ -5,10 +5,14 @@ export type CodecovContextData = {
   codecovPeriod: string;
   branch?: string;
   integratedOrgId?: string;
+  lastVisitedOrgId?: string;
   repository?: string;
 };
 
-export type CodecovContextDataParams = Omit<CodecovContextData, 'changeContextValue'>;
+export type CodecovContextDataParams = Omit<
+  CodecovContextData,
+  'changeContextValue' | 'lastVisitedOrgId'
+>;
 
 export const CodecovContext = createContext<CodecovContextData | undefined>(undefined);
 

--- a/static/app/components/codecov/integratedOrgSelector/integratedOrgSelector.tsx
+++ b/static/app/components/codecov/integratedOrgSelector/integratedOrgSelector.tsx
@@ -52,7 +52,7 @@ function OrgFooterMessage() {
 }
 
 export function IntegratedOrgSelector() {
-  const {integratedOrgId, changeContextValue} = useCodecovContext();
+  const {integratedOrgId, codecovPeriod, changeContextValue} = useCodecovContext();
   const organization = useOrganization();
 
   const {data: integrations = []} = useApiQuery<Integration[]>(
@@ -65,9 +65,9 @@ export function IntegratedOrgSelector() {
 
   const handleChange = useCallback(
     (selectedOption: SelectOption<string>) => {
-      changeContextValue({integratedOrgId: selectedOption.value});
+      changeContextValue({codecovPeriod, integratedOrgId: selectedOption.value});
     },
-    [changeContextValue]
+    [changeContextValue, codecovPeriod]
   );
 
   const options = useMemo((): Array<SelectOption<string>> => {

--- a/static/app/components/codecov/repoSelector/repoSelector.tsx
+++ b/static/app/components/codecov/repoSelector/repoSelector.tsx
@@ -63,9 +63,9 @@ export function RepoSelector() {
 
   const handleChange = useCallback(
     (selectedOption: SelectOption<string>) => {
-      changeContextValue({repository: selectedOption.value});
+      changeContextValue({integratedOrgId, repository: selectedOption.value});
     },
-    [changeContextValue]
+    [changeContextValue, integratedOrgId]
   );
 
   const handleOnSearch = useMemo(

--- a/static/app/components/codecov/repoSelector/repoSelector.tsx
+++ b/static/app/components/codecov/repoSelector/repoSelector.tsx
@@ -55,7 +55,8 @@ function MenuFooter({repoAccessLink}: MenuFooterProps) {
 }
 
 export function RepoSelector() {
-  const {repository, integratedOrgId, changeContextValue} = useCodecovContext();
+  const {repository, integratedOrgId, codecovPeriod, changeContextValue} =
+    useCodecovContext();
   const [searchValue, setSearchValue] = useState<string | undefined>();
   const {data: repositories} = useInfiniteRepositories({term: searchValue});
 
@@ -63,9 +64,13 @@ export function RepoSelector() {
 
   const handleChange = useCallback(
     (selectedOption: SelectOption<string>) => {
-      changeContextValue({integratedOrgId, repository: selectedOption.value});
+      changeContextValue({
+        integratedOrgId,
+        codecovPeriod,
+        repository: selectedOption.value,
+      });
     },
-    [changeContextValue, integratedOrgId]
+    [changeContextValue, integratedOrgId, codecovPeriod]
   );
 
   const handleOnSearch = useMemo(


### PR DESCRIPTION
This PR expands the codecov context to save data on an integrated org basis rather than a flat 1 org/repo/branch. This allows us to save datasets per org, creating a nicer UX for the customer. Video illustrates the change of integrated orgs within the same Sentry organization - don't focus on the data brought back, just on the selectors.

Closes https://linear.app/getsentry/issue/CCMRG-1427/select-last-visited-by-default

https://github.com/user-attachments/assets/981d1b4f-8171-4a52-a6c4-a6ffb2b02cde

Notes
- 
- Adjusted the CodecovContext to allow a lastVisitedIntegratedOrg field
- Adjusted the CodecovProvider to adhere to the new changes and surface appropriate values based on the integrated org id
- Adjusted selectors to pass org Id, repo and branch when necessary