### PR TITLE
fix(integrations): cramped metadata layout

### DIFF
--- a/static/app/views/settings/organizationIntegrations/detailedView/integrationLayout.tsx
+++ b/static/app/views/settings/organizationIntegrations/detailedView/integrationLayout.tsx
@@ -372,6 +372,7 @@ const Metadata = styled('div')`
   margin-left: ${space(4)};
   margin-right: 100px;
   align-self: flex-start;
+  flex-shrink: 0;
 `;
 
 const AuthorInfo = styled('div')`


### PR DESCRIPTION
- Fix the metadata layout in integrations to not be so cramped

Before:
<img width="857" height="587" alt="Screenshot 2025-08-08 at 10 25 17" src="https://github.com/user-attachments/assets/a109388b-8566-4391-a850-d7fd7b9b5273" />

After:
<img width="857" height="585" alt="Screenshot 2025-08-08 at 10 25 15" src="https://github.com/user-attachments/assets/44f70e05-a6de-47bc-b74f-856bc2fb55bb" />
