### PR TITLE
nit(aci): add word break to prevent conditions panel overflow

### DIFF
--- a/static/app/views/automations/components/conditionsPanel.tsx
+++ b/static/app/views/automations/components/conditionsPanel.tsx
@@ -80,10 +80,6 @@ interface ActionFilterProps {
 function ActionFilter({actionFilter, totalFilters}: ActionFilterProps) {
   const {data: availableActions = [], isLoading} = useAvailableActionsQuery();
 
-  // if (isLoading) {
-  //   return <LoadingIndicator />;
-  // }
-
   return (
     <ConditionGroupWrapper showDivider={totalFilters > 1}>
       <ConditionGroupHeader>
@@ -157,6 +153,7 @@ const Panel = styled('div')`
   border: 1px solid ${p => p.theme.translucentBorder};
   border-radius: ${p => p.theme.borderRadius};
   padding: ${space(1.5)};
+  word-break: break-word;
 `;
 
 const ConditionGroupHeader = styled('div')`


### PR DESCRIPTION
before
<img width="403" height="327" alt="Screenshot 2025-08-01 at 2 15 22 PM" src="https://github.com/user-attachments/assets/8b74b129-225e-4cfa-a51b-5e58f56f4c8a" />

after
<img width="391" height="390" alt="Screenshot 2025-08-01 at 2 15 32 PM" src="https://github.com/user-attachments/assets/3f5158a1-d0a3-4129-93f1-3e7318520faf" />