### PR TITLE
feat(trace-eap-waterfall): Updating eap span row children count

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
@@ -1728,14 +1728,18 @@ export class TraceTree extends TraceTreeEventDispatcher {
 
       // When eap-transaction nodes are collapsed, they still render transactions as visible children.
       // Reparent the transactions from under the eap-spans in the expanded state, to under the closest eap-transaction
-      // in the collapsed state.
+      // in the collapsed state. This only targets the embedded transactions that are to be direct children of the node upon collapse.
       if (isEAPTransactionNode(node)) {
         TraceTree.ReparentEAPTransactions(
           node,
           t =>
-            TraceTree.FindAll(t, n => isEAPTransactionNode(n) && n !== t) as Array<
-              TraceTreeNode<TraceTree.EAPSpan>
-            >,
+            TraceTree.FindAll(
+              t,
+              n =>
+                isEAPTransactionNode(n) &&
+                n !== t &&
+                TraceTree.ParentEAPTransaction(n) === node
+            ) as Array<TraceTreeNode<TraceTree.EAPSpan>>,
           t => TraceTree.ParentEAPTransaction(t)
         );
       }

--- a/static/app/views/performance/newTraceDetails/traceRow/traceSpanRow.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceSpanRow.tsx
@@ -2,10 +2,15 @@ import React from 'react';
 import {PlatformIcon} from 'platformicons';
 
 import {ellipsize} from 'sentry/utils/string/ellipsize';
-import {isEAPSpanNode} from 'sentry/views/performance/newTraceDetails/traceGuards';
+import {
+  isEAPSpanNode,
+  isEAPTransactionNode,
+} from 'sentry/views/performance/newTraceDetails/traceGuards';
 import {TraceIcons} from 'sentry/views/performance/newTraceDetails/traceIcons';
-import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
-import {getNodeDescriptionPrefix} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
+import {
+  getNodeDescriptionPrefix,
+  TraceTree,
+} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import type {TraceTreeNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode';
 import {
   makeTraceNodeBarColor,
@@ -30,6 +35,7 @@ export function TraceSpanRow(
     : props.node.value.span_id;
 
   const shouldUseOTelFriendlyUI = useOTelFriendlyUI();
+  const childrenCount = getChildrenCount(props.node);
 
   return (
     <div
@@ -69,9 +75,7 @@ export function TraceSpanRow(
                   props.node.canFetch ? props.onZoomIn(e) : props.onExpand(e)
                 }
               >
-                {props.node.children.length > 0
-                  ? TRACE_COUNT_FORMATTER.format(props.node.children.length)
-                  : null}
+                {childrenCount > 0 ? TRACE_COUNT_FORMATTER.format(childrenCount) : null}
               </TraceChildrenButton>
             ) : null}
           </div>
@@ -129,4 +133,14 @@ export function TraceSpanRow(
       </div>
     </div>
   );
+}
+
+function getChildrenCount(
+  node: TraceTreeNode<TraceTree.Span> | TraceTreeNode<TraceTree.EAPSpan>
+) {
+  if (isEAPTransactionNode(node) && !node.expanded) {
+    return node.children.length - TraceTree.DirectVisibleChildren(node).length;
+  }
+
+  return node.children.length;
 }


### PR DESCRIPTION
- When an eap txn is collapsed we still display embedded transactions
- This PR makes expand buttons always display the count of children upon expand, on eap txn rows. This prevents the number from changing as we toggle the expand state.

Collapsed:
<img width="443" height="181" alt="Screenshot 2025-08-06 at 10 55 05 AM" src="https://github.com/user-attachments/assets/8ed737e4-2df8-4f1b-a80d-4f7ccdc25a07" />

Expanded:
<img width="488" height="269" alt="Screenshot 2025-08-06 at 10 55 12 AM" src="https://github.com/user-attachments/assets/32fd5f1e-1b3e-42b8-baa8-459f9eb96963" />