### PR TITLE
feat(issue-details): Add upsampling tag to header 

### DIFF
--- a/static/app/views/issueDetails/streamline/header/header.tsx
+++ b/static/app/views/issueDetails/streamline/header/header.tsx
@@ -4,6 +4,7 @@ import Color from 'color';
 
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
 import {FeatureBadge} from 'sentry/components/core/badge/featureBadge';
+import {Tag} from 'sentry/components/core/badge/tag';
 import {Button} from 'sentry/components/core/button';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
@@ -84,6 +85,8 @@ export default function StreamlinedGroupHeader({
     ReprocessingStatus.REPROCESSED_AND_HASNT_EVENT,
   ].includes(groupReprocessingStatus);
 
+  const hasErrorUpsampling = project.features.includes('error-upsampling');
+
   const isQueryInjection = group.issueType === IssueType.QUERY_INJECTION_VULNERABILITY;
   const openForm = useFeedbackForm();
   const feedbackButton = openForm ? (
@@ -117,7 +120,7 @@ export default function StreamlinedGroupHeader({
     <Fragment>
       <Header>
         <Flex justify="between">
-          <Flex align="center">
+          <Flex align="center" gap="md">
             <Breadcrumbs
               crumbs={[
                 {
@@ -132,6 +135,15 @@ export default function StreamlinedGroupHeader({
                 },
               ]}
             />
+            {hasErrorUpsampling && (
+              <Tooltip
+                title={t(
+                  'Error counts on this page have been upsampled based on your sampling rate.'
+                )}
+              >
+                <StyledTag>{t('Errors Upsampled')}</StyledTag>
+              </Tooltip>
+            )}
           </Flex>
           <ButtonBar gap="xs">
             {!hasOnlyOneUIOption && !isQueryInjection && (
@@ -405,4 +417,10 @@ const Title = styled('div')`
   grid-template-columns: minmax(0, max-content) min-content;
   align-items: center;
   column-gap: ${p => p.theme.space.sm};
+`;
+
+const StyledTag = styled(Tag)`
+  @media (max-width: ${p => p.theme.breakpoints.xs}) {
+    display: none;
+  }
 `;


### PR DESCRIPTION
this pr adds the error upsampling tag to the issue details page, if the project has the flag 
<img width="299" height="37" alt="Screenshot 2025-08-04 at 3 31 58 PM" src="https://github.com/user-attachments/assets/4ddcf30e-b23d-4d91-adcf-02c5471036fb" />
fixes https://linear.app/getsentry/issue/ID-638/add-errors-upsampled-tag-in-issue-details-page
