### PR TITLE
ref(aci): enqueue project ids to sharded list in process_workflows

### DIFF
--- a/src/sentry/rules/processing/buffer_processing.py
+++ b/src/sentry/rules/processing/buffer_processing.py
@@ -179,9 +179,7 @@ def process_buffer() -> None:
                     for project_id, timestamps in all_project_ids_and_timestamps.items()
                 )
                 log_name = f"{processing_type}.project_id_list"
-                logger.info(
-                    log_name, extra={"project_ids": log_str}
-                )
+                logger.info(log_name, extra={"project_ids": log_str})
 
             project_ids = list(all_project_ids_and_timestamps.keys())
             for project_id in project_ids:

--- a/src/sentry/rules/processing/buffer_processing.py
+++ b/src/sentry/rules/processing/buffer_processing.py
@@ -179,7 +179,9 @@ def process_buffer() -> None:
                     for project_id, timestamps in all_project_ids_and_timestamps.items()
                 )
                 log_name = f"{processing_type}.project_id_list"
-                logger.info(log_name, extra={"project_ids": log_str})
+                logger.info(
+                    log_name, extra={"project_ids": log_str}
+                )
 
             project_ids = list(all_project_ids_and_timestamps.keys())
             for project_id in project_ids:

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -25,7 +25,6 @@ from sentry.workflow_engine.processors.data_condition_group import process_data_
 from sentry.workflow_engine.processors.detector import get_detector_by_event
 from sentry.workflow_engine.processors.workflow_fire_history import create_workflow_fire_histories
 from sentry.workflow_engine.tasks.actions import build_trigger_action_task_params, trigger_action
-from sentry.workflow_engine.tasks.delayed_workflows import DelayedWorkflow
 from sentry.workflow_engine.types import WorkflowEventData
 from sentry.workflow_engine.utils import log_context
 from sentry.workflow_engine.utils.metrics import metrics_incr
@@ -100,6 +99,8 @@ class DelayedWorkflowItem:
 def enqueue_workflows(
     items_by_workflow: dict[Workflow, DelayedWorkflowItem],
 ) -> None:
+    from sentry.workflow_engine.tasks.delayed_workflows import DelayedWorkflow
+
     items_by_project_id = DefaultDict[int, list[DelayedWorkflowItem]](list)
     for queue_item in items_by_workflow.values():
         if not queue_item.delayed_if_group_ids and not queue_item.passing_if_group_ids:

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -98,6 +98,18 @@ class DelayedWorkflowItem:
         )
 
 
+def get_all_buffer_keys() -> list[str]:
+    return [_get_buffer_key(i) for i in range(WORKFLOW_ENGINE_BUFFER_LIST_KEY_SHARDS)]
+
+
+def _get_buffer_key(shard: int) -> str:
+    return (
+        f"{WORKFLOW_ENGINE_BUFFER_LIST_KEY}:{shard}"
+        if shard > 0
+        else WORKFLOW_ENGINE_BUFFER_LIST_KEY
+    )
+
+
 def enqueue_workflows(
     items_by_workflow: dict[Workflow, DelayedWorkflowItem],
 ) -> None:
