### PR TITLE
:bug: fix(aci): dedupe actions based on workflow_id as well

### DIFF
--- a/src/sentry/workflow_engine/models/action.py
+++ b/src/sentry/workflow_engine/models/action.py
@@ -110,8 +110,10 @@ class Action(DefaultFieldsModel, JSONConfigBase):
             },
         )
 
-    def get_dedup_key(self, workflow_id: int) -> str:
-        key_parts = [self.type, str(workflow_id)]
+    def get_dedup_key(self, workflow_id: int | None) -> str:
+        key_parts = [self.type]
+        if workflow_id is not None:
+            key_parts.append(str(workflow_id))
 
         if self.integration_id:
             key_parts.append(str(self.integration_id))

--- a/src/sentry/workflow_engine/models/action.py
+++ b/src/sentry/workflow_engine/models/action.py
@@ -110,8 +110,8 @@ class Action(DefaultFieldsModel, JSONConfigBase):
             },
         )
 
-    def get_dedup_key(self) -> str:
-        key_parts = [self.type]
+    def get_dedup_key(self, workflow_id: int) -> str:
+        key_parts = [self.type, str(workflow_id)]
 
         if self.integration_id:
             key_parts.append(str(self.integration_id))

--- a/src/sentry/workflow_engine/processors/action.py
+++ b/src/sentry/workflow_engine/processors/action.py
@@ -134,7 +134,8 @@ def deduplicate_actions(
 
     for action in actions_queryset:
         # workflow_id is annotated in the queryset
-        dedup_key = action.get_dedup_key(action.workflow_id)
+        workflow_id = getattr(action, "workflow_id")
+        dedup_key = action.get_dedup_key(workflow_id)
         dedup_key_to_action_id[dedup_key] = action.id
 
     return actions_queryset.filter(id__in=dedup_key_to_action_id.values())

--- a/src/sentry/workflow_engine/processors/action.py
+++ b/src/sentry/workflow_engine/processors/action.py
@@ -133,7 +133,8 @@ def deduplicate_actions(
     dedup_key_to_action_id: dict[str, int] = {}
 
     for action in actions_queryset:
-        dedup_key = action.get_dedup_key()
+        # workflow_id is annotated in the queryset
+        dedup_key = action.get_dedup_key(action.workflow_id)
         dedup_key_to_action_id[dedup_key] = action.id
 
     return actions_queryset.filter(id__in=dedup_key_to_action_id.values())

--- a/tests/sentry/workflow_engine/processors/test_action_deduplication.py
+++ b/tests/sentry/workflow_engine/processors/test_action_deduplication.py
@@ -1,3 +1,6 @@
+from django.db import models
+from django.db.models import Value
+
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import region_silo_test
@@ -61,7 +64,9 @@ class TestActionDeduplication(TestCase):
             },
         )
 
-        actions_queryset = Action.objects.filter(id__in=[self.slack_action.id, email_action.id])
+        actions_queryset = Action.objects.filter(
+            id__in=[self.slack_action.id, email_action.id]
+        ).annotate(workflow_id=Value(1, output_field=models.IntegerField()))
 
         result = deduplicate_actions(actions_queryset)
 
@@ -84,7 +89,9 @@ class TestActionDeduplication(TestCase):
             },
         )
 
-        actions_queryset = Action.objects.filter(id__in=[slack_action_1.id, slack_action_2.id])
+        actions_queryset = Action.objects.filter(
+            id__in=[slack_action_1.id, slack_action_2.id]
+        ).annotate(workflow_id=Value(1, output_field=models.IntegerField()))
 
         result = deduplicate_actions(actions_queryset)
 
@@ -111,7 +118,9 @@ class TestActionDeduplication(TestCase):
             },
         )
 
-        actions_queryset = Action.objects.filter(id__in=[slack_action_1.id, slack_action_2.id])
+        actions_queryset = Action.objects.filter(
+            id__in=[slack_action_1.id, slack_action_2.id]
+        ).annotate(workflow_id=Value(1, output_field=models.IntegerField()))
 
         result = deduplicate_actions(actions_queryset)
 
@@ -135,7 +144,9 @@ class TestActionDeduplication(TestCase):
             },
         )
 
-        actions_queryset = Action.objects.filter(id__in=[slack_action_1.id, slack_action_2.id])
+        actions_queryset = Action.objects.filter(
+            id__in=[slack_action_1.id, slack_action_2.id]
+        ).annotate(workflow_id=Value(1, output_field=models.IntegerField()))
 
         result = deduplicate_actions(actions_queryset)
 
@@ -167,7 +178,9 @@ class TestActionDeduplication(TestCase):
             data={"notes": "second action"},
         )
 
