### PR TITLE
chore(aci): log project ids that were pushed to buffer list

### DIFF
--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -1,5 +1,6 @@
 from dataclasses import asdict, dataclass, replace
 from datetime import datetime
+from datetime import timezone as tz
 from enum import StrEnum
 from typing import DefaultDict
 
@@ -130,14 +131,17 @@ def enqueue_workflows(
     )
 
     buffer_project_ids = buffer.backend.get_sorted_set(
-        WORKFLOW_ENGINE_BUFFER_LIST_KEY, min=0, max=timezone.now().timestamp()
+        WORKFLOW_ENGINE_BUFFER_LIST_KEY, min=0, max=datetime.now(tz=tz.utc).timestamp()
+    )
+    log_str = ", ".join(
+        f"{project_id}: {timestamp}" for project_id, timestamp in buffer_project_ids
     )
 
     logger.debug(
         "workflow_engine.workflows.enqueued",
         extra={
             "project_to_workflow": project_to_workflow,
-            "buffer_project_ids": sorted([project_id for project_id, _ in buffer_project_ids]),
+            "buffer_project_ids": log_str,
         },
     )
 

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -124,13 +124,21 @@ def enqueue_workflows(
         project_to_workflow[project_id] = sorted({item.workflow.id for item in queue_items})
 
     sentry_sdk.set_tag("delayed_workflow_items", items)
-    logger.debug(
-        "workflow_engine.workflows.enqueued",
-        extra={"project_to_workflow": project_to_workflow},
-    )
 
     buffer.backend.push_to_sorted_set(
         key=WORKFLOW_ENGINE_BUFFER_LIST_KEY, value=list(items_by_project_id.keys())
+    )
+
+    buffer_project_ids = buffer.backend.get_sorted_set(
+        WORKFLOW_ENGINE_BUFFER_LIST_KEY, min=0, max=timezone.now().timestamp()
+    )
+
+    logger.debug(
+        "workflow_engine.workflows.enqueued",
+        extra={
+            "project_to_workflow": project_to_workflow,
+            "buffer_project_ids": sorted([project_id for project_id, _ in buffer_project_ids]),
+        },
     )
 
 


### PR DESCRIPTION
We are logging what we pull out of the buffer in delayed processing and it seems to look like some project ids aren't being added to the buffer list even though we are running the enqueuing logic. Also add a log on the other side to see if we're actually putting the project id in.