### PR TITLE
fix(insights): performance score should show as none when it doesn't exist

### DIFF
--- a/src/sentry/search/eap/spans/formulas.py
+++ b/src/sentry/search/eap/spans/formulas.py
@@ -60,6 +60,12 @@ def get_total_span_count(settings: ResolverSettings) -> Column:
     )
 
 
+def none_if_zero_processor(value: float) -> float | None:
+    if value == 0:
+        return None
+    return value
+
+
 def division_if(args: ResolvedArguments, settings: ResolverSettings) -> Column.BinaryFormula:
     extrapolation_mode = settings["extrapolation_mode"]
 
@@ -1115,6 +1121,7 @@ SPAN_FORMULA_DEFINITIONS = {
             ),
         ],
         formula_resolver=performance_score,
+        processor=none_if_zero_processor,
         is_aggregate=True,
     ),
     "avg_compare": FormulaDefinition(

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -3326,7 +3326,7 @@ class OrganizationEventsSpansEndpointTest(OrganizationEventsEndpointTestBase):
         assert len(data) == 1
         assert data[0]["performance_score(measurements.score.lcp)"] == 0.02
         assert data[0]["performance_score(measurements.score.cls)"] == 0.08
-        assert data[0]["performance_score(measurements.score.ttfb)"] == 0.0
+        assert data[0]["performance_score(measurements.score.ttfb)"] is None
         assert data[0]["performance_score(measurements.score.fcp)"] == 0.08
         assert data[0]["performance_score(measurements.score.inp)"] == 0.5
         self.assertAlmostEqual(data[0]["performance_score(measurements.score.total)"], 0.20)
@@ -3384,8 +3384,8 @@ class OrganizationEventsSpansEndpointTest(OrganizationEventsEndpointTestBase):
         assert data[0]["transaction"] == "foo_transaction"
         self.assertAlmostEqual(data[0]["performance_score(measurements.score.total)"], 0.8)
         assert data[0]["performance_score(measurements.score.lcp)"] == 0.8
-        assert data[0]["performance_score(measurements.score.cls)"] == 0.0
-        assert data[0]["performance_score(measurements.score.fcp)"] == 0.0
+        assert data[0]["performance_score(measurements.score.cls)"] is None
+        assert data[0]["performance_score(measurements.score.fcp)"] is None
         self.assertAlmostEqual(
             data[0]["opportunity_score(measurements.score.total)"], 0.13333333333333333
         )
@@ -3394,9 +3394,9 @@ class OrganizationEventsSpansEndpointTest(OrganizationEventsEndpointTestBase):
         assert data[0]["opportunity_score(measurements.score.fcp)"] == 0.0
         assert data[1]["transaction"] == "bar_transaction"
         self.assertAlmostEqual(data[1]["performance_score(measurements.score.total)"], 0.7)
-        assert data[1]["performance_score(measurements.score.lcp)"] == 0.0
+        assert data[1]["performance_score(measurements.score.lcp)"] is None
         assert data[1]["performance_score(measurements.score.cls)"] == 0.7
-        assert data[1]["performance_score(measurements.score.fcp)"] == 0.0
+        assert data[1]["performance_score(measurements.score.fcp)"] is None
         self.assertAlmostEqual(data[1]["opportunity_score(measurements.score.total)"], 0.1)
         assert data[1]["opportunity_score(measurements.score.lcp)"] == 0.0
         self.assertAlmostEqual(data[1]["opportunity_score(measurements.score.cls)"], 0.3)

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -3080,6 +3080,25 @@ class OrganizationEventsSpansEndpointTest(OrganizationEventsEndpointTestBase):
         assert data[0]["performance_score(measurements.score.lcp)"] == 0.06
         assert meta["dataset"] == "spans"
 
+    def test_performance_score_zero(self) -> None:
+
+        response = self.do_request(
+            {
+                "field": [
+                    "performance_score(measurements.score.lcp)",
+                ],
+                "project": self.project.id,
+                "dataset": "spans",
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert len(data) == 1
+        assert data[0]["performance_score(measurements.score.lcp)"] is None
+        assert meta["dataset"] == "spans"
+
     def test_division_if(self) -> None:
         self.store_spans(
             [


### PR DESCRIPTION
We want to ensure anytime there is no perf score, the UI shows `(no value)`, this can be done by returning None when the score is 0. Technically, if all your vital measurements are 0 we would return None, but i don't think that's a case we need to worry about.