### PR TITLE
chore(launchpad): Return created instead of OK upon chunks being successfully uploaded

### DIFF
--- a/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
+++ b/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
@@ -184,5 +184,5 @@ class ProjectPreprodArtifactAssembleEndpoint(ProjectEndpoint):
                 update_org_auth_token_last_used(request.auth, [project.id])
 
         return Response(
-            {"state": ChunkFileState.OK, "missingChunks": [], "artifactId": artifact_id}
+            {"state": ChunkFileState.CREATED, "missingChunks": [], "artifactId": artifact_id}
         )

--- a/tests/sentry/preprod/api/endpoints/test_organization_preprod_artifact_assemble.py
+++ b/tests/sentry/preprod/api/endpoints/test_organization_preprod_artifact_assemble.py
@@ -374,7 +374,7 @@ class ProjectPreprodArtifactAssembleTest(APITestCase):
             HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
         )
         assert response.status_code == 200, response.content
-        assert response.data["state"] == ChunkFileState.OK
+        assert response.data["state"] == ChunkFileState.CREATED
         assert set(response.data["missingChunks"]) == set()
         assert response.data["artifactId"] == artifact_id
 
@@ -440,7 +440,7 @@ class ProjectPreprodArtifactAssembleTest(APITestCase):
             HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
         )
         assert response.status_code == 200, response.content
-        assert response.data["state"] == ChunkFileState.OK
+        assert response.data["state"] == ChunkFileState.CREATED
         assert set(response.data["missingChunks"]) == set()
         assert response.data["artifactId"] == artifact_id
 
@@ -500,7 +500,7 @@ class ProjectPreprodArtifactAssembleTest(APITestCase):
         )
 
         assert response.status_code == 200, response.content
-        assert response.data["state"] == ChunkFileState.OK
+        assert response.data["state"] == ChunkFileState.CREATED
 
     def test_assemble_response(self) -> None:
         content = b"test response content"
@@ -518,7 +518,7 @@ class ProjectPreprodArtifactAssembleTest(APITestCase):
         )
 
         assert response.status_code == 200, response.content
-        assert response.data["state"] == ChunkFileState.OK
+        assert response.data["state"] == ChunkFileState.CREATED
 
     def test_assemble_with_pending_deletion_project(self) -> None:
         self.project.status = ObjectStatus.PENDING_DELETION
@@ -637,7 +637,7 @@ class ProjectPreprodArtifactAssembleTest(APITestCase):
 
         # Even if assembly status exists, endpoint doesn't check it
         set_assemble_status(
-            AssembleTask.PREPROD_ARTIFACT, self.project.id, checksum, ChunkFileState.OK
+            AssembleTask.PREPROD_ARTIFACT, self.project.id, checksum, ChunkFileState.CREATED
         )
 
         response = self.client.post(
@@ -671,7 +671,7 @@ class ProjectPreprodArtifactAssembleTest(APITestCase):
 
         # Even if task sets status, this endpoint doesn't read it
         set_assemble_status(
-            AssembleTask.PREPROD_ARTIFACT, self.project.id, total_checksum, ChunkFileState.OK
+            AssembleTask.PREPROD_ARTIFACT, self.project.id, total_checksum, ChunkFileState.CREATED
         )
 
         response = self.client.post(


### PR DESCRIPTION
A request made by @szokeasaurusrex so that we're more idiomatically correct even though we aren't ultimately going to return "OK" state anymore. This will be landed after we land a change to the CLI to be satisfied by the endpoint when it receives "CREATED" instead of "OK" (current functionality).