### PR TITLE
fix(trace-waterfall): Don't show "Previous trace not available" messages

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceLinksNavigation/traceLinkNavigationButton.tsx
+++ b/static/app/views/performance/newTraceDetails/traceLinksNavigation/traceLinkNavigationButton.tsx
@@ -45,7 +45,6 @@ export function TraceLinkNavigationButton({
     available: isPreviousTraceAvailable,
     id: previousTraceSpanId,
     trace: previousTraceId,
-    sampled: previousTraceSampled,
     isLoading: isPreviousTraceLoading,
   } = useFindPreviousTrace({
     direction,
@@ -79,70 +78,47 @@ export function TraceLinkNavigationButton({
     });
   }
 
-  if (direction === 'previous' && previousTraceId && !isPreviousTraceLoading) {
-    if (isPreviousTraceAvailable) {
-      return (
-        <StyledTooltip
-          position="right"
-          delay={400}
-          isHoverable
-          title={tct(
-            `This links to the previous trace within the same session. To learn more, [link:read the docs].`,
-            {
-              link: (
-                <ExternalLink
-                  href={
-                    'https://docs.sentry.io/concepts/key-terms/tracing/trace-view/#previous-and-next-traces'
-                  }
-                />
-              ),
-            }
-          )}
+  if (
+    direction === 'previous' &&
+    previousTraceId &&
+    !isPreviousTraceLoading &&
+    isPreviousTraceAvailable
+  ) {
+    return (
+      <StyledTooltip
+        position="right"
+        delay={400}
+        isHoverable
+        title={tct(
+          `This links to the previous trace within the same session. To learn more, [link:read the docs].`,
+          {
+            link: (
+              <ExternalLink
+                href={
+                  'https://docs.sentry.io/concepts/key-terms/tracing/trace-view/#previous-and-next-traces'
+                }
+              />
+            ),
+          }
+        )}
+      >
+        <TraceLink
+          color="gray500"
+          onClick={() => closeSpanDetailsDrawer()}
+          to={getTraceDetailsUrl({
+            traceSlug: previousTraceId,
+            spanId: previousTraceSpanId,
+            dateSelection,
+            timestamp: linkedTraceWindowTimestamp,
+            location,
+            organization,
+          })}
         >
-          <TraceLink
-            color="gray500"
-            onClick={() => closeSpanDetailsDrawer()}
-            to={getTraceDetailsUrl({
-              traceSlug: previousTraceId,
-              spanId: previousTraceSpanId,
-              dateSelection,
-              timestamp: linkedTraceWindowTimestamp,
-              location,
-              organization,
-            })}
-          >
-            <IconChevron direction="left" />
-            <TraceLinkText>{t('Go to Previous Trace')}</TraceLinkText>
-          </TraceLink>
-        </StyledTooltip>
-      );
-    }
-
-    if (!previousTraceSampled) {
-      return (
-        <StyledTooltip
-          position="right"
-          title={t(
-            'Trace contains a link to an unsampled trace. Increase traces sample rate in SDK settings to see more connected traces'
-          )}
-        >
-          <TraceLinkText>{t('Previous trace not sampled')}</TraceLinkText>
-        </StyledTooltip>
-      );
-    }
-
-    if (!isPreviousTraceAvailable) {
-      return (
-        <StyledTooltip
-          position="right"
-          title={t(
-            'Trace contains a link to a trace that is not available. This means that the trace was not stored.'
-          )}
-        >
-          <TraceLinkText>{t('Previous trace not available')}</TraceLinkText>
-        </StyledTooltip>
-      );
-    }
+          <IconChevron direction="left" />
+          <TraceLinkText>{t('Go to Previous Trace')}</TraceLinkText>
+        </TraceLink>
+      </StyledTooltip>
+    );
   }
 
   if (direction === 'next' && !isNextTraceLoading && nextTraceId && nextTraceSpanId) {


### PR DESCRIPTION
Removes the messages about the previous trace not being available or sampled. I initially added this because in contrast to "next trace", we _have_ this information. But I agree with the request to remove it because it's unnecessary bloat for users. 

I for now kept the placeholder to avoid the layout shift. If reviewers prefer adding layout shift in favour of more vertical space, we can do that as well of course. Happy to go with whatever y'all prefer :)

Long-term, we need different placement for the buttons all together. Tracked [in linear](https://linear.app/getsentry/issue/FE-573/linked-traces-rethink-link-button-position) and waiting on a discussion in Slack.

Before:

<img width="1249" height="810" alt="image" src="https://github.com/user-attachments/assets/2114b29b-81b0-4bf3-8496-bb40db3b2bd4" />


After:

<img width="1241" height="770" alt="image" src="https://github.com/user-attachments/assets/3ed491d3-6015-447f-800e-46f43901e199" />