### PR TITLE
ref(grouping): make BE send grouping info with underscores and not dashes

### DIFF
--- a/src/sentry/issues/endpoints/event_grouping_info.py
+++ b/src/sentry/issues/endpoints/event_grouping_info.py
@@ -48,22 +48,7 @@ class EventGroupingInfoEndpoint(ProjectEndpoint):
         )
         grouping_config.initial_context["reverse_stacktraces"] = should_reverse_stacktraces
 
-        _grouping_info = get_grouping_info(grouping_config, project, event)
-
-        # TODO: All of the below is a temporary hack to preserve compatibility between the BE and FE as
-        # we transition from using dashes in the keys/variant types to using underscores. For now, until
-        # we change the FE, we switch back to dashes before sending the data.
-        grouping_info = {}
-
-        for key, variant_dict in _grouping_info.items():
-            new_key = key.replace("_", "-")
-            new_type = variant_dict.get("type", "").replace("_", "-")
-
-            variant_dict["key"] = new_key
-            if "type" in variant_dict:
-                variant_dict["type"] = new_type
-
-            grouping_info[new_key] = variant_dict
+        grouping_info = get_grouping_info(grouping_config, project, event)
 
         return HttpResponse(
             orjson.dumps(grouping_info, option=orjson.OPT_UTC_Z), content_type="application/json"

--- a/tests/sentry/issues/endpoints/test_event_grouping_info.py
+++ b/tests/sentry/issues/endpoints/test_event_grouping_info.py
@@ -216,32 +216,3 @@ class EventGroupingInfoEndpointTestCase(APITestCase, PerformanceIssueTestCase):
             "event_grouping_info.hash_mismatch",
             extra={"project_id": self.project.id, "event_id": javascript_event.event_id},
         )
-
-    def test_variant_keys_and_types_use_underscores_not_dashes(self) -> None:
-        """
-        Test to make sure switching to using underscores on the BE doesn't change what we send
-        to the FE.
-        """
-        data = load_data(platform="javascript")
-        data["fingerprint"] = ["dogs are great"]
-        event = self.store_event(data=data, project_id=self.project.id)
-
-        url = reverse(
-            "sentry-api-0-event-grouping-info",
-            kwargs={
-                "organization_id_or_slug": self.organization.slug,
-                "project_id_or_slug": self.project.slug,
-                "event_id": event.event_id,
-            },
-        )
-
-        response = self.client.get(url, format="json")
-        content = orjson.loads(response.content)
-
-        assert response.status_code == 200
-
-        assert "custom_fingerprint" in content
-        assert "custom-fingerprint" not in content
-
-        assert content["custom_fingerprint"]["key"] == "custom_fingerprint"
-        assert content["custom_fingerprint"]["type"] == "custom_fingerprint"

--- a/tests/sentry/issues/endpoints/test_event_grouping_info.py
+++ b/tests/sentry/issues/endpoints/test_event_grouping_info.py
@@ -217,7 +217,7 @@ class EventGroupingInfoEndpointTestCase(APITestCase, PerformanceIssueTestCase):
             extra={"project_id": self.project.id, "event_id": javascript_event.event_id},
         )
 
-    def test_variant_keys_and_types_use_dashes_not_underscores(self) -> None:
+    def test_variant_keys_and_types_use_underscores_not_dashes(self) -> None:
         """
         Test to make sure switching to using underscores on the BE doesn't change what we send
         to the FE.
@@ -240,8 +240,8 @@ class EventGroupingInfoEndpointTestCase(APITestCase, PerformanceIssueTestCase):
 
         assert response.status_code == 200
 
-        assert "custom-fingerprint" in content
-        assert "custom_fingerprint" not in content
+        assert "custom_fingerprint" in content
+        assert "custom-fingerprint" not in content
 
-        assert content["custom-fingerprint"]["key"] == "custom-fingerprint"
-        assert content["custom-fingerprint"]["type"] == "custom-fingerprint"
+        assert content["custom_fingerprint"]["key"] == "custom_fingerprint"
+        assert content["custom_fingerprint"]["type"] == "custom_fingerprint"


### PR DESCRIPTION
Continuation of #97683.

Delete section in `event_grouping_info.py` that changes grouping info data with `_` to `-`. FE is already configured to accept underscores. 

Also updated tests. 


