### PR TITLE
fix(typing): Codemod return types for literal returns

### DIFF
--- a/fixtures/integrations/jira/stub_client.py
+++ b/fixtures/integrations/jira/stub_client.py
@@ -44,7 +44,7 @@ class StubJiraApiClient(StubService):
     def transition_issue(self, issue_key, transition_id):
         pass
 
-    def user_id_field(self):
+    def user_id_field(self) -> str:
         return "accountId"
 
     def get_user(self, user_id):

--- a/src/sentry/api/bases/avatar.py
+++ b/src/sentry/api/bases/avatar.py
@@ -59,7 +59,7 @@ class AvatarMixin(Generic[AvatarT]):
     def get_serializer_context(self, obj, **kwargs: Any):
         return {"type": self.model, "kwargs": {self.object_type: obj}}
 
-    def get_avatar_filename(self, obj):
+    def get_avatar_filename(self, obj) -> str:
         return f"{obj.id}.png"
 
     def parse(self, request: Request, **kwargs: Any) -> tuple[Any, serializers.Serializer]:

--- a/src/sentry/api/endpoints/organization_member/utils.py
+++ b/src/sentry/api/endpoints/organization_member/utils.py
@@ -50,5 +50,5 @@ class RelaxedMemberPermission(OrganizationPermission):
 
     # Allow deletions to happen for disabled members so they can remove themselves
     # allowing other methods should be fine as well even if we don't strictly need to allow them
-    def is_member_disabled_from_limit(self, request: Request, organization):
+    def is_member_disabled_from_limit(self, request: Request, organization) -> bool:
         return False

--- a/src/sentry/audit_log/events.py
+++ b/src/sentry/audit_log/events.py
@@ -230,7 +230,7 @@ class ProjectOwnershipRuleEditAuditLogEvent(AuditLogEvent):
             event_id=179, name="PROJECT_OWNERSHIPRULE_EDIT", api_name="project.ownership-rule.edit"
         )
 
-    def render(self, audit_log_entry: AuditLogEntry):
+    def render(self, audit_log_entry: AuditLogEntry) -> str:
         return "modified ownership rules"
 
 

--- a/src/sentry/codecov/endpoints/test_results/test_results.py
+++ b/src/sentry/codecov/endpoints/test_results/test_results.py
@@ -31,7 +31,7 @@ class TestResultsEndpoint(CodecovEndpoint):
     }
 
     # Disable pagination requirement for this endpoint
