### PR TITLE
feat(explore): New query params context for explore

### DIFF
--- a/static/app/types/utils.tsx
+++ b/static/app/types/utils.tsx
@@ -20,3 +20,7 @@ export type DeepPartial<T> =
         [P in keyof T]?: DeepPartial<T[P]>;
       }
     : T;
+
+export type Nullable<T> = {
+  [P in keyof T]: T[P] | null;
+};

--- a/static/app/views/explore/logs/content.tsx
+++ b/static/app/views/explore/logs/content.tsx
@@ -15,6 +15,7 @@ import {LogsPageDataProvider} from 'sentry/views/explore/contexts/logs/logsPageD
 import {LogsPageParamsProvider} from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {TraceItemAttributeProvider} from 'sentry/views/explore/contexts/traceItemAttributeContext';
 import {LOGS_INSTRUCTIONS_URL} from 'sentry/views/explore/logs/constants';
+import {LogsQueryParamsProvider} from 'sentry/views/explore/logs/logsQueryParamsProvider';
 import {LogsTabContent} from 'sentry/views/explore/logs/logsTab';
 import {logsPickableDays} from 'sentry/views/explore/logs/utils';
 import {TraceItemDataset} from 'sentry/views/explore/types';
@@ -103,17 +104,19 @@ export default function LogsContent() {
             </Layout.HeaderActions>
           </Layout.Header>
           <TraceItemAttributeProvider traceItemType={TraceItemDataset.LOGS} enabled>
-            <LogsPageParamsProvider
-              analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}
-            >
-              <LogsPageDataProvider>
-                <LogsTabContent
-                  defaultPeriod={defaultPeriod}
-                  maxPickableDays={maxPickableDays}
-                  relativeOptions={relativeOptions}
-                />
-              </LogsPageDataProvider>
-            </LogsPageParamsProvider>
+            <LogsQueryParamsProvider>
+              <LogsPageParamsProvider
+                analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}
+              >
+                <LogsPageDataProvider>
+                  <LogsTabContent
+                    defaultPeriod={defaultPeriod}
+                    maxPickableDays={maxPickableDays}
+                    relativeOptions={relativeOptions}
+                  />
+                </LogsPageDataProvider>
+              </LogsPageParamsProvider>
+            </LogsQueryParamsProvider>
           </TraceItemAttributeProvider>
         </Layout.Page>
       </PageFiltersContainer>

--- a/static/app/views/explore/logs/logsQueryParams.spec.tsx
+++ b/static/app/views/explore/logs/logsQueryParams.spec.tsx
@@ -1,0 +1,218 @@
+import type {Location} from 'history';
+import {LocationFixture} from 'sentry-fixture/locationFixture';
+
+import {getReadableQueryParamsFromLocation} from 'sentry/views/explore/logs/logsQueryParams';
+import {Mode} from 'sentry/views/explore/queryParams/mode';
+import type {ReadableQueryParamsOptions} from 'sentry/views/explore/queryParams/readableQueryParams';
+import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
+import {Visualize} from 'sentry/views/explore/queryParams/visualize';
+
+function locationFixture(query: Location['query']): Location {
+  return LocationFixture({query});
+}
+
+function readableQueryParamOptions(
+  options: Partial<ReadableQueryParamsOptions> = {}
+): ReadableQueryParamsOptions {
+  return {
+    mode: Mode.SAMPLES,
+    query: '',
+    cursor: '',
+    fields: ['timestamp', 'message'],
+    sortBys: [{field: 'timestamp', kind: 'desc'}],
+    aggregateCursor: '',
+    aggregateFields: [{groupBy: ''}, new Visualize('count(message)')],
+    aggregateSortBys: [
+      {
+        field: 'count(message)',
+        kind: 'desc',
+      },
+    ],
+    ...options,
+  };
+}
+
+describe('getReadableQueryParamsFromLocation', function () {
+  it('decodes defaults correctly', function () {
+    const location = locationFixture({});
+    const queryParams = getReadableQueryParamsFromLocation(location);
+    expect(queryParams).toEqual(new ReadableQueryParams(readableQueryParamOptions()));
+  });
+
+  it('decodes samples mode correctly', function () {
+    const location = locationFixture({mode: 'samples'});
+    const queryParams = getReadableQueryParamsFromLocation(location);
+    expect(queryParams).toEqual(
+      new ReadableQueryParams(readableQueryParamOptions({mode: Mode.SAMPLES}))
+    );
+  });
+
+  it('decodes aggregate mode correctly', function () {
+    const location = locationFixture({mode: 'aggregate'});
+    const queryParams = getReadableQueryParamsFromLocation(location);
+    expect(queryParams).toEqual(
+      new ReadableQueryParams(readableQueryParamOptions({mode: Mode.AGGREGATE}))
+    );
+  });
+
+  it('defaults to samples mode for invalid mode values', function () {
+    const location = locationFixture({mode: 'invalid'});
+    const queryParams = getReadableQueryParamsFromLocation(location);
+    expect(queryParams).toEqual(
+      new ReadableQueryParams(readableQueryParamOptions({mode: Mode.SAMPLES}))
+    );
+  });
+
+  it('decodes empty query correctly', function () {
+    const location = locationFixture({query: ''});
+    const queryParams = getReadableQueryParamsFromLocation(location);
+    expect(queryParams).toEqual(
+      new ReadableQueryParams(readableQueryParamOptions({query: ''}))
+    );
+  });
+
+  it('decodes custom query parameter correctly', function () {
+    const location = locationFixture({logsQuery: 'message:foobar'});
+    const queryParams = getReadableQueryParamsFromLocation(location);
+    expect(queryParams).toEqual(
+      new ReadableQueryParams(readableQueryParamOptions({query: 'message:foobar'}))
+    );
+  });
+
+  it('decodes empty cursor correctly', function () {
+    const location = locationFixture({cursor: ''});
+    const queryParams = getReadableQueryParamsFromLocation(location);
+    expect(queryParams).toEqual(
+      new ReadableQueryParams(readableQueryParamOptions({cursor: ''}))
+    );
+  });
+
+  it('decodes custom cursor parameter correctly', function () {
+    const location = locationFixture({logsCursor: '0:0:1'});
+    const queryParams = getReadableQueryParamsFromLocation(location);
+    expect(queryParams).toEqual(
+      new ReadableQueryParams(readableQueryParamOptions({cursor: '0:0:1'}))
+    );
+  });
+
+  it('decodes empty fields correctly', function () {
+    const location = locationFixture({field: []});
+    const queryParams = getReadableQueryParamsFromLocation(location);
+    expect(queryParams).toEqual(
+      new ReadableQueryParams(
+        readableQueryParamOptions({
+          fields: ['timestamp', 'message'],
+        })
+      )
+    );
+  });
+
+  it('decodes custom fields correctly', function () {
+    const location = locationFixture({
+      logsFields: ['timestamp', 'severity', 'message'],
+    });
+    const queryParams = getReadableQueryParamsFromLocation(location);
+    expect(queryParams).toEqual(
+      new ReadableQueryParams(
+        readableQueryParamOptions({
+          fields: ['timestamp', 'severity', 'message'],
+        })
+      )
+    );
+  });
+
+  it('decodes custom sortBys correctly', function () {
+    const location = locationFixture({logsSortBys: ['-timestamp', 'message']});
+    const queryParams = getReadableQueryParamsFromLocation(location);
+    expect(queryParams).toEqual(
+      new ReadableQueryParams(
+        readableQueryParamOptions({
+          sortBys: [
+            {field: 'timestamp', kind: 'desc'},
+            {field: 'message', kind: 'asc'},
+          ],
+        })
+      )
+    );
+  });
+
+  it('uses timestamp sort when fields include timestamp', function () {
+    const location = locationFixture({logsSortBys: ['severity']});
+    const queryParams = getReadableQueryParamsFromLocation(location);
+    expect(queryParams).toEqual(
+      new ReadableQueryParams(
+        readableQueryParamOptions({
+          sortBys: [{field: 'timestamp', kind: 'desc'}],
+        })
+      )
+    );
+  });
+
+  it('falls back to first field when fields do not include timestamp', function () {
+    const location = locationFixture({logsFields: ['severity', 'message'], sort: []});
+    const queryParams = getReadableQueryParamsFromLocation(location);
+    expect(queryParams).toEqual(
+      new ReadableQueryParams(
+        readableQueryParamOptions({
+          fields: ['severity', 'message'],
+          sortBys: [{field: 'severity', kind: 'desc'}],
+        })
+      )
+    );
+  });
+
+  it('decodes empty sort correctly', function () {
+    const location = locationFixture({sort: []});
+    const queryParams = getReadableQueryParamsFromLocation(location);
+    expect(queryParams).toEqual(
+      new ReadableQueryParams(
+        readableQueryParamOptions({
+          sortBys: [{field: 'timestamp', kind: 'desc'}],
+        })
+      )
+    );
+  });
+
+  it('decodes custom group bys correctly', function () {
+    const location = locationFixture({logsGroupBy: 'severity'});
+    const queryParams = getReadableQueryParamsFromLocation(location);
+    expect(queryParams).toEqual(
+      new ReadableQueryParams(
+        readableQueryParamOptions({
+          aggregateFields: [{groupBy: 'severity'}, new Visualize('count(message)')],
+        })
+      )
+    );
+  });
+
+  it('decodes custom visualizes correctly', function () {
+    const location = locationFixture({logsAggregate: 'avg', logsAggregateParam: 'foo'});
+    const queryParams = getReadableQueryParamsFromLocation(location);
+    expect(queryParams).toEqual(
+      new ReadableQueryParams(
+        readableQueryParamOptions({
+          aggregateFields: [{groupBy: ''}, new Visualize('avg(foo)')],
+          aggregateSortBys: [{field: 'avg(foo)', kind: 'desc'}],
+        })
+      )
+    );
+  });
+
+  it('decodes custom aggregate sort bys correctly', function () {
+    const location = locationFixture({
+      logsGroupBy: 'severity',
+      logsAggregate: 'avg',
+      logsAggregateParam: 'foo',
+      logsAggregateSortBys: '-severity',
+    });
+    const queryParams = getReadableQueryParamsFromLocation(location);
+    expect(queryParams).toEqual(
+      new ReadableQueryParams(
+        readableQueryParamOptions({
+          aggregateFields: [{groupBy: 'severity'}, new Visualize('avg(foo)')],
+          aggregateSortBys: [{field: 'severity', kind: 'desc'}],
+        })
+      )
+    );
+  });
+});

