### PR TITLE
chore(detectors): Add broader package filters to sql injection detector

### DIFF
--- a/src/sentry/performance_issues/detectors/sql_injection_detector.py
+++ b/src/sentry/performance_issues/detectors/sql_injection_detector.py
@@ -61,12 +61,14 @@ EXCLUDED_KEYWORDS = [
 # - gorm.io/gorm: GORM ORM for Go
 # - @nestjs/typeorm: NestJS TypeORM
 # - @mikro-orm/nestjs: MikroORM NestJS ORM
+# - typeorm: TypeORM ORM
 EXCLUDED_PACKAGES = [
     "github.com/go-sql-driver/mysql",
     "sequelize",
     "gorm.io/gorm",
     "@nestjs/typeorm",
     "@mikro-orm/nestjs",
+    "typeorm",
 ]
 PARAMETERIZED_KEYWORDS = ["?", "$1", "%s"]
 

--- a/src/sentry/performance_issues/detectors/sql_injection_detector.py
+++ b/src/sentry/performance_issues/detectors/sql_injection_detector.py
@@ -62,6 +62,7 @@ EXCLUDED_KEYWORDS = [
 # - @nestjs/typeorm: NestJS TypeORM
 # - @mikro-orm/nestjs: MikroORM NestJS ORM
 # - typeorm: TypeORM ORM
+# - @mikro-orm/core: MikroORM
 EXCLUDED_PACKAGES = [
     "github.com/go-sql-driver/mysql",
     "sequelize",
@@ -69,6 +70,7 @@ EXCLUDED_PACKAGES = [
     "@nestjs/typeorm",
     "@mikro-orm/nestjs",
     "typeorm",
+    "@mikro-orm/core",
 ]
 PARAMETERIZED_KEYWORDS = ["?", "$1", "%s"]
 


### PR DESCRIPTION
we already have `@nestjs/typeorm` and `@mikro-orm/nestjs` as filters, but we received feedback that both more generally also causes false positives outside of nestjs