-        actions_queryset = Action.objects.filter(id__in=[slack_action_1.id, slack_action_2.id])
+        actions_queryset = Action.objects.filter(
+            id__in=[slack_action_1.id, slack_action_2.id]
+        ).annotate(workflow_id=Value(1, output_field=models.IntegerField()))
 
         result = deduplicate_actions(actions_queryset)
 
@@ -202,7 +215,9 @@ class TestActionDeduplication(TestCase):
             data={"notes": "second action"},
         )
 
-        actions_queryset = Action.objects.filter(id__in=[slack_action_1.id, slack_action_2.id])
+        actions_queryset = Action.objects.filter(
+            id__in=[slack_action_1.id, slack_action_2.id]
+        ).annotate(workflow_id=Value(1, output_field=models.IntegerField()))
 
         result = deduplicate_actions(actions_queryset)
 
@@ -231,7 +246,9 @@ class TestActionDeduplication(TestCase):
             },
         )
 
-        actions_queryset = Action.objects.filter(id__in=[email_action_1.id, email_action_2.id])
+        actions_queryset = Action.objects.filter(
+            id__in=[email_action_1.id, email_action_2.id]
+        ).annotate(workflow_id=Value(1, output_field=models.IntegerField()))
 
         result = deduplicate_actions(actions_queryset)
 
@@ -257,7 +274,9 @@ class TestActionDeduplication(TestCase):
             },
         )
 
-        actions_queryset = Action.objects.filter(id__in=[email_action_1.id, email_action_2.id])
+        actions_queryset = Action.objects.filter(
+            id__in=[email_action_1.id, email_action_2.id]
+        ).annotate(workflow_id=Value(1, output_field=models.IntegerField()))
 
         result = deduplicate_actions(actions_queryset)
 
@@ -285,7 +304,9 @@ class TestActionDeduplication(TestCase):
             },
         )
 
-        actions_queryset = Action.objects.filter(id__in=[email_action_1.id, email_action_2.id])
+        actions_queryset = Action.objects.filter(
+            id__in=[email_action_1.id, email_action_2.id]
+        ).annotate(workflow_id=Value(1, output_field=models.IntegerField()))
 
         result = deduplicate_actions(actions_queryset)
 
@@ -319,7 +340,9 @@ class TestActionDeduplication(TestCase):
             },
         )
 
-        actions_queryset = Action.objects.filter(id__in=[email_action_1.id, email_action_2.id])
+        actions_queryset = Action.objects.filter(
+            id__in=[email_action_1.id, email_action_2.id]
+        ).annotate(workflow_id=Value(1, output_field=models.IntegerField()))
 
         result = deduplicate_actions(actions_queryset)
 
@@ -352,7 +375,9 @@ class TestActionDeduplication(TestCase):
             },
         )
 
-        actions_queryset = Action.objects.filter(id__in=[email_action_1.id, email_action_2.id])
+        actions_queryset = Action.objects.filter(
+            id__in=[email_action_1.id, email_action_2.id]
+        ).annotate(workflow_id=Value(1, output_field=models.IntegerField()))
 
         result = deduplicate_actions(actions_queryset)
 
@@ -383,7 +408,7 @@ class TestActionDeduplication(TestCase):
 
         actions_queryset = Action.objects.filter(
             id__in=[sentry_app_action_1.id, sentry_app_action_2.id]
-        )
+        ).annotate(workflow_id=Value(1, output_field=models.IntegerField()))
 
         result = deduplicate_actions(actions_queryset)
 
@@ -408,7 +433,9 @@ class TestActionDeduplication(TestCase):
             },
         )
 
-        actions_queryset = Action.objects.filter(id__in=[webhook_action_1.id, webhook_action_2.id])
+        actions_queryset = Action.objects.filter(
+            id__in=[webhook_action_1.id, webhook_action_2.id]
+        ).annotate(workflow_id=Value(1, output_field=models.IntegerField()))
 
         result = deduplicate_actions(actions_queryset)
 
@@ -421,7 +448,9 @@ class TestActionDeduplication(TestCase):
 
         plugin_action_2 = self.create_action(type=Action.Type.PLUGIN)
 
-        actions_queryset = Action.objects.filter(id__in=[plugin_action_1.id, plugin_action_2.id])
+        actions_queryset = Action.objects.filter(
+            id__in=[plugin_action_1.id, plugin_action_2.id]
+        ).annotate(workflow_id=Value(1, output_field=models.IntegerField()))
 
         result = deduplicate_actions(actions_queryset)
 
@@ -451,7 +480,9 @@ class TestActionDeduplication(TestCase):
             },
         )
 
