### PR TITLE
fix(insights): overview page should not query metrics on most am1 customers

### DIFF
--- a/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
@@ -112,15 +112,24 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
     props.chartSetting
   );
   const useEap = useInsightsEap();
+  const canUseMetrics = canUseMetricsData(organization);
+
+  // Some am1 customers have on demand metrics, so we still need to keep metrics here.
+  let metricsDataset = canUseMetrics
+    ? DiscoverDatasets.METRICS
+    : DiscoverDatasets.TRANSACTIONS;
+
   const spanDataset = DiscoverDatasets.SPANS;
 
-  const metricsDataset = useEap ? DiscoverDatasets.SPANS : DiscoverDatasets.METRICS;
+  if (useEap) {
+    metricsDataset = DiscoverDatasets.SPANS;
+  }
 
   const spanQueryParams: Record<string, string> = {...EAP_QUERY_PARAMS};
 
   const metricsQueryParams: Record<string, string> = useEap
     ? {...EAP_QUERY_PARAMS}
-    : {dataset: DiscoverDatasets.METRICS};
+    : {dataset: metricsDataset};
 
   let emptyComponent: any;
   if (props.chartSetting === PerformanceWidgetSetting.MOST_TIME_SPENT_DB_QUERIES) {
@@ -173,7 +182,7 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
           ];
           eventView.additionalConditions.setFilterValues('event.type', ['error']);
           eventView.additionalConditions.setFilterValues('!tags[transaction]', ['']);
-          if (canUseMetricsData(organization)) {
+          if (canUseMetrics) {
             eventView.additionalConditions.setFilterValues('!transaction', [
               UNPARAMETERIZED_TRANSACTION,
             ]);
@@ -390,7 +399,7 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
             ]);
             eventView.additionalConditions.setFilterValues('event.type', ['error']);
 
-            if (canUseMetricsData(organization)) {
+            if (canUseMetrics) {
               eventView.additionalConditions.setFilterValues('!transaction', [
                 UNPARAMETERIZED_TRANSACTION,
               ]);


### PR DESCRIPTION
The logic for the overview page widgets have been updated to the following.

1. If the org has eap, am1 or am2, then always use `spans` dataset (this was the old behaviour)
2. If the org is am1, we either use `metrics` or `transactions`
a. Metrics is used if `canUseMetricsData == true`, in practice this is true if the am1 org has on demand metrics enabled, i.e the `dynamic-sampling` flag is true.
b. Transactions is used in all other cases

Previously, the `transactions` dataset was never used, which shouldn't be the case for the majority of am1 customers which don't receive on demand metrics.