### PR TITLE
ref(autofix): migrate to EAP and continuous profiling

### DIFF
--- a/src/sentry/seer/autofix/autofix.py
+++ b/src/sentry/seer/autofix/autofix.py
@@ -17,15 +17,15 @@ from sentry.constants import DataCategory, ObjectStatus
 from sentry.eventstore.models import Event, GroupEvent
 from sentry.models.group import Group
 from sentry.models.project import Project
-from sentry.profiles.utils import get_from_profiling_service
 from sentry.search.eap.types import SearchResolverConfig
 from sentry.search.events.types import EventsResponse, SnubaParams
 from sentry.seer.autofix.utils import get_autofix_repos_from_project_code_mappings
+from sentry.seer.explorer.utils import _convert_profile_to_execution_tree, fetch_profile_data
 from sentry.seer.seer_setup import get_seer_org_acknowledgement
 from sentry.seer.signed_seer_api import sign_with_seer_secret
-from sentry.snuba.dataset import Dataset
 from sentry.snuba.ourlogs import OurLogs
 from sentry.snuba.referrer import Referrer
+from sentry.snuba.spans_rpc import Spans
 from sentry.tasks.autofix import check_autofix_status
 from sentry.users.models.user import User
 from sentry.users.services.user.model import RpcUser
@@ -236,30 +236,50 @@ def _get_trace_tree_for_event(event: Event | GroupEvent, project: Project) -> di
     if not trace_id:
         return None
 
