### PR TITLE
ref(commit-context): Remove fallback to release-based suspect commits

### DIFF
--- a/src/sentry/integrations/utils/commit_context.py
+++ b/src/sentry/integrations/utils/commit_context.py
@@ -48,6 +48,7 @@ def find_commit_context_for_event_all_frames(
     """
     Given a list of event frames and code mappings, finds the most recent commit.
     Will also emit analytics events for success or failure.
+    This is the logic behind SuspectCommitStrategy.SCM_BASED
     """
     valid_frames = list(
         OrderedSet(

--- a/src/sentry/tasks/groupowner.py
+++ b/src/sentry/tasks/groupowner.py
@@ -42,6 +42,9 @@ def _process_suspect_commits(
     sdk_name=None,
     **kwargs,
 ):
+    """
+    This is the logic behind SuspectCommitStrategy.RELEASE_BASED
+    """
     metrics.incr("sentry.tasks.process_suspect_commits.start")
     set_current_event_project(project_id)
 
@@ -209,6 +212,9 @@ def process_suspect_commits(
     sdk_name=None,
     **kwargs,
 ):
+    """
+    This is the task behind SuspectCommitStrategy.RELEASE_BASED
+    """
     lock = locks.get(
         f"process-suspect-commits:{group_id}", duration=10, name="process_suspect_commits"
     )

--- a/tests/sentry/tasks/test_commit_context.py
+++ b/tests/sentry/tasks/test_commit_context.py
@@ -527,8 +527,7 @@ class TestCommitContextAllFrames(TestCommitContextIntegration):
         self, mock_get_commit_context, mock_record, mock_process_suspect_commits
     ):
         """
-        A simple failure case where the event has no in app frames, so we bail out
-        and fall back to the release-based suspect commits.
+        A simple failure case where the event has no in app frames, so we bail out.
         """
         self.event_with_no_inapp_frames = self.store_event(
             data={
@@ -575,14 +574,7 @@ class TestCommitContextAllFrames(TestCommitContextIntegration):
 
         assert not mock_get_commit_context.called
         assert not GroupOwner.objects.filter(group=self.event.group).exists()
-        mock_process_suspect_commits.assert_called_once_with(
-            event_id=self.event.event_id,
-            event_platform=self.event.platform,
-            event_frames=event_frames,
-            group_id=self.event.group_id,
-            project_id=self.event.project_id,
-            sdk_name="sentry.python",
-        )
+        mock_process_suspect_commits.assert_not_called()
 
         assert_any_analytics_event(
             mock_record,
@@ -607,8 +599,7 @@ class TestCommitContextAllFrames(TestCommitContextIntegration):
         self, mock_get_commit_context, mock_record, mock_process_suspect_commits, mock_logger_info
     ):
         """
-        A simple failure case where no blames are returned. We bail out and fall back
-        to the release-based suspect commits.
+        A simple failure case where no blames are returned. We bail out.
         """
         mock_get_commit_context.return_value = []
         with self.tasks():
@@ -624,14 +615,7 @@ class TestCommitContextAllFrames(TestCommitContextIntegration):
             )
 
         assert not GroupOwner.objects.filter(group=self.event.group).exists()
-        mock_process_suspect_commits.assert_called_once_with(
-            event_id=self.event.event_id,
-            event_platform=self.event.platform,
-            event_frames=event_frames,
-            group_id=self.event.group_id,
-            project_id=self.event.project_id,
-            sdk_name="sentry.python",
-        )
+        mock_process_suspect_commits.assert_not_called()
 
         assert_any_analytics_event(
             mock_record,
@@ -668,8 +652,7 @@ class TestCommitContextAllFrames(TestCommitContextIntegration):
         self, mock_get_commit_context, mock_record, mock_process_suspect_commits, mock_logger_info
     ):
         """
-        A failure case where the only blame returned is past the time threshold. We bail out and fall back
-        to the release-based suspect commits.
+        A failure case where the only blame returned is past the time threshold. We bail out.
         """
         mock_get_commit_context.return_value = [self.blame_too_old]
         with self.tasks():
@@ -685,14 +668,7 @@ class TestCommitContextAllFrames(TestCommitContextIntegration):
             )
 
         assert not GroupOwner.objects.filter(group=self.event.group).exists()
-        mock_process_suspect_commits.assert_called_once_with(
-            event_id=self.event.event_id,
-            event_platform=self.event.platform,
-            event_frames=event_frames,
-            group_id=self.event.group_id,
-            project_id=self.event.project_id,
-            sdk_name="sentry.python",
-        )
+        mock_process_suspect_commits.assert_not_called()
 
         assert_any_analytics_event(
             mock_record,
@@ -757,7 +733,7 @@ class TestCommitContextAllFrames(TestCommitContextIntegration):
     ):
         """
         A failure case where the integration hits an a 404 error.
-        This type of failure should immediately fall back to the release-based suspesct commits.
+        This type of failure should immediately bail.
         """
         with self.tasks():
             assert not GroupOwner.objects.filter(group=self.event.group).exists()
@@ -772,7 +748,7 @@ class TestCommitContextAllFrames(TestCommitContextIntegration):
             )
 
         assert not GroupOwner.objects.filter(group=self.event.group).exists()
-        mock_process_suspect_commits.assert_called_once()
+        mock_process_suspect_commits.assert_not_called()
 
     @patch("celery.app.task.Task.request")
     @patch("sentry.tasks.groupowner.process_suspect_commits.delay")
@@ -780,12 +756,12 @@ class TestCommitContextAllFrames(TestCommitContextIntegration):
         "sentry.integrations.github.integration.GitHubIntegration.get_commit_context_all_frames",
         side_effect=ApiError("Unknown API error"),
     )
