### PR TITLE
ref: Move Credentials Button to a separate file

### DIFF
--- a/static/app/views/settings/project/tempest/PlayStationSettings.tsx
+++ b/static/app/views/settings/project/tempest/PlayStationSettings.tsx
@@ -1,17 +1,13 @@
 import {Fragment, useEffect, useMemo} from 'react';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
-import {openAddTempestCredentialsModal} from 'sentry/actionCreators/modal';
 import {Alert} from 'sentry/components/core/alert';
-import {Button} from 'sentry/components/core/button';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
-import {Tooltip} from 'sentry/components/core/tooltip';
 import FeedbackWidgetButton from 'sentry/components/feedback/widget/feedbackWidgetButton';
 import List from 'sentry/components/list';
 import ListItem from 'sentry/components/list/listItem';
 import Panel from 'sentry/components/panels/panel';
 import {PanelTable} from 'sentry/components/panels/panelTable';
-import {IconAdd} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
@@ -19,6 +15,7 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {handleXhrErrorResponse} from 'sentry/utils/handleXhrErrorResponse';
 import {fetchMutation, useMutation} from 'sentry/utils/queryClient';
 import type RequestError from 'sentry/utils/requestError/requestError';
+import {AddCredentialsButton} from 'sentry/views/settings/project/tempest/addCredentialsButton';
 import {ConfigForm} from 'sentry/views/settings/project/tempest/configForm';
 import {useFetchTempestCredentials} from 'sentry/views/settings/project/tempest/hooks/useFetchTempestCredentials';
 import {MessageType} from 'sentry/views/settings/project/tempest/types';
@@ -129,7 +126,6 @@ export default function PlayStationSettings({organization, project}: Props) {
 }
 
 export const getPlayStationHeaderAction = (
-  hasWriteAccess: boolean,
   organization: Organization,
   project: Project
 ) => (
@@ -137,27 +133,7 @@ export const getPlayStationHeaderAction = (
     <ButtonBar gap="lg">
       <FeedbackWidgetButton />
       <RequestSdkAccessButton organization={organization} project={project} />
-      <Tooltip
-        title={t('You must be an organization admin to add new credentials.')}
-        disabled={hasWriteAccess}
-      >
-        <Button
-          priority="primary"
-          size="sm"
-          data-test-id="create-new-credentials"
-          disabled={!hasWriteAccess}
-          icon={<IconAdd isCircled />}
-          onClick={() => {
-            openAddTempestCredentialsModal({organization, project});
-            trackAnalytics('tempest.credentials.add_modal_opened', {
-              organization,
-              project_slug: project.slug,
-            });
-          }}
-        >
-          {t('Add Credentials')}
-        </Button>
-      </Tooltip>
+      <AddCredentialsButton project={project} />
     </ButtonBar>
   </Fragment>
 );

--- a/static/app/views/settings/project/tempest/addCredentialsButton.tsx
+++ b/static/app/views/settings/project/tempest/addCredentialsButton.tsx
@@ -1,0 +1,42 @@
+import {openAddTempestCredentialsModal} from 'sentry/actionCreators/modal';
+import {Button} from 'sentry/components/core/button';
+import {Tooltip} from 'sentry/components/core/tooltip';
+import {IconAdd} from 'sentry/icons/iconAdd';
+import {t} from 'sentry/locale';
+import type {Project} from 'sentry/types/project';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import useOrganization from 'sentry/utils/useOrganization';
+import {useHasTempestWriteAccess} from 'sentry/views/settings/project/tempest/utils/access';
+
+interface AddCredentialsButtonProps {
+  project: Project;
+}
+
+export function AddCredentialsButton({project}: AddCredentialsButtonProps) {
+  const organization = useOrganization();
+  const hasWriteAccess = useHasTempestWriteAccess();
+
+  return (
+    <Tooltip
+      title={t('You must be an organization admin to add new credentials.')}
+      disabled={hasWriteAccess}
+    >
+      <Button
+        priority="primary"
+        size="sm"
+        data-test-id="create-new-credentials"
+        disabled={!hasWriteAccess}
+        icon={<IconAdd isCircled />}
+        onClick={() => {
+          openAddTempestCredentialsModal({organization, project});
+          trackAnalytics('tempest.credentials.add_modal_opened', {
+            organization,
+            project_slug: project.slug,
+          });
+        }}
+      >
+        {t('Add Credentials')}
+      </Button>
+    </Tooltip>
+  );
+}

--- a/static/app/views/settings/project/tempest/index.tsx
+++ b/static/app/views/settings/project/tempest/index.tsx
@@ -14,7 +14,6 @@ import useDismissAlert from 'sentry/utils/useDismissAlert';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
-import {useHasTempestWriteAccess} from 'sentry/views/settings/project/tempest/utils/access';
 
 import DevKitSettings, {getDevKitHeaderAction} from './DevKitSettings';
 import PlayStationSettings, {getPlayStationHeaderAction} from './PlayStationSettings';
@@ -34,7 +33,6 @@ const TAB_LABELS: Record<Tab, string> = {
 const PS5_WARNING_DISMISS_KEY = 'tempest-ps5-warning-dismissed';
 
 export default function TempestSettings({organization, project}: Props) {
-  const hasWriteAccess = useHasTempestWriteAccess();
   const location = useLocation();
   const navigate = useNavigate();
   const {dismiss: dismissPS5Warning, isDismissed: isPS5WarningDismissed} =
@@ -108,7 +106,7 @@ export default function TempestSettings({organization, project}: Props) {
         return getDevKitHeaderAction(organization, project);
       case 'playstation':
       default:
-        return getPlayStationHeaderAction(hasWriteAccess, organization, project);
+        return getPlayStationHeaderAction(organization, project);
     }
   };
 


### PR DESCRIPTION
Moved the button to a separate file, as I plan to reuse it in the onboarding docs for console platforms.