### PR TITLE
chore(autofix): better state when no consent

### DIFF
--- a/static/app/components/events/autofix/autofixChanges.tsx
+++ b/static/app/components/events/autofix/autofixChanges.tsx
@@ -278,7 +278,7 @@ export function AutofixChanges({
                   <IconCode size="md" color="blue400" />
                 </HeaderIconWrapper>
                 {t('Code Changes')}
-                <ChatButton
+                <Button
                   size="zero"
                   borderless
                   title={t('Chat with Seer')}
@@ -287,7 +287,7 @@ export function AutofixChanges({
                   analyticsEventKey="autofix.changes.chat"
                 >
                   <IconChat />
-                </ChatButton>
+                </Button>
               </HeaderText>
               {!prsMade && (
                 <ButtonBar>
@@ -480,10 +480,6 @@ const HeaderIconWrapper = styled('div')`
   display: flex;
   align-items: center;
   justify-content: center;
-`;
-
-const ChatButton = styled(Button)`
-  color: ${p => p.theme.subText};
 `;
 
 function CreatePRsButton({

--- a/static/app/components/events/autofix/autofixInsightCards.tsx
+++ b/static/app/components/events/autofix/autofixInsightCards.tsx
@@ -711,7 +711,7 @@ const VerticalLine = styled('div')`
   transform: translateX(-50%);
   top: 0;
   bottom: 0;
-  width: 2px;
+  width: 1px;
   background-color: ${p => p.theme.subText};
   transition: background-color 0.2s ease;
   z-index: 0;
@@ -757,6 +757,10 @@ const MiniHeader = styled('p')<{expanded?: boolean}>`
   flex: 1;
   word-break: break-word;
   color: ${p => (p.expanded ? p.theme.textColor : p.theme.subText)};
+
+  code {
+    color: ${p => (p.expanded ? p.theme.textColor : p.theme.subText)};
+  }
 `;
 
 const ContextBody = styled('div')`

--- a/static/app/components/events/autofix/autofixOutputStream.tsx
+++ b/static/app/components/events/autofix/autofixOutputStream.tsx
@@ -421,8 +421,8 @@ const ActiveLog = styled('div')`
 const VerticalLine = styled('div')`
   width: 0;
   height: ${space(4)};
-  border-left: 2px dashed ${p => p.theme.subText};
-  margin-left: 16px;
+  border-left: 1px dashed ${p => p.theme.subText};
+  margin-left: 16.5px;
   margin-bottom: -1px;
 `;
 

--- a/static/app/components/events/autofix/autofixRootCause.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.tsx
@@ -170,13 +170,14 @@ function CopyRootCauseButton({
 }) {
   const text = formatRootCauseText(cause, customRootCause);
   return (
-    <CopyToClipboardButton
+    <StyledCopyToClipboardButton
       size="zero"
       text={text}
       borderless
       title="Copy root cause as Markdown"
       analyticsEventName="Autofix: Copy Root Cause as Markdown"
       analyticsEventKey="autofix.root_cause.copy"
+      color="black"
     />
   );
 }
@@ -245,7 +246,7 @@ function AutofixRootCauseDisplay({
             </IconWrapper>
             {t('Root Cause')}
             <ButtonBar gap={'0'}>
-              <ChatButton
+              <Button
                 size="zero"
                 borderless
                 title={t('Chat with Seer')}
@@ -254,7 +255,7 @@ function AutofixRootCauseDisplay({
                 analyticsEventKey="autofix.root_cause.chat"
               >
                 <IconChat />
-              </ChatButton>
+              </Button>
               <CopyRootCauseButton cause={cause} />
             </ButtonBar>
           </HeaderText>
@@ -378,6 +379,6 @@ const AnimationWrapper = styled(motion.div)`
   transform-origin: top center;
 `;
 
-const ChatButton = styled(Button)`
-  color: ${p => p.theme.subText};
+const StyledCopyToClipboardButton = styled(CopyToClipboardButton)`
+  color: ${p => p.theme.textColor};
 `;

--- a/static/app/components/events/autofix/autofixSolution.tsx
+++ b/static/app/components/events/autofix/autofixSolution.tsx
@@ -310,7 +310,7 @@ function CopySolutionButton({
   }
   const text = formatSolutionText(solution, customSolution);
   return (
-    <CopyToClipboardButton
+    <StyledCopyToClipboardButton
       size="zero"
       text={text}
       borderless
@@ -480,7 +480,7 @@ function AutofixSolutionDisplay({
             </HeaderIconWrapper>
             {t('Solution')}
             <ButtonBar gap={'0'}>
-              <ChatButton
+              <Button
                 size="zero"
                 borderless
                 title={t('Chat with Seer')}
@@ -489,7 +489,7 @@ function AutofixSolutionDisplay({
                 analyticsEventKey="autofix.solution.chat"
               >
                 <IconChat />
-              </ChatButton>
+              </Button>
               <CopySolutionButton solution={solution} />
             </ButtonBar>
           </HeaderText>
@@ -710,6 +710,6 @@ const AddInstructionWrapper = styled('div')`
   padding: ${space(1)} ${space(1)} 0 ${space(3)};
 `;
 
-const ChatButton = styled(Button)`
-  color: ${p => p.theme.subText};
+const StyledCopyToClipboardButton = styled(CopyToClipboardButton)`
+  color: ${p => p.theme.textColor};
 `;

--- a/static/app/views/issueDetails/streamline/sidebar/seerSection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerSection.spec.tsx
@@ -105,7 +105,7 @@ describe('SeerSection', () => {
   });
 
   describe('Seer button text', () => {
-    it('shows "Find Root Cause" when Seer needs setup and no run already', async () => {
+    it('shows "Fix it for me" when Seer needs setup and no run already', async () => {
       const customOrganization = OrganizationFixture({
         hideAiFeatures: false,
         features: ['gen-ai-features'],
@@ -128,9 +128,9 @@ describe('SeerSection', () => {
       });
 
       expect(
-        await screen.findByText('Explore potential root causes and solutions with Seer.')
+        await screen.findByText('Meet Seer, the AI debugging agent.')
       ).toBeInTheDocument();
-      expect(screen.getByRole('button', {name: 'Find Root Cause'})).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: 'Fix it for me'})).toBeInTheDocument();
     });
 
     it('shows "Find Root Cause" even when autofix needs setup', async () => {

--- a/static/app/views/issueDetails/streamline/sidebar/seerSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerSection.tsx
@@ -2,7 +2,10 @@ import {useState} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
+import autofixSetupImg from 'sentry-images/features/autofix-setup.svg';
+
 import {Button} from 'sentry/components/core/button';
+import {Text} from 'sentry/components/core/text';
 import {GroupSummary} from 'sentry/components/group/groupSummary';
 import {GroupSummaryWithAutofix} from 'sentry/components/group/groupSummaryWithAutofix';
 import Placeholder from 'sentry/components/placeholder';
@@ -20,6 +23,26 @@ import Resources from 'sentry/views/issueDetails/streamline/sidebar/resources';
 import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
 
 import {SeerSectionCtaButton} from './seerSectionCtaButton';
+
+function SeerWelcomeEntrypoint() {
+  return (
+    <WelcomeContainer>
+      <WelcomeTextContainer>
+        <Text>{t('Meet Seer, the AI debugging agent.')}</Text>
+      </WelcomeTextContainer>
+      <WelcomeImageContainer>
+        <img src={autofixSetupImg} alt="Seer AI debugging agent" />
+      </WelcomeImageContainer>
+      <WelcomeTextContainer>
+        <Text>
+          {t(
+            'Find the root cause of the issue, and even open a PR to fix it, in minutes.'
+          )}
+        </Text>
+      </WelcomeTextContainer>
+    </WelcomeContainer>
+  );
+}
 
 function SeerSectionContent({
   group,
@@ -117,8 +140,9 @@ export default function SeerSection({
       preventCollapse={!hasStreamlinedUI}
     >
       <SeerSectionContainer>
-        {aiConfig.orgNeedsGenAiAcknowledgement && !aiConfig.isAutofixSetupLoading ? (
-          <Summary>{t('Explore potential root causes and solutions with Seer.')}</Summary>
+        {(aiConfig.orgNeedsGenAiAcknowledgement || !aiConfig.hasAutofixQuota) &&
+        !aiConfig.isAutofixSetupLoading ? (
+          <SeerWelcomeEntrypoint />
         ) : aiConfig.hasAutofix || aiConfig.hasSummary ? (
           <SeerSectionContent group={group} project={project} event={event} />
         ) : issueTypeConfig.resources ? (
@@ -210,4 +234,24 @@ const HeaderContainer = styled('div')`
 
 const StyledP = styled('p')`
   margin-bottom: ${p => p.theme.space.md};
+`;
+
+const WelcomeContainer = styled('div')`
+  margin-bottom: ${p => p.theme.space.lg};
+`;
+
+const WelcomeImageContainer = styled('div')`
+  margin-bottom: ${p => p.theme.space.lg};
+  margin-top: ${p => p.theme.space.lg};
+
+  img {
+    max-width: 100%;
+    height: auto;
+  }
+`;
+
+const WelcomeTextContainer = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: ${p => p.theme.space.sm};
 `;

--- a/static/app/views/issueDetails/streamline/sidebar/seerSectionCtaButton.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerSectionCtaButton.tsx
@@ -147,6 +147,13 @@ export function SeerSectionCtaButton({
       return t('Open Resources');
     }
 
+    if (
+      (aiConfig.orgNeedsGenAiAcknowledgement || !aiConfig.hasAutofixQuota) &&
+      !aiConfig.isAutofixSetupLoading
+    ) {
+      return t('Fix it for me');
+    }
+
     if (!lastStep) {
       return t('Find Root Cause');
     }


### PR DESCRIPTION
Makes the sidebar content more enticing when there is no consent or quota. 

<img width="354" height="394" alt="Screenshot 2025-08-12 at 5 53 39 PM" src="https://github.com/user-attachments/assets/889071b8-cd14-4817-80c2-0899a6f67ad4" />

Also tacking on some color tweaks inside the drawer for slight readability

<img width="611" height="308" alt="Screenshot 2025-08-12 at 4 48 50 PM" src="https://github.com/user-attachments/assets/b989069d-e9c3-45f4-a2e3-27b713354139" />
