### PR TITLE
fix(project-config): Handle cases when new project configs do not have a revision

### DIFF
--- a/src/sentry/relay/projectconfig_cache/redis.py
+++ b/src/sentry/relay/projectconfig_cache/redis.py
@@ -67,6 +67,7 @@ class RedisProjectConfigCache(ProjectConfigCache):
         with self.cluster.pipeline() as p:
             for public_key in public_keys:
                 p.delete(self.__get_redis_key(public_key))
+                p.delete(self.__get_redis_rev_key(public_key))
             return_values = p.execute()
 
         metrics.incr(

--- a/src/sentry/relay/projectconfig_cache/redis.py
+++ b/src/sentry/relay/projectconfig_cache/redis.py
@@ -71,9 +71,7 @@ class RedisProjectConfigCache(ProjectConfigCache):
 
         # Count deletions of project configs, not deletions of individual Redis keys.
         amount = sum(1 for rv in return_values if rv >= 1)
-        metrics.incr(
-            "relay.projectconfig_cache.write", amount=amount, tags={"action": "delete"}
-        )
+        metrics.incr("relay.projectconfig_cache.write", amount=amount, tags={"action": "delete"})
 
     def get(self, public_key):
         rv_b = self.cluster_read.get(self.__get_redis_key(public_key))

--- a/src/sentry/relay/projectconfig_cache/redis.py
+++ b/src/sentry/relay/projectconfig_cache/redis.py
@@ -57,6 +57,8 @@ class RedisProjectConfigCache(ProjectConfigCache):
             # made transactional.
             if rev := config.get("rev"):
                 p.setex(self.__get_redis_rev_key(public_key), REDIS_CACHE_TIMEOUT, rev)
+            else:
+                p.delete(self.__get_redis_rev_key(public_key))
 
         p.execute()
 

--- a/tests/sentry/relay/test_projectconfig_cache.py
+++ b/tests/sentry/relay/test_projectconfig_cache.py
@@ -38,3 +38,19 @@ def test_read_write() -> None:
     cache.set_many({dsn1: value1})
     assert cache.get(dsn1) == value1
     assert cache.get_rev(dsn1) is None
+
+
+@django_db_all
+def test_write_delete() -> None:
+    cache = redis.RedisProjectConfigCache()
+
+    dsn = "fake-dsn-1"
+    value = {"my-value": "foo", "rev": "my_rev_123"}
+
+    cache.set_many({dsn: value})
+    assert cache.get(dsn) == value
+    assert cache.get_rev(dsn) == "my_rev_123"
+
+    cache.delete_many([dsn])
+    assert cache.get(dsn) is None
+    assert cache.get_rev(dsn) is None

--- a/tests/sentry/relay/test_projectconfig_cache.py
+++ b/tests/sentry/relay/test_projectconfig_cache.py
@@ -33,3 +33,8 @@ def test_read_write() -> None:
 
     assert cache.get_rev(dsn1) == "my_rev_123"
     assert cache.get_rev(dsn2) is None
+
+    del value1["rev"]
+    cache.set_many({dsn1: value1})
+    assert cache.get(dsn1) == value1
+    assert cache.get_rev(dsn1) is None


### PR DESCRIPTION
It is possible that for some reason new project configs do not also have a new revision. In this case the revision in the cache should be reset instead of left untouched.