### PR TITLE
Update deployBadge.tsx – some env names look the same

### DIFF
--- a/static/app/components/core/badge/deployBadge.tsx
+++ b/static/app/components/core/badge/deployBadge.tsx
@@ -15,6 +15,8 @@ interface DeployBadgeProps {
 }
 
 export function DeployBadge(props: DeployBadgeProps) {
+  const tooltipTitle = `${t('Open In Issues')}: ${props.deploy.environment}`;
+  
   return (
     <Link
       to={{
@@ -26,7 +28,7 @@ export function DeployBadge(props: DeployBadgeProps) {
         },
       }}
     >
-      <Tooltip title={t('Open In Issues')} skipWrapper>
+      <Tooltip title={tooltipTitle} skipWrapper>
         <TruncatedTag type="highlight">{props.deploy.environment}</TruncatedTag>
       </Tooltip>
     </Link>
@@ -35,4 +37,7 @@ export function DeployBadge(props: DeployBadgeProps) {
 
 const TruncatedTag = styled(Tag)`
   max-width: 96px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `;


### PR DESCRIPTION
Display full env names in the tooltip.

In our case the full env names are not visible. We use suffixes to differentiate them, so this gets lost. 

<img width="343" height="215" alt="Screenshot 2025-08-05 at 16 42 43" src="https://github.com/user-attachments/assets/b2e01f84-82c9-4ac6-8e63-4dc85b9a7af5" />

My proposition is to make them at least visible in the tooltip, without breaking the badge design. Not sure about the ellipsis cause it may also take some space. By the way, I didn't test it, so please check it out before considering a merge. Thanks for your great software!

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
