### PR TITLE
fix(spans): Clarify signatures in segment enrichment

### DIFF
--- a/src/sentry/spans/consumers/process_segments/enrichment.py
+++ b/src/sentry/spans/consumers/process_segments/enrichment.py
@@ -54,7 +54,7 @@ class Span(SegmentSpan, total=True):
 
     sentry_tags: dict[str, Any]  # type: ignore[misc]  # XXX: fix w/ TypedDict extra_items once available
 
-    # XXX: unclear where this comes from as it's not from enrichment!
+    # Added by `SpanGroupingResults.write_to_spans` in `_enrich_spans`
     hash: NotRequired[str]
 
 
@@ -221,8 +221,7 @@ def _us(timestamp: float) -> int:
     return int(timestamp * 1_000_000)
 
 
-def segment_span_measurement_updates(
-    segment: Span,
+def compute_breakdowns(
     spans: list[SegmentSpan],
     breakdowns_config: dict[str, dict[str, Any]],
 ) -> dict[str, MeasurementValue]:

--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -24,11 +24,7 @@ from sentry.performance_issues.performance_detection import detect_performance_p
 from sentry.receivers.features import record_generic_event_processed
 from sentry.receivers.onboarding import record_release_received
 from sentry.signals import first_insight_span_received, first_transaction_received
-from sentry.spans.consumers.process_segments.enrichment import (
-    Enricher,
-    Span,
-    segment_span_measurement_updates,
-)
+from sentry.spans.consumers.process_segments.enrichment import Enricher, Span, compute_breakdowns
 from sentry.spans.grouping.api import load_span_grouping_config
 from sentry.utils import metrics
 from sentry.utils.dates import to_datetime
@@ -56,11 +52,7 @@ def process_segment(unprocessed_spans: list[SegmentSpan], skip_produce: bool = F
         return []
 
     segment_span.setdefault("measurements", {}).update(
-        segment_span_measurement_updates(
-            segment_span,
-            unprocessed_spans,
-            project.get_option("sentry:breakdowns"),
-        )
+        compute_breakdowns(unprocessed_spans, project.get_option("sentry:breakdowns"))
     )
     _create_models(segment_span, project)
     _detect_performance_problems(segment_span, spans, project)

--- a/tests/sentry/spans/consumers/process_segments/test_enrichment.py
+++ b/tests/sentry/spans/consumers/process_segments/test_enrichment.py
@@ -1,7 +1,4 @@
-from sentry.spans.consumers.process_segments.enrichment import (
-    Enricher,
-    segment_span_measurement_updates,
-)
+from sentry.spans.consumers.process_segments.enrichment import Enricher, compute_breakdowns
 from tests.sentry.spans.consumers.process import build_mock_span
 
 # Tests ported from Relay
@@ -369,7 +366,7 @@ def test_emit_ops_breakdown() -> None:
     # Compute breakdowns for the segment span
     enriched_segment, _ = Enricher.enrich_spans(spans)
     assert enriched_segment is not None
-    updates = segment_span_measurement_updates(enriched_segment, spans, breakdowns_config)
+    updates = compute_breakdowns(enriched_segment, spans, breakdowns_config)
 
     assert updates["span_ops.ops.http"]["value"] == 3600000.0
     assert updates["span_ops.ops.db"]["value"] == 7200000.0

--- a/tests/sentry/spans/consumers/process_segments/test_enrichment.py
+++ b/tests/sentry/spans/consumers/process_segments/test_enrichment.py
@@ -364,9 +364,8 @@ def test_emit_ops_breakdown() -> None:
     }
 
     # Compute breakdowns for the segment span
-    enriched_segment, _ = Enricher.enrich_spans(spans)
-    assert enriched_segment is not None
-    updates = compute_breakdowns(enriched_segment, spans, breakdowns_config)
+    _ = Enricher.enrich_spans(spans)
+    updates = compute_breakdowns(spans, breakdowns_config)
 
     assert updates["span_ops.ops.http"]["value"] == 3600000.0
     assert updates["span_ops.ops.db"]["value"] == 7200000.0


### PR DESCRIPTION
Clarifies where the `hash` attribute is added during enrichment and renames breakdown calculation back to its original name for clarity.