### PR TITLE
feat(eap): Support wildcard in filters

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -453,6 +453,10 @@ class SearchValue(NamedTuple):
         # If we're using the raw value only it'll never be a wildcard
         if self.use_raw_value:
             return False
+        if self.is_str_sequence():
+            return isinstance(self.raw_value, list) and any(
+                _is_wildcard(value) for value in self.raw_value
+            )
         return _is_wildcard(self.raw_value)
 
     def is_str_sequence(self) -> bool:

--- a/src/sentry/search/eap/resolver.py
+++ b/src/sentry/search/eap/resolver.py
@@ -127,7 +127,10 @@ class SearchResolver:
         AggregationFilter | None,
         list[VirtualColumnDefinition | None],
     ]:
-        """Given a query string in the public search syntax eg. `span.description:foo` construct the TraceItemFilter"""
+        """Given a query string in the public search syntax eg. `span.description:foo` construct the TraceItemFilter
+
+        This is the public interface to resolver the query, for the logic see __resolve_query, this is because we
+        also append the environment before returning the final TraceItemFilter"""
         environment_query = self.__resolve_environment_query()
         where, having, contexts = self.__resolve_query(querystring)
         span = sentry_sdk.get_current_span()
@@ -467,14 +470,47 @@ class SearchResolver:
                 resolved_column, _ = self.resolve_attribute(context_definition.filter_column)
 
         if term.value.is_wildcard():
+            is_list = False
             if term.operator == "=":
                 operator = ComparisonFilter.OP_LIKE
             elif term.operator == "!=":
                 operator = ComparisonFilter.OP_NOT_LIKE
+            elif term.operator == "IN":
+                operator = ComparisonFilter.OP_LIKE
+                is_list = True
+            elif term.operator == "NOT IN":
+                operator = ComparisonFilter.OP_NOT_LIKE
+                is_list = True
+
+            if is_list:
+                raw_value = cast(list[str], term.value.raw_value)
+                filters = [
+                    TraceItemFilter(
+                        comparison_filter=ComparisonFilter(
+                            key=resolved_column.proto_definition,
+                            op=operator,
+                            value=self._resolve_search_value(
+                                resolved_column,
+                                (
+                                    "=" if operator == ComparisonFilter.OP_LIKE else "!="
+                                ),  # tell this function the single operator since its being ORed
+                                event_search.translate_wildcard_as_clickhouse_pattern(str(value)),
+                            ),
+                        )
+                    )
+                    for value in raw_value
+                ]
+                return (
+                    (
+                        TraceItemFilter(or_filter=OrFilter(filters=filters))
+                        if term.operator == "IN"
+                        else TraceItemFilter(and_filter=AndFilter(filters=filters))
+                    ),
+                    context_definition,
+                )
             else:
-                raise InvalidSearchQuery(f"Cannot use a wildcard with a {term.operator} filter")
-            value = str(term.value.raw_value)
-            value = event_search.translate_wildcard_as_clickhouse_pattern(value)
+                value = str(term.value.raw_value)
+                value = event_search.translate_wildcard_as_clickhouse_pattern(value)
         elif term.operator in constants.OPERATOR_MAP:
             operator = constants.OPERATOR_MAP[term.operator]
         else:

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -5440,6 +5440,84 @@ class OrganizationEventsSpansEndpointTest(OrganizationEventsEndpointTestBase):
             },
         ]
 
+    def test_tag_wildcards_with_in_filter(self) -> None:
+        self.store_spans(
+            [
+                self.create_span(
+                    {"description": "foo", "tags": {"foo": "bar"}},
+                    start_ts=self.ten_mins_ago,
+                ),
+                self.create_span(
+                    {"description": "qux", "tags": {"foo": "qux"}},
+                    start_ts=self.ten_mins_ago,
+                ),
+                self.create_span(
+                    {"description": "bux", "tags": {"foo": "bux"}},
+                    start_ts=self.ten_mins_ago,
+                ),
+                self.create_span(
+                    {"description": "qar", "tags": {"foo": "qar"}},
+                    start_ts=self.ten_mins_ago,
+                ),
+            ],
+            is_eap=True,
+        )
+
+        response = self.do_request(
+            {
+                "field": ["foo", "count()"],
+                "query": "foo:[b*,*ux]",
+                "project": self.project.id,
+                "orderby": "foo",
+                "dataset": "spans",
+            }
+        )
+        assert response.status_code == 200, response.content
+        assert len(response.data["data"]) == 3
+        assert response.data["data"] == [
+            {"foo": "bar", "count()": 1},
+            {"foo": "bux", "count()": 1},
+            {"foo": "qux", "count()": 1},
+        ]
+
+    def test_tag_wildcards_with_not_in_filter(self) -> None:
+        self.store_spans(
+            [
+                self.create_span(
+                    {"description": "bar", "tags": {"foo": "bar"}},
+                    start_ts=self.ten_mins_ago,
+                ),
+                self.create_span(
+                    {"description": "qux", "tags": {"foo": "qux"}},
+                    start_ts=self.ten_mins_ago,
+                ),
+                self.create_span(
+                    {"description": "bux", "tags": {"foo": "bux"}},
+                    start_ts=self.ten_mins_ago,
+                ),
+                self.create_span(
+                    {"description": "qar", "tags": {"foo": "qar"}},
+                    start_ts=self.ten_mins_ago,
+                ),
+            ],
+            is_eap=True,
+        )
+
+        response = self.do_request(
+            {
+                "field": ["foo", "count()"],
+                "query": "!foo:[ba*,*ux]",
+                "project": self.project.id,
+                "orderby": "foo",
+                "dataset": "spans",
+            }
+        )
+        assert response.status_code == 200, response.content
+        assert len(response.data["data"]) == 1
+        assert response.data["data"] == [
+            {"foo": "qar", "count()": 1},
+        ]
+
     def test_disable_extrapolation(self) -> None:
         spans = []
         spans.append(


### PR DESCRIPTION
- This adds support for doing wildcards in an IN filter like `foo:[*endswith,startswith*]`

Fixes: EXP-97