### PR TITLE
fix(ui2): use a default Input for search in UI2

### DIFF
--- a/static/app/components/events/eventDrawer.tsx
+++ b/static/app/components/events/eventDrawer.tsx
@@ -4,6 +4,7 @@ import {Breadcrumbs as NavigationBreadcrumbs} from 'sentry/components/breadcrumb
 import {InputGroup} from 'sentry/components/core/input/inputGroup';
 import {DrawerBody, DrawerHeader} from 'sentry/components/globalDrawer/components';
 import {space} from 'sentry/styles/space';
+import {withChonk} from 'sentry/utils/theme/withChonk';
 import {MIN_NAV_HEIGHT} from 'sentry/views/issueDetails/streamline/eventTitle';
 
 export const Header = styled('h3')`
@@ -13,11 +14,14 @@ export const Header = styled('h3')`
   margin: 0;
 `;
 
-export const SearchInput = styled(InputGroup.Input)`
-  border: 0;
-  box-shadow: unset;
-  color: inherit;
-`;
+export const SearchInput = withChonk(
+  styled(InputGroup.Input)`
+    border: 0;
+    box-shadow: unset;
+    color: inherit;
+  `,
+  InputGroup.Input
+);
 
 export const NavigationCrumbs = styled(NavigationBreadcrumbs)`
   margin: 0;


### PR DESCRIPTION
before:

<img width="859" height="212" alt="Screenshot 2025-08-11 at 16 21 43" src="https://github.com/user-attachments/assets/c0bedc59-ed52-43fb-bf1e-a860e5ca8940" />


after:

<img width="859" height="212" alt="Screenshot 2025-08-11 at 16 21 31" src="https://github.com/user-attachments/assets/2f46cfe2-e706-4c41-a77d-ce9523e9eda3" />

note: there is no change to UI1