### PR TITLE
fix(search): MutableSearch stripping quotes from escaped values

### DIFF
--- a/static/app/utils/tokenizeSearch.spec.tsx
+++ b/static/app/utils/tokenizeSearch.spec.tsx
@@ -528,6 +528,53 @@ describe('utils/tokenizeSearch', function () {
         object: new MutableSearch(['transaction:["this has a space",thisdoesnot]']),
         string: 'transaction:["this has a space",thisdoesnot]',
       },
+      {
+        name: 'should preserve quotes around bracket expressions when parsing and formatting',
+        object: new MutableSearch(['message:"[filtered]"']),
+        string: 'message:"[filtered]"',
+      },
+      {
+        name: 'should preserve quotes around bracket expressions when parsing and formatting',
+        object: new MutableSearch(['message:"[Filtered]"']),
+        string: 'message:"[Filtered]"',
+      },
+      {
+        name: 'should not add quotes to unquoted bracket expressions',
+        object: new MutableSearch(['message:[Test]']),
+        string: 'message:[Test]',
+      },
+      {
+        name: 'should not add quotes to unquoted bracket expressions',
+        object: new MutableSearch(['message:[test]']),
+        string: 'message:[test]',
+      },
+      {
+        name: 'should not add quotes to unquoted bracket expressions',
+        object: new MutableSearch(['message:[test,[test2]]']),
+        string: 'message:[test,[test2]]',
+      },
+      {
+        name: 'should preserve brackets within quoted strings when flattening',
+        object: new MutableSearch(['message:["[test]",test,[test2]]']),
+        string: 'message:["[test]",test,[test2]]',
+      },
+      {
+        name: 'should correctly handle nested brackets with quoted brackets inside',
+        object: new MutableSearch(['message:[test,"[nested]",other]']),
+        string: 'message:[test,"[nested]",other]',
+      },
+      {
+        name: 'should handle escaped quotes in array syntax correctly',
+        object: new MutableSearch(['message:["value with \\" escaped quote",other]']),
+        string: 'message:["value with \\" escaped quote",other]',
+      },
+      {
+        name: 'should handle complex escape sequences in array syntax correctly',
+        object: new MutableSearch([
+          'message:["value with \\\\\\" complex escape",other]',
+        ]),
+        string: 'message:["value with \\\\\\" complex escape",other]',
+      },
     ];
 
     for (const {name, string, object} of cases) {

--- a/static/app/utils/tokenizeSearch.spec.tsx
+++ b/static/app/utils/tokenizeSearch.spec.tsx
@@ -575,6 +575,11 @@ describe('utils/tokenizeSearch', function () {
         ]),
         string: 'message:["value with \\\\\\" complex escape",other]',
       },
+      {
+        name: 'should leave escaped brackets as is',
+        object: new MutableSearch(['message:"[test, "[Filtered]"]"']),
+        string: 'message:"[test, "[Filtered]"]"',
+      },
     ];
 
     for (const {name, string, object} of cases) {

--- a/static/app/utils/tokenizeSearch.tsx
+++ b/static/app/utils/tokenizeSearch.tsx
@@ -492,7 +492,17 @@ function parseFilter(filter: string) {
 
     if (c === ':' && !quoted) {
       const key = removeSurroundingQuotes(filter.slice(0, idx));
-      const value = removeSurroundingQuotes(filter.slice(idx + 1));
+      const foundValue = filter.slice(idx + 1);
+
+      const isEscapingBracketsAndSingleValue =
+        foundValue.startsWith('"[') &&
+        foundValue.endsWith(']"') &&
+        !foundValue.includes(',');
+
+      const value = isEscapingBracketsAndSingleValue
+        ? foundValue
+        : removeSurroundingQuotes(foundValue);
+
       return [key, value];
     }
   }

--- a/static/app/utils/tokenizeSearch.tsx
+++ b/static/app/utils/tokenizeSearch.tsx
@@ -493,16 +493,8 @@ function parseFilter(filter: string) {
     if (c === ':' && !quoted) {
       const key = removeSurroundingQuotes(filter.slice(0, idx));
       const foundValue = filter.slice(idx + 1);
-
-      const isEscapingBracketsAndSingleValue =
-        foundValue.startsWith('"[') &&
-        foundValue.endsWith(']"') &&
-        !foundValue.includes(',');
-
-      const value = isEscapingBracketsAndSingleValue
-        ? foundValue
-        : removeSurroundingQuotes(foundValue);
-
+      const isEscapingBrackets = foundValue.startsWith('"[') && foundValue.endsWith(']"');
+      const value = isEscapingBrackets ? foundValue : removeSurroundingQuotes(foundValue);
       return [key, value];
     }
   }

--- a/static/app/utils/tokenizeSearch.tsx
+++ b/static/app/utils/tokenizeSearch.tsx
@@ -506,7 +506,12 @@ function parseFilter(filter: string) {
   // something went wrong, fallback to the naive approach of spliting the filter
   idx = filter.indexOf(':');
   const key = removeSurroundingQuotes(filter.slice(0, idx));
-  const value = removeSurroundingQuotes(filter.slice(idx + 1));
+  const foundValue = filter.slice(idx + 1);
+
+  // This snippet here handles the case where we have a single value that uses quotes
+  // to escape the brackets e.g. message:"[foo]" whereas before it was removing them.
+  const isEscapingBrackets = foundValue.startsWith('"[') && foundValue.endsWith(']"');
+  const value = isEscapingBrackets ? foundValue : removeSurroundingQuotes(foundValue);
 
   return [key, value];
 }

--- a/static/app/utils/tokenizeSearch.tsx
+++ b/static/app/utils/tokenizeSearch.tsx
@@ -493,8 +493,12 @@ function parseFilter(filter: string) {
     if (c === ':' && !quoted) {
       const key = removeSurroundingQuotes(filter.slice(0, idx));
       const foundValue = filter.slice(idx + 1);
+
+      // This snippet here handles the case where we have a single value that uses quotes
+      // to escape the brackets e.g. message:"[foo]" whereas before it was removing them.
       const isEscapingBrackets = foundValue.startsWith('"[') && foundValue.endsWith(']"');
       const value = isEscapingBrackets ? foundValue : removeSurroundingQuotes(foundValue);
+
       return [key, value];
     }
   }


### PR DESCRIPTION
This is the second attempt to fix an issue where the `MutableSearch` class is removing quotes from escaped single values i.e. `message:"[Filtered]" -> message:[Filtered]`, however this PR fixes this to be `message:"[Filtered]" -> message:"[Filtered]"`

Ticket: LOGS-277