### PR TITLE
fix(replay): Fix error breadcrumb not in Chapter

### DIFF
--- a/static/app/utils/replays/replayReader.tsx
+++ b/static/app/utils/replays/replayReader.tsx
@@ -744,6 +744,26 @@ export default class ReplayReader {
     )
   );
 
+  getSummaryChapterFrames = memoize(() => {
+    return [
+      ...this.getPerfFrames(),
+      ...this.getCustomFrames(),
+      ...this._sortedBreadcrumbFrames.filter(frame =>
+        [
+          'replay.hydrate-error',
+          'replay.mutations',
+          'feedback',
+          'device.battery',
+          'device.connectivity',
+          'device.orientation',
+          'app.foreground',
+          'app.background',
+        ].includes(frame.category)
+      ),
+      ...this._errors,
+    ].sort(sortFrames);
+  });
+
   getPerfFrames = memoize(() => {
     const crumbs = removeDuplicateClicks(
       this._sortedBreadcrumbFrames.filter(

--- a/static/app/views/replays/detail/ai/chapterList.tsx
+++ b/static/app/views/replays/detail/ai/chapterList.tsx
@@ -47,7 +47,7 @@ export function ChapterList({timeRanges}: Props) {
           feedback,
           breadcrumbs:
             replay
-              ?.getChapterFrames()
+              ?.getSummaryChapterFrames()
               .filter(
                 breadcrumb =>
                   breadcrumb.timestampMs >= period_start &&


### PR DESCRIPTION
It looks like we are losing millisecond precision w/ the start timestamp and/or duration if the error is the last event we receive in the replay.

Take a look at [this replay](https://sentry.sentry.io/explore/replays/6037de22e46640159865493446790405/?project=11276&query=count_errors%3A%3E0&referrer=%2Fexplore%2Freplays%2F&statsPeriod=7d&t_main=ai&yAxis=count%28%29) for an example. `getChapterFrames()` trims to between start + end and error occurs 718ms later:

Start TS: 1754421644000
Duration: 246000
End TS: 1754421890000
Error: 1754421890718 (+718ms)

The proposed solution creates a new getter that does not trim frames since we use the chapter timestamps to trim anyway.
