### PR TITLE
chore(emerge): Remove axes from app size viz

### DIFF
--- a/static/app/views/preprod/components/visualizations/appSizeCategories.tsx
+++ b/static/app/views/preprod/components/visualizations/appSizeCategories.tsx
@@ -115,6 +115,13 @@ export function AppSizeCategories(props: AppSizeCategoriesProps) {
   };
 
   return (
-    <BaseChart autoHeightResize renderer="canvas" series={series} tooltip={tooltip} />
+    <BaseChart
+      autoHeightResize
+      renderer="canvas"
+      series={series}
+      tooltip={tooltip}
+      xAxis={null}
+      yAxis={null}
+    />
   );
 }

--- a/static/app/views/preprod/components/visualizations/appSizeTreemap.tsx
+++ b/static/app/views/preprod/components/visualizations/appSizeTreemap.tsx
@@ -219,6 +219,8 @@ export function AppSizeTreemap(props: AppSizeTreemapProps) {
     <BaseChart
       autoHeightResize
       renderer="canvas"
+      xAxis={null}
+      yAxis={null}
       series={series}
       visualMap={visualMap}
       tooltip={tooltip}


### PR DESCRIPTION
The app size visualizations had a black line on the bottom. This was due to an implicit xaxis being set by `BaseChart` when none was provided. Passing null forces no xaxis to be used, clearing the line. There is also a non-visible yAxis present, so I forced that off as well.

Before
<img width="214" height="272" alt="Screenshot 2025-08-05 at 2 15 09 PM" src="https://github.com/user-attachments/assets/15007140-efd1-4cde-925a-112a40d98bd7" />

After
<img width="265" height="385" alt="Screenshot 2025-08-05 at 2 14 58 PM" src="https://github.com/user-attachments/assets/95fc3ce0-a080-4802-8a19-dc8ca28f3e1e" />
