### PR TITLE
feat(aci): Add disabled text to list views and properly apply system created icon

### DIFF
--- a/static/app/components/workflowEngine/gridCell/automationTitleCell.tsx
+++ b/static/app/components/workflowEngine/gridCell/automationTitleCell.tsx
@@ -15,6 +15,7 @@ export default function AutomationTitleCell({automation}: Props) {
       name={automation.name}
       link={makeAutomationDetailsPathname(organization.slug, automation.id)}
       systemCreated={!automation.createdBy}
+      disabled={!automation.enabled}
     />
   );
 }

--- a/static/app/components/workflowEngine/gridCell/automationTitleCell.tsx
+++ b/static/app/components/workflowEngine/gridCell/automationTitleCell.tsx
@@ -14,7 +14,6 @@ export default function AutomationTitleCell({automation}: Props) {
     <TitleCell
       name={automation.name}
       link={makeAutomationDetailsPathname(organization.slug, automation.id)}
-      systemCreated={!automation.createdBy}
       disabled={!automation.enabled}
     />
   );

--- a/static/app/components/workflowEngine/gridCell/titleCell.tsx
+++ b/static/app/components/workflowEngine/gridCell/titleCell.tsx
@@ -23,8 +23,8 @@ export function TitleCell({
   className,
 }: TitleCellProps) {
   return (
-    <TitleWrapper to={link} disabled={disabled} className={className}>
-      <Name disabled={disabled}>
+    <TitleWrapper to={link} className={className}>
+      <Name>
         <NameText>{name}</NameText>
         {systemCreated && <CreatedBySentryIcon size="xs" color="subText" />}
         {disabled && <span>&mdash; Disabled</span>}
@@ -34,7 +34,7 @@ export function TitleCell({
   );
 }
 
-const Name = styled('div')<{disabled: boolean}>`
+const Name = styled('div')`
   color: ${p => p.theme.textColor};
   display: flex;
   align-items: center;
@@ -51,7 +51,7 @@ const CreatedBySentryIcon = styled(IconSentry)`
   flex-shrink: 0;
 `;
 
-const TitleWrapper = styled(Link)<{disabled: boolean}>`
+const TitleWrapper = styled(Link)`
   display: flex;
   flex-direction: column;
   gap: ${space(0.5)};

--- a/static/app/views/detectors/components/detectorLink.tsx
+++ b/static/app/views/detectors/components/detectorLink.tsx
@@ -23,6 +23,7 @@ import {unreachable} from 'sentry/utils/unreachable';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjectFromId from 'sentry/utils/useProjectFromId';
 import {makeMonitorDetailsPathname} from 'sentry/views/detectors/pathnames';
+import {detectorTypeIsUserCreateable} from 'sentry/views/detectors/utils/detectorTypeConfig';
 import {getMetricDetectorSuffix} from 'sentry/views/detectors/utils/metricDetectorSuffix';
 
 type DetectorLinkProps = {
@@ -183,7 +184,8 @@ export function DetectorLink({detector, className}: DetectorLinkProps) {
       className={className}
       name={detector.name}
       link={makeMonitorDetailsPathname(org.slug, detector.id)}
-      systemCreated={!detector.createdBy}
+      systemCreated={!detectorTypeIsUserCreateable(detector.type)}
+      disabled={!detector.enabled}
       details={
         <Fragment>
           {project && (


### PR DESCRIPTION
Disabled monitors/automations weren't showing the `- disabled` text.

Also, we can now avoid the sentry icon being applied to some old converted metric alerts by using the `detectorTypeIsUserCreateable` function.

<img width="986" height="436" alt="CleanShot 2025-08-06 at 12 49 49@2x" src="https://github.com/user-attachments/assets/764a0598-308e-4163-be23-bb8206ecb1f3" />
