### PR TITLE
fix(✂️): knip config testing entrypoints

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -26,6 +26,8 @@ const productionEntryPoints = [
 ];
 
 const testingEntryPoints = [
+  'static/**/*.spec.{js,mjs,ts,tsx}',
+  'tests/js/**/*.spec.{js,mjs,ts,tsx}',
   // jest uses this
   'tests/js/test-balancer/index.js',
 ];
@@ -52,7 +54,7 @@ const config: KnipConfig = {
     '!static/**/*{t,T}estUtils*.{js,mjs,ts,tsx}!',
     // helper files for stories - it's fine that they are only used in tests
     '!static/app/**/__stories__/*.{js,mjs,ts,tsx}!',
-    '!static/app/stories/*.{js,mjs,ts,tsx}!',
+    '!static/app/stories/**/*.{js,mjs,ts,tsx}!',
   ],
   compilers: {
     mdx: async text => String(await compile(text)),


### PR DESCRIPTION
the test entrypoints weren't picked up correctly, which lead to dead code not being found in the --production setting

the violations were already merged in the following PRs:

- https://github.com/getsentry/sentry/pull/97367
- https://github.com/getsentry/sentry/pull/97280
- https://github.com/getsentry/sentry/pull/97278

so in this PR, we’re just adapting the config as we are now on zero errors.