### PR TITLE
fix(ourlogs): Elide deprecated fields from json response

### DIFF
--- a/static/app/views/explore/logs/utils.tsx
+++ b/static/app/views/explore/logs/utils.tsx
@@ -473,6 +473,7 @@ export function ourlogToJson(ourlog: TraceItemDetailsResponse | undefined): stri
   // Trimming any sentry. prefixes
   for (const key in copy) {
     if (DeprecatedLogDetailFields.includes(key)) {
+      delete copy[key];
       continue;
     }
     if (key.startsWith('sentry.')) {


### PR DESCRIPTION
Should be deleting the key as well.
