### PR TITLE
fix(widget-legend): Skip prettify for pushing params to URL

### DIFF
--- a/static/app/views/dashboards/widgetLegendNameEncoderDecoder.tsx
+++ b/static/app/views/dashboards/widgetLegendNameEncoderDecoder.tsx
@@ -13,7 +13,7 @@ const WidgetLegendNameEncoderDecoder = {
     return `${seriesName}${SERIES_NAME_DELIMITER}${widgetId}`;
   },
 
-  decodeSeriesNameForLegend(encodedSeriesName: string) {
+  decodeSeriesNameForLegend(encodedSeriesName: string, skipPrettify = false) {
     let seriesName = encodedSeriesName.split(SERIES_NAME_DELIMITER)[0];
     if (!seriesName) {
       return '';
@@ -21,7 +21,7 @@ const WidgetLegendNameEncoderDecoder = {
 
     // If the series name contains an aggregate function, prettify it
     const functionMatch = seriesName.match(AGGREGATE_BASE);
-    if (functionMatch?.[0] && parseFunction(functionMatch[0])) {
+    if (!skipPrettify && functionMatch?.[0] && parseFunction(functionMatch[0])) {
       seriesName = seriesName.replace(
         functionMatch[0],
         prettifyParsedFunction(parseFunction(functionMatch[0])!)

--- a/static/app/views/dashboards/widgetLegendSelectionState.tsx
+++ b/static/app/views/dashboards/widgetLegendSelectionState.tsx
@@ -19,7 +19,7 @@ type LegendSelection = Record<string, boolean>;
 const SERIES_LIST_DELIMITER = ',';
 const WIDGET_ID_DELIMITER = ':';
 
-const SERIES_NAME_DELIMITER = ';';
+const SERIES_NAME_DELIMITER = '|~|';
 
 class WidgetLegendSelectionState {
   dashboard: DashboardDetails | null;
@@ -177,7 +177,7 @@ class WidgetLegendSelectionState {
         .filter(key => !selected[key])
         .map(series =>
           encodeURIComponent(
-            WidgetLegendNameEncoderDecoder.decodeSeriesNameForLegend(series)
+            WidgetLegendNameEncoderDecoder.decodeSeriesNameForLegend(series, true)
           )
         )
         .join(SERIES_LIST_DELIMITER)


### PR DESCRIPTION
The URL params needs the actual value, not the prettified user facing value. This fixes `count(spans)` from not being togglable in charts.
