### PR TITLE
Type tests/sentry_plugins

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -795,6 +795,7 @@ module = [
     "tests.sentry.workflow_engine.endpoints.utils.*",
     "tests.sentry.workflow_engine.handlers.action.*",
     "tests.sentry.workflow_engine.models.*",
+    "tests.sentry_plugins.*",
     "tools.*",
 ]
 disallow_any_generics = true

--- a/tests/sentry_plugins/amazon_sqs/test_plugin.py
+++ b/tests/sentry_plugins/amazon_sqs/test_plugin.py
@@ -5,6 +5,7 @@ import orjson
 import pytest
 from botocore.client import ClientError
 
+from sentry.services.eventstore.models import Event
 from sentry.testutils.cases import PluginTestCase
 from sentry_plugins.amazon_sqs.plugin import AmazonSQSPlugin
 
@@ -15,10 +16,10 @@ def test_conf_key() -> None:
 
 class AmazonSQSPluginTest(PluginTestCase):
     @cached_property
-    def plugin(self):
+    def plugin(self) -> AmazonSQSPlugin:
         return AmazonSQSPlugin()
 
-    def run_test(self):
+    def run_test(self) -> Event:
         self.plugin.set_option("access_key", "access-key", self.project)
         self.plugin.set_option("secret_key", "secret-key", self.project)
         self.plugin.set_option("region", "us-east-1", self.project)
@@ -128,7 +129,7 @@ class AmazonSQSPluginTest(PluginTestCase):
 
     @patch("boto3.client")
     @pytest.mark.skip(reason="https://github.com/getsentry/sentry/issues/44858")
