### PR TITLE
feat(search-bar): Update dropdowns to loop around when using arrows

### DIFF
--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -280,7 +280,7 @@ describe('SearchQueryBuilder', function () {
   });
 
   describe('disabled', function () {
-    it('disables all interactable elements', async function () {
+    it('disables all intractable elements', async function () {
       const mockOnChange = jest.fn();
       render(
         <SearchQueryBuilder
@@ -1589,6 +1589,57 @@ describe('SearchQueryBuilder', function () {
 
       const updatedListBox = screen.getByRole('checkbox', {name: 'Toggle randomValue'});
       expect(updatedListBox).toBeChecked();
+    });
+
+    describe('filter key combobox', function () {
+      it.each([
+        {
+          description: 'goes to first item when pressing arrow down',
+          arrow: '{ArrowDown}',
+          expected: 'option-age',
+        },
+        {
+          description: 'goes to last item when pressing arrow up',
+          arrow: '{ArrowUp}',
+          expected: 'option-custom_tag_name',
+        },
+        {
+          description: 'goes to first item when pressing arrow down on the last item',
+          arrow: '{ArrowDown}{ArrowUp}',
+          expected: 'option-custom_tag_name',
+        },
+        {
+          description: 'goes to last item when pressing arrow up on the first item',
+          arrow: '{ArrowUp}{ArrowDown}',
+          expected: 'option-age',
+        },
+        {
+          description: 'goes to the last item after going from second up to first',
+          arrow: '{ArrowDown}{ArrowDown}{ArrowUp}{ArrowUp}',
+          expected: 'option-custom_tag_name',
+        },
+        {
+          description:
+            'goes to the first item after going from second last item up to first',
+          arrow: '{ArrowUp}{ArrowUp}{ArrowDown}{ArrowDown}',
+          expected: 'option-age',
+        },
+      ])('$description', async function ({arrow, expected}) {
+        render(
+          <SearchQueryBuilder {...defaultProps} initialQuery="browser.name:Firefox" />
+        );
+
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Edit key for filter: browser.name'})
+        );
+
+        await userEvent.keyboard(arrow);
+        const input = await screen.findByRole('combobox', {name: 'Edit filter key'});
+        expect(input).toHaveAttribute(
+          'aria-activedescendant',
+          expect.stringContaining(expected)
+        );
+      });
     });
   });
 

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -280,7 +280,7 @@ describe('SearchQueryBuilder', function () {
   });
 
   describe('disabled', function () {
-    it('disables all intractable elements', async function () {
+    it('disables all interactable elements', async function () {
       const mockOnChange = jest.fn();
       render(
         <SearchQueryBuilder

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -1633,6 +1633,8 @@ describe('SearchQueryBuilder', function () {
           screen.getByRole('button', {name: 'Edit key for filter: browser.name'})
         );
 
+        await userEvent.clear(screen.getByRole('combobox', {name: 'Edit filter key'}));
+
         await userEvent.keyboard(arrow);
         const input = await screen.findByRole('combobox', {name: 'Edit filter key'});
         expect(input).toHaveAttribute(

--- a/static/app/components/searchQueryBuilder/tokens/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/combobox.tsx
@@ -423,6 +423,7 @@ export function SearchQueryBuilderCombobox<
       listBoxRef,
       inputRef,
       popoverRef,
+      shouldFocusWrap: true,
       onFocus: e => {
         if (openOnFocus) {
           state.open();

--- a/static/app/components/searchQueryBuilder/tokens/filter/filterKeyCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filterKeyCombobox.tsx
@@ -171,6 +171,7 @@ export function FilterKeyCombobox({token, onCommit, item}: KeyComboboxProps) {
         const firstKey = state.collection.getFirstKey();
         const lastKey = state.collection.getLastKey();
         const currentKey = state.selectionManager.focusedKey;
+        if (!firstKey || !lastKey || !currentKey) return;
 
         if (currentKey === firstKey) {
           keyUpCounter.current++;
@@ -196,6 +197,7 @@ export function FilterKeyCombobox({token, onCommit, item}: KeyComboboxProps) {
         const firstKey = state.collection.getFirstKey();
         const lastKey = state.collection.getLastKey();
         const currentKey = state.selectionManager.focusedKey;
+        if (!firstKey || !lastKey || !currentKey) return;
 
         if (currentKey === lastKey) {
           keyUpCounter.current++;

--- a/static/app/components/searchQueryBuilder/tokens/filter/filterKeyCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filterKeyCombobox.tsx
@@ -1,8 +1,7 @@
 import {useCallback, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import {Item} from '@react-stately/collections';
-import type {ComboBoxState} from '@react-stately/combobox';
-import type {KeyboardEvent, Node} from '@react-types/shared';
+import type {Node} from '@react-types/shared';
 
 import {useSeerAcknowledgeMutation} from 'sentry/components/events/autofix/useSeerAcknowledgeMutation';
 import {ASK_SEER_CONSENT_ITEM_KEY} from 'sentry/components/searchQueryBuilder/askSeer/askSeerConsentOption';
@@ -162,65 +161,6 @@ export function FilterKeyCombobox({token, onCommit, item}: KeyComboboxProps) {
     onCommit();
   }, [onCommit]);
 
-  const keyUpCounter = useRef(0);
-  const keyDownCounter = useRef(0);
-  const onKeyDown = useCallback(
-    (e: KeyboardEvent, {state}: {state: ComboBoxState<SearchKeyItem>}) => {
-      if (e.key === 'ArrowUp') {
-        e.preventDefault();
-        const firstKey = state.collection.getFirstKey();
-        const lastKey = state.collection.getLastKey();
-        const currentKey = state.selectionManager.focusedKey;
-        if (!firstKey || !lastKey || !currentKey) return;
-
-        if (currentKey === firstKey) {
-          keyUpCounter.current++;
-          keyDownCounter.current++;
-
-          if (keyUpCounter.current >= 2) {
-            keyUpCounter.current = 0;
-            state.selectionManager.setFocusedKey(state.collection.getLastKey());
-          }
-        }
-        // Case when user goes from input to last item
-        else if (currentKey === lastKey && keyDownCounter.current === 0) {
-          keyDownCounter.current = 2;
-        } else {
-          keyUpCounter.current = 0;
-          keyDownCounter.current = 0;
-        }
-        return;
-      }
-
-      if (e.key === 'ArrowDown') {
-        e.preventDefault();
-        const firstKey = state.collection.getFirstKey();
-        const lastKey = state.collection.getLastKey();
-        const currentKey = state.selectionManager.focusedKey;
-        if (!firstKey || !lastKey || !currentKey) return;
-
-        if (currentKey === lastKey) {
-          keyUpCounter.current++;
-          keyDownCounter.current++;
-
-          if (keyDownCounter.current >= 2) {
-            keyDownCounter.current = 0;
-            state.selectionManager.setFocusedKey(state.collection.getFirstKey());
-          }
-        }
-        // case when user goes from input to first item
-        else if (currentKey === firstKey && keyUpCounter.current === 0) {
-          keyUpCounter.current = 2;
-        } else {
-          keyUpCounter.current = 0;
-          keyDownCounter.current = 0;
-        }
-        return;
-      }
-    },
-    []
-  );
-
   return (
     <EditingWrapper>
       <SearchQueryBuilderCombobox
@@ -229,7 +169,6 @@ export function FilterKeyCombobox({token, onCommit, item}: KeyComboboxProps) {
         onOptionSelected={onOptionSelected}
         onCustomValueCommitted={onValueCommitted}
         onCustomValueBlurred={onCustomValueBlurred}
-        onKeyDown={onKeyDown}
         onExit={onExit}
         inputValue={inputValue}
         placeholder={getKeyLabel(token.key)}

--- a/static/app/components/searchQueryBuilder/tokens/filter/filterKeyCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filterKeyCombobox.tsx
@@ -207,7 +207,7 @@ export function FilterKeyCombobox({token, onCommit, item}: KeyComboboxProps) {
           }
         }
         // case when user goes from input to first item
-        else if (currentKey === firstKey) {
+        else if (currentKey === firstKey && keyUpCounter.current === 0) {
           keyUpCounter.current = 2;
         } else {
           keyUpCounter.current = 0;

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
@@ -53,7 +53,6 @@ import {
 } from 'sentry/components/searchSyntax/parser';
 import {getKeyName} from 'sentry/components/searchSyntax/utils';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import type {Tag, TagCollection} from 'sentry/types/group';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {uniq} from 'sentry/utils/array/uniq';
@@ -966,7 +965,7 @@ const TrailingWrap = styled('div')`
   display: grid;
   grid-auto-flow: column;
   align-items: center;
-  gap: ${space(1)};
+  gap: ${p => p.theme.space.md};
 `;
 
 const CheckWrap = styled('div')<{visible: boolean}>`
@@ -974,5 +973,8 @@ const CheckWrap = styled('div')<{visible: boolean}>`
   justify-content: center;
   align-items: center;
   opacity: ${p => (p.visible ? 1 : 0)};
-  padding: ${space(0.25)} 0 ${space(0.25)} ${space(0.25)};
+  padding-top: ${p => p.theme.space['2xs']};
+  padding-right: 0;
+  padding-bottom: ${p => p.theme.space['2xs']};
+  padding-left: ${p => p.theme.space['2xs']};
 `;

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
@@ -875,7 +875,7 @@ export function SearchQueryBuilderValueCombobox({
           }
         }
         // case when user goes from input to first item
-        else if (currentKey === firstKey) {
+        else if (currentKey === firstKey && keyUpCounter.current === 0) {
           keyUpCounter.current = 2;
         } else {
           keyUpCounter.current = 0;

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
@@ -831,11 +831,12 @@ export function SearchQueryBuilderValueCombobox({
       if (e.key === 'ArrowUp') {
         e.preventDefault();
         const firstKey = state.collection.getFirstKey();
-        if (firstKey === null) return;
-
         const lastKey = state.collection.getLastKey();
-        const secondKey = state.collection.getKeyAfter(firstKey);
         const currentKey = state.selectionManager.focusedKey;
+        if (!firstKey || !lastKey || !currentKey) return;
+
+        const secondKey = state.collection.getKeyAfter(firstKey);
+        if (!secondKey) return;
 
         if (currentKey === secondKey) {
           keyUpCounter.current++;
@@ -859,11 +860,12 @@ export function SearchQueryBuilderValueCombobox({
       if (e.key === 'ArrowDown') {
         e.preventDefault();
         const firstKey = state.collection.getFirstKey();
-        if (firstKey === null) return;
-
         const lastKey = state.collection.getLastKey();
-        const secondKey = state.collection.getKeyAfter(firstKey);
         const currentKey = state.selectionManager.focusedKey;
+        if (!firstKey || !lastKey || !currentKey) return;
+
+        const secondKey = state.collection.getKeyAfter(firstKey);
+        if (!secondKey) return;
 
         if (currentKey === lastKey) {
           keyUpCounter.current++;

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
@@ -2,7 +2,6 @@ import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import {isMac} from '@react-aria/utils';
 import {Item, Section} from '@react-stately/collections';
-import type {ComboBoxState} from '@react-stately/combobox';
 import type {KeyboardEvent} from '@react-types/shared';
 
 import {Checkbox} from 'sentry/components/core/checkbox';
@@ -812,10 +811,8 @@ export function SearchQueryBuilderValueCombobox({
     ]
   );
 
-  const keyUpCounter = useRef(0);
-  const keyDownCounter = useRef(0);
   const onKeyDown = useCallback(
-    (e: KeyboardEvent, {state}: {state: ComboBoxState<SelectOptionWithKey<string>>}) => {
+    (e: KeyboardEvent) => {
       // Default combobox behavior stops events from propagating outside of input
       // Certain keys like ctrl+z should be handled handled in useQueryBuilderGrid()
       // so we need to continue propagation for those.
@@ -826,64 +823,6 @@ export function SearchQueryBuilderValueCombobox({
       // If there's nothing in the input and we hit a delete key, we should focus the filter
       if ((e.key === 'Backspace' || e.key === 'Delete') && !inputRef.current?.value) {
         onDelete();
-      }
-
-      if (e.key === 'ArrowUp') {
-        e.preventDefault();
-        const firstKey = state.collection.getFirstKey();
-        const lastKey = state.collection.getLastKey();
-        const currentKey = state.selectionManager.focusedKey;
-        if (!firstKey || !lastKey || !currentKey) return;
-
-        const secondKey = state.collection.getKeyAfter(firstKey);
-        if (!secondKey) return;
-
-        if (currentKey === secondKey) {
-          keyUpCounter.current++;
-          keyDownCounter.current++;
-
-          if (keyUpCounter.current >= 2) {
-            keyUpCounter.current = 0;
-            state.selectionManager.setFocusedKey(state.collection.getLastKey());
-          }
-        }
-        // Case when user goes from input to last item
-        else if (currentKey === lastKey && keyDownCounter.current === 0) {
-          keyDownCounter.current = 2;
-        } else {
-          keyUpCounter.current = 0;
-          keyDownCounter.current = 0;
-        }
-        return;
-      }
-
-      if (e.key === 'ArrowDown') {
-        e.preventDefault();
-        const firstKey = state.collection.getFirstKey();
-        const lastKey = state.collection.getLastKey();
-        const currentKey = state.selectionManager.focusedKey;
-        if (!firstKey || !lastKey || !currentKey) return;
-
-        const secondKey = state.collection.getKeyAfter(firstKey);
-        if (!secondKey) return;
-
-        if (currentKey === lastKey) {
-          keyUpCounter.current++;
-          keyDownCounter.current++;
-
-          if (keyDownCounter.current >= 2) {
-            keyDownCounter.current = 0;
-            state.selectionManager.setFocusedKey(secondKey);
-          }
-        }
-        // case when user goes from input to first item
-        else if (currentKey === firstKey && keyUpCounter.current === 0) {
-          keyUpCounter.current = 2;
-        } else {
-          keyUpCounter.current = 0;
-          keyDownCounter.current = 0;
-        }
-        return;
       }
     },
     [onDelete]

--- a/static/app/components/tokenizedInput/token/comboBox.tsx
+++ b/static/app/components/tokenizedInput/token/comboBox.tsx
@@ -228,6 +228,7 @@ export function ComboBox({
       listBoxRef,
       inputRef,
       popoverRef,
+      shouldFocusWrap: true,
       onFocus: handleComboBoxFocus,
       onBlur: handleComboBoxBlur,
       onKeyDown: handleComboBoxKeyDown,


### PR DESCRIPTION
This PR updates the combobox dropdowns to loop when hitting the top or bottom items in the list, similar to the behaviour of the larger suggestion dropdown that first appears when entering the input.

This PR also removes uses cases `space` and moves them to their theme equivalent in touched files.