### PR TITLE
fix(ui): remove after pseudo element

### DIFF
--- a/static/app/views/organizationStats/index.tsx
+++ b/static/app/views/organizationStats/index.tsx
@@ -463,18 +463,6 @@ const DropdownDataCategory = styled(CompactSelect)`
   @media (min-width: ${p => p.theme.breakpoints.lg}) {
     grid-column: auto / span 1;
   }
-
-  &::after {
-    content: '';
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    pointer-events: none;
-    box-shadow: inset 0 0 0 1px ${p => p.theme.border};
-    border-radius: ${p => p.theme.borderRadius};
-  }
 `;
 
 const NewLayoutBody = styled('div')``;


### PR DESCRIPTION
that didn't do much in ui1, but creates a double border in ui2

| before | after |
|--------|--------|
| <img width="687" height="206" alt="Screenshot 2025-08-05 at 13 28 46" src="https://github.com/user-attachments/assets/093ea6e2-a29e-4ce3-8f2e-c06e048d9c01" /> | <img width="687" height="206" alt="Screenshot 2025-08-05 at 13 28 37" src="https://github.com/user-attachments/assets/20e77389-5047-421e-88fd-cfb8f0b824e3" /> |
| <img width="687" height="206" alt="Screenshot 2025-08-05 at 13 28 49" src="https://github.com/user-attachments/assets/ef37db92-9b10-4411-96b2-999f7266abd6" /> | <img width="687" height="206" alt="Screenshot 2025-08-05 at 13 28 31" src="https://github.com/user-attachments/assets/93708640-4672-449b-9dcc-f9967f8961a9" /> | 
