### PR TITLE
feat(preprod): Add preprod list-builds endpoint

### DIFF
--- a/src/sentry/preprod/analytics.py
+++ b/src/sentry/preprod/analytics.py
@@ -36,6 +36,13 @@ class PreprodArtifactApiGetBuildDetailsEvent(analytics.Event):
     artifact_id: str
 
 
+@analytics.eventclass("preprod_artifact.api.list_builds")
+class PreprodArtifactApiListBuildsEvent(analytics.Event):
+    organization_id: int
+    project_id: int
+    user_id: int | None = None
+
+
 class PreprodArtifactApiInstallDetailsEvent(analytics.Event):
     type = "preprod_artifact.api.install_details"
 
@@ -52,4 +59,5 @@ analytics.register(PreprodArtifactApiUpdateEvent)
 analytics.register(PreprodArtifactApiAssembleGenericEvent)
 analytics.register(PreprodArtifactApiSizeAnalysisDownloadEvent)
 analytics.register(PreprodArtifactApiGetBuildDetailsEvent)
+analytics.register(PreprodArtifactApiListBuildsEvent)
 analytics.register(PreprodArtifactApiInstallDetailsEvent)

--- a/src/sentry/preprod/api/endpoints/project_preprod_build_details.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_build_details.py
@@ -9,15 +9,8 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.preprod.analytics import PreprodArtifactApiGetBuildDetailsEvent
-from sentry.preprod.api.models.project_preprod_build_details_models import (
-    BuildDetailsApiResponse,
-    BuildDetailsAppInfo,
-    BuildDetailsSizeInfo,
-    BuildDetailsVcsInfo,
-    platform_from_artifact_type,
-)
-from sentry.preprod.build_distribution_utils import is_installable_artifact
-from sentry.preprod.models import PreprodArtifact, PreprodArtifactSizeMetrics
+from sentry.preprod.build_details_utils import transform_preprod_artifact_to_build_details
+from sentry.preprod.models import PreprodArtifact
 
 logger = logging.getLogger(__name__)
 
@@ -66,113 +59,5 @@ class ProjectPreprodBuildDetailsEndpoint(ProjectEndpoint):
         except PreprodArtifact.DoesNotExist:
             return Response({"error": f"Preprod artifact {artifact_id} not found"}, status=404)
 
