### PR TITLE
fix(nav): Increase collapsed sidebar open delay on hover

### DIFF
--- a/static/app/views/nav/constants.tsx
+++ b/static/app/views/nav/constants.tsx
@@ -7,8 +7,7 @@ export const SECONDARY_SIDEBAR_WIDTH = 190;
 export const SECONDARY_SIDEBAR_MIN_WIDTH = 150;
 export const SECONDARY_SIDEBAR_MAX_WIDTH = 450;
 
-// Slightly delay closing the nav to prevent accidental dismissal
 export const NAV_SIDEBAR_COLLAPSE_DELAY_MS = 200;
-export const NAV_SIDEBAR_OPEN_DELAY_MS = 150;
+export const NAV_SIDEBAR_OPEN_DELAY_MS = 250;
 export const NAV_SIDEBAR_PREVIEW_DELAY_MS = 300;
 export const NAV_SIDEBAR_RESET_DELAY_MS = 300;


### PR DESCRIPTION
Adjusts the hover interaction for the collapsed nav sidebar after some feedback that it was too eager to open. Increased the delay by 100ms. This still felt reasonable and not too sluggish while I was testing.