### PR TITLE
fix(sentry apps): Add task to update sh on a per installation basis

### DIFF
--- a/src/sentry/sentry_apps/metrics.py
+++ b/src/sentry/sentry_apps/metrics.py
@@ -135,3 +135,4 @@ class SentryAppEventType(StrEnum):
     REQUESTS = "requests"
     WEBHOOK_UPDATE = "webhook_update"
     INSTALLATION_CREATE = "install_create"
+    INSTALLATION_WEBHOOK_UPDATE = "installation_webhook_update"

--- a/src/sentry/sentry_apps/tasks/__init__.py
+++ b/src/sentry/sentry_apps/tasks/__init__.py
@@ -4,6 +4,7 @@ from .sentry_apps import (
     create_or_update_service_hooks_for_sentry_app,
     installation_webhook,
     process_resource_change_bound,
+    regenerate_service_hooks_for_installation,
     send_alert_webhook,
     send_alert_webhook_v2,
     send_resource_change_webhook,
@@ -22,5 +23,5 @@ __all__ = (
     "process_service_hook",
     "send_alert_webhook",
     "send_alert_webhook_v2",
-    "create_or_update_service_hooks_for_installation",
+    "regenerate_service_hooks_for_installation",
 )

--- a/src/sentry/sentry_apps/tasks/__init__.py
+++ b/src/sentry/sentry_apps/tasks/__init__.py
@@ -22,4 +22,5 @@ __all__ = (
     "process_service_hook",
     "send_alert_webhook",
     "send_alert_webhook_v2",
+    "create_or_update_service_hooks_for_installation",
 )

--- a/src/sentry/sentry_apps/tasks/sentry_apps.py
+++ b/src/sentry/sentry_apps/tasks/sentry_apps.py
@@ -47,6 +47,7 @@ from sentry.sentry_apps.services.app.service import (
     get_installation,
     get_installations_for_organization,
 )
+from sentry.sentry_apps.services.hook.service import hook_service
 from sentry.sentry_apps.utils.errors import SentryAppSentryError
 from sentry.shared_integrations.exceptions import ApiHostError, ApiTimeoutError, ClientError
 from sentry.silo.base import SiloMode
@@ -835,17 +836,29 @@ def create_or_update_service_hooks_for_sentry_app(
 @instrumented_task(
     "sentry.sentry_apps.tasks.sentry_apps.regenerate_service_hooks_for_installation",
     taskworker_config=TaskworkerConfig(
-        namespace=sentryapp_tasks, retry=Retry(times=3), processing_deadline_duration=60
+        namespace=sentryapp_control_tasks, retry=Retry(times=3), processing_deadline_duration=60
     ),
-    **TASK_OPTIONS,
+    **CONTROL_TASK_OPTIONS,
 )
-def regenerate_service_hooks_for_installation(installation_id: int) -> None:
+def regenerate_service_hooks_for_installation(
+    *,
+    installation_id: int,
+    webhook_url: str | None,
+    events: list[str],
+) -> None:
+    """
+    This function creates or updates service hooks for a given Sentry app installation.
+    It first attempts to update the webhook URL and events for existing service hooks.
+    If no hooks are found and a webhook URL is provided, it creates a new service hook.
+    Should only be called in the control silo
+    """
     with SentryAppInteractionEvent(
         operation_type=SentryAppInteractionType.MANAGEMENT,
         event_type=SentryAppEventType.INSTALLATION_WEBHOOK_UPDATE,
     ).capture() as lifecycle:
-        installation = app_service.installation_by_id(id=installation_id)
-        if installation is None:
+        try:
+            installation = SentryAppInstallation.objects.get(id=installation_id)
+        except SentryAppInstallation.DoesNotExist:
             lifecycle.record_failure(
                 SentryAppWebhookFailureReason.MISSING_INSTALLATION,
                 extra={"installation_id": installation_id},
@@ -853,10 +866,25 @@ def regenerate_service_hooks_for_installation(installation_id: int) -> None:
             return
 
         lifecycle.add_extras(
-            {"installation_id": installation_id, "sentry_app": installation.sentry_app.id}
+            {"installation_id": installation.id, "sentry_app": installation.sentry_app.id}
         )
-        create_or_update_service_hooks_for_installation(
-            installation=installation,
-            events=installation.sentry_app.events,
-            webhook_url=installation.sentry_app.webhook_url,
+        hooks = hook_service.update_webhook_and_events(
+            organization_id=installation.organization_id,
+            application_id=installation.sentry_app.application_id,
+            webhook_url=webhook_url,
+            events=events,
         )
+        if webhook_url and not hooks:
+            # Note that because the update transaction is disjoint with this transaction, it is still
+            # possible we redundantly create service hooks in the face of two concurrent requests.
+            # If this proves a problem, we would need to add an additional semantic, "only create if does not exist".
+            # But I think, it should be fine.
+            hook_service.create_service_hook(
+                application_id=installation.sentry_app.application_id,
+                actor_id=installation.id,
+                installation_id=installation.id,
+                organization_id=installation.organization_id,
+                project_ids=[],
+                events=events,
+                url=webhook_url,
+            )

--- a/src/sentry/utils/sentry_apps/service_hook_manager.py
+++ b/src/sentry/utils/sentry_apps/service_hook_manager.py
@@ -1,9 +1,12 @@
 from sentry.sentry_apps.models.sentry_app_installation import SentryAppInstallation
+from sentry.sentry_apps.services.app.model import RpcSentryAppInstallation
 from sentry.sentry_apps.services.hook import hook_service
 
 
 def create_or_update_service_hooks_for_installation(
-    installation: SentryAppInstallation, webhook_url: str | None, events: list[str]
+    installation: SentryAppInstallation | RpcSentryAppInstallation,
+    webhook_url: str | None,
+    events: list[str],
 ) -> None:
     """
     This function creates or updates service hooks for a given Sentry app installation.

--- a/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
+++ b/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
@@ -26,12 +26,14 @@ from sentry.sentry_apps.tasks.sentry_apps import (
     installation_webhook,
     notify_sentry_app,
     process_resource_change_bound,
+    regenerate_service_hooks_for_installation,
     send_alert_webhook_v2,
     send_webhooks,
     workflow_notification,
 )
 from sentry.sentry_apps.utils.errors import SentryAppSentryError
 from sentry.shared_integrations.exceptions import ClientError
+from sentry.silo.base import SiloMode
 from sentry.tasks.post_process import post_process_group
 from sentry.testutils.asserts import (
     assert_count_of_metric,
@@ -44,7 +46,7 @@ from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.helpers.eventprocessing import write_event_to_cache
-from sentry.testutils.silo import assume_test_silo_mode_of, control_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, assume_test_silo_mode_of, control_silo_test
 from sentry.testutils.skips import requires_snuba
 from sentry.types.activity import ActivityType
 from sentry.types.rules import RuleFuture
@@ -1715,3 +1717,53 @@ class TestWebhookRequests(TestCase):
         assert first_request["organization_id"] == self.install.organization_id
         assert first_request["error_id"] == "d5111da2c28645c5889d072017e3445d"
         assert first_request["project_id"] == "1"
+
+
+class TestBackfillServiceHooksEvents(TestCase):
+    def setUp(self) -> None:
+        self.sentry_app = self.create_sentry_app(
+            name="Test App",
+            webhook_url="https://example.com",
+            organization=self.organization,
+            events=["issue.created", "issue.resolved", "error.created"],
+        )
+        self.install = self.create_sentry_app_installation(
+            organization=self.organization, slug=self.sentry_app.slug
+        )
+
+    def test_regenerate_service_hook_for_installation_success(self):
+        with assume_test_silo_mode(SiloMode.REGION):
+            hook = ServiceHook.objects.get(installation_id=self.install.id)
+            hook.events = ["issue.resolved", "error.created"]
+            hook.save()
+
+        with self.tasks(), assume_test_silo_mode(SiloMode.REGION):
+            regenerate_service_hooks_for_installation(installation_id=self.install.id)
+
+        with assume_test_silo_mode(SiloMode.REGION):
+            hook.refresh_from_db()
+            assert set(hook.events) == {"issue.created", "issue.resolved", "error.created"}
+
+    def test_regenerate_service_hook_for_installation_event_not_in_app_events(self):
+        with self.tasks(), assume_test_silo_mode(SiloMode.REGION):
+            regenerate_service_hooks_for_installation(installation_id=self.install.id)
+
+        with assume_test_silo_mode(SiloMode.REGION):
+            hook = ServiceHook.objects.get(installation_id=self.install.id)
+            assert set(hook.events) == {"issue.created", "issue.resolved", "error.created"}
+
+    def test_regenerate_service_hook_for_installation_with_empty_app_events(self):
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.sentry_app.update(events=[])
+            assert self.sentry_app.events == []
+
+        with assume_test_silo_mode(SiloMode.REGION):
+            hook = ServiceHook.objects.get(installation_id=self.install.id)
+            assert hook.events != []
+
+        with self.tasks(), assume_test_silo_mode(SiloMode.REGION):
+            regenerate_service_hooks_for_installation(installation_id=self.install.id)
+
+        with assume_test_silo_mode(SiloMode.REGION):
+            hook.refresh_from_db()
+            assert hook.events == []

--- a/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
+++ b/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
@@ -1737,16 +1737,24 @@ class TestBackfillServiceHooksEvents(TestCase):
             hook.events = ["issue.resolved", "error.created"]
             hook.save()
 
-        with self.tasks(), assume_test_silo_mode(SiloMode.REGION):
-            regenerate_service_hooks_for_installation(installation_id=self.install.id)
+        with self.tasks(), assume_test_silo_mode(SiloMode.CONTROL):
+            regenerate_service_hooks_for_installation(
+                installation_id=self.install.id,
+                webhook_url=self.sentry_app.webhook_url,
+                events=self.sentry_app.events,
+            )
 
         with assume_test_silo_mode(SiloMode.REGION):
             hook.refresh_from_db()
             assert set(hook.events) == {"issue.created", "issue.resolved", "error.created"}
 
     def test_regenerate_service_hook_for_installation_event_not_in_app_events(self):
-        with self.tasks(), assume_test_silo_mode(SiloMode.REGION):
-            regenerate_service_hooks_for_installation(installation_id=self.install.id)
+        with self.tasks(), assume_test_silo_mode(SiloMode.CONTROL):
+            regenerate_service_hooks_for_installation(
+                installation_id=self.install.id,
+                webhook_url=self.sentry_app.webhook_url,
+                events=self.sentry_app.events,
+            )
 
         with assume_test_silo_mode(SiloMode.REGION):
             hook = ServiceHook.objects.get(installation_id=self.install.id)
@@ -1761,8 +1769,12 @@ class TestBackfillServiceHooksEvents(TestCase):
             hook = ServiceHook.objects.get(installation_id=self.install.id)
             assert hook.events != []
 
-        with self.tasks(), assume_test_silo_mode(SiloMode.REGION):
-            regenerate_service_hooks_for_installation(installation_id=self.install.id)
+        with self.tasks(), assume_test_silo_mode(SiloMode.CONTROL):
+            regenerate_service_hooks_for_installation(
+                installation_id=self.install.id,
+                webhook_url=self.sentry_app.webhook_url,
+                events=self.sentry_app.events,
+            )
 
         with assume_test_silo_mode(SiloMode.REGION):
             hook.refresh_from_db()


### PR DESCRIPTION
We had ~18 sentry apps timing out when backfilling servicehooks (SH). These apps had >100 installations to update, so instead of increasing the timeout of the previous task, let's make a task that updates SHs on a per installation basis. Since increasing the task duration of [create_or_update_service_hooks_for_sentry_app](https://github.com/getsentry/sentry/blob/master/src/sentry/sentry_apps/tasks/sentry_apps.py#L817) could be upwards of 3+ hours.