### PR TITLE
fix(explorer): Attempt fix at profile execution tree construction

### DIFF
--- a/src/sentry/seer/autofix/autofix.py
+++ b/src/sentry/seer/autofix/autofix.py
@@ -515,8 +515,12 @@ def _get_profile_from_trace_tree(
                 "matching_transaction": matching_transaction,
                 "project_slug": project.slug,
                 "organization_slug": project.organization.slug,
-                "profile_id": matching_transaction.get("profile_id"),
-                "profiler_id": matching_transaction.get("profiler_id"),
+                "profile_id": (
+                    matching_transaction.get("profile_id") if matching_transaction else None
+                ),
+                "profiler_id": (
+                    matching_transaction.get("profiler_id") if matching_transaction else None
+                ),
             },
         )
         return None

--- a/src/sentry/seer/autofix/autofix.py
+++ b/src/sentry/seer/autofix/autofix.py
@@ -508,6 +508,17 @@ def _get_profile_from_trace_tree(
                 break
 
     if not matching_transaction or not matching_transaction.get("profile_id"):
+        logger.info(
+            "[Autofix] No matching transaction with profile_id found for event",
+            extra={
+                "trace_to_search_id": event.trace_id,
+                "matching_transaction": matching_transaction,
+                "project_slug": project.slug,
+                "organization_slug": project.organization.slug,
+                "profile_id": matching_transaction.get("profile_id"),
+                "profiler_id": matching_transaction.get("profiler_id"),
+            },
+        )
         return None
 
     profile_id = matching_transaction.get("profile_id")
@@ -541,9 +552,15 @@ def _convert_profile_to_execution_tree(profile_data: dict) -> list[dict]:
     including only items from the MainThread and app frames.
     Calculates accurate durations for all nodes based on call stack transitions.
     """
-    profile = profile_data.get("profile")
+    profile = profile_data.get(
+        "profile"
+    )  # transaction profiles are formatted as {"profile": {"frames": [], "samples": [], "stacks": []}}
     if not profile:
-        return []
+        profile = profile_data.get("chunk", {}).get(
+            "profile"
+        )  # continuous profiles are wrapped as {"chunk": {"profile": {"frames": [], "samples": [], "stacks": []}}}
+        if not profile:
+            return []
 
     frames = profile.get("frames")
     stacks = profile.get("stacks")

--- a/src/sentry/seer/explorer/index_data.py
+++ b/src/sentry/seer/explorer/index_data.py
@@ -220,8 +220,8 @@ def _fetch_profile_data(
     profile_id: str,
     organization_id: int,
     project_id: int,
-    start_ts: float,
-    end_ts: float,
+    start_ts: float | None = None,
+    end_ts: float | None = None,
     is_continuous: bool = False,
 ) -> dict[str, Any] | None:
     """
@@ -239,6 +239,18 @@ def _fetch_profile_data(
         Raw profile data or None if not found
     """
     if is_continuous:
+        if start_ts is None or end_ts is None:
+            logger.info(
+                "Start and end timestamps not provided for fetching continuous profiles, skipping",
+                extra={
+                    "profile_id": profile_id,
+                    "is_continuous": is_continuous,
+                    "start_ts": start_ts,
+                    "end_ts": end_ts,
+                },
+            )
+            return None
+
         span_start = datetime.fromtimestamp(start_ts, UTC)
         span_end = datetime.fromtimestamp(end_ts, UTC)
         try:


### PR DESCRIPTION
Issues queries are working.
From logs, it seems that most profile queries succeed, but fail to convert to execution tree. I managed to log one json payload and i think this fix should do it (hopefully). Just need to unwrap the dict with an extra key.

Also adding logging to autofix that'll tell me if the issue is simply continuous profiling there too