### PR TITLE
ref(issues): decrease rate limits for GroupTagKeyValues endpoint even more

### DIFF
--- a/src/sentry/api/endpoints/group_tagkey_values.py
+++ b/src/sentry/api/endpoints/group_tagkey_values.py
@@ -36,9 +36,9 @@ class GroupTagKeyValuesEndpoint(GroupEndpoint):
     enforce_rate_limit = True
     rate_limits = {
         "GET": {
-            RateLimitCategory.IP: RateLimit(limit=150, window=60, concurrent_limit=5),
-            RateLimitCategory.USER: RateLimit(limit=300, window=60, concurrent_limit=10),
-            RateLimitCategory.ORGANIZATION: RateLimit(limit=600, window=60, concurrent_limit=5),
+            RateLimitCategory.IP: RateLimit(limit=100, window=60, concurrent_limit=5),
+            RateLimitCategory.USER: RateLimit(limit=200, window=60, concurrent_limit=10),
+            RateLimitCategory.ORGANIZATION: RateLimit(limit=400, window=60, concurrent_limit=5),
         }
     }
 

--- a/tests/sentry/api/endpoints/test_group_tagkey_values.py
+++ b/tests/sentry/api/endpoints/test_group_tagkey_values.py
@@ -206,7 +206,7 @@ class GroupTagKeyValuesTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase
         url = f"/api/0/issues/{group.id}/tags/{key}/values/"
 
         with freeze_time(datetime.datetime.now()):
-            for i in range(300):
+            for i in range(200):
                 response = self.client.get(url)
                 assert response.status_code == 200
             response = self.client.get(url)


### PR DESCRIPTION
Cut the rate limit by 1/3 on GroupTagKeyValues. Follow up to this: https://github.com/getsentry/sentry/pull/97028.

We saw a reduced # of tagstore queries after reducing the rate limits in half, with [no impact on frontend users](https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Alabels.name%3D%22sentry.access.api%22%0AjsonPayload.view%3D%22sentry.api.endpoints.group_tagkey_values.GroupTagKeyValuesEndpoint%22%20OR%20jsonPayload.view%3D%22sentry.api.endpoints.group_tagkey_details.GroupTagKeyDetailsEndpoint%22%0AjsonPayload.rate_limited%3D%22True%22%0AjsonPayload.is_frontend_request%3D%22True%22;summaryFields=:true:32:beginning;cursorTimestamp=2025-08-04T21:28:04.605604162Z;duration=PT1H?project=internal-sentry&rapt=AEjHL4PlAlabnBhF2ZdK1LSydzxRnGsncIOGK_1hRxsiiOcBLISC1IUfCpscrtrQ80ntXh7jAzfN6Dn4udBtmPk9aWCHJnNt0O3Go46anGeO8aot9SmRQ5Y&inv=1&invt=Ab4mqQ) — examining this further, this endpoint is very rarely called from the frontend anyways (<200 total requests per min total), so we can reduce this rate limit further as a temporary solution. This endpoint is also by far the biggest offender in terms of requests, see [this redashboard](https://redash.getsentry.net/dashboards/363-rate-limiting) + [query](https://redash.getsentry.net/queries/9293?p_day=d_now#12100)


Long term, I believe discussion is starting around making this query generally more efficient, which will allow us to raise this rate limit again.