### PR TITLE
feat(integrations): Add POST endpoint for coding agent launch

### DIFF
--- a/src/sentry/integrations/api/endpoints/organization_coding_agents.py
+++ b/src/sentry/integrations/api/endpoints/organization_coding_agents.py
@@ -208,6 +208,7 @@ class OrganizationCodingAgentsEndpoint(OrganizationEndpoint):
         for solution_item in solution_step["solution"]:
             if (
                 solution_item["relevant_code_file"]
+                and "repo_name" in solution_item["relevant_code_file"]
                 and solution_item["relevant_code_file"]["repo_name"]
             ):
                 repos.add(solution_item["relevant_code_file"]["repo_name"])

--- a/src/sentry/integrations/api/endpoints/organization_coding_agents.py
+++ b/src/sentry/integrations/api/endpoints/organization_coding_agents.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
 import logging
+import secrets
+import string
 
+import orjson
+import requests
+from django.conf import settings
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -11,10 +16,93 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.constants import ObjectStatus
+from sentry.integrations.coding_agent.integration import CodingAgentIntegration
+from sentry.integrations.coding_agent.models import CodingAgentLaunchRequest
 from sentry.integrations.coding_agent.utils import get_coding_agent_providers
 from sentry.integrations.services.integration import integration_service
+from sentry.seer.autofix.utils import (
+    AutofixState,
+    CodingAgentState,
+    get_autofix_state,
+    get_coding_agent_prompt,
+)
+from sentry.seer.signed_seer_api import sign_with_seer_secret
+from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)
+
+
+VALID_BRANCH_NAME_CHARS = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-/"
+
+
+def sanitize_branch_name(branch_name: str) -> str:
+    """
+    Sanitize a branch name by taking the first 3 words, converting to lowercase,
+    removing/replacing special characters, and adding 6 unique random characters.
+
+    Args:
+        branch_name: The raw branch name to sanitize
+
+    Returns:
+        A sanitized branch name safe for use as a Git branch
+    """
+    # Take only the first 3 words
+    words = branch_name.strip().split()[:3]
+    truncated_name = " ".join(words)
+
+    kebab_case = truncated_name.replace(" ", "-").replace("_", "-").lower()
+    sanitized = "".join(c for c in kebab_case if c in VALID_BRANCH_NAME_CHARS)
+    sanitized = sanitized.rstrip("/")
+
+    # Generate 6 unique random characters (alphanumeric)
+    random_suffix = "".join(
+        secrets.choice(string.ascii_lowercase + string.digits) for _ in range(6)
+    )
+
+    # Combine sanitized name with random suffix
+    return f"{sanitized}-{random_suffix}" if sanitized else f"branch-{random_suffix}"
+
+
+def store_coding_agent_state_to_seer(run_id: int, coding_agent_state: CodingAgentState) -> bool:
+    """Store coding agent state via Seer API."""
+    try:
+        path = "/v1/automation/autofix/coding-agent/state"
+        body = orjson.dumps(
+            {
+                "run_id": run_id,
+                "coding_agent_state": coding_agent_state.dict(),
+            }
+        )
+
+        response = requests.post(
+            f"{settings.SEER_AUTOFIX_URL}{path}",
+            data=body,
+            headers={
+                "content-type": "application/json;charset=utf-8",
+                **sign_with_seer_secret(body),
+            },
+            timeout=30,
+        )
+
+        response.raise_for_status()
+        logger.info(
+            "coding_agent.state_stored_to_seer",
+            extra={
+                "run_id": run_id,
+                "status_code": response.status_code,
+            },
+        )
+        return True
+
+    except Exception as e:
+        logger.warning(
+            "coding_agent.seer_store_error",
+            extra={
+                "run_id": run_id,
+                "error": str(e),
+            },
+        )
+        return False
 
 
 @region_silo_endpoint
@@ -22,6 +110,7 @@ class OrganizationCodingAgentsEndpoint(OrganizationEndpoint):
     owner = ApiOwner.ML_AI
     publish_status = {
         "GET": ApiPublishStatus.EXPERIMENTAL,
+        "POST": ApiPublishStatus.EXPERIMENTAL,
     }
 
     def get(self, request: Request, organization) -> Response:
@@ -50,3 +139,254 @@ class OrganizationCodingAgentsEndpoint(OrganizationEndpoint):
         )
 
         return self.respond({"integrations": integrations_data})
+
+    def _validate_and_get_integration(self, request: Request, organization):
+        """Validate request and get the coding agent integration."""
+        integration_id = request.data.get("integration_id")
+        if not integration_id:
+            return Response({"error": "integration_id is required"}, status=400)
+
+        # Get the integration using hybrid cloud service
+        try:
+            integration_id_int = int(integration_id)
+        except (ValueError, TypeError):
+            return Response({"error": "Invalid integration_id"}, status=400)
+
+        org_integration = integration_service.get_organization_integration(
+            organization_id=organization.id,
+            integration_id=integration_id_int,
+        )
+
+        if not org_integration or org_integration.status != ObjectStatus.ACTIVE:
+            return Response({"error": "Integration not found"}, status=404)
+
+        integration = integration_service.get_integration(
+            organization_integration_id=org_integration.id,
+            status=ObjectStatus.ACTIVE,
+        )
+
+        if not integration:
+            return Response({"error": "Integration not found"}, status=404)
+
+        # Verify it's a coding agent integration
+        if integration.provider not in get_coding_agent_providers():
+            return Response({"error": "Not a coding agent integration"}, status=400)
+
+        # Get the installation
+        installation = integration.get_installation(organization.id)
+        if not isinstance(installation, CodingAgentIntegration):
+            return Response({"error": "Invalid coding agent integration"}, status=400)
+
+        return integration, installation
+
+    def _get_autofix_state(
+        self, request: Request, organization
+    ) -> tuple[int | None, AutofixState | None]:
+        """Extract and validate run_id and get autofix state."""
+        run_id_raw = request.data.get("run_id")
+
+        # Convert run_id to integer for autofix state lookup
+        try:
+            run_id = int(run_id_raw) if run_id_raw is not None else None
+        except (ValueError, TypeError):
+            return None, None
+
+        autofix_state = get_autofix_state(run_id=run_id)
+
+        if not autofix_state:
+            logger.warning(
+                "coding_agent.autofix_state_not_found",
+                extra={
+                    "organization_id": organization.id,
+                    "run_id": run_id,
+                },
+            )
+            return run_id, None
+
+        return run_id, autofix_state
+
+    def _extract_repos_from_solution(self, autofix_state: AutofixState) -> set[str]:
+        """Extract repository names from autofix state solution."""
+        repos = set()
+        solution_step = next(step for step in autofix_state.steps if step["key"] == "solution")
+
+        for solution_item in solution_step["solution"]:
+            if (
+                solution_item["relevant_code_file"]
+                and solution_item["relevant_code_file"]["repo_name"]
+            ):
+                repos.add(solution_item["relevant_code_file"]["repo_name"])
+
+        return repos
+
+    def _launch_agents_for_repos(
+        self,
+        installation: CodingAgentIntegration,
+        autofix_state: AutofixState,
+        run_id: int,
+        organization,
+        trigger_source: str,
+    ) -> list[dict]:
+        """Launch coding agents for all repositories in the solution."""
+        repos = self._extract_repos_from_solution(autofix_state)
+
+        results = []
+
+        for repo_name in repos:
+            try:
+                repo = next(
+                    (
+                        repo
+                        for repo in autofix_state.request["repos"]
+                        if f"{repo['owner']}/{repo['name']}" == repo_name
+                    ),
+                    None,
+                )
+                if not repo:
+                    logger.error(
+                        "coding_agent.repo_not_found",
+                        extra={
+                            "organization_id": organization.id,
+                            "run_id": run_id,
+                            "repo_name": repo_name,
+                        },
+                    )
+                    # Continue with other repos instead of failing entirely
+                    continue
+                prompt = get_coding_agent_prompt(run_id, trigger_source)
+
+                if not prompt:
+                    logger.warning(
+                        "coding_agent.prompt_not_available",
+                        extra={
+                            "organization_id": organization.id,
+                            "run_id": run_id,
+                            "repo_name": repo_name,
+                            "trigger_source": trigger_source,
+                        },
+                    )
+                    continue
+
+                launch_request = CodingAgentLaunchRequest(
+                    prompt=prompt,
+                    repository=repo,
+                    branch_name=sanitize_branch_name(autofix_state.request["issue"]["title"]),
+                )
+
+                # Launch the agent
+                coding_agent_state = installation.launch(launch_request)
+
+                # Store the coding agent state to Seer
+                repo_store_success = store_coding_agent_state_to_seer(
+                    run_id=run_id,
+                    coding_agent_state=coding_agent_state,
+                )
+
+                if not repo_store_success:
+                    logger.warning(
+                        "coding_agent.seer_store_failed",
+                        extra={
+                            "organization_id": organization.id,
+                            "run_id": run_id,
+                            "repo_name": repo_name,
+                        },
+                    )
+
+                results.append(
+                    {
+                        "repo_name": repo_name,
+                        "coding_agent_state": coding_agent_state,
+                    }
+                )
+
+            except Exception as e:
+                logger.exception(
+                    "coding_agent.repo_launch_error",
+                    extra={
+                        "organization_id": organization.id,
+                        "run_id": run_id,
+                        "repo_name": repo_name,
+                        "error": str(e),
+                    },
+                )
+                # Continue with other repos instead of failing entirely
+                continue
+
+        return results
+
+    def post(self, request: Request, organization) -> Response:
+        """Launch a coding agent."""
+        if not features.has("organizations:seer-coding-agent-integrations", organization):
+            return Response({"detail": "Feature not available"}, status=404)
+
+        try:
+            # Validate request and get integration
+            validation_result = self._validate_and_get_integration(request, organization)
+            if isinstance(validation_result, Response):
+                return validation_result
+            integration, installation = validation_result
+
+            # Get autofix state
+            run_id, autofix_state = self._get_autofix_state(request, organization)
+            if run_id is None:
+                return Response({"error": "Invalid run_id format"}, status=400)
+            if autofix_state is None:
+                return Response({"error": "Autofix state not found"}, status=400)
+
+            # Get and validate trigger_source
+            trigger_source = request.data.get("trigger_source", "solution")
+            if trigger_source not in ["root_cause", "solution"]:
+                return Response(
+                    {"error": "Invalid trigger_source. Must be 'root_cause' or 'solution'"},
+                    status=400,
+                )
+
+            logger.info(
+                "coding_agent.launch_request",
+                extra={
+                    "organization_id": organization.id,
+                    "integration_id": integration.id,
+                    "run_id": run_id,
+                },
+            )
+
+            # Launch agents for all repos
+            results = self._launch_agents_for_repos(
+                installation, autofix_state, run_id, organization, trigger_source
+            )
+
+            if not results:
+                return Response({"error": "No agents were successfully launched"}, status=500)
+
+            logger.info(
+                "coding_agent.launch_success",
+                extra={
+                    "organization_id": organization.id,
+                    "integration_id": integration.id,
+                    "provider": integration.provider,
+                    "run_id": run_id,
+                    "repos_processed": len(results),
+                },
+            )
+
+            metrics.incr("coding_agent.launch", tags={"provider": integration.provider})
+
+            return Response(
+                {
+                    "success": True,
+                }
+            )
+
+        except Exception as e:
+            logger.exception(
+                "coding_agent.launch_error",
+                extra={
+                    "organization_id": organization.id,
+                    "integration_id": request.data.get("integration_id"),
+                    "error": str(e),
+                },
+            )
+            metrics.incr("coding_agent.launch_error")
+            return Response(
+                {"error": "Failed to launch coding agent due to an internal error."}, status=500
+            )

