### PR TITLE
fix(explore): Insert group bys before visualizes if possible

### DIFF
--- a/static/app/views/explore/contexts/pageParamsContext/index.spec.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/index.spec.tsx
@@ -157,10 +157,10 @@ describe('PageParamsProvider', () => {
         aggregateSortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
         aggregateFields: [
           {groupBy: 'browser.name'},
+          {groupBy: 'sdk.name'},
           new Visualize('count(span.self_time)', {
             chartType: ChartType.AREA,
           }),
-          {groupBy: 'sdk.name'},
         ],
       })
     );


### PR DESCRIPTION
When adding a group by from the toolbar, we want them to appear before the visualizes when the existing aggregate fields are sorted with group bys first then visualizes.

Closes EXP-380