### PR TITLE
ref(aci): Remove 'retry_timeouts' decorator

### DIFF
--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -51,7 +51,6 @@ from sentry.utils.email import MessageBuilder
 from sentry.utils.outcomes import Outcome
 from sentry.utils.query import RangeQuerySetWrapper
 from sentry.utils.snuba import parse_snuba_datetime
-from sentry.workflow_engine.tasks.utils import retry_timeouts
 
 date_format = partial(dateformat.format, format_string="F jS, Y")
 
@@ -71,8 +70,7 @@ logger = logging.getLogger(__name__)
         processing_deadline_duration=timedelta(minutes=15),
     ),
 )
-@retry_timeouts
-@retry
+@retry(timeouts=True)
 def schedule_organizations(
     dry_run: bool = False, timestamp: float | None = None, duration: int | None = None
 ) -> None:

--- a/src/sentry/workflow_engine/tasks/workflows.py
+++ b/src/sentry/workflow_engine/tasks/workflows.py
@@ -11,7 +11,7 @@ from sentry.taskworker.retry import Retry, retry_task
 from sentry.utils import metrics
 from sentry.workflow_engine.models import Detector
 from sentry.workflow_engine.processors.workflow import process_workflows
-from sentry.workflow_engine.tasks.utils import build_workflow_event_data_from_event, retry_timeouts
+from sentry.workflow_engine.tasks.utils import build_workflow_event_data_from_event
 from sentry.workflow_engine.types import WorkflowEventData
 from sentry.workflow_engine.utils import log_context
 
@@ -91,8 +91,7 @@ def process_workflow_activity(activity_id: int, group_id: int, detector_id: int)
         ),
     ),
 )
-@retry_timeouts
-@retry
+@retry(timeouts=True)
 def process_workflows_event(
     project_id: int,
     event_id: str,


### PR DESCRIPTION
We can now just use the standard `retry` decorator.
