### PR TITLE
feat(insights): add perf score and assets chart to frontend overview

### DIFF
--- a/static/app/components/charts/chartWidgetLoader.tsx
+++ b/static/app/components/charts/chartWidgetLoader.tsx
@@ -188,6 +188,8 @@ const CHART_MAP = {
     import(
       'sentry/views/insights/common/components/widgets/overviewSlowQueriesChartWidget'
     ),
+  overviewSlowAssetsWidget: () =>
+    import('sentry/views/insights/common/components/widgets/overviewSlowAssetsWidget'),
   mcpTrafficWidget: () =>
     import('sentry/views/insights/common/components/widgets/mcpTrafficWidget'),
 } satisfies Record<string, () => Promise<{default: React.FC<LoadableChartWidgetProps>}>>;

--- a/static/app/views/insights/common/components/widgets/overviewSlowAssetsWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/overviewSlowAssetsWidget.tsx
@@ -1,0 +1,161 @@
+import {Fragment} from 'react';
+import {useTheme} from '@emotion/react';
+
+import {t} from 'sentry/locale';
+import getDuration from 'sentry/utils/duration/getDuration';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {Line} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/line';
+import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
+import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
+import {getResourcesEventViewQuery} from 'sentry/views/insights/browser/common/queries/useResourcesQuery';
+import {DEFAULT_RESOURCE_TYPES} from 'sentry/views/insights/browser/resources/settings';
+import {ChartType} from 'sentry/views/insights/common/components/chart';
+import {ChartActionDropdown} from 'sentry/views/insights/common/components/chartActionDropdown';
+import {SpanDescriptionCell} from 'sentry/views/insights/common/components/tableCells/spanDescriptionCell';
+import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/components/widgets/types';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import {useTopNSpanSeries} from 'sentry/views/insights/common/queries/useTopNDiscoverSeries';
+import {convertSeriesToTimeseries} from 'sentry/views/insights/common/utils/convertSeriesToTimeseries';
+import {Referrer} from 'sentry/views/insights/pages/frontend/referrers';
+import {usePageFilterChartParams} from 'sentry/views/insights/pages/platform/laravel/utils';
+import {WidgetVisualizationStates} from 'sentry/views/insights/pages/platform/laravel/widgetVisualizationStates';
+import {useReleaseBubbleProps} from 'sentry/views/insights/pages/platform/shared/getReleaseBubbleProps';
+import {
+  SeriesColorIndicator,
+  WidgetFooterTable,
+} from 'sentry/views/insights/pages/platform/shared/styles';
+import {useTransactionNameQuery} from 'sentry/views/insights/pages/platform/shared/useTransactionNameQuery';
+import {ModuleName, SpanFields} from 'sentry/views/insights/types';
+import {TimeSpentInDatabaseWidgetEmptyStateWarning} from 'sentry/views/performance/landing/widgets/components/selectableList';
+
+export default function OverviewAssetsByTimeSpentWidget(props: LoadableChartWidgetProps) {
+  const theme = useTheme();
+  const {query} = useTransactionNameQuery();
+  const releaseBubbleProps = useReleaseBubbleProps(props);
+  const pageFilterChartParams = usePageFilterChartParams(props);
+
+  const resourceQuery = getResourcesEventViewQuery({}, DEFAULT_RESOURCE_TYPES).join(' ');
+
+  const search = new MutableSearch(`has:span.group ${resourceQuery} ${query}`);
+
+  const assetRequest = useSpans(
+    {
+      fields: [
+        'span.group',
+        'project.id',
+        'sentry.normalized_description',
+        'sum(span.self_time)',
+      ],
+      sorts: [{field: 'sum(span.self_time)', kind: 'desc'}],
+      search,
+      limit: 3,
+      noPagination: true,
+      pageFilters: props.pageFilters,
+    },
+    Referrer.ASSETS_BY_TIME_SPENT
+  );
+
+  const timeSeriesRequest = useTopNSpanSeries(
+    {
+      ...pageFilterChartParams,
+      search: `span.group:[${assetRequest.data?.map(item => `"${item['span.group']}"`).join(',')}]`,
+      fields: ['span.group', 'sum(span.self_time)'],
+      yAxis: ['sum(span.self_time)'],
+      sort: {field: 'sum(span.self_time)', kind: 'desc'},
+      topN: 3,
+      enabled: assetRequest.data.length > 0,
+    },
+    Referrer.ASSETS_BY_TIME_SPENT,
+    props.pageFilters
+  );
+
+  const timeSeries = timeSeriesRequest.data.filter(ts => ts.seriesName !== 'Other');
+
+  const isLoading = timeSeriesRequest.isLoading || assetRequest.isLoading;
+  const error = timeSeriesRequest.error || assetRequest.error;
+
+  const hasData =
+    assetRequest.data && assetRequest.data.length > 0 && timeSeries.length > 0;
+
+  const colorPalette = theme.chart.getColorPalette(timeSeries.length - 1);
+
+  const aliases: Record<string, string> = {};
+
+  assetRequest.data?.forEach(asset => {
+    aliases[asset['span.group']] = asset['sentry.normalized_description'];
+  });
+
+  const visualization = (
+    <WidgetVisualizationStates
+      isEmpty={!hasData}
+      isLoading={isLoading}
+      error={error}
+      emptyMessage={<TimeSpentInDatabaseWidgetEmptyStateWarning />}
+      VisualizationType={TimeSeriesWidgetVisualization}
+      visualizationProps={{
+        id: 'overviewSlowQueriesChartWidget',
+        showLegend: props.loaderSource === 'releases-drawer' ? 'auto' : 'never',
+        plottables: timeSeries.map(
+          (ts, index) =>
+            new Line(convertSeriesToTimeseries(ts), {
+              color: colorPalette[index],
+              alias: aliases[ts.seriesName],
+            })
+        ),
+        ...props,
+        ...releaseBubbleProps,
+      }}
+    />
+  );
+
+  const footer = hasData && (
+    <WidgetFooterTable>
+      {assetRequest.data?.map((item, index) => (
+        <Fragment
+          key={`${item['project.id']}-${item['span.group']}-${item['sentry.normalized_description']}`}
+        >
+          <div>
+            <SeriesColorIndicator
+              style={{
+                backgroundColor: colorPalette[index],
+              }}
+            />
+          </div>
+          <div>
+            <SpanDescriptionCell
+              projectId={Number(item['project.id'])}
+              group={item['span.group']}
+              description={item['sentry.normalized_description']}
+              moduleName={ModuleName.RESOURCE}
+            />
+          </div>
+          <span>{getDuration((item['sum(span.self_time)'] ?? 0) / 1000, 2, true)}</span>
+        </Fragment>
+      ))}
+    </WidgetFooterTable>
+  );
+
+  return (
+    <Widget
+      Title={<Widget.WidgetTitle title={t('Assets by Time Spent')} />}
+      Visualization={visualization}
+      Actions={
+        hasData && (
+          <Widget.WidgetToolbar>
+            <ChartActionDropdown
+              chartType={ChartType.LINE}
+              yAxes={['sum(span.self_time)']}
+              groupBy={[SpanFields.NORMALIZED_DESCRIPTION]}
+              title={t('Assets by Time Spent')}
+              search={search}
+              aliases={aliases}
+              referrer={Referrer.ASSETS_BY_TIME_SPENT}
+            />
+          </Widget.WidgetToolbar>
+        )
+      }
+      noFooterPadding
+      Footer={props.loaderSource === 'releases-drawer' ? undefined : footer}
+    />
+  );
+}

