### PR TITLE
ref(groupingInfo): always show reason for ignoring client fingerprint

### DIFF
--- a/static/app/components/events/groupingInfo/groupingComponent.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponent.tsx
@@ -88,7 +88,7 @@ const GroupingComponentWrapper = styled('div')<{isContributing: boolean}>`
   }
 `;
 
-const GroupingHint = styled('small')`
+export const GroupingHint = styled('small')`
   font-size: 0.8em;
 `;
 

--- a/static/app/components/events/groupingInfo/groupingVariant.tsx
+++ b/static/app/components/events/groupingInfo/groupingVariant.tsx
@@ -62,9 +62,7 @@ function addFingerprintInfo(
         {variant.client_values?.join(', ') || ''}
         {'matched_rule' in variant && (
           <OverrideText>
-            <OverrideText>
-              {`(${t('overridden by server-side fingerprint rule')})`}
-            </OverrideText>
+            {`(${t('overridden by server-side fingerprint rule')})`}
           </OverrideText>
         )}
       </TextWithQuestionTooltip>,

--- a/static/app/components/events/groupingInfo/groupingVariant.tsx
+++ b/static/app/components/events/groupingInfo/groupingVariant.tsx
@@ -60,14 +60,11 @@ function addFingerprintInfo(
       t('Client fingerprint values'),
       <TextWithQuestionTooltip key="type">
         {variant.client_values?.join(', ') || ''}
-        {'matched_rule' in variant && ( // Only display override tooltip if overriding actually happened
-          <QuestionTooltip
-            size="xs"
-            position="top"
-            title={t(
-              'The client sent a fingerprint that was overridden by a server-side fingerprinting rule.'
-            )}
-          />
+        {'matched_rule' in variant && (
+          <OverrideText>
+            {' '}
+            ({t('overridden by server-side fingerprint rule')})
+          </OverrideText>
         )}
       </TextWithQuestionTooltip>,
     ]);
@@ -254,6 +251,10 @@ const Hash = styled('span')`
     ${p => p.theme.overflowEllipsis};
     width: 210px;
   }
+`;
+
+const OverrideText = styled('span')`
+  color: ${p => p.theme.subText};
 `;
 
 export default GroupingVariant;

--- a/static/app/components/events/groupingInfo/groupingVariant.tsx
+++ b/static/app/components/events/groupingInfo/groupingVariant.tsx
@@ -62,8 +62,9 @@ function addFingerprintInfo(
         {variant.client_values?.join(', ') || ''}
         {'matched_rule' in variant && (
           <OverrideText>
-            {' '}
-            ({t('overridden by server-side fingerprint rule')})
+            <OverrideText>
+              {`(${t('overridden by server-side fingerprint rule')})`}
+            </OverrideText>
           </OverrideText>
         )}
       </TextWithQuestionTooltip>,

--- a/static/app/components/events/groupingInfo/groupingVariant.tsx
+++ b/static/app/components/events/groupingInfo/groupingVariant.tsx
@@ -16,7 +16,7 @@ import type {
 import {EventGroupVariantType} from 'sentry/types/event';
 import {capitalize} from 'sentry/utils/string/capitalize';
 
-import GroupingComponent from './groupingComponent';
+import GroupingComponent, {GroupingHint} from './groupingComponent';
 
 interface GroupingVariantProps {
   event: Event;
@@ -61,9 +61,9 @@ function addFingerprintInfo(
       <TextWithQuestionTooltip key="type">
         {variant.client_values?.join(', ') || ''}
         {'matched_rule' in variant && (
-          <OverrideText>
+          <GroupingHint>
             {`(${t('overridden by server-side fingerprint rule')})`}
-          </OverrideText>
+          </GroupingHint>
         )}
       </TextWithQuestionTooltip>,
     ]);
@@ -250,10 +250,6 @@ const Hash = styled('span')`
     ${p => p.theme.overflowEllipsis};
     width: 210px;
   }
-`;
-
-const OverrideText = styled('span')`
-  color: ${p => p.theme.subText};
 `;
 
 export default GroupingVariant;


### PR DESCRIPTION
For #72289.

For consistency between grouping variants and the client fingerprint rule, change the `custom-fingerprint` tooltip explaining why it is non-contributing to an inline hint.

<img width="865" height="605" alt="image" src="https://github.com/user-attachments/assets/f333fec4-2a4d-404c-859b-3346136bb5ff" />

before:
<img width="856" height="156" alt="image" src="https://github.com/user-attachments/assets/12ef8ab9-db14-4127-9711-6516a353fd36" />


