### PR TITLE
ref(feedback): add save_event_feedback metric and cleanup other ingest metrics

### DIFF
--- a/src/sentry/feedback/usecases/ingest/create_feedback.py
+++ b/src/sentry/feedback/usecases/ingest/create_feedback.py
@@ -215,17 +215,17 @@ def create_feedback_issue(
     if should_filter:
         if filter_reason == "too_large":
             feedback_message = event["contexts"]["feedback"]["message"]
+            metrics.distribution(
+                "feedback.large_message",
+                len(feedback_message),
+                tags={
+                    "entrypoint": "create_feedback_issue",
+                    "referrer": source.value,
+                    "platform": project.platform,
+                },
+                sample_rate=1.0,
+            )
             if random.random() < 0.1:
-                metrics.distribution(
-                    "feedback.large_message",
-                    len(feedback_message),
-                    tags={
-                        "entrypoint": "create_feedback_issue",
-                        "referrer": source.value,
-                        "platform": project.platform,
-                    },
-                    sample_rate=1.0,
-                )
                 logger.info(
                     "Feedback message exceeds max size.",
                     extra={

--- a/src/sentry/feedback/usecases/ingest/create_feedback.py
+++ b/src/sentry/feedback/usecases/ingest/create_feedback.py
@@ -271,21 +271,14 @@ def create_feedback_issue(
         except Exception:
             # until we have LLM error types ironed out, just catch all exceptions
             logger.exception("Error checking if message is spam", extra={"project_id": project.id})
-            metrics.incr(
-                "feedback.create_feedback_issue.spam_detection.error",
-                tags={"referrer": source.value},
-                sample_rate=1.0,
-            )
-
-        if is_message_spam is not None:
-            metrics.incr(
-                "feedback.create_feedback_issue.spam_detection",
-                tags={
-                    "is_spam": is_message_spam,
-                    "referrer": source.value,
-                },
-                sample_rate=1.0,
-            )
+        metrics.incr(
+            "feedback.create_feedback_issue.spam_detection",
+            tags={
+                "is_spam": is_message_spam,
+                "referrer": source.value,
+            },
+            sample_rate=1.0,
+        )
 
     # Prepare the data for issue platform processing and attach useful tags.
 

--- a/src/sentry/feedback/usecases/ingest/create_feedback.py
+++ b/src/sentry/feedback/usecases/ingest/create_feedback.py
@@ -271,6 +271,8 @@ def create_feedback_issue(
         except Exception:
             # until we have LLM error types ironed out, just catch all exceptions
             logger.exception("Error checking if message is spam", extra={"project_id": project.id})
+
+        # In DD we use is_spam = None to indicate spam failed.
         metrics.incr(
             "feedback.create_feedback_issue.spam_detection",
             tags={

--- a/src/sentry/feedback/usecases/ingest/create_feedback.py
+++ b/src/sentry/feedback/usecases/ingest/create_feedback.py
@@ -105,7 +105,6 @@ def fix_for_issue_platform(event_data: dict[str, Any]) -> dict[str, Any]:
         # This metric confirms this behavior is still used.
         metrics.incr(
             "feedback.create_feedback_issue.filled_missing_replay_context",
-            sample_rate=1.0,
         )
         ret_event["contexts"]["replay"] = {
             "replay_id": event_data["contexts"].get("feedback", {}).get("replay_id")
@@ -245,7 +244,6 @@ def create_feedback_issue(
                     "reason": filter_reason,
                     "referrer": source.value,
                 },
-                sample_rate=1.0,
             )
 
         track_outcome(
@@ -279,7 +277,6 @@ def create_feedback_issue(
                 "is_spam": is_message_spam,
                 "referrer": source.value,
             },
-            sample_rate=1.0,
         )
 
     # Prepare the data for issue platform processing and attach useful tags.
@@ -355,7 +352,7 @@ def create_feedback_issue(
             event_fixed["tags"][f"{AI_LABEL_TAG_PREFIX}.labels"] = json.dumps(labels)
         except Exception:
             logger.exception("Error generating labels", extra={"project_id": project.id})
-            metrics.incr("feedback.label_generation.error", sample_rate=1.0)
+            metrics.incr("feedback.label_generation.error")
 
     # Set the user.email tag since we want to be able to display user.email on the feedback UI as a tag
     # as well as be able to write alert conditions on it
@@ -405,7 +402,6 @@ def create_feedback_issue(
             "referrer": source.value,
             "platform": project.platform,
         },
-        sample_rate=1.0,
     )
 
     track_outcome(

--- a/src/sentry/feedback/usecases/ingest/create_feedback.py
+++ b/src/sentry/feedback/usecases/ingest/create_feedback.py
@@ -98,11 +98,12 @@ def fix_for_issue_platform(event_data: dict[str, Any]) -> dict[str, Any]:
 
     ret_event["contexts"] = event_data.get("contexts", {})
 
-    # TODO: confirm whether we still need to fill in replay context, or if frontend looks in both feedback and replay context.
+    # TODO: investigate if this can be removed. If the frontend looks in both
+    # feedback and replay context for replay_id, this might not be needed.
     if not event_data["contexts"].get("replay") and event_data["contexts"].get("feedback", {}).get(
         "replay_id"
     ):
-        # This metric confirms this behavior is still used.
+        # This metric confirms this block is still entered.
         metrics.incr(
             "feedback.create_feedback_issue.filled_missing_replay_context",
         )

--- a/src/sentry/feedback/usecases/ingest/create_feedback.py
+++ b/src/sentry/feedback/usecases/ingest/create_feedback.py
@@ -271,14 +271,21 @@ def create_feedback_issue(
         except Exception:
             # until we have LLM error types ironed out, just catch all exceptions
             logger.exception("Error checking if message is spam", extra={"project_id": project.id})
-        metrics.incr(
-            "feedback.create_feedback_issue.spam_detection",
-            tags={
-                "is_spam": is_message_spam,
-                "referrer": source.value,
-            },
-            sample_rate=1.0,
-        )
+            metrics.incr(
+                "feedback.create_feedback_issue.spam_detection.error",
+                tags={"referrer": source.value},
+                sample_rate=1.0,
+            )
+
+        if is_message_spam is not None:
+            metrics.incr(
+                "feedback.create_feedback_issue.spam_detection",
+                tags={
+                    "is_spam": is_message_spam,
+                    "referrer": source.value,
+                },
+                sample_rate=1.0,
+            )
 
     # Prepare the data for issue platform processing and attach useful tags.
 

--- a/src/sentry/feedback/usecases/ingest/create_feedback.py
+++ b/src/sentry/feedback/usecases/ingest/create_feedback.py
@@ -104,7 +104,8 @@ def fix_for_issue_platform(event_data: dict[str, Any]) -> dict[str, Any]:
     ):
         # This metric confirms this behavior is still used.
         metrics.incr(
-            "feedback.create_feedback_issue.filled_missing_replay_context", sample_rate=1.0
+            "feedback.create_feedback_issue.filled_missing_replay_context",
+            sample_rate=1.0,
         )
         ret_event["contexts"]["replay"] = {
             "replay_id": event_data["contexts"].get("feedback", {}).get("replay_id")
@@ -223,7 +224,6 @@ def create_feedback_issue(
                     "referrer": source.value,
                     "platform": project.platform,
                 },
-                sample_rate=1.0,
             )
             if random.random() < 0.1:
                 logger.info(

--- a/src/sentry/feedback/usecases/ingest/create_feedback.py
+++ b/src/sentry/feedback/usecases/ingest/create_feedback.py
@@ -98,17 +98,18 @@ def fix_for_issue_platform(event_data: dict[str, Any]) -> dict[str, Any]:
 
     ret_event["contexts"] = event_data.get("contexts", {})
 
-    # TODO: remove this once feedback_ingest API deprecated
-    # as replay context will be filled in
+    # TODO: confirm whether we still need to fill in replay context, or if frontend looks in both feedback and replay context.
     if not event_data["contexts"].get("replay") and event_data["contexts"].get("feedback", {}).get(
         "replay_id"
     ):
-        # Temporary metric to confirm this behavior is no longer needed.
-        metrics.incr("feedback.create_feedback_issue.filled_missing_replay_context")
-
+        # This metric confirms this behavior is still used.
+        metrics.incr(
+            "feedback.create_feedback_issue.filled_missing_replay_context", sample_rate=1.0
+        )
         ret_event["contexts"]["replay"] = {
             "replay_id": event_data["contexts"].get("feedback", {}).get("replay_id")
         }
+
     ret_event["event_id"] = event_data["event_id"]
 
     ret_event["platform"] = event_data.get("platform", "other")
@@ -162,11 +163,7 @@ def validate_issue_platform_event_schema(event_data):
     The issue platform schema validation does not run in dev atm so we have to do the validation
     ourselves, or else our tests are not representative of what happens in prod.
     """
-    try:
-        jsonschema.validate(event_data, EVENT_PAYLOAD_SCHEMA)
-    except jsonschema.exceptions.ValidationError:
-        metrics.incr("feedback.create_feedback_issue.invalid_schema")
-        raise
+    jsonschema.validate(event_data, EVENT_PAYLOAD_SCHEMA)
 
 
 def should_filter_feedback(event: dict) -> tuple[bool, str | None]:
@@ -214,27 +211,21 @@ def create_feedback_issue(
     Returns the formatted event data that was sent to issue platform.
     """
 
-    metrics.incr(
-        "feedback.create_feedback_issue.entered",
-        tags={
-            "referrer": source.value,
-        },
-    )
-
     should_filter, filter_reason = should_filter_feedback(event)
     if should_filter:
         if filter_reason == "too_large":
             feedback_message = event["contexts"]["feedback"]["message"]
-            metrics.distribution(
-                "feedback.large_message",
-                len(feedback_message),
-                tags={
-                    "entrypoint": "create_feedback_issue",
-                    "referrer": source.value,
-                    "platform": project.platform,
-                },
-            )
             if random.random() < 0.1:
+                metrics.distribution(
+                    "feedback.large_message",
+                    len(feedback_message),
+                    tags={
+                        "entrypoint": "create_feedback_issue",
+                        "referrer": source.value,
+                        "platform": project.platform,
+                    },
+                    sample_rate=1.0,
+                )
                 logger.info(
                     "Feedback message exceeds max size.",
                     extra={
@@ -254,6 +245,7 @@ def create_feedback_issue(
                     "reason": filter_reason,
                     "referrer": source.value,
                 },
+                sample_rate=1.0,
             )
 
         track_outcome(
@@ -361,7 +353,7 @@ def create_feedback_issue(
             event_fixed["tags"][f"{AI_LABEL_TAG_PREFIX}.labels"] = json.dumps(labels)
         except Exception:
             logger.exception("Error generating labels", extra={"project_id": project.id})
-            metrics.incr("feedback.label_generation.error")
+            metrics.incr("feedback.label_generation.error", sample_rate=1.0)
 
     # Set the user.email tag since we want to be able to display user.email on the feedback UI as a tag
     # as well as be able to write alert conditions on it

--- a/src/sentry/feedback/usecases/ingest/save_event_feedback.py
+++ b/src/sentry/feedback/usecases/ingest/save_event_feedback.py
@@ -15,8 +15,8 @@ logger = logging.getLogger(__name__)
 
 def save_event_feedback(event_data: Mapping[str, Any], project_id: int):
     """Saves feedback given data in an event format. This function should only
-    be called by the new feedback consumer's ingest strategy, to process
-    feedback envelopes (feedback v2). It is currently instrumented as a task in
+    be called by the feedback consumer's ingest strategy, to process
+    event envelopes (feedback v2). It is currently called in a task in
     sentry.tasks.store.
 
     If the save is successful and the `associated_event_id` field is present,

--- a/src/sentry/feedback/usecases/label_generation.py
+++ b/src/sentry/feedback/usecases/label_generation.py
@@ -26,7 +26,7 @@ MAX_AI_LABELS_JSON_LENGTH = 200
 SEER_GENERATE_LABELS_URL = f"{settings.SEER_AUTOFIX_URL}/v1/automation/summarize/feedback/labels"
 
 
-@metrics.wraps("feedback.generate_labels", sample_rate=1.0)
+@metrics.wraps("feedback.generate_labels")
 def generate_labels(feedback_message: str, organization_id: int) -> list[str]:
     """
     Generate labels for a feedback message.

--- a/src/sentry/feedback/usecases/label_generation.py
+++ b/src/sentry/feedback/usecases/label_generation.py
@@ -26,6 +26,7 @@ MAX_AI_LABELS_JSON_LENGTH = 200
 SEER_GENERATE_LABELS_URL = f"{settings.SEER_AUTOFIX_URL}/v1/automation/summarize/feedback/labels"
 
 
+# TODO: remove sample_rate=1.0 once GA'd and we're confident Seer can handle the load.
 @metrics.wraps("feedback.generate_labels", sample_rate=1.0)
 def generate_labels(feedback_message: str, organization_id: int) -> list[str]:
     """

--- a/src/sentry/feedback/usecases/label_generation.py
+++ b/src/sentry/feedback/usecases/label_generation.py
@@ -26,7 +26,6 @@ MAX_AI_LABELS_JSON_LENGTH = 200
 SEER_GENERATE_LABELS_URL = f"{settings.SEER_AUTOFIX_URL}/v1/automation/summarize/feedback/labels"
 
 
-# TODO: remove sample_rate=1.0 once GA'd and we're confident Seer can handle the load.
 @metrics.wraps("feedback.generate_labels", sample_rate=1.0)
 def generate_labels(feedback_message: str, organization_id: int) -> list[str]:
     """

--- a/src/sentry/feedback/usecases/spam_detection.py
+++ b/src/sentry/feedback/usecases/spam_detection.py
@@ -32,7 +32,7 @@ def make_input_prompt(message: str):
 **Classify:** """
 
 
-@metrics.wraps("feedback.spam_detection", sample_rate=1.0)
+@metrics.wraps("feedback.spam_detection")
 def is_spam(message: str):
     labeled_spam = False
     response = complete_prompt(

--- a/src/sentry/feedback/usecases/spam_detection.py
+++ b/src/sentry/feedback/usecases/spam_detection.py
@@ -32,7 +32,7 @@ def make_input_prompt(message: str):
 **Classify:** """
 
 
-@metrics.wraps("feedback.spam_detection")
+@metrics.wraps("feedback.spam_detection", sample_rate=1.0)
 def is_spam(message: str):
     labeled_spam = False
     response = complete_prompt(

--- a/src/sentry/feedback/usecases/title_generation.py
+++ b/src/sentry/feedback/usecases/title_generation.py
@@ -75,6 +75,8 @@ def format_feedback_title(title: str, max_words: int = 10) -> str:
     return title
 
 
+# TODO: remove sample_rate=1.0 once GA'd and we're confident Seer can handle the load.
+@metrics.wraps("feedback.ai_title_generation", sample_rate=1.0)
 def get_feedback_title_from_seer(feedback_message: str, organization_id: int) -> str | None:
     """
     Generate an AI-powered title for user feedback using Seer, or None if generation fails.
@@ -99,6 +101,7 @@ def get_feedback_title_from_seer(feedback_message: str, organization_id: int) ->
         metrics.incr(
             "feedback.ai_title_generation.error",
             tags={"reason": "seer_response_failed"},
+            sample_rate=1.0,
         )
         return None
 
@@ -109,6 +112,7 @@ def get_feedback_title_from_seer(feedback_message: str, organization_id: int) ->
         metrics.incr(
             "feedback.ai_title_generation.error",
             tags={"reason": "invalid_response"},
+            sample_rate=1.0,
         )
         return None
 
@@ -116,12 +120,10 @@ def get_feedback_title_from_seer(feedback_message: str, organization_id: int) ->
         metrics.incr(
             "feedback.ai_title_generation.error",
             tags={"reason": "invalid_response"},
+            sample_rate=1.0,
         )
         return None
 
-    metrics.incr(
-        "feedback.ai_title_generation.success",
-    )
     return title
 
 

--- a/src/sentry/feedback/usecases/title_generation.py
+++ b/src/sentry/feedback/usecases/title_generation.py
@@ -67,7 +67,7 @@ def format_feedback_title(title: str, max_words: int = 10) -> str:
     return title
 
 
-@metrics.wraps("feedback.ai_title_generation", sample_rate=1.0)
+@metrics.wraps("feedback.ai_title_generation")
 def get_feedback_title_from_seer(feedback_message: str, organization_id: int) -> str | None:
     """
     Generate an AI-powered title for user feedback using Seer, or None if generation fails.
@@ -92,7 +92,6 @@ def get_feedback_title_from_seer(feedback_message: str, organization_id: int) ->
         metrics.incr(
             "feedback.ai_title_generation.error",
             tags={"reason": "seer_response_failed"},
-            sample_rate=1.0,
         )
         return None
 
@@ -103,7 +102,6 @@ def get_feedback_title_from_seer(feedback_message: str, organization_id: int) ->
         metrics.incr(
             "feedback.ai_title_generation.error",
             tags={"reason": "invalid_response"},
-            sample_rate=1.0,
         )
         return None
 
@@ -111,7 +109,6 @@ def get_feedback_title_from_seer(feedback_message: str, organization_id: int) ->
         metrics.incr(
             "feedback.ai_title_generation.error",
             tags={"reason": "invalid_response"},
-            sample_rate=1.0,
         )
         return None
 

--- a/src/sentry/feedback/usecases/title_generation.py
+++ b/src/sentry/feedback/usecases/title_generation.py
@@ -26,17 +26,9 @@ class GenerateFeedbackTitleRequest(TypedDict):
 def should_get_ai_title(organization: Organization) -> bool:
     """Check if AI title generation should be used for the given organization."""
     if not features.has("organizations:gen-ai-features", organization):
-        metrics.incr(
-            "feedback.ai_title_generation.skipped",
-            tags={"reason": "gen_ai_disabled"},
-        )
         return False
 
     if not features.has("organizations:user-feedback-ai-titles", organization):
-        metrics.incr(
-            "feedback.ai_title_generation.skipped",
-            tags={"reason": "feedback_ai_titles_disabled"},
-        )
         return False
 
     return True

--- a/src/sentry/feedback/usecases/title_generation.py
+++ b/src/sentry/feedback/usecases/title_generation.py
@@ -67,7 +67,6 @@ def format_feedback_title(title: str, max_words: int = 10) -> str:
     return title
 
 
-# TODO: remove sample_rate=1.0 once GA'd and we're confident Seer can handle the load.
 @metrics.wraps("feedback.ai_title_generation", sample_rate=1.0)
 def get_feedback_title_from_seer(feedback_message: str, organization_id: int) -> str | None:
     """

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -717,6 +717,7 @@ def save_event_transaction(
         processing_deadline_duration=65,
     ),
 )
+@metrics.wraps("feedback_consumer.save_event_feedback_task")
 def save_event_feedback(
     cache_key: str | None = None,
     start_time: float | None = None,


### PR DESCRIPTION
- Adds a timer metric for the task feedback v2 ingest runs in - `save_event_feedback`. (The v1 equivalent is `ingest_consumer.process_userreport`)
- Rm all `sample_rate=1.0`s. Digging into metrics code, you can see this is only used for internal metrics, which we don't use anymore.
- cleans up some unused metrics (see comments)