### PR TITLE
Update token colors on summary.tsx

### DIFF
--- a/static/app/components/codecov/summary.tsx
+++ b/static/app/components/codecov/summary.tsx
@@ -38,7 +38,7 @@ export function useCreateSummaryFilterLink(filterBy: SummaryFilterKey) {
 const StyledSummaryEntryLabel = styled('span')`
   font-size: ${p => p.theme.fontSize.lg};
   font-weight: ${p => p.theme.fontWeight.bold};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 
 interface SummaryEntryLabelProps extends React.ComponentProps<typeof Hovercard> {
@@ -67,7 +67,7 @@ export const SummaryEntryValue = styled('span')`
 
 const StyledSummaryEntryValueLink = styled('span')`
   font-variant-numeric: tabular-nums;
-  color: ${p => p.theme.blue300};
+  color: ${p => p.theme.linkColor};
   font-size: 2.25rem;
 
   /* This stops the text from jumping when becoming bold */


### PR DESCRIPTION
Update <StyledSummaryEntryLabel> text and link color in dark mode Chonk.
<img width="1237" height="293" alt="Screenshot 2025-08-06 at 10 32 32 AM" src="https://github.com/user-attachments/assets/ebd8b046-755b-4c5f-8513-db6cc7744067" />

<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
