### PR TITLE
ref(feedback): rm org id from seer request params

### DIFF
--- a/src/sentry/feedback/endpoints/organization_feedback_categories.py
+++ b/src/sentry/feedback/endpoints/organization_feedback_categories.py
@@ -59,7 +59,6 @@ class LabelGroupFeedbacksContext(TypedDict):
 class LabelGroupsRequest(TypedDict):
     """Corresponds to GenerateFeedbackLabelGroupsRequest in Seer."""
 
-    organization_id: int
     labels: list[str]
     # Providing the LLM context so it knows what labels are used in the same context and are direct children
     feedbacks_context: list[LabelGroupFeedbacksContext]
@@ -196,7 +195,6 @@ class OrganizationFeedbackCategoriesEndpoint(OrganizationEndpoint):
         top_labels = [result["label"] for result in top_labels_result]
 
         seer_request = LabelGroupsRequest(
-            organization_id=organization.id,
             labels=top_labels,
             feedbacks_context=context_feedbacks,
         )

--- a/src/sentry/feedback/endpoints/organization_feedback_summary.py
+++ b/src/sentry/feedback/endpoints/organization_feedback_summary.py
@@ -38,7 +38,6 @@ SUMMARY_CACHE_TIMEOUT = 86400
 class SummaryRequest(TypedDict):
     """Corresponds to SummarizeFeedbacksRequest in Seer."""
 
-    organization_id: int
     feedbacks: list[str]
 
 
@@ -136,7 +135,6 @@ class OrganizationFeedbackSummaryEndpoint(OrganizationEndpoint):
             logger.error("Too few feedbacks to summarize after enforcing the character limit")
 
         seer_request = SummaryRequest(
-            organization_id=organization.id,
             feedbacks=group_feedbacks,
         )
 

