### PR TITLE
fix(ourlogs): Add some missing aliases

### DIFF
--- a/src/sentry/search/eap/ourlogs/attributes.py
+++ b/src/sentry/search/eap/ourlogs/attributes.py
@@ -56,7 +56,7 @@ OURLOG_ATTRIBUTE_DEFINITIONS = {
         ResolvedAttribute(
             public_alias="payload_size",
             internal_name="sentry.payload_size_bytes",
-            search_type="number",
+            search_type="byte",
         ),
         simple_sentry_field("browser.name"),
         simple_sentry_field("browser.version"),

--- a/src/sentry/search/eap/ourlogs/attributes.py
+++ b/src/sentry/search/eap/ourlogs/attributes.py
@@ -44,7 +44,7 @@ OURLOG_ATTRIBUTE_DEFINITIONS = {
         ),
         ResolvedAttribute(
             public_alias="timestamp_precise",
-            internal_name="tags[sentry.timestamp_precise,number]",
+            internal_name="sentry.timestamp_precise",
             search_type="number",
         ),
         ResolvedAttribute(
@@ -55,7 +55,7 @@ OURLOG_ATTRIBUTE_DEFINITIONS = {
         ),
         ResolvedAttribute(
             public_alias="payload_size",
-            internal_name="tags[sentry.payload_size_bytes,number]",
+            internal_name="sentry.payload_size_bytes",
             search_type="number",
         ),
         simple_sentry_field("browser.name"),

--- a/src/sentry/search/eap/ourlogs/attributes.py
+++ b/src/sentry/search/eap/ourlogs/attributes.py
@@ -48,12 +48,12 @@ OURLOG_ATTRIBUTE_DEFINITIONS = {
             search_type="number",
         ),
         ResolvedAttribute(
-            public_alias="observed_timestamp_nanos",
+            public_alias="observed_timestamp",
             internal_name="sentry.observed_timestamp_nanos",
             search_type="string",
         ),
         ResolvedAttribute(
-            public_alias="payload_size_bytes",
+            public_alias="payload_size",
             internal_name="sentry.payload_size_bytes",
             search_type="number",
         ),

--- a/src/sentry/search/eap/ourlogs/attributes.py
+++ b/src/sentry/search/eap/ourlogs/attributes.py
@@ -42,6 +42,16 @@ OURLOG_ATTRIBUTE_DEFINITIONS = {
             search_type="string",
             validator=is_event_id_or_list,
         ),
+        ResolvedAttribute(
+            public_alias="timestamp_precise",
+            internal_name="tags[sentry.timestamp_precise,number]",
+            search_type="number",
+        ),
+        ResolvedAttribute(
+            public_alias="observed_timestamp_nanos",
+            internal_name="sentry.observed_timestamp_nanos",
+            search_type="string",
+        ),
         simple_sentry_field("browser.name"),
         simple_sentry_field("browser.version"),
         simple_sentry_field("environment"),

--- a/src/sentry/search/eap/ourlogs/attributes.py
+++ b/src/sentry/search/eap/ourlogs/attributes.py
@@ -52,6 +52,11 @@ OURLOG_ATTRIBUTE_DEFINITIONS = {
             internal_name="sentry.observed_timestamp_nanos",
             search_type="string",
         ),
+        ResolvedAttribute(
+            public_alias="payload_size_bytes",
+            internal_name="sentry.payload_size_bytes",
+            search_type="number",
+        ),
         simple_sentry_field("browser.name"),
         simple_sentry_field("browser.version"),
         simple_sentry_field("environment"),

--- a/src/sentry/search/eap/ourlogs/attributes.py
+++ b/src/sentry/search/eap/ourlogs/attributes.py
@@ -55,7 +55,7 @@ OURLOG_ATTRIBUTE_DEFINITIONS = {
         ),
         ResolvedAttribute(
             public_alias="payload_size",
-            internal_name="sentry.payload_size_bytes",
+            internal_name="tags[sentry.payload_size_bytes,number]",
             search_type="number",
         ),
         simple_sentry_field("browser.name"),

--- a/src/sentry/search/eap/ourlogs/attributes.py
+++ b/src/sentry/search/eap/ourlogs/attributes.py
@@ -50,7 +50,8 @@ OURLOG_ATTRIBUTE_DEFINITIONS = {
         ResolvedAttribute(
             public_alias="observed_timestamp",
             internal_name="sentry.observed_timestamp_nanos",
-            search_type="string",
+            internal_type=constants.STRING,  # Stored as string, but we want to search as a number.
+            search_type="number",
         ),
         ResolvedAttribute(
             public_alias="payload_size",

--- a/src/sentry/snuba/rpc_dataset_common.py
+++ b/src/sentry/snuba/rpc_dataset_common.py
@@ -157,6 +157,7 @@ class RPCBase:
             query.selected_columns,
             has_aggregates=any(equation for equation in equations if equation.is_aggregate),
         )
+
         all_columns = columns + equations
         contexts = resolver.resolve_contexts(query_contexts + column_contexts)
         # We allow orderby function_aliases if they're a selected_column

--- a/tests/sentry/search/eap/test_ourlogs.py
+++ b/tests/sentry/search/eap/test_ourlogs.py
@@ -279,3 +279,50 @@ def test_monoid_functions(function_name, proto_function) -> None:
             extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_SAMPLE_WEIGHTED,
         )
         assert virtual_context is None
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        {
+            "attribute_definition": OURLOG_DEFINITIONS.columns["observed_timestamp"],
+            "search_term": 1234567890,
+            "expected_value": AttributeValue(val_str="1234567890.0"),
+            "expected_search_proto_type": AttributeKey.Type.TYPE_STRING,
+        },
+        {
+            "attribute_definition": OURLOG_DEFINITIONS.columns["observed_timestamp"],
+            "search_term": "1111111111",
+            "expected_value": AttributeValue(val_str="1111111111.0"),
+            "expected_search_proto_type": AttributeKey.Type.TYPE_STRING,
+        },
+        {
+            "attribute_definition": OURLOG_DEFINITIONS.columns["payload_size"],
+            "search_term": 1337,
+            "expected_value": AttributeValue(val_double=1337),
+            "expected_search_proto_type": AttributeKey.Type.TYPE_DOUBLE,
+        },
+    ],
+)
+def test_attribute_search(test_case) -> None:
+    attribute_definition = test_case["attribute_definition"]
+    search_term = test_case["search_term"]
+    expected_value = test_case["expected_value"]
+    expected_search_proto_type = test_case["expected_search_proto_type"]
+    attribute_alias = attribute_definition.public_alias
+    resolver = SearchResolver(
+        params=SnubaParams(), config=SearchResolverConfig(), definitions=OURLOG_DEFINITIONS
+    )
+    query = f"{attribute_alias}:{search_term}"
+    where, having, _ = resolver.resolve_query(query)
+
+    assert where == TraceItemFilter(
+        comparison_filter=ComparisonFilter(
+            key=AttributeKey(
+                name=attribute_definition.internal_name, type=expected_search_proto_type
+            ),
+            op=ComparisonFilter.OP_EQUALS,
+            value=expected_value,
+        )
+    )
+    assert having is None

