### PR TITLE
chore(dynamic-sampling): add more detailed logs to sample rate calculations

### DIFF
--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
@@ -538,14 +538,18 @@ def calculate_sample_rates_of_projects(
             "log-project-config: rebalanced_projects for org %s",
             org_id,
             extra={
-                "rebalanced_projects": [
-                    {
-                        "id": project.id,
-                        "count": project.count,
-                        "new_sample_rate": project.new_sample_rate,
-                    }
-                    for project in rebalanced_projects
-                ],
+                "rebalanced_projects": (
+                    [
+                        {
+                            "id": project.id,
+                            "count": project.count,
+                            "new_sample_rate": project.new_sample_rate,
+                        }
+                        for project in rebalanced_projects
+                    ]
+                    if rebalanced_projects
+                    else None
+                ),
                 "sample_rate": sample_rate,
             },
         )

--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
@@ -537,7 +537,17 @@ def calculate_sample_rates_of_projects(
         logger.info(
             "log-project-config: rebalanced_projects for org %s",
             org_id,
-            extra={"rebalanced_projects": rebalanced_projects, "sample_rate": sample_rate},
+            extra={
+                "rebalanced_projects": [
+                    {
+                        "id": project.id,
+                        "count": project.count,
+                        "new_sample_rate": project.new_sample_rate,
+                    }
+                    for project in rebalanced_projects
+                ],
+                "sample_rate": sample_rate,
+            },
         )
 
     return rebalanced_projects

--- a/src/sentry/dynamic_sampling/tasks/helpers/sample_rate.py
+++ b/src/sentry/dynamic_sampling/tasks/helpers/sample_rate.py
@@ -37,7 +37,7 @@ def get_org_sample_rate(
                 "log-project-config: org.get_option: %s",
                 sample_rate,
                 extra={
-                    "org": org.id,
+                    "org": org.id if org else None,
                     "target_sample_rate": sample_rate,
                     "default_sample_rate": default_sample_rate,
                 },

--- a/src/sentry/dynamic_sampling/tasks/helpers/sample_rate.py
+++ b/src/sentry/dynamic_sampling/tasks/helpers/sample_rate.py
@@ -8,6 +8,10 @@ from sentry.models.organization import Organization
 
 __all__ = ["get_org_sample_rate"]
 
+import logging
+
+logger = logging.getLogger("sentry.dynamic_sampling")
+
 
 def get_org_sample_rate(
     org_id: int, default_sample_rate: float | None
@@ -28,6 +32,16 @@ def get_org_sample_rate(
     has_dynamic_sampling_custom = features.has("organizations:dynamic-sampling-custom", org)
     if has_dynamic_sampling_custom:
         sample_rate = org.get_option("sentry:target_sample_rate") if org else None
+        if features.has("organizations:log-project-config", org):
+            logger.info(
+                "log-project-config: org.get_option: %s",
+                sample_rate,
+                extra={
+                    "org": org.id,
+                    "target_sample_rate": sample_rate,
+                    "default_sample_rate": default_sample_rate,
+                },
+            )
         if sample_rate is not None:
             return float(sample_rate), True
         if default_sample_rate is not None:
@@ -35,7 +49,8 @@ def get_org_sample_rate(
         return TARGET_SAMPLE_RATE_DEFAULT, False
 
     # fallback to sliding window calculation
-    return _get_sliding_window_org_sample_rate(org_id, default_sample_rate)
+    sample_rate, is_custom = _get_sliding_window_org_sample_rate(org_id, default_sample_rate)
+    return sample_rate, is_custom
 
 
 def _get_sliding_window_org_sample_rate(

--- a/src/sentry/dynamic_sampling/tasks/helpers/sample_rate.py
+++ b/src/sentry/dynamic_sampling/tasks/helpers/sample_rate.py
@@ -50,6 +50,16 @@ def get_org_sample_rate(
 
     # fallback to sliding window calculation
     sample_rate, is_custom = _get_sliding_window_org_sample_rate(org_id, default_sample_rate)
+    if features.has("organizations:log-project-config", org):
+        logger.info(
+            "log-project-config: _get_sliding_window_org_sample_rate for org %s",
+            org_id,
+            extra={
+                "sample_rate": sample_rate,
+                "is_custom": is_custom,
+                "default_sample_rate": default_sample_rate,
+            },
+        )
     return sample_rate, is_custom
 
 


### PR DESCRIPTION
- https://github.com/getsentry/sentry/pull/97362 showed that we actually read the 1.0 from cache - which means that we must write this value somehow
- For further debugging, add additional logs to the calculation of sample rates before storing them in redis:
    - log executions associated with org_id in boost_low_volume_projects_of_org
    - log calculated & default sample rates, project counts and rebalanced sample rates in calculate_sample_rates_of_projects
    - log retrieved sample rates in get_org_sample_rate

Contributes to TET-994