### PR TITLE
feat(preprod): Add new vcs related fields to preprod artifact assemble endpoint

### DIFF
--- a/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
+++ b/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
@@ -34,8 +34,16 @@ def validate_preprod_artifact_schema(request_body: bytes) -> tuple[dict, str | N
                 "items": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
             },
             # Optional metadata
-            "git_sha": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
             "build_configuration": {"type": "string"},
+            # VCS parameters
+            "head_sha": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+            "base_sha": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+            "provider": {"type": "string", "maxLength": 64},
+            "head_repo_name": {"type": "string", "maxLength": 255},
+            "base_repo_name": {"type": "string", "maxLength": 255},
+            "head_ref": {"type": "string", "maxLength": 255},
+            "base_ref": {"type": "string", "maxLength": 255},
+            "pr_number": {"type": "integer", "minimum": 1},
         },
         "required": ["checksum", "chunks"],
         "additionalProperties": False,
@@ -44,8 +52,15 @@ def validate_preprod_artifact_schema(request_body: bytes) -> tuple[dict, str | N
     error_messages = {
         "checksum": "The checksum field is required and must be a 40-character hexadecimal string.",
         "chunks": "The chunks field is required and must be provided as an array of 40-character hexadecimal strings.",
-        "git_sha": "The git_sha field must be a 40-character hexadecimal SHA1 string (no uppercase letters).",
         "build_configuration": "The build_configuration field must be a string.",
+        "head_sha": "The head_sha field must be a 40-character hexadecimal SHA1 string (no uppercase letters).",
+        "base_sha": "The base_sha field must be a 40-character hexadecimal SHA1 string (no uppercase letters).",
+        "provider": "The provider field must be a string with maximum length of 64 characters.",
+        "head_repo_name": "The head_repo_name field must be a string with maximum length of 255 characters.",
+        "base_repo_name": "The base_repo_name field must be a string with maximum length of 255 characters.",
+        "head_ref": "The head_ref field must be a string with maximum length of 255 characters.",
+        "base_ref": "The base_ref field must be a string with maximum length of 255 characters.",
+        "pr_number": "The pr_number field must be a positive integer.",
     }
 
     try:
@@ -144,6 +159,15 @@ class ProjectPreprodArtifactAssembleEndpoint(ProjectEndpoint):
                     "checksum": checksum,
                     "chunks": chunks,
                     "artifact_id": artifact_id,
+                    # VCS parameters
+                    "head_sha": data.get("head_sha"),
+                    "base_sha": data.get("base_sha"),
+                    "provider": data.get("provider"),
+                    "head_repo_name": data.get("head_repo_name"),
+                    "base_repo_name": data.get("base_repo_name"),
+                    "head_ref": data.get("head_ref"),
+                    "base_ref": data.get("base_ref"),
+                    "pr_number": data.get("pr_number"),
                 }
             )
             if is_org_auth_token_auth(request.auth):

--- a/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
+++ b/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
@@ -168,6 +168,7 @@ class ProjectPreprodArtifactAssembleEndpoint(ProjectEndpoint):
                     "checksum": checksum,
                     "chunks": chunks,
                     "artifact_id": artifact_id,
+                    "build_configuration": data.get("build_configuration"),
                     # VCS parameters
                     "head_sha": data.get("head_sha"),
                     "base_sha": data.get("base_sha"),

