### PR TITLE
feat(aci): Remove checks to enable open period creation

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -92,11 +92,7 @@ from sentry.models.groupenvironment import GroupEnvironment
 from sentry.models.grouphash import GroupHash
 from sentry.models.grouphistory import GroupHistoryStatus, record_group_history
 from sentry.models.grouplink import GroupLink
-from sentry.models.groupopenperiod import (
-    GroupOpenPeriod,
-    create_open_period,
-    has_initial_open_period,
-)
+from sentry.models.groupopenperiod import GroupOpenPeriod, create_open_period
 from sentry.models.grouprelease import GroupRelease
 from sentry.models.groupresolution import GroupResolution
 from sentry.models.organization import Organization
@@ -1822,8 +1818,7 @@ def _handle_regression(group: Group, event: BaseEvent, release: Release | None) 
         kick_off_status_syncs.apply_async(
             kwargs={"project_id": group.project_id, "group_id": group.id}
         )
-        if has_initial_open_period(group):
-            create_open_period(group, activity.datetime)
+        create_open_period(group, activity.datetime)
 
     return is_regression
 

--- a/src/sentry/models/groupopenperiod.py
+++ b/src/sentry/models/groupopenperiod.py
@@ -276,9 +276,9 @@ def update_group_open_period(
     if not features.has("organizations:issue-open-periods", group.project.organization):
         return
 
-    # Until we've backfilled the GroupOpenPeriod table, we don't want to update open periods for
-    # groups that weren't initially created with one.
-    if not has_initial_open_period(group):
+    # If a group was missed during backfill, we can create a new open period for it on unresolve.
+    if not has_any_open_period(group) and new_status == GroupStatus.UNRESOLVED:
+        create_open_period(group, timezone.now())
         return
 
     open_period = get_latest_open_period(group)
@@ -302,8 +302,8 @@ def update_group_open_period(
         open_period.reopen_open_period()
 
 
-def has_initial_open_period(group: Group) -> bool:
-    return GroupOpenPeriod.objects.filter(group=group, date_started__lte=group.first_seen).exists()
+def has_any_open_period(group: Group) -> bool:
+    return GroupOpenPeriod.objects.filter(group=group).exists()
 
 
 def get_latest_open_period(group: Group) -> GroupOpenPeriod | None:

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -389,7 +389,10 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         assert not group.is_resolved()
         assert send_robust.called
 
-        assert GroupOpenPeriod.objects.filter(group=group).count() == 0
+        activity = Activity.objects.get(group=group, type=ActivityType.SET_REGRESSION.value)
+        assert GroupOpenPeriod.objects.filter(group=group).count() == 1
+        assert GroupOpenPeriod.objects.get(group=group).date_ended is None
+        assert GroupOpenPeriod.objects.get(group=group).date_started == activity.datetime
 
     @mock.patch("sentry.event_manager.plugin_is_regression")
     def test_does_not_unresolve_group(self, plugin_is_regression: mock.MagicMock) -> None:


### PR DESCRIPTION
Removing the check that was used to easily backfill open periods for issues. Going forward, issues will either
 1. have the open periods created on the first event and should update as expected OR 
 2. have an open period created for the most recent unresolve action and have following actions update the open periods as expected. This should only happen for the issues that were too large to backfill. 