### PR TITLE
ref(grouping): change dashes to underscores in FE to match BE

### DIFF
--- a/src/sentry/api/endpoints/event_grouping_info.py
+++ b/src/sentry/api/endpoints/event_grouping_info.py
@@ -48,22 +48,7 @@ class EventGroupingInfoEndpoint(ProjectEndpoint):
         )
         grouping_config.initial_context["reverse_stacktraces"] = should_reverse_stacktraces
 
-        _grouping_info = get_grouping_info(grouping_config, project, event)
-
-        # TODO: All of the below is a temporary hack to preserve compatibility between the BE and FE as
-        # we transition from using dashes in the keys/variant types to using underscores. For now, until
-        # we change the FE, we switch back to dashes before sending the data.
-        grouping_info = {}
-
-        for key, variant_dict in _grouping_info.items():
-            new_key = key.replace("_", "-")
-            new_type = variant_dict.get("type", "").replace("_", "-")
-
-            variant_dict["key"] = new_key
-            if "type" in variant_dict:
-                variant_dict["type"] = new_type
-
-            grouping_info[new_key] = variant_dict
+        grouping_info = get_grouping_info(grouping_config, project, event)
 
         return HttpResponse(
             orjson.dumps(grouping_info, option=orjson.OPT_UTC_Z), content_type="application/json"

--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -54,11 +54,11 @@ type VariantEvidence = {
 export const enum EventGroupVariantType {
   CHECKSUM = 'checksum',
   FALLBACK = 'fallback',
-  CUSTOM_FINGERPRINT = 'custom-fingerprint',
-  BUILT_IN_FINGERPRINT = 'built-in-fingerprint',
+  CUSTOM_FINGERPRINT = 'custom_fingerprint',
+  BUILT_IN_FINGERPRINT = 'built_in_fingerprint',
   COMPONENT = 'component',
-  SALTED_COMPONENT = 'salted-component',
-  PERFORMANCE_PROBLEM = 'performance-problem',
+  SALTED_COMPONENT = 'salted_component',
+  PERFORMANCE_PROBLEM = 'performance_problem',
 }
 
 interface BaseVariant {

--- a/tests/sentry/api/endpoints/test_event_grouping_info.py
+++ b/tests/sentry/api/endpoints/test_event_grouping_info.py
@@ -270,7 +270,7 @@ class EventGroupingInfoEndpointTestCase(APITestCase, PerformanceIssueTestCase):
             extra={"project_id": self.project.id, "event_id": javascript_event.event_id},
         )
 
-    def test_variant_keys_and_types_use_dashes_not_underscores(self) -> None:
+    def test_variant_keys_and_types_use_underscored_not_dashes(self) -> None:
         """
         Test to make sure switching to using underscores on the BE doesn't change what we send
         to the FE.
@@ -293,8 +293,8 @@ class EventGroupingInfoEndpointTestCase(APITestCase, PerformanceIssueTestCase):
 
         assert response.status_code == 200
 
-        assert "custom-fingerprint" in content
-        assert "custom_fingerprint" not in content
+        assert "custom_fingerprint" in content
+        assert "custom-fingerprint" not in content
 
-        assert content["custom-fingerprint"]["key"] == "custom-fingerprint"
-        assert content["custom-fingerprint"]["type"] == "custom-fingerprint"
+        assert content["custom_fingerprint"]["key"] == "custom_fingerprint"
+        assert content["custom_fingerprint"]["type"] == "custom_fingerprint"


### PR DESCRIPTION
Change `-` to `_` in `eventGroupVariantType` for consistency across front end and back end. 

Previously the backend used `_` (i.e. `custom_fingerprint`) and the frontend used `-` (i.e. `custom-fingerprint`).

The temporary fix in `event_grouping_info` looped through all names in the back end and swapped `_` for `-`, this is a more permanent implementation. 
