### PR TITLE
fix(detectors): Filter "filtered" spans from http overhead detection 

### DIFF
--- a/fixtures/events/performance_problems/http-overhead-filtered-url.json
+++ b/fixtures/events/performance_problems/http-overhead-filtered-url.json
@@ -1,0 +1,36 @@
+{
+  "event_id": "5d6401994d7949d2ac3474f472564370",
+  "platform": "php",
+  "message": "",
+  "datetime": "2025-05-12T22:42:38.642986+00:00",
+  "request": {
+    "url": "http://localhost:3001/test",
+    "method": "GET"
+  },
+  "_meta": {
+    "spans": {
+      "0": {
+        "data": {
+          "url": "http://[Filtered]/test"
+        }
+      }
+    }
+  },
+  "spans": [
+    {
+      "timestamp": 1747089758.637715,
+      "start_timestamp": 1747089758.572,
+      "exclusive_time": 65.715075,
+      "op": "http.client",
+      "span_id": "4703181ac343f71a",
+      "parent_span_id": "91fa92ff0205967d",
+      "trace_id": "375a86eca09a4a4e91903838dd771f50",
+      "status": "ok",
+      "data": {
+        "url": "http://[Filtered]/test",
+        "network.protocol.version": "1.1",
+        "http.request.request_start": 1747089758.572
+      }
+    }
+  ]
+}

--- a/src/sentry/performance_issues/detectors/http_overhead_detector.py
+++ b/src/sentry/performance_issues/detectors/http_overhead_detector.py
@@ -113,6 +113,16 @@ class HTTPOverheadDetector(PerformanceDetector):
 
         if not span_op or not span_op == "http.client" or not protocol_version == "1.1":
             return False
+
+        # Check if any spans have filtered URLs
+        event_spans = self._event.get("spans", [])
+        span_index = str(event_spans.index(span))
+        meta = self._event.get("_meta", {}).get("spans", [])
+        if span_index in meta:
+            has_filtered_url = meta[span_index].get("data", {}).get("url", {})
+            if has_filtered_url:
+                return False
+
         return True
 
     def _store_performance_problem(self, location: str) -> None:

--- a/src/sentry/performance_issues/detectors/http_overhead_detector.py
+++ b/src/sentry/performance_issues/detectors/http_overhead_detector.py
@@ -116,8 +116,8 @@ class HTTPOverheadDetector(PerformanceDetector):
 
         # Check if any spans have filtered URLs
         event_spans = self._event.get("spans", [])
-        span_index = str(event_spans.index(span))
-        meta = self._event.get("_meta", {}).get("spans", [])
+        span_index = str(event_spans.index(span) if span in event_spans else -1)
+        meta = self._event.get("_meta", {}).get("spans", {})
         if span_index in meta:
             has_filtered_url = meta[span_index].get("data", {}).get("url", {})
             if has_filtered_url:

--- a/tests/sentry/performance_issues/test_http_overhead_detector.py
+++ b/tests/sentry/performance_issues/test_http_overhead_detector.py
@@ -15,6 +15,7 @@ from sentry.testutils.cases import TestCase
 from sentry.testutils.performance_issues.event_generators import (
     PROJECT_ID,
     create_span,
+    get_event,
     modify_span_start,
 )
 
@@ -280,3 +281,7 @@ class HTTPOverheadDetectorTest(TestCase):
         event["spans"] = [span]
 
         assert self.find_problems(event) == []
+
+    def test_filtered_url(self) -> None:
+        injection_event = get_event("http-overhead-filtered-url")
+        assert len(self.find_problems(injection_event)) == 0


### PR DESCRIPTION
when we call `urlparse(url)` on a filtered URL, it throws an error. this pr filters out these spans. a couple other detectors also do this, but will confirm it works before moving the logic over