### PR TITLE
ref(scm): always pass integration_id and organization_id in SCM LifeCycleMetric

### DIFF
--- a/src/sentry/integrations/bitbucket/search.py
+++ b/src/sentry/integrations/bitbucket/search.py
@@ -43,7 +43,9 @@ class BitbucketSearchEndpoint(SourceCodeSearchEndpoint):
 
     def handle_search_issues(self, installation: T, query: str, repo: str | None) -> Response:
         with self.record_event(
-            SCMIntegrationInteractionType.HANDLE_SEARCH_ISSUES
+            SCMIntegrationInteractionType.HANDLE_SEARCH_ISSUES,
+            organization_id=installation.organization_id,
+            integration_id=installation.org_integration.integration_id,
         ).capture() as lifecycle:
             assert repo
 
@@ -75,6 +77,10 @@ class BitbucketSearchEndpoint(SourceCodeSearchEndpoint):
     def handle_search_repositories(
         self, integration: Integration, installation: T, query: str
     ) -> Response:
-        with self.record_event(SCMIntegrationInteractionType.HANDLE_SEARCH_REPOSITORIES).capture():
+        with self.record_event(
+            SCMIntegrationInteractionType.HANDLE_SEARCH_REPOSITORIES,
+            organization_id=installation.organization_id,
+            integration_id=integration.id,
+        ).capture():
             result = installation.get_repositories(query)
             return Response([{"label": i["name"], "value": i["name"]} for i in result])

--- a/src/sentry/integrations/github/search.py
+++ b/src/sentry/integrations/github/search.py
@@ -35,7 +35,9 @@ class GithubSharedSearchEndpoint(SourceCodeSearchEndpoint):
 
     def handle_search_issues(self, installation: T, query: str, repo: str | None) -> Response:
         with self.record_event(
-            SCMIntegrationInteractionType.HANDLE_SEARCH_ISSUES
+            SCMIntegrationInteractionType.HANDLE_SEARCH_ISSUES,
+            organization_id=installation.organization_id,
+            integration_id=installation.org_integration.integration_id,
         ).capture() as lifecycle:
             assert repo
 
@@ -59,7 +61,9 @@ class GithubSharedSearchEndpoint(SourceCodeSearchEndpoint):
         self, integration: Integration, installation: T, query: str
     ) -> Response:
         with self.record_event(
-            SCMIntegrationInteractionType.HANDLE_SEARCH_REPOSITORIES
+            SCMIntegrationInteractionType.HANDLE_SEARCH_REPOSITORIES,
+            organization_id=installation.organization_id,
+            integration_id=integration.id,
         ).capture() as lifecyle:
             assert isinstance(installation, self.installation_class)
 

--- a/src/sentry/integrations/github/tasks/link_all_repos.py
+++ b/src/sentry/integrations/github/tasks/link_all_repos.py
@@ -51,9 +51,10 @@ def link_all_repos(
 
     with SCMIntegrationInteractionEvent(
         interaction_type=SCMIntegrationInteractionType.LINK_ALL_REPOS,
+        integration_id=integration_id,
+        organization_id=organization_id,
         provider_key=integration_key,
     ).capture() as lifecycle:
-        lifecycle.add_extra("organization_id", organization_id)
         integration = integration_service.get_integration(
             integration_id=integration_id, status=ObjectStatus.ACTIVE
         )

--- a/src/sentry/integrations/gitlab/search.py
+++ b/src/sentry/integrations/gitlab/search.py
@@ -30,7 +30,9 @@ class GitlabIssueSearchEndpoint(SourceCodeSearchEndpoint):
 
     def handle_search_issues(self, installation: T, query: str, repo: str | None) -> Response:
         with self.record_event(
-            SCMIntegrationInteractionType.HANDLE_SEARCH_ISSUES
+            SCMIntegrationInteractionType.HANDLE_SEARCH_ISSUES,
+            organization_id=installation.organization_id,
+            integration_id=installation.org_integration.integration_id,
         ).capture() as lifecycle:
             assert repo
 
@@ -63,7 +65,9 @@ class GitlabIssueSearchEndpoint(SourceCodeSearchEndpoint):
         self, integration: Integration, installation: T, query: str
     ) -> Response:
         with self.record_event(
-            SCMIntegrationInteractionType.HANDLE_SEARCH_REPOSITORIES
+            SCMIntegrationInteractionType.HANDLE_SEARCH_REPOSITORIES,
+            organization_id=installation.organization_id,
+            integration_id=integration.id,
         ).capture() as lifecyle:
             assert isinstance(installation, self.installation_class)
             try:

