### PR TITLE
fix(ask-seer): Initial Ask Seer UX improvments

### DIFF
--- a/static/app/components/searchQueryBuilder/context.tsx
+++ b/static/app/components/searchQueryBuilder/context.tsx
@@ -33,7 +33,7 @@ interface SearchQueryBuilderContextData {
   askSeerSuggestedQueryRef: React.RefObject<string | null>;
   autoSubmitSeer: boolean;
   committedQuery: string;
-  currentInputValue: string;
+  currentInputValueRef: React.RefObject<string>;
   disabled: boolean;
   disallowFreeText: boolean;
   disallowWildcard: boolean;
@@ -55,7 +55,6 @@ interface SearchQueryBuilderContextData {
   query: string;
   searchSource: string;
   setAutoSubmitSeer: (enabled: boolean) => void;
-  setCurrentInputValue: (value: string) => void;
   setDisplayAskSeer: (enabled: boolean) => void;
   setDisplayAskSeerFeedback: (enabled: boolean) => void;
   size: 'small' | 'normal';
@@ -118,9 +117,9 @@ export function SearchQueryBuilderProvider({
   const {setupAcknowledgement} = useOrganizationSeerSetup({enabled: enableAISearch});
 
   const [autoSubmitSeer, setAutoSubmitSeer] = useState(false);
-  const [currentInputValue, setCurrentInputValue] = useState('');
   const [displayAskSeer, setDisplayAskSeer] = useState(false);
   const [displayAskSeerFeedback, setDisplayAskSeerFeedback] = useState(false);
+  const currentInputValueRef = useRef<string>('');
   const askSeerNLQueryRef = useRef<string | null>(null);
   const askSeerSuggestedQueryRef = useRef<string | null>(null);
 
@@ -214,8 +213,7 @@ export function SearchQueryBuilderProvider({
       matchKeySuggestions,
       filterKeyAliases,
       gaveSeerConsent: setupAcknowledgement.orgHasAcknowledged,
-      currentInputValue,
-      setCurrentInputValue,
+      currentInputValueRef,
       displayAskSeerFeedback,
       setDisplayAskSeerFeedback,
       askSeerNLQueryRef,
@@ -223,7 +221,6 @@ export function SearchQueryBuilderProvider({
     };
   }, [
     autoSubmitSeer,
-    currentInputValue,
     disabled,
     disallowFreeText,
     disallowWildcard,

--- a/static/app/components/searchQueryBuilder/context.tsx
+++ b/static/app/components/searchQueryBuilder/context.tsx
@@ -128,6 +128,8 @@ export function SearchQueryBuilderProvider({
     initialQuery,
     getFieldDefinition: fieldDefinitionGetter,
     disabled,
+    displayAskSeerFeedback,
+    setDisplayAskSeerFeedback,
   });
 
   const stableFieldDefinitionGetter = useMemo(

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -126,6 +126,8 @@ type UpdateAggregateArgsAction = {
   focusOverride?: FocusOverride;
 };
 
+type ResetClearAskSeerFeedbackAction = {type: 'RESET_CLEAR_ASK_SEER_FEEDBACK'};
+
 export type QueryBuilderActions =
   | ClearAction
   | CommitQueryAction
@@ -139,7 +141,8 @@ export type QueryBuilderActions =
   | UpdateFilterOpAction
   | UpdateTokenValueAction
   | UpdateAggregateArgsAction
-  | MultiSelectFilterValueAction;
+  | MultiSelectFilterValueAction
+  | ResetClearAskSeerFeedbackAction;
 
 function removeQueryTokensFromQuery(
   query: string,
@@ -731,6 +734,8 @@ export function useQueryBuilderState({
           return updateAggregateArgs(state, action, {getFieldDefinition});
         case 'TOGGLE_FILTER_VALUE':
           return multiSelectTokenValue(state, action);
+        case 'RESET_CLEAR_ASK_SEER_FEEDBACK':
+          return {...state, clearAskSeerFeedback: false};
         default:
           return state;
       }
@@ -743,6 +748,8 @@ export function useQueryBuilderState({
   useEffect(() => {
     if (state.clearAskSeerFeedback) {
       setDisplayAskSeerFeedback(false);
+      // Reset the flag after clearing the feedback
+      dispatch({type: 'RESET_CLEAR_ASK_SEER_FEEDBACK'});
     }
   }, [setDisplayAskSeerFeedback, state.clearAskSeerFeedback]);
 

--- a/static/app/components/searchQueryBuilder/selectionKeyHandler.tsx
+++ b/static/app/components/searchQueryBuilder/selectionKeyHandler.tsx
@@ -30,7 +30,7 @@ export function SelectionKeyHandler({
   undo,
   gridRef,
 }: SelectionKeyHandlerProps) {
-  const {dispatch, disabled} = useSearchQueryBuilder();
+  const {dispatch, disabled, currentInputValueRef} = useSearchQueryBuilder();
   const {selectInDirection} = useKeyboardSelection();
 
   const selectedTokens: ParseResultToken[] = [...state.collection.getKeys()]
@@ -70,6 +70,11 @@ export function SelectionKeyHandler({
             findNearestFreeTextKey(state, state.selectionManager.firstSelectedKey, 'left')
           );
           state.selectionManager.clearSelection();
+
+          // Ask Seer - Clear the input value when the user deletes all tokens
+          if (state.collection.size === selectedTokens.length) {
+            currentInputValueRef.current = '';
+          }
           return;
         }
         case 'ArrowRight':
@@ -152,7 +157,7 @@ export function SelectionKeyHandler({
           return;
       }
     },
-    [dispatch, selectInDirection, selectedTokens, state, undo]
+    [currentInputValueRef, dispatch, selectInDirection, selectedTokens, state, undo]
   );
 
   // Ensure that the selection is cleared when this input loses focus

--- a/static/app/components/searchQueryBuilder/tokens/filter/filterKeyCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filterKeyCombobox.tsx
@@ -45,7 +45,7 @@ export function FilterKeyCombobox({token, onCommit, item}: KeyComboboxProps) {
     getFieldDefinition,
     getSuggestedFilterKey,
     setDisplayAskSeer,
-    currentInputValue,
+    currentInputValueRef,
     setAutoSubmitSeer,
   } = useSearchQueryBuilder();
 
@@ -66,7 +66,7 @@ export function FilterKeyCombobox({token, onCommit, item}: KeyComboboxProps) {
         });
         setDisplayAskSeer(true);
 
-        if (currentInputValue?.trim()) {
+        if (currentInputValueRef.current?.trim()) {
           setAutoSubmitSeer(true);
         } else {
           setAutoSubmitSeer(false);
@@ -119,7 +119,7 @@ export function FilterKeyCombobox({token, onCommit, item}: KeyComboboxProps) {
     },
     [
       currentFilterValueType,
-      currentInputValue,
+      currentInputValueRef,
       dispatch,
       getFieldDefinition,
       item.key,

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/useFilterKeyListBox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/useFilterKeyListBox.tsx
@@ -171,7 +171,7 @@ export function useFilterKeyListBox({filterValue}: {filterValue: string}) {
     setDisplayAskSeer,
     enableAISearch,
     gaveSeerConsent,
-    currentInputValue,
+    currentInputValueRef,
   } = useSearchQueryBuilder();
   const {sectionedItems} = useFilterKeyItems();
   const recentFilters = useRecentSearchFilters();
@@ -394,7 +394,7 @@ export function useFilterKeyListBox({filterValue}: {filterValue: string}) {
         });
         setDisplayAskSeer(true);
 
-        if (currentInputValue?.trim()) {
+        if (currentInputValueRef.current?.trim()) {
           setAutoSubmitSeer(true);
         } else {
           setAutoSubmitSeer(false);
@@ -413,7 +413,7 @@ export function useFilterKeyListBox({filterValue}: {filterValue: string}) {
       }
     },
     [
-      currentInputValue,
+      currentInputValueRef,
       organization,
       seerAcknowledgeMutate,
       setAutoSubmitSeer,

--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -265,14 +265,13 @@ function SearchQueryBuilderInputInternal({
     placeholder,
     searchSource,
     recentSearches,
-    setCurrentInputValue,
+    currentInputValueRef,
   } = useSearchQueryBuilder();
 
   const resetInputValue = useCallback(() => {
     setInputValue(trimmedTokenValue);
-    setCurrentInputValue(trimmedTokenValue);
     updateSelectionIndex();
-  }, [trimmedTokenValue, updateSelectionIndex, setCurrentInputValue]);
+  }, [trimmedTokenValue, updateSelectionIndex]);
 
   const {customMenu, sectionItems, maxOptions, onKeyDownCapture, handleOptionSelected} =
     useFilterKeyListBox({
@@ -291,6 +290,11 @@ function SearchQueryBuilderInputInternal({
   if (trimmedTokenValue !== prevValue) {
     setPrevValue(trimmedTokenValue);
     setInputValue(trimmedTokenValue);
+  }
+
+  // This is a hack to get the current input for ask seer.
+  if (inputValue !== currentInputValueRef.current) {
+    currentInputValueRef.current = inputValue;
   }
 
   const onKeyDown = useCallback(
@@ -619,7 +623,6 @@ function SearchQueryBuilderInputInternal({
           }
 
           setInputValue(e.target.value);
-          setCurrentInputValue(e.target.value);
           setSelectionIndex(e.target.selectionStart ?? 0);
         }}
         onKeyDown={onKeyDown}

--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -291,6 +291,7 @@ function SearchQueryBuilderInputInternal({
   if (trimmedTokenValue !== prevValue) {
     setPrevValue(trimmedTokenValue);
     setInputValue(trimmedTokenValue);
+    setCurrentInputValue(trimmedTokenValue);
   }
 
   const onKeyDown = useCallback(

--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, useRef, useState} from 'react';
+import {Fragment, useCallback, useEffect, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import {mergeProps} from '@react-aria/utils';
 import {Item, Section} from '@react-stately/collections';
@@ -292,10 +292,10 @@ function SearchQueryBuilderInputInternal({
     setInputValue(trimmedTokenValue);
   }
 
-  // This is a hack to get the current input for ask seer.
-  if (inputValue !== currentInputValueRef.current) {
+  // Update the ref when inputValue changes for ask seer
+  useEffect(() => {
     currentInputValueRef.current = inputValue;
-  }
+  }, [inputValue, currentInputValueRef]);
 
   const onKeyDown = useCallback(
     (e: KeyboardEvent) => {

--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -291,7 +291,6 @@ function SearchQueryBuilderInputInternal({
   if (trimmedTokenValue !== prevValue) {
     setPrevValue(trimmedTokenValue);
     setInputValue(trimmedTokenValue);
-    setCurrentInputValue(trimmedTokenValue);
   }
 
   const onKeyDown = useCallback(

--- a/static/app/views/explore/components/seerComboBox/seerComboBox.spec.tsx
+++ b/static/app/views/explore/components/seerComboBox/seerComboBox.spec.tsx
@@ -61,7 +61,7 @@ describe('SeerComboBox', () => {
       name: 'Ask Seer with Natural Language',
     });
     expect(input).toBeInTheDocument();
-    expect(input).toHaveValue('test');
+    expect(input).toHaveValue('test ');
   });
 
   it('sets the passed initial query as the input value', async () => {
@@ -74,7 +74,7 @@ describe('SeerComboBox', () => {
     const input = await screen.findByRole('combobox', {
       name: 'Ask Seer with Natural Language',
     });
-    expect(input).toHaveValue('test');
+    expect(input).toHaveValue('test ');
   });
 
   it('defaults popover to be open', async () => {

--- a/static/app/views/explore/components/seerComboBox/seerComboBox.tsx
+++ b/static/app/views/explore/components/seerComboBox/seerComboBox.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useLayoutEffect, useMemo, useRef, useState} from 'react';
+import {useLayoutEffect, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import {type AriaComboBoxProps} from '@react-aria/combobox';
 import {mergeRefs} from '@react-aria/utils';
@@ -431,6 +431,10 @@ export function SeerComboBox({initialQuery, ...props}: SeerComboBoxProps) {
     }
   }, [autoSubmitSeer, searchQuery, organization, submitQuery, setAutoSubmitSeer]);
 
+  const onMouseLeave = () => {
+    state.selectionManager.setFocusedKey(null);
+  };
+
   return (
     <Wrapper ref={containerRef} isDropdownOpen={state.isOpen}>
       <PositionedSearchIconContainer>
@@ -472,19 +476,19 @@ export function SeerComboBox({initialQuery, ...props}: SeerComboBoxProps) {
           overlayProps={overlayProps}
         >
           {isPending ? (
-            <Fragment>
+            <SeerContent>
               <SeerSearchHeader title={t('Let me think about that...')} loading />
               <SeerSearchSkeleton />
-            </Fragment>
+            </SeerContent>
           ) : rawResult && (rawResult?.length ?? 0) > 0 ? (
-            <Fragment>
+            <SeerContent onMouseLeave={onMouseLeave}>
               <SeerSearchHeader title={t('Do any of these look right to you?')} />
               <SeerSearchListBox
                 {...listBoxProps}
                 listBoxRef={listBoxRef}
                 state={state}
               />
-            </Fragment>
+            </SeerContent>
           ) : unsupportedReason ? (
             <SeerContent>
               <SeerSearchHeader
@@ -492,7 +496,7 @@ export function SeerComboBox({initialQuery, ...props}: SeerComboBoxProps) {
               />
             </SeerContent>
           ) : (
-            <SeerContent>
+            <SeerContent onMouseLeave={onMouseLeave}>
               <SeerSearchHeader
                 title={t(
                   "Describe what you're looking for, or try one of these examples:"

--- a/static/app/views/explore/components/seerComboBox/utils.ts
+++ b/static/app/views/explore/components/seerComboBox/utils.ts
@@ -40,7 +40,7 @@ export function formatQueryToNaturalLanguage(query: string): string {
   const tokens = query.match(/(?:[^\s"]+|"[^"]*")+/g) || [];
   const formattedTokens = tokens.map(formatToken);
 
-  return formattedTokens.reduce((result, token, index) => {
+  const formattedQuery = formattedTokens.reduce((result, token, index) => {
     if (index === 0) return token;
 
     const currentOriginalToken = tokens[index] || '';
@@ -64,6 +64,9 @@ export function formatQueryToNaturalLanguage(query: string): string {
 
     return `${result} ${token}`;
   }, '');
+
+  // add a space at the end of the query to give space for the cursor
+  return `${formattedQuery} `;
 }
 
 export function generateQueryTokensString({

--- a/static/app/views/explore/spans/spansTab.spec.tsx
+++ b/static/app/views/explore/spans/spansTab.spec.tsx
@@ -332,7 +332,7 @@ describe('SpansTabContent', () => {
     });
   });
 
-  describe('Ask Seer', function () {
+  describe('Ask Seer', () => {
     beforeEach(() => {
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/seer/setup-check/',
@@ -345,7 +345,7 @@ describe('SpansTabContent', () => {
       });
     });
 
-    it('brings along only the submitted query', async function () {
+    it('brings along only the submitted query', async () => {
       render(
         <Wrapper>
           <SpansTabContent datePageFilterProps={datePageFilterProps} />

--- a/static/app/views/explore/spans/spansTab.spec.tsx
+++ b/static/app/views/explore/spans/spansTab.spec.tsx
@@ -345,7 +345,57 @@ describe('SpansTabContent', () => {
       });
     });
 
-    it('brings along only the submitted query', async () => {
+    it('brings along the query', async () => {
+      render(
+        <Wrapper>
+          <SpansTabContent datePageFilterProps={datePageFilterProps} />
+        </Wrapper>,
+        {organization}
+      );
+
+      const input = screen.getByRole('combobox');
+      await userEvent.click(input);
+      await userEvent.type(input, 'span.duration:>10ms{enter}');
+
+      // re-open the combobox
+      await userEvent.click(input);
+      const askSeer = await screen.findByText(/Ask Seer/);
+      await userEvent.click(askSeer);
+
+      const askSeerInput = screen.getByRole('combobox', {
+        name: 'Ask Seer with Natural Language',
+      });
+
+      await waitFor(() => {
+        expect(askSeerInput).toHaveValue('span.duration is greater than 10ms ');
+      });
+    });
+
+    it('brings along the user input', async () => {
+      render(
+        <Wrapper>
+          <SpansTabContent datePageFilterProps={datePageFilterProps} />
+        </Wrapper>,
+        {organization}
+      );
+
+      const input = screen.getByRole('combobox');
+      await userEvent.click(input);
+      await userEvent.type(input, ' random');
+
+      const askSeer = await screen.findByText(/Ask Seer/);
+      await userEvent.click(askSeer);
+
+      const askSeerInput = screen.getByRole('combobox', {
+        name: 'Ask Seer with Natural Language',
+      });
+
+      await waitFor(() => {
+        expect(askSeerInput).toHaveValue('random ');
+      });
+    });
+
+    it('brings along only the query and the user input', async () => {
       render(
         <Wrapper>
           <SpansTabContent datePageFilterProps={datePageFilterProps} />
@@ -366,7 +416,7 @@ describe('SpansTabContent', () => {
       });
 
       await waitFor(() => {
-        expect(askSeerInput).toHaveValue('span.duration is greater than 10ms ');
+        expect(askSeerInput).toHaveValue('span.duration is greater than 10ms random ');
       });
     });
   });

--- a/static/app/views/explore/spans/spansTab.spec.tsx
+++ b/static/app/views/explore/spans/spansTab.spec.tsx
@@ -2,7 +2,13 @@ import type {ReactNode} from 'react';
 import {AutofixSetupFixture} from 'sentry-fixture/autofixSetupFixture';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
+import {
+  render,
+  screen,
+  userEvent,
+  waitFor,
+  within,
+} from 'sentry-test/reactTestingLibrary';
 
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import type {TagCollection} from 'sentry/types/group';
@@ -349,7 +355,7 @@ describe('SpansTabContent', () => {
 
       const input = screen.getByRole('combobox');
       await userEvent.click(input);
-      await userEvent.type(input, 'span.duration:>30s{enter}');
+      await userEvent.type(input, 'span.duration:>10ms{enter}');
       await userEvent.type(input, ' random');
 
       const askSeer = await screen.findByText(/Ask Seer/);
@@ -359,7 +365,9 @@ describe('SpansTabContent', () => {
         name: 'Ask Seer with Natural Language',
       });
 
-      expect(askSeerInput).toHaveValue('span.duration is greater than 10ms ');
+      await waitFor(() => {
+        expect(askSeerInput).toHaveValue('span.duration is greater than 10ms ');
+      });
     });
   });
 });

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -170,11 +170,13 @@ function SpansSearchBar({
 }: {
   eapSpanSearchQueryBuilderProps: EAPSpanSearchQueryBuilderProps;
 }) {
-  const {displayAskSeer, currentInputValueRef, committedQuery} = useSearchQueryBuilder();
+  const {displayAskSeer, currentInputValueRef, query, committedQuery} =
+    useSearchQueryBuilder();
 
   if (displayAskSeer) {
     const inputValue = currentInputValueRef.current.trim();
-    const parsedQuery = parseQueryBuilderValue(committedQuery, getFieldDefinition);
+    const queryToUse = committedQuery.length > 0 ? committedQuery : query;
+    const parsedQuery = parseQueryBuilderValue(queryToUse, getFieldDefinition);
 
     // Remove any tokens that include the user inputted value.
     const filteredCommittedQuery = parsedQuery
@@ -188,8 +190,8 @@ function SpansSearchBar({
     let initialSeerQuery = '';
     if (typeof filteredCommittedQuery === 'string') {
       initialSeerQuery = `${filteredCommittedQuery}`;
-    } else if (committedQuery) {
-      initialSeerQuery = `${committedQuery}`;
+    } else if (queryToUse) {
+      initialSeerQuery = `${queryToUse}`;
     }
 
     if (inputValue) {

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -167,9 +167,7 @@ function SpansSearchBar({
   eapSpanSearchQueryBuilderProps: EAPSpanSearchQueryBuilderProps;
 }) {
   const {displayAskSeer, query, currentInputValue} = useSearchQueryBuilder();
-  let initialSeerQuery = currentInputValue.trim()
-    ? currentInputValue.trim()
-    : query.trim();
+  let initialSeerQuery = query.trim() ? query.trim() : currentInputValue.trim();
 
   // if the user has cleared out the input, but hasn't committed it, we shouldn't bring
   // it along, and clear the query input string.

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -172,19 +172,22 @@ function SpansTabSeerComboBox() {
   }, [committedQuery, query]);
 
   const inputValue = currentInputValueRef.current.trim();
-  // Remove any tokens that include the user inputted value.
+
+  // Only filter out FREE_TEXT tokens if there's actual input value to filter by
   const filteredCommittedQuery = queryDetails?.parsedQuery
     ?.filter(
-      token => !(token.type === Token.FREE_TEXT && token.text.includes(inputValue))
+      token =>
+        !(token.type === Token.FREE_TEXT && inputValue && token.text.includes(inputValue))
     )
     ?.map(token => stringifyToken(token))
     ?.join(' ')
     ?.trim();
 
-  if (typeof filteredCommittedQuery === 'string') {
-    initialSeerQuery = `${filteredCommittedQuery}`;
+  // Use filteredCommittedQuery if it exists and has content, otherwise fall back to queryToUse
+  if (filteredCommittedQuery && filteredCommittedQuery.length > 0) {
+    initialSeerQuery = filteredCommittedQuery;
   } else if (queryDetails?.queryToUse) {
-    initialSeerQuery = `${queryDetails?.queryToUse}`;
+    initialSeerQuery = queryDetails.queryToUse;
   }
 
   if (inputValue) {

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -168,16 +168,18 @@ function SpansSearchBar({
 }) {
   const {displayAskSeer, query, currentInputValue} = useSearchQueryBuilder();
 
-  const initialSeerQuery = (() => {
-    const committedQuery = query.trim();
-    const inputValue = currentInputValue.trim();
-
-    if (!inputValue) return committedQuery;
-
-    if (!committedQuery) return inputValue;
-
-    return `${committedQuery} ${inputValue}`;
-  })();
+  let initialSeerQuery = '';
+  const committedQuery = query.trim();
+  const inputValue = currentInputValue.trim();
+  if (inputValue && committedQuery && inputValue === committedQuery) {
+    initialSeerQuery = inputValue;
+  } else if (inputValue && committedQuery) {
+    initialSeerQuery = `${committedQuery} ${inputValue}`;
+  } else if (!inputValue && committedQuery) {
+    initialSeerQuery = committedQuery;
+  } else if (!committedQuery && inputValue) {
+    initialSeerQuery = inputValue;
+  }
 
   return displayAskSeer ? (
     <SeerComboBox initialQuery={initialSeerQuery} />

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -167,9 +167,15 @@ function SpansSearchBar({
   eapSpanSearchQueryBuilderProps: EAPSpanSearchQueryBuilderProps;
 }) {
   const {displayAskSeer, query, currentInputValue} = useSearchQueryBuilder();
-  const initialSeerQuery = currentInputValue.trim()
+  let initialSeerQuery = currentInputValue.trim()
     ? currentInputValue.trim()
     : query.trim();
+
+  // if the user has cleared out the input, but hasn't committed it, we shouldn't bring
+  // it along, and clear the query input string.
+  if (currentInputValue.trim().length === 0 && query.trim().length > 0) {
+    initialSeerQuery = '';
+  }
 
   return displayAskSeer ? (
     <SeerComboBox initialQuery={initialSeerQuery} />

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -20,6 +20,7 @@ import {
   useSearchQueryBuilder,
 } from 'sentry/components/searchQueryBuilder/context';
 import {parseQueryBuilderValue} from 'sentry/components/searchQueryBuilder/utils';
+import {Token} from 'sentry/components/searchSyntax/parser';
 import {stringifyToken} from 'sentry/components/searchSyntax/utils';
 import {TourElement} from 'sentry/components/tours/components';
 import {IconChevron} from 'sentry/icons/iconChevron';
@@ -176,7 +177,9 @@ function SpansSearchBar({
     const parsedQuery = parseQueryBuilderValue(committedQuery, getFieldDefinition);
     // Remove any tokens that include the user inputted value.
     const filteredCommittedQuery = parsedQuery
-      ?.filter(token => token.text.length > 0 && !token.text.includes(inputValue))
+      ?.filter(
+        token => !(token.type === Token.FREE_TEXT && token.text.includes(inputValue))
+      )
       ?.map(token => stringifyToken(token))
       .join(' ')
       .trim();

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -166,14 +166,32 @@ function SpansSearchBar({
 }: {
   eapSpanSearchQueryBuilderProps: EAPSpanSearchQueryBuilderProps;
 }) {
-  const {displayAskSeer, query, currentInputValueRef} = useSearchQueryBuilder();
+  const {displayAskSeer, query, currentInputValueRef, committedQuery} =
+    useSearchQueryBuilder();
+  const previousInputValue = usePrevious(
+    currentInputValueRef.current,
+    // We want to skip updating the previous input value if the value has gone empty, but
+    // there is still a query value.
+    currentInputValueRef.current.trim().length === 0 && !(query.trim().length === 0)
+  );
+
   let initialSeerQuery = query.trim()
     ? query.trim()
     : currentInputValueRef.current.trim();
 
-  // if the user has cleared out the input, but hasn't committed it, we shouldn't bring
-  // it along, and clear the query input string.
-  if (currentInputValueRef.current.trim().length !== 0 && query.trim().length > 0) {
+  // If the user manually selects an input value, we never actually have an input value,
+  // so we need to check if the user has ever inputted a value.
+  const userHasInputted =
+    currentInputValueRef.current.trim().length > 0 ||
+    previousInputValue.trim().length > 0;
+
+  // We want to reset the query if the user has cleared the input, but there's still
+  // a committed query present
+  if (
+    userHasInputted &&
+    previousInputValue.trim().length === 0 &&
+    committedQuery.trim().length > 0
+  ) {
     initialSeerQuery = '';
   }
 

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -166,12 +166,14 @@ function SpansSearchBar({
 }: {
   eapSpanSearchQueryBuilderProps: EAPSpanSearchQueryBuilderProps;
 }) {
-  const {displayAskSeer, query, currentInputValue} = useSearchQueryBuilder();
-  let initialSeerQuery = query.trim() ? query.trim() : currentInputValue.trim();
+  const {displayAskSeer, query, currentInputValueRef} = useSearchQueryBuilder();
+  let initialSeerQuery = query.trim()
+    ? query.trim()
+    : currentInputValueRef.current.trim();
 
   // if the user has cleared out the input, but hasn't committed it, we shouldn't bring
   // it along, and clear the query input string.
-  if (currentInputValue.trim().length === 0 && query.trim().length > 0) {
+  if (currentInputValueRef.current.trim().length !== 0 && query.trim().length > 0) {
     initialSeerQuery = '';
   }
 

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -167,19 +167,9 @@ function SpansSearchBar({
   eapSpanSearchQueryBuilderProps: EAPSpanSearchQueryBuilderProps;
 }) {
   const {displayAskSeer, query, currentInputValue} = useSearchQueryBuilder();
-
-  let initialSeerQuery = '';
-  const committedQuery = query.trim();
-  const inputValue = currentInputValue.trim();
-  if (inputValue && committedQuery && inputValue === committedQuery) {
-    initialSeerQuery = inputValue;
-  } else if (inputValue && committedQuery) {
-    initialSeerQuery = `${committedQuery} ${inputValue}`;
-  } else if (!inputValue && committedQuery) {
-    initialSeerQuery = committedQuery;
-  } else if (!committedQuery && inputValue) {
-    initialSeerQuery = inputValue;
-  }
+  const initialSeerQuery = currentInputValue.trim()
+    ? currentInputValue.trim()
+    : query.trim();
 
   return displayAskSeer ? (
     <SeerComboBox initialQuery={initialSeerQuery} />

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -175,18 +175,21 @@ function SpansSearchBar({
   if (displayAskSeer) {
     const inputValue = currentInputValueRef.current.trim();
     const parsedQuery = parseQueryBuilderValue(committedQuery, getFieldDefinition);
+
     // Remove any tokens that include the user inputted value.
     const filteredCommittedQuery = parsedQuery
       ?.filter(
         token => !(token.type === Token.FREE_TEXT && token.text.includes(inputValue))
       )
       ?.map(token => stringifyToken(token))
-      .join(' ')
-      .trim();
+      ?.join(' ')
+      ?.trim();
 
     let initialSeerQuery = '';
-    if (filteredCommittedQuery) {
+    if (typeof filteredCommittedQuery === 'string') {
       initialSeerQuery = `${filteredCommittedQuery}`;
+    } else if (committedQuery) {
+      initialSeerQuery = `${committedQuery}`;
     }
 
     if (inputValue) {


### PR DESCRIPTION
This PR fixes a couple of UX issues with the current implementation of "Ask Seer", these changes include:

- Carry over only the committed query if present, if not carry over the user input
- Ensure that we clear the the carry over input state value
- Clear focus state when user's mouse leaves selection dropdown
- Remove feedback prompt if the user modifies the submitted query

Ticket: EXP-438