### PR TITLE
ref(groupingInfo): Move contributing values/all values switch to section header

### DIFF
--- a/static/app/components/events/groupingInfo/groupingInfo.tsx
+++ b/static/app/components/events/groupingInfo/groupingInfo.tsx
@@ -92,9 +92,9 @@ export default function GroupingInfo({
           onChange={key => setShowNonContributing(key === 'all')}
         >
           <SegmentedControl.Item key="relevant">
-            {t('Contributing values')}
+            {t('Contributing Values')}
           </SegmentedControl.Item>
-          <SegmentedControl.Item key="all">{t('All values')}</SegmentedControl.Item>
+          <SegmentedControl.Item key="all">{t('All Values')}</SegmentedControl.Item>
         </SegmentedControl>
       </div>
       {isError ? <LoadingError message={t('Failed to fetch grouping info.')} /> : null}

--- a/static/app/components/events/groupingInfo/groupingInfo.tsx
+++ b/static/app/components/events/groupingInfo/groupingInfo.tsx
@@ -84,7 +84,14 @@ export default function GroupingInfo({
           </div>
         )}
       </ConfigHeader>
-      <div style={{display: 'flex', justifyContent: 'flex-end', width: '100%'}}>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'flex-start',
+          width: '100%',
+          paddingBottom: '20px',
+        }}
+      >
         <SegmentedControl
           aria-label={t('Filter by contribution')}
           size="xs"
@@ -119,7 +126,7 @@ const ConfigHeader = styled('div')`
   display: flex;
   justify-content: space-between;
   gap: ${space(1)};
-  margin-bottom: ${space(2)};
+  margin-bottom: ${space(0.25)};
 `;
 
 const VariantDivider = styled('hr')`

--- a/static/app/components/events/groupingInfo/groupingInfo.tsx
+++ b/static/app/components/events/groupingInfo/groupingInfo.tsx
@@ -1,6 +1,7 @@
 import {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 
+import {SegmentedControl} from 'sentry/components/core/segmentedControl';
 import {GroupInfoSummary} from 'sentry/components/events/groupingInfo/groupingSummary';
 import {useEventGroupingInfo} from 'sentry/components/events/groupingInfo/useEventGroupingInfo';
 import {FeatureFeedback} from 'sentry/components/featureFeedback';
@@ -83,6 +84,19 @@ export default function GroupingInfo({
           </div>
         )}
       </ConfigHeader>
+      <div style={{display: 'flex', justifyContent: 'flex-end', width: '100%'}}>
+        <SegmentedControl
+          aria-label={t('Filter by contribution')}
+          size="xs"
+          value={showNonContributing ? 'all' : 'relevant'}
+          onChange={key => setShowNonContributing(key === 'all')}
+        >
+          <SegmentedControl.Item key="relevant">
+            {t('Contributing values')}
+          </SegmentedControl.Item>
+          <SegmentedControl.Item key="all">{t('All values')}</SegmentedControl.Item>
+        </SegmentedControl>
+      </div>
       {isError ? <LoadingError message={t('Failed to fetch grouping info.')} /> : null}
       {isPending && !hasPerformanceGrouping ? <LoadingIndicator /> : null}
       {hasPerformanceGrouping || isSuccess

--- a/static/app/components/events/groupingInfo/groupingInfo.tsx
+++ b/static/app/components/events/groupingInfo/groupingInfo.tsx
@@ -9,7 +9,6 @@ import {FeatureFeedback} from 'sentry/components/featureFeedback';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
@@ -119,8 +118,8 @@ export default function GroupingInfo({
 const ConfigHeader = styled('div')`
   display: flex;
   justify-content: space-between;
-  gap: ${space(1)};
-  margin-bottom: ${space(0.25)};
+  gap: ${p => p.theme.space.md};
+  margin-bottom: ${p => p.theme.space['2xs']};
 `;
 
 const ToggleContainer = styled(Flex)`
@@ -129,6 +128,6 @@ const ToggleContainer = styled(Flex)`
 `;
 
 const VariantDivider = styled('hr')`
-  padding-top: ${space(1)};
+  padding-top: ${p => p.theme.space.md};
   border-top: 1px solid ${p => p.theme.border};
 `;

