### PR TITLE
fix(aci): enqueue workflows only if there are slow conditions we can fire actions for

### DIFF
--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -65,7 +65,7 @@ def delete_workflow(workflow: Workflow) -> bool:
     return True
 
 
-@dataclass(frozen=True)
+@dataclass
 class DelayedWorkflowItem:
     workflow: Workflow
     event: GroupEvent

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -206,7 +206,7 @@ def evaluate_workflows_action_filters(
     workflows: set[Workflow],
     event_data: WorkflowEventData,
     queue_items_by_workflow: dict[Workflow, DelayedWorkflowItem],
-) -> set[DataConditionGroup]:
+) -> tuple[set[DataConditionGroup], dict[Workflow, DelayedWorkflowItem]]:
     """
     Evaluate the action filters for the given workflows.
     Returns a set of DataConditionGroups that were evaluated to True.

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -6,6 +6,7 @@ import pytest
 from django.utils import timezone
 
 from sentry import buffer
+from sentry.eventstore.models import GroupEvent
 from sentry.eventstream.base import GroupState
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.models.activity import Activity
@@ -29,7 +30,6 @@ from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.processors.workflow import (
     WORKFLOW_ENGINE_BUFFER_LIST_KEY,
     DelayedWorkflowItem,
-    WorkflowDataConditionGroupType,
     delete_workflow,
     enqueue_workflows,
     evaluate_workflow_triggers,
@@ -315,18 +315,18 @@ class TestEvaluateWorkflowTriggers(BaseWorkflowTest):
         self.event_data = WorkflowEventData(event=self.group_event, group=self.group)
 
     def test_workflow_trigger(self) -> None:
-        triggered_workflows = evaluate_workflow_triggers({self.workflow}, self.event_data)
+        triggered_workflows, _ = evaluate_workflow_triggers({self.workflow}, self.event_data)
         assert triggered_workflows == {self.workflow}
 
     def test_workflow_trigger__no_conditions(self) -> None:
         assert self.workflow.when_condition_group
         self.workflow.when_condition_group.conditions.all().delete()
 
-        triggered_workflows = evaluate_workflow_triggers({self.workflow}, self.event_data)
+        triggered_workflows, _ = evaluate_workflow_triggers({self.workflow}, self.event_data)
         assert triggered_workflows == {self.workflow}
 
     def test_no_workflow_trigger(self) -> None:
-        triggered_workflows = evaluate_workflow_triggers(set(), self.event_data)
+        triggered_workflows, _ = evaluate_workflow_triggers(set(), self.event_data)
         assert not triggered_workflows
 
     def test_workflow_many_filters(self) -> None:
@@ -340,7 +340,7 @@ class TestEvaluateWorkflowTriggers(BaseWorkflowTest):
             condition_result=75,
         )
 
-        triggered_workflows = evaluate_workflow_triggers({self.workflow}, self.event_data)
+        triggered_workflows, _ = evaluate_workflow_triggers({self.workflow}, self.event_data)
         assert triggered_workflows == {self.workflow}
 
     def test_workflow_filtered_out(self) -> None:
@@ -353,12 +353,12 @@ class TestEvaluateWorkflowTriggers(BaseWorkflowTest):
             comparison=self.detector.id + 1,
         )
 
-        triggered_workflows = evaluate_workflow_triggers({self.workflow}, self.event_data)
+        triggered_workflows, _ = evaluate_workflow_triggers({self.workflow}, self.event_data)
         assert not triggered_workflows
 
     def test_many_workflows(self) -> None:
         workflow_two, _, _, _ = self.create_detector_and_workflow(name_prefix="two")
-        triggered_workflows = evaluate_workflow_triggers(
+        triggered_workflows, _ = evaluate_workflow_triggers(
             {self.workflow, workflow_two}, self.event_data
         )
 
@@ -378,9 +378,13 @@ class TestEvaluateWorkflowTriggers(BaseWorkflowTest):
             condition_result=True,
         )
 
-        triggered_workflows = evaluate_workflow_triggers({self.workflow}, self.event_data)
+        triggered_workflows, queue_items_by_workflow_id = evaluate_workflow_triggers(
+            {self.workflow}, self.event_data
+        )
         # no workflows are triggered because the slow conditions need to be evaluated
         assert triggered_workflows == set()
+        # we return the list of items we may enqueue in the filtering function
+        assert list(queue_items_by_workflow_id.keys()) == [self.workflow]
 
     def test_activity_update__slow_condition(self) -> None:
         # Setup slow conditions
@@ -407,18 +411,19 @@ class TestEvaluateWorkflowTriggers(BaseWorkflowTest):
             event=self.event,
             group=self.group,
         )
-        with patch("sentry.workflow_engine.processors.workflow.enqueue_workflows") as mock_enqueue:
-            triggered_workflows = evaluate_workflow_triggers({self.workflow}, self.event_data)
+        triggered_workflows, queue_items_by_workflow_id = evaluate_workflow_triggers(
+            {self.workflow}, self.event_data
+        )
 
-            empty_list = DefaultDict[int, list[DelayedWorkflowItem]](list)
-            mock_enqueue.assert_called_once_with(empty_list)
-
-            # no workflows are triggered because the slow conditions need to be evaluated
-            assert triggered_workflows == set()
+        # no workflows are triggered because the slow conditions need to be evaluated
+        assert triggered_workflows == set()
+        assert (
+            not queue_items_by_workflow_id.keys()
+        )  # TODO: implement evaluating slow conditions for activity updates
 
 
 @freeze_time(FROZEN_TIME)
-class TestEnqueueWorkflow(BaseWorkflowTest):
+class TestWorkflowEnqueuing(BaseWorkflowTest):
     buffer_timestamp = (FROZEN_TIME + timedelta(seconds=1)).timestamp()
 
     def setUp(self) -> None:
@@ -434,7 +439,7 @@ class TestEnqueueWorkflow(BaseWorkflowTest):
             occurrence=occurrence,
         )
         self.event_data = WorkflowEventData(event=self.group_event, group=self.group)
-        self.create_workflow_action(self.workflow)
+        self.action_group, _ = self.create_workflow_action(self.workflow)
         self.mock_redis_buffer = mock_redis_buffer()
         self.mock_redis_buffer.__enter__()
 
@@ -454,7 +459,7 @@ class TestEnqueueWorkflow(BaseWorkflowTest):
             condition_result=True,
         )
 
-        triggered_workflows = evaluate_workflow_triggers({self.workflow}, self.event_data)
+        triggered_workflows, _ = evaluate_workflow_triggers({self.workflow}, self.event_data)
         assert not triggered_workflows
 
         process_workflows(self.event_data)
@@ -485,8 +490,10 @@ class TestEnqueueWorkflow(BaseWorkflowTest):
             condition_result=True,
         )
 
-        triggered_workflows = evaluate_workflow_triggers({self.workflow}, self.event_data)
+        triggered_workflows, _ = evaluate_workflow_triggers({self.workflow}, self.event_data)
         assert not triggered_workflows
+
+        process_workflows(self.event_data)
 
         project_ids = buffer.backend.get_sorted_set(
             WORKFLOW_ENGINE_BUFFER_LIST_KEY, 0, self.buffer_timestamp
@@ -510,12 +517,11 @@ class TestEnqueueWorkflow(BaseWorkflowTest):
             condition_result=True,
         )
 
-        triggered_workflows = evaluate_workflow_triggers({self.workflow}, self.event_data)
-        assert triggered_workflows == {self.workflow}
-        project_ids = buffer.backend.get_sorted_set(
-            WORKFLOW_ENGINE_BUFFER_LIST_KEY, 0, self.buffer_timestamp
+        triggered_workflows, queue_items_by_workflow_id = evaluate_workflow_triggers(
+            {self.workflow}, self.event_data
         )
-        assert len(project_ids) == 0
+        assert triggered_workflows == {self.workflow}
+        assert not queue_items_by_workflow_id
 
     def test_skips_enqueuing_all(self) -> None:
         assert self.workflow.when_condition_group
@@ -538,14 +544,81 @@ class TestEnqueueWorkflow(BaseWorkflowTest):
             condition_result=True,
         )
 
-        triggered_workflows = evaluate_workflow_triggers({self.workflow}, self.event_data)
+        triggered_workflows, queue_items_by_workflow_id = evaluate_workflow_triggers(
+            {self.workflow}, self.event_data
+        )
         assert not triggered_workflows
+        assert not queue_items_by_workflow_id
+
+    def test_enqueues_with_when_and_if_slow_conditions(self) -> None:
+        assert self.workflow.when_condition_group
+        self.workflow.when_condition_group.update(logic_type=DataConditionGroup.Type.ALL)
+        self.create_data_condition(
+            condition_group=self.workflow.when_condition_group,
+            type=Condition.EVENT_FREQUENCY_COUNT,
+            comparison={
+                "interval": "1h",
+                "value": 100,
+            },
+            condition_result=True,
+        )
+
+        self.create_data_condition(
+            condition_group=self.action_group,
+            type=Condition.EVENT_FREQUENCY_COUNT,
+            comparison={
+                "interval": "1h",
+                "value": 100,
+            },
+            condition_result=True,
+        )
+
+        process_workflows(self.event_data)
+
         project_ids = buffer.backend.get_sorted_set(
             WORKFLOW_ENGINE_BUFFER_LIST_KEY, 0, self.buffer_timestamp
         )
-        assert len(project_ids) == 0
+        assert project_ids[0][0] == self.project.id
+
+    def test_enqueues_event_if_meets_fast_conditions(self) -> None:
+        assert self.workflow.when_condition_group
+        self.workflow.when_condition_group.update(logic_type=DataConditionGroup.Type.ALL)
+        self.create_data_condition(
+            condition_group=self.workflow.when_condition_group,
+            type=Condition.EVENT_FREQUENCY_COUNT,
+            comparison={
+                "interval": "1h",
+                "value": 100,
+            },
+            condition_result=True,
+        )
+
+        tag_condition = self.create_data_condition(
+            condition_group=self.action_group,
+            type=Condition.TAGGED_EVENT,
+            comparison={"key": "hello", "value": "world", "match": "eq"},
+            condition_result=True,
+        )
+
+        process_workflows(self.event_data)
+
+        project_ids = buffer.backend.get_sorted_set(
+            WORKFLOW_ENGINE_BUFFER_LIST_KEY, 0, self.buffer_timestamp
+        )
+        assert not project_ids
+
+        # enqueue if the tag condition is met
+        tag_condition.update(comparison={"key": "level", "value": "error", "match": "eq"})
+
+        process_workflows(self.event_data)
+
+        project_ids = buffer.backend.get_sorted_set(
+            WORKFLOW_ENGINE_BUFFER_LIST_KEY, 0, self.buffer_timestamp
+        )
+        assert project_ids[0][0] == self.project.id
 
 
+@freeze_time(FROZEN_TIME)
 @mock_redis_buffer()
 class TestEvaluateWorkflowActionFilters(BaseWorkflowTest):
     def setUp(self) -> None:
@@ -580,7 +653,7 @@ class TestEvaluateWorkflowActionFilters(BaseWorkflowTest):
 
     def test_basic__no_filter(self) -> None:
         triggered_action_filters = evaluate_workflows_action_filters(
-            {self.workflow}, self.event_data
+            {self.workflow}, self.event_data, {}
         )
         assert set(triggered_action_filters) == {self.action_group}
 
@@ -593,7 +666,7 @@ class TestEvaluateWorkflowActionFilters(BaseWorkflowTest):
         )
 
         triggered_action_filters = evaluate_workflows_action_filters(
-            {self.workflow}, self.event_data
+            {self.workflow}, self.event_data, {}
         )
         assert set(triggered_action_filters) == {self.action_group}
 
@@ -606,7 +679,7 @@ class TestEvaluateWorkflowActionFilters(BaseWorkflowTest):
         )
 
         triggered_action_filters = evaluate_workflows_action_filters(
-            {self.workflow}, self.event_data
+            {self.workflow}, self.event_data, {}
         )
         assert not triggered_action_filters
 
@@ -628,7 +701,7 @@ class TestEvaluateWorkflowActionFilters(BaseWorkflowTest):
         self.action_group.save()
 
         triggered_action_filters = evaluate_workflows_action_filters(
-            {self.workflow}, self.event_data
+            {self.workflow}, self.event_data, {}
         )
 
         assert self.action_group.conditions.count() == 2
@@ -668,19 +741,61 @@ class TestEvaluateWorkflowActionFilters(BaseWorkflowTest):
         with patch("sentry.workflow_engine.processors.workflow.enqueue_workflows") as mock_enqueue:
             with patch("sentry.workflow_engine.processors.workflow.metrics_incr") as mock_incr:
                 # Evaluate the workflow actions with a slow condition
-                evaluate_workflows_action_filters({self.workflow}, self.event_data)
+                evaluate_workflows_action_filters({self.workflow}, self.event_data, {})
 
                 # ensure we do not enqueue slow condition evaluation
                 empty_list = DefaultDict[int, list[DelayedWorkflowItem]](list)
                 mock_enqueue.assert_called_once_with(empty_list)
                 mock_incr.assert_called_once_with("process_workflows.enqueue_workflow.activity")
 
+    def test_enqueues_when_slow_conditions(self):
+        assert isinstance(self.event_data.event, GroupEvent)
+        queue_items_by_workflow_id = {
+            self.workflow: DelayedWorkflowItem(
+                workflow=self.workflow,
+                event=self.event_data.event,
+                delayed_when_group_id=self.workflow.when_condition_group_id,
+                delayed_if_group_ids=[],
+                passing_if_group_ids=[],
+                timestamp=timezone.now(),
+            )
+        }
+
+        triggered_action_filters = evaluate_workflows_action_filters(
+            set(), self.event_data, queue_items_by_workflow_id
+        )
+        assert not triggered_action_filters
+
+        project_ids = buffer.backend.get_sorted_set(
+            WORKFLOW_ENGINE_BUFFER_LIST_KEY, 0, timezone.now().timestamp()
+        )
+        assert project_ids
+        assert project_ids[0][0] == self.project.id
+
 
 class TestEnqueueWorkflows(BaseWorkflowTest):
     def setUp(self) -> None:
-        self.workflow = self.create_workflow()
         self.data_condition_group = self.create_data_condition_group()
         self.condition = self.create_data_condition(condition_group=self.data_condition_group)
+        self.workflow = self.create_workflow(when_condition_group=self.data_condition_group)
+
+        self.workflow_filter_group = self.create_data_condition_group()
+        self.create_workflow_data_condition_group(
+            workflow=self.workflow,
+            condition_group=self.workflow_filter_group,
+        )
+
+        self.slow_workflow_filter_group = self.create_data_condition_group()
+        self.create_workflow_data_condition_group(
+            workflow=self.workflow,
+            condition_group=self.slow_workflow_filter_group,
+        )
+        self.create_data_condition(
+            condition_group=self.slow_workflow_filter_group,
+            type=Condition.EVENT_FREQUENCY_COUNT,
+            comparison={"interval": "1d", "value": 7},
+        )
+
         _, self.event, self.group_event = self.create_group_event()
         self.workflow_event_data = WorkflowEventData(
             event=self.group_event,
@@ -694,15 +809,14 @@ class TestEnqueueWorkflows(BaseWorkflowTest):
     ):
         enqueue_workflows(
             {
-                self.group_event.project_id: [
-                    DelayedWorkflowItem(
-                        self.workflow,
-                        [self.condition],
-                        self.group_event,
-                        WorkflowDataConditionGroupType.WORKFLOW_TRIGGER,
-                        timestamp=timezone.now(),
-                    )
-                ]
+                self.workflow: DelayedWorkflowItem(
+                    self.workflow,
+                    self.group_event,
+                    self.workflow.when_condition_group_id,
+                    [self.slow_workflow_filter_group.id],
+                    [self.workflow_filter_group.id],
+                    timestamp=timezone.now(),
+                )
             }
         )
 
@@ -717,31 +831,46 @@ class TestEnqueueWorkflows(BaseWorkflowTest):
         self, mock_push_to_hash_bulk, mock_push_to_sorted_set
     ):
         current_time = timezone.now()
-        condition2 = self.create_data_condition(condition_group=self.create_data_condition_group())
-        condition3 = self.create_data_condition(condition_group=self.create_data_condition_group())
+        workflow_filter_group_2 = self.create_data_condition_group()
+        self.create_workflow_data_condition_group(
+            workflow=self.workflow,
+            condition_group=workflow_filter_group_2,
+        )
+
+        slow_workflow_filter_group_2 = self.create_data_condition_group()
+        self.create_workflow_data_condition_group(
+            workflow=self.workflow,
+            condition_group=slow_workflow_filter_group_2,
+        )
+        self.create_data_condition(
+            condition_group=slow_workflow_filter_group_2,
+            type=Condition.EVENT_FREQUENCY_COUNT,
+            comparison={"interval": "1d", "value": 7},
+        )
         enqueue_workflows(
             {
-                self.group_event.project_id: [
-                    DelayedWorkflowItem(
-                        self.workflow,
-                        [self.condition, condition2, condition3],
-                        self.group_event,
-                        WorkflowDataConditionGroupType.WORKFLOW_TRIGGER,
-                        timestamp=current_time,
-                    )
-                ]
+                self.workflow: DelayedWorkflowItem(
+                    self.workflow,
+                    self.group_event,
+                    self.workflow.when_condition_group_id,
+                    [self.slow_workflow_filter_group.id, slow_workflow_filter_group_2.id],
+                    [self.workflow_filter_group.id, workflow_filter_group_2.id],
+                    timestamp=current_time,
+                )
             }
         )
 
-        condition_group_ids = ",".join(
-            str(condition.condition_group_id)
-            for condition in [self.condition, condition2, condition3]
+        slow_condition_group_ids = ",".join(
+            str(id) for id in [self.slow_workflow_filter_group.id, slow_workflow_filter_group_2.id]
+        )
+        passing_condition_group_ids = ",".join(
+            str(id) for id in [self.workflow_filter_group.id, workflow_filter_group_2.id]
         )
         mock_push_to_hash_bulk.assert_called_once_with(
             model=Workflow,
             filters={"project_id": self.group_event.project_id},
             data={
-                f"{self.workflow.id}:{self.group_event.group_id}:{condition_group_ids}:workflow_trigger": json.dumps(
+                f"{self.workflow.id}:{self.group_event.group_id}:{self.workflow.when_condition_group_id}:{slow_condition_group_ids}:{passing_condition_group_ids}": json.dumps(
                     {
                         "event_id": self.event.event_id,
                         "occurrence_id": self.group_event.occurrence_id,

--- a/tests/sentry/workflow_engine/test_integration.py
+++ b/tests/sentry/workflow_engine/test_integration.py
@@ -414,21 +414,15 @@ class TestWorkflowEngineIntegrationFromErrorPostProcess(BaseWorkflowIntegrationT
         )
         assert not project_ids
 
-        # event that does not have the tags = no fire
+        # event that does not have the tags = no enqueue
         event_2 = self.create_error_event(fingerprint="asdf")
         self.post_process_error(event_2, is_new=True)
-        assert not mock_trigger.called
-
-        event_3 = self.create_error_event(fingerprint="asdf")
-        self.post_process_error(event_3)
         assert not mock_trigger.called
 
         project_ids = buffer.backend.get_sorted_set(
             WORKFLOW_ENGINE_BUFFER_LIST_KEY, 0, timezone.now().timestamp()
         )
-
-        process_delayed_workflows(project_ids[0][0])
-        assert not mock_trigger.called
+        assert not project_ids
 
         # event that fires
         event_4 = self.create_error_event(tags=[["hello", "world"]])

--- a/tests/sentry/workflow_engine/test_task.py
+++ b/tests/sentry/workflow_engine/test_task.py
@@ -146,7 +146,8 @@ class TestProcessWorkflowActivity(TestCase):
             assert mock_evaluate.call_count == 0
 
     @mock.patch(
-        "sentry.workflow_engine.processors.workflow.evaluate_workflow_triggers", return_value=set()
+        "sentry.workflow_engine.processors.workflow.evaluate_workflow_triggers",
+        return_value=(set(), {}),
     )
     @mock.patch(
         "sentry.workflow_engine.processors.workflow.evaluate_workflows_action_filters",


### PR DESCRIPTION
This PR fixes the failing tests from https://github.com/getsentry/sentry/pull/96923, so should be merged into it

We should enqueue workflows only if we have slow conditions to evaluate that would result in us firing actions!