### PR TITLE
fix(aci): record WorkflowFireHistory before deduping actions

### DIFF
--- a/src/sentry/workflow_engine/processors/action.py
+++ b/src/sentry/workflow_engine/processors/action.py
@@ -28,7 +28,9 @@ from sentry.workflow_engine.models import (
     Workflow,
     WorkflowActionGroupStatus,
 )
+from sentry.workflow_engine.models.detector import Detector
 from sentry.workflow_engine.registry import action_handler_registry
+from sentry.workflow_engine.tasks.actions import build_trigger_action_task_params, trigger_action
 from sentry.workflow_engine.types import WorkflowEventData
 
 logger = logging.getLogger(__name__)
@@ -137,6 +139,15 @@ def deduplicate_actions(
     return actions_queryset.filter(id__in=dedup_key_to_action_id.values())
 
 
+def fire_actions(
+    actions: BaseQuerySet[Action], detector: Detector, event_data: WorkflowEventData
+) -> None:
+    deduped_actions = deduplicate_actions(actions)
+    for action in deduped_actions:
+        task_params = build_trigger_action_task_params(action, detector, event_data)
+        trigger_action.apply_async(kwargs=task_params, headers={"sentry-propagate-traces": False})
+
+
 def filter_recently_fired_workflow_actions(
     filtered_action_groups: set[DataConditionGroup], event_data: WorkflowEventData
 ) -> BaseQuerySet[Action]:
@@ -182,11 +193,9 @@ def filter_recently_fired_workflow_actions(
         for action_id, workflow_id in action_to_workflow_ids.items()
     ]
 
-    decorated_actions = actions_queryset.annotate(
+    return actions_queryset.annotate(
         workflow_id=Case(*workflow_id_cases, output_field=models.IntegerField()),
     )
-
-    return deduplicate_actions(decorated_actions)
 
 
 def get_available_action_integrations_for_org(organization: Organization) -> list[RpcIntegration]:

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -44,7 +44,10 @@ from sentry.workflow_engine.models.data_condition import (
     SLOW_CONDITIONS,
     Condition,
 )
-from sentry.workflow_engine.processors.action import filter_recently_fired_workflow_actions
+from sentry.workflow_engine.processors.action import (
+    filter_recently_fired_workflow_actions,
+    fire_actions,
+)
 from sentry.workflow_engine.processors.data_condition_group import (
     evaluate_data_conditions,
     get_slow_conditions_for_groups,
@@ -52,7 +55,6 @@ from sentry.workflow_engine.processors.data_condition_group import (
 from sentry.workflow_engine.processors.detector import get_detectors_by_groupevents_bulk
 from sentry.workflow_engine.processors.log_util import track_batch_performance
 from sentry.workflow_engine.processors.workflow_fire_history import create_workflow_fire_histories
-from sentry.workflow_engine.tasks.actions import build_trigger_action_task_params, trigger_action
 from sentry.workflow_engine.types import WorkflowEventData
 from sentry.workflow_engine.utils import log_context
 
@@ -747,14 +749,7 @@ def fire_actions_for_groups(
                 total_actions += len(filtered_actions)
 
                 if should_trigger_actions(group_event.group.type):
-                    for action in filtered_actions:
-                        # TODO: populate workflow env in WorkflowEventData correctly
-                        task_params = build_trigger_action_task_params(
-                            action, detector, workflow_event_data
-                        )
-                        trigger_action.apply_async(
-                            kwargs=task_params, headers={"sentry-propagate-traces": False}
-                        )
+                    fire_actions(filtered_actions, detector, workflow_event_data)
 
     logger.info(
         "workflow_engine.delayed_workflow.triggered_actions_summary",

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -463,7 +463,6 @@ def process_workflows(
     create_workflow_fire_histories(
         detector, actions, event_data, should_trigger_actions, is_delayed=False
     )
-    if should_trigger_actions:
-        fire_actions(actions, detector, event_data)
+    fire_actions(actions, detector, event_data)
 
     return triggered_workflows

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -16,7 +16,10 @@ from sentry.models.environment import Environment
 from sentry.utils import json
 from sentry.workflow_engine.models import Action, DataConditionGroup, Detector, Workflow
 from sentry.workflow_engine.models.workflow_data_condition_group import WorkflowDataConditionGroup
-from sentry.workflow_engine.processors.action import filter_recently_fired_workflow_actions
+from sentry.workflow_engine.processors.action import (
+    filter_recently_fired_workflow_actions,
+    fire_actions,
+)
 from sentry.workflow_engine.processors.contexts.workflow_event_context import (
     WorkflowEventContext,
     WorkflowEventContextData,
@@ -24,7 +27,6 @@ from sentry.workflow_engine.processors.contexts.workflow_event_context import (
 from sentry.workflow_engine.processors.data_condition_group import process_data_condition_group
 from sentry.workflow_engine.processors.detector import get_detector_by_event
 from sentry.workflow_engine.processors.workflow_fire_history import create_workflow_fire_histories
-from sentry.workflow_engine.tasks.actions import build_trigger_action_task_params, trigger_action
 from sentry.workflow_engine.types import WorkflowEventData
 from sentry.workflow_engine.utils import log_context
 from sentry.workflow_engine.utils.metrics import metrics_incr
@@ -458,13 +460,10 @@ def process_workflows(
         return triggered_workflows
 
     should_trigger_actions = should_fire_workflow_actions(organization, event_data.group.type)
-
     create_workflow_fire_histories(
         detector, actions, event_data, should_trigger_actions, is_delayed=False
     )
-
-    for action in actions:
-        task_params = build_trigger_action_task_params(action, detector, event_data)
-        trigger_action.apply_async(kwargs=task_params, headers={"sentry-propagate-traces": False})
+    if should_trigger_actions:
+        fire_actions(actions, detector, event_data)
 
     return triggered_workflows

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -277,7 +277,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
         self, mock_trigger_action: MagicMock
     ) -> None:
         """Fire a single action, but record that it was fired for multiple workflows"""
-        
+
         self.action_group, self.action = self.create_workflow_action(workflow=self.error_workflow)
 
         error_workflow_2 = self.create_workflow(

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -276,10 +276,10 @@ class TestProcessWorkflows(BaseWorkflowTest):
     def test_workflow_fire_history_with_action_deduping(
         self, mock_trigger_action: MagicMock
     ) -> None:
-        # fire a single action, but record that it was fired for multiple workflows
+        """Fire a single action, but record that it was fired for multiple workflows"""
+        
         self.action_group, self.action = self.create_workflow_action(workflow=self.error_workflow)
 
-        # TODO: create new error workflow 2
         error_workflow_2 = self.create_workflow(
             name="error_workflow_2",
             when_condition_group=self.create_data_condition_group(),

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -12,7 +12,6 @@ from sentry.models.environment import Environment
 from sentry.services.eventstore.models import GroupEvent
 from sentry.testutils.factories import Factories
 from sentry.testutils.helpers.datetime import before_now, freeze_time
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.redis import mock_redis_buffer
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.types.activity import ActivityType
@@ -273,7 +272,6 @@ class TestProcessWorkflows(BaseWorkflowTest):
             tags={"detector_type": self.error_detector.type},
         )
 
-    @with_feature("organizations:workflow-engine-trigger-actions")
     @patch("sentry.workflow_engine.processors.action.trigger_action.apply_async")
     def test_workflow_fire_history_with_action_deduping(
         self, mock_trigger_action: MagicMock

--- a/tests/sentry/workflow_engine/test_integration.py
+++ b/tests/sentry/workflow_engine/test_integration.py
@@ -198,7 +198,7 @@ class TestWorkflowEngineIntegrationFromIssuePlatform(BaseWorkflowIntegrationTest
             mock_process_workflow.assert_not_called()
 
 
-@mock.patch("sentry.workflow_engine.processors.workflow.trigger_action.apply_async")
+@mock.patch("sentry.workflow_engine.processors.action.trigger_action.apply_async")
 @mock_redis_buffer()
 class TestWorkflowEngineIntegrationFromErrorPostProcess(BaseWorkflowIntegrationTest):
     def setUp(self) -> None:


### PR DESCRIPTION
We use the list of actions to fire to record `WorkflowFireHistory` by going backwards from the `Action` objects to find `Workflows`.

Different `Workflows` can have identical but not shared `Actions` (e.g. two workflows notify the same Slack channel). Since we dedupe `Actions` based on content, we will filter out some Actions that would point to Workflows we should be creating `WorkflowFireHistories` for.

Example
- Two `Actions` both send to the same Slack channel but are connected to different `Workflows`. If we should send notifications for both `Workflows`, we'll dedupe the `Actions` and end up with a single `Action`. Then when we try to create the `WorkflowFireHistories` we'll only create it for a single `Workflow`, when we should create it for 2.

This PR fixes this by creating `WorkflowFireHistory` objects before deduping `Actions`.