### PR TITLE
fix(workflow_engine): Update the `comparison` key on a DataCondition to be CamelCased

### DIFF
--- a/src/sentry/workflow_engine/endpoints/serializers.py
+++ b/src/sentry/workflow_engine/endpoints/serializers.py
@@ -193,10 +193,14 @@ class DataSourceSerializer(Serializer):
 @register(DataCondition)
 class DataConditionSerializer(Serializer):
     def serialize(self, obj: DataCondition, *args, **kwargs) -> dict[str, Any]:
+        comparison = obj.comparison
+        if isinstance(comparison, dict):
+            comparison = convert_dict_key_case(obj.comparison, snake_to_camel_case)
+
         return {
             "id": str(obj.id),
             "type": obj.type,
-            "comparison": obj.comparison,
+            "comparison": comparison,
             "conditionResult": obj.condition_result,
         }
 

--- a/tests/sentry/workflow_engine/endpoints/test_serializers.py
+++ b/tests/sentry/workflow_engine/endpoints/test_serializers.py
@@ -232,6 +232,49 @@ class TestDataSourceSerializer(TestCase):
         }
 
 
+class TestDataConditionSerializer(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.condition_group = self.create_data_condition_group(
+            organization_id=self.organization.id,
+            logic_type=DataConditionGroup.Type.ANY,
+        )
+
+    def test_serializer_simple(self) -> None:
+        condition = self.create_data_condition(
+            condition_group=self.condition_group,
+            type=Condition.GREATER,
+            comparison=100,
+            condition_result=DetectorPriorityLevel.HIGH,
+        )
+
+        result = serialize(condition)
+
+        assert result == {
+            "id": str(condition.id),
+            "type": "gt",
+            "comparison": 100,
+            "conditionResult": DetectorPriorityLevel.HIGH,
+        }
+
+    def test_complex_comparison(self) -> None:
+        condition = self.create_data_condition(
+            condition_group=self.condition_group,
+            type=Condition.GREATER,
+            comparison={"count": 100, "count_time": 60},
+            condition_result=DetectorPriorityLevel.HIGH,
+        )
+        result = serialize(condition)
+
+        assert result == {
+            "id": str(condition.id),
+            "type": "gt",
+            "comparison": {"count": 100, "countTime": 60},
+            "conditionResult": DetectorPriorityLevel.HIGH,
+        }
+
+
 class TestDataConditionGroupSerializer(TestCase):
     def test_serialize_simple(self) -> None:
         condition_group = self.create_data_condition_group(


### PR DESCRIPTION
# Description
The response is currently snake case, which is causing some problems in the UI. Since this is possible to be a `dict` or a primitive, we'll first check the field to make sure it's a `dict` then convert it to camelCase if needed.