### PR TITLE
ref(aci): Add supported detection types to dataset config

### DIFF
--- a/static/app/views/detectors/components/forms/metric/metric.tsx
+++ b/static/app/views/detectors/components/forms/metric/metric.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import {FeatureBadge} from 'sentry/components/core/badge/featureBadge';
 import {Flex} from 'sentry/components/core/layout';
 import {Tooltip} from 'sentry/components/core/tooltip';
+import type {RadioOption} from 'sentry/components/forms/controls/radioGroup';
 import NumberField from 'sentry/components/forms/fields/numberField';
 import SegmentedRadioField from 'sentry/components/forms/fields/segmentedRadioField';
 import SelectField from 'sentry/components/forms/fields/selectField';
@@ -18,7 +19,7 @@ import {
   DataConditionType,
   DetectorPriorityLevel,
 } from 'sentry/types/workflowEngine/dataConditions';
-import type {Detector} from 'sentry/types/workflowEngine/detectors';
+import type {Detector, MetricDetectorConfig} from 'sentry/types/workflowEngine/detectors';
 import {generateFieldAsString} from 'sentry/utils/discover/fields';
 import useOrganization from 'sentry/utils/useOrganization';
 import {
@@ -85,22 +86,34 @@ export function NewMetricDetectorForm() {
   );
 }
 
