### PR TITLE
perf(aci): Remove unnecessary Organization load

### DIFF
--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -422,7 +422,7 @@ class SubscriptionProcessor:
 
                     if features.has(
                         "organizations:workflow-engine-metric-alert-dual-processing-logs",
-                        self.alert_rule.organization,
+                        organization,
                     ):
                         logger.info(
                             "dual processing results for alert rule",


### PR DESCRIPTION
We already have an organization being used for gating, might as well use it everywhere and not force a load.
