### PR TITLE
feat(workflow_engine): Add a generic way to see if a models attribute is cached or not

### DIFF
--- a/src/sentry/db/models/utils.py
+++ b/src/sentry/db/models/utils.py
@@ -14,6 +14,21 @@ if TYPE_CHECKING:
     from sentry.db.models.base import Model as SentryModel
 
 
+def is_model_attr_cached(model: Model, attr: str) -> bool:
+    is_prefetched = (
+        hasattr(model, "_prefetched_objects_cache") and attr in model._prefetched_objects_cache
+    )
+    field = getattr(type(model), attr)
+
+    if hasattr(field, "is_cached"):
+        is_selected = field.is_cached(model)
+    else:
+        # For regular fields, check if not deferred
+        is_selected = attr not in model.get_deferred_fields()
+
+    return is_prefetched or is_selected
+
+
 def unique_db_instance(
     inst: SentryModel,
     base_value: str,

--- a/src/sentry/db/models/utils.py
+++ b/src/sentry/db/models/utils.py
@@ -15,6 +15,17 @@ if TYPE_CHECKING:
 
 
 def is_model_attr_cached(model: Model, attr: str) -> bool:
+    """
+    This method will check to see if the given attribute is already annotated / cached
+    on the given model instance. The primary use case for this method is to determine
+    if django will issue a query to fetch a related attribute or not.
+
+    If the attribute has been prefetched or selected, then this method will return True,
+    otherwise it will return False.
+
+    model `Model`: The model instance to check, this can be any model that's based on `django.db.models.Model`
+    attr `str`: The attribute, as a string, to check if it's cached or prefetched on the django model
+    """
     is_prefetched = (
         hasattr(model, "_prefetched_objects_cache") and attr in model._prefetched_objects_cache
     )

--- a/tests/sentry/db/models/test_utils.py
+++ b/tests/sentry/db/models/test_utils.py
@@ -1,6 +1,74 @@
-from sentry.db.models.utils import slugify_instance
+from sentry.db.models.utils import is_model_attr_cached, slugify_instance
 from sentry.models.organization import Organization
 from sentry.testutils.cases import TestCase
+from sentry.workflow_engine.models import Detector
+
+
+class TestIsModelAttrCached(TestCase):
+    def test_works_with_standard_attrs(self) -> None:
+        org = self.create_organization()
+        assert is_model_attr_cached(org, "name") is True
+
+    def test_creation_association(self) -> None:
+        detector = self.create_detector()
+        assert is_model_attr_cached(detector, "workflow_condition_group") is False
+
+        detector.workflow_condition_group = self.create_data_condition_group()
+        detector.save()
+        refetched_detector = Detector.objects.get(id=detector.id)
+
+        # Detector maintains the association in memory
+        assert is_model_attr_cached(detector, "workflow_condition_group") is True
+
+        # When refetched, the association is not cached
+        assert is_model_attr_cached(refetched_detector, "workflow_condition_group") is False
+
+    def test_select_related(self) -> None:
+        detector = self.create_detector()
+        detector.workflow_condition_group = self.create_data_condition_group()
+        self.create_data_condition(
+            condition_group=detector.workflow_condition_group,
+            condition_result=75,
+        )
+
+        detector.save()
+
+        refetched_detector = (
+            Detector.objects.filter(id=detector.id)
+            .select_related("workflow_condition_group")
+            .first()
+        )
+
+        assert refetched_detector is not None
+        assert is_model_attr_cached(refetched_detector, "workflow_condition_group") is True
+
+    def test_prefetch(self) -> None:
+        detector = self.create_detector()
+        detector.workflow_condition_group = self.create_data_condition_group()
+        self.create_data_condition(
+            condition_group=detector.workflow_condition_group,
+            condition_result=75,
+        )
+
+        detector.save()
+
+        refetched_detector = (
+            Detector.objects.filter(id=detector.id)
+            .select_related("workflow_condition_group")
+            .prefetch_related("workflow_condition_group__conditions")
+            .first()
+        )
+
+        assert refetched_detector is not None
+        assert refetched_detector.workflow_condition_group is not None
+        assert is_model_attr_cached(refetched_detector, "workflow_condition_group") is True
+        assert (
+            is_model_attr_cached(refetched_detector.workflow_condition_group, "conditions") is True
+        )
+
+        # use the same model, but different query to ensure cache check is correct
+        another = Detector.objects.get(id=detector.id)
+        assert is_model_attr_cached(another, "workflow_condition_group") is False
 
 
 class SlugifyInstanceTest(TestCase):


### PR DESCRIPTION
# Description
Adding a generic helper to see if the attribute of a django model has already been fetched or not. This is useful in the `workflow_engine` as a way to check if the model being passed in has all the nested attributes or not.