### PR TITLE
feat(dashboards): open spans table row in explore

### DIFF
--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -921,7 +921,6 @@ function WidgetViewerModal(props: Props) {
                 tableResults={tableData}
                 errorMessage={undefined}
                 loading={false}
-                location={location}
                 widget={widget}
                 selection={selection}
                 organization={organization}

--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -70,6 +70,8 @@ import useProjects from 'sentry/utils/useProjects';
 import {useUser} from 'sentry/utils/useUser';
 import {useUserTeams} from 'sentry/utils/useUserTeams';
 import withPageFilters from 'sentry/utils/withPageFilters';
+// eslint-disable-next-line no-restricted-imports
+import withSentryRouter from 'sentry/utils/withSentryRouter';
 import {getDatasetConfig} from 'sentry/views/dashboards/datasetConfig/base';
 import {checkUserHasEditAccess} from 'sentry/views/dashboards/detail';
 import {DiscoverSplitAlert} from 'sentry/views/dashboards/discoverSplitAlert';
@@ -171,7 +173,9 @@ const MemoizedWidgetCardChartContainer = memo(
   WidgetCardChartContainer,
   shouldWidgetCardChartMemo
 );
-const MemoizedWidgetCardChart = memo(WidgetCardChart, shouldWidgetCardChartMemo);
+const MemoizedWidgetCardChart = withSentryRouter(
+  memo(WidgetCardChart, shouldWidgetCardChartMemo)
+);
 
 async function fetchDiscoverTotal(
   api: Client,

--- a/static/app/views/dashboards/utils/getWidgetExploreUrl.tsx
+++ b/static/app/views/dashboards/utils/getWidgetExploreUrl.tsx
@@ -11,6 +11,7 @@ import {
 } from 'sentry/utils/discover/fields';
 import {FieldKind, getFieldDefinition} from 'sentry/utils/fields';
 import {decodeBoolean, decodeScalar, decodeSorts} from 'sentry/utils/queryString';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import type {DashboardFilters, Widget} from 'sentry/views/dashboards/types';
 import {DisplayType} from 'sentry/views/dashboards/types';
@@ -19,6 +20,7 @@ import {
   eventViewFromWidget,
   getWidgetInterval,
 } from 'sentry/views/dashboards/utils';
+import type {TabularRow} from 'sentry/views/dashboards/widgets/common/types';
 import {
   LOGS_AGGREGATE_FN_KEY,
   LOGS_AGGREGATE_PARAM_KEY,
@@ -162,7 +164,8 @@ function _getWidgetExploreUrl(
   dashboardFilters: DashboardFilters | undefined,
   selection: PageFilters,
   organization: Organization,
-  preferMode?: Mode
+  preferMode?: Mode,
+  overrideQuery?: MutableSearch
 ) {
   const eventView = eventViewFromWidget(widget.title, widget.queries[0]!, selection);
   const locationQueryParams = eventView.generateQueryStringObject();
@@ -215,7 +218,9 @@ function _getWidgetExploreUrl(
 
   let groupBy: string[] =
     defined(query.fields) && widget.displayType === DisplayType.TABLE
-      ? query.fields.filter(field => !isAggregateFieldOrEquation(field))
+      ? query.fields.filter(
+          field => !isAggregateFieldOrEquation(field) && field !== 'timestamp'
+        )
       : [...query.columns];
   if (groupBy && groupBy.length === 0) {
     // Force the groupBy to be an array with a single empty string
@@ -226,7 +231,7 @@ function _getWidgetExploreUrl(
   }
 
   const yAxisFields: string[] = locationQueryParams.yAxes.flatMap(getAggregateArguments);
-  const fields = [...groupBy, ...yAxisFields].filter(Boolean);
+  const fields = [...new Set([...groupBy, ...yAxisFields])].filter(Boolean);
 
   const sortDirection = widget.queries[0]?.orderby?.startsWith('-') ? '-' : '';
   const sortColumn = trimStart(widget.queries[0]?.orderby ?? '', '-');
@@ -273,7 +278,7 @@ function _getWidgetExploreUrl(
     groupBy: visualize.length > 0 ? groupBy : [],
     field: fields,
     query: applyDashboardFilters(
-      decodeScalar(locationQueryParams.query),
+      overrideQuery?.formatString() ?? decodeScalar(locationQueryParams.query),
       dashboardFilters
     ),
     sort: sort || undefined,
@@ -324,4 +329,38 @@ function _getWidgetExploreUrlForMultipleQueries(
     })),
     interval: getWidgetInterval(widget, currentSelection.datetime),
   });
+}
+
+export function getWidgetTableRowExploreUrlFunction(
+  selection: PageFilters,
+  widget: Widget,
+  organization: Organization,
+  dashboardFilters?: DashboardFilters
+) {
+  return (dataRow: TabularRow) => {
+    let fields: string[] = [];
+    if (widget.queries[0]?.fields) {
+      fields = widget.queries[0].fields.filter(
+        (field: string) => !isAggregateFieldOrEquation(field)
+      );
+    }
+
+    const query = new MutableSearch('');
+    fields.map(field => {
+      const value = dataRow[field];
+      if (!defined(value)) {
+        return query.addFilterValue('!has', field);
+      }
+      return query.addFilterValue(field, String(value));
+    });
+
+    return _getWidgetExploreUrl(
+      widget,
+      dashboardFilters,
+      selection,
+      organization,
+      Mode.SAMPLES,
+      query
+    );
+  };
 }

--- a/static/app/views/dashboards/utils/getWidgetExploreUrl.tsx
+++ b/static/app/views/dashboards/utils/getWidgetExploreUrl.tsx
@@ -351,6 +351,9 @@ export function getWidgetTableRowExploreUrlFunction(
       if (!defined(value)) {
         return query.addFilterValue('!has', field);
       }
+      if (Array.isArray(value)) {
+        return query.addFilterValues(field, value);
+      }
       return query.addFilterValue(field, String(value));
     });
 

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -57,8 +57,6 @@ import {
 } from 'sentry/utils/discover/fields';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import {decodeSorts} from 'sentry/utils/queryString';
-// eslint-disable-next-line no-restricted-imports
-import withSentryRouter from 'sentry/utils/withSentryRouter';
 import {getDatasetConfig} from 'sentry/views/dashboards/datasetConfig/base';
 import type {DashboardFilters, Widget} from 'sentry/views/dashboards/types';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
@@ -694,7 +692,7 @@ class WidgetCardChart extends Component<WidgetCardChartProps> {
   }
 }
 
