### PR TITLE
fix(typing): Add low-lift `__init__` return types

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -315,7 +315,7 @@ def create_test_producer_factory():
 
 # Dependency injection pattern for testable Kafka producers
 class MultiProducer:
-    def __init__(self, topic: Topic, producer_factory: Callable[[Mapping[str, object]], Producer[KafkaPayload]] | None = None):
+    def __init__(self, topic: Topic, producer_factory: Callable[[Mapping[str, object]], Producer[KafkaPayload]] | None = None) -> None:
         self.producer_factory = producer_factory or self._default_producer_factory
         # ... setup code
 

--- a/fixtures/integrations/mock_service.py
+++ b/fixtures/integrations/mock_service.py
@@ -20,7 +20,7 @@ class MockService(StubService):
     Like stubs, mocks can make tests simpler and more reliable.
     """
 
-    def __init__(self, mode="memory"):
+    def __init__(self, mode="memory") -> None:
         """
         Initialize the mock instance. Wipe the previous instance's data if it exists.
         """

--- a/fixtures/integrations/mock_service.py
+++ b/fixtures/integrations/mock_service.py
@@ -20,7 +20,7 @@ class MockService(StubService):
     Like stubs, mocks can make tests simpler and more reliable.
     """
 
-    def __init__(self, mode="memory") -> None:
+    def __init__(self, mode="memory"):
         """
         Initialize the mock instance. Wipe the previous instance's data if it exists.
         """

--- a/fixtures/page_objects/base.py
+++ b/fixtures/page_objects/base.py
@@ -6,7 +6,7 @@ from sentry.testutils.pytest.selenium import Browser
 class BasePage:
     """Base class for PageObjects"""
 
-    def __init__(self, browser: Browser):
+    def __init__(self, browser: Browser) -> None:
         self.browser = browser
 
     @property
@@ -18,7 +18,7 @@ class BasePage:
 
 
 class BaseElement:
-    def __init__(self, element):
+    def __init__(self, element) -> None:
         self.element = element
 
 

--- a/fixtures/page_objects/dashboard_detail.py
+++ b/fixtures/page_objects/dashboard_detail.py
@@ -11,7 +11,9 @@ WIDGET_TITLE_FIELD = 'input[aria-label="Widget title"]'
 
 
 class DashboardDetailPage(BasePage):
-    def __init__(self, browser, client, *, organization: Organization, dashboard: Dashboard):
+    def __init__(
+        self, browser, client, *, organization: Organization, dashboard: Dashboard
+    ) -> None:
         super().__init__(browser)
         self.client = client
         self.organization = organization

--- a/fixtures/page_objects/explore_logs.py
+++ b/fixtures/page_objects/explore_logs.py
@@ -5,7 +5,7 @@ from .global_selection import GlobalSelectionPage
 
 
 class ExploreLogsPage(BasePage):
-    def __init__(self, browser, client):
+    def __init__(self, browser, client) -> None:
         super().__init__(browser)
         self.client = client
         self.global_selection = GlobalSelectionPage(browser)

--- a/fixtures/page_objects/explore_spans.py
+++ b/fixtures/page_objects/explore_spans.py
@@ -5,7 +5,7 @@ from .global_selection import GlobalSelectionPage
 
 
 class ExploreSpansPage(BasePage):
-    def __init__(self, browser, client):
+    def __init__(self, browser, client) -> None:
         super().__init__(browser)
         self.client = client
         self.global_selection = GlobalSelectionPage(browser)

--- a/fixtures/page_objects/issue_details.py
+++ b/fixtures/page_objects/issue_details.py
@@ -7,7 +7,7 @@ from .global_selection import GlobalSelectionPage
 
 
 class IssueDetailsPage(BasePage):
-    def __init__(self, browser, client):
+    def __init__(self, browser, client) -> None:
         super().__init__(browser)
         self.client = client
         self.global_selection = GlobalSelectionPage(browser)

--- a/fixtures/page_objects/issue_list.py
+++ b/fixtures/page_objects/issue_list.py
@@ -4,7 +4,7 @@ from .issue_details import IssueDetailsPage
 
 
 class IssueListPage(BasePage):
-    def __init__(self, browser, client):
+    def __init__(self, browser, client) -> None:
         super().__init__(browser)
         self.client = client
         self.global_selection = GlobalSelectionPage(browser)

