### PR TITLE
fix(replays): Remove one too many of the same aliases

### DIFF
--- a/src/sentry/replays/query.py
+++ b/src/sentry/replays/query.py
@@ -232,7 +232,10 @@ def query_replays_dataset_tagkey_values(
     if tag_substr_query:
         where.append(
             Condition(
-                Function("positionCaseInsensitive", parameters=[grouped_column, tag_substr_query]),
+                Function(
+                    "positionCaseInsensitive",
+                    parameters=[grouped_column, tag_substr_query],
+                ),
                 Op.NEQ,
                 0,
             )
@@ -269,7 +272,9 @@ def query_replays_dataset_tagkey_values(
         tenant_ids=tenant_ids,
     )
     return raw_snql_query(
-        snuba_request, referrer="replays.query.query_replays_dataset_tagkey_values", use_cache=True
+        snuba_request,
+        referrer="replays.query.query_replays_dataset_tagkey_values",
+        use_cache=True,
     )
 
 
@@ -280,7 +285,10 @@ def anyIfNonZeroIP(
 ) -> Function:
     return Function(
         "anyIf",
-        parameters=[Column(column_name), Function("greater", parameters=[Column(column_name), 0])],
+        parameters=[
+            Column(column_name),
+            Function("greater", parameters=[Column(column_name), 0]),
+        ],
         alias=alias or column_name if aliased else None,
     )
 
@@ -305,7 +313,8 @@ def _sorted_aggregated_urls(agg_urls_column, alias):
         "arrayMap",
         parameters=[
             Lambda(
-                ["url_tuple"], Function("tupleElement", parameters=[Identifier("url_tuple"), 2])
+                ["url_tuple"],
+                Function("tupleElement", parameters=[Identifier("url_tuple"), 2]),
             ),
             agg_urls_column,
         ],
@@ -314,7 +323,8 @@ def _sorted_aggregated_urls(agg_urls_column, alias):
         "arrayMap",
         parameters=[
             Lambda(
-                ["url_tuple"], Function("tupleElement", parameters=[Identifier("url_tuple"), 1])
+                ["url_tuple"],
+                Function("tupleElement", parameters=[Identifier("url_tuple"), 1]),
             ),
             agg_urls_column,
         ],
@@ -450,7 +460,11 @@ def _collect_event_ids(alias, ids_type_list):
         parameters=[
             Lambda(
                 ["error_id_no_dashes"],
-                _strip_uuid_dashes("error_id_no_dashes", Identifier("error_id_no_dashes")),
+                _strip_uuid_dashes(
+                    "error_id_no_dashes",
+                    Identifier("error_id_no_dashes"),
+                    aliased=False,
+                ),
             ),
             Function("flatten", [id_types_to_aggregate]),
         ],
@@ -558,7 +572,11 @@ FIELD_QUERY_ALIAS_MAP: dict[str, list[str]] = {
     "browser": ["browser_name", "browser_version"],
     "device": ["device_name", "device_brand", "device_family", "device_model"],
     "sdk": ["sdk_name", "sdk_version"],
-    "ota_updates": ["ota_updates_channel", "ota_updates_runtime_version", "ota_updates_update_id"],
+    "ota_updates": [
+        "ota_updates_channel",
+        "ota_updates_runtime_version",
+        "ota_updates_update_id",
+    ],
     "tags": ["tk", "tv"],
     # Nested fields.  Useful for selecting searchable fields.
     "user.id": ["user_id"],
@@ -634,7 +652,10 @@ QUERY_ALIAS_COLUMN_MAP = {
     "replay_id": Column("replay_id"),
     "agg_project_id": Function(
         "anyIf",
-        parameters=[Column("project_id"), Function("equals", parameters=[Column("segment_id"), 0])],
+        parameters=[
+            Column("project_id"),
+            Function("equals", parameters=[Column("segment_id"), 0]),
+        ],
         alias="agg_project_id",
     ),
     "trace_ids": Function(
@@ -762,7 +783,9 @@ QUERY_ALIAS_COLUMN_MAP = {
     "click.text": Function("groupArray", parameters=[Column("click_text")], alias="click_text"),
     "click.title": Function("groupArray", parameters=[Column("click_title")], alias="click_title"),
     "click.component_name": Function(
-        "groupArray", parameters=[Column("click_component_name")], alias="click_component_name"
+        "groupArray",
+        parameters=[Column("click_component_name")],
+        alias="click_component_name",
     ),
     "error_ids": _collect_new_errors(),
     "warning_ids": _collect_event_ids("warning_ids", ["warning_id"]),


### PR DESCRIPTION
Remove aliases for `_strip_uuid_dashes` since we're calling this function many times which adds too many of the same aliases in the query and it ends up confusing ClickHouse 25.3, blocking our upgrade to this version of ClickHouse.

https://github.com/getsentry/snuba/pull/7339