### PR TITLE
fix(ui2): remove padding-top from issues view tab panel

### DIFF
--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -917,4 +917,5 @@ const GroupTabPanels = styled(TabPanels)`
   display: flex;
   flex-direction: column;
   justify-content: stretch;
+  padding-top: 0;
 `;


### PR DESCRIPTION
note: there is no impact on the old UI, as there is no padding on the TabPanel.

before:

<img width="731" height="301" alt="Screenshot 2025-08-05 at 13 44 09" src="https://github.com/user-attachments/assets/addca69a-60a5-4e22-8820-7cfdddc50735" />

after:

<img width="731" height="301" alt="Screenshot 2025-08-05 at 13 43 31" src="https://github.com/user-attachments/assets/80822672-6768-4149-8a5a-ce5460bbc036" />
