### PR TITLE
fix(detectors): Add "@nestjs/typeorm" to excluded packages list

### DIFF
--- a/fixtures/events/performance_problems/sql-injection/sql-injection-event-nestjs-typeorm.json
+++ b/fixtures/events/performance_problems/sql-injection/sql-injection-event-nestjs-typeorm.json
@@ -1,0 +1,58 @@
+{
+  "event_id": "5d6401994d7949d2ac3474f472564370",
+  "platform": "node",
+  "message": "",
+  "datetime": "2025-05-12T22:42:38.642986+00:00",
+  "breakdowns": {
+    "span_ops": {
+      "ops.db": {
+        "value": 65.715075,
+        "unit": "millisecond"
+      },
+      "total.time": {
+        "value": 67.105293,
+        "unit": "millisecond"
+      }
+    }
+  },
+  "request": {
+    "url": "http://localhost:3001/vulnerable-login",
+    "method": "POST",
+    "data": {
+      "username": "bob"
+    }
+  },
+  "modules": {
+    "@nestjs/typeorm": "10.0.0"
+  },
+  "spans": [
+    {
+      "timestamp": 1747089758.637715,
+      "start_timestamp": 1747089758.572,
+      "exclusive_time": 65.715075,
+      "op": "db",
+      "span_id": "4703181ac343f71a",
+      "parent_span_id": "91fa92ff0205967d",
+      "trace_id": "375a86eca09a4a4e91903838dd771f50",
+      "status": "ok",
+      "description": "SELECT * FROM \"user\" WHERE username = 'bob' AND \"user\".\"deleted_at\" IS NULL ORDER BY \"user\".\"id\" LIMIT 1",
+      "origin": "auto.db.otel.mysql2",
+      "sentry_tags": {
+        "description": "SELECT * FROM \"user\" WHERE username = 'bob' AND \"user\".\"deleted_at\" IS NULL ORDER BY \"user\".\"id\" LIMIT 1"
+      },
+      "data": {
+        "db.system": "mysql",
+        "db.connection_string": "jdbc:mysql://localhost:3306/injection_test",
+        "db.name": "injection_test",
+        "db.statement": "SELECT * FROM \"user\" WHERE username = 'bob' AND \"user\".\"deleted_at\" IS NULL ORDER BY \"user\".\"id\" LIMIT 1",
+        "db.user": "root",
+        "net.peer.name": "localhost",
+        "net.peer.port": 3306,
+        "otel.kind": "CLIENT",
+        "sentry.op": "db",
+        "sentry.origin": "auto.db.otel.mysql2"
+      },
+      "hash": "45330ba0cafa5997"
+    }
+  ]
+}

--- a/src/sentry/performance_issues/detectors/sql_injection_detector.py
+++ b/src/sentry/performance_issues/detectors/sql_injection_detector.py
@@ -55,7 +55,12 @@ EXCLUDED_KEYWORDS = [
     "PAGE",
 ]
 
-EXCLUDED_PACKAGES = ["github.com/go-sql-driver/mysql", "sequelize", "gorm.io/gorm"]
+EXCLUDED_PACKAGES = [
+    "github.com/go-sql-driver/mysql",
+    "sequelize",
+    "gorm.io/gorm",
+    "@nestjs/typeorm",
+]
 PARAMETERIZED_KEYWORDS = ["?", "$1", "%s"]
 
 

--- a/tests/sentry/performance_issues/test_sql_injection_detector.py
+++ b/tests/sentry/performance_issues/test_sql_injection_detector.py
@@ -87,8 +87,11 @@ class SQLInjectionDetectorTest(TestCase):
         injection_event = get_event("sql-injection/sql-injection-query-with-bindings")
         assert len(self.find_problems(injection_event)) == 0
 
-    def test_sql_injection_on_event_with_gorm(self) -> None:
+    def test_sql_injection_on_event_with_excluded_package(self) -> None:
         injection_event = get_event("sql-injection/sql-injection-event-gorm")
+        assert len(self.find_problems(injection_event)) == 0
+
+        injection_event = get_event("sql-injection/sql-injection-event-nestjs-typeorm")
         assert len(self.find_problems(injection_event)) == 0
 
     def test_sql_injection_on_orm_queries(self) -> None:


### PR DESCRIPTION
we've seen 2 examples recently where TypeORM for NestJS platforms has caused false positives - https://github.com/getsentry/sentry/pull/96902 helped prevent some of them, but safer to filter on the package as well. 