### PR TITLE
chore(detectors): Remove `is_span_eligible` class methods 

### DIFF
--- a/src/sentry/performance_issues/detectors/experiments/n_plus_one_api_calls_detector.py
+++ b/src/sentry/performance_issues/detectors/experiments/n_plus_one_api_calls_detector.py
@@ -53,7 +53,7 @@ class NPlusOneAPICallsExperimentalDetector(PerformanceDetector):
         return True
 
     def visit_span(self, span: Span) -> None:
-        if not NPlusOneAPICallsExperimentalDetector.is_span_eligible(span):
+        if not self._is_span_eligible(span):
             return
 
         op = span.get("op", None)
@@ -86,8 +86,7 @@ class NPlusOneAPICallsExperimentalDetector(PerformanceDetector):
 
         return True
 
-    @classmethod
-    def is_span_eligible(cls, span: Span) -> bool:
+    def _is_span_eligible(self, span: Span) -> bool:
         span_id = span.get("span_id", None)
         op = span.get("op", None)
         hash = span.get("hash", None)

--- a/src/sentry/performance_issues/detectors/n_plus_one_api_calls_detector.py
+++ b/src/sentry/performance_issues/detectors/n_plus_one_api_calls_detector.py
@@ -51,7 +51,7 @@ class NPlusOneAPICallsDetector(PerformanceDetector):
         self.span_hashes: dict[str, str | None] = {}
 
     def visit_span(self, span: Span) -> None:
-        if not NPlusOneAPICallsDetector.is_span_eligible(span):
+        if not self._is_span_eligible(span):
             return
 
         op = span.get("op", None)
@@ -86,8 +86,7 @@ class NPlusOneAPICallsDetector(PerformanceDetector):
 
         return True
 
-    @classmethod
-    def is_span_eligible(cls, span: Span) -> bool:
+    def _is_span_eligible(self, span: Span) -> bool:
         span_id = span.get("span_id", None)
         op = span.get("op", None)
         hash = span.get("hash", None)

--- a/src/sentry/performance_issues/detectors/query_injection_detector.py
+++ b/src/sentry/performance_issues/detectors/query_injection_detector.py
@@ -45,7 +45,7 @@ class QueryInjectionDetector(PerformanceDetector):
                 self.potential_unsafe_inputs.append(query_pair)
 
     def visit_span(self, span: Span) -> None:
-        if not QueryInjectionDetector.is_span_eligible(span):
+        if not self._is_span_eligible(span):
             return
 
         if len(self.potential_unsafe_inputs) == 0:
@@ -120,8 +120,7 @@ class QueryInjectionDetector(PerformanceDetector):
     def is_creation_allowed_for_project(self, project: Project | None) -> bool:
         return self.settings["detection_enabled"]
 
-    @classmethod
-    def is_span_eligible(cls, span: Span) -> bool:
+    def _is_span_eligible(self, span: Span) -> bool:
         if not span.get("span_id"):
             return False
 

--- a/src/sentry/performance_issues/detectors/slow_db_query_detector.py
+++ b/src/sentry/performance_issues/detectors/slow_db_query_detector.py
@@ -45,7 +45,7 @@ class SlowDBQueryDetector(PerformanceDetector):
         if not fingerprint:
             return
 
-        if not SlowDBQueryDetector.is_span_eligible(span):
+        if not self._is_span_eligible(span):
             return
 
         description = span["description"].strip()
@@ -97,8 +97,7 @@ class SlowDBQueryDetector(PerformanceDetector):
     def is_creation_allowed_for_project(self, project: Project | None) -> bool:
         return self.settings["detection_enabled"]
 
-    @classmethod
-    def is_span_eligible(cls, span: Span) -> bool:
+    def _is_span_eligible(self, span: Span) -> bool:
         description = span.get("description", None)
         if not description:
             return False

--- a/src/sentry/performance_issues/detectors/sql_injection_detector.py
+++ b/src/sentry/performance_issues/detectors/sql_injection_detector.py
@@ -115,7 +115,7 @@ class SQLInjectionDetector(PerformanceDetector):
         self.request_parameters = valid_parameters
 
     def visit_span(self, span: Span) -> None:
-        if not SQLInjectionDetector.is_span_eligible(span) or not self.request_parameters:
+        if not self._is_span_eligible(span) or not self.request_parameters:
             return
         description = span.get("description") or ""
         op = span.get("op") or ""
