### PR TITLE
Allow double-sending metrics to another "precise" backend

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2206,6 +2206,8 @@ SENTRY_TSDB_ROLLUPS = (
 # Internal metrics
 SENTRY_METRICS_BACKEND = "sentry.metrics.dummy.DummyMetricsBackend"
 SENTRY_METRICS_OPTIONS: dict[str, Any] = {}
+SENTRY_METRICS_PRECISE_BACKEND: str | None = None
+SENTRY_METRICS_PRECISE_OPTIONS: dict[str, Any] = {}
 SENTRY_METRICS_SAMPLE_RATE = 1.0
 SENTRY_METRICS_PREFIX = "sentry."
 SENTRY_METRICS_SKIP_INTERNAL_PREFIXES: list[str] = []  # Order this by most frequent prefixes.

--- a/src/sentry/metrics/base.py
+++ b/src/sentry/metrics/base.py
@@ -76,6 +76,7 @@ class MetricsBackend(local):
         sample_rate: float = 1,
         unit: str | None = None,
         stacklevel: int = 0,
+        precise: bool = False,
     ) -> None:
         raise NotImplementedError
 

--- a/src/sentry/metrics/datadog.py
+++ b/src/sentry/metrics/datadog.py
@@ -108,9 +108,23 @@ class DatadogMetricsBackend(MetricsBackend):
         sample_rate: float = 1,
         unit: str | None = None,
         stacklevel: int = 0,
+        precise: bool = False,
     ) -> None:
-        # We keep the same implementation for Datadog.
-        self.timing(key, value, instance, tags, sample_rate)
+        if not precise:
+            # We keep the same implementation for Datadog.
+            return self.timing(key, value, instance, tags, sample_rate)
+
+        tags = dict(tags or ())
+
+        if self.tags:
+            tags.update(self.tags)
+        if instance:
+            tags["instance"] = instance
+
+        tags_list = [f"{k}:{v}" for k, v in tags.items()]
+        self.stats.distribution(
+            self._get_key(key), value, sample_rate=sample_rate, tags=tags_list, host=self.host
+        )
 
     def event(
         self,

--- a/src/sentry/metrics/dummy.py
+++ b/src/sentry/metrics/dummy.py
@@ -48,6 +48,7 @@ class DummyMetricsBackend(MetricsBackend):
         sample_rate: float = 1,
         unit: str | None = None,
         stacklevel: int = 0,
+        precise: bool = False,
     ) -> None:
         pass
 

--- a/src/sentry/metrics/logging.py
+++ b/src/sentry/metrics/logging.py
@@ -52,6 +52,7 @@ class LoggingBackend(MetricsBackend):
         sample_rate: float = 1,
         unit: str | None = None,
         stacklevel: int = 0,
+        precise: bool = False,
     ) -> None:
         logger.debug("%r: %+g", key, value, extra={"instance": instance, "tags": tags or {}})
 

--- a/src/sentry/metrics/middleware.py
+++ b/src/sentry/metrics/middleware.py
@@ -180,6 +180,7 @@ class MiddlewareWrapper(MetricsBackend):
         sample_rate: float = 1,
         unit: str | None = None,
         stacklevel: int = 0,
+        precise: bool = False,
     ) -> None:
         current_tags = get_current_global_tags()
         if tags is not None:
@@ -187,7 +188,7 @@ class MiddlewareWrapper(MetricsBackend):
         current_tags = _filter_tags(key, current_tags)
 
         return self.inner.distribution(
-            key, value, instance, current_tags, sample_rate, unit, stacklevel + 1
+            key, value, instance, current_tags, sample_rate, unit, stacklevel + 1, precise
         )
 
     def event(

--- a/src/sentry/metrics/statsd.py
+++ b/src/sentry/metrics/statsd.py
@@ -61,7 +61,9 @@ class StatsdMetricsBackend(MetricsBackend):
         sample_rate: float = 1,
         unit: str | None = None,
         stacklevel: int = 0,
+        precise: bool = False,
     ) -> None:
+        # NOTE: the statsd client does not have a `distribution` method
         self.timing(key, value, instance, tags, sample_rate)
 
     def event(

--- a/src/sentry/utils/metrics.py
+++ b/src/sentry/utils/metrics.py
@@ -31,6 +31,7 @@ __all__ = [
     "timing",
     "gauge",
     "backend",
+    "precise_backend",  # just for mocking in tests
     "MutableTags",
     "ensure_crash_rate_in_bounds",
 ]
@@ -171,11 +172,16 @@ def timing(
 ) -> None:
     try:
         backend.timing(key, value, instance, tags, sample_rate, stacklevel + 1)
-        if precise and precise_backend:
-            precise_backend.timing(key, value, instance, tags, sample_rate, stacklevel + 1)
     except Exception:
         logger = logging.getLogger("sentry.errors")
         logger.exception("Unable to record backend metric")
+
+    if precise and precise_backend:
+        try:
+            precise_backend.timing(key, value, instance, tags, sample_rate, stacklevel + 1)
+        except Exception:
+            logger = logging.getLogger("sentry.errors")
+            logger.exception("Unable to record precise metric")
 
 
 def distribution(
@@ -190,13 +196,18 @@ def distribution(
 ) -> None:
     try:
         backend.distribution(key, value, instance, tags, sample_rate, unit, stacklevel + 1)
-        if precise and precise_backend:
-            precise_backend.distribution(
-                key, value, instance, tags, sample_rate, unit, stacklevel + 1
-            )
     except Exception:
         logger = logging.getLogger("sentry.errors")
         logger.exception("Unable to record backend metric")
+
+    if precise and precise_backend:
+        try:
+            precise_backend.distribution(
+                key, value, instance, tags, sample_rate, unit, stacklevel + 1, precise=True
+            )
+        except Exception:
+            logger = logging.getLogger("sentry.errors")
+            logger.exception("Unable to record precise metric")
 
 
 @contextmanager

--- a/tests/sentry/metrics/test_precise.py
+++ b/tests/sentry/metrics/test_precise.py
@@ -1,0 +1,18 @@
+from unittest import mock
+
+from sentry.utils import metrics
+
+
+@mock.patch("sentry.utils.metrics.precise_backend")
+@mock.patch("sentry.utils.metrics.backend")
+def test_precise_distribution(backend, precise):
+    metrics.distribution("foo", 100, tags={"some": "stuff"}, unit="byte")
+
+    backend.distribution.assert_called_once()
+    precise.distribution.assert_not_called()
+    backend.reset_mock()
+
+    metrics.distribution("foo", 100, tags={"some": "stuff"}, unit="byte", precise=True)
+
+    backend.distribution.assert_called_once()
+    precise.distribution.assert_called_once()


### PR DESCRIPTION
We are using an in-between service doing pre-aggregation of distribution-like (distribution and timer) metrics. This preaggregation is bad, and we would like to get rid both of the preaggregation, and the service doing it.

As a first step, this allows configuring a second "precise" metrics backend, and opting into sending "precise" metrics to that second backend if it is configured.

See also https://github.com/getsentry/getsentry/pull/18133