### PR TITLE
test(uptime): Extend uptime edit test timeout

### DIFF
--- a/static/app/views/alerts/rules/uptime/uptimeAlertForm.spec.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeAlertForm.spec.tsx
@@ -238,7 +238,7 @@ describe('Uptime Alert Form', function () {
         }),
       })
     );
-  });
+  }, 20_000);
 
   it('does not show body for GET and HEAD', async function () {
     OrganizationStore.onUpdate(organization);


### PR DESCRIPTION
seems to timeout on master somewhat frequently. [example flake](https://sentry.sentry.io/issues/trace/ed6464fd68ce0d9d0453ad03bc3e2da1/?environment=ci%3Amaster&environment=ci%3Apull_request&groupId=6746368950&node=span-c6f88faa25c09bbb&pageEnd=2025-08-13T08%3A57%3A23.512&pageStart=2025-08-12T08%3A57%3A23.512&project=4857230&referrer=event-or-group-header&source=issue_details&timestamp=1755032242.837)
