### PR TITLE
fix(autofix): Fix repo def type

### DIFF
--- a/src/sentry/seer/models.py
+++ b/src/sentry/seer/models.py
@@ -33,7 +33,7 @@ class SeerRepoDefinition(BaseModel):
     name: str
     external_id: str
     branch_name: str | None = None
-    branch_overrides: list[BranchOverride] | None = None
+    branch_overrides: list[BranchOverride] = []
     instructions: str | None = None
     base_commit_sha: str | None = None
     provider_raw: str | None = None


### PR DESCRIPTION
Default the branch overrides to an empty list instead of None to match the typing on the Seer side.