### PR TITLE
feat(preprod): Use camelCase for artifactId in preprod response

### DIFF
--- a/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
+++ b/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
@@ -129,8 +129,6 @@ class ProjectPreprodArtifactAssembleEndpoint(ProjectEndpoint):
                         org_id=project.organization_id,
                         project_id=project.id,
                         checksum=checksum,
-                        chunks=chunks,
-                        git_sha=data.get("git_sha"),
                         build_configuration=data.get("build_configuration"),
                     )
                     if artifact_id:
@@ -139,7 +137,7 @@ class ProjectPreprodArtifactAssembleEndpoint(ProjectEndpoint):
                                 "state": state,
                                 "detail": detail,
                                 "missingChunks": [],
-                                "artifact_id": artifact_id,
+                                "artifactId": artifact_id,
                             }
                         )
                     else:

--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -12,7 +12,11 @@ from django.db import router, transaction
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.preprod.api.models.project_preprod_size_analysis_models import SizeAnalysisResults
-from sentry.preprod.models import PreprodArtifact
+from sentry.preprod.models import (
+    PreprodArtifact,
+    PreprodArtifactSizeMetrics,
+    PreprodBuildConfiguration,
+)
 from sentry.preprod.producer import produce_preprod_artifact_to_kafka
 from sentry.silo.base import SiloMode
 from sentry.tasks.assemble import (
@@ -125,13 +129,9 @@ def create_preprod_artifact(
     org_id,
     project_id,
     checksum,
-    # chunks,
-    git_sha=None,
     build_configuration=None,
-    **kwargs,
 ) -> str | None:
     from sentry.models.files.file import File
-    from sentry.preprod.models import PreprodArtifact, PreprodBuildConfiguration
 
     preprod_artifact = None
     try:
@@ -269,8 +269,6 @@ def _assemble_preprod_artifact_file(
 def _assemble_preprod_artifact_size_analysis(
     assemble_result: AssembleResult, project, artifact_id, org_id
 ):
-    from sentry.preprod.models import PreprodArtifactSizeMetrics
-
     try:
         preprod_artifact = PreprodArtifact.objects.get(
             project=project,

--- a/tests/sentry/preprod/api/endpoints/test_organization_preprod_artifact_assemble.py
+++ b/tests/sentry/preprod/api/endpoints/test_organization_preprod_artifact_assemble.py
@@ -559,8 +559,8 @@ class ProjectPreprodArtifactAssembleTest(APITestCase):
         assert response.status_code == 200
         assert response.data["state"] == ChunkFileState.OK
         assert response.data["missingChunks"] == []
-        assert "artifact_id" in response.data
-        assert response.data["artifact_id"] == "12345"
+        assert "artifactId" in response.data
+        assert response.data["artifactId"] == "12345"
 
     @patch(
         "sentry.preprod.api.endpoints.organization_preprod_artifact_assemble.create_preprod_artifact"
@@ -600,8 +600,8 @@ class ProjectPreprodArtifactAssembleTest(APITestCase):
         assert response.status_code == 200
         assert response.data["state"] == ChunkFileState.OK
         assert response.data["missingChunks"] == []
-        assert "artifact_id" in response.data
-        assert response.data["artifact_id"] == "98765"
+        assert "artifactId" in response.data
+        assert response.data["artifactId"] == "98765"
 
     def test_permission_required(self) -> None:
         content = b"test permission content"


### PR DESCRIPTION
sentry-cli expects the fields to be camelCase, see:
https://github.com/getsentry/sentry-cli/blob/42124d6169f43c986d6405af62811ac46ebaeeb2/src/api/data_types/chunking/mobile_app.rs#L18

Also:
- Remove some unused params.
- Move some imports to the top of the file.
   We already imported that file so weren't gaining anything from the nested import.
