### PR TITLE
fix(issues): Correct globe icon breadcrumb alignment

### DIFF
--- a/static/app/views/issueDetails/streamline/header/issueIdBreadcrumb.tsx
+++ b/static/app/views/issueDetails/streamline/header/issueIdBreadcrumb.tsx
@@ -117,6 +117,7 @@ export function IssueIdBreadcrumb({project, group}: ShortIdBreadcrumbProps) {
 
 const BreadcrumbContainer = styled('div')`
   display: flex;
+  align-items: center;
   gap: ${space(0.5)};
 `;
 


### PR DESCRIPTION
Before

<img alt="clipboard.png" width="324" src="https://i.imgur.com/vNMEGR2.png" />

After

<img alt="clipboard.png" width="301" src="https://i.imgur.com/dTbMS90.png" />