### PR TITLE
ref(grouping): Remove unused code

### DIFF
--- a/src/sentry/grouping/component.py
+++ b/src/sentry/grouping/component.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 from collections import Counter
 from collections.abc import Generator, Iterator, Sequence
 from functools import cached_property
-from typing import Any, Self
+from typing import Any
 
 from sentry.grouping.utils import hash_from_values
 
@@ -148,13 +148,6 @@ class BaseGroupingComponent[ValuesType: str | int | BaseGroupingComponent[Any]](
             self.values = values
         if contributes is not None:
             self.contributes = contributes
-
-    def shallow_copy(self) -> Self:
-        """Creates a shallow copy."""
-        copy = object.__new__(self.__class__)
-        copy.__dict__.update(self.__dict__)
-        copy.values = list(self.values)
-        return copy
 
     def iter_values(self) -> Generator[str | int]:
         """

--- a/src/sentry/grouping/strategies/base.py
+++ b/src/sentry/grouping/strategies/base.py
@@ -332,7 +332,7 @@ class StrategyConfiguration:
     enhancements_base: str | None = DEFAULT_ENHANCEMENTS_BASE
     fingerprinting_bases: Sequence[str] | None = DEFAULT_GROUPING_FINGERPRINTING_BASES
 
-    def __init__(self, enhancements: str | None = None, **extra: Any):
+    def __init__(self, enhancements: str | None = None):
         if enhancements is None:
             enhancements_instance = Enhancements.from_rules_text("", referrer="strategy_config")
         else:

--- a/src/sentry/grouping/variants.py
+++ b/src/sentry/grouping/variants.py
@@ -96,34 +96,6 @@ class FallbackVariant(BaseVariant):
         return hash_from_values([])
 
 
-class PerformanceProblemVariant(BaseVariant):
-    """
-    Applies only to transaction events! Transactions are not subject to the
-    normal grouping pipeline. Instead, they are fingerprinted by
-    `PerformanceDetector` when the event is saved by `EventManager`. We detect
-    problems, generate some metadata called "evidence" and use that evidence
-    for fingerprinting. The evidence is then stored in `nodestore`. This
-        variant's hash is delegated to the `EventPerformanceProblem` that
-        contains the event and the evidence.
-    """
-
-    type = "performance_problem"
-    description = "performance problem"
-
-    def __init__(self, event_performance_problem: Any):
-        self.event_performance_problem = event_performance_problem
-        self.problem = event_performance_problem.problem
-
-    def get_hash(self) -> str | None:
-        return self.problem.fingerprint
-
-    def _get_metadata_as_dict(self) -> Mapping[str, Any]:
-        problem_data = self.problem.to_dict()
-        evidence_hashes = self.event_performance_problem.evidence_hashes
-
-        return {"evidence": {**problem_data, **evidence_hashes}}
-
-
 class ComponentVariant(BaseVariant):
     """A variant that produces a hash from the `BaseGroupingComponent` it encloses."""
 


### PR DESCRIPTION
This removes a few bits of unused grouping code:

- The last use of the grouping component class's `shallow_copy` method was removed in https://github.com/getsentry/sentry/pull/96379.

- The `StrategyConfiguration` constructor doesn't use its `**extras` argument, and nothing that calls it passes any unexpected parameters.

- The only use of the `PerformanceProblemVariant` class was removed in https://github.com/getsentry/sentry/pull/97016.