### PR TITLE
fix(autofix): Identify profiles by transaction name instead of span id

### DIFF
--- a/src/sentry/seer/autofix/autofix_tools.py
+++ b/src/sentry/seer/autofix/autofix_tools.py
@@ -8,8 +8,8 @@ def get_profile_details(
     project_id: int,
     profile_id: str,
     is_continuous: bool = False,
-    precise_start_ts: float = None,
-    precise_finish_ts: float = None,
+    precise_start_ts: float | None = None,
+    precise_finish_ts: float | None = None,
 ):
     profile = fetch_profile_data(
         profile_id=profile_id,

--- a/src/sentry/seer/autofix/autofix_tools.py
+++ b/src/sentry/seer/autofix/autofix_tools.py
@@ -1,22 +1,28 @@
-import orjson
-
 from sentry import eventstore
 from sentry.api.serializers import EventSerializer, serialize
-from sentry.profiles.utils import get_from_profiling_service
-from sentry.seer.explorer.utils import _convert_profile_to_execution_tree
+from sentry.seer.explorer.utils import _convert_profile_to_execution_tree, fetch_profile_data
 
 
-def get_profile_details(organization_id: int, project_id: int, profile_id: str):
-    response = get_from_profiling_service(
-        "GET",
-        f"/organizations/{organization_id}/projects/{project_id}/profiles/{profile_id}",
-        params={"format": "sample"},
+def get_profile_details(
+    organization_id: int,
+    project_id: int,
+    profile_id: str,
+    is_continuous: bool = False,
+    precise_start_ts: float = None,
+    precise_finish_ts: float = None,
+):
+    profile = fetch_profile_data(
+        profile_id=profile_id,
+        organization_id=organization_id,
+        project_id=project_id,
+        start_ts=precise_start_ts,
+        end_ts=precise_finish_ts,
+        is_continuous=is_continuous,
     )
 
-    if response.status == 200:
-        profile = orjson.loads(response.data)
+    if profile:
         execution_tree = _convert_profile_to_execution_tree(profile)
-        output = (
+        return (
             None
             if not execution_tree
             else {
@@ -24,7 +30,6 @@ def get_profile_details(organization_id: int, project_id: int, profile_id: str):
                 "execution_tree": execution_tree,
             }
         )
-        return output
 
 
 def get_error_event_details(project_id: int, event_id: str):


### PR DESCRIPTION
Use a looser matching condition to find profiles. I think the spans dataset does not include error spans, breaking the old logic.

Also refactor the profile fetching RPC tool to use the shared util and support continuous profiles.