### PR TITLE
feat(explore): Support grouping by numeric attributes for spans and logs

### DIFF
--- a/static/app/views/explore/hooks/useGroupByFields.tsx
+++ b/static/app/views/explore/hooks/useGroupByFields.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 
 import type {SelectOption} from 'sentry/components/core/compactSelect';
 import {t} from 'sentry/locale';
-import type {TagCollection} from 'sentry/types/group';
+import type {Tag, TagCollection} from 'sentry/types/group';
 import {FieldKind} from 'sentry/utils/fields';
 import {AttributeDetails} from 'sentry/views/explore/components/attributeDetails';
 import {TypeBadge} from 'sentry/views/explore/components/typeBadge';
@@ -16,29 +16,52 @@ interface UseGroupByFieldsProps {
    * they dont exist already.
    */
   groupBys: string[];
-  tags: TagCollection;
+  numberTags: TagCollection;
+  stringTags: TagCollection;
   traceItemType: TraceItemDataset;
   hideEmptyOption?: boolean;
 }
 
 export function useGroupByFields({
-  tags,
+  numberTags,
+  stringTags,
   groupBys,
   traceItemType,
   hideEmptyOption,
-}: UseGroupByFieldsProps) {
-  const options: Array<SelectOption<string>> = useMemo(() => {
-    const potentialOptions = [
-      ...Object.keys(tags).filter(key => !DISALLOWED_GROUP_BY_FIELDS.has(key)),
-
-      // These options aren't known to exist on this project but it was inserted into
-      // the group bys somehow so it should be a valid options in the group bys.
-      //
-      // One place this may come from is when switching projects/environment/date range,
-      // a tag may disappear based on the selection.
-      ...groupBys.filter(groupBy => groupBy && !tags.hasOwnProperty(groupBy)),
+}: UseGroupByFieldsProps): Array<SelectOption<string>> {
+  return useMemo(() => {
+    const options = [
+      ...Object.entries(numberTags)
+        .filter(([key, _]) => !DISALLOWED_GROUP_BY_FIELDS.has(key))
+        .map(([_, tag]) => optionFromTag(tag, traceItemType)),
+      ...Object.entries(stringTags)
+        .filter(([key, _]) => !DISALLOWED_GROUP_BY_FIELDS.has(key))
+        .map(([_, tag]) => optionFromTag(tag, traceItemType)),
+      ...groupBys
+        .filter(
+          groupBy =>
+            groupBy &&
+            !numberTags.hasOwnProperty(groupBy) &&
+            !stringTags.hasOwnProperty(groupBy)
+        )
+        .map(groupBy =>
+          optionFromTag({key: groupBy, name: groupBy, kind: FieldKind.TAG}, traceItemType)
+        ),
     ];
-    potentialOptions.sort();
+
+    options.sort((a, b) => {
+      const aLabel = a.label || '';
+      const bLabel = b.label || '';
+      if (aLabel < bLabel) {
+        return -1;
+      }
+
+      if (aLabel > bLabel) {
+        return 1;
+      }
+
+      return 0;
+    });
 
     return [
       // hard code in an empty option
@@ -51,28 +74,27 @@ export function useGroupByFields({
               textValue: t('\u2014'),
             },
           ]),
-      ...potentialOptions.map(key => {
-        const kind = FieldKind.TAG;
-        return {
-          label: key,
-          value: key,
-          textValue: key,
-          trailingItems: <TypeBadge kind={kind} />,
-          showDetailsInOverlay: true,
-          details: (
-            <AttributeDetails
-              column={key}
-              kind={kind}
-              label={key}
-              traceItemType={traceItemType}
-            />
-          ),
-        };
-      }),
+      ...options,
     ];
-  }, [tags, groupBys, hideEmptyOption, traceItemType]);
+  }, [numberTags, stringTags, groupBys, hideEmptyOption, traceItemType]);
+}
 
-  return options;
+function optionFromTag(tag: Tag, traceItemType: TraceItemDataset) {
+  return {
+    label: tag.name,
+    value: tag.key,
+    textValue: tag.key,
+    trailingItems: <TypeBadge kind={tag.kind} />,
+    showDetailsInOverlay: true,
+    details: (
+      <AttributeDetails
+        column={tag.key}
+        kind={tag.kind}
+        label={tag.key}
+        traceItemType={traceItemType}
+      />
+    ),
+  };
 }
 
 // Some fields don't make sense to allow users to group by as they create

--- a/static/app/views/explore/logs/logsToolbar.tsx
+++ b/static/app/views/explore/logs/logsToolbar.tsx
@@ -273,23 +273,38 @@ function VisualizeDropdown({
   );
 }
 
