### PR TITLE
feat(logs): Swap logs to query params context for visualizes readonly

### DIFF
--- a/static/app/views/explore/contexts/logs/logsPageParams.tsx
+++ b/static/app/views/explore/contexts/logs/logsPageParams.tsx
@@ -357,22 +357,6 @@ export function useLogsCursor() {
   return cursor;
 }
 
-export function useLogsAggregateFunction() {
-  const {aggregateFn} = useLogsPageParams();
-  return aggregateFn;
-}
-
-export function useLogsAggregateParam() {
-  const {aggregateParam} = useLogsPageParams();
-  return aggregateParam;
-}
-
-export function useLogsAggregate() {
-  const aggregateFn = useLogsAggregateFunction();
-  const aggregateParam = useLogsAggregateParam();
-  return `${aggregateFn}(${aggregateParam})`;
-}
-
 export function useLogsLimitToTraceId() {
   const {limitToTraceId} = useLogsPageParams();
   return limitToTraceId;

--- a/static/app/views/explore/logs/logsGraph.tsx
+++ b/static/app/views/explore/logs/logsGraph.tsx
@@ -8,14 +8,17 @@ import {defined} from 'sentry/utils';
 import {determineSeriesSampleCountAndIsSampled} from 'sentry/views/alerts/rules/metric/utils/determineSeriesSampleCount';
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 import {ChartVisualization} from 'sentry/views/explore/components/chart/chartVisualization';
-import {useLogsAggregate} from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {
   ChartIntervalUnspecifiedStrategy,
   useChartInterval,
 } from 'sentry/views/explore/hooks/useChartInterval';
 import {TOP_EVENTS_LIMIT} from 'sentry/views/explore/hooks/useTopEvents';
 import {ConfidenceFooter} from 'sentry/views/explore/logs/confidenceFooter';
-import {useQueryParamsTopEventsLimit} from 'sentry/views/explore/queryParams/context';
+import {
+  useQueryParamsTopEventsLimit,
+  useQueryParamsVisualizes,
+} from 'sentry/views/explore/queryParams/context';
+import type {Visualize} from 'sentry/views/explore/queryParams/visualize';
 import {EXPLORE_CHART_TYPE_OPTIONS} from 'sentry/views/explore/spans/charts';
 import {
   combineConfidenceForSeries,
@@ -29,7 +32,25 @@ interface LogsGraphProps {
 }
 
 export function LogsGraph({timeseriesResult}: LogsGraphProps) {
-  const aggregate = useLogsAggregate();
+  const visualizes = useQueryParamsVisualizes();
+
+  return (
+    <Fragment>
+      {visualizes.map((visualize, index) => {
+        return (
+          <Graph key={index} visualize={visualize} timeseriesResult={timeseriesResult} />
+        );
+      })}
+    </Fragment>
+  );
+}
+
+interface GraphProps extends LogsGraphProps {
+  visualize: Visualize;
+}
+
+function Graph({timeseriesResult, visualize}: GraphProps) {
+  const aggregate = visualize.yAxis;
   const topEventsLimit = useQueryParamsTopEventsLimit();
 
   const [chartType, setChartType] = useState<ChartType>(ChartType.BAR);

--- a/static/app/views/explore/logs/logsQueryParams.spec.tsx
+++ b/static/app/views/explore/logs/logsQueryParams.spec.tsx
@@ -5,7 +5,7 @@ import {getReadableQueryParamsFromLocation} from 'sentry/views/explore/logs/logs
 import {Mode} from 'sentry/views/explore/queryParams/mode';
 import type {ReadableQueryParamsOptions} from 'sentry/views/explore/queryParams/readableQueryParams';
 import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
-import {Visualize} from 'sentry/views/explore/queryParams/visualize';
+import {VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
 
 function locationFixture(query: Location['query']): Location {
   return LocationFixture({query});
@@ -21,7 +21,7 @@ function readableQueryParamOptions(
     fields: ['timestamp', 'message'],
     sortBys: [{field: 'timestamp', kind: 'desc'}],
     aggregateCursor: '',
-    aggregateFields: [{groupBy: ''}, new Visualize('count(message)')],
+    aggregateFields: [{groupBy: ''}, new VisualizeFunction('count(message)')],
     aggregateSortBys: [
       {
         field: 'count(message)',
@@ -179,7 +179,10 @@ describe('getReadableQueryParamsFromLocation', function () {
     expect(queryParams).toEqual(
       new ReadableQueryParams(
         readableQueryParamOptions({
-          aggregateFields: [{groupBy: 'severity'}, new Visualize('count(message)')],
+          aggregateFields: [
+            {groupBy: 'severity'},
+            new VisualizeFunction('count(message)'),
+          ],
         })
       )
     );
@@ -191,7 +194,7 @@ describe('getReadableQueryParamsFromLocation', function () {
     expect(queryParams).toEqual(
       new ReadableQueryParams(
         readableQueryParamOptions({
-          aggregateFields: [{groupBy: ''}, new Visualize('avg(foo)')],
+          aggregateFields: [{groupBy: ''}, new VisualizeFunction('avg(foo)')],
           aggregateSortBys: [{field: 'avg(foo)', kind: 'desc'}],
         })
       )
@@ -209,7 +212,7 @@ describe('getReadableQueryParamsFromLocation', function () {
     expect(queryParams).toEqual(
       new ReadableQueryParams(
         readableQueryParamOptions({
-          aggregateFields: [{groupBy: 'severity'}, new Visualize('avg(foo)')],
+          aggregateFields: [{groupBy: 'severity'}, new VisualizeFunction('avg(foo)')],
           aggregateSortBys: [{field: 'severity', kind: 'desc'}],
         })
       )

--- a/static/app/views/explore/logs/logsQueryParams.tsx
+++ b/static/app/views/explore/logs/logsQueryParams.tsx
@@ -1,6 +1,7 @@
 import type {Location} from 'history';
 
 import type {Sort} from 'sentry/utils/discover/fields';
+import {AggregationKey} from 'sentry/utils/fields';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {defaultLogFields} from 'sentry/views/explore/contexts/logs/fields';
 import {
@@ -31,7 +32,8 @@ import {getModeFromLocation} from 'sentry/views/explore/queryParams/mode';
 import {getQueryFromLocation} from 'sentry/views/explore/queryParams/query';
 import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
 import {getSortBysFromLocation} from 'sentry/views/explore/queryParams/sortBy';
-import {isVisualize, Visualize} from 'sentry/views/explore/queryParams/visualize';
+import type {Visualize} from 'sentry/views/explore/queryParams/visualize';
+import {isVisualize, VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
 import type {WritableQueryParams} from 'sentry/views/explore/queryParams/writableQueryParams';
 
 const LOGS_MODE_KEY = 'mode';
@@ -102,17 +104,20 @@ function defaultSortBys(fields: string[]) {
 }
 
 export function defaultVisualizes() {
-  return [new Visualize('count(message)')];
+  return [new VisualizeFunction('count(message)')];
 }
 
 function getVisualizesFromLocation(location: Location): [Visualize] {
-  const aggregateFn = decodeScalar(location.query?.[LOGS_AGGREGATE_FN_KEY], 'count');
+  const aggregateFn = decodeScalar(
+    location.query?.[LOGS_AGGREGATE_FN_KEY],
+    AggregationKey.COUNT
+  );
   const aggregateParam = decodeScalar(
     location.query?.[LOGS_AGGREGATE_PARAM_KEY],
-    'message'
+    aggregateFn === AggregationKey.COUNT ? OurLogKnownFieldKey.MESSAGE : ''
   );
 
-  return [new Visualize(`${aggregateFn}(${aggregateParam})`)];
+  return [new VisualizeFunction(`${aggregateFn}(${aggregateParam})`)];
 }
 
 function getLogsAggregateFieldsFromLocation(location: Location): AggregateField[] {

--- a/static/app/views/explore/logs/tables/logsAggregateTable.tsx
+++ b/static/app/views/explore/logs/tables/logsAggregateTable.tsx
@@ -11,7 +11,6 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {
   LOGS_AGGREGATE_CURSOR_KEY,
-  useLogsAggregate,
   useLogsAggregateSortBys,
   useSetLogsPageParams,
 } from 'sentry/views/explore/contexts/logs/logsPageParams';
@@ -21,7 +20,10 @@ import {LogFieldRenderer} from 'sentry/views/explore/logs/fieldRenderers';
 import {getLogColors} from 'sentry/views/explore/logs/styles';
 import {useLogsAggregatesQuery} from 'sentry/views/explore/logs/useLogsQuery';
 import {SeverityLevel} from 'sentry/views/explore/logs/utils';
-import {useQueryParamsGroupBys} from 'sentry/views/explore/queryParams/context';
+import {
+  useQueryParamsGroupBys,
+  useQueryParamsVisualizes,
+} from 'sentry/views/explore/queryParams/context';
 
 export function LogsAggregateTable() {
   const {data, pageLinks, isLoading, error} = useLogsAggregatesQuery({
@@ -30,7 +32,7 @@ export function LogsAggregateTable() {
 
   const setLogsPageParams = useSetLogsPageParams();
   const groupBys = useQueryParamsGroupBys();
-  const aggregate = useLogsAggregate();
+  const visualizes = useQueryParamsVisualizes();
   const aggregateSortBys = useLogsAggregateSortBys();
   const location = useLocation();
   const theme = useTheme();
@@ -38,7 +40,7 @@ export function LogsAggregateTable() {
 
   const fields: string[] = [];
   fields.push(...groupBys.filter(Boolean));
-  fields.push(aggregate);
+  fields.push(...visualizes.map(visualize => visualize.yAxis));
 
   return (
     <TableContainer>

--- a/static/app/views/explore/logs/useLogsQuery.tsx
+++ b/static/app/views/explore/logs/useLogsQuery.tsx
@@ -22,7 +22,6 @@ import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {useLogsAutoRefreshEnabled} from 'sentry/views/explore/contexts/logs/logsAutoRefreshContext';
 import {
-  useLogsAggregate,
   useLogsAggregateCursor,
   useLogsAggregateSortBys,
   useLogsBaseSearch,
@@ -53,7 +52,10 @@ import {
   useVirtualStreaming,
 } from 'sentry/views/explore/logs/useVirtualStreaming';
 import {getTimeBasedSortBy} from 'sentry/views/explore/logs/utils';
-import {useQueryParamsGroupBys} from 'sentry/views/explore/queryParams/context';
+import {
+  useQueryParamsGroupBys,
+  useQueryParamsVisualizes,
+} from 'sentry/views/explore/queryParams/context';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 import {getEventView} from 'sentry/views/insights/common/queries/useDiscover';
 import {getStaleTimeForEventView} from 'sentry/views/insights/common/queries/useSpansQuery';
@@ -116,12 +118,12 @@ function useLogsAggregatesQueryKey({
   const location = useLocation();
   const projectIds = useLogsProjectIds();
   const groupBys = useQueryParamsGroupBys();
-  const aggregate = useLogsAggregate();
+  const visualizes = useQueryParamsVisualizes();
   const aggregateSortBys = useLogsAggregateSortBys();
   const aggregateCursor = useLogsAggregateCursor();
   const fields: string[] = [];
   fields.push(...groupBys.filter(Boolean));
-  fields.push(aggregate);
+  fields.push(...visualizes.map(visualize => visualize.yAxis));
 
   const search = baseSearch ? _search.copy() : _search;
   if (baseSearch) {

--- a/static/app/views/explore/logs/useSaveAsItems.spec.tsx
+++ b/static/app/views/explore/logs/useSaveAsItems.spec.tsx
@@ -17,6 +17,7 @@ import usePageFilters from 'sentry/utils/usePageFilters';
 import {LogsPageParamsProvider} from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {useSaveAsItems} from 'sentry/views/explore/logs/useSaveAsItems';
+import {VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
 import {OrganizationContext} from 'sentry/views/organizationContext';
 
 jest.mock('sentry/utils/useLocation');
@@ -101,7 +102,7 @@ describe('useSaveAsItems', () => {
     const {result} = renderHook(
       () =>
         useSaveAsItems({
-          aggregate: 'count()',
+          visualizes: [new VisualizeFunction('count()')],
           groupBys: ['message.template'],
           interval: '5m',
           mode: Mode.AGGREGATE,
@@ -130,7 +131,7 @@ describe('useSaveAsItems', () => {
     const {result} = renderHook(
       () =>
         useSaveAsItems({
-          aggregate: 'count()',
+          visualizes: [new VisualizeFunction('count()')],
           groupBys: ['message.template'],
           interval: '5m',
           mode: Mode.AGGREGATE,

--- a/static/app/views/explore/logs/useSaveAsItems.tsx
+++ b/static/app/views/explore/logs/useSaveAsItems.tsx
@@ -28,25 +28,26 @@ import {handleAddQueryToDashboard} from 'sentry/views/discover/utils';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {formatSort} from 'sentry/views/explore/contexts/pageParamsContext/sortBys';
 import {useLogsSaveQuery} from 'sentry/views/explore/hooks/useSaveQuery';
+import type {Visualize} from 'sentry/views/explore/queryParams/visualize';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 import {getAlertsUrl} from 'sentry/views/insights/common/utils/getAlertsUrl';
 
 interface UseSaveAsItemsOptions {
-  aggregate: string;
   groupBys: readonly string[];
   interval: string;
   mode: Mode;
   search: MutableSearch;
   sortBys: Sort[];
+  visualizes: readonly Visualize[];
 }
 
 export function useSaveAsItems({
-  aggregate,
   groupBys,
   interval,
   mode,
   search,
   sortBys,
+  visualizes,
 }: UseSaveAsItemsOptions) {
   const location = useLocation();
   const router = useRouter();
@@ -60,7 +61,10 @@ export function useSaveAsItems({
       ? projects[0]
       : projects.find(p => p.id === `${pageFilters.selection.projects[0]}`);
 
-  const aggregates = useMemo(() => [aggregate], [aggregate]);
+  const aggregates = useMemo(
+    () => visualizes.map(visualize => visualize.yAxis),
+    [visualizes]
+  );
 
   const saveAsQuery = useMemo(() => {
     return {

--- a/static/app/views/explore/logs/useStreamingTimeseriesResult.tsx
+++ b/static/app/views/explore/logs/useStreamingTimeseriesResult.tsx
@@ -13,14 +13,16 @@ import type {
 } from 'sentry/views/dashboards/widgets/common/types';
 import {useLogsAutoRefreshEnabled} from 'sentry/views/explore/contexts/logs/logsAutoRefreshContext';
 import type {useLogsPageDataQueryResult} from 'sentry/views/explore/contexts/logs/logsPageData';
-import {useLogsAggregate} from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {AlwaysPresentLogFields} from 'sentry/views/explore/logs/constants';
 import type {OurLogsResponseItem} from 'sentry/views/explore/logs/types';
 import {
   getLogRowTimestampMillis,
   getLogTimestampBucketIndex,
 } from 'sentry/views/explore/logs/utils';
-import {useQueryParamsGroupBys} from 'sentry/views/explore/queryParams/context';
+import {
+  useQueryParamsGroupBys,
+  useQueryParamsVisualizes,
+} from 'sentry/views/explore/queryParams/context';
 import type {useSortedTimeSeries} from 'sentry/views/insights/common/queries/useSortedTimeSeries';
 
 type BufferEntry = {
@@ -80,7 +82,11 @@ export function useStreamingTimeseriesResult(
 ): ReturnType<typeof useSortedTimeSeries> {
   const organization = useOrganization();
   const groupBys = useQueryParamsGroupBys();
-  const aggregate = useLogsAggregate();
+  const visualizes = useQueryParamsVisualizes();
+  if (!visualizes[0] || visualizes.length !== 1) {
+    throw new Error('single visualize only');
+  }
+  const aggregate = visualizes[0].yAxis;
 
   const autoRefresh = useLogsAutoRefreshEnabled();
   const {selection} = usePageFilters();

--- a/static/app/views/explore/queryParams/context.tsx
+++ b/static/app/views/explore/queryParams/context.tsx
@@ -3,8 +3,9 @@ import {useCallback, useMemo} from 'react';
 
 import {createDefinedContext} from 'sentry/utils/performance/contexts/utils';
 import {TOP_EVENTS_LIMIT} from 'sentry/views/explore/hooks/useTopEvents';
-import {Mode} from 'sentry/views/explore/queryParams/mode';
+import type {Mode} from 'sentry/views/explore/queryParams/mode';
 import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
+import type {Visualize} from 'sentry/views/explore/queryParams/visualize';
 import type {WritableQueryParams} from 'sentry/views/explore/queryParams/writableQueryParams';
 
 interface QueryParamsContextValue {
@@ -65,6 +66,11 @@ export function useSetQueryParamsMode() {
     },
     [setQueryParams]
   );
+}
+
+export function useQueryParamsVisualizes(): readonly Visualize[] {
+  const queryParams = useQueryParams();
+  return queryParams.visualizes;
 }
 
 export function useQueryParamsGroupBys(): readonly string[] {

--- a/static/app/views/explore/queryParams/visualize.spec.ts
+++ b/static/app/views/explore/queryParams/visualize.spec.ts
@@ -1,11 +1,11 @@
-import {Visualize} from 'sentry/views/explore/queryParams/visualize';
+import {Visualize, VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
 
-describe('Visualize', function () {
+describe('VisualizeFunction', function () {
   it.each(['count(span.duration)', 'count_unique(span.op)', 'sum(span.duration)'])(
     'defaults to bar charts for %s',
     function (yAxis) {
-      const visualize = new Visualize(yAxis);
+      const visualize = new VisualizeFunction(yAxis);
       expect(visualize.chartType).toEqual(ChartType.BAR);
     }
   );
@@ -21,72 +21,63 @@ describe('Visualize', function () {
     'min(span.duration)',
     'max(span.duration)',
   ])('defaults to bar charts for %s', function (yAxis) {
-    const visualize = new Visualize(yAxis);
+    const visualize = new VisualizeFunction(yAxis);
     expect(visualize.chartType).toEqual(ChartType.LINE);
   });
 
   it('uses selected chart type', function () {
-    const visualize = new Visualize('count(span.duration)', {
+    const visualize = new VisualizeFunction('count(span.duration)', {
       chartType: ChartType.AREA,
     });
     expect(visualize.chartType).toEqual(ChartType.AREA);
   });
 
   it('clones', function () {
-    const vis1 = new Visualize('count(span.duration)', {chartType: ChartType.AREA});
+    const vis1 = new VisualizeFunction('count(span.duration)', {
+      chartType: ChartType.AREA,
+    });
     const vis2 = vis1.clone();
     expect(vis1).toEqual(vis2);
   });
 
   it('replaces yAxes', function () {
-    const vis1 = new Visualize('count(span.duration)', {chartType: ChartType.AREA});
+    const vis1 = new VisualizeFunction('count(span.duration)', {
+      chartType: ChartType.AREA,
+    });
     const vis2 = vis1.replace({yAxis: 'avg(span.duration)'});
     expect(vis2).toEqual(
-      new Visualize('avg(span.duration)', {chartType: ChartType.AREA})
+      new VisualizeFunction('avg(span.duration)', {chartType: ChartType.AREA})
     );
   });
 
   it('replaces chart type', function () {
-    const vis1 = new Visualize('count(span.duration)', {chartType: ChartType.AREA});
+    const vis1 = new VisualizeFunction('count(span.duration)', {
+      chartType: ChartType.AREA,
+    });
     const vis2 = vis1.replace({chartType: ChartType.LINE});
     expect(vis2).toEqual(
-      new Visualize('count(span.duration)', {chartType: ChartType.LINE})
+      new VisualizeFunction('count(span.duration)', {chartType: ChartType.LINE})
     );
   });
 
   it('replaces yAxes and chart type', function () {
-    const vis1 = new Visualize('count(span.duration)', {chartType: ChartType.AREA});
+    const vis1 = new VisualizeFunction('count(span.duration)', {
+      chartType: ChartType.AREA,
+    });
     const vis2 = vis1.replace({
       yAxis: 'avg(span.duration)',
       chartType: ChartType.LINE,
     });
     expect(vis2).toEqual(
-      new Visualize('avg(span.duration)', {chartType: ChartType.LINE})
+      new VisualizeFunction('avg(span.duration)', {chartType: ChartType.LINE})
     );
-  });
-
-  it('converts to JSON without chart type', function () {
-    const visualize = new Visualize('count(span.duration)');
-    expect(visualize.toJSON()).toEqual({
-      yAxes: ['count(span.duration)'],
-    });
-  });
-
-  it('converts to JSON with chart type', function () {
-    const visualize = new Visualize('count(span.duration)', {
-      chartType: ChartType.AREA,
-    });
-    expect(visualize.toJSON()).toEqual({
-      yAxes: ['count(span.duration)'],
-      chartType: ChartType.AREA,
-    });
   });
 
   it('converts from JSON without chart type', function () {
     const visualize = Visualize.fromJSON({
       yAxes: ['count(span.duration)'],
     });
-    expect(visualize).toEqual([new Visualize('count(span.duration)')]);
+    expect(visualize).toEqual([new VisualizeFunction('count(span.duration)')]);
   });
 
   it('converts from JSON with chart type', function () {
@@ -95,7 +86,7 @@ describe('Visualize', function () {
       chartType: ChartType.AREA,
     });
     expect(visualize).toEqual([
-      new Visualize('count(span.duration)', {chartType: ChartType.AREA}),
+      new VisualizeFunction('count(span.duration)', {chartType: ChartType.AREA}),
     ]);
   });
 });

--- a/static/app/views/explore/queryParams/visualize.ts
+++ b/static/app/views/explore/queryParams/visualize.ts
@@ -1,6 +1,13 @@
 import type {Location} from 'history';
 
+import {Expression} from 'sentry/components/arithmeticBuilder/expression';
 import {defined} from 'sentry/utils';
+import {type ParsedFunction} from 'sentry/utils/discover/fields';
+import {
+  isEquation,
+  parseFunction,
+  stripEquationPrefix,
+} from 'sentry/utils/discover/fields';
 import {decodeList} from 'sentry/utils/queryString';
 import {determineDefaultChartType} from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
@@ -9,10 +16,11 @@ interface VisualizeOptions {
   chartType?: ChartType;
 }
 
-export class Visualize {
+export abstract class Visualize {
   readonly yAxis: string;
   readonly chartType: ChartType;
-  private readonly selectedChartType?: ChartType;
+  abstract readonly kind: 'function' | 'equation';
+  protected readonly selectedChartType?: ChartType;
 
   constructor(yAxis: string, options?: VisualizeOptions) {
     this.yAxis = yAxis;
@@ -20,32 +28,66 @@ export class Visualize {
     this.chartType = this.selectedChartType ?? determineDefaultChartType([yAxis]);
   }
 
+  abstract clone(): Visualize;
+  abstract replace({
+    chartType,
+    yAxis,
+  }: {
+    chartType?: ChartType;
+    yAxis?: string;
+  }): Visualize;
+
+  static fromJSON(json: BaseVisualize): Visualize[] {
+    return json.yAxes.map(yAxis => {
+      if (isEquation(yAxis)) {
+        return new VisualizeEquation(yAxis, {chartType: json.chartType});
+      }
+      return new VisualizeFunction(yAxis, {chartType: json.chartType});
+    });
+  }
+}
+
+export class VisualizeFunction extends Visualize {
+  readonly kind = 'function';
+  readonly parsedFunction: ParsedFunction | null;
+
+  constructor(yAxis: string, options?: VisualizeOptions) {
+    super(yAxis, options);
+    this.parsedFunction = parseFunction(yAxis);
+  }
+
   clone(): Visualize {
-    return new Visualize(this.yAxis, {
+    return new VisualizeFunction(this.yAxis, {
       chartType: this.selectedChartType,
     });
   }
 
   replace({chartType, yAxis}: {chartType?: ChartType; yAxis?: string}): Visualize {
-    return new Visualize(yAxis ?? this.yAxis, {
+    return new VisualizeFunction(yAxis ?? this.yAxis, {
       chartType: chartType ?? this.selectedChartType,
     });
   }
+}
 
-  toJSON(): BaseVisualize {
-    const json: BaseVisualize = {
-      yAxes: [this.yAxis],
-    };
+class VisualizeEquation extends Visualize {
+  readonly kind = 'equation';
+  readonly expression: Expression;
 
-    if (defined(this.selectedChartType)) {
-      json.chartType = this.selectedChartType;
-    }
-
-    return json;
+  constructor(yAxis: string, options?: VisualizeOptions) {
+    super(yAxis, options);
+    this.expression = new Expression(stripEquationPrefix(yAxis));
   }
 
-  static fromJSON(json: BaseVisualize): Visualize[] {
-    return json.yAxes.map(yAxis => new Visualize(yAxis, {chartType: json.chartType}));
+  clone(): Visualize {
+    return new VisualizeEquation(this.yAxis, {
+      chartType: this.selectedChartType,
+    });
+  }
+
+  replace({chartType, yAxis}: {chartType?: ChartType; yAxis?: string}): Visualize {
+    return new VisualizeEquation(yAxis ?? this.yAxis, {
+      chartType: chartType ?? this.selectedChartType,
+    });
   }
 }
 
@@ -74,13 +116,19 @@ export function getVisualizesFromLocation(
 
 export function parseVisualize(value: any): Visualize[] {
   if (isBaseVisualize(value)) {
-    return value.yAxes.map(yAxis => new Visualize(yAxis, {chartType: value.chartType}));
+    return Visualize.fromJSON(value);
   }
   return [];
 }
 
 export function isVisualize(value: any): value is Visualize {
   return defined(value) && typeof value === 'object' && typeof value.yAxis === 'string';
+}
+
+export function isVisualizeFunction(
+  visualize: Visualize
+): visualize is VisualizeFunction {
+  return visualize.kind === 'function';
 }
 
 interface BaseVisualize {

--- a/static/app/views/explore/queryParams/visualize.ts
+++ b/static/app/views/explore/queryParams/visualize.ts
@@ -2,11 +2,11 @@ import type {Location} from 'history';
 
 import {Expression} from 'sentry/components/arithmeticBuilder/expression';
 import {defined} from 'sentry/utils';
-import {type ParsedFunction} from 'sentry/utils/discover/fields';
 import {
   isEquation,
   parseFunction,
   stripEquationPrefix,
+  type ParsedFunction,
 } from 'sentry/utils/discover/fields';
 import {decodeList} from 'sentry/utils/queryString';
 import {determineDefaultChartType} from 'sentry/views/explore/contexts/pageParamsContext/visualizes';

--- a/static/app/views/explore/spans/spansQueryParams.spec.tsx
+++ b/static/app/views/explore/spans/spansQueryParams.spec.tsx
@@ -6,7 +6,7 @@ import {initializeOrg} from 'sentry-test/initializeOrg';
 import {Mode} from 'sentry/views/explore/queryParams/mode';
 import type {ReadableQueryParamsOptions} from 'sentry/views/explore/queryParams/readableQueryParams';
 import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
-import {Visualize} from 'sentry/views/explore/queryParams/visualize';
+import {VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
 import {getReadableQueryParamsFromLocation} from 'sentry/views/explore/spans/spansQueryParams';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
 
@@ -31,7 +31,7 @@ function readableQueryParamOptions(
     ],
     sortBys: [{field: 'timestamp', kind: 'desc'}],
     aggregateCursor: '',
-    aggregateFields: [{groupBy: ''}, new Visualize('count(span.duration)')],
+    aggregateFields: [{groupBy: ''}, new VisualizeFunction('count(span.duration)')],
     aggregateSortBys: [
       {
         field: 'count(span.duration)',
@@ -224,7 +224,7 @@ describe('getReadableQueryParamsFromLocation', function () {
           aggregateFields: [
             {groupBy: 'span.op'},
             {groupBy: 'transaction'},
-            new Visualize('count(span.duration)'),
+            new VisualizeFunction('count(span.duration)'),
           ],
         })
       )
@@ -238,15 +238,19 @@ describe('getReadableQueryParamsFromLocation', function () {
     const queryParams = getReadableQueryParamsFromLocation(location, organization);
     expect(queryParams.aggregateFields).toHaveLength(3);
     expect(queryParams.aggregateFields[0]).toEqual({groupBy: ''});
-    expect(queryParams.aggregateFields[1]).toEqual(new Visualize('count(span.duration)'));
-    expect(queryParams.aggregateFields[2]).toEqual(new Visualize('avg(span.self_time)'));
+    expect(queryParams.aggregateFields[1]).toEqual(
+      new VisualizeFunction('count(span.duration)')
+    );
+    expect(queryParams.aggregateFields[2]).toEqual(
+      new VisualizeFunction('avg(span.self_time)')
+    );
     expect(queryParams).toEqual(
       new ReadableQueryParams(
         readableQueryParamOptions({
           aggregateFields: [
             {groupBy: ''},
-            new Visualize('count(span.duration)'),
-            new Visualize('avg(span.self_time)'),
+            new VisualizeFunction('count(span.duration)'),
+            new VisualizeFunction('avg(span.self_time)'),
           ],
         })
       )
@@ -266,8 +270,8 @@ describe('getReadableQueryParamsFromLocation', function () {
         readableQueryParamOptions({
           aggregateFields: [
             {groupBy: ''},
-            new Visualize('count(span.duration)', {chartType: ChartType.LINE}),
-            new Visualize('avg(span.self_time)', {chartType: ChartType.LINE}),
+            new VisualizeFunction('count(span.duration)', {chartType: ChartType.LINE}),
+            new VisualizeFunction('avg(span.self_time)', {chartType: ChartType.LINE}),
           ],
         })
       )
@@ -287,10 +291,10 @@ describe('getReadableQueryParamsFromLocation', function () {
       new ReadableQueryParams(
         readableQueryParamOptions({
           aggregateFields: [
-            new Visualize('count(span.duration)', {chartType: ChartType.AREA}),
+            new VisualizeFunction('count(span.duration)', {chartType: ChartType.AREA}),
             {groupBy: 'span.op'},
-            new Visualize('p50(span.duration)'),
-            new Visualize('p75(span.duration)'),
+            new VisualizeFunction('p50(span.duration)'),
+            new VisualizeFunction('p75(span.duration)'),
           ],
         })
       )
@@ -308,7 +312,7 @@ describe('getReadableQueryParamsFromLocation', function () {
       new ReadableQueryParams(
         readableQueryParamOptions({
           aggregateFields: [
-            new Visualize('count(span.duration)', {chartType: ChartType.LINE}),
+            new VisualizeFunction('count(span.duration)', {chartType: ChartType.LINE}),
             {groupBy: ''},
           ],
         })
@@ -323,11 +327,16 @@ describe('getReadableQueryParamsFromLocation', function () {
     const queryParams = getReadableQueryParamsFromLocation(location, organization);
     expect(queryParams.aggregateFields).toHaveLength(2);
     expect(queryParams.aggregateFields[0]).toEqual({groupBy: 'span.op'});
-    expect(queryParams.aggregateFields[1]).toEqual(new Visualize('count(span.duration)'));
+    expect(queryParams.aggregateFields[1]).toEqual(
+      new VisualizeFunction('count(span.duration)')
+    );
     expect(queryParams).toEqual(
       new ReadableQueryParams(
         readableQueryParamOptions({
-          aggregateFields: [{groupBy: 'span.op'}, new Visualize('count(span.duration)')],
+          aggregateFields: [
+            {groupBy: 'span.op'},
+            new VisualizeFunction('count(span.duration)'),
+          ],
         })
       )
     );
@@ -348,8 +357,8 @@ describe('getReadableQueryParamsFromLocation', function () {
         readableQueryParamOptions({
           aggregateFields: [
             {groupBy: 'span.op'},
-            new Visualize('p50(span.duration)'),
-            new Visualize('avg(span.duration)', {chartType: ChartType.AREA}),
+            new VisualizeFunction('p50(span.duration)'),
+            new VisualizeFunction('avg(span.duration)', {chartType: ChartType.AREA}),
           ],
           aggregateSortBys: [
             {field: 'span.op', kind: 'desc'},
@@ -371,7 +380,7 @@ describe('getReadableQueryParamsFromLocation', function () {
     expect(queryParams).toEqual(
       new ReadableQueryParams(
         readableQueryParamOptions({
-          aggregateFields: [{groupBy: ''}, new Visualize('p50(span.duration)')],
+          aggregateFields: [{groupBy: ''}, new VisualizeFunction('p50(span.duration)')],
           aggregateSortBys: [{field: 'p50(span.duration)', kind: 'desc'}],
         })
       )

--- a/static/app/views/explore/spans/spansQueryParams.tsx
+++ b/static/app/views/explore/spans/spansQueryParams.tsx
@@ -17,10 +17,11 @@ import {getModeFromLocation} from 'sentry/views/explore/queryParams/mode';
 import {getQueryFromLocation} from 'sentry/views/explore/queryParams/query';
 import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
 import {getSortBysFromLocation} from 'sentry/views/explore/queryParams/sortBy';
+import type {Visualize} from 'sentry/views/explore/queryParams/visualize';
 import {
   getVisualizesFromLocation,
   isVisualize,
-  Visualize,
+  VisualizeFunction,
 } from 'sentry/views/explore/queryParams/visualize';
 import {SpanFields} from 'sentry/views/insights/types';
 
@@ -117,7 +118,7 @@ function defaultGroupBys(): [GroupBy] {
 }
 
 function defaultVisualizes(): [Visualize] {
-  return [new Visualize(DEFAULT_VISUALIZATION)];
+  return [new VisualizeFunction(DEFAULT_VISUALIZATION)];
 }
 
 function getSpansAggregateFieldsFromLocation(location: Location): AggregateField[] {


### PR DESCRIPTION
This swaps out the read portions for visualizes to use the new query params context.