### PR TITLE
fix: invalid syntax in md file code blocks

### DIFF
--- a/static/.cursor/BUGBOT.md
+++ b/static/.cursor/BUGBOT.md
@@ -12,7 +12,6 @@ CRITICAL:
 - Use <Grid> from `sentry/components/core/layout` for elements that require grid layout as opposed to styled components with `display: grid`
 
 ```tsx
-// ✅ Use the Grid layout primitive
 import {Grid} from 'sentry/components/core/layout';
 
 // ❌ No need to use styled and create a new styled component
@@ -21,13 +20,13 @@ const Component = styled('div')`
   flex-directon: column;
 `;
 
+// ✅ Use the Grid layout primitive
 <Grid direction="column"></Grid>;
 ```
 
 - Use <Flex> from `sentry/components/core/layout` for elements that require flex layout as opposed to styled components with `display: flex`.
 
 ```tsx
-// ✅ Use the Flex layout primitive
 import {Flex} from 'sentry/components/core/layout';
 
 // ❌ No need to use styled and create a new styled component
@@ -36,13 +35,13 @@ const Component = styled('div')`
   flex-directon: column;
 `;
 
+// ✅ Use the Flex layout primitive
 <Flex direction="column"></Flex>;
 ```
 
 - Use using <Container> from `sentry/components/core/layout` over simple elements that require a border or border radius.
 
 ```tsx
-// ✅ Use the Container primitive
 import {Container} from 'sentry/components/core/layout';
 
 // ❌ No need to use styled and create a new styled component
@@ -51,13 +50,13 @@ const Component = styled('div')`
   border: 1px solid ${p => p.theme.tokens.border.primary};
 `;
 
+// ✅ Use the Container primitive
 <Container padding="md" border="primary"></Container>;
 ```
 
 - Use responsive props instead of styled media queries for Flex, Grid and Container.
 
 ```tsx
-// ✅ Use the responsive prop signature
 import {Flex} from 'sentry/components/core/layout';
 
 // ❌ No need to use styled and create a new styled component
@@ -70,6 +69,7 @@ const Component = styled('div')`
   }
 `;
 
+// ✅ Use the responsive prop signature
 <Flex direction={{xs: 'column', md: 'row'}}></Flex>;
 ```
 
@@ -80,7 +80,6 @@ const Component = styled('div')`
 - Use <Heading> from `sentry/components/core/text` for headings instead of styled components that style heading typography.
 
 ```tsx
-// ✅ Use the Heading typography primitive
 import {Heading} from 'sentry/components/core/text';
 
 // ❌ No need to use styled and create a new styled component
@@ -89,13 +88,13 @@ const Title = styled('h2')`
   font-weight: bold;
 `;
 
+// ✅ Use the Heading typography primitive
 <Heading as="h2">Heading</Heading>;
 ```
 
 - Use <Text> from `sentry/components/core/text` for text styling instead of styled components that handle typography features like color, overflow, font-size, font-weight.
 
 ```tsx
-// ✅ Use the Text typography primitive
 import {Text} from 'sentry/components/core/text';
 
 // ❌ No need to use styled and create a new styled component
@@ -104,6 +103,7 @@ const Label = styled('span')`
   font-size: ${p => p.theme.fontSizes.small};
 `;
 
+// ✅ Use the Text typography primitive
 <Text variant="muted" size="sm">
   Text
 </Text>;

--- a/static/.cursor/BUGBOT.md
+++ b/static/.cursor/BUGBOT.md
@@ -12,58 +12,65 @@ CRITICAL:
 - Use <Grid> from `sentry/components/core/layout` for elements that require grid layout as opposed to styled components with `display: grid`
 
 ```tsx
+// ✅ Use the Grid layout primitive
+import {Grid} from 'sentry/components/core/layout';
+
 // ❌ No need to use styled and create a new styled component
 const Component = styled('div')`
   display: flex;
   flex-directon: column;
 `;
-// ✅ Use the Grid layout primitive
-import {Grid} from 'sentry/components/core/layout';
+
 <Grid direction="column"></Grid>;
 ```
 
 - Use <Flex> from `sentry/components/core/layout` for elements that require flex layout as opposed to styled components with `display: flex`.
 
 ```tsx
+// ✅ Use the Flex layout primitive
+import {Flex} from 'sentry/components/core/layout';
+
 // ❌ No need to use styled and create a new styled component
 const Component = styled('div')`
   display: flex;
   flex-directon: column;
 `;
-// ✅ Use the Flex layout primitive
-import {Flex} from 'sentry/components/core/layout';
+
 <Flex direction="column"></Flex>;
 ```
 
 - Use using <Container> from `sentry/components/core/layout` over simple elements that require a border or border radius.
 
 ```tsx
+// ✅ Use the Container primitive
+import {Container} from 'sentry/components/core/layout';
+
 // ❌ No need to use styled and create a new styled component
 const Component = styled('div')`
   padding: space(2);
   border: 1px solid ${p => p.theme.tokens.border.primary};
 `;
 
-// ✅ Use the Container primitive
-import {Container} from 'sentry/components/core/layout';
 <Container padding="md" border="primary"></Container>;
 ```
 
 - Use responsive props instead of styled media queries for Flex, Grid and Container.
 
 ```tsx
+// ✅ Use the responsive prop signature
+import {Flex} from 'sentry/components/core/layout';
+
 // ❌ No need to use styled and create a new styled component
 const Component = styled('div')`
   display: flex;
   flex-directon: column;
 
