### PR TITLE
test(ui): Attempt to fix flake in dropdown menu test

### DIFF
--- a/static/app/components/dropdownMenu/index.spec.tsx
+++ b/static/app/components/dropdownMenu/index.spec.tsx
@@ -1,12 +1,6 @@
 import {Fragment} from 'react';
 
-import {
-  render,
-  screen,
-  userEvent,
-  waitFor,
-  waitForElementToBeRemoved,
-} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 
@@ -289,7 +283,9 @@ describe('DropdownMenu', function () {
 
     await userEvent.click(screen.getByRole('button', {name: 'Menu'}));
     await userEvent.click(screen.getByRole('menuitemradio', {name: 'Item One'}));
-    await waitForElementToBeRemoved(screen.queryByRole('menuitemradio'));
+    await waitFor(() => {
+      expect(screen.queryByRole('menuitemradio')).not.toBeInTheDocument();
+    });
   });
 
   it('navigates to link on enter', async function () {


### PR DESCRIPTION
> The element(s) given to waitForElementToBeRemoved are already removed. waitForElementToBeRemoved requires that the element(s) exist(s) before waiting for removal.

fixes [JEST-1N51](https://sentry.sentry.io/issues/6761127654/)