--- a/static/app/views/explore/logs/logsQueryParams.tsx
+++ b/static/app/views/explore/logs/logsQueryParams.tsx
@@ -1,0 +1,140 @@
+import type {Location} from 'history';
+
+import type {Sort} from 'sentry/utils/discover/fields';
+import {decodeScalar} from 'sentry/utils/queryString';
+import {defaultLogFields} from 'sentry/views/explore/contexts/logs/fields';
+import {
+  LOGS_AGGREGATE_CURSOR_KEY,
+  LOGS_AGGREGATE_FN_KEY,
+  LOGS_AGGREGATE_PARAM_KEY,
+  LOGS_CURSOR_KEY,
+  LOGS_FIELDS_KEY,
+  LOGS_GROUP_BY_KEY,
+  LOGS_QUERY_KEY,
+} from 'sentry/views/explore/contexts/logs/logsPageParams';
+import {
+  LOGS_AGGREGATE_SORT_BYS_KEY,
+  LOGS_SORT_BYS_KEY,
+} from 'sentry/views/explore/contexts/logs/sortBys';
+import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
+import type {AggregateField} from 'sentry/views/explore/queryParams/aggregateField';
+import {getAggregateSortBysFromLocation} from 'sentry/views/explore/queryParams/aggregateSortBy';
+import {getCursorFromLocation} from 'sentry/views/explore/queryParams/cursor';
+import {getFieldsFromLocation} from 'sentry/views/explore/queryParams/field';
+import type {GroupBy} from 'sentry/views/explore/queryParams/groupBy';
+import {
+  getGroupBysFromLocation,
+  isGroupBy,
+} from 'sentry/views/explore/queryParams/groupBy';
+import {getModeFromLocation} from 'sentry/views/explore/queryParams/mode';
+import {getQueryFromLocation} from 'sentry/views/explore/queryParams/query';
+import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
+import {getSortBysFromLocation} from 'sentry/views/explore/queryParams/sortBy';
+import {isVisualize, Visualize} from 'sentry/views/explore/queryParams/visualize';
+
+const LOGS_MODE_KEY = 'mode';
+
+export function getReadableQueryParamsFromLocation(
+  location: Location
+): ReadableQueryParams {
+  const mode = getModeFromLocation(location, LOGS_MODE_KEY);
+  const query = getQueryFromLocation(location, LOGS_QUERY_KEY) ?? '';
+
+  const cursor = getCursorFromLocation(location, LOGS_CURSOR_KEY);
+  const fields = getFieldsFromLocation(location, LOGS_FIELDS_KEY) ?? defaultLogFields();
+  const sortBys =
+    getSortBysFromLocation(location, LOGS_SORT_BYS_KEY, fields) ?? defaultSortBys(fields);
+
+  const aggregateCursor = getCursorFromLocation(location, LOGS_AGGREGATE_CURSOR_KEY);
+  const aggregateFields = getLogsAggregateFieldsFromLocation(location);
+  const aggregateSortBys =
+    getAggregateSortBysFromLocation(
+      location,
+      LOGS_AGGREGATE_SORT_BYS_KEY,
+      aggregateFields
+    ) ?? defaultAggregateSortBys(aggregateFields);
+
+  return new ReadableQueryParams({
+    mode,
+    query,
+
+    cursor,
+    fields,
+    sortBys,
+
+    aggregateCursor,
+    aggregateFields,
+    aggregateSortBys,
+  });
+}
+
+function defaultSortBys(fields: string[]) {
+  if (fields.includes(OurLogKnownFieldKey.TIMESTAMP)) {
+    return [
+      {
+        field: OurLogKnownFieldKey.TIMESTAMP,
+        kind: 'desc' as const,
+      },
+    ];
+  }
+
+  if (fields.length) {
+    return [
+      {
+        field: fields[0]!,
+        kind: 'desc' as const,
+      },
+    ];
+  }
+
+  return [];
+}
+
+function defaultGroupBys(): [GroupBy] {
+  return [{groupBy: ''}];
+}
+
+function getVisualizesFromLocation(location: Location): [Visualize] {
+  const aggregateFn = decodeScalar(location.query?.[LOGS_AGGREGATE_FN_KEY], 'count');
+  const aggregateParam = decodeScalar(
+    location.query?.[LOGS_AGGREGATE_PARAM_KEY],
+    'message'
+  );
+
+  return [new Visualize(`${aggregateFn}(${aggregateParam})`)];
+}
+
+function getLogsAggregateFieldsFromLocation(location: Location): AggregateField[] {
+  // TODO: support a list of aggregate fields,
+  // needed for re-ordering columns in aggregate mode
+  return [
+    ...(getGroupBysFromLocation(location, LOGS_GROUP_BY_KEY) ?? defaultGroupBys()),
+    ...getVisualizesFromLocation(location),
+  ];
+}
+
+function defaultAggregateSortBys(aggregateFields: AggregateField[]): Sort[] {
+  for (const aggregateField of aggregateFields) {
+    if (isVisualize(aggregateField)) {
+      return [
+        {
+          field: aggregateField.yAxis,
+          kind: 'desc' as const,
+        },
+      ];
+    }
+  }
+
+  for (const aggregateField of aggregateFields) {
+    if (isGroupBy(aggregateField)) {
+      return [
+        {
+          field: aggregateField.groupBy,
+          kind: 'desc' as const,
+        },
+      ];
+    }
+  }
+
+  return [];
+}

