### PR TITLE
chore(dynamic-sampling): add smaller logs for project configs

### DIFF
--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -1158,7 +1158,7 @@ def _get_project_config(
                         "organizations:dynamic-sampling-custom", project.organization
                     ),
                     "dynamic_sampling_mode": project.organization.get_option(
-                        "sentry:dynamic_sampling_mode", None
+                        "sentry:sampling_mode", None
                     ),
                     "dynamic_sampling_org_target_rate": project.organization.get_option(
                         "sentry:target_sample_rate", None
@@ -1180,7 +1180,7 @@ def _get_project_config(
                         "organizations:dynamic-sampling-custom", project.organization
                     ),
                     "dynamic_sampling_mode": project.organization.get_option(
-                        "sentry:dynamic_sampling_mode", None
+                        "sentry:sampling_mode", None
                     ),
                     "dynamic_sampling_org_target_rate": project.organization.get_option(
                         "sentry:target_sample_rate", None

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -1148,6 +1148,7 @@ def _get_project_config(
                 extra={
                     "project_id": str(project.id),
                     "org_id": str(project.organization.id),
+                    "sampling_rule_count": len(config["sampling"]["rules"]),
                     "dynamic_sampling_feature_flag": features.has(
                         "organizations:dynamic-sampling", project.organization
                     ),

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -1142,11 +1142,32 @@ def _get_project_config(
     if features.has("organizations:log-project-config", project.organization):
         try:
             logger.info(
-                "Logging project config for project %s in org %s.",
+                "Logging sampling feature flags for project %s in org %s.",
                 project.id,
                 project.organization.id,
                 extra={
-                    "project_config": config,
+                    "project_id": str(project.id),
+                    "org_id": str(project.organization.id),
+                    "dynamic_sampling_feature_flag": features.has(
+                        "organizations:dynamic-sampling", project.organization
+                    ),
+                    "dynamic_sampling_custom_feature_flag": features.has(
+                        "organizations:dynamic-sampling-custom", project.organization
+                    ),
+                    "dynamic_sampling_mode": project.organization.get_option(
+                        "sentry:dynamic_sampling_mode", None
+                    ),
+                    "dynamic_sampling_org_target_rate": project.organization.get_option(
+                        "sentry:target_sample_rate", None
+                    ),
+                },
+            )
+            logger.info(
+                "Logging project sampling config for project %s in org %s.",
+                project.id,
+                project.organization.id,
+                extra={
+                    "project_sampling_config": config["sampling"],
                     "project_id": str(project.id),
                     "org_id": str(project.organization.id),
                     "dynamic_sampling_feature_flag": features.has(

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -1148,7 +1148,9 @@ def _get_project_config(
                 extra={
                     "project_id": str(project.id),
                     "org_id": str(project.organization.id),
-                    "sampling_rule_count": len(config["sampling"]["rules"]),
+                    "sampling_rule_count": (
+                        len(config["sampling"]["rules"]) if "sampling" in config else None
+                    ),
                     "dynamic_sampling_feature_flag": features.has(
                         "organizations:dynamic-sampling", project.organization
                     ),
@@ -1168,7 +1170,7 @@ def _get_project_config(
                 project.id,
                 project.organization.id,
                 extra={
-                    "project_sampling_config": config["sampling"],
+                    "project_sampling_config": config["sampling"] if "sampling" in config else None,
                     "project_id": str(project.id),
                     "org_id": str(project.organization.id),
                     "dynamic_sampling_feature_flag": features.has(

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -17,6 +17,9 @@ from sentry.constants import (
 )
 from sentry.datascrubbing import get_datascrubbing_settings, get_pii_config
 from sentry.dynamic_sampling import generate_rules
+from sentry.dynamic_sampling.tasks.helpers.boost_low_volume_projects import (
+    get_boost_low_volume_projects_sample_rate,
+)
 from sentry.grouping.api import get_grouping_config_dict_for_project
 from sentry.ingest.inbound_filters import (
     FilterStatKeys,
@@ -1162,6 +1165,14 @@ def _get_project_config(
                     ),
                     "dynamic_sampling_org_target_rate": project.organization.get_option(
                         "sentry:target_sample_rate", None
+                    ),
+                    "dynamic_sampling_biases": project.get_option(
+                        "sentry:dynamic_sampling_biases", None
+                    ),
+                    "low_volume_projects_sample_rate": get_boost_low_volume_projects_sample_rate(
+                        org_id=project.organization.id,
+                        project_id=project.id,
+                        error_sample_rate_fallback=None,
                     ),
                 },
             )

--- a/tests/sentry/relay/test_config.py
+++ b/tests/sentry/relay/test_config.py
@@ -161,7 +161,10 @@ def test_get_project_config_with_logging(mock_logger, default_project, insta_sna
     )
 
     with Feature(
-        {"organizations:log-project-config": True, "organizations:dynamic-sampling": True}
+        {
+            "organizations:log-project-config": True,
+            "organizations:dynamic-sampling": True,
+        }
     ):
         project_cfg = get_project_config(default_project, project_keys=keys)
         cfg = project_cfg.to_dict()
@@ -169,23 +172,41 @@ def test_get_project_config_with_logging(mock_logger, default_project, insta_sna
     _validate_project_config(cfg["config"])
 
     # Verify that logging was called
-    mock_logger.info.assert_called_once()
-    call_args = mock_logger.info.call_args
+    assert mock_logger.info.call_count == 2
 
     # Check that the log message contains the expected project and org IDs
-    assert "Logging project config for project" in call_args[0][0]
-    assert call_args[0][1] == default_project.id
-    assert call_args[0][2] == default_project.organization.id
+    first_call_args = mock_logger.info.call_args_list[0]
+    second_call_args = mock_logger.info.call_args_list[1]
 
-    # Check that extra logging data is present
-    extra_data = call_args[1]["extra"]
-    assert "project_config" in extra_data
-    assert "project_id" in extra_data
-    assert "org_id" in extra_data
-    assert "dynamic_sampling_feature_flag" in extra_data
-    assert "dynamic_sampling_custom_feature_flag" in extra_data
-    assert "dynamic_sampling_mode" in extra_data
-    assert "dynamic_sampling_org_target_rate" in extra_data
+    assert "Logging sampling feature flags for project" in first_call_args[0][0]
+    assert first_call_args[0][1] == default_project.id
+    assert first_call_args[0][2] == default_project.organization.id
+    first_extra = first_call_args[1]["extra"]
+    assert "sampling_rule_count" in first_extra
+    assert "project_sampling_config" not in first_extra
+
+    assert "Logging project sampling config for project" in second_call_args[0][0]
+    assert second_call_args[0][1] == default_project.id
+    assert second_call_args[0][2] == default_project.organization.id
+    second_extra = second_call_args[1]["extra"]
+    assert "project_sampling_config" in second_extra
+
+    # Check that extra logging data is present for both logging calls
+    first_extra_data = first_call_args[1]["extra"]
+    assert "project_id" in first_extra_data
+    assert "org_id" in first_extra_data
+    assert "dynamic_sampling_feature_flag" in first_extra_data
+    assert "dynamic_sampling_custom_feature_flag" in first_extra_data
+    assert "dynamic_sampling_mode" in first_extra_data
+    assert "dynamic_sampling_org_target_rate" in first_extra_data
+
+    second_extra_data = second_call_args[1]["extra"]
+    assert "project_id" in second_extra_data
+    assert "org_id" in second_extra_data
+    assert "dynamic_sampling_feature_flag" in second_extra_data
+    assert "dynamic_sampling_custom_feature_flag" in second_extra_data
+    assert "dynamic_sampling_mode" in second_extra_data
+    assert "dynamic_sampling_org_target_rate" in second_extra_data
 
     # Verify that the custom dynamic sampling rule is included in the config
     sampling_config = get_path(cfg, "config", "sampling")
@@ -370,7 +391,8 @@ def test_project_config_with_all_biases_enabled(
     # Set factor
     default_factor = 0.5
     redis_client.set(
-        f"ds::o:{default_project.organization.id}:rate_rebalance_factor2", default_factor
+        f"ds::o:{default_project.organization.id}:rate_rebalance_factor2",
+        default_factor,
     )
 
     with Feature(
@@ -627,7 +649,8 @@ def test_accept_transaction_names(default_project) -> None:
 @django_db_all
 def test_txnames_ready(default_project, num_clusterer_runs) -> None:
     with mock.patch(
-        "sentry.relay.config.get_clusterer_meta", return_value={"runs": num_clusterer_runs}
+        "sentry.relay.config.get_clusterer_meta",
+        return_value={"runs": num_clusterer_runs},
     ):
         config = get_project_config(default_project).to_dict()["config"]
     _validate_project_config(config)
@@ -763,7 +786,11 @@ def test_alert_metric_extraction_rules(default_project, factories) -> None:
                     "category": "transaction",
                     "mri": "c:transactions/on_demand@none",
                     "field": None,
-                    "condition": {"name": "event.duration", "op": "lt", "value": 600000.0},
+                    "condition": {
+                        "name": "event.duration",
+                        "op": "lt",
+                        "value": 600000.0,
+                    },
                     "tags": [{"key": "query_hash", "value": ANY}],
                 }
             ],
@@ -790,10 +817,34 @@ def test_desktop_performance_calculate_score(default_project) -> None:
     assert performance_score[0] == {
         "name": "Chrome",
         "scoreComponents": [
-            {"measurement": "fcp", "weight": 0.15, "p10": 900, "p50": 1600, "optional": True},
-            {"measurement": "lcp", "weight": 0.3, "p10": 1200, "p50": 2400, "optional": True},
-            {"measurement": "cls", "weight": 0.15, "p10": 0.1, "p50": 0.25, "optional": True},
-            {"measurement": "ttfb", "weight": 0.1, "p10": 200, "p50": 400, "optional": True},
+            {
+                "measurement": "fcp",
+                "weight": 0.15,
+                "p10": 900,
+                "p50": 1600,
+                "optional": True,
+            },
+            {
+                "measurement": "lcp",
+                "weight": 0.3,
+                "p10": 1200,
+                "p50": 2400,
+                "optional": True,
+            },
+            {
+                "measurement": "cls",
+                "weight": 0.15,
+                "p10": 0.1,
+                "p50": 0.25,
+                "optional": True,
+            },
+            {
+                "measurement": "ttfb",
+                "weight": 0.1,
+                "p10": 200,
+                "p50": 400,
+                "optional": True,
+            },
         ],
         "condition": {
             "op": "eq",
@@ -819,7 +870,13 @@ def test_desktop_performance_calculate_score(default_project) -> None:
                 "p50": 2400.0,
                 "optional": True,
             },
-            {"measurement": "cls", "weight": 0.0, "p10": 0.1, "p50": 0.25, "optional": False},
+            {
+                "measurement": "cls",
+                "weight": 0.0,
+                "p10": 0.1,
+                "p50": 0.25,
+                "optional": False,
+            },
             {
                 "measurement": "ttfb",
                 "weight": 0.1,
@@ -852,7 +909,13 @@ def test_desktop_performance_calculate_score(default_project) -> None:
                 "p50": 2400.0,
                 "optional": False,
             },
-            {"measurement": "cls", "weight": 0.0, "p10": 0.1, "p50": 0.25, "optional": False},
+            {
+                "measurement": "cls",
+                "weight": 0.0,
+                "p10": 0.1,
+                "p50": 0.25,
+                "optional": False,
+            },
             {
                 "measurement": "ttfb",
                 "weight": 0.1,
@@ -871,10 +934,34 @@ def test_desktop_performance_calculate_score(default_project) -> None:
     assert performance_score[3] == {
         "name": "Edge",
         "scoreComponents": [
-            {"measurement": "fcp", "weight": 0.15, "p10": 900, "p50": 1600, "optional": True},
-            {"measurement": "lcp", "weight": 0.3, "p10": 1200, "p50": 2400, "optional": True},
-            {"measurement": "cls", "weight": 0.15, "p10": 0.1, "p50": 0.25, "optional": True},
-            {"measurement": "ttfb", "weight": 0.1, "p10": 200, "p50": 400, "optional": True},
+            {
+                "measurement": "fcp",
+                "weight": 0.15,
+                "p10": 900,
+                "p50": 1600,
+                "optional": True,
+            },
+            {
+                "measurement": "lcp",
+                "weight": 0.3,
+                "p10": 1200,
+                "p50": 2400,
+                "optional": True,
+            },
+            {
+                "measurement": "cls",
+                "weight": 0.15,
+                "p10": 0.1,
+                "p50": 0.25,
+                "optional": True,
+            },
+            {
+                "measurement": "ttfb",
+                "weight": 0.1,
+                "p10": 200,
+                "p50": 400,
+                "optional": True,
+            },
         ],
         "condition": {
             "op": "eq",
@@ -886,10 +973,34 @@ def test_desktop_performance_calculate_score(default_project) -> None:
     assert performance_score[4] == {
         "name": "Opera",
         "scoreComponents": [
-            {"measurement": "fcp", "weight": 0.15, "p10": 900, "p50": 1600, "optional": True},
-            {"measurement": "lcp", "weight": 0.3, "p10": 1200, "p50": 2400, "optional": True},
-            {"measurement": "cls", "weight": 0.15, "p10": 0.1, "p50": 0.25, "optional": True},
-            {"measurement": "ttfb", "weight": 0.1, "p10": 200, "p50": 400, "optional": True},
+            {
+                "measurement": "fcp",
+                "weight": 0.15,
+                "p10": 900,
+                "p50": 1600,
+                "optional": True,
+            },
+            {
+                "measurement": "lcp",
+                "weight": 0.3,
+                "p10": 1200,
+                "p50": 2400,
+                "optional": True,
+            },
+            {
+                "measurement": "cls",
+                "weight": 0.15,
+                "p10": 0.1,
+                "p50": 0.25,
+                "optional": True,
+            },
+            {
+                "measurement": "ttfb",
+                "weight": 0.1,
+                "p10": 200,
+                "p50": 400,
+                "optional": True,
+            },
         ],
         "condition": {
             "op": "eq",
@@ -902,7 +1013,13 @@ def test_desktop_performance_calculate_score(default_project) -> None:
     assert performance_score[5] == {
         "name": "Chrome INP",
         "scoreComponents": [
-            {"measurement": "inp", "weight": 1.0, "p10": 200, "p50": 500, "optional": False},
+            {
+                "measurement": "inp",
+                "weight": 1.0,
+                "p10": 200,
+                "p50": 500,
+                "optional": False,
+            },
         ],
         "condition": {
             "op": "or",
@@ -925,16 +1042,32 @@ def test_desktop_performance_calculate_score(default_project) -> None:
     assert performance_score[6] == {
         "name": "Edge INP",
         "scoreComponents": [
-            {"measurement": "inp", "weight": 1.0, "p10": 200.0, "p50": 500.0, "optional": False},
+            {
+                "measurement": "inp",
+                "weight": 1.0,
+                "p10": 200.0,
+                "p50": 500.0,
+                "optional": False,
+            },
         ],
-        "condition": {"op": "eq", "name": "event.contexts.browser.name", "value": "Edge"},
+        "condition": {
+            "op": "eq",
+            "name": "event.contexts.browser.name",
+            "value": "Edge",
+        },
         "version": "1",
     }
 
     assert performance_score[7] == {
         "name": "Opera INP",
         "scoreComponents": [
-            {"measurement": "inp", "weight": 1.0, "p10": 200.0, "p50": 500.0, "optional": False},
+            {
+                "measurement": "inp",
+                "weight": 1.0,
+                "p10": 200.0,
+                "p50": 500.0,
+                "optional": False,
+            },
         ],
         "condition": {
             "op": "eq",
@@ -959,10 +1092,34 @@ def test_mobile_performance_calculate_score(default_project) -> None:
     assert performance_score[8] == {
         "name": "Chrome Mobile",
         "scoreComponents": [
-            {"measurement": "fcp", "weight": 0.15, "p10": 1800.0, "p50": 3000.0, "optional": True},
-            {"measurement": "lcp", "weight": 0.30, "p10": 2500.0, "p50": 4000.0, "optional": True},
-            {"measurement": "cls", "weight": 0.15, "p10": 0.1, "p50": 0.25, "optional": True},
-            {"measurement": "ttfb", "weight": 0.10, "p10": 800.0, "p50": 1800.0, "optional": True},
+            {
+                "measurement": "fcp",
+                "weight": 0.15,
+                "p10": 1800.0,
+                "p50": 3000.0,
+                "optional": True,
+            },
+            {
+                "measurement": "lcp",
+                "weight": 0.30,
+                "p10": 2500.0,
+                "p50": 4000.0,
+                "optional": True,
+            },
+            {
+                "measurement": "cls",
+                "weight": 0.15,
+                "p10": 0.1,
+                "p50": 0.25,
+                "optional": True,
+            },
+            {
+                "measurement": "ttfb",
+                "weight": 0.10,
+                "p10": 800.0,
+                "p50": 1800.0,
+                "optional": True,
+            },
         ],
         "condition": {
             "op": "eq",
@@ -974,10 +1131,34 @@ def test_mobile_performance_calculate_score(default_project) -> None:
     assert performance_score[9] == {
         "name": "Firefox Mobile",
         "scoreComponents": [
-            {"measurement": "fcp", "weight": 0.15, "p10": 1800.0, "p50": 3000.0, "optional": True},
-            {"measurement": "lcp", "weight": 0.30, "p10": 2500.0, "p50": 4000.0, "optional": True},
-            {"measurement": "cls", "weight": 0.0, "p10": 0.1, "p50": 0.25, "optional": False},
-            {"measurement": "ttfb", "weight": 0.10, "p10": 800.0, "p50": 1800.0, "optional": True},
+            {
+                "measurement": "fcp",
+                "weight": 0.15,
+                "p10": 1800.0,
+                "p50": 3000.0,
+                "optional": True,
+            },
+            {
+                "measurement": "lcp",
+                "weight": 0.30,
+                "p10": 2500.0,
+                "p50": 4000.0,
+                "optional": True,
+            },
+            {
+                "measurement": "cls",
+                "weight": 0.0,
+                "p10": 0.1,
+                "p50": 0.25,
+                "optional": False,
+            },
+            {
+                "measurement": "ttfb",
+                "weight": 0.10,
+                "p10": 800.0,
+                "p50": 1800.0,
+                "optional": True,
+            },
         ],
         "condition": {
             "op": "eq",
@@ -989,10 +1170,34 @@ def test_mobile_performance_calculate_score(default_project) -> None:
     assert performance_score[10] == {
         "name": "Safari Mobile",
         "scoreComponents": [
-            {"measurement": "fcp", "weight": 0.15, "p10": 1800.0, "p50": 3000.0, "optional": True},
-            {"measurement": "lcp", "weight": 0.0, "p10": 2500.0, "p50": 4000.0, "optional": False},
-            {"measurement": "cls", "weight": 0.0, "p10": 0.1, "p50": 0.25, "optional": False},
-            {"measurement": "ttfb", "weight": 0.10, "p10": 800.0, "p50": 1800.0, "optional": True},
+            {
+                "measurement": "fcp",
+                "weight": 0.15,
+                "p10": 1800.0,
+                "p50": 3000.0,
+                "optional": True,
+            },
+            {
+                "measurement": "lcp",
+                "weight": 0.0,
+                "p10": 2500.0,
+                "p50": 4000.0,
+                "optional": False,
+            },
+            {
+                "measurement": "cls",
+                "weight": 0.0,
+                "p10": 0.1,
+                "p50": 0.25,
+                "optional": False,
+            },
+            {
+                "measurement": "ttfb",
+                "weight": 0.10,
+                "p10": 800.0,
+                "p50": 1800.0,
+                "optional": True,
+            },
         ],
         "condition": {
             "op": "eq",
@@ -1004,10 +1209,34 @@ def test_mobile_performance_calculate_score(default_project) -> None:
     assert performance_score[11] == {
         "name": "Edge Mobile",
         "scoreComponents": [
-            {"measurement": "fcp", "weight": 0.15, "p10": 1800.0, "p50": 3000.0, "optional": True},
-            {"measurement": "lcp", "weight": 0.30, "p10": 2500.0, "p50": 4000.0, "optional": True},
-            {"measurement": "cls", "weight": 0.15, "p10": 0.1, "p50": 0.25, "optional": True},
-            {"measurement": "ttfb", "weight": 0.10, "p10": 800.0, "p50": 1800.0, "optional": True},
+            {
+                "measurement": "fcp",
+                "weight": 0.15,
+                "p10": 1800.0,
+                "p50": 3000.0,
+                "optional": True,
+            },
+            {
+                "measurement": "lcp",
+                "weight": 0.30,
+                "p10": 2500.0,
+                "p50": 4000.0,
+                "optional": True,
+            },
+            {
+                "measurement": "cls",
+                "weight": 0.15,
+                "p10": 0.1,
+                "p50": 0.25,
+                "optional": True,
+            },
+            {
+                "measurement": "ttfb",
+                "weight": 0.10,
+                "p10": 800.0,
+                "p50": 1800.0,
+                "optional": True,
+            },
         ],
         "condition": {
             "op": "eq",
@@ -1020,10 +1249,34 @@ def test_mobile_performance_calculate_score(default_project) -> None:
     assert performance_score[12] == {
         "name": "Opera Mobile",
         "scoreComponents": [
-            {"measurement": "fcp", "weight": 0.15, "p10": 1800.0, "p50": 3000.0, "optional": True},
-            {"measurement": "lcp", "weight": 0.30, "p10": 2500.0, "p50": 4000.0, "optional": True},
-            {"measurement": "cls", "weight": 0.15, "p10": 0.1, "p50": 0.25, "optional": True},
-            {"measurement": "ttfb", "weight": 0.10, "p10": 800.0, "p50": 1800.0, "optional": True},
+            {
+                "measurement": "fcp",
+                "weight": 0.15,
+                "p10": 1800.0,
+                "p50": 3000.0,
+                "optional": True,
+            },
+            {
+                "measurement": "lcp",
+                "weight": 0.30,
+                "p10": 2500.0,
+                "p50": 4000.0,
+                "optional": True,
+            },
+            {
+                "measurement": "cls",
+                "weight": 0.15,
+                "p10": 0.1,
+                "p50": 0.25,
+                "optional": True,
+            },
+            {
+                "measurement": "ttfb",
+                "weight": 0.10,
+                "p10": 800.0,
+                "p50": 1800.0,
+                "optional": True,
+            },
         ],
         "condition": {
             "op": "eq",
@@ -1035,7 +1288,13 @@ def test_mobile_performance_calculate_score(default_project) -> None:
     assert performance_score[13] == {
         "name": "Chrome Mobile INP",
         "scoreComponents": [
-            {"measurement": "inp", "weight": 1.0, "p10": 200.0, "p50": 500.0, "optional": False},
+            {
+                "measurement": "inp",
+                "weight": 1.0,
+                "p10": 200.0,
+                "p50": 500.0,
+                "optional": False,
+            },
         ],
         "condition": {
             "op": "or",
@@ -1052,7 +1311,13 @@ def test_mobile_performance_calculate_score(default_project) -> None:
     assert performance_score[14] == {
         "name": "Edge Mobile INP",
         "scoreComponents": [
-            {"measurement": "inp", "weight": 1.0, "p10": 200.0, "p50": 500.0, "optional": False},
+            {
+                "measurement": "inp",
+                "weight": 1.0,
+                "p10": 200.0,
+                "p50": 500.0,
+                "optional": False,
+            },
         ],
         "condition": {
             "op": "eq",
@@ -1064,7 +1329,13 @@ def test_mobile_performance_calculate_score(default_project) -> None:
     assert performance_score[15] == {
         "name": "Opera Mobile INP",
         "scoreComponents": [
-            {"measurement": "inp", "weight": 1.0, "p10": 200.0, "p50": 500.0, "optional": False}
+            {
+                "measurement": "inp",
+                "weight": 1.0,
+                "p10": 200.0,
+                "p50": 500.0,
+                "optional": False,
+            }
         ],
         "condition": {
             "op": "eq",


### PR DESCRIPTION
- Our logs were too big for GCP logs (which has a limit of 256kB) and were presumably discarded
- Instead, try logging only the dynamic sampling rules , and in a separate logging call, only the number of dynamic sampling rules - this should give us sufficient information about whether a given project config is well-behaved or not
- Fix wrong naming of the option dynamic_sampling_mode to sampling_mode