--- a/src/sentry/integrations/source_code_management/commit_context.py
+++ b/src/sentry/integrations/source_code_management/commit_context.py
@@ -249,7 +249,7 @@ class CommitContextIntegration(ABC):
         with CommitContextIntegrationInteractionEvent(
             interaction_type=SCMIntegrationInteractionType.QUEUE_COMMENT_TASK,
             provider_key=self.integration_name,
-            organization=project.organization,
+            organization_id=project.organization_id,
             project=project,
             commit=commit,
         ).capture() as lifecycle:

--- a/src/sentry/integrations/source_code_management/issues.py
+++ b/src/sentry/integrations/source_code_management/issues.py
@@ -24,8 +24,8 @@ class SourceCodeIssueIntegration(IssueBasicIntegration, BaseRepositoryIntegratio
         return SCMIntegrationInteractionEvent(
             interaction_type=event,
             provider_key=self.model.provider,
-            organization=self.organization,
-            org_integration=self.org_integration,
+            organization_id=self.organization.id,
+            integration_id=self.org_integration.integration_id,
         )
 
     def _get_repository_choices(

--- a/src/sentry/integrations/source_code_management/metrics.py
+++ b/src/sentry/integrations/source_code_management/metrics.py
@@ -5,14 +5,10 @@ from typing import Any
 from attr import dataclass
 
 from sentry.integrations.base import IntegrationDomain
-from sentry.integrations.models.organization_integration import OrganizationIntegration
-from sentry.integrations.services.integration import RpcOrganizationIntegration
 from sentry.integrations.utils.metrics import IntegrationEventLifecycleMetric
 from sentry.models.commit import Commit
-from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.repository import Repository
-from sentry.organizations.services.organization import RpcOrganization
 
 
 class SCMIntegrationInteractionType(StrEnum):
@@ -63,10 +59,8 @@ class SCMIntegrationInteractionEvent(IntegrationEventLifecycleMetric):
 
     interaction_type: SCMIntegrationInteractionType
     provider_key: str
-
-    # Optional attributes to populate extras
-    organization: Organization | RpcOrganization | None = None
-    org_integration: OrganizationIntegration | RpcOrganizationIntegration | None = None
+    integration_id: int | None = None
+    organization_id: int | None = None
 
     def get_integration_domain(self) -> IntegrationDomain:
         return IntegrationDomain.SOURCE_CODE_MANAGEMENT
@@ -79,8 +73,8 @@ class SCMIntegrationInteractionEvent(IntegrationEventLifecycleMetric):
 
     def get_extras(self) -> Mapping[str, Any]:
         return {
-            "organization_id": (self.organization.id if self.organization else None),
-            "org_integration_id": (self.org_integration.id if self.org_integration else None),
+            "organization_id": (self.organization_id if self.organization_id else None),
+            "integration_id": (self.integration_id if self.integration_id else None),
         }
 
 

--- a/src/sentry/integrations/source_code_management/repository.py
+++ b/src/sentry/integrations/source_code_management/repository.py
@@ -108,8 +108,8 @@ class RepositoryIntegration(IntegrationInstallation, BaseRepositoryIntegration, 
         return SCMIntegrationInteractionEvent(
             interaction_type=event,
             provider_key=self.integration_name,
-            organization=self.organization,
-            org_integration=self.org_integration,
+            organization_id=self.organization.id,
+            integration_id=self.org_integration.integration_id,
         )
 
     def check_file(self, repo: Repository, filepath: str, branch: str | None = None) -> str | None:

--- a/src/sentry/integrations/source_code_management/search.py
+++ b/src/sentry/integrations/source_code_management/search.py
@@ -61,7 +61,12 @@ class SourceCodeSearchEndpoint(IntegrationEndpoint, Generic[T], ABC):
     def handle_search_issues(self, installation: T, query: str, repo: str | None) -> Response:
         raise NotImplementedError
 
-    def record_event(self, event: SCMIntegrationInteractionType):
+    def record_event(
+        self,
+        event: SCMIntegrationInteractionType,
+        organization_id: int,
+        integration_id: int,
+    ):
         # XXX (mifu67): self.integration_provider is None for the GithubSharedSearchEndpoint,
         # which is used by both GitHub and GitHub Enterprise.
         provider_name = (
@@ -72,6 +77,8 @@ class SourceCodeSearchEndpoint(IntegrationEndpoint, Generic[T], ABC):
         return SCMIntegrationInteractionEvent(
             interaction_type=event,
             provider_key=provider_name,
+            organization_id=organization_id,
+            integration_id=integration_id,
         )
 
     # not used in VSTS
@@ -83,7 +90,11 @@ class SourceCodeSearchEndpoint(IntegrationEndpoint, Generic[T], ABC):
     def get(
         self, request: Request, organization: RpcOrganization, integration_id: int, **kwds: Any
     ) -> Response:
-        with self.record_event(SCMIntegrationInteractionType.GET).capture() as lifecycle:
+        with self.record_event(
+            SCMIntegrationInteractionType.GET,
+            organization_id=organization.id,
+            integration_id=integration_id,
+        ).capture() as lifecycle:
             integration_query = Q(
                 organizationintegration__organization_id=organization.id, id=integration_id
             )

--- a/src/sentry/integrations/tasks/create_comment.py
+++ b/src/sentry/integrations/tasks/create_comment.py
@@ -52,9 +52,9 @@ def create_comment(external_issue_id: int, user_id: int, group_note_id: int) -> 
 
     with SCMIntegrationInteractionEvent(
         interaction_type=SCMIntegrationInteractionType.SYNC_EXTERNAL_ISSUE_COMMENT_CREATE,
-        organization=external_issue.organization,
         provider_key=installation.model.get_provider().name,
-        org_integration=installation.org_integration,
+        organization_id=external_issue.organization.id,
+        integration_id=installation.org_integration.integration_id,
     ).capture() as lifecycle:
         lifecycle.add_extras(
             {

--- a/src/sentry/integrations/tasks/update_comment.py
+++ b/src/sentry/integrations/tasks/update_comment.py
@@ -55,9 +55,9 @@ def update_comment(external_issue_id: int, user_id: int, group_note_id: int) -> 
 
     with SCMIntegrationInteractionEvent(
         interaction_type=SCMIntegrationInteractionType.SYNC_EXTERNAL_ISSUE_COMMENT_UPDATE,
-        organization=external_issue.organization,
         provider_key=installation.model.get_provider().name,
-        org_integration=installation.org_integration,
+        integration_id=installation.org_integration.integration_id,
+        organization_id=external_issue.organization.id,
     ).capture() as lifecycle:
         lifecycle.add_extras(
             {

--- a/src/sentry/integrations/vsts/search.py
+++ b/src/sentry/integrations/vsts/search.py
@@ -23,7 +23,11 @@ class VstsSearchEndpoint(SourceCodeSearchEndpoint):
         return VstsIntegration
 
     def handle_search_issues(self, installation: T, query: str, repo: str | None) -> Response:
-        with self.record_event(SCMIntegrationInteractionType.HANDLE_SEARCH_ISSUES).capture():
+        with self.record_event(
+            SCMIntegrationInteractionType.HANDLE_SEARCH_ISSUES,
+            organization_id=installation.organization_id,
+            integration_id=installation.org_integration.integration_id,
+        ).capture():
             if not query:
                 return Response([])
 

--- a/src/sentry/issues/auto_source_code_config/task.py
+++ b/src/sentry/issues/auto_source_code_config/task.py
@@ -173,6 +173,8 @@ def get_trees_for_org(
     with SCMIntegrationInteractionEvent(
         SCMIntegrationInteractionType.DERIVE_CODEMAPPINGS,
         provider_key=installation.model.provider,
+        organization_id=org.id,
+        integration_id=installation.org_integration.integration_id,
     ).capture() as lifecycle:
         try:
             with lock.acquire():

--- a/src/sentry/tasks/commits.py
+++ b/src/sentry/tasks/commits.py
@@ -168,6 +168,8 @@ def fetch_commits(release_id: int, user_id: int, refs, prev_release_id=None, **k
         with SCMIntegrationInteractionEvent(
             SCMIntegrationInteractionType.COMPARE_COMMITS,
             provider_key=provider_key,
+            organization_id=repo.organization_id,
+            integration_id=repo.integration_id,
         ).capture() as lifecycle:
             lifecycle.add_extras(
                 {


### PR DESCRIPTION
To make combing through logs easier, so we can search by organization id and integration id. Like find common patterns if an error is all coming from one org