### PR TITLE
fix(release): Quote release search term in Issue GroupList links

### DIFF
--- a/static/app/views/releases/detail/overview/releaseIssues.spec.tsx
+++ b/static/app/views/releases/detail/overview/releaseIssues.spec.tsx
@@ -179,7 +179,7 @@ describe('ReleaseIssues', function () {
 
     const link = await screen.findByRole('link', {name: /RequestError/});
 
-    // Should pass the query param `query` with value `release:1.0.0`
+    // Should pass the query param `query` with value `release:"1.0.0"`
     expect(link).toHaveAttribute(
       'href',
       '/organizations/org-slug/issues/123/?_allp=1&project=2&query=release%3A%221.0.0%22&referrer=release-issue-stream'

--- a/static/app/views/releases/detail/overview/releaseIssues.spec.tsx
+++ b/static/app/views/releases/detail/overview/releaseIssues.spec.tsx
@@ -182,7 +182,7 @@ describe('ReleaseIssues', function () {
     // Should pass the query param `query` with value `release:1.0.0`
     expect(link).toHaveAttribute(
       'href',
-      '/organizations/org-slug/issues/123/?_allp=1&project=2&query=release%3A1.0.0&referrer=release-issue-stream'
+      '/organizations/org-slug/issues/123/?_allp=1&project=2&query=release%3A%221.0.0%22&referrer=release-issue-stream'
     );
   });
 });

--- a/static/app/views/releases/detail/overview/releaseIssues.tsx
+++ b/static/app/views/releases/detail/overview/releaseIssues.tsx
@@ -407,7 +407,7 @@ class ReleaseIssues extends Component<Props, State> {
           <GroupList
             endpointPath={path}
             queryParams={queryParams}
-            query={`release:${version}`}
+            query={`release:"${version}"`}
             canSelectGroups={false}
             queryFilterDescription={queryFilterDescription}
             withChart={withChart}

--- a/static/app/views/releases/detail/overview/releaseIssues.tsx
+++ b/static/app/views/releases/detail/overview/releaseIssues.tsx
@@ -15,6 +15,7 @@ import {DEFAULT_RELATIVE_PERIODS} from 'sentry/constants';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
+import {escapeDoubleQuotes} from 'sentry/utils';
 import {browserHistory} from 'sentry/utils/browserHistory';
 import {DemoTourElement, DemoTourStep} from 'sentry/utils/demoMode/demoTours';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
@@ -407,7 +408,7 @@ class ReleaseIssues extends Component<Props, State> {
           <GroupList
             endpointPath={path}
             queryParams={queryParams}
-            query={`release:"${version}"`}
+            query={`release:"${escapeDoubleQuotes(version)}"`}
             canSelectGroups={false}
             queryFilterDescription={queryFilterDescription}
             withChart={withChart}

--- a/static/app/views/releases/drawer/newIssues.tsx
+++ b/static/app/views/releases/drawer/newIssues.tsx
@@ -39,7 +39,7 @@ export function NewIssues({release, projectId, withChart = false}: Props) {
     <GroupList
       endpointPath={path}
       queryParams={queryParams}
-      query={`release:${releaseDetails?.versionInfo.version.raw}`}
+      query={`release:"${releaseDetails?.versionInfo.version.raw}"`}
       canSelectGroups={false}
       withChart={withChart}
       renderEmptyMessage={renderEmptyMessage}

--- a/static/app/views/releases/drawer/newIssues.tsx
+++ b/static/app/views/releases/drawer/newIssues.tsx
@@ -42,7 +42,7 @@ export function NewIssues({release, projectId, withChart = false}: Props) {
     <GroupList
       endpointPath={path}
       queryParams={queryParams}
-      query={`release:"${escapeDoubleQuotes (releaseDetails?.versionInfo.version.raw)}"`}
+      query={`release:"${escapeDoubleQuotes(releaseDetails?.versionInfo.version.raw)}"`}
       canSelectGroups={false}
       withChart={withChart}
       renderEmptyMessage={renderEmptyMessage}

--- a/static/app/views/releases/drawer/newIssues.tsx
+++ b/static/app/views/releases/drawer/newIssues.tsx
@@ -1,5 +1,6 @@
 import GroupList from 'sentry/components/issues/groupList';
 import {t} from 'sentry/locale';
+import {escapeDoubleQuotes} from 'sentry/utils';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -28,7 +29,9 @@ export function NewIssues({release, projectId, withChart = false}: Props) {
     limit: 10,
     sort: IssueSortOptions.FREQ,
     groupStatsPeriod: 'auto',
-    query: new MutableSearch([`first-release:${release}`]).formatString(),
+    query: new MutableSearch([
+      `first-release:${escapeDoubleQuotes(release)}`,
+    ]).formatString(),
   };
 
   const renderEmptyMessage = () => {

--- a/static/app/views/releases/drawer/newIssues.tsx
+++ b/static/app/views/releases/drawer/newIssues.tsx
@@ -42,7 +42,11 @@ export function NewIssues({release, projectId, withChart = false}: Props) {
     <GroupList
       endpointPath={path}
       queryParams={queryParams}
-      query={`release:"${escapeDoubleQuotes(releaseDetails?.versionInfo.version.raw)}"`}
+      query={
+        releaseDetails
+          ? `release:"${escapeDoubleQuotes(releaseDetails?.versionInfo.version.raw)}"`
+          : ''
+      }
       canSelectGroups={false}
       withChart={withChart}
       renderEmptyMessage={renderEmptyMessage}

--- a/static/app/views/releases/drawer/newIssues.tsx
+++ b/static/app/views/releases/drawer/newIssues.tsx
@@ -30,7 +30,7 @@ export function NewIssues({release, projectId, withChart = false}: Props) {
     sort: IssueSortOptions.FREQ,
     groupStatsPeriod: 'auto',
     query: new MutableSearch([
-      `first-release:${escapeDoubleQuotes(release)}`,
+      `first-release:"${escapeDoubleQuotes(release)}"`,
     ]).formatString(),
   };
 
@@ -42,7 +42,7 @@ export function NewIssues({release, projectId, withChart = false}: Props) {
     <GroupList
       endpointPath={path}
       queryParams={queryParams}
-      query={`release:"${releaseDetails?.versionInfo.version.raw}"`}
+      query={`release:"${escapeDoubleQuotes (releaseDetails?.versionInfo.version.raw)}"`}
       canSelectGroups={false}
       withChart={withChart}
       renderEmptyMessage={renderEmptyMessage}


### PR DESCRIPTION
We need to quote the release name because it could contain spaces. The quotes will make the url look like `?query=release%3A"my%20release%401.2.3"`, unescaped it's `?query=release:"my release@1.2.3"` 

Previously, without the quotes, the issue details page would parse the query to be `release:my` instead of `release: "my release@1.2.3"`

Fixes https://linear.app/getsentry/issue/REPLAY-604/improve-handling-of-improperly-formatted-release-names