### PR TITLE
fix(access-logs): use `quota_allowance` instead of `stats` from snuba response

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -1258,12 +1258,13 @@ def _bulk_snuba_query(snuba_requests: Sequence[SnubaRequest]) -> ResultSet:
                     if response.status == 429:
                         if options.get("issues.use-snuba-error-data"):
                             try:
-                                if "stats" not in error:
-                                    # Should not hit this - snuba always returns stats when there is an error
+                                if (
+                                    "quota_allowance" not in error
+                                    or "summary" not in error["quota_allowance"]
+                                ):
+                                    # Should not hit this - snuba gives us quota_allowance with a 429
                                     raise RateLimitExceeded(error["message"])
-                                quota_allowance_summary = error["stats"]["quota_allowance"][
-                                    "details"
-                                ]["summary"]
+                                quota_allowance_summary = error["quota_allowance"]["summary"]
                                 rejected_by = quota_allowance_summary["rejected_by"]
                                 throttled_by = quota_allowance_summary["throttled_by"]
 

--- a/tests/sentry/utils/test_snuba.py
+++ b/tests/sentry/utils/test_snuba.py
@@ -487,20 +487,16 @@ class SnubaQueryRateLimitTest(TestCase):
             {
                 "error": {
                     "message": "Query on could not be run due to allocation policies, info: ...",
-                    "stats": {
-                        "quota_allowance": {
-                            "details": {
-                                "summary": {
-                                    "rejected_by": {
-                                        "policy": "ConcurrentRateLimitAllocationPolicy",
-                                        "quota_used": 1000,
-                                        "rejection_threshold": 100,
-                                        "quota_unit": "no_units",
-                                        "storage_key": "test_storage_key",
-                                    },
-                                    "throttled_by": {},
-                                }
-                            }
+                    "quota_allowance": {
+                        "summary": {
+                            "rejected_by": {
+                                "policy": "ConcurrentRateLimitAllocationPolicy",
+                                "quota_used": 1000,
+                                "rejection_threshold": 100,
+                                "quota_unit": "no_units",
+                                "storage_key": "test_storage_key",
+                            },
+                            "throttled_by": {},
                         }
                     },
                 }
@@ -559,7 +555,7 @@ class SnubaQueryRateLimitTest(TestCase):
             {
                 "error": {
                     "message": "Query on could not be run due to allocation policies, info: ...",
-                    "stats": {"quota_allowance": {"details": {"summary": {}}}},
+                    "quota_allowance": {"summary": {}},
                 }
             }
         ).encode()


### PR DESCRIPTION
Fix a mistake from https://github.com/getsentry/sentry/pull/96151 — we should rely on `quota_allowance` rather than `stats`, since all 429 errors from snuba come from allocation policies that will (soon) populate `quota_allowance` with the quota details we want to log. Motivation is from [this sentry error ](https://sentry.sentry.io/issues/6788843275/?project=1&referrer=github-pr-bot) where we saw that a 429 response was missing stats, so we can't rely on it to have the quota information.