### PR TITLE
ref(grouping): change GroupingEventVariantType to use underscores in FE

### DIFF
--- a/static/app/components/events/groupingInfo/useEventGroupingInfo.tsx
+++ b/static/app/components/events/groupingInfo/useEventGroupingInfo.tsx
@@ -1,6 +1,8 @@
 import {t} from 'sentry/locale';
 import {
+  convertVariantFromBackend,
   EventGroupVariantType,
+  isEventGroupVariantType,
   type Event,
   type EventGroupVariant,
 } from 'sentry/types/event';
@@ -66,7 +68,16 @@ export function useEventGroupingInfo({
 
   const groupInfo = hasPerformanceGrouping
     ? generatePerformanceGroupInfo({group, event})
-    : (data ?? null);
+    : data
+      ? Object.fromEntries(
+          Object.entries(data).map(([key, variant]) => [
+            key,
+            isEventGroupVariantType(variant.type)
+              ? convertVariantFromBackend(variant)
+              : variant,
+          ])
+        )
+      : null;
 
   return {groupInfo, isPending, isError, isSuccess, hasPerformanceGrouping};
 }

--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -50,11 +50,38 @@ type VariantEvidence = {
 export const enum EventGroupVariantType {
   CHECKSUM = 'checksum',
   FALLBACK = 'fallback',
-  CUSTOM_FINGERPRINT = 'custom-fingerprint',
-  BUILT_IN_FINGERPRINT = 'built-in-fingerprint',
+  CUSTOM_FINGERPRINT = 'custom_fingerprint',
+  BUILT_IN_FINGERPRINT = 'built_in_fingerprint',
   COMPONENT = 'component',
-  SALTED_COMPONENT = 'salted-component',
-  PERFORMANCE_PROBLEM = 'performance-problem',
+  SALTED_COMPONENT = 'salted_component',
+  PERFORMANCE_PROBLEM = 'performance_problem',
+}
+
+export function convertVariantTypeToUnderscore(type: string): EventGroupVariantType {
+  const converted = type.replace(/-/g, '_');
+  return converted as EventGroupVariantType;
+}
+
+export function isEventGroupVariantType(value: string): value is EventGroupVariantType {
+  const eventGroupVariantTypes = new Set<string>([
+    'checksum',
+    'fallback',
+    'custom_fingerprint',
+    'built_in_fingerprint',
+    'component',
+    'salted_component',
+    'performance_problem',
+  ]);
+  return eventGroupVariantTypes.has(value);
+}
+
+export function convertVariantFromBackend(variant: any): EventGroupVariant {
+  const convertedVariant = {
+    ...variant,
+    type: convertVariantTypeToUnderscore(variant.type),
+  };
+
+  return convertedVariant as EventGroupVariant;
 }
 
 interface BaseVariant {

--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -66,11 +66,11 @@ export function isEventGroupVariantType(value: string): value is EventGroupVaria
   const eventGroupVariantTypes = new Set<string>([
     'checksum',
     'fallback',
-    'custom_fingerprint',
-    'built_in_fingerprint',
+    'custom-fingerprint',
+    'built-in-fingerprint',
     'component',
-    'salted_component',
-    'performance_problem',
+    'salted-component',
+    'performance-problem',
   ]);
   return eventGroupVariantTypes.has(value);
 }

--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -57,7 +57,7 @@ export const enum EventGroupVariantType {
   PERFORMANCE_PROBLEM = 'performance_problem',
 }
 
-export function convertVariantTypeToUnderscore(type: string): EventGroupVariantType {
+function convertVariantTypeToUnderscore(type: string): EventGroupVariantType {
   const converted = type.replace(/-/g, '_');
   return converted as EventGroupVariantType;
 }


### PR DESCRIPTION
Changes `-` to `_` in `eventGroupVariantType` in `event.tsx`. 

Since data is sent with dashes in the back end, `convertVariantFromBackend()` is needed to convert incoming data from back end with dashes to data with underscores in the front end. This function will eventually be removed when the back end is changed to send data in the correct format. 

*First PR in a series of changes to change - to _ in eventGroupVariantType for consistency across front end and back end.*