--- a/static/app/views/explore/logs/logsQueryParamsProvider.tsx
+++ b/static/app/views/explore/logs/logsQueryParamsProvider.tsx
@@ -1,0 +1,36 @@
+import type {ReactNode} from 'react';
+import {useCallback, useMemo} from 'react';
+
+import {useLocation} from 'sentry/utils/useLocation';
+import {getReadableQueryParamsFromLocation} from 'sentry/views/explore/logs/logsQueryParams';
+import {QueryParamsContextProvider} from 'sentry/views/explore/queryParams/context';
+import type {WritableQueryParams} from 'sentry/views/explore/queryParams/writableQueryParams';
+
+interface LogsQueryParamsProviderProps {
+  children: ReactNode;
+}
+
+export function LogsQueryParamsProvider({children}: LogsQueryParamsProviderProps) {
+  const location = useLocation();
+
+  const readableQueryParams = useMemo(
+    () => getReadableQueryParamsFromLocation(location),
+    [location]
+  );
+
+  const setWritableQueryParams = useCallback(
+    (_writableQueryParams: WritableQueryParams) => {
+      // TODO
+    },
+    []
+  );
+
+  return (
+    <QueryParamsContextProvider
+      queryParams={readableQueryParams}
+      setQueryParams={setWritableQueryParams}
+    >
+      {children}
+    </QueryParamsContextProvider>
+  );
+}

--- a/static/app/views/explore/queryParams/aggregateField.ts
+++ b/static/app/views/explore/queryParams/aggregateField.ts
@@ -1,0 +1,48 @@
+import type {Location} from 'history';
+
+import {decodeList} from 'sentry/utils/queryString';
+import type {GroupBy} from 'sentry/views/explore/queryParams/groupBy';
+import {isGroupBy} from 'sentry/views/explore/queryParams/groupBy';
+import {parseVisualize, Visualize} from 'sentry/views/explore/queryParams/visualize';
+
+export type AggregateField = GroupBy | Visualize;
+
+export function getAggregateFieldsFromLocation(
+  location: Location,
+  key: string
+): AggregateField[] | null {
+  const rawAggregateFields = decodeList(location.query?.[key]);
+
+  if (rawAggregateFields.length <= 0) {
+    return null;
+  }
+
+  const aggregateFields = [];
+
+  for (const rawAggregateField of rawAggregateFields) {
+    let value: any;
+    try {
+      value = JSON.parse(rawAggregateField);
+    } catch (error) {
+      continue;
+    }
+    for (const aggregateField of parseAggregateField(value)) {
+      aggregateFields.push(aggregateField);
+    }
+  }
+
+  return aggregateFields;
+}
+
+function parseAggregateField(value: any): AggregateField[] {
+  if (isGroupBy(value)) {
+    return [value];
+  }
+
+  const visualizes = parseVisualize(value);
+  if (visualizes.length) {
+    return visualizes;
+  }
+
+  return [];
+}

--- a/static/app/views/explore/queryParams/aggregateSortBy.ts
+++ b/static/app/views/explore/queryParams/aggregateSortBy.ts
@@ -1,0 +1,37 @@
+import type {Location} from 'history';
+
+import type {Sort} from 'sentry/utils/discover/fields';
+import {decodeSorts} from 'sentry/utils/queryString';
+import type {AggregateField} from 'sentry/views/explore/queryParams/aggregateField';
+import {isGroupBy} from 'sentry/views/explore/queryParams/groupBy';
+import {isVisualize} from 'sentry/views/explore/queryParams/visualize';
+
+export function getAggregateSortBysFromLocation(
+  location: Location,
+  key: string,
+  aggregateFields: AggregateField[]
+): Sort[] | null {
+  const sortBys = decodeSorts(location.query?.[key]);
+
+  if (sortBys.length > 0) {
+    if (sortBys.every(sort => validateSort(sort, aggregateFields))) {
+      return sortBys;
+    }
+  }
+
+  return null;
+}
+
+function validateSort(sort: Sort, aggregateFields: AggregateField[]): boolean {
+  return aggregateFields.some(aggregateField => {
+    if (isGroupBy(aggregateField)) {
+      return aggregateField.groupBy === sort.field;
+    }
+
+    if (isVisualize(aggregateField)) {
+      return aggregateField.yAxis === sort.field;
+    }
+
+    throw new Error('Unknown aggregate field');
+  });
+}

