### PR TITLE
feat(crons): Implement `MonitorIncidentDetectorValidator` and `MonitorDataSourceValidator` and configure them in `MonitorIncidentType`

### DIFF
--- a/src/sentry/monitors/grouptype.py
+++ b/src/sentry/monitors/grouptype.py
@@ -5,7 +5,9 @@ from dataclasses import dataclass
 from sentry_redis_tools.sliding_windows_rate_limiter import Quota
 
 from sentry.issues.grouptype import GroupCategory, GroupType, NotificationConfig
+from sentry.monitors.validators import MonitorIncidentDetectorValidator
 from sentry.types.group import PriorityLevel
+from sentry.workflow_engine.types import DetectorSettings
 
 
 @dataclass(frozen=True)
@@ -19,3 +21,8 @@ class MonitorIncidentType(GroupType):
     creation_quota = Quota(3600, 60, 60_000)  # 60,000 per hour, sliding window of 60 seconds
     default_priority = PriorityLevel.HIGH
     notification_config = NotificationConfig(context=[])
+    detector_settings = DetectorSettings(
+        handler=None,
+        validator=MonitorIncidentDetectorValidator,
+        config_schema={},
+    )

--- a/src/sentry/monitors/utils.py
+++ b/src/sentry/monitors/utils.py
@@ -13,7 +13,6 @@ from sentry.models.group import Group
 from sentry.models.project import Project
 from sentry.models.rule import Rule, RuleActivity, RuleActivityType, RuleSource
 from sentry.monitors.constants import DEFAULT_CHECKIN_MARGIN, MAX_TIMEOUT, TIMEOUT
-from sentry.monitors.grouptype import MonitorIncidentType
 from sentry.monitors.models import CheckInStatus, Monitor, MonitorCheckIn
 from sentry.monitors.types import DATA_SOURCE_CRON_MONITOR
 from sentry.projects.project_rules.creator import ProjectRuleCreator
