### PR TITLE
feat(Prevent): add correct link to integrated org button

### DIFF
--- a/static/app/components/prevent/integratedOrgSelector/integratedOrgSelector.tsx
+++ b/static/app/components/prevent/integratedOrgSelector/integratedOrgSelector.tsx
@@ -21,10 +21,11 @@ import {IconIntegratedOrg} from './iconIntegratedOrg';
 function AddIntegratedOrgButton() {
   return (
     <LinkButton
-      href="https://github.com/apps/sentry-io"
+      href="https://github.com/apps/sentry/installations/select_target"
       size="sm"
       icon={<IconAdd size="sm" />}
       priority="default"
+      external
     >
       {t('Integrated Organization')}
     </LinkButton>
@@ -107,8 +108,7 @@ export function IntegratedOrgSelector() {
                   <IconIntegratedOrg />
                 </IconContainer>
                 <TriggerLabel>
-                  {integratedOrgIdToName(integratedOrgId, integrations) ||
-                    t('Select integrated organization')}
+                  {integratedOrgIdToName(integratedOrgId, integrations)}
                 </TriggerLabel>
               </Flex>
             </TriggerLabelWrap>

--- a/static/app/components/prevent/integratedOrgSelector/utils.tsx
+++ b/static/app/components/prevent/integratedOrgSelector/utils.tsx
@@ -1,7 +1,6 @@
-import {t} from 'sentry/locale';
 import type {Integration} from 'sentry/types/integrations';
 
-const EMPTY_MESSAGE = t('Select integrated organization');
+const EMPTY_MESSAGE = 'Select integrated organization';
 
 export const integratedOrgIdToName = (id?: string, integrations?: Integration[]) => {
   if (!id || !integrations) {

--- a/static/app/components/prevent/integratedOrgSelector/utils.tsx
+++ b/static/app/components/prevent/integratedOrgSelector/utils.tsx
@@ -1,11 +1,10 @@
+import {t} from 'sentry/locale';
 import type {Integration} from 'sentry/types/integrations';
-
-const EMPTY_MESSAGE = 'Select integrated organization';
 
 export const integratedOrgIdToName = (id?: string, integrations?: Integration[]) => {
   if (!id || !integrations) {
-    return EMPTY_MESSAGE;
+    return t('Select integrated organization');
   }
   const result = integrations.find(item => item.id === id);
-  return result ? result.name : EMPTY_MESSAGE;
+  return result?.name || t('Select integrated organization');
 };

--- a/static/app/components/prevent/integratedOrgSelector/utils.tsx
+++ b/static/app/components/prevent/integratedOrgSelector/utils.tsx
@@ -3,8 +3,8 @@ import type {Integration} from 'sentry/types/integrations';
 
 export const integratedOrgIdToName = (id?: string, integrations?: Integration[]) => {
   if (!id || !integrations) {
-    return t('Select integrated organization');
+    return t('Select Integrated Org');
   }
   const result = integrations.find(item => item.id === id);
-  return result?.name || t('Select integrated organization');
+  return result?.name || t('Select Integrated Org');
 };

--- a/static/app/components/prevent/integratedOrgSelector/utils.tsx
+++ b/static/app/components/prevent/integratedOrgSelector/utils.tsx
@@ -1,9 +1,12 @@
+import {t} from 'sentry/locale';
 import type {Integration} from 'sentry/types/integrations';
+
+const EMPTY_MESSAGE = t('Select integrated organization');
 
 export const integratedOrgIdToName = (id?: string, integrations?: Integration[]) => {
   if (!id || !integrations) {
-    return 'No Integration';
+    return EMPTY_MESSAGE;
   }
   const result = integrations.find(item => item.id === id);
-  return result ? result.name : 'Select Integration';
+  return result ? result.name : EMPTY_MESSAGE;
 };


### PR DESCRIPTION
This PR adds correct link to the integrated org button, also making it external and adjusting a constant value from another PR I mistakenly thought I pushed to 😬. Replaces [this](https://github.com/getsentry/sentry/pull/97736)

Closes https://linear.app/getsentry/issue/CCMRG-1505/enable-functionality-for-integrated-org-button