### PR TITLE
bug(preprod): Fix CommitComparison creation

### DIFF
--- a/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
+++ b/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
@@ -147,6 +147,14 @@ class ProjectPreprodArtifactAssembleEndpoint(ProjectEndpoint):
                 checksum=checksum,
                 build_configuration=data.get("build_configuration"),
                 release_notes=data.get("release_notes"),
+                head_sha=data.get("head_sha"),
+                base_sha=data.get("base_sha"),
+                provider=data.get("provider"),
+                head_repo_name=data.get("head_repo_name"),
+                base_repo_name=data.get("base_repo_name"),
+                head_ref=data.get("head_ref"),
+                base_ref=data.get("base_ref"),
+                pr_number=data.get("pr_number"),
             )
 
             if artifact_id is None:
@@ -165,15 +173,6 @@ class ProjectPreprodArtifactAssembleEndpoint(ProjectEndpoint):
                     "chunks": chunks,
                     "artifact_id": artifact_id,
                     "build_configuration": data.get("build_configuration"),
-                    # VCS parameters
-                    "head_sha": data.get("head_sha"),
-                    "base_sha": data.get("base_sha"),
-                    "provider": data.get("provider"),
-                    "head_repo_name": data.get("head_repo_name"),
-                    "base_repo_name": data.get("base_repo_name"),
-                    "head_ref": data.get("head_ref"),
-                    "base_ref": data.get("base_ref"),
-                    "pr_number": data.get("pr_number"),
                 }
             )
             if is_org_auth_token_auth(request.auth):

--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -105,14 +105,7 @@ def assemble_preprod_artifact(
             project_id=project_id,
             organization_id=org_id,
             artifact_id=artifact_id,
-            head_sha=kwargs.get("head_sha"),
-            base_sha=kwargs.get("base_sha"),
-            provider=kwargs.get("provider"),
-            head_repo_name=kwargs.get("head_repo_name"),
-            base_repo_name=kwargs.get("base_repo_name"),
-            head_ref=kwargs.get("head_ref"),
-            base_ref=kwargs.get("base_ref"),
-            pr_number=kwargs.get("pr_number"),
+            **kwargs,
         )
 
     except Exception as e:

--- a/tests/sentry/preprod/api/endpoints/test_organization_preprod_artifact_assemble.py
+++ b/tests/sentry/preprod/api/endpoints/test_organization_preprod_artifact_assemble.py
@@ -373,6 +373,14 @@ class ProjectPreprodArtifactAssembleTest(APITestCase):
             checksum=total_checksum,
             build_configuration=None,
             release_notes=None,
+            head_sha=None,
+            base_sha=None,
+            provider=None,
+            head_repo_name=None,
+            base_repo_name=None,
+            head_ref=None,
+            base_ref=None,
+            pr_number=None,
         )
 
         mock_assemble_preprod_artifact.apply_async.assert_called_once_with(
@@ -383,14 +391,6 @@ class ProjectPreprodArtifactAssembleTest(APITestCase):
                 "chunks": [blob.checksum],
                 "artifact_id": artifact_id,
                 "build_configuration": None,
-                "head_sha": None,
-                "base_sha": None,
-                "provider": None,
-                "head_repo_name": None,
-                "base_repo_name": None,
-                "head_ref": None,
-                "base_ref": None,
-                "pr_number": None,
             }
         )
 
@@ -443,6 +443,14 @@ class ProjectPreprodArtifactAssembleTest(APITestCase):
             checksum=total_checksum,
             build_configuration="release",
             release_notes=None,
+            head_sha="e" * 40,
+            base_sha="f" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+            head_ref="feature/xyz",
+            base_ref="main",
+            pr_number=123,
         )
 
         mock_assemble_preprod_artifact.apply_async.assert_called_once_with(
@@ -453,14 +461,6 @@ class ProjectPreprodArtifactAssembleTest(APITestCase):
                 "chunks": [blob.checksum],
                 "artifact_id": artifact_id,
                 "build_configuration": "release",
-                "head_sha": "e" * 40,
-                "base_sha": "f" * 40,
-                "provider": "github",
-                "head_repo_name": "owner/repo",
-                "base_repo_name": "owner/repo",
-                "head_ref": "feature/xyz",
-                "base_ref": "main",
-                "pr_number": 123,
             }
         )
 
@@ -729,4 +729,12 @@ class ProjectPreprodArtifactAssembleTest(APITestCase):
             checksum=total_checksum,
             build_configuration=None,
             release_notes=None,
+            head_sha=None,
+            base_sha=None,
+            provider=None,
+            head_repo_name=None,
+            base_repo_name=None,
+            head_ref=None,
+            base_ref=None,
+            pr_number=None,
         )


### PR DESCRIPTION
Passes the arguments to the correct function now when creating the artifact.  I believe this got messed up with much of the recent churn when updating the assemble endpoint to no longer be a polling endpoint.