### PR TITLE
:recycle: ref(identity service): update `RpcIdentity` to contain `scopes`

### DIFF
--- a/src/sentry/identity/services/identity/model.py
+++ b/src/sentry/identity/services/identity/model.py
@@ -21,6 +21,7 @@ class RpcIdentity(RpcModel):
     idp_id: int  # IdentityProvider id
     user_id: int
     external_id: str
+    scopes: list[str]
     data: dict[str, Any]
 
     def get_identity(self) -> "Provider":

--- a/src/sentry/identity/services/identity/serial.py
+++ b/src/sentry/identity/services/identity/serial.py
@@ -20,5 +20,6 @@ def serialize_identity(identity: "Identity") -> RpcIdentity:
         idp_id=identity.idp_id,
         user_id=identity.user_id,
         external_id=identity.external_id,
+        scopes=identity.scopes,
         data=identity.data,
     )


### PR DESCRIPTION
while fixing typing for OAuth Provider, i found that theoretically we can pass both `Identity` and `RpcIdentity`  here


https://github.com/getsentry/sentry/blob/9f83bb9eeb7df1444145a1d7ac04d53798697992/src/sentry/identity/vsts/provider.py#L93-L94

but RpcIdentity doesn't have scopes. Allthough this provider logic is smelly, i don't see why the RpcIdentity model can't contain the scopes as well (esp since it also already contains the data blob).

A followup PR will read this data.