### PR TITLE
icons: offset by whole numbers

### DIFF
--- a/static/app/icons/svgIcon.tsx
+++ b/static/app/icons/svgIcon.tsx
@@ -52,14 +52,14 @@ export function SvgIcon(props: IconProps) {
     return (
       <svg
         role="img"
-        viewBox={'1.25 1.25 13.5 13.5'}
+        viewBox={'1 1 14 14'}
         height={size}
         width={size}
         fill="none"
         stroke={color}
         strokeLinecap="round"
         strokeLinejoin="round"
-        strokeWidth="1.25px"
+        strokeWidth="1px"
         {...rest}
       />
     );


### PR DESCRIPTION
Offset by and use whole numbers for icon SVG to avoid aliasing problems.