### PR TITLE
feat(onboarding): Add logs empty state onboarding for react

### DIFF
--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -305,7 +305,7 @@ export const withoutPerformanceSupport: Set<PlatformKey> = new Set([
 ]);
 
 // List of platforms that have logging onboarding checklist content
-export const withLoggingOnboarding: Set<PlatformKey> = new Set([]);
+export const withLoggingOnboarding: Set<PlatformKey> = new Set(['javascript-react']);
 
 // List of platforms that do not have logging support. We make use of this list in the product to not provide any Logging
 export const withoutLoggingSupport: Set<PlatformKey> = new Set([

--- a/static/app/gettingStartedDocs/javascript/javascript.tsx
+++ b/static/app/gettingStartedDocs/javascript/javascript.tsx
@@ -423,8 +423,8 @@ Sentry.init({
 Sentry.init({
   dsn: "${params.dsn.public}",
   integrations: [
-    // send console.log, console.error, and console.warn calls as logs to Sentry
-    Sentry.consoleLoggingIntegration({ levels: ["log", "error", "warn"] }),
+    // send console.log, console.warn, and console.error calls as logs to Sentry
+    Sentry.consoleLoggingIntegration({ levels: ["log", "warn", "error"] }),
   ],
 });
 \`\`\`

--- a/static/app/gettingStartedDocs/javascript/nextjs.tsx
+++ b/static/app/gettingStartedDocs/javascript/nextjs.tsx
@@ -185,8 +185,8 @@ Sentry.init({
 Sentry.init({
   dsn: "${params.dsn.public}",
   integrations: [
-    // send console.log, console.error, and console.warn calls as logs to Sentry
-    Sentry.consoleLoggingIntegration({ levels: ["log", "error", "warn"] }),
+    // send console.log, console.warn, and console.error calls as logs to Sentry
+    Sentry.consoleLoggingIntegration({ levels: ["log", "warn", "error"] }),
   ],
 });
 \`\`\`

--- a/static/app/gettingStartedDocs/javascript/react.tsx
+++ b/static/app/gettingStartedDocs/javascript/react.tsx
@@ -637,7 +637,7 @@ const profilingOnboarding = getJavascriptProfilingOnboarding({
 
 const logsOnboarding: OnboardingConfig = getJavascriptLogsOnboarding({
   installSnippetBlock,
-  docsLink: 'https://docs.sentry.io/platforms/javascript/guides/react/logs/',
+  docsPlatform: 'react',
   sdkPackage: '@sentry/react',
 });
 

--- a/static/app/gettingStartedDocs/javascript/react.tsx
+++ b/static/app/gettingStartedDocs/javascript/react.tsx
@@ -28,7 +28,10 @@ import {
 } from 'sentry/components/onboarding/gettingStartedDoc/utils/replayOnboarding';
 import {featureFlagOnboarding} from 'sentry/gettingStartedDocs/javascript/javascript';
 import {t, tct} from 'sentry/locale';
-import {getJavascriptProfilingOnboarding} from 'sentry/utils/gettingStartedDocs/javascript';
+import {
+  getJavascriptLogsOnboarding,
+  getJavascriptProfilingOnboarding,
+} from 'sentry/utils/gettingStartedDocs/javascript';
 
 type Params = DocsParams;
 
@@ -52,7 +55,7 @@ const getDynamicParts = (params: Params): string[] => {
 
   if (params.isLogsSelected) {
     dynamicParts.push(`
-      // Logs
+      // Enable logs to be sent to Sentry
       enableLogs: true`);
   }
 
@@ -122,9 +125,29 @@ root.render(<App />);
 `;
 };
 
-const getVerifySnippet = () => `
-return <button onClick={() => {throw new Error("This is your first error!");}}>Break the world</button>;
-`;
+const getVerifySnippet = (params: Params) => {
+  const logsCode = params.isLogsSelected
+    ? `
+        // Send a log before throwing the error
+        Sentry.logger.info('User triggered test error', {
+          action: 'test_error_button_click',
+        });`
+    : '';
+
+  return `import * as Sentry from '@sentry/react';
+// Add this button component to your app to test Sentry's error tracking
+function ErrorButton() {
+  return (
+    <button
+      onClick={() => {${logsCode}
+        throw new Error('This is your first error!');
+      }}
+    >
+      Break the world
+    </button>
+  );
+}`;
+};
 
 const installSnippetBlock: ContentBlock = {
   type: 'code',
@@ -326,7 +349,7 @@ logger.fatal("Database connection pool exhausted", {
 `,
     }),
   ],
-  verify: () => [
+  verify: (params: Params) => [
     {
       type: StepType.VERIFY,
       content: [
@@ -342,7 +365,7 @@ logger.fatal("Database connection pool exhausted", {
             {
               label: 'React',
               language: 'javascript',
-              code: getVerifySnippet(),
+              code: getVerifySnippet(params),
             },
           ],
         },
@@ -359,15 +382,18 @@ logger.fatal("Database connection pool exhausted", {
         ),
         link: 'https://docs.sentry.io/platforms/javascript/guides/react/features/',
       },
-      {
+    ];
+
+    if (params.isPerformanceSelected) {
+      steps.push({
         id: 'react-router',
         name: t('React Router'),
         description: t(
-          'Configure routing, so Sentry can generate parameterized transaction names for a better overview on the Performance page.'
+          'Configure routing, so Sentry can generate parameterized route names for better grouping of tracing data.'
         ),
         link: 'https://docs.sentry.io/platforms/javascript/guides/react/configuration/integrations/react-router/',
-      },
-    ];
+      });
+    }
 
     if (params.isLogsSelected) {
       steps.push({
@@ -609,6 +635,13 @@ const profilingOnboarding = getJavascriptProfilingOnboarding({
     'https://docs.sentry.io/platforms/javascript/guides/react/profiling/browser-profiling/',
 });
 
+const logsOnboarding: OnboardingConfig = getJavascriptLogsOnboarding({
+  installSnippetBlock,
+  integrationsLink:
+    'https://docs.sentry.io/platforms/javascript/guides/react/logs/#integrations',
+  sdkPackage: '@sentry/react',
+});
+
 const docs: Docs = {
   onboarding,
   feedbackOnboardingNpm: feedbackOnboarding,
@@ -616,6 +649,7 @@ const docs: Docs = {
   performanceOnboarding,
   crashReportOnboarding,
   profilingOnboarding,
+  logsOnboarding,
   featureFlagOnboarding,
 };
 

--- a/static/app/gettingStartedDocs/javascript/react.tsx
+++ b/static/app/gettingStartedDocs/javascript/react.tsx
@@ -637,8 +637,7 @@ const profilingOnboarding = getJavascriptProfilingOnboarding({
 
 const logsOnboarding: OnboardingConfig = getJavascriptLogsOnboarding({
   installSnippetBlock,
-  integrationsLink:
-    'https://docs.sentry.io/platforms/javascript/guides/react/logs/#integrations',
+  docsLink: 'https://docs.sentry.io/platforms/javascript/guides/react/logs/',
   sdkPackage: '@sentry/react',
 });
 

--- a/static/app/gettingStartedDocs/javascript/react.tsx
+++ b/static/app/gettingStartedDocs/javascript/react.tsx
@@ -319,8 +319,8 @@ Sentry.init({
 Sentry.init({
   dsn: "${params.dsn.public}",
   integrations: [
-    // send console.log, console.error, and console.warn calls as logs to Sentry
-    Sentry.consoleLoggingIntegration({ levels: ["log", "error", "warn"] }),
+    // send console.log, console.warn, and console.error calls as logs to Sentry
+    Sentry.consoleLoggingIntegration({ levels: ["log", "warn", "error"] }),
   ],
 });
 \`\`\`

--- a/static/app/gettingStartedDocs/node/node.tsx
+++ b/static/app/gettingStartedDocs/node/node.tsx
@@ -201,8 +201,8 @@ Sentry.init({
 Sentry.init({
   dsn: "${params.dsn.public}",
   integrations: [
-    // send console.log, console.error, and console.warn calls as logs to Sentry
-    Sentry.consoleLoggingIntegration({ levels: ["log", "error", "warn"] }),
+    // send console.log, console.warn, and console.error calls as logs to Sentry
+    Sentry.consoleLoggingIntegration({ levels: ["log", "warn", "error"] }),
   ],
 });
 \`\`\`

--- a/static/app/utils/gettingStartedDocs/javascript.tsx
+++ b/static/app/utils/gettingStartedDocs/javascript.tsx
@@ -247,15 +247,15 @@ Sentry.init({
           code: `import * as Sentry from "${sdkPackage}";
 
 function LogButton() {
-return (
-<button
-  onClick={() =>
-    Sentry.logger.info('User triggered test log', { action: 'test_log_button_click' })
-  }
->
-  Click this button to send a test log
-</button>
-);
+  return (
+    <button
+      onClick={() =>
+        Sentry.logger.info('User triggered test log', { action: 'test_log_button_click' })
+      }
+    >
+      Click this button to send a test log
+    </button>
+  );
 }`,
         },
       ],

--- a/static/app/utils/gettingStartedDocs/javascript.tsx
+++ b/static/app/utils/gettingStartedDocs/javascript.tsx
@@ -213,7 +213,7 @@ import * as Sentry from "${sdkPackage}";
 Sentry.init({
   dsn: "${params.dsn.public}",
   integrations: [
-    // Send console.log, console.warn, and console.error calls as logs to Sentry
+    // send console.log, console.warn, and console.error calls as logs to Sentry
     Sentry.consoleLoggingIntegration({ levels: ["log", "warn", "error"] }),
   ],
   // Enable logs to be sent to Sentry

--- a/static/app/utils/gettingStartedDocs/javascript.tsx
+++ b/static/app/utils/gettingStartedDocs/javascript.tsx
@@ -153,12 +153,12 @@ export const getJavascriptProfilingOnboarding = <
 export const getJavascriptLogsOnboarding = <
   PlatformOptions extends BasePlatformOptions = BasePlatformOptions,
 >({
+  docsLink,
   sdkPackage,
   installSnippetBlock,
-  integrationsLink,
 }: {
+  docsLink: string;
   installSnippetBlock: ContentBlock;
-  integrationsLink: string;
   sdkPackage: `@sentry/${string}`;
 }): OnboardingConfig<PlatformOptions> => ({
   install: () => [
@@ -202,6 +202,12 @@ Sentry.init({
 });
 `,
         },
+        {
+          type: 'text',
+          text: tct('For more detailed information, see the [link:logs documentation].', {
+            link: <ExternalLink href={docsLink} />,
+          }),
+        },
       ],
     },
   ],
@@ -236,16 +242,6 @@ function LogButton() {
           ],
         },
       ],
