### PR TITLE
feat(issues): Add flag to enable workflow notifications for a group type

### DIFF
--- a/src/sentry/incidents/grouptype.py
+++ b/src/sentry/incidents/grouptype.py
@@ -332,6 +332,7 @@ class MetricIssue(GroupType):
     enable_auto_resolve = False
     enable_escalation_detection = False
     enable_status_change_workflow_notifications = False
+    enable_workflow_notifications = False
     detector_settings = DetectorSettings(
         handler=MetricIssueDetectorHandler,
         validator=MetricIssueDetectorValidator,

--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -214,6 +214,9 @@ class GroupType:
     # Controls whether status change (i.e. resolved, regressed) workflow notifications are enabled.
     # Defaults to true to maintain the default workflow notification behavior as it exists for error group types.
     enable_status_change_workflow_notifications: bool = True
+    # Controls whether _all_ workflow notification types are enabled (e.g. assignment).
+    # Useful when the group type is still in development
+    enable_workflow_notifications = True
 
     def __init_subclass__(cls: type[GroupType], **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)

--- a/src/sentry/models/activity.py
+++ b/src/sentry/models/activity.py
@@ -199,13 +199,18 @@ class Activity(Model):
         if self.group:
             group_type = get_group_type_by_type_id(self.group.type)
             has_status_change_notifications = group_type.enable_status_change_workflow_notifications
+            has_workflow_notifications = group_type.enable_workflow_notifications
             is_status_change = self.type in {
                 activity.value for activity in STATUS_CHANGE_ACTIVITY_TYPES
             }
 
             # Skip sending the activity notification if the group type does not
             # support status change workflow notifications
-            if is_status_change and not has_status_change_notifications:
+            if (
+                is_status_change
+                and not has_status_change_notifications
+                or not has_workflow_notifications
+            ):
                 return
 
         activity.send_activity_notifications.delay(self.id)


### PR DESCRIPTION
Add a flag to group types to disable all workflow notifications. We ran into an issue where customers were receiving assignment notifications for metric issues when the feature isn't fully released yet (the issues are created but are not searchable / otherwise findable by users). 