### PR TITLE
feat(eco): add option to allow collecting metrics from specific orgs

### DIFF
--- a/src/sentry/integrations/utils/metrics.py
+++ b/src/sentry/integrations/utils/metrics.py
@@ -164,12 +164,12 @@ class EventLifecycle:
         )
         should_log = effective_sample_log_rate >= 1.0 or random.random() < effective_sample_log_rate
 
-        if "organization_id" in extra:
-            org_id = extra["organization_id"]
-            if org_id in options.get("integration.debugging.org-ids"):
-                create_issue = True
-                effective_sample_log_rate = 1.0
-                should_log = True
+        if (org_id := extra.get("organization_id")) and org_id in options.get(
+            "integration.debugging.org-ids"
+        ):
+            create_issue = True
+            effective_sample_log_rate = 1.0
+            should_log = True
 
         if isinstance(outcome_reason, BaseException):
             # Capture exception in Sentry if create_issue is True

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -621,6 +621,14 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Integration debugging
+register(
+    "integration.debugging.org-ids",
+    type=Sequence,
+    default=[],
+    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # Codecov Integration
 register("codecov.client-secret", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)
 register("codecov.base-url", default="https://api.codecov.io")

--- a/tests/sentry/integrations/utils/test_lifecycle_metrics.py
+++ b/tests/sentry/integrations/utils/test_lifecycle_metrics.py
@@ -483,7 +483,7 @@ class IntegrationEventLifecycleMetricTest(TestCase):
     def test_integration_debugging_org_id_override(
         self, mock_metrics: mock.MagicMock, mock_logger: mock.MagicMock, mock_random: mock.MagicMock
     ) -> None:
-        mock_random.random.return_value = 0
+        mock_random.random.return_value = 0.5
         metric_obj = self.TestLifecycleMetric()
 
         with metric_obj.capture(sample_log_rate=0.1) as lifecycle:

--- a/tests/sentry/integrations/utils/test_lifecycle_metrics.py
+++ b/tests/sentry/integrations/utils/test_lifecycle_metrics.py
@@ -486,10 +486,9 @@ class IntegrationEventLifecycleMetricTest(TestCase):
         mock_random.random.return_value = 0
         metric_obj = self.TestLifecycleMetric()
 
-        # Test default through capture()
         with metric_obj.capture(sample_log_rate=0.1) as lifecycle:
             lifecycle.add_extra("organization_id", 123)
             lifecycle.record_failure("test failure")
 
-        # Should log since default is 1.0
+        # Should log due to override
         mock_logger.warning.assert_called_once()


### PR DESCRIPTION
For debugging issues for specific orgs, add an allowlist of org ids that will sample all integration metrics for the org at 1.0 and emit Sentry issues for any errors.