### PR TITLE
feat(notif-platform): Add template validation on provider

### DIFF
--- a/src/sentry/notifications/platform/discord/provider.py
+++ b/src/sentry/notifications/platform/discord/provider.py
@@ -38,6 +38,10 @@ class DiscordNotificationProvider(NotificationProvider[DiscordRenderable]):
     ]
 
     @classmethod
+    def validate_rendered_template(cls, *, rendered_template: NotificationRenderedTemplate) -> None:
+        pass
+
+    @classmethod
     def is_available(cls, *, organization: RpcOrganizationSummary | None = None) -> bool:
         # TODO(ecosystem): Check for the integration, maybe a feature as well
         return False

--- a/src/sentry/notifications/platform/email/provider.py
+++ b/src/sentry/notifications/platform/email/provider.py
@@ -35,6 +35,10 @@ class EmailNotificationProvider(NotificationProvider[EmailRenderable]):
     target_resource_types = [NotificationTargetResourceType.EMAIL]
 
     @classmethod
+    def validate_rendered_template(cls, *, rendered_template: NotificationRenderedTemplate) -> None:
+        pass
+
+    @classmethod
     def is_available(cls, *, organization: RpcOrganizationSummary | None = None) -> bool:
         return True
 

--- a/src/sentry/notifications/platform/msteams/provider.py
+++ b/src/sentry/notifications/platform/msteams/provider.py
@@ -38,6 +38,10 @@ class MSTeamsNotificationProvider(NotificationProvider[MSTeamsRenderable]):
     ]
 
     @classmethod
+    def validate_rendered_template(cls, *, rendered_template: NotificationRenderedTemplate) -> None:
+        pass
+
+    @classmethod
     def is_available(cls, *, organization: RpcOrganizationSummary | None = None) -> bool:
         # TODO(ecosystem): Check for the integration, maybe a feature as well
         return False

--- a/src/sentry/notifications/platform/provider.py
+++ b/src/sentry/notifications/platform/provider.py
@@ -5,6 +5,7 @@ from sentry.notifications.platform.types import (
     NotificationCategory,
     NotificationData,
     NotificationProviderKey,
+    NotificationRenderedTemplate,
     NotificationTarget,
     NotificationTargetResourceType,
 )
@@ -49,6 +50,14 @@ class NotificationProvider[RenderableT](Protocol):
                 f"Supported resource types: {', '.join(t.value for t in cls.target_resource_types)}"
             )
         return
+
+    @classmethod
+    def validate_rendered_template(cls, *, rendered_template: NotificationRenderedTemplate) -> None:
+        """
+        Validates that a given rendered template is permissible for the provider.
+        This adheres to provider-specific constrains such as character limits.
+        """
+        ...
 
     @classmethod
     def get_renderer(

--- a/src/sentry/notifications/platform/service.py
+++ b/src/sentry/notifications/platform/service.py
@@ -46,6 +46,14 @@ class NotificationService[T: NotificationData]:
         template_cls = template_registry.get(self.data.source)
         template = template_cls()
         rendered_template = template.render(data=self.data)
+        try:
+            provider.validate_rendered_template(rendered_template=rendered_template)
+        except Exception as e:
+            raise NotificationServiceError(
+                f"Rendered template is invalid for provider {provider.key}: {e}"
+            )
+
+        # Step 5: Create the provider-specific renderable
         renderer = provider.get_renderer(data=self.data, category=template.category)
         renderable = renderer.render(data=self.data, rendered_template=rendered_template)
 

--- a/src/sentry/notifications/platform/slack/provider.py
+++ b/src/sentry/notifications/platform/slack/provider.py
@@ -38,6 +38,10 @@ class SlackNotificationProvider(NotificationProvider[SlackRenderable]):
     ]
 
     @classmethod
+    def validate_rendered_template(cls, *, rendered_template: NotificationRenderedTemplate) -> None:
+        pass
+
+    @classmethod
     def is_available(cls, *, organization: RpcOrganizationSummary | None = None) -> bool:
         # TODO(ecosystem): Check for the integration, maybe a feature as well
         return False

--- a/src/sentry/notifications/platform/types.py
+++ b/src/sentry/notifications/platform/types.py
@@ -32,6 +32,8 @@ class NotificationProviderKey(StrEnum):
     The unique keys for each registered notification provider.
     """
 
+    MOCK = "mock"  # For testing purposes only
+
     EMAIL = ExternalProviderEnum.EMAIL
     SLACK = ExternalProviderEnum.SLACK
     MSTEAMS = ExternalProviderEnum.MSTEAMS
@@ -149,14 +151,6 @@ class NotificationTemplate[T: NotificationData](abc.ABC):
     The category that a notification belongs to. This will be used to determine which settings a
     user needs to modify to manage receipt of these notifications (if applicable).
     """
-    # @property
-    # @abc.abstractmethod
-    # def category(self) -> NotificationCategory:
-    #     """
-    #     The category that a notification belongs to. This will be used to determine which settings a
-    #     user needs to modify to manage receipt of these notifications (if applicable).
-    #     """
-    #     ...
 
     @abc.abstractmethod
     def render(self, data: T) -> NotificationRenderedTemplate:
@@ -172,3 +166,4 @@ class NotificationTemplate[T: NotificationData](abc.ABC):
         Used to produce a debugging example rendered template for this notification. This
         implementation should be pure, and not populate with any live data.
         """
+        ...

--- a/src/sentry/testutils/notifications/platform.py
+++ b/src/sentry/testutils/notifications/platform.py
@@ -1,14 +1,51 @@
 from dataclasses import dataclass
+from typing import Any
 
-from sentry.notifications.platform.registry import template_registry
+from sentry.notifications.platform.provider import NotificationProvider
+from sentry.notifications.platform.registry import provider_registry, template_registry
+from sentry.notifications.platform.renderer import NotificationRenderer
+from sentry.notifications.platform.target import IntegrationNotificationTarget
 from sentry.notifications.platform.types import (
     NotificationCategory,
     NotificationData,
+    NotificationProviderKey,
     NotificationRenderedTemplate,
     NotificationStrategy,
     NotificationTarget,
+    NotificationTargetResourceType,
     NotificationTemplate,
 )
+
+
+class MockRenderer(NotificationRenderer[Any]):
+    provider_key = NotificationProviderKey.MOCK
+
+    @classmethod
+    def render[DataT: NotificationData](
+        cls, *, data: DataT, rendered_template: NotificationRenderedTemplate
+    ) -> Any:
+        return {
+            "subject": rendered_template.subject,
+            "body": rendered_template.body,
+            "actions": rendered_template.actions,
+            "chart": rendered_template.chart,
+            "footer": rendered_template.footer,
+        }
+
+
+@provider_registry.register(NotificationProviderKey.MOCK)
+class MockIntegrationProvider(NotificationProvider[Any]):
+    key = NotificationProviderKey.MOCK
+    target_class = IntegrationNotificationTarget
+    target_resource_types = [
+        NotificationTargetResourceType.CHANNEL,
+        NotificationTargetResourceType.DIRECT_MESSAGE,
+    ]
+    default_renderer = MockRenderer
+
+    @classmethod
+    def validate_rendered_template(cls, *, rendered_template: NotificationRenderedTemplate) -> None:
+        assert isinstance(rendered_template.body, str)
 
 
 @dataclass(kw_only=True, frozen=True)


### PR DESCRIPTION
This will enable a system in the service layer to validate the template against the provider. This will be iterated on, but the idea is for providers like slack to have a place to adhere to character limits or sets (or other constraints).