### PR TITLE
ref(grouping): Clarify `has_url_origin` parameter

### DIFF
--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -145,7 +145,7 @@ def get_filename_component(
     filename = _basename_re.split(filename)[-1].lower()
     filename_component = FilenameGroupingComponent(values=[filename])
 
-    if has_url_origin(abs_path, allow_file_origin=True):
+    if has_url_origin(abs_path, files_count_as_urls=False):
         filename_component.update(contributes=False, hint="ignored because frame points to a URL")
     elif filename == "<anonymous>":
         filename_component.update(contributes=False, hint="anonymous filename discarded")
@@ -395,7 +395,7 @@ def get_contextline_component(
         elif (
             get_behavior_family_for_platform(platform) == "javascript"
             and not function
-            and has_url_origin(frame.abs_path)
+            and has_url_origin(frame.abs_path, files_count_as_urls=True)
         ):
             context_line_component.update(
                 hint="discarded because from URL origin and no function", contributes=False

--- a/src/sentry/grouping/strategies/utils.py
+++ b/src/sentry/grouping/strategies/utils.py
@@ -42,7 +42,7 @@ def remove_non_stacktrace_variants(variants: ReturnedVariants) -> ReturnedVarian
     return variants
 
 
-def has_url_origin(path: str, allow_file_origin: bool = False) -> bool:
+def has_url_origin(path: str, files_count_as_urls: bool) -> bool:
     # URLs can be generated such that they are:
     #   blob:http://example.com/7f7aaadf-a006-4217-9ed5-5fbf8585c6c0
     # https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL
@@ -51,5 +51,5 @@ def has_url_origin(path: str, allow_file_origin: bool = False) -> bool:
     if path.startswith(("http:", "https:", "applewebdata:", "blob:")):
         return True
     if path.startswith("file:"):
-        return not allow_file_origin
+        return files_count_as_urls
     return False


### PR DESCRIPTION
This is a small refactor of a grouping helper, `has_url_origin`, to make it easier to understand. Included changes:

- Rename the `allow_file_origin` parameter. For it to make sense, you have to know whether having a URL origin means something will be allowed or disallowed (one of each, as it turns out).
- Reverse the parameter's boolean meaning, to be positive (files are URLs) rather than negative (files aren't URLs).
- Make the parameter required, just to make the behavior explicit everywhere the helper is used.