--- a/static/app/components/events/groupingInfo/groupingInfo.tsx
+++ b/static/app/components/events/groupingInfo/groupingInfo.tsx
@@ -106,7 +106,6 @@ export default function GroupingInfo({
                 event={event}
                 variant={variant}
                 showNonContributing={showNonContributing}
-                onShowNonContributingChange={setShowNonContributing}
               />
               {index < variants.length - 1 && <VariantDivider />}
             </Fragment>

--- a/static/app/components/events/groupingInfo/groupingInfo.tsx
+++ b/static/app/components/events/groupingInfo/groupingInfo.tsx
@@ -1,4 +1,4 @@
-import {Fragment} from 'react';
+import {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {GroupInfoSummary} from 'sentry/components/events/groupingInfo/groupingSummary';
@@ -27,6 +27,8 @@ export default function GroupingInfo({
   showGroupingConfig,
   group,
 }: GroupingSummaryProps) {
+  const [showNonContributing, setShowNonContributing] = useState(false);
+
   const hasStreamlinedUI = useHasStreamlinedUI();
 
   const {groupInfo, isPending, isError, isSuccess, hasPerformanceGrouping} =
@@ -86,7 +88,12 @@ export default function GroupingInfo({
       {hasPerformanceGrouping || isSuccess
         ? variants.map((variant, index) => (
             <Fragment key={variant.key}>
-              <GroupingVariant event={event} variant={variant} />
+              <GroupingVariant
+                event={event}
+                variant={variant}
+                showNonContributing={showNonContributing}
+                onShowNonContributingChange={setShowNonContributing}
+              />
               {index < variants.length - 1 && <VariantDivider />}
             </Fragment>
           ))

--- a/static/app/components/events/groupingInfo/groupingInfo.tsx
+++ b/static/app/components/events/groupingInfo/groupingInfo.tsx
@@ -23,11 +23,6 @@ interface GroupingSummaryProps {
   showGroupingConfig: boolean;
 }
 
-// Helper function to check if any variant has non-contributing components
-function hasNonContributingComponents(variants: any[]) {
-  return variants.some(variant => variant.hash === null);
-}
-
 export default function GroupingInfo({
   event,
   projectSlug,
@@ -90,21 +85,19 @@ export default function GroupingInfo({
           </div>
         )}
       </ConfigHeader>
-      {hasNonContributingComponents(variants) && (
-        <ToggleContainer>
-          <SegmentedControl
-            aria-label={t('Filter by contribution')}
-            size="xs"
-            value={showNonContributing ? 'all' : 'relevant'}
-            onChange={key => setShowNonContributing(key === 'all')}
-          >
-            <SegmentedControl.Item key="relevant">
-              {t('Contributing Values')}
-            </SegmentedControl.Item>
-            <SegmentedControl.Item key="all">{t('All Values')}</SegmentedControl.Item>
-          </SegmentedControl>
-        </ToggleContainer>
-      )}
+      <ToggleContainer>
+        <SegmentedControl
+          aria-label={t('Filter by contribution')}
+          size="xs"
+          value={showNonContributing ? 'all' : 'relevant'}
+          onChange={key => setShowNonContributing(key === 'all')}
+        >
+          <SegmentedControl.Item key="relevant">
+            {t('Contributing Values')}
+          </SegmentedControl.Item>
+          <SegmentedControl.Item key="all">{t('All Values')}</SegmentedControl.Item>
+        </SegmentedControl>
+      </ToggleContainer>
       {isError ? <LoadingError message={t('Failed to fetch grouping info.')} /> : null}
       {isPending && !hasPerformanceGrouping ? <LoadingIndicator /> : null}
       {hasPerformanceGrouping || isSuccess

--- a/static/app/components/events/groupingInfo/groupingInfo.tsx
+++ b/static/app/components/events/groupingInfo/groupingInfo.tsx
@@ -1,6 +1,7 @@
 import {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 
+import {Flex} from 'sentry/components/core/layout';
 import {SegmentedControl} from 'sentry/components/core/segmentedControl';
 import {GroupInfoSummary} from 'sentry/components/events/groupingInfo/groupingSummary';
 import {useEventGroupingInfo} from 'sentry/components/events/groupingInfo/useEventGroupingInfo';
@@ -20,6 +21,11 @@ interface GroupingSummaryProps {
   group: Group | undefined;
   projectSlug: string;
   showGroupingConfig: boolean;
+}
+
+// Helper function to check if any variant has non-contributing components
+function hasNonContributingComponents(variants: any[]) {
+  return variants.some(variant => variant.hash === null);
 }
 
 export default function GroupingInfo({
@@ -84,26 +90,21 @@ export default function GroupingInfo({
           </div>
         )}
       </ConfigHeader>
-      <div
-        style={{
-          display: 'flex',
-          justifyContent: 'flex-start',
-          width: '100%',
-          paddingBottom: '20px',
-        }}
-      >
-        <SegmentedControl
-          aria-label={t('Filter by contribution')}
-          size="xs"
-          value={showNonContributing ? 'all' : 'relevant'}
-          onChange={key => setShowNonContributing(key === 'all')}
-        >
-          <SegmentedControl.Item key="relevant">
-            {t('Contributing Values')}
-          </SegmentedControl.Item>
-          <SegmentedControl.Item key="all">{t('All Values')}</SegmentedControl.Item>
-        </SegmentedControl>
-      </div>
+      {hasNonContributingComponents(variants) && (
+        <ToggleContainer>
+          <SegmentedControl
+            aria-label={t('Filter by contribution')}
+            size="xs"
+            value={showNonContributing ? 'all' : 'relevant'}
+            onChange={key => setShowNonContributing(key === 'all')}
+          >
+            <SegmentedControl.Item key="relevant">
+              {t('Contributing Values')}
+            </SegmentedControl.Item>
+            <SegmentedControl.Item key="all">{t('All Values')}</SegmentedControl.Item>
+          </SegmentedControl>
+        </ToggleContainer>
+      )}
       {isError ? <LoadingError message={t('Failed to fetch grouping info.')} /> : null}
       {isPending && !hasPerformanceGrouping ? <LoadingIndicator /> : null}
       {hasPerformanceGrouping || isSuccess
@@ -127,6 +128,11 @@ const ConfigHeader = styled('div')`
   justify-content: space-between;
   gap: ${space(1)};
   margin-bottom: ${space(0.25)};
+`;
+
+const ToggleContainer = styled(Flex)`
+  justify-content: flex-start;
+  padding-bottom: ${p => p.theme.space.lg};
 `;
 
 const VariantDivider = styled('hr')`

--- a/static/app/components/events/groupingInfo/groupingVariant.spec.tsx
+++ b/static/app/components/events/groupingInfo/groupingVariant.spec.tsx
@@ -52,7 +52,13 @@ describe('Grouping Variant', () => {
   };
 
   it('renders the span hashes for performance issues from event data', () => {
-    render(<GroupingVariant variant={performanceIssueVariant} event={event} />);
+    render(
+      <GroupingVariant
+        variant={performanceIssueVariant}
+        event={event}
+        showNonContributing={false}
+      />
+    );
 
     expect(
       within(screen.getByText('Parent Span Hashes').closest('tr') as HTMLElement)
@@ -72,7 +78,13 @@ describe('Grouping Variant', () => {
   });
 
   it('renders grouping details for occurrence-backed performance issues', () => {
-    render(<GroupingVariant variant={performanceIssueVariant} event={occurrenceEvent} />);
+    render(
+      <GroupingVariant
+        variant={performanceIssueVariant}
+        event={occurrenceEvent}
+        showNonContributing={false}
+      />
+    );
 
     expect(
       within(screen.getByText('Parent Span Hashes').closest('tr') as HTMLElement)

--- a/static/app/components/events/groupingInfo/groupingVariant.tsx
+++ b/static/app/components/events/groupingInfo/groupingVariant.tsx
@@ -1,4 +1,3 @@
-import {useState} from 'react';
 import styled from '@emotion/styled';
 
 import {SegmentedControl} from 'sentry/components/core/segmentedControl';
@@ -23,6 +22,8 @@ import {hasNonContributingComponent} from './utils';
 
 interface GroupingVariantProps {
   event: Event;
+  onShowNonContributingChange: (show: boolean) => void;
+  showNonContributing: boolean;
   variant: EventGroupVariant;
 }
 
@@ -69,9 +70,14 @@ function addFingerprintInfo(data: VariantData, variant: EventGroupVariant) {
   }
 }
 
-function GroupingVariant({event, variant}: GroupingVariantProps) {
-  const [showNonContributing, setShowNonContributing] = useState(false);
 
+
+function GroupingVariant({
+  event,
+  variant,
+  showNonContributing,
+  onShowNonContributingChange,
+}: GroupingVariantProps) {
   const getVariantData = (): [VariantData, EventGroupComponent | undefined] => {
     const data: VariantData = [];
     let component: EventGroupComponent | undefined;
@@ -163,7 +169,7 @@ function GroupingVariant({event, variant}: GroupingVariantProps) {
         aria-label={t('Filter by contribution')}
         size="xs"
         value={showNonContributing ? 'all' : 'relevant'}
-        onChange={key => setShowNonContributing(key === 'all')}
+        onChange={key => onShowNonContributingChange(key === 'all')}
       >
         <SegmentedControl.Item key="relevant">
           {t('Contributing values')}

--- a/static/app/components/events/groupingInfo/groupingVariant.tsx
+++ b/static/app/components/events/groupingInfo/groupingVariant.tsx
@@ -68,13 +68,7 @@ function addFingerprintInfo(data: VariantData, variant: EventGroupVariant) {
   }
 }
 
-
-
-function GroupingVariant({
-  event,
-  variant,
-  showNonContributing,
-}: GroupingVariantProps) {
+function GroupingVariant({event, variant, showNonContributing}: GroupingVariantProps) {
   const getVariantData = (): [VariantData, EventGroupComponent | undefined] => {
     const data: VariantData = [];
     let component: EventGroupComponent | undefined;

--- a/static/app/components/events/groupingInfo/groupingVariant.tsx
+++ b/static/app/components/events/groupingInfo/groupingVariant.tsx
@@ -20,7 +20,6 @@ import GroupingComponent from './groupingComponent';
 
 interface GroupingVariantProps {
   event: Event;
-  onShowNonContributingChange: (show: boolean) => void;
   showNonContributing: boolean;
   variant: EventGroupVariant;
 }

--- a/static/app/components/events/groupingInfo/groupingVariant.tsx
+++ b/static/app/components/events/groupingInfo/groupingVariant.tsx
@@ -1,6 +1,5 @@
 import styled from '@emotion/styled';
 
-import {SegmentedControl} from 'sentry/components/core/segmentedControl';
 import {Tooltip} from 'sentry/components/core/tooltip';
 import KeyValueList from 'sentry/components/events/interfaces/keyValueList';
 import type {RawSpanType} from 'sentry/components/events/interfaces/spans/types';
@@ -18,7 +17,6 @@ import {EventGroupVariantType} from 'sentry/types/event';
 import {capitalize} from 'sentry/utils/string/capitalize';
 
 import GroupingComponent from './groupingComponent';
-import {hasNonContributingComponent} from './utils';
 
 interface GroupingVariantProps {
   event: Event;
@@ -76,7 +74,6 @@ function GroupingVariant({
   event,
   variant,
   showNonContributing,
-  onShowNonContributingChange,
 }: GroupingVariantProps) {
   const getVariantData = (): [VariantData, EventGroupComponent | undefined] => {
     const data: VariantData = [];
@@ -163,22 +160,6 @@ function GroupingVariant({
     return [data, component];
   };
 
-  const renderContributionToggle = () => {
-    return (
-      <SegmentedControl
-        aria-label={t('Filter by contribution')}
-        size="xs"
-        value={showNonContributing ? 'all' : 'relevant'}
-        onChange={key => onShowNonContributingChange(key === 'all')}
-      >
-        <SegmentedControl.Item key="relevant">
-          {t('Contributing values')}
-        </SegmentedControl.Item>
-        <SegmentedControl.Item key="all">{t('All values')}</SegmentedControl.Item>
-      </SegmentedControl>
-    );
-  };
-
   const renderTitle = () => {
     const isContributing = variant.hash !== null;
 
@@ -208,13 +189,10 @@ function GroupingVariant({
     );
   };
 
-  const [data, component] = getVariantData();
+  const [data] = getVariantData();
   return (
     <VariantWrapper>
-      <Header>
-        {renderTitle()}
-        {hasNonContributingComponent(component) && renderContributionToggle()}
-      </Header>
+      <Header>{renderTitle()}</Header>
 
       <KeyValueList
         data={data.map(d => ({

--- a/static/app/components/events/groupingInfo/utils.tsx
+++ b/static/app/components/events/groupingInfo/utils.tsx
@@ -1,22 +1,5 @@
 import type {EventGroupComponent} from 'sentry/types/event';
 
-export function hasNonContributingComponent(component: EventGroupComponent | undefined) {
-  if (component === undefined) {
-    return false;
-  }
-
-  if (!component.contributes) {
-    return true;
-  }
-
-  for (const value of component.values) {
-    if (value && typeof value === 'object' && hasNonContributingComponent(value)) {
-      return true;
-    }
-  }
-  return false;
-}
-
 export function shouldInlineComponentValue(component: EventGroupComponent) {
   return (component.values as EventGroupComponent[]).every(
     value => !value || typeof value !== 'object'


### PR DESCRIPTION
For issue #97590.

Moves contributing values/all values toggle to section header because having it for each variant is redundant. 

<img width="720" height="607" alt="image" src="https://github.com/user-attachments/assets/9bd6deb4-3ae0-4fde-8e28-81f8c04fea5e" />

