### PR TITLE
fix(workflow_engine): Reduce number of queries when evaluating detectors

### DIFF
--- a/src/sentry/db/models/utils.py
+++ b/src/sentry/db/models/utils.py
@@ -14,6 +14,21 @@ if TYPE_CHECKING:
     from sentry.db.models.base import Model as SentryModel
 
 
+def is_model_attr_cached(model: Model, attr: str) -> bool:
+    is_prefetched = (
+        hasattr(model, "_prefetched_objects_cache") and attr in model._prefetched_objects_cache
+    )
+    field = getattr(type(model), attr)
+
+    if hasattr(field, "is_cached"):
+        is_selected = field.is_cached(model)
+    else:
+        # For regular fields, check if not deferred
+        is_selected = attr not in model.get_deferred_fields()
+
+    return is_prefetched or is_selected
+
+
 def unique_db_instance(
     inst: SentryModel,
     base_value: str,

--- a/src/sentry/db/models/utils.py
+++ b/src/sentry/db/models/utils.py
@@ -15,6 +15,17 @@ if TYPE_CHECKING:
 
 
 def is_model_attr_cached(model: Model, attr: str) -> bool:
+    """
+    This method will check to see if the given attribute is already annotated / cached
+    on the given model instance. The primary use case for this method is to determine
+    if django will issue a query to fetch a related attribute or not.
+
+    If the attribute has been prefetched or selected, then this method will return True,
+    otherwise it will return False.
+
+    model `Model`: The model instance to check, this can be any model that's based on `django.db.models.Model`
+    attr `str`: The attribute, as a string, to check if it's cached or prefetched on the django model
+    """
     is_prefetched = (
         hasattr(model, "_prefetched_objects_cache") and attr in model._prefetched_objects_cache
     )

--- a/src/sentry/workflow_engine/handlers/detector/stateful.py
+++ b/src/sentry/workflow_engine/handlers/detector/stateful.py
@@ -573,11 +573,16 @@ class StatefulDetectorHandler(
             hasattr(self.detector.workflow_condition_group, "_prefetched_objects_cache")
             and "conditions" in self.detector.workflow_condition_group._prefetched_objects_cache
         ):
-            condition_result_levels = list(self.detector.workflow_condition_group.conditions.all())
+            condition_result_levels = list(
+                condition.condition_result
+                for condition in self.detector.workflow_condition_group.conditions.all()
+            )
         else:
-            condition_result_levels = self.detector.workflow_condition_group.conditions.filter(
-                condition_result__in=priority_levels
-            ).values_list("condition_result", flat=True)
+            condition_result_levels = list(
+                self.detector.workflow_condition_group.conditions.filter(
+                    condition_result__in=priority_levels
+                ).values_list("condition_result", flat=True)
+            )
 
         return list(DetectorPriorityLevel(level) for level in condition_result_levels)
 

--- a/src/sentry/workflow_engine/handlers/detector/stateful.py
+++ b/src/sentry/workflow_engine/handlers/detector/stateful.py
@@ -569,11 +569,15 @@ class StatefulDetectorHandler(
         if self.detector.workflow_condition_group is None:
             return []
 
-        # TODO - Is this something that should be provided by the detector itself rather
-        # than having to query the db for each level?
-        condition_result_levels = self.detector.workflow_condition_group.conditions.filter(
-            condition_result__in=priority_levels
-        ).values_list("condition_result", flat=True)
+        if (
+            hasattr(self.detector.workflow_condition_group, "_prefetched_objects_cache")
+            and "conditions" in self.detector.workflow_condition_group._prefetched_objects_cache
+        ):
+            condition_result_levels = list(self.detector.workflow_condition_group.conditions.all())
+        else:
+            condition_result_levels = self.detector.workflow_condition_group.conditions.filter(
+                condition_result__in=priority_levels
+            ).values_list("condition_result", flat=True)
 
         return list(DetectorPriorityLevel(level) for level in condition_result_levels)
 

--- a/src/sentry/workflow_engine/handlers/detector/stateful.py
+++ b/src/sentry/workflow_engine/handlers/detector/stateful.py
@@ -9,6 +9,7 @@ from django.conf import settings
 from django.db.models import Q
 from sentry_redis_tools.retrying_cluster import RetryingRedisCluster
 
+from sentry.db.models.utils import is_model_attr_cached
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.issues.status_change_message import StatusChangeMessage
 from sentry.models.group import GroupStatus
@@ -569,10 +570,7 @@ class StatefulDetectorHandler(
         if self.detector.workflow_condition_group is None:
             return []
 
-        if (
-            hasattr(self.detector.workflow_condition_group, "_prefetched_objects_cache")
-            and "conditions" in self.detector.workflow_condition_group._prefetched_objects_cache
-        ):
+        if is_model_attr_cached(self.detector.workflow_condition_group, "conditions"):
             condition_result_levels = list(
                 condition.condition_result
                 for condition in self.detector.workflow_condition_group.conditions.all()

--- a/tests/sentry/db/models/test_utils.py
+++ b/tests/sentry/db/models/test_utils.py
@@ -1,6 +1,74 @@
-from sentry.db.models.utils import slugify_instance
+from sentry.db.models.utils import is_model_attr_cached, slugify_instance
 from sentry.models.organization import Organization
 from sentry.testutils.cases import TestCase
+from sentry.workflow_engine.models import Detector
+
+
+class TestIsModelAttrCached(TestCase):
+    def test_works_with_standard_attrs(self) -> None:
+        org = self.create_organization()
+        assert is_model_attr_cached(org, "name") is True
+
+    def test_creation_association(self) -> None:
+        detector = self.create_detector()
+        assert is_model_attr_cached(detector, "workflow_condition_group") is False
+
+        detector.workflow_condition_group = self.create_data_condition_group()
+        detector.save()
+        refetched_detector = Detector.objects.get(id=detector.id)
+
+        # Detector maintains the association in memory
+        assert is_model_attr_cached(detector, "workflow_condition_group") is True
+
+        # When refetched, the association is not cached
+        assert is_model_attr_cached(refetched_detector, "workflow_condition_group") is False
+
+    def test_select_related(self) -> None:
+        detector = self.create_detector()
+        detector.workflow_condition_group = self.create_data_condition_group()
+        self.create_data_condition(
+            condition_group=detector.workflow_condition_group,
+            condition_result=75,
+        )
+
+        detector.save()
+
+        refetched_detector = (
+            Detector.objects.filter(id=detector.id)
+            .select_related("workflow_condition_group")
+            .first()
+        )
+
+        assert refetched_detector is not None
+        assert is_model_attr_cached(refetched_detector, "workflow_condition_group") is True
+
+    def test_prefetch(self) -> None:
+        detector = self.create_detector()
+        detector.workflow_condition_group = self.create_data_condition_group()
+        self.create_data_condition(
+            condition_group=detector.workflow_condition_group,
+            condition_result=75,
+        )
+
+        detector.save()
+
+        refetched_detector = (
+            Detector.objects.filter(id=detector.id)
+            .select_related("workflow_condition_group")
+            .prefetch_related("workflow_condition_group__conditions")
+            .first()
+        )
+
+        assert refetched_detector is not None
+        assert refetched_detector.workflow_condition_group is not None
+        assert is_model_attr_cached(refetched_detector, "workflow_condition_group") is True
+        assert (
+            is_model_attr_cached(refetched_detector.workflow_condition_group, "conditions") is True
+        )
+
+        # use the same model, but different query to ensure cache check is correct
+        another = Detector.objects.get(id=detector.id)
+        assert is_model_attr_cached(another, "workflow_condition_group") is False
 
 
 class SlugifyInstanceTest(TestCase):

--- a/tests/sentry/workflow_engine/handlers/detector/test_stateful.py
+++ b/tests/sentry/workflow_engine/handlers/detector/test_stateful.py
@@ -3,7 +3,7 @@ import unittest.mock as mock
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.issues.status_change_message import StatusChangeMessage
 from sentry.testutils.cases import TestCase
-from sentry.workflow_engine.models import DataPacket
+from sentry.workflow_engine.models import DataPacket, Detector
 from sentry.workflow_engine.types import DetectorGroupKey, DetectorPriorityLevel
 from tests.sentry.workflow_engine.handlers.detector.test_base import MockDetectorStateHandler
 
@@ -16,6 +16,21 @@ class TestStatefulDetectorHandler(TestCase):
             name="Stateful Detector",
             project=self.project,
         )
+
+    def _get_full_detector(self) -> Detector:
+        """
+        Fetches the full detector with its workflow condition group and conditions.
+        This is useful to ensure that the detector is fully populated for testing.
+        """
+        detector = (
+            Detector.objects.filter(id=self.detector.id)
+            .select_related("workflow_condition_group")
+            .prefetch_related("workflow_condition_group__conditions")
+            .first()
+        )
+
+        assert detector is not None
+        return detector
 
     def test__init_creates_default_thresholds(self) -> None:
         handler = MockDetectorStateHandler(detector=self.detector)
@@ -46,22 +61,20 @@ class TestStatefulDetectorHandler(TestCase):
             condition_result=Level.HIGH,
         )
 
-        with mock.patch.object(
-            self.detector.workflow_condition_group.conditions, "filter"
-        ) as mock_filter:
-            handler = MockDetectorStateHandler(detector=self.detector)
-            assert not mock_filter.called
+        fetched_detector = self._get_full_detector()
+
+        with self.assertNumQueries(0):
+            handler = MockDetectorStateHandler(detector=fetched_detector)
             assert handler._thresholds == {Level.OK: 1, Level.HIGH: 1}
 
     def test_init__threshold_query_no_conditions(self) -> None:
         self.detector.workflow_condition_group = self.create_data_condition_group()
         self.detector.save()
 
-        with mock.patch.object(
-            self.detector.workflow_condition_group.conditions, "filter"
-        ) as mock_filter:
-            handler = MockDetectorStateHandler(detector=self.detector)
-            assert not mock_filter.called
+        fetched_detector = self._get_full_detector()
+
+        with self.assertNumQueries(0):
+            handler = MockDetectorStateHandler(detector=fetched_detector)
             assert handler._thresholds == {Level.OK: 1}
 
     def test_init__threshold_makes_query(self) -> None:
@@ -75,11 +88,11 @@ class TestStatefulDetectorHandler(TestCase):
             condition_result=Level.HIGH,
         )
 
-        with mock.patch.object(
-            self.detector.workflow_condition_group.conditions, "filter"
-        ) as mock_filter:
-            handler = MockDetectorStateHandler(detector=self.detector)
-            assert mock_filter.called
+        fetched_detector = Detector.objects.get(id=self.detector.id)
+
+        with self.assertNumQueries(1):
+            # Should make a query since we don't know the detector conditions
+            handler = MockDetectorStateHandler(detector=fetched_detector)
             assert handler._thresholds == {Level.OK: 1, Level.HIGH: 1}
 
 

--- a/tests/sentry/workflow_engine/models/test_detector.py
+++ b/tests/sentry/workflow_engine/models/test_detector.py
@@ -1,5 +1,6 @@
 from sentry.constants import ObjectStatus
 from sentry.workflow_engine.models import Detector
+from sentry.workflow_engine.types import DetectorPriorityLevel
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 
 
@@ -19,3 +20,63 @@ class DetectorTest(BaseWorkflowTest):
         self.detector.status = ObjectStatus.DELETION_IN_PROGRESS
         self.detector.save()
         assert not Detector.objects.filter(id=self.detector.id).exists()
+
+    def test_get_conditions__cached(self) -> None:
+        self.detector.workflow_condition_group = self.create_data_condition_group()
+        self.detector.save()
+
+        self.create_data_condition(
+            type="eq",
+            comparison="HIGH",
+            condition_group=self.detector.workflow_condition_group,
+            condition_result=DetectorPriorityLevel.HIGH,
+        )
+
+        fetched_detector = (
+            Detector.objects.filter(id=self.detector.id)
+            .select_related("workflow_condition_group")
+            .prefetch_related("workflow_condition_group__conditions")
+            .first()
+        )
+
+        assert fetched_detector is not None
+        with self.assertNumQueries(0):
+            conditions = fetched_detector.get_conditions()
+            assert conditions
+
+    def test_get_conditions__cached_group_only(self) -> None:
+        self.detector.workflow_condition_group = self.create_data_condition_group()
+        self.detector.save()
+        self.create_data_condition(
+            type="eq",
+            comparison="HIGH",
+            condition_group=self.detector.workflow_condition_group,
+            condition_result=DetectorPriorityLevel.HIGH,
+        )
+
+        fetched_detector = (
+            Detector.objects.filter(id=self.detector.id)
+            .select_related("workflow_condition_group")
+            .first()
+        )
+
+        assert fetched_detector is not None
+        with self.assertNumQueries(1):
+            conditions = fetched_detector.get_conditions()
+            assert conditions
+
+    def test_get_conditions__not_cached(self) -> None:
+        self.detector.workflow_condition_group = self.create_data_condition_group()
+        self.detector.save()
+
+        self.create_data_condition(
+            type="eq",
+            comparison="HIGH",
+            condition_group=self.detector.workflow_condition_group,
+            condition_result=DetectorPriorityLevel.HIGH,
+        )
+
+        fetched_detector = Detector.objects.get(id=self.detector.id)
+        with self.assertNumQueries(1):
+            conditions = fetched_detector.get_conditions()
+            assert conditions

--- a/tests/sentry/workflow_engine/processors/test_detector.py
+++ b/tests/sentry/workflow_engine/processors/test_detector.py
@@ -16,6 +16,7 @@ from sentry.models.activity import Activity
 from sentry.models.group import GroupStatus
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import freeze_time
+from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.types.activity import ActivityType
 from sentry.types.group import PriorityLevel
 from sentry.utils.cache import cache
@@ -339,6 +340,7 @@ class TestProcessDetectors(BaseDetectorHandlerTest):
             mock_incr.assert_not_called()
 
 
+@django_db_all
 class TestKeyBuilders(unittest.TestCase):
     def build_handler(self, detector: Detector | None = None) -> MockDetectorStateHandler:
         if detector is None:


### PR DESCRIPTION
# Description
We only need to lookup the thresholds on detectors that aren't fully decorated. Currently we fetch these conditions each time.

This PR will check to see if the model has the associated data, if it doesn't the query will still happen. However, if the detector was fetched using `process_data_source` we can skip this second query and access the conditions directly.