### PR TITLE
fix(search-bar): Eagerly removing wildcards for release.version

### DIFF
--- a/static/app/components/searchQueryBuilder/formattedQuery.tsx
+++ b/static/app/components/searchQueryBuilder/formattedQuery.tsx
@@ -54,10 +54,14 @@ function Filter({token}: {token: TokenResult<Token.FILTER>}) {
   const hasWildcardOperators = organization.features.includes(
     'search-query-builder-wildcard-operators'
   );
+  const label = useMemo(
+    () => getOperatorInfo(token, hasWildcardOperators).label,
+    [hasWildcardOperators, token]
+  );
 
   return (
     <FilterWrapper aria-label={token.text}>
-      <FilterKey token={token} /> {getOperatorInfo(token, hasWildcardOperators).label}{' '}
+      <FilterKey token={token} /> {label}{' '}
       <FilterValue>
         <FilterValueText token={token} />
       </FilterValue>

--- a/static/app/components/searchQueryBuilder/tokens/filter/filter.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filter.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useLayoutEffect, useRef, useState} from 'react';
+import {Fragment, useLayoutEffect, useMemo, useRef, useState} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import {useFocusWithin} from '@react-aria/interactions';
@@ -32,7 +32,7 @@ import {IconClose} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
-import {prettifyTagKey} from 'sentry/utils/fields';
+import {getFieldDefinition, prettifyTagKey} from 'sentry/utils/fields';
 import useOrganization from 'sentry/utils/useOrganization';
 
 interface SearchQueryTokenProps {
@@ -50,6 +50,10 @@ export function FilterValueText({token}: {token: TokenResult<Token.FILTER>}) {
   const {size} = useSearchQueryBuilder();
   const hasWildcardOperators = useOrganization().features.includes(
     'search-query-builder-wildcard-operators'
+  );
+  const fieldDefinition = useMemo(
+    () => getFieldDefinition(token.key.text),
+    [token.key.text]
   );
 
   if (token.filter === FilterType.HAS) {
@@ -73,7 +77,10 @@ export function FilterValueText({token}: {token: TokenResult<Token.FILTER>}) {
           <FilterValueSingleTruncatedValue>
             {formatFilterValue({
               token: items[0]!.value,
-              stripWildcards: allContains && hasWildcardOperators,
+              stripWildcards:
+                allContains &&
+                hasWildcardOperators &&
+                !fieldDefinition?.disallowWildcardOperators,
             })}
           </FilterValueSingleTruncatedValue>
         );
@@ -91,7 +98,10 @@ export function FilterValueText({token}: {token: TokenResult<Token.FILTER>}) {
               <FilterMultiValueTruncated>
                 {formatFilterValue({
                   token: item.value!,
-                  stripWildcards: allContains && hasWildcardOperators,
+                  stripWildcards:
+                    allContains &&
+                    hasWildcardOperators &&
+                    !fieldDefinition?.disallowWildcardOperators,
                 })}
               </FilterMultiValueTruncated>
               {index !== items.length - 1 && index < maxItems - 1 ? (
@@ -117,7 +127,10 @@ export function FilterValueText({token}: {token: TokenResult<Token.FILTER>}) {
         <FilterValueSingleTruncatedValue>
           {formatFilterValue({
             token: token.value,
-            stripWildcards: allContains && hasWildcardOperators,
+            stripWildcards:
+              allContains &&
+              hasWildcardOperators &&
+              !fieldDefinition?.disallowWildcardOperators,
           })}
         </FilterValueSingleTruncatedValue>
       );

--- a/static/app/components/searchQueryBuilder/tokens/filter/filter.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filter.tsx
@@ -16,6 +16,7 @@ import {FilterOperator} from 'sentry/components/searchQueryBuilder/tokens/filter
 import {UnstyledButton} from 'sentry/components/searchQueryBuilder/tokens/filter/unstyledButton';
 import {useFilterButtonProps} from 'sentry/components/searchQueryBuilder/tokens/filter/useFilterButtonProps';
 import {
+  areWildcardOperatorsAllowed,
   formatFilterValue,
   isAggregateFilterToken,
 } from 'sentry/components/searchQueryBuilder/tokens/filter/utils';
@@ -80,7 +81,7 @@ export function FilterValueText({token}: {token: TokenResult<Token.FILTER>}) {
               stripWildcards:
                 allContains &&
                 hasWildcardOperators &&
-                !fieldDefinition?.disallowWildcardOperators,
+                areWildcardOperatorsAllowed(fieldDefinition),
             })}
           </FilterValueSingleTruncatedValue>
         );
@@ -101,7 +102,7 @@ export function FilterValueText({token}: {token: TokenResult<Token.FILTER>}) {
                   stripWildcards:
                     allContains &&
                     hasWildcardOperators &&
-                    !fieldDefinition?.disallowWildcardOperators,
+                    areWildcardOperatorsAllowed(fieldDefinition),
                 })}
               </FilterMultiValueTruncated>
               {index !== items.length - 1 && index < maxItems - 1 ? (
@@ -130,7 +131,7 @@ export function FilterValueText({token}: {token: TokenResult<Token.FILTER>}) {
             stripWildcards:
               allContains &&
               hasWildcardOperators &&
-              !fieldDefinition?.disallowWildcardOperators,
+              areWildcardOperatorsAllowed(fieldDefinition),
           })}
         </FilterValueSingleTruncatedValue>
       );

--- a/static/app/components/searchQueryBuilder/tokens/filter/utils.spec.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/utils.spec.tsx
@@ -1,0 +1,59 @@
+import {type FieldDefinition, FieldKind, FieldValueType} from 'sentry/utils/fields';
+
+import {areWildcardOperatorsAllowed} from './utils';
+
+describe('areWildcardOperatorsAllowed', () => {
+  it('returns false when fieldDefinition is null', () => {
+    expect(areWildcardOperatorsAllowed(null)).toBe(false);
+  });
+
+  it('returns false when allowWildcard is explicitly false', () => {
+    const fieldDefinition: FieldDefinition = {
+      kind: FieldKind.FIELD,
+      valueType: FieldValueType.STRING,
+      allowWildcard: false,
+    };
+
+    expect(areWildcardOperatorsAllowed(fieldDefinition)).toBe(false);
+  });
+
+  it('returns true when allowWildcard is true, even if disallowWildcardOperators is true', () => {
+    const fieldDefinition: FieldDefinition = {
+      kind: FieldKind.FIELD,
+      valueType: FieldValueType.STRING,
+      allowWildcard: true,
+      disallowWildcardOperators: true,
+    };
+
+    expect(areWildcardOperatorsAllowed(fieldDefinition)).toBe(false);
+  });
+
+  it('returns false when allowWildcard is undefined and disallowWildcardOperators is true', () => {
+    const fieldDefinition: FieldDefinition = {
+      kind: FieldKind.FIELD,
+      valueType: FieldValueType.STRING,
+      disallowWildcardOperators: true,
+    };
+
+    expect(areWildcardOperatorsAllowed(fieldDefinition)).toBe(false);
+  });
+
+  it('returns true when allowWildcard is undefined and disallowWildcardOperators is false', () => {
+    const fieldDefinition: FieldDefinition = {
+      kind: FieldKind.FIELD,
+      valueType: FieldValueType.STRING,
+      disallowWildcardOperators: false,
+    };
+
+    expect(areWildcardOperatorsAllowed(fieldDefinition)).toBe(true);
+  });
+
+  it('returns true when allowWildcard is undefined and disallowWildcardOperators is undefined', () => {
+    const fieldDefinition: FieldDefinition = {
+      kind: FieldKind.FIELD,
+      valueType: FieldValueType.STRING,
+    };
+
+    expect(areWildcardOperatorsAllowed(fieldDefinition)).toBe(true);
+  });
+});

--- a/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
@@ -103,8 +103,7 @@ export function getValidOpsForFilter(
   // Special case for text, add contains operator
   if (
     hasWildcardOperators &&
-    fieldDefinition?.allowWildcard !== false &&
-    !fieldDefinition?.disallowWildcardOperators &&
+    areWildcardOperatorsAllowed(fieldDefinition) &&
     (filterToken.filter === FilterType.TEXT || filterToken.filter === FilterType.TEXT_IN)
   ) {
     validOps.add(WildcardOperators.CONTAINS);
@@ -229,7 +228,7 @@ export function getLabelAndOperatorFromToken(
   if (
     token.value.type === Token.VALUE_TEXT &&
     hasWildcardOperators &&
-    !fieldDefinition?.disallowWildcardOperators
+    areWildcardOperatorsAllowed(fieldDefinition)
   ) {
     if (getIsContains(token.value.wildcard)) {
       return {
@@ -256,7 +255,7 @@ export function getLabelAndOperatorFromToken(
   } else if (
     token.value.type === Token.VALUE_TEXT_LIST &&
     hasWildcardOperators &&
-    !fieldDefinition?.disallowWildcardOperators
+    areWildcardOperatorsAllowed(fieldDefinition)
   ) {
     if (token.value.items.every(entry => getIsContains(entry.value?.wildcard))) {
       return {
@@ -289,4 +288,25 @@ export function getLabelAndOperatorFromToken(
     label,
     operator,
   };
+}
+
+/**
+ * Determines if wildcard operators should be allowed for a field.
+ *
+ * The logic is:
+ * - If `disallowWildcardOperators` is explicitly true, wildcard operators are not allowed
+ * - If `disallowWildcardOperators` is explicitly false or undefined, check `allowWildcard` (defaults to true)
+ */
+export function areWildcardOperatorsAllowed(
+  fieldDefinition: FieldDefinition | null
+): boolean {
+  if (!fieldDefinition) {
+    return false;
+  }
+
+  if (fieldDefinition.disallowWildcardOperators === true) {
+    return false;
+  }
+
+  return fieldDefinition.allowWildcard ?? true;
 }

--- a/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
@@ -104,6 +104,7 @@ export function getValidOpsForFilter(
   if (
     hasWildcardOperators &&
     fieldDefinition?.allowWildcard !== false &&
+    !fieldDefinition?.disallowWildcardOperators &&
     (filterToken.filter === FilterType.TEXT || filterToken.filter === FilterType.TEXT_IN)
   ) {
     validOps.add(WildcardOperators.CONTAINS);
@@ -223,7 +224,13 @@ export function getLabelAndOperatorFromToken(
   token: TokenResult<Token.FILTER>,
   hasWildcardOperators: boolean
 ) {
-  if (token.value.type === Token.VALUE_TEXT && hasWildcardOperators) {
+  const fieldDefinition = getFieldDefinition(token.key.text);
+
+  if (
+    token.value.type === Token.VALUE_TEXT &&
+    hasWildcardOperators &&
+    !fieldDefinition?.disallowWildcardOperators
+  ) {
     if (getIsContains(token.value.wildcard)) {
       return {
         label: token.negated ? t('does not contain') : t('contains'),
@@ -246,7 +253,11 @@ export function getLabelAndOperatorFromToken(
         operator: WildcardOperators.ENDS_WITH,
       };
     }
-  } else if (token.value.type === Token.VALUE_TEXT_LIST && hasWildcardOperators) {
+  } else if (
+    token.value.type === Token.VALUE_TEXT_LIST &&
+    hasWildcardOperators &&
+    !fieldDefinition?.disallowWildcardOperators
+  ) {
     if (token.value.items.every(entry => getIsContains(entry.value?.wildcard))) {
       return {
         label: token.negated ? t('does not contain') : t('contains'),

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -471,7 +471,7 @@ export interface FieldDefinition {
   /**
    * Allow wildcard (*) matching for this field.
    * This is only valid for string fields and will default to true.
-   * Note that the `disallowWilcard` setting will override this.
+   * Note that the `disallowWildcardOperators` setting will override this.
    */
   allowWildcard?: boolean;
   /**
@@ -489,7 +489,7 @@ export interface FieldDefinition {
   /**
    * Disallow wildcard (contains, starts with, ends with) operators for this field
    * This is only valid for string fields and will default to false.
-   * `allowWildcard` will override this.
+   * Setting this to true will override `allowWildcard`.
    */
   disallowWildcardOperators?: boolean;
   /**

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -487,6 +487,12 @@ export interface FieldDefinition {
    */
   desc?: string;
   /**
+   * Disallow wildcard (contains, starts with, ends with) operators for this field
+   * This is only valid for string fields and will default to false.
+   * `allowWildcard` will override this.
+   */
+  disallowWildcardOperators?: boolean;
+  /**
    * Feature flag that indicates gating of the field from use
    */
   featureFlag?: string;
@@ -1990,6 +1996,7 @@ const RELEASE_FIELD_DEFINITION: Record<ReleaseFieldKey, FieldDefinition> = {
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
     allowComparisonOperators: true,
+    disallowWildcardOperators: true,
   },
 };
 


### PR DESCRIPTION
This PR updates some logic around how we determine if we want to keep wildcard operators appearing and stripping wildcards. By adding a new field to the `FieldDefinition` type `disallowWildcardOperators`, we can disable these operators for defined fields.

This PR currently addresses issues with `release.version` as it follows semantic versioning format which isn't really applicable to these new "wildcard operators" in their current form.

Before:
<img width="255" height="39" alt="Screenshot 2025-08-01 at 11 05 36" src="https://github.com/user-attachments/assets/9388d694-afbd-4c22-a154-5986bd5281de" />

After:
<img width="207" height="38" alt="Screenshot 2025-08-01 at 11 08 09" src="https://github.com/user-attachments/assets/1f85e03a-7635-4400-baf8-3105f9cda6ac" />