### PR TITLE
feat(ourlogs): Add save query for logs

### DIFF
--- a/static/app/components/modals/explore/saveQueryModal.spec.tsx
+++ b/static/app/components/modals/explore/saveQueryModal.spec.tsx
@@ -3,6 +3,7 @@ import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrar
 
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import SaveQueryModal from 'sentry/components/modals/explore/saveQueryModal';
+import {TraceItemDataset} from 'sentry/views/explore/types';
 
 const stubEl = (props: {children?: React.ReactNode}) => <div>{props.children}</div>;
 
@@ -24,6 +25,7 @@ describe('SaveQueryModal', function () {
         closeModal={() => {}}
         organization={initialData.organization}
         saveQuery={saveQuery}
+        traceItemDataset={TraceItemDataset.SPANS}
       />
     );
 
@@ -45,6 +47,7 @@ describe('SaveQueryModal', function () {
         closeModal={() => {}}
         organization={initialData.organization}
         saveQuery={saveQuery}
+        traceItemDataset={TraceItemDataset.SPANS}
       />
     );
 
@@ -69,6 +72,7 @@ describe('SaveQueryModal', function () {
         closeModal={() => {}}
         organization={initialData.organization}
         saveQuery={saveQuery}
+        traceItemDataset={TraceItemDataset.SPANS}
       />
     );
 
@@ -95,6 +99,28 @@ describe('SaveQueryModal', function () {
         organization={initialData.organization}
         saveQuery={saveQuery}
         name="Initial Query Name"
+        traceItemDataset={TraceItemDataset.SPANS}
+      />
+    );
+
+    expect(screen.getByRole('textbox')).toHaveValue('Initial Query Name');
+    expect(screen.getByText('Rename Query')).toBeInTheDocument();
+    expect(screen.getByText('Save Changes')).toBeInTheDocument();
+  });
+
+  it('should render ui with logs dataset', function () {
+    const saveQuery = jest.fn();
+    render(
+      <SaveQueryModal
+        Header={stubEl}
+        Footer={stubEl as ModalRenderProps['Footer']}
+        Body={stubEl as ModalRenderProps['Body']}
+        CloseButton={stubEl}
+        closeModal={() => {}}
+        organization={initialData.organization}
+        saveQuery={saveQuery}
+        name="Initial Query Name"
+        traceItemDataset={TraceItemDataset.LOGS}
       />
     );
 

--- a/static/app/components/modals/explore/saveQueryModal.tsx
+++ b/static/app/components/modals/explore/saveQueryModal.tsx
@@ -18,11 +18,14 @@ import type {Organization, SavedQuery} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import useOrganization from 'sentry/utils/useOrganization';
+import {useSetLogsQuery} from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {useSetExplorePageParams} from 'sentry/views/explore/contexts/pageParamsContext';
+import {TraceItemDataset} from 'sentry/views/explore/types';
 
 export type SaveQueryModalProps = {
   organization: Organization;
   saveQuery: (name: string, starred?: boolean) => Promise<SavedQuery>;
+  traceItemDataset: TraceItemDataset;
   name?: string;
   source?: 'toolbar' | 'table';
 };
@@ -37,6 +40,7 @@ function SaveQueryModal({
   saveQuery,
   name: initialName,
   source,
+  traceItemDataset,
 }: Props) {
   const organization = useOrganization();
 
@@ -45,12 +49,17 @@ function SaveQueryModal({
   const [starred, setStarred] = useState(true);
 
   const setExplorePageParams = useSetExplorePageParams();
+  const setLogsQuery = useSetLogsQuery();
 
   const updatePageIdAndTitle = useCallback(
     (id: string, title: string) => {
-      setExplorePageParams({id, title});
+      if (traceItemDataset === TraceItemDataset.LOGS) {
+        setLogsQuery(id, title);
+      } else if (traceItemDataset === TraceItemDataset.SPANS) {
+        setExplorePageParams({id, title});
+      }
     },
-    [setExplorePageParams]
+    [setExplorePageParams, setLogsQuery, traceItemDataset]
   );
 
   const onSave = useCallback(async () => {
@@ -63,12 +72,21 @@ function SaveQueryModal({
       }
       addSuccessMessage(t('Query saved successfully'));
       if (defined(source)) {
-        trackAnalytics('trace_explorer.save_query_modal', {
-          action: 'submit',
-          save_type: initialName === undefined ? 'save_new_query' : 'rename_query',
-          ui_source: source,
-          organization,
-        });
+        if (traceItemDataset === TraceItemDataset.LOGS) {
+          trackAnalytics('logs.save_query_modal', {
+            action: 'submit',
+            save_type: initialName === undefined ? 'save_new_query' : 'rename_query',
+            ui_source: source,
+            organization,
+          });
+        } else if (traceItemDataset === TraceItemDataset.SPANS) {
+          trackAnalytics('trace_explorer.save_query_modal', {
+            action: 'submit',
+            save_type: initialName === undefined ? 'save_new_query' : 'rename_query',
+            ui_source: source,
+            organization,
+          });
+        }
       }
       closeModal();
     } catch (error) {
@@ -86,6 +104,7 @@ function SaveQueryModal({
     organization,
     initialName,
     source,
+    traceItemDataset,
   ]);
 
   return (

--- a/static/app/components/modals/explore/saveQueryModal.tsx
+++ b/static/app/components/modals/explore/saveQueryModal.tsx
@@ -18,7 +18,7 @@ import type {Organization, SavedQuery} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import useOrganization from 'sentry/utils/useOrganization';
-import {useSetLogsQuery} from 'sentry/views/explore/contexts/logs/logsPageParams';
+import {useSetLogsSavedQueryInfo} from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {useSetExplorePageParams} from 'sentry/views/explore/contexts/pageParamsContext';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 
@@ -49,7 +49,7 @@ function SaveQueryModal({
   const [starred, setStarred] = useState(true);
 
   const setExplorePageParams = useSetExplorePageParams();
-  const setLogsQuery = useSetLogsQuery();
+  const setLogsQuery = useSetLogsSavedQueryInfo();
 
   const updatePageIdAndTitle = useCallback(
     (id: string, title: string) => {

--- a/static/app/utils/analytics/logsAnalyticsEvent.tsx
+++ b/static/app/utils/analytics/logsAnalyticsEvent.tsx
@@ -35,6 +35,15 @@ export type LogsAnalyticsEventParameters = {
   'logs.issue_details.drawer_opened': {
     organization: Organization;
   };
+  'logs.save_as': {
+    save_type: 'alert' | 'dashboard' | 'update_query';
+    ui_source: 'toolbar' | 'chart' | 'compare chart' | 'searchbar';
+  };
+  'logs.save_query_modal': {
+    action: 'open' | 'submit';
+    save_type: 'save_new_query' | 'rename_query';
+    ui_source: 'toolbar' | 'table';
+  };
   'logs.table.row_expanded': {
     log_id: string;
     page_source: LogsAnalyticsPageSource;
@@ -50,4 +59,6 @@ export const logsAnalyticsEventMap: Record<LogsAnalyticsEventKey, string | null>
   'logs.explorer.metadata': 'Log Explorer Pageload Metadata',
   'logs.issue_details.drawer_opened': 'Issues Page Logs Drawer Opened',
   'logs.table.row_expanded': 'Expanded Log Row Details',
+  'logs.save_as': 'Logs Save As',
+  'logs.save_query_modal': 'Logs Save Query Modal',
 };

--- a/static/app/views/explore/contexts/logs/logsPageParams.tsx
+++ b/static/app/views/explore/contexts/logs/logsPageParams.tsx
@@ -317,7 +317,7 @@ export function useSetLogsPageParams() {
   return useCallback(
     (pageParams: LogPageParamsUpdate) => {
       const target = setLogsPageParams(location, pageParams);
-      navigate(target, {replace: false});
+      navigate(target);
     },
     [location, navigate]
   );
@@ -449,7 +449,7 @@ export function useSetLogsFields() {
   );
 }
 
-export function useSetLogsQuery() {
+export function useSetLogsSavedQueryInfo() {
   const setPageParams = useSetLogsPageParams();
   return useCallback(
     (id: string, title: string) => {

--- a/static/app/views/explore/contexts/logs/logsPageParams.tsx
+++ b/static/app/views/explore/contexts/logs/logsPageParams.tsx
@@ -90,16 +90,25 @@ interface LogsPageParams {
   readonly groupBy?: string;
 
   /**
+   * The id of the query, if a saved query.
+   */
+  readonly id?: string;
+  /**
    * If provided, add a 'trace:{trace id}' to all queries.
    * Used in embedded views like error page and trace page.
    * Can be an array of trace IDs on some pages (eg. replays)
    */
   readonly limitToTraceId?: string | string[];
+
   /**
    * If provided, ignores the project in the location and uses the provided project IDs.
    * Useful for cross-project traces when project is in the location.
    */
   readonly projectIds?: number[];
+  /**
+   * The title of the query, if a saved query.
+   */
+  readonly title?: string;
 }
 
 type NullablePartial<T> = {
@@ -437,6 +446,16 @@ export function useSetLogsFields() {
       setPersistentParams(prev => ({...prev, fields}));
     },
     [setPageParams, setPersistentParams]
+  );
+}
+
+export function useSetLogsQuery() {
+  const setPageParams = useSetLogsPageParams();
+  return useCallback(
+    (id: string, title: string) => {
+      setPageParams({id, title});
+    },
+    [setPageParams]
   );
 }
 

--- a/static/app/views/explore/contexts/logs/logsPageParams.tsx
+++ b/static/app/views/explore/contexts/logs/logsPageParams.tsx
@@ -29,13 +29,11 @@ import {
   updateLocationWithAggregateSortBys,
   updateLocationWithLogSortBys,
 } from 'sentry/views/explore/contexts/logs/sortBys';
-import type {AggregateField} from 'sentry/views/explore/contexts/pageParamsContext/aggregateFields';
 import {
   getModeFromLocation,
   type Mode,
   updateLocationWithMode,
 } from 'sentry/views/explore/contexts/pageParamsContext/mode';
-import {Visualize} from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
 import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
 
 const LOGS_PARAMS_VERSION = 2;
@@ -319,7 +317,7 @@ export function useSetLogsPageParams() {
   return useCallback(
     (pageParams: LogPageParamsUpdate) => {
       const target = setLogsPageParams(location, pageParams);
-      navigate(target);
+      navigate(target, {replace: false});
     },
     [location, navigate]
   );
@@ -531,26 +529,4 @@ function getLogsParamsStorageKey(version: number) {
 
 function getPastLogsParamsStorageKey(version: number) {
   return `logs-params-v${version - 1}`;
-}
-
-/**
- * Converts logs page parameters to AggregateField types compatible with explore page params
- */
-export function logsPageParamsToAggregateFields(
-  groupBy?: string,
-  aggregateFn?: string,
-  aggregateParam?: string
-): AggregateField[] {
-  const fields: AggregateField[] = [];
-
-  if (groupBy) {
-    fields.push({groupBy});
-  }
-
-  if (aggregateFn && aggregateParam) {
-    const yAxis = `${aggregateFn}(${aggregateParam})`;
-    fields.push(new Visualize(yAxis));
-  }
-
-  return fields;
 }

--- a/static/app/views/explore/contexts/logs/logsPageParams.tsx
+++ b/static/app/views/explore/contexts/logs/logsPageParams.tsx
@@ -232,7 +232,7 @@ export function LogsPageParamsProvider({
   );
 }
 
-const useLogsPageParams = _useLogsPageParams;
+export const useLogsPageParams = _useLogsPageParams;
 
 const decodeLogsQuery = (location: Location): string => {
   if (!location.query?.[LOGS_QUERY_KEY]) {

--- a/static/app/views/explore/contexts/logs/logsPageParams.tsx
+++ b/static/app/views/explore/contexts/logs/logsPageParams.tsx
@@ -29,11 +29,13 @@ import {
   updateLocationWithAggregateSortBys,
   updateLocationWithLogSortBys,
 } from 'sentry/views/explore/contexts/logs/sortBys';
+import type {AggregateField} from 'sentry/views/explore/contexts/pageParamsContext/aggregateFields';
 import {
   getModeFromLocation,
   type Mode,
   updateLocationWithMode,
 } from 'sentry/views/explore/contexts/pageParamsContext/mode';
+import {Visualize} from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
 import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
 
 const LOGS_PARAMS_VERSION = 2;
@@ -529,4 +531,26 @@ function getLogsParamsStorageKey(version: number) {
 
 function getPastLogsParamsStorageKey(version: number) {
   return `logs-params-v${version - 1}`;
+}
+
+/**
+ * Converts logs page parameters to AggregateField types compatible with explore page params
+ */
+export function logsPageParamsToAggregateFields(
+  groupBy?: string,
+  aggregateFn?: string,
+  aggregateParam?: string
+): AggregateField[] {
+  const fields: AggregateField[] = [];
+
+  if (groupBy) {
+    fields.push({groupBy});
+  }
+
+  if (aggregateFn && aggregateParam) {
+    const yAxis = `${aggregateFn}(${aggregateParam})`;
+    fields.push(new Visualize(yAxis));
+  }
+
+  return fields;
 }

--- a/static/app/views/explore/hooks/useGetSavedQueries.tsx
+++ b/static/app/views/explore/hooks/useGetSavedQueries.tsx
@@ -149,10 +149,10 @@ export class SavedQuery {
     this.start = savedQuery.start;
     this.dataset = savedQuery.dataset;
   }
+}
 
-  get traceItemDataset(): TraceItemDataset {
-    return DATASET_TO_TRACE_ITEM_DATASET_MAP[this.dataset];
-  }
+export function getSavedQueryTraceItemDataset(dataset: ReadableSavedQuery['dataset']) {
+  return DATASET_TO_TRACE_ITEM_DATASET_MAP[dataset];
 }
 
 type Props = {

--- a/static/app/views/explore/hooks/useGetSavedQueries.tsx
+++ b/static/app/views/explore/hooks/useGetSavedQueries.tsx
@@ -1,5 +1,6 @@
 import {useCallback, useMemo} from 'react';
 
+import type {DateString} from 'sentry/types/core';
 import type {User} from 'sentry/types/user';
 import {defined} from 'sentry/utils';
 import {useApiQuery, useQueryClient} from 'sentry/utils/queryClient';
@@ -42,7 +43,8 @@ type ReadableQuery = {
   visualize?: RawVisualize[];
 };
 
-class Query {
+// This is the `query` property on our SavedQuery, which indicates the actualy query portion of the saved query, hence SavedQueryQuery.
+export class SavedQueryQuery {
   fields: string[];
   mode: Mode;
   orderby: string;
@@ -115,15 +117,15 @@ export class SavedQuery {
   name: string;
   position: number | null;
   projects: number[];
-  query: [Query, ...Query[]];
+  query: [SavedQueryQuery, ...SavedQueryQuery[]];
   dataset: ReadableSavedQuery['dataset'];
   starred: boolean;
   createdBy?: User;
-  end?: string;
+  end?: string | DateString;
   environment?: string[];
   isPrebuilt?: boolean;
   range?: string;
-  start?: string;
+  start?: string | DateString;
 
   constructor(savedQuery: ReadableSavedQuery) {
     this.dateAdded = savedQuery.dateAdded;
@@ -135,8 +137,8 @@ export class SavedQuery {
     this.position = savedQuery.position;
     this.projects = savedQuery.projects;
     this.query = [
-      new Query(savedQuery.query[0]),
-      ...savedQuery.query.slice(1).map(q => new Query(q)),
+      new SavedQueryQuery(savedQuery.query[0]),
+      ...savedQuery.query.slice(1).map(q => new SavedQueryQuery(q)),
     ];
     this.starred = savedQuery.starred;
     this.createdBy = savedQuery.createdBy;

--- a/static/app/views/explore/hooks/useSaveQuery.tsx
+++ b/static/app/views/explore/hooks/useSaveQuery.tsx
@@ -20,7 +20,7 @@ import {
 } from 'sentry/views/explore/hooks/useGetSavedQueries';
 
 // Request payload type that matches the backend ExploreSavedQuerySerializer
-export type ExploreSavedQueryRequest = {
+type ExploreSavedQueryRequest = {
   dataset: 'logs' | 'spans' | 'segment_spans';
   name: string;
   projects: number[];
@@ -77,7 +77,7 @@ export function useSpansSaveQuery() {
   return {saveQuery, updateQuery, saveQueryFromSavedQuery, updateQueryFromSavedQuery};
 }
 
-export function useCreateOrUpdateSavedQuery(id?: string) {
+function useCreateOrUpdateSavedQuery(id?: string) {
   const api = useApi();
   const organization = useOrganization();
   const invalidateSavedQueries = useInvalidateSavedQueries();

--- a/static/app/views/explore/hooks/useSaveQuery.tsx
+++ b/static/app/views/explore/hooks/useSaveQuery.tsx
@@ -1,75 +1,26 @@
 import {useCallback, useMemo} from 'react';
 
 import {encodeSort} from 'sentry/utils/discover/eventView';
-import type {Sort} from 'sentry/utils/discover/fields';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import {
-  logsPageParamsToAggregateFields,
-  useLogsPageParams,
-} from 'sentry/views/explore/contexts/logs/logsPageParams';
+import {useLogsPageParams} from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {useExplorePageParams} from 'sentry/views/explore/contexts/pageParamsContext';
-import type {AggregateField} from 'sentry/views/explore/contexts/pageParamsContext/aggregateFields';
 import {
+  type AggregateField,
   isGroupBy,
   isVisualize,
 } from 'sentry/views/explore/contexts/pageParamsContext/aggregateFields';
-import type {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {useChartInterval} from 'sentry/views/explore/hooks/useChartInterval';
 import {
+  type RawGroupBy,
+  type RawVisualize,
   type SavedQuery,
+  SavedQueryQuery,
   useInvalidateSavedQueries,
   useInvalidateSavedQuery,
 } from 'sentry/views/explore/hooks/useGetSavedQueries';
 import {TraceItemDataset} from 'sentry/views/explore/types';
-
-interface SaveQueryParams {
-  aggregateFields: AggregateField[];
-  fields: string[];
-  mode: Mode;
-  query: string;
-  sortBys: Sort[];
-  aggregateFn?: string;
-  aggregateParam?: string;
-  groupBy?: string;
-  id?: string;
-  title?: string;
-}
-
-function usePageParamsForDataset(dataset: TraceItemDataset): SaveQueryParams {
-  const explorePageParams = useExplorePageParams();
-  const logsPageParams = useLogsPageParams();
-
-  if (dataset === TraceItemDataset.LOGS) {
-    return {
-      aggregateFields: logsPageParamsToAggregateFields(
-        logsPageParams.groupBy,
-        logsPageParams.aggregateFn,
-        logsPageParams.aggregateParam
-      ),
-      fields: logsPageParams.fields,
-      sortBys: logsPageParams.sortBys,
-      query: logsPageParams.search?.formatString() ?? '',
-      mode: logsPageParams.mode,
-      id: logsPageParams.id,
-      title: logsPageParams.title,
-      groupBy: logsPageParams.groupBy,
-      aggregateFn: logsPageParams.aggregateFn,
-      aggregateParam: logsPageParams.aggregateParam,
-    };
-  }
-
-  return {
-    aggregateFields: explorePageParams.aggregateFields,
-    fields: explorePageParams.fields,
-    sortBys: explorePageParams.sortBys,
-    query: explorePageParams.query,
-    mode: explorePageParams.mode,
-    id: explorePageParams.id,
-    title: explorePageParams.title,
-  };
-}
 
 export function useSaveQuery(dataset: TraceItemDataset) {
   const {selection} = usePageFilters();
@@ -78,14 +29,164 @@ export function useSaveQuery(dataset: TraceItemDataset) {
   const [interval] = useChartInterval();
 
   const {aggregateFields, sortBys, fields, query, mode, id, title} =
-    usePageParamsForDataset(dataset);
+    useExplorePageParams();
 
+  const {saveQueryFromSavedQuery, updateQueryFromSavedQuery} = useFromSavedQuery();
+
+  const data = useMemo((): SavedQuery => {
+    return {
+      name: title ?? '',
+      dataset,
+      start,
+      end,
+      range: period ?? undefined,
+      interval,
+      projects,
+      environment: environments,
+      query: [
+        new SavedQueryQuery({
+          aggregateField: aggregateFieldsToRaw(aggregateFields),
+          fields,
+          orderby: sortBys[0] ? encodeSort(sortBys[0]) : '',
+          query: query ?? '',
+          mode,
+        }),
+      ],
+    };
+  }, [
+    aggregateFields,
+    sortBys,
+    fields,
+    query,
+    mode,
+    start,
+    end,
+    period,
+    interval,
+    projects,
+    environments,
+    title,
+    dataset,
+  ]);
+
+  const {saveQueryApi, updateQueryApi} = useCreateOrUpdateSavedQuery(id);
+
+  const saveQuery = useCallback(
+    (newTitle: string, starred = true) => {
+      return saveQueryApi(data, newTitle, starred);
+    },
+    [saveQueryApi, data]
+  );
+
+  const updateQuery = useCallback(() => {
+    return updateQueryApi(data);
+  }, [updateQueryApi, data]);
+
+  return {saveQuery, updateQuery, saveQueryFromSavedQuery, updateQueryFromSavedQuery};
+}
+
+export function useCreateOrUpdateSavedQuery(id?: string) {
   const api = useApi();
   const organization = useOrganization();
   const invalidateSavedQueries = useInvalidateSavedQueries();
   const invalidateSavedQuery = useInvalidateSavedQuery(id);
+  const saveQueryApi = useCallback(
+    async (data: SavedQuery, newTitle: string, starred = true) => {
+      const response = await api.requestPromise(
+        `/organizations/${organization.slug}/explore/saved/`,
+        {
+          method: 'POST',
+          data: {
+            ...data,
+            name: newTitle,
+            starred,
+          },
+        }
+      );
+      invalidateSavedQueries();
+      invalidateSavedQuery();
+      return response;
+    },
+    [api, organization.slug, invalidateSavedQueries, invalidateSavedQuery]
+  );
 
-  const data = useMemo(() => {
+  const updateQueryApi = useCallback(
+    async (data: SavedQuery) => {
+      const response = await api.requestPromise(
+        `/organizations/${organization.slug}/explore/saved/${id}/`,
+        {
+          method: 'PUT',
+          data,
+        }
+      );
+      invalidateSavedQueries();
+      invalidateSavedQuery();
+      return response;
+    },
+    [api, organization.slug, id, invalidateSavedQueries, invalidateSavedQuery]
+  );
+
+  return {saveQueryApi, updateQueryApi};
+}
+
+/**
+ * For updating or duplicating queries, agnostic to dataset since it's operating on existing data
+ */
+export function useFromSavedQuery() {
+  const api = useApi();
+  const organization = useOrganization();
+  const invalidateSavedQueries = useInvalidateSavedQueries();
+
+  const saveQueryFromSavedQuery = useCallback(
+    async (savedQuery: SavedQuery) => {
+      const response = await api.requestPromise(
+        `/organizations/${organization.slug}/explore/saved/`,
+        {
+          method: 'POST',
+          data: {
+            ...savedQuery,
+          },
+        }
+      );
+      invalidateSavedQueries();
+      return response;
+    },
+    [api, organization.slug, invalidateSavedQueries]
+  );
+
+  const updateQueryFromSavedQuery = useCallback(
+    async (savedQuery: SavedQuery) => {
+      const response = await api.requestPromise(
+        `/organizations/${organization.slug}/explore/saved/${savedQuery.id}/`,
+        {
+          method: 'PUT',
+          data: {
+            ...savedQuery,
+          },
+        }
+      );
+      invalidateSavedQueries();
+      return response;
+    },
+    [api, organization.slug, invalidateSavedQueries]
+  );
+
+  return {saveQueryFromSavedQuery, updateQueryFromSavedQuery};
+}
+
+export function useLogsSaveQuery() {
+  const {selection} = usePageFilters();
+  const {datetime, projects, environments} = selection;
+  const {start, end, period} = datetime;
+  const [interval] = useChartInterval();
+
+  const {sortBys, fields, search, mode, id, title, groupBy, search, aggregate} =
+    useLogsPageParams();
+  const query = search?.formatString();
+
+  const {saveQueryFromSavedQuery, updateQueryFromSavedQuery} = useFromSavedQuery();
+
+  const data = useMemo((): SavedQuery => {
     return {
       name: title,
       dataset,
@@ -132,76 +233,32 @@ export function useSaveQuery(dataset: TraceItemDataset) {
     dataset,
   ]);
 
+  const {saveQueryApi, updateQueryApi} = useCreateOrUpdateSavedQuery(id);
+
   const saveQuery = useCallback(
-    async (newTitle: string, starred = true) => {
-      const response = await api.requestPromise(
-        `/organizations/${organization.slug}/explore/saved/`,
-        {
-          method: 'POST',
-          data: {
-            ...data,
-            name: newTitle,
-            starred,
-          },
-        }
-      );
-      invalidateSavedQueries();
-      invalidateSavedQuery();
-      return response;
+    (newTitle: string, starred = true) => {
+      return saveQueryApi(data, newTitle, starred);
     },
-    [api, organization.slug, data, invalidateSavedQueries, invalidateSavedQuery]
+    [saveQueryApi, data]
   );
 
-  const updateQuery = useCallback(async () => {
-    const response = await api.requestPromise(
-      `/organizations/${organization.slug}/explore/saved/${id}/`,
-      {
-        method: 'PUT',
-        data,
-      }
-    );
-    invalidateSavedQueries();
-    invalidateSavedQuery();
-    return response;
-  }, [api, organization.slug, id, data, invalidateSavedQueries, invalidateSavedQuery]);
-
-  const saveQueryFromSavedQuery = useCallback(
-    async (savedQuery: SavedQuery) => {
-      const response = await api.requestPromise(
-        `/organizations/${organization.slug}/explore/saved/`,
-        {
-          method: 'POST',
-          data: {
-            ...savedQuery,
-          },
-        }
-      );
-      invalidateSavedQueries();
-      return response;
-    },
-    [api, organization.slug, invalidateSavedQueries]
-  );
-
-  const updateQueryFromSavedQuery = useCallback(
-    async (savedQuery: SavedQuery) => {
-      const response = await api.requestPromise(
-        `/organizations/${organization.slug}/explore/saved/${savedQuery.id}/`,
-        {
-          method: 'PUT',
-          data: {
-            ...savedQuery,
-          },
-        }
-      );
-      invalidateSavedQueries();
-      return response;
-    },
-    [api, organization.slug, invalidateSavedQueries]
-  );
+  const updateQuery = useCallback(() => {
+    return updateQueryApi(data);
+  }, [updateQueryApi, data]);
 
   return {saveQuery, updateQuery, saveQueryFromSavedQuery, updateQueryFromSavedQuery};
 }
 
-export function useLogsSaveQuery() {
-  return useSaveQuery(TraceItemDataset.LOGS);
+function aggregateFieldsToRaw(
+  aggregateFields: AggregateField[]
+): Array<RawVisualize | RawGroupBy> {
+  return aggregateFields.map(aggregateField => {
+    if (isVisualize(aggregateField)) {
+      return aggregateField.toJSON();
+    }
+    if (isGroupBy(aggregateField)) {
+      return aggregateField.toJSON();
+    }
+    return aggregateField.toJSON();
+  });
 }

--- a/static/app/views/explore/hooks/useSaveQuery.tsx
+++ b/static/app/views/explore/hooks/useSaveQuery.tsx
@@ -263,7 +263,6 @@ function convertLogsPageParamsToRequest(
     ? [
         {
           yAxes: [aggregate],
-          chartType: 0,
         },
       ]
     : undefined;

--- a/static/app/views/explore/hooks/useSaveQuery.tsx
+++ b/static/app/views/explore/hooks/useSaveQuery.tsx
@@ -15,10 +15,9 @@ import {
   useInvalidateSavedQueries,
   useInvalidateSavedQuery,
 } from 'sentry/views/explore/hooks/useGetSavedQueries';
+import {TraceItemDataset} from 'sentry/views/explore/types';
 
-const TRACE_EXPLORER_DATASET = 'spans';
-
-export function useSaveQuery() {
+export function useSaveQuery(dataset: TraceItemDataset) {
   const {aggregateFields, sortBys, fields, query, mode, id, title} =
     useExplorePageParams();
   const {selection} = usePageFilters();
@@ -34,7 +33,7 @@ export function useSaveQuery() {
   const data = useMemo(() => {
     return {
       name: title,
-      dataset: TRACE_EXPLORER_DATASET, // Only supported for trace explorer for now
+      dataset,
       start,
       end,
       range: period,
@@ -75,6 +74,7 @@ export function useSaveQuery() {
     projects,
     environments,
     title,
+    dataset,
   ]);
 
   const saveQuery = useCallback(
@@ -145,4 +145,8 @@ export function useSaveQuery() {
   );
 
   return {saveQuery, updateQuery, saveQueryFromSavedQuery, updateQueryFromSavedQuery};
+}
+
+export function useLogsSaveQuery() {
+  return useSaveQuery(TraceItemDataset.LOGS);
 }

--- a/static/app/views/explore/hooks/useSaveQuery.tsx
+++ b/static/app/views/explore/hooks/useSaveQuery.tsx
@@ -253,8 +253,20 @@ function convertLogsPageParamsToRequest(
   const {datetime, projects, environments} = selection;
   const {start, end, period} = datetime;
 
-  const {sortBys, fields, search, mode, groupBy} = logsParams;
+  const {sortBys, fields, search, mode, groupBy, aggregateFn, aggregateParam} =
+    logsParams;
   const query = search?.formatString() ?? '';
+
+  const aggregate =
+    aggregateFn && aggregateParam ? `${aggregateFn}(${aggregateParam})` : undefined;
+  const visualize = aggregate
+    ? [
+        {
+          yAxes: [aggregate],
+          chartType: 0,
+        },
+      ]
+    : undefined;
 
   return {
     name: title,
@@ -272,6 +284,7 @@ function convertLogsPageParamsToRequest(
         query,
         groupby: groupBy ? [groupBy] : undefined,
         mode,
+        visualize,
       },
     ],
   };

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -1,5 +1,4 @@
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
-import styled from '@emotion/styled';
 
 import {openModal} from 'sentry/actionCreators/modal';
 import Feature from 'sentry/components/acl/feature';
@@ -13,28 +12,9 @@ import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilt
 import {SearchQueryBuilderProvider} from 'sentry/components/searchQueryBuilder/context';
 import {IconChevron, IconTable} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import type {NewQuery} from 'sentry/types/organization';
-import {defined} from 'sentry/utils';
-import {trackAnalytics} from 'sentry/utils/analytics';
 import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
-import EventView from 'sentry/utils/discover/eventView';
-import type {Sort} from 'sentry/utils/discover/fields';
-import {parseFunction, prettifyParsedFunction} from 'sentry/utils/discover/fields';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
-import {MutableSearch} from 'sentry/utils/tokenizeSearch';
-import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
-import usePageFilters from 'sentry/utils/usePageFilters';
-import useProjects from 'sentry/utils/useProjects';
-import useRouter from 'sentry/utils/useRouter';
-import {Dataset} from 'sentry/views/alerts/rules/metric/types';
-import {
-  DashboardWidgetSource,
-  DEFAULT_WIDGET_NAME,
-  DisplayType,
-  WidgetType,
-} from 'sentry/views/dashboards/types';
-import {handleAddQueryToDashboard} from 'sentry/views/discover/utils';
 import SchemaHintsList, {
   SchemaHintsSection,
 } from 'sentry/views/explore/components/schemaHints/schemaHintsList';
@@ -90,6 +70,7 @@ import {
 } from 'sentry/views/explore/logs/useLogsQuery';
 import {useLogsSearchQueryBuilderProps} from 'sentry/views/explore/logs/useLogsSearchQueryBuilderProps';
 import {usePersistentLogsPageParameters} from 'sentry/views/explore/logs/usePersistentLogsPageParameters';
+import {useSaveAsItems} from 'sentry/views/explore/logs/useSaveAsItems';
 import {useStreamingTimeseriesResult} from 'sentry/views/explore/logs/useStreamingTimeseriesResult';
 import {calculateAverageLogsPerSecond} from 'sentry/views/explore/logs/utils';
 import {
@@ -99,7 +80,6 @@ import {
 import {ColumnEditorModal} from 'sentry/views/explore/tables/columnEditorModal';
 import type {PickableDays} from 'sentry/views/explore/utils';
 import {useSortedTimeSeries} from 'sentry/views/insights/common/queries/useSortedTimeSeries';
-import {getAlertsUrl} from 'sentry/views/insights/common/utils/getAlertsUrl';
 
 type LogsTabProps = PickableDays;
 
@@ -367,166 +347,3 @@ export function LogsTabContent({
     </SearchQueryBuilderProvider>
   );
 }
-
-interface UseSaveAsItemsOptions {
-  aggregate: string;
-  groupBy: string | undefined;
-  interval: string;
-  mode: Mode;
-  search: MutableSearch;
-  sortBys: Sort[];
-}
-
-function useSaveAsItems({
-  aggregate,
-  groupBy,
-  interval,
-  mode,
-  search,
-  sortBys,
-}: UseSaveAsItemsOptions) {
-  const location = useLocation();
-  const router = useRouter();
-  const organization = useOrganization();
-  const {projects} = useProjects();
-  const pageFilters = usePageFilters();
-
-  const project =
-    projects.length === 1
-      ? projects[0]
-      : projects.find(p => p.id === `${pageFilters.selection.projects[0]}`);
-
-  const aggregates = useMemo(() => [aggregate], [aggregate]);
-
-  const saveAsAlert = useMemo(() => {
-    const alertsUrls = aggregates.map((yAxis: string, index: number) => {
-      const func = parseFunction(yAxis);
-      const label = func ? prettifyParsedFunction(func) : yAxis;
-      return {
-        key: `${yAxis}-${index}`,
-        label,
-        to: getAlertsUrl({
-          project,
-          query: search.formatString(),
-          pageFilters: pageFilters.selection,
-          aggregate: yAxis,
-          organization,
-          dataset: Dataset.EVENTS_ANALYTICS_PLATFORM,
-          interval,
-          eventTypes: 'trace_item_log',
-        }),
-        onAction: () => {
-          trackAnalytics('logs.save_as', {
-            save_type: 'alert',
-            ui_source: 'searchbar',
-            organization,
-          });
-        },
-      };
-    });
-
-    return {
-      key: 'create-alert',
-      label: t('An Alert for'),
-      textValue: t('An Alert for'),
-      children: alertsUrls ?? [],
-      disabled: !alertsUrls || alertsUrls.length === 0,
-      isSubmenu: true,
-    };
-  }, [aggregates, interval, organization, pageFilters, project, search]);
-
-  const saveAsDashboard = useMemo(() => {
-    const dashboardsUrls = aggregates.map((yAxis: string, index: number) => {
-      const func = parseFunction(yAxis);
-      const label = func ? prettifyParsedFunction(func) : yAxis;
-
-      return {
-        key: String(index),
-        label,
-        onAction: () => {
-          trackAnalytics('logs.save_as', {
-            save_type: 'dashboard',
-            ui_source: 'searchbar',
-            organization,
-          });
-
-          const fields =
-            mode === Mode.SAMPLES
-              ? []
-              : [...new Set([groupBy, yAxis, ...sortBys.map(sort => sort.field)])].filter(
-                  defined
-                );
-
-          const discoverQuery: NewQuery = {
-            name: DEFAULT_WIDGET_NAME,
-            fields,
-            orderby: sortBys.map(formatSort),
-            query: search.formatString(),
-            version: 2,
-            dataset: DiscoverDatasets.OURLOGS,
-            yAxis: [yAxis],
-          };
-
-          const eventView = EventView.fromNewQueryWithPageFilters(
-            discoverQuery,
-            pageFilters.selection
-          );
-          // the chart currently track the chart type internally so force bar type for now
-          eventView.display = DisplayType.BAR;
-
-          handleAddQueryToDashboard({
-            organization,
-            location,
-            eventView,
-            router,
-            yAxis: eventView.yAxis,
-            widgetType: WidgetType.LOGS,
-            source: DashboardWidgetSource.LOGS,
-          });
-        },
-      };
-    });
-
-    return {
-      key: 'add-to-dashboard',
-      label: (
-        <Feature
-          hookName="feature-disabled:dashboards-edit"
-          features="organizations:dashboards-edit"
-          renderDisabled={() => <DisabledText>{t('A Dashboard widget')}</DisabledText>}
-        >
-          {t('A Dashboard widget')}
-        </Feature>
-      ),
-      textValue: t('A Dashboard widget'),
-      children: dashboardsUrls,
-      disabled: !dashboardsUrls || dashboardsUrls.length === 0,
-      isSubmenu: true,
-    };
-  }, [
-    aggregates,
-    groupBy,
-    mode,
-    organization,
-    pageFilters,
-    search,
-    sortBys,
-    location,
-    router,
-  ]);
-
-  return useMemo(() => {
-    const saveAs = [];
-    if (organization.features.includes('ourlogs-alerts')) {
-      saveAs.push(saveAsAlert);
-    }
-    if (organization.features.includes('ourlogs-dashboards')) {
-      saveAs.push(saveAsDashboard);
-    }
-    return saveAs;
-  }, [organization, saveAsAlert, saveAsDashboard]);
-}
-
-const DisabledText = styled('span')`
-  color: ${p => p.theme.disabled};
-`;

--- a/static/app/views/explore/logs/useSaveAsItems.spec.tsx
+++ b/static/app/views/explore/logs/useSaveAsItems.spec.tsx
@@ -1,0 +1,189 @@
+import {LocationFixture} from 'sentry-fixture/locationFixture';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {makeTestQueryClient} from 'sentry-test/queryClient';
+import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import * as modal from 'sentry/actionCreators/modal';
+import ProjectsStore from 'sentry/stores/projectsStore';
+import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
+import {QueryClientProvider} from 'sentry/utils/queryClient';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import {LogsPageParamsProvider} from 'sentry/views/explore/contexts/logs/logsPageParams';
+import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
+import {useSaveAsItems} from 'sentry/views/explore/logs/useSaveAsItems';
+import {OrganizationContext} from 'sentry/views/organizationContext';
+
+jest.mock('sentry/utils/useLocation');
+jest.mock('sentry/utils/useNavigate');
+jest.mock('sentry/utils/usePageFilters');
+jest.mock('sentry/utils/useRouter');
+jest.mock('sentry/actionCreators/modal');
+
+const mockedUseLocation = jest.mocked(useLocation);
+const mockUseNavigate = jest.mocked(useNavigate);
+const mockUsePageFilters = jest.mocked(usePageFilters);
+const mockOpenSaveQueryModal = jest.mocked(modal.openSaveQueryModal);
+
+describe('useSaveAsItems', () => {
+  const organization = OrganizationFixture({
+    features: ['ourlogs-alerts', 'ourlogs-dashboards', 'ourlogs-saved-queries'],
+  });
+  const project = ProjectFixture({id: '1'});
+  const queryClient = makeTestQueryClient();
+  let saveQueryMock: jest.Mock;
+  ProjectsStore.loadInitialData([project]);
+
+  function createWrapper() {
+    return function ({children}: {children?: React.ReactNode}) {
+      return (
+        <OrganizationContext.Provider value={organization}>
+          <QueryClientProvider client={queryClient}>
+            <LogsPageParamsProvider
+              analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}
+              _testContext={{
+                fields: ['timestamp', 'message', 'user.email'],
+                search: new MutableSearch('message:"test error"'),
+                sortBys: [{field: 'timestamp', kind: 'desc'}],
+                groupBy: 'message.template',
+                aggregateFn: 'count',
+                aggregateParam: undefined,
+                mode: Mode.AGGREGATE,
+                id: undefined,
+                title: undefined,
+              }}
+            >
+              {children}
+            </LogsPageParamsProvider>
+          </QueryClientProvider>
+        </OrganizationContext.Provider>
+      );
+    };
+  }
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    MockApiClient.clearMockResponses();
+    queryClient.clear();
+
+    mockedUseLocation.mockReturnValue(LocationFixture());
+    mockUseNavigate.mockReturnValue(jest.fn());
+    mockUsePageFilters.mockReturnValue({
+      isReady: true,
+      desyncedFilters: new Set(),
+      pinnedFilters: new Set(),
+      shouldPersist: true,
+      selection: PageFiltersFixture({
+        projects: [1],
+        environments: ['production'],
+        datetime: {
+          start: '2024-01-01T00:00:00.000Z',
+          end: '2024-01-01T01:00:00.000Z',
+          period: '1h',
+          utc: false,
+        },
+      }),
+    });
+
+    saveQueryMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/explore/saved/`,
+      method: 'POST',
+      body: {id: 'new-query-id', name: 'Test Query'},
+    });
+  });
+
+  it('should open save query modal when save as query is clicked', () => {
+    const {result} = renderHook(
+      () =>
+        useSaveAsItems({
+          aggregate: 'count()',
+          groupBy: 'message.template',
+          interval: '5m',
+          mode: Mode.AGGREGATE,
+          search: new MutableSearch('message:"test error"'),
+          sortBys: [{field: 'timestamp', kind: 'desc'}],
+        }),
+      {wrapper: createWrapper()}
+    );
+
+    const saveAsItems = result.current;
+    const saveAsQuery = saveAsItems.find(item => item.key === 'save-query') as {
+      onAction: () => void;
+    };
+
+    saveAsQuery?.onAction?.();
+
+    expect(mockOpenSaveQueryModal).toHaveBeenCalledWith({
+      organization,
+      saveQuery: expect.any(Function),
+      source: 'table',
+      traceItemDataset: 'logs',
+    });
+  });
+
+  it('should call saveQuery with correct parameters when modal saves', async () => {
+    const {result} = renderHook(
+      () =>
+        useSaveAsItems({
+          aggregate: 'count()',
+          groupBy: 'message.template',
+          interval: '5m',
+          mode: Mode.AGGREGATE,
+          search: new MutableSearch('message:"test error"'),
+          sortBys: [{field: 'timestamp', kind: 'desc'}],
+        }),
+      {wrapper: createWrapper()}
+    );
+
+    const saveAsItems = result.current;
+    const saveAsQuery = saveAsItems.find(item => item.key === 'save-query') as {
+      onAction: () => void;
+    };
+
+    saveAsQuery?.onAction?.();
+
+    expect(mockOpenSaveQueryModal).toHaveBeenCalled();
+
+    const modalCall = mockOpenSaveQueryModal.mock.calls[0];
+    if (!modalCall) {
+      throw new Error('No modal call found');
+    }
+    const saveQueryFn = modalCall[0].saveQuery;
+
+    await saveQueryFn('Test Query Title', true);
+
+    await waitFor(() => {
+      expect(saveQueryMock).toHaveBeenCalledWith(
+        `/organizations/${organization.slug}/explore/saved/`,
+        expect.objectContaining({
+          method: 'POST',
+          data: expect.objectContaining({
+            name: 'Test Query Title',
+            projects: [1],
+            dataset: 'logs',
+            start: '2024-01-01T00:00:00.000Z',
+            end: '2024-01-01T01:00:00.000Z',
+            range: '1h',
+            environment: ['production'],
+            interval: '5m',
+            query: [
+              {
+                fields: ['timestamp', 'message', 'user.email'],
+                orderby: '-timestamp',
+                query: 'message:"test error"',
+                groupby: ['message.template'],
+                mode: Mode.AGGREGATE,
+              },
+            ],
+            starred: true,
+          }),
+        })
+      );
+    });
+  });
+});

--- a/static/app/views/explore/logs/useSaveAsItems.tsx
+++ b/static/app/views/explore/logs/useSaveAsItems.tsx
@@ -1,0 +1,220 @@
+import {useMemo} from 'react';
+import styled from '@emotion/styled';
+
+import {openSaveQueryModal} from 'sentry/actionCreators/modal';
+import Feature from 'sentry/components/acl/feature';
+import {t} from 'sentry/locale';
+import type {NewQuery} from 'sentry/types/organization';
+import {defined} from 'sentry/utils';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import EventView from 'sentry/utils/discover/eventView';
+import type {Sort} from 'sentry/utils/discover/fields';
+import {parseFunction, prettifyParsedFunction} from 'sentry/utils/discover/fields';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import useProjects from 'sentry/utils/useProjects';
+import useRouter from 'sentry/utils/useRouter';
+import {Dataset} from 'sentry/views/alerts/rules/metric/types';
+import {
+  DashboardWidgetSource,
+  DEFAULT_WIDGET_NAME,
+  DisplayType,
+  WidgetType,
+} from 'sentry/views/dashboards/types';
+import {handleAddQueryToDashboard} from 'sentry/views/discover/utils';
+import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
+import {formatSort} from 'sentry/views/explore/contexts/pageParamsContext/sortBys';
+import {useLogsSaveQuery} from 'sentry/views/explore/hooks/useSaveQuery';
+import {TraceItemDataset} from 'sentry/views/explore/types';
+import {getAlertsUrl} from 'sentry/views/insights/common/utils/getAlertsUrl';
+
+interface UseSaveAsItemsOptions {
+  aggregate: string;
+  groupBy: string | undefined;
+  interval: string;
+  mode: Mode;
+  search: MutableSearch;
+  sortBys: Sort[];
+}
+
+export function useSaveAsItems({
+  aggregate,
+  groupBy,
+  interval,
+  mode,
+  search,
+  sortBys,
+}: UseSaveAsItemsOptions) {
+  const location = useLocation();
+  const router = useRouter();
+  const organization = useOrganization();
+  const {projects} = useProjects();
+  const pageFilters = usePageFilters();
+  const {saveQuery} = useLogsSaveQuery();
+
+  const project =
+    projects.length === 1
+      ? projects[0]
+      : projects.find(p => p.id === `${pageFilters.selection.projects[0]}`);
+
+  const aggregates = useMemo(() => [aggregate], [aggregate]);
+
+  const saveAsQuery = useMemo(() => {
+    return {
+      key: 'save-query',
+      label: <span>{t('A New Query')}</span>,
+      textValue: t('A New Query'),
+      onAction: () => {
+        trackAnalytics('logs.save_query_modal', {
+          action: 'open',
+          save_type: 'save_new_query',
+          ui_source: 'table',
+          organization,
+        });
+        openSaveQueryModal({
+          organization,
+          saveQuery,
+          source: 'table',
+          traceItemDataset: TraceItemDataset.LOGS,
+        });
+      },
+    };
+  }, [organization, saveQuery]);
+
+  const saveAsAlert = useMemo(() => {
+    const alertsUrls = aggregates.map((yAxis: string, index: number) => {
+      const func = parseFunction(yAxis);
+      const label = func ? prettifyParsedFunction(func) : yAxis;
+      return {
+        key: `${yAxis}-${index}`,
+        label,
+        to: getAlertsUrl({
+          project,
+          query: search.formatString(),
+          pageFilters: pageFilters.selection,
+          aggregate: yAxis,
+          organization,
+          dataset: Dataset.EVENTS_ANALYTICS_PLATFORM,
+          interval,
+          eventTypes: 'trace_item_log',
+        }),
+        onAction: () => {
+          trackAnalytics('logs.save_as', {
+            save_type: 'alert',
+            ui_source: 'searchbar',
+            organization,
+          });
+        },
+      };
+    });
+
+    return {
+      key: 'create-alert',
+      label: t('An Alert for'),
+      textValue: t('An Alert for'),
+      children: alertsUrls ?? [],
+      disabled: !alertsUrls || alertsUrls.length === 0,
+      isSubmenu: true,
+    };
+  }, [aggregates, interval, organization, pageFilters, project, search]);
+
+  const saveAsDashboard = useMemo(() => {
+    const dashboardsUrls = aggregates.map((yAxis: string, index: number) => {
+      const func = parseFunction(yAxis);
+      const label = func ? prettifyParsedFunction(func) : yAxis;
+
+      return {
+        key: String(index),
+        label,
+        onAction: () => {
+          trackAnalytics('logs.save_as', {
+            save_type: 'dashboard',
+            ui_source: 'searchbar',
+            organization,
+          });
+
+          const fields =
+            mode === Mode.SAMPLES
+              ? []
+              : [...new Set([groupBy, yAxis, ...sortBys.map(sort => sort.field)])].filter(
+                  defined
+                );
+
+          const discoverQuery: NewQuery = {
+            name: DEFAULT_WIDGET_NAME,
+            fields,
+            orderby: sortBys.map(formatSort),
+            query: search.formatString(),
+            version: 2,
+            dataset: DiscoverDatasets.OURLOGS,
+            yAxis: [yAxis],
+          };
+
+          const eventView = EventView.fromNewQueryWithPageFilters(
+            discoverQuery,
+            pageFilters.selection
+          );
+          // the chart currently track the chart type internally so force bar type for now
+          eventView.display = DisplayType.BAR;
+
+          handleAddQueryToDashboard({
+            organization,
+            location,
+            eventView,
+            router,
+            yAxis: eventView.yAxis,
+            widgetType: WidgetType.LOGS,
+            source: DashboardWidgetSource.LOGS,
+          });
+        },
+      };
+    });
+
+    return {
+      key: 'add-to-dashboard',
+      label: (
+        <Feature
+          hookName="feature-disabled:dashboards-edit"
+          features="organizations:dashboards-edit"
+          renderDisabled={() => <DisabledText>{t('A Dashboard widget')}</DisabledText>}
+        >
+          {t('A Dashboard widget')}
+        </Feature>
+      ),
+      textValue: t('A Dashboard widget'),
+      children: dashboardsUrls,
+      disabled: !dashboardsUrls || dashboardsUrls.length === 0,
+      isSubmenu: true,
+    };
+  }, [
+    aggregates,
+    groupBy,
+    mode,
+    organization,
+    pageFilters,
+    search,
+    sortBys,
+    location,
+    router,
+  ]);
+
+  return useMemo(() => {
+    const saveAs = [];
+    // Add save query option first
+    saveAs.push(saveAsQuery);
+    if (organization.features.includes('ourlogs-alerts')) {
+      saveAs.push(saveAsAlert);
+    }
+    if (organization.features.includes('ourlogs-dashboards')) {
+      saveAs.push(saveAsDashboard);
+    }
+    return saveAs;
+  }, [organization, saveAsQuery, saveAsAlert, saveAsDashboard]);
+}
+
+const DisabledText = styled('span')`
+  color: ${p => p.theme.disabled};
+`;

--- a/static/app/views/explore/logs/useSaveAsItems.tsx
+++ b/static/app/views/explore/logs/useSaveAsItems.tsx
@@ -203,8 +203,9 @@ export function useSaveAsItems({
 
   return useMemo(() => {
     const saveAs = [];
-    // Add save query option first
-    saveAs.push(saveAsQuery);
+    if (organization.features.includes('ourlogs-saved-queries')) {
+      saveAs.push(saveAsQuery);
+    }
     if (organization.features.includes('ourlogs-alerts')) {
       saveAs.push(saveAsAlert);
     }

--- a/static/app/views/explore/logs/utils.tsx
+++ b/static/app/views/explore/logs/utils.tsx
@@ -22,6 +22,8 @@ import type {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {prettifyAttributeName} from 'sentry/views/explore/components/traceItemAttributes/utils';
 import {
+  LOGS_AGGREGATE_FN_KEY,
+  LOGS_AGGREGATE_PARAM_KEY,
   LOGS_FIELDS_KEY,
   LOGS_GROUP_BY_KEY,
   LOGS_QUERY_KEY,
@@ -352,8 +354,12 @@ export function getLogsUrl({
   referrer,
   sortBy,
   title,
+  aggregateFn,
+  aggregateParam,
 }: {
   organization: Organization;
+  aggregateFn?: string;
+  aggregateParam?: string;
   field?: string[];
   groupBy?: string[];
   id?: number;
@@ -382,6 +388,8 @@ export function getLogsUrl({
     mode,
     referrer,
     [LOGS_SORT_BYS_KEY]: sortBy,
+    [LOGS_AGGREGATE_FN_KEY]: aggregateFn,
+    [LOGS_AGGREGATE_PARAM_KEY]: aggregateParam,
     title,
   };
 
@@ -406,6 +414,10 @@ export function getLogsUrlFromSavedQueryUrl(
   organization: Organization
 ) {
   const firstQuery = savedQuery.query[0];
+  const visualize = firstQuery.visualize?.[0]?.yAxes?.[0];
+  const aggregateFn = visualize ? visualize.split('(')[0] : undefined;
+  const aggregateParam = visualize ? visualize.split('(')[1]?.split(')')[0] : undefined;
+
   return getLogsUrl({
     organization,
     field: firstQuery.fields,
@@ -416,6 +428,8 @@ export function getLogsUrlFromSavedQueryUrl(
     interval: savedQuery.interval,
     mode: firstQuery.mode,
     query: firstQuery.query,
+    aggregateFn,
+    aggregateParam,
     selection: {
       datetime: {
         end: savedQuery.end ?? null,

--- a/static/app/views/explore/logs/utils.tsx
+++ b/static/app/views/explore/logs/utils.tsx
@@ -21,6 +21,8 @@ import type {InfiniteData, InfiniteQueryObserverResult} from 'sentry/utils/query
 import type {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {prettifyAttributeName} from 'sentry/views/explore/components/traceItemAttributes/utils';
+import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
+import {SavedQuery} from 'sentry/views/explore/hooks/useGetSavedQueries';
 import type {TraceItemResponseAttribute} from 'sentry/views/explore/hooks/useTraceItemDetails';
 import {
   LogAttributesHumanLabel,
@@ -336,10 +338,26 @@ export function getLogsUrl({
   organization,
   selection,
   query,
+  field,
+  groupBy,
+  id,
+  interval,
+  mode,
+  referrer,
+  sort,
+  title,
 }: {
   organization: Organization;
+  field?: string[];
+  groupBy?: string[];
+  id?: number;
+  interval?: string;
+  mode?: Mode;
   query?: string;
+  referrer?: string;
   selection?: PageFilters;
+  sort?: string;
+  title?: string;
 }) {
   const {start, end, period: statsPeriod, utc} = selection?.datetime ?? {};
   const {environments, projects} = selection ?? {};
@@ -351,6 +369,14 @@ export function getLogsUrl({
     end,
     query,
     utc,
+    field,
+    groupBy,
+    id,
+    interval,
+    mode,
+    referrer,
+    sort,
+    title,
   };
 
   return (
@@ -367,4 +393,25 @@ function makeLogsPathname({
   path: string;
 }) {
   return normalizeUrl(`/organizations/${organization.slug}/explore/logs${path}`);
+}
+
+export function getLogsUrlFromSavedQueryUrl(
+  savedQuery: SavedQuery,
+  organization: Organization
+) {
+  const firstQuery = savedQuery.query[0];
+  return getLogsUrl({
+    organization,
+    query: firstQuery.query,
+    selection: {
+      datetime: {
+        end: savedQuery.end ?? null,
+        period: savedQuery.range ?? null,
+        start: savedQuery.start ?? null,
+        utc: null,
+      },
+      environments: savedQuery.environment ? [...savedQuery.environment] : [],
+      projects: savedQuery.projects ? [...savedQuery.projects] : [],
+    },
+  });
 }

--- a/static/app/views/explore/logs/utils.tsx
+++ b/static/app/views/explore/logs/utils.tsx
@@ -21,6 +21,12 @@ import type {InfiniteData, InfiniteQueryObserverResult} from 'sentry/utils/query
 import type {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {prettifyAttributeName} from 'sentry/views/explore/components/traceItemAttributes/utils';
+import {
+  LOGS_FIELDS_KEY,
+  LOGS_GROUP_BY_KEY,
+  LOGS_QUERY_KEY,
+} from 'sentry/views/explore/contexts/logs/logsPageParams';
+import {LOGS_SORT_BYS_KEY} from 'sentry/views/explore/contexts/logs/sortBys';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {SavedQuery} from 'sentry/views/explore/hooks/useGetSavedQueries';
 import type {TraceItemResponseAttribute} from 'sentry/views/explore/hooks/useTraceItemDetails';
@@ -344,7 +350,7 @@ export function getLogsUrl({
   interval,
   mode,
   referrer,
-  sort,
+  sortBy,
   title,
 }: {
   organization: Organization;
@@ -356,7 +362,7 @@ export function getLogsUrl({
   query?: string;
   referrer?: string;
   selection?: PageFilters;
-  sort?: string;
+  sortBy?: string;
   title?: string;
 }) {
   const {start, end, period: statsPeriod, utc} = selection?.datetime ?? {};
@@ -367,15 +373,15 @@ export function getLogsUrl({
     statsPeriod,
     start,
     end,
-    query,
+    [LOGS_QUERY_KEY]: query,
     utc,
-    field,
-    groupBy,
+    [LOGS_FIELDS_KEY]: field,
+    [LOGS_GROUP_BY_KEY]: groupBy,
     id,
     interval,
     mode,
     referrer,
-    sort,
+    [LOGS_SORT_BYS_KEY]: sortBy,
     title,
   };
 
@@ -402,6 +408,13 @@ export function getLogsUrlFromSavedQueryUrl(
   const firstQuery = savedQuery.query[0];
   return getLogsUrl({
     organization,
+    field: firstQuery.fields,
+    groupBy: firstQuery.groupby,
+    sortBy: firstQuery.orderby,
+    title: savedQuery.name,
+    id: savedQuery.id,
+    interval: savedQuery.interval,
+    mode: firstQuery.mode,
     query: firstQuery.query,
     selection: {
       datetime: {

--- a/static/app/views/explore/multiQueryMode/content.tsx
+++ b/static/app/views/explore/multiQueryMode/content.tsx
@@ -153,6 +153,7 @@ function Content() {
                     organization,
                     saveQuery,
                     source: 'toolbar',
+                    traceItemDataset: TraceItemDataset.SPANS,
                   });
                 },
               },

--- a/static/app/views/explore/savedQueries/index.tsx
+++ b/static/app/views/explore/savedQueries/index.tsx
@@ -16,7 +16,9 @@ import {getExploreUrl} from 'sentry/views/explore/utils';
 
 export default function SavedQueriesView() {
   const organization = useOrganization();
-  const hasLogsFeature = organization.features.includes('ourlogs-enabled');
+  const hasLogsFeature =
+    organization.features.includes('ourlogs-enabled') &&
+    organization.features.includes('ourlogs-saved-queries');
   const navigate = useNavigate();
 
   const items = [

--- a/static/app/views/explore/savedQueries/index.tsx
+++ b/static/app/views/explore/savedQueries/index.tsx
@@ -1,16 +1,42 @@
+import {useNavigate} from 'react-router-dom';
+
+import {Button} from 'sentry/components/core/button';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
+import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import FeedbackWidgetButton from 'sentry/components/feedback/widget/feedbackWidgetButton';
 import * as Layout from 'sentry/components/layouts/thirds';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {IconAdd} from 'sentry/icons/iconAdd';
 import {t} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
+import {getLogsUrl} from 'sentry/views/explore/logs/utils';
 import {SavedQueriesLandingContent} from 'sentry/views/explore/savedQueries/savedQueriesLandingContent';
 import {getExploreUrl} from 'sentry/views/explore/utils';
 
 export default function SavedQueriesView() {
   const organization = useOrganization();
+  const hasLogsFeature = organization.features.includes('ourlogs-enabled');
+  const navigate = useNavigate();
+
+  const items = [
+    {
+      key: 'create-query-spans',
+      label: <span>{t('Trace Query')}</span>,
+      textValue: t('Create Traces Query'),
+      onAction: () => {
+        navigate(getExploreUrl({organization, visualize: []}));
+      },
+    },
+    {
+      key: 'create-query-logs',
+      label: <span>{t('Logs Query')}</span>,
+      textValue: t('Create Logs Query'),
+      onAction: () => {
+        navigate(getLogsUrl({organization}));
+      },
+    },
+  ];
 
   return (
     <SentryDocumentTitle title={t('All Queries')} orgSlug={organization?.slug}>
@@ -22,14 +48,37 @@ export default function SavedQueriesView() {
           <Layout.HeaderActions>
             <ButtonBar>
               <FeedbackWidgetButton />
-              <LinkButton
-                priority="primary"
-                icon={<IconAdd />}
-                size="sm"
-                to={getExploreUrl({organization, visualize: []})}
-              >
-                {t('Create Query')}
-              </LinkButton>
+              {hasLogsFeature ? (
+                <DropdownMenu
+                  items={items}
+                  trigger={triggerProps => (
+                    <Button
+                      {...triggerProps}
+                      priority="primary"
+                      icon={<IconAdd />}
+                      size="sm"
+                      aria-label={t('Save as')}
+                      onClick={e => {
+                        e.stopPropagation();
+                        e.preventDefault();
+
+                        triggerProps.onClick?.(e);
+                      }}
+                    >
+                      {t('Create Query')}
+                    </Button>
+                  )}
+                />
+              ) : (
+                <LinkButton
+                  priority="primary"
+                  icon={<IconAdd />}
+                  size="sm"
+                  to={getExploreUrl({organization, visualize: []})}
+                >
+                  {t('Create Query')}
+                </LinkButton>
+              )}
             </ButtonBar>
           </Layout.HeaderActions>
         </Layout.Header>

--- a/static/app/views/explore/savedQueries/savedQueriesTable.spec.tsx
+++ b/static/app/views/explore/savedQueries/savedQueriesTable.spec.tsx
@@ -178,6 +178,39 @@ describe('SavedQueriesTable', () => {
     );
   });
 
+  it('should link to a single query view for logs dataset', async () => {
+    getQueriesMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/explore/saved/`,
+      body: [
+        {
+          id: 1,
+          name: 'Logs Query Name',
+          projects: [1],
+          environment: ['production'],
+          createdBy: {
+            name: 'Test User',
+          },
+          query: [
+            {
+              fields: ['message', 'timestamp', 'custom_field'],
+              query: 'test:foo',
+              groupby: ['message'],
+              sort: 'timestamp',
+            },
+          ],
+          dataset: 'logs',
+        },
+      ],
+    });
+    render(<SavedQueriesTable mode="owned" title="title" />, {
+      deprecatedRouterMocks: true,
+    });
+    expect(await screen.findByText('Logs Query Name')).toHaveAttribute(
+      'href',
+      '/organizations/org-slug/explore/logs/?environment=production&project=1&query=test%3Afoo&field=message&field=timestamp&field=custom_field'
+    );
+  });
+
   it('should display starred status', async () => {
     getQueriesMock = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/explore/saved/`,

--- a/static/app/views/explore/savedQueries/savedQueriesTable.spec.tsx
+++ b/static/app/views/explore/savedQueries/savedQueriesTable.spec.tsx
@@ -215,6 +215,43 @@ describe('SavedQueriesTable', () => {
     );
   });
 
+  it('should link to a single query view for logs dataset with aggregate', async () => {
+    getQueriesMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/explore/saved/`,
+      body: [
+        {
+          id: 1,
+          name: 'ABC',
+          projects: [1],
+          environment: ['production'],
+          createdBy: {
+            name: 'User1',
+          },
+          query: [
+            {
+              mode: 'samples',
+              fields: ['timestamp', 'tags[amount,number]'],
+              groupby: ['message'],
+              query: 'message:foo',
+              orderby: 'user.email',
+              visualize: [{yAxes: ['avg(tags[amount,number])']}],
+            },
+          ],
+          range: '1h',
+          interval: '5m',
+          dataset: 'logs',
+        },
+      ],
+    });
+    render(<SavedQueriesTable mode="owned" title="title" />, {
+      deprecatedRouterMocks: true,
+    });
+    expect(await screen.findByText('ABC')).toHaveAttribute(
+      'href',
+      '/organizations/org-slug/explore/logs/?environment=production&id=1&interval=5m&logsAggregate=avg&logsAggregateParam=tags%5Bamount%2Cnumber%5D&logsFields=timestamp&logsFields=tags%5Bamount%2Cnumber%5D&logsGroupBy=message&logsQuery=message%3Afoo&logsSortBys=user.email&mode=samples&project=1&statsPeriod=1h&title=ABC'
+    );
+  });
+
   it('should display starred status', async () => {
     getQueriesMock = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/explore/saved/`,

--- a/static/app/views/explore/savedQueries/savedQueriesTable.spec.tsx
+++ b/static/app/views/explore/savedQueries/savedQueriesTable.spec.tsx
@@ -192,12 +192,16 @@ describe('SavedQueriesTable', () => {
           },
           query: [
             {
-              fields: ['message', 'timestamp', 'custom_field'],
-              query: 'test:foo',
+              mode: 'samples',
+              fields: ['timestamp', 'message', 'user.email'],
               groupby: ['message'],
-              sort: 'timestamp',
+              query:
+                'message:"System time zone does not match user preferences time zone"',
+              orderby: 'user.email',
             },
           ],
+          range: '1h',
+          interval: '5m',
           dataset: 'logs',
         },
       ],
@@ -207,7 +211,7 @@ describe('SavedQueriesTable', () => {
     });
     expect(await screen.findByText('Logs Query Name')).toHaveAttribute(
       'href',
-      '/organizations/org-slug/explore/logs/?environment=production&project=1&query=test%3Afoo&field=message&field=timestamp&field=custom_field'
+      '/organizations/org-slug/explore/logs/?environment=production&id=1&interval=5m&logsFields=timestamp&logsFields=message&logsFields=user.email&logsGroupBy=message&logsQuery=message%3A%22System%20time%20zone%20does%20not%20match%20user%20preferences%20time%20zone%22&logsSortBys=user.email&mode=samples&project=1&statsPeriod=1h&title=Logs%20Query%20Name'
     );
   });
 

--- a/static/app/views/explore/savedQueries/savedQueriesTable.tsx
+++ b/static/app/views/explore/savedQueries/savedQueriesTable.tsx
@@ -23,6 +23,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {useDeleteQuery} from 'sentry/views/explore/hooks/useDeleteQuery';
 import {
   getSavedQueryDatasetLabel,
+  getSavedQueryTraceItemDataset,
   type SavedQuery,
   type SortOption,
   useGetSavedQueries,
@@ -123,7 +124,6 @@ export function SavedQueriesTable({
         return updateQueryFromSavedQuery({
           ...savedQuery,
           name,
-          traceItemDataset: savedQuery.traceItemDataset,
         });
       };
     },
@@ -134,7 +134,6 @@ export function SavedQueriesTable({
     await saveQueryFromSavedQuery({
       ...savedQuery,
       name: `${savedQuery.name} (Copy)`,
-      traceItemDataset: savedQuery.traceItemDataset,
     });
   };
 
@@ -219,14 +218,18 @@ export function SavedQueriesTable({
               <SavedEntityTable.CellStar
                 isStarred={starredIds.includes(query.id)}
                 onClick={() =>
-                  debouncedOnClick(query.id, query.starred, query.traceItemDataset)
+                  debouncedOnClick(
+                    query.id,
+                    query.starred,
+                    getSavedQueryTraceItemDataset(query.dataset)
+                  )
                 }
               />
             </SavedEntityTable.Cell>
             <SavedEntityTable.Cell data-column="name">
               <SavedEntityTable.CellName
                 to={
-                  query.traceItemDataset === TraceItemDataset.LOGS
+                  query.dataset === 'logs'
                     ? getLogsUrlFromSavedQueryUrl(query, organization)
                     : getExploreUrlFromSavedQueryUrl({savedQuery: query, organization})
                 }
@@ -274,14 +277,20 @@ export function SavedQueriesTable({
                           key: 'rename',
                           label: t('Rename'),
                           onAction: () => {
-                            if (query.traceItemDataset === TraceItemDataset.SPANS) {
+                            if (
+                              getSavedQueryTraceItemDataset(query.dataset) ===
+                              TraceItemDataset.SPANS
+                            ) {
                               trackAnalytics('trace_explorer.save_query_modal', {
                                 action: 'open',
                                 save_type: 'rename_query',
                                 ui_source: 'table',
                                 organization,
                               });
-                            } else if (query.traceItemDataset === TraceItemDataset.LOGS) {
+                            } else if (
+                              getSavedQueryTraceItemDataset(query.dataset) ===
+                              TraceItemDataset.LOGS
+                            ) {
                               trackAnalytics('logs.save_query_modal', {
                                 action: 'open',
                                 save_type: 'rename_query',
@@ -294,7 +303,9 @@ export function SavedQueriesTable({
                               saveQuery: getHandleUpdateFromSavedQuery(query),
                               name: query.name,
                               source: 'table',
-                              traceItemDataset: query.traceItemDataset,
+                              traceItemDataset: getSavedQueryTraceItemDataset(
+                                query.dataset
+                              ),
                             });
                           },
                         },

--- a/static/app/views/explore/savedQueries/savedQueriesTable.tsx
+++ b/static/app/views/explore/savedQueries/savedQueriesTable.tsx
@@ -59,7 +59,9 @@ export function SavedQueriesTable({
   const organization = useOrganization();
   const location = useLocation();
   const navigate = useNavigate();
-  const hasLogsEnabled = organization.features.includes('ourlogs-enabled');
+  const hasLogsSavedQueriesEnabled =
+    organization.features.includes('ourlogs-enabled') &&
+    organization.features.includes('ourlogs-saved-queries');
   const cursor = decodeScalar(location.query[cursorKey]);
   const {data, isLoading, pageLinks, isFetched, isError} = useGetSavedQueries({
     sortBy: ['starred', sort],
@@ -171,7 +173,7 @@ export function SavedQueriesTable({
     <Container>
       <TableHeading>{title}</TableHeading>
       <SavedEntityTableWithColumns
-        hasLogsEnabled={hasLogsEnabled}
+        hasLogsEnabled={hasLogsSavedQueriesEnabled}
         pageSize={perPage}
         isLoading={isLoading}
         header={
@@ -180,7 +182,7 @@ export function SavedQueriesTable({
             <SavedEntityTable.HeaderCell data-column="name">
               {t('Name')}
             </SavedEntityTable.HeaderCell>
-            {hasLogsEnabled && (
+            {hasLogsSavedQueriesEnabled && (
               <SavedEntityTable.HeaderCell data-column="dataset">
                 {t('Type')}
               </SavedEntityTable.HeaderCell>
@@ -232,7 +234,7 @@ export function SavedQueriesTable({
                 {query.name}
               </SavedEntityTable.CellName>
             </SavedEntityTable.Cell>
-            {hasLogsEnabled && (
+            {hasLogsSavedQueriesEnabled && (
               <SavedEntityTable.Cell data-column="dataset">
                 {getSavedQueryDatasetLabel(query.dataset)}
               </SavedEntityTable.Cell>

--- a/static/app/views/explore/savedQueryEditMenu.tsx
+++ b/static/app/views/explore/savedQueryEditMenu.tsx
@@ -9,7 +9,10 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {getIdFromLocation} from 'sentry/views/explore/contexts/pageParamsContext/id';
 import {useDeleteQuery} from 'sentry/views/explore/hooks/useDeleteQuery';
-import {useGetSavedQuery} from 'sentry/views/explore/hooks/useGetSavedQueries';
+import {
+  getSavedQueryTraceItemDataset,
+  useGetSavedQuery,
+} from 'sentry/views/explore/hooks/useGetSavedQueries';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 import {confirmDeleteSavedQuery} from 'sentry/views/explore/utils';
 
@@ -47,11 +50,17 @@ export function SavedQueryEditMenu() {
                     normalizeUrl(`/organizations/${organization.slug}/explore/traces/`)
                   );
                 }
-                if (savedQuery.traceItemDataset === TraceItemDataset.SPANS) {
+                if (
+                  getSavedQueryTraceItemDataset(savedQuery.dataset) ===
+                  TraceItemDataset.SPANS
+                ) {
                   trackAnalytics('trace_explorer.delete_query', {
                     organization,
                   });
-                } else if (savedQuery.traceItemDataset === TraceItemDataset.LOGS) {
+                } else if (
+                  getSavedQueryTraceItemDataset(savedQuery.dataset) ===
+                  TraceItemDataset.LOGS
+                ) {
                   trackAnalytics('logs.delete_query', {
                     organization,
                   });

--- a/static/app/views/explore/savedQueryEditMenu.tsx
+++ b/static/app/views/explore/savedQueryEditMenu.tsx
@@ -13,6 +13,7 @@ import {
   getSavedQueryTraceItemDataset,
   useGetSavedQuery,
 } from 'sentry/views/explore/hooks/useGetSavedQueries';
+import {getLogsUrl} from 'sentry/views/explore/logs/utils';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 import {confirmDeleteSavedQuery} from 'sentry/views/explore/utils';
 
@@ -64,6 +65,12 @@ export function SavedQueryEditMenu() {
                   trackAnalytics('logs.delete_query', {
                     organization,
                   });
+                } else {
+                  navigate(
+                    getLogsUrl({
+                      organization,
+                    })
+                  );
                 }
               },
               savedQuery,

--- a/static/app/views/explore/savedQueryEditMenu.tsx
+++ b/static/app/views/explore/savedQueryEditMenu.tsx
@@ -39,21 +39,21 @@ export function SavedQueryEditMenu() {
             confirmDeleteSavedQuery({
               handleDelete: async () => {
                 await deleteQuery(savedQuery.id);
-                if (location.pathname.endsWith('compare/')) {
-                  navigate(
-                    normalizeUrl(
-                      `/organizations/${organization.slug}/explore/traces/compare/`
-                    )
-                  );
-                } else {
-                  navigate(
-                    normalizeUrl(`/organizations/${organization.slug}/explore/traces/`)
-                  );
-                }
                 if (
                   getSavedQueryTraceItemDataset(savedQuery.dataset) ===
                   TraceItemDataset.SPANS
                 ) {
+                  if (location.pathname.endsWith('compare/')) {
+                    navigate(
+                      normalizeUrl(
+                        `/organizations/${organization.slug}/explore/traces/compare/`
+                      )
+                    );
+                  } else {
+                    navigate(
+                      normalizeUrl(`/organizations/${organization.slug}/explore/traces/`)
+                    );
+                  }
                   trackAnalytics('trace_explorer.delete_query', {
                     organization,
                   });

--- a/static/app/views/explore/savedQueryEditMenu.tsx
+++ b/static/app/views/explore/savedQueryEditMenu.tsx
@@ -10,6 +10,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {getIdFromLocation} from 'sentry/views/explore/contexts/pageParamsContext/id';
 import {useDeleteQuery} from 'sentry/views/explore/hooks/useDeleteQuery';
 import {useGetSavedQuery} from 'sentry/views/explore/hooks/useGetSavedQueries';
+import {TraceItemDataset} from 'sentry/views/explore/types';
 import {confirmDeleteSavedQuery} from 'sentry/views/explore/utils';
 
 export function SavedQueryEditMenu() {
@@ -46,9 +47,15 @@ export function SavedQueryEditMenu() {
                     normalizeUrl(`/organizations/${organization.slug}/explore/traces/`)
                   );
                 }
-                trackAnalytics('trace_explorer.delete_query', {
-                  organization,
-                });
+                if (savedQuery.traceItemDataset === TraceItemDataset.SPANS) {
+                  trackAnalytics('trace_explorer.delete_query', {
+                    organization,
+                  });
+                } else if (savedQuery.traceItemDataset === TraceItemDataset.LOGS) {
+                  trackAnalytics('logs.delete_query', {
+                    organization,
+                  });
+                }
               },
               savedQuery,
             });

--- a/static/app/views/explore/starSavedQueryButton.tsx
+++ b/static/app/views/explore/starSavedQueryButton.tsx
@@ -10,7 +10,10 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {getIdFromLocation} from 'sentry/views/explore/contexts/pageParamsContext/id';
-import {useGetSavedQuery} from 'sentry/views/explore/hooks/useGetSavedQueries';
+import {
+  getSavedQueryTraceItemDataset,
+  useGetSavedQuery,
+} from 'sentry/views/explore/hooks/useGetSavedQueries';
 import {useStarQuery} from 'sentry/views/explore/hooks/useStarQuery';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 
@@ -35,18 +38,22 @@ export function StarSavedQueryButton() {
           return;
         }
         try {
-          if (data?.traceItemDataset === TraceItemDataset.SPANS) {
-            trackAnalytics('trace_explorer.star_query', {
-              save_type: starred ? 'star_query' : 'unstar_query',
-              ui_source: 'explorer',
-              organization,
-            });
-          } else if (data?.traceItemDataset === TraceItemDataset.LOGS) {
-            trackAnalytics('logs.star_query', {
-              save_type: starred ? 'star_query' : 'unstar_query',
-              ui_source: 'explorer',
-              organization,
-            });
+          if (data?.dataset) {
+            if (getSavedQueryTraceItemDataset(data?.dataset) === TraceItemDataset.SPANS) {
+              trackAnalytics('trace_explorer.star_query', {
+                save_type: starred ? 'star_query' : 'unstar_query',
+                ui_source: 'explorer',
+                organization,
+              });
+            } else if (
+              getSavedQueryTraceItemDataset(data?.dataset) === TraceItemDataset.LOGS
+            ) {
+              trackAnalytics('logs.star_query', {
+                save_type: starred ? 'star_query' : 'unstar_query',
+                ui_source: 'explorer',
+                organization,
+              });
+            }
           }
           starQuery(parseInt(id, 10), starred);
           setIsStarred(starred);
@@ -59,7 +66,7 @@ export function StarSavedQueryButton() {
       1000,
       {leading: true}
     );
-  }, [starQuery, organization, data?.traceItemDataset]);
+  }, [starQuery, organization, data?.dataset]);
 
   if (isLoading || !locationId) {
     return null;

--- a/static/app/views/explore/starSavedQueryButton.tsx
+++ b/static/app/views/explore/starSavedQueryButton.tsx
@@ -12,6 +12,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {getIdFromLocation} from 'sentry/views/explore/contexts/pageParamsContext/id';
 import {useGetSavedQuery} from 'sentry/views/explore/hooks/useGetSavedQueries';
 import {useStarQuery} from 'sentry/views/explore/hooks/useStarQuery';
+import {TraceItemDataset} from 'sentry/views/explore/types';
 
 export function StarSavedQueryButton() {
   const organization = useOrganization();
@@ -34,11 +35,19 @@ export function StarSavedQueryButton() {
           return;
         }
         try {
-          trackAnalytics('trace_explorer.star_query', {
-            save_type: starred ? 'star_query' : 'unstar_query',
-            ui_source: 'explorer',
-            organization,
-          });
+          if (data?.traceItemDataset === TraceItemDataset.SPANS) {
+            trackAnalytics('trace_explorer.star_query', {
+              save_type: starred ? 'star_query' : 'unstar_query',
+              ui_source: 'explorer',
+              organization,
+            });
+          } else if (data?.traceItemDataset === TraceItemDataset.LOGS) {
+            trackAnalytics('logs.star_query', {
+              save_type: starred ? 'star_query' : 'unstar_query',
+              ui_source: 'explorer',
+              organization,
+            });
+          }
           starQuery(parseInt(id, 10), starred);
           setIsStarred(starred);
         } catch (error) {
@@ -50,7 +59,7 @@ export function StarSavedQueryButton() {
       1000,
       {leading: true}
     );
-  }, [starQuery, organization]);
+  }, [starQuery, organization, data?.traceItemDataset]);
 
   if (isLoading || !locationId) {
     return null;

--- a/static/app/views/explore/toolbar/toolbarSaveAs.tsx
+++ b/static/app/views/explore/toolbar/toolbarSaveAs.tsx
@@ -41,11 +41,12 @@ import {useGetSavedQuery} from 'sentry/views/explore/hooks/useGetSavedQueries';
 import {useSaveQuery} from 'sentry/views/explore/hooks/useSaveQuery';
 import {generateExploreCompareRoute} from 'sentry/views/explore/multiQueryMode/locationUtils';
 import {useQueryParamsMode} from 'sentry/views/explore/queryParams/context';
+import {TraceItemDataset} from 'sentry/views/explore/types';
 import {getAlertsUrl} from 'sentry/views/insights/common/utils/getAlertsUrl';
 
 export function ToolbarSaveAs() {
   const {addToDashboard} = useAddToDashboard();
-  const {updateQuery, saveQuery} = useSaveQuery();
+  const {updateQuery, saveQuery} = useSaveQuery(TraceItemDataset.SPANS);
   const location = useLocation();
   const organization = useOrganization();
 
@@ -141,6 +142,7 @@ export function ToolbarSaveAs() {
         organization,
         saveQuery,
         source: 'toolbar',
+        traceItemDataset: TraceItemDataset.SPANS,
       });
     },
   });

--- a/static/app/views/explore/toolbar/toolbarSaveAs.tsx
+++ b/static/app/views/explore/toolbar/toolbarSaveAs.tsx
@@ -38,7 +38,7 @@ import {
 import {useAddToDashboard} from 'sentry/views/explore/hooks/useAddToDashboard';
 import {useChartInterval} from 'sentry/views/explore/hooks/useChartInterval';
 import {useGetSavedQuery} from 'sentry/views/explore/hooks/useGetSavedQueries';
-import {useSaveQuery} from 'sentry/views/explore/hooks/useSaveQuery';
+import {useSpansSaveQuery} from 'sentry/views/explore/hooks/useSaveQuery';
 import {generateExploreCompareRoute} from 'sentry/views/explore/multiQueryMode/locationUtils';
 import {useQueryParamsMode} from 'sentry/views/explore/queryParams/context';
 import {TraceItemDataset} from 'sentry/views/explore/types';
@@ -46,7 +46,7 @@ import {getAlertsUrl} from 'sentry/views/insights/common/utils/getAlertsUrl';
 
 export function ToolbarSaveAs() {
   const {addToDashboard} = useAddToDashboard();
-  const {updateQuery, saveQuery} = useSaveQuery(TraceItemDataset.SPANS);
+  const {updateQuery, saveQuery} = useSpansSaveQuery();
   const location = useLocation();
   const organization = useOrganization();
 


### PR DESCRIPTION
### Summary
This adds "save query" action item for logs in the "save as" on explore, and adds 'logs' type when ourlogs-enabled flag is set on the "All Queries" saved table view.

#### Screenshots

|<img width="825" height="340" alt="Screenshot 2025-08-07 at 7 29 35 PM" src="https://github.com/user-attachments/assets/9cb2f004-7788-445d-9e0a-70c18417b27e" />|<img width="1075" height="276" alt="Screenshot 2025-08-07 at 7 29 16 PM" src="https://github.com/user-attachments/assets/00bb87e7-fbd5-48b3-bb06-58f6d3e420c5" />|
|-|-|
