### PR TITLE
fix(search): Convert search syntax error to log

### DIFF
--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -1507,11 +1507,9 @@ function tryParseSearch<T extends {config: SearchConfig}>(
   try {
     return grammar.parse(query, config);
   } catch (e) {
-    Sentry.withScope(scope => {
-      scope.setFingerprint(['search-syntax-parse-error']);
-      scope.setExtra('message', e.message?.slice(-100));
-      scope.setExtra('found', e.found);
-      Sentry.captureException(e);
+    Sentry.logger.error('Search syntax parse error', {
+      message: e.message?.slice(-100),
+      found: e.found,
     });
 
     return null;


### PR DESCRIPTION
We were not actioning on this noisy event. https://sentry.sentry.io/issues/4938956026/

```
SyntaxError: Expected " ", "!", "(", ")", ":", "AND", "OR", "\"", "flags", "tags", [^()\n ], [a-zA-Z0-9_.\-], or end of input but "\n" found.
```
