### PR TITLE
feat(tasks) Simplify taskworker rollout options & update devservices/server

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -94,6 +94,8 @@ x-sentry-service-config:
       description: Workers that process tasks from the taskbroker
     taskworker-scheduler:
       description: Task scheduler that can spawn tasks based on their schedules
+    celery-worker:
+      description: Worker that processes tasks from celery (deprecated)
     # Kafka consumer services for event ingestion
     ingest-events:
       description: Kafka consumer for processing ingested events
@@ -147,8 +149,6 @@ x-sentry-service-config:
     # Uptime monitoring
     uptime-results:
       description: Kafka consumer for uptime monitoring results
-    worker:
-      description: Worker that processes tasks from celery
 
   modes:
     default: [snuba, postgres, relay, spotlight]
@@ -183,7 +183,7 @@ x-sentry-service-config:
         process-spans,
         ingest-occurrences,
         process-segments,
-        worker,
+        taskworker,
       ]
     crons:
       [
@@ -195,7 +195,7 @@ x-sentry-service-config:
         monitors-clock-tick,
         monitors-clock-tasks,
         monitors-incident-occurrences,
-        worker,
+        taskworker,
       ]
     profiling:
       [
@@ -208,7 +208,7 @@ x-sentry-service-config:
         ingest-transactions,
         ingest-profiles,
         ingest-occurrences,
-        worker,
+        taskworker,
         post-process-forwarder-errors,
         post-process-forwarder-transactions,
       ]
@@ -218,7 +218,7 @@ x-sentry-service-config:
         postgres,
         relay,
         spotlight,
-        worker,
+        taskworker,
         ingest-events,
         ingest-transactions,
         ingest-attachments,
@@ -251,7 +251,7 @@ x-sentry-service-config:
         relay,
         snuba,
         spotlight,
-        worker,
+        taskworker,
         vroom,
       ]
     full:
@@ -280,9 +280,8 @@ x-sentry-service-config:
         post-process-forwarder-errors,
         post-process-forwarder-transactions,
         post-process-forwarder-issue-platform,
-        taskworker,
         taskworker-scheduler,
-        worker,
+        taskworker,
       ]
 
 x-programs:
@@ -338,7 +337,7 @@ x-programs:
     command: sentry run consumer metrics-subscription-results --consumer-group=sentry-consumer --auto-offset-reset=latest --no-strict-offset-reset
   generic-metrics-subscription-results:
     command: sentry run consumer generic-metrics-subscription-results --consumer-group=sentry-consumer --auto-offset-reset=latest --no-strict-offset-reset
-  worker:
+  celery-worker:
     command: sentry run worker -c 1 --autoreload
 
 services:

--- a/self-hosted/sentry.conf.py
+++ b/self-hosted/sentry.conf.py
@@ -240,6 +240,12 @@ else:
 if SENTRY_OPTIONS["mail.enable-replies"]:
     SENTRY_OPTIONS["mail.reply-hostname"] = env("SENTRY_SMTP_HOSTNAME") or ""
 
+#########
+# Tasks #
+#########
+# Disable taskworker and continue using celery until docs can be published.
+SENTRY_OPTIONS["taskworker.enabled"] = False
+
 # If this value ever becomes compromised, it's important to regenerate your
 # SENTRY_SECRET_KEY. Changing this value will result in all current sessions
 # being invalidated.

--- a/src/sentry/celery.py
+++ b/src/sentry/celery.py
@@ -112,6 +112,7 @@ class SentryTask(Task):
         self._validate_parameters(args, kwargs)
 
         with metrics.timer("jobs.delay", instance=self.name):
