### PR TITLE
fix(insights): asset module shows "we couldn't find any size info" before finishing loading

### DIFF
--- a/static/app/views/insights/browser/resources/components/resourceInfo.tsx
+++ b/static/app/views/insights/browser/resources/components/resourceInfo.tsx
@@ -113,7 +113,7 @@ function ResourceInfo(props: Props) {
         />
       </ReadoutRibbon>
 
-      {hasNoData && (
+      {!isLoading && hasNoData && (
         <Alert.Container>
           <Alert style={{width: '100%'}} type="warning">
             {t(


### PR DESCRIPTION
Fixes a bug where the asset summary page would show "we couldn't find any size information" before the page finishes loading (see screenshot for before behaviour)

<img width="1302" height="556" alt="image" src="https://github.com/user-attachments/assets/0fc749d1-ac98-478e-864b-714990537743" />