--- a/src/sentry/feedback/usecases/ingest/create_feedback.py
+++ b/src/sentry/feedback/usecases/ingest/create_feedback.py
@@ -310,7 +310,7 @@ def create_feedback_issue(
     use_ai_title = should_query_seer and features.has(
         "organizations:user-feedback-ai-titles", project.organization
     )
-    title = get_feedback_title(feedback_message, project.organization_id, use_ai_title)
+    title = get_feedback_title(feedback_message, use_ai_title)
 
     occurrence = IssueOccurrence(
         id=uuid4().hex,
@@ -343,7 +343,7 @@ def create_feedback_issue(
         "organizations:user-feedback-ai-categorization", project.organization
     ):
         try:
-            labels = generate_labels(feedback_message, project.organization_id)
+            labels = generate_labels(feedback_message)
             # This will rarely happen unless the user writes a really long feedback message
             if len(labels) > MAX_AI_LABELS:
                 logger.info(

--- a/src/sentry/feedback/usecases/label_generation.py
+++ b/src/sentry/feedback/usecases/label_generation.py
@@ -26,7 +26,7 @@ SEER_GENERATE_LABELS_URL = f"{settings.SEER_AUTOFIX_URL}/v1/automation/summarize
 
 
 @metrics.wraps("feedback.generate_labels")
-def generate_labels(feedback_message: str, organization_id: int) -> list[str]:
+def generate_labels(feedback_message: str) -> list[str]:
     """
     Generate labels for a feedback message.
 

--- a/src/sentry/feedback/usecases/label_generation.py
+++ b/src/sentry/feedback/usecases/label_generation.py
@@ -13,7 +13,6 @@ logger = logging.getLogger(__name__)
 class LabelRequest(TypedDict):
     """Corresponds to GenerateFeedbackLabelsRequest in Seer."""
 
-    organization_id: int
     feedback_message: str
 
 
@@ -38,7 +37,6 @@ def generate_labels(feedback_message: str, organization_id: int) -> list[str]:
     - KeyError / ValueError if the response JSON doesn't have the expected structure
     """
     request = LabelRequest(
-        organization_id=organization_id,
         feedback_message=feedback_message,
     )
 

--- a/src/sentry/feedback/usecases/title_generation.py
+++ b/src/sentry/feedback/usecases/title_generation.py
@@ -54,7 +54,7 @@ def format_feedback_title(title: str, max_words: int = 10) -> str:
 
 
 @metrics.wraps("feedback.ai_title_generation")
-def get_feedback_title_from_seer(feedback_message: str, organization_id: int) -> str | None:
+def get_feedback_title_from_seer(feedback_message: str) -> str | None:
     """
     Generate an AI-powered title for user feedback using Seer, or None if generation fails.
 
@@ -120,12 +120,10 @@ def make_seer_request(request: GenerateFeedbackTitleRequest) -> bytes:
     return response.content
 
 
-def get_feedback_title(feedback_message: str, organization_id: int, use_seer: bool) -> str:
+def get_feedback_title(feedback_message: str, use_seer: bool) -> str:
     if use_seer:
         # Message is fallback if Seer fails.
-        raw_title = (
-            get_feedback_title_from_seer(feedback_message, organization_id) or feedback_message
-        )
+        raw_title = get_feedback_title_from_seer(feedback_message) or feedback_message
     else:
         raw_title = feedback_message
 

--- a/src/sentry/feedback/usecases/title_generation.py
+++ b/src/sentry/feedback/usecases/title_generation.py
@@ -17,7 +17,6 @@ SEER_GENERATE_TITLE_URL = f"{settings.SEER_AUTOFIX_URL}/v1/automation/summarize/
 class GenerateFeedbackTitleRequest(TypedDict):
     """Corresponds to GenerateFeedbackTitleRequest in Seer."""
 
-    organization_id: int
     feedback_message: str
 
 
@@ -68,7 +67,6 @@ def get_feedback_title_from_seer(feedback_message: str, organization_id: int) ->
         A title string or None if generation fails
     """
     seer_request = GenerateFeedbackTitleRequest(
-        organization_id=organization_id,
         feedback_message=feedback_message,
     )
 

--- a/tests/sentry/feedback/usecases/test_label_generation.py
+++ b/tests/sentry/feedback/usecases/test_label_generation.py
@@ -25,7 +25,7 @@ class TestGenerateLabels(TestCase):
         )
 
         labels = generate_labels(
-            "I don't like the new right sidebar, it makes navigating everywhere hard!", 1
+            "I don't like the new right sidebar, it makes navigating everywhere hard!"
         )
 
         test_request = responses.calls[0].request
@@ -46,7 +46,7 @@ class TestGenerateLabels(TestCase):
 
         with pytest.raises(requests.exceptions.HTTPError):
             generate_labels(
-                "I don't like the new right sidebar, it makes navigating everywhere hard!", 1
+                "I don't like the new right sidebar, it makes navigating everywhere hard!"
             )
 
         test_request = responses.calls[0].request
@@ -63,7 +63,7 @@ class TestGenerateLabels(TestCase):
 
         with pytest.raises(requests.exceptions.Timeout):
             generate_labels(
-                "I don't like the new right sidebar, it makes navigating everywhere hard!", 1
+                "I don't like the new right sidebar, it makes navigating everywhere hard!"
             )
 
         test_request = responses.calls[0].request

--- a/tests/sentry/feedback/usecases/test_label_generation.py
+++ b/tests/sentry/feedback/usecases/test_label_generation.py
@@ -34,7 +34,6 @@ class TestGenerateLabels(TestCase):
         assert labels == ["User Interface", "Navigation", "Right Sidebar"]
         assert json.loads(test_request.body) == {
             "feedback_message": "I don't like the new right sidebar, it makes navigating everywhere hard!",
-            "organization_id": 1,
         }
         assert test_response.status_code == 200
 
@@ -56,7 +55,6 @@ class TestGenerateLabels(TestCase):
         assert test_response.status_code == 500
         assert json.loads(test_request.body) == {
             "feedback_message": "I don't like the new right sidebar, it makes navigating everywhere hard!",
-            "organization_id": 1,
         }
 
     @responses.activate
@@ -73,5 +71,4 @@ class TestGenerateLabels(TestCase):
         assert len(responses.calls) == 1
         assert json.loads(test_request.body) == {
             "feedback_message": "I don't like the new right sidebar, it makes navigating everywhere hard!",
-            "organization_id": 1,
         }

--- a/tests/sentry/feedback/usecases/test_title_generation.py
+++ b/tests/sentry/feedback/usecases/test_title_generation.py
@@ -52,7 +52,6 @@ class TestTitleGeneration(TestCase):
             mock_sign.assert_called_once()
             call_args = mock_sign.call_args[0][0]
             assert isinstance(call_args, bytes)
-            assert b"123" in call_args
             assert b"Test feedback message" in call_args
 
     @responses.activate

--- a/tests/sentry/feedback/usecases/test_title_generation.py
+++ b/tests/sentry/feedback/usecases/test_title_generation.py
@@ -107,7 +107,7 @@ class TestTitleGeneration(TestCase):
             status=200,
             body='{"invalid": "response"}',
         )
-        assert get_feedback_title_from_seer("Login button broken", 123) is None
+        assert get_feedback_title_from_seer("Login button broken") is None
 
     @responses.activate
     def test_get_feedback_title_from_seer_empty_title(self):
@@ -116,7 +116,7 @@ class TestTitleGeneration(TestCase):
             status=200,
             body='{"title": ""}',
         )
