### PR TITLE
fix(access-logs): use correct error body in snuba response

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -1259,12 +1259,12 @@ def _bulk_snuba_query(snuba_requests: Sequence[SnubaRequest]) -> ResultSet:
                         if options.get("issues.use-snuba-error-data"):
                             try:
                                 if (
-                                    "quota_allowance" not in error
-                                    or "summary" not in error["quota_allowance"]
+                                    "quota_allowance" not in body
+                                    or "summary" not in body["quota_allowance"]
                                 ):
                                     # Should not hit this - snuba gives us quota_allowance with a 429
                                     raise RateLimitExceeded(error["message"])
-                                quota_allowance_summary = error["quota_allowance"]["summary"]
+                                quota_allowance_summary = body["quota_allowance"]["summary"]
                                 rejected_by = quota_allowance_summary["rejected_by"]
                                 throttled_by = quota_allowance_summary["throttled_by"]
 

--- a/tests/sentry/utils/test_snuba.py
+++ b/tests/sentry/utils/test_snuba.py
@@ -487,19 +487,19 @@ class SnubaQueryRateLimitTest(TestCase):
             {
                 "error": {
                     "message": "Query on could not be run due to allocation policies, info: ...",
-                    "quota_allowance": {
-                        "summary": {
-                            "rejected_by": {
-                                "policy": "ConcurrentRateLimitAllocationPolicy",
-                                "quota_used": 1000,
-                                "rejection_threshold": 100,
-                                "quota_unit": "no_units",
-                                "storage_key": "test_storage_key",
-                            },
-                            "throttled_by": {},
-                        }
-                    },
-                }
+                },
+                "quota_allowance": {
+                    "summary": {
+                        "rejected_by": {
+                            "policy": "ConcurrentRateLimitAllocationPolicy",
+                            "quota_used": 1000,
+                            "rejection_threshold": 100,
+                            "quota_unit": "no_units",
+                            "storage_key": "test_storage_key",
+                        },
+                        "throttled_by": {},
+                    }
+                },
             }
         ).encode()
 
@@ -518,7 +518,7 @@ class SnubaQueryRateLimitTest(TestCase):
     @override_options({"issues.use-snuba-error-data": 1.0})
     def test_rate_limit_error_handling_without_quota_details(self, mock_snuba_query) -> None:
         """
-        Test that error handling gracefully handles missing quota details
+        Test that error handling gracefully handles malformed message
         """
         mock_response = mock.Mock(spec=HTTPResponse)
         mock_response.status = 429
@@ -547,7 +547,7 @@ class SnubaQueryRateLimitTest(TestCase):
         self, mock_snuba_query
     ) -> None:
         """
-        Test that error handling gracefully handles stats but no quota details
+        Test that error handling gracefully handles empty quota_allowance
         """
         mock_response = mock.Mock(spec=HTTPResponse)
         mock_response.status = 429
@@ -555,8 +555,8 @@ class SnubaQueryRateLimitTest(TestCase):
             {
                 "error": {
                     "message": "Query on could not be run due to allocation policies, info: ...",
-                    "quota_allowance": {"summary": {}},
-                }
+                },
+                "quota_allowance": {},
             }
         ).encode()
 


### PR DESCRIPTION
Original PR https://github.com/getsentry/sentry/pull/96151 had a small typo where we accessed error['stats'] rather than body['stats'] that also wasn't caught in https://github.com/getsentry/sentry/pull/97092. This fixes the issue, and resolves errors where we're reading the wrong thing in the error response like https://sentry.sentry.io/issues/6791854756/?project=1&referrer=github-pr-bot

Here's an example error response from snuba tests:
[example-error-response.json](https://github.com/user-attachments/files/21604658/example-error-response.json)