### PR TITLE
chore(preprod): Allow for duplicate preprod artifact uploads

### DIFF
--- a/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
+++ b/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
@@ -13,7 +13,7 @@ from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
 from sentry.debug_files.upload import find_missing_chunks
 from sentry.models.orgauthtoken import is_org_auth_token_auth, update_org_auth_token_last_used
 from sentry.preprod.analytics import PreprodArtifactApiAssembleEvent
-from sentry.preprod.tasks import assemble_preprod_artifact
+from sentry.preprod.tasks import assemble_preprod_artifact, create_preprod_artifact
 from sentry.tasks.assemble import (
     AssembleTask,
     ChunkFileState,
@@ -124,6 +124,22 @@ class ProjectPreprodArtifactAssembleEndpoint(ProjectEndpoint):
             # Check current assembly status
             state, detail = get_assemble_status(AssembleTask.PREPROD_ARTIFACT, project.id, checksum)
             if state is not None:
+                if state == ChunkFileState.OK:
+                    artifact_id = create_preprod_artifact(
+                        org_id=project.organization_id,
+                        project_id=project.id,
+                        checksum=checksum,
+                        chunks=chunks,
+                    )
+                    if artifact_id:
+                        return Response(
+                            {
+                                "state": state,
+                                "detail": detail,
+                                "missingChunks": [],
+                                "artifact_id": artifact_id,
+                            }
+                        )
                 return Response({"state": state, "detail": detail, "missingChunks": []})
 
             # There is neither a known file nor a cached state, so we will
@@ -135,18 +151,14 @@ class ProjectPreprodArtifactAssembleEndpoint(ProjectEndpoint):
             set_assemble_status(
                 AssembleTask.PREPROD_ARTIFACT, project.id, checksum, ChunkFileState.CREATED
             )
-
             assemble_preprod_artifact.apply_async(
                 kwargs={
                     "org_id": project.organization_id,
                     "project_id": project.id,
                     "checksum": checksum,
                     "chunks": chunks,
-                    "git_sha": data.get("git_sha"),
-                    "build_configuration": data.get("build_configuration"),
                 }
             )
-
             if is_org_auth_token_auth(request.auth):
                 update_org_auth_token_last_used(request.auth, [project.id])
 

--- a/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
+++ b/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
@@ -130,6 +130,8 @@ class ProjectPreprodArtifactAssembleEndpoint(ProjectEndpoint):
                         project_id=project.id,
                         checksum=checksum,
                         chunks=chunks,
+                        git_sha=data.get("git_sha"),
+                        build_configuration=data.get("build_configuration"),
                     )
                     if artifact_id:
                         return Response(

--- a/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
+++ b/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
@@ -142,6 +142,13 @@ class ProjectPreprodArtifactAssembleEndpoint(ProjectEndpoint):
                                 "artifact_id": artifact_id,
                             }
                         )
+                    else:
+                        return Response(
+                            {
+                                "state": ChunkFileState.ERROR,
+                                "detail": "File not found when trying to create preprod artifact object.",
+                            }
+                        )
                 return Response({"state": state, "detail": detail, "missingChunks": []})
 
             # There is neither a known file nor a cached state, so we will

--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -46,16 +46,11 @@ def assemble_preprod_artifact(
     project_id,
     checksum,
     chunks,
-    git_sha=None,
-    build_configuration=None,
     **kwargs,
 ) -> None:
     """
     Creates a preprod artifact from uploaded chunks.
     """
