### PR TITLE
fix(sdk_crashes): KeyError for multiple exceptions

### DIFF
--- a/tests/sentry/utils/sdk_crashes/test_event_stripper.py
+++ b/tests/sentry/utils/sdk_crashes/test_event_stripper.py
@@ -452,3 +452,77 @@ def test_strip_event_without_frames_returns_empty_dict(store_and_strip_event) ->
     stripped_event_data = store_and_strip_event(data=event_data)
 
     assert stripped_event_data == {}
+
+
+@django_db_all
+@pytest.mark.snuba
+def test_strip_event_with_multiple_exceptions_only_keep_last_one(store_and_strip_event) -> None:
+    event_data = get_crash_event()
+
+    exception_values = list(get_path(event_data, "exception", "values"))
+
+    crash_exception = dict(exception_values[0])
+    set_path(crash_exception, "type", value="SIGPIPE")
+    set_path(crash_exception, "value", value="Broken pipe")
+
+    exception_values.append(crash_exception)
+
+    set_path(event_data, "exception", value=exception_values)
+
+    stripped_event_data = store_and_strip_event(data=event_data)
+
+    assert len(get_path(stripped_event_data, "exception", "values")) == 1
+
+    exception = get_path(stripped_event_data, "exception", "values", 0)
+    assert exception["type"] == "SIGPIPE"
+    assert "value" not in exception
+
+
+@django_db_all
+@pytest.mark.snuba
+def test_strip_event_with_multiple_exceptions_last_without_frames_discard_event(
+    store_and_strip_event,
+) -> None:
+    event_data = get_crash_event()
+
+    exception_values = list(get_path(event_data, "exception", "values"))
+
+    crash_exception = dict(exception_values[0])
+    set_path(crash_exception, "type", value="SIGPIPE")
+    set_path(crash_exception, "value", value="Broken pipe")
+    set_path(crash_exception, "stacktrace", value=None)
+    exception_values.append(crash_exception)
+
+    set_path(event_data, "exception", value=exception_values)
+
+    stripped_event_data = store_and_strip_event(data=event_data)
+
+    assert stripped_event_data == {}
+
+
+@django_db_all
+@pytest.mark.snuba
+def test_strip_event_with_multiple_exceptions_first_without_frames_keeps_last_exception(
+    store_and_strip_event,
+) -> None:
+    event_data = get_crash_event()
+
+    exception_values = list(get_path(event_data, "exception", "values"))
+
+    crash_exception = dict(exception_values[0])
+    set_path(crash_exception, "type", value="SIGPIPE")
+    set_path(crash_exception, "value", value="Broken pipe")
+    exception_values.append(crash_exception)
+
+    # Remove the stacktrace from the first exception.
+    exception_values[0]["stacktrace"] = None
+
+    set_path(event_data, "exception", value=exception_values)
+
+    stripped_event_data = store_and_strip_event(data=event_data)
+
+    assert len(get_path(stripped_event_data, "exception", "values")) == 1
+
+    exception = get_path(stripped_event_data, "exception", "values", 0)
+    assert exception["type"] == "SIGPIPE"
+    assert "value" not in exception

--- a/tests/sentry/utils/sdk_crashes/test_event_stripper.py
+++ b/tests/sentry/utils/sdk_crashes/test_event_stripper.py
@@ -467,7 +467,7 @@ def test_strip_event_with_multiple_exceptions_only_keep_last_one(store_and_strip
 
     exception_values.append(crash_exception)
 
-    set_path(event_data, "exception", value=exception_values)
+    set_path(event_data, "exception", "values", value=exception_values)
 
     stripped_event_data = store_and_strip_event(data=event_data)
 
@@ -493,7 +493,7 @@ def test_strip_event_with_multiple_exceptions_last_without_frames_discard_event(
     set_path(crash_exception, "stacktrace", value=None)
     exception_values.append(crash_exception)
 
-    set_path(event_data, "exception", value=exception_values)
+    set_path(event_data, "exception", "values", value=exception_values)
 
     stripped_event_data = store_and_strip_event(data=event_data)
 
@@ -517,7 +517,7 @@ def test_strip_event_with_multiple_exceptions_first_without_frames_keeps_last_ex
     # Remove the stacktrace from the first exception.
     exception_values[0]["stacktrace"] = None
 
-    set_path(event_data, "exception", value=exception_values)
+    set_path(event_data, "exception", "values", value=exception_values)
 
     stripped_event_data = store_and_strip_event(data=event_data)
 


### PR DESCRIPTION
Fixes [SENTRY-2ZEM](https://sentry.io/organizations/sentry/issues/5061321425/). The issue was that: strip_event_data attempts to write to exception.values[0].stacktrace after reading from exception.values[-1].stacktrace, but exception.values[0] lacks the stacktrace key.

**The solution**
Only keep the last exception when a crash has multiple ones. The SDK crash detection only detects crashes based on the last exception. Keeping multiple exceptions and stripping data would be the ideal solution, but that requires more changes.
We're going to follow up to make this work with https://github.com/getsentry/sentry/issues/97830.

This PR replaces https://github.com/getsentry/sentry/pull/96979.