-    },
-  ],
-  nextSteps: () => [
-    {
-      id: 'logs',
-      name: t('Logging Integrations'),
-      description: t(
-        'Add logging integrations to automatically capture logs from your application.'
-      ),
-      link: integrationsLink,
     },
   ],
 });

--- a/static/app/utils/gettingStartedDocs/javascript.tsx
+++ b/static/app/utils/gettingStartedDocs/javascript.tsx
@@ -153,11 +153,11 @@ export const getJavascriptProfilingOnboarding = <
 export const getJavascriptLogsOnboarding = <
   PlatformOptions extends BasePlatformOptions = BasePlatformOptions,
 >({
-  docsLink,
+  docsPlatform,
   sdkPackage,
   installSnippetBlock,
 }: {
-  docsLink: string;
+  docsPlatform: string;
   installSnippetBlock: ContentBlock;
   sdkPackage: `@sentry/${string}`;
 }): OnboardingConfig<PlatformOptions> => ({
@@ -167,9 +167,28 @@ export const getJavascriptLogsOnboarding = <
       content: [
         {
           type: 'text',
-          text: t('Add the Sentry SDK as a dependency using npm, yarn, or pnpm.'),
+          text: tct(
+            'Add the Sentry SDK as a dependency using npm, yarn, or pnpm. The minimum version of [sdkPackage] that supports logs is [code:9.17.0].',
+            {
+              code: <code />,
+              sdkPackage: <code>{sdkPackage}</code>,
+            }
+          ),
         },
         installSnippetBlock,
+        {
+          type: 'text',
+          text: tct(
+            'If you are on an older version of the SDK, follow our [link:migration guide] to upgrade.',
+            {
+              link: (
+                <ExternalLink
+                  href={`https://docs.sentry.io/platforms/javascript/guides/${docsPlatform}/migration/`}
+                />
+              ),
+            }
+          ),
+        },
       ],
     },
   ],
