### PR TITLE
chore(aci): start to move delayed workflow task to workflow engine pool

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3088,6 +3088,12 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
+    "delayed_workflow.use_workflow_engine_pool",
+    type=Bool,
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
     "delayed_workflow.rollout",
     type=Bool,
     default=False,

--- a/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
@@ -326,6 +326,18 @@ class TestDelayedWorkflowHelpers(TestDelayedWorkflowBase):
         for instance in event_data.events.values():
             assert instance.timestamp == timezone.now()
 
+    @override_options(
+        {"delayed_processing.batch_size": 1, "delayed_workflow.use_workflow_engine_pool": True}
+    )
+    @patch(
+        "sentry.workflow_engine.processors.delayed_workflow.process_delayed_workflows_shim.apply_async"
+    )
+    def test_delayed_workflow_shim(self, mock_process_delayed: MagicMock) -> None:
+        self._push_base_events()
+
+        process_in_batches(self.project.id, "delayed_workflow")
+        assert mock_process_delayed.call_count == 2
+
 
 class TestDelayedWorkflowQueries(BaseWorkflowTest):
     def setUp(self) -> None:


### PR DESCRIPTION
Part 1 is adding a version of the task that is bound to the new pool, and adding an option that can toggle between spawning the new task and the old one

Following directions from https://github.com/getsentry/sentry/pull/96717#discussion_r2242767771