### PR TITLE
fix(alerts): Stop passing empty sessions environment

### DIFF
--- a/static/app/views/issueDetails/metricIssues/useMetricSessionStats.tsx
+++ b/static/app/views/issueDetails/metricIssues/useMetricSessionStats.tsx
@@ -38,7 +38,7 @@ export function useMetricSessionStats(
     {
       query: {
         project: project.id ? [Number(project.id)] : [],
-        environment,
+        environment: environment ? environment : undefined,
         field: SESSION_AGGREGATE_TO_FIELD[aggregate],
         query,
         groupBy: ['session.status'],


### PR DESCRIPTION
Instead of passing an empty string, omit the environment query parameter completely. Backend might have changed here?

Fixes an issue where the sessions stats come back entirely filled with zeros

<img width="805" height="349" alt="image" src="https://github.com/user-attachments/assets/de178b48-7af0-42ec-b05e-f7c41094e3ed" />
