### PR TITLE
ref(grouping): remove line and column numbers from similar issues stacktrace diff

### DIFF
--- a/static/app/components/events/interfaces/crashContent/stackTrace/rawContent.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/rawContent.spec.tsx
@@ -17,7 +17,8 @@ describe('RawStacktraceContent', () => {
             function: 'run',
             filename: 'QueuedThreadPool.java',
             lineNo: 582,
-          })
+          }),
+          true
         )
       ).toBe(
         '    at org.mortbay.thread.QueuedThreadPool$PoolThread.run(QueuedThreadPool.java:582)'
@@ -30,7 +31,8 @@ describe('RawStacktraceContent', () => {
             module: 'org.mortbay.thread.QueuedThreadPool$PoolThread',
             function: 'run',
             filename: 'QueuedThreadPool.java',
-          })
+          }),
+          false
         )
       ).toBe(
         '    at org.mortbay.thread.QueuedThreadPool$PoolThread.run(QueuedThreadPool.java)'
@@ -43,7 +45,8 @@ describe('RawStacktraceContent', () => {
             module: 'org.mortbay.thread.QueuedThreadPool$PoolThread',
             function: 'run',
             filename: 'QueuedThreadPool.java',
-          })
+          }),
+          false
         )
       ).toBe(
         '    at org.mortbay.thread.QueuedThreadPool$PoolThread.run(QueuedThreadPool.java)'

--- a/static/app/components/events/interfaces/crashContent/stackTrace/rawContent.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/rawContent.spec.tsx
@@ -32,7 +32,7 @@ describe('RawStacktraceContent', () => {
             function: 'run',
             filename: 'QueuedThreadPool.java',
           }),
-          false
+          true
         )
       ).toBe(
         '    at org.mortbay.thread.QueuedThreadPool$PoolThread.run(QueuedThreadPool.java)'
@@ -46,7 +46,7 @@ describe('RawStacktraceContent', () => {
             function: 'run',
             filename: 'QueuedThreadPool.java',
           }),
-          false
+          true
         )
       ).toBe(
         '    at org.mortbay.thread.QueuedThreadPool$PoolThread.run(QueuedThreadPool.java)'

--- a/static/app/components/events/interfaces/crashContent/stackTrace/rawContent.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/rawContent.tsx
@@ -3,7 +3,7 @@ import type {ExceptionValue, Frame} from 'sentry/types/event';
 import type {StacktraceType} from 'sentry/types/stacktrace';
 import {defined} from 'sentry/utils';
 
-function getJavaScriptFrame(frame: Frame, includeLocation = true): string {
+function getJavaScriptFrame(frame: Frame, includeLocation: boolean): string {
   let result = '';
   if (defined(frame.function)) {
     result += '  at ' + frame.function + '(';
@@ -25,7 +25,7 @@ function getJavaScriptFrame(frame: Frame, includeLocation = true): string {
   return result;
 }
 
-function getRubyFrame(frame: Frame, includeLocation = true): string {
+function getRubyFrame(frame: Frame, includeLocation: boolean): string {
   let result = '  from ';
   if (defined(frame.filename)) {
     result += frame.filename;
@@ -46,7 +46,7 @@ function getRubyFrame(frame: Frame, includeLocation = true): string {
   return result;
 }
 
-function getPHPFrame(frame: Frame, idx: number, includeLocation = true): string {
+function getPHPFrame(frame: Frame, idx: number, includeLocation: boolean): string {
   const funcName = frame.function === 'null' ? '{main}' : frame.function;
   let result = `#${idx} ${frame.filename || frame.module}`;
   if (includeLocation && defined(frame.lineNo) && frame.lineNo >= 0) {
@@ -56,7 +56,7 @@ function getPHPFrame(frame: Frame, idx: number, includeLocation = true): string 
   return result;
 }
 
-function getPythonFrame(frame: Frame, includeLocation = true): string {
+function getPythonFrame(frame: Frame, includeLocation: boolean): string {
   let result = '';
   if (defined(frame.filename)) {
     result += '  File "' + frame.filename + '"';
@@ -84,7 +84,7 @@ function getPythonFrame(frame: Frame, includeLocation = true): string {
   return result;
 }
 
-export function getJavaFrame(frame: Frame, includeLocation = true): string {
+export function getJavaFrame(frame: Frame, includeLocation: boolean): string {
   let result = '    at';
 
   if (defined(frame.module)) {
@@ -106,7 +106,7 @@ export function getJavaFrame(frame: Frame, includeLocation = true): string {
 function getDartFrame(
   frame: Frame,
   frameIdxFromEnd: number,
-  includeLocation = true
+  includeLocation: boolean
 ): string {
   let result = `  #${frameIdxFromEnd}`;
 
@@ -138,7 +138,7 @@ function ljust(str: string, len: number) {
   return str + new Array(Math.max(0, len - str.length) + 1).join(' ');
 }
 
-function getNativeFrame(frame: Frame, includeLocation = true): string {
+function getNativeFrame(frame: Frame, includeLocation: boolean): string {
   let result = '  ';
   if (defined(frame.package)) {
     result += ljust(trimPackage(frame.package), 20);
@@ -179,7 +179,7 @@ function getFrame(
   frameIdx: number,
   frameIdxFromEnd: number,
   platform: string | undefined,
-  includeLocation = true
+  includeLocation: boolean
 ): string {
   if (frame.platform) {
     platform = frame.platform;

--- a/static/app/components/events/interfaces/crashContent/stackTrace/rawContent.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/rawContent.tsx
@@ -3,7 +3,7 @@ import type {ExceptionValue, Frame} from 'sentry/types/event';
 import type {StacktraceType} from 'sentry/types/stacktrace';
 import {defined} from 'sentry/utils';
 
-function getJavaScriptFrame(frame: Frame): string {
+function getJavaScriptFrame(frame: Frame, includeLocation = true): string {
   let result = '';
   if (defined(frame.function)) {
     result += '  at ' + frame.function + '(';
@@ -15,17 +15,17 @@ function getJavaScriptFrame(frame: Frame): string {
   } else if (defined(frame.module)) {
     result += frame.module;
   }
-  if (defined(frame.lineNo) && frame.lineNo >= 0) {
+  if (defined(frame.lineNo) && frame.lineNo >= 0 && includeLocation) {
     result += ':' + frame.lineNo;
   }
-  if (defined(frame.colNo) && frame.colNo >= 0) {
+  if (defined(frame.colNo) && frame.colNo >= 0 && includeLocation) {
     result += ':' + frame.colNo;
   }
   result += ')';
   return result;
 }
 
-function getRubyFrame(frame: Frame): string {
+function getRubyFrame(frame: Frame, includeLocation = true): string {
   let result = '  from ';
   if (defined(frame.filename)) {
     result += frame.filename;
@@ -34,10 +34,10 @@ function getRubyFrame(frame: Frame): string {
   } else {
     result += '?';
   }
-  if (defined(frame.lineNo) && frame.lineNo >= 0) {
+  if (defined(frame.lineNo) && frame.lineNo >= 0 && includeLocation) {
     result += ':' + frame.lineNo;
   }
-  if (defined(frame.colNo) && frame.colNo >= 0) {
+  if (defined(frame.colNo) && frame.colNo >= 0 && includeLocation) {
     result += ':' + frame.colNo;
   }
   if (defined(frame.function)) {
@@ -51,7 +51,7 @@ function getPHPFrame(frame: Frame, idx: number): string {
   return `#${idx} ${frame.filename || frame.module}(${frame.lineNo}): ${funcName}`;
 }
 
-function getPythonFrame(frame: Frame): string {
+function getPythonFrame(frame: Frame, includeLocation = true): string {
   let result = '';
   if (defined(frame.filename)) {
     result += '  File "' + frame.filename + '"';
@@ -60,10 +60,10 @@ function getPythonFrame(frame: Frame): string {
   } else {
     result += '  ?';
   }
-  if (defined(frame.lineNo) && frame.lineNo >= 0) {
+  if (defined(frame.lineNo) && frame.lineNo >= 0 && includeLocation) {
     result += ', line ' + frame.lineNo;
   }
-  if (defined(frame.colNo) && frame.colNo >= 0) {
+  if (defined(frame.colNo) && frame.colNo >= 0 && includeLocation) {
     result += ', col ' + frame.colNo;
   }
   if (defined(frame.function)) {
@@ -79,7 +79,7 @@ function getPythonFrame(frame: Frame): string {
   return result;
 }
 
-export function getJavaFrame(frame: Frame): string {
+export function getJavaFrame(frame: Frame, includeLocation = true): string {
   let result = '    at';
 
   if (defined(frame.module)) {
@@ -90,7 +90,7 @@ export function getJavaFrame(frame: Frame): string {
   }
   if (defined(frame.filename)) {
     result += '(' + frame.filename;
-    if (defined(frame.lineNo) && frame.lineNo >= 0) {
+    if (defined(frame.lineNo) && frame.lineNo >= 0 && includeLocation) {
       result += ':' + frame.lineNo;
     }
     result += ')';
@@ -98,7 +98,11 @@ export function getJavaFrame(frame: Frame): string {
   return result;
 }
 
-function getDartFrame(frame: Frame, frameIdxFromEnd: number): string {
+function getDartFrame(
+  frame: Frame,
+  frameIdxFromEnd: number,
+  includeLocation = true
+): string {
   let result = `  #${frameIdxFromEnd}`;
 
   if (frame.function === '<asynchronous suspension>') {
@@ -112,10 +116,10 @@ function getDartFrame(frame: Frame, frameIdxFromEnd: number): string {
     result += ' (';
 
     result += frame.absPath;
-    if (defined(frame.lineNo) && frame.lineNo >= 0) {
+    if (defined(frame.lineNo) && frame.lineNo >= 0 && includeLocation) {
       result += ':' + frame.lineNo;
     }
-    if (defined(frame.colNo) && frame.colNo >= 0) {
+    if (defined(frame.colNo) && frame.colNo >= 0 && includeLocation) {
       result += ':' + frame.colNo;
     }
 
@@ -129,7 +133,7 @@ function ljust(str: string, len: number) {
   return str + new Array(Math.max(0, len - str.length) + 1).join(' ');
 }
 
-function getNativeFrame(frame: Frame): string {
+function getNativeFrame(frame: Frame, includeLocation = true): string {
   let result = '  ';
   if (defined(frame.package)) {
     result += ljust(trimPackage(frame.package), 20);
@@ -140,7 +144,7 @@ function getNativeFrame(frame: Frame): string {
   result += ' ' + (frame.function || frame.symbolAddr);
   if (defined(frame.filename)) {
     result += ' (' + frame.filename;
-    if (defined(frame.lineNo) && frame.lineNo >= 0) {
+    if (defined(frame.lineNo) && frame.lineNo >= 0 && includeLocation) {
       result += ':' + frame.lineNo;
     }
     result += ')';
@@ -169,32 +173,33 @@ function getFrame(
   frame: Frame,
   frameIdx: number,
   frameIdxFromEnd: number,
-  platform: string | undefined
+  platform: string | undefined,
+  includeLocation = true
 ): string {
   if (frame.platform) {
     platform = frame.platform;
   }
   switch (platform) {
     case 'javascript':
-      return getJavaScriptFrame(frame);
+      return getJavaScriptFrame(frame, includeLocation);
     case 'ruby':
-      return getRubyFrame(frame);
+      return getRubyFrame(frame, includeLocation);
     case 'php':
       return getPHPFrame(frame, frameIdx);
     case 'python':
-      return getPythonFrame(frame);
+      return getPythonFrame(frame, includeLocation);
     case 'java':
-      return getJavaFrame(frame);
+      return getJavaFrame(frame, includeLocation);
     case 'dart':
-      return getDartFrame(frame, frameIdxFromEnd);
+      return getDartFrame(frame, frameIdxFromEnd, includeLocation);
     case 'objc':
     // fallthrough
     case 'cocoa':
     // fallthrough
     case 'native':
-      return getNativeFrame(frame);
+      return getNativeFrame(frame, includeLocation);
     default:
-      return getPythonFrame(frame);
+      return getPythonFrame(frame, includeLocation);
   }
 }
 
@@ -202,7 +207,8 @@ export default function displayRawContent(
   data: StacktraceType | null,
   platform?: string,
   exception?: ExceptionValue,
-  hasSimilarityEmbeddingsFeature = false
+  hasSimilarityEmbeddingsFeature = false,
+  includeLocation = true
 ) {
   const rawFrames = data?.frames || [];
 
@@ -214,7 +220,13 @@ export default function displayRawContent(
     : rawFrames;
 
   const frames = framesToUse.map((frame, frameIdx) =>
-    getFrame(frame, frameIdx, framesToUse.length - frameIdx - 1, platform)
+    getFrame(
+      frame,
+      frameIdx,
+      framesToUse.length - frameIdx - 1,
+      platform,
+      includeLocation
+    )
   );
 
   if (platform !== 'python') {

--- a/static/app/components/events/interfaces/crashContent/stackTrace/rawContent.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/rawContent.tsx
@@ -46,9 +46,14 @@ function getRubyFrame(frame: Frame, includeLocation = true): string {
   return result;
 }
 
-function getPHPFrame(frame: Frame, idx: number): string {
+function getPHPFrame(frame: Frame, idx: number, includeLocation = true): string {
   const funcName = frame.function === 'null' ? '{main}' : frame.function;
-  return `#${idx} ${frame.filename || frame.module}(${frame.lineNo}): ${funcName}`;
+  let result = `#${idx} ${frame.filename || frame.module}`;
+  if (includeLocation && defined(frame.lineNo) && frame.lineNo >= 0) {
+    result += `(${frame.lineNo})`;
+  }
+  result += `: ${funcName}`;
+  return result;
 }
 
 function getPythonFrame(frame: Frame, includeLocation = true): string {
@@ -185,7 +190,7 @@ function getFrame(
     case 'ruby':
       return getRubyFrame(frame, includeLocation);
     case 'php':
-      return getPHPFrame(frame, frameIdx);
+      return getPHPFrame(frame, frameIdx, includeLocation);
     case 'python':
       return getPythonFrame(frame, includeLocation);
     case 'java':

--- a/static/app/components/issueDiff/index.tsx
+++ b/static/app/components/issueDiff/index.tsx
@@ -87,10 +87,18 @@ class IssueDiff extends Component<Props, State> {
           this.fetchEvent(baseIssueId, baseEventId ?? 'latest'),
           this.fetchEvent(targetIssueId, targetEventId ?? 'latest'),
         ]);
-
+        const includeLocation = false;
         const [baseEvent, targetEvent] = await Promise.all([
-          getStacktraceBody(baseEventData, hasSimilarityEmbeddingsFeature),
-          getStacktraceBody(targetEventData, hasSimilarityEmbeddingsFeature),
+          getStacktraceBody(
+            baseEventData,
+            hasSimilarityEmbeddingsFeature,
+            includeLocation
+          ),
+          getStacktraceBody(
+            targetEventData,
+            hasSimilarityEmbeddingsFeature,
+            includeLocation
+          ),
         ]);
 
         this.setState({

--- a/static/app/utils/getStacktraceBody.tsx
+++ b/static/app/utils/getStacktraceBody.tsx
@@ -3,7 +3,8 @@ import type {Event} from 'sentry/types/event';
 
 export default function getStacktraceBody(
   event: Event,
-  hasSimilarityEmbeddingsFeature = false
+  hasSimilarityEmbeddingsFeature = false,
+  includeLocation = true
 ) {
   if (!event?.entries) {
     return [];
@@ -40,7 +41,8 @@ export default function getStacktraceBody(
         value.stacktrace,
         event.platform,
         value,
-        hasSimilarityEmbeddingsFeature
+        hasSimilarityEmbeddingsFeature,
+        includeLocation
       )
     )
     .reduce((acc: any, value: any) => acc.concat(value), []);


### PR DESCRIPTION
Line and column numbers aren't considered in grouping so there is no need to highlight them in the stacktrace diff for similar issues. 

Added an `includeLocation` option to the `getFrame` functions to turn off getting line/column numbers.

Before:
<img width="1413" height="686" alt="include_location_true" src="https://github.com/user-attachments/assets/bab8582c-6348-4232-b759-442d7d0fefa6" />

After:
<img width="1421" height="687" alt="include_location_false" src="https://github.com/user-attachments/assets/93566aec-a254-4b65-9c6f-b1f8ac503138" />
