### PR TITLE
feat: Add new hook for fetching repo token list + pagination to repo token table

### DIFF
--- a/static/app/components/codecov/branchSelector/useInfiniteRepositoryBranches.tsx
+++ b/static/app/components/codecov/branchSelector/useInfiniteRepositoryBranches.tsx
@@ -70,12 +70,12 @@ export function useInfiniteRepositoryBranches({term}: Props) {
 
       return result as ApiResult<RepositoryBranches>;
     },
-    getNextPageParam: ([lastPage]) => {
-      return lastPage.pageInfo?.hasNextPage ? lastPage.pageInfo.endCursor : undefined;
+    getNextPageParam: ([pageData]) => {
+      return pageData.pageInfo?.hasNextPage ? pageData.pageInfo.endCursor : undefined;
     },
-    getPreviousPageParam: ([firstPage]) => {
-      return firstPage.pageInfo?.hasPreviousPage
-        ? firstPage.pageInfo.startCursor
+    getPreviousPageParam: ([pageData]) => {
+      return pageData.pageInfo?.hasPreviousPage
+        ? pageData.pageInfo.startCursor
         : undefined;
     },
     initialPageParam: undefined,

--- a/static/app/components/codecov/repoSelector/useInfiniteRepositories.tsx
+++ b/static/app/components/codecov/repoSelector/useInfiniteRepositories.tsx
@@ -72,12 +72,12 @@ export function useInfiniteRepositories({term}: Props) {
 
       return result as ApiResult<Repositories>;
     },
-    getNextPageParam: ([lastPage]) => {
-      return lastPage.pageInfo?.hasNextPage ? lastPage.pageInfo.endCursor : undefined;
+    getNextPageParam: ([pageData]) => {
+      return pageData.pageInfo?.hasNextPage ? pageData.pageInfo.endCursor : undefined;
     },
-    getPreviousPageParam: ([firstPage]) => {
-      return firstPage.pageInfo?.hasPreviousPage
-        ? firstPage.pageInfo.startCursor
+    getPreviousPageParam: ([pageData]) => {
+      return pageData.pageInfo?.hasPreviousPage
+        ? pageData.pageInfo.startCursor
         : undefined;
     },
     initialPageParam: undefined,

--- a/static/app/views/codecov/tests/queries/useGetTestResults.ts
+++ b/static/app/views/codecov/tests/queries/useGetTestResults.ts
@@ -144,12 +144,12 @@ export function useInfiniteTestResults({
 
       return result as ApiResult<TestResults>;
     },
-    getNextPageParam: ([lastPage]) => {
-      return lastPage.pageInfo?.hasNextPage ? lastPage.pageInfo.endCursor : undefined;
+    getNextPageParam: ([pageData]) => {
+      return pageData.pageInfo?.hasNextPage ? pageData.pageInfo.endCursor : undefined;
     },
-    getPreviousPageParam: ([firstPage]) => {
-      return firstPage.pageInfo?.hasPreviousPage
-        ? firstPage.pageInfo.startCursor
+    getPreviousPageParam: ([pageData]) => {
+      return pageData.pageInfo?.hasPreviousPage
+        ? pageData.pageInfo.startCursor
         : undefined;
     },
     initialPageParam: null,

--- a/static/app/views/codecov/tokens/repoTokenTable/hooks/useInfiniteRepositoryTokens.spec.tsx
+++ b/static/app/views/codecov/tokens/repoTokenTable/hooks/useInfiniteRepositoryTokens.spec.tsx
@@ -1,0 +1,265 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {makeTestQueryClient} from 'sentry-test/queryClient';
+import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {CodecovContext} from 'sentry/components/codecov/context/codecovContext';
+import {QueryClientProvider} from 'sentry/utils/queryClient';
+import {OrganizationContext} from 'sentry/views/organizationContext';
+
+import {useInfiniteRepositoryTokens} from './useInfiniteRepositoryTokens';
+
+const mockRepositoryTokensResponse = {
+  pageInfo: {
+    endCursor: 'cursor123',
+    hasNextPage: true,
+    hasPreviousPage: false,
+    startCursor: 'cursor000',
+  },
+  results: [
+    {
+      name: 'test-repo-one',
+      token: 'sk_test_token_12345abcdef',
+    },
+    {
+      name: 'test-repo-two',
+      token: 'sk_test_token_67890ghijkl',
+    },
+  ],
+  totalCount: 25,
+};
+
+const emptyRepositoryTokensResponse = {
+  pageInfo: {
+    endCursor: null,
+    hasNextPage: false,
+    hasPreviousPage: false,
+    startCursor: null,
+  },
+  results: [],
+  totalCount: 0,
+};
+
+const codecovContextValue = {
+  integratedOrgId: 'org123',
+  repository: 'test-repo',
+  branch: 'main',
+  codecovPeriod: '30d',
+  changeContextValue: jest.fn(),
+};
+
+describe('useInfiniteRepositoryTokens', () => {
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('fetches repository tokens with no params and returns successful response', async () => {
+    const organization = OrganizationFixture({slug: 'test-org'});
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/prevent/owner/${codecovContextValue.integratedOrgId}/repositories/tokens/`,
+      body: mockRepositoryTokensResponse,
+    });
+
+    const wrapper = ({children}: {children: React.ReactNode}) => (
+      <QueryClientProvider client={makeTestQueryClient()}>
+        <OrganizationContext value={organization}>
+          <CodecovContext.Provider value={codecovContextValue}>
+            {children}
+          </CodecovContext.Provider>
+        </OrganizationContext>
+      </QueryClientProvider>
+    );
+
+    const {result} = renderHook(
+      () =>
+        useInfiniteRepositoryTokens({
+          cursor: undefined,
+          navigation: undefined,
+        }),
+      {
+        wrapper,
+      }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toHaveLength(2);
+    expect(result.current.totalCount).toBe(25);
+    expect(result.current.startCursor).toBe('cursor000');
+    expect(result.current.endCursor).toBe('cursor123');
+
+    // Verifies that the data is transformed correctly
+    expect(result.current.data[0]).toEqual({
+      name: 'test-repo-one',
+      token: 'sk_test_token_12345abcdef',
+    });
+    expect(result.current.data[1]).toEqual({
+      name: 'test-repo-two',
+      token: 'sk_test_token_67890ghijkl',
+    });
+  });
+
+  it('fetches repository tokens with navigation and cursor props', async () => {
+    const organization = OrganizationFixture({slug: 'test-org'});
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/prevent/owner/${codecovContextValue.integratedOrgId}/repositories/tokens/`,
+      body: mockRepositoryTokensResponse,
+      match: [
+        MockApiClient.matchQuery({
+          cursor: 'next-cursor',
+          navigation: 'next',
+        }),
+      ],
+    });
+
+    const wrapper = ({children}: {children: React.ReactNode}) => (
+      <QueryClientProvider client={makeTestQueryClient()}>
+        <OrganizationContext value={organization}>
+          <CodecovContext.Provider value={codecovContextValue}>
+            {children}
+          </CodecovContext.Provider>
+        </OrganizationContext>
+      </QueryClientProvider>
+    );
+
+    const {result} = renderHook(
+      () =>
+        useInfiniteRepositoryTokens({
+          cursor: 'next-cursor',
+          navigation: 'next',
+        }),
+      {
+        wrapper,
+      }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toHaveLength(2);
+    expect(result.current.totalCount).toBe(25);
+    expect(result.current.hasNextPage).toBe(true);
+  });
+
+  it('handles empty results response', async () => {
+    const organization = OrganizationFixture({slug: 'test-org'});
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/prevent/owner/${codecovContextValue.integratedOrgId}/repositories/tokens/`,
+      body: emptyRepositoryTokensResponse,
+    });
+
+    const wrapper = ({children}: {children: React.ReactNode}) => (
+      <QueryClientProvider client={makeTestQueryClient()}>
+        <OrganizationContext value={organization}>
+          <CodecovContext.Provider value={codecovContextValue}>
+            {children}
+          </CodecovContext.Provider>
+        </OrganizationContext>
+      </QueryClientProvider>
+    );
+
+    const {result} = renderHook(
+      () =>
+        useInfiniteRepositoryTokens({
+          cursor: undefined,
+          navigation: undefined,
+        }),
+      {
+        wrapper,
+      }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toHaveLength(0);
+    expect(result.current.totalCount).toBe(0);
+    expect(result.current.startCursor).toBeNull();
+    expect(result.current.endCursor).toBeNull();
+    expect(result.current.hasNextPage).toBe(false);
+    expect(result.current.hasPreviousPage).toBe(false);
+  });
+
+  it('handles API errors gracefully', async () => {
+    const organization = OrganizationFixture({slug: 'test-org'});
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/prevent/owner/${codecovContextValue.integratedOrgId}/repositories/tokens/`,
+      statusCode: 500,
+      body: {error: 'Internal Server Error'},
+    });
+
+    const wrapper = ({children}: {children: React.ReactNode}) => (
+      <QueryClientProvider client={makeTestQueryClient()}>
+        <OrganizationContext value={organization}>
+          <CodecovContext.Provider value={codecovContextValue}>
+            {children}
+          </CodecovContext.Provider>
+        </OrganizationContext>
+      </QueryClientProvider>
+    );
+
+    const {result} = renderHook(
+      () =>
+        useInfiniteRepositoryTokens({
+          cursor: undefined,
+          navigation: undefined,
+        }),
+      {
+        wrapper,
+      }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.error).toBeDefined();
+    expect(result.current.data).toHaveLength(0);
+    expect(result.current.totalCount).toBe(0);
+  });
+
+  it('is disabled when integratedOrgId is not provided', () => {
+    const organization = OrganizationFixture({slug: 'test-org'});
+
+    const codecovContextWithoutOrgId = {
+      ...codecovContextValue,
+      integratedOrgId: '',
+    };
+
+    const wrapper = ({children}: {children: React.ReactNode}) => (
+      <QueryClientProvider client={makeTestQueryClient()}>
+        <OrganizationContext value={organization}>
+          <CodecovContext.Provider value={codecovContextWithoutOrgId}>
+            {children}
+          </CodecovContext.Provider>
+        </OrganizationContext>
+      </QueryClientProvider>
+    );
+
+    const {result} = renderHook(
+      () =>
+        useInfiniteRepositoryTokens({
+          cursor: undefined,
+          navigation: undefined,
+        }),
+      {
+        wrapper,
+      }
+    );
+
+    expect(result.current.data).toHaveLength(0);
+    expect(result.current.totalCount).toBe(0);
+  });
+});

--- a/static/app/views/codecov/tokens/repoTokenTable/hooks/useInfiniteRepositoryTokens.tsx
+++ b/static/app/views/codecov/tokens/repoTokenTable/hooks/useInfiniteRepositoryTokens.tsx
@@ -1,0 +1,113 @@
+import {useMemo} from 'react';
+
+import type {ApiResult} from 'sentry/api';
+import {useCodecovContext} from 'sentry/components/codecov/context/codecovContext';
+import {
+  fetchDataQuery,
+  type InfiniteData,
+  type QueryKeyEndpointOptions,
+  useInfiniteQuery,
+} from 'sentry/utils/queryClient';
+import useOrganization from 'sentry/utils/useOrganization';
+
+type RepositoryTokenItem = {
+  name: string;
+  token: string;
+};
+
+interface RepositoryTokens {
+  pageInfo: {
+    endCursor: string;
+    hasNextPage: boolean;
+    hasPreviousPage: boolean;
+    startCursor: string;
+  };
+  results: RepositoryTokenItem[];
+  totalCount: number;
+}
+
+type QueryKey = [url: string, endpointOptions: QueryKeyEndpointOptions];
+
+export function useInfiniteRepositoryTokens({
+  cursor,
+  navigation,
+}: {
+  cursor: string | undefined;
+  navigation: 'next' | 'prev' | undefined;
+}) {
+  const {integratedOrgId} = useCodecovContext();
+  const organization = useOrganization();
+
+  const {data, ...rest} = useInfiniteQuery<
+    ApiResult<RepositoryTokens>,
+    Error,
+    InfiniteData<ApiResult<RepositoryTokens>>,
+    QueryKey
+  >({
+    queryKey: [
+      `/organizations/${organization.slug}/prevent/owner/${integratedOrgId}/repositories/tokens/`,
+      {
+        query: {
+          cursor: cursor ?? undefined,
+          navigation: navigation ?? undefined,
+        },
+      },
+    ],
+    queryFn: async ({
+      queryKey: [url, {query}],
+      client,
+      signal,
+      meta,
+    }): Promise<ApiResult<RepositoryTokens>> => {
+      const result = await fetchDataQuery({
+        queryKey: [
+          url,
+          {
+            query: {
+              ...query,
+              ...(cursor ? {cursor} : {}),
+              ...(navigation ? {navigation} : {}),
+            },
+          },
+        ],
+        client,
+        signal,
+        meta,
+      });
+
+      return result as ApiResult<RepositoryTokens>;
+    },
+    getNextPageParam: ([lastPage]) => {
+      return lastPage.pageInfo?.hasNextPage ? lastPage.pageInfo.endCursor : undefined;
+    },
+    getPreviousPageParam: ([firstPage]) => {
+      return firstPage.pageInfo?.hasPreviousPage
+        ? firstPage.pageInfo.startCursor
+        : undefined;
+    },
+    initialPageParam: undefined,
+    enabled: Boolean(integratedOrgId),
+  });
+
+  const memoizedData = useMemo(
+    () =>
+      data?.pages?.flatMap(([pageData]) =>
+        pageData.results.map(({name, token}) => {
+          return {
+            name,
+            token,
+          };
+        })
+      ) ?? [],
+    [data]
+  );
+
+  return {
+    data: memoizedData,
+    totalCount: data?.pages?.[0]?.[0]?.totalCount ?? 0,
+    startCursor: data?.pages?.[0]?.[0]?.pageInfo?.startCursor,
+    endCursor: data?.pages?.[0]?.[0]?.pageInfo?.endCursor,
+    // TODO: only provide the values that we're interested in
+    ...rest,
+  };
+}

--- a/static/app/views/codecov/tokens/repoTokenTable/hooks/useInfiniteRepositoryTokens.tsx
+++ b/static/app/views/codecov/tokens/repoTokenTable/hooks/useInfiniteRepositoryTokens.tsx
@@ -77,12 +77,12 @@ export function useInfiniteRepositoryTokens({
 
       return result as ApiResult<RepositoryTokens>;
     },
-    getNextPageParam: ([lastPage]) => {
-      return lastPage.pageInfo?.hasNextPage ? lastPage.pageInfo.endCursor : undefined;
+    getNextPageParam: ([pageData]) => {
+      return pageData.pageInfo?.hasNextPage ? pageData.pageInfo.endCursor : undefined;
     },
-    getPreviousPageParam: ([firstPage]) => {
-      return firstPage.pageInfo?.hasPreviousPage
-        ? firstPage.pageInfo.startCursor
+    getPreviousPageParam: ([pageData]) => {
+      return pageData.pageInfo?.hasPreviousPage
+        ? pageData.pageInfo.startCursor
         : undefined;
     },
     initialPageParam: undefined,

--- a/static/app/views/codecov/tokens/repoTokenTable/repoTokenTable.spec.tsx
+++ b/static/app/views/codecov/tokens/repoTokenTable/repoTokenTable.spec.tsx
@@ -1,0 +1,112 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import RepoTokenTable, {DEFAULT_SORT} from './repoTokenTable';
+
+jest.mock('sentry/actionCreators/modal', () => ({
+  openTokenRegenerationConfirmationModal: jest.fn(),
+}));
+
+jest.mock('sentry/components/confirm', () => {
+  return function MockConfirm({children}: {children: React.ReactNode}) {
+    return <div>{children}</div>;
+  };
+});
+
+const mockData = [
+  {
+    name: 'sentry-frontend',
+    token: 'sk_test_token_12345abcdef',
+  },
+  {
+    name: 'sentry-backend',
+    token: 'sk_test_token_67890ghijkl',
+  },
+];
+
+const defaultProps = {
+  response: {
+    data: mockData,
+    isLoading: false,
+    error: null,
+  },
+  sort: DEFAULT_SORT,
+};
+
+describe('RepoTokenTable', () => {
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('renders table with repository tokens data', () => {
+    render(<RepoTokenTable {...defaultProps} />);
+
+    expect(screen.getByLabelText('Repository Tokens Table')).toBeInTheDocument();
+
+    // Check table headers
+    expect(screen.getByText('Repository Name')).toBeInTheDocument();
+    expect(screen.getByText('Token')).toBeInTheDocument();
+
+    // Check table data
+    expect(screen.getByText('sentry-frontend')).toBeInTheDocument();
+    expect(screen.getByText('sentry-backend')).toBeInTheDocument();
+    expect(screen.getByText('sk_test_token_12345abcdef')).toBeInTheDocument();
+    expect(screen.getByText('sk_test_token_67890ghijkl')).toBeInTheDocument();
+
+    // Check regenerate buttons
+    const regenerateButtons = screen.getAllByText('Regenerate token');
+    expect(regenerateButtons).toHaveLength(2);
+  });
+
+  it('renders empty table when no data is provided', () => {
+    const emptyProps = {
+      ...defaultProps,
+      response: {
+        data: [],
+        isLoading: false,
+        error: null,
+      },
+    };
+
+    render(<RepoTokenTable {...emptyProps} />);
+
+    expect(screen.getByLabelText('Repository Tokens Table')).toBeInTheDocument();
+    expect(screen.getByText('Repository Name')).toBeInTheDocument();
+    expect(screen.getByText('Token')).toBeInTheDocument();
+
+    // Should not have any repository data
+    expect(screen.queryByText('sentry-frontend')).not.toBeInTheDocument();
+    expect(screen.queryByText('sentry-backend')).not.toBeInTheDocument();
+  });
+
+  it('renders table with single repository token', () => {
+    const singleDataProps = {
+      ...defaultProps,
+      response: {
+        data: [mockData[0]!],
+        isLoading: false,
+        error: null,
+      },
+    };
+
+    render(<RepoTokenTable {...singleDataProps} />);
+
+    expect(screen.getByText('sentry-frontend')).toBeInTheDocument();
+    expect(screen.getByText('sk_test_token_12345abcdef')).toBeInTheDocument();
+    expect(screen.queryByText('sentry-backend')).not.toBeInTheDocument();
+
+    const regenerateButtons = screen.getAllByText('Regenerate token');
+    expect(regenerateButtons).toHaveLength(1);
+  });
+
+  it('renders regenerate buttons that can be interacted with', () => {
+    render(<RepoTokenTable {...defaultProps} />);
+
+    const regenerateButtons = screen.getAllByText('Regenerate token');
+    expect(regenerateButtons).toHaveLength(2);
+
+    // Check that buttons are clickable
+    regenerateButtons.forEach(button => {
+      expect(button.closest('button')).toBeEnabled();
+    });
+  });
+});

--- a/static/app/views/codecov/tokens/repoTokenTable/repoTokenTable.tsx
+++ b/static/app/views/codecov/tokens/repoTokenTable/repoTokenTable.tsx
@@ -1,20 +1,16 @@
-import GridEditable, {
-  COL_WIDTH_UNDEFINED,
-  type GridColumnHeader,
-} from 'sentry/components/tables/gridEditable';
+import GridEditable, {type GridColumnHeader} from 'sentry/components/tables/gridEditable';
 import {t} from 'sentry/locale';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {renderTableBody} from 'sentry/views/codecov/tokens/repoTokenTable/tableBody';
 import {renderTableHeader} from 'sentry/views/codecov/tokens/repoTokenTable/tableHeader';
 
 type RepoTokenTableResponse = {
-  createdAt: string;
   name: string;
   token: string;
 };
 
-export type Row = Pick<RepoTokenTableResponse, 'name' | 'token' | 'createdAt'>;
-export type Column = GridColumnHeader<'name' | 'token' | 'createdAt' | 'regenerateToken'>;
+export type Row = Pick<RepoTokenTableResponse, 'name' | 'token'>;
+export type Column = GridColumnHeader<'name' | 'token' | 'regenerateToken'>;
 
 type ValidField = (typeof SORTABLE_FIELDS)[number];
 
@@ -27,16 +23,15 @@ export type ValidSort = Sort & {
 };
 
 const COLUMNS_ORDER: Column[] = [
-  {key: 'name', name: t('Repository Name'), width: 350},
-  {key: 'token', name: t('Token'), width: 275},
-  {key: 'createdAt', name: t('Created Date'), width: COL_WIDTH_UNDEFINED},
+  {key: 'name', name: t('Repository Name'), width: 400},
+  {key: 'token', name: t('Token'), width: 350},
   {key: 'regenerateToken', name: '', width: 100},
 ];
 
-export const SORTABLE_FIELDS = ['name', 'createdAt'] as const;
+export const SORTABLE_FIELDS = ['name'] as const;
 
 export const DEFAULT_SORT: ValidSort = {
-  field: 'createdAt',
+  field: 'name',
   kind: 'desc',
 };
 

--- a/static/app/views/codecov/tokens/repoTokenTable/tableBody.tsx
+++ b/static/app/views/codecov/tokens/repoTokenTable/tableBody.tsx
@@ -55,10 +55,6 @@ export function renderTableBody({column, row}: TableBodyProps) {
     return <AlignmentContainer alignment={alignment}>{value}</AlignmentContainer>;
   }
 
-  if (key === 'createdAt') {
-    return <DateContainer>{value}</DateContainer>;
-  }
-
   return <AlignmentContainer alignment={alignment}>{value}</AlignmentContainer>;
 }
 
@@ -68,9 +64,4 @@ const StyledButton = styled(Button)`
 
 export const AlignmentContainer = styled('div')<{alignment: string}>`
   text-align: ${p => (p.alignment === 'left' ? 'left' : 'right')};
-`;
-
-const DateContainer = styled('div')`
-  color: ${p => p.theme.tokens.content.muted};
-  text-align: 'left';
 `;


### PR DESCRIPTION
This PR aims to create the hook for the new repo token list endpoint as well as the pagination stuff for us to swap between pages in the repo token table.

We also remove the createdAt stuff from the token regen table since that doesn't exist on the codecov side. So there are a couple styling updates there to reflect that too.

Follows similar conventions to https://github.com/getsentry/sentry/pull/96228

Depends on https://github.com/getsentry/sentry/pull/97007

Closes https://linear.app/getsentry/issue/CCMRG-1482/hook-up-list-endpoint
Closes https://linear.app/getsentry/issue/CCMRG-1443/drop-column-for-token-creation-date

<img width="1070" height="851" alt="Screenshot 2025-08-04 at 10 58 32 AM" src="https://github.com/user-attachments/assets/1cdac64e-2d6b-4118-aaff-6f61f1380738" />


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
