### PR TITLE
fix(replay): lower z index of div covering replay table row

### DIFF
--- a/static/app/components/replays/table/replayTableColumns.tsx
+++ b/static/app/components/replays/table/replayTableColumns.tsx
@@ -675,6 +675,7 @@ const CellLink = styled(Link)`
     left: 0;
     right: 0;
     bottom: 0;
+    z-index: -1;
   }
 `;
 


### PR DESCRIPTION
closes https://linear.app/getsentry/issue/REPLAY-624/replay-index-page-missing-tooltip-for-absolute-date-and-time

the div covering the whole table row was causing users to be unable to interact with tooltips and buttons on the row. (for example on the issue detail > replays page)

<img width="822" height="125" alt="SCR-20250813-hwiu" src="https://github.com/user-attachments/assets/c2b2f68a-44d7-4261-8d46-f258b116e474" />
