### PR TITLE
fix(crons): Don't drop invalid schema when writing checkin rows

### DIFF
--- a/src/sentry/monitors/models.py
+++ b/src/sentry/monitors/models.py
@@ -370,9 +370,11 @@ class Monitor(Model):
     def get_validated_config(self):
         try:
             jsonschema.validate(self.config, MONITOR_CONFIG)
-            return self.config
         except jsonschema.ValidationError:
-            logging.exception("Monitor: %s invalid config: %s", self.id, self.config)
+            logging.warning("Monitor: %s invalid config: %s", self.id, self.config, exc_info=True)
+        # We should always return the config here - just log an error if we detect that it doesn't
+        # match the schema
+        return self.config
 
     def get_issue_alert_rule(self):
         issue_alert_rule_id = self.config.get("alert_rule_id")

--- a/tests/sentry/incidents/endpoints/validators/test_validators.py
+++ b/tests/sentry/incidents/endpoints/validators/test_validators.py
@@ -23,6 +23,7 @@ from sentry.snuba.models import (
     SnubaQuery,
     SnubaQueryEventType,
 )
+from sentry.workflow_engine.endpoints.validators.utils import get_unknown_detector_type_error
 from sentry.workflow_engine.models import DataCondition, DataConditionGroup, DataSource, Detector
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.registry import data_source_type_registry
@@ -320,7 +321,8 @@ class TestMetricAlertsDetectorValidator(BaseValidatorTest):
         assert not validator.is_valid()
         assert validator.errors.get("type") == [
             ErrorDetail(
-                string="Unknown detector type 'invalid_type'. Must be one of: error", code="invalid"
+                string=get_unknown_detector_type_error("invalid_type", self.organization),
+                code="invalid",
             )
         ]
 

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
@@ -30,6 +30,7 @@ from sentry.testutils.silo import region_silo_test
 from sentry.uptime.grouptype import UptimeDomainCheckFailure
 from sentry.uptime.types import DATA_SOURCE_UPTIME_SUBSCRIPTION
 from sentry.workflow_engine.endpoints.organization_detector_index import convert_assignee_values
+from sentry.workflow_engine.endpoints.validators.utils import get_unknown_detector_type_error
 from sentry.workflow_engine.models import DataCondition, DataConditionGroup, DataSource, Detector
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.models.detector_group import DetectorGroup
@@ -682,7 +683,7 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
             status_code=400,
         )
         assert response.data == {
-            "type": ["Unknown detector type 'invalid_type'. Must be one of: error"]
+            "type": [get_unknown_detector_type_error("invalid_type", self.organization)]
         }
 
     def test_incompatible_group_type(self) -> None:


### PR DESCRIPTION
We had a bug where we accidentally didn't save all the required fields for the monitor config. This causes a bug when we copy the config over to the monitor checkin where we end up storing a null value.

We should instead treat this as a warning - if the config is already stored in the monitor, it should be replicated regardless of whether it's valid or not. The validation should happen at mutation time, which is being fixed in https://github.com/getsentry/sentry/pull/97943

Fixes SENTRY-4DDN
