### PR TITLE
ref: Include GitHub Enterprise option in the Seer settings page

### DIFF
--- a/static/app/views/settings/projectSeer/autofixRepositories.tsx
+++ b/static/app/views/settings/projectSeer/autofixRepositories.tsx
@@ -18,6 +18,7 @@ import PanelHeader from 'sentry/components/panels/panelHeader';
 import QuestionTooltip from 'sentry/components/questionTooltip';
 import {IconAdd} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
+import {PluginIcon} from 'sentry/plugins/components/pluginIcon';
 import {space} from 'sentry/styles/space';
 import type {Project} from 'sentry/types/project';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -244,12 +245,22 @@ export function AutofixRepositories({project}: ProjectSeerProps) {
             items={[
               {
                 key: 'github',
-                label: t('GitHub'),
+                label: (
+                  <Flex gap="sm" align="center">
+                    <PluginIcon pluginId="github" size={16} />
+                    <div>{t('GitHub')}</div>
+                  </Flex>
+                ),
                 to: `/settings/${organization.slug}/integrations/github/`,
               },
               {
                 key: 'github_enterprise',
-                label: t('GitHub Enterprise'),
+                label: (
+                  <Flex gap="sm" align="center">
+                    <PluginIcon pluginId="github_enterprise" size={16} />
+                    <div>{t('GitHub Enterprise')}</div>
+                  </Flex>
+                ),
                 to: `/settings/${organization.slug}/integrations/github_enterprise/`,
               },
             ]}

--- a/static/app/views/settings/projectSeer/autofixRepositories.tsx
+++ b/static/app/views/settings/projectSeer/autofixRepositories.tsx
@@ -4,10 +4,10 @@ import styled from '@emotion/styled';
 import {openModal} from 'sentry/actionCreators/modal';
 import {Alert} from 'sentry/components/core/alert';
 import {Button} from 'sentry/components/core/button';
-import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {Flex} from 'sentry/components/core/layout';
 import {Link} from 'sentry/components/core/link';
 import {Tooltip} from 'sentry/components/core/tooltip';
+import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {useOrganizationRepositories} from 'sentry/components/events/autofix/preferences/hooks/useOrganizationRepositories';
 import {useProjectSeerPreferences} from 'sentry/components/events/autofix/preferences/hooks/useProjectSeerPreferences';
 import {useUpdateProjectSeerPreferences} from 'sentry/components/events/autofix/preferences/hooks/useUpdateProjectSeerPreferences';
@@ -16,7 +16,7 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Panel from 'sentry/components/panels/panel';
 import PanelHeader from 'sentry/components/panels/panelHeader';
 import QuestionTooltip from 'sentry/components/questionTooltip';
-import {IconAdd, IconGithub} from 'sentry/icons';
+import {IconAdd} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Project} from 'sentry/types/project';
@@ -238,14 +238,22 @@ export function AutofixRepositories({project}: ProjectSeerProps) {
           />
         </Flex>
         <div style={{display: 'flex', alignItems: 'center', gap: space(1)}}>
-          <LinkButton
+          <DropdownMenu
             size="sm"
-            icon={<IconGithub />}
-            to={`/settings/${organization.slug}/integrations/github/`}
-            style={{textTransform: 'none'}}
-          >
-            {t('Manage Integration')}
-          </LinkButton>
+            triggerLabel={t('Manage Integration')}
+            items={[
+              {
+                key: 'github',
+                label: t('GitHub'),
+                to: `/settings/${organization.slug}/integrations/github/`,
+              },
+              {
+                key: 'github_enterprise',
+                label: t('GitHub Enterprise'),
+                to: `/settings/${organization.slug}/integrations/github_enterprise/`,
+              },
+            ]}
+          />
           <Tooltip
             isHoverable
             title={


### PR DESCRIPTION
1. Convert Manage Integration button into a dropdown.
2. Add GitHub Enterprise as an option.

<img width="1273" height="650" alt="Screenshot 2025-08-14 at 20 13 30" src="https://github.com/user-attachments/assets/f8d27361-0e32-40bc-9fa4-34f59a5535e5" />
