### PR TITLE
fix(uptime): Don't include `guid` twice with different names

### DIFF
--- a/src/sentry/search/eap/uptime_results/attributes.py
+++ b/src/sentry/search/eap/uptime_results/attributes.py
@@ -27,11 +27,6 @@ UPTIME_ATTRIBUTE_DEFINITIONS = {
             search_type="string",
         ),
         ResolvedAttribute(
-            public_alias="guid",
-            internal_name="guid",
-            search_type="string",
-        ),
-        ResolvedAttribute(
             public_alias="subscription_id",
             internal_name="subscription_id",
             search_type="string",

--- a/src/sentry/search/eap/uptime_results/attributes.py
+++ b/src/sentry/search/eap/uptime_results/attributes.py
@@ -27,13 +27,13 @@ UPTIME_ATTRIBUTE_DEFINITIONS = {
             search_type="string",
         ),
         ResolvedAttribute(
-            public_alias="guid",
-            internal_name="guid",
+            public_alias="subscription_id",
+            internal_name="subscription_id",
             search_type="string",
         ),
         ResolvedAttribute(
-            public_alias="subscription_id",
-            internal_name="subscription_id",
+            public_alias="check_id",
+            internal_name="check_id",
             search_type="string",
         ),
         ResolvedAttribute(

--- a/src/sentry/search/eap/uptime_results/attributes.py
+++ b/src/sentry/search/eap/uptime_results/attributes.py
@@ -27,13 +27,13 @@ UPTIME_ATTRIBUTE_DEFINITIONS = {
             search_type="string",
         ),
         ResolvedAttribute(
-            public_alias="subscription_id",
-            internal_name="subscription_id",
+            public_alias="guid",
+            internal_name="guid",
             search_type="string",
         ),
         ResolvedAttribute(
-            public_alias="check_id",
-            internal_name="check_id",
+            public_alias="subscription_id",
+            internal_name="subscription_id",
             search_type="string",
         ),
         ResolvedAttribute(

--- a/src/sentry/uptime/consumers/eap_converter.py
+++ b/src/sentry/uptime/consumers/eap_converter.py
@@ -72,7 +72,6 @@ def convert_uptime_request_to_trace_item(
     """
     attributes: MutableMapping[str, AnyValue] = {}
 
-    attributes["guid"] = _anyvalue(result["guid"])
     attributes["subscription_id"] = _anyvalue(result["subscription_id"])
     attributes["check_status"] = _anyvalue(result["status"])
     if "region" in result:

--- a/src/sentry/uptime/consumers/eap_converter.py
+++ b/src/sentry/uptime/consumers/eap_converter.py
@@ -72,7 +72,6 @@ def convert_uptime_request_to_trace_item(
     """
     attributes: MutableMapping[str, AnyValue] = {}
 
-    attributes["guid"] = _anyvalue(result["guid"])
     attributes["subscription_id"] = _anyvalue(result["subscription_id"])
     attributes["check_status"] = _anyvalue(result["status"])
     if "region" in result:
@@ -98,6 +97,7 @@ def convert_uptime_request_to_trace_item(
             # we should be cautious here
             attributes["original_url"] = _anyvalue(first_request["url"])
 
+    attributes["check_id"] = _anyvalue(result["guid"])
     attributes["request_sequence"] = _anyvalue(request_sequence)
     attributes["incident_status"] = _anyvalue(incident_status.value)
     attributes["span_id"] = _anyvalue(result["span_id"])

--- a/src/sentry/uptime/consumers/eap_converter.py
+++ b/src/sentry/uptime/consumers/eap_converter.py
@@ -72,6 +72,7 @@ def convert_uptime_request_to_trace_item(
     """
     attributes: MutableMapping[str, AnyValue] = {}
 
+    attributes["guid"] = _anyvalue(result["guid"])
     attributes["subscription_id"] = _anyvalue(result["subscription_id"])
     attributes["check_status"] = _anyvalue(result["status"])
     if "region" in result:
@@ -97,7 +98,6 @@ def convert_uptime_request_to_trace_item(
             # we should be cautious here
             attributes["original_url"] = _anyvalue(first_request["url"])
 
-    attributes["check_id"] = _anyvalue(result["guid"])
     attributes["request_sequence"] = _anyvalue(request_sequence)
     attributes["incident_status"] = _anyvalue(incident_status.value)
     attributes["span_id"] = _anyvalue(result["span_id"])

--- a/src/sentry/uptime/endpoints/organization_uptime_stats.py
+++ b/src/sentry/uptime/endpoints/organization_uptime_stats.py
@@ -98,7 +98,7 @@ class OrganizationUptimeStatsEndpoint(OrganizationEndpoint, StatsMixin):
                     timerange_args,
                     epoch_cutoff,
                     TraceItemType.TRACE_ITEM_TYPE_UPTIME_RESULT,
-                    "guid",
+                    "check_id",
                     "subscription_id",
                     include_request_sequence_filter=True,
                 )

--- a/src/sentry/uptime/endpoints/organization_uptime_stats.py
+++ b/src/sentry/uptime/endpoints/organization_uptime_stats.py
@@ -98,7 +98,7 @@ class OrganizationUptimeStatsEndpoint(OrganizationEndpoint, StatsMixin):
                     timerange_args,
                     epoch_cutoff,
                     TraceItemType.TRACE_ITEM_TYPE_UPTIME_RESULT,
-                    "check_id",
+                    "guid",
                     "subscription_id",
                     include_request_sequence_filter=True,
                 )


### PR DESCRIPTION
We include `guid` as both `guid` and `check_id`. Switching to just calling it `check_id`.

<!-- Describe your PR here. -->