### PR TITLE
ref(grouping): Remove dead grouping config choice code

### DIFF
--- a/src/sentry/grouping/__init__.py
+++ b/src/sentry/grouping/__init__.py
@@ -117,7 +117,6 @@ This for instance is how one of the configurations is defined::
         id="newstyle:SomeDate",
         base="newstyle:AnotherDate",
         delegates=["frame:v4"],
-        risk=RISK_LEVEL_MEDIUM,
         changelog="...",
     )
 

--- a/src/sentry/grouping/__init__.py
+++ b/src/sentry/grouping/__init__.py
@@ -117,7 +117,6 @@ This for instance is how one of the configurations is defined::
         id="newstyle:SomeDate",
         base="newstyle:AnotherDate",
         delegates=["frame:v4"],
-        changelog="...",
     )
 
 The configuration ID (`newstyle:YYYY-MM-DD`) is defined in the project

--- a/src/sentry/grouping/fingerprinting/__init__.py
+++ b/src/sentry/grouping/fingerprinting/__init__.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import inspect
 import logging
 from collections.abc import Generator, Mapping, Sequence
 from pathlib import Path
@@ -256,7 +255,6 @@ class FingerprintingRules:
     def __init__(
         self,
         rules: Sequence[FingerprintRule],
-        changelog: Sequence[object] | None = None,
         version: int | None = None,
         bases: Sequence[str] | None = None,
     ) -> None:
@@ -264,7 +262,6 @@ class FingerprintingRules:
             version = VERSION
         self.version = version
         self.rules = rules
-        self.changelog = changelog
         self.bases = bases or []
 
     def iter_rules(self, include_builtin: bool = True) -> Generator[FingerprintRule]:
@@ -581,23 +578,8 @@ class FingerprintingVisitor(NodeVisitorBase):
     def visit_fingerprinting_rules(
         self, _: object, children: list[str | FingerprintRule | None]
     ) -> FingerprintingRules:
-        changelog = []
-        rules = []
-        in_header = True
-
-        for child in children:
-            if isinstance(child, str):
-                if in_header and child.startswith("##"):
-                    changelog.append(child[2:].rstrip())
-                else:
-                    in_header = False
-            elif child is not None:
-                rules.append(child)
-                in_header = False
-
         return FingerprintingRules(
-            rules=rules,
-            changelog=inspect.cleandoc("\n".join(changelog)).rstrip() or None,
+            rules=[child for child in children if not isinstance(child, str) and child is not None],
             bases=self.bases,
         )
 

