### PR TITLE
fix(autofix): Set branch_overrides to an empty list in the setup wizard

### DIFF
--- a/static/gsApp/views/seerAutomation/onboarding.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding.tsx
@@ -68,6 +68,7 @@ function transformRepositoriesToApiFormat(repositories: any[], repoIds: string[]
       external_id: repo.externalId,
       branch_name: '',
       instructions: '',
+      branch_overrides: [],
     };
   });
 }


### PR DESCRIPTION
Set branch overrides to an empty list to prevent validation errors on the backend.