### PR TITLE
feat(tempest): Clarify onboarding 

### DIFF
--- a/static/app/views/settings/project/tempest/DevKitSettings.tsx
+++ b/static/app/views/settings/project/tempest/DevKitSettings.tsx
@@ -313,12 +313,10 @@ const CardIllustration = styled('img')`
 
 const IntroText = styled('p')`
   margin-bottom: ${space(2)};
-  font-size: ${p => p.theme.fontSizeMedium};
 `;
 
 const AccordionHeader = styled('span')`
   font-weight: ${p => p.theme.fontWeight.bold};
-  font-size: ${p => p.theme.fontSizeMedium};
 `;
 
 const AccordionContentWrapper = styled('div')`

--- a/static/app/views/settings/project/tempest/DevKitSettings.tsx
+++ b/static/app/views/settings/project/tempest/DevKitSettings.tsx
@@ -9,6 +9,7 @@ import windowToolImg from 'sentry-images/tempest/windows-tool-devkit.png';
 
 import {Button} from 'sentry/components/core/button';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
+import Accordion from 'sentry/components/container/accordion';
 import FeedbackWidgetButton from 'sentry/components/feedback/widget/feedbackWidgetButton';
 import {GuidedSteps} from 'sentry/components/guidedSteps/guidedSteps';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
@@ -23,6 +24,7 @@ import {decodeInteger} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useProjectKeys} from 'sentry/utils/useProjectKeys';
+import {useState} from 'react';
 
 import {RequestSdkAccessButton} from './RequestSdkAccessButton';
 
