### PR TITLE
chore(crons): Move crons grouptype into `monitors/grouptype.py`

### DIFF
--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -607,36 +607,6 @@ class ProfileFunctionRegressionType(GroupType):
 
 
 @dataclass(frozen=True)
-class MonitorIncidentType(GroupType):
-    type_id = 4001
-    slug = "monitor_check_in_failure"
-    description = "Crons Monitor Failed"
-    category = GroupCategory.CRON.value
-    category_v2 = GroupCategory.OUTAGE.value
-    released = True
-    creation_quota = Quota(3600, 60, 60_000)  # 60,000 per hour, sliding window of 60 seconds
-    default_priority = PriorityLevel.HIGH
-    notification_config = NotificationConfig(context=[])
-
-
-# XXX(epurkhiser): We renamed this group type but we keep the alias since we
-# store group type in pickles
-MonitorCheckInFailure = MonitorIncidentType
-
-
-@dataclass(frozen=True)
-class MonitorCheckInTimeout(MonitorIncidentType):
-    # This is deprecated, only kept around for it's type_id
-    type_id = 4002
-
-
-@dataclass(frozen=True)
-class MonitorCheckInMissed(MonitorIncidentType):
-    # This is deprecated, only kept around for it's type_id
-    type_id = 4003
-
-
-@dataclass(frozen=True)
 class ReplayRageClickType(ReplayGroupTypeDefaults, GroupType):
     type_id = 5002
     slug = "replay_click_rage"

--- a/src/sentry/monitors/grouptype.py
+++ b/src/sentry/monitors/grouptype.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sentry_redis_tools.sliding_windows_rate_limiter import Quota
+
+from sentry.issues.grouptype import GroupCategory, GroupType, NotificationConfig
+from sentry.types.group import PriorityLevel
+
+
+@dataclass(frozen=True)
+class MonitorIncidentType(GroupType):
+    type_id = 4001
+    slug = "monitor_check_in_failure"
+    description = "Crons Monitor Failed"
+    category = GroupCategory.CRON.value
+    category_v2 = GroupCategory.OUTAGE.value
+    released = True
+    creation_quota = Quota(3600, 60, 60_000)  # 60,000 per hour, sliding window of 60 seconds
+    default_priority = PriorityLevel.HIGH
+    notification_config = NotificationConfig(context=[])
+
+
+@dataclass(frozen=True)
+class MonitorCheckInTimeout(MonitorIncidentType):
+    # This is deprecated, only kept around for its type_id
+    type_id = 4002
+
+
+@dataclass(frozen=True)
+class MonitorCheckInMissed(MonitorIncidentType):
+    # This is deprecated, only kept around for its type_id
+    type_id = 4003

--- a/src/sentry/monitors/grouptype.py
+++ b/src/sentry/monitors/grouptype.py
@@ -19,15 +19,3 @@ class MonitorIncidentType(GroupType):
     creation_quota = Quota(3600, 60, 60_000)  # 60,000 per hour, sliding window of 60 seconds
     default_priority = PriorityLevel.HIGH
     notification_config = NotificationConfig(context=[])
-
-
-@dataclass(frozen=True)
-class MonitorCheckInTimeout(MonitorIncidentType):
-    # This is deprecated, only kept around for its type_id
-    type_id = 4002
-
-
-@dataclass(frozen=True)
-class MonitorCheckInMissed(MonitorIncidentType):
-    # This is deprecated, only kept around for its type_id
-    type_id = 4003

--- a/src/sentry/monitors/logic/incident_occurrence.py
+++ b/src/sentry/monitors/logic/incident_occurrence.py
@@ -16,11 +16,11 @@ from sentry_kafka_schemas.schema_types.monitors_incident_occurrences_v1 import I
 
 from sentry import options
 from sentry.conf.types.kafka_definition import Topic, get_topic_codec
-from sentry.issues.grouptype import MonitorIncidentType
 from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence
 from sentry.issues.producer import PayloadType, produce_occurrence_to_kafka
 from sentry.issues.status_change_message import StatusChangeMessage
 from sentry.models.group import GroupStatus
