### PR TITLE
fix(slack): Use region URL template for slack linking

### DIFF
--- a/src/sentry/integrations/slack/views/__init__.py
+++ b/src/sentry/integrations/slack/views/__init__.py
@@ -3,6 +3,9 @@ from typing import Any
 from django.http import HttpRequest, HttpResponse
 from django.urls import reverse
 
+from sentry import options
+from sentry.api.utils import generate_region_url
+from sentry.silo.base import SiloMode
 from sentry.utils.http import absolute_uri
 from sentry.utils.signing import sign
 from sentry.web.helpers import render_to_response
@@ -11,7 +14,14 @@ SALT = "sentry-slack-integration"
 
 
 def build_linking_url(endpoint: str, **kwargs: Any) -> str:
-    url: str = absolute_uri(reverse(endpoint, kwargs={"signed_params": sign(salt=SALT, **kwargs)}))
+    url: str = absolute_uri(
+        url=reverse(endpoint, kwargs={"signed_params": sign(salt=SALT, **kwargs)}),
+        url_prefix=(
+            generate_region_url()
+            if SiloMode.get_current_mode() == SiloMode.REGION
+            else options.get("system.url-prefix")
+        ),
+    )
     return url
 
 


### PR DESCRIPTION
For identity links, the system URL is fine, and matches the default in the implementation of `absolute_uri` but for team linking, we need to target the region silo so it doesn't break by trying to forward from control.