--- a/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
+++ b/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
@@ -38,7 +38,16 @@ def validate_preprod_artifact_schema(request_body: bytes) -> tuple[dict, str | N
             # VCS parameters
             "head_sha": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
             "base_sha": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
-            "provider": {"type": "string", "maxLength": 64},
+            "provider": {
+                "type": "string",
+                "enum": [
+                    "github",
+                    "github_enterprise",
+                    "gitlab",
+                    "bitbucket",
+                    "bitbucket_server",
+                ],
+            },
             "head_repo_name": {"type": "string", "maxLength": 255},
             "base_repo_name": {"type": "string", "maxLength": 255},
             "head_ref": {"type": "string", "maxLength": 255},
@@ -55,7 +64,7 @@ def validate_preprod_artifact_schema(request_body: bytes) -> tuple[dict, str | N
         "build_configuration": "The build_configuration field must be a string.",
         "head_sha": "The head_sha field must be a 40-character hexadecimal SHA1 string (no uppercase letters).",
         "base_sha": "The base_sha field must be a 40-character hexadecimal SHA1 string (no uppercase letters).",
-        "provider": "The provider field must be a string with maximum length of 64 characters.",
+        "provider": "The provider field must be a string with one of the following values: github, github_enterprise, gitlab, bitbucket, bitbucket_server.",
         "head_repo_name": "The head_repo_name field must be a string with maximum length of 255 characters.",
         "base_repo_name": "The base_repo_name field must be a string with maximum length of 255 characters.",
         "head_ref": "The head_ref field must be a string with maximum length of 255 characters.",

--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -104,6 +104,14 @@ def assemble_preprod_artifact(
             project_id=project_id,
             organization_id=org_id,
             artifact_id=artifact_id,
+            head_sha=kwargs.get("head_sha"),
+            base_sha=kwargs.get("base_sha"),
+            provider=kwargs.get("provider"),
+            head_repo_name=kwargs.get("head_repo_name"),
+            base_repo_name=kwargs.get("base_repo_name"),
+            head_ref=kwargs.get("head_ref"),
+            base_ref=kwargs.get("base_ref"),
+            pr_number=kwargs.get("pr_number"),
         )
 
     except Exception as e:
@@ -138,6 +146,14 @@ def create_preprod_artifact(
     project_id,
     checksum,
     build_configuration=None,
+    head_sha=None,
+    base_sha=None,
+    provider=None,
+    head_repo_name=None,
+    base_repo_name=None,
+    head_ref=None,
+    base_ref=None,
+    pr_number=None,
 ) -> str | None:
     try:
         organization = Organization.objects.get_from_cache(pk=org_id)
@@ -145,18 +161,34 @@ def create_preprod_artifact(
         bind_organization_context(organization)
 
         with transaction.atomic(router.db_for_write(PreprodArtifact)):
-            build_config = None
-            if build_configuration:
-                build_config, _ = PreprodBuildConfiguration.objects.get_or_create(
-                    project=project,
-                    name=build_configuration,
-                )
+            # Create CommitComparison if git information is provided
+        commit_comparison = None
+        if head_sha and head_repo_name:
+            commit_comparison, _ = CommitComparison.objects.get_or_create(
+                organization_id=org_id,
+                head_sha=head_sha,
+                base_sha=base_sha,
+                provider=provider,
+                head_repo_name=head_repo_name,
+                base_repo_name=base_repo_name,
+                head_ref=head_ref,
+                base_ref=base_ref,
+                pr_number=pr_number,
+            )
+
+        build_config = None
+        if build_configuration:
+            build_config, _ = PreprodBuildConfiguration.objects.get_or_create(
+                project=project,
+                name=build_configuration,
+            )
 
             preprod_artifact, _ = PreprodArtifact.objects.get_or_create(
                 project=project,
                 build_configuration=build_config,
                 state=PreprodArtifact.ArtifactState.UPLOADING,
-            )
+            commit_comparison=commit_comparison,
+        )
 
             logger.info(
                 "Created preprod artifact row",

--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -9,6 +9,7 @@ from typing import Any
 import sentry_sdk
 from django.db import router, transaction
 
+from sentry.models.commitcomparison import CommitComparison
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.preprod.api.models.project_preprod_size_analysis_models import SizeAnalysisResults

--- a/tests/sentry/preprod/api/endpoints/test_organization_preprod_artifact_assemble.py
+++ b/tests/sentry/preprod/api/endpoints/test_organization_preprod_artifact_assemble.py
@@ -38,8 +38,35 @@ class ValidatePreprodArtifactSchemaTest(TestCase):
         data = {
             "checksum": "a" * 40,
             "chunks": ["b" * 40, "c" * 40],
-            "git_sha": "d" * 40,
             "build_configuration": "release",
+            "head_sha": "e" * 40,
+            "base_sha": "f" * 40,
+            "provider": "github",
+            "head_repo_name": "owner/repo",
+            "base_repo_name": "owner/repo",
+            "head_ref": "feature/xyz",
+            "base_ref": "main",
+            "pr_number": 123,
+        }
+        body = orjson.dumps(data)
+        result, error = validate_preprod_artifact_schema(body)
+        assert error is None
+        assert result == data
+
+    def test_valid_schema_with_commit_comparison(self) -> None:
+        """Test valid schema with CommitComparison fields passes validation."""
+        data = {
+            "checksum": "a" * 40,
+            "chunks": ["b" * 40, "c" * 40],
+            "build_configuration": "release",
+            "head_sha": "e" * 40,
+            "base_sha": "f" * 40,
+            "provider": "github",
+            "head_repo_name": "owner/repo",
+            "base_repo_name": "owner/repo",
+            "head_ref": "feature/xyz",
+            "base_ref": "main",
+            "pr_number": 123,
         }
         body = orjson.dumps(data)
         result, error = validate_preprod_artifact_schema(body)
@@ -105,24 +132,46 @@ class ValidatePreprodArtifactSchemaTest(TestCase):
         assert error is not None
         assert result == {}
 
-    def test_git_sha_wrong_type(self) -> None:
-        """Test non-string git_sha returns error."""
-        body = orjson.dumps({"checksum": "a" * 40, "chunks": [], "git_sha": 123})
-        result, error = validate_preprod_artifact_schema(body)
-        assert error is not None
-        assert result == {}
-
-    def test_git_sha_invalid_format(self) -> None:
-        """Test invalid git_sha format returns error."""
-        body = orjson.dumps({"checksum": "a" * 40, "chunks": [], "git_sha": "invalid"})
-        result, error = validate_preprod_artifact_schema(body)
-        assert error is not None
-        assert "git_sha" in error
-        assert result == {}
-
     def test_build_configuration_wrong_type(self) -> None:
         """Test non-string build_configuration returns error."""
         body = orjson.dumps({"checksum": "a" * 40, "chunks": [], "build_configuration": 123})
+        result, error = validate_preprod_artifact_schema(body)
+        assert error is not None
+        assert result == {}
+
+    def test_head_sha_invalid_format(self) -> None:
+        """Test invalid head_sha format returns error."""
+        body = orjson.dumps({"checksum": "a" * 40, "chunks": [], "head_sha": "invalid"})
+        result, error = validate_preprod_artifact_schema(body)
+        assert error is not None
+        assert "head_sha" in error
+        assert result == {}
+
+    def test_base_sha_invalid_format(self) -> None:
+        """Test invalid base_sha format returns error."""
+        body = orjson.dumps({"checksum": "a" * 40, "chunks": [], "base_sha": "invalid"})
+        result, error = validate_preprod_artifact_schema(body)
+        assert error is not None
+        assert "base_sha" in error
+        assert result == {}
+
+    def test_provider_too_long(self) -> None:
+        """Test provider field too long returns error."""
+        body = orjson.dumps({"checksum": "a" * 40, "chunks": [], "provider": "a" * 65})
+        result, error = validate_preprod_artifact_schema(body)
+        assert error is not None
+        assert result == {}
+
+    def test_head_repo_name_too_long(self) -> None:
+        """Test head_repo_name field too long returns error."""
+        body = orjson.dumps({"checksum": "a" * 40, "chunks": [], "head_repo_name": "a" * 256})
+        result, error = validate_preprod_artifact_schema(body)
+        assert error is not None
+        assert result == {}
+
+    def test_pr_number_invalid(self) -> None:
+        """Test invalid pr_number returns error."""
+        body = orjson.dumps({"checksum": "a" * 40, "chunks": [], "pr_number": 0})
         result, error = validate_preprod_artifact_schema(body)
         assert error is not None
         assert result == {}
@@ -255,26 +304,6 @@ class ProjectPreprodArtifactAssembleTest(APITestCase):
         )
         assert response.status_code == 400, response.content
 
-    def test_assemble_json_schema_git_sha_wrong_type(self) -> None:
-        """Test that non-string git_sha is rejected."""
-        checksum = sha1(b"1").hexdigest()
-        response = self.client.post(
-            self.url,
-            data={"checksum": checksum, "chunks": [], "git_sha": 123},
-            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
-        )
-        assert response.status_code == 400, response.content
-
-    def test_assemble_json_schema_git_sha_invalid_format(self) -> None:
-        """Test that invalid git_sha format is rejected."""
-        checksum = sha1(b"1").hexdigest()
-        response = self.client.post(
-            self.url,
-            data={"checksum": checksum, "chunks": [], "git_sha": "invalid_sha"},
-            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
-        )
-        assert response.status_code == 400, response.content
-
     def test_assemble_json_schema_build_configuration_wrong_type(self) -> None:
         """Test that non-string build_configuration is rejected."""
         checksum = sha1(b"1").hexdigest()
@@ -304,8 +333,15 @@ class ProjectPreprodArtifactAssembleTest(APITestCase):
             data={
                 "checksum": checksum,
                 "chunks": [],
-                "git_sha": "c076e3b84d9d7c43f456908535ea78b9de6ec59b",
                 "build_configuration": "release",
+                "head_sha": "e" * 40,
+                "base_sha": "f" * 40,
+                "provider": "github",
+                "head_repo_name": "owner/repo",
+                "base_repo_name": "owner/repo",
+                "head_ref": "feature/xyz",
+                "base_ref": "main",
+                "pr_number": 123,
             },
             HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
         )
@@ -382,8 +418,15 @@ class ProjectPreprodArtifactAssembleTest(APITestCase):
             data={
                 "checksum": total_checksum,
                 "chunks": [blob.checksum],
-                "git_sha": "c076e3b84d9d7c43f456908535ea78b9de6ec59b",
                 "build_configuration": "release",
+                "head_sha": "e" * 40,
+                "base_sha": "f" * 40,
+                "provider": "github",
+                "head_repo_name": "owner/repo",
+                "base_repo_name": "owner/repo",
+                "head_ref": "feature/xyz",
+                "base_ref": "main",
+                "pr_number": 123,
             },
             HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
         )