--- a/static/app/views/explore/queryParams/context.tsx
+++ b/static/app/views/explore/queryParams/context.tsx
@@ -1,0 +1,34 @@
+import type {ReactNode} from 'react';
+import {useMemo} from 'react';
+
+import {createDefinedContext} from 'sentry/utils/performance/contexts/utils';
+import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
+import type {WritableQueryParams} from 'sentry/views/explore/queryParams/writableQueryParams';
+
+interface QueryParamsContextValue {
+  queryParams: ReadableQueryParams;
+  setQueryParams: (queryParams: WritableQueryParams) => void;
+}
+
+const [_QueryParamsContextProvider, _useQueryParamsContext, QueryParamsContext] =
+  createDefinedContext<QueryParamsContextValue>({
+    name: 'QueryParamsContext',
+  });
+
+interface QueryParamsContextProps extends QueryParamsContextValue {
+  children: ReactNode;
+}
+
+export function QueryParamsContextProvider({
+  children,
+  queryParams,
+  setQueryParams,
+}: QueryParamsContextProps) {
+  const value = useMemo(() => {
+    return {
+      queryParams,
+      setQueryParams,
+    };
+  }, [queryParams, setQueryParams]);
+  return <QueryParamsContext value={value}>{children}</QueryParamsContext>;
+}

--- a/static/app/views/explore/queryParams/cursor.ts
+++ b/static/app/views/explore/queryParams/cursor.ts
@@ -1,0 +1,11 @@
+import type {Location} from 'history';
+
+import {decodeScalar} from 'sentry/utils/queryString';
+
+function defaultCursor(): string {
+  return '';
+}
+
+export function getCursorFromLocation(location: Location, key: string) {
+  return decodeScalar(location.query?.[key], defaultCursor());
+}

--- a/static/app/views/explore/queryParams/field.ts
+++ b/static/app/views/explore/queryParams/field.ts
@@ -1,0 +1,13 @@
+import type {Location} from 'history';
+
+import {decodeList} from 'sentry/utils/queryString';
+
+export function getFieldsFromLocation(location: Location, key: string): string[] | null {
+  const fields = decodeList(location.query?.[key]);
+
+  if (fields.length) {
+    return fields;
+  }
+
+  return null;
+}

--- a/static/app/views/explore/queryParams/groupBy.ts
+++ b/static/app/views/explore/queryParams/groupBy.ts
@@ -1,0 +1,25 @@
+import type {Location} from 'history';
+
+import {defined} from 'sentry/utils';
+import {decodeList} from 'sentry/utils/queryString';
+
+export interface GroupBy {
+  groupBy: string;
+}
+
+export function getGroupBysFromLocation(
+  location: Location,
+  key: string
+): GroupBy[] | null {
+  const rawGroupBys = decodeList(location.query?.[key]);
+
+  if (rawGroupBys.length) {
+    return rawGroupBys.map(groupBy => ({groupBy}));
+  }
+
+  return null;
+}
+
+export function isGroupBy(value: any): value is GroupBy {
+  return defined(value) && typeof value === 'object' && typeof value.groupBy === 'string';
+}

--- a/static/app/views/explore/queryParams/mode.ts
+++ b/static/app/views/explore/queryParams/mode.ts
@@ -1,0 +1,20 @@
+import type {Location} from 'history';
+
+import {decodeScalar} from 'sentry/utils/queryString';
+
+export enum Mode {
+  SAMPLES = 'samples',
+  AGGREGATE = 'aggregate',
+}
+
+function defaultMode(): Mode {
+  return Mode.SAMPLES;
+}
+
+export function getModeFromLocation(location: Location, key: string): Mode {
+  const rawMode = decodeScalar(location.query?.[key]);
+  if (rawMode === Mode.AGGREGATE) {
+    return Mode.AGGREGATE;
+  }
+  return defaultMode();
+}

--- a/static/app/views/explore/queryParams/query.ts
+++ b/static/app/views/explore/queryParams/query.ts
@@ -1,0 +1,7 @@
+import type {Location} from 'history';
+
+import {decodeScalar} from 'sentry/utils/queryString';
+
+export function getQueryFromLocation(location: Location, key: string) {
+  return decodeScalar(location.query?.[key]);
+}

--- a/static/app/views/explore/queryParams/readableQueryParams.ts
+++ b/static/app/views/explore/queryParams/readableQueryParams.ts
@@ -1,0 +1,51 @@
+import type {Sort} from 'sentry/utils/discover/fields';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import type {AggregateField} from 'sentry/views/explore/queryParams/aggregateField';
+import {isGroupBy} from 'sentry/views/explore/queryParams/groupBy';
+import type {Mode} from 'sentry/views/explore/queryParams/mode';
+import type {Visualize} from 'sentry/views/explore/queryParams/visualize';
+import {isVisualize} from 'sentry/views/explore/queryParams/visualize';
+
+export interface ReadableQueryParamsOptions {
+  readonly aggregateCursor: string;
+  readonly aggregateFields: readonly AggregateField[];
+  readonly aggregateSortBys: readonly Sort[];
+  readonly cursor: string;
+  readonly fields: string[];
+  readonly mode: Mode;
+  readonly query: string;
+  readonly sortBys: Sort[];
+}
+
+export class ReadableQueryParams {
+  readonly mode: Mode;
+  readonly query: string;
+  readonly search: MutableSearch;
+
+  readonly cursor: string;
+  readonly fields: string[];
+  readonly sortBys: Sort[];
+
+  readonly aggregateCursor: string;
+  readonly aggregateFields: readonly AggregateField[];
+  readonly aggregateSortBys: readonly Sort[];
+  readonly groupBys: readonly string[];
+  readonly visualizes: readonly Visualize[];
+
+  constructor(options: ReadableQueryParamsOptions) {
+    this.mode = options.mode;
+    this.query = options.query;
+    this.search = new MutableSearch(this.query);
+
+    this.cursor = options.cursor;
+    this.fields = options.fields;
+    this.sortBys = options.sortBys;
+
+    this.aggregateCursor = options.aggregateCursor;
+    this.aggregateFields = options.aggregateFields;
+    this.aggregateSortBys = options.aggregateSortBys;
+
+    this.groupBys = this.aggregateFields.filter(isGroupBy).map(({groupBy}) => groupBy);
+    this.visualizes = this.aggregateFields.filter(isVisualize);
+  }
+}

