### PR TITLE
ref(issues): improve similar issues stacktrace diff

### DIFF
--- a/static/app/components/issueDiff/index.tsx
+++ b/static/app/components/issueDiff/index.tsx
@@ -212,6 +212,7 @@ const StyledIssueDiff = styled('div', {
   flex: 1;
   display: flex;
   flex-direction: column;
+  min-height: 0;
 
   ${p =>
     p.loading &&
@@ -226,11 +227,15 @@ const SegmentedControlContainer = styled('div')`
   position: relative;
   display: flex;
   justify-content: flex-end;
+  align-items: center;
   top: -${space(1)};
-  right: ${space(1)};
+  right: 0;
   z-index: 1;
 `;
 
 const Container = styled('div')`
   position: relative;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
 `;

--- a/static/app/components/issueDiff/index.tsx
+++ b/static/app/components/issueDiff/index.tsx
@@ -6,7 +6,6 @@ import type {Location} from 'history';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import type {Client} from 'sentry/api';
-import {SegmentedControl} from 'sentry/components/core/segmentedControl';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import type SplitDiff from 'sentry/components/splitDiff';
 import {t} from 'sentry/locale';
@@ -41,7 +40,6 @@ type Props = {
 
 type State = {
   baseEvent: string[];
-  diffType: 'lines' | 'words';
   loading: boolean;
   targetEvent: string[];
   SplitDiffAsync?: typeof SplitDiff;
@@ -51,11 +49,13 @@ class IssueDiff extends Component<Props, State> {
   static defaultProps: DefaultProps = defaultProps;
 
   state: State = {
-    baseEvent: [],
-    diffType: 'lines',
     loading: true,
-    SplitDiffAsync: undefined,
+    baseEvent: [],
     targetEvent: [],
+
+    // `SplitDiffAsync` is an async-loaded component
+    // This will eventually contain a reference to the exported component from `./splitDiff`
+    SplitDiffAsync: undefined,
   };
 
   componentDidMount() {
@@ -160,40 +160,22 @@ class IssueDiff extends Component<Props, State> {
 
   render() {
     const {className} = this.props;
-    const {
-      SplitDiffAsync: DiffComponent,
-      loading,
-      baseEvent,
-      targetEvent,
-      diffType,
-    } = this.state;
+    const {SplitDiffAsync: DiffComponent, loading, baseEvent, targetEvent} = this.state;
 
     return (
-      <Container>
-        <SegmentedControlContainer>
-          <SegmentedControl
-            value={diffType}
-            onChange={value => this.setState({diffType: value as 'lines' | 'words'})}
-            size="xs"
-          >
-            <SegmentedControl.Item key="lines">{t('Lines')}</SegmentedControl.Item>
-            <SegmentedControl.Item key="words">{t('Words')}</SegmentedControl.Item>
-          </SegmentedControl>
-        </SegmentedControlContainer>
-        <StyledIssueDiff className={className} loading={loading}>
-          {loading && <LoadingIndicator />}
-          {!loading &&
-            DiffComponent &&
-            baseEvent.map((value, i) => (
-              <DiffComponent
-                key={i}
-                base={value}
-                target={targetEvent[i] ?? ''}
-                type={diffType}
-              />
-            ))}
-        </StyledIssueDiff>
-      </Container>
+      <StyledIssueDiff className={className} loading={loading}>
+        {loading && <LoadingIndicator />}
+        {!loading &&
+          DiffComponent &&
+          baseEvent.map((value, i) => (
+            <DiffComponent
+              key={i}
+              base={value}
+              target={targetEvent[i] ?? ''}
+              type="lines"
+            />
+          ))}
+      </StyledIssueDiff>
     );
   }
 }
@@ -212,7 +194,6 @@ const StyledIssueDiff = styled('div', {
   flex: 1;
   display: flex;
   flex-direction: column;
-  min-height: 0;
 
   ${p =>
     p.loading &&
@@ -221,21 +202,4 @@ const StyledIssueDiff = styled('div', {
       justify-content: center;
       align-items: center;
     `};
-`;
-
-const SegmentedControlContainer = styled('div')`
-  position: relative;
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
-  top: -${space(1)};
-  right: 0;
-  z-index: 1;
-`;
-
-const Container = styled('div')`
-  position: relative;
-  height: 100%;
-  display: flex;
-  flex-direction: column;
 `;

--- a/static/app/components/issueDiff/index.tsx
+++ b/static/app/components/issueDiff/index.tsx
@@ -6,6 +6,7 @@ import type {Location} from 'history';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import type {Client} from 'sentry/api';
+import {SegmentedControl} from 'sentry/components/core/segmentedControl';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import type SplitDiff from 'sentry/components/splitDiff';
 import {t} from 'sentry/locale';
@@ -40,6 +41,7 @@ type Props = {
 
 type State = {
   baseEvent: string[];
+  diffType: 'lines' | 'words';
   loading: boolean;
   targetEvent: string[];
   SplitDiffAsync?: typeof SplitDiff;
@@ -49,13 +51,11 @@ class IssueDiff extends Component<Props, State> {
   static defaultProps: DefaultProps = defaultProps;
 
   state: State = {
-    loading: true,
     baseEvent: [],
-    targetEvent: [],
-
-    // `SplitDiffAsync` is an async-loaded component
-    // This will eventually contain a reference to the exported component from `./splitDiff`
+    diffType: 'lines',
+    loading: true,
     SplitDiffAsync: undefined,
+    targetEvent: [],
   };
 
   componentDidMount() {
@@ -160,22 +160,40 @@ class IssueDiff extends Component<Props, State> {
 
   render() {
     const {className} = this.props;
-    const {SplitDiffAsync: DiffComponent, loading, baseEvent, targetEvent} = this.state;
+    const {
+      SplitDiffAsync: DiffComponent,
+      loading,
+      baseEvent,
+      targetEvent,
+      diffType,
+    } = this.state;
 
     return (
-      <StyledIssueDiff className={className} loading={loading}>
-        {loading && <LoadingIndicator />}
-        {!loading &&
-          DiffComponent &&
-          baseEvent.map((value, i) => (
-            <DiffComponent
-              key={i}
-              base={value}
-              target={targetEvent[i] ?? ''}
-              type="words"
-            />
-          ))}
-      </StyledIssueDiff>
+      <Container>
+        <SegmentedControlContainer>
+          <SegmentedControl
+            value={diffType}
+            onChange={value => this.setState({diffType: value as 'lines' | 'words'})}
+            size="xs"
+          >
+            <SegmentedControl.Item key="lines">{t('Lines')}</SegmentedControl.Item>
+            <SegmentedControl.Item key="words">{t('Words')}</SegmentedControl.Item>
+          </SegmentedControl>
+        </SegmentedControlContainer>
+        <StyledIssueDiff className={className} loading={loading}>
+          {loading && <LoadingIndicator />}
+          {!loading &&
+            DiffComponent &&
+            baseEvent.map((value, i) => (
+              <DiffComponent
+                key={i}
+                base={value}
+                target={targetEvent[i] ?? ''}
+                type={diffType}
+              />
+            ))}
+        </StyledIssueDiff>
+      </Container>
     );
   }
 }
@@ -202,4 +220,17 @@ const StyledIssueDiff = styled('div', {
       justify-content: center;
       align-items: center;
     `};
+`;
+
+const SegmentedControlContainer = styled('div')`
+  position: relative;
+  display: flex;
+  justify-content: flex-end;
+  top: -${space(1)};
+  right: ${space(1)};
+  z-index: 1;
+`;
+
+const Container = styled('div')`
+  position: relative;
 `;

--- a/static/app/components/replays/diff/replayTextDiff.tsx
+++ b/static/app/components/replays/diff/replayTextDiff.tsx
@@ -52,7 +52,7 @@ export function ReplayTextDiff() {
         </After>
       </ContentSliderDiff.Header>
       <SplitDiffScrollWrapper>
-        <SplitDiff base={leftBody ?? ''} target={rightBody ?? ''} type="words" />
+        <SplitDiff base={leftBody ?? ''} target={rightBody ?? ''} type="lines" />
       </SplitDiffScrollWrapper>
     </Container>
   );

--- a/static/app/components/splitDiff.tsx
+++ b/static/app/components/splitDiff.tsx
@@ -28,26 +28,26 @@ function SplitDiff({className, type = 'lines', base, target}: Props) {
 
   const results = diffFn(base, target, {newlineIsToken: true});
 
+  // split one change that includes multiple linse into one change per line (for formatting)
   const processResults = (
     currentLine: Change[] = [],
     processedLines: Change[][] = []
   ): Change[][] => {
     for (const change of results) {
-      if (change.value.includes('\n')) {
-        // multiple lines if it should be
-        const lines = change.value.split('\n');
-        for (let i = 0; i < lines.length; i++) {
-          const lineValue = lines[i];
-          if (lineValue !== undefined && lineValue !== '') {
-            currentLine.push({...change, value: lineValue});
-          }
-          if (i < lines.length - 1) {
-            processedLines.push(currentLine);
-            currentLine = [];
-          }
+      const lines = change.value.split('\n');
+      for (let i = 0; i < lines.length; i++) {
+        const lineValue = lines[i];
+        if (lineValue !== undefined && lineValue !== '') {
+          currentLine.push({
+            value: lineValue,
+            added: change.added,
+            removed: change.removed,
+          });
         }
-      } else {
-        currentLine.push(change);
+        if (i < lines.length - 1) {
+          processedLines.push(currentLine);
+          currentLine = [];
+        }
       }
     }
     // Push remaining changes if any
@@ -57,7 +57,6 @@ function SplitDiff({className, type = 'lines', base, target}: Props) {
     return processedLines;
   };
 
-  // Call the function and store the result
   const groupedChanges = processResults();
 
   return (

--- a/static/app/components/splitDiff.tsx
+++ b/static/app/components/splitDiff.tsx
@@ -1,3 +1,4 @@
+import {useMemo} from 'react';
 import styled from '@emotion/styled';
 import type {Change} from 'diff';
 import {diffChars, diffLines, diffWords} from 'diff';
@@ -55,7 +56,7 @@ function SplitDiff({className, type = 'lines', base, target}: Props) {
   const results = diffFn(base, target, {newlineIsToken: true});
 
   // split one change that includes multiple lines into one change per line (for formatting)
-  const processResults = (): Change[][] => {
+  const groupedChanges = useMemo((): Change[][] => {
     let currentLine: Change[] = [];
     const processedLines: Change[][] = [];
     for (const change of results) {
@@ -79,9 +80,7 @@ function SplitDiff({className, type = 'lines', base, target}: Props) {
       processedLines.push(currentLine);
     }
     return processedLines;
-  };
-
-  const groupedChanges = processResults();
+  }, [results]);
 
   return (
     <SplitTable className={className} data-test-id="split-diff">

--- a/static/app/components/splitDiff.tsx
+++ b/static/app/components/splitDiff.tsx
@@ -29,27 +29,24 @@ function getDisplayData(
   highlightAdded: Change | undefined,
   highlightRemoved: Change | undefined
 ): Change[] {
-  const displayData =
-    highlightAdded || highlightRemoved
-      ? (() => {
-          const leftText = line.reduce(
-            (acc, result) => (result.added ? acc : acc + result.value),
-            ''
-          );
-          const rightText = line.reduce(
-            (acc, result) => (result.removed ? acc : acc + result.value),
-            ''
-          );
+  if (!highlightAdded && !highlightRemoved) {
+    return line;
+  }
 
-          if (!leftText && !rightText) {
-            return line;
-          }
+  const leftText = line.reduce(
+    (acc, result) => (result.added ? acc : acc + result.value),
+    ''
+  );
+  const rightText = line.reduce(
+    (acc, result) => (result.removed ? acc : acc + result.value),
+    ''
+  );
 
-          return diffWords(leftText, rightText);
-        })()
-      : line;
+  if (!leftText && !rightText) {
+    return line;
+  }
 
-  return displayData;
+  return diffWords(leftText, rightText);
 }
 
 function SplitDiff({className, type = 'lines', base, target}: Props) {


### PR DESCRIPTION
Improve similar issues stacktrace diff by changing diff `type` to `lines`, and then diffing those lines by `word`.

#### Before/After
<img width="1456" height="720" alt="bffr" src="https://github.com/user-attachments/assets/3ddbfebf-b09e-4cb2-a7af-76ad5364ff46" />
<img width="1430" height="703" alt="afterrrrrr" src="https://github.com/user-attachments/assets/e605aad1-4601-4306-8752-3a6d9afeb8ca" />


#### Change to `lines`
The diff library does not know how to split stacktraces into words effectively, leading to weird formatting like file names and function calls being split up. 
<img width="1434" height="296" alt="image" src="https://github.com/user-attachments/assets/22115c89-2fec-4abd-934c-8294b6f97aa9" />
Changing the diff type to `lines` preserves the structure of the stack trace when diffing. Then, diffing those split lines by `words` keeps the structure made with `lines` but gives a more accurate diff. 

#### `processChange`
`diffFn()` returns a list of `Change` objects whos values have to be put back together to form the stack trace in the UI. To preserve formatting, each change has to only contain one line, or you get multi line highlights like this.
<img width="573" height="90" alt="image" src="https://github.com/user-attachments/assets/73396d29-4600-4af4-b221-cd1c858d5a77" />

Additionally, including newlines can cause spacing issues(below) in the `<SplitBody>` component so generally they are removed, and lines are broken up instead by the `<Line>` component. 
<img width="1422" height="694" alt="line_no_formatting" src="https://github.com/user-attachments/assets/6c99b427-146e-4b01-bff7-fb68d4ff8a3f" />
