### PR TITLE
Count paying sentry organizations

### DIFF
--- a/tmp_zack_tables_query.txt
+++ b/tmp_zack_tables_query.txt
@@ -1,9 +1,9 @@
 SQL queries to list tables in tmp_zack schema:
 
 === For PostgreSQL/Redshift ===
-SELECT table_name 
-FROM information_schema.tables 
-WHERE table_schema = 'tmp_zack' 
+SELECT table_name
+FROM information_schema.tables
+WHERE table_schema = 'tmp_zack'
 ORDER BY table_name;
 
 === For BigQuery ===
@@ -21,18 +21,18 @@ ORDER BY table_name;
 SHOW TABLES FROM tmp_zack;
 
 === Alternative PostgreSQL query ===
-SELECT schemaname, tablename 
-FROM pg_tables 
-WHERE schemaname = 'tmp_zack' 
+SELECT schemaname, tablename
+FROM pg_tables
+WHERE schemaname = 'tmp_zack'
 ORDER BY tablename;
 
 === To get more detailed information (PostgreSQL) ===
-SELECT 
+SELECT
     table_name,
     table_type,
     is_insertable_into
-FROM information_schema.tables 
-WHERE table_schema = 'tmp_zack' 
+FROM information_schema.tables
+WHERE table_schema = 'tmp_zack'
 ORDER BY table_name;
 
 Instructions:

--- a/tmp_zack_tables_query.txt
+++ b/tmp_zack_tables_query.txt
@@ -1,0 +1,41 @@
+SQL queries to list tables in tmp_zack schema:
+
+=== For PostgreSQL/Redshift ===
+SELECT table_name 
+FROM information_schema.tables 
+WHERE table_schema = 'tmp_zack' 
+ORDER BY table_name;
+
+=== For BigQuery ===
+SELECT table_name
+FROM `your_project.tmp_zack.INFORMATION_SCHEMA.TABLES`
+ORDER BY table_name;
+
+=== For Snowflake ===
+SELECT table_name
+FROM information_schema.tables
+WHERE table_schema = 'TMP_ZACK'
+ORDER BY table_name;
+
+=== For Generic SQL with system tables ===
+SHOW TABLES FROM tmp_zack;
+
+=== Alternative PostgreSQL query ===
+SELECT schemaname, tablename 
+FROM pg_tables 
+WHERE schemaname = 'tmp_zack' 
+ORDER BY tablename;
+
+=== To get more detailed information (PostgreSQL) ===
+SELECT 
+    table_name,
+    table_type,
+    is_insertable_into
+FROM information_schema.tables 
+WHERE table_schema = 'tmp_zack' 
+ORDER BY table_name;
+
+Instructions:
+1. Run one of the above queries depending on your database system
+2. Copy the results into this file
+3. Let me know if you need help with a specific query for the tables you find


### PR DESCRIPTION
<!-- Describe your PR here. -->
Adds `tmp_zack_tables_query.txt` containing SQL queries to list tables within the `tmp_zack` schema. This was created to assist in identifying relevant tables for the "how many orgs currently pay for Sentry?" query, particularly after the user mentioned `facts_v2.daily_financial_data`.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
[Slack Thread](https://sentry.slack.com/archives/C04NBDZUVKJ/p1755621288144029?thread_ts=1755621288.144029&cid=C04NBDZUVKJ)

<a href="https://cursor.com/background-agent?bcId=bc-2fe21a90-a799-42c4-aed4-77047b4578a6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2fe21a90-a799-42c4-aed4-77047b4578a6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

