### PR TITLE
fix(logs): Rename log body filter name

### DIFF
--- a/src/sentry/ingest/inbound_filters.py
+++ b/src/sentry/ingest/inbound_filters.py
@@ -427,7 +427,7 @@ def get_log_messages_generic_filter(log_messages: list[str]) -> GenericFilter | 
         return None
 
     return {
-        "id": "gen_body",
+        "id": "log-message",
         "isEnabled": True,
         "condition": {
             "op": "glob",

--- a/tests/sentry/relay/test_config.py
+++ b/tests/sentry/relay/test_config.py
@@ -302,7 +302,7 @@ def test_project_config_uses_filter_features(
         assert {"patterns": error_messages} == cfg_error_messages
         assert {"releases": releases} == cfg_releases
         assert {
-            "id": "gen_body",
+            "id": "log-message",
             "isEnabled": True,
             "condition": {
                 "op": "glob",


### PR DESCRIPTION
The filter name gets used as the filter reason so use something that aligns with existing reasons.