### PR TITLE
feat(logs): Enable the sampling param

### DIFF
--- a/src/sentry/api/endpoints/organization_trace_logs.py
+++ b/src/sentry/api/endpoints/organization_trace_logs.py
@@ -12,6 +12,7 @@ from sentry.api.utils import handle_query_errors, update_snuba_params_with_times
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.organizations.services.organization import RpcOrganization
+from sentry.search.eap import constants
 from sentry.search.eap.types import SearchResolverConfig
 from sentry.search.events.types import EventsResponse, SnubaParams
 from sentry.snuba.ourlogs import OurLogs
@@ -91,7 +92,8 @@ class OrganizationTraceLogsEndpoint(OrganizationEventsV2EndpointBase):
             limit=limit,
             referrer=Referrer.API_TRACE_VIEW_LOGS.value,
             config=SearchResolverConfig(use_aggregate_conditions=False),
-            sampling_mode=snuba_params.sampling_mode,
+            # Since we're getting all logs for a given trace we always want highest accuracy
+            sampling_mode=constants.SAMPLING_MODE_HIGHEST_ACCURACY,
         )
         return results
 

--- a/src/sentry/api/endpoints/organization_trace_logs.py
+++ b/src/sentry/api/endpoints/organization_trace_logs.py
@@ -91,6 +91,7 @@ class OrganizationTraceLogsEndpoint(OrganizationEventsV2EndpointBase):
             limit=limit,
             referrer=Referrer.API_TRACE_VIEW_LOGS.value,
             config=SearchResolverConfig(use_aggregate_conditions=False),
+            sampling_mode=snuba_params.sampling_mode,
         )
         return results
 

--- a/src/sentry/search/eap/constants.py
+++ b/src/sentry/search/eap/constants.py
@@ -160,11 +160,12 @@ RESPONSE_CODE_MAP = {
     5: ["500", "501", "502", "503", "504", "505", "506", "507", "508", "509", "510", "511"],
 }
 
+SAMPLING_MODE_HIGHEST_ACCURACY: SAMPLING_MODES = "HIGHEST_ACCURACY"
 SAMPLING_MODE_MAP: dict[SAMPLING_MODES, DownsampledStorageConfig.Mode.ValueType] = {
     "BEST_EFFORT": DownsampledStorageConfig.MODE_BEST_EFFORT,
     "PREFLIGHT": DownsampledStorageConfig.MODE_PREFLIGHT,
     "NORMAL": DownsampledStorageConfig.MODE_NORMAL,
-    "HIGHEST_ACCURACY": DownsampledStorageConfig.MODE_HIGHEST_ACCURACY,
+    SAMPLING_MODE_HIGHEST_ACCURACY: DownsampledStorageConfig.MODE_HIGHEST_ACCURACY,
 }
 
 ARITHMETIC_OPERATOR_MAP: dict[str, Column.BinaryFormula.Op.ValueType] = {

--- a/src/sentry/snuba/ourlogs.py
+++ b/src/sentry/snuba/ourlogs.py
@@ -55,7 +55,7 @@ class OurLogs(rpc_dataset_common.RPCBase):
                 offset=offset,
                 limit=limit,
                 referrer=referrer,
-                sampling_mode=None,
+                sampling_mode=sampling_mode,
                 resolver=search_resolver
                 or cls.get_resolver(
                     params=params,
@@ -87,7 +87,7 @@ class OurLogs(rpc_dataset_common.RPCBase):
             y_axes=y_axes,
             groupby=[],
             referrer=referrer,
-            sampling_mode=None,
+            sampling_mode=sampling_mode,
         )
 
         """Run the query"""


### PR DESCRIPTION
- Currently logs always passes None to sampling to snuba, which allows them to do the default parameter
- This updates it so the sampling param is passed on