### PR TITLE
fix(ourlogs): TraceItemQuery builder should have attributes named as such

### DIFF
--- a/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
+++ b/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
@@ -199,7 +199,7 @@ function useFilterKeySections(
       }),
       {
         value: 'custom_fields',
-        label: 'Custom Tags',
+        label: t('Attributes'),
         children: Object.keys(stringAttributes).filter(key => !predefined.has(key)),
       },
     ].filter(section => section.children.length);


### PR DESCRIPTION
They are currently named 'Custom Tags' which is causing confusion.

