### PR TITLE
chore(project-options): Remove template option lookup

### DIFF
--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -443,10 +443,6 @@ class Project(Model):
     def get_option(
         self, key: str, default: Any | None = None, validate: Callable[[object], bool] | None = None
     ) -> Any:
-        # if the option is not set, check the template
-        if not self.option_manager.isset(self, key) and self.template is not None:
-            return self.template_manager.get_value(self.template, key, default, validate)
-
         return self.option_manager.get_value(self, key, default, validate)
 
     def update_option(self, key: str, value: Any, reload_cache: bool = True) -> bool:

--- a/tests/sentry/models/test_project.py
+++ b/tests/sentry/models/test_project.py
@@ -1,4 +1,5 @@
 from collections.abc import Iterable
+from unittest import skip
 from unittest.mock import MagicMock, patch
 
 from sentry.deletions.models.scheduleddeletion import RegionScheduledDeletion
@@ -471,6 +472,7 @@ class ProjectOptionsTests(TestCase):
         ProjectOption.objects.set_value(self.project, self.option_key, True)
         assert self.project.get_option(self.option_key) is True
 
+    @skip("Template feature is not active at the moment")
     def test_get_template_option(self) -> None:
         assert self.project.get_option(self.option_key) is None
         ProjectTemplateOption.objects.set_value(self.project_template, self.option_key, "test")

--- a/tests/sentry/projectoptions/test_basic.py
+++ b/tests/sentry/projectoptions/test_basic.py
@@ -1,5 +1,7 @@
 from unittest import mock
 
+import pytest
+
 from sentry.models.options.project_option import ProjectOption
 from sentry.models.options.project_template_option import ProjectTemplateOption
 from sentry.models.projecttemplate import ProjectTemplate
@@ -76,6 +78,7 @@ def test_isset_differentiates_unset_from_set_to_default(default_project) -> None
 
 
 @django_db_all
+@pytest.mark.skip
 def test_project_template_options(default_project) -> None:
     default_manager.register("test_option", default="default")
     assert default_project.get_option("test_option") == "default"


### PR DESCRIPTION
Project tempaltes is the feature that was paused, and is not currently not used anywhere, but it may be revisited so we don't want to completely remove it.

This PR removes code that causes an extra unnecessary lookup, and simplifies the code in `get_option` method.
