### PR TITLE
fix(stats): Better links for stats tabs

### DIFF
--- a/static/app/views/nav/useRedirectNavV2Routes.spec.tsx
+++ b/static/app/views/nav/useRedirectNavV2Routes.spec.tsx
@@ -164,5 +164,18 @@ describe('useRedirectNavV2Routes', () => {
 
       expect(screen.getByText('no redirect')).toBeInTheDocument();
     });
+
+    it('handles settings routes', () => {
+      render(<TestComponent oldPathPrefix="/stats/" newPathPrefix="/settings/stats/" />, {
+        organization,
+        initialRouterConfig: {
+          location: {
+            pathname: '/organizations/org-slug/stats/',
+          },
+        },
+      });
+
+      expect(screen.getByText('/settings/org-slug/stats/')).toBeInTheDocument();
+    });
   });
 });

--- a/static/app/views/nav/useRedirectNavV2Routes.tsx
+++ b/static/app/views/nav/useRedirectNavV2Routes.tsx
@@ -87,10 +87,14 @@ export function useRedirectNavV2Routes({
     );
   }
 
+  const newPath = newPathPrefix.startsWith('/settings/')
+    ? newPathPrefix.replace('/settings/', `/settings/${organization.slug}/`)
+    : `/organizations/${organization.slug}${newPathPrefix}`;
+
   return (
     location.pathname.replace(
       new RegExp(`^/organizations/${organization.slug}${oldPathPrefix}`),
-      `/organizations/${organization.slug}${newPathPrefix}`
+      newPath
     ) +
     location.search +
     location.hash

--- a/static/app/views/organizationStats/organizationStatsWrapper.tsx
+++ b/static/app/views/organizationStats/organizationStatsWrapper.tsx
@@ -1,5 +1,4 @@
 import Redirect from 'sentry/components/redirect';
-import useOrganization from 'sentry/utils/useOrganization';
 import {useRedirectNavV2Routes} from 'sentry/views/nav/useRedirectNavV2Routes';
 
 type OrganizationStatsWrapperProps = {
@@ -9,11 +8,9 @@ type OrganizationStatsWrapperProps = {
 // Wraps all routes under /stats/ to redirect to /settings/stats/
 // Can be removed once navigation-sidebar-v2 is fully launched
 export function OrganizationStatsWrapper({children}: OrganizationStatsWrapperProps) {
-  const organization = useOrganization();
-
   const redirectPath = useRedirectNavV2Routes({
     oldPathPrefix: '/stats/',
-    newPathPrefix: `/settings/${organization.slug}/stats/`,
+    newPathPrefix: `/settings/stats/`,
   });
 
   if (redirectPath) {

--- a/static/app/views/organizationStats/organizationStatsWrapper.tsx
+++ b/static/app/views/organizationStats/organizationStatsWrapper.tsx
@@ -1,4 +1,5 @@
 import Redirect from 'sentry/components/redirect';
+import useOrganization from 'sentry/utils/useOrganization';
 import {useRedirectNavV2Routes} from 'sentry/views/nav/useRedirectNavV2Routes';
 
 type OrganizationStatsWrapperProps = {
@@ -8,9 +9,11 @@ type OrganizationStatsWrapperProps = {
 // Wraps all routes under /stats/ to redirect to /settings/stats/
 // Can be removed once navigation-sidebar-v2 is fully launched
 export function OrganizationStatsWrapper({children}: OrganizationStatsWrapperProps) {
+  const organization = useOrganization();
+
   const redirectPath = useRedirectNavV2Routes({
     oldPathPrefix: '/stats/',
-    newPathPrefix: '/settings/stats/',
+    newPathPrefix: `/settings/${organization.slug}/stats/`,
   });
 
   if (redirectPath) {

--- a/static/app/views/organizationStats/pathname.tsx
+++ b/static/app/views/organizationStats/pathname.tsx
@@ -3,7 +3,6 @@ import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {prefersStackedNav} from 'sentry/views/nav/prefersStackedNav';
 
 const LEGACY_STATS_BASE_PATHNAME = 'stats';
-const STATS_BASE_PATHNAME = 'settings/stats';
 
 export function makeStatsPathname({
   path,
@@ -14,7 +13,7 @@ export function makeStatsPathname({
 }) {
   return normalizeUrl(
     prefersStackedNav(organization)
-      ? `/organizations/${organization.slug}/${STATS_BASE_PATHNAME}${path}`
+      ? `/settings/${organization.slug}/stats${path}`
       : `/organizations/${organization.slug}/${LEGACY_STATS_BASE_PATHNAME}${path}`
   );
 }


### PR DESCRIPTION
Fixes JAVASCRIPT-32PR

Fixes some tab links on the new stats page which were using `/organization/:orgSlug/settings/stats` to use the correct `/settings/:orgSlug/stats`. Also fixes the redirect which was also slightly off.

I'm not sure how this was working for most people, but failed for others. Either way this should fix it.

<img width="373" height="175" alt="CleanShot 2025-08-04 at 15 27 33" src="https://github.com/user-attachments/assets/4313355c-dba5-4373-9953-81981ad466ee" />
