### PR TITLE
feat(replay): Use IconRuler for replay screen-size info

### DIFF
--- a/static/app/views/replays/detail/replayViewScale.tsx
+++ b/static/app/views/replays/detail/replayViewScale.tsx
@@ -2,7 +2,7 @@ import {Tooltip} from 'sentry/components/core/tooltip';
 import Placeholder from 'sentry/components/placeholder';
 import CountTooltipContent from 'sentry/components/replays/countTooltipContent';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
-import {IconWindow} from 'sentry/icons/iconWindow';
+import {IconRuler} from 'sentry/icons/iconRuler';
 import {t} from 'sentry/locale';
 import toPercent from 'sentry/utils/number/toPercent';
 import {useReplayPlayerSize} from 'sentry/utils/replays/playback/providers/replayPlayerSizeContext';
@@ -33,7 +33,7 @@ export default function ReplayViewScale({isLoading}: Props) {
         </CountTooltipContent>
       }
     >
-      <IconWindow size="md" />
+      <IconRuler size="md" />
     </Tooltip>
   );
 }


### PR DESCRIPTION
**Before**
<img width="225" height="78" alt="SCR-20250804-iioe" src="https://github.com/user-attachments/assets/c89a27cb-4c47-4a59-bfd3-8a5d394a8020" />


**After**
<img width="222" height="98" alt="SCR-20250804-ilbg" src="https://github.com/user-attachments/assets/7c1df68d-1640-494e-bb7f-51cd0f2906ec" />

<img width="311" height="128" alt="SCR-20250804-ikxp" src="https://github.com/user-attachments/assets/c122c537-b990-40e1-8fbd-769b334ddf44" />
