### PR TITLE
ref(aci): handle sharding project list key for buffer processing

### DIFF
--- a/src/sentry/buffer/base.py
+++ b/src/sentry/buffer/base.py
@@ -63,8 +63,8 @@ class Buffer(Service):
 
     def get_sharded_sorted_set(
         self, key: str, separator: str, shards: int, min: float, max: float
-    ) -> list[tuple[int, datetime]]:
-        return []
+    ) -> dict[int, list[datetime]]:
+        return {}
 
     def push_to_sorted_set(self, key: str, value: list[int] | int) -> None:
         return None

--- a/src/sentry/buffer/base.py
+++ b/src/sentry/buffer/base.py
@@ -61,6 +61,11 @@ class Buffer(Service):
     def get_sorted_set(self, key: str, min: float, max: float) -> list[tuple[int, datetime]]:
         return []
 
+    def get_sharded_sorted_set(
+        self, key: str, separator: str, shards: int, min: float, max: float
+    ) -> list[tuple[int, datetime]]:
+        return []
+
     def push_to_sorted_set(self, key: str, value: list[int] | int) -> None:
         return None
 
@@ -90,6 +95,11 @@ class Buffer(Service):
         return None
 
     def delete_key(self, key: str, min: float, max: float) -> None:
+        return None
+
+    def delete_sharded_key(
+        self, key: str, separator: str, shards: int, min: float, max: float
+    ) -> None:
         return None
 
     def incr(

--- a/src/sentry/buffer/base.py
+++ b/src/sentry/buffer/base.py
@@ -58,12 +58,12 @@ class Buffer(Service):
     def get_hash_length(self, model: type[models.Model], field: dict[str, BufferField]) -> int:
         raise NotImplementedError
 
-    def get_sorted_set(self, key: str, min: float, max: float) -> list[tuple[int, datetime]]:
+    def get_sorted_set(self, key: str, min: float, max: float) -> list[tuple[int, float]]:
         return []
 
     def bulk_get_sorted_set(
         self, keys: list[str], min: float, max: float
-    ) -> dict[int, list[datetime]]:
+    ) -> dict[int, list[float]]:
         return {}
 
     def push_to_sorted_set(self, key: str, value: list[int] | int) -> None:

--- a/src/sentry/buffer/base.py
+++ b/src/sentry/buffer/base.py
@@ -61,8 +61,8 @@ class Buffer(Service):
     def get_sorted_set(self, key: str, min: float, max: float) -> list[tuple[int, datetime]]:
         return []
 
