### PR TITLE
feat(prevent): Initial prevent AI onboarding routes + enum update

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -2482,6 +2482,22 @@ function buildRoutes(): RouteObject[] {
       ],
     },
     {
+      path: 'prevent-ai/',
+      children: [
+        // Render prevent AI onboarding with layout wrapper
+        {
+          path: 'new/',
+          component: make(() => import('sentry/views/codecov/preventAI/wrapper')),
+          children: [
+            {
+              index: true,
+              component: make(() => import('sentry/views/codecov/preventAI/onboarding')),
+            },
+          ],
+        },
+      ],
+    },
+    {
       path: 'tokens/',
       children: [
         {

--- a/static/app/views/codecov/pathnames.spec.ts
+++ b/static/app/views/codecov/pathnames.spec.ts
@@ -22,6 +22,16 @@ const testCases: TestCase[] = [
     path: '/test/',
     expected: '/organizations/test-org-slug/codecov/test/',
   },
+  {
+    organization: testOrg,
+    path: '/tokens/',
+    expected: '/organizations/test-org-slug/codecov/tokens/',
+  },
+  {
+    organization: testOrg,
+    path: '/prevent-ai/',
+    expected: '/organizations/test-org-slug/codecov/prevent-ai/',
+  },
 ];
 
 describe('makeCodecovPathname', () => {

--- a/static/app/views/codecov/preventAI/onboarding.tsx
+++ b/static/app/views/codecov/preventAI/onboarding.tsx
@@ -1,0 +1,10 @@
+import {t} from 'sentry/locale';
+
+export default function PreventAIOnboarding() {
+  return (
+    <div>
+      <h1>{t('Prevent AI Onboarding')}</h1>
+      <p>{t('Welcome to Prevent AI! This onboarding page is under construction.')}</p>
+    </div>
+  );
+}

--- a/static/app/views/codecov/preventAI/wrapper.spec.tsx
+++ b/static/app/views/codecov/preventAI/wrapper.spec.tsx
@@ -1,0 +1,21 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import PreventAIPageWrapper from 'sentry/views/codecov/preventAI/wrapper';
+import {PREVENT_AI_PAGE_TITLE} from 'sentry/views/codecov/settings';
+
+const COVERAGE_FEATURE = 'codecov-ui';
+
+describe('PreventAIPageWrapper', () => {
+  describe('when the wrapper is used', () => {
+    it('renders the document title', () => {
+      render(<PreventAIPageWrapper />, {
+        organization: OrganizationFixture({features: [COVERAGE_FEATURE]}),
+      });
+
+      const preventAITitle = screen.getByText(PREVENT_AI_PAGE_TITLE);
+      expect(preventAITitle).toBeInTheDocument();
+    });
+  });
+});

--- a/static/app/views/codecov/preventAI/wrapper.tsx
+++ b/static/app/views/codecov/preventAI/wrapper.tsx
@@ -1,0 +1,42 @@
+import {Outlet} from 'react-router-dom';
+import styled from '@emotion/styled';
+
+import CodecovQueryParamsProvider from 'sentry/components/codecov/container/codecovParamsProvider';
+import {FeatureBadge} from 'sentry/components/core/badge/featureBadge';
+import * as Layout from 'sentry/components/layouts/thirds';
+import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
+import useOrganization from 'sentry/utils/useOrganization';
+import {PREVENT_AI_PAGE_TITLE} from 'sentry/views/codecov/settings';
+
+export default function PreventAIPageWrapper() {
+  const organization = useOrganization();
+
+  return (
+    <SentryDocumentTitle title={PREVENT_AI_PAGE_TITLE} orgSlug={organization.slug}>
+      <Layout.Header unified>
+        <Layout.HeaderContent>
+          <HeaderContentBar>
+            <Layout.Title>
+              {PREVENT_AI_PAGE_TITLE}
+              <FeatureBadge type="beta" />
+            </Layout.Title>
+          </HeaderContentBar>
+        </Layout.HeaderContent>
+      </Layout.Header>
+      <Layout.Body>
+        <CodecovQueryParamsProvider>
+          <Layout.Main fullWidth>
+            <Outlet />
+          </Layout.Main>
+        </CodecovQueryParamsProvider>
+      </Layout.Body>
+    </SentryDocumentTitle>
+  );
+}
+
+const HeaderContentBar = styled('div')`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-direction: row;
+`;

--- a/static/app/views/codecov/settings.tsx
+++ b/static/app/views/codecov/settings.tsx
@@ -11,3 +11,6 @@ export const TESTS_BASE_URL = 'tests';
 
 export const TOKENS_PAGE_TITLE = t('Tokens');
 export const TOKENS_BASE_URL = 'tokens';
+
+export const PREVENT_AI_PAGE_TITLE = t('Prevent AI');
+export const PREVENT_AI_BASE_URL = 'prevent-ai';

--- a/static/app/views/nav/primary/config.tsx
+++ b/static/app/views/nav/primary/config.tsx
@@ -32,7 +32,7 @@ export const PRIMARY_NAV_GROUP_CONFIG: PrimaryNavGroupConfig = {
     basePaths: ['settings'],
     label: t('Settings'),
   },
-  [PrimaryNavGroup.CODECOV]: {
+  [PrimaryNavGroup.PREVENT]: {
     basePaths: ['codecov'],
     label: t('Prevent'),
   },

--- a/static/app/views/nav/primary/index.tsx
+++ b/static/app/views/nav/primary/index.tsx
@@ -128,7 +128,7 @@ export function PrimaryNavigationItems() {
             to={`/${prefix}/${CODECOV_BASE_URL}/${COVERAGE_BASE_URL}/commits/`}
             activeTo={`/${prefix}/${CODECOV_BASE_URL}/`}
             analyticsKey="codecov"
-            group={PrimaryNavGroup.CODECOV}
+            group={PrimaryNavGroup.PREVENT}
           >
             <IconPrevent />
           </SidebarLink>

--- a/static/app/views/nav/secondary/secondaryNavContent.tsx
+++ b/static/app/views/nav/secondary/secondaryNavContent.tsx
@@ -20,7 +20,7 @@ export function SecondaryNavContent({group}: {group: PrimaryNavGroup}): ReactNod
       return <DashboardsSecondaryNav />;
     case PrimaryNavGroup.EXPLORE:
       return <ExploreSecondaryNav />;
-    case PrimaryNavGroup.CODECOV:
+    case PrimaryNavGroup.PREVENT:
       return <CodecovSecondaryNav />;
     case PrimaryNavGroup.SETTINGS:
       return <SettingsSecondaryNav />;

--- a/static/app/views/nav/secondary/sections/codecov/codecovSecondaryNav.spec.tsx
+++ b/static/app/views/nav/secondary/sections/codecov/codecovSecondaryNav.spec.tsx
@@ -92,4 +92,28 @@ describe('CodecovSecondaryNav', () => {
     expect(tokensLink).toBeInTheDocument();
     expect(tokensLink).toHaveAttribute('href', '/organizations/org-slug/codecov/tokens/');
   });
+
+  it('renders the correct prevent AI link', () => {
+    render(
+      <NavContextProvider>
+        <Nav />
+        <div id="main" />
+      </NavContextProvider>,
+      {
+        organization: OrganizationFixture({features: ALL_AVAILABLE_FEATURES}),
+        initialRouterConfig: {
+          location: {
+            pathname: '/organizations/org-slug/codecov/prevent-ai/new/',
+          },
+        },
+      }
+    );
+
+    const preventAILink = screen.getByRole('link', {name: 'Prevent AI'});
+    expect(preventAILink).toBeInTheDocument();
+    expect(preventAILink).toHaveAttribute(
+      'href',
+      '/organizations/org-slug/codecov/prevent-ai/new/'
+    );
+  });
 });

--- a/static/app/views/nav/secondary/sections/codecov/codecovSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/codecov/codecovSecondaryNav.tsx
@@ -5,6 +5,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {makeCodecovPathname} from 'sentry/views/codecov/pathnames';
 import {
   COVERAGE_BASE_URL,
+  PREVENT_AI_BASE_URL,
   TESTS_BASE_URL,
   TOKENS_BASE_URL,
 } from 'sentry/views/codecov/settings';
@@ -26,11 +27,15 @@ function CodecovSecondaryNav() {
     organization,
     path: `/${TOKENS_BASE_URL}/`,
   });
+  const preventAIPathName = makeCodecovPathname({
+    organization,
+    path: `/${PREVENT_AI_BASE_URL}/`,
+  });
 
   return (
     <Fragment>
       <SecondaryNav.Header>
-        {PRIMARY_NAV_GROUP_CONFIG[PrimaryNavGroup.CODECOV].label}
+        {PRIMARY_NAV_GROUP_CONFIG[PrimaryNavGroup.PREVENT].label}
       </SecondaryNav.Header>
       <SecondaryNav.Body>
         <SecondaryNav.Section id="codecov-main">
@@ -42,6 +47,9 @@ function CodecovSecondaryNav() {
           </SecondaryNav.Item>
           <SecondaryNav.Item to={testsPathname} activeTo={testsPathname}>
             {t('Tests')}
+          </SecondaryNav.Item>
+          <SecondaryNav.Item to={preventAIPathName} activeTo={preventAIPathName}>
+            {t('Prevent AI')}
           </SecondaryNav.Item>
         </SecondaryNav.Section>
         <SecondaryNav.Section id="codecov-configure" title={t('Configure')}>

--- a/static/app/views/nav/secondary/sections/codecov/codecovSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/codecov/codecovSecondaryNav.tsx
@@ -49,8 +49,8 @@ function CodecovSecondaryNav() {
             {t('Tests')}
           </SecondaryNav.Item>
           <SecondaryNav.Item
-            to={`${preventAIPathName}new`}
-            activeTo={`${preventAIPathName}new`}
+            to={`${preventAIPathName}new/`}
+            activeTo={`${preventAIPathName}new/`}
           >
             {t('Prevent AI')}
           </SecondaryNav.Item>

--- a/static/app/views/nav/secondary/sections/codecov/codecovSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/codecov/codecovSecondaryNav.tsx
@@ -48,7 +48,10 @@ function CodecovSecondaryNav() {
           <SecondaryNav.Item to={testsPathname} activeTo={testsPathname}>
             {t('Tests')}
           </SecondaryNav.Item>
-          <SecondaryNav.Item to={preventAIPathName} activeTo={preventAIPathName}>
+          <SecondaryNav.Item
+            to={`${preventAIPathName}new`}
+            activeTo={`${preventAIPathName}new`}
+          >
             {t('Prevent AI')}
           </SecondaryNav.Item>
         </SecondaryNav.Section>

--- a/static/app/views/nav/types.tsx
+++ b/static/app/views/nav/types.tsx
@@ -9,6 +9,6 @@ export enum PrimaryNavGroup {
   EXPLORE = 'explore',
   INSIGHTS = 'insights',
   SETTINGS = 'settings',
-  CODECOV = 'codecov',
+  PREVENT = 'prevent',
   ADMIN = 'admin',
 }

--- a/static/app/views/nav/useActiveNavGroup.spec.tsx
+++ b/static/app/views/nav/useActiveNavGroup.spec.tsx
@@ -35,7 +35,7 @@ describe('useActiveNavGroup', function () {
       [PrimaryNavGroup.DASHBOARDS, '/dashboard/foo/'],
       [PrimaryNavGroup.INSIGHTS, '/insights/foo/'],
       [PrimaryNavGroup.SETTINGS, '/settings/foo/'],
-      [PrimaryNavGroup.CODECOV, '/codecov/foo/'],
+      [PrimaryNavGroup.PREVENT, '/codecov/foo/'],
     ])('correctly matches %s nav group', async function (navGroup, path) {
       render(<TestComponent />, {
         initialRouterConfig: {
@@ -58,7 +58,7 @@ describe('useActiveNavGroup', function () {
       [PrimaryNavGroup.INSIGHTS, '/organizations/org-slug/insights/foo/'],
       [PrimaryNavGroup.SETTINGS, '/organizations/org-slug/settings/foo/'],
       [PrimaryNavGroup.SETTINGS, '/settings/account/details/'],
-      [PrimaryNavGroup.CODECOV, '/organizations/org-slug/codecov/foo/'],
+      [PrimaryNavGroup.PREVENT, '/organizations/org-slug/codecov/foo/'],
     ])('correctly matches %s nav group', async function (navGroup, path) {
       mockUsingCustomerDomain.mockReturnValue(false);
       render(<TestComponent />, {


### PR DESCRIPTION
This PR aims to add the new prevent ai route structure / nav bar stuff along with a rudimentary onboarding page, just so that I can put all the actual onboarding stuff in its own commit for clarity later.

Relates to https://linear.app/getsentry/issue/PREVENT-218/engineering-build-the-static-onboarding-page-for-prevent-ai

Looks something like this:

<img width="2216" height="1146" alt="Screenshot 2025-08-04 at 11 50 47 AM" src="https://github.com/user-attachments/assets/85471e13-c508-4fb2-8e08-7aaae682284b" />



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
