### PR TITLE
fix(detectors): Filter prefetch requests for large http payload 

### DIFF
--- a/src/sentry/performance_issues/detectors/large_payload_detector.py
+++ b/src/sentry/performance_issues/detectors/large_payload_detector.py
@@ -116,6 +116,10 @@ class LargeHTTPPayloadDetector(PerformanceDetector):
         if any([x in description for x in ["_next/static/", "_next/data/"]]):
             return False
 
+        span_data = span.get("data", {})
+        if span_data and span_data.get("http.request.prefetch"):
+            return False
+
         return True
 
     def _fingerprint(self, span: Span) -> str:

--- a/tests/sentry/performance_issues/test_large_http_payload_detector.py
+++ b/tests/sentry/performance_issues/test_large_http_payload_detector.py
@@ -284,3 +284,18 @@ class LargeHTTPPayloadDetectorTest(TestCase):
                 evidence_display=[],
             )
         ]
+
+    def test_does_not_trigger_detection_for_prefetch_spans(self) -> None:
+        spans = [
+            create_span(
+                "http.client",
+                hash="hash1",
+                desc="GET https://s1.sentry-cdn.com/_static/dist/sentry/entrypoints/app.json/?foo=bar",
+                duration=1000.0,
+                data={
+                    "http.request.prefetch": True,
+                },
+            )
+        ]
+        event = create_event(spans)
+        assert self.find_problems(event) == []

--- a/tests/sentry/performance_issues/test_large_http_payload_detector.py
+++ b/tests/sentry/performance_issues/test_large_http_payload_detector.py
@@ -294,8 +294,11 @@ class LargeHTTPPayloadDetectorTest(TestCase):
                 duration=1000.0,
                 data={
                     "http.request.prefetch": True,
+                    "http.response_transfer_size": 50_000_000,
+                    "http.response_content_length": 50_000_000,
+                    "http.decoded_response_content_length": 50_000_000,
                 },
             )
         ]
         event = create_event(spans)
-        assert self.find_problems(event) == []
+        assert len(self.find_problems(event)) == 0


### PR DESCRIPTION
these aren't super actionable so we should ignore spans that have `http.request.prefetch = true` 
fixes https://linear.app/getsentry/issue/ID-818/exclude-prefetch-requests-for-large-http-payload-issue-detection