### PR TITLE
chore(issues): Clean up group-issues-by killswitch

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3454,14 +3454,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Use "first-seen" group instead of "most-seen" group when merging
-register(
-    "issues.merging.first-seen",
-    type=Bool,
-    default=True,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-
 # Enables saving the suspectCommitStrategy on GroupOwner
 register(
     "issues.suspect-commit-strategy",


### PR DESCRIPTION
[#96592](https://github.com/getsentry/sentry/pull/96592) has been merged for two weeks, and we haven't seen any problems. Let's clean up this KS.