@@ -205,7 +224,11 @@ Sentry.init({
         {
           type: 'text',
           text: tct('For more detailed information, see the [link:logs documentation].', {
-            link: <ExternalLink href={docsLink} />,
+            link: (
+              <ExternalLink
+                href={`https://docs.sentry.io/platforms/javascript/guides/${docsPlatform}/logs/`}
+              />
+            ),
           }),
         },
       ],

--- a/static/app/utils/gettingStartedDocs/javascript.tsx
+++ b/static/app/utils/gettingStartedDocs/javascript.tsx
@@ -150,6 +150,120 @@ export const getJavascriptProfilingOnboarding = <
   ],
 });
 
+export const getJavascriptLogsOnboarding = <
+  PlatformOptions extends BasePlatformOptions = BasePlatformOptions,
+>({
+  sdkPackage,
+  installSnippetBlock,
+  integrationsLink,
+}: {
+  installSnippetBlock: ContentBlock;
+  integrationsLink: string;
+  sdkPackage: `@sentry/${string}`;
+}): OnboardingConfig<PlatformOptions> => ({
+  install: () => [
+    {
+      type: StepType.INSTALL,
+      content: [
+        {
+          type: 'text',
+          text: t('Add the Sentry SDK as a dependency using npm, yarn, or pnpm.'),
+        },
+        installSnippetBlock,
+      ],
+    },
+  ],
+  configure: (params: DocsParams) => [
+    {
+      type: StepType.CONFIGURE,
+      content: [
+        {
+          type: 'text',
+          text: t(
+            'Enable Sentry logs by adding enableLogs: true to your Sentry.init configuration.'
+          ),
+        },
+        {
+          type: 'code',
+          tabs: [
+            {
+              label: 'Baseline',
+              language: 'javascript',
+              code: `
+import * as Sentry from "${sdkPackage}";
+
+Sentry.init({
+  dsn: "${params.dsn.public}",
+  enableLogs: true,
+});
+`,
+            },
+            {
+              label: 'Logger Integration',
+              language: 'javascript',
+              code: `
+import * as Sentry from "${sdkPackage}";
+
+Sentry.init({
+  dsn: "${params.dsn.public}",
+  integrations: [
+    // send console.log, console.error, and console.warn calls as logs to Sentry
+    Sentry.consoleLoggingIntegration({ levels: ["log", "error", "warn"] }),
+  ],
+  enableLogs: true,
+});
+`,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  verify: () => [
+    {
+      type: StepType.VERIFY,
+      content: [
+        {
+          type: 'text',
+          text: t('Send a test log from your app to verify logs are arriving in Sentry.'),
+        },
+        {
+          type: 'code',
+          tabs: [
+            {
+              label: 'React',
+              language: 'javascript',
+              code: `import * as Sentry from "${sdkPackage}";
+
+function LogButton() {
+  return (
+    <button
+      onClick={() =>
+        Sentry.logger.info('User triggered test log', { action: 'test_log_button_click' })
+      }
+    >
+      Send test log
+    </button>
+  );
+}`,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  nextSteps: () => [
+    {
+      id: 'logs',
+      name: t('Logging Integrations'),
+      description: t(
+        'Add logging integrations to automatically capture logs from your application.'
+      ),
+      link: integrationsLink,
+    },
+  ],
+});
+
 export const getJavascriptFullStackOnboarding = <
   PlatformOptions extends BasePlatformOptions = BasePlatformOptions,
 >({

--- a/static/app/utils/gettingStartedDocs/javascript.tsx
+++ b/static/app/utils/gettingStartedDocs/javascript.tsx
@@ -168,7 +168,7 @@ export const getJavascriptLogsOnboarding = <
         {
           type: 'text',
           text: tct(
-            'Add the Sentry SDK as a dependency using npm, yarn, or pnpm. The minimum version of [sdkPackage] that supports logs is [code:9.17.0].',
+            'Add the Sentry SDK as a dependency using npm, yarn, or pnpm. The minimum version of [sdkPackage] that supports logs is [code:9.41.0].',
             {
               code: <code />,
               sdkPackage: <code>{sdkPackage}</code>,

--- a/static/app/utils/gettingStartedDocs/javascript.tsx
+++ b/static/app/utils/gettingStartedDocs/javascript.tsx
@@ -179,42 +179,28 @@ export const getJavascriptLogsOnboarding = <
       content: [
         {
           type: 'text',
-          text: t(
-            'Enable Sentry logs by adding enableLogs: true to your Sentry.init configuration.'
+          text: tct(
+            'Enable Sentry logs by adding [code:enableLogs: true] to your [code:Sentry.init()] configuration.',
+            {code: <code />}
           ),
         },
         {
+          label: 'React',
           type: 'code',
-          tabs: [
-            {
-              label: 'Baseline',
-              language: 'javascript',
-              code: `
-import * as Sentry from "${sdkPackage}";
-
-Sentry.init({
-  dsn: "${params.dsn.public}",
-  enableLogs: true,
-});
-`,
-            },
-            {
-              label: 'Logger Integration',
-              language: 'javascript',
-              code: `
+          language: 'javascript',
+          code: `
 import * as Sentry from "${sdkPackage}";
 
 Sentry.init({
   dsn: "${params.dsn.public}",
   integrations: [
-    // send console.log, console.error, and console.warn calls as logs to Sentry
-    Sentry.consoleLoggingIntegration({ levels: ["log", "error", "warn"] }),
+    // Send console.log, console.warn, and console.error calls as logs to Sentry
+    Sentry.consoleLoggingIntegration({ levels: ["log", "warn", "error"] }),
   ],
+  // Enable logs to be sent to Sentry
   enableLogs: true,
 });
 `,
-            },
-          ],
         },
       ],
     },
@@ -232,7 +218,7 @@ Sentry.init({
           tabs: [
             {
               label: 'React',
-              language: 'javascript',
+              language: 'jsx',
               code: `import * as Sentry from "${sdkPackage}";
 
 function LogButton() {
@@ -242,7 +228,7 @@ function LogButton() {
         Sentry.logger.info('User triggered test log', { action: 'test_log_button_click' })
       }
     >
-      Send test log
+      Click this button to send a test log
     </button>
   );
 }`,

--- a/static/app/utils/gettingStartedDocs/javascript.tsx
+++ b/static/app/utils/gettingStartedDocs/javascript.tsx
@@ -204,7 +204,6 @@ export const getJavascriptLogsOnboarding = <
           ),
         },
         {
-          label: 'React',
           type: 'code',
           language: 'javascript',
           code: `

--- a/static/app/utils/gettingStartedDocs/javascript.tsx
+++ b/static/app/utils/gettingStartedDocs/javascript.tsx
@@ -243,25 +243,20 @@ Sentry.init({
         },
         {
           type: 'code',
-          tabs: [
-            {
-              label: 'React',
-              language: 'jsx',
-              code: `import * as Sentry from "${sdkPackage}";
+          language: 'jsx',
+          code: `import * as Sentry from "${sdkPackage}";
 
 function LogButton() {
-  return (
-    <button
-      onClick={() =>
-        Sentry.logger.info('User triggered test log', { action: 'test_log_button_click' })
-      }
-    >
-      Click this button to send a test log
-    </button>
-  );
+return (
+<button
+  onClick={() =>
+    Sentry.logger.info('User triggered test log', { action: 'test_log_button_click' })
+  }
+>
+  Click this button to send a test log
+</button>
+);
 }`,
-            },
-          ],
         },
       ],
     },

--- a/static/app/views/explore/logs/content.spec.tsx
+++ b/static/app/views/explore/logs/content.spec.tsx
@@ -111,6 +111,11 @@ describe('LogsPage', function () {
       },
     });
     TeamStore.loadInitialData([TeamFixture()]);
+    MockApiClient.addMockResponse({
+      url: `/projects/${onboardingOrganization.slug}/${onboardingProject.slug}/`,
+      method: 'GET',
+      body: [],
+    });
     const projectSlugMock = MockApiClient.addMockResponse({
       url: `/projects/${onboardingOrganization.slug}/${onboardingProject.slug}/keys/`,
       method: 'GET',

--- a/static/app/views/explore/logs/logsOnboarding.tsx
+++ b/static/app/views/explore/logs/logsOnboarding.tsx
@@ -463,6 +463,7 @@ const EventWaitingIndicator = styled((p: React.HTMLAttributes<HTMLDivElement>) =
     <PulsingIndicator />
   </div>
 ))`
+  padding-top: ${p => p.theme.space.md};
   display: flex;
   align-items: center;
   position: relative;
@@ -483,6 +484,7 @@ const EventReceivedIndicator = styled((p: React.HTMLAttributes<HTMLDivElement>) 
     {t("We've received this project's first log!")}
   </div>
 ))`
+  padding-top: ${p => p.theme.space.md};
   display: flex;
   align-items: center;
   flex-grow: 1;

--- a/static/app/views/explore/logs/logsOnboarding.tsx
+++ b/static/app/views/explore/logs/logsOnboarding.tsx
@@ -1,16 +1,8 @@
-import {Fragment, useEffect, useState} from 'react';
+import {useEffect} from 'react';
 import styled from '@emotion/styled';
-import * as Sentry from '@sentry/react';
 
 import connectDotsImg from 'sentry-images/spot/performance-connect-dots.svg';
 
-import {
-  addErrorMessage,
-  addLoadingMessage,
-  clearIndicators,
-} from 'sentry/actionCreators/indicator';
-import type {Client} from 'sentry/api';
-import {Button} from 'sentry/components/core/button';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {GuidedSteps} from 'sentry/components/guidedSteps/guidedSteps';
 import * as Layout from 'sentry/components/layouts/thirds';
@@ -43,85 +35,20 @@ import platforms, {otherPlatform} from 'sentry/data/platforms';
 import {t, tct} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
-import pulsingIndicatorStyles from 'sentry/styles/pulsingIndicator';
 import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import EventWaiter from 'sentry/utils/eventWaiter';
 import {decodeInteger} from 'sentry/utils/queryString';
-import {testableWindowLocation} from 'sentry/utils/testableWindowLocation';
 import useApi from 'sentry/utils/useApi';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
-import {LOGS_QUERY_KEY} from 'sentry/views/explore/contexts/logs/logsPageParams';
-import {Tab} from 'sentry/views/explore/hooks/useTab';
 import {
   FilterBarContainer,
   StyledPageFilterBar,
   TopSectionBody,
 } from 'sentry/views/explore/logs/styles';
-import {useLogsQuery} from 'sentry/views/explore/logs/useLogsQuery';
 import type {PickableDays} from 'sentry/views/explore/utils';
-
-type SampleButtonProps = {
-  api: Client;
-  errorMessage: React.ReactNode;
-  loadingMessage: React.ReactNode;
-  organization: Organization;
-  project: Project;
-  triggerText: React.ReactNode;
-};
-
-function SampleButton({
-  triggerText,
-  loadingMessage,
-  errorMessage,
-  project,
-  organization,
-  api,
-}: SampleButtonProps) {
-  const navigate = useNavigate();
-  // TODO: Fix this to create a sample log
-  return (
-    <Button
-      data-test-id="create-sample-transaction-btn"
-      onClick={async () => {
-        trackAnalytics('logs.onboarding_create_sample_log', {
-          platform: project.platform,
-          organization,
-        });
-        addLoadingMessage(loadingMessage, {
-          duration: 15000,
-        });
-        const url = `/projects/${organization.slug}/${project.slug}/create-sample-log/`;
-        try {
-          const eventData = await api.requestPromise(url, {method: 'POST'});
-          // TODO: Update with logs url function with item id / trace id
-          const traceSlug = eventData.contexts?.trace?.trace_id ?? '';
-
-          navigate({
-            pathname: '/explore/logs/',
-            query: {
-              [LOGS_QUERY_KEY]: `trace:${traceSlug}`,
-            },
-          });
-          clearIndicators();
-        } catch (error) {
-          Sentry.withScope(scope => {
-            scope.setExtra('error', error);
-            Sentry.captureException(new Error('Failed to create sample log'));
-          });
-          clearIndicators();
-          addErrorMessage(errorMessage);
-          return;
-        }
-      }}
-    >
-      {triggerText}
-    </Button>
-  );
-}
 
 type OnboardingProps = {
   organization: Organization;
@@ -227,17 +154,6 @@ function Onboarding({organization, project}: OnboardingProps) {
   const location = useLocation();
   const navigate = useNavigate();
   const {isSelfHosted, urlPrefix} = useLegacyStore(ConfigStore);
-  const [received, setReceived] = useState<boolean>(false);
-  const logsQuery = useLogsQuery({
-    disabled: !received,
-    limit: 1,
-    refetchInterval: query => {
-      const logId = query.state.data?.[0]?.data?.[0]?.id;
-      return logId ? 0 : 5000; // 5s
-    },
-  });
-  const logId = logsQuery.data?.[0]?.id;
-
   const currentPlatform = project.platform
     ? platforms.find(p => p.id === project.platform)
     : undefined;
@@ -371,22 +287,6 @@ function Onboarding({organization, project}: OnboardingProps) {
 
   const steps = [...installSteps, ...configureSteps, ...verifySteps];
 
-  const eventWaitingIndicator = (
-    <EventWaiter
-      api={api}
-      organization={organization}
-      project={project}
-      eventType="log"
-      onIssueReceived={() => {
-        setReceived(true);
-      }}
-    >
-      {({firstIssue}) =>
-        firstIssue ? <EventReceivedIndicator /> : <EventWaitingIndicator />
-      }
-    </EventWaiter>
-  );
-
   return (
     <OnboardingPanel project={project}>
       <SetupTitle project={project} />
@@ -410,39 +310,9 @@ function Onboarding({organization, project}: OnboardingProps) {
                 <ConfigurationRenderer configuration={step} />
               </RenderBlocksOrFallback>
               {index === steps.length - 1 ? (
-                <Fragment>
-                  {eventWaitingIndicator}
-                  <GuidedSteps.ButtonWrapper>
-                    <GuidedSteps.BackButton size="md" />
-                    {received ? (
-                      <Button
-                        priority="primary"
-                        busy={!logId}
-                        title={logId ? undefined : t('Processing logs\u2026')}
-                        onClick={() => {
-                          const params = new URLSearchParams(window.location.search);
-                          params.set('table', Tab.TRACE);
-                          params.set('query', `trace:${logId}`);
-                          params.delete('guidedStep');
-                          testableWindowLocation.assign(
-                            `${window.location.pathname}?${params.toString()}`
-                          );
-                        }}
-                      >
-                        {t('Take me to my logs')}
-                      </Button>
-                    ) : (
-                      <SampleButton
-                        triggerText={t('Take me to an example log')}
-                        loadingMessage={t('Processing sample logs...')}
-                        errorMessage={t('Failed to create sample logs')}
-                        organization={organization}
-                        project={project}
-                        api={api}
-                      />
-                    )}
-                  </GuidedSteps.ButtonWrapper>
-                </Fragment>
+                <GuidedSteps.ButtonWrapper>
+                  <GuidedSteps.BackButton size="md" />
+                </GuidedSteps.ButtonWrapper>
               ) : (
                 <GuidedSteps.ButtonWrapper>
                   <GuidedSteps.BackButton size="md" />
@@ -456,41 +326,6 @@ function Onboarding({organization, project}: OnboardingProps) {
     </OnboardingPanel>
   );
 }
-
-const EventWaitingIndicator = styled((p: React.HTMLAttributes<HTMLDivElement>) => (
-  <div {...p}>
-    {t("Waiting for this project's first log")}
-    <PulsingIndicator />
-  </div>
-))`
-  padding-top: ${p => p.theme.space.md};
-  display: flex;
-  align-items: center;
-  position: relative;
-  z-index: 10;
-  flex-grow: 1;
-  font-size: ${p => p.theme.fontSize.md};
-  color: ${p => p.theme.pink400};
-`;
-
-const PulsingIndicator = styled('div')`
-  ${pulsingIndicatorStyles};
-  margin-left: ${space(1)};
-`;
-
-const EventReceivedIndicator = styled((p: React.HTMLAttributes<HTMLDivElement>) => (
-  <div {...p}>
-    {'🎉 '}
-    {t("We've received this project's first log!")}
-  </div>
-))`
-  padding-top: ${p => p.theme.space.md};
-  display: flex;
-  align-items: center;
-  flex-grow: 1;
-  font-size: ${p => p.theme.fontSize.md};
-  color: ${p => p.theme.successText};
-`;
 
 const SubTitle = styled('div')`
   margin-bottom: ${space(1)};

--- a/static/app/views/explore/logs/logsOnboarding.tsx
+++ b/static/app/views/explore/logs/logsOnboarding.tsx
@@ -278,7 +278,7 @@ function Onboarding({organization, project}: OnboardingProps) {
     analyticsPlatform,
   ]);
 
-  const logsDocs = docs?.onboarding;
+  const logsDocs = docs?.logsOnboarding ?? docs?.onboarding;
 
   if (isLoading) {
     return <LoadingIndicator />;

--- a/static/app/views/onboarding/setupDocs.spec.tsx
+++ b/static/app/views/onboarding/setupDocs.spec.tsx
@@ -204,9 +204,10 @@ describe('Onboarding Setup Docs', function () {
         await screen.findByRole('heading', {name: 'Configure React SDK'})
       ).toBeInTheDocument();
 
-      const codeBlock = await screen.findByText(/import \* as Sentry/);
-      expect(codeBlock).toHaveTextContent(/Tracing/);
-      expect(codeBlock).toHaveTextContent(/Session Replay/);
+      // First code block is the install snippet, second is the verify snippet
+      const codeBlocks = await screen.findAllByText(/import \* as Sentry/);
+      expect(codeBlocks[0]).toHaveTextContent(/Tracing/);
+      expect(codeBlocks[0]).toHaveTextContent(/Session Replay/);
     });
 
     it('only performance checked', async function () {

--- a/static/app/views/onboarding/setupDocs.spec.tsx
+++ b/static/app/views/onboarding/setupDocs.spec.tsx
@@ -255,9 +255,10 @@ describe('Onboarding Setup Docs', function () {
         }
       );
 
-      const codeBlock = await screen.findByText(/import \* as Sentry/);
-      expect(codeBlock).toHaveTextContent(/Tracing/);
-      expect(codeBlock).not.toHaveTextContent(/Session Replay/);
+      // First code block is the install snippet, second is the verify snippet
+      const codeBlocks = await screen.findAllByText(/import \* as Sentry/);
+      expect(codeBlocks[0]).toHaveTextContent(/Tracing/);
+      expect(codeBlocks[0]).not.toHaveTextContent(/Session Replay/);
     });
 
     it('only session replay checked', async function () {
@@ -306,9 +307,10 @@ describe('Onboarding Setup Docs', function () {
         }
       );
 
-      const codeBlock = await screen.findByText(/import \* as Sentry/);
-      expect(codeBlock).toHaveTextContent(/Session Replay/);
-      expect(codeBlock).not.toHaveTextContent(/Tracing/);
+      // First code block is the install snippet, second is the verify snippet
+      const codeBlocks = await screen.findAllByText(/import \* as Sentry/);
+      expect(codeBlocks[0]).toHaveTextContent(/Session Replay/);
+      expect(codeBlocks[0]).not.toHaveTextContent(/Tracing/);
     });
 
     it('only error monitoring checked', async function () {
@@ -359,9 +361,10 @@ describe('Onboarding Setup Docs', function () {
 
       await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
 
-      const codeBlock = await screen.findByText(/import \* as Sentry/);
-      expect(codeBlock).not.toHaveTextContent(/Tracing/);
-      expect(codeBlock).not.toHaveTextContent(/Session Replay/);
+      // First code block is the install snippet, second is the verify snippet
+      const codeBlocks = await screen.findAllByText(/import \* as Sentry/);
+      expect(codeBlocks[0]).not.toHaveTextContent(/Tracing/);
+      expect(codeBlocks[0]).not.toHaveTextContent(/Session Replay/);
     });
   });
 

--- a/static/app/views/performance/newTraceDetails/traceModels/__snapshots__/issuesTraceTree.spec.tsx.snap
+++ b/static/app/views/performance/newTraceDetails/traceModels/__snapshots__/issuesTraceTree.spec.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`IssuesTraceTree FromSpans collapses spans 1`] = `
 "


### PR DESCRIPTION
resolves https://linear.app/getsentry/issue/LOGS-294/add-logs-onboarding-for-react-js-sdk
resolves https://linear.app/getsentry/issue/LOGS-295/add-verify-steps-to-react-js-onboarding

Adds a `getJavascriptLogsOnboarding` helper we can use in all of the JS SDKs for empty state onboarding.

<img width="2082" height="1143" alt="image" src="https://github.com/user-attachments/assets/7a404ca2-597d-46d3-955d-06654281b858" />

<img width="2082" height="1143" alt="image" src="https://github.com/user-attachments/assets/10a3e2b9-5f1a-4c95-8acc-7d1bb910b5d7" />

Dependent on https://github.com/getsentry/sentry/pull/97455