### PR TITLE
feat(aci): redirect to alert rules when UI FF is off

### DIFF
--- a/static/app/views/automations/detail.tsx
+++ b/static/app/views/automations/detail.tsx
@@ -18,7 +18,6 @@ import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import TimeSince from 'sentry/components/timeSince';
 import DetailLayout from 'sentry/components/workflowEngine/layout/detail';
 import Section from 'sentry/components/workflowEngine/ui/section';
-import {useWorkflowEngineFeatureGate} from 'sentry/components/workflowEngine/useWorkflowEngineFeatureGate';
 import {IconEdit} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import type {Automation} from 'sentry/types/workflowEngine/automations';
@@ -196,7 +195,6 @@ function AutomationDetailLoadingStates({automationId}: {automationId: string}) {
 }
 
 export default function AutomationDetail() {
-  useWorkflowEngineFeatureGate({redirect: true});
   const params = useParams<{automationId: string}>();
 
   const {data: automation, isPending} = useAutomationQuery(params.automationId);

--- a/static/app/views/automations/edit.tsx
+++ b/static/app/views/automations/edit.tsx
@@ -14,7 +14,6 @@ import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {FullHeightForm} from 'sentry/components/workflowEngine/form/fullHeightForm';
 import {useFormField} from 'sentry/components/workflowEngine/form/useFormField';
 import {StickyFooter} from 'sentry/components/workflowEngine/ui/footer';
-import {useWorkflowEngineFeatureGate} from 'sentry/components/workflowEngine/useWorkflowEngineFeatureGate';
 import {t} from 'sentry/locale';
 import type {Automation, NewAutomation} from 'sentry/types/workflowEngine/automations';
 import {DataConditionGroupLogicType} from 'sentry/types/workflowEngine/dataConditions';
@@ -71,8 +70,6 @@ function AutomationBreadcrumbs({automationId}: {automationId: string}) {
 
 export default function AutomationEdit() {
   const params = useParams<{automationId: string}>();
-
-  useWorkflowEngineFeatureGate({redirect: true});
 
   const {
     data: automation,

--- a/static/app/views/automations/list.tsx
+++ b/static/app/views/automations/list.tsx
@@ -6,7 +6,6 @@ import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilt
 import Pagination from 'sentry/components/pagination';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import ListLayout from 'sentry/components/workflowEngine/layout/list';
-import {useWorkflowEngineFeatureGate} from 'sentry/components/workflowEngine/useWorkflowEngineFeatureGate';
 import {IconAdd} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import parseLinkHeader from 'sentry/utils/parseLinkHeader';
@@ -25,8 +24,6 @@ import {useAutomationsQuery} from 'sentry/views/automations/hooks';
 import {makeAutomationCreatePathname} from 'sentry/views/automations/pathnames';
 
 export default function AutomationsList() {
-  useWorkflowEngineFeatureGate({redirect: true});
-
   const location = useLocation();
   const navigate = useNavigate();
   const {selection, isReady} = usePageFilters();

--- a/static/app/views/automations/new.tsx
+++ b/static/app/views/automations/new.tsx
@@ -12,7 +12,6 @@ import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {FullHeightForm} from 'sentry/components/workflowEngine/form/fullHeightForm';
 import {useFormField} from 'sentry/components/workflowEngine/form/useFormField';
 import {StickyFooter} from 'sentry/components/workflowEngine/ui/footer';
-import {useWorkflowEngineFeatureGate} from 'sentry/components/workflowEngine/useWorkflowEngineFeatureGate';
 import {t} from 'sentry/locale';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
@@ -71,7 +70,6 @@ export default function AutomationNewSettings() {
   const navigate = useNavigate();
   const location = useLocation();
   const organization = useOrganization();
-  useWorkflowEngineFeatureGate({redirect: true});
   const model = useMemo(() => new FormModel(), []);
   const {state, actions} = useAutomationBuilderReducer();
   const theme = useTheme();

--- a/static/app/views/automations/routes.tsx
+++ b/static/app/views/automations/routes.tsx
@@ -1,10 +1,7 @@
-import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Redirect from 'sentry/components/redirect';
 import {makeLazyloadComponent as make} from 'sentry/makeLazyloadComponent';
 import type {SentryRouteObject} from 'sentry/router/types';
-import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
-import {useParams} from 'sentry/utils/useParams';
 import {useUser} from 'sentry/utils/useUser';
 import {makeAlertsPathname} from 'sentry/views/alerts/pathnames';
 
@@ -31,7 +28,7 @@ export const automationRoutes: SentryRouteObject = {
     },
     {
       path: ':automationId/',
-      component: RedirectToRuleDetails,
+      component: RedirectToRuleList,
       deprecatedRouteProps: true,
       children: [
         {
@@ -55,12 +52,14 @@ function RedirectToRuleList({children}: {children: React.ReactNode}) {
     !user.isStaff && !organization.features.includes('workflow-engine-ui');
 
   if (shouldRedirect) {
-    <Redirect
-      to={makeAlertsPathname({
-        path: '/rules/',
-        organization,
-      })}
-    />;
+    return (
+      <Redirect
+        to={makeAlertsPathname({
+          path: '/rules/',
+          organization,
+        })}
+      />
+    );
   }
 
   return children;
@@ -82,58 +81,6 @@ function RedirectToNewRule({children}: {children: React.ReactNode}) {
         })}
       />
     );
-  }
-
-  return children;
-}
-
-interface AlertRuleWorkflow {
-  workflowId: string;
-  alertRuleId?: string;
-  ruleId?: string;
-}
-
-function RedirectToRuleDetails({children}: {children: React.ReactNode}) {
-  const user = useUser();
-  const organization = useOrganization();
-
-  const params = useParams<{automationId: string}>();
-
-  const shouldRedirect =
-    !user.isStaff && !organization.features.includes('workflow-engine-ui');
-
-  const {data, isLoading} = useApiQuery<AlertRuleWorkflow>(
-    [
-      `/organizations/${organization.slug}/alert-rule-workflows/`,
-      {
-        query: {workflowId: params.automationId},
-      },
-    ],
-    {staleTime: Infinity, retry: false, enabled: shouldRedirect}
-  );
-
-  if (shouldRedirect) {
-    if (isLoading) {
-      return <LoadingIndicator />;
-    }
-    if (data) {
-      return (
-        <Redirect
-          to={makeAlertsPathname({
-            path: data.ruleId
-              ? `/rules/details/${data.ruleId}/`
-              : `/rules/details/${data.alertRuleId}/`,
-            organization,
-          })}
-        />
-      );
-    }
-    <Redirect
-      to={makeAlertsPathname({
-        path: '/rules/',
-        organization,
-      })}
-    />;
   }
 
   return children;

--- a/static/app/views/automations/routes.tsx
+++ b/static/app/views/automations/routes.tsx
@@ -1,8 +1,8 @@
 import LoadingIndicator from 'sentry/components/loadingIndicator';
+import Redirect from 'sentry/components/redirect';
 import type {SentryRouteObject} from 'sentry/components/route';
 import {makeLazyloadComponent as make} from 'sentry/makeLazyloadComponent';
 import {useApiQuery} from 'sentry/utils/queryClient';
-import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {useUser} from 'sentry/utils/useUser';
@@ -12,14 +12,11 @@ export const automationRoutes: SentryRouteObject = {
   path: 'alerts/',
   children: [
     {
-      index: true,
-      component: make(() => import('sentry/views/automations/list')),
-      // BROKEN: Results in empty page
-      // component: RedirectToRuleList,
-      // deprecatedRouteProps: true,
-      // children: [
-      //   {index: true, component: make(() => import('sentry/views/automations/list'))},
-      // ],
+      component: RedirectToRuleList,
+      deprecatedRouteProps: true,
+      children: [
+        {index: true, component: make(() => import('sentry/views/automations/list'))},
+      ],
     },
     {
       path: 'new',
@@ -53,21 +50,17 @@ export const automationRoutes: SentryRouteObject = {
 function RedirectToRuleList({children}: {children: React.ReactNode}) {
   const user = useUser();
   const organization = useOrganization();
-  const navigate = useNavigate();
 
   const shouldRedirect =
     !user.isStaff && !organization.features.includes('workflow-engine-ui');
 
   if (shouldRedirect) {
-    navigate(
-      makeAlertsPathname({
+    <Redirect
+      to={makeAlertsPathname({
         path: '/rules/',
         organization,
-      }),
-      {
-        replace: true,
-      }
-    );
+      })}
+    />;
   }
 
   return children;
@@ -76,20 +69,18 @@ function RedirectToRuleList({children}: {children: React.ReactNode}) {
 export function RedirectToNewRule({children}: {children: React.ReactNode}) {
   const user = useUser();
   const organization = useOrganization();
-  const navigate = useNavigate();
 
   const shouldRedirect =
     !user.isStaff && !organization.features.includes('workflow-engine-ui');
 
   if (shouldRedirect) {
-    navigate(
-      makeAlertsPathname({
-        path: '/new/',
-        organization,
-      }),
-      {
-        replace: true,
-      }
+    return (
+      <Redirect
+        to={makeAlertsPathname({
+          path: '/new/',
+          organization,
+        })}
+      />
     );
   }
 
@@ -105,7 +96,6 @@ interface AlertRuleWorkflow {
 export function RedirectToRuleDetails({children}: {children: React.ReactNode}) {
   const user = useUser();
   const organization = useOrganization();
-  const navigate = useNavigate();
 
   const params = useParams<{automationId: string}>();
 
@@ -126,16 +116,15 @@ export function RedirectToRuleDetails({children}: {children: React.ReactNode}) {
     if (!data) {
       return <LoadingIndicator />;
     }
-    navigate(
-      makeAlertsPathname({
-        path: data.ruleId
-          ? `/rules/details/${data.ruleId}/`
-          : `/rules/details/${data.alertRuleId}/`,
-        organization,
-      }),
-      {
-        replace: true,
-      }
+    return (
+      <Redirect
+        to={makeAlertsPathname({
+          path: data.ruleId
+            ? `/rules/details/${data.ruleId}/`
+            : `/rules/details/${data.alertRuleId}/`,
+          organization,
+        })}
+      />
     );
   }
 

--- a/static/app/views/automations/routes.tsx
+++ b/static/app/views/automations/routes.tsx
@@ -102,7 +102,7 @@ function RedirectToRuleDetails({children}: {children: React.ReactNode}) {
   const shouldRedirect =
     !user.isStaff && !organization.features.includes('workflow-engine-ui');
 
-  const {data} = useApiQuery<AlertRuleWorkflow>(
+  const {data, isLoading} = useApiQuery<AlertRuleWorkflow>(
     [
       `/organizations/${organization.slug}/alert-rule-workflows/`,
       {
@@ -113,19 +113,27 @@ function RedirectToRuleDetails({children}: {children: React.ReactNode}) {
   );
 
   if (shouldRedirect) {
-    if (!data) {
+    if (isLoading) {
       return <LoadingIndicator />;
     }
-    return (
-      <Redirect
-        to={makeAlertsPathname({
-          path: data.ruleId
-            ? `/rules/details/${data.ruleId}/`
-            : `/rules/details/${data.alertRuleId}/`,
-          organization,
-        })}
-      />
-    );
+    if (data) {
+      return (
+        <Redirect
+          to={makeAlertsPathname({
+            path: data.ruleId
+              ? `/rules/details/${data.ruleId}/`
+              : `/rules/details/${data.alertRuleId}/`,
+            organization,
+          })}
+        />
+      );
+    }
+    <Redirect
+      to={makeAlertsPathname({
+        path: '/rules/',
+        organization,
+      })}
+    />;
   }
 
   return children;

--- a/static/app/views/automations/routes.tsx
+++ b/static/app/views/automations/routes.tsx
@@ -1,7 +1,7 @@
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Redirect from 'sentry/components/redirect';
-import type {SentryRouteObject} from 'sentry/components/route';
 import {makeLazyloadComponent as make} from 'sentry/makeLazyloadComponent';
+import type {SentryRouteObject} from 'sentry/router/types';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';

--- a/static/app/views/automations/routes.tsx
+++ b/static/app/views/automations/routes.tsx
@@ -66,7 +66,7 @@ function RedirectToRuleList({children}: {children: React.ReactNode}) {
   return children;
 }
 
-export function RedirectToNewRule({children}: {children: React.ReactNode}) {
+function RedirectToNewRule({children}: {children: React.ReactNode}) {
   const user = useUser();
   const organization = useOrganization();
 
@@ -93,7 +93,7 @@ interface AlertRuleWorkflow {
   ruleId?: string;
 }
 
-export function RedirectToRuleDetails({children}: {children: React.ReactNode}) {
+function RedirectToRuleDetails({children}: {children: React.ReactNode}) {
   const user = useUser();
   const organization = useOrganization();
 

--- a/static/app/views/automations/routes.tsx
+++ b/static/app/views/automations/routes.tsx
@@ -1,5 +1,12 @@
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import type {SentryRouteObject} from 'sentry/components/route';
 import {makeLazyloadComponent as make} from 'sentry/makeLazyloadComponent';
-import type {SentryRouteObject} from 'sentry/router/types';
+import {useApiQuery} from 'sentry/utils/queryClient';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import useOrganization from 'sentry/utils/useOrganization';
+import {useParams} from 'sentry/utils/useParams';
+import {useUser} from 'sentry/utils/useUser';
+import {makeAlertsPathname} from 'sentry/views/alerts/pathnames';
 
 export const automationRoutes: SentryRouteObject = {
   path: 'alerts/',
@@ -7,9 +14,17 @@ export const automationRoutes: SentryRouteObject = {
     {
       index: true,
       component: make(() => import('sentry/views/automations/list')),
+      // BROKEN: Results in empty page
+      // component: RedirectToRuleList,
+      // deprecatedRouteProps: true,
+      // children: [
+      //   {index: true, component: make(() => import('sentry/views/automations/list'))},
+      // ],
     },
     {
       path: 'new',
+      component: RedirectToNewRule,
+      deprecatedRouteProps: true,
       children: [
         {
           index: true,
@@ -19,6 +34,8 @@ export const automationRoutes: SentryRouteObject = {
     },
     {
       path: ':automationId/',
+      component: RedirectToRuleDetails,
+      deprecatedRouteProps: true,
       children: [
         {
           index: true,
@@ -32,3 +49,95 @@ export const automationRoutes: SentryRouteObject = {
     },
   ],
 };
+
+function RedirectToRuleList({children}: {children: React.ReactNode}) {
+  const user = useUser();
+  const organization = useOrganization();
+  const navigate = useNavigate();
+
+  const shouldRedirect =
+    !user.isStaff && !organization.features.includes('workflow-engine-ui');
+
+  if (shouldRedirect) {
+    navigate(
+      makeAlertsPathname({
+        path: '/rules/',
+        organization,
+      }),
+      {
+        replace: true,
+      }
+    );
+  }
+
+  return children;
+}
+
+export function RedirectToNewRule({children}: {children: React.ReactNode}) {
+  const user = useUser();
+  const organization = useOrganization();
+  const navigate = useNavigate();
+
+  const shouldRedirect =
+    !user.isStaff && !organization.features.includes('workflow-engine-ui');
+
+  if (shouldRedirect) {
+    navigate(
+      makeAlertsPathname({
+        path: '/new/',
+        organization,
+      }),
+      {
+        replace: true,
+      }
+    );
+  }
+
+  return children;
+}
+
+interface AlertRuleWorkflow {
+  workflowId: string;
+  alertRuleId?: string;
+  ruleId?: string;
+}
+
+export function RedirectToRuleDetails({children}: {children: React.ReactNode}) {
+  const user = useUser();
+  const organization = useOrganization();
+  const navigate = useNavigate();
+
+  const params = useParams<{automationId: string}>();
+
+  const shouldRedirect =
+    !user.isStaff && !organization.features.includes('workflow-engine-ui');
+
+  const {data} = useApiQuery<AlertRuleWorkflow>(
+    [
+      `/organizations/${organization.slug}/alert-rule-workflows/`,
+      {
+        query: {workflowId: params.automationId},
+      },
+    ],
+    {staleTime: Infinity, retry: false, enabled: shouldRedirect}
+  );
+
+  if (shouldRedirect) {
+    if (!data) {
+      return <LoadingIndicator />;
+    }
+    navigate(
+      makeAlertsPathname({
+        path: data.ruleId
+          ? `/rules/details/${data.ruleId}/`
+          : `/rules/details/${data.alertRuleId}/`,
+        organization,
+      }),
+      {
+        replace: true,
+      }
+    );
+  }
+
+  return children;
+}


### PR DESCRIPTION
- automation list view -> rule list view
- automation create (new) view -> rule create (new) view
- automation detail view -> rule list view (because with de-duplication of automations, automations will not always map 1:1 with a single alert rule/rule)