### PR TITLE
fix(ourlogs): Remove special casing from logs severity

### DIFF
--- a/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
@@ -50,6 +50,7 @@ describe('logsTableRow', () => {
     [OurLogKnownFieldKey.PROJECT_ID]: project.id,
     [OurLogKnownFieldKey.ORGANIZATION_ID]: Number(organization.id),
     [OurLogKnownFieldKey.TRACE_ID]: '7b91699f',
+    [OurLogKnownFieldKey.SEVERITY]: 'info',
   });
 
   // These are the detailed attributes of the row - only displayed when you click the row.
@@ -286,7 +287,7 @@ describe('logsTableRow', () => {
 
     // Check that the attribute values are rendered
     expect(screen.queryByText(projects[0]!.id)).not.toBeInTheDocument();
-    expect(screen.getByText('error')).toBeInTheDocument();
+    expect(screen.getAllByText('info')).toHaveLength(2); // Severity circle and text
     expect(screen.getByText('7b91699f')).toBeInTheDocument();
 
     // Check that the attributes keys are rendered
@@ -444,7 +445,7 @@ describe('logsTableRow', () => {
     expect(parsedData).toMatchObject({
       message: 'test log body',
       trace: '7b91699f',
-      severity: 'error',
+      severity: 'info',
       item_id: '1',
     });
 

--- a/static/app/views/explore/logs/utils.tsx
+++ b/static/app/views/explore/logs/utils.tsx
@@ -130,14 +130,14 @@ export enum SeverityLevel {
  */
 export function severityLevelToText(level: SeverityLevel) {
   return {
-    [SeverityLevel.TRACE]: t('TRACE'),
-    [SeverityLevel.DEBUG]: t('DEBUG'),
-    [SeverityLevel.INFO]: t('INFO'),
-    [SeverityLevel.WARN]: t('WARN'),
-    [SeverityLevel.ERROR]: t('ERROR'),
-    [SeverityLevel.FATAL]: t('FATAL'),
-    [SeverityLevel.DEFAULT]: t('DEFAULT'),
-    [SeverityLevel.UNKNOWN]: t('UNKNOWN'), // Maps to info for now.
+    [SeverityLevel.TRACE]: t('trace'),
+    [SeverityLevel.DEBUG]: t('debug'),
+    [SeverityLevel.INFO]: t('info'),
+    [SeverityLevel.WARN]: t('warn'),
+    [SeverityLevel.ERROR]: t('error'),
+    [SeverityLevel.FATAL]: t('fatal'),
+    [SeverityLevel.DEFAULT]: t('default'),
+    [SeverityLevel.UNKNOWN]: t('unknown'), // Maps to info for now.
   }[level];
 }
 


### PR DESCRIPTION
### Summary
Log severity are only valid as lower case (which is how they're sent), transforming them to all uppercase causes a mismatch between representation and filtering

#### Other
These functions can be cleaned up later (we no longer use severity number to calculate log level), but for now lower them so they match the text when filtering

Closes ENG-5274
Refs #97825

