### PR TITLE
feat(issues): Make event count more clear

### DIFF
--- a/static/app/views/issueDetails/streamline/header/header.tsx
+++ b/static/app/views/issueDetails/streamline/header/header.tsx
@@ -202,7 +202,7 @@ export default function StreamlinedGroupHeader({
                 to={`${baseUrl}events/${location.search}`}
                 aria-label={t('View events')}
               >
-                {t('Events')}
+                {t('Events (total)')}
               </StatLink>
             )}
           </StatTitle>


### PR DESCRIPTION
This aligns better with the "Users (90d)" which we show and makes it more clear that this count is for the lifetime of the issue itself.

The lack of this has caused confusion for users: https://sentry.slack.com/archives/CDXAKMGTU/p1754594605952669