### PR TITLE
perf(rules): Don't load a Team to check for a team_id

### DIFF
--- a/src/sentry/rules/filters/assigned_to.py
+++ b/src/sentry/rules/filters/assigned_to.py
@@ -43,7 +43,7 @@ class AssignedToFilter(EventFilter):
 
             if target_type == AssigneeTargetType.TEAM:
                 for assignee in self.get_assignees(event.group):
-                    if assignee.team and assignee.team_id == target_id:
+                    if assignee.team_id and assignee.team_id == target_id:
                         return True
             elif target_type == AssigneeTargetType.MEMBER:
                 for assignee in self.get_assignees(event.group):


### PR DESCRIPTION
Checking `assignee.team` results in the team being loaded when there is a team; instead, we check team_id which also works and doesn't trigger a new query.

This a backport of a performance fix from workflows engine to fix a commonly flagged N+1 issue.