### PR TITLE
fix(aci): handle deleted Workflows and DataConditionGroups in delayed workflow task

### DIFF
--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -556,8 +556,10 @@ def get_groups_to_fire(
         group_id = event_key.group_id
         workflow_env = workflows_to_envs[event_key.workflow_id]
         if when_dcg_id := event_key.when_dcg_id:
-            if not _evaluate_group_result_for_dcg(
-                data_condition_group_mapping[when_dcg_id],
+            if not (
+                dcg := data_condition_group_mapping.get(when_dcg_id)
+            ) or not _evaluate_group_result_for_dcg(
+                dcg,
                 dcg_to_slow_conditions,
                 group_id,
                 workflow_env,
@@ -567,18 +569,20 @@ def get_groups_to_fire(
 
         # the WHEN condition passed / was not evaluated, so we can now check the IF conditions
         for if_dcg_id in event_key.if_dcg_ids:
-            if _evaluate_group_result_for_dcg(
-                data_condition_group_mapping[if_dcg_id],
+            if (
+                dcg := data_condition_group_mapping.get(if_dcg_id)
+            ) and _evaluate_group_result_for_dcg(
+                dcg,
                 dcg_to_slow_conditions,
                 group_id,
                 workflow_env,
                 condition_group_results,
             ):
-                groups_to_fire[group_id].add(data_condition_group_mapping[if_dcg_id])
+                groups_to_fire[group_id].add(dcg)
 
-        groups_to_fire[group_id].update(
-            data_condition_group_mapping[if_dcg_id] for if_dcg_id in event_key.passing_dcg_ids
-        )
+        for if_dcg_id in event_key.passing_dcg_ids:
+            if dcg := data_condition_group_mapping.get(if_dcg_id):
+                groups_to_fire[group_id].add(dcg)
 
     return groups_to_fire
 

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -554,6 +554,10 @@ def get_groups_to_fire(
 
     for event_key in event_data.events:
         group_id = event_key.group_id
+        if event_key.workflow_id not in workflows_to_envs:
+            # The workflow is deleted, so we can skip it
+            continue
+
         workflow_env = workflows_to_envs[event_key.workflow_id]
         if when_dcg_id := event_key.when_dcg_id:
             if not (

--- a/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
@@ -806,7 +806,7 @@ class TestGetGroupsToFire(TestDelayedWorkflowBase):
             self.dcg_to_slow_conditions,
         )
 
-        # NOTE: no WHEN DCGs. We only collect IF DCGs here to fire their actions in the fire_actions_for_groups function
+        # NOTE: same result as test_simple but without the deleted DCGs
         assert result == {
             self.group1.id: {self.workflow1_if_dcgs[1]},
         }

--- a/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
@@ -785,6 +785,32 @@ class TestGetGroupsToFire(TestDelayedWorkflowBase):
             self.group2.id: {self.workflow2_if_dcgs[1]},
         }
 
+    def test_ignored_deleted_dcgs(self) -> None:
+        self.workflow1_if_dcgs[0].delete()
+        self.workflow2_if_dcgs[1].delete()
+
+        self.data_condition_groups: list[DataConditionGroup] = (
+            [
+                self.workflow1.when_condition_group,
+                self.workflow2.when_condition_group,
+            ]
+            + [self.workflow1_if_dcgs[1]]
+            + [self.workflow2_if_dcgs[0]]
+        )
+
+        result = get_groups_to_fire(
+            self.data_condition_groups,
+            self.workflows_to_envs,
+            self.event_data,
+            self.condition_group_results,
+            self.dcg_to_slow_conditions,
+        )
+
+        # NOTE: no WHEN DCGs. We only collect IF DCGs here to fire their actions in the fire_actions_for_groups function
+        assert result == {
+            self.group1.id: {self.workflow1_if_dcgs[1]},
+        }
+
     def test_dcg_any_fails(self) -> None:
         self.condition_group_results.update(
             {

--- a/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
@@ -810,7 +810,10 @@ class TestGetGroupsToFire(TestDelayedWorkflowBase):
         self.workflow1_if_dcgs[0].delete()
         self.workflow2_if_dcgs[1].delete()
 
-        self.data_condition_groups: list[DataConditionGroup] = (
+        assert self.workflow1.when_condition_group
+        assert self.workflow2.when_condition_group
+
+        self.data_condition_groups = (
             [
                 self.workflow1.when_condition_group,
                 self.workflow2.when_condition_group,


### PR DESCRIPTION
If `Workflows` and/or `DataConditionGroups` are deleted in between an event being enqueued from `process_workflows` and the delayed workflows task being run, we shouldn't evaluate their results.

We iterate through all the event keys and process the DCGs within them one by one, but if the `Workflow`/`DataConditionGroup` doesn't exist we should skip evaluation. Currently this will result in a `KeyError` because the `Workflow` won't exist in the mapping of Workflow id to env and/or the DCG won't exist in the mapping of DCG id to DCG that we create within `get_groups_to_fire`.