### PR TITLE
fix(tests): Use Sentry's TestCase class in referrer and URL tests

### DIFF
--- a/tests/sentry/utils/test_urls.py
+++ b/tests/sentry/utils/test_urls.py
@@ -1,7 +1,6 @@
-from unittest import TestCase
-
 import pytest
 
+from sentry.testutils.cases import TestCase
 from sentry.utils.urls import (
     add_params_to_url,
     non_standard_url_join,

--- a/tests/snuba/test_referrer.py
+++ b/tests/snuba/test_referrer.py
@@ -1,7 +1,7 @@
-from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
 from sentry.snuba.referrer import Referrer, validate_referrer
+from sentry.testutils.cases import TestCase
 from sentry.tsdb.base import TSDBModel
 
 


### PR DESCRIPTION
Replace `unittest.TestCase` with `sentry.testutils.cases.TestCase` in `tests/snuba/test_referrer.py` and `tests/sentry/utils/test_urls.py` to try fixing database teardown issues in CI parallel execution.

I suspect the flakiness mentioned in GH-97193, GH-97088 and GH-97191 are all due to the fact that the test class inherits from `unittest.TestCase` instead of the more common `sentry.testutils.cases.TestCase`, from which an immense majority of test classes inherit from. There must be something in the `sentry.testutils.cases.TestCase` class that prevents the database teardown error: it would be a surprising coincidence that three tests flake with the exact same error while sharing the same unusual inheritance pattern.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.