### PR TITLE
fix(alerts): Remove `has_high_priority_alerts` condition in `NewHighPriorityIssueCondition`

### DIFF
--- a/src/sentry/rules/conditions/new_high_priority_issue.py
+++ b/src/sentry/rules/conditions/new_high_priority_issue.py
@@ -21,9 +21,6 @@ class NewHighPriorityIssueCondition(EventCondition):
 
     def passes(self, event: GroupEvent, state: EventState) -> bool:
         is_new = self.is_new(state)
-        if not event.project.flags.has_high_priority_alerts:
-            return is_new
-
         return is_new and event.group.priority == PriorityLevel.HIGH
 
     def get_activity(

--- a/src/sentry/workflow_engine/handlers/condition/new_high_priority_issue_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/new_high_priority_issue_handler.py
@@ -15,8 +15,4 @@ class NewHighPriorityIssueConditionHandler(DataConditionHandler[WorkflowEventDat
     @staticmethod
     def evaluate_value(event_data: WorkflowEventData, comparison: Any) -> bool:
         is_new = is_new_event(event_data)
-        event = event_data.event
-        if not event.project.flags.has_high_priority_alerts:
-            return is_new
-
         return is_new and event_data.group.priority == PriorityLevel.HIGH

--- a/tests/sentry/rules/conditions/test_new_high_priority_issue.py
+++ b/tests/sentry/rules/conditions/test_new_high_priority_issue.py
@@ -13,8 +13,7 @@ class NewHighPriorityIssueConditionTest(RuleTestCase):
     def setUp(self) -> None:
         self.rule = Rule(environment_id=1, project=self.project, label="label")
 
-    def test_applies_correctly_with_high_priority_alerts(self) -> None:
-        self.project.flags.has_high_priority_alerts = True
+    def test_applies_correctly(self) -> None:
         self.project.save()
         rule = self.get_rule(rule=self.rule)
 
@@ -31,20 +30,3 @@ class NewHighPriorityIssueConditionTest(RuleTestCase):
 
         self.event.group.update(priority=PriorityLevel.LOW)
         self.assertDoesNotPass(rule, is_new_group_environment=True)
-
-    def test_applies_correctly_without_high_priority_alerts(self) -> None:
-        self.project.flags.has_high_priority_alerts = False
-        self.project.save()
-        rule = self.get_rule(rule=self.rule)
-
-        self.event.group.update(priority=PriorityLevel.HIGH)
-        self.assertPasses(rule, self.event, is_new_group_environment=True)
-        self.assertDoesNotPass(rule, self.event, is_new_group_environment=False)
-
-        self.event.group.update(priority=PriorityLevel.MEDIUM)
-        self.assertPasses(rule, self.event, is_new_group_environment=True)
-        self.assertDoesNotPass(rule, self.event, is_new_group_environment=False)
-
-        self.event.group.update(priority=PriorityLevel.LOW)
-        self.assertPasses(rule, self.event, is_new_group_environment=True)
-        self.assertDoesNotPass(rule, self.event, is_new_group_environment=False)

--- a/tests/sentry/workflow_engine/handlers/condition/test_new_high_priority_issue_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_new_high_priority_issue_handler.py
@@ -61,10 +61,7 @@ class TestNewHighPriorityIssueCondition(ConditionTestCase):
         with pytest.raises(ValidationError):
             dc.save()
 
-    def test_with_high_priority_alerts(self) -> None:
-        self.project.flags.has_high_priority_alerts = True
-        self.project.save()
-
+    def test_applies_correctly(self) -> None:
         assert self.event_data.group_state
 
         # This will only pass for new issues
@@ -80,28 +77,4 @@ class TestNewHighPriorityIssueCondition(ConditionTestCase):
         self.assert_does_not_pass(self.dc, self.event_data)
 
         self.group_event.group.update(priority=PriorityLevel.LOW)
-        self.assert_does_not_pass(self.dc, self.event_data)
-
-    def test_without_high_priority_alerts(self) -> None:
-        self.project.flags.has_high_priority_alerts = False
-        self.project.save()
-
-        assert self.event_data.group_state
-
-        self.group_event.group.update(priority=PriorityLevel.HIGH)
-        self.event_data.group_state["is_new_group_environment"] = True
-        self.assert_passes(self.dc, self.event_data)
-        self.event_data.group_state["is_new_group_environment"] = False
-        self.assert_does_not_pass(self.dc, self.event_data)
-
-        self.group_event.group.update(priority=PriorityLevel.MEDIUM)
-        self.event_data.group_state["is_new_group_environment"] = True
-        self.assert_passes(self.dc, self.event_data)
-        self.event_data.group_state["is_new_group_environment"] = False
-        self.assert_does_not_pass(self.dc, self.event_data)
-
-        self.group_event.group.update(priority=PriorityLevel.LOW)
-        self.event_data.group_state["is_new_group_environment"] = True
-        self.assert_passes(self.dc, self.event_data)
-        self.event_data.group_state["is_new_group_environment"] = False
         self.assert_does_not_pass(self.dc, self.event_data)

--- a/tests/sentry/workflow_engine/test_integration.py
+++ b/tests/sentry/workflow_engine/test_integration.py
@@ -278,8 +278,6 @@ class TestWorkflowEngineIntegrationFromErrorPostProcess(BaseWorkflowIntegrationT
         from sentry.types.group import GroupSubStatus
 
         project = self.create_project(fire_project_created=True)
-        project.flags.has_high_priority_alerts = True
-        project.save()
         detector = Detector.objects.get(project=project)
         workflow = DetectorWorkflow.objects.get(detector=detector).workflow
         workflow.update(config={"frequency": 0})
@@ -374,9 +372,6 @@ class TestWorkflowEngineIntegrationFromErrorPostProcess(BaseWorkflowIntegrationT
         assert not mock_trigger.called  # Should not trigger for events without the environment
 
     def test_slow_condition_workflow_with_conditions(self, mock_trigger: MagicMock) -> None:
-        self.project.flags.has_high_priority_alerts = True
-        self.project.save()
-
         # slow condition + trigger, and filter condition
         self.workflow_triggers.update(logic_type="all")
         self.create_data_condition(


### PR DESCRIPTION
right now, we still alert on non-high priority issues if the project doesn't have the `has_high_priority_alerts` flag which is confusing. This isn't exposed in the UI which makes it look like a bug when we alert on medium/low priority issues. This PR removes that check from the conditions - other clean up related to this flag will be done in future PRs
fixes https://linear.app/getsentry/issue/ID-871/remove-condition-with-has-high-priority-alerts