### PR TITLE
fix(trials): Don't force trial if already on trial plan

### DIFF
--- a/static/gsApp/components/gsBanner.spec.tsx
+++ b/static/gsApp/components/gsBanner.spec.tsx
@@ -943,6 +943,40 @@ describe('GSBanner', function () {
     expect(openForcedTrialModal).toHaveBeenCalled();
   });
 
+  it('does not automatically start forced trial if already on a trial', async function () {
+    const organization = OrganizationFixture({
+      access: ['org:billing'],
+    });
+
+    const subscription = SubscriptionFixture({
+      plan: 'am1_f',
+      organization,
+      totalLicenses: 1,
+      usedLicenses: 2,
+      isTrial: true,
+      isForcedTrial: false,
+    });
+
+    SubscriptionStore.set(organization.slug, subscription);
+
+    const mockForceTrial = MockApiClient.addMockResponse({
+      method: 'POST',
+      url: `/organizations/${organization.slug}/over-member-limit-trial/`,
+      body: {},
+    });
+
+    const {container} = render(<GSBanner organization={organization} />, {
+      organization,
+    });
+
+    // wait for requests to finish
+    await act(tick);
+    expect(container).toBeEmptyDOMElement();
+
+    expect(mockForceTrial).not.toHaveBeenCalled();
+    expect(openForcedTrialModal).not.toHaveBeenCalled();
+  });
+
   it('automatically starts forced trial for restricted integration', async function () {
     const organization = OrganizationFixture({
       access: ['org:billing'],

--- a/static/gsApp/components/gsBanner.tsx
+++ b/static/gsApp/components/gsBanner.tsx
@@ -582,7 +582,8 @@ class GSBanner extends Component<Props, State> {
     // check for required conditions of triggering a forced trial of any type
     const considerTrigger =
       subscription.canSelfServe && // must be self serve
-      subscription.isFree &&
+      subscription.isFree && // must be on Developer plan
+      !subscription.isTrial && // don't trigger if already on a trial
       hasPerformance(subscription.planDetails) &&
       !subscription.isExemptFromForcedTrial && // orgs who ever did enterprise trials are exempt
       !user?.isSuperuser; // never trigger for superusers


### PR DESCRIPTION
We shouldn't try to force a trial if the customer is already on a trial, even if that trial is a plan trial and not a subscription trial.

Prevents [SENTRY-4AY5](https://sentry.sentry.io/issues/6791100926/?alert_rule_id=1661436&alert_type=issue&environment=prod&notification_uuid=63ce6fa6-b1a1-4d21-90cf-797b8425794d&project=1&referrer=slack)