### PR TITLE
feat(logs): Return log messages filter in project options

### DIFF
--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -1128,6 +1128,9 @@ class DetailedProjectSerializer(ProjectWithTeamSerializer):
             f"filters:{FilterTypes.ERROR_MESSAGES}": "\n".join(
                 options.get(f"sentry:{FilterTypes.ERROR_MESSAGES}", [])
             ),
+            f"filters:{FilterTypes.LOG_MESSAGES}": "\n".join(
+                options.get(f"sentry:{FilterTypes.LOG_MESSAGES}", [])
+            ),
             "feedback:branding": options.get("feedback:branding", "1") == "1",
             "sentry:feedback_user_report_notifications": bool(
                 self.get_value_with_default(attrs, "sentry:feedback_user_report_notifications")

--- a/src/sentry/models/options/project_option.py
+++ b/src/sentry/models/options/project_option.py
@@ -38,6 +38,7 @@ OPTION_KEYS = frozenset(
         "sentry:blacklisted_ips",
         "sentry:releases",
         "sentry:error_messages",
+        "sentry:log_messages",
         "sentry:scrape_javascript",
         "sentry:replay_hydration_error_issues",
         "sentry:replay_rage_click_issues",

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -262,6 +262,22 @@ class ProjectDetailsTest(APITestCase):
             resp = self.get_success_response(self.project.organization.slug, self.project.slug)
             assert resp.data["isDynamicallySampled"]
 
+    def test_filter_options(self):
+        self.project.update_option("sentry:releases", ["1.*", "2.1.*"])
+        self.project.update_option(
+            "sentry:error_messages", ["TypeError*", "*: integer division by modulo or zero"]
+        )
+        self.project.update_option("sentry:log_messages", ["Updated*", "*.sentry.io"])
+
+        resp = self.get_success_response(self.project.organization.slug, self.project.slug)
+
+        assert resp.data["options"]["filters:releases"] == "1.*\n2.1.*"
+        assert (
+            resp.data["options"]["filters:error_messages"]
+            == "TypeError*\n*: integer division by modulo or zero"
+        )
+        assert resp.data["options"]["filters:log_messages"] == "Updated*\n*.sentry.io"
+
 
 class ProjectUpdateTestTokenAuthenticated(APITestCase):
     endpoint = "sentry-api-0-project-details"


### PR DESCRIPTION
This needs to be returned in the project model or it won't render.