### PR TITLE
ref(feedback): emit metric instead of outcome for ingest denylist

### DIFF
--- a/src/sentry/feedback/lib/utils.py
+++ b/src/sentry/feedback/lib/utils.py
@@ -37,4 +37,5 @@ class FeedbackCreationSource(Enum):
 
 
 def is_in_feedback_denylist(organization):
+    # Note option queries are cached.
     return organization.slug in options.get("feedback.organizations.slug-denylist")

--- a/src/sentry/feedback/lib/utils.py
+++ b/src/sentry/feedback/lib/utils.py
@@ -37,5 +37,4 @@ class FeedbackCreationSource(Enum):
 
 
 def is_in_feedback_denylist(organization):
-    # Note option queries are cached.
     return organization.slug in options.get("feedback.organizations.slug-denylist")

--- a/src/sentry/feedback/usecases/ingest/shim_to_feedback.py
+++ b/src/sentry/feedback/usecases/ingest/shim_to_feedback.py
@@ -1,17 +1,14 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime
 from typing import Any
 
-from sentry.constants import DataCategory
 from sentry.feedback.lib.types import UserReportDict
 from sentry.feedback.lib.utils import FeedbackCreationSource, is_in_feedback_denylist
 from sentry.feedback.usecases.ingest.create_feedback import create_feedback_issue
 from sentry.models.project import Project
 from sentry.services.eventstore.models import Event, GroupEvent
 from sentry.utils import metrics
-from sentry.utils.outcomes import Outcome, track_outcome
 from sentry.utils.safe import get_path
 
 logger = logging.getLogger(__name__)
@@ -31,17 +28,7 @@ def shim_to_feedback(
     legacy user report and event to create the new feedback.
     """
     if is_in_feedback_denylist(project.organization):
-        track_outcome(
-            org_id=project.organization_id,
-            project_id=project.id,
-            key_id=None,
-            outcome=Outcome.RATE_LIMITED,
-            reason="feedback_denylist",
-            timestamp=datetime.fromisoformat(event.timestamp),
-            event_id=event.event_id,
-            category=DataCategory.USER_REPORT_V2,
-            quantity=1,
-        )
+        metrics.incr("feedback.ingest.denylist")
         return
 
     try:

--- a/src/sentry/feedback/usecases/ingest/userreport.py
+++ b/src/sentry/feedback/usecases/ingest/userreport.py
@@ -49,17 +49,8 @@ def save_userreport(
                 "user_report.create_user_report.filtered",
                 tags={"reason": "org.denylist", "referrer": source.value},
             )
-            track_outcome(
-                org_id=project.organization_id,
-                project_id=project.id,
-                key_id=None,
-                outcome=Outcome.RATE_LIMITED,
-                reason="feedback_denylist",
-                timestamp=start_time,
-                event_id=None,  # Note report["event_id"] is id of the associated event, not the report itself.
-                category=DataCategory.USER_REPORT_V2,
-                quantity=1,
-            )
+            metrics.incr("feedback.ingest.denylist")
+
             if (
                 source == FeedbackCreationSource.USER_REPORT_DJANGO_ENDPOINT
                 or source == FeedbackCreationSource.CRASH_REPORT_EMBED_FORM

--- a/src/sentry/ingest/consumer/processors.py
+++ b/src/sentry/ingest/consumer/processors.py
@@ -277,7 +277,7 @@ def process_event(
                     project_id=project_id,
                 )
             else:
-                metrics.incr("feedback.ingest.filtered", tags={"reason": "org.denylist"})
+                metrics.incr("feedback.ingest.denylist")
         else:
             # Preprocess this event, which spawns either process_event or
             # save_event. Pass data explicitly to avoid fetching it again from the

--- a/src/sentry/tasks/update_user_reports.py
+++ b/src/sentry/tasks/update_user_reports.py
@@ -118,6 +118,9 @@ def update_user_reports(
                             project,
                             FeedbackCreationSource.UPDATE_USER_REPORTS_TASK,
                         )
+                    else:
+                        metrics.incr("feedback.ingest.denylist")
+
                 # XXX(aliu): If a report has environment_id but not group_id, this report was shimmed from a feedback issue, so no need to shim again.
                 report.update(group_id=event.group_id, environment_id=event.get_environment().id)
                 updated_reports += 1


### PR DESCRIPTION
We don't want to emit a rate limited outcome for feedback manually filtered by the denylist. This inflates the count of fb that's actually rate limited by Relay abuse quotas. Instead we'll use a metric to check how much use this denylist is still getting.