### PR TITLE
ghsa: ignore GHSA-8qvm-5x2c-j2w7

### DIFF
--- a/.github/dependency-review-config.yml
+++ b/.github/dependency-review-config.yml
@@ -1,0 +1,5 @@
+fail-on-severity: high
+
+allow-ghsas:
+  # doesn't apply; we don't use the pure python wheel
+  - GHSA-8qvm-5x2c-j2w7


### PR DESCRIPTION
https://github.com/advisories/GHSA-8qvm-5x2c-j2w7

this doesn't apply to us - we're installing the platform-specific wheel in prod + PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION is not set

codeowners should still be work on bumping this dependency though, we're quite behind
ref: https://github.com/getsentry/sentry/pull/95772#issuecomment-3096802072
