### PR TITLE
:wrench: chore: prevent plugin post process from generating sentry issues

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1325,8 +1325,9 @@ def plugin_post_process_group(plugin_slug, event, **kwargs):
         )
     except PluginError as e:
         logger.info("post_process.process_error_ignored", extra={"exception": e})
+    # Since plugins are deprecated, instead of creating issues, lets just create a warning log
     except Exception as e:
-        logger.exception("post_process.process_error", extra={"exception": e})
+        logger.warning("post_process.process_error", extra={"exception": e})
 
 
 def feedback_filter_decorator(func):


### PR DESCRIPTION
instead of creating new sentry issues, lets add logs. we can probably remove these logs once we deprecate the plugins, but there are some plugins we need replacements for first, so not sure if i felt comfortable in nuking the log all together.