--- a/tests/sentry/preprod/api/endpoints/test_organization_preprod_artifact_assemble.py
+++ b/tests/sentry/preprod/api/endpoints/test_organization_preprod_artifact_assemble.py
@@ -392,6 +392,15 @@ class ProjectPreprodArtifactAssembleTest(APITestCase):
                 "checksum": total_checksum,
                 "chunks": [blob.checksum],
                 "artifact_id": artifact_id,
+                "build_configuration": None,
+                "head_sha": None,
+                "base_sha": None,
+                "provider": None,
+                "head_repo_name": None,
+                "base_repo_name": None,
+                "head_ref": None,
+                "base_ref": None,
+                "pr_number": None,
             }
         )
 
@@ -449,6 +458,15 @@ class ProjectPreprodArtifactAssembleTest(APITestCase):
                 "checksum": total_checksum,
                 "chunks": [blob.checksum],
                 "artifact_id": artifact_id,
+                "build_configuration": "release",
+                "head_sha": "e" * 40,
+                "base_sha": "f" * 40,
+                "provider": "github",
+                "head_repo_name": "owner/repo",
+                "base_repo_name": "owner/repo",
+                "head_ref": "feature/xyz",
+                "base_ref": "main",
+                "pr_number": 123,
             }
         )
 

--- a/tests/sentry/preprod/test_tasks.py
+++ b/tests/sentry/preprod/test_tasks.py
@@ -2,6 +2,7 @@ from hashlib import sha1
 
 from django.core.files.base import ContentFile
 