--- a/fixtures/page_objects/organization_integration_settings.py
+++ b/fixtures/page_objects/organization_integration_settings.py
@@ -7,7 +7,7 @@ class ExampleIntegrationSetupWindowElement(ModalElement):
     name_field_selector = "name"
     submit_button_selector = '[type="submit"]'
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.name = self.element.find_element(by=By.NAME, value="name")
         continue_button_element = self.element.find_element(

--- a/fixtures/page_objects/trace_view.py
+++ b/fixtures/page_objects/trace_view.py
@@ -5,7 +5,7 @@ from .global_selection import GlobalSelectionPage
 
 
 class TraceViewWaterfallPage(BasePage):
-    def __init__(self, browser, client):
+    def __init__(self, browser, client) -> None:
         super().__init__(browser)
         self.client = client
         self.global_selection = GlobalSelectionPage(browser)

--- a/src/bitfield/models.py
+++ b/src/bitfield/models.py
@@ -13,7 +13,7 @@ MAX_FLAG_COUNT = int(len(bin(BigIntegerField.MAX_BIGINT)) - 2)
 
 
 class BitFieldFlags:
-    def __init__(self, flags):
+    def __init__(self, flags) -> None:
         if len(flags) > MAX_FLAG_COUNT:
             raise ValueError("Too many flags")
         self._flags = flags
@@ -61,7 +61,7 @@ class BitFieldCreator:
     available (usually during deploys).
     """
 
-    def __init__(self, field):
+    def __init__(self, field) -> None:
         self.field = field
 
     def __set__(self, obj, value):
@@ -82,7 +82,7 @@ class BitField(BigIntegerField):
         super().contribute_to_class(cls, name, private_only=private_only)
         setattr(cls, self.name, BitFieldCreator(self))
 
-    def __init__(self, flags, default=None, *args, **kwargs):
+    def __init__(self, flags, default=None, *args, **kwargs) -> None:
         if isinstance(flags, dict):
             # Get only integer keys in correct range
             valid_keys = (

--- a/src/bitfield/types.py
+++ b/src/bitfield/types.py
@@ -3,7 +3,7 @@ def cmp(a, b):
 
 
 class Bit:
-    def __init__(self, number, is_set=True):
+    def __init__(self, number, is_set=True) -> None:
         self.number = number
         self.is_set = bool(is_set)
         self.mask = 2 ** int(number)
@@ -103,7 +103,7 @@ class BitHandler:
     Represents an array of bits, each as a ``Bit`` object.
     """
 
-    def __init__(self, value, keys, labels=None):
+    def __init__(self, value, keys, labels=None) -> None:
         # TODO: change to bitarray?
         if value:
             self._value = int(value)

--- a/src/bitfield/types.py
+++ b/src/bitfield/types.py
@@ -3,7 +3,7 @@ def cmp(a, b):
 
 
 class Bit:
-    def __init__(self, number, is_set=True) -> None:
+    def __init__(self, number, is_set=True):
         self.number = number
         self.is_set = bool(is_set)
         self.mask = 2 ** int(number)
@@ -103,7 +103,7 @@ class BitHandler:
     Represents an array of bits, each as a ``Bit`` object.
     """
 
-    def __init__(self, value, keys, labels=None) -> None:
+    def __init__(self, value, keys, labels=None):
         # TODO: change to bitarray?
         if value:
             self._value = int(value)

--- a/src/flagpole/evaluation_context.py
+++ b/src/flagpole/evaluation_context.py
@@ -23,7 +23,9 @@ class EvaluationContext:
     __identity_fields: set[str]
     __id: int
 
-    def __init__(self, data: EvaluationContextDict, identity_fields: set[str] | None = None):
+    def __init__(
+        self, data: EvaluationContextDict, identity_fields: set[str] | None = None
+    ) -> None:
         self.__data = deepcopy(data)
         self.__set_identity_fields(identity_fields)
         self.__id = self.__generate_id()
@@ -100,7 +102,7 @@ class ContextBuilder(Generic[T_CONTEXT_DATA]):
     exception_handler: Callable[[Exception], Any] | None
     __identity_fields: set[str]
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.context_transformers = []
         self.exception_handler = None
         self.__identity_fields = set()

--- a/src/sentry/adoption/manager.py
+++ b/src/sentry/adoption/manager.py
@@ -10,7 +10,7 @@ class UnknownFeature(KeyError):
 
 
 class AdoptionManager:
-    def __init__(self) -> None:
+    def __init__(self):
         self._id_registry = {}
         self._slug_registry = {}
         self._integration_slugs = defaultdict(set)

--- a/src/sentry/adoption/manager.py
+++ b/src/sentry/adoption/manager.py
@@ -10,7 +10,7 @@ class UnknownFeature(KeyError):
 
 
 class AdoptionManager:
-    def __init__(self):
+    def __init__(self) -> None:
         self._id_registry = {}
         self._slug_registry = {}
         self._integration_slugs = defaultdict(set)

--- a/src/sentry/api/bases/project.py
+++ b/src/sentry/api/bases/project.py
@@ -29,7 +29,7 @@ class ProjectEventsError(Exception):
 
 
 class ProjectMoved(Exception):
-    def __init__(self, new_url: str, slug: str):
+    def __init__(self, new_url: str, slug: str) -> None:
         self.new_url = new_url
         self.slug = slug
         super().__init__(new_url, slug)

--- a/src/sentry/api/client.py
+++ b/src/sentry/api/client.py
@@ -14,7 +14,7 @@ __all__ = ("ApiClient",)
 
 
 class ApiError(Exception):
-    def __init__(self, status_code, body):
+    def __init__(self, status_code, body) -> None:
         self.status_code = status_code
         self.body = body
 

--- a/src/sentry/api/endpoints/artifact_lookup.py
+++ b/src/sentry/api/endpoints/artifact_lookup.py
@@ -279,7 +279,7 @@ def get_legacy_releasefile_by_file_url(
 
 
 class UrlConstructor:
-    def __init__(self, request: Request, project: Project):
+    def __init__(self, request: Request, project: Project) -> None:
         if is_system_auth(request.auth):
             self.base_url = get_internal_artifact_lookup_source_url(project)
         else:

--- a/src/sentry/api/endpoints/chunk.py
+++ b/src/sentry/api/endpoints/chunk.py
@@ -44,7 +44,7 @@ CHUNK_UPLOAD_ACCEPT = (
 
 
 class GzipChunk(BytesIO):
-    def __init__(self, file):
+    def __init__(self, file) -> None:
         data = GzipFile(fileobj=file, mode="rb").read()
         self.size = len(data)
         self.name = file.name

--- a/src/sentry/api/endpoints/custom_rules.py
+++ b/src/sentry/api/endpoints/custom_rules.py
@@ -35,7 +35,7 @@ class UnsupportedSearchQueryReason(Enum):
 
 
 class UnsupportedSearchQuery(Exception):
-    def __init__(self, error_code: UnsupportedSearchQueryReason, *args, **kwargs):
+    def __init__(self, error_code: UnsupportedSearchQueryReason, *args, **kwargs) -> None:
         super().__init__(error_code.value, *args, **kwargs)
         self.error_code = error_code.value
 

--- a/src/sentry/api/endpoints/organization_events_spans_performance.py
+++ b/src/sentry/api/endpoints/organization_events_spans_performance.py
@@ -306,7 +306,7 @@ class OrganizationEventsSpansExamplesEndpoint(OrganizationEventsSpansEndpointBas
 
 
 class SpanExamplesPaginator:
-    def __init__(self, data_fn: Callable[[int, int], list[_Example]]):
+    def __init__(self, data_fn: Callable[[int, int], list[_Example]]) -> None:
         self.data_fn = data_fn
 
     def get_result(self, limit: int, cursor: Cursor | None = None) -> CursorResult[_Example]:

--- a/src/sentry/api/endpoints/organization_index.py
+++ b/src/sentry/api/endpoints/organization_index.py
@@ -49,7 +49,7 @@ class OrganizationPostSerializer(BaseOrganizationSerializer):
     aggregatedDataConsent = serializers.BooleanField(required=False)
     idempotencyKey = serializers.CharField(max_length=IDEMPOTENCY_KEY_LENGTH, required=False)
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         if not (settings.TERMS_URL and settings.PRIVACY_URL):
             del self.fields["agreeTerms"]

--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -76,7 +76,7 @@ class TraceItemAttributesNamesPaginator:
     even if it exceeds limit + 1.
     """
 
-    def __init__(self, data_fn):
+    def __init__(self, data_fn) -> None:
         self.data_fn = data_fn
 
     def get_result(self, limit, cursor=None):

--- a/src/sentry/api/endpoints/project_artifact_bundle_files.py
+++ b/src/sentry/api/endpoints/project_artifact_bundle_files.py
@@ -17,7 +17,7 @@ from sentry.ratelimits.config import SENTRY_RATELIMITER_GROUP_DEFAULTS, RateLimi
 
 
 class ArtifactFile:
-    def __init__(self, file_path: str, info: dict[str, str]):
+    def __init__(self, file_path: str, info: dict[str, str]) -> None:
         self.file_path = file_path
         self.info = info
 
@@ -32,7 +32,7 @@ class ArtifactFile:
 
 
 class ArtifactBundleSource:
-    def __init__(self, files: dict):
+    def __init__(self, files: dict) -> None:
         self._files = files
 
     @cached_property

--- a/src/sentry/api/endpoints/source_map_debug_blue_thunder_edition.py
+++ b/src/sentry/api/endpoints/source_map_debug_blue_thunder_edition.py
@@ -306,7 +306,7 @@ def get_scraping_data_for_frame(
 
 
 class ReleaseLookupData:
-    def __init__(self, abs_path: str, project: Project, release: Release, event):
+    def __init__(self, abs_path: str, project: Project, release: Release, event) -> None:
         self.abs_path = abs_path
         self.project = project
         self.release = release

--- a/src/sentry/api/endpoints/team_members.py
+++ b/src/sentry/api/endpoints/team_members.py
@@ -29,7 +29,7 @@ class OrganizationMemberOnTeamResponse(OrganizationMemberResponse):
 
 @register(OrganizationMemberTeam)
 class DetailedOrganizationMemberTeamSerializer(Serializer):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         self.team = kwargs.pop("team", None)
         super().__init__(*args, **kwargs)
 

--- a/src/sentry/api/exceptions.py
+++ b/src/sentry/api/exceptions.py
@@ -21,7 +21,7 @@ class SentryAPIException(APIException):
     code = ""
     message = ""
 
-    def __init__(self, code=None, message=None, detail=None, **kwargs):
+    def __init__(self, code=None, message=None, detail=None, **kwargs) -> None:
         # Note that we no longer call the base `__init__` here. This is because
         # DRF now forces all detail messages that subclass `APIException` to a
         # string, which breaks our format.
@@ -77,7 +77,7 @@ class MemberDisabledOverLimit(SentryAPIException):
     code = "member-disabled-over-limit"
     message = "Organization over member limit"
 
-    def __init__(self, organization):
+    def __init__(self, organization) -> None:
         super().__init__(
             next=reverse("sentry-organization-disabled-member", args=[organization.slug])
         )
@@ -105,7 +105,7 @@ class SudoRequired(SentryAPIException):
     code = "sudo-required"
     message = "Account verification required."
 
-    def __init__(self, user):
+    def __init__(self, user) -> None:
         super().__init__(username=user.username)
 
 
@@ -114,7 +114,7 @@ class PrimaryEmailVerificationRequired(SentryAPIException):
     code = "primary-email-verification-required"
     message = "Primary email verification required."
 
-    def __init__(self, user):
+    def __init__(self, user) -> None:
         super().__init__(username=user.username)
 
 

--- a/src/sentry/api/fields/actor.py
+++ b/src/sentry/api/fields/actor.py
@@ -9,7 +9,7 @@ from sentry.types.actor import Actor, parse_and_validate_actor
 
 @extend_schema_field(field=OpenApiTypes.STR)
 class ActorField(serializers.Field):
-    def __init__(self, *args, **kwds):
+    def __init__(self, *args, **kwds) -> None:
         super().__init__(*args, **kwds)
 
     def to_representation(self, value):

--- a/src/sentry/api/paginator.py
+++ b/src/sentry/api/paginator.py
@@ -514,7 +514,7 @@ class GenericOffsetPaginator:
     return full object if necessary. (if isinstance statement)
     """
 
-    def __init__(self, data_fn):
+    def __init__(self, data_fn) -> None:
         self.data_fn = data_fn
 
     def get_result(self, limit, cursor=None):
@@ -551,7 +551,7 @@ class GenericOffsetPaginator:
 class CombinedQuerysetIntermediary:
     is_empty = False
 
-    def __init__(self, queryset, order_by):
+    def __init__(self, queryset, order_by) -> None:
         assert isinstance(order_by, list), "order_by must be a list of keys/field names"
         self.queryset = queryset
         self.order_by = order_by
@@ -589,7 +589,7 @@ class CombinedQuerysetPaginator:
     multiplier = 1000000  # Use microseconds for date keys.
     using_dates = False
 
-    def __init__(self, intermediaries, desc=False, on_results=None, case_insensitive=False):
+    def __init__(self, intermediaries, desc=False, on_results=None, case_insensitive=False) -> None:
         self.desc = desc
         self.intermediaries = intermediaries
         self.on_results = on_results
@@ -719,7 +719,7 @@ class ChainPaginator:
     assumed that sources have their data sorted already.
     """
 
-    def __init__(self, sources, max_limit=MAX_LIMIT, max_offset=None, on_results=None):
+    def __init__(self, sources, max_limit=MAX_LIMIT, max_offset=None, on_results=None) -> None:
         self.sources = sources
         self.max_limit = max_limit
         self.max_offset = max_offset

--- a/src/sentry/api/serializers/models/activity.py
+++ b/src/sentry/api/serializers/models/activity.py
@@ -14,7 +14,7 @@ from sentry.users.services.user.service import user_service
 
 @register(Activity)
 class ActivitySerializer(Serializer):
-    def __init__(self, environment_func=None):
+    def __init__(self, environment_func=None) -> None:
         self.environment_func = environment_func
 
     def get_attrs(self, item_list, user, **kwargs):

--- a/src/sentry/api/serializers/models/artifactbundle.py
+++ b/src/sentry/api/serializers/models/artifactbundle.py
@@ -56,7 +56,7 @@ class ArtifactBundlesSerializer(Serializer):
 
 
 class ArtifactBundleFilesSerializer(Serializer):
-    def __init__(self, archive, *args, **kwargs):
+    def __init__(self, archive, *args, **kwargs) -> None:
         Serializer.__init__(self, *args, **kwargs)
         self.archive = archive
 

--- a/src/sentry/api/serializers/models/commit.py
+++ b/src/sentry/api/serializers/models/commit.py
@@ -51,7 +51,7 @@ def get_users_for_commits(item_list, user=None) -> Mapping[str, Author]:
 
 @register(Commit)
 class CommitSerializer(Serializer):
-    def __init__(self, exclude=None, include=None, type=None, *args, **kwargs):
+    def __init__(self, exclude=None, include=None, type=None, *args, **kwargs) -> None:
         Serializer.__init__(self, *args, **kwargs)
         self.exclude = frozenset(exclude if exclude else ())
         self.type = type or ""
@@ -111,7 +111,7 @@ class CommitSerializer(Serializer):
 
 @register(Commit)
 class CommitWithReleaseSerializer(CommitSerializer):
-    def __init__(self, exclude=None, include=None, type=None, *args, **kwargs):
+    def __init__(self, exclude=None, include=None, type=None, *args, **kwargs) -> None:
         Serializer.__init__(self, *args, **kwargs)
         self.exclude = frozenset(exclude if exclude else ())
         self.type = type or ""

--- a/src/sentry/api/serializers/models/group_stream.py
+++ b/src/sentry/api/serializers/models/group_stream.py
@@ -194,7 +194,7 @@ class StreamGroupSerializerResponse(BaseGroupSerializerResponse, _MaybeStats):
 
 
 class StreamGroupSerializer(GroupSerializer, GroupStatsMixin):
-    def __init__(self, environment_func=None, stats_period=None):
+    def __init__(self, environment_func=None, stats_period=None) -> None:
         super().__init__(environment_func=environment_func)
 
         assert (

--- a/src/sentry/api/serializers/models/grouprelease.py
+++ b/src/sentry/api/serializers/models/grouprelease.py
@@ -39,7 +39,7 @@ class GroupReleaseWithStatsSerializer(GroupReleaseSerializer):
         "30d": StatsPeriod(30, timedelta(hours=24)),
     }
 
-    def __init__(self, since=None, until=None):
+    def __init__(self, since=None, until=None) -> None:
         self.since = since
         self.until = until
 

--- a/src/sentry/api/serializers/models/groupsearchview.py
+++ b/src/sentry/api/serializers/models/groupsearchview.py
@@ -28,7 +28,7 @@ class GroupSearchViewSerializerResponse(TypedDict):
 
 @register(GroupSearchView)
 class GroupSearchViewSerializer(Serializer):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         self.has_global_views = kwargs.pop("has_global_views", None)
         self.default_project = kwargs.pop("default_project", None)
         self.organization = kwargs.pop("organization", None)

--- a/src/sentry/api/serializers/models/groupsearchviewstarred.py
+++ b/src/sentry/api/serializers/models/groupsearchviewstarred.py
@@ -24,7 +24,7 @@ class GroupSearchViewStarredSerializerResponse(TypedDict):
 
 @register(GroupSearchViewStarred)
 class GroupSearchViewStarredSerializer(Serializer):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         self.has_global_views = kwargs.pop("has_global_views", None)
         self.default_project = kwargs.pop("default_project", None)
         self.organization = kwargs.pop("organization", None)

--- a/src/sentry/api/serializers/models/plugin.py
+++ b/src/sentry/api/serializers/models/plugin.py
@@ -31,7 +31,7 @@ def is_plugin_deprecated(plugin, project: Project) -> bool:
 
 
 class PluginSerializer(Serializer):
-    def __init__(self, project=None):
+    def __init__(self, project=None) -> None:
         self.project = project
 
     def serialize(self, obj, attrs, user, **kwargs):
@@ -108,7 +108,7 @@ class PluginSerializer(Serializer):
 
 
 class PluginWithConfigSerializer(PluginSerializer):
-    def __init__(self, project=None):
+    def __init__(self, project=None) -> None:
         self.project = project
 
     def get_attrs(self, item_list, user, **kwargs):

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -672,7 +672,7 @@ class _DeployDict(TypedDict):
 
 
 class ProjectSummarySerializer(ProjectWithTeamSerializer):
-    def __init__(self, access: Access | None = None, **kwargs):
+    def __init__(self, access: Access | None = None, **kwargs) -> None:
         self.access = access
         super().__init__(**kwargs)
 

--- a/src/sentry/api/serializers/models/role.py
+++ b/src/sentry/api/serializers/models/role.py
@@ -52,7 +52,7 @@ def _serialize_base_role(
 
 
 class OrganizationRoleSerializer(Serializer):
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs) -> None:
         """
         Remove this when deleting "organizations:team-roles" flag
         """
@@ -77,7 +77,7 @@ class OrganizationRoleSerializer(Serializer):
 
 
 class TeamRoleSerializer(Serializer):
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs) -> None:
         """
         Remove this when deleting "organizations:team-roles" flag
         """

--- a/src/sentry/api/serializers/models/tagvalue.py
+++ b/src/sentry/api/serializers/models/tagvalue.py
@@ -6,7 +6,7 @@ from sentry.utils.eventuser import EventUser
 
 
 class UserTagValueSerializer(Serializer):
-    def __init__(self, project_id):
+    def __init__(self, project_id) -> None:
         self.project_id = project_id
 
     def get_attrs(self, item_list, user, **kwargs):

--- a/src/sentry/api/serializers/models/userreport.py
+++ b/src/sentry/api/serializers/models/userreport.py
@@ -94,7 +94,7 @@ class UserReportSerializer(Serializer):
 
 
 class UserReportWithGroupSerializer(UserReportSerializer):
-    def __init__(self, environment_func=None):
+    def __init__(self, environment_func=None) -> None:
         self.environment_func = environment_func
 
     def get_attrs(self, item_list, user, **kwargs):

--- a/src/sentry/api/serializers/rest_framework/base.py
+++ b/src/sentry/api/serializers/rest_framework/base.py
@@ -56,7 +56,7 @@ class CamelSnakeSerializer(Serializer[T]):
     Errors are output in camel case.
     """
 
-    def __init__(self, instance=None, data=empty, **kwargs):
+    def __init__(self, instance=None, data=empty, **kwargs) -> None:
         if data is not empty:
             data = convert_dict_key_case(data, camel_to_snake_case)
         super().__init__(instance=instance, data=data, **kwargs)
@@ -77,7 +77,7 @@ class CamelSnakeModelSerializer(ModelSerializer[M]):
     Errors are output in camel case.
     """
 
-    def __init__(self, instance=None, data=empty, **kwargs):
+    def __init__(self, instance=None, data=empty, **kwargs) -> None:
         if data is not empty:
             data = convert_dict_key_case(data, camel_to_snake_case)
         super().__init__(instance=instance, data=data, **kwargs)

--- a/src/sentry/api/serializers/rest_framework/project.py
+++ b/src/sentry/api/serializers/rest_framework/project.py
@@ -9,7 +9,7 @@ ValidationError = serializers.ValidationError
 
 @extend_schema_field(field=OpenApiTypes.STR)
 class ProjectField(serializers.Field):
-    def __init__(self, scope="project:write", id_allowed=False, **kwags):
+    def __init__(self, scope="project:write", id_allowed=False, **kwags) -> None:
         self.scope = scope
         self.id_allowed = id_allowed
         super().__init__(**kwags)

--- a/src/sentry/api/serializers/rest_framework/rule.py
+++ b/src/sentry/api/serializers/rest_framework/rule.py
@@ -17,7 +17,7 @@ from sentry.rules.actions.sentry_apps.base import SentryAppEventAction
 
 @extend_schema_field(field=OpenApiTypes.OBJECT)
 class RuleNodeField(serializers.Field):
-    def __init__(self, type):
+    def __init__(self, type) -> None:
         super().__init__()
         self.type_name = type
 

--- a/src/sentry/api/serializers/snuba.py
+++ b/src/sentry/api/serializers/snuba.py
@@ -55,7 +55,7 @@ class SnubaTSResultSerializer:
     Serializer for time-series Snuba data.
     """
 
-    def __init__(self, organization, lookup, user):
+    def __init__(self, organization, lookup, user) -> None:
         self.organization = organization
         self.lookup = lookup
         self.user = user

--- a/src/sentry/assistant/manager.py
+++ b/src/sentry/assistant/manager.py
@@ -1,5 +1,5 @@
 class AssistantManager:
-    def __init__(self):
+    def __init__(self) -> None:
         self._guides = {}
 
     def add(self, guides):

--- a/src/sentry/assistant/manager.py
+++ b/src/sentry/assistant/manager.py
@@ -1,5 +1,5 @@
 class AssistantManager:
-    def __init__(self) -> None:
+    def __init__(self):
         self._guides = {}
 
     def add(self, guides):

--- a/src/sentry/attachments/base.py
+++ b/src/sentry/attachments/base.py
@@ -103,7 +103,7 @@ class CachedAttachment:
 
 
 class BaseAttachmentCache:
-    def __init__(self, inner):
+    def __init__(self, inner) -> None:
         self.inner = inner
 
     def set(self, key, attachments, timeout=None):

--- a/src/sentry/attachments/default.py
+++ b/src/sentry/attachments/default.py
@@ -4,5 +4,5 @@ from .base import BaseAttachmentCache
 
 
 class DefaultAttachmentCache(BaseAttachmentCache):
-    def __init__(self, **options):
+    def __init__(self, **options) -> None:
         super().__init__(default_cache, **options)

--- a/src/sentry/attachments/redis.py
+++ b/src/sentry/attachments/redis.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 
 class RedisClusterAttachmentCache(BaseAttachmentCache):
-    def __init__(self, **options):
+    def __init__(self, **options) -> None:
         cluster_id = options.pop("cluster_id", None)
         if cluster_id is None:
             cluster_id = getattr(settings, "SENTRY_ATTACHMENTS_REDIS_CLUSTER", "rc-short")

--- a/src/sentry/audit_log/events.py
+++ b/src/sentry/audit_log/events.py
@@ -23,7 +23,7 @@ def _get_member_display(email: str | None, target_user: User | None) -> str:
 
 
 class MemberAddAuditLogEvent(AuditLogEvent):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(event_id=2, name="MEMBER_ADD", api_name="member.add")
 
     def render(self, audit_log_entry: AuditLogEntry):
@@ -35,7 +35,7 @@ class MemberAddAuditLogEvent(AuditLogEvent):
 
 
 class MemberEditAuditLogEvent(AuditLogEvent):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(event_id=4, name="MEMBER_EDIT", api_name="member.edit")
 
     def render(self, audit_log_entry: AuditLogEntry):
@@ -50,7 +50,7 @@ class MemberEditAuditLogEvent(AuditLogEvent):
 
 
 class MemberRemoveAuditLogEvent(AuditLogEvent):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(event_id=5, name="MEMBER_REMOVE", api_name="member.remove")
 
     def render(self, audit_log_entry: AuditLogEntry):
@@ -62,7 +62,7 @@ class MemberRemoveAuditLogEvent(AuditLogEvent):
 
 
 class MemberJoinTeamAuditLogEvent(AuditLogEvent):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(event_id=6, name="MEMBER_JOIN_TEAM", api_name="member.join-team")
 
     def render(self, audit_log_entry: AuditLogEntry):
@@ -76,7 +76,7 @@ class MemberJoinTeamAuditLogEvent(AuditLogEvent):
 
 
 class MemberLeaveTeamAuditLogEvent(AuditLogEvent):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(event_id=7, name="MEMBER_LEAVE_TEAM", api_name="member.leave-team")
 
     def render(self, audit_log_entry: AuditLogEntry):
@@ -90,7 +90,7 @@ class MemberLeaveTeamAuditLogEvent(AuditLogEvent):
 
 
 class MemberPendingAuditLogEvent(AuditLogEvent):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(event_id=8, name="MEMBER_PENDING", api_name="member.pending")
 
     def render(self, audit_log_entry: AuditLogEntry):
@@ -101,7 +101,7 @@ class MemberPendingAuditLogEvent(AuditLogEvent):
 
 
 class OrgAddAuditLogEvent(AuditLogEvent):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(event_id=10, name="ORG_ADD", api_name="org.create")
 
     def render(self, audit_log_entry: AuditLogEntry):
@@ -111,7 +111,7 @@ class OrgAddAuditLogEvent(AuditLogEvent):
 
 
 class OrgEditAuditLogEvent(AuditLogEvent):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(event_id=11, name="ORG_EDIT", api_name="org.edit")
 
     def render(self, audit_log_entry: AuditLogEntry):
@@ -120,7 +120,7 @@ class OrgEditAuditLogEvent(AuditLogEvent):
 
 
 class TeamEditAuditLogEvent(AuditLogEvent):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(event_id=21, name="TEAM_EDIT", api_name="team.edit")
 
     def render(self, audit_log_entry: AuditLogEntry):
@@ -130,7 +130,7 @@ class TeamEditAuditLogEvent(AuditLogEvent):
 
 
 class ProjectEditAuditLogEvent(AuditLogEvent):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(event_id=31, name="PROJECT_EDIT", api_name="project.edit")
 
     def render(self, audit_log_entry: AuditLogEntry):
@@ -145,7 +145,7 @@ class ProjectEditAuditLogEvent(AuditLogEvent):
 
 
 class ProjectKeyEditAuditLogEvent(AuditLogEvent):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(event_id=51, name="PROJECTKEY_EDIT", api_name="projectkey.edit")
 
     def render(self, audit_log_entry: AuditLogEntry):
@@ -171,7 +171,7 @@ class ProjectKeyEditAuditLogEvent(AuditLogEvent):
 
 
 class ProjectPerformanceDetectionSettingsAuditLogEvent(AuditLogEvent):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(
             event_id=178,
             name="PROJECT_PERFORMANCE_ISSUE_DETECTION_CHANGE",
@@ -209,7 +209,7 @@ def render_project_action(audit_log_entry: AuditLogEntry, action: str):
 
 
 class ProjectEnableAuditLogEvent(AuditLogEvent):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(event_id=37, name="PROJECT_ENABLE", api_name="project.enable")
 
     def render(self, audit_log_entry: AuditLogEntry):
@@ -217,7 +217,7 @@ class ProjectEnableAuditLogEvent(AuditLogEvent):
 
 
 class ProjectDisableAuditLogEvent(AuditLogEvent):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(event_id=38, name="PROJECT_DISABLE", api_name="project.disable")
 
     def render(self, audit_log_entry: AuditLogEntry):
@@ -225,7 +225,7 @@ class ProjectDisableAuditLogEvent(AuditLogEvent):
 
 
 class ProjectOwnershipRuleEditAuditLogEvent(AuditLogEvent):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(
             event_id=179, name="PROJECT_OWNERSHIPRULE_EDIT", api_name="project.ownership-rule.edit"
         )
@@ -235,7 +235,7 @@ class ProjectOwnershipRuleEditAuditLogEvent(AuditLogEvent):
 
 
 class SSOEditAuditLogEvent(AuditLogEvent):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(event_id=62, name="SSO_EDIT", api_name="sso.edit")
 
     def render(self, audit_log_entry: AuditLogEntry):
@@ -244,7 +244,7 @@ class SSOEditAuditLogEvent(AuditLogEvent):
 
 
 class ServiceHookAddAuditLogEvent(AuditLogEvent):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(event_id=100, name="SERVICEHOOK_ADD", api_name="servicehook.create")
 
     def render(self, audit_log_entry: AuditLogEntry):
@@ -253,7 +253,7 @@ class ServiceHookAddAuditLogEvent(AuditLogEvent):
 
 
 class ServiceHookEditAuditLogEvent(AuditLogEvent):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(event_id=101, name="SERVICEHOOK_EDIT", api_name="servicehook.edit")
 
     def render(self, audit_log_entry: AuditLogEntry):
@@ -262,7 +262,7 @@ class ServiceHookEditAuditLogEvent(AuditLogEvent):
 
 
 class ServiceHookRemoveAuditLogEvent(AuditLogEvent):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(event_id=102, name="SERVICEHOOK_REMOVE", api_name="servicehook.remove")
 
     def render(self, audit_log_entry: AuditLogEntry):
@@ -271,7 +271,7 @@ class ServiceHookRemoveAuditLogEvent(AuditLogEvent):
 
 
 class IntegrationDisabledAuditLogEvent(AuditLogEvent):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(event_id=108, name="INTEGRATION_DISABLED", api_name="integration.disable")
 
     def render(self, audit_log_entry: AuditLogEntry):
@@ -280,7 +280,7 @@ class IntegrationDisabledAuditLogEvent(AuditLogEvent):
 
 
 class IntegrationUpgradeAuditLogEvent(AuditLogEvent):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(event_id=109, name="INTEGRATION_UPGRADE", api_name="integration.upgrade")
 
     def render(self, audit_log_entry: AuditLogEntry):
@@ -290,7 +290,7 @@ class IntegrationUpgradeAuditLogEvent(AuditLogEvent):
 
 
 class IntegrationAddAuditLogEvent(AuditLogEvent):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(event_id=110, name="INTEGRATION_ADD", api_name="integration.add")
 
     def render(self, audit_log_entry: AuditLogEntry):
@@ -302,7 +302,7 @@ class IntegrationAddAuditLogEvent(AuditLogEvent):
 
 
 class IntegrationEditAuditLogEvent(AuditLogEvent):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(event_id=111, name="INTEGRATION_EDIT", api_name="integration.edit")
 
     def render(self, audit_log_entry: AuditLogEntry):
@@ -314,7 +314,7 @@ class IntegrationEditAuditLogEvent(AuditLogEvent):
 
 
 class IntegrationRemoveAuditLogEvent(AuditLogEvent):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(event_id=112, name="INTEGRATION_REMOVE", api_name="integration.remove")
 
     def render(self, audit_log_entry: AuditLogEntry):
@@ -328,7 +328,7 @@ class IntegrationRemoveAuditLogEvent(AuditLogEvent):
 
 
 class InternalIntegrationAddAuditLogEvent(AuditLogEvent):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(
             event_id=130, name="INTERNAL_INTEGRATION_ADD", api_name="internal-integration.create"
         )
@@ -339,7 +339,7 @@ class InternalIntegrationAddAuditLogEvent(AuditLogEvent):
 
 
 class InternalIntegrationDisabledAuditLogEvent(AuditLogEvent):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(
             event_id=131,
             name="INTERNAL_INTEGRATION_DISABLED",
@@ -352,7 +352,7 @@ class InternalIntegrationDisabledAuditLogEvent(AuditLogEvent):
 
 
 class MonitorAddAuditLogEvent(AuditLogEvent):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(
             event_id=120,
             name="MONITOR_ADD",

--- a/src/sentry/audit_log/manager.py
+++ b/src/sentry/audit_log/manager.py
@@ -67,7 +67,7 @@ class AuditLogEvent:
     # subclass AuditLogEvent and override the render method.
     template: str | None = None
 
-    def __init__(self, event_id, name, api_name, template=None):
+    def __init__(self, event_id, name, api_name, template=None) -> None:
         self.event_id = event_id
         self.name = name
         self.api_name = api_name

--- a/src/sentry/auth/services/auth/impl.py
+++ b/src/sentry/auth/services/auth/impl.py
@@ -216,7 +216,7 @@ class FakeRequestDict:
     d: Mapping[str, str | bytes | None]
     _accessed: set[str]
 
-    def __init__(self, **d: Any):
+    def __init__(self, **d: Any) -> None:
         self.d = d
         self._accessed = set()
 

--- a/src/sentry/auth/superuser.py
+++ b/src/sentry/auth/superuser.py
@@ -184,7 +184,7 @@ class Superuser(ElevatedMode):
                 return False
         return self._is_active
 
-    def __init__(self, request, allowed_ips=UNSET, org_id=UNSET, current_datetime=None):
+    def __init__(self, request, allowed_ips=UNSET, org_id=UNSET, current_datetime=None) -> None:
         self.uid: str | None = None
         self.request = request
         if allowed_ips is not UNSET:

--- a/src/sentry/auth_v2/utils/session.py
+++ b/src/sentry/auth_v2/utils/session.py
@@ -65,7 +65,7 @@ class SessionBuilder:
     flow on the frontend, based on the current user's state.
     """
 
-    def __init__(self, request: Request):
+    def __init__(self, request: Request) -> None:
         self.request = request
 
     def initialize_auth_flags(self) -> None:

--- a/src/sentry/backup/comparators.py
+++ b/src/sentry/backup/comparators.py
@@ -43,7 +43,7 @@ class JSONScrubbingComparator(ABC):
     the `scrub(...)` methods are. This ensures that comparators that touch the same fields do not
     have their inputs mangled by one another."""
 
-    def __init__(self, *fields: str):
+    def __init__(self, *fields: str) -> None:
         self.fields = set(fields)
 
     def check(self, side: Side, data: Any) -> None:
@@ -246,7 +246,7 @@ class ForeignKeyComparator(JSONScrubbingComparator):
     left_pk_map: PrimaryKeyMap | None = None
     right_pk_map: PrimaryKeyMap | None = None
 
-    def __init__(self, foreign_fields: dict[str, type[models.base.Model]]):
+    def __init__(self, foreign_fields: dict[str, type[models.base.Model]]) -> None:
         super().__init__(*(foreign_fields.keys()))
         self.foreign_fields = foreign_fields
 
@@ -309,7 +309,7 @@ class ObfuscatingComparator(JSONScrubbingComparator, ABC):
     """Comparator that compares private values, but then safely truncates them to ensure that they
     do not leak out in logs, stack traces, etc."""
 
-    def __init__(self, *fields: str):
+    def __init__(self, *fields: str) -> None:
         super().__init__(*fields)
 
     def compare(self, on: InstanceID, left: Any, right: Any) -> list[ComparatorFinding]:
@@ -393,7 +393,7 @@ class UserPasswordObfuscatingComparator(ObfuscatingComparator):
     - If the right side is `is_unclaimed = False`, make sure that the password stays the same.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__("password")
 
     def compare(self, on: InstanceID, left: Any, right: Any) -> list[ComparatorFinding]:
@@ -503,7 +503,7 @@ class IgnoredComparator(JSONScrubbingComparator):
 class RegexComparator(JSONScrubbingComparator, ABC):
     """Comparator that ensures that both sides match a certain regex."""
 
-    def __init__(self, regex: re.Pattern, *fields: str):
+    def __init__(self, regex: re.Pattern, *fields: str) -> None:
         self.regex = regex
         super().__init__(*fields)
 
@@ -595,7 +595,7 @@ class EqualOrRemovedComparator(JSONScrubbingComparator):
 class SecretHexComparator(RegexComparator):
     """Certain 16-byte hexadecimal API keys are regenerated during an import operation."""
 
-    def __init__(self, bytes: int, *fields: str):
+    def __init__(self, bytes: int, *fields: str) -> None:
         super().__init__(re.compile(f"""^[0-9a-f]{{{bytes * 2}}}$"""), *fields)
 
 
@@ -603,7 +603,7 @@ class SubscriptionIDComparator(RegexComparator):
     """Compare the basic format of `QuerySubscription` IDs, which is basically a UUID1 with a
     numeric prefix. Ensure that the two values are NOT equivalent."""
 
-    def __init__(self, *fields: str):
+    def __init__(self, *fields: str) -> None:
         super().__init__(re.compile("^\\d+/[0-9a-f]{32}$"), *fields)
 
     def compare(self, on: InstanceID, left: Any, right: Any) -> list[ComparatorFinding]:
@@ -666,7 +666,7 @@ class UUID4Comparator(RegexComparator):
     """UUIDs must be regenerated on import (otherwise they would not be unique...). This comparator
     ensures that they retain their validity, but are not equivalent."""
 
-    def __init__(self, *fields: str):
+    def __init__(self, *fields: str) -> None:
         super().__init__(
             re.compile(
                 "^[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}\\Z$", re.I

--- a/src/sentry/backup/crypto.py
+++ b/src/sentry/backup/crypto.py
@@ -64,7 +64,7 @@ class LocalFileEncryptor(Encryptor):
     Encrypt using a public key stored on the local machine.
     """
 
-    def __init__(self, fp: IO[bytes]):
+    def __init__(self, fp: IO[bytes]) -> None:
         self.__key = fp.read()
 
     def get_public_key_pem(self) -> bytes:
@@ -79,7 +79,7 @@ class GCPKMSEncryptor(Encryptor):
 
     crypto_key_version: CryptoKeyVersion | None = None
 
-    def __init__(self, fp: IO[bytes]):
+    def __init__(self, fp: IO[bytes]) -> None:
         self.__key = fp.read()
 
     @classmethod
@@ -225,7 +225,7 @@ class LocalFileDecryptor(Decryptor):
     Decrypt using a private key stored on the local machine.
     """
 
-    def __init__(self, fp: IO[bytes]):
+    def __init__(self, fp: IO[bytes]) -> None:
         self.__key = fp.read()
 
     @classmethod
@@ -274,7 +274,7 @@ class GCPKMSDecryptor(Decryptor):
     Management Service.
     """
 
-    def __init__(self, fp: IO[bytes]):
+    def __init__(self, fp: IO[bytes]) -> None:
         self.__key = fp.read()
 
     @classmethod
@@ -338,6 +338,6 @@ class EncryptorDecryptorPair:
     An Encryptor and Decryptor that use paired public and private keys, respectively.
     """
 
-    def __init__(self, encryptor: Encryptor, decryptor: Decryptor):
+    def __init__(self, encryptor: Encryptor, decryptor: Decryptor) -> None:
         self.encryptor = encryptor
         self.decryptor = decryptor

--- a/src/sentry/backup/dependencies.py
+++ b/src/sentry/backup/dependencies.py
@@ -23,7 +23,7 @@ class NormalizedModelName:
     backup, so a string of the form `{app_label.lower()}.{model_name.lower()}`.
     """
 
-    def __init__(self, model_name: str):
+    def __init__(self, model_name: str) -> None:
         if "." not in model_name:
             raise TypeError("cannot create NormalizedModelName from invalid input string")
         self.__model_name = model_name.lower()
@@ -245,7 +245,7 @@ class PrimaryKeyMap:
 
     mapping: dict[str, dict[int, tuple[int, ImportKind, str | None]]]
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.mapping = defaultdict(dict)
 
     def get_pk(self, model_name: NormalizedModelName, old: int) -> int | None:

--- a/src/sentry/backup/exports.py
+++ b/src/sentry/backup/exports.py
@@ -98,7 +98,7 @@ class NoopExportCheckpointer(ExportCheckpointer):
     This means that no checkpointing ever occurs.
     """
 
-    def __init__(self, crypto: EncryptorDecryptorPair | None, printer: Printer):
+    def __init__(self, crypto: EncryptorDecryptorPair | None, printer: Printer) -> None:
         pass
 
     def get(self, model_name: NormalizedModelName) -> RpcExportOk | None:

--- a/src/sentry/backup/findings.py
+++ b/src/sentry/backup/findings.py
@@ -196,7 +196,7 @@ class ComparatorFinding(Finding):
 class ComparatorFindings:
     """A wrapper type for a list of 'ComparatorFinding' which enables pretty-printing in asserts."""
 
-    def __init__(self, findings: list[ComparatorFinding]):
+    def __init__(self, findings: list[ComparatorFinding]) -> None:
         self.findings = findings
 
     def append(self, finding: ComparatorFinding) -> None:

--- a/src/sentry/backup/sanitize.py
+++ b/src/sentry/backup/sanitize.py
@@ -189,7 +189,7 @@ class Sanitizer:
     interned_strings: dict[str, str]
     interned_datetimes: dict[datetime, datetime]
 
-    def __init__(self, export: Any, datetime_offset: timedelta | None = None):
+    def __init__(self, export: Any, datetime_offset: timedelta | None = None) -> None:
         self.json = export
         self.interned_strings = {"": ""}  # Always map empty string to itself.
         self.interned_datetimes = dict()

--- a/src/sentry/backup/validate.py
+++ b/src/sentry/backup/validate.py
@@ -39,7 +39,7 @@ def validate(
         max_seen_ordinal_value: int | tuple | None
         next_ordinal: int
 
-        def __init__(self):
+        def __init__(self) -> None:
             self.max_seen_ordinal_value = None
             self.next_ordinal = 1
 

--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -195,7 +195,7 @@ class RedisOperation(Enum):
 
 
 class PendingBuffer:
-    def __init__(self, size: int):
+    def __init__(self, size: int) -> None:
         assert size > 0
         self.buffer: list[str | None] = [None] * size
         self.size = size
@@ -225,7 +225,7 @@ class RedisBuffer(Buffer):
     key_expire = 60 * 60  # 1 hour
     pending_key = "b:p"
 
-    def __init__(self, incr_batch_size: int = 2, **options: object):
+    def __init__(self, incr_batch_size: int = 2, **options: object) -> None:
         self.is_redis_cluster, self.cluster, options = get_dynamic_cluster_from_options(
             "SENTRY_BUFFER_OPTIONS", options
         )

--- a/src/sentry/cache/base.py
+++ b/src/sentry/cache/base.py
@@ -19,7 +19,7 @@ def unwrap_key(prefix: str, version: Any, value: str) -> str:
 class BaseCache(local):
     prefix = "c"
 
-    def __init__(self, version=None, prefix=None, is_default_cache=False):
+    def __init__(self, version=None, prefix=None, is_default_cache=False) -> None:
         self.version = version or settings.CACHE_VERSION
         if prefix is not None:
             self.prefix = prefix

--- a/src/sentry/cache/redis.py
+++ b/src/sentry/cache/redis.py
@@ -12,7 +12,7 @@ class CommonRedisCache(BaseCache):
     key_expire = 60 * 60  # 1 hour
     max_size = 50 * 1024 * 1024  # 50MB
 
-    def __init__(self, client, raw_client, **options):
+    def __init__(self, client, raw_client, **options) -> None:
         self._text_client = client
         self._bytes_client = raw_client
         super().__init__(**options)

--- a/src/sentry/celery.py
+++ b/src/sentry/celery.py
@@ -154,7 +154,7 @@ class SentryTask(Task):
 
 
 class SentryRequest(Request):
-    def __init__(self, message, **kwargs):
+    def __init__(self, message, **kwargs) -> None:
         super().__init__(message, **kwargs)
         self._request_dict["headers"] = message.headers
 

--- a/src/sentry/consumers/__init__.py
+++ b/src/sentry/consumers/__init__.py
@@ -665,7 +665,7 @@ class MinPartitionMetricTagWrapper(ProcessingStrategyFactory):
     and debugging partition-specific issues.
     """
 
-    def __init__(self, inner: ProcessingStrategyFactory):
+    def __init__(self, inner: ProcessingStrategyFactory) -> None:
         self.inner = inner
 
     def create_with_partitions(self, commit, partitions):
@@ -680,7 +680,7 @@ class MinPartitionMetricTagWrapper(ProcessingStrategyFactory):
 
 
 class HealthcheckStrategyFactoryWrapper(ProcessingStrategyFactory):
-    def __init__(self, healthcheck_file_path: str, inner: ProcessingStrategyFactory):
+    def __init__(self, healthcheck_file_path: str, inner: ProcessingStrategyFactory) -> None:
         self.healthcheck_file_path = healthcheck_file_path
         self.inner = inner
 

--- a/src/sentry/data_export/base.py
+++ b/src/sentry/data_export/base.py
@@ -9,7 +9,7 @@ DEFAULT_EXPIRATION = timedelta(weeks=4)
 
 
 class ExportError(Exception):
-    def __init__(self, message, recoverable=False):
+    def __init__(self, message, recoverable=False) -> None:
         super().__init__(message)
         self.recoverable = recoverable
 

--- a/src/sentry/data_export/processors/discover.py
+++ b/src/sentry/data_export/processors/discover.py
@@ -21,7 +21,7 @@ class DiscoverProcessor:
     Processor for exports of discover data based on a provided query
     """
 
-    def __init__(self, organization, discover_query):
+    def __init__(self, organization, discover_query) -> None:
         self.projects = self.get_projects(organization.id, discover_query)
         self.environments = self.get_environments(organization.id, discover_query)
         self.start, self.end = get_date_range_from_params(discover_query)

--- a/src/sentry/db/analyze.py
+++ b/src/sentry/db/analyze.py
@@ -4,7 +4,7 @@ from django.db import connections, router
 
 
 class AnalyzeQuery:
-    def __init__(self, model):
+    def __init__(self, model) -> None:
         self.model = model
         self.using = router.db_for_write(model)
 

--- a/src/sentry/db/models/fields/array.py
+++ b/src/sentry/db/models/fields/array.py
@@ -16,7 +16,7 @@ from sentry.utils import json
 # Adapted from django-pgfields
 # https://github.com/lukesneeringer/django-pgfields/blob/master/django_pg/models/fields/array.py
 class ArrayField(models.Field):
-    def __init__(self, of=models.TextField, **kwargs):
+    def __init__(self, of=models.TextField, **kwargs) -> None:
         # Arrays in PostgreSQL are arrays of a particular type.
         # Save the subtype in our field class.
         if isinstance(of, type):

--- a/src/sentry/db/models/fields/foreignkey.py
+++ b/src/sentry/db/models/fields/foreignkey.py
@@ -11,6 +11,6 @@ __all__ = ("FlexibleForeignKey",)
 
 
 class FlexibleForeignKey(ForeignKey[FieldSetType, FieldGetType]):
-    def __init__(self, *args: Any, **kwargs: Any):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         kwargs.setdefault("on_delete", models.CASCADE)
         super().__init__(*args, **kwargs)

--- a/src/sentry/db/models/fields/jsonfield.py
+++ b/src/sentry/db/models/fields/jsonfield.py
@@ -58,7 +58,7 @@ class JSONField(models.TextField):
     description = "JSON object"
     no_creator_hook = False
 
-    def __init__(self, *args, json_dumps=json.dumps, **kwargs):
+    def __init__(self, *args, json_dumps=json.dumps, **kwargs) -> None:
         self.json_dumps = json_dumps
         if not kwargs.get("null", False):
             kwargs["default"] = kwargs.get("default", dict)

--- a/src/sentry/db/models/fields/node.py
+++ b/src/sentry/db/models/fields/node.py
@@ -27,7 +27,7 @@ class NodeData(MutableMapping[str, Any]):
     data={...} means, this is an object that should be saved to nodestore.
     """
 
-    def __init__(self, id, data=None, wrapper=None, ref_version=None, ref_func=None):
+    def __init__(self, id, data=None, wrapper=None, ref_version=None, ref_func=None) -> None:
         self.id = id
         self.ref = None
         # ref version is used to discredit a previous ref

--- a/src/sentry/db/models/fields/onetoone.py
+++ b/src/sentry/db/models/fields/onetoone.py
@@ -7,6 +7,6 @@ __all__ = ("OneToOneCascadeDeletes",)
 
 
 class OneToOneCascadeDeletes(OneToOneField):
-    def __init__(self, *args: Any, **kwargs: Any):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         kwargs.setdefault("on_delete", models.CASCADE)
         super().__init__(*args, **kwargs)

--- a/src/sentry/db/models/fields/uuid.py
+++ b/src/sentry/db/models/fields/uuid.py
@@ -47,7 +47,7 @@ class UUIDField(models.Field):
 
     description = "Universally unique identifier."
 
-    def __init__(self, auto_add=False, coerce_to=UUID, **kwargs):
+    def __init__(self, auto_add=False, coerce_to=UUID, **kwargs) -> None:
         """Instantiate the field."""
 
         # If the `auto_add` argument is specified as True, substitute an
@@ -152,7 +152,7 @@ class UUIDField(models.Field):
 
 
 class UUIDAdapter:
-    def __init__(self, value):
+    def __init__(self, value) -> None:
         if not isinstance(value, UUID):
             raise TypeError("UUIDAdapter only understands UUID objects.")
         self.value = value

--- a/src/sentry/db/postgres/base.py
+++ b/src/sentry/db/postgres/base.py
@@ -76,7 +76,7 @@ class DatabaseWrapper(DjangoDatabaseWrapper):
     SchemaEditorClass = DatabaseSchemaEditorProxy  # type: ignore[assignment]  # a proxy class isn't exactly the original type
     queries_limit = 15000
 
-    def __init__(self, *args: Any, **kwargs: Any):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.ops = DatabaseOperations(self)
         self.execute_wrappers.extend((_execute__include_sql_in_error, _execute__clean_params))

--- a/src/sentry/db/postgres/schema.py
+++ b/src/sentry/db/postgres/schema.py
@@ -125,7 +125,7 @@ class DatabaseSchemaEditorProxy:
     class AlreadyInUse(Exception):
         pass
 
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args, **kwargs):
         self.args = args
         self.kwargs = kwargs
         self._safe = False

--- a/src/sentry/db/postgres/schema.py
+++ b/src/sentry/db/postgres/schema.py
@@ -125,7 +125,7 @@ class DatabaseSchemaEditorProxy:
     class AlreadyInUse(Exception):
         pass
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         self.args = args
         self.kwargs = kwargs
         self._safe = False

--- a/src/sentry/db/router.py
+++ b/src/sentry/db/router.py
@@ -85,7 +85,7 @@ class SiloRouter:
     we can provide compatibility for existing migrations.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         # Memoized results of table : silo pairings
         self.__table_to_silo: dict[str, str | None] = {}
         try:

--- a/src/sentry/discover/arithmetic.py
+++ b/src/sentry/discover/arithmetic.py
@@ -195,7 +195,7 @@ class ArithmeticVisitor(NodeVisitor):
         "percentile_range",
     }
 
-    def __init__(self, max_operators: int | None, custom_measurements: set[str] | None):
+    def __init__(self, max_operators: int | None, custom_measurements: set[str] | None) -> None:
         super().__init__()
         self.operators: int = 0
         self.terms: int = 0

--- a/src/sentry/discover/endpoints/discover_key_transactions.py
+++ b/src/sentry/discover/endpoints/discover_key_transactions.py
@@ -182,7 +182,7 @@ class TeamKeyTransactionSerializer(Serializer):
 
 
 class KeyTransactionTeamSerializer(Serializer):
-    def __init__(self, projects):
+    def __init__(self, projects) -> None:
         self.project_ids = {project.id for project in projects}
 
     def get_attrs(self, item_list, user, **kwargs):

