### PR TITLE
feat(alerts): Disable new metric alerts when over quota

### DIFF
--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -196,6 +196,8 @@ type ComponentHooks = {
   'component:insights-date-range-query-limit-footer': () => React.ComponentType;
   'component:insights-upsell-page': () => React.ComponentType<InsightsUpsellHook>;
   'component:member-list-header': () => React.ComponentType<MemberListHeaderProps>;
+  'component:metric-alert-quota-icon': React.ComponentType;
+  'component:metric-alert-quota-message': React.ComponentType;
   'component:org-stats-banner': () => React.ComponentType<DashboardHeadersProps>;
   'component:org-stats-profiling-banner': () => React.ComponentType;
   'component:organization-header': () => React.ComponentType<OrganizationHeaderProps>;
@@ -327,6 +329,11 @@ type ReactHooks = {
   ) => React.ContextType<typeof RouteAnalyticsContext>;
   'react-hook:use-button-tracking': (props: ButtonProps) => () => void;
   'react-hook:use-get-max-retention-days': () => number | undefined;
+  'react-hook:use-metric-detector-limit': () => {
+    isLimitExceeded: boolean;
+    limit: number;
+    numMetricMonitors: number;
+  } | null;
 };
 
 /**

--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -335,7 +335,7 @@ type ReactHooks = {
     hasReachedLimit: boolean;
     isError: boolean;
     isLoading: boolean;
-  } | null;
+  };
 };
 
 /**

--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -330,9 +330,11 @@ type ReactHooks = {
   'react-hook:use-button-tracking': (props: ButtonProps) => () => void;
   'react-hook:use-get-max-retention-days': () => number | undefined;
   'react-hook:use-metric-detector-limit': () => {
-    isLimitExceeded: boolean;
-    limit: number;
-    numMetricMonitors: number;
+    detectorCount: number;
+    detectorLimit: number;
+    hasReachedLimit: boolean;
+    isError: boolean;
+    isLoading: boolean;
   } | null;
 };
 

--- a/static/app/views/alerts/wizard/index.tsx
+++ b/static/app/views/alerts/wizard/index.tsx
@@ -5,6 +5,7 @@ import Feature from 'sentry/components/acl/feature';
 import FeatureDisabled from 'sentry/components/acl/featureDisabled';
 import {ExternalLink} from 'sentry/components/core/link';
 import CreateAlertButton from 'sentry/components/createAlertButton';
+import Hook from 'sentry/components/hook';
 import {Hovercard} from 'sentry/components/hovercard';
 import * as Layout from 'sentry/components/layouts/thirds';
 import List from 'sentry/components/list';
@@ -14,6 +15,7 @@ import PanelBody from 'sentry/components/panels/panelBody';
 import PanelHeader from 'sentry/components/panels/panelHeader';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
+import HookStore from 'sentry/stores/hookStore';
 import {space} from 'sentry/styles/space';
 import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import type {Organization} from 'sentry/types/organization';
@@ -23,7 +25,7 @@ import {makeAlertsPathname} from 'sentry/views/alerts/pathnames';
 import {Dataset} from 'sentry/views/alerts/rules/metric/types';
 import {AlertRuleType} from 'sentry/views/alerts/types';
 
-import type {AlertType, WizardRuleTemplate} from './options';
+import type {AlertType, MetricAlertType, WizardRuleTemplate} from './options';
 import {
   AlertWizardAlertNames,
   AlertWizardExtraContent,
@@ -45,6 +47,10 @@ type AlertWizardProps = RouteComponentProps<RouteParams> & {
 const DEFAULT_ALERT_OPTION = 'issues';
 
 function AlertWizard({organization, params, location, projectId}: AlertWizardProps) {
+  const useMetricDetectorLimit =
+    HookStore.get('react-hook:use-metric-detector-limit')[0] ?? (() => null);
+  const quota = useMetricDetectorLimit();
+  const canCreateMetricAlert = !quota?.isLimitExceeded;
   const [alertOption, setAlertOption] = useState<AlertType>(
     location.query.alert_option in AlertWizardAlertNames
       ? location.query.alert_option
@@ -56,11 +62,13 @@ function AlertWizard({organization, params, location, projectId}: AlertWizardPro
     setAlertOption(option);
   };
 
+  let metricRuleTemplate: Readonly<WizardRuleTemplate> | undefined =
+    alertOption in AlertWizardRuleTemplates
+      ? AlertWizardRuleTemplates[alertOption as MetricAlertType]
+      : undefined;
+  const isMetricAlert = !!metricRuleTemplate;
+
   function renderCreateAlertButton() {
-    let metricRuleTemplate: Readonly<WizardRuleTemplate> | undefined =
-      // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-      AlertWizardRuleTemplates[alertOption];
-    const isMetricAlert = !!metricRuleTemplate;
     const isTransactionDataset = metricRuleTemplate?.dataset === Dataset.TRANSACTIONS;
 
     // If theres anything using the legacy sessions dataset, we need to convert it to metrics
@@ -114,7 +122,7 @@ function AlertWizard({organization, params, location, projectId}: AlertWizardPro
             <CreateAlertButton
               organization={organization}
               projectSlug={projectSlug}
-              disabled={!hasFeature}
+              disabled={!hasFeature || (isMetricAlert && !canCreateMetricAlert)}
               priority="primary"
               to={{
                 pathname: makeAlertsPathname({
@@ -169,14 +177,17 @@ function AlertWizard({organization, params, location, projectId}: AlertWizardPro
                   <div key={categoryHeading}>
                     <CategoryTitle>{categoryHeading} </CategoryTitle>
                     <WizardGroupedOptions
-                      choices={options.map((alertType: any) => {
-                        return [
-                          alertType,
-                          // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-                          AlertWizardAlertNames[alertType],
-                          // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-                          AlertWizardExtraContent[alertType],
-                        ];
+                      choices={options.map((alertType: MetricAlertType) => {
+                        const optionIsMetricAlert = alertType in AlertWizardRuleTemplates;
+
+                        return {
+                          id: alertType,
+                          name: AlertWizardAlertNames[alertType],
+                          badge: AlertWizardExtraContent[alertType],
+                          trailingContent: optionIsMetricAlert ? (
+                            <Hook name="component:metric-alert-quota-icon" />
+                          ) : null,
+                        };
                       })}
                       onChange={option => handleChangeAlertOption(option as AlertType)}
                       value={alertOption}
@@ -209,6 +220,7 @@ function AlertWizard({organization, params, location, projectId}: AlertWizardPro
                   </PanelBody>
                 </div>
                 <WizardFooter>{renderCreateAlertButton()}</WizardFooter>
+                {isMetricAlert && <Hook name="component:metric-alert-quota-message" />}
               </WizardPanelBody>
             </WizardPanel>
           </WizardBody>

--- a/static/app/views/alerts/wizard/index.tsx
+++ b/static/app/views/alerts/wizard/index.tsx
@@ -50,7 +50,8 @@ function AlertWizard({organization, params, location, projectId}: AlertWizardPro
   const useMetricDetectorLimit =
     HookStore.get('react-hook:use-metric-detector-limit')[0] ?? (() => null);
   const quota = useMetricDetectorLimit();
-  const canCreateMetricAlert = !quota?.isLimitExceeded;
+  const canCreateMetricAlert = !quota?.hasReachedLimit;
+
   const [alertOption, setAlertOption] = useState<AlertType>(
     location.query.alert_option in AlertWizardAlertNames
       ? location.query.alert_option

--- a/static/app/views/alerts/wizard/radioPanelGroup.spec.tsx
+++ b/static/app/views/alerts/wizard/radioPanelGroup.spec.tsx
@@ -11,9 +11,9 @@ describe('RadioGroupPanel', function () {
         label="test"
         value="choice_one"
         choices={[
-          ['choice_one', 'Choice One'],
-          ['choice_two', 'Choice Two'],
-          ['choice_three', 'Choice Three'],
+          {id: 'choice_one', name: 'Choice One'},
+          {id: 'choice_two', name: 'Choice Two'},
+          {id: 'choice_three', name: 'Choice Three'},
         ]}
         onChange={mock}
       />
@@ -32,9 +32,9 @@ describe('RadioGroupPanel', function () {
         label="test"
         value="choice_one"
         choices={[
-          ['choice_one', 'Choice One'],
-          ['choice_two', 'Choice Two', 'extra content'],
-          ['choice_three', 'Choice Three'],
+          {id: 'choice_one', name: 'Choice One'},
+          {id: 'choice_two', name: 'Choice Two', trailingContent: 'extra content'},
+          {id: 'choice_three', name: 'Choice Three'},
         ]}
         onChange={mock}
       />

--- a/static/app/views/alerts/wizard/radioPanelGroup.tsx
+++ b/static/app/views/alerts/wizard/radioPanelGroup.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 
+import {Flex} from 'sentry/components/core/layout';
 import {Radio} from 'sentry/components/core/radio';
 import {space} from 'sentry/styles/space';
 
@@ -7,7 +8,12 @@ type RadioPanelGroupProps<C extends string> = {
   /**
    * An array of [id, name]
    */