-export default withSentryRouter(withTheme(WidgetCardChart));
+export default withTheme(WidgetCardChart);
 
 const StyledTransparentLoadingMask = styled((props: any) => (
   <TransparentLoadingMask {...props} maskBackgroundColor="transparent" />

--- a/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
@@ -19,6 +19,8 @@ import type {Organization} from 'sentry/types/organization';
 import type {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 import type {AggregationOutputType, Sort} from 'sentry/utils/discover/fields';
 import {useLocation} from 'sentry/utils/useLocation';
+// eslint-disable-next-line no-restricted-imports
+import withSentryRouter from 'sentry/utils/withSentryRouter';
 import type {DashboardFilters, Widget} from 'sentry/views/dashboards/types';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
 import WidgetLegendNameEncoderDecoder from 'sentry/views/dashboards/widgetLegendNameEncoderDecoder';
@@ -69,6 +71,8 @@ type Props = {
   tableItemLimit?: number;
   windowWidth?: number;
 };
+
+const WidgetCardChartWithRouter = withSentryRouter(WidgetCardChart);
 
 export function WidgetCardChartContainer({
   organization,
@@ -190,7 +194,7 @@ export function WidgetCardChartContainer({
             {typeof renderErrorMessage === 'function'
               ? renderErrorMessage(errorOrEmptyMessage)
               : null}
-            <WidgetCardChart
+            <WidgetCardChartWithRouter
               disableZoom={disableZoom}
               timeseriesResults={modifiedTimeseriesResults}
               tableResults={tableResults}

--- a/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
@@ -227,6 +227,7 @@ export function WidgetCardChartContainer({
               onWidgetTableSort={onWidgetTableSort}
               onWidgetTableResizeColumn={onWidgetTableResizeColumn}
               disableTableActions={disableTableActions}
+              dashboardFilters={dashboardFilters}
             />
           </Fragment>
         );

--- a/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
@@ -196,7 +196,6 @@ export function WidgetCardChartContainer({
               tableResults={tableResults}
               errorMessage={errorOrEmptyMessage}
               loading={loading}
-              location={location}
               widget={widget}
               selection={selection}
               organization={organization}

--- a/static/app/views/dashboards/widgets/common/settings.tsx
+++ b/static/app/views/dashboards/widgets/common/settings.tsx
@@ -1,5 +1,6 @@
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {Actions} from 'sentry/views/discover/table/cellAction';
 
 // NOTE: This is a subset! Some types like `"string"`, `"date"`, and
 // `"percent_change"` are not supported yet. Once we support them, we can remove
@@ -26,3 +27,9 @@ export const DEFAULT_FIELD = 'unknown'; // Numeric data might, in theory, have a
 export const MISSING_DATA_MESSAGE = t('No Data');
 export const NO_PLOTTABLE_VALUES = t('The data does not contain any plottable values.');
 export const NON_FINITE_NUMBER_MESSAGE = t('Value is not a finite number.');
+
+export const ALLOWED_CELL_ACTIONS = [
+  Actions.OPEN_INTERNAL_LINK,
+  Actions.COPY_TO_CLIPBOARD,
+  Actions.OPEN_EXTERNAL_LINK,
+];

--- a/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.spec.tsx
+++ b/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.spec.tsx
@@ -285,7 +285,7 @@ describe('TableWidgetVisualization', function () {
 
     it('Uses onTriggerCellAction if supplied on action click', async function () {
       const onTriggerCellActionMock = jest.fn(
-        (_actions: Actions, _value: string | number) => {}
+        (_actions: Actions, _value: string | number, _dataRow: TabularRow) => {}
       );
       Object.assign(navigator, {
         clipboard: {
@@ -307,7 +307,8 @@ describe('TableWidgetVisualization', function () {
       await waitFor(() =>
         expect(onTriggerCellActionMock).toHaveBeenCalledWith(
           Actions.COPY_TO_CLIPBOARD,
-          sampleHTTPRequestTableData.data[0]!['http.request_method']
+          sampleHTTPRequestTableData.data[0]!['http.request_method'],
+          sampleHTTPRequestTableData.data[0]
         )
       );
     });

--- a/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.tsx
@@ -21,6 +21,7 @@ import {decodeSorts} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
+import {ALLOWED_CELL_ACTIONS} from 'sentry/views/dashboards/widgets/common/settings';
 import type {
   TabularColumn,
   TabularData,
@@ -105,7 +106,11 @@ interface TableWidgetVisualizationProps {
   /**
    * A callback function that is invoked when a user clicks an option in the cell action dropdown.
    */
-  onTriggerCellAction?: (action: Actions, value: string | number) => void;
+  onTriggerCellAction?: (
+    action: Actions,
+    value: string | number,
+    dataRow: TabularRow
+  ) => void;
   /**
    * If true, will allow table columns to be resized, otherwise no resizing. By default this is true
    */
@@ -145,11 +150,7 @@ export function TableWidgetVisualization(props: TableWidgetVisualizationProps) {
     onResizeColumn,
     resizable = true,
     onTriggerCellAction,
-    allowedCellActions = [
-      Actions.COPY_TO_CLIPBOARD,
-      Actions.OPEN_EXTERNAL_LINK,
-      Actions.OPEN_INTERNAL_LINK,
-    ],
+    allowedCellActions = ALLOWED_CELL_ACTIONS,
   } = props;
 
   const theme = useTheme();
@@ -285,7 +286,7 @@ export function TableWidgetVisualization(props: TableWidgetVisualizationProps) {
               column={formattedColumn}
               dataRow={dataRow as TableDataRow}
               handleCellAction={(action: Actions, value: string | number) => {
-                onTriggerCellAction?.(action, value);
+                onTriggerCellAction?.(action, value, dataRow);
                 switch (action) {
                   case Actions.COPY_TO_CLIPBOARD:
                     copyToClipboard(value);

--- a/static/app/views/discover/table/cellAction.tsx
+++ b/static/app/views/discover/table/cellAction.tsx
@@ -34,6 +34,7 @@ export enum Actions {
   COPY_TO_CLIPBOARD = 'copy_to_clipboard',
   OPEN_EXTERNAL_LINK = 'open_external_link',
   OPEN_INTERNAL_LINK = 'open_internal_link',
+  OPEN_ROW_IN_EXPLORE = 'open_row_in_explore',
 }
 
 export function updateQuery(
@@ -234,6 +235,10 @@ function makeCellActions({
 
   if (isUrl(value)) {
     addMenuItem(Actions.OPEN_EXTERNAL_LINK, t('Open external link'));
+  }
+
+  if (allowActions) {
+    addMenuItem(Actions.OPEN_ROW_IN_EXPLORE, t('View span samples'));
   }
 
   if (value) addMenuItem(Actions.COPY_TO_CLIPBOARD, t('Copy to clipboard'));


### PR DESCRIPTION
### Changes

Add a cell action that opens the widget table row in explore, which add the table row in the search bar so only relevant samples appear.

Also filtered out duplicate columns (from the aggregates) and filtered out `timestamp` from `groupBy` as it was breaking the charts.

Only visible when the `discover-cell-actions-v2` flag is enabled.

### Video

https://github.com/user-attachments/assets/036b2eff-6369-4cfc-94cd-211d091ee0ad

