### PR TITLE
Replace the `precise` metrics flag with a dedicated backend

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2206,8 +2206,6 @@ SENTRY_TSDB_ROLLUPS = (
 # Internal metrics
 SENTRY_METRICS_BACKEND = "sentry.metrics.dummy.DummyMetricsBackend"
 SENTRY_METRICS_OPTIONS: dict[str, Any] = {}
-SENTRY_METRICS_PRECISE_BACKEND: str | None = None
-SENTRY_METRICS_PRECISE_OPTIONS: dict[str, Any] = {}
 SENTRY_METRICS_SAMPLE_RATE = 1.0
 SENTRY_METRICS_PREFIX = "sentry."
 SENTRY_METRICS_SKIP_INTERNAL_PREFIXES: list[str] = []  # Order this by most frequent prefixes.

--- a/src/sentry/metrics/base.py
+++ b/src/sentry/metrics/base.py
@@ -76,7 +76,6 @@ class MetricsBackend(local):
         sample_rate: float = 1,
         unit: str | None = None,
         stacklevel: int = 0,
-        precise: bool = False,
     ) -> None:
         raise NotImplementedError
 

--- a/src/sentry/metrics/datadog.py
+++ b/src/sentry/metrics/datadog.py
@@ -108,23 +108,9 @@ class DatadogMetricsBackend(MetricsBackend):
         sample_rate: float = 1,
         unit: str | None = None,
         stacklevel: int = 0,
-        precise: bool = False,
     ) -> None:
-        if not precise:
-            # We keep the same implementation for Datadog.
-            return self.timing(key, value, instance, tags, sample_rate)
-
-        tags = dict(tags or ())
-
-        if self.tags:
-            tags.update(self.tags)
-        if instance:
-            tags["instance"] = instance
-
-        tags_list = [f"{k}:{v}" for k, v in tags.items()]
-        self.stats.distribution(
-            self._get_key(key), value, sample_rate=sample_rate, tags=tags_list, host=self.host
-        )
+        # We keep the same implementation for Datadog.
+        return self.timing(key, value, instance, tags, sample_rate)
 
     def event(
         self,

--- a/src/sentry/metrics/dummy.py
+++ b/src/sentry/metrics/dummy.py
@@ -48,7 +48,6 @@ class DummyMetricsBackend(MetricsBackend):
         sample_rate: float = 1,
         unit: str | None = None,
         stacklevel: int = 0,
-        precise: bool = False,
     ) -> None:
         pass
 

--- a/src/sentry/metrics/logging.py
+++ b/src/sentry/metrics/logging.py
@@ -52,7 +52,6 @@ class LoggingBackend(MetricsBackend):
         sample_rate: float = 1,
         unit: str | None = None,
         stacklevel: int = 0,
-        precise: bool = False,
     ) -> None:
         logger.debug("%r: %+g", key, value, extra={"instance": instance, "tags": tags or {}})
 

--- a/src/sentry/metrics/middleware.py
+++ b/src/sentry/metrics/middleware.py
@@ -180,7 +180,6 @@ class MiddlewareWrapper(MetricsBackend):
         sample_rate: float = 1,
         unit: str | None = None,
         stacklevel: int = 0,
-        precise: bool = False,
     ) -> None:
         current_tags = get_current_global_tags()
         if tags is not None:
@@ -188,7 +187,7 @@ class MiddlewareWrapper(MetricsBackend):
         current_tags = _filter_tags(key, current_tags)
 
         return self.inner.distribution(
-            key, value, instance, current_tags, sample_rate, unit, stacklevel + 1, precise
+            key, value, instance, current_tags, sample_rate, unit, stacklevel + 1
         )
 
     def event(

--- a/src/sentry/metrics/precise_dogstatsd.py
+++ b/src/sentry/metrics/precise_dogstatsd.py
@@ -1,45 +1,41 @@
 import atexit
 from typing import Any
 
-from datadog import initialize
-from datadog.dogstatsd.base import statsd
+from datadog.dogstatsd.base import DogStatsd
 
 from .base import MetricsBackend, Tags
 
-__all__ = ["DogStatsdMetricsBackend"]
-
-# Set the maximum number of packets to queue for the sender.
-# How may packets to queue before blocking or dropping the packet if the packet queue is already full.
-# 0 means unlimited.
-SENDER_QUEUE_SIZE = 0
-
-# Set timeout for packet queue operations, in seconds
-# How long the application thread is willing to wait for the queue clear up before dropping the metric packet.
-# If set to None, wait forever.
-# If set to zero drop the packet immediately if the queue is full.
-SENDER_QUEUE_TIMEOUT = 0
+__all__ = ["PreciseDogStatsdMetricsBackend"]
 
 
-class DogStatsdMetricsBackend(MetricsBackend):
+class PreciseDogStatsdMetricsBackend(MetricsBackend):
     def __init__(self, prefix: str | None = None, **kwargs: Any) -> None:
-        # TODO(dcramer): it'd be nice if the initialize call wasn't a global
         self.tags = kwargs.pop("tags", None)
-        kwargs["statsd_disable_buffering"] = False
 
-        initialize(**kwargs)
-        statsd.disable_telemetry()
+        instance_kwargs: dict[str, Any] = {
+            "disable_telemetry": True,
+            "disable_buffering": False,
+            # When enabled, a background thread will be used to send metric payloads to the Agent.
+            "disable_background_sender": False,
+        }
+        if socket_path := kwargs.get("statsd_socket_path"):
+            instance_kwargs["socket_path"] = socket_path
+        else:
+            if host := kwargs.get("statsd_host"):
+                instance_kwargs["host"] = host
+            if port := kwargs.get("statsd_port"):
+                instance_kwargs["port"] = int(port)
 
-        # When enabled, a background thread will be used to send metric payloads to the Agent.
-        statsd.enable_background_sender(
-            sender_queue_size=SENDER_QUEUE_SIZE, sender_queue_timeout=SENDER_QUEUE_TIMEOUT
-        )
-        # Applications should call wait_for_pending() before exiting to make sure all pending payloads are sent.
-        atexit.register(statsd.wait_for_pending)
+        self.statsd = DogStatsd(**instance_kwargs)
 
         # Origin detection is enabled after 0.45 by default.
         # Disable it since it silently fails.
         # Ref: https://github.com/DataDog/datadogpy/issues/764
-        statsd._container_id = None
+        self.statsd._container_id = None
+
+        # Applications should call wait_for_pending() before exiting to make sure all pending payloads are sent.
+        atexit.register(self.statsd.wait_for_pending)
+
         super().__init__(prefix=prefix)
 
     def incr(
@@ -60,7 +56,7 @@ class DogStatsdMetricsBackend(MetricsBackend):
             tags["instance"] = instance
 
         tags_list = [f"{k}:{v}" for k, v in tags.items()]
-        statsd.increment(self._get_key(key), amount, sample_rate=sample_rate, tags=tags_list)
+        self.statsd.increment(self._get_key(key), amount, sample_rate=sample_rate, tags=tags_list)
 
     def timing(
         self,
@@ -79,7 +75,7 @@ class DogStatsdMetricsBackend(MetricsBackend):
             tags["instance"] = instance
 
         tags_list = [f"{k}:{v}" for k, v in tags.items()]
-        statsd.timing(self._get_key(key), value, sample_rate=sample_rate, tags=tags_list)
+        self.statsd.distribution(self._get_key(key), value, sample_rate=sample_rate, tags=tags_list)
 
     def gauge(
         self,
@@ -99,7 +95,7 @@ class DogStatsdMetricsBackend(MetricsBackend):
             tags["instance"] = instance
 
         tags_list = [f"{k}:{v}" for k, v in tags.items()]
-        statsd.gauge(self._get_key(key), value, sample_rate=sample_rate, tags=tags_list)
+        self.statsd.gauge(self._get_key(key), value, sample_rate=sample_rate, tags=tags_list)
 
     def distribution(
         self,
@@ -111,8 +107,15 @@ class DogStatsdMetricsBackend(MetricsBackend):
         unit: str | None = None,
         stacklevel: int = 0,
     ) -> None:
-        # We keep the same implementation for Datadog.
-        return self.timing(key, value, instance, tags, sample_rate)
+        tags = dict(tags or ())
+
+        if self.tags:
+            tags.update(self.tags)
+        if instance:
+            tags["instance"] = instance
+
+        tags_list = [f"{k}:{v}" for k, v in tags.items()]
+        self.statsd.distribution(self._get_key(key), value, sample_rate=sample_rate, tags=tags_list)
 
     def event(
         self,
@@ -134,7 +137,7 @@ class DogStatsdMetricsBackend(MetricsBackend):
             tags["instance"] = instance
 
         tags_list = [f"{k}:{v}" for k, v in tags.items()]
-        statsd.event(
+        self.statsd.event(
             title=title,
             message=message,
             alert_type=alert_type,

--- a/src/sentry/metrics/statsd.py
+++ b/src/sentry/metrics/statsd.py
@@ -61,7 +61,6 @@ class StatsdMetricsBackend(MetricsBackend):
         sample_rate: float = 1,
         unit: str | None = None,
         stacklevel: int = 0,
-        precise: bool = False,
     ) -> None:
         # NOTE: the statsd client does not have a `distribution` method
         self.timing(key, value, instance, tags, sample_rate)

--- a/src/sentry/models/debugfile.py
+++ b/src/sentry/models/debugfile.py
@@ -323,7 +323,6 @@ def create_dif_from_id(
         file.size,
         tags={"usecase": "debug-files", "compression": "none"},
         unit="byte",
-        precise=True,
     )
 
     dif = ProjectDebugFile.objects.create(

--- a/src/sentry/objectstore/metrics.py
+++ b/src/sentry/objectstore/metrics.py
@@ -19,21 +19,17 @@ class StorageMetricEmitter:
 
     def record_latency(self, elapsed: float):
         tags = {"usecase": self.usecase}
-        metrics.timing(f"storage.{self.operation}.latency", elapsed, tags=tags, precise=True)
+        metrics.timing(f"storage.{self.operation}.latency", elapsed, tags=tags)
         self.elapsed = elapsed
 
     def record_uncompressed_size(self, value: int):
         tags = {"usecase": self.usecase, "compression": "none"}
-        metrics.distribution(
-            f"storage.{self.operation}.size", value, tags=tags, unit="byte", precise=True
-        )
+        metrics.distribution(f"storage.{self.operation}.size", value, tags=tags, unit="byte")
         self.uncompressed_size = value
 
     def record_compressed_size(self, value: int, compression: str = "unknown"):
         tags = {"usecase": self.usecase, "compression": compression}
-        metrics.distribution(
-            f"storage.{self.operation}.size", value, tags=tags, unit="byte", precise=True
-        )
+        metrics.distribution(f"storage.{self.operation}.size", value, tags=tags, unit="byte")
         self.compressed_size = value
         self.compression = compression
 
@@ -46,7 +42,6 @@ class StorageMetricEmitter:
             f"storage.{self.operation}.compression_ratio",
             self.compressed_size / self.uncompressed_size,
             tags=tags,
-            precise=True,
         )
 
     def maybe_record_throughputs(self):
@@ -62,13 +57,10 @@ class StorageMetricEmitter:
         for size, compression in sizes:
             tags = {"usecase": self.usecase, "compression": compression}
             metrics.distribution(
-                f"storage.{self.operation}.throughput", size / self.elapsed, tags=tags, precise=True
+                f"storage.{self.operation}.throughput", size / self.elapsed, tags=tags
             )
             metrics.distribution(
-                f"storage.{self.operation}.inverse_throughput",
-                self.elapsed / size,
-                tags=tags,
-                precise=True,
+                f"storage.{self.operation}.inverse_throughput", self.elapsed / size, tags=tags
             )
 
 

--- a/src/sentry/tasks/assemble.py
+++ b/src/sentry/tasks/assemble.py
@@ -522,7 +522,6 @@ class ArtifactBundlePostAssembler:
                 file.size,
                 tags={"usecase": "artifact-bundles", "compression": "none"},
                 unit="byte",
-                precise=True,
             )
 
             artifact_bundle = ArtifactBundle.objects.create(

--- a/src/sentry/utils/kvstore/bigtable.py
+++ b/src/sentry/utils/kvstore/bigtable.py
@@ -246,7 +246,6 @@ class BigtableKVStorage(KVStorage[str, bytes]):
                 len(value),
                 tags={"usecase": "nodestore", "compression": self.compression},
                 unit="byte",
-                precise=True,
             )
 
         # Only need to write the column at all if any flags are enabled. And if

--- a/src/sentry/utils/metrics.py
+++ b/src/sentry/utils/metrics.py
@@ -31,7 +31,6 @@ __all__ = [
     "timing",
     "gauge",
     "backend",
-    "precise_backend",  # just for mocking in tests
     "MutableTags",
     "ensure_crash_rate_in_bounds",
 ]
@@ -41,21 +40,15 @@ T = TypeVar("T")
 F = TypeVar("F", bound=Callable[..., Any])
 
 
-def get_default_backend() -> tuple[MetricsBackend, MetricsBackend | None]:
+def get_default_backend() -> MetricsBackend:
     from sentry.utils.imports import import_string
 
-    default_cls: type[MetricsBackend] = import_string(settings.SENTRY_METRICS_BACKEND)
-    default_backend = MiddlewareWrapper(default_cls(**settings.SENTRY_METRICS_OPTIONS))
+    cls: type[MetricsBackend] = import_string(settings.SENTRY_METRICS_BACKEND)
 
-    precise_backend = None
-    if precise_import := settings.SENTRY_METRICS_PRECISE_BACKEND:
-        precise_cls: type[MetricsBackend] = import_string(precise_import)
-        precise_backend = MiddlewareWrapper(precise_cls(**settings.SENTRY_METRICS_PRECISE_OPTIONS))
-
-    return default_backend, precise_backend
+    return MiddlewareWrapper(cls(**settings.SENTRY_METRICS_OPTIONS))
 
 
-backend, precise_backend = get_default_backend()
+backend = get_default_backend()
 
 
 def _should_sample(sample_rate: float) -> bool:
@@ -168,20 +161,12 @@ def timing(
     tags: Tags | None = None,
     sample_rate: float = settings.SENTRY_METRICS_SAMPLE_RATE,
     stacklevel: int = 0,
-    precise: bool = False,
 ) -> None:
     try:
         backend.timing(key, value, instance, tags, sample_rate, stacklevel + 1)
     except Exception:
         logger = logging.getLogger("sentry.errors")
         logger.exception("Unable to record backend metric")
-
-    if precise and precise_backend:
-        try:
-            precise_backend.timing(key, value, instance, tags, sample_rate, stacklevel + 1)
-        except Exception:
-            logger = logging.getLogger("sentry.errors")
-            logger.exception("Unable to record precise metric")
 
 
 def distribution(
@@ -192,22 +177,12 @@ def distribution(
     sample_rate: float = settings.SENTRY_METRICS_SAMPLE_RATE,
     unit: str | None = None,
     stacklevel: int = 0,
-    precise: bool = False,
 ) -> None:
     try:
         backend.distribution(key, value, instance, tags, sample_rate, unit, stacklevel + 1)
     except Exception:
         logger = logging.getLogger("sentry.errors")
         logger.exception("Unable to record backend metric")
-
-    if precise and precise_backend:
-        try:
-            precise_backend.distribution(
-                key, value, instance, tags, sample_rate, unit, stacklevel + 1, precise=True
-            )
-        except Exception:
-            logger = logging.getLogger("sentry.errors")
-            logger.exception("Unable to record precise metric")
 
 
 @contextmanager
@@ -217,7 +192,6 @@ def timer(
     tags: Tags | None = None,
     sample_rate: float = settings.SENTRY_METRICS_SAMPLE_RATE,
     stacklevel: int = 0,
-    precise: bool = False,
 ) -> Generator[MutableTags]:
     start = time.monotonic()
     current_tags: MutableTags = dict(tags or ())
@@ -230,15 +204,7 @@ def timer(
         current_tags["result"] = "success"
     finally:
         # stacklevel must be increased by 2 because of the contextmanager indirection
-        timing(
-            key,
-            time.monotonic() - start,
-            instance,
-            current_tags,
-            sample_rate,
-            stacklevel + 2,
-            precise,
-        )
+        timing(key, time.monotonic() - start, instance, current_tags, sample_rate, stacklevel + 2)
 
 
 def wraps(
@@ -247,7 +213,6 @@ def wraps(
     tags: Tags | None = None,
     sample_rate: float = settings.SENTRY_METRICS_SAMPLE_RATE,
     stacklevel: int = 0,
-    precise: bool = False,
 ) -> Callable[[F], F]:
     def wrapper(f: F) -> F:
         @functools.wraps(f)
@@ -258,7 +223,6 @@ def wraps(
                 tags=tags,
                 sample_rate=sample_rate,
                 stacklevel=stacklevel + 1,
-                precise=precise,
             ):
                 return f(*args, **kwargs)
 

--- a/tests/sentry/metrics/test_precise.py
+++ b/tests/sentry/metrics/test_precise.py
@@ -1,18 +1,15 @@
 from unittest import mock
 
-from sentry.utils import metrics
+from sentry.metrics.precise_dogstatsd import PreciseDogStatsdMetricsBackend
 
 
-@mock.patch("sentry.utils.metrics.precise_backend")
-@mock.patch("sentry.utils.metrics.backend")
-def test_precise_distribution(backend, precise):
-    metrics.distribution("foo", 100, tags={"some": "stuff"}, unit="byte")
+@mock.patch("datadog.dogstatsd.base.DogStatsd.distribution")
+def test_precise_distribution(distribution):
+    backend = PreciseDogStatsdMetricsBackend(prefix="sentrytest.")
 
-    backend.distribution.assert_called_once()
-    precise.distribution.assert_not_called()
-    backend.reset_mock()
+    backend.distribution("foo", 100, tags={"some": "stuff"}, unit="byte")
+    distribution.assert_called_once()
+    distribution.reset_mock()
 
-    metrics.distribution("foo", 100, tags={"some": "stuff"}, unit="byte", precise=True)
-
-    backend.distribution.assert_called_once()
-    precise.distribution.assert_called_once()
+    backend.timing("bar", 100, tags={"some": "stuff"})
+    distribution.assert_called_once()


### PR DESCRIPTION
This reverts all the changes related to the `precise` flag, and having two different metrics backends.

Instead, it adds a new `PreciseDogStatsd` backend. The difference to the normal `DogStatsd` backend is that it constructs a instance-local `DogStatsd` client, instead of messing with the global `statsd` singleton. And of course, it emits distributions and timings as the proper datadog `distribution` type.