-    project_ids = list(
-        dict(
-            Project.objects.filter(
-                organization=project.organization, status=ObjectStatus.ACTIVE
-            ).values_list("id", "slug")
-        ).keys()
+    projects_qs = Project.objects.filter(
+        organization=project.organization, status=ObjectStatus.ACTIVE
     )
+    projects = list(projects_qs)
+    project_ids = [p.id for p in projects]
     start = event.datetime - timedelta(days=1)
     end = event.datetime + timedelta(days=1)
-    transaction_event_filter = eventstore.Filter(
-        project_ids=project_ids,
-        conditions=[
-            ["trace_id", "=", trace_id],
-        ],
-        organization_id=project.organization_id,
+
+    # 1) Query for all spans in the trace using direct span query
+    snuba_params = SnubaParams(
         start=start,
         end=end,
+        projects=projects,
+        organization=project.organization,
     )
-    transactions = eventstore.backend.get_events(
-        filter=transaction_event_filter,
-        dataset=Dataset.Transactions,
+    config = SearchResolverConfig(
+        auto_fields=True,
+    )
+    all_spans_result = Spans.run_table_query(
+        params=snuba_params,
+        query_string=f"trace:{trace_id}",
+        selected_columns=[
+            "span_id",
+            "parent_span",
+            "span.op",
+            "span.description",
+            "precise.start_ts",
+            "precise.finish_ts",
+            "is_transaction",
+            "transaction",
+            "project.id",
+            "platform",
+            "profile.id",
+            "profiler.id",
+        ],
+        orderby=["precise.start_ts"],
+        offset=0,
+        limit=1000,
         referrer=Referrer.API_GROUP_AI_AUTOFIX,
-        tenant_ids={"organization_id": project.organization_id},
+        config=config,
+        sampling_mode="NORMAL",
     )
+
+    # 2) Query for all errors using existing eventstore approach
     error_event_filter = eventstore.Filter(
         project_ids=project_ids,
         conditions=[
@@ -274,6 +294,129 @@ def _get_trace_tree_for_event(event: Event | GroupEvent, project: Project) -> di
         referrer=Referrer.API_GROUP_AI_AUTOFIX,
         tenant_ids={"organization_id": project.organization_id},
     )
+
+    # 3) Separate out transaction spans and non-transaction spans
+    all_spans_data = all_spans_result.get("data", [])
+    transaction_spans = []
+    non_transaction_spans = []
+
+    for span_row in all_spans_data:
+        if span_row.get("is_transaction", False):
+            transaction_spans.append(span_row)
+        else:
+            non_transaction_spans.append(span_row)
+
+    # 4) Create trees of non-transaction spans and attach them to transactions
+    # Build a lookup of all spans by span_id
+    spans_by_id = {}
+    transaction_span_ids = set()
+
+    for span_row in non_transaction_spans:
+        span_id = span_row.get("span_id")
+        if span_id:
+            spans_by_id[span_id] = {
+                "span_id": span_id,
+                "parent_span_id": span_row.get("parent_span"),
+                "op": span_row.get("span.op"),
+                "description": span_row.get("span.description"),
+                "start_timestamp": span_row.get("precise.start_ts"),
+                "timestamp": span_row.get("precise.finish_ts"),
+                "data": {},  # empty, but we can add fields we want later
+            }
+
+    for tx_span in transaction_spans:
+        span_id = tx_span.get("span_id")
+        if span_id:
+            transaction_span_ids.add(span_id)
+
+    def find_transaction_parent(span_id: str) -> str | None:
+        """Recursively find which transaction this span belongs to by following parent_span_id chain"""
+        if not span_id:
+            return None
+
+        # If this span_id is itself a transaction, return it
+        if span_id in transaction_span_ids:
+            return span_id
+
+        # If this span exists in our spans lookup, check its parent
+        if span_id in spans_by_id:
+            parent_id = spans_by_id[span_id]["parent_span_id"]
+            if parent_id:
+                return find_transaction_parent(parent_id)
+
+        return None
+
+    # Group non-transaction spans by their parent transaction
+    spans_by_transaction: dict[str, list] = {}
+    for span_data in spans_by_id.values():
+        span_id = span_data["span_id"]
+        transaction_parent = find_transaction_parent(span_id)
+
+        if transaction_parent:
+            if transaction_parent not in spans_by_transaction:
+                spans_by_transaction[transaction_parent] = []
+            spans_by_transaction[transaction_parent].append(span_data)
+
+    # Convert transaction spans to event-like objects
+    transactions = []
+    for tx_span in transaction_spans:
+        event_id = tx_span.get("span_id")
+        project_id = tx_span.get("project.id")
+        span_id = tx_span.get("span_id")
+        parent_span_id = tx_span.get("parent_span")
+        transaction_name = tx_span.get("transaction")
+        start_ts = tx_span.get("precise.start_ts")
+        finish_ts = tx_span.get("precise.finish_ts")
+        span_op = tx_span.get("span.op")
+        platform_name = tx_span.get("platform")
+        profile_id = tx_span.get("profile.id")
+        profiler_id = tx_span.get("profiler.id")
+
+        # Get nested spans for this transaction
+        nested_spans = spans_by_transaction.get(span_id, [])
+
+        # Create a transaction-like event object
+        class MockTransaction:
+            def __init__(self):
+                self.event_id = event_id
+                self.project_id = project_id
+                self.platform = platform_name
+                self.title = transaction_name
+
+                # Find project by id to get project object
+                self.project = next((p for p in projects if p.id == project_id), None)
+
+                self.data = {
+                    "start_timestamp": start_ts,
+                    "precise_start_ts": start_ts,
+                    "precise_finish_ts": finish_ts,
+                    "contexts": {
+                        "trace": {
+                            "span_id": span_id,
+                            "parent_span_id": parent_span_id,
+                            "op": span_op,
+                        },
+                        "profile": {
+                            "profile_id": profile_id or profiler_id,
+                            "is_continuous": profiler_id and not profile_id,
+                        },
+                    },
+                    "spans": nested_spans,
+                    "breakdowns": {
+                        "span_ops": {
+                            "total.time": {
+                                "value": (
+                                    (finish_ts - start_ts) * 1000 if finish_ts and start_ts else 0
+                                ),
+                                "unit": "millisecond",
+                            }
+                        }
+                    },
+                }
+
+        transactions.append(MockTransaction())
+
+    # 5) Process transaction and error events as before to get expected output
     results = transactions + errors
 
     if not results:
@@ -526,18 +669,28 @@ def _get_profile_from_trace_tree(
         return None
 
     profile_id = matching_transaction.get("profile_id")
+    is_continuous = matching_transaction.get("is_continuous", False)
 
-    # Fetch the profile data
-    response = get_from_profiling_service(
-        "GET",
-        f"/organizations/{project.organization_id}/projects/{project.id}/profiles/{profile_id}",
-        params={"format": "sample"},
+    if not profile_id:
+        return None
+
+    # Get precise timestamps for continuous profiles
+    start_ts = matching_transaction.get("precise_start_ts")
+    end_ts = matching_transaction.get("precise_finish_ts")
+
+    # Fetch the profile data using the shared utility
+    profile = fetch_profile_data(
+        profile_id=profile_id,
+        organization_id=project.organization_id,
+        project_id=project.id,
+        start_ts=start_ts,
+        end_ts=end_ts,
+        is_continuous=is_continuous,
     )
 
-    if response.status == 200:
-        profile = orjson.loads(response.data)
+    if profile:
         execution_tree = _convert_profile_to_execution_tree(profile)
-        output = (
+        return (
             None
             if not execution_tree
             else {
@@ -545,284 +698,8 @@ def _get_profile_from_trace_tree(
                 "execution_tree": execution_tree,
             }
         )
-        if not output:
-            logger.info(
-                "[Autofix] Failed to convert profile to execution tree",
-                extra={
-                    "profile_id": profile_id,
-                    "project_slug": project.slug,
-                    "organization_slug": project.organization.slug,
-                },
-            )
-        return output
-    else:
-        logger.info(
-            "[Autofix] Failed to get profile from profiling service",
-            extra={
-                "response.status": response.status,
-                "profile_id": profile_id,
-                "project_slug": project.slug,
-                "organization_slug": project.organization.slug,
-            },
-        )
-        return None
 
-
-def _convert_profile_to_execution_tree(profile_data: dict) -> list[dict]:
-    """
-    Converts profile data into a hierarchical representation of code execution,
-    including only items from the MainThread and app frames.
-    Calculates accurate durations for all nodes based on call stack transitions.
-    """
-    profile = profile_data.get(
-        "profile"
-    )  # transaction profiles are formatted as {"profile": {"frames": [], "samples": [], "stacks": []}}
-    if not profile:
-        profile = profile_data.get("chunk", {}).get(
-            "profile"
-        )  # continuous profiles are wrapped as {"chunk": {"profile": {"frames": [], "samples": [], "stacks": []}}}
-        if not profile:
-            return []
-
-    frames = profile.get("frames")
-    stacks = profile.get("stacks")
-    samples = profile.get("samples")
-    if not all([frames, stacks, samples]):
-        return []
-
-    # Find the MainThread ID
-    thread_metadata = profile.get("thread_metadata", {}) or {}
-    main_thread_id = next(
-        (key for key, value in thread_metadata.items() if value.get("name") == "MainThread"), None
-    )
-    if (
-        not main_thread_id and len(thread_metadata) == 1
-    ):  # if there is only one thread, use that as the main thread
-        main_thread_id = list(thread_metadata.keys())[0]
-
-    def _get_elapsed_since_start_ns(
-        sample: dict[str, Any], all_samples: list[dict[str, Any]]
-    ) -> int:
-        """
-        Get the elapsed time since start for a sample.
-        Handles both transaction and continuous profiles.
-        """
-        if "elapsed_since_start_ns" in sample:
-            return sample["elapsed_since_start_ns"]
-        elif "timestamp" in sample:
-            min_timestamp = min(s["timestamp"] for s in all_samples)
-            return int((sample["timestamp"] - min_timestamp) * 1e9)
-        else:
-            return 0
-
-    # Sort samples chronologically
-    sorted_samples = sorted(samples, key=lambda x: _get_elapsed_since_start_ns(x, samples))
-
-    # Calculate average sampling interval
-    if len(sorted_samples) >= 2:
-        time_diffs = [
-            _get_elapsed_since_start_ns(sorted_samples[i + 1], sorted_samples)
-            - _get_elapsed_since_start_ns(sorted_samples[i], sorted_samples)
-            for i in range(len(sorted_samples) - 1)
-        ]
-        sample_interval_ns = int(sum(time_diffs) / len(time_diffs)) if time_diffs else 10000000
-    else:
-        sample_interval_ns = 10000000  # default 10ms
-
-    def create_frame_node(frame_index: int) -> dict[str, Any]:
-        """Create a node representation for a single frame"""
-        frame = frames[frame_index]
-        return {
-            "function": frame.get("function", ""),
-            "module": frame.get("module", ""),
-            "filename": frame.get("filename", ""),
-            "lineno": frame.get("lineno", 0),
-            "in_app": frame.get("in_app", False),
-            "children": [],
-            "node_id": None,
-            "sample_count": 0,
-            "first_seen_ns": None,
-            "last_seen_ns": None,
-            "duration_ns": None,
-        }
-
-    def get_node_path(node: dict[str, Any], parent_path: str = "") -> str:
-        """Generate a unique path identifier for a node"""
-        return f"{parent_path}/{node['function']}:{node['filename']}:{node['lineno']}"
-
-    def find_or_create_child(parent: dict[str, Any], frame_data: dict[str, Any]) -> dict[str, Any]:
-        """Find existing child node or create new one"""
-        for child in parent["children"]:
-            if (
-                child["function"] == frame_data["function"]
-                and child["module"] == frame_data["module"]
-                and child["filename"] == frame_data["filename"]
-                and child["lineno"] == frame_data["lineno"]
-            ):
-                return child
-
-        parent["children"].append(frame_data)
-        return frame_data
-
-    def process_stack(stack_index):
-        """Extract app frames from a stack trace"""
-        frame_indices = stacks[stack_index]
-        if not frame_indices:
-            return []
-
-        # Create nodes for app frames only, maintaining order (bottom to top)
-        nodes = []
-        for idx in reversed(frame_indices):
-            frame = frames[idx]
-            if frame.get("in_app", False) and not (
-                frame.get("filename", "").startswith("<")
-                and frame.get("filename", "").endswith(">")
-            ):
-                nodes.append(create_frame_node(idx))
-
-        return nodes
-
-    # Build the execution tree and track call stacks
-    execution_tree: list[dict[str, Any]] = []
-    call_stack_history: list[tuple[list[str], int]] = []  # [(node_ids, timestamp), ...]
-    node_registry: dict[str, dict[str, Any]] = {}  # {node_id: node_reference}
-
-    for sample in sorted_samples:
-        if str(sample["thread_id"]) != str(main_thread_id):
-            continue
-
-        timestamp_ns = _get_elapsed_since_start_ns(sample, sorted_samples)
-        stack_frames = process_stack(sample["stack_id"])
-        if not stack_frames:
-            continue
-
-        # Process this stack sample
-        current_stack_ids = []
-
-        # Find or create root node
-        root = None
-        for existing_root in execution_tree:
-            if (
-                existing_root["function"] == stack_frames[0]["function"]
-                and existing_root["module"] == stack_frames[0]["module"]
-                and existing_root["filename"] == stack_frames[0]["filename"]
-                and existing_root["lineno"] == stack_frames[0]["lineno"]
-            ):
-                root = existing_root
-                break
-
-        if root is None:
-            root = stack_frames[0]
-            execution_tree.append(root)
-
-        # Process root node
-        if root["node_id"] is None:
-            node_id = get_node_path(root)
-            root["node_id"] = node_id
-            node_registry[node_id] = root
-            root["first_seen_ns"] = timestamp_ns
-
-        root["sample_count"] += 1
-        root["last_seen_ns"] = timestamp_ns
-        current_stack_ids.append(root["node_id"])
-
-        # Process rest of the stack
-        current = root
-        current_path = root["node_id"]
-
-        for frame in stack_frames[1:]:
-            current = find_or_create_child(current, frame)
-
-            if current["node_id"] is None:
-                node_id = get_node_path(current, current_path)
-                current["node_id"] = node_id
-                node_registry[node_id] = current
-                current["first_seen_ns"] = timestamp_ns
-
-            current["sample_count"] += 1
-            current["last_seen_ns"] = timestamp_ns
-            current_stack_ids.append(current["node_id"])
-            current_path = current["node_id"]
-
-        # Record this call stack with its timestamp
-        call_stack_history.append((current_stack_ids, timestamp_ns))
-
-    # Calculate function active periods from call stack history
-    function_periods: dict[str, list[list[int | None]]] = {}
-
-    for i, (call_path, timestamp) in enumerate(call_stack_history):
-        # Mark functions as started
-        for node_id in call_path:
-            if node_id not in function_periods:
-                function_periods[node_id] = []
-
-            # Start a new period if needed
-            if not function_periods[node_id] or function_periods[node_id][-1][1] is not None:
-                function_periods[node_id].append([timestamp, None])
-
-        # Mark functions that disappeared as ended
-        if i > 0:
-            prev_call_path = call_stack_history[i - 1][0]
-            for node_id in prev_call_path:
-                if node_id not in call_path and function_periods.get(node_id):
-                    if function_periods[node_id][-1][1] is None:
-                        function_periods[node_id][-1][1] = timestamp
-
-    # Handle the last sample - all active functions end
-    if call_stack_history:
-        last_timestamp = call_stack_history[-1][1]
-        last_call_path = call_stack_history[-1][0]
-
-        for node_id in last_call_path:
-            if function_periods.get(node_id) and function_periods[node_id][-1][1] is None:
-                function_periods[node_id][-1][1] = last_timestamp + sample_interval_ns
-
-    # Calculate durations
-    def apply_durations(node):
-        """Calculate and set duration for a node and its children"""
-        node_id = node["node_id"]
-
-        # Primary method: use function periods if available
-        if node_id in function_periods:
-            periods = function_periods[node_id]
-            total_duration = sum(
-                (end - start) for start, end in periods if start is not None and end is not None
-            )
-
-            if total_duration > 0:
-                node["duration_ns"] = total_duration
-
-        # Apply to all children
-        for child in node["children"]:
-            apply_durations(child)
-
-        # Fallback methods if needed
-        if node["duration_ns"] is None or node["duration_ns"] == 0:
-            # Method 1: Use first and last seen timestamps
-            if node["first_seen_ns"] is not None and node["last_seen_ns"] is not None:
-                node["duration_ns"] = (
-                    node["last_seen_ns"] - node["first_seen_ns"] + sample_interval_ns
-                )
-
-            # Method 2: Use sample count as an estimate
-            elif node["sample_count"] > 0:
-                node["duration_ns"] = node["sample_count"] * sample_interval_ns
-
-            # Method 3: Use sum of children's durations
-            elif node["children"]:
-                child_duration = sum(
-                    child["duration_ns"]
-                    for child in node["children"]
-                    if child["duration_ns"] is not None
-                )
-                if child_duration > 0:
-                    node["duration_ns"] = child_duration
-
-    # Apply durations to all nodes
-    for node in execution_tree:
-        apply_durations(node)
-
-    return execution_tree
+    return None
 
 
 def _respond_with_error(reason: str, status: int):

--- a/src/sentry/seer/autofix/autofix.py
+++ b/src/sentry/seer/autofix/autofix.py
@@ -465,6 +465,9 @@ def _get_trace_tree_for_event(event: Event | GroupEvent, project: Project) -> di
                 f"{duration_obj.get('value', 0)} {duration_obj.get('unit', 'millisecond')}s"
             )
             profile_id = event_data.get("contexts", {}).get("profile", {}).get("profile_id")
+            is_continuous = event_data.get("contexts", {}).get("profile", {}).get("is_continuous")
+            precise_start_ts = event_data.get("precise_start_ts")
+            precise_finish_ts = event_data.get("precise_finish_ts")
 
             # Store all span IDs from this transaction for later relationship building
             spans = event_data.get("spans", [])
@@ -489,6 +492,9 @@ def _get_trace_tree_for_event(event: Event | GroupEvent, project: Project) -> di
                     "profile_id": profile_id,
                     "span_ids": span_ids,  # Store for later use
                     "spans": selected_spans_tree,
+                    "is_continuous": is_continuous,
+                    "precise_start_ts": precise_start_ts,
+                    "precise_finish_ts": precise_finish_ts,
                 }
             )
 

--- a/src/sentry/seer/autofix/autofix_tools.py
+++ b/src/sentry/seer/autofix/autofix_tools.py
@@ -3,7 +3,7 @@ import orjson
 from sentry import eventstore
 from sentry.api.serializers import EventSerializer, serialize
 from sentry.profiles.utils import get_from_profiling_service
-from sentry.seer.autofix.autofix import _convert_profile_to_execution_tree
+from sentry.seer.explorer.utils import _convert_profile_to_execution_tree
 
 
 def get_profile_details(organization_id: int, project_id: int, profile_id: str):

--- a/src/sentry/seer/explorer/index_data.py
+++ b/src/sentry/seer/explorer/index_data.py
@@ -2,7 +2,6 @@ import logging
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
-import orjson
 from django.contrib.auth.models import AnonymousUser
 
 from sentry import search
@@ -13,11 +12,13 @@ from sentry.api.serializers.models.event import EventSerializer
 from sentry.eventstore import backend as eventstore
 from sentry.eventstore.models import Event, GroupEvent
 from sentry.models.project import Project
-from sentry.profiles.profile_chunks import get_chunk_ids
-from sentry.profiles.utils import get_from_profiling_service
 from sentry.search.eap.types import SearchResolverConfig
 from sentry.search.events.types import SnubaParams
-from sentry.seer.explorer.utils import convert_profile_to_execution_tree, normalize_description
+from sentry.seer.explorer.utils import (
+    convert_profile_to_execution_tree,
+    fetch_profile_data,
+    normalize_description,
+)
 from sentry.seer.sentry_data_models import (
     IssueDetails,
     ProfileData,
@@ -216,92 +217,6 @@ def get_trace_for_transaction(transaction_name: str, project_id: int) -> TraceDa
     )
 
 
-def _fetch_profile_data(
-    profile_id: str,
-    organization_id: int,
-    project_id: int,
-    start_ts: float | None = None,
-    end_ts: float | None = None,
-    is_continuous: bool = False,
-) -> dict[str, Any] | None:
-    """
-    Fetch raw profile data from the profiling service.
-
-    Args:
-        profile_id: The profile ID to fetch (profile_id for transaction profiles, profiler_id for continuous)
-        organization_id: Organization ID
-        project_id: Project ID
-        start_ts: Start timestamp from span
-        end_ts: End timestamp from span
-        is_continuous: Whether this is a continuous profile (uses /chunk endpoint)
-
-    Returns:
-        Raw profile data or None if not found
-    """
-    if is_continuous:
-        if start_ts is None or end_ts is None:
-            logger.info(
-                "Start and end timestamps not provided for fetching continuous profiles, skipping",
-                extra={
-                    "profile_id": profile_id,
-                    "is_continuous": is_continuous,
-                    "start_ts": start_ts,
-                    "end_ts": end_ts,
-                },
-            )
-            return None
-
-        span_start = datetime.fromtimestamp(start_ts, UTC)
-        span_end = max(
-            datetime.fromtimestamp(end_ts, UTC),
-            span_start + timedelta(milliseconds=10),
-        )  # Ensure span_end is at least 10ms ahead of span_start
-        try:
-            project = Project.objects.get(id=project_id)
-        except Project.DoesNotExist:
-            logger.warning("Project not found for chunk_ids", extra={"project_id": project_id})
-            return None
-        span_snuba_params = SnubaParams(
-            start=span_start,
-            end=span_end,
-            projects=[project],
-            organization=project.organization,
-        )
-
-        chunk_ids = get_chunk_ids(span_snuba_params, profile_id, project_id)
-
-        response = get_from_profiling_service(
-            method="POST",
-            path=f"/organizations/{organization_id}/projects/{project_id}/chunks",
-            json_data={
-                "profiler_id": profile_id,
-                "chunk_ids": chunk_ids,
-                "start": str(int(start_ts * 1e9)),
-                "end": str(int(end_ts * 1e9)),
-            },
-        )
-    else:
-        # For transaction profiles (profile_id), use the profile endpoint
-        response = get_from_profiling_service(
-            "GET",
-            f"/organizations/{organization_id}/projects/{project_id}/profiles/{profile_id}",
-            params={"format": "sample"},
-        )
-
-    logger.info(
-        "Got response from profiling service",
-        extra={
-            "profile_id": profile_id,
-            "is_continuous": is_continuous,
-            "response.status": response.status,
-            "response.msg": response.msg,
-        },
-    )
-    if response.status == 200:
-        return orjson.loads(response.data)
-    return None
-
-
 def get_profiles_for_trace(trace_id: str, project_id: int) -> TraceProfiles | None:
     """
     Get profiles for a given trace, with one profile per unique span/transaction.
@@ -466,7 +381,7 @@ def get_profiles_for_trace(trace_id: str, project_id: int) -> TraceProfiles | No
         end_ts = profile_info["end_ts"]
 
         # Fetch raw profile data
-        raw_profile = _fetch_profile_data(
+        raw_profile = fetch_profile_data(
             profile_id=profile_id,
             organization_id=project.organization_id,
             project_id=project_id,

--- a/src/sentry/seer/explorer/utils.py
+++ b/src/sentry/seer/explorer/utils.py
@@ -1,7 +1,17 @@
+import logging
 import re
+from datetime import UTC, datetime, timedelta
+from typing import Any
 
-from sentry.seer.autofix.autofix import _convert_profile_to_execution_tree
+import orjson
+
+from sentry.models.project import Project
+from sentry.profiles.profile_chunks import get_chunk_ids
+from sentry.profiles.utils import get_from_profiling_service
+from sentry.search.events.types import SnubaParams
 from sentry.seer.sentry_data_models import ExecutionTreeNode
+
+logger = logging.getLogger(__name__)
 
 
 def normalize_description(description: str) -> str:
@@ -36,13 +46,269 @@ def normalize_description(description: str) -> str:
     return description
 
 
+def _convert_profile_to_execution_tree(profile_data: dict) -> list[dict]:
+    """
+    Converts profile data into a hierarchical representation of code execution,
+    including only items from the MainThread and app frames.
+    Calculates accurate durations for all nodes based on call stack transitions.
+    """
+    profile = profile_data.get(
+        "profile"
+    )  # transaction profiles are formatted as {"profile": {"frames": [], "samples": [], "stacks": []}}
+    if not profile:
+        profile = profile_data.get("chunk", {}).get(
+            "profile"
+        )  # continuous profiles are wrapped as {"chunk": {"profile": {"frames": [], "samples": [], "stacks": []}}}
+        if not profile:
+            return []
+
+    frames = profile.get("frames")
+    stacks = profile.get("stacks")
+    samples = profile.get("samples")
+    if not all([frames, stacks, samples]):
+        return []
+
+    # Find the MainThread ID
+    thread_metadata = profile.get("thread_metadata", {}) or {}
+    main_thread_id = next(
+        (key for key, value in thread_metadata.items() if value.get("name") == "MainThread"), None
+    )
+    if (
+        not main_thread_id and len(thread_metadata) == 1
+    ):  # if there is only one thread, use that as the main thread
+        main_thread_id = list(thread_metadata.keys())[0]
+
+    def _get_elapsed_since_start_ns(
+        sample: dict[str, Any], all_samples: list[dict[str, Any]]
+    ) -> int:
+        """
+        Get the elapsed time since start for a sample.
+        Handles both transaction and continuous profiles.
+        """
+        if "elapsed_since_start_ns" in sample:
+            return sample["elapsed_since_start_ns"]
+        elif "timestamp" in sample:
+            min_timestamp = min(s["timestamp"] for s in all_samples)
+            return int((sample["timestamp"] - min_timestamp) * 1e9)
+        else:
+            return 0
+
+    # Sort samples chronologically
+    sorted_samples = sorted(samples, key=lambda x: _get_elapsed_since_start_ns(x, samples))
+
+    # Calculate average sampling interval
+    if len(sorted_samples) >= 2:
+        time_diffs = [
+            _get_elapsed_since_start_ns(sorted_samples[i + 1], sorted_samples)
+            - _get_elapsed_since_start_ns(sorted_samples[i], sorted_samples)
+            for i in range(len(sorted_samples) - 1)
+        ]
+        sample_interval_ns = int(sum(time_diffs) / len(time_diffs)) if time_diffs else 10000000
+    else:
+        sample_interval_ns = 10000000  # default 10ms
+
+    def create_frame_node(frame_index: int) -> dict[str, Any]:
+        """Create a node representation for a single frame"""
+        frame = frames[frame_index]
+        return {
+            "function": frame.get("function", ""),
+            "module": frame.get("module", ""),
+            "filename": frame.get("filename", ""),
+            "lineno": frame.get("lineno", 0),
+            "in_app": frame.get("in_app", False),
+            "children": [],
+            "node_id": None,
+            "sample_count": 0,
+            "first_seen_ns": None,
+            "last_seen_ns": None,
+            "duration_ns": None,
+        }
+
+    def get_node_path(node: dict[str, Any], parent_path: str = "") -> str:
+        """Generate a unique path identifier for a node"""
+        return f"{parent_path}/{node['function']}:{node['filename']}:{node['lineno']}"
+
+    def find_or_create_child(parent: dict[str, Any], frame_data: dict[str, Any]) -> dict[str, Any]:
+        """Find existing child node or create new one"""
+        for child in parent["children"]:
+            if (
+                child["function"] == frame_data["function"]
+                and child["module"] == frame_data["module"]
+                and child["filename"] == frame_data["filename"]
+                and child["lineno"] == frame_data["lineno"]
+            ):
+                return child
+
+        parent["children"].append(frame_data)
+        return frame_data
+
+    def process_stack(stack_index):
+        """Extract app frames from a stack trace"""
+        frame_indices = stacks[stack_index]
+        if not frame_indices:
+            return []
+
+        # Create nodes for app frames only, maintaining order (bottom to top)
+        nodes = []
+        for idx in reversed(frame_indices):
+            frame = frames[idx]
+            if frame.get("in_app", False) and not (
+                frame.get("filename", "").startswith("<")
+                and frame.get("filename", "").endswith(">")
+            ):
+                nodes.append(create_frame_node(idx))
+
+        return nodes
+
+    # Build the execution tree and track call stacks
+    execution_tree: list[dict[str, Any]] = []
+    call_stack_history: list[tuple[list[str], int]] = []  # [(node_ids, timestamp), ...]
+    node_registry: dict[str, dict[str, Any]] = {}  # {node_id: node_reference}
+
+    for sample in sorted_samples:
+        if str(sample["thread_id"]) != str(main_thread_id):
+            continue
+
+        timestamp_ns = _get_elapsed_since_start_ns(sample, sorted_samples)
+        stack_frames = process_stack(sample["stack_id"])
+        if not stack_frames:
+            continue
+
+        # Process this stack sample
+        current_stack_ids = []
+
+        # Find or create root node
+        root = None
+        for existing_root in execution_tree:
+            if (
+                existing_root["function"] == stack_frames[0]["function"]
+                and existing_root["module"] == stack_frames[0]["module"]
+                and existing_root["filename"] == stack_frames[0]["filename"]
+                and existing_root["lineno"] == stack_frames[0]["lineno"]
+            ):
+                root = existing_root
+                break
+
+        if root is None:
+            root = stack_frames[0]
+            execution_tree.append(root)
+
+        # Process root node
+        if root["node_id"] is None:
+            node_id = get_node_path(root)
+            root["node_id"] = node_id
+            node_registry[node_id] = root
+            root["first_seen_ns"] = timestamp_ns
+
+        root["sample_count"] += 1
+        root["last_seen_ns"] = timestamp_ns
+        current_stack_ids.append(root["node_id"])
+
+        # Process rest of the stack
+        current = root
+        current_path = root["node_id"]
+
+        for frame in stack_frames[1:]:
+            current = find_or_create_child(current, frame)
+
+            if current["node_id"] is None:
+                node_id = get_node_path(current, current_path)
+                current["node_id"] = node_id
+                node_registry[node_id] = current
+                current["first_seen_ns"] = timestamp_ns
+
+            current["sample_count"] += 1
+            current["last_seen_ns"] = timestamp_ns
+            current_stack_ids.append(current["node_id"])
+            current_path = current["node_id"]
+
+        # Record this call stack with its timestamp
+        call_stack_history.append((current_stack_ids, timestamp_ns))
+
+    # Calculate function active periods from call stack history
+    function_periods: dict[str, list[list[int | None]]] = {}
+
+    for i, (call_path, timestamp) in enumerate(call_stack_history):
+        # Mark functions as started
+        for node_id in call_path:
+            if node_id not in function_periods:
+                function_periods[node_id] = []
+
+            # Start a new period if needed
+            if not function_periods[node_id] or function_periods[node_id][-1][1] is not None:
+                function_periods[node_id].append([timestamp, None])
+
+        # Mark functions that disappeared as ended
+        if i > 0:
+            prev_call_path = call_stack_history[i - 1][0]
+            for node_id in prev_call_path:
+                if node_id not in call_path and function_periods.get(node_id):
+                    if function_periods[node_id][-1][1] is None:
+                        function_periods[node_id][-1][1] = timestamp
+
+    # Handle the last sample - all active functions end
+    if call_stack_history:
+        last_timestamp = call_stack_history[-1][1]
+        last_call_path = call_stack_history[-1][0]
+
+        for node_id in last_call_path:
+            if function_periods.get(node_id) and function_periods[node_id][-1][1] is None:
+                function_periods[node_id][-1][1] = last_timestamp + sample_interval_ns
+
+    # Calculate durations
+    def apply_durations(node):
+        """Calculate and set duration for a node and its children"""
+        node_id = node["node_id"]
+
+        # Primary method: use function periods if available
+        if node_id in function_periods:
+            periods = function_periods[node_id]
+            total_duration = sum(
+                (end - start) for start, end in periods if start is not None and end is not None
+            )
+
+            if total_duration > 0:
+                node["duration_ns"] = total_duration
+
+        # Apply to all children
+        for child in node["children"]:
+            apply_durations(child)
+
+        # Fallback methods if needed
+        if node["duration_ns"] is None or node["duration_ns"] == 0:
+            # Method 1: Use first and last seen timestamps
+            if node["first_seen_ns"] is not None and node["last_seen_ns"] is not None:
+                node["duration_ns"] = (
+                    node["last_seen_ns"] - node["first_seen_ns"] + sample_interval_ns
+                )
+
+            # Method 2: Use sample count as an estimate
+            elif node["sample_count"] > 0:
+                node["duration_ns"] = node["sample_count"] * sample_interval_ns
+
+            # Method 3: Use sum of children's durations
+            elif node["children"]:
+                child_duration = sum(
+                    child["duration_ns"]
+                    for child in node["children"]
+                    if child["duration_ns"] is not None
+                )
+                if child_duration > 0:
+                    node["duration_ns"] = child_duration
+
+    # Apply durations to all nodes
+    for node in execution_tree:
+        apply_durations(node)
+
+    return execution_tree
+
+
 def convert_profile_to_execution_tree(profile_data: dict) -> list[ExecutionTreeNode]:
     """
     Converts profile data into a hierarchical representation of code execution,
     including only items from the MainThread and app frames.
     Calculates accurate durations for all nodes based on call stack transitions.
     """
-    # Use the autofix implementation to get dict-based results
     dict_tree = _convert_profile_to_execution_tree(profile_data)
 
     def dict_to_execution_tree_node(node_dict: dict) -> ExecutionTreeNode:
@@ -64,3 +330,89 @@ def convert_profile_to_execution_tree(profile_data: dict) -> list[ExecutionTreeN
         )
 
     return [dict_to_execution_tree_node(node) for node in dict_tree]
+
+
+def fetch_profile_data(
+    profile_id: str,
+    organization_id: int,
+    project_id: int,
+    start_ts: float | None = None,
+    end_ts: float | None = None,
+    is_continuous: bool = False,
+) -> dict[str, Any] | None:
+    """
+    Fetch raw profile data from the profiling service.
+
+    Args:
+        profile_id: The profile ID to fetch (profile_id for transaction profiles, profiler_id for continuous)
+        organization_id: Organization ID
+        project_id: Project ID
+        start_ts: Start timestamp from span
+        end_ts: End timestamp from span
+        is_continuous: Whether this is a continuous profile (uses /chunk endpoint)
+
+    Returns:
+        Raw profile data or None if not found
+    """
+    if is_continuous:
+        if start_ts is None or end_ts is None:
+            logger.info(
+                "Start and end timestamps not provided for fetching continuous profiles, skipping",
+                extra={
+                    "profile_id": profile_id,
+                    "is_continuous": is_continuous,
+                    "start_ts": start_ts,
+                    "end_ts": end_ts,
+                },
+            )
+            return None
+
+        span_start = datetime.fromtimestamp(start_ts, UTC)
+        span_end = max(
+            datetime.fromtimestamp(end_ts, UTC),
+            span_start + timedelta(milliseconds=10),
+        )  # Ensure span_end is at least 10ms ahead of span_start
+        try:
+            project = Project.objects.get(id=project_id)
+        except Project.DoesNotExist:
+            logger.warning("Project not found for chunk_ids", extra={"project_id": project_id})
+            return None
+        span_snuba_params = SnubaParams(
+            start=span_start,
+            end=span_end,
+            projects=[project],
+            organization=project.organization,
+        )
+
+        chunk_ids = get_chunk_ids(span_snuba_params, profile_id, project_id)
+
+        response = get_from_profiling_service(
+            method="POST",
+            path=f"/organizations/{organization_id}/projects/{project_id}/chunks",
+            json_data={
+                "profiler_id": profile_id,
+                "chunk_ids": chunk_ids,
+                "start": str(int(start_ts * 1e9)),
+                "end": str(int(end_ts * 1e9)),
+            },
+        )
+    else:
+        # For transaction profiles (profile_id), use the profile endpoint
+        response = get_from_profiling_service(
+            "GET",
+            f"/organizations/{organization_id}/projects/{project_id}/profiles/{profile_id}",
+            params={"format": "sample"},
+        )
+
+    logger.info(
+        "Got response from profiling service",
+        extra={
+            "profile_id": profile_id,
+            "is_continuous": is_continuous,
+            "response.status": response.status,
+            "response.msg": response.msg,
+        },
+    )
+    if response.status == 200:
+        return orjson.loads(response.data)
+    return None

--- a/tests/sentry/seer/autofix/test_autofix.py
+++ b/tests/sentry/seer/autofix/test_autofix.py
@@ -8,7 +8,6 @@ from django.contrib.auth.models import AnonymousUser
 from sentry.seer.autofix.autofix import (
     TIMEOUT_SECONDS,
     _call_autofix,
-    _convert_profile_to_execution_tree,
     _get_logs_for_event,
     _get_profile_from_trace_tree,
     _get_trace_tree_for_event,
@@ -16,8 +15,8 @@ from sentry.seer.autofix.autofix import (
     build_spans_tree,
     trigger_autofix,
 )
-from sentry.snuba.dataset import Dataset
-from sentry.testutils.cases import APITestCase, SnubaTestCase, TestCase
+from sentry.seer.explorer.utils import _convert_profile_to_execution_tree
+from sentry.testutils.cases import APITestCase, SnubaTestCase, SpanTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.skips import requires_snuba
@@ -293,7 +292,7 @@ class TestConvertProfileToExecutionTree(TestCase):
 
 @requires_snuba
 @pytest.mark.django_db
-class TestGetTraceTreeForEvent(APITestCase, SnubaTestCase):
+class TestGetTraceTreeForEvent(APITestCase, SnubaTestCase, SpanTestCase):
     def test_get_trace_tree_for_event(self) -> None:
         """
         Tests that a trace tree is correctly created with the expected structure:
@@ -317,7 +316,7 @@ class TestGetTraceTreeForEvent(APITestCase, SnubaTestCase):
         root_tx_span_id = "aaaaaaaaaaaaaaaa"
         root_tx_event_data = {
             "event_id": "root-tx-id",
-            "start_timestamp": 1672567200.0,
+            "start_timestamp": (event.datetime - timedelta(seconds=60)).timestamp(),
             "spans": [{"span_id": "child1-span-id"}, {"span_id": "child2-span-id"}],
             "contexts": {
                 "trace": {"trace_id": trace_id, "span_id": root_tx_span_id, "op": "http.server"}
@@ -328,11 +327,11 @@ class TestGetTraceTreeForEvent(APITestCase, SnubaTestCase):
         }
 
         # Child 1 - transaction that happens before child 2
-        child1_span_id = "child1-span-id"
+        child1_span_id = "bbbbbbbbbbbbbbbb"
         child1_tx_event_data = {
             "event_id": "child1-tx-id",
-            "start_timestamp": 1672567210.0,
-            "spans": [{"span_id": "grandchild1-span-id"}],
+            "start_timestamp": (event.datetime - timedelta(seconds=50)).timestamp(),
+            "spans": [{"span_id": "dddddddddddddddd"}],
             "contexts": {
                 "trace": {
                     "trace_id": trace_id,
@@ -347,10 +346,10 @@ class TestGetTraceTreeForEvent(APITestCase, SnubaTestCase):
         }
 
         # Child 2 - error that happens after child 1
-        child2_span_id = "child2-span-id"
+        child2_span_id = "cccccccccccccccc"
         child2_error_event_data = {
             "event_id": "child2-error-id",
-            "start_timestamp": 1672567220.0,
+            "start_timestamp": (event.datetime - timedelta(seconds=40)).timestamp(),
             "contexts": {
                 "trace": {
                     "trace_id": trace_id,
@@ -364,10 +363,10 @@ class TestGetTraceTreeForEvent(APITestCase, SnubaTestCase):
         }
 
         # Grandchild 1 - error event (child of child1)
-        grandchild1_span_id = "grandchild1-span-id"
+        grandchild1_span_id = "dddddddddddddddd"
         grandchild1_error_event_data = {
             "event_id": "grandchild1-error-id",
-            "start_timestamp": 1672567215.0,
+            "start_timestamp": (event.datetime - timedelta(seconds=45)).timestamp(),
             "contexts": {
                 "trace": {
                     "trace_id": trace_id,
@@ -381,10 +380,10 @@ class TestGetTraceTreeForEvent(APITestCase, SnubaTestCase):
         }
 
         # Add another root event that happens earlier
-        another_root_span_id = "bbbbbbbbbbbbbbbb"
+        another_root_span_id = "eeeeeeeeeeeeeeee"
         another_root_tx_event_data = {
             "event_id": "another-root-id",
-            "start_timestamp": 1672567140.0,
+            "start_timestamp": (event.datetime - timedelta(seconds=120)).timestamp(),
             "spans": [],
             "contexts": {
                 "trace": {"trace_id": trace_id, "span_id": another_root_span_id, "op": "browser"}
@@ -444,16 +443,41 @@ class TestGetTraceTreeForEvent(APITestCase, SnubaTestCase):
                     sort_tree(child)
             return node
 
-        # Update to patch both Transactions and Events dataset calls
+        spans = []
+
+        # Create transaction spans
+        for tx_event in tx_events:
+            span_id = tx_event.data["contexts"]["trace"]["span_id"]
+            parent_span_id = tx_event.data["contexts"]["trace"].get("parent_span_id")
+            transaction_name = tx_event.title
+            op = tx_event.data["contexts"]["trace"].get("op")
+
+            span = self.create_span(
+                {
+                    "trace_id": trace_id,
+                    "span_id": span_id,
+                    "parent_span_id": parent_span_id,
+                    "description": transaction_name,
+                    "sentry_tags": {
+                        "transaction": transaction_name,
+                        "op": op,
+                    },
+                    "is_segment": True,  # This marks it as a transaction span
+                },
+                start_ts=datetime.fromtimestamp(tx_event.start_timestamp),
+            )
+            span.update(
+                {
+                    "platform": tx_event.platform,
+                }
+            )
+            spans.append(span)
+
+        self.store_spans(spans, is_eap=True)
+
+        # Mock the error events query
         with patch("sentry.eventstore.backend.get_events") as mock_get_events:
-
-            def side_effect(filter, dataset=None, **kwargs):
-                if dataset == Dataset.Transactions:
-                    return tx_events
-                else:
-                    return error_events
-
-            mock_get_events.side_effect = side_effect
+            mock_get_events.return_value = error_events
 
             # Call the function directly instead of through an endpoint
             trace_tree = _get_trace_tree_for_event(event, self.project)
@@ -467,18 +491,18 @@ class TestGetTraceTreeForEvent(APITestCase, SnubaTestCase):
 
         # First root should be the earlier transaction
         first_root = trace_tree["events"][0]
-        assert first_root["event_id"] == "another-root-id"
+        assert first_root["event_id"] == "eeeeeeeeeeeeeeee"
         assert first_root["title"] == "browser - Earlier Transaction"
-        assert first_root["datetime"] == 1672567140.0
+        assert first_root["datetime"] == (event.datetime - timedelta(seconds=120)).timestamp()
         assert first_root["is_transaction"] is True
         assert first_root["is_error"] is False
         assert len(first_root["children"]) == 0
 
         # Second root should be the main root transaction
         second_root = trace_tree["events"][1]
-        assert second_root["event_id"] == "root-tx-id"
+        assert second_root["event_id"] == "aaaaaaaaaaaaaaaa"
         assert second_root["title"] == "http.server - Root Transaction"
-        assert second_root["datetime"] == 1672567200.0
+        assert second_root["datetime"] == (event.datetime - timedelta(seconds=60)).timestamp()
         assert second_root["is_transaction"] is True
         assert second_root["is_error"] is False
 
@@ -487,9 +511,9 @@ class TestGetTraceTreeForEvent(APITestCase, SnubaTestCase):
 
         # First child of main root is child1
         child1 = second_root["children"][0]
-        assert child1["event_id"] == "child1-tx-id"
+        assert child1["event_id"] == "bbbbbbbbbbbbbbbb"
         assert child1["title"] == "db - Database Query"
-        assert child1["datetime"] == 1672567210.0
+        assert child1["datetime"] == (event.datetime - timedelta(seconds=50)).timestamp()
         assert child1["is_transaction"] is True
         assert child1["is_error"] is False
 
@@ -498,7 +522,7 @@ class TestGetTraceTreeForEvent(APITestCase, SnubaTestCase):
         grandchild1 = child1["children"][0]
         assert grandchild1["event_id"] == "grandchild1-error-id"
         assert grandchild1["title"] == "Database Error"
-        assert grandchild1["datetime"] == 1672567215.0
+        assert grandchild1["datetime"] == (event.datetime - timedelta(seconds=45)).timestamp()
         assert grandchild1["is_transaction"] is False
         assert grandchild1["is_error"] is True
         assert len(grandchild1["children"]) == 0
@@ -507,16 +531,15 @@ class TestGetTraceTreeForEvent(APITestCase, SnubaTestCase):
         child2 = second_root["children"][1]
         assert child2["event_id"] == "child2-error-id"
         assert child2["title"] == "Division by zero"
-        assert child2["datetime"] == 1672567220.0
+        assert child2["datetime"] == (event.datetime - timedelta(seconds=40)).timestamp()
         assert child2["is_transaction"] is False
         assert child2["is_error"] is True
         assert len(child2["children"]) == 0
 
-        # Verify that get_events was called twice - once for transactions and once for errors
-        assert mock_get_events.call_count == 2
+        # Verify that get_events was called once (for errors only)
+        assert mock_get_events.call_count == 1
 
-    @patch("sentry.eventstore.backend.get_events")
-    def test_get_trace_tree_empty_results(self, mock_get_events) -> None:
+    def test_get_trace_tree_empty_results(self) -> None:
         """
         Expected trace structure:
 
@@ -524,23 +547,24 @@ class TestGetTraceTreeForEvent(APITestCase, SnubaTestCase):
 
         This test checks the behavior when no events are found for a trace.
         """
-        mock_get_events.return_value = []
-
         event_data = load_data("python")
         trace_id = "1234567890abcdef1234567890abcdef"
         test_span_id = "abcdef0123456789"
         event_data.update({"contexts": {"trace": {"trace_id": trace_id, "span_id": test_span_id}}})
         event = self.store_event(data=event_data, project_id=self.project.id)
 
-        # Call the function directly instead of through an endpoint
-        trace_tree = _get_trace_tree_for_event(event, self.project)
+        # Don't create any spans - this should result in an empty trace tree
+        # Mock the error events query to return empty results
+        with patch("sentry.eventstore.backend.get_events") as mock_get_events:
+            mock_get_events.return_value = []
+
+            trace_tree = _get_trace_tree_for_event(event, self.project)
 
         assert trace_tree is None
-        # Should be called twice - once for transactions and once for errors
-        assert mock_get_events.call_count == 2
+        # Should be called once (for errors only)
+        assert mock_get_events.call_count == 1
 
-    @patch("sentry.eventstore.backend.get_events")
-    def test_get_trace_tree_out_of_order_processing(self, mock_get_events) -> None:
+    def test_get_trace_tree_out_of_order_processing(self) -> None:
         """
         Expected trace structure:
 
@@ -559,9 +583,32 @@ class TestGetTraceTreeForEvent(APITestCase, SnubaTestCase):
 
         # Child event that references a parent we haven't seen yet
         child_span_id = "cccccccccccccccc"
-        parent_span_id = "pppppppppppppppp"
+        parent_span_id = "ffffffffffffffff"
 
-        # Create proper child event object
+        # Create parent transaction span
+        parent_span = self.create_span(
+            {
+                "trace_id": trace_id,
+                "span_id": parent_span_id,
+                "parent_span_id": None,
+                "description": "Parent Last",
+                "sentry_tags": {
+                    "transaction": "Parent Last",
+                    "op": "http.server",
+                },
+                "is_segment": True,
+            },
+            start_ts=event.datetime - timedelta(seconds=10),
+        )
+        parent_span.update(
+            {
+                "platform": "python",
+            }
+        )
+
+        self.store_spans([parent_span], is_eap=True)
+
+        # Create proper child error event object
         child_event = Mock()
         child_event.event_id = "child-id"
         child_event.start_timestamp = 1672567210.0
@@ -586,46 +633,18 @@ class TestGetTraceTreeForEvent(APITestCase, SnubaTestCase):
         child_event.message = "Child First"
         child_event.transaction = None
 
-        # Create proper parent event object
-        parent_event = Mock()
-        parent_event.event_id = "parent-id"
-        parent_event.start_timestamp = 1672567200.0
-        parent_event.data = {
-            "event_id": "parent-id",
-            "start_timestamp": 1672567200.0,
-            "spans": [],
-            "contexts": {
-                "trace": {"trace_id": trace_id, "span_id": parent_span_id, "op": "http.server"}
-            },
-            "title": "Parent Last",
-            "platform": "python",
-            "project_id": self.project.id,
-        }
-        parent_event.title = "Parent Last"
-        parent_event.platform = "python"
-        parent_event.project_id = self.project.id
-        parent_event.trace_id = trace_id
-        parent_event.message = "Parent Last"
-        parent_event.transaction = None
+        # Mock the error events query
+        with patch("sentry.eventstore.backend.get_events") as mock_get_events:
+            mock_get_events.return_value = [child_event]
 
-        # Set up the mock to return different results for different dataset calls
-        def side_effect(filter, dataset=None, **kwargs):
-            if dataset == Dataset.Transactions:
-                return [parent_event]  # Parent is a transaction
-            else:
-                return [child_event]  # Child is an error
-
-        mock_get_events.side_effect = side_effect
-
-        # Call the function directly instead of through an endpoint
-        trace_tree = _get_trace_tree_for_event(event, self.project)
+            trace_tree = _get_trace_tree_for_event(event, self.project)
 
         assert trace_tree is not None
         assert len(trace_tree["events"]) == 1
 
         # Parent should be the root
         root = trace_tree["events"][0]
-        assert root["event_id"] == "parent-id"
+        assert root["event_id"] == "ffffffffffffffff"
         assert root["span_id"] == parent_span_id
 
         # Child should be under parent
@@ -634,11 +653,10 @@ class TestGetTraceTreeForEvent(APITestCase, SnubaTestCase):
         assert child["event_id"] == "child-id"
         assert child["span_id"] == child_span_id
 
-        # Verify that get_events was called twice
-        assert mock_get_events.call_count == 2
+        # Verify that get_events was called once (for errors only)
+        assert mock_get_events.call_count == 1
 
-    @patch("sentry.eventstore.backend.get_events")
-    def test_get_trace_tree_with_only_errors(self, mock_get_events) -> None:
+    def test_get_trace_tree_with_only_errors(self) -> None:
         """
         Tests that when results contain only error events (no transactions),
         the function still creates a valid trace tree.
@@ -659,8 +677,10 @@ class TestGetTraceTreeForEvent(APITestCase, SnubaTestCase):
         event_data.update({"contexts": {"trace": {"trace_id": trace_id, "span_id": test_span_id}}})
         event = self.store_event(data=event_data, project_id=self.project.id)
 
+        # Don't create any transaction spans - this test is for errors only
+
         # Create error events with parent-child relationships
-        error1_span_id = "error1-span-id"
+        error1_span_id = "1111111111111111"
         error1 = Mock()
         error1.event_id = "error1-id"
         error1.start_timestamp = 1672567200.0
@@ -681,7 +701,7 @@ class TestGetTraceTreeForEvent(APITestCase, SnubaTestCase):
         error1.message = "First Error"
         error1.transaction = None
 
-        error2_span_id = "error2-span-id"
+        error2_span_id = "2222222222222222"
         error2 = Mock()
         error2.event_id = "error2-id"
         error2.start_timestamp = 1672567210.0
@@ -710,7 +730,7 @@ class TestGetTraceTreeForEvent(APITestCase, SnubaTestCase):
             "contexts": {
                 "trace": {
                     "trace_id": trace_id,
-                    "span_id": "error3-span-id",
+                    "span_id": "3333333333333333",
                     "parent_span_id": error2_span_id,  # Points to error2
                 }
             },
@@ -731,7 +751,7 @@ class TestGetTraceTreeForEvent(APITestCase, SnubaTestCase):
             "contexts": {
                 "trace": {
                     "trace_id": trace_id,
-                    "span_id": "error4-span-id",
+                    "span_id": "4444444444444444",
                     "parent_span_id": "non-existent-parent-3",  # Parent that doesn't exist in our data
                 }
             },
@@ -744,17 +764,11 @@ class TestGetTraceTreeForEvent(APITestCase, SnubaTestCase):
         error4.message = "Orphaned Error"
         error4.transaction = None
 
-        # Return empty transactions list but populate errors list
-        def side_effect(filter, dataset=None, **kwargs):
-            if dataset == Dataset.Transactions:
-                return []
-            else:
-                return [error1, error2, error3, error4]
+        # Mock the error events query to return all errors
+        with patch("sentry.eventstore.backend.get_events") as mock_get_events:
+            mock_get_events.return_value = [error1, error2, error3, error4]
 
-        mock_get_events.side_effect = side_effect
-
-        # Call the function directly
-        trace_tree = _get_trace_tree_for_event(event, self.project)
+            trace_tree = _get_trace_tree_for_event(event, self.project)
 
         # Verify the trace tree structure
         assert trace_tree is not None
@@ -776,11 +790,10 @@ class TestGetTraceTreeForEvent(APITestCase, SnubaTestCase):
         assert child["event_id"] == "error3-id"
         assert child["title"] == "Child Error"
 
-        # Verify get_events was called twice - once for transactions and once for errors
-        assert mock_get_events.call_count == 2
+        # Verify get_events was called once (for errors only)
+        assert mock_get_events.call_count == 1
 
-    @patch("sentry.eventstore.backend.get_events")
-    def test_get_trace_tree_all_relationship_rules(self, mock_get_events) -> None:
+    def test_get_trace_tree_all_relationship_rules(self) -> None:
         """
         Tests that all three relationship rules are correctly implemented:
         1. An event whose span_id is X is a parent of an event whose parent_span_id is X
@@ -801,26 +814,63 @@ class TestGetTraceTreeForEvent(APITestCase, SnubaTestCase):
         event = self.store_event(data=event_data, project_id=self.project.id)
 
         # Root transaction with two spans
-        root_tx_span_id = "root-tx-span-id"
-        tx_span_1 = "tx-span-1"
-        tx_span_2 = "tx-span-2"
+        root_tx_span_id = "aaaaaaaaaaaaaaaa"
+        tx_span_1 = "bbbbbbbbbbbbbbbb"
+        tx_span_2 = "cccccccccccccccc"
 
-        root_tx = Mock()
-        root_tx.event_id = "root-tx-id"
-        root_tx.start_timestamp = 1672567200.0
-        root_tx.data = {
-            "spans": [{"span_id": tx_span_1}, {"span_id": tx_span_2}],
-            "contexts": {
-                "trace": {"trace_id": trace_id, "span_id": root_tx_span_id, "op": "http.server"}
+        # Create root transaction span
+        root_span = self.create_span(
+            {
+                "trace_id": trace_id,
+                "span_id": root_tx_span_id,
+                "parent_span_id": None,
+                "description": "Root Transaction",
+                "sentry_tags": {
+                    "transaction": "Root Transaction",
+                    "op": "http.server",
+                },
+                "is_segment": True,
             },
-            "title": "Root Transaction",
-        }
-        root_tx.title = "Root Transaction"
-        root_tx.platform = "python"
-        root_tx.project_id = self.project.id
-        root_tx.trace_id = trace_id
-        root_tx.message = "Root Transaction"
-        root_tx.transaction = "Root Transaction"
+            start_ts=event.datetime - timedelta(seconds=20),
+        )
+        root_span.update(
+            {
+                "platform": "python",
+            }
+        )
+
+        # Create child spans for the transaction
+        child_span_1 = self.create_span(
+            {
+                "trace_id": trace_id,
+                "span_id": tx_span_1,
+                "parent_span_id": root_tx_span_id,
+                "description": "Child Span 1",
+                "sentry_tags": {
+                    "transaction": "Root Transaction",
+                    "op": "db.query",
+                },
+                "is_segment": False,
+            },
+            start_ts=event.datetime - timedelta(seconds=19),
+        )
+
+        child_span_2 = self.create_span(
+            {
+                "trace_id": trace_id,
+                "span_id": tx_span_2,
+                "parent_span_id": root_tx_span_id,
+                "description": "Child Span 2",
+                "sentry_tags": {
+                    "transaction": "Root Transaction",
+                    "op": "http.request",
+                },
+                "is_segment": False,
+            },
+            start_ts=event.datetime - timedelta(seconds=18),
+        )
+
+        self.store_spans([root_span, child_span_1, child_span_2], is_eap=True)
 
         # Rule 1: Child whose parent_span_id matches another event's span_id
         rule1_child = Mock()
@@ -830,7 +880,7 @@ class TestGetTraceTreeForEvent(APITestCase, SnubaTestCase):
             "contexts": {
                 "trace": {
                     "trace_id": trace_id,
-                    "span_id": "rule1-child-span-id",
+                    "span_id": "dddddddddddddddd",
                     "parent_span_id": root_tx_span_id,  # Points to root transaction's span_id
                 }
             },
@@ -851,7 +901,7 @@ class TestGetTraceTreeForEvent(APITestCase, SnubaTestCase):
             "contexts": {
                 "trace": {
                     "trace_id": trace_id,
-                    "span_id": "rule2-child-span-id",
+                    "span_id": "eeeeeeeeeeeeeeee",
                     "parent_span_id": tx_span_1,  # Points to a span in the root transaction
                 }
             },
@@ -884,17 +934,11 @@ class TestGetTraceTreeForEvent(APITestCase, SnubaTestCase):
         rule3_child.message = "Rule 3 Child"
         rule3_child.transaction = None
 
-        # Set up the mock to return our test events
-        def side_effect(filter, dataset=None, **kwargs):
-            if dataset == Dataset.Transactions:
-                return [root_tx]
-            else:
-                return [rule1_child, rule2_child, rule3_child]
+        # Mock the error events query
+        with patch("sentry.eventstore.backend.get_events") as mock_get_events:
+            mock_get_events.return_value = [rule1_child, rule2_child, rule3_child]
 
-        mock_get_events.side_effect = side_effect
-
-        # Call the function
-        trace_tree = _get_trace_tree_for_event(event, self.project)
+            trace_tree = _get_trace_tree_for_event(event, self.project)
 
         # Verify the trace tree structure
         assert trace_tree is not None
@@ -903,7 +947,7 @@ class TestGetTraceTreeForEvent(APITestCase, SnubaTestCase):
 
         # Verify root transaction
         root = trace_tree["events"][0]
-        assert root["event_id"] == "root-tx-id"
+        assert root["event_id"] == "aaaaaaaaaaaaaaaa"
         assert root["title"] == "http.server - Root Transaction"
         assert root["is_transaction"] is True
         assert root["is_error"] is False
@@ -926,14 +970,14 @@ class TestGetTraceTreeForEvent(APITestCase, SnubaTestCase):
         assert children[2]["event_id"] == "rule3-child-id"
         assert children[2]["title"] == "Rule 3 Child"
 
-        # Verify get_events was called twice
-        assert mock_get_events.call_count == 2
+        # Verify get_events was called once (for errors only)
+        assert mock_get_events.call_count == 1
 
 
 @requires_snuba
 @pytest.mark.django_db
 class TestGetProfileFromTraceTree(APITestCase, SnubaTestCase):
-    @patch("sentry.seer.autofix.autofix.get_from_profiling_service")
+    @patch("sentry.seer.explorer.utils.get_from_profiling_service")
     def test_get_profile_from_trace_tree(self, mock_get_from_profiling_service) -> None:
         """
         Test the _get_profile_from_trace_tree method which finds a transaction
@@ -1015,7 +1059,7 @@ class TestGetProfileFromTraceTree(APITestCase, SnubaTestCase):
             params={"format": "sample"},
         )
 
-    @patch("sentry.seer.autofix.autofix.get_from_profiling_service")
+    @patch("sentry.seer.explorer.utils.get_from_profiling_service")
     def test_get_profile_from_trace_tree_matching_span_id(
         self, mock_get_from_profiling_service
     ) -> None:
@@ -1096,7 +1140,7 @@ class TestGetProfileFromTraceTree(APITestCase, SnubaTestCase):
             params={"format": "sample"},
         )
 
-    @patch("sentry.seer.autofix.autofix.get_from_profiling_service")
+    @patch("sentry.seer.explorer.utils.get_from_profiling_service")
     def test_get_profile_from_trace_tree_api_error(self, mock_get_from_profiling_service) -> None:
         """
         Test the behavior when the profiling service API returns an error.
@@ -1154,7 +1198,7 @@ class TestGetProfileFromTraceTree(APITestCase, SnubaTestCase):
             params={"format": "sample"},
         )
 
-    @patch("sentry.seer.autofix.autofix.get_from_profiling_service")
+    @patch("sentry.seer.explorer.utils.get_from_profiling_service")
     def test_get_profile_from_trace_tree_no_matching_transaction(
         self, mock_get_from_profiling_service
     ):
@@ -1204,7 +1248,7 @@ class TestGetProfileFromTraceTree(APITestCase, SnubaTestCase):
         # API should not be called if no matching transaction is found
         mock_get_from_profiling_service.assert_not_called()
 
-    @patch("sentry.seer.autofix.autofix.get_from_profiling_service")
+    @patch("sentry.seer.explorer.utils.get_from_profiling_service")
     def test_get_profile_from_trace_tree_no_span_id(self, mock_get_from_profiling_service) -> None:
         """
         Test the behavior when the event doesn't have a span_id.

--- a/tests/sentry/seer/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/seer/endpoints/test_group_ai_autofix.py
@@ -286,7 +286,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         # Should have empty repositories list since there are no codebases
         assert len(response.data["autofix"]["repositories"]) == 0
 
-    @patch("sentry.seer.autofix.autofix.get_from_profiling_service")
+    @patch("sentry.seer.explorer.utils.get_from_profiling_service")
     @patch("sentry.seer.autofix.autofix._get_profile_from_trace_tree")
     @patch("sentry.seer.autofix.autofix._call_autofix")
     @patch("sentry.seer.autofix.autofix._get_trace_tree_for_event")
@@ -368,7 +368,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
 
         mock_check_autofix_status.assert_called_once_with(args=[123], countdown=900)
 
-    @patch("sentry.seer.autofix.autofix.get_from_profiling_service")
+    @patch("sentry.seer.explorer.utils.get_from_profiling_service")
     @patch("sentry.seer.autofix.autofix._get_profile_from_trace_tree")
     @patch("sentry.seer.autofix.autofix._call_autofix")
     @patch("sentry.seer.autofix.autofix._get_trace_tree_for_event")
@@ -436,7 +436,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
 
         mock_check_autofix_status.assert_called_once_with(args=[123], countdown=900)
 
-    @patch("sentry.seer.autofix.autofix.get_from_profiling_service")
+    @patch("sentry.seer.explorer.utils.get_from_profiling_service")
     @patch("sentry.seer.autofix.autofix._get_profile_from_trace_tree")
     @patch("sentry.seer.autofix.autofix._call_autofix")
     @patch("sentry.seer.autofix.autofix._get_trace_tree_for_event")
@@ -517,7 +517,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         mock_check_autofix_status.assert_called_once_with(args=[123], countdown=900)
 
     @patch("sentry.models.Group.get_recommended_event_for_environments", return_value=None)
-    @patch("sentry.seer.autofix.autofix.get_from_profiling_service")
+    @patch("sentry.seer.explorer.utils.get_from_profiling_service")
     @patch("sentry.seer.autofix.autofix._call_autofix")
     @patch("sentry.seer.autofix.autofix._get_trace_tree_for_event")
     @patch("sentry.tasks.autofix.check_autofix_status.apply_async")


### PR DESCRIPTION
- Migrates Autofix's trace context from the Transactions dataset to Spans since the former will be deprecated soon
- Refactors Explorer's profile-fetching utils so Autofix can re-use them for continuous profiles

Sorry for the large diff, but most of it is moving stuff between files and re-doing tests.