### PR TITLE
ref(settings): Remove getDynamicText from settings

### DIFF
--- a/static/app/views/settings/account/apiApplications/details.tsx
+++ b/static/app/views/settings/account/apiApplications/details.tsx
@@ -21,7 +21,6 @@ import apiApplication from 'sentry/data/forms/apiApplication';
 import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import type {ApiApplication} from 'sentry/types/user';
-import getDynamicText from 'sentry/utils/getDynamicText';
 import {
   useApiQuery,
   useMutation,
@@ -116,11 +115,7 @@ function ApiApplicationsDetails() {
 
           <PanelBody>
             <FormField name="clientID" label="Client ID" flexibleControlStateSize>
-              {({value}: any) => (
-                <TextCopyInput>
-                  {getDynamicText({value, fixed: 'CI_CLIENT_ID'})}
-                </TextCopyInput>
-              )}
+              {({value}: any) => <TextCopyInput>{value}</TextCopyInput>}
             </FormField>
 
             <FormField
@@ -132,9 +127,7 @@ function ApiApplicationsDetails() {
             >
               {({value}: any) =>
                 value ? (
-                  <TextCopyInput>
-                    {getDynamicText({value, fixed: 'CI_CLIENT_SECRET'})}
-                  </TextCopyInput>
+                  <TextCopyInput>{value}</TextCopyInput>
                 ) : (
                   <ClientSecret>
                     <HiddenSecret>{t('hidden')}</HiddenSecret>

--- a/static/app/views/settings/account/apiApplications/row.tsx
+++ b/static/app/views/settings/account/apiApplications/row.tsx
@@ -14,7 +14,6 @@ import {IconDelete} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {ApiApplication} from 'sentry/types/user';
-import getDynamicText from 'sentry/utils/getDynamicText';
 import useApi from 'sentry/utils/useApi';
 
 const ROUTE_PREFIX = '/settings/account/api/';
@@ -52,11 +51,9 @@ function Row({app, onRemove}: Props) {
     <StyledPanelItem>
       <ApplicationNameWrapper>
         <ApplicationName to={`${ROUTE_PREFIX}applications/${app.id}/`}>
-          {getDynamicText({value: app.name, fixed: 'CI_APPLICATION_NAME'})}
+          {app.name}
         </ApplicationName>
-        <ClientId>
-          {getDynamicText({value: app.clientID, fixed: 'CI_CLIENT_ID'})}
-        </ClientId>
+        <ClientId>{app.clientID}</ClientId>
       </ApplicationNameWrapper>
 
       <ConfirmDelete

--- a/static/app/views/settings/account/apiTokenRow.tsx
+++ b/static/app/views/settings/account/apiTokenRow.tsx
@@ -9,7 +9,6 @@ import {DateTime} from 'sentry/components/dateTime';
 import {IconDelete} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {InternalAppApiToken} from 'sentry/types/user';
-import getDynamicText from 'sentry/utils/getDynamicText';
 import {tokenPreview} from 'sentry/views/settings/organizationAuthTokens';
 
 type Props = {
@@ -32,13 +31,7 @@ function ApiTokenRow({
       <div>
         {token.name}
         <TokenPreview aria-label={t('Token preview')}>
-          {tokenPreview(
-            getDynamicText({
-              value: token.tokenLastCharacters,
-              fixed: 'ABCD',
-            }),
-            tokenPrefix
-          )}
+          {tokenPreview(token.tokenLastCharacters, tokenPrefix)}
         </TokenPreview>
       </div>
       <div>

--- a/static/app/views/settings/organizationAuthTokens/authTokenRow.tsx
+++ b/static/app/views/settings/organizationAuthTokens/authTokenRow.tsx
@@ -13,7 +13,6 @@ import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import type {OrgAuthToken} from 'sentry/types/user';
-import getDynamicText from 'sentry/utils/getDynamicText';
 import {tokenPreview} from 'sentry/views/settings/organizationAuthTokens';
 
 function LastUsed({
@@ -29,14 +28,7 @@ function LastUsed({
     return (
       <Fragment>
         {tct('[date] in project [project]', {
-          date: (
-            <TimeSince
-              date={getDynamicText({
-                value: dateLastUsed,
-                fixed: new Date(1508208080000), // National Pasta Day
-              })}
-            />
-          ),
+          date: <TimeSince date={dateLastUsed} />,
           project: (
             <Link to={`/settings/${organization.slug}/projects/${projectLastUsed.slug}/`}>
               {projectLastUsed.name}
@@ -50,12 +42,7 @@ function LastUsed({
   if (dateLastUsed) {
     return (
       <Fragment>
-        <TimeSince
-          date={getDynamicText({
-            value: dateLastUsed,
-            fixed: new Date(1508208080000), // National Pasta Day
-          })}
-        />
+        <TimeSince date={dateLastUsed} />
       </Fragment>
     );
   }
@@ -103,13 +90,7 @@ export function OrganizationAuthTokensAuthTokenRow({
 
         {token.tokenLastCharacters && (
           <TokenPreview aria-label={t('Token preview')}>
-            {tokenPreview(
-              getDynamicText({
-                value: token.tokenLastCharacters,
-                fixed: 'ABCD',
-              }),
-              'sntrys_'
-            )}
+            {tokenPreview(token.tokenLastCharacters, 'sntrys_')}
           </TokenPreview>
         )}
       </div>
@@ -119,12 +100,7 @@ export function OrganizationAuthTokensAuthTokenRow({
           <Placeholder height="1.25em" />
         ) : (
           <Fragment>
-            <TimeSince
-              date={getDynamicText({
-                value: token.dateCreated,
-                fixed: new Date(1508208080000), // National Pasta Day
-              })}
-            />
+            <TimeSince date={token.dateCreated} />
           </Fragment>
         )}
       </DateTime>

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
@@ -41,7 +41,6 @@ import type {Avatar, Scope} from 'sentry/types/core';
 import type {SentryApp, SentryAppAvatar} from 'sentry/types/integrations';
 import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import type {InternalAppApiToken, NewInternalAppApiToken} from 'sentry/types/user';
-import getDynamicText from 'sentry/utils/getDynamicText';
 import {
   setApiQueryData,
   useApiQuery,
@@ -462,11 +461,7 @@ export default function SentryApplicationDetails(props: Props) {
               <PanelBody>
                 {app.status !== 'internal' && (
                   <FormField name="clientId" label="Client ID">
-                    {({value, id}: any) => (
-                      <TextCopyInput id={id}>
-                        {getDynamicText({value, fixed: 'CI_CLIENT_ID'})}
-                      </TextCopyInput>
-                    )}
+                    {({value, id}: any) => <TextCopyInput id={id}>{value}</TextCopyInput>}
                   </FormField>
                 )}
                 <FormField
@@ -485,9 +480,7 @@ export default function SentryApplicationDetails(props: Props) {
                           'Only Manager or Owner can view these credentials, or the permissions for this integration exceed those of your role.'
                         )}
                       >
-                        <TextCopyInput id={id}>
-                          {getDynamicText({value, fixed: 'CI_CLIENT_SECRET'})}
-                        </TextCopyInput>
+                        <TextCopyInput id={id}>{value}</TextCopyInput>
                       </Tooltip>
                     ) : (
                       <ClientSecret>

--- a/static/app/views/settings/project/projectKeys/details/loaderSettings.tsx
+++ b/static/app/views/settings/project/projectKeys/details/loaderSettings.tsx
@@ -13,7 +13,6 @@ import SelectField from 'sentry/components/forms/fields/selectField';
 import TextCopyInput from 'sentry/components/textCopyInput';
 import {t, tct} from 'sentry/locale';
 import type {Project, ProjectKey} from 'sentry/types/project';
-import getDynamicText from 'sentry/utils/getDynamicText';
 import {handleXhrErrorResponse} from 'sentry/utils/handleXhrErrorResponse';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import useApi from 'sentry/utils/useApi';
@@ -57,10 +56,7 @@ export function LoaderSettings({keyId, orgSlug, project, data, updateData}: Prop
     : [];
 
   const apiEndpoint = `/projects/${orgSlug}/${project.slug}/keys/${keyId}/`;
-  const loaderLink = getDynamicText({
-    value: data.dsn.cdn,
-    fixed: '__JS_SDK_LOADER_URL__',
-  });
+  const loaderLink = data.dsn.cdn;
 
   const updateLoaderOption = useCallback(
     async (changes: {

--- a/static/app/views/settings/project/projectKeys/list/loaderScript.tsx
+++ b/static/app/views/settings/project/projectKeys/list/loaderScript.tsx
@@ -9,7 +9,6 @@ import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import type {ProjectKey} from 'sentry/types/project';
-import getDynamicText from 'sentry/utils/getDynamicText';
 import recreateRoute from 'sentry/utils/recreateRoute';
 
 type Props = {
@@ -17,10 +16,7 @@ type Props = {
 } & Pick<RouteComponentProps, 'routes' | 'location' | 'params'>;
 
 export function LoaderScript({projectKey, routes, params, location}: Props) {
-  const loaderLink = getDynamicText({
-    value: projectKey.dsn.cdn,
-    fixed: '__JS_SDK_LOADER_URL__',
-  });
+  const loaderLink = projectKey.dsn.cdn;
 
   const editUrl = recreateRoute(`${projectKey.id}/`, {routes, params, location});
 

--- a/static/app/views/settings/project/projectKeys/projectKeyCredentials.tsx
+++ b/static/app/views/settings/project/projectKeys/projectKeyCredentials.tsx
@@ -7,7 +7,6 @@ import TextCopyInput from 'sentry/components/textCopyInput';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {ProjectKey} from 'sentry/types/project';
-import getDynamicText from 'sentry/utils/getDynamicText';
 
 type Props = {
   data: ProjectKey;
@@ -53,12 +52,7 @@ function ProjectKeyCredentials({
             ) : null,
           })}
         >
-          <TextCopyInput aria-label={t('DSN URL')}>
-            {getDynamicText({
-              value: data.dsn.public,
-              fixed: '__DSN__',
-            })}
-          </TextCopyInput>
+          <TextCopyInput aria-label={t('DSN URL')}>{data.dsn.public}</TextCopyInput>
           {showDeprecatedDsn && (
             <StyledField
               label={null}
@@ -68,12 +62,7 @@ function ProjectKeyCredentials({
               inline={false}
               flexibleControlStateSize
             >
-              <TextCopyInput>
-                {getDynamicText({
-                  value: data.dsn.secret,
-                  fixed: '__DSN_DEPRECATED__',
-                })}
-              </TextCopyInput>
+              <TextCopyInput>{data.dsn.secret}</TextCopyInput>
             </StyledField>
           )}
         </FieldGroup>
@@ -89,12 +78,7 @@ function ProjectKeyCredentials({
           inline={false}
           flexibleControlStateSize
         >
-          <TextCopyInput>
-            {getDynamicText({
-              value: data.dsn.secret,
-              fixed: '__DSN_DEPRECATED__',
-            })}
-          </TextCopyInput>
+          <TextCopyInput>{data.dsn.secret}</TextCopyInput>
         </FieldGroup>
       )}
 
@@ -107,10 +91,7 @@ function ProjectKeyCredentials({
             flexibleControlStateSize
           >
             <TextCopyInput aria-label={t('OTLP Traces Endpoint')}>
-              {getDynamicText({
-                value: data.dsn.otlp_traces,
-                fixed: '__OTLP_ENDPOINT__',
-              })}
+              {data.dsn.otlp_traces}
             </TextCopyInput>
           </FieldGroup>
 
@@ -121,10 +102,7 @@ function ProjectKeyCredentials({
             flexibleControlStateSize
           >
             <TextCopyInput aria-label={t('OTLP Traces Endpoint Headers')}>
-              {getDynamicText({
-                value: `x-sentry-auth=sentry sentry_key=${data.public}`,
-                fixed: '__OTLP_ENDPOINT_HEADERS__',
-              })}
+              {`x-sentry-auth=sentry sentry_key=${data.public}`}
             </TextCopyInput>
           </FieldGroup>
         </Fragment>
@@ -144,10 +122,7 @@ function ProjectKeyCredentials({
           flexibleControlStateSize
         >
           <TextCopyInput aria-label={t('Security Header Endpoint URL')}>
-            {getDynamicText({
-              value: data.dsn.security,
-              fixed: '__SECURITY_HEADER_ENDPOINT__',
-            })}
+            {data.dsn.security}
           </TextCopyInput>
         </FieldGroup>
       )}
@@ -169,10 +144,7 @@ function ProjectKeyCredentials({
           flexibleControlStateSize
         >
           <TextCopyInput aria-label={t('Minidump Endpoint URL')}>
-            {getDynamicText({
-              value: data.dsn.minidump,
-              fixed: '__MINIDUMP_ENDPOINT__',
-            })}
+            {data.dsn.minidump}
           </TextCopyInput>
         </FieldGroup>
       )}
@@ -185,44 +157,26 @@ function ProjectKeyCredentials({
           flexibleControlStateSize
         >
           <TextCopyInput aria-label={t('Unreal Engine Endpoint URL')}>
-            {getDynamicText({
-              value: data.dsn.unreal || '',
-              fixed: '__UNREAL_ENDPOINT__',
-            })}
+            {data.dsn.unreal || ''}
           </TextCopyInput>
         </FieldGroup>
       )}
 
       {showPublicKey && (
         <FieldGroup label={t('Public Key')} inline flexibleControlStateSize>
-          <TextCopyInput>
-            {getDynamicText({
-              value: data.public,
-              fixed: '__PUBLICKEY__',
-            })}
-          </TextCopyInput>
+          <TextCopyInput>{data.public}</TextCopyInput>
         </FieldGroup>
       )}
 
       {showSecretKey && (
         <FieldGroup label={t('Secret Key')} inline flexibleControlStateSize>
-          <TextCopyInput>
-            {getDynamicText({
-              value: data.secret,
-              fixed: '__SECRETKEY__',
-            })}
-          </TextCopyInput>
+          <TextCopyInput>{data.secret}</TextCopyInput>
         </FieldGroup>
       )}
 
       {showProjectId && (
         <FieldGroup label={t('Project ID')} inline flexibleControlStateSize>
-          <TextCopyInput>
-            {getDynamicText({
-              value: projectId,
-              fixed: '__PROJECTID__',
-            })}
-          </TextCopyInput>
+          <TextCopyInput>{projectId}</TextCopyInput>
         </FieldGroup>
       )}
 

--- a/static/app/views/settings/project/projectReleaseTracking.tsx
+++ b/static/app/views/settings/project/projectReleaseTracking.tsx
@@ -18,7 +18,6 @@ import {t, tct} from 'sentry/locale';
 import type {Plugin} from 'sentry/types/integrations';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
-import getDynamicText from 'sentry/utils/getDynamicText';
 import {
   setApiQueryData,
   useApiQuery,
@@ -220,21 +219,9 @@ function ProjectReleaseTracking({organization, project, plugins}: Props) {
             )}
           </p>
 
-          {getDynamicText({
-            value: (
-              <AutoSelectText>
-                <pre>{getReleaseWebhookIntructions()}</pre>
-              </AutoSelectText>
-            ),
-            fixed: (
-              <pre>
-                {`curl __WEBHOOK_URL__ \\
--X POST \\
--H 'Content-Type: application/json' \\
--d \'{"version": "abcdefg"}\'`}
-              </pre>
-            ),
-          })}
+          <AutoSelectText>
+            <pre>{getReleaseWebhookIntructions()}</pre>
+          </AutoSelectText>
         </PanelBody>
       </Panel>
 

--- a/static/app/views/settings/projectPlugins/details.tsx
+++ b/static/app/views/settings/projectPlugins/details.tsx
@@ -19,7 +19,6 @@ import {space} from 'sentry/styles/space';
 import type {Plugin} from 'sentry/types/integrations';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
-import getDynamicText from 'sentry/utils/getDynamicText';
 import {trackIntegrationAnalytics} from 'sentry/utils/integrationUtil';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useApi from 'sentry/utils/useApi';
@@ -202,12 +201,7 @@ function ProjectPluginDetails({organization, plugins, project}: Props) {
                 </div>
               )}
               <dt>{t('Version')}</dt>
-              <dd>
-                {getDynamicText({
-                  value: pluginDetails.version,
-                  fixed: '1.0.0',
-                })}
-              </dd>
+              <dd>{pluginDetails.version}</dd>
             </dl>
 
             {pluginDetails.description && (

--- a/static/app/views/settings/projectPlugins/projectPluginRow.tsx
+++ b/static/app/views/settings/projectPlugins/projectPluginRow.tsx
@@ -11,7 +11,6 @@ import type {Plugin} from 'sentry/types/integrations';
 import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
-import getDynamicText from 'sentry/utils/getDynamicText';
 import {trackIntegrationAnalytics} from 'sentry/utils/integrationUtil';
 import recreateRoute from 'sentry/utils/recreateRoute';
 import withOrganization from 'sentry/utils/withOrganization';
@@ -64,12 +63,7 @@ class ProjectPluginRow extends PureComponent<Props> {
                 <PluginDescription>
                   <PluginName>
                     {`${name} `}
-                    {getDynamicText({
-                      value: (
-                        <Version>{version ? `v${version}` : <em>{t('n/a')}</em>}</Version>
-                      ),
-                      fixed: <Version>v10</Version>,
-                    })}
+                    <Version>{version ? `v${version}` : <em>{t('n/a')}</em>}</Version>
                   </PluginName>
                   <div>
                     {author && (

--- a/static/app/views/settings/projectSecurityHeaders/reportUri.tsx
+++ b/static/app/views/settings/projectSecurityHeaders/reportUri.tsx
@@ -7,16 +7,12 @@ import PanelHeader from 'sentry/components/panels/panelHeader';
 import TextCopyInput from 'sentry/components/textCopyInput';
 import {t, tct} from 'sentry/locale';
 import type {ProjectKey} from 'sentry/types/project';
-import getDynamicText from 'sentry/utils/getDynamicText';
 
 const DEFAULT_ENDPOINT = 'https://sentry.example.com/api/security-report/';
 
 export function getSecurityDsn(keyList: ProjectKey[]) {
   const endpoint = keyList.length ? keyList[0]!.dsn.security : DEFAULT_ENDPOINT;
-  return getDynamicText({
-    value: endpoint,
-    fixed: DEFAULT_ENDPOINT,
-  });
+  return endpoint;
 }
 
 type Props = {


### PR DESCRIPTION
Removes dynamic text values from the settings pages. No longer needed now that we don't have screenshot testing
