### PR TITLE
fix(profiling): always fall back to pure profile chunks when we don't have enough data

### DIFF
--- a/src/sentry/profiles/flamegraph.py
+++ b/src/sentry/profiles/flamegraph.py
@@ -713,19 +713,10 @@ class FlamegraphExecutor:
             for candidate in continuous_profile_candidates
         }
 
-        always_use_direct_chunks = features.has(
-            "organizations:profiling-flamegraph-always-use-direct-chunks",
-            self.snuba_params.organization,
-            actor=self.request.user,
-        )
-
         # If we still don't have enough continuous profile candidates + transaction profile candidates,
         # we'll fall back to directly using the continuous profiling data
-        if (
-            len(continuous_profile_candidates) + len(transaction_profile_candidates) < max_profiles
-            and always_use_direct_chunks
-        ):
-            total_duration = continuous_duration if always_use_direct_chunks else 0.0
+        if len(continuous_profile_candidates) + len(transaction_profile_candidates) < max_profiles:
+            total_duration = 0.0
             max_duration = options.get("profiling.continuous-profiling.flamegraph.max-seconds")
 
             conditions = []

--- a/src/sentry/profiles/flamegraph.py
+++ b/src/sentry/profiles/flamegraph.py
@@ -716,8 +716,6 @@ class FlamegraphExecutor:
         # If we still don't have enough continuous profile candidates + transaction profile candidates,
         # we'll fall back to directly using the continuous profiling data
         if len(continuous_profile_candidates) + len(transaction_profile_candidates) < max_profiles:
-            total_duration = 0.0
-            max_duration = options.get("profiling.continuous-profiling.flamegraph.max-seconds")
 
             conditions = []
             conditions.append(Condition(Column("project_id"), Op.IN, self.snuba_params.project_ids))
@@ -781,10 +779,8 @@ class FlamegraphExecutor:
 
                 continuous_profile_candidates.append(candidate)
 
-                total_duration += end_timestamp - start_timestamp
-
                 # can set max duration to negative to skip this check
-                if (max_duration >= 0 and total_duration >= max_duration) or (
+                if (
                     len(continuous_profile_candidates) + len(transaction_profile_candidates)
                     >= max_profiles
                 ):


### PR DESCRIPTION
When we don't have enough `continuous profile candidates` + `transaction profile candidates`, we'll fall back to directly using the continuous profiling data.

This way, if profiling was used without transactions, we'll still be able to show something.