### PR TITLE
feat(aci): add bulk actions to detector list table

### DIFF
--- a/static/app/views/detectors/components/detectorListTable/actions.tsx
+++ b/static/app/views/detectors/components/detectorListTable/actions.tsx
@@ -1,0 +1,255 @@
+import {Fragment, useCallback, useState} from 'react';
+import styled from '@emotion/styled';
+
+import {openConfirmModal} from 'sentry/components/confirm';
+import {Alert} from 'sentry/components/core/alert';
+import {Button} from 'sentry/components/core/button';
+import {Checkbox} from 'sentry/components/core/checkbox';
+import {Flex} from 'sentry/components/core/layout';
+import {Tooltip} from 'sentry/components/core/tooltip';
+import {SimpleTable} from 'sentry/components/tables/simpleTable';
+import {t, tct, tn} from 'sentry/locale';
+import {decodeScalar} from 'sentry/utils/queryString';
+import useLocationQuery from 'sentry/utils/url/useLocationQuery';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import {useDeleteDetectorsMutation} from 'sentry/views/detectors/hooks/useDeleteDetectorsMutation';
+import {useUpdateDetectorsMutation} from 'sentry/views/detectors/hooks/useEditDetectorsMutation';
+
+interface DetectorsTableActionsProps {
+  allResultsVisible: boolean;
+  canEdit: boolean;
+  detectorLimitReached: boolean;
+  pageSelected: boolean;
+  queryCount: string;
+  selected: Set<string>;
+  showDisable: boolean;
+  showEnable: boolean;
+  togglePageSelected: (pageSelected: boolean) => void;
+}
+
+export function DetectorsTableActions({
+  selected,
+  pageSelected,
+  togglePageSelected,
+  queryCount,
+  allResultsVisible,
+  showEnable,
+  showDisable,
+  canEdit,
+  detectorLimitReached,
+}: DetectorsTableActionsProps) {
+  const [allInQuerySelected, setAllInQuerySelected] = useState(false);
+  const anySelected = selected.size > 0;
+
+  const {selection} = usePageFilters();
+  const {query} = useLocationQuery({
+    fields: {
+      query: decodeScalar,
+    },
+  });
+
+  const {mutateAsync: deleteDetectors, isPending: isDeleting} =
+    useDeleteDetectorsMutation();
+  const {mutateAsync: updateDetectors, isPending: isUpdating} =
+    useUpdateDetectorsMutation();
+
+  const getEnableConfirmMessage = useCallback(() => {
+    if (allInQuerySelected) {
+      return tct(
+        'Are you sure you want to enable all [queryCount] monitors that match the search?',
+        {
+          queryCount,
+        }
+      );
+    }
+    return tn(
+      `Are you sure you want to enable this %s monitor?`,
+      `Are you sure you want to enable these %s monitors?`,
+      selected.size
+    );
+  }, [allInQuerySelected, queryCount, selected.size]);
+
+  const getDisableConfirmMessage = useCallback(() => {
+    if (allInQuerySelected) {
+      return tct(
+        'Are you sure you want to disable all [queryCount] monitors that match the search?',
+        {
+          queryCount,
+        }
+      );
+    }
+    return tn(
+      `Are you sure you want to disable this %s monitor?`,
+      `Are you sure you want to disable these %s monitors?`,
+      selected.size
+    );
+  }, [allInQuerySelected, queryCount, selected.size]);
+
+  const handleUpdate = useCallback(
+    ({enabled}: {enabled: boolean}) => {
+      openConfirmModal({
+        message: enabled ? getEnableConfirmMessage() : getDisableConfirmMessage(),
+        confirmText: enabled ? t('Enable') : t('Disable'),
+        priority: 'danger',
+        onConfirm: async () => {
+          if (allInQuerySelected) {
+            await updateDetectors({enabled, query, projects: selection.projects});
+          } else {
+            await updateDetectors({enabled, ids: Array.from(selected)});
+          }
+          togglePageSelected(false);
+        },
+      });
+    },
+    [
+      selected,
+      allInQuerySelected,
+      updateDetectors,
+      getEnableConfirmMessage,
+      getDisableConfirmMessage,
+      togglePageSelected,
+      selection.projects,
+      query,
+    ]
+  );
+
+  const getDeleteConfirmMessage = useCallback(() => {
+    if (allInQuerySelected) {
+      return tct(
+        'Are you sure you want to delete all [queryCount] monitors that match the search?',
+        {
+          queryCount,
+        }
+      );
+    }
+    return tn(
+      `Are you sure you want to delete this %s monitor?`,
+      `Are you sure you want to delete these %s monitors?`,
+      selected.size
+    );
+  }, [allInQuerySelected, queryCount, selected.size]);
+
+  const handleDelete = useCallback(() => {
+    openConfirmModal({
+      message: getDeleteConfirmMessage(),
+      confirmText: t('Delete'),
+      priority: 'danger',
+      onConfirm: async () => {
+        if (allInQuerySelected) {
+          await deleteDetectors({query, projects: selection.projects});
+        } else {
+          await deleteDetectors({ids: Array.from(selected)});
+        }
+        togglePageSelected(false);
+      },
+    });
+  }, [
+    selected,
+    allInQuerySelected,
+    deleteDetectors,
+    getDeleteConfirmMessage,
+    togglePageSelected,
+    selection.projects,
+    query,
+  ]);
+
+  return (
+    <Fragment>
+      <SimpleTable.Header>
+        <ActionsBarWrapper>
+          <Checkbox
+            checked={pageSelected || (anySelected ? 'indeterminate' : false)}
+            onChange={s => {
+              togglePageSelected(s.target.checked);
+              setAllInQuerySelected(false);
+            }}
+          />
+          {showEnable && (
+            <Tooltip
+              title={
+                canEdit
+                  ? detectorLimitReached
+                    ? "You've reached your plan's limit on metric monitors."
+                    : ''
+                  : 'You do not have permission to modify the selected monitors.'
+              }
+              disabled={canEdit && !detectorLimitReached}
+            >
+              <Button
+                size="xs"
+                onClick={() => handleUpdate({enabled: true})}
+                disabled={isUpdating || !canEdit || detectorLimitReached}
+              >
+                {t('Enable')}
+              </Button>
+            </Tooltip>
+          )}
+          {showDisable && (
+            <Tooltip
+              title={'You do not have permission to modify the selected monitors.'}
+              disabled={canEdit}
+            >
+              <Button
+                size="xs"
+                onClick={() => handleUpdate({enabled: false})}
+                disabled={isUpdating || !canEdit}
+              >
+                {t('Disable')}
+              </Button>
+            </Tooltip>
+          )}
+          <Tooltip
+            title={t('You do not have permission to delete the selected monitors.')}
+            disabled={canEdit}
+          >
+            <Button
+              size="xs"
+              priority="danger"
+              onClick={handleDelete}
+              disabled={isDeleting || !canEdit}
+            >
+              {t('Delete')}
+            </Button>
+          </Tooltip>
+        </ActionsBarWrapper>
+      </SimpleTable.Header>
+      {pageSelected && !allResultsVisible && (
+        <FullWidthAlert type="warning" showIcon={false}>
+          <Flex justify="center" wrap="wrap" gap="md">
+            {allInQuerySelected ? (
+              tct('Selected all [count] monitors that match this search query.', {
+                count: queryCount,
+              })
+            ) : (
+              <Fragment>
+                {tn(
+                  '%s monitor on this page selected.',
+                  '%s monitors on this page selected.',
+                  selected.size
+                )}
+                <Button priority={'link'} onClick={() => setAllInQuerySelected(true)}>
+                  {tct('Select all [count] monitors that match this search query.', {
+                    count: queryCount,
+                  })}
+                </Button>
+              </Fragment>
+            )}
+          </Flex>
+        </FullWidthAlert>
+      )}
+    </Fragment>
+  );
+}
+
+const FullWidthAlert = styled(Alert)`
+  grid-column: 1 / -1;
+`;
+
+const ActionsBarWrapper = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${p => p.theme.space.md};
+  padding: 0 ${p => p.theme.space.xl};
+  width: 100%;
+  grid-column: 1 / -1;
+`;

--- a/static/app/views/detectors/components/detectorListTable/detectorListRow.tsx
+++ b/static/app/views/detectors/components/detectorListTable/detectorListRow.tsx
@@ -1,5 +1,7 @@
 import styled from '@emotion/styled';
 
+import {Checkbox} from 'sentry/components/core/checkbox';
+import {Flex} from 'sentry/components/core/layout';
 import Placeholder from 'sentry/components/placeholder';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {IssueCell} from 'sentry/components/workflowEngine/gridCell/issueCell';
@@ -11,16 +13,28 @@ import {DetectorTypeCell} from 'sentry/views/detectors/components/detectorListTa
 
 interface DetectorListRowProps {
   detector: Detector;
+  onSelect: (id: string) => void;
+  selected: boolean;
 }
 
-export function DetectorListRow({detector}: DetectorListRowProps) {
+export function DetectorListRow({detector, selected, onSelect}: DetectorListRowProps) {
   return (
     <DetectorSimpleTableRow
       variant={detector.enabled ? 'default' : 'faded'}
       data-test-id="detector-list-row"
     >
       <SimpleTable.RowCell>
-        <DetectorLink detector={detector} />
+        <Flex gap="md">
+          <CheckboxWrapper>
+            <Checkbox
+              checked={selected}
+              onChange={() => onSelect(detector.id)}
+              className="select-row"
+            />
+          </CheckboxWrapper>
+
+          <DetectorLink detector={detector} />
+        </Flex>
       </SimpleTable.RowCell>
       <SimpleTable.RowCell data-column-name="type">
         <DetectorTypeCell type={detector.type} />
@@ -65,4 +79,20 @@ export function DetectorListRowSkeleton() {
 
 const DetectorSimpleTableRow = styled(SimpleTable.Row)`
   min-height: 76px;
