### PR TITLE
fix(typing): add return types to "special" methods

### DIFF
--- a/src/bitfield/models.py
+++ b/src/bitfield/models.py
@@ -18,7 +18,7 @@ class BitFieldFlags:
             raise ValueError("Too many flags")
         self._flags = flags
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return repr(self._flags)
 
     def __iter__(self):

--- a/src/bitfield/types.py
+++ b/src/bitfield/types.py
@@ -181,7 +181,7 @@ class BitHandler:
 
     __getitem__ = __getattr__
 
-    def __setattr__(self, key, value):
+    def __setattr__(self, key, value) -> None:
         if key.startswith("_"):
             return object.__setattr__(self, key, value)
         if key not in self._keys:

--- a/src/bitfield/types.py
+++ b/src/bitfield/types.py
@@ -138,7 +138,7 @@ class BitHandler:
             ", ".join(f"{k}={self.get_bit(n).is_set}" for n, k in enumerate(self._keys)),
         )
 
-    def __str__(self):
+    def __str__(self) -> str:
         return str(self._value)
 
     def __int__(self):

--- a/src/bitfield/types.py
+++ b/src/bitfield/types.py
@@ -11,7 +11,7 @@ class Bit:
         if not self.is_set:
             self.mask = ~self.mask
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<%s: number=%d, is_set=%s>" % (self.__class__.__name__, self.number, self.is_set)
 
     def __int__(self):
@@ -132,7 +132,7 @@ class BitHandler:
     def __cmp__(self, other):
         return cmp(self._value, other)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<{}: {}>".format(
             self.__class__.__name__,
             ", ".join(f"{k}={self.get_bit(n).is_set}" for n, k in enumerate(self._keys)),

--- a/src/sentry/api/client.py
+++ b/src/sentry/api/client.py
@@ -18,7 +18,7 @@ class ApiError(Exception):
         self.status_code = status_code
         self.body = body
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"status={self.status_code} body={self.body}"
 
     def __repr__(self):

--- a/src/sentry/api/client.py
+++ b/src/sentry/api/client.py
@@ -21,7 +21,7 @@ class ApiError(Exception):
     def __str__(self) -> str:
         return f"status={self.status_code} body={self.body}"
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<ApiError: {self}>"
 
 

--- a/src/sentry/api/endpoints/project_artifact_bundle_files.py
+++ b/src/sentry/api/endpoints/project_artifact_bundle_files.py
@@ -44,7 +44,7 @@ class ArtifactBundleSource:
             ]
         )
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self.sorted_and_filtered_files)
 
     def __getitem__(self, range):

--- a/src/sentry/api/endpoints/project_release_files.py
+++ b/src/sentry/api/endpoints/project_release_files.py
@@ -205,7 +205,7 @@ class ArtifactSource:
 
         return files
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self.sorted_and_filtered_files)
 
     def __getitem__(self, range):

--- a/src/sentry/db/models/fields/node.py
+++ b/src/sentry/db/models/fields/node.py
@@ -65,7 +65,7 @@ class NodeData(MutableMapping[str, Any]):
     def __len__(self):
         return len(self.data)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         cls_name = type(self).__name__
         if self._node_data:
             return f"<{cls_name}: id={self.id} data={self._node_data!r}>"

--- a/src/sentry/db/models/fields/node.py
+++ b/src/sentry/db/models/fields/node.py
@@ -62,7 +62,7 @@ class NodeData(MutableMapping[str, Any]):
     def __iter__(self):
         return iter(self.data)
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self.data)
 
     def __repr__(self) -> str:

--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -596,7 +596,7 @@ class Event(BaseEvent):
         state.pop("_groups_cache", None)
         return state
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<sentry.eventstore.models.Event at 0x{:x}: event_id={}>".format(
             id(self), self.event_id
         )

--- a/src/sentry/exceptions.py
+++ b/src/sentry/exceptions.py
@@ -17,7 +17,7 @@ class InvalidOrigin(InvalidRequest):
     def __init__(self, origin):
         self.origin = origin
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "Invalid origin: '%s'" % self.origin
 
 

--- a/src/sentry/integrations/messaging/commands.py
+++ b/src/sentry/integrations/messaging/commands.py
@@ -46,7 +46,7 @@ class CommandSlug:
         cmd_tokens = tuple(token.casefold() for token in cmd_prefix)
         return self.tokens == cmd_tokens
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         joined_tokens = " ".join(self.tokens)
         return f"{type(self).__name__}({joined_tokens!r})"
 