--- a/static/app/views/explore/queryParams/sortBy.ts
+++ b/static/app/views/explore/queryParams/sortBy.ts
@@ -1,0 +1,24 @@
+import type {Location} from 'history';
+
+import type {Sort} from 'sentry/utils/discover/fields';
+import {decodeSorts} from 'sentry/utils/queryString';
+
+export function getSortBysFromLocation(
+  location: Location,
+  key: string,
+  fields: string[]
+): Sort[] | null {
+  const sortBys = decodeSorts(location.query?.[key]);
+
+  if (sortBys.length > 0) {
+    if (sortBys.every(sort => validateSort(sort, fields))) {
+      return sortBys;
+    }
+  }
+
+  return null;
+}
+
+function validateSort(sort: Sort, fields: string[]) {
+  return fields.includes(sort.field);
+}

--- a/static/app/views/explore/queryParams/visualize.ts
+++ b/static/app/views/explore/queryParams/visualize.ts
@@ -1,0 +1,81 @@
+import type {Location} from 'history';
+
+import {defined} from 'sentry/utils';
+import {decodeList} from 'sentry/utils/queryString';
+import {determineDefaultChartType} from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
+import {ChartType} from 'sentry/views/insights/common/components/chart';
+
+interface VisualizeOptions {
+  chartType?: ChartType;
+}
+
+export class Visualize {
+  readonly yAxis: string;
+  readonly chartType: ChartType;
+  private readonly selectedChartType?: ChartType;
+
+  constructor(yAxis: string, options?: VisualizeOptions) {
+    this.yAxis = yAxis;
+    this.selectedChartType = options?.chartType;
+    this.chartType = this.selectedChartType ?? determineDefaultChartType([yAxis]);
+  }
+}
+
+export function getVisualizesFromLocation(
+  location: Location,
+  key: string
+): Visualize[] | null {
+  const rawVisualizes = decodeList(location.query?.[key]);
+
+  const visualizes: Visualize[] = [];
+
+  for (const rawVisualize of rawVisualizes) {
+    let value: any;
+    try {
+      value = JSON.parse(rawVisualize);
+    } catch (error) {
+      continue;
+    }
+    for (const visualize of parseVisualize(value)) {
+      visualizes.push(visualize);
+    }
+  }
+
+  return visualizes.length ? visualizes : null;
+}
+
+export function parseVisualize(value: any): Visualize[] {
+  if (isBaseVisualize(value)) {
+    return value.yAxes.map(yAxis => new Visualize(yAxis, {chartType: value.chartType}));
+  }
+  return [];
+}
+
+export function isVisualize(value: any): value is Visualize {
+  return defined(value) && typeof value === 'object' && typeof value.yAxis === 'string';
+}
+
+interface BaseVisualize {
+  yAxes: readonly string[];
+  chartType?: ChartType;
+}
+
+function isBaseVisualize(value: any): value is BaseVisualize {
+  const hasYAxes =
+    defined(value) &&
+    typeof value === 'object' &&
+    Array.isArray(value.yAxes) &&
+    value.yAxes.every((yAxis: any) => typeof yAxis === 'string');
+
+  if (hasYAxes) {
+    // check for valid chart type
+    if (defined(value.chartType)) {
+      return Object.values(ChartType).includes(value.chartType);
+    }
+
+    // unselected chart type
+    return true;
+  }
+
+  return false;
+}

--- a/static/app/views/explore/queryParams/writableQueryParams.ts
+++ b/static/app/views/explore/queryParams/writableQueryParams.ts
@@ -1,0 +1,4 @@
+import type {Nullable} from 'sentry/types/utils';
+import type {ReadableQueryParamsOptions} from 'sentry/views/explore/queryParams/readableQueryParams';
+
+export type WritableQueryParams = Partial<Nullable<ReadableQueryParamsOptions>>;