-  @media screen and (min-width: ${p => p.theme.breakpoints.md}){
+  @media screen and (min-width: ${p => p.theme.breakpoints.md}) {
     flex-direction: row;
   }
 `;
-// ✅ Use the responsive prop signature
-import {Flex} from 'sentry/components/core/layout';
-<Flex direction={{xs: 'column' md: 'row'}}></Flex>;
+
+<Flex direction={{xs: 'column', md: 'row'}}></Flex>;
 ```
 
 - Prefer the use of gap or padding over margin.
@@ -73,28 +80,30 @@ import {Flex} from 'sentry/components/core/layout';
 - Use <Heading> from `sentry/components/core/text` for headings instead of styled components that style heading typography.
 
 ```tsx
+// ✅ Use the Heading typography primitive
+import {Heading} from 'sentry/components/core/text';
+
 // ❌ No need to use styled and create a new styled component
 const Title = styled('h2')`
   font-size: ${p => p.theme.fontSize.md};
   font-weight: bold;
 `;
 
-// ✅ Use the Heading typography primitive
-import {Heading} from 'sentry/components/core/text';
 <Heading as="h2">Heading</Heading>;
 ```
 
 - Use <Text> from `sentry/components/core/text` for text styling instead of styled components that handle typography features like color, overflow, font-size, font-weight.
 
 ```tsx
+// ✅ Use the Text typography primitive
+import {Text} from 'sentry/components/core/text';
+
 // ❌ No need to use styled and create a new styled component
 const Label = styled('span')`
   color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizes.small};
 `;
 
-// ✅ Use the Text typography primitive
-import {Text} from 'sentry/components/core/text';
 <Text variant="muted" size="sm">
   Text
 </Text>;

--- a/static/CLAUDE.md
+++ b/static/CLAUDE.md
@@ -156,9 +156,7 @@ const data = await api.requestPromise('/organizations/');
 ### Frontend
 
 ```tsx
-// NO!
-
-import {Client} from 'sentry/api';
+import {Client, Client} from 'sentry/api';
 
 // WRONG: Class component
 class MyComponent extends React.Component {} // NO!
@@ -167,15 +165,14 @@ class MyComponent extends React.Component {} // NO!
 function MyComponent() {}
 
 // WRONG: Direct API call
-fetch('/api/0/organizations/')  // NO!
+fetch('/api/0/organizations/'); // NO!
 
 // RIGHT: Use API client
-import {Client} from 'sentry/api';
 const api = new Client();
 api.requestPromise('/organizations/');
 
 // WRONG: Inline styles
-<div style={{padding: 16}}>  // NO!
+<div style={{padding: 16}} />; // NO!
 
 // RIGHT: Emotion styled
 const Container = styled('div')`

--- a/static/CLAUDE.md
+++ b/static/CLAUDE.md
@@ -67,10 +67,11 @@ pnpm run fix
 
 ### React Component Pattern
 
-```typescript
+```tsx
 // static/app/components/myComponent.tsx
 import {useState} from 'react';
 import styled from '@emotion/styled';
+
 import {space} from 'sentry/styles/space';
 
 interface MyComponentProps {
@@ -154,9 +155,13 @@ const data = await api.requestPromise('/organizations/');
 
 ### Frontend
 
-```typescript
+```tsx
+// NO!
+
+import {Client} from 'sentry/api';
+
 // WRONG: Class component
-class MyComponent extends React.Component  // NO!
+class MyComponent extends React.Component {} // NO!
 
 // RIGHT: Function component
 function MyComponent() {}

--- a/static/app/components/events/contexts/README.md
+++ b/static/app/components/events/contexts/README.md
@@ -76,9 +76,9 @@ export function getMyContextData({
 
 ```ts
 export type EventContexts = {
-    browser?: BrowserContext;
+  browser?: BrowserContext;
   'Current Culture'?: CultureContext;
-  ...
+  /* ... */
   my_context?: MyContext;
 };
 ```
@@ -86,23 +86,25 @@ export type EventContexts = {
 5. Add the new context to the relevant utility function (`getFormattedContextData` or `getPlatformContextData`). This will trigger your function from Step 3 to be called when the event payload contains the `key` you specify (which should match the key from Step 4 if adding a known context, but the types are a bit loose).
 
 ```ts
-export function getFormattedContextData({...}) {
-    switch (contextType) {
-        case 'my_context':
-            return getMyContextData({data: contextValue, meta});
-        ...
-    }
+export function getFormattedContextData({}) {
+  switch (contextType) {
+    case 'my_context':
+      return getMyContextData({data: contextValue, meta});
+    // ...
+  }
 }
 ```
 
 6. To add an icon for the context, add a new case to the `getContextIcon` or `getPlatformContextIcon` function. The `generateIconName` utility is useful for company logos.
 
 ```tsx
-export function getContextIcon({...}) {
-    switch (type) {
-        case 'my_context':
-            return <img src={"my-logo.svg"} size={iconSize} />
-            ...
+export function getContextIcon({}) {
+  switch (type) {
+    case 'my_context':
+      return <img src={'my-logo.svg'} size={iconSize} />;
+    // ...
+  }
+}
 ```
 
 7. Add a test for the new context. Copying an existing test is the best way to get started, but some common usecases to test are custom formatting or titles, redacted data, and that user-specified keys are still rendered.


### PR DESCRIPTION
prettier tries to format these blocks, but silently fails when there are syntactical errors. I stumbled upon this after trying out the prettier-plugin-sort-imports, which prints those errors to the console