--- a/src/sentry/interfaces/base.py
+++ b/src/sentry/interfaces/base.py
@@ -99,7 +99,7 @@ class Interface:
     def __getattr__(self, name):
         return self._data[name]
 
-    def __setattr__(self, name, value):
+    def __setattr__(self, name, value) -> None:
         if name == "_data":
             self.__dict__["_data"] = value
         else:

--- a/src/sentry/interfaces/exception.py
+++ b/src/sentry/interfaces/exception.py
@@ -402,7 +402,7 @@ class Exception(Interface):
     def __iter__(self):
         return iter(self.exceptions())
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self.exceptions())
 
     @classmethod

--- a/src/sentry/lang/native/applecrashreport.py
+++ b/src/sentry/lang/native/applecrashreport.py
@@ -71,7 +71,7 @@ class AppleCrashReport:
                 self.image_addrs_to_vmaddrs[new_image["image_addr"]] = new_image["image_vmaddr"]
 
     @sentry_sdk.trace
-    def __str__(self):
+    def __str__(self) -> str:
         rv = []
         rv.append(self._get_meta_header())
         rv.append(self._get_exception_info())

--- a/src/sentry/lang/native/error.py
+++ b/src/sentry/lang/native/error.py
@@ -76,7 +76,7 @@ class SymbolicationFailed(Exception):
             rv["image_arch"] = self.image_arch
         return rv
 
-    def __str__(self):
+    def __str__(self) -> str:
         rv = []
         if self.type is not None:
             rv.append("%s: " % self.type)

--- a/src/sentry/models/apiapplication.py
+++ b/src/sentry/models/apiapplication.py
@@ -80,7 +80,7 @@ class ApiApplication(Model):
 
     __repr__ = sane_repr("name", "owner_id")
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.name
 
     def delete(self, *args, **kwargs):

--- a/src/sentry/models/apigrant.py
+++ b/src/sentry/models/apigrant.py
@@ -87,7 +87,7 @@ class ApiGrant(Model):
         app_label = "sentry"
         db_table = "sentry_apigrant"
 
-    def __str__(self):
+    def __str__(self) -> str:
         return (
             f"api_grant_id={self.id}, user_id={self.user.id}, application_id={self.application.id}"
         )

--- a/src/sentry/models/apikey.py
+++ b/src/sentry/models/apikey.py
@@ -61,7 +61,7 @@ class ApiKey(ReplicatedControlModel, HasApiScopes):
             api_key=serialize_api_key(self), region_name=region_name
         )
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"api_key_id={self.id}, status={self.status}"
 
     @classmethod

--- a/src/sentry/models/apiscopes.py
+++ b/src/sentry/models/apiscopes.py
@@ -46,7 +46,7 @@ class ApiScopes(Sequence):
     def __getitem__(self, value):
         return self.scopes.__getitem__(value)
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self.scopes)
 
     def __repr__(self) -> str:

--- a/src/sentry/models/apiscopes.py
+++ b/src/sentry/models/apiscopes.py
@@ -49,7 +49,7 @@ class ApiScopes(Sequence):
     def __len__(self):
         return len(self.scopes)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return self.scopes.__repr__()
 
 

--- a/src/sentry/models/apitoken.py
+++ b/src/sentry/models/apitoken.py
@@ -138,7 +138,7 @@ class ApiToken(ReplicatedControlModel, HasApiScopes):
 
     __repr__ = sane_repr("user_id", "token", "application_id")
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"token_id={force_str(self.id)}"
 
     def _set_plaintext_token(self, token: str) -> None:

--- a/src/sentry/models/authidentity.py
+++ b/src/sentry/models/authidentity.py
@@ -64,7 +64,7 @@ class AuthIdentity(ReplicatedControlModel):
 
     __repr__ = sane_repr("user_id", "auth_provider_id")
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.ident
 
     def get_audit_log_data(self):

--- a/src/sentry/models/authidentityreplica.py
+++ b/src/sentry/models/authidentityreplica.py
@@ -36,7 +36,7 @@ class AuthIdentityReplica(Model):
 
     __repr__ = sane_repr("user_id", "auth_provider_id")
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.ident
 
     def get_audit_log_data(self):

