### PR TITLE
feat(aci): Improved search config for detectors

### DIFF
--- a/static/app/views/detectors/components/detectorSearch.tsx
+++ b/static/app/views/detectors/components/detectorSearch.tsx
@@ -1,6 +1,5 @@
 import {SearchQueryBuilder} from 'sentry/components/searchQueryBuilder';
 import {t} from 'sentry/locale';
-import {getFieldDefinition} from 'sentry/utils/fields';
 import {useDetectorFilterKeys} from 'sentry/views/detectors/utils/useDetectorFilterKeys';
 
 type DetectorSearchProps = {
@@ -9,7 +8,7 @@ type DetectorSearchProps = {
 };
 
 export function DetectorSearch({initialQuery, onSearch}: DetectorSearchProps) {
-  const filterKeys = useDetectorFilterKeys();
+  const {filterKeys, getFieldDefinition} = useDetectorFilterKeys();
 
   return (
     <SearchQueryBuilder
@@ -21,8 +20,8 @@ export function DetectorSearch({initialQuery, onSearch}: DetectorSearchProps) {
       searchSource="detectors-list"
       fieldDefinitionGetter={getFieldDefinition}
       disallowUnsupportedFilters
-      disallowWildcard
       disallowLogicalOperators
+      replaceRawSearchKeys={['name']}
     />
   );
 }

--- a/static/app/views/detectors/constants.tsx
+++ b/static/app/views/detectors/constants.tsx
@@ -1,6 +1,5 @@
 import {t} from 'sentry/locale';
 import type {DetectorType} from 'sentry/types/workflowEngine/detectors';
-import {FieldValueType} from 'sentry/utils/fields';
 
 export const DETECTOR_LIST_PAGE_LIMIT = 20;
 
@@ -9,36 +8,4 @@ export const DETECTOR_TYPE_LABELS: Record<DetectorType, string> = {
   uptime_domain_failure: t('Uptime'),
   error: t('Error'),
   uptime_subscription: t('Cron'),
-};
-
-export const DETECTOR_FILTER_KEYS: Record<
-  string,
-  {
-    description: string;
-    keywords: string[];
-    valueType: FieldValueType;
-    values?: string[];
-  }
-> = {
-  name: {
-    description: 'Name of the detector (exact match)',
-    valueType: FieldValueType.STRING,
-    keywords: ['title'],
-  },
-  type: {
-    description: 'Type of the detector (error, metric_issue, etc)',
-    valueType: FieldValueType.STRING,
-    values: [
-      'error',
-      'metric_issue',
-      'uptime_subscription',
-      'uptime_domain_failure',
-    ] satisfies DetectorType[],
-    keywords: ['type'],
-  },
-  assignee: {
-    description: 'User or team assigned to the monitor',
-    valueType: FieldValueType.STRING,
-    keywords: ['assigned', 'owner'],
-  },
 };

--- a/static/app/views/detectors/list.spec.tsx
+++ b/static/app/views/detectors/list.spec.tsx
@@ -162,9 +162,9 @@ describe('DetectorsList', function () {
       const options = await screen.findAllByRole('option');
       expect(options).toHaveLength(4);
       expect(options[0]).toHaveTextContent('error');
-      expect(options[1]).toHaveTextContent('metric_issue');
-      expect(options[2]).toHaveTextContent('uptime_subscription');
-      expect(options[3]).toHaveTextContent('uptime_domain_failure');
+      expect(options[1]).toHaveTextContent('metric');
+      expect(options[2]).toHaveTextContent('cron');
+      expect(options[3]).toHaveTextContent('uptime');
       await userEvent.click(screen.getByText('error'));
 
       await screen.findByText('Error Detector');

--- a/static/app/views/detectors/utils/useDetectorFilterKeys.tsx
+++ b/static/app/views/detectors/utils/useDetectorFilterKeys.tsx
@@ -1,16 +1,57 @@
-import {useMemo} from 'react';
+import {useCallback, useMemo} from 'react';
 
+import type {FieldDefinitionGetter} from 'sentry/components/searchQueryBuilder/types';
 import type {TagCollection} from 'sentry/types/group';
+import {type FieldDefinition, FieldKind, FieldValueType} from 'sentry/utils/fields';
 import useAssignedSearchValues from 'sentry/utils/membersAndTeams/useAssignedSearchValues';
-import {DETECTOR_FILTER_KEYS} from 'sentry/views/detectors/constants';
 
-export function useDetectorFilterKeys(): TagCollection {
+const DETECTOR_FILTER_KEYS: Record<
+  string,
+  {
+    fieldDefinition: FieldDefinition;
+    predefined?: boolean;
+  }
+> = {
+  name: {
+    fieldDefinition: {
+      desc: 'Name of the monitor',
+      kind: FieldKind.FIELD,
+      valueType: FieldValueType.STRING,
+      allowWildcard: false,
+      keywords: ['title'],
+    },
+  },
+  type: {
+    predefined: true,
+    fieldDefinition: {
+      desc: 'Type of the detector',
+      kind: FieldKind.FIELD,
+      valueType: FieldValueType.STRING,
+      allowWildcard: false,
+      values: ['error', 'metric', 'cron', 'uptime'],
+    },
+  },
+  assignee: {
+    predefined: true,
+    fieldDefinition: {
+      desc: 'User or team assigned to the monitor',
+      kind: FieldKind.FIELD,
+      valueType: FieldValueType.STRING,
+      allowWildcard: false,
+      keywords: ['assigned', 'owner'],
+    },
+  },
+};
+
+export function useDetectorFilterKeys(): {
+  filterKeys: TagCollection;
+  getFieldDefinition: FieldDefinitionGetter;
+} {
   const assignedValues = useAssignedSearchValues();
 
-  return useMemo(() => {
+  const filterKeys = useMemo(() => {
     return Object.fromEntries(
       Object.entries(DETECTOR_FILTER_KEYS).map(([key, config]) => {
-        const {values} = config ?? {};
         const isAssignee = key === 'assignee';
 
         return [
@@ -18,11 +59,20 @@ export function useDetectorFilterKeys(): TagCollection {
           {
             key,
             name: key,
-            predefined: isAssignee || values !== undefined,
-            values: isAssignee ? assignedValues : values,
+            predefined: config.predefined,
+            values: isAssignee ? assignedValues : undefined,
           },
         ];
       })
     );
   }, [assignedValues]);
+
+  const getFieldDefinition = useCallback<FieldDefinitionGetter>((key: string) => {
+    return DETECTOR_FILTER_KEYS[key]?.fieldDefinition ?? null;
+  }, []);
+
+  return {
+    filterKeys,
+    getFieldDefinition,
+  };
 }


### PR DESCRIPTION
- `type` accepts aliases now
- typing free text will suggest `name contains "text"`
- search config uses field definitions now so we can properly disable wildcards for `type` but allow it for the others