### PR TITLE
fix(explore): Bad collapsing of explore charts

### DIFF
--- a/static/app/views/explore/components/chart/chartVisualization.tsx
+++ b/static/app/views/explore/components/chart/chartVisualization.tsx
@@ -34,7 +34,6 @@ export function ChartVisualization({
   toolBox,
   chartInfo,
   chartRef,
-  hidden = false,
 }: ChartVisualizationProps) {
   const theme = useTheme();
 
@@ -72,10 +71,6 @@ export function ChartVisualization({
     plottables,
     chartInfo.timeseriesResult.isPending
   );
-
-  if (hidden) {
-    return null;
-  }
 
   if (chartInfo.timeseriesResult.isPending) {
     if (previousPlottables.length === 0) {

--- a/static/app/views/explore/spans/charts/index.tsx
+++ b/static/app/views/explore/spans/charts/index.tsx
@@ -246,27 +246,30 @@ function Chart({
         Title={Title}
         Actions={Actions}
         Visualization={
-          <ChartVisualization
-            chartInfo={chartInfo}
-            hidden={!visible}
-            chartRef={chartRef}
-            brush={boxSelectOptions.brush}
-            onBrushEnd={boxSelectOptions.onBrushEnd}
-            onBrushStart={boxSelectOptions.onBrushStart}
-            toolBox={boxSelectOptions.toolBox}
-          />
+          visible && (
+            <ChartVisualization
+              chartInfo={chartInfo}
+              chartRef={chartRef}
+              brush={boxSelectOptions.brush}
+              onBrushEnd={boxSelectOptions.onBrushEnd}
+              onBrushStart={boxSelectOptions.onBrushStart}
+              toolBox={boxSelectOptions.toolBox}
+            />
+          )
         }
         Footer={
-          <ConfidenceFooter
-            sampleCount={chartInfo.sampleCount}
-            isLoading={chartInfo.timeseriesResult?.isPending || false}
-            isSampled={chartInfo.isSampled}
-            confidence={chartInfo.confidence}
-            topEvents={
-              topEvents ? Math.min(topEvents, chartInfo.series.length) : undefined
-            }
-            dataScanned={chartInfo.dataScanned}
-          />
+          visible && (
+            <ConfidenceFooter
+              sampleCount={chartInfo.sampleCount}
+              isLoading={chartInfo.timeseriesResult?.isPending || false}
+              isSampled={chartInfo.isSampled}
+              confidence={chartInfo.confidence}
+              topEvents={
+                topEvents ? Math.min(topEvents, chartInfo.series.length) : undefined
+              }
+              dataScanned={chartInfo.dataScanned}
+            />
+          )
         }
         height={chartHeight}
         revealActions="always"


### PR DESCRIPTION
The footer was still visible when the charts were collapsed.