+
+  @media (hover: hover) {
+    &:not(:has(:hover)):not(:has(input:checked)) {
+      .select-row {
+        ${p => p.theme.visuallyHidden}
+      }
+    }
+  }
+`;
+
+const CheckboxWrapper = styled('div')`
+  width: 20px;
+  height: 20px;
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
 `;

--- a/static/app/views/detectors/components/detectorListTable/detectorListRow.tsx
+++ b/static/app/views/detectors/components/detectorListTable/detectorListRow.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 
 import {Checkbox} from 'sentry/components/core/checkbox';
+import {Flex} from 'sentry/components/core/layout';
 import Placeholder from 'sentry/components/placeholder';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {IssueCell} from 'sentry/components/workflowEngine/gridCell/issueCell';
@@ -22,17 +23,18 @@ export function DetectorListRow({detector, selected, onSelect}: DetectorListRowP
       variant={detector.enabled ? 'default' : 'faded'}
       data-test-id="detector-list-row"
     >
-      <StyledRowCell data-column-name="selected">
-        <CheckboxWrapper>
-          <Checkbox
-            checked={selected}
-            onChange={() => onSelect(detector.id)}
-            className="select-row"
-          />
-        </CheckboxWrapper>
-      </StyledRowCell>
-      <SimpleTable.RowCell data-column-name="name">
-        <DetectorLink detector={detector} />
+      <SimpleTable.RowCell>
+        <Flex gap="md">
+          <CheckboxWrapper>
+            <Checkbox
+              checked={selected}
+              onChange={() => onSelect(detector.id)}
+              className="select-row"
+            />
+          </CheckboxWrapper>
+
+          <DetectorLink detector={detector} />
+        </Flex>
       </SimpleTable.RowCell>
       <SimpleTable.RowCell data-column-name="type">
         <DetectorTypeCell type={detector.type} />
@@ -88,10 +90,9 @@ const DetectorSimpleTableRow = styled(SimpleTable.Row)`
 `;
 
 const CheckboxWrapper = styled('div')`
