### PR TITLE
fix(detectors): Fix bug with empty `path_parameters` 

### DIFF
--- a/src/sentry/performance_issues/detectors/experiments/n_plus_one_api_calls_detector.py
+++ b/src/sentry/performance_issues/detectors/experiments/n_plus_one_api_calls_detector.py
@@ -221,7 +221,9 @@ class NPlusOneAPICallsExperimentalDetector(PerformanceDetector):
 
         # Note: dict.fromkeys() is just to deduplicate values and Python dicts are ordered
         path_params_list: list[str] = list(
-            dict.fromkeys([f"{', '.join(param_group)}" for param_group in path_params]).keys()
+            dict.fromkeys(
+                [f"{', '.join(param_group)}" for param_group in path_params if param_group]
+            ).keys()
         )
         query_params_list: list[str] = list(
             dict.fromkeys(

--- a/tests/sentry/performance_issues/experiments/test_n_plus_one_api_calls_detector.py
+++ b/tests/sentry/performance_issues/experiments/test_n_plus_one_api_calls_detector.py
@@ -300,6 +300,18 @@ class NPlusOneAPICallsExperimentalDetectorTest(TestCase):
 
         assert problem1.fingerprint == problem2.fingerprint
 
+    def test_does_not_include_empty_path_params_in_evidence(self) -> None:
+        """Test that empty path_params lists are properly filtered out."""
+        # Create URLs that have no path parameters (only query parameters)
+        # This would result in path_params being a list of empty lists [[], [], []]
+        event = self.create_event(lambda i: f"GET /api/users?user_id={i}")
+        [problem] = self.find_problems(event)
+
+        assert problem.evidence_data is not None
+        # If `path_params` is a list of empty lists, we shouldn't return any path parameters
+        path_params = problem.evidence_data.get("path_parameters", [])
+        assert path_params == []
+
 
 @pytest.mark.parametrize(
     "url,parameterized_url",


### PR DESCRIPTION
in some instances `path_parameters` in the evidence section for the experimental N+1 API Calls detector would show up even though there was nothing to show - this pr fixes that bug and ensure we only show that section if the values exist 