### PR TITLE
fix: Use trimmed package name for flamegraph

### DIFF
--- a/static/app/utils/profiling/frame.tsx
+++ b/static/app/utils/profiling/frame.tsx
@@ -1,3 +1,4 @@
+import {trimPackage} from 'sentry/components/events/interfaces/frame/utils';
 import type {SymbolicatorStatus} from 'sentry/components/events/interfaces/types';
 import {t} from 'sentry/locale';
 
@@ -159,8 +160,9 @@ export class Frame {
   }
 
   getSourceLocation(): string {
+    const trimmedPackage = this.package ? trimPackage(this.package) : this.package;
     const packageFileOrPath: string =
-      this.file ?? this.module ?? this.package ?? this.path ?? '<unknown>';
+      this.file ?? this.module ?? trimmedPackage ?? this.path ?? '<unknown>';
 
     const line = typeof this.line === 'number' ? this.line : '<unknown line>';
     const column = typeof this.column === 'number' ? this.column : '<unknown column>';


### PR DESCRIPTION
The aggregate flamegraph on the transaction summary page is getting the flamegraph data from  vroom which is already applying package name trimming when it aggregates the flamegraphs. However the individual profile view did not do this and showed the whole package name, which wasn't a good UX.
Before:
<img width="1980" height="374" alt="Screenshot 2025-08-07 at 5 08 46 PM" src="https://github.com/user-attachments/assets/0ebe228f-edf4-4c49-9217-d3c6d6cabfe4" />


After:
<img width="1228" height="386" alt="Screenshot 2025-08-07 at 5 08 23 PM" src="https://github.com/user-attachments/assets/58e4e127-ecfb-4edd-9731-63f2563bd85e" />
