### PR TITLE
fix: uv sync --active

### DIFF
--- a/.github/actions/setup-sentry/action.yml
+++ b/.github/actions/setup-sentry/action.yml
@@ -91,7 +91,7 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
         cache-dependency-path: ${{ inputs.workdir }}/uv.lock
-        install-cmd: cd ${{ inputs.workdir }} && uv sync --frozen
+        install-cmd: cd ${{ inputs.workdir }} && uv sync --frozen --active
 
     - name: Set up outputs
       id: config

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -339,7 +339,7 @@ jobs:
         with:
           python-version: 3.13.1
           cache-dependency-path: uv.lock
-          install-cmd: uv sync --frozen
+          install-cmd: uv sync --frozen --active
 
       - name: setup sentry (lite)
         run: |

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           python-version: 3.13.1
           cache-dependency-path: uv.lock
-          install-cmd: uv sync --only-dev --frozen
+          install-cmd: uv sync --only-dev --frozen --active
 
       - name: test-tools
         run: make test-tools
@@ -71,7 +71,7 @@ jobs:
           python-version: 3.13.1
           cache-dependency-path: uv.lock
           # technically we can just use --only-dev but more cache is nice
-          install-cmd: uv sync --frozen
+          install-cmd: uv sync --frozen --active
 
       - name: devenv sync
         run: |

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -81,7 +81,7 @@ jobs:
         with:
           python-version: 3.13.1
           cache-dependency-path: uv.lock
-          install-cmd: uv sync --only-dev --frozen
+          install-cmd: uv sync --only-dev --frozen --active
       - uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ~/.cache/pre-commit

--- a/devenv/sync.py
+++ b/devenv/sync.py
@@ -226,6 +226,7 @@ Then, use it to run sync this time:
                     "sync",
                     "--frozen",
                     "--quiet",
+                    "--active",
                 ),
                 {},
             ),


### PR DESCRIPTION
forces uv to use the activated virtualenv

relay ci fails here: https://github.com/getsentry/relay/actions/runs/16889766628/job/47847320387