### PR TITLE
feat: Set DevKit as default tab in tempest

### DIFF
--- a/static/app/views/settings/project/tempest/index.spec.tsx
+++ b/static/app/views/settings/project/tempest/index.spec.tsx
@@ -1,4 +1,5 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectKeysFixture} from 'sentry-fixture/projectKeys';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
@@ -12,6 +13,11 @@ describe('TempestSettings', function () {
     MockApiClient.addMockResponse({
       url: `/projects/${organization.slug}/${project.slug}/tempest-credentials/`,
       body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/keys/`,
+      method: 'GET',
+      body: [ProjectKeysFixture()[0]],
     });
   });
 
@@ -47,7 +53,7 @@ describe('TempestSettings', function () {
       expect(
         screen.queryByText("You don't have access to this feature")
       ).not.toBeInTheDocument();
-      expect(screen.getByRole('heading', {name: 'PlayStation'})).toBeInTheDocument();
+      expect(screen.getByRole('heading', {name: 'DevKit Crashes'})).toBeInTheDocument();
     });
 
     it('renders settings when user has playstation console platform enabled', function () {
@@ -63,7 +69,7 @@ describe('TempestSettings', function () {
       expect(
         screen.queryByText("You don't have access to this feature")
       ).not.toBeInTheDocument();
-      expect(screen.getByRole('heading', {name: 'PlayStation'})).toBeInTheDocument();
+      expect(screen.getByRole('heading', {name: 'DevKit Crashes'})).toBeInTheDocument();
     });
 
     it('renders settings when user has both tempest-access feature and playstation platform', function () {
@@ -77,7 +83,7 @@ describe('TempestSettings', function () {
       expect(
         screen.queryByText("You don't have access to this feature")
       ).not.toBeInTheDocument();
-      expect(screen.getByRole('heading', {name: 'PlayStation'})).toBeInTheDocument();
+      expect(screen.getByRole('heading', {name: 'DevKit Crashes'})).toBeInTheDocument();
     });
 
     it('does not grant access with other console platforms', function () {
@@ -94,7 +100,7 @@ describe('TempestSettings', function () {
         screen.getByText("You don't have access to this feature")
       ).toBeInTheDocument();
       expect(
-        screen.queryByRole('heading', {name: 'PlayStation'})
+        screen.queryByRole('heading', {name: 'DevKit Crashes'})
       ).not.toBeInTheDocument();
     });
   });

--- a/static/app/views/settings/project/tempest/index.tsx
+++ b/static/app/views/settings/project/tempest/index.tsx
@@ -47,7 +47,7 @@ export default function TempestSettings({organization, project}: Props) {
     return (
       ['playstation', 'devkit-crashes'].includes(queryTab || '')
         ? queryTab
-        : 'playstation'
+        : 'devkit-crashes'
     ) as Tab;
   };
 


### PR DESCRIPTION
Since Devkit doesn't require credentials, it's simpler, we believe it should be the default tab.