--- a/src/sentry/discover/translation/mep_to_eap.py
+++ b/src/sentry/discover/translation/mep_to_eap.py
@@ -138,7 +138,7 @@ def search_term_switcheroo(term):
 
 
 class TranslationVisitor(NodeVisitor):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
 
     def visit_raw_aggregate_param(self, node, children):

--- a/src/sentry/dynamic_sampling/rules/combinators/base.py
+++ b/src/sentry/dynamic_sampling/rules/combinators/base.py
@@ -12,7 +12,7 @@ class OrderedBias:
     biases.
     """
 
-    def __init__(self, bias: Bias, order_number: float):
+    def __init__(self, bias: Bias, order_number: float) -> None:
         self.bias = bias
         self.order_number = order_number
 

--- a/src/sentry/dynamic_sampling/rules/helpers/latest_releases.py
+++ b/src/sentry/dynamic_sampling/rules/helpers/latest_releases.py
@@ -134,7 +134,7 @@ class ProjectBoostedReleases:
     # Limit of boosted releases per project.
     BOOSTED_RELEASES_HASH_EXPIRATION = 60 * 60 * 1000
 
-    def __init__(self, project_id: int):
+    def __init__(self, project_id: int) -> None:
         self.redis_client = get_redis_client_for_ds()
         self.project_id = project_id
         self.project_platform = _get_project_platform(self.project_id)
@@ -293,7 +293,7 @@ class LatestReleaseBias:
     OBSERVED_VALUE = "1"
     ONE_DAY_TIMEOUT_MS = 60 * 60 * 24 * 1000
 
-    def __init__(self, latest_release_params: LatestReleaseParams):
+    def __init__(self, latest_release_params: LatestReleaseParams) -> None:
         self.redis_client = get_redis_client_for_ds()
         self.latest_release_params = latest_release_params
         self.project_boosted_releases = ProjectBoostedReleases(

--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
@@ -284,7 +284,7 @@ class FetchProjectTransactionTotals:
     project in the given organizations
     """
 
-    def __init__(self, orgs: Sequence[int]):
+    def __init__(self, orgs: Sequence[int]) -> None:
         self.log_state: DynamicSamplingLogState | None = None
 
         transaction_string_id = indexer.resolve_shared_org("transaction")

--- a/src/sentry/dynamic_sampling/tasks/common.py
+++ b/src/sentry/dynamic_sampling/tasks/common.py
@@ -42,7 +42,7 @@ ACTIVE_ORGS_VOLUMES_DEFAULT_GRANULARITY = Granularity(60)
 
 
 class TimeoutException(Exception):
-    def __init__(self, task_context: TaskContext, *args):
+    def __init__(self, task_context: TaskContext, *args) -> None:
         super().__init__(
             [task_context, *args],
         )
@@ -117,7 +117,7 @@ class ContextIterator(Protocol):
 
 
 class _SimpleContextIterator(Iterator[Any]):
-    def __init__(self, inner: Iterator[Any]):
+    def __init__(self, inner: Iterator[Any]) -> None:
         self.inner = inner
         self.log_state = DynamicSamplingLogState()
 

--- a/src/sentry/dynamic_sampling/tasks/task_context.py
+++ b/src/sentry/dynamic_sampling/tasks/task_context.py
@@ -154,7 +154,7 @@ class Timers:
 
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.timers: dict[str, TimerState] = {}
 
     def get_timer(self, name: str) -> "NamedTimer":
@@ -209,7 +209,7 @@ class NamedTimer:
         assert t.current() == 10
     """
 
-    def __init__(self, name: str, timers: Timers):
+    def __init__(self, name: str, timers: Timers) -> None:
         self.name = name
         self.timers = timers
 

--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -792,7 +792,7 @@ class EventSubjectTemplate(string.Template):
 class EventSubjectTemplateData:
     tag_aliases = {"release": "sentry:release", "dist": "sentry:dist", "user": "sentry:user"}
 
-    def __init__(self, event: Event):
+    def __init__(self, event: Event) -> None:
         self.event = event
 
     def __getitem__(self, name: str) -> str:

--- a/src/sentry/eventstore/processing/base.py
+++ b/src/sentry/eventstore/processing/base.py
@@ -29,7 +29,7 @@ class EventProcessingStore(Service):
 
     __all__ = ("exists", "store", "get", "delete", "delete_by_key")
 
-    def __init__(self, inner: KVStorage[str, Event]):
+    def __init__(self, inner: KVStorage[str, Event]) -> None:
         self.inner = inner
         self.timeout = timedelta(seconds=DEFAULT_TIMEOUT)
 

--- a/src/sentry/eventtypes/manager.py
+++ b/src/sentry/eventtypes/manager.py
@@ -1,5 +1,5 @@
 class EventTypeManager:
-    def __init__(self):
+    def __init__(self) -> None:
         self.__values = []
         self.__lookup = {}
 

--- a/src/sentry/eventtypes/manager.py
+++ b/src/sentry/eventtypes/manager.py
@@ -1,5 +1,5 @@
 class EventTypeManager:
-    def __init__(self) -> None:
+    def __init__(self):
         self.__values = []
         self.__lookup = {}
 

--- a/src/sentry/exceptions.py
+++ b/src/sentry/exceptions.py
@@ -14,7 +14,7 @@ class InvalidRequest(Exception):
 
 
 class InvalidOrigin(InvalidRequest):
-    def __init__(self, origin):
+    def __init__(self, origin) -> None:
         self.origin = origin
 
     def __str__(self) -> str:
@@ -42,7 +42,7 @@ class PluginIdentityRequired(PluginError):
 
 
 class InvalidIdentity(Exception):
-    def __init__(self, message="", identity=None):
+    def __init__(self, message="", identity=None) -> None:
         super().__init__(message)
         self.identity = identity
 

--- a/src/sentry/filestore/gcs.py
+++ b/src/sentry/filestore/gcs.py
@@ -147,7 +147,7 @@ def safe_join(base, *paths):
 
 
 class FancyBlob(Blob):
-    def __init__(self, download_url, *args, **kwargs) -> None:
+    def __init__(self, download_url, *args, **kwargs):
         self.download_url = download_url
         super().__init__(*args, **kwargs)
 
@@ -160,7 +160,7 @@ class FancyBlob(Blob):
 
 
 class GoogleCloudFile(File):
-    def __init__(self, name, mode, storage) -> None:
+    def __init__(self, name, mode, storage):
         self.name = name
         self.mime_type = mimetypes.guess_type(name)[0]
         self._mode = mode

--- a/src/sentry/filestore/gcs.py
+++ b/src/sentry/filestore/gcs.py
@@ -147,7 +147,7 @@ def safe_join(base, *paths):
 
 
 class FancyBlob(Blob):
-    def __init__(self, download_url, *args, **kwargs):
+    def __init__(self, download_url, *args, **kwargs) -> None:
         self.download_url = download_url
         super().__init__(*args, **kwargs)
 
@@ -160,7 +160,7 @@ class FancyBlob(Blob):
 
 
 class GoogleCloudFile(File):
-    def __init__(self, name, mode, storage):
+    def __init__(self, name, mode, storage) -> None:
         self.name = name
         self.mime_type = mimetypes.guess_type(name)[0]
         self._mode = mode

--- a/src/sentry/filestore/s3.py
+++ b/src/sentry/filestore/s3.py
@@ -127,7 +127,7 @@ class S3Boto3StorageFile(File):
     #       BufferedIO streams in the Python 2.6 io module.
     buffer_size = 5242880
 
-    def __init__(self, name, mode, storage, buffer_size=None):
+    def __init__(self, name, mode, storage, buffer_size=None) -> None:
         self._storage = storage
         self.name = name[len(self._storage.location) :].lstrip("/")
         self._mode = mode
@@ -293,7 +293,7 @@ class S3Boto3Storage(Storage):
     region_name: str | None = None
     use_ssl = True
 
-    def __init__(self, acl=None, bucket=None, **settings):
+    def __init__(self, acl=None, bucket=None, **settings) -> None:
         # check if some of the settings we've provided as class attributes
         # need to be overwritten with values passed in here
         for name, value in settings.items():

--- a/src/sentry/filestore/s3.py
+++ b/src/sentry/filestore/s3.py
@@ -127,7 +127,7 @@ class S3Boto3StorageFile(File):
     #       BufferedIO streams in the Python 2.6 io module.
     buffer_size = 5242880
 
-    def __init__(self, name, mode, storage, buffer_size=None) -> None:
+    def __init__(self, name, mode, storage, buffer_size=None):
         self._storage = storage
         self.name = name[len(self._storage.location) :].lstrip("/")
         self._mode = mode
@@ -293,7 +293,7 @@ class S3Boto3Storage(Storage):
     region_name: str | None = None
     use_ssl = True
 
-    def __init__(self, acl=None, bucket=None, **settings) -> None:
+    def __init__(self, acl=None, bucket=None, **settings):
         # check if some of the settings we've provided as class attributes
         # need to be overwritten with values passed in here
         for name, value in settings.items():

--- a/src/sentry/flags/providers.py
+++ b/src/sentry/flags/providers.py
@@ -67,7 +67,7 @@ class ProviderProtocol(Protocol[T]):
 class DeserializationError(Exception):
     """The request body could not be deserialized."""
 
-    def __init__(self, errors):
+    def __init__(self, errors) -> None:
         self.errors = errors
 
 

--- a/src/sentry/grouping/enhancer/matchers.py
+++ b/src/sentry/grouping/enhancer/matchers.py
@@ -221,7 +221,7 @@ class FrameMatch(EnhancementMatch):
 
         return subclass(key, pattern, negated)
 
-    def __init__(self, key: str, pattern: str, negated: bool = False):
+    def __init__(self, key: str, pattern: str, negated: bool = False) -> None:
         super().__init__()
         try:
             self.key = MATCHERS[key]
@@ -303,7 +303,7 @@ def path_like_match(pattern: bytes, value: bytes) -> bool:
 
 
 class PathLikeMatch(FrameMatch):
-    def __init__(self, key: str, pattern: str, negated: bool = False):
+    def __init__(self, key: str, pattern: str, negated: bool = False) -> None:
         # NOTE: We do not want to mess with `pattern` directly, as that is used for the `description`.
         # We rather want to `lower()` only the encoded pattern used within glob matching.
         super().__init__(key, pattern, negated)
@@ -331,7 +331,7 @@ class PathMatch(PathLikeMatch):
 
 
 class FamilyMatch(FrameMatch):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self._flags = set(self._encoded_pattern.split(b","))
 
@@ -345,7 +345,7 @@ class FamilyMatch(FrameMatch):
 
 
 class InAppMatch(FrameMatch):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self._ref_val = bool_from_string(self.pattern)
 
@@ -423,7 +423,7 @@ class ExceptionMechanismMatch(ExceptionFieldMatch):
 
 
 class CallerMatch(EnhancementMatch):
-    def __init__(self, inner: FrameMatch):
+    def __init__(self, inner: FrameMatch) -> None:
         self.inner = inner
 
     @property
@@ -444,7 +444,7 @@ class CallerMatch(EnhancementMatch):
 
 
 class CalleeMatch(EnhancementMatch):
-    def __init__(self, inner: FrameMatch):
+    def __init__(self, inner: FrameMatch) -> None:
         self.inner = inner
 
     @property

--- a/src/sentry/grouping/enhancer/rules.py
+++ b/src/sentry/grouping/enhancer/rules.py
@@ -12,7 +12,7 @@ class EnhancementRuleDict(TypedDict):
 
 
 class EnhancementRule:
-    def __init__(self, matchers: list[EnhancementMatch], actions: list[EnhancementAction]):
+    def __init__(self, matchers: list[EnhancementMatch], actions: list[EnhancementAction]) -> None:
         self.matchers = matchers
 
         self._exception_matchers = []

--- a/src/sentry/grouping/strategies/base.py
+++ b/src/sentry/grouping/strategies/base.py
@@ -119,7 +119,7 @@ class GroupingContext:
         value_at_some_key = context["some_key"] # will be "original_value"
     """
 
-    def __init__(self, strategy_config: StrategyConfiguration, event: Event):
+    def __init__(self, strategy_config: StrategyConfiguration, event: Event) -> None:
         # The initial context is essentially the grouping config options
         self._stack = [strategy_config.initial_context]
         self.config = strategy_config
@@ -328,7 +328,7 @@ class StrategyConfiguration:
     enhancements_base: str | None = DEFAULT_ENHANCEMENTS_BASE
     fingerprinting_bases: Sequence[str] | None = DEFAULT_GROUPING_FINGERPRINTING_BASES
 
-    def __init__(self, enhancements: str | None = None, **extra: Any):
+    def __init__(self, enhancements: str | None = None, **extra: Any) -> None:
         if enhancements is None:
             enhancements_instance = Enhancements.from_rules_text("", referrer="strategy_config")
         else:

--- a/src/sentry/grouping/variants.py
+++ b/src/sentry/grouping/variants.py
@@ -67,7 +67,7 @@ class ChecksumVariant(BaseVariant):
     type = "checksum"
     description = "legacy checksum"
 
-    def __init__(self, checksum: str):
+    def __init__(self, checksum: str) -> None:
         self.checksum = checksum
 
     def get_hash(self) -> str | None:
@@ -81,7 +81,7 @@ class HashedChecksumVariant(ChecksumVariant):
     type = "hashed_checksum"
     description = "hashed legacy checksum"
 
-    def __init__(self, checksum: str, raw_checksum: str):
+    def __init__(self, checksum: str, raw_checksum: str) -> None:
         self.checksum = checksum
         self.raw_checksum = raw_checksum
 
@@ -110,7 +110,7 @@ class PerformanceProblemVariant(BaseVariant):
     type = "performance_problem"
     description = "performance problem"
 
-    def __init__(self, event_performance_problem: Any):
+    def __init__(self, event_performance_problem: Any) -> None:
         self.event_performance_problem = event_performance_problem
         self.problem = event_performance_problem.problem
 
@@ -191,7 +191,7 @@ class CustomFingerprintVariant(BaseVariant):
 
     type = "custom_fingerprint"
 
-    def __init__(self, fingerprint: list[str], fingerprint_info: FingerprintInfo):
+    def __init__(self, fingerprint: list[str], fingerprint_info: FingerprintInfo) -> None:
         self.values = fingerprint
         self.fingerprint_info = fingerprint_info
 

--- a/src/sentry/http.py
+++ b/src/sentry/http.py
@@ -43,7 +43,7 @@ class UrlResult(NamedTuple):
 class BadSource(Exception):
     error_type = EventError.UNKNOWN_ERROR
 
-    def __init__(self, data=None):
+    def __init__(self, data=None) -> None:
         if data is None:
             data = {}
         data.setdefault("type", self.error_type)

--- a/src/sentry/hybridcloud/apigateway/middleware.py
+++ b/src/sentry/hybridcloud/apigateway/middleware.py
@@ -12,7 +12,7 @@ from sentry.hybridcloud.apigateway import proxy_request_if_needed
 class ApiGatewayMiddleware:
     """Proxy requests intended for remote silos"""
 
-    def __init__(self, get_response: Callable[[Request], HttpResponseBase]):
+    def __init__(self, get_response: Callable[[Request], HttpResponseBase]) -> None:
         self.get_response = get_response
 
     def __call__(self, request: Request) -> HttpResponseBase:

--- a/src/sentry/hybridcloud/apigateway/proxy.py
+++ b/src/sentry/hybridcloud/apigateway/proxy.py
@@ -75,7 +75,7 @@ def _parse_response(response: ExternalResponse, remote_url: str) -> StreamingHtt
 class _body_with_length:
     """Wraps an HttpRequest with a __len__ so that the request library does not assume length=0 in all cases"""
 
-    def __init__(self, request: HttpRequest):
+    def __init__(self, request: HttpRequest) -> None:
         self.request = request
 
     def __iter__(self) -> Iterator[bytes]:

--- a/src/sentry/hybridcloud/rpc/__init__.py
+++ b/src/sentry/hybridcloud/rpc/__init__.py
@@ -113,7 +113,7 @@ class DelegatedBySiloMode(Generic[ServiceInterface]):
     service is closed, or when the backing service implementation changes.
     """
 
-    def __init__(self, mapping: Mapping[SiloMode, Callable[[], ServiceInterface]]):
+    def __init__(self, mapping: Mapping[SiloMode, Callable[[], ServiceInterface]]) -> None:
         self._constructors = mapping
         self._singleton: dict[SiloMode, ServiceInterface] = {}
         self._lock = threading.RLock()

--- a/src/sentry/identity/base.py
+++ b/src/sentry/identity/base.py
@@ -17,7 +17,7 @@ class Provider(PipelineProvider["IdentityPipeline"], abc.ABC):
     A provider indicates how identity authenticate should happen for a given service.
     """
 
-    def __init__(self, **config):
+    def __init__(self, **config) -> None:
         super().__init__()
         self.config = config
         self.logger = logging.getLogger(f"sentry.identity.{self.key}")

--- a/src/sentry/identity/manager.py
+++ b/src/sentry/identity/manager.py
@@ -5,7 +5,7 @@ from sentry.exceptions import NotRegistered
 
 
 class IdentityManager:
-    def __init__(self):
+    def __init__(self) -> None:
         self.__values = {}
         self._login_providers = {}
 

--- a/src/sentry/identity/manager.py
+++ b/src/sentry/identity/manager.py
@@ -5,7 +5,7 @@ from sentry.exceptions import NotRegistered
 
 
 class IdentityManager:
-    def __init__(self) -> None:
+    def __init__(self):
         self.__values = {}
         self._login_providers = {}
 

--- a/src/sentry/identity/oauth2.py
+++ b/src/sentry/identity/oauth2.py
@@ -219,7 +219,7 @@ class OAuth2LoginView:
     client_id: str | None = None
     scope = ""
 
-    def __init__(self, authorize_url=None, client_id=None, scope=None, *args, **kwargs):
+    def __init__(self, authorize_url=None, client_id=None, scope=None, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         if authorize_url is not None:
             self.authorize_url = authorize_url
@@ -269,7 +269,9 @@ class OAuth2CallbackView:
     client_id: str | None = None
     client_secret: str | None = None
 
-    def __init__(self, access_token_url=None, client_id=None, client_secret=None, *args, **kwargs):
+    def __init__(
+        self, access_token_url=None, client_id=None, client_secret=None, *args, **kwargs
+    ) -> None:
         super().__init__(*args, **kwargs)
         if access_token_url is not None:
             self.access_token_url = access_token_url

--- a/src/sentry/identity/slack/provider.py
+++ b/src/sentry/identity/slack/provider.py
@@ -81,7 +81,7 @@ class SlackOAuth2LoginView(OAuth2LoginView):
 
     user_scope = ""
 
-    def __init__(self, authorize_url=None, client_id=None, scope=None, user_scope=None):
+    def __init__(self, authorize_url=None, client_id=None, scope=None, user_scope=None) -> None:
         super().__init__(authorize_url=authorize_url, client_id=client_id, scope=scope)
         if user_scope is not None:
             self.user_scope = user_scope

--- a/src/sentry/incidents/endpoints/serializers/alert_rule.py
+++ b/src/sentry/incidents/endpoints/serializers/alert_rule.py
@@ -99,7 +99,9 @@ class AlertRuleSerializer(Serializer):
     Serializer for returning an alert rule to the client
     """
 
-    def __init__(self, expand: list[str] | None = None, prepare_component_fields: bool = False):
+    def __init__(
+        self, expand: list[str] | None = None, prepare_component_fields: bool = False
+    ) -> None:
         self.expand = expand or []
         self.prepare_component_fields = prepare_component_fields
 
@@ -349,7 +351,7 @@ class DetailedAlertRuleSerializer(AlertRuleSerializer):
 
 
 class CombinedRuleSerializer(Serializer):
-    def __init__(self, expand: list[str] | None = None):
+    def __init__(self, expand: list[str] | None = None) -> None:
         self.expand = expand or []
 
     def get_attrs(

--- a/src/sentry/incidents/endpoints/serializers/incident.py
+++ b/src/sentry/incidents/endpoints/serializers/incident.py
@@ -38,7 +38,7 @@ class DetailedIncidentSerializerResponse(IncidentSerializerResponse):
 
 @register(Incident)
 class IncidentSerializer(Serializer):
-    def __init__(self, expand=None):
+    def __init__(self, expand=None) -> None:
         self.expand = expand or []
 
     def get_attrs(self, item_list, user, **kwargs):
@@ -96,7 +96,7 @@ class IncidentSerializer(Serializer):
 
 
 class DetailedIncidentSerializer(IncidentSerializer):
-    def __init__(self, expand=None):
+    def __init__(self, expand=None) -> None:
         if expand is None:
             expand = []
         if "original_alert_rule" not in expand:

--- a/src/sentry/incidents/endpoints/serializers/workflow_engine_detector.py
+++ b/src/sentry/incidents/endpoints/serializers/workflow_engine_detector.py
@@ -41,7 +41,9 @@ class WorkflowEngineDetectorSerializer(Serializer):
     A temporary serializer to be used by the old alert rule endpoints to return data read from the new ACI models
     """
 
-    def __init__(self, expand: list[str] | None = None, prepare_component_fields: bool = False):
+    def __init__(
+        self, expand: list[str] | None = None, prepare_component_fields: bool = False
+    ) -> None:
         self.expand = expand or []
         self.prepare_component_fields = prepare_component_fields
 

--- a/src/sentry/incidents/endpoints/serializers/workflow_engine_incident.py
+++ b/src/sentry/incidents/endpoints/serializers/workflow_engine_incident.py
@@ -46,7 +46,7 @@ class WorkflowEngineIncidentSerializer(Serializer):
         PriorityLevel.LOW.value: IncidentStatus.OPEN.value,
     }
 
