### PR TITLE
ref: Update code to collect only team access

### DIFF
--- a/static/app/views/projectInstall/createProject.tsx
+++ b/static/app/views/projectInstall/createProject.tsx
@@ -324,7 +324,7 @@ export function CreateProject() {
               org_features: organization.features,
               org_allow_member_project_creation: organization.allowMemberProjectCreation,
               user_team_access: team
-                ? accessTeams.find(teamItem => teamItem.slug === team)
+                ? accessTeams.find(teamItem => teamItem.slug === team)?.access
                 : null,
               available_teams_count: accessTeams.length,
             });


### PR DESCRIPTION
the team access is unavailable. Maybe because the object is long and we don't collect all the data? Anyways...modifying the code to only send access 