### PR TITLE
fix(ourlogs): Fix logs breadcrumb wrapper

### DIFF
--- a/static/app/views/explore/logs/content.tsx
+++ b/static/app/views/explore/logs/content.tsx
@@ -113,10 +113,11 @@ function LogsHeader() {
   return (
     <Layout.Header unified={prefersStackedNav}>
       <Layout.HeaderContent unified={prefersStackedNav}>
+        {title && defined(pageId) ? (
+          <ExploreBreadcrumb traceItemDataset={TraceItemDataset.LOGS} />
+        ) : null}
+
         <Layout.Title>
-          {title && defined(pageId) ? (
-            <ExploreBreadcrumb traceItemDataset={TraceItemDataset.LOGS} />
-          ) : null}
           {title ? title : t('Logs')}
           <FeatureBadge
             type="beta"


### PR DESCRIPTION
### Summary
Title was wrapping the wrong component and the actual title was being hidden.

#### Screenshot
<img width="288" height="88" alt="Screenshot 2025-08-13 at 11 11 10 AM" src="https://github.com/user-attachments/assets/7faedea3-a35a-4b60-9fa2-a876a9faeb5b" />