--- a/src/sentry/models/authprovider.py
+++ b/src/sentry/models/authprovider.py
@@ -86,7 +86,7 @@ class AuthProvider(ReplicatedControlModel):
 
     __repr__ = sane_repr("organization_id", "provider")
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.provider
 
     def get_provider(self):

--- a/src/sentry/models/authproviderreplica.py
+++ b/src/sentry/models/authproviderreplica.py
@@ -44,7 +44,7 @@ class AuthProviderReplica(Model):
 
     __repr__ = sane_repr("organization_id", "provider")
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.provider
 
     def get_provider(self):

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -648,7 +648,7 @@ class Group(Model):
 
     __repr__ = sane_repr("project_id")
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"({self.times_seen}) {self.title}"
 
     def save(self, *args, **kwargs):

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -62,7 +62,7 @@ class OrganizationStatus(IntEnum):
     # alias for OrganizationStatus.ACTIVE
     VISIBLE = 0
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.name
 
     @property
@@ -231,7 +231,7 @@ class Organization(ReplicatedRegionModel):
 
         return cls.objects.filter(status=OrganizationStatus.ACTIVE)[0]
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"{self.name} ({self.slug})"
 
     snowflake_redis_key = "organization_snowflake_key"

--- a/src/sentry/models/orgauthtoken.py
+++ b/src/sentry/models/orgauthtoken.py
@@ -65,7 +65,7 @@ class OrgAuthToken(ReplicatedControlModel):
 
     __repr__ = sane_repr("organization_id", "token_hashed")
 
-    def __str__(self):
+    def __str__(self) -> str:
         return force_str(self.token_hashed)
 
     def get_audit_log_data(self):

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -369,7 +369,7 @@ class Project(Model):
 
     __repr__ = sane_repr("team_id", "name", "slug", "organization_id")
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"{self.name} ({self.slug})"
 
     def next_short_id(self, delta: int = 1) -> int:

--- a/src/sentry/models/projectkey.py
+++ b/src/sentry/models/projectkey.py
@@ -146,7 +146,7 @@ class ProjectKey(Model):
 
     __repr__ = sane_repr("project_id", "public_key")
 
-    def __str__(self):
+    def __str__(self) -> str:
         return str(self.public_key)
 
     @classmethod

--- a/src/sentry/models/team.py
+++ b/src/sentry/models/team.py
@@ -146,7 +146,7 @@ class Team(ReplicatedRegionModel):
     def class_name(self):
         return "Team"
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"{self.name} ({self.slug})"
 
     def handle_async_replication(self, shard_identifier: int) -> None:

--- a/src/sentry/net/http.py
+++ b/src/sentry/net/http.py
@@ -245,7 +245,7 @@ class UnixHTTPConnection(HTTPConnection):
 class UnixHTTPConnectionPool(HTTPConnectionPool):
     ConnectionCls = UnixHTTPConnection
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"{type(self).__name__}(host={self.host!r})"
 
 

--- a/src/sentry/plugins/providers/integration_repository.py
+++ b/src/sentry/plugins/providers/integration_repository.py
@@ -51,7 +51,7 @@ class RepoExistsError(SentryAPIException):
         super().__init__(code=code, message=message, detail=detail, **kwargs)
         self.repos = repos
 
-    def __str__(self):
+    def __str__(self) -> str:
         if self.repos:
             return f"Repositories already exist: {', '.join(repo['name'] for repo in self.repos)}"
         return "Repositories already exist."

--- a/src/sentry/relocation/models/relocation.py
+++ b/src/sentry/relocation/models/relocation.py
@@ -90,7 +90,7 @@ class Relocation(DefaultFieldsModelExisting):
         def get_choices(cls) -> list[tuple[int, str]]:
             return [(key.value, key.name) for key in cls]
 
-        def __str__(self):
+        def __str__(self) -> str:
             if self.name == "SELF_HOSTED":
                 return "self-hosted"
             elif self.name == "SAAS_TO_SAAS":
@@ -230,7 +230,7 @@ class RelocationFile(DefaultFieldsModelExisting):
         def get_choices(cls) -> list[tuple[int, str]]:
             return [(key.value, key.name) for key in cls]
 
-        def __str__(self):
+        def __str__(self) -> str:
             if self.name == "RAW_USER_DATA":
                 return "raw-relocation-data"
             elif self.name == "NORMALIZED_USER_DATA":

