### PR TITLE
fix: forward nativeSizeProp on input 

### DIFF
--- a/static/app/components/core/input/index.tsx
+++ b/static/app/components/core/input/index.tsx
@@ -37,7 +37,7 @@ export const Input = styled(
 
     ...props
   }: InputProps) => <input {...props} ref={ref} size={nativeSize} />,
-  {shouldForwardProp: prop => typeof prop === 'string' && isPropValid(prop)}
+  {shouldForwardProp: prop => prop === 'nativeSize' || isPropValid(prop)}
 )`
   ${inputStyles};
 `;

--- a/static/app/components/core/input/input.spec.tsx
+++ b/static/app/components/core/input/input.spec.tsx
@@ -1,0 +1,12 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {Input} from '.';
+
+describe('Input', () => {
+  it('maps nativeSize to size', () => {
+    render(<Input size="md" nativeSize={5} />);
+
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+    expect(screen.getByRole('textbox')).toHaveAttribute('size', '5');
+  });
+});


### PR DESCRIPTION
the underlying component takes `nativeSize` and maps it towards `size`, while also ignoring the actual `size` prop. However, this only works if `nativeSize` isn't filtered out by `shouldForwardProp`;

additionally, the typeof 'string' check is unnecessary because according to the types, `prop` is `propName`, which is always a string