### PR TITLE
featautofix): Add UI for stopping at RCA

### DIFF
--- a/static/app/components/events/autofix/autofixChanges.tsx
+++ b/static/app/components/events/autofix/autofixChanges.tsx
@@ -271,109 +271,43 @@ export function AutofixChanges({
     <AnimatePresence initial={isChangesFirstAppearance}>
       <AnimationWrapper key="card" {...cardAnimationProps}>
         <ChangesContainer>
+          <HeaderWrapper>
+            <HeaderText>
+              <HeaderIconWrapper ref={iconCodeRef}>
+                <IconCode size="md" color="blue400" />
+              </HeaderIconWrapper>
+              {t('Code Changes')}
+              <Button
+                size="zero"
+                borderless
+                title={t('Chat with Seer')}
+                onClick={handleSelectFirstChange}
+                analyticsEventName="Autofix: Changes Chat"
+                analyticsEventKey="autofix.changes.chat"
+              >
+                <IconChat />
+              </Button>
+            </HeaderText>
+          </HeaderWrapper>
+          <AnimatePresence>
+            {agentCommentThread && iconCodeRef.current && (
+              <AutofixHighlightPopup
+                selectedText=""
+                referenceElement={iconCodeRef.current}
+                groupId={groupId}
+                runId={runId}
+                stepIndex={previousDefaultStepIndex ?? 0}
+                retainInsightCardIndex={
+                  previousInsightCount !== undefined && previousInsightCount >= 0
+                    ? previousInsightCount
+                    : null
+                }
+                isAgentComment
+                blockName={t('Seer is uncertain of the code changes...')}
+              />
+            )}
+          </AnimatePresence>
           <ClippedBox clipHeight={408}>
-            <HeaderWrapper>
-              <HeaderText>
-                <HeaderIconWrapper ref={iconCodeRef}>
-                  <IconCode size="md" color="blue400" />
-                </HeaderIconWrapper>
-                {t('Code Changes')}
-                <Button
-                  size="zero"
-                  borderless
-                  title={t('Chat with Seer')}
-                  onClick={handleSelectFirstChange}
-                  analyticsEventName="Autofix: Changes Chat"
-                  analyticsEventKey="autofix.changes.chat"
-                >
-                  <IconChat />
-                </Button>
-              </HeaderText>
-              {!prsMade && (
-                <ButtonBar>
-                  {branchesMade ? (
-                    step.changes.length === 1 && step.changes[0] ? (
-                      <BranchButton change={step.changes[0]} />
-                    ) : (
-                      <ScrollCarousel aria-label={t('Check out branches')}>
-                        {step.changes.map(
-                          change =>
-                            change.branch_name && (
-                              <BranchButton
-                                key={`${change.repo_external_id}-${Math.random()}`}
-                                change={change}
-                              />
-                            )
-                        )}
-                      </ScrollCarousel>
-                    )
-                  ) : (
-                    <SetupAndCreateBranchButton
-                      changes={step.changes}
-                      groupId={groupId}
-                      runId={runId}
-                      isBusy={isBusy || isPrProcessing}
-                      onProcessingChange={setIsBranchProcessing}
-                    />
-                  )}
-                  <SetupAndCreatePRsButton
-                    changes={step.changes}
-                    groupId={groupId}
-                    runId={runId}
-                    isBusy={isBusy || isBranchProcessing}
-                    onProcessingChange={setIsPrProcessing}
-                  />
-                </ButtonBar>
-              )}
-              {prsMade &&
-                (step.changes.length === 1 && step.changes[0]?.pull_request?.pr_url ? (
-                  <LinkButton
-                    size="xs"
-                    priority="primary"
-                    icon={<IconOpen size="xs" />}
-                    href={step.changes[0].pull_request.pr_url}
-                    external
-                  >
-                    View PR in {step.changes[0].repo_name}
-                  </LinkButton>
-                ) : (
-                  <ScrollCarousel aria-label={t('View pull requests')}>
-                    {step.changes.map(
-                      change =>
-                        change.pull_request?.pr_url && (
-                          <LinkButton
-                            key={`${change.repo_external_id}-${Math.random()}`}
-                            size="xs"
-                            priority="primary"
-                            icon={<IconOpen size="xs" />}
-                            href={change.pull_request.pr_url}
-                            external
-                          >
-                            View PR in {change.repo_name}
-                          </LinkButton>
-                        )
-                    )}
-                  </ScrollCarousel>
-                ))}
-            </HeaderWrapper>
-            <AnimatePresence>
-              {agentCommentThread && iconCodeRef.current && (
-                <AutofixHighlightPopup
-                  selectedText=""
-                  referenceElement={iconCodeRef.current}
-                  groupId={groupId}
-                  runId={runId}
-                  stepIndex={previousDefaultStepIndex ?? 0}
-                  retainInsightCardIndex={
-                    previousInsightCount !== undefined && previousInsightCount >= 0
-                      ? previousInsightCount
-                      : null
-                  }
-                  isAgentComment
-                  blockName={t('Seer is uncertain of the code changes...')}
-                />
-              )}
-            </AnimatePresence>
             {step.changes.map((change, i) => (
               <Fragment key={change.repo_external_id}>
                 {i > 0 && <Separator />}
@@ -388,6 +322,75 @@ export function AutofixChanges({
               </Fragment>
             ))}
           </ClippedBox>
+          <BottomDivider />
+          <BottomButtonContainer>
+            {!prsMade && (
+              <ButtonBar>
+                {branchesMade ? (
+                  step.changes.length === 1 && step.changes[0] ? (
+                    <BranchButton change={step.changes[0]} />
+                  ) : (
+                    <ScrollCarousel aria-label={t('Check out branches')}>
+                      {step.changes.map(
+                        change =>
+                          change.branch_name && (
+                            <BranchButton
+                              key={`${change.repo_external_id}-${Math.random()}`}
+                              change={change}
+                            />
+                          )
+                      )}
+                    </ScrollCarousel>
+                  )
+                ) : (
+                  <SetupAndCreateBranchButton
+                    changes={step.changes}
+                    groupId={groupId}
+                    runId={runId}
+                    isBusy={isBusy || isPrProcessing}
+                    onProcessingChange={setIsBranchProcessing}
+                  />
+                )}
+                <SetupAndCreatePRsButton
+                  changes={step.changes}
+                  groupId={groupId}
+                  runId={runId}
+                  isBusy={isBusy || isBranchProcessing}
+                  onProcessingChange={setIsPrProcessing}
+                />
+              </ButtonBar>
+            )}
+            {prsMade &&
+              (step.changes.length === 1 && step.changes[0]?.pull_request?.pr_url ? (
+                <LinkButton
+                  size="xs"
+                  priority="primary"
+                  icon={<IconOpen size="xs" />}
+                  href={step.changes[0].pull_request.pr_url}
+                  external
+                >
+                  View PR in {step.changes[0].repo_name}
+                </LinkButton>
+              ) : (
+                <ScrollCarousel aria-label={t('View pull requests')}>
+                  {step.changes.map(
+                    change =>
+                      change.pull_request?.pr_url && (
+                        <LinkButton
+                          key={`${change.repo_external_id}-${Math.random()}`}
+                          size="xs"
+                          priority="primary"
+                          icon={<IconOpen size="xs" />}
+                          href={change.pull_request.pr_url}
+                          external
+                        >
+                          View PR in {change.repo_name}
+                        </LinkButton>
+                      )
+                  )}
+                </ScrollCarousel>
+              ))}
+          </BottomButtonContainer>
         </ChangesContainer>
       </AnimationWrapper>
     </AnimatePresence>
@@ -411,8 +414,7 @@ const ChangesContainer = styled('div')`
   border: 1px solid ${p => p.theme.border};
   border-radius: ${p => p.theme.borderRadius};
   box-shadow: ${p => p.theme.dropShadowMedium};
-  padding-left: ${space(2)};
-  padding-right: ${space(2)};
+  padding: ${p => p.theme.space.xl};
 `;
 
 const Content = styled('div')`
@@ -434,8 +436,6 @@ const PullRequestTitle = styled('div')`
 `;
 
 const RepoChangesHeader = styled('div')`
-  padding-top: ${space(2)};
-  padding-bottom: 0;
   display: grid;
   align-items: center;
   grid-template-columns: 1fr auto;
@@ -480,6 +480,17 @@ const HeaderIconWrapper = styled('div')`
   display: flex;
   align-items: center;
   justify-content: center;
+`;
+
+const BottomDivider = styled('div')`
+  border-top: 1px solid ${p => p.theme.innerBorder};
+  margin-top: ${p => p.theme.space.xl};
+  margin-bottom: ${p => p.theme.space.xl};
+`;
+
+const BottomButtonContainer = styled('div')`
+  display: flex;
+  justify-content: flex-end;
 `;
 
 function CreatePRsButton({
@@ -641,7 +652,7 @@ function CreateBranchButton({
       analyticsEventKey="autofix.push_to_branch_clicked"
       analyticsParams={{group_id: groupId}}
     >
-      Check Out Locally
+      {t('Check Out Locally')}
     </Button>
   );
 }

--- a/static/app/components/events/autofix/autofixChanges.tsx
+++ b/static/app/components/events/autofix/autofixChanges.tsx
@@ -332,10 +332,10 @@ export function AutofixChanges({
                   ) : (
                     <ScrollCarousel aria-label={t('Check out branches')}>
                       {step.changes.map(
-                        change =>
+                        (change, idx) =>
                           change.branch_name && (
                             <BranchButton
-                              key={`${change.repo_external_id}-${Math.random()}`}
+                              key={`${change.repo_external_id}-${idx}`}
                               change={change}
                             />
                           )
@@ -374,10 +374,10 @@ export function AutofixChanges({
               ) : (
                 <ScrollCarousel aria-label={t('View pull requests')}>
                   {step.changes.map(
-                    change =>
+                    (change, idx) =>
                       change.pull_request?.pr_url && (
                         <LinkButton
-                          key={`${change.repo_external_id}-${Math.random()}`}
+                          key={`${change.repo_external_id}-${idx}`}
                           size="xs"
                           priority="primary"
                           icon={<IconOpen size="xs" />}

--- a/static/app/components/events/autofix/autofixHighlightPopup.tsx
+++ b/static/app/components/events/autofix/autofixHighlightPopup.tsx
@@ -778,7 +778,7 @@ const Arrow = styled('div')`
   position: absolute;
   width: 12px;
   height: 12px;
-  background: ${p => p.theme.backgroundTertiary};
+  background: ${p => p.theme.backgroundSecondary};
   border: 1px dashed ${p => p.theme.border};
   border-right: none;
   border-bottom: none;

--- a/static/app/components/events/autofix/autofixRootCause.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.tsx
@@ -1,26 +1,76 @@
-import React, {Fragment, useRef} from 'react';
+import React, {Fragment, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import {AnimatePresence, motion, type AnimationProps} from 'framer-motion';
 
-import ClippedBox from 'sentry/components/clippedBox';
-import {CopyToClipboardButton} from 'sentry/components/copyToClipboardButton';
+import {addErrorMessage, addLoadingMessage} from 'sentry/actionCreators/indicator';
 import {Alert} from 'sentry/components/core/alert';
 import {Button} from 'sentry/components/core/button';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
+import {TextArea} from 'sentry/components/core/textarea';
 import {AutofixHighlightWrapper} from 'sentry/components/events/autofix/autofixHighlightWrapper';
 import {
   type AutofixRootCauseData,
   type AutofixRootCauseSelection,
   type CommentThread,
 } from 'sentry/components/events/autofix/types';
-import {IconChat, IconFocus} from 'sentry/icons';
+import {makeAutofixQueryKey} from 'sentry/components/events/autofix/useAutofix';
+import {
+  IconArrow,
+  IconChat,
+  IconClose,
+  IconCopy,
+  IconFix,
+  IconFocus,
+  IconInput,
+} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {singleLineRenderer} from 'sentry/utils/marked/marked';
+import {useMutation, useQueryClient} from 'sentry/utils/queryClient';
 import testableTransition from 'sentry/utils/testableTransition';
+import useApi from 'sentry/utils/useApi';
+import useCopyToClipboard from 'sentry/utils/useCopyToClipboard';
+import useOrganization from 'sentry/utils/useOrganization';
 
 import AutofixHighlightPopup from './autofixHighlightPopup';
 import {AutofixTimeline} from './autofixTimeline';
+
+function useSelectRootCause({groupId, runId}: {groupId: string; runId: string}) {
+  const api = useApi();
+  const queryClient = useQueryClient();
+  const orgSlug = useOrganization().slug;
+
+  return useMutation({
+    mutationFn: (params: {cause_id: string; instruction?: string}) => {
+      return api.requestPromise(
+        `/organizations/${orgSlug}/issues/${groupId}/autofix/update/`,
+        {
+          method: 'POST',
+          data: {
+            run_id: runId,
+            payload: {
+              type: 'select_root_cause',
+              cause_id: params.cause_id,
+              instruction: params.instruction || null,
+            },
+          },
+        }
+      );
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: makeAutofixQueryKey(orgSlug, groupId, true),
+      });
+      queryClient.invalidateQueries({
+        queryKey: makeAutofixQueryKey(orgSlug, groupId, false),
+      });
+      addLoadingMessage(t('On it...'));
+    },
+    onError: () => {
+      addErrorMessage(t('Something went wrong when selecting the root cause.'));
+    },
+  });
+}
 
 type AutofixRootCauseProps = {
   causes: AutofixRootCauseData[];
@@ -169,16 +219,22 @@ function CopyRootCauseButton({
   customRootCause?: string;
 }) {
   const text = formatRootCauseText(cause, customRootCause);
+  const {onClick, label} = useCopyToClipboard({
+    text,
+  });
+
   return (
-    <StyledCopyToClipboardButton
-      size="zero"
-      text={text}
-      borderless
-      title="Copy root cause as Markdown"
+    <Button
+      size="sm"
+      aria-label={label}
+      title="Copy analysis as Markdown / LLM prompt"
+      onClick={onClick}
       analyticsEventName="Autofix: Copy Root Cause as Markdown"
       analyticsEventKey="autofix.root_cause.copy"
-      color="black"
-    />
+      icon={<IconCopy />}
+    >
+      {t('Copy')}
+    </Button>
   );
 }
 
@@ -194,6 +250,12 @@ function AutofixRootCauseDisplay({
   const cause = causes[0];
   const iconFocusRef = useRef<HTMLDivElement>(null);
   const descriptionRef = useRef<HTMLDivElement | null>(null);
+  const [isProvidingSolution, setIsProvidingSolution] = useState(false);
+  const [solutionText, setSolutionText] = useState('');
+  const {mutate: selectRootCause, isPending: isSelectingRootCause} = useSelectRootCause({
+    groupId,
+    runId,
+  });
 
   const handleSelectDescription = () => {
     if (descriptionRef.current) {
@@ -204,6 +266,44 @@ function AutofixRootCauseDisplay({
         view: window,
       });
       descriptionRef.current.dispatchEvent(clickEvent);
+    }
+  };
+
+  const handleSelectRootCause = () => {
+    if (cause?.id !== undefined && cause.id !== null) {
+      selectRootCause({
+        cause_id: cause.id,
+      });
+    } else {
+      addErrorMessage(t('No root cause available.'));
+    }
+  };
+
+  const handleMySolution = () => {
+    setIsProvidingSolution(true);
+    setSolutionText('');
+  };
+
+  const handleCancelSolution = () => {
+    setIsProvidingSolution(false);
+    setSolutionText('');
+  };
+
+  const handleSubmitSolution = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!solutionText.trim()) {
+      return;
+    }
+
+    if (cause?.id !== undefined && cause.id !== null) {
+      selectRootCause({
+        cause_id: cause.id,
+        instruction: solutionText.trim().length > 0 ? solutionText.trim() : undefined,
+      });
+      setIsProvidingSolution(false);
+      setSolutionText('');
+    } else {
+      addErrorMessage(t('No root cause available.'));
     }
   };
 
@@ -228,9 +328,12 @@ function AutofixRootCauseDisplay({
               </IconWrapper>
               {t('Custom Root Cause')}
             </HeaderText>
-            <CopyRootCauseButton customRootCause={rootCauseSelection.custom_root_cause} />
           </HeaderWrapper>
           <CauseDescription>{rootCauseSelection.custom_root_cause}</CauseDescription>
+          <BottomDivider />
+          <BottomButtonContainer>
+            <CopyRootCauseButton customRootCause={rootCauseSelection.custom_root_cause} />
+          </BottomButtonContainer>
         </CustomRootCausePadding>
       </CausesContainer>
     );
@@ -238,59 +341,123 @@ function AutofixRootCauseDisplay({
 
   return (
     <CausesContainer>
-      <ClippedBox clipHeight={408}>
-        <HeaderWrapper>
-          <HeaderText>
-            <IconWrapper ref={iconFocusRef}>
-              <IconFocus size="md" color="pink400" />
-            </IconWrapper>
-            {t('Root Cause')}
-            <ButtonBar gap={'0'}>
-              <Button
-                size="zero"
-                borderless
-                title={t('Chat with Seer')}
-                onClick={handleSelectDescription}
-                analyticsEventName="Autofix: Root Cause Chat"
-                analyticsEventKey="autofix.root_cause.chat"
-              >
-                <IconChat />
-              </Button>
-              <CopyRootCauseButton cause={cause} />
-            </ButtonBar>
-          </HeaderText>
-        </HeaderWrapper>
-        <AnimatePresence>
-          {agentCommentThread && iconFocusRef.current && (
-            <AutofixHighlightPopup
-              selectedText=""
-              referenceElement={iconFocusRef.current}
-              groupId={groupId}
-              runId={runId}
-              stepIndex={previousDefaultStepIndex ?? 0}
-              retainInsightCardIndex={
-                previousInsightCount !== undefined && previousInsightCount >= 0
-                  ? previousInsightCount
-                  : null
+      <HeaderWrapper>
+        <HeaderText>
+          <IconWrapper ref={iconFocusRef}>
+            <IconFocus size="md" color="pink400" />
+          </IconWrapper>
+          {t('Root Cause')}
+          <Button
+            size="zero"
+            borderless
+            title={t('Chat with Seer')}
+            onClick={handleSelectDescription}
+            analyticsEventName="Autofix: Root Cause Chat"
+            analyticsEventKey="autofix.root_cause.chat"
+          >
+            <IconChat />
+          </Button>
+        </HeaderText>
+      </HeaderWrapper>
+      <AnimatePresence>
+        {agentCommentThread && iconFocusRef.current && (
+          <AutofixHighlightPopup
+            selectedText=""
+            referenceElement={iconFocusRef.current}
+            groupId={groupId}
+            runId={runId}
+            stepIndex={previousDefaultStepIndex ?? 0}
+            retainInsightCardIndex={
+              previousInsightCount !== undefined && previousInsightCount >= 0
+                ? previousInsightCount
+                : null
+            }
+            isAgentComment
+            blockName={t('Seer is uncertain of the root cause...')}
+          />
+        )}
+      </AnimatePresence>
+      <Content>
+        <Fragment>
+          <RootCauseDescription
+            cause={cause}
+            groupId={groupId}
+            runId={runId}
+            previousDefaultStepIndex={previousDefaultStepIndex}
+            previousInsightCount={previousInsightCount}
+            ref={descriptionRef}
+          />
+        </Fragment>
+      </Content>
+      <BottomDivider />
+      <BottomButtonContainer>
+        {isProvidingSolution ? (
+          <SolutionInputContainer>
+            <form onSubmit={handleSubmitSolution}>
+              <SolutionFormRow>
+                <SolutionInput
+                  autosize
+                  value={solutionText}
+                  maxLength={4096}
+                  onChange={e => setSolutionText(e.target.value)}
+                  placeholder={t('Provide a solution for Seer to follow...')}
+                  autoFocus
+                  maxRows={5}
+                  size="sm"
+                  onKeyDown={e => {
+                    if (e.key === 'Enter' && !e.shiftKey) {
+                      e.preventDefault();
+                      handleSubmitSolution(e);
+                    } else if (e.key === 'Escape') {
+                      handleCancelSolution();
+                    }
+                  }}
+                />
+                <ButtonBar merged gap="0">
+                  <Button type="button" size="sm" onClick={handleCancelSolution}>
+                    <IconClose size="sm" />
+                  </Button>
+                  <Button
+                    type="submit"
+                    priority="primary"
+                    size="sm"
+                    busy={isSelectingRootCause}
+                    disabled={!solutionText.trim()}
+                  >
+                    <IconArrow direction="right" />
+                  </Button>
+                </ButtonBar>
+              </SolutionFormRow>
+            </form>
+          </SolutionInputContainer>
+        ) : (
+          <ButtonBar>
+            <CopyRootCauseButton cause={cause} />
+            <Button
+              size="sm"
+              onClick={handleMySolution}
+              title={t('Specify your own solution for Seer to follow')}
+              icon={<IconInput />}
+            >
+              {t('Give Solution')}
+            </Button>
+            <Button
+              size="sm"
+              priority={
+                rootCauseSelection && 'cause_id' in rootCauseSelection
+                  ? 'default'
+                  : 'primary'
               }
-              isAgentComment
-              blockName={t('Seer is uncertain of the root cause...')}
-            />
-          )}
-        </AnimatePresence>
-        <Content>
-          <Fragment>
-            <RootCauseDescription
-              cause={cause}
-              groupId={groupId}
-              runId={runId}
-              previousDefaultStepIndex={previousDefaultStepIndex}
-              previousInsightCount={previousInsightCount}
-              ref={descriptionRef}
-            />
-          </Fragment>
-        </Content>
-      </ClippedBox>
+              busy={isSelectingRootCause}
+              onClick={handleSelectRootCause}
+              icon={<IconFix />}
+              title={t('Let Seer plan a solution to this issue')}
+            >
+              {t('Find Solution')}
+            </Button>
+          </ButtonBar>
+        )}
+      </BottomButtonContainer>
     </CausesContainer>
   );
 }
@@ -336,8 +503,7 @@ const CausesContainer = styled('div')`
   border-radius: ${p => p.theme.borderRadius};
   overflow: hidden;
   box-shadow: ${p => p.theme.dropShadowMedium};
-  padding-left: ${space(2)};
-  padding-right: ${space(2)};
+  padding: ${p => p.theme.space.lg};
 `;
 
 const Content = styled('div')`
@@ -379,6 +545,30 @@ const AnimationWrapper = styled(motion.div)`
   transform-origin: top center;
 `;
 
-const StyledCopyToClipboardButton = styled(CopyToClipboardButton)`
-  color: ${p => p.theme.textColor};
+const BottomDivider = styled('div')`
+  border-top: 1px solid ${p => p.theme.innerBorder};
+`;
+
+const BottomButtonContainer = styled('div')`
+  display: flex;
+  justify-content: flex-end;
+  padding-top: ${p => p.theme.space.xl};
+`;
+
+const SolutionInputContainer = styled('div')`
+  width: 100%;
+  background: ${p => p.theme.background};
+  border-radius: ${p => p.theme.borderRadius};
+`;
+
+const SolutionFormRow = styled('div')`
+  display: flex;
+  gap: ${space(1)};
+  align-items: center;
+  width: 100%;
+`;
+
+const SolutionInput = styled(TextArea)`
+  flex: 1;
+  resize: none;
 `;

--- a/static/app/components/events/autofix/autofixRootCause.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.tsx
@@ -298,7 +298,7 @@ function AutofixRootCauseDisplay({
     if (cause?.id !== undefined && cause.id !== null) {
       selectRootCause({
         cause_id: cause.id,
-        instruction: solutionText.trim().length > 0 ? solutionText.trim() : undefined,
+        instruction: solutionText.trim(),
       });
       setIsProvidingSolution(false);
       setSolutionText('');

--- a/static/app/components/events/autofix/autofixSolution.tsx
+++ b/static/app/components/events/autofix/autofixSolution.tsx
@@ -3,8 +3,6 @@ import styled from '@emotion/styled';
 import {AnimatePresence, motion, type AnimationProps} from 'framer-motion';
 
 import {addErrorMessage, addLoadingMessage} from 'sentry/actionCreators/indicator';
-import ClippedBox from 'sentry/components/clippedBox';
-import {CopyToClipboardButton} from 'sentry/components/copyToClipboardButton';
 import {Alert} from 'sentry/components/core/alert';
 import {Button} from 'sentry/components/core/button';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
@@ -25,7 +23,7 @@ import {
   type AutofixResponse,
 } from 'sentry/components/events/autofix/useAutofix';
 import {Timeline} from 'sentry/components/timeline';
-import {IconAdd, IconChat, IconFix} from 'sentry/icons';
+import {IconAdd, IconChat, IconCode, IconCopy, IconFix} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -34,6 +32,7 @@ import {valueIsEqual} from 'sentry/utils/object/valueIsEqual';
 import {setApiQueryData, useMutation, useQueryClient} from 'sentry/utils/queryClient';
 import testableTransition from 'sentry/utils/testableTransition';
 import useApi from 'sentry/utils/useApi';
+import useCopyToClipboard from 'sentry/utils/useCopyToClipboard';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useGroup} from 'sentry/views/issueDetails/useGroup';
 
@@ -305,19 +304,27 @@ function CopySolutionButton({
   customSolution?: string;
   isEditing?: boolean;
 }) {
+  const text = formatSolutionText(solution, customSolution);
+  const {onClick, label} = useCopyToClipboard({
+    text,
+  });
+
   if (isEditing) {
     return null;
   }
-  const text = formatSolutionText(solution, customSolution);
+
   return (
-    <StyledCopyToClipboardButton
-      size="zero"
-      text={text}
-      borderless
-      title="Copy solution as Markdown"
+    <Button
+      size="sm"
+      aria-label={label}
+      title="Copy plan as Markdown / LLM prompt"
+      onClick={onClick}
       analyticsEventName="Autofix: Copy Solution as Markdown"
       analyticsEventKey="autofix.solution.copy"
-    />
+      icon={<IconCopy />}
+    >
+      {t('Copy')}
+    </Button>
   );
 }
 
@@ -460,11 +467,15 @@ function AutofixSolutionDisplay({
               </HeaderIconWrapper>
               {t('Custom Solution')}
             </HeaderText>
-            <CopySolutionButton solution={solution} customSolution={customSolution} />
           </HeaderWrapper>
           <Content>
             <SolutionDescriptionWrapper>{customSolution}</SolutionDescriptionWrapper>
           </Content>
+          <BottomDivider />
+          <BottomFooter>
+            <div style={{flex: 1}} />
+            <CopySolutionButton solution={solution} customSolution={customSolution} />
+          </BottomFooter>
         </CustomSolutionPadding>
       </SolutionContainer>
     );
@@ -472,133 +483,132 @@ function AutofixSolutionDisplay({
 
   return (
     <SolutionContainer ref={containerRef}>
-      <ClippedBox clipHeight={408}>
-        <HeaderWrapper>
-          <HeaderText>
-            <HeaderIconWrapper ref={iconFixRef}>
-              <IconFix size="md" color="green400" />
-            </HeaderIconWrapper>
-            {t('Solution')}
-            <ButtonBar gap={'0'}>
-              <Button
-                size="zero"
-                borderless
-                title={t('Chat with Seer')}
-                onClick={handleSelectDescription}
-                analyticsEventName="Autofix: Solution Chat"
-                analyticsEventKey="autofix.solution.chat"
-              >
-                <IconChat />
-              </Button>
-              <CopySolutionButton solution={solution} />
-            </ButtonBar>
-          </HeaderText>
-          <ButtonBar>
-            <ButtonBar gap="0">
-              <Tooltip
-                isHoverable
-                title={
-                  codingDisabled
-                    ? t(
-                        'Your organization has disabled code generation with Seer. This can be re-enabled in organization settings by an admin.'
-                      )
-                    : hasNoRepos
-                      ? tct(
-                          'Seer needs to be able to access your repos to write code for you. [link:Manage your integration and working repos here.]',
-                          {
-                            link: (
-                              <Link
-                                to={`/settings/${organization.slug}/projects/${project?.slug}/seer/`}
-                              />
-                            ),
-                          }
-                        )
-                      : cantReadRepos
-                        ? t(
-                            "Seer can't access any of your selected repos. Check your GitHub integration and make sure Seer has read access."
-                          )
-                        : undefined
-                }
-              >
-                <Button
-                  size="sm"
-                  priority={
-                    !solutionSelected || !valueIsEqual(solutionItems, solution, true)
-                      ? 'primary'
-                      : 'default'
-                  }
-                  busy={isPending}
-                  disabled={hasNoRepos || cantReadRepos || codingDisabled}
-                  onClick={() => {
-                    handleContinue({
-                      mode: 'fix',
-                      solution: solutionItems,
-                    });
-                  }}
-                  analyticsEventName="Autofix: Code It Up"
-                  analyticsEventKey="autofix.solution.code"
-                >
-                  {t('Code It Up')}
-                </Button>
-              </Tooltip>
-            </ButtonBar>
-          </ButtonBar>
-        </HeaderWrapper>
-        <AnimatePresence>
-          {agentCommentThread && iconFixRef.current && (
-            <AutofixHighlightPopup
-              selectedText=""
-              referenceElement={iconFixRef.current}
-              groupId={groupId}
-              runId={runId}
-              stepIndex={previousDefaultStepIndex ?? 0}
-              retainInsightCardIndex={
-                previousInsightCount !== undefined && previousInsightCount >= 0
-                  ? previousInsightCount
-                  : null
-              }
-              isAgentComment
-              blockName={t('Seer is uncertain of the solution...')}
-            />
-          )}
-        </AnimatePresence>
-        <Content>
-          <SolutionDescription
-            solution={solutionItems}
+      <HeaderWrapper>
+        <HeaderText>
+          <HeaderIconWrapper ref={iconFixRef}>
+            <IconFix size="md" color="green400" />
+          </HeaderIconWrapper>
+          {t('Solution')}
+          <Button
+            size="zero"
+            borderless
+            title={t('Chat with Seer')}
+            onClick={handleSelectDescription}
+            analyticsEventName="Autofix: Solution Chat"
+            analyticsEventKey="autofix.solution.chat"
+          >
+            <IconChat />
+          </Button>
+        </HeaderText>
+      </HeaderWrapper>
+      <AnimatePresence>
+        {agentCommentThread && iconFixRef.current && (
+          <AutofixHighlightPopup
+            selectedText=""
+            referenceElement={iconFixRef.current}
             groupId={groupId}
             runId={runId}
-            description={description}
-            previousDefaultStepIndex={previousDefaultStepIndex}
-            previousInsightCount={previousInsightCount}
-            onDeleteItem={handleDeleteItem}
-            onToggleActive={handleToggleActive}
-            ref={descriptionRef}
+            stepIndex={previousDefaultStepIndex ?? 0}
+            retainInsightCardIndex={
+              previousInsightCount !== undefined && previousInsightCount >= 0
+                ? previousInsightCount
+                : null
+            }
+            isAgentComment
+            blockName={t('Seer is uncertain of the solution...')}
           />
-          <AddInstructionWrapper>
-            <InstructionsInputWrapper onSubmit={handleFormSubmit}>
-              <InstructionsInput
-                type="text"
-                name="additional-instructions"
-                placeholder={t('Add more instructions...')}
-                value={instructions}
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                  setInstructions(e.target.value)
-                }
-                size="sm"
-              />
-              <SubmitButton
-                size="zero"
-                type="submit"
-                borderless
-                disabled={!instructions.trim()}
-                aria-label={t('Add to solution')}
-              >
-                <IconAdd size="xs" />
-              </SubmitButton>
-            </InstructionsInputWrapper>
-          </AddInstructionWrapper>
-        </Content>
-      </ClippedBox>
+        )}
+      </AnimatePresence>
+      <Content>
+        <SolutionDescription
+          solution={solutionItems}
+          groupId={groupId}
+          runId={runId}
+          description={description}
+          previousDefaultStepIndex={previousDefaultStepIndex}
+          previousInsightCount={previousInsightCount}
+          onDeleteItem={handleDeleteItem}
+          onToggleActive={handleToggleActive}
+          ref={descriptionRef}
+        />
+      </Content>
+      <BottomDivider />
+      <BottomFooter>
+        <AddInstructionWrapper>
+          <InstructionsInputWrapper onSubmit={handleFormSubmit}>
+            <InstructionsInput
+              type="text"
+              name="additional-instructions"
+              placeholder={t('Add more instructions...')}
+              value={instructions}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                setInstructions(e.target.value)
+              }
+              size="sm"
+            />
+            <SubmitButton
+              size="zero"
+              type="submit"
+              borderless
+              disabled={!instructions.trim()}
+              aria-label={t('Add to solution')}
+            >
+              <IconAdd size="xs" />
+            </SubmitButton>
+          </InstructionsInputWrapper>
+        </AddInstructionWrapper>
+        <ButtonBar>
+          <CopySolutionButton solution={solution} />
+          <Tooltip
+            isHoverable
+            title={
+              codingDisabled
+                ? t(
+                    'Your organization has disabled code generation with Seer. This can be re-enabled in organization settings by an admin.'
+                  )
+                : hasNoRepos
+                  ? tct(
+                      'Seer needs to be able to access your repos to write code for you. [link:Manage your integration and working repos here.]',
+                      {
+                        link: (
+                          <Link
+                            to={`/settings/${organization.slug}/projects/${project?.slug}/seer/`}
+                          />
+                        ),
+                      }
+                    )
+                  : cantReadRepos
+                    ? t(
+                        "Seer can't access any of your selected repos. Check your GitHub integration and make sure Seer has read access."
+                      )
+                    : undefined
+            }
+          >
+            <Button
+              size="sm"
+              priority={
+                !solutionSelected || !valueIsEqual(solutionItems, solution, true)
+                  ? 'primary'
+                  : 'default'
+              }
+              busy={isPending}
+              disabled={hasNoRepos || cantReadRepos || codingDisabled}
+              onClick={() => {
+                handleContinue({
+                  mode: 'fix',
+                  solution: solutionItems,
+                });
+              }}
+              analyticsEventName="Autofix: Code It Up"
+              analyticsEventKey="autofix.solution.code"
+              title={t('Implement this solution in code with Seer')}
+              icon={<IconCode />}
+            >
+              {t('Code It Up')}
+            </Button>
+          </Tooltip>
+        </ButtonBar>
+      </BottomFooter>
     </SolutionContainer>
   );
 }
@@ -636,8 +646,7 @@ const SolutionContainer = styled('div')`
   border-radius: ${p => p.theme.borderRadius};
   overflow: hidden;
   box-shadow: ${p => p.theme.dropShadowMedium};
-  padding-left: ${space(2)};
-  padding-right: ${space(2)};
+  padding: ${p => p.theme.space.lg};
 `;
 
 const Content = styled('div')`
@@ -683,8 +692,6 @@ const InstructionsInputWrapper = styled('form')`
   display: flex;
   position: relative;
   border-radius: ${p => p.theme.borderRadius};
-  margin-top: ${space(0.5)};
-  margin-right: ${space(0.25)};
 `;
 
 const InstructionsInput = styled(Input)`
@@ -706,10 +713,18 @@ const SubmitButton = styled(Button)`
   border-radius: 5px;
 `;
 
-const AddInstructionWrapper = styled('div')`
-  padding: ${space(1)} ${space(1)} 0 ${space(3)};
+const BottomDivider = styled('div')`
+  border-top: 1px solid ${p => p.theme.innerBorder};
+  margin-top: ${p => p.theme.space.lg};
 `;
 
-const StyledCopyToClipboardButton = styled(CopyToClipboardButton)`
-  color: ${p => p.theme.textColor};
+const BottomFooter = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${p => p.theme.space.lg};
+  padding: ${p => p.theme.space.xl} 0 0 0;
+`;
+
+const AddInstructionWrapper = styled('div')`
+  flex: 1;
 `;

--- a/static/app/components/events/autofix/autofixTimeline.tsx
+++ b/static/app/components/events/autofix/autofixTimeline.tsx
@@ -1,3 +1,5 @@
+import {useState} from 'react';
+
 import {AutofixTimelineItem} from 'sentry/components/events/autofix/autofixTimelineItem';
 import {Timeline} from 'sentry/components/timeline';
 
@@ -22,9 +24,15 @@ export function AutofixTimeline({
   retainInsightCardIndex = null,
   eventCodeUrls,
 }: Props) {
+  const [expandedItemIndex, setExpandedItemIndex] = useState<number | null>(null);
+
   if (!events?.length) {
     return null;
   }
+
+  const handleToggleExpand = (index: number) => {
+    setExpandedItemIndex(prevIndex => (prevIndex === index ? null : index));
+  };
 
   return (
     <Timeline.Container>
@@ -44,6 +52,8 @@ export function AutofixTimeline({
             stepIndex={stepIndex}
             retainInsightCardIndex={retainInsightCardIndex}
             codeUrl={eventCodeUrls ? eventCodeUrls[index] : null}
+            isExpanded={expandedItemIndex === index}
+            onToggleExpand={handleToggleExpand}
           />
         );
       })}

--- a/static/app/components/events/autofix/autofixTimelineItem.tsx
+++ b/static/app/components/events/autofix/autofixTimelineItem.tsx
@@ -1,4 +1,4 @@
-import {useMemo, useState} from 'react';
+import {useMemo} from 'react';
 import {useTheme, type Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {AnimatePresence, motion} from 'framer-motion';
@@ -57,7 +57,9 @@ interface AutofixTimelineItemProps {
   event: AutofixTimelineEvent;
   groupId: string;
   index: number;
+  isExpanded: boolean;
   isMostImportantEvent: boolean;
+  onToggleExpand: (index: number) => void;
   retainInsightCardIndex: number | null | undefined;
   runId: string;
   stepIndex: number;
@@ -70,17 +72,18 @@ export function AutofixTimelineItem({
   getCustomIcon,
   groupId,
   index,
+  isExpanded,
   isMostImportantEvent,
+  onToggleExpand,
   retainInsightCardIndex,
   runId,
   stepIndex,
   codeUrl,
 }: AutofixTimelineItemProps) {
   const theme = useTheme();
-  const [isExpanded, setIsExpanded] = useState(false);
 
   const handleToggle = () => {
-    setIsExpanded(current => !current);
+    onToggleExpand(index);
   };
 
   const titleHtml = useMemo(() => {

--- a/static/app/components/events/autofix/preferences/hooks/useUpdateProjectSeerPreferences.ts
+++ b/static/app/components/events/autofix/preferences/hooks/useUpdateProjectSeerPreferences.ts
@@ -12,7 +12,7 @@ export function useUpdateProjectSeerPreferences(project: Project) {
     mutationFn: (data: ProjectSeerPreferences) => {
       const payload: ProjectSeerPreferences = {
         repositories: data.repositories,
-        automated_run_stopping_point: data.automated_run_stopping_point ?? 'solution',
+        automated_run_stopping_point: data.automated_run_stopping_point ?? 'root_cause',
       };
       return api.requestPromise(
         `/projects/${organization.slug}/${project.slug}/seer/preferences/`,

--- a/static/app/components/events/autofix/types.ts
+++ b/static/app/components/events/autofix/types.ts
@@ -273,7 +273,7 @@ export interface SeerRepoDefinition {
 
 export interface ProjectSeerPreferences {
   repositories: SeerRepoDefinition[];
-  automated_run_stopping_point?: 'solution' | 'code_changes' | 'open_pr';
+  automated_run_stopping_point?: 'root_cause' | 'solution' | 'code_changes' | 'open_pr';
 }
 
 export const AUTOFIX_TTL_IN_DAYS = 30;

--- a/static/app/views/settings/projectSeer/autofixRepositories.tsx
+++ b/static/app/views/settings/projectSeer/autofixRepositories.tsx
@@ -45,8 +45,8 @@ export function AutofixRepositories({project}: ProjectSeerProps) {
   const [repoSettings, setRepoSettings] = useState<Record<string, RepoSettings>>({});
   const [showSaveNotice, setShowSaveNotice] = useState(false);
   const [automatedRunStoppingPoint, setAutomatedRunStoppingPoint] = useState<
-    'solution' | 'code_changes' | 'open_pr'
-  >('solution');
+    'root_cause' | 'solution' | 'code_changes' | 'open_pr'
+  >('root_cause');
 
   useEffect(() => {
     if (repositories) {
@@ -76,7 +76,7 @@ export function AutofixRepositories({project}: ProjectSeerProps) {
 
         setRepoSettings(initialSettings);
         setAutomatedRunStoppingPoint(
-          preference.automated_run_stopping_point || 'solution'
+          preference.automated_run_stopping_point || 'root_cause'
         );
       } else if (codeMappingRepos?.length) {
         // Set default settings using codeMappingRepos when no preferences exist
@@ -93,7 +93,7 @@ export function AutofixRepositories({project}: ProjectSeerProps) {
         });
 
         setRepoSettings(initialSettings);
-        setAutomatedRunStoppingPoint('solution');
+        setAutomatedRunStoppingPoint('root_cause');
       }
     }
   }, [preference, repositories, codeMappingRepos, updateProjectSeerPreferences]);
@@ -102,7 +102,7 @@ export function AutofixRepositories({project}: ProjectSeerProps) {
     (
       updatedIds?: string[],
       updatedSettings?: Record<string, RepoSettings>,
-      newStoppingPoint?: 'solution' | 'code_changes' | 'open_pr'
+      newStoppingPoint?: 'root_cause' | 'solution' | 'code_changes' | 'open_pr'
     ) => {
       if (!repositories) {
         return;

--- a/static/app/views/settings/projectSeer/index.spec.tsx
+++ b/static/app/views/settings/projectSeer/index.spec.tsx
@@ -160,7 +160,7 @@ describe('ProjectSeer', function () {
         expect.anything(),
         expect.objectContaining({
           data: {
-            automated_run_stopping_point: 'solution',
+            automated_run_stopping_point: 'root_cause',
             repositories: [
               {
                 branch_name: '',
@@ -220,7 +220,7 @@ describe('ProjectSeer', function () {
         expect.anything(),
         expect.objectContaining({
           data: {
-            automated_run_stopping_point: 'solution',
+            automated_run_stopping_point: 'root_cause',
             repositories: [
               {
                 external_id: '101',
@@ -267,7 +267,7 @@ describe('ProjectSeer', function () {
         expect.anything(),
         expect.objectContaining({
           data: {
-            automated_run_stopping_point: 'solution',
+            automated_run_stopping_point: 'root_cause',
             repositories: [],
           },
         })

--- a/static/app/views/settings/projectSeer/index.tsx
+++ b/static/app/views/settings/projectSeer/index.tsx
@@ -106,7 +106,7 @@ function ProjectSeerGeneralForm({project}: ProjectSeerProps) {
   );
 
   const handleStoppingPointChange = useCallback(
-    (value: 'solution' | 'code_changes' | 'open_pr') => {
+    (value: 'root_cause' | 'solution' | 'code_changes' | 'open_pr') => {
       updateProjectSeerPreferences({
         repositories: preference?.repositories || [],
         automated_run_stopping_point: value,
@@ -125,8 +125,13 @@ function ProjectSeerGeneralForm({project}: ProjectSeerProps) {
     type: 'choice',
     options: [
       {
+        value: 'root_cause',
+        label: <SeerSelectLabel>{t('Root Cause (default)')}</SeerSelectLabel>,
+        details: t('Seer will stop after identifying the root cause.'),
+      },
+      {
         value: 'solution',
-        label: <SeerSelectLabel>{t('Solution (default)')}</SeerSelectLabel>,
+        label: <SeerSelectLabel>{t('Solution')}</SeerSelectLabel>,
         details: t('Seer will stop after planning out a solution.'),
       },
       {
@@ -182,7 +187,7 @@ function ProjectSeerGeneralForm({project}: ProjectSeerProps) {
   return (
     <Fragment>
       <Form
-        key={preference?.automated_run_stopping_point ?? 'solution'}
+        key={preference?.automated_run_stopping_point ?? 'root_cause'}
         saveOnBlur
         apiMethod="PUT"
         apiEndpoint={`/projects/${organization.slug}/${project.slug}/`}
@@ -191,7 +196,7 @@ function ProjectSeerGeneralForm({project}: ProjectSeerProps) {
           seerScannerAutomation: project.seerScannerAutomation ?? false,
           autofixAutomationTuning: project.autofixAutomationTuning ?? 'off',
           automated_run_stopping_point:
-            preference?.automated_run_stopping_point ?? 'solution',
+            preference?.automated_run_stopping_point ?? 'root_cause',
         }}
         onSubmitSuccess={handleSubmitSuccess}
         additionalFieldProps={{organization}}


### PR DESCRIPTION
By default, runs stop at the root cause step, so adding buttons back to continue to solution from there.
Also adding root cause as the default option for automated runs.

In the process of adding the necessary controls for the root cause step, it helped to move the main actions on each card to the bottom for clarity:
<img width="798" height="1334" alt="Screenshot 2025-08-13 at 4 41 54 PM" src="https://github.com/user-attachments/assets/da53f050-278a-4afc-80bc-85f6d99103ac" />
