### PR TITLE
ref(access-logs): revert logging access logs 

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3448,8 +3448,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-register("issues.log-access-logs", type=Float, default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
-
 # Use "first-seen" group instead of "most-seen" group when merging
 register(
     "issues.merging.first-seen",


### PR DESCRIPTION
Reverts https://github.com/getsentry/sentry/pull/97183 (also see https://github.com/getsentry/sentry-options-automator/pull/4886) — even with the additional information, I haven't been able to narrow down the issue and am planning to move on (https://linear.app/getsentry/issue/ID-805/fix-missing-organization-id-in-api-access-logs for more investigation), so this cleans the leftover logging up before I stop working on it.