### PR TITLE
chore(hc): Remove option for routing slack requests

### DIFF
--- a/src/sentry/hybridcloud/options.py
+++ b/src/sentry/hybridcloud/options.py
@@ -165,6 +165,6 @@ register(
 # Controls whether or not the pathway to target regions via integration request contents is enabled for the system.
 register(
     "hybrid_cloud.integration_region_targeting_rate",
-    default=0.0,
+    default=1.0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )

--- a/src/sentry/integrations/middleware/hybrid_cloud/parser.py
+++ b/src/sentry/integrations/middleware/hybrid_cloud/parser.py
@@ -30,7 +30,6 @@ from sentry.silo.base import SiloLimit, SiloMode
 from sentry.silo.client import RegionSiloClient, SiloClientError
 from sentry.types.region import Region, find_regions_for_orgs, get_region_by_name
 from sentry.utils import metrics
-from sentry.utils.options import sample_modulo
 
 logger = logging.getLogger(__name__)
 if TYPE_CHECKING:
@@ -320,11 +319,7 @@ class BaseRequestParser(ABC):
                 organization_ids=organization_ids
             )
 
-            # (1-TARGET_RATE)% of integrations will return all the organizations
-            if not sample_modulo("hybrid_cloud.integration_region_targeting_rate", integration.id):
-                return all_organizations
-
-            # (TARGET_RATE)% of integrations will attempt to target a specific organization
+            # Integrations will attempt to target a specific organization
             return self.filter_organizations_from_request(organizations=all_organizations)
 
     def filter_organizations_from_request(

--- a/src/sentry/integrations/slack/message_builder/help.py
+++ b/src/sentry/integrations/slack/message_builder/help.py
@@ -3,7 +3,6 @@ from collections.abc import Mapping, Sequence
 
 from sentry.integrations.slack.message_builder.base.block import BlockSlackMessageBuilder
 from sentry.integrations.slack.message_builder.types import SlackBlock
-from sentry.utils.options import sample_modulo
 
 _logger = logging.getLogger(__name__)
 
@@ -23,10 +22,6 @@ DM_COMMANDS = {
     "unlink": "Unlink your Slack identity from your Sentry account.",
 }
 CHANNEL_COMMANDS = {
-    "link team": "Get your Sentry team's issue alert notifications in this channel.",
-    "unlink team": "Unlink a team from this channel.",
-}
-CHANNEL_COMMANDS_ROUTING = {
     "link team [organization_slug]": "Get your Sentry team's issue alert notifications in this channel.",
     "unlink team [organization_slug]": "Unlink a team from this channel.",
 }
@@ -56,7 +51,6 @@ def list_commands(commands: Mapping[str, str]) -> str:
 
 DM_COMMANDS_MESSAGE = list_commands(DM_COMMANDS)
 CHANNEL_COMMANDS_MESSAGE = list_commands(CHANNEL_COMMANDS)
-CHANNEL_COMMANDS_ROUTING_MESSAGE = list_commands(CHANNEL_COMMANDS_ROUTING)
 HELP_COMMANDS_MESSAGE = list_commands(HELP_COMMANDS)
 
 
@@ -78,18 +72,12 @@ class SlackHelpMessageBuilder(BlockSlackMessageBuilder):
         return blocks
 
     def get_help_message(self) -> SlackBlock:
-        channel_commands_message = CHANNEL_COMMANDS_MESSAGE
-        if self.integration_id and sample_modulo(
-            "hybrid_cloud.integration_region_targeting_rate", self.integration_id
-        ):
-            channel_commands_message = CHANNEL_COMMANDS_ROUTING_MESSAGE
-
         return self._build_blocks(
             *self.get_header_blocks(),
             self.get_markdown_block(DM_COMMAND_HEADER),
             self.get_markdown_block(DM_COMMANDS_MESSAGE),
             self.get_markdown_block(CHANNEL_COMMANDS_HEADER),
-            self.get_markdown_block(channel_commands_message),
+            self.get_markdown_block(CHANNEL_COMMANDS_MESSAGE),
             self.get_markdown_block(HELP_COMMANDS_HEADER),
             self.get_markdown_block(HELP_COMMANDS_HEADER_MESSAGE),
             self.get_markdown_block(HELP_COMMANDS_MESSAGE),

--- a/tests/sentry/integrations/slack/webhooks/commands/test_help.py
+++ b/tests/sentry/integrations/slack/webhooks/commands/test_help.py
@@ -4,7 +4,6 @@ from sentry.integrations.slack.message_builder.help import SlackHelpMessageBuild
 from sentry.integrations.slack.message_builder.types import SlackBody
 from sentry.silo.base import SiloMode
 from sentry.testutils.helpers import get_response_text
-from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import control_silo_test
 from sentry.types.region import Region, RegionCategory
 from tests.sentry.integrations.slack.webhooks.commands import SlackCommandsTest
@@ -64,26 +63,6 @@ class SlackCommandsHelpTest(SlackCommandsTest):
         assert_unknown_command_text(data, "invalid command")
 
     @responses.activate
-    @override_options({"hybrid_cloud.integration_region_targeting_rate": 0.0})
-    def test_help_command(self) -> None:
-        if SiloMode.get_current_mode() == SiloMode.CONTROL:
-            region_response = SlackHelpMessageBuilder(
-                command="help",
-                integration_id=self.integration.id,
-            ).as_payload()
-            responses.add(
-                method=responses.POST,
-                url="http://us.testserver/extensions/slack/commands/",
-                json=region_response,
-            )
-        data = self.send_slack_message("help")
-        assert_is_help_text(data)
-        text = get_response_text(data)
-        assert "`/sentry link team`:" in text
-        assert "`/sentry unlink team`:" in text
-
-    @responses.activate
-    @override_options({"hybrid_cloud.integration_region_targeting_rate": 1.0})
     def test_help_command_with_organization_team_linking(self) -> None:
         if SiloMode.get_current_mode() == SiloMode.CONTROL:
             region_response = SlackHelpMessageBuilder(

--- a/tests/sentry/middleware/integrations/parsers/test_slack.py
+++ b/tests/sentry/middleware/integrations/parsers/test_slack.py
@@ -19,7 +19,6 @@ from sentry.integrations.slack.utils.auth import _encode_data
 from sentry.integrations.slack.views import SALT
 from sentry.middleware.integrations.parsers.slack import SlackRequestParser
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers.options import override_options
 from sentry.testutils.outbox import assert_no_webhook_payloads
 from sentry.testutils.silo import assume_test_silo_mode_of, control_silo_test, create_test_regions
 from sentry.utils import json
@@ -185,7 +184,6 @@ class SlackRequestParserTest(TestCase):
         assert "body" in result
         assert result["body"] == request.body.decode("utf8")
 
-    @override_options({"hybrid_cloud.integration_region_targeting_rate": 1.0})
     def test_targeting_all_orgs(self) -> None:
         # Install the integration on two organizations
         other_organization = self.create_organization()
@@ -211,7 +209,6 @@ class SlackRequestParserTest(TestCase):
             assert self.organization.id in organization_ids
             assert other_organization.id in organization_ids
 
-    @override_options({"hybrid_cloud.integration_region_targeting_rate": 1.0})
     def test_targeting_specific_org(self) -> None:
         # Install the integration on two organizations
         other_organization = self.create_organization()
@@ -236,7 +233,6 @@ class SlackRequestParserTest(TestCase):
             assert len(organizations) == 1
             assert organizations[0].id == other_organization.id
 
-    @override_options({"hybrid_cloud.integration_region_targeting_rate": 1.0})
     def test_targeting_irrelevant_org(self) -> None:
         # Install the integration on two organizations
         other_organization = self.create_organization()
@@ -263,7 +259,6 @@ class SlackRequestParserTest(TestCase):
             assert len(organization_ids) == 2
             assert irrelevant_organization.id not in organization_ids
 
-    @override_options({"hybrid_cloud.integration_region_targeting_rate": 1.0})
     def test_targeting_issue_actions(self) -> None:
         # Install the integration on two organizations
         other_organization = self.create_organization()


### PR DESCRIPTION
Removing its usage here, defaulting to GA, then going to remove the declaration in flagpole, before removing the flag altogether.