### PR TITLE
chore(detectors): Remove pattern span ids from evidence section

### DIFF
--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
@@ -204,7 +204,6 @@ describe('SpanEvidenceKeyValueList', () => {
         ...event.occurrence,
         evidenceData: {
           patternSize: 2,
-          patternSpanIds: ['aaa', 'bbb'],
         },
       } as EventTransaction['occurrence'];
 
@@ -252,10 +251,6 @@ describe('SpanEvidenceKeyValueList', () => {
       expect(
         screen.getByTestId('span-evidence-key-value-list.pattern-size')
       ).toHaveTextContent('2');
-      expect(screen.getByRole('cell', {name: 'Pattern Span IDs'})).toBeInTheDocument();
-      expect(
-        screen.getByTestId('span-evidence-key-value-list.pattern-span-i-ds')
-      ).toHaveTextContent('aaa, bbb');
     });
   });
 

--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
@@ -184,7 +184,6 @@ function NPlusOneDBQueriesSpanEvidence({
     );
   const evidenceData = event?.occurrence?.evidenceData ?? {};
   const patternSize = evidenceData.patternSize ?? 0;
-  const patternSpanIds = (evidenceData.patternSpanIds ?? []).join(', ');
 
   return (
     <PresortedKeyValueList
@@ -197,9 +196,6 @@ function NPlusOneDBQueriesSpanEvidence({
             : null,
           ...repeatingSpanRows,
           patternSize > 0 ? makeRow(t('Pattern Size'), patternSize) : null,
-          patternSpanIds.length > 0
-            ? makeRow(t('Pattern Span IDs'), patternSpanIds)
-            : null,
         ].filter(Boolean) as KeyValueListData
       }
     />


### PR DESCRIPTION
https://github.com/getsentry/sentry/pull/97523 removes it from the backend