### PR TITLE
feat(replay): Show error level in Replay Details error table

### DIFF
--- a/static/app/views/replays/detail/errorList/errorFilters.tsx
+++ b/static/app/views/replays/detail/errorList/errorFilters.tsx
@@ -6,30 +6,41 @@ import type {ErrorFrame} from 'sentry/utils/replays/types';
 import type useErrorFilters from 'sentry/views/replays/detail/errorList/useErrorFilters';
 import FiltersGrid from 'sentry/views/replays/detail/filtersGrid';
 
-type Props = {
+interface Props extends ReturnType<typeof useErrorFilters> {
   errorFrames: undefined | ErrorFrame[];
-} & ReturnType<typeof useErrorFilters>;
+}
 
-function ErrorFilters({
-  getProjectOptions,
+export default function ErrorFilters({
   errorFrames,
+  getLevelOptions,
+  getProjectOptions,
   searchTerm,
   selectValue,
   setFilters,
   setSearchTerm,
 }: Props) {
   const projectOptions = getProjectOptions();
+  const levelOptions = getLevelOptions();
 
   return (
     <FiltersGrid>
       <CompactSelect
-        disabled={!projectOptions.length}
+        disabled={!projectOptions.length && !levelOptions.length}
         multiple
         onChange={setFilters as (selection: Array<SelectOption<string>>) => void}
-        options={projectOptions}
+        options={[
+          {
+            label: t('Project'),
+            options: projectOptions,
+          },
+          {
+            label: t('Level'),
+            options: levelOptions,
+          },
+        ]}
         size="sm"
         triggerLabel={selectValue?.length === 0 ? t('Any') : null}
-        triggerProps={{prefix: t('Project')}}
+        triggerProps={{prefix: t('Filter')}}
         value={selectValue}
       />
       <SearchBar
@@ -42,5 +53,3 @@ function ErrorFilters({
     </FiltersGrid>
   );
 }
-
-export default ErrorFilters;

--- a/static/app/views/replays/detail/errorList/errorHeaderCell.tsx
+++ b/static/app/views/replays/detail/errorList/errorHeaderCell.tsx
@@ -22,6 +22,7 @@ const COLUMNS: Array<{
   {field: 'id', label: t('Event ID')},
   {field: 'title', label: t('Title')},
   {field: 'project', label: t('Issue')},
+  {field: 'level', label: t('Level')},
   {field: 'timestamp', label: t('Timestamp')},
 ];
 

--- a/static/app/views/replays/detail/errorList/errorTableCell.tsx
+++ b/static/app/views/replays/detail/errorList/errorTableCell.tsx
@@ -36,7 +36,7 @@ interface Props extends ReturnType<typeof useCrumbHandlers> {
   ref?: React.Ref<HTMLDivElement>;
 }
 
-const ErrorTableCell = ({
+export default function ErrorTableCell({
   columnIndex,
   currentHoverTime,
   currentTime,
@@ -48,10 +48,10 @@ const ErrorTableCell = ({
   startTimestampMs,
   style,
   ref,
-}: Props) => {
+}: Props) {
   const organization = useOrganization();
 
-  const {eventId, groupId, groupShortId, projectSlug} = frame.data;
+  const {eventId, groupId, groupShortId, level, projectSlug} = frame.data;
   const title = frame.message;
   const {projects} = useProjects();
   const project = useMemo(
@@ -193,6 +193,17 @@ const ErrorTableCell = ({
       </Cell>
     ),
     () => (
+      <Cell {...columnProps} numeric align="flex-start">
+        {eventUrl ? (
+          <Link to={eventUrl}>
+            <Text>{level}</Text>
+          </Link>
+        ) : (
+          <Text>{level}</Text>
+        )}
+      </Cell>
+    ),
+    () => (
       <Cell {...columnProps} numeric>
         <ButtonWrapper>
           <TimestampButton
@@ -210,6 +221,4 @@ const ErrorTableCell = ({
   ];
 
   return renderFns[columnIndex]!();
-};
-
-export default ErrorTableCell;
+}

--- a/static/app/views/replays/detail/errorList/useErrorFilters.spec.tsx
+++ b/static/app/views/replays/detail/errorList/useErrorFilters.spec.tsx
@@ -31,6 +31,7 @@ const {
       'issue.id': 11,
       issue: 'JAVASCRIPT-RANGE',
       title: 'Invalid time value',
+      level: 'info',
       'project.name': 'javascript',
     }),
     RawReplayErrorFixture({
@@ -40,6 +41,7 @@ const {
       'issue.id': 22,
       issue: 'NEXTJS-TYPE',
       title: `undefined is not an object (evaluating 'e.apply').`,
+      level: 'error',
       'project.name': 'next-js',
     }),
     RawReplayErrorFixture({
@@ -49,6 +51,7 @@ const {
       'issue.id': 22,
       issue: 'JAVASCRIPT-UNDEF',
       title: `Maximum update depth exceeded`,
+      level: 'error',
       'project.name': 'javascript',
     }),
   ]
@@ -90,6 +93,7 @@ describe('useErrorFilters', () => {
       {
         pathname: '/',
         query: {
+          f_e_level: [],
           f_e_project: [PROJECT_OPTION.value],
         },
       },
@@ -152,6 +156,29 @@ describe('useErrorFilters', () => {
     ]);
   });
 
+  it('should filter by level', () => {
+    const errorFrames = [
+      ERROR_1_JS_RANGEERROR!,
+      ERROR_2_NEXTJS_TYPEERROR!,
+      ERROR_3_JS_UNDEFINED!,
+    ];
+
+    mockUseLocation.mockReturnValue({
+      pathname: '/',
+      query: {
+        f_e_level: ['error'],
+      },
+    } as Location<FilterFields>);
+
+    const {result} = renderHook(useErrorFilters, {
+      initialProps: {errorFrames},
+    });
+    expect(result.current.items).toStrictEqual([
+      ERROR_2_NEXTJS_TYPEERROR!,
+      ERROR_3_JS_UNDEFINED!,
+    ]);
+  });
+
   it('should filter by searchTerm', () => {
     const errorFrames = [
       ERROR_1_JS_RANGEERROR!,
@@ -203,6 +230,41 @@ describe('useErrorFilters', () => {
 
       expect(result.current.getProjectOptions()).toStrictEqual([
         {label: 'javascript', value: 'javascript', qs: 'f_e_project'},
+      ]);
+    });
+  });
+
+  describe('getLevelOptions', () => {
+    it('should default to having nothing in the list of method types', () => {
+      const {result} = renderHook(useErrorFilters, {
+        initialProps: {errorFrames: []},
+      });
+
+      expect(result.current.getLevelOptions()).toStrictEqual([]);
+    });
+
+    it('should return a sorted list of project slugs', () => {
+      const errorFrames = [ERROR_1_JS_RANGEERROR!, ERROR_3_JS_UNDEFINED!];
+
+      const {result} = renderHook(useErrorFilters, {
+        initialProps: {errorFrames},
+      });
+
+      expect(result.current.getLevelOptions()).toStrictEqual([
+        {label: 'Error', value: 'error', qs: 'f_e_level'},
+        {label: 'Info', value: 'info', qs: 'f_e_level'},
+      ]);
+    });
+
+    it('should deduplicate BreadcrumbType', () => {
+      const errorFrames = [ERROR_2_NEXTJS_TYPEERROR!, ERROR_3_JS_UNDEFINED!];
+
+      const {result} = renderHook(useErrorFilters, {
+        initialProps: {errorFrames},
+      });
+
+      expect(result.current.getLevelOptions()).toStrictEqual([
+        {label: 'Error', value: 'error', qs: 'f_e_level'},
       ]);
     });
   });

--- a/static/app/views/replays/detail/errorList/useErrorFilters.spec.tsx
+++ b/static/app/views/replays/detail/errorList/useErrorFilters.spec.tsx
@@ -208,7 +208,7 @@ describe('useErrorFilters', () => {
       expect(result.current.getProjectOptions()).toStrictEqual([]);
     });
 
-    it('should return a sorted list of project slugs', () => {
+    it('should return a sorted list of options', () => {
       const errorFrames = [ERROR_2_NEXTJS_TYPEERROR!, ERROR_3_JS_UNDEFINED!];
 
       const {result} = renderHook(useErrorFilters, {
@@ -221,13 +221,15 @@ describe('useErrorFilters', () => {
       ]);
     });
 
-    it('should deduplicate BreadcrumbType', () => {
+    it('should deduplicate ProjectOptions', () => {
       const errorFrames = [ERROR_1_JS_RANGEERROR!, ERROR_3_JS_UNDEFINED!];
 
       const {result} = renderHook(useErrorFilters, {
         initialProps: {errorFrames},
       });
 
+      // Given >1 errorFrames each with the same projectSlug, we should only
+      // have one option in the list.
       expect(result.current.getProjectOptions()).toStrictEqual([
         {label: 'javascript', value: 'javascript', qs: 'f_e_project'},
       ]);

--- a/static/app/views/replays/detail/errorList/useSortErrors.spec.tsx
+++ b/static/app/views/replays/detail/errorList/useSortErrors.spec.tsx
@@ -33,6 +33,7 @@ const {
       'issue.id': 11,
       issue: 'JAVASCRIPT-RANGE',
       title: 'Invalid time value',
+      level: 'warning',
       'project.name': 'javascript',
     }),
     RawReplayErrorFixture({
@@ -42,6 +43,7 @@ const {
       'issue.id': 22,
       issue: 'NEXTJS-TYPE',
       title: `undefined is not an object (evaluating 'e.apply').`,
+      level: 'error',
       'project.name': 'next-js',
     }),
     RawReplayErrorFixture({
@@ -51,6 +53,7 @@ const {
       'issue.id': 22,
       issue: 'JAVASCRIPT-UNDEF',
       title: `Maximum update depth exceeded`,
+      level: 'error',
       'project.name': 'javascript',
     }),
   ]

--- a/static/app/views/replays/detail/errorList/useSortErrors.tsx
+++ b/static/app/views/replays/detail/errorList/useSortErrors.tsx
@@ -6,6 +6,7 @@ import useUrlParams from 'sentry/utils/url/useUrlParams';
 
 const SortStrategies: Record<string, (row: ErrorFrame) => any> = {
   id: row => row.data.eventId,
+  level: row => row.data.level,
   title: row => row.message,
   project: row => row.data.projectSlug,
   timestamp: row => row.timestamp,


### PR DESCRIPTION
Related to REPLAY-616

This shows the 'level' column inside Replay Details > Error Table
The column is also sortable & filterable.

<img width="700" height="233" alt="SCR-20250816-jace" src="https://github.com/user-attachments/assets/09756274-5a39-4f15-b17c-eef3522b2fd0" />