+from sentry.monitors.grouptype import MonitorIncidentType
 from sentry.monitors.models import (
     CheckInStatus,
     MonitorCheckIn,

--- a/src/sentry/monitors/utils.py
+++ b/src/sentry/monitors/utils.py
@@ -9,11 +9,11 @@ from rest_framework.request import Request
 from sentry import audit_log
 from sentry.api.serializers.rest_framework.rule import RuleSerializer
 from sentry.db.models import BoundedPositiveIntegerField
-from sentry.issues.grouptype import MonitorIncidentType
 from sentry.models.group import Group
 from sentry.models.project import Project
 from sentry.models.rule import Rule, RuleActivity, RuleActivityType, RuleSource
 from sentry.monitors.constants import DEFAULT_CHECKIN_MARGIN, MAX_TIMEOUT, TIMEOUT
+from sentry.monitors.grouptype import MonitorIncidentType
 from sentry.monitors.models import CheckInStatus, Monitor, MonitorCheckIn
 from sentry.monitors.types import DATA_SOURCE_CRON_MONITOR
 from sentry.projects.project_rules.creator import ProjectRuleCreator

--- a/tests/sentry/integrations/slack/notifications/test_issue_alert.py
+++ b/tests/sentry/integrations/slack/notifications/test_issue_alert.py
@@ -14,13 +14,13 @@ from sentry.integrations.models.external_actor import ExternalActor
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.slack.message_builder.issues import get_tags
 from sentry.integrations.types import ExternalProviders
-from sentry.issues.grouptype import MonitorIncidentType
 from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence
 from sentry.issues.ownership.grammar import Matcher, Owner
 from sentry.issues.ownership.grammar import Rule as GrammarRule
 from sentry.issues.ownership.grammar import dump_schema
 from sentry.models.projectownership import ProjectOwnership
 from sentry.models.rule import Rule
+from sentry.monitors.grouptype import MonitorIncidentType
 from sentry.notifications.models.notificationsettingoption import NotificationSettingOption
 from sentry.notifications.models.notificationsettingprovider import NotificationSettingProvider
 from sentry.notifications.notifications.rules import AlertRuleNotification

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -40,7 +40,6 @@ from sentry.integrations.time_utils import time_since
 from sentry.issues.grouptype import (
     FeedbackGroup,
     GroupCategory,
-    MonitorIncidentType,
     PerformanceP95EndpointRegressionGroupType,
     ProfileFileIOGroupType,
 )
@@ -53,6 +52,7 @@ from sentry.models.pullrequest import PullRequest
 from sentry.models.repository import Repository
 from sentry.models.rule import Rule as IssueAlertRule
 from sentry.models.team import Team
+from sentry.monitors.grouptype import MonitorIncidentType
 from sentry.notifications.utils.actions import MessageAction
 from sentry.seer.anomaly_detection.types import StoreDataResponse
 from sentry.seer.autofix.constants import SeerAutomationSource

--- a/tests/sentry/issues/test_ingest.py
+++ b/tests/sentry/issues/test_ingest.py
@@ -17,7 +17,6 @@ from sentry.issues.grouptype import (
     GroupCategory,
     GroupType,
     GroupTypeRegistry,
-    MonitorIncidentType,
     NoiseConfig,
 )
 from sentry.issues.ingest import (
@@ -39,6 +38,7 @@ from sentry.models.grouprelease import GroupRelease
 from sentry.models.release import Release
 from sentry.models.releaseprojectenvironment import ReleaseProjectEnvironment
 from sentry.models.releases.release_project import ReleaseProject
+from sentry.monitors.grouptype import MonitorIncidentType
 from sentry.ratelimits.sliding_windows import RequestedQuota
 from sentry.receivers import create_default_projects
 from sentry.snuba.dataset import Dataset

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -18,7 +18,6 @@ from sentry.api.serializers import serialize
 from sentry.api.serializers.models.userreport import UserReportWithGroupSerializer
 from sentry.digests.notifications import build_digest, event_to_record
 from sentry.event_manager import EventManager, get_event_type
-from sentry.issues.grouptype import MonitorIncidentType
 from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence
 from sentry.issues.ownership import grammar
 from sentry.issues.ownership.grammar import Matcher, Owner, dump_schema
@@ -34,6 +33,7 @@ from sentry.models.projectownership import ProjectOwnership
 from sentry.models.repository import Repository
 from sentry.models.rule import Rule
 from sentry.models.userreport import UserReport
+from sentry.monitors.grouptype import MonitorIncidentType
 from sentry.notifications.models.notificationsettingoption import NotificationSettingOption
 from sentry.notifications.models.notificationsettingprovider import NotificationSettingProvider
 from sentry.notifications.notifications.rules import AlertRuleNotification

--- a/tests/sentry/monitors/logic/test_incident_occurrence.py
+++ b/tests/sentry/monitors/logic/test_incident_occurrence.py
@@ -8,7 +8,7 @@ from django.test import override_settings
 from django.utils import timezone
 from sentry_kafka_schemas.schema_types.monitors_incident_occurrences_v1 import IncidentOccurrence
 
-from sentry.issues.grouptype import MonitorIncidentType
+from sentry.monitors.grouptype import MonitorIncidentType
 from sentry.monitors.logic.incident_occurrence import (
     MONITORS_INCIDENT_OCCURRENCES,
     dispatch_incident_occurrence,

--- a/tests/sentry/monitors/test_utils.py
+++ b/tests/sentry/monitors/test_utils.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 from django.db import IntegrityError
 
-from sentry.issues.grouptype import MonitorIncidentType
+from sentry.monitors.grouptype import MonitorIncidentType
 from sentry.monitors.types import DATA_SOURCE_CRON_MONITOR
 from sentry.monitors.utils import ensure_cron_detector, get_detector_for_monitor
 from sentry.testutils.cases import TestCase

--- a/tests/sentry/tasks/test_weekly_reports.py
+++ b/tests/sentry/tasks/test_weekly_reports.py
@@ -12,12 +12,13 @@ from django.utils import timezone
 
 from sentry.analytics.events.weekly_report import WeeklyReportSent
 from sentry.constants import DataCategory
-from sentry.issues.grouptype import MonitorIncidentType, PerformanceNPlusOneGroupType
+from sentry.issues.grouptype import PerformanceNPlusOneGroupType
 from sentry.models.group import GroupStatus
 from sentry.models.grouphistory import GroupHistoryStatus
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.project import Project
 from sentry.models.team import TeamStatus
+from sentry.monitors.grouptype import MonitorIncidentType
 from sentry.notifications.models.notificationsettingoption import NotificationSettingOption
 from sentry.silo.base import SiloMode
 from sentry.silo.safety import unguarded_write

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_types.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_types.py
@@ -6,9 +6,9 @@ from sentry.issues.grouptype import (
     GroupCategory,
     GroupType,
     GroupTypeRegistry,
-    MonitorIncidentType,
     PerformanceSlowDBQueryGroupType,
 )
+from sentry.monitors.grouptype import MonitorIncidentType
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import region_silo_test
 from sentry.uptime.grouptype import UptimeDomainCheckFailure


### PR DESCRIPTION
We'll end up with circular imports as we work on this project if we leave these where they were.

Also removing various deprecated and unused types

<!-- Describe your PR here. -->