-  height: 100%;
-  align-self: flex-start;
-`;
-
-const StyledRowCell = styled(SimpleTable.RowCell)`
-  height: 100%;
+  width: 20px;
+  height: 20px;
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
 `;

--- a/static/app/views/detectors/components/detectorListTable/detectorListRow.tsx
+++ b/static/app/views/detectors/components/detectorListTable/detectorListRow.tsx
@@ -1,7 +1,6 @@
 import styled from '@emotion/styled';
 
 import {Checkbox} from 'sentry/components/core/checkbox';
-import {Flex} from 'sentry/components/core/layout';
 import Placeholder from 'sentry/components/placeholder';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {IssueCell} from 'sentry/components/workflowEngine/gridCell/issueCell';
@@ -23,18 +22,17 @@ export function DetectorListRow({detector, selected, onSelect}: DetectorListRowP
       variant={detector.enabled ? 'default' : 'faded'}
       data-test-id="detector-list-row"
     >
-      <SimpleTable.RowCell>
-        <Flex gap="md">
-          <CheckboxWrapper>
-            <Checkbox
-              checked={selected}
-              onChange={() => onSelect(detector.id)}
-              className="select-row"
-            />
-          </CheckboxWrapper>
-
-          <DetectorLink detector={detector} />
-        </Flex>
+      <StyledRowCell data-column-name="selected">
+        <CheckboxWrapper>
+          <Checkbox
+            checked={selected}
+            onChange={() => onSelect(detector.id)}
+            className="select-row"
+          />
+        </CheckboxWrapper>
+      </StyledRowCell>
+      <SimpleTable.RowCell data-column-name="name">
+        <DetectorLink detector={detector} />
       </SimpleTable.RowCell>
       <SimpleTable.RowCell data-column-name="type">
         <DetectorTypeCell type={detector.type} />
@@ -90,9 +88,10 @@ const DetectorSimpleTableRow = styled(SimpleTable.Row)`
 `;
 
 const CheckboxWrapper = styled('div')`
