### PR TITLE
fix(ui): use PageFilterBar in issue detail

### DIFF
--- a/static/app/components/organizations/environmentPageFilter/index.tsx
+++ b/static/app/components/organizations/environmentPageFilter/index.tsx
@@ -16,7 +16,10 @@ import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
 import useRouter from 'sentry/utils/useRouter';
 
-import {EnvironmentPageFilterTrigger} from './trigger';
+import {
+  EnvironmentPageFilterTrigger,
+  type EnvironmentPageFilterTriggerProps,
+} from './trigger';
 
 interface EnvironmentPageFilterProps
   extends Partial<
@@ -35,6 +38,7 @@ interface EnvironmentPageFilterProps
       | 'menuFooterMessage'
       | 'checkboxWrapper'
       | 'shouldCloseOnInteractOutside'
+      | 'triggerProps'
     >
   > {
   /**
@@ -45,6 +49,7 @@ interface EnvironmentPageFilterProps
    * Reset these URL params when we fire actions (custom routing only)
    */
   resetParamsOnChange?: string[];
+  triggerProps?: Partial<EnvironmentPageFilterTriggerProps>;
 }
 
 export function EnvironmentPageFilter({

--- a/static/app/components/organizations/environmentPageFilter/trigger.tsx
+++ b/static/app/components/organizations/environmentPageFilter/trigger.tsx
@@ -8,11 +8,13 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trimSlug} from 'sentry/utils/string/trimSlug';
 
-interface EnvironmentPageFilterTriggerProps extends Omit<DropdownButtonProps, 'value'> {
+export interface EnvironmentPageFilterTriggerProps
+  extends Omit<DropdownButtonProps, 'value'> {
   desynced: boolean;
   environments: string[];
   ready: boolean;
   value: string[];
+  label?: string;
 }
 
 export function EnvironmentPageFilterTrigger({
@@ -20,6 +22,7 @@ export function EnvironmentPageFilterTrigger({
   environments,
   ready,
   desynced,
+  label,
   ...props
 }: EnvironmentPageFilterTriggerProps) {
   const isAllEnvironmentsSelected =
@@ -33,7 +36,8 @@ export function EnvironmentPageFilterTrigger({
   // e.g. "production, staging"
   const enumeratedLabel = envsToShow.map(env => trimSlug(env, 25)).join(', ');
 
-  const label = isAllEnvironmentsSelected ? t('All Envs') : enumeratedLabel;
+  const readyLabel =
+    label ?? (isAllEnvironmentsSelected ? t('All Envs') : enumeratedLabel);
 
   // Number of environments that aren't listed in the trigger label
   const remainingCount = isAllEnvironmentsSelected ? 0 : value.length - envsToShow.length;
@@ -41,7 +45,7 @@ export function EnvironmentPageFilterTrigger({
   return (
     <DropdownButton {...props} data-test-id="page-filter-environment-selector">
       <TriggerLabelWrap>
-        <TriggerLabel>{ready ? label : t('Loading\u2026')}</TriggerLabel>
+        <TriggerLabel>{ready ? readyLabel : t('Loading\u2026')}</TriggerLabel>
         {desynced && <DesyncedFilterIndicator role="presentation" />}
       </TriggerLabelWrap>
       {remainingCount > 0 && (

--- a/static/app/components/searchQueryBuilder/index.tsx
+++ b/static/app/components/searchQueryBuilder/index.tsx
@@ -256,7 +256,6 @@ export function SearchQueryBuilder({...props}: SearchQueryBuilderProps) {
 const Wrapper = styled(Input.withComponent('div'))`
   min-height: ${p => p.theme.form.md.minHeight};
   padding: 0;
-  height: auto;
   width: 100%;
   position: relative;
   font-size: ${p => p.theme.fontSize.md};

--- a/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
@@ -1,9 +1,8 @@
 import {useEffect} from 'react';
+import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import {Flex} from 'ui/layout';
-
-import {Button} from 'sentry/components/core/button';
+import {Flex, Grid} from 'sentry/components/core/layout';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
@@ -51,6 +50,7 @@ interface EventDetailsHeaderProps {
 }
 
 export function EventDetailsHeader({group, event, project}: EventDetailsHeaderProps) {
+  const theme = useTheme();
   const organization = useOrganization();
   const navigate = useNavigate();
   const location = useLocation();
@@ -114,7 +114,12 @@ export function EventDetailsHeader({group, event, project}: EventDetailsHeaderPr
             position="bottom-start"
           >
             <Flex>
-              <FilterContainer>
+              <Grid
+                width="100%"
+                gap="sm"
+                columns="auto minmax(100px, 1fr) auto"
+                rows={`minmax(${theme.form.md.height}, auto)`}
+              >
                 <PageFilterBar condensed>
                   <EnvironmentSelector group={group} event={event} project={project} />
                   <TimeRangeSelector
@@ -177,7 +182,7 @@ export function EventDetailsHeader({group, event, project}: EventDetailsHeaderPr
                     label: searchText,
                   }}
                 />
-              </FilterContainer>
+              </Grid>
               <ToggleSidebar />
             </Flex>
           </TourElement>
@@ -219,9 +224,13 @@ function EnvironmentSelector({group, event, project}: EventDetailsHeaderProps) {
   const eventEnvironment = event?.tags?.find(tag => tag.key === 'environment')?.value;
 
   return isFixedEnvironment ? (
-    <Button disabled title={t('This issue only occurs in a single environment')}>
-      {eventEnvironment ?? t('All Envs')}
-    </Button>
+    <EnvironmentPageFilter
+      disabled
+      triggerProps={{
+        label: eventEnvironment ?? t('All Envs'),
+        title: t('This issue only occurs in a single environment'),
+      }}
+    />
   ) : (
     <EnvironmentPageFilter />
   );
@@ -242,14 +251,6 @@ const DetailsContainer = styled('div')<{
   @media (min-width: ${p => p.theme.breakpoints.lg}) {
     border-right: 1px solid ${p => p.theme.translucentBorder};
   }
-`;
-
-const FilterContainer = styled('div')`
-  display: grid;
-  flex: 1;
-  gap: ${p => p.theme.space.sm};
-  grid-template-columns: auto minmax(100px, 1fr) auto;
-  grid-template-rows: ${p => `minmax(${p.theme.form.md.height}, auto)`};
 `;
 
 const GraphSection = styled('div')`

--- a/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
@@ -1,10 +1,12 @@
 import {useEffect} from 'react';
-import {css, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
+
+import {Flex} from 'ui/layout';
 
 import {Button} from 'sentry/components/core/button';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
+import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {TimeRangeSelector} from 'sentry/components/timeRangeSelector';
 import {getRelativeSummary} from 'sentry/components/timeRangeSelector/utils';
 import {TourElement} from 'sentry/components/tours/components';
@@ -111,56 +113,55 @@ export function EventDetailsHeader({group, event, project}: EventDetailsHeaderPr
             )}
             position="bottom-start"
           >
-            <FilterSection>
+            <Flex>
               <FilterContainer>
-                <EnvironmentSelector group={group} event={event} project={project} />
-                <DateFilter
-                  menuTitle={t('Filter Time Range')}
-                  start={period?.start}
-                  end={period?.end}
-                  utc={location.query.utc === 'true'}
-                  relative={period?.statsPeriod}
-                  relativeOptions={props => {
-                    return {
-                      ...props.arbitraryOptions,
-                      // Always display arbitrary issue open period
-                      ...(defaultStatsPeriod?.statsPeriod
-                        ? {
-                            [defaultStatsPeriod.statsPeriod]: t(
-                              '%s (since first seen)',
-                              getRelativeSummary(defaultStatsPeriod.statsPeriod)
-                            ),
-                          }
-                        : {}),
-                      ...props.defaultOptions,
-                    };
-                  }}
-                  onChange={({relative, start, end, utc}) => {
-                    navigate({
-                      ...location,
-                      query: {
-                        ...location.query,
-                        // If selecting the issue open period, remove the stats period query param
-                        statsPeriod:
-                          relative === defaultStatsPeriod?.statsPeriod
-                            ? undefined
-                            : relative,
-                        start: start ? getUtcDateString(start) : undefined,
-                        end: end ? getUtcDateString(end) : undefined,
-                        utc: utc ? 'true' : undefined,
-                      },
-                    });
-                  }}
-                  triggerLabel={
-                    period === defaultStatsPeriod && !defaultStatsPeriod.isMaxRetention
-                      ? t('Since First Seen')
-                      : undefined
-                  }
-                  triggerProps={{
-                    borderless: true,
-                  }}
-                />
-                <SearchFilter
+                <PageFilterBar condensed>
+                  <EnvironmentSelector group={group} event={event} project={project} />
+                  <TimeRangeSelector
+                    menuTitle={t('Filter Time Range')}
+                    start={period?.start}
+                    end={period?.end}
+                    utc={location.query.utc === 'true'}
+                    relative={period?.statsPeriod}
+                    relativeOptions={props => {
+                      return {
+                        ...props.arbitraryOptions,
+                        // Always display arbitrary issue open period
+                        ...(defaultStatsPeriod?.statsPeriod
+                          ? {
+                              [defaultStatsPeriod.statsPeriod]: t(
+                                '%s (since first seen)',
+                                getRelativeSummary(defaultStatsPeriod.statsPeriod)
+                              ),
+                            }
+                          : {}),
+                        ...props.defaultOptions,
+                      };
+                    }}
+                    onChange={({relative, start, end, utc}) => {
+                      navigate({
+                        ...location,
+                        query: {
+                          ...location.query,
+                          // If selecting the issue open period, remove the stats period query param
+                          statsPeriod:
+                            relative === defaultStatsPeriod?.statsPeriod
+                              ? undefined
+                              : relative,
+                          start: start ? getUtcDateString(start) : undefined,
+                          end: end ? getUtcDateString(end) : undefined,
+                          utc: utc ? 'true' : undefined,
+                        },
+                      });
+                    }}
+                    triggerLabel={
+                      period === defaultStatsPeriod && !defaultStatsPeriod.isMaxRetention
+                        ? t('Since First Seen')
+                        : undefined
+                    }
+                  />
+                </PageFilterBar>
+                <EventSearch
                   group={group}
                   handleSearch={query => {
                     navigate(
@@ -178,7 +179,7 @@ export function EventDetailsHeader({group, event, project}: EventDetailsHeaderPr
                 />
               </FilterContainer>
               <ToggleSidebar />
-            </FilterSection>
+            </Flex>
           </TourElement>
         )}
         {issueTypeConfig.header.graph.enabled && (
@@ -213,40 +214,16 @@ export function EventDetailsHeader({group, event, project}: EventDetailsHeaderPr
 }
 
 function EnvironmentSelector({group, event, project}: EventDetailsHeaderProps) {
-  const theme = useTheme();
   const issueTypeConfig = getConfigForIssueType(group, project);
   const isFixedEnvironment = issueTypeConfig.header.filterBar.fixedEnvironment;
   const eventEnvironment = event?.tags?.find(tag => tag.key === 'environment')?.value;
 
-  const environmentCss = css`
-    display: block;
-    &:before {
-      right: 0;
-      top: ${theme.space.md};
-      bottom: ${theme.space.md};
-      width: 1px;
-      content: '';
-      position: absolute;
-      background: ${theme.translucentInnerBorder};
-    }
-  `;
-
   return isFixedEnvironment ? (
-    <Button
-      disabled
-      borderless
-      title={t('This issue only occurs in a single environment')}
-      css={environmentCss}
-    >
+    <Button disabled title={t('This issue only occurs in a single environment')}>
       {eventEnvironment ?? t('All Envs')}
     </Button>
   ) : (
-    <EnvironmentPageFilter
-      css={environmentCss}
-      triggerProps={{
-        borderless: true,
-      }}
-    />
+    <EnvironmentPageFilter />
   );
 }
 
@@ -266,38 +243,13 @@ const DetailsContainer = styled('div')<{
     border-right: 1px solid ${p => p.theme.translucentBorder};
   }
 `;
-const FilterSection = styled('div')`
-  display: flex;
-  gap: ${p => p.theme.space.xs};
-`;
 
 const FilterContainer = styled('div')`
   display: grid;
-  grid-template-columns: auto auto minmax(100px, 1fr) auto;
-  grid-template-rows: minmax(38px, auto);
-  width: 100%;
-  background: ${p => p.theme.background};
-  border-radius: ${p => p.theme.borderRadius};
-  border: 1px solid ${p => p.theme.translucentBorder};
-`;
-
-const SearchFilter = styled(EventSearch)`
-  display: block;
-  border-color: transparent;
-  box-shadow: none;
-`;
-
-const DateFilter = styled(TimeRangeSelector)`
-  display: block;
-  &:before {
-    right: 0;
-    top: ${p => p.theme.space.md};
-    bottom: ${p => p.theme.space.md};
-    width: 1px;
-    content: '';
-    position: absolute;
-    background: ${p => p.theme.translucentInnerBorder};
-  }
+  flex: 1;
+  gap: ${p => p.theme.space.sm};
+  grid-template-columns: auto minmax(100px, 1fr) auto;
+  grid-template-rows: ${p => `minmax(${p.theme.form.md.height}, auto)`};
 `;
 
 const GraphSection = styled('div')`

--- a/static/app/views/issueDetails/streamline/sidebar/toggleSidebar.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/toggleSidebar.tsx
@@ -9,13 +9,13 @@ import {withChonk} from 'sentry/utils/theme/withChonk';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useIssueDetails} from 'sentry/views/issueDetails/streamline/context';
 
-export function ToggleSidebar({size = 'lg'}: {size?: 'lg' | 'sm'}) {
+export function ToggleSidebar({size = 'md'}: {size?: 'md' | 'sm'}) {
   const organization = useOrganization();
   const {isSidebarOpen, dispatch} = useIssueDetails();
   const direction = isSidebarOpen ? 'right' : 'left';
   const theme = useTheme();
 
-  const props = {style: {height: size === 'lg' ? '40px' : '26px'}};
+  const props = size === 'md' ? undefined : {style: {height: '26px'}};
 
   return (
     <ToggleContainer sidebarOpen={isSidebarOpen ?? true}>


### PR DESCRIPTION
This PR uses the `PageFilterBar` for Environment and Date Filter in issue details. It affects both old UI and UI2.

|-       | UI1 light | UI1 dark | UI2 light | UI2 dark |
|--------|-----------|----------|-----------|--------|
| before | <img width="1399" height="406" alt="Screenshot 2025-08-04 at 15 49 50" src="https://github.com/user-attachments/assets/8db91f2f-0137-489e-b11a-6587d4b9333c" />      | <img width="1399" height="406" alt="Screenshot 2025-08-04 at 15 49 45" src="https://github.com/user-attachments/assets/9acf9c92-6209-41f8-9e6f-38dc2bbf96d1" />     | <img width="1399" height="406" alt="Screenshot 2025-08-04 at 15 49 39" src="https://github.com/user-attachments/assets/e98d9f8d-fa14-48b2-8266-eee88132fa0c" />      | <img width="1399" height="406" alt="Screenshot 2025-08-04 at 15 49 43" src="https://github.com/user-attachments/assets/71be8e92-7239-4a3d-96eb-687875131275" /> |
| after  | <img width="1399" height="406" alt="Screenshot 2025-08-04 at 15 49 21" src="https://github.com/user-attachments/assets/46d06493-671b-4bfd-a087-24f3a1f9e428" />      | <img width="1399" height="406" alt="Screenshot 2025-08-04 at 15 49 15" src="https://github.com/user-attachments/assets/99128247-5f4d-4416-8d0d-b06db765f4a8" /> | <img width="1399" height="406" alt="Screenshot 2025-08-04 at 15 49 26" src="https://github.com/user-attachments/assets/b42cabba-1d81-4714-bdee-f96f70c46868" />      | <img width="1399" height="406" alt="Screenshot 2025-08-04 at 15 49 10" src="https://github.com/user-attachments/assets/f80c40dd-9ece-4868-8bc7-d944944c7adc" /> | 

Additionally, there is one case where a `Button` was used instead of a `CompactSelect` for the Env filtering; this didn’t work well for `PageFilterBar`, so I replaced it with a disabled `EnvironmentPageFilter` with a static label + tooltip:

|-       | UI1 light | UI1 dark | UI2 light | UI2 dark |
|--------|-----------|----------|-----------|--------|
| before | <img width="1455" height="406" alt="Screenshot 2025-08-04 at 15 51 03" src="https://github.com/user-attachments/assets/71a5f7f9-489e-4c17-b4eb-3e734e16435e" /> | <img width="1455" height="406" alt="Screenshot 2025-08-04 at 15 51 42" src="https://github.com/user-attachments/assets/79c886af-841d-42ae-ad74-cc655ba99859" /> | <img width="1455" height="406" alt="Screenshot 2025-08-04 at 15 51 06" src="https://github.com/user-attachments/assets/aa39126e-f405-4f58-8023-b362d64d8754" /> | <img width="1455" height="406" alt="Screenshot 2025-08-04 at 15 51 09" src="https://github.com/user-attachments/assets/18d29456-ea87-41a7-a7ab-a28b362d7f8b" /> |
| after | <img width="1455" height="406" alt="Screenshot 2025-08-04 at 15 52 54" src="https://github.com/user-attachments/assets/85b293aa-578b-4591-b1ef-239e712e078e" /> | <img width="1455" height="406" alt="Screenshot 2025-08-04 at 15 52 32" src="https://github.com/user-attachments/assets/1453445f-f6ac-42ca-b776-042a8c3dd2a6" /> | <img width="1455" height="406" alt="Screenshot 2025-08-04 at 15 52 49" src="https://github.com/user-attachments/assets/5b6aa92b-85f7-4b1a-9300-b979c8a48e20" /> | <img width="1455" height="406" alt="Screenshot 2025-08-04 at 15 52 40" src="https://github.com/user-attachments/assets/dc5225c8-a9a8-409c-a4ae-8553d546f8d3" /> | 

