### PR TITLE
fix(dashboards-spans): Hide time range warning

### DIFF
--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -185,7 +185,9 @@ function WidgetCard(props: Props) {
   const onDemandWarning = useOnDemandWarning({widget});
   const discoverSplitAlert = useDiscoverSplitAlert({widget, onSetTransactionsDataset});
   const sessionDurationWarning = hasSessionDuration ? SESSION_DURATION_ALERT_TEXT : null;
-  const spanTimeRangeWarning = useTimeRangeWarning({widget});
+
+  // TODO: DAIN-840 Enable this depending on user's plans
+  const spanTimeRangeWarning = useTimeRangeWarning({widget, enabled: false});
 
   const onDataFetchStart = () => {
     if (timeoutRef.current) {
@@ -380,12 +382,12 @@ function useOnDemandWarning(props: {widget: Widget}): string | null {
   return null;
 }
 
-function useTimeRangeWarning(props: {widget: Widget}) {
+function useTimeRangeWarning(props: {enabled: boolean; widget: Widget}) {
   const {
     selection: {datetime},
   } = usePageFilters();
 
-  if (props.widget.widgetType !== WidgetType.SPANS) {
+  if (props.widget.widgetType !== WidgetType.SPANS || !props.enabled) {
     return null;
   }
 


### PR DESCRIPTION
This isn't necessary for now, but we'll need to use it for other plans in the near future so we're keeping it around