### PR TITLE
fix(access-logs): rate limit type not correctly set to snuba

### DIFF
--- a/src/sentry/middleware/access_log.py
+++ b/src/sentry/middleware/access_log.py
@@ -57,7 +57,7 @@ def _get_rate_limit_stats_dict(request: Request) -> dict[str, str]:
     rate_limit_type = "DNE"
     if rate_limit_metadata:
         rate_limit_type = str(getattr(rate_limit_metadata, "rate_limit_type", "DNE"))
-    elif snuba_rate_limit_metadata:
+    if snuba_rate_limit_metadata:
         rate_limit_type = "RateLimitType.SNUBA"
 
     rate_limit_stats = {

--- a/tests/sentry/middleware/test_access_log_middleware.py
+++ b/tests/sentry/middleware/test_access_log_middleware.py
@@ -16,7 +16,7 @@ from sentry.ratelimits.config import RateLimitConfig
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import all_silo_test, assume_test_silo_mode, control_silo_test
-from sentry.types.ratelimit import RateLimit, RateLimitCategory
+from sentry.types.ratelimit import RateLimit, RateLimitCategory, RateLimitMeta, RateLimitType
 from sentry.utils.snuba import RateLimitExceeded
 
 
@@ -38,6 +38,22 @@ class SnubaRateLimitedEndpoint(Endpoint):
     permission_classes = (AllowAny,)
 
     def get(self, request):
+
+        # Rate limit middleware will set metadata to indicate the request is not limited by the endpoint itself
+        request._request.rate_limit_metadata = RateLimitMeta(
+            rate_limit_type=RateLimitType.NOT_LIMITED,
+            concurrent_limit=123,
+            concurrent_requests=1,
+            reset_time=123,
+            group="test_group",
+            limit=123,
+            window=123,
+            current=1,
+            remaining=122,
+        )
+
+        # However, snuba's 429 will be caught by the custom handler and raise an exception
+        # with the snuba metadata
         raise RateLimitExceeded(
             "Query on could not be run due to allocation policies, ... 'rejection_threshold': 40, 'quota_used': 41, ...",
             policy="ConcurrentRateLimitAllocationPolicy",
@@ -190,12 +206,12 @@ class TestAccessLogSnubaRateLimited(LogCaptureAPITestCase):
         assert self.captured_logs[0].rate_limit_type == "RateLimitType.SNUBA"
         assert self.captured_logs[0].rate_limited == "True"
 
-        # All the types from the standard rate limit metadata should not be set
-        assert self.captured_logs[0].remaining == "None"
-        assert self.captured_logs[0].concurrent_limit == "None"
-        assert self.captured_logs[0].concurrent_requests == "None"
-        assert self.captured_logs[0].limit == "None"
-        assert self.captured_logs[0].reset_time == "None"
+        # All the types from the standard rate limit metadata should be set
+        assert self.captured_logs[0].remaining == "122"
+        assert self.captured_logs[0].concurrent_limit == "123"
+        assert self.captured_logs[0].concurrent_requests == "1"
+        assert self.captured_logs[0].limit == "123"
+        assert self.captured_logs[0].reset_time == "123"
 
         # Snuba rate limit specific fields should be set
         assert self.captured_logs[0].snuba_policy == "ConcurrentRateLimitAllocationPolicy"


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/97199. We're now seeing logs with snuba info (see [here](https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Alabels.name%3D%22sentry.access.api%22%0A-jsonPayload.snuba_policy%3D%22None%22%0A--%20jsonPayload.response%3D%22429%22;summaryFields=jsonPayload%252Fsnuba_policy:true:32:beginning;cursorTimestamp=2025-08-06T15:30:30.107622095Z;duration=PT6H?project=internal-sentry&inv=1&invt=Ab4xUQ&rapt=AEjHL4NivrJYEIhr36atfUalUZIcwCYZjvYww0eGEMey3GYzVzSRQyr1DFLozgYmc-quqALJKFUH-jXq5G72I_WT6iWlAjpbgdwqwr9qw6IsGJn43ToXwto&pli=1)), but those logs have a `rate_limit_type` of `RateLimitType.NOT_LIMITED` rather than `RateLimitType.SNUBA`. This is because rate limit metadata is returned on all endpoints implementing rate limiting, even when the request is not limited, when access logs assumed previously that it would not be returned at all.