### PR TITLE
feat(tasks): Remove Celery support from task retry helpers

### DIFF
--- a/src/sentry/tasks/base.py
+++ b/src/sentry/tasks/base.py
@@ -8,7 +8,6 @@ from typing import Any, ParamSpec, TypeVar
 
 import sentry_sdk
 from celery import Task
-from celery.exceptions import Ignore, MaxRetriesExceededError, Reject, Retry, SoftTimeLimitExceeded
 from django.conf import settings
 from django.db.models import Model
 
@@ -236,7 +235,7 @@ def retry(
         return retry()(func)
 
     timeout_exceptions: tuple[type[BaseException], ...]
-    timeout_exceptions = (ProcessingDeadlineExceeded, SoftTimeLimitExceeded)
+    timeout_exceptions = (ProcessingDeadlineExceeded,)
     if not timeouts:
         timeout_exceptions = ()
 
@@ -247,7 +246,7 @@ def retry(
                 return func(*args, **kwargs)
             except ignore:
                 return
-            except (RetryError, Retry, Ignore, Reject, MaxRetriesExceededError):
+            except RetryError:
                 # We shouldn't interfere with exceptions that exist to communicate
                 # retry state.
                 raise

--- a/src/sentry/taskworker/retry.py
+++ b/src/sentry/taskworker/retry.py
@@ -53,6 +53,8 @@ def retry_task(exc: Exception | None = None, raise_on_no_retries: bool = True) -
             raise NoRetriesRemainingError()
         else:
             return
+    if exc:
+        raise RetryError(exc) from exc
     raise RetryError()
 
 

--- a/src/sentry/taskworker/retry.py
+++ b/src/sentry/taskworker/retry.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from enum import Enum
 from multiprocessing.context import TimeoutError
 
-from celery import current_task
 from sentry_protos.taskbroker.v1.taskbroker_pb2 import (
     ON_ATTEMPTS_EXCEEDED_DEADLETTER,
     ON_ATTEMPTS_EXCEEDED_DISCARD,
@@ -45,26 +44,16 @@ def retry_task(exc: Exception | None = None, raise_on_no_retries: bool = True) -
     """
     Helper for triggering retry errors.
     If all retries have been consumed, this will raise a
-    sentry.taskworker.retry.NoRetriesRemaining or
-    celery.exceptions.MaxRetriesExceededError depending on how
-    the task is operated.
-
-    During task conversion, this function will shim
-    between celery's retry API and Taskworker retry API.
+    sentry.taskworker.retry.NoRetriesRemaining.
     """
-    celery_retry = getattr(current_task, "retry", None)
-    if celery_retry:
-        current_task.retry(exc=exc)
-        assert False, "unreachable"
-    else:
-        current = taskworker_current_task()
-        if current and not current.retries_remaining:
-            metrics.incr("taskworker.retry.no_retries_remaining")
-            if raise_on_no_retries:
-                raise NoRetriesRemainingError()
-            else:
-                return
-        raise RetryError()
+    current = taskworker_current_task()
+    if current and not current.retries_remaining:
+        metrics.incr("taskworker.retry.no_retries_remaining")
+        if raise_on_no_retries:
+            raise NoRetriesRemainingError()
+        else:
+            return
+    raise RetryError()
 
 
 class Retry:

--- a/tests/sentry/integrations/github/tasks/test_link_all_repos.py
+++ b/tests/sentry/integrations/github/tasks/test_link_all_repos.py
@@ -185,8 +185,16 @@ class LinkAllReposTestCase(IntegrationTestCase):
         assert_failure_metric(mock_record, LinkAllReposHaltReason.MISSING_ORGANIZATION.value)
 
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    @patch("sentry.tasks.base.retry_task")
     @responses.activate
-    def test_link_all_repos_api_error(self, mock_record: MagicMock, _: MagicMock) -> None:
+    def test_link_all_repos_api_error(
+        self, mock_retry: MagicMock, mock_record: MagicMock, _: MagicMock
+    ) -> None:
+        # Poke a hole through retry logic.
+        def raise_it(exc, raise_on_no_retries):
+            raise exc
+
+        mock_retry.side_effect = raise_it
 
         responses.add(
             responses.GET,

--- a/tests/sentry/tasks/test_commit_context.py
+++ b/tests/sentry/tasks/test_commit_context.py
@@ -5,7 +5,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import responses
-from celery.exceptions import Retry
 from django.utils import timezone
 
 from sentry.analytics.events.integration_commit_context_all_frames import (
@@ -37,6 +36,7 @@ from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.silo.base import SiloMode
 from sentry.tasks.commit_context import PR_COMMENT_WINDOW, process_commit_context
+from sentry.taskworker.retry import NoRetriesRemainingError, RetryError
 from sentry.testutils.asserts import assert_halt_metric
 from sentry.testutils.cases import IntegrationTestCase, TestCase
 from sentry.testutils.helpers.analytics import assert_any_analytics_event
@@ -825,7 +825,7 @@ class TestCommitContextAllFrames(TestCommitContextIntegration):
         with self.tasks():
             assert not GroupOwner.objects.filter(group=self.event.group).exists()
             event_frames = get_frame_paths(self.event)
-            with pytest.raises(Retry):
+            with pytest.raises(RetryError):
                 process_commit_context(
                     event_id=self.event.event_id,
                     event_platform=self.event.platform,
@@ -865,21 +865,19 @@ class TestCommitContextAllFrames(TestCommitContextIntegration):
         assert not GroupOwner.objects.filter(group=self.event.group).exists()
         mock_process_suspect_commits.assert_not_called()
 
-    @patch("celery.app.task.Task.request")
+    @patch("sentry.tasks.commit_context.retry_task", side_effect=NoRetriesRemainingError)
     @patch("sentry.tasks.groupowner.process_suspect_commits.delay")
     @patch(
         "sentry.integrations.github.integration.GitHubIntegration.get_commit_context_all_frames",
         side_effect=ApiError("Unknown API error"),
     )
     def test_no_fall_back_on_max_retries(
-        self, mock_get_commit_context, mock_process_suspect_commits, mock_request
+        self, mock_get_commit_context, mock_process_suspect_commits, mock_retry_task
     ):
         """
         A failure case where the integration hits an unknown API error a fifth time.
         After 5 retries, the task should bail.
         """
-        mock_request.called_directly = False
-        mock_request.retries = 5
 
         with self.tasks():
             assert not GroupOwner.objects.filter(group=self.event.group).exists()


### PR DESCRIPTION
Now that we've transitioned to full taskbroker, the celery support only adds confusion.