### PR TITLE
chore(autofix): remove icons on buttons except for copy button

### DIFF
--- a/static/app/components/events/autofix/autofixRootCause.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.tsx
@@ -14,15 +14,7 @@ import {
   type CommentThread,
 } from 'sentry/components/events/autofix/types';
 import {makeAutofixQueryKey} from 'sentry/components/events/autofix/useAutofix';
-import {
-  IconArrow,
-  IconChat,
-  IconClose,
-  IconCopy,
-  IconFix,
-  IconFocus,
-  IconInput,
-} from 'sentry/icons';
+import {IconArrow, IconChat, IconClose, IconCopy, IconFocus} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {singleLineRenderer} from 'sentry/utils/marked/marked';
@@ -437,7 +429,6 @@ function AutofixRootCauseDisplay({
               size="sm"
               onClick={handleMySolution}
               title={t('Specify your own solution for Seer to follow')}
-              icon={<IconInput />}
             >
               {t('Give Solution')}
             </Button>
@@ -450,7 +441,6 @@ function AutofixRootCauseDisplay({
               }
               busy={isSelectingRootCause}
               onClick={handleSelectRootCause}
-              icon={<IconFix />}
               title={t('Let Seer plan a solution to this issue')}
             >
               {t('Find Solution')}

--- a/static/app/components/events/autofix/autofixSolution.tsx
+++ b/static/app/components/events/autofix/autofixSolution.tsx
@@ -23,7 +23,7 @@ import {
   type AutofixResponse,
 } from 'sentry/components/events/autofix/useAutofix';
 import {Timeline} from 'sentry/components/timeline';
-import {IconAdd, IconChat, IconCode, IconCopy, IconFix} from 'sentry/icons';
+import {IconAdd, IconChat, IconCopy, IconFix} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -602,7 +602,6 @@ function AutofixSolutionDisplay({
               analyticsEventName="Autofix: Code It Up"
               analyticsEventKey="autofix.solution.code"
               title={t('Implement this solution in code with Seer')}
-              icon={<IconCode />}
             >
               {t('Code It Up')}
             </Button>


### PR DESCRIPTION
Removing icons on buttons (except copy button) because they don't communicate anything and add noise and take up space