### PR TITLE
fix(alerts): Update available filter keys when switching projects

### DIFF
--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
@@ -137,16 +137,14 @@ class RuleConditionsForm extends PureComponent<Props, State> {
   }
 
   componentDidUpdate(prevProps: Props) {
-    if (
-      prevProps.project.id === this.props.project.id &&
-      prevProps.tags === this.props.tags
-    ) {
-      return;
+    if (prevProps.tags !== this.props.tags) {
+      const filterKeys = this.getFilterKeys();
+      this.setState({filterKeys});
     }
 
-    this.fetchData();
-    const filterKeys = this.getFilterKeys();
-    this.setState({filterKeys});
+    if (prevProps.project.id !== this.props.project.id) {
+      this.fetchData();
+    }
   }
 
   getFilterKeys = () => {

--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
@@ -137,11 +137,16 @@ class RuleConditionsForm extends PureComponent<Props, State> {
   }
 
   componentDidUpdate(prevProps: Props) {
-    if (prevProps.project.id === this.props.project.id) {
+    if (
+      prevProps.project.id === this.props.project.id &&
+      prevProps.tags === this.props.tags
+    ) {
       return;
     }
 
     this.fetchData();
+    const filterKeys = this.getFilterKeys();
+    this.setState({filterKeys});
   }
 
   getFilterKeys = () => {

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -201,13 +201,6 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
     fetchOrganizationTags(this.api, organization.slug, [project.id]);
   }
 
-  componentDidUpdate(prevProps: Props) {
-    const {project} = this.state;
-    if (prevProps.project.id !== project.id) {
-      fetchOrganizationTags(this.api, this.props.organization.slug, [project.id]);
-    }
-  }
-
   componentWillUnmount() {
     window.clearTimeout(this.pollingTimeout);
   }
@@ -603,6 +596,9 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
         },
         () => {
           this.reloadData();
+          fetchOrganizationTags(this.api, this.props.organization.slug, [
+            this.state.project.id,
+          ]);
         }
       );
     }

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -201,6 +201,13 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
     fetchOrganizationTags(this.api, organization.slug, [project.id]);
   }
 
+  componentDidUpdate(prevProps: Props) {
+    const {project} = this.state;
+    if (prevProps.project.id !== project.id) {
+      fetchOrganizationTags(this.api, this.props.organization.slug, [project.id]);
+    }
+  }
+
   componentWillUnmount() {
     window.clearTimeout(this.pollingTimeout);
   }


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/96982

If you create a new metric alert and then change projects, the search bar doesn't update the autocomplete for the new set of tags. That's because the component wasn't refetching the organization tags.

There are more changes that would make the searching experience better, but that will come when we release the new monitors UI.