### PR TITLE
feat(logs): Swap logs to query params context for mode

### DIFF
--- a/static/app/views/explore/contexts/logs/logsPageParams.tsx
+++ b/static/app/views/explore/contexts/logs/logsPageParams.tsx
@@ -472,21 +472,6 @@ export function useLogsAnalyticsPageSource() {
   return analyticsPageSource;
 }
 
-export function useLogsMode() {
-  const {mode} = useLogsPageParams();
-  return mode;
-}
-
-export function useSetLogsMode() {
-  const setPageParams = useSetLogsPageParams();
-  return useCallback(
-    (mode: Mode) => {
-      setPageParams({mode});
-    },
-    [setPageParams]
-  );
-}
-
 function getLogCursorFromLocation(location: Location): string {
   if (!location.query?.[LOGS_CURSOR_KEY]) {
     return '';

--- a/static/app/views/explore/logs/logsLocationQueryParamsProvider.tsx
+++ b/static/app/views/explore/logs/logsLocationQueryParamsProvider.tsx
@@ -2,7 +2,11 @@ import type {ReactNode} from 'react';
 import {useCallback, useMemo} from 'react';
 
 import {useLocation} from 'sentry/utils/useLocation';
-import {getReadableQueryParamsFromLocation} from 'sentry/views/explore/logs/logsQueryParams';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import {
+  getReadableQueryParamsFromLocation,
+  getTargetWithReadableQueryParams,
+} from 'sentry/views/explore/logs/logsQueryParams';
 import {QueryParamsContextProvider} from 'sentry/views/explore/queryParams/context';
 import type {WritableQueryParams} from 'sentry/views/explore/queryParams/writableQueryParams';
 
@@ -14,6 +18,7 @@ export function LogsLocationQueryParamsProvider({
   children,
 }: LogsLocationQueryParamsProviderProps) {
   const location = useLocation();
+  const navigate = useNavigate();
 
   const readableQueryParams = useMemo(
     () => getReadableQueryParamsFromLocation(location),
@@ -21,10 +26,11 @@ export function LogsLocationQueryParamsProvider({
   );
 
   const setWritableQueryParams = useCallback(
-    (_writableQueryParams: WritableQueryParams) => {
-      // TODO
+    (writableQueryParams: WritableQueryParams) => {
+      const target = getTargetWithReadableQueryParams(location, writableQueryParams);
+      navigate(target);
     },
-    []
+    [location, navigate]
   );
 
   return (

--- a/static/app/views/explore/logs/logsQueryParams.tsx
+++ b/static/app/views/explore/logs/logsQueryParams.tsx
@@ -26,11 +26,13 @@ import {
   getGroupBysFromLocation,
   isGroupBy,
 } from 'sentry/views/explore/queryParams/groupBy';
+import {updateNullableLocation} from 'sentry/views/explore/queryParams/location';
 import {getModeFromLocation} from 'sentry/views/explore/queryParams/mode';
 import {getQueryFromLocation} from 'sentry/views/explore/queryParams/query';
 import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
 import {getSortBysFromLocation} from 'sentry/views/explore/queryParams/sortBy';
 import {isVisualize, Visualize} from 'sentry/views/explore/queryParams/visualize';
+import type {WritableQueryParams} from 'sentry/views/explore/queryParams/writableQueryParams';
 
 const LOGS_MODE_KEY = 'mode';
 
@@ -66,6 +68,15 @@ export function getReadableQueryParamsFromLocation(
     aggregateFields,
     aggregateSortBys,
   });
+}
+
+export function getTargetWithReadableQueryParams(
+  location: Location,
+  writableQueryParams: WritableQueryParams
+): Location {
+  const target: Location = {...location, query: {...location.query}};
+  updateNullableLocation(target, LOGS_MODE_KEY, writableQueryParams.mode);
+  return target;
 }
 
 function defaultSortBys(fields: string[]) {

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -53,10 +53,8 @@ import {
   useLogsAggregateSortBys,
   useLogsFields,
   useLogsGroupBy,
-  useLogsMode,
   useLogsSearch,
   useSetLogsFields,
-  useSetLogsMode,
   useSetLogsPageParams,
 } from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
@@ -98,6 +96,10 @@ import {
 import {usePersistentLogsPageParameters} from 'sentry/views/explore/logs/usePersistentLogsPageParameters';
 import {useStreamingTimeseriesResult} from 'sentry/views/explore/logs/useStreamingTimeseriesResult';
 import {calculateAverageLogsPerSecond} from 'sentry/views/explore/logs/utils';
+import {
+  useQueryParamsMode,
+  useSetQueryParamsMode,
+} from 'sentry/views/explore/queryParams/context';
 import {ColumnEditorModal} from 'sentry/views/explore/tables/columnEditorModal';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 import type {PickableDays} from 'sentry/views/explore/utils';
@@ -116,9 +118,9 @@ export function LogsTabContent({
   const logsSearch = useLogsSearch();
   const fields = useLogsFields();
   const groupBy = useLogsGroupBy();
-  const mode = useLogsMode();
+  const mode = useQueryParamsMode();
   const sortBys = useLogsAggregateSortBys();
-  const setMode = useSetLogsMode();
+  const setMode = useSetQueryParamsMode();
   const setFields = useSetLogsFields();
   const setLogsPageParams = useSetLogsPageParams();
   const tableData = useLogsPageDataQueryResult();
@@ -365,10 +367,7 @@ export function LogsTabContent({
               </Feature>
               <TableActionsContainer>
                 <Feature features="organizations:ourlogs-live-refresh">
-                  <AutorefreshToggle
-                    disabled={tableTab === 'aggregates'}
-                    averageLogsPerSecond={averageLogsPerSecond}
-                  />
+                  <AutorefreshToggle averageLogsPerSecond={averageLogsPerSecond} />
                 </Feature>
                 <Button onClick={openColumnEditor} icon={<IconTable />} size="sm">
                   {t('Edit Table')}

--- a/static/app/views/explore/queryParams/context.tsx
+++ b/static/app/views/explore/queryParams/context.tsx
@@ -1,5 +1,5 @@
 import type {ReactNode} from 'react';
-import {useMemo} from 'react';
+import {useCallback, useMemo} from 'react';
 
 import {createDefinedContext} from 'sentry/utils/performance/contexts/utils';
 import {Mode} from 'sentry/views/explore/queryParams/mode';
@@ -34,7 +34,34 @@ export function QueryParamsContextProvider({
   return <QueryParamsContext value={value}>{children}</QueryParamsContext>;
 }
 
-export function useQueryParamsMode(): Mode {
+function useQueryParams() {
   const {queryParams} = useQueryParamsContext();
+  return queryParams;
+}
+
+function useSetQueryParams() {
+  const {setQueryParams} = useQueryParamsContext();
+
+  return useCallback(
+    (writableQueryParams: WritableQueryParams) => {
+      setQueryParams(writableQueryParams);
+    },
+    [setQueryParams]
+  );
+}
+
+export function useQueryParamsMode(): Mode {
+  const queryParams = useQueryParams();
   return queryParams.mode;
+}
+
+export function useSetQueryParamsMode() {
+  const setQueryParams = useSetQueryParams();
+
+  return useCallback(
+    (mode: Mode) => {
+      setQueryParams({mode});
+    },
+    [setQueryParams]
+  );
 }

--- a/static/app/views/explore/queryParams/location.ts
+++ b/static/app/views/explore/queryParams/location.ts
@@ -1,0 +1,33 @@
+import type {Location} from 'history';
+
+import {defined} from 'sentry/utils';
+
+/**
+ * Allows updating a location field, removing it if the value is null.
+ *
+ * Return true if the location field was updated, in case of side effects.
+ */
+export function updateNullableLocation(
+  location: Location,
+  key: string,
+  value: boolean | string | string[] | null | undefined
+): boolean {
+  if (typeof value === 'boolean') {
+    if (value) {
+      location.query[key] = 'true';
+    } else {
+      // Delete boolean keys to minimize the number of query params.
+      delete location.query[key];
+    }
+    return true;
+  }
+  if (defined(value) && location.query[key] !== value) {
+    location.query[key] = value;
+    return true;
+  }
+  if (value === null && location.query[key]) {
+    delete location.query[key];
+    return true;
+  }
+  return false;
+}


### PR DESCRIPTION
This swaps logs to use the mode from the new query params context. This is safe as it's only used in the logs page. The embedded views currently do not use the mode value from the context.