-  choices: Array<[C, React.ReactNode, React.ReactNode?]>;
+  choices: Array<{
+    id: C;
+    name: React.ReactNode;
+    badge?: React.ReactNode;
+    trailingContent?: React.ReactNode;
+  }>;
   label: string;
   onChange: (id: C, e: React.FormEvent<HTMLInputElement>) => void;
   value: string | null;
@@ -25,17 +31,20 @@ function RadioPanelGroup<C extends string>({
 }: Props<C>) {
   return (
     <Container {...props} role="radiogroup" aria-labelledby={label}>
-      {(choices || []).map(([id, name, extraContent], index) => (
+      {(choices || []).map(({id, name, badge, trailingContent}, index) => (
         <RadioPanel key={index}>
           <RadioLineItem role="radio" index={index} aria-checked={value === id}>
-            <Radio
-              size="sm"
-              aria-label={id}
-              checked={value === id}
-              onChange={(e: React.FormEvent<HTMLInputElement>) => onChange(id, e)}
-            />
-            <div>{name}</div>
-            {extraContent}
+            <Flex align="center" gap="sm">
+              <Radio
+                size="sm"
+                aria-label={id}
+                checked={value === id}
+                onChange={(e: React.FormEvent<HTMLInputElement>) => onChange(id, e)}
+              />
+              {name}
+              {badge}
+            </Flex>
+            {trailingContent && <div>{trailingContent}</div>}
           </RadioLineItem>
         </RadioPanel>
       ))}
@@ -56,10 +65,10 @@ const Container = styled('div')`
 const RadioLineItem = styled('label')<{
   index: number;
 }>`
-  display: grid;
-  gap: ${space(0.25)} ${space(1)};
-  grid-template-columns: max-content auto max-content;
+  display: flex;
+  gap: ${p => p.theme.space.sm};
   align-items: center;
+  justify-content: space-between;
   cursor: pointer;
   outline: none;
   font-weight: ${p => p.theme.fontWeight.normal};
@@ -72,11 +81,6 @@ const RadioLineItem = styled('label')<{
   &:hover,
   &:focus {
     color: ${p => p.theme.textColor};
-  }
-
-  svg {
-    display: none;
-    opacity: 0;
   }
 
   &[aria-checked='true'] {

--- a/static/gsApp/__fixtures__/plan.tsx
+++ b/static/gsApp/__fixtures__/plan.tsx
@@ -12,6 +12,7 @@ export function PlanFixture(fields: Partial<Plan>): Plan {
     availableReservedBudgetTypes: {},
     contractInterval: 'monthly',
     dashboardLimit: 10,
+    metricDetectorLimit: 20,
     description: '',
     features: [],
     hasOnDemandModes: false,

--- a/static/gsApp/components/metricAlertQuotaMessage.spec.tsx
+++ b/static/gsApp/components/metricAlertQuotaMessage.spec.tsx
@@ -1,0 +1,87 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {openUpsellModal} from 'getsentry/actionCreators/modal';
+import {useMetricDetectorLimit} from 'getsentry/hooks/useMetricDetectorLimit';
+
+import {MetricAlertQuotaMessage} from './metricAlertQuotaMessage';
+
+jest.mock('getsentry/hooks/useMetricDetectorLimit', () => ({
+  useMetricDetectorLimit: jest.fn(),
+}));
+
+jest.mock('getsentry/actionCreators/modal', () => ({
+  openUpsellModal: jest.fn(),
+}));
+
+const mockUseMetricDetectorLimit = useMetricDetectorLimit as unknown as jest.Mock;
+
+describe('MetricAlertQuotaMessage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders nothing when hook returns null', () => {
+    mockUseMetricDetectorLimit.mockReturnValue(null);
+
+    const {container} = render(<MetricAlertQuotaMessage />, {
+      organization: OrganizationFixture(),
+    });
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders approaching limit message with upgrade action', async () => {
+    mockUseMetricDetectorLimit.mockReturnValue({
+      isLimitExceeded: false,
+      limit: 11,
+      numMetricMonitors: 10,
+    });
+
+    const organization = OrganizationFixture({slug: 'acme'});
+
+    render(<MetricAlertQuotaMessage />, {organization});
+
+    expect(
+      await screen.findByText(/approaching the limit of 11 metric monitors/i)
+    ).toBeInTheDocument();
+
+    const upgrade = screen.getByRole('button', {name: /upgrade your plan/i});
+    await userEvent.click(upgrade);
+
+    expect(openUpsellModal).toHaveBeenCalledWith({
+      organization,
+      source: 'metric-alert-quota',
+    });
+  });
+
+  it('renders reached limit message with remove and upgrade actions when at limit', async () => {
+    mockUseMetricDetectorLimit.mockReturnValue({
+      isLimitExceeded: true,
+      limit: 20,
+      numMetricMonitors: 20,
+    });
+
+    const organization = OrganizationFixture({slug: 'acme'});
+
+    render(<MetricAlertQuotaMessage />, {organization});
+
+    expect(
+      screen.getByText(/reached your plan's limit on metric monitors/i)
+    ).toBeInTheDocument();
+
+    // Remove link and upgrade button are present
+    expect(
+      screen.getByRole('link', {name: /remove existing monitors/i})
+    ).toBeInTheDocument();
+
+    const upgrade = screen.getByRole('button', {name: /upgrade your plan/i});
+    await userEvent.click(upgrade);
+
+    expect(openUpsellModal).toHaveBeenCalledWith({
+      organization,
+      source: 'metric-alert-quota',
+    });
+  });
+});

--- a/static/gsApp/components/metricAlertQuotaMessage.spec.tsx
+++ b/static/gsApp/components/metricAlertQuotaMessage.spec.tsx
@@ -15,7 +15,7 @@ jest.mock('getsentry/actionCreators/modal', () => ({
   openUpsellModal: jest.fn(),
 }));
 
-const mockUseMetricDetectorLimit = useMetricDetectorLimit as unknown as jest.Mock;
+const mockuseMetricDetectorLimit = useMetricDetectorLimit as unknown as jest.Mock;
 
 describe('MetricAlertQuotaMessage', () => {
   beforeEach(() => {
@@ -23,7 +23,7 @@ describe('MetricAlertQuotaMessage', () => {
   });
 
   it('renders nothing when hook returns null', () => {
-    mockUseMetricDetectorLimit.mockReturnValue(null);
+    mockuseMetricDetectorLimit.mockReturnValue(null);
 
     const {container} = render(<MetricAlertQuotaMessage />, {
       organization: OrganizationFixture(),
@@ -32,20 +32,18 @@ describe('MetricAlertQuotaMessage', () => {
     expect(container).toBeEmptyDOMElement();
   });
 
-  it('renders approaching limit message with upgrade action', async () => {
-    mockUseMetricDetectorLimit.mockReturnValue({
-      isLimitExceeded: false,
-      limit: 11,
-      numMetricMonitors: 10,
+  it('renders approaching detectorLimit message with upgrade action', async () => {
+    mockuseMetricDetectorLimit.mockReturnValue({
+      hasReachedLimit: false,
+      detectorLimit: 11,
+      detectorCount: 10,
     });
 
     const organization = OrganizationFixture({slug: 'acme'});
 
     render(<MetricAlertQuotaMessage />, {organization});
 
-    expect(
-      await screen.findByText(/approaching the limit of 11 metric monitors/i)
-    ).toBeInTheDocument();
+    expect(await screen.findByText(/used 10 of 11 metric monitors/i)).toBeInTheDocument();
 
     const upgrade = screen.getByRole('button', {name: /upgrade your plan/i});
     await userEvent.click(upgrade);
@@ -56,11 +54,11 @@ describe('MetricAlertQuotaMessage', () => {
     });
   });
 
-  it('renders reached limit message with remove and upgrade actions when at limit', async () => {
-    mockUseMetricDetectorLimit.mockReturnValue({
-      isLimitExceeded: true,
-      limit: 20,
-      numMetricMonitors: 20,
+  it('renders reached detectorLimit message with remove and upgrade actions when at detectorLimit', async () => {
+    mockuseMetricDetectorLimit.mockReturnValue({
+      hasReachedLimit: true,
+      detectorLimit: 20,
+      detectorCount: 20,
     });
 
     const organization = OrganizationFixture({slug: 'acme'});

--- a/static/gsApp/components/metricAlertQuotaMessage.tsx
+++ b/static/gsApp/components/metricAlertQuotaMessage.tsx
@@ -1,0 +1,100 @@
+import styled from '@emotion/styled';
+
+import {Button} from 'sentry/components/core/button';
+import {Link} from 'sentry/components/core/link';
+import {Tooltip} from 'sentry/components/core/tooltip';
+import {IconWarning} from 'sentry/icons';
+import {tct} from 'sentry/locale';
+import useOrganization from 'sentry/utils/useOrganization';
+import {makeAlertsPathname} from 'sentry/views/alerts/pathnames';
+
+import {openUpsellModal} from 'getsentry/actionCreators/modal';
+import {useMetricDetectorLimit} from 'getsentry/hooks/useMetricDetectorLimit';
+
+function UpgradeLink({children}: {children?: React.ReactNode}) {
+  const organization = useOrganization();
+
+  return (
+    <Button
+      priority="link"
+      onClick={() => {
+        openUpsellModal({
+          organization,
+          source: 'metric-alert-quota',
+        });
+      }}
+    >
+      {children}
+    </Button>
+  );
+}
+
+export function MetricAlertQuotaIcon() {
+  const metricAlertQuota = useMetricDetectorLimit();
+  const organization = useOrganization();
+
+  if (metricAlertQuota?.isLimitExceeded) {
+    return (
+      <Tooltip
+        isHoverable
+        title={tct(
+          "You have reached your plan's limit on metric monitors. [removeLink:Remove existing monitors] or [upgradeLink:upgrade your plan].",
+          {
+            removeLink: <Link to={makeAlertsPathname({organization, path: '/rules/'})} />,
+            upgradeLink: <UpgradeLink />,
+          }
+        )}
+      >
+        <IconWarning color="subText" size="sm" />
+      </Tooltip>
+    );
+  }
+
+  return null;
+}
+
+export function MetricAlertQuotaMessage() {
+  const organization = useOrganization();
+  const metricAlertQuota = useMetricDetectorLimit();
+
+  if (
+    metricAlertQuota &&
+    metricAlertQuota.limit === metricAlertQuota.numMetricMonitors + 1
+  ) {
+    return (
+      <DisabledAlertMessageContainer>
+        {tct(
+          'You are approaching the limit of [limit] metric monitors for your plan. To increase the limit, [upgradeLink:upgrade your plan].',
+          {
+            limit: metricAlertQuota.limit.toLocaleString(),
+            upgradeLink: <UpgradeLink />,
+          }
+        )}
+      </DisabledAlertMessageContainer>
+    );
+  }
+
+  if (metricAlertQuota && metricAlertQuota.limit >= metricAlertQuota.numMetricMonitors) {
+    return (
+      <DisabledAlertMessageContainer>
+        {tct(
+          "You have reached your plan's limit on metric monitors. [removeLink:Remove existing monitors] or [upgradeLink:upgrade your plan].",
+          {
+            removeLink: <Link to={makeAlertsPathname({organization, path: '/rules/'})} />,
+            upgradeLink: <UpgradeLink />,
+          }
+        )}
+      </DisabledAlertMessageContainer>
+    );
+  }
+
+  return null;
+}
+
+const DisabledAlertMessageContainer = styled('div')`
+  border-top: 1px solid ${p => p.theme.border};
+  padding: ${p => p.theme.space.md} ${p => p.theme.space.lg};
+  background-color: ${p => p.theme.backgroundSecondary};
+  color: ${p => p.theme.subText};
+  border-radius: 0 0 ${p => p.theme.borderRadius} ${p => p.theme.borderRadius};
+`;

--- a/static/gsApp/components/metricAlertQuotaMessage.tsx
+++ b/static/gsApp/components/metricAlertQuotaMessage.tsx
@@ -33,7 +33,7 @@ export function MetricAlertQuotaIcon() {
   const metricAlertQuota = useMetricDetectorLimit();
   const organization = useOrganization();
 
-  if (metricAlertQuota?.isLimitExceeded) {
+  if (metricAlertQuota?.hasReachedLimit) {
     return (
       <Tooltip
         isHoverable
@@ -57,13 +57,13 @@ export function MetricAlertQuotaMessage() {
   const organization = useOrganization();
   const metricAlertQuota = useMetricDetectorLimit();
 
-  if (metricAlertQuota?.isLimitExceeded) {
+  if (metricAlertQuota?.hasReachedLimit) {
     return (
       <DisabledAlertMessageContainer>
         {tct(
           "You have reached your plan's limit on metric monitors ([limit]). [removeLink:Remove existing monitors] or [upgradeLink:upgrade your plan].",
           {
-            limit: metricAlertQuota.limit.toLocaleString(),
+            limit: metricAlertQuota.detectorLimit.toLocaleString(),
             removeLink: <Link to={makeAlertsPathname({organization, path: '/rules/'})} />,
             upgradeLink: <UpgradeLink />,
           }
@@ -74,14 +74,15 @@ export function MetricAlertQuotaMessage() {
 
   if (
     metricAlertQuota &&
-    metricAlertQuota.limit === metricAlertQuota.numMetricMonitors + 1
+    metricAlertQuota.detectorLimit === metricAlertQuota.detectorCount + 1
   ) {
     return (
       <DisabledAlertMessageContainer>
         {tct(
-          'You are approaching the limit of [limit] metric monitors for your plan. To increase the limit, [upgradeLink:upgrade your plan].',
+          'You have used [count] of [limit] metric monitors for your plan. To increase the limit, [upgradeLink:upgrade your plan].',
           {
-            limit: metricAlertQuota.limit.toLocaleString(),
+            count: metricAlertQuota.detectorCount.toLocaleString(),
+            limit: metricAlertQuota.detectorLimit.toLocaleString(),
             upgradeLink: <UpgradeLink />,
           }
         )}

--- a/static/gsApp/components/metricAlertQuotaMessage.tsx
+++ b/static/gsApp/components/metricAlertQuotaMessage.tsx
@@ -57,6 +57,21 @@ export function MetricAlertQuotaMessage() {
   const organization = useOrganization();
   const metricAlertQuota = useMetricDetectorLimit();
 
+  if (metricAlertQuota?.isLimitExceeded) {
+    return (
+      <DisabledAlertMessageContainer>
+        {tct(
+          "You have reached your plan's limit on metric monitors ([limit]). [removeLink:Remove existing monitors] or [upgradeLink:upgrade your plan].",
+          {
+            limit: metricAlertQuota.limit.toLocaleString(),
+            removeLink: <Link to={makeAlertsPathname({organization, path: '/rules/'})} />,
+            upgradeLink: <UpgradeLink />,
+          }
+        )}
+      </DisabledAlertMessageContainer>
+    );
+  }
+
   if (
     metricAlertQuota &&
     metricAlertQuota.limit === metricAlertQuota.numMetricMonitors + 1
@@ -67,20 +82,6 @@ export function MetricAlertQuotaMessage() {
           'You are approaching the limit of [limit] metric monitors for your plan. To increase the limit, [upgradeLink:upgrade your plan].',
           {
             limit: metricAlertQuota.limit.toLocaleString(),
-            upgradeLink: <UpgradeLink />,
-          }
-        )}
-      </DisabledAlertMessageContainer>
-    );
-  }
-
-  if (metricAlertQuota && metricAlertQuota.limit >= metricAlertQuota.numMetricMonitors) {
-    return (
-      <DisabledAlertMessageContainer>
-        {tct(
-          "You have reached your plan's limit on metric monitors. [removeLink:Remove existing monitors] or [upgradeLink:upgrade your plan].",
-          {
-            removeLink: <Link to={makeAlertsPathname({organization, path: '/rules/'})} />,
             upgradeLink: <UpgradeLink />,
           }
         )}

--- a/static/gsApp/hooks/useMetricDetectorLimit.spec.tsx
+++ b/static/gsApp/hooks/useMetricDetectorLimit.spec.tsx
@@ -84,20 +84,12 @@ describe('useMetricDetectorLimit', () => {
     expect(result.current).toEqual({
       hasReachedLimit: false,
       detectorLimit: -1,
-      detectorCount: 2,
+      detectorCount: -1,
       isLoading: false,
       isError: false,
     });
 
-    expect(detectorsRequest).toHaveBeenCalledWith(
-      '/organizations/org-slug/detectors/',
-      expect.objectContaining({
-        query: expect.objectContaining({
-          query: 'type:metric',
-          per_page: 0,
-        }),
-      })
-    );
+    expect(detectorsRequest).not.toHaveBeenCalled();
   });
 
   it('handles detectors count is below limit', async () => {
@@ -140,7 +132,7 @@ describe('useMetricDetectorLimit', () => {
       expect.objectContaining({
         query: expect.objectContaining({
           query: 'type:metric',
-          per_page: 0,
+          per_page: 1,
         }),
       })
     );
@@ -212,12 +204,12 @@ describe('useMetricDetectorLimit', () => {
     expect(result.current).toEqual({
       hasReachedLimit: false,
       detectorLimit: -1,
-      detectorCount: 10,
+      detectorCount: -1,
       isLoading: false,
       isError: false,
     });
 
-    expect(detectorsRequest).toHaveBeenCalled();
+    expect(detectorsRequest).not.toHaveBeenCalled();
   });
 
   it('handles detectors API error gracefully', async () => {

--- a/static/gsApp/hooks/useMetricDetectorLimit.spec.tsx
+++ b/static/gsApp/hooks/useMetricDetectorLimit.spec.tsx
@@ -246,40 +246,4 @@ describe('useMetricDetectorLimit', () => {
       isError: true,
     });
   });
-
-  it('handles missing X-Hits header as error', async () => {
-    const wrapper = createWrapper(mockOrganization);
-
-    const subscription = SubscriptionFixture({
-      organization: mockOrganization,
-      planDetails: {
-        ...SubscriptionFixture({
-          organization: mockOrganization,
-        }).planDetails,
-        metricDetectorLimit: 5,
-      },
-    });
-
-    SubscriptionStore.set(mockOrganization.slug, subscription);
-
-    MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/detectors/',
-      body: [],
-      // No X-Hits header
-    });
-
-    const {result} = renderHook(() => useMetricDetectorLimit(), {wrapper});
-
-    await waitFor(() => {
-      expect(result.current.isLoading).toBe(false);
-    });
-
-    expect(result.current).toEqual({
-      hasReachedLimit: false,
-      detectorLimit: 5,
-      detectorCount: -1,
-      isLoading: false,
-      isError: true,
-    });
-  });
 });

--- a/static/gsApp/hooks/useMetricDetectorLimit.spec.tsx
+++ b/static/gsApp/hooks/useMetricDetectorLimit.spec.tsx
@@ -1,0 +1,293 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
+import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import type {Organization} from 'sentry/types/organization';
+import {QueryClient, QueryClientProvider} from 'sentry/utils/queryClient';
+import {OrganizationContext} from 'sentry/views/organizationContext';
+
+import SubscriptionStore from 'getsentry/stores/subscriptionStore';
+
+import {useMetricDetectorLimit} from './useMetricDetectorLimit';
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+    },
+  },
+});
+
+function createWrapper(organization: Organization) {
+  return function Wrapper({children}: {children?: React.ReactNode}) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <OrganizationContext value={organization}>{children}</OrganizationContext>
+      </QueryClientProvider>
+    );
+  };
+}
+
+const mockOrganization = OrganizationFixture({
+  features: ['workflow-engine-metric-detector-limit'],
+});
+
+const mockOrganizationWithoutFeature = OrganizationFixture({
+  features: [],
+});
+
+describe('useMetricDetectorLimit', () => {
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    queryClient.clear();
+    SubscriptionStore.init();
+  });
+
+  it('handles feature flag is disabled', () => {
+    const wrapper = createWrapper(mockOrganizationWithoutFeature);
+    const detectorsRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/detectors/',
+      headers: {'X-Hits': '5'},
+      body: [],
+    });
+
+    const {result} = renderHook(() => useMetricDetectorLimit(), {wrapper});
+
+    expect(result.current).toEqual({
+      hasReachedLimit: false,
+      detectorLimit: -1,
+      detectorCount: -1,
+      isLoading: false,
+      isError: false,
+    });
+
+    expect(detectorsRequest).not.toHaveBeenCalled();
+  });
+
+  it('handles no subscription data', async () => {
+    const wrapper = createWrapper(mockOrganization);
+
+    SubscriptionStore.set(mockOrganization.slug, null as any);
+    const detectorsRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/detectors/',
+      headers: {'X-Hits': '2'},
+      body: [],
+    });
+
+    const {result} = renderHook(() => useMetricDetectorLimit(), {wrapper});
+
+    await waitFor(() => {
+      expect(result.current?.isLoading).toBe(false);
+    });
+
+    expect(result.current).toEqual({
+      hasReachedLimit: false,
+      detectorLimit: -1,
+      detectorCount: 2,
+      isLoading: false,
+      isError: false,
+    });
+
+    expect(detectorsRequest).toHaveBeenCalledWith(
+      '/organizations/org-slug/detectors/',
+      expect.objectContaining({
+        query: expect.objectContaining({
+          query: 'type:metric',
+          per_page: 0,
+        }),
+      })
+    );
+  });
+
+  it('handles detectors count is below limit', async () => {
+    const wrapper = createWrapper(mockOrganization);
+
+    const subscription = SubscriptionFixture({
+      organization: mockOrganization,
+      planDetails: {
+        ...SubscriptionFixture({
+          organization: mockOrganization,
+        }).planDetails,
+        metricDetectorLimit: 4,
+      },
+    });
+
+    SubscriptionStore.set(mockOrganization.slug, subscription);
+
+    const detectorsRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/detectors/',
+      headers: {'X-Hits': '3'},
+      body: [],
+    });
+
+    const {result} = renderHook(() => useMetricDetectorLimit(), {wrapper});
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current).toEqual({
+      hasReachedLimit: false,
+      detectorLimit: 4,
+      detectorCount: 3,
+      isLoading: false,
+      isError: false,
+    });
+
+    expect(detectorsRequest).toHaveBeenCalledWith(
+      '/organizations/org-slug/detectors/',
+      expect.objectContaining({
+        query: expect.objectContaining({
+          query: 'type:metric',
+          per_page: 0,
+        }),
+      })
+    );
+  });
+
+  it('handles detectors count equals limit', async () => {
+    const wrapper = createWrapper(mockOrganization);
+
+    const subscription = SubscriptionFixture({
+      organization: mockOrganization,
+      planDetails: {
+        ...SubscriptionFixture({
+          organization: mockOrganization,
+        }).planDetails,
+        metricDetectorLimit: 3,
+      },
+    });
+
+    SubscriptionStore.set(mockOrganization.slug, subscription);
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/detectors/',
+      headers: {'X-Hits': '3'},
+      body: [],
+    });
+
+    const {result} = renderHook(() => useMetricDetectorLimit(), {wrapper});
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current).toEqual({
+      hasReachedLimit: true,
+      detectorLimit: 3,
+      detectorCount: 3,
+      isLoading: false,
+      isError: false,
+    });
+  });
+
+  it('handles detector limit is -1', async () => {
+    const wrapper = createWrapper(mockOrganization);
+
+    const subscription = SubscriptionFixture({
+      organization: mockOrganization,
+      planDetails: {
+        ...SubscriptionFixture({
+          organization: mockOrganization,
+        }).planDetails,
+        metricDetectorLimit: -1,
+      },
+    });
+
+    SubscriptionStore.set(mockOrganization.slug, subscription);
+
+    const detectorsRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/detectors/',
+      headers: {'X-Hits': '10'},
+      body: [],
+    });
+
+    const {result} = renderHook(() => useMetricDetectorLimit(), {wrapper});
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current).toEqual({
+      hasReachedLimit: false,
+      detectorLimit: -1,
+      detectorCount: 10,
+      isLoading: false,
+      isError: false,
+    });
+
+    expect(detectorsRequest).toHaveBeenCalled();
+  });
+
+  it('handles detectors API error gracefully', async () => {
+    const wrapper = createWrapper(mockOrganization);
+
+    const subscription = SubscriptionFixture({
+      organization: mockOrganization,
+      planDetails: {
+        ...SubscriptionFixture({
+          organization: mockOrganization,
+        }).planDetails,
+        metricDetectorLimit: 20,
+      },
+    });
+
+    SubscriptionStore.set(mockOrganization.slug, subscription);
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/detectors/',
+      statusCode: 500,
+    });
+
+    const {result} = renderHook(() => useMetricDetectorLimit(), {wrapper});
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current).toEqual({
+      hasReachedLimit: false,
+      detectorLimit: 20,
+      detectorCount: -1,
+      isLoading: false,
+      isError: true,
+    });
+  });
+
+  it('handles missing X-Hits header as error', async () => {
+    const wrapper = createWrapper(mockOrganization);
+
+    const subscription = SubscriptionFixture({
+      organization: mockOrganization,
+      planDetails: {
+        ...SubscriptionFixture({
+          organization: mockOrganization,
+        }).planDetails,
+        metricDetectorLimit: 5,
+      },
+    });
+
+    SubscriptionStore.set(mockOrganization.slug, subscription);
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/detectors/',
+      body: [],
+      // No X-Hits header
+    });
+
+    const {result} = renderHook(() => useMetricDetectorLimit(), {wrapper});
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current).toEqual({
+      hasReachedLimit: false,
+      detectorLimit: 5,
+      detectorCount: -1,
+      isLoading: false,
+      isError: true,
+    });
+  });
+});

--- a/static/gsApp/hooks/useMetricDetectorLimit.tsx
+++ b/static/gsApp/hooks/useMetricDetectorLimit.tsx
@@ -12,7 +12,7 @@ type MetricDetectorLimitResponse = {
 };
 
 const UNLIMITED_QUOTA = -1;
-const ERROR_COUNT = -1;
+const NO_COUNT = -1;
 
 export function useMetricDetectorLimit(): MetricDetectorLimitResponse {
   const organization = useOrganization();
@@ -32,7 +32,7 @@ export function useMetricDetectorLimit(): MetricDetectorLimitResponse {
   );
 
   const hits = getResponseHeader?.('X-Hits');
-  const detectorCount = hits ? parseInt(hits, 10) : ERROR_COUNT;
+  const detectorCount = hits ? parseInt(hits, 10) : NO_COUNT;
 
   if (!hasFlag || detectorLimit === UNLIMITED_QUOTA) {
     return {
@@ -49,6 +49,6 @@ export function useMetricDetectorLimit(): MetricDetectorLimitResponse {
     detectorLimit,
     hasReachedLimit: detectorCount >= detectorLimit,
     isLoading,
-    isError: isError || detectorCount === ERROR_COUNT,
+    isError,
   };
 }

--- a/static/gsApp/hooks/useMetricDetectorLimit.tsx
+++ b/static/gsApp/hooks/useMetricDetectorLimit.tsx
@@ -6,14 +6,20 @@ type MetricDetectorLimitResponse = {
   hasReachedLimit: boolean;
   isError: boolean;
   isLoading: boolean;
-} | null;
+};
 
 // TODO: Replace with actual hook
 export function useMetricDetectorLimit(): MetricDetectorLimitResponse {
   const organization = useOrganization();
 
   if (!organization.features.includes('workflow-engine-metric-detector-limit')) {
-    return null;
+    return {
+      hasReachedLimit: false,
+      detectorLimit: -1,
+      detectorCount: -1,
+      isLoading: false,
+      isError: false,
+    };
   }
 
   return {

--- a/static/gsApp/hooks/useMetricDetectorLimit.tsx
+++ b/static/gsApp/hooks/useMetricDetectorLimit.tsx
@@ -22,7 +22,7 @@ export function useMetricDetectorLimit(): MetricDetectorLimitResponse {
   const {isLoading, isError, getResponseHeader} = useDetectorsQuery(
     {
       query: 'type:metric',
-      limit: 0,
+      limit: 1,
     },
     {enabled: hasFlag}
   );

--- a/static/gsApp/hooks/useMetricDetectorLimit.tsx
+++ b/static/gsApp/hooks/useMetricDetectorLimit.tsx
@@ -1,10 +1,12 @@
 import useOrganization from 'sentry/utils/useOrganization';
 
 type MetricDetectorLimitResponse = {
-  isLimitExceeded: boolean;
-  limit: number;
-  numMetricMonitors: number;
-} | null; // null means there is no limit
+  detectorCount: number;
+  detectorLimit: number;
+  hasReachedLimit: boolean;
+  isError: boolean;
+  isLoading: boolean;
+} | null;
 
 // TODO: Replace with actual hook
 export function useMetricDetectorLimit(): MetricDetectorLimitResponse {
@@ -15,8 +17,10 @@ export function useMetricDetectorLimit(): MetricDetectorLimitResponse {
   }
 
   return {
-    isLimitExceeded: true,
-    numMetricMonitors: 20,
-    limit: 20,
+    hasReachedLimit: true,
+    detectorCount: 20,
+    detectorLimit: 20,
+    isError: false,
+    isLoading: false,
   };
 }

--- a/static/gsApp/hooks/useMetricDetectorLimit.tsx
+++ b/static/gsApp/hooks/useMetricDetectorLimit.tsx
@@ -25,7 +25,10 @@ export function useMetricDetectorLimit(): MetricDetectorLimitResponse {
       query: 'type:metric',
       limit: 1,
     },
-    {enabled: hasFlag && detectorLimit !== UNLIMITED_QUOTA}
+    {
+      enabled: hasFlag && detectorLimit !== UNLIMITED_QUOTA,
+      staleTime: 5 * 60 * 1000, // Set stale time to 5 mins to avoid unnecessary re-fetching
+    }
   );
 
   const hits = getResponseHeader?.('X-Hits');

--- a/static/gsApp/hooks/useMetricDetectorLimit.tsx
+++ b/static/gsApp/hooks/useMetricDetectorLimit.tsx
@@ -1,0 +1,14 @@
+type MetricDetectorLimitResponse = {
+  isLimitExceeded: boolean;
+  limit: number;
+  numMetricMonitors: number;
+} | null;
+
+// TODO: Replace with actual hook
+export function useMetricDetectorLimit(): MetricDetectorLimitResponse {
+  return {
+    isLimitExceeded: true,
+    numMetricMonitors: 20,
+    limit: 20,
+  };
+}

--- a/static/gsApp/hooks/useMetricDetectorLimit.tsx
+++ b/static/gsApp/hooks/useMetricDetectorLimit.tsx
@@ -17,6 +17,7 @@ const ERROR_COUNT = -1;
 export function useMetricDetectorLimit(): MetricDetectorLimitResponse {
   const organization = useOrganization();
   const subscription = useSubscription();
+  const detectorLimit = subscription?.planDetails?.metricDetectorLimit ?? UNLIMITED_QUOTA;
   const hasFlag = organization.features.includes('workflow-engine-metric-detector-limit');
 
   const {isLoading, isError, getResponseHeader} = useDetectorsQuery(
@@ -24,12 +25,11 @@ export function useMetricDetectorLimit(): MetricDetectorLimitResponse {
       query: 'type:metric',
       limit: 1,
     },
-    {enabled: hasFlag}
+    {enabled: hasFlag && detectorLimit !== UNLIMITED_QUOTA}
   );
 
   const hits = getResponseHeader?.('X-Hits');
   const detectorCount = hits ? parseInt(hits, 10) : ERROR_COUNT;
-  const detectorLimit = subscription?.planDetails?.metricDetectorLimit ?? UNLIMITED_QUOTA;
 
   if (!hasFlag || detectorLimit === UNLIMITED_QUOTA) {
     return {

--- a/static/gsApp/hooks/useMetricDetectorLimit.tsx
+++ b/static/gsApp/hooks/useMetricDetectorLimit.tsx
@@ -1,11 +1,19 @@
+import useOrganization from 'sentry/utils/useOrganization';
+
 type MetricDetectorLimitResponse = {
   isLimitExceeded: boolean;
   limit: number;
   numMetricMonitors: number;
-} | null;
+} | null; // null means there is no limit
 
 // TODO: Replace with actual hook
 export function useMetricDetectorLimit(): MetricDetectorLimitResponse {
+  const organization = useOrganization();
+
+  if (!organization.features.includes('workflow-engine-metric-detector-limit')) {
+    return null;
+  }
+
   return {
     isLimitExceeded: true,
     numMetricMonitors: 20,

--- a/static/gsApp/registerHooks.tsx
+++ b/static/gsApp/registerHooks.tsx
@@ -32,6 +32,10 @@ import HelpSearchFooter from 'getsentry/components/helpSearchFooter';
 import InviteMembersButtonCustomization from 'getsentry/components/inviteMembersButtonCustomization';
 import LabelWithPowerIcon from 'getsentry/components/labelWithPowerIcon';
 import MemberInviteModalCustomization from 'getsentry/components/memberInviteModalCustomization';
+import {
+  MetricAlertQuotaIcon,
+  MetricAlertQuotaMessage,
+} from 'getsentry/components/metricAlertQuotaMessage';
 import {OrganizationHeader} from 'getsentry/components/organizationHeader';
 import PowerFeatureHovercard from 'getsentry/components/powerFeatureHovercard';
 import {ProductSelectionAvailability} from 'getsentry/components/productSelectionAvailability';
@@ -68,6 +72,7 @@ import EnhancedOrganizationStats from 'getsentry/hooks/spendVisibility/enhancedI
 import SpikeProtectionProjectSettings from 'getsentry/hooks/spendVisibility/spikeProtectionProjectSettings';
 import SuperuserAccessCategory from 'getsentry/hooks/superuserAccessCategory';
 import TargetedOnboardingHeader from 'getsentry/hooks/targetedOnboardingHeader';
+import {useMetricDetectorLimit} from 'getsentry/hooks/useMetricDetectorLimit';
 import rawTrackAnalyticsEvent from 'getsentry/utils/rawTrackAnalyticsEvent';
 import trackMetric from 'getsentry/utils/trackMetric';
 
@@ -242,6 +247,7 @@ const GETSENTRY_HOOKS: Partial<Hooks> = {
   'react-hook:route-activated': useRouteActivatedHook,
   'react-hook:use-button-tracking': useButtonTracking,
   'react-hook:use-get-max-retention-days': useGetMaxRetentionDays,
+  'react-hook:use-metric-detector-limit': useMetricDetectorLimit,
   'component:partnership-agreement': p => (
     <LazyLoad LazyComponent={PartnershipAgreement} {...p} />
   ),
@@ -251,6 +257,8 @@ const GETSENTRY_HOOKS: Partial<Hooks> = {
   'component:data-consent-org-creation-checkbox': () => DataConsentOrgCreationCheckbox,
   'component:organization-membership-settings': () => OrganizationMembershipSettingsForm,
   'component:scm-multi-org-install-button': () => GithubInstallationSelectInstallButton,
+  'component:metric-alert-quota-message': MetricAlertQuotaMessage,
+  'component:metric-alert-quota-icon': MetricAlertQuotaIcon,
 
   /**
    * Augment disable feature hooks for augmenting with upsell interfaces

--- a/static/gsApp/types/index.tsx
+++ b/static/gsApp/types/index.tsx
@@ -154,6 +154,7 @@ export type Plan = {
   id: string;
   isTestPlan: boolean;
   maxMembers: number | null;
+  metricDetectorLimit: number;
   name: string;
   onDemandCategories: DataCategory[];
   onDemandEventPrice: number;

--- a/tests/js/getsentry-test/fixtures/am1Plans.ts
+++ b/tests/js/getsentry-test/fixtures/am1Plans.ts
@@ -175,6 +175,7 @@ const AM1_PLANS: Record<string, Plan> = {
     budgetTerm: BUDGET_TERM,
     availableReservedBudgetTypes: AM1_AVAILABLE_RESERVED_BUDGET_TYPES,
     dashboardLimit: 10,
+    metricDetectorLimit: 20,
   },
   am1_t: {
     allowAdditionalReservedEvents: false,
@@ -249,6 +250,7 @@ const AM1_PLANS: Record<string, Plan> = {
     budgetTerm: BUDGET_TERM,
     availableReservedBudgetTypes: AM1_AVAILABLE_RESERVED_BUDGET_TYPES,
     dashboardLimit: 10,
+    metricDetectorLimit: 20,
   },
   am1_team: {
     allowAdditionalReservedEvents: false,
@@ -833,6 +835,7 @@ const AM1_PLANS: Record<string, Plan> = {
     budgetTerm: BUDGET_TERM,
     availableReservedBudgetTypes: AM1_AVAILABLE_RESERVED_BUDGET_TYPES,
     dashboardLimit: 20,
+    metricDetectorLimit: 20,
   },
   am1_team_auf: {
     allowAdditionalReservedEvents: false,
@@ -1417,6 +1420,7 @@ const AM1_PLANS: Record<string, Plan> = {
     budgetTerm: BUDGET_TERM,
     availableReservedBudgetTypes: AM1_AVAILABLE_RESERVED_BUDGET_TYPES,
     dashboardLimit: 20,
+    metricDetectorLimit: 20,
   },
   am1_business: {
     allowAdditionalReservedEvents: false,
@@ -2001,6 +2005,7 @@ const AM1_PLANS: Record<string, Plan> = {
     budgetTerm: BUDGET_TERM,
     availableReservedBudgetTypes: AM1_AVAILABLE_RESERVED_BUDGET_TYPES,
     dashboardLimit: -1,
+    metricDetectorLimit: -1,
   },
   am1_business_auf: {
     allowAdditionalReservedEvents: false,
@@ -2585,6 +2590,7 @@ const AM1_PLANS: Record<string, Plan> = {
     budgetTerm: BUDGET_TERM,
     availableReservedBudgetTypes: AM1_AVAILABLE_RESERVED_BUDGET_TYPES,
     dashboardLimit: -1,
+    metricDetectorLimit: -1,
   },
   am1_business_ent: {
     id: 'am1_business_ent',
@@ -2666,6 +2672,7 @@ const AM1_PLANS: Record<string, Plan> = {
     budgetTerm: BUDGET_TERM,
     availableReservedBudgetTypes: AM1_AVAILABLE_RESERVED_BUDGET_TYPES,
     dashboardLimit: -1,
+    metricDetectorLimit: -1,
   },
 };
 

--- a/tests/js/getsentry-test/fixtures/am2Plans.ts
+++ b/tests/js/getsentry-test/fixtures/am2Plans.ts
@@ -841,6 +841,7 @@ const AM2_PLANS: Record<string, Plan> = {
     budgetTerm: BUDGET_TERM,
     availableReservedBudgetTypes: AM2_AVAILABLE_RESERVED_BUDGET_TYPES,
     dashboardLimit: -1,
+    metricDetectorLimit: -1,
   },
   am2_f: {
     id: 'am2_f',
@@ -937,6 +938,7 @@ const AM2_PLANS: Record<string, Plan> = {
     budgetTerm: BUDGET_TERM,
     availableReservedBudgetTypes: AM2_AVAILABLE_RESERVED_BUDGET_TYPES,
     dashboardLimit: 10,
+    metricDetectorLimit: 20,
   },
   am2_team: {
     id: 'am2_team',
@@ -1665,6 +1667,7 @@ const AM2_PLANS: Record<string, Plan> = {
     budgetTerm: BUDGET_TERM,
     availableReservedBudgetTypes: AM2_AVAILABLE_RESERVED_BUDGET_TYPES,
     dashboardLimit: 20,
+    metricDetectorLimit: 20,
   },
   am2_t: {
     id: 'am2_t',
@@ -1761,6 +1764,7 @@ const AM2_PLANS: Record<string, Plan> = {
     budgetTerm: BUDGET_TERM,
     availableReservedBudgetTypes: AM2_AVAILABLE_RESERVED_BUDGET_TYPES,
     dashboardLimit: 20,
+    metricDetectorLimit: 20,
   },
   am2_team_auf: {
     id: 'am2_team_auf',
@@ -2452,6 +2456,7 @@ const AM2_PLANS: Record<string, Plan> = {
       ...SEER_TIERS_ANNUAL,
     },
     dashboardLimit: 20,
+    metricDetectorLimit: 20,
   },
   am2_business_auf: {
     id: 'am2_business_auf',
@@ -3143,6 +3148,7 @@ const AM2_PLANS: Record<string, Plan> = {
     },
     availableReservedBudgetTypes: AM2_AVAILABLE_RESERVED_BUDGET_TYPES,
     dashboardLimit: -1,
+    metricDetectorLimit: -1,
   },
   am2_sponsored: {
     // NOTE: being deprecated
@@ -3185,6 +3191,7 @@ const AM2_PLANS: Record<string, Plan> = {
     budgetTerm: BUDGET_TERM,
     availableReservedBudgetTypes: {},
     dashboardLimit: 20,
+    metricDetectorLimit: 20,
   },
   am2_sponsored_team_auf: {
     id: 'am2_sponsored_team_auf',
@@ -3226,6 +3233,7 @@ const AM2_PLANS: Record<string, Plan> = {
     budgetTerm: BUDGET_TERM,
     availableReservedBudgetTypes: {},
     dashboardLimit: 20,
+    metricDetectorLimit: 20,
   },
   am2_business_bundle: {
     id: 'am2_business_bundle',
@@ -3727,6 +3735,7 @@ const AM2_PLANS: Record<string, Plan> = {
     },
     availableReservedBudgetTypes: AM2_AVAILABLE_RESERVED_BUDGET_TYPES,
     dashboardLimit: -1,
+    metricDetectorLimit: -1,
   },
   am2_business_249_bundle: {
     id: 'am2_business_249_bundle',
@@ -4278,6 +4287,7 @@ const AM2_PLANS: Record<string, Plan> = {
     },
     availableReservedBudgetTypes: AM2_AVAILABLE_RESERVED_BUDGET_TYPES,
     dashboardLimit: -1,
+    metricDetectorLimit: -1,
   },
   am2_team_bundle: {
     id: 'am2_team_bundle',
@@ -4844,6 +4854,7 @@ const AM2_PLANS: Record<string, Plan> = {
     },
     availableReservedBudgetTypes: AM2_AVAILABLE_RESERVED_BUDGET_TYPES,
     dashboardLimit: 20,
+    metricDetectorLimit: 20,
   },
   am2_business_ent_auf: {
     id: 'am2_business_ent_auf',
@@ -4939,6 +4950,7 @@ const AM2_PLANS: Record<string, Plan> = {
     },
     availableReservedBudgetTypes: AM2_AVAILABLE_RESERVED_BUDGET_TYPES,
     dashboardLimit: -1,
+    metricDetectorLimit: -1,
   },
   am2_business_ent: {
     id: 'am2_business_ent',
@@ -5035,6 +5047,7 @@ const AM2_PLANS: Record<string, Plan> = {
     },
     availableReservedBudgetTypes: AM2_AVAILABLE_RESERVED_BUDGET_TYPES,
     dashboardLimit: -1,
+    metricDetectorLimit: -1,
   },
 };
 

--- a/tests/js/getsentry-test/fixtures/am3Plans.ts
+++ b/tests/js/getsentry-test/fixtures/am3Plans.ts
@@ -270,6 +270,7 @@ const AM3_PLANS: Record<string, Plan> = {
     hasOnDemandModes: false,
     budgetTerm: BUDGET_TERM,
     dashboardLimit: -1,
+    metricDetectorLimit: -1,
     planCategories: {
       errors: [
         {
@@ -1472,6 +1473,7 @@ const AM3_PLANS: Record<string, Plan> = {
     categoryDisplayNames: AM3_CATEGORY_DISPLAY_NAMES,
     availableReservedBudgetTypes: AM3_AVAILABLE_RESERVED_BUDGET_TYPES,
     dashboardLimit: -1,
+    metricDetectorLimit: -1,
   },
   am3_business_ent: {
     id: 'am3_business_ent',
@@ -1577,6 +1579,7 @@ const AM3_PLANS: Record<string, Plan> = {
     categoryDisplayNames: AM3_CATEGORY_DISPLAY_NAMES,
     availableReservedBudgetTypes: AM3_AVAILABLE_RESERVED_BUDGET_TYPES,
     dashboardLimit: -1,
+    metricDetectorLimit: -1,
   },
   am3_business_ent_auf: {
     id: 'am3_business_ent_auf',
@@ -1682,6 +1685,7 @@ const AM3_PLANS: Record<string, Plan> = {
     categoryDisplayNames: AM3_CATEGORY_DISPLAY_NAMES,
     availableReservedBudgetTypes: AM3_AVAILABLE_RESERVED_BUDGET_TYPES,
     dashboardLimit: -1,
+    metricDetectorLimit: -1,
   },
   am3_business_ent_ds: {
     id: 'am3_business_ent_ds',
@@ -1795,6 +1799,7 @@ const AM3_PLANS: Record<string, Plan> = {
     categoryDisplayNames: AM3_DS_CATEGORY_DISPLAY_NAMES,
     availableReservedBudgetTypes: AM3_DS_AVAILABLE_RESERVED_BUDGET_TYPES,
     dashboardLimit: -1,
+    metricDetectorLimit: -1,
   },
   am3_business_ent_ds_auf: {
     id: 'am3_business_ent_ds_auf',
@@ -1908,6 +1913,7 @@ const AM3_PLANS: Record<string, Plan> = {
     categoryDisplayNames: AM3_DS_CATEGORY_DISPLAY_NAMES,
     availableReservedBudgetTypes: AM3_DS_AVAILABLE_RESERVED_BUDGET_TYPES,
     dashboardLimit: -1,
+    metricDetectorLimit: -1,
   },
   am3_f: {
     id: 'am3_f',
@@ -2013,6 +2019,7 @@ const AM3_PLANS: Record<string, Plan> = {
     categoryDisplayNames: AM3_CATEGORY_DISPLAY_NAMES,
     availableReservedBudgetTypes: AM3_AVAILABLE_RESERVED_BUDGET_TYPES,
     dashboardLimit: 10,
+    metricDetectorLimit: 20,
   },
   am3_t_ent: {
     id: 'am3_t_ent',
@@ -2118,6 +2125,7 @@ const AM3_PLANS: Record<string, Plan> = {
     categoryDisplayNames: AM3_CATEGORY_DISPLAY_NAMES,
     availableReservedBudgetTypes: AM3_AVAILABLE_RESERVED_BUDGET_TYPES,
     dashboardLimit: 20,
+    metricDetectorLimit: 20,
   },
   am3_t_ent_ds: {
     id: 'am3_t_ent_ds',
@@ -2231,6 +2239,7 @@ const AM3_PLANS: Record<string, Plan> = {
     categoryDisplayNames: AM3_DS_CATEGORY_DISPLAY_NAMES,
     availableReservedBudgetTypes: AM3_DS_AVAILABLE_RESERVED_BUDGET_TYPES,
     dashboardLimit: 20,
+    metricDetectorLimit: 20,
   },
   am3_team: {
     id: 'am3_team',
@@ -2259,6 +2268,7 @@ const AM3_PLANS: Record<string, Plan> = {
     hasOnDemandModes: false,
     budgetTerm: BUDGET_TERM,
     dashboardLimit: 20,
+    metricDetectorLimit: 20,
     planCategories: {
       errors: [
         {
@@ -2766,6 +2776,7 @@ const AM3_PLANS: Record<string, Plan> = {
     hasOnDemandModes: false,
     budgetTerm: BUDGET_TERM,
     dashboardLimit: 20,
+    metricDetectorLimit: 20,
     planCategories: {
       errors: [
         {
@@ -3273,6 +3284,7 @@ const AM3_PLANS: Record<string, Plan> = {
     hasOnDemandModes: false,
     budgetTerm: BUDGET_TERM,
     dashboardLimit: 20,
+    metricDetectorLimit: 20,
     planCategories: {
       errors: [
         {

--- a/tests/js/getsentry-test/fixtures/mm1Plans.ts
+++ b/tests/js/getsentry-test/fixtures/mm1Plans.ts
@@ -56,6 +56,7 @@ const MM1_PLANS: Record<string, Plan> = {
     budgetTerm: BUDGET_TERM,
     availableReservedBudgetTypes: {},
     dashboardLimit: 0,
+    metricDetectorLimit: 0,
   },
   e1_auf: {
     isTestPlan: false,
@@ -101,6 +102,7 @@ const MM1_PLANS: Record<string, Plan> = {
     budgetTerm: BUDGET_TERM,
     availableReservedBudgetTypes: {},
     dashboardLimit: 0,
+    metricDetectorLimit: 0,
   },
   f1: {
     isTestPlan: false,
@@ -138,6 +140,7 @@ const MM1_PLANS: Record<string, Plan> = {
     budgetTerm: BUDGET_TERM,
     availableReservedBudgetTypes: {},
     dashboardLimit: 0,
+    metricDetectorLimit: 0,
   },
   l1: {
     isTestPlan: false,
@@ -185,6 +188,7 @@ const MM1_PLANS: Record<string, Plan> = {
     budgetTerm: BUDGET_TERM,
     availableReservedBudgetTypes: {},
     dashboardLimit: 0,
+    metricDetectorLimit: 0,
   },
   l1_ac: {
     isTestPlan: false,
@@ -232,6 +236,7 @@ const MM1_PLANS: Record<string, Plan> = {
     budgetTerm: BUDGET_TERM,
     availableReservedBudgetTypes: {},
     dashboardLimit: 0,
+    metricDetectorLimit: 0,
   },
   l1_auf: {
     isTestPlan: false,
@@ -279,6 +284,7 @@ const MM1_PLANS: Record<string, Plan> = {
     budgetTerm: BUDGET_TERM,
     availableReservedBudgetTypes: {},
     dashboardLimit: 0,
+    metricDetectorLimit: 0,
   },
   m1: {
     isTestPlan: false,
@@ -323,6 +329,7 @@ const MM1_PLANS: Record<string, Plan> = {
     budgetTerm: BUDGET_TERM,
     availableReservedBudgetTypes: {},
     dashboardLimit: 0,
+    metricDetectorLimit: 0,
   },
   m1_ac: {
     isTestPlan: false,
@@ -367,6 +374,7 @@ const MM1_PLANS: Record<string, Plan> = {
     budgetTerm: BUDGET_TERM,
     availableReservedBudgetTypes: {},
     dashboardLimit: 0,
+    metricDetectorLimit: 0,
   },
   m1_auf: {
     isTestPlan: false,
@@ -411,6 +419,7 @@ const MM1_PLANS: Record<string, Plan> = {
     budgetTerm: BUDGET_TERM,
     availableReservedBudgetTypes: {},
     dashboardLimit: 0,
+    metricDetectorLimit: 0,
   },
   s1: {
     isTestPlan: false,
@@ -453,6 +462,7 @@ const MM1_PLANS: Record<string, Plan> = {
     budgetTerm: BUDGET_TERM,
     availableReservedBudgetTypes: {},
     dashboardLimit: 0,
+    metricDetectorLimit: 0,
   },
   s1_ac: {
     isTestPlan: false,
@@ -495,6 +505,7 @@ const MM1_PLANS: Record<string, Plan> = {
     budgetTerm: BUDGET_TERM,
     availableReservedBudgetTypes: {},
     dashboardLimit: 0,
+    metricDetectorLimit: 0,
   },
 };
 

--- a/tests/js/getsentry-test/fixtures/mm2Plans.ts
+++ b/tests/js/getsentry-test/fixtures/mm2Plans.ts
@@ -67,6 +67,7 @@ const MM2_PLANS: Record<string, Plan> = {
     ],
     availableReservedBudgetTypes: {},
     dashboardLimit: 0,
+    metricDetectorLimit: 0,
   },
   mm2_a_100k_ac: {
     isTestPlan: false,
@@ -123,6 +124,7 @@ const MM2_PLANS: Record<string, Plan> = {
     ],
     availableReservedBudgetTypes: {},
     dashboardLimit: 0,
+    metricDetectorLimit: 0,
   },
   mm2_a_100k_auf: {
     isTestPlan: false,
@@ -179,6 +181,7 @@ const MM2_PLANS: Record<string, Plan> = {
     ],
     availableReservedBudgetTypes: {},
     dashboardLimit: 0,
+    metricDetectorLimit: 0,
   },
   mm2_a_500k: {
     isTestPlan: false,
@@ -235,6 +238,7 @@ const MM2_PLANS: Record<string, Plan> = {
     ],
     availableReservedBudgetTypes: {},
     dashboardLimit: 0,
+    metricDetectorLimit: 0,
   },
   mm2_a_500k_ac: {
     isTestPlan: false,
@@ -291,6 +295,7 @@ const MM2_PLANS: Record<string, Plan> = {
     ],
     availableReservedBudgetTypes: {},
     dashboardLimit: 0,
+    metricDetectorLimit: 0,
   },
   mm2_a_500k_auf: {
     isTestPlan: false,
@@ -347,6 +352,7 @@ const MM2_PLANS: Record<string, Plan> = {
     ],
     availableReservedBudgetTypes: {},
     dashboardLimit: 0,
+    metricDetectorLimit: 0,
   },
   mm2_b_100k: {
     isTestPlan: false,
@@ -393,6 +399,7 @@ const MM2_PLANS: Record<string, Plan> = {
     ],
     availableReservedBudgetTypes: {},
     dashboardLimit: 0,
+    metricDetectorLimit: 0,
   },
   mm2_b_100k_ac: {
     isTestPlan: false,
@@ -439,6 +446,7 @@ const MM2_PLANS: Record<string, Plan> = {
     ],
     availableReservedBudgetTypes: {},
     dashboardLimit: 0,
+    metricDetectorLimit: 0,
   },
   mm2_b_100k_auf: {
     isTestPlan: false,
@@ -485,6 +493,7 @@ const MM2_PLANS: Record<string, Plan> = {
     ],
     availableReservedBudgetTypes: {},
     dashboardLimit: 0,
+    metricDetectorLimit: 0,
   },
   mm2_b_500k: {
     isTestPlan: false,
@@ -532,6 +541,7 @@ const MM2_PLANS: Record<string, Plan> = {
     ],
     availableReservedBudgetTypes: {},
     dashboardLimit: 0,
+    metricDetectorLimit: 0,
   },
   mm2_b_500k_ac: {
     isTestPlan: false,
@@ -578,6 +588,7 @@ const MM2_PLANS: Record<string, Plan> = {
     ],
     availableReservedBudgetTypes: {},
     dashboardLimit: 0,
+    metricDetectorLimit: 0,
   },
   mm2_b_500k_auf: {
     isTestPlan: false,
@@ -624,6 +635,7 @@ const MM2_PLANS: Record<string, Plan> = {
     ],
     availableReservedBudgetTypes: {},
     dashboardLimit: 0,
+    metricDetectorLimit: 0,
   },
   mm2_f: {
     isTestPlan: false,
@@ -661,6 +673,7 @@ const MM2_PLANS: Record<string, Plan> = {
     features: ['advanced-search'],
     availableReservedBudgetTypes: {},
     dashboardLimit: 0,
+    metricDetectorLimit: 0,
   },
   mm2_a: {
     id: 'mm2_a',
@@ -723,6 +736,7 @@ const MM2_PLANS: Record<string, Plan> = {
     budgetTerm: BUDGET_TERM,
     availableReservedBudgetTypes: {},
     dashboardLimit: 0,
+    metricDetectorLimit: 0,
   },
 };
 


### PR DESCRIPTION
When the `workflow-engine-metric-detector-limit` flag is on and the subscription metric detector limit is exceeded, will disable creation of new ones.

<img width="2170" height="1714" alt="CleanShot 2025-08-15 at 13 16 16@2x" src="https://github.com/user-attachments/assets/3794d142-055b-49bd-a3d2-d180ede178ea" />
