### PR TITLE
fix(uptime): Make sure timestamps are in actual timestamp format when returning from various EAP endpoints

### DIFF
--- a/src/sentry/snuba/trace.py
+++ b/src/sentry/snuba/trace.py
@@ -412,10 +412,8 @@ def _serialize_columnar_uptime_item(
             if resolved_val is not None:
                 additional_attrs[resolved_column.public_alias] = resolved_val
 
-    span["start_timestamp"] = datetime.fromtimestamp(scheduled_check_time_us / 1_000_000)
-    span["end_timestamp"] = datetime.fromtimestamp(
-        (scheduled_check_time_us + check_duration_us) / 1_000_000
-    )
+    span["start_timestamp"] = scheduled_check_time_us / 1_000_000
+    span["end_timestamp"] = (scheduled_check_time_us + check_duration_us) / 1_000_000
     span["duration"] = check_duration_us / 1_000.0
     description = f"Uptime Check [{check_status}] - {request_url}"
     if http_status_code:

--- a/tests/snuba/api/endpoints/test_organization_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_trace.py
@@ -1,5 +1,4 @@
 import logging
-from datetime import datetime
 from unittest import mock
 from uuid import uuid4
 
@@ -61,8 +60,8 @@ class TestSerializeColumnarUptimeItem(TestCase):
         assert result["duration"] == 500.0
         assert result["name"] == "https://example.com"
         assert result["description"] == "Uptime Check [success] - https://example.com (200)"
-        assert result["start_timestamp"] == datetime.fromtimestamp(1700000000)
-        assert result["end_timestamp"] == datetime.fromtimestamp(1700000000.5)
+        assert result["start_timestamp"] == 1700000000
+        assert result["end_timestamp"] == 1700000000.5
         attrs = result["additional_attributes"]
         assert attrs["guid"] == "check-123"
         assert attrs["check_status"] == "success"


### PR DESCRIPTION
This makes them consistent with other span like data

<!-- Describe your PR here. -->