### PR TITLE
feat(preprod): Remove enum on vcs provider field

### DIFF
--- a/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
+++ b/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
@@ -38,16 +38,7 @@ def validate_preprod_artifact_schema(request_body: bytes) -> tuple[dict, str | N
             # VCS parameters
             "head_sha": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
             "base_sha": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
-            "provider": {
-                "type": "string",
-                "enum": [
-                    "github",
-                    "github_enterprise",
-                    "gitlab",
-                    "bitbucket",
-                    "bitbucket_server",
-                ],
-            },
+            "provider": {"type": "string", "maxLength": 255},
             "head_repo_name": {"type": "string", "maxLength": 255},
             "base_repo_name": {"type": "string", "maxLength": 255},
             "head_ref": {"type": "string", "maxLength": 255},
@@ -64,7 +55,7 @@ def validate_preprod_artifact_schema(request_body: bytes) -> tuple[dict, str | N
         "build_configuration": "The build_configuration field must be a string.",
         "head_sha": "The head_sha field must be a 40-character hexadecimal SHA1 string (no uppercase letters).",
         "base_sha": "The base_sha field must be a 40-character hexadecimal SHA1 string (no uppercase letters).",
-        "provider": "The provider field must be a string with one of the following values: github, github_enterprise, gitlab, bitbucket, bitbucket_server.",
+        "provider": "The provider field must be a string with maximum length of 255 characters.",
         "head_repo_name": "The head_repo_name field must be a string with maximum length of 255 characters.",
         "base_repo_name": "The base_repo_name field must be a string with maximum length of 255 characters.",
         "head_ref": "The head_ref field must be a string with maximum length of 255 characters.",

--- a/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
+++ b/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
@@ -55,7 +55,7 @@ def validate_preprod_artifact_schema(request_body: bytes) -> tuple[dict, str | N
         "build_configuration": "The build_configuration field must be a string.",
         "head_sha": "The head_sha field must be a 40-character hexadecimal SHA1 string (no uppercase letters).",
         "base_sha": "The base_sha field must be a 40-character hexadecimal SHA1 string (no uppercase letters).",
-        "provider": "The provider field must be a string with maximum length of 255 characters.",
+        "provider": "The provider field must be a string with maximum length of 255 characters containing the domain of the VCS provider (ex. github.com)",
         "head_repo_name": "The head_repo_name field must be a string with maximum length of 255 characters.",
         "base_repo_name": "The base_repo_name field must be a string with maximum length of 255 characters.",
         "head_ref": "The head_ref field must be a string with maximum length of 255 characters.",

--- a/tests/sentry/preprod/api/endpoints/test_organization_preprod_artifact_assemble.py
+++ b/tests/sentry/preprod/api/endpoints/test_organization_preprod_artifact_assemble.py
@@ -155,20 +155,6 @@ class ValidatePreprodArtifactSchemaTest(TestCase):
         assert "base_sha" in error
         assert result == {}
 
-    def test_provider_too_long(self) -> None:
-        """Test provider field too long returns error."""
-        body = orjson.dumps({"checksum": "a" * 40, "chunks": [], "provider": "a" * 65})
-        result, error = validate_preprod_artifact_schema(body)
-        assert error is not None
-        assert result == {}
-
-    def test_head_repo_name_too_long(self) -> None:
-        """Test head_repo_name field too long returns error."""
-        body = orjson.dumps({"checksum": "a" * 40, "chunks": [], "head_repo_name": "a" * 256})
-        result, error = validate_preprod_artifact_schema(body)
-        assert error is not None
-        assert result == {}
-
     def test_pr_number_invalid(self) -> None:
         """Test invalid pr_number returns error."""
         body = orjson.dumps({"checksum": "a" * 40, "chunks": [], "pr_number": 0})


### PR DESCRIPTION
Noticed the CLI already has some parsing mechanisms for the VCS provider. These pull out the base URL from a given VCS url, so we should leverage this. In the future we can add logic to the backend to determine the "simple provider" from these URLs.

Sentry-cli parsing:
<img width="576" height="855" alt="Screenshot 2025-08-11 at 11 22 19 AM" src="https://github.com/user-attachments/assets/f0bccb0a-c575-4005-b807-7859dee66de3" />
