### PR TITLE
ref(groupingInfo): add highlight to contributing values when All Values is set

### DIFF
--- a/static/app/components/events/groupingInfo/groupingComponent.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponent.tsx
@@ -70,17 +70,14 @@ export const GroupingValue = styled('code')<{
   margin: ${space(0.25)} ${space(0.5)} ${space(0.25)} 0;
   font-size: ${p => p.theme.fontSize.sm};
   padding: 0 ${space(0.25)};
-  background: ${p =>
-    p.contributes && p.showNonContributing
-      ? 'rgba(64, 123, 255, 0.15)'
-      : 'rgba(112, 163, 214, 0.1)'};
-  color: ${p => p.theme.textColor};
+  background: rgba(112, 163, 214, 0.1);
+  color: ${p => (p.contributes ? p.theme.textColor : p.theme.subText)};
 
-  ${({valueType, theme}) =>
+  ${({valueType, theme, contributes}) =>
     (valueType === 'function' || valueType === 'symbol') &&
     css`
-      font-weight: ${theme.fontWeight.bold};
-      color: ${theme.textColor};
+      font-weight: ${contributes ? theme.fontWeight.bold : 'normal'};
+      color: ${contributes ? theme.textColor : theme.subText};
     `}
 `;
 

--- a/static/app/components/events/groupingInfo/groupingComponent.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponent.tsx
@@ -70,7 +70,7 @@ export const GroupingValue = styled('code')<{
   margin: ${space(0.25)} ${space(0.5)} ${space(0.25)} 0;
   font-size: ${p => p.theme.fontSize.sm};
   padding: 0 ${space(0.25)};
-  background: rgba(112, 163, 214, 0.1);
+  background: ${p => (p.contributes ? 'rgba(112, 163, 214, 0.1)' : 'transparent')};
   color: ${p => (p.contributes ? p.theme.textColor : p.theme.subText)};
 
   ${({valueType, theme, contributes}) =>

--- a/static/app/components/events/groupingInfo/groupingComponent.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponent.tsx
@@ -64,7 +64,6 @@ export const GroupingComponentListItem = styled('li')<{isCollapsible?: boolean}>
 export const GroupingValue = styled('code')<{
   valueType: string;
   contributes?: boolean;
-  showNonContributing?: boolean;
 }>`
   display: inline-block;
   margin: ${space(0.25)} ${space(0.5)} ${space(0.25)} 0;

--- a/static/app/components/events/groupingInfo/groupingComponent.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponent.tsx
@@ -61,12 +61,19 @@ export const GroupingComponentListItem = styled('li')<{isCollapsible?: boolean}>
     `}
 `;
 
-export const GroupingValue = styled('code')<{valueType: string}>`
+export const GroupingValue = styled('code')<{
+  valueType: string;
+  contributes?: boolean;
+  showNonContributing?: boolean;
+}>`
   display: inline-block;
   margin: ${space(0.25)} ${space(0.5)} ${space(0.25)} 0;
   font-size: ${p => p.theme.fontSize.sm};
   padding: 0 ${space(0.25)};
-  background: rgba(112, 163, 214, 0.1);
+  background: ${p =>
+    p.contributes && p.showNonContributing
+      ? 'rgba(64, 123, 255, 0.15)'
+      : 'rgba(112, 163, 214, 0.1)'};
   color: ${p => p.theme.textColor};
 
   ${({valueType, theme}) =>
@@ -78,7 +85,7 @@ export const GroupingValue = styled('code')<{valueType: string}>`
 `;
 
 const GroupingComponentWrapper = styled('div')<{isContributing: boolean}>`
-  color: ${p => (p.isContributing ? null : p.theme.textColor)};
+  color: ${p => (p.isContributing ? p.theme.textColor : p.theme.subText)};
 
   ${GroupingValue}, button {
     opacity: 1;

--- a/static/app/components/events/groupingInfo/groupingComponentChildren.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponentChildren.tsx
@@ -26,7 +26,14 @@ function GroupingComponentChildren({component, showNonContributing}: Props) {
                 showNonContributing={showNonContributing}
               />
             ) : (
-              <GroupingValue valueType={component.name || component.id}>
+              <GroupingValue
+                valueType={component.name || component.id}
+                contributes={
+                  component.contributes ||
+                  (typeof value === 'object' && value?.contributes)
+                }
+                showNonContributing={showNonContributing}
+              >
                 {typeof value === 'string' || typeof value === 'number'
                   ? value
                   : JSON.stringify(value, null, 2)}

--- a/static/app/components/events/groupingInfo/groupingComponentChildren.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponentChildren.tsx
@@ -32,7 +32,6 @@ function GroupingComponentChildren({component, showNonContributing}: Props) {
                   component.contributes ||
                   (typeof value === 'object' && value?.contributes)
                 }
-                showNonContributing={showNonContributing}
               >
                 {typeof value === 'string' || typeof value === 'number'
                   ? value

--- a/static/app/components/events/groupingInfo/groupingComponentChildren.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponentChildren.tsx
@@ -28,10 +28,7 @@ function GroupingComponentChildren({component, showNonContributing}: Props) {
             ) : (
               <GroupingValue
                 valueType={component.name || component.id}
-                contributes={
-                  component.contributes ||
-                  (typeof value === 'object' && value?.contributes)
-                }
+                contributes={component.contributes}
               >
                 {typeof value === 'string' || typeof value === 'number'
                   ? value


### PR DESCRIPTION
For #72288.

Highlight contributing values and grey non-contributing values in stacktrace when toggle is switched to 'All Values'. This makes it easier to tell which values are actually contributing and which are not. 

before:
<img width="890" height="626" alt="image" src="https://github.com/user-attachments/assets/36270f84-6545-4cf9-9543-6ece0c5dbfad" />
after:
<img width="911" height="638" alt="image" src="https://github.com/user-attachments/assets/5cd6b565-affa-4232-b9ba-bc0d885fb430" />
