### PR TITLE
feat: Add list repo tokens endpoint

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -73,6 +73,7 @@ from sentry.codecov.endpoints.repositories.repositories import RepositoriesEndpo
 from sentry.codecov.endpoints.repository_token_regenerate.repository_token_regenerate import (
     RepositoryTokenRegenerateEndpoint,
 )
+from sentry.codecov.endpoints.repository_tokens.repository_tokens import RepositoryTokensEndpoint
 from sentry.codecov.endpoints.test_results.test_results import TestResultsEndpoint
 from sentry.codecov.endpoints.test_results_aggregates.test_results_aggregates import (
     TestResultsAggregatesEndpoint,
@@ -1090,6 +1091,11 @@ PREVENT_URLS = [
         r"^owner/(?P<owner>[^/]+)/repositories/$",
         RepositoriesEndpoint.as_view(),
         name="sentry-api-0-repositories",
+    ),
+    re_path(
+        r"^owner/(?P<owner>[^/]+)/repositories/tokens/$",
+        RepositoryTokensEndpoint.as_view(),
+        name="sentry-api-0-repository-tokens",
     ),
     re_path(
         r"^owner/(?P<owner>[^/]+)/repository/(?P<repository>[^/]+)/token/regenerate/$",

--- a/src/sentry/codecov/endpoints/repository_tokens/query.py
+++ b/src/sentry/codecov/endpoints/repository_tokens/query.py
@@ -1,0 +1,36 @@
+query = """query RepoTokensForOwner(
+  $owner: String!
+  $filters: RepositorySetFilters!
+  $ordering: RepositoryOrdering!
+  $direction: OrderingDirection!
+  $first: Int
+  $after: String
+  $last: Int
+  $before: String
+) {
+  owner(username: $owner) {
+    repositories(
+      filters: $filters
+      ordering: $ordering
+      orderingDirection: $direction
+      first: $first
+      after: $after
+      last: $last
+      before: $before
+    ) {
+      edges {
+        node {
+          name
+          uploadToken
+        }
+      }
+      pageInfo {
+          startCursor
+          endCursor
+          hasNextPage
+          hasPreviousPage
+      }
+      totalCount
+    }
+  }
+}"""

--- a/src/sentry/codecov/endpoints/repository_tokens/query.py
+++ b/src/sentry/codecov/endpoints/repository_tokens/query.py
@@ -1,6 +1,5 @@
 query = """query RepoTokensForOwner(
   $owner: String!
-  $filters: RepositorySetFilters!
   $ordering: RepositoryOrdering!
   $direction: OrderingDirection!
   $first: Int
@@ -10,7 +9,6 @@ query = """query RepoTokensForOwner(
 ) {
   owner(username: $owner) {
     repositories(
-      filters: $filters
       ordering: $ordering
       orderingDirection: $direction
       first: $first
@@ -21,7 +19,7 @@ query = """query RepoTokensForOwner(
       edges {
         node {
           name
-          uploadToken
+          token
         }
       }
       pageInfo {
@@ -33,4 +31,5 @@ query = """query RepoTokensForOwner(
       totalCount
     }
   }
-}"""
+}
+"""

--- a/src/sentry/codecov/endpoints/repository_tokens/repository_tokens.py
+++ b/src/sentry/codecov/endpoints/repository_tokens/repository_tokens.py
@@ -75,9 +75,8 @@ class RepositoryTokensEndpoint(CodecovEndpoint):
 
         variables = {
             "owner": owner_slug,
-            "filters": {"term": request.query_params.get("term")},
             "direction": OrderingDirection.DESC.value,
-            "ordering": "UPDATED_AT",
+            "ordering": "COMMIT_DATE",
             "first": limit if navigation != NavigationParameter.PREV.value else None,
             "last": limit if navigation == NavigationParameter.PREV.value else None,
             "before": cursor if cursor and navigation == NavigationParameter.PREV.value else None,

--- a/src/sentry/codecov/endpoints/repository_tokens/repository_tokens.py
+++ b/src/sentry/codecov/endpoints/repository_tokens/repository_tokens.py
@@ -1,0 +1,91 @@
+from drf_spectacular.utils import extend_schema
+from rest_framework import status
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.apidocs.constants import RESPONSE_BAD_REQUEST, RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND
+from sentry.apidocs.parameters import GlobalParams, PreventParams
+from sentry.codecov.base import CodecovEndpoint
+from sentry.codecov.client import CodecovApiClient
+from sentry.codecov.endpoints.repository_tokens.query import query
+from sentry.codecov.endpoints.repository_tokens.serializers import RepositoryTokensSerializer
+from sentry.codecov.enums import NavigationParameter, OrderingDirection
+from sentry.integrations.services.integration.model import RpcIntegration
+
+MAX_RESULTS_PER_PAGE = 25
+
+
+@extend_schema(tags=["Prevent"])
+@region_silo_endpoint
+class RepositoryTokensEndpoint(CodecovEndpoint):
+    owner = ApiOwner.CODECOV
+    publish_status = {
+        "GET": ApiPublishStatus.PUBLIC,
+    }
+
+    @extend_schema(
+        operation_id="Retrieves a paginated list of repository tokens for a given owner",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            PreventParams.OWNER,
+            PreventParams.LIMIT,
+            PreventParams.NAVIGATION,
+            PreventParams.CURSOR,
+            PreventParams.TERM,
+        ],
+        request=None,
+        responses={
+            200: RepositoryTokensSerializer,
+            400: RESPONSE_BAD_REQUEST,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
+    def get(self, request: Request, owner: RpcIntegration, **kwargs) -> Response:
+        """
+        Retrieves a paginated list of repository tokens for a given owner.
+        """
+
+        navigation = request.query_params.get("navigation", NavigationParameter.NEXT.value)
+        limit_param = request.query_params.get("limit", MAX_RESULTS_PER_PAGE)
+        cursor = request.query_params.get("cursor")
+
+        owner_slug = owner.name
+
+        # When calling request.query_params, the URL is decoded so + is replaced with spaces. We need to change them back so Codecov can properly fetch the next page.
+        if cursor:
+            cursor = cursor.replace(" ", "+")
+
+        try:
+            limit = int(limit_param)
+        except ValueError:
+            return Response(
+                status=status.HTTP_400_BAD_REQUEST,
+                data={"details": "provided `limit` parameter must be a positive integer"},
+            )
+
+        if limit <= 0:
+            return Response(
+                status=status.HTTP_400_BAD_REQUEST,
+                data={"details": "provided `limit` parameter must be a positive integer"},
+            )
+
+        variables = {
+            "owner": owner_slug,
+            "filters": {"term": request.query_params.get("term")},
+            "direction": OrderingDirection.DESC.value,
+            "ordering": "UPDATED_AT",
+            "first": limit if navigation != NavigationParameter.PREV.value else None,
+            "last": limit if navigation == NavigationParameter.PREV.value else None,
+            "before": cursor if cursor and navigation == NavigationParameter.PREV.value else None,
+            "after": cursor if cursor and navigation == NavigationParameter.NEXT.value else None,
+        }
+
+        client = CodecovApiClient(git_provider_org=owner_slug)
+        graphql_response = client.query(query=query, variables=variables)
+        repository_tokens = RepositoryTokensSerializer().to_representation(graphql_response.json())
+
+        return Response(repository_tokens)

--- a/src/sentry/codecov/endpoints/repository_tokens/serializers.py
+++ b/src/sentry/codecov/endpoints/repository_tokens/serializers.py
@@ -14,7 +14,7 @@ class RepositoryTokenNodeSerializer(serializers.Serializer):
     """
 
     name = serializers.CharField()
-    uploadToken = serializers.CharField()
+    token = serializers.CharField()
 
 
 class RepositoryTokensSerializer(serializers.Serializer):

--- a/src/sentry/codecov/endpoints/repository_tokens/serializers.py
+++ b/src/sentry/codecov/endpoints/repository_tokens/serializers.py
@@ -1,0 +1,73 @@
+import logging
+
+import sentry_sdk
+from rest_framework import serializers
+
+from sentry.codecov.endpoints.common.serializers import PageInfoSerializer
+
+logger = logging.getLogger(__name__)
+
+
+class RepositoryTokenNodeSerializer(serializers.Serializer):
+    """
+    Serializer for individual repository nodes from GraphQL response
+    """
+
+    name = serializers.CharField()
+    uploadToken = serializers.CharField()
+
+
+class RepositoryTokensSerializer(serializers.Serializer):
+    """
+    Serializer for repository tokens response
+    """
+
+    results = RepositoryTokenNodeSerializer(many=True)
+    pageInfo = PageInfoSerializer()
+    totalCount = serializers.IntegerField()
+
+    def to_representation(self, graphql_response):
+        """
+        Transform the GraphQL response to the serialized format
+        """
+        try:
+            repository_tokens_data = graphql_response["data"]["owner"]["repositories"]
+            repository_tokens = repository_tokens_data["edges"]
+            page_info = repository_tokens_data.get("pageInfo", {})
+
+            nodes = []
+            for edge in repository_tokens:
+                node = edge["node"]
+                nodes.append(node)
+
+            response_data = {
+                "results": nodes,
+                "pageInfo": repository_tokens_data.get(
+                    "pageInfo",
+                    {
+                        "hasNextPage": page_info.get("hasNextPage", False),
+                        "hasPreviousPage": page_info.get("hasPreviousPage", False),
+                        "startCursor": page_info.get("startCursor"),
+                        "endCursor": page_info.get("endCursor"),
+                    },
+                ),
+                "totalCount": repository_tokens_data.get("totalCount", len(nodes)),
+            }
+
+            return super().to_representation(response_data)
+
+        except (KeyError, TypeError) as e:
+            sentry_sdk.capture_exception(e)
+            logger.exception(
+                "Error parsing GraphQL response",
+                extra={
+                    "error": str(e),
+                    "endpoint": "repository-tokens",
+                    "response_keys": (
+                        list(graphql_response.keys())
+                        if isinstance(graphql_response, dict)
+                        else None
+                    ),
+                },
+            )
+            raise

--- a/tests/sentry/codecov/endpoints/test_repository_tokens.py
+++ b/tests/sentry/codecov/endpoints/test_repository_tokens.py
@@ -1,0 +1,174 @@
+from typing import Any
+from unittest.mock import MagicMock, Mock, patch
+
+from django.urls import reverse
+
+from sentry.codecov.endpoints.repository_tokens.serializers import (
+    RepositoryTokenNodeSerializer as NodeSerializer,
+)
+from sentry.constants import ObjectStatus
+from sentry.testutils.cases import APITestCase
+
+mock_graphql_response_populated: dict[str, Any] = {
+    "data": {
+        "owner": {
+            "repositories": {
+                "edges": [
+                    {
+                        "node": {
+                            "name": "test-repo-one",
+                            "token": "sk_test_token_12345abcdef",
+                        }
+                    },
+                    {
+                        "node": {
+                            "name": "test-repo-two",
+                            "token": "sk_test_token_67890ghijkl",
+                        }
+                    },
+                ],
+                "pageInfo": {
+                    "endCursor": "cursor123",
+                    "hasNextPage": True,
+                    "hasPreviousPage": False,
+                    "startCursor": "cursor001",
+                },
+                "totalCount": 2,
+            }
+        }
+    }
+}
+
+mock_graphql_response_empty: dict[str, Any] = {
+    "data": {
+        "owner": {
+            "repositories": {
+                "edges": [],
+                "pageInfo": {
+                    "endCursor": None,
+                    "hasNextPage": False,
+                    "hasPreviousPage": False,
+                    "startCursor": None,
+                },
+                "totalCount": 0,
+            }
+        }
+    }
+}
+
+
+class RepositoryTokensEndpointTest(APITestCase):
+    endpoint_name = "sentry-api-0-repository-tokens"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.organization = self.create_organization(owner=self.user)
+        self.integration = self.create_integration(
+            organization=self.organization,
+            external_id="1234",
+            name="testowner",
+            provider="github",
+            status=ObjectStatus.ACTIVE,
+        )
+        self.login_as(user=self.user)
+
+    def reverse_url(self, owner="testowner"):
+        """Custom reverse URL method to handle required URL parameters"""
+        return reverse(
+            self.endpoint_name,
+            kwargs={
+                "organization_id_or_slug": self.organization.slug,
+                "owner": self.integration.id,
+            },
+        )
+
+    @patch("sentry.codecov.endpoints.repository_tokens.repository_tokens.CodecovApiClient")
+    def test_get_returns_mock_response_with_default_variables(
+        self, mock_codecov_client_class: MagicMock
+    ) -> None:
+        mock_codecov_client_instance = Mock()
+        mock_response = Mock()
+        mock_response.json.return_value = mock_graphql_response_populated
+        mock_codecov_client_instance.query.return_value = mock_response
+        mock_codecov_client_class.return_value = mock_codecov_client_instance
+
+        url = self.reverse_url()
+        response = self.client.get(url)
+
+        mock_codecov_client_class.assert_called_once_with(git_provider_org="testowner")
+
+        # Verify the correct variables are passed to the GraphQL query
+        expected_variables = {
+            "owner": "testowner",
+            "direction": "DESC",
+            "ordering": "COMMIT_DATE",
+            "first": 25,
+            "last": None,
+            "after": None,
+            "before": None,
+        }
+
+        mock_codecov_client_instance.query.assert_called_once()
+        call_args = mock_codecov_client_instance.query.call_args
+        assert call_args[1]["variables"] == expected_variables
+
+        assert response.status_code == 200
+        assert len(response.data["results"]) == 2
+        assert response.data["results"][0]["name"] == "test-repo-one"
+        assert response.data["results"][0]["token"] == "sk_test_token_12345abcdef"
+        assert response.data["results"][1]["name"] == "test-repo-two"
+        assert response.data["results"][1]["token"] == "sk_test_token_67890ghijkl"
+        assert response.data["pageInfo"]["endCursor"] == "cursor123"
+        assert response.data["pageInfo"]["hasNextPage"] is True
+        assert response.data["pageInfo"]["hasPreviousPage"] is False
+        assert response.data["pageInfo"]["startCursor"] == "cursor001"
+        assert response.data["totalCount"] == 2
+
+        serializer_fields = set(NodeSerializer().fields.keys())
+        response_keys = set(response.data["results"][0].keys())
+
+        assert (
+            response_keys == serializer_fields
+        ), f"Response keys {response_keys} don't match serializer fields {serializer_fields}"
+
+    @patch("sentry.codecov.endpoints.repository_tokens.repository_tokens.CodecovApiClient")
+    def test_get_with_query_parameters(self, mock_codecov_client_class: MagicMock) -> None:
+        mock_codecov_client_instance = Mock()
+        mock_response = Mock()
+        mock_response.json.return_value = mock_graphql_response_empty
+        mock_codecov_client_instance.query.return_value = mock_response
+        mock_codecov_client_class.return_value = mock_codecov_client_instance
+
+        url = self.reverse_url()
+        query_params = {"cursor": "cursor123", "limit": "5", "navigation": "prev"}
+        response = self.client.get(url, query_params)
+
+        expected_variables = {
+            "owner": "testowner",
+            "direction": "DESC",
+            "ordering": "COMMIT_DATE",
+            "first": None,
+            "last": 5,
+            "before": "cursor123",
+            "after": None,
+        }
+
+        call_args = mock_codecov_client_instance.query.call_args
+        assert call_args[1]["variables"] == expected_variables
+        assert response.status_code == 200
+
+    def test_get_with_negative_limit_returns_bad_request(self) -> None:
+        url = self.reverse_url()
+        query_params = {"limit": "-5"}
+        response = self.client.get(url, query_params)
+
+        assert response.status_code == 400
+        assert response.data == {"details": "provided `limit` parameter must be a positive integer"}
+
+    def test_get_with_zero_limit_returns_bad_request(self) -> None:
+        url = self.reverse_url()
+        query_params = {"limit": "0"}
+        response = self.client.get(url, query_params)
+
+        assert response.status_code == 400
+        assert response.data == {"details": "provided `limit` parameter must be a positive integer"}


### PR DESCRIPTION
This PR aims to add the list tokens endpoint for showing all the repo tokens for a particular organization.

Closes https://linear.app/getsentry/issue/CCMRG-1310/create-list-endpoint-for-repository-tokens

Depends on https://github.com/codecov/umbrella/pull/371 which adds a new "token" property to the repository resolver which bypasses some other checks we have on the uploadToken endpoint. I didn't want to make the modifications to the uploadToken endpoint directly because then Gazebo would probably break and/or it'd just look really hacky.

Follows similar conventions to the list repositories endpoint, just a slightly different GQL query

<img width="974" height="771" alt="Screenshot 2025-08-01 at 1 29 02 PM" src="https://github.com/user-attachments/assets/7b943e90-1912-4b2b-a07d-7ec63cff8374" />


Hiding all the token info for privacy

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
