### PR TITLE
feat(ourlogs): Change max period for logs to 30d

### DIFF
--- a/static/app/components/timeRangeSelector/index.tsx
+++ b/static/app/components/timeRangeSelector/index.tsx
@@ -332,7 +332,7 @@ export function TimeRangeSelector({
           }}
           searchPlaceholder={
             (searchPlaceholder ?? disallowArbitraryRelativeRanges)
-              ? t('Search…')
+              ? (searchPlaceholder ?? t('Search…'))
               : t('Custom range: 2h, 4d, 8w…')
           }
           options={getOptions(items)}

--- a/static/app/views/explore/logs/content.tsx
+++ b/static/app/views/explore/logs/content.tsx
@@ -55,8 +55,7 @@ function FeedbackButton() {
 
 export default function LogsContent() {
   const organization = useOrganization();
-  const {defaultPeriod, maxPickableDays, relativeOptions} =
-    logsPickableDays(organization);
+  const {defaultPeriod, maxPickableDays, relativeOptions} = logsPickableDays();
 
   return (
     <SentryDocumentTitle title={t('Logs')} orgSlug={organization?.slug}>

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -290,6 +290,7 @@ export function LogsTabContent({
                 defaultPeriod={defaultPeriod}
                 maxPickableDays={maxPickableDays}
                 relativeOptions={relativeOptions}
+                searchPlaceholder={t('Custom range: 2h, 4d, 3w')}
               />
             </StyledPageFilterBar>
             <TraceItemSearchQueryBuilder {...tracesItemSearchQueryBuilderProps} />

--- a/static/app/views/explore/logs/utils.tsx
+++ b/static/app/views/explore/logs/utils.tsx
@@ -229,20 +229,18 @@ export function adjustLogTraceID(traceID: string) {
   return traceID.replace(/-/g, '');
 }
 
-export function logsPickableDays(organization: Organization): PickableDays {
+export function logsPickableDays(): PickableDays {
   const relativeOptions: Array<[string, ReactNode]> = [
     ['1h', t('Last hour')],
     ['24h', t('Last 24 hours')],
     ['7d', t('Last 7 days')],
+    ['14d', t('Last 14 days')],
+    ['30d', t('Last 30 days')],
   ];
-
-  if (organization.features.includes('visibility-explore-range-high')) {
-    relativeOptions.push(['14d', t('Last 14 days')]);
-  }
 
   return {
     defaultPeriod: '24h',
-    maxPickableDays: 14,
+    maxPickableDays: 30,
     relativeOptions: ({
       arbitraryOptions,
     }: {


### PR DESCRIPTION
### Summary
We are extending the maximum range of logs to 30d, and no longer differentiating between plans. Default period remains 24h.

#### Screenshot
<img width="567" height="408" alt="Screenshot 2025-08-08 at 6 11 32 PM" src="https://github.com/user-attachments/assets/a51f3b95-fe17-4b3c-b024-c92c18f05d47" />
