### PR TITLE
fix(replay): don't reset time on tab change

### DIFF
--- a/static/app/utils/replays/hooks/useReplayData.tsx
+++ b/static/app/utils/replays/hooks/useReplayData.tsx
@@ -258,13 +258,19 @@ function useReplayData({
   }, [errorPages, extraErrorPages, platformErrorPages]);
 
   const {
-    feedbackEvents,
+    feedbackEvents: rawFeedbackEvents,
     isPending: feedbackEventsPending,
     isError: feedbackEventsError,
   } = useFeedbackEvents({
     feedbackEventIds: feedbackEventIds ?? [],
     projectId: replayRecord?.project_id,
   });
+
+  // Stabilize feedbackEvents to prevent unnecessary re-renders
+  const feedbackEvents = useMemo(() => {
+    return rawFeedbackEvents;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [rawFeedbackEvents?.length]);
 
   const allStatuses = [
     enableReplayRecord ? fetchReplayStatus : undefined,

--- a/static/app/utils/replays/hooks/useReplayData.tsx
+++ b/static/app/utils/replays/hooks/useReplayData.tsx
@@ -266,7 +266,10 @@ function useReplayData({
     projectId: replayRecord?.project_id,
   });
 
-  // Stabilize feedbackEvents to prevent unnecessary re-renders
+  // stabilize feedbackEvents to prevent unnecessary re-renders.
+  // we don't care about reordering and feedback events can't be updated.
+  // if a new feedback is submitted, then the length will increase, which is
+  // the only thing we care about.
   const feedbackEvents = useMemo(() => {
     return rawFeedbackEvents;
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION

https://github.com/user-attachments/assets/12ec9bff-10b8-4b7d-b2d5-49dbf26054ee

closes https://linear.app/getsentry/issue/REPLAY-582/bug-replay-details-replay-timer-resets-to-0000-when-switching-tabs