### PR TITLE
chore(cell-actions): use built-in external linking instead of helper function

### DIFF
--- a/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.tsx
@@ -6,6 +6,7 @@ import GridEditable, {COL_WIDTH_UNDEFINED} from 'sentry/components/tables/gridEd
 import SortLink from 'sentry/components/tables/gridEditable/sortLink';
 import {defined} from 'sentry/utils';
 import {getSortField} from 'sentry/utils/dashboards/issueFieldRenderers';
+import type {TableDataRow} from 'sentry/utils/discover/discoverQuery';
 import type {MetaType} from 'sentry/utils/discover/eventView';
 import type {RenderFunctionBaggage} from 'sentry/utils/discover/fieldRenderers';
 import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
@@ -29,7 +30,6 @@ import type {
 import CellAction, {
   Actions,
   copyToClipboard,
-  openExternalLink,
 } from 'sentry/views/discover/table/cellAction';
 
 type FieldRendererGetter = (
@@ -283,16 +283,12 @@ export function TableWidgetVisualization(props: TableWidgetVisualizationProps) {
             <CellAction
               key={`${rowIndex}-${columnIndex}:${tableColumn.name}`}
               column={formattedColumn}
-              // id is not used by CellAction, but is required for the TableDataRow type
-              dataRow={{...dataRow, id: ''}}
+              dataRow={dataRow as TableDataRow}
               handleCellAction={(action: Actions, value: string | number) => {
                 onTriggerCellAction?.(action, value);
                 switch (action) {
                   case Actions.COPY_TO_CLIPBOARD:
                     copyToClipboard(value);
-                    break;
-                  case Actions.OPEN_EXTERNAL_LINK:
-                    openExternalLink(value);
                     break;
                   default:
                     break;

--- a/static/app/views/discover/table/cellAction.tsx
+++ b/static/app/views/discover/table/cellAction.tsx
@@ -95,8 +95,6 @@ export function updateQuery(
       copyToClipboard(value);
       break;
     case Actions.OPEN_EXTERNAL_LINK:
-      openExternalLink(value);
-      break;
     case Actions.RELEASE:
     case Actions.DRILLDOWN:
     case Actions.OPEN_INTERNAL_LINK:
@@ -166,18 +164,6 @@ export function copyToClipboard(value: string | number | string[]) {
   });
 }
 
-/**
- * If provided value is a valid url, opens the url in a new tab
- * @param value
- */
-export function openExternalLink(value: string | number | string[]) {
-  if (typeof value === 'string' && isUrl(value)) {
-    window.open(value, '_blank', 'noopener,noreferrer');
-  } else {
-    addErrorMessage('Could not open link');
-  }
-}
-
 type CellActionsOpts = {
   column: TableColumn<keyof TableDataRow>;
   dataRow: TableDataRow;
@@ -235,6 +221,8 @@ function makeCellActions({
         textValue: itemTextValue,
         onAction: () => handleCellAction(action, value!),
         to: action === Actions.OPEN_INTERNAL_LINK && to ? stripURLOrigin(to) : undefined,
+        externalHref:
+          action === Actions.OPEN_EXTERNAL_LINK ? (value as string) : undefined,
       });
     }
   }

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -19,7 +19,6 @@ import CellAction, {
   Actions,
   ActionTriggerType,
   copyToClipboard,
-  openExternalLink,
 } from 'sentry/views/discover/table/cellAction';
 import type {TableColumn} from 'sentry/views/discover/table/types';
 import {AttributesTree} from 'sentry/views/explore/components/traceItemAttributes/attributesTree';
@@ -331,9 +330,6 @@ export const LogRowContent = memo(function LogRowContent({
                         break;
                       case Actions.COPY_TO_CLIPBOARD:
                         copyToClipboard(cellValue);
-                        break;
-                      case Actions.OPEN_EXTERNAL_LINK:
-                        openExternalLink(cellValue);
                         break;
                       default:
                         break;


### PR DESCRIPTION
### Changes
Move external linking for cell actions V2 into menu item's `externalHref` prop so there's no need to call the `openExternalLink` helper function in the switch case.

There are no visual UI changes for this PR