-    def __init__(self, expand=None):
+    def __init__(self, expand=None) -> None:
         self.expand = expand or []
 
     def get_attrs(
@@ -282,7 +282,7 @@ class WorkflowEngineIncidentSerializer(Serializer):
 
 
 class WorkflowEngineDetailedIncidentSerializer(WorkflowEngineIncidentSerializer):
-    def __init__(self, expand=None):
+    def __init__(self, expand=None) -> None:
         if expand is None:
             expand = []
         super().__init__(expand=expand)

--- a/src/sentry/incidents/endpoints/team_alerts_triggered.py
+++ b/src/sentry/incidents/endpoints/team_alerts_triggered.py
@@ -82,7 +82,7 @@ class TeamAlertsTriggeredTotalsEndpoint(TeamEndpoint):
 
 
 class TriggeredAlertRuleSerializer(AlertRuleSerializer):
-    def __init__(self, start, end):
+    def __init__(self, start, end) -> None:
         super().__init__()
         self.start = start
         self.end = end

--- a/src/sentry/ingest/inbound_filters.py
+++ b/src/sentry/ingest/inbound_filters.py
@@ -185,7 +185,7 @@ class _FilterSpec:
     config_name: the name under which it will be serialized in the config (if None id will be used)
     """
 
-    def __init__(self, id, name, description, serializer_cls=None, config_name=None):
+    def __init__(self, id, name, description, serializer_cls=None, config_name=None) -> None:
         self.id = id
         self.name = name
         self.description = description

--- a/src/sentry/ingest/transaction_clusterer/rules.py
+++ b/src/sentry/ingest/transaction_clusterer/rules.py
@@ -42,7 +42,7 @@ class RedisRuleStore:
     responsible for that.
     """
 
-    def __init__(self, namespace: ClustererNamespace):
+    def __init__(self, namespace: ClustererNamespace) -> None:
         self._rules_prefix = namespace.value.rules
 
     def _get_rules_key(self, project: Project) -> str:
@@ -79,7 +79,7 @@ class RedisRuleStore:
 
 
 class ProjectOptionRuleStore:
-    def __init__(self, namespace: ClustererNamespace):
+    def __init__(self, namespace: ClustererNamespace) -> None:
         self._storage = namespace.value.persistent_storage
         self._tracker = namespace.value.tracker
 
@@ -112,7 +112,7 @@ class CompositeRuleStore:
     #: Maximum number (non-negative integer) of rules to write to stores.
     MERGE_MAX_RULES: int = 50
 
-    def __init__(self, namespace: ClustererNamespace, stores: list[RuleStore]):
+    def __init__(self, namespace: ClustererNamespace, stores: list[RuleStore]) -> None:
         self._namespace = namespace
         self._stores = stores
 
@@ -163,7 +163,7 @@ class CompositeRuleStore:
 
 
 class LocalRuleStore:
-    def __init__(self, rules: RuleSet):
+    def __init__(self, rules: RuleSet) -> None:
         self._rules = rules
 
     def read(self, project: Project) -> RuleSet:

--- a/src/sentry/integrations/api/endpoints/integration_proxy.py
+++ b/src/sentry/integrations/api/endpoints/integration_proxy.py
@@ -48,7 +48,7 @@ class InternalIntegrationProxyEndpoint(Endpoint):
     integration on behalf of credentials stored in the control silo.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.log_extra = dict()
 

--- a/src/sentry/integrations/aws_lambda/integration.py
+++ b/src/sentry/integrations/aws_lambda/integration.py
@@ -80,7 +80,7 @@ metadata = IntegrationMetadata(
 
 
 class AwsLambdaIntegration(IntegrationInstallation, ServerlessMixin):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self._client = None
 

--- a/src/sentry/integrations/bitbucket/client.py
+++ b/src/sentry/integrations/bitbucket/client.py
@@ -56,7 +56,7 @@ class BitbucketApiClient(ApiClient, RepositoryClient):
 
     integration_name = IntegrationProviderSlug.BITBUCKET.value
 
-    def __init__(self, integration: RpcIntegration | Integration):
+    def __init__(self, integration: RpcIntegration | Integration) -> None:
         self.base_url = integration.metadata["base_url"]
         self.shared_secret = integration.metadata["shared_secret"]
         # subject is probably the clientKey

--- a/src/sentry/integrations/bitbucket_server/client.py
+++ b/src/sentry/integrations/bitbucket_server/client.py
@@ -28,7 +28,9 @@ class BitbucketServerSetupClient(ApiClient):
     authorize_url = "{}/plugins/servlet/oauth/authorize?oauth_token={}"
     integration_name = "bitbucket_server_setup"
 
-    def __init__(self, base_url, consumer_key, private_key, verify_ssl=True, *args, **kwargs):
+    def __init__(
+        self, base_url, consumer_key, private_key, verify_ssl=True, *args, **kwargs
+    ) -> None:
         super().__init__(*args, **kwargs)
         self.base_url = base_url
         self.consumer_key = consumer_key

--- a/src/sentry/integrations/discord/client.py
+++ b/src/sentry/integrations/discord/client.py
@@ -51,7 +51,7 @@ class DiscordClient(ApiClient):
     _METRICS_USER_ERROR_KEY: str = "sentry.integrations.discord.failure.user_error"
     _METRICS_RATE_LIMIT_KEY: str = "sentry.integrations.discord.failure.rate_limit"
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.application_id = options.get("discord.application-id")
         self.client_secret = options.get("discord.client-secret")

--- a/src/sentry/integrations/discord/integration.py
+++ b/src/sentry/integrations/discord/integration.py
@@ -284,7 +284,7 @@ class DiscordIntegrationProvider(IntegrationProvider):
 
 
 class DiscordInstallPipeline:
-    def __init__(self, params):
+    def __init__(self, params) -> None:
         self.params = params
         super().__init__()
 

--- a/src/sentry/integrations/discord/message_builder/base/component/action_row.py
+++ b/src/sentry/integrations/discord/message_builder/base/component/action_row.py
@@ -13,7 +13,7 @@ class DiscordActionRowError(Exception):
 
 
 class DiscordActionRow(DiscordMessageComponent):
-    def __init__(self, components: Iterable[DiscordMessageComponent]):
+    def __init__(self, components: Iterable[DiscordMessageComponent]) -> None:
         for component in components:
             if isinstance(component, DiscordActionRow):
                 raise DiscordActionRowError()

--- a/src/sentry/integrations/discord/message_builder/base/flags.py
+++ b/src/sentry/integrations/discord/message_builder/base/flags.py
@@ -15,7 +15,7 @@ class DiscordMessageFlags:
     https://discord.com/developers/docs/resources/channel#message-object-message-flags
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.value = 0
 
     def set_ephemeral(self) -> DiscordMessageFlags:

--- a/src/sentry/integrations/discord/requests/base.py
+++ b/src/sentry/integrations/discord/requests/base.py
@@ -56,7 +56,7 @@ class DiscordRequest:
     appropriate response code that the endpoint should respond with.
     """
 
-    def __init__(self, request: Request):
+    def __init__(self, request: Request) -> None:
         self.request = request
         self._body = self.request.body.decode()
         self._data: Mapping[str, object] = orjson.loads(self.request.body)

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -68,7 +68,7 @@ class GithubSetupApiClient(IntegrationProxyClient):
     base_url = "https://api.github.com"
     integration_name = "github_setup"
 
-    def __init__(self, access_token: str | None = None, verify_ssl: bool = True):
+    def __init__(self, access_token: str | None = None, verify_ssl: bool = True) -> None:
         super().__init__(verify_ssl=verify_ssl)
         self.jwt = get_jwt()
         self.access_token = access_token

--- a/src/sentry/integrations/github_enterprise/client.py
+++ b/src/sentry/integrations/github_enterprise/client.py
@@ -6,7 +6,9 @@ from sentry.integrations.types import IntegrationProviderSlug
 class GitHubEnterpriseApiClient(GitHubBaseClient):
     integration_name = IntegrationProviderSlug.GITHUB_ENTERPRISE.value
 
-    def __init__(self, base_url, integration, app_id, private_key, verify_ssl, org_integration_id):
+    def __init__(
+        self, base_url, integration, app_id, private_key, verify_ssl, org_integration_id
+    ) -> None:
         self.base_url = f"https://{base_url}"
         self.integration = integration
         self.app_id = app_id

--- a/src/sentry/integrations/github_enterprise/integration.py
+++ b/src/sentry/integrations/github_enterprise/integration.py
@@ -330,7 +330,7 @@ class InstallationForm(forms.Form):
         widget=forms.TextInput(attrs={"placeholder": "XXXXXXXXXXXXXXXXXXXXXXXXXXX"}),
     )
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.fields["verify_ssl"].initial = True
 

--- a/src/sentry/integrations/gitlab/client.py
+++ b/src/sentry/integrations/gitlab/client.py
@@ -41,7 +41,7 @@ class GitLabSetupApiClient(IntegrationProxyClient):
 
     integration_name = "gitlab_setup"
 
-    def __init__(self, base_url: str, access_token: str, verify_ssl: bool):
+    def __init__(self, base_url: str, access_token: str, verify_ssl: bool) -> None:
         super().__init__(verify_ssl=verify_ssl)
         self.base_url = base_url
         self.token = access_token
@@ -69,7 +69,7 @@ class GitLabSetupApiClient(IntegrationProxyClient):
 
 
 class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextClient):
-    def __init__(self, installation: GitlabIntegration):
+    def __init__(self, installation: GitlabIntegration) -> None:
         self.installation = installation
         verify_ssl = self.metadata["verify_ssl"]
         self.is_refreshing_token = False

--- a/src/sentry/integrations/jira_server/client.py
+++ b/src/sentry/integrations/jira_server/client.py
@@ -237,7 +237,7 @@ class JiraServerSetupClient(ApiClient):
     LEGACY_WEBHOOK_URL = "/rest/webhooks/1.0/webhook"
 
     @control_silo_function
-    def __init__(self, base_url, consumer_key, private_key, verify_ssl=True):
+    def __init__(self, base_url, consumer_key, private_key, verify_ssl=True) -> None:
         self.base_url = base_url
         self.consumer_key = consumer_key
         self.private_key = private_key

--- a/src/sentry/integrations/messaging/spec.py
+++ b/src/sentry/integrations/messaging/spec.py
@@ -181,7 +181,7 @@ class MessagingIntegrationSpec(ABC):
 
 
 class MessagingActionHandler(DefaultActionHandler):
-    def __init__(self, spec: MessagingIntegrationSpec):
+    def __init__(self, spec: MessagingIntegrationSpec) -> None:
         super().__init__()
         self._spec = spec
 

--- a/src/sentry/integrations/middleware/hybrid_cloud/parser.py
+++ b/src/sentry/integrations/middleware/hybrid_cloud/parser.py
@@ -66,7 +66,7 @@ class BaseRequestParser(ABC):
     webhook_identifier: ClassVar[WebhookProviderIdentifier]
     """The webhook provider identifier"""
 
-    def __init__(self, request: HttpRequest, response_handler: ResponseHandler):
+    def __init__(self, request: HttpRequest, response_handler: ResponseHandler) -> None:
         self.request = request
         self.match: ResolverMatch = resolve(self.request.path)
         self.view_class = None

--- a/src/sentry/integrations/msteams/actions/form.py
+++ b/src/sentry/integrations/msteams/actions/form.py
@@ -13,7 +13,7 @@ class MsTeamsNotifyServiceForm(forms.Form):
     channel = forms.CharField(widget=forms.TextInput())
     channel_id = forms.HiddenInput()
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         self._team_list = [(i.id, i.name) for i in kwargs.pop("integrations")]
         self.channel_transformer = kwargs.pop("channel_transformer")
 

--- a/src/sentry/integrations/msteams/actions/notification.py
+++ b/src/sentry/integrations/msteams/actions/notification.py
@@ -25,7 +25,7 @@ class MsTeamsNotifyServiceAction(IntegrationEventAction):
     provider = IntegrationProviderSlug.MSTEAMS.value
     integration_key = "team"
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.form_fields = {
             "team": {

--- a/src/sentry/integrations/msteams/client.py
+++ b/src/sentry/integrations/msteams/client.py
@@ -77,7 +77,7 @@ class MsTeamsClientABC(ApiClient, ABC):
 class MsTeamsPreInstallClient(MsTeamsClientABC):
     integration_name = IntegrationProviderSlug.MSTEAMS.value
 
-    def __init__(self, access_token: str, service_url: str):
+    def __init__(self, access_token: str, service_url: str) -> None:
         super().__init__()
         self.access_token = access_token
         self.base_url = service_url.rstrip("/")
@@ -91,7 +91,7 @@ class MsTeamsPreInstallClient(MsTeamsClientABC):
 class MsTeamsClient(MsTeamsClientABC, IntegrationProxyClient):
     integration_name = IntegrationProviderSlug.MSTEAMS.value
 
-    def __init__(self, integration: Integration | RpcIntegration):
+    def __init__(self, integration: Integration | RpcIntegration) -> None:
         self.integration = integration
         self.metadata = self.integration.metadata
         self.base_url = self.metadata["service_url"].rstrip("/")
@@ -142,7 +142,7 @@ class OAuthMsTeamsClient(ApiClient):
 
     TOKEN_URL = "/oauth2/v2.0/token"
 
-    def __init__(self, client_id, client_secret):
+    def __init__(self, client_id, client_secret) -> None:
         super().__init__()
         self.client_id = client_id
         self.client_secret = client_secret

--- a/src/sentry/integrations/opsgenie/actions/form.py
+++ b/src/sentry/integrations/opsgenie/actions/form.py
@@ -36,7 +36,7 @@ class OpsgenieNotifyTeamForm(forms.Form):
     account = forms.ChoiceField(choices=(), widget=forms.Select())
     team = forms.ChoiceField(required=False, choices=(), widget=forms.Select())
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         self.org_id = kwargs.pop("org_id")
         self._integrations = [(i.id, i.name) for i in kwargs.pop("integrations")]
         self._teams = kwargs.pop("teams")

--- a/src/sentry/integrations/opsgenie/actions/notification.py
+++ b/src/sentry/integrations/opsgenie/actions/notification.py
@@ -29,7 +29,7 @@ class OpsgenieNotifyTeamAction(IntegrationEventAction):
     provider = IntegrationProviderSlug.OPSGENIE.value
     integration_key = "account"
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.form_fields = {
             "account": {

--- a/src/sentry/integrations/pagerduty/actions/form.py
+++ b/src/sentry/integrations/pagerduty/actions/form.py
@@ -29,7 +29,7 @@ class PagerDutyNotifyServiceForm(forms.Form):
     account = forms.ChoiceField(choices=(), widget=forms.Select())
     service = forms.ChoiceField(required=False, choices=(), widget=forms.Select())
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         integrations = [(i.id, i.name) for i in kwargs.pop("integrations")]
         services = kwargs.pop("services")
 

--- a/src/sentry/integrations/pagerduty/actions/notification.py
+++ b/src/sentry/integrations/pagerduty/actions/notification.py
@@ -29,7 +29,7 @@ class PagerDutyNotifyServiceAction(IntegrationEventAction):
     provider = IntegrationProviderSlug.PAGERDUTY.value
     integration_key = "account"
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.form_fields = {
             "account": {

--- a/src/sentry/integrations/slack/sdk_client.py
+++ b/src/sentry/integrations/slack/sdk_client.py
@@ -90,7 +90,7 @@ class MetaClass(type):
 
 
 class SlackSdkClient(WebClient, metaclass=MetaClass):
-    def __init__(self, integration_id: int):
+    def __init__(self, integration_id: int) -> None:
         self.integration_id = integration_id
 
         integration: Integration | RpcIntegration | None

--- a/src/sentry/integrations/slack/views/link_team.py
+++ b/src/sentry/integrations/slack/views/link_team.py
@@ -47,7 +47,7 @@ def build_team_linking_url(
 class SelectTeamForm(forms.Form):
     team = forms.ChoiceField(label="Team")
 
-    def __init__(self, teams: Sequence[Team], *args: Any, **kwargs: Any):
+    def __init__(self, teams: Sequence[Team], *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
         team_field = self.fields["team"]

--- a/src/sentry/integrations/source_code_management/commit_context.py
+++ b/src/sentry/integrations/source_code_management/commit_context.py
@@ -496,7 +496,7 @@ class CommitContextClient(ABC):
 
 
 class PRCommentWorkflow(ABC):
-    def __init__(self, integration: CommitContextIntegration):
+    def __init__(self, integration: CommitContextIntegration) -> None:
         self.integration = integration
 
     @property
@@ -611,7 +611,7 @@ class PRCommentWorkflow(ABC):
 
 
 class OpenPRCommentWorkflow(ABC):
-    def __init__(self, integration: CommitContextIntegration):
+    def __init__(self, integration: CommitContextIntegration) -> None:
         self.integration = integration
 
     @property

--- a/src/sentry/integrations/vercel/client.py
+++ b/src/sentry/integrations/vercel/client.py
@@ -45,7 +45,7 @@ class VercelClient(ApiClient):
     # https://vercel.com/docs/rest-api#endpoints/integrations/delete-an-integration-configuration
     UNINSTALL = "/v1/integrations/configuration/%s"
 
-    def __init__(self, access_token, team_id=None):
+    def __init__(self, access_token, team_id=None) -> None:
         super().__init__()
         self.access_token = access_token
         self.team_id = team_id

--- a/src/sentry/integrations/vsts/client.py
+++ b/src/sentry/integrations/vsts/client.py
@@ -123,7 +123,7 @@ class VstsSetupApiClient(ApiClient):
     api_version = "4.1"  # TODO: update api version
     api_version_preview = "-preview.1"
 
-    def __init__(self, base_url: str, oauth_redirect_url: str, access_token: str):
+    def __init__(self, base_url: str, oauth_redirect_url: str, access_token: str) -> None:
         super().__init__()
         self.base_url = base_url
         self.oauth_redirect_url = oauth_redirect_url

--- a/src/sentry/interfaces/base.py
+++ b/src/sentry/interfaces/base.py
@@ -67,7 +67,7 @@ class Interface:
     ephemeral = False
     grouping_variants = ["default"]
 
-    def __init__(self, **data):
+    def __init__(self, **data) -> None:
         self._data = data or {}
 
     @classproperty

--- a/src/sentry/interfaces/contexts.py
+++ b/src/sentry/interfaces/contexts.py
@@ -83,7 +83,7 @@ class ContextType:
     type: str
     """This should match the `type` key in context object"""
 
-    def __init__(self, alias, data):
+    def __init__(self, alias, data) -> None:
         self.alias = alias
         ctx_data = {}
         for key, value in data.items():

--- a/src/sentry/issues/auto_source_code_config/code_mapping.py
+++ b/src/sentry/issues/auto_source_code_config/code_mapping.py
@@ -65,7 +65,7 @@ def derive_code_mappings(
 class CodeMappingTreesHelper:
     platform: str | None = None
 
-    def __init__(self, trees: Mapping[str, RepoTree]):
+    def __init__(self, trees: Mapping[str, RepoTree]) -> None:
         self.trees = trees
         self.code_mappings: dict[str, CodeMapping] = {}
 

--- a/src/sentry/lang/javascript/cache.py
+++ b/src/sentry/lang/javascript/cache.py
@@ -11,7 +11,7 @@ def is_utf8(codec):
 
 
 class SourceCache:
-    def __init__(self) -> None:
+    def __init__(self):
         self._cache = {}
         self._errors = {}
         self._aliases = {}
@@ -68,7 +68,7 @@ class SourceMapCache:
         - a source map's url and the map's contents.
     """
 
-    def __init__(self) -> None:
+    def __init__(self):
         self._cache = {}
         self._mapping = {}
 

--- a/src/sentry/lang/javascript/cache.py
+++ b/src/sentry/lang/javascript/cache.py
@@ -11,7 +11,7 @@ def is_utf8(codec):
 
 
 class SourceCache:
-    def __init__(self):
+    def __init__(self) -> None:
         self._cache = {}
         self._errors = {}
         self._aliases = {}
@@ -68,7 +68,7 @@ class SourceMapCache:
         - a source map's url and the map's contents.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._cache = {}
         self._mapping = {}
 

--- a/src/sentry/lang/javascript/errormapping.py
+++ b/src/sentry/lang/javascript/errormapping.py
@@ -39,7 +39,7 @@ def is_expired(ts):
 
 
 class Processor:
-    def __init__(self, vendor: str, mapping_url, regex, func):
+    def __init__(self, vendor: str, mapping_url, regex, func) -> None:
         self.vendor: str = vendor
         self.mapping_url = mapping_url
         self.regex = re.compile(regex)

--- a/src/sentry/lang/native/error.py
+++ b/src/sentry/lang/native/error.py
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 
 
 class SymbolicationFailed(Exception):
-    def __init__(self, message=None, type=None, obj=None):
+    def __init__(self, message=None, type=None, obj=None) -> None:
         Exception.__init__(self)
         self.message = str(message)
         self.type = type

--- a/src/sentry/lang/native/utils.py
+++ b/src/sentry/lang/native/utils.py
@@ -167,7 +167,7 @@ class Backoff:
     Creates a new exponential backoff.
     """
 
-    def __init__(self, initial, max):
+    def __init__(self, initial, max) -> None:
         """
         :param initial: The initial backoff time in seconds.
         :param max: The maximum backoff time in seconds.

--- a/src/sentry/logging/handlers.py
+++ b/src/sentry/logging/handlers.py
@@ -143,7 +143,7 @@ class MessageContainsFilter(logging.Filter):
     contains -- a string or list of strings to match
     """
 
-    def __init__(self, contains):
+    def __init__(self, contains) -> None:
         if not isinstance(contains, list):
             contains = [contains]
         if not all(isinstance(c, str) for c in contains):
@@ -184,7 +184,7 @@ class SamplingFilter(logging.Filter):
     level  -- sampling applies to log records with this level OR LOWER. Other records always pass through.
     """
 
-    def __init__(self, p: float, level: int | None = None):
+    def __init__(self, p: float, level: int | None = None) -> None:
         super().__init__()
         assert 0.0 <= p <= 1.0
         self.sample_rate = p

--- a/src/sentry/mail/actions.py
+++ b/src/sentry/mail/actions.py
@@ -21,7 +21,7 @@ class NotifyEmailAction(EventAction):
     prompt = "Send a notification"
     metrics_slug = "EmailAction"
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.form_fields = {
             "targetType": {"type": "mailAction", "choices": ACTION_CHOICES},

--- a/src/sentry/mail/forms/member_team.py
+++ b/src/sentry/mail/forms/member_team.py
@@ -21,7 +21,7 @@ class MemberTeamForm(forms.Form, Generic[T]):
     memberValue: T
     targetTypeEnum: type[T]
 
-    def __init__(self, project, *args, **kwargs):
+    def __init__(self, project, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.project = project
 

--- a/src/sentry/middleware/devtoolbar.py
+++ b/src/sentry/middleware/devtoolbar.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 class DevToolbarAnalyticsMiddleware:
-    def __init__(self, get_response):
+    def __init__(self, get_response) -> None:
         self.get_response = get_response
 
     def __call__(self, request):

--- a/src/sentry/middleware/integrations/integration_control.py
+++ b/src/sentry/middleware/integrations/integration_control.py
@@ -30,7 +30,7 @@ class IntegrationControlMiddleware:
     getsentry expands this list on django initialization.
     """
 
-    def __init__(self, get_response: ResponseHandler):
+    def __init__(self, get_response: ResponseHandler) -> None:
         self.get_response = get_response
 
     def _should_operate(self, request: HttpRequest) -> bool:

--- a/src/sentry/middleware/ratelimit.py
+++ b/src/sentry/middleware/ratelimit.py
@@ -38,7 +38,7 @@ class RatelimitMiddleware:
     See: https://docs.djangoproject.com/en/4.0/topics/http/middleware/#writing-your-own-middleware
     """
 
-    def __init__(self, get_response: Callable[[HttpRequest], HttpResponseBase]):
+    def __init__(self, get_response: Callable[[HttpRequest], HttpResponseBase]) -> None:
         self.get_response = get_response
 
     def __call__(self, request: HttpRequest) -> HttpResponseBase:

--- a/src/sentry/middleware/reporting_endpoint.py
+++ b/src/sentry/middleware/reporting_endpoint.py
@@ -11,7 +11,7 @@ class ReportingEndpointMiddleware:
     Add ReportingEndpoint header for Sentry staff users only.
     """
 
-    def __init__(self, get_response: Callable[[HttpRequest], HttpResponseBase]):
+    def __init__(self, get_response: Callable[[HttpRequest], HttpResponseBase]) -> None:
         self.get_response = get_response
 
     def __call__(self, request: HttpRequest) -> HttpResponseBase:

--- a/src/sentry/middleware/staff.py
+++ b/src/sentry/middleware/staff.py
@@ -8,7 +8,7 @@ from sentry.auth.staff import Staff, logger
 
 
 class StaffMiddleware:
-    def __init__(self, get_response: Callable[[HttpRequest], HttpResponseBase]):
+    def __init__(self, get_response: Callable[[HttpRequest], HttpResponseBase]) -> None:
         self.get_response = get_response
 
     def process_request(self, request: HttpRequest) -> None:

--- a/src/sentry/middleware/subdomain.py
+++ b/src/sentry/middleware/subdomain.py
@@ -21,7 +21,7 @@ class SubdomainMiddleware:
     If no subdomain is extracted, then request.subdomain is None.
     """
 
-    def __init__(self, get_response: Callable[[HttpRequest], HttpResponseBase]):
+    def __init__(self, get_response: Callable[[HttpRequest], HttpResponseBase]) -> None:
         self.base_hostname = options.get("system.base-hostname")
 
         if self.base_hostname:

--- a/src/sentry/models/apiscopes.py
+++ b/src/sentry/models/apiscopes.py
@@ -33,7 +33,7 @@ class ApiScopes(Sequence):
 
     alerts = (("alerts:read"), ("alerts:write"))
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.scopes = (
             self.__class__.project
             + self.__class__.team

--- a/src/sentry/models/artifactbundle.py
+++ b/src/sentry/models/artifactbundle.py
@@ -211,7 +211,7 @@ class ProjectArtifactBundle(Model):
 class ArtifactBundleArchive:
     """Read-only view of uploaded ZIP artifact bundle."""
 
-    def __init__(self, fileobj: IO, build_memory_map: bool = True):
+    def __init__(self, fileobj: IO, build_memory_map: bool = True) -> None:
         self._fileobj = fileobj
         self._zip_file = zipfile.ZipFile(self._fileobj)
         self._entries_by_debug_id: dict[tuple[str, SourceFileType], tuple[str, str, dict[str, Any]]]

--- a/src/sentry/models/eventerror.py
+++ b/src/sentry/models/eventerror.py
@@ -103,7 +103,7 @@ class EventError:
     def get_message(cls, data):
         return cls(data).message
 
-    def __init__(self, data):
+    def __init__(self, data) -> None:
         self._data = data
 
     @property

--- a/src/sentry/models/featureadoption.py
+++ b/src/sentry/models/featureadoption.py
@@ -120,7 +120,7 @@ manager.add(92, "metric_alert_rules", "Metric Alert Rules", "web", prerequisite=
 
 
 class FeatureAdoptionRedisBackend:
-    def __init__(self, key_tpl=FEATURE_ADOPTION_REDIS_KEY, **options):
+    def __init__(self, key_tpl=FEATURE_ADOPTION_REDIS_KEY, **options) -> None:
         self.key_tpl = key_tpl
         self.is_redis_cluster, self.cluster, _config = get_dynamic_cluster_from_options(
             "SENTRY_FEATURE_ADOPTION_CACHE_OPTIONS", options

--- a/src/sentry/models/files/abstractfile.py
+++ b/src/sentry/models/files/abstractfile.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 
 
 class ChunkedFileBlobIndexWrapper:
-    def __init__(self, indexes, mode=None, prefetch=False, prefetch_to=None, delete=True):
+    def __init__(self, indexes, mode=None, prefetch=False, prefetch_to=None, delete=True) -> None:
         # eager load from database incase its a queryset
         self._indexes = list(indexes)
         self._curfile = None

--- a/src/sentry/models/files/abstractfile.py
+++ b/src/sentry/models/files/abstractfile.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 
 
 class ChunkedFileBlobIndexWrapper:
-    def __init__(self, indexes, mode=None, prefetch=False, prefetch_to=None, delete=True) -> None:
+    def __init__(self, indexes, mode=None, prefetch=False, prefetch_to=None, delete=True):
         # eager load from database incase its a queryset
         self._indexes = list(indexes)
         self._curfile = None

--- a/src/sentry/models/groupmeta.py
+++ b/src/sentry/models/groupmeta.py
@@ -17,7 +17,7 @@ class GroupMetaCacheNotPopulated(Exception):
 
 
 class GroupMetaManager(BaseManager["GroupMeta"]):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.__local_cache = threading.local()
 

--- a/src/sentry/models/releasefile.py
+++ b/src/sentry/models/releasefile.py
@@ -153,7 +153,7 @@ class ReleaseFile(Model):
 class ReleaseArchive:
     """Read-only view of uploaded ZIP-archive of release files"""
 
-    def __init__(self, fileobj: IO):
+    def __init__(self, fileobj: IO) -> None:
         self._fileobj = fileobj
         self._zip_file = zipfile.ZipFile(self._fileobj)
         self.manifest = self._read_manifest()
@@ -205,7 +205,7 @@ class ReleaseArchive:
 class _ArtifactIndexData:
     """Holds data of artifact index and keeps track of changes"""
 
-    def __init__(self, data: dict, fresh=False):
+    def __init__(self, data: dict, fresh=False) -> None:
         self._data = data
         self.changed = fresh
 
@@ -238,7 +238,7 @@ class _ArtifactIndexData:
 class _ArtifactIndexGuard:
     """Ensures atomic write operations to the artifact index"""
 
-    def __init__(self, release: Release, dist: Distribution | None, **filter_args):
+    def __init__(self, release: Release, dist: Distribution | None, **filter_args) -> None:
         self._release = release
         self._dist = dist
         self._ident = ReleaseFile.get_ident(ARTIFACT_INDEX_FILENAME, dist and dist.name)

--- a/src/sentry/models/sourcemapprocessingissue.py
+++ b/src/sentry/models/sourcemapprocessingissue.py
@@ -31,7 +31,7 @@ class SourceMapProcessingIssue:
     def get_message(cls, data):
         return cls(data).message
 
-    def __init__(self, type, data=None):
+    def __init__(self, type, data=None) -> None:
         self.type = type
         self.data = data
 

--- a/src/sentry/monitors/serializers.py
+++ b/src/sentry/monitors/serializers.py
@@ -174,7 +174,7 @@ class MonitorBulkEditResponse:
 
 @register(Monitor)
 class MonitorSerializer(Serializer):
-    def __init__(self, environments=None, expand=None):
+    def __init__(self, environments=None, expand=None) -> None:
         self.environments = environments
         self.expand = expand
 
@@ -288,7 +288,9 @@ class MonitorCheckInSerializerResponse(MonitorCheckInSerializerResponseOptional)
 
 @register(MonitorCheckIn)
 class MonitorCheckInSerializer(Serializer):
-    def __init__(self, start=None, end=None, expand=None, organization_id=None, project_id=None):
+    def __init__(
+        self, start=None, end=None, expand=None, organization_id=None, project_id=None
+    ) -> None:
         self.start = start  # timestamp of the beginning of the specified date range
         self.end = end  # timestamp of the end of the specified date range
         self.expand = expand

--- a/src/sentry/net/http.py
+++ b/src/sentry/net/http.py
@@ -31,7 +31,9 @@ class SafeConnectionMixin:
 
     is_ipaddress_permitted: IsIpAddressPermitted = None
 
-    def __init__(self, *args, is_ipaddress_permitted: IsIpAddressPermitted = None, **kwargs):
+    def __init__(
+        self, *args, is_ipaddress_permitted: IsIpAddressPermitted = None, **kwargs
+    ) -> None:
         self.is_ipaddress_permitted = is_ipaddress_permitted
         super().__init__(*args, **kwargs)
 
@@ -109,7 +111,9 @@ class SafeHTTPSConnection(SafeConnectionMixin, HTTPSConnection):
 class SafeHTTPConnectionPool(HTTPConnectionPool):
     ConnectionCls = SafeHTTPConnection
 
-    def __init__(self, *args, is_ipaddress_permitted: IsIpAddressPermitted = None, **kwargs):
+    def __init__(
+        self, *args, is_ipaddress_permitted: IsIpAddressPermitted = None, **kwargs
+    ) -> None:
         super().__init__(*args, **kwargs)
         self.ConnectionCls = partial(
             self.ConnectionCls, is_ipaddress_permitted=is_ipaddress_permitted
@@ -119,7 +123,9 @@ class SafeHTTPConnectionPool(HTTPConnectionPool):
 class SafeHTTPSConnectionPool(HTTPSConnectionPool):
     ConnectionCls = SafeHTTPSConnection
 
-    def __init__(self, *args, is_ipaddress_permitted: IsIpAddressPermitted = None, **kwargs):
+    def __init__(
+        self, *args, is_ipaddress_permitted: IsIpAddressPermitted = None, **kwargs
+    ) -> None:
         super().__init__(*args, **kwargs)
         self.ConnectionCls = partial(
             self.ConnectionCls, is_ipaddress_permitted=is_ipaddress_permitted
@@ -133,7 +139,9 @@ class SafePoolManager(PoolManager):
     ConnectionPool classes to create.
     """
 
-    def __init__(self, *args, is_ipaddress_permitted: IsIpAddressPermitted = None, **kwargs):
+    def __init__(
+        self, *args, is_ipaddress_permitted: IsIpAddressPermitted = None, **kwargs
+    ) -> None:
         PoolManager.__init__(self, *args, **kwargs)
         self.pool_classes_by_scheme = {
             "http": partial(SafeHTTPConnectionPool, is_ipaddress_permitted=is_ipaddress_permitted),  # type: ignore[dict-item]  # https://github.com/urllib3/urllib3/issues/3554
@@ -177,7 +185,7 @@ class BlacklistAdapter(HTTPAdapter):
 
 
 class TimeoutAdapter(HTTPAdapter):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         timeout = kwargs.pop("timeout", None)
         HTTPAdapter.__init__(self, *args, **kwargs)
         if timeout is None:
@@ -220,7 +228,7 @@ class SafeSession(Session):
 class UnixHTTPConnection(HTTPConnection):
     default_socket_options = []
 
-    def __init__(self, host, **kwargs):
+    def __init__(self, host, **kwargs) -> None:
         # We're using the `host` as the socket path, but
         # urllib3 uses this host as the Host header by default.
         # If we send along the socket path as a Host header, this is

--- a/src/sentry/new_migrations/monkey/fields.py
+++ b/src/sentry/new_migrations/monkey/fields.py
@@ -23,7 +23,7 @@ def deconstruct(self):
 
 
 class SafeRemoveField(RemoveField):
-    def __init__(self, *args, deletion_action: DeletionAction, **kwargs):
+    def __init__(self, *args, deletion_action: DeletionAction, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.deletion_action = deletion_action
 

--- a/src/sentry/new_migrations/monkey/models.py
+++ b/src/sentry/new_migrations/monkey/models.py
@@ -6,7 +6,7 @@ from sentry.new_migrations.monkey.state import DeletionAction, SentryProjectStat
 
 
 class SafeDeleteModel(DeleteModel):
-    def __init__(self, *args, deletion_action: DeletionAction, **kwargs):
+    def __init__(self, *args, deletion_action: DeletionAction, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.deletion_action = deletion_action
 

--- a/src/sentry/new_migrations/monkey/special.py
+++ b/src/sentry/new_migrations/monkey/special.py
@@ -3,7 +3,7 @@ from django.db.migrations.operations.special import RunSQL
 
 
 class SafeRunSQL(RunSQL):
-    def __init__(self, *args, use_statement_timeout=True, **kwargs):
+    def __init__(self, *args, use_statement_timeout=True, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.use_statement_timeout = use_statement_timeout
 

--- a/src/sentry/new_migrations/monkey/state.py
+++ b/src/sentry/new_migrations/monkey/state.py
@@ -14,7 +14,7 @@ class DeletionAction(Enum):
 
 
 class SentryProjectState(ProjectState):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.pending_deletion_models: dict[tuple[str, str], type[Model]] = {}
         self.pending_deletion_fields: dict[tuple[str, str, str], type[Field]] = {}

--- a/src/sentry/nodestore/filesystem/backend.py
+++ b/src/sentry/nodestore/filesystem/backend.py
@@ -12,7 +12,7 @@ class FileSystemNodeStorage(NodeStorage):
     debugging and development!
     """
 
-    def __init__(self, path: str | None = None):
+    def __init__(self, path: str | None = None) -> None:
         self.path: str = ""
 
         if not settings.DEBUG:

--- a/src/sentry/notifications/models/notificationaction.py
+++ b/src/sentry/notifications/models/notificationaction.py
@@ -118,7 +118,7 @@ class ActionTrigger(FlexibleIntEnum):
 
 
 class ActionRegistration(metaclass=ABCMeta):
-    def __init__(self, action: NotificationAction):
+    def __init__(self, action: NotificationAction) -> None:
         self.action = action
 
     @abstractmethod

--- a/src/sentry/notifications/notifications/base.py
+++ b/src/sentry/notifications/notifications/base.py
@@ -52,7 +52,7 @@ class BaseNotification(abc.ABC):
     notification_setting_type_enum: NotificationSettingEnum | None = None
     analytics_event: str = ""
 
-    def __init__(self, organization: Organization, notification_uuid: str | None = None):
+    def __init__(self, organization: Organization, notification_uuid: str | None = None) -> None:
         self.organization = organization
         self.notification_uuid = notification_uuid if notification_uuid else str(uuid.uuid4())
 

--- a/src/sentry/notifications/notifications/strategies/role_based_recipient_strategy.py
+++ b/src/sentry/notifications/notifications/strategies/role_based_recipient_strategy.py
@@ -22,7 +22,7 @@ class RoleBasedRecipientStrategy(metaclass=ABCMeta):
     role: OrganizationRole | None = None
     scope: str | None = None
 
-    def __init__(self, organization: Organization):
+    def __init__(self, organization: Organization) -> None:
         self.organization = organization
 
     def get_member(self, user: RpcUser | Actor) -> OrganizationMember:

--- a/src/sentry/notifications/platform/service.py
+++ b/src/sentry/notifications/platform/service.py
@@ -17,7 +17,7 @@ class NotificationServiceError(Exception):
 
 
 class NotificationService[T: NotificationData]:
-    def __init__(self, *, data: T):
+    def __init__(self, *, data: T) -> None:
         self.data: Final[T] = data
 
     # TODO(ecosystem): Eventually this should be converted to spawn a task with the business logic below

--- a/src/sentry/options/manager.py
+++ b/src/sentry/options/manager.py
@@ -177,7 +177,7 @@ class OptionsManager:
     constants in the global configuration.
     """
 
-    def __init__(self, store: OptionsStore):
+    def __init__(self, store: OptionsStore) -> None:
         self.store = store
         self.registry: dict[str, Key] = {}
 

--- a/src/sentry/options/store.py
+++ b/src/sentry/options/store.py
@@ -77,7 +77,7 @@ class OptionsStore:
     OptionsManager instead, unless you need raw access to something.
     """
 
-    def __init__(self, cache=None, ttl=None):
+    def __init__(self, cache=None, ttl=None) -> None:
         self.cache = cache
         self.ttl = ttl
         self.flush_local_cache()

--- a/src/sentry/partnerships/base.py
+++ b/src/sentry/partnerships/base.py
@@ -12,7 +12,7 @@ class Partnership(Service):
 
     __all__ = ("get_inbound_filters",)
 
-    def __init__(self, **options):
+    def __init__(self, **options) -> None:
         pass
 
     def get_inbound_filters(self, organization: Organization) -> list[GenericFilter]:

--- a/src/sentry/performance_issues/performance_detection.py
+++ b/src/sentry/performance_issues/performance_detection.py
@@ -65,7 +65,7 @@ class EventPerformanceProblem:
     to and fetch from Nodestore
     """
 
-    def __init__(self, event: Event | GroupEvent, problem: PerformanceProblem):
+    def __init__(self, event: Event | GroupEvent, problem: PerformanceProblem) -> None:
         self.event = event
         self.problem = problem
 

--- a/src/sentry/plugins/base/binding_manager.py
+++ b/src/sentry/plugins/base/binding_manager.py
@@ -8,7 +8,7 @@ from sentry.plugins.providers import IntegrationRepositoryProvider, RepositoryPr
 class ProviderManager:
     type: type[Any] | None = None
 
-    def __init__(self) -> None:
+    def __init__(self):
         self._items = {}
 
     def __iter__(self):
@@ -41,7 +41,7 @@ class BindingManager:
         "integration-repository.provider": IntegrationRepositoryProviderManager,
     }
 
-    def __init__(self) -> None:
+    def __init__(self):
         self._bindings = {k: v() for k, v in self.BINDINGS.items()}
 
     def add(self, name, binding, **kwargs):

--- a/src/sentry/plugins/base/binding_manager.py
+++ b/src/sentry/plugins/base/binding_manager.py
@@ -8,7 +8,7 @@ from sentry.plugins.providers import IntegrationRepositoryProvider, RepositoryPr
 class ProviderManager:
     type: type[Any] | None = None
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._items = {}
 
     def __iter__(self):
@@ -41,7 +41,7 @@ class BindingManager:
         "integration-repository.provider": IntegrationRepositoryProviderManager,
     }
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._bindings = {k: v() for k, v in self.BINDINGS.items()}
 
     def add(self, name, binding, **kwargs):

--- a/src/sentry/plugins/base/structs.py
+++ b/src/sentry/plugins/base/structs.py
@@ -4,14 +4,14 @@ import warnings
 
 
 class Annotation:
-    def __init__(self, label, url=None, description=None):
+    def __init__(self, label, url=None, description=None) -> None:
         self.label = label
         self.url = url
         self.description = description
 
 
 class Notification:
-    def __init__(self, event, rule=None, rules=None):
+    def __init__(self, event, rule=None, rules=None) -> None:
         if rule and not rules:
             rules = [rule]
 

--- a/src/sentry/plugins/config.py
+++ b/src/sentry/plugins/config.py
@@ -16,7 +16,7 @@ ERR_FIELD_REQUIRED = "This field is required."
 # TODO(dcramer): replace one-off validation code with standardized validator
 # (e.g. project_plugin_details.py)
 class ConfigValidator:
-    def __init__(self, config, data=None, initial=None, context=None) -> None:
+    def __init__(self, config, data=None, initial=None, context=None):
         self.errors = {}
         self.result = {}
         self.context = context or {}

--- a/src/sentry/plugins/config.py
+++ b/src/sentry/plugins/config.py
@@ -16,7 +16,7 @@ ERR_FIELD_REQUIRED = "This field is required."
 # TODO(dcramer): replace one-off validation code with standardized validator
 # (e.g. project_plugin_details.py)
 class ConfigValidator:
-    def __init__(self, config, data=None, initial=None, context=None):
+    def __init__(self, config, data=None, initial=None, context=None) -> None:
         self.errors = {}
         self.result = {}
         self.context = context or {}

--- a/src/sentry/plugins/interfaces/releasehook.py
+++ b/src/sentry/plugins/interfaces/releasehook.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 
 class ReleaseHook:
-    def __init__(self, project):
+    def __init__(self, project) -> None:
         self.project = project
 
     # TODO(dcramer): this is being used by the release details endpoint, but

--- a/src/sentry/plugins/providers/integration_repository.py
+++ b/src/sentry/plugins/providers/integration_repository.py
@@ -79,7 +79,7 @@ class IntegrationRepositoryProvider:
     name: ClassVar[str]
     repo_provider: ClassVar[str]
 
-    def __init__(self, id):
+    def __init__(self, id) -> None:
         self.id = id
         self.logger = logging.getLogger(f"sentry.integrations.{self.repo_provider}")
 

--- a/src/sentry/plugins/providers/repository.py
+++ b/src/sentry/plugins/providers/repository.py
@@ -31,7 +31,7 @@ class RepositoryProvider(ProviderMixin):
 
     name: ClassVar[str]
 
-    def __init__(self, id):
+    def __init__(self, id) -> None:
         self.id = id
 
     def needs_auth(self, user, **kwargs):

--- a/src/sentry/plugins/sentry_webhooks/client.py
+++ b/src/sentry/plugins/sentry_webhooks/client.py
@@ -6,7 +6,7 @@ class WebhookApiClient(ApiClient):
     allow_redirects = False
     metrics_prefix = "integrations.webhook"
 
-    def __init__(self, data):
+    def __init__(self, data) -> None:
         self.data = data
         super().__init__(verify_ssl=False)
 

--- a/src/sentry/processing/backpressure/arroyo.py
+++ b/src/sentry/processing/backpressure/arroyo.py
@@ -11,7 +11,7 @@ from sentry.processing.backpressure.health import is_consumer_healthy
 
 
 class HealthChecker:
-    def __init__(self, consumer_name: str = "default"):
+    def __init__(self, consumer_name: str = "default") -> None:
         self.consumer_name = consumer_name
         self.last_check: float = 0
         # Queue is healthy by default

--- a/src/sentry/processing/backpressure/memory.py
+++ b/src/sentry/processing/backpressure/memory.py
@@ -17,7 +17,7 @@ class ServiceMemory:
     host: str | None = None
     port: int | None = None
 
-    def __init__(self, name: str, used: int, available: int):
+    def __init__(self, name: str, used: int, available: int) -> None:
         self.name = name
         self.used = used
         self.available = available

--- a/src/sentry/projectoptions/manager.py
+++ b/src/sentry/projectoptions/manager.py
@@ -2,7 +2,7 @@ import bisect
 
 
 class WellKnownProjectOption:
-    def __init__(self, key, default=None, epoch_defaults=None) -> None:
+    def __init__(self, key, default=None, epoch_defaults=None):
         self.key = key
         self.default = default
         self.epoch_defaults = epoch_defaults
@@ -34,7 +34,7 @@ class ProjectOptionsManager:
     time of the option lookup.
     """
 
-    def __init__(self) -> None:
+    def __init__(self):
         self.registry = {}
 
     def lookup_well_known_key(self, key):

--- a/src/sentry/projectoptions/manager.py
+++ b/src/sentry/projectoptions/manager.py
@@ -2,7 +2,7 @@ import bisect
 
 
 class WellKnownProjectOption:
-    def __init__(self, key, default=None, epoch_defaults=None):
+    def __init__(self, key, default=None, epoch_defaults=None) -> None:
         self.key = key
         self.default = default
         self.epoch_defaults = epoch_defaults
@@ -34,7 +34,7 @@ class ProjectOptionsManager:
     time of the option lookup.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.registry = {}
 
     def lookup_well_known_key(self, key):

--- a/src/sentry/quotas/base.py
+++ b/src/sentry/quotas/base.py
@@ -211,7 +211,7 @@ class RateLimit:
 
     __slots__ = ["is_limited", "retry_after", "reason", "reason_code"]
 
-    def __init__(self, is_limited, retry_after=None, reason=None, reason_code=None):
+    def __init__(self, is_limited, retry_after=None, reason=None, reason_code=None) -> None:
         self.is_limited = is_limited
         # delta of seconds in the future to retry
         self.retry_after = retry_after
@@ -238,12 +238,12 @@ class RateLimit:
 
 
 class NotRateLimited(RateLimit):
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs) -> None:
         super().__init__(False, **kwargs)
 
 
 class RateLimited(RateLimit):
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs) -> None:
         super().__init__(True, **kwargs)
 
 
@@ -316,7 +316,7 @@ class Quota(Service):
         "update_monitor_slug",
     )
 
-    def __init__(self, **options):
+    def __init__(self, **options) -> None:
         pass
 
     def get_quotas(

--- a/src/sentry/quotas/redis.py
+++ b/src/sentry/quotas/redis.py
@@ -28,7 +28,7 @@ class RedisQuota(Quota):
     #: metrics may not be in sync with the computer running this code.
     grace = 60
 
-    def __init__(self, **options: object):
+    def __init__(self, **options: object) -> None:
         self.is_redis_cluster, self.cluster, options = get_dynamic_cluster_from_options(
             "SENTRY_QUOTA_OPTIONS", options
         )

--- a/src/sentry/relay/projectconfig_cache/base.py
+++ b/src/sentry/relay/projectconfig_cache/base.py
@@ -4,7 +4,7 @@ from sentry.utils.services import Service
 class ProjectConfigCache(Service):
     __all__ = ("set_many", "delete_many", "get")
 
-    def __init__(self, **options):
+    def __init__(self, **options) -> None:
         pass
 
     def set_many(self, configs):

--- a/src/sentry/relay/projectconfig_cache/redis.py
+++ b/src/sentry/relay/projectconfig_cache/redis.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 class RedisProjectConfigCache(ProjectConfigCache):
-    def __init__(self, **options):
+    def __init__(self, **options) -> None:
         cluster_key = options.get("cluster", "default")
         self.cluster = redis.redis_clusters.get_binary(cluster_key)
 

--- a/src/sentry/relay/projectconfig_debounce_cache/base.py
+++ b/src/sentry/relay/projectconfig_debounce_cache/base.py
@@ -19,7 +19,7 @@ class ProjectConfigDebounceCache(Service):
 
     __all__ = ("is_debounced", "debounce", "mark_task_done")
 
-    def __init__(self, **options):
+    def __init__(self, **options) -> None:
         pass
 
     def is_debounced(self, *, public_key, project_id, organization_id):

--- a/src/sentry/relay/projectconfig_debounce_cache/redis.py
+++ b/src/sentry/relay/projectconfig_debounce_cache/redis.py
@@ -14,7 +14,7 @@ REDIS_CACHE_TIMEOUT = 3600  # 1 hr
 
 
 class RedisProjectConfigDebounceCache(ProjectConfigDebounceCache):
-    def __init__(self, **options):
+    def __init__(self, **options) -> None:
         self._key_prefix = options.pop("key_prefix", "relayconfig-debounce")
         self._debounce_ttl = options.pop("debounce_ttl", REDIS_CACHE_TIMEOUT)
         self.is_redis_cluster, self.cluster, options = get_dynamic_cluster_from_options(

--- a/src/sentry/release_health/metrics_sessions_v2.py
+++ b/src/sentry/release_health/metrics_sessions_v2.py
@@ -303,7 +303,7 @@ class CountUniqueUser(CountField):
 
 
 class DurationField(Field):
-    def __init__(self, name: str, raw_groupby: Sequence[str], status_filter: StatusFilter):
+    def __init__(self, name: str, raw_groupby: Sequence[str], status_filter: StatusFilter) -> None:
         self.op = name[:3]  # That this works is just a lucky coincidence
         super().__init__(name, raw_groupby, status_filter)
 
@@ -343,7 +343,7 @@ class SimpleForwardingField(Field):
         "foreground_anr_rate()": SessionMRI.FOREGROUND_ANR_RATE,
     }
 
-    def __init__(self, name: str, raw_groupby: Sequence[str], status_filter: StatusFilter):
+    def __init__(self, name: str, raw_groupby: Sequence[str], status_filter: StatusFilter) -> None:
         if "session.status" in raw_groupby:
             raise InvalidParams(f"Cannot group field {name} by session.status")
         if status_filter is not None:

--- a/src/sentry/relocation/utils.py
+++ b/src/sentry/relocation/utils.py
@@ -405,7 +405,7 @@ class LoggingPrinter(Printer):
     and `export_*` backup methods rely on.
     """
 
-    def __init__(self, uuid: str):
+    def __init__(self, uuid: str) -> None:
         self.uuid = uuid
         super().__init__()
 

--- a/src/sentry/remote_subscriptions/consumers/result_consumer.py
+++ b/src/sentry/remote_subscriptions/consumers/result_consumer.py
@@ -38,7 +38,7 @@ FAKE_SUBSCRIPTION_ID = 12345
 
 
 class ResultProcessor(abc.ABC, Generic[T, U]):
-    def __init__(self, use_subscription_lock: bool = False):
+    def __init__(self, use_subscription_lock: bool = False) -> None:
         self.use_subscription_lock = use_subscription_lock
 
     @property

--- a/src/sentry/replays/_case_studies/INC_1184_consumer_backlog_from_increased_threads/report.py
+++ b/src/sentry/replays/_case_studies/INC_1184_consumer_backlog_from_increased_threads/report.py
@@ -22,7 +22,7 @@ from arroyo.types import FilteredPayload, Message, Value
 
 
 class Producer:
-    def __init__(self, step):
+    def __init__(self, step) -> None:
         self.step = step
         self.produced_count = 0
 
@@ -35,7 +35,7 @@ class Producer:
 
 
 class Consumer(ProcessingStrategy[FilteredPayload | None]):
-    def __init__(self):
+    def __init__(self) -> None:
         self.consumed_count = 0
 
     def submit(self, message):
@@ -51,7 +51,7 @@ class Consumer(ProcessingStrategy[FilteredPayload | None]):
 
 
 class SharedResource:
-    def __init__(self, max_workers, wait):
+    def __init__(self, max_workers, wait) -> None:
         self.lock = Semaphore(max_workers)
         self.wait = wait
 

--- a/src/sentry/replays/lib/selector/parse.py
+++ b/src/sentry/replays/lib/selector/parse.py
@@ -9,7 +9,7 @@ SelectorType = Union[Attrib, Class, Element, Hash]
 
 
 class QueryType:
-    def __init__(self):
+    def __init__(self) -> None:
         self.alt: str | None = None
         self.aria_label: str | None = None
         self.classes: list[str] = []

--- a/src/sentry/replays/usecases/ingest/event_parser.py
+++ b/src/sentry/replays/usecases/ingest/event_parser.py
@@ -226,7 +226,7 @@ def which_iter(events: list[dict[str, Any]]) -> Iterator[tuple[EventType, dict[s
 
 class EAPEventsBuilder:
 
-    def __init__(self, context: EventContext):
+    def __init__(self, context: EventContext) -> None:
         self.context = context
         self.events: list[TraceItem] = []
 
@@ -560,7 +560,7 @@ class HighlightedEvents(TypedDict, total=False):
 
 class HighlightedEventsBuilder:
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.events: HighlightedEvents = {
             "canvas_sizes": [],
             "clicks": [],

--- a/src/sentry/reprocessing2.py
+++ b/src/sentry/reprocessing2.py
@@ -141,7 +141,7 @@ CannotReprocessReason = Literal[
 
 
 class CannotReprocess(Exception):
-    def __init__(self, reason: CannotReprocessReason):
+    def __init__(self, reason: CannotReprocessReason) -> None:
         Exception.__init__(self, reason)
 
 

--- a/src/sentry/rules/filters/latest_adopted_release_filter.py
+++ b/src/sentry/rules/filters/latest_adopted_release_filter.py
@@ -33,7 +33,7 @@ class LatestAdoptedReleaseForm(forms.Form):
     older_or_newer = forms.ChoiceField(choices=list(age_comparison_choices))
     environment = forms.CharField()
 
-    def __init__(self, project, *args, **kwargs):
+    def __init__(self, project, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.project = project
 

--- a/src/sentry/rules/processing/buffer_processing.py
+++ b/src/sentry/rules/processing/buffer_processing.py
@@ -34,7 +34,7 @@ class DelayedProcessingBase(ABC):
     buffer_key: ClassVar[str]
     option: ClassVar[str | None]
 
-    def __init__(self, project_id: int):
+    def __init__(self, project_id: int) -> None:
         self.project_id = project_id
 
     @property

--- a/src/sentry/scim/endpoints/utils.py
+++ b/src/sentry/scim/endpoints/utils.py
@@ -24,7 +24,7 @@ ACCEPTED_FILTERED_KEYS = ["userName", "value", "displayName"]
 
 
 class SCIMApiError(APIException):
-    def __init__(self, detail, status_code=400):
+    def __init__(self, detail, status_code=400) -> None:
         transaction = sentry_sdk.get_current_scope().transaction
         if transaction is not None:
             transaction.set_tag("http.status_code", status_code)

--- a/src/sentry/sdk_updates.py
+++ b/src/sentry/sdk_updates.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 class SdkSetupState:
-    def __init__(self, sdk_name, sdk_version, modules, integrations):
+    def __init__(self, sdk_name, sdk_version, modules, integrations) -> None:
         self.sdk_name = sdk_name
         self.sdk_version = sdk_version
         self.modules = dict(modules or ())
@@ -46,7 +46,7 @@ class SdkSetupState:
 
 
 class SdkIndexState:
-    def __init__(self, sdk_versions=None, deprecated_sdks=None, sdk_supported_modules=None):
+    def __init__(self, sdk_versions=None, deprecated_sdks=None, sdk_supported_modules=None) -> None:
         self.sdk_versions = sdk_versions or get_sdk_versions()
         self.deprecated_sdks = deprecated_sdks or settings.DEPRECATED_SDKS
         self.sdk_supported_modules = sdk_supported_modules or SDK_SUPPORTED_MODULES
@@ -61,7 +61,7 @@ class Suggestion:
 
 
 class EnableIntegrationSuggestion(Suggestion):
-    def __init__(self, integration_name, integration_url):
+    def __init__(self, integration_name, integration_url) -> None:
         self.integration_name = integration_name
         self.integration_url = integration_url
 
@@ -82,7 +82,7 @@ class EnableIntegrationSuggestion(Suggestion):
 
 
 class UpdateSDKSuggestion(Suggestion):
-    def __init__(self, sdk_name, new_sdk_version, ignore_patch_version):
+    def __init__(self, sdk_name, new_sdk_version, ignore_patch_version) -> None:
         self.sdk_name = sdk_name
         self.new_sdk_version = new_sdk_version
         self.ignore_patch_version = ignore_patch_version
@@ -123,7 +123,7 @@ class ChangeSDKSuggestion(Suggestion):
         multiple SDKs in e.g. .NET.
     """
 
-    def __init__(self, new_sdk_name, module_names=None):
+    def __init__(self, new_sdk_name, module_names=None) -> None:
         self.new_sdk_name = new_sdk_name
         self.module_names = module_names
 

--- a/src/sentry/search/base.py
+++ b/src/sentry/search/base.py
@@ -22,7 +22,7 @@ class SearchBackend(Service):
     __write_methods__ = ()
     __all__ = tuple(set(__read_methods__ + __write_methods__))
 
-    def __init__(self, **options: Mapping[str, Any] | None):
+    def __init__(self, **options: Mapping[str, Any] | None) -> None:
         pass
 
     def query(

--- a/src/sentry/search/events/builder/errors.py
+++ b/src/sentry/search/events/builder/errors.py
@@ -31,7 +31,7 @@ value_converters = {"status": convert_status_value}
 
 
 class ErrorsQueryBuilderMixin:
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         self.match = None
         self.entities = set()
         super().__init__(*args, **kwargs)
@@ -153,7 +153,7 @@ class ErrorsQueryBuilder(ErrorsQueryBuilderMixin, DiscoverQueryBuilder):
 
 
 class ErrorsTimeseriesQueryBuilder(ErrorsQueryBuilderMixin, TimeseriesQueryBuilder):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
     @property
@@ -179,7 +179,7 @@ class ErrorsTimeseriesQueryBuilder(ErrorsQueryBuilderMixin, TimeseriesQueryBuild
 
 
 class ErrorsTopEventsQueryBuilder(ErrorsQueryBuilderMixin, TopEventsQueryBuilder):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
     @property

--- a/src/sentry/search/events/builder/errors.py
+++ b/src/sentry/search/events/builder/errors.py
@@ -31,7 +31,7 @@ value_converters = {"status": convert_status_value}
 
 
 class ErrorsQueryBuilderMixin:
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args, **kwargs):
         self.match = None
         self.entities = set()
         super().__init__(*args, **kwargs)
@@ -153,7 +153,7 @@ class ErrorsQueryBuilder(ErrorsQueryBuilderMixin, DiscoverQueryBuilder):
 
 
 class ErrorsTimeseriesQueryBuilder(ErrorsQueryBuilderMixin, TimeseriesQueryBuilder):
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
     @property
@@ -179,7 +179,7 @@ class ErrorsTimeseriesQueryBuilder(ErrorsQueryBuilderMixin, TimeseriesQueryBuild
 
 
 class ErrorsTopEventsQueryBuilder(ErrorsQueryBuilderMixin, TopEventsQueryBuilder):
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
     @property

--- a/src/sentry/search/events/builder/spans_indexed.py
+++ b/src/sentry/search/events/builder/spans_indexed.py
@@ -53,7 +53,7 @@ class SpansIndexedQueryBuilder(BaseQueryBuilder):
     size_fields = SIZE_FIELDS
     config_class = SpansIndexedDatasetConfig
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.value_resolver_map[constants.SPAN_STATUS] = (
             lambda status: SPAN_STATUS_CODE_TO_NAME.get(status)

--- a/src/sentry/search/events/datasets/base.py
+++ b/src/sentry/search/events/datasets/base.py
@@ -23,7 +23,7 @@ class DatasetConfig(abc.ABC):
     optimize_wildcard_searches = False
     subscriptables_with_index: set[str] = set()
 
-    def __init__(self, builder: BaseQueryBuilder):
+    def __init__(self, builder: BaseQueryBuilder) -> None:
         pass
 
     @property

--- a/src/sentry/search/events/datasets/discover.py
+++ b/src/sentry/search/events/datasets/discover.py
@@ -110,7 +110,7 @@ class DiscoverDatasetConfig(DatasetConfig):
     nullable_context_keys = {"thread.id"}
     use_entity_prefix_for_fields: bool = False
 
-    def __init__(self, builder: BaseQueryBuilder):
+    def __init__(self, builder: BaseQueryBuilder) -> None:
         self.builder = builder
         self.total_count: int | None = None
         self.total_sum_transaction_duration: float | None = None

--- a/src/sentry/search/events/datasets/metrics.py
+++ b/src/sentry/search/events/datasets/metrics.py
@@ -18,7 +18,7 @@ from sentry.snuba.referrer import Referrer
 class MetricsDatasetConfig(DatasetConfig):
     missing_function_error = IncompatibleMetricsQuery
 
-    def __init__(self, builder: metrics.MetricsQueryBuilder):
+    def __init__(self, builder: metrics.MetricsQueryBuilder) -> None:
         self.builder = builder
         self.total_transaction_duration: float | None = None
         self.total_score_weights: dict[str, int] = {}

--- a/src/sentry/search/events/datasets/metrics_layer.py
+++ b/src/sentry/search/events/datasets/metrics_layer.py
@@ -17,7 +17,7 @@ from sentry.utils.numbers import format_grouped_length
 
 
 class MetricsLayerDatasetConfig(MetricsDatasetConfig):
-    def __init__(self, builder: metrics.MetricsQueryBuilder):
+    def __init__(self, builder: metrics.MetricsQueryBuilder) -> None:
         self.builder = builder
 
     @property

--- a/src/sentry/search/events/datasets/profile_functions.py
+++ b/src/sentry/search/events/datasets/profile_functions.py
@@ -144,7 +144,7 @@ class ProfileFunctionsDatasetConfig(DatasetConfig):
         "platform.name",
     }
 
-    def __init__(self, builder: BaseQueryBuilder):
+    def __init__(self, builder: BaseQueryBuilder) -> None:
         self.builder = builder
 
     @property

--- a/src/sentry/search/events/datasets/profiles.py
+++ b/src/sentry/search/events/datasets/profiles.py
@@ -162,7 +162,7 @@ class ProfilesDatasetConfig(DatasetConfig):
         "project_id",
     }
 
-    def __init__(self, builder: BaseQueryBuilder):
+    def __init__(self, builder: BaseQueryBuilder) -> None:
         self.builder = builder
 
     @property

--- a/src/sentry/search/events/datasets/sessions.py
+++ b/src/sentry/search/events/datasets/sessions.py
@@ -22,7 +22,7 @@ from sentry.search.events.types import SelectType, WhereType
 class SessionsDatasetConfig(DatasetConfig):
     non_nullable_keys = {"project", "project_id", "environment", "release"}
 
-    def __init__(self, builder: BaseQueryBuilder):
+    def __init__(self, builder: BaseQueryBuilder) -> None:
         self.builder = builder
 
     @property

--- a/src/sentry/search/events/datasets/spans_indexed.py
+++ b/src/sentry/search/events/datasets/spans_indexed.py
@@ -36,7 +36,7 @@ class SpansIndexedDatasetConfig(DatasetConfig):
     subscriptables_with_index = {"tags"}
     non_nullable_keys = {"id", "span_id", "trace", "trace_id"}
 
-    def __init__(self, builder: BaseQueryBuilder):
+    def __init__(self, builder: BaseQueryBuilder) -> None:
         self.builder = builder
         self.total_count: int | None = None
         self.total_sum_transaction_duration: float | None = None
@@ -544,7 +544,7 @@ class SpansEAPDatasetConfig(SpansIndexedDatasetConfig):
 
     sampling_weight = Column("sampling_weight")
 
-    def __init__(self, builder: BaseQueryBuilder):
+    def __init__(self, builder: BaseQueryBuilder) -> None:
         super().__init__(builder)
         self._cached_count_and_weighted: tuple[float, float] | None = None
 

--- a/src/sentry/search/events/datasets/spans_metrics.py
+++ b/src/sentry/search/events/datasets/spans_metrics.py
@@ -33,7 +33,7 @@ class SpansMetricsDatasetConfig(DatasetConfig):
         constants.SPAN_METRICS_MAP["ai.total_tokens.used"],
     }
 
-    def __init__(self, builder: spans_metrics.SpansMetricsQueryBuilder):
+    def __init__(self, builder: spans_metrics.SpansMetricsQueryBuilder) -> None:
         self.builder = builder
         self.total_span_duration: float | None = None
 

--- a/src/sentry/search/events/fields.py
+++ b/src/sentry/search/events/fields.py
@@ -68,7 +68,7 @@ class InvalidFunctionArgument(Exception):
 
 
 class PseudoField:
-    def __init__(self, name, alias, expression=None, expression_fn=None, result_type=None):
+    def __init__(self, name, alias, expression=None, expression_fn=None, result_type=None) -> None:
         self.name = name
         self.alias = alias
         self.expression = expression
@@ -752,7 +752,7 @@ class Combinator:
     # The kind of combinator this is, to be overridden in the subclasses
     kind: str | None = None
 
-    def __init__(self, private: bool = True):
+    def __init__(self, private: bool = True) -> None:
         self.private = private
 
     def validate_argument(self, column: str) -> bool:
@@ -768,7 +768,7 @@ class Combinator:
 class ArrayCombinator(Combinator):
     kind = "Array"
 
-    def __init__(self, column_name: str, array_columns: set[str], private: bool = True):
+    def __init__(self, column_name: str, array_columns: set[str], private: bool = True) -> None:
         super().__init__(private=private)
         self.column_name = column_name
         self.array_columns = array_columns
@@ -792,14 +792,14 @@ COMBINATORS = [ArrayCombinator]
 
 
 class ArgValue:
-    def __init__(self, arg: str):
+    def __init__(self, arg: str) -> None:
         self.arg = arg
 
 
 class FunctionArg:
     """Parent class to function arguments, including both column references and values"""
 
-    def __init__(self, name: str):
+    def __init__(self, name: str) -> None:
         self.name = name
         self.has_default = False
 
@@ -901,7 +901,7 @@ class NullColumn(FunctionArg):
     required argument that we ignore.
     """
 
-    def __init__(self, name: str):
+    def __init__(self, name: str) -> None:
         super().__init__(name)
         self.has_default = True
 
@@ -913,7 +913,7 @@ class NullColumn(FunctionArg):
 
 
 class IntArg(FunctionArg):
-    def __init__(self, name: str, negative: bool):
+    def __init__(self, name: str, negative: bool) -> None:
         super().__init__(name)
         self.negative = negative
 
@@ -930,7 +930,7 @@ class IntArg(FunctionArg):
 
 
 class NumberRange(FunctionArg):
-    def __init__(self, name: str, start: float | None, end: float | None):
+    def __init__(self, name: str, start: float | None, end: float | None) -> None:
         super().__init__(name)
         self.start = start
         self.end = end
@@ -953,7 +953,7 @@ class NumberRange(FunctionArg):
 
 
 class NullableNumberRange(NumberRange):
-    def __init__(self, name: str, start: float | None, end: float | None):
+    def __init__(self, name: str, start: float | None, end: float | None) -> None:
         super().__init__(name, start, end)
         self.has_default = True
 
@@ -969,7 +969,7 @@ class NullableNumberRange(NumberRange):
 
 
 class IntervalDefault(NumberRange):
-    def __init__(self, name: str, start: float | None, end: float | None):
+    def __init__(self, name: str, start: float | None, end: float | None) -> None:
         super().__init__(name, start, end)
         self.has_default = True
 
@@ -986,7 +986,7 @@ class IntervalDefault(NumberRange):
 
 
 class TimestampArg(FunctionArg):
-    def __init__(self, name: str):
+    def __init__(self, name: str) -> None:
         super().__init__(name)
 
     def normalize(self, value: str, params: ParamsType, combinator: Combinator | None) -> datetime:
@@ -1065,7 +1065,7 @@ class ColumnTagArg(ColumnArg):
 
 
 class CountColumn(ColumnArg):
-    def __init__(self, name: str, **kwargs):
+    def __init__(self, name: str, **kwargs) -> None:
         super().__init__(name, **kwargs)
         self.has_default = True
 

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -302,7 +302,7 @@ class Condition:
 
 
 class QCallbackCondition(Condition):
-    def __init__(self, callback: Callable[[Any], Q]):
+    def __init__(self, callback: Callable[[Any], Q]) -> None:
         self.callback = callback
 
     def apply(
@@ -327,7 +327,7 @@ class ScalarCondition(Condition):
     instances
     """
 
-    def __init__(self, field: str, extra: dict[str, Sequence[int]] | None = None):
+    def __init__(self, field: str, extra: dict[str, Sequence[int]] | None = None) -> None:
         self.field = field
         self.extra = extra
 
@@ -351,7 +351,7 @@ class ScalarCondition(Condition):
 
 
 class QuerySetBuilder:
-    def __init__(self, conditions: Mapping[str, Condition]):
+    def __init__(self, conditions: Mapping[str, Condition]) -> None:
         self.conditions = conditions
 
     def build(

--- a/src/sentry/sentry_apps/api/parsers/sentry_app.py
+++ b/src/sentry/sentry_apps/api/parsers/sentry_app.py
@@ -144,7 +144,7 @@ class SentryAppParser(Serializer):
         allow_null=True,
     )
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         self.active_staff = kwargs.pop("active_staff", False)
         self.access = kwargs.pop("access", None)
         Serializer.__init__(self, *args, **kwargs)

--- a/src/sentry/sentry_apps/api/serializers/app_platform_event.py
+++ b/src/sentry/sentry_apps/api/serializers/app_platform_event.py
@@ -9,7 +9,7 @@ class AppPlatformEvent:
     This data structure encapsulates the payload sent to a SentryApp's webhook.
     """
 
-    def __init__(self, resource, action, install, data, actor=None):
+    def __init__(self, resource, action, install, data, actor=None) -> None:
         self.resource = resource
         self.action = action
         self.install = install

--- a/src/sentry/sentry_apps/models/servicehook.py
+++ b/src/sentry/sentry_apps/models/servicehook.py
@@ -94,7 +94,7 @@ class ServiceHook(Model):
         else:
             return app_service.get_by_application_id(application_id=self.application_id)
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         if self.guid is None:
             self.guid = uuid4().hex

--- a/src/sentry/sentry_metrics/consumers/indexer/processing.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/processing.py
@@ -37,7 +37,7 @@ INGEST_CODEC: Codec[IngestMetric] = get_topic_codec(Topic.INGEST_METRICS)
 
 
 class MessageProcessor:
-    def __init__(self, config: MetricsIngestConfiguration):
+    def __init__(self, config: MetricsIngestConfiguration) -> None:
         self._indexer = STORAGE_TO_INDEXER[config.db_backend](**config.db_backend_options)
         self._config = config
 

--- a/src/sentry/sentry_metrics/indexer/base.py
+++ b/src/sentry/sentry_metrics/indexer/base.py
@@ -74,7 +74,7 @@ class KeyCollection:
         { 1: {"a", "b", "c"}, 2: {"e", "f"} }
     """
 
-    def __init__(self, mapping: Mapping[OrgId, set[str]]):
+    def __init__(self, mapping: Mapping[OrgId, set[str]]) -> None:
         self.mapping = mapping
         self.size = self._size()
 
@@ -124,7 +124,9 @@ class UseCaseKeyCollection:
         {UseCaseID.TRANSACTIONS: { 1: {"a", "b", "c"}, 2: {"e", "f"} }}
     """
 
-    def __init__(self, mapping: Mapping[UseCaseID, Mapping[OrgId, set[str]] | KeyCollection]):
+    def __init__(
+        self, mapping: Mapping[UseCaseID, Mapping[OrgId, set[str]] | KeyCollection]
+    ) -> None:
         self.mapping = {
             use_case_id: keys if isinstance(keys, KeyCollection) else KeyCollection(keys)
             for use_case_id, keys in mapping.items()

--- a/src/sentry/sentry_metrics/indexer/cache.py
+++ b/src/sentry/sentry_metrics/indexer/cache.py
@@ -46,7 +46,7 @@ RESOLVE_CACHE_NAMESPACE = "res"
 
 
 class StringIndexerCache:
-    def __init__(self, cache_name: str, partition_key: str):
+    def __init__(self, cache_name: str, partition_key: str) -> None:
         self.version = 1
         self.cache = caches[cache_name]
         self.partition_key = partition_key

--- a/src/sentry/sentry_metrics/querying/data/execution.py
+++ b/src/sentry/sentry_metrics/querying/data/execution.py
@@ -513,7 +513,9 @@ class QueryExecutor:
     Represents an executor that is responsible for scheduling execution of the supplied ScheduledQuery(s).
     """
 
-    def __init__(self, organization: Organization, projects: Sequence[Project], referrer: str):
+    def __init__(
+        self, organization: Organization, projects: Sequence[Project], referrer: str
+    ) -> None:
         self._organization = organization
         self._projects = projects
         self._referrer = referrer

--- a/src/sentry/sentry_metrics/querying/data/mapping/base.py
+++ b/src/sentry/sentry_metrics/querying/data/mapping/base.py
@@ -10,7 +10,7 @@ class Mapper(abc.ABC):
     to_key: str = ""
     applied_on_groupby: bool = False
 
-    def __init__(self):
+    def __init__(self) -> None:
         # This exists to satisfy mypy, which complains otherwise
         self.map: dict[Any, Any] = {}
 
@@ -27,7 +27,7 @@ class Mapper(abc.ABC):
 
 
 class MapperConfig:
-    def __init__(self):
+    def __init__(self) -> None:
         self.mappers: set[type[Mapper]] = set()
 
     def add(self, mapper: type[Mapper]) -> "MapperConfig":

--- a/src/sentry/sentry_metrics/querying/data/mapping/project_mapper.py
+++ b/src/sentry/sentry_metrics/querying/data/mapping/project_mapper.py
@@ -8,7 +8,7 @@ class Project2ProjectIDMapper(Mapper):
     from_key: str = "project"
     to_key: str = "project_id"
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
 
     def forward(self, projects: Sequence[Project], value: str) -> int:

--- a/src/sentry/sentry_metrics/querying/data/postprocessing/remapping.py
+++ b/src/sentry/sentry_metrics/querying/data/postprocessing/remapping.py
@@ -9,7 +9,7 @@ from sentry.sentry_metrics.querying.data.postprocessing.base import PostProcessi
 
 
 class QueryRemappingStep(PostProcessingStep):
-    def __init__(self, projects: Sequence[Project]):
+    def __init__(self, projects: Sequence[Project]) -> None:
         self.projects = projects
 
     def run(self, query_results: list[QueryResult]) -> list[QueryResult]:

--- a/src/sentry/sentry_metrics/querying/data/preparation/mapping.py
+++ b/src/sentry/sentry_metrics/querying/data/preparation/mapping.py
@@ -8,7 +8,7 @@ from sentry.sentry_metrics.querying.visitors.query_expression import MapperVisit
 
 
 class QueryMappingStep(PreparationStep):
-    def __init__(self, projects: Sequence[Project], mapper_config: MapperConfig):
+    def __init__(self, projects: Sequence[Project], mapper_config: MapperConfig) -> None:
         self.projects = projects
         self.mapper_config = mapper_config
 

--- a/src/sentry/sentry_metrics/querying/data/transformation/metrics_api.py
+++ b/src/sentry/sentry_metrics/querying/data/transformation/metrics_api.py
@@ -66,7 +66,7 @@ class QueryMeta:
 
     meta: dict[str, Any]
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs) -> None:
         self.meta = kwargs
         self._transform_meta()
 

--- a/src/sentry/sentry_metrics/querying/visitors/base.py
+++ b/src/sentry/sentry_metrics/querying/visitors/base.py
@@ -89,7 +89,7 @@ class QueryConditionVisitor(ABC, Generic[TVisited]):
 
 
 class VisitableQueryExpression:
-    def __init__(self, query: QueryExpression):
+    def __init__(self, query: QueryExpression) -> None:
         self._query = query
         self._visitors: list[QueryExpressionVisitor[QueryExpression]] = []
 

--- a/src/sentry/sentry_metrics/querying/visitors/query_condition.py
+++ b/src/sentry/sentry_metrics/querying/visitors/query_condition.py
@@ -20,7 +20,7 @@ class LatestReleaseTransformationVisitor(QueryConditionVisitor[QueryCondition]):
     `release IN [x, y, ...]` where `x` and `y` are the latest releases belonging to the supplied projects.
     """
 
-    def __init__(self, projects: Sequence[Project]):
+    def __init__(self, projects: Sequence[Project]) -> None:
         self._projects = projects
 
     def _visit_condition(self, condition: Condition) -> QueryCondition:
@@ -52,7 +52,7 @@ class TagsTransformationVisitor(QueryConditionVisitor[QueryCondition]):
     Visitor that recursively transforms all conditions to work on tags in the form `tags[x]`.
     """
 
-    def __init__(self, check_sentry_tags: bool):
+    def __init__(self, check_sentry_tags: bool) -> None:
         self._check_sentry_tags = check_sentry_tags
 
     def _visit_condition(self, condition: Condition) -> QueryCondition:
@@ -89,7 +89,7 @@ class MappingTransformationVisitor(QueryConditionVisitor[QueryCondition]):
     replaces it with the mapped value.
     """
 
-    def __init__(self, mappings: Mapping[str, str]):
+    def __init__(self, mappings: Mapping[str, str]) -> None:
         self._mappings = mappings
 
     def _visit_condition(self, condition: Condition) -> QueryCondition:
@@ -104,7 +104,7 @@ class MappingTransformationVisitor(QueryConditionVisitor[QueryCondition]):
 
 
 class MapperConditionVisitor(QueryConditionVisitor):
-    def __init__(self, projects: Sequence[Project], mapper_config: MapperConfig):
+    def __init__(self, projects: Sequence[Project], mapper_config: MapperConfig) -> None:
         self.projects = projects
         self.mapper_config = mapper_config
         self.mappers: list[Mapper] = []

--- a/src/sentry/sentry_metrics/querying/visitors/query_expression.py
+++ b/src/sentry/sentry_metrics/querying/visitors/query_expression.py
@@ -37,7 +37,7 @@ class EnvironmentsInjectionVisitor(QueryExpressionVisitor[QueryExpression]):
     Visitor that recursively injects the environments filter into all `Timeseries`.
     """
 
-    def __init__(self, environments: Sequence[Environment]) -> None:
+    def __init__(self, environments: Sequence[Environment]):
         self._environment_names = [environment.name for environment in environments]
 
     def _visit_timeseries(self, timeseries: Timeseries) -> QueryExpression:
@@ -57,7 +57,7 @@ class TimeseriesConditionInjectionVisitor(QueryExpressionVisitor[QueryExpression
     Visitor that recursively injects a `ConditionGroup` into all `Timeseries`.
     """
 
-    def __init__(self, condition_group: ConditionGroup) -> None:
+    def __init__(self, condition_group: ConditionGroup):
         self._condition_group = condition_group
 
     def _visit_formula(self, formula: Formula) -> QueryExpression:
@@ -94,7 +94,7 @@ class QueryValidationV2Visitor(QueryExpressionVisitor[QueryExpression]):
     Visitor that recursively validates the `QueryExpression` of the new endpoint.
     """
 
-    def __init__(self) -> None:
+    def __init__(self):
         self._query_namespace = None
         self._query_entity = None
         self._query_group_bys = None
@@ -198,7 +198,7 @@ class QueryConditionsCompositeVisitor(QueryExpressionVisitor[QueryExpression]):
     Visitor that runs a series of `QueryConditionVisitor`(s) on each filters of elements of a `QueryExpression`.
     """
 
-    def __init__(self, *visitors: QueryConditionVisitor) -> None:
+    def __init__(self, *visitors: QueryConditionVisitor):
         self._visitors = list(visitors)
 
     def _visit_formula(self, formula: Formula) -> QueryExpression:
@@ -260,7 +260,7 @@ class UsedGroupBysVisitor(QueryExpressionVisitor[set[str]]):
     Visitor that recursively computes all the groups of the `QueryExpression`.
     """
 
-    def __init__(self, mappers: list[Mapper] | None = None) -> None:
+    def __init__(self, mappers: list[Mapper] | None = None):
         self.mappers = mappers or []
 
     def _visit_formula(self, formula: Formula) -> set[str]:
@@ -319,7 +319,7 @@ class UnitsNormalizationVisitor(QueryExpressionVisitor[tuple[UnitMetadata, Query
 
     UNITLESS_AGGREGATES = {"count", "count_unique"}
 
-    def __init__(self) -> None:
+    def __init__(self):
         self._unit_family = None
 
     def _visit_formula(self, formula: Formula) -> tuple[UnitMetadata, QueryExpression]:
@@ -443,7 +443,7 @@ class NumericScalarsNormalizationVisitor(QueryExpressionVisitor[QueryExpression]
     Visitor that recursively applies a unit transformation on all the numeric scalars in a `QueryExpression`.
     """
 
-    def __init__(self, unit: Unit) -> None:
+    def __init__(self, unit: Unit):
         self._unit = unit
 
     def _visit_formula(self, formula: Formula) -> QueryExpression:
@@ -481,7 +481,7 @@ class MapperVisitor(QueryExpressionVisitor):
     by API that need to be translated for Snuba to be able to query the data.
     """
 
-    def __init__(self, projects: Sequence[Project], mapper_config: MapperConfig) -> None:
+    def __init__(self, projects: Sequence[Project], mapper_config: MapperConfig):
         self.projects = projects
         self.mapper_config = mapper_config
         self.mappers: list[Mapper] = []

--- a/src/sentry/sentry_metrics/querying/visitors/query_expression.py
+++ b/src/sentry/sentry_metrics/querying/visitors/query_expression.py
@@ -37,7 +37,7 @@ class EnvironmentsInjectionVisitor(QueryExpressionVisitor[QueryExpression]):
     Visitor that recursively injects the environments filter into all `Timeseries`.
     """
 
-    def __init__(self, environments: Sequence[Environment]):
+    def __init__(self, environments: Sequence[Environment]) -> None:
         self._environment_names = [environment.name for environment in environments]
 
     def _visit_timeseries(self, timeseries: Timeseries) -> QueryExpression:
@@ -57,7 +57,7 @@ class TimeseriesConditionInjectionVisitor(QueryExpressionVisitor[QueryExpression
     Visitor that recursively injects a `ConditionGroup` into all `Timeseries`.
     """
 
-    def __init__(self, condition_group: ConditionGroup):
+    def __init__(self, condition_group: ConditionGroup) -> None:
         self._condition_group = condition_group
 
     def _visit_formula(self, formula: Formula) -> QueryExpression:
@@ -94,7 +94,7 @@ class QueryValidationV2Visitor(QueryExpressionVisitor[QueryExpression]):
     Visitor that recursively validates the `QueryExpression` of the new endpoint.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._query_namespace = None
         self._query_entity = None
         self._query_group_bys = None
@@ -198,7 +198,7 @@ class QueryConditionsCompositeVisitor(QueryExpressionVisitor[QueryExpression]):
     Visitor that runs a series of `QueryConditionVisitor`(s) on each filters of elements of a `QueryExpression`.
     """
 
-    def __init__(self, *visitors: QueryConditionVisitor):
+    def __init__(self, *visitors: QueryConditionVisitor) -> None:
         self._visitors = list(visitors)
 
     def _visit_formula(self, formula: Formula) -> QueryExpression:
@@ -260,7 +260,7 @@ class UsedGroupBysVisitor(QueryExpressionVisitor[set[str]]):
     Visitor that recursively computes all the groups of the `QueryExpression`.
     """
 
-    def __init__(self, mappers: list[Mapper] | None = None):
+    def __init__(self, mappers: list[Mapper] | None = None) -> None:
         self.mappers = mappers or []
 
     def _visit_formula(self, formula: Formula) -> set[str]:
@@ -319,7 +319,7 @@ class UnitsNormalizationVisitor(QueryExpressionVisitor[tuple[UnitMetadata, Query
 
     UNITLESS_AGGREGATES = {"count", "count_unique"}
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._unit_family = None
 
     def _visit_formula(self, formula: Formula) -> tuple[UnitMetadata, QueryExpression]:
@@ -443,7 +443,7 @@ class NumericScalarsNormalizationVisitor(QueryExpressionVisitor[QueryExpression]
     Visitor that recursively applies a unit transformation on all the numeric scalars in a `QueryExpression`.
     """
 
-    def __init__(self, unit: Unit):
+    def __init__(self, unit: Unit) -> None:
         self._unit = unit
 
     def _visit_formula(self, formula: Formula) -> QueryExpression:
@@ -481,7 +481,7 @@ class MapperVisitor(QueryExpressionVisitor):
     by API that need to be translated for Snuba to be able to query the data.
     """
 
-    def __init__(self, projects: Sequence[Project], mapper_config: MapperConfig):
+    def __init__(self, projects: Sequence[Project], mapper_config: MapperConfig) -> None:
         self.projects = projects
         self.mapper_config = mapper_config
         self.mappers: list[Mapper] = []

--- a/src/sentry/signals.py
+++ b/src/sentry/signals.py
@@ -28,7 +28,9 @@ class receivers_raise_on_send:
 
     receivers: Any
 
-    def __init__(self, receivers: _AllReceivers | Receiver | list[Receiver] = _AllReceivers.ALL):
+    def __init__(
+        self, receivers: _AllReceivers | Receiver | list[Receiver] = _AllReceivers.ALL
+    ) -> None:
         self.receivers = receivers
 
     def __enter__(self) -> None:

--- a/src/sentry/similarity/backends/metrics.py
+++ b/src/sentry/similarity/backends/metrics.py
@@ -3,7 +3,7 @@ from sentry.utils.metrics import timer
 
 
 class MetricsWrapper(AbstractIndexBackend):
-    def __init__(self, backend, template="similarity.{}", scope_tag_name="scope"):
+    def __init__(self, backend, template="similarity.{}", scope_tag_name="scope") -> None:
         self.backend = backend
         self.template = template
         self.scope_tag_name = scope_tag_name

--- a/src/sentry/similarity/encoder.py
+++ b/src/sentry/similarity/encoder.py
@@ -4,7 +4,7 @@ from collections.abc import Mapping, Sequence, Set
 class Encoder:
     number_types = (int, float)
 
-    def __init__(self, types=None):
+    def __init__(self, types=None) -> None:
         self.types = types if types is not None else {}
 
     def dumps(self, value):

--- a/src/sentry/similarity/features.py
+++ b/src/sentry/similarity/features.py
@@ -24,7 +24,7 @@ class InterfaceDoesNotExist(KeyError):
 
 
 class ExceptionFeature:
-    def __init__(self, function):
+    def __init__(self, function) -> None:
         self.function = function
 
     def extract(self, event):
@@ -36,7 +36,7 @@ class ExceptionFeature:
 
 
 class MessageFeature:
-    def __init__(self, function):
+    def __init__(self, function) -> None:
         self.function = function
 
     def extract(self, event):

--- a/src/sentry/snuba/sessions_v2.py
+++ b/src/sentry/snuba/sessions_v2.py
@@ -175,7 +175,7 @@ class DurationAverageField:
 
 
 class DurationQuantileField:
-    def __init__(self, quantile_index):
+    def __init__(self, quantile_index) -> None:
         self.quantile_index = quantile_index
 
     def get_snuba_columns(self, raw_groupby):
@@ -210,7 +210,7 @@ class _GroupBy(Protocol):
 
 
 class SimpleGroupBy:
-    def __init__(self, row_name: str, name: str | None = None):
+    def __init__(self, row_name: str, name: str | None = None) -> None:
         self.row_name = row_name
         self.name = name or row_name
 

--- a/src/sentry/snuba/snuba_query_validator.py
+++ b/src/sentry/snuba/snuba_query_validator.py
@@ -101,7 +101,7 @@ class SnubaQueryValidator(BaseDataSourceValidator[QuerySubscription]):
 
     data_source_type_handler = QuerySubscriptionDataSourceHandler
 
-    def __init__(self, *args, timeWindowSeconds=False, **kwargs):
+    def __init__(self, *args, timeWindowSeconds=False, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         # if true, time_window is interpreted as seconds.
         # if false, time_window is interpreted as minutes.

--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -151,7 +151,7 @@ class FlushedSegment(NamedTuple):
 
 
 class SpansBuffer:
-    def __init__(self, assigned_shards: list[int], slice_id: int | None = None):
+    def __init__(self, assigned_shards: list[int], slice_id: int | None = None) -> None:
         self.assigned_shards = list(assigned_shards)
         self.slice_id = slice_id
         self.add_buffer_sha: str | None = None

--- a/src/sentry/stacktraces/processing.py
+++ b/src/sentry/stacktraces/processing.py
@@ -50,7 +50,7 @@ def _safe_get_frames(stacktrace) -> Sequence[dict[str, Any]]:
 
 
 class ProcessableFrame:
-    def __init__(self, frame, idx, processor, stacktrace_info, processable_frames):
+    def __init__(self, frame, idx, processor, stacktrace_info, processable_frames) -> None:
         self.frame = frame
         self.idx = idx
         self.processor = processor
@@ -107,7 +107,7 @@ class ProcessableFrame:
 
 
 class StacktraceProcessingTask:
-    def __init__(self, processable_stacktraces, processors):
+    def __init__(self, processable_stacktraces, processors) -> None:
         self.processable_stacktraces = processable_stacktraces
         self.processors = processors
 
@@ -129,7 +129,7 @@ class StacktraceProcessingTask:
 
 
 class StacktraceProcessor:
-    def __init__(self, data, stacktrace_infos, project=None):
+    def __init__(self, data, stacktrace_infos, project=None) -> None:
         self.data = data
         self.stacktrace_infos = stacktrace_infos
         if project is None:

--- a/src/sentry/stacktraces/processing.py
+++ b/src/sentry/stacktraces/processing.py
@@ -50,7 +50,7 @@ def _safe_get_frames(stacktrace) -> Sequence[dict[str, Any]]:
 
 
 class ProcessableFrame:
-    def __init__(self, frame, idx, processor, stacktrace_info, processable_frames) -> None:
+    def __init__(self, frame, idx, processor, stacktrace_info, processable_frames):
         self.frame = frame
         self.idx = idx
         self.processor = processor
@@ -107,7 +107,7 @@ class ProcessableFrame:
 
 
 class StacktraceProcessingTask:
-    def __init__(self, processable_stacktraces, processors) -> None:
+    def __init__(self, processable_stacktraces, processors):
         self.processable_stacktraces = processable_stacktraces
         self.processors = processors
 
@@ -129,7 +129,7 @@ class StacktraceProcessingTask:
 
 
 class StacktraceProcessor:
-    def __init__(self, data, stacktrace_infos, project=None) -> None:
+    def __init__(self, data, stacktrace_infos, project=None):
         self.data = data
         self.stacktrace_infos = stacktrace_infos
         if project is None:

--- a/src/sentry/tagstore/types.py
+++ b/src/sentry/tagstore/types.py
@@ -59,7 +59,7 @@ class TagValue(TagType):
     __slots__ = ("key", "value", "times_seen", "first_seen", "last_seen")
     _sort_key = "value"
 
-    def __init__(self, key, value, times_seen, first_seen, last_seen):
+    def __init__(self, key, value, times_seen, first_seen, last_seen) -> None:
         self.key = key
         self.value = value
         self.times_seen = times_seen
@@ -71,7 +71,7 @@ class GroupTagKey(TagType):
     __slots__ = ("group_id", "key", "values_seen", "count", "top_values")
     _sort_key = "values_seen"
 
-    def __init__(self, group_id, key, values_seen=None, count=None, top_values=None):
+    def __init__(self, group_id, key, values_seen=None, count=None, top_values=None) -> None:
         self.group_id = group_id
         self.key = key
         self.values_seen = values_seen
@@ -83,7 +83,7 @@ class GroupTagValue(TagType):
     __slots__ = ("group_id", "key", "value", "times_seen", "first_seen", "last_seen")
     _sort_key = "value"
 
-    def __init__(self, group_id, key, value, times_seen, first_seen, last_seen):
+    def __init__(self, group_id, key, value, times_seen, first_seen, last_seen) -> None:
         self.group_id = group_id
         self.key = key
         self.value = value

--- a/src/sentry/tasks/summaries/utils.py
+++ b/src/sentry/tasks/summaries/utils.py
@@ -72,7 +72,7 @@ class ProjectContext:
     regression_substatus_count = 0
     total_substatus_count = 0
 
-    def __init__(self, project):
+    def __init__(self, project) -> None:
         self.project = project
 
         self.key_errors_by_id: list[tuple[int, int]] = []
@@ -116,7 +116,7 @@ class ProjectContext:
 
 
 class DailySummaryProjectContext:
-    def __init__(self, project: Project):
+    def __init__(self, project: Project) -> None:
         self.total_today = 0
         self.comparison_period_total = 0
         self.comparison_period_avg = 0

--- a/src/sentry/tasks/summaries/utils.py
+++ b/src/sentry/tasks/summaries/utils.py
@@ -72,7 +72,7 @@ class ProjectContext:
     regression_substatus_count = 0
     total_substatus_count = 0
 
-    def __init__(self, project) -> None:
+    def __init__(self, project):
         self.project = project
 
         self.key_errors_by_id: list[tuple[int, int]] = []
@@ -116,7 +116,7 @@ class ProjectContext:
 
 
 class DailySummaryProjectContext:
-    def __init__(self, project: Project) -> None:
+    def __init__(self, project: Project):
         self.total_today = 0
         self.comparison_period_total = 0
         self.comparison_period_avg = 0

--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -367,7 +367,7 @@ class OrganizationReportBatch:
 
 
 class _DuplicateDeliveryCheck:
-    def __init__(self, batch: OrganizationReportBatch, user_id: int, timestamp: float):
+    def __init__(self, batch: OrganizationReportBatch, user_id: int, timestamp: float) -> None:
         self.batch = batch
         self.user_id = user_id
         # note that if the timestamps between batches cross a UTC day boundary,

--- a/src/sentry/taskworker/client/client.py
+++ b/src/sentry/taskworker/client/client.py
@@ -63,7 +63,7 @@ else:
 
 
 class RequestSignatureInterceptor(InterceptorBase):
-    def __init__(self, shared_secret: list[str]):
+    def __init__(self, shared_secret: list[str]) -> None:
         self._secret = shared_secret[0].encode("utf-8")
 
     def intercept_unary_unary(

--- a/src/sentry/templatetags/sentry_assets.py
+++ b/src/sentry/templatetags/sentry_assets.py
@@ -68,7 +68,7 @@ def injected_script_assets() -> list[str]:
 
 
 class ScriptNode(template.Node):
-    def __init__(self, nodelist, **kwargs):
+    def __init__(self, nodelist, **kwargs) -> None:
         self.nodelist = nodelist
         self.attrs = kwargs
 

--- a/src/sentry/templatetags/sentry_features.py
+++ b/src/sentry/templatetags/sentry_features.py
@@ -29,7 +29,7 @@ def feature(parser, token):
 
 
 class FeatureNode(template.Node):
-    def __init__(self, nodelist_true, nodelist_false, name, params):
+    def __init__(self, nodelist_true, nodelist_false, name, params) -> None:
         self.nodelist_true = nodelist_true
         self.nodelist_false = nodelist_false
         self.name = name

--- a/src/sentry/templatetags/sentry_helpers.py
+++ b/src/sentry/templatetags/sentry_helpers.py
@@ -44,7 +44,7 @@ def multiply(x, y):
 
 
 class AbsoluteUriNode(template.Node):
-    def __init__(self, args, target_var):
+    def __init__(self, args, target_var) -> None:
         self.args = args
         self.target_var = target_var
 

--- a/src/sentry/testutils/helpers/backups.py
+++ b/src/sentry/testutils/helpers/backups.py
@@ -129,7 +129,7 @@ NOOP_PRINTER = Printer()
 
 
 class ValidationError(Exception):
-    def __init__(self, info: ComparatorFindings):
+    def __init__(self, info: ComparatorFindings) -> None:
         super().__init__(info.pretty())
         self.info = info
 

--- a/src/sentry/testutils/helpers/datetime.py
+++ b/src/sentry/testutils/helpers/datetime.py
@@ -21,7 +21,7 @@ def isoformat_z(dt: datetime) -> str:
 class MockClock:
     """Returns a distinct, increasing timestamp each time it is called."""
 
-    def __init__(self, initial=None):
+    def __init__(self, initial=None) -> None:
         self.time = initial or datetime.now(UTC)
 
     def __call__(self):

--- a/src/sentry/testutils/helpers/features.py
+++ b/src/sentry/testutils/helpers/features.py
@@ -143,7 +143,7 @@ def Feature(names: str | Iterable[str] | dict[str, bool]) -> Generator[None]:
 
 
 class FeatureContextManagerOrDecorator:
-    def __init__(self, feature_names):
+    def __init__(self, feature_names) -> None:
         self.feature_names = feature_names
         self._context_manager = None
 

--- a/src/sentry/testutils/helpers/features.py
+++ b/src/sentry/testutils/helpers/features.py
@@ -143,7 +143,7 @@ def Feature(names: str | Iterable[str] | dict[str, bool]) -> Generator[None]:
 
 
 class FeatureContextManagerOrDecorator:
-    def __init__(self, feature_names) -> None:
+    def __init__(self, feature_names):
         self.feature_names = feature_names
         self._context_manager = None
 

--- a/src/sentry/testutils/hybrid_cloud.py
+++ b/src/sentry/testutils/hybrid_cloud.py
@@ -103,7 +103,7 @@ class CrossTransactionAssertionError(AssertionError):
 class EnforceNoCrossTransactionWrapper:
     alias: str
 
-    def __init__(self, alias: str):
+    def __init__(self, alias: str) -> None:
         self.alias = alias
 
     def __call__(self, execute: Callable[..., Any], *params: Any) -> Any:
@@ -150,7 +150,7 @@ class TransactionDetailsWrapper:
     result: list[TransactionDetails]
     alias: str
 
-    def __init__(self, alias: str, result: list[TransactionDetails]):
+    def __init__(self, alias: str, result: list[TransactionDetails]) -> None:
         self.result = result
         self.alias = alias
 

--- a/src/sentry/testutils/notifications/platform.py
+++ b/src/sentry/testutils/notifications/platform.py
@@ -39,7 +39,7 @@ class MockNotificationTemplate(NotificationTemplate[MockNotification]):
 
 
 class MockStrategy(NotificationStrategy):
-    def __init__(self, *, targets: list[NotificationTarget]):
+    def __init__(self, *, targets: list[NotificationTarget]) -> None:
         self.targets = targets
 
     def get_targets(self) -> list[NotificationTarget]:

--- a/src/sentry/testutils/pytest/json_report_reruns.py
+++ b/src/sentry/testutils/pytest/json_report_reruns.py
@@ -25,7 +25,7 @@ def pytest_plugin_registered(plugin: object, manager: pytest.PytestPluginManager
 
 
 class PytestRerunJSONReporter:
-    def __init__(self, json_tests: JSONTestItems):
+    def __init__(self, json_tests: JSONTestItems) -> None:
         self.json_tests = json_tests
 
     def pytest_json_runtest_stage(self, report: pytest.TestReport) -> None:

--- a/src/sentry/testutils/pytest/kafka.py
+++ b/src/sentry/testutils/pytest/kafka.py
@@ -23,7 +23,7 @@ def kafka_producer():
 
 
 class _KafkaAdminWrapper:
-    def __init__(self, request, settings):
+    def __init__(self, request, settings) -> None:
         self.test_name = request.node.name
 
         kafka_config = {}

--- a/src/sentry/testutils/pytest/selenium.py
+++ b/src/sentry/testutils/pytest/selenium.py
@@ -28,7 +28,7 @@ logger = logging.getLogger("sentry.testutils")
 
 
 class Browser:
-    def __init__(self, driver, live_server):
+    def __init__(self, driver, live_server) -> None:
         self.driver = driver
         self.live_server_url = live_server.url
         self.domain = urlparse(self.live_server_url).hostname

--- a/src/sentry/tsdb/redis.py
+++ b/src/sentry/tsdb/redis.py
@@ -48,7 +48,7 @@ class SuppressionWrapper(Generic[T]):
     You probably shouldn't use this.
     """
 
-    def __init__(self, wrapped: ContextManager[T]):
+    def __init__(self, wrapped: ContextManager[T]) -> None:
         self.wrapped = wrapped
 
     def __enter__(self) -> T:
@@ -123,7 +123,7 @@ class RedisTSDB(BaseTSDB):
 
     DEFAULT_SKETCH_PARAMETERS = SketchParameters(3, 128, 50)
 
-    def __init__(self, prefix: str = "ts:", vnodes: int = 64, **options: Any):
+    def __init__(self, prefix: str = "ts:", vnodes: int = 64, **options: Any) -> None:
         cluster, options = get_cluster_from_options("SENTRY_TSDB_OPTIONS", options)
         self.cluster = cluster
         self.prefix = prefix

--- a/src/sentry/tsdb/redissnuba.py
+++ b/src/sentry/tsdb/redissnuba.py
@@ -100,7 +100,7 @@ class RedisSnubaTSDBMeta(type):
 
 
 class RedisSnubaTSDB(BaseTSDB, metaclass=RedisSnubaTSDBMeta):
-    def __init__(self, switchover_timestamp=None, **options):
+    def __init__(self, switchover_timestamp=None, **options) -> None:
         """
         A TSDB backend that uses the Snuba outcomes and events datasets as far
         as possible instead of reading/writing to redis. Reading will trigger a

--- a/src/sentry/tsdb/snuba.py
+++ b/src/sentry/tsdb/snuba.py
@@ -211,7 +211,7 @@ class SnubaTSDB(BaseTSDB):
         )
     )
 
-    def __init__(self, **options):
+    def __init__(self, **options) -> None:
         super().__init__(**options)
 
     def __manual_group_on_time_aggregation(self, rollup, time_column_alias) -> list[Any]:

--- a/src/sentry/uptime/endpoints/serializers.py
+++ b/src/sentry/uptime/endpoints/serializers.py
@@ -54,7 +54,7 @@ class ProjectUptimeSubscriptionSerializerResponse(UptimeSubscriptionSerializerRe
 
 @register(ProjectUptimeSubscription)
 class ProjectUptimeSubscriptionSerializer(Serializer):
-    def __init__(self, expand=None):
+    def __init__(self, expand=None) -> None:
         self.expand = expand
 
     def get_attrs(

--- a/src/sentry/uptime/subscriptions/subscriptions.py
+++ b/src/sentry/uptime/subscriptions/subscriptions.py
@@ -544,7 +544,7 @@ def check_and_update_regions(
 
 
 class MaxUrlsForDomainReachedException(Exception):
-    def __init__(self, domain, suffix, max_urls):
+    def __init__(self, domain, suffix, max_urls) -> None:
         self.domain = domain
         self.suffix = suffix
         self.max_urls = max_urls

--- a/src/sentry/utils/circuit_breaker2.py
+++ b/src/sentry/utils/circuit_breaker2.py
@@ -123,7 +123,7 @@ class CircuitBreaker:
     easily monitored.
     """
 
-    def __init__(self, key: str, config: CircuitBreakerConfig):
+    def __init__(self, key: str, config: CircuitBreakerConfig) -> None:
         self.key = key
         self.broken_state_key = f"{key}.circuit_breaker.broken"
         self.recovery_state_key = f"{key}.circuit_breaker.in_recovery"

--- a/src/sentry/utils/codecs.py
+++ b/src/sentry/utils/codecs.py
@@ -55,7 +55,7 @@ class BytesCodec(Codec[str, bytes]):
     constructor.
     """
 
-    def __init__(self, encoding: str = "utf8"):
+    def __init__(self, encoding: str = "utf8") -> None:
         self.encoding = encoding
 
     def encode(self, value: str) -> bytes:

--- a/src/sentry/utils/concurrent.py
+++ b/src/sentry/utils/concurrent.py
@@ -54,7 +54,7 @@ class TimedFuture[T](Future[T]):
     _condition: threading.Condition
     _state: str
 
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args, **kwargs):
         self.__timing: list[float | None] = [None, None]  # [started, finished/cancelled]
         super().__init__(*args, **kwargs)
 
@@ -134,9 +134,7 @@ class Executor:
     to allow controlling whether or not queue insertion should be blocking.
     """
 
-    def submit[
-        T
-    ](
+    def submit[T](
         self,
         callable: Callable[[], T],
         priority: int = 0,
@@ -190,7 +188,7 @@ class ThreadedExecutor(Executor):
     exits. Any items remaining in the queue at this point may not be executed!
     """
 
-    def __init__(self, worker_count=1, maxsize=0) -> None:
+    def __init__(self, worker_count=1, maxsize=0):
         self.__worker_count = worker_count
         self.__workers = set()
         self.__started = False
@@ -227,9 +225,9 @@ class ThreadedExecutor(Executor):
 
             self.__started = True
 
-    def submit[
-        T
-    ](self, callable: Callable[[], T], priority=0, block=True, timeout=None) -> TimedFuture[T]:
+    def submit[T](
+        self, callable: Callable[[], T], priority=0, block=True, timeout=None
+    ) -> TimedFuture[T]:
         """\
         Enqueue a task to be executed, returning a ``TimedFuture``.
 
@@ -268,7 +266,7 @@ class FutureSet:
     attaching a callback when all futures have completed execution.
     """
 
-    def __init__(self, futures) -> None:
+    def __init__(self, futures):
         self.__pending = set(futures)
         self.__completed = set()
         self.__callbacks = []

--- a/src/sentry/utils/concurrent.py
+++ b/src/sentry/utils/concurrent.py
@@ -54,7 +54,7 @@ class TimedFuture[T](Future[T]):
     _condition: threading.Condition
     _state: str
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         self.__timing: list[float | None] = [None, None]  # [started, finished/cancelled]
         super().__init__(*args, **kwargs)
 
@@ -134,7 +134,9 @@ class Executor:
     to allow controlling whether or not queue insertion should be blocking.
     """
 
-    def submit[T](
+    def submit[
+        T
+    ](
         self,
         callable: Callable[[], T],
         priority: int = 0,
@@ -188,7 +190,7 @@ class ThreadedExecutor(Executor):
     exits. Any items remaining in the queue at this point may not be executed!
     """
 
-    def __init__(self, worker_count=1, maxsize=0):
+    def __init__(self, worker_count=1, maxsize=0) -> None:
         self.__worker_count = worker_count
         self.__workers = set()
         self.__started = False
@@ -225,9 +227,9 @@ class ThreadedExecutor(Executor):
 
             self.__started = True
 
-    def submit[T](
-        self, callable: Callable[[], T], priority=0, block=True, timeout=None
-    ) -> TimedFuture[T]:
+    def submit[
+        T
+    ](self, callable: Callable[[], T], priority=0, block=True, timeout=None) -> TimedFuture[T]:
         """\
         Enqueue a task to be executed, returning a ``TimedFuture``.
 
@@ -266,7 +268,7 @@ class FutureSet:
     attaching a callback when all futures have completed execution.
     """
 
-    def __init__(self, futures):
+    def __init__(self, futures) -> None:
         self.__pending = set(futures)
         self.__completed = set()
         self.__callbacks = []

--- a/src/sentry/utils/datastructures.py
+++ b/src/sentry/utils/datastructures.py
@@ -13,7 +13,7 @@ class BidirectionalMapping(MutableMapping):
     provided to ``get_key``.
     """
 
-    def __init__(self, data):
+    def __init__(self, data) -> None:
         self.__data = data
         self.__inverse = {v: k for k, v in self.__data.items()}
         if len(self.__data) != len(self.__inverse):

--- a/src/sentry/utils/function_cache.py
+++ b/src/sentry/utils/function_cache.py
@@ -120,7 +120,7 @@ class CachedFunction(Generic[*Ts, R]):
     for processing multiple sets of arguments efficiently.
     """
 
-    def __init__(self, func: Callable[[*Ts], R], cache_ttl: timedelta):
+    def __init__(self, func: Callable[[*Ts], R], cache_ttl: timedelta) -> None:
         self.func = func
         self.cache_ttl = cache_ttl
         update_wrapper(self, func)

--- a/src/sentry/utils/locking/backends/redis.py
+++ b/src/sentry/utils/locking/backends/redis.py
@@ -50,7 +50,9 @@ class BaseRedisLockBackend(LockBackend):
 class RedisBlasterLockBackend(BaseRedisLockBackend):
     cluster: rb.Cluster
 
-    def __init__(self, cluster: str | rb.Cluster, prefix: str = "l:", uuid: str | None = None):
+    def __init__(
+        self, cluster: str | rb.Cluster, prefix: str = "l:", uuid: str | None = None
+    ) -> None:
         if isinstance(cluster, str):
             cluster = redis.clusters.get(cluster)
         super().__init__(cluster, prefix=prefix, uuid=uuid)

--- a/src/sentry/utils/managers.py
+++ b/src/sentry/utils/managers.py
@@ -2,7 +2,7 @@ import logging
 
 
 class InstanceManager:
-    def __init__(self, class_list=None, instances=True):
+    def __init__(self, class_list=None, instances=True) -> None:
         if class_list is None:
             class_list = []
         self.instances = instances

--- a/src/sentry/utils/marketo_client.py
+++ b/src/sentry/utils/marketo_client.py
@@ -15,7 +15,7 @@ class MarketoErrorResponse(TypedDict):
 
 
 class MarketoError(Exception):
-    def __init__(self, data: MarketoErrorResponse):
+    def __init__(self, data: MarketoErrorResponse) -> None:
         # just use the first error
         error = data["errors"][0]
         self.code = error["code"]

--- a/src/sentry/utils/math.py
+++ b/src/sentry/utils/math.py
@@ -43,7 +43,7 @@ class MovingAverage(ABC):
 
 
 class ExponentialMovingAverage(MovingAverage):
-    def __init__(self, weight: float):
+    def __init__(self, weight: float) -> None:
         super().__init__()
         assert 0 < weight and weight < 1
         self.weight = weight

--- a/src/sentry/utils/meta.py
+++ b/src/sentry/utils/meta.py
@@ -27,7 +27,7 @@ class Meta:
     dict. Alternatively, use the ``merge`` or ``add_error`` convenience methods.
     """
 
-    def __init__(self, meta=None, path=None):
+    def __init__(self, meta=None, path=None) -> None:
         self._meta = {} if meta is None else meta
         self._path = path or []
 

--- a/src/sentry/utils/pagination_factory.py
+++ b/src/sentry/utils/pagination_factory.py
@@ -11,7 +11,7 @@ from sentry.utils.numbers import format_grouped_length
 
 
 class PaginatorLike(Protocol):
-    def __init__(self, *args: Any, **kwds: Any):
+    def __init__(self, *args: Any, **kwds: Any) -> None:
         pass
 
     def get_result(

--- a/src/sentry/utils/prompts.py
+++ b/src/sentry/utils/prompts.py
@@ -49,7 +49,7 @@ class PromptsConfig:
     required_fields available: [organization_id, project_id]
     """
 
-    def __init__(self, prompts: dict[str, _PromptConfig]):
+    def __init__(self, prompts: dict[str, _PromptConfig]) -> None:
         self.prompts = prompts
 
     def add(self, name: str, config: _PromptConfig) -> None:

--- a/src/sentry/utils/retries.py
+++ b/src/sentry/utils/retries.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 class RetryException(Exception):
-    def __init__(self, message, exception):
+    def __init__(self, message, exception) -> None:
         super().__init__(message)
         self.message = message
         self.exception = exception

--- a/src/sentry/utils/sdk_crashes/path_replacer.py
+++ b/src/sentry/utils/sdk_crashes/path_replacer.py
@@ -50,7 +50,7 @@ class KeepAfterPatternMatchPathReplacer(PathReplacer):
 
 
 class KeepFieldPathReplacer(PathReplacer):
-    def __init__(self, fields: set[str]):
+    def __init__(self, fields: set[str]) -> None:
         self.fields = fields
 
     def replace_path(self, path_field: str, path_value: str) -> str | None:

--- a/src/sentry/utils/services.py
+++ b/src/sentry/utils/services.py
@@ -303,9 +303,7 @@ def build_instance_from_options(
     return constructor(**options.get("options", {}))
 
 
-def build_instance_from_options_of_type[
-    T
-](
+def build_instance_from_options_of_type[T](
     tp: type[T],
     options: ServiceOptions,
     *,

--- a/src/sentry/utils/services.py
+++ b/src/sentry/utils/services.py
@@ -31,7 +31,7 @@ def resolve_callable[CallableT: Callable[..., object]](value: str | CallableT) -
 
 
 class Context:
-    def __init__(self, backends: dict[type[Service | None], Service]):
+    def __init__(self, backends: dict[type[Service | None], Service]) -> None:
         self.backends = backends
 
     def copy(self) -> Context:
@@ -303,7 +303,9 @@ def build_instance_from_options(
     return constructor(**options.get("options", {}))
 
 
-def build_instance_from_options_of_type[T](
+def build_instance_from_options_of_type[
+    T
+](
     tp: type[T],
     options: ServiceOptions,
     *,

--- a/src/sentry/utils/session_store.py
+++ b/src/sentry/utils/session_store.py
@@ -50,7 +50,7 @@ class RedisSessionStore:
 
     redis_namespace = "session-cache"
 
-    def __init__(self, request, prefix, ttl=EXPIRATION_TTL):
+    def __init__(self, request, prefix, ttl=EXPIRATION_TTL) -> None:
         self.request = request
         self.prefix = prefix
         self.ttl = ttl

--- a/src/sentry/web/forms/accounts.py
+++ b/src/sentry/web/forms/accounts.py
@@ -169,7 +169,7 @@ class PasswordlessRegistrationForm(forms.ModelForm):
     )
     timezone = forms.CharField(widget=forms.HiddenInput(), required=False)
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         if not newsletter.backend.is_enabled():
             del self.fields["subscribe"]

--- a/src/sentry/web/forms/fields.py
+++ b/src/sentry/web/forms/fields.py
@@ -59,7 +59,7 @@ class ReadOnlyTextWidget(Widget):
 class ReadOnlyTextField(Field):
     widget = ReadOnlyTextWidget
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         kwargs.setdefault("required", False)
         super().__init__(*args, **kwargs)
 

--- a/src/sentry/web/frontend/auth_login.py
+++ b/src/sentry/web/frontend/auth_login.py
@@ -55,7 +55,7 @@ logger = logging.getLogger("sentry.auth")
 # is rendered. Callbacks are called in any order. If an error is encountered in a callback it is
 # ignored. This works like HookStore in Javascript.
 class AdditionalContext:
-    def __init__(self):
+    def __init__(self) -> None:
         self._callbacks = set()
 
     def add_callback(self, callback: Any) -> None:

--- a/src/sentry/web/frontend/auth_login.py
+++ b/src/sentry/web/frontend/auth_login.py
@@ -55,7 +55,7 @@ logger = logging.getLogger("sentry.auth")
 # is rendered. Callbacks are called in any order. If an error is encountered in a callback it is
 # ignored. This works like HookStore in Javascript.
 class AdditionalContext:
-    def __init__(self) -> None:
+    def __init__(self):
         self._callbacks = set()
 
     def add_callback(self, callback: Any) -> None:

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -303,7 +303,7 @@ def add_unsubscribe_link(context):
 
 # TODO(dcramer): use https://github.com/disqus/django-mailviews
 class MailPreview:
-    def __init__(self, html_template, text_template, context=None, subject=None):
+    def __init__(self, html_template, text_template, context=None, subject=None) -> None:
         self.html_template = html_template
         self.text_template = text_template
         self.subject = subject
@@ -372,7 +372,7 @@ class MailPreviewAdapter(MailPreview):
     This is an adapter for MailPreview that will take similar arguments to MessageBuilder
     """
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs) -> None:
         kwargs["text_template"] = kwargs["template"]
         del kwargs["template"]
         if "from_email" in kwargs:
@@ -382,7 +382,7 @@ class MailPreviewAdapter(MailPreview):
 
 
 class ActivityMailPreview:
-    def __init__(self, request, activity):
+    def __init__(self, request, activity) -> None:
         self.request = request
         self.email = EMAIL_CLASSES_BY_TYPE[activity.type](activity)
 

--- a/src/sentry/workflow_engine/endpoints/validators/base/data_source.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/data_source.py
@@ -12,7 +12,7 @@ T = TypeVar("T", bound=Model)
 
 
 class DataSourceCreator(Generic[T]):
-    def __init__(self, create_fn: Callable[[], T]):
+    def __init__(self, create_fn: Callable[[], T]) -> None:
         self._create_fn = create_fn
         self._instance: T | None = None
 

--- a/src/sentry/workflow_engine/handlers/condition/latest_release_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/latest_release_handler.py
@@ -41,7 +41,7 @@ class _LatestReleaseCacheAccess(CacheAccess[Release | Literal[False]]):
     If we don't, we cache False.
     """
 
-    def __init__(self, event: GroupEvent, environment: Environment | None):
+    def __init__(self, event: GroupEvent, environment: Environment | None) -> None:
         self._key = latest_release_cache_key(
             event.group.project_id, environment.id if environment else None
         )
@@ -56,7 +56,7 @@ class _LatestAdoptedReleaseCacheAccess(CacheAccess[Release | Literal[False]]):
     If we don't, we cache False.
     """
 
-    def __init__(self, event: GroupEvent, environment: Environment):
+    def __init__(self, event: GroupEvent, environment: Environment) -> None:
         self._key = latest_adopted_release_cache_key(event.group.project_id, environment.id)
 
     def key(self) -> str:

--- a/src/sentry/workflow_engine/handlers/detector/base.py
+++ b/src/sentry/workflow_engine/handlers/detector/base.py
@@ -78,7 +78,7 @@ class DetectorOccurrence:
 # TODO - @saponifi3d - Change this class to be a pure ABC and remove the `__init__` method.
 # TODO - @saponifi3d - Once the change is made, we should introduce a `BaseDetector` class to evaluate simple cases
 class DetectorHandler(abc.ABC, Generic[DataPacketType, DataPacketEvaluationType]):
-    def __init__(self, detector: Detector):
+    def __init__(self, detector: Detector) -> None:
         self.detector = detector
         if detector.workflow_condition_group_id is not None:
             try:

--- a/src/sentry/workflow_engine/handlers/detector/stateful.py
+++ b/src/sentry/workflow_engine/handlers/detector/stateful.py
@@ -311,7 +311,7 @@ class StatefulDetectorHandler(
     Stateful Detectors are provided as a base class for new detectors that need to track state.
     """
 
-    def __init__(self, detector: Detector, thresholds: DetectorThresholds | None = None):
+    def __init__(self, detector: Detector, thresholds: DetectorThresholds | None = None) -> None:
         super().__init__(detector)
 
         # Default to 1 for all the possible levels on a given detector

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -493,7 +493,12 @@ class MissingQueryResult(Exception):
     Raised when a group is missing from a query result.
     """
 
-    def __init__(self, group_id: GroupId, query: UniqueConditionQuery, query_result: QueryResult):
+    def __init__(
+        self,
+        group_id: GroupId,
+        query: UniqueConditionQuery,
+        query_result: QueryResult,
+    ) -> None:
         self.group_id = group_id
         self.query = query
         self.query_result = query_result

--- a/src/sentry/workflow_engine/typings/notification_action.py
+++ b/src/sentry/workflow_engine/typings/notification_action.py
@@ -186,7 +186,7 @@ class BaseActionTranslator(ABC):
     # Represents the mapping of a target field to a source field {target_field: FieldMapping}
     field_mappings: ClassVar[dict[str, FieldMapping]] = {}
 
-    def __init__(self, action: dict[str, Any]):
+    def __init__(self, action: dict[str, Any]) -> None:
         self.action = action
 
     @property

--- a/src/sentry_plugins/client.py
+++ b/src/sentry_plugins/client.py
@@ -22,7 +22,7 @@ class ApiClient(BaseApiClient):
 
 
 class AuthApiClient(ApiClient):
-    def __init__(self, auth=None, *args, **kwargs):
+    def __init__(self, auth=None, *args, **kwargs) -> None:
         self.auth = auth
         super().__init__(*args, **kwargs)
 

--- a/src/sentry_plugins/github/client.py
+++ b/src/sentry_plugins/github/client.py
@@ -27,7 +27,7 @@ class GithubPluginClientMixin(AuthApiClient):
 
 
 class GithubPluginClient(GithubPluginClientMixin, AuthApiClient):
-    def __init__(self, url=None, auth=None):
+    def __init__(self, url=None, auth=None) -> None:
         if url is not None:
             self.base_url = url.rstrip("/")
         super().__init__(auth=auth)
@@ -73,7 +73,7 @@ class GithubPluginClient(GithubPluginClientMixin, AuthApiClient):
 
 
 class GithubPluginAppsClient(GithubPluginClientMixin, ApiClient):
-    def __init__(self, integration: RpcIntegration):
+    def __init__(self, integration: RpcIntegration) -> None:
         self.integration = integration
         self.token: str | None = None
         self.expires_at: datetime.datetime | None = None

--- a/src/sentry_plugins/gitlab/client.py
+++ b/src/sentry_plugins/gitlab/client.py
@@ -8,7 +8,7 @@ class GitLabClient(ApiClient):
     allow_redirects = False
     plugin_name = "gitlab"
 
-    def __init__(self, url, token):
+    def __init__(self, url, token) -> None:
         super().__init__()
         self.base_url = url
         self.token = token

--- a/src/sentry_plugins/jira/client.py
+++ b/src/sentry_plugins/jira/client.py
@@ -32,7 +32,7 @@ class JiraClient(ApiClient):
 
     cache_time = 60
 
-    def __init__(self, instance_uri, username, password):
+    def __init__(self, instance_uri, username, password) -> None:
         self.base_url = instance_uri.rstrip("/")
         self.username = username
         self.password = password

--- a/src/sentry_plugins/opsgenie/client.py
+++ b/src/sentry_plugins/opsgenie/client.py
@@ -6,7 +6,7 @@ class OpsGenieApiClient(ApiClient):
     plugin_name = "opsgenie"
     allow_redirects = False
 
-    def __init__(self, api_key, alert_url, recipients=None):
+    def __init__(self, api_key, alert_url, recipients=None) -> None:
         self.api_key = api_key
         self.alert_url = alert_url
         self.recipients = recipients

--- a/src/sentry_plugins/pagerduty/client.py
+++ b/src/sentry_plugins/pagerduty/client.py
@@ -10,7 +10,7 @@ class PagerDutyPluginClient(ApiClient):
     plugin_name = "pagerduty"
     allow_redirects = False
 
-    def __init__(self, service_key=None):
+    def __init__(self, service_key=None) -> None:
         self.service_key = service_key
         super().__init__()
 

--- a/src/sentry_plugins/pushover/client.py
+++ b/src/sentry_plugins/pushover/client.py
@@ -6,7 +6,7 @@ class PushoverClient(ApiClient):
     allow_redirects = False
     plugin_name = "pushover"
 
-    def __init__(self, userkey=None, apikey=None):
+    def __init__(self, userkey=None, apikey=None) -> None:
         self.userkey = userkey
         self.apikey = apikey
         super().__init__()

--- a/src/sentry_plugins/redmine/client.py
+++ b/src/sentry_plugins/redmine/client.py
@@ -3,7 +3,7 @@ from sentry.utils import json
 
 
 class RedmineClient:
-    def __init__(self, host, key):
+    def __init__(self, host, key) -> None:
         self.host = host.rstrip("/")
         self.key = key
 

--- a/src/sentry_plugins/redmine/plugin.py
+++ b/src/sentry_plugins/redmine/plugin.py
@@ -51,7 +51,7 @@ class RedminePlugin(CorePluginMixin, IssuePlugin):
 
     new_issue_form = RedmineNewIssueForm
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.client_errors = []
         self.fields = []

--- a/src/sentry_plugins/redmine/plugin.py
+++ b/src/sentry_plugins/redmine/plugin.py
@@ -51,7 +51,7 @@ class RedminePlugin(CorePluginMixin, IssuePlugin):
 
     new_issue_form = RedmineNewIssueForm
 
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__()
         self.client_errors = []
         self.fields = []

--- a/src/sentry_plugins/sessionstack/client.py
+++ b/src/sentry_plugins/sessionstack/client.py
@@ -20,7 +20,7 @@ MILLISECONDS_BEFORE_EVENT = 5000
 
 
 class SessionStackClient:
-    def __init__(self, account_email, api_token, website_id, **kwargs):
+    def __init__(self, account_email, api_token, website_id, **kwargs) -> None:
         self.website_id = website_id
 
         api_url = kwargs.get("api_url") or API_URL

--- a/src/sentry_plugins/splunk/client.py
+++ b/src/sentry_plugins/splunk/client.py
@@ -6,7 +6,7 @@ class SplunkApiClient(ApiClient):
     allow_redirects = False
     metrics_prefix = "integrations.splunk"
 
-    def __init__(self, endpoint, token):
+    def __init__(self, endpoint, token) -> None:
         self.endpoint = endpoint
         self.token = token
         super().__init__(verify_ssl=False)

--- a/src/sentry_plugins/trello/client.py
+++ b/src/sentry_plugins/trello/client.py
@@ -16,7 +16,7 @@ class TrelloApiClient(ApiClient):
     base_url = "https://api.trello.com/1"
     plugin_name = "trello"
 
-    def __init__(self, api_key, token=None, **kwargs):
+    def __init__(self, api_key, token=None, **kwargs) -> None:
         self.api_key = api_key
         self.token = token
         super().__init__(**kwargs)

--- a/src/sentry_plugins/twilio/client.py
+++ b/src/sentry_plugins/twilio/client.py
@@ -10,7 +10,7 @@ class TwilioApiClient(ApiClient):
     allow_redirects = False
     twilio_messages_endpoint = "https://api.twilio.com/2010-04-01/Accounts/{0}/Messages.json"
 
-    def __init__(self, account_sid, auth_token, sms_from, sms_to):
+    def __init__(self, account_sid, auth_token, sms_from, sms_to) -> None:
         self.account_sid = account_sid
         self.auth_token = auth_token
         self.sms_from = sms_from

--- a/src/sentry_plugins/victorops/client.py
+++ b/src/sentry_plugins/victorops/client.py
@@ -7,7 +7,7 @@ class VictorOpsClient(ApiClient):
     plugin_name = "victorops"
     allow_redirects = False
 
-    def __init__(self, api_key, routing_key=None):
+    def __init__(self, api_key, routing_key=None) -> None:
         self.api_key = api_key
 
         if routing_key:

--- a/src/social_auth/backends/__init__.py
+++ b/src/social_auth/backends/__init__.py
@@ -256,7 +256,7 @@ class BaseAuth:
 
     AUTH_BACKEND: type[SocialAuthBackend]
 
-    def __init__(self, request, redirect):
+    def __init__(self, request, redirect) -> None:
         self.request = request
         # TODO(python3): use {**x, **y} syntax once 2.7 support is dropped
         data = request.GET.copy()
@@ -376,7 +376,7 @@ class OAuthAuth(BaseAuth):
     DEFAULT_SCOPE: list[str] | None = None
     SCOPE_SEPARATOR = " "
 
-    def __init__(self, request, redirect):
+    def __init__(self, request, redirect) -> None:
         """Init method"""
         super().__init__(request, redirect)
         self.redirect_uri = self.build_absolute_uri(self.redirect)

--- a/src/social_auth/exceptions.py
+++ b/src/social_auth/exceptions.py
@@ -11,7 +11,7 @@ class BackendError(SocialAuthBaseException):
 
 
 class WrongBackend(BackendError):
-    def __init__(self, backend_name):
+    def __init__(self, backend_name) -> None:
         self.backend_name = backend_name
 
     def __str__(self) -> str:
@@ -30,7 +30,7 @@ class StopPipeline(SocialAuthBaseException):
 class AuthException(SocialAuthBaseException):
     """Auth process exception."""
 
-    def __init__(self, backend, *args, **kwargs):
+    def __init__(self, backend, *args, **kwargs) -> None:
         self.backend = backend
         super().__init__(*args, **kwargs)
 
@@ -71,7 +71,7 @@ class AuthTokenError(AuthException):
 class AuthMissingParameter(AuthException):
     """Missing parameter needed to start or complete the process."""
 
-    def __init__(self, backend, parameter, *args, **kwargs):
+    def __init__(self, backend, parameter, *args, **kwargs) -> None:
         self.parameter = parameter
         super().__init__(backend, *args, **kwargs)
 

--- a/tests/sentry/analytics/test_base.py
+++ b/tests/sentry/analytics/test_base.py
@@ -1,13 +1,14 @@
 from sentry.analytics import Analytics
+from sentry.analytics.event import Event
 from sentry.testutils.cases import TestCase
 
 
 class DummyAnalytics(Analytics):
-    def __init__(self):
+    def __init__(self) -> None:
         self.events = []
         super().__init__()
 
-    def record_event(self, event):
+    def record_event(self, event: Event):
         self.events.append(event)
 
 

--- a/tests/sentry/analytics/test_base.py
+++ b/tests/sentry/analytics/test_base.py
@@ -1,14 +1,13 @@
 from sentry.analytics import Analytics
-from sentry.analytics.event import Event
 from sentry.testutils.cases import TestCase
 
 
 class DummyAnalytics(Analytics):
-    def __init__(self) -> None:
+    def __init__(self):
         self.events = []
         super().__init__()
 
-    def record_event(self, event: Event):
+    def record_event(self, event):
         self.events.append(event)
 
 

--- a/tests/sentry/api/test_api_pagination_check.py
+++ b/tests/sentry/api/test_api_pagination_check.py
@@ -12,7 +12,7 @@ from sentry.api.paginator import MissingPaginationError, OffsetPaginator
 class APIPaginationCheckTestCase(TestCase):
     def test_if_wrong_api_method_fails(self) -> None:
         class ExampleEndpoint(TestCase, Endpoint):
-            def __init__(self, *args, **kwargs):
+            def __init__(self, *args, **kwargs) -> None:
                 super().__init__(*args, **kwargs)
                 self.access = "read"
 
@@ -32,7 +32,7 @@ class APIPaginationCheckTestCase(TestCase):
 
     def test_endpoint_in_allowlist(self) -> None:
         class GroupTagsEndpoint(TestCase, Endpoint):
-            def __init__(self, *args, **kwargs):
+            def __init__(self, *args, **kwargs) -> None:
                 super().__init__(*args, **kwargs)
                 self.access = "read"
 
@@ -51,7 +51,7 @@ class APIPaginationCheckTestCase(TestCase):
 
     def test_empty_payload_with_pagination(self) -> None:
         class ExampleEndpoint(Endpoint):
-            def __init__(self, *args, **kwargs):
+            def __init__(self, *args, **kwargs) -> None:
                 super().__init__(*args, **kwargs)
                 self.access = "read"
 

--- a/tests/sentry/attachments/test_base.py
+++ b/tests/sentry/attachments/test_base.py
@@ -9,7 +9,7 @@ class InMemoryCache:
     internal assertions to ensure correct use of `raw`.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.data = {}
         #: Used to check for consistent usage of `raw` param
         self.raw_map = {}

--- a/tests/sentry/attachments/test_base.py
+++ b/tests/sentry/attachments/test_base.py
@@ -9,7 +9,7 @@ class InMemoryCache:
     internal assertions to ensure correct use of `raw`.
     """
 
-    def __init__(self) -> None:
+    def __init__(self):
         self.data = {}
         #: Used to check for consistent usage of `raw` param
         self.raw_map = {}

--- a/tests/sentry/attachments/test_redis.py
+++ b/tests/sentry/attachments/test_redis.py
@@ -11,7 +11,7 @@ KEY_FMT = "c:1:%s"
 
 
 class FakeClient:
-    def __init__(self):
+    def __init__(self) -> None:
         self.data = {}
 
     def get(self, key):

--- a/tests/sentry/attachments/test_redis.py
+++ b/tests/sentry/attachments/test_redis.py
@@ -11,7 +11,7 @@ KEY_FMT = "c:1:%s"
 
 
 class FakeClient:
-    def __init__(self) -> None:
+    def __init__(self):
         self.data = {}
 
     def get(self, key):

--- a/tests/sentry/auth_v2/utils/test_session.py
+++ b/tests/sentry/auth_v2/utils/test_session.py
@@ -13,7 +13,7 @@ EXPIRY_DATE = datetime(2023, 12, 31)
 class MockSession(SessionBase):
     """Mock session class for testing."""
 
-    def __init__(self) -> None:
+    def __init__(self):
         self.data = {}
 
     def get(self, key, default=None):

--- a/tests/sentry/auth_v2/utils/test_session.py
+++ b/tests/sentry/auth_v2/utils/test_session.py
@@ -13,7 +13,7 @@ EXPIRY_DATE = datetime(2023, 12, 31)
 class MockSession(SessionBase):
     """Mock session class for testing."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.data = {}
 
     def get(self, key, default=None):

--- a/tests/sentry/dynamic_sampling/tasks/test_common.py
+++ b/tests/sentry/dynamic_sampling/tasks/test_common.py
@@ -36,7 +36,7 @@ def test_timeout_exception() -> None:
 
 
 class FakeContextIterator:
-    def __init__(self, frozen_time, tick_seconds):
+    def __init__(self, frozen_time, tick_seconds) -> None:
         self.count = 0
         self.frozen_time = frozen_time
         self.tick_seconds = tick_seconds

--- a/tests/sentry/features/test_manager.py
+++ b/tests/sentry/features/test_manager.py
@@ -114,7 +114,7 @@ class FeatureManagerTest(TestCase):
         class TestProjectHandler(features.FeatureHandler):
             features = {project_flag}
 
-            def __init__(self, true_set, false_set):
+            def __init__(self, true_set, false_set) -> None:
                 self.true_set = frozenset(true_set)
                 self.false_set = frozenset(false_set)
 
@@ -222,7 +222,7 @@ class FeatureManagerTest(TestCase):
             class OrganizationTestHandler(features.BatchFeatureHandler):
                 features = set(flags)
 
-                def __init__(self):
+                def __init__(self) -> None:
                     self.hit_counter = 0
 
                 def _check_for_batch(self, feature_name, organization, actor):

--- a/tests/sentry/grouping/__init__.py
+++ b/tests/sentry/grouping/__init__.py
@@ -58,7 +58,7 @@ register_strategy_config(
 
 
 class GroupingInput:
-    def __init__(self, inputs_dir: str, filename: str):
+    def __init__(self, inputs_dir: str, filename: str) -> None:
         self.filename = filename  # Necessary for test naming
         with open(path.join(inputs_dir, self.filename)) as f:
             self.data = json.load(f)

--- a/tests/sentry/integrations/api/endpoints/test_user_organizationintegration.py
+++ b/tests/sentry/integrations/api/endpoints/test_user_organizationintegration.py
@@ -26,7 +26,7 @@ class MockOrganizationRoles:
         {"id": "alice", "name": "Alice", "desc": "In Wonderland"},
     ]
 
-    def __init__(self):
+    def __init__(self) -> None:
         from sentry.roles.manager import RoleManager
 
         self.default_manager = RoleManager(self.TEST_ORG_ROLES, self.TEST_TEAM_ROLES)

--- a/tests/sentry/integrations/jira/test_webhooks.py
+++ b/tests/sentry/integrations/jira/test_webhooks.py
@@ -196,7 +196,7 @@ class MockErroringJiraEndpoint(JiraWebhookBase):
     # kwarg we'd like to pass must already be an attibute of the class
     error = BaseException("unreachable")
 
-    def __init__(self, error: Exception = dummy_exception, *args, **kwargs):
+    def __init__(self, error: Exception = dummy_exception, *args, **kwargs) -> None:
         # We allow the error to be passed in so that we have access to it in the test for use
         # in equality checks
         self.error = error

--- a/tests/sentry/integrations/source_code_management/test_commit_context.py
+++ b/tests/sentry/integrations/source_code_management/test_commit_context.py
@@ -20,7 +20,7 @@ class MockCommitContextIntegration(CommitContextIntegration):
 
     integration_name = "mock_integration"
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.client = Mock()
         self.client.base_url = "https://example.com"
 
@@ -155,7 +155,7 @@ class TestCommitContextIntegrationSLO(TestCase):
             integration_name = "gitlab"
             base_url = "https://bufo-bot.gitlab.com"
 
-            def __init__(self):
+            def __init__(self) -> None:
                 super().__init__()
                 self.client.base_url = self.base_url
 
@@ -181,7 +181,7 @@ class TestCommitContextIntegrationSLO(TestCase):
             integration_name = "gitlab"
             base_url = GITLAB_CLOUD_BASE_URL
 
-            def __init__(self):
+            def __init__(self) -> None:
                 super().__init__()
                 self.client.base_url = self.base_url
 

--- a/tests/sentry/models/test_organizationmember.py
+++ b/tests/sentry/models/test_organizationmember.py
@@ -42,7 +42,7 @@ class MockOrganizationRoles:
         {"id": "carol", "name": "Carol", "desc": "A nanny?"},
     ]
 
-    def __init__(self):
+    def __init__(self) -> None:
         from sentry.roles.manager import RoleManager
 
         self.default_manager = RoleManager(self.TEST_ORG_ROLES, self.TEST_TEAM_ROLES)

--- a/tests/sentry/pipeline/test_pipeline.py
+++ b/tests/sentry/pipeline/test_pipeline.py
@@ -33,7 +33,7 @@ class DummyProvider(PipelineProvider["DummyPipeline"]):
 class DummyPipeline(Pipeline[Never, PipelineSessionStore]):
     pipeline_name = "test_pipeline"
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.finished = False
         self.dispatch_count = 0

--- a/tests/sentry/preprod/test_tasks.py
+++ b/tests/sentry/preprod/test_tasks.py
@@ -260,7 +260,7 @@ class AssemblePreprodArtifactTest(BaseAssembleTest):
         assert initial_config_count == 0
 
         class MockAssembleResult:
-            def __init__(self):
+            def __init__(self) -> None:
                 self.bundle = type("MockBundle", (), {"id": 12345})()
 
         with (

--- a/tests/sentry/ratelimits/test_cardinality.py
+++ b/tests/sentry/ratelimits/test_cardinality.py
@@ -21,7 +21,7 @@ class LimiterHelper:
     primitive interface for more readable tests.
     """
 
-    def __init__(self, limiter: RedisCardinalityLimiter):
+    def __init__(self, limiter: RedisCardinalityLimiter) -> None:
         self.limiter = limiter
         self.quota = Quota(window_seconds=3600, granularity_seconds=60, limit=10)
         self.timestamp = 3600

--- a/tests/sentry/ratelimits/test_redis_concurrent.py
+++ b/tests/sentry/ratelimits/test_redis_concurrent.py
@@ -36,7 +36,7 @@ class ConcurrentLimiterTest(TestCase):
 
     def test_fails_open(self) -> None:
         class FakeClient:
-            def __init__(self, real_client):
+            def __init__(self, real_client) -> None:
                 self._client = real_client
 
             def __getattr__(self, name):

--- a/tests/sentry/seer/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/seer/endpoints/test_group_ai_autofix.py
@@ -97,7 +97,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         mock_get_autofix_state.return_value = autofix_state
 
         class TestRepo:
-            def __init__(self):
+            def __init__(self) -> None:
                 self.url = "example.com"
                 self.external_id = "id123"
                 self.name = "test_repo"
@@ -154,7 +154,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         mock_get_autofix_state.return_value = autofix_state
 
         class TestRepo:
-            def __init__(self, external_id, name, provider, url, integration_id):
+            def __init__(self, external_id, name, provider, url, integration_id) -> None:
                 self.url = url
                 self.external_id = external_id
                 self.name = name
@@ -227,7 +227,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         mock_get_autofix_state.return_value = autofix_state
 
         class TestRepo:
-            def __init__(self, external_id):
+            def __init__(self, external_id) -> None:
                 self.url = "example.com"
                 self.external_id = external_id
                 self.name = "test_repo"
@@ -267,7 +267,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         mock_get_autofix_state.return_value = autofix_state
 
         class TestRepo:
-            def __init__(self):
+            def __init__(self) -> None:
                 self.url = "example.com"
                 self.external_id = "id123"
                 self.name = "test_repo"

--- a/tests/sentry/sentry_apps/api/endpoints/test_sentry_apps.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_sentry_apps.py
@@ -61,7 +61,7 @@ class MockOrganizationRoles:
         {"id": "alice", "name": "Alice", "desc": "In Wonderland"},
     ]
 
-    def __init__(self):
+    def __init__(self) -> None:
         from sentry.roles.manager import RoleManager
 
         self.default_manager = RoleManager(self.TEST_ORG_ROLES, self.TEST_TEAM_ROLES)

--- a/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
+++ b/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
@@ -79,7 +79,7 @@ def raiseHTTPError():
 
 
 class RequestMock:
-    def __init__(self):
+    def __init__(self) -> None:
         self.body = "blah blah"
 
 

--- a/tests/sentry/similarity/test_encoder.py
+++ b/tests/sentry/similarity/test_encoder.py
@@ -28,7 +28,7 @@ def test_builtin_types() -> None:
 
 def test_custom_types() -> None:
     class Widget:
-        def __init__(self, color):
+        def __init__(self, color) -> None:
             self.color = color
 
     encoder = Encoder({Widget: lambda i: {"color": i.color}})

--- a/tests/sentry/snuba/metrics/test_query.py
+++ b/tests/sentry/snuba/metrics/test_query.py
@@ -29,7 +29,7 @@ from sentry.utils.dates import parse_stats_period
 class MetricsQueryBuilder:
     AVG_DURATION_METRIC = MetricField(op="avg", metric_mri=SessionMRI.DURATION.value)
 
-    def __init__(self):
+    def __init__(self) -> None:
         now = datetime.now()
         self.org_id: int = 1
         self.project_ids: Sequence[int] = [1, 2]

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -86,7 +86,7 @@ pytestmark = [requires_snuba]
 
 
 class EventMatcher:
-    def __init__(self, expected, group=None):
+    def __init__(self, expected, group=None) -> None:
         self.expected = expected
         self.expected_group = group
 

--- a/tests/sentry/taskworker/test_client.py
+++ b/tests/sentry/taskworker/test_client.py
@@ -64,7 +64,7 @@ class MockServiceMethod:
 
 
 class MockChannel:
-    def __init__(self):
+    def __init__(self) -> None:
         self._responses = defaultdict(list)
 
     def unary_unary(
@@ -91,7 +91,7 @@ class MockChannel:
 class MockGrpcError(grpc.RpcError):
     """Grpc error are elusive and this mock simulates the interface in mypy stubs"""
 
-    def __init__(self, code, message):
+    def __init__(self, code, message) -> None:
         self._code = code
         self._message = message
 

--- a/tests/sentry/taskworker/test_client.py
+++ b/tests/sentry/taskworker/test_client.py
@@ -64,7 +64,7 @@ class MockServiceMethod:
 
 
 class MockChannel:
-    def __init__(self) -> None:
+    def __init__(self):
         self._responses = defaultdict(list)
 
     def unary_unary(
@@ -91,7 +91,7 @@ class MockChannel:
 class MockGrpcError(grpc.RpcError):
     """Grpc error are elusive and this mock simulates the interface in mypy stubs"""
 
-    def __init__(self, code, message) -> None:
+    def __init__(self, code, message):
         self._code = code
         self._message = message
 

--- a/tests/sentry/utils/locking/backends/test_migration.py
+++ b/tests/sentry/utils/locking/backends/test_migration.py
@@ -10,7 +10,7 @@ from sentry.utils.locking.backends.redis import RedisLockBackend
 class DummyLockBackend(LockBackend):
     path = "tests.sentry.utils.locking.backends.test_migration.DummyLockBackend"
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._locks = {}
 
     def acquire(self, key: str, duration: int, routing_key: str | None = None) -> None:

--- a/tests/sentry/utils/locking/backends/test_migration.py
+++ b/tests/sentry/utils/locking/backends/test_migration.py
@@ -10,7 +10,7 @@ from sentry.utils.locking.backends.redis import RedisLockBackend
 class DummyLockBackend(LockBackend):
     path = "tests.sentry.utils.locking.backends.test_migration.DummyLockBackend"
 
-    def __init__(self) -> None:
+    def __init__(self):
         self._locks = {}
 
     def acquire(self, key: str, duration: int, routing_key: str | None = None) -> None:

--- a/tests/sentry/utils/test_snuba.py
+++ b/tests/sentry/utils/test_snuba.py
@@ -420,7 +420,7 @@ class QuantizeTimeTest(unittest.TestCase):
 
 
 class FakeConnectionPool(HTTPConnectionPool):
-    def __init__(self, connection, **kwargs):
+    def __init__(self, connection, **kwargs) -> None:
         self.connection = connection
         super().__init__(**kwargs)
 


### PR DESCRIPTION
# What
Any normal `__init__` implementation returns `None` (& `mypy` is very good at catching returns from `None`-returning functions). So it should be safe to automatically add the `None` return type to all our `__init__` functions.

This PR does so in the majority of cases — while avoiding 28 files that would cause type errors.

> Why would adding `-> None` to `__init__` cause a type error?

Once `__init__` is typed, `mypy` starts inferring types on properties — and those can be incorrect. (e.g. if you init a property to `None` in `__init__`, any future non-`None` assignment to that property raises an error.) 

Fixing those is not hard but non-trivial, so I figured I'd split them into a separate commit.

# How

Ran command: 
```
rg 'def __init__\([^\)>]*\):' -ls | xargs sed -i '' -E -e 's/def __init__\(([^\)>]*)\):/def __init__(\1) -> None:/'
mypy > files_with_errors
# a bit of processing to get a set of files with errors
git checkout origin/master src/sentry/models/files/abstractfile.py tests/sentry/attachments/test_redis.py src/sentry/web/frontend/auth_login.py src/sentry/search/events/builder/errors.py tests/sentry/analytics/test_base.py src/sentry/utils/concurrent.py tests/sentry/attachments/test_base.py src/sentry/tasks/summaries/utils.py src/sentry/identity/manager.py src/sentry/eventtypes/manager.py src/sentry/testutils/helpers/features.py fixtures/integrations/mock_service.py src/sentry/filestore/s3.py src/sentry/adoption/manager.py src/sentry/db/postgres/schema.py src/sentry/plugins/config.py tests/sentry/auth_v2/utils/test_session.py tests/sentry/taskworker/test_client.py tests/sentry/utils/locking/backends/test_migration.py src/sentry/assistant/manager.py src/sentry/filestore/gcs.py src/sentry/stacktraces/processing.py src/sentry/sentry_metrics/querying/visitors/query_expression.py src/sentry/projectoptions/manager.py src/sentry/plugins/base/binding_manager.py src/bitfield/types.py src/sentry_plugins/redmine/plugin.py src/sentry/lang/javascript/cache.py
```