### PR TITLE
feat(aci): add hits to detector/workflow GET response headers

### DIFF
--- a/src/sentry/workflow_engine/endpoints/organization_detector_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_index.py
@@ -238,6 +238,7 @@ class OrganizationDetectorIndexEndpoint(OrganizationEndpoint):
             queryset=queryset,
             order_by=sort_by.db_order_by,
             on_results=lambda x: serialize(x, request.user),
+            count_hits=True,
         )
 
     @extend_schema(

--- a/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
@@ -195,6 +195,7 @@ class OrganizationWorkflowIndexEndpoint(OrganizationEndpoint):
             order_by=sort_by.db_order_by,
             paginator_cls=OffsetPaginator,
             on_results=lambda x: serialize(x, request.user),
+            count_hits=True,
         )
 
     @extend_schema(

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
@@ -66,6 +66,11 @@ class OrganizationDetectorIndexGetTest(OrganizationDetectorIndexBaseTest):
         )
         assert response.data == serialize([detector, detector_2])
 
+        # Verify X-Hits header is present and correct
+        assert "X-Hits" in response
+        hits = int(response["X-Hits"])
+        assert hits == 2
+
     def test_uptime_detector(self) -> None:
         subscription = self.create_uptime_subscription()
         data_source = self.create_data_source(

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
@@ -57,6 +57,11 @@ class OrganizationWorkflowIndexBaseTest(OrganizationWorkflowAPITestCase):
         response = self.get_success_response(self.organization.slug)
         assert response.data == serialize([self.workflow, self.workflow_two, self.workflow_three])
 
+        # Verify X-Hits header is present and correct
+        assert "X-Hits" in response
+        hits = int(response["X-Hits"])
+        assert hits == 3
+
     def test_empty_result(self) -> None:
         response = self.get_success_response(
             self.organization.slug, qs_params={"query": "aaaaaaaaaaaaa"}


### PR DESCRIPTION
adds `X-Hits` and `X-Max-Hits` to the response headers so that we know how many objects the full query contains, even if the response itself is paginated

this will be useful for the UI when users are performing bulk disable/delete actions and we want to display how many detectors/workflows they are modifying