### PR TITLE
feat: Add console section to unreal and native docs

### DIFF
--- a/static/app/components/onboarding/consoleModal.tsx
+++ b/static/app/components/onboarding/consoleModal.tsx
@@ -7,13 +7,14 @@ import {Button} from 'sentry/components/core/button';
 import {Flex} from 'sentry/components/core/layout';
 import {Heading} from 'sentry/components/core/text';
 import ExternalLink from 'sentry/components/links/externalLink';
+import {ConsolePlatform} from 'sentry/constants/consolePlatforms';
 import {t, tct} from 'sentry/locale';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
 import type {Organization} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
 
-const consoleConfig = {
-  playstation: (
+export const CONSOLE_PLATFORM_INSTRUCTIONS = {
+  [ConsolePlatform.PLAYSTATION]: (
     <Fragment>
       <p>
         {t(
@@ -33,7 +34,7 @@ const consoleConfig = {
       </p>
     </Fragment>
   ),
-  'nintendo-switch': (
+  [ConsolePlatform.NINTENDO_SWITCH]: (
     <Fragment>
       <p>
         {tct(
@@ -68,7 +69,7 @@ const consoleConfig = {
       <p>{t('Sentry supports both the original Switch and Switch 2.')}</p>
     </Fragment>
   ),
-  xbox: (
+  [ConsolePlatform.XBOX]: (
     <Fragment>
       <p>
         {t('Sentry supports Xbox One and Series X|S, devkits as well as retail devices.')}
@@ -101,7 +102,7 @@ export function ConsoleModal({
   organization,
 }: ConsoleModalProps & ModalRenderProps) {
   const platformKey = selectedPlatform.key;
-  const config = consoleConfig[platformKey as keyof typeof consoleConfig];
+  const config = CONSOLE_PLATFORM_INSTRUCTIONS[platformKey as ConsolePlatform];
 
   useEffect(() => {
     trackAnalytics('gaming.partner_request_access_guidance_modal_opened', {

--- a/static/app/components/onboarding/gettingStartedDoc/utils/consoleExtensions.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/utils/consoleExtensions.tsx
@@ -1,0 +1,126 @@
+import {Fragment, useState} from 'react';
+
+import {openPrivateGamingSdkAccessModal} from 'sentry/actionCreators/modal';
+import {Alert} from 'sentry/components/core/alert';
+import {Button} from 'sentry/components/core/button';
+import {Flex} from 'sentry/components/core/layout';
+import {ExternalLink} from 'sentry/components/core/link';
+import {SegmentedControl} from 'sentry/components/core/segmentedControl';
+import {CONSOLE_PLATFORM_INSTRUCTIONS} from 'sentry/components/onboarding/consoleModal';
+import type {
+  DocsParams,
+  OnboardingStep,
+} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {
+  CONSOLE_PLATFORM_METADATA,
+  ConsolePlatform,
+} from 'sentry/constants/consolePlatforms';
+import platforms from 'sentry/data/platforms';
+import {IconLock} from 'sentry/icons/iconLock';
+import {t, tct} from 'sentry/locale';
+
+function ConsolePlatformsContent(params: DocsParams) {
+  const [consolePlatform, setConsolePlatform] = useState<ConsolePlatform>(
+    ConsolePlatform.NINTENDO_SWITCH
+  );
+
+  const consoleData = CONSOLE_PLATFORM_METADATA[consolePlatform];
+
+  return (
+    <Flex gap="md" direction="column">
+      <div>
+        <SegmentedControl
+          aria-label={t('Console Platforms')}
+          size="sm"
+          value={consolePlatform}
+          onChange={setConsolePlatform}
+        >
+          <SegmentedControl.Item key={ConsolePlatform.NINTENDO_SWITCH}>
+            {CONSOLE_PLATFORM_METADATA[ConsolePlatform.NINTENDO_SWITCH].displayName}
+          </SegmentedControl.Item>
+          <SegmentedControl.Item key={ConsolePlatform.PLAYSTATION}>
+            {CONSOLE_PLATFORM_METADATA[ConsolePlatform.PLAYSTATION].displayName}
+          </SegmentedControl.Item>
+          <SegmentedControl.Item key={ConsolePlatform.XBOX}>
+            {CONSOLE_PLATFORM_METADATA[ConsolePlatform.XBOX].displayName}
+          </SegmentedControl.Item>
+        </SegmentedControl>
+      </div>
+      {params.organization.enabledConsolePlatforms?.includes(consolePlatform) ? (
+        <Fragment>
+          <p>
+            {tct(
+              'Our Sentry [repoUrl: [consoleName] SDK] extends the core [sentryNativeRepositoryLink:sentry-native] library with [consoleName]-specific implementations for standalone engines and proprietary game engines.',
+              {
+                repoUrl: <ExternalLink href={consoleData.repoURL} />,
+                consoleName: consoleData.displayName,
+                sentryNativeRepositoryLink: (
+                  <ExternalLink href="https://github.com/getsentry/sentry-native" />
+                ),
+              }
+            )}
+          </p>
+          <Alert
+            type="warning"
+            icon={<IconLock size="sm" locked />}
+            showIcon
+            trailingItems={
+              <Button
+                size="sm"
+                priority="primary"
+                onClick={() => {
+                  openPrivateGamingSdkAccessModal({
+                    organization: params.organization,
+                    projectSlug: params.projectSlug,
+                    projectId: params.projectId,
+                    sdkName: consoleData.displayName,
+                    gamingPlatform: consolePlatform,
+                  });
+                }}
+              >
+                {t('Request Access')}
+              </Button>
+            }
+          >
+            {tct(
+              '[strong:Access Restricted]. The [consoleName] SDK is distributed through a private repository under NDA.',
+              {
+                strong: <strong />,
+                consoleName: consoleData.displayName,
+              }
+            )}
+          </Alert>
+          <p>
+            {t('Once the access is granted, you can proceed with the SDK integration.')}
+          </p>
+        </Fragment>
+      ) : (
+        CONSOLE_PLATFORM_INSTRUCTIONS[consolePlatform]
+      )}
+    </Flex>
+  );
+}
+export function getConsoleExtensions(params: DocsParams): OnboardingStep {
+  const platformData = platforms.find(p => p.id === params.platformKey);
+  const platformName = platformData?.name ?? params.platformKey;
+
+  return {
+    title: t('Console Extensions'),
+    collapsible: true,
+    content: [
+      {
+        type: 'text',
+        text: tct(
+          'Sentry provides private console extensions that work alongside your [platformName] project. These extensions offer platform-specific optimizations and additional features.',
+          {
+            platformName,
+          }
+        ),
+      },
+      {
+        type: 'custom',
+        content: <ConsolePlatformsContent {...params} />,
+      },
+    ],
+  };
+}

--- a/static/app/constants/consolePlatforms.ts
+++ b/static/app/constants/consolePlatforms.ts
@@ -1,0 +1,20 @@
+export enum ConsolePlatform {
+  NINTENDO_SWITCH = 'nintendo-switch',
+  PLAYSTATION = 'playstation',
+  XBOX = 'xbox',
+}
+
+export const CONSOLE_PLATFORM_METADATA = {
+  [ConsolePlatform.NINTENDO_SWITCH]: {
+    displayName: 'Nintendo Switch',
+    repoURL: 'https://github.com/getsentry/sentry-switch',
+  },
+  [ConsolePlatform.PLAYSTATION]: {
+    displayName: 'PlayStation',
+    repoURL: 'https://github.com/getsentry/sentry-playstation',
+  },
+  [ConsolePlatform.XBOX]: {
+    displayName: 'Xbox',
+    repoURL: 'https://github.com/getsentry/sentry-xbox',
+  },
+};

--- a/static/app/gettingStartedDocs/native/native.tsx
+++ b/static/app/gettingStartedDocs/native/native.tsx
@@ -5,6 +5,7 @@ import type {
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {getConsoleExtensions} from 'sentry/components/onboarding/gettingStartedDoc/utils/consoleExtensions';
 import {CrashReportWebApiOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
 import {t, tct} from 'sentry/locale';
 
@@ -85,7 +86,7 @@ const onboarding: OnboardingConfig = {
       ],
     },
   ],
-  verify: () => [
+  verify: params => [
     {
       type: StepType.VERIFY,
       content: [
@@ -114,6 +115,7 @@ const onboarding: OnboardingConfig = {
         },
       ],
     },
+    getConsoleExtensions(params),
   ],
 };
 

--- a/static/app/gettingStartedDocs/unreal/unreal.tsx
+++ b/static/app/gettingStartedDocs/unreal/unreal.tsx
@@ -12,6 +12,7 @@ import type {
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {getConsoleExtensions} from 'sentry/components/onboarding/gettingStartedDoc/utils/consoleExtensions';
 import {
   getCrashReportApiIntroduction,
   getCrashReportInstallDescription,
@@ -353,6 +354,7 @@ export SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___`,
         },
       ],
     },
+    getConsoleExtensions(params),
     {
       title: t('Further Settings'),
       content: [


### PR DESCRIPTION
This adds Console Extensions to the Unreal and Native getting started docs. If the console isn’t enabled, we show the same content as the consoleModal. Otherwise, we show content similar to the Console docs (we could potentially make this reusable, but will leave for a follow-up) an intro + a warning with a button to open the modal and request access to the private repo.

**Preview**

https://github.com/user-attachments/assets/80eb6e40-761c-4f26-9543-72cca943b964


closes
https://linear.app/getsentry/issue/TET-971/update-the-unreal-getting-started-doc-to-include-sections-for
https://linear.app/getsentry/issue/TET-970/update-the-native-getting-started-doc-to-include-sections-for

