### PR TITLE
ref(performance): Remove deprecated route props from two routes

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -2218,7 +2218,6 @@ function buildRoutes(): RouteObject[] {
     {
       path: ':eventSlug/',
       component: make(() => import('sentry/views/performance/transactionDetails')),
-      deprecatedRouteProps: true,
     },
   ];
   const performanceRoutes: SentryRouteObject = {
@@ -2226,7 +2225,6 @@ function buildRoutes(): RouteObject[] {
     component: make(() => import('sentry/views/performance')),
     withOrgPath: true,
     children: performanceChildren,
-    deprecatedRouteProps: true,
   };
 
   const tracesChildren: SentryRouteObject[] = [

--- a/static/app/utils/useParams.tsx
+++ b/static/app/utils/useParams.tsx
@@ -23,6 +23,7 @@ type ParamKeys =
   | 'detectorId'
   | 'docIntegrationSlug'
   | 'eventId'
+  | 'eventSlug'
   | 'fineTuneType'
   | 'groupId'
   | 'id'

--- a/static/app/views/performance/index.tsx
+++ b/static/app/views/performance/index.tsx
@@ -1,22 +1,19 @@
-import type {Location} from 'history';
+import {Outlet} from 'react-router-dom';
 
 import Feature from 'sentry/components/acl/feature';
 import {Alert} from 'sentry/components/core/alert';
 import * as Layout from 'sentry/components/layouts/thirds';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
 import {t} from 'sentry/locale';
-import type {Organization} from 'sentry/types/organization';
 import {MetricsCardinalityProvider} from 'sentry/utils/performance/contexts/metricsCardinality';
 import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
-import withOrganization from 'sentry/utils/withOrganization';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
 
-type Props = {
-  children: React.ReactNode;
-  location: Location;
-  organization: Organization;
-};
+function PerformanceContainer() {
+  const organization = useOrganization();
+  const location = useLocation();
 
-function PerformanceContainer({organization, location, children}: Props) {
   function renderNoAccess() {
     return (
       <Layout.Page withPadding>
@@ -38,11 +35,13 @@ function PerformanceContainer({organization, location, children}: Props) {
     >
       <NoProjectMessage organization={organization}>
         <MetricsCardinalityProvider location={location} organization={organization}>
-          <MEPSettingProvider>{children}</MEPSettingProvider>
+          <MEPSettingProvider>
+            <Outlet />
+          </MEPSettingProvider>
         </MetricsCardinalityProvider>
       </NoProjectMessage>
     </Feature>
   );
 }
 
-export default withOrganization(PerformanceContainer);
+export default PerformanceContainer;

--- a/static/app/views/performance/transactionDetails/index.tsx
+++ b/static/app/views/performance/transactionDetails/index.tsx
@@ -1,28 +1,21 @@
 import * as Layout from 'sentry/components/layouts/thirds';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
-import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
-import type {Organization} from 'sentry/types/organization';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import {useParams} from 'sentry/utils/useParams';
 import useProjects from 'sentry/utils/useProjects';
-import withOrganization from 'sentry/utils/withOrganization';
 
 import EventDetailsContent from './content';
 
-type Props = RouteComponentProps<{eventSlug: string}> & {
-  organization: Organization;
-};
-
-function EventDetails(props: Props) {
+function EventDetails() {
+  const organization = useOrganization();
   const {projects} = useProjects();
+  const location = useLocation();
+  const params = useParams<{eventSlug: string}>();
 
-  const getEventSlug = (): string => {
-    const {eventSlug} = props.params;
-    return typeof eventSlug === 'string' ? eventSlug.trim() : '';
-  };
-
-  const {organization, location, params} = props;
   const documentTitle = t('Performance Details');
-  const eventSlug = getEventSlug();
+  const eventSlug = typeof params.eventSlug === 'string' ? params.eventSlug.trim() : '';
   const projectSlug = eventSlug.split(':')[0];
 
   return (
@@ -44,4 +37,4 @@ function EventDetails(props: Props) {
   );
 }
 
-export default withOrganization(EventDetails);
+export default EventDetails;


### PR DESCRIPTION
Removes use of the deprecated router props from a parent route and a child route.
Removes withOrganization use
