### PR TITLE
feat(explore): Update max pickable days for explore spans

### DIFF
--- a/static/app/views/explore/utils.tsx
+++ b/static/app/views/explore/utils.tsx
@@ -350,8 +350,8 @@ export function viewSamplesTarget({
   });
 }
 
-type MaxPickableDays = 7 | 14 | 30;
-type DefaultPeriod = '24h' | '7d' | '14d' | '30d';
+type MaxPickableDays = 7 | 14 | 30 | 90;
+type DefaultPeriod = '24h' | '7d' | '14d' | '30d' | '90d';
 
 export interface PickableDays {
   defaultPeriod: DefaultPeriod;
@@ -370,21 +370,21 @@ export function limitMaxPickableDays(organization: Organization): PickableDays {
     7: '7d',
     14: '14d',
     30: '30d',
+    90: '90d',
   };
 
   const relativeOptions: Array<[DefaultPeriod, ReactNode]> = [
     ['7d', t('Last 7 days')],
     ['14d', t('Last 14 days')],
     ['30d', t('Last 30 days')],
+    ['90d', t('Last 90 days')],
   ];
 
   const maxPickableDays: MaxPickableDays = organization.features.includes(
     'visibility-explore-range-high'
   )
-    ? 30
-    : organization.features.includes('visibility-explore-range-medium')
-      ? 14
-      : 7;
+    ? 90
+    : 30;
   const defaultPeriod: DefaultPeriod = defaultPeriods[maxPickableDays];
 
   const index = relativeOptions.findIndex(([period, _]) => period === defaultPeriod) + 1;


### PR DESCRIPTION
This updates the max pickable days for explore spans as follows
- orgs with `visibility-explore-range-high` (business/enterprise) get 90 days
- all others get 30 days

Closes LOGS-300