### PR TITLE
fix(dynamic-sampling): lower query granularity for project rebalancing

### DIFF
--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
@@ -344,7 +344,10 @@ def query_project_counts_by_org(
     if query_interval > timedelta(days=1):
         granularity = Granularity(24 * 3600)
     else:
-        granularity = Granularity(3600)
+        if options.get("dynamic-sampling.query-granularity-60s", None):
+            granularity = Granularity(60)
+        else:
+            granularity = Granularity(3600)
 
     org_ids = list(org_ids)
     project_ids = list(

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3466,3 +3466,11 @@ register(
 
 # Whether the new objectstore implementation is being used for attachments
 register("objectstore.enable_for.attachments", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
+
+# Whether to use 60s granularity for the dynamic sampling query
+register(
+    "dynamic-sampling.query-granularity-60s",
+    type=Bool,
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)


### PR DESCRIPTION
- Register an option
- Use option to control whether to use 60s query granularity instead of 3600s to prevent underquerying and oversampling in dynamic sampling

Contributes to TET-994