-        actions_queryset = Action.objects.filter(id__in=[slack_action.id, pagerduty_action.id])
+        actions_queryset = Action.objects.filter(
+            id__in=[slack_action.id, pagerduty_action.id]
+        ).annotate(workflow_id=Value(1, output_field=models.IntegerField()))
 
         result = deduplicate_actions(actions_queryset)
 
@@ -486,7 +517,9 @@ class TestActionDeduplication(TestCase):
             },
         )
 
-        actions_queryset = Action.objects.filter(id__in=[jira_action_1.id, jira_action_2.id])
+        actions_queryset = Action.objects.filter(
+            id__in=[jira_action_1.id, jira_action_2.id]
+        ).annotate(workflow_id=Value(1, output_field=models.IntegerField()))
 
         result = deduplicate_actions(actions_queryset)
 
@@ -520,7 +553,9 @@ class TestActionDeduplication(TestCase):
             },
         )
 
-        actions_queryset = Action.objects.filter(id__in=[jira_action_1.id, jira_action_2.id])
+        actions_queryset = Action.objects.filter(
+            id__in=[jira_action_1.id, jira_action_2.id]
+        ).annotate(workflow_id=Value(1, output_field=models.IntegerField()))
 
         result = deduplicate_actions(actions_queryset)
 
@@ -541,7 +576,9 @@ class TestActionDeduplication(TestCase):
         """Test deduplication with single action."""
         single_action = self.slack_action
 
-        actions_queryset = Action.objects.filter(id=single_action.id)
+        actions_queryset = Action.objects.filter(id=single_action.id).annotate(
+            workflow_id=Value(1, output_field=models.IntegerField())
+        )
 
         result = deduplicate_actions(actions_queryset)
 
@@ -549,3 +586,45 @@ class TestActionDeduplication(TestCase):
         result_ids = list(result.values_list("id", flat=True))
         assert len(result_ids) == 1
         assert result_ids[0] == single_action.id
+
+    def test_deduplicate_actions_same_actions_different_workflows(self) -> None:
+        """Test that identical actions from different workflows are NOT deduplicated."""
+        # Create two identical Slack actions
+        slack_action_1 = self.create_action(
+            type=Action.Type.SLACK,
+            integration_id=self.slack_integration.id,
+            config={
+                "target_type": ActionTarget.SPECIFIC,
+                "target_identifier": "channel-123",
+                "target_display": "Test Channel",
+            },
+        )
+
+        slack_action_2 = self.create_action(
+            type=Action.Type.SLACK,
+            integration_id=self.slack_integration.id,
+            config={
+                "target_type": ActionTarget.SPECIFIC,
+                "target_identifier": "channel-123",
+                "target_display": "Test Channel",
+            },
+        )
+
+        # Annotate with different workflow IDs
+        actions_queryset = Action.objects.filter(
+            id__in=[slack_action_1.id, slack_action_2.id]
+        ).annotate(
+            workflow_id=models.Case(
+                models.When(id=slack_action_1.id, then=models.Value(1)),
+                models.When(id=slack_action_2.id, then=models.Value(2)),
+                output_field=models.IntegerField(),
+            )
+        )
+
+        result = deduplicate_actions(actions_queryset)
+
+        # Both actions should remain since they're from different workflows
+        result_ids = list(result.values_list("id", flat=True))
+        assert len(result_ids) == 2
+        assert slack_action_1.id in result_ids
+        assert slack_action_2.id in result_ids

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -302,9 +302,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
         process_workflows(self.event_data)
 
         assert WorkflowFireHistory.objects.count() == 3
-        assert (
-            mock_trigger_action.call_count == 1
-        )  # TODO: determine if this is ideal, the actions are duped but not in the same workflows
+        assert mock_trigger_action.call_count == 3
 
 
 @mock_redis_buffer()


### PR DESCRIPTION
Thanks to @cathteng  for finding this bug:
>For the current configuration of metric detectors + workflows this works as intended because we want to not double trigger a warning+critical action upon escalation if they are identical (e.g. notify a Slack channel), and we should just send 1 notification.
For issue alerts, should this still be the case? Two separate workflows can be sending to the same Slack channel (and have 2 different Action objects). If they are both triggered by a single event, I believe our deduping mechanism will send a single notification. I wrote a test [here](https://github.com/getsentry/sentry/pull/97746/files#diff-38a8af68c7706ef3cf69e9178a67f467a3e5fc9c6fb5f65fda546dfd345e6fa9R276) that shows the current behavior in workflow engine. In the existing system we would send two notifications. (Note that this is different from the case where the same action is connected to 2 workflows, in that case we’d send 1 notification)

this pr fixes the behavior by making the dedupe key `workflow_id` aware
