### PR TITLE
fix(dynamic-sampling): run GetActiveOrgs with 60s granularity instead of 3600

### DIFF
--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
@@ -119,7 +119,14 @@ def boost_low_volume_transactions(context: TaskContext) -> None:
     get_volumes_small = "GetTransactionVolumes(small)"
     get_volumes_big = "GetTransactionVolumes(big)"
 
-    orgs_iterator = TimedIterator(context, GetActiveOrgs(max_projects=MAX_PROJECTS_PER_QUERY))
+    if options.get("dynamic-sampling.query-granularity-60s.active-orgs", None):
+        granularity = Granularity(60)
+    else:
+        granularity = Granularity(3600)
+
+    orgs_iterator = TimedIterator(
+        context, GetActiveOrgs(max_projects=MAX_PROJECTS_PER_QUERY, granularity=granularity)
+    )
     for orgs in orgs_iterator:
         # get the low and high transactions
         totals_it = TimedIterator(

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3481,6 +3481,7 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+
 # option used to enable/disable tracking
 # rate of potential functions metrics to
 # be written into EAP
@@ -3488,5 +3489,13 @@ register(
     "profiling.track_functions_metrics_write_rate.eap.enabled",
     default=False,
     type=Bool,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
+# Whether to use 60s granularity for the dynamic sampling query
+register(
+    "dynamic-sampling.query-granularity-60s.active-orgs",
+    type=Bool,
+    default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3481,7 +3481,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-
 # option used to enable/disable tracking
 # rate of potential functions metrics to
 # be written into EAP


### PR DESCRIPTION
- GetActiveOrgs has also been running on 3600 granularity, which is probably why there has been flakiness when it comes to execution of these jobs at the full hour
- Move GetActiveOrgs to 60s granularity, so that the low volume project boosting is consistently executed every 10 minutes
- Move boost_low_volume_Transactions to 60s granularity as well, because this presumably also suffers from the same issue
- The overall effect of this change is that the dynamic sampling jobs should be running more consistently and with more consistent results
- Use a separate option for this because it will cause more load at the full hour, just to make sure we can gradually roll this out in a controlled manner.

Closes TET-1018