-function ToolbarGroupBy({stringTags}: LogsToolbarProps) {
+function ToolbarGroupBy({numberTags, stringTags}: LogsToolbarProps) {
   const groupBys = useQueryParamsGroupBys();
   const setGroupBys = useSetQueryParamsGroupBys();
 
   const options = useMemo(
-    () => [
-      {
-        label: '\u2014',
-        value: '',
-        textValue: '\u2014',
-      },
-      ...Object.keys(stringTags ?? {}).map(key => ({
-        label: key,
-        value: key,
-      })),
-    ],
-    [stringTags]
+    () =>
+      [
+        {
+          label: '\u2014',
+          value: '',
+          textValue: '\u2014',
+        },
+        ...Object.keys(numberTags ?? {}).map(key => ({
+          label: prettifyTagKey(key),
+          value: key,
+        })),
+        ...Object.keys(stringTags ?? {}).map(key => ({
+          label: prettifyTagKey(key),
+          value: key,
+        })),
+      ].toSorted((a, b) => {
+        if (a.label < b.label) {
+          return -1;
+        }
+
+        if (a.label > b.label) {
+          return 1;
+        }
+
+        return 0;
+      }),
+    [numberTags, stringTags]
   );
 
   const setGroupBysWithOp = useCallback(

--- a/static/app/views/explore/logs/logsToolbar.tsx
+++ b/static/app/views/explore/logs/logsToolbar.tsx
@@ -5,7 +5,8 @@ import type {SelectKey, SelectOption} from 'sentry/components/core/compactSelect
 import {t} from 'sentry/locale';
 import type {TagCollection} from 'sentry/types/group';
 import {defined} from 'sentry/utils';
-import {AggregationKey, prettifyTagKey} from 'sentry/utils/fields';
+import {AggregationKey, FieldKind, prettifyTagKey} from 'sentry/utils/fields';
+import {AttributeDetails} from 'sentry/views/explore/components/attributeDetails';
 import {
   ToolbarFooter,
   ToolbarSection,
@@ -20,6 +21,7 @@ import {
   ToolbarVisualizeDropdown,
   ToolbarVisualizeHeader,
 } from 'sentry/views/explore/components/toolbar/toolbarVisualize';
+import {TypeBadge} from 'sentry/views/explore/components/typeBadge';
 import {DragNDropContext} from 'sentry/views/explore/contexts/dragNDropContext';
 import {
   OurLogKnownFieldKey,
@@ -37,6 +39,7 @@ import {
   VisualizeFunction,
   type Visualize,
 } from 'sentry/views/explore/queryParams/visualize';
+import {TraceItemDataset} from 'sentry/views/explore/types';
 
 export const LOG_AGGREGATES: Array<SelectOption<OurLogsAggregate>> = [
   {
@@ -288,17 +291,41 @@ function ToolbarGroupBy({numberTags, stringTags}: LogsToolbarProps) {
         ...Object.keys(numberTags ?? {}).map(key => ({
           label: prettifyTagKey(key),
           value: key,
+          textValue: key,
+          trailingItems: <TypeBadge kind={FieldKind.MEASUREMENT} />,
+          showDetailsInOverlay: true,
+          details: (
+            <AttributeDetails
+              column={key}
+              kind={FieldKind.MEASUREMENT}
+              label={key}
+              traceItemType={TraceItemDataset.LOGS}
+            />
+          ),
         })),
         ...Object.keys(stringTags ?? {}).map(key => ({
           label: prettifyTagKey(key),
           value: key,
+          textValue: key,
+          trailingItems: <TypeBadge kind={FieldKind.TAG} />,
+          showDetailsInOverlay: true,
+          details: (
+            <AttributeDetails
+              column={key}
+              kind={FieldKind.TAG}
+              label={key}
+              traceItemType={TraceItemDataset.LOGS}
+            />
+          ),
         })),
       ].toSorted((a, b) => {
-        if (a.label < b.label) {
+        const aLabel = prettifyTagKey(a.value);
+        const bLabel = prettifyTagKey(b.value);
+        if (aLabel < bLabel) {
           return -1;
         }
 
-        if (a.label > b.label) {
+        if (aLabel > bLabel) {
           return 1;
         }
 

--- a/static/app/views/explore/multiQueryMode/content.spec.tsx
+++ b/static/app/views/explore/multiQueryMode/content.spec.tsx
@@ -58,7 +58,16 @@ describe('MultiQueryModeContent', () => {
       url: `/organizations/${organization.slug}/trace-items/attributes/`,
       method: 'GET',
       body: [{key: 'span.op', name: 'span.op'}],
+      match: [MockApiClient.matchQuery({attributeType: 'string'})],
     });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/trace-items/attributes/`,
+      method: 'GET',
+      body: [{key: 'span.duration', name: 'span.duration'}],
+      match: [MockApiClient.matchQuery({attributeType: 'number'})],
+    });
+
     eventsRequest = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/`,
       method: 'GET',

--- a/static/app/views/explore/multiQueryMode/queryConstructors/groupBy.tsx
+++ b/static/app/views/explore/multiQueryMode/queryConstructors/groupBy.tsx
@@ -19,13 +19,15 @@ import {TraceItemDataset} from 'sentry/views/explore/types';
 type Props = {index: number; query: ReadableExploreQueryParts};
 
 export function GroupBySection({query, index}: Props) {
-  const {tags} = useTraceItemTags();
+  const {tags: numberTags} = useTraceItemTags('number');
+  const {tags: stringTags} = useTraceItemTags('string');
 
   const updateGroupBys = useUpdateQueryAtIndex(index);
 
   const enabledOptions: Array<SelectOption<string>> = useGroupByFields({
     groupBys: [],
-    tags,
+    numberTags,
+    stringTags,
     traceItemType: TraceItemDataset.SPANS,
     hideEmptyOption: true,
   });

--- a/static/app/views/explore/tables/aggregateColumnEditorModal.spec.tsx
+++ b/static/app/views/explore/tables/aggregateColumnEditorModal.spec.tsx
@@ -249,14 +249,23 @@ describe('AggregateColumnEditorModal', () => {
       new Visualize('count(span.duration)'),
     ]);
 
-    const options: string[] = ['\u2014', 'geo.city', 'geo.country', 'project', 'span.op'];
+    const options: string[] = [
+      '\u2014',
+      'foo',
+      'geo.city',
+      'geo.country',
+      'project',
+      'span.duration',
+      'span.op',
+      'span.self_time',
+    ];
     await userEvent.click(screen.getByRole('button', {name: 'Group By geo.country'}));
     const groupByOptions = await screen.findAllByRole('option');
     groupByOptions.forEach((option, i) => {
       expect(option).toHaveTextContent(options[i]!);
     });
 
-    await userEvent.click(groupByOptions[1]!);
+    await userEvent.click(groupByOptions[2]!);
     rows = await screen.findAllByTestId('editor-row');
     expectRows(rows).toHaveAggregateFields([
       {groupBy: 'geo.city'},

--- a/static/app/views/explore/tables/aggregateColumnEditorModal.tsx
+++ b/static/app/views/explore/tables/aggregateColumnEditorModal.tsx
@@ -216,6 +216,7 @@ function ColumnEditorRow({
         <GroupBySelector
           groupBy={column.column}
           groupBys={groupBys}
+          numberTags={numberTags}
           onChange={onColumnChange}
           stringTags={stringTags}
         />
@@ -243,6 +244,7 @@ function ColumnEditorRow({
 interface GroupBySelectorProps {
   groupBy: GroupBy;
   groupBys: string[];
+  numberTags: TagCollection;
   onChange: (groupBy: GroupBy) => void;
   stringTags: TagCollection;
 }
@@ -250,12 +252,14 @@ interface GroupBySelectorProps {
 function GroupBySelector({
   groupBy,
   groupBys,
+  numberTags,
   onChange,
   stringTags,
 }: GroupBySelectorProps) {
   const options: Array<SelectOption<string>> = useGroupByFields({
     groupBys,
-    tags: stringTags,
+    numberTags,
+    stringTags,
     traceItemType: TraceItemDataset.SPANS,
   });
 

--- a/static/app/views/explore/toolbar/toolbarGroupBy.tsx
+++ b/static/app/views/explore/toolbar/toolbarGroupBy.tsx
@@ -22,11 +22,13 @@ interface ToolbarGroupByProps {
 }
 
 export function ToolbarGroupBy({groupBys, setGroupBys}: ToolbarGroupByProps) {
+  const {tags: numberTags} = useTraceItemTags('number');
   const {tags: stringTags} = useTraceItemTags('string');
 
   const options: Array<SelectOption<string>> = useGroupByFields({
     groupBys,
-    tags: stringTags,
+    numberTags,
+    stringTags,
     traceItemType: TraceItemDataset.SPANS,
   });
 


### PR DESCRIPTION
This adds support in the UI to support numeric attributes for spans and logs.

Requires #98002

Closes LOGS-288