### PR TITLE
fix(explorer): More profiling fixes

### DIFF
--- a/src/sentry/seer/autofix/autofix.py
+++ b/src/sentry/seer/autofix/autofix.py
@@ -582,14 +582,29 @@ def _convert_profile_to_execution_tree(profile_data: dict) -> list[dict]:
     ):  # if there is only one thread, use that as the main thread
         main_thread_id = list(thread_metadata.keys())[0]
 
+    def _get_elapsed_since_start_ns(
+        sample: dict[str, Any], all_samples: list[dict[str, Any]]
+    ) -> int:
+        """
+        Get the elapsed time since start for a sample.
+        Handles both transaction and continuous profiles.
+        """
+        if "elapsed_since_start_ns" in sample:
+            return sample["elapsed_since_start_ns"]
+        elif "timestamp" in sample:
+            min_timestamp = min(s["timestamp"] for s in all_samples)
+            return int((sample["timestamp"] - min_timestamp) * 1e9)
+        else:
+            return 0
+
     # Sort samples chronologically
-    sorted_samples = sorted(samples, key=lambda x: x["elapsed_since_start_ns"])
+    sorted_samples = sorted(samples, key=lambda x: _get_elapsed_since_start_ns(x, samples))
 
     # Calculate average sampling interval
     if len(sorted_samples) >= 2:
         time_diffs = [
-            sorted_samples[i + 1]["elapsed_since_start_ns"]
-            - sorted_samples[i]["elapsed_since_start_ns"]
+            _get_elapsed_since_start_ns(sorted_samples[i + 1], sorted_samples)
+            - _get_elapsed_since_start_ns(sorted_samples[i], sorted_samples)
             for i in range(len(sorted_samples) - 1)
         ]
         sample_interval_ns = sum(time_diffs) / len(time_diffs) if time_diffs else 10000000
@@ -658,7 +673,7 @@ def _convert_profile_to_execution_tree(profile_data: dict) -> list[dict]:
         if str(sample["thread_id"]) != str(main_thread_id):
             continue
 
-        timestamp_ns = sample["elapsed_since_start_ns"]
+        timestamp_ns = _get_elapsed_since_start_ns(sample, sorted_samples)
         stack_frames = process_stack(sample["stack_id"])
         if not stack_frames:
             continue

--- a/src/sentry/seer/autofix/autofix.py
+++ b/src/sentry/seer/autofix/autofix.py
@@ -607,7 +607,7 @@ def _convert_profile_to_execution_tree(profile_data: dict) -> list[dict]:
             - _get_elapsed_since_start_ns(sorted_samples[i], sorted_samples)
             for i in range(len(sorted_samples) - 1)
         ]
-        sample_interval_ns = sum(time_diffs) / len(time_diffs) if time_diffs else 10000000
+        sample_interval_ns = int(sum(time_diffs) / len(time_diffs)) if time_diffs else 10000000
     else:
         sample_interval_ns = 10000000  # default 10ms
 

