### PR TITLE
:mag: nit(aci): reduce action trigger log length

### DIFF
--- a/src/sentry/workflow_engine/models/action.py
+++ b/src/sentry/workflow_engine/models/action.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import builtins
 import logging
-from dataclasses import asdict
 from enum import StrEnum
 from typing import TYPE_CHECKING
 
@@ -111,7 +110,6 @@ class Action(DefaultFieldsModel, JSONConfigBase):
             extra={
                 "detector_id": detector.id,
                 "action_id": self.id,
-                "event_data": asdict(event_data),
             },
         )
 


### PR DESCRIPTION
at this point, we should already have the context for why this action was triggered by logs in `process_workflows` and `delayed_workflows` so we don't need to emit event_data again.

inspired by https://github.com/getsentry/sentry/pull/97957