### PR TITLE
feat(agent-insights): Prioritize response model

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
@@ -66,7 +66,7 @@ function getAISpanAttributes(
 ) {
   const highlightedAttributes = [];
 
-  const model = attributes['gen_ai.request.model'] || attributes['gen_ai.response.model'];
+  const model = attributes['gen_ai.response.model'] || attributes['gen_ai.request.model'];
   if (model) {
     highlightedAttributes.push({
       name: t('Model'),

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
@@ -192,7 +192,7 @@ export function AIInputSection({
 
   const toolArgs = getTraceNodeAttribute('gen_ai.tool.input', node, event, attributes);
 
-  if (!messages && !toolArgs) {
+  if ((!messages || messages.length === 0) && !toolArgs) {
     return null;
   }
 


### PR DESCRIPTION
Prioritize displaying response model vs request model in span details.
Hide ai input section if the messages array is empty.

- closes [TET-1008: Update Spans summary to show response model first](https://linear.app/getsentry/issue/TET-1008/update-spans-summary-to-show-response-model-first)
