### PR TITLE
ref(workflow_engine): Fix dataSource in post to be dataSources

### DIFF
--- a/src/sentry/incidents/metric_issue_detector.py
+++ b/src/sentry/incidents/metric_issue_detector.py
@@ -125,7 +125,9 @@ class MetricIssueConditionGroupValidator(BaseDataConditionGroupValidator):
 
 
 class MetricIssueDetectorValidator(BaseDetectorTypeValidator):
-    data_source = SnubaQueryValidator(required=True, timeWindowSeconds=True)
+    data_sources = serializers.ListField(
+        child=SnubaQueryValidator(required=True, timeWindowSeconds=True),
+    )
     condition_group = MetricIssueConditionGroupValidator(required=True)
 
     def validate(self, attrs):

--- a/src/sentry/snuba/models.py
+++ b/src/sentry/snuba/models.py
@@ -116,6 +116,10 @@ class QuerySubscription(Model):
         DELETING = 3
         DISABLED = 4
 
+        @classmethod
+        def choices(cls):
+            return [(item.value, item.name) for item in cls]
+
     # NOTE: project fk SHOULD match AlertRule's fk
     project = FlexibleForeignKey("sentry.Project", db_constraint=False)
     snuba_query = FlexibleForeignKey("sentry.SnubaQuery", related_name="subscriptions")

--- a/src/sentry/snuba/snuba_query_validator.py
+++ b/src/sentry/snuba/snuba_query_validator.py
@@ -413,3 +413,22 @@ class SnubaQueryValidator(BaseDataSourceValidator[QuerySubscription]):
             subscription_type=INCIDENTS_SNUBA_SUBSCRIPTION_TYPE,
             snuba_query=snuba_query,
         )
+
+
+class QuerySubscriptionValidator(BaseDataSourceValidator[QuerySubscription]):
+    """
+    The QuerySubscriptionValidator is used to validate the entire QuerySubscription as a detector data source.
+    This is distinct from the SnubaQueryValidator which shares its validation with the AlertRuleSerializer.
+
+    When the AlertRule API is deprecated, we can remove the SnubaQueryValidator, and replace its usage with this.
+
+    TODO
+    - Add this on the MetricIsueDetectorHandler
+    """
+
+    id = serializers.IntegerField(required=False)
+    status = serializers.ChoiceField(choices=QuerySubscription.Status.choices, required=False)
+    subscription = serializers.CharField(required=False)
+    # TODO make sure the snubaQuery field is validated correctly, this should match: SnubaQuerySerializer
+    # -- in src/sentry/incidents/endpoints/serializers/query_subscription.py
+    snubaQuery = serializers.ListField(child=SnubaQueryValidator())

--- a/src/sentry/snuba/snuba_query_validator.py
+++ b/src/sentry/snuba/snuba_query_validator.py
@@ -426,8 +426,8 @@ class QuerySubscriptionValidator(BaseDataSourceValidator[QuerySubscription]):
     - Add this on the MetricIsueDetectorHandler
     """
 
-    id = serializers.IntegerField(required=False)
-    status = serializers.ChoiceField(choices=QuerySubscription.Status.choices, required=False)
+    id = serializers.CharField(required=False)
+    status = serializers.ChoiceField(choices=QuerySubscription.Status.choices(), required=False)
     subscription = serializers.CharField(required=False)
     # TODO make sure the snubaQuery field is validated correctly, this should match: SnubaQuerySerializer
     # -- in src/sentry/incidents/endpoints/serializers/query_subscription.py

--- a/src/sentry/workflow_engine/endpoints/organization_detector_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_index.py
@@ -318,7 +318,7 @@ class OrganizationDetectorIndexEndpoint(OrganizationEndpoint):
         :param string name: The name of the detector
         :param string type: The type of detector to create
         :param string projectId: The detector project
-        :param object dataSource: Configuration for the data source
+        :param array dataSources: Configuration for the data source
         :param array dataConditions: List of conditions to trigger the detector
         :param array workflowIds: List of workflow IDs to connect to the detector
         """

--- a/src/sentry/workflow_engine/endpoints/validators/base/detector.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/detector.py
@@ -147,7 +147,6 @@ class BaseDetectorTypeValidator(CamelSnakeSerializer):
             )
 
             validated_data_sources = validated_data.pop("data_sources", [])
-
             for validated_data_source in validated_data_sources:
                 data_source_creator = validated_data_source["_creator"]
                 data_source = data_source_creator.create()
