### PR TITLE
ref(issues): decrease rate limits for GroupTagKeyValues endpoint again

### DIFF
--- a/src/sentry/api/endpoints/group_tagkey_values.py
+++ b/src/sentry/api/endpoints/group_tagkey_values.py
@@ -36,9 +36,9 @@ class GroupTagKeyValuesEndpoint(GroupEndpoint):
     enforce_rate_limit = True
     rate_limits = {
         "GET": {
-            RateLimitCategory.IP: RateLimit(limit=50, window=10, concurrent_limit=5),
-            RateLimitCategory.USER: RateLimit(limit=100, window=10, concurrent_limit=10),
-            RateLimitCategory.ORGANIZATION: RateLimit(limit=200, window=10, concurrent_limit=5),
+            RateLimitCategory.IP: RateLimit(limit=150, window=60, concurrent_limit=5),
+            RateLimitCategory.USER: RateLimit(limit=100, window=60, concurrent_limit=10),
+            RateLimitCategory.ORGANIZATION: RateLimit(limit=600, window=60, concurrent_limit=5),
         }
     }
 

--- a/src/sentry/api/endpoints/group_tagkey_values.py
+++ b/src/sentry/api/endpoints/group_tagkey_values.py
@@ -37,7 +37,7 @@ class GroupTagKeyValuesEndpoint(GroupEndpoint):
     rate_limits = {
         "GET": {
             RateLimitCategory.IP: RateLimit(limit=150, window=60, concurrent_limit=5),
-            RateLimitCategory.USER: RateLimit(limit=100, window=60, concurrent_limit=10),
+            RateLimitCategory.USER: RateLimit(limit=300, window=60, concurrent_limit=10),
             RateLimitCategory.ORGANIZATION: RateLimit(limit=600, window=60, concurrent_limit=5),
         }
     }

--- a/tests/sentry/api/endpoints/test_group_tagkey_values.py
+++ b/tests/sentry/api/endpoints/test_group_tagkey_values.py
@@ -206,7 +206,7 @@ class GroupTagKeyValuesTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase
         url = f"/api/0/issues/{group.id}/tags/{key}/values/"
 
         with freeze_time(datetime.datetime.now()):
-            for i in range(100):
+            for i in range(300):
                 response = self.client.get(url)
                 assert response.status_code == 200
             response = self.client.get(url)


### PR DESCRIPTION
We're still seeing this endpoint get very heavily hit ([ticket](https://linear.app/getsentry/issue/ID-830/adjust-group-tag-rate-limits-to-limit-snuba-abuse), [datadog metric showing the spike over the last month and a half](https://app.datadoghq.com/notebook/12697226/inc-1228?fullscreen_end_ts=1754088060866&fullscreen_paused=false&fullscreen_refresh_mode=sliding&fullscreen_section=overview&fullscreen_start_ts=1746312060866&fullscreen_widget=2wostwol&range=5270400000&from_ts=1748713375373&start=1748549007024&to_ts=1753983775373&live=false), [previous change to expand window](https://github.com/getsentry/sentry/pull/96890)) while [little to no frontend users getting rate limited](https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Alabels.name%3D%22sentry.access.api%22%0AjsonPayload.view%3D%22sentry.api.endpoints.group_tagkey_values.GroupTagKeyValuesEndpoint%22%20OR%20jsonPayload.view%3D%22sentry.api.endpoints.group_tagkey_details.GroupTagKeyDetailsEndpoint%22%0AjsonPayload.rate_limited%3D%22True%22%0AjsonPayload.is_frontend_request%3D%22True%22;summaryFields=:true:32:beginning;cursorTimestamp=2025-08-01T16:18:51.411350251Z;duration=PT1H?project=internal-sentry&rapt=AEjHL4MkkzmXpu2TgiQs2ui_LtNmvrHwoWOPA3TPf44095INlyjdXPA9IQ8HdSDTkV2vVYxsK-DtjNz8vtCybXpU9Bmn77JrZt5GUNWnzADenXP9A40l2xw&inv=1&invt=Ab4WLw). This halves the allowed # of requests and expands the window from 10 seconds -> 1 minute, which should alleviate some of the impact on snuba while giving some additional allowance for frontend users. We'll continue investigating and hopefully will come back to this change once we have a better rate limiting solution