--- a/static/app/views/explore/spans/content.tsx
+++ b/static/app/views/explore/spans/content.tsx
@@ -24,6 +24,7 @@ import {
 import {TraceItemAttributeProvider} from 'sentry/views/explore/contexts/traceItemAttributeContext';
 import {useGetSavedQuery} from 'sentry/views/explore/hooks/useGetSavedQueries';
 import {SavedQueryEditMenu} from 'sentry/views/explore/savedQueryEditMenu';
+import {SpansQueryParamsProvider} from 'sentry/views/explore/spans/spansQueryParamsProvider';
 import {SpansTabContent, SpansTabOnboarding} from 'sentry/views/explore/spans/spansTab';
 import {
   EXPLORE_SPANS_TOUR_GUIDE_KEY,
@@ -72,9 +73,11 @@ function SpansTabWrapper({children}: SpansTabContextProps) {
   return (
     <SpansTabTourProvider>
       <SpansTabTourTrigger />
-      <PageParamsProvider>
-        <ExploreTagsProvider>{children}</ExploreTagsProvider>
-      </PageParamsProvider>
+      <SpansQueryParamsProvider>
+        <PageParamsProvider>
+          <ExploreTagsProvider>{children}</ExploreTagsProvider>
+        </PageParamsProvider>
+      </SpansQueryParamsProvider>
     </SpansTabTourProvider>
   );
 }

--- a/static/app/views/explore/spans/spansQueryParams.spec.tsx
+++ b/static/app/views/explore/spans/spansQueryParams.spec.tsx
@@ -1,0 +1,380 @@
+import type {Location} from 'history';
+import {LocationFixture} from 'sentry-fixture/locationFixture';
+
+import {initializeOrg} from 'sentry-test/initializeOrg';
+
+import {Mode} from 'sentry/views/explore/queryParams/mode';
+import type {ReadableQueryParamsOptions} from 'sentry/views/explore/queryParams/readableQueryParams';
+import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
+import {Visualize} from 'sentry/views/explore/queryParams/visualize';
+import {getReadableQueryParamsFromLocation} from 'sentry/views/explore/spans/spansQueryParams';
+import {ChartType} from 'sentry/views/insights/common/components/chart';
+
+function locationFixture(query: Location['query']): Location {
+  return LocationFixture({query});
+}
+
+function readableQueryParamOptions(
+  options: Partial<ReadableQueryParamsOptions> = {}
+): ReadableQueryParamsOptions {
+  return {
+    mode: Mode.SAMPLES,
+    query: '',
+    cursor: '',
+    fields: [
+      'id',
+      'span.op',
+      'span.description',
+      'span.duration',
+      'transaction',
+      'timestamp',
+    ],
+    sortBys: [{field: 'timestamp', kind: 'desc'}],
+    aggregateCursor: '',
+    aggregateFields: [{groupBy: ''}, new Visualize('count(span.duration)')],
+    aggregateSortBys: [
+      {
+        field: 'count(span.duration)',
+        kind: 'desc',
+      },
+    ],
+    ...options,
+  };
+}
+
+describe('getReadableQueryParamsFromLocation', function () {
+  const {organization} = initializeOrg();
+
+  it('decodes defaults correctly', function () {
+    const location = locationFixture({});
+    const queryParams = getReadableQueryParamsFromLocation(location, organization);
+    expect(queryParams).toEqual(new ReadableQueryParams(readableQueryParamOptions()));
+  });
+
+  it('decodes samples mode correctly', function () {
+    const location = locationFixture({mode: 'samples'});
+    const queryParams = getReadableQueryParamsFromLocation(location, organization);
+    expect(queryParams).toEqual(
+      new ReadableQueryParams(readableQueryParamOptions({mode: Mode.SAMPLES}))
+    );
+  });
+
+  it('decodes aggregate mode correctly', function () {
+    const location = locationFixture({mode: 'aggregate'});
+    const queryParams = getReadableQueryParamsFromLocation(location, organization);
+    expect(queryParams).toEqual(
+      new ReadableQueryParams(readableQueryParamOptions({mode: Mode.AGGREGATE}))
+    );
+  });
+
+  it('defaults to samples mode for invalid mode values', function () {
+    const location = locationFixture({mode: 'invalid'});
+    const queryParams = getReadableQueryParamsFromLocation(location, organization);
+    expect(queryParams).toEqual(
+      new ReadableQueryParams(readableQueryParamOptions({mode: Mode.SAMPLES}))
+    );
+  });
+
+  it('decodes empty query correctly', function () {
+    const location = locationFixture({query: ''});
+    const queryParams = getReadableQueryParamsFromLocation(location, organization);
+    expect(queryParams).toEqual(
+      new ReadableQueryParams(readableQueryParamOptions({query: ''}))
+    );
+  });
+
+  it('decodes custom query parameter correctly', function () {
+    const location = locationFixture({query: 'span.op:db'});
+    const queryParams = getReadableQueryParamsFromLocation(location, organization);
+    expect(queryParams).toEqual(
+      new ReadableQueryParams(readableQueryParamOptions({query: 'span.op:db'}))
+    );
+  });
+
+  it('decodes empty cursor correctly', function () {
+    const location = locationFixture({cursor: ''});
+    const queryParams = getReadableQueryParamsFromLocation(location, organization);
+    expect(queryParams).toEqual(
+      new ReadableQueryParams(
+        readableQueryParamOptions({cursor: '', aggregateCursor: ''})
+      )
+    );
+  });
+
+  it('decodes custom cursor parameter correctly', function () {
+    const location = locationFixture({cursor: '0:0:1'});
+    const queryParams = getReadableQueryParamsFromLocation(location, organization);
+    expect(queryParams).toEqual(
+      new ReadableQueryParams(
+        readableQueryParamOptions({cursor: '0:0:1', aggregateCursor: '0:0:1'})
+      )
+    );
+  });
+
+  it('decodes empty fields correctly', function () {
+    const location = locationFixture({field: []});
+    const queryParams = getReadableQueryParamsFromLocation(location, organization);
+    expect(queryParams).toEqual(
+      new ReadableQueryParams(
+        readableQueryParamOptions({
+          fields: [
+            'id',
+            'span.op',
+            'span.description',
+            'span.duration',
+            'transaction',
+            'timestamp',
+          ],
+        })
+      )
+    );
+  });
+
+  it('decodes empty fields correctly for otel', function () {
+    const {organization: org} = initializeOrg({
+      organization: {
+        features: ['performance-otel-friendly-ui'],
+      },
+    });
+
+    const location = locationFixture({field: []});
+    const queryParams = getReadableQueryParamsFromLocation(location, org);
+    expect(queryParams).toEqual(
+      new ReadableQueryParams(
+        readableQueryParamOptions({
+          fields: ['id', 'span.name', 'span.duration', 'timestamp'],
+        })
+      )
+    );
+  });
+
+  it('decodes custom fields correctly', function () {
+    const location = locationFixture({
+      field: ['id', 'span.op', 'span.duration', 'timestamp'],
+    });
+    const queryParams = getReadableQueryParamsFromLocation(location, organization);
+    expect(queryParams).toEqual(
+      new ReadableQueryParams(
+        readableQueryParamOptions({
+          fields: ['id', 'span.op', 'span.duration', 'timestamp'],
+        })
+      )
+    );
+  });
+
+  it('decodes custom sortBys correctly', function () {
+    const location = locationFixture({sort: ['-span.duration', 'timestamp']});
+    const queryParams = getReadableQueryParamsFromLocation(location, organization);
+    expect(queryParams).toEqual(
+      new ReadableQueryParams(
+        readableQueryParamOptions({
+          sortBys: [
+            {field: 'span.duration', kind: 'desc'},
+            {field: 'timestamp', kind: 'asc'},
+          ],
+        })
+      )
+    );
+  });
+
+  it('uses timestamp sort when fields include timestamp', function () {
+    const location = locationFixture({field: ['id', 'span.op', 'timestamp'], sort: []});
+    const queryParams = getReadableQueryParamsFromLocation(location, organization);
+    expect(queryParams).toEqual(
+      new ReadableQueryParams(
+        readableQueryParamOptions({
+          fields: ['id', 'span.op', 'timestamp'],
+          sortBys: [{field: 'timestamp', kind: 'desc'}],
+        })
+      )
+    );
+  });
+
+  it('falls back to first field when fields do not include timestamp', function () {
+    const location = locationFixture({field: ['id', 'span.op'], sort: []});
+    const queryParams = getReadableQueryParamsFromLocation(location, organization);
+    expect(queryParams).toEqual(
+      new ReadableQueryParams(
+        readableQueryParamOptions({
+          fields: ['id', 'span.op'],
+          sortBys: [{field: 'id', kind: 'desc'}],
+        })
+      )
+    );
+  });
+
+  it('decodes empty sort correctly', function () {
+    const location = locationFixture({sort: []});
+    const queryParams = getReadableQueryParamsFromLocation(location, organization);
+    expect(queryParams).toEqual(
+      new ReadableQueryParams(
+        readableQueryParamOptions({
+          sortBys: [{field: 'timestamp', kind: 'desc'}],
+        })
+      )
+    );
+  });
+
+  it('decodes custom group bys correctly', function () {
+    const location = locationFixture({groupBy: ['span.op', 'transaction']});
+    const queryParams = getReadableQueryParamsFromLocation(location, organization);
+    expect(queryParams).toEqual(
+      new ReadableQueryParams(
+        readableQueryParamOptions({
+          aggregateFields: [
+            {groupBy: 'span.op'},
+            {groupBy: 'transaction'},
+            new Visualize('count(span.duration)'),
+          ],
+        })
+      )
+    );
+  });
+
+  it('decodes custom visualizes correctly', function () {
+    const location = locationFixture({
+      visualize: JSON.stringify({yAxes: ['count(span.duration)', 'avg(span.self_time)']}),
+    });
+    const queryParams = getReadableQueryParamsFromLocation(location, organization);
+    expect(queryParams.aggregateFields).toHaveLength(3);
+    expect(queryParams.aggregateFields[0]).toEqual({groupBy: ''});
+    expect(queryParams.aggregateFields[1]).toEqual(new Visualize('count(span.duration)'));
+    expect(queryParams.aggregateFields[2]).toEqual(new Visualize('avg(span.self_time)'));
+    expect(queryParams).toEqual(
+      new ReadableQueryParams(
+        readableQueryParamOptions({
+          aggregateFields: [
+            {groupBy: ''},
+            new Visualize('count(span.duration)'),
+            new Visualize('avg(span.self_time)'),
+          ],
+        })
+      )
+    );
+  });
+
+  it('decodes custom visualizes with chart type correctly', function () {
+    const location = locationFixture({
+      visualize: JSON.stringify({
+        yAxes: ['count(span.duration)', 'avg(span.self_time)'],
+        chartType: ChartType.LINE,
+      }),
+    });
+    const queryParams = getReadableQueryParamsFromLocation(location, organization);
+    expect(queryParams).toEqual(
+      new ReadableQueryParams(
+        readableQueryParamOptions({
+          aggregateFields: [
+            {groupBy: ''},
+            new Visualize('count(span.duration)', {chartType: ChartType.LINE}),
+            new Visualize('avg(span.self_time)', {chartType: ChartType.LINE}),
+          ],
+        })
+      )
+    );
+  });
+
+  it('decodes custom aggregate fields correctly', function () {
+    const location = locationFixture({
+      aggregateField: [
+        {yAxes: ['count(span.duration)'], chartType: ChartType.AREA},
+        {groupBy: 'span.op'},
+        {yAxes: ['p50(span.duration)', 'p75(span.duration)']},
+      ].map(aggregateField => JSON.stringify(aggregateField)),
+    });
+    const queryParams = getReadableQueryParamsFromLocation(location, organization);
+    expect(queryParams).toEqual(
+      new ReadableQueryParams(
+        readableQueryParamOptions({
+          aggregateFields: [
+            new Visualize('count(span.duration)', {chartType: ChartType.AREA}),
+            {groupBy: 'span.op'},
+            new Visualize('p50(span.duration)'),
+            new Visualize('p75(span.duration)'),
+          ],
+        })
+      )
+    );
+  });
+
+  it('decodes custom aggregatefields and inserts default group bys', function () {
+    const location = locationFixture({
+      aggregateField: [
+        JSON.stringify({yAxes: ['count(span.duration)'], chartType: ChartType.LINE}),
+      ],
+    });
+    const queryParams = getReadableQueryParamsFromLocation(location, organization);
+    expect(queryParams).toEqual(
+      new ReadableQueryParams(
+        readableQueryParamOptions({
+          aggregateFields: [
+            new Visualize('count(span.duration)', {chartType: ChartType.LINE}),
+            {groupBy: ''},
+          ],
+        })
+      )
+    );
+  });
+
+  it('decodes custom aggregatefields and inserts default visualizes', function () {
+    const location = locationFixture({
+      aggregateField: [JSON.stringify({groupBy: 'span.op'})],
+    });
+    const queryParams = getReadableQueryParamsFromLocation(location, organization);
+    expect(queryParams.aggregateFields).toHaveLength(2);
+    expect(queryParams.aggregateFields[0]).toEqual({groupBy: 'span.op'});
+    expect(queryParams.aggregateFields[1]).toEqual(new Visualize('count(span.duration)'));
+    expect(queryParams).toEqual(
+      new ReadableQueryParams(
+        readableQueryParamOptions({
+          aggregateFields: [{groupBy: 'span.op'}, new Visualize('count(span.duration)')],
+        })
+      )
+    );
+  });
+
+  it('decodes custom aggregate sort bys correctly', function () {
+    const location = locationFixture({
+      aggregateField: [
+        {groupBy: 'span.op'},
+        {yAxes: ['p50(span.duration)']},
+        {yAxes: ['avg(span.duration)'], chartType: ChartType.AREA},
+      ].map(aggregateField => JSON.stringify(aggregateField)),
+      aggregateSort: ['-span.op', 'avg(span.duration)'],
+    });
+    const queryParams = getReadableQueryParamsFromLocation(location, organization);
+    expect(queryParams).toEqual(
+      new ReadableQueryParams(
+        readableQueryParamOptions({
+          aggregateFields: [
+            {groupBy: 'span.op'},
+            new Visualize('p50(span.duration)'),
+            new Visualize('avg(span.duration)', {chartType: ChartType.AREA}),
+          ],
+          aggregateSortBys: [
+            {field: 'span.op', kind: 'desc'},
+            {field: 'avg(span.duration)', kind: 'asc'},
+          ],
+        })
+      )
+    );
+  });
+
+  it('decodes invalid aggregate sorts and falls back to first visualize', function () {
+    const location = locationFixture({
+      aggregateField: [{groupBy: ''}, {yAxes: ['p50(span.duration)']}].map(
+        aggregateField => JSON.stringify(aggregateField)
+      ),
+      aggregateSort: ['-avg(span.duration)'],
+    });
+    const queryParams = getReadableQueryParamsFromLocation(location, organization);
+    expect(queryParams).toEqual(
+      new ReadableQueryParams(
+        readableQueryParamOptions({
+          aggregateFields: [{groupBy: ''}, new Visualize('p50(span.duration)')],
+          aggregateSortBys: [{field: 'p50(span.duration)', kind: 'desc'}],
+        })
+      )
+    );
+  });
+});

--- a/static/app/views/explore/spans/spansQueryParams.tsx
+++ b/static/app/views/explore/spans/spansQueryParams.tsx
@@ -1,0 +1,185 @@
+import type {Location} from 'history';
+
+import type {Organization} from 'sentry/types/organization';
+import type {Sort} from 'sentry/utils/discover/fields';
+import {DEFAULT_VISUALIZATION} from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
+import type {AggregateField} from 'sentry/views/explore/queryParams/aggregateField';
+import {getAggregateFieldsFromLocation} from 'sentry/views/explore/queryParams/aggregateField';
+import {getAggregateSortBysFromLocation} from 'sentry/views/explore/queryParams/aggregateSortBy';
+import {getCursorFromLocation} from 'sentry/views/explore/queryParams/cursor';
+import {getFieldsFromLocation} from 'sentry/views/explore/queryParams/field';
+import type {GroupBy} from 'sentry/views/explore/queryParams/groupBy';
+import {
+  getGroupBysFromLocation,
+  isGroupBy,
+} from 'sentry/views/explore/queryParams/groupBy';
+import {getModeFromLocation} from 'sentry/views/explore/queryParams/mode';
+import {getQueryFromLocation} from 'sentry/views/explore/queryParams/query';
+import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
+import {getSortBysFromLocation} from 'sentry/views/explore/queryParams/sortBy';
+import {
+  getVisualizesFromLocation,
+  isVisualize,
+  Visualize,
+} from 'sentry/views/explore/queryParams/visualize';
+import {SpanFields} from 'sentry/views/insights/types';
+
+const SPANS_MODE_KEY = 'mode';
+const SPANS_QUERY_KEY = 'query';
+const SPANS_CURSOR_KEY = 'cursor';
+const SPANS_FIELD_KEY = 'field';
+const SPANS_SORT_KEY = 'sort';
+const SPANS_AGGREGATE_FIELD_KEY = 'aggregateField';
+const SPANS_GROUP_BY_KEY = 'groupBy';
+const SPANS_VISUALIZATION_KEY = 'visualize';
+const SPANS_AGGREGATE_SORT_KEY = 'aggregateSort';
+
+export function getReadableQueryParamsFromLocation(
+  location: Location,
+  organization: Organization
+): ReadableQueryParams {
+  const mode = getModeFromLocation(location, SPANS_MODE_KEY);
+  const query = getQueryFromLocation(location, SPANS_QUERY_KEY) ?? '';
+
+  const cursor = getCursorFromLocation(location, SPANS_CURSOR_KEY);
+  const fields =
+    getFieldsFromLocation(location, SPANS_FIELD_KEY) ?? defaultFields(organization);
+  const sortBys =
+    getSortBysFromLocation(location, SPANS_SORT_KEY, fields) ?? defaultSortBys(fields);
+
+  const aggregateCursor = cursor; // currently sharing a single cursor between modes
+  const aggregateFields = getSpansAggregateFieldsFromLocation(location);
+  const aggregateSortBys =
+    getAggregateSortBysFromLocation(
+      location,
+      SPANS_AGGREGATE_SORT_KEY,
+      aggregateFields
+    ) ?? defaultAggregateSortBys(aggregateFields);
+
+  return new ReadableQueryParams({
+    mode,
+    query,
+
+    cursor,
+    fields,
+    sortBys,
+
+    aggregateCursor,
+    aggregateFields,
+    aggregateSortBys,
+  });
+}
+
+function defaultFields(organization: Organization): string[] {
+  if (organization.features.includes('performance-otel-friendly-ui')) {
+    return [
+      SpanFields.ID,
+      SpanFields.NAME,
+      SpanFields.SPAN_DURATION,
+      SpanFields.TIMESTAMP,
+    ];
+  }
+
+  return [
+    'id',
+    'span.op',
+    'span.description',
+    'span.duration',
+    'transaction',
+    'timestamp',
+  ];
+}
+
+function defaultSortBys(fields: string[]): Sort[] {
+  if (fields.includes('timestamp')) {
+    return [
+      {
+        field: 'timestamp',
+        kind: 'desc' as const,
+      },
+    ];
+  }
+
+  if (fields.length) {
+    return [
+      {
+        field: fields[0]!,
+        kind: 'desc' as const,
+      },
+    ];
+  }
+
+  return [];
+}
+
+function defaultGroupBys(): [GroupBy] {
+  return [{groupBy: ''}];
+}
+
+function defaultVisualizes(): [Visualize] {
+  return [new Visualize(DEFAULT_VISUALIZATION)];
+}
+
+function getSpansAggregateFieldsFromLocation(location: Location): AggregateField[] {
+  const aggregateFields = getAggregateFieldsFromLocation(
+    location,
+    SPANS_AGGREGATE_FIELD_KEY
+  );
+
+  if (aggregateFields?.length) {
+    let hasGroupBy = false;
+    let hasVisualize = false;
+    for (const aggregateField of aggregateFields) {
+      if (isGroupBy(aggregateField)) {
+        hasGroupBy = true;
+      } else if (isVisualize(aggregateField)) {
+        hasVisualize = true;
+      }
+    }
+
+    // We have at least 1 group by or 1 visualize, insert some
+    // defaults to make sure we have at least 1 of both
+
+    if (!hasGroupBy) {
+      aggregateFields.push(...defaultGroupBys());
+    }
+
+    if (!hasVisualize) {
+      aggregateFields.push(...defaultVisualizes());
+    }
+
+    return aggregateFields;
+  }
+
+  return [
+    ...(getGroupBysFromLocation(location, SPANS_GROUP_BY_KEY) ?? defaultGroupBys()),
+    ...(getVisualizesFromLocation(location, SPANS_VISUALIZATION_KEY) ??
+      defaultVisualizes()),
+  ];
+}
+
+function defaultAggregateSortBys(aggregateFields: AggregateField[]): Sort[] {
+  for (const aggregateField of aggregateFields) {
+    if (isVisualize(aggregateField)) {
+      return [
+        {
+          field: aggregateField.yAxis,
+          kind: 'desc' as const,
+        },
+      ];
+    }
+  }
+
+  for (const aggregateField of aggregateFields) {
+    if (isGroupBy(aggregateField)) {
+      return [
+        {
+          field: aggregateField.groupBy,
+          kind: 'desc' as const,
+        },
+      ];
+    }
+  }
+
+  return [];
+}

--- a/static/app/views/explore/spans/spansQueryParamsProvider.tsx
+++ b/static/app/views/explore/spans/spansQueryParamsProvider.tsx
@@ -1,0 +1,38 @@
+import type {ReactNode} from 'react';
+import {useCallback, useMemo} from 'react';
+
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import {QueryParamsContextProvider} from 'sentry/views/explore/queryParams/context';
+import type {WritableQueryParams} from 'sentry/views/explore/queryParams/writableQueryParams';
+import {getReadableQueryParamsFromLocation} from 'sentry/views/explore/spans/spansQueryParams';
+
+interface SpansQueryParamsProviderProps {
+  children: ReactNode;
+}
+
+export function SpansQueryParamsProvider({children}: SpansQueryParamsProviderProps) {
+  const location = useLocation();
+  const organization = useOrganization();
+
+  const readableQueryParams = useMemo(
+    () => getReadableQueryParamsFromLocation(location, organization),
+    [location, organization]
+  );
+
+  const setWritableQueryParams = useCallback(
+    (_writableQueryParams: WritableQueryParams) => {
+      // TODO
+    },
+    []
+  );
+
+  return (
+    <QueryParamsContextProvider
+      queryParams={readableQueryParams}
+      setQueryParams={setWritableQueryParams}
+    >
+      {children}
+    </QueryParamsContextProvider>
+  );
+}


### PR DESCRIPTION
This introduces SpansQueryParamsProvider and LogsQueryParamsProvider that shares a context and will serve as the unified replacement for the existing providers.