### PR TITLE
ref(issue detection): adjust suspect commit time threshold

### DIFF
--- a/src/sentry/integrations/utils/commit_context.py
+++ b/src/sentry/integrations/utils/commit_context.py
@@ -79,10 +79,11 @@ def find_commit_context_for_event_all_frames(
     )
 
     most_recent_blame = max(file_blames, key=lambda blame: blame.commit.committedDate, default=None)
-    # Only return suspect commits that are less than a year old
+    # Only return suspect commits that are less than 2 months old
     selected_blame = (
         most_recent_blame
-        if most_recent_blame and is_date_less_than_year(most_recent_blame.commit.committedDate)
+        if most_recent_blame
+        and is_date_less_than_two_months(most_recent_blame.commit.committedDate)
         else None
     )
 
@@ -109,8 +110,8 @@ def find_commit_context_for_event_all_frames(
     return (selected_blame, selected_install)
 
 
-def is_date_less_than_year(date: datetime) -> bool:
-    return date > datetime.now(tz=timezone.utc) - timedelta(days=365)
+def is_date_less_than_two_months(date: datetime) -> bool:
+    return date > datetime.now(tz=timezone.utc) - timedelta(days=60)
 
 
 def get_or_create_commit_from_blame(

--- a/tests/sentry/tasks/test_commit_context.py
+++ b/tests/sentry/tasks/test_commit_context.py
@@ -132,7 +132,7 @@ class TestCommitContextAllFrames(TestCommitContextIntegration):
             lineno=30,
             commit=CommitInfo(
                 commitId="commit-id-old",
-                committedDate=datetime.now(tz=datetime_timezone.utc) - timedelta(days=370),
+                committedDate=datetime.now(tz=datetime_timezone.utc) - timedelta(days=62),
                 commitMessage="old commit message",
                 commitAuthorName=None,
                 commitAuthorEmail="old@localhost",
@@ -668,7 +668,7 @@ class TestCommitContextAllFrames(TestCommitContextIntegration):
         self, mock_get_commit_context, mock_record, mock_process_suspect_commits, mock_logger_info
     ):
         """
-        A simple failure case where no blames are returned. We bail out and fall back
+        A failure case where the only blame returned is past the time threshold. We bail out and fall back
         to the release-based suspect commits.
         """
         mock_get_commit_context.return_value = [self.blame_too_old]


### PR DESCRIPTION
as part of the Suspect Commits Improvement Project, we are narrowing the time threshold for commits.

before: any commit from the last year could be the suspect commit for an issue

after: any commit _from the last 2 months_ could be the suspect commit for an issue. Commits older than that will not be eligible to be named the suspect commit for the issue - so code that is more than 2 months old is not able to be "blamed".

ID-877
