### PR TITLE
feat(aci): Add cron create/edit form

### DIFF
--- a/static/app/components/workflowEngine/ui/section.tsx
+++ b/static/app/components/workflowEngine/ui/section.tsx
@@ -18,6 +18,12 @@ export default function Section({children, title, description}: SectionProps) {
   );
 }
 
+export const SectionSubHeading = styled('h5')`
+  font-size: ${p => p.theme.fontSize.md};
+  font-weight: ${p => p.theme.fontWeight.bold};
+  margin: 0;
+`;
+
 const SectionContainer = styled(Flex)`
   > p {
     margin-bottom: ${p => p.theme.space['0']};

--- a/static/app/types/workflowEngine/detectors.tsx
+++ b/static/app/types/workflowEngine/detectors.tsx
@@ -191,6 +191,16 @@ interface UpdateUptimeDataSourcePayload {
   url: string;
 }
 
+interface UpdateCronDataSourcePayload {
+  checkinMargin: number | null;
+  failureIssueThreshold: number | null;
+  maxRuntime: number | null;
+  recoveryThreshold: number | null;
+  schedule: string | [number, string]; // Crontab or interval
+  scheduleType: 'crontab' | 'interval';
+  timezone: string;
+}
+
 export interface BaseDetectorUpdatePayload {
   name: string;
   owner: Detector['owner'];
@@ -209,4 +219,10 @@ export interface MetricDetectorUpdatePayload extends BaseDetectorUpdatePayload {
   config: MetricDetectorConfig;
   dataSource: UpdateSnubaDataSourcePayload;
   type: 'metric_issue';
+}
+
+export interface CronDetectorUpdatePayload extends BaseDetectorUpdatePayload {
+  config: CronDetectorConfig;
+  dataSource: UpdateCronDataSourcePayload;
+  type: 'uptime_subscription';
 }

--- a/static/app/views/detectors/components/forms/common/assignSection.tsx
+++ b/static/app/views/detectors/components/forms/common/assignSection.tsx
@@ -2,15 +2,13 @@ import {useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import SentryMemberTeamSelectorField from 'sentry/components/forms/fields/sentryMemberTeamSelectorField';
+import {useFormField} from 'sentry/components/workflowEngine/form/useFormField';
+import {Container} from 'sentry/components/workflowEngine/ui/container';
+import Section from 'sentry/components/workflowEngine/ui/section';
 import {t} from 'sentry/locale';
 import useProjects from 'sentry/utils/useProjects';
-import {METRIC_DETECTOR_FORM_FIELDS} from 'sentry/views/detectors/components/forms/metric/metricFormData';
 
-type AssigneeFieldProps = {
-  projectId: string;
-};
-
-export function AssigneeField({projectId}: AssigneeFieldProps) {
+function AssigneeField({projectId}: {projectId?: string}) {
   const {projects} = useProjects();
   const memberOfProjectSlugs = useMemo(() => {
     const project = projects.find(p => p.id === projectId);
@@ -22,10 +20,22 @@ export function AssigneeField({projectId}: AssigneeFieldProps) {
       placeholder={t('Select a member or team')}
       label={t('Default assignee')}
       help={t('Sentry will assign new issues to this assignee.')}
-      name={METRIC_DETECTOR_FORM_FIELDS.owner}
+      name="owner"
       flexibleControlStateSize
       memberOfProjectSlugs={memberOfProjectSlugs}
     />
+  );
+}
+
+export function AssignSection() {
+  const projectId = useFormField<string>('projectId');
+
+  return (
+    <Container>
+      <Section title={t('Assign')}>
+        <AssigneeField projectId={projectId} />
+      </Section>
+    </Container>
   );
 }
 

--- a/static/app/views/detectors/components/forms/cron/detect.tsx
+++ b/static/app/views/detectors/components/forms/cron/detect.tsx
@@ -18,6 +18,9 @@ import type {SelectValue} from 'sentry/types/core';
 import {
   CRON_DEFAULT_CHECKIN_MARGIN,
   CRON_DEFAULT_MAX_RUNTIME,
+  CRON_DEFAULT_SCHEDULE_INTERVAL_UNIT,
+  CRON_DEFAULT_SCHEDULE_INTERVAL_VALUE,
+  CRON_DEFAULT_SCHEDULE_TYPE,
   DEFAULT_CRONTAB,
   useCronDetectorFormField,
 } from 'sentry/views/detectors/components/forms/cron/fields';
@@ -39,20 +42,18 @@ type Props = {
 
 function ScheduleTypeField() {
   return (
-    <Fragment>
-      <SelectField
-        name="scheduleType"
-        label={t('Schedule Type')}
-        hideLabel
-        options={SCHEDULE_OPTIONS}
-        defaultValue={ScheduleType.CRONTAB}
-        orientInline
-        required
-        stacked
-        inline={false}
-        preserveOnUnmount
-      />
-    </Fragment>
+    <SelectField
+      name="scheduleType"
+      label={t('Schedule Type')}
+      hideLabel
+      options={SCHEDULE_OPTIONS}
+      defaultValue={CRON_DEFAULT_SCHEDULE_TYPE}
+      orientInline
+      required
+      stacked
+      inline={false}
+      preserveOnUnmount
+    />
   );
 }
 
@@ -114,7 +115,7 @@ function Schedule() {
             label={t('Interval Frequency')}
             hideLabel
             placeholder="e.g. 1"
-            defaultValue="1"
+            defaultValue={CRON_DEFAULT_SCHEDULE_INTERVAL_VALUE}
             min={1}
             required
             stacked
@@ -126,7 +127,7 @@ function Schedule() {
             label={t('Interval Type')}
             hideLabel
             options={getScheduleIntervals(scheduleIntervalValue)}
-            defaultValue="day"
+            defaultValue={CRON_DEFAULT_SCHEDULE_INTERVAL_UNIT}
             required
             stacked
             inline={false}

--- a/static/app/views/detectors/components/forms/cron/detect.tsx
+++ b/static/app/views/detectors/components/forms/cron/detect.tsx
@@ -1,0 +1,284 @@
+import {Fragment} from 'react';
+import {css, useTheme} from '@emotion/react';
+import styled from '@emotion/styled';
+
+import {Alert} from 'sentry/components/core/alert';
+import {ExternalLink} from 'sentry/components/core/link';
+import {Text} from 'sentry/components/core/text';
+import {FieldWrapper} from 'sentry/components/forms/fieldGroup/fieldWrapper';
+import NumberField from 'sentry/components/forms/fields/numberField';
+import SelectField from 'sentry/components/forms/fields/selectField';
+import TextField from 'sentry/components/forms/fields/textField';
+import {Container} from 'sentry/components/workflowEngine/ui/container';
+import Section, {SectionSubHeading} from 'sentry/components/workflowEngine/ui/section';
+import {timezoneOptions} from 'sentry/data/timezones';
+import {t, tct, tn} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import type {SelectValue} from 'sentry/types/core';
+import {useCronDetectorFormField} from 'sentry/views/detectors/components/forms/cron/fields';
+import {ScheduleType} from 'sentry/views/insights/crons/types';
+import {getScheduleIntervals} from 'sentry/views/insights/crons/utils';
+import {crontabAsText} from 'sentry/views/insights/crons/utils/crontabAsText';
+
+const SCHEDULE_OPTIONS: Array<SelectValue<string>> = [
+  {value: ScheduleType.CRONTAB, label: t('Crontab')},
+  {value: ScheduleType.INTERVAL, label: t('Interval')},
+];
+
+export const DEFAULT_MONITOR_TYPE = 'cron_job';
+export const DEFAULT_CRONTAB = '0 0 * * *';
+
+// In minutes
+export const DEFAULT_MAX_RUNTIME = 30;
+export const DEFAULT_CHECKIN_MARGIN = 1;
+const CHECKIN_MARGIN_MINIMUM = 1;
+const TIMEOUT_MINIMUM = 1;
+
+type Props = {
+  isEditing: boolean;
+};
+
+function ScheduleTypeField() {
+  return (
+    <Fragment>
+      <SelectField
+        name="config.scheduleType"
+        label={t('Schedule Type')}
+        hideLabel
+        options={SCHEDULE_OPTIONS}
+        defaultValue={ScheduleType.CRONTAB}
+        orientInline
+        required
+        stacked
+        inline={false}
+      />
+    </Fragment>
+  );
+}
+
+function Schedule() {
+  const theme = useTheme();
+  const schedule = useCronDetectorFormField('schedule');
+  const scheduleType = useCronDetectorFormField('scheduleType');
+
+  const parsedSchedule =
+    scheduleType === 'crontab'
+      ? crontabAsText(typeof schedule === 'string' ? schedule : '')
+      : null;
+
+  if (scheduleType === 'crontab') {
+    return (
+      <InputGroup removeFieldPadding>
+        <ScheduleTypeField />
+        <MultiColumnInput columns="1fr 2fr">
+          <TextField
+            name="config.schedule"
+            label={t('Crontab Schedule')}
+            hideLabel
+            placeholder="* * * * *"
+            defaultValue={DEFAULT_CRONTAB}
+            css={css`
+              input {
+                font-family: ${theme.text.familyMono};
+              }
+            `}
+            required
+            stacked
+            inline={false}
+          />
+          <SelectField
+            name="config.timezone"
+            label={t('Timezone')}
+            hideLabel
+            defaultValue="UTC"
+            options={timezoneOptions}
+            required
+            stacked
+            inline={false}
+          />
+          {parsedSchedule && <CronstrueText>"{parsedSchedule}"</CronstrueText>}
+        </MultiColumnInput>
+      </InputGroup>
+    );
+  }
+  if (scheduleType === 'interval') {
+    return (
+      <InputGroup removeFieldPadding>
+        <ScheduleTypeField />
+        <MultiColumnInput columns="auto 1fr 2fr">
+          <LabelText>{t('Every')}</LabelText>
+          <NumberField
+            name="config.schedule.frequency"
+            label={t('Interval Frequency')}
+            hideLabel
+            placeholder="e.g. 1"
+            defaultValue="1"
+            min={1}
+            required
+            stacked
+            inline={false}
+          />
+          <SelectField
+            name="config.schedule.interval"
+            label={t('Interval Type')}
+            hideLabel
+            options={getScheduleIntervals(
+              Number(Array.isArray(schedule) ? schedule[0] : 1)
+            )}
+            defaultValue="day"
+            required
+            stacked
+            inline={false}
+          />
+        </MultiColumnInput>
+      </InputGroup>
+    );
+  }
+  return null;
+}
+
+function Margins() {
+  return (
+    <Fragment>
+      <SubSectionSeparator aria-hidden="true" />
+      <SectionSubHeading>{t('Set margins')}</SectionSubHeading>
+      <Text variant="muted">
+        {t('Configure when we mark your monitor as failed or missed.')}
+      </Text>
+      <InputGroup>
+        <NumberField
+          name="config.checkinMargin"
+          min={CHECKIN_MARGIN_MINIMUM}
+          placeholder={tn(
+            'Defaults to %s minute',
+            'Defaults to %s minutes',
+            DEFAULT_CHECKIN_MARGIN
+          )}
+          help={t('Number of minutes before a check-in is considered missed.')}
+          label={t('Grace Period')}
+        />
+        <NumberField
+          name="config.maxRuntime"
+          min={TIMEOUT_MINIMUM}
+          placeholder={tn(
+            'Defaults to %s minute',
+            'Defaults to %s minutes',
+            DEFAULT_MAX_RUNTIME
+          )}
+          help={t(
+            'Number of minutes before an in-progress check-in is marked timed out.'
+          )}
+          label={t('Max Runtime')}
+        />
+      </InputGroup>
+    </Fragment>
+  );
+}
+
+function Thresholds() {
+  return (
+    <Fragment>
+      <SubSectionSeparator aria-hidden="true" />
+      <SectionSubHeading>{t('Set thresholds')}</SectionSubHeading>
+      <Text variant="muted">{t('Configure when an issue is created or resolved.')}</Text>
+      <InputGroup>
+        <NumberField
+          name="config.failureIssueThreshold"
+          min={1}
+          placeholder="1"
+          help={t(
+            'Create a new issue when this many consecutive missed or error check-ins are processed.'
+          )}
+          label={t('Failure Tolerance')}
+        />
+      </InputGroup>
+    </Fragment>
+  );
+}
+
+export function CronDetectorFormDetectSection({isEditing}: Props) {
+  return (
+    <Container>
+      <Section title={t('Detect')}>
+        <DetectFieldsContainer>
+          <div>
+            <SectionSubHeading>{t('Set your schedule')}</SectionSubHeading>
+            <Text variant="muted">
+              {tct('You can use [link:the crontab syntax] or our interval schedule.', {
+                link: <ExternalLink href="https://en.wikipedia.org/wiki/Cron" />,
+              })}
+            </Text>
+            {isEditing && (
+              <Alert type="info" showIcon={false}>
+                {t(
+                  'Any changes you make to the execution schedule will only be applied after the next expected check-in.'
+                )}
+              </Alert>
+            )}
+            <Schedule />
+            <Margins />
+            <Thresholds />
+          </div>
+        </DetectFieldsContainer>
+      </Section>
+    </Container>
+  );
+}
+
+const DetectFieldsContainer = styled('div')`
+  ${FieldWrapper} {
+    padding-left: 0;
+  }
+`;
+
+const SubSectionSeparator = styled('hr')`
+  height: 1px;
+  border: none;
+  margin: 0;
+  margin-bottom: ${p => p.theme.space.lg};
+  background-color: ${p => p.theme.border};
+`;
+
+const InputGroup = styled('div')<{removeFieldPadding?: boolean}>`
+  display: flex;
+  flex-direction: column;
+  gap: ${space(1)};
+
+  ${p =>
+    p.removeFieldPadding &&
+    css`
+      padding: ${p.theme.space.xl};
+      padding-left: 0;
+    `};
+
+  ${FieldWrapper} {
+    ${p =>
+      p.removeFieldPadding &&
+      css`
+        padding: 0;
+      `};
+  }
+`;
+
+const LabelText = styled(Text)`
+  font-weight: ${p => p.theme.fontWeight.bold};
+  color: ${p => p.theme.subText};
+`;
+
+const MultiColumnInput = styled('div')<{columns?: string}>`
+  display: grid;
+  align-items: center;
+  gap: ${space(1)};
+  grid-template-columns: ${p => p.columns};
+
+  ${FieldWrapper} {
+    padding-bottom: 0;
+  }
+`;
+
+const CronstrueText = styled(LabelText)`
+  font-weight: ${p => p.theme.fontWeight.normal};
+  font-size: ${p => p.theme.fontSize.xs};
+  font-family: ${p => p.theme.text.familyMono};
+  grid-column: auto / span 2;
+`;

--- a/static/app/views/detectors/components/forms/cron/detect.tsx
+++ b/static/app/views/detectors/components/forms/cron/detect.tsx
@@ -83,6 +83,7 @@ function Schedule() {
             required
             stacked
             inline={false}
+            preserveOnUnmount
           />
           <SelectField
             name="timezone"
@@ -93,6 +94,7 @@ function Schedule() {
             required
             stacked
             inline={false}
+            preserveOnUnmount
           />
           {parsedSchedule && <CronstrueText>"{parsedSchedule}"</CronstrueText>}
         </MultiColumnInput>
@@ -116,6 +118,7 @@ function Schedule() {
             required
             stacked
             inline={false}
+            preserveOnUnmount
           />
           <SelectField
             name="scheduleIntervalUnit"
@@ -126,6 +129,7 @@ function Schedule() {
             required
             stacked
             inline={false}
+            preserveOnUnmount
           />
         </MultiColumnInput>
       </InputGroup>
@@ -140,9 +144,6 @@ function Margins() {
     <Fragment>
       <SubSectionSeparator aria-hidden="true" />
       <SectionSubHeading>{t('Set margins')}</SectionSubHeading>
-      <Text variant="muted">
-        {t('Configure when we mark your monitor as failed or missed.')}
-      </Text>
       <InputGroup>
         <NumberField
           name="checkinMargin"
@@ -154,6 +155,7 @@ function Margins() {
           )}
           help={t('Number of minutes before a check-in is considered missed.')}
           label={t('Grace Period')}
+          defaultValue={DEFAULT_CHECKIN_MARGIN}
         />
         <NumberField
           name="maxRuntime"
@@ -167,6 +169,7 @@ function Margins() {
             'Number of minutes before an in-progress check-in is marked timed out.'
           )}
           label={t('Max Runtime')}
+          defaultValue={DEFAULT_MAX_RUNTIME}
         />
       </InputGroup>
     </Fragment>
@@ -178,12 +181,12 @@ function Thresholds() {
     <Fragment>
       <SubSectionSeparator aria-hidden="true" />
       <SectionSubHeading>{t('Set thresholds')}</SectionSubHeading>
-      <Text variant="muted">{t('Configure when an issue is created or resolved.')}</Text>
       <InputGroup>
         <NumberField
           name="failureIssueThreshold"
           min={1}
           placeholder="1"
+          defaultValue={1}
           help={t(
             'Create a new issue when this many consecutive missed or error check-ins are processed.'
           )}

--- a/static/app/views/detectors/components/forms/cron/detect.tsx
+++ b/static/app/views/detectors/components/forms/cron/detect.tsx
@@ -42,7 +42,7 @@ function ScheduleTypeField() {
   return (
     <Fragment>
       <SelectField
-        name="config.scheduleType"
+        name="scheduleType"
         label={t('Schedule Type')}
         hideLabel
         options={SCHEDULE_OPTIONS}
@@ -58,13 +58,12 @@ function ScheduleTypeField() {
 
 function Schedule() {
   const theme = useTheme();
-  const schedule = useCronDetectorFormField('schedule');
+  const scheduleCrontab = useCronDetectorFormField('scheduleCrontab');
+  const scheduleIntervalValue = useCronDetectorFormField('scheduleIntervalValue');
   const scheduleType = useCronDetectorFormField('scheduleType');
 
   const parsedSchedule =
-    scheduleType === 'crontab'
-      ? crontabAsText(typeof schedule === 'string' ? schedule : '')
-      : null;
+    scheduleType === 'crontab' ? crontabAsText(scheduleCrontab) : null;
 
   if (scheduleType === 'crontab') {
     return (
@@ -72,7 +71,7 @@ function Schedule() {
         <ScheduleTypeField />
         <MultiColumnInput columns="1fr 2fr">
           <TextField
-            name="config.schedule"
+            name="scheduleCrontab"
             label={t('Crontab Schedule')}
             hideLabel
             placeholder="* * * * *"
@@ -87,7 +86,7 @@ function Schedule() {
             inline={false}
           />
           <SelectField
-            name="config.timezone"
+            name="timezone"
             label={t('Timezone')}
             hideLabel
             defaultValue="UTC"
@@ -101,6 +100,7 @@ function Schedule() {
       </InputGroup>
     );
   }
+
   if (scheduleType === 'interval') {
     return (
       <InputGroup removeFieldPadding>
@@ -108,7 +108,7 @@ function Schedule() {
         <MultiColumnInput columns="auto 1fr 2fr">
           <LabelText>{t('Every')}</LabelText>
           <NumberField
-            name="config.schedule.frequency"
+            name="scheduleIntervalValue"
             label={t('Interval Frequency')}
             hideLabel
             placeholder="e.g. 1"
@@ -119,12 +119,10 @@ function Schedule() {
             inline={false}
           />
           <SelectField
-            name="config.schedule.interval"
+            name="scheduleIntervalUnit"
             label={t('Interval Type')}
             hideLabel
-            options={getScheduleIntervals(
-              Number(Array.isArray(schedule) ? schedule[0] : 1)
-            )}
+            options={getScheduleIntervals(scheduleIntervalValue)}
             defaultValue="day"
             required
             stacked
@@ -134,6 +132,7 @@ function Schedule() {
       </InputGroup>
     );
   }
+
   return null;
 }
 
@@ -147,7 +146,7 @@ function Margins() {
       </Text>
       <InputGroup>
         <NumberField
-          name="config.checkinMargin"
+          name="checkinMargin"
           min={CHECKIN_MARGIN_MINIMUM}
           placeholder={tn(
             'Defaults to %s minute',
@@ -158,7 +157,7 @@ function Margins() {
           label={t('Grace Period')}
         />
         <NumberField
-          name="config.maxRuntime"
+          name="maxRuntime"
           min={TIMEOUT_MINIMUM}
           placeholder={tn(
             'Defaults to %s minute',
@@ -183,7 +182,7 @@ function Thresholds() {
       <Text variant="muted">{t('Configure when an issue is created or resolved.')}</Text>
       <InputGroup>
         <NumberField
-          name="config.failureIssueThreshold"
+          name="failureIssueThreshold"
           min={1}
           placeholder="1"
           help={t(

--- a/static/app/views/detectors/components/forms/cron/detect.tsx
+++ b/static/app/views/detectors/components/forms/cron/detect.tsx
@@ -17,6 +17,7 @@ import {space} from 'sentry/styles/space';
 import type {SelectValue} from 'sentry/types/core';
 import {
   CRON_DEFAULT_CHECKIN_MARGIN,
+  CRON_DEFAULT_FAILURE_ISSUE_THRESHOLD,
   CRON_DEFAULT_MAX_RUNTIME,
   CRON_DEFAULT_SCHEDULE_INTERVAL_UNIT,
   CRON_DEFAULT_SCHEDULE_INTERVAL_VALUE,
@@ -188,7 +189,7 @@ function Thresholds() {
           name="failureIssueThreshold"
           min={1}
           placeholder="1"
-          defaultValue={1}
+          defaultValue={CRON_DEFAULT_FAILURE_ISSUE_THRESHOLD}
           help={t(
             'Create a new issue when this many consecutive missed or error check-ins are processed.'
           )}

--- a/static/app/views/detectors/components/forms/cron/detect.tsx
+++ b/static/app/views/detectors/components/forms/cron/detect.tsx
@@ -25,12 +25,11 @@ const SCHEDULE_OPTIONS: Array<SelectValue<string>> = [
   {value: ScheduleType.INTERVAL, label: t('Interval')},
 ];
 
-export const DEFAULT_MONITOR_TYPE = 'cron_job';
-export const DEFAULT_CRONTAB = '0 0 * * *';
+const DEFAULT_CRONTAB = '0 0 * * *';
 
 // In minutes
-export const DEFAULT_MAX_RUNTIME = 30;
-export const DEFAULT_CHECKIN_MARGIN = 1;
+const DEFAULT_MAX_RUNTIME = 30;
+const DEFAULT_CHECKIN_MARGIN = 1;
 const CHECKIN_MARGIN_MINIMUM = 1;
 const TIMEOUT_MINIMUM = 1;
 

--- a/static/app/views/detectors/components/forms/cron/detect.tsx
+++ b/static/app/views/detectors/components/forms/cron/detect.tsx
@@ -15,7 +15,12 @@ import {timezoneOptions} from 'sentry/data/timezones';
 import {t, tct, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {SelectValue} from 'sentry/types/core';
-import {useCronDetectorFormField} from 'sentry/views/detectors/components/forms/cron/fields';
+import {
+  CRON_DEFAULT_CHECKIN_MARGIN,
+  CRON_DEFAULT_MAX_RUNTIME,
+  DEFAULT_CRONTAB,
+  useCronDetectorFormField,
+} from 'sentry/views/detectors/components/forms/cron/fields';
 import {ScheduleType} from 'sentry/views/insights/crons/types';
 import {getScheduleIntervals} from 'sentry/views/insights/crons/utils';
 import {crontabAsText} from 'sentry/views/insights/crons/utils/crontabAsText';
@@ -25,11 +30,6 @@ const SCHEDULE_OPTIONS: Array<SelectValue<string>> = [
   {value: ScheduleType.INTERVAL, label: t('Interval')},
 ];
 
-const DEFAULT_CRONTAB = '0 0 * * *';
-
-// In minutes
-const DEFAULT_MAX_RUNTIME = 30;
-const DEFAULT_CHECKIN_MARGIN = 1;
 const CHECKIN_MARGIN_MINIMUM = 1;
 const TIMEOUT_MINIMUM = 1;
 
@@ -50,6 +50,7 @@ function ScheduleTypeField() {
         required
         stacked
         inline={false}
+        preserveOnUnmount
       />
     </Fragment>
   );
@@ -151,11 +152,11 @@ function Margins() {
           placeholder={tn(
             'Defaults to %s minute',
             'Defaults to %s minutes',
-            DEFAULT_CHECKIN_MARGIN
+            CRON_DEFAULT_CHECKIN_MARGIN
           )}
           help={t('Number of minutes before a check-in is considered missed.')}
           label={t('Grace Period')}
-          defaultValue={DEFAULT_CHECKIN_MARGIN}
+          defaultValue={CRON_DEFAULT_CHECKIN_MARGIN}
         />
         <NumberField
           name="maxRuntime"
@@ -163,13 +164,13 @@ function Margins() {
           placeholder={tn(
             'Defaults to %s minute',
             'Defaults to %s minutes',
-            DEFAULT_MAX_RUNTIME
+            CRON_DEFAULT_MAX_RUNTIME
           )}
           help={t(
             'Number of minutes before an in-progress check-in is marked timed out.'
           )}
           label={t('Max Runtime')}
-          defaultValue={DEFAULT_MAX_RUNTIME}
+          defaultValue={CRON_DEFAULT_MAX_RUNTIME}
         />
       </InputGroup>
     </Fragment>

--- a/static/app/views/detectors/components/forms/cron/fields.tsx
+++ b/static/app/views/detectors/components/forms/cron/fields.tsx
@@ -15,7 +15,9 @@ interface CronDetectorFormData {
 
   projectId: string;
   recoveryThreshold: number;
-  schedule: string | [number, string]; // Crontab or interval
+  scheduleCrontab: string;
+  scheduleIntervalUnit: string;
+  scheduleIntervalValue: number;
   scheduleType: 'crontab' | 'interval';
   timezone: string;
   workflowIds: string[];
@@ -47,7 +49,10 @@ export function cronFormDataToEndpointPayload(
       failureIssueThreshold: data.failureIssueThreshold,
       maxRuntime: data.maxRuntime,
       recoveryThreshold: data.recoveryThreshold,
-      schedule: data.schedule,
+      schedule:
+        data.scheduleType === 'crontab'
+          ? data.scheduleCrontab
+          : [data.scheduleIntervalValue, data.scheduleIntervalUnit],
       scheduleType: data.scheduleType,
       timezone: data.timezone,
     },
@@ -70,29 +75,19 @@ export function cronSavedDetectorToFormData(
     projectId: detector.projectId,
   };
 
-  if (dataSource?.type === 'cron_subscription') {
-    return {
-      ...common,
-      checkinMargin: dataSource.queryObj.checkinMargin,
-      failureIssueThreshold: dataSource.queryObj.failureIssueThreshold ?? 1,
-      recoveryThreshold: dataSource.queryObj.recoveryThreshold ?? 1,
-      maxRuntime: dataSource.queryObj.maxRuntime,
-      schedule: dataSource.queryObj.schedule,
-      scheduleType: dataSource.queryObj.scheduleType,
-      timezone: dataSource.queryObj.timezone,
-      workflowIds: detector.workflowIds,
-    };
-  }
-
   return {
     ...common,
-    checkinMargin: null,
-    failureIssueThreshold: 1,
-    maxRuntime: null,
-    recoveryThreshold: 1,
-    schedule: '0 0 * * *',
-    scheduleType: 'crontab',
-    timezone: 'UTC',
+    checkinMargin: dataSource.queryObj.checkinMargin,
+    failureIssueThreshold: dataSource.queryObj.failureIssueThreshold ?? 1,
+    recoveryThreshold: dataSource.queryObj.recoveryThreshold ?? 1,
+    maxRuntime: dataSource.queryObj.maxRuntime,
+    scheduleCrontab: dataSource.queryObj.schedule,
+    scheduleIntervalValue: Array.isArray(dataSource.queryObj.schedule)
+      ? dataSource.queryObj.schedule[0]
+      : 1,
+    scheduleIntervalUnit: dataSource.queryObj.schedule?.[1] ?? 'day',
+    scheduleType: dataSource.queryObj.scheduleType,
+    timezone: dataSource.queryObj.timezone,
     workflowIds: detector.workflowIds,
   };
 }

--- a/static/app/views/detectors/components/forms/cron/fields.tsx
+++ b/static/app/views/detectors/components/forms/cron/fields.tsx
@@ -95,8 +95,8 @@ export function cronSavedDetectorToFormData(
     recoveryThreshold: dataSource.queryObj.recoveryThreshold ?? 1,
     maxRuntime: dataSource.queryObj.maxRuntime,
     scheduleCrontab: Array.isArray(dataSource.queryObj.schedule)
-      ? dataSource.queryObj.schedule[0]
-      : DEFAULT_CRONTAB,
+      ? DEFAULT_CRONTAB
+      : dataSource.queryObj.schedule,
     scheduleIntervalValue: Array.isArray(dataSource.queryObj.schedule)
       ? dataSource.queryObj.schedule[0]
       : CRON_DEFAULT_SCHEDULE_INTERVAL_VALUE,

--- a/static/app/views/detectors/components/forms/cron/fields.tsx
+++ b/static/app/views/detectors/components/forms/cron/fields.tsx
@@ -4,7 +4,9 @@ import type {
   CronDetectorUpdatePayload,
 } from 'sentry/types/workflowEngine/detectors';
 import {getDetectorEnvironment} from 'sentry/views/detectors/utils/getDetectorEnvironment';
+import {ScheduleType} from 'sentry/views/insights/crons/types';
 
+export const CRON_DEFAULT_SCHEDULE_TYPE = ScheduleType.CRONTAB;
 export const DEFAULT_CRONTAB = '0 0 * * *';
 export const CRON_DEFAULT_SCHEDULE_INTERVAL_VALUE = 1;
 export const CRON_DEFAULT_SCHEDULE_INTERVAL_UNIT = 'day';

--- a/static/app/views/detectors/components/forms/cron/fields.tsx
+++ b/static/app/views/detectors/components/forms/cron/fields.tsx
@@ -85,7 +85,9 @@ export function cronSavedDetectorToFormData(
     scheduleIntervalValue: Array.isArray(dataSource.queryObj.schedule)
       ? dataSource.queryObj.schedule[0]
       : 1,
-    scheduleIntervalUnit: dataSource.queryObj.schedule?.[1] ?? 'day',
+    scheduleIntervalUnit: Array.isArray(dataSource.queryObj.schedule)
+      ? dataSource.queryObj.schedule[1]
+      : 'day',
     scheduleType: dataSource.queryObj.scheduleType,
     timezone: dataSource.queryObj.timezone,
     workflowIds: detector.workflowIds,

--- a/static/app/views/detectors/components/forms/cron/fields.tsx
+++ b/static/app/views/detectors/components/forms/cron/fields.tsx
@@ -1,0 +1,98 @@
+import {useFormField} from 'sentry/components/workflowEngine/form/useFormField';
+import type {
+  CronDetector,
+  CronDetectorUpdatePayload,
+} from 'sentry/types/workflowEngine/detectors';
+import {getDetectorEnvironment} from 'sentry/views/detectors/utils/getDetectorEnvironment';
+
+interface CronDetectorFormData {
+  checkinMargin: number | null;
+  environment: string;
+  failureIssueThreshold: number;
+  maxRuntime: number | null;
+  name: string;
+  owner: string;
+
+  projectId: string;
+  recoveryThreshold: number;
+  schedule: string | [number, string]; // Crontab or interval
+  scheduleType: 'crontab' | 'interval';
+  timezone: string;
+  workflowIds: string[];
+}
+
+type CronDetectorFormFieldName = keyof CronDetectorFormData;
+
+/**
+ * Small helper to automatically get the type of the form field.
+ */
+export function useCronDetectorFormField<T extends CronDetectorFormFieldName>(
+  name: T
+): CronDetectorFormData[T] {
+  const value = useFormField(name);
+  return value;
+}
+
+export function cronFormDataToEndpointPayload(
+  data: CronDetectorFormData
+): CronDetectorUpdatePayload {
+  return {
+    type: 'uptime_subscription',
+    name: data.name,
+    owner: data.owner,
+    projectId: data.projectId,
+    workflowIds: data.workflowIds,
+    dataSource: {
+      checkinMargin: data.checkinMargin,
+      failureIssueThreshold: data.failureIssueThreshold,
+      maxRuntime: data.maxRuntime,
+      recoveryThreshold: data.recoveryThreshold,
+      schedule: data.schedule,
+      scheduleType: data.scheduleType,
+      timezone: data.timezone,
+    },
+    config: {
+      environment: data.environment,
+    },
+  };
+}
+
+export function cronSavedDetectorToFormData(
+  detector: CronDetector
+): CronDetectorFormData {
+  const dataSource = detector.dataSources?.[0];
+  const environment = getDetectorEnvironment(detector) ?? '';
+
+  const common = {
+    name: detector.name,
+    environment,
+    owner: detector.owner || '',
+    projectId: detector.projectId,
+  };
+
+  if (dataSource?.type === 'cron_subscription') {
+    return {
+      ...common,
+      checkinMargin: dataSource.queryObj.checkinMargin,
+      failureIssueThreshold: dataSource.queryObj.failureIssueThreshold ?? 1,
+      recoveryThreshold: dataSource.queryObj.recoveryThreshold ?? 1,
+      maxRuntime: dataSource.queryObj.maxRuntime,
+      schedule: dataSource.queryObj.schedule,
+      scheduleType: dataSource.queryObj.scheduleType,
+      timezone: dataSource.queryObj.timezone,
+      workflowIds: detector.workflowIds,
+    };
+  }
+
+  return {
+    ...common,
+    checkinMargin: null,
+    failureIssueThreshold: 1,
+    maxRuntime: null,
+    recoveryThreshold: 1,
+    schedule: '0 0 * * *',
+    scheduleType: 'crontab',
+    timezone: 'UTC',
+    workflowIds: detector.workflowIds,
+  };
+}

--- a/static/app/views/detectors/components/forms/cron/fields.tsx
+++ b/static/app/views/detectors/components/forms/cron/fields.tsx
@@ -5,6 +5,17 @@ import type {
 } from 'sentry/types/workflowEngine/detectors';
 import {getDetectorEnvironment} from 'sentry/views/detectors/utils/getDetectorEnvironment';
 
+export const DEFAULT_CRONTAB = '0 0 * * *';
+export const CRON_DEFAULT_SCHEDULE_INTERVAL_VALUE = 1;
+export const CRON_DEFAULT_SCHEDULE_INTERVAL_UNIT = 'day';
+
+export const CRON_DEFAULT_CHECKIN_MARGIN = 1;
+export const CRON_DEFAULT_FAILURE_ISSUE_THRESHOLD = 1;
+export const CRON_DEFAULT_RECOVERY_THRESHOLD = 1;
+
+// In minutes
+export const CRON_DEFAULT_MAX_RUNTIME = 30;
+
 interface CronDetectorFormData {
   checkinMargin: number | null;
   environment: string;
@@ -81,13 +92,15 @@ export function cronSavedDetectorToFormData(
     failureIssueThreshold: dataSource.queryObj.failureIssueThreshold ?? 1,
     recoveryThreshold: dataSource.queryObj.recoveryThreshold ?? 1,
     maxRuntime: dataSource.queryObj.maxRuntime,
-    scheduleCrontab: dataSource.queryObj.schedule,
+    scheduleCrontab: Array.isArray(dataSource.queryObj.schedule)
+      ? dataSource.queryObj.schedule[0]
+      : DEFAULT_CRONTAB,
     scheduleIntervalValue: Array.isArray(dataSource.queryObj.schedule)
       ? dataSource.queryObj.schedule[0]
-      : 1,
+      : CRON_DEFAULT_SCHEDULE_INTERVAL_VALUE,
     scheduleIntervalUnit: Array.isArray(dataSource.queryObj.schedule)
       ? dataSource.queryObj.schedule[1]
-      : 'day',
+      : CRON_DEFAULT_SCHEDULE_INTERVAL_UNIT,
     scheduleType: dataSource.queryObj.scheduleType,
     timezone: dataSource.queryObj.timezone,
     workflowIds: detector.workflowIds,

--- a/static/app/views/detectors/components/forms/cron/index.tsx
+++ b/static/app/views/detectors/components/forms/cron/index.tsx
@@ -28,7 +28,9 @@ export function NewCronDetectorForm() {
       detectorType="uptime_subscription"
       formDataToEndpointPayload={cronFormDataToEndpointPayload}
       initialFormData={{
-        schedule: '0 0 * * *',
+        scheduleCrontab: '0 0 * * *',
+        scheduleIntervalValue: 1,
+        scheduleIntervalUnit: 'day',
         scheduleType: 'crontab',
         timezone: 'UTC',
         failureIssueThreshold: 1,

--- a/static/app/views/detectors/components/forms/cron/index.tsx
+++ b/static/app/views/detectors/components/forms/cron/index.tsx
@@ -6,6 +6,7 @@ import {AutomateSection} from 'sentry/views/detectors/components/forms/automateS
 import {AssignSection} from 'sentry/views/detectors/components/forms/common/assignSection';
 import {CronDetectorFormDetectSection} from 'sentry/views/detectors/components/forms/cron/detect';
 import {
+  CRON_DEFAULT_SCHEDULE_TYPE,
   cronFormDataToEndpointPayload,
   cronSavedDetectorToFormData,
 } from 'sentry/views/detectors/components/forms/cron/fields';
@@ -29,7 +30,9 @@ export function NewCronDetectorForm() {
     <NewDetectorLayout
       detectorType="uptime_subscription"
       formDataToEndpointPayload={cronFormDataToEndpointPayload}
-      initialFormData={{}}
+      initialFormData={{
+        scheduleType: CRON_DEFAULT_SCHEDULE_TYPE,
+      }}
     >
       <CronDetectorForm isEditing={false} />
     </NewDetectorLayout>

--- a/static/app/views/detectors/components/forms/cron/index.tsx
+++ b/static/app/views/detectors/components/forms/cron/index.tsx
@@ -9,6 +9,7 @@ import {
   cronFormDataToEndpointPayload,
   cronSavedDetectorToFormData,
 } from 'sentry/views/detectors/components/forms/cron/fields';
+import {CronDetectorFormResolveSection} from 'sentry/views/detectors/components/forms/cron/resolve';
 import {EditDetectorLayout} from 'sentry/views/detectors/components/forms/editDetectorLayout';
 import {NewDetectorLayout} from 'sentry/views/detectors/components/forms/newDetectorLayout';
 
@@ -16,6 +17,7 @@ function CronDetectorForm({isEditing}: {isEditing: boolean}) {
   return (
     <FormStack>
       <CronDetectorFormDetectSection isEditing={isEditing} />
+      <CronDetectorFormResolveSection />
       <AssignSection />
       <AutomateSection />
     </FormStack>
@@ -27,18 +29,7 @@ export function NewCronDetectorForm() {
     <NewDetectorLayout
       detectorType="uptime_subscription"
       formDataToEndpointPayload={cronFormDataToEndpointPayload}
-      initialFormData={{
-        scheduleCrontab: '0 0 * * *',
-        scheduleIntervalValue: 1,
-        scheduleIntervalUnit: 'day',
-        scheduleType: 'crontab',
-        timezone: 'UTC',
-        failureIssueThreshold: 1,
-        recoveryThreshold: 1,
-        maxRuntime: 30,
-        checkinMargin: 1,
-        workflowIds: [],
-      }}
+      initialFormData={{}}
     >
       <CronDetectorForm isEditing={false} />
     </NewDetectorLayout>

--- a/static/app/views/detectors/components/forms/cron/index.tsx
+++ b/static/app/views/detectors/components/forms/cron/index.tsx
@@ -1,0 +1,63 @@
+import styled from '@emotion/styled';
+
+import {space} from 'sentry/styles/space';
+import type {CronDetector} from 'sentry/types/workflowEngine/detectors';
+import {AutomateSection} from 'sentry/views/detectors/components/forms/automateSection';
+import {AssignSection} from 'sentry/views/detectors/components/forms/common/assignSection';
+import {CronDetectorFormDetectSection} from 'sentry/views/detectors/components/forms/cron/detect';
+import {
+  cronFormDataToEndpointPayload,
+  cronSavedDetectorToFormData,
+} from 'sentry/views/detectors/components/forms/cron/fields';
+import {EditDetectorLayout} from 'sentry/views/detectors/components/forms/editDetectorLayout';
+import {NewDetectorLayout} from 'sentry/views/detectors/components/forms/newDetectorLayout';
+
+function CronDetectorForm({isEditing}: {isEditing: boolean}) {
+  return (
+    <FormStack>
+      <CronDetectorFormDetectSection isEditing={isEditing} />
+      <AssignSection />
+      <AutomateSection />
+    </FormStack>
+  );
+}
+
+export function NewCronDetectorForm() {
+  return (
+    <NewDetectorLayout
+      detectorType="uptime_subscription"
+      formDataToEndpointPayload={cronFormDataToEndpointPayload}
+      initialFormData={{
+        schedule: '0 0 * * *',
+        scheduleType: 'crontab',
+        timezone: 'UTC',
+        failureIssueThreshold: 1,
+        recoveryThreshold: 1,
+        maxRuntime: 30,
+        checkinMargin: 1,
+        workflowIds: [],
+      }}
+    >
+      <CronDetectorForm isEditing={false} />
+    </NewDetectorLayout>
+  );
+}
+
+export function EditExistingCronDetectorForm({detector}: {detector: CronDetector}) {
+  return (
+    <EditDetectorLayout
+      detector={detector}
+      formDataToEndpointPayload={cronFormDataToEndpointPayload}
+      savedDetectorToFormData={cronSavedDetectorToFormData}
+    >
+      <CronDetectorForm isEditing />
+    </EditDetectorLayout>
+  );
+}
+
+const FormStack = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: ${space(3)};
+  max-width: ${p => p.theme.breakpoints.xl};
+`;

