### PR TITLE
ref(alerts): Remove getDynamicText from alerts pages

### DIFF
--- a/static/app/views/alerts/list/incidents/row.tsx
+++ b/static/app/views/alerts/list/incidents/row.tsx
@@ -15,7 +15,6 @@ import {space} from 'sentry/styles/space';
 import type {Actor} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
-import getDynamicText from 'sentry/utils/getDynamicText';
 import type {Incident} from 'sentry/views/alerts/types';
 import {IncidentStatus} from 'sentry/views/alerts/types';
 import {alertDetailsLink} from 'sentry/views/alerts/utils';
@@ -58,14 +57,11 @@ function AlertListRow({incident, projectsLoaded, projects, organization}: Props)
       </FlexCenter>
 
       <NoWrapNumeric>
-        {getDynamicText({
-          value: <TimeSince date={incident.dateStarted} unitStyle="extraShort" />,
-          fixed: '1w ago',
-        })}
+        <TimeSince date={incident.dateStarted} unitStyle="extraShort" />
       </NoWrapNumeric>
       <NoWrapNumeric>
         {incident.status === IncidentStatus.CLOSED ? (
-          <Duration seconds={getDynamicText({value: duration, fixed: 1200})} />
+          <Duration seconds={duration} />
         ) : (
           <Tag type="warning">{t('Still Active')}</Tag>
         )}

--- a/static/app/views/alerts/rules/issue/details/alertChart.tsx
+++ b/static/app/views/alerts/rules/issue/details/alertChart.tsx
@@ -12,7 +12,6 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {IssueAlertRule, ProjectAlertRuleStats} from 'sentry/types/alerts';
 import type {Project} from 'sentry/types/project';
