### PR TITLE
feat: allow passing `skipToken` to apiOptions

### DIFF
--- a/static/app/api/apiOptions.spec.tsx
+++ b/static/app/api/apiOptions.spec.tsx
@@ -1,4 +1,4 @@
-import {useQuery} from '@tanstack/react-query';
+import {skipToken, useQuery} from '@tanstack/react-query';
 import {expectTypeOf} from 'expect-type';
 
 import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
@@ -66,6 +66,20 @@ describe('apiOptions', () => {
     });
 
     expect(options.queryKey).toEqual(['/projects/456/123']);
+  });
+
+  test('should allow skipToken as path', () => {
+    function getOptions(id: string | null) {
+      return apiOptions.as<unknown>()('/projects/$id/', {
+        staleTime: 0,
+        path: id ? {id} : skipToken,
+      });
+    }
+
+    expect(getOptions('123').queryFn).toEqual(expect.any(Function));
+    expect(getOptions('123').queryKey).toEqual(['/projects/123/']);
+    expect(getOptions(null).queryFn).toEqual(skipToken);
+    expect(getOptions(null).queryKey).toEqual(['/projects/$id/']);
   });
 
   test('should extract content data per default', async () => {

--- a/static/app/api/apiOptions.ts
+++ b/static/app/api/apiOptions.ts
@@ -1,17 +1,17 @@
-import {queryOptions} from '@tanstack/react-query';
+import {queryOptions, type SkipToken, skipToken} from '@tanstack/react-query';
 
 import type {ApiResult} from 'sentry/api';
 import {fetchDataQuery, type QueryKeyEndpointOptions} from 'sentry/utils/queryClient';
 
 import type {MaybeApiPath} from './apiDefinition';
-import {
-  type ExtractPathParams,
-  getApiUrl,
-  type OptionalPathParams,
-  type PathParamOptions,
-} from './getApiUrl';
+import {type ExtractPathParams, getApiUrl, type OptionalPathParams} from './getApiUrl';
 
 type Options = QueryKeyEndpointOptions & {staleTime: number};
+
+type PathParamOptions<TApiPath extends string> =
+  ExtractPathParams<TApiPath> extends never
+    ? {path?: never}
+    : {path: Record<ExtractPathParams<TApiPath>, string | number> | SkipToken};
 
 const selectContent = <TData>(data: ApiResult<TData>) => data[0];
 export const selectWithHeaders =
@@ -39,19 +39,26 @@ function _apiOptions<
     ? [Options & {path?: never}]
     : [Options & PathParamOptions<TApiPath>]
 ) {
-  const url = getApiUrl(
-    path,
-    ...([
-      {
-        path: pathParams,
-      },
-    ] as OptionalPathParams<TApiPath>)
-  );
+  const url =
+    pathParams === skipToken
+      ? null
+      : getApiUrl(
+          path,
+          ...([
+            {
+              path: pathParams,
+            },
+          ] as OptionalPathParams<TApiPath>)
+        );
 
   return queryOptions({
     queryKey:
-      Object.keys(options).length > 0 ? ([url, options] as const) : ([url] as const),
-    queryFn: fetchDataQuery<TActualData>,
+      url === null
+        ? [path]
+        : Object.keys(options).length > 0
+          ? ([url, options] as const)
+          : ([url] as const),
+    queryFn: url === null ? skipToken : fetchDataQuery<TActualData>,
     staleTime,
     select: selectContent,
   });

--- a/static/app/api/getApiUrl.ts
+++ b/static/app/api/getApiUrl.ts
@@ -7,7 +7,7 @@ export type ExtractPathParams<TApiPath extends string> =
       ? Param
       : never;
 
-export type PathParamOptions<TApiPath extends string> =
+type PathParamOptions<TApiPath extends string> =
   ExtractPathParams<TApiPath> extends never
     ? {path?: never}
     : {path: Record<ExtractPathParams<TApiPath>, string | number>};


### PR DESCRIPTION
With this addition, we can pass `skipToken` instead of the path parameters to set a query to `disabled`. Without this, we would not be able to use `apiOptions` without creating a fallback empty string for parts that should disable the query. Example:

```
function projectOptions(id: string | null){
  return apiOptions('/projects/$id/, {
    path: { id }
  })
}
```

This won’t work at compile time, because `id` needs to be of type sting. If we pass { id: id ?? ''}, we're relying on the usage sites to pass `enabled: !!id`.

The solution to this problem is `skipToken`, which can be passed to to the `queryFn` to disable the query instead of `enabled`. With this PR, we can now do:

```
import { skipToken } from '@tanstack/react-query'

function projectOptions(id: string | null){
  return apiOptions('/projects/$id/, {
    path: id ? { id } : skipToken
  })
}
```

and the query will be enabled / disabled automatically depending on `id`, without needing the `enabled` option at all.