### PR TITLE
fix(ourlogs): Add another guard for timestamp precise being missing

### DIFF
--- a/static/app/views/explore/logs/useVirtualStreaming.spec.tsx
+++ b/static/app/views/explore/logs/useVirtualStreaming.spec.tsx
@@ -1,11 +1,13 @@
+import {MemoryRouter} from 'react-router-dom';
 import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {initializeLogsTest, LogFixture} from 'sentry-fixture/log';
 
+import {makeTestQueryClient} from 'sentry-test/queryClient';
 import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import type {ApiResult} from 'sentry/api';
 import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
-import type {InfiniteData} from 'sentry/utils/queryClient';
+import {type InfiniteData, QueryClientProvider} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
 import {type AutoRefreshState} from 'sentry/views/explore/contexts/logs/logsAutoRefreshContext';
 import {LogsPageParamsProvider} from 'sentry/views/explore/contexts/logs/logsPageParams';
@@ -53,14 +55,18 @@ describe('useVirtualStreaming', () => {
     const testContext = {autoRefresh};
     return function ({children}: {children: React.ReactNode}) {
       return (
-        <OrganizationContext.Provider value={organization}>
-          <LogsPageParamsProvider
-            analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}
-            _testContext={testContext}
-          >
-            {children}
-          </LogsPageParamsProvider>
-        </OrganizationContext.Provider>
+        <MemoryRouter future={{v7_startTransition: true, v7_relativeSplatPath: true}}>
+          <QueryClientProvider client={makeTestQueryClient()}>
+            <OrganizationContext.Provider value={organization}>
+              <LogsPageParamsProvider
+                analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}
+                _testContext={testContext}
+              >
+                {children}
+              </LogsPageParamsProvider>
+            </OrganizationContext.Provider>
+          </QueryClientProvider>
+        </MemoryRouter>
       );
     };
   };

--- a/static/app/views/explore/logs/useVirtualStreaming.tsx
+++ b/static/app/views/explore/logs/useVirtualStreaming.tsx
@@ -153,6 +153,7 @@ export function useVirtualStreaming(
     const latestPage = data.pages[data.pages.length - 1];
     const latestPageData = latestPage?.[0]?.data;
     const rawTimestamp = latestPageData?.[0]?.[OurLogKnownFieldKey.TIMESTAMP_PRECISE];
+
     if (!rawTimestamp) {
       return null;
     }
@@ -196,7 +197,7 @@ export function useVirtualStreaming(
         const targetVirtualTime = Date.now() - MAX_LOG_INGEST_DELAY - refreshInterval;
         const mostRecentPageDataTimestamp = getMostRecentPageDataTimestamp();
 
-        if (!mostRecentPageDataTimestamp) {
+        if (mostRecentPageDataTimestamp === null) {
           warnRef.current();
           setLogsAutoRefresh('error');
           return;


### PR DESCRIPTION
### Summary
These should be able to be removed by (jul 30th + retention window).
