### PR TITLE
chore(sentry apps): Increase time limit for updating servie hooks

### DIFF
--- a/src/sentry/sentry_apps/tasks/sentry_apps.py
+++ b/src/sentry/sentry_apps/tasks/sentry_apps.py
@@ -810,7 +810,9 @@ def send_webhooks(installation: RpcSentryAppInstallation, event: str, **kwargs: 
 @instrumented_task(
     "sentry.sentry_apps.tasks.sentry_apps.create_or_update_service_hooks_for_sentry_app",
     taskworker_config=TaskworkerConfig(
-        namespace=sentryapp_control_tasks, retry=Retry(times=3), processing_deadline_duration=60
+        namespace=sentryapp_control_tasks,
+        retry=Retry(times=3),
+        processing_deadline_duration=60 * 10,
     ),
     **CONTROL_TASK_OPTIONS,
 )


### PR DESCRIPTION
When doing the ServiceHook backfilling script we're getting 18 orgs with at least 100+ installations reaching the task time out.