### PR TITLE
feat(upsampling) - Error Upsampling on Metric Alerts under ACI

### DIFF
--- a/src/sentry/snuba/snuba_query_validator.py
+++ b/src/sentry/snuba/snuba_query_validator.py
@@ -108,6 +108,18 @@ class SnubaQueryValidator(BaseDataSourceValidator[QuerySubscription]):
         # TODO: only accept time_window in seconds once AlertRuleSerializer is removed
         self.time_window_seconds = timeWindowSeconds
 
+    def validate_aggregate(self, aggregate: str) -> str:
+        """
+        Reject upsampled_count() as user input. This function is reserved for internal use
+        and will be applied automatically when appropriate. Users should specify count().
+        """
+        if aggregate == "upsampled_count()":
+            raise serializers.ValidationError(
+                "upsampled_count() is not allowed as user input. Use count() instead - "
+                "it will be automatically converted to upsampled_count() when appropriate."
+            )
+        return aggregate
+
     def validate_query_type(self, value: int) -> SnubaQuery.Type:
         try:
             return SnubaQuery.Type(value)

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
@@ -652,6 +652,18 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
             "workflowIds": [self.connected_workflow.id],
         }
 
+    def test_reject_upsampled_count_aggregate(self) -> None:
+        """Users should not be able to submit upsampled_count() directly in ACI."""
+        data = {**self.valid_data}
+        data["dataSource"] = {**self.valid_data["dataSource"], "aggregate": "upsampled_count()"}
+
+        response = self.get_error_response(
+            self.organization.slug,
+            **data,
+            status_code=400,
+        )
+        assert "upsampled_count() is not allowed as user input" in str(response.data)
+
     def test_missing_group_type(self) -> None:
         data = {**self.valid_data}
         del data["type"]


### PR DESCRIPTION
- Converted count() aggregation to upsampled_count() for Entity Subscriptions on Events dataset for matching projects
- Prevented "upsampled_count()" aggregate from being used directly on Detector creation

Follow up to: https://github.com/getsentry/sentry/pull/96830, supporting the same thing but under ACI