### PR TITLE
chore(eco): Bumps timeout slightly higher for weekly report scheduling task

### DIFF
--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -107,7 +107,7 @@ class WeeklyReportProgressTracker:
     taskworker_config=TaskworkerConfig(
         namespace=reports_tasks,
         retry=Retry(times=5),
-        processing_deadline_duration=timedelta(minutes=15),
+        processing_deadline_duration=timedelta(minutes=30),
     ),
 )
 @retry(timeouts=True)


### PR DESCRIPTION
The total run takes about 45 mins, this should at least reduce the total queue time for organizations, or come close to running in a single shot.
