### PR TITLE
chore(autofix): Collapse issue summary by default if autofix run has started

### DIFF
--- a/static/app/components/group/groupSummary.spec.tsx
+++ b/static/app/components/group/groupSummary.spec.tsx
@@ -118,8 +118,8 @@ describe('GroupSummary', function () {
       organization,
     });
 
-    // Should show loading placeholders. Currently we load the whatsWrong and possibleCause sections
-    expect(screen.getAllByTestId('loading-placeholder')).toHaveLength(2);
+    // Should show loading placeholders. Currently we load the headline, whatsWrong, and possibleCause sections
+    expect(screen.getAllByTestId('loading-placeholder')).toHaveLength(3);
   });
 
   it('shows error state', async function () {

--- a/static/app/components/group/groupSummary.tsx
+++ b/static/app/components/group/groupSummary.tsx
@@ -265,39 +265,41 @@ function GroupSummaryCollapsed({
   return (
     <div data-testid="group-summary-collapsed">
       {isError ? <div>{t('Error loading summary')}</div> : null}
-      <CollapsedContent>
-        <CollapsedHeader onClick={handleToggle}>
-          <CollapsedHeaderContent>
-            {isPending ? (
-              <Placeholder height="1.5rem" width="80%" />
-            ) : (
-              <Text size="md" bold ellipsis>
-                {data?.headline || t('Issue Summary')}
-              </Text>
-            )}
-            <ChevronIcon>
-              {isExpanded ? (
-                <IconChevron direction="up" size="sm" />
+      {!isError && (
+        <CollapsedContent>
+          <CollapsedHeader onClick={handleToggle}>
+            <CollapsedHeaderContent>
+              {isPending ? (
+                <Placeholder height="1.5rem" width="80%" />
               ) : (
-                <IconChevron direction="down" size="sm" />
+                <Text size="md" bold ellipsis>
+                  {data?.headline || t('Issue Summary')}
+                </Text>
               )}
-            </ChevronIcon>
-          </CollapsedHeaderContent>
-        </CollapsedHeader>
+              <ChevronIcon>
+                {isExpanded ? (
+                  <IconChevron direction="up" size="sm" />
+                ) : (
+                  <IconChevron direction="down" size="sm" />
+                )}
+              </ChevronIcon>
+            </CollapsedHeaderContent>
+          </CollapsedHeader>
 
-        <ExpandableContent isExpanded={isExpanded}>
-          <GroupSummaryFull
-            group={group}
-            project={project}
-            data={data}
-            isPending={isPending}
-            isError={isError}
-            preview={false}
-            setForceEvent={setForceEvent}
-            event={event}
-          />
-        </ExpandableContent>
-      </CollapsedContent>
+          <ExpandableContent isExpanded={isExpanded}>
+            <GroupSummaryFull
+              group={group}
+              project={project}
+              data={data}
+              isPending={isPending}
+              isError={isError}
+              preview={false}
+              setForceEvent={setForceEvent}
+              event={event}
+            />
+          </ExpandableContent>
+        </CollapsedContent>
+      )}
     </div>
   );
 }

--- a/static/app/components/group/groupSummary.tsx
+++ b/static/app/components/group/groupSummary.tsx
@@ -2,9 +2,17 @@ import {isValidElement, useEffect, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/core/button';
+import {Text} from 'sentry/components/core/text';
 import {makeAutofixQueryKey} from 'sentry/components/events/autofix/useAutofix';
 import Placeholder from 'sentry/components/placeholder';
-import {IconDocs, IconFatal, IconFocus, IconRefresh, IconSpan} from 'sentry/icons';
+import {
+  IconChevron,
+  IconDocs,
+  IconFatal,
+  IconFocus,
+  IconRefresh,
+  IconSpan,
+} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
@@ -104,10 +112,12 @@ export function GroupSummary({
   event,
   project,
   preview = false,
+  collapsed = false,
 }: {
   event: Event | null | undefined;
   group: Group;
   project: Project;
+  collapsed?: boolean;
   preview?: boolean;
 }) {
   const queryClient = useQueryClient();
@@ -149,16 +159,17 @@ export function GroupSummary({
   if (preview) {
     return <GroupSummaryPreview data={data} isPending={isPending} isError={isError} />;
   }
+
   return (
-    <GroupSummaryFull
+    <GroupSummaryCollapsed
       group={group}
       project={project}
+      event={event}
       data={data}
       isPending={isPending}
       isError={isError}
       setForceEvent={setForceEvent}
-      preview={preview}
-      event={event}
+      defaultCollapsed={collapsed}
     />
   );
 }
@@ -218,6 +229,75 @@ function GroupSummaryPreview({
           })}
         </InsightGrid>
       </Content>
+    </div>
+  );
+}
+
+function GroupSummaryCollapsed({
+  group,
+  project,
+  event,
+  data,
+  isPending,
+  setForceEvent,
+  isError,
+  defaultCollapsed = false,
+}: {
+  data: GroupSummaryData | undefined;
+  event: Event | null | undefined;
+  group: Group;
+  isError: boolean;
+  isPending: boolean;
+  project: Project;
+  setForceEvent: (v: boolean) => void;
+  defaultCollapsed?: boolean;
+}) {
+  const [isExpanded, setIsExpanded] = useState(!defaultCollapsed);
+
+  const handleToggle = () => {
+    setIsExpanded(!isExpanded);
+  };
+
+  useEffect(() => {
+    setIsExpanded(!defaultCollapsed);
+  }, [defaultCollapsed]);
+
+  return (
+    <div data-testid="group-summary-collapsed">
+      {isError ? <div>{t('Error loading summary')}</div> : null}
+      <CollapsedContent>
+        <CollapsedHeader onClick={handleToggle}>
+          <CollapsedHeaderContent>
+            {isPending ? (
+              <Placeholder height="1.5rem" width="80%" />
+            ) : (
+              <Text size="md" bold ellipsis>
+                {data?.headline || t('Issue Summary')}
+              </Text>
+            )}
+            <ChevronIcon>
+              {isExpanded ? (
+                <IconChevron direction="up" size="sm" />
+              ) : (
+                <IconChevron direction="down" size="sm" />
+              )}
+            </ChevronIcon>
+          </CollapsedHeaderContent>
+        </CollapsedHeader>
+
+        <ExpandableContent isExpanded={isExpanded}>
+          <GroupSummaryFull
+            group={group}
+            project={project}
+            data={data}
+            isPending={isPending}
+            isError={isError}
+            preview={false}
+            setForceEvent={setForceEvent}
+            event={event}
+          />
+        </ExpandableContent>
+      </CollapsedContent>
     </div>
   );
 }
@@ -417,4 +497,42 @@ const ResummarizeWrapper = styled('div')`
   align-items: center;
   margin-top: ${space(1)};
   flex-shrink: 0;
+`;
+
+const CollapsedContent = styled('div')`
+  display: flex;
+  flex-direction: column;
+  position: relative;
+`;
+
+const CollapsedHeader = styled('div')`
+  cursor: pointer;
+  transition: all 0.2s ease-in-out;
+`;
+
+const CollapsedHeaderContent = styled('div')`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: ${space(1)};
+`;
+
+const ChevronIcon = styled('div')`
+  display: flex;
+  align-items: center;
+  color: ${p => p.theme.subText};
+  transition: transform 0.2s ease-in-out;
+  flex-shrink: 0;
+`;
+
+const ExpandableContent = styled('div')<{isExpanded: boolean}>`
+  max-height: ${p => (p.isExpanded ? '1000px' : '0')};
+  overflow: hidden;
+  transition: max-height 0.3s ease-in-out;
+
+  ${p =>
+    p.isExpanded &&
+    `
+    padding-top: ${p.theme.space.lg};
+  `}
 `;

--- a/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
@@ -306,7 +306,12 @@ export function SeerDrawer({group, project, event}: SeerDrawerProps) {
             />
             {aiConfig.hasSummary && (
               <StyledCard>
-                <GroupSummary group={group} event={event} project={project} />
+                <GroupSummary
+                  group={group}
+                  event={event}
+                  project={project}
+                  collapsed={!!autofixData}
+                />
               </StyledCard>
             )}
             {aiConfig.hasAutofix && (
@@ -397,6 +402,7 @@ const StyledCard = styled('div')`
   border-radius: ${p => p.theme.borderRadius};
   padding: ${space(2)} ${space(2)};
   box-shadow: ${p => p.theme.dropShadowMedium};
+  transition: all 0.3s ease-in-out;
 `;
 
 const SeerDrawerContainer = styled('div')`


### PR DESCRIPTION
To reduce visual noise, collapse issue summary by default when an autofix run is present. Adds the summary headline as a header.

<img width="757" height="726" alt="Screenshot 2025-08-05 at 8 01 58 AM" src="https://github.com/user-attachments/assets/27bdd928-acbc-4450-97d0-0f4810709635" />
<img width="781" height="778" alt="Screenshot 2025-08-05 at 8 03 12 AM" src="https://github.com/user-attachments/assets/68639c22-1ab8-4adc-a0b5-24b97d66c0ef" />
