### PR TITLE
feat(otlp): Allow searching trace waterfall by span name

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeTestUtils.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeTestUtils.tsx
@@ -77,6 +77,7 @@ export function makeEAPSpan(
     event_id: overrides.event_id ?? uuid4(),
     op: 'span.op',
     description: 'span.description',
+    name: 'span.name',
     start_timestamp: 0,
     end_timestamp: 10,
     is_transaction: false,

--- a/static/app/views/performance/newTraceDetails/traceSearch/traceSearchEvaluator.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceSearch/traceSearchEvaluator.spec.tsx
@@ -493,59 +493,6 @@ describe('TraceSearchEvaluator', () => {
       expect(cb.mock.calls[0][0][0]).toEqual([{index: 1, value: tree.list[1]}]);
       expect(cb.mock.calls[0][0][2]).toBeNull();
     });
-
-    it('name filter', async () => {
-      const tree = TraceTree.FromTrace(
-        {
-          transactions: [makeTransaction({'transaction.op': 'operation'})],
-          orphan_errors: [],
-        },
-        {
-          meta: null,
-          replay: null,
-        }
-      );
-      TraceTree.FromSpans(
-        tree.root.children[0]!,
-        [makeSpan({name: 'authentication'} as any), makeSpan({name: 'database'} as any)],
-        makeEventTransaction()
-      );
-
-      const cb = jest.fn();
-      search('name:authentication', tree, cb);
-      await waitFor(() => expect(cb).toHaveBeenCalled());
-      expect(cb.mock.calls[0][0][1].size).toBe(1);
-      expect(cb.mock.calls[0][0][0]).toEqual([{index: 1, value: tree.list[1]}]);
-      expect(cb.mock.calls[0][0][2]).toBeNull();
-    });
-
-    it('name free text search', async () => {
-      const tree = TraceTree.FromTrace(
-        {
-          transactions: [makeTransaction({'transaction.op': 'operation'})],
-          orphan_errors: [],
-        },
-        {
-          meta: null,
-          replay: null,
-        }
-      );
-      TraceTree.FromSpans(
-        tree.root.children[0]!,
-        [
-          makeSpan({name: 'user_authentication_service', op: 'http'} as any),
-          makeSpan({name: 'database_query', op: 'db'} as any),
-        ],
-        makeEventTransaction()
-      );
-
-      const cb = jest.fn();
-      search('authentication', tree, cb);
-      await waitFor(() => expect(cb).toHaveBeenCalled());
-      expect(cb.mock.calls[0][0][1].size).toBe(1);
-      expect(cb.mock.calls[0][0][0]).toEqual([{index: 1, value: tree.list[1]}]);
-      expect(cb.mock.calls[0][0][2]).toBeNull();
-    });
   });
 
   // TODO Abdullah Khan: Add eap span tests for self_time/exclusive_time

--- a/static/app/views/performance/newTraceDetails/traceSearch/traceSearchEvaluator.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceSearch/traceSearchEvaluator.spec.tsx
@@ -493,6 +493,59 @@ describe('TraceSearchEvaluator', () => {
       expect(cb.mock.calls[0][0][0]).toEqual([{index: 1, value: tree.list[1]}]);
       expect(cb.mock.calls[0][0][2]).toBeNull();
     });
