### PR TITLE
fix(eap): Handle None in top events correctly

### DIFF
--- a/src/sentry/search/eap/resolver.py
+++ b/src/sentry/search/eap/resolver.py
@@ -480,6 +480,20 @@ class SearchResolver:
         else:
             raise InvalidSearchQuery(f"Unknown operator: {term.operator}")
 
+        if value is None:
+            exists_filter = TraceItemFilter(
+                exists_filter=ExistsFilter(
+                    key=resolved_column.proto_definition,
+                )
+            )
+            if term.operator == "=":
+                not_exists_filter = TraceItemFilter(not_filter=NotFilter(filters=[exists_filter]))
+                return not_exists_filter, context_definition
+            elif term.operator == "!=":
+                return exists_filter, context_definition
+            else:
+                raise InvalidSearchQuery(f"Unsupported operator for None {term.operator}")
+
         if value == "" and context_definition is None:
             exists_filter = TraceItemFilter(
                 exists_filter=ExistsFilter(

--- a/tests/snuba/api/endpoints/test_organization_events_stats_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_span_indexed.py
@@ -2358,3 +2358,41 @@ class OrganizationEventsStatsSpansEndpointTest(OrganizationEventsEndpointTestBas
                 "aggregate"
             ]
         )
+
+    def test_groupby_non_existent_attribute(self):
+        self.store_spans(
+            [
+                self.create_span({"description": "span"}, start_ts=self.day_ago),
+                self.create_span({"description": "span"}, start_ts=self.day_ago),
+                self.create_span(
+                    {
+                        "description": "span",
+                        "tags": {"foo": "foo"},
+                        "measurements": {"bar": {"value": 1}},
+                    },
+                    start_ts=self.day_ago,
+                ),
+            ],
+            is_eap=True,
+        )
+        response = self._do_request(
+            data={
+                "start": self.day_ago,
+                "end": self.day_ago + timedelta(minutes=6),
+                "interval": "1m",
+                "yAxis": "count(span.duration)",
+                "field": ["foo", "tags[bar,number]", "count(span.duration)"],
+                "orderby": ["-count(span.duration)"],
+                "project": self.project.id,
+                "dataset": "spans",
+                "excludeOther": 0,
+                "topEvents": 2,
+            },
+        )
+        assert response.status_code == 200, response.content
+
+        count_none = sum(entry[1][0]["count"] for entry in response.data["None,None"]["data"])
+        assert count_none == 2
+
+        count_foo_1 = sum(entry[1][0]["count"] for entry in response.data["foo,1.0"]["data"])
+        assert count_foo_1 == 1


### PR DESCRIPTION
When top events find None in one of the values, it's not being handled correctly.