### PR TITLE
Refactor create_preprod_artifact

### DIFF
--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -133,7 +133,6 @@ def create_preprod_artifact(
 ) -> str | None:
     from sentry.models.files.file import File
 
-    preprod_artifact = None
     try:
         organization = Organization.objects.get_from_cache(pk=org_id)
         project = Project.objects.get(id=project_id, organization=organization)
@@ -182,8 +181,7 @@ def create_preprod_artifact(
             },
         )
         return None
-
-    if preprod_artifact:
+    else:
         produce_preprod_artifact_to_kafka(
             project_id=project_id,
             organization_id=org_id,
@@ -199,9 +197,9 @@ def create_preprod_artifact(
                 "checksum": checksum,
             },
         )
-    # This will be a non-int display id in future so prepare for that
-    # by returning a string.
-    return str(preprod_artifact.id)
+        # This will be a non-int display id in future so prepare for that
+        # by returning a string.
+        return str(preprod_artifact.id)
 
 
 def _assemble_preprod_artifact_file(


### PR DESCRIPTION
`preprod_artifact` is always assigned if we don't throw an exception.
Try to make that clearer by:
- removing the extra if
- moving the tail code into an else branch of the exception handler