### PR TITLE
chore(access-logs): use `RateLimitType` enum value 

### DIFF
--- a/src/sentry/middleware/access_log.py
+++ b/src/sentry/middleware/access_log.py
@@ -56,9 +56,9 @@ def _get_rate_limit_stats_dict(request: Request) -> dict[str, str | int | None]:
 
     rate_limit_type = "DNE"
     if rate_limit_metadata:
-        rate_limit_type = str(getattr(rate_limit_metadata, "rate_limit_type", "DNE"))
+        rate_limit_type = rate_limit_metadata.rate_limit_type.value
     if snuba_rate_limit_metadata:
-        rate_limit_type = "RateLimitType.SNUBA"
+        rate_limit_type = "snuba"
 
     rate_limit_stats = {
         "rate_limit_type": rate_limit_type,

--- a/tests/sentry/middleware/test_access_log_middleware.py
+++ b/tests/sentry/middleware/test_access_log_middleware.py
@@ -208,7 +208,7 @@ class TestAccessLogSnubaRateLimited(LogCaptureAPITestCase):
         self.get_error_response(status_code=429)
         self.assert_access_log_recorded()
 
-        assert self.captured_logs[0].rate_limit_type == "RateLimitType.SNUBA"
+        assert self.captured_logs[0].rate_limit_type == "snuba"
         assert self.captured_logs[0].rate_limited == "True"
 
         # All the types from the standard rate limit metadata should be set
@@ -259,7 +259,7 @@ class TestAccessLogConcurrentRateLimited(LogCaptureAPITestCase):
             assert self.captured_logs[0].group == RateLimitedEndpoint.rate_limits.group
             assert self.captured_logs[i].concurrent_requests == "1"
             assert self.captured_logs[i].concurrent_limit == "1"
-            assert self.captured_logs[i].rate_limit_type == "RateLimitType.NOT_LIMITED"
+            assert self.captured_logs[i].rate_limit_type == "not_limited"
             assert self.captured_logs[i].limit == "20"
             # we cannot assert on the exact amount of remaining requests because
             # we may be crossing a second boundary during our test. That would make things


### PR DESCRIPTION
Small optimization of `rate_limit_type` in access logs — in [current logs ](https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Alabels.name%3D%22sentry.access.api%22%0A--%20jsonPayload.response%3D%22429%22;summaryFields=jsonPayload%252Fsnuba_policy:true:32:beginning;cursorTimestamp=2025-08-11T23:43:41.079123994Z;duration=PT1M?project=internal-sentry&inv=1&invt=Ab5OdQ&rapt=AEjHL4PBrQWV3ZJmqd0wvF-1f15JTm86isi56piku40Bpor7Pw4QyzlOKqaUr1vnKVKeYaF3kvGWXGwzrdUWzBmwHjG35PPzYfeh8qtsU-9Qf_I4Yb8EOfU&pli=1), `rate_limit_type` is the enum key (`RateLimitType.NOT_LIMITED`) rather than the value (`not_limited`).

Refs https://linear.app/getsentry/project/improve-rate-limiting-visibility-alerting-5feda23c3f5e/issues?layout=list&ordering=priority&grouping=workflowState&subGrouping=none&showCompletedIssues=all&showSubIssues=true&showTriageIssues=false