### PR TITLE
fix(aci): fix delayed workflow after evaluating all fast conditions first

### DIFF
--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -775,9 +775,9 @@ def repr_keys[T, V](d: dict[T, V]) -> dict[str, V]:
     return {repr(key): value for key, value in d.items()}
 
 
-def _summarize_by_first[
-    T1, T2: int | str
-](it: Iterable[tuple[T1, T2]],) -> dict[T1, list[T2]]:
+def _summarize_by_first[T1, T2: int | str](
+    it: Iterable[tuple[T1, T2]],
+) -> dict[T1, list[T2]]:
     "Logging helper to allow pairs to be summarized as a mapping from first to list of second"
     result = defaultdict(set)
     for key, value in it:

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -232,7 +232,7 @@ class EventRedisData:
 
         for key, instance in self.events.items():
             timestamp = instance.timestamp
-            for dcg_id in self.dcg_ids:
+            for dcg_id in key.dcg_ids:
                 existing_timestamp = result[dcg_id]
                 if timestamp is None:
                     continue

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -199,7 +199,7 @@ class EventRedisData:
         """Get mapping of DCG IDs to workflow IDs, combining both trigger and action filter groups."""
         dcg_to_workflow = {}
         for key in self.events:
-            for dcg_id in self.dcg_ids:
+            for dcg_id in key.dcg_ids:
                 dcg_to_workflow[dcg_id] = key.workflow_id
 
         return dcg_to_workflow

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -137,6 +137,13 @@ class EventKey:
             return NotImplemented
         return self.original_key == other.original_key
 
+    @cached_property
+    def dcg_ids(self) -> set[DataConditionGroupId]:
+        ids = {self.when_dcg_id} if self.when_dcg_id else set()
+        ids.update(id for id in self.if_dcg_ids)
+        ids.update(id for id in self.passing_dcg_ids)
+        return ids
+
 
 @dataclass(frozen=True)
 class EventRedisData:
@@ -170,19 +177,13 @@ class EventRedisData:
 
     @cached_property
     def dcg_ids(self) -> set[DataConditionGroupId]:
-        ids = {key.when_dcg_id for key in self.events if key.when_dcg_id}
-        ids.update(dcg_id for key in self.events for dcg_id in key.if_dcg_ids)
-        ids.update(dcg_id for key in self.events for dcg_id in key.passing_dcg_ids)
-        return ids
+        return {id for key in self.events for id in key.dcg_ids}
 
     @cached_property
     def dcg_to_groups(self) -> Mapping[DataConditionGroupId, set[GroupId]]:
         dcg_to_groups: dict[DataConditionGroupId, set[GroupId]] = defaultdict(set)
         for key in self.events:
-            key_dcg_ids = set(key.if_dcg_ids)
-            if key.when_dcg_id:
-                key_dcg_ids.add(key.when_dcg_id)
-            for dcg_id in key_dcg_ids:
+            for dcg_id in key.dcg_ids:
                 dcg_to_groups[dcg_id].add(key.group_id)
         return dcg_to_groups
 
@@ -492,6 +493,29 @@ class MissingQueryResult(Exception):
         self.query_result = query_result
 
 
