### PR TITLE
ref(trace): search in all nodes

### DIFF
--- a/static/app/views/performance/newTraceDetails/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.tsx
@@ -251,7 +251,10 @@ export function Trace({
       treeRef.current.expand(node, value);
       rerenderRef.current();
 
-      if (traceStateRef.current.search.query) {
+      // Only trigger search if we are expandign the tree, else if the user is collapsing a part
+      // of the subtree that matches a query, it will get re-expanded by and undo the user action.
+      const shouldTriggerSearch = traceStateRef.current.search.query && value;
+      if (shouldTriggerSearch) {
         // If a query exists, we want to reapply the search after expanding
         // so that new nodes are also highlighted if they match a query
         onTraceSearch(traceStateRef.current.search.query, node, 'persist');

--- a/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
+++ b/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
@@ -233,6 +233,11 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
           return;
         }
 
+        // Ensure that all matches in the tree are visible.
+        for (const match of matches) {
+          TraceTree.EnforceVisibility(props.tree, match.value);
+        }
+
         if (activeNode && behavior === 'persist') {
           traceDispatch({
             type: 'set results',


### PR DESCRIPTION
Alternative implementation to https://github.com/getsentry/sentry/pull/97197/

We can forEach to collect the nodes, and then search over them as opposed to only matching on the visible list.