--- a/static/app/views/insights/common/components/widgets/overviewSlowAssetsWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/overviewSlowAssetsWidget.tsx
@@ -160,7 +160,7 @@ export default function OverviewAssetsByTimeSpentWidget(props: LoadableChartWidg
 
   const chartActions = (
     <BaseChartActionDropdown
-      key="http response chart widget"
+      key="slow assets widget"
       exploreUrl={exploreUrl}
       referrer={referrer}
       alertMenuOptions={assetSeriesData.map(series => ({

--- a/static/app/views/insights/common/components/widgets/overviewSlowAssetsWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/overviewSlowAssetsWidget.tsx
@@ -17,7 +17,6 @@ import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {useTopNSpanSeries} from 'sentry/views/insights/common/queries/useTopNDiscoverSeries';
 import {convertSeriesToTimeseries} from 'sentry/views/insights/common/utils/convertSeriesToTimeseries';
 import {Referrer} from 'sentry/views/insights/pages/frontend/referrers';
-import {usePageFilterChartParams} from 'sentry/views/insights/pages/platform/laravel/utils';
 import {WidgetVisualizationStates} from 'sentry/views/insights/pages/platform/laravel/widgetVisualizationStates';
 import {useReleaseBubbleProps} from 'sentry/views/insights/pages/platform/shared/getReleaseBubbleProps';
 import {
@@ -32,7 +31,6 @@ export default function OverviewAssetsByTimeSpentWidget(props: LoadableChartWidg
   const theme = useTheme();
   const {query} = useTransactionNameQuery();
   const releaseBubbleProps = useReleaseBubbleProps(props);
-  const pageFilterChartParams = usePageFilterChartParams(props);
 
   const resourceQuery = getResourcesEventViewQuery({}, DEFAULT_RESOURCE_TYPES).join(' ');
 
@@ -50,14 +48,12 @@ export default function OverviewAssetsByTimeSpentWidget(props: LoadableChartWidg
       search,
       limit: 3,
       noPagination: true,
-      pageFilters: props.pageFilters,
     },
     Referrer.ASSETS_BY_TIME_SPENT
   );
 
   const timeSeriesRequest = useTopNSpanSeries(
     {
-      ...pageFilterChartParams,
       search: `span.group:[${assetRequest.data?.map(item => `"${item['span.group']}"`).join(',')}]`,
       fields: ['span.group', 'sum(span.self_time)'],
       yAxis: ['sum(span.self_time)'],
@@ -65,8 +61,7 @@ export default function OverviewAssetsByTimeSpentWidget(props: LoadableChartWidg
       topN: 3,
       enabled: assetRequest.data.length > 0,
     },
-    Referrer.ASSETS_BY_TIME_SPENT,
-    props.pageFilters
+    Referrer.ASSETS_BY_TIME_SPENT
   );
 
   const timeSeries = timeSeriesRequest.data.filter(ts => ts.seriesName !== 'Other');

--- a/static/app/views/insights/common/components/widgets/overviewSlowAssetsWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/overviewSlowAssetsWidget.tsx
@@ -32,7 +32,7 @@ import {
 } from 'sentry/views/insights/pages/platform/shared/styles';
 import {useTransactionNameQuery} from 'sentry/views/insights/pages/platform/shared/useTransactionNameQuery';
 import {ModuleName, SpanFields} from 'sentry/views/insights/types';
-import {TimeSpentInDatabaseWidgetEmptyStateWarning} from 'sentry/views/performance/landing/widgets/components/selectableList';
+import {WidgetEmptyStateWarning} from 'sentry/views/performance/landing/widgets/components/selectableList';
 
 export default function OverviewAssetsByTimeSpentWidget(props: LoadableChartWidgetProps) {
   const theme = useTheme();
@@ -80,31 +80,29 @@ export default function OverviewAssetsByTimeSpentWidget(props: LoadableChartWidg
       yAxis: [yAxes],
       sort: {field: yAxes, kind: 'desc'},
       topN: 3,
-      enabled: assetListData.length > 0,
+      enabled: assetListData?.length > 0,
     },
     referrer
   );
 
-  const timeSeries = assetSeriesData.filter(ts => ts.seriesName !== 'Other');
-
   const isLoading = isAssetSeriesLoading || isAssetListLoading;
   const error = assetSeriesError || assetListError;
 
-  const hasData = assetListData && assetListData.length > 0 && timeSeries.length > 0;
+  const hasData = assetListData && assetListData.length > 0 && assetSeriesData.length > 0;
 
-  const colorPalette = theme.chart.getColorPalette(timeSeries.length - 1);
+  const colorPalette = theme.chart.getColorPalette(assetSeriesData.length - 1);
 
   const visualization = (
     <WidgetVisualizationStates
       isEmpty={!hasData}
       isLoading={isLoading}
       error={error}
-      emptyMessage={<TimeSpentInDatabaseWidgetEmptyStateWarning />}
+      emptyMessage={<WidgetEmptyStateWarning />}
       VisualizationType={TimeSeriesWidgetVisualization}
       visualizationProps={{
         id: 'overviewSlowAssetsWidget',
         showLegend: props.loaderSource === 'releases-drawer' ? 'auto' : 'never',
-        plottables: timeSeries.map(
+        plottables: assetSeriesData.map(
           (ts, index) =>
             new Line(convertSeriesToTimeseries(ts), {
               color: colorPalette[index],

--- a/static/app/views/insights/common/components/widgets/overviewSlowAssetsWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/overviewSlowAssetsWidget.tsx
@@ -47,6 +47,7 @@ export default function OverviewAssetsByTimeSpentWidget(props: LoadableChartWidg
   const referrer = Referrer.ASSETS_BY_TIME_SPENT;
   const groupBy = SpanFields.NORMALIZED_DESCRIPTION;
   const yAxes = 'sum(span.self_time)';
+  const totalTimeField = 'sum(span.self_time)';
 
   const {
     data: assetListData,
@@ -58,9 +59,9 @@ export default function OverviewAssetsByTimeSpentWidget(props: LoadableChartWidg
         'span.group',
         'project.id',
         'sentry.normalized_description',
-        'sum(span.self_time)',
+        totalTimeField,
       ],
-      sorts: [{field: 'sum(span.self_time)', kind: 'desc'}],
+      sorts: [{field: totalTimeField, kind: 'desc'}],
       search,
       limit: 3,
       noPagination: true,
@@ -136,7 +137,7 @@ export default function OverviewAssetsByTimeSpentWidget(props: LoadableChartWidg
               moduleName={ModuleName.RESOURCE}
             />
           </div>
-          <span>{getDuration((item['sum(span.self_time)'] ?? 0) / 1000, 2, true)}</span>
+          <span>{getDuration((item[totalTimeField] ?? 0) / 1000, 2, true)}</span>
         </Fragment>
       ))}
     </WidgetFooterTable>

--- a/static/app/views/insights/common/components/widgets/overviewSlowAssetsWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/overviewSlowAssetsWidget.tsx
@@ -102,7 +102,7 @@ export default function OverviewAssetsByTimeSpentWidget(props: LoadableChartWidg
       emptyMessage={<TimeSpentInDatabaseWidgetEmptyStateWarning />}
       VisualizationType={TimeSeriesWidgetVisualization}
       visualizationProps={{
-        id: 'overviewSlowQueriesChartWidget',
+        id: 'overviewSlowAssetsWidget',
         showLegend: props.loaderSource === 'releases-drawer' ? 'auto' : 'never',
         plottables: timeSeries.map(
           (ts, index) =>

--- a/static/app/views/insights/common/components/widgets/overviewSlowAssetsWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/overviewSlowAssetsWidget.tsx
@@ -1,8 +1,8 @@
 import {Fragment} from 'react';
 import {useTheme} from '@emotion/react';
 
+import Duration from 'sentry/components/duration';
 import {t} from 'sentry/locale';
-import getDuration from 'sentry/utils/duration/getDuration';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
@@ -118,7 +118,7 @@ export default function OverviewAssetsByTimeSpentWidget(props: LoadableChartWidg
     <WidgetFooterTable>
       {assetListData?.map((item, index) => (
         <Fragment
-          key={`${item['project.id']}-${item['span.group']}-${item['sentry.normalized_description']}`}
+          key={`${item[SpanFields.PROJECT_ID]}-${item[SpanFields.SPAN_GROUP]}-${item[SpanFields.NORMALIZED_DESCRIPTION]}`}
         >
           <div>
             <SeriesColorIndicator
@@ -129,13 +129,17 @@ export default function OverviewAssetsByTimeSpentWidget(props: LoadableChartWidg
           </div>
           <div>
             <SpanDescriptionCell
-              projectId={Number(item['project.id'])}
-              group={item['span.group']}
-              description={item['sentry.normalized_description']}
+              projectId={Number(item[SpanFields.PROJECT_ID])}
+              group={item[SpanFields.SPAN_GROUP]}
+              description={item[SpanFields.NORMALIZED_DESCRIPTION]}
               moduleName={ModuleName.RESOURCE}
             />
           </div>
-          <span>{getDuration((item[totalTimeField] ?? 0) / 1000, 2, true)}</span>
+          <Duration
+            seconds={(item[totalTimeField] ?? 0) / 1000}
+            fixedDigits={2}
+            abbreviation
+          />
         </Fragment>
       ))}
     </WidgetFooterTable>
@@ -172,7 +176,7 @@ export default function OverviewAssetsByTimeSpentWidget(props: LoadableChartWidg
           organization,
           pageFilters: selection,
           dataset: Dataset.EVENTS_ANALYTICS_PLATFORM,
-          query: `sentry.normalized_description:${series.seriesName}`,
+          query: `${SpanFields.NORMALIZED_DESCRIPTION}:${series.seriesName}`,
           referrer,
         }),
       }))}

--- a/static/app/views/insights/pages/frontend/newFrontendOverviewPage.tsx
+++ b/static/app/views/insights/pages/frontend/newFrontendOverviewPage.tsx
@@ -25,6 +25,7 @@ import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLay
 import {InsightsProjectSelector} from 'sentry/views/insights/common/components/projectSelector';
 import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
 import {STARRED_SEGMENT_TABLE_QUERY_KEY} from 'sentry/views/insights/common/components/tableCells/starredSegmentCell';
+import OverviewAssetsByTimeSpentWidget from 'sentry/views/insights/common/components/widgets/overviewSlowAssetsWidget';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
 import {QueryParameterNames} from 'sentry/views/insights/common/views/queryParameters';
@@ -49,6 +50,7 @@ import {
   SPAN_OP_QUERY_PARAM,
 } from 'sentry/views/insights/pages/frontend/settings';
 import {InsightsSpanTagProvider} from 'sentry/views/insights/pages/insightsSpanTagProvider';
+import {WebVitalsWidget} from 'sentry/views/insights/pages/platform/nextjs/webVitalsWidget';
 import {IssuesWidget} from 'sentry/views/insights/pages/platform/shared/issuesWidget';
 import {TransactionNameSearchBar} from 'sentry/views/insights/pages/transactionNameSearchBar';
 import {useOverviewPageTrackPageload} from 'sentry/views/insights/pages/useOverviewPageTrackAnalytics';
@@ -243,10 +245,10 @@ export function NewFrontendOverviewPage() {
                 <ModuleLayout.Full>
                   <TripleRowWidgetWrapper>
                     <ModuleLayout.Third>
-                      <div>Web perf score chart</div>
+                      <WebVitalsWidget />
                     </ModuleLayout.Third>
                     <ModuleLayout.Third>
-                      <div>Assets by time spent</div>
+                      <OverviewAssetsByTimeSpentWidget />
                     </ModuleLayout.Third>
                     <ModuleLayout.Third>
                       <div>Requests by time spent</div>

--- a/static/app/views/insights/pages/frontend/referrers.ts
+++ b/static/app/views/insights/pages/frontend/referrers.ts
@@ -1,0 +1,3 @@
+export enum Referrer {
+  ASSETS_BY_TIME_SPENT = 'api.performance.frontend.overview.assets-by-time-spent',
+}


### PR DESCRIPTION
Add perf score chart and assets by time spent chart to modern frontend overview.

The assets chart has weird yAxis intervals, probably because the time spent is in days/months/years instead of a typical duration chart which is in seconds. I'll look into this separately, but there's also a chance we don't end up graphing time spent.
<img width="840" height="386" alt="image" src="https://github.com/user-attachments/assets/9238aa87-76f6-4bc6-84e5-f2f5ea10e8ec" />

closes DAIN-806