### PR TITLE
:wrench: chore(integrations): rewrap unidiff parse errors and log them

### DIFF
--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -335,7 +335,11 @@ class GitlabOpenPRCommentWorkflow(OpenPRCommentWorkflow):
             try:
                 file_modifications = patch_to_file_modifications(diff["diff"])
             except PatchParseError:
-                logger.exception(
+                # TODO: This is caused because of the diffs are not in the correct format.
+                # This happens for Gitlab versions older than 16.5.
+                # The fix for this is to rebuild a consistent format using the other parts of the response.
+                # https://gitlab.com/gitlab-org/gitlab/-/issues/24913#note_1015454661
+                logger.warning(
                     _open_pr_comment_log(
                         integration_name=self.integration.integration_name,
                         suffix="patch_parsing_error",

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -55,7 +55,7 @@ from sentry.users.models.identity import Identity
 from sentry.utils import metrics
 from sentry.utils.hashlib import sha1_text
 from sentry.utils.http import absolute_uri
-from sentry.utils.patch_set import patch_to_file_modifications
+from sentry.utils.patch_set import PatchParseError, patch_to_file_modifications
 from sentry.web.helpers import render_to_response
 
 from .client import GitLabApiClient, GitLabSetupApiClient
@@ -334,12 +334,12 @@ class GitlabOpenPRCommentWorkflow(OpenPRCommentWorkflow):
 
             try:
                 file_modifications = patch_to_file_modifications(diff["diff"])
-            except Exception:
+            except PatchParseError:
                 logger.exception(
                     _open_pr_comment_log(
                         integration_name=self.integration.integration_name,
                         suffix="patch_parsing_error",
-                    ),
+                    )
                 )
                 continue
 

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -342,6 +342,14 @@ class GitlabOpenPRCommentWorkflow(OpenPRCommentWorkflow):
                     )
                 )
                 continue
+            except Exception:
+                logger.exception(
+                    _open_pr_comment_log(
+                        integration_name=self.integration.integration_name,
+                        suffix="unexpected_error",
+                    )
+                )
+                continue
 
             if not file_modifications.modified:
                 continue

--- a/src/sentry/utils/patch_set.py
+++ b/src/sentry/utils/patch_set.py
@@ -4,6 +4,11 @@ from dataclasses import dataclass
 from typing import Literal, TypedDict
 
 import unidiff
+from unidiff.errors import UnidiffParseError
+
+
+class PatchParseError(Exception):
+    pass
 
 
 class FileChange(TypedDict):
@@ -43,7 +48,10 @@ class FileModifications:
 
 
 def patch_to_file_modifications(patch: str) -> FileModifications:
-    patch_set = unidiff.PatchSet.from_string(patch)
+    try:
+        patch_set = unidiff.PatchSet.from_string(patch)
+    except UnidiffParseError:
+        raise PatchParseError("Failed to parse file modifications from patch")
 
     return FileModifications(
         added=_patched_files_to_file_modifications(patch_set.added_files),


### PR DESCRIPTION
we are making a lot of unidiff parser issues. lets re-wrap and log. we have already root caused the problem and we should put up a separate pr for the fix.