### PR TITLE
feat(checkout v3): plan select row -> card

### DIFF
--- a/static/gsApp/views/amCheckout/moreFeaturesLink.tsx
+++ b/static/gsApp/views/amCheckout/moreFeaturesLink.tsx
@@ -1,9 +1,10 @@
 import styled from '@emotion/styled';
 
 import {ExternalLink} from 'sentry/components/core/link';
-import {IconBusiness} from 'sentry/icons';
+import {IconBusiness, IconCheckmark} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import type {IconSize} from 'sentry/utils/theme/theme';
 
 type Props = {
   color?: string;
@@ -11,12 +12,17 @@ type Props = {
    * To match power icon
    */
   iconSize?: string;
+  isNewCheckout?: boolean;
 };
 
-function MoreFeaturesLink({color, iconSize}: Props) {
+function MoreFeaturesLink({color, iconSize, isNewCheckout}: Props) {
   return (
     <MoreLink href="https://sentry.io/pricing" color={color}>
-      <IconBusiness legacySize={iconSize} />
+      {isNewCheckout ? (
+        <IconCheckmark size={(iconSize as IconSize) ?? 'sm'} />
+      ) : (
+        <IconBusiness legacySize={iconSize} />
+      )}
       {t('And more...')}
     </MoreLink>
   );

--- a/static/gsApp/views/amCheckout/steps/contractSelect.tsx
+++ b/static/gsApp/views/amCheckout/steps/contractSelect.tsx
@@ -125,6 +125,8 @@ class ContractSelect extends Component<Props> {
               priceHeader={priceHeader}
               price={price}
               planWarning={hasWarning ? this.annualContractWarning : undefined}
+              shouldShowDefaultPayAsYouGo={false}
+              shouldShowEventPrice={false}
             />
           );
         })}

--- a/static/gsApp/views/amCheckout/steps/planSelect.spec.tsx
+++ b/static/gsApp/views/amCheckout/steps/planSelect.spec.tsx
@@ -72,6 +72,50 @@ describe('PlanSelect', function () {
     expect(screen.getByTestId('footer-choose-your-plan')).toBeInTheDocument();
   });
 
