### PR TITLE
feat(aci): add bulk actions to automation list table

### DIFF
--- a/static/app/components/workflowEngine/gridCell/automationTitleCell.tsx
+++ b/static/app/components/workflowEngine/gridCell/automationTitleCell.tsx
@@ -14,6 +14,7 @@ export default function AutomationTitleCell({automation}: Props) {
     <TitleCell
       name={automation.name}
       link={makeAutomationDetailsPathname(organization.slug, automation.id)}
+      systemCreated={!automation.createdBy}
       disabled={!automation.enabled}
     />
   );

--- a/static/app/views/automations/components/automationListTable/actions.tsx
+++ b/static/app/views/automations/components/automationListTable/actions.tsx
@@ -47,7 +47,7 @@ export function AutomationsTableActions({
 
   const {mutateAsync: deleteAutomations, isPending: isDeleting} =
     useDeleteAutomationsMutation();
-  const {mutate: updateAutomations, isPending: isUpdating} =
+  const {mutateAsync: updateAutomations, isPending: isUpdating} =
     useUpdateAutomationsMutation();
 
   const getConfirmMessage = useCallback(
@@ -85,8 +85,6 @@ export function AutomationsTableActions({
           } else {
             updateAutomations({enabled, ids: Array.from(selected)});
           }
-        },
-        onClose: () => {
           togglePageSelected(false);
         },
       });
@@ -113,8 +111,6 @@ export function AutomationsTableActions({
         } else {
           deleteAutomations({ids: Array.from(selected)});
         }
-      },
-      onClose: () => {
         togglePageSelected(false);
       },
     });

