### PR TITLE
fix(access-logs): capture more info in access log trace

### DIFF
--- a/src/sentry/middleware/access_log.py
+++ b/src/sentry/middleware/access_log.py
@@ -132,7 +132,13 @@ def _create_api_access_log(
         metrics.incr("middleware.access_log.created")
 
         if in_random_rollout("issues.log-access-logs") and not org_id:
-            sentry_sdk.capture_message("Acesss log created without org_id", level="debug")
+            with sentry_sdk.scope.use_isolation_scope() as scope:
+                scope.set_extra("request_auth", request_auth)
+                scope.set_extra("request._request", request._request)
+                sentry_sdk.capture_message(
+                    "Acesss log created without org_id",
+                    level="debug",
+                )
 
     except Exception:
         api_access_logger.exception("api.access: Error capturing API access logs")

--- a/src/sentry/middleware/access_log.py
+++ b/src/sentry/middleware/access_log.py
@@ -132,7 +132,7 @@ def _create_api_access_log(
         metrics.incr("middleware.access_log.created")
 
         if in_random_rollout("issues.log-access-logs") and not org_id:
-            with sentry_sdk.scope.use_isolation_scope() as scope:
+            with sentry_sdk.isolation_scope() as scope:
                 scope.set_extra("request_auth", request_auth)
                 scope.set_extra("request._request", request._request)
                 sentry_sdk.capture_message(


### PR DESCRIPTION
We need a bit more info to debug missing `organization_id`s  (see [sentry issue](https://sentry.sentry.io/issues/6803717682/?project=1&query=is%3Aunresolved&referrer=issue-stream), [ticket](https://linear.app/getsentry/issue/ID-805/fix-missing-organization-id-in-api-access-logs)). From previous work, we suspect org id might be on either `_request` or `request_auth`, so logging those to see if we can find a pattern. 

See previous PR adding this: https://github.com/getsentry/sentry/pull/97183