### PR TITLE
feat(feedback): Hide `ai_categorization.*` tags from feedback UI

### DIFF
--- a/static/app/components/feedback/feedbackItem/feedbackItem.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItem.tsx
@@ -46,7 +46,7 @@ export default function FeedbackItem({feedbackItem, eventData}: Props) {
   }, [feedbackItem.id, overflowRef]);
 
   const tagsWithoutAi = useMemo(
-    () => eventData?.tags.filter(tag => tag.key !== 'ai_categorization') ?? [],
+    () => eventData?.tags.filter(tag => !tag.key.startsWith('ai_categorization.')) ?? [],
     [eventData?.tags]
   );
 

--- a/static/app/components/feedback/feedbackItem/feedbackItem.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItem.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useEffect, useRef} from 'react';
+import {Fragment, useEffect, useMemo, useRef} from 'react';
 import styled from '@emotion/styled';
 
 import AnalyticsArea from 'sentry/components/analyticsArea';
@@ -44,6 +44,11 @@ export default function FeedbackItem({feedbackItem, eventData}: Props) {
       });
     }, 100);
   }, [feedbackItem.id, overflowRef]);
+
+  const tagsWithoutAi = useMemo(
+    () => eventData?.tags.filter(tag => tag.key !== 'ai_categorization') ?? [],
+    [eventData?.tags]
+  );
 
   return (
     <Fragment>
@@ -95,7 +100,7 @@ export default function FeedbackItem({feedbackItem, eventData}: Props) {
               <EventTagsTree
                 event={eventData}
                 projectSlug={feedbackItem.project.slug}
-                tags={eventData.tags}
+                tags={tagsWithoutAi}
               />
             </FeedbackItemSection>
           ) : null}


### PR DESCRIPTION
We don't want to show these internal details of feedback to users. 

However maybe later we will show them again, and make them easier to directly search by. Nothing is set in stone.