-        try:
-            size_metrics_qs = PreprodArtifactSizeMetrics.objects.select_related(
-                "preprod_artifact"
-            ).filter(
-                preprod_artifact__project=project,
-                preprod_artifact__id=artifact_id,
-            )
-            main_artifact_size_metrics = size_metrics_qs.filter(
-                metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT
-            )
-            if main_artifact_size_metrics.count() == 0:
-                logger.info("No size analysis results found for preprod artifact %s", artifact_id)
-                size_info = None
-            else:
-                size_metrics = main_artifact_size_metrics.first()
-
-                if size_metrics is None:
-                    logger.error(
-                        "No size analysis results found for preprod artifact %s", artifact_id
-                    )
-                    size_info = None
-                elif (
-                    size_metrics.max_install_size is None or size_metrics.max_download_size is None
-                ):
-                    logger.error(
-                        "Size analysis results found for preprod artifact %s but no max install or download size",
-                        artifact_id,
-                    )
-                    size_info = None
-                else:
-                    size_info = BuildDetailsSizeInfo(
-                        install_size_bytes=size_metrics.max_install_size,
-                        download_size_bytes=size_metrics.max_download_size,
-                    )
-        except Exception:
-            logger.exception(
-                "Failed to retrieve size analysis results for preprod artifact %s", artifact_id
-            )
-            size_info = None
-
-        app_info = BuildDetailsAppInfo(
-            app_id=preprod_artifact.app_id,
-            name=preprod_artifact.app_name,
-            version=preprod_artifact.build_version,
-            build_number=preprod_artifact.build_number,
-            date_added=(
-                preprod_artifact.date_added.isoformat() if preprod_artifact.date_added else None
-            ),
-            date_built=(
-                preprod_artifact.date_built.isoformat() if preprod_artifact.date_built else None
-            ),
-            artifact_type=preprod_artifact.artifact_type,
-            platform=platform_from_artifact_type(preprod_artifact.artifact_type),
-            is_installable=is_installable_artifact(preprod_artifact),
-            # TODO: Implement in the future when available
-            # build_configuration=preprod_artifact.build_configuration.name if preprod_artifact.build_configuration else None,
-            # icon=None,
-        )
-
-        vcs_info = BuildDetailsVcsInfo(
-            head_sha=(
-                preprod_artifact.commit_comparison.head_sha
-                if preprod_artifact.commit_comparison
-                else None
-            ),
-            base_sha=(
-                preprod_artifact.commit_comparison.base_sha
-                if preprod_artifact.commit_comparison
-                else None
-            ),
-            provider=(
-                preprod_artifact.commit_comparison.provider
-                if preprod_artifact.commit_comparison
-                else None
-            ),
-            head_repo_name=(
-                preprod_artifact.commit_comparison.head_repo_name
-                if preprod_artifact.commit_comparison
-                else None
-            ),
-            base_repo_name=(
-                preprod_artifact.commit_comparison.base_repo_name
-                if preprod_artifact.commit_comparison
-                else None
-            ),
-            head_ref=(
-                preprod_artifact.commit_comparison.head_ref
-                if preprod_artifact.commit_comparison
-                else None
-            ),
-            base_ref=(
-                preprod_artifact.commit_comparison.base_ref
-                if preprod_artifact.commit_comparison
-                else None
-            ),
-            pr_number=(
-                preprod_artifact.commit_comparison.pr_number
-                if preprod_artifact.commit_comparison
-                else None
-            ),
-        )
-
-        api_response = BuildDetailsApiResponse(
-            state=preprod_artifact.state,
-            app_info=app_info,
-            vcs_info=vcs_info,
-            size_info=size_info,
-        )
-
-        return Response(api_response.dict())
+        build_details = transform_preprod_artifact_to_build_details(preprod_artifact)
+        return Response(build_details.dict())

--- a/src/sentry/preprod/api/endpoints/project_preprod_build_details.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_build_details.py
@@ -9,7 +9,9 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.preprod.analytics import PreprodArtifactApiGetBuildDetailsEvent
-from sentry.preprod.build_details_utils import transform_preprod_artifact_to_build_details
+from sentry.preprod.api.models.project_preprod_build_details_models import (
+    transform_preprod_artifact_to_build_details,
+)
 from sentry.preprod.models import PreprodArtifact
 
 logger = logging.getLogger(__name__)

