### PR TITLE
Organization removal analytics

### DIFF
--- a/src/sentry/analytics/events/__init__.py
+++ b/src/sentry/analytics/events/__init__.py
@@ -67,6 +67,7 @@ from .org_auth_token_created import *  # noqa: F401,F403
 from .org_auth_token_deleted import *  # noqa: F401,F403
 from .organization_created import *  # noqa: F401,F403
 from .organization_joined import *  # noqa: F401,F403
+from .organization_removed import *  # noqa: F401,F403
 from .plugin_enabled import *  # noqa: F401,F403
 from .project_created import *  # noqa: F401,F403
 from .project_issue_searched import *  # noqa: F401,F403

--- a/src/sentry/analytics/events/organization_removed.py
+++ b/src/sentry/analytics/events/organization_removed.py
@@ -1,0 +1,14 @@
+from sentry import analytics
+from sentry.analytics import Event, eventclass
+
+
+@eventclass("organization.removed")
+class OrganizationRemoved(Event):
+    organization_id: int
+    slug: str
+    user_id: int | None = None
+    deletion_request_datetime: str | None = None
+    deletion_datetime: str | None = None
+
+
+analytics.register(OrganizationRemoved)


### PR DESCRIPTION
Redo of #97378 after endpoints moved to core, easier to start fresh. 

When performing an org removal, we write the removal event to the organization audit log. That's great if the organization is restored, but after org removal is completed we purge the organization's audit log. Finding the time of deletion and organization slugs when they're gone from the database is more difficult than necessary and this occasionally appears in customer support requests.

We have existing organization_created and organization_joined events in analytics, so I'm adding an organization_removed to the mix.