-    def has_pagination(self, response):
+    def has_pagination(self, response) -> bool:
         return True
 
     @extend_schema(

--- a/src/sentry/db/models/fields/array.py
+++ b/src/sentry/db/models/fields/array.py
@@ -38,10 +38,10 @@ class ArrayField(models.Field):
         super().contribute_to_class(cls, name, private_only=private_only)
         setattr(cls, name, Creator(self))
 
-    def db_type(self, connection):
+    def db_type(self, connection) -> str:
         return f"{self.of.db_type(connection)}[]"
 
-    def get_internal_type(self):
+    def get_internal_type(self) -> str:
         return "TextField"
 
     def get_prep_value(self, value):

--- a/src/sentry/db/models/fields/jsonfield.py
+++ b/src/sentry/db/models/fields/jsonfield.py
@@ -96,10 +96,10 @@ class JSONField(models.TextField):
             return json.loads(self.json_dumps(default))
         return super().get_default()
 
-    def get_internal_type(self):
+    def get_internal_type(self) -> str:
         return "TextField"
 
-    def db_type(self, connection):
+    def db_type(self, connection) -> str:
         return "text"
 
     def to_python(self, value):

--- a/src/sentry/db/models/fields/uuid.py
+++ b/src/sentry/db/models/fields/uuid.py
@@ -89,10 +89,10 @@ class UUIDField(models.Field):
         # Now pass the rest of the work to CharField.
         super().__init__(**kwargs)
 
-    def db_type(self, connection):
+    def db_type(self, connection) -> str:
         return "uuid"
 
-    def get_internal_type(self):
+    def get_internal_type(self) -> str:
         return "CharField"
 
     def get_prep_value(self, value):

--- a/src/sentry/identity/slack/provider.py
+++ b/src/sentry/identity/slack/provider.py
@@ -18,14 +18,14 @@ class SlackIdentityProvider(OAuth2Provider):
     # user_scope, needed for unfurling.
     user_scopes = ()
 
-    def get_oauth_authorize_url(self):
+    def get_oauth_authorize_url(self) -> str:
         return "https://slack.com/oauth/v2/authorize"
 
     # XXX(epurkhiser): While workspace tokens _do_ support the oauth.access
     # endpoint, it will not include the authorizing_user, so we continue to use
     # the deprecated oauth.token endpoint until we are able to migrate to a bot
     # app which uses oauth.access.
-    def get_oauth_access_token_url(self):
+    def get_oauth_access_token_url(self) -> str:
         return "https://slack.com/api/oauth.v2.access"
 
     def get_oauth_client_id(self):

--- a/src/sentry/integrations/api/endpoints/doc_integration_avatar.py
+++ b/src/sentry/integrations/api/endpoints/doc_integration_avatar.py
@@ -20,5 +20,5 @@ class DocIntegrationAvatarEndpoint(AvatarMixin[DocIntegrationAvatar], DocIntegra
     model = DocIntegrationAvatar
     serializer_cls = DocIntegrationAvatarSerializer
 
-    def get_avatar_filename(self, obj):
+    def get_avatar_filename(self, obj) -> str:
         return f"{obj.slug}.png"

--- a/src/sentry/integrations/bitbucket/search.py
+++ b/src/sentry/integrations/bitbucket/search.py
@@ -30,7 +30,7 @@ class BitbucketSearchEndpoint(SourceCodeSearchEndpoint):
     }
 
     @property
-    def repository_field(self):
+    def repository_field(self) -> str:
         return "repo"
 
     @property

--- a/src/sentry/integrations/example/integration.py
+++ b/src/sentry/integrations/example/integration.py
@@ -85,7 +85,7 @@ class ExampleIntegration(RepositoryIntegration, SourceCodeIssueIntegration, Issu
     def get_client(self):
         pass
 
-    def get_issue_url(self, key):
+    def get_issue_url(self, key) -> str:
         return f"https://example/issues/{key}"
 
     def create_comment(self, issue_id, user_id, group_note):
@@ -173,7 +173,7 @@ class ExampleIntegration(RepositoryIntegration, SourceCodeIssueIntegration, Issu
             should_unresolve=category != "done",
         )
 
-    def get_issue_display_name(self, external_issue):
+    def get_issue_display_name(self, external_issue) -> str:
         return f"display name: {external_issue.key}"
 
     def get_stacktrace_link(

--- a/src/sentry/integrations/github/search.py
+++ b/src/sentry/integrations/github/search.py
@@ -22,7 +22,7 @@ class GithubSharedSearchEndpoint(SourceCodeSearchEndpoint):
     """NOTE: This endpoint is a shared search endpoint for Github and Github Enterprise integrations."""
 
     @property
-    def repository_field(self):
+    def repository_field(self) -> str:
         return "repo"
 
     @property

--- a/src/sentry/integrations/gitlab/repository.py
+++ b/src/sentry/integrations/gitlab/repository.py
@@ -119,7 +119,7 @@ class GitlabRepositoryProvider(IntegrationRepositoryProvider):
 
         return file_changes
 
-    def pull_request_url(self, repo, pull_request):
+    def pull_request_url(self, repo, pull_request) -> str:
         return f"{repo.url}/merge_requests/{pull_request.key}"
 
     def repository_external_slug(self, repo):

--- a/src/sentry/integrations/gitlab/search.py
+++ b/src/sentry/integrations/gitlab/search.py
@@ -17,7 +17,7 @@ T = TypeVar("T", bound=SourceCodeIssueIntegration)
 @control_silo_endpoint
 class GitlabIssueSearchEndpoint(SourceCodeSearchEndpoint):
     @property
-    def repository_field(self):
+    def repository_field(self) -> str:
         return "project"
 
     @property

--- a/src/sentry/integrations/gitlab/utils.py
+++ b/src/sentry/integrations/gitlab/utils.py
@@ -49,7 +49,7 @@ class GitLabApiClientPath:
     user = "/user"
 
     @staticmethod
-    def build_api_url(base_url, path):
+    def build_api_url(base_url, path) -> str:
         return f"{base_url.rstrip('/')}{API_VERSION}{path}"
 
     @classmethod

--- a/src/sentry/integrations/jira/client.py
+++ b/src/sentry/integrations/jira/client.py
@@ -86,7 +86,7 @@ class JiraCloudClient(ApiClient):
         prepared_request.headers["Authorization"] = f"JWT {encoded_jwt}"
         return prepared_request
 
-    def get_cache_prefix(self):
+    def get_cache_prefix(self) -> str:
         return "sentry-jira-2:"
 
     def user_id_get_param(self):

--- a/src/sentry/integrations/jira_server/client.py
+++ b/src/sentry/integrations/jira_server/client.py
@@ -73,7 +73,7 @@ class JiraServerClient(ApiClient):
             logging_context=logging_context,
         )
 
-    def get_cache_prefix(self):
+    def get_cache_prefix(self) -> str:
         return "sentry-jira-server:"
 
     def finalize_request(self, prepared_request: PreparedRequest) -> PreparedRequest:
@@ -95,13 +95,13 @@ class JiraServerClient(ApiClient):
         prepared_request.prepare_auth(auth=auth_scheme)
         return prepared_request
 
-    def user_id_get_param(self):
+    def user_id_get_param(self) -> str:
         return "username"
 
-    def user_id_field(self):
+    def user_id_field(self) -> str:
         return "name"
 
-    def user_query_param(self):
+    def user_query_param(self) -> str:
         return "username"
 
     def get_issue(self, issue_id):

--- a/src/sentry/integrations/mixins/issues.py
+++ b/src/sentry/integrations/mixins/issues.py
@@ -70,7 +70,7 @@ class ResolveSyncAction(enum.Enum):
 
 
 class IssueBasicIntegration(IntegrationInstallation, ABC):
-    def should_sync(self, attribute, sync_source: AssignmentSource | None = None):
+    def should_sync(self, attribute, sync_source: AssignmentSource | None = None) -> bool:
         return False
 
     def get_group_title(self, group, event, **kwargs):

--- a/src/sentry/integrations/models/doc_integration_avatar.py
+++ b/src/sentry/integrations/models/doc_integration_avatar.py
@@ -29,5 +29,5 @@ class DocIntegrationAvatar(ControlAvatarBase):
 
     url_path = "doc-integration-avatar"
 
-    def get_cache_key(self, size):
+    def get_cache_key(self, size) -> str:
         return f"doc_integration_avatar:{self.doc_integration_id}:{size}"

--- a/src/sentry/integrations/models/utils.py
+++ b/src/sentry/integrations/models/utils.py
@@ -35,5 +35,5 @@ def has_feature(instance: Integration | RpcIntegration, feature: IntegrationFeat
     return feature in instance.get_provider().features
 
 
-def get_redis_key(sentryapp: SentryApp | RpcSentryApp, org_id):
+def get_redis_key(sentryapp: SentryApp | RpcSentryApp, org_id) -> str:
     return f"sentry-app-error:{sentryapp.id}:{org_id}"

--- a/src/sentry/integrations/web/integration_extension_configuration.py
+++ b/src/sentry/integrations/web/integration_extension_configuration.py
@@ -134,7 +134,7 @@ class IntegrationExtensionConfigurationView(BaseView):
     def map_params_to_state(self, params):
         return params
 
-    def is_enabled_for_org(self, _org, _user):
+    def is_enabled_for_org(self, _org, _user) -> bool:
         return True
 
     def has_one_required_feature(self, org, user):

--- a/src/sentry/lang/dart/plugin.py
+++ b/src/sentry/lang/dart/plugin.py
@@ -13,7 +13,7 @@ class DartPlugin(Plugin2):
     This plugin is responsible for Dart specific processing on events or attachments.
     """
 
-    def can_configure_for_project(self, project, **kwargs):
+    def can_configure_for_project(self, project, **kwargs) -> bool:
         return False
 
     def get_event_preprocessors(self, data: Mapping[str, Any]) -> Sequence[EventPreprocessor]:

--- a/src/sentry/lang/java/plugin.py
+++ b/src/sentry/lang/java/plugin.py
@@ -11,7 +11,7 @@ from sentry.plugins.base.v2 import EventPreprocessor, Plugin2
 class JavaPlugin(Plugin2):
     can_disable = False
 
-    def can_configure_for_project(self, project, **kwargs):
+    def can_configure_for_project(self, project, **kwargs) -> bool:
         return False
 
     def get_stacktrace_processors(self, data, stacktrace_infos, platforms, **kwargs):

--- a/src/sentry/lang/javascript/plugin.py
+++ b/src/sentry/lang/javascript/plugin.py
@@ -36,7 +36,7 @@ def generate_modules(data):
 class JavascriptPlugin(Plugin2):
     can_disable = False
 
-    def can_configure_for_project(self, project, **kwargs):
+    def can_configure_for_project(self, project, **kwargs) -> bool:
         return False
 
     def get_event_preprocessors(self, data: Mapping[str, Any]) -> Sequence[EventPreprocessor]:

--- a/src/sentry/models/apigrant.py
+++ b/src/sentry/models/apigrant.py
@@ -107,7 +107,7 @@ class ApiGrant(Model):
         return uri == self.redirect_uri
 
     @classmethod
-    def get_lock_key(cls, grant_id):
+    def get_lock_key(cls, grant_id) -> str:
         return f"api_grant:{grant_id}"
 
     @classmethod

--- a/src/sentry/models/avatars/organization_avatar.py
+++ b/src/sentry/models/avatars/organization_avatar.py
@@ -30,5 +30,5 @@ class OrganizationAvatar(AvatarBase):
         app_label = "sentry"
         db_table = "sentry_organizationavatar"
 
-    def get_cache_key(self, size):
+    def get_cache_key(self, size) -> str:
         return f"org_avatar:{self.organization_id}:{size}"

--- a/src/sentry/models/environment.py
+++ b/src/sentry/models/environment.py
@@ -65,7 +65,7 @@ class Environment(Model):
         return OK_NAME_PATTERN.match(value) is not None
 
     @classmethod
-    def get_cache_key(cls, organization_id, name):
+    def get_cache_key(cls, organization_id, name) -> str:
         return f"env:2:{organization_id}:{md5_text(name).hexdigest()}"
 
     @classmethod

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -730,7 +730,7 @@ class Group(Model):
                 teams=[],
             )
 
-        def _cache_key(issue_id):
+        def _cache_key(issue_id) -> str:
             return f"group:has_replays:{issue_id}"
 
         from sentry.replays.usecases.replay_counts import get_replay_counts
@@ -1006,7 +1006,7 @@ class Group(Model):
         warnings.warn("Group.checksum is no longer used", DeprecationWarning)
         return ""
 
-    def get_email_subject(self):
+    def get_email_subject(self) -> str:
         return f"{self.qualified_short_id} - {self.title}"
 
     def count_users_seen(

--- a/src/sentry/models/groupenvironment.py
+++ b/src/sentry/models/groupenvironment.py
@@ -34,7 +34,7 @@ class GroupEnvironment(Model):
     __repr__ = sane_repr("group_id", "environment_id")
 
     @classmethod
-    def _get_cache_key(self, group_id, environment_id):
+    def _get_cache_key(self, group_id, environment_id) -> str:
         return f"groupenv:1:{group_id}:{environment_id}"
 
     @classmethod

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -672,7 +672,7 @@ class Project(Model):
                 self.update_option("sentry:token", security_token)
             return security_token
 
-    def get_lock_key(self):
+    def get_lock_key(self) -> str:
         return f"project_token:{self.id}"
 
     def copy_settings_from(self, project_id: int) -> bool:

--- a/src/sentry/models/projectkey.py
+++ b/src/sentry/models/projectkey.py
@@ -272,11 +272,11 @@ class ProjectKey(Model):
         return f"{endpoint}/api/{self.project_id}/otlp/v1/traces"
 
     @property
-    def unreal_endpoint(self):
+    def unreal_endpoint(self) -> str:
         return f"{self.get_endpoint()}/api/{self.project_id}/unreal/{self.public_key}/"
 
     @property
-    def crons_endpoint(self):
+    def crons_endpoint(self) -> str:
         return f"{self.get_endpoint()}/api/{self.project_id}/cron/___MONITOR_SLUG___/{self.public_key}/"
 
     @property

--- a/src/sentry/models/projectsdk.py
+++ b/src/sentry/models/projectsdk.py
@@ -53,11 +53,11 @@ class ProjectSDK(DefaultFieldsModel):
     __repr__ = sane_repr("project", "event_type", "sdk_name", "sdk_version")
 
     @classmethod
-    def get_lock_key(cls, project: Project, event_type: EventType, sdk_name: str):
+    def get_lock_key(cls, project: Project, event_type: EventType, sdk_name: str) -> str:
         return f"lprojectsdk:{project.id}:{event_type.value}:{md5_text(sdk_name).hexdigest()}"
 
     @classmethod
-    def get_cache_key(cls, project: Project, event_type: EventType, sdk_name: str):
+    def get_cache_key(cls, project: Project, event_type: EventType, sdk_name: str) -> str:
         return f"projectsdk:{project.id}:{event_type.value}:{md5_text(sdk_name).hexdigest()}"
 
     @classmethod

--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -386,11 +386,11 @@ class Release(Model):
         )
 
     @classmethod
-    def get_cache_key(cls, organization_id, version):
+    def get_cache_key(cls, organization_id, version) -> str:
         return f"release:3:{organization_id}:{md5_text(version).hexdigest()}"
 
     @classmethod
-    def get_lock_key(cls, organization_id, release_id):
+    def get_lock_key(cls, organization_id, release_id) -> str:
         return f"releasecommits:{organization_id}:{release_id}"
 
     @classmethod

--- a/src/sentry/models/releaseenvironment.py
+++ b/src/sentry/models/releaseenvironment.py
@@ -35,7 +35,7 @@ class ReleaseEnvironment(Model):
     __repr__ = sane_repr("organization_id", "release_id", "environment_id")
 
     @classmethod
-    def get_cache_key(cls, organization_id, release_id, environment_id):
+    def get_cache_key(cls, organization_id, release_id, environment_id) -> str:
         return f"releaseenv:2:{organization_id}:{release_id}:{environment_id}"
 
     @classmethod

--- a/src/sentry/models/releaseprojectenvironment.py
+++ b/src/sentry/models/releaseprojectenvironment.py
@@ -51,7 +51,7 @@ class ReleaseProjectEnvironment(Model):
     __repr__ = sane_repr("project", "release", "environment")
 
     @classmethod
-    def get_cache_key(cls, release_id, project_id, environment_id):
+    def get_cache_key(cls, release_id, project_id, environment_id) -> str:
         return f"releaseprojectenv:{release_id}:{project_id}:{environment_id}"
 
     @classmethod

--- a/src/sentry/models/team.py
+++ b/src/sentry/models/team.py
@@ -143,7 +143,7 @@ class Team(ReplicatedRegionModel):
 
     __repr__ = sane_repr("name", "slug")
 
-    def class_name(self):
+    def class_name(self) -> str:
         return "Team"
 
     def __str__(self) -> str:

--- a/src/sentry/plugins/base/v1.py
+++ b/src/sentry/plugins/base/v1.py
@@ -80,10 +80,10 @@ class IPlugin(local, PluggableViewMixin, PluginConfigMixin):
     # used by queries to determine if the plugin is configured
     required_field: str | None = None
 
-    def _get_option_key(self, key):
+    def _get_option_key(self, key) -> str:
         return f"{self.get_conf_key()}:{key}"
 
-    def get_plugin_type(self):
+    def get_plugin_type(self) -> str:
         return "default"
 
     def is_enabled(self, project: Project | RpcProject | None = None):

--- a/src/sentry/plugins/base/v2.py
+++ b/src/sentry/plugins/base/v2.py
@@ -78,10 +78,10 @@ class IPlugin2(local, PluginConfigMixin):
     # used by queries to determine if the plugin is configured
     required_field: str | None = None
 
-    def _get_option_key(self, key):
+    def _get_option_key(self, key) -> str:
         return f"{self.get_conf_key()}:{key}"
 
-    def get_plugin_type(self):
+    def get_plugin_type(self) -> str:
         return "default"
 
     def is_enabled(self, project=None):

--- a/src/sentry/plugins/bases/data_forwarding.py
+++ b/src/sentry/plugins/bases/data_forwarding.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 
 class DataForwardingPlugin(Plugin):
-    def has_project_conf(self):
+    def has_project_conf(self) -> bool:
         return True
 
     def get_rate_limit(self):
@@ -28,10 +28,10 @@ class DataForwardingPlugin(Plugin):
     def get_event_payload(self, event):
         return serialize(event)
 
-    def get_plugin_type(self):
+    def get_plugin_type(self) -> str:
         return "data-forwarding"
 
-    def get_rl_key(self, event):
+    def get_rl_key(self, event) -> str:
         return f"{self.conf_key}:{event.project.organization_id}"
 
     def initialize_variables(self, event):

--- a/src/sentry/plugins/bases/issue.py
+++ b/src/sentry/plugins/bases/issue.py
@@ -30,7 +30,7 @@ class IssueTrackingPlugin(Plugin):
     needs_auth_template = "sentry/plugins/bases/issue/needs_auth.html"
     auth_provider: str | None = None
 
-    def get_plugin_type(self):
+    def get_plugin_type(self) -> str:
         return "issue-tracking"
 
     def _get_group_body(self, group, event, **kwargs):

--- a/src/sentry/plugins/bases/issue2.py
+++ b/src/sentry/plugins/bases/issue2.py
@@ -95,10 +95,10 @@ class IssueTrackingPlugin2(Plugin):
     issue_fields: frozenset[str] | None = None
     # issue_fields = frozenset(['id', 'title', 'url'])
 
-    def get_plugin_type(self):
+    def get_plugin_type(self) -> str:
         return "issue-tracking"
 
-    def has_project_conf(self):
+    def has_project_conf(self) -> bool:
         return True
 
     def get_group_body(self, group, event, **kwargs):

--- a/src/sentry/plugins/bases/notify.py
+++ b/src/sentry/plugins/bases/notify.py
@@ -27,7 +27,7 @@ class NotificationPlugin(Plugin):
     )
     project_conf_form: type[forms.Form] = NotificationConfigurationForm
 
-    def get_plugin_type(self):
+    def get_plugin_type(self) -> str:
         return "notification"
 
     def notify(self, notification: Notification, raise_exception: bool = False) -> None:

--- a/src/sentry/plugins/bases/releasetracking.py
+++ b/src/sentry/plugins/bases/releasetracking.py
@@ -2,7 +2,7 @@ from sentry.plugins.base.v2 import Plugin2
 
 
 class ReleaseTrackingPlugin(Plugin2):
-    def get_plugin_type(self):
+    def get_plugin_type(self) -> str:
         return "release-tracking"
 
     def get_release_doc_html(self, hook_url):

--- a/src/sentry/plugins/examples/issue_tracking.py
+++ b/src/sentry/plugins/examples/issue_tracking.py
@@ -28,7 +28,7 @@ class ExampleIssueTrackingPlugin(IssuePlugin2):
             *fields,
         ]
 
-    def create_issue(self, request: Request, group, form_data):
+    def create_issue(self, request: Request, group, form_data) -> str:
         return "1"
 
     def get_issue_label(self, group, issue_id: str) -> str:

--- a/src/sentry/relay/projectconfig_cache/redis.py
+++ b/src/sentry/relay/projectconfig_cache/redis.py
@@ -27,10 +27,10 @@ class RedisProjectConfigCache(ProjectConfigCache):
     def validate(self):
         validate_dynamic_cluster(True, self.cluster)
 
-    def __get_redis_key(self, public_key):
+    def __get_redis_key(self, public_key) -> str:
         return f"relayconfig:{public_key}"
 
-    def __get_redis_rev_key(self, public_key):
+    def __get_redis_rev_key(self, public_key) -> str:
         return f"{self.__get_redis_key(public_key)}.rev"
 
     def set_many(self, configs: dict[str, Mapping[str, Any]]):

--- a/src/sentry/sentry_apps/api/endpoints/sentry_app_avatar.py
+++ b/src/sentry/sentry_apps/api/endpoints/sentry_app_avatar.py
@@ -32,5 +32,5 @@ class SentryAppAvatarEndpoint(AvatarMixin[SentryAppAvatar], SentryAppBaseEndpoin
             request, access=request.access, serializer=SentryAppSerializer(), **kwargs
         )
 
-    def get_avatar_filename(self, obj):
+    def get_avatar_filename(self, obj) -> str:
         return f"{obj.slug}.png"

--- a/src/sentry/sentry_metrics/indexer/cache.py
+++ b/src/sentry/sentry_metrics/indexer/cache.py
@@ -75,7 +75,7 @@ class StringIndexerCache:
 
         return f"indexer:{self.partition_key}:{namespace}:org:str:{use_case_id}:{hashed}"
 
-    def _make_cache_val(self, val: int, timestamp: int):
+    def _make_cache_val(self, val: int, timestamp: int) -> str:
         return f"{val}:{timestamp}"
 
     def _format_results(

--- a/src/sentry/similarity/backends/dummy.py
+++ b/src/sentry/similarity/backends/dummy.py
@@ -11,10 +11,10 @@ class DummyIndexBackend(AbstractIndexBackend):
     def record(self, scope, key, items, timestamp=None):
         return {}
 
-    def merge(self, scope, destination, items, timestamp=None):
+    def merge(self, scope, destination, items, timestamp=None) -> bool:
         return False
 
-    def delete(self, scope, items, timestamp=None):
+    def delete(self, scope, items, timestamp=None) -> bool:
         return False
 
     def scan(self, scope, indices, batch=1000, timestamp=None):

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -1457,7 +1457,7 @@ class SnubaFlagStorage(SnubaTagStorage):
     def get_generic_groups_user_counts(self, *args, **kwargs):
         raise NotImplementedError
 
-    def get_snuba_column_name(self, key: str, dataset: Dataset):
+    def get_snuba_column_name(self, key: str, dataset: Dataset) -> str:
         return f"flags[{key}]"
 
     def is_reserved_key(self, key: str) -> bool:

--- a/src/sentry/tasks/check_am2_compatibility.py
+++ b/src/sentry/tasks/check_am2_compatibility.py
@@ -296,11 +296,11 @@ class CheckStatus(Enum):
 
 class CheckAM2Compatibility:
     @classmethod
-    def get_widget_url(cls, org_slug, dashboard_id, widget_id):
+    def get_widget_url(cls, org_slug, dashboard_id, widget_id) -> str:
         return f"https://{org_slug}.sentry.io/organizations/{org_slug}/dashboard/{dashboard_id}/widget/{widget_id}/"
 
     @classmethod
-    def get_alert_url(cls, org_slug, alert_id):
+    def get_alert_url(cls, org_slug, alert_id) -> str:
         return f"https://{org_slug}.sentry.io/organizations/{org_slug}/alerts/rules/details/{alert_id}/"
 
     @classmethod
@@ -658,11 +658,11 @@ class CheckAM2Compatibility:
         )
 
 
-def generate_cache_key_for_async_progress(org_id):
+def generate_cache_key_for_async_progress(org_id) -> str:
     return f"ds::o:{org_id}:check_am2_compatibility_status"
 
 
-def generate_cache_key_for_async_result(org_id):
+def generate_cache_key_for_async_result(org_id) -> str:
     return f"ds::o:{org_id}:check_am2_compatibility_results"
 
 

--- a/src/sentry/testutils/helpers/notifications.py
+++ b/src/sentry/testutils/helpers/notifications.py
@@ -34,7 +34,7 @@ class DummyNotification(BaseNotification):
     def determine_recipients(self) -> list[Actor]:
         return []
 
-    def build_attachment_title(self, *args):
+    def build_attachment_title(self, *args) -> str:
         return "My Title"
 
     def get_title_link(self, *args):
@@ -87,10 +87,10 @@ class DummyNotificationWithMoreFields(DummyNotification):
         some_value = context["some_field"]
         return f"Notification Title with {some_value}"
 
-    def build_notification_footer(self, *args):
+    def build_notification_footer(self, *args) -> str:
         return "Notification Footer"
 
-    def get_message_description(self, recipient: Actor, provider: ExternalProviders):
+    def get_message_description(self, recipient: Actor, provider: ExternalProviders) -> str:
         return "Message Description"
 
     def get_title_link(self, *args):

--- a/src/sentry/testutils/pytest/fixtures.py
+++ b/src/sentry/testutils/pytest/fixtures.py
@@ -196,7 +196,7 @@ def log():
 class ReadableYamlDumper(yaml.dumper.SafeDumper):
     """Disable pyyaml aliases for identical object references"""
 
-    def ignore_aliases(self, data):
+    def ignore_aliases(self, data) -> bool:
         return True
 
 

--- a/src/sentry/testutils/pytest/relay.py
+++ b/src/sentry/testutils/pytest/relay.py
@@ -24,7 +24,7 @@ RELAY_TEST_IMAGE = environ.get(
 )
 
 
-def _relay_server_container_name():
+def _relay_server_container_name() -> str:
     return "sentry_test_relay_server"
 
 

--- a/src/sentry/uptime/detectors/ranking.py
+++ b/src/sentry/uptime/detectors/ranking.py
@@ -142,7 +142,7 @@ def get_project_base_url_rank_key(project: Project) -> str:
     return f"p:r:{project.id}"
 
 
-def build_organization_bucket_key(bucket: int):
+def build_organization_bucket_key(bucket: int) -> str:
     return f"o:{bucket}"
 
 

--- a/src/sentry/utils/session_store.py
+++ b/src/sentry/utils/session_store.py
@@ -60,7 +60,7 @@ class RedisSessionStore:
         return clusters.get("default").get_local_client_for_key(self.redis_key)
 
     @property
-    def session_key(self):
+    def session_key(self) -> str:
         return f"store:{self.prefix}"
 
     @property

--- a/src/sentry/web/frontend/debug/debug_incident_trigger_email.py
+++ b/src/sentry/web/frontend/debug/debug_incident_trigger_email.py
@@ -74,9 +74,9 @@ class DebugIncidentTriggerEmailView(MailPreviewView):
         )
 
     @property
-    def html_template(self):
+    def html_template(self) -> str:
         return "sentry/emails/incidents/trigger.html"
 
     @property
-    def text_template(self):
+    def text_template(self) -> str:
         return "sentry/emails/incidents/trigger.txt"

--- a/src/sentry/web/frontend/debug/debug_weekly_report.py
+++ b/src/sentry/web/frontend/debug/debug_weekly_report.py
@@ -118,9 +118,9 @@ class DebugWeeklyReportView(MailPreviewView):
         return render_template_context(ctx, None)
 
     @property
-    def html_template(self):
+    def html_template(self) -> str:
         return "sentry/emails/reports/body.html"
 
     @property
-    def text_template(self):
+    def text_template(self) -> str:
         return "sentry/emails/reports/body.txt"

--- a/src/sentry/web/frontend/disabled_member_view.py
+++ b/src/sentry/web/frontend/disabled_member_view.py
@@ -10,7 +10,7 @@ from .react_page import ReactPageView
 
 @control_silo_view
 class DisabledMemberView(ReactPageView):
-    def is_member_disabled_from_limit(self, request: object, organization):
+    def is_member_disabled_from_limit(self, request: object, organization) -> bool:
         return False
 
     def handle(self, request: HttpRequest, organization, **kwargs) -> HttpResponse:

--- a/src/sentry_plugins/bitbucket/plugin.py
+++ b/src/sentry_plugins/bitbucket/plugin.py
@@ -87,7 +87,7 @@ class BitbucketPlugin(CorePluginMixin, IssuePlugin2):
             )
         ]
 
-    def get_url_module(self):
+    def get_url_module(self) -> str:
         return "sentry_plugins.bitbucket.urls"
 
     def is_configured(self, project) -> bool:

--- a/src/sentry_plugins/github/plugin.py
+++ b/src/sentry_plugins/github/plugin.py
@@ -108,7 +108,7 @@ class GitHubPlugin(CorePluginMixin, IssuePlugin2):
             )
         ]
 
-    def get_url_module(self):
+    def get_url_module(self) -> str:
         return "sentry_plugins.github.urls"
 
     def is_configured(self, project) -> bool:

--- a/src/sentry_plugins/gitlab/plugin.py
+++ b/src/sentry_plugins/gitlab/plugin.py
@@ -100,7 +100,7 @@ class GitLabPlugin(CorePluginMixin, IssuePlugin2):
 
         return (("", "(Unassigned)"),) + users
 
-    def get_new_issue_title(self, **kwargs):
+    def get_new_issue_title(self, **kwargs) -> str:
         return "Create GitLab Issue"
 
     def get_client(self, project):

--- a/src/sentry_plugins/heroku/plugin.py
+++ b/src/sentry_plugins/heroku/plugin.py
@@ -149,16 +149,16 @@ class HerokuPlugin(CorePluginMixin, ReleaseTrackingPlugin):
         )
     ]
 
-    def can_enable_for_projects(self):
+    def can_enable_for_projects(self) -> bool:
         return True
 
-    def can_configure_for_project(self, project):
+    def can_configure_for_project(self, project) -> bool:
         return True
 
-    def has_project_conf(self):
+    def has_project_conf(self) -> bool:
         return True
 
-    def get_conf_key(self):
+    def get_conf_key(self) -> str:
         return "heroku"
 
     def get_config(self, project, user=None, initial=None, add_additional_fields: bool = False):

--- a/src/sentry_plugins/redmine/plugin.py
+++ b/src/sentry_plugins/redmine/plugin.py
@@ -56,13 +56,13 @@ class RedminePlugin(CorePluginMixin, IssuePlugin):
         self.client_errors = []
         self.fields = []
 
-    def has_project_conf(self):
+    def has_project_conf(self) -> bool:
         return True
 
     def is_configured(self, project) -> bool:
         return all(self.get_option(k, project) for k in ("host", "key", "project_id"))
 
-    def get_new_issue_title(self, **kwargs):
+    def get_new_issue_title(self, **kwargs) -> str:
         return "Create Redmine Task"
 
     def get_initial_form_data(self, request: Request, group, event, **kwargs):

--- a/src/sentry_plugins/sessionstack/plugin.py
+++ b/src/sentry_plugins/sessionstack/plugin.py
@@ -43,7 +43,7 @@ class SessionStackPlugin(CorePluginMixin, Plugin2):
         )
     ]
 
-    def has_project_conf(self):
+    def has_project_conf(self) -> bool:
         return True
 
     def get_custom_contexts(self):
@@ -58,7 +58,7 @@ class SessionStackPlugin(CorePluginMixin, Plugin2):
         self.set_option("player_url", "", project)
         self.set_option("api_url", "", project)
 
-    def is_testable(self, **kwargs):
+    def is_testable(self, **kwargs) -> bool:
         return False
 
     def validate_config(self, project, config, actor=None):

--- a/src/sentry_plugins/splunk/plugin.py
+++ b/src/sentry_plugins/splunk/plugin.py
@@ -168,7 +168,7 @@ class SplunkPlugin(CorePluginMixin, DataForwardingPlugin):
 
         self.project_source = self.get_option("source", event.project) or "sentry"
 
-    def get_rl_key(self, event):
+    def get_rl_key(self, event) -> str:
         return f"{self.conf_key}:{md5_text(self.project_token).hexdigest()}"
 
     def is_ratelimited(self, event):

--- a/tests/acceptance/test_organization_switch.py
+++ b/tests/acceptance/test_organization_switch.py
@@ -84,5 +84,5 @@ class OrganizationSwitchTest(AcceptanceTestCase, SnubaTestCase):
         assert {e.text for e in elements} == {p.slug for p in projects}
 
     @staticmethod
-    def url_creator(page_path, org_slug):
+    def url_creator(page_path, org_slug) -> str:
         return f"organizations/{org_slug}/{page_path}/"

--- a/tests/sentry/api/bases/test_organization.py
+++ b/tests/sentry/api/bases/test_organization.py
@@ -46,7 +46,7 @@ from sentry.utils.security.orgauthtoken_token import hash_token
 
 class MockSuperUser:
     @property
-    def is_active(self):
+    def is_active(self) -> bool:
         return True
 
 

--- a/tests/sentry/api/serializers/test_base.py
+++ b/tests/sentry/api/serializers/test_base.py
@@ -8,7 +8,7 @@ class Foo:
 
 
 class FooSerializer(Serializer):
-    def serialize(self, *args, **kwargs):
+    def serialize(self, *args, **kwargs) -> str:
         return "lol"
 
 

--- a/tests/sentry/api/serializers/test_base.py
+++ b/tests/sentry/api/serializers/test_base.py
@@ -8,7 +8,7 @@ class Foo:
 
 
 class FooSerializer(Serializer):
-    def serialize(self, *args, **kwargs) -> str:
+    def serialize(self, *args, **kwargs):
         return "lol"
 
 

--- a/tests/sentry/feedback/endpoints/test_project_user_reports.py
+++ b/tests/sentry/feedback/endpoints/test_project_user_reports.py
@@ -11,7 +11,7 @@ from sentry.testutils.cases import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now
 
 
-def _make_url(project: Project):
+def _make_url(project: Project) -> str:
     return f"/api/0/projects/{project.organization.slug}/{project.slug}/user-feedback/"
 
 

--- a/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py
+++ b/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py
@@ -69,7 +69,7 @@ def get_test_message(default_project):
 
 
 @pytest.fixture
-def random_group_id():
+def random_group_id() -> str:
     return f"test-consumer-{random.randint(0, 2 ** 16)}"
 
 

--- a/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_transactions.py
+++ b/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_transactions.py
@@ -65,7 +65,7 @@ def get_test_message(project):
 
 
 @pytest.fixture
-def random_group_id():
+def random_group_id() -> str:
     return f"test-consumer-{random.randint(0, 2 ** 16)}"
 
 

--- a/tests/sentry/integrations/api/endpoints/test_organization_integration_migrate_opsgenie.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_integration_migrate_opsgenie.py
@@ -9,7 +9,7 @@ class OrganizationIntegrationMigrateOpsgenieTest(APITestCase):
         self.login_as(self.user)
         self.organization = self.create_organization(owner=self.user)
 
-    def get_path(self, integration_id):
+    def get_path(self, integration_id) -> str:
         return f"/api/0/organizations/{self.organization.slug}/integrations/{integration_id}/migrate-opsgenie/"
 
     def test_no_integration(self) -> None:

--- a/tests/sentry/plugins/base/test_v2.py
+++ b/tests/sentry/plugins/base/test_v2.py
@@ -5,7 +5,7 @@ from sentry.testutils.cases import TestCase
 class Plugin2TestCase(TestCase):
     def test_reset_config(self) -> None:
         class APlugin(Plugin2):
-            def get_conf_key(self):
+            def get_conf_key(self) -> str:
                 return "a-plugin"
 
         project = self.create_project()

--- a/tests/sentry/rules/actions/test_create_ticket_utils.py
+++ b/tests/sentry/rules/actions/test_create_ticket_utils.py
@@ -16,7 +16,7 @@ class CreateTicketUtilsTest(TestCase):
         installation = MagicMock()
         installation.get_group_description.return_value = "Test description"
 
-        def generate_footer(url):
+        def generate_footer(url) -> str:
             return f"\n\nThis issue was created by a rule: {url}"
 
         description = build_description(self.event, self.rule.id, installation, generate_footer)
@@ -31,7 +31,7 @@ class CreateTicketUtilsTest(TestCase):
         installation.get_group_description.return_value = "Test description"
         workflow_id = 123
 
-        def generate_footer(url):
+        def generate_footer(url) -> str:
             return f"\n\nThis issue was created by a workflow: {url}"
 
         description = build_description_workflow_engine_ui(

--- a/tests/sentry/rules/processing/test_processor.py
+++ b/tests/sentry/rules/processing/test_processor.py
@@ -45,7 +45,7 @@ class MockConditionTrue(EventCondition):
     id = "tests.sentry.rules.processing.test_processor.MockConditionTrue"
     label = "Mock condition which always passes."
 
-    def passes(self, event, state):
+    def passes(self, event, state) -> bool:
         return True
 
 
@@ -679,7 +679,7 @@ class MockFilterTrue(EventFilter):
     id = "tests.sentry.rules.processing.test_processor.MockFilterTrue"
     label = "Mock filter which always passes."
 
-    def passes(self, event, state):
+    def passes(self, event, state) -> bool:
         return True
 
 
@@ -687,7 +687,7 @@ class MockFilterFalse(EventFilter):
     id = "tests.sentry.rules.processing.test_processor.MockFilterFalse"
     label = "Mock filter which never passes."
 
-    def passes(self, event, state):
+    def passes(self, event, state) -> bool:
         return False
 
 

--- a/tests/sentry/seer/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/seer/endpoints/test_group_ai_autofix.py
@@ -20,7 +20,7 @@ pytestmark = [requires_snuba]
 @with_feature("organizations:gen-ai-features")
 @patch("sentry.seer.autofix.autofix.get_seer_org_acknowledgement", return_value=True)
 class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
-    def _get_url(self, group_id: int):
+    def _get_url(self, group_id: int) -> str:
         return f"/api/0/issues/{group_id}/autofix/"
 
     def setUp(self) -> None:

--- a/tests/sentry/seer/endpoints/test_group_ai_summary.py
+++ b/tests/sentry/seer/endpoints/test_group_ai_summary.py
@@ -16,7 +16,7 @@ class GroupAiSummaryEndpointTest(APITestCase, SnubaTestCase):
         self.url = self._get_url(self.group.id)
         self.login_as(user=self.user)
 
-    def _get_url(self, group_id: int):
+    def _get_url(self, group_id: int) -> str:
         return f"/api/0/issues/{group_id}/summarize/"
 
     @patch("sentry.seer.endpoints.group_ai_summary.get_issue_summary")

--- a/tests/sentry/seer/endpoints/test_organization_page_web_vitals_summary.py
+++ b/tests/sentry/seer/endpoints/test_organization_page_web_vitals_summary.py
@@ -83,7 +83,7 @@ class OrganizationPageWebVitalsSummaryEndpointTest(APITestCase, SnubaTestCase):
 
         self.url = self._get_url()
 
-    def _get_url(self):
+    def _get_url(self) -> str:
         return f"/api/0/organizations/{self.org.slug}/page-web-vitals-summary/"
 
     @patch("sentry.seer.endpoints.organization_page_web_vitals_summary.get_page_web_vitals_summary")

--- a/tests/sentry/seer/endpoints/test_organization_trace_summary.py
+++ b/tests/sentry/seer/endpoints/test_organization_trace_summary.py
@@ -77,7 +77,7 @@ class OrganizationTraceSummaryEndpointTest(APITestCase, SnubaTestCase):
 
         self.url = self._get_url()
 
-    def _get_url(self):
+    def _get_url(self) -> str:
         return f"/api/0/organizations/{self.org.slug}/trace-summary/"
 
     @patch("sentry.seer.endpoints.organization_trace_summary.get_trace_summary")

--- a/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
+++ b/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
@@ -62,11 +62,11 @@ from tests.sentry.issues.test_utils import OccurrenceTestMixin
 pytestmark = [requires_snuba]
 
 
-def raiseStatusFalse():
+def raiseStatusFalse() -> bool:
     return False
 
 
-def raiseStatusTrue():
+def raiseStatusTrue() -> bool:
     return True
 
 

--- a/tests/sentry/sentry_apps/test_sentry_app_installation_notifier.py
+++ b/tests/sentry/sentry_apps/test_sentry_app_installation_notifier.py
@@ -12,7 +12,7 @@ from sentry.utils import json
 from sentry.utils.sentry_apps import SentryAppWebhookRequestsBuffer
 
 
-def raiseStatusFalse():
+def raiseStatusFalse() -> bool:
     return False
 
 

--- a/tests/sentry/sudo/test_utils.py
+++ b/tests/sentry/sudo/test_utils.py
@@ -71,7 +71,7 @@ class HasSudoPrivilegesTestCase(BaseTestCase):
     def test_cookie_and_token_match(self) -> None:
         self.login()
 
-        def get_signed_cookie(key, salt="", max_age=None):
+        def get_signed_cookie(key, salt="", max_age=None) -> str:
             return "abc123"
 
         self.request.session[COOKIE_NAME] = "abc123"
@@ -81,7 +81,7 @@ class HasSudoPrivilegesTestCase(BaseTestCase):
     def test_cookie_and_token_mismatch(self) -> None:
         self.login()
 
-        def get_signed_cookie(key, salt="", max_age=None):
+        def get_signed_cookie(key, salt="", max_age=None) -> str:
             return "nope"
 
         self.request.session[COOKIE_NAME] = "abc123"

--- a/tests/sentry/tasks/test_activity.py
+++ b/tests/sentry/tasks/test_activity.py
@@ -10,7 +10,7 @@ class BasicPreprocessorPlugin(NotificationPlugin):
     def notify_about_activity(self, activity):
         pass
 
-    def is_enabled(self, project=None):
+    def is_enabled(self, project=None) -> bool:
         return True
 
 

--- a/tests/sentry/tasks/test_base.py
+++ b/tests/sentry/tasks/test_base.py
@@ -19,7 +19,7 @@ from sentry.testutils.helpers.options import override_options
     silo_mode=SiloMode.REGION,
     taskworker_config=TaskworkerConfig(namespace=test_tasks),
 )
-def region_task(param):
+def region_task(param) -> str:
     return f"Region task {param}"
 
 
@@ -28,7 +28,7 @@ def region_task(param):
     silo_mode=SiloMode.CONTROL,
     taskworker_config=TaskworkerConfig(namespace=test_tasks),
 )
-def control_task(param):
+def control_task(param) -> str:
     return f"Control task {param}"
 
 

--- a/tests/sentry/tasks/test_reprocessing2.py
+++ b/tests/sentry/tasks/test_reprocessing2.py
@@ -95,7 +95,7 @@ def register_event_preprocessor(register_plugin):
             def get_event_preprocessors(self, data):
                 return [f]
 
-            def is_enabled(self, project=None):
+            def is_enabled(self, project=None) -> bool:
                 return True
 
         register_plugin(globals(), ReprocessingTestPlugin)

--- a/tests/sentry/tasks/test_store.py
+++ b/tests/sentry/tasks/test_store.py
@@ -40,7 +40,7 @@ class BasicPreprocessorPlugin(Plugin2):
 
         return []
 
-    def is_enabled(self, project=None):
+    def is_enabled(self, project=None) -> bool:
         return True
 
 
@@ -258,7 +258,7 @@ def test_scrubbing_after_processing(
 
             return [more_extra]
 
-        def is_enabled(self, project=None):
+        def is_enabled(self, project=None) -> bool:
             return True
 
     register_plugin(globals(), TestPlugin)

--- a/tests/sentry/tasks/test_taskworker_rollout.py
+++ b/tests/sentry/tasks/test_taskworker_rollout.py
@@ -46,7 +46,7 @@ class TestTaskworkerRollout(TestCase):
             name="test.test_without_taskworker_rollout",
             taskworker_config=self.config,
         )
-        def test_task(msg):
+        def test_task(msg) -> str:
             return f"hello {msg}"
 
         assert test_task.name == "test.test_without_taskworker_rollout"

--- a/tests/sentry/testutils/pytest/mocking/animals/__init__.py
+++ b/tests/sentry/testutils/pytest/mocking/animals/__init__.py
@@ -1,8 +1,8 @@
-def get_dog():
+def get_dog() -> str:
     return "maisey"
 
 
-def get_cat():
+def get_cat() -> str:
     return "piper"
 
 
@@ -10,11 +10,11 @@ def erroring_get_dog():
     raise TypeError("Expected dog, but got cat instead.")
 
 
-def a_function_that_calls_get_dog():
+def a_function_that_calls_get_dog() -> str:
     return f"{get_dog()} is a good dog!"
 
 
-def a_function_that_calls_get_cat():
+def a_function_that_calls_get_cat() -> str:
     return f"{get_cat()} is a good cat, because she thinks she's a dog!"
 
 

--- a/tests/sentry/web/frontend/test_group_event_json.py
+++ b/tests/sentry/web/frontend/test_group_event_json.py
@@ -7,7 +7,7 @@ from sentry.utils import json
 
 class GroupEventJsonTest(TestCase):
     @cached_property
-    def path(self):
+    def path(self) -> str:
         return f"/organizations/{self.organization.slug}/issues/{self.event.group_id}/events/{self.event.event_id}/json/"
 
     def test_does_render(self) -> None:

--- a/tests/sentry/web/frontend/test_oauth_authorize.py
+++ b/tests/sentry/web/frontend/test_oauth_authorize.py
@@ -12,7 +12,7 @@ from sentry.testutils.silo import control_silo_test
 @control_silo_test
 class OAuthAuthorizeCodeTest(TestCase):
     @cached_property
-    def path(self):
+    def path(self) -> str:
         return "/oauth/authorize/"
 
     def setUp(self) -> None:
@@ -246,7 +246,7 @@ class OAuthAuthorizeCodeTest(TestCase):
 @control_silo_test
 class OAuthAuthorizeTokenTest(TestCase):
     @cached_property
-    def path(self):
+    def path(self) -> str:
         return "/oauth/authorize/"
 
     def setUp(self) -> None:
@@ -351,7 +351,7 @@ class OAuthAuthorizeTokenTest(TestCase):
 @control_silo_test
 class OAuthAuthorizeOrgScopedTest(TestCase):
     @cached_property
-    def path(self):
+    def path(self) -> str:
         return "/oauth/authorize/"
 
     def setUp(self) -> None:

--- a/tests/sentry/web/frontend/test_oauth_token.py
+++ b/tests/sentry/web/frontend/test_oauth_token.py
@@ -14,7 +14,7 @@ from sentry.utils import json
 @control_silo_test
 class OAuthTokenTest(TestCase):
     @cached_property
-    def path(self):
+    def path(self) -> str:
         return "/oauth/token/"
 
     def test_no_get(self) -> None:
@@ -46,7 +46,7 @@ class OAuthTokenTest(TestCase):
 @control_silo_test
 class OAuthTokenCodeTest(TestCase):
     @cached_property
-    def path(self):
+    def path(self) -> str:
         return "/oauth/token/"
 
     def setUp(self) -> None:
@@ -390,7 +390,7 @@ class OAuthTokenCodeTest(TestCase):
 @control_silo_test
 class OAuthTokenRefreshTokenTest(TestCase):
     @cached_property
-    def path(self):
+    def path(self) -> str:
         return "/oauth/token/"
 
     def setUp(self) -> None:
@@ -500,7 +500,7 @@ class OAuthTokenRefreshTokenTest(TestCase):
 @control_silo_test
 class OAuthTokenOrganizationScopedTest(TestCase):
     @cached_property
-    def path(self):
+    def path(self) -> str:
         return "/oauth/token/"
 
     def setUp(self) -> None:

--- a/tests/snuba/api/endpoints/test_organization_events_spans_histogram.py
+++ b/tests/snuba/api/endpoints/test_organization_events_spans_histogram.py
@@ -58,7 +58,7 @@ class OrganizationEventsSpansHistogramEndpointTest(APITestCase, SnubaTestCase):
 
         return self.store_event(data, project_id=self.project.id)
 
-    def format_span(self, op, group):
+    def format_span(self, op, group) -> str:
         return f"{op}:{group}"
 
     def do_request(self, query, with_feature=True):

--- a/tests/snuba/api/endpoints/test_project_group_index.py
+++ b/tests/snuba/api/endpoints/test_project_group_index.py
@@ -56,7 +56,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
         return links
 
     @cached_property
-    def path(self):
+    def path(self) -> str:
         return f"/api/0/projects/{self.project.organization.slug}/{self.project.slug}/issues/"
 
     def test_sort_by_date_with_tag(self) -> None:
@@ -400,7 +400,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         self.min_ago = timezone.now() - timedelta(minutes=1)
 
     @cached_property
-    def path(self):
+    def path(self) -> str:
         return f"/api/0/projects/{self.project.organization.slug}/{self.project.slug}/issues/"
 
     def assertNoResolution(self, group):
@@ -1495,7 +1495,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
 class GroupDeleteTest(APITestCase, SnubaTestCase):
     @cached_property
-    def path(self):
+    def path(self) -> str:
         return f"/api/0/projects/{self.project.organization.slug}/{self.project.slug}/issues/"
 
     def create_groups(


### PR DESCRIPTION
Added return types to functions that just return literal strings, ints, or bools.

Used the following python script:
```
from re import sub

# find **/*.py > files.txt
for file in open("files.txt"):
    source = open(file.strip()).read()
    """
    def foo(x: int, y):
        return f"1234"
    """

    # Literal strings
    source = sub(
        r"def ([^\n>]+):(\n\s+)(return [rf]?(\"[^\"]*\"|'[^']*')\n)",
        r"def \1 -> str:\2\3",
        source,
    )

    # Literal ints
    source = sub(
        r"def ([^\n>]+):(\n\s+)(return \d+\n)",
        r"def \1 -> int:\2\3",
        source,
    )

    # Literal bools
    source = sub(
        r"def ([^\n>]+):(\n\s+)(return (True|False)\n)",
        r"def \1 -> bool:\2\3",
        source,
    )

    open(file.strip(), "w").write(source)
```