+
+    it('name filter', async () => {
+      const tree = TraceTree.FromTrace(
+        {
+          transactions: [makeTransaction({'transaction.op': 'operation'})],
+          orphan_errors: [],
+        },
+        {
+          meta: null,
+          replay: null,
+        }
+      );
+      TraceTree.FromSpans(
+        tree.root.children[0]!,
+        [makeSpan({name: 'authentication'} as any), makeSpan({name: 'database'} as any)],
+        makeEventTransaction()
+      );
+
+      const cb = jest.fn();
+      search('name:authentication', tree, cb);
+      await waitFor(() => expect(cb).toHaveBeenCalled());
+      expect(cb.mock.calls[0][0][1].size).toBe(1);
+      expect(cb.mock.calls[0][0][0]).toEqual([{index: 1, value: tree.list[1]}]);
+      expect(cb.mock.calls[0][0][2]).toBeNull();
+    });
+
+    it('name free text search', async () => {
+      const tree = TraceTree.FromTrace(
+        {
+          transactions: [makeTransaction({'transaction.op': 'operation'})],
+          orphan_errors: [],
+        },
+        {
+          meta: null,
+          replay: null,
+        }
+      );
+      TraceTree.FromSpans(
+        tree.root.children[0]!,
+        [
+          makeSpan({name: 'user_authentication_service', op: 'http'} as any),
+          makeSpan({name: 'database_query', op: 'db'} as any),
+        ],
+        makeEventTransaction()
+      );
+
+      const cb = jest.fn();
+      search('authentication', tree, cb);
+      await waitFor(() => expect(cb).toHaveBeenCalled());
+      expect(cb.mock.calls[0][0][1].size).toBe(1);
+      expect(cb.mock.calls[0][0][0]).toEqual([{index: 1, value: tree.list[1]}]);
+      expect(cb.mock.calls[0][0][2]).toBeNull();
+    });
   });
 
   // TODO Abdullah Khan: Add eap span tests for self_time/exclusive_time
