### PR TITLE
Measure compression, and precise sizes for manually emitted usecases

### DIFF
--- a/src/sentry/models/debugfile.py
+++ b/src/sentry/models/debugfile.py
@@ -323,6 +323,7 @@ def create_dif_from_id(
         file.size,
         tags={"usecase": "debug-files", "compression": "none"},
         unit="byte",
+        precise=True,
     )
 
     dif = ProjectDebugFile.objects.create(

--- a/src/sentry/models/eventattachment.py
+++ b/src/sentry/models/eventattachment.py
@@ -181,11 +181,9 @@ class EventAttachment(Model):
             blob_path = "eventattachments/v1/" + FileBlob.generate_unique_path()
 
             storage = get_storage()
-            compressed_blob = zstandard.compress(data)
-
-            with measure_storage_operation(
-                "put", "attachments", size, len(compressed_blob), "zstd"
-            ):
+            with measure_storage_operation("put", "attachments", size) as metric_emitter:
+                compressed_blob = zstandard.compress(data)
+                metric_emitter.record_compressed_size(len(compressed_blob), "zstd")
                 storage.save(blob_path, BytesIO(compressed_blob))
 
         else:

--- a/src/sentry/tasks/assemble.py
+++ b/src/sentry/tasks/assemble.py
@@ -522,6 +522,7 @@ class ArtifactBundlePostAssembler:
                 file.size,
                 tags={"usecase": "artifact-bundles", "compression": "none"},
                 unit="byte",
+                precise=True,
             )
 
             artifact_bundle = ArtifactBundle.objects.create(

--- a/src/sentry/utils/kvstore/bigtable.py
+++ b/src/sentry/utils/kvstore/bigtable.py
@@ -246,6 +246,7 @@ class BigtableKVStorage(KVStorage[str, bytes]):
                 len(value),
                 tags={"usecase": "nodestore", "compression": self.compression},
                 unit="byte",
+                precise=True,
             )
 
         # Only need to write the column at all if any flags are enabled. And if


### PR DESCRIPTION
This moves the compression step into the measured block, so we measure the storage operation end to end including compression.

Also, this will now opt into precise metrics for the places where we manually emit file sizes, like compressed nodestore, debug files and bundles.