### PR TITLE
fix(slack): Only use region URLs for team linking

### DIFF
--- a/src/sentry/integrations/slack/views/__init__.py
+++ b/src/sentry/integrations/slack/views/__init__.py
@@ -3,9 +3,6 @@ from typing import Any
 from django.http import HttpRequest, HttpResponse
 from django.urls import reverse
 
-from sentry import options
-from sentry.api.utils import generate_region_url
-from sentry.silo.base import SiloMode
 from sentry.utils.http import absolute_uri
 from sentry.utils.signing import sign
 from sentry.web.helpers import render_to_response
@@ -13,14 +10,10 @@ from sentry.web.helpers import render_to_response
 SALT = "sentry-slack-integration"
 
 
-def build_linking_url(endpoint: str, **kwargs: Any) -> str:
+def build_linking_url(endpoint: str, url_prefix: str | None = None, **kwargs: Any) -> str:
     url: str = absolute_uri(
         url=reverse(endpoint, kwargs={"signed_params": sign(salt=SALT, **kwargs)}),
-        url_prefix=(
-            generate_region_url()
-            if SiloMode.get_current_mode() == SiloMode.REGION
-            else options.get("system.url-prefix")
-        ),
+        url_prefix=url_prefix,
     )
     return url
 

--- a/src/sentry/integrations/slack/views/link_team.py
+++ b/src/sentry/integrations/slack/views/link_team.py
@@ -8,7 +8,6 @@ from django import forms
 from django.http import HttpRequest, HttpResponse
 from slack_sdk.errors import SlackApiError
 
-from sentry import options
 from sentry.api.utils import generate_region_url
 from sentry.integrations.messaging.linkage import LinkTeamView
 from sentry.integrations.models.integration import Integration
@@ -46,9 +45,7 @@ def build_team_linking_url(
         response_url=response_url,
         # The team-linking view is region-specific, so skip the middleware proxy if necessary.
         url_prefix=(
-            generate_region_url()
-            if SiloMode.get_current_mode() == SiloMode.REGION
-            else options.get("system.url-prefix")
+            generate_region_url() if SiloMode.get_current_mode() == SiloMode.REGION else None
         ),
     )
 

--- a/src/sentry/integrations/slack/views/link_team.py
+++ b/src/sentry/integrations/slack/views/link_team.py
@@ -8,12 +8,15 @@ from django import forms
 from django.http import HttpRequest, HttpResponse
 from slack_sdk.errors import SlackApiError
 
+from sentry import options
+from sentry.api.utils import generate_region_url
 from sentry.integrations.messaging.linkage import LinkTeamView
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.services.integration import RpcIntegration
 from sentry.integrations.slack.sdk_client import SlackSdkClient
 from sentry.integrations.slack.views.linkage import SlackLinkageView
 from sentry.models.team import Team
+from sentry.silo.base import SiloMode
 from sentry.web.frontend.base import region_silo_view
 from sentry.web.helpers import render_to_response
 
@@ -41,6 +44,12 @@ def build_team_linking_url(
         channel_id=channel_id,
         channel_name=channel_name,
         response_url=response_url,
+        # The team-linking view is region-specific, so skip the middleware proxy if necessary.
+        url_prefix=(
+            generate_region_url()
+            if SiloMode.get_current_mode() == SiloMode.REGION
+            else options.get("system.url-prefix")
+        ),
     )
 
 

--- a/src/sentry/integrations/slack/views/unlink_team.py
+++ b/src/sentry/integrations/slack/views/unlink_team.py
@@ -1,6 +1,5 @@
 import logging
 
-from sentry import options
 from sentry.api.utils import generate_region_url
 from sentry.integrations.messaging.linkage import UnlinkTeamView
 from sentry.integrations.models.integration import Integration
@@ -36,9 +35,7 @@ def build_team_unlinking_url(
         response_url=response_url,
         # The team-linking view is region-specific, so skip the middleware proxy if necessary.
         url_prefix=(
-            generate_region_url()
-            if SiloMode.get_current_mode() == SiloMode.REGION
-            else options.get("system.url-prefix")
+            generate_region_url() if SiloMode.get_current_mode() == SiloMode.REGION else None
         ),
     )
 

--- a/src/sentry/integrations/slack/views/unlink_team.py
+++ b/src/sentry/integrations/slack/views/unlink_team.py
@@ -1,9 +1,12 @@
 import logging
 
+from sentry import options
+from sentry.api.utils import generate_region_url
 from sentry.integrations.messaging.linkage import UnlinkTeamView
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.services.integration import RpcIntegration
 from sentry.integrations.slack.views.linkage import SlackLinkageView
+from sentry.silo.base import SiloMode
 from sentry.web.frontend.base import region_silo_view
 
 from . import build_linking_url as base_build_linking_url
@@ -31,6 +34,12 @@ def build_team_unlinking_url(
         channel_name=channel_name,
         channel_id=channel_id,
         response_url=response_url,
+        # The team-linking view is region-specific, so skip the middleware proxy if necessary.
+        url_prefix=(
+            generate_region_url()
+            if SiloMode.get_current_mode() == SiloMode.REGION
+            else options.get("system.url-prefix")
+        ),
     )
 
 


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/96985/, fixes issue with identity linking.

The command endpoint is always handled at the region, so the check I though would carve out exceptions for identity linking wasn't doing that, and the URL was always regioned. Instead, we'll just have the team linking functions actually pass in their intended prefix, and added a comment for clarity behind this decision.

Should resolve https://github.com/getsentry/sentry/issues/97107

