### PR TITLE
ref(grouping): Remove unused properties in `EventGroupingConfig` type

### DIFF
--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -30,12 +30,8 @@ export type EventGroupComponent = {
 };
 export type EventGroupingConfig = {
   base: string | null;
-  changelog: string;
   delegates: string[];
-  hidden: boolean;
   id: string;
-  latest: boolean;
-  risk: number;
   strategies: string[];
 };
 

--- a/tests/js/fixtures/groupingConfigs.ts
+++ b/tests/js/fixtures/groupingConfigs.ts
@@ -5,11 +5,7 @@ export function GroupingConfigsFixture(): EventGroupingConfig[] {
     {
       id: 'default:XXXX',
       base: null,
-      changelog: '',
       delegates: [],
-      hidden: false,
-      latest: true,
-      risk: 1,
       strategies: [],
     },
   ];


### PR DESCRIPTION
This is a follow-up to https://github.com/getsentry/sentry/pull/97234, which removed some legacy attributes from grouping configs, since they weren't being used in either the front end or the backend. In this PR, the same attributes are removed from the front end `EventGroupingConfig` type.