### PR TITLE
:sparkles: feat(aci): enable/disable action backed integrations behind ff

### DIFF
--- a/src/sentry/deletions/defaults/organizationintegration.py
+++ b/src/sentry/deletions/defaults/organizationintegration.py
@@ -34,7 +34,7 @@ class OrganizationIntegrationDeletionTask(ModelDeletionTask[OrganizationIntegrat
             organization = organization_service.get(id=instance.organization_id)
 
             if organization and features.has("organizations:update-action-status", organization):
-                # Delete all actions for the organization integration
+                # Disable all actions for the organization integration
                 action_service.update_action_status_for_organization_integration(
                     organization_id=instance.organization_id,
                     integration_id=instance.integration_id,

--- a/src/sentry/deletions/defaults/organizationintegration.py
+++ b/src/sentry/deletions/defaults/organizationintegration.py
@@ -1,8 +1,11 @@
+from sentry import features
 from sentry.constants import ObjectStatus
 from sentry.deletions.base import BaseRelation, ModelDeletionTask, ModelRelation
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.services.repository import repository_service
+from sentry.organizations.services.organization import organization_service
 from sentry.types.region import RegionMappingNotFound
+from sentry.workflow_engine.service.action import action_service
 
 
 class OrganizationIntegrationDeletionTask(ModelDeletionTask[OrganizationIntegration]):
@@ -27,6 +30,17 @@ class OrganizationIntegrationDeletionTask(ModelDeletionTask[OrganizationIntegrat
                 organization_integration_id=instance.id,
                 integration_id=instance.integration_id,
             )
+
+            organization = organization_service.get(id=instance.organization_id)
+
+            if organization and features.has("organizations:update-action-status", organization):
+                # Delete all actions for the organization integration
+                action_service.update_action_status_for_organization_integration(
+                    organization_id=instance.organization_id,
+                    integration_id=instance.integration_id,
+                    status=ObjectStatus.DISABLED,
+                )
+
         except RegionMappingNotFound:
             # This can happen when an organization has been deleted already.
             pass

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -497,6 +497,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:visibility-explore-range-medium", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enforce stacked navigation feature (with ability to opt out)
     manager.add("organizations:enforce-stacked-navigation", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Update action status when integration is installed/deleted
+    manager.add("organizations:update-action-status", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable processing activity updates in workflow engine
     manager.add("organizations:workflow-engine-process-activity", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable dual writing for issue alert issues (see: alerts create issues)

--- a/src/sentry/integrations/pipeline.py
+++ b/src/sentry/integrations/pipeline.py
@@ -34,6 +34,7 @@ from sentry.silo.base import SiloMode
 from sentry.users.models.identity import Identity, IdentityProvider, IdentityStatus
 from sentry.utils import metrics
 from sentry.web.helpers import render_to_response
+from sentry.workflow_engine.service.action import action_service
 
 __all__ = ["IntegrationPipeline"]
 
@@ -186,6 +187,8 @@ class IntegrationPipeline(Pipeline[Never, PipelineSessionStore]):
             self.provider.create_audit_log_entry(
                 self.integration, self.organization, self.request, "install", extra=extra
             )
+            # Enable all actions for the organization installing the integration
+            self._enable_actions()
             self.provider.post_install(self.integration, self.organization, extra=extra)
             self.clear_session()
 
@@ -333,6 +336,19 @@ class IntegrationPipeline(Pipeline[Never, PipelineSessionStore]):
             },
         )
         return render_to_response("sentry/integrations/dialog-complete.html", context, self.request)
+
+    def _enable_actions(self) -> None:
+        """
+        Enables all disabled actions for the integration.
+        """
+        if not features.has("organizations:update-action-status", self.organization):
+            return
+
+        action_service.update_action_status_for_organization_integration(
+            organization_id=self.organization.id,
+            integration_id=self.integration.id,
+            status=ObjectStatus.ACTIVE,
+        )
 
     def _get_redirect_response(self, redirect_url_format: str) -> HttpResponseRedirect:
         redirect_url = redirect_url_format.format(org_slug=self.organization.slug)


### PR DESCRIPTION
this PR introduces the ability to enable and disable action-backed integrations, behind a ff

## Changes:
- Added enable actions logic in integration pipeline installation flow to handle integrations that are reinstalled
- Added disable actions logic in organization integration delations

## TODO
[ ] Add warning to FE during integration deletion
[ ] Possible add warning when installing integrations?

cc @ameliahsu  i will probably need your help for the product/fe aspect of this.