### PR TITLE
ref(feedback): add spam_detection_enabled to evidence

### DIFF
--- a/src/sentry/feedback/usecases/ingest/create_feedback.py
+++ b/src/sentry/feedback/usecases/ingest/create_feedback.py
@@ -75,9 +75,9 @@ def make_evidence(
             IssueEvidence(name="is_spam", value=str(is_message_spam), important=False)
         )
 
-    evidence_data["spam_enabled"] = is_spam_enabled
+    evidence_data["spam_detection_enabled"] = is_spam_enabled
     evidence_display.append(
-        IssueEvidence(name="spam_enabled", value=str(is_spam_enabled), important=False)
+        IssueEvidence(name="spam_detection_enabled", value=str(is_spam_enabled), important=False)
     )
 
     return evidence_data, evidence_display

--- a/src/sentry/feedback/usecases/ingest/create_feedback.py
+++ b/src/sentry/feedback/usecases/ingest/create_feedback.py
@@ -380,7 +380,9 @@ def create_feedback_issue(
     if event_fixed.get("release"):
         event_fixed["tags"]["release"] = event_fixed["release"]
 
-    event_fixed["tags"]["has_spam_filter"] = "true" if is_message_spam is not None else "false"
+    event_fixed["tags"]["sentry:has_spam_filter"] = (
+        "true" if is_message_spam is not None else "false"
+    )
 
     # make sure event data is valid for issue platform
     validate_issue_platform_event_schema(event_fixed)

--- a/src/sentry/feedback/usecases/ingest/create_feedback.py
+++ b/src/sentry/feedback/usecases/ingest/create_feedback.py
@@ -380,6 +380,8 @@ def create_feedback_issue(
     if event_fixed.get("release"):
         event_fixed["tags"]["release"] = event_fixed["release"]
 
+    event_fixed["tags"]["skipped_spam_filter"] = "true" if is_message_spam is None else "false"
+
     # make sure event data is valid for issue platform
     validate_issue_platform_event_schema(event_fixed)
 

--- a/src/sentry/feedback/usecases/ingest/create_feedback.py
+++ b/src/sentry/feedback/usecases/ingest/create_feedback.py
@@ -380,7 +380,7 @@ def create_feedback_issue(
     if event_fixed.get("release"):
         event_fixed["tags"]["release"] = event_fixed["release"]
 
-    event_fixed["tags"]["skipped_spam_filter"] = "true" if is_message_spam is None else "false"
+    event_fixed["tags"]["has_spam_filter"] = "true" if is_message_spam is not None else "false"
 
     # make sure event data is valid for issue platform
     validate_issue_platform_event_schema(event_fixed)

--- a/tests/sentry/feedback/usecases/ingest/test_create_feedback.py
+++ b/tests/sentry/feedback/usecases/ingest/test_create_feedback.py
@@ -810,26 +810,6 @@ def test_create_feedback_tags_skips_email_if_empty(
     assert "user.email" not in tags
 
 
-@pytest.mark.parametrize("spam_enabled", (True, False))
-@django_db_all
-def test_create_feedback_tags_has_spam_filter(
-    default_project, mock_produce_occurrence_to_kafka, spam_enabled
-) -> None:
-    with (
-        patch(
-            "sentry.feedback.usecases.ingest.create_feedback.spam_detection_enabled",
-            return_value=spam_enabled,
-        ),
-        patch("sentry.feedback.usecases.ingest.create_feedback.is_spam", return_value=True),
-    ):
-        event = mock_feedback_event(default_project.id)
-        create_feedback_issue(event, default_project, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE)
-
-    assert mock_produce_occurrence_to_kafka.call_count > 0  # is 2 when spam enabled
-    tags = mock_produce_occurrence_to_kafka.call_args_list[0].kwargs["event_data"]["tags"]
-    assert tags["sentry:has_spam_filter"] == "true" if spam_enabled else "false"
-
-
 @django_db_all
 @pytest.mark.parametrize("spam_enabled", (True, False))
 def test_create_feedback_filters_large_message(
@@ -889,6 +869,31 @@ def test_create_feedback_evidence_has_spam(
     assert mock_produce_occurrence_to_kafka.call_count == 2  # second call is status change
     evidence = mock_produce_occurrence_to_kafka.call_args_list[0].kwargs["occurrence"].evidence_data
     assert evidence["is_spam"] is True
+
+
+@pytest.mark.parametrize("spam_enabled", (True, False))
+@django_db_all
+def test_create_feedback_evidence_spam_detection_enabled(
+    default_project, mock_produce_occurrence_to_kafka, spam_enabled
+) -> None:
+    with (
+        patch(
+            "sentry.feedback.usecases.ingest.create_feedback.spam_detection_enabled",
+            return_value=spam_enabled,
+        ),
+        patch("sentry.feedback.usecases.ingest.create_feedback.is_spam", return_value=True),
+    ):
+        event = mock_feedback_event(default_project.id)
+        create_feedback_issue(event, default_project, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE)
+
+    assert mock_produce_occurrence_to_kafka.call_count == 2 if spam_enabled else 1
+    occurrence = mock_produce_occurrence_to_kafka.call_args_list[0].kwargs["occurrence"]
+    assert occurrence.evidence_data["spam_detection_enabled"] == spam_enabled
+    evidence_display = list(
+        filter(lambda x: x.name == "spam_detection_enabled", occurrence.evidence_display)
+    )
+    assert len(evidence_display) == 1
+    assert evidence_display[0].value == str(spam_enabled)
 
 
 @django_db_all

--- a/tests/sentry/feedback/usecases/ingest/test_create_feedback.py
+++ b/tests/sentry/feedback/usecases/ingest/test_create_feedback.py
@@ -827,7 +827,7 @@ def test_create_feedback_tags_has_spam_filter(
 
     assert mock_produce_occurrence_to_kafka.call_count > 0  # is 2 when spam enabled
     tags = mock_produce_occurrence_to_kafka.call_args_list[0].kwargs["event_data"]["tags"]
-    assert tags["has_spam_filter"] == "true" if spam_enabled else "false"
+    assert tags["sentry:has_spam_filter"] == "true" if spam_enabled else "false"
 
 
 @django_db_all

--- a/tests/sentry/feedback/usecases/ingest/test_create_feedback.py
+++ b/tests/sentry/feedback/usecases/ingest/test_create_feedback.py
@@ -812,7 +812,7 @@ def test_create_feedback_tags_skips_email_if_empty(
 
 @pytest.mark.parametrize("spam_enabled", (True, False))
 @django_db_all
-def test_create_feedback_tags_skipped_spam_filter(
+def test_create_feedback_tags_has_spam_filter(
     default_project, mock_produce_occurrence_to_kafka, spam_enabled
 ) -> None:
     with (
@@ -825,9 +825,9 @@ def test_create_feedback_tags_skipped_spam_filter(
         event = mock_feedback_event(default_project.id)
         create_feedback_issue(event, default_project, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE)
 
-    assert mock_produce_occurrence_to_kafka.call_count == 1
-    tags = mock_produce_occurrence_to_kafka.call_args.kwargs["event_data"]["tags"]
-    assert tags["skipped_spam_filter"] is not spam_enabled
+    assert mock_produce_occurrence_to_kafka.call_count > 0  # is 2 when spam enabled
+    tags = mock_produce_occurrence_to_kafka.call_args_list[0].kwargs["event_data"]["tags"]
+    assert tags["has_spam_filter"] == "true" if spam_enabled else "false"
 
 
 @django_db_all


### PR DESCRIPTION
Relates to [REPLAY-602: \[User Feedback\] Unhelpful feedback and profanity should be detected as spam](https://linear.app/getsentry/issue/REPLAY-602/user-feedback-unhelpful-feedback-and-profanity-should-be-detected-as)