### PR TITLE
chore(replay): remove event type FCP

### DIFF
--- a/src/sentry/replays/lib/summarize.py
+++ b/src/sentry/replays/lib/summarize.py
@@ -319,11 +319,6 @@ def as_log_message(event: dict[str, Any]) -> str | None:
                 duration = event["data"]["payload"]["data"]["size"]
                 rating = event["data"]["payload"]["data"]["rating"]
                 return f"Application largest contentful paint: {duration} ms and has a {rating} rating at {timestamp_ms}"
-            case EventType.FCP:
-                timestamp_ms = timestamp * 1000
-                duration = event["data"]["payload"]["data"]["size"]
-                rating = event["data"]["payload"]["data"]["rating"]
-                return f"Application first contentful paint: {duration} ms and has a {rating} rating at {timestamp_ms}"
             case EventType.HYDRATION_ERROR:
                 return f"There was a hydration error on the page at {timestamp}"
             case EventType.RESOURCE_XHR:

--- a/src/sentry/replays/usecases/ingest/event_parser.py
+++ b/src/sentry/replays/usecases/ingest/event_parser.py
@@ -93,7 +93,7 @@ class EventType(Enum):
     CLICK = 1
     CONSOLE = 2
     DEAD_CLICK = 3
-    FCP = 4
+    # FCP = 4 deprecated
     FEEDBACK = 5
     HYDRATION_ERROR = 6
     LCP = 7
@@ -191,8 +191,6 @@ def which(event: dict[str, Any]) -> EventType:
                 elif op == "web-vital":
                     if payload["description"] == "largest-contentful-paint":
                         return EventType.LCP
-                    elif payload["description"] == "first-contentful-paint":
-                        return EventType.FCP
                     elif payload["description"] == "cumulative-layout-shift":
                         return EventType.CLS
                     else:
@@ -413,13 +411,11 @@ def as_trace_item_context(event_type: EventType, event: dict[str, Any]) -> Trace
                 "event_hash": uuid.uuid4().bytes,
                 "timestamp": float(event["data"]["payload"]["startTimestamp"]),
             }
-        case EventType.LCP | EventType.FCP | EventType.CLS:
+        case EventType.LCP | EventType.CLS:
             payload = event["data"]["payload"]
 
             if event_type == EventType.CLS:
                 category = "web-vital.cls"
-            elif event_type == EventType.FCP:
-                category = "web-vital.fcp"
             else:
                 category = "web-vital.lcp"
 

--- a/tests/sentry/replays/unit/lib/test_summarize.py
+++ b/tests/sentry/replays/unit/lib/test_summarize.py
@@ -242,20 +242,6 @@ def test_as_log_message() -> None:
     event = {
         "type": 5,
         "timestamp": 0.0,
-        "data": {
-            "tag": "performanceSpan",
-            "payload": {
-                "op": "web-vital",
-                "description": "first-contentful-paint",
-                "data": {"size": 0, "rating": "good"},
-            },
-        },
-    }
-    assert as_log_message(event) is not None
-
-    event = {
-        "type": 5,
-        "timestamp": 0.0,
         "data": {"tag": "breadcrumb", "payload": {"category": "replay.hydrate-error"}},
     }
     assert as_log_message(event) is not None

--- a/tests/sentry/replays/unit/test_event_parser.py
+++ b/tests/sentry/replays/unit/test_event_parser.py
@@ -1186,32 +1186,6 @@ def test_as_trace_item_context_lcp_event() -> None:
     assert "event_hash" in result and len(result["event_hash"]) == 16
 
 
-def test_as_trace_item_context_fcp_event() -> None:
-    event = {
-        "type": 5,
-        "timestamp": 1753712471.43,
-        "data": {
-            "tag": "performanceSpan",
-            "payload": {
-                "op": "web-vital",
-                "description": "first-contentful-paint",
-                "startTimestamp": 1674298825.0,
-                "endTimestamp": 1674298825.0,
-                "data": {"rating": "needs-improvement", "size": 512, "value": 2000},
-            },
-        },
-    }
-
-    result = as_trace_item_context(which(event), event)
-    assert result is not None
-    assert result["attributes"]["category"] == "web-vital.fcp"
-    assert result["attributes"]["duration"] == 0
-    assert result["attributes"]["rating"] == "needs-improvement"
-    assert result["attributes"]["size"] == 512
-    assert result["attributes"]["value"] == 2000
-    assert "event_hash" in result and len(result["event_hash"]) == 16
-
-
 def test_as_trace_item_context_cls_event() -> None:
     event = {
         "type": 5,

--- a/tests/sentry/replays/unit/test_event_parser.py
+++ b/tests/sentry/replays/unit/test_event_parser.py
@@ -694,16 +694,6 @@ def test_which() -> None:
     event = {
         "type": 5,
         "timestamp": 0.0,
-        "data": {
-            "tag": "performanceSpan",
-            "payload": {"op": "web-vital", "description": "first-contentful-paint"},
-        },
-    }
-    assert which(event) == EventType.FCP
-
-    event = {
-        "type": 5,
-        "timestamp": 0.0,
         "data": {"tag": "breadcrumb", "payload": {"category": "replay.hydrate-error"}},
     }
     assert which(event) == EventType.HYDRATION_ERROR


### PR DESCRIPTION
- closes https://linear.app/getsentry/issue/REPLAY-590/get-rid-of-fcp-logs
- remove the FCP event type and its log message from the replay breadcrumb summaries, as it's deprecated