### PR TITLE
fix(preprod): update insight text color

### DIFF
--- a/static/app/views/preprod/main/insights/appSizeInsights.tsx
+++ b/static/app/views/preprod/main/insights/appSizeInsights.tsx
@@ -70,7 +70,7 @@ export function AppSizeInsights({processedInsights}: AppSizeInsightsProps) {
             height="22px"
             padding="xs sm"
           >
-            <Text variant="primary" size="sm" bold>
+            <Text variant="accent" size="sm" bold>
               {insight.name}
             </Text>
             <Flex align="center" gap="sm">


### PR DESCRIPTION
Simple fix, was using the wrong text color for this:

<img width="267" height="194" alt="Screenshot 2025-08-06 at 11 58 50 AM" src="https://github.com/user-attachments/assets/f7915232-7521-4896-a760-2d368a43b962" />
