### PR TITLE
fix(issue summary): Fix state where no event

### DIFF
--- a/static/app/views/issueDetails/streamline/sidebar/seerSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerSection.tsx
@@ -32,6 +32,9 @@ function SeerSectionContent({
 }) {
   const aiConfig = useAiConfig(group, project);
 
+  if (!event && !aiConfig.isAutofixSetupLoading) {
+    return <StyledP>{t('No event to analyze.')}</StyledP>;
+  }
   if (!event || aiConfig.isAutofixSetupLoading) {
     return <Placeholder height="160px" />;
   }
@@ -203,4 +206,8 @@ const HeaderContainer = styled('div')`
   display: flex;
   align-items: center;
   gap: ${space(0.5)};
+`;
+
+const StyledP = styled('p')`
+  margin-bottom: ${p => p.theme.space.md};
 `;


### PR DESCRIPTION
Before, if there were no events on the page, we'd show a infinite loading state. Now, we show a message.

<img width="1214" height="709" alt="Screenshot 2025-08-01 at 10 51 33 AM" src="https://github.com/user-attachments/assets/84f47f64-a08c-4586-bff2-417a0c247db1" />
<img width="1205" height="850" alt="Screenshot 2025-08-01 at 11 00 28 AM" src="https://github.com/user-attachments/assets/a50f6242-81cc-45fe-8329-d51437cd425e" />
