### PR TITLE
fix(eco): downgrades weekly report timeouts from a failure to a halt

### DIFF
--- a/src/sentry/tasks/summaries/metrics.py
+++ b/src/sentry/tasks/summaries/metrics.py
@@ -6,14 +6,6 @@ from sentry.integrations.types import EventLifecycleOutcome
 from sentry.integrations.utils.metrics import EventLifecycleMetric
 
 
-class WeeklyReportFailureReason(StrEnum):
-    """
-    The reason for a failure in the weekly reporting pipeline.
-    """
-
-    TIMEOUT = "timeout"
-
-
 class WeeklyReportHaltReason(StrEnum):
     """
     The reason for a halt in the weekly reporting pipeline.
@@ -22,6 +14,7 @@ class WeeklyReportHaltReason(StrEnum):
     EMPTY_REPORT = "empty_report"
     DRY_RUN = "dry_run"
     DUPLICATE_DELIVERY = "duplicate_delivery"
+    TIMEOUT = "timeout"
 
 
 class WeeklyReportOperationType(StrEnum):

--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -26,7 +26,6 @@ from sentry.notifications.services import notifications_service
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task, retry
 from sentry.tasks.summaries.metrics import (
-    WeeklyReportFailureReason,
     WeeklyReportHaltReason,
     WeeklyReportOperationType,
     WeeklyReportSLO,
@@ -158,7 +157,7 @@ def schedule_organizations(
 
             batching.delete_min_org_id()
         except ProcessingDeadlineExceeded:
-            lifecycle.record_failure(WeeklyReportFailureReason.TIMEOUT)
+            lifecycle.record_halt(WeeklyReportHaltReason.TIMEOUT)
             raise
 
 


### PR DESCRIPTION
Timeouts of our organization scheduling task doesn't specifically flag that our weekly reports are broken. Because our reporting is reentrant, these should be marked as halts, not failures.
