### PR TITLE
tests(ourlogs): Add basic tests for ourlogs in replays

### DIFF
--- a/static/app/views/replays/detail/ourlogs/index.spec.tsx
+++ b/static/app/views/replays/detail/ourlogs/index.spec.tsx
@@ -1,0 +1,106 @@
+import type {ReactNode} from 'react';
+import {ReplayRecordFixture} from 'sentry-fixture/replayRecord';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {Provider as ReplayContextProvider} from 'sentry/components/replays/replayContext';
+import {ReplayReaderProvider} from 'sentry/utils/replays/playback/providers/replayReaderProvider';
+import ReplayReader from 'sentry/utils/replays/replayReader';
+import OurLogs from 'sentry/views/replays/detail/ourlogs';
+import {useReplayTraces} from 'sentry/views/replays/detail/trace/useReplayTraces';
+
+jest.mock('sentry/views/replays/detail/trace/useReplayTraces');
+
+function Wrappers({
+  children,
+  replay = null,
+}: {
+  children: ReactNode;
+  replay?: ReplayReader | null;
+}) {
+  return (
+    <ReplayReaderProvider replay={replay}>
+      <ReplayContextProvider analyticsContext="" isFetching={false} replay={replay}>
+        {children}
+      </ReplayContextProvider>
+    </ReplayReaderProvider>
+  );
+}
+
+const mockReplay = ReplayReader.factory({
+  replayRecord: ReplayRecordFixture({
+    browser: {
+      name: 'Chrome',
+      version: '110.0.0',
+    },
+    tags: {
+      foo: ['bar', 'baz'],
+      my_custom_tag: ['a wordy value'],
+    },
+  }),
+  errors: [],
+  fetching: false,
+  attachments: [],
+});
+
+describe('OurLogs', function () {
+  beforeEach(function () {
+    // Seeing this error: <tbody> cannot be a child of <div>.
+    jest.spyOn(console, 'error').mockImplementation();
+  });
+
+  afterEach(function () {
+    jest.clearAllMocks();
+  });
+
+  it("should show a placeholder if there's no replay record", function () {
+    jest.mocked(useReplayTraces).mockReturnValue({
+      replayTraces: [],
+      indexComplete: true,
+      indexError: undefined,
+    } as any);
+
+    render(
+      <Wrappers>
+        <OurLogs />
+      </Wrappers>
+    );
+
+    expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
+  });
+
+  it("shows empty if there's no replay traces", function () {
+    jest.mocked(useReplayTraces).mockReturnValue({
+      replayTraces: [],
+      indexComplete: true,
+      indexError: undefined,
+    } as any);
+
+    render(
+      <Wrappers replay={mockReplay}>
+        <OurLogs />
+      </Wrappers>
+    );
+
+    expect(screen.getByText(/No logs found/)).toBeInTheDocument();
+  });
+
+  it("shows logs table if there's replay traces", function () {
+    jest.mocked(useReplayTraces).mockReturnValue({
+      replayTraces: [
+        {timestamp: undefined, traceSlug: 'trace1'},
+        {timestamp: undefined, traceSlug: 'trace2'},
+      ],
+      indexComplete: true,
+      indexError: undefined,
+    } as any);
+
+    render(
+      <Wrappers replay={mockReplay}>
+        <OurLogs />
+      </Wrappers>
+    );
+
+    expect(screen.getByTestId('loading-placeholder')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Some basic tests for ourlogs in replays.

Without the `LogsQueryParamsProvider`, this test will fail starting in #97497.