--- a/src/sentry/integrations/api/endpoints/organization_coding_agents.py
+++ b/src/sentry/integrations/api/endpoints/organization_coding_agents.py
@@ -151,7 +151,9 @@ class OrganizationCodingAgentsEndpoint(OrganizationEndpoint):
     def post(self, request: Request, organization: Organization) -> Response:
         """Launch a coding agent."""
         if not features.has("organizations:seer-coding-agent-integrations", organization):
-            return self.respond("Feature not available", status=status.HTTP_404_NOT_FOUND)
+            return self.respond(
+                {"detail": "Feature not available"}, status=status.HTTP_404_NOT_FOUND
+            )
 
         serializer = OrganizationCodingAgentLaunchSerializer(data=request.data)
         if not serializer.is_valid():
@@ -166,7 +168,9 @@ class OrganizationCodingAgentsEndpoint(OrganizationEndpoint):
         run_id = validated["run_id"]
         autofix_state = self._get_autofix_state(run_id, organization)
         if autofix_state is None:
-            return self.respond("Autofix state not found", status=status.HTTP_400_BAD_REQUEST)
+            return self.respond(
+                {"detail": "Autofix state not found"}, status=status.HTTP_400_BAD_REQUEST
+            )
 
         trigger_source = validated.get("trigger_source", AutofixTriggerSource.SOLUTION)
 