+            # The Task.apply_async() without super is load bearing for BurstRunner :|
             return Task.apply_async(self, *args, **kwargs)
 
     def _validate_parameters(self, args: tuple[Any, ...], kwargs: dict[str, Any]):

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3338,13 +3338,6 @@ register(
 )
 
 register(
-    "taskworker.grpc_service_config",
-    type=String,
-    default="""{"loadBalancingConfig": [{"round_robin": {}}]}""",
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-
-register(
     "sentry.demo_mode.sync_debug_artifacts.enable",
     type=Bool,
     default=False,
@@ -3357,6 +3350,18 @@ register(
 )
 
 # Taskbroker flags
+# Disabled in self-hosted until docs are published.
+register(
+    "taskworker.enabled",
+    default=True,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "taskworker.grpc_service_config",
+    type=String,
+    default="""{"loadBalancingConfig": [{"round_robin": {}}]}""",
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 register(
     "taskworker.route.overrides",
     default={},

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -313,8 +313,8 @@ def taskworker_scheduler(redis_cluster: str, **options: Any) -> None:
 )
 @click.option(
     "--processing-pool-name",
-    help="The name of the processing pool being used",
-    default="unknown",
+    help="The name of the processing pool metrics and logs are attributed to.",
+    default="default",
 )
 @log_options()
 @configuration

--- a/src/sentry/tasks/base.py
+++ b/src/sentry/tasks/base.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import functools
 import logging
-import random
 from collections.abc import Callable, Iterable
 from datetime import datetime
 from typing import Any, ParamSpec, TypeVar
@@ -74,16 +73,7 @@ def taskworker_override(
     task_name: str,
 ) -> Callable[P, R]:
     def override(*args: P.args, **kwargs: P.kwargs) -> R:
-        rollout_rate = 0
-        option_flag = f"taskworker.{namespace}.rollout"
-        rollout_map = options.get(option_flag)
-        if rollout_map:
-            if task_name in rollout_map:
-                rollout_rate = rollout_map.get(task_name, 0)
-            elif "*" in rollout_map:
-                rollout_rate = rollout_map.get("*", 0)
-
-        if rollout_rate > random.random():
+        if options.get("taskworker.enabled"):
             return taskworker_attr(*args, **kwargs)
 
         return celery_task_attr(*args, **kwargs)

--- a/src/sentry/testutils/helpers/task_runner.py
+++ b/src/sentry/testutils/helpers/task_runner.py
@@ -33,6 +33,10 @@ class BurstTaskRunnerRetryError(Exception):
     """
 
 
+# TODO(mark) This will need to be reworked when celery is removed.
+# Currently we rely on being able to monkeypatch the static call to Task.apply_async()
+# that is buried inside sentry.celery.Task.apply_async() to monkeypatch any task that may
+# run within a BurstRunner.
 class _BurstState:
     def __init__(self) -> None:
         self._active = False

--- a/tests/sentry/deletions/tasks/test_hybrid_cloud.py
+++ b/tests/sentry/deletions/tasks/test_hybrid_cloud.py
@@ -35,6 +35,7 @@ from sentry.monitors.models import Monitor
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.factories import Factories
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.helpers.task_runner import BurstTaskRunner
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.pytest.fixtures import django_db_all
@@ -153,6 +154,7 @@ def setup_deletable_objects(
     assert False, "find_regions_for_user could not determine a region for production."
 
 
+@override_options({"taskworker.enabled": False})
 @django_db_all
 def test_region_processing(task_runner):
     reset_watermarks()
@@ -190,6 +192,7 @@ def test_region_processing(task_runner):
     assert not results3.exists()
 
 
+@override_options({"taskworker.enabled": False})
 @django_db_all
 @control_silo_test
 def test_control_processing(task_runner):
@@ -231,6 +234,7 @@ def setup_deletion_test():
     }
 
 
+@override_options({"taskworker.enabled": False})
 @django_db_all
 def test_cascade_deletion_behavior(task_runner):
     data = setup_deletion_test()
@@ -252,6 +256,7 @@ def test_cascade_deletion_behavior(task_runner):
     assert not ExternalIssue.objects.filter(id=external_issue.id).exists()
 
 
+@override_options({"taskworker.enabled": False})
 @django_db_all
 def test_do_nothing_deletion_behavior(task_runner):
     data = setup_deletion_test()
@@ -275,6 +280,7 @@ def test_do_nothing_deletion_behavior(task_runner):
     assert model.integration_id == integration_id
 
 
+@override_options({"taskworker.enabled": False})
 @django_db_all
 def test_set_null_deletion_behavior(task_runner):
     data = setup_deletion_test()
@@ -355,6 +361,7 @@ def setup_cross_db_deletion_data(
     )
 
 
+@override_options({"taskworker.enabled": False})
 @region_silo_test
 class TestCrossDatabaseTombstoneCascadeBehavior(TestCase):
     def setUp(self) -> None:

--- a/tests/sentry/relocation/tasks/test_process.py
+++ b/tests/sentry/relocation/tasks/test_process.py
@@ -89,6 +89,7 @@ from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase, TransactionTestCase
 from sentry.testutils.factories import get_fixture_path
 from sentry.testutils.helpers.backups import generate_rsa_key_pair
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.helpers.task_runner import BurstTaskRunner, BurstTaskRunnerRetryError
 from sentry.testutils.silo import assume_test_silo_mode, create_test_regions, region_silo_test
 from sentry.users.models.lostpasswordhash import LostPasswordHash
@@ -2519,6 +2520,7 @@ class CompletedTest(RelocationTaskTestCase):
         assert not relocation.failure_reason
 
 
+@override_options({"taskworker.enabled": False})
 @patch("sentry.backup.crypto.KeyManagementServiceClient")
 @patch("sentry.relocation.tasks.process.CloudBuildClient")
 @patch("sentry.relocation.utils.MessageBuilder")

--- a/tests/sentry/tasks/test_base.py
+++ b/tests/sentry/tasks/test_base.py
@@ -121,7 +121,7 @@ def test_exclude_exception_retry(capture_exception: MagicMock) -> None:
 )
 @override_options(
     {
-        "taskworker.test.rollout": {"*": 0.0},
+        "taskworker.enabled": False,
         "taskworker.route.overrides": {},
     }
 )
@@ -144,7 +144,7 @@ def test_capture_payload_metrics(mock_distribution: MagicMock) -> None:
 )
 @override_options(
     {
-        "taskworker.test.rollout": {"*": 0.0},
+        "taskworker.enabled": False,
         "taskworker.route.overrides": {},
     }
 )

--- a/tests/sentry/tasks/test_reprocessing2.py
+++ b/tests/sentry/tasks/test_reprocessing2.py
@@ -25,6 +25,7 @@ from sentry.reprocessing2 import is_group_finished
 from sentry.tasks.reprocessing2 import finish_reprocessing, reprocess_group
 from sentry.tasks.store import preprocess_event
 from sentry.testutils.helpers.datetime import before_now
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.helpers.task_runner import BurstTaskRunner
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.testutils.skips import requires_snuba
@@ -103,6 +104,7 @@ def register_event_preprocessor(register_plugin):
     return inner
 
 
+@override_options({"taskworker.enabled": False})
 @django_db_all
 @pytest.mark.snuba
 @pytest.mark.parametrize("change_groups", (True, False), ids=("new_group", "same_group"))
@@ -214,6 +216,7 @@ def test_basic(
             assert not tombstone_calls
 
 
+@override_options({"taskworker.enabled": False})
 @django_db_all
 @pytest.mark.snuba
 def test_concurrent_events_go_into_new_group(
@@ -286,6 +289,7 @@ def test_concurrent_events_go_into_new_group(
     assert activity.ident == str(original_issue_id)
 
 
+@override_options({"taskworker.enabled": False})
 @django_db_all
 @pytest.mark.snuba
 @pytest.mark.parametrize("remaining_events", ["delete", "keep"])
@@ -368,6 +372,7 @@ def test_max_events(
     assert is_group_finished(group_id)
 
 
+@override_options({"taskworker.enabled": False})
 @django_db_all
 @pytest.mark.snuba
 def test_attachments_and_userfeedback(
@@ -437,6 +442,7 @@ def test_attachments_and_userfeedback(
     assert is_group_finished(event.group_id)
 
 
+@override_options({"taskworker.enabled": False})
 @django_db_all
 @pytest.mark.snuba
 @pytest.mark.parametrize("remaining_events", ["keep", "delete"])
@@ -486,6 +492,7 @@ def test_nodestore_missing(
     mock_logger.warning.assert_called_once_with("reprocessing2.%s", "unprocessed_event.not_found")
 
 
+@override_options({"taskworker.enabled": False})
 @django_db_all
 @pytest.mark.snuba
 def test_apply_new_fingerprinting_rules(
@@ -559,6 +566,7 @@ def test_apply_new_fingerprinting_rules(
     assert event2.group.message == "hello world 2"
 
 
+@override_options({"taskworker.enabled": False})
 @django_db_all
 @pytest.mark.snuba
 def test_apply_new_stack_trace_rules(

--- a/tests/sentry/tasks/test_taskworker_rollout.py
+++ b/tests/sentry/tasks/test_taskworker_rollout.py
@@ -1,6 +1,5 @@
 from unittest import mock
 
-from sentry import options
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.config import TaskworkerConfig
 from sentry.taskworker.registry import TaskRegistry
@@ -21,22 +20,10 @@ class TestTaskworkerRollout(TestCase):
             at_most_once=False,
             wait_for_delivery=False,
         )
-        options.register("taskworker.test_namespace.rollout", default={})
 
-    def tearDown(self):
-        super().tearDown()
-        options.unregister("taskworker.test_namespace.rollout")
-
-    @mock.patch("sentry.tasks.base.random.random")
     @mock.patch("sentry.taskworker.registry.TaskNamespace.send_task")
-    @override_options(
-        {"taskworker.test_namespace.rollout": {"test.test_with_taskworker_rollout": 0.5}}
-    )
-    def test_with_taskworker_rollout(
-        self, mock_send_task: mock.MagicMock, mock_random: mock.MagicMock
-    ) -> None:
-        mock_random.return_value = 0.3
-
+    @override_options({"taskworker.enabled": True})
+    def test_with_taskworker_rollout(self, mock_send_task: mock.MagicMock) -> None:
         @instrumented_task(
             name="test.test_with_taskworker_rollout",
             taskworker_config=self.config,
@@ -52,74 +39,9 @@ class TestTaskworkerRollout(TestCase):
         test_task.apply_async()
         assert mock_send_task.call_count == 2
 
-    @mock.patch("sentry.tasks.base.random.random")
-    @mock.patch("sentry.taskworker.registry.TaskNamespace.send_task")
-    @override_options(
-        {"taskworker.test_namespace.rollout": {"test.test_with_taskworker_rollout": 0.5}}
-    )
-    def test_with_taskworker_rollout_with_args(
-        self, mock_send_task: mock.MagicMock, mock_random: mock.MagicMock
-    ) -> None:
-        mock_random.return_value = 0.3
-
-        @instrumented_task(
-            name="test.test_with_taskworker_rollout",
-            taskworker_config=self.config,
-        )
-        def test_task(msg):
-            return f"hello {msg}"
-
-        assert test_task.name == "test.test_with_taskworker_rollout"
-        task = self.namespace.get("test.test_with_taskworker_rollout")
-        assert task is not None
-        assert task.name == "test.test_with_taskworker_rollout"
-        test_task.delay("world")
-        test_task.apply_async(["world"])
-        assert mock_send_task.call_count == 2
-
-    @mock.patch("sentry.tasks.base.random.random")
-    @mock.patch("sentry.taskworker.registry.TaskNamespace.send_task")
     @mock.patch("sentry.celery.Task.apply_async")
-    @override_options({"taskworker.test_namespace.rollout": {"*": 0.5, "test.low_rate": 0.1}})
-    def test_with_taskworker_rollout_with_glob_option(
-        self, mock_celery_apply, mock_send_task, mock_random
-    ):
-        mock_random.return_value = 0.3
-
-        @instrumented_task(
-            name="test.test_with_taskworker_rollout",
-            taskworker_config=self.config,
-        )
-        def test_task(msg):
-            return f"hello {msg}"
-
-        @instrumented_task(
-            name="test.low_rate",
-            taskworker_config=self.config,
-        )
-        def test_low_rate(msg):
-            return f"hello {msg}"
-
-        test_task.delay("world")
-        test_task.apply_async(["world"])
-        assert mock_send_task.call_count == 2
-        assert mock_celery_apply.call_count == 0
-
-        test_low_rate.delay("world")
-        test_low_rate.apply_async(["world"])
-        assert mock_send_task.call_count == 2
-        assert mock_celery_apply.call_count == 2
-
-    @mock.patch("sentry.tasks.base.random.random")
-    @mock.patch("sentry.celery.Task.apply_async")
-    @override_options(
-        {"taskworker.test_namespace.rollout": {"test.test_without_taskworker_rollout": 0.3}}
-    )
-    def test_without_taskworker_rollout(
-        self, mock_celery_apply_async: mock.MagicMock, mock_random: mock.MagicMock
-    ) -> None:
-        mock_random.return_value = 0.5
-
+    @override_options({"taskworker.enabled": False})
+    def test_without_taskworker_rollout(self, mock_celery_apply_async: mock.MagicMock) -> None:
         @instrumented_task(
             name="test.test_without_taskworker_rollout",
             taskworker_config=self.config,
@@ -131,61 +53,4 @@ class TestTaskworkerRollout(TestCase):
         assert self.namespace.contains("test.test_without_taskworker_rollout") is True
         test_task.delay()
         test_task.apply_async()
-        assert mock_celery_apply_async.call_count == 2
-
-    @mock.patch("sentry.tasks.base.random.random")
-    @mock.patch("sentry.celery.Task.apply_async")
-    @override_options(
-        {"taskworker.test_namespace.rollout": {"test.test_without_taskworker_rollout": 0.3}}
-    )
-    def test_without_taskworker_rollout_with_args(
-        self, mock_celery_apply_async: mock.MagicMock, mock_random: mock.MagicMock
-    ) -> None:
-        mock_random.return_value = 0.5
-
-        @instrumented_task(
-            name="test.test_without_taskworker_rollout",
-            taskworker_config=self.config,
-        )
-        def test_task(a, b):
-            return a + b
-
-        assert test_task.name == "test.test_without_taskworker_rollout"
-        assert self.namespace.contains("test.test_without_taskworker_rollout") is True
-        test_task.delay(1, 2)
-        test_task.apply_async(1, 2)
-        assert mock_celery_apply_async.call_count == 2
-
-    @mock.patch("sentry.celery.Task.apply_async")
-    def test_taskworker_no_rollout_configured(
-        self, mock_celery_apply_async: mock.MagicMock
-    ) -> None:
-        @instrumented_task(
-            name="test.test_taskworker_no_rollout_configured",
-            taskworker_config=self.config,
-        )
-        def test_task() -> str:
-            return "done"
-
-        assert test_task.name == "test.test_taskworker_no_rollout_configured"
-        assert self.namespace.contains("test.test_without_taskworker_rollout") is False
-        test_task.delay()
-        test_task.apply_async()
-        assert mock_celery_apply_async.call_count == 2
-
-    @mock.patch("sentry.celery.Task.apply_async")
-    def test_taskworker_no_rollout_configured_with_args(
-        self, mock_celery_apply_async: mock.MagicMock
-    ) -> None:
-        @instrumented_task(
-            name="test.test_taskworker_no_rollout_configured",
-            taskworker_config=self.config,
-        )
-        def test_task(msg):
-            return f"hello {msg}"
-
-        assert test_task.name == "test.test_taskworker_no_rollout_configured"
-        assert self.namespace.contains("test.test_without_taskworker_rollout") is False
-        test_task.delay("world")
-        test_task.apply_async("world")
         assert mock_celery_apply_async.call_count == 2

--- a/tests/sentry/users/web/test_accounts.py
+++ b/tests/sentry/users/web/test_accounts.py
@@ -9,6 +9,7 @@ from django.utils import timezone
 
 from sentry.organizations.services.organization import organization_service
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.helpers.task_runner import BurstTaskRunner
 from sentry.testutils.silo import control_silo_test
 from sentry.users.models.lostpasswordhash import LostPasswordHash
@@ -376,6 +377,7 @@ class TestAccounts(TestCase):
 
         assert not UserEmail.objects.get(email=user.email).is_verified
 
+    @override_options({"taskworker.enabled": False})
     def test_relocate_reclaim_success(self) -> None:
         user = self.create_user(email="member@example.com", is_unclaimed=True)
         lost_password = LostPasswordHash.objects.create(user=user)

--- a/tests/symbolicator/test_minidump_full.py
+++ b/tests/symbolicator/test_minidump_full.py
@@ -11,6 +11,7 @@ from sentry.lang.native.utils import STORE_CRASH_REPORTS_ALL
 from sentry.models.eventattachment import EventAttachment
 from sentry.testutils.cases import TransactionTestCase
 from sentry.testutils.factories import get_fixture_path
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.helpers.task_runner import BurstTaskRunner
 from sentry.testutils.relay import RelayStoreHelper
 from sentry.testutils.skips import requires_kafka, requires_symbolicator
@@ -154,6 +155,7 @@ class SymbolicatorMinidumpIntegrationTest(RelayStoreHelper, TransactionTestCase)
         insta_snapshot_native_stacktrace_data(self, event.data)
         assert not EventAttachment.objects.filter(event_id=event.event_id)
 
+    @override_options({"taskworker.enabled": False})
     def test_reprocessing(self):
         # NOTE:
         # When running this test against a local symbolicator instance,


### PR DESCRIPTION
With the rollout of taskworkers complete in saas, we can simplify the rollout option and enable taskworkers by default in local development. I'm going to disable this option for the August self-hosted release and enable it for the September relase once docs have been published.

I've also updated the devservices mode configuration and devserver options to prefer taskworker but left escape hatches for running celery if required.

Refs getsentry/taskbroker#453
