### PR TITLE
:wrench: chore(tasks): update retry handler so that ignore errors more important than retry state

### DIFF
--- a/src/sentry/tasks/base.py
+++ b/src/sentry/tasks/base.py
@@ -247,12 +247,12 @@ def retry(
         def wrapped(*args, **kwargs):
             try:
                 return func(*args, **kwargs)
+            except ignore:
+                return
             except (RetryError, Retry, Ignore, Reject, MaxRetriesExceededError):
                 # We shouldn't interfere with exceptions that exist to communicate
                 # retry state.
                 raise
-            except ignore:
-                return
             except ignore_and_capture:
                 sentry_sdk.capture_exception(level="info")
                 return


### PR DESCRIPTION
if i want my task to be fire & forget, i would like to ignore all Retry Errors. to do so, i need the ignored exceptions to be caught before the retry state