### PR TITLE
fix(ui): Improve zendesk "loaded" checks

### DIFF
--- a/static/app/utils/zendesk.tsx
+++ b/static/app/utils/zendesk.tsx
@@ -3,12 +3,34 @@
  *
  * Zendesk script is only loaded in SaaS. This will operate as a noop otherwise.
  */
-export function activateZendesk() {
-  if (zendeskIsLoaded()) {
+export async function activateZendesk() {
+  if (await zendeskIsLoaded()) {
     window.zE.activate({hideOnClose: true});
   }
 }
 
-export function zendeskIsLoaded() {
+/**
+ * Check that zendesk widget is available. Use zendeskIsLoaded to ensure the
+ * widget is correctly loaded.
+ */
+export function hasZendesk() {
   return window.zE && typeof window.zE.activate === 'function';
+}
+
+/**
+ * Determines if the zendesk widget is loaded and not blocked by web browser
+ * configurations (such as Firefox's Strict Mode)
+ */
+export async function zendeskIsLoaded() {
+  if (!window.zE || typeof window.zE.activate !== 'function') {
+    return false;
+  }
+
+  // Ensure the zendesk widget configuration can be loaded
+  try {
+    await fetch('https://sentry.zendesk.com/embeddable/config');
+    return true;
+  } catch {
+    return false;
+  }
 }

--- a/static/app/views/nav/primary/help.tsx
+++ b/static/app/views/nav/primary/help.tsx
@@ -13,7 +13,7 @@ import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
 import useMutateUserOptions from 'sentry/utils/useMutateUserOptions';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useUser} from 'sentry/utils/useUser';
-import {activateZendesk, zendeskIsLoaded} from 'sentry/utils/zendesk';
+import {activateZendesk, hasZendesk} from 'sentry/utils/zendesk';
 import {SidebarMenu} from 'sentry/views/nav/primary/components';
 import {
   StackedNavigationTourReminder,
@@ -31,7 +31,7 @@ function getContactSupportItem({
     return null;
   }
 
-  if (zendeskIsLoaded()) {
+  if (hasZendesk()) {
     return {
       key: 'support',
       label: t('Contact Support'),

--- a/static/gsApp/components/zendeskLink.tsx
+++ b/static/gsApp/components/zendeskLink.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect} from 'react';
 
 import {ExternalLink} from 'sentry/components/core/link';
 import type {Organization} from 'sentry/types/organization';
@@ -17,48 +17,42 @@ type Props = {
   subject?: string;
 };
 
-class ZendeskLink extends React.Component<Props> {
-  componentDidMount() {
-    const {organization, source} = this.props;
+function ZendeskLink({
+  organization,
+  source,
+  Component,
+  subject,
+  address,
+  children,
+  ...props
+}: Props) {
+  useEffect(() => {
     if (organization) {
       trackGetsentryAnalytics('zendesk_link.viewed', {organization, source});
     }
-  }
+  }, [organization, source]);
 
-  activateSupportWidget = (e: React.MouseEvent) => {
-    const {organization, source} = this.props;
-
-    if (zendeskIsLoaded()) {
+  async function activateSupportWidget(e: React.MouseEvent) {
+    if (await zendeskIsLoaded()) {
       e.preventDefault();
       activateZendesk();
     }
 
     trackGetsentryAnalytics('zendesk_link.clicked', {organization, source});
-  };
-
-  render() {
-    const {
-      Component,
-      subject,
-      address,
-      source: _source,
-      organization: _organization,
-      ...props
-    } = this.props;
-
-    let mailto = `mailto:${address ?? 'support'}@sentry.io`;
-    if (subject) {
-      mailto = `${mailto}?subject=${window.encodeURIComponent(subject)}`;
-    }
-
-    const LinkComponent = Component ?? ExternalLink;
-
-    return (
-      <LinkComponent href={mailto} onClick={this.activateSupportWidget} {...props}>
-        {this.props.children}
-      </LinkComponent>
-    );
   }
+
+  let mailto = `mailto:${address ?? 'support'}@sentry.io`;
+  if (subject) {
+    mailto = `${mailto}?subject=${window.encodeURIComponent(subject)}`;
+  }
+
+  const LinkComponent = Component ?? ExternalLink;
+
+  return (
+    <LinkComponent href={mailto} onClick={activateSupportWidget} {...props}>
+      {children}
+    </LinkComponent>
+  );
 }
 
 export default withOrganization(ZendeskLink);


### PR DESCRIPTION
In some cases the zendesk widget may fail to load it's configuration due to strict CSRF checks (Firefox strict mode). In these cases we should just fallback to email.

This is similar to https://github.com/getsentry/sentry/pull/92684

This implementation will attempt to fetch the config once the link has been clicked, if successful it will open the widget, otherwise it will fallback to the mailto.

Fixes [RTC-570: Embedded Zendesk Widget Fails to Send Messages in Firefox on Ubuntu 22.04](https://linear.app/getsentry/issue/RTC-570/embedded-zendesk-widget-fails-to-send-messages-in-firefox-on-ubuntu)