### PR TITLE
fix(stories): responsive layout

### DIFF
--- a/static/app/stories/demo.tsx
+++ b/static/app/stories/demo.tsx
@@ -19,6 +19,7 @@ export const Demo = styled((props: React.HTMLAttributes<HTMLDivElement>) => (
   padding: 64px 16px;
   min-height: 160px;
   max-height: 512px;
+  overflow: auto;
   border-radius: ${p => p.theme.borderRadius} ${p => p.theme.borderRadius} 0 0;
   box-shadow: inset 0 0 0 1px ${p => p.theme.tokens.background.tertiary};
 `;

--- a/static/app/stories/view/storyExports.tsx
+++ b/static/app/stories/view/storyExports.tsx
@@ -14,7 +14,10 @@ import {StoryFooter} from './storyFooter';
 import {storyMdxComponents} from './storyMdxComponent';
 import {StoryResources} from './storyResources';
 import {StorySourceLinks} from './storySourceLinks';
-import {StoryTableOfContents} from './storyTableOfContents';
+import {
+  StoryTableOfContents,
+  StoryTableOfContentsPlaceholder,
+} from './storyTableOfContents';
 import {
   isMDXStory,
   type MDXStoryDescriptor,
@@ -87,6 +90,7 @@ function MDXStoryTitle(props: {story: MDXStoryDescriptor}) {
 
           <StoryTabList />
         </StoryContainer>
+        <StoryTableOfContentsPlaceholder />
       </StoryGrid>
     </StoryHeader>
   );
@@ -217,17 +221,27 @@ const StoryHeader = styled('header')`
 `;
 
 function StoryGrid(props: React.ComponentProps<typeof Grid>) {
-  return <Grid {...props} columns={'1fr minmax(auto, 360px)'} height="100%" />;
+  return (
+    <Grid
+      {...props}
+      columns={{xs: 'minmax(0, 1fr) auto', md: 'minmax(580px, 1fr) minmax(0, 256px)'}}
+      height="100%"
+    />
+  );
 }
 
 const StoryContainer = styled('div')`
-  max-width: 820px;
-  width: calc(-32px + 100vw);
-  margin-inline: auto;
+  max-width: 580px;
+  width: 100%;
   display: flex;
   flex-direction: column;
   gap: ${space(4)};
   padding-inline: ${space(2)};
+
+  @media (min-width: ${p => p.theme.breakpoints.md}) {
+    max-width: 832px;
+    margin-inline: auto;
+  }
 `;
 
 const StoryContent = styled('main')`

--- a/static/app/stories/view/storyTableOfContents.tsx
+++ b/static/app/stories/view/storyTableOfContents.tsx
@@ -179,6 +179,10 @@ export function StoryTableOfContents() {
   );
 }
 
+export function StoryTableOfContentsPlaceholder() {
+  return <StoryIndexContainer aria-hidden="true" />;
+}
+
 function StoryContentsList({
   entry,
   activeId,


### PR DESCRIPTION
Improves the responsive behavior of the `/stories` layout.

**Before**

https://github.com/user-attachments/assets/4da14993-118a-4290-b37f-49dd18f5478c


**After**

https://github.com/user-attachments/assets/adb568b8-d1fb-4cf8-af61-304965285586

