### PR TITLE
fix(aci): Limit error dataset to supported aggregates and fields

### DIFF
--- a/static/app/views/detectors/datasetConfig/errors.tsx
+++ b/static/app/views/detectors/datasetConfig/errors.tsx
@@ -1,20 +1,68 @@
+import type {SelectValue} from 'sentry/types/core';
 import type {EventsStats} from 'sentry/types/organization';
+import type {QueryFieldValue} from 'sentry/utils/discover/fields';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
-import {ErrorsConfig} from 'sentry/views/dashboards/datasetConfig/errors';
+import {AggregationKey, FieldKey} from 'sentry/utils/fields';
 import {EventsSearchBar} from 'sentry/views/detectors/datasetConfig/components/eventSearchBar';
 import {
   getDiscoverSeriesQueryOptions,
   transformEventsStatsComparisonSeries,
   transformEventsStatsToSeries,
 } from 'sentry/views/detectors/datasetConfig/utils/discoverSeries';
+import {FieldValueKind, type FieldValue} from 'sentry/views/discover/table/types';
 
 import type {DetectorDatasetConfig} from './base';
 
 type ErrorsSeriesResponse = EventsStats;
 
+const AGGREGATE_OPTIONS: Record<string, SelectValue<FieldValue>> = {
+  'function:count': {
+    label: 'count',
+    value: {
+      kind: FieldValueKind.FUNCTION,
+      meta: {
+        name: 'count',
+        parameters: [],
+      },
+    },
+  },
+  'function:count_unique': {
+    label: 'count_unique',
+    value: {
+      kind: FieldValueKind.FUNCTION,
+      meta: {
+        name: 'count_unique',
+        parameters: [
+          {
+            kind: 'column',
+            columnTypes: ['string'],
+            defaultValue: FieldKey.USER,
+            required: true,
+          },
+        ],
+      },
+    },
+  },
+  'field:user': {
+    label: 'user',
+    value: {
+      kind: FieldValueKind.FIELD,
+      meta: {
+        name: FieldKey.USER,
+        dataType: 'string',
+      },
+    },
+  },
+};
+
+const DEFAULT_FIELD: QueryFieldValue = {
+  function: [AggregationKey.COUNT, '', undefined, undefined],
+  kind: FieldValueKind.FUNCTION,
+};
+
 export const DetectorErrorsConfig: DetectorDatasetConfig<ErrorsSeriesResponse> = {
-  defaultField: ErrorsConfig.defaultField,
-  getAggregateOptions: ErrorsConfig.getTableFieldOptions,
+  defaultField: DEFAULT_FIELD,
+  getAggregateOptions: () => AGGREGATE_OPTIONS,
   SearchBar: EventsSearchBar,
   getSeriesQueryOptions: options =>
     getDiscoverSeriesQueryOptions({


### PR DESCRIPTION
Error dataset can now only do `count()` and `count_unique(user)` which matches the alerts UI (and the backend doesn't accept anything else)