### PR TITLE
ref(db): Stop using legacy create_or_update in buffer update

### DIFF
--- a/src/sentry/buffer/base.py
+++ b/src/sentry/buffer/base.py
@@ -178,7 +178,7 @@ class Buffer(Service):
             # HACK(dcramer): this is gross, but we don't have a good hook to compute this property today
             # XXX(dcramer): remove once we can replace 'priority' with something reasonable via Snuba
             if model is Group:
-                # XXX: create_or_update doesn't fire `post_save` signals, and so this update never
+                # XXX: update_or_create doesn't fire `post_save` signals, and so this update never
                 # ends up in the cache. This causes issues when handling issue alerts, and likely
                 # elsewhere. Use `update` here since we're already special casing, and we know that
                 # the group will already exist.
@@ -192,7 +192,7 @@ class Buffer(Service):
                     group.update(using=None, **update_kwargs)
                 created = False
             elif model:
-                _, created = model.objects.create_or_update(values=update_kwargs, **filters)
+                _, created = model.objects.update_or_create(defaults=update_kwargs, **filters)
 
         buffer_incr_complete.send_robust(
             model=model,

--- a/tests/sentry/test_no_create_or_update_usage.py
+++ b/tests/sentry/test_no_create_or_update_usage.py
@@ -10,7 +10,6 @@ from typing import Any
 # create_or_update. Instead, use Django's update_or_create.
 # Reduce over time as code is refactored. DO NOT add new files here.
 ALLOWLIST_FILES: set[str] = {
-    "src/sentry/buffer/base.py",
     "src/sentry/db/models/manager/base.py",
     "src/sentry/notifications/services/impl.py",
     "src/sentry/nodestore/django/backend.py",


### PR DESCRIPTION
In a lot of places we are still using our custom `create_or_update` method. That method is legacy one, and less performant than Django's `update_or_create`.