--- a/tests/snuba/api/endpoints/test_project_trace_item_details.py
+++ b/tests/snuba/api/endpoints/test_project_trace_item_details.py
@@ -77,7 +77,7 @@ class ProjectTraceItemDetailsEndpointTest(APITestCase, SnubaTestCase, OurLogTest
                 "value": str(timestamp_nanos),
             },
             {
-                "name": "tags[sentry.timestamp_precise,number]",
+                "name": "timestamp_precise",
                 "type": "int",
                 "value": str(timestamp_nanos),
             },
@@ -133,7 +133,7 @@ class ProjectTraceItemDetailsEndpointTest(APITestCase, SnubaTestCase, OurLogTest
                     "value": str(timestamp_nanos),
                 },
                 {
-                    "name": "tags[sentry.timestamp_precise,number]",
+                    "name": "timestamp_precise",
                     "type": "int",
                     "value": str(timestamp_nanos),
                 },
@@ -328,7 +328,7 @@ class ProjectTraceItemDetailsEndpointTest(APITestCase, SnubaTestCase, OurLogTest
                     "value": str(timestamp_nanos),
                 },
                 {
-                    "name": "tags[sentry.timestamp_precise,number]",
+                    "name": "timestamp_precise",
                     "type": "int",
                     "value": str(timestamp_nanos),
                 },
@@ -377,7 +377,7 @@ class ProjectTraceItemDetailsEndpointTest(APITestCase, SnubaTestCase, OurLogTest
                     "value": str(timestamp_nanos),
                 },
                 {
-                    "name": "tags[sentry.timestamp_precise,number]",
+                    "name": "timestamp_precise",
                     "type": "int",
                     "value": str(timestamp_nanos),
                 },


### PR DESCRIPTION
### Summary
Adds aliases for precise and observed timestamp, which should be emitted.
