### PR TITLE
ref(issues): decrease rate limits for GroupTagKeyValues endpoint 3

### DIFF
--- a/src/sentry/api/endpoints/group_tagkey_values.py
+++ b/src/sentry/api/endpoints/group_tagkey_values.py
@@ -36,9 +36,9 @@ class GroupTagKeyValuesEndpoint(GroupEndpoint):
     enforce_rate_limit = True
     rate_limits = {
         "GET": {
-            RateLimitCategory.IP: RateLimit(limit=100, window=60, concurrent_limit=5),
-            RateLimitCategory.USER: RateLimit(limit=200, window=60, concurrent_limit=10),
-            RateLimitCategory.ORGANIZATION: RateLimit(limit=400, window=60, concurrent_limit=5),
+            RateLimitCategory.IP: RateLimit(limit=75, window=60, concurrent_limit=5),
+            RateLimitCategory.USER: RateLimit(limit=150, window=60, concurrent_limit=10),
+            RateLimitCategory.ORGANIZATION: RateLimit(limit=300, window=60, concurrent_limit=5),
         }
     }
 

--- a/tests/sentry/api/endpoints/test_group_tagkey_values.py
+++ b/tests/sentry/api/endpoints/test_group_tagkey_values.py
@@ -206,7 +206,7 @@ class GroupTagKeyValuesTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase
         url = f"/api/0/issues/{group.id}/tags/{key}/values/"
 
         with freeze_time(datetime.datetime.now()):
-            for i in range(200):
+            for i in range(150):
                 response = self.client.get(url)
                 assert response.status_code == 200
             response = self.client.get(url)


### PR DESCRIPTION
Cut the rate limit one last time on GroupTagKeyValues to 1/2 of original values (original was ip: 150, user: 300, org: 600), same reasoning as https://github.com/getsentry/sentry/pull/97130 — we don't see frontend users getting rate limited, and this gets us back to old tagstore query levels.