### PR TITLE
:wrench: chore: update tags of timeout errors for slack metrics

### DIFF
--- a/src/sentry/integrations/slack/sdk_client.py
+++ b/src/sentry/integrations/slack/sdk_client.py
@@ -64,7 +64,7 @@ def wrapper(method: FunctionType):
             metrics.incr(
                 SLACK_DATADOG_METRIC,
                 sample_rate=1.0,
-                tags={"ok": False, "status": "429"},
+                tags={"ok": False, "status": "408"},
             )
             raise
 

--- a/src/sentry/integrations/slack/sdk_client.py
+++ b/src/sentry/integrations/slack/sdk_client.py
@@ -64,7 +64,7 @@ def wrapper(method: FunctionType):
             metrics.incr(
                 SLACK_DATADOG_METRIC,
                 sample_rate=1.0,
-                tags={"status": "timeout"},
+                tags={"ok": False, "status": "429"},
             )
             raise
 

--- a/tests/sentry/integrations/slack/test_sdk_client.py
+++ b/tests/sentry/integrations/slack/test_sdk_client.py
@@ -94,5 +94,5 @@ class SlackClientTest(TestCase):
         mock_metrics.incr.assert_called_with(
             SLACK_DATADOG_METRIC,
             sample_rate=1.0,
-            tags={"status": "timeout"},
+            tags={"ok": False, "status": "429"},
         )


### PR DESCRIPTION
when looking at metrics in DD, the lack of tags here makes it a little be difficult to aggregate