### PR TITLE
fix(widget-builder): Turn autocomplete off for name and description

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/nameAndDescFields.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/nameAndDescFields.tsx
@@ -37,7 +37,8 @@ function WidgetBuilderNameAndDescription({
         tooltipText={t('This will appear in the header of your widget.')}
       />
       <StyledTextField
-        name={t('Name')}
+        autoComplete="off"
+        name="widget-name"
         size="md"
         placeholder={t('Name')}
         title={t('Name')}
@@ -77,6 +78,7 @@ function WidgetBuilderNameAndDescription({
       )}
       {isDescSelected && (
         <TextArea
+          autoComplete="off"
           placeholder={t('Description')}
           aria-label={t('Description')}
           autosize


### PR DESCRIPTION
Turn off autocomplete so 1password doesn't automatically prompt. Not having autocomplete on widget titles is fine.