-    from sentry.models.files.file import File
-    from sentry.preprod.models import PreprodBuildConfiguration
-
     logger.info(
         "Starting preprod artifact assembly",
         extra={
@@ -66,84 +61,34 @@ def assemble_preprod_artifact(
         },
     )
 
-    preprod_artifact = None
     try:
         organization = Organization.objects.get_from_cache(pk=org_id)
         project = Project.objects.get(id=project_id, organization=organization)
         bind_organization_context(organization)
 
-        with transaction.atomic(router.db_for_write(PreprodArtifact)):
-            # First check if there's already a file with this checksum and type
-            existing_file = File.objects.filter(checksum=checksum, type="preprod.artifact").first()
+        set_assemble_status(
+            AssembleTask.PREPROD_ARTIFACT, project_id, checksum, ChunkFileState.ASSEMBLING
+        )
 
-            existing_artifact = None
-            if existing_file:
-                existing_artifact = (
-                    PreprodArtifact.objects.select_for_update()
-                    .filter(project=project, file_id=existing_file.id)
-                    .first()
-                )
+        assemble_result = assemble_file(
+            task=AssembleTask.PREPROD_ARTIFACT,
+            org_or_project=project,
+            name=f"preprod-artifact-{uuid.uuid4().hex}",
+            checksum=checksum,
+            chunks=chunks,
+            file_type="preprod.artifact",
+        )
 
-            if existing_artifact:
-                logger.info(
-                    "PreprodArtifact already exists for this checksum, using existing artifact",
-                    extra={
-                        "preprod_artifact_id": existing_artifact.id,
-                        "project_id": project_id,
-                        "organization_id": org_id,
-                        "checksum": checksum,
-                    },
-                )
-                preprod_artifact = existing_artifact
-            else:
-                set_assemble_status(
-                    AssembleTask.PREPROD_ARTIFACT, project_id, checksum, ChunkFileState.ASSEMBLING
-                )
-
-                assemble_result = assemble_file(
-                    task=AssembleTask.PREPROD_ARTIFACT,
-                    org_or_project=project,
-                    name=f"preprod-artifact-{uuid.uuid4().hex}",
-                    checksum=checksum,
-                    chunks=chunks,
-                    file_type="preprod.artifact",
-                )
-
-                if assemble_result is None:
-                    logger.warning(
-                        "Assemble result is None, returning early",
-                        extra={
-                            "project_id": project_id,
-                            "organization_id": org_id,
-                            "checksum": checksum,
-                        },
-                    )
-                    return
-
-                build_config = None
-                if build_configuration:
-                    build_config, _ = PreprodBuildConfiguration.objects.get_or_create(
-                        project=project,
-                        name=build_configuration,
-                    )
-
-                # Create PreprodArtifact record
-                preprod_artifact, _ = PreprodArtifact.objects.get_or_create(
-                    project=project,
-                    file_id=assemble_result.bundle.id,
-                    build_configuration=build_config,
-                    state=PreprodArtifact.ArtifactState.UPLOADED,
-                )
-
-                logger.info(
-                    "Created preprod artifact",
-                    extra={
-                        "preprod_artifact_id": preprod_artifact.id,
-                        "project_id": project_id,
-                        "organization_id": org_id,
-                        "checksum": checksum,
-                    },
-                )
+        if assemble_result is None:
+            logger.warning(
+                "Assemble result is None, returning early",
+                extra={
+                    "project_id": project_id,
+                    "organization_id": org_id,
+                    "checksum": checksum,
+                },
+            )
+            return
 
     except Exception as e:
         sentry_sdk.capture_exception(e)
@@ -166,6 +111,72 @@ def assemble_preprod_artifact(
 
     # Mark assembly as successful since the artifact was created successfully
     set_assemble_status(AssembleTask.PREPROD_ARTIFACT, project_id, checksum, ChunkFileState.OK)
+    logger.info(
+        "Finished preprod artifact assembly",
+        extra={
+            "project_id": project_id,
+            "organization_id": org_id,
+            "checksum": checksum,
+        },
+    )
+
+
+def create_preprod_artifact(
+    org_id,
+    project_id,
+    checksum,
+    # chunks,
+    git_sha=None,
+    build_configuration=None,
+    **kwargs,
+) -> str | None:
+    from sentry.models.files.file import File
+    from sentry.preprod.models import PreprodArtifact, PreprodBuildConfiguration
+
+    preprod_artifact = None
+    try:
+        organization = Organization.objects.get_from_cache(pk=org_id)
+        project = Project.objects.get(id=project_id, organization=organization)
+        bind_organization_context(organization)
+
+        with transaction.atomic(router.db_for_write(PreprodArtifact)):
+            existing_file = File.objects.filter(checksum=checksum, type="preprod.artifact").first()
+
+            build_config = None
+            if build_configuration:
+                build_config, _ = PreprodBuildConfiguration.objects.get_or_create(
+                    project=project,
+                    name=build_configuration,
+                )
+
+            preprod_artifact, _ = PreprodArtifact.objects.get_or_create(
+                project=project,
+                file_id=existing_file.id,
+                build_configuration=build_config,
+                state=PreprodArtifact.ArtifactState.UPLOADED,
+            )
+
+            logger.info(
+                "Created preprod artifact",
+                extra={
+                    "preprod_artifact_id": preprod_artifact.id,
+                    "project_id": project_id,
+                    "organization_id": org_id,
+                    "checksum": checksum,
+                },
+            )
+
+    except Exception as e:
+        sentry_sdk.capture_exception(e)
+        logger.exception(
+            "Failed to create preprod artifact row",
+            extra={
+                "project_id": project_id,
+                "organization_id": org_id,
+                "checksum": checksum,
+            },
+        )
+        return
 
     if preprod_artifact:
         produce_preprod_artifact_to_kafka(
@@ -175,7 +186,7 @@ def assemble_preprod_artifact(
         )
 
         logger.info(
-            "Finished preprod artifact assembly and Kafka dispatch",
+            "Finished preprod artifact row creation and kafka dispatch",
             extra={
                 "preprod_artifact_id": preprod_artifact.id,
                 "project_id": project_id,
@@ -183,6 +194,7 @@ def assemble_preprod_artifact(
                 "checksum": checksum,
             },
         )
+    return preprod_artifact.id
 
 
 def _assemble_preprod_artifact_file(

--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -181,7 +181,7 @@ def create_preprod_artifact(
                 "checksum": checksum,
             },
         )
-        return
+        return None
 
     if preprod_artifact:
         produce_preprod_artifact_to_kafka(
@@ -199,7 +199,9 @@ def create_preprod_artifact(
                 "checksum": checksum,
             },
         )
-    return preprod_artifact.id
+    # This will be a non-int display id in future so prepare for that
+    # by returning a string.
+    return str(preprod_artifact.id)
 
 
 def _assemble_preprod_artifact_file(

--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -142,6 +142,11 @@ def create_preprod_artifact(
         with transaction.atomic(router.db_for_write(PreprodArtifact)):
             existing_file = File.objects.filter(checksum=checksum, type="preprod.artifact").first()
 
+            if existing_file is None:
+                raise ValueError(
+                    f"No existing file found for checksum when trying to create preprod artifact. checksum={checksum}"
+                )
+
             build_config = None
             if build_configuration:
                 build_config, _ = PreprodBuildConfiguration.objects.get_or_create(

--- a/tests/sentry/preprod/test_tasks.py
+++ b/tests/sentry/preprod/test_tasks.py
@@ -1,5 +1,4 @@
 from hashlib import sha1
-from unittest.mock import patch
 
 from django.core.files.base import ContentFile
 
@@ -30,6 +29,7 @@ class AssemblePreprodArtifactTest(BaseAssembleTest):
         super().tearDown()
 
     def test_assemble_preprod_artifact_success(self) -> None:
+        """Test that assemble_preprod_artifact only handles file assembly"""
         content = b"test preprod artifact content"
         fileobj = ContentFile(content)
         total_checksum = sha1(content).hexdigest()
@@ -51,26 +51,23 @@ class AssemblePreprodArtifactTest(BaseAssembleTest):
         assert status == ChunkFileState.OK
         assert details is None
 
+        # Verify file was created
         files = File.objects.filter(type="preprod.artifact")
         assert len(files) == 1
         assert files[0].checksum == total_checksum
         assert files[0].name.startswith("preprod-artifact-")
 
-        build_configs = PreprodBuildConfiguration.objects.filter(
-            project=self.project, name="release"
-        )
-        assert len(build_configs) == 1
+        # Verify NO database records were created (this is now handled by create_preprod_artifact)
+        build_configs = PreprodBuildConfiguration.objects.filter(project=self.project)
+        assert len(build_configs) == 0
 
         artifacts = PreprodArtifact.objects.filter(project=self.project)
-        assert len(artifacts) == 1
-        artifact = artifacts[0]
-        assert artifact.file_id == files[0].id
-        assert artifact.build_configuration == build_configs[0]
-        assert artifact.state == PreprodArtifact.ArtifactState.UPLOADED
+        assert len(artifacts) == 0
 
         delete_assemble_status(AssembleTask.PREPROD_ARTIFACT, self.project.id, total_checksum)
 
     def test_assemble_preprod_artifact_without_build_configuration(self) -> None:
+        """Test that assemble_preprod_artifact works without build configuration"""
         content = b"test preprod artifact without build config"
         fileobj = ContentFile(content)
         total_checksum = sha1(content).hexdigest()
@@ -89,10 +86,12 @@ class AssemblePreprodArtifactTest(BaseAssembleTest):
         )
         assert status == ChunkFileState.OK
 
+        # Verify file was created but no database records
+        files = File.objects.filter(type="preprod.artifact")
+        assert len(files) == 1
+
         artifacts = PreprodArtifact.objects.filter(project=self.project)
-        assert len(artifacts) == 1
-        artifact = artifacts[0]
-        assert artifact.build_configuration is None
+        assert len(artifacts) == 0
 
         delete_assemble_status(AssembleTask.PREPROD_ARTIFACT, self.project.id, total_checksum)
 
@@ -212,87 +211,8 @@ class AssemblePreprodArtifactTest(BaseAssembleTest):
             AssembleTask.PREPROD_ARTIFACT, nonexistent_project_id, total_checksum
         )
 
-    def test_assemble_preprod_artifact_reuses_build_configuration(self) -> None:
-        existing_config, _ = PreprodBuildConfiguration.objects.get_or_create(
-            project=self.project, name="debug"
-        )
-
-        content = b"test preprod artifact with existing config"
-        fileobj = ContentFile(content)
-        total_checksum = sha1(content).hexdigest()
-
-        blob = FileBlob.from_file_with_organization(fileobj, self.organization)
-
-        assemble_preprod_artifact(
-            org_id=self.organization.id,
-            project_id=self.project.id,
-            checksum=total_checksum,
-            chunks=[blob.checksum],
-            build_configuration="debug",
-        )
-
-        status, details = get_assemble_status(
-            AssembleTask.PREPROD_ARTIFACT, self.project.id, total_checksum
-        )
-        assert status == ChunkFileState.OK
-
-        build_configs = PreprodBuildConfiguration.objects.filter(project=self.project, name="debug")
-        assert len(build_configs) == 1
-        assert build_configs[0].id == existing_config.id
-
-        artifacts = PreprodArtifact.objects.filter(project=self.project)
-        assert len(artifacts) == 1
-        assert artifacts[0].build_configuration == existing_config
-
-        delete_assemble_status(AssembleTask.PREPROD_ARTIFACT, self.project.id, total_checksum)
-
-    def test_assemble_preprod_artifact_transaction_rollback(self) -> None:
-        """Test that if PreprodArtifact creation fails, PreprodBuildConfiguration is also rolled back"""
-        content = b"test transaction rollback"
-        fileobj = ContentFile(content)
-        total_checksum = sha1(content).hexdigest()
-
-        blob = FileBlob.from_file_with_organization(fileobj, self.organization)
-
-        initial_config_count = PreprodBuildConfiguration.objects.filter(
-            project=self.project, name="transaction_test"
-        ).count()
-        assert initial_config_count == 0
-
-        class MockAssembleResult:
-            def __init__(self):
-                self.bundle = type("MockBundle", (), {"id": 12345})()
-
-        with (
-            patch("sentry.preprod.tasks.assemble_file", return_value=MockAssembleResult()),
-            patch.object(
-                PreprodArtifact.objects, "get_or_create", side_effect=Exception("Simulated failure")
-            ),
-        ):
-
-            assemble_preprod_artifact(
-                org_id=self.organization.id,
-                project_id=self.project.id,
-                checksum=total_checksum,
-                chunks=[blob.checksum],
-                build_configuration="transaction_test",
-            )
-
-        status, details = get_assemble_status(
-            AssembleTask.PREPROD_ARTIFACT, self.project.id, total_checksum
-        )
-        assert status == ChunkFileState.ERROR
-        assert "Simulated failure" in details
-
-        final_config_count = PreprodBuildConfiguration.objects.filter(
-            project=self.project, name="transaction_test"
-        ).count()
-        assert final_config_count == 0, "PreprodBuildConfiguration should have been rolled back"
-
-        artifacts = PreprodArtifact.objects.filter(project=self.project)
-        assert len(artifacts) == 0
-
-        delete_assemble_status(AssembleTask.PREPROD_ARTIFACT, self.project.id, total_checksum)
+    # Note: Tests for build configuration and artifact creation have been removed
+    # since those are now handled by the separate create_preprod_artifact function
 
 
 class AssemblePreprodArtifactInstallableAppTest(BaseAssembleTest):


### PR DESCRIPTION
Currently if you upload the same artifact twice, we identify that the checksum is the same and de-dup the request. We don't upload the file again and we don't create a new preprodartifact row.

While this was the intention, we've realized this is actually not desirable. There are legitimate cases where a user would want to upload the same build two times and we should support it. It's also very confusing to upload a build and have nothing happen.


Before this change, this is how this endpoint worked:

1. Upload chunks with a checksum.
2. In the endpoint, check if the build is being assembled/is done being assembled. If so, return. If not, then wait until all the chunks are uploaded and then begin assembling the file in an async task.
3. While the async task is going, the client continues to poll the endpoint waiting for the assemble state to be OK.
4. The async task checks if the file already exists. If so, it just returns the existing file. If not, it assembles the file, saves it to our sql DB, creates the preprod related rows, and then finally sets the assembly status to OK and messages to kafka to trigger the processing.


After this change:
1. Upload chunks with a checksum.
2.  In the endpoint, check if the build is being assembled. If so, return. **If it's done being assembled, then create the preprodartifact rows and kick off kafka. Then tell the client that we're done uploading and return the upload id.** 

If no assembling has happened yet, then wait until all the chunks are uploaded and then begin assembling the file in an async task.
3. While the async task is going, the client continues to poll the endpoint waiting for the assemble state to be OK.
4. The async task checks if the file already exists. If so, it just returns the existing file. **If not, it assembles the file, saves it to our sql DB and then sets the assembly status to OK.**


This was the simplest way to allow uploading the same file twice, only actually save the file itself once, but allowing us to treat them as two different uploaded artifacts.