### PR TITLE
fix(insights): Fix 404 for span details table on mobile screen rendering tab

### DIFF
--- a/static/app/views/insights/mobile/ui/components/tables/spanOperationTable.tsx
+++ b/static/app/views/insights/mobile/ui/components/tables/spanOperationTable.tsx
@@ -37,7 +37,7 @@ export function SpanOperationTable({
   primaryRelease,
   secondaryRelease,
 }: SpanOperationTableProps) {
-  const moduleURL = useModuleURL('mobile-ui');
+  const moduleURL = useModuleURL('mobile-vitals');
   const location = useLocation();
   const {selection} = usePageFilters();
   const cursor = decodeScalar(location.query?.[MobileCursors.SPANS_TABLE]);
@@ -161,8 +161,7 @@ export function SpanOperationTable({
   function renderBodyCell(column: any, row: any) {
     if (column.key === SPAN_DESCRIPTION) {
       const label = row[SpanFields.SPAN_DESCRIPTION];
-
-      const pathname = `${moduleURL}/spans/`;
+      const pathname = `${moduleURL}/details/`;
 
       const query = {
         ...location.query,


### PR DESCRIPTION
Clicking on a span on Insights -> Mobile -> Screen -> Screen Rendering causes a 404 right now, this PR fixes this by simply re-using our span details pane.

<img width="856" height="356" alt="image" src="https://github.com/user-attachments/assets/4654101e-a03e-4e22-98bd-55d908227bff" />
