### PR TITLE
fix(replay): Add `textValue` to tabs in replay details

### DIFF
--- a/static/app/views/replays/detail/layout/focusTabs.tsx
+++ b/static/app/views/replays/detail/layout/focusTabs.tsx
@@ -79,7 +79,11 @@ export default function FocusTabs({isVideoReplay}: Props) {
       >
         <TabList hideBorder>
           {tabs.map(([tab, label]) => (
-            <TabList.Item key={tab} data-test-id={`replay-details-${tab}-btn`}>
+            <TabList.Item
+              key={tab}
+              textValue={tab}
+              data-test-id={`replay-details-${tab}-btn`}
+            >
               {label}
             </TabList.Item>
           ))}


### PR DESCRIPTION
This fixes the warning:

```
<Item> with non-plain text contents is unsupported by type to select for accessibility. Please add a `textValue` prop.
```

This comes from the "experimental" icon of the Summary tab causing the it to no longer be text-only.