-    def test_invalid_s3_bucket(self, mock_client, logger) -> None:
+    def test_invalid_s3_bucket(self, mock_client: MagicMock, logger: MagicMock) -> None:
         self.plugin.set_option("s3_bucket", "bad_bucket", self.project)
         mock_client.return_value.put_object.side_effect = ClientError(
             {"Error": {"Code": "NoSuchBucket"}},

--- a/tests/sentry_plugins/asana/test_plugin.py
+++ b/tests/sentry_plugins/asana/test_plugin.py
@@ -17,11 +17,11 @@ def test_conf_key() -> None:
 
 class AsanaPluginTest(PluginTestCase):
     @cached_property
-    def plugin(self):
+    def plugin(self) -> AsanaPlugin:
         return AsanaPlugin()
 
     @cached_property
-    def request(self):
+    def request(self) -> RequestFactory:
         return RequestFactory()
 
     def test_get_issue_label(self) -> None:

--- a/tests/sentry_plugins/bitbucket/test_plugin.py
+++ b/tests/sentry_plugins/bitbucket/test_plugin.py
@@ -16,11 +16,11 @@ def test_conf_key() -> None:
 
 class BitbucketPluginTest(PluginTestCase):
     @cached_property
-    def plugin(self):
+    def plugin(self) -> BitbucketPlugin:
         return BitbucketPlugin()
 
     @cached_property
-    def request(self):
+    def request(self) -> RequestFactory:
         return RequestFactory()
 
     def test_get_issue_label(self) -> None:

--- a/tests/sentry_plugins/bitbucket/test_plugin.py
+++ b/tests/sentry_plugins/bitbucket/test_plugin.py
@@ -1,9 +1,9 @@
 from functools import cached_property
+from unittest.mock import MagicMock
 
 import pytest
 import responses
 from django.contrib.auth.models import AnonymousUser
-from django.test import RequestFactory
 
 from sentry.exceptions import PluginError
 from sentry.testutils.cases import PluginTestCase
@@ -19,19 +19,15 @@ class BitbucketPluginTest(PluginTestCase):
     def plugin(self) -> BitbucketPlugin:
         return BitbucketPlugin()
 
-    @cached_property
-    def request(self) -> RequestFactory:
-        return RequestFactory()
-
     def test_get_issue_label(self) -> None:
         group = self.create_group(message="Hello world", culprit="foo.bar")
-        assert self.plugin.get_issue_label(group, 1) == "Bitbucket-1"
+        assert self.plugin.get_issue_label(group, "1") == "Bitbucket-1"
 
     def test_get_issue_url(self) -> None:
         self.plugin.set_option("repo", "maxbittker/newsdiffs", self.project)
         group = self.create_group(message="Hello world", culprit="foo.bar")
         assert (
-            self.plugin.get_issue_url(group, 1)
+            self.plugin.get_issue_url(group, "1")
             == "https://bitbucket.org/maxbittker/newsdiffs/issue/1/"
         )
 
@@ -51,7 +47,7 @@ class BitbucketPluginTest(PluginTestCase):
         self.plugin.set_option("repo", "maxbittker/newsdiffs", self.project)
         group = self.create_group(message="Hello world", culprit="foo.bar")
 
-        request = self.request.get("/")
+        request = MagicMock()
         request.user = AnonymousUser()
         form_data = {
             "title": "Hello",
@@ -97,7 +93,7 @@ class BitbucketPluginTest(PluginTestCase):
         self.plugin.set_option("repo", "maxbittker/newsdiffs", self.project)
         group = self.create_group(message="Hello world", culprit="foo.bar")
 
-        request = self.request.get("/")
+        request = MagicMock()
         request.user = AnonymousUser()
         form_data = {"comment": "Hello", "issue_id": "1"}
         with pytest.raises(PluginError):

--- a/tests/sentry_plugins/bitbucket/test_repository_provider.py
+++ b/tests/sentry_plugins/bitbucket/test_repository_provider.py
@@ -10,7 +10,7 @@ from sentry_plugins.bitbucket.testutils import COMMIT_DIFF_PATCH, COMPARE_COMMIT
 
 class BitbucketPluginTest(TestCase):
     @cached_property
-    def provider(self):
+    def provider(self) -> BitbucketRepositoryProvider:
         return BitbucketRepositoryProvider("bitbucket")
 
     @responses.activate

--- a/tests/sentry_plugins/github/endpoints/test_push_event.py
+++ b/tests/sentry_plugins/github/endpoints/test_push_event.py
@@ -1,4 +1,5 @@
 import contextlib
+from collections.abc import Generator
 from datetime import datetime, timezone
 from uuid import uuid4
 
@@ -14,7 +15,7 @@ from sentry_plugins.github.testutils import PUSH_EVENT_EXAMPLE
 
 
 @contextlib.contextmanager
-def mock_baxter_response():
+def mock_baxter_response() -> Generator[None]:
     with responses.RequestsMock() as mck:
         mck.add(
             "GET",

--- a/tests/sentry_plugins/github/test_plugin.py
+++ b/tests/sentry_plugins/github/test_plugin.py
@@ -17,11 +17,11 @@ def test_conf_key() -> None:
 
 class GitHubPluginTest(PluginTestCase):
     @cached_property
-    def plugin(self):
+    def plugin(self) -> GitHubPlugin:
         return GitHubPlugin()
 
     @cached_property
-    def request(self):
+    def request(self) -> RequestFactory:
         return RequestFactory()
 
     def test_get_issue_label(self) -> None:

--- a/tests/sentry_plugins/github/test_plugin.py
+++ b/tests/sentry_plugins/github/test_plugin.py
@@ -1,10 +1,10 @@
 from functools import cached_property
+from unittest.mock import MagicMock
 
 import orjson
 import pytest
 import responses
 from django.contrib.auth.models import AnonymousUser
-from django.test import RequestFactory
 
 from sentry.exceptions import PluginError
 from sentry.testutils.cases import PluginTestCase
@@ -20,18 +20,16 @@ class GitHubPluginTest(PluginTestCase):
     def plugin(self) -> GitHubPlugin:
         return GitHubPlugin()
 
-    @cached_property
-    def request(self) -> RequestFactory:
-        return RequestFactory()
-
     def test_get_issue_label(self) -> None:
         group = self.create_group(message="Hello world", culprit="foo.bar")
-        assert self.plugin.get_issue_label(group, 1) == "GH-1"
+        assert self.plugin.get_issue_label(group, "1") == "GH-1"
 
     def test_get_issue_url(self) -> None:
         self.plugin.set_option("repo", "getsentry/sentry", self.project)
         group = self.create_group(message="Hello world", culprit="foo.bar")
-        assert self.plugin.get_issue_url(group, 1) == "https://github.com/getsentry/sentry/issues/1"
+        assert (
+            self.plugin.get_issue_url(group, "1") == "https://github.com/getsentry/sentry/issues/1"
+        )
 
     def test_is_configured(self) -> None:
         assert self.plugin.is_configured(self.project) is False
@@ -49,7 +47,7 @@ class GitHubPluginTest(PluginTestCase):
         self.plugin.set_option("repo", "getsentry/sentry", self.project)
         group = self.create_group(message="Hello world", culprit="foo.bar")
 
-        request = self.request.get("/")
+        request = MagicMock()
         request.user = AnonymousUser()
         form_data = {"title": "Hello", "description": "Fix this."}
         with pytest.raises(PluginError):
@@ -83,7 +81,7 @@ class GitHubPluginTest(PluginTestCase):
         self.plugin.set_option("repo", "getsentry/sentry", self.project)
         group = self.create_group(message="Hello world", culprit="foo.bar")
 
-        request = self.request.get("/")
+        request = MagicMock()
         request.user = AnonymousUser()
         form_data = {"comment": "Hello", "issue_id": "1"}
         with pytest.raises(PluginError):

--- a/tests/sentry_plugins/github/test_provider.py
+++ b/tests/sentry_plugins/github/test_provider.py
@@ -21,7 +21,7 @@ from sentry_plugins.github.testutils import (
 
 class GitHubPluginTest(TestCase):
     @cached_property
-    def provider(self):
+    def provider(self) -> GitHubRepositoryProvider:
         return GitHubRepositoryProvider("github")
 
     def test_compare_commits(self) -> None:
@@ -172,7 +172,7 @@ class GitHubPluginTest(TestCase):
 
 class GitHubAppsProviderTest(TestCase):
     @cached_property
-    def provider(self):
+    def provider(self) -> GitHubAppsRepositoryProvider:
         return GitHubAppsRepositoryProvider("github_apps")
 
     @patch.object(
@@ -185,7 +185,7 @@ class GitHubAppsProviderTest(TestCase):
         "get_installations",
         return_value=orjson.loads(LIST_INSTALLATION_API_RESPONSE),
     )
-    def test_link_auth(self, *args) -> None:
+    def test_link_auth(self, *args: MagicMock) -> None:
         user = self.create_user()
         organization = self.create_organization()
         self.create_usersocialauth(

--- a/tests/sentry_plugins/gitlab/test_plugin.py
+++ b/tests/sentry_plugins/gitlab/test_plugin.py
@@ -15,11 +15,11 @@ def test_conf_key() -> None:
 
 class GitLabPluginTest(PluginTestCase):
     @cached_property
-    def plugin(self):
+    def plugin(self) -> GitLabPlugin:
         return GitLabPlugin()
 
     @cached_property
-    def request(self):
+    def request(self) -> RequestFactory:
         return RequestFactory()
 
     def test_get_issue_label(self) -> None:

--- a/tests/sentry_plugins/gitlab/test_plugin.py
+++ b/tests/sentry_plugins/gitlab/test_plugin.py
@@ -1,8 +1,8 @@
 from functools import cached_property
+from unittest.mock import MagicMock
 
 import orjson
 import responses
-from django.test import RequestFactory
 from django.urls import reverse
 
 from sentry.testutils.cases import PluginTestCase
@@ -18,13 +18,9 @@ class GitLabPluginTest(PluginTestCase):
     def plugin(self) -> GitLabPlugin:
         return GitLabPlugin()
 
-    @cached_property
-    def request(self) -> RequestFactory:
-        return RequestFactory()
-
     def test_get_issue_label(self) -> None:
         group = self.create_group(message="Hello world", culprit="foo.bar")
-        assert self.plugin.get_issue_label(group, 1) == "GL-1"
+        assert self.plugin.get_issue_label(group, "1") == "GL-1"
 
     def test_get_issue_url(self) -> None:
         self.plugin.set_option("gitlab_url", "https://gitlab.com", self.project)
@@ -57,7 +53,7 @@ class GitLabPluginTest(PluginTestCase):
         self.plugin.set_option("gitlab_token", "abcdefg", self.project)
         group = self.create_group(message="Hello world", culprit="foo.bar")
 
-        request = self.request.get("/")
+        request = MagicMock()
         request.user = self.user
         form_data = {"title": "Hello", "description": "Fix this."}
 
@@ -91,7 +87,7 @@ class GitLabPluginTest(PluginTestCase):
         self.plugin.set_option("gitlab_token", "abcdefg", self.project)
         group = self.create_group(message="Hello world", culprit="foo.bar")
 
-        request = self.request.get("/")
+        request = MagicMock()
         request.user = self.user
         form_data = {"comment": "Hello", "issue_id": "1"}
 

--- a/tests/sentry_plugins/heroku/test_plugin.py
+++ b/tests/sentry_plugins/heroku/test_plugin.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Generator
 from datetime import timedelta
 from typing import Any
 from unittest.mock import MagicMock, Mock, patch
@@ -126,7 +127,7 @@ class SetRefsTest(TestCase):
 
 class HookHandleTest(TestCase):
     @pytest.fixture(autouse=True)
-    def patch_is_valid_signature(self):
+    def patch_is_valid_signature(self) -> Generator[None]:
         with patch.object(HerokuReleaseHook, "is_valid_signature"):
             yield
 

--- a/tests/sentry_plugins/jira/test_plugin.py
+++ b/tests/sentry_plugins/jira/test_plugin.py
@@ -213,11 +213,11 @@ user_search_response: list[dict[str, Any]] = [
 
 class JiraPluginTest(TestCase):
     @cached_property
-    def plugin(self):
+    def plugin(self) -> JiraPlugin:
         return JiraPlugin()
 
     @cached_property
-    def request(self):
+    def request(self) -> RequestFactory:
         return RequestFactory()
 
     def test_conf_key(self) -> None:
@@ -318,7 +318,7 @@ class JiraPluginTest(TestCase):
             }
         ) == {"id": "robot", "text": "robot (robot)"}
 
-    def _setup_autocomplete_jira(self):
+    def _setup_autocomplete_jira(self) -> None:
         self.plugin.set_option("instance_url", "https://getsentry.atlassian.net", self.project)
         self.plugin.set_option("default_project", "SEN", self.project)
         self.login_as(user=self.user)

--- a/tests/sentry_plugins/jira/test_plugin.py
+++ b/tests/sentry_plugins/jira/test_plugin.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 from functools import cached_property
 from typing import Any
+from unittest.mock import MagicMock
 
 import orjson
 import responses
 from django.contrib.auth.models import AnonymousUser
-from django.test import RequestFactory
 from django.urls import reverse
 
 from sentry.testutils.cases import TestCase
@@ -216,10 +216,6 @@ class JiraPluginTest(TestCase):
     def plugin(self) -> JiraPlugin:
         return JiraPlugin()
 
-    @cached_property
-    def request(self) -> RequestFactory:
-        return RequestFactory()
-
     def test_conf_key(self) -> None:
         assert self.plugin.conf_key == "jira"
 
@@ -255,7 +251,7 @@ class JiraPluginTest(TestCase):
         self.plugin.set_option("instance_url", "https://getsentry.atlassian.net", self.project)
         group = self.create_group(message="Hello world", culprit="foo.bar")
 
-        request = self.request.get("/")
+        request = MagicMock()
         request.user = AnonymousUser()
         form_data = {
             "title": "Hello",
@@ -275,7 +271,7 @@ class JiraPluginTest(TestCase):
         self.plugin.set_option("instance_url", "https://getsentry.atlassian.net", self.project)
         group = self.create_group(message="Hello world", culprit="foo.bar")
 
-        request = self.request.get("/")
+        request = MagicMock()
         request.user = AnonymousUser()
         form_data = {"issue_id": "SEN-19"}
         assert (

--- a/tests/sentry_plugins/opgsenie/test_plugin.py
+++ b/tests/sentry_plugins/opgsenie/test_plugin.py
@@ -15,7 +15,7 @@ def test_conf_key() -> None:
 
 class OpsGeniePluginTest(PluginTestCase):
     @cached_property
-    def plugin(self):
+    def plugin(self) -> OpsGeniePlugin:
         return OpsGeniePlugin()
 
     def test_is_configured(self) -> None:

--- a/tests/sentry_plugins/pagerduty/test_plugin.py
+++ b/tests/sentry_plugins/pagerduty/test_plugin.py
@@ -26,7 +26,7 @@ def test_conf_key() -> None:
 
 class PagerDutyPluginTest(PluginTestCase):
     @cached_property
-    def plugin(self):
+    def plugin(self) -> PagerDutyPlugin:
         return PagerDutyPlugin()
 
     def test_is_configured(self) -> None:

--- a/tests/sentry_plugins/pivotal/test_pivotal_plugin.py
+++ b/tests/sentry_plugins/pivotal/test_pivotal_plugin.py
@@ -13,7 +13,7 @@ def test_conf_key() -> None:
 
 class PivotalPluginTest(PluginTestCase):
     @cached_property
-    def plugin(self):
+    def plugin(self) -> PivotalPlugin:
         return PivotalPlugin()
 
     def test_get_issue_label(self) -> None:

--- a/tests/sentry_plugins/pivotal/test_pivotal_plugin.py
+++ b/tests/sentry_plugins/pivotal/test_pivotal_plugin.py
@@ -18,11 +18,13 @@ class PivotalPluginTest(PluginTestCase):
 
     def test_get_issue_label(self) -> None:
         group = self.create_group(message="Hello world", culprit="foo.bar")
-        assert self.plugin.get_issue_label(group, 1) == "#1"
+        assert self.plugin.get_issue_label(group, "1") == "#1"
 
     def test_get_issue_url(self) -> None:
         group = self.create_group(message="Hello world", culprit="foo.bar")
-        assert self.plugin.get_issue_url(group, 1) == "https://www.pivotaltracker.com/story/show/1"
+        assert (
+            self.plugin.get_issue_url(group, "1") == "https://www.pivotaltracker.com/story/show/1"
+        )
 
     def test_is_configured(self) -> None:
         assert self.plugin.is_configured(self.project) is False

--- a/tests/sentry_plugins/pushover/test_plugin.py
+++ b/tests/sentry_plugins/pushover/test_plugin.py
@@ -19,7 +19,7 @@ def test_conf_key() -> None:
 
 class PushoverPluginTest(PluginTestCase):
     @cached_property
-    def plugin(self):
+    def plugin(self) -> PushoverPlugin:
         return PushoverPlugin()
 
     def test_is_configured(self) -> None:

--- a/tests/sentry_plugins/redmine/test_plugin.py
+++ b/tests/sentry_plugins/redmine/test_plugin.py
@@ -14,7 +14,7 @@ def test_conf_key() -> None:
 
 class RedminePluginTest(PluginTestCase):
     @cached_property
-    def plugin(self):
+    def plugin(self) -> RedminePlugin:
         return RedminePlugin()
 
     @responses.activate

--- a/tests/sentry_plugins/segment/test_plugin.py
+++ b/tests/sentry_plugins/segment/test_plugin.py
@@ -13,7 +13,7 @@ def test_conf_key() -> None:
 
 class SegmentPluginTest(PluginTestCase):
     @cached_property
-    def plugin(self):
+    def plugin(self) -> SegmentPlugin:
         return SegmentPlugin()
 
     @responses.activate

--- a/tests/sentry_plugins/sessionstack/test_plugin.py
+++ b/tests/sentry_plugins/sessionstack/test_plugin.py
@@ -23,7 +23,7 @@ def test_conf_key() -> None:
 
 class SessionStackPluginTest(PluginTestCase):
     @cached_property
-    def plugin(self):
+    def plugin(self) -> SessionStackPlugin:
         return SessionStackPlugin()
 
     @responses.activate

--- a/tests/sentry_plugins/sessionstack/test_plugin.py
+++ b/tests/sentry_plugins/sessionstack/test_plugin.py
@@ -68,11 +68,15 @@ class SessionStackPluginTest(PluginTestCase):
         add_sessionstack_context = event_preprocessors[0]
 
         processed_event = add_sessionstack_context(event)
+        assert processed_event is not None
 
         event_contexts = processed_event.get("contexts")
-        sessionstack_context = event_contexts.get("sessionstack")
-        session_url = sessionstack_context.get("session_url")
+        assert event_contexts is not None
 
+        sessionstack_context = event_contexts.get("sessionstack")
+        assert sessionstack_context is not None
+
+        session_url = sessionstack_context.get("session_url")
         assert session_url == EXPECTED_SESSION_URL
 
     def test_no_secrets(self) -> None:

--- a/tests/sentry_plugins/slack/test_plugin.py
+++ b/tests/sentry_plugins/slack/test_plugin.py
@@ -19,7 +19,7 @@ def test_conf_key() -> None:
 
 class SlackPluginTest(PluginTestCase):
     @cached_property
-    def plugin(self):
+    def plugin(self) -> SlackPlugin:
         return SlackPlugin()
 
     @responses.activate

--- a/tests/sentry_plugins/splunk/test_plugin.py
+++ b/tests/sentry_plugins/splunk/test_plugin.py
@@ -15,7 +15,7 @@ def test_conf_key() -> None:
 
 class SplunkPluginTest(PluginTestCase):
     @cached_property
-    def plugin(self):
+    def plugin(self) -> SplunkPlugin:
         return SplunkPlugin()
 
     @responses.activate

--- a/tests/sentry_plugins/trello/test_plugin.py
+++ b/tests/sentry_plugins/trello/test_plugin.py
@@ -1,4 +1,5 @@
 from functools import cached_property
+from unittest.mock import MagicMock
 from urllib.parse import parse_qsl, urlparse
 
 import orjson
@@ -122,7 +123,9 @@ class TrelloPluginApiTests(TrelloPluginTestBase):
             "board": "ads23f",
             "list": "23tds",
         }
-        request = self.make_request(user=self.user, method="POST")
+        request = MagicMock()
+        request.user = self.user
+        request.method = "POST"
 
         assert self.plugin.create_issue(request, self.group, form_data) == "rds43"
         responses_request = responses.calls[0].request
@@ -142,7 +145,9 @@ class TrelloPluginApiTests(TrelloPluginTestBase):
         )
 
         form_data = {"comment": "please fix this", "issue_id": "SstgnBIQ"}
-        request = self.make_request(user=self.user, method="POST")
+        request = MagicMock()
+        request.user = self.user
+        request.method = "POST"
 
         assert self.plugin.link_issue(request, self.group, form_data) == {
             "title": "MyTitle",
@@ -169,9 +174,10 @@ class TrelloPluginApiTests(TrelloPluginTestBase):
             json=[{"id": "8f3", "name": "list 1"}, {"id": "j8f", "name": "list 2"}],
         )
 
-        request = self.make_request(
-            user=self.user, method="GET", GET={"option_field": "list", "board": "f34"}
-        )
+        request = MagicMock()
+        request.user = self.user
+        request.method = "GET"
+        request.GET = {"option_field": "list", "board": "f34"}
 
         response = self.plugin.view_options(request, self.group)
         assert response.data == {"list": [("8f3", "list 1"), ("j8f", "list 2")]}
@@ -195,11 +201,10 @@ class TrelloPluginApiTests(TrelloPluginTestBase):
             },
         )
 
-        request = self.make_request(
-            user=self.user,
-            method="GET",
-            GET={"autocomplete_field": "issue_id", "autocomplete_query": "Key"},
-        )
+        request = MagicMock()
+        request.user = self.user
+        request.method = "GET"
+        request.GET = {"autocomplete_field": "issue_id", "autocomplete_query": "Key"}
 
         response = self.plugin.view_autocomplete(request, self.group)
         assert response.data == {
@@ -240,11 +245,10 @@ class TrelloPluginApiTests(TrelloPluginTestBase):
             },
         )
 
-        request = self.make_request(
-            user=self.user,
-            method="GET",
-            GET={"autocomplete_field": "issue_id", "autocomplete_query": "Key"},
-        )
+        request = MagicMock()
+        request.user = self.user
+        request.method = "GET"
+        request.GET = {"autocomplete_field": "issue_id", "autocomplete_query": "Key"}
 
         response = self.plugin.view_autocomplete(request, self.group)
         assert response.data == {

--- a/tests/sentry_plugins/trello/test_plugin.py
+++ b/tests/sentry_plugins/trello/test_plugin.py
@@ -14,7 +14,7 @@ def test_conf_key() -> None:
 
 class TrelloPluginTestBase(PluginTestCase):
     @cached_property
-    def plugin(self):
+    def plugin(self) -> TrelloPlugin:
         return TrelloPlugin()
 
 
@@ -45,7 +45,7 @@ class TrelloPluginTest(TrelloPluginTestBase):
 
 
 class TrelloPluginApiTests(TrelloPluginTestBase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.group = self.create_group(message="Hello world", culprit="foo.bar")
         self.plugin.set_option("token", "7c8951d1", self.project)
         self.plugin.set_option("key", "39g", self.project)

--- a/tests/sentry_plugins/twilio/test_plugin.py
+++ b/tests/sentry_plugins/twilio/test_plugin.py
@@ -107,7 +107,7 @@ def test_conf_key() -> None:
 
 class TwilioPluginTest(PluginTestCase):
     @cached_property
-    def plugin(self):
+    def plugin(self) -> TwilioPlugin:
         return TwilioPlugin()
 
     def test_is_configured(self) -> None:

--- a/tests/sentry_plugins/victorops/test_plugin.py
+++ b/tests/sentry_plugins/victorops/test_plugin.py
@@ -6,6 +6,7 @@ import responses
 from sentry.interfaces.base import Interface
 from sentry.models.rule import Rule
 from sentry.plugins.base import Notification
+from sentry.services.eventstore.models import Event
 from sentry.testutils.cases import PluginTestCase
 from sentry_plugins.victorops.plugin import VictorOpsPlugin
 
@@ -16,10 +17,10 @@ SUCCESS = """{
 
 
 class UnicodeTestInterface(Interface):
-    def to_string(self, event) -> str:
+    def to_string(self, event: Event) -> str:
         return self.body
 
-    def get_title(self):
+    def get_title(self) -> str:
         return self.title
 
 
@@ -29,7 +30,7 @@ def test_conf_key() -> None:
 
 class VictorOpsPluginTest(PluginTestCase):
     @cached_property
-    def plugin(self):
+    def plugin(self) -> VictorOpsPlugin:
         return VictorOpsPlugin()
 
     def test_is_configured(self) -> None:


### PR DESCRIPTION
# Summary
Grabbed this because I thought it would just be a bunch of easy missing-return-type errors. It turns out, when you add return types you expose other errors. Who'd've thunk? 😅 

Here's the complicating factor: the plugin framework uses `Request`. `RequestFactory` returns `WSGIRequest`. `BaseTestCase.make_request` returns `HttpRequest`. Our typing revealed that a bunch of incorrect `Request-ish` types were being passed around.

This PR changes the incompatible frameworks to `MagicMock`, which more correctly limits behavior to what is explicitly defined (and not what would not actually happen due to type differences).

# Test Plan
`mypy tests/sentry_plugins` ==> no errors
`pytest tests/sentry_plugins/**` ==> `162 passed, 1 skipped`