### PR TITLE
fix(upsampling) - fix events-stats failing on queries including status for upsampled projects

### DIFF
--- a/src/sentry/search/events/datasets/discover.py
+++ b/src/sentry/search/events/datasets/discover.py
@@ -10,6 +10,7 @@ from snuba_sdk import (
     Condition,
     CurriedFunction,
     Direction,
+    Entity,
     Function,
     Identifier,
     Lambda,
@@ -1043,7 +1044,23 @@ class DiscoverDatasetConfig(DatasetConfig):
                     required_args=[],
                     snql_aggregate=lambda args, alias: Function(
                         "toInt64",
-                        [Function("sum", [Function("ifNull", [Column("sample_weight"), 1])])],
+                        [
+                            Function(
+                                "sum",
+                                [
+                                    Function(
+                                        "ifNull",
+                                        [
+                                            Column(
+                                                "sample_weight",
+                                                entity=Entity("events", alias="events"),
+                                            ),
+                                            1,
+                                        ],
+                                    )
+                                ],
+                            )
+                        ],
                         alias,
                     ),
                     default_result_type="integer",

--- a/src/sentry/search/events/datasets/function_aliases.py
+++ b/src/sentry/search/events/datasets/function_aliases.py
@@ -1,7 +1,7 @@
 from collections.abc import Callable, Mapping, Sequence
 from typing import Any
 
-from snuba_sdk import Column, Function
+from snuba_sdk import Column, Entity, Function
 
 from sentry.exceptions import IncompatibleMetricsQuery, InvalidSearchQuery
 from sentry.models.transaction_threshold import (
@@ -390,7 +390,18 @@ def resolve_upsampled_eps(
         interval = args["interval"]
     return Function(
         "divide",
-        [Function("sum", [Function("ifNull", [Column("sample_weight"), 1])]), interval],
+        [
+            Function(
+                "sum",
+                [
+                    Function(
+                        "ifNull",
+                        [Column("sample_weight", entity=Entity("events", alias="events")), 1],
+                    )
+                ],
+            ),
+            interval,
+        ],
         alias,
     )
 
@@ -423,7 +434,15 @@ def resolve_upsampled_epm(
     return Function(
         "divide",
         [
-            Function("sum", [Function("ifNull", [Column("sample_weight"), 1])]),
+            Function(
+                "sum",
+                [
+                    Function(
+                        "ifNull",
+                        [Column("sample_weight", entity=Entity("events", alias="events")), 1],
+                    )
+                ],
+            ),
             Function("divide", [interval, 60]),
         ],
         alias,


### PR DESCRIPTION
When querying for group status we join on group-attributes, but the way `upsampled_count` was implemented the `sample_weight` column was not mapped to the events entity and so the query failed.
Added explicit entity mapping to fix the issue.