### PR TITLE
chore(detectors): Increase query injection group type noise config

### DIFF
--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -532,7 +532,7 @@ class QueryInjectionVulnerabilityGroupType(PerformanceGroupTypeDefaults, GroupTy
     category_v2 = GroupCategory.DB_QUERY.value
     enable_auto_resolve = False
     enable_escalation_detection = False
-    noise_config = NoiseConfig(ignore_limit=5)
+    noise_config = NoiseConfig(ignore_limit=10000)
     default_priority = PriorityLevel.MEDIUM
 
 


### PR DESCRIPTION
this pr increases the noise config for the query injection group type to 10,000 - we don't want to stop ingesting events for existing issues, but would like to limit how many new issues we create while we continue to look into improvements. redis shouldn't be impacted too much given the detection numbers we are currently seeing 