### PR TITLE
ref(replay): add temperature param for replay summaries

### DIFF
--- a/src/sentry/replays/endpoints/project_replay_summary.py
+++ b/src/sentry/replays/endpoints/project_replay_summary.py
@@ -39,8 +39,6 @@ SEER_POLL_STATE_URL = (
     f"{settings.SEER_AUTOFIX_URL}/v1/automation/summarize/replay/breadcrumbs/state"
 )
 
-DEFAULT_TEMPERATURE = 0.2
-
 
 def _get_request_exc_extras(e: requests.exceptions.RequestException) -> dict[str, Any]:
     return {
@@ -160,7 +158,7 @@ class ProjectReplaySummaryEndpoint(ProjectEndpoint):
 
         filter_params = self.get_filter_params(request, project)
         num_segments = request.data.get("num_segments", 0)
-        temperature = request.data.get("temperature", DEFAULT_TEMPERATURE)
+        temperature = request.data.get("temperature", None)
 
         # Limit data with the frontend's segment count, to keep summaries consistent with the video displayed in the UI.
         # While the replay is live, the FE and BE may have different counts.

--- a/src/sentry/replays/endpoints/project_replay_summary.py
+++ b/src/sentry/replays/endpoints/project_replay_summary.py
@@ -39,6 +39,8 @@ SEER_POLL_STATE_URL = (
     f"{settings.SEER_AUTOFIX_URL}/v1/automation/summarize/replay/breadcrumbs/state"
 )
 
+DEFAULT_TEMPERATURE = 0.2
+
 
 def _get_request_exc_extras(e: requests.exceptions.RequestException) -> dict[str, Any]:
     return {
@@ -157,10 +159,11 @@ class ProjectReplaySummaryEndpoint(ProjectEndpoint):
             )
 
         filter_params = self.get_filter_params(request, project)
+        num_segments = request.data.get("num_segments", 0)
+        temperature = request.data.get("temperature", DEFAULT_TEMPERATURE)
 
         # Limit data with the frontend's segment count, to keep summaries consistent with the video displayed in the UI.
         # While the replay is live, the FE and BE may have different counts.
-        num_segments = request.data.get("num_segments", 0)
         if num_segments > MAX_SEGMENTS_TO_SUMMARIZE:
             logger.warning(
                 "Replay Summary: hit max segment limit.",
@@ -218,5 +221,6 @@ class ProjectReplaySummaryEndpoint(ProjectEndpoint):
                 "replay_id": replay_id,
                 "organization_id": project.organization.id,
                 "project_id": project.id,
+                "temperature": temperature,
             },
         )

--- a/tests/sentry/replays/endpoints/test_project_replay_summary.py
+++ b/tests/sentry/replays/endpoints/test_project_replay_summary.py
@@ -8,7 +8,11 @@ import responses
 from django.conf import settings
 from django.urls import reverse
 
-from sentry.replays.endpoints.project_replay_summary import SEER_POLL_STATE_URL, SEER_START_TASK_URL
+from sentry.replays.endpoints.project_replay_summary import (
+    DEFAULT_TEMPERATURE,
+    SEER_POLL_STATE_URL,
+    SEER_START_TASK_URL,
+)
 from sentry.replays.lib.storage import FilestoreBlob, RecordingSegmentStorageMeta
 from sentry.replays.testutils import mock_replay
 from sentry.testutils.cases import TransactionTestCase
@@ -163,6 +167,7 @@ class ProjectReplaySummaryTestCase(
             "replay_id": self.replay_id,
             "organization_id": self.organization.id,
             "project_id": self.project.id,
+            "temperature": DEFAULT_TEMPERATURE,
         }
 
     @patch("sentry.replays.endpoints.project_replay_summary.requests")
@@ -365,6 +370,46 @@ class ProjectReplaySummaryTestCase(
             "replay_id": self.replay_id,
             "organization_id": self.organization.id,
             "project_id": self.project.id,
+            "temperature": DEFAULT_TEMPERATURE,
+        }
+
+    @responses.activate
+    def test_post_with_temperature(self) -> None:
+        mock_seer_response("POST", status=200, json={"hello": "world"})
+
+        data = [
+            {
+                "type": 5,
+                "timestamp": 0.0,
+                "data": {
+                    "tag": "breadcrumb",
+                    "payload": {"category": "console", "message": "hello"},
+                },
+            },
+        ]
+        self.save_recording_segment(0, json.dumps(data).encode())
+
+        with self.feature(self.features):
+            response = self.client.post(
+                self.url,
+                data={"num_segments": 1, "temperature": 0.73},
+                content_type="application/json",
+            )
+
+        assert response.status_code == 200
+
+        assert len(responses.calls) == 1
+        seer_request = responses.calls[0].request
+        assert seer_request.url == SEER_START_TASK_URL
+        assert seer_request.method == "POST"
+        assert seer_request.headers["content-type"] == "application/json;charset=utf-8"
+        assert json.loads(seer_request.body) == {
+            "logs": ["Logged: hello at 0.0"],
+            "num_segments": 1,
+            "replay_id": self.replay_id,
+            "organization_id": self.organization.id,
+            "project_id": self.project.id,
+            "temperature": 0.73,
         }
 
     @responses.activate

--- a/tests/sentry/replays/endpoints/test_project_replay_summary.py
+++ b/tests/sentry/replays/endpoints/test_project_replay_summary.py
@@ -8,11 +8,7 @@ import responses
 from django.conf import settings
 from django.urls import reverse
 
-from sentry.replays.endpoints.project_replay_summary import (
-    DEFAULT_TEMPERATURE,
-    SEER_POLL_STATE_URL,
-    SEER_START_TASK_URL,
-)
+from sentry.replays.endpoints.project_replay_summary import SEER_POLL_STATE_URL, SEER_START_TASK_URL
 from sentry.replays.lib.storage import FilestoreBlob, RecordingSegmentStorageMeta
 from sentry.replays.testutils import mock_replay
 from sentry.testutils.cases import TransactionTestCase
@@ -167,7 +163,7 @@ class ProjectReplaySummaryTestCase(
             "replay_id": self.replay_id,
             "organization_id": self.organization.id,
             "project_id": self.project.id,
-            "temperature": DEFAULT_TEMPERATURE,
+            "temperature": None,
         }
 
     @patch("sentry.replays.endpoints.project_replay_summary.requests")
@@ -370,7 +366,7 @@ class ProjectReplaySummaryTestCase(
             "replay_id": self.replay_id,
             "organization_id": self.organization.id,
             "project_id": self.project.id,
-            "temperature": DEFAULT_TEMPERATURE,
+            "temperature": None,
         }
 
     @responses.activate


### PR DESCRIPTION
Allows passing a temperature to summary generation. Defaults to None if not provided, then Seer picks the default temp. This can be merged independently of Seer, since pydantic ignores extra fields and https://github.com/getsentry/seer/pull/3152 handles missing temp.