--- a/src/sentry/grouping/fingerprinting/configs/README.md
+++ b/src/sentry/grouping/fingerprinting/configs/README.md
@@ -50,10 +50,6 @@ To add one or more of these rule configs
 register_strategy_config(
     id="newstyle:YYYY-MM-DD",
     base="newstyle:YYYY-MM-DD", # Some other existing config
-    changelog="""
-        * Added built-in fingerprinting for Foo
-        * Added built-in fingerprinting for Bar
-    """,
     fingerprinting_bases=["foo@YYYY-MM-DD", "bar@YYYY-MM-DD"],
 )
 ```

--- a/src/sentry/grouping/fingerprinting/configs/README.md
+++ b/src/sentry/grouping/fingerprinting/configs/README.md
@@ -50,7 +50,6 @@ To add one or more of these rule configs
 register_strategy_config(
     id="newstyle:YYYY-MM-DD",
     base="newstyle:YYYY-MM-DD", # Some other existing config
-    risk=RISK_LEVEL_MEDIUM,
     changelog="""
         * Added built-in fingerprinting for Foo
         * Added built-in fingerprinting for Bar

--- a/src/sentry/grouping/strategies/base.py
+++ b/src/sentry/grouping/strategies/base.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import inspect
 from collections.abc import Callable, Iterator, Sequence
 from typing import TYPE_CHECKING, Any, Generic, Protocol, Self, TypeVar, overload
 
@@ -327,7 +326,6 @@ class StrategyConfiguration:
     base: type[StrategyConfiguration] | None = None
     strategies: dict[str, Strategy[Any]] = {}
     delegates: dict[str, Strategy[Any]] = {}
-    changelog: str | None = None
     initial_context: ContextDict = {}
     enhancements_base: str | None = DEFAULT_ENHANCEMENTS_BASE
     fingerprinting_bases: Sequence[str] | None = DEFAULT_GROUPING_FINGERPRINTING_BASES
@@ -363,7 +361,6 @@ class StrategyConfiguration:
             "id": cls.id,
             "base": cls.base.id if cls.base else None,
             "strategies": sorted(cls.strategies),
-            "changelog": cls.changelog,
             "delegates": sorted(x.id for x in cls.delegates.values()),
         }
 
@@ -372,7 +369,6 @@ def create_strategy_configuration_class(
     id: str,
     strategies: Sequence[str] | None = None,
     delegates: Sequence[str] | None = None,
-    changelog: str | None = None,
     base: type[StrategyConfiguration] | None = None,
     initial_context: ContextDict | None = None,
     enhancements_base: str | None = None,
@@ -434,7 +430,6 @@ def create_strategy_configuration_class(
     if fingerprinting_bases:
         NewStrategyConfiguration.fingerprinting_bases = fingerprinting_bases
 
-    NewStrategyConfiguration.changelog = inspect.cleandoc(changelog or "")
     NewStrategyConfiguration.__name__ = "StrategyConfiguration(%s)" % id
     return NewStrategyConfiguration
 

--- a/src/sentry/grouping/strategies/base.py
+++ b/src/sentry/grouping/strategies/base.py
@@ -328,7 +328,6 @@ class StrategyConfiguration:
     strategies: dict[str, Strategy[Any]] = {}
     delegates: dict[str, Strategy[Any]] = {}
     changelog: str | None = None
-    hidden = False
     initial_context: ContextDict = {}
     enhancements_base: str | None = DEFAULT_ENHANCEMENTS_BASE
     fingerprinting_bases: Sequence[str] | None = DEFAULT_GROUPING_FINGERPRINTING_BASES
@@ -366,7 +365,6 @@ class StrategyConfiguration:
             "strategies": sorted(cls.strategies),
             "changelog": cls.changelog,
             "delegates": sorted(x.id for x in cls.delegates.values()),
-            "hidden": cls.hidden,
         }
 
 
@@ -375,7 +373,6 @@ def create_strategy_configuration_class(
     strategies: Sequence[str] | None = None,
     delegates: Sequence[str] | None = None,
     changelog: str | None = None,
-    hidden: bool = False,
     base: type[StrategyConfiguration] | None = None,
     initial_context: ContextDict | None = None,
     enhancements_base: str | None = None,
@@ -404,8 +401,6 @@ def create_strategy_configuration_class(
         NewStrategyConfiguration.fingerprinting_bases = list(base.fingerprinting_bases)
     else:
         NewStrategyConfiguration.fingerprinting_bases = None
-
-    NewStrategyConfiguration.hidden = hidden
 
     by_class: dict[str, list[str]] = {}
     for strategy in NewStrategyConfiguration.strategies.values():

--- a/src/sentry/grouping/strategies/base.py
+++ b/src/sentry/grouping/strategies/base.py
@@ -24,11 +24,6 @@ if TYPE_CHECKING:
 
 STRATEGIES: dict[str, Strategy[Any]] = {}
 
-RISK_LEVEL_LOW = 0
-RISK_LEVEL_MEDIUM = 1
-RISK_LEVEL_HIGH = 2
-
-Risk = int  # TODO: make enum or union of literals
 
 # XXX: Want to make ContextDict typeddict but also want to type/overload dict
 # API on GroupingContext
@@ -335,7 +330,6 @@ class StrategyConfiguration:
     delegates: dict[str, Strategy[Any]] = {}
     changelog: str | None = None
     hidden = False
-    risk = RISK_LEVEL_LOW
     initial_context: ContextDict = {}
     enhancements_base: str | None = DEFAULT_ENHANCEMENTS_BASE
     fingerprinting_bases: Sequence[str] | None = DEFAULT_GROUPING_FINGERPRINTING_BASES
@@ -374,7 +368,6 @@ class StrategyConfiguration:
             "changelog": cls.changelog,
             "delegates": sorted(x.id for x in cls.delegates.values()),
             "hidden": cls.hidden,
-            "risk": cls.risk,
             "latest": projectoptions.lookup_well_known_key("sentry:grouping_config").get_default(
                 epoch=projectoptions.LATEST_EPOCH
             )
@@ -389,7 +382,6 @@ def create_strategy_configuration_class(
     changelog: str | None = None,
     hidden: bool = False,
     base: type[StrategyConfiguration] | None = None,
-    risk: Risk | None = None,
     initial_context: ContextDict | None = None,
     enhancements_base: str | None = None,
     fingerprinting_bases: Sequence[str] | None = None,
@@ -418,9 +410,6 @@ def create_strategy_configuration_class(
     else:
         NewStrategyConfiguration.fingerprinting_bases = None
 
-    if risk is None:
-        risk = RISK_LEVEL_LOW
-    NewStrategyConfiguration.risk = risk
     NewStrategyConfiguration.hidden = hidden
 
     by_class: dict[str, list[str]] = {}

--- a/src/sentry/grouping/strategies/base.py
+++ b/src/sentry/grouping/strategies/base.py
@@ -4,7 +4,6 @@ import inspect
 from collections.abc import Callable, Iterator, Sequence
 from typing import TYPE_CHECKING, Any, Generic, Protocol, Self, TypeVar, overload
 
-from sentry import projectoptions
 from sentry.grouping.component import (
     BaseGroupingComponent,
     ExceptionGroupingComponent,
@@ -368,10 +367,6 @@ class StrategyConfiguration:
             "changelog": cls.changelog,
             "delegates": sorted(x.id for x in cls.delegates.values()),
             "hidden": cls.hidden,
-            "latest": projectoptions.lookup_well_known_key("sentry:grouping_config").get_default(
-                epoch=projectoptions.LATEST_EPOCH
-            )
-            == cls.id,
         }
 
 

--- a/src/sentry/grouping/strategies/configurations.py
+++ b/src/sentry/grouping/strategies/configurations.py
@@ -64,15 +64,7 @@ register_grouping_config(
     id="newstyle:2023-01-11",
     # There's no `base` argument here because this config is based on `BASE_STRATEGY`. To base a
     # config on a previous config, include its `id` value as the value for `base` here.
-    changelog="""
-        * Better rules for when to take context lines into account for
-          JavaScript platforms for grouping purposes.
-        * Better support for PHP7 anonymous classes.
-        * Added new language/platform specific stack trace grouping enhancements rules
-          that should make the default grouping experience better.
-          This includes JavaScript, Python, PHP, Go, Java and Kotlin.
-        * Added ChukloadErrors via new built-in fingerprinting support.
-    """,
+    #
     # There's nothing in the initial context because this config uses all the default values. If we
     # change grouping behavior in a future config, it should be gated by a config feature, that
     # feature should be defaulted to False in the base config, and then the `initial_context` in the

--- a/src/sentry/grouping/strategies/configurations.py
+++ b/src/sentry/grouping/strategies/configurations.py
@@ -1,5 +1,4 @@
 from sentry.grouping.strategies.base import (
-    RISK_LEVEL_HIGH,
     StrategyConfiguration,
     create_strategy_configuration_class,
 )
@@ -65,7 +64,6 @@ register_grouping_config(
     id="newstyle:2023-01-11",
     # There's no `base` argument here because this config is based on `BASE_STRATEGY`. To base a
     # config on a previous config, include its `id` value as the value for `base` here.
-    risk=RISK_LEVEL_HIGH,
     changelog="""
         * Better rules for when to take context lines into account for
           JavaScript platforms for grouping purposes.

--- a/tests/sentry/issues/endpoints/test_grouping_configs.py
+++ b/tests/sentry/issues/endpoints/test_grouping_configs.py
@@ -17,7 +17,6 @@ class GroupingConfigsNoSlugTest(APITestCase):
         assert len(body)
         assert "id" in body[0]
         assert "base" in body[0]
-        assert "changelog" in body[0]
         assert "delegates" in body[0]
 
 
@@ -37,5 +36,4 @@ class GroupingConfigsWithSlugTest(APITestCase):
         assert len(body)
         assert "id" in body[0]
         assert "base" in body[0]
-        assert "changelog" in body[0]
         assert "delegates" in body[0]


### PR DESCRIPTION
This removes a number of small things in the grouping code left over from the time when we let users choose what grouping config to use.

- In order to experiment with new configs without releasing them to users, we allowed configs to be hidden.

- In order to help users make decisions about when and if to upgrade their grouping config, we indicated whether their current config was up to date and displayed both a risk level and a changelog for each config.