### PR TITLE
fix(issues): Start writing new_group_first_seen in merge case

### DIFF
--- a/src/sentry/eventstream/base.py
+++ b/src/sentry/eventstream/base.py
@@ -147,7 +147,11 @@ class EventStream(Service):
         pass
 
     def start_merge(
-        self, project_id: int, previous_group_ids: Sequence[int], new_group_id: int
+        self,
+        project_id: int,
+        previous_group_ids: Sequence[int],
+        new_group_id: int,
+        new_group_first_seen: datetime | None = None,
     ) -> dict[str, Any]:
         raise NotImplementedError
 

--- a/src/sentry/issues/merge.py
+++ b/src/sentry/issues/merge.py
@@ -56,7 +56,7 @@ def handle_merge(
 
     group_ids_to_merge = [g.id for g in groups_to_merge]
     eventstream_state = eventstream.backend.start_merge(
-        primary_group.project_id, group_ids_to_merge, primary_group.id
+        primary_group.project_id, group_ids_to_merge, primary_group.id, primary_group.first_seen
     )
 
     Group.objects.filter(id__in=group_ids_to_merge).update(

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -4034,7 +4034,10 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         )
 
         mock_eventstream.start_merge.assert_called_once_with(
-            group1.project_id, [group3.id, group1.id], group2.id
+            group1.project_id,
+            [group3.id, group1.id],
+            group2.id,
+            group2.first_seen,
         )
 
         assert len(merge_groups.mock_calls) == 1

--- a/tests/sentry/issues/test_merge.py
+++ b/tests/sentry/issues/test_merge.py
@@ -1,5 +1,4 @@
-from typing import Any
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import rest_framework
@@ -13,6 +12,7 @@ from sentry.testutils.cases import TestCase
 from sentry.testutils.skips import requires_snuba
 from sentry.types.activity import ActivityType
 from sentry.types.group import GroupSubStatus
+from sentry.utils import json
 
 pytestmark = [requires_snuba]
 
@@ -29,7 +29,7 @@ class HandleIssueMergeTest(TestCase):
             self.groups.append(group)
 
     @patch("sentry.tasks.merge.merge_groups.delay")
-    def test_handle_merge(self, merge_groups: Any) -> None:
+    def test_handle_merge(self, merge_groups: MagicMock) -> None:
         Activity.objects.all().delete()
         merge = handle_merge(self.groups, self.project_lookup, self.user)
 
@@ -38,6 +38,10 @@ class HandleIssueMergeTest(TestCase):
         assert len(groups.filter(status=GroupStatus.PENDING_MERGE)) == 4
         assert len(groups.filter(substatus__isnull=True)) == 4
         assert merge_groups.called
+
+        assert merge_groups.call_args[1]["eventstream_state"][
+            "new_group_first_seen"
+        ] == json.datetime_to_str(min([g.first_seen for g in groups]))
 
         primary_group = self.groups[0]
         assert Activity.objects.filter(type=ActivityType.MERGE.value, group=primary_group)

--- a/tests/snuba/api/endpoints/test_project_group_index.py
+++ b/tests/snuba/api/endpoints/test_project_group_index.py
@@ -1342,7 +1342,10 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         )
 
         mock_eventstream.start_merge.assert_called_once_with(
-            group1.project_id, [group3.id, group1.id], group2.id
+            group1.project_id,
+            [group3.id, group1.id],
+            group2.id,
+            group2.first_seen,
         )
 
         assert len(merge_groups.mock_calls) == 1


### PR DESCRIPTION
This is part of an effort to fix the issue-search's sort-by-age feature. As part of that feature, we are adding the "first_seen" time of a group to each error. When we merge groups, we want to update the errors to have the new group's "group_first_seen".

We've decided to do that by explicitly passing the primary group's "first_seen" time along with the Kafka message. This PR starts writing that field properly; it must wait until [snuba#7351](https://github.com/getsentry/snuba/pull/7351) has fully deployed.