### PR TITLE
fix(nav): Correctly use new nav for route not found page

### DIFF
--- a/static/app/views/routeNotFound.tsx
+++ b/static/app/views/routeNotFound.tsx
@@ -10,6 +10,8 @@ import {t} from 'sentry/locale';
 import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useLastKnownRoute} from 'sentry/views/lastKnownRouteContextProvider';
+import {usePrefersStackedNav} from 'sentry/views/nav/usePrefersStackedNav';
+import OrganizationLayout from 'sentry/views/organizationLayout';
 
 type Props = RouteComponentProps;
 
@@ -17,6 +19,7 @@ function RouteNotFound({location}: Props) {
   const navigate = useNavigate();
   const {pathname, search, hash} = location;
   const lastKnownRoute = useLastKnownRoute();
+  const prefersStackedNav = usePrefersStackedNav();
 
   const isMissingSlash = pathname[pathname.length - 1] !== '/';
 
@@ -40,15 +43,27 @@ function RouteNotFound({location}: Props) {
     return null;
   }
 
+  if (!prefersStackedNav) {
+    return (
+      <SentryDocumentTitle title={t('Page Not Found')}>
+        <div className="app">
+          <Sidebar />
+          <Layout.Page withPadding>
+            <NotFound />
+          </Layout.Page>
+          <Footer />
+        </div>
+      </SentryDocumentTitle>
+    );
+  }
+
   return (
     <SentryDocumentTitle title={t('Page Not Found')}>
-      <div className="app">
-        <Sidebar />
+      <OrganizationLayout>
         <Layout.Page withPadding>
           <NotFound />
         </Layout.Page>
-        <Footer />
-      </div>
+      </OrganizationLayout>
     </SentryDocumentTitle>
   );
 }


### PR DESCRIPTION
Before:

<img width="638" height="335" alt="CleanShot 2025-08-04 at 15 53 35" src="https://github.com/user-attachments/assets/5e1aba41-16a8-47af-a08d-d817c6847de5" />

After:

<img width="610" height="412" alt="CleanShot 2025-08-04 at 15 54 06" src="https://github.com/user-attachments/assets/d0aaa0f9-42ca-49f3-a718-31102c6b2b20" />
