### PR TITLE
feat(uptime): Optionally include uptime stats in `organization_trace_meta`

### DIFF
--- a/src/sentry/api/endpoints/organization_trace_meta.py
+++ b/src/sentry/api/endpoints/organization_trace_meta.py
@@ -1,9 +1,11 @@
+import logging
 from concurrent.futures import ThreadPoolExecutor
 from typing import TypedDict
 
 from django.http import HttpRequest, HttpResponse
 from rest_framework.request import Request
 from rest_framework.response import Response
+from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import TraceItemTableResponse
 
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
@@ -21,15 +23,32 @@ from sentry.snuba.ourlogs import OurLogs
 from sentry.snuba.referrer import Referrer
 from sentry.snuba.rpc_dataset_common import RPCBase, TableQuery
 from sentry.snuba.spans_rpc import Spans
+from sentry.snuba.trace import _run_uptime_results_query, _uptime_results_query
+
+logger = logging.getLogger(__name__)
 
 
-class SerializedResponse(TypedDict):
+class SerializedResponse(TypedDict, total=False):
     logs: int
     errors: int
     performance_issues: int
     span_count: int
     transaction_child_count_map: SnubaData
     span_count_map: dict[str, int]
+    uptime_checks: int  # Only present when include_uptime is True
+
+
+def extract_uptime_count(uptime_result: list[TraceItemTableResponse]) -> int:
+    """Safely extract uptime count from query result."""
+    if not uptime_result:
+        return 0
+
+    first_result = uptime_result[0]
+    if not first_result.column_values:
+        return 0
+
+    first_column = first_result.column_values[0]
+    return len(first_column.results) if first_column.results else 0
 
 
 @region_silo_endpoint
@@ -151,9 +170,11 @@ class OrganizationTraceMetaEndpoint(OrganizationEventsV2EndpointBase):
                 query=f"trace:{trace_id}",
                 limit=1,
             )
+            include_uptime = request.GET.get("include_uptime", "0") == "1"
+            max_workers = 3 + (1 if include_uptime else 0)
             with ThreadPoolExecutor(
                 thread_name_prefix=__name__,
-                max_workers=3,
+                max_workers=max_workers,
             ) as query_thread_pool:
                 spans_future = query_thread_pool.submit(
                     self.query_span_data, trace_id, snuba_params
@@ -165,15 +186,31 @@ class OrganizationTraceMetaEndpoint(OrganizationEventsV2EndpointBase):
                     errors_query.run_query, Referrer.API_TRACE_VIEW_GET_EVENTS.value
                 )
 
+                uptime_future = None
+                if include_uptime:
+                    uptime_query = _uptime_results_query(snuba_params, trace_id)
+                    uptime_future = query_thread_pool.submit(
+                        _run_uptime_results_query, uptime_query
+                    )
+
             results = spans_future.result()
             perf_issues = perf_issues_future.result()
             errors = errors_future.result()
             results["errors"] = errors
 
-        return Response(self.serialize(results, perf_issues))
+            uptime_count = None
+            if uptime_future:
+                try:
+                    uptime_result = uptime_future.result()
+                    uptime_count = extract_uptime_count(uptime_result)
+                except Exception:
+                    logger.exception("Failed to fetch uptime results")
+        return Response(self.serialize(results, perf_issues, uptime_count))
 
-    def serialize(self, results: dict[str, EAPResponse], perf_issues: int) -> SerializedResponse:
-        return {
+    def serialize(
+        self, results: dict[str, EAPResponse], perf_issues: int, uptime_count: int | None = None
+    ) -> SerializedResponse:
+        response: SerializedResponse = {
             # Values can be null if there's no result
             "logs": results["logs_meta"]["data"][0].get("count()") or 0,
             "errors": results["errors"]["data"][0].get("errors") or 0,
@@ -184,3 +221,6 @@ class OrganizationTraceMetaEndpoint(OrganizationEventsV2EndpointBase):
                 row["span.op"]: row["count()"] for row in results["spans_op_count"]["data"]
             },
         }
+        if uptime_count is not None:
+            response["uptime_checks"] = uptime_count
+        return response


### PR DESCRIPTION
This adds `include_uptime` to the meta endpoint as well. When it's passed, we'll include the number of uptime spans in the meta as well

Relies on https://github.com/getsentry/sentry/pull/96821