-        assert get_feedback_title_from_seer("Login button broken", 123) is None
+        assert get_feedback_title_from_seer("Login button broken") is None
 
     @responses.activate
     def test_get_feedback_title_from_seer_whitespace_only_title(self):
@@ -125,7 +125,7 @@ class TestTitleGeneration(TestCase):
             status=200,
             body='{"title": "   "}',
         )
-        assert get_feedback_title_from_seer("Login button broken", 123) is None
+        assert get_feedback_title_from_seer("Login button broken") is None
 
     @responses.activate
     def test_get_feedback_title_from_seer_non_string_title(self):
@@ -134,7 +134,7 @@ class TestTitleGeneration(TestCase):
             status=200,
             body='{"title": 123}',
         )
-        assert get_feedback_title_from_seer("Login button broken", 123) is None
+        assert get_feedback_title_from_seer("Login button broken") is None
 
     @responses.activate
     def test_get_feedback_title_from_seer_invalid_json(self):
@@ -143,7 +143,7 @@ class TestTitleGeneration(TestCase):
             status=200,
             body='{"invalid": json}',
         )
-        assert get_feedback_title_from_seer("Login button broken", 123) is None
+        assert get_feedback_title_from_seer("Login button broken") is None
 
     @responses.activate
     def test_get_feedback_title_from_seer_http_error(self):
@@ -152,13 +152,13 @@ class TestTitleGeneration(TestCase):
             status=500,
             body="Internal Server Error",
         )
-        assert get_feedback_title_from_seer("Login button broken", 123) is None
+        assert get_feedback_title_from_seer("Login button broken") is None
 
     @responses.activate
     def test_get_feedback_title_from_seer_network_error(self):
         """Test the get_feedback_title_from_seer function with network error."""
         mock_seer_response(body=Exception("Network error"))
-        assert get_feedback_title_from_seer("Login button broken", 123) is None
+        assert get_feedback_title_from_seer("Login button broken") is None
 
     @responses.activate
     def test_get_feedback_title_from_seer_success(self):
@@ -167,4 +167,4 @@ class TestTitleGeneration(TestCase):
             status=200,
             body='{"title": "Login Button Issue"}',
         )
-        assert get_feedback_title_from_seer("Login button broken", 123) == "Login Button Issue"
+        assert get_feedback_title_from_seer("Login button broken") == "Login Button Issue"

--- a/tests/sentry/feedback/usecases/test_title_generation.py
+++ b/tests/sentry/feedback/usecases/test_title_generation.py
@@ -29,9 +29,7 @@ class TestTitleGeneration(TestCase):
     @responses.activate
     def test_make_seer_request(self):
         """Test the make_seer_request function with successful response."""
-        request = GenerateFeedbackTitleRequest(
-            organization_id=123, feedback_message="Test feedback message"
-        )
+        request = GenerateFeedbackTitleRequest(feedback_message="Test feedback message")
 
         mock_seer_response(
             status=200,
@@ -60,9 +58,7 @@ class TestTitleGeneration(TestCase):
     @responses.activate
     def test_make_seer_request_http_error(self):
         """Test the make_seer_request function with HTTP error."""
-        request = GenerateFeedbackTitleRequest(
-            organization_id=123, feedback_message="Test feedback message"
-        )
+        request = GenerateFeedbackTitleRequest(feedback_message="Test feedback message")
 
         mock_seer_response(status=500, body="Internal Server Error")
 


### PR DESCRIPTION
No longer needed for these endpoints. Merge after https://github.com/getsentry/seer/pull/3150 deploys