### PR TITLE
test(javascript): Fixup test with correct values

### DIFF
--- a/tests/relay_integration/lang/javascript/test_plugin.py
+++ b/tests/relay_integration/lang/javascript/test_plugin.py
@@ -1281,8 +1281,6 @@ class TestJavascriptIntegration(RelayStoreHelper):
         frame_list = exception.values[0].stacktrace.frames
 
         assert len(frame_list) == 6
-        print(frame_list[3].to_json())
-        print(frame_list[5].to_json())
 
         def assert_abs_path(abs_path):
             # This makes the test assertion forward compatible with percent-encoded URLs

--- a/tests/relay_integration/lang/javascript/test_plugin.py
+++ b/tests/relay_integration/lang/javascript/test_plugin.py
@@ -1302,29 +1302,23 @@ class TestJavascriptIntegration(RelayStoreHelper):
         assert frame_list[2].function == "App"
         assert frame_list[2].lineno == 2
 
-        # TODO: 1:1014 in the minified source file is _unmapped_.
+        # 1:1014 in the minified source file is _unmapped_.
         # There are no tokens in the sourcemap for line 1.
-        # Previous versions of JS symbolication erroneously returned
-        # wrong values here. This needs to be enabled once Symbolicator
-        # is updated.
-        # assert frame_list[3].abs_path == "app:///dist.bundle.js"
-        # assert frame_list[3].function == "Object.<anonymous>"
-        # assert frame_list[3].lineno == 1
-        # assert frame_list[3].colno == 1014
+        assert frame_list[3].abs_path == "app:///dist.bundle.js"
+        assert frame_list[3].function == "Object.<anonymous>"
+        assert frame_list[3].lineno == 1
+        assert frame_list[3].colno == 1014
 
         assert_abs_path(frame_list[4].abs_path)
         assert frame_list[4].function == "__webpack_require__"
         assert frame_list[4].lineno == 19
 
-        # TODO: 18:63 in the minified source file is _unmapped_.
+        # 18:63 in the minified source file is _unmapped_.
         # There are no tokens in the sourcemap for line 18.
-        # Previous versions of JS symbolication erroneously returned
-        # wrong values here. This needs to be enabled once Symbolicator
-        # is updated.
-        # assert frame_list[5].abs_path == "app:///dist.bundle.js"
-        # assert frame_list[5].function == "Object.<anonymous>"
-        # assert frame_list[5].lineno == 18
-        # assert frame_list[5].colno ==  63
+        assert frame_list[5].abs_path == "app:///dist.bundle.js"
+        assert frame_list[5].function == "Object.<anonymous>"
+        assert frame_list[5].lineno == 18
+        assert frame_list[5].colno == 63
 
     @responses.activate
     def test_no_fetch_from_http(self) -> None:

--- a/tests/relay_integration/lang/javascript/test_plugin.py
+++ b/tests/relay_integration/lang/javascript/test_plugin.py
@@ -1316,7 +1316,7 @@ class TestJavascriptIntegration(RelayStoreHelper):
         # 18:63 in the minified source file is _unmapped_.
         # There are no tokens in the sourcemap for line 18.
         assert frame_list[5].abs_path == "app:///dist.bundle.js"
-        assert frame_list[5].function == "Object.<anonymous>"
+        assert frame_list[5].function == "<unknown>"
         assert frame_list[5].lineno == 18
         assert frame_list[5].colno == 63
 

--- a/tests/relay_integration/lang/javascript/test_plugin.py
+++ b/tests/relay_integration/lang/javascript/test_plugin.py
@@ -1281,6 +1281,8 @@ class TestJavascriptIntegration(RelayStoreHelper):
         frame_list = exception.values[0].stacktrace.frames
 
         assert len(frame_list) == 6
+        print(frame_list[3].to_json())
+        print(frame_list[5].to_json())
 
         def assert_abs_path(abs_path):
             # This makes the test assertion forward compatible with percent-encoded URLs


### PR DESCRIPTION
Follow-up to #97069. The test now correctly asserts that two frames are unmapped.