### PR TITLE
fix(preprod): update to latest type schema

### DIFF
--- a/static/app/views/preprod/main/appSizeTreemap.tsx
+++ b/static/app/views/preprod/main/appSizeTreemap.tsx
@@ -68,15 +68,15 @@ export function AppSizeTreemap(props: AppSizeTreemapProps) {
   };
 
   function convertToEChartsData(element: TreemapElement): any {
-    const color = element.element_type
-      ? TYPE_COLORS[element.element_type]
+    const color = element.type
+      ? TYPE_COLORS[element.type]
       : TYPE_COLORS[TreemapType.OTHER];
 
     const data: any = {
       name: element.name,
       value: element.size,
       path: element.path,
-      category: element.element_type,
+      category: element.type,
       itemStyle: {
         color: 'transparent',
         borderColor: color,

--- a/static/app/views/preprod/types/appSizeTypes.ts
+++ b/static/app/views/preprod/types/appSizeTypes.ts
@@ -13,11 +13,10 @@ export interface TreemapResults {
 
 export interface TreemapElement {
   children: TreemapElement[];
-  details: Record<string, unknown>;
-  element_type: TreemapType;
-  is_directory: boolean;
+  is_dir: boolean;
   name: string;
   size: number;
+  type: TreemapType;
   path?: string;
 }
 


### PR DESCRIPTION
Updates to the latest schema used in launchpad. We did some work recently to remove fields no longer needed + shorten key names to reduce the file size at rest, although we will probably still store the file compressed at some point.