+  it('renders for checkout v3', async function () {
+    MockApiClient.addMockResponse({
+      url: `/customers/${organization.slug}/billing-config/`,
+      method: 'GET',
+      body: BillingConfigFixture(PlanTier.AM3),
+    });
+    const newCheckoutOrg = OrganizationFixture({
+      features: ['checkout-v3'],
+    });
+    const freeSubscription = SubscriptionFixture({
+      organization: newCheckoutOrg,
+      plan: 'am3_f',
+      isFree: true,
+    });
+    SubscriptionStore.set(newCheckoutOrg.slug, freeSubscription);
+
+    render(
+      <AMCheckout
+        {...RouteComponentPropsFixture()}
+        params={params}
+        api={api}
+        onToggleLegacy={jest.fn()}
+        checkoutTier={PlanTier.AM3}
+      />,
+      {organization: newCheckoutOrg}
+    );
+
+    expect(await screen.findByTestId('body-choose-your-plan')).toBeInTheDocument();
+    expect(screen.getByTestId('footer-choose-your-plan')).toBeInTheDocument();
+
+    const teamPlan = await screen.findByTestId('plan-option-am3_team');
+    const businessPlan = screen.getByTestId('plan-option-am3_business');
+
+    // no longer use lightning icon for business plan
+    expect(within(teamPlan).getAllByTestId('icon-check-mark').length).toBeGreaterThan(0);
+    expect(within(businessPlan).getAllByTestId('icon-check-mark').length).toBeGreaterThan(
+      0
+    );
+
+    // new excess usage pricing warning
+    expect(within(teamPlan).queryByText(/Excess usage/)).not.toBeInTheDocument();
+    expect(within(businessPlan).getByText(/Excess usage/)).toBeInTheDocument();
+  });
+
   it('renders checkmarks on team plan', async function () {
     const org = OrganizationFixture();
     const teamSubscription = SubscriptionFixture({

--- a/static/gsApp/views/amCheckout/steps/planSelect.tsx
+++ b/static/gsApp/views/amCheckout/steps/planSelect.tsx
@@ -255,7 +255,7 @@ function PlanSelect({
                 key={plan.id}
                 planIcon={planIcon}
                 priorPlan={priorPlan}
-                shouldShowEventPrice={isBizPlanFamily(plan)}
+                shouldShowEventPrice={!!isBizPlanFamily(plan)}
                 {...commonProps}
               />
             );

--- a/static/gsApp/views/amCheckout/steps/planSelect.tsx
+++ b/static/gsApp/views/amCheckout/steps/planSelect.tsx
@@ -7,7 +7,7 @@ import {Button} from 'sentry/components/core/button';
 import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
 import PanelFooter from 'sentry/components/panels/panelFooter';
-import {IconLightning, IconWarning} from 'sentry/icons';
+import {IconGroup, IconLightning, IconUser, IconWarning} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import getDaysSinceDate from 'sentry/utils/getDaysSinceDate';
@@ -186,18 +186,18 @@ function PlanSelect({
         if (i > 0) {
           const nextPlan = planOptions[i - 1];
           if (nextPlan) {
-            acc[nextPlan.id] = plan.name;
+            acc[nextPlan.id] = plan;
           }
         }
         return acc;
       },
-      {} as Record<string, string>
+      {} as Record<string, Plan>
     );
     return (
       <StyledPanelBody data-test-id="body-choose-your-plan">
         {planOptions.map(plan => {
           const isSelected = plan.id === formData.plan;
-          const priorPlanName = planToPriorPlan[plan.id];
+          const priorPlan = planToPriorPlan[plan.id];
 
           // calculate the price with discount
           const cents =
@@ -227,6 +227,14 @@ function PlanSelect({
             planContent.features.deactivated_member_header = t('Unlimited members');
           }
 
+          const planIcon = isBizPlanFamily(plan) ? (
+            <IconLightning />
+          ) : isTeamPlanFamily(plan) ? (
+            <IconGroup />
+          ) : (
+            <IconUser />
+          );
+
           const commonProps = {
             plan,
             isSelected,
@@ -245,8 +253,8 @@ function PlanSelect({
             return (
               <PlanSelectCard
                 key={plan.id}
-                planIcon={<IconLightning />}
-                priorPlanName={priorPlanName}
+                planIcon={planIcon}
+                priorPlan={priorPlan}
                 shouldShowEventPrice={isBizPlanFamily(plan)}
                 {...commonProps}
               />
@@ -394,5 +402,6 @@ const FooterWarningWrapper = styled('div')`
 const StyledPanelBody = styled(PanelBody)`
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  padding: ${space(2)};
   gap: ${space(2)};
 `;

--- a/static/gsApp/views/amCheckout/steps/planSelect.tsx
+++ b/static/gsApp/views/amCheckout/steps/planSelect.tsx
@@ -194,7 +194,7 @@ function PlanSelect({
       {} as Record<string, Plan>
     );
     return (
-      <StyledPanelBody data-test-id="body-choose-your-plan">
+      <PanelBody data-test-id="body-choose-your-plan">
         {planOptions.map(plan => {
           const isSelected = plan.id === formData.plan;
           const priorPlan = planToPriorPlan[plan.id];
@@ -228,7 +228,7 @@ function PlanSelect({
           }
 
           const planIcon = isBizPlanFamily(plan) ? (
-            <IconLightning />
+            <IconLightning /> // TODO(checkout v3): replace with building icon
           ) : isTeamPlanFamily(plan) ? (
             <IconGroup />
           ) : (
@@ -275,7 +275,7 @@ function PlanSelect({
             />
           );
         })}
-      </StyledPanelBody>
+      </PanelBody>
     );
   };
 
@@ -396,12 +396,4 @@ const FooterWarningWrapper = styled('div')`
   display: flex;
   align-items: center;
   gap: ${space(1)};
-`;
-
-// TODO(ISABELLA): DELETE THIS
-const StyledPanelBody = styled(PanelBody)`
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-  padding: ${space(2)};
-  gap: ${space(2)};
 `;

--- a/static/gsApp/views/amCheckout/steps/planSelectCard.tsx
+++ b/static/gsApp/views/amCheckout/steps/planSelectCard.tsx
@@ -130,8 +130,8 @@ function PlanSelectCard({
         <Description isSelected={isSelected}>{description}</Description>
       </div>
       <div>
-        <Price>{price === 'Free' ? price : `$${price}`}</Price>
-        {price !== 'Free' && <BillingInterval>{`/${billingInterval}`}</BillingInterval>}
+        <Price>{`$${price}`}</Price>
+        <BillingInterval>{`/${billingInterval}`}</BillingInterval>
       </div>
       <Separator />
       <FeatureList>

--- a/static/gsApp/views/amCheckout/steps/planSelectCard.tsx
+++ b/static/gsApp/views/amCheckout/steps/planSelectCard.tsx
@@ -1,0 +1,292 @@
+import {Fragment} from 'react';
+import {useTheme} from '@emotion/react';
+import styled from '@emotion/styled';
+
+import {Tag} from 'sentry/components/core/badge/tag';
+import {Flex} from 'sentry/components/core/layout';
+import {Radio} from 'sentry/components/core/radio';
+import {Tooltip} from 'sentry/components/core/tooltip';
+import {IconCheckmark, IconInfo, IconLightning} from 'sentry/icons';
+import {t, tct} from 'sentry/locale';
+import {DataCategory} from 'sentry/types/core';
+import type {Color} from 'sentry/utils/theme';
+
+import {PAYG_BUSINESS_DEFAULT, PAYG_TEAM_DEFAULT} from 'getsentry/constants';
+import {OnDemandBudgetMode} from 'getsentry/types';
+import {isBizPlanFamily} from 'getsentry/utils/billing';
+import {getPlanCategoryName} from 'getsentry/utils/dataCategory';
+import MoreFeaturesLink from 'getsentry/views/amCheckout/moreFeaturesLink';
+import type {
+  PlanSelectRowProps,
+  PlanUpdateData,
+} from 'getsentry/views/amCheckout/steps/planSelectRow';
+import {displayUnitPrice, getShortInterval} from 'getsentry/views/amCheckout/utils';
+
+function PlanSelectCard({
+  plan,
+  isSelected,
+  onUpdate,
+  planValue,
+  planName,
+  planContent,
+  price,
+  highlightedFeatures,
+  badge,
+  shouldShowDefaultPayAsYouGo = false,
+  planIcon,
+  shouldShowEventPrice = false,
+  priorPlanName,
+}: Omit<
+  PlanSelectRowProps,
+  'isFeaturesCheckmarked' | 'discountInfo' | 'planWarning' | 'priceHeader'
+> & {
+  planIcon: React.ReactNode;
+  priorPlanName?: string;
+}) {
+  const theme = useTheme();
+
+  const billingInterval = getShortInterval(plan.billingInterval);
+  const {features, description, hasMoreLink} = planContent;
+
+  const describeId = `plan-details-${plan.id}`;
+  const errorsStartingPrice = shouldShowEventPrice
+    ? plan.planCategories.errors
+      ? plan.planCategories.errors[1]?.onDemandPrice
+      : null
+    : null;
+  const spansStartingPrice = shouldShowEventPrice
+    ? plan.planCategories.spans
+      ? plan.planCategories.spans[1]?.onDemandPrice
+      : null
+    : null;
+  const showEventPriceWarning = errorsStartingPrice && spansStartingPrice;
+
+  const onPlanSelect = () => {
+    const data: PlanUpdateData = {plan: plan.id};
+    if (shouldShowDefaultPayAsYouGo) {
+      data.onDemandMaxSpend = isBizPlanFamily(plan)
+        ? PAYG_BUSINESS_DEFAULT
+        : PAYG_TEAM_DEFAULT;
+      data.onDemandBudget = {
+        budgetMode: OnDemandBudgetMode.SHARED,
+        sharedMaxBudget: data.onDemandMaxSpend,
+      };
+    }
+    onUpdate(data);
+  };
+
+  return (
+    <PlanOption isSelected={isSelected} onClick={onPlanSelect}>
+      <Row>
+        <PlanIconContainer>
+          {planIcon}
+          {badge}
+        </PlanIconContainer>
+        <StyledRadio
+          readOnly
+          id={plan.id}
+          value={planValue}
+          checked={isSelected}
+          onClick={onPlanSelect}
+        />
+      </Row>
+      <div>
+        <Title>{planName}</Title>
+        <Description id={describeId} isSelected={isSelected}>
+          {description}
+        </Description>
+      </div>
+      <div>
+        <Price>{price === 'Free' ? price : `$${price}`}</Price>
+        {price !== 'Free' && <BillingInterval>{`/${billingInterval}`}</BillingInterval>}
+      </div>
+      <Separator />
+      <FeatureList>
+        {priorPlanName && (
+          <PriorPlanItem>
+            {tct('Everything in [priorPlanName], plus:', {
+              priorPlanName,
+            })}
+          </PriorPlanItem>
+        )}
+        {features && highlightedFeatures ? (
+          <Fragment>
+            {Object.entries(features)
+              .filter(([featureId, _]) => highlightedFeatures.includes(featureId))
+              .map(([featureId, feature]) => (
+                <FeatureItem key={featureId}>
+                  <FeatureIconContainer>
+                    <IconLightning size="sm" />
+                  </FeatureIconContainer>
+                  {
+                    // Only shows hovercard when one feature was highlighted
+                    highlightedFeatures.length === 1 ? (
+                      <Fragment>
+                        <strong>{feature}</strong>
+                        <Tag>{t('Looking for this?')}</Tag>
+                      </Fragment>
+                    ) : (
+                      <b>{feature}</b>
+                    )
+                  }
+                </FeatureItem>
+              ))}
+            {Object.entries(features)
+              .filter(([featureId, _]) => !highlightedFeatures.includes(featureId))
+              .map(([featureId, feature]) => (
+                <FeatureItem key={featureId}>
+                  <FeatureIconContainer>
+                    <IconCheckmark size="sm" color={theme.activeText as Color} />
+                  </FeatureIconContainer>
+                  {feature}
+                </FeatureItem>
+              ))}
+            {hasMoreLink && (
+              <MoreFeaturesLink
+                color={theme.activeText as Color}
+                iconSize="sm"
+                isNewCheckout
+              />
+            )}
+          </Fragment>
+        ) : (
+          <Fragment>
+            {Object.entries(features).map(([featureId, feature]) => (
+              <FeatureItem key={featureId}>
+                <FeatureIconContainer>
+                  <IconCheckmark size="sm" />
+                </FeatureIconContainer>
+                {feature}
+              </FeatureItem>
+            ))}
+            {hasMoreLink && <MoreFeaturesLink iconSize="sm" isNewCheckout />}
+          </Fragment>
+        )}
+      </FeatureList>
+      {showEventPriceWarning && (
+        <EventPriceWarning>
+          <IconInfo size="xs" />
+          <Tooltip
+            title={tct(
+              'Errors start at [errorsStartingPrice]/error and spans start at [spansStartingPrice]/span.',
+              {
+                errorsStartingPrice: displayUnitPrice({cents: errorsStartingPrice}),
+                spansStartingPrice: displayUnitPrice({cents: spansStartingPrice}),
+              }
+            )}
+          >
+            {/* TODO(checkout v3): verify tooltip copy */}
+            {tct('Excess usage for [errors] and [spans] costs more on [planName]', {
+              errors: getPlanCategoryName({
+                plan,
+                category: DataCategory.ERRORS,
+                title: true,
+              }),
+              spans: getPlanCategoryName({
+                plan,
+                category: DataCategory.SPANS,
+                title: true,
+              }),
+              planName,
+            })}
+          </Tooltip>
+        </EventPriceWarning>
+      )}
+    </PlanOption>
+  );
+}
+
+export default PlanSelectCard;
+
+const PlanOption = styled(Flex)<{isSelected?: boolean}>`
+  padding: ${p => p.theme.space['2xl']};
+  gap: ${p => p.theme.space.md};
+  flex-direction: column;
+  background: ${p => (p.isSelected ? `${p.theme.active}05` : p.theme.background)};
+  color: ${p => (p.isSelected ? p.theme.activeText : p.theme.textColor)};
+  border-radius: ${p => p.theme.borderRadius};
+  border: 1px solid ${p => (p.isSelected ? p.theme.active : p.theme.border)};
+  cursor: pointer;
+`;
+
+const Row = styled('div')`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const PlanIconContainer = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${p => p.theme.space.xs};
+`;
+
+const Title = styled('div')`
+  font-size: ${p => p.theme.fontSize.lg};
+  font-weight: ${p => p.theme.fontWeight.bold};
+`;
+
+const Description = styled('div')<{isSelected?: boolean}>`
+  color: ${p => (p.isSelected ? p.theme.activeText : p.theme.subText)};
+`;
+
+const Price = styled('span')`
+  font-size: ${p => p.theme.fontSize['2xl']};
+  font-weight: ${p => p.theme.fontWeight.bold};
+`;
+
+const BillingInterval = styled('span')`
+  font-size: ${p => p.theme.fontSize.lg};
+`;
+
+const Separator = styled('div')`
+  border-top: 1px solid ${p => p.theme.innerBorder};
+  margin: 0;
+`;
+
+const PriorPlanItem = styled('div')`
+  color: ${p => p.theme.activeText};
+`;
+
+const FeatureItem = styled('div')`
+  display: grid;
+  grid-template-columns: min-content 1fr;
+  align-items: start;
+  color: ${p => p.theme.textColor};
+`;
+
+const FeatureIconContainer = styled('div')`
+  margin-right: ${p => p.theme.space.md};
+  display: flex;
+  align-items: center;
+`;
+
+const StyledRadio = styled(Radio)`
+  background: ${p => p.theme.background};
+`;
+
+const EventPriceWarning = styled('div')`
+  display: flex;
+  align-items: center;
+  font-size: ${p => p.theme.fontSize.sm};
+  color: ${p => p.theme.subText};
+  gap: ${p => p.theme.space.md};
+  margin-top: ${p => p.theme.space['2xs']};
+
+  > span {
+    text-decoration: underline dotted;
+    line-height: normal;
+  }
+`;
+
+const FeatureList = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: ${p => p.theme.space.xs};
+
+  @media (max-width: ${p => p.theme.breakpoints.sm}) {
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: ${p => p.theme.space.md};
+  }
+`;

--- a/static/gsApp/views/amCheckout/steps/planSelectCard.tsx
+++ b/static/gsApp/views/amCheckout/steps/planSelectCard.tsx
@@ -15,7 +15,7 @@ import type {Color} from 'sentry/utils/theme';
 
 import {PAYG_BUSINESS_DEFAULT, PAYG_TEAM_DEFAULT} from 'getsentry/constants';
 import {OnDemandBudgetMode, type Plan} from 'getsentry/types';
-import {isBizPlanFamily, isDeveloperPlan} from 'getsentry/utils/billing';
+import {isBizPlanFamily} from 'getsentry/utils/billing';
 import {getSingularCategoryName, listDisplayNames} from 'getsentry/utils/dataCategory';
 import MoreFeaturesLink from 'getsentry/views/amCheckout/moreFeaturesLink';
 import type {
@@ -51,7 +51,7 @@ function PlanSelectCard({
   const {features, description, hasMoreLink} = planContent;
 
   const perUnitPriceDiffs: Partial<Record<DataCategory, number>> = {};
-  if (shouldShowEventPrice && priorPlan && !isDeveloperPlan(priorPlan)) {
+  if (shouldShowEventPrice && priorPlan) {
     Object.entries(plan.planCategories).forEach(([category, eventBuckets]) => {
       const priorPlanEventBuckets = priorPlan.planCategories[category as DataCategory];
       const currentStartingPrice = eventBuckets[1]?.onDemandPrice ?? 0;

--- a/static/gsApp/views/amCheckout/steps/planSelectRow.tsx
+++ b/static/gsApp/views/amCheckout/steps/planSelectRow.tsx
@@ -26,15 +26,15 @@ import {
   getShortInterval,
 } from 'getsentry/views/amCheckout/utils';
 
-type UpdateData = {
+export type PlanUpdateData = {
   plan: string;
   onDemandBudget?: SharedOnDemandBudget;
   onDemandMaxSpend?: number;
 };
 
-type Props = {
+export type PlanSelectRowProps = {
   isSelected: boolean;
-  onUpdate: (data: UpdateData) => void;
+  onUpdate: (data: PlanUpdateData) => void;
   plan: Plan;
   planContent: PlanContent;
   planName: string;
@@ -79,7 +79,7 @@ function PlanSelectRow({
   badge,
   shouldShowDefaultPayAsYouGo = false,
   shouldShowEventPrice = false,
-}: Props) {
+}: PlanSelectRowProps) {
   const billingInterval = getShortInterval(plan.billingInterval);
   const {features, description, hasMoreLink} = planContent;
 
@@ -113,7 +113,7 @@ function PlanSelectRow({
               value={planValue}
               checked={isSelected}
               onClick={() => {
-                const data: UpdateData = {plan: plan.id};
+                const data: PlanUpdateData = {plan: plan.id};
                 if (shouldShowDefaultPayAsYouGo) {
                   data.onDemandMaxSpend = isBizPlanFamily(plan)
                     ? PAYG_BUSINESS_DEFAULT

--- a/static/gsApp/views/amCheckout/steps/planSelectRow.tsx
+++ b/static/gsApp/views/amCheckout/steps/planSelectRow.tsx
@@ -41,6 +41,14 @@ export type PlanSelectRowProps = {
   planValue: string;
   price: string;
   priceHeader: React.ReactNode;
+  /**
+   * Flag to show default pay as you go values
+   */
+  shouldShowDefaultPayAsYouGo: boolean;
+  /**
+   * Flag to show event price tags or warnings
+   */
+  shouldShowEventPrice: boolean;
   badge?: React.ReactNode;
   discountInfo?: Promotion['discountInfo'];
   highlightedFeatures?: string[];
@@ -53,14 +61,6 @@ export type PlanSelectRowProps = {
    * Optional warning at the bottom of the row
    */
   planWarning?: React.ReactNode;
-  /**
-   * Optional flag to show default pay as you go values
-   */
-  shouldShowDefaultPayAsYouGo?: boolean;
-  /**
-   * Optional flag to show event price tags
-   */
-  shouldShowEventPrice?: boolean;
 };
 
 function PlanSelectRow({


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/BIL-1204/update-individual-plan-select-row-styling-and-copy
I made an entirely new component instead of shoving the logic into `planSelectRow` since there were substantial changes + "row" doesn't describe it so well anymore :)

NOTE: 
- screenshots are from when i tweaked styling in `planSelect` just for the screenshots, the layout of the cards within the plan step will be handled in future PR
- copy to be finalized
- business icon added here https://github.com/getsentry/sentry/pull/97717
- free plan being surfaced to be handled in future PR

<img width="795" height="457" alt="Screenshot 2025-08-13 at 12 29 10 PM" src="https://github.com/user-attachments/assets/035ade47-828b-452e-9650-5123e0f4feb1" />
<img width="598" height="548" alt="Screenshot 2025-08-13 at 12 29 03 PM" src="https://github.com/user-attachments/assets/5112c56a-ecc8-465c-a8b4-81047c3ba7cc" />