--- a/src/sentry/preprod/api/endpoints/project_preprod_list_builds.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_list_builds.py
@@ -139,7 +139,7 @@ class ProjectPreprodListBuildsEndpoint(ProjectEndpoint):
 
         # Build response with pagination info
         response_data = ListBuildsApiResponse(
-            builds=[item.dict() for item in build_details_list],
+            builds=build_details_list,
             pagination=PaginationInfo(
                 next=result.next.offset if result.next.has_results else None,
                 prev=result.prev.offset if result.prev.has_results else None,

--- a/src/sentry/preprod/api/endpoints/project_preprod_list_builds.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_list_builds.py
@@ -1,0 +1,154 @@
+import logging
+
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry import analytics, features
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases.project import ProjectEndpoint
+from sentry.api.paginator import OffsetPaginator
+from sentry.preprod.analytics import PreprodArtifactApiListBuildsEvent
+from sentry.preprod.api.models.project_preprod_build_details_models import (
+    transform_preprod_artifact_to_build_details,
+)
+from sentry.preprod.api.models.project_preprod_list_builds_models import (
+    ListBuildsApiResponse,
+    PaginationInfo,
+)
+from sentry.preprod.models import PreprodArtifact
+from sentry.utils.cursors import Cursor
+
+logger = logging.getLogger(__name__)
+
+
+@region_silo_endpoint
+class ProjectPreprodListBuildsEndpoint(ProjectEndpoint):
+    owner = ApiOwner.EMERGE_TOOLS
+    publish_status = {
+        "GET": ApiPublishStatus.EXPERIMENTAL,
+    }
+
+    def get(self, request: Request, project) -> Response:
+        """
+        List preprod builds for a project
+        ````````````````````````````````````````````````````
+
+        List preprod builds for a project with optional filtering and pagination.
+
+        :pparam string organization_id_or_slug: the id or slug of the organization the
+                                          artifacts belong to.
+        :pparam string project_id_or_slug: the id or slug of the project to retrieve the
+                                     artifacts from.
+        :qparam string app_id: filter by app identifier (e.g., "com.myapp.MyApp")
+        :qparam string state: filter by artifact state (0=uploading, 1=uploaded, 3=processed, 4=failed)
+        :qparam string build_version: filter by build version
+        :qparam string build_configuration: filter by build configuration name
+        :qparam string platform: filter by platform (ios, android, macos)
+        :qparam int limit: number of results per page (default 25, max 100)
+        :qparam int page: page number (default 1)
+        :auth: required
+        """
+
+        analytics.record(
+            PreprodArtifactApiListBuildsEvent(
+                organization_id=project.organization_id,
+                project_id=project.id,
+                user_id=request.user.id,
+            )
+        )
+
+        if not features.has(
+            "organizations:preprod-frontend-routes", project.organization, actor=request.user
+        ):
+            return Response({"error": "Feature not enabled"}, status=403)
+
+        queryset = PreprodArtifact.objects.filter(project=project)
+
+        app_id = request.GET.get("app_id")
+        if app_id:
+            queryset = queryset.filter(app_id__icontains=app_id)
+
+        state = request.GET.get("state")
+        if state:
+            try:
+                state_int = int(state)
+                if state_int in [0, 1, 3, 4]:  # Valid states
+                    queryset = queryset.filter(state=state_int)
+            except ValueError:
+                pass
+
+        build_version = request.GET.get("build_version")
+        if build_version:
+            queryset = queryset.filter(build_version__icontains=build_version)
+
+        build_configuration = request.GET.get("build_configuration")
+        if build_configuration:
+            queryset = queryset.filter(build_configuration__name__icontains=build_configuration)
+
+        platform = request.GET.get("platform")
+        if platform:
+            if platform.lower() == "ios":
+                queryset = queryset.filter(artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE)
+            elif platform.lower() == "android":
+                queryset = queryset.filter(
+                    artifact_type__in=[
+                        PreprodArtifact.ArtifactType.AAB,
+                        PreprodArtifact.ArtifactType.APK,
+                    ]
+                )
+            elif platform.lower() == "macos":
+                # For now, macos artifacts are also XCARCHIVE type
+                queryset = queryset.filter(artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE)
+
+        # Order by most recent first
+        queryset = queryset.order_by("-date_added")
+
+        # Get pagination parameters
+        per_page = min(int(request.GET.get("per_page", 25)), 100)
+        page = max(int(request.GET.get("page", 1)), 1)
+
+        # Create paginator
+        paginator = OffsetPaginator(
+            queryset,
+            order_by="-date_added",
+            max_limit=100,
+        )
+
+        # Create cursor for pagination
+        # For OffsetPaginator: cursor.offset = page number, cursor.value = limit
+        # Since we want page 1 to start at offset 0, we need to adjust
+        cursor = Cursor(per_page, page - 1, False)
+
+        # Get paginated results
+        result = paginator.get_result(
+            limit=per_page,
+            cursor=cursor,
+            count_hits=True,
+        )
+
+        # Transform the results using shared utility
+        build_details_list = []
+        for artifact in result.results:
+            try:
+                build_details_list.append(transform_preprod_artifact_to_build_details(artifact))
+            except Exception as e:
+                logger.warning("Failed to transform artifact %s: %s", artifact.id, str(e))
+                continue
+
+        # Build response with pagination info
+        response_data = ListBuildsApiResponse(
+            builds=[item.dict() for item in build_details_list],
+            pagination=PaginationInfo(
+                next=result.next.offset if result.next.has_results else None,
+                prev=result.prev.offset if result.prev.has_results else None,
+                has_next=result.next.has_results,
+                has_prev=result.prev.has_results,
+                page=page,
+                per_page=per_page,
+                total_count=result.hits if result.hits is not None else "unknown",
+            ),
+        )
+
+        return Response(response_data.dict())

--- a/src/sentry/preprod/api/endpoints/project_preprod_list_builds.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_list_builds.py
@@ -126,7 +126,8 @@ class ProjectPreprodListBuildsEndpoint(ProjectEndpoint):
         # Create cursor for pagination
         # For OffsetPaginator: cursor.offset = page number, cursor.value = limit
         # Since we want page 1 to start at offset 0, we need to adjust
-        cursor = Cursor(per_page, page - 1, False)
+        indexed_page = page - 1
+        cursor = Cursor(per_page, indexed_page, False)
 
         # Get paginated results
         result = paginator.get_result(
@@ -152,7 +153,7 @@ class ProjectPreprodListBuildsEndpoint(ProjectEndpoint):
                 prev=result.prev.offset if result.prev.has_results else None,
                 has_next=result.next.has_results,
                 has_prev=result.prev.has_results,
-                page=page,
+                page=indexed_page,
                 per_page=per_page,
                 total_count=result.hits if result.hits is not None else "unknown",
             ),

--- a/src/sentry/preprod/api/endpoints/urls.py
+++ b/src/sentry/preprod/api/endpoints/urls.py
@@ -13,6 +13,7 @@ from .project_preprod_artifact_size_analysis_download import (
 from .project_preprod_artifact_update import ProjectPreprodArtifactUpdateEndpoint
 from .project_preprod_build_details import ProjectPreprodBuildDetailsEndpoint
 from .project_preprod_check_for_updates import ProjectPreprodArtifactCheckForUpdatesEndpoint
+from .project_preprod_list_builds import ProjectPreprodListBuildsEndpoint
 
 preprod_urlpatterns = [
     re_path(
@@ -24,6 +25,11 @@ preprod_urlpatterns = [
         r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/preprodartifacts/check-for-updates/$",
         ProjectPreprodArtifactCheckForUpdatesEndpoint.as_view(),
         name="sentry-api-0-project-preprod-check-for-updates",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/preprodartifacts/list-builds/$",
+        ProjectPreprodListBuildsEndpoint.as_view(),
+        name="sentry-api-0-project-preprod-list-builds",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/files/preprodartifacts/(?P<artifact_id>[^/]+)/size-analysis/$",

--- a/src/sentry/preprod/api/models/project_preprod_build_details_models.py
+++ b/src/sentry/preprod/api/models/project_preprod_build_details_models.py
@@ -1,8 +1,12 @@
+import logging
 from enum import StrEnum
 
 from pydantic import BaseModel
 
-from sentry.preprod.models import PreprodArtifact
+from sentry.preprod.build_distribution_utils import is_installable_artifact
+from sentry.preprod.models import PreprodArtifact, PreprodArtifactSizeMetrics
+
+logger = logging.getLogger(__name__)
 
 
 class Platform(StrEnum):
@@ -58,3 +62,56 @@ def platform_from_artifact_type(artifact_type: PreprodArtifact.ArtifactType) -> 
         return Platform.ANDROID
     else:
         raise ValueError(f"Unknown artifact type: {artifact_type}")
+
+
+def transform_preprod_artifact_to_build_details(
+    artifact: PreprodArtifact,
+) -> BuildDetailsApiResponse:
+    size_info = None
+    try:
+        size_metrics = PreprodArtifactSizeMetrics.objects.filter(
+            preprod_artifact=artifact,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+        ).first()
+
+        if size_metrics and size_metrics.max_install_size and size_metrics.max_download_size:
+            size_info = BuildDetailsSizeInfo(
+                install_size_bytes=size_metrics.max_install_size,
+                download_size_bytes=size_metrics.max_download_size,
+            )
+    except Exception:
+        logger.debug("Failed to get size metrics for artifact %s", artifact.id)
+
+    app_info = BuildDetailsAppInfo(
+        app_id=artifact.app_id,
+        name=artifact.app_name,
+        version=artifact.build_version,
+        build_number=artifact.build_number,
+        date_added=(artifact.date_added.isoformat() if artifact.date_added else None),
+        date_built=(artifact.date_built.isoformat() if artifact.date_built else None),
+        artifact_type=artifact.artifact_type,
+        platform=platform_from_artifact_type(artifact.artifact_type),
+        is_installable=is_installable_artifact(artifact),
+    )
+
+    vcs_info = BuildDetailsVcsInfo(
+        head_sha=(artifact.commit_comparison.head_sha if artifact.commit_comparison else None),
+        base_sha=(artifact.commit_comparison.base_sha if artifact.commit_comparison else None),
+        provider=(artifact.commit_comparison.provider if artifact.commit_comparison else None),
+        head_repo_name=(
+            artifact.commit_comparison.head_repo_name if artifact.commit_comparison else None
+        ),
+        base_repo_name=(
+            artifact.commit_comparison.base_repo_name if artifact.commit_comparison else None
+        ),
+        head_ref=(artifact.commit_comparison.head_ref if artifact.commit_comparison else None),
+        base_ref=(artifact.commit_comparison.base_ref if artifact.commit_comparison else None),
+        pr_number=(artifact.commit_comparison.pr_number if artifact.commit_comparison else None),
+    )
+
+    return BuildDetailsApiResponse(
+        state=artifact.state,
+        app_info=app_info,
+        vcs_info=vcs_info,
+        size_info=size_info,
+    )

--- a/src/sentry/preprod/api/models/project_preprod_build_details_models.py
+++ b/src/sentry/preprod/api/models/project_preprod_build_details_models.py
@@ -46,6 +46,7 @@ class BuildDetailsSizeInfo(BaseModel):
 
 
 class BuildDetailsApiResponse(BaseModel):
+    id: str
     state: PreprodArtifact.ArtifactState
     app_info: BuildDetailsAppInfo
     vcs_info: BuildDetailsVcsInfo
@@ -110,6 +111,7 @@ def transform_preprod_artifact_to_build_details(
     )
 
     return BuildDetailsApiResponse(
+        id=artifact.id,
         state=artifact.state,
         app_info=app_info,
         vcs_info=vcs_info,

--- a/src/sentry/preprod/api/models/project_preprod_list_builds_models.py
+++ b/src/sentry/preprod/api/models/project_preprod_list_builds_models.py
@@ -1,0 +1,18 @@
+from pydantic import BaseModel
+
+from sentry.preprod.api.models.project_preprod_build_details_models import BuildDetailsApiResponse
+
+
+class PaginationInfo(BaseModel):
+    next: int | None
+    prev: int | None
+    has_next: bool
+    has_prev: bool
+    page: int
+    per_page: int
+    total_count: int | str
+
+
+class ListBuildsApiResponse(BaseModel):
+    builds: list[BuildDetailsApiResponse]
+    pagination: PaginationInfo

--- a/tests/sentry/preprod/api/endpoints/test_project_preprod_list_builds.py
+++ b/tests/sentry/preprod/api/endpoints/test_project_preprod_list_builds.py
@@ -1,0 +1,220 @@
+from django.urls import reverse
+
+from sentry.models.commitcomparison import CommitComparison
+from sentry.preprod.models import PreprodArtifact
+from sentry.testutils.cases import APITestCase
+
+
+class ProjectPreprodListBuildsEndpointTest(APITestCase):
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.user = self.create_user(email="test@example.com")
+        self.org = self.create_organization(owner=self.user)
+        self.project = self.create_project(organization=self.org)
+        self.api_token = self.create_user_auth_token(
+            user=self.user, scope_list=["org:admin", "project:admin"]
+        )
+
+        self.file = self.create_file(name="test_artifact.apk", type="application/octet-stream")
+
+        commit_comparison = CommitComparison.objects.create(
+            organization_id=self.org.id,
+            head_sha="1234567890098765432112345678900987654321",
+            base_sha="9876543210012345678998765432100123456789",
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+            head_ref="feature/xyz",
+            base_ref="main",
+            pr_number=123,
+        )
+
+        # Create multiple artifacts for testing pagination
+        self.artifact1 = PreprodArtifact.objects.create(
+            project=self.project,
+            file_id=self.file.id,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            artifact_type=PreprodArtifact.ArtifactType.APK,
+            app_id="com.example.app",
+            app_name="TestApp",
+            build_version="1.0.0",
+            build_number=42,
+            build_configuration=None,
+            installable_app_file_id=1234,
+            commit_comparison=commit_comparison,
+        )
+
+        self.artifact2 = PreprodArtifact.objects.create(
+            project=self.project,
+            file_id=self.file.id,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            artifact_type=PreprodArtifact.ArtifactType.AAB,
+            app_id="com.example.app2",
+            app_name="TestApp2",
+            build_version="2.0.0",
+            build_number=43,
+            build_configuration=None,
+            installable_app_file_id=1235,
+            commit_comparison=commit_comparison,
+        )
+
+        self.artifact3 = PreprodArtifact.objects.create(
+            project=self.project,
+            file_id=self.file.id,
+            state=PreprodArtifact.ArtifactState.UPLOADED,
+            artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
+            app_id="com.example.app3",
+            app_name="TestApp3",
+            build_version="3.0.0",
+            build_number=44,
+            build_configuration=None,
+            installable_app_file_id=1236,
+            commit_comparison=commit_comparison,
+        )
+
+        # Enable the feature flag for all tests by default
+        self.feature_context = self.feature({"organizations:preprod-frontend-routes": True})
+        self.feature_context.__enter__()
+
+    def tearDown(self):
+        # Exit the feature flag context manager
+        self.feature_context.__exit__(None, None, None)
+        super().tearDown()
+
+    def _get_url(self):
+        return reverse(
+            "sentry-api-0-project-preprod-list-builds",
+            args=[self.org.slug, self.project.slug],
+        )
+
+    def test_list_builds_success(self) -> None:
+        url = self._get_url()
+        response = self.client.get(
+            url, format="json", HTTP_AUTHORIZATION=f"Bearer {self.api_token.token}"
+        )
+
+        assert response.status_code == 200
+        resp_data = response.json()
+        assert "results" in resp_data
+        assert "pagination" in resp_data
+        assert len(resp_data["results"]) == 3  # Should return all 3 artifacts
+
+        # Check that results are ordered by date_added (most recent first)
+        assert resp_data["results"][0]["app_info"]["app_id"] == "com.example.app3"
+        assert resp_data["results"][1]["app_info"]["app_id"] == "com.example.app2"
+        assert resp_data["results"][2]["app_info"]["app_id"] == "com.example.app"
+
+    def test_list_builds_with_pagination(self) -> None:
+        url = self._get_url()
+        response = self.client.get(
+            f"{url}?per_page=2&page=1",
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {self.api_token.token}",
+        )
+
+        assert response.status_code == 200
+        resp_data = response.json()
+        assert len(resp_data["results"]) == 2
+        assert resp_data["pagination"]["per_page"] == 2
+        assert resp_data["pagination"]["page"] == 1
+        assert resp_data["pagination"]["has_next"] is True
+        assert resp_data["pagination"]["has_prev"] is False
+
+        # Get second page
+        response = self.client.get(
+            f"{url}?per_page=2&page=2",
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {self.api_token.token}",
+        )
+
+        assert response.status_code == 200
+        resp_data = response.json()
+        assert len(resp_data["results"]) == 1
+        assert resp_data["pagination"]["has_next"] is False
+        assert resp_data["pagination"]["has_prev"] is True
+
+    def test_list_builds_with_filters(self) -> None:
+        url = self._get_url()
+
+        # Filter by app_id
+        response = self.client.get(
+            f"{url}?app_id=com.example.app2",
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {self.api_token.token}",
+        )
+        assert response.status_code == 200
+        resp_data = response.json()
+        assert len(resp_data["results"]) == 1
+        assert resp_data["results"][0]["app_info"]["app_id"] == "com.example.app2"
+
+        # Filter by platform
+        response = self.client.get(
+            f"{url}?platform=android",
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {self.api_token.token}",
+        )
+        assert response.status_code == 200
+        resp_data = response.json()
+        assert len(resp_data["results"]) == 2  # APK and AAB are both Android
+        for result in resp_data["results"]:
+            assert result["app_info"]["platform"] in ["android"]
+
+        # Filter by state
+        response = self.client.get(
+            f"{url}?state=3",  # PROCESSED state
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {self.api_token.token}",
+        )
+        assert response.status_code == 200
+        resp_data = response.json()
+        assert len(resp_data["results"]) == 2  # Only 2 artifacts are PROCESSED
+
+    def test_list_builds_feature_flag_disabled(self) -> None:
+        with self.feature({"organizations:preprod-frontend-routes": False}):
+            url = self._get_url()
+            response = self.client.get(
+                url, format="json", HTTP_AUTHORIZATION=f"Bearer {self.api_token.token}"
+            )
+            assert response.status_code == 403
+            assert response.json()["error"] == "Feature not enabled"
+
+    def test_list_builds_invalid_pagination_params(self) -> None:
+        url = self._get_url()
+
+        # Test invalid per_page (should be capped at 100)
+        response = self.client.get(
+            f"{url}?per_page=200",
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {self.api_token.token}",
+        )
+        assert response.status_code == 200
+        resp_data = response.json()
+        assert resp_data["pagination"]["per_page"] == 100
+
+        # Test invalid page (should default to 1)
+        response = self.client.get(
+            f"{url}?page=0",
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {self.api_token.token}",
+        )
+        assert response.status_code == 200
+        resp_data = response.json()
+        assert resp_data["pagination"]["page"] == 1
+
+    def test_list_builds_empty_results(self) -> None:
+        # Create a different project with no artifacts
+        other_project = self.create_project(organization=self.org)
+        url = reverse(
+            "sentry-api-0-project-preprod-list-builds",
+            args=[self.org.slug, other_project.slug],
+        )
+
+        response = self.client.get(
+            url, format="json", HTTP_AUTHORIZATION=f"Bearer {self.api_token.token}"
+        )
+        assert response.status_code == 200
+        resp_data = response.json()
+        assert len(resp_data["results"]) == 0
+        assert resp_data["pagination"]["has_next"] is False
+        assert resp_data["pagination"]["has_prev"] is False

--- a/tests/sentry/preprod/api/endpoints/test_project_preprod_list_builds.py
+++ b/tests/sentry/preprod/api/endpoints/test_project_preprod_list_builds.py
@@ -96,14 +96,14 @@ class ProjectPreprodListBuildsEndpointTest(APITestCase):
 
         assert response.status_code == 200
         resp_data = response.json()
-        assert "results" in resp_data
+        assert "builds" in resp_data
         assert "pagination" in resp_data
-        assert len(resp_data["results"]) == 3  # Should return all 3 artifacts
+        assert len(resp_data["builds"]) == 3  # Should return all 3 artifacts
 
-        # Check that results are ordered by date_added (most recent first)
-        assert resp_data["results"][0]["app_info"]["app_id"] == "com.example.app3"
-        assert resp_data["results"][1]["app_info"]["app_id"] == "com.example.app2"
-        assert resp_data["results"][2]["app_info"]["app_id"] == "com.example.app"
+        # Check that builds are ordered by date_added (most recent first)
+        assert resp_data["builds"][0]["app_info"]["app_id"] == "com.example.app3"
+        assert resp_data["builds"][1]["app_info"]["app_id"] == "com.example.app2"
+        assert resp_data["builds"][2]["app_info"]["app_id"] == "com.example.app"
 
     def test_list_builds_with_pagination(self) -> None:
         url = self._get_url()
@@ -115,7 +115,7 @@ class ProjectPreprodListBuildsEndpointTest(APITestCase):
 
         assert response.status_code == 200
         resp_data = response.json()
-        assert len(resp_data["results"]) == 2
+        assert len(resp_data["builds"]) == 2
         assert resp_data["pagination"]["per_page"] == 2
         assert resp_data["pagination"]["page"] == 1
         assert resp_data["pagination"]["has_next"] is True
@@ -130,7 +130,7 @@ class ProjectPreprodListBuildsEndpointTest(APITestCase):
 
         assert response.status_code == 200
         resp_data = response.json()
-        assert len(resp_data["results"]) == 1
+        assert len(resp_data["builds"]) == 1
         assert resp_data["pagination"]["has_next"] is False
         assert resp_data["pagination"]["has_prev"] is True
 
@@ -145,8 +145,8 @@ class ProjectPreprodListBuildsEndpointTest(APITestCase):
         )
         assert response.status_code == 200
         resp_data = response.json()
-        assert len(resp_data["results"]) == 1
-        assert resp_data["results"][0]["app_info"]["app_id"] == "com.example.app2"
+        assert len(resp_data["builds"]) == 1
+        assert resp_data["builds"][0]["app_info"]["app_id"] == "com.example.app2"
 
         # Filter by platform
         response = self.client.get(
@@ -156,8 +156,8 @@ class ProjectPreprodListBuildsEndpointTest(APITestCase):
         )
         assert response.status_code == 200
         resp_data = response.json()
-        assert len(resp_data["results"]) == 2  # APK and AAB are both Android
-        for result in resp_data["results"]:
+        assert len(resp_data["builds"]) == 2  # APK and AAB are both Android
+        for result in resp_data["builds"]:
             assert result["app_info"]["platform"] in ["android"]
 
         # Filter by state
@@ -168,7 +168,7 @@ class ProjectPreprodListBuildsEndpointTest(APITestCase):
         )
         assert response.status_code == 200
         resp_data = response.json()
-        assert len(resp_data["results"]) == 2  # Only 2 artifacts are PROCESSED
+        assert len(resp_data["builds"]) == 2  # Only 2 artifacts are PROCESSED
 
     def test_list_builds_feature_flag_disabled(self) -> None:
         with self.feature({"organizations:preprod-frontend-routes": False}):
@@ -202,7 +202,7 @@ class ProjectPreprodListBuildsEndpointTest(APITestCase):
         resp_data = response.json()
         assert resp_data["pagination"]["page"] == 1
 
-    def test_list_builds_empty_results(self) -> None:
+    def test_list_builds_empty_builds(self) -> None:
         # Create a different project with no artifacts
         other_project = self.create_project(organization=self.org)
         url = reverse(
@@ -215,6 +215,6 @@ class ProjectPreprodListBuildsEndpointTest(APITestCase):
         )
         assert response.status_code == 200
         resp_data = response.json()
-        assert len(resp_data["results"]) == 0
+        assert len(resp_data["builds"]) == 0
         assert resp_data["pagination"]["has_next"] is False
         assert resp_data["pagination"]["has_prev"] is False

--- a/tests/sentry/preprod/api/endpoints/test_project_preprod_list_builds.py
+++ b/tests/sentry/preprod/api/endpoints/test_project_preprod_list_builds.py
@@ -117,7 +117,7 @@ class ProjectPreprodListBuildsEndpointTest(APITestCase):
         resp_data = response.json()
         assert len(resp_data["builds"]) == 2
         assert resp_data["pagination"]["per_page"] == 2
-        assert resp_data["pagination"]["page"] == 1
+        assert resp_data["pagination"]["page"] == 0
         assert resp_data["pagination"]["has_next"] is True
         assert resp_data["pagination"]["has_prev"] is False
 
@@ -200,7 +200,7 @@ class ProjectPreprodListBuildsEndpointTest(APITestCase):
         )
         assert response.status_code == 200
         resp_data = response.json()
-        assert resp_data["pagination"]["page"] == 1
+        assert resp_data["pagination"]["page"] == 0
 
     def test_list_builds_empty_builds(self) -> None:
         # Create a different project with no artifacts


### PR DESCRIPTION
Adds a new `preprodartifacts/list-builds` endpoint for creating a builds list page. Initially this will just be used from #97743 for a standalone build list page (for convenience and basic UI iteration), but later I intend for this to be leveraged from the release page.