-import getDynamicText from 'sentry/utils/getDynamicText';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import RouteError from 'sentry/views/routeError';
@@ -64,44 +63,41 @@ export function IssueAlertDetailsChart({
         <ChartHeader>
           <HeaderTitleLegend>{t('Alerts Triggered')}</HeaderTitleLegend>
         </ChartHeader>
-        {getDynamicText({
-          value: isPending ? (
-            <Placeholder height="200px" />
-          ) : (
-            <ChartZoom period={period} start={start} end={end} utc={utc} usePageDate>
-              {zoomRenderProps => (
-                <AreaChart
-                  {...zoomRenderProps}
-                  isGroupedByDate
-                  showTimeInTooltip
-                  grid={{
-                    left: space(0.25),
-                    right: space(2),
-                    top: space(3),
-                    bottom: 0,
-                  }}
-                  yAxis={{
-                    minInterval: 1,
-                  }}
-                  series={[
-                    {
-                      seriesName: 'Alerts Triggered',
-                      data:
-                        ruleFireHistory?.map(alert => ({
-                          name: alert.date,
-                          value: alert.count,
-                        })) ?? [],
-                      emphasis: {
-                        disabled: true,
-                      },
+        {isPending ? (
+          <Placeholder height="200px" />
+        ) : (
+          <ChartZoom period={period} start={start} end={end} utc={utc} usePageDate>
+            {zoomRenderProps => (
+              <AreaChart
+                {...zoomRenderProps}
+                isGroupedByDate
+                showTimeInTooltip
+                grid={{
+                  left: space(0.25),
+                  right: space(2),
+                  top: space(3),
+                  bottom: 0,
+                }}
+                yAxis={{
+                  minInterval: 1,
+                }}
+                series={[
+                  {
+                    seriesName: 'Alerts Triggered',
+                    data:
+                      ruleFireHistory?.map(alert => ({
+                        name: alert.date,
+                        value: alert.count,
+                      })) ?? [],
+                    emphasis: {
+                      disabled: true,
                     },
-                  ]}
-                />
-              )}
-            </ChartZoom>
-          ),
-          fixed: <Placeholder height="200px" testId="skeleton-ui" />,
-        })}
+                  },
+                ]}
+              />
+            )}
+          </ChartZoom>
+        )}
       </StyledPanelBody>
       <ChartFooter>
         <FooterHeader>{t('Total Alerts')}</FooterHeader>

--- a/static/app/views/alerts/rules/issue/details/issuesList.tsx
+++ b/static/app/views/alerts/rules/issue/details/issuesList.tsx
@@ -16,7 +16,6 @@ import type {Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
 import {getMessage, getTitle} from 'sentry/utils/events';
 import type {FeedbackIssue} from 'sentry/utils/feedback/types';
-import getDynamicText from 'sentry/utils/getDynamicText';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import {makeFeedbackPathname} from 'sentry/views/userFeedback/pathnames';
@@ -115,15 +114,7 @@ function AlertRuleIssuesList({project, rule, period, start, end, utc, cursor}: P
                 <Count value={issue.count} />
               </AlignRight>
               <div>
-                <StyledDateTime
-                  date={getDynamicText({
-                    value: lastTriggered,
-                    fixed: 'Mar 16, 2020 9:10:13 AM UTC',
-                  })}
-                  year
-                  seconds
-                  timeZone
-                />
+                <StyledDateTime date={lastTriggered} year seconds timeZone />
               </div>
             </Fragment>
           );

--- a/static/app/views/alerts/rules/metric/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricChart.tsx
@@ -43,7 +43,6 @@ import type {Project} from 'sentry/types/project';
 import toArray from 'sentry/utils/array/toArray';
 import {DiscoverDatasets, SavedQueryDatasets} from 'sentry/utils/discover/types';
 import getDuration from 'sentry/utils/duration/getDuration';
-import getDynamicText from 'sentry/utils/getDynamicText';
 import {shouldShowOnDemandMetricAlertUI} from 'sentry/utils/onDemandMetrics/features';
 import {MINUTES_THRESHOLD_TO_DISPLAY_SECONDS} from 'sentry/utils/sessions';
 import {capitalize} from 'sentry/utils/string/capitalize';
@@ -419,33 +418,28 @@ export default function MetricChart({
                 <QueryFilters>{queryFilter}</QueryFilters>
               </Tooltip>
             </ChartFilters>
-            {getDynamicText({
-              value: (
-                <ChartZoom
-                  start={start}
-                  end={end}
-                  onZoom={zoomArgs => handleZoom(zoomArgs.start, zoomArgs.end)}
-                >
-                  {zoomRenderProps => (
-                    <AreaChart
-                      {...zoomRenderProps}
-                      {...chartOption}
-                      showTimeInTooltip
-                      minutesThresholdToDisplaySeconds={minutesThresholdToDisplaySeconds}
-                      additionalSeries={additionalSeries}
-                      tooltip={getMetricChartTooltipFormatter({
-                        formattedAggregate,
-                        rule,
-                        interval,
-                        comparisonSeriesName,
-                        theme,
-                      })}
-                    />
-                  )}
-                </ChartZoom>
-              ),
-              fixed: <Placeholder height="200px" testId="skeleton-ui" />,
-            })}
+            <ChartZoom
+              start={start}
+              end={end}
+              onZoom={zoomArgs => handleZoom(zoomArgs.start, zoomArgs.end)}
+            >
+              {zoomRenderProps => (
+                <AreaChart
+                  {...zoomRenderProps}
+                  {...chartOption}
+                  showTimeInTooltip
+                  minutesThresholdToDisplaySeconds={minutesThresholdToDisplaySeconds}
+                  additionalSeries={additionalSeries}
+                  tooltip={getMetricChartTooltipFormatter({
+                    formattedAggregate,
+                    rule,
+                    interval,
+                    comparisonSeriesName,
+                    theme,
+                  })}
+                />
+              )}
+            </ChartZoom>
           </StyledPanelBody>
           {renderChartActions(
             totalDuration,

--- a/static/app/views/alerts/rules/metric/details/metricHistory.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricHistory.tsx
@@ -13,7 +13,6 @@ import {t, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
 import getDuration from 'sentry/utils/duration/getDuration';
-import getDynamicText from 'sentry/utils/getDynamicText';
 import {capitalize} from 'sentry/utils/string/capitalize';
 import useOrganization from 'sentry/utils/useOrganization';
 import {COMPARISON_DELTA_OPTIONS} from 'sentry/views/alerts/rules/metric/constants';
@@ -122,22 +121,10 @@ function MetricAlertActivity({organization, incident}: MetricAlertActivityProps)
         )}
       </Cell>
       <Cell>
-        {activityDuration &&
-          getDynamicText({
-            value: <Duration abbreviation seconds={activityDuration / 1000} />,
-            fixed: '30s',
-          })}
+        {activityDuration && <Duration abbreviation seconds={activityDuration / 1000} />}
       </Cell>
       <Cell>
-        <StyledDateTime
-          date={getDynamicText({
-            value: incident.dateCreated,
-            fixed: 'Mar 4, 2022 10:44:13 AM UTC',
-          })}
-          year
-          seconds
-          timeZone
-        />
+        <StyledDateTime date={incident.dateCreated} year seconds timeZone />
       </Cell>
     </Fragment>
   );

--- a/static/app/views/alerts/rules/metric/details/sidebar.tsx
+++ b/static/app/views/alerts/rules/metric/details/sidebar.tsx
@@ -15,7 +15,6 @@ import {IconDiamond, IconMegaphone} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Actor} from 'sentry/types/core';
-import getDynamicText from 'sentry/utils/getDynamicText';
 import {getSearchFilters, isOnDemandSearchKey} from 'sentry/utils/onDemandMetrics/index';
 import {capitalize} from 'sentry/utils/string/capitalize';
 import {isChonkTheme} from 'sentry/utils/theme/withChonk';
@@ -258,15 +257,7 @@ export function MetricDetailsSidebar({
           />
           <KeyValueTableRow
             keyName={t('Date created')}
-            value={
-              <DateTime
-                date={getDynamicText({
-                  value: rule.dateCreated,
-                  fixed: new Date('2021-04-20'),
-                })}
-                format="ll"
-              />
-            }
+            value={<DateTime date={rule.dateCreated} format="ll" />}
           />
           {rule.createdBy && (
             <KeyValueTableRow


### PR DESCRIPTION
No longer needed since we don't do screenshot testing
