### PR TITLE
chore(access-logs): trace access logs via sentry exception option

### DIFF
--- a/src/sentry/middleware/access_log.py
+++ b/src/sentry/middleware/access_log.py
@@ -132,7 +132,7 @@ def _create_api_access_log(
         metrics.incr("middleware.access_log.created")
 
         if in_random_rollout("issues.log-access-logs"):
-            sentry_sdk.capture_exception(level="info")
+            sentry_sdk.capture_exception(level="debug")
 
     except Exception:
         api_access_logger.exception("api.access: Error capturing API access logs")

--- a/src/sentry/middleware/access_log.py
+++ b/src/sentry/middleware/access_log.py
@@ -5,6 +5,7 @@ import time
 from collections.abc import Callable
 from dataclasses import dataclass
 
+import sentry_sdk
 from django.conf import settings
 from django.utils.encoding import force_str
 from rest_framework.authentication import get_authorization_header
@@ -12,6 +13,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.auth.services.auth import AuthenticatedToken
+from sentry.options.rollout import in_random_rollout
 from sentry.types.ratelimit import RateLimitMeta, SnubaRateLimitMeta
 from sentry.utils import metrics
 
@@ -128,6 +130,10 @@ def _create_api_access_log(
             log_metrics["token_last_characters"] = force_str(auth[1])[-4:]
         api_access_logger.info("api.access", extra=log_metrics)
         metrics.incr("middleware.access_log.created")
+
+        if in_random_rollout("issues.log-access-logs"):
+            sentry_sdk.capture_exception(Exception("api.access", extra=log_metrics))
+
     except Exception:
         api_access_logger.exception("api.access: Error capturing API access logs")
 

--- a/src/sentry/middleware/access_log.py
+++ b/src/sentry/middleware/access_log.py
@@ -132,7 +132,7 @@ def _create_api_access_log(
         metrics.incr("middleware.access_log.created")
 
         if in_random_rollout("issues.log-access-logs"):
-            sentry_sdk.capture_exception(level="debug")
+            sentry_sdk.capture_message("Acesss log created", level="debug")
 
     except Exception:
         api_access_logger.exception("api.access: Error capturing API access logs")

--- a/src/sentry/middleware/access_log.py
+++ b/src/sentry/middleware/access_log.py
@@ -132,7 +132,7 @@ def _create_api_access_log(
         metrics.incr("middleware.access_log.created")
 
         if in_random_rollout("issues.log-access-logs"):
-            sentry_sdk.capture_exception(Exception("api.access", extra=log_metrics))
+            sentry_sdk.capture_exception(level="info")
 
     except Exception:
         api_access_logger.exception("api.access: Error capturing API access logs")

--- a/src/sentry/middleware/access_log.py
+++ b/src/sentry/middleware/access_log.py
@@ -131,8 +131,8 @@ def _create_api_access_log(
         api_access_logger.info("api.access", extra=log_metrics)
         metrics.incr("middleware.access_log.created")
 
-        if in_random_rollout("issues.log-access-logs"):
-            sentry_sdk.capture_message("Acesss log created", level="debug")
+        if in_random_rollout("issues.log-access-logs") and not org_id:
+            sentry_sdk.capture_message("Acesss log created without org_id", level="debug")
 
     except Exception:
         api_access_logger.exception("api.access: Error capturing API access logs")

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3434,6 +3434,8 @@ register(
 # Enable enhancing access logs with snuba responses
 register("issues.use-snuba-error-data", type=Float, default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
+register("issues.log-access-logs", type=Float, default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
+
 # Use "first-seen" group instead of "most-seen" group when merging
 register(
     "issues.merging.first-seen",


### PR DESCRIPTION
Send a (very very) small portion of API access log stack traces to Sentry. We're having difficulty debugging [missing organization id](https://linear.app/getsentry/issue/ID-805/fix-missing-organization-id-in-api-access-logs) from access logs, and so we want to send the stack traces to check if the request and request auth have the correct fields.

Planning to roll this out at 0.0001 — with [~10M access logs created per hour](https://app.datadoghq.com/metric/explorer?fromUser=false&graph_layout=stacked&start=1754407289153&end=1754410889153&paused=false#N4Ig7glgJg5gpgFxALlAGwIYE8D2BXJVEADxQEYAaELcqyKBAC1pEbghkcLIF8qo4AMwgA7CAgg4RKUAiwAHOChASAtnADOcAE4RNIKtrgBHPJoQaUAbVBGN8qVoD6gnNtUZCKiOq279VKY6epbINiAiGOrKQdpYZAYgUJ4YThr42gDGSsgg6gi6mZaBZnHKGniqyFoiBVgAdKrQUGhwYBhG9RiZ2RoaTmg4MPWZRp5wUMAAVDxd-Zn4tQAUAJQgPAC6VK7ueJih4TuqexjKmZUVqkux8WubVBpyrTIg8hitCAg5SUNOmfsaCCZRJoURwJxyRTlHCgqAgsFOehMZQiNweNDrfgQeyYLAQhTfUEiJSbHh8EA48QAYSkwhgKBEezQPCAA) we should get ~1000 access logs an hour, or ~16 a minute — should be very doable by sentry.