### PR TITLE
fix(crons): add sentry dependency to backfill migration

### DIFF
--- a/src/sentry/monitors/migrations/0008_fix_processing_error_keys.py
+++ b/src/sentry/monitors/migrations/0008_fix_processing_error_keys.py
@@ -213,6 +213,7 @@ class Migration(CheckedMigration):
 
     dependencies = [
         ("monitors", "0007_monitors_json_field"),
+        ("sentry", "0964_add_commitcomparison_table"),
     ]
 
     operations = [


### PR DESCRIPTION
We were unable to fetch the sentry migration models.