### PR TITLE
fix(aci): Don't propagate traces to process_workflows_event

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -964,14 +964,17 @@ def process_workflow_engine(job: PostProcessJob) -> None:
         return
 
     try:
-        process_workflows_event.delay(
-            project_id=job["event"].project_id,
-            event_id=job["event"].event_id,
-            occurrence_id=job["event"].occurrence_id,
-            group_id=job["event"].group_id,
-            group_state=job["group_state"],
-            has_reappeared=job["has_reappeared"],
-            has_escalated=job["has_escalated"],
+        process_workflows_event.apply_async(
+            kwargs=dict(
+                project_id=job["event"].project_id,
+                event_id=job["event"].event_id,
+                occurrence_id=job["event"].occurrence_id,
+                group_id=job["event"].group_id,
+                group_state=job["group_state"],
+                has_reappeared=job["has_reappeared"],
+                has_escalated=job["has_escalated"],
+            ),
+            headers={"sentry-propagate-traces": False},
         )
     except Exception:
         logger.exception("Could not process workflow task", extra={"job": job})

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -640,7 +640,7 @@ class ServiceHooksTestMixin(BasePostProgressGroupMixin):
         assert mock_processor.call_count == 0
 
         # Call the function inside process_workflow_engine
-        assert mock_process_event.delay.call_count == 1
+        assert mock_process_event.apply_async.call_count == 1
 
     @with_feature("organizations:workflow-engine-single-process-workflows")
     @override_options({"workflow_engine.issue_alert.group.type_id.rollout": [1]})
@@ -669,7 +669,7 @@ class ServiceHooksTestMixin(BasePostProgressGroupMixin):
         assert mock_processor.call_count == 0
 
         # Don't process workflows for ignored issue
-        assert mock_process_event.delay.call_count == 0
+        assert mock_process_event.apply_async.call_count == 0
 
 
 class ResourceChangeBoundsTestMixin(BasePostProgressGroupMixin):

--- a/tests/sentry/workflow_engine/test_integration.py
+++ b/tests/sentry/workflow_engine/test_integration.py
@@ -153,7 +153,7 @@ class TestWorkflowEngineIntegrationFromIssuePlatform(BaseWorkflowIntegrationTest
         self.create_event(self.project.id, datetime.utcnow(), str(self.detector.id))
 
         with mock.patch(
-            "sentry.workflow_engine.tasks.workflows.process_workflows_event.delay"
+            "sentry.workflow_engine.tasks.workflows.process_workflows_event.apply_async"
         ) as mock_process_workflow:
             self.call_post_process_group(self.group.id)
             mock_process_workflow.assert_called_once()
@@ -177,7 +177,7 @@ class TestWorkflowEngineIntegrationFromIssuePlatform(BaseWorkflowIntegrationTest
         self.group = Group.objects.get(grouphash__hash=self.occurrence.fingerprint[0])
 
         with mock.patch(
-            "sentry.workflow_engine.tasks.workflows.process_workflows_event.delay"
+            "sentry.workflow_engine.tasks.workflows.process_workflows_event.apply_async"
         ) as mock_process_workflow:
             self.call_post_process_group(error_event.group_id)
 
@@ -190,7 +190,7 @@ class TestWorkflowEngineIntegrationFromIssuePlatform(BaseWorkflowIntegrationTest
         assert self.group
 
         with mock.patch(
-            "sentry.workflow_engine.tasks.workflows.process_workflows_event.delay"
+            "sentry.workflow_engine.tasks.workflows.process_workflows_event.apply_async"
         ) as mock_process_workflow:
             self.call_post_process_group(self.group.id)
 


### PR DESCRIPTION
Recent attempts to view traces on Sentry have been timing out, and the few that don't show a history that we don't particularly care about.
It's not clear there's any value here at the moment in being able to trace back to post_process and before, so better to keep our trace nice and compact.