### PR TITLE
fix: check for URIError instead of URI malformed error message

### DIFF
--- a/static/app/bootstrap/renderMain.tsx
+++ b/static/app/bootstrap/renderMain.tsx
@@ -7,7 +7,7 @@ export function renderMain() {
   try {
     renderDom(Main, `#${ROOT_ELEMENT}`, {});
   } catch (err) {
-    if (err.message === 'URI malformed') {
+    if (err instanceof URIError) {
       // eslint-disable-next-line no-console
       console.error(
         new Error(


### PR DESCRIPTION
Checking for `err.message === 'URI malformed'` is brittle because:

1. Messages can differ per browser, [according to MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Malformed_URI):

```
URIError: URI malformed (V8-based)
URIError: malformed URI sequence (Firefox)
URIError: String contained an illegal UTF-16 sequence. (Safari)
```

2. The current code only compiles because `err` is implicitly `any`; When switching to `unknown`, it will error because `message` might not exist.

---

Switching to an `err instanceof URIError` check should fix both problems.

/edit: apparently, this has been fixed in ReactRouter v5, so we shouldn’t even hit this path:

- https://github.com/remix-run/history/pull/656