-  width: 20px;
-  height: 20px;
-  display: flex;
-  align-items: center;
-  flex-shrink: 0;
+  height: 100%;
+  align-self: flex-start;
+`;
+
+const StyledRowCell = styled(SimpleTable.RowCell)`
+  height: 100%;
 `;

--- a/static/app/views/detectors/components/detectorListTable/index.tsx
+++ b/static/app/views/detectors/components/detectorListTable/index.tsx
@@ -1,4 +1,4 @@
-import {type ComponentProps, useCallback, useMemo, useState} from 'react';
+import {useCallback, useMemo, useState, type ComponentProps} from 'react';
 import styled from '@emotion/styled';
 
 import {hasEveryAccess} from 'sentry/components/acl/access';

--- a/static/app/views/detectors/components/detectorListTable/index.tsx
+++ b/static/app/views/detectors/components/detectorListTable/index.tsx
@@ -1,6 +1,7 @@
-import type {ComponentProps} from 'react';
+import {type ComponentProps, useCallback, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 
+import {hasEveryAccess} from 'sentry/components/acl/access';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -8,17 +9,23 @@ import type {Detector} from 'sentry/types/workflowEngine/detectors';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
+import useOrganization from 'sentry/utils/useOrganization';
+import useProjects from 'sentry/utils/useProjects';
+import {DetectorsTableActions} from 'sentry/views/detectors/components/detectorListTable/actions';
 import {
   DetectorListRow,
   DetectorListRowSkeleton,
 } from 'sentry/views/detectors/components/detectorListTable/detectorListRow';
 import {DETECTOR_LIST_PAGE_LIMIT} from 'sentry/views/detectors/constants';
+import {detectorTypeIsUserCreateable} from 'sentry/views/detectors/utils/detectorTypeConfig';
 
 type DetectorListTableProps = {
+  allResultsVisible: boolean;
   detectors: Detector[];
   isError: boolean;
   isPending: boolean;
   isSuccess: boolean;
+  queryCount: string;
   sort: Sort | undefined;
 };
 
@@ -71,44 +78,146 @@ function DetectorListTable({
   isError,
   isSuccess,
   sort,
+  queryCount,
+  allResultsVisible,
 }: DetectorListTableProps) {
+  const organization = useOrganization();
+  const {projects} = useProjects();
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+
+  const detectorIds = new Set(detectors.map(d => d.id));
+  const togglePageSelected = (pageSelected: boolean) => {
+    if (pageSelected) {
+      setSelected(detectorIds);
+    } else {
+      setSelected(new Set<string>());
+    }
+  };
+  const pageSelected = detectorIds.difference(selected).size === 0;
+
+  const handleSelect = useCallback(
+    (id: string) => {
+      const newSelected = new Set(selected);
+      if (newSelected.has(id)) {
+        newSelected.delete(id);
+      } else {
+        newSelected.add(id);
+      }
+      setSelected(newSelected);
+    },
+    [selected]
+  );
+
+  const canEnable = useMemo(
+    () => detectors.some(d => selected.has(d.id) && !d.enabled),
+    [detectors, selected]
+  );
+  const canDisable = useMemo(
+    () => detectors.some(d => selected.has(d.id) && d.enabled),
+    [detectors, selected]
+  );
+
+  const canEditDetectors = useMemo(() => {
+    const selectedDetectors = detectors.filter(d => selected.has(d.id));
+    const projectToDetectors: Record<string, Detector[]> = {};
+
+    if (
+      organization.access.includes('org:write') ||
+      organization.access.includes('org:admin')
+    ) {
+      return true;
+    }
+
+    for (const detector of selectedDetectors) {
+      const projectId = detector.projectId;
+      if (!projectToDetectors[projectId]) {
+        projectToDetectors[projectId] = [];
+      }
+      projectToDetectors[projectId]?.push(detector);
+    }
+
+    for (const projectId of Object.keys(projectToDetectors)) {
+      const project = projects.find(p => p.id === projectId) ?? undefined;
+      if (!project) {
+        return false;
+      }
+
+      if (hasEveryAccess(['alerts:write', 'project:read'], {organization, project})) {
+        // team admins can modify all detectors for projects they have admin access to
+        if (project.access.includes('project:write')) {
+          continue;
+        }
+        // members can modify only user-createable detectors for projects they have access to
+        if (
+          projectToDetectors[projectId]?.every(d => detectorTypeIsUserCreateable(d.type))
+        ) {
+          continue;
+        }
+      }
+      return false;
+    }
+
+    return true;
+  }, [selected, detectors, organization, projects]);
+
   return (
     <Container>
       <DetectorListSimpleTable>
-        <SimpleTable.Header>
-          <HeaderCell sortKey="name" sort={sort}>
-            {t('Name')}
-          </HeaderCell>
-          <HeaderCell data-column-name="type" divider sortKey="type" sort={sort}>
-            {t('Type')}
-          </HeaderCell>
-          <HeaderCell
-            data-column-name="last-issue"
-            divider
-            sortKey="latestGroup"
-            sort={sort}
-          >
-            {t('Last Issue')}
-          </HeaderCell>
-          <HeaderCell data-column-name="assignee" divider sort={sort}>
-            {t('Assignee')}
-          </HeaderCell>
-          <HeaderCell
-            data-column-name="connected-automations"
-            divider
-            sortKey="connectedWorkflows"
-            sort={sort}
-          >
-            {t('Automations')}
-          </HeaderCell>
-        </SimpleTable.Header>
+        {selected.size === 0 ? (
+          <SimpleTable.Header>
+            <HeaderCell sortKey="name" sort={sort}>
+              <NamePadding>{t('Name')}</NamePadding>
+            </HeaderCell>
+            <HeaderCell data-column-name="type" divider sortKey="type" sort={sort}>
+              {t('Type')}
+            </HeaderCell>
+            <HeaderCell
+              data-column-name="last-issue"
+              divider
+              sortKey="latestGroup"
+              sort={sort}
+            >
+              {t('Last Issue')}
+            </HeaderCell>
+            <HeaderCell data-column-name="assignee" divider sort={sort}>
+              {t('Assignee')}
+            </HeaderCell>
+            <HeaderCell
+              data-column-name="connected-automations"
+              divider
+              sortKey="connectedWorkflows"
+              sort={sort}
+            >
+              {t('Automations')}
+            </HeaderCell>
+          </SimpleTable.Header>
+        ) : (
+          <DetectorsTableActions
+            key="actions"
+            selected={selected}
+            pageSelected={pageSelected}
+            togglePageSelected={togglePageSelected}
+            queryCount={queryCount}
+            allResultsVisible={allResultsVisible}
+            showDisable={canDisable}
+            showEnable={canEnable}
+            canEdit={canEditDetectors}
+            // TODO: Check if metric detector limit is reached
+            detectorLimitReached={false}
+          />
+        )}
         {isError && <SimpleTable.Empty>{t('Error loading monitors')}</SimpleTable.Empty>}
         {isPending && <LoadingSkeletons />}
         {isSuccess && detectors.length === 0 && (
           <SimpleTable.Empty>{t('No monitors found')}</SimpleTable.Empty>
         )}
         {detectors.map(detector => (
-          <DetectorListRow key={detector.id} detector={detector} />
+          <DetectorListRow
+            key={detector.id}
+            detector={detector}
+            selected={selected.has(detector.id)}
+            onSelect={handleSelect}
+          />
         ))}
       </DetectorListSimpleTable>
     </Container>
@@ -117,6 +226,10 @@ function DetectorListTable({
 
 const Container = styled('div')`
   container-type: inline-size;
+`;
+
+const NamePadding = styled('div')`
+  padding-left: 28px;
 `;
 
 const DetectorListSimpleTable = styled(SimpleTable)`

--- a/static/app/views/detectors/components/detectorListTable/index.tsx
+++ b/static/app/views/detectors/components/detectorListTable/index.tsx
@@ -1,7 +1,6 @@
 import {useCallback, useMemo, useState, type ComponentProps} from 'react';
 import styled from '@emotion/styled';
 
