### PR TITLE
chore(seer): delete usage of seer automation feature flag

### DIFF
--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -491,28 +491,6 @@ class OrganizationSerializer(BaseOrganizationSerializer):
 
         return value
 
-    def validate_defaultAutofixAutomationTuning(self, value):
-        organization = self.context["organization"]
-        request = self.context["request"]
-        if not features.has(
-            "organizations:trigger-autofix-on-issue-summary", organization, actor=request.user
-        ):
-            raise serializers.ValidationError(
-                "Organization does not have the trigger-autofix-on-issue-summary feature enabled."
-            )
-        return value
-
-    def validate_defaultSeerScannerAutomation(self, value):
-        organization = self.context["organization"]
-        request = self.context["request"]
-        if not features.has(
-            "organizations:trigger-autofix-on-issue-summary", organization, actor=request.user
-        ):
-            raise serializers.ValidationError(
-                "Organization does not have the trigger-autofix-on-issue-summary feature enabled."
-            )
-        return value
-
     def validate(self, attrs):
         attrs = super().validate(attrs)
         if attrs.get("avatarType") == "upload":

--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -101,28 +101,6 @@ class ProjectMemberSerializer(serializers.Serializer):
     )
     seerScannerAutomation = serializers.BooleanField(required=False)
 
-    def validate_autofixAutomationTuning(self, value):
-        organization = self.context["project"].organization
-        actor = self.context["request"].user
-        if not features.has(
-            "organizations:trigger-autofix-on-issue-summary", organization, actor=actor
-        ):
-            raise serializers.ValidationError(
-                "Organization does not have the trigger-autofix-on-issue-summary feature enabled."
-            )
-        return value
-
-    def validate_seerScannerAutomation(self, value):
-        organization = self.context["project"].organization
-        actor = self.context["request"].user
-        if not features.has(
-            "organizations:trigger-autofix-on-issue-summary", organization, actor=actor
-        ):
-            raise serializers.ValidationError(
-                "Organization does not have the trigger-autofix-on-issue-summary feature enabled."
-            )
-        return value
-
 
 @extend_schema_serializer(
     exclude_fields=[

--- a/src/sentry/integrations/utils/issue_summary_for_alerts.py
+++ b/src/sentry/integrations/utils/issue_summary_for_alerts.py
@@ -24,8 +24,6 @@ def fetch_issue_summary(group: Group) -> dict[str, Any] | None:
         return None
     if not features.has("organizations:gen-ai-features", group.organization):
         return None
-    if not features.has("organizations:trigger-autofix-on-issue-summary", group.organization):
-        return None
     project = group.project
     if not project.get_option("sentry:seer_scanner_automation"):
         return None

--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -271,12 +271,7 @@ def _run_automation(
     event: GroupEvent,
     source: SeerAutomationSource,
 ) -> None:
-    if (
-        not features.has(
-            "organizations:trigger-autofix-on-issue-summary", group.organization, actor=user
-        )
-        or source == SeerAutomationSource.ISSUE_DETAILS
-    ):
+    if source == SeerAutomationSource.ISSUE_DETAILS:
         return
 
     user_id = user.id if user else None

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1592,9 +1592,7 @@ def kick_off_seer_automation(job: PostProcessJob) -> None:
     ]:
         return
 
-    if not features.has("organizations:gen-ai-features", group.organization) or not features.has(
-        "organizations:trigger-autofix-on-issue-summary", group.organization
-    ):
+    if not features.has("organizations:gen-ai-features", group.organization):
         return
 
     gen_ai_allowed = not group.organization.get_option("sentry:hide_ai_features")

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -1349,31 +1349,12 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
         data = {"samplingMode": "invalid"}
         self.get_error_response(self.organization.slug, status_code=400, **data)
 
-    @with_feature("organizations:trigger-autofix-on-issue-summary")
-    def test_default_autofix_automation_tuning_feature_enabled(self) -> None:
+    def test_default_autofix_automation_tuning(self) -> None:
         data = {"defaultAutofixAutomationTuning": "high"}
         self.get_success_response(self.organization.slug, **data)
         assert self.organization.get_option("sentry:default_autofix_automation_tuning") == "high"
 
-    @with_feature({"organizations:trigger-autofix-on-issue-summary": False})
-    def test_default_autofix_automation_tuning_feature_disabled(self) -> None:
-        data = {"defaultAutofixAutomationTuning": "high"}
-        response = self.get_error_response(self.organization.slug, status_code=400, **data)
-        assert response.data["defaultAutofixAutomationTuning"] == [
-            "Organization does not have the trigger-autofix-on-issue-summary feature enabled."
-        ]
-        assert self.organization.get_option("sentry:default_autofix_automation_tuning") is None
-
-    @with_feature({"organizations:trigger-autofix-on-issue-summary": False})
-    def test_default_seer_scanner_automation_feature_disabled(self) -> None:
-        data = {"defaultSeerScannerAutomation": True}
-        response = self.get_error_response(self.organization.slug, status_code=400, **data)
-        assert response.data["defaultSeerScannerAutomation"] == [
-            "Organization does not have the trigger-autofix-on-issue-summary feature enabled."
-        ]
-
-    @with_feature({"organizations:trigger-autofix-on-issue-summary": True})
-    def test_default_seer_scanner_automation_feature_enabled(self) -> None:
+    def test_default_seer_scanner_automation(self) -> None:
         data = {"defaultSeerScannerAutomation": True}
         self.get_success_response(self.organization.slug, **data)
         assert self.organization.get_option("sentry:default_seer_scanner_automation") is True

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -2121,69 +2121,41 @@ class TestSeerProjectDetails(TestProjectDetailsBase):
         self.authorization = f"Bearer {token.token}"
 
     def test_autofix_automation_tuning(self) -> None:
-        # Test without feature flag - should fail
+        # Test with invalid value - should fail
         resp = self.get_error_response(
-            self.org_slug, self.proj_slug, autofixAutomationTuning="off", status_code=400
+            self.org_slug, self.proj_slug, autofixAutomationTuning="invalid", status_code=400
         )
-        assert (
-            "trigger-autofix-on-issue-summary feature enabled"
-            in resp.data["autofixAutomationTuning"][0]
-        )
+        assert '"invalid" is not a valid choice.' in resp.data["autofixAutomationTuning"][0]
         assert self.project.get_option("sentry:autofix_automation_tuning") == "off"  # default
 
-        # Test with feature flag but invalid value - should fail
-        with self.feature("organizations:trigger-autofix-on-issue-summary"):
-            resp = self.get_error_response(
-                self.org_slug, self.proj_slug, autofixAutomationTuning="invalid", status_code=400
-            )
-            assert '"invalid" is not a valid choice.' in resp.data["autofixAutomationTuning"][0]
-            assert self.project.get_option("sentry:autofix_automation_tuning") == "off"  # default
+        # Test with valid value - should succeed
+        resp = self.get_success_response(
+            self.org_slug, self.proj_slug, autofixAutomationTuning="medium"
+        )
+        assert self.project.get_option("sentry:autofix_automation_tuning") == "medium"
+        assert resp.data["autofixAutomationTuning"] == "medium"
 
-            # Test with feature flag and valid value - should succeed
-            resp = self.get_success_response(
-                self.org_slug, self.proj_slug, autofixAutomationTuning="medium"
-            )
-            assert self.project.get_option("sentry:autofix_automation_tuning") == "medium"
-            assert resp.data["autofixAutomationTuning"] == "medium"
-
-            # Test setting back to off
-            resp = self.get_success_response(
-                self.org_slug, self.proj_slug, autofixAutomationTuning="off"
-            )
-            assert self.project.get_option("sentry:autofix_automation_tuning") == "off"
-            assert resp.data["autofixAutomationTuning"] == "off"
+        # Test setting back to off
+        resp = self.get_success_response(
+            self.org_slug, self.proj_slug, autofixAutomationTuning="off"
+        )
+        assert self.project.get_option("sentry:autofix_automation_tuning") == "off"
+        assert resp.data["autofixAutomationTuning"] == "off"
 
     def test_seer_scanner_automation(self) -> None:
-        # Test without feature flag - should fail
+        # Test with invalid value - should fail
         resp = self.get_error_response(
-            self.org_slug, self.proj_slug, seerScannerAutomation=False, status_code=400
+            self.org_slug, self.proj_slug, seerScannerAutomation="invalid", status_code=400
         )
-        assert (
-            "trigger-autofix-on-issue-summary feature enabled"
-            in resp.data["seerScannerAutomation"][0]
-        )
+        assert "Must be a valid boolean." in resp.data["seerScannerAutomation"][0]
         assert self.project.get_option("sentry:seer_scanner_automation") is True  # default
 
-        # Test with feature flag but invalid value - should fail
-        with self.feature("organizations:trigger-autofix-on-issue-summary"):
-            resp = self.get_error_response(
-                self.org_slug, self.proj_slug, seerScannerAutomation="invalid", status_code=400
-            )
-            assert "Must be a valid boolean." in resp.data["seerScannerAutomation"][0]
-            assert self.project.get_option("sentry:seer_scanner_automation") is True  # default
-
-        # Test with feature flag and valid value - should succeed
-        with self.feature("organizations:trigger-autofix-on-issue-summary"):
-            resp = self.get_success_response(
-                self.org_slug, self.proj_slug, seerScannerAutomation=False
-            )
-            assert self.project.get_option("sentry:seer_scanner_automation") is False
-            assert resp.data["seerScannerAutomation"] is False
+        # Test with valid value - should succeed
+        resp = self.get_success_response(self.org_slug, self.proj_slug, seerScannerAutomation=False)
+        assert self.project.get_option("sentry:seer_scanner_automation") is False
+        assert resp.data["seerScannerAutomation"] is False
 
         # Test setting back to on
-        with self.feature("organizations:trigger-autofix-on-issue-summary"):
-            resp = self.get_success_response(
-                self.org_slug, self.proj_slug, seerScannerAutomation=True
-            )
-            assert self.project.get_option("sentry:seer_scanner_automation") is True
-            assert resp.data["seerScannerAutomation"] is True
+        resp = self.get_success_response(self.org_slug, self.proj_slug, seerScannerAutomation=True)
+        assert self.project.get_option("sentry:seer_scanner_automation") is True
+        assert resp.data["seerScannerAutomation"] is True

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -971,16 +971,12 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         }
 
     @override_options({"alerts.issue_summary_timeout": 5})