--- a/static/app/views/automations/components/automationListTable/actions.tsx
+++ b/static/app/views/automations/components/automationListTable/actions.tsx
@@ -173,12 +173,12 @@ export function AutomationsTableActions({
             ) : (
               <Fragment>
                 {tn(
-                  '%s issue on this page selected.',
-                  '%s issues on this page selected.',
+                  '%s automation on this page selected.',
+                  '%s automations on this page selected.',
                   selected.size
                 )}
                 <a onClick={() => setAllInQuerySelected(true)}>
-                  {tct('Select all [count] issues that match this search query.', {
+                  {tct('Select all [count] automations that match this search query.', {
                     count: queryCount,
                   })}
                 </a>

--- a/static/app/views/automations/components/automationListTable/actions.tsx
+++ b/static/app/views/automations/components/automationListTable/actions.tsx
@@ -1,0 +1,209 @@
+import {Fragment, useCallback, useState} from 'react';
+import styled from '@emotion/styled';
+
+import {openConfirmModal} from 'sentry/components/confirm';
+import {Alert} from 'sentry/components/core/alert';
+import {Button} from 'sentry/components/core/button';
+import {Checkbox} from 'sentry/components/core/checkbox';
+import {Flex} from 'sentry/components/core/layout';
+import {SimpleTable} from 'sentry/components/tables/simpleTable';
+import {t, tct, tn} from 'sentry/locale';
+import {decodeScalar} from 'sentry/utils/queryString';
+import useLocationQuery from 'sentry/utils/url/useLocationQuery';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import {
+  useDeleteAutomationsMutation,
+  useUpdateAutomationsMutation,
+} from 'sentry/views/automations/hooks';
+
+interface AutomationsTableActionsProps {
+  allResultsVisible: boolean;
+  canDisable: boolean;
+  canEnable: boolean;
+  pageSelected: boolean;
+  queryCount: string;
+  selected: Set<string>;
+  togglePageSelected: (pageSelected: boolean) => void;
+}
+
+export function AutomationsTableActions({
+  selected,
+  pageSelected,
+  togglePageSelected,
+  queryCount,
+  allResultsVisible,
+  canEnable,
+  canDisable,
+}: AutomationsTableActionsProps) {
+  const [allInQuerySelected, setAllInQuerySelected] = useState(false);
+  const anySelected = selected.size > 0;
+
+  const {selection} = usePageFilters();
+  const {query} = useLocationQuery({
+    fields: {
+      query: decodeScalar,
+    },
+  });
+
+  const {mutateAsync: deleteAutomations, isPending: isDeleting} =
+    useDeleteAutomationsMutation();
+  const {mutate: updateAutomations, isPending: isUpdating} =
+    useUpdateAutomationsMutation();
+
+  const getConfirmMessage = useCallback(
+    (action: string) => {
+      if (allInQuerySelected) {
+        return tct(
+          'Are you sure you want to [action] all [queryCount] automations that match the search?',
+          {
+            action,
+            queryCount,
+          }
+        );
+      }
+      return tn(
+        // Use sprintf argument swapping since the number value must come
+        // first. See https://github.com/alexei/sprintf.js#argument-swapping
+        `Are you sure you want to %2$s this %s automation?`,
+        `Are you sure you want to %2$s these %s automations?`,
+        selected.size,
+        action
+      );
+    },
+    [allInQuerySelected, queryCount, selected.size]
+  );
+
+  const handleUpdate = useCallback(
+    ({enabled}: {enabled: boolean}) => {
+      openConfirmModal({
+        message: getConfirmMessage(enabled ? t('enable') : t('disable')),
+        confirmText: enabled ? t('Enable') : t('Disable'),
+        priority: 'danger',
+        onConfirm: () => {
+          if (allInQuerySelected) {
+            updateAutomations({enabled, query, projects: selection.projects});
+          } else {
+            updateAutomations({enabled, ids: Array.from(selected)});
+          }
+        },
+        onClose: () => {
+          togglePageSelected(false);
+        },
+      });
+    },
+    [
+      selected,
+      allInQuerySelected,
+      updateAutomations,
+      getConfirmMessage,
+      togglePageSelected,
+      selection.projects,
+      query,
+    ]
+  );
+
+  const handleDelete = useCallback(() => {
+    openConfirmModal({
+      message: getConfirmMessage(t('delete')),
+      confirmText: t('Delete'),
+      priority: 'danger',
+      onConfirm: () => {
+        if (allInQuerySelected) {
+          deleteAutomations({query, projects: selection.projects});
+        } else {
+          deleteAutomations({ids: Array.from(selected)});
+        }
+      },
+      onClose: () => {
+        togglePageSelected(false);
+      },
+    });
+  }, [
+    selected,
+    allInQuerySelected,
+    deleteAutomations,
+    getConfirmMessage,
+    togglePageSelected,
+    selection.projects,
+    query,
+  ]);
+
+  return (
+    <Fragment>
+      <SimpleTable.Header>
+        <ActionsBarWrapper>
+          <Checkbox
+            checked={pageSelected || (anySelected ? 'indeterminate' : false)}
+            onChange={s => {
+              togglePageSelected(s.target.checked);
+              setAllInQuerySelected(false);
+            }}
+          />
+          {canEnable && (
+            <Button
+              size="xs"
+              onClick={() => handleUpdate({enabled: true})}
+              disabled={isUpdating}
+            >
+              {t('Enable')}
+            </Button>
+          )}
+          {canDisable && (
+            <Button
+              size="xs"
+              onClick={() => handleUpdate({enabled: false})}
+              disabled={isUpdating}
+            >
+              {t('Disable')}
+            </Button>
+          )}
+          <Button
+            size="xs"
+            priority="danger"
+            onClick={handleDelete}
+            disabled={isDeleting}
+          >
+            {t('Delete')}
+          </Button>
+        </ActionsBarWrapper>
+      </SimpleTable.Header>
+      {pageSelected && !allResultsVisible && (
+        <FullWidthAlert type="warning" showIcon={false}>
+          <Flex justify="center" wrap="wrap" gap="md">
+            {allInQuerySelected ? (
+              tct('Selected all [count] automations that match this search query.', {
+                count: queryCount,
+              })
+            ) : (
+              <Fragment>
+                {tn(
+                  '%s issue on this page selected.',
+                  '%s issues on this page selected.',
+                  selected.size
+                )}
+                <a onClick={() => setAllInQuerySelected(true)}>
+                  {tct('Select all [count] issues that match this search query.', {
+                    count: queryCount,
+                  })}
+                </a>
+              </Fragment>
+            )}
+          </Flex>
+        </FullWidthAlert>
+      )}
+    </Fragment>
+  );
+}
+
+const FullWidthAlert = styled(Alert)`
+  grid-column: 1 / -1;
+`;
+
+const ActionsBarWrapper = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${p => p.theme.space.md};
+  padding: 0 ${p => p.theme.space.xl};
+  width: 100%;
+  grid-column: 1 / -1;
+`;

--- a/static/app/views/automations/components/automationListTable/index.tsx
+++ b/static/app/views/automations/components/automationListTable/index.tsx
@@ -1,6 +1,7 @@
 import {type ComponentProps, useCallback, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 
+import {hasEveryAccess} from 'sentry/components/acl/access';
 import LoadingError from 'sentry/components/loadingError';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {t} from 'sentry/locale';
@@ -9,6 +10,7 @@ import type {Automation} from 'sentry/types/workflowEngine/automations';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
+import useOrganization from 'sentry/utils/useOrganization';
 import {AutomationsTableActions} from 'sentry/views/automations/components/automationListTable/actions';
 import {
   AutomationListRow,
@@ -79,6 +81,9 @@ function AutomationListTable({
   queryCount,
   allResultsVisible,
 }: AutomationListTableProps) {
+  const organization = useOrganization();
+  const canEditAutomations = hasEveryAccess(['alerts:write'], {organization});
+
   const [selected, setSelected] = useState(new Set<string>());
 
   const togglePageSelected = (pageSelected: boolean) => {
@@ -89,7 +94,6 @@ function AutomationListTable({
     setSelected(newSelected);
   };
   const automationIds = new Set(automations.map(a => a.id));
-
   const pageSelected = automationIds.difference(selected).size === 0;
 
   const canEnable = useMemo(
@@ -118,7 +122,7 @@ function AutomationListTable({
 
   return (
     <AutomationsSimpleTable>
-      {selected.size === 0 ? (
+      {canEditAutomations && selected.size === 0 ? (
         <SimpleTable.Header key="header">
           <HeaderCell sort={sort} sortKey="name">
             <NamePadding>{t('Name')}</NamePadding>

--- a/static/app/views/automations/components/automationListTable/index.tsx
+++ b/static/app/views/automations/components/automationListTable/index.tsx
@@ -179,7 +179,7 @@ function AutomationListTable({
 }
 
 const AutomationsSimpleTable = styled(SimpleTable)`
-  grid-template-columns: 0.25fr 1fr;
+  grid-template-columns: 1fr;
 
   margin-bottom: ${space(2)};
 

--- a/static/app/views/automations/components/automationListTable/index.tsx
+++ b/static/app/views/automations/components/automationListTable/index.tsx
@@ -1,4 +1,4 @@
-import type {ComponentProps} from 'react';
+import {type ComponentProps, useCallback, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 
 import LoadingError from 'sentry/components/loadingError';
@@ -9,6 +9,7 @@ import type {Automation} from 'sentry/types/workflowEngine/automations';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
+import {AutomationsTableActions} from 'sentry/views/automations/components/automationListTable/actions';
 import {
   AutomationListRow,
   AutomationListRowSkeleton,
@@ -16,10 +17,12 @@ import {
 import {AUTOMATION_LIST_PAGE_LIMIT} from 'sentry/views/automations/constants';
 
 type AutomationListTableProps = {
+  allResultsVisible: boolean;
   automations: Automation[];
   isError: boolean;
   isPending: boolean;
   isSuccess: boolean;
+  queryCount: string;
   sort: Sort | undefined;
 };
 
@@ -37,6 +40,7 @@ function HeaderCell({
 }: {
   children: React.ReactNode;
   sort: Sort | undefined;
+  className?: string;
   divider?: boolean;
   sortKey?: string;
 } & Omit<ComponentProps<typeof SimpleTable.HeaderCell>, 'sort'>) {
@@ -72,30 +76,86 @@ function AutomationListTable({
   isError,
   isSuccess,
   sort,
+  queryCount,
+  allResultsVisible,
 }: AutomationListTableProps) {
+  const [selected, setSelected] = useState(new Set<string>());
+
+  const togglePageSelected = (pageSelected: boolean) => {
+    const newSelected = new Set<string>();
+    if (pageSelected) {
+      automations.forEach(automation => newSelected.add(automation.id));
+    }
+    setSelected(newSelected);
+  };
+  const automationIds = new Set(automations.map(a => a.id));
+
+  const pageSelected = automationIds.difference(selected).size === 0;
+
+  const canEnable = useMemo(
+    () =>
+      automations.some(automation => selected.has(automation.id) && !automation.enabled),
+    [automations, selected]
+  );
+  const canDisable = useMemo(
+    () =>
+      automations.some(automation => selected.has(automation.id) && automation.enabled),
+    [automations, selected]
+  );
+
+  const handleSelect = useCallback(
+    (id: string) => {
+      const newSelected = new Set(selected);
+      if (newSelected.has(id)) {
+        newSelected.delete(id);
+      } else {
+        newSelected.add(id);
+      }
+      setSelected(newSelected);
+    },
+    [selected]
+  );
+
   return (
     <AutomationsSimpleTable>
-      <SimpleTable.Header>
-        <HeaderCell sort={sort} sortKey="name">
-          {t('Name')}
-        </HeaderCell>
-        <HeaderCell data-column-name="last-triggered" sort={sort} sortKey="lastTriggered">
-          {t('Last Triggered')}
-        </HeaderCell>
-        <HeaderCell data-column-name="action" sort={sort} sortKey="actions">
-          {t('Actions')}
-        </HeaderCell>
-        <HeaderCell data-column-name="projects" sort={sort}>
-          {t('Projects')}
-        </HeaderCell>
-        <HeaderCell
-          data-column-name="connected-monitors"
-          sort={sort}
-          sortKey="connectedDetectors"
-        >
-          {t('Monitors')}
-        </HeaderCell>
-      </SimpleTable.Header>
+      {selected.size === 0 ? (
+        <SimpleTable.Header key="header">
+          <HeaderCell sort={sort} sortKey="name">
+            <NamePadding>{t('Name')}</NamePadding>
+          </HeaderCell>
+          <HeaderCell
+            data-column-name="last-triggered"
+            sort={sort}
+            sortKey="lastTriggered"
+          >
+            {t('Last Triggered')}
+          </HeaderCell>
+          <HeaderCell data-column-name="action" sort={sort} sortKey="actions">
+            {t('Actions')}
+          </HeaderCell>
+          <HeaderCell data-column-name="projects" sort={sort}>
+            {t('Projects')}
+          </HeaderCell>
+          <HeaderCell
+            data-column-name="connected-monitors"
+            sort={sort}
+            sortKey="connectedDetectors"
+          >
+            {t('Monitors')}
+          </HeaderCell>
+        </SimpleTable.Header>
+      ) : (
+        <AutomationsTableActions
+          key="actions"
+          selected={selected}
+          pageSelected={pageSelected}
+          togglePageSelected={togglePageSelected}
+          queryCount={queryCount}
+          allResultsVisible={allResultsVisible}
+          canEnable={canEnable}
+          canDisable={canDisable}
+        />
+      )}
       {isSuccess && automations.length === 0 && (
         <SimpleTable.Empty>{t('No automations found')}</SimpleTable.Empty>
       )}
@@ -103,14 +163,19 @@ function AutomationListTable({
       {isPending && <LoadingSkeletons />}
       {isSuccess &&
         automations.map(automation => (
-          <AutomationListRow key={automation.id} automation={automation} />
+          <AutomationListRow
+            key={automation.id}
+            automation={automation}
+            selected={selected.has(automation.id)}
+            onSelect={handleSelect}
+          />
         ))}
     </AutomationsSimpleTable>
   );
 }
 
 const AutomationsSimpleTable = styled(SimpleTable)`
-  grid-template-columns: 1fr;
+  grid-template-columns: 0.25fr 1fr;
 
   margin-bottom: ${space(2)};
 
@@ -152,6 +217,10 @@ const AutomationsSimpleTable = styled(SimpleTable)`
       display: flex;
     }
   }
+`;
+
+const NamePadding = styled('div')`
+  padding-left: 28px;
 `;
 
 export default AutomationListTable;

--- a/static/app/views/automations/components/automationListTable/row.tsx
+++ b/static/app/views/automations/components/automationListTable/row.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 
+import {hasEveryAccess} from 'sentry/components/acl/access';
 import {Checkbox} from 'sentry/components/core/checkbox';
 import {Flex} from 'sentry/components/core/layout';
 import Placeholder from 'sentry/components/placeholder';
@@ -10,6 +11,7 @@ import AutomationTitleCell from 'sentry/components/workflowEngine/gridCell/autom
 import {TimeAgoCell} from 'sentry/components/workflowEngine/gridCell/timeAgoCell';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import type {Automation} from 'sentry/types/workflowEngine/automations';
+import useOrganization from 'sentry/utils/useOrganization';
 import {AutomationListConnectedDetectors} from 'sentry/views/automations/components/automationListTable/connectedDetectors';
 import {
   getAutomationActions,
@@ -27,6 +29,9 @@ export function AutomationListRow({
   selected,
   onSelect,
 }: AutomationListRowProps) {
+  const organization = useOrganization();
+  const canEditAutomations = hasEveryAccess(['alerts:write'], {organization});
+
   const actions = getAutomationActions(automation);
   const {enabled, lastTriggered, detectorIds = []} = automation;
   const projectIds = useAutomationProjectIds(automation);
@@ -41,13 +46,15 @@ export function AutomationListRow({
     >
       <SimpleTable.RowCell>
         <Flex gap="md" align="center">
-          <CheckboxWrapper>
-            <Checkbox
-              checked={selected}
-              onChange={() => onSelect(automation.id)}
-              className="select-row"
-            />
-          </CheckboxWrapper>
+          {canEditAutomations && (
+            <CheckboxWrapper>
+              <Checkbox
+                checked={selected}
+                onChange={() => onSelect(automation.id)}
+                className="select-row"
+              />
+            </CheckboxWrapper>
+          )}
           <AutomationTitleCell automation={automation} />
         </Flex>
       </SimpleTable.RowCell>

--- a/static/app/views/automations/components/automationListTable/row.tsx
+++ b/static/app/views/automations/components/automationListTable/row.tsx
@@ -1,5 +1,7 @@
 import styled from '@emotion/styled';
 
+import {Checkbox} from 'sentry/components/core/checkbox';
+import {Flex} from 'sentry/components/core/layout';
 import Placeholder from 'sentry/components/placeholder';
 import {ProjectList} from 'sentry/components/projectList';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
@@ -16,9 +18,15 @@ import {
 
 type AutomationListRowProps = {
   automation: Automation;
+  onSelect: (id: string) => void;
+  selected: boolean;
 };
 
-export function AutomationListRow({automation}: AutomationListRowProps) {
+export function AutomationListRow({
+  automation,
+  selected,
+  onSelect,
+}: AutomationListRowProps) {
   const actions = getAutomationActions(automation);
   const {enabled, lastTriggered, detectorIds = []} = automation;
   const projectIds = useAutomationProjectIds(automation);
@@ -32,7 +40,16 @@ export function AutomationListRow({automation}: AutomationListRowProps) {
       data-test-id="automation-list-row"
     >
       <SimpleTable.RowCell>
-        <AutomationTitleCell automation={automation} />
+        <Flex gap="md" align="center">
+          <CheckboxWrapper>
+            <Checkbox
+              checked={selected}
+              onChange={() => onSelect(automation.id)}
+              className="select-row"
+            />
+          </CheckboxWrapper>
+          <AutomationTitleCell automation={automation} />
+        </Flex>
       </SimpleTable.RowCell>
       <SimpleTable.RowCell data-column-name="last-triggered">
         <TimeAgoCell date={lastTriggered} />
@@ -74,4 +91,20 @@ export function AutomationListRowSkeleton() {
 
 const AutomationSimpleTableRow = styled(SimpleTable.Row)`
   min-height: 54px;
+
+  @media (hover: hover) {
+    &:not(:has(:hover)):not(:has(input:checked)) {
+      .select-row {
+        ${p => p.theme.visuallyHidden}
+      }
+    }
+  }
+`;
+
+const CheckboxWrapper = styled('div')`
+  width: 20px;
+  height: 20px;
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
 `;

--- a/static/app/views/automations/hooks/index.tsx
+++ b/static/app/views/automations/hooks/index.tsx
@@ -181,6 +181,39 @@ export function useDeleteAutomationMutation() {
   });
 }
 
+/** Bulk delete automations */
+export function useDeleteAutomationsMutation() {
+  const org = useOrganization();
+  const api = useApi({persistInFlight: true});
+  const queryClient = useQueryClient();
+
+  return useMutation<
+    void,
+    RequestError,
+    {ids?: string[]; projects?: number[]; query?: string}
+  >({
+    mutationFn: params => {
+      return api.requestPromise(`/organizations/${org.slug}/workflows/`, {
+        method: 'DELETE',
+        query: {
+          id: params.ids,
+          query: params.query,
+          project: params.projects,
+        },
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [`/organizations/${org.slug}/workflows/`],
+      });
+      addSuccessMessage(t('Automations deleted'));
+    },
+    onError: error => {
+      addErrorMessage(t('Unable to delete automations: %s', error.message));
+    },
+  });
+}
+
 export function useUpdateAutomation() {
   const org = useOrganization();
   const api = useApi({persistInFlight: true});
@@ -210,6 +243,48 @@ export function useUpdateAutomation() {
     },
     onError: _ => {
       AlertStore.addAlert({type: 'error', message: t('Unable to update automation')});
+    },
+  });
+}
+
+/** Bulk update automations. Currently supports enabling/disabling automations. */
+export function useUpdateAutomationsMutation() {
+  const org = useOrganization();
+  const api = useApi({persistInFlight: true});
+  const queryClient = useQueryClient();
+
+  return useMutation<
+    void,
+    RequestError,
+    {enabled: boolean; ids?: string[]; projects?: number[]; query?: string}
+  >({
+    mutationFn: params => {
+      return api.requestPromise(`/organizations/${org.slug}/workflows/`, {
+        method: 'PUT',
+        data: {enabled: params.enabled},
+        query: {
+          id: params.ids,
+          query: params.query,
+          project: params.projects,
+        },
+      });
+    },
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: [`/organizations/${org.slug}/workflows/`],
+      });
+      addSuccessMessage(
+        variables.enabled ? t('Automations enabled') : t('Automations disabled')
+      );
+    },
+    onError: (error, variables) => {
+      addErrorMessage(
+        t(
+          'Unable to %s automations: %2$s',
+          variables.enabled ? t('enable') : t('disable'),
+          error.message
+        )
+      );
     },
   });
 }

--- a/static/app/views/automations/list.spec.tsx
+++ b/static/app/views/automations/list.spec.tsx
@@ -442,9 +442,11 @@ describe('AutomationsList', function () {
       await userEvent.click(masterCheckbox);
 
       // Should show alert with option to select all query results
-      expect(screen.getByText(/20 issues on this page selected/)).toBeInTheDocument();
+      expect(
+        screen.getByText(/20 automations on this page selected/)
+      ).toBeInTheDocument();
       const selectAllForQuery = screen.getByText(
-        /Select all 50 issues that match this search query/
+        /Select all 50 automations that match this search query/
       );
       await userEvent.click(selectAllForQuery);
 

--- a/static/app/views/automations/list.spec.tsx
+++ b/static/app/views/automations/list.spec.tsx
@@ -208,7 +208,7 @@ describe('AutomationsList', function () {
       );
     });
 
-    it('can select individual automations', async function () {
+    it('can select automations', async function () {
       render(<AutomationsList />, {organization});
       await screen.findByText('Enabled Automation');
 
@@ -236,26 +236,12 @@ describe('AutomationsList', function () {
       expect(screen.getByRole('button', {name: 'Disable'})).toBeInTheDocument();
       // Should always show Delete button
       expect(screen.getByRole('button', {name: 'Delete'})).toBeInTheDocument();
-    });
-
-    it('can select all automations on page', async function () {
-      render(<AutomationsList />, {organization});
-      await screen.findByText('Enabled Automation');
-
-      const rows = screen.getAllByTestId('automation-list-row');
-
-      // Select first automation
-      const firstRowCheckbox = within(rows[0]!).getByRole('checkbox');
-      await userEvent.click(firstRowCheckbox);
-      expect(firstRowCheckbox).toBeChecked();
 
       // Select master checkbox to select all on page
-      const masterCheckbox = screen.getAllByRole('checkbox')[0]!;
       await userEvent.click(masterCheckbox);
       expect(masterCheckbox).toBeChecked();
 
       // // All checkboxes should be checked
-      const checkboxes = screen.getAllByRole('checkbox');
       checkboxes.forEach(checkbox => {
         expect(checkbox).toBeChecked();
       });

--- a/static/app/views/automations/list.spec.tsx
+++ b/static/app/views/automations/list.spec.tsx
@@ -7,6 +7,7 @@ import {UserFixture} from 'sentry-fixture/user';
 
 import {
   render,
+  renderGlobalModal,
   screen,
   userEvent,
   waitFor,
@@ -167,6 +168,299 @@ describe('AutomationsList', function () {
 
       await screen.findByText('Slack Automation');
       expect(mockAutomationActionSlack).toHaveBeenCalled();
+    });
+  });
+
+  describe('bulk actions', function () {
+    beforeEach(function () {
+      MockApiClient.clearMockResponses();
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/users/1/',
+        body: UserFixture(),
+      });
+      // Set up multiple automations with different states
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/workflows/',
+        body: [
+          AutomationFixture({
+            id: '1',
+            name: 'Enabled Automation',
+            detectorIds: [],
+            enabled: true,
+          }),
+          AutomationFixture({
+            id: '2',
+            name: 'Disabled Automation',
+            detectorIds: [],
+            enabled: false,
+          }),
+          AutomationFixture({
+            id: '3',
+            name: 'Another Enabled',
+            detectorIds: [],
+            enabled: true,
+          }),
+        ],
+      });
+      PageFiltersStore.onInitializeUrlState(
+        PageFiltersFixture({projects: [1]}),
+        new Set()
+      );
+    });
+
+    it('can select individual automations', async function () {
+      render(<AutomationsList />, {organization});
+      await screen.findByText('Enabled Automation');
+
+      const rows = screen.getAllByTestId('automation-list-row');
+      expect(rows).toHaveLength(3);
+
+      // Initially no checkboxes should be checked
+      const checkboxes = screen.getAllByRole('checkbox');
+      checkboxes.forEach(checkbox => {
+        expect(checkbox).not.toBeChecked();
+      });
+
+      // Select first automation
+      const firstRowCheckbox = within(rows[0]!).getByRole('checkbox');
+      await userEvent.click(firstRowCheckbox);
+      expect(firstRowCheckbox).toBeChecked();
+
+      // Master checkbox should be in indeterminate state
+      const masterCheckbox = screen.getAllByRole('checkbox')[0] as HTMLInputElement; // First checkbox is the master
+      expect(masterCheckbox.indeterminate).toBe(true);
+
+      // Should not show Enable button since we have no disabled automations selected
+      expect(screen.queryByRole('button', {name: 'Enable'})).not.toBeInTheDocument();
+      // Should show Disable button since we have enabled automations selected
+      expect(screen.getByRole('button', {name: 'Disable'})).toBeInTheDocument();
+      // Should always show Delete button
+      expect(screen.getByRole('button', {name: 'Delete'})).toBeInTheDocument();
+    });
+
+    it('can select all automations on page', async function () {
+      render(<AutomationsList />, {organization});
+      await screen.findByText('Enabled Automation');
+
+      const rows = screen.getAllByTestId('automation-list-row');
+
+      // Select first automation
+      const firstRowCheckbox = within(rows[0]!).getByRole('checkbox');
+      await userEvent.click(firstRowCheckbox);
+      expect(firstRowCheckbox).toBeChecked();
+
+      // Select master checkbox to select all on page
+      const masterCheckbox = screen.getAllByRole('checkbox')[0]!;
+      await userEvent.click(masterCheckbox);
+      expect(masterCheckbox).toBeChecked();
+
+      // // All checkboxes should be checked
+      const checkboxes = screen.getAllByRole('checkbox');
+      checkboxes.forEach(checkbox => {
+        expect(checkbox).toBeChecked();
+      });
+
+      // Should show Enable button since we have disabled automations
+      expect(screen.getByRole('button', {name: 'Enable'})).toBeInTheDocument();
+      // Should show Disable button since we have enabled automations
+      expect(screen.getByRole('button', {name: 'Disable'})).toBeInTheDocument();
+      // Should always show Delete button
+      expect(screen.getByRole('button', {name: 'Delete'})).toBeInTheDocument();
+    });
+
+    it('can enable selected automations with confirmation', async function () {
+      const updateRequest = MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/workflows/',
+        method: 'PUT',
+        body: {},
+      });
+
+      render(<AutomationsList />, {organization});
+      renderGlobalModal();
+
+      await screen.findByText('Disabled Automation');
+
+      const rows = screen.getAllByTestId('automation-list-row');
+      const disabledRow = rows.find(row =>
+        within(row).queryByText('Disabled Automation')
+      );
+      const disabledCheckbox = within(disabledRow!).getByRole('checkbox');
+      await userEvent.click(disabledCheckbox);
+
+      // Click Enable button
+      await userEvent.click(screen.getByRole('button', {name: 'Enable'}));
+
+      // Should show confirmation modal
+      const confirmModal = screen.getByRole('dialog');
+      expect(
+        screen.getByText(/Are you sure you want to enable this/)
+      ).toBeInTheDocument();
+
+      // Confirm the action
+      await userEvent.click(within(confirmModal).getByRole('button', {name: 'Enable'}));
+
+      await waitFor(() => {
+        expect(updateRequest).toHaveBeenCalledWith(
+          '/organizations/org-slug/workflows/',
+          expect.objectContaining({
+            data: {enabled: true},
+            query: {id: ['2'], query: undefined, project: undefined},
+          })
+        );
+      });
+    });
+
+    it('can disable selected automations with confirmation', async function () {
+      const updateRequest = MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/workflows/',
+        method: 'PUT',
+        body: {},
+      });
+
+      render(<AutomationsList />, {organization});
+      renderGlobalModal();
+      await screen.findByText('Enabled Automation');
+
+      const rows = screen.getAllByTestId('automation-list-row');
+      const enabledRow = rows.find(row => within(row).queryByText('Enabled Automation'));
+      const enabledCheckbox = within(enabledRow!).getByRole('checkbox');
+      await userEvent.click(enabledCheckbox);
+
+      // Click Disable button
+      await userEvent.click(screen.getByRole('button', {name: 'Disable'}));
+
+      // Should show confirmation modal
+      const confirmModal = screen.getByRole('dialog');
+      expect(
+        screen.getByText(/Are you sure you want to disable this/)
+      ).toBeInTheDocument();
+
+      // Confirm the action
+      await userEvent.click(within(confirmModal).getByRole('button', {name: 'Disable'}));
+
+      await waitFor(() => {
+        expect(updateRequest).toHaveBeenCalledWith(
+          '/organizations/org-slug/workflows/',
+          expect.objectContaining({
+            data: {enabled: false},
+            query: {id: ['1'], query: undefined, project: undefined},
+          })
+        );
+      });
+    });
+
+    it('can delete selected automations with confirmation', async function () {
+      const deleteRequest = MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/workflows/',
+        method: 'DELETE',
+        body: {},
+      });
+
+      render(<AutomationsList />, {organization});
+      renderGlobalModal();
+      await screen.findByText('Enabled Automation');
+
+      const rows = screen.getAllByTestId('automation-list-row');
+      const firstRowCheckbox = within(rows[0]!).getByRole('checkbox');
+      await userEvent.click(firstRowCheckbox);
+
+      // Click Delete button
+      await userEvent.click(screen.getByRole('button', {name: 'Delete'}));
+
+      // Should show confirmation modal
+      const confirmModal = screen.getByRole('dialog');
+      expect(
+        screen.getByText(/Are you sure you want to delete this/)
+      ).toBeInTheDocument();
+
+      // Confirm the action
+      await userEvent.click(within(confirmModal).getByRole('button', {name: 'Delete'}));
+
+      await waitFor(() => {
+        expect(deleteRequest).toHaveBeenCalledWith(
+          '/organizations/org-slug/workflows/',
+          expect.objectContaining({
+            query: {id: ['1'], query: undefined, project: undefined},
+          })
+        );
+      });
+    });
+
+    it('shows option to select all query results when page is selected', async function () {
+      const deleteRequest = MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/workflows/',
+        method: 'DELETE',
+        body: {},
+      });
+
+      render(<AutomationsList />, {organization});
+      renderGlobalModal();
+
+      // Mock the filtered search results - this will be used when search is applied
+      const filteredAutomations = Array.from({length: 20}, (_, i) =>
+        AutomationFixture({
+          id: `filtered-${i}`,
+          name: `Slack Automation ${i + 1}`,
+          enabled: i % 2 === 0,
+          detectorIds: [],
+        })
+      );
+
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/workflows/',
+        method: 'GET',
+        body: filteredAutomations,
+        headers: {
+          'X-Hits': '50',
+        },
+        match: [
+          MockApiClient.matchQuery({
+            query: 'action:slack',
+            project: [1],
+          }),
+        ],
+      });
+
+      // Click through menus to select action:slack
+      await userEvent.click(screen.getByRole('combobox', {name: 'Add a search term'}));
+      await userEvent.click(await screen.findByRole('option', {name: 'action'}));
+      await userEvent.click(await screen.findByRole('option', {name: 'slack'}));
+
+      // Wait for filtered results to load
+      await screen.findByText('Slack Automation 1');
+
+      const rows = screen.getAllByTestId('automation-list-row');
+
+      // Focus on first row to make checkbox visible
+      await userEvent.click(rows[0]!);
+      const firstRowCheckbox = within(rows[0]!).getByRole('checkbox');
+      await userEvent.click(firstRowCheckbox);
+      expect(firstRowCheckbox).toBeChecked();
+
+      // Select all on page - master checkbox should now be visible since we have a selection
+      const masterCheckbox = screen.getAllByRole('checkbox')[0]!;
+      await userEvent.click(masterCheckbox);
+
+      // Should show alert with option to select all query results
+      expect(screen.getByText(/20 issues on this page selected/)).toBeInTheDocument();
+      const selectAllForQuery = screen.getByText(
+        /Select all 50 issues that match this search query/
+      );
+      await userEvent.click(selectAllForQuery);
+
+      // Perform an action to verify query-based selection
+      await userEvent.click(screen.getByRole('button', {name: 'Delete'}));
+      const confirmModal = screen.getByRole('dialog');
+      await userEvent.click(within(confirmModal).getByRole('button', {name: 'Delete'})); // Confirm
+
+      await waitFor(() => {
+        expect(deleteRequest).toHaveBeenCalledWith(
+          '/organizations/org-slug/workflows/',
+          expect.objectContaining({
+            query: {id: undefined, query: 'action:slack', project: [1]},
+          })
+        );
+      });
     });
   });
 });

--- a/static/app/views/detectors/components/detectorLink.tsx
+++ b/static/app/views/detectors/components/detectorLink.tsx
@@ -203,7 +203,6 @@ export function DetectorLink({detector, className}: DetectorLinkProps) {
           <Details detector={detector} />
         </Fragment>
       }
-      disabled={!detector.enabled}
     />
   );
 }

--- a/static/app/views/detectors/components/detectorLink.tsx
+++ b/static/app/views/detectors/components/detectorLink.tsx
@@ -203,6 +203,7 @@ export function DetectorLink({detector, className}: DetectorLinkProps) {
           <Details detector={detector} />
         </Fragment>
       }
+      disabled={!detector.enabled}
     />
   );
 }


### PR DESCRIPTION
implemented enable/disable/delete bulk actions for automation list table. checkboxes/action buttons will not appear if the user does not have `alerts:write`

https://github.com/user-attachments/assets/1824026f-35e3-42d7-8eae-decb84711be3

no animations yet