### PR TITLE
fix(search-bar): Add height: auto back

### DIFF
--- a/static/app/components/searchQueryBuilder/index.tsx
+++ b/static/app/components/searchQueryBuilder/index.tsx
@@ -260,6 +260,7 @@ const Wrapper = styled(Input.withComponent('div'))`
   padding: 0;
   width: 100%;
   position: relative;
+  height: auto;
   font-size: ${p => p.theme.fontSize.md};
   cursor: text;
 `;


### PR DESCRIPTION
Adding back `height: auto` CSS style to the `SearchQueryBuilder` that was removed in #97074