--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -72,7 +72,7 @@ class UniqueConditionQuery(NamedTuple):
     environment_id: int
     comparison_interval: str | None = None
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             f"<UniqueConditionQuery:\nid: {self.cls_id},\ninterval: {self.interval},\nenv id: {self.environment_id},\n"
             f"comp interval: {self.comparison_interval}\n>"
@@ -84,7 +84,7 @@ class DataAndGroups(NamedTuple):
     group_ids: set[int]
     rule_id: int | None = None
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             f"<DataAndGroups data: {self.data} group_ids: {self.group_ids} rule_id: {self.rule_id}>"
         )

--- a/src/sentry/sentry_apps/models/servicehook.py
+++ b/src/sentry/sentry_apps/models/servicehook.py
@@ -99,7 +99,7 @@ class ServiceHook(Model):
         if self.guid is None:
             self.guid = uuid4().hex
 
-    def __str__(self):
+    def __str__(self) -> str:
         return str(self.guid)
 
     def build_signature(self, body):

--- a/src/sentry/snuba/sessions_v2.py
+++ b/src/sentry/snuba/sessions_v2.py
@@ -392,7 +392,7 @@ class QueryDefinition:
                 if condition.lhs.function == "match":
                     raise InvalidField("Invalid condition: wildcard search is not supported")
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"{self.__class__.__name__}({repr(self.__dict__)})"
 
 

--- a/src/sentry/stacktraces/processing.py
+++ b/src/sentry/stacktraces/processing.py
@@ -60,7 +60,7 @@ class ProcessableFrame:
         self.cache_value = None
         self.processable_frames = processable_frames
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<ProcessableFrame {!r} #{!r} at {!r}>".format(
             self.frame.get("function") or "unknown",
             self.idx,

--- a/src/sentry/tasks/summaries/utils.py
+++ b/src/sentry/tasks/summaries/utils.py
@@ -54,7 +54,7 @@ class OrganizationReportContext:
             else:
                 self.projects_context_map[project.id] = ProjectContext(project)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return self.projects_context_map.__repr__()
 
 
