### PR TITLE
feat(flutter): deobfuscate exception value occurrences of `Instance of 'xyz'`

### DIFF
--- a/src/sentry/lang/dart/utils.py
+++ b/src/sentry/lang/dart/utils.py
@@ -90,16 +90,14 @@ def deobfuscate_exception_type(data: MutableMapping[str, Any]):
 
         for exception in exceptions:
             exception_type = exception.get("type")
-            if exception_type is None:
-                continue
-
-            deobfuscated_type = symbol_map.get(exception_type)
-            if deobfuscated_type is not None:
-                exception["type"] = deobfuscated_type
+            if isinstance(exception_type, str):
+                mapped_type = symbol_map.get(exception_type)
+                if mapped_type is not None:
+                    exception["type"] = mapped_type
 
             # Deobfuscate occurrences of "Instance of 'xYz'" in the exception value
-            value = exception.get("value")
-            if isinstance(value, str):
+            exception_value = exception.get("value")
+            if isinstance(exception_value, str):
 
                 def replace_symbol(match: re.Match[str]) -> str:
                     symbol = match.group(1)
@@ -108,8 +106,8 @@ def deobfuscate_exception_type(data: MutableMapping[str, Any]):
                         return match.group(0)
                     return f"Instance of '{deobfuscated_symbol}'"
 
-                new_value = re.sub(INSTANCE_OF_VALUE_RE, replace_symbol, value)
-                if new_value != value:
+                new_value = re.sub(INSTANCE_OF_VALUE_RE, replace_symbol, exception_value)
+                if new_value != exception_value:
                     exception["value"] = new_value
 
 

--- a/tests/sentry/lang/dart/test_plugin_deobfuscation.py
+++ b/tests/sentry/lang/dart/test_plugin_deobfuscation.py
@@ -92,8 +92,7 @@ class DartPluginDeobfuscationTest(TestCase):
         # Verify the exception type and value were deobfuscated
         assert data["exception"]["values"][0]["type"] == "NetworkException"
         assert (
-            data["exception"]["values"][0]["value"]
-            == "Instance of 'NetworkException' was thrown"
+            data["exception"]["values"][0]["value"] == "Instance of 'NetworkException' was thrown"
         )
 
     def test_dart_multiple_exceptions_deobfuscation_direct(self) -> None:

--- a/tests/sentry/lang/dart/test_plugin_deobfuscation.py
+++ b/tests/sentry/lang/dart/test_plugin_deobfuscation.py
@@ -89,9 +89,12 @@ class DartPluginDeobfuscationTest(TestCase):
         preprocessor = preprocessors[0]
         preprocessor(data)
 
-        # Verify the exception type was deobfuscated, value remains unchanged
+        # Verify the exception type and value were deobfuscated
         assert data["exception"]["values"][0]["type"] == "NetworkException"
-        assert data["exception"]["values"][0]["value"] == "Instance of 'xyz' was thrown"
+        assert (
+            data["exception"]["values"][0]["value"]
+            == "Instance of 'NetworkException' was thrown"
+        )
 
     def test_dart_multiple_exceptions_deobfuscation_direct(self) -> None:
         """Test that multiple Dart exceptions are deobfuscated."""

--- a/tests/sentry/lang/dart/test_utils.py
+++ b/tests/sentry/lang/dart/test_utils.py
@@ -412,28 +412,29 @@ def test_deobfuscate_exception_type_instance_of_pattern() -> None:
     ):
         deobfuscate_exception_type(data)
 
-        # Only exception types should be deobfuscated, values remain unchanged
+        # Exception types should be deobfuscated
         assert data["exception"]["values"][0]["type"] == "NetworkException"
-        assert data["exception"]["values"][0]["value"] == "Instance of 'xyz'"
+        # Value starts with pattern: quoted symbol should be deobfuscated
+        assert data["exception"]["values"][0]["value"] == "Instance of 'NetworkException'"
 
         assert data["exception"]["values"][1]["type"] == "DatabaseException"
+        # Pattern can appear anywhere: deobfuscate occurrences
         assert (
             data["exception"]["values"][1]["value"]
-            == "Unhandled Exception: Instance of 'abc' was thrown"
+            == "Unhandled Exception: Instance of 'DatabaseException' was thrown"
         )
 
         assert data["exception"]["values"][2]["type"] == "FileException"
-        # No 'Instance of' pattern, so value should remain unchanged
+        # No pattern, value should remain unchanged
         assert (
             data["exception"]["values"][2]["value"]
             == "Error: def occurred outside of Instance pattern"
         )
 
         assert data["exception"]["values"][3]["type"] == "IOException"
-        # Values remain unchanged
         assert (
             data["exception"]["values"][3]["value"]
-            == "Instance of 'xyz' and Instance of 'ghi' both occurred"
+            == "Instance of 'NetworkException' and Instance of 'IOException' both occurred"
         )
 
 
@@ -480,18 +481,17 @@ def test_deobfuscate_exception_type_special_regex_chars() -> None:
     ):
         deobfuscate_exception_type(data)
 
-        # Exception types deobfuscated, values remain unchanged
+        # Exception types deobfuscated; values with the pattern are updated
         assert data["exception"]["values"][0]["type"] == "NetworkException"
-        assert data["exception"]["values"][0]["value"] == "Instance of 'a.b'"
+        assert data["exception"]["values"][0]["value"] == "Instance of 'NetworkException'"
 
         assert data["exception"]["values"][1]["type"] == "MathException"
-        assert data["exception"]["values"][1]["value"] == "Instance of 'x+y' occurred"
+        assert data["exception"]["values"][1]["value"] == "Instance of 'MathException' occurred"
 
         assert data["exception"]["values"][2]["type"] == "ArrayException"
-        # Values remain unchanged
         assert (
             data["exception"]["values"][2]["value"]
-            == "Instance of 'test[0]' and Instance of 'other' patterns"
+            == "Instance of 'ArrayException' and Instance of 'other' patterns"
         )
 
 


### PR DESCRIPTION
Currently for dart/flutter we get the symbol map and map the obfuscated exception type to the de-obfuscated one.

Additionally `Instance of 'xyz'` where xyz is obfuscated also occurs very often in the exception value.

This PR adds support for de-obfuscating these occurrences within the exception value as well.