--- a/static/app/views/detectors/components/forms/cron/resolve.tsx
+++ b/static/app/views/detectors/components/forms/cron/resolve.tsx
@@ -12,7 +12,7 @@ export function CronDetectorFormResolveSection() {
       <Section title={t('Resolve')}>
         <RemoveFieldPadding>
           <NumberField
-            name="config.recoveryThreshold"
+            name="recoveryThreshold"
             min={1}
             placeholder="1"
             help={t(

--- a/static/app/views/detectors/components/forms/cron/resolve.tsx
+++ b/static/app/views/detectors/components/forms/cron/resolve.tsx
@@ -1,0 +1,33 @@
+import styled from '@emotion/styled';
+
+import {FieldWrapper} from 'sentry/components/forms/fieldGroup/fieldWrapper';
+import NumberField from 'sentry/components/forms/fields/numberField';
+import {Container} from 'sentry/components/workflowEngine/ui/container';
+import Section from 'sentry/components/workflowEngine/ui/section';
+import {t} from 'sentry/locale';
+
+export function CronDetectorFormResolveSection() {
+  return (
+    <Container>
+      <Section title={t('Resolve')}>
+        <RemoveFieldPadding>
+          <NumberField
+            name="config.recoveryThreshold"
+            min={1}
+            placeholder="1"
+            help={t(
+              'Resolve the issue when this many consecutive healthy check-ins are processed.'
+            )}
+            label={t('Recovery Tolerance')}
+          />
+        </RemoveFieldPadding>
+      </Section>
+    </Container>
+  );
+}
+
+const RemoveFieldPadding = styled('div')`
+  ${FieldWrapper} {
+    padding-left: 0;
+  }
+`;

--- a/static/app/views/detectors/components/forms/cron/resolve.tsx
+++ b/static/app/views/detectors/components/forms/cron/resolve.tsx
@@ -5,6 +5,7 @@ import NumberField from 'sentry/components/forms/fields/numberField';
 import {Container} from 'sentry/components/workflowEngine/ui/container';
 import Section from 'sentry/components/workflowEngine/ui/section';
 import {t} from 'sentry/locale';
+import {CRON_DEFAULT_RECOVERY_THRESHOLD} from 'sentry/views/detectors/components/forms/cron/fields';
 
 export function CronDetectorFormResolveSection() {
   return (
@@ -19,6 +20,7 @@ export function CronDetectorFormResolveSection() {
               'Resolve the issue when this many consecutive healthy check-ins are processed.'
             )}
             label={t('Recovery Tolerance')}
+            defaultValue={CRON_DEFAULT_RECOVERY_THRESHOLD}
           />
         </RemoveFieldPadding>
       </Section>

--- a/static/app/views/detectors/components/forms/editDetectorLayout.tsx
+++ b/static/app/views/detectors/components/forms/editDetectorLayout.tsx
@@ -57,7 +57,7 @@ export function EditDetectorLayout<
 
         <EditLayout.HeaderFields>
           <DetectorBaseFields />
-          {previewChart}
+          {previewChart ?? <div />}
         </EditLayout.HeaderFields>
       </EditLayout.Header>
 

--- a/static/app/views/detectors/components/forms/index.tsx
+++ b/static/app/views/detectors/components/forms/index.tsx
@@ -4,6 +4,10 @@ import {t} from 'sentry/locale';
 import type {Detector, DetectorType} from 'sentry/types/workflowEngine/detectors';
 import {unreachable} from 'sentry/utils/unreachable';
 import {
+  EditExistingCronDetectorForm,
+  NewCronDetectorForm,
+} from 'sentry/views/detectors/components/forms/cron';
+import {
   EditExistingErrorDetectorForm,
   NewErrorDetectorForm,
 } from 'sentry/views/detectors/components/forms/error';
@@ -37,10 +41,10 @@ export function NewDetectorForm({detectorType}: {detectorType: DetectorType}) {
     case 'error':
       return <NewErrorDetectorForm />;
     case 'uptime_subscription':
-      return <PlaceholderForm />;
+      return <NewCronDetectorForm />;
     default:
       unreachable(detectorType);
-      return null;
+      return <PlaceholderForm />;
   }
 }
 
@@ -54,9 +58,9 @@ export function EditExistingDetectorForm({detector}: {detector: Detector}) {
     case 'error':
       return <EditExistingErrorDetectorForm detector={detector} />;
     case 'uptime_subscription':
-      return <PlaceholderForm />;
+      return <EditExistingCronDetectorForm detector={detector} />;
     default:
       unreachable(detectorType);
-      return null;
+      return <PlaceholderForm />;
   }
 }

--- a/static/app/views/detectors/components/forms/metric/metric.tsx
+++ b/static/app/views/detectors/components/forms/metric/metric.tsx
@@ -26,8 +26,8 @@ import {
   AlertRuleThresholdType,
 } from 'sentry/views/alerts/rules/metric/types';
 import {hasLogAlerts} from 'sentry/views/alerts/wizard/utils';
-import {AssigneeField} from 'sentry/views/detectors/components/forms/assigneeField';
 import {AutomateSection} from 'sentry/views/detectors/components/forms/automateSection';
+import {AssignSection} from 'sentry/views/detectors/components/forms/common/assignSection';
 import {EditDetectorLayout} from 'sentry/views/detectors/components/forms/editDetectorLayout';
 import type {MetricDetectorFormData} from 'sentry/views/detectors/components/forms/metric/metricFormData';
 import {
@@ -158,18 +158,6 @@ function ResolveSection() {
   return (
     <Container>
       <Section title={t('Resolve')} description={description} />
-    </Container>
-  );
-}
-
-function AssignSection() {
-  const projectId = useMetricDetectorFormField(METRIC_DETECTOR_FORM_FIELDS.projectId);
-
-  return (
-    <Container>
-      <Section title={t('Assign')}>
-        <AssigneeField projectId={projectId} />
-      </Section>
     </Container>
   );
 }

--- a/static/app/views/detectors/components/forms/newDetectorLayout.tsx
+++ b/static/app/views/detectors/components/forms/newDetectorLayout.tsx
@@ -72,7 +72,7 @@ export function NewDetectorLayout<
 
         <EditLayout.HeaderFields>
           <DetectorBaseFields />
-          {previewChart}
+          {previewChart ?? <div />}
         </EditLayout.HeaderFields>
       </EditLayout.Header>
 

--- a/static/app/views/detectors/components/forms/uptime/fields.tsx
+++ b/static/app/views/detectors/components/forms/uptime/fields.tsx
@@ -1,4 +1,3 @@
-import {useFormField} from 'sentry/components/workflowEngine/form/useFormField';
 import type {
   UptimeDetector,
   UptimeDetectorUpdatePayload,
@@ -19,40 +18,6 @@ interface UptimeDetectorFormData {
   url: string;
   workflowIds: string[];
 }
-
-type UptimeDetectorFormFieldName = keyof UptimeDetectorFormData;
-
-/**
- * Small helper to automatically get the type of the form field.
- */
-export function useUptimeDetectorFormField<T extends UptimeDetectorFormFieldName>(
-  name: T
-): UptimeDetectorFormData[T] {
-  const value = useFormField(name);
-  return value;
-}
-
-/**
- * Enables type-safe form field names.
- * Helps you find areas setting specific fields.
- */
-export const UPTIME_DETECTOR_FORM_FIELDS = {
-  // Core detector fields
-  name: 'name',
-  environment: 'environment',
-  projectId: 'projectId',
-  owner: 'owner',
-  workflowIds: 'workflowIds',
-
-  // Uptime fields
-  intervalSeconds: 'intervalSeconds',
-  timeoutMs: 'timeoutMs',
-  url: 'url',
-  method: 'method',
-  traceSampling: 'traceSampling',
-  headers: 'headers',
-  body: 'body',
-} satisfies Record<UptimeDetectorFormFieldName, UptimeDetectorFormFieldName>;
 
 export function uptimeFormDataToEndpointPayload(
   data: UptimeDetectorFormData

--- a/static/app/views/detectors/components/forms/uptime/index.tsx
+++ b/static/app/views/detectors/components/forms/uptime/index.tsx
@@ -1,32 +1,16 @@
 import styled from '@emotion/styled';
 
-import {Container} from 'sentry/components/workflowEngine/ui/container';
-import Section from 'sentry/components/workflowEngine/ui/section';
-import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {UptimeDetector} from 'sentry/types/workflowEngine/detectors';
-import {AssigneeField} from 'sentry/views/detectors/components/forms/assigneeField';
 import {AutomateSection} from 'sentry/views/detectors/components/forms/automateSection';
+import {AssignSection} from 'sentry/views/detectors/components/forms/common/assignSection';
 import {EditDetectorLayout} from 'sentry/views/detectors/components/forms/editDetectorLayout';
 import {NewDetectorLayout} from 'sentry/views/detectors/components/forms/newDetectorLayout';
 import {UptimeDetectorFormDetectSection} from 'sentry/views/detectors/components/forms/uptime/detect';
 import {
-  UPTIME_DETECTOR_FORM_FIELDS,
   uptimeFormDataToEndpointPayload,
   uptimeSavedDetectorToFormData,
-  useUptimeDetectorFormField,
 } from 'sentry/views/detectors/components/forms/uptime/fields';
-
-function AssignSection() {
-  const projectId = useUptimeDetectorFormField(UPTIME_DETECTOR_FORM_FIELDS.projectId);
-  return (
-    <Container>
-      <Section title={t('Assign')}>
-        <AssigneeField projectId={projectId} />
-      </Section>
-    </Container>
-  );
-}
 
 function UptimeDetectorForm() {
   return (


### PR DESCRIPTION
Added a basic cron form to monitors. Doesn't completely match the designs, but I thought that the existing crons form had good reasons for some of the differences (like showing the crontab human-readable label).

This will need to go through some changes once we get the crons actually migrated since we don't quite know the shape of the data yet.

<img width="2242" height="1702" alt="CleanShot 2025-08-01 at 10 03 30@2x" src="https://github.com/user-attachments/assets/71a9e0af-1552-455b-ae51-1370f25f2f18" />