-    @with_feature(
-        {"organizations:gen-ai-features", "organizations:trigger-autofix-on-issue-summary"}
-    )
+    @with_feature({"organizations:gen-ai-features"})
     @patch(
         "sentry.integrations.utils.issue_summary_for_alerts.get_seer_org_acknowledgement",
         return_value=True,
     )
-    def test_build_group_block_with_ai_summary_with_feature_flag(
-        self, mock_get_seer_org_acknowledgement
-    ):
+    def test_build_group_block_with_ai_summary(self, mock_get_seer_org_acknowledgement):
         event = self.store_event(
             data={
                 "event_id": "a" * 32,
@@ -1038,52 +1034,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
             assert "This is a possible cause" in content_block
 
     @override_options({"alerts.issue_summary_timeout": 5})
-    @patch(
-        "sentry.integrations.utils.issue_summary_for_alerts.get_seer_org_acknowledgement",
-        return_value=True,
-    )
-    def test_build_group_block_with_ai_summary_without_feature_flag(
-        self, mock_get_seer_org_acknowledgement
-    ):
-        event = self.store_event(
-            data={
-                "event_id": "a" * 32,
-                "message": "IntegrationError",
-                "fingerprint": ["group-1"],
-                "exception": {
-                    "values": [
-                        {
-                            "type": "IntegrationError",
-                            "value": "Identity not found.",
-                        }
-                    ]
-                },
-                "level": "error",
-            },
-            project_id=self.project.id,
-        )
-        assert event.group
-        group = event.group
-        group.type = ErrorGroupType.type_id
-        group.save()
-        assert group.issue_category == GroupCategory.ERROR
-
-        self.project.flags.has_releases = True
-        self.project.save(update_fields=["flags"])
-        self.project.update_option("sentry:seer_scanner_automation", True)
-
-        patch_path = "sentry.integrations.utils.issue_summary_for_alerts.get_issue_summary"
-
-        with patch(patch_path) as mock_get_summary:
-            mock_get_summary.assert_not_called()
-            blocks = SlackIssuesMessageBuilder(group).build()
-            title_text = blocks["blocks"][0]["elements"][0]["elements"][-1]["text"]
-            assert "IntegrationError" in title_text
-
-    @override_options({"alerts.issue_summary_timeout": 5})
-    @with_feature(
-        {"organizations:gen-ai-features", "organizations:trigger-autofix-on-issue-summary"}
-    )
+    @with_feature({"organizations:gen-ai-features"})
     @patch(
         "sentry.integrations.utils.issue_summary_for_alerts.get_seer_org_acknowledgement",
         return_value=True,
@@ -1233,9 +1184,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         "sentry.integrations.utils.issue_summary_for_alerts.get_issue_summary",
         return_value=(None, 403),
     )
-    @with_feature(
-        {"organizations:gen-ai-features", "organizations:trigger-autofix-on-issue-summary"}
-    )
+    @with_feature({"organizations:gen-ai-features"})
     def test_build_group_block_with_ai_summary_without_org_acknowledgement(
         self, mock_get_issue_summary, mock_get_seer_org_acknowledgement
     ):

--- a/tests/sentry/integrations/utils/test_issue_summary_for_alerts.py
+++ b/tests/sentry/integrations/utils/test_issue_summary_for_alerts.py
@@ -26,7 +26,6 @@ class FetchIssueSummaryTest(TestCase):
         assert result is None
 
     @with_feature("organizations:gen-ai-features")
-    @with_feature("organizations:trigger-autofix-on-issue-summary")
     @patch("sentry.integrations.utils.issue_summary_for_alerts.get_seer_org_acknowledgement")
     @patch("sentry.integrations.utils.issue_summary_for_alerts.is_seer_scanner_rate_limited")
     @patch("sentry.quotas.backend.has_available_reserved_budget")
@@ -48,7 +47,6 @@ class FetchIssueSummaryTest(TestCase):
         mock_has_budget.assert_not_called()
 
     @with_feature("organizations:gen-ai-features")
-    @with_feature("organizations:trigger-autofix-on-issue-summary")
     @patch("sentry.integrations.utils.issue_summary_for_alerts.get_issue_summary")
     @patch("sentry.integrations.utils.issue_summary_for_alerts.get_seer_org_acknowledgement")
     @patch("sentry.integrations.utils.issue_summary_for_alerts.is_seer_scanner_rate_limited")
@@ -78,7 +76,6 @@ class FetchIssueSummaryTest(TestCase):
         mock_get_issue_summary.assert_called_once()
 
     @with_feature("organizations:gen-ai-features")
-    @with_feature("organizations:trigger-autofix-on-issue-summary")
     @patch("sentry.integrations.utils.issue_summary_for_alerts.get_seer_org_acknowledgement")
     def test_fetch_issue_summary_without_seer_scanner_automation(
         self, mock_seer_ack: MagicMock
@@ -92,7 +89,6 @@ class FetchIssueSummaryTest(TestCase):
         assert result is None
 
     @with_feature("organizations:gen-ai-features")
-    @with_feature("organizations:trigger-autofix-on-issue-summary")
     @patch("sentry.integrations.utils.issue_summary_for_alerts.get_seer_org_acknowledgement")
     def test_fetch_issue_summary_without_org_acknowledgement(
         self, mock_seer_ack: MagicMock
@@ -115,17 +111,6 @@ class FetchIssueSummaryTest(TestCase):
         assert result is None
 
     @with_feature("organizations:gen-ai-features")
-    def test_fetch_issue_summary_without_trigger_autofix_feature(self) -> None:
-        """Test that fetch_issue_summary returns None without trigger-autofix-on-issue-summary flag"""
-        self.project.update_option("sentry:seer_scanner_automation", True)
-
-        # Only gen-ai-features enabled, not trigger-autofix-on-issue-summary
-        result = fetch_issue_summary(self.group)
-
-        assert result is None
-
-    @with_feature("organizations:gen-ai-features")
-    @with_feature("organizations:trigger-autofix-on-issue-summary")
     @patch("sentry.integrations.utils.issue_summary_for_alerts.get_seer_org_acknowledgement")
     @patch("sentry.integrations.utils.issue_summary_for_alerts.is_seer_scanner_rate_limited")
     def test_fetch_issue_summary_rate_limited(
@@ -141,7 +126,6 @@ class FetchIssueSummaryTest(TestCase):
         assert result is None
 
     @with_feature("organizations:gen-ai-features")
-    @with_feature("organizations:trigger-autofix-on-issue-summary")
     @patch("sentry.integrations.utils.issue_summary_for_alerts.get_seer_org_acknowledgement")
     @patch("sentry.integrations.utils.issue_summary_for_alerts.is_seer_scanner_rate_limited")
     @patch("sentry.quotas.backend.has_available_reserved_budget")
@@ -159,7 +143,6 @@ class FetchIssueSummaryTest(TestCase):
         assert result is None
 
     @with_feature("organizations:gen-ai-features")
-    @with_feature("organizations:trigger-autofix-on-issue-summary")
     @patch("sentry.integrations.utils.issue_summary_for_alerts.get_issue_summary")
     @patch("sentry.integrations.utils.issue_summary_for_alerts.get_seer_org_acknowledgement")
     @patch("sentry.integrations.utils.issue_summary_for_alerts.is_seer_scanner_rate_limited")
@@ -183,7 +166,6 @@ class FetchIssueSummaryTest(TestCase):
         assert result is None
 
     @with_feature("organizations:gen-ai-features")
-    @with_feature("organizations:trigger-autofix-on-issue-summary")
     @patch("sentry.integrations.utils.issue_summary_for_alerts.get_issue_summary")
     @patch("sentry.integrations.utils.issue_summary_for_alerts.get_seer_org_acknowledgement")
     @patch("sentry.integrations.utils.issue_summary_for_alerts.is_seer_scanner_rate_limited")

--- a/tests/sentry/seer/autofix/test_issue_summary.py
+++ b/tests/sentry/seer/autofix/test_issue_summary.py
@@ -530,7 +530,6 @@ class IssueSummaryTest(APITestCase, SnubaTestCase):
     @patch("sentry.seer.autofix.issue_summary._trigger_autofix_task.delay")
     @patch("sentry.seer.autofix.issue_summary.get_autofix_state")
     @patch("sentry.seer.autofix.issue_summary._generate_fixability_score")
-    @with_feature("organizations:trigger-autofix-on-issue-summary")
     def test_run_automation_saves_fixability_score(
         self,
         mock_generate_fixability_score,
@@ -573,7 +572,6 @@ class IssueSummaryTest(APITestCase, SnubaTestCase):
         self.group.refresh_from_db()
         assert self.group.seer_fixability_score == 0.5
 
-    @with_feature("organizations:trigger-autofix-on-issue-summary")
     @patch("sentry.seer.autofix.issue_summary._trigger_autofix_task.delay")
     @patch("sentry.seer.autofix.issue_summary.get_autofix_state")
     @patch("sentry.seer.autofix.issue_summary._generate_fixability_score")

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -2605,7 +2605,6 @@ class KickOffSeerAutomationTestMixin(BasePostProgressGroupMixin):
     )
     @patch("sentry.tasks.autofix.start_seer_automation.delay")
     @with_feature("organizations:gen-ai-features")
-    @with_feature("organizations:trigger-autofix-on-issue-summary")
     def test_kick_off_seer_automation_with_features(
         self, mock_start_seer_automation, mock_get_seer_org_acknowledgement
     ):
@@ -2629,7 +2628,6 @@ class KickOffSeerAutomationTestMixin(BasePostProgressGroupMixin):
         return_value=True,
     )
     @patch("sentry.tasks.autofix.start_seer_automation.delay")
-    @with_feature("organizations:trigger-autofix-on-issue-summary")
     def test_kick_off_seer_automation_without_org_feature(
         self, mock_start_seer_automation, mock_get_seer_org_acknowledgement
     ):
@@ -2653,7 +2651,6 @@ class KickOffSeerAutomationTestMixin(BasePostProgressGroupMixin):
     )
     @patch("sentry.tasks.autofix.start_seer_automation.delay")
     @with_feature("organizations:gen-ai-features")
-    @with_feature("organizations:trigger-autofix-on-issue-summary")
     def test_kick_off_seer_automation_without_seer_enabled(
         self, mock_start_seer_automation, mock_get_seer_org_acknowledgement
     ):
@@ -2678,7 +2675,6 @@ class KickOffSeerAutomationTestMixin(BasePostProgressGroupMixin):
     )
     @patch("sentry.tasks.autofix.start_seer_automation.delay")
     @with_feature("organizations:gen-ai-features")
-    @with_feature("organizations:trigger-autofix-on-issue-summary")
     def test_kick_off_seer_automation_without_scanner_on(
         self, mock_start_seer_automation, mock_get_seer_org_acknowledgement
     ):
@@ -2704,7 +2700,6 @@ class KickOffSeerAutomationTestMixin(BasePostProgressGroupMixin):
     )
     @patch("sentry.tasks.autofix.start_seer_automation.delay")
     @with_feature("organizations:gen-ai-features")
-    @with_feature("organizations:trigger-autofix-on-issue-summary")
     def test_kick_off_seer_automation_skips_existing_fixability_score(
         self, mock_start_seer_automation, mock_get_seer_org_acknowledgement
     ):
@@ -2734,7 +2729,6 @@ class KickOffSeerAutomationTestMixin(BasePostProgressGroupMixin):
     )
     @patch("sentry.tasks.autofix.start_seer_automation.delay")
     @with_feature("organizations:gen-ai-features")