@@ -91,7 +91,7 @@ class ProjectContext:
         # Dictionary of { timestamp: count }
         self.replay_count_by_day = {}
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "\n".join(
             [
                 f"{self.key_errors_by_group}, ",

--- a/src/sentry/utils/datastructures.py
+++ b/src/sentry/utils/datastructures.py
@@ -45,7 +45,7 @@ class BidirectionalMapping(MutableMapping):
     def __iter__(self):
         return iter(self.__data)
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self.__data)
 
     def get_key(self, value, default=__unset__):

--- a/src/sentry/utils/marketo_client.py
+++ b/src/sentry/utils/marketo_client.py
@@ -21,7 +21,7 @@ class MarketoError(Exception):
         self.code = error["code"]
         self.message = error["message"]
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"MarketoError: {self.code} - {self.message}"
 
 

--- a/src/sentry/utils/retries.py
+++ b/src/sentry/utils/retries.py
@@ -22,7 +22,7 @@ class RetryException(Exception):
     def __reduce__(self):
         return RetryException, (self.message, self.exception)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return force_bytes(self.message, errors="replace")
 
     def __repr__(self):

--- a/src/sentry/utils/retries.py
+++ b/src/sentry/utils/retries.py
@@ -25,7 +25,7 @@ class RetryException(Exception):
     def __str__(self) -> str:
         return force_bytes(self.message, errors="replace")
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<{type(self).__name__}: {self.message!r}>"
 
 

--- a/src/social_auth/exceptions.py
+++ b/src/social_auth/exceptions.py
@@ -6,7 +6,7 @@ class SocialAuthBaseException(ValueError):
 
 
 class BackendError(SocialAuthBaseException):
-    def __str__(self):
+    def __str__(self) -> str:
         return gettext("Backend error: %s") % super().__str__()
 
 
@@ -14,7 +14,7 @@ class WrongBackend(BackendError):
     def __init__(self, backend_name):
         self.backend_name = backend_name
 
-    def __str__(self):
+    def __str__(self) -> str:
         return gettext('Incorrect authentication service "%s"') % self.backend_name
 
 
@@ -23,7 +23,7 @@ class StopPipeline(SocialAuthBaseException):
     Raise this exception to stop the rest of the pipeline process.
     """
 
-    def __str__(self):
+    def __str__(self) -> str:
         return gettext("Stop pipeline")
 
 
@@ -38,7 +38,7 @@ class AuthException(SocialAuthBaseException):
 class AuthFailed(AuthException):
     """Auth process failed for some reason."""
 
-    def __str__(self):
+    def __str__(self) -> str:
         if self.args == ("access_denied",):
             return gettext("Authentication process was cancelled")
         else:
@@ -48,14 +48,14 @@ class AuthFailed(AuthException):
 class AuthCanceled(AuthException):
     """Auth process was canceled by user."""
 
-    def __str__(self):
+    def __str__(self) -> str:
         return gettext("Authentication process canceled")
 
 
 class AuthUnknownError(AuthException):
     """Unknown auth process error."""
 
-    def __str__(self):
+    def __str__(self) -> str:
         err = "An unknown error happened while authenticating %s"
         return gettext(err) % super().__str__()
 
@@ -63,7 +63,7 @@ class AuthUnknownError(AuthException):
 class AuthTokenError(AuthException):
     """Auth token error."""
 
-    def __str__(self):
+    def __str__(self) -> str:
         msg = super().__str__()
         return gettext("Token error: %s") % msg
 
@@ -75,26 +75,26 @@ class AuthMissingParameter(AuthException):
         self.parameter = parameter
         super().__init__(backend, *args, **kwargs)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return gettext("Missing needed parameter %s") % self.parameter
 
 
 class AuthStateMissing(AuthException):
     """State parameter is incorrect."""
 
-    def __str__(self):
+    def __str__(self) -> str:
         return gettext("Session value state missing.")
 
 
 class AuthStateForbidden(AuthException):
     """State parameter is incorrect."""
 
-    def __str__(self):
+    def __str__(self) -> str:
         return gettext("Wrong state parameter given.")
 
 
 class AuthTokenRevoked(AuthException):
     """User revoked the access_token in the provider."""
 
-    def __str__(self):
+    def __str__(self) -> str:
         return gettext("User revoke access to the token")

--- a/src/social_auth/models.py
+++ b/src/social_auth/models.py
@@ -36,7 +36,7 @@ class UserSocialAuth(models.Model):
         unique_together = ("provider", "uid", "user")
         app_label = "social_auth"
 
-    def __str__(self):
+    def __str__(self) -> str:
         """Return associated user unicode representation"""
         return f"{self.user} - {self.provider.title()}"
 

--- a/tests/sentry/api/test_utils.py
+++ b/tests/sentry/api/test_utils.py
@@ -200,7 +200,7 @@ class HandleQueryErrorsTest(APITestCase):
 
     def test_handle_postgres_timeout(self) -> None:
         class TimeoutError(OperationalError):
-            def __str__(self):
+            def __str__(self) -> str:
                 return "canceling statement due to statement timeout"
 
         try:
@@ -214,7 +214,7 @@ class HandleQueryErrorsTest(APITestCase):
 
     def test_handle_postgres_user_cancel(self) -> None:
         class UserCancelError(OperationalError):
-            def __str__(self):
+            def __str__(self) -> str:
                 return "canceling statement due to user request"
 
         try:


### PR DESCRIPTION
# What

Some of Python's "special" methods will always have the same return type — e.g. any reasonable implementation of `__str__` will always return a `str`.  Let's add return types to these special methods.

Functions modified:
* `__str__`
* `__repr__`
* `__setattr__`
* `__len__`

# How

Ran the following commands:
```
rg -ls 'def __str__\(self\):' | xargs sed -i '' -e 's/def __str__(self):/def __str__(self) -> str:/'
rg -ls 'def __repr__\(self\):' | xargs sed -i '' -e 's/def __repr__(self):/def __repr__(self) -> str:/'
rg -ls 'def __setattr__\(self, [^\)]+\):' | xargs sed -i '' -E -e 's/def __setattr__\(self(, [^\)]+)\):/def __setattr__(self\1) -> None:/'
rg -ls 'def __len__\(self\):' | xargs sed -i '' -e 's/def __len__(self):/def __len__(self) -> int:/'
```

No manual changes were required to make `mypy` pass.

# Further Work

> Why not extend this to the most common special method — `__init__`, which should always return `None`?

`mypy` special-cases `__init__`. If we add a return type, `mypy` will start inferring types about all the properties set during initialization... sometimes incorrectly. (e.g. if you set a property to `None`, `mypy` will complain about any later non-`None` assignment). I have that on deck for a rainy day, but I decided to split out the low-manual-work changes into this separate PR.