### PR TITLE
chore(explore): Add gen ai consent to explore analytics

### DIFF
--- a/static/app/utils/analytics/tracingEventMap.tsx
+++ b/static/app/utils/analytics/tracingEventMap.tsx
@@ -38,6 +38,7 @@ export type TracingEventParameters = {
     columns_count: number;
     confidences: string[];
     dataset: string;
+    gave_seer_consent: 'given' | 'not_given' | 'gen_ai_features_disabled';
     has_exceeded_performance_usage_limit: boolean | null;
     interval: string;
     page_source: 'explore' | 'compare';

--- a/static/app/views/explore/hooks/useAnalytics.tsx
+++ b/static/app/views/explore/hooks/useAnalytics.tsx
@@ -107,7 +107,7 @@ function useTrackAnalytics({
     const columns = aggregatesTableResult.eventView.getColumns() as unknown as string[];
     const gaveSeerConsent = organization.hideAiFeatures
       ? 'gen_ai_features_disabled'
-      : seerSetup.orgHasAcknowledged
+      : seerSetup?.orgHasAcknowledged
         ? 'given'
         : 'not_given';
 
@@ -173,7 +173,7 @@ function useTrackAnalytics({
     query,
     queryType,
     query_status,
-    seerSetup.orgHasAcknowledged,
+    seerSetup?.orgHasAcknowledged,
     timeseriesResult.data,
     timeseriesResult.isPending,
     title,
@@ -194,7 +194,7 @@ function useTrackAnalytics({
     const search = new MutableSearch(query);
     const gaveSeerConsent = organization.hideAiFeatures
       ? 'gen_ai_features_disabled'
-      : seerSetup.orgHasAcknowledged
+      : seerSetup?.orgHasAcknowledged
         ? 'given'
         : 'not_given';
 
@@ -253,7 +253,7 @@ function useTrackAnalytics({
     query,
     queryType,
     query_status,
-    seerSetup.orgHasAcknowledged,
+    seerSetup?.orgHasAcknowledged,
     spansTableResult.result.data?.length,
     spansTableResult.result.isPending,
     timeseriesResult.data,
@@ -290,7 +290,7 @@ function useTrackAnalytics({
         .length ?? 0;
     const gaveSeerConsent = organization.hideAiFeatures
       ? 'gen_ai_features_disabled'
-      : seerSetup.orgHasAcknowledged
+      : seerSetup?.orgHasAcknowledged
         ? 'given'
         : 'not_given';
 
@@ -332,7 +332,7 @@ function useTrackAnalytics({
     query,
     queryType,
     query_status,
-    seerSetup.orgHasAcknowledged,
+    seerSetup?.orgHasAcknowledged,
     timeseriesResult.data,
     timeseriesResult.isPending,
     title,

--- a/static/app/views/explore/hooks/useAnalytics.tsx
+++ b/static/app/views/explore/hooks/useAnalytics.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useMemo, useRef} from 'react';
+import {useEffect, useRef} from 'react';
 import * as Sentry from '@sentry/react';
 
 import {useOrganizationSeerSetup} from 'sentry/components/events/autofix/useOrganizationSeerSetup';
@@ -87,32 +87,29 @@ function useTrackAnalytics({
   const chartError = timeseriesResult.error?.message ?? '';
   const query_status = tableError || chartError ? 'error' : 'success';
 
-  const {setupAcknowledgement: seerSetup} = useOrganizationSeerSetup({
-    enabled: !organization.hideAiFeatures,
-  });
-
-  const gaveSeerConsent = useMemo(
-    () =>
-      organization.hideAiFeatures
-        ? 'gen_ai_features_disabled'
-        : seerSetup.orgHasAcknowledged
-          ? 'given'
-          : 'not_given',
-    [organization.hideAiFeatures, seerSetup.orgHasAcknowledged]
-  );
+  const {setupAcknowledgement: seerSetup, isLoading: isLoadingSeerSetup} =
+    useOrganizationSeerSetup({
+      enabled: !organization.hideAiFeatures,
+    });
 
   useEffect(() => {
     if (
       queryType !== 'aggregate' ||
       aggregatesTableResult.result.isPending ||
       timeseriesResult.isPending ||
-      isLoadingSubscriptionDetails
+      isLoadingSubscriptionDetails ||
+      isLoadingSeerSetup
     ) {
       return;
     }
 
     const search = new MutableSearch(query);
     const columns = aggregatesTableResult.eventView.getColumns() as unknown as string[];
+    const gaveSeerConsent = organization.hideAiFeatures
+      ? 'gen_ai_features_disabled'
+      : seerSetup.orgHasAcknowledged
+        ? 'given'
+        : 'not_given';
 
     trackAnalytics('trace.explorer.metadata', {
       organization,
@@ -166,9 +163,9 @@ function useTrackAnalytics({
     aggregatesTableResult.result.data?.length,
     aggregatesTableResult.result.isPending,
     dataset,
-    gaveSeerConsent,
     hasExceededPerformanceUsageLimit,
     interval,
+    isLoadingSeerSetup,
     isLoadingSubscriptionDetails,
     isTopN,
     organization,
@@ -176,6 +173,7 @@ function useTrackAnalytics({
     query,
     queryType,
     query_status,
+    seerSetup.orgHasAcknowledged,
     timeseriesResult.data,
     timeseriesResult.isPending,
     title,
@@ -187,12 +185,19 @@ function useTrackAnalytics({
       queryType !== 'samples' ||
       spansTableResult.result.isPending ||
       timeseriesResult.isPending ||
-      isLoadingSubscriptionDetails
+      isLoadingSubscriptionDetails ||
+      isLoadingSeerSetup
     ) {
       return;
     }
 
     const search = new MutableSearch(query);
+    const gaveSeerConsent = organization.hideAiFeatures
+      ? 'gen_ai_features_disabled'
+      : seerSetup.orgHasAcknowledged
+        ? 'given'
+        : 'not_given';
+
     trackAnalytics('trace.explorer.metadata', {
       organization,
       dataset,
@@ -238,9 +243,9 @@ function useTrackAnalytics({
   }, [
     dataset,
     fields,
-    gaveSeerConsent,
     hasExceededPerformanceUsageLimit,
     interval,
+    isLoadingSeerSetup,
     isLoadingSubscriptionDetails,
     isTopN,
     organization,
@@ -248,6 +253,7 @@ function useTrackAnalytics({
     query,
     queryType,
     query_status,
+    seerSetup.orgHasAcknowledged,
     spansTableResult.result.data?.length,
     spansTableResult.result.isPending,
     timeseriesResult.data,
@@ -264,7 +270,8 @@ function useTrackAnalytics({
       queryType !== 'traces' ||
       tracesTableResult.result.isPending ||
       timeseriesResult.isPending ||
-      isLoadingSubscriptionDetails
+      isLoadingSubscriptionDetails ||
+      isLoadingSeerSetup
     ) {
       return;
     }
@@ -281,6 +288,11 @@ function useTrackAnalytics({
     const resultMissingRoot =
       tracesTableResult?.result?.data?.data?.filter(trace => !defined(trace.name))
         .length ?? 0;
+    const gaveSeerConsent = organization.hideAiFeatures
+      ? 'gen_ai_features_disabled'
+      : seerSetup.orgHasAcknowledged
+        ? 'given'
+        : 'not_given';
 
     trackAnalytics('trace.explorer.metadata', {
       organization,
@@ -310,9 +322,9 @@ function useTrackAnalytics({
     });
   }, [
     dataset,
-    gaveSeerConsent,
     hasExceededPerformanceUsageLimit,
     interval,
+    isLoadingSeerSetup,
     isLoadingSubscriptionDetails,
     isTopN,
     organization,
@@ -320,6 +332,7 @@ function useTrackAnalytics({
     query,
     queryType,
     query_status,
+    seerSetup.orgHasAcknowledged,
     timeseriesResult.data,
     timeseriesResult.isPending,
     title,

--- a/static/app/views/explore/multiQueryMode/content.spec.tsx
+++ b/static/app/views/explore/multiQueryMode/content.spec.tsx
@@ -1,3 +1,4 @@
+import {AutofixSetupFixture} from 'sentry-fixture/autofixSetupFixture';
 import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
@@ -42,6 +43,16 @@ describe('MultiQueryModeContent', function () {
       },
       new Set()
     );
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/seer/setup-check/`,
+      body: AutofixSetupFixture({
+        setupAcknowledgement: {
+          orgHasAcknowledged: true,
+          userHasAcknowledged: true,
+        },
+      }),
+    });
 
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/trace-items/attributes/`,

--- a/static/app/views/explore/spans/spansTab.spec.tsx
+++ b/static/app/views/explore/spans/spansTab.spec.tsx
@@ -1,4 +1,5 @@
 import type {ReactNode} from 'react';
+import {AutofixSetupFixture} from 'sentry-fixture/autofixSetupFixture';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
@@ -102,6 +103,15 @@ describe('SpansTabContent', function () {
       url: `/organizations/${organization.slug}/traces/`,
       method: 'GET',
       body: {},
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/seer/setup-check/`,
+      body: AutofixSetupFixture({
+        setupAcknowledgement: {
+          orgHasAcknowledged: true,
+          userHasAcknowledged: true,
+        },
+      }),
     });
   });
 


### PR DESCRIPTION
This PR adds a `gave_seer_consent` field to the `trace.explorer.metadata` analytic event.