--- a/src/sentry/seer/explorer/index_data.py
+++ b/src/sentry/seer/explorer/index_data.py
@@ -252,7 +252,10 @@ def _fetch_profile_data(
             return None
 
         span_start = datetime.fromtimestamp(start_ts, UTC)
-        span_end = datetime.fromtimestamp(end_ts, UTC)
+        span_end = max(
+            datetime.fromtimestamp(end_ts, UTC),
+            span_start + timedelta(milliseconds=10),
+        )  # Ensure span_end is at least 10ms ahead of span_start
         try:
             project = Project.objects.get(id=project_id)
         except Project.DoesNotExist:
@@ -301,7 +304,7 @@ def _fetch_profile_data(
 
 def get_profiles_for_trace(trace_id: str, project_id: int) -> TraceProfiles | None:
     """
-    Get profiles for a given trace, with one profile per unique span/transaction.
+    Get profiles for a given trace, merging profiles with the same profile_id and is_continuous.
 
     Args:
         trace_id: The trace ID to find profiles for
@@ -356,9 +359,8 @@ def get_profiles_for_trace(trace_id: str, project_id: int) -> TraceProfiles | No
         sampling_mode="NORMAL",
     )
 
-    # Step 2: Deduplicate by span_id (one profile per span/transaction)
-    seen_spans = set()
-    unique_profiles = []
+    # Step 2: Collect all profiles and merge those with same profile_id, transaction, and is_continuous
+    all_profiles = []
 
     logger.info(
         "Span query for profiles completed",
@@ -385,9 +387,9 @@ def get_profiles_for_trace(trace_id: str, project_id: int) -> TraceProfiles | No
             },
         )
 
-        if not span_id or span_id in seen_spans:
+        if not span_id:
             logger.info(
-                "Span already seen or doesn't have an id, skipping",
+                "Span doesn't have an id, skipping",
                 extra={"span_id": span_id},
             )
             continue
@@ -413,8 +415,7 @@ def get_profiles_for_trace(trace_id: str, project_id: int) -> TraceProfiles | No
             },
         )
 
-        seen_spans.add(span_id)
-        unique_profiles.append(
+        all_profiles.append(
             {
                 "span_id": span_id,
                 "profile_id": actual_profile_id,
@@ -424,6 +425,43 @@ def get_profiles_for_trace(trace_id: str, project_id: int) -> TraceProfiles | No
                 "end_ts": end_ts,
             }
         )
+
+    # Merge profiles with same profile_id and is_continuous
+    # Use the earliest start_ts and latest end_ts for merged profiles
+    profile_groups = {}
+    for profile in all_profiles:
+        key = (profile["profile_id"], profile["is_continuous"])
+
+        if key not in profile_groups:
+            profile_groups[key] = {
+                "span_id": profile["span_id"],  # Keep the first span_id
+                "profile_id": profile["profile_id"],
+                "transaction_name": profile["transaction_name"],
+                "is_continuous": profile["is_continuous"],
+                "start_ts": profile["start_ts"],
+                "end_ts": profile["end_ts"],
+            }
+        else:
+            # Merge time ranges - use earliest start and latest end
+            existing = profile_groups[key]
+            if profile["start_ts"] and (
+                existing["start_ts"] is None or profile["start_ts"] < existing["start_ts"]
+            ):
+                existing["start_ts"] = profile["start_ts"]
+            if profile["end_ts"] and (
+                existing["end_ts"] is None or profile["end_ts"] > existing["end_ts"]
+            ):
+                existing["end_ts"] = profile["end_ts"]
+
+    unique_profiles = list(profile_groups.values())
+
+    logger.info(
+        "Merged profiles",
+        extra={
+            "original_count": len(all_profiles),
+            "merged_count": len(unique_profiles),
+        },
+    )
 
     if not unique_profiles:
         logger.info(
@@ -484,7 +522,6 @@ def get_profiles_for_trace(trace_id: str, project_id: int) -> TraceProfiles | No
                     "profile_id": profile_id,
                     "trace_id": trace_id,
                     "project_id": project_id,
-                    "raw_profile": raw_profile,
                 },
             )
 

--- a/src/sentry/seer/explorer/index_data.py
+++ b/src/sentry/seer/explorer/index_data.py
@@ -304,7 +304,7 @@ def _fetch_profile_data(
 
 def get_profiles_for_trace(trace_id: str, project_id: int) -> TraceProfiles | None:
     """
-    Get profiles for a given trace, merging profiles with the same profile_id and is_continuous.
+    Get profiles for a given trace, with one profile per unique span/transaction.
 
     Args:
         trace_id: The trace ID to find profiles for
@@ -359,15 +359,8 @@ def get_profiles_for_trace(trace_id: str, project_id: int) -> TraceProfiles | No
         sampling_mode="NORMAL",
     )
 
-    # Step 2: Collect all profiles and merge those with same profile_id, transaction, and is_continuous
+    # Step 2: Collect all profiles and merge those with same profile_id and is_continuous
     all_profiles = []
-
-    logger.info(
-        "Span query for profiles completed",
-        extra={
-            "num_rows": len(profiles_result.get("data", [])),
-        },
-    )
 
     for row in profiles_result.get("data", []):
         span_id = row.get("span_id")
@@ -405,15 +398,6 @@ def get_profiles_for_trace(trace_id: str, project_id: int) -> TraceProfiles | No
 
         # Determine if this is a continuous profile (profiler.id without profile.id)
         is_continuous = profile_id is None and profiler_id is not None
-
-        logger.info(
-            "Span is continuous and has profile",
-            extra={
-                "span_id": span_id,
-                "is_continuous": is_continuous,
-                "actual_profile_id": actual_profile_id,
-            },
-        )
 
         all_profiles.append(
             {

--- a/tests/sentry/seer/explorer/test_index_data.py
+++ b/tests/sentry/seer/explorer/test_index_data.py
@@ -348,6 +348,266 @@ class TestGetProfilesForTrace(APITransactionTestCase, SnubaTestCase, SpanTestCas
                 json_data=mock.ANY,
             )
 
+    def test_get_profiles_for_trace_merges_duplicate_profiles(self) -> None:
+        """Test that profiles with same profile_id and is_continuous are merged, regardless of transaction name."""
+        trace_id = "b" * 32  # Valid 32-char hex trace ID
+
+        profile_id = uuid.uuid4().hex  # Same profile ID for multiple spans
+        transaction_name1 = "api/duplicate/test"
+        transaction_name2 = "api/different/transaction"
+
+        # Create multiple spans with the same profile_id but different transactions
+        span1 = self.create_span(
+            {
+                "trace_id": trace_id,
+                "description": "First span with profile",
+                "sentry_tags": {"transaction": transaction_name1, "op": "http.server"},
+                "is_segment": True,
+            },
+            start_ts=self.ten_mins_ago,
+        )
+        span1.update({"profile_id": profile_id})
+
+        span2 = self.create_span(
+            {
+                "trace_id": trace_id,
+                "description": "Second span with same profile",
+                "sentry_tags": {"transaction": transaction_name1, "op": "db.query"},
+                "is_segment": False,
+            },
+            start_ts=self.ten_mins_ago + timedelta(milliseconds=100),
+        )
+        span2.update({"profile_id": profile_id})
+
+        span3 = self.create_span(
+            {
+                "trace_id": trace_id,
+                "description": "Third span with same profile",
+                "sentry_tags": {"transaction": transaction_name2, "op": "cache.get"},
+                "is_segment": False,
+            },
+            start_ts=self.ten_mins_ago + timedelta(milliseconds=200),
+        )
+        span3.update({"profile_id": profile_id})
+
+        # Create a span with different profile_id (should not be merged)
+        different_profile_id = uuid.uuid4().hex
+        span4 = self.create_span(
+            {
+                "trace_id": trace_id,
+                "description": "Different profile span",
+                "sentry_tags": {"transaction": transaction_name1, "op": "http.server"},
+                "is_segment": True,
+            },
+            start_ts=self.ten_mins_ago + timedelta(milliseconds=300),
+        )
+        span4.update({"profile_id": different_profile_id})
+
+        self.store_spans([span1, span2, span3, span4], is_eap=True)
+
+        # Mock the external profiling service calls
+        with (
+            mock.patch(
+                "sentry.seer.explorer.index_data.get_from_profiling_service"
+            ) as mock_service,
+            mock.patch(
+                "sentry.seer.explorer.index_data.convert_profile_to_execution_tree"
+            ) as mock_convert,
+        ):
+            # Mock profile service response
+            def mock_service_response(method, path, *args, **kwargs):
+                response = mock.Mock()
+                response.status = 200
+                response.data = orjson.dumps({"profile": "merged_profile_data"})
+                return response
+
+            mock_service.side_effect = mock_service_response
+
+            # Mock execution tree conversion
+            def mock_convert_response(data):
+                return [
+                    ExecutionTreeNode(
+                        function="merged_function",
+                        module="app",
+                        filename="merged.py",
+                        lineno=10,
+                        in_app=True,
+                        children=[],
+                        node_id="merged_node",
+                        sample_count=10,
+                    )
+                ]
+
+            mock_convert.side_effect = mock_convert_response
+
+            # Call the function
+            result = get_profiles_for_trace(trace_id, self.project.id)
+
+            # Verify the result structure
+            assert result is not None
+            assert result.trace_id == trace_id
+            assert result.project_id == self.project.id
+
+            # Should have 2 profiles: 1 merged for the shared profile_id and 1 for the different profile_id
+            assert len(result.profiles) == 2
+
+            # Find the profiles by profile_id
+            merged_profiles = [p for p in result.profiles if p.profile_id == profile_id]
+            different_profiles = [
+                p for p in result.profiles if p.profile_id == different_profile_id
+            ]
+
+            assert (
+                len(merged_profiles) == 1
+            ), "Should merge 3 spans with same profile_id into 1, regardless of transaction name"
+            assert len(different_profiles) == 1, "Should keep different profile_id separate"
+
+            # Verify that the profile service was called only twice (once per unique profile_id)
+            assert mock_service.call_count == 2
+
+            # Check that both unique profile_ids were processed
+            profile_ids_found = [p.profile_id for p in result.profiles]
+            assert profile_id in profile_ids_found
+            assert different_profile_id in profile_ids_found
+
+    def test_get_profiles_for_trace_merges_continuous_profiles(self) -> None:
+        """Test that continuous profiles with same profiler_id and is_continuous are merged, regardless of transaction name."""
+        trace_id = "c" * 32  # Valid 32-char hex trace ID
+
+        profiler_id = uuid.uuid4().hex  # Same profiler ID for multiple spans
+        thread_id = "67890"
+        transaction_name1 = "api/continuous/test"
+        transaction_name2 = "api/different/continuous"
+
+        # Create multiple spans with the same profiler_id but different transactions (continuous profiles)
+        spans = []
+        for i in range(3):
+            # Alternate between transaction names to test merging across transactions
+            transaction_name = transaction_name1 if i % 2 == 0 else transaction_name2
+            span = self.create_span(
+                {
+                    "trace_id": trace_id,
+                    "description": f"Continuous span {i + 1}",
+                    "sentry_tags": {
+                        "transaction": transaction_name,
+                        "op": f"continuous.{i + 1}",
+                        "profiler_id": profiler_id,
+                        "thread.id": thread_id,
+                    },
+                    "is_segment": i == 0,  # First span is transaction
+                },
+                start_ts=self.ten_mins_ago + timedelta(milliseconds=i * 100),
+            )
+            # Remove any default profile_id and set continuous profile fields
+            if "profile_id" in span:
+                del span["profile_id"]
+            span.update(
+                {
+                    "profiler_id": profiler_id,
+                    "thread_id": thread_id,
+                }
+            )
+            spans.append(span)
+
+        # Create a continuous profile span with different profiler_id (should not be merged)
+        different_profiler_id = uuid.uuid4().hex
+        span_different = self.create_span(
+            {
+                "trace_id": trace_id,
+                "description": "Different profiler continuous span",
+                "sentry_tags": {
+                    "transaction": transaction_name1,
+                    "op": "continuous.different",
+                    "profiler_id": different_profiler_id,
+                    "thread.id": thread_id,
+                },
+                "is_segment": True,
+            },
+            start_ts=self.ten_mins_ago + timedelta(milliseconds=400),
+        )
+        if "profile_id" in span_different:
+            del span_different["profile_id"]
+        span_different.update(
+            {
+                "profiler_id": different_profiler_id,
+                "thread_id": thread_id,
+            }
+        )
+        spans.append(span_different)
+
+        self.store_spans(spans, is_eap=True)
+
+        # Mock the external profiling service calls
+        with (
+            mock.patch(
+                "sentry.seer.explorer.index_data.get_from_profiling_service"
+            ) as mock_service,
+            mock.patch(
+                "sentry.seer.explorer.index_data.convert_profile_to_execution_tree"
+            ) as mock_convert,
+        ):
+            # Mock profile service response for continuous profiles (/chunks endpoint)
+            def mock_service_response(method, path, *args, **kwargs):
+                response = mock.Mock()
+                response.status = 200
+                response.data = orjson.dumps({"profile": "continuous_merged_data"})
+                return response
+
+            mock_service.side_effect = mock_service_response
+
+            # Mock execution tree conversion
+            def mock_convert_response(data):
+                return [
+                    ExecutionTreeNode(
+                        function="continuous_merged_function",
+                        module="profiler",
+                        filename="continuous.py",
+                        lineno=15,
+                        in_app=True,
+                        children=[],
+                        node_id="continuous_merged_node",
+                        sample_count=15,
+                    )
+                ]
+
+            mock_convert.side_effect = mock_convert_response
+
+            # Call the function
+            result = get_profiles_for_trace(trace_id, self.project.id)
+
+            # Verify the result structure
+            assert result is not None
+            assert result.trace_id == trace_id
+            assert result.project_id == self.project.id
+
+            # Should have 2 profiles: 1 merged for the shared profiler_id and 1 for the different profiler_id
+            assert len(result.profiles) == 2
+
+            # Find the profiles by profiler_id
+            merged_profiles = [p for p in result.profiles if p.profile_id == profiler_id]
+            different_profiles = [
+                p for p in result.profiles if p.profile_id == different_profiler_id
+            ]
+
+            assert (
+                len(merged_profiles) == 1
+            ), "Should merge 3 continuous spans with same profiler_id into 1, regardless of transaction name"
+            assert len(different_profiles) == 1, "Should keep different profiler_id separate"
+
+            # Verify that the profile service was called only twice (once per unique profiler_id)
+            # Both should use the /chunks endpoint for continuous profiles
+            assert mock_service.call_count == 2
+
+            # Check that all calls used the /chunks endpoint (continuous profiles)
+            for call in mock_service.call_args_list:
+                assert call[1]["method"] == "POST"
+                assert "/chunks" in call[1]["path"]
+
+            # Check that both unique profiler_ids were processed
+            profile_ids_found = [p.profile_id for p in result.profiles]
+            assert profiler_id in profile_ids_found
+            assert different_profiler_id in profile_ids_found
+
 
 class TestGetIssuesForTransaction(APITransactionTestCase, SpanTestCase, SharedSnubaMixin):
     @property


### PR DESCRIPTION
- Turns out continuous profile chunks name their timestamp field differently, so adding support for that (thanks Seer for the solution)
- For continuous profiles, it seems like we're spamming the profiling service. We can stop this by treating continuous spans with the same profiler as one big continuous profile, instead of trying to fetch a chunk for 1 span at a time