### PR TITLE
feat(aci): Allow releases dataset to be saved for metric detector

### DIFF
--- a/static/app/views/detectors/components/details/metric/detect.tsx
+++ b/static/app/views/detectors/components/details/metric/detect.tsx
@@ -10,6 +10,8 @@ import type {
   SnubaQueryDataSource,
 } from 'sentry/types/workflowEngine/detectors';
 import {getExactDuration} from 'sentry/utils/duration/getExactDuration';
+import {getDetectorDataset} from 'sentry/views/detectors/components/forms/metric/metricFormData';
+import {getDatasetConfig} from 'sentry/views/detectors/datasetConfig/getDatasetConfig';
 
 interface MetricDetectorDetectProps {
   detector: MetricDetector;
@@ -20,13 +22,22 @@ function SnubaQueryDetails({dataSource}: {dataSource: SnubaQueryDataSource}) {
     return <Container>{t('Query not found.')}</Container>;
   }
 
+  const datasetConfig = getDatasetConfig(
+    getDetectorDataset(
+      dataSource.queryObj.snubaQuery.dataset,
+      dataSource.queryObj.snubaQuery.eventTypes
+    )
+  );
+
   return (
     <Container>
       <Flex direction="column" gap="xs">
         <Heading>{t('Query:')}</Heading>
         <Query>
           <Label>{t('visualize:')}</Label>
-          <Value>{dataSource.queryObj.snubaQuery.aggregate}</Value>
+          <Value>
+            {datasetConfig.fromApiAggregate(dataSource.queryObj.snubaQuery.aggregate)}
+          </Value>
           {dataSource.queryObj.snubaQuery.query && (
             <Fragment>
               <Label>{t('where:')}</Label>

--- a/static/app/views/detectors/components/forms/metric/metric.tsx
+++ b/static/app/views/detectors/components/forms/metric/metric.tsx
@@ -32,7 +32,6 @@ import {EditDetectorLayout} from 'sentry/views/detectors/components/forms/editDe
 import type {MetricDetectorFormData} from 'sentry/views/detectors/components/forms/metric/metricFormData';
 import {
   DEFAULT_THRESHOLD_METRIC_FORM_DATA,
-  DetectorDataset,
   METRIC_DETECTOR_FORM_FIELDS,
   metricDetectorFormDataToEndpointPayload,
   metricSavedDetectorToFormData,
@@ -44,6 +43,7 @@ import {Visualize} from 'sentry/views/detectors/components/forms/metric/visualiz
 import {NewDetectorLayout} from 'sentry/views/detectors/components/forms/newDetectorLayout';
 import {SectionLabel} from 'sentry/views/detectors/components/forms/sectionLabel';
 import {getDatasetConfig} from 'sentry/views/detectors/datasetConfig/getDatasetConfig';
+import {DetectorDataset} from 'sentry/views/detectors/datasetConfig/types';
 import {getResolutionDescription} from 'sentry/views/detectors/utils/getDetectorResolutionDescription';
 import {getStaticDetectorThresholdSuffix} from 'sentry/views/detectors/utils/metricDetectorSuffix';
 

--- a/static/app/views/detectors/components/forms/metric/metricDetectorChart.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricDetectorChart.tsx
@@ -15,7 +15,7 @@ import {
   AlertRuleThresholdType,
   TimePeriod,
 } from 'sentry/views/alerts/rules/metric/types';
-import type {DetectorDataset} from 'sentry/views/detectors/components/forms/metric/metricFormData';
+import type {DetectorDataset} from 'sentry/views/detectors/datasetConfig/types';
 import {useIncidentMarkers} from 'sentry/views/detectors/hooks/useIncidentMarkers';
 import {useMetricDetectorAnomalyPeriods} from 'sentry/views/detectors/hooks/useMetricDetectorAnomalyPeriods';
 import {useMetricDetectorSeries} from 'sentry/views/detectors/hooks/useMetricDetectorSeries';

--- a/static/app/views/detectors/components/forms/metric/useIntervalChoices.tsx
+++ b/static/app/views/detectors/components/forms/metric/useIntervalChoices.tsx
@@ -2,10 +2,8 @@ import {useMemo} from 'react';
 
 import getDuration from 'sentry/utils/duration/getDuration';
 import {TimeWindow} from 'sentry/views/alerts/rules/metric/types';
-import {
-  DetectorDataset,
-  type MetricDetectorFormData,
-} from 'sentry/views/detectors/components/forms/metric/metricFormData';
+import {type MetricDetectorFormData} from 'sentry/views/detectors/components/forms/metric/metricFormData';
+import {DetectorDataset} from 'sentry/views/detectors/datasetConfig/types';
 
 const baseIntervals: TimeWindow[] = [
   TimeWindow.ONE_MINUTE,

--- a/static/app/views/detectors/components/forms/metric/visualize.tsx
+++ b/static/app/views/detectors/components/forms/metric/visualize.tsx
@@ -17,13 +17,13 @@ import {unreachable} from 'sentry/utils/unreachable';
 import useOrganization from 'sentry/utils/useOrganization';
 import useTags from 'sentry/utils/useTags';
 import {
-  DetectorDataset,
   METRIC_DETECTOR_FORM_FIELDS,
   useMetricDetectorFormField,
 } from 'sentry/views/detectors/components/forms/metric/metricFormData';
 import {DetectorQueryFilterBuilder} from 'sentry/views/detectors/components/forms/metric/queryFilterBuilder';
 import {SectionLabel} from 'sentry/views/detectors/components/forms/sectionLabel';
 import {getDatasetConfig} from 'sentry/views/detectors/datasetConfig/getDatasetConfig';
+import {DetectorDataset} from 'sentry/views/detectors/datasetConfig/types';
 import {useCustomMeasurements} from 'sentry/views/detectors/datasetConfig/useCustomMeasurements';
 import {
   useTraceItemNumberAttributes,

--- a/static/app/views/detectors/datasetConfig/base.tsx
+++ b/static/app/views/detectors/datasetConfig/base.tsx
@@ -59,6 +59,11 @@ export interface DetectorDatasetConfig<SeriesResponse> {
    */
   defaultField: QueryFieldValue;
   /**
+   * Transform the aggregate function from the API response to a more user friendly title.
+   * This is currently only used for the releases dataset.
+   */
+  fromApiAggregate: (aggregate: string) => string;
+  /**
    * Field options to display in the aggregate and field selectors
    */
   getAggregateOptions: (
@@ -67,6 +72,11 @@ export interface DetectorDatasetConfig<SeriesResponse> {
     customMeasurements?: CustomMeasurementCollection
   ) => Record<string, SelectValue<FieldValue>>;
   getSeriesQueryOptions: (options: DetectorSeriesQueryOptions) => ApiQueryKey;
+  /**
+   * Transform the user-friendly aggregate function to the API aggregate function.
+   * This is currently only used for the releases dataset.
+   */
+  toApiAggregate: (aggregate: string) => string;
   /**
    * Transform comparison series data for % change alerts
    */

--- a/static/app/views/detectors/datasetConfig/errors.tsx
+++ b/static/app/views/detectors/datasetConfig/errors.tsx
@@ -27,4 +27,6 @@ export const DetectorErrorsConfig: DetectorDatasetConfig<ErrorsSeriesResponse> =
   transformComparisonSeriesData: data => {
     return [transformEventsStatsComparisonSeries(data)];
   },
+  fromApiAggregate: aggregate => aggregate,
+  toApiAggregate: aggregate => aggregate,
 };

--- a/static/app/views/detectors/datasetConfig/getDatasetConfig.tsx
+++ b/static/app/views/detectors/datasetConfig/getDatasetConfig.tsx
@@ -1,9 +1,9 @@
-import {DetectorDataset} from 'sentry/views/detectors/components/forms/metric/metricFormData';
 import {DetectorErrorsConfig} from 'sentry/views/detectors/datasetConfig/errors';
 import {DetectorLogsConfig} from 'sentry/views/detectors/datasetConfig/logs';
 import {DetectorReleasesConfig} from 'sentry/views/detectors/datasetConfig/releases';
 import {DetectorSpansConfig} from 'sentry/views/detectors/datasetConfig/spans';
 import {DetectorTransactionsConfig} from 'sentry/views/detectors/datasetConfig/transactions';
+import {DetectorDataset} from 'sentry/views/detectors/datasetConfig/types';
 
 const DATASET_CONFIG_MAP = {
   [DetectorDataset.ERRORS]: DetectorErrorsConfig,

--- a/static/app/views/detectors/datasetConfig/logs.tsx
+++ b/static/app/views/detectors/datasetConfig/logs.tsx
@@ -22,4 +22,6 @@ export const DetectorLogsConfig: DetectorDatasetConfig<LogsSeriesRepsonse> = {
   transformComparisonSeriesData: data => {
     return [transformEventsStatsComparisonSeries(data)];
   },
+  fromApiAggregate: aggregate => aggregate,
+  toApiAggregate: aggregate => aggregate,
 };

--- a/static/app/views/detectors/datasetConfig/releases.tsx
+++ b/static/app/views/detectors/datasetConfig/releases.tsx
@@ -1,20 +1,87 @@
+import type {SelectValue} from 'sentry/types/core';
 import type {SessionApiResponse} from 'sentry/types/organization';
+import {SessionField} from 'sentry/types/sessions';
 import {ReleasesConfig} from 'sentry/views/dashboards/datasetConfig/releases';
 import {ReleaseSearchBar} from 'sentry/views/detectors/datasetConfig/components/releaseSearchBar';
 import {
   getReleasesSeriesQueryOptions,
   transformMetricsResponseToSeries,
 } from 'sentry/views/detectors/datasetConfig/utils/releasesSeries';
+import type {FieldValue} from 'sentry/views/discover/table/types';
+import {FieldValueKind} from 'sentry/views/discover/table/types';
 
 import type {DetectorDatasetConfig} from './base';
 
 type ReleasesSeriesResponse = SessionApiResponse;
 
+const AGGREGATE_OPTIONS: Readonly<Record<string, SelectValue<FieldValue>>> = {
+  'function:crash_free_rate': {
+    label: 'crash_free_rate',
+    value: {
+      kind: FieldValueKind.FUNCTION,
+      meta: {
+        name: 'crash_free_rate',
+        parameters: [
+          {
+            kind: 'column',
+            columnTypes: ['integer', 'string'],
+            defaultValue: SessionField.SESSION,
+            required: true,
+          },
+        ],
+      },
+    },
+  },
+  'field:session': {
+    label: 'session',
+    value: {
+      kind: FieldValueKind.METRICS,
+      meta: {
+        name: SessionField.SESSION,
+        dataType: 'integer',
+      },
+    },
+  },
+  'field:user': {
+    label: 'user',
+    value: {
+      kind: FieldValueKind.METRICS,
+      meta: {
+        name: SessionField.USER,
+        dataType: 'string',
+      },
+    },
+  },
+};
+
+// For crash_free_rate, the aggregate we store in the backend is not user friendly so
+// we use this mapping to display a more user friendly title.
+const AGGREGATE_FUNCTION_MAP: Record<string, string> = {
+  'crash_free_rate(session)':
+    'percentage(sessions_crashed, sessions) AS _crash_rate_alert_aggregate',
+  'crash_free_rate(user)':
+    'percentage(users_crashed, users) AS _crash_rate_alert_aggregate',
+};
+
+const fromApiAggregate = (aggregate: string) => {
+  return (
+    Object.keys(AGGREGATE_FUNCTION_MAP).find(
+      key => AGGREGATE_FUNCTION_MAP[key] === aggregate
+    ) ?? aggregate
+  );
+};
+
+const toApiAggregate = (aggregate: string) => {
+  return AGGREGATE_FUNCTION_MAP[aggregate] ?? aggregate;
+};
+
 export const DetectorReleasesConfig: DetectorDatasetConfig<ReleasesSeriesResponse> = {
   defaultField: ReleasesConfig.defaultField,
-  getAggregateOptions: ReleasesConfig.getTableFieldOptions,
+  getAggregateOptions: () => AGGREGATE_OPTIONS,
   SearchBar: ReleaseSearchBar,
   getSeriesQueryOptions: getReleasesSeriesQueryOptions,
+  toApiAggregate,
+  fromApiAggregate,
   transformSeriesQueryData: (data, aggregate) => {
     return [transformMetricsResponseToSeries(data, aggregate)];
   },

--- a/static/app/views/detectors/datasetConfig/spans.tsx
+++ b/static/app/views/detectors/datasetConfig/spans.tsx
@@ -22,4 +22,6 @@ export const DetectorSpansConfig: DetectorDatasetConfig<SpansSeriesResponse> = {
   transformComparisonSeriesData: data => {
     return [transformEventsStatsComparisonSeries(data)];
   },
+  fromApiAggregate: aggregate => aggregate,
+  toApiAggregate: aggregate => aggregate,
 };

--- a/static/app/views/detectors/datasetConfig/transactions.tsx
+++ b/static/app/views/detectors/datasetConfig/transactions.tsx
@@ -28,4 +28,6 @@ export const DetectorTransactionsConfig: DetectorDatasetConfig<TransactionsSerie
     transformComparisonSeriesData: data => {
       return [transformEventsStatsComparisonSeries(data)];
     },
+    fromApiAggregate: aggregate => aggregate,
+    toApiAggregate: aggregate => aggregate,
   };

--- a/static/app/views/detectors/datasetConfig/types.tsx
+++ b/static/app/views/detectors/datasetConfig/types.tsx
@@ -1,0 +1,7 @@
+export enum DetectorDataset {
+  ERRORS = 'errors',
+  TRANSACTIONS = 'transactions',
+  SPANS = 'spans',
+  RELEASES = 'releases',
+  LOGS = 'logs',
+}

--- a/static/app/views/detectors/datasetConfig/utils/discoverDatasetMap.tsx
+++ b/static/app/views/detectors/datasetConfig/utils/discoverDatasetMap.tsx
@@ -1,5 +1,5 @@
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
-import {DetectorDataset} from 'sentry/views/detectors/components/forms/metric/metricFormData';
+import {DetectorDataset} from 'sentry/views/detectors/datasetConfig/types';
 
 export const DETECTOR_DATASET_TO_DISCOVER_DATASET_MAP: Record<
   DetectorDataset,

--- a/static/app/views/detectors/edit.spec.tsx
+++ b/static/app/views/detectors/edit.spec.tsx
@@ -15,6 +15,8 @@ import {
 
 import OrganizationStore from 'sentry/stores/organizationStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
+import {Dataset} from 'sentry/views/alerts/rules/metric/types';
+import {SnubaQueryType} from 'sentry/views/detectors/components/forms/metric/metricFormData';
 import DetectorEdit from 'sentry/views/detectors/edit';
 
 describe('DetectorEdit', () => {
@@ -237,6 +239,12 @@ describe('DetectorEdit', () => {
   describe('Metric', () => {
     const name = 'Test Metric Detector';
     const mockDetector = MetricDetectorFixture({name, projectId: project.id});
+
+    beforeEach(() => {
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/metrics/data/`,
+      });
+    });
 
     it('allows editing the detector name/environment and saving changes', async () => {
       MockApiClient.addMockResponse({
@@ -585,6 +593,53 @@ describe('DetectorEdit', () => {
         ],
         organization_id: organization.id,
         project_id: project.id,
+      });
+    });
+
+    describe('releases dataset', () => {
+      it('can save crash_free_rate(sessions)', async () => {
+        MockApiClient.addMockResponse({
+          url: `/organizations/${organization.slug}/detectors/${mockDetector.id}/`,
+          body: mockDetector,
+        });
+
+        const updateRequest = MockApiClient.addMockResponse({
+          url: `/organizations/${organization.slug}/detectors/${mockDetector.id}/`,
+          method: 'PUT',
+          body: mockDetector,
+        });
+
+        render(<DetectorEdit />, {
+          organization,
+          initialRouterConfig,
+        });
+
+        expect(await screen.findByRole('link', {name})).toBeInTheDocument();
+
+        // Change dataset to releases
+        const datasetField = screen.getByLabelText('Dataset');
+        await userEvent.click(datasetField);
+        await userEvent.click(screen.getByRole('menuitemradio', {name: 'Releases'}));
+
+        await userEvent.click(screen.getByRole('button', {name: 'Save'}));
+
+        await waitFor(() => {
+          expect(updateRequest).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({
+              data: expect.objectContaining({
+                dataSource: expect.objectContaining({
+                  // Aggreate needs to be transformed to this in order to save correctly
+                  aggregate:
+                    'percentage(sessions_crashed, sessions) AS _crash_rate_alert_aggregate',
+                  dataset: Dataset.METRICS,
+                  eventTypes: [],
+                  queryType: SnubaQueryType.CRASH_RATE,
+                }),
+              }),
+            })
+          );
+        });
       });
     });
   });

--- a/static/app/views/detectors/hooks/useMetricDetectorAnomalyPeriods.spec.tsx
+++ b/static/app/views/detectors/hooks/useMetricDetectorAnomalyPeriods.spec.tsx
@@ -11,7 +11,7 @@ import {
   TimePeriod,
 } from 'sentry/views/alerts/rules/metric/types';
 import {type Anomaly, AnomalyType} from 'sentry/views/alerts/types';
-import {DetectorDataset} from 'sentry/views/detectors/components/forms/metric/metricFormData';
+import {DetectorDataset} from 'sentry/views/detectors/datasetConfig/types';
 import {useMetricDetectorAnomalyPeriods} from 'sentry/views/detectors/hooks/useMetricDetectorAnomalyPeriods';
 import {OrganizationContext} from 'sentry/views/organizationContext';
 

--- a/static/app/views/detectors/hooks/useMetricDetectorAnomalyPeriods.tsx
+++ b/static/app/views/detectors/hooks/useMetricDetectorAnomalyPeriods.tsx
@@ -15,7 +15,7 @@ import {
   HISTORICAL_TIME_PERIOD_MAP,
   HISTORICAL_TIME_PERIOD_MAP_FIVE_MINS,
 } from 'sentry/views/alerts/utils/timePeriods';
-import type {DetectorDataset} from 'sentry/views/detectors/components/forms/metric/metricFormData';
+import {DetectorDataset} from 'sentry/views/detectors/datasetConfig/types';
 import {useMetricDetectorSeries} from 'sentry/views/detectors/hooks/useMetricDetectorSeries';
 
 import type {IncidentPeriod} from './useIncidentMarkers';

--- a/static/app/views/detectors/hooks/useMetricDetectorSeries.tsx
+++ b/static/app/views/detectors/hooks/useMetricDetectorSeries.tsx
@@ -4,8 +4,8 @@ import type {Series} from 'sentry/types/echarts';
 import {useApiQuery, type UseApiQueryOptions} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import {TimePeriod} from 'sentry/views/alerts/rules/metric/types';
-import type {DetectorDataset} from 'sentry/views/detectors/components/forms/metric/metricFormData';
 import {getDatasetConfig} from 'sentry/views/detectors/datasetConfig/getDatasetConfig';
+import {DetectorDataset} from 'sentry/views/detectors/datasetConfig/types';
 import {DETECTOR_DATASET_TO_DISCOVER_DATASET_MAP} from 'sentry/views/detectors/datasetConfig/utils/discoverDatasetMap';
 
 interface UseMetricDetectorSeriesProps {


### PR DESCRIPTION
It turns out that the metrics dataset doesn't actually understand `crash_free_rate()` and we instead need to save `percentage(sessions_crashed, sessions) AS _crash_rate_alert_aggregate` for the aggregate. Since this doesn't work with the rest of the logic that expects the saved aggregate to match the labels, I decided to add some transformation functions to the dataset config that we can use to go between the user-friendly version and the one that's required from the endpoint.

This allows the save request to go through successfully, but there is still more work to be done. The endpoint response is as expected, but from my testing it looks like it isn't quite saved correctly on refresh.