### PR TITLE
fix(tasks): Bucket retried ProcessingDeadlineExceeded together

### DIFF
--- a/src/sentry/tasks/base.py
+++ b/src/sentry/tasks/base.py
@@ -17,6 +17,7 @@ from sentry.celery import app
 from sentry.silo.base import SiloLimit, SiloMode
 from sentry.taskworker.config import TaskworkerConfig
 from sentry.taskworker.retry import RetryError, retry_task
+from sentry.taskworker.state import current_task
 from sentry.taskworker.task import Task as TaskworkerTask
 from sentry.taskworker.workerchild import ProcessingDeadlineExceeded
 from sentry.utils import metrics
@@ -250,7 +251,14 @@ def retry(
                 raise
             except timeout_exceptions:
                 if timeouts:
-                    sentry_sdk.capture_exception(level="info")
+                    with sentry_sdk.isolation_scope() as scope:
+                        task_state = current_task()
+                        scope.fingerprint = [
+                            "task.processing_deadline_exceeded",
+                            task_state.namespace,
+                            task_state.taskname,
+                        ]
+                        sentry_sdk.capture_exception(level="info")
                     retry_task()
                 else:
                     raise

--- a/src/sentry/tasks/base.py
+++ b/src/sentry/tasks/base.py
@@ -253,11 +253,12 @@ def retry(
                 if timeouts:
                     with sentry_sdk.isolation_scope() as scope:
                         task_state = current_task()
-                        scope.fingerprint = [
-                            "task.processing_deadline_exceeded",
-                            task_state.namespace,
-                            task_state.taskname,
-                        ]
+                        if task_state:
+                            scope.fingerprint = [
+                                "task.processing_deadline_exceeded",
+                                task_state.namespace,
+                                task_state.taskname,
+                            ]
                         sentry_sdk.capture_exception(level="info")
                     retry_task()
                 else:


### PR DESCRIPTION
Retried timeouts for a given task should share an issue; they can have a huge variety of stack traces, and the differences are almost never meaningful.