### PR TITLE
fix(prevent): Use regular link and link directly to the AI toggle

### DIFF
--- a/static/app/views/prevent/preventAI/onboarding.spec.tsx
+++ b/static/app/views/prevent/preventAI/onboarding.spec.tsx
@@ -66,14 +66,14 @@ describe('PreventAIOnboarding', () => {
     render(<PreventAIOnboarding />, {organization});
 
     const orgSettingsLink = screen.getByRole('link', {name: 'organization settings'});
-    expect(orgSettingsLink).toHaveAttribute('href', '/settings/test-org');
+    expect(orgSettingsLink).toHaveAttribute('href', '/settings/test-org/#hideAiFeatures');
 
     const sentryGitHubAppLink = screen.getByRole('link', {
       name: 'Sentry GitHub App',
     });
     expect(sentryGitHubAppLink).toHaveAttribute(
       'href',
-      '/settings/test-org/integrations/github'
+      '/settings/test-org/integrations/github/'
     );
 
     const githubIntegrationLink = screen.getByRole('link', {

--- a/static/app/views/prevent/preventAI/onboarding.tsx
+++ b/static/app/views/prevent/preventAI/onboarding.tsx
@@ -6,7 +6,7 @@ import preventPrCommentsDark from 'sentry-images/features/prevent-pr-comments-da
 import preventPrCommentsLight from 'sentry-images/features/prevent-pr-comments-light.png';
 
 import {Container, Flex} from 'sentry/components/core/layout';
-import {ExternalLink} from 'sentry/components/core/link';
+import {ExternalLink, Link} from 'sentry/components/core/link';
 import {Text} from 'sentry/components/core/text';
 import {Heading} from 'sentry/components/core/text/heading';
 import {IconInfo} from 'sentry/icons/iconInfo';
@@ -109,7 +109,7 @@ export default function PreventAIOnboarding() {
                     </Text>
                   ),
                   organizationSettingsLink: (
-                    <ExternalLink href={`/settings/${organization.slug}`} />
+                    <Link to={`/settings/${organization.slug}/#hideAiFeatures`} />
                   ),
                 }
               )}
@@ -121,9 +121,7 @@ export default function PreventAIOnboarding() {
                 'To grant Seer access to your codebase, install the [sentryGitHubApp:Sentry GitHub App] to connect your GitHub repositories. Learn more about [gitHubIntegration:GitHub integration].',
                 {
                   sentryGitHubApp: (
-                    <ExternalLink
-                      href={`/settings/${organization.slug}/integrations/github`}
-                    />
+                    <Link to={`/settings/${organization.slug}/integrations/github/`} />
                   ),
                   gitHubIntegration: (
                     <ExternalLink href="https://docs.sentry.io/organization/integrations/source-code-mgmt/github/#installing-github" />


### PR DESCRIPTION
Instead of having this open in a new tab, just link directly to settings
and target the AI field