### PR TITLE
fix(aci): attach workflow env to triggered actions

### DIFF
--- a/src/sentry/workflow_engine/processors/action.py
+++ b/src/sentry/workflow_engine/processors/action.py
@@ -46,7 +46,7 @@ def get_workflow_action_group_statuses(
 
     all_statuses = WorkflowActionGroupStatus.objects.filter(
         group=group, action_id__in=action_to_workflows_ids.keys(), workflow_id__in=workflow_ids
-    ).order_by("workflow_id")
+    )
 
     actions_with_statuses: dict[int, list[WorkflowActionGroupStatus]] = defaultdict(list)
 

--- a/src/sentry/workflow_engine/processors/action.py
+++ b/src/sentry/workflow_engine/processors/action.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 from datetime import datetime, timedelta
 
 from django.db import models
+from django.db.models import Case, Value, When
 from django.utils import timezone
 
 from sentry import features
@@ -45,7 +46,7 @@ def get_workflow_action_group_statuses(
 
     all_statuses = WorkflowActionGroupStatus.objects.filter(
         group=group, action_id__in=action_to_workflows_ids.keys(), workflow_id__in=workflow_ids
-    )
+    ).order_by("workflow_id")
 
     actions_with_statuses: dict[int, list[WorkflowActionGroupStatus]] = defaultdict(list)
 
@@ -157,10 +158,14 @@ def filter_recently_fired_workflow_actions(
     )
     update_workflow_action_group_statuses(now, statuses_to_update, missing_statuses)
 
+    # annotate actions with workflow_id they are firing for (deduped)
+    workflow_id_cases = [
+        When(id=action_id, then=Value(workflow_id))
+        for action_id, workflow_id in action_to_workflow_ids.items()
+    ]
+
     return Action.objects.filter(id__in=list(action_to_workflow_ids.keys())).annotate(
-        workflow_id=models.F(
-            "dataconditiongroupaction__condition_group__workflowdataconditiongroup__workflow__id"
-        )
+        workflow_id=Case(*workflow_id_cases, output_field=models.IntegerField()),
     )
 
 

--- a/src/sentry/workflow_engine/tasks/actions.py
+++ b/src/sentry/workflow_engine/tasks/actions.py
@@ -51,7 +51,6 @@ def build_trigger_action_task_params(action, detector, event_data: WorkflowEvent
         "group_state": event_data.group_state,
         "has_reappeared": event_data.has_reappeared,
         "has_escalated": event_data.has_escalated,
-        "workflow_env_id": event_data.workflow_env.id if event_data.workflow_env else None,
     }
 
 
@@ -85,7 +84,6 @@ def trigger_action(
     group_state: GroupState,
     has_reappeared: bool,
     has_escalated: bool,
-    workflow_env_id: int | None,
 ) -> None:
     from sentry.notifications.notification_action.utils import should_fire_workflow_actions
 
@@ -113,11 +111,11 @@ def trigger_action(
             project_id=project_id,
             event_id=event_id,
             group_id=group_id,
+            workflow_id=workflow_id,
             occurrence_id=occurrence_id,
             group_state=group_state,
             has_reappeared=has_reappeared,
             has_escalated=has_escalated,
-            workflow_env_id=workflow_env_id,
         )
 
     elif activity_id is not None:

