### PR TITLE
nit(aci): fix links and text widths for title cells

### DIFF
--- a/static/app/components/workflowEngine/gridCell/titleCell.tsx
+++ b/static/app/components/workflowEngine/gridCell/titleCell.tsx
@@ -27,7 +27,7 @@ export function TitleCell({
       <Name>
         <NameText>{name}</NameText>
         {systemCreated && <CreatedBySentryIcon size="xs" color="subText" />}
-        {disabled && <span>&mdash; Disabled</span>}
+        {disabled && <DisabledText>&mdash; Disabled</DisabledText>}
       </Name>
       {defined(details) && <DetailsWrapper>{details}</DetailsWrapper>}
     </TitleWrapper>
@@ -44,7 +44,11 @@ const Name = styled('div')`
 const NameText = styled('span')`
   font-weight: ${p => p.theme.fontWeight.bold};
   ${p => p.theme.overflowEllipsis};
-  width: auto;
+  width: fit-content;
+`;
+
+const DisabledText = styled('span')`
+  flex-shrink: 0;
 `;
 
 const CreatedBySentryIcon = styled(IconSentry)`
@@ -57,6 +61,7 @@ const TitleWrapper = styled(Link)`
   gap: ${space(0.5)};
   flex: 1;
   overflow: hidden;
+  min-height: 20px;
 
   &:hover {
     ${Name} {


### PR DESCRIPTION
- title cells for monitors/automations with no name are now clickable (just needed a min-height)
- fixed widths so that "disabled" text for disabled monitors/automations is always visible
<img width="838" height="383" alt="Screenshot 2025-08-07 at 11 12 27 AM" src="https://github.com/user-attachments/assets/640de0ba-fec8-4a56-8f08-5f1e6cf21c60" />
