### PR TITLE
fix(integrations): Fix typo in comment

### DIFF
--- a/src/sentry/integrations/tasks/sync_status_inbound.py
+++ b/src/sentry/integrations/tasks/sync_status_inbound.py
@@ -275,7 +275,7 @@ def sync_status_inbound(
             activity_type=activity_type,
             activity_data=activity_data,
         )
-        # after we update the group, pdate the resolutions
+        # after we update the group, update the resolutions
         for group in resolvable_groups:
             resolution_params = resolutions_by_group_id.get(group.id)
             if resolution_params:


### PR DESCRIPTION
This fixes a typo in a comment relating to syncing the status of groups and their resolutions.