### PR TITLE
chore(prevent): Remove use_codecov guard + update get tokens endpoint to allow for name sort

### DIFF
--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -1150,3 +1150,16 @@ Available fields are:
         many=True,
         description="""A list of test suites belonging to a repository's test results.""",
     )
+    TOKENS_SORT_BY = OpenApiParameter(
+        name="sortBy",
+        location="query",
+        required=False,
+        type=str,
+        description="""The property to sort results by. If not specified, the default is `COMMIT_DATE` in descending order. Use `-`
+        for descending order.
+
+Available fields are:
+- `NAME`
+- `COMMIT_DATE`
+        """,
+    )

--- a/src/sentry/codecov/endpoints/repository_token_regenerate/repository_token_regenerate.py
+++ b/src/sentry/codecov/endpoints/repository_token_regenerate/repository_token_regenerate.py
@@ -1,5 +1,3 @@
-import uuid
-
 from drf_spectacular.utils import extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -46,25 +44,15 @@ class RepositoryTokenRegenerateEndpoint(CodecovEndpoint):
         Regenerates a repository upload token and returns the new token.
         """
 
-        # Check if we should call Codecov or return a generic UUID
-        # don't document this because we don't want to expose it just yet to users
-        use_codecov = request.GET.get("use_codecov")
+        owner_slug = owner.name
 
-        if use_codecov:
-            # Make actual request to Codecov
-            owner_slug = owner.name
+        variables = {
+            "owner": owner_slug,
+            "repoName": repository,
+        }
 
-            variables = {
-                "owner": owner_slug,
-                "repoName": repository,
-            }
-
-            client = CodecovApiClient(git_provider_org=owner_slug)
-            graphql_response = client.query(query=query, variables=variables)
-            token = RepositoryTokenRegenerateSerializer().to_representation(graphql_response.json())
-        else:
-            # Return a generic UUID token
-            generic_token = str(uuid.uuid4())
-            token = {"token": generic_token}
+        client = CodecovApiClient(git_provider_org=owner_slug)
+        graphql_response = client.query(query=query, variables=variables)
+        token = RepositoryTokenRegenerateSerializer().to_representation(graphql_response.json())
 
         return Response(token)

--- a/src/sentry/codecov/endpoints/repository_tokens/repository_tokens.py
+++ b/src/sentry/codecov/endpoints/repository_tokens/repository_tokens.py
@@ -53,6 +53,14 @@ class RepositoryTokensEndpoint(CodecovEndpoint):
         limit_param = request.query_params.get("limit", MAX_RESULTS_PER_PAGE)
         cursor = request.query_params.get("cursor")
 
+        sort_by = request.query_params.get("sortBy", "-COMMIT_DATE")
+
+        if sort_by.startswith("-"):
+            sort_by = sort_by[1:]
+            ordering_direction = OrderingDirection.DESC.value
+        else:
+            ordering_direction = OrderingDirection.ASC.value
+
         owner_slug = owner.name
 
         # When calling request.query_params, the URL is decoded so + is replaced with spaces. We need to change them back so Codecov can properly fetch the next page.
@@ -75,8 +83,8 @@ class RepositoryTokensEndpoint(CodecovEndpoint):
 
         variables = {
             "owner": owner_slug,
-            "direction": OrderingDirection.DESC.value,
-            "ordering": "COMMIT_DATE",
+            "orderingDirection": ordering_direction,
+            "ordering": sort_by,
             "first": limit if navigation != NavigationParameter.PREV.value else None,
             "last": limit if navigation == NavigationParameter.PREV.value else None,
             "before": cursor if cursor and navigation == NavigationParameter.PREV.value else None,

--- a/src/sentry/codecov/endpoints/repository_tokens/repository_tokens.py
+++ b/src/sentry/codecov/endpoints/repository_tokens/repository_tokens.py
@@ -34,7 +34,7 @@ class RepositoryTokensEndpoint(CodecovEndpoint):
             PreventParams.LIMIT,
             PreventParams.NAVIGATION,
             PreventParams.CURSOR,
-            PreventParams.TERM,
+            PreventParams.TOKENS_SORT_BY,
         ],
         request=None,
         responses={

--- a/src/sentry/codecov/endpoints/repository_tokens/repository_tokens.py
+++ b/src/sentry/codecov/endpoints/repository_tokens/repository_tokens.py
@@ -83,7 +83,7 @@ class RepositoryTokensEndpoint(CodecovEndpoint):
 
         variables = {
             "owner": owner_slug,
-            "orderingDirection": ordering_direction,
+            "direction": ordering_direction,
             "ordering": sort_by,
             "first": limit if navigation != NavigationParameter.PREV.value else None,
             "last": limit if navigation == NavigationParameter.PREV.value else None,

--- a/tests/sentry/codecov/endpoints/test_repository_token_regenerate.py
+++ b/tests/sentry/codecov/endpoints/test_repository_token_regenerate.py
@@ -34,7 +34,7 @@ class RepositoryTokenRegenerateEndpointTest(APITestCase):
     @patch(
         "sentry.codecov.endpoints.repository_token_regenerate.repository_token_regenerate.CodecovApiClient"
     )
-    def test_post_with_codecov_param_calls_api(self, mock_codecov_client_class) -> None:
+    def test_post_calls_api(self, mock_codecov_client_class) -> None:
         """Test that when use_codecov param is provided, it calls the Codecov API"""
         mock_graphql_response = {
             "data": {
@@ -51,7 +51,7 @@ class RepositoryTokenRegenerateEndpointTest(APITestCase):
         mock_codecov_client_class.return_value = mock_codecov_client_instance
 
         url = self.reverse_url()
-        response = self.client.post(url, data={}, QUERY_STRING="use_codecov=true")
+        response = self.client.post(url, data={})
 
         mock_codecov_client_class.assert_called_once_with(git_provider_org="testowner")
         mock_codecov_client_instance.query.assert_called_once_with(
@@ -67,21 +67,7 @@ class RepositoryTokenRegenerateEndpointTest(APITestCase):
     @patch(
         "sentry.codecov.endpoints.repository_token_regenerate.repository_token_regenerate.CodecovApiClient"
     )
-    def test_post_without_codecov_param_returns_uuid(self, mock_codecov_client_class) -> None:
-        """Test that when use_codecov param is not provided, it returns a generic UUID and doesn't call Codecov"""
-        url = self.reverse_url()
-        response = self.client.post(url)
-
-        assert response.status_code == 200
-        assert response.data["token"]
-
-        # Verify Codecov client was not called
-        mock_codecov_client_class.assert_not_called()
-
-    @patch(
-        "sentry.codecov.endpoints.repository_token_regenerate.repository_token_regenerate.CodecovApiClient"
-    )
-    def test_post_with_codecov_param_handles_errors(self, mock_codecov_client_class) -> None:
+    def test_post_handles_errors(self, mock_codecov_client_class) -> None:
         """Test that GraphQL errors are properly handled when calling Codecov API"""
         mock_graphql_response = {
             "data": {
@@ -101,7 +87,7 @@ class RepositoryTokenRegenerateEndpointTest(APITestCase):
         mock_codecov_client_class.return_value = mock_codecov_client_instance
 
         url = self.reverse_url()
-        response = self.client.post(url, data={}, QUERY_STRING="use_codecov=true")
+        response = self.client.post(url, data={})
 
         assert response.status_code == 400
         assert response.data[0] == "Repository not found"

--- a/tests/sentry/codecov/endpoints/test_repository_tokens.py
+++ b/tests/sentry/codecov/endpoints/test_repository_tokens.py
@@ -100,7 +100,7 @@ class RepositoryTokensEndpointTest(APITestCase):
         # Verify the correct variables are passed to the GraphQL query
         expected_variables = {
             "owner": "testowner",
-            "orderingDirection": "DESC",
+            "direction": "DESC",
             "ordering": "COMMIT_DATE",
             "first": 25,
             "last": None,
@@ -140,13 +140,18 @@ class RepositoryTokensEndpointTest(APITestCase):
         mock_codecov_client_class.return_value = mock_codecov_client_instance
 
         url = self.reverse_url()
-        query_params = {"cursor": "cursor123", "limit": "5", "navigation": "prev"}
+        query_params = {
+            "cursor": "cursor123",
+            "limit": "5",
+            "navigation": "prev",
+            "sortBy": "-NAME",
+        }
         response = self.client.get(url, query_params)
 
         expected_variables = {
             "owner": "testowner",
-            "orderingDirection": "DESC",
-            "ordering": "COMMIT_DATE",
+            "direction": "DESC",
+            "ordering": "NAME",
             "first": None,
             "last": 5,
             "before": "cursor123",

--- a/tests/sentry/codecov/endpoints/test_repository_tokens.py
+++ b/tests/sentry/codecov/endpoints/test_repository_tokens.py
@@ -100,7 +100,7 @@ class RepositoryTokensEndpointTest(APITestCase):
         # Verify the correct variables are passed to the GraphQL query
         expected_variables = {
             "owner": "testowner",
-            "direction": "DESC",
+            "orderingDirection": "DESC",
             "ordering": "COMMIT_DATE",
             "first": 25,
             "last": None,
@@ -145,7 +145,7 @@ class RepositoryTokensEndpointTest(APITestCase):
 
         expected_variables = {
             "owner": "testowner",
-            "direction": "DESC",
+            "orderingDirection": "DESC",
             "ordering": "COMMIT_DATE",
             "first": None,
             "last": 5,


### PR DESCRIPTION
Main objective of this PR was to add sortBy query param to the get repository tokens endpoint so the frontend can allow sorting by repository name. Updates the API doc stuff to reflect that as well

Also does a little cleanup to remove the "use_codecov" guard when regenerating repository tokens so now we'll always talk with codecov. Had that originally so we could test on the FE without issue but it's no longer needed now.

Closes https://linear.app/getsentry/issue/CCMRG-1497/remove-use-codecov-guard-update-filter-params

Some screenshots below showing the sort behavior on postman

<img width="969" height="666" alt="Screenshot 2025-08-11 at 10 47 23 AM" src="https://github.com/user-attachments/assets/d35cebbe-d150-4be5-8dee-96626f96995d" />
<img width="968" height="665" alt="Screenshot 2025-08-11 at 10 47 37 AM" src="https://github.com/user-attachments/assets/9c00f17d-9bac-4621-be36-4dfe361aef52" />
<img width="966" height="661" alt="Screenshot 2025-08-11 at 10 47 57 AM" src="https://github.com/user-attachments/assets/79d87713-5367-41b2-8e16-7c42d50fe17f" />



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