@@ -127,7 +139,7 @@ def enqueue_workflows(
 
     sentry_sdk.set_tag("delayed_workflow_items", items)
 
-    sharded_key = f"{WORKFLOW_ENGINE_BUFFER_LIST_KEY}:{random.randrange(WORKFLOW_ENGINE_BUFFER_LIST_KEY_SHARDS)}"
+    sharded_key = _get_buffer_key(random.randrange(WORKFLOW_ENGINE_BUFFER_LIST_KEY_SHARDS))
     buffer.backend.push_to_sorted_set(key=sharded_key, value=list(items_by_project_id.keys()))
 
     logger.debug(

--- a/src/sentry/workflow_engine/tasks/delayed_workflows.py
+++ b/src/sentry/workflow_engine/tasks/delayed_workflows.py
@@ -17,7 +17,10 @@ from sentry.taskworker.config import TaskworkerConfig
 from sentry.taskworker.namespaces import workflow_engine_tasks
 from sentry.taskworker.retry import Retry
 from sentry.workflow_engine.models import Workflow
-from sentry.workflow_engine.processors.workflow import WORKFLOW_ENGINE_BUFFER_LIST_KEY
+from sentry.workflow_engine.processors.workflow import (
+    WORKFLOW_ENGINE_BUFFER_LIST_KEY,
+    WORKFLOW_ENGINE_BUFFER_LIST_KEY_SHARDS,
+)
 from sentry.workflow_engine.utils import log_context
 
 logger = log_context.get_logger("sentry.workflow_engine.tasks.delayed_workflows")
@@ -53,6 +56,8 @@ def process_delayed_workflows_shim(
 @delayed_processing_registry.register("delayed_workflow")
 class DelayedWorkflow(DelayedProcessingBase):
     buffer_key = WORKFLOW_ENGINE_BUFFER_LIST_KEY
+    buffer_separator = ":"
+    buffer_shards = WORKFLOW_ENGINE_BUFFER_LIST_KEY_SHARDS
     option = "delayed_workflow.rollout"
 
     @property

--- a/src/sentry/workflow_engine/tasks/delayed_workflows.py
+++ b/src/sentry/workflow_engine/tasks/delayed_workflows.py
@@ -17,10 +17,6 @@ from sentry.taskworker.config import TaskworkerConfig
 from sentry.taskworker.namespaces import workflow_engine_tasks
 from sentry.taskworker.retry import Retry
 from sentry.workflow_engine.models import Workflow
-from sentry.workflow_engine.processors.workflow import (
-    WORKFLOW_ENGINE_BUFFER_LIST_KEY,
-    WORKFLOW_ENGINE_BUFFER_LIST_KEY_SHARDS,
-)
 from sentry.workflow_engine.utils import log_context
 
 logger = log_context.get_logger("sentry.workflow_engine.tasks.delayed_workflows")
@@ -55,9 +51,8 @@ def process_delayed_workflows_shim(
 
 @delayed_processing_registry.register("delayed_workflow")
 class DelayedWorkflow(DelayedProcessingBase):
-    buffer_key = WORKFLOW_ENGINE_BUFFER_LIST_KEY
-    buffer_separator = ":"
-    buffer_shards = WORKFLOW_ENGINE_BUFFER_LIST_KEY_SHARDS
+    buffer_key = "workflow_engine_delayed_processing_buffer"
+    buffer_shards = 8
     option = "delayed_workflow.rollout"
 
     @property

--- a/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
@@ -60,7 +60,7 @@ from sentry.workflow_engine.processors.delayed_workflow import (
     get_group_to_groupevent,
     get_groups_to_fire,
 )
-from sentry.workflow_engine.processors.workflow import WORKFLOW_ENGINE_BUFFER_LIST_KEY
+from sentry.workflow_engine.tasks.delayed_workflows import DelayedWorkflow
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 from tests.snuba.rules.conditions.test_event_frequency import BaseEventFrequencyPercentTest
 
@@ -119,12 +119,8 @@ class TestDelayedWorkflowBase(BaseWorkflowTest, BaseEventFrequencyPercentTest):
         self.mock_redis_buffer = mock_redis_buffer()
         self.mock_redis_buffer.__enter__()
 
-        buffer.backend.push_to_sorted_set(
-            key=WORKFLOW_ENGINE_BUFFER_LIST_KEY, value=self.project.id
-        )
-        buffer.backend.push_to_sorted_set(
-            key=WORKFLOW_ENGINE_BUFFER_LIST_KEY, value=self.project2.id
-        )
+        buffer.backend.push_to_sorted_set(key=DelayedWorkflow.buffer_key, value=self.project.id)
+        buffer.backend.push_to_sorted_set(key=DelayedWorkflow.buffer_key, value=self.project2.id)
 
     def tearDown(self):
         self.mock_redis_buffer.__exit__(None, None, None)

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -25,7 +25,6 @@ from sentry.workflow_engine.models import (
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.processors.workflow import (
     WORKFLOW_ENGINE_BUFFER_LIST_KEY,
-    WORKFLOW_ENGINE_BUFFER_LIST_KEY_SHARDS,
     DelayedWorkflowItem,
     delete_workflow,
     enqueue_workflows,
@@ -439,10 +438,8 @@ class TestWorkflowEnqueuing(BaseWorkflowTest):
 
         process_workflows(self.event_data)
 
-        project_ids = buffer.backend.get_sharded_sorted_set(
-            WORKFLOW_ENGINE_BUFFER_LIST_KEY,
-            separator=":",
-            shards=WORKFLOW_ENGINE_BUFFER_LIST_KEY_SHARDS,
+        project_ids = buffer.backend.bulk_get_sorted_set(
+            [WORKFLOW_ENGINE_BUFFER_LIST_KEY],
             min=0,
             max=self.buffer_timestamp,
         )
@@ -474,10 +471,8 @@ class TestWorkflowEnqueuing(BaseWorkflowTest):
 
         process_workflows(self.event_data)
 
-        project_ids = buffer.backend.get_sharded_sorted_set(
-            WORKFLOW_ENGINE_BUFFER_LIST_KEY,
-            separator=":",
-            shards=WORKFLOW_ENGINE_BUFFER_LIST_KEY_SHARDS,
+        project_ids = buffer.backend.bulk_get_sorted_set(
+            [WORKFLOW_ENGINE_BUFFER_LIST_KEY],
             min=0,
             max=self.buffer_timestamp,
         )
@@ -558,10 +553,8 @@ class TestWorkflowEnqueuing(BaseWorkflowTest):
 
         process_workflows(self.event_data)
 
-        project_ids = buffer.backend.get_sharded_sorted_set(
-            WORKFLOW_ENGINE_BUFFER_LIST_KEY,
-            separator=":",
-            shards=WORKFLOW_ENGINE_BUFFER_LIST_KEY_SHARDS,
+        project_ids = buffer.backend.bulk_get_sorted_set(
+            [WORKFLOW_ENGINE_BUFFER_LIST_KEY],
             min=0,
             max=self.buffer_timestamp,
         )
@@ -589,10 +582,8 @@ class TestWorkflowEnqueuing(BaseWorkflowTest):
 
         process_workflows(self.event_data)
 
-        project_ids = buffer.backend.get_sharded_sorted_set(
-            WORKFLOW_ENGINE_BUFFER_LIST_KEY,
-            separator=":",
-            shards=WORKFLOW_ENGINE_BUFFER_LIST_KEY_SHARDS,
+        project_ids = buffer.backend.bulk_get_sorted_set(
+            [WORKFLOW_ENGINE_BUFFER_LIST_KEY],
             min=0,
             max=self.buffer_timestamp,
         )
@@ -603,10 +594,8 @@ class TestWorkflowEnqueuing(BaseWorkflowTest):
 
         process_workflows(self.event_data)
 
-        project_ids = buffer.backend.get_sharded_sorted_set(
-            WORKFLOW_ENGINE_BUFFER_LIST_KEY,
-            separator=":",
-            shards=WORKFLOW_ENGINE_BUFFER_LIST_KEY_SHARDS,
+        project_ids = buffer.backend.bulk_get_sorted_set(
+            [WORKFLOW_ENGINE_BUFFER_LIST_KEY],
             min=0,
             max=self.buffer_timestamp,
         )
@@ -757,10 +746,8 @@ class TestEvaluateWorkflowActionFilters(BaseWorkflowTest):
 
         enqueue_workflows(queue_items)
 
-        project_ids = buffer.backend.get_sharded_sorted_set(
-            WORKFLOW_ENGINE_BUFFER_LIST_KEY,
-            separator=":",
-            shards=WORKFLOW_ENGINE_BUFFER_LIST_KEY_SHARDS,
+        project_ids = buffer.backend.bulk_get_sorted_set(
+            [WORKFLOW_ENGINE_BUFFER_LIST_KEY],
             min=0,
             max=timezone.now().timestamp(),
         )

--- a/tests/sentry/workflow_engine/test_integration.py
+++ b/tests/sentry/workflow_engine/test_integration.py
@@ -24,7 +24,7 @@ from sentry.workflow_engine.models import Detector, DetectorWorkflow
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.processors import process_data_source, process_detectors
 from sentry.workflow_engine.processors.delayed_workflow import process_delayed_workflows
-from sentry.workflow_engine.processors.workflow import get_all_buffer_keys
+from sentry.workflow_engine.tasks.delayed_workflows import DelayedWorkflow
 from sentry.workflow_engine.types import DetectorPriorityLevel
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 
@@ -213,7 +213,7 @@ class TestWorkflowEngineIntegrationFromErrorPostProcess(BaseWorkflowIntegrationT
         )
         self.workflow_triggers.conditions.all().delete()
         self.action_group, self.action = self.create_workflow_action(workflow=self.workflow)
-        self.buffer_keys = get_all_buffer_keys()
+        self.buffer_keys = DelayedWorkflow.get_buffer_keys()
 
     @pytest.fixture(autouse=True)
     def with_feature_flags(self):

--- a/tests/sentry/workflow_engine/test_integration.py
+++ b/tests/sentry/workflow_engine/test_integration.py
@@ -24,7 +24,7 @@ from sentry.workflow_engine.models import Detector, DetectorWorkflow
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.processors import process_data_source, process_detectors
 from sentry.workflow_engine.processors.delayed_workflow import process_delayed_workflows
-from sentry.workflow_engine.processors.workflow import WORKFLOW_ENGINE_BUFFER_LIST_KEY
+from sentry.workflow_engine.processors.workflow import get_all_buffer_keys
 from sentry.workflow_engine.types import DetectorPriorityLevel
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 
@@ -213,6 +213,7 @@ class TestWorkflowEngineIntegrationFromErrorPostProcess(BaseWorkflowIntegrationT
         )
         self.workflow_triggers.conditions.all().delete()
         self.action_group, self.action = self.create_workflow_action(workflow=self.workflow)
+        self.buffer_keys = get_all_buffer_keys()
 
     @pytest.fixture(autouse=True)
     def with_feature_flags(self):
@@ -409,8 +410,8 @@ class TestWorkflowEngineIntegrationFromErrorPostProcess(BaseWorkflowIntegrationT
         self.post_process_error(event_1, is_new=True)
         assert not mock_trigger.called
 
-        project_ids = buffer.backend.get_sorted_set(
-            WORKFLOW_ENGINE_BUFFER_LIST_KEY, 0, timezone.now().timestamp()
+        project_ids = buffer.backend.bulk_get_sorted_set(
+            self.buffer_keys, 0, timezone.now().timestamp()
         )
         assert not project_ids
 
@@ -419,8 +420,8 @@ class TestWorkflowEngineIntegrationFromErrorPostProcess(BaseWorkflowIntegrationT
         self.post_process_error(event_2, is_new=True)
         assert not mock_trigger.called
 
-        project_ids = buffer.backend.get_sorted_set(
-            WORKFLOW_ENGINE_BUFFER_LIST_KEY, 0, timezone.now().timestamp()
+        project_ids = buffer.backend.bulk_get_sorted_set(
+            self.buffer_keys, 0, timezone.now().timestamp()
         )
         assert not project_ids
 
@@ -434,12 +435,12 @@ class TestWorkflowEngineIntegrationFromErrorPostProcess(BaseWorkflowIntegrationT
         assert not mock_trigger.called
 
         project_ids = buffer.backend.bulk_get_sorted_set(
-            [WORKFLOW_ENGINE_BUFFER_LIST_KEY],
+            self.buffer_keys,
             min=0,
             max=timezone.now().timestamp(),
         )
 
-        process_delayed_workflows(project_ids[0][0])
+        process_delayed_workflows(list(project_ids.keys())[0])
         mock_trigger.assert_called_once()
 
     def test_slow_condition_subqueries(self, mock_trigger: MagicMock) -> None:
@@ -477,12 +478,12 @@ class TestWorkflowEngineIntegrationFromErrorPostProcess(BaseWorkflowIntegrationT
             assert not mock_trigger.called
 
             project_ids = buffer.backend.bulk_get_sorted_set(
-                [WORKFLOW_ENGINE_BUFFER_LIST_KEY],
+                self.buffer_keys,
                 min=0,
                 max=timezone.now().timestamp(),
             )
 
-            process_delayed_workflows(project_ids[0][0])
+            process_delayed_workflows(list(project_ids.keys())[0])
             assert not mock_trigger.called
 
         with freeze_time(now + timedelta(minutes=1)):
@@ -492,10 +493,10 @@ class TestWorkflowEngineIntegrationFromErrorPostProcess(BaseWorkflowIntegrationT
             assert not mock_trigger.called
 
             project_ids = buffer.backend.bulk_get_sorted_set(
-                [WORKFLOW_ENGINE_BUFFER_LIST_KEY],
+                self.buffer_keys,
                 min=0,
                 max=timezone.now().timestamp(),
             )
 
-            process_delayed_workflows(project_ids[0][0])
+            process_delayed_workflows(list(project_ids.keys())[0])
             mock_trigger.assert_called_once()

--- a/tests/sentry/workflow_engine/test_integration.py
+++ b/tests/sentry/workflow_engine/test_integration.py
@@ -24,10 +24,7 @@ from sentry.workflow_engine.models import Detector, DetectorWorkflow
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.processors import process_data_source, process_detectors
 from sentry.workflow_engine.processors.delayed_workflow import process_delayed_workflows
-from sentry.workflow_engine.processors.workflow import (
-    WORKFLOW_ENGINE_BUFFER_LIST_KEY,
-    WORKFLOW_ENGINE_BUFFER_LIST_KEY_SHARDS,
-)
+from sentry.workflow_engine.processors.workflow import WORKFLOW_ENGINE_BUFFER_LIST_KEY
 from sentry.workflow_engine.types import DetectorPriorityLevel
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 
@@ -436,10 +433,8 @@ class TestWorkflowEngineIntegrationFromErrorPostProcess(BaseWorkflowIntegrationT
         self.post_process_error(event_5)
         assert not mock_trigger.called
 
-        project_ids = buffer.backend.get_sharded_sorted_set(
-            WORKFLOW_ENGINE_BUFFER_LIST_KEY,
-            separator=":",
-            shards=WORKFLOW_ENGINE_BUFFER_LIST_KEY_SHARDS,
+        project_ids = buffer.backend.bulk_get_sorted_set(
+            [WORKFLOW_ENGINE_BUFFER_LIST_KEY],
             min=0,
             max=timezone.now().timestamp(),
         )
@@ -481,10 +476,8 @@ class TestWorkflowEngineIntegrationFromErrorPostProcess(BaseWorkflowIntegrationT
             self.post_process_error(event_3)
             assert not mock_trigger.called
 
-            project_ids = buffer.backend.get_sharded_sorted_set(
-                WORKFLOW_ENGINE_BUFFER_LIST_KEY,
-                separator=":",
-                shards=WORKFLOW_ENGINE_BUFFER_LIST_KEY_SHARDS,
+            project_ids = buffer.backend.bulk_get_sorted_set(
+                [WORKFLOW_ENGINE_BUFFER_LIST_KEY],
                 min=0,
                 max=timezone.now().timestamp(),
             )
@@ -498,10 +491,8 @@ class TestWorkflowEngineIntegrationFromErrorPostProcess(BaseWorkflowIntegrationT
             self.post_process_error(event_4)
             assert not mock_trigger.called
 
-            project_ids = buffer.backend.get_sharded_sorted_set(
-                WORKFLOW_ENGINE_BUFFER_LIST_KEY,
-                separator=":",
-                shards=WORKFLOW_ENGINE_BUFFER_LIST_KEY_SHARDS,
+            project_ids = buffer.backend.bulk_get_sorted_set(
+                [WORKFLOW_ENGINE_BUFFER_LIST_KEY],
                 min=0,
                 max=timezone.now().timestamp(),
             )

--- a/tests/sentry/workflow_engine/test_integration.py
+++ b/tests/sentry/workflow_engine/test_integration.py
@@ -24,7 +24,10 @@ from sentry.workflow_engine.models import Detector, DetectorWorkflow
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.processors import process_data_source, process_detectors
 from sentry.workflow_engine.processors.delayed_workflow import process_delayed_workflows
-from sentry.workflow_engine.processors.workflow import WORKFLOW_ENGINE_BUFFER_LIST_KEY
+from sentry.workflow_engine.processors.workflow import (
+    WORKFLOW_ENGINE_BUFFER_LIST_KEY,
+    WORKFLOW_ENGINE_BUFFER_LIST_KEY_SHARDS,
+)
 from sentry.workflow_engine.types import DetectorPriorityLevel
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 
@@ -433,8 +436,12 @@ class TestWorkflowEngineIntegrationFromErrorPostProcess(BaseWorkflowIntegrationT
         self.post_process_error(event_5)
         assert not mock_trigger.called
 
-        project_ids = buffer.backend.get_sorted_set(
-            WORKFLOW_ENGINE_BUFFER_LIST_KEY, 0, timezone.now().timestamp()
+        project_ids = buffer.backend.get_sharded_sorted_set(
+            WORKFLOW_ENGINE_BUFFER_LIST_KEY,
+            separator=":",
+            shards=WORKFLOW_ENGINE_BUFFER_LIST_KEY_SHARDS,
+            min=0,
+            max=timezone.now().timestamp(),
         )
 
         process_delayed_workflows(project_ids[0][0])
@@ -474,8 +481,12 @@ class TestWorkflowEngineIntegrationFromErrorPostProcess(BaseWorkflowIntegrationT
             self.post_process_error(event_3)
             assert not mock_trigger.called
 
-            project_ids = buffer.backend.get_sorted_set(
-                WORKFLOW_ENGINE_BUFFER_LIST_KEY, 0, timezone.now().timestamp()
+            project_ids = buffer.backend.get_sharded_sorted_set(
+                WORKFLOW_ENGINE_BUFFER_LIST_KEY,
+                separator=":",
+                shards=WORKFLOW_ENGINE_BUFFER_LIST_KEY_SHARDS,
+                min=0,
+                max=timezone.now().timestamp(),
             )
 
             process_delayed_workflows(project_ids[0][0])
@@ -487,8 +498,12 @@ class TestWorkflowEngineIntegrationFromErrorPostProcess(BaseWorkflowIntegrationT
             self.post_process_error(event_4)
             assert not mock_trigger.called
 
-            project_ids = buffer.backend.get_sorted_set(
-                WORKFLOW_ENGINE_BUFFER_LIST_KEY, 0, timezone.now().timestamp()
+            project_ids = buffer.backend.get_sharded_sorted_set(
+                WORKFLOW_ENGINE_BUFFER_LIST_KEY,
+                separator=":",
+                shards=WORKFLOW_ENGINE_BUFFER_LIST_KEY_SHARDS,
+                min=0,
+                max=timezone.now().timestamp(),
             )
 
             process_delayed_workflows(project_ids[0][0])


### PR DESCRIPTION
Continues https://github.com/getsentry/sentry/pull/97638 to enqueue project ids in workflow engine to the sharded list. The previous PR already handles pulling from the sharded list