### PR TITLE
feat(issue detection): Add time-based commit filtering for suspect commit detection

### DIFF
--- a/src/sentry/integrations/utils/commit_context.py
+++ b/src/sentry/integrations/utils/commit_context.py
@@ -83,23 +83,15 @@ def find_commit_context_for_event_all_frames(
         extra=extra,
     )
 
-    # Sort blames by commit date (most recent first)
-    sorted_blames = sorted(file_blames, key=lambda blame: blame.commit.committedDate, reverse=True)
-
+    # We want the most recent commit that is within MAX_COMMIT_AGE_DAYS of group_first_seen
+    earliest_valid_date = group_first_seen - timedelta(days=MAX_COMMIT_AGE_DAYS)
     selected_blame = None
-    for blame in sorted_blames:
+    selected_date = earliest_valid_date
+    for blame in file_blames:
         commit_date = blame.commit.committedDate
-
-        if is_too_young(group_first_seen, commit_date):
-            # Skip commits that happened after the issue was first seen
-            continue
-        elif is_too_old(group_first_seen, commit_date):
-            # Stop checking - all remaining commits will be even older
-            break
-        else:
-            # Found a valid commit within the time window
+        if selected_date < commit_date < group_first_seen:
             selected_blame = blame
-            break
+            selected_date = commit_date
 
     selected_install, selected_provider = (
         integration_to_install_mapping[selected_blame.code_mapping.organization_integration_id]
@@ -109,7 +101,7 @@ def find_commit_context_for_event_all_frames(
 
     _record_commit_context_all_frames_analytics(
         selected_blame=selected_blame,
-        most_recent_blame=sorted_blames[0] if sorted_blames else None,
+        most_recent_blame=None,
         organization_id=organization_id,
         project_id=project_id,
         extra=extra,
@@ -122,25 +114,6 @@ def find_commit_context_for_event_all_frames(
     )
 
     return (selected_blame, selected_install)
-
-
-def is_too_young(group_first_seen: datetime, commit_date: datetime) -> bool:
-    """
-    Returns True if the commit happened after the issue was first seen.
-    These commits cannot have caused the issue.
-    """
-    return commit_date > group_first_seen
-
-
-def is_too_old(
-    group_first_seen: datetime, commit_date: datetime, max_age_days: int = MAX_COMMIT_AGE_DAYS
-) -> bool:
-    """
-    Returns True if the commit is too old to be considered relevant.
-    Commits older than max_age_days before the issue was first seen are ignored.
-    """
-    time_threshold = group_first_seen - timedelta(days=max_age_days)
-    return commit_date < time_threshold
 
 
 def get_or_create_commit_from_blame(

--- a/src/sentry/tasks/commit_context.py
+++ b/src/sentry/tasks/commit_context.py
@@ -25,6 +25,7 @@ from sentry.issues.auto_source_code_config.code_mapping import get_sorted_code_m
 from sentry.locks import locks
 from sentry.models.commit import Commit
 from sentry.models.commitauthor import CommitAuthor
+from sentry.models.group import Group
 from sentry.models.groupowner import GroupOwner, GroupOwnerType, SuspectCommitStrategy
 from sentry.models.project import Project
 from sentry.models.projectownership import ProjectOwnership
@@ -92,6 +93,7 @@ def process_commit_context(
             set_current_event_project(project_id)
 
             project = Project.objects.get_from_cache(id=project_id)
+            group = Group.objects.get_from_cache(id=group_id)
             set_tag("organization.slug", project.organization.slug)
             basic_logging_details = {
                 "event": event_id,
@@ -135,6 +137,7 @@ def process_commit_context(
                     project_id=project_id,
                     platform=event_platform,
                     sdk_name=sdk_name,
+                    group_first_seen=group.first_seen,
                     extra=basic_logging_details,
                 )
             except ApiError:

--- a/tests/sentry/tasks/test_commit_context.py
+++ b/tests/sentry/tasks/test_commit_context.py
@@ -741,8 +741,7 @@ class TestCommitContextAllFrames(TestCommitContextIntegration):
                         )
 
                 # Assert GroupOwner existence
-                group_owners = GroupOwner.objects.filter(group=self.event.group)
-                actual_exists = group_owners.exists()
+                actual_exists = GroupOwner.objects.filter(group=self.event.group).exists()
                 self.assertEqual(
                     actual_exists,
                     expected_group_owner_exists,
@@ -752,7 +751,7 @@ class TestCommitContextAllFrames(TestCommitContextIntegration):
                 # Assert correct commit selected
                 if expected_group_owner_exists and expected_commit_id:
                     created_commit = Commit.objects.get(key=expected_commit_id)
-                    group_owner = group_owners.first()
+                    group_owner = GroupOwner.objects.get(group=self.event.group)
                     self.assertEqual(
                         group_owner.context["commitId"],
                         created_commit.id,

--- a/tests/sentry/tasks/test_commit_context.py
+++ b/tests/sentry/tasks/test_commit_context.py
@@ -626,7 +626,7 @@ class TestCommitContextAllFrames(TestCommitContextIntegration):
                 event_id=self.event.event_id,
                 num_frames=1,
                 num_successfully_mapped_frames=1,
-                reason="no_commit_found",
+                reason="no_commits_found",
             ),
         )
 
@@ -637,7 +637,7 @@ class TestCommitContextAllFrames(TestCommitContextIntegration):
                 "group": self.event.group_id,
                 "event": self.event.event_id,
                 "project_id": self.project.id,
-                "reason": "no_commit_found",
+                "reason": "no_commits_found",
                 "num_frames": 1,
             },
         )

--- a/tests/sentry/tasks/test_commit_context.py
+++ b/tests/sentry/tasks/test_commit_context.py
@@ -656,32 +656,30 @@ class TestCommitContextAllFrames(TestCommitContextIntegration):
         """
         # Test cases: each tuple contains (test_case_name, blames_setup, group_first_seen_days_ago, expected_group_owner_exists, expected_commit_id)
         test_cases = [
-            # All commits too young
-            ("all_commits_too_young", ["blame_recent"], 3, False, None),
-            # Early exit on too old
-            ("early_exit_too_old", ["blame_too_old", "blame_existing_commit"], 10, False, None),
-            # All outside threshold
-            ("mixed_young_then_old", ["blame_recent", "blame_too_old"], 10, False, None),
-            # Skip young, find valid
+            ("all_commits_too_young", ["blame_recent"], 3, False, None),  # All commits too young
+            (
+                "all_outside_range",
+                ["blame_recent", "blame_too_old"],
+                10,
+                False,
+                None,
+            ),  # All outside range
             (
                 "skip_young_find_valid",
                 ["blame_recent", "blame_existing_commit"],
                 5,
                 True,
                 "existing-commit",
-            ),
-            # All valid, picks most recent
+            ),  # Skip young, find valid
             (
                 "all_valid_picks_most_recent",
                 ["blame_existing_commit", "blame_no_existing_commit"],
                 5,
                 True,
                 "existing-commit",
-            ),
-            # All commits too old
-            ("only_old_commits", ["blame_too_old"], 10, False, None),
-            # Empty blames
-            ("empty_blames", [], 10, False, None),
+            ),  # All valid, picks most recent
+            ("only_old_commits", ["blame_too_old"], 10, False, None),  # All commits too old
+            ("empty_blames", [], 10, False, None),  # No blames
         ]
 
         existing_commit = self.create_commit(


### PR DESCRIPTION
  Replaces simple "most recent commit" selection with time-based filtering that:
  - Filters out commits that occurred _after_ the issue was first seen (too recent)
  - Filters out commits older than 60 days before the issue occurred (too old)
  - Selects the most recent valid commit within the time window
  - Time window is defined by `first_seen` on the Issue rather than time of assessment (`.now()`)