### PR TITLE
chore(hybrid-cloud): Clean up unused rollout option

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3431,13 +3431,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-register(
-    "sentry.hybridcloud.cacheversion.rollout",
-    type=Float,
-    default=0.0,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-
 # Enable enhancing access logs with snuba responses
 register("issues.use-snuba-error-data", type=Float, default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 


### PR DESCRIPTION
After https://github.com/getsentry/sentry-options-automator/pull/4871 is merged and deployed, we can finalize the clean up of this option. 
