### PR TITLE
feat(replay): update states of ai summaries

### DIFF
--- a/static/app/views/replays/detail/ai/ai.tsx
+++ b/static/app/views/replays/detail/ai/ai.tsx
@@ -128,7 +128,27 @@ export default function Ai() {
     return (
       <Wrapper data-test-id="replay-details-ai-summary-tab">
         <EmptySummaryContainer>
-          <Alert type="error">{t('Failed to load replay summary.')}</Alert>
+          <Alert
+            type="error"
+            trailingItems={
+              <Button
+                priority="default"
+                type="button"
+                size="xs"
+                onClick={() => {
+                  startSummaryRequest();
+                  trackAnalytics('replay.ai-summary.regenerate-requested', {
+                    organization,
+                  });
+                }}
+                icon={<IconSync size="xs" />}
+              >
+                {t('Retry')}
+              </Button>
+            }
+          >
+            {t('Failed to load replay summary.')}
+          </Alert>
         </EmptySummaryContainer>
       </Wrapper>
     );

--- a/static/app/views/replays/detail/ai/ai.tsx
+++ b/static/app/views/replays/detail/ai/ai.tsx
@@ -86,7 +86,11 @@ export default function Ai() {
             )}
           </div>
           <div>
-            <LinkButton size="sm" priority="primary" to="/settings/seer/">
+            <LinkButton
+              size="sm"
+              priority="primary"
+              to={`/settings/${organization.slug}/seer/`}
+            >
               {t('View Seer Settings')}
             </LinkButton>
           </div>

