### PR TITLE
feat(agents-insights): backend analytics

### DIFF
--- a/src/sentry/analytics/events/agent_monitoring_events.py
+++ b/src/sentry/analytics/events/agent_monitoring_events.py
@@ -1,0 +1,10 @@
+from sentry import analytics
+
+
+@analytics.eventclass("agent_monitoring.query")
+class AgentMonitoringQuery(analytics.Event):
+    organization_id: int
+    referrer: str
+
+
+analytics.register(AgentMonitoringQuery)

--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -7,7 +7,8 @@ from rest_framework.exceptions import ParseError, ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
+from sentry import analytics, features
+from sentry.analytics.events.agent_monitoring_events import AgentMonitoringQuery
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import OrganizationEventsV2EndpointBase
@@ -150,6 +151,17 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):
 
             if referrer in SENTRY_BACKEND_REFERRERS:
                 query_source = QuerySource.SENTRY_BACKEND
+
+            if "agent_monitoring" in referrer:
+                try:
+                    analytics.record(
+                        AgentMonitoringQuery(
+                            organization_id=organization.id,
+                            referrer=referrer,
+                        )
+                    )
+                except Exception as e:
+                    sentry_sdk.capture_exception(e)
 
             batch_features = self.get_features(organization, request)
             has_chart_interpolation = batch_features.get(


### PR DESCRIPTION
Records analytics events for all agent_monitoring requests to events-stats

closes [TET-985: Agent monitoring backend analytics](https://linear.app/getsentry/issue/TET-985/agent-monitoring-backend-analytics)