### PR TITLE
chore(assignment): log projects being rate limited

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import random
 import uuid
 from collections.abc import MutableMapping, Sequence
 from datetime import datetime
@@ -236,6 +237,15 @@ def handle_owner_assignment(job):
         group_id=group.id,
         organization_id=event.project.organization_id,
     ):
+        if random.random() < 0.01:
+            logger.warning(
+                "handle_owner_assignment.ratelimited",
+                extra={
+                    "organization_id": event.project.organization_id,
+                    "project_id": project.id,
+                    "group_id": group.id,
+                },
+            )
         metrics.incr("sentry.task.post_process.handle_owner_assignment.ratelimited")
         return
 


### PR DESCRIPTION
we do not currently have a way to identify projects which are getting their ownership rule evaluations rate limited. adds a 1% log when this happens.