@@ -185,7 +184,21 @@ class BaseDetectorTypeValidator(CamelSnakeSerializer):
                 owner_team_id=owner_team_id,
                 created_by_id=self.context["request"].user.id,
             )
-            DataSourceDetector.objects.create(data_source=detector_data_source, detector=detector)
+
+            # TODO - bulk create these?
+            validated_data_sources = validated_data.pop("data_sources", [])
+            for validated_data_source in validated_data_sources:
+                data_source_creator = validated_data_source["_creator"]
+                data_source = data_source_creator.create()
+                detector_data_source = DataSource.objects.create(
+                    organization_id=self.context["project"].organization_id,
+                    source_id=data_source.id,
+                    type=validated_data_source["data_source_type"],
+                )
+
+                DataSourceDetector.objects.create(
+                    data_source=detector_data_source, detector=detector
+                )
 
             create_audit_entry(
                 request=self.context["request"],

--- a/src/sentry/workflow_engine/endpoints/validators/base/detector.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/detector.py
@@ -17,7 +17,6 @@ from sentry.workflow_engine.endpoints.validators.base import (
 )
 from sentry.workflow_engine.endpoints.validators.utils import (
     get_unknown_detector_type_error,
-    remove_items_by_api_input,
     toggle_detector,
 )
 from sentry.workflow_engine.models import (
@@ -128,43 +127,25 @@ class BaseDetectorTypeValidator(CamelSnakeSerializer):
             if "data_sources" in validated_data:
                 validated_data_sources = validated_data.pop("data_sources", [])
 
-                # Remove any data sources that are not in the input data
-                remove_items_by_api_input(validated_data_sources, instance.datasource_set, "id")
+                # Remove all existing data sources
+                DataSource.objects.filter(detector=instance).delete()
 
-                # create or update the data source
+                # create new data sources
                 for validated_data_source in validated_data_sources:
-                    # TODO - batch the create an update operations
-                    # for now it's less important cause the should only be one data source.
-                    data_source_id = validated_data_source.get("id")
+                    # TODO - update to handle batches
+                    # TODO - handle updates rather than destroying / recreating -- this is a hack for now
 
-                    if data_source_id is None:
-                        # If the data doesn't include an id, it means this is a new data source.
-                        data_source_creator = validated_data_source.get("_creator")
-                        source = data_source_creator.create()
-                        data_source = DataSource.objects.create(
-                            organization_id=self.context["organization"].id,
-                            source_id=source.id,
-                            type=validated_data_source["data_source_type"],
-                        )
-                        DataSourceDetector.objects.create(
-                            data_source=data_source,
-                            detector=instance,
-                        )
-                    else:
-                        # TODO - figure out why the id isn't being passed into here
-                        data_source = DataSource.objects.get(id=data_source_id)
-
-                        # TODO - figure out a way to get the validator from self.data_sources
-                        import pdb
-
-                        pdb.set_trace()
-
-                        class validator:
-                            @staticmethod
-                            def update(data_source, validated_data_source):
-                                pass
-
-                        validator.update(data_source, validated_data_source)
+                    data_source_creator = validated_data_source.get("_creator")
+                    source = data_source_creator.create()
+                    data_source = DataSource.objects.create(
+                        organization_id=self.context["organization"].id,
+                        source_id=source.id,
+                        type=validated_data_source["data_source_type"],
+                    )
+                    DataSourceDetector.objects.create(
+                        data_source=data_source,
+                        detector=instance,
+                    )
 
             instance.save()
 

--- a/tests/sentry/incidents/endpoints/validators/test_validators.py
+++ b/tests/sentry/incidents/endpoints/validators/test_validators.py
@@ -130,15 +130,17 @@ class TestMetricAlertsDetectorValidator(BaseValidatorTest):
         self.valid_data = {
             "name": "Test Detector",
             "type": MetricIssue.slug,
-            "dataSource": {
-                "queryType": SnubaQuery.Type.ERROR.value,
-                "dataset": Dataset.Events.value,
-                "query": "test query",
-                "aggregate": "count()",
-                "timeWindow": 3600,
-                "environment": self.environment.name,
-                "eventTypes": [SnubaQueryEventType.EventType.ERROR.name.lower()],
-            },
+            "dataSources": [
+                {
+                    "queryType": SnubaQuery.Type.ERROR.value,
+                    "dataset": Dataset.Events.value,
+                    "query": "test query",
+                    "aggregate": "count()",
+                    "timeWindow": 3600,
+                    "environment": self.environment.name,
+                    "eventTypes": [SnubaQueryEventType.EventType.ERROR.name.lower()],
+                }
+            ],
             "conditionGroup": {
                 "id": self.data_condition_group.id,
                 "organizationId": self.organization.id,

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
@@ -153,15 +153,17 @@ class OrganizationDetectorDetailsPutTest(OrganizationDetectorDetailsBaseTest):
             "type": MetricIssue.slug,
             "dateCreated": self.detector.date_added,
             "dateUpdated": timezone.now(),
-            "dataSource": {
-                "queryType": self.snuba_query.type,
-                "dataset": self.snuba_query.dataset,
-                "query": "updated query",
-                "aggregate": self.snuba_query.aggregate,
-                "timeWindow": 300,
-                "environment": self.environment.name,
-                "eventTypes": [event_type.name for event_type in self.snuba_query.event_types],
-            },
+            "dataSources": [
+                {
+                    "queryType": self.snuba_query.type,
+                    "dataset": self.snuba_query.dataset,
+                    "query": "updated query",
+                    "aggregate": self.snuba_query.aggregate,
+                    "timeWindow": 300,
+                    "environment": self.environment.name,
+                    "eventTypes": [event_type.name for event_type in self.snuba_query.event_types],
+                }
+            ],
             "conditionGroup": {
                 "id": self.data_condition_group.id,
                 "organizationId": self.organization.id,

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
@@ -239,7 +239,10 @@ class OrganizationDetectorDetailsPutTest(OrganizationDetectorDetailsBaseTest):
         snuba_query = SnubaQuery.objects.get(id=query_subscription.snuba_query.id)
         self.assert_snuba_query_updated(snuba_query)
 
-    def test_update__new_data_source(self) -> None:
+    @mock.patch("sentry.incidents.metric_issue_detector.schedule_update_project_config")
+    def test_update__new_data_source(
+        self, mock_schedule_update_project_config: mock.MagicMock
+    ) -> None:
         with self.tasks():
             response = self.get_success_response(
                 self.organization.slug,

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
@@ -707,15 +707,17 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
             "name": "Test Detector",
             "type": MetricIssue.slug,
             "projectId": self.project.id,
-            "dataSource": {
-                "queryType": SnubaQuery.Type.ERROR.value,
-                "dataset": Dataset.Events.name.lower(),
-                "query": "test query",
-                "aggregate": "count()",
-                "timeWindow": 3600,
-                "environment": self.environment.name,
-                "eventTypes": [SnubaQueryEventType.EventType.ERROR.name.lower()],
-            },
+            "dataSources": [
+                {
+                    "queryType": SnubaQuery.Type.ERROR.value,
+                    "dataset": Dataset.Events.name.lower(),
+                    "query": "test query",
+                    "aggregate": "count()",
+                    "timeWindow": 3600,
+                    "environment": self.environment.name,
+                    "eventTypes": [SnubaQueryEventType.EventType.ERROR.name.lower()],
+                }
+            ],
             "conditionGroup": {
                 "id": self.data_condition_group.id,
                 "organizationId": self.organization.id,
@@ -943,7 +945,7 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
 
     def test_empty_query_string(self) -> None:
         data = {**self.valid_data}
-        data["dataSource"]["query"] = ""
+        data["dataSources"][0]["query"] = ""
 
         with self.tasks():
             response = self.get_success_response(

--- a/tests/sentry/workflow_engine/endpoints/test_validators.py
+++ b/tests/sentry/workflow_engine/endpoints/test_validators.py
@@ -101,7 +101,7 @@ class MockConditionGroupValidator(BaseDataConditionGroupValidator):
 
 
 class MockDetectorValidator(BaseDetectorTypeValidator):
-    data_source = MockDataSourceValidator()
+    data_sources = serializers.ListField(child=MockDataSourceValidator())
     condition_group = MockConditionGroupValidator()
 
 
@@ -165,10 +165,12 @@ class DetectorValidatorTest(BaseValidatorTest):
         self.valid_data = {
             "name": "Test Detector",
             "type": MetricIssue.slug,
-            "dataSource": {
-                "field1": "test",
-                "field2": 123,
-            },
+            "dataSources": [
+                {
+                    "field1": "test",
+                    "field2": 123,
+                }
+            ],
             "conditionGroup": {
                 "id": self.data_condition_group.id,
                 "organizationId": self.organization.id,


### PR DESCRIPTION
# Description
The API drifted on the DataSource property; POST requests only supported creating a single data source vs the GET request supporting many.