### PR TITLE
chore(billing): Remove unused prop from upsell modal

### DIFF
--- a/static/gsApp/components/powerFeatureHovercard.tsx
+++ b/static/gsApp/components/powerFeatureHovercard.tsx
@@ -48,8 +48,6 @@ type Props = {
    */
   partial?: boolean;
 
-  upsellDefaultSelection?: string;
-
   /**
    * Replaces the default learn more button with a more subtle link text that
    * opens the upsell modal.
@@ -75,7 +73,6 @@ class PowerFeatureHovercard extends Component<Props> {
     openUpsellModal({
       organization,
       source: id ?? '',
-      defaultSelection: this.props.upsellDefaultSelection,
     });
   };
 

--- a/static/gsApp/registerHooks.tsx
+++ b/static/gsApp/registerHooks.tsx
@@ -330,7 +330,6 @@ const GETSENTRY_HOOKS: Partial<Hooks> = {
     <PowerFeatureHovercard
       features={['organizations:dashboards-edit']}
       id="dashboards-edit"
-      upsellDefaultSelection="custom-dashboards"
     >
       {typeof p.children === 'function' ? p.children(p) : p.children}
     </PowerFeatureHovercard>


### PR DESCRIPTION
This prop gets passed down, but it doesn't seem to be used anywhere downstream. `openUpsellModal` doesn't do anything with it.