### PR TITLE
fix(ourlogs): Analytic events renames and fixes

### DIFF
--- a/static/app/components/events/ourlogs/ourlogsSection.tsx
+++ b/static/app/components/events/ourlogs/ourlogsSection.tsx
@@ -71,37 +71,41 @@ function OurlogsSectionContent({
   const sharedHoverTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   const limitToTraceId = event.contexts?.trace?.trace_id;
-  const onOpenLogsDrawer = useCallback(() => {
-    trackAnalytics('logs.issue_details.drawer_opened', {
-      organization,
-    });
-    openDrawer(
-      () => (
-        <LogsQueryParamsProvider source="state">
-          <LogsPageParamsProvider
-            analyticsPageSource={LogsAnalyticsPageSource.ISSUE_DETAILS}
-            isTableFrozen
-            limitToTraceId={limitToTraceId}
-          >
-            <LogsPageDataProvider>
-              <TraceItemAttributeProvider traceItemType={TraceItemDataset.LOGS} enabled>
-                <OurlogsDrawer group={group} event={event} project={project} />
-              </TraceItemAttributeProvider>
-            </LogsPageDataProvider>
-          </LogsPageParamsProvider>
-        </LogsQueryParamsProvider>
-      ),
-      {
-        ariaLabel: 'logs drawer',
-        drawerKey: 'logs-issue-drawer',
+  const onOpenLogsDrawer = useCallback(
+    (e: React.MouseEvent<HTMLDivElement | HTMLButtonElement>) => {
+      e.stopPropagation();
+      trackAnalytics('logs.issue_details.drawer_opened', {
+        organization,
+      });
+      openDrawer(
+        () => (
+          <LogsQueryParamsProvider source="state">
+            <LogsPageParamsProvider
+              analyticsPageSource={LogsAnalyticsPageSource.ISSUE_DETAILS}
+              isTableFrozen
+              limitToTraceId={limitToTraceId}
+            >
+              <LogsPageDataProvider>
+                <TraceItemAttributeProvider traceItemType={TraceItemDataset.LOGS} enabled>
+                  <OurlogsDrawer group={group} event={event} project={project} />
+                </TraceItemAttributeProvider>
+              </LogsPageDataProvider>
+            </LogsPageParamsProvider>
+          </LogsQueryParamsProvider>
+        ),
+        {
+          ariaLabel: 'logs drawer',
+          drawerKey: 'logs-issue-drawer',
 
-        shouldCloseOnInteractOutside: element => {
-          const viewAllButton = viewAllButtonRef.current;
-          return !viewAllButton?.contains(element);
-        },
-      }
-    );
-  }, [group, event, project, openDrawer, organization, limitToTraceId]);
+          shouldCloseOnInteractOutside: element => {
+            const viewAllButton = viewAllButtonRef.current;
+            return !viewAllButton?.contains(element);
+          },
+        }
+      );
+    },
+    [group, event, project, openDrawer, organization, limitToTraceId]
+  );
   if (!feature) {
     return null;
   }
@@ -121,7 +125,7 @@ function OurlogsSectionContent({
       title={t('Logs')}
       data-test-id="logs-data-section"
     >
-      <SmallTableContentWrapper onClick={() => onOpenLogsDrawer()}>
+      <SmallTableContentWrapper onClick={onOpenLogsDrawer}>
         <SmallTable>
           <TableBody>
             {abbreviatedTableData?.map((row, index) => (
@@ -143,7 +147,7 @@ function OurlogsSectionContent({
               icon={<IconChevron direction="right" />}
               aria-label={t('View more')}
               size="sm"
-              onClick={() => onOpenLogsDrawer()}
+              onClick={onOpenLogsDrawer}
               ref={viewAllButtonRef}
             >
               {t('View more')}

--- a/static/app/utils/analytics/logsAnalyticsEvent.tsx
+++ b/static/app/utils/analytics/logsAnalyticsEvent.tsx
@@ -36,31 +36,40 @@ export type LogsAnalyticsEventParameters = {
   'logs.issue_details.drawer_opened': {
     organization: Organization;
   };
+  'logs.onboarding': {
+    organization: Organization;
+    platform: PlatformKey | 'unknown';
+    supports_onboarding_checklist: boolean;
+  };
+  'logs.onboarding_platform_docs_viewed': {
+    organization: Organization;
+    platform: PlatformKey | 'unknown';
+  };
+
   'logs.save_as': {
     save_type: 'alert' | 'dashboard' | 'update_query';
     ui_source: 'toolbar' | 'chart' | 'compare chart' | 'searchbar';
   };
+
   'logs.save_query_modal': {
     action: 'open' | 'submit';
     save_type: 'save_new_query' | 'rename_query';
     ui_source: 'toolbar' | 'table';
   };
+
   'logs.table.row_expanded': {
     log_id: string;
     page_source: LogsAnalyticsPageSource;
   };
-
   'logs.tracing_onboarding': {
     organization: Organization;
     platform: PlatformKey | 'unknown';
     supports_onboarding_checklist: boolean;
   };
-
   'logs.tracing_onboarding_performance_docs_viewed': {
     organization: Organization;
     platform: PlatformKey | 'unknown';
   };
-
   'logs.tracing_onboarding_platform_docs_viewed': {
     organization: Organization;
     platform: PlatformKey | 'unknown';
@@ -74,6 +83,7 @@ export const logsAnalyticsEventMap: Record<LogsAnalyticsEventKey, string | null>
   'logs.auto_refresh.toggled': 'Log Auto-refresh Toggled',
   'logs.doc_link.clicked': 'Logs documentation link clicked',
   'logs.explorer.metadata': 'Log Explorer Pageload Metadata',
+  'logs.onboarding': 'Logs Explore Empty State (Onboarding)',
   'logs.issue_details.drawer_opened': 'Issues Page Logs Drawer Opened',
   'logs.table.row_expanded': 'Expanded Log Row Details',
   'logs.tracing_onboarding': 'Logs Tracing Onboarding',
@@ -83,4 +93,6 @@ export const logsAnalyticsEventMap: Record<LogsAnalyticsEventKey, string | null>
     'Logs Tracing Onboarding Platform Docs Viewed',
   'logs.save_as': 'Logs Save As',
   'logs.save_query_modal': 'Logs Save Query Modal',
+  'logs.onboarding_platform_docs_viewed':
+    'Logs Explore Empty State (Onboarding) - Platform Docs Viewed',
 };


### PR DESCRIPTION
### Summary
This gives names to the log onboarding events so they appear in our analytics, and fixes the issues section double firing analytics due to a missing stopPropagation call.

