### PR TITLE
:wrench: chore: don't raise if integration is missing for pagerduty netric alert notifications

### DIFF
--- a/src/sentry/integrations/pagerduty/utils.py
+++ b/src/sentry/integrations/pagerduty/utils.py
@@ -4,7 +4,6 @@ import logging
 from typing import Any, TypedDict
 
 from django.db import router, transaction
-from django.http import Http404
 
 from sentry.incidents.models.incident import IncidentStatus
 from sentry.incidents.typings.metric_detector import (
@@ -178,7 +177,7 @@ def send_incident_alert_notification(
                 "organization_id": organization_id,
             },
         )
-        raise Http404
+        return False
 
     org_integration_id: int | None = None
     if org_integration:

--- a/tests/sentry/incidents/action_handlers/test_pagerduty.py
+++ b/tests/sentry/incidents/action_handlers/test_pagerduty.py
@@ -2,9 +2,7 @@ import uuid
 from unittest.mock import MagicMock, patch
 
 import orjson
-import pytest
 import responses
-from django.http import Http404
 from urllib3.response import HTTPResponse
 
 from sentry.analytics.events.alert_sent import AlertSentEvent
@@ -205,15 +203,6 @@ class PagerDutyActionHandlerTest(FireTest):
 
     def test_fire_metric_alert(self) -> None:
         self.run_fire_test()
-
-    def test_fire_metric_alert_no_org_integration(self) -> None:
-        # We've had orgs in prod that have alerts referencing
-        # pagerduty integrations that no longer attached to the org.
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            self.integration.organizationintegration_set.first().delete()
-
-        with pytest.raises(Http404):
-            self.run_fire_test()
 
     def test_fire_metric_alert_multiple_services(self) -> None:
         service = [


### PR DESCRIPTION
this currently happens when a action/rule/alert rule trigger action exists but the integration has been uninstalled. instead of creating a bunch of sentry issues, lets return False, which will signal every callee that we didn't not send a notification.

Closes ECO-944