### PR TITLE
:running: perf(aci): measure trigger action execution time

### DIFF
--- a/src/sentry/workflow_engine/models/action.py
+++ b/src/sentry/workflow_engine/models/action.py
@@ -92,8 +92,13 @@ class Action(DefaultFieldsModel, JSONConfigBase):
         return action_handler_registry.get(action_type)
 
     def trigger(self, event_data: WorkflowEventData, detector: Detector) -> None:
-        handler = self.get_handler()
-        handler.execute(event_data, self, detector)
+        with metrics.timer(
+            "workflow_engine.action.trigger.execution_time",
+            tags={"action_type": self.type, "detector_type": detector.type},
+            sample_rate=1.0,
+        ):
+            handler = self.get_handler()
+            handler.execute(event_data, self, detector)
 
         metrics.incr(
             "workflow_engine.action.trigger",


### PR DESCRIPTION
with ACI, we have an opportunity to truly understand how fast or slow sending notifications is at sentry. 

a majority of the notifications we send at sentry are through alerts, and now they have 1 common entry point. lets add a timing metric to understand common patterns in performance when triggering actions.