### PR TITLE
fix(detectors): Add filter for queries with &param 

### DIFF
--- a/fixtures/events/performance_problems/sql-injection/sql-injection-event-parameterized-query.json
+++ b/fixtures/events/performance_problems/sql-injection/sql-injection-event-parameterized-query.json
@@ -1,0 +1,56 @@
+{
+  "event_id": "5d6401994d7949d2ac3474f472564370",
+  "platform": "node",
+  "message": "",
+  "datetime": "2025-05-12T22:42:38.642986+00:00",
+  "breakdowns": {
+    "span_ops": {
+      "ops.db": {
+        "value": 65.715075,
+        "unit": "millisecond"
+      },
+      "total.time": {
+        "value": 67.105293,
+        "unit": "millisecond"
+      }
+    }
+  },
+  "request": {
+    "url": "http://localhost:3001/vulnerable-login",
+    "method": "POST",
+    "data": {
+      "username": "bob"
+    }
+  },
+
+  "spans": [
+    {
+      "timestamp": 1747089758.637715,
+      "start_timestamp": 1747089758.572,
+      "exclusive_time": 65.715075,
+      "op": "db",
+      "span_id": "4703181ac343f71a",
+      "parent_span_id": "91fa92ff0205967d",
+      "trace_id": "375a86eca09a4a4e91903838dd771f50",
+      "status": "ok",
+      "description": "SELECT * FROM users WHERE uid = &uid and username in ('bob')",
+      "origin": "auto.db.otel.mysql2",
+      "sentry_tags": {
+        "description": "SELECT * FROM users WHERE uid = &uid and username in ('bob')"
+      },
+      "data": {
+        "db.system": "mysql",
+        "db.connection_string": "jdbc:mysql://localhost:3306/injection_test",
+        "db.name": "injection_test",
+        "db.statement": "SELECT * FROM users WHERE uid = &uid and username in ('bob')",
+        "db.user": "root",
+        "net.peer.name": "localhost",
+        "net.peer.port": 3306,
+        "otel.kind": "CLIENT",
+        "sentry.op": "db",
+        "sentry.origin": "auto.db.otel.mysql2"
+      },
+      "hash": "45330ba0cafa5997"
+    }
+  ]
+}

--- a/src/sentry/performance_issues/detectors/sql_injection_detector.py
+++ b/src/sentry/performance_issues/detectors/sql_injection_detector.py
@@ -246,7 +246,7 @@ class SQLInjectionDetector(PerformanceDetector):
             description[:6].upper() != "SELECT"
             or "WHERE" not in description.upper()
             or any(keyword in description for keyword in PARAMETERIZED_KEYWORDS)
-            or re.search(r"&[A-Za-z_]+", description)
+            or re.search(r"&[A-Za-z_][A-Za-z0-9_]*", description)
         ):
             return False
 

--- a/src/sentry/performance_issues/detectors/sql_injection_detector.py
+++ b/src/sentry/performance_issues/detectors/sql_injection_detector.py
@@ -246,6 +246,7 @@ class SQLInjectionDetector(PerformanceDetector):
             description[:6].upper() != "SELECT"
             or "WHERE" not in description.upper()
             or any(keyword in description for keyword in PARAMETERIZED_KEYWORDS)
+            or re.search(r"&[A-Za-z_]+", description)
         ):
             return False
 

--- a/tests/sentry/performance_issues/test_sql_injection_detector.py
+++ b/tests/sentry/performance_issues/test_sql_injection_detector.py
@@ -107,3 +107,7 @@ class SQLInjectionDetectorTest(TestCase):
     def test_sql_injection_on_zf1_event(self) -> None:
         injection_event = get_event("sql-injection/sql-injection-event-zf1")
         assert len(self.find_problems(injection_event)) == 0
+
+    def test_sql_injection_on_parameterized_query(self) -> None:
+        injection_event = get_event("sql-injection/sql-injection-event-parameterized-query")
+        assert len(self.find_problems(injection_event)) == 0


### PR DESCRIPTION
similar to the existing filter for queries with "?" or other strings we expect in parameterized queries, this pr adds a check to see if the query has "&param" in it (example  - `select * from tasks where status = &status`). 