### PR TITLE
ref(cell-actions): better interactions for ID and clearer menu indication

### DIFF
--- a/static/app/views/discover/table/cellAction.tsx
+++ b/static/app/views/discover/table/cellAction.tsx
@@ -299,8 +299,6 @@ function makeCellActions({
  */
 function getInternalLinkActionLabel(field: string): string {
   switch (field) {
-    case FieldKey.ID:
-      return t('Open view');
     case FieldKey.TRACE:
       return t('Open trace');
     case FieldKey.PROJECT:
@@ -478,8 +476,12 @@ const ActionMenuTrigger = styled(Button)`
 `;
 
 const ActionMenuTriggerV2 = styled('div')`
+  a,
+  span {
+    color: ${p => p.theme.textColor};
+  }
   :hover {
     cursor: pointer;
-    font-weight: ${p => p.theme.fontWeight.bold};
+    text-shadow: 0.5px 0px;
   }
 `;

--- a/static/app/views/explore/tables/fieldRenderer.tsx
+++ b/static/app/views/explore/tables/fieldRenderer.tsx
@@ -162,6 +162,10 @@ function BaseExploreFieldRenderer({
     });
 
     rendered = <Link to={target}>{rendered}</Link>;
+
+    if (field === 'id') {
+      return rendered;
+    }
   }
 
   if (field === 'profile.id') {

--- a/static/app/views/explore/tables/fieldRenderer.tsx
+++ b/static/app/views/explore/tables/fieldRenderer.tsx
@@ -163,7 +163,7 @@ function BaseExploreFieldRenderer({
 
     rendered = <Link to={target}>{rendered}</Link>;
 
-    if (field === 'id') {
+    if (organization.features.includes('discover-cell-actions-v2') && field === 'id') {
       return rendered;
     }
   }


### PR DESCRIPTION
### Changes

See for more context: https://sentry.slack.com/archives/C05FUFGPGFM/p1755198491001089 

* Span ID has no cell actions in Explore table
* URLs with cell actions are no longer styled with blue/purple text colour to indicate they open a menu
* Swapped the text bold to a text shadow to avoid shifting columns

### Video

https://github.com/user-attachments/assets/79a4c0b6-55e2-4c5e-9b78-81b7e51f9af1
