### PR TITLE
ref(grouping): remove check for transaction event type in grouping_info

### DIFF
--- a/src/sentry/grouping/grouping_info.py
+++ b/src/sentry/grouping/grouping_info.py
@@ -3,9 +3,8 @@ from typing import Any
 
 from sentry.eventstore.models import Event, GroupEvent
 from sentry.grouping.strategies.base import StrategyConfiguration
-from sentry.grouping.variants import BaseVariant, PerformanceProblemVariant
+from sentry.grouping.variants import BaseVariant
 from sentry.models.project import Project
-from sentry.performance_issues.performance_detection import EventPerformanceProblem
 from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)
@@ -19,23 +18,7 @@ def get_grouping_info(
     # produced hashes that would normally also appear in the event.
     hashes = event.get_hashes()
 
-    if event.get_event_type() == "transaction":
-        # Transactions events are grouped using performance detection. They
-        # are not subject to grouping configs, and the only relevant
-        # grouping variant is `PerformanceProblemVariant`.
-
-        problems = EventPerformanceProblem.fetch_multi([(event, h) for h in hashes])
-
-        # Create a variant for every problem associated with the event
-        # TODO: Generate more unique keys, in case this event has more than
-        # one problem of a given type
-        variants: dict[str, BaseVariant] = {
-            problem.problem.type.slug: PerformanceProblemVariant(problem)
-            for problem in problems
-            if problem
-        }
-    else:
-        variants = event.get_grouping_variants(grouping_config, normalize_stacktraces=True)
+    variants = event.get_grouping_variants(grouping_config, normalize_stacktraces=True)
 
     grouping_info = get_grouping_info_from_variants(variants)
 

--- a/tests/sentry/api/endpoints/test_event_grouping_info.py
+++ b/tests/sentry/api/endpoints/test_event_grouping_info.py
@@ -1,7 +1,6 @@
 from unittest import mock
 
 import orjson
-import pytest
 from django.urls import reverse
 
 from sentry.conf.server import DEFAULT_GROUPING_CONFIG
@@ -150,58 +149,6 @@ class EventGroupingInfoEndpointTestCase(APITestCase, PerformanceIssueTestCase):
                 assert response_error_types == list(reversed(orig_exception_types))
             else:
                 assert response_error_types == orig_exception_types
-
-    def test_transaction_event(self) -> None:
-        data = load_data(platform="transaction")
-        event = self.store_event(data=data, project_id=self.project.id)
-
-        url = reverse(
-            "sentry-api-0-event-grouping-info",
-            kwargs={
-                "organization_id_or_slug": self.organization.slug,
-                "project_id_or_slug": self.project.slug,
-                "event_id": event.event_id,
-            },
-        )
-
-        response = self.client.get(url, format="json")
-        content = orjson.loads(response.content)
-
-        assert response.status_code == 200
-        assert content == {}
-
-    @pytest.mark.skip("We no longer return perf issue info from the grouping info endpoint")
-    def test_transaction_event_with_problem(self) -> None:
-        event = self.create_performance_issue()
-        url = reverse(
-            "sentry-api-0-event-grouping-info",
-            kwargs={
-                "organization_id_or_slug": self.organization.slug,
-                "project_id_or_slug": self.project.slug,
-                "event_id": event.event_id,
-            },
-        )
-
-        response = self.client.get(url, format="json")
-        content = orjson.loads(response.content)
-
-        assert response.status_code == 200
-        assert content["performance_n_plus_one_db_queries"]["type"] == "performance-problem"
-        assert content["performance_n_plus_one_db_queries"]["evidence"]["parent_span_hashes"] == [
-            "6a992d5529f459a4"
-        ]
-        assert content["performance_n_plus_one_db_queries"]["evidence"]["offender_span_hashes"] == [
-            "d74ed7012596c3fb",
-            "d74ed7012596c3fb",
-            "d74ed7012596c3fb",
-            "d74ed7012596c3fb",
-            "d74ed7012596c3fb",
-            "d74ed7012596c3fb",
-            "d74ed7012596c3fb",
-            "d74ed7012596c3fb",
-            "d74ed7012596c3fb",
-            "d74ed7012596c3fb",
-        ]
 
     def test_no_event(self) -> None:
         url = reverse(


### PR DESCRIPTION
Removed handling of transaction events in get_grouping_info, since

a) as of https://github.com/getsentry/sentry/pull/48715 transaction events with occurrences no longer get sent to the endpoint which uses the function, and
b) now that performance issues are issue-platform-based, transactions in an issue will always have an occurrence.
