### PR TITLE
ref(groupingInfo): Hide client fingerprint in Contributing Values view if it doesn't contribute

### DIFF
--- a/static/app/components/events/groupingInfo/groupingVariant.tsx
+++ b/static/app/components/events/groupingInfo/groupingVariant.tsx
@@ -26,7 +26,11 @@ interface GroupingVariantProps {
 
 type VariantData = Array<[string, React.ReactNode]>;
 
-function addFingerprintInfo(data: VariantData, variant: EventGroupVariant) {
+function addFingerprintInfo(
+  data: VariantData,
+  variant: EventGroupVariant,
+  showNonContributing: boolean
+) {
   if ('matched_rule' in variant) {
     data.push([
       t('Fingerprint rule'),
@@ -48,7 +52,10 @@ function addFingerprintInfo(data: VariantData, variant: EventGroupVariant) {
       </TextWithQuestionTooltip>,
     ]);
   }
-  if ('client_values' in variant) {
+  if (
+    'client_values' in variant &&
+    (showNonContributing || !('matched_rule' in variant))
+  ) {
     data.push([
       t('Client fingerprint values'),
       <TextWithQuestionTooltip key="type">
@@ -102,14 +109,14 @@ function GroupingVariant({event, variant, showNonContributing}: GroupingVariantP
         component = variant.component;
         break;
       case EventGroupVariantType.CUSTOM_FINGERPRINT:
-        addFingerprintInfo(data, variant);
+        addFingerprintInfo(data, variant, showNonContributing);
         break;
       case EventGroupVariantType.BUILT_IN_FINGERPRINT:
-        addFingerprintInfo(data, variant);
+        addFingerprintInfo(data, variant, showNonContributing);
         break;
       case EventGroupVariantType.SALTED_COMPONENT:
         component = variant.component;
-        addFingerprintInfo(data, variant);
+        addFingerprintInfo(data, variant, showNonContributing);
         break;
       case EventGroupVariantType.PERFORMANCE_PROBLEM: {
         const spansToHashes = Object.fromEntries(


### PR DESCRIPTION
For #72291.

The client fingerprint should not show up in 'Contributing Values' if it is overridden, only when 'All Values' is set. 

<img width="868" height="239" alt="image" src="https://github.com/user-attachments/assets/3fb023c9-2696-44eb-a37b-e1ffeafd65dd" />
<img width="871" height="291" alt="image" src="https://github.com/user-attachments/assets/d4324b37-7fdd-41c4-8365-5bb1c65823a2" />