-    @with_feature("organizations:trigger-autofix-on-issue-summary")
     def test_kick_off_seer_automation_runs_with_missing_fixability_score(
         self, mock_start_seer_automation, mock_get_seer_org_acknowledgement
     ):
@@ -2763,7 +2757,6 @@ class KickOffSeerAutomationTestMixin(BasePostProgressGroupMixin):
     )
     @patch("sentry.tasks.autofix.start_seer_automation.delay")
     @with_feature("organizations:gen-ai-features")
-    @with_feature("organizations:trigger-autofix-on-issue-summary")
     def test_kick_off_seer_automation_skips_with_existing_fixability_score(
         self, mock_start_seer_automation, mock_get_seer_org_acknowledgement
     ):
@@ -2798,7 +2791,6 @@ class KickOffSeerAutomationTestMixin(BasePostProgressGroupMixin):
     @patch("sentry.seer.seer_setup.get_seer_org_acknowledgement")
     @patch("sentry.tasks.autofix.start_seer_automation.delay")
     @with_feature("organizations:gen-ai-features")
-    @with_feature("organizations:trigger-autofix-on-issue-summary")
     def test_rate_limit_only_checked_after_all_other_checks_pass(
         self,
         mock_start_seer_automation,
@@ -2895,7 +2887,6 @@ class KickOffSeerAutomationTestMixin(BasePostProgressGroupMixin):
     )
     @patch("sentry.tasks.autofix.start_seer_automation.delay")
     @with_feature("organizations:gen-ai-features")
-    @with_feature("organizations:trigger-autofix-on-issue-summary")
     def test_kick_off_seer_automation_skips_when_lock_held(
         self, mock_start_seer_automation, mock_get_seer_org_acknowledgement
     ):
@@ -2947,7 +2938,6 @@ class KickOffSeerAutomationTestMixin(BasePostProgressGroupMixin):
     )
     @patch("sentry.tasks.autofix.start_seer_automation.delay")
     @with_feature("organizations:gen-ai-features")
-    @with_feature("organizations:trigger-autofix-on-issue-summary")
     def test_kick_off_seer_automation_with_hide_ai_features_enabled(
         self, mock_start_seer_automation, mock_get_seer_org_acknowledgement
     ):


### PR DESCRIPTION
The feature is fully rolled out so we can remove usage of the flag. This PR removes all backend usage of it and I'll follow up with other PRs