### PR TITLE
ref(feedback): Remove skipped & success metrics from user feedback AI title gen

### DIFF
--- a/src/sentry/feedback/usecases/title_generation.py
+++ b/src/sentry/feedback/usecases/title_generation.py
@@ -25,21 +25,9 @@ class GenerateFeedbackTitleRequest(TypedDict):
 
 def should_get_ai_title(organization: Organization) -> bool:
     """Check if AI title generation should be used for the given organization."""
-    if not features.has("organizations:gen-ai-features", organization):
-        metrics.incr(
-            "feedback.ai_title_generation.skipped",
-            tags={"reason": "gen_ai_disabled"},
-        )
-        return False
-
-    if not features.has("organizations:user-feedback-ai-titles", organization):
-        metrics.incr(
-            "feedback.ai_title_generation.skipped",
-            tags={"reason": "feedback_ai_titles_disabled"},
-        )
-        return False
-
-    return True
+    return features.has("organizations:gen-ai-features", organization) and features.has(
+        "organizations:user-feedback-ai-titles", organization
+    )
 
 
 def format_feedback_title(title: str, max_words: int = 10) -> str:
@@ -75,6 +63,7 @@ def format_feedback_title(title: str, max_words: int = 10) -> str:
     return title
 
 
+@metrics.wraps("feedback.ai_title_generation")
 def get_feedback_title_from_seer(feedback_message: str, organization_id: int) -> str | None:
     """
     Generate an AI-powered title for user feedback using Seer, or None if generation fails.
@@ -119,9 +108,6 @@ def get_feedback_title_from_seer(feedback_message: str, organization_id: int) ->
         )
         return None
 
-    metrics.incr(
-        "feedback.ai_title_generation.success",
-    )
     return title
 
 


### PR DESCRIPTION
The skipped metric is not so useful, and the success metric can be calculated using the error metric. Let's remove the skipped and success metrics from user feedback AI title generation.

The Datadog dashboards can still calculate these metrics like so:
- success = feedback.ai_title_generation.count - feedback.ai_title_generation.error
- skipped = feedback.create_feedback_issue.produced_occurrence - feedback.ai_title_generation.count