### PR TITLE
feat(tasks) Add a simpler control for taskworker tasks

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3338,13 +3338,6 @@ register(
 )
 
 register(
-    "taskworker.grpc_service_config",
-    type=String,
-    default="""{"loadBalancingConfig": [{"round_robin": {}}]}""",
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-
-register(
     "sentry.demo_mode.sync_debug_artifacts.enable",
     type=Bool,
     default=False,
@@ -3358,8 +3351,19 @@ register(
 
 # Taskbroker flags
 register(
+    "taskworker.enabled",
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
     "taskworker.route.overrides",
     default={},
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "taskworker.grpc_service_config",
+    type=String,
+    default="""{"loadBalancingConfig": [{"round_robin": {}}]}""",
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(

--- a/src/sentry/tasks/base.py
+++ b/src/sentry/tasks/base.py
@@ -83,7 +83,7 @@ def taskworker_override(
             elif "*" in rollout_map:
                 rollout_rate = rollout_map.get("*", 0)
 
-        if rollout_rate > random.random():
+        if rollout_rate > random.random() or options.get("taskworker.enabled"):
             return taskworker_attr(*args, **kwargs)
 
         return celery_task_attr(*args, **kwargs)

--- a/src/sentry/taskworker/task.py
+++ b/src/sentry/taskworker/task.py
@@ -133,7 +133,7 @@ class Task(Generic[P, R]):
                 wait_for_delivery=self.wait_for_delivery,
             )
 
-    def _signal_send(self, task: Task, args: Any, kwargs: Any) -> None:
+    def _signal_send(self, task: Task[Any, Any], args: Any, kwargs: Any) -> None:
         """
         This method is a stub that sentry.testutils.task_runner.BurstRunner or other testing
         hooks can monkeypatch to capture tasks that are being produced.

--- a/src/sentry/taskworker/task.py
+++ b/src/sentry/taskworker/task.py
@@ -117,6 +117,8 @@ class Task(Generic[P, R]):
         if kwargs is None:
             kwargs = {}
 
+        self._signal_send(task=self, args=args, kwargs=kwargs)
+
         # Generate an activation even if we're in immediate mode to
         # catch serialization errors in tests.
         activation = self.create_activation(
@@ -130,6 +132,13 @@ class Task(Generic[P, R]):
                 activation,
                 wait_for_delivery=self.wait_for_delivery,
             )
+
+    def _signal_send(self, task: Task, args: Any, kwargs: Any) -> None:
+        """
+        This method is a stub that sentry.testutils.task_runner.BurstRunner or other testing
+        hooks can monkeypatch to capture tasks that are being produced.
+        """
+        pass
 
     def create_activation(
         self,

--- a/tests/sentry/tasks/test_relay.py
+++ b/tests/sentry/tasks/test_relay.py
@@ -16,6 +16,7 @@ from sentry.tasks.relay import (
     schedule_build_project_config,
     schedule_invalidate_project_config,
 )
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.helpers.task_runner import BurstTaskRunner
 from sentry.testutils.hybrid_cloud import simulated_transaction_watermarks
 from sentry.testutils.pytest.fixtures import django_db_all
@@ -497,6 +498,7 @@ class TestInvalidationTask:
         assert schedule_inner.call_count == 2
 
 
+@override_options({"taskworker.enabled": True})
 @django_db_all(transaction=True)
 def test_invalidate_hierarchy(
     default_project,


### PR DESCRIPTION
While we still support celery and taskworkers (for self-hosted) we can simplify the options and option checking logic.

Once this option is deployed, I'll enable it for all regions and local development and then for self-hosted when documentation is published.

Refs getsentry/taskbroker#453