@@ -185,7 +189,7 @@ class OrganizationCodingAgentsEndpoint(OrganizationEndpoint):
 
         if not results:
             return self.respond(
-                "No agents were successfully launched",
+                {"detail": "No agents were launched"},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 

--- a/src/sentry/integrations/api/endpoints/organization_coding_agents.py
+++ b/src/sentry/integrations/api/endpoints/organization_coding_agents.py
@@ -6,6 +6,7 @@ import string
 
 import orjson
 from django.conf import settings
+from requests import HTTPError
 from rest_framework import serializers, status
 from rest_framework.exceptions import APIException, NotFound, ValidationError
 from rest_framework.request import Request
@@ -16,7 +17,6 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
-from sentry.api.client import ApiError
 from sentry.constants import ObjectStatus
 from sentry.integrations.coding_agent.integration import CodingAgentIntegration
 from sentry.integrations.coding_agent.models import CodingAgentLaunchRequest
@@ -341,7 +341,7 @@ class OrganizationCodingAgentsEndpoint(OrganizationEndpoint):
 
             try:
                 coding_agent_state = installation.launch(launch_request)
-            except ApiError:
+            except HTTPError:
                 logger.exception(
                     "coding_agent.repo_launch_error",
                     extra={

--- a/src/sentry/integrations/api/endpoints/organization_coding_agents.py
+++ b/src/sentry/integrations/api/endpoints/organization_coding_agents.py
@@ -355,13 +355,23 @@ class OrganizationCodingAgentsEndpoint(OrganizationEndpoint):
                         "repo_name": repo_name,
                     },
                 )
-                # Continue with other repos instead of failing entirely
                 continue
 
-            store_coding_agent_state_to_seer(
-                run_id=run_id,
-                coding_agent_state=coding_agent_state,
-            )
+            try:
+                store_coding_agent_state_to_seer(
+                    run_id=run_id,
+                    coding_agent_state=coding_agent_state,
+                )
+            except SeerApiError:
+                logger.exception(
+                    "coding_agent.seer_storage_error",
+                    extra={
+                        "organization_id": organization.id,
+                        "run_id": run_id,
+                        "repo_name": repo_name,
+                    },
+                )
+                continue
 
             results.append(
                 {

--- a/src/sentry/integrations/api/endpoints/organization_coding_agents.py
+++ b/src/sentry/integrations/api/endpoints/organization_coding_agents.py
@@ -371,7 +371,6 @@ class OrganizationCodingAgentsEndpoint(OrganizationEndpoint):
                         "repo_name": repo_name,
                     },
                 )
-                continue
 
             results.append(
                 {

--- a/src/sentry/integrations/api/endpoints/organization_coding_agents.py
+++ b/src/sentry/integrations/api/endpoints/organization_coding_agents.py
@@ -244,7 +244,7 @@ class OrganizationCodingAgentsEndpoint(OrganizationEndpoint):
 
     def _get_autofix_state(self, run_id: int, organization: Organization) -> AutofixState | None:
         """Extract and validate run_id and get autofix state."""
-        autofix_state = get_autofix_state(run_id=run_id)
+        autofix_state = get_autofix_state(run_id=run_id, organization_id=organization.id)
 
         if not autofix_state:
             logger.warning(

--- a/src/sentry/integrations/api/endpoints/organization_coding_agents.py
+++ b/src/sentry/integrations/api/endpoints/organization_coding_agents.py
@@ -20,6 +20,7 @@ from sentry.integrations.coding_agent.integration import CodingAgentIntegration
 from sentry.integrations.coding_agent.models import CodingAgentLaunchRequest
 from sentry.integrations.coding_agent.utils import get_coding_agent_providers
 from sentry.integrations.services.integration import integration_service
+from sentry.models.organization import Organization
 from sentry.seer.autofix.utils import (
     AutofixState,
     CodingAgentState,
@@ -179,7 +180,7 @@ class OrganizationCodingAgentsEndpoint(OrganizationEndpoint):
 
         return integration, installation
 
-    def _get_autofix_state(self, run_id: int, organization) -> AutofixState:
+    def _get_autofix_state(self, run_id: int, organization: Organization) -> AutofixState | None:
         """Extract and validate run_id and get autofix state."""
         autofix_state = get_autofix_state(run_id=run_id)
 
@@ -236,7 +237,7 @@ class OrganizationCodingAgentsEndpoint(OrganizationEndpoint):
             )
 
             # Fallback to run on all repos
-            repos = autofix_state.request["repos"]
+            repos = [f"{repo['owner']}/{repo['name']}" for repo in autofix_state.request["repos"]]
 
             if not repos:
                 logger.error(

--- a/src/sentry/integrations/api/endpoints/organization_coding_agents.py
+++ b/src/sentry/integrations/api/endpoints/organization_coding_agents.py
@@ -161,18 +161,19 @@ class OrganizationCodingAgentsEndpoint(OrganizationEndpoint):
 
         validated = serializer.validated_data
 
+        run_id = validated["run_id"]
+        integration_id = validated["integration_id"]
+        trigger_source = validated["trigger_source"]
+
         integration, installation = self._validate_and_get_integration(
-            request, organization, validated["integration_id"]
+            request, organization, integration_id
         )
 
-        run_id = validated["run_id"]
         autofix_state = self._get_autofix_state(run_id, organization)
         if autofix_state is None:
             return self.respond(
                 {"detail": "Autofix state not found"}, status=status.HTTP_400_BAD_REQUEST
             )
-
-        trigger_source = validated.get("trigger_source", AutofixTriggerSource.SOLUTION)
 
         logger.info(
             "coding_agent.launch_request",

--- a/tests/sentry/integrations/api/endpoints/test_organization_coding_agents.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_coding_agents.py
@@ -387,7 +387,7 @@ class OrganizationCodingAgentsPostParameterValidationTest(BaseOrganizationCoding
             response = self.get_error_response(
                 self.organization.slug, method="post", status_code=400, **data
             )
-            assert response.data["error"] == "Invalid run_id format"
+            assert response.data["error"] == "Invalid run_id"
 
     @patch(
         "sentry.integrations.api.endpoints.organization_coding_agents.get_coding_agent_providers"
@@ -415,7 +415,7 @@ class OrganizationCodingAgentsPostParameterValidationTest(BaseOrganizationCoding
             response = self.get_error_response(
                 self.organization.slug, method="post", status_code=400, **data
             )
-            assert response.data["error"] == "Invalid run_id format"
+            assert response.data["error"] == "run_id is required"
 
     @patch(
         "sentry.integrations.api.endpoints.organization_coding_agents.get_coding_agent_providers"
@@ -440,7 +440,7 @@ class OrganizationCodingAgentsPostParameterValidationTest(BaseOrganizationCoding
             response = self.get_error_response(
                 self.organization.slug, method="post", status_code=400, **data
             )
-            assert response.data["error"] == "Invalid run_id format"
+            assert response.data["error"] == "Invalid run_id"
 
     @patch(
         "sentry.integrations.api.endpoints.organization_coding_agents.get_coding_agent_providers"

--- a/tests/sentry/integrations/api/endpoints/test_organization_coding_agents.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_coding_agents.py
@@ -720,6 +720,7 @@ class OrganizationCodingAgentsPostLaunchTest(BaseOrganizationCodingAgentsTest):
         "sentry.integrations.api.endpoints.organization_coding_agents.get_coding_agent_providers"
     )
     @patch("sentry.integrations.api.endpoints.organization_coding_agents.get_autofix_state")
+    @patch("sentry.integrations.api.endpoints.organization_coding_agents.get_coding_agent_prompt")
     @patch(
         "sentry.integrations.services.integration.integration_service.get_organization_integration"
     )
@@ -728,6 +729,7 @@ class OrganizationCodingAgentsPostLaunchTest(BaseOrganizationCodingAgentsTest):
         self,
         mock_get_integration,
         mock_get_org_integration,
+        mock_get_prompt,
         mock_get_autofix_state,
         mock_get_providers,
     ):
@@ -743,6 +745,7 @@ class OrganizationCodingAgentsPostLaunchTest(BaseOrganizationCodingAgentsTest):
 
         mock_get_org_integration.return_value = self.rpc_org_integration
         mock_get_integration.return_value = mock_rpc_integration
+        mock_get_prompt.return_value = None
 
         # Create multi-repo autofix state
         multi_repo_list = [
@@ -767,7 +770,7 @@ class OrganizationCodingAgentsPostLaunchTest(BaseOrganizationCodingAgentsTest):
             response = self.get_error_response(
                 self.organization.slug, method="post", status_code=500, **data
             )
-            assert response.data == "No agents were successfully launched"
+            assert response.data["detail"] == "No prompt to send to agents."
 
     @patch(
         "sentry.integrations.api.endpoints.organization_coding_agents.get_coding_agent_providers"
@@ -981,4 +984,4 @@ class OrganizationCodingAgentsPostTriggerSourceTest(BaseOrganizationCodingAgents
             response = self.get_error_response(
                 self.organization.slug, method="post", status_code=500, **data
             )
-            assert response.data == "No agents were successfully launched"
+            assert response.data["detail"] == "No prompt to send to agents."

--- a/tests/sentry/integrations/api/endpoints/test_organization_coding_agents.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_coding_agents.py
@@ -519,7 +519,6 @@ class OrganizationCodingAgentsPostLaunchTest(BaseOrganizationCodingAgentsTest):
             self.feature("organizations:seer-coding-agent-integrations"),
             patch(
                 "sentry.integrations.api.endpoints.organization_coding_agents.store_coding_agent_state_to_seer",
-                return_value=True,
             ),
         ):
             response = self.get_success_response(self.organization.slug, method="post", **data)
@@ -563,7 +562,6 @@ class OrganizationCodingAgentsPostLaunchTest(BaseOrganizationCodingAgentsTest):
             self.feature("organizations:seer-coding-agent-integrations"),
             patch(
                 "sentry.integrations.api.endpoints.organization_coding_agents.store_coding_agent_state_to_seer",
-                return_value=True,
             ),
         ):
             response = self.get_success_response(self.organization.slug, method="post", **data)
@@ -660,7 +658,6 @@ class OrganizationCodingAgentsPostLaunchTest(BaseOrganizationCodingAgentsTest):
             self.feature("organizations:seer-coding-agent-integrations"),
             patch(
                 "sentry.integrations.api.endpoints.organization_coding_agents.store_coding_agent_state_to_seer",
-                return_value=True,
             ),
         ):
             response = self.get_success_response(self.organization.slug, method="post", **data)
@@ -737,7 +734,6 @@ class OrganizationCodingAgentsPostLaunchTest(BaseOrganizationCodingAgentsTest):
             self.feature("organizations:seer-coding-agent-integrations"),
             patch(
                 "sentry.integrations.api.endpoints.organization_coding_agents.store_coding_agent_state_to_seer",
-                return_value=True,
             ),
         ):
             response = self.get_success_response(self.organization.slug, method="post", **data)
@@ -880,7 +876,6 @@ class OrganizationCodingAgentsPostTriggerSourceTest(BaseOrganizationCodingAgents
             self.feature("organizations:seer-coding-agent-integrations"),
             patch(
                 "sentry.integrations.api.endpoints.organization_coding_agents.store_coding_agent_state_to_seer",
-                return_value=True,
             ),
         ):
             response = self.get_success_response(self.organization.slug, method="post", **data)
@@ -925,7 +920,6 @@ class OrganizationCodingAgentsPostTriggerSourceTest(BaseOrganizationCodingAgents
             self.feature("organizations:seer-coding-agent-integrations"),
             patch(
                 "sentry.integrations.api.endpoints.organization_coding_agents.store_coding_agent_state_to_seer",
-                return_value=True,
             ),
         ):
             response = self.get_success_response(self.organization.slug, method="post", **data)

--- a/tests/sentry/integrations/api/endpoints/test_organization_coding_agents.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_coding_agents.py
@@ -11,6 +11,7 @@ from sentry.integrations.coding_agent.integration import (
 from sentry.integrations.coding_agent.models import CodingAgentLaunchRequest
 from sentry.integrations.services.integration.serial import serialize_integration
 from sentry.seer.autofix.utils import CodingAgentState, CodingAgentStatus
+from sentry.seer.models import SeerRepoDefinition
 from sentry.testutils.cases import APITestCase
 
 
@@ -122,7 +123,14 @@ class BaseOrganizationCodingAgentsTest(APITestCase):
     def _create_mock_autofix_state(self, repos=None):
         """Create a mock autofix state for testing."""
         if repos is None:
-            repos = [{"owner": "test", "name": "repo", "external_id": "123", "provider": "github"}]
+            repos = [
+                SeerRepoDefinition(
+                    owner="test",
+                    name="repo",
+                    external_id="123",
+                    provider="github",
+                )
+            ]
 
         mock_autofix_state = MagicMock()
         mock_autofix_state.steps = [
@@ -618,10 +626,19 @@ class OrganizationCodingAgentsPostLaunchTest(BaseOrganizationCodingAgentsTest):
         mock_get_org_integration.return_value = self.rpc_org_integration
         mock_get_integration.return_value = mock_rpc_integration
 
-        # Create multi-repo autofix state
         multi_repo_list = [
-            {"owner": "owner1", "name": "repo1", "external_id": "123", "provider": "github"},
-            {"owner": "owner2", "name": "repo2", "external_id": "456", "provider": "github"},
+            SeerRepoDefinition(
+                owner="owner1",
+                name="repo1",
+                external_id="123",
+                provider="github",
+            ),
+            SeerRepoDefinition(
+                owner="owner2",
+                name="repo2",
+                external_id="456",
+                provider="github",
+            ),
         ]
         mock_autofix_state = self._create_mock_autofix_state(repos=multi_repo_list)
         mock_autofix_state.steps = [
@@ -686,10 +703,19 @@ class OrganizationCodingAgentsPostLaunchTest(BaseOrganizationCodingAgentsTest):
         mock_get_org_integration.return_value = self.rpc_org_integration
         mock_get_integration.return_value = mock_rpc_integration
 
-        # Create multi-repo autofix state
         multi_repo_list = [
-            {"owner": "owner1", "name": "repo1", "external_id": "123", "provider": "github"},
-            {"owner": "owner2", "name": "repo2", "external_id": "456", "provider": "github"},
+            SeerRepoDefinition(
+                owner="owner1",
+                name="repo1",
+                external_id="123",
+                provider="github",
+            ),
+            SeerRepoDefinition(
+                owner="owner2",
+                name="repo2",
+                external_id="456",
+                provider="github",
+            ),
         ]
         mock_autofix_state = self._create_mock_autofix_state(repos=multi_repo_list)
         mock_autofix_state.steps = [

--- a/tests/sentry/integrations/api/endpoints/test_organization_coding_agents.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_coding_agents.py
@@ -1,16 +1,162 @@
-from unittest.mock import Mock
+import contextlib
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, Mock, patch
 
+from sentry.constants import ObjectStatus
+from sentry.integrations.coding_agent.client import CodingAgentClient
+from sentry.integrations.coding_agent.integration import (
+    CodingAgentIntegration,
+    CodingAgentIntegrationProvider,
+)
+from sentry.integrations.coding_agent.models import CodingAgentLaunchRequest
+from sentry.integrations.services.integration.serial import serialize_integration
+from sentry.seer.autofix.utils import CodingAgentState, CodingAgentStatus
 from sentry.testutils.cases import APITestCase
 
 
-class OrganizationCodingAgentsEndpointTest(APITestCase):
+class MockCodingAgentProvider(CodingAgentIntegrationProvider):
+    """Mock coding agent provider for tests."""
+
+    key = "mock_agent"
+    name = "Mock Agent"
+
+    def get_agent_name(self) -> str:
+        return "Mock Agent"
+
+    def get_agent_key(self) -> str:
+        return "mock_agent"
+
+    def get_pipeline_views(self):
+        return []
+
+    def build_integration(self, state):
+        return {
+            "external_id": "mock_agent",
+            "name": "Mock Agent",
+            "metadata": {"api_key": "test_key"},
+        }
+
+
+class MockCodingAgentInstallation(CodingAgentIntegration):
+    """Mock coding agent installation for tests."""
+
+    def get_client(self):
+        return MockCodingAgentClient(integration=self.model)
+
+
+class MockCodingAgentClient(CodingAgentClient):
+    """Mock coding agent client for tests."""
+
+    base_url = "https://api.mock-agent.com/v1"
+
+    def launch(self, webhook_url: str, request: CodingAgentLaunchRequest) -> CodingAgentState:
+        """Mock implementation of launch method."""
+        return CodingAgentState(
+            id="mock-123",
+            status=CodingAgentStatus.PENDING,
+            name="Mock Agent",
+            started_at=datetime.now(UTC),
+        )
+
+
+class BaseOrganizationCodingAgentsTest(APITestCase):
+    """Base test class with common setup for coding agent endpoint tests."""
+
     endpoint = "sentry-api-0-organization-coding-agents"
 
     def setUp(self):
         super().setUp()
-        self.login_as(user=self.user)
+        self.login_as(self.user)
+        self._setup_mock_integration()
 
-    def test_get_feature_flag_disabled(self):
+    def _setup_mock_integration(self):
+        """Set up mock integration and related objects for testing."""
+        # Mock the coding agent providers to include our mock provider
+        self.mock_provider = MockCodingAgentProvider()
+
+        # Create a GitHub integration to use as our test integration
+        self.integration = self.create_integration(
+            organization=self.organization,
+            provider="github",
+            name="GitHub",
+            external_id="github:123",
+            metadata={
+                "api_key": "test_api_key_123",
+                "domain_name": "github.com",
+            },
+        )
+
+        # Create proper RPC objects using serialization
+        self.rpc_integration = serialize_integration(self.integration)
+
+        # Get the organization integration and serialize it using the integration service
+        from sentry.integrations.services.integration import integration_service
+
+        org_integration = integration_service.get_organization_integration(
+            integration_id=self.integration.id,
+            organization_id=self.organization.id,
+        )
+        self.rpc_org_integration = org_integration
+
+        # Create mock installation
+        self.mock_installation = MockCodingAgentInstallation(self.integration, self.organization.id)
+
+    def _create_mock_rpc_integration(self):
+        """Create a mock RPC integration for testing."""
+        mock_rpc_integration = MagicMock()
+        mock_rpc_integration.id = self.integration.id
+        mock_rpc_integration.name = self.integration.name
+        mock_rpc_integration.provider = "github"
+        mock_rpc_integration.metadata = self.integration.metadata
+        mock_rpc_integration.get_installation = MagicMock(return_value=self.mock_installation)
+        return mock_rpc_integration
+
+    def _create_mock_autofix_state(self, repos=None):
+        """Create a mock autofix state for testing."""
+        if repos is None:
+            repos = [{"owner": "test", "name": "repo", "external_id": "123", "provider": "github"}]
+
+        mock_autofix_state = MagicMock()
+        mock_autofix_state.steps = [
+            {"key": "solution", "solution": [{"relevant_code_file": {"repo_name": "test/repo"}}]}
+        ]
+        mock_autofix_state.request = {
+            "repos": repos,
+            "issue": {"title": "Test Issue"},
+        }
+        return mock_autofix_state
+
+    def mock_integration_service_calls(self, org_integrations=None, integration=None):
+        """Helper to mock integration service calls."""
+        from unittest.mock import patch
+
+        from sentry.integrations.services.integration import integration_service
+
+        org_integrations = org_integrations or []
+
+        @contextlib.contextmanager
+        def mock_context():
+            with (
+                patch.object(
+                    integration_service,
+                    "get_organization_integrations",
+                    return_value=org_integrations,
+                ),
+                patch.object(integration_service, "get_integration", return_value=integration),
+                patch(
+                    "sentry.integrations.coding_agent.utils.get_coding_agent_providers",
+                    return_value=["test_provider"],
+                ),
+            ):
+                yield
+
+        return mock_context()
+
+
+class OrganizationCodingAgentsGetTest(BaseOrganizationCodingAgentsTest):
+    """Test class for GET endpoint functionality."""
+
+    def test_feature_flag_disabled(self):
         """Test GET request when feature flag is disabled."""
         organization = self.create_organization(owner=self.user)
 
@@ -20,7 +166,7 @@ class OrganizationCodingAgentsEndpointTest(APITestCase):
         assert response.status_code == 404
         assert response.data["detail"] == "Feature not available"
 
-    def test_get_no_integrations(self):
+    def test_no_integrations(self):
         """Test GET request with no coding agent integrations."""
         organization = self.create_organization(owner=self.user)
 
@@ -30,7 +176,7 @@ class OrganizationCodingAgentsEndpointTest(APITestCase):
         assert response.status_code == 200
         assert response.data["integrations"] == []
 
-    def test_get_with_mock_integration(self):
+    def test_with_mock_integration(self):
         """Test GET request with mocked coding agent integration."""
         organization = self.create_organization(owner=self.user)
 
@@ -54,28 +200,748 @@ class OrganizationCodingAgentsEndpointTest(APITestCase):
         assert integration_data["name"] == "Test Coding Agent"
         assert integration_data["provider"] == "test_provider"
 
-    def mock_integration_service_calls(self, integrations=None):
-        """Helper to mock integration service calls."""
-        import contextlib
-        from unittest.mock import patch
+    @patch(
+        "sentry.integrations.services.integration.integration_service.get_organization_integrations"
+    )
+    @patch("sentry.integrations.services.integration.integration_service.get_integration")
+    def test_returns_coding_agent_integrations(
+        self, mock_get_integration, mock_get_org_integrations
+    ):
+        """Test GET endpoint returns coding agent integrations."""
+        mock_rpc_integration = self._create_mock_rpc_integration()
 
-        from sentry.integrations.services.integration import integration_service
+        # Mock integration service calls
+        mock_get_org_integrations.return_value = [self.rpc_org_integration]
+        mock_get_integration.return_value = mock_rpc_integration
 
-        integrations = integrations or []
+        with self.feature("organizations:seer-coding-agent-integrations"):
+            response = self.get_success_response(self.organization.slug)
 
-        @contextlib.contextmanager
-        def mock_context():
-            with (
-                patch.object(
-                    integration_service,
-                    "get_integrations",
-                    return_value=integrations,
-                ),
-                patch(
-                    "sentry.integrations.coding_agent.utils.get_coding_agent_providers",
-                    return_value=["test_provider"],
-                ),
-            ):
-                yield
+            assert "integrations" in response.data
+            integrations = response.data["integrations"]
+            assert len(integrations) == 1
+            integration_data = integrations[0]
 
-        return mock_context()
+            # The endpoint only returns basic integration data
+            assert integration_data["id"] == str(self.integration.id)
+            assert integration_data["name"] == "GitHub"
+            assert integration_data["provider"] == "github"
+
+    @patch(
+        "sentry.integrations.services.integration.integration_service.get_organization_integrations"
+    )
+    @patch("sentry.integrations.services.integration.integration_service.get_integration")
+    def test_handles_integration_processing_error(
+        self, mock_get_integration, mock_get_org_integrations
+    ):
+        """Test GET endpoint handles integration processing errors gracefully."""
+        mock_get_org_integrations.return_value = [self.rpc_org_integration]
+
+        # Make get_integration return None to simulate processing error
+        mock_get_integration.return_value = None
+
+        with self.feature("organizations:seer-coding-agent-integrations"):
+            response = self.get_success_response(self.organization.slug)
+
+            # Should return empty integrations list when processing fails
+            assert "integrations" in response.data
+            assert len(response.data["integrations"]) == 0
+
+    @patch(
+        "sentry.integrations.services.integration.integration_service.get_organization_integrations"
+    )
+    def test_handles_service_error(self, mock_get_org_integrations):
+        """Test GET endpoint handles organization integrations service errors."""
+        # Mock service to raise an exception
+        mock_get_org_integrations.side_effect = Exception("Service unavailable")
+
+        with self.feature("organizations:seer-coding-agent-integrations"):
+            response = self.get_error_response(self.organization.slug, status_code=500)
+            assert response.data["error"] == "Failed to retrieve coding agent integrations"
+
+    @patch(
+        "sentry.integrations.services.integration.integration_service.get_organization_integrations"
+    )
+    @patch("sentry.integrations.services.integration.integration_service.get_integration")
+    def test_handles_integration_not_found(self, mock_get_integration, mock_get_org_integrations):
+        """Test GET endpoint handles case where integration is not found."""
+        # Mock organization integrations but integration lookup returns None
+        mock_get_org_integrations.return_value = [self.rpc_org_integration]
+        mock_get_integration.return_value = None
+
+        with self.feature("organizations:seer-coding-agent-integrations"):
+            response = self.get_success_response(self.organization.slug)
+
+            # Should skip integrations that can't be found
+            assert "integrations" in response.data
+            assert len(response.data["integrations"]) == 0
+
+
+class OrganizationCodingAgentsPostParameterValidationTest(BaseOrganizationCodingAgentsTest):
+    """Test class for POST endpoint parameter validation."""
+
+    def test_feature_flag_disabled(self):
+        """Test POST endpoint when feature flag is disabled."""
+        data = {"integration_id": "123"}
+        response = self.get_error_response(
+            self.organization.slug, method="post", status_code=404, **data
+        )
+        assert response.data["detail"] == "Feature not available"
+
+    def test_missing_integration_id(self):
+        """Test POST endpoint with missing integration_id."""
+        with self.feature({"organizations:seer-coding-agent-integrations": True}):
+            response = self.get_error_response(
+                self.organization.slug, method="post", status_code=400
+            )
+            assert response.data["error"] == "integration_id is required"
+
+    def test_invalid_integration_id(self):
+        """Test POST endpoint with invalid integration_id."""
+        data = {"integration_id": "invalid_id"}
+
+        with self.feature({"organizations:seer-coding-agent-integrations": True}):
+            response = self.get_error_response(
+                self.organization.slug, method="post", status_code=400, **data
+            )
+            assert response.data["error"] == "Invalid integration_id"
+
+    def test_non_coding_agent_integration(self):
+        """Test POST endpoint with non-coding agent integration."""
+        # Create a non-coding agent integration (e.g., Slack)
+        slack_integration = self.create_integration(
+            organization=self.organization,
+            provider="slack",
+            name="Slack",
+            external_id="slack:123",
+        )
+
+        data = {"integration_id": str(slack_integration.id)}
+
+        with self.feature({"organizations:seer-coding-agent-integrations": True}):
+            response = self.get_error_response(
+                self.organization.slug, method="post", status_code=400, **data
+            )
+            assert response.data["error"] == "Not a coding agent integration"
+
+    @patch(
+        "sentry.integrations.api.endpoints.organization_coding_agents.get_coding_agent_providers"
+    )
+    @patch(
+        "sentry.integrations.services.integration.integration_service.get_organization_integration"
+    )
+    def test_integration_not_found(self, mock_get_org_integration, mock_get_providers):
+        """Test POST endpoint with integration that doesn't exist."""
+        mock_get_providers.return_value = ["github"]
+        mock_get_org_integration.return_value = None
+
+        data = {"integration_id": "999"}
+
+        with self.feature({"organizations:seer-coding-agent-integrations": True}):
+            response = self.get_error_response(
+                self.organization.slug, method="post", status_code=404, **data
+            )
+            assert response.data["error"] == "Integration not found"
+
+    @patch(
+        "sentry.integrations.api.endpoints.organization_coding_agents.get_coding_agent_providers"
+    )
+    @patch(
+        "sentry.integrations.services.integration.integration_service.get_organization_integration"
+    )
+    def test_inactive_integration(self, mock_get_org_integration, mock_get_providers):
+        """Test POST endpoint with inactive integration."""
+        mock_get_providers.return_value = ["github"]
+
+        # Create inactive organization integration
+        inactive_org_integration = MagicMock()
+        inactive_org_integration.status = ObjectStatus.PENDING_DELETION
+        mock_get_org_integration.return_value = inactive_org_integration
+
+        data = {"integration_id": str(self.integration.id)}
+
+        with self.feature({"organizations:seer-coding-agent-integrations": True}):
+            response = self.get_error_response(
+                self.organization.slug, method="post", status_code=404, **data
+            )
+            assert response.data["error"] == "Integration not found"
+
+    @patch(
+        "sentry.integrations.api.endpoints.organization_coding_agents.get_coding_agent_providers"
+    )
+    @patch(
+        "sentry.integrations.services.integration.integration_service.get_organization_integration"
+    )
+    @patch("sentry.integrations.services.integration.integration_service.get_integration")
+    def test_empty_run_id(self, mock_get_integration, mock_get_org_integration, mock_get_providers):
+        """Test POST endpoint with empty run_id."""
+        mock_get_providers.return_value = ["github"]
+        mock_get_org_integration.return_value = self.rpc_org_integration
+
+        mock_rpc_integration = self._create_mock_rpc_integration()
+        mock_get_integration.return_value = mock_rpc_integration
+
+        data = {"integration_id": str(self.integration.id), "run_id": ""}
+
+        with self.feature({"organizations:seer-coding-agent-integrations": True}):
+            response = self.get_error_response(
+                self.organization.slug, method="post", status_code=400, **data
+            )
+            assert response.data["error"] == "Invalid run_id format"
+
+    @patch(
+        "sentry.integrations.api.endpoints.organization_coding_agents.get_coding_agent_providers"
+    )
+    @patch(
+        "sentry.integrations.services.integration.integration_service.get_organization_integration"
+    )
+    @patch("sentry.integrations.services.integration.integration_service.get_integration")
+    def test_null_run_id(
+        self,
+        mock_get_integration,
+        mock_get_org_integration,
+        mock_get_providers,
+    ):
+        """Test POST endpoint with null run_id."""
+        mock_get_providers.return_value = ["github"]
+        mock_get_org_integration.return_value = self.rpc_org_integration
+
+        mock_rpc_integration = self._create_mock_rpc_integration()
+        mock_get_integration.return_value = mock_rpc_integration
+
+        data = {"integration_id": str(self.integration.id), "run_id": None}
+
+        with self.feature({"organizations:seer-coding-agent-integrations": True}):
+            response = self.get_error_response(
+                self.organization.slug, method="post", status_code=400, **data
+            )
+            assert response.data["error"] == "Invalid run_id format"
+
+    @patch(
+        "sentry.integrations.api.endpoints.organization_coding_agents.get_coding_agent_providers"
+    )
+    @patch(
+        "sentry.integrations.services.integration.integration_service.get_organization_integration"
+    )
+    @patch("sentry.integrations.services.integration.integration_service.get_integration")
+    def test_string_run_id(
+        self, mock_get_integration, mock_get_org_integration, mock_get_providers
+    ):
+        """Test POST endpoint with non-numeric run_id."""
+        mock_get_providers.return_value = ["github"]
+        mock_get_org_integration.return_value = self.rpc_org_integration
+
+        mock_rpc_integration = self._create_mock_rpc_integration()
+        mock_get_integration.return_value = mock_rpc_integration
+
+        data = {"integration_id": str(self.integration.id), "run_id": "not_a_number"}
+
+        with self.feature({"organizations:seer-coding-agent-integrations": True}):
+            response = self.get_error_response(
+                self.organization.slug, method="post", status_code=400, **data
+            )
+            assert response.data["error"] == "Invalid run_id format"
+
+    @patch(
+        "sentry.integrations.api.endpoints.organization_coding_agents.get_coding_agent_providers"
+    )
+    @patch(
+        "sentry.integrations.services.integration.integration_service.get_organization_integration"
+    )
+    @patch("sentry.integrations.services.integration.integration_service.get_integration")
+    def test_invalid_coding_agent_installation(
+        self, mock_get_integration, mock_get_org_integration, mock_get_providers
+    ):
+        """Test POST endpoint when installation is not a CodingAgentIntegration."""
+        mock_get_providers.return_value = ["github"]
+        mock_get_org_integration.return_value = self.rpc_org_integration
+
+        # Mock integration that returns non-CodingAgentIntegration
+        mock_rpc_integration = MagicMock()
+        mock_rpc_integration.id = self.integration.id
+        mock_rpc_integration.provider = "github"
+        mock_rpc_integration.get_installation.return_value = (
+            MagicMock()
+        )  # Not CodingAgentIntegration
+        mock_get_integration.return_value = mock_rpc_integration
+
+        data = {"integration_id": str(self.integration.id)}
+
+        with self.feature({"organizations:seer-coding-agent-integrations": True}):
+            response = self.get_error_response(
+                self.organization.slug, method="post", status_code=400, **data
+            )
+            assert response.data["error"] == "Invalid coding agent integration"
+
+
+class OrganizationCodingAgentsPostLaunchTest(BaseOrganizationCodingAgentsTest):
+    """Test class for POST endpoint launch functionality."""
+
+    @patch(
+        "sentry.integrations.api.endpoints.organization_coding_agents.get_coding_agent_providers"
+    )
+    @patch("sentry.integrations.api.endpoints.organization_coding_agents.get_autofix_state")
+    @patch("sentry.integrations.api.endpoints.organization_coding_agents.get_coding_agent_prompt")
+    @patch(
+        "sentry.integrations.services.integration.integration_service.get_organization_integration"
+    )
+    @patch("sentry.integrations.services.integration.integration_service.get_integration")
+    def test_launches_coding_agent(
+        self,
+        mock_get_integration,
+        mock_get_org_integration,
+        mock_get_prompt,
+        mock_get_autofix_state,
+        mock_get_providers,
+    ):
+        """Test POST endpoint launches coding agent."""
+        # Mock coding agent providers to include github
+        mock_get_providers.return_value = ["github"]
+        mock_get_prompt.return_value = "Test coding agent prompt"
+
+        mock_rpc_integration = self._create_mock_rpc_integration()
+        mock_get_org_integration.return_value = self.rpc_org_integration
+        mock_get_integration.return_value = mock_rpc_integration
+        mock_get_autofix_state.return_value = self._create_mock_autofix_state()
+
+        data = {
+            "integration_id": str(self.integration.id),
+            "run_id": 123,
+        }
+
+        with self.feature("organizations:seer-coding-agent-integrations"):
+            response = self.get_success_response(self.organization.slug, method="post", **data)
+            assert response.data["success"] is True
+
+            # Verify prompt was called with default trigger_source
+            mock_get_prompt.assert_called_with(123, "solution")
+
+    @patch(
+        "sentry.integrations.api.endpoints.organization_coding_agents.get_coding_agent_providers"
+    )
+    @patch("sentry.integrations.api.endpoints.organization_coding_agents.get_autofix_state")
+    @patch("sentry.integrations.api.endpoints.organization_coding_agents.get_coding_agent_prompt")
+    @patch(
+        "sentry.integrations.services.integration.integration_service.get_organization_integration"
+    )
+    @patch("sentry.integrations.services.integration.integration_service.get_integration")
+    def test_launch_with_all_parameters(
+        self,
+        mock_get_integration,
+        mock_get_org_integration,
+        mock_get_prompt,
+        mock_get_autofix_state,
+        mock_get_providers,
+    ):
+        """Test POST endpoint with all launch parameters."""
+        mock_get_providers.return_value = ["github"]
+        mock_get_prompt.return_value = "Test prompt for all parameters"
+
+        mock_rpc_integration = self._create_mock_rpc_integration()
+        mock_get_org_integration.return_value = self.rpc_org_integration
+        mock_get_integration.return_value = mock_rpc_integration
+        mock_get_autofix_state.return_value = self._create_mock_autofix_state()
+
+        data = {
+            "integration_id": str(self.integration.id),
+            "run_id": 123,
+        }
+
+        with self.feature("organizations:seer-coding-agent-integrations"):
+            response = self.get_success_response(self.organization.slug, method="post", **data)
+            assert response.data["success"] is True
+
+    @patch(
+        "sentry.integrations.api.endpoints.organization_coding_agents.get_coding_agent_providers"
+    )
+    @patch("sentry.integrations.api.endpoints.organization_coding_agents.get_autofix_state")
+    @patch(
+        "sentry.integrations.services.integration.integration_service.get_organization_integration"
+    )
+    @patch("sentry.integrations.services.integration.integration_service.get_integration")
+    def test_handles_launch_exception(
+        self,
+        mock_get_integration,
+        mock_get_org_integration,
+        mock_get_autofix_state,
+        mock_get_providers,
+    ):
+        """Test POST endpoint handles launch exceptions."""
+        mock_get_providers.return_value = ["github"]
+
+        mock_rpc_integration = self._create_mock_rpc_integration()
+        mock_get_org_integration.return_value = self.rpc_org_integration
+        mock_get_integration.return_value = mock_rpc_integration
+
+        # Mock get_autofix_state to return None (no state found)
+        mock_get_autofix_state.return_value = None
+
+        data = {"integration_id": str(self.integration.id), "run_id": 123}
+
+        with self.feature("organizations:seer-coding-agent-integrations"):
+            response = self.get_error_response(
+                self.organization.slug, method="post", status_code=400, **data
+            )
+            assert response.data["error"] == "Autofix state not found"
+
+    @patch(
+        "sentry.integrations.api.endpoints.organization_coding_agents.get_coding_agent_providers"
+    )
+    @patch("sentry.integrations.api.endpoints.organization_coding_agents.get_autofix_state")
+    @patch("sentry.integrations.api.endpoints.organization_coding_agents.get_coding_agent_prompt")
+    @patch(
+        "sentry.integrations.services.integration.integration_service.get_organization_integration"
+    )
+    @patch("sentry.integrations.services.integration.integration_service.get_integration")
+    def test_multi_repo_launch(
+        self,
+        mock_get_integration,
+        mock_get_org_integration,
+        mock_get_prompt,
+        mock_get_autofix_state,
+        mock_get_providers,
+    ):
+        """Test POST endpoint launches agents for multiple repositories."""
+        mock_get_providers.return_value = ["github"]
+        mock_get_prompt.return_value = "Multi-repo test prompt"
+
+        mock_rpc_integration = self._create_mock_rpc_integration()
+        mock_get_org_integration.return_value = self.rpc_org_integration
+        mock_get_integration.return_value = mock_rpc_integration
+
+        # Create multi-repo autofix state
+        multi_repo_list = [
+            {"owner": "owner1", "name": "repo1", "external_id": "123", "provider": "github"},
+            {"owner": "owner2", "name": "repo2", "external_id": "456", "provider": "github"},
+        ]
+        mock_autofix_state = self._create_mock_autofix_state(repos=multi_repo_list)
+        mock_autofix_state.steps = [
+            {
+                "key": "solution",
+                "solution": [
+                    {"relevant_code_file": {"repo_name": "owner1/repo1"}},
+                    {"relevant_code_file": {"repo_name": "owner2/repo2"}},
+                ],
+            }
+        ]
+        mock_get_autofix_state.return_value = mock_autofix_state
+
+        data = {"integration_id": str(self.integration.id), "run_id": 123}
+
+        with self.feature("organizations:seer-coding-agent-integrations"):
+            response = self.get_success_response(self.organization.slug, method="post", **data)
+            assert response.data["success"] is True
+
+    @patch(
+        "sentry.integrations.api.endpoints.organization_coding_agents.get_coding_agent_providers"
+    )
+    @patch("sentry.integrations.api.endpoints.organization_coding_agents.get_autofix_state")
+    @patch("sentry.integrations.api.endpoints.organization_coding_agents.get_coding_agent_prompt")
+    @patch(
+        "sentry.integrations.services.integration.integration_service.get_organization_integration"
+    )
+    @patch("sentry.integrations.services.integration.integration_service.get_integration")
+    def test_repo_launch_error_continues_with_others(
+        self,
+        mock_get_integration,
+        mock_get_org_integration,
+        mock_get_prompt,
+        mock_get_autofix_state,
+        mock_get_providers,
+    ):
+        """Test POST endpoint continues with other repos when one repo fails."""
+        mock_get_providers.return_value = ["github"]
+        mock_get_prompt.return_value = "Test prompt for repo launch error"
+
+        # Create mock installation that fails for first repo
+        failing_installation = MagicMock(spec=MockCodingAgentInstallation)
+        failing_installation.launch.side_effect = [
+            Exception("Repository not accessible"),  # First call fails
+            CodingAgentState(  # Second call succeeds
+                id="success-123",
+                status=CodingAgentStatus.PENDING,
+                name="Success Agent",
+                started_at=datetime.now(UTC),
+            ),
+        ]
+
+        mock_rpc_integration = self._create_mock_rpc_integration()
+        mock_rpc_integration.get_installation = MagicMock(return_value=failing_installation)
+
+        mock_get_org_integration.return_value = self.rpc_org_integration
+        mock_get_integration.return_value = mock_rpc_integration
+
+        # Create multi-repo autofix state
+        multi_repo_list = [
+            {"owner": "owner1", "name": "repo1", "external_id": "123", "provider": "github"},
+            {"owner": "owner2", "name": "repo2", "external_id": "456", "provider": "github"},
+        ]
+        mock_autofix_state = self._create_mock_autofix_state(repos=multi_repo_list)
+        mock_autofix_state.steps = [
+            {
+                "key": "solution",
+                "solution": [
+                    {"relevant_code_file": {"repo_name": "owner1/repo1"}},
+                    {"relevant_code_file": {"repo_name": "owner2/repo2"}},
+                ],
+            }
+        ]
+        mock_get_autofix_state.return_value = mock_autofix_state
+
+        data = {"integration_id": str(self.integration.id), "run_id": 123}
+
+        with self.feature("organizations:seer-coding-agent-integrations"):
+            response = self.get_success_response(self.organization.slug, method="post", **data)
+            # Should succeed because at least one repo launched successfully
+            assert response.data["success"] is True
+
+    @patch(
+        "sentry.integrations.api.endpoints.organization_coding_agents.get_coding_agent_providers"
+    )
+    @patch("sentry.integrations.api.endpoints.organization_coding_agents.get_autofix_state")
+    @patch(
+        "sentry.integrations.services.integration.integration_service.get_organization_integration"
+    )
+    @patch("sentry.integrations.services.integration.integration_service.get_integration")
+    def test_all_repos_fail_returns_error(
+        self,
+        mock_get_integration,
+        mock_get_org_integration,
+        mock_get_autofix_state,
+        mock_get_providers,
+    ):
+        """Test POST endpoint returns error when all repos fail to launch."""
+        mock_get_providers.return_value = ["github"]
+
+        # Create mock installation that always fails
+        failing_installation = MagicMock(spec=MockCodingAgentInstallation)
+        failing_installation.launch.side_effect = Exception("Repository not accessible")
+
+        mock_rpc_integration = self._create_mock_rpc_integration()
+        mock_rpc_integration.get_installation = MagicMock(return_value=failing_installation)
+
+        mock_get_org_integration.return_value = self.rpc_org_integration
+        mock_get_integration.return_value = mock_rpc_integration
+
+        # Create multi-repo autofix state
+        multi_repo_list = [
+            {"owner": "owner1", "name": "repo1", "external_id": "123", "provider": "github"},
+            {"owner": "owner2", "name": "repo2", "external_id": "456", "provider": "github"},
+        ]
+        mock_autofix_state = self._create_mock_autofix_state(repos=multi_repo_list)
+        mock_autofix_state.steps = [
+            {
+                "key": "solution",
+                "solution": [
+                    {"relevant_code_file": {"repo_name": "owner1/repo1"}},
+                    {"relevant_code_file": {"repo_name": "owner2/repo2"}},
+                ],
+            }
+        ]
+        mock_get_autofix_state.return_value = mock_autofix_state
+
+        data = {"integration_id": str(self.integration.id), "run_id": 123}
+
+        with self.feature("organizations:seer-coding-agent-integrations"):
+            response = self.get_error_response(
+                self.organization.slug, method="post", status_code=500, **data
+            )
+            assert response.data["error"] == "No agents were successfully launched"
+
+    @patch(
+        "sentry.integrations.api.endpoints.organization_coding_agents.get_coding_agent_providers"
+    )
+    @patch("sentry.integrations.api.endpoints.organization_coding_agents.get_autofix_state")
+    @patch("sentry.integrations.api.endpoints.organization_coding_agents.get_coding_agent_prompt")
+    @patch(
+        "sentry.integrations.services.integration.integration_service.get_organization_integration"
+    )
+    @patch("sentry.integrations.services.integration.integration_service.get_integration")
+    @patch(
+        "sentry.integrations.api.endpoints.organization_coding_agents.store_coding_agent_state_to_seer"
+    )
+    def test_seer_storage_failure_continues(
+        self,
+        mock_store_to_seer,
+        mock_get_integration,
+        mock_get_org_integration,
+        mock_get_prompt,
+        mock_get_autofix_state,
+        mock_get_providers,
+    ):
+        """Test POST endpoint continues when Seer storage fails."""
+        mock_get_providers.return_value = ["github"]
+        mock_get_prompt.return_value = "Test prompt for seer storage failure"
+        mock_store_to_seer.return_value = False  # Simulate Seer storage failure
+
+        mock_rpc_integration = self._create_mock_rpc_integration()
+        mock_get_org_integration.return_value = self.rpc_org_integration
+        mock_get_integration.return_value = mock_rpc_integration
+        mock_get_autofix_state.return_value = self._create_mock_autofix_state()
+
+        data = {"integration_id": str(self.integration.id), "run_id": 123}
+
+        with self.feature("organizations:seer-coding-agent-integrations"):
+            response = self.get_success_response(self.organization.slug, method="post", **data)
+            # Should still succeed even if Seer storage fails
+            assert response.data["success"] is True
+            # Verify Seer storage was attempted
+            mock_store_to_seer.assert_called_once()
+
+
+class OrganizationCodingAgentsPostTriggerSourceTest(BaseOrganizationCodingAgentsTest):
+    """Test class for POST endpoint trigger source functionality."""
+
+    @patch(
+        "sentry.integrations.api.endpoints.organization_coding_agents.get_coding_agent_providers"
+    )
+    @patch("sentry.integrations.api.endpoints.organization_coding_agents.get_autofix_state")
+    @patch("sentry.integrations.api.endpoints.organization_coding_agents.get_coding_agent_prompt")
+    @patch(
+        "sentry.integrations.services.integration.integration_service.get_organization_integration"
+    )
+    @patch("sentry.integrations.services.integration.integration_service.get_integration")
+    def test_root_cause_trigger_source(
+        self,
+        mock_get_integration,
+        mock_get_org_integration,
+        mock_get_prompt,
+        mock_get_autofix_state,
+        mock_get_providers,
+    ):
+        """Test POST endpoint with root_cause trigger_source."""
+        mock_get_providers.return_value = ["github"]
+        mock_get_prompt.return_value = "Root cause prompt"
+
+        mock_rpc_integration = self._create_mock_rpc_integration()
+        mock_get_org_integration.return_value = self.rpc_org_integration
+        mock_get_integration.return_value = mock_rpc_integration
+        mock_get_autofix_state.return_value = self._create_mock_autofix_state()
+
+        data = {
+            "integration_id": str(self.integration.id),
+            "run_id": 123,
+            "trigger_source": "root_cause",
+        }
+
+        with self.feature("organizations:seer-coding-agent-integrations"):
+            response = self.get_success_response(self.organization.slug, method="post", **data)
+            assert response.data["success"] is True
+
+            # Verify prompt was called with root_cause trigger_source
+            mock_get_prompt.assert_called_with(123, "root_cause")
+
+    @patch(
+        "sentry.integrations.api.endpoints.organization_coding_agents.get_coding_agent_providers"
+    )
+    @patch("sentry.integrations.api.endpoints.organization_coding_agents.get_autofix_state")
+    @patch("sentry.integrations.api.endpoints.organization_coding_agents.get_coding_agent_prompt")
+    @patch(
+        "sentry.integrations.services.integration.integration_service.get_organization_integration"
+    )
+    @patch("sentry.integrations.services.integration.integration_service.get_integration")
+    def test_solution_trigger_source(
+        self,
+        mock_get_integration,
+        mock_get_org_integration,
+        mock_get_prompt,
+        mock_get_autofix_state,
+        mock_get_providers,
+    ):
+        """Test POST endpoint with solution trigger_source."""
+        mock_get_providers.return_value = ["github"]
+        mock_get_prompt.return_value = "Solution prompt"
+
+        mock_rpc_integration = self._create_mock_rpc_integration()
+        mock_get_org_integration.return_value = self.rpc_org_integration
+        mock_get_integration.return_value = mock_rpc_integration
+        mock_get_autofix_state.return_value = self._create_mock_autofix_state()
+
+        data = {
+            "integration_id": str(self.integration.id),
+            "run_id": 123,
+            "trigger_source": "solution",
+        }
+
+        with self.feature("organizations:seer-coding-agent-integrations"):
+            response = self.get_success_response(self.organization.slug, method="post", **data)
+            assert response.data["success"] is True
+
+            # Verify prompt was called with solution trigger_source
+            mock_get_prompt.assert_called_with(123, "solution")
+
+    @patch(
+        "sentry.integrations.api.endpoints.organization_coding_agents.get_coding_agent_providers"
+    )
+    @patch("sentry.integrations.api.endpoints.organization_coding_agents.get_autofix_state")
+    @patch(
+        "sentry.integrations.services.integration.integration_service.get_organization_integration"
+    )
+    @patch("sentry.integrations.services.integration.integration_service.get_integration")
+    def test_invalid_trigger_source(
+        self,
+        mock_get_integration,
+        mock_get_org_integration,
+        mock_get_autofix_state,
+        mock_get_providers,
+    ):
+        """Test POST endpoint with invalid trigger_source."""
+        mock_get_providers.return_value = ["github"]
+
+        mock_rpc_integration = self._create_mock_rpc_integration()
+        mock_get_org_integration.return_value = self.rpc_org_integration
+        mock_get_integration.return_value = mock_rpc_integration
+        mock_get_autofix_state.return_value = self._create_mock_autofix_state()
+
+        data = {
+            "integration_id": str(self.integration.id),
+            "run_id": 123,
+            "trigger_source": "invalid_source",
+        }
+
+        with self.feature("organizations:seer-coding-agent-integrations"):
+            response = self.get_error_response(
+                self.organization.slug, method="post", status_code=400, **data
+            )
+            assert (
+                response.data["error"]
+                == "Invalid trigger_source. Must be 'root_cause' or 'solution'"
+            )
+
+    @patch(
+        "sentry.integrations.api.endpoints.organization_coding_agents.get_coding_agent_providers"
+    )
+    @patch("sentry.integrations.api.endpoints.organization_coding_agents.get_autofix_state")
+    @patch("sentry.integrations.api.endpoints.organization_coding_agents.get_coding_agent_prompt")
+    @patch(
+        "sentry.integrations.services.integration.integration_service.get_organization_integration"
+    )
+    @patch("sentry.integrations.services.integration.integration_service.get_integration")
+    def test_prompt_not_available(
+        self,
+        mock_get_integration,
+        mock_get_org_integration,
+        mock_get_prompt,
+        mock_get_autofix_state,
+        mock_get_providers,
+    ):
+        """Test POST endpoint when prompt is not available."""
+        mock_get_providers.return_value = ["github"]
+        mock_get_prompt.return_value = None  # Prompt not available
+
+        mock_rpc_integration = self._create_mock_rpc_integration()
+        mock_get_org_integration.return_value = self.rpc_org_integration
+        mock_get_integration.return_value = mock_rpc_integration
+        mock_get_autofix_state.return_value = self._create_mock_autofix_state()
+
+        data = {
+            "integration_id": str(self.integration.id),
+            "run_id": 123,
+            "trigger_source": "solution",
+        }
+
+        with self.feature("organizations:seer-coding-agent-integrations"):
+            response = self.get_error_response(
+                self.organization.slug, method="post", status_code=500, **data
+            )
+            assert response.data["error"] == "No agents were successfully launched"


### PR DESCRIPTION
- Add POST method to OrganizationCodingAgentsEndpoint for launching coding agents
- Support launching agents for multiple repositories from autofix solutions
- Include branch name sanitization and stores coding agent state to Seer on trigger
- Feature flagged behind `organizations:seer-coding-agent-integrations`

Adds the POST endpoint that enables launching coding agents from the Seer UI. The endpoint:

1. Validates the integration and autofix state
2. Extracts repositories from the autofix solution
3. Generates appropriate prompts based on trigger source
4. Launches coding agents for each repository
5. Stores the agent state in Seer for tracking
6. Handles errors gracefully and continues processing other repos

**Stacked on:** #97986