### PR TITLE
fix(ui2): hover state for disabled buttons

### DIFF
--- a/static/app/components/core/button/linkButton.tsx
+++ b/static/app/components/core/button/linkButton.tsx
@@ -96,8 +96,15 @@ const StyledLinkButton = styled(
       (typeof prop === 'string' && isPropValid(prop)),
   }
 )<LinkButtonProps>`
-  ${p => (p.theme.isChonk ? getChonkButtonStyles(p as any) : getButtonStyles(p as any))}
+  ${p => (p.theme.isChonk ? getChonkLinkButtonStyles(p) : getButtonStyles(p as any))}
 `;
+
+const getChonkLinkButtonStyles = (p: LinkButtonProps) => {
+  return {
+    ...getChonkButtonStyles(p as any),
+    ...(p.disabled || p.busy ? {color: 'inherit'} : undefined),
+  };
+};
 
 const ButtonLabel = styled('span', {
   shouldForwardProp: prop =>

--- a/static/app/components/core/button/styles.chonk.tsx
+++ b/static/app/components/core/button/styles.chonk.tsx
@@ -139,7 +139,7 @@ export function DO_NOT_USE_getChonkButtonStyles(
     },
 
     '&:hover': {
-      color: p.disabled || p.busy ? 'inherit' : chonkButtonTheme.color,
+      color: p.disabled || p.busy ? undefined : chonkButtonTheme.color,
 
       '&::after': {
         transform: `translateY(calc(-${elevation} - ${chonkHoverElevation}))`,


### PR DESCRIPTION
in #95974, we wanted to make sure that disabled link buttons don't get hover styles applied; however, the fix being at the button styles introduced a slight hover effect for disabled, non-link buttons

in this PR, we've reverted the fix from #95974 and instead applied the same thing directly on linkButton styles