### PR TITLE
fix(aci): limit Github repository choices fetched for create issue config

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -555,6 +555,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:ourlogs-saved-queries", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable using paginated projects endpoint for Jira integration
     manager.add("organizations:jira-paginated-projects", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Enable fetching first page of repositories for Github integration
+    manager.add("organizations:github-get-repos-page-limit", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable single trace summary
     manager.add("organizations:single-trace-summary", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable users to connect many Sentry orgs to a single Github org

--- a/src/sentry/integrations/bitbucket/integration.py
+++ b/src/sentry/integrations/bitbucket/integration.py
@@ -119,7 +119,9 @@ class BitbucketIntegration(RepositoryIntegration, BitbucketIssuesSpec):
 
     # RepositoryIntegration methods
 
-    def get_repositories(self, query: str | None = None) -> list[dict[str, Any]]:
+    def get_repositories(
+        self, query: str | None = None, page_number_limit: int | None = None
+    ) -> list[dict[str, Any]]:
         username = self.model.metadata.get("uuid", self.username)
         if not query:
             resp = self.get_client().get_repos(username)

--- a/src/sentry/integrations/bitbucket_server/integration.py
+++ b/src/sentry/integrations/bitbucket_server/integration.py
@@ -280,7 +280,9 @@ class BitbucketServerIntegration(RepositoryIntegration):
 
     # RepositoryIntegration methods
 
-    def get_repositories(self, query: str | None = None) -> list[dict[str, Any]]:
+    def get_repositories(
+        self, query: str | None = None, page_number_limit: int | None = None
+    ) -> list[dict[str, Any]]:
         if not query:
             resp = self.get_client().get_repos()
 

--- a/src/sentry/integrations/example/integration.py
+++ b/src/sentry/integrations/example/integration.py
@@ -146,7 +146,9 @@ class ExampleIntegration(RepositoryIntegration, SourceCodeIssueIntegration, Issu
             "description": "This is a test external issue description",
         }
 
-    def get_repositories(self, query: str | None = None) -> list[dict[str, Any]]:
+    def get_repositories(
+        self, query: str | None = None, page_number_limit: int | None = None
+    ) -> list[dict[str, Any]]:
         return [{"name": "repo", "identifier": "user/repo"}]
 
     def get_unmigratable_repositories(self):

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -422,7 +422,7 @@ class GitHubBaseClient(GithubProxyClient, RepositoryClient, CommitContextClient,
 
         return should_count_error
 
-    def get_repos(self) -> list[dict[str, Any]]:
+    def get_repos(self, page_number_limit: int | None = None) -> list[dict[str, Any]]:
         """
         This fetches all repositories accessible to the Github App
         https://docs.github.com/en/rest/apps/installations#list-repositories-accessible-to-the-app-installation
@@ -430,7 +430,11 @@ class GitHubBaseClient(GithubProxyClient, RepositoryClient, CommitContextClient,
         It uses page_size from the base class to specify how many items per page.
         The upper bound of requests is controlled with self.page_number_limit to prevent infinite requests.
         """
-        return self._get_with_pagination("/installation/repositories", response_key="repositories")
+        return self._get_with_pagination(
+            "/installation/repositories",
+            response_key="repositories",
+            page_number_limit=page_number_limit,
+        )
 
     def search_repositories(self, query: bytes) -> Mapping[str, Sequence[Any]]:
         """

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -267,7 +267,9 @@ class GitHubIntegration(
         _, _, source_path = url.partition("/")
         return source_path
 
-    def get_repositories(self, query: str | None = None) -> list[dict[str, Any]]:
+    def get_repositories(
+        self, query: str | None = None, page_number_limit: int | None = None
+    ) -> list[dict[str, Any]]:
         """
         args:
         * query - a query to filter the repositories by
@@ -276,7 +278,7 @@ class GitHubIntegration(
         https://docs.github.com/en/rest/apps/installations#list-repositories-accessible-to-the-app-installation
         """
         if not query:
-            all_repos = self.get_client().get_repos()
+            all_repos = self.get_client().get_repos(page_number_limit=page_number_limit)
             return [
                 {
                     "name": i["name"],

--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -7,6 +7,7 @@ from typing import Any, NoReturn
 
 from django.urls import reverse
 
+from sentry import features
 from sentry.integrations.mixins.issues import MAX_CHAR
 from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.integrations.source_code_management.issues import SourceCodeIssueIntegration
@@ -165,7 +166,10 @@ class GitHubIssuesSpec(SourceCodeIssueIntegration):
             org = org_context.organization
 
         params = kwargs.pop("params", {})
-        default_repo, repo_choices = self.get_repository_choices(group, params)
+        page_number_limit = (
+            features.has("organizations:github-get-repos-page-limit", org) and 1 or None
+        )
+        default_repo, repo_choices = self.get_repository_choices(group, params, page_number_limit)
 
         assignees = self.get_allowed_assignees(default_repo) if default_repo else []
         labels: Sequence[tuple[str, str]] = []

--- a/src/sentry/integrations/github_enterprise/integration.py
+++ b/src/sentry/integrations/github_enterprise/integration.py
@@ -190,9 +190,11 @@ class GitHubEnterpriseIntegration(
 
     # RepositoryIntegration methods
 
-    def get_repositories(self, query: str | None = None) -> list[dict[str, Any]]:
+    def get_repositories(
+        self, query: str | None = None, page_number_limit: int | None = None
+    ) -> list[dict[str, Any]]:
         if not query:
-            all_repos = self.get_client().get_repos()
+            all_repos = self.get_client().get_repos(page_number_limit=page_number_limit)
             return [
                 {
                     "name": i["name"],

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -157,7 +157,9 @@ class GitlabIntegration(RepositoryIntegration, GitlabIssuesSpec, CommitContextIn
         # TODO: define this, used to migrate repositories
         return False
 
-    def get_repositories(self, query: str | None = None) -> list[dict[str, Any]]:
+    def get_repositories(
+        self, query: str | None = None, page_number_limit: int | None = None
+    ) -> list[dict[str, Any]]:
         # Note: gitlab projects are the same things as repos everywhere else
         group = self.get_group_id()
         resp = self.get_client().search_projects(group, query)

--- a/src/sentry/integrations/source_code_management/issues.py
+++ b/src/sentry/integrations/source_code_management/issues.py
@@ -29,10 +29,15 @@ class SourceCodeIssueIntegration(IssueBasicIntegration, BaseRepositoryIntegratio
         )
 
     def _get_repository_choices(
-        self, *, group: Group | None, params: Mapping[str, Any], lifecycle: EventLifecycle
+        self,
+        *,
+        group: Group | None,
+        params: Mapping[str, Any],
+        lifecycle: EventLifecycle,
+        page_number_limit: int | None = None,
     ):
         try:
-            repos = self.get_repositories()
+            repos = self.get_repositories(page_number_limit=page_number_limit)
         except ApiError as exc:
             if any(pattern in str(exc) for pattern in SOURCE_CODE_ISSUE_HALT_PATTERNS):
                 lifecycle.record_halt(exc)
@@ -60,7 +65,9 @@ class SourceCodeIssueIntegration(IssueBasicIntegration, BaseRepositoryIntegratio
 
         return default_repo, repo_choices
 
-    def get_repository_choices(self, group: Group | None, params: Mapping[str, Any]):
+    def get_repository_choices(
+        self, group: Group | None, params: Mapping[str, Any], page_number_limit: int | None = None
+    ):
         """
         Returns the default repository and a set/subset of repositories of associated with the installation
         """
@@ -69,7 +76,12 @@ class SourceCodeIssueIntegration(IssueBasicIntegration, BaseRepositoryIntegratio
             SCMIntegrationInteractionType.GET_REPOSITORY_CHOICES
         ).capture() as lifecycle:
             try:
-                return self._get_repository_choices(group=group, params=params, lifecycle=lifecycle)
+                return self._get_repository_choices(
+                    group=group,
+                    params=params,
+                    lifecycle=lifecycle,
+                    page_number_limit=page_number_limit,
+                )
             except IntegrationError as exc:
                 user_facing_error = exc
         # Now that we're outside the lifecycle, we can raise the user facing error

--- a/src/sentry/integrations/source_code_management/repository.py
+++ b/src/sentry/integrations/source_code_management/repository.py
@@ -29,7 +29,9 @@ from sentry.users.models.identity import Identity
 
 class BaseRepositoryIntegration(ABC):
     @abstractmethod
-    def get_repositories(self, query: str | None = None) -> list[dict[str, Any]]:
+    def get_repositories(
+        self, query: str | None = None, page_number_limit: int | None = None
+    ) -> list[dict[str, Any]]:
         """
         Get a list of available repositories for an installation
 

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -307,7 +307,9 @@ class VstsIntegration(RepositoryIntegration, VstsIssuesSpec):
 
     # RepositoryIntegration methods
 
-    def get_repositories(self, query: str | None = None) -> list[dict[str, Any]]:
+    def get_repositories(
+        self, query: str | None = None, page_number_limit: int | None = None
+    ) -> list[dict[str, Any]]:
         try:
             repos = self.get_client().get_repos()
         except (ApiError, IdentityNotValid) as e:

--- a/tests/sentry/integrations/github/test_issues.py
+++ b/tests/sentry/integrations/github/test_issues.py
@@ -24,6 +24,7 @@ from sentry.shared_integrations.exceptions import (
 )
 from sentry.silo.util import PROXY_BASE_URL_HEADER, PROXY_OI_HEADER, PROXY_SIGNATURE_HEADER
 from sentry.testutils.cases import IntegratedApiTestCase, PerformanceIssueTestCase, TestCase
+from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE
 from sentry.testutils.silo import all_silo_test
@@ -435,6 +436,66 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
 
     @responses.activate
     def test_repo_dropdown_choices(self) -> None:
+        event = self.store_event(
+            data={"event_id": "a" * 32, "timestamp": self.min_ago}, project_id=self.project.id
+        )
+
+        responses.add(
+            responses.GET,
+            "https://api.github.com/repos/getsentry/sentry/assignees",
+            json=[{"login": "MeredithAnya"}],
+        )
+        responses.add(
+            responses.GET,
+            "https://api.github.com/repos/getsentry/sentry/labels",
+            json=[{"name": "bug"}, {"name": "enhancement"}],
+        )
+
+        responses.add(
+            responses.GET,
+            "https://api.github.com/installation/repositories",
+            json={
+                "total_count": 2,
+                "repositories": [
+                    {"full_name": "getsentry/sentry", "name": "sentry"},
+                    {"full_name": "getsentry/other", "name": "other", "archived": True},
+                ],
+            },
+        )
+
+        resp = self.install.get_create_issue_config(group=event.group, user=self.user)
+        assert resp[0]["choices"] == [("getsentry/sentry", "sentry")]
+
+        responses.add(
+            responses.GET,
+            "https://api.github.com/repos/getsentry/hello/assignees",
+            json=[{"login": "MeredithAnya"}],
+        )
+        responses.add(
+            responses.GET,
+            "https://api.github.com/repos/getsentry/hello/labels",
+            json=[{"name": "bug"}, {"name": "enhancement"}],
+        )
+
+        # create an issue
+        data = {"params": {"repo": "getsentry/hello"}}
+        resp = self.install.get_create_issue_config(group=event.group, user=self.user, **data)
+        assert resp[0]["choices"] == [
+            ("getsentry/hello", "hello"),
+            ("getsentry/sentry", "sentry"),
+        ]
+        # link an issue
+        data = {"params": {"repo": "getsentry/hello"}}
+        assert event.group is not None
+        resp = self.install.get_link_issue_config(group=event.group, **data)
+        assert resp[0]["choices"] == [
+            ("getsentry/hello", "hello"),
+            ("getsentry/sentry", "sentry"),
+        ]
+
+    @responses.activate
+    @with_feature("organizations:github-get-repos-page-limit")
+    def test_repo_dropdown_choices_with_page_limit(self) -> None:
         event = self.store_event(
             data={"event_id": "a" * 32, "timestamp": self.min_ago}, project_id=self.project.id
         )


### PR DESCRIPTION
the load time for getting Github repos for the ticket creation modal can take a long time depending on how many repos the org has, therefore we want to limit the repo options to the first page of the Github API response

feature-flagging this first so we can check load times internally

https://linear.app/getsentry/issue/ECO-966/reduce-loadtime-for-github-create-issue-modal