### PR TITLE
feat(upsampling) - Remove error upsampling redundancies

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -14,7 +14,6 @@ from django.contrib.auth.models import AnonymousUser
 from django.db.models import Min, prefetch_related_objects
 
 from sentry import features, tagstore
-from sentry.api.helpers.error_upsampling import are_any_projects_error_upsampled
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.models.actor import ActorSerializer
 from sentry.api.serializers.models.plugin import is_plugin_deprecated
@@ -1109,10 +1108,6 @@ class GroupSerializerSnuba(GroupSerializerBase):
             ["max", "timestamp", "last_seen"],
             ["uniq", "tags[sentry:user]", "count"],
         ]
-        # Check if any projects are allowlisted for error upsampling
-        is_upsampled = are_any_projects_error_upsampled(project_ids)
-        if is_upsampled:
-            aggregations[0] = ["upsampled_count", "", "times_seen"]
 
         filters = {"project_id": project_ids, "group_id": group_ids}
         if environment_ids:


### PR DESCRIPTION
GroupSerializers level conversions no longer needed as
- for TSDB queries we figured out how to just check the model being queried, just needed to pass in project_ids
- We now do this convesrion in `snuba.py -> query()` by checking the project_id filter and the queried Dataset to be Events