### PR TITLE
chore(trace ai queries): Display unsupported reason and mode

### DIFF
--- a/static/app/views/explore/components/seerComboBox/hooks.ts
+++ b/static/app/views/explore/components/seerComboBox/hooks.ts
@@ -34,6 +34,7 @@ export interface SeerSearchItem<S extends string> extends SeerSearchQuery {
 interface SeerSearchResponse {
   queries: Array<{
     group_by: string[];
+    mode: string;
     query: string;
     sort: string;
     stats_period: string;

--- a/static/app/views/explore/components/seerComboBox/hooks.ts
+++ b/static/app/views/explore/components/seerComboBox/hooks.ts
@@ -20,6 +20,7 @@ interface Visualization {
 
 interface SeerSearchQuery {
   groupBys: string[];
+  mode: string;
   query: string;
   sort: string;
   statsPeriod: string;
@@ -42,6 +43,7 @@ interface SeerSearchResponse {
     }>;
   }>;
   status: string;
+  unsupported_reason?: string;
 }
 
 export const useSeerSearch = () => {
@@ -50,6 +52,7 @@ export const useSeerSearch = () => {
   const organization = useOrganization();
   const memberProjects = projects.filter(p => p.isMember);
   const [rawResult, setRawResult] = useState<SeerSearchQuery[]>([]);
+  const [unsupportedReason, setUnsupportedReason] = useState<string | null>(null);
 
   const {
     mutate: submitQuery,
@@ -75,6 +78,7 @@ export const useSeerSearch = () => {
       });
     },
     onSuccess: result => {
+      setUnsupportedReason(result.unsupported_reason || null);
       setRawResult(
         result.queries.map((query: any) => {
           const visualizations =
@@ -89,11 +93,13 @@ export const useSeerSearch = () => {
             sort: query?.sort ?? '',
             groupBys: query?.group_by ?? [],
             statsPeriod: query?.stats_period ?? '',
+            mode: query?.mode ?? 'spans',
           };
         })
       );
     },
     onError: (error: Error) => {
+      setUnsupportedReason(null);
       addErrorMessage(t('Failed to process AI query: %(error)s', {error: error.message}));
     },
   });
@@ -103,6 +109,7 @@ export const useSeerSearch = () => {
     submitQuery,
     isPending,
     isError,
+    unsupportedReason,
   };
 };
 
@@ -139,7 +146,13 @@ export const useApplySeerSearchQuery = () => {
         },
       };
 
-      const mode = groupBys.length > 0 ? Mode.AGGREGATE : Mode.SAMPLES;
+      // TODO: Include traces mode once we can switch the table in getExploreUrl
+      const mode =
+        groupBys.length > 0
+          ? Mode.AGGREGATE
+          : result.mode === 'aggregates'
+            ? Mode.AGGREGATE
+            : Mode.SAMPLES;
       const visualize =
         visualizations?.map((v: Visualization) => ({
           chartType: v.chartType,

--- a/static/app/views/explore/components/seerComboBox/seerComboBox.tsx
+++ b/static/app/views/explore/components/seerComboBox/seerComboBox.tsx
@@ -130,7 +130,7 @@ export function SeerComboBox({initialQuery, ...props}: SeerComboBoxProps) {
     autoSubmitSeer,
     setAutoSubmitSeer,
   } = useSearchQueryBuilder();
-  const {rawResult, submitQuery, isPending, isError} = useSeerSearch();
+  const {rawResult, submitQuery, isPending, isError, unsupportedReason} = useSeerSearch();
   const applySeerSearchQuery = useApplySeerSearchQuery();
   const organization = useOrganization();
   const areAiFeaturesAllowed =
@@ -464,6 +464,12 @@ export function SeerComboBox({initialQuery, ...props}: SeerComboBoxProps) {
                 state={state}
               />
             </Fragment>
+          ) : unsupportedReason ? (
+            <SeerContent>
+              <SeerSearchHeader
+                title={unsupportedReason || 'This query is not supported'}
+              />
+            </SeerContent>
           ) : (
             <SeerContent>
               <SeerSearchHeader


### PR DESCRIPTION
- Displays the `unsupported_reason` message if the query is not possible
  - in the format: "Trace Explorer has limited information about {self.requested_functionality}. Have you tried looking in {self.recommended_tool}?"
  - ie: Trace Explorer has limited information about errors. Have you tried looking in Issues?

- Switches to aggregates for queries which may not have a group by, but are better answered in the aggregates tab
  - ie: How many post requests did I make?
    - There wouldnt be a group by here, but the user in interested in an aggregated number which the aggregates tab would show