-import {Checkbox} from 'sentry/components/core/checkbox';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -121,16 +120,8 @@ function DetectorListTable({
       <DetectorListSimpleTable>
         {selected.size === 0 ? (
           <SimpleTable.Header>
-            <HeaderCell sort={sort}>
-              <Checkbox
-                checked={pageSelected || (selected.size > 0 ? 'indeterminate' : false)}
-                onChange={s => {
-                  togglePageSelected(s.target.checked);
-                }}
-              />
-            </HeaderCell>
             <HeaderCell sortKey="name" sort={sort}>
-              {t('Name')}
+              <NamePadding>{t('Name')}</NamePadding>
             </HeaderCell>
             <HeaderCell data-column-name="type" divider sortKey="type" sort={sort}>
               {t('Type')}
@@ -192,8 +183,12 @@ const Container = styled('div')`
   container-type: inline-size;
 `;
 
+const NamePadding = styled('div')`
+  padding-left: 28px;
+`;
+
 const DetectorListSimpleTable = styled(SimpleTable)`
-  grid-template-columns: 30px 1fr;
+  grid-template-columns: 1fr;
 
   margin-bottom: ${space(2)};
 
@@ -205,7 +200,7 @@ const DetectorListSimpleTable = styled(SimpleTable)`
   }
 
   @container (min-width: ${p => p.theme.breakpoints.xs}) {
-    grid-template-columns: 30px 3fr 0.8fr;
+    grid-template-columns: 3fr 0.8fr;
 
     [data-column-name='type'] {
       display: flex;
@@ -213,7 +208,7 @@ const DetectorListSimpleTable = styled(SimpleTable)`
   }
 
   @container (min-width: ${p => p.theme.breakpoints.sm}) {
-    grid-template-columns: 30px 3fr 0.8fr 1.5fr 0.8fr;
+    grid-template-columns: 3fr 0.8fr 1.5fr 0.8fr;
 
     [data-column-name='last-issue'] {
       display: flex;
@@ -221,7 +216,7 @@ const DetectorListSimpleTable = styled(SimpleTable)`
   }
 
   @container (min-width: ${p => p.theme.breakpoints.md}) {
-    grid-template-columns: 30px 3fr 0.8fr 1.5fr 0.8fr;
+    grid-template-columns: 3fr 0.8fr 1.5fr 0.8fr;
 
     [data-column-name='assignee'] {
       display: flex;
@@ -229,7 +224,7 @@ const DetectorListSimpleTable = styled(SimpleTable)`
   }
 
   @container (min-width: ${p => p.theme.breakpoints.lg}) {
-    grid-template-columns: 30px 4.5fr 0.8fr 1.5fr 0.8fr 2fr;
+    grid-template-columns: 4.5fr 0.8fr 1.5fr 0.8fr 2fr;
 
     [data-column-name='connected-automations'] {
       display: flex;

--- a/static/app/views/detectors/hooks/useDeleteDetectorsMutation.tsx
+++ b/static/app/views/detectors/hooks/useDeleteDetectorsMutation.tsx
@@ -33,7 +33,7 @@ export function useDeleteDetectorsMutation() {
       addSuccessMessage(t('Monitors deleted'));
     },
     onError: error => {
-      addErrorMessage(t('Unable to delete monitors: %s', error.message));
+      addErrorMessage(t('Unable to delete monitors: %s', error.responseText));
     },
   });
 }

--- a/static/app/views/detectors/hooks/useDeleteDetectorsMutation.tsx
+++ b/static/app/views/detectors/hooks/useDeleteDetectorsMutation.tsx
@@ -1,0 +1,39 @@
+import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
+import {t} from 'sentry/locale';
+import {useMutation, useQueryClient} from 'sentry/utils/queryClient';
+import type RequestError from 'sentry/utils/requestError/requestError';
+import useApi from 'sentry/utils/useApi';
+import useOrganization from 'sentry/utils/useOrganization';
+
+/** Bulk delete detectors */
+export function useDeleteDetectorsMutation() {
+  const org = useOrganization();
+  const api = useApi({persistInFlight: true});
+  const queryClient = useQueryClient();
+
+  return useMutation<
+    void,
+    RequestError,
+    {ids?: string[]; projects?: number[]; query?: string}
+  >({
+    mutationFn: params => {
+      return api.requestPromise(`/organizations/${org.slug}/detectors/`, {
+        method: 'DELETE',
+        query: {
+          id: params.ids,
+          query: params.query,
+          project: params.projects,
+        },
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [`/organizations/${org.slug}/detectors/`],
+      });
+      addSuccessMessage(t('Monitors deleted'));
+    },
+    onError: error => {
+      addErrorMessage(t('Unable to delete monitors: %s', error.message));
+    },
+  });
+}

--- a/static/app/views/detectors/hooks/useDeleteDetectorsMutation.tsx
+++ b/static/app/views/detectors/hooks/useDeleteDetectorsMutation.tsx
@@ -32,8 +32,8 @@ export function useDeleteDetectorsMutation() {
       });
       addSuccessMessage(t('Monitors deleted'));
     },
-    onError: error => {
-      addErrorMessage(t('Unable to delete monitors: %s', error.responseText));
+    onError: () => {
+      addErrorMessage(t('Unable to delete monitors'));
     },
   });
 }

--- a/static/app/views/detectors/hooks/useEditDetectorsMutation.tsx
+++ b/static/app/views/detectors/hooks/useEditDetectorsMutation.tsx
@@ -1,0 +1,48 @@
+import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
+import {t} from 'sentry/locale';
+import {useMutation, useQueryClient} from 'sentry/utils/queryClient';
+import type RequestError from 'sentry/utils/requestError/requestError';
+import useApi from 'sentry/utils/useApi';
+import useOrganization from 'sentry/utils/useOrganization';
+
+/** Bulk update detectors. Currently supports enabling/disabling detectors. */
+export function useUpdateDetectorsMutation() {
+  const org = useOrganization();
+  const api = useApi({persistInFlight: true});
+  const queryClient = useQueryClient();
+
+  return useMutation<
+    void,
+    RequestError,
+    {enabled: boolean; ids?: string[]; projects?: number[]; query?: string}
+  >({
+    mutationFn: params => {
+      return api.requestPromise(`/organizations/${org.slug}/detectors/`, {
+        method: 'PUT',
+        data: {enabled: params.enabled},
+        query: {
+          id: params.ids,
+          query: params.query,
+          project: params.projects,
+        },
+      });
+    },
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: [`/organizations/${org.slug}/detectors/`],
+      });
+      addSuccessMessage(
+        variables.enabled ? t('Monitors enabled') : t('Monitors disabled')
+      );
+    },
+    onError: (error, variables) => {
+      addErrorMessage(
+        t(
+          'Unable to %s monitors: %2$s',
+          variables.enabled ? t('enable') : t('disable'),
+          error.message
+        )
+      );
+    },
+  });
+}

--- a/static/app/views/detectors/hooks/useEditDetectorsMutation.tsx
+++ b/static/app/views/detectors/hooks/useEditDetectorsMutation.tsx
@@ -35,13 +35,9 @@ export function useUpdateDetectorsMutation() {
         variables.enabled ? t('Monitors enabled') : t('Monitors disabled')
       );
     },
-    onError: (error, variables) => {
+    onError: (_, variables) => {
       addErrorMessage(
-        t(
-          'Unable to %s monitors: %2$s',
-          variables.enabled ? t('enable') : t('disable'),
-          error.responseText
-        )
+        t('Unable to %s monitors', variables.enabled ? t('enable') : t('disable'))
       );
     },
   });

--- a/static/app/views/detectors/hooks/useEditDetectorsMutation.tsx
+++ b/static/app/views/detectors/hooks/useEditDetectorsMutation.tsx
@@ -40,7 +40,7 @@ export function useUpdateDetectorsMutation() {
         t(
           'Unable to %s monitors: %2$s',
           variables.enabled ? t('enable') : t('disable'),
-          error.message
+          error.responseText
         )
       );
     },

--- a/static/app/views/detectors/list.spec.tsx
+++ b/static/app/views/detectors/list.spec.tsx
@@ -6,6 +6,7 @@ import {UserFixture} from 'sentry-fixture/user';
 
 import {
   render,
+  renderGlobalModal,
   screen,
   userEvent,
   waitFor,
@@ -21,8 +22,11 @@ import {
 import {Dataset, EventTypes} from 'sentry/views/alerts/rules/metric/types';
 import DetectorsList from 'sentry/views/detectors/list';
 
-describe('DetectorsList', () => {
-  const organization = OrganizationFixture({features: ['workflow-engine-ui']});
+describe('DetectorsList', function () {
+  const organization = OrganizationFixture({
+    features: ['workflow-engine-ui'],
+    access: ['org:write'],
+  });
 
   beforeEach(() => {
     MockApiClient.clearMockResponses();
@@ -247,6 +251,305 @@ describe('DetectorsList', () => {
         );
       });
       expect(router.location.query.sort).toBe('-name');
+    });
+  });
+
+  describe('bulk actions', function () {
+    beforeEach(function () {
+      MockApiClient.clearMockResponses();
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/users/1/',
+        body: UserFixture(),
+      });
+      // Set up multiple detectors with different states
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/detectors/',
+        body: [
+          MetricDetectorFixture({
+            id: '1',
+            name: 'Enabled Detector',
+            workflowIds: [],
+            enabled: true,
+          }),
+          MetricDetectorFixture({
+            id: '2',
+            name: 'Disabled Detector',
+            workflowIds: [],
+            enabled: false,
+          }),
+          MetricDetectorFixture({
+            id: '3',
+            name: 'Another Enabled Detector',
+            workflowIds: [],
+            enabled: true,
+          }),
+        ],
+      });
+      PageFiltersStore.onInitializeUrlState(
+        PageFiltersFixture({projects: [1]}),
+        new Set()
+      );
+    });
+
+    it('can select detectors', async function () {
+      render(<DetectorsList />, {organization});
+      await screen.findByText('Enabled Detector');
+
+      const rows = screen.getAllByTestId('detector-list-row');
+      expect(rows).toHaveLength(3);
+
+      // Initially no checkboxes should be checked
+      const checkboxes = screen.getAllByRole('checkbox');
+      checkboxes.forEach(checkbox => {
+        expect(checkbox).not.toBeChecked();
+      });
+
+      // Select first detector
+      const firstRowCheckbox = within(rows[0]!).getByRole('checkbox');
+      await userEvent.click(firstRowCheckbox);
+      expect(firstRowCheckbox).toBeChecked();
+
+      // Master checkbox should be in indeterminate state
+      const masterCheckbox = screen.getAllByRole('checkbox')[0] as HTMLInputElement; // First checkbox is the master
+      expect(masterCheckbox.indeterminate).toBe(true);
+
+      // Should not show Enable button since we have no disabled detectors selected
+      expect(screen.queryByRole('button', {name: 'Enable'})).not.toBeInTheDocument();
+      // Should show Disable button since we have enabled detectors selected
+      expect(screen.getByRole('button', {name: 'Disable'})).toBeInTheDocument();
+      // Should always show Delete button
+      expect(screen.getByRole('button', {name: 'Delete'})).toBeInTheDocument();
+
+      // Select master checkbox to select all on page
+      await userEvent.click(masterCheckbox);
+      expect(masterCheckbox).toBeChecked();
+
+      // // All checkboxes should be checked
+      checkboxes.forEach(checkbox => {
+        expect(checkbox).toBeChecked();
+      });
+
+      // Should show Enable button since we have disabled detectors
+      expect(screen.getByRole('button', {name: 'Enable'})).toBeInTheDocument();
+      // Should show Disable button since we have enabled detectors
+      expect(screen.getByRole('button', {name: 'Disable'})).toBeInTheDocument();
+      // Should always show Delete button
+      expect(screen.getByRole('button', {name: 'Delete'})).toBeInTheDocument();
+    });
+
+    it('can enable selected detectors with confirmation', async function () {
+      const updateRequest = MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/detectors/',
+        method: 'PUT',
+        body: {},
+      });
+
+      render(<DetectorsList />, {organization});
+      renderGlobalModal();
+
+      await screen.findByText('Disabled Detector');
+
+      const rows = screen.getAllByTestId('detector-list-row');
+      const disabledRow = rows.find(row => within(row).queryByText('Disabled Detector'));
+      const disabledCheckbox = within(disabledRow!).getByRole('checkbox');
+      await userEvent.click(disabledCheckbox);
+
+      // Click Enable button
+      await userEvent.click(screen.getByRole('button', {name: 'Enable'}));
+
+      // Should show confirmation modal
+      const confirmModal = screen.getByRole('dialog');
+      expect(
+        screen.getByText(/Are you sure you want to enable this/)
+      ).toBeInTheDocument();
+
+      // Confirm the action
+      await userEvent.click(within(confirmModal).getByRole('button', {name: 'Enable'}));
+
+      await waitFor(() => {
+        expect(updateRequest).toHaveBeenCalledWith(
+          '/organizations/org-slug/detectors/',
+          expect.objectContaining({
+            data: {enabled: true},
+            query: {id: ['2'], query: undefined, project: undefined},
+          })
+        );
+      });
+    });
+
+    it('can disable selected detectors with confirmation', async function () {
+      const updateRequest = MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/detectors/',
+        method: 'PUT',
+        body: {},
+      });
+
+      render(<DetectorsList />, {organization});
+      renderGlobalModal();
+      await screen.findByText('Enabled Detector');
+
+      const rows = screen.getAllByTestId('detector-list-row');
+      const enabledRow = rows.find(row => within(row).queryByText('Enabled Detector'));
+      const enabledCheckbox = within(enabledRow!).getByRole('checkbox');
+      await userEvent.click(enabledCheckbox);
+
+      // Click Disable button
+      await userEvent.click(screen.getByRole('button', {name: 'Disable'}));
+
+      // Should show confirmation modal
+      const confirmModal = await screen.findByRole('dialog');
+      expect(
+        screen.getByText(/Are you sure you want to disable this/)
+      ).toBeInTheDocument();
+
+      // Confirm the action
+      await userEvent.click(within(confirmModal).getByRole('button', {name: 'Disable'}));
+
+      await waitFor(() => {
+        expect(updateRequest).toHaveBeenCalledWith(
+          '/organizations/org-slug/detectors/',
+          expect.objectContaining({
+            data: {enabled: false},
+            query: {id: ['1'], query: undefined, project: undefined},
+          })
+        );
+      });
+    });
+
+    it('can delete selected detectors with confirmation', async function () {
+      const deleteRequest = MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/detectors/',
+        method: 'DELETE',
+        body: {},
+      });
+
+      render(<DetectorsList />, {organization});
+      renderGlobalModal();
+      await screen.findByText('Enabled Detector');
+
+      const rows = screen.getAllByTestId('detector-list-row');
+      const firstRowCheckbox = within(rows[0]!).getByRole('checkbox');
+      await userEvent.click(firstRowCheckbox);
+
+      // Click Delete button
+      await userEvent.click(screen.getByRole('button', {name: 'Delete'}));
+
+      // Should show confirmation modal
+      const confirmModal = await screen.findByRole('dialog');
+      expect(
+        screen.getByText(/Are you sure you want to delete this/)
+      ).toBeInTheDocument();
+
+      // Confirm the action
+      await userEvent.click(within(confirmModal).getByRole('button', {name: 'Delete'}));
+
+      await waitFor(() => {
+        expect(deleteRequest).toHaveBeenCalledWith(
+          '/organizations/org-slug/detectors/',
+          expect.objectContaining({
+            query: {id: ['1'], query: undefined, project: undefined},
+          })
+        );
+      });
+    });
+
+    it('shows option to select all query results when page is selected', async function () {
+      const deleteRequest = MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/detectors/',
+        method: 'DELETE',
+        body: {},
+      });
+
+      render(<DetectorsList />, {organization});
+      renderGlobalModal();
+
+      const testUser = UserFixture({id: '2', email: 'test@example.com'});
+      // Mock the filtered search results - this will be used when search is applied
+      const filteredDetectors = Array.from({length: 20}, (_, i) =>
+        MetricDetectorFixture({
+          id: `filtered-${i}`,
+          name: `Assigned Detector ${i + 1}`,
+          owner: testUser.id,
+        })
+      );
+
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/detectors/',
+        body: filteredDetectors,
+        headers: {
+          'X-Hits': '50',
+        },
+        match: [MockApiClient.matchQuery({query: 'assignee:test@example.com'})],
+      });
+
+      // Click through menus to select assignee
+      const searchInput = await screen.findByRole('combobox', {
+        name: 'Add a search term',
+      });
+      await userEvent.type(searchInput, 'assignee:test@example.com');
+
+      // It takes two enters. One to enter the search term, and one to submit the search.
+      await userEvent.keyboard('{enter}');
+      await userEvent.keyboard('{enter}');
+
+      // Wait for filtered results to load
+      await screen.findByText('Assigned Detector 1');
+
+      const rows = screen.getAllByTestId('detector-list-row');
+
+      // Focus on first row to make checkbox visible
+      await userEvent.click(rows[0]!);
+      const firstRowCheckbox = within(rows[0]!).getByRole('checkbox');
+      await userEvent.click(firstRowCheckbox);
+      expect(firstRowCheckbox).toBeChecked();
+
+      // Select all on page - master checkbox should now be visible since we have a selection
+      const masterCheckbox = screen.getAllByRole('checkbox')[0]!;
+      await userEvent.click(masterCheckbox);
+
+      // Should show alert with option to select all query results
+      expect(screen.getByText(/20 monitors on this page selected/)).toBeInTheDocument();
+      const selectAllForQuery = screen.getByRole('button', {
+        name: /Select all 50 monitors that match this search query/,
+      });
+      await userEvent.click(selectAllForQuery);
+
+      // Perform an action to verify query-based selection
+      await userEvent.click(screen.getByRole('button', {name: 'Delete'}));
+      const confirmModal = await screen.findByRole('dialog');
+      await userEvent.click(within(confirmModal).getByRole('button', {name: 'Delete'})); // Confirm
+
+      await waitFor(() => {
+        expect(deleteRequest).toHaveBeenCalledWith(
+          '/organizations/org-slug/detectors/',
+          expect.objectContaining({
+            query: {id: undefined, query: 'assignee:test@example.com', project: [1]},
+          })
+        );
+      });
+    });
+
+    it('disables action buttons when user does not have permissions', async function () {
+      const noPermsOrganization = OrganizationFixture({
+        features: ['workflow-engine-ui'],
+        access: [],
+      });
+      render(<DetectorsList />, {organization: noPermsOrganization});
+      renderGlobalModal();
+
+      await screen.findByText('Disabled Detector');
+
+      const rows = screen.getAllByTestId('detector-list-row');
+      const disabledRow = rows.find(row => within(row).queryByText('Disabled Detector'));
+      const disabledCheckbox = within(disabledRow!).getByRole('checkbox');
+      await userEvent.click(disabledCheckbox);
+      const enabledRow = rows.find(row => within(row).queryByText('Enabled Detector'));
+      const enabledCheckbox = within(enabledRow!).getByRole('checkbox');
+      await userEvent.click(enabledCheckbox);
+
+      expect(screen.getByRole('button', {name: 'Enable'})).toBeDisabled();
+      expect(screen.getByRole('button', {name: 'Disable'})).toBeDisabled();
+      expect(screen.getByRole('button', {name: 'Delete'})).toBeDisabled();
     });
   });
 });

--- a/static/app/views/detectors/list.spec.tsx
+++ b/static/app/views/detectors/list.spec.tsx
@@ -22,7 +22,7 @@ import {
 import {Dataset, EventTypes} from 'sentry/views/alerts/rules/metric/types';
 import DetectorsList from 'sentry/views/detectors/list';
 
-describe('DetectorsList', function () {
+describe('DetectorsList', () => {
   const organization = OrganizationFixture({
     features: ['workflow-engine-ui'],
     access: ['org:write'],
@@ -254,8 +254,8 @@ describe('DetectorsList', function () {
     });
   });
 
-  describe('bulk actions', function () {
-    beforeEach(function () {
+  describe('bulk actions', () => {
+    beforeEach(() => {
       MockApiClient.clearMockResponses();
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/users/1/',
@@ -291,7 +291,7 @@ describe('DetectorsList', function () {
       );
     });
 
-    it('can select detectors', async function () {
+    it('can select detectors', async () => {
       render(<DetectorsList />, {organization});
       await screen.findByText('Enabled Detector');
 
@@ -337,7 +337,7 @@ describe('DetectorsList', function () {
       expect(screen.getByRole('button', {name: 'Delete'})).toBeInTheDocument();
     });
 
-    it('can enable selected detectors with confirmation', async function () {
+    it('can enable selected detectors with confirmation', async () => {
       const updateRequest = MockApiClient.addMockResponse({
         url: '/organizations/org-slug/detectors/',
         method: 'PUT',
@@ -377,7 +377,7 @@ describe('DetectorsList', function () {
       });
     });
 
-    it('can disable selected detectors with confirmation', async function () {
+    it('can disable selected detectors with confirmation', async () => {
       const updateRequest = MockApiClient.addMockResponse({
         url: '/organizations/org-slug/detectors/',
         method: 'PUT',
@@ -416,7 +416,7 @@ describe('DetectorsList', function () {
       });
     });
 
-    it('can delete selected detectors with confirmation', async function () {
+    it('can delete selected detectors with confirmation', async () => {
       const deleteRequest = MockApiClient.addMockResponse({
         url: '/organizations/org-slug/detectors/',
         method: 'DELETE',
@@ -453,7 +453,7 @@ describe('DetectorsList', function () {
       });
     });
 
-    it('shows option to select all query results when page is selected', async function () {
+    it('shows option to select all query results when page is selected', async () => {
       const deleteRequest = MockApiClient.addMockResponse({
         url: '/organizations/org-slug/detectors/',
         method: 'DELETE',
@@ -529,7 +529,7 @@ describe('DetectorsList', function () {
       });
     });
 
-    it('disables action buttons when user does not have permissions', async function () {
+    it('disables action buttons when user does not have permissions', async () => {
       const noPermsOrganization = OrganizationFixture({
         features: ['workflow-engine-ui'],
         access: [],


### PR DESCRIPTION
similar to https://github.com/getsentry/sentry/pull/97315, with differences being
- an additional `canEdit` field to know when to disable actions based on  permissions
- an additional `detectorLimitReached` field to disable the Enable action when the org plan limit will be exceeded/has already been reached