@@ -393,7 +392,6 @@ def update_issue_alert_rule(
 
 
 def ensure_cron_detector(monitor: Monitor):
-
     try:
         with atomic_transaction(using=router.db_for_write(DataSource)):
             data_source, created = DataSource.objects.get_or_create(
@@ -402,12 +400,15 @@ def ensure_cron_detector(monitor: Monitor):
                 source_id=str(monitor.id),
             )
             if created:
+                from sentry.monitors.grouptype import MonitorIncidentType
+
                 detector = Detector.objects.create(
                     type=MonitorIncidentType.slug,
                     project_id=monitor.project_id,
                     name=monitor.name,
                     owner_user_id=monitor.owner_user_id,
                     owner_team_id=monitor.owner_team_id,
+                    config={},
                 )
                 DataSourceDetector.objects.create(data_source=data_source, detector=detector)
     except Exception:

--- a/src/sentry/monitors/validators.py
+++ b/src/sentry/monitors/validators.py
@@ -21,11 +21,13 @@ from sentry.api.serializers.rest_framework.project import ProjectField
 from sentry.constants import ObjectStatus
 from sentry.db.models import BoundedPositiveIntegerField
 from sentry.db.models.fields.slug import DEFAULT_SLUG_MAX_LENGTH
+from sentry.db.postgres.transactions import in_test_hide_transaction_boundary
 from sentry.models.project import Project
 from sentry.monitors.constants import MAX_MARGIN, MAX_THRESHOLD, MAX_TIMEOUT
 from sentry.monitors.models import (
     MONITOR_CONFIG,
     CheckInStatus,
+    CronMonitorDataSourceHandler,
     Monitor,
     MonitorCheckIn,
     MonitorEnvironment,
@@ -43,16 +45,23 @@ from sentry.monitors.utils import (
 from sentry.utils.audit import create_audit_entry
 from sentry.utils.dates import AVAILABLE_TIMEZONES
 from sentry.utils.outcomes import Outcome
+from sentry.workflow_engine.endpoints.validators.base import (
+    BaseDataSourceValidator,
+    BaseDetectorTypeValidator,
+)
+from sentry.workflow_engine.models import DataSourceDetector, Detector
 
 MONITOR_STATUSES = {
     "active": ObjectStatus.ACTIVE,
     "disabled": ObjectStatus.DISABLED,
 }
+MONITOR_STATUSES_REVERSE = {val: key for key, val in MONITOR_STATUSES.items()}
 
 SCHEDULE_TYPES = {
     "crontab": ScheduleType.CRONTAB,
     "interval": ScheduleType.INTERVAL,
 }
+SCHEDULE_TYPES_REVERSE = {val: key for key, val in SCHEDULE_TYPES.items()}
 
 IntervalNames = Literal["year", "month", "week", "day", "hour", "minute"]
 
@@ -537,3 +546,137 @@ class MonitorBulkEditValidator(MonitorValidator):
         ).count() != len(value):
             raise ValidationError("Not all ids are valid for this organization.")
         return value
+
+
+class MonitorDataSourceValidator(BaseDataSourceValidator[Monitor]):
+    """
+    Data source validator for cron monitors.
+
+    This handles creating/updating the Monitor when a detector is created/updated.
+    """
+
+    name = serializers.CharField(
+        max_length=128, required=False, help_text="Name of the monitor. Used for notifications."
+    )
+    slug = serializers.SlugField(
+        max_length=50,
+        required=False,
+        help_text="Uniquely identifies your monitor within your organization.",
+    )
+    status = serializers.CharField(required=False)
+    owner = serializers.CharField(required=False, allow_null=True)
+    is_muted = serializers.BooleanField(required=False)
+    config = serializers.JSONField(required=True)
+
+    class Meta:
+        model = Monitor
+        fields = ["name", "slug", "status", "owner", "is_muted", "config"]
+
+    def validate_status(self, value):
+        if isinstance(value, str) and value.isdigit():
+            return MONITOR_STATUSES_REVERSE[int(value)]
+        return value
+
+    def validate_config(self, value):
+        if value and "schedule_type" in value:
+            schedule_type = value["schedule_type"]
+            if isinstance(schedule_type, int):
+                value["schedule_type"] = SCHEDULE_TYPES_REVERSE[int(schedule_type)]
+        return value
+
+    @property
+    def data_source_type_handler(self) -> type[CronMonitorDataSourceHandler]:
+        return CronMonitorDataSourceHandler
+
+    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
+        if not attrs.get("name") and not attrs.get("slug"):
+            raise serializers.ValidationError("Either name or slug must be provided")
+
+        if not attrs.get("name") and attrs.get("slug"):
+            attrs["name"] = attrs["slug"]
+
+        if attrs.get("name") and not attrs.get("slug") and not self.instance:
+            attrs["slug"] = slugify_monitor_slug(attrs["name"])
+
+        monitor_data = attrs.copy()
+
+        if "is_muted" in monitor_data:
+            monitor_data["isMuted"] = monitor_data.pop("is_muted")
+
+        monitor_data["project"] = self.context["project"].slug
+
+        monitor_instance = None
+        if self.instance:
+            monitor_instance = self.instance
+
+        monitor_validator = MonitorValidator(
+            data=monitor_data,
+            context=self.context,
+            instance=monitor_instance,
+            partial=self.partial,
+        )
+
+        if not monitor_validator.is_valid():
+            raise serializers.ValidationError(monitor_validator.errors)
+
+        attrs["_monitor_validator"] = monitor_validator
+
+        validated = monitor_validator.validated_data
+        if "name" in validated:
+            attrs["name"] = validated["name"]
+        if "slug" in validated:
+            attrs["slug"] = validated["slug"]
+        if "config" in validated:
+            attrs["config"] = validated["config"]
+        if "status" in validated:
+            attrs["status"] = validated["status"]
+        if "owner" in validated:
+            attrs["owner"] = validated["owner"]
+        if "is_muted" in validated:
+            attrs["is_muted"] = validated["is_muted"]
+
+        return super().validate(attrs)
+
+    def create_source(self, validated_data: dict[str, Any]) -> Monitor:
+        """Create the Monitor using MonitorValidator."""
+        monitor_validator = validated_data.pop("_monitor_validator")
+        with in_test_hide_transaction_boundary():
+            return monitor_validator.create(monitor_validator.validated_data)
+
+    def update(self, instance: Monitor, validated_data: dict[str, Any]) -> Monitor:
+        monitor_validator = validated_data.pop("_monitor_validator")
+        with in_test_hide_transaction_boundary():
+            return monitor_validator.update(instance, monitor_validator.validated_data)
+
+
+class MonitorIncidentDetectorValidator(BaseDetectorTypeValidator):
+    """
+    Validator for monitor incident detection configuration.
+
+    This is a lightweight validator that delegates Monitor creation/update to the
+    data_source field (MonitorDataSourceValidator).
+    """
+
+    data_source = MonitorDataSourceValidator(required=True)
+
+    def update(self, instance: Detector, validated_data: dict[str, Any]) -> Detector:
+        super().update(instance, validated_data)
+
+        if "data_source" in validated_data:
+            data_source_data = validated_data.pop("data_source")
+            data_source_detector = DataSourceDetector.objects.get(detector=instance)
+            data_source = data_source_detector.data_source
+            monitor = Monitor.objects.get(id=data_source.source_id)
+
+            monitor_validator = MonitorDataSourceValidator(
+                instance=monitor,
+                data=data_source_data,
+                context=self.context,
+                partial=True,
+            )
+
+            if monitor_validator.is_valid(raise_exception=True):
+                with in_test_hide_transaction_boundary():
+                    monitor_validator.save()
+
+        return instance

--- a/src/sentry/monitors/validators.py
+++ b/src/sentry/monitors/validators.py
@@ -49,7 +49,7 @@ from sentry.workflow_engine.endpoints.validators.base import (
     BaseDataSourceValidator,
     BaseDetectorTypeValidator,
 )
-from sentry.workflow_engine.models import DataSourceDetector, Detector
+from sentry.workflow_engine.models import DataSource, Detector
 
 MONITOR_STATUSES = {
     "active": ObjectStatus.ACTIVE,
@@ -664,8 +664,7 @@ class MonitorIncidentDetectorValidator(BaseDetectorTypeValidator):
 
         if "data_source" in validated_data:
             data_source_data = validated_data.pop("data_source")
-            data_source_detector = DataSourceDetector.objects.get(detector=instance)
-            data_source = data_source_detector.data_source
+            data_source = DataSource.objects.get(detectors=instance)
             monitor = Monitor.objects.get(id=data_source.source_id)
 
             monitor_validator = MonitorDataSourceValidator(

--- a/src/sentry/workflow_engine/endpoints/organization_detector_details.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_details.py
@@ -21,6 +21,7 @@ from sentry.apidocs.constants import (
 )
 from sentry.apidocs.parameters import DetectorParams, GlobalParams
 from sentry.constants import ObjectStatus
+from sentry.db.postgres.transactions import in_test_hide_transaction_boundary
 from sentry.deletions.models.scheduleddeletion import RegionScheduledDeletion
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.issues import grouptype
@@ -154,7 +155,8 @@ class OrganizationDetectorDetailsEndpoint(OrganizationEndpoint):
             return Response(validator.errors, status=status.HTTP_400_BAD_REQUEST)
 
         with transaction.atomic(router.db_for_write(Detector)):
-            updated_detector = validator.save()
+            with in_test_hide_transaction_boundary():
+                updated_detector = validator.save()
 
             workflow_ids = request.data.get("workflowIds")
             if workflow_ids is not None:

--- a/tests/sentry/monitors/endpoints/test_organization_detector_details.py
+++ b/tests/sentry/monitors/endpoints/test_organization_detector_details.py
@@ -1,0 +1,147 @@
+from sentry.api.serializers import serialize
+from sentry.constants import ObjectStatus
+from sentry.deletions.models.scheduleddeletion import RegionScheduledDeletion
+from sentry.monitors.grouptype import MonitorIncidentType
+from sentry.monitors.models import Monitor, ScheduleType
+from sentry.monitors.serializers import MonitorSerializer
+from sentry.monitors.types import DATA_SOURCE_CRON_MONITOR
+from sentry.testutils.cases import APITestCase
+from sentry.testutils.outbox import outbox_runner
+from sentry.testutils.silo import region_silo_test
+from sentry.workflow_engine.models import DataSource, DataSourceDetector, Detector
+
+
+@region_silo_test
+class OrganizationMonitorIncidentDetectorDetailsTest(APITestCase):
+    """Test PUT/DELETE operations for monitor incident detectors."""
+
+    endpoint = "sentry-api-0-organization-detector-details"
+
+    def setUp(self):
+        super().setUp()
+        self.login_as(user=self.user)
+        self.monitor = Monitor.objects.create(
+            organization_id=self.organization.id,
+            project_id=self.project.id,
+            name="Test Monitor",
+            slug="test-monitor",
+            config={
+                "schedule": "0 * * * *",
+                "schedule_type": ScheduleType.CRONTAB,
+            },
+        )
+        self.data_source = DataSource.objects.create(
+            organization_id=self.organization.id,
+            type=DATA_SOURCE_CRON_MONITOR,
+            source_id=str(self.monitor.id),
+        )
+        self.detector = Detector.objects.create(
+            project=self.project,
+            type=MonitorIncidentType.slug,
+            name="Monitor Incident Detector",
+            owner_user_id=self.user.id,
+            config={},
+        )
+        DataSourceDetector.objects.create(
+            data_source=self.data_source,
+            detector=self.detector,
+        )
+
+    def test_get_monitor_incident_detector_details(self):
+        """Test getting a monitor incident detector details with proper monitor serialization."""
+        response = self.get_success_response(
+            self.organization.slug,
+            self.detector.id,
+            status_code=200,
+            method="GET",
+        )
+        assert response.data == {
+            "id": str(self.detector.id),
+            "projectId": str(self.project.id),
+            "name": "Monitor Incident Detector",
+            "type": MonitorIncidentType.slug,
+            "workflowIds": [],
+            "owner": f"user:{self.user.id}",
+            "createdBy": None,
+            "dateCreated": response.data["dateCreated"],
+            "dateUpdated": response.data["dateUpdated"],
+            "dataSources": [
+                {
+                    "id": response.data["dataSources"][0]["id"],
+                    "organizationId": str(self.organization.id),
+                    "type": DATA_SOURCE_CRON_MONITOR,
+                    "sourceId": str(self.monitor.id),
+                    "queryObj": serialize(
+                        self.monitor, user=self.user, serializer=MonitorSerializer()
+                    ),
+                }
+            ],
+            "conditionGroup": None,
+            "config": {},
+            "enabled": True,
+            "alertRuleId": None,
+            "ruleId": None,
+            "latestGroup": None,
+        }
+
+    def test_update_monitor_incident_detector(self):
+        """Test updating a monitor incident detector name and owner."""
+        team = self.create_team(organization=self.organization)
+
+        original_monitor_name = self.monitor.name
+        original_monitor_config = self.monitor.config.copy()
+
+        data = {
+            "name": "Updated Monitor Detector",
+            "owner": f"team:{team.id}",
+        }
+
+        response = self.get_success_response(
+            self.organization.slug,
+            self.detector.id,
+            **data,
+            status_code=200,
+            method="PUT",
+        )
+
+        assert response.data["name"] == "Updated Monitor Detector"
+        assert response.data["owner"] == f"team:{team.id}"
+        assert response.data["type"] == MonitorIncidentType.slug
+
+        self.monitor.refresh_from_db()
+        expected_data_sources = [
+            {
+                "id": response.data["dataSources"][0]["id"],
+                "organizationId": str(self.organization.id),
+                "type": DATA_SOURCE_CRON_MONITOR,
+                "sourceId": str(self.monitor.id),
+                "queryObj": serialize(self.monitor, user=self.user, serializer=MonitorSerializer()),
+            }
+        ]
+        assert response.data["dataSources"] == expected_data_sources
+
+        self.detector.refresh_from_db()
+        assert self.detector.name == "Updated Monitor Detector"
+        assert self.detector.owner_team_id == team.id
+        assert self.detector.owner_user_id is None
+        assert self.monitor.name == original_monitor_name
+        assert self.monitor.config == original_monitor_config
+
+    def test_delete_monitor_incident_detector(self):
+        """Test deleting a monitor incident detector."""
+        with outbox_runner():
+            self.get_success_response(
+                self.organization.slug,
+                self.detector.id,
+                method="DELETE",
+            )
+
+        assert RegionScheduledDeletion.objects.filter(
+            model_name="Detector", object_id=self.detector.id
+        ).exists()
+
+        self.detector.refresh_from_db()
+        assert self.detector.status == ObjectStatus.PENDING_DELETION
+
+        self.monitor.refresh_from_db()
+        assert self.monitor.status == ObjectStatus.ACTIVE

--- a/tests/sentry/monitors/endpoints/test_organization_detector_index.py
+++ b/tests/sentry/monitors/endpoints/test_organization_detector_index.py
@@ -1,0 +1,301 @@
+from rest_framework import status
+
+from sentry.api.serializers import serialize
+from sentry.constants import ObjectStatus
+from sentry.monitors.grouptype import MonitorIncidentType
+from sentry.monitors.models import Monitor, ScheduleType
+from sentry.monitors.serializers import MonitorSerializer
+from sentry.monitors.types import DATA_SOURCE_CRON_MONITOR
+from sentry.testutils.cases import APITestCase
+from sentry.testutils.silo import region_silo_test
+from sentry.workflow_engine.models import DataSource, DataSourceDetector, Detector
+
+
+@region_silo_test
+class BaseDetectorTestCase(APITestCase):
+    def setUp(self):
+        super().setUp()
+        self.login_as(user=self.user)
+        self.monitor = Monitor.objects.create(
+            organization_id=self.organization.id,
+            project_id=self.project.id,
+            name="Original Monitor",
+            slug="original-monitor",
+            status=ObjectStatus.ACTIVE,
+            config={
+                "schedule": "0 * * * *",
+                "schedule_type": ScheduleType.CRONTAB,
+                "checkin_margin": 5,
+                "max_runtime": 30,
+            },
+        )
+        self.data_source = self.create_data_source(
+            organization=self.organization,
+            type=DATA_SOURCE_CRON_MONITOR,
+            source_id=str(self.monitor.id),
+        )
+        self.condition_group = self.create_data_condition_group()
+        self.detector = self.create_detector(
+            project=self.project,
+            type=MonitorIncidentType.slug,
+            name="Original Detector",
+            workflow_condition_group=self.condition_group,
+        )
+        self.create_data_source_detector(data_source=self.data_source, detector=self.detector)
+
+
+@region_silo_test
+class OrganizationDetectorIndexGetTest(BaseDetectorTestCase):
+    endpoint = "sentry-api-0-organization-detector-index"
+
+    def test_list_monitor_incident_detectors(self):
+        response = self.get_success_response(self.organization.slug)
+
+        detector_data = response.data[0]
+
+        assert response.data == [
+            {
+                "id": str(self.detector.id),
+                "projectId": str(self.project.id),
+                "name": "Original Detector",
+                "type": MonitorIncidentType.slug,
+                "workflowIds": [],
+                "owner": None,
+                "createdBy": None,
+                "dateCreated": detector_data["dateCreated"],
+                "dateUpdated": detector_data["dateUpdated"],
+                "dataSources": [
+                    {
+                        "id": detector_data["dataSources"][0]["id"],
+                        "organizationId": str(self.organization.id),
+                        "type": DATA_SOURCE_CRON_MONITOR,
+                        "sourceId": str(self.monitor.id),
+                        "queryObj": serialize(
+                            self.monitor, user=self.user, serializer=MonitorSerializer()
+                        ),
+                    }
+                ],
+                "conditionGroup": detector_data["conditionGroup"],
+                "config": {},
+                "enabled": True,
+                "alertRuleId": None,
+                "ruleId": None,
+                "latestGroup": None,
+            }
+        ]
+
+
+@region_silo_test
+class OrganizationDetectorIndexPostTest(APITestCase):
+    endpoint = "sentry-api-0-organization-detector-index"
+    method = "post"
+
+    def setUp(self):
+        super().setUp()
+        self.login_as(user=self.user)
+
+    def _get_detector_post_data(self, **overrides):
+        data = {
+            "projectId": self.project.id,
+            "type": MonitorIncidentType.slug,
+            "name": "Test Monitor Detector",
+            "dataSource": {
+                "name": "Test Monitor",
+                "config": {
+                    "schedule": "0 * * * *",
+                    "scheduleType": "crontab",
+                },
+            },
+            "conditionGroup": {
+                "logicType": "any",
+                "conditions": [
+                    {
+                        "comparison": 1,
+                        "type": "gt",
+                        "conditionResult": "low",
+                    }
+                ],
+            },
+        }
+        data.update(overrides)
+        return data
+
+    def test_create_monitor_incident_detector_validates_correctly(self):
+        data = self._get_detector_post_data()
+        with self.tasks():
+            response = self.get_success_response(
+                self.organization.slug,
+                **data,
+                status_code=201,
+            )
+
+        assert response.data["name"] == "Test Monitor Detector"
+        assert response.data["type"] == MonitorIncidentType.slug
+
+        monitor = Monitor.objects.get(organization_id=self.organization.id, slug="test-monitor")
+        assert monitor.name == "Test Monitor"
+        assert monitor.config["schedule"] == "0 * * * *"
+        assert monitor.config["schedule_type"] == ScheduleType.CRONTAB
+        assert monitor.project_id == self.project.id
+        assert monitor.organization_id == self.organization.id
+
+        detector = Detector.objects.get(id=response.data["id"])
+        assert detector.name == "Test Monitor Detector"
+        assert detector.type == MonitorIncidentType.slug
+        assert detector.project_id == self.project.id
+
+        data_source = DataSource.objects.get(
+            organization_id=self.organization.id,
+            type=DATA_SOURCE_CRON_MONITOR,
+            source_id=str(monitor.id),
+        )
+        assert DataSourceDetector.objects.filter(
+            data_source=data_source, detector=detector
+        ).exists()
+
+        data_sources = response.data["dataSources"]
+        assert len(data_sources) == 1
+        data_source_data = data_sources[0]
+        assert data_source_data["type"] == DATA_SOURCE_CRON_MONITOR
+        assert data_source_data["sourceId"] == str(monitor.id)
+
+        expected_monitor_data = serialize(monitor, user=self.user, serializer=MonitorSerializer())
+        assert data_source_data["queryObj"] == expected_monitor_data
+
+    def test_create_monitor_incident_detector_validation_error(self):
+        data = self._get_detector_post_data(
+            dataSource={
+                "config": {
+                    "schedule": "invalid cron",
+                    "scheduleType": "crontab",
+                },
+            }
+        )
+        response = self.get_error_response(
+            self.organization.slug,
+            **data,
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+        assert "dataSource" in response.data
+        assert "Either name or slug must be provided" in str(response.data["dataSource"])
+
+    def test_create_monitor_with_optional_fields(self):
+        data = self._get_detector_post_data(
+            dataSource={
+                "name": "Full Config Monitor",
+                "slug": "full-config-monitor",
+                "status": "disabled",
+                "isMuted": True,
+                "config": {
+                    "schedule": "*/30 * * * *",
+                    "scheduleType": "crontab",
+                    "checkinMargin": 15,
+                    "maxRuntime": 120,
+                    "timezone": "America/New_York",
+                    "failureIssueThreshold": 3,
+                    "recoveryThreshold": 2,
+                },
+            },
+        )
+        with self.tasks():
+            self.get_success_response(
+                self.organization.slug,
+                **data,
+                status_code=201,
+            )
+
+        monitor = Monitor.objects.get(
+            organization_id=self.organization.id, slug="full-config-monitor"
+        )
+        assert monitor.name == "Full Config Monitor"
+        assert monitor.status == ObjectStatus.DISABLED
+        assert monitor.is_muted is True
+        assert monitor.config["schedule"] == "*/30 * * * *"
+        assert monitor.config["checkin_margin"] == 15
+        assert monitor.config["max_runtime"] == 120
+        assert monitor.config["timezone"] == "America/New_York"
+        assert monitor.config["failure_issue_threshold"] == 3
+        assert monitor.config["recovery_threshold"] == 2
+
+
+@region_silo_test
+class OrganizationDetectorIndexPutTest(BaseDetectorTestCase):
+    endpoint = "sentry-api-0-organization-detector-details"
+    method = "put"
+
+    def test_update_monitor_incident_detector(self):
+        new_user = self.create_user()
+        self.create_member(user=new_user, organization=self.organization)
+        data = {
+            "name": "Updated Detector",
+            "owner": new_user.get_actor_identifier(),
+        }
+        with self.tasks():
+            response = self.get_success_response(
+                self.organization.slug,
+                self.detector.id,
+                **data,
+                status_code=200,
+            )
+
+        assert response.data["name"] == "Updated Detector"
+        assert response.data["owner"] == new_user.get_actor_identifier()
+        assert response.data["type"] == MonitorIncidentType.slug
+
+        self.detector.refresh_from_db()
+        assert self.detector.name == "Updated Detector"
+        assert self.detector.owner_user_id == new_user.id
+        assert self.detector.owner_team_id is None
+
+        self.monitor.refresh_from_db()
+        assert self.monitor.name == "Original Monitor"
+        assert self.monitor.slug == "original-monitor"
+
+    def test_update_monitor_config_through_detector(self):
+        data = {
+            "name": "Updated Detector With Monitor Config",
+            "dataSource": {
+                "name": "Updated Monitor Name",
+                "config": {
+                    "schedule": "*/30 * * * *",
+                    "scheduleType": "crontab",
+                    "checkinMargin": 10,
+                    "maxRuntime": 60,
+                },
+            },
+        }
+        with self.tasks():
+            self.get_success_response(
+                self.organization.slug,
+                self.detector.id,
+                **data,
+                status_code=200,
+            )
+
+        self.detector.refresh_from_db()
+        assert self.detector.name == "Updated Detector With Monitor Config"
+
+        self.monitor.refresh_from_db()
+        assert self.monitor.name == "Updated Monitor Name"
+        assert self.monitor.config["schedule"] == "*/30 * * * *"
+        assert self.monitor.config["checkin_margin"] == 10
+        assert self.monitor.config["max_runtime"] == 60
+
+
+@region_silo_test
+class OrganizationDetectorDeleteTest(BaseDetectorTestCase):
+    endpoint = "sentry-api-0-organization-detector-details"
+    method = "delete"
+
+    def test_delete_monitor_incident_detector(self):
+        detector_id = self.detector.id
+        monitor_id = self.monitor.id
+        with self.tasks():
+            self.get_success_response(
+                self.organization.slug,
+                detector_id,
+                status_code=204,
+            )
+        self.detector.refresh_from_db()
+        assert self.detector.status == ObjectStatus.PENDING_DELETION
+        assert Monitor.objects.filter(id=monitor_id).exists()


### PR DESCRIPTION
This stitches together the `Monitor` validator and the `Detector` endpoints. The api payload to create one looks like

```
  {
    "projectId": 123,
    "type": "monitor_check_in_failure",
    "name": "Production Cron Monitor",
    "dataSource": {
      "name": "Daily Backup Job",
      "slug": "daily-backup-job",
      "status": "active",
      "isMuted": false,
      "config": {
        "schedule": "0 2 * * *",
        "scheduleType": "crontab",
        "checkinMargin": 10,
        "maxRuntime": 30,
        "timezone": "UTC",
        "failureIssueThreshold": 2,
        "recoveryThreshold": 1
      }
    },
  }
```

Most of this pr is tests to validate that things work as expected
