### PR TITLE
feat(ourlogs): Limit schema hints to static list 

### DIFF
--- a/static/app/views/explore/components/schemaHints/schemaHintsList.tsx
+++ b/static/app/views/explore/components/schemaHints/schemaHintsList.tsx
@@ -30,6 +30,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import SchemaHintsDrawer from 'sentry/views/explore/components/schemaHints/schemaHintsDrawer';
 import {
   getSchemaHintsListOrder,
+  onlyShowSchemaHintsKeys,
   removeHiddenSchemaHintsKeys,
   SchemaHintsSources,
   USER_IDENTIFIER_KEY,
@@ -161,7 +162,7 @@ function SchemaHintsList({
   }, [supportedAggregates]);
 
   // sort tags by the order they show up in the query builder
-  const filterTagsSorted = useMemo(() => {
+  const fullFilterTagsSorted = useMemo(() => {
     const filterTags = removeHiddenSchemaHintsKeys({
       ...functionTags,
       ...numberTags,
@@ -185,6 +186,11 @@ function SchemaHintsList({
 
     return [...schemaHintsPresetTags, ...sectionSortedTags, ...otherTags];
   }, [functionTags, numberTags, stringTags, source]);
+
+  // In the bar, we can limit the schema hints shown to ONLY be ones in the list order set (eg. logs), but should still show the fullFilterTagsSorted in the drawer.
+  const filterTagsSorted = useMemo(() => {
+    return onlyShowSchemaHintsKeys(fullFilterTagsSorted, source);
+  }, [fullFilterTagsSorted, source]);
 
   const [visibleHints, setVisibleHints] = useState([seeFullListTag]);
   const [tagListState, setTagListState] = useState<{
@@ -307,7 +313,7 @@ function SchemaHintsList({
           openDrawer(
             () => (
               <SchemaHintsDrawer
-                hints={filterTagsSorted}
+                hints={fullFilterTagsSorted}
                 exploreQuery={query}
                 searchBarDispatch={dispatch}
                 queryRef={queryRef}
@@ -401,7 +407,7 @@ function SchemaHintsList({
       isDrawerOpen,
       searchBarWrapperRef,
       openDrawer,
-      filterTagsSorted,
+      fullFilterTagsSorted,
       location.pathname,
       location.query,
     ]

--- a/static/app/views/explore/components/schemaHints/schemaHintsUtils.tsx
+++ b/static/app/views/explore/components/schemaHints/schemaHintsUtils.tsx
@@ -1,7 +1,7 @@
-import type {TagCollection} from 'sentry/types/group';
+import type {Tag, TagCollection} from 'sentry/types/group';
 import {FieldKey} from 'sentry/utils/fields';
 import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
-import {removeHiddenKeys} from 'sentry/views/explore/utils';
+import {onlyShowKeys, removeHiddenKeys} from 'sentry/views/explore/utils';
 import {SpanFields} from 'sentry/views/insights/types';
 
 export const USER_IDENTIFIER_KEY = 'user.key';
@@ -25,20 +25,15 @@ const LOGS_HINT_KEYS = [
   OurLogKnownFieldKey.MESSAGE,
   OurLogKnownFieldKey.SEVERITY,
   OurLogKnownFieldKey.SEVERITY_NUMBER,
-  OurLogKnownFieldKey.ORGANIZATION_ID,
-  OurLogKnownFieldKey.PROJECT_ID,
-  OurLogKnownFieldKey.PARENT_SPAN_ID,
-  OurLogKnownFieldKey.TIMESTAMP,
+  OurLogKnownFieldKey.TEMPLATE,
+  OurLogKnownFieldKey.RELEASE,
+  OurLogKnownFieldKey.BROWSER_NAME,
+  OurLogKnownFieldKey.USER_ID,
+  OurLogKnownFieldKey.USER_EMAIL,
+  OurLogKnownFieldKey.USER_NAME,
 ];
 
-const SCHEMA_HINTS_LIST_ORDER_KEYS_LOGS = [
-  ...new Set([
-    ...FRONTEND_HINT_KEYS,
-    ...MOBILE_HINT_KEYS,
-    ...LOGS_HINT_KEYS,
-    ...COMMON_HINT_KEYS,
-  ]),
-];
+const SCHEMA_HINTS_LIST_ORDER_KEYS_LOGS = [...new Set([...LOGS_HINT_KEYS])];
 
 const SCHEMA_HINTS_LIST_ORDER_KEYS_EXPLORE = [
   ...new Set([...FRONTEND_HINT_KEYS, ...MOBILE_HINT_KEYS, ...COMMON_HINT_KEYS]),
@@ -72,4 +67,15 @@ export const removeHiddenSchemaHintsKeys = (
   tagCollection: TagCollection
 ): TagCollection => {
   return removeHiddenKeys(tagCollection, SCHEMA_HINTS_HIDDEN_KEYS);
+};
+
+export const onlyShowSchemaHintsKeys = (
+  tagCollection: Tag[],
+  source: SchemaHintsSources
+): Tag[] => {
+  if (source === SchemaHintsSources.LOGS) {
+    return onlyShowKeys(tagCollection, SCHEMA_HINTS_LIST_ORDER_KEYS_LOGS);
+  }
+
+  return tagCollection;
 };

--- a/static/app/views/explore/components/schemaHints/schemaHintsUtils.tsx
+++ b/static/app/views/explore/components/schemaHints/schemaHintsUtils.tsx
@@ -31,6 +31,7 @@ const LOGS_HINT_KEYS = [
   OurLogKnownFieldKey.USER_ID,
   OurLogKnownFieldKey.USER_EMAIL,
   OurLogKnownFieldKey.USER_NAME,
+  OurLogKnownFieldKey.SERVER_ADDRESS,
 ];
 
 const SCHEMA_HINTS_LIST_ORDER_KEYS_LOGS = [...new Set([...LOGS_HINT_KEYS])];

--- a/static/app/views/explore/logs/types.tsx
+++ b/static/app/views/explore/logs/types.tsx
@@ -31,11 +31,16 @@ export enum OurLogKnownFieldKey {
   CODE_LINE_NUMBER = 'tags[code.line.number,number]',
   CODE_FUNCTION_NAME = 'code.function.name',
 
-  RELEASE = 'release',
   TEMPLATE = 'message.template',
   PARENT_SPAN_ID = 'trace.parent_span_id',
+  // SDK attributes https://github.com/getsentry/sentry-javascript/blob/735c1d8f143212f2e96fdc175c452f96ca2ca582/packages/core/src/logs/exports.ts#L139-L151
+  RELEASE = 'release',
   SDK_NAME = 'sdk.name',
   SDK_VERSION = 'sdk.version',
+  BROWSER_NAME = 'browser.name',
+  USER_ID = 'user.id',
+  USER_EMAIL = 'user.email',
+  USER_NAME = 'user.name',
 
   // From the EAP dataset directly not using a column alias.
   ID = 'sentry.item_id',

--- a/static/app/views/explore/logs/types.tsx
+++ b/static/app/views/explore/logs/types.tsx
@@ -33,7 +33,7 @@ export enum OurLogKnownFieldKey {
 
   TEMPLATE = 'message.template',
   PARENT_SPAN_ID = 'trace.parent_span_id',
-  // SDK attributes https://github.com/getsentry/sentry-javascript/blob/735c1d8f143212f2e96fdc175c452f96ca2ca582/packages/core/src/logs/exports.ts#L139-L151
+  // SDK attributes https://develop.sentry.dev/sdk/telemetry/logs/#default-attributes
   RELEASE = 'release',
   SDK_NAME = 'sdk.name',
   SDK_VERSION = 'sdk.version',

--- a/static/app/views/explore/logs/types.tsx
+++ b/static/app/views/explore/logs/types.tsx
@@ -41,6 +41,7 @@ export enum OurLogKnownFieldKey {
   USER_ID = 'user.id',
   USER_EMAIL = 'user.email',
   USER_NAME = 'user.name',
+  SERVER_ADDRESS = 'server.address',
 
   // From the EAP dataset directly not using a column alias.
   ID = 'sentry.item_id',

--- a/static/app/views/explore/utils.tsx
+++ b/static/app/views/explore/utils.tsx
@@ -11,7 +11,7 @@ import HookOrDefault from 'sentry/components/hookOrDefault';
 import {IconBusiness} from 'sentry/icons/iconBusiness';
 import {t} from 'sentry/locale';
 import type {PageFilters} from 'sentry/types/core';
-import type {TagCollection} from 'sentry/types/group';
+import type {Tag, TagCollection} from 'sentry/types/group';
 import type {Confidence, Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {defined} from 'sentry/utils';
@@ -644,5 +644,15 @@ export const removeHiddenKeys = (
       result[key] = tagCollection[key];
     }
   }
+  return result;
+};
+
+export const onlyShowKeys = (tagCollection: Tag[], keys: string[]): Tag[] => {
+  const result: Tag[] = [];
+  tagCollection.forEach(tag => {
+    if (keys.includes(tag.key) && tag.name) {
+      result.push(tag);
+    }
+  });
   return result;
 };


### PR DESCRIPTION
This limits the schema hints visible in the schema hints bar (below search) for logs to just ones defined by the schema hint order. The full list is still available in the drawer.

refs LOGS-116