### PR TITLE
chore(replays/feedback) Enable match key suggestions for email search

### DIFF
--- a/static/app/components/events/contexts/knownContext/user.tsx
+++ b/static/app/components/events/contexts/knownContext/user.tsx
@@ -30,7 +30,7 @@ enum UserContextGeoKeys {
   REGION = 'region',
 }
 
-const EMAIL_REGEX = /[^@]+@[^\.]+\..+/;
+export const EMAIL_REGEX = /[^@]+@[^\.]+\..+/;
 
 function formatGeo(geoData: UserContext['geo'] = {}): string | undefined {
   if (!geoData) {

--- a/static/app/components/feedback/feedbackSearch.tsx
+++ b/static/app/components/feedback/feedbackSearch.tsx
@@ -27,6 +27,9 @@ import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {Dataset} from 'sentry/views/alerts/rules/metric/types';
 
+// copied from static/app/components/events/contexts/knownContext/user.tsx
+const EMAIL_PATTERN = /[^@]+@[^\.]+\..+/;
+
 const EXCLUDED_TAGS: string[] = [
   // These are found in issue platform and redundant (= __.name, ex os.name)
   'browser',
@@ -284,6 +287,7 @@ export default function FeedbackSearch() {
       onSearch={onSearch}
       searchSource={'feedback-list'}
       placeholder={t('Search Feedback')}
+      matchKeySuggestions={[{key: 'user.email', valuePattern: EMAIL_PATTERN}]}
     />
   );
 }

--- a/static/app/components/feedback/feedbackSearch.tsx
+++ b/static/app/components/feedback/feedbackSearch.tsx
@@ -4,6 +4,7 @@ import union from 'lodash/union';
 
 import {fetchTagValues, useFetchOrganizationTags} from 'sentry/actionCreators/tags';
 import type {SearchGroup} from 'sentry/components/deprecatedSmartSearchBar/types';
+import {EMAIL_REGEX} from 'sentry/components/events/contexts/knownContext/user';
 import {SearchQueryBuilder} from 'sentry/components/searchQueryBuilder';
 import type {FilterKeySection} from 'sentry/components/searchQueryBuilder/types';
 import {t} from 'sentry/locale';
@@ -26,9 +27,6 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {Dataset} from 'sentry/views/alerts/rules/metric/types';
-
-// copied from static/app/components/events/contexts/knownContext/user.tsx
-const EMAIL_PATTERN = /[^@]+@[^\.]+\..+/;
 
 const EXCLUDED_TAGS: string[] = [
   // These are found in issue platform and redundant (= __.name, ex os.name)
@@ -287,7 +285,7 @@ export default function FeedbackSearch() {
       onSearch={onSearch}
       searchSource={'feedback-list'}
       placeholder={t('Search Feedback')}
-      matchKeySuggestions={[{key: 'user.email', valuePattern: EMAIL_PATTERN}]}
+      matchKeySuggestions={[{key: 'user.email', valuePattern: EMAIL_REGEX}]}
     />
   );
 }

--- a/static/app/views/replays/list/replaySearchBar.tsx
+++ b/static/app/views/replays/list/replaySearchBar.tsx
@@ -26,6 +26,9 @@ import {Dataset} from 'sentry/views/alerts/rules/metric/types';
 
 const getReplayFieldDefinition = (key: string) => getFieldDefinition(key, 'replay');
 
+// copied from static/app/components/events/contexts/knownContext/user.tsx
+const EMAIL_PATTERN = /[^@]+@[^\.]+\..+/;
+
 function fieldDefinitionsToTagCollection(fieldKeys: string[]): TagCollection {
   return Object.fromEntries(
     fieldKeys.map(key => [
@@ -211,6 +214,7 @@ function ReplaySearchBar(props: Props) {
       filterKeys={filterKeys}
       filterKeySections={filterKeySections}
       getTagValues={getTagValues}
+      matchKeySuggestions={[{key: 'user.email', valuePattern: EMAIL_PATTERN}]}
       initialQuery={props.query ?? props.defaultQuery ?? ''}
       onSearch={onSearchWithAnalytics}
       searchSource={props.searchSource ?? 'replay_index'}

--- a/static/app/views/replays/list/replaySearchBar.tsx
+++ b/static/app/views/replays/list/replaySearchBar.tsx
@@ -3,6 +3,7 @@ import orderBy from 'lodash/orderBy';
 
 import {fetchTagValues, useFetchOrganizationTags} from 'sentry/actionCreators/tags';
 import type SmartSearchBar from 'sentry/components/deprecatedSmartSearchBar';
+import {EMAIL_REGEX} from 'sentry/components/events/contexts/knownContext/user';
 import {SearchQueryBuilder} from 'sentry/components/searchQueryBuilder';
 import type {FilterKeySection} from 'sentry/components/searchQueryBuilder/types';
 import {t} from 'sentry/locale';
@@ -25,9 +26,6 @@ import useApi from 'sentry/utils/useApi';
 import {Dataset} from 'sentry/views/alerts/rules/metric/types';
 
 const getReplayFieldDefinition = (key: string) => getFieldDefinition(key, 'replay');
-
-// copied from static/app/components/events/contexts/knownContext/user.tsx
-const EMAIL_PATTERN = /[^@]+@[^\.]+\..+/;
 
 function fieldDefinitionsToTagCollection(fieldKeys: string[]): TagCollection {
   return Object.fromEntries(
@@ -214,7 +212,7 @@ function ReplaySearchBar(props: Props) {
       filterKeys={filterKeys}
       filterKeySections={filterKeySections}
       getTagValues={getTagValues}
-      matchKeySuggestions={[{key: 'user.email', valuePattern: EMAIL_PATTERN}]}
+      matchKeySuggestions={[{key: 'user.email', valuePattern: EMAIL_REGEX}]}
       initialQuery={props.query ?? props.defaultQuery ?? ''}
       onSearch={onSearchWithAnalytics}
       searchSource={props.searchSource ?? 'replay_index'}


### PR DESCRIPTION
This PR updates the search query builders for Replays, and User Feedback to utilize the new [`matchKeySuggestions`](https://sentry.sentry.io/stories/?name=app%2Fcomponents%2FsearchQueryBuilder%2Findex.stories.tsx#match-key-suggestions) to suggest entries with pre-filled key value pairs for `user.email` once a valid email has been entered.