@@ -34,6 +36,7 @@ interface Props {
 export default function DevKitSettings({organization, project}: Props) {
   const navigate = useNavigate();
   const location = useLocation();
+  const [expandedAccordionIndex, setExpandedAccordionIndex] = useState<number>(-1);
 
   const {data: projectKeys, isPending: isLoadingKeys} = useProjectKeys({
     orgSlug: organization.slug,
@@ -93,65 +96,82 @@ export default function DevKitSettings({organization, project}: Props) {
 
                   <GuidedSteps.Step
                     stepKey="step-2"
-                    title={t('Using Windows tool to set up Upload URL')}
+                    title={t('Configure Upload URL')}
                   >
                     <DescriptionWrapper>
-                      <StepContentColumn>
-                        <StepTextSection>
-                          <p>
-                            {t(
-                              'Using Windows tool enter that link into the DevKit as the URL to the Recap Server.'
-                            )}
-                          </p>
-                        </StepTextSection>
-                        <StepImageSection>
-                          <CardIllustration
-                            src={windowToolImg}
-                            alt="Setup Configuration"
-                          />
-                        </StepImageSection>
-                      </StepContentColumn>
+                      <IntroText>
+                        {t(
+                          'There are two ways to configure the Upload URL on your DevKit. Choose one of the following methods:'
+                        )}
+                      </IntroText>
+                      
+                      <Accordion
+                        expandedIndex={expandedAccordionIndex}
+                        setExpandedIndex={setExpandedAccordionIndex}
+                        items={[
+                          {
+                            header: <AccordionHeader>{t('Using Windows tool to set up Upload URL')}</AccordionHeader>,
+                            content: (
+                              <AccordionContentWrapper>
+                                <StepContentColumn>
+                                  <StepTextSection>
+                                    <p>
+                                      {t(
+                                        'Using Windows tool enter that link into the DevKit as the URL to the Recap Server.'
+                                      )}
+                                    </p>
+                                  </StepTextSection>
+                                  <StepImageSection>
+                                    <CardIllustration
+                                      src={windowToolImg}
+                                      alt="Setup Configuration"
+                                    />
+                                  </StepImageSection>
+                                </StepContentColumn>
+                              </AccordionContentWrapper>
+                            ),
+                          },
+                          {
+                            header: <AccordionHeader>{t('Using DevKit Directly to set up Upload URL')}</AccordionHeader>,
+                            content: (
+                              <AccordionContentWrapper>
+                                <StepContentColumn>
+                                  <StepTextSection>
+                                    <p>
+                                      {t(
+                                        `If you haven't done it via Windows tool, you can set up the Upload URL directly in the DevKit. It is under 'Debug Settings' > 'Core Dump' > 'Upload' > 'Upload URL'.`
+                                      )}
+                                    </p>
+                                  </StepTextSection>
+                                  <StepImageSection>
+                                    <CardIllustration
+                                      src={devkitCrashesStep1}
+                                      alt="Setup Configuration"
+                                    />
+                                  </StepImageSection>
+                                  <StepImageSection>
+                                    <CardIllustration
+                                      src={devkitCrashesStep2}
+                                      alt="Setup Configuration"
+                                    />
+                                  </StepImageSection>
+                                  <StepImageSection>
+                                    <CardIllustration
+                                      src={devkitCrashesStep3}
+                                      alt="Setup Configuration"
+                                    />
+                                  </StepImageSection>
+                                </StepContentColumn>
+                              </AccordionContentWrapper>
+                            ),
+                          },
+                        ]}
+                      />
                     </DescriptionWrapper>
                     <GuidedSteps.StepButtons />
                   </GuidedSteps.Step>
 
-                  <GuidedSteps.Step
-                    stepKey="step-3"
-                    title={t('Using DevKit Directly to set up Upload URL')}
-                  >
-                    <DescriptionWrapper>
-                      <StepContentColumn>
-                        <StepTextSection>
-                          <p>
-                            {t(
-                              `If you haven't done it via Windows tool, you can set up the Upload URL directly in the DevKit. It is under 'Debug Settings' > 'Core Dump' > 'Upload' > 'Upload URL'.`
-                            )}
-                          </p>
-                        </StepTextSection>
-                        <StepImageSection>
-                          <CardIllustration
-                            src={devkitCrashesStep1}
-                            alt="Setup Configuration"
-                          />
-                        </StepImageSection>
-                        <StepImageSection>
-                          <CardIllustration
-                            src={devkitCrashesStep2}
-                            alt="Setup Configuration"
-                          />
-                        </StepImageSection>
-                        <StepImageSection>
-                          <CardIllustration
-                            src={devkitCrashesStep3}
-                            alt="Setup Configuration"
-                          />
-                        </StepImageSection>
-                      </StepContentColumn>
-                    </DescriptionWrapper>
-                    <GuidedSteps.StepButtons />
-                  </GuidedSteps.Step>
-
-                  <GuidedSteps.Step stepKey="step-4" title={t('Important Notes')}>
+                  <GuidedSteps.Step stepKey="step-3" title={t('Important Notes')}>
                     <DescriptionWrapper>
                       <p>
                         {t(
@@ -285,4 +305,18 @@ const CardIllustration = styled('img')`
   border: 1px solid ${p => p.theme.border};
   border-radius: ${p => p.theme.borderRadius};
   box-shadow: ${p => p.theme.dropShadowLight};
+`;
+
+const IntroText = styled('p')`
+  margin-bottom: ${space(2)};
+  font-size: ${p => p.theme.fontSizeMedium};
+`;
+
+const AccordionHeader = styled('span')`
+  font-weight: ${p => p.theme.fontWeight.bold};
+  font-size: ${p => p.theme.fontSizeMedium};
+`;
+
+const AccordionContentWrapper = styled('div')`
+  padding: ${space(2)};
 `;

--- a/static/app/views/settings/project/tempest/DevKitSettings.tsx
+++ b/static/app/views/settings/project/tempest/DevKitSettings.tsx
@@ -1,4 +1,4 @@
-import {Fragment} from 'react';
+import {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 
 import waitingForEventImg from 'sentry-images/spot/waiting-for-event.svg';
@@ -7,9 +7,9 @@ import devkitCrashesStep2 from 'sentry-images/tempest/devkit-crashes-step2.png';
 import devkitCrashesStep3 from 'sentry-images/tempest/devkit-crashes-step3.png';
 import windowToolImg from 'sentry-images/tempest/windows-tool-devkit.png';
 
+import Accordion from 'sentry/components/container/accordion';
 import {Button} from 'sentry/components/core/button';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
-import Accordion from 'sentry/components/container/accordion';
 import FeedbackWidgetButton from 'sentry/components/feedback/widget/feedbackWidgetButton';
 import {GuidedSteps} from 'sentry/components/guidedSteps/guidedSteps';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
@@ -24,7 +24,6 @@ import {decodeInteger} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useProjectKeys} from 'sentry/utils/useProjectKeys';
-import {useState} from 'react';
 
 import {RequestSdkAccessButton} from './RequestSdkAccessButton';
 
@@ -94,23 +93,24 @@ export default function DevKitSettings({organization, project}: Props) {
                     <GuidedSteps.StepButtons />
                   </GuidedSteps.Step>
 
-                  <GuidedSteps.Step
-                    stepKey="step-2"
-                    title={t('Configure Upload URL')}
-                  >
+                  <GuidedSteps.Step stepKey="step-2" title={t('Configure Upload URL')}>
                     <DescriptionWrapper>
                       <IntroText>
                         {t(
                           'There are two ways to configure the Upload URL on your DevKit. Choose one of the following methods:'
                         )}
                       </IntroText>
-                      
+
                       <Accordion
                         expandedIndex={expandedAccordionIndex}
                         setExpandedIndex={setExpandedAccordionIndex}
                         items={[
                           {
-                            header: <AccordionHeader>{t('Using Windows tool to set up Upload URL')}</AccordionHeader>,
+                            header: (
+                              <AccordionHeader>
+                                {t('Using Windows tool to set up Upload URL')}
+                              </AccordionHeader>
+                            ),
                             content: (
                               <AccordionContentWrapper>
                                 <StepContentColumn>
@@ -132,7 +132,11 @@ export default function DevKitSettings({organization, project}: Props) {
                             ),
                           },
                           {
-                            header: <AccordionHeader>{t('Using DevKit Directly to set up Upload URL')}</AccordionHeader>,
+                            header: (
+                              <AccordionHeader>
+                                {t('Using DevKit Directly to set up Upload URL')}
+                              </AccordionHeader>
+                            ),
                             content: (
                               <AccordionContentWrapper>
                                 <StepContentColumn>

--- a/static/app/views/settings/project/tempest/EmptyState.tsx
+++ b/static/app/views/settings/project/tempest/EmptyState.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 
 import waitingForEventImg from 'sentry-images/spot/waiting-for-event.svg';
 
+import {Alert} from 'sentry/components/core/alert';
 import {Button} from 'sentry/components/core/button';
 import {GuidedSteps} from 'sentry/components/guidedSteps/guidedSteps';
 import {OnboardingCodeSnippet} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCodeSnippet';
@@ -32,6 +33,13 @@ export default function EmptyState() {
       <Body>
         <Setup>
           <BodyTitle>{t('Install instructions')}</BodyTitle>
+          <Alert.Container>
+            <Alert type="info">
+              {t(
+                "Note: You need PlayStation access to complete these instructions. Sentry admin access alone isn't sufficient."
+              )}
+            </Alert>
+          </Alert.Container>
           <GuidedSteps
             initialStep={decodeInteger(location.query.guidedStep)}
             onStepChange={step => {

--- a/static/app/views/settings/project/tempest/index.tsx
+++ b/static/app/views/settings/project/tempest/index.tsx
@@ -52,12 +52,15 @@ export default function TempestSettings({organization, project}: Props) {
   const tab = getCurrentTab();
 
   const handleTabChange = (newTab: Tab) => {
+    const newQuery: any = {
+      ...location.query,
+      tab: newTab,
+    };
+    // Reset guided step when switching tabs to avoid cross-tab bleed
+    delete newQuery.guidedStep;
     navigate({
       pathname: location.pathname,
-      query: {
-        ...location.query,
-        tab: newTab,
-      },
+      query: newQuery,
     });
   };
 


### PR DESCRIPTION
This PR:
- refactors the DevKit settings onboarding flow to clarify that steps 2 and 3 are alternative methods, not sequential steps. This is now done using accordion component
- adds a note that user needs playstation access to, Sentry admin is not enough
- fixes a bug when `guidedStep` was part of URL after the tab was switched, which would then shown wrong onboarding step. Now that parameter is removed from URL on tab swtich