### PR TITLE
ref(grouping): Simplify recursive frame handling

### DIFF
--- a/src/sentry/grouping/strategies/configurations.py
+++ b/src/sentry/grouping/strategies/configurations.py
@@ -27,11 +27,6 @@ BASE_CONFIG_CLASS = create_strategy_configuration_class(
     ],
     delegates=["frame:v1", "stacktrace:v1", "single-exception:v1"],
     initial_context={
-        # This is a flag that can be used by any delegate to respond to
-        # a detected recursion.  This is currently used by the frame
-        # strategy to disable itself.  Recursion is detected by the outer
-        # strategy.
-        "is_recursion": False,
         # Perform automatic message trimming and parameter substitution in the message strategy.
         # (Should be kept on - only configurable so it can be turned off in tests.)
         "normalize_message": True,

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -370,9 +370,6 @@ def frame(
         ):
             frame_component.update(contributes=False, hint="ignored low quality javascript frame")
 
-    if context["is_recursion"]:
-        frame_component.update(contributes=False, hint="ignored due to recursion")
-
     return {variant_name: frame_component}
 
 
@@ -438,8 +435,9 @@ def _single_stacktrace_variant(
 
     for frame in frames:
         with context:
-            context["is_recursion"] = _is_recursive_frame(frame, prev_frame)
             frame_component = context.get_single_grouping_component(frame, event=event, **kwargs)
+            if _is_recursive_frame(frame, prev_frame):
+                frame_component.update(contributes=False, hint="ignored due to recursion")
 
         if variant_name == "app":
             if frame.in_app:

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -434,10 +434,9 @@ def _single_stacktrace_variant(
     found_in_app_frame = False
 
     for frame in frames:
-        with context:
-            frame_component = context.get_single_grouping_component(frame, event=event, **kwargs)
-            if _is_recursive_frame(frame, prev_frame):
-                frame_component.update(contributes=False, hint="ignored due to recursion")
+        frame_component = context.get_single_grouping_component(frame, event=event, **kwargs)
+        if _is_recursive_frame(frame, prev_frame):
+            frame_component.update(contributes=False, hint="ignored due to recursion")
 
         if variant_name == "app":
             if frame.in_app:


### PR DESCRIPTION
In our grouping algorithm, we ignore recursion, that is to say, we count _n_ consecutive copies of a frame the same as if there were just 1 copy. Currently, in order to do this, we have the stacktrace strategy compare successive frames, and if recursion is detected, we add a flag to the grouping context so that all frames but the first in a recursion mark themselves as non-contributing. This works, but is more complicated than it needs to be.

To simplify things, this PR lets the stacktrace component mark recursive frames non-contributing rather than having the frames do it themselves. This saves us from having to transmit that data through to the frame strategy, and therefore means we don't need to include the data in the grouping context.