-    def test_falls_back_on_max_retries(
+    def test_no_fall_back_on_max_retries(
         self, mock_get_commit_context, mock_process_suspect_commits, mock_request
     ):
         """
         A failure case where the integration hits an unknown API error a fifth time.
-        After 5 retries, the task should fall back to the release-based suspect commits.
+        After 5 retries, the task should bail.
         """
         mock_request.called_directly = False
         mock_request.retries = 5
@@ -804,7 +780,7 @@ class TestCommitContextAllFrames(TestCommitContextIntegration):
             )
 
         assert not GroupOwner.objects.filter(group=self.event.group).exists()
-        mock_process_suspect_commits.assert_called_once()
+        mock_process_suspect_commits.assert_not_called()
 
     @patch("sentry.integrations.utils.commit_context.logger.exception")
     @patch("sentry.tasks.groupowner.process_suspect_commits.delay")
@@ -820,7 +796,7 @@ class TestCommitContextAllFrames(TestCommitContextIntegration):
     ):
         """
         A failure case where the integration returned an API error.
-        The error should be recorded and we should fall back to the release-based suspect commits.
+        The error should be recorded.
         """
         with self.tasks():
             assert not GroupOwner.objects.filter(group=self.event.group).exists()
@@ -835,14 +811,7 @@ class TestCommitContextAllFrames(TestCommitContextIntegration):
             )
 
         assert not GroupOwner.objects.filter(group=self.event.group).exists()
-        mock_process_suspect_commits.assert_called_once_with(
-            event_id=self.event.event_id,
-            event_platform=self.event.platform,
-            event_frames=event_frames,
-            group_id=self.event.group_id,
-            project_id=self.event.project_id,
-            sdk_name="sentry.python",
-        )
+        mock_process_suspect_commits.assert_not_called()
 
         mock_logger_exception.assert_any_call(
             "process_commit_context_all_frames.get_commit_context_all_frames.unknown_error",


### PR DESCRIPTION
 ## Summary
  Removes the automatic fallback from SCM-based suspect commit detection to release-based logic when SCM detection fails.

  Previously, when `process_commit_context` failed to find blame information (no in-app frames, API errors, no commits found), it would automatically queue `process_suspect_commits` as a fallback. This change removes that fallback behavior as part of the suspect commit improvement project. We want fewer but better suspect commits.

  ## Changes
  - Remove calls to `process_suspect_commits.delay()` from `process_commit_context`
  - Clean up docstrings
  - Clean up verbose logging that's no longer needed

  ## Motivation
  This change separates the two suspect commit strategies (SCM_BASED and RELEASE_BASED), and reduces RELEASE_BASED suspect commit assignments.

  ticket: ID-876