### PR TITLE
fix(replay): fix scroll issue on ai summary tab

### DIFF
--- a/static/app/views/replays/detail/ai/chapterList.tsx
+++ b/static/app/views/replays/detail/ai/chapterList.tsx
@@ -253,7 +253,6 @@ const ChapterIconArrow = styled(IconChevron)`
 
 const ChaptersList = styled('div')`
   flex: 1;
-  overflow: auto;
 `;
 
 const ChapterWrapper = styled('details')`


### PR DESCRIPTION
the `overflow: auto` style was causing the scrollbar to get stuck sometimes

before:

https://github.com/user-attachments/assets/2275d85e-c39d-4f6d-ab46-3d9601eda593

after:

https://github.com/user-attachments/assets/846a48d2-ef19-4e8b-aeb2-a0cb9cf5e45a

