### PR TITLE
ref(grouping): Refactor context line handling

### DIFF
--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -384,7 +384,10 @@ def get_contextline_component(
     quality of the sourcecode.  It does however protect against some bad
     JavaScript environments based on origin checks.
     """
-    line = " ".join((frame.context_line or "").expandtabs(2).split())
+    # Normalize all whitespace into single spaces
+    raw_line = frame.context_line or ""
+    line = " ".join(raw_line.split())
+
     if not line:
         return ContextLineGroupingComponent()
 

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -311,7 +311,7 @@ def frame(
     if module_component.contributes and filename_component.contributes:
         filename_component.update(contributes=False, hint="module takes precedence")
 
-    if platform in context["contextline_platforms"]:
+    if frame.context_line and platform in context["contextline_platforms"]:
         context_line_component = get_contextline_component(
             frame,
             platform,

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -389,17 +389,17 @@ def get_contextline_component(
         return ContextLineGroupingComponent()
 
     context_line_component = ContextLineGroupingComponent(values=[line])
-    if line:
-        if len(frame.context_line) > 120:
-            context_line_component.update(hint="discarded because line too long", contributes=False)
-        elif (
-            get_behavior_family_for_platform(platform) == "javascript"
-            and not function
-            and has_url_origin(frame.abs_path, files_count_as_urls=True)
-        ):
-            context_line_component.update(
-                hint="discarded because from URL origin and no function", contributes=False
-            )
+
+    if len(frame.context_line) > 120:
+        context_line_component.update(hint="discarded because line too long", contributes=False)
+    elif (
+        get_behavior_family_for_platform(platform) == "javascript"
+        and not function
+        and has_url_origin(frame.abs_path, files_count_as_urls=True)
+    ):
+        context_line_component.update(
+            hint="discarded because from URL origin and no function", contributes=False
+        )
 
     return context_line_component
 

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -311,9 +311,6 @@ def frame(
     if module_component.contributes and filename_component.contributes:
         filename_component.update(contributes=False, hint="module takes precedence")
 
-    context_line_component = None
-
-    # If we are allowed to use the contextline we add it now.
     if platform in context["contextline_platforms"]:
         context_line_component = get_contextline_component(
             frame,
@@ -321,8 +318,8 @@ def frame(
             function=frame.function,
             context=context,
         )
-
-    context_line_available = bool(context_line_component and context_line_component.contributes)
+    else:
+        context_line_component = None
 
     function_component = get_function_component(
         context=context,
@@ -330,7 +327,7 @@ def frame(
         raw_function=frame.raw_function,
         platform=platform,
         sourcemap_used=frame.data and frame.data.get("sourcemap") is not None,
-        context_line_available=context_line_available,
+        context_line_available=bool(context_line_component and context_line_component.contributes),
     )
 
     values: list[


### PR DESCRIPTION
This PR contains a few small refactors related to our handling of context lines during grouping. In addition to some general moving around, it includes two key changes:

- Only create a context line component if we actually have context line data (i.e., let it remain `None` rather than creating an empty component if we don't have a context line).
- In `get_contextline_component`, remove check for the existence of `line`, since if `line` is falsy, we already will have bailed out 2 lines earlier.