--- a/src/sentry/workflow_engine/tasks/utils.py
+++ b/src/sentry/workflow_engine/tasks/utils.py
@@ -71,7 +71,7 @@ def build_workflow_event_data_from_event(
     group_event = GroupEvent.from_event(event, group)
     group_event.occurrence = occurrence
 
-    # Fetch environment if provided
+    # Fetch environment from workflow
     workflow_env: Environment | None = (
         Workflow.objects.filter(id=workflow_id).select_related("environment").get().environment
     )

--- a/src/sentry/workflow_engine/tasks/utils.py
+++ b/src/sentry/workflow_engine/tasks/utils.py
@@ -50,7 +50,7 @@ def build_workflow_event_data_from_event(
     project_id: int,
     event_id: str,
     group_id: int,
-    workflow_id: int,
+    workflow_id: int | None = None,
     occurrence_id: str | None = None,
     group_state: GroupState | None = None,
     has_reappeared: bool = False,
@@ -71,10 +71,12 @@ def build_workflow_event_data_from_event(
     group_event = GroupEvent.from_event(event, group)
     group_event.occurrence = occurrence
 
-    # Fetch environment from workflow
-    workflow_env: Environment | None = (
-        Workflow.objects.filter(id=workflow_id).select_related("environment").get().environment
-    )
+    # Fetch environment from workflow, if provided
+    workflow_env: Environment | None = None
+    if workflow_id:
+        workflow_env = (
+            Workflow.objects.filter(id=workflow_id).select_related("environment").get().environment
+        )
 
     return WorkflowEventData(
         event=group_event,

--- a/src/sentry/workflow_engine/tasks/utils.py
+++ b/src/sentry/workflow_engine/tasks/utils.py
@@ -9,6 +9,7 @@ from sentry.models.environment import Environment
 from sentry.models.group import Group
 from sentry.types.activity import ActivityType
 from sentry.utils.retries import ConditionalRetryPolicy, exponential_delay
+from sentry.workflow_engine.models.workflow import Workflow
 from sentry.workflow_engine.types import WorkflowEventData
 from sentry.workflow_engine.utils import log_context
 
@@ -49,11 +50,11 @@ def build_workflow_event_data_from_event(
     project_id: int,
     event_id: str,
     group_id: int,
+    workflow_id: int,
     occurrence_id: str | None = None,
     group_state: GroupState | None = None,
     has_reappeared: bool = False,
     has_escalated: bool = False,
-    workflow_env_id: int | None = None,
 ) -> WorkflowEventData:
     """
     Build a WorkflowEventData object from individual parameters.
@@ -71,9 +72,9 @@ def build_workflow_event_data_from_event(
     group_event.occurrence = occurrence
 
     # Fetch environment if provided
-    workflow_env = None
-    if workflow_env_id:
-        workflow_env = Environment.objects.get(id=workflow_env_id)
+    workflow_env: Environment | None = (
+        Workflow.objects.filter(id=workflow_id).select_related("environment").get().environment
+    )
 
     return WorkflowEventData(
         event=group_event,

--- a/tests/sentry/workflow_engine/processors/test_action.py
+++ b/tests/sentry/workflow_engine/processors/test_action.py
@@ -104,10 +104,8 @@ class TestFilterRecentlyFiredWorkflowActions(BaseWorkflowTest):
         )
         # dedupes action if both workflows will fire it
         assert set(triggered_actions) == {self.action}
-        assert {getattr(action, "workflow_id") for action in triggered_actions} == {
-            self.workflow.id,
-            workflow.id,
-        }
+        # Dedupes action so we have a single workflow_id -> environment to fire with
+        assert {getattr(action, "workflow_id") for action in triggered_actions} == {workflow.id}
 
         assert WorkflowActionGroupStatus.objects.filter(action=self.action).count() == 2
 
@@ -131,8 +129,7 @@ class TestFilterRecentlyFiredWorkflowActions(BaseWorkflowTest):
         # fires one action for the workflow that can fire it
         assert set(triggered_actions) == {self.action}
         assert {getattr(action, "workflow_id") for action in triggered_actions} == {
-            self.workflow.id,
-            workflow.id,
+            self.workflow.id
         }
 
         assert WorkflowActionGroupStatus.objects.filter(action=self.action).count() == 2

--- a/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
@@ -926,12 +926,14 @@ class TestFireActionsForGroups(TestDelayedWorkflowBase):
         assert first_call_kwargs["detector_id"] == self.detector.id
         assert first_call_kwargs["event_id"] == self.event1.event_id
         assert first_call_kwargs["group_id"] == self.group1.id
+        assert first_call_kwargs["workflow_id"] == self.workflow1.id
 
         # Second call should be for workflow2/group2
         second_call_kwargs = mock_trigger.call_args_list[1].kwargs["kwargs"]
         assert second_call_kwargs["detector_id"] == self.detector.id
         assert second_call_kwargs["event_id"] == self.event2.event_id
         assert second_call_kwargs["group_id"] == self.group2.id
+        assert second_call_kwargs["workflow_id"] == self.workflow2.id
 
     @patch("sentry.workflow_engine.processors.workflow.process_data_condition_group")
     def test_fire_actions_for_groups__workflow_fire_history(self, mock_process: MagicMock) -> None:


### PR DESCRIPTION
Fixes filtering actions to correctly attach the workflow the action is firing for. In the future an action can be attached to multiple workflows, and we want to dedupe them to not fire multiple times for a single event.

This deduped list is already being returned as `action_to_workflow_ids` (mapping an action to a single workflow even if it's attached to multiple). We should annotate the Action objects with these `workflow_ids` and find the workflow environment in the trigger actions task.

This change will cover firing actions with the correct workflow env for both `process_workflows` and `process_delayed_workflows`

Fixes ACI-447