-function DetectionType() {
-  const options: Array<[MetricDetectorFormData['detectionType'], string, string]> = [
-    ['static', t('Threshold'), t('Absolute-valued thresholds, for non-seasonal data.')],
-    ['percent', t('Change'), t('Percentage changes over defined time windows.')],
-    [
-      'dynamic',
-      t('Dynamic'),
-      t('Auto-detect anomalies and mean deviation, for seasonal/noisy data.'),
-    ],
-  ];
+const DETECTION_TYPE_MAP: Record<
+  MetricDetectorConfig['detectionType'],
+  {description: string; label: string}
+> = {
+  static: {
+    label: t('Threshold'),
+    description: t('Absolute-valued thresholds, for non-seasonal data.'),
+  },
+  percent: {
+    label: t('Change'),
+    description: t('Percentage changes over defined time windows.'),
+  },
+  dynamic: {
+    label: t('Dynamic'),
+    description: t('Auto-detect anomalies and mean deviation, for seasonal/noisy data.'),
+  },
+};
 
+function DetectionType() {
   const dataset = useMetricDetectorFormField(METRIC_DETECTOR_FORM_FIELDS.dataset);
-  // Disable choices for releases dataset, does not support
-  if (dataset === DetectorDataset.RELEASES) {
-    return null;
-  }
+  const datasetConfig = getDatasetConfig(dataset);
+  const options: RadioOption[] = datasetConfig.supportedDetectionTypes.map(
+    detectionType => [
+      detectionType,
+      DETECTION_TYPE_MAP[detectionType].label,
+      DETECTION_TYPE_MAP[detectionType].description,
+    ]
+  );
 
   return (
     <DetectionTypeField
@@ -293,11 +306,11 @@ function DetectSection() {
                 defaultAggregate
               );
 
-              // Reset detection type to static for releases dataset
-              if (newDataset === DetectorDataset.RELEASES) {
+              const supportedDetectionTypes = datasetConfig.supportedDetectionTypes;
+              if (!supportedDetectionTypes.includes(detectionType)) {
                 formContext.form?.setValue(
                   METRIC_DETECTOR_FORM_FIELDS.detectionType,
-                  'static'
+                  supportedDetectionTypes[0]
                 );
               }
             }}

--- a/static/app/views/detectors/datasetConfig/base.tsx
+++ b/static/app/views/detectors/datasetConfig/base.tsx
@@ -2,6 +2,7 @@ import type {SelectValue} from 'sentry/types/core';
 import type {Series} from 'sentry/types/echarts';
 import type {TagCollection} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
+import type {MetricDetectorConfig} from 'sentry/types/workflowEngine/detectors';
 import type {CustomMeasurementCollection} from 'sentry/utils/customMeasurements/customMeasurements';
 import type {QueryFieldValue} from 'sentry/utils/discover/fields';
 import type {DiscoverDatasets} from 'sentry/utils/discover/types';
@@ -72,6 +73,7 @@ export interface DetectorDatasetConfig<SeriesResponse> {
     customMeasurements?: CustomMeasurementCollection
   ) => Record<string, SelectValue<FieldValue>>;
   getSeriesQueryOptions: (options: DetectorSeriesQueryOptions) => ApiQueryKey;
+  supportedDetectionTypes: Array<MetricDetectorConfig['detectionType']>;
   /**
    * Transform the user-friendly aggregate function to the API aggregate function.
    * This is currently only used for the releases dataset.

--- a/static/app/views/detectors/datasetConfig/errors.tsx
+++ b/static/app/views/detectors/datasetConfig/errors.tsx
@@ -29,4 +29,5 @@ export const DetectorErrorsConfig: DetectorDatasetConfig<ErrorsSeriesResponse> =
   },
   fromApiAggregate: aggregate => aggregate,
   toApiAggregate: aggregate => aggregate,
+  supportedDetectionTypes: ['static', 'percent', 'dynamic'],
 };

--- a/static/app/views/detectors/datasetConfig/logs.tsx
+++ b/static/app/views/detectors/datasetConfig/logs.tsx
@@ -24,4 +24,5 @@ export const DetectorLogsConfig: DetectorDatasetConfig<LogsSeriesRepsonse> = {
   },
   fromApiAggregate: aggregate => aggregate,
   toApiAggregate: aggregate => aggregate,
+  supportedDetectionTypes: ['static', 'percent', 'dynamic'],
 };

--- a/static/app/views/detectors/datasetConfig/releases.tsx
+++ b/static/app/views/detectors/datasetConfig/releases.tsx
@@ -1,7 +1,10 @@
 import type {SelectValue} from 'sentry/types/core';
 import type {SessionApiResponse} from 'sentry/types/organization';
 import {SessionField} from 'sentry/types/sessions';
-import {ReleasesConfig} from 'sentry/views/dashboards/datasetConfig/releases';
+import type {
+  AggregationKeyWithAlias,
+  QueryFieldValue,
+} from 'sentry/utils/discover/fields';
 import {ReleaseSearchBar} from 'sentry/views/detectors/datasetConfig/components/releaseSearchBar';
 import {
   getReleasesSeriesQueryOptions,
@@ -63,6 +66,16 @@ const AGGREGATE_FUNCTION_MAP: Record<string, string> = {
     'percentage(users_crashed, users) AS _crash_rate_alert_aggregate',
 };
 
+const DEFAULT_FIELD: QueryFieldValue = {
+  function: [
+    'crash_free_rate' as AggregationKeyWithAlias,
+    SessionField.SESSION,
+    undefined,
+    undefined,
+  ],
+  kind: FieldValueKind.FUNCTION,
+};
+
 const fromApiAggregate = (aggregate: string) => {
   return (
     Object.keys(AGGREGATE_FUNCTION_MAP).find(
@@ -76,7 +89,7 @@ const toApiAggregate = (aggregate: string) => {
 };
 
 export const DetectorReleasesConfig: DetectorDatasetConfig<ReleasesSeriesResponse> = {
-  defaultField: ReleasesConfig.defaultField,
+  defaultField: DEFAULT_FIELD,
   getAggregateOptions: () => AGGREGATE_OPTIONS,
   SearchBar: ReleaseSearchBar,
   getSeriesQueryOptions: getReleasesSeriesQueryOptions,
@@ -89,4 +102,5 @@ export const DetectorReleasesConfig: DetectorDatasetConfig<ReleasesSeriesRespons
     // Releases cannot have a comparison series currently
     return [];
   },
+  supportedDetectionTypes: ['static'],
 };

--- a/static/app/views/detectors/datasetConfig/spans.tsx
+++ b/static/app/views/detectors/datasetConfig/spans.tsx
@@ -24,4 +24,5 @@ export const DetectorSpansConfig: DetectorDatasetConfig<SpansSeriesResponse> = {
   },
   fromApiAggregate: aggregate => aggregate,
   toApiAggregate: aggregate => aggregate,
+  supportedDetectionTypes: ['static', 'percent', 'dynamic'],
 };

--- a/static/app/views/detectors/datasetConfig/transactions.tsx
+++ b/static/app/views/detectors/datasetConfig/transactions.tsx
@@ -30,4 +30,5 @@ export const DetectorTransactionsConfig: DetectorDatasetConfig<TransactionsSerie
     },
     fromApiAggregate: aggregate => aggregate,
     toApiAggregate: aggregate => aggregate,
+    supportedDetectionTypes: ['static', 'percent', 'dynamic'],
   };


### PR DESCRIPTION
- Remove a couple checks for `dataset === RELEASES` by adding `supportedDetectorTypes` to the dataset config
- Add a separate default value for the releases dataset so that we no longer rely on the one from the dashboards config