### PR TITLE
:recycle: ref(integrations): refactor Event Lifecycle context manager to use `contextmanager` decorator

### DIFF
--- a/src/sentry/integrations/utils/metrics.py
+++ b/src/sentry/integrations/utils/metrics.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import logging
 import random
 from abc import ABC, abstractmethod
-from collections.abc import Mapping
+from collections.abc import Generator, Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass
 from enum import StrEnum
@@ -96,8 +98,15 @@ def event_lifecycle_context(
     payload: EventLifecycleMetric,
     assume_success: bool = True,
     sample_log_rate: float = 1.0,
-):
-    """Context manager for measuring event lifecycle."""
+) -> Generator[EventLifecycle]:
+    """
+    Context manager for measuring event lifecycle.
+
+    Args:
+        payload: The metric to measure.
+        assume_success: Whether to assume success if the context is exited without a failure.
+        sample_log_rate: The rate at which to sample logs.
+    """
     lifecycle = EventLifecycle(payload, assume_success, sample_log_rate)
 
     # Enter logic


### PR DESCRIPTION
Refactor EventLifecycle context management to use `@contextmanager` decorator instead of enter/exit methods.

-  Moved the context management logic from EventLifecycle's
  `__enter__`/`__exit__` methods to a new `event_lifecycle_context` function
  decorated with `@contextmanager`
- **Updated capture method:** Modified `EventLifecycleMetric.capture()` to
  return the new context manager function instead of an `EventLifecycle`
  instance directly

## Benefits of Using @contextmanager

1. **Improved Readability:** The context management logic is now in a single,
   linear function rather than split across `__enter__` and `__exit__` methods,
   making the flow easier to follow
2. The context manager is better typed
3. Developers don't need to understand the
  context manager protocol details - the `@contextmanager` decorator handles
  the boilerplate
4. **Better Exception Handling:** The exception handling logic is more
  explicit and easier to reason about, with clear separation between normal
   exit and exception exit
5. Future modifications to the context management
  behavior only require changes in one location

closes ECO-938