### PR TITLE
feat(aci): Add simple group serializer

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -1238,6 +1238,6 @@ class SimpleGroupSerializer(Serializer):
             substatus=_get_substatus_label(obj),
             platform=obj.platform,
             project=_make_group_project_response(obj.project),
-            type=obj.type,
+            type=obj.get_event_type(),
             issueType=obj.issue_type.slug,
         )

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -1205,12 +1205,12 @@ class GroupSerializerSnuba(GroupSerializerBase):
 class SimpleGroupSerializerResponse(TypedDict):
     id: str
     title: str
-    culprit: str
+    culprit: str | None
     shortId: str | None
     level: str
     status: str
     substatus: str | None
-    platform: str
+    platform: str | None
     project: GroupProjectResponse
     type: str
     issueType: str
@@ -1227,6 +1227,7 @@ class SimpleGroupSerializer(Serializer):
         obj: Group,
         attrs: Mapping[str, Any],
         user: User | RpcUser | AnonymousUser,
+        **kwargs: Any,
     ) -> SimpleGroupSerializerResponse:
         return SimpleGroupSerializerResponse(
             id=str(obj.id),

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -39,6 +39,7 @@ from sentry.models.groupsnooze import GroupSnooze
 from sentry.models.groupsubscription import GroupSubscription
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.orgauthtoken import is_org_auth_token_auth
+from sentry.models.project import Project
 from sentry.models.team import Team
 from sentry.notifications.helpers import (
     SubscriptionDetails,
@@ -162,6 +163,47 @@ class SeenStatsResponse(TypedDict):
 def is_seen_stats(o: object) -> TypeGuard[SeenStats]:
     # not a perfect check, but simulates what was being validated before
     return isinstance(o, dict) and "times_seen" in o
+
+
+def _make_group_project_response(project: Project) -> GroupProjectResponse:
+    return {
+        "id": str(project.id),
+        "name": project.name,
+        "slug": project.slug,
+        "platform": project.platform,
+    }
+
+
+def _get_status_label(group: Group):
+    status = group.status
+
+    if status == GroupStatus.UNRESOLVED and group.is_over_resolve_age():
+        # When an issue is over the auto-resolve age but the task has not yet run
+        # Only show as auto-resolved if this group type has auto-resolve enabled
+        if group.issue_type.enable_auto_resolve:
+            status = GroupStatus.RESOLVED
+    if status == GroupStatus.RESOLVED:
+        status_label = "resolved"
+    elif status == GroupStatus.IGNORED:
+        status_label = "ignored"
+    elif status in [GroupStatus.PENDING_DELETION, GroupStatus.DELETION_IN_PROGRESS]:
+        status_label = "pending_deletion"
+    elif status == GroupStatus.PENDING_MERGE:
+        status_label = "pending_merge"
+    elif status == GroupStatus.REPROCESSING:
+        status_label = "reprocessing"
+    else:
+        status_label = "unresolved"
+
+    return status_label
+
+
+def _get_substatus_label(group: Group):
+    return SUBSTATUS_TO_STR[group.substatus] if group.substatus else None
+
+
+def _get_level_label(group: Group):
+    return LOG_LEVELS.get(group.level, "unknown")
 
 
 class GroupSerializerBase(Serializer, ABC):
@@ -346,18 +388,13 @@ class GroupSerializerBase(Serializer, ABC):
             "culprit": obj.culprit,
             "permalink": permalink,
             "logger": obj.logger or None,
-            "level": LOG_LEVELS.get(obj.level, "unknown"),
+            "level": _get_level_label(obj),
             "status": status_label,
             "statusDetails": status_details,
-            "substatus": SUBSTATUS_TO_STR[obj.substatus] if obj.substatus else None,
+            "substatus": _get_substatus_label(obj),
             "isPublic": share_id is not None,
             "platform": obj.platform,
-            "project": {
-                "id": str(obj.project.id),
-                "name": obj.project.name,
-                "slug": obj.project.slug,
-                "platform": obj.project.platform,
-            },
+            "project": _make_group_project_response(obj.project),
             "type": obj.get_event_type(),
             "metadata": obj.get_event_metadata(),
             "numComments": obj.num_comments,
@@ -1163,3 +1200,44 @@ class GroupSerializerSnuba(GroupSerializerBase):
             }
             for item in item_list
         }
+
+
+class SimpleGroupSerializerResponse(TypedDict):
+    id: str
+    title: str
+    culprit: str
+    shortId: str | None
+    level: str
+    status: str
+    substatus: str | None
+    platform: str
+    project: GroupProjectResponse
+    type: str
+    issueType: str
+
+
+class SimpleGroupSerializer(Serializer):
+    """
+    A serializer that only returns the most basic information about a group.
+    It should make minimal queries to the database.
+    """
+
+    def serialize(
+        self,
+        obj: Group,
+        attrs: Mapping[str, Any],
+        user: User | RpcUser | AnonymousUser,
+    ) -> SimpleGroupSerializerResponse:
+        return SimpleGroupSerializerResponse(
+            id=str(obj.id),
+            title=obj.title,
+            culprit=obj.culprit,
+            shortId=obj.qualified_short_id,
+            level=_get_level_label(obj),
+            status=_get_status_label(obj),
+            substatus=_get_substatus_label(obj),
+            platform=obj.platform,
+            project=_make_group_project_response(obj.project),
+            type=obj.type,
+            issueType=obj.issue_type.slug,
+        )

--- a/tests/sentry/api/serializers/test_group.py
+++ b/tests/sentry/api/serializers/test_group.py
@@ -449,5 +449,5 @@ class SimpleGroupSerializerTest(TestCase):
         assert serialized["shortId"] == group.qualified_short_id
         assert serialized["status"] == "unresolved"
         assert serialized["substatus"] == "new"
-        assert serialized["type"] == group.type
+        assert serialized["type"] == "default"
         assert serialized["issueType"] == "error"

--- a/tests/sentry/api/serializers/test_group.py
+++ b/tests/sentry/api/serializers/test_group.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 from django.utils import timezone
 
 from sentry.api.serializers import serialize
+from sentry.api.serializers.models.group import SimpleGroupSerializer
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.integrations.types import ExternalProviderEnum
 from sentry.issues.grouptype import FeedbackGroup
@@ -429,3 +430,24 @@ class GroupSerializerTest(TestCase, PerformanceIssueTestCase):
         assert serialized["count"] == "1"
         assert serialized["issueCategory"] == "performance"
         assert serialized["issueType"] == "performance_n_plus_one_db_queries"
+
+
+class SimpleGroupSerializerTest(TestCase):
+    def test_simple_group_serializer(self) -> None:
+        group = self.create_group()
+        serialized = serialize(group, self.user, SimpleGroupSerializer())
+        assert serialized["id"] == str(group.id)
+        assert serialized["title"] == group.title
+        assert serialized["culprit"] == group.culprit
+        assert serialized["level"] == "error"
+        assert serialized["project"] == {
+            "id": str(group.project.id),
+            "name": group.project.name,
+            "slug": group.project.slug,
+            "platform": group.project.platform,
+        }
+        assert serialized["shortId"] == group.qualified_short_id
+        assert serialized["status"] == "unresolved"
+        assert serialized["substatus"] == "new"
+        assert serialized["type"] == group.type
+        assert serialized["issueType"] == "error"


### PR DESCRIPTION
For detectors, we need to return the most recently created group. We don't need all the information that the normal group serializer returns, so I'm adding a SimpleGroupSerializer that avoids unnecessary queries.

While doing so, pulled out some common logic to share between this and the base serializer.