### PR TITLE
feat(integrations): Refetch code mappings on delete

### DIFF
--- a/static/app/views/settings/organizationIntegrations/integrationCodeMappings.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationCodeMappings.tsx
@@ -115,6 +115,11 @@ function useDeletePathConfig() {
     onError: error => {
       addErrorMessage(`${error.statusText}: ${error.responseText}`);
     },
+    onSettled: () => {
+      queryClient.invalidateQueries({
+        queryKey: [`/organizations/${organization.slug}/code-mappings/`],
+      });
+    },
   });
 }
 
@@ -123,6 +128,7 @@ export default function IntegrationCodeMappings({
 }: {
   integration: Integration;
 }) {
+  const queryClient = useQueryClient();
   useRouteAnalyticsEventNames(
     'integrations.code_mappings_viewed',
     'Integrations: Code Mappings Viewed'
@@ -142,16 +148,13 @@ export default function IntegrationCodeMappings({
     isPending: isPendingPathConfigs,
     isError: isErrorPathConfigs,
     getResponseHeader: getPathConfigsResponseHeader,
-    refetch: refetchPathConfigs,
   } = useApiQuery<RepositoryProjectPathConfig[]>(
     makePathConfigQueryKey({
       orgSlug: organization.slug,
       integrationId,
       cursor: location.query.cursor,
     }),
-    {
-      staleTime: 30000,
-    }
+    {staleTime: 10_000}
   );
 
   const {
@@ -160,7 +163,7 @@ export default function IntegrationCodeMappings({
     isError: isErrorRepos,
   } = useApiQuery<Repository[]>(
     [`/organizations/${organization.slug}/repos/`, {query: {status: 'active'}}],
-    {staleTime: 30000}
+    {staleTime: 10_000}
   );
 
   const pathConfigs = useMemo(() => {
@@ -184,6 +187,12 @@ export default function IntegrationCodeMappings({
 
   const {mutate: deletePathConfig} = useDeletePathConfig();
 
+  const invalidateCodeMappings = useCallback(() => {
+    queryClient.invalidateQueries({
+      queryKey: [`/organizations/${organization.slug}/code-mappings/`],
+    });
+  }, [queryClient, organization.slug]);
+
   const openCodeMappingModal = useCallback(
     (pathConfig?: RepositoryProjectPathConfig) => {
       trackAnalytics('integrations.stacktrace_start_setup', {
@@ -193,35 +202,43 @@ export default function IntegrationCodeMappings({
         organization,
       });
 
-      openModal(({Body, Header, closeModal}) => (
-        <Fragment>
-          <Header closeButton>
-            <h4>{t('Configure code path mapping')}</h4>
-          </Header>
-          <Body>
-            <RepositoryProjectPathConfigForm
-              organization={organization}
-              integration={integration}
-              projects={projects}
-              repos={repos}
-              onSubmitSuccess={() => {
-                trackAnalytics('integrations.stacktrace_complete_setup', {
-                  setup_type: 'manual',
-                  view: 'integration_configuration_detail',
-                  provider: integration.provider.key,
-                  organization,
-                });
-                refetchPathConfigs();
-                closeModal();
-              }}
-              existingConfig={pathConfig}
-              onCancel={closeModal}
-            />
-          </Body>
-        </Fragment>
-      ));
+      openModal(
+        ({Body, Header, closeModal}) => (
+          <Fragment>
+            <Header closeButton>
+              <h4>{t('Configure code path mapping')}</h4>
+            </Header>
+            <Body>
+              <RepositoryProjectPathConfigForm
+                organization={organization}
+                integration={integration}
+                projects={projects}
+                repos={repos}
+                onSubmitSuccess={() => {
+                  trackAnalytics('integrations.stacktrace_complete_setup', {
+                    setup_type: 'manual',
+                    view: 'integration_configuration_detail',
+                    provider: integration.provider.key,
+                    organization,
+                  });
+                  closeModal();
+                }}
+                existingConfig={pathConfig}
+                onCancel={() => {
+                  closeModal();
+                }}
+              />
+            </Body>
+          </Fragment>
+        ),
+        {
+          onClose: () => {
+            invalidateCodeMappings();
+          },
+        }
+      );
     },
-    [repos, projects, integration, organization, refetchPathConfigs]
+    [repos, projects, integration, organization, invalidateCodeMappings]
   );
 
   const isLoading = isPendingPathConfigs || isPendingRepos;


### PR DESCRIPTION
fixes https://linear.app/getsentry/issue/ID-837/ui-does-not-refresh-after-saving-code-mapping

I wasn't able to find any place that wasn't already refreshing on creation, but now any closing of the modal will refresh the query and delete will reload as well.
