### PR TITLE
fix(search): Release builde filter use recents

### DIFF
--- a/src/sentry/search/eap/spans/filter_aliases.py
+++ b/src/sentry/search/eap/spans/filter_aliases.py
@@ -199,7 +199,9 @@ def semver_build_filter_converter(
             build,
             project_ids=params.project_ids,
             negated=negated,
-        ).values_list("version", flat=True)[: constants.MAX_SEARCH_RELEASES]
+        )
+        .values_list("version", flat=True)
+        .order_by("-date_added")[: constants.MAX_SEARCH_RELEASES]
     )
 
     if not validate_snuba_array_parameter(versions):

--- a/src/sentry/search/events/datasets/filter_aliases.py
+++ b/src/sentry/search/events/datasets/filter_aliases.py
@@ -290,7 +290,9 @@ def semver_build_filter_converter(
             build,
             project_ids=builder.params.project_ids,
             negated=negated,
-        ).values_list("version", flat=True)[: constants.MAX_SEARCH_RELEASES]
+        )
+        .values_list("version", flat=True)
+        .order_by("-date_added")[: constants.MAX_SEARCH_RELEASES]
     )
 
     if not validate_snuba_array_parameter(versions):


### PR DESCRIPTION
There is a 1000 release limit on the way the release.build filter works. By biasing towards recent releases, it's more likely that the filter will work. This is helpful in the situation when there are 1000s of releases created over a long period of time. This way, we only look for releases that are more likely to appear in the results instead of populating the IN condition with a bunch of old releases that likely doesn't exist anymore.