### PR TITLE
fix(replay): Correctly show 50+ instead of 51 when "all" replays are selected

### DIFF
--- a/static/app/components/replays/table/replayTableHeaderActions.tsx
+++ b/static/app/components/replays/table/replayTableHeaderActions.tsx
@@ -71,7 +71,7 @@ export default function ReplayTableHeaderActions({
                     queryString: <var>{queryString}</var>,
                   })
                 : countSelected > replays.length
-                  ? t('Select all %s+ replays.', replays.length)
+                  ? t('Selected all %s+ replays.', replays.length)
                   : tn(
                       'Selected all %s replay.',
                       'Selected all %s replays.',

--- a/static/app/components/replays/table/replayTableHeaderActions.tsx
+++ b/static/app/components/replays/table/replayTableHeaderActions.tsx
@@ -70,11 +70,13 @@ export default function ReplayTableHeaderActions({
                 ? tct('Selected all replays matching: [queryString].', {
                     queryString: <var>{queryString}</var>,
                   })
-                : tn(
-                    'Selected all %s replay.',
-                    'Selected all %s replays.',
-                    countSelected
-                  )}
+                : countSelected > replays.length
+                  ? t('Select all %s+ replays.', replays.length)
+                  : tn(
+                      'Selected all %s replay.',
+                      'Selected all %s replays.',
+                      countSelected
+                    )}
             </span>
           </Flex>
         </FullGridAlert>


### PR DESCRIPTION
It's hard to count the number of replays matching a query, we have to iterate over too many things. So instead we just look at if there are more pages of data before/after the page we're on: if there are then we show something like `50+` to indicate that there's a lot of things. 

instead of hard-coding the `50` we're using `replays.length` which represenst the size of the list you're looking at currently. This help account for pages before the current page.