### PR TITLE
feat: adjust search functionality to prevent jumpiness

### DIFF
--- a/static/app/components/prevent/branchSelector/branchSelector.tsx
+++ b/static/app/components/prevent/branchSelector/branchSelector.tsx
@@ -49,9 +49,6 @@ export function BranchSelector() {
   );
 
   const options = useMemo((): Array<SelectOption<string>> => {
-    if (isFetching) {
-      return [];
-    }
     const optionSet = new Set<string>([
       ALL_BRANCHES,
       ...(branch ? [branch] : []),
@@ -67,7 +64,7 @@ export function BranchSelector() {
     };
 
     return [...optionSet].map(makeOption);
-  }, [branch, isFetching, displayedBranches]);
+  }, [branch, displayedBranches]);
 
   useEffect(() => {
     // Only update displayedBranches if the hook returned something non-empty
@@ -85,6 +82,10 @@ export function BranchSelector() {
 
   const branchResetButton = useCallback(
     ({closeOverlay}: any) => {
+      if (!defaultBranch || !branch || branch === defaultBranch) {
+        return null;
+      }
+
       return (
         <ResetButton
           onClick={() => {
@@ -103,15 +104,22 @@ export function BranchSelector() {
         </ResetButton>
       );
     },
-    [integratedOrgId, preventPeriod, repository, changeContextValue, defaultBranch]
+    [
+      branch,
+      integratedOrgId,
+      preventPeriod,
+      repository,
+      changeContextValue,
+      defaultBranch,
+    ]
   );
 
   function getEmptyMessage() {
-    if (branches.length) {
+    if (displayedBranches.length) {
       return '';
     }
 
-    if (searchValue && !branches.length) {
+    if (searchValue && !displayedBranches.length) {
       return t('Sorry, no branches match your search query');
     }
 

--- a/static/app/components/prevent/branchSelector/branchSelector.tsx
+++ b/static/app/components/prevent/branchSelector/branchSelector.tsx
@@ -69,7 +69,7 @@ export function BranchSelector() {
   useEffect(() => {
     // Only update displayedBranches if the hook returned something non-empty
     if (!isFetching) {
-      setDisplayedBranches(branches.map(item => item.name));
+      setDisplayedBranches((branches ?? []).map(item => item.name));
     }
   }, [branches, isFetching]);
 
@@ -115,16 +115,12 @@ export function BranchSelector() {
   );
 
   function getEmptyMessage() {
-    if (displayedBranches.length) {
-      return '';
+    if (isFetching) {
+      return t('Getting branches...');
     }
 
     if (searchValue && !displayedBranches.length) {
       return t('Sorry, no branches match your search query');
-    }
-
-    if (isFetching) {
-      return t('Getting branches...');
     }
 
     return t('No branches found');

--- a/static/app/components/prevent/branchSelector/branchSelector.tsx
+++ b/static/app/components/prevent/branchSelector/branchSelector.tsx
@@ -19,8 +19,12 @@ export const ALL_BRANCHES = 'All Branches';
 export function BranchSelector() {
   const {branch, integratedOrgId, repository, preventPeriod, changeContextValue} =
     usePreventContext();
+  const [displayedBranches, setDisplayedBranches] = useState<string[]>([]);
   const [searchValue, setSearchValue] = useState<string | undefined>();
-  const {data} = useInfiniteRepositoryBranches({term: searchValue});
+
+  const {data, isFetching, isLoading} = useInfiniteRepositoryBranches({
+    term: searchValue,
+  });
   const branches = data.branches;
   const defaultBranch = data.defaultBranch;
 
@@ -40,15 +44,18 @@ export function BranchSelector() {
     () =>
       debounce((value: string) => {
         setSearchValue(value);
-      }, 500),
+      }, 300),
     [setSearchValue]
   );
 
   const options = useMemo((): Array<SelectOption<string>> => {
+    if (isFetching) {
+      return [];
+    }
     const optionSet = new Set<string>([
-      ...[ALL_BRANCHES],
+      ALL_BRANCHES,
       ...(branch ? [branch] : []),
-      ...(branches.length > 0 ? branches.map(item => item.name) : []),
+      ...displayedBranches,
     ]);
 
     const makeOption = (value: string): SelectOption<string> => {
@@ -60,7 +67,14 @@ export function BranchSelector() {
     };
 
     return [...optionSet].map(makeOption);
-  }, [branch, branches]);
+  }, [branch, isFetching, displayedBranches]);
+
+  useEffect(() => {
+    // Only update displayedBranches if the hook returned something non-empty
+    if (!isFetching) {
+      setDisplayedBranches(branches.map(item => item.name));
+    }
+  }, [branches, isFetching]);
 
   useEffect(() => {
     // Create a use effect to cancel handleOnSearch fn on unmount to avoid memory leaks
@@ -71,14 +85,15 @@ export function BranchSelector() {
 
   const branchResetButton = useCallback(
     ({closeOverlay}: any) => {
-      if (!defaultBranch || !branch || branch === defaultBranch) {
-        return null;
-      }
-
       return (
         <ResetButton
           onClick={() => {
-            changeContextValue({branch: defaultBranch});
+            changeContextValue({
+              integratedOrgId,
+              repository,
+              preventPeriod,
+              branch: defaultBranch,
+            });
             closeOverlay();
           }}
           size="zero"
@@ -88,22 +103,41 @@ export function BranchSelector() {
         </ResetButton>
       );
     },
-    [branch, changeContextValue, defaultBranch]
+    [integratedOrgId, preventPeriod, repository, changeContextValue, defaultBranch]
   );
+
+  function getEmptyMessage() {
+    if (branches.length) {
+      return '';
+    }
+
+    if (searchValue && !branches.length) {
+      return t('Sorry, no branches match your search query');
+    }
+
+    if (isFetching) {
+      return t('Getting branches...');
+    }
+
+    return t('No branches found');
+  }
 
   const disabled = !repository;
 
   return (
     <CompactSelect
+      loading={isLoading}
       searchable
       onSearch={handleOnSearch}
+      disableSearchFilter
       searchPlaceholder={t('search by branch name')}
       options={options}
       value={branch ?? ''}
       onChange={handleChange}
+      onOpenChange={_ => setSearchValue(undefined)}
       menuHeaderTrailingItems={branchResetButton}
       disabled={disabled}
-      emptyMessage={'No branches found'}
+      emptyMessage={getEmptyMessage()}
       closeOnSelect
       trigger={(triggerProps, isOpen) => {
         return (

--- a/static/app/components/prevent/integratedOrgSelector/utils.tsx
+++ b/static/app/components/prevent/integratedOrgSelector/utils.tsx
@@ -5,5 +5,5 @@ export const integratedOrgIdToName = (id?: string, integrations?: Integration[])
     return 'No Integration';
   }
   const result = integrations.find(item => item.id === id);
-  return result ? result.name : 'Unknown Integration';
+  return result ? result.name : 'Select Integration';
 };

--- a/static/app/components/prevent/repoSelector/repoSelector.tsx
+++ b/static/app/components/prevent/repoSelector/repoSelector.tsx
@@ -102,11 +102,11 @@ export function RepoSelector() {
   }, [displayedRepos, repository]);
 
   function getEmptyMessage() {
-    if (displayedRepos.length) {
-      return '';
+    if (isFetching) {
+      return t('Getting repositories...');
     }
 
-    if (searchValue && !displayedRepos.length && !isFetching) {
+    if (searchValue && !repositories?.length) {
       return t('No repositories found. Please enter at least 3 characters to search.');
     }
 
@@ -114,9 +114,9 @@ export function RepoSelector() {
   }
 
   useEffect(() => {
-    // Only update displayedBranches if the hook returned something non-empty
+    // Only update displayedRepos if the hook returned something non-empty
     if (!isFetching) {
-      setDisplayedRepos(repositories.map(item => item.name));
+      setDisplayedRepos((repositories ?? []).map(item => item.name));
     }
   }, [isFetching, repositories]);
 

--- a/static/app/components/prevent/repoSelector/repoSelector.tsx
+++ b/static/app/components/prevent/repoSelector/repoSelector.tsx
@@ -88,10 +88,6 @@ export function RepoSelector() {
   );
 
   const options = useMemo((): Array<SelectOption<string>> => {
-    if (isFetching) {
-      return [];
-    }
-
     const repoSet = new Set([...(repository ? [repository] : []), ...displayedRepos]);
 
     return [...repoSet].map((value): SelectOption<string> => {
@@ -103,14 +99,14 @@ export function RepoSelector() {
         textValue: value,
       };
     });
-  }, [displayedRepos, isFetching, repository]);
+  }, [displayedRepos, repository]);
 
   function getEmptyMessage() {
-    if (repositories.length) {
+    if (displayedRepos.length) {
       return '';
     }
 
-    if (searchValue && !repositories.length) {
+    if (searchValue && !displayedRepos.length && !isFetching) {
       return t('No repositories found. Please enter at least 3 characters to search.');
     }
 

--- a/static/app/components/prevent/repoSelector/repoSelector.tsx
+++ b/static/app/components/prevent/repoSelector/repoSelector.tsx
@@ -57,8 +57,14 @@ function MenuFooter({repoAccessLink}: MenuFooterProps) {
 export function RepoSelector() {
   const {repository, integratedOrgId, preventPeriod, changeContextValue} =
     usePreventContext();
+  const [displayedRepos, setDisplayedRepos] = useState<string[]>([]);
+
   const [searchValue, setSearchValue] = useState<string | undefined>();
-  const {data: repositories} = useInfiniteRepositories({term: searchValue});
+  const {
+    data: repositories,
+    isFetching,
+    isLoading,
+  } = useInfiniteRepositories({term: searchValue});
 
   const disabled = !integratedOrgId;
 
@@ -77,16 +83,16 @@ export function RepoSelector() {
     () =>
       debounce((value: string) => {
         setSearchValue(value);
-      }, 500),
+      }, 300),
     [setSearchValue]
   );
 
   const options = useMemo((): Array<SelectOption<string>> => {
-    // TODO: When API is ready, replace placeholder w/ api response
-    const repoSet = new Set([
-      ...(repository ? [repository] : []),
-      ...(repositories.length > 0 ? repositories.map(item => item.name) : []),
-    ]);
+    if (isFetching) {
+      return [];
+    }
+
+    const repoSet = new Set([...(repository ? [repository] : []), ...displayedRepos]);
 
     return [...repoSet].map((value): SelectOption<string> => {
       return {
@@ -97,7 +103,26 @@ export function RepoSelector() {
         textValue: value,
       };
     });
-  }, [repository, repositories]);
+  }, [displayedRepos, isFetching, repository]);
+
+  function getEmptyMessage() {
+    if (repositories.length) {
+      return '';
+    }
+
+    if (searchValue && !repositories.length) {
+      return t('No repositories found. Please enter at least 3 characters to search.');
+    }
+
+    return t('No repositories found');
+  }
+
+  useEffect(() => {
+    // Only update displayedBranches if the hook returned something non-empty
+    if (!isFetching) {
+      setDisplayedRepos(repositories.map(item => item.name));
+    }
+  }, [isFetching, repositories]);
 
   useEffect(() => {
     // Create a use effect to cancel handleOnSearch fn on unmount to avoid memory leaks
@@ -108,19 +133,20 @@ export function RepoSelector() {
 
   return (
     <CompactSelect
+      loading={isLoading}
       onSearch={handleOnSearch}
       searchable
+      disableSearchFilter
       searchPlaceholder={t('search by repository name')}
       options={options}
       value={repository ?? ''}
       onChange={handleChange}
+      onOpenChange={_ => setSearchValue(undefined)}
       menuWidth={'16rem'}
       menuBody={<SyncRepoButton />}
       menuFooter={<MenuFooter repoAccessLink="placeholder" />}
       disabled={disabled}
-      emptyMessage={
-        'No repositories found. Please enter at least 3 characters to search.'
-      }
+      emptyMessage={getEmptyMessage()}
       trigger={(triggerProps, isOpen) => {
         const defaultLabel = options.some(item => item.value === repository)
           ? repository

--- a/static/app/components/prevent/testSuiteDropdown/testSuiteDropdown.tsx
+++ b/static/app/components/prevent/testSuiteDropdown/testSuiteDropdown.tsx
@@ -64,6 +64,14 @@ export function TestSuiteDropdown() {
     [setDropdownSearch]
   );
 
+  function getEmptyMessage() {
+    if (testSuites.length) {
+      return '';
+    }
+
+    return t('No test suites found');
+  }
+
   useEffect(() => {
     // Create a use effect to cancel handleOnSearch fn on unmount to avoid memory leaks
     return () => {
@@ -89,7 +97,7 @@ export function TestSuiteDropdown() {
       defaultValue={[]}
       onChange={handleChange}
       onSearch={handleOnSearch}
-      // TODO: Add the disabled and emptyMessage when connected to backend hook
+      emptyMessage={getEmptyMessage()}
       menuTitle={t('Filter Test Suites')}
       menuWidth={`${MAX_SUITE_UI_LENGTH}em`}
       trigger={triggerProps => {


### PR DESCRIPTION
This PR adds logic to help w/ flickering/jumpiness behavior for prevent selectors when searching for a value.

Main issue was a double search, one from the CompactSelect's internal search and the custom onSearch. By adding `disableSearchFilter`, you get rid of the internal search, avoiding doing double search that ends up in flickering.

# Notes
- Adjust BranchSelector and RepositorySelector to account for flickering changes + other minor QOL changes
- Add emptymessage to those + test suite component