### PR TITLE
feat(preprod): Add build comparison header and some minor modifications

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -2506,6 +2506,13 @@ function buildRoutes(): RouteObject[] {
       deprecatedRouteProps: true,
     },
     {
+      path: 'compare/:headArtifactId/',
+      component: make(
+        () => import('sentry/views/preprod/buildComparison/buildComparison')
+      ),
+      deprecatedRouteProps: true,
+    },
+    {
       path: 'compare/:headArtifactId/:baseArtifactId/',
       component: make(
         () => import('sentry/views/preprod/buildComparison/buildComparison')

--- a/static/app/views/preprod/buildComparison/buildComparison.tsx
+++ b/static/app/views/preprod/buildComparison/buildComparison.tsx
@@ -1,21 +1,72 @@
+import {useTheme} from '@emotion/react';
+
 import * as Layout from 'sentry/components/layouts/thirds';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import Placeholder from 'sentry/components/placeholder';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
+import {useApiQuery, type UseApiQueryResult} from 'sentry/utils/queryClient';
+import type RequestError from 'sentry/utils/requestError/requestError';
+import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
+import {BuildComparisonHeaderContent} from 'sentry/views/preprod/buildComparison/header/buildComparisonHeaderContent';
+import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
 
 export default function BuildComparison() {
+  const organization = useOrganization();
+  const theme = useTheme();
   const params = useParams<{
-    baseArtifactId: string | null;
-    headArtifactId: string | null;
+    headArtifactId: string | undefined;
+    // eslint-disable-next-line typescript-sort-keys/interface
+    baseArtifactId: string;
     projectId: string;
   }>();
+
   const headArtifactId = params.headArtifactId;
   const baseArtifactId = params.baseArtifactId;
   const projectId = params.projectId;
 
+  const headBuildDetailsQuery: UseApiQueryResult<BuildDetailsApiResponse, RequestError> =
+    useApiQuery<BuildDetailsApiResponse>(
+      [
+        `/projects/${organization.slug}/${projectId}/preprodartifacts/${headArtifactId}/build-details/`,
+      ],
+      {
+        staleTime: 0,
+        enabled: !!projectId && !!headArtifactId,
+      }
+    );
+
+  if (headBuildDetailsQuery.isLoading) {
+    return (
+      <SentryDocumentTitle title="Build comparison">
+        <Layout.Page>
+          <Layout.Header>
+            <Placeholder
+              height="20px"
+              width="200px"
+              style={{marginBottom: theme.space.md}}
+            />
+          </Layout.Header>
+
+          <Layout.Body>
+            <Layout.Main>
+              <LoadingIndicator />
+            </Layout.Main>
+          </Layout.Body>
+        </Layout.Page>
+      </SentryDocumentTitle>
+    );
+  }
+
   return (
     <SentryDocumentTitle title="Build comparison">
       <Layout.Page>
-        <Layout.Header>Build comparison header</Layout.Header>
+        <Layout.Header>
+          <BuildComparisonHeaderContent
+            buildDetails={headBuildDetailsQuery.data}
+            projectId={projectId}
+          />
+        </Layout.Header>
 
         <Layout.Body>
           <Layout.Main>

--- a/static/app/views/preprod/buildComparison/buildComparison.tsx
+++ b/static/app/views/preprod/buildComparison/buildComparison.tsx
@@ -15,9 +15,9 @@ export default function BuildComparison() {
   const organization = useOrganization();
   const theme = useTheme();
   const params = useParams<{
-    headArtifactId: string | undefined;
+    headArtifactId: string;
     // eslint-disable-next-line typescript-sort-keys/interface
-    baseArtifactId: string;
+    baseArtifactId: string | undefined;
     projectId: string;
   }>();
 

--- a/static/app/views/preprod/buildComparison/buildComparison.tsx
+++ b/static/app/views/preprod/buildComparison/buildComparison.tsx
@@ -1,5 +1,6 @@
 import {useTheme} from '@emotion/react';
 
+import {Alert} from 'sentry/components/core/alert';
 import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Placeholder from 'sentry/components/placeholder';
@@ -56,6 +57,10 @@ export default function BuildComparison() {
         </Layout.Page>
       </SentryDocumentTitle>
     );
+  }
+
+  if (headBuildDetailsQuery.isError || !headBuildDetailsQuery.data) {
+    return <Alert type="error">{headBuildDetailsQuery.error?.message}</Alert>;
   }
 
   return (

--- a/static/app/views/preprod/buildComparison/header/buildComparisonHeaderContent.tsx
+++ b/static/app/views/preprod/buildComparison/header/buildComparisonHeaderContent.tsx
@@ -34,7 +34,7 @@ export function BuildComparisonHeaderContent(props: BuildComparisonHeaderContent
       label: buildDetails.app_info.version,
     },
     {
-      label: 'Build Details',
+      label: 'Compare',
     },
   ];
 

--- a/static/app/views/preprod/buildComparison/header/buildComparisonHeaderContent.tsx
+++ b/static/app/views/preprod/buildComparison/header/buildComparisonHeaderContent.tsx
@@ -1,0 +1,96 @@
+import {useTheme} from '@emotion/react';
+import styled from '@emotion/styled';
+import {PlatformIcon} from 'platformicons';
+
+import {Breadcrumbs, type Crumb} from 'sentry/components/breadcrumbs';
+import {Flex} from 'sentry/components/core/layout';
+import {Text} from 'sentry/components/core/text';
+import {Heading} from 'sentry/components/core/text/heading';
+import {IconJson} from 'sentry/icons';
+import useOrganization from 'sentry/utils/useOrganization';
+import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
+import {
+  getPlatformIconFromPlatform,
+  getReadablePlatformLabel,
+} from 'sentry/views/preprod/utils/labelUtils';
+
+interface BuildComparisonHeaderContentProps {
+  buildDetails: BuildDetailsApiResponse;
+  projectId: string;
+}
+
+export function BuildComparisonHeaderContent(props: BuildComparisonHeaderContentProps) {
+  const {buildDetails, projectId} = props;
+  const organization = useOrganization();
+  const theme = useTheme();
+
+  const breadcrumbs: Crumb[] = [
+    {
+      to: '#',
+      label: 'Releases',
+    },
+    {
+      to: `/organizations/${organization.slug}/preprod/${projectId}/${buildDetails.id}/`,
+      label: buildDetails.app_info.version,
+    },
+    {
+      label: 'Build Details',
+    },
+  ];
+
+  return (
+    <Flex direction="column" gap="lg" style={{padding: `0 0 ${theme.space.lg} 0`}}>
+      <Breadcrumbs crumbs={breadcrumbs} />
+      <Heading as="h1">Build comparison</Heading>
+      <Flex gap="lg">
+        <Flex gap="sm" align="center">
+          <AppIcon>
+            <AppIconPlaceholder>
+              {buildDetails.app_info.name?.charAt(0) || ''}
+            </AppIconPlaceholder>
+          </AppIcon>
+          <Text>{buildDetails.app_info.name}</Text>
+        </Flex>
+        <Flex gap="sm" align="center">
+          <InfoIcon>
+            <PlatformIcon
+              platform={getPlatformIconFromPlatform(buildDetails.app_info.platform)}
+            />
+          </InfoIcon>
+          <Text>{getReadablePlatformLabel(buildDetails.app_info.platform)}</Text>
+        </Flex>
+        <Flex gap="sm" align="center">
+          <InfoIcon>
+            <IconJson />
+          </InfoIcon>
+          <Text>{buildDetails.app_info.app_id}</Text>
+        </Flex>
+      </Flex>
+    </Flex>
+  );
+}
+
+const AppIcon = styled('div')`
+  width: 24px;
+  height: 24px;
+  border-radius: 4px;
+  background: #ff6600;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+`;
+
+const AppIconPlaceholder = styled('div')`
+  color: white;
+  font-weight: ${p => p.theme.fontWeight.bold};
+  font-size: ${p => p.theme.fontSize.sm};
+`;
+
+const InfoIcon = styled('div')`
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;

--- a/static/app/views/preprod/buildDetails/buildDetails.tsx
+++ b/static/app/views/preprod/buildDetails/buildDetails.tsx
@@ -44,7 +44,10 @@ export default function BuildDetails() {
     <SentryDocumentTitle title="Build details">
       <Layout.Page>
         <Layout.Header>
-          <BuildDetailsHeaderContent buildDetailsQuery={buildDetailsQuery} />
+          <BuildDetailsHeaderContent
+            buildDetailsQuery={buildDetailsQuery}
+            projectId={projectId}
+          />
         </Layout.Header>
 
         <Layout.Body>

--- a/static/app/views/preprod/buildDetails/header/buildDetailsHeaderContent.tsx
+++ b/static/app/views/preprod/buildDetails/header/buildDetailsHeaderContent.tsx
@@ -1,3 +1,6 @@
+import {Link} from 'react-router-dom';
+import {useTheme} from '@emotion/react';
+
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {Breadcrumbs, type Crumb} from 'sentry/components/breadcrumbs';
 import {Alert} from 'sentry/components/core/alert';
@@ -6,18 +9,22 @@ import {Flex} from 'sentry/components/core/layout';
 import {Heading} from 'sentry/components/core/text';
 import Placeholder from 'sentry/components/placeholder';
 import {IconEllipsis, IconTelescope} from 'sentry/icons';
+import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {UseApiQueryResult} from 'sentry/utils/queryClient';
 import type RequestError from 'sentry/utils/requestError/requestError';
+import useOrganization from 'sentry/utils/useOrganization';
 import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
 
 interface BuildDetailsHeaderContentProps {
   buildDetailsQuery: UseApiQueryResult<BuildDetailsApiResponse, RequestError>;
+  projectId: string;
 }
 
 export function BuildDetailsHeaderContent(props: BuildDetailsHeaderContentProps) {
-  const {buildDetailsQuery} = props;
-
+  const organization = useOrganization();
+  const {buildDetailsQuery, projectId} = props;
+  const theme = useTheme();
   const {
     data: buildDetailsData,
     isPending: isBuildDetailsPending,
@@ -27,7 +34,7 @@ export function BuildDetailsHeaderContent(props: BuildDetailsHeaderContentProps)
 
   if (isBuildDetailsPending) {
     return (
-      <Flex direction="column" style={{padding: `0 0 ${space(2)} 0`}}>
+      <Flex direction="column" style={{padding: `0 0 ${theme.space.lg} 0`}}>
         <Placeholder height="20px" width="200px" style={{marginBottom: space(2)}} />
         <Flex align="center" justify="between" gap="md">
           <Heading as="h1">
@@ -65,32 +72,26 @@ export function BuildDetailsHeaderContent(props: BuildDetailsHeaderContentProps)
     },
   ];
 
-  const handleCompareBuild = () => {
-    // TODO: Implement compare build functionality
-    addErrorMessage('Not implemented (coming soon)');
-  };
-
   const handleMoreActions = () => {
     // TODO: Implement more actions menu
     addErrorMessage('Not implemented (coming soon)');
   };
 
   return (
-    <Flex direction="column" style={{padding: `0 0 ${space(2)} 0`}}>
+    <Flex direction="column" style={{padding: `0 0 ${theme.space.lg} 0`}}>
       <Breadcrumbs crumbs={breadcrumbs} />
       <Flex align="center" justify="between" gap="md">
         <Heading as="h1">
           v{buildDetailsData.app_info.version} ({buildDetailsData.app_info.build_number})
         </Heading>
         <Flex align="center" gap="sm" style={{flexShrink: 0}}>
-          <Button
-            size="sm"
-            priority="default"
-            icon={<IconTelescope />}
-            onClick={handleCompareBuild}
+          <Link
+            to={`/organizations/${organization.slug}/preprod/${projectId}/compare/${buildDetailsData.id}/`}
           >
-            {'Compare Build'}
-          </Button>
+            <Button size="sm" priority="default" icon={<IconTelescope />}>
+              {t('Compare Build')}
+            </Button>
+          </Link>
           {/* TODO: Actions dropdown */}
           <Button
             size="sm"


### PR DESCRIPTION
Actual
<img width="480" height="149" alt="Screenshot 2025-08-15 at 11 38 29 AM" src="https://github.com/user-attachments/assets/726aa3bb-6138-48fd-b76b-cff33c90292d" />


Designs
<img width="439" height="181" alt="Screenshot 2025-08-15 at 11 41 32 AM" src="https://github.com/user-attachments/assets/b1f0dccb-ce0b-4f25-bb3f-8076e3b8f6b2" />



Also makes some small tweaks to support routing when no base selected and some best-practice theme changes to other emerge-related build components