--- a/static/app/views/replays/detail/ai/ai.tsx
+++ b/static/app/views/replays/detail/ai/ai.tsx
@@ -52,7 +52,7 @@ export default function Ai() {
     return (
       <Wrapper data-test-id="replay-details-ai-summary-tab">
         <EndStateContainer>
-          <img src={replayEmptyState} height={300} />
+          <img src={replayEmptyState} height={300} alt="" />
           <div>{t('AI features are not available for this organization.')}</div>
         </EndStateContainer>
       </Wrapper>
@@ -64,7 +64,9 @@ export default function Ai() {
     return (
       <Wrapper data-test-id="replay-details-ai-summary-tab">
         <LoadingContainer>
-          <img src={loadingGif} height={400} />
+          <div>
+            <img src={loadingGif} style={{maxHeight: 400}} alt={t('Loading...')} />
+          </div>
         </LoadingContainer>
       </Wrapper>
     );
@@ -76,7 +78,7 @@ export default function Ai() {
     return (
       <Wrapper data-test-id="replay-details-ai-summary-tab">
         <EndStateContainer>
-          <img src={aiBanner} />
+          <img src={aiBanner} alt="" />
           <div>
             <strong>{t('AI-Powered Replay Summaries')}</strong>
           </div>
@@ -110,7 +112,9 @@ export default function Ai() {
     return (
       <Wrapper data-test-id="replay-details-ai-summary-tab">
         <LoadingContainer>
-          <img src={loadingGif} height={400} />
+          <div>
+            <img src={loadingGif} style={{maxHeight: 400}} alt={t('Loading...')} />
+          </div>
           <div>{t('This might take a few moments...')}</div>
         </LoadingContainer>
       </Wrapper>
@@ -121,7 +125,7 @@ export default function Ai() {
     return (
       <Wrapper data-test-id="replay-details-ai-summary-tab">
         <EndStateContainer>
-          <img src={replayEmptyState} height={300} />
+          <img src={replayEmptyState} height={300} alt="" />
           <div>{t('Project not found. Unable to load replay summary.')}</div>
         </EndStateContainer>
       </Wrapper>
@@ -132,7 +136,7 @@ export default function Ai() {
     return (
       <Wrapper data-test-id="replay-details-ai-summary-tab">
         <EndStateContainer>
-          <img src={aiBanner} />
+          <img src={aiBanner} alt="" />
           <div>{t('Failed to load replay summary.')}</div>
           <div>
             <Button
@@ -159,35 +163,34 @@ export default function Ai() {
     return (
       <Wrapper data-test-id="replay-details-ai-summary-tab">
         <EndStateContainer>
-          <img src={aiBanner} />
+          <img src={aiBanner} alt="" />
           <div>{t('No summary available for this replay.')}</div>
         </EndStateContainer>
       </Wrapper>
     );
   }
 
-  if (summaryData.data.time_ranges.length <= 1) {
-    if (
-      replay
-        ?.getChapterFrames()
-        ?.filter(frame => isSpanFrame(frame) || frame.category !== 'replay.init')
-        .length === 0
-    ) {
-      return (
-        <Wrapper data-test-id="replay-details-ai-summary-tab">
-          <EndStateContainer>
-            <img src={aiBanner} />
-            <div>
-              {
-                NO_REPLAY_SUMMARY_MESSAGES[
-                  Math.floor(Math.random() * NO_REPLAY_SUMMARY_MESSAGES.length)
-                ]
-              }
-            </div>
-          </EndStateContainer>
-        </Wrapper>
-      );
-    }
+  if (
+    summaryData.data.time_ranges.length <= 1 &&
+    replay
+      ?.getChapterFrames()
+      ?.filter(frame => isSpanFrame(frame) || frame.category !== 'replay.init').length ===
+      0
+  ) {
+    return (
+      <Wrapper data-test-id="replay-details-ai-summary-tab">
+        <EndStateContainer>
+          <img src={aiBanner} alt="" />
+          <div>
+            {
+              NO_REPLAY_SUMMARY_MESSAGES[
+                Math.floor(Math.random() * NO_REPLAY_SUMMARY_MESSAGES.length)
+              ]
+            }
+          </div>
+        </EndStateContainer>
+      </Wrapper>
+    );
   }
 
   return (

--- a/static/app/views/replays/detail/ai/ai.tsx
+++ b/static/app/views/replays/detail/ai/ai.tsx
@@ -1,13 +1,15 @@
 import styled from '@emotion/styled';
 
-import {Alert} from 'sentry/components/core/alert';
+import loadingGif from 'sentry-images/spot/ai-loader.gif';
+import aiBanner from 'sentry-images/spot/ai-suggestion-banner-stars.svg';
+import replayEmptyState from 'sentry-images/spot/replays-empty-state.svg';
+
 import {Badge} from 'sentry/components/core/badge';
 import {Button} from 'sentry/components/core/button';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {Flex} from 'sentry/components/core/layout';
 import {Text} from 'sentry/components/core/text';
 import {useOrganizationSeerSetup} from 'sentry/components/events/autofix/useOrganizationSeerSetup';
-import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {IconSeer, IconSync, IconThumb} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -49,11 +51,10 @@ export default function Ai() {
   if (!organization.features.includes('replay-ai-summaries') || !areAiFeaturesAllowed) {
     return (
       <Wrapper data-test-id="replay-details-ai-summary-tab">
-        <EmptySummaryContainer>
-          <Alert type="warning">
-            {t('AI features are not available for this organization.')}
-          </Alert>
-        </EmptySummaryContainer>
+        <EndStateContainer>
+          <img src={replayEmptyState} height={300} />
+          <div>{t('AI features are not available for this organization.')}</div>
+        </EndStateContainer>
       </Wrapper>
     );
   }
@@ -63,7 +64,7 @@ export default function Ai() {
     return (
       <Wrapper data-test-id="replay-details-ai-summary-tab">
         <LoadingContainer>
-          <LoadingIndicator />
+          <img src={loadingGif} height={400} />
         </LoadingContainer>
       </Wrapper>
     );
@@ -74,23 +75,22 @@ export default function Ai() {
   if (!setupAcknowledgement.orgHasAcknowledged) {
     return (
       <Wrapper data-test-id="replay-details-ai-summary-tab">
-        <EmptySummaryContainer>
-          <CallToActionContainer>
-            <div>
-              <strong>{t('AI-Powered Replay Summaries')}</strong>
-            </div>
-            <div>
-              {t(
-                'Seer access is required to use replay summaries. Please view the Seer settings page for more information.'
-              )}
-            </div>
-            <div>
-              <LinkButton size="sm" priority="primary" to="/settings/seer/">
-                {t('View Seer Settings')}
-              </LinkButton>
-            </div>
-          </CallToActionContainer>
-        </EmptySummaryContainer>
+        <EndStateContainer>
+          <img src={aiBanner} />
+          <div>
+            <strong>{t('AI-Powered Replay Summaries')}</strong>
+          </div>
+          <div>
+            {t(
+              'Seer access is required to use replay summaries. Please view the Seer settings page for more information.'
+            )}
+          </div>
+          <div>
+            <LinkButton size="sm" priority="primary" to="/settings/seer/">
+              {t('View Seer Settings')}
+            </LinkButton>
+          </div>
+        </EndStateContainer>
       </Wrapper>
     );
   }
@@ -106,7 +106,8 @@ export default function Ai() {
     return (
       <Wrapper data-test-id="replay-details-ai-summary-tab">
         <LoadingContainer>
-          <LoadingIndicator />
+          <img src={loadingGif} height={400} />
+          <div>{t('This might take a few moments...')}</div>
         </LoadingContainer>
       </Wrapper>
     );
@@ -115,11 +116,10 @@ export default function Ai() {
   if (replayRecord?.project_id && !project) {
     return (
       <Wrapper data-test-id="replay-details-ai-summary-tab">
-        <EmptySummaryContainer>
-          <Alert type="error">
-            {t('Project not found. Unable to load replay summary.')}
-          </Alert>
-        </EmptySummaryContainer>
+        <EndStateContainer>
+          <img src={replayEmptyState} height={300} />
+          <div>{t('Project not found. Unable to load replay summary.')}</div>
+        </EndStateContainer>
       </Wrapper>
     );
   }
@@ -127,29 +127,26 @@ export default function Ai() {
   if (isError) {
     return (
       <Wrapper data-test-id="replay-details-ai-summary-tab">
-        <EmptySummaryContainer>
-          <Alert
-            type="error"
-            trailingItems={
-              <Button
-                priority="default"
-                type="button"
-                size="xs"
-                onClick={() => {
-                  startSummaryRequest();
-                  trackAnalytics('replay.ai-summary.regenerate-requested', {
-                    organization,
-                  });
-                }}
-                icon={<IconSync size="xs" />}
-              >
-                {t('Retry')}
-              </Button>
-            }
-          >
-            {t('Failed to load replay summary.')}
-          </Alert>
-        </EmptySummaryContainer>
+        <EndStateContainer>
+          <img src={aiBanner} />
+          <div>{t('Failed to load replay summary.')}</div>
+          <div>
+            <Button
+              priority="default"
+              type="button"
+              size="xs"
+              onClick={() => {
+                startSummaryRequest();
+                trackAnalytics('replay.ai-summary.regenerate-requested', {
+                  organization,
+                });
+              }}
+              icon={<IconSync size="xs" />}
+            >
+              {t('Retry')}
+            </Button>
+          </div>
+        </EndStateContainer>
       </Wrapper>
     );
   }
@@ -157,11 +154,10 @@ export default function Ai() {
   if (!summaryData?.data) {
     return (
       <Wrapper data-test-id="replay-details-ai-summary-tab">
-        <EmptySummaryContainer>
-          <Alert type="info" showIcon={false}>
-            {t('No summary available for this replay.')}
-          </Alert>
-        </EmptySummaryContainer>
+        <EndStateContainer>
+          <img src={aiBanner} />
+          <div>{t('No summary available for this replay.')}</div>
+        </EndStateContainer>
       </Wrapper>
     );
   }
@@ -175,15 +171,16 @@ export default function Ai() {
     ) {
       return (
         <Wrapper data-test-id="replay-details-ai-summary-tab">
-          <EmptySummaryContainer>
-            <Alert type="info" showIcon={false}>
+          <EndStateContainer>
+            <img src={aiBanner} />
+            <div>
               {
                 NO_REPLAY_SUMMARY_MESSAGES[
                   Math.floor(Math.random() * NO_REPLAY_SUMMARY_MESSAGES.length)
                 ]
               }
-            </Alert>
-          </EmptySummaryContainer>
+            </div>
+          </EndStateContainer>
         </Wrapper>
       );
     }
@@ -277,15 +274,13 @@ const Wrapper = styled('div')`
   border-radius: ${p => p.theme.borderRadius};
 `;
 
-const EmptySummaryContainer = styled('div')`
-  padding: ${space(2)};
-  overflow: auto;
-`;
-
 const LoadingContainer = styled('div')`
   display: flex;
   justify-content: center;
   padding: ${space(4)};
+  overflow: auto;
+  text-align: center;
+  flex-direction: column;
 `;
 
 const Summary = styled('div')`
@@ -348,10 +343,11 @@ const OverflowBody = styled('section')`
   overflow: auto;
 `;
 
-const CallToActionContainer = styled('div')`
+const EndStateContainer = styled('div')`
+  overflow: auto;
   display: flex;
   flex-direction: column;
-  gap: ${space(2)};
+  gap: ${space(4)};
   padding: ${space(2)};
   align-items: center;
   text-align: center;


### PR DESCRIPTION
closes https://linear.app/getsentry/issue/REPLAY-585/add-regenerate-button-on-summary-error
closes https://linear.app/getsentry/issue/REPLAY-586/add-a-better-loading-stateplaceholder-when-polling

update the UI of the loading & completion states for ai summary tab:

### any loading state:

https://github.com/user-attachments/assets/c4736218-8cc2-4d2a-850c-55f83dddf8ab

### replay too short state:
<img width="523" height="562" alt="SCR-20250801-ndbv" src="https://github.com/user-attachments/assets/1c6f15fe-f9a2-4a33-a41b-923adb63d62a" />

### no proj found or no ai access states:

<img width="578" height="523" alt="SCR-20250801-nfuk" src="https://github.com/user-attachments/assets/9601e989-32ec-4d8b-a005-8e87ff1752e2" />


<img width="571" height="531" alt="SCR-20250801-ngwl" src="https://github.com/user-attachments/assets/ddacebbe-9d4f-47fe-ba76-493cb294b11a" />

### failure state with retry:

<img width="561" height="439" alt="SCR-20250801-nhvy" src="https://github.com/user-attachments/assets/e8dcd702-ee98-4775-9de6-c371d350d064" />

### no seer access cta state:

<img width="655" height="541" alt="SCR-20250801-naso" src="https://github.com/user-attachments/assets/fd5e11f4-7a31-4b13-8da2-03124b976922" />