@@ -196,8 +196,7 @@ class SQLInjectionDetector(PerformanceDetector):
     def is_creation_allowed_for_project(self, project: Project | None) -> bool:
         return self.settings["detection_enabled"]
 
-    @classmethod
-    def is_span_eligible(cls, span: Span) -> bool:
+    def _is_span_eligible(self, span: Span) -> bool:
         if not span.get("span_id"):
             return False
 

--- a/tests/sentry/performance_issues/experiments/test_n_plus_one_api_calls_detector.py
+++ b/tests/sentry/performance_issues/experiments/test_n_plus_one_api_calls_detector.py
@@ -428,6 +428,7 @@ def test_parameterizes_url(url, parameterized_url) -> None:
         },
     ],
 )
+@pytest.mark.django_db
 def test_allows_eligible_spans(span) -> None:
     detector = NPlusOneAPICallsExperimentalDetector(get_detection_settings(), {})
     assert detector._is_span_eligible(span)
@@ -487,6 +488,7 @@ def test_allows_eligible_spans(span) -> None:
         },
     ],
 )
+@pytest.mark.django_db
 def test_rejects_ineligible_spans(span) -> None:
     detector = NPlusOneAPICallsExperimentalDetector(get_detection_settings(), {})
     assert not detector._is_span_eligible(span)

--- a/tests/sentry/performance_issues/experiments/test_n_plus_one_api_calls_detector.py
+++ b/tests/sentry/performance_issues/experiments/test_n_plus_one_api_calls_detector.py
@@ -429,7 +429,8 @@ def test_parameterizes_url(url, parameterized_url) -> None:
     ],
 )
 def test_allows_eligible_spans(span) -> None:
-    assert NPlusOneAPICallsExperimentalDetector.is_span_eligible(span)
+    detector = NPlusOneAPICallsExperimentalDetector(get_detection_settings(), {})
+    assert detector._is_span_eligible(span)
 
 
 @pytest.mark.parametrize(
@@ -487,7 +488,8 @@ def test_allows_eligible_spans(span) -> None:
     ],
 )
 def test_rejects_ineligible_spans(span) -> None:
-    assert not NPlusOneAPICallsExperimentalDetector.is_span_eligible(span)
+    detector = NPlusOneAPICallsExperimentalDetector(get_detection_settings(), {})
+    assert not detector._is_span_eligible(span)
 
 
 @pytest.mark.parametrize(

--- a/tests/sentry/performance_issues/test_n_plus_one_api_calls_detector.py
+++ b/tests/sentry/performance_issues/test_n_plus_one_api_calls_detector.py
@@ -372,7 +372,8 @@ def test_parameterizes_url(url, parameterized_url) -> None:
     ],
 )
 def test_allows_eligible_spans(span) -> None:
-    assert NPlusOneAPICallsDetector.is_span_eligible(span)
+    detector = NPlusOneAPICallsDetector(get_detection_settings(), {})
+    assert detector._is_span_eligible(span)
 
 
 @pytest.mark.parametrize(
@@ -430,7 +431,8 @@ def test_allows_eligible_spans(span) -> None:
     ],
 )
 def test_rejects_ineligible_spans(span) -> None:
-    assert not NPlusOneAPICallsDetector.is_span_eligible(span)
+    detector = NPlusOneAPICallsDetector(get_detection_settings(), {})
+    assert not detector._is_span_eligible(span)
 
 
 @pytest.mark.parametrize(

--- a/tests/sentry/performance_issues/test_n_plus_one_api_calls_detector.py
+++ b/tests/sentry/performance_issues/test_n_plus_one_api_calls_detector.py
@@ -371,6 +371,7 @@ def test_parameterizes_url(url, parameterized_url) -> None:
         },
     ],
 )
+@pytest.mark.django_db
 def test_allows_eligible_spans(span) -> None:
     detector = NPlusOneAPICallsDetector(get_detection_settings(), {})
     assert detector._is_span_eligible(span)
@@ -430,6 +431,7 @@ def test_allows_eligible_spans(span) -> None:
         },
     ],
 )
+@pytest.mark.django_db
 def test_rejects_ineligible_spans(span) -> None:
     detector = NPlusOneAPICallsDetector(get_detection_settings(), {})
     assert not detector._is_span_eligible(span)


### PR DESCRIPTION
some detectors were defining `is_span_eligible` as a class method - this pr removes these usages to unify it's definition across all detectors 