### PR TITLE
feat(aci): default to the error detector for grouptypes without detector

### DIFF
--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -36,7 +36,6 @@ def get_detector_by_event(event_data: WorkflowEventData) -> Detector:
 
     try:
         if issue_occurrence is None or evt.group.issue_type.detector_settings is None:
-            # TODO - @saponifi3d - check to see if there's a way to confirm these are for the error detector
             # if there are no detector settings, default to the error detector
             detector = Detector.objects.get(project_id=evt.project_id, type=ErrorGroupType.slug)
         else:

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -23,6 +23,8 @@ logger = logging.getLogger(__name__)
 
 
 def get_detector_by_event(event_data: WorkflowEventData) -> Detector:
+    from sentry.grouping.grouptype import ErrorGroupType
+
     evt = event_data.event
 
     if not isinstance(evt, GroupEvent):
@@ -33,11 +35,10 @@ def get_detector_by_event(event_data: WorkflowEventData) -> Detector:
     issue_occurrence = evt.occurrence
 
     try:
-        if issue_occurrence is None:
+        if issue_occurrence is None or evt.group.issue_type.detector_settings is None:
             # TODO - @saponifi3d - check to see if there's a way to confirm these are for the error detector
-            detector = Detector.objects.get(
-                project_id=evt.project_id, type=evt.group.issue_type.slug
-            )
+            # if there are no detector settings, default to the error detector
+            detector = Detector.objects.get(project_id=evt.project_id, type=ErrorGroupType.slug)
         else:
             detector = Detector.objects.get(
                 id=issue_occurrence.evidence_data.get("detector_id", None)

--- a/tests/sentry/workflow_engine/processors/test_detector.py
+++ b/tests/sentry/workflow_engine/processors/test_detector.py
@@ -8,6 +8,7 @@ import pytest
 from django.utils import timezone
 
 from sentry.incidents.grouptype import MetricIssue
+from sentry.issues.grouptype import PerformanceNPlusOneAPICallsGroupType
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.issues.producer import PayloadType
 from sentry.issues.status_change_message import StatusChangeMessage
@@ -919,6 +920,33 @@ class TestGetDetectorByEvent(TestCase):
 
         with pytest.raises(Detector.DoesNotExist):
             get_detector_by_event(event_data)
+
+    def test_defaults_to_error_detector(self) -> None:
+        occurrence = IssueOccurrence(
+            id=uuid.uuid4().hex,
+            project_id=self.project.id,
+            event_id="asdf",
+            fingerprint=["asdf"],
+            issue_title="title",
+            subtitle="subtitle",
+            resource_id=None,
+            evidence_data={},
+            evidence_display=[],
+            type=PerformanceNPlusOneAPICallsGroupType,
+            detection_time=timezone.now(),
+            level="error",
+            culprit="",
+        )
+
+        group_event = GroupEvent.from_event(self.event, self.group)
+        self.group.update(type=PerformanceNPlusOneAPICallsGroupType.type_id)
+        group_event.occurrence = occurrence
+
+        event_data = WorkflowEventData(event=group_event, group=self.group)
+
+        result = get_detector_by_event(event_data)
+
+        assert result == self.error_detector
 
 
 class TestGetDetectorsByGroupEventsBulk(TestCase):

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -304,6 +304,14 @@ class TestProcessWorkflows(BaseWorkflowTest):
         assert WorkflowFireHistory.objects.count() == 3
         assert mock_trigger_action.call_count == 3
 
+    def test_defaults_to_error_workflows(self) -> None:
+        issue_occurrence = self.build_occurrence()
+        self.group_event.occurrence = issue_occurrence
+        self.group.update(type=issue_occurrence.type.type_id)
+
+        triggered_workflows = process_workflows(self.event_data)
+        assert triggered_workflows == {self.error_workflow}
+
 
 @mock_redis_buffer()
 class TestEvaluateWorkflowTriggers(BaseWorkflowTest):


### PR DESCRIPTION
To prepare for moving rule processing for all issue types to workflow engine, we need to default to selecting the error detector if a GroupType does not yet have a Detector/DetectorHandler configured.

Rules process all issue (group) types today. In workflow engine, a workflow will only process an event if it's connected to the detector for the event's group type. Since the detectors for all issue group types do not yet exist, we'll need to somehow send those events through to the project's workflows (aka migrated version of rules). We can do this by defaulting to the error detector, which exists for every project and is connected to all of the project's workflows.

When a grouptype defines the `DetectorSettings` on it, we'll fetch the detector according to the `detector_id` in the issue occurrence's `evidence_data`. We will always fetch the error detector if an event does not have an issue occurrence (errors don't have them).