### PR TITLE
ref(replay): hide num_feedbacks_used tag from replay/uf search

### DIFF
--- a/static/app/components/feedback/feedbackSearch.tsx
+++ b/static/app/components/feedback/feedbackSearch.tsx
@@ -35,6 +35,7 @@ const EXCLUDED_TAGS: string[] = [
   'os',
   'user',
   FieldKey.PLATFORM,
+  'feedback.num_feedbacks_used',
 ];
 
 const NON_TAG_FIELDS: string[] = [

--- a/static/app/views/replays/list/replaySearchBar.tsx
+++ b/static/app/views/replays/list/replaySearchBar.tsx
@@ -47,7 +47,7 @@ const REPLAY_CLICK_FIELDS_AS_TAGS = fieldDefinitionsToTagCollection(REPLAY_CLICK
  * device.name, etc are effectively the same and included from REPLAY_FIELDS.
  * Displaying these would be redundant and confusing.
  */
-const EXCLUDED_TAGS = ['browser', 'device', 'os', 'user'];
+const EXCLUDED_TAGS = ['browser', 'device', 'os', 'user', 'feedback.num_feedbacks_used'];
 
 /**
  * Merges a list of supported tags and replay search properties


### PR DESCRIPTION
closes https://linear.app/getsentry/issue/REPLAY-626/investigate-if-items-should-appear-in-replay-search

we were exposing the `num_feedbacks_used` tag in both replay & feedback search which we don't need/want. the other feedback tags remaining:
- `type`: "positive" or "negative"
- `owner`: string
- `source`: string
are still useful to be searched on. for replays too, we are able to use these search terms to look for replays that contain feedbacks with those specific tags

before:
<img width="672" height="352" alt="SCR-20250813-jpvq" src="https://github.com/user-attachments/assets/6b789d0c-d0c1-4747-b9bc-1cc818c2fc7a" />


<img width="266" height="343" alt="SCR-20250813-jkww" src="https://github.com/user-attachments/assets/65dfde68-123b-4696-8947-582f480341d4" />


after:

<img width="661" height="379" alt="SCR-20250813-jplm" src="https://github.com/user-attachments/assets/54af8d74-9758-44c7-b792-d21c1301a89c" />

<img width="506" height="340" alt="SCR-20250813-jggg" src="https://github.com/user-attachments/assets/695e7df7-60a3-41dc-91eb-2f92cefa97dd" />


