### PR TITLE
fix(replay): add space in error breadcrumb and capitalize level 

### DIFF
--- a/static/app/components/replays/breadcrumbs/breadcrumbIssueLink.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbIssueLink.tsx
@@ -3,7 +3,6 @@ import styled from '@emotion/styled';
 import {ProjectAvatar} from 'sentry/components/core/avatar/projectAvatar';
 import {Link} from 'sentry/components/core/link';
 import {useReplayGroupContext} from 'sentry/components/replays/replayGroupContext';
-import {space} from 'sentry/styles/space';
 import type {ErrorFrame, FeedbackFrame, ReplayFrame} from 'sentry/utils/replays/types';
 import {isErrorFrame, isFeedbackFrame} from 'sentry/utils/replays/types';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -63,7 +62,8 @@ function CrumbErrorIssue({frame}: {frame: FeedbackFrame | ErrorFrame}) {
 const CrumbIssueWrapper = styled('div')`
   display: flex;
   align-items: center;
-  gap: ${space(0.5)};
+  gap: ${p => p.theme.space.xs};
   font-size: ${p => p.theme.fontSize.sm};
   color: ${p => p.theme.subText};
+  margin-top: ${p => p.theme.space.xs};
 `;

--- a/static/app/components/replays/breadcrumbs/errorTitle.tsx
+++ b/static/app/components/replays/breadcrumbs/errorTitle.tsx
@@ -1,4 +1,5 @@
 import {Fragment} from 'react';
+import capitalize from 'lodash/capitalize';
 
 import {Link} from 'sentry/components/core/link';
 import {useReplayGroupContext} from 'sentry/components/replays/replayGroupContext';
@@ -14,9 +15,11 @@ export default function CrumbErrorTitle({frame}: {frame: ErrorFrame}) {
     return <Fragment>Error: This Event</Fragment>;
   }
 
+  const level = frame.data.level || 'error';
+
   return (
     <Fragment>
-      {frame.data.level || 'Error'}:{' '}
+      {capitalize(level)}:{' '}
       <Link
         to={`/organizations/${organization.slug}/issues/${frame.data.groupId}/events/${frame.data.eventId}/#replay`}
       >


### PR DESCRIPTION
before:
<img width="639" height="261" alt="SCR-20250812-mpoc" src="https://github.com/user-attachments/assets/6e6e0aed-ff24-4295-892d-6492fc477aff" />

after:
<img width="607" height="356" alt="SCR-20250812-mpmk" src="https://github.com/user-attachments/assets/4896425d-c14b-4c20-a1c1-ad05f0ed5a9a" />