+def _evaluate_group_result_for_dcg(
+    dcg_id: int,
+    data_condition_group_mapping: dict[int, DataConditionGroup],
+    dcg_to_slow_conditions: dict[DataConditionGroupId, list[DataCondition]],
+    event_key: EventKey,
+    workflow_env: int | None,
+    condition_group_results: dict[UniqueConditionQuery, QueryResult],
+) -> bool:
+    result = False
+    dcg = data_condition_group_mapping[dcg_id]
+    when_slow_conditions = dcg_to_slow_conditions[dcg_id]
+    group_id = event_key.group_id
+    try:
+        result = _group_result_for_dcg(
+            group_id, dcg, workflow_env, condition_group_results, when_slow_conditions
+        )
+    except MissingQueryResult:
+        # If we didn't get complete query results, don't fire.
+        metrics.incr("workflow_engine.delayed_workflow.missing_query_result")
+        logger.warning("workflow_engine.delayed_workflow.missing_query_result", exc_info=True)
+    return result
+
+
 def _group_result_for_dcg(
     group_id: GroupId,
     dcg: DataConditionGroup,
@@ -529,38 +553,30 @@ def get_groups_to_fire(
         workflow_env = workflows_to_envs[event_key.workflow_id]
         result = False
         if when_dcg_id := event_key.when_dcg_id:
-            when_dcg = data_condition_group_mapping[when_dcg_id]
-            when_slow_conditions = dcg_to_slow_conditions[when_dcg_id]
-            group_id = event_key.group_id
-            try:
-                result = _group_result_for_dcg(
-                    group_id, when_dcg, workflow_env, condition_group_results, when_slow_conditions
-                )
-            except MissingQueryResult:
-                # If we didn't get complete query results, don't fire.
-                metrics.incr("workflow_engine.delayed_workflow.missing_query_result")
-                logger.warning(
-                    "workflow_engine.delayed_workflow.missing_query_result", exc_info=True
-                )
+            result = _evaluate_group_result_for_dcg(
+                when_dcg_id,
+                data_condition_group_mapping,
+                dcg_to_slow_conditions,
+                event_key,
+                workflow_env,
+                condition_group_results,
+            )
         if when_dcg_id and not result:
             continue
 
         # the WHEN condition passed / was not evaluated, so we can now check the IF conditions
+        group_id = event_key.group_id
         for if_dcg_id in event_key.if_dcg_ids:
-            if_dcg = data_condition_group_mapping[if_dcg_id]
-            if_slow_conditions = dcg_to_slow_conditions[if_dcg_id]
-            try:
-                result = _group_result_for_dcg(
-                    group_id, if_dcg, workflow_env, condition_group_results, if_slow_conditions
-                )
-                if result:
-                    groups_to_fire[group_id].add(if_dcg)
-            except MissingQueryResult:
-                # If we didn't get complete query results, don't fire.
-                metrics.incr("workflow_engine.delayed_workflow.missing_query_result")
-                logger.warning(
-                    "workflow_engine.delayed_workflow.missing_query_result", exc_info=True
-                )
+            result = _evaluate_group_result_for_dcg(
+                if_dcg_id,
+                data_condition_group_mapping,
+                dcg_to_slow_conditions,
+                event_key,
+                workflow_env,
+                condition_group_results,
+            )
+            if result:
+                groups_to_fire[group_id].add(data_condition_group_mapping[if_dcg_id])
 
         for if_dcg_id in event_key.passing_dcg_ids:
             if_dcg = data_condition_group_mapping[if_dcg_id]
@@ -623,8 +639,7 @@ def get_group_to_groupevent(
 
     group_to_groupevent: dict[Group, GroupEvent] = {}
     for key, instance in event_data.events.items():
-        key_dcgs = {key.when_dcg_id}.union(key.if_dcg_ids)
-        if key_dcgs.intersection(groups_to_dcg_ids.get(key.group_id, set())):
+        if key.dcg_ids.intersection(groups_to_dcg_ids.get(key.group_id, set())):
             event = bulk_event_id_to_events.get(instance.event_id)
             group = group_id_to_group.get(key.group_id)
 

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -61,9 +61,8 @@ from sentry.workflow_engine.processors.log_util import track_batch_performance
 from sentry.workflow_engine.processors.workflow import WORKFLOW_ENGINE_BUFFER_LIST_KEY
 from sentry.workflow_engine.processors.workflow_fire_history import create_workflow_fire_histories
 from sentry.workflow_engine.tasks.actions import build_trigger_action_task_params, trigger_action
-from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
 from sentry.workflow_engine.tasks.utils import retry_timeouts
-from sentry.workflow_engine.types import WorkflowEventData
+from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
 from sentry.workflow_engine.utils import log_context
 
 logger = log_context.get_logger("sentry.workflow_engine.processors.delayed_workflow")

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -61,8 +61,7 @@ from sentry.workflow_engine.processors.log_util import track_batch_performance
 from sentry.workflow_engine.processors.workflow import WORKFLOW_ENGINE_BUFFER_LIST_KEY
 from sentry.workflow_engine.processors.workflow_fire_history import create_workflow_fire_histories
 from sentry.workflow_engine.tasks.actions import build_trigger_action_task_params, trigger_action
-from sentry.workflow_engine.tasks.utils import retry_timeouts
-from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
+from sentry.workflow_engine.types import WorkflowEventData
 from sentry.workflow_engine.utils import log_context
 
 logger = log_context.get_logger("sentry.workflow_engine.processors.delayed_workflow")
@@ -776,9 +775,9 @@ def repr_keys[T, V](d: dict[T, V]) -> dict[str, V]:
     return {repr(key): value for key, value in d.items()}
 
 
-def _summarize_by_first[T1, T2: int | str](
-    it: Iterable[tuple[T1, T2]],
-) -> dict[T1, list[T2]]:
+def _summarize_by_first[
+    T1, T2: int | str
+](it: Iterable[tuple[T1, T2]],) -> dict[T1, list[T2]]:
     "Logging helper to allow pairs to be summarized as a mapping from first to list of second"
     result = defaultdict(set)
     for key, value in it:

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -1,4 +1,3 @@
-from collections.abc import Collection, Mapping
 from dataclasses import asdict, dataclass, replace
 from datetime import datetime
 from enum import StrEnum
@@ -14,13 +13,7 @@ from sentry.eventstore.models import GroupEvent
 from sentry.models.activity import Activity
 from sentry.models.environment import Environment
 from sentry.utils import json
-from sentry.workflow_engine.models import (
-    Action,
-    DataCondition,
-    DataConditionGroup,
-    Detector,
-    Workflow,
-)
+from sentry.workflow_engine.models import Action, DataConditionGroup, Detector, Workflow
 from sentry.workflow_engine.models.workflow_data_condition_group import WorkflowDataConditionGroup
 from sentry.workflow_engine.processors.action import filter_recently_fired_workflow_actions
 from sentry.workflow_engine.processors.contexts.workflow_event_context import (
@@ -39,6 +32,7 @@ logger = log_context.get_logger(__name__)
 
 WORKFLOW_ENGINE_BUFFER_LIST_KEY = "workflow_engine_delayed_processing_buffer"
 DetectorId = int | None
+DataConditionGroupId = int
 
 
 class WorkflowDataConditionGroupType(StrEnum):
@@ -72,25 +66,25 @@ def delete_workflow(workflow: Workflow) -> bool:
     return True
 
 
-@dataclass(frozen=True)
+@dataclass
 class DelayedWorkflowItem:
     workflow: Workflow
-    delayed_conditions: list[DataCondition]
     event: GroupEvent
-    source: WorkflowDataConditionGroupType
+    delayed_when_group_id: DataConditionGroupId | None
+    delayed_if_group_ids: list[DataConditionGroupId]
+    passing_if_group_ids: list[DataConditionGroupId]
 
     # Used to pick the end of the time window in snuba querying.
     # Should be close to when fast conditions were evaluated to try to be consistent.
     timestamp: datetime
 
     def buffer_key(self) -> str:
-        condition_group_set = {
-            condition.condition_group_id for condition in self.delayed_conditions
-        }
-        condition_groups = ",".join(
-            str(condition_group_id) for condition_group_id in sorted(condition_group_set)
+        when_condition_group_str = (
+            str(self.delayed_when_group_id) if self.delayed_when_group_id else ""
         )
-        return f"{self.workflow.id}:{self.event.group.id}:{condition_groups}:{self.source}"
+        if_condition_groups = ",".join(str(id) for id in sorted(self.delayed_if_group_ids))
+        passing_if_groups = ",".join(str(id) for id in sorted(self.passing_if_group_ids))
+        return f"{self.workflow.id}:{self.event.group.id}:{when_condition_group_str}:{if_condition_groups}:{passing_if_groups}"
 
     def buffer_value(self) -> str:
         return json.dumps(
@@ -103,10 +97,20 @@ class DelayedWorkflowItem:
 
 
 def enqueue_workflows(
-    items_by_project_id: Mapping[int, Collection[DelayedWorkflowItem]],
+    items_by_workflow: dict[Workflow, DelayedWorkflowItem],
 ) -> None:
+    items_by_project_id = DefaultDict[int, list[DelayedWorkflowItem]](list)
+    for queue_item in items_by_workflow.values():
+        if not queue_item.delayed_if_group_ids and not queue_item.passing_if_group_ids:
+            # Skip because there are no IF groups we could possibly fire actions for if
+            # the WHEN/IF delayed condtions are met
+            continue
+        project_id = queue_item.event.project_id
+        items_by_project_id[project_id].append(queue_item)
+
     if not items_by_project_id:
         return
+
     for project_id, queue_items in items_by_project_id.items():
         buffer.backend.push_to_hash_bulk(
             model=Workflow,
@@ -122,9 +126,16 @@ def enqueue_workflows(
 @sentry_sdk.trace
 def evaluate_workflow_triggers(
     workflows: set[Workflow], event_data: WorkflowEventData
-) -> set[Workflow]:
+) -> tuple[set[Workflow], dict[Workflow, DelayedWorkflowItem]]:
+    """
+    Returns a tuple of (triggered_workflows, queue_items_by_workflow)
+    - triggered_workflows: set of workflows that were triggered
+    - queue_items_by_workflow: mapping of workflow to the delayed workflow item, used
+      in the next step (evaluate action filters) to enqueue workflows with slow conditions
+      within that function
+    """
     triggered_workflows: set[Workflow] = set()
-    queue_items_by_project_id = DefaultDict[int, list[DelayedWorkflowItem]](list)
+    queue_items_by_workflow: dict[Workflow, DelayedWorkflowItem] = {}
     current_time = timezone.now()
 
     for workflow in workflows:
@@ -132,14 +143,13 @@ def evaluate_workflow_triggers(
 
         if remaining_conditions:
             if isinstance(event_data.event, GroupEvent):
-                queue_items_by_project_id[event_data.event.group.project_id].append(
-                    DelayedWorkflowItem(
-                        workflow,
-                        remaining_conditions,
-                        event_data.event,
-                        WorkflowDataConditionGroupType.WORKFLOW_TRIGGER,
-                        timestamp=current_time,
-                    )
+                queue_items_by_workflow[workflow] = DelayedWorkflowItem(
+                    workflow=workflow,
+                    event=event_data.event,
+                    delayed_when_group_id=workflow.when_condition_group_id,
+                    delayed_if_group_ids=[],
+                    passing_if_group_ids=[],
+                    timestamp=current_time,
                 )
             else:
                 """
@@ -159,8 +169,6 @@ def evaluate_workflow_triggers(
             if evaluation:
                 triggered_workflows.add(workflow)
 
-    enqueue_workflows(queue_items_by_project_id)
-
     metrics_incr(
         "process_workflows.triggered_workflows",
         len(triggered_workflows),
@@ -172,7 +180,7 @@ def evaluate_workflow_triggers(
         try:
             environment = get_environment_by_event(event_data)
         except Environment.DoesNotExist:
-            return set()
+            return set(), {}
 
     event_id = (
         event_data.event.event_id
@@ -190,25 +198,35 @@ def evaluate_workflow_triggers(
         },
     )
 
-    return triggered_workflows
+    return triggered_workflows, queue_items_by_workflow
 
 
-def evaluate_action_filters(
+@sentry_sdk.trace
+def evaluate_workflows_action_filters(
+    workflows: set[Workflow],
     event_data: WorkflowEventData,
-    dcg_to_workflow: dict[DataConditionGroup, Workflow],
-) -> set[DataConditionGroup]:
+    queue_items_by_workflow: dict[Workflow, DelayedWorkflowItem],
+) -> tuple[set[DataConditionGroup], dict[Workflow, DelayedWorkflowItem]]:
     """
-    Evaluate the action filters for the given mapping of DataConditionGroup to Workflow. (dcg_to_workflow_id)
+    Evaluate the action filters for the given workflows.
     Returns a set of DataConditionGroups that were evaluated to True.
-
-    Use this function if you are repeatedly evaluating action filters in a loop --
-    query for all the DataConditionGroups in a single query before using this function to avoid N+1s queries.
+    Enqueues workflows with slow conditions to be evaluated in a batched task.
     """
+    # Collect all workflows, including those with pending slow condition results (queue_items_by_workflow)
+    # to evaluate all fast conditions
+    all_workflows = workflows.union(set(queue_items_by_workflow.keys()))
+
+    action_conditions_to_workflow = {
+        wdcg.condition_group: wdcg.workflow
+        for wdcg in WorkflowDataConditionGroup.objects.select_related(
+            "workflow", "condition_group"
+        ).filter(workflow__in=all_workflows)
+    }
+
     filtered_action_groups: set[DataConditionGroup] = set()
-    queue_items_by_project_id = DefaultDict[int, list[DelayedWorkflowItem]](list)
     current_time = timezone.now()
 
-    for action_condition, workflow in dcg_to_workflow.items():
+    for action_condition, workflow in action_conditions_to_workflow.items():
         env = (
             Environment.objects.get_from_cache(id=workflow.environment_id)
             if workflow.environment_id
@@ -224,16 +242,17 @@ def evaluate_action_filters(
             # then return the list of conditions to enqueue.
 
             if isinstance(event_data.event, GroupEvent):
-                # `delayed_workflows` only supports group events
-                queue_items_by_project_id[event_data.event.group.project_id].append(
-                    DelayedWorkflowItem(
-                        workflow,
-                        slow_conditions,
-                        event_data.event,
-                        WorkflowDataConditionGroupType.ACTION_FILTER,
+                if delayed_workflow_item := queue_items_by_workflow.get(workflow):
+                    delayed_workflow_item.delayed_if_group_ids.append(action_condition.id)
+                else:
+                    queue_items_by_workflow[workflow] = DelayedWorkflowItem(
+                        workflow=workflow,
+                        delayed_when_group_id=None,
+                        delayed_if_group_ids=[action_condition.id],
+                        event=event_data.event,
+                        passing_if_group_ids=[],
                         timestamp=current_time,
                     )
-                )
             else:
                 # We should not include activity updates in delayed conditions,
                 # this is because the actions should always be triggered if this condition is met.
@@ -249,9 +268,13 @@ def evaluate_action_filters(
                 )
         else:
             if group_evaluation.logic_result:
-                filtered_action_groups.add(action_condition)
-
-    enqueue_workflows(queue_items_by_project_id)
+                if delayed_workflow_item := queue_items_by_workflow.get(workflow):
+                    if delayed_workflow_item.delayed_when_group_id:
+                        # If there are already delayed when conditions,
+                        # we need to evaluate them before firing the action group
+                        delayed_workflow_item.passing_if_group_ids.append(action_condition.id)
+                else:
+                    filtered_action_groups.add(action_condition)
 
     event_id = (
         event_data.event.event_id
@@ -264,36 +287,15 @@ def evaluate_action_filters(
         extra={
             "group_id": event_data.group.id,
             "event_id": event_id,
-            "workflow_ids": [workflow.id for workflow in dcg_to_workflow.values()],
+            "workflow_ids": [workflow.id for workflow in action_conditions_to_workflow.values()],
             "action_conditions": [
-                action_condition.id for action_condition in dcg_to_workflow.keys()
+                action_condition.id for action_condition in action_conditions_to_workflow.keys()
             ],
             "filtered_action_groups": [action_group.id for action_group in filtered_action_groups],
         },
     )
 
-    return filtered_action_groups
-
-
-@sentry_sdk.trace
-def evaluate_workflows_action_filters(
-    workflows: set[Workflow],
-    event_data: WorkflowEventData,
-) -> set[DataConditionGroup]:
-    """
-    Evaluate the action filters for the given workflows.
-    Returns a set of DataConditionGroups that were evaluated to True.
-
-    Use this function if you only have a set of workflows to evaluate and will not repeatedly evaluate action filters in a loop.
-    """
-    action_conditions_to_workflow = {
-        wdcg.condition_group: wdcg.workflow
-        for wdcg in WorkflowDataConditionGroup.objects.select_related(
-            "workflow", "condition_group"
-        ).filter(workflow__in=workflows)
-    }
-
-    return evaluate_action_filters(event_data, action_conditions_to_workflow)
+    return filtered_action_groups, queue_items_by_workflow
 
 
 def get_environment_by_event(event_data: WorkflowEventData) -> Environment | None:
@@ -420,12 +422,17 @@ def process_workflows(
         # If there aren't any workflows, there's nothing to evaluate
         return set()
 
-    triggered_workflows = evaluate_workflow_triggers(workflows, event_data)
-    if not triggered_workflows:
+    triggered_workflows, queue_items_by_workflow_id = evaluate_workflow_triggers(
+        workflows, event_data
+    )
+    if not triggered_workflows and not queue_items_by_workflow_id:
         # if there aren't any triggered workflows, there's no action filters to evaluate
         return set()
 
-    actions_to_trigger = evaluate_workflows_action_filters(triggered_workflows, event_data)
+    actions_to_trigger, queue_items_by_workflow_id = evaluate_workflows_action_filters(
+        triggered_workflows, event_data, queue_items_by_workflow_id
+    )
+    enqueue_workflows(queue_items_by_workflow_id)
     actions = filter_recently_fired_workflow_actions(actions_to_trigger, event_data)
 
     if not actions:

--- a/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
@@ -660,7 +660,6 @@ class TestGetGroupsToFire(TestDelayedWorkflowBase):
             + self.workflow2_if_dcgs
         )
 
-        self.data_condition_group_mapping = {dcg.id: dcg for dcg in self.data_condition_groups}
         self.workflows_to_envs = {self.workflow1.id: self.environment.id, self.workflow2.id: None}
         self.condition_group_results: dict[UniqueConditionQuery, QueryResult] = {
             UniqueConditionQuery(
@@ -724,7 +723,7 @@ class TestGetGroupsToFire(TestDelayedWorkflowBase):
 
     def test_simple(self) -> None:
         result = get_groups_to_fire(
-            self.data_condition_group_mapping,
+            self.data_condition_groups,
             self.workflows_to_envs,
             self.event_data,
             self.condition_group_results,
@@ -750,7 +749,7 @@ class TestGetGroupsToFire(TestDelayedWorkflowBase):
         }
 
         result = get_groups_to_fire(
-            self.data_condition_group_mapping,
+            self.data_condition_groups,
             self.workflows_to_envs,
             self.event_data,
             self.condition_group_results,
@@ -774,7 +773,7 @@ class TestGetGroupsToFire(TestDelayedWorkflowBase):
         )
 
         result = get_groups_to_fire(
-            self.data_condition_group_mapping,
+            self.data_condition_groups,
             self.workflows_to_envs,
             self.event_data,
             self.condition_group_results,
@@ -796,7 +795,7 @@ class TestGetGroupsToFire(TestDelayedWorkflowBase):
         )
 
         result = get_groups_to_fire(
-            self.data_condition_group_mapping,
+            self.data_condition_groups,
             self.workflows_to_envs,
             self.event_data,
             self.condition_group_results,

--- a/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
@@ -1,6 +1,6 @@
 from dataclasses import asdict
 from datetime import datetime, timedelta
-from unittest.mock import ANY, MagicMock, Mock, call, patch
+from unittest.mock import ANY, MagicMock, Mock, patch
 
 import pytest
 from django.utils import timezone
@@ -60,38 +60,32 @@ from sentry.workflow_engine.processors.delayed_workflow import (
     get_group_to_groupevent,
     get_groups_to_fire,
 )
-from sentry.workflow_engine.processors.workflow import (
-    WORKFLOW_ENGINE_BUFFER_LIST_KEY,
-    DelayedWorkflowItem,
-    WorkflowDataConditionGroupType,
-)
-from sentry.workflow_engine.types import DataConditionHandler
+from sentry.workflow_engine.processors.workflow import WORKFLOW_ENGINE_BUFFER_LIST_KEY
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 from tests.snuba.rules.conditions.test_event_frequency import BaseEventFrequencyPercentTest
 
 FROZEN_TIME = before_now(days=1).replace(hour=1, minute=30, second=0, microsecond=0)
 
 
-def dcg_ids_to_str(dcgs: list[DataConditionGroup]) -> str:
-    """Convert a list of DCGs to a comma-delimited string of their IDs."""
-    return ",".join(str(dcg.id) for dcg in dcgs)
-
-
 class TestDelayedWorkflowBase(BaseWorkflowTest, BaseEventFrequencyPercentTest):
     def setUp(self) -> None:
         super().setUp()
 
-        self.workflow1, self.workflow1_dcgs = self.create_project_event_freq_workflow(
-            self.project, self.environment
+        self.workflow1, self.workflow1_if_dcgs = self.create_project_event_freq_workflow(
+            self.project, self.environment, has_when_slow_condition=True
         )
-        self.workflow2, self.workflow2_dcgs = self.create_project_event_freq_workflow(self.project)
+        self.workflow2, self.workflow2_if_dcgs = self.create_project_event_freq_workflow(
+            self.project
+        )
 
         self.project2 = self.create_project()
         self.environment2 = self.create_environment(project=self.project2)
-        self.workflow3, self.workflow3_dcgs = self.create_project_event_freq_workflow(
-            self.project2, self.environment2
+        self.workflow3, self.workflow3_if_dcgs = self.create_project_event_freq_workflow(
+            self.project2, self.environment2, has_when_slow_condition=True
         )
-        self.workflow4, self.workflow4_dcgs = self.create_project_event_freq_workflow(self.project2)
+        self.workflow4, self.workflow4_if_dcgs = self.create_project_event_freq_workflow(
+            self.project2
+        )
 
         self.event1, self.group1 = self.setup_event(self.project, self.environment, "group-1")
         self.create_event(self.project.id, FROZEN_TIME, "group-1", self.environment.name)
@@ -100,10 +94,8 @@ class TestDelayedWorkflowBase(BaseWorkflowTest, BaseEventFrequencyPercentTest):
         self.create_event(self.project.id, FROZEN_TIME, "group-2", self.environment.name)
 
         self.workflow_group_dcg_mapping = {
-            f"{self.workflow1.id}:{self.group1.id}:{dcg_ids_to_str([self.workflow1_dcgs[0]])}:{DataConditionHandler.Group.WORKFLOW_TRIGGER}",
-            f"{self.workflow1.id}:{self.group1.id}:{dcg_ids_to_str([self.workflow1_dcgs[1]])}:{DataConditionHandler.Group.ACTION_FILTER}",
-            f"{self.workflow2.id}:{self.group2.id}:{dcg_ids_to_str([self.workflow2_dcgs[0]])}:{DataConditionHandler.Group.WORKFLOW_TRIGGER}",
-            f"{self.workflow2.id}:{self.group2.id}:{dcg_ids_to_str([self.workflow2_dcgs[1]])}:{DataConditionHandler.Group.ACTION_FILTER}",
+            f"{self.workflow1.id}:{self.group1.id}:{self.workflow1.when_condition_group_id}:{self.workflow1_if_dcgs[0].id}:{self.workflow1_if_dcgs[1].id}",
+            f"{self.workflow2.id}:{self.group2.id}::{self.workflow2_if_dcgs[0].id}:{self.workflow2_if_dcgs[1].id}",
         }
 
         self.event3, self.group3 = self.setup_event(self.project2, self.environment2, "group-3")
@@ -116,10 +108,8 @@ class TestDelayedWorkflowBase(BaseWorkflowTest, BaseEventFrequencyPercentTest):
         self._make_sessions(60, project=self.project2)
 
         self.workflow_group_dcg_mapping2 = {
-            f"{self.workflow3.id}:{self.group3.id}:{dcg_ids_to_str([self.workflow3_dcgs[0]])}:{DataConditionHandler.Group.WORKFLOW_TRIGGER}",
-            f"{self.workflow3.id}:{self.group3.id}:{dcg_ids_to_str([self.workflow3_dcgs[1]])}:{DataConditionHandler.Group.ACTION_FILTER}",
-            f"{self.workflow4.id}:{self.group4.id}:{dcg_ids_to_str([self.workflow4_dcgs[0]])}:{DataConditionHandler.Group.WORKFLOW_TRIGGER}",
-            f"{self.workflow4.id}:{self.group4.id}:{dcg_ids_to_str([self.workflow4_dcgs[1]])}:{DataConditionHandler.Group.ACTION_FILTER}",
+            f"{self.workflow3.id}:{self.group3.id}:{self.workflow3.when_condition_group_id}:{self.workflow3_if_dcgs[0].id}:{self.workflow3_if_dcgs[1].id}",
+            f"{self.workflow4.id}:{self.group4.id}::{self.workflow4_if_dcgs[0].id}:{self.workflow4_if_dcgs[1].id}",
         }
 
         self.detector = Detector.objects.get(project_id=self.project.id, type=ErrorGroupType.slug)
@@ -140,7 +130,10 @@ class TestDelayedWorkflowBase(BaseWorkflowTest, BaseEventFrequencyPercentTest):
         self.mock_redis_buffer.__exit__(None, None, None)
 
     def create_project_event_freq_workflow(
-        self, project: Project, environment: Environment | None = None
+        self,
+        project: Project,
+        environment: Environment | None = None,
+        has_when_slow_condition: bool = False,
     ) -> tuple[Workflow, list[DataConditionGroup]]:
         detector, _ = Detector.objects.get_or_create(
             project_id=project.id, type=ErrorGroupType.slug, defaults={"config": {}}
@@ -149,13 +142,13 @@ class TestDelayedWorkflowBase(BaseWorkflowTest, BaseEventFrequencyPercentTest):
         workflow_trigger_group = self.create_data_condition_group(
             logic_type=DataConditionGroup.Type.ANY_SHORT_CIRCUIT
         )
-        self.create_data_condition(
-            condition_group=workflow_trigger_group,
-            type=Condition.EVENT_FREQUENCY_COUNT,
-            comparison={"interval": "1h", "value": 100},
-            condition_result=True,
-        )
-        # TODO: add other conditions
+        if has_when_slow_condition:
+            self.create_data_condition(
+                condition_group=workflow_trigger_group,
+                type=Condition.EVENT_FREQUENCY_COUNT,
+                comparison={"interval": "1h", "value": 100},
+                condition_result=True,
+            )
 
         workflow = self.create_workflow(
             when_condition_group=workflow_trigger_group,
@@ -167,22 +160,33 @@ class TestDelayedWorkflowBase(BaseWorkflowTest, BaseEventFrequencyPercentTest):
             workflow=workflow,
         )
 
+        workflow_action_slow_filter_group = self.create_data_condition_group(
+            logic_type=DataConditionGroup.Type.ALL
+        )
+        self.create_data_condition(
+            condition_group=workflow_action_slow_filter_group,
+            type=Condition.EVENT_FREQUENCY_PERCENT,
+            comparison={"interval": "1h", "value": 100, "comparison_interval": "1w"},
+            condition_result=True,
+        )
+
         workflow_action_filter_group = self.create_data_condition_group(
             logic_type=DataConditionGroup.Type.ALL
         )
         self.create_data_condition(
             condition_group=workflow_action_filter_group,
-            type=Condition.EVENT_FREQUENCY_PERCENT,
-            comparison={"interval": "1h", "value": 100, "comparison_interval": "1w"},
+            type=Condition.EVENT_FREQUENCY_COUNT,
+            comparison={"interval": "1h", "value": 100},
             condition_result=True,
         )
-        # TODO: add other conditions
-
         self.create_workflow_data_condition_group(
             workflow=workflow, condition_group=workflow_action_filter_group
         )
+        self.create_workflow_data_condition_group(
+            workflow=workflow, condition_group=workflow_action_slow_filter_group
+        )
 
-        return workflow, [workflow_trigger_group, workflow_action_filter_group]
+        return workflow, [workflow_action_slow_filter_group, workflow_action_filter_group]
 
     def setup_event(self, project, environment, name) -> tuple[Event, Group]:
         event = self.create_event(project.id, FROZEN_TIME, name, environment.name)
@@ -194,10 +198,11 @@ class TestDelayedWorkflowBase(BaseWorkflowTest, BaseEventFrequencyPercentTest):
         project_id: int,
         workflow_id: int,
         group_id: int,
-        dcg_ids: list[int],
+        when_dcg_id: int | None,
+        if_dcgs: list[DataConditionGroup],
+        passing_dcgs: list[DataConditionGroup],
         event_id: str | None = None,
         occurrence_id: str | None = None,
-        dcg_group: DataConditionHandler.Group = DataConditionHandler.Group.WORKFLOW_TRIGGER,
         timestamp: datetime | None = None,
     ) -> None:
         value_dict: dict[str, str | None | datetime] = {
@@ -207,7 +212,8 @@ class TestDelayedWorkflowBase(BaseWorkflowTest, BaseEventFrequencyPercentTest):
         if timestamp:
             value_dict["timestamp"] = timestamp
         value = json.dumps(value_dict)
-        field = f"{workflow_id}:{group_id}:{','.join(map(str, dcg_ids))}:{dcg_group}"
+        when_dcg_str = str(when_dcg_id) if when_dcg_id else ""
+        field = f"{workflow_id}:{group_id}:{when_dcg_str}:{','.join([str(dcg.id) for dcg in if_dcgs])}:{','.join([str(dcg.id) for dcg in passing_dcgs])}"
         buffer.backend.push_to_hash(
             model=Workflow,
             filters={"project_id": project_id},
@@ -217,27 +223,58 @@ class TestDelayedWorkflowBase(BaseWorkflowTest, BaseEventFrequencyPercentTest):
 
     def _push_base_events(self, timestamp: datetime | None = None) -> None:
         workflow_to_data = {
-            self.workflow1: (self.project, self.workflow1_dcgs, self.event1, self.group1),
-            self.workflow2: (self.project, self.workflow2_dcgs, self.event2, self.group2),
-            self.workflow3: (self.project2, self.workflow3_dcgs, self.event3, self.group3),
-            self.workflow4: (self.project2, self.workflow4_dcgs, self.event4, self.group4),
+            self.workflow1: (
+                self.project,
+                self.workflow1.when_condition_group_id,
+                [self.workflow1_if_dcgs[0]],
+                [self.workflow1_if_dcgs[1]],
+                self.event1,
+                self.group1,
+            ),
+            self.workflow2: (
+                self.project,
+                None,
+                [self.workflow2_if_dcgs[0]],
+                [self.workflow2_if_dcgs[1]],
+                self.event2,
+                self.group2,
+            ),
+            self.workflow3: (
+                self.project2,
+                self.workflow3.when_condition_group_id,
+                [self.workflow3_if_dcgs[0]],
+                [self.workflow3_if_dcgs[1]],
+                self.event3,
+                self.group3,
+            ),
+            self.workflow4: (
+                self.project2,
+                None,
+                [self.workflow4_if_dcgs[0]],
+                [self.workflow4_if_dcgs[1]],
+                self.event4,
+                self.group4,
+            ),
         }
-        dcg_group = [
-            DataConditionHandler.Group.WORKFLOW_TRIGGER,
-            DataConditionHandler.Group.ACTION_FILTER,
-        ]
 
-        for workflow, (project, dcgs, event, group) in workflow_to_data.items():
-            for i, dcg in enumerate(dcgs):
-                self.push_to_hash(
-                    project_id=project.id,
-                    workflow_id=workflow.id,
-                    group_id=group.id,
-                    dcg_ids=[dcg.id],
-                    event_id=event.event_id,
-                    dcg_group=dcg_group[i],
-                    timestamp=timestamp,
-                )
+        for workflow, (
+            project,
+            when_condition_group_id,
+            if_condition_groups,
+            passing_if_groups,
+            event,
+            group,
+        ) in workflow_to_data.items():
+            self.push_to_hash(
+                project_id=project.id,
+                workflow_id=workflow.id,
+                group_id=group.id,
+                when_dcg_id=when_condition_group_id,
+                if_dcgs=if_condition_groups,
+                passing_dcgs=passing_if_groups,
+                event_id=event.event_id,
+                timestamp=timestamp,
+            )
 
 
 class TestDelayedWorkflowHelpers(TestDelayedWorkflowBase):
@@ -251,11 +288,11 @@ class TestDelayedWorkflowHelpers(TestDelayedWorkflowBase):
 
         self._push_base_events()
         buffer_data = fetch_group_to_event_data(self.project.id, Workflow)
-        assert len(buffer_data) == 4
+        assert len(buffer_data) == 2
         assert set(buffer_data.keys()) == self.workflow_group_dcg_mapping
 
         buffer_data = fetch_group_to_event_data(self.project2.id, Workflow)
-        assert len(buffer_data) == 4
+        assert len(buffer_data) == 2
         assert set(buffer_data.keys()) == self.workflow_group_dcg_mapping2
 
     def test_fetch_workflows_envs(self) -> None:
@@ -611,7 +648,19 @@ class TestGetGroupsToFire(TestDelayedWorkflowBase):
     def setUp(self) -> None:
         super().setUp()
 
-        self.data_condition_groups = self.workflow1_dcgs + self.workflow2_dcgs + [self.detector_dcg]
+        assert self.workflow1.when_condition_group
+        assert self.workflow2.when_condition_group
+
+        self.data_condition_groups: list[DataConditionGroup] = (
+            [
+                self.workflow1.when_condition_group,
+                self.workflow2.when_condition_group,
+            ]
+            + self.workflow1_if_dcgs
+            + self.workflow2_if_dcgs
+        )
+
+        self.data_condition_group_mapping = {dcg.id: dcg for dcg in self.data_condition_groups}
         self.workflows_to_envs = {self.workflow1.id: self.environment.id, self.workflow2.id: None}
         self.condition_group_results: dict[UniqueConditionQuery, QueryResult] = {
             UniqueConditionQuery(
@@ -644,40 +693,30 @@ class TestGetGroupsToFire(TestDelayedWorkflowBase):
             ): {self.group1.id: 50, self.group2.id: 50},
         }
 
-        # add slow condition to workflow1 IF dcg (ALL), passes
+        # add slow condition to workflow1 slow condition IF dcg (ALL), passes
         self.create_data_condition(
-            condition_group=self.workflow1_dcgs[1],
-            type=Condition.EVENT_UNIQUE_USER_FREQUENCY_COUNT,
-            comparison={"interval": "1h", "value": 100},
-            condition_result=True,
-        )
-        # add slow condition to detector WHEN dcg (ANY), passes but not in result
-        self.create_data_condition(
-            condition_group=self.detector_dcg,
-            type=Condition.EVENT_UNIQUE_USER_FREQUENCY_COUNT,
-            comparison={"interval": "1h", "value": 100},
-            condition_result=True,
-        )
-        # add slow condition to workflow2 WHEN dcg (ANY), fails but the DCG itself passes
-        self.create_data_condition(
-            condition_group=self.workflow2_dcgs[0],
+            condition_group=self.workflow1_if_dcgs[0],
             type=Condition.EVENT_UNIQUE_USER_FREQUENCY_COUNT,
             comparison={"interval": "1h", "value": 100},
             condition_result=True,
         )
 
-        # Create event data
+        # add slow condition to workflow2 WHEN dcg (ANY), passes
+        self.create_data_condition(
+            condition_group=self.workflow2.when_condition_group,
+            type=Condition.EVENT_UNIQUE_USER_FREQUENCY_COUNT,
+            comparison={"interval": "1h", "value": 20},
+            condition_result=True,
+        )
+
         self.event_data = EventRedisData(
             events={
                 EventKey.from_redis_key(
-                    f"{self.workflow1.id}:{self.group1.id}:{dcg_ids_to_str(self.workflow1_dcgs)}:workflow_trigger"
+                    f"{self.workflow1.id}:{self.group1.id}:{self.workflow1.when_condition_group_id}:{self.workflow1_if_dcgs[0].id}:{self.workflow1_if_dcgs[1].id}"
                 ): EventInstance(event_id="test-event-1"),
                 EventKey.from_redis_key(
-                    f"{self.workflow2.id}:{self.group2.id}:{dcg_ids_to_str(self.workflow2_dcgs)}:workflow_trigger"
+                    f"{self.workflow2.id}:{self.group2.id}:{self.workflow2.when_condition_group_id}:{self.workflow2_if_dcgs[0].id}:{self.workflow2_if_dcgs[1].id}"
                 ): EventInstance(event_id="test-event-2"),
-                EventKey.from_redis_key(
-                    f"{self.detector.id}:{self.group1.id}:{self.detector_dcg.id}:detector_trigger"
-                ): EventInstance(event_id="test-event-1"),
             }
         )
 
@@ -685,21 +724,24 @@ class TestGetGroupsToFire(TestDelayedWorkflowBase):
 
     def test_simple(self) -> None:
         result = get_groups_to_fire(
-            self.data_condition_groups,
+            self.data_condition_group_mapping,
             self.workflows_to_envs,
             self.event_data,
             self.condition_group_results,
             self.dcg_to_slow_conditions,
         )
 
+        # NOTE: no WHEN DCGs. We only collect IF DCGs here to fire their actions in the fire_actions_for_groups function
         assert result == {
-            self.group1.id: set(self.workflow1_dcgs),  # WHEN dcg (ANY-short), IF dcg (ALL)
-            self.group2.id: {self.workflow2_dcgs[0]},  # WHEN dcg (ANY-short)
+            self.group1.id: set(self.workflow1_if_dcgs),
+            self.group2.id: {
+                self.workflow2_if_dcgs[1]
+            },  # WHEN DCG passed so we have the passing if dcg here. IF DCG with slow condition did not pass
         }
 
     def test_missing_query_result_excludes_group(self) -> None:
         existing_query = UniqueConditionQuery(
-            handler=EventFrequencyQueryHandler, interval="1h", environment_id=None
+            handler=EventUniqueUserFrequencyQueryHandler, interval="1h", environment_id=None
         )
         existing_result = self.condition_group_results[existing_query]
         assert self.group2.id in existing_result
@@ -708,7 +750,7 @@ class TestGetGroupsToFire(TestDelayedWorkflowBase):
         }
 
         result = get_groups_to_fire(
-            self.data_condition_groups,
+            self.data_condition_group_mapping,
             self.workflows_to_envs,
             self.event_data,
             self.condition_group_results,
@@ -717,7 +759,7 @@ class TestGetGroupsToFire(TestDelayedWorkflowBase):
 
         # group2 should be excluded because it's missing from the query result
         assert result == {
-            self.group1.id: set(self.workflow1_dcgs),
+            self.group1.id: set(self.workflow1_if_dcgs),
         }
 
     def test_dcg_all_fails(self) -> None:
@@ -732,7 +774,7 @@ class TestGetGroupsToFire(TestDelayedWorkflowBase):
         )
 
         result = get_groups_to_fire(
-            self.data_condition_groups,
+            self.data_condition_group_mapping,
             self.workflows_to_envs,
             self.event_data,
             self.condition_group_results,
@@ -740,21 +782,21 @@ class TestGetGroupsToFire(TestDelayedWorkflowBase):
         )
 
         assert result == {
-            self.group1.id: {self.workflow1_dcgs[0]},  # WHEN dcg (ANY-short)
-            self.group2.id: {self.workflow2_dcgs[0]},  # WHEN dcg (ANY-short)
+            self.group1.id: {self.workflow1_if_dcgs[1]},
+            self.group2.id: {self.workflow2_if_dcgs[1]},
         }
 
     def test_dcg_any_fails(self) -> None:
         self.condition_group_results.update(
             {
                 UniqueConditionQuery(
-                    handler=EventFrequencyQueryHandler, interval="1h", environment_id=None
-                ): {self.group2.id: 99}
+                    handler=EventUniqueUserFrequencyQueryHandler, interval="1h", environment_id=None
+                ): {self.group2.id: 10}
             }
         )
 
         result = get_groups_to_fire(
-            self.data_condition_groups,
+            self.data_condition_group_mapping,
             self.workflows_to_envs,
             self.event_data,
             self.condition_group_results,
@@ -762,40 +804,7 @@ class TestGetGroupsToFire(TestDelayedWorkflowBase):
         )
 
         assert result == {
-            self.group1.id: set(self.workflow1_dcgs),  # WHEN dcg (ANY-short), IF dcg (ALL)
-        }
-
-    def test_multiple_dcgs_per_group(self) -> None:
-        # Create new entries for additional DCGs
-        new_entries = {
-            # Add workflow2 DCGs for group1
-            EventKey.from_redis_key(
-                f"{self.workflow2.id}:{self.group1.id}:{dcg_ids_to_str(self.workflow2_dcgs)}:workflow_trigger"
-            ): EventInstance(event_id="test-event-1"),
-            # Add workflow1 DCGs for group2
-            EventKey.from_redis_key(
-                f"{self.workflow1.id}:{self.group2.id}:{dcg_ids_to_str(self.workflow1_dcgs)}:workflow_trigger"
-            ): EventInstance(event_id="test-event-2"),
-            # Add workflow2 DCGs for group2
-            EventKey.from_redis_key(
-                f"{self.workflow2.id}:{self.group2.id}:{dcg_ids_to_str(self.workflow2_dcgs)}:workflow_trigger"
-            ): EventInstance(event_id="test-event-2"),
-        }
-
-        event_data = EventRedisData(events={**self.event_data.events, **new_entries})
-
-        result = get_groups_to_fire(
-            self.data_condition_groups,
-            self.workflows_to_envs,
-            event_data,
-            self.condition_group_results,
-            self.dcg_to_slow_conditions,
-        )
-        assert result == {
-            self.group1.id: set(self.workflow1_dcgs + [self.workflow2_dcgs[0]]),
-            self.group2.id: set(
-                self.workflow1_dcgs + [self.workflow2_dcgs[0]],
-            ),
+            self.group1.id: set(self.workflow1_if_dcgs),
         }
 
 
@@ -810,7 +819,7 @@ class TestFireActionsForGroups(TestDelayedWorkflowBase):
             data={"tags": "environment,user,my_tag"},
         )
         self.create_data_condition_group_action(
-            condition_group=self.workflow1_dcgs[1], action=action1
+            condition_group=self.workflow1_if_dcgs[0], action=action1
         )
 
         action2 = self.create_action(
@@ -824,12 +833,12 @@ class TestFireActionsForGroups(TestDelayedWorkflowBase):
             },
         )
         self.create_data_condition_group_action(
-            condition_group=self.workflow2_dcgs[1], action=action2
+            condition_group=self.workflow2_if_dcgs[0], action=action2
         )
 
         self.groups_to_dcgs = {
-            self.group1.id: set(self.workflow1_dcgs),
-            self.group2.id: set(self.workflow2_dcgs),
+            self.group1.id: set(self.workflow1_if_dcgs),
+            self.group2.id: set(self.workflow2_if_dcgs),
         }
 
         self.group_to_groupevent = {
@@ -860,13 +869,9 @@ class TestFireActionsForGroups(TestDelayedWorkflowBase):
     @patch("sentry.workflow_engine.tasks.actions.trigger_action.delay")
     @with_feature("organizations:workflow-engine-trigger-actions")
     def test_fire_actions_for_groups__fire_actions(self, mock_trigger: MagicMock) -> None:
-        self._push_base_events()
-        buffer_data = fetch_group_to_event_data(self.project.id, Workflow)
-        event_data = EventRedisData.from_redis_data(buffer_data, continue_on_error=False)
         fire_actions_for_groups(
             self.project.organization,
             self.groups_to_dcgs,
-            event_data,
             self.group_to_groupevent,
         )
 
@@ -884,52 +889,6 @@ class TestFireActionsForGroups(TestDelayedWorkflowBase):
         assert second_call_kwargs["event_id"] == self.event2.event_id
         assert second_call_kwargs["group_id"] == self.group2.id
 
-    @freeze_time()
-    @patch("sentry.workflow_engine.processors.workflow.enqueue_workflows")
-    def test_fire_actions_for_groups__enqueue(self, mock_enqueue: MagicMock) -> None:
-        # enqueue the IF DCGs with slow conditions!
-        self._push_base_events()
-        buffer_data = fetch_group_to_event_data(self.project.id, Workflow)
-        event_data = EventRedisData.from_redis_data(buffer_data, continue_on_error=False)
-        fire_actions_for_groups(
-            self.project.organization,
-            self.groups_to_dcgs,
-            event_data,
-            self.group_to_groupevent,
-        )
-
-        assert mock_enqueue.call_count == 2
-        mock_enqueue.assert_has_calls(
-            [
-                call(
-                    {
-                        self.project.id: [
-                            DelayedWorkflowItem(
-                                workflow=self.workflow1,
-                                delayed_conditions=[self.workflow1_dcgs[1].conditions.all()[0]],
-                                event=self.event1.for_group(self.group1),
-                                source=WorkflowDataConditionGroupType.ACTION_FILTER,
-                                timestamp=timezone.now(),
-                            ),
-                        ],
-                    }
-                ),
-                call(
-                    {
-                        self.project.id: [
-                            DelayedWorkflowItem(
-                                workflow=self.workflow2,
-                                delayed_conditions=[self.workflow2_dcgs[1].conditions.all()[0]],
-                                event=self.event2.for_group(self.group2),
-                                source=WorkflowDataConditionGroupType.ACTION_FILTER,
-                                timestamp=timezone.now(),
-                            ),
-                        ],
-                    }
-                ),
-            ]
-        )
-
     @patch("sentry.workflow_engine.processors.workflow.process_data_condition_group")
     def test_fire_actions_for_groups__workflow_fire_history(self, mock_process: MagicMock) -> None:
         mock_process.return_value = (
@@ -937,27 +896,14 @@ class TestFireActionsForGroups(TestDelayedWorkflowBase):
             [],
         )
 
-        # Create event data with specific workflow trigger and action filter mappings
-        event_data = EventRedisData(
-            events={
-                EventKey.from_redis_key(
-                    f"{self.workflow1.id}:{self.group1.id}:{self.workflow1_dcgs[0].id}:workflow_trigger"
-                ): EventInstance(event_id=self.event1.event_id),
-                EventKey.from_redis_key(
-                    f"{self.workflow2.id}:{self.group2.id}:{self.workflow2_dcgs[1].id}:action_filter"
-                ): EventInstance(event_id=self.event2.event_id),
-            }
-        )
-
         self.groups_to_dcgs = {
-            self.group1.id: {self.workflow1_dcgs[0]},
-            self.group2.id: {self.workflow2_dcgs[1]},
+            self.group1.id: {self.workflow1_if_dcgs[0]},
+            self.group2.id: {self.workflow2_if_dcgs[0]},
         }
 
         fire_actions_for_groups(
             self.project.organization,
             self.groups_to_dcgs,
-            event_data,
             self.group_to_groupevent,
         )
 
@@ -986,7 +932,7 @@ class TestCleanupRedisBuffer(TestDelayedWorkflowBase):
         data = buffer.backend.get_hash(Workflow, {"project_id": self.project.id})
         assert data == {}
 
-    @override_options({"delayed_processing.batch_size": 2})
+    @override_options({"delayed_processing.batch_size": 1})
     @patch(
         "sentry.workflow_engine.processors.delayed_workflow.process_delayed_workflows.apply_async"
     )
@@ -1025,24 +971,25 @@ class TestCleanupRedisBuffer(TestDelayedWorkflowBase):
 
 class TestEventKeyAndInstance:
     def test_event_key_from_redis_key(self) -> None:
-        key = "123:456:789,101:workflow_trigger"
+        key = "123:456:789:1,2,3:10,9,8"
         event_key = EventKey.from_redis_key(key)
         assert event_key.workflow_id == 123
         assert event_key.group_id == 456
-        assert event_key.dcg_ids == frozenset([789, 101])
-        assert event_key.dcg_type == DataConditionHandler.Group.WORKFLOW_TRIGGER
+        assert event_key.when_dcg_id == 789
+        assert event_key.if_dcg_ids == frozenset([1, 2, 3])
+        assert event_key.passing_dcg_ids == frozenset([10, 9, 8])
         assert event_key.original_key == key
 
     def test_event_key_from_redis_key_invalid(self) -> None:
         # Test various invalid key formats
         invalid_cases = [
             "invalid-key",  # missing colons
-            "1:2:3:4:5:workflow_trigger",  # too many parts
-            "1:2:workflow_trigger",  # too few parts
+            "1:2:3:4:5:6",  # too many parts
+            "1:2",  # too few parts
             "1:2:3:invalid_type",  # invalid type
-            "1:2:invalid_dcgs:workflow_trigger",  # invalid dcg_ids format
-            "not_a_number:2:3:workflow_trigger",  # non-numeric workflow_id
-            "1:not_a_number:3:workflow_trigger",  # non-numeric group_id
+            "1:2:3:invalid_type:2",  # invalid dcg_ids format
+            "not_a_number:2:3:4:5",  # non-numeric workflow_id
+            "1:not_a_number:3:4:5,6",  # non-numeric group_id
         ]
 
         for key in invalid_cases:
@@ -1050,12 +997,12 @@ class TestEventKeyAndInstance:
                 EventKey.from_redis_key(key)
 
     def test_event_key_str_and_hash(self) -> None:
-        key = "123:456:789:workflow_trigger"
+        key = "123:456:789:1,2,3:10,9,8"
         event_key = EventKey.from_redis_key(key)
         assert str(event_key) == key
         assert hash(event_key) == hash(key)
         assert event_key == EventKey.from_redis_key(key)
-        assert event_key != EventKey.from_redis_key("123:456:789:action_filter")
+        assert event_key != EventKey.from_redis_key("122:456:789:1,2,3:10,9,8")
 
     def test_event_instance_validation(self) -> None:
         # Test valid event instance
@@ -1105,26 +1052,24 @@ class TestEventKeyAndInstance:
     def test_from_redis_data_continue_on_error(self, mock_logger: MagicMock) -> None:
         # Create a mix of valid and invalid data
         redis_data = {
-            "1:2:3:workflow_trigger": '{"event_id": "valid-1"}',  # valid
-            "4:5:6:workflow_trigger": '{"occurrence_id": "invalid-1"}',  # missing event_id
-            "7:8:9:workflow_trigger": '{"event_id": "valid-2"}',  # valid
+            "123:456:789:1,2,3:10,9,8": '{"event_id": "valid-1"}',  # valid
+            "439:1:3487:134,6:34": '{"occurrence_id": "invalid-1"}',  # missing event_id
+            "5:456:22:1:44,33": '{"event_id": "valid-2"}',  # valid
         }
 
         # With continue_on_error=True, should return valid entries and log errors
         result = EventRedisData.from_redis_data(redis_data, continue_on_error=True)
         assert len(result.events) == 2
         assert (
-            result.events[EventKey.from_redis_key("1:2:3:workflow_trigger")].event_id == "valid-1"
+            result.events[EventKey.from_redis_key("123:456:789:1,2,3:10,9,8")].event_id == "valid-1"
         )
-        assert (
-            result.events[EventKey.from_redis_key("7:8:9:workflow_trigger")].event_id == "valid-2"
-        )
+        assert result.events[EventKey.from_redis_key("5:456:22:1:44,33")].event_id == "valid-2"
 
         # Verify error was logged
         mock_logger.exception.assert_called_once_with(
             "Failed to parse workflow event data",
             extra={
-                "key": "4:5:6:workflow_trigger",
+                "key": "439:1:3487:134,6:34",
                 "value": '{"occurrence_id": "invalid-1"}',
                 "error": ANY,
             },
@@ -1138,20 +1083,18 @@ class TestEventKeyAndInstance:
     def test_from_redis_data_invalid_keys(self, mock_logger: MagicMock) -> None:
         # Create data with an invalid key structure
         redis_data = {
-            "1:2:3:workflow_trigger": '{"event_id": "valid-1"}',  # valid
+            "123:456:789:1,2,3:10,9,8": '{"event_id": "valid-1"}',  # valid
             "invalid-key": '{"event_id": "valid-2"}',  # invalid key format
-            "1:2:4:workflow_trigger": '{"event_id": "valid-3"}',  # valid
+            "5:456:22:1:44,33": '{"event_id": "valid-3"}',  # valid
         }
 
         # With continue_on_error=True, should return valid entries and log errors
         result = EventRedisData.from_redis_data(redis_data, continue_on_error=True)
         assert len(result.events) == 2
         assert (
-            result.events[EventKey.from_redis_key("1:2:3:workflow_trigger")].event_id == "valid-1"
+            result.events[EventKey.from_redis_key("123:456:789:1,2,3:10,9,8")].event_id == "valid-1"
         )
-        assert (
-            result.events[EventKey.from_redis_key("1:2:4:workflow_trigger")].event_id == "valid-3"
-        )
+        assert result.events[EventKey.from_redis_key("5:456:22:1:44,33")].event_id == "valid-3"
 
         # Verify error was logged
         mock_logger.exception.assert_called_once_with(

--- a/tests/sentry/workflow_engine/test_integration.py
+++ b/tests/sentry/workflow_engine/test_integration.py
@@ -414,21 +414,15 @@ class TestWorkflowEngineIntegrationFromErrorPostProcess(BaseWorkflowIntegrationT
         )
         assert not project_ids
 
-        # event that does not have the tags = no fire
+        # event that does not have the tags = no enqueue
         event_2 = self.create_error_event(fingerprint="asdf")
         self.post_process_error(event_2, is_new=True)
-        assert not mock_trigger.called
-
-        event_3 = self.create_error_event(fingerprint="asdf")
-        self.post_process_error(event_3)
         assert not mock_trigger.called
 
         project_ids = buffer.backend.get_sorted_set(
             WORKFLOW_ENGINE_BUFFER_LIST_KEY, 0, timezone.now().timestamp()
         )
-
-        process_delayed_workflows(project_ids[0][0])
-        assert not mock_trigger.called
+        assert not project_ids
 
         # event that fires
         event_4 = self.create_error_event(tags=[["hello", "world"]])

--- a/tests/sentry/workflow_engine/test_task.py
+++ b/tests/sentry/workflow_engine/test_task.py
@@ -146,7 +146,8 @@ class TestProcessWorkflowActivity(TestCase):
             assert mock_evaluate.call_count == 0
 
     @mock.patch(
-        "sentry.workflow_engine.processors.workflow.evaluate_workflow_triggers", return_value=set()
+        "sentry.workflow_engine.processors.workflow.evaluate_workflow_triggers",
+        return_value=(set(), {}),
     )
     @mock.patch(
         "sentry.workflow_engine.processors.workflow.evaluate_workflows_action_filters",


### PR DESCRIPTION
Change the delayed workflow task to process the new shape being enqueued from `process_workflows`.

Now we only have to evaluate the slow condition results and we have the list of IF condition groups that can possibly fire actions already.