### PR TITLE
ref(access-logs): remove option for using snuba data for access logs

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3432,7 +3432,7 @@ register(
 )
 
 # Enable enhancing access logs with snuba responses
-register("issues.log-access-logs", type=Float, default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
+register("issues.use-snuba-error-data", type=Float, default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 # Use "first-seen" group instead of "most-seen" group when merging
 register(

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3431,8 +3431,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Enable enhancing access logs with snuba responses
-register("issues.use-snuba-error-data", type=Float, default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 # Use "first-seen" group instead of "most-seen" group when merging
 register(

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3431,6 +3431,8 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Enable enhancing access logs with snuba responses
+register("issues.log-access-logs", type=Float, default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 # Use "first-seen" group instead of "most-seen" group when merging
 register(

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -27,7 +27,6 @@ from snuba_sdk import Column, DeleteQuery, Function, MetricsQuery, Request
 from snuba_sdk.legacy import json_to_snql
 from snuba_sdk.query import SelectableExpression
 
-from sentry import options
 from sentry.api.helpers.error_upsampling import (
     UPSAMPLED_ERROR_AGGREGATION,
     are_any_projects_error_upsampled,
@@ -1256,34 +1255,33 @@ def _bulk_snuba_query(snuba_requests: Sequence[SnubaRequest]) -> ResultSet:
                 if body.get("error"):
                     error = body["error"]
                     if response.status == 429:
-                        if options.get("issues.use-snuba-error-data"):
-                            try:
-                                if (
-                                    "quota_allowance" not in body
-                                    or "summary" not in body["quota_allowance"]
-                                ):
-                                    # Should not hit this - snuba gives us quota_allowance with a 429
-                                    raise RateLimitExceeded(error["message"])
-                                quota_allowance_summary = body["quota_allowance"]["summary"]
-                                rejected_by = quota_allowance_summary["rejected_by"]
-                                throttled_by = quota_allowance_summary["throttled_by"]
+                        try:
+                            if (
+                                "quota_allowance" not in body
+                                or "summary" not in body["quota_allowance"]
+                            ):
+                                # Should not hit this - snuba gives us quota_allowance with a 429
+                                raise RateLimitExceeded(error["message"])
+                            quota_allowance_summary = body["quota_allowance"]["summary"]
+                            rejected_by = quota_allowance_summary["rejected_by"]
+                            throttled_by = quota_allowance_summary["throttled_by"]
 
-                                policy_info = rejected_by or throttled_by
+                            policy_info = rejected_by or throttled_by
 
-                                if policy_info:
-                                    raise RateLimitExceeded(
-                                        error["message"],
-                                        policy=policy_info["policy"],
-                                        quota_unit=policy_info["quota_unit"],
-                                        storage_key=policy_info["storage_key"],
-                                        quota_used=policy_info["quota_used"],
-                                        rejection_threshold=policy_info["rejection_threshold"],
-                                    )
-                            except KeyError:
-                                logger.warning(
-                                    "Failed to parse rate limit error details from Snuba response",
-                                    extra={"error": error["message"]},
+                            if policy_info:
+                                raise RateLimitExceeded(
+                                    error["message"],
+                                    policy=policy_info["policy"],
+                                    quota_unit=policy_info["quota_unit"],
+                                    storage_key=policy_info["storage_key"],
+                                    quota_used=policy_info["quota_used"],
+                                    rejection_threshold=policy_info["rejection_threshold"],
                                 )
+                        except KeyError:
+                            logger.warning(
+                                "Failed to parse rate limit error details from Snuba response",
+                                extra={"error": error["message"]},
+                            )
 
                         raise RateLimitExceeded(error["message"])
 

--- a/tests/sentry/utils/test_snuba.py
+++ b/tests/sentry/utils/test_snuba.py
@@ -14,7 +14,6 @@ from sentry.models.project import Project
 from sentry.models.release import Release
 from sentry.snuba.dataset import Dataset
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers import override_options
 from sentry.utils import json
 from sentry.utils.snuba import (
     ROUND_UP,
@@ -475,7 +474,6 @@ class SnubaQueryRateLimitTest(TestCase):
         )
 
     @mock.patch("sentry.utils.snuba._snuba_query")
-    @override_options({"issues.use-snuba-error-data": 1.0})
     def test_rate_limit_error_handling(self, mock_snuba_query) -> None:
         """
         Test error handling for rate limit errors creates a RateLimitExceeded exception
@@ -515,7 +513,6 @@ class SnubaQueryRateLimitTest(TestCase):
         )
 
     @mock.patch("sentry.utils.snuba._snuba_query")
-    @override_options({"issues.use-snuba-error-data": 1.0})
     def test_rate_limit_error_handling_without_quota_details(self, mock_snuba_query) -> None:
         """
         Test that error handling gracefully handles malformed message
@@ -542,7 +539,6 @@ class SnubaQueryRateLimitTest(TestCase):
         )
 
     @mock.patch("sentry.utils.snuba._snuba_query")
-    @override_options({"issues.use-snuba-error-data": 1.0})
     def test_rate_limit_error_handling_with_stats_but_no_quota_details(
         self, mock_snuba_query
     ) -> None:


### PR DESCRIPTION
Remove `issues.use-snuba-error-data` usage. Should go in after https://github.com/getsentry/sentry-options-automator/pull/4862. Motivation is that we don't need to both fail open and have a killswitch — now that we've verified the code path works ([logs w/ snuba data](https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Alabels.name%3D%22sentry.access.api%22%0A-jsonPayload.snuba_policy%3D%22None%22%0A--%20jsonPayload.response%3D%22429%22;summaryFields=jsonPayload%252Fsnuba_policy:true:32:beginning;cursorTimestamp=2025-08-07T21:37:09.823313816Z;duration=PT6H?project=internal-sentry&inv=1&invt=Ab43iQ&rapt=AEjHL4Pf1e49WiIqwkOXnWIFUH_r2n-fFMRlbIbefj77sbOm6ZXepTN941fhfFdO5FJf6QtevWBov25pBUOx3x08iStEw2y313tDEHyD_ylWtwjxhhesnJ4&pli=1)) we should clean up the option.