### PR TITLE
feat(dashboard-limits): Disable Add to Dashboard flows if at max

### DIFF
--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useEffect, useMemo, useState} from 'react';
+import {Fragment, useCallback, useEffect, useState, type ReactNode} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
@@ -27,6 +27,7 @@ import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import useApi from 'sentry/utils/useApi';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useParams} from 'sentry/utils/useParams';
+import {DashboardCreateLimitWrapper} from 'sentry/views/dashboards/createLimitWrapper';
 import {IndexedEventsSelectionAlert} from 'sentry/views/dashboards/indexedEventsSelectionAlert';
 import type {
   DashboardDetails,
@@ -68,7 +69,6 @@ export type AddToDashboardModalProps = {
   selection: PageFilters;
   widget: Widget;
   actions?: AddToDashboardModalActions[];
-  allowCreateNewDashboard?: boolean;
   source?: DashboardWidgetSource;
 };
 
@@ -101,7 +101,6 @@ function AddToDashboardModal({
   selection,
   widget,
   actions = DEFAULT_ACTIONS,
-  allowCreateNewDashboard = true,
   source,
 }: Props) {
   const api = useApi();
@@ -249,34 +248,44 @@ function AddToDashboardModal({
 
   const canSubmit = selectedDashboardId !== null;
 
-  const options = useMemo(() => {
-    if (dashboards === null) {
-      return null;
-    }
+  const getOptions = useCallback(
+    (
+      hasReachedDashboardLimit: boolean,
+      isLoading: boolean,
+      limitMessage: ReactNode | null
+    ) => {
+      if (dashboards === null) {
+        return null;
+      }
 
-    return [
-      allowCreateNewDashboard && {
-        label: t('+ Create New Dashboard'),
-        value: 'new',
-      },
-      ...dashboards
-        .filter(dashboard =>
-          // if adding from a dashboard, currentDashboardId will be set and we'll remove it from the list of options
-          currentDashboardId ? dashboard.id !== currentDashboardId : true
-        )
-        .map(({title, id, widgetDisplay}) => ({
-          label: title,
-          value: id,
-          disabled: widgetDisplay.length >= MAX_WIDGETS,
-          tooltip:
-            widgetDisplay.length >= MAX_WIDGETS &&
-            tct('Max widgets ([maxWidgets]) per dashboard reached.', {
-              maxWidgets: MAX_WIDGETS,
-            }),
+      return [
+        {
+          label: t('+ Create New Dashboard'),
+          value: 'new',
+          disabled: hasReachedDashboardLimit || isLoading,
+          tooltip: hasReachedDashboardLimit ? limitMessage : undefined,
           tooltipOptions: {position: 'right'},
-        })),
-    ].filter(Boolean) as Array<SelectValue<string>>;
-  }, [allowCreateNewDashboard, currentDashboardId, dashboards]);
+        },
+        ...dashboards
+          .filter(dashboard =>
+            // if adding from a dashboard, currentDashboardId will be set and we'll remove it from the list of options
+            currentDashboardId ? dashboard.id !== currentDashboardId : true
+          )
+          .map(({title, id, widgetDisplay}) => ({
+            label: title,
+            value: id,
+            disabled: widgetDisplay.length >= MAX_WIDGETS,
+            tooltip:
+              widgetDisplay.length >= MAX_WIDGETS &&
+              tct('Max widgets ([maxWidgets]) per dashboard reached.', {
+                maxWidgets: MAX_WIDGETS,
+              }),
+            tooltipOptions: {position: 'right'},
+          })),
+      ].filter(Boolean) as Array<SelectValue<string>>;
+    },
+    [currentDashboardId, dashboards]
+  );
 
   const widgetLegendState = new WidgetLegendSelectionState({
     location,
@@ -308,20 +317,24 @@ function AddToDashboardModal({
       </Header>
       <Body>
         <Wrapper>
-          <Select
-            disabled={dashboards === null}
-            menuPlacement="auto"
-            name="dashboard"
-            placeholder={t('Select Dashboard')}
-            value={selectedDashboardId}
-            options={options}
-            onChange={(option: SelectValue<string>) => {
-              if (option.disabled) {
-                return;
-              }
-              setSelectedDashboardId(option.value);
-            }}
-          />
+          <DashboardCreateLimitWrapper>
+            {({hasReachedDashboardLimit, isLoading, limitMessage}) => (
+              <Select
+                disabled={dashboards === null}
+                menuPlacement="auto"
+                name="dashboard"
+                placeholder={t('Select Dashboard')}
+                value={selectedDashboardId}
+                options={getOptions(hasReachedDashboardLimit, isLoading, limitMessage)}
+                onChange={(option: SelectValue<string>) => {
+                  if (option.disabled) {
+                    return;
+                  }
+                  setSelectedDashboardId(option.value);
+                }}
+              />
+            )}
+          </DashboardCreateLimitWrapper>
         </Wrapper>
         <Wrapper>
           <SectionHeader title={t('Widget Name')} optional />

--- a/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
@@ -418,7 +418,6 @@ export function getMenuOptions(
             layout: undefined,
           },
           actions: ['add-and-stay-on-current-page', 'open-in-widget-builder'],
-          allowCreateNewDashboard: true,
           source: DashboardWidgetSource.DASHBOARDS,
         });
       },


### PR DESCRIPTION
Disables the "Create New Dashboard" option in Add to Dashboard flows if the limit has been reached (indicated by the `DashboardCreateLimitWrapper`

If we've hit the limit, disable the option and display the tooltip to the right of the text. Note, the message in the following screenshot is a forced example on the `sentry` org, that has no limit (which is why it says -1).

<img width="986" height="318" alt="Screenshot 2025-08-12 at 5 40 03 PM" src="https://github.com/user-attachments/assets/399c4e8d-f5f0-4f74-a5d5-ce873acc5b48" />
