### PR TITLE
test(issues): Extend time of issue overview test

### DIFF
--- a/static/app/views/issueList/overview.spec.tsx
+++ b/static/app/views/issueList/overview.spec.tsx
@@ -501,7 +501,7 @@ describe('IssueList', function () {
           statsPeriod: '14d',
         })
       );
-    });
+    }, 20_000);
 
     it('pins a custom query', async function () {
       const pinnedSearch = {


### PR DESCRIPTION
flaking a bit at 5 secnods, extend to 20. [example](https://github.com/getsentry/sentry/actions/runs/16731394655/job/47360071185#step:7:697)
