### PR TITLE
feat(ui): Provide feedback for unknown form errors

### DIFF
--- a/static/app/components/forms/model.tsx
+++ b/static/app/components/forms/model.tsx
@@ -805,8 +805,11 @@ class FormModel {
 
   handleErrorResponse({responseJSON: resp}: {responseJSON?: any} = {}) {
     if (!resp) {
+      addErrorMessage(t('Unknown error while saving'));
       return;
     }
+
+    let errorDisplayed = false;
 
     // Show resp msg from API endpoint if possible
     Object.keys(resp).forEach(id => {
@@ -818,11 +821,17 @@ class FormModel {
         nonFieldErrors.length
       ) {
         addErrorMessage(nonFieldErrors[0], {duration: 10000});
+        errorDisplayed = true;
       } else if (Array.isArray(resp[id]) && resp[id].length) {
         // Just take first resp for now
         this.setError(id, resp[id][0]);
+        errorDisplayed = true;
       }
     });
+
+    if (!errorDisplayed) {
+      addErrorMessage(t('Unknown error while saving'));
+    }
   }
 
   submitSuccess(data: Record<string, FieldValue>) {


### PR DESCRIPTION
Right now nothing happens if a form is saved and results in a 500. We should give SOME kind of feedback, even if it's just an error toast

Fixes [RTC-1008: Uptime alert form does not display errors if back-end request fails](https://linear.app/getsentry/issue/RTC-1008/uptime-alert-form-does-not-display-errors-if-back-end-request-fails)