### PR TITLE
fix(aci): remove ff check before triggering actions task in delayed workflow

### DIFF
--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -748,8 +748,7 @@ def fire_actions_for_groups(
                 )
                 total_actions += len(filtered_actions)
 
-                if should_trigger_actions(group_event.group.type):
-                    fire_actions(filtered_actions, detector, workflow_event_data)
+                fire_actions(filtered_actions, detector, workflow_event_data)
 
     logger.info(
         "workflow_engine.delayed_workflow.triggered_actions_summary",

--- a/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
@@ -16,7 +16,7 @@ from sentry.rules.match import MatchType
 from sentry.rules.processing.buffer_processing import process_in_batches
 from sentry.rules.processing.delayed_processing import fetch_project
 from sentry.services.eventstore.models import Event
-from sentry.testutils.helpers import override_options, with_feature
+from sentry.testutils.helpers import override_options
 from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.testutils.helpers.redis import mock_redis_buffer
 from sentry.utils import json
@@ -919,7 +919,6 @@ class TestFireActionsForGroups(TestDelayedWorkflowBase):
         assert group_to_groupevent == self.group_to_groupevent
 
     @patch("sentry.workflow_engine.tasks.actions.trigger_action.apply_async")
-    @with_feature("organizations:workflow-engine-trigger-actions")
     def test_fire_actions_for_groups__fire_actions(self, mock_trigger: MagicMock) -> None:
         fire_actions_for_groups(
             self.project.organization,

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -277,7 +277,6 @@ class TestProcessWorkflows(BaseWorkflowTest):
         self, mock_trigger_action: MagicMock
     ) -> None:
         """Fire a single action, but record that it was fired for multiple workflows"""
-
         self.action_group, self.action = self.create_workflow_action(workflow=self.error_workflow)
 
         error_workflow_2 = self.create_workflow(

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -12,7 +12,6 @@ from sentry.models.environment import Environment
 from sentry.services.eventstore.models import GroupEvent
 from sentry.testutils.factories import Factories
 from sentry.testutils.helpers.datetime import before_now, freeze_time
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.redis import mock_redis_buffer
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.types.activity import ActivityType

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -12,6 +12,7 @@ from sentry.models.environment import Environment
 from sentry.services.eventstore.models import GroupEvent
 from sentry.testutils.factories import Factories
 from sentry.testutils.helpers.datetime import before_now, freeze_time
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.redis import mock_redis_buffer
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.types.activity import ActivityType


### PR DESCRIPTION
There is some drift in the implementation of how we trigger the actions task in `process_workflows` vs delayed workflow processing.

We should always be triggering the actions task. The task does a feature flag check before firing any notifications. It would also be good to remove the FF to get an idea of how many actions tasks spawn from delayed processing during dual processing.

https://github.com/getsentry/sentry/blob/424f6f660082237f389ebf221b64d4760d3cf077/src/sentry/workflow_engine/processors/workflow.py#L462-L467