### PR TITLE
feat(mcp-insights): link errors to trace explorer

### DIFF
--- a/static/app/views/insights/mcp/components/mcpPromptsTable.tsx
+++ b/static/app/views/insights/mcp/components/mcpPromptsTable.tsx
@@ -100,6 +100,11 @@ export function McpPromptsTable() {
             <ErrorRateCell
               errorRate={dataRow['failure_rate()']}
               total={dataRow['count()']}
+              issuesLink={getExploreUrl({
+                query: `${query} span.status:internal_error mcp.prompt.name:${dataRow[SpanFields.MCP_PROMPT_NAME]}`,
+                organization,
+                referrer: MCPReferrer.MCP_PROMPT_TABLE,
+              })}
             />
           );
         case 'count()':
@@ -111,7 +116,7 @@ export function McpPromptsTable() {
           return <div />;
       }
     },
-    [tableDataRequest]
+    [tableDataRequest, organization, query]
   );
 
   return (

--- a/static/app/views/insights/mcp/components/mcpPromptsTable.tsx
+++ b/static/app/views/insights/mcp/components/mcpPromptsTable.tsx
@@ -101,7 +101,7 @@ export function McpPromptsTable() {
               errorRate={dataRow['failure_rate()']}
               total={dataRow['count()']}
               issuesLink={getExploreUrl({
-                query: `${query} span.status:internal_error mcp.prompt.name:${dataRow[SpanFields.MCP_PROMPT_NAME]}`,
+                query: `${query} span.status:internal_error ${SpanFields.MCP_PROMPT_NAME}:${dataRow[SpanFields.MCP_PROMPT_NAME]}`,
                 organization,
                 referrer: MCPReferrer.MCP_PROMPT_TABLE,
               })}

--- a/static/app/views/insights/mcp/components/mcpResourcesTable.tsx
+++ b/static/app/views/insights/mcp/components/mcpResourcesTable.tsx
@@ -100,6 +100,11 @@ export function McpResourcesTable() {
             <ErrorRateCell
               errorRate={dataRow['failure_rate()']}
               total={dataRow['count()']}
+              issuesLink={getExploreUrl({
+                query: `${query} span.status:internal_error mcp.resource.uri:${dataRow[SpanFields.MCP_RESOURCE_URI]}`,
+                organization,
+                referrer: MCPReferrer.MCP_RESOURCE_TABLE,
+              })}
             />
           );
         case 'count()':
@@ -111,7 +116,7 @@ export function McpResourcesTable() {
           return <div />;
       }
     },
-    [tableDataRequest]
+    [tableDataRequest, organization, query]
   );
 
   return (

--- a/static/app/views/insights/mcp/components/mcpResourcesTable.tsx
+++ b/static/app/views/insights/mcp/components/mcpResourcesTable.tsx
@@ -101,7 +101,7 @@ export function McpResourcesTable() {
               errorRate={dataRow['failure_rate()']}
               total={dataRow['count()']}
               issuesLink={getExploreUrl({
-                query: `${query} span.status:internal_error mcp.resource.uri:${dataRow[SpanFields.MCP_RESOURCE_URI]}`,
+                query: `${query} span.status:internal_error ${SpanFields.MCP_RESOURCE_URI}:${dataRow[SpanFields.MCP_RESOURCE_URI]}`,
                 organization,
                 referrer: MCPReferrer.MCP_RESOURCE_TABLE,
               })}

--- a/static/app/views/insights/mcp/components/mcpToolsTable.tsx
+++ b/static/app/views/insights/mcp/components/mcpToolsTable.tsx
@@ -100,6 +100,11 @@ export function McpToolsTable() {
             <ErrorRateCell
               errorRate={dataRow['failure_rate()']}
               total={dataRow['count()']}
+              issuesLink={getExploreUrl({
+                query: `${query} span.status:internal_error mcp.tool.name:${dataRow[SpanFields.MCP_TOOL_NAME]}`,
+                organization,
+                referrer: MCPReferrer.MCP_TOOL_TABLE,
+              })}
             />
           );
         case 'count()':
@@ -111,7 +116,7 @@ export function McpToolsTable() {
           return <div />;
       }
     },
-    [tableDataRequest]
+    [tableDataRequest, organization, query]
   );
 
   return (

--- a/static/app/views/insights/mcp/components/mcpToolsTable.tsx
+++ b/static/app/views/insights/mcp/components/mcpToolsTable.tsx
@@ -101,7 +101,7 @@ export function McpToolsTable() {
               errorRate={dataRow['failure_rate()']}
               total={dataRow['count()']}
               issuesLink={getExploreUrl({
-                query: `${query} span.status:internal_error mcp.tool.name:${dataRow[SpanFields.MCP_TOOL_NAME]}`,
+                query: `${query} span.status:internal_error ${SpanFields.MCP_TOOL_NAME}:${dataRow[SpanFields.MCP_TOOL_NAME]}`,
                 organization,
                 referrer: MCPReferrer.MCP_TOOL_TABLE,
               })}


### PR DESCRIPTION
Closes [TET-903: Figure out how to link error count in table to explorer](https://linear.app/getsentry/issue/TET-903/figure-out-how-to-link-error-count-in-table-to-explorer)