### PR TITLE
fix(detectors): Add filtering for Zend1 framework queries 

### DIFF
--- a/fixtures/events/performance_problems/sql-injection/sql-injection-event-zf1.json
+++ b/fixtures/events/performance_problems/sql-injection/sql-injection-event-zf1.json
@@ -1,0 +1,59 @@
+{
+  "event_id": "5d6401994d7949d2ac3474f472564370",
+  "platform": "php",
+  "message": "",
+  "datetime": "2025-05-12T22:42:38.642986+00:00",
+  "breakdowns": {
+    "span_ops": {
+      "ops.db": {
+        "value": 65.715075,
+        "unit": "millisecond"
+      },
+      "total.time": {
+        "value": 67.105293,
+        "unit": "millisecond"
+      }
+    }
+  },
+  "request": {
+    "url": "http://localhost:3001/vulnerable-login",
+    "method": "POST",
+    "data": {
+      "id": "100"
+    }
+  },
+  "spans": [
+    {
+      "timestamp": 1747089758.637715,
+      "start_timestamp": 1747089758.572,
+      "exclusive_time": 65.715075,
+      "op": "db",
+      "span_id": "4703181ac343f71a",
+      "parent_span_id": "91fa92ff0205967d",
+      "trace_id": "375a86eca09a4a4e91903838dd771f50",
+      "status": "ok",
+      "description": "SELECT `users`.* FROM `users` WHERE (id = 100) LIMIT 1",
+      "origin": "auto.db.otel.mysql2",
+      "sentry_tags": {
+        "description": "SELECT `users`.* FROM `users` WHERE (id = 100) LIMIT 1",
+        "platform": "php"
+      },
+      "data": {
+        "event.trace": [
+          {
+            "file": "/models/User.php:101",
+            "function": "Application_Model_User::findById"
+          },
+          {
+            "file": "/models/User.php:102",
+            "function": "Application_Model_User::getRowByIdFromMaster"
+          },
+          {
+            "file": "/models/User.php:300",
+            "function": "Zend_Db_Adapter_Pdo_Mysqext::fetchRow"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/sentry/performance_issues/detectors/sql_injection_detector.py
+++ b/src/sentry/performance_issues/detectors/sql_injection_detector.py
@@ -247,13 +247,13 @@ class SQLInjectionDetector(PerformanceDetector):
 
         # Zend1 can cause false positives
         if span.get("sentry_tags", {}).get("platform") == "php":
-            span_data = span.get("data", {})
-            event_traces = span_data.get("event.trace", []) if span_data else []
-            has_zf1_framework = any(
-                [trace.get("function", "").startswith("Zend_") for trace in event_traces]
-            )
-            if has_zf1_framework:
-                return False
+            span_data = span.get("data")
+            if span_data:
+                event_traces = span_data.get("event.trace", [])
+                if isinstance(event_traces, list) and any(
+                    trace.get("function", "").startswith("Zend_") for trace in event_traces
+                ):
+                    return False
         return True
 
     @classmethod

--- a/src/sentry/performance_issues/detectors/sql_injection_detector.py
+++ b/src/sentry/performance_issues/detectors/sql_injection_detector.py
@@ -247,7 +247,8 @@ class SQLInjectionDetector(PerformanceDetector):
 
         # Zend1 can cause false positives
         if span.get("sentry_tags", {}).get("platform") == "php":
-            event_traces = span.get("data", {}).get("event.trace", [])
+            span_data = span.get("data", {})
+            event_traces = span_data.get("event.trace", []) if span_data else []
             has_zf1_framework = any(
                 [trace.get("function", "").startswith("Zend_") for trace in event_traces]
             )

--- a/src/sentry/performance_issues/detectors/sql_injection_detector.py
+++ b/src/sentry/performance_issues/detectors/sql_injection_detector.py
@@ -247,13 +247,12 @@ class SQLInjectionDetector(PerformanceDetector):
 
         # Zend1 can cause false positives
         if span.get("sentry_tags", {}).get("platform") == "php":
-            span_data = span.get("data")
-            if span_data:
-                event_traces = span_data.get("event.trace", [])
-                if isinstance(event_traces, list) and any(
-                    trace.get("function", "").startswith("Zend_") for trace in event_traces
-                ):
-                    return False
+            span_data = span.get("data", {})
+            event_traces = span_data.get("event.trace", []) if span_data else []
+            if isinstance(event_traces, list) and any(
+                [trace.get("function", "").startswith("Zend_") for trace in event_traces]
+            ):
+                return False
         return True
 
     @classmethod

--- a/tests/sentry/performance_issues/test_sql_injection_detector.py
+++ b/tests/sentry/performance_issues/test_sql_injection_detector.py
@@ -97,3 +97,7 @@ class SQLInjectionDetectorTest(TestCase):
 
         injection_event = get_event("sql-injection/sql-injection-orm-event-deleted-at-null")
         assert len(self.find_problems(injection_event)) == 0
+
+    def test_sql_injection_on_zf1_event(self) -> None:
+        injection_event = get_event("sql-injection/sql-injection-event-zf1")
+        assert len(self.find_problems(injection_event)) == 0


### PR DESCRIPTION
even though the framework is no longer maintained, some users are using it and it can cause false positives. it doesn't show up as a package/module so we have to look at the trace data to see if it appears. 