### PR TITLE
fix(issues): Use new group-first-seen for "age" search sort

### DIFF
--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -721,7 +721,7 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
 
     aggregation_defs = {
         "times_seen": ["count()", ""],
-        "first_seen": ["multiply(toUInt64(min(timestamp)), 1000)", ""],
+        "first_seen": ["multiply(toUInt64(min(coalesce(group_first_seen, timestamp))), 1000)", ""],
         "last_seen": ["multiply(toUInt64(max(timestamp)), 1000)", ""],
         "trends": trends_aggregation,
         # Only makes sense with WITH TOTALS, returns 1 for an individual group.


### PR DESCRIPTION
# Summary

This is part of an effort to fix the issue-search's sort-by-age feature. As part of that feature, we are adding the "first_seen" time of a group to each error. When we merge groups, we want to update the errors to have the new group's "group_first_seen".

This PR finally uses that field as sort key. For events that don't have the field (for backwards compatibility), it coalesces down into the event timestamp. Because event timestamp is strictly greater-than-or-equal-to issue age, the "functional age" used in the sort should be correct as long as one event in the search window has the new field.

# Test Plan

Loaded the issue search in my local dev environment; saw no errors using the new sort strategy. 