### PR TITLE
fix(test) Try to fix flaky test

### DIFF
--- a/tests/sentry/taskworker/test_config.py
+++ b/tests/sentry/taskworker/test_config.py
@@ -44,20 +44,20 @@ def test_taskworker_schedule_type(name: str, config: dict[str, Any]) -> None:
     ), f"Schedule {name} has a schedule of type {type(schedule)}"
 
 
-@pytest.mark.parametrize("config", list(settings.TASKWORKER_SCHEDULES.values()))
-def test_taskworker_schedule_parameters(config: dict[str, Any]) -> None:
-    (namespace, taskname) = config["task"].split(":")
-    task = taskregistry.get_task(namespace, taskname)
-    signature = inspect.signature(task)
+def test_taskworker_schedule_parameters() -> None:
+    for config in settings.TASKWORKER_SCHEDULES.values():
+        (namespace, taskname) = config["task"].split(":")
+        task = taskregistry.get_task(namespace, taskname)
+        signature = inspect.signature(task)
 
-    for parameter in signature.parameters.values():
-        # Skip *args and **kwargs
-        if parameter.kind in (parameter.VAR_POSITIONAL, parameter.VAR_KEYWORD):
-            continue
-        # The dynamic sampling tasks splice in a TaskContext via a decorator :(
-        if parameter.annotation == TaskContext:
-            continue
-        if parameter.default == parameter.empty:
-            raise AssertionError(
-                f"Parameter `{parameter.name}` for task `{task.name}` must have a default value."
-            )
+        for parameter in signature.parameters.values():
+            # Skip *args and **kwargs
+            if parameter.kind in (parameter.VAR_POSITIONAL, parameter.VAR_KEYWORD):
+                continue
+            # The dynamic sampling tasks splice in a TaskContext via a decorator :(
+            if parameter.annotation == TaskContext:
+                continue
+            if parameter.default == parameter.empty:
+                raise AssertionError(
+                    f"Parameter `{parameter.name}` for task `{task.name}` must have a default value."
+                )


### PR DESCRIPTION
The scheduler parameter validation test has been identified as flaky. Remove the use of parameterize() to see if that makes the test more stable.

Refs #96867
