### PR TITLE
ref(replay-feedback): Use seer default timeout for feedback ingest and replay summaries

### DIFF
--- a/src/sentry/feedback/usecases/label_generation.py
+++ b/src/sentry/feedback/usecases/label_generation.py
@@ -51,7 +51,7 @@ def generate_labels(feedback_message: str, organization_id: int) -> list[str]:
             "content-type": "application/json;charset=utf-8",
             **sign_with_seer_secret(serialized_request.encode()),
         },
-        timeout=settings.SEER_DEFAULT_TIMEOUT or 5,
+        timeout=getattr(settings, "SEER_DEFAULT_TIMEOUT", 5),
     )
 
     if response.status_code != 200:

--- a/src/sentry/feedback/usecases/label_generation.py
+++ b/src/sentry/feedback/usecases/label_generation.py
@@ -51,7 +51,7 @@ def generate_labels(feedback_message: str, organization_id: int) -> list[str]:
             "content-type": "application/json;charset=utf-8",
             **sign_with_seer_secret(serialized_request.encode()),
         },
-        timeout=10,
+        timeout=settings.SEER_DEFAULT_TIMEOUT or 5,
     )
 
     if response.status_code != 200:

--- a/src/sentry/feedback/usecases/title_generation.py
+++ b/src/sentry/feedback/usecases/title_generation.py
@@ -134,7 +134,7 @@ def make_seer_request(request: GenerateFeedbackTitleRequest) -> bytes:
             "content-type": "application/json;charset=utf-8",
             **sign_with_seer_secret(serialized_request.encode()),
         },
-        timeout=settings.SEER_DEFAULT_TIMEOUT or 5,
+        timeout=getattr(settings, "SEER_DEFAULT_TIMEOUT", 5),
     )
 
     if response.status_code != 200:

--- a/src/sentry/feedback/usecases/title_generation.py
+++ b/src/sentry/feedback/usecases/title_generation.py
@@ -134,6 +134,7 @@ def make_seer_request(request: GenerateFeedbackTitleRequest) -> bytes:
             "content-type": "application/json;charset=utf-8",
             **sign_with_seer_secret(serialized_request.encode()),
         },
+        timeout=settings.SEER_DEFAULT_TIMEOUT or 5,
     )
 
     if response.status_code != 200:

--- a/src/sentry/replays/endpoints/project_replay_summary.py
+++ b/src/sentry/replays/endpoints/project_replay_summary.py
@@ -99,7 +99,7 @@ class ProjectReplaySummaryEndpoint(ProjectEndpoint):
                     "content-type": "application/json;charset=utf-8",
                     **sign_with_seer_secret(data.encode()),
                 },
-                timeout=settings.SEER_DEFAULT_TIMEOUT or 5,
+                timeout=getattr(settings, "SEER_DEFAULT_TIMEOUT", 5),
             )
             response.raise_for_status()  # Raises HTTPError for 4xx and 5xx.
 

--- a/src/sentry/replays/endpoints/project_replay_summary.py
+++ b/src/sentry/replays/endpoints/project_replay_summary.py
@@ -99,6 +99,7 @@ class ProjectReplaySummaryEndpoint(ProjectEndpoint):
                     "content-type": "application/json;charset=utf-8",
                     **sign_with_seer_secret(data.encode()),
                 },
+                timeout=settings.SEER_DEFAULT_TIMEOUT or 5,
             )
             response.raise_for_status()  # Raises HTTPError for 4xx and 5xx.
 


### PR DESCRIPTION
We should bound the execution time of these Seer requests. The current default timeout of none could hang - see https://requests.readthedocs.io/en/latest/user/advanced/#timeouts. Skipping this for feedback summary endpoints for now.

Note for replay summary seer endpoints, both are expected to be fast. POST submits a celery task and GET makes a simple DB query.