### PR TITLE
fix(ci): Push docker image on release branches

### DIFF
--- a/.github/workflows/self-hosted.yml
+++ b/.github/workflows/self-hosted.yml
@@ -81,7 +81,7 @@ jobs:
           python3 -m tools.fast_editable --path .
           python3 -m sentry.build.main
 
-      - uses: getsentry/action-build-and-push-images@6a8b87ba640ef1a79854ce57a7ba4411deb84762
+      - uses: getsentry/action-build-and-push-images@07a1c835f7a78e0f438fc766cc6024ed0ca1bf03
         with:
           image_name: 'sentry'
           platforms: linux/${{ matrix.platform }}


### PR DESCRIPTION
Picks up https://github.com/getsentry/action-build-and-push-images/pull/13

Docker images were not being pushed for self-hosted images on release branches because of typo in regex matching for `release/*` branches instead of the correct `releases/*` name. 

Verified the behavior here: https://github.com/getsentry/sentry/actions/runs/16995779650/job/48186009883

Release 25.8.0 failure: https://github.com/getsentry/sentry/actions/runs/16995124446/job/48184013822