### PR TITLE
ref(grouping): Pull helper code into callers

### DIFF
--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -18,6 +18,7 @@ from django.utils.functional import cached_property
 
 from sentry import eventtypes
 from sentry.db.models import NodeData
+from sentry.grouping.api import get_grouping_config_dict_for_project
 from sentry.grouping.variants import BaseVariant
 from sentry.interfaces.base import Interface, get_interfaces
 from sentry.issues.grouptype import GroupCategory
@@ -329,9 +330,10 @@ class BaseEvent(metaclass=abc.ABCMeta):
 
     def get_grouping_config(self) -> GroupingConfig:
         """Returns the event grouping config."""
-        from sentry.grouping.api import get_grouping_config_dict_for_event_data
 
-        return get_grouping_config_dict_for_event_data(self.data, self.project)
+        return self.data.get("grouping_config") or get_grouping_config_dict_for_project(
+            self.project
+        )
 
     def get_hashes_and_variants(
         self, config: StrategyConfiguration | None = None

--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -9,7 +9,6 @@ import sentry_sdk
 
 from sentry import options
 from sentry.conf.server import DEFAULT_GROUPING_CONFIG
-from sentry.db.models.fields.node import NodeData
 from sentry.grouping.component import (
     AppGroupingComponent,
     BaseGroupingComponent,
@@ -180,11 +179,6 @@ def get_grouping_config_dict_for_project(project: Project) -> GroupingConfig:
     """
     loader = PrimaryGroupingConfigLoader()
     return loader.get_config_dict(project)
-
-
-def get_grouping_config_dict_for_event_data(data: NodeData, project: Project) -> GroupingConfig:
-    """Returns the grouping config for an event dictionary."""
-    return data.get("grouping_config") or get_grouping_config_dict_for_project(project)
 
 
 def _get_default_base64_enhancements(config_id: str | None = None) -> str:

--- a/src/sentry/grouping/strategies/base.py
+++ b/src/sentry/grouping/strategies/base.py
@@ -262,27 +262,17 @@ class Strategy(Generic[ConcreteInterface]):
         self.variant_processor_func = func
         return func
 
-    def get_grouping_component(
-        self, event: Event, context: GroupingContext
-    ) -> None | BaseGroupingComponent[Any] | ReturnedVariants:
-        """Create a grouping component using this strategy."""
-        interface = event.interfaces.get(self.interface_name)
-
-        if interface is None:
-            return None
-
-        with context:
-            return self(interface, event=event, context=context)
-
     def get_grouping_components(self, event: Event, context: GroupingContext) -> ReturnedVariants:
         """
         Return a dictionary, keyed by variant name, of components produced by this strategy.
         """
-        components_by_variant = self.get_grouping_component(event, context)
-        if components_by_variant is None:
+        interface = event.interfaces.get(self.interface_name)
+
+        if interface is None:
             return {}
 
-        assert isinstance(components_by_variant, dict)
+        with context:
+            components_by_variant = self(interface, event=event, context=context)
 
         final_components_by_variant = {}
         priority_contributing_variants_by_hash = {}


### PR DESCRIPTION
This PR simplifies two places in grouping code where we had a very simple helper which was only called in one place, so that now the code from the helper is just included in its caller: `get_grouping_config_dict_for_event_data` has been absorbed into `Event.get_grouping_config`, and`get_grouping_component` has been absorbed into `get_grouping_components`.

