### PR TITLE
chore(aci): add workflow engine snuba referrers to enum

### DIFF
--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -1080,6 +1080,13 @@ class Referrer(StrEnum):
     TSDB_MODELID_300_alert_event_uniq_user_frequency = (
         "tsdb-modelid:300.alert_event_uniq_user_frequency"
     )
+    TSDB_MODELID_4_wf_batch_alert_event_frequency = "tsdb-modelid:4.wf_batch_alert_event_frequency"
+    TSDB_MODELID_4_wf_batch_alert_event_frequency_percent = (
+        "tsdb-modelid:4.wf_batch_alert_event_frequency_percent"
+    )
+    TSDB_MODELID_300_wf_batch_alert_event_uniq_user_frequency = (
+        "tsdb-modelid:300.wf_batch_alert_event_uniq_user_frequency"
+    )
 
     UNKNOWN = "unknown"
     UNMERGE = "unmerge"


### PR DESCRIPTION
We emit warning logs every time a Snuba query is made in delayed workflow because the referrer suffixes we use are not registered to the `Referrer` `Enum`. These are constructed here

https://github.com/getsentry/sentry/blob/bda9c866122155a48f488033e431788388d40266/src/sentry/tsdb/snuba.py#L461-L464

where model is TSDBModel
https://github.com/getsentry/sentry/blob/bda9c866122155a48f488033e431788388d40266/src/sentry/issues/constants.py#L8-L13
https://github.com/getsentry/sentry/blob/bda9c866122155a48f488033e431788388d40266/src/sentry/tsdb/base.py#L31-L54