### PR TITLE
chore(launchpad): Return artifact URL upon creation

### DIFF
--- a/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
+++ b/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
@@ -190,6 +190,6 @@ class ProjectPreprodArtifactAssembleEndpoint(ProjectEndpoint):
             {
                 "state": ChunkFileState.CREATED,
                 "missingChunks": [],
-                "artifact_url": artifact_url,
+                "artifactUrl": artifact_url,
             }
         )

--- a/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
+++ b/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
@@ -188,7 +188,7 @@ class ProjectPreprodArtifactAssembleEndpoint(ProjectEndpoint):
 
         return Response(
             {
-                "state": ChunkFileState.OK,
+                "state": ChunkFileState.CREATED,
                 "missingChunks": [],
                 "artifact_url": artifact_url,
             }

--- a/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
+++ b/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
@@ -14,6 +14,7 @@ from sentry.debug_files.upload import find_missing_chunks
 from sentry.models.orgauthtoken import is_org_auth_token_auth, update_org_auth_token_last_used
 from sentry.preprod.analytics import PreprodArtifactApiAssembleEvent
 from sentry.preprod.tasks import assemble_preprod_artifact, create_preprod_artifact
+from sentry.preprod.url_utils import get_preprod_artifact_url
 from sentry.tasks.assemble import ChunkFileState
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
@@ -183,6 +184,12 @@ class ProjectPreprodArtifactAssembleEndpoint(ProjectEndpoint):
             if is_org_auth_token_auth(request.auth):
                 update_org_auth_token_last_used(request.auth, [project.id])
 
+        artifact_url = get_preprod_artifact_url(project.organization_id, artifact_id)
+
         return Response(
-            {"state": ChunkFileState.OK, "missingChunks": [], "artifactId": artifact_id}
+            {
+                "state": ChunkFileState.OK,
+                "missingChunks": [],
+                "artifact_url": artifact_url,
+            }
         )

--- a/src/sentry/preprod/url_utils.py
+++ b/src/sentry/preprod/url_utils.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from sentry.models.organization import Organization
 
 
-def get_preprod_artifact_url(organization_id: int, artifact_id: int) -> str:
+def get_preprod_artifact_url(organization_id: int, artifact_id: str) -> str:
     """
     Build a region/customer-domain aware absolute URL for the preprod artifact UI.
     """

--- a/src/sentry/preprod/url_utils.py
+++ b/src/sentry/preprod/url_utils.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from sentry.models.organization import Organization
+
+
+def get_preprod_artifact_url(organization_id: int, artifact_id: int) -> str:
+    """
+    Build a region/customer-domain aware absolute URL for the preprod artifact UI.
+    """
+    organization: Organization = Organization.objects.get_from_cache(id=organization_id)
+
+    path = f"/organizations/{organization.slug}/preprod/internal/{artifact_id}"
+    return organization.absolute_url(path)

--- a/tests/sentry/preprod/api/endpoints/test_organization_preprod_artifact_assemble.py
+++ b/tests/sentry/preprod/api/endpoints/test_organization_preprod_artifact_assemble.py
@@ -374,7 +374,7 @@ class ProjectPreprodArtifactAssembleTest(APITestCase):
             HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
         )
         assert response.status_code == 200, response.content
-        assert response.data["state"] == ChunkFileState.OK
+        assert response.data["state"] == ChunkFileState.CREATED
         assert set(response.data["missingChunks"]) == set()
         assert response.data["artifactId"] == artifact_id
 
@@ -440,7 +440,7 @@ class ProjectPreprodArtifactAssembleTest(APITestCase):
             HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
         )
         assert response.status_code == 200, response.content
-        assert response.data["state"] == ChunkFileState.OK
+        assert response.data["state"] == ChunkFileState.CREATED
         assert set(response.data["missingChunks"]) == set()
         assert response.data["artifactId"] == artifact_id
 
@@ -500,7 +500,7 @@ class ProjectPreprodArtifactAssembleTest(APITestCase):
         )
 
         assert response.status_code == 200, response.content
-        assert response.data["state"] == ChunkFileState.OK
+        assert response.data["state"] == ChunkFileState.CREATED
 
     def test_assemble_response(self) -> None:
         content = b"test response content"
@@ -518,7 +518,7 @@ class ProjectPreprodArtifactAssembleTest(APITestCase):
         )
 
         assert response.status_code == 200, response.content
-        assert response.data["state"] == ChunkFileState.OK
+        assert response.data["state"] == ChunkFileState.CREATED
 
     def test_assemble_with_pending_deletion_project(self) -> None:
         self.project.status = ObjectStatus.PENDING_DELETION
@@ -637,7 +637,7 @@ class ProjectPreprodArtifactAssembleTest(APITestCase):
 
         # Even if assembly status exists, endpoint doesn't check it
         set_assemble_status(
-            AssembleTask.PREPROD_ARTIFACT, self.project.id, checksum, ChunkFileState.OK
+            AssembleTask.PREPROD_ARTIFACT, self.project.id, checksum, ChunkFileState.CREATED
         )
 
         response = self.client.post(
@@ -671,7 +671,7 @@ class ProjectPreprodArtifactAssembleTest(APITestCase):
 
         # Even if task sets status, this endpoint doesn't read it
         set_assemble_status(
-            AssembleTask.PREPROD_ARTIFACT, self.project.id, total_checksum, ChunkFileState.OK
+            AssembleTask.PREPROD_ARTIFACT, self.project.id, total_checksum, ChunkFileState.CREATED
         )
 
         response = self.client.post(

--- a/tests/sentry/preprod/api/endpoints/test_organization_preprod_artifact_assemble.py
+++ b/tests/sentry/preprod/api/endpoints/test_organization_preprod_artifact_assemble.py
@@ -376,7 +376,8 @@ class ProjectPreprodArtifactAssembleTest(APITestCase):
         assert response.status_code == 200, response.content
         assert response.data["state"] == ChunkFileState.CREATED
         assert set(response.data["missingChunks"]) == set()
-        assert response.data["artifactId"] == artifact_id
+        expected_url = f"/organizations/{self.organization.slug}/preprod/internal/{artifact_id}"
+        assert expected_url in response.data["artifactUrl"]
 
         mock_create_preprod_artifact.assert_called_once_with(
             org_id=self.organization.id,
@@ -442,7 +443,8 @@ class ProjectPreprodArtifactAssembleTest(APITestCase):
         assert response.status_code == 200, response.content
         assert response.data["state"] == ChunkFileState.CREATED
         assert set(response.data["missingChunks"]) == set()
-        assert response.data["artifactId"] == artifact_id
+        expected_url = f"/organizations/{self.organization.slug}/preprod/internal/{artifact_id}"
+        assert expected_url in response.data["artifactUrl"]
 
         mock_create_preprod_artifact.assert_called_once_with(
             org_id=self.organization.id,


### PR DESCRIPTION
Instead of just returning the artifact id, lets return the full URL