### PR TITLE
fix(ourlogs): Hide filter actions in table row in embedded views

### DIFF
--- a/static/app/views/explore/contexts/logs/logsPageParams.tsx
+++ b/static/app/views/explore/contexts/logs/logsPageParams.tsx
@@ -358,6 +358,11 @@ export function useLogsLimitToTraceId() {
   return limitToTraceId;
 }
 
+export function useLogsIsTableFrozen() {
+  const {isTableFrozen} = useLogsPageParams();
+  return isTableFrozen;
+}
+
 export function useSetLogsCursor() {
   const setPageParams = useSetLogsPageParams();
   const {setCursorForFrozenPages, isTableFrozen} = useLogsPageParams();


### PR DESCRIPTION
### Summary
This hides the filter actions buttons (but not copy json) when embedded.

#### Screenshots

|before|after|
|-|-|
|<img width="785" height="59" alt="Screenshot 2025-08-18 at 5 42 07 PM" src="https://github.com/user-attachments/assets/ef6b9966-5b41-451f-9478-68fb095a924c" />|<img width="771" height="66" alt="Screenshot 2025-08-18 at 5 42 34 PM" src="https://github.com/user-attachments/assets/18c4b3d4-9f34-405b-be6a-8bbc2725fae1" />|
