### PR TITLE
chore(access-logs): remove use snuba error data option

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3441,9 +3441,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Enable enhancing access logs with snuba responses
-register("issues.use-snuba-error-data", type=Float, default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
-
 register("issues.log-access-logs", type=Float, default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 # Use "first-seen" group instead of "most-seen" group when merging


### PR DESCRIPTION
Fully removed:
- from automator: https://github.com/getsentry/sentry-options-automator/pull/4876
- from sentry: https://github.com/getsentry/sentry/pull/97447

Closes https://linear.app/getsentry/issue/ID-804/add-snuba-rate-limits-to-api-access-log-data