### PR TITLE
fix(grid-editable): remove grid-template-columns style

### DIFF
--- a/static/app/components/tables/gridEditable/styles.tsx
+++ b/static/app/components/tables/gridEditable/styles.tsx
@@ -84,8 +84,6 @@ export const Grid = styled('table')<{
   position: inherit;
   display: grid;
 
-  /* Overwritten by GridEditable.setGridTemplateColumns */
-  grid-template-columns: repeat(auto-fill, minmax(50px, auto));
   box-sizing: border-box;
   border-collapse: collapse;
   margin: 0;


### PR DESCRIPTION
### Changes

Removes the `grid-template-columns` style which causes Safari page crashes (e.g., https://sentry.sentry.io/dashboard/138600/?project=11276&statsPeriod=24h when the `dashboards-use-widget-table-visualization` is enabled)

The style doesn't affect the UI since it gets overridden by `setGridTemplateColumns` on mount.