### PR TITLE
feat(search-bar): Enable automatic replacement of raw search keys

### DIFF
--- a/static/app/components/searchQueryBuilder/context.tsx
+++ b/static/app/components/searchQueryBuilder/context.tsx
@@ -129,6 +129,7 @@ export function SearchQueryBuilderProvider({
     disabled,
     displayAskSeerFeedback,
     setDisplayAskSeerFeedback,
+    replaceRawSearchKeys,
   });
 
   const stableFieldDefinitionGetter = useMemo(

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.spec.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.spec.tsx
@@ -1,0 +1,156 @@
+import type {FocusOverride} from 'sentry/components/searchQueryBuilder/types';
+
+import {replaceFreeTextTokens, type UpdateQueryAction} from './useQueryBuilderState';
+
+describe('replaceFreeTextTokens', () => {
+  describe('when there are no tokens', () => {
+    it('should return the original query', () => {
+      const result = replaceFreeTextTokens(
+        {type: 'UPDATE_QUERY', query: ''},
+        () => null,
+        [],
+        'browser.name:"firefox"'
+      );
+      expect(result.newQuery).toBe('browser.name:"firefox"');
+    });
+  });
+
+  describe('when there are no free text tokens', () => {
+    it('should return the original query', () => {
+      const result = replaceFreeTextTokens(
+        {type: 'UPDATE_QUERY', query: 'browser.name:"firefox"'},
+        () => null,
+        [],
+        'browser.name:"firefox"'
+      );
+
+      expect(result.newQuery).toBe('browser.name:"firefox"');
+    });
+  });
+
+  describe('when there are free text tokens', () => {
+    type TestCase = {
+      description: string;
+      expected: {
+        focusOverride: FocusOverride | null;
+        newQuery: string;
+      };
+      input: {
+        action: UpdateQueryAction;
+        getFieldDefinition: () => null;
+        queryToCommit: string;
+        rawSearchReplacement: string[];
+      };
+    };
+
+    const testCases: TestCase[] = [
+      {
+        description: 'when there are no tokens',
+        input: {
+          action: {type: 'UPDATE_QUERY', query: ''},
+          getFieldDefinition: () => null,
+          rawSearchReplacement: ['span.description'],
+          queryToCommit: '',
+        },
+        expected: {newQuery: '', focusOverride: null},
+      },
+      {
+        description: 'when there is no raw search replacement',
+        input: {
+          action: {type: 'UPDATE_QUERY', query: 'browser.name:"firefox"'},
+          getFieldDefinition: () => null,
+          rawSearchReplacement: [],
+          queryToCommit: 'browser.name:"firefox"',
+        },
+        expected: {newQuery: 'browser.name:"firefox"', focusOverride: null},
+      },
+      {
+        description: 'when there are no free text tokens',
+        input: {
+          action: {type: 'UPDATE_QUERY', query: 'browser.name:"firefox"'},
+          getFieldDefinition: () => null,
+          rawSearchReplacement: ['span.description'],
+          queryToCommit: 'browser.name:"firefox"',
+        },
+        expected: {newQuery: 'browser.name:"firefox"', focusOverride: null},
+      },
+      {
+        description: 'when there is one free text token',
+        input: {
+          action: {type: 'UPDATE_QUERY', query: 'test'},
+          getFieldDefinition: () => null,
+          rawSearchReplacement: ['span.description'],
+          queryToCommit: '',
+        },
+        expected: {
+          newQuery: 'span.description:[*test*]',
+          focusOverride: {itemKey: 'end'},
+        },
+      },
+      {
+        description: 'when there is one free text token that has a space',
+        input: {
+          action: {type: 'UPDATE_QUERY', query: 'test test'},
+          getFieldDefinition: () => null,
+          rawSearchReplacement: ['span.description'],
+          queryToCommit: '',
+        },
+        expected: {
+          newQuery: 'span.description:["*test test*"]',
+          focusOverride: {itemKey: 'end'},
+        },
+      },
+      {
+        description: 'when there is already a token present',
+        input: {
+          action: {type: 'UPDATE_QUERY', query: 'span.op:eq test'},
+          getFieldDefinition: () => null,
+          rawSearchReplacement: ['span.description'],
+          queryToCommit: '',
+        },
+        expected: {
+          newQuery: 'span.op:eq span.description:[*test*]',
+          focusOverride: {itemKey: 'end'},
+        },
+      },
+      {
+        description: 'when there is already a replace token present',
+        input: {
+          action: {type: 'UPDATE_QUERY', query: 'span.description:[*test*] test2'},
+          getFieldDefinition: () => null,
+          rawSearchReplacement: ['span.description'],
+          queryToCommit: '',
+        },
+        expected: {
+          newQuery: 'span.description:[*test*,*test2*]',
+          focusOverride: {itemKey: 'end'},
+        },
+      },
+      {
+        description: 'when there is already a replace token present with a space',
+        input: {
+          action: {type: 'UPDATE_QUERY', query: 'span.description:[*test*] other value'},
+          getFieldDefinition: () => null,
+          rawSearchReplacement: ['span.description'],
+          queryToCommit: '',
+        },
+        expected: {
+          newQuery: 'span.description:[*test*,"*other value*"]',
+          focusOverride: {itemKey: 'end'},
+        },
+      },
+    ];
+
+    it.each(testCases)('$description', ({input, expected}) => {
+      const result = replaceFreeTextTokens(
+        input.action,
+        input.getFieldDefinition,
+        input.rawSearchReplacement,
+        input.queryToCommit
+      );
+
+      expect(result.newQuery).toBe(expected.newQuery);
+      expect(result.focusOverride).toEqual(expected.focusOverride);
+    });
+  });
+});

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.spec.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.spec.tsx
@@ -1,6 +1,6 @@
 import {
   replaceFreeTextTokens,
-  type ReplaceTokensWithTextAction,
+  type ReplaceTokensWithTextOnPasteAction,
   type UpdateFreeTextAction,
 } from './useQueryBuilderState';
 
@@ -10,7 +10,7 @@ describe('replaceFreeTextTokens', () => {
       description: string;
       expected: string | undefined;
       input: {
-        action: UpdateFreeTextAction | ReplaceTokensWithTextAction;
+        action: UpdateFreeTextAction | ReplaceTokensWithTextOnPasteAction;
         currentQuery: string;
         getFieldDefinition: () => null;
         rawSearchReplacement: string[];
@@ -102,7 +102,7 @@ describe('replaceFreeTextTokens', () => {
         description: 'when there is one free text token',
         input: {
           action: {
-            type: 'REPLACE_TOKENS_WITH_TEXT',
+            type: 'REPLACE_TOKENS_WITH_TEXT_ON_PASTE',
             text: 'test',
             tokens: [],
             focusOverride: undefined,

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -662,7 +662,20 @@ export function replaceFreeTextTokens(
     filteredTokens.add(`${primarySearchKey}:${values}`);
   }
 
-  return Array.from(filteredTokens).join(' ');
+  const newQuery = Array.from(filteredTokens).join(' ');
+
+  const newParsedQuery = parseQueryBuilderValue(newQuery, getFieldDefinition) ?? [];
+  const cursorPosition = (tokens[0]?.location.start.offset ?? 0) + action.text.length; // TODO: Ensure this is sorted
+  const focusedToken = newParsedQuery?.findLast(
+    (token: any) =>
+      token.type === Token.FREE_TEXT && token.location.end.offset >= cursorPosition
+  );
+
+  const focusOverride = focusedToken
+    ? {itemKey: makeTokenKey(focusedToken, newParsedQuery)}
+    : null;
+
+  return {newQuery, focusOverride};
 }
 
 export function useQueryBuilderState({
@@ -760,6 +773,8 @@ export function useQueryBuilderState({
             committedQuery: currentCommittedQuery,
           } = updateFreeText(state, action);
 
+          let newFocusOverride = focusOverride;
+
           let replacedQuery: string | undefined;
           if (
             replaceRawSearchKeys &&
@@ -767,17 +782,18 @@ export function useQueryBuilderState({
             (action?.replaceRawSearchKey ?? true) &&
             hasRawSearchReplacement
           ) {
-            const newQuery = replaceFreeTextTokens(
+            const replacedValues = replaceFreeTextTokens(
               action,
               getFieldDefinition,
               replaceRawSearchKeys,
               query
             );
-            replacedQuery = newQuery;
+            replacedQuery = replacedValues?.newQuery;
+            newFocusOverride = replacedValues?.focusOverride ?? focusOverride;
           }
 
           return {
-            focusOverride,
+            focusOverride: newFocusOverride,
             committedQuery: action.shouldCommitQuery
               ? (replacedQuery ?? query)
               : currentCommittedQuery,
@@ -807,23 +823,27 @@ export function useQueryBuilderState({
             getFieldDefinition,
           });
 
+          let newFocusOverride = focusOverride;
+
           let replacedQuery: string | undefined;
           if (
             replaceRawSearchKeys &&
             replaceRawSearchKeys.length > 0 &&
             hasRawSearchReplacement
           ) {
-            replacedQuery = replaceFreeTextTokens(
+            const replacedValues = replaceFreeTextTokens(
               action,
               getFieldDefinition,
               replaceRawSearchKeys,
               query
             );
+            replacedQuery = replacedValues?.newQuery;
+            newFocusOverride = replacedValues?.focusOverride ?? focusOverride;
           }
 
           return {
             ...state,
-            focusOverride,
+            focusOverride: newFocusOverride,
             committedQuery: replacedQuery ?? committedQuery,
             query: replacedQuery ?? query,
             replacedRawSearchKey: replacedQuery ? true : state.replacedRawSearchKey,

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -85,6 +85,12 @@ export type UpdateFreeTextAction = {
   tokens: ParseResultToken[];
   type: 'UPDATE_FREE_TEXT';
   focusOverride?: FocusOverride;
+  /**
+   * If `false`, the raw search key will not be replaced.
+   * If `true`, the raw search key will be replaced with the new value.
+   * If not provided, and there is a `replaceRawSearchKeys`, the raw search key will be replaced.
+   */
+  replaceRawSearchKey?: boolean;
 };
 
 export type ReplaceTokensWithTextOnPasteAction = {
@@ -758,6 +764,7 @@ export function useQueryBuilderState({
           if (
             replaceRawSearchKeys &&
             replaceRawSearchKeys.length > 0 &&
+            (action?.replaceRawSearchKey ?? true) &&
             hasRawSearchReplacement
           ) {
             const newQuery = replaceFreeTextTokens(

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -548,19 +548,19 @@ function updateFilterKey(
 export function replaceFreeTextTokens(
   action: UpdateQueryAction,
   getFieldDefinition: FieldDefinitionGetter,
-  rawSearchReplacement: string[],
+  replaceRawSearchKeys: string[],
   queryToCommit: string
 ) {
   const tokens = parseQueryBuilderValue(action.query, getFieldDefinition) ?? [];
 
-  if (tokens.length === 0 || rawSearchReplacement.length === 0) {
+  if (tokens.length === 0 || replaceRawSearchKeys.length === 0) {
     return {newQuery: queryToCommit, focusOverride: null};
   }
 
   // Single pass to collect free text tokens and find replace token
   const freeTextTokens: Array<TokenResult<Token.FREE_TEXT>> = [];
   let replaceToken: TokenResult<Token.FILTER> | undefined;
-  const rawSearchFirst = rawSearchReplacement[0] ?? '';
+  const rawSearchFirst = replaceRawSearchKeys[0] ?? '';
 
   for (const token of tokens) {
     if (token.type === Token.FREE_TEXT && /[a-zA-Z0-9]/.test(token.value)) {
@@ -587,7 +587,7 @@ export function replaceFreeTextTokens(
     .filter(
       token =>
         token.type !== Token.FREE_TEXT &&
-        !token.text.includes(rawSearchReplacement[0] ?? '')
+        !token.text.includes(replaceRawSearchKeys[0] ?? '')
     )
     .map(token => token.text);
 
@@ -602,10 +602,10 @@ export function replaceFreeTextTokens(
       previousValue = previousValue.slice(0, -1);
     }
 
-    filteredTokens.push(`${rawSearchReplacement[0]}:[${previousValue},${values}]`);
+    filteredTokens.push(`${replaceRawSearchKeys[0]}:[${previousValue},${values}]`);
   } else {
     filteredTokens.push(
-      `${rawSearchReplacement[0]}:${values.length > 1 ? `[${values}]` : values}`
+      `${replaceRawSearchKeys[0]}:${values.length > 1 ? `[${values}]` : values}`
     );
   }
 
@@ -621,14 +621,14 @@ export function useQueryBuilderState({
   disabled,
   displayAskSeerFeedback,
   setDisplayAskSeerFeedback,
-  rawSearchReplacement,
+  replaceRawSearchKeys,
 }: {
   disabled: boolean;
   displayAskSeerFeedback: boolean;
   getFieldDefinition: FieldDefinitionGetter;
   initialQuery: string;
   setDisplayAskSeerFeedback: (value: boolean) => void;
-  rawSearchReplacement?: string[];
+  replaceRawSearchKeys?: string[];
 }) {
   const organization = useOrganization();
   const hasWildcardOperators = organization.features.includes(
@@ -675,14 +675,14 @@ export function useQueryBuilderState({
 
           let replacedQuery: string | undefined;
           if (
-            rawSearchReplacement &&
-            rawSearchReplacement.length > 0 &&
+            replaceRawSearchKeys &&
+            replaceRawSearchKeys.length > 0 &&
             hasRawSearchReplacement
           ) {
             const {newQuery, focusOverride} = replaceFreeTextTokens(
               action,
               getFieldDefinition,
-              rawSearchReplacement,
+              replaceRawSearchKeys,
               queryToCommit
             );
             replacedQuery = newQuery;
@@ -757,7 +757,7 @@ export function useQueryBuilderState({
       displayAskSeerFeedback,
       getFieldDefinition,
       hasRawSearchReplacement,
-      rawSearchReplacement,
+      replaceRawSearchKeys,
     ]
   );
 

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -605,7 +605,7 @@ export function replaceFreeTextTokens(
     }
   });
 
-  // case when there is a span.description already present
+  // case when there is a replace key and value present
   if (replaceToken) {
     const previousValue =
       replaceToken.value.text.startsWith('[') && replaceToken.value.text.endsWith(']')

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -3,6 +3,7 @@ import {useCallback, useEffect, useReducer, type Reducer} from 'react';
 import {parseFilterValueDate} from 'sentry/components/searchQueryBuilder/tokens/filter/parsers/date/parser';
 import {
   convertTokenTypeToValueType,
+  escapeTagValue,
   getArgsToken,
 } from 'sentry/components/searchQueryBuilder/tokens/filter/utils';
 import {getDefaultValueForValueType} from 'sentry/components/searchQueryBuilder/tokens/utils';
@@ -590,8 +591,8 @@ export function replaceFreeTextTokens(
   if (!valueText) {
     return undefined;
   }
-  const values = valueText.includes(' ') ? `"*${valueText}*"` : `*${valueText}*`;
 
+  const values = escapeTagValue(`*${valueText}*`);
   // Combine both action and current tokens, and filter out the free text tokens
   const filteredTokens = new Set<string>();
   actionTokens.forEach(token => {
@@ -608,7 +609,7 @@ export function replaceFreeTextTokens(
   // case when there is a replace key and value present
   if (replaceToken) {
     const previousValue =
-      replaceToken.value.text.startsWith('[') && replaceToken.value.text.endsWith(']')
+      replaceToken.value.type === Token.VALUE_TEXT_LIST
         ? replaceToken.value.text.slice(1, -1)
         : replaceToken.value.text;
 

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -730,13 +730,11 @@ export function useQueryBuilderState({
             replacedQuery = newQuery;
           }
 
-          const committedQuery = action.shouldCommitQuery
-            ? (replacedQuery ?? query)
-            : currentCommittedQuery;
-
           return {
             focusOverride,
-            committedQuery,
+            committedQuery: action.shouldCommitQuery
+              ? (replacedQuery ?? query)
+              : currentCommittedQuery,
             query: replacedQuery ?? query,
             replacedRawSearchKey: replacedQuery ? true : state.replacedRawSearchKey,
             clearAskSeerFeedback:
@@ -746,7 +744,11 @@ export function useQueryBuilderState({
           };
         }
         case 'REPLACE_TOKENS_WITH_TEXT': {
-          const {query, focusOverride} = replaceTokensWithText(state, {
+          const {
+            query,
+            focusOverride,
+            committedQuery: currentCommittedQuery,
+          } = replaceTokensWithText(state, {
             tokens: action.tokens,
             text: action.text,
             focusOverride: action.focusOverride,
@@ -768,12 +770,10 @@ export function useQueryBuilderState({
             replacedQuery = newQuery;
           }
 
-          const committedQuery = replacedQuery ?? query;
-
           return {
             ...state,
             focusOverride,
-            committedQuery,
+            committedQuery: replacedQuery ?? currentCommittedQuery,
             query: replacedQuery ?? query,
             replacedRawSearchKey: replacedQuery ? true : state.replacedRawSearchKey,
           };

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -636,7 +636,7 @@ export function replaceFreeTextTokens(
   if (!valueText) {
     return undefined;
   }
-  const values = escapeTagValue(`*${valueText}*`);
+  const values = escapeTagValue(valueText);
 
   const filteredTokens = new Set<string>();
   actionTokens.forEach(token => {
@@ -694,9 +694,6 @@ export function useQueryBuilderState({
   replaceRawSearchKeys?: string[];
 }) {
   const organization = useOrganization();
-  const hasWildcardOperators = organization.features.includes(
-    'search-query-builder-wildcard-operators'
-  );
   const hasRawSearchReplacement = organization.features.includes(
     'search-query-builder-raw-search-replacement'
   );

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -24,6 +24,7 @@ import {
   type TokenResult,
 } from 'sentry/components/searchSyntax/parser';
 import {getKeyName, stringifyToken} from 'sentry/components/searchSyntax/utils';
+import useOrganization from 'sentry/utils/useOrganization';
 
 type QueryBuilderState = {
   /**
@@ -56,7 +57,7 @@ type CommitQueryAction = {
   type: 'COMMIT_QUERY';
 };
 
-type UpdateQueryAction = {
+export type UpdateQueryAction = {
   query: string;
   type: 'UPDATE_QUERY';
   focusOverride?: FocusOverride | null;
@@ -435,7 +436,10 @@ function updateFilterMultipleValues(
     new Set(values.filter(value => value.length > 0))
   );
   if (uniqNonEmptyValues.length === 0) {
-    return {...state, query: replaceQueryToken(state.query, token.value, '""')};
+    return {
+      ...state,
+      query: replaceQueryToken(state.query, token.value, '""'),
+    };
   }
 
   const newValue =
@@ -443,7 +447,10 @@ function updateFilterMultipleValues(
       ? `[${uniqNonEmptyValues.join(',')}]`
       : uniqNonEmptyValues[0]!;
 
-  return {...state, query: replaceQueryToken(state.query, token.value, newValue)};
+  return {
+    ...state,
+    query: replaceQueryToken(state.query, token.value, newValue),
+  };
 }
 
 function multiSelectTokenValue(
@@ -538,19 +545,99 @@ function updateFilterKey(
   };
 }
 
+export function replaceFreeTextTokens(
+  action: UpdateQueryAction,
+  getFieldDefinition: FieldDefinitionGetter,
+  rawSearchReplacement: string[],
+  queryToCommit: string
+) {
+  const tokens = parseQueryBuilderValue(action.query, getFieldDefinition) ?? [];
+
+  if (tokens.length === 0 || rawSearchReplacement.length === 0) {
+    return {newQuery: queryToCommit, focusOverride: null};
+  }
+
+  // Single pass to collect free text tokens and find replace token
+  const freeTextTokens: Array<TokenResult<Token.FREE_TEXT>> = [];
+  let replaceToken: TokenResult<Token.FILTER> | undefined;
+  const rawSearchFirst = rawSearchReplacement[0] ?? '';
+
+  for (const token of tokens) {
+    if (token.type === Token.FREE_TEXT && /[a-zA-Z0-9]/.test(token.value)) {
+      freeTextTokens.push(token);
+    } else if (token.type === Token.FILTER && token.text.includes(rawSearchFirst)) {
+      replaceToken = token;
+    }
+  }
+
+  // return early if there are no free text tokens
+  if (freeTextTokens.length === 0) {
+    return {newQuery: queryToCommit, focusOverride: null};
+  }
+
+  const values = freeTextTokens
+    .map(token =>
+      token.value.trim().includes(' ')
+        ? `"*${token.value.trim()}*"`
+        : `*${token.value.trim()}*`
+    )
+    .join(',');
+
+  const filteredTokens = tokens
+    .filter(
+      token =>
+        token.type !== Token.FREE_TEXT &&
+        !token.text.includes(rawSearchReplacement[0] ?? '')
+    )
+    .map(token => token.text);
+
+  // case when there is a span.description already present
+  if (replaceToken) {
+    let previousValue = replaceToken.value.text;
+    if (replaceToken.value.text.startsWith('[')) {
+      previousValue = previousValue.slice(1);
+    }
+
+    if (replaceToken.value.text.endsWith(']')) {
+      previousValue = previousValue.slice(0, -1);
+    }
+
+    filteredTokens.push(`${rawSearchReplacement[0]}:[${previousValue},${values}]`);
+  } else {
+    filteredTokens.push(
+      `${rawSearchReplacement[0]}:${values.length > 1 ? `[${values}]` : values}`
+    );
+  }
+
+  return {
+    newQuery: filteredTokens.join(' '),
+    focusOverride: {itemKey: 'end'},
+  };
+}
+
 export function useQueryBuilderState({
   initialQuery,
   getFieldDefinition,
   disabled,
   displayAskSeerFeedback,
   setDisplayAskSeerFeedback,
+  rawSearchReplacement,
 }: {
   disabled: boolean;
   displayAskSeerFeedback: boolean;
   getFieldDefinition: FieldDefinitionGetter;
   initialQuery: string;
   setDisplayAskSeerFeedback: (value: boolean) => void;
+  rawSearchReplacement?: string[];
 }) {
+  const organization = useOrganization();
+  const hasWildcardOperators = organization.features.includes(
+    'search-query-builder-wildcard-operators'
+  );
+  const hasRawSearchReplacement = organization.features.includes(
+    'search-query-builder-raw-search-replacement'
+  );
+
   const initialState: QueryBuilderState = {
     query: initialQuery,
     committedQuery: initialQuery,
@@ -570,21 +657,42 @@ export function useQueryBuilderState({
             ...state,
             query: '',
             committedQuery: '',
-            focusOverride: {
-              itemKey: `${Token.FREE_TEXT}:0`,
-            },
+            focusOverride: {itemKey: `${Token.FREE_TEXT}:0`},
           };
-        case 'COMMIT_QUERY':
+        case 'COMMIT_QUERY': {
           if (state.query === state.committedQuery) {
             return state;
           }
-          return {...state, committedQuery: state.query};
-        case 'UPDATE_QUERY': {
-          const shouldCommitQuery = action.shouldCommitQuery ?? true;
           return {
             ...state,
-            query: action.query,
-            committedQuery: shouldCommitQuery ? action.query : state.committedQuery,
+            committedQuery: state.query,
+          };
+        }
+        case 'UPDATE_QUERY': {
+          const shouldCommitQuery = action.shouldCommitQuery ?? true;
+
+          const queryToCommit = shouldCommitQuery ? action.query : state.committedQuery;
+
+          let replacedQuery: string | undefined;
+          if (
+            rawSearchReplacement &&
+            rawSearchReplacement.length > 0 &&
+            hasRawSearchReplacement
+          ) {
+            const {newQuery, focusOverride} = replaceFreeTextTokens(
+              action,
+              getFieldDefinition,
+              rawSearchReplacement,
+              queryToCommit
+            );
+            replacedQuery = newQuery;
+            action.focusOverride = focusOverride;
+          }
+
+          return {
+            ...state,
+            query: replacedQuery ?? action.query,
+            committedQuery: replacedQuery ?? queryToCommit,
             focusOverride: action.focusOverride ?? null,
           };
         }
@@ -644,7 +752,13 @@ export function useQueryBuilderState({
           return state;
       }
     },
-    [disabled, displayAskSeerFeedback, getFieldDefinition]
+    [
+      disabled,
+      displayAskSeerFeedback,
+      getFieldDefinition,
+      hasRawSearchReplacement,
+      rawSearchReplacement,
+    ]
   );
 
   const [state, dispatch] = useReducer(reducer, initialState);

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -87,7 +87,7 @@ export type UpdateFreeTextAction = {
   focusOverride?: FocusOverride;
 };
 
-type ReplaceTokensWithTextOnPasteAction = {
+export type ReplaceTokensWithTextOnPasteAction = {
   text: string;
   tokens: ParseResultToken[];
   type: 'REPLACE_TOKENS_WITH_TEXT_ON_PASTE';

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -87,35 +87,35 @@ export type UpdateFreeTextAction = {
   focusOverride?: FocusOverride;
 };
 
-export type ReplaceTokensWithTextOnPasteAction = {
+type ReplaceTokensWithTextOnPasteAction = {
   text: string;
   tokens: ParseResultToken[];
   type: 'REPLACE_TOKENS_WITH_TEXT_ON_PASTE';
   focusOverride?: FocusOverride;
 };
 
-export type ReplaceTokensWithTextOnDeleteAction = {
+type ReplaceTokensWithTextOnDeleteAction = {
   text: string;
   tokens: ParseResultToken[];
   type: 'REPLACE_TOKENS_WITH_TEXT_ON_DELETE';
   focusOverride?: FocusOverride;
 };
 
-export type ReplaceTokensWithTextOnCutAction = {
+type ReplaceTokensWithTextOnCutAction = {
   text: string;
   tokens: ParseResultToken[];
   type: 'REPLACE_TOKENS_WITH_TEXT_ON_CUT';
   focusOverride?: FocusOverride;
 };
 
-export type ReplaceTokensWithTextOnKeyDownAction = {
+type ReplaceTokensWithTextOnKeyDownAction = {
   text: string;
   tokens: ParseResultToken[];
   type: 'REPLACE_TOKENS_WITH_TEXT_ON_KEY_DOWN';
   focusOverride?: FocusOverride;
 };
 
-export type ReplaceTokensWithTextOnSelectAction = {
+type ReplaceTokensWithTextOnSelectAction = {
   text: string;
   tokens: ParseResultToken[];
   type: 'REPLACE_TOKENS_WITH_TEXT_ON_SELECT';

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -49,6 +49,7 @@ type QueryBuilderState = {
    * This is the basic source of truth for what is currently being displayed.
    */
   query: string;
+  replacedRawSearchKey: boolean;
 };
 
 type ClearAction = {type: 'CLEAR'};
@@ -57,7 +58,7 @@ type CommitQueryAction = {
   type: 'COMMIT_QUERY';
 };
 
-export type UpdateQueryAction = {
+type UpdateQueryAction = {
   query: string;
   type: 'UPDATE_QUERY';
   focusOverride?: FocusOverride | null;
@@ -77,7 +78,7 @@ type DeleteTokensAction = {
   focusOverride?: FocusOverride;
 };
 
-type UpdateFreeTextAction = {
+export type UpdateFreeTextAction = {
   shouldCommitQuery: boolean;
   text: string;
   tokens: ParseResultToken[];
@@ -85,7 +86,7 @@ type UpdateFreeTextAction = {
   focusOverride?: FocusOverride;
 };
 
-type ReplaceTokensWithTextAction = {
+export type ReplaceTokensWithTextAction = {
   text: string;
   tokens: ParseResultToken[];
   type: 'REPLACE_TOKENS_WITH_TEXT';
@@ -546,50 +547,64 @@ function updateFilterKey(
 }
 
 export function replaceFreeTextTokens(
-  action: UpdateQueryAction,
+  action: UpdateFreeTextAction | ReplaceTokensWithTextAction,
   getFieldDefinition: FieldDefinitionGetter,
   replaceRawSearchKeys: string[],
-  queryToCommit: string
+  currentQuery: string
 ) {
-  const tokens = parseQueryBuilderValue(action.query, getFieldDefinition) ?? [];
-
-  if (tokens.length === 0 || replaceRawSearchKeys.length === 0) {
-    return {newQuery: queryToCommit, focusOverride: null};
+  // if the free text is empty, return early
+  if (!action.text || action.text === '') {
+    return undefined;
   }
 
-  // Single pass to collect free text tokens and find replace token
-  const freeTextTokens: Array<TokenResult<Token.FREE_TEXT>> = [];
-  let replaceToken: TokenResult<Token.FILTER> | undefined;
-  const rawSearchFirst = replaceRawSearchKeys[0] ?? '';
+  // if the free text is not actually free text i.e. user entered a filter, return early
+  const actionTokens = parseQueryBuilderValue(action.text, getFieldDefinition) ?? [];
+  if (actionTokens.every(token => token.type !== Token.FREE_TEXT)) {
+    return undefined;
+  }
 
+  const tokens = parseQueryBuilderValue(currentQuery, getFieldDefinition) ?? [];
+  if (tokens.length === 0 || replaceRawSearchKeys.length === 0) {
+    return undefined;
+  }
+
+  // Single pass to find replace token
+  const rawSearchFirst = replaceRawSearchKeys[0] ?? '';
+  let replaceToken: TokenResult<Token.FILTER> | undefined;
   for (const token of tokens) {
-    if (token.type === Token.FREE_TEXT && /[a-zA-Z0-9]/.test(token.value)) {
-      freeTextTokens.push(token);
-    } else if (token.type === Token.FILTER && token.text.includes(rawSearchFirst)) {
+    if (token.type === Token.FILTER && token.text.includes(rawSearchFirst)) {
       replaceToken = token;
     }
   }
 
-  // return early if there are no free text tokens
-  if (freeTextTokens.length === 0) {
-    return {newQuery: queryToCommit, focusOverride: null};
+  const freeTextTokens = actionTokens
+    .filter(token => token.type === Token.FREE_TEXT)
+    .find(token => token.type === Token.FREE_TEXT && /[a-zA-Z0-9]/.test(token.value));
+
+  const valueText = freeTextTokens?.text.trim();
+  if (!valueText) {
+    return undefined;
   }
+  const values = valueText.includes(' ') ? `"*${valueText}*"` : `*${valueText}*`;
 
-  const values = freeTextTokens
-    .map(token =>
-      token.value.trim().includes(' ')
-        ? `"*${token.value.trim()}*"`
-        : `*${token.value.trim()}*`
-    )
-    .join(',');
-
-  const filteredTokens = tokens
-    .filter(
-      token =>
-        token.type !== Token.FREE_TEXT &&
-        !token.text.includes(replaceRawSearchKeys[0] ?? '')
-    )
-    .map(token => token.text);
+  // merge the action tokens and the current query tokens,
+  // and filter out the free text tokens or duplicates
+  const filteredTokens = new Set([
+    ...actionTokens
+      .filter(
+        token =>
+          token.type !== Token.FREE_TEXT &&
+          !token.text.includes(replaceRawSearchKeys[0] ?? '')
+      )
+      .map(token => token.text),
+    ...tokens
+      .filter(
+        token =>
+          token.type !== Token.FREE_TEXT &&
+          !token.text.includes(replaceRawSearchKeys[0] ?? '')
+      )
+      .map(token => token.text),
+  ]);
 
   // case when there is a span.description already present
   if (replaceToken) {
@@ -602,17 +617,12 @@ export function replaceFreeTextTokens(
       previousValue = previousValue.slice(0, -1);
     }
 
-    filteredTokens.push(`${replaceRawSearchKeys[0]}:[${previousValue},${values}]`);
+    filteredTokens.add(`${replaceRawSearchKeys[0]}:[${previousValue},${values}]`);
   } else {
-    filteredTokens.push(
-      `${replaceRawSearchKeys[0]}:${values.length > 1 ? `[${values}]` : values}`
-    );
+    filteredTokens.add(`${replaceRawSearchKeys[0]}:${values}`);
   }
 
-  return {
-    newQuery: filteredTokens.join(' '),
-    focusOverride: {itemKey: 'end'},
-  };
+  return Array.from(filteredTokens).join(' ');
 }
 
 export function useQueryBuilderState({
@@ -643,6 +653,7 @@ export function useQueryBuilderState({
     committedQuery: initialQuery,
     focusOverride: null,
     clearAskSeerFeedback: false,
+    replacedRawSearchKey: false,
   };
 
   const reducer: Reducer<QueryBuilderState, QueryBuilderActions> = useCallback(
@@ -671,29 +682,16 @@ export function useQueryBuilderState({
         case 'UPDATE_QUERY': {
           const shouldCommitQuery = action.shouldCommitQuery ?? true;
 
-          const queryToCommit = shouldCommitQuery ? action.query : state.committedQuery;
-
-          let replacedQuery: string | undefined;
-          if (
-            replaceRawSearchKeys &&
-            replaceRawSearchKeys.length > 0 &&
-            hasRawSearchReplacement
-          ) {
-            const {newQuery, focusOverride} = replaceFreeTextTokens(
-              action,
-              getFieldDefinition,
-              replaceRawSearchKeys,
-              queryToCommit
-            );
-            replacedQuery = newQuery;
-            action.focusOverride = focusOverride;
-          }
+          const focusOverride = state.replacedRawSearchKey
+            ? {itemKey: 'end'}
+            : (action.focusOverride ?? null);
 
           return {
             ...state,
-            query: replacedQuery ?? action.query,
-            committedQuery: replacedQuery ?? queryToCommit,
-            focusOverride: action.focusOverride ?? null,
+            replacedRawSearchKey: false,
+            query: action.query,
+            committedQuery: shouldCommitQuery ? action.query : state.committedQuery,
+            focusOverride,
           };
         }
         case 'RESET_FOCUS_OVERRIDE':
@@ -701,7 +699,7 @@ export function useQueryBuilderState({
             ...state,
             focusOverride: null,
           };
-        case 'DELETE_TOKEN': {
+        case 'DELETE_TOKEN':
           return {
             ...replaceTokensWithText(state, {
               tokens: [action.token],
@@ -710,29 +708,81 @@ export function useQueryBuilderState({
             }),
             clearAskSeerFeedback: displayAskSeerFeedback ? true : false,
           };
-        }
-        case 'DELETE_TOKENS': {
+        case 'DELETE_TOKENS':
           return {
             ...deleteQueryTokens(state, action),
             clearAskSeerFeedback: displayAskSeerFeedback ? true : false,
           };
-        }
         case 'UPDATE_FREE_TEXT': {
-          const newState = updateFreeText(state, action);
+          const {
+            query,
+            focusOverride,
+            committedQuery: currentCommittedQuery,
+          } = updateFreeText(state, action);
+
+          let replacedQuery: string | undefined;
+          if (
+            replaceRawSearchKeys &&
+            replaceRawSearchKeys.length > 0 &&
+            hasRawSearchReplacement
+          ) {
+            const newQuery = replaceFreeTextTokens(
+              action,
+              getFieldDefinition,
+              replaceRawSearchKeys,
+              query
+            );
+            replacedQuery = newQuery;
+          }
+
+          const committedQuery = action.shouldCommitQuery
+            ? (replacedQuery ?? query)
+            : currentCommittedQuery;
 
           return {
-            ...newState,
+            focusOverride,
+            committedQuery,
+            query: replacedQuery ?? query,
+            replacedRawSearchKey: replacedQuery ? true : state.replacedRawSearchKey,
             clearAskSeerFeedback:
-              newState.query !== state.query && displayAskSeerFeedback ? true : false,
+              (replacedQuery ?? query) !== state.query && displayAskSeerFeedback
+                ? true
+                : false,
           };
         }
-        case 'REPLACE_TOKENS_WITH_TEXT':
-          return replaceTokensWithText(state, {
+        case 'REPLACE_TOKENS_WITH_TEXT': {
+          const {query, focusOverride} = replaceTokensWithText(state, {
             tokens: action.tokens,
             text: action.text,
             focusOverride: action.focusOverride,
             getFieldDefinition,
           });
+
+          let replacedQuery: string | undefined;
+          if (
+            replaceRawSearchKeys &&
+            replaceRawSearchKeys.length > 0 &&
+            hasRawSearchReplacement
+          ) {
+            const newQuery = replaceFreeTextTokens(
+              action,
+              getFieldDefinition,
+              replaceRawSearchKeys,
+              query
+            );
+            replacedQuery = newQuery;
+          }
+
+          const committedQuery = replacedQuery ?? query;
+
+          return {
+            ...state,
+            focusOverride,
+            committedQuery,
+            query: replacedQuery ?? query,
+            replacedRawSearchKey: replacedQuery ? true : state.replacedRawSearchKey,
+          };
+        }
         case 'UPDATE_FILTER_KEY':
           return updateFilterKey(state, action);
         case 'UPDATE_FILTER_OP':

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -4022,7 +4022,7 @@ describe('SearchQueryBuilder', () => {
       ).toBeInTheDocument();
     });
 
-    it.only('replaces key on enter, and focuses the last item', async () => {
+    it('replaces key on enter, and focuses the last item', async () => {
       render(
         <SearchQueryBuilder
           {...defaultProps}
@@ -4042,37 +4042,17 @@ describe('SearchQueryBuilder', () => {
       await userEvent.type(screen.getByRole('textbox'), 'random value');
       await userEvent.keyboard('{enter}');
 
-      // Wait for the raw search replacement to complete
-      await waitFor(() => {
-        const rows = screen.getAllByRole('row');
-        // Should have more than just the initial empty row
-        expect(rows.length).toBeGreaterThan(1);
-      });
+      await waitFor(() => expect(screen.getAllByRole('row').length).toBeGreaterThan(1));
 
-      // Look for the filter row
-      const filterRow = await screen.findByRole('row', {
-        name: /span\.description/,
-      });
-      expect(filterRow).toBeInTheDocument();
+      expect(
+        await screen.findByRole('row', {name: /span\.description/})
+      ).toBeInTheDocument();
 
-      // Check if it has the right content - could be with or without wildcards
-      const rows = screen.getAllByRole('row');
-      const hasCorrectFilter = rows.some(
-        row =>
-          row.getAttribute('aria-label')?.includes('span.description') &&
-          row.getAttribute('aria-label')?.includes('random value')
-      );
-      expect(hasCorrectFilter).toBe(true);
+      expect(
+        screen.getByRole('row', {name: 'span.description:"*random value*"'})
+      ).toBeInTheDocument();
 
-      // Check focus behavior
-      const inputs = await screen.findAllByRole('row');
-      const lastInput = inputs.at(-1);
-      expect(lastInput).toBeDefined();
-      expect(lastInput).toHaveAttribute('data-key', 'freeText:1');
-
-      // The focus should be on the input inside the last row
-      const focusedInput = screen.getByTestId('query-builder-input');
-      expect(focusedInput).toHaveFocus();
+      expect(getLastInput()).toHaveFocus();
     });
   });
 

--- a/static/app/components/searchQueryBuilder/index.stories.tsx
+++ b/static/app/components/searchQueryBuilder/index.stories.tsx
@@ -766,7 +766,10 @@ export default Storybook.story('SearchQueryBuilder', story => {
         <p>
           The raw search will be replaced with option(s) in the dropdown. The options will
           be the values for the provided keys. The following example shows the prop set as{' '}
-          <code>{`replaceRawSearchKeys={['span.description']}`}</code>.
+          <code>{`replaceRawSearchKeys={['span.description']}`}</code>. This will also
+          augment the search bar when a user types in a free text value, and hits enter,
+          it will be transformed to <code>{`'span.description':<free text value>`}</code>,
+          the replacement will choose the first key in the prop array.
         </p>
         <SearchQueryBuilder
           initialQuery=""

--- a/static/app/components/searchQueryBuilder/index.tsx
+++ b/static/app/components/searchQueryBuilder/index.tsx
@@ -144,9 +144,14 @@ export interface SearchQueryBuilderProps {
    * replacing it with options that include the provided keys, and the user's input
    * as value.
    *
-   * e.g. if `replaceRawSearchKeys` is set to `['span.description']`, the user will be
-   * able to type `randomValue` and the combobox will show `span.description:randomValue`
-   * as an option, and so on with any other provided keys.
+   * @note e.g. if `replaceRawSearchKeys` is set to `['span.description']`, the user will
+   * be able to type `randomValue` and the combobox will show
+   * `span description:randomValue` as an option, and so on with any other provided keys.
+   *
+   * @note The order of the keys in the array is important. The first key will be
+   * used as the default value transformation, i.e. if the user types `random value`,
+   * when the query is submitted it will be transformed to
+   * `span.description:"random value"`.
    */
   replaceRawSearchKeys?: string[];
   /**

--- a/static/app/components/searchQueryBuilder/selectionKeyHandler.tsx
+++ b/static/app/components/searchQueryBuilder/selectionKeyHandler.tsx
@@ -46,7 +46,7 @@ export function SelectionKeyHandler({
       const text = e.clipboardData.getData('text/plain').replace('\n', '').trim();
 
       dispatch({
-        type: 'REPLACE_TOKENS_WITH_TEXT',
+        type: 'REPLACE_TOKENS_WITH_TEXT_ON_PASTE',
         tokens: selectedTokens,
         text,
       });
@@ -62,7 +62,7 @@ export function SelectionKeyHandler({
           e.preventDefault();
           e.stopPropagation();
           dispatch({
-            type: 'REPLACE_TOKENS_WITH_TEXT',
+            type: 'REPLACE_TOKENS_WITH_TEXT_ON_DELETE',
             tokens: selectedTokens,
             text: '',
           });
@@ -128,7 +128,7 @@ export function SelectionKeyHandler({
               state.selectionManager.clearSelection();
               copySelectedTokens();
               dispatch({
-                type: 'REPLACE_TOKENS_WITH_TEXT',
+                type: 'REPLACE_TOKENS_WITH_TEXT_ON_CUT',
                 tokens: selectedTokens,
                 text: '',
               });
@@ -145,7 +145,7 @@ export function SelectionKeyHandler({
           // If the key pressed will generate a symbol, replace the selection with it
           if (/^.$/u.test(e.key)) {
             dispatch({
-              type: 'REPLACE_TOKENS_WITH_TEXT',
+              type: 'REPLACE_TOKENS_WITH_TEXT_ON_KEY_DOWN',
               text: e.key,
               tokens: selectedTokens,
             });

--- a/static/app/components/searchQueryBuilder/tokens/filter/filterKeyCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filterKeyCombobox.tsx
@@ -106,7 +106,7 @@ export function FilterKeyCombobox({token, onCommit, item}: KeyComboboxProps) {
       }
 
       dispatch({
-        type: 'REPLACE_TOKENS_WITH_TEXT',
+        type: 'REPLACE_TOKENS_WITH_TEXT_ON_SELECT',
         tokens: [token],
         text: getInitialFilterText(keyName, newFieldDef),
         focusOverride: {

--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -370,7 +370,7 @@ function SearchQueryBuilderInputInternal({
         .trim();
 
       dispatch({
-        type: 'REPLACE_TOKENS_WITH_TEXT',
+        type: 'REPLACE_TOKENS_WITH_TEXT_ON_PASTE',
         tokens: [token],
         text: clipboardText,
       });

--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -507,10 +507,8 @@ function SearchQueryBuilderInputInternal({
           resetInputValue();
         }}
         onCustomValueCommitted={value => {
-          // If we haven't changed anything, just search. Note, we override this if
-          // the search query builder has raw search replacement enabled, as we want to
-          // always replace any free text tokens with raw search keys.
-          if (value.trim() === trimmedTokenValue && !shouldReplaceRawSearchKey) {
+          // If we haven't changed anything, just search
+          if (value.trim() === trimmedTokenValue) {
             handleSearch(query);
             return;
           }

--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -517,6 +517,7 @@ function SearchQueryBuilderInputInternal({
               tokens: [token],
               text: inputValue,
               shouldCommitQuery: false,
+              replaceRawSearchKey: false,
             });
             resetInputValue();
           }

--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -310,15 +310,6 @@ function SearchQueryBuilderInputInternal({
     currentInputValueRef.current = inputValue;
   }, [inputValue, currentInputValueRef]);
 
-  // Track the usage of ctrl+a so that we can ignore replacing the raw search key and keep
-  // it as a free text token, so that the functionality of doing ctrl+a to select the
-  // text to replace or delete still works as expected.
-  const ctrlABeingPressed = useRef(false);
-  const onKeyUp = useCallback(() => {
-    // reset once the key has been released
-    ctrlABeingPressed.current = false;
-  }, []);
-
   const onKeyDown = useCallback(
     (e: KeyboardEvent) => {
       updateSelectionIndex();
@@ -334,10 +325,7 @@ function SearchQueryBuilderInputInternal({
             e.continuePropagation();
           }
         } else if (e.key === 'a') {
-          ctrlABeingPressed.current = true;
           e.continuePropagation();
-        } else {
-          ctrlABeingPressed.current = false;
         }
       }
 
@@ -512,7 +500,8 @@ function SearchQueryBuilderInputInternal({
               value,
             }),
             shouldCommitQuery: false,
-            replaceRawSearchKey: !suppressBlur.current && !ctrlABeingPressed.current,
+            replaceRawSearchKey:
+              !suppressBlur.current && !inputRef.current?.selectionStart,
           });
 
           resetInputValue();
@@ -659,7 +648,6 @@ function SearchQueryBuilderInputInternal({
           setInputValue(e.target.value);
           setSelectionIndex(e.target.selectionStart ?? 0);
         }}
-        onKeyUp={onKeyUp}
         onKeyDown={onKeyDown}
         onKeyDownCapture={onKeyDownCapture}
         onOpenChange={setIsOpen}


### PR DESCRIPTION
This PR updates the state update functionality of the search bar to automatically replace free text values with their first `replaceRawSearchKeys` value.


https://github.com/user-attachments/assets/6ca3d7ae-4183-4547-8637-32eb81716d13