### PR TITLE
fix(aci): Make deferred project retrieval more reliable

### DIFF
--- a/src/sentry/buffer/base.py
+++ b/src/sentry/buffer/base.py
@@ -99,11 +99,12 @@ class Buffer(Service):
     ) -> None:
         return None
 
-    def delete_key(self, key: str, min: float = -math.inf, max: float = math.inf) -> None:
+    def delete_key(self, key: str, min: float = -math.inf, max: float = math.inf) -> int:
         """
         Delete all members of a sorted set with scores between min and max.
+        Returns the number of members deleted.
         """
-        return None
+        return 0
 
     def incr(
         self,

--- a/src/sentry/buffer/base.py
+++ b/src/sentry/buffer/base.py
@@ -1,3 +1,4 @@
+import math
 from datetime import datetime
 from typing import Any
 
@@ -58,10 +59,19 @@ class Buffer(Service):
     def get_hash_length(self, model: type[models.Model], field: dict[str, BufferField]) -> int:
         raise NotImplementedError
 
-    def get_sorted_set(self, key: str, min: float, max: float) -> list[tuple[int, datetime]]:
+    def get_sorted_set(
+        self, key: str, min: float = -math.inf, max: float = math.inf
+    ) -> list[tuple[int, float]]:
+        """
+        Retrieve all members of a sorted set with scores between min and max.
+        """
         return []
 
     def push_to_sorted_set(self, key: str, value: list[int] | int) -> None:
+        """
+        Add a value or list of values to the sorted set at the provided key,
+        with the current time as the score.
+        """
         return None
 
     def push_to_hash(
@@ -89,7 +99,10 @@ class Buffer(Service):
     ) -> None:
         return None
 
-    def delete_key(self, key: str, min: float, max: float) -> None:
+    def delete_key(self, key: str, min: float = -math.inf, max: float = math.inf) -> None:
+        """
+        Delete all members of a sorted set with scores between min and max.
+        """
         return None
 
     def incr(

--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -399,8 +399,10 @@ class RedisBuffer(Buffer):
         return decoded_set
 
     @override
-    def delete_key(self, key: str, min: float = -math.inf, max: float = math.inf) -> None:
-        self._execute_redis_operation(key, RedisOperation.SORTED_SET_DELETE_RANGE, min=min, max=max)
+    def delete_key(self, key: str, min: float = -math.inf, max: float = math.inf) -> int:
+        return self._execute_redis_operation(
+            key, RedisOperation.SORTED_SET_DELETE_RANGE, min=min, max=max
+        )
 
     def delete_hash(
         self,

--- a/src/sentry/rules/processing/buffer_processing.py
+++ b/src/sentry/rules/processing/buffer_processing.py
@@ -182,10 +182,8 @@ def clear_processed_project_ids(
         for _, timestamp in to_delete:
             if timestamp >= min_new_proj_ts:
                 break
-            if timestamp > max_processed_ts:
-                break
             max_safe_ts = max(max_safe_ts or timestamp, timestamp)
-        if not max_safe_ts:
+        if max_safe_ts is None:
             # Something went wrong.
             logger.error(
                 "Can't safely clear projects from buffer",

--- a/src/sentry/rules/processing/buffer_processing.py
+++ b/src/sentry/rules/processing/buffer_processing.py
@@ -9,7 +9,7 @@ from typing import ClassVar
 from celery import Task
 
 from sentry import buffer, options
-from sentry.buffer.base import BufferField
+from sentry.buffer.base import Buffer, BufferField
 from sentry.buffer.redis import BufferHookEvent, redis_buffer_registry
 from sentry.db import models
 from sentry.utils import metrics
@@ -140,6 +140,78 @@ def process_in_batches(project_id: int, processing_type: str) -> None:
             )
 
 
+def to_log_format(project_ids: list[tuple[int, float]]) -> str:
+    return ", ".join(f"{project_id}: {timestamp}" for project_id, timestamp in project_ids)
+
+
+def clear_processed_project_ids(
+    buf: Buffer, processing_type: str, processed: list[tuple[int, float]], buffer_key: str
+) -> None:
+    """
+    Safely clear processed project IDs from the buffer.
+    We want to remove all of the projects we've processed unless they've been updated since.
+    This can typically be done by deleting all up to the latest processed timestamp, but it's
+    possible that a new update has been added within that time window since we checked, so this
+    method errs toward only removing projects in a range we know doesn't include any new projects.
+
+    This may rarely result in duplicate scheduling, but that is expected to be safe.
+    """
+    if not processed:
+        return
+    max_processed_ts = max(timestamp for _, timestamp in processed)
+    expected_deleted = len(processed)
+    # Delete all project IDs that we've processed unless they've been updated since.
+    # Any newly added projects should be above max_observed and will be processed on
+    # next execution.
+    to_delete = buf.get_sorted_set(buffer_key, max=max_processed_ts)
+    new_project_ids = {proj_id for proj_id, _ in to_delete} - {proj_id for proj_id, _ in processed}
+    if new_project_ids:
+        # We had some older timestamps show up after our fetch.
+        logger.warning(
+            "buffer_processing.project_id_list_new_project_ids",
+            extra={
+                "project_ids": to_log_format(processed),
+                "new_project_ids": new_project_ids,
+                "processing_type": processing_type,
+            },
+        )
+        max_safe_ts = None
+        min_new_proj_ts = min(
+            timestamp for proj_id, timestamp in to_delete if proj_id in new_project_ids
+        )
+        for _, timestamp in to_delete:
+            if timestamp >= min_new_proj_ts:
+                break
+            if timestamp > max_processed_ts:
+                break
+            max_safe_ts = max(max_safe_ts or timestamp, timestamp)
+        if not max_safe_ts:
+            # Something went wrong.
+            logger.error(
+                "Can't safely clear projects from buffer",
+                extra={
+                    "project_ids": to_log_format(processed),
+                    "new_project_ids": new_project_ids,
+                    "processing_type": processing_type,
+                },
+            )
+            return
+        # Since deleting up to the latest time we processed will remove unprocessed projects, we instead
+        # delete up to the latest timestamp that isn't associated with a newly scheduled project.
+        # This can result in duplicate scheduling, but that should be safe.
+        max_delete_time = max_safe_ts
+        expected_deleted = len([proj_id for proj_id, ts in to_delete if ts <= max_delete_time])
+    else:
+        max_delete_time = max_processed_ts
+    deleted = buf.delete_key(buffer_key, max=max_delete_time)
+    # Deleting fewer is expected if a new update comes in for an existing project id.
+    if deleted > expected_deleted:
+        logger.error(
+            "buffer_processing.project_id_list_delete_mismatch",
+            extra={"project_ids": to_log_format(processed), "deleted": deleted},
+        )
+
+
 def process_buffer() -> None:
     should_emit_logs = options.get("delayed_processing.emit_logs")
 
@@ -153,21 +225,15 @@ def process_buffer() -> None:
             # Retrieve all project IDs in the buffer with their timestamps.
             project_ids = buffer.backend.get_sorted_set(handler.buffer_key)
             if should_emit_logs:
-                log_str = ", ".join(
-                    f"{project_id}: {timestamp}" for project_id, timestamp in project_ids
-                )
                 log_name = f"{processing_type}.project_id_list"
-                logger.info(log_name, extra={"project_ids": log_str})
+                logger.info(log_name, extra={"project_ids": to_log_format(project_ids)})
 
             for project_id, _ in project_ids:
                 process_in_batches(project_id, processing_type)
 
-            if project_ids:
-                max_observed = max(timestamp for _, timestamp in project_ids)
-                # Delete all project IDs that we've processed unless they've been updated since.
-                # Any newly added projects should be above max_observed and will be processed on
-                # next execution.
-                buffer.backend.delete_key(handler.buffer_key, max=max_observed)
+            clear_processed_project_ids(
+                buffer.backend, processing_type, project_ids, handler.buffer_key
+            )
 
 
 if not redis_buffer_registry.has(BufferHookEvent.FLUSH):


### PR DESCRIPTION
When dispatching batch delayed processing jobs, we want to retrieve all currently scheduled projects, dispatch the appropriate tasks, then remove project IDs from the buffer if they haven't been updated since our processing.

The previous approach was to retrieve project ids up until almost now, process, then delete up until almost now.
This generally works, but there's a risk that a project is added with a timestamp after our fetch timestamp (resulting in it being missed in this pass), or that one is added within our fetch timestamp after we query but before we delete (resulting in it being dropped).

Retrieving all known project IDs, processing them, and deleting up until our newest that isn't after a project ID we haven't processed should ensure we don't miss any projects or drop any that haven't been processed.