### PR TITLE
fix(recommended-event): Add subquery to limit ordering to last 1000 events

### DIFF
--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -314,6 +314,7 @@ def get_recommended_event(
         referrer="Group.get_helpful",
         dataset=dataset,
         tenant_ids={"organization_id": group.project.organization_id},
+        inner_limit=1000,
     )
 
     if events:

--- a/src/sentry/services/eventstore/base.py
+++ b/src/sentry/services/eventstore/base.py
@@ -191,6 +191,7 @@ class EventStorage(Service):
         conditions: Sequence[Condition],
         orderby: Sequence[str],
         limit: int = 100,
+        inner_limit: int | None = None,
         offset: int = 0,
         referrer: str = "eventstore.get_events_snql",
         dataset: Dataset = Dataset.Events,

--- a/src/sentry/testutils/pytest/metrics.py
+++ b/src/sentry/testutils/pytest/metrics.py
@@ -4,7 +4,7 @@ import functools
 from unittest import mock
 
 import pytest
-from snuba_sdk import Entity, Join
+from snuba_sdk import Entity, Join, Query
 
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 
@@ -70,7 +70,11 @@ def control_metrics_access(request, set_sentry_option):
                 query = args[0][0].request.query
                 is_performance_metrics = False
                 is_metrics = False
-                if not isinstance(query, MetricsQuery) and not isinstance(query.match, Join):
+                if (
+                    not isinstance(query, MetricsQuery)
+                    and not isinstance(query.match, Join)
+                    and not isinstance(query.match, Query)
+                ):
                     is_performance_metrics = query.match.name.startswith("generic")
                     is_metrics = "metrics" in query.match.name
 
@@ -93,7 +97,7 @@ def control_metrics_access(request, set_sentry_option):
                 query = snql_query.query
                 is_performance_metrics = False
                 is_metrics = False
-                if isinstance(query.match, Entity):
+                if isinstance(query.match, Entity) and not isinstance(query.match, Query):
                     is_performance_metrics = query.match.name.startswith("generic")
                     is_metrics = "metrics" in query.match.name
 


### PR DESCRIPTION
Followup to https://getsentry.atlassian.net/browse/INC-1319

When there is a very large number of recent events, the recommended event query will time out. The current logic is:

- Query for events in the past 7 days
- Sort by a number of properties: https://github.com/getsentry/sentry/blob/8fb2fd435af0ebfb84d3ad6104f8019ce11edffd/src/sentry/models/group.py#L225-L232
- Return the top result

This PR adds an `inner_limit` option to `get_events_snql()` that will create a initial subquery for the most recent n events before applying the sort order on top of it. The recommended event query supplies `inner_limit=1000` which should retain similar behavior and be much more performant when there are a large number of events.