@@ -585,6 +638,60 @@ describe('TraceSearchEvaluator', () => {
 
       const cb = jest.fn();
       search('span.total_time:>0.5s', tree, cb);
+      await waitFor(() => expect(cb).toHaveBeenCalled());
+      expect(cb.mock.calls[0][0][1].size).toBe(1);
+      expect(cb.mock.calls[0][0][0]).toEqual([{index: 1, value: tree.list[1]}]);
+      expect(cb.mock.calls[0][0][2]).toBeNull();
+    });
+
+    it('name filter', async () => {
+      const tree = TraceTree.FromTrace(
+        [makeEAPSpan({name: 'authentication'}), makeEAPSpan({name: 'database'})],
+        {
+          meta: null,
+          replay: null,
+        }
+      );
+
+      const cb = jest.fn();
+      search('name:authentication', tree, cb);
+      await waitFor(() => expect(cb).toHaveBeenCalled());
+      expect(cb.mock.calls[0][0][1].size).toBe(1);
+      expect(cb.mock.calls[0][0][0]).toEqual([{index: 1, value: tree.list[1]}]);
+      expect(cb.mock.calls[0][0][2]).toBeNull();
+    });
+
+    it('name filter with prefix', async () => {
+      const tree = TraceTree.FromTrace(
+        [makeEAPSpan({name: 'authentication'}), makeEAPSpan({name: 'database'})],
+        {
+          meta: null,
+          replay: null,
+        }
+      );
+
+      const cb = jest.fn();
+      search('span.name:authentication', tree, cb);
+      await waitFor(() => expect(cb).toHaveBeenCalled());
+      expect(cb.mock.calls[0][0][1].size).toBe(1);
+      expect(cb.mock.calls[0][0][0]).toEqual([{index: 1, value: tree.list[1]}]);
+      expect(cb.mock.calls[0][0][2]).toBeNull();
+    });
+
+    it('name free text search', async () => {
+      const tree = TraceTree.FromTrace(
+        [
+          makeEAPSpan({name: 'user_authentication_service', op: 'http'}),
+          makeEAPSpan({name: 'database_query', op: 'db'}),
+        ],
+        {
+          meta: null,
+          replay: null,
+        }
+      );
+
+      const cb = jest.fn();
+      search('authentication', tree, cb);
       await waitFor(() => expect(cb).toHaveBeenCalled());
       expect(cb.mock.calls[0][0][1].size).toBe(1);
       expect(cb.mock.calls[0][0][0]).toEqual([{index: 1, value: tree.list[1]}]);

--- a/static/app/views/performance/newTraceDetails/traceSearch/traceSearchEvaluator.tsx
+++ b/static/app/views/performance/newTraceDetails/traceSearch/traceSearchEvaluator.tsx
@@ -604,6 +604,13 @@ function evaluateNodeFreeText(
     if (node.value.description?.includes(query)) {
       return true;
     }
+    if (
+      'name' in node.value &&
+      typeof node.value.name === 'string' &&
+      node.value.name.includes(query)
+    ) {
+      return true;
+    }
 
     const spanId = 'span_id' in node.value ? node.value.span_id : node.value.event_id;
     if (spanId && spanId === query) {
@@ -628,6 +635,13 @@ function evaluateNodeFreeText(
       return true;
     }
     if (node.value.description?.includes(query)) {
+      return true;
+    }
+    if (
+      'name' in node.value &&
+      typeof node.value.name === 'string' &&
+      node.value.name.includes(query)
+    ) {
       return true;
     }
   }

--- a/static/app/views/performance/newTraceDetails/traceSearch/traceTokenConverter.tsx
+++ b/static/app/views/performance/newTraceDetails/traceSearch/traceTokenConverter.tsx
@@ -76,8 +76,10 @@ const SPAN_DURATION_SYNTHETIC_KEYS: SpanKey[] = [
   'self_time',
 ];
 
-// Span OTel fields - fields that exist on OTel/EAP spans but may not be on legacy spans
-const SPAN_OTEL_FIELDS = ['name'];
+// New span keys that are available on Span-First SDK and OTLP SDK spans for
+// now. In the future we'll backfill the `name` key for all spans, and this can
+// be moved into `SPAN_TEXT_KEYS`
+const SPAN_FIRST_TEXT_KEYS = ['name'];
 
 // @TODO the current date parsing does not support timestamps, so we
 // exclude these keys for now and parse them as numeric keys
@@ -101,7 +103,7 @@ const TEXT_KEYS = new Set([
   ...SYNTHETIC_KEYS,
   ...withPrefixedPermutation('transaction', TRANSACTION_TEXT_KEYS),
   ...withPrefixedPermutation('span', SPAN_TEXT_KEYS),
-  ...withPrefixedPermutation('span', SPAN_OTEL_FIELDS),
+  ...withPrefixedPermutation('span', SPAN_FIRST_TEXT_KEYS),
 ]);
 const NUMERIC_KEYS = new Set([
   ...withPrefixedPermutation('transaction', TRANSACTION_NUMERIC_KEYS),

--- a/static/app/views/performance/newTraceDetails/traceSearch/traceTokenConverter.tsx
+++ b/static/app/views/performance/newTraceDetails/traceSearch/traceTokenConverter.tsx
@@ -76,6 +76,9 @@ const SPAN_DURATION_SYNTHETIC_KEYS: SpanKey[] = [
   'self_time',
 ];
 
+// Span OTel fields - fields that exist on OTel/EAP spans but may not be on legacy spans
+const SPAN_OTEL_FIELDS = ['name'];
+
 // @TODO the current date parsing does not support timestamps, so we
 // exclude these keys for now and parse them as numeric keys
 const SPAN_DATE_KEYS: SpanKey[] = [
@@ -98,6 +101,7 @@ const TEXT_KEYS = new Set([
   ...SYNTHETIC_KEYS,
   ...withPrefixedPermutation('transaction', TRANSACTION_TEXT_KEYS),
   ...withPrefixedPermutation('span', SPAN_TEXT_KEYS),
+  ...withPrefixedPermutation('span', SPAN_OTEL_FIELDS),
 ]);
 const NUMERIC_KEYS = new Set([
   ...withPrefixedPermutation('transaction', TRANSACTION_NUMERIC_KEYS),


### PR DESCRIPTION
Allow queries like `name:select` and `span.name:select`, which will search on `span.name` attribute, if possible. This is technically only relevant for OTel folks right now, but feature-flagging this seemed like it's not needed, since `span.name` isn't in autocomplete, or anywhere a user might accidentally spot it.