-    def get_sharded_sorted_set(
-        self, key: str, separator: str, shards: int, min: float, max: float
+    def bulk_get_sorted_set(
+        self, keys: list[str], min: float, max: float
     ) -> dict[int, list[datetime]]:
         return {}
 
@@ -97,9 +97,7 @@ class Buffer(Service):
     def delete_key(self, key: str, min: float, max: float) -> None:
         return None
 
-    def delete_sharded_key(
-        self, key: str, separator: str, shards: int, min: float, max: float
-    ) -> None:
+    def delete_keys(self, keys: list[str], min: float, max: float) -> None:
         return None
 
     def incr(

--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -377,7 +377,7 @@ class RedisBuffer(Buffer):
         **kwargs: Any,
     ) -> Any:
         metrics_str = f"redis_buffer.{operation.value}"
-        metrics.incr(metrics_str)
+        metrics.incr(metrics_str, amount=len(keys))
         pipe = self.get_redis_connection(self.pending_key)
         for key in keys:
             getattr(pipe, operation.value)(key, *args, **kwargs)

--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -397,7 +397,7 @@ class RedisBuffer(Buffer):
             value_dict = {value: now}
         self._execute_redis_operation(key, RedisOperation.SORTED_SET_ADD, value_dict)
 
-    def get_sorted_set(self, key: str, min: float, max: float) -> list[tuple[int, datetime]]:
+    def get_sorted_set(self, key: str, min: float, max: float) -> list[tuple[int, float]]:
         redis_set = self._execute_redis_operation(
             key,
             RedisOperation.SORTED_SET_GET_RANGE,
@@ -416,8 +416,8 @@ class RedisBuffer(Buffer):
 
     def bulk_get_sorted_set(
         self, keys: list[str], min: float, max: float
-    ) -> dict[int, list[datetime]]:
-        data_to_timestamps: dict[int, list[datetime]] = defaultdict(list)
+    ) -> dict[int, list[float]]:
+        data_to_timestamps: dict[int, list[float]] = defaultdict(list)
 
         redis_set = self._execute_sharded_redis_operation(
             keys,

--- a/src/sentry/rules/processing/buffer_processing.py
+++ b/src/sentry/rules/processing/buffer_processing.py
@@ -179,7 +179,6 @@ def process_buffer() -> None:
             for project_id in project_ids:
                 process_in_batches(project_id, processing_type)
 
-            buffer.backend.delete_key(handler.buffer_key, min=0, max=fetch_time)
             buffer.backend.delete_sharded_key(
                 handler.buffer_key,
                 separator=handler.buffer_separator,

--- a/tests/sentry/buffer/test_redis.py
+++ b/tests/sentry/buffer/test_redis.py
@@ -286,8 +286,12 @@ class TestRedisBuffer:
         shards = 3
         project_ids = [1, 2, 2, 3, 3, 3, 4, 4, 4, 4]
         for id in project_ids:
-            sharded_key = f"{PROJECT_ID_BUFFER_LIST_KEY}:{random.randrange(shards)}"
-            self.buf.push_to_sorted_set(key=sharded_key, value=id)
+            shard = random.randrange(shards)
+            if shard == 0:
+                key = PROJECT_ID_BUFFER_LIST_KEY
+            else:
+                key = f"{PROJECT_ID_BUFFER_LIST_KEY}:{shard}"
+            self.buf.push_to_sorted_set(key=key, value=id)
 
         project_ids_and_timestamps = self.buf.get_sharded_sorted_set(
             key=PROJECT_ID_BUFFER_LIST_KEY,
@@ -297,7 +301,7 @@ class TestRedisBuffer:
             max=datetime.datetime.now().timestamp(),
         )
         assert len(project_ids_and_timestamps) == 4
-        assert {project_id for project_id, _ in project_ids_and_timestamps} == set(project_ids)
+        assert set(project_ids_and_timestamps.keys()) == set(project_ids)
 
         self.buf.delete_sharded_key(
             key=PROJECT_ID_BUFFER_LIST_KEY,
@@ -314,6 +318,30 @@ class TestRedisBuffer:
             max=datetime.datetime.now().timestamp(),
         )
         assert len(project_ids_and_timestamps) == 0
+
+    def test_sharded_sorted_set_single_shard(self) -> None:
+        project_ids = [1, 2, 2, 3, 3, 3, 4, 4, 4, 4]
+        for id in project_ids:
+            self.buf.push_to_sorted_set(key=PROJECT_ID_BUFFER_LIST_KEY, value=id)
+        project_ids_and_timestamps = self.buf.get_sharded_sorted_set(
+            key=PROJECT_ID_BUFFER_LIST_KEY,
+            separator=":",
+            shards=1,
+            min=0,
+            max=datetime.datetime.now().timestamp(),
+        )
+        assert len(project_ids_and_timestamps) == 4
+        assert set(project_ids_and_timestamps.keys()) == set(project_ids)
+
+    def test_sharded_sorted_set_zero_shards(self) -> None:
+        with pytest.raises(ValueError):
+            self.buf.get_sharded_sorted_set(
+                key=PROJECT_ID_BUFFER_LIST_KEY,
+                separator=":",
+                shards=0,
+                min=0,
+                max=datetime.datetime.now().timestamp(),
+            )
 
     def test_buffer_hook_registry(self) -> None:
         """Test that we can add an event to the registry and that the callback is invoked"""

--- a/tests/sentry/buffer/test_redis.py
+++ b/tests/sentry/buffer/test_redis.py
@@ -282,7 +282,7 @@ class TestRedisBuffer:
         result = json.loads(project_ids_to_rule_data[project_id2][0].get(f"{rule2_id}:{group3_id}"))
         assert result.get("event_id") == event4_id
 
-    def test_sharded_sorted_set(self) -> None:
+    def test_get_bulk_sorted_set(self) -> None:
         shards = 3
         project_ids = [1, 2, 2, 3, 3, 3, 4, 4, 4, 4]
         for id in project_ids:
@@ -293,55 +293,42 @@ class TestRedisBuffer:
                 key = f"{PROJECT_ID_BUFFER_LIST_KEY}:{shard}"
             self.buf.push_to_sorted_set(key=key, value=id)
 
-        project_ids_and_timestamps = self.buf.get_sharded_sorted_set(
-            key=PROJECT_ID_BUFFER_LIST_KEY,
-            separator=":",
-            shards=shards,
+        buffer_keys = [
+            f"{PROJECT_ID_BUFFER_LIST_KEY}:{shard}" if shard > 0 else PROJECT_ID_BUFFER_LIST_KEY
+            for shard in range(shards)
+        ]
+
+        project_ids_and_timestamps = self.buf.bulk_get_sorted_set(
+            buffer_keys,
             min=0,
             max=datetime.datetime.now().timestamp(),
         )
         assert len(project_ids_and_timestamps) == 4
         assert set(project_ids_and_timestamps.keys()) == set(project_ids)
 
-        self.buf.delete_sharded_key(
-            key=PROJECT_ID_BUFFER_LIST_KEY,
-            separator=":",
-            shards=shards,
+        self.buf.delete_keys(
+            buffer_keys,
             min=0,
             max=datetime.datetime.now().timestamp(),
         )
-        project_ids_and_timestamps = self.buf.get_sharded_sorted_set(
-            key=PROJECT_ID_BUFFER_LIST_KEY,
-            separator=":",
-            shards=shards,
+        project_ids_and_timestamps = self.buf.bulk_get_sorted_set(
+            buffer_keys,
             min=0,
             max=datetime.datetime.now().timestamp(),
         )
         assert len(project_ids_and_timestamps) == 0
 
-    def test_sharded_sorted_set_single_shard(self) -> None:
+    def test_bulk_sorted_set_single_key(self) -> None:
         project_ids = [1, 2, 2, 3, 3, 3, 4, 4, 4, 4]
         for id in project_ids:
             self.buf.push_to_sorted_set(key=PROJECT_ID_BUFFER_LIST_KEY, value=id)
-        project_ids_and_timestamps = self.buf.get_sharded_sorted_set(
-            key=PROJECT_ID_BUFFER_LIST_KEY,
-            separator=":",
-            shards=1,
+        project_ids_and_timestamps = self.buf.bulk_get_sorted_set(
+            [PROJECT_ID_BUFFER_LIST_KEY],
             min=0,
             max=datetime.datetime.now().timestamp(),
         )
         assert len(project_ids_and_timestamps) == 4
         assert set(project_ids_and_timestamps.keys()) == set(project_ids)
-
-    def test_sharded_sorted_set_zero_shards(self) -> None:
-        with pytest.raises(ValueError):
-            self.buf.get_sharded_sorted_set(
-                key=PROJECT_ID_BUFFER_LIST_KEY,
-                separator=":",
-                shards=0,
-                min=0,
-                max=datetime.datetime.now().timestamp(),
-            )
 
     def test_buffer_hook_registry(self) -> None:
         """Test that we can add an event to the registry and that the callback is invoked"""

--- a/tests/sentry/rules/processing/test_buffer_processing.py
+++ b/tests/sentry/rules/processing/test_buffer_processing.py
@@ -249,7 +249,7 @@ class ProcessBufferTest(ProcessDelayedAlertConditionsTestBase):
     @patch("sentry.rules.processing.delayed_processing.DelayedRule.buffer_shards", 3)
     def test_fetches_with_shards(self, mock_process_in_batches: MagicMock) -> None:
         project = self.create_project()
-        buffer.backend.push_to_sorted_set(key=f"{PROJECT_ID_BUFFER_LIST_KEY}:0", value=project.id)
+        buffer.backend.push_to_sorted_set(key=f"{PROJECT_ID_BUFFER_LIST_KEY}", value=project.id)
         buffer.backend.push_to_sorted_set(
             key=f"{PROJECT_ID_BUFFER_LIST_KEY}:1", value=self.project_two.id
         )

--- a/tests/sentry/rules/processing/test_buffer_processing.py
+++ b/tests/sentry/rules/processing/test_buffer_processing.py
@@ -245,6 +245,20 @@ class ProcessBufferTest(ProcessDelayedAlertConditionsTestBase):
             self.project_two.id,
         }
 
+    @patch("sentry.rules.processing.buffer_processing.process_in_batches")
+    @patch("sentry.rules.processing.delayed_processing.DelayedRule.buffer_shards", 3)
+    def test_fetches_with_shards(self, mock_process_in_batches: MagicMock) -> None:
+        project = self.create_project()
+        buffer.backend.push_to_sorted_set(key=f"{PROJECT_ID_BUFFER_LIST_KEY}:0", value=project.id)
+        buffer.backend.push_to_sorted_set(
+            key=f"{PROJECT_ID_BUFFER_LIST_KEY}:1", value=self.project_two.id
+        )
+        buffer.backend.push_to_sorted_set(key=f"{PROJECT_ID_BUFFER_LIST_KEY}:2", value=project.id)
+
+        process_buffer()
+
+        assert mock_process_in_batches.call_count == 3
+
 
 class ProcessInBatchesTest(CreateEventTestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
(A follow up will actually use this within workflow engine only!)

Add the ability to pull from and delete a "sharded" key in the Redis buffer. "Shard" here really just means splitting the same key into multiple lists. The lists can be stored + read from different places and we won't put load on a single node by using a single list.