+from sentry.models.commitcomparison import CommitComparison
 from sentry.models.files.file import File
 from sentry.models.files.fileblob import FileBlob
 from sentry.preprod.models import (
@@ -57,6 +58,7 @@ class AssemblePreprodArtifactTest(BaseAssembleTest):
             checksum=total_checksum,
             chunks=[blob.checksum],
             artifact_id=artifact_id,
+            build_configuration="release",
         )
 
         # The main assemble_preprod_artifact task doesn't set assembly status
@@ -76,8 +78,57 @@ class AssemblePreprodArtifactTest(BaseAssembleTest):
 
         artifacts = PreprodArtifact.objects.filter(project=self.project)
         assert len(artifacts) == 1
+        assert artifacts[0].file_id == files[0].id
         assert artifacts[0].build_configuration == build_configs[0]
-        assert artifacts[0].state == PreprodArtifact.ArtifactState.UPLOADED
+
+        delete_assemble_status(AssembleTask.PREPROD_ARTIFACT, self.project.id, total_checksum)
+
+    def test_assemble_preprod_artifact_with_commit_comparison(self) -> None:
+        """Test that assemble_preprod_artifact creates CommitComparison when git info is provided"""
+        content = b"test preprod artifact with commit comparison"
+        fileobj = ContentFile(content)
+        total_checksum = sha1(content).hexdigest()
+
+        blob = FileBlob.from_file_with_organization(fileobj, self.organization)
+
+        assemble_preprod_artifact(
+            org_id=self.organization.id,
+            project_id=self.project.id,
+            checksum=total_checksum,
+            chunks=[blob.checksum],
+            head_sha="a" * 40,
+            base_sha="b" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+            head_ref="feature/xyz",
+            base_ref="main",
+            pr_number=123,
+        )
+
+        status, details = get_assemble_status(
+            AssembleTask.PREPROD_ARTIFACT, self.project.id, total_checksum
+        )
+        assert status == ChunkFileState.OK
+
+        # Verify CommitComparison was created
+        commit_comparisons = CommitComparison.objects.filter(
+            organization_id=self.organization.id,
+            head_sha="a" * 40,
+            base_sha="b" * 40,
+        )
+        assert len(commit_comparisons) == 1
+        commit_comparison = commit_comparisons[0]
+        assert commit_comparison.provider == "github"
+        assert commit_comparison.head_repo_name == "owner/repo"
+        assert commit_comparison.base_repo_name == "owner/repo"
+        assert commit_comparison.head_ref == "feature/xyz"
+        assert commit_comparison.base_ref == "main"
+        assert commit_comparison.pr_number == 123
+
+        # Verify PreprodArtifact was created
+        artifacts = PreprodArtifact.objects.filter(project=self.project)
+        assert len(artifacts) == 1
 
     def test_assemble_preprod_artifact_without_build_configuration(self) -> None:
         """Test that assemble_preprod_artifact succeeds without build_configuration"""


### PR DESCRIPTION
Pending FK being added on PreprodArtifact to CommitComparison, this wires up the assemble endpoint to take VCS-related params and create the CommitComparison model. sentry-cli changes to come.

Notably, this removes the unused `git_sha` param in favor of the new fields.