### PR TITLE
Add types to some low-lift files

### DIFF
--- a/src/sentry/lang/dart/apps.py
+++ b/src/sentry/lang/dart/apps.py
@@ -4,7 +4,7 @@ from django.apps import AppConfig
 class Config(AppConfig):
     name = "sentry.lang.dart"
 
-    def ready(self):
+    def ready(self) -> None:
         from sentry.plugins.base import register
 
         from .plugin import DartPlugin

--- a/src/sentry/lang/java/apps.py
+++ b/src/sentry/lang/java/apps.py
@@ -4,7 +4,7 @@ from django.apps import AppConfig
 class Config(AppConfig):
     name = "sentry.lang.java"
 
-    def ready(self):
+    def ready(self) -> None:
         from sentry.plugins.base import register
 
         from .plugin import JavaPlugin

--- a/src/sentry/lang/javascript/apps.py
+++ b/src/sentry/lang/javascript/apps.py
@@ -4,7 +4,7 @@ from django.apps import AppConfig
 class Config(AppConfig):
     name = "sentry.lang.javascript"
 
-    def ready(self):
+    def ready(self) -> None:
         from sentry.plugins.base import register
 
         from .plugin import JavascriptPlugin

--- a/src/sentry/models/organizationaccessrequest.py
+++ b/src/sentry/models/organizationaccessrequest.py
@@ -25,7 +25,7 @@ class OrganizationAccessRequest(Model):
 
     __repr__ = sane_repr("team_id", "member_id")
 
-    def send_request_email(self):
+    def send_request_email(self) -> None:
         from sentry.models.organizationmember import OrganizationMember
         from sentry.utils.email import MessageBuilder
 
@@ -78,7 +78,7 @@ class OrganizationAccessRequest(Model):
 
         msg.send_async([user.email for user in member_users])
 
-    def send_approved_email(self):
+    def send_approved_email(self) -> None:
         from sentry.utils.email import MessageBuilder
 
         if self.member.user_id is None:

--- a/src/sentry/replays/usecases/ingest/event_parser.py
+++ b/src/sentry/replays/usecases/ingest/event_parser.py
@@ -584,7 +584,7 @@ class HighlightedEvents(TypedDict, total=False):
 
 class HighlightedEventsBuilder:
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.events: HighlightedEvents = {
             "canvas_sizes": [],
             "clicks": [],

--- a/src/sentry/sentry_apps/installations.py
+++ b/src/sentry/sentry_apps/installations.py
@@ -248,13 +248,13 @@ class SentryAppInstallationUpdater:
             self.record_analytics()
             return self.sentry_app_installation
 
-    def _update_status(self):
+    def _update_status(self) -> None:
         # convert from string to integer
         if self.status == SentryAppInstallationStatus.INSTALLED_STR:
             for install in SentryAppInstallation.objects.filter(id=self.sentry_app_installation.id):
                 install.update(status=SentryAppInstallationStatus.INSTALLED)
 
-    def record_analytics(self):
+    def record_analytics(self) -> None:
         analytics.record(
             "sentry_app_installation.updated",
             sentry_app_installation_id=self.sentry_app_installation.id,

--- a/src/sentry/sentry_metrics/querying/data/mapping/project_mapper.py
+++ b/src/sentry/sentry_metrics/querying/data/mapping/project_mapper.py
@@ -8,7 +8,7 @@ class Project2ProjectIDMapper(Mapper):
     from_key: str = "project"
     to_key: str = "project_id"
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
 
     def forward(self, projects: Sequence[Project], value: str) -> int:

--- a/src/sentry/tasks/auto_remove_inbox.py
+++ b/src/sentry/tasks/auto_remove_inbox.py
@@ -16,5 +16,5 @@ from sentry.taskworker.namespaces import issues_tasks
         processing_deadline_duration=120,
     ),
 )
-def auto_remove_inbox():
+def auto_remove_inbox() -> None:
     BulkDeleteQuery(model=GroupInbox, days=7, dtfield="date_added").execute()

--- a/src/sentry/tasks/clear_expired_rulesnoozes.py
+++ b/src/sentry/tasks/clear_expired_rulesnoozes.py
@@ -17,6 +17,6 @@ from sentry.taskworker.namespaces import issues_tasks
         processing_deadline_duration=65,
     ),
 )
-def clear_expired_rulesnoozes():
+def clear_expired_rulesnoozes() -> None:
     rule_snooze_ids = RuleSnooze.objects.filter(until__lte=timezone.now()).values_list("id")[:1000]
     RuleSnooze.objects.filter(id__in=rule_snooze_ids).delete()

--- a/src/sentry/tasks/clear_expired_snoozes.py
+++ b/src/sentry/tasks/clear_expired_snoozes.py
@@ -21,7 +21,7 @@ from sentry.taskworker.namespaces import issues_tasks
         processing_deadline_duration=65,
     ),
 )
-def clear_expired_snoozes():
+def clear_expired_snoozes() -> None:
     groupsnooze_list = list(
         GroupSnooze.objects.filter(until__lte=timezone.now()).values_list("id", "group", "until")[
             :1000

--- a/src/sentry/tasks/ping.py
+++ b/src/sentry/tasks/ping.py
@@ -10,6 +10,6 @@ from sentry.taskworker.namespaces import selfhosted_tasks
 @instrumented_task(
     name="sentry.tasks.send_ping", taskworker_config=TaskworkerConfig(namespace=selfhosted_tasks)
 )
-def send_ping():
+def send_ping() -> None:
     options.set("sentry:last_worker_ping", time())
     options.set("sentry:last_worker_version", sentry.VERSION)

--- a/src/sentry/tasks/symbolication.py
+++ b/src/sentry/tasks/symbolication.py
@@ -157,7 +157,7 @@ def _do_symbolicate_event(
             "organization", Organization.objects.get_from_cache(id=project.organization_id)
         )
 
-    def on_symbolicator_request():
+    def on_symbolicator_request() -> None:
         duration = time() - symbolication_start_time
         if duration > settings.SYMBOLICATOR_PROCESS_EVENT_HARD_TIMEOUT:
             raise SymbolicationTimeout

--- a/src/sentry/uptime/apps.py
+++ b/src/sentry/uptime/apps.py
@@ -4,5 +4,5 @@ from django.apps import AppConfig
 class Config(AppConfig):
     name = "sentry.uptime"
 
-    def ready(self):
+    def ready(self) -> None:
         from sentry.uptime.endpoints import serializers  # NOQA

--- a/src/sentry/workflow_engine/apps.py
+++ b/src/sentry/workflow_engine/apps.py
@@ -4,7 +4,7 @@ from django.apps import AppConfig
 class Config(AppConfig):
     name = "sentry.workflow_engine"
 
-    def ready(self):
+    def ready(self) -> None:
         # Import our base DataConditionHandlers for the workflow engine platform
         import sentry.workflow_engine.handlers  # NOQA
         from sentry.workflow_engine.endpoints import serializers  # NOQA

--- a/tests/sentry/api/bases/test_group.py
+++ b/tests/sentry/api/bases/test_group.py
@@ -3,9 +3,12 @@ from typing import ContextManager
 from rest_framework.views import APIView
 
 from sentry.api.bases.group import GroupAiEndpoint, GroupAiPermission
+from sentry.models.apitoken import ApiToken
+from sentry.models.group import Group
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.requests import drf_request_from_request
+from sentry.users.models.user import User
 
 
 class GroupAiPermissionTest(TestCase):
@@ -19,7 +22,14 @@ class GroupAiPermissionTest(TestCase):
     def _demo_mode_enabled(self) -> ContextManager[None]:
         return override_options({"demo-mode.enabled": True, "demo-mode.users": [self.demo_user.id]})
 
-    def has_object_perm(self, method, obj, auth=None, user=None, is_superuser=None):
+    def has_object_perm(
+        self,
+        method: str,
+        obj: Group,
+        auth: ApiToken | None = None,
+        user: User | None = None,
+        is_superuser: bool | None = None,
+    ) -> bool:
         request = self.make_request(user=user, auth=auth, method=method, is_superuser=is_superuser)
         drf_request = drf_request_from_request(request)
         return self.permission.has_permission(

--- a/tests/sentry/api/bases/test_project.py
+++ b/tests/sentry/api/bases/test_project.py
@@ -1,9 +1,12 @@
 from rest_framework.views import APIView
 
 from sentry.api.bases.project import ProjectAndStaffPermission, ProjectPermission
+from sentry.models.apitoken import ApiToken
+from sentry.models.project import Project
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import with_feature
 from sentry.testutils.requests import drf_request_from_request
+from sentry.users.models.user import User
 from sentry.users.services.user.serial import serialize_rpc_user
 
 
@@ -12,7 +15,15 @@ class ProjectPermissionBase(TestCase):
         super().setUp()
         self.permission_cls = ProjectPermission
 
-    def has_object_perm(self, method, obj, auth=None, user=None, is_superuser=None, is_staff=None):
+    def has_object_perm(
+        self,
+        method: str,
+        obj: Project,
+        auth: ApiToken | None = None,
+        user: User | None = None,
+        is_superuser: bool | None = None,
+        is_staff: bool | None = None,
+    ) -> bool:
         perm = self.permission_cls()
         request = self.make_request(
             user=user, auth=auth, method=method, is_superuser=is_superuser, is_staff=is_staff

--- a/tests/sentry/api/bases/test_team.py
+++ b/tests/sentry/api/bases/test_team.py
@@ -1,9 +1,12 @@
 from rest_framework.views import APIView
 
 from sentry.api.bases.team import TeamPermission
+from sentry.models.apitoken import ApiToken
+from sentry.models.team import Team
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import with_feature
 from sentry.testutils.requests import drf_request_from_request
+from sentry.users.models.user import User
 
 
 class TeamPermissionBase(TestCase):
@@ -12,7 +15,14 @@ class TeamPermissionBase(TestCase):
         self.team = self.create_team(organization=self.org)
         super().setUp()
 
-    def has_object_perm(self, method, obj, auth=None, user=None, is_superuser=None):
+    def has_object_perm(
+        self,
+        method: str,
+        obj: Team,
+        auth: ApiToken | None = None,
+        user: User | None = None,
+        is_superuser: bool | None = None,
+    ) -> bool:
         perm = TeamPermission()
         request = self.make_request(user=user, auth=auth, method=method)
         if is_superuser:

--- a/tests/sentry/api/endpoints/release_thresholds/test_release_threshold_status.py
+++ b/tests/sentry/api/endpoints/release_thresholds/test_release_threshold_status.py
@@ -1,5 +1,5 @@
 from datetime import UTC, datetime, timedelta
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from sentry.models.deploy import Deploy
 from sentry.models.environment import Environment
@@ -427,13 +427,13 @@ class ReleaseThresholdStatusTest(APITestCase):
     )
     def test_fetches_relevant_stats(
         self,
-        mock_is_new_issue_count_healthy,
-        mock_get_new_issue_counts,
-        mock_is_error_count_healthy,
-        mock_get_error_counts,
-        mock_is_crash_free_rate_healthy,
-        mock_fetch_sessions_data,
-    ):
+        mock_is_new_issue_count_healthy: MagicMock,
+        mock_get_new_issue_counts: MagicMock,
+        mock_is_error_count_healthy: MagicMock,
+        mock_get_error_counts: MagicMock,
+        mock_is_crash_free_rate_healthy: MagicMock,
+        mock_fetch_sessions_data: MagicMock,
+    ) -> None:
         self.project4 = self.create_project(name="baz", organization=self.organization)
         self.release4 = Release.objects.create(version="v4", organization=self.organization)
         self.release4.add_project(self.project4)

--- a/tests/sentry/api/endpoints/test_admin_project_configs.py
+++ b/tests/sentry/api/endpoints/test_admin_project_configs.py
@@ -39,7 +39,7 @@ class AdminRelayProjectConfigsEndpointTest(APITestCase):
             }
         )
 
-    def get_url(self, proj_id=None, key=None):
+    def get_url(self, proj_id: str | int | None = None, key: str | int | None = None) -> str:
         query = {}
         if proj_id is not None:
             query["projectId"] = proj_id

--- a/tests/sentry/api/endpoints/test_api_tokens.py
+++ b/tests/sentry/api/endpoints/test_api_tokens.py
@@ -1,3 +1,5 @@
+from collections.abc import Generator
+
 from django.urls import reverse
 from pytest import fixture
 from rest_framework import status
@@ -229,7 +231,7 @@ class ApiTokensStaffTest(APITestCase):
     url = reverse("sentry-api-0-api-tokens")
 
     @fixture(autouse=True)
-    def _set_staff_option(self):
+    def _set_staff_option(self) -> Generator[None]:
         with override_options({"staff.ga-rollout": True}):
             yield
 

--- a/tests/sentry/api/endpoints/test_event_attachment_details.py
+++ b/tests/sentry/api/endpoints/test_event_attachment_details.py
@@ -18,7 +18,9 @@ ATTACHMENT_CONTENT = b"File contents here" * 10_000
 
 
 class CreateAttachmentMixin(TestCase):
-    def create_attachment(self, content: bytes | None = None, group_id: int | None = None):
+    def create_attachment(
+        self, content: bytes | None = None, group_id: int | None = None
+    ) -> EventAttachment:
         self.project = self.create_project()
         self.release = self.create_release(self.project, self.user)
         min_ago = before_now(minutes=1).isoformat()

--- a/tests/sentry/api/endpoints/test_organization_insights_tree.py
+++ b/tests/sentry/api/endpoints/test_organization_insights_tree.py
@@ -30,7 +30,7 @@ class OrganizationInsightsTreeEndpointTest(
         self._store_nextjs_function_spans()
         self._store_unrelated_spans()
 
-    def _store_nextjs_function_spans(self):
+    def _store_nextjs_function_spans(self) -> None:
         descriptions = [
             "Page Server Component (/app/dashboard/)",
             "Loading Server Component (/app/dashboard/)",
@@ -66,7 +66,7 @@ class OrganizationInsightsTreeEndpointTest(
             self.store_span(span, is_eap=True)
             spans.append(span)
 
-    def _store_unrelated_spans(self):
+    def _store_unrelated_spans(self) -> None:
         descriptions = [
             "INSERT value INTO table",
             "SELECT * FROM table",

--- a/tests/sentry/api/endpoints/test_organization_invite_request_index.py
+++ b/tests/sentry/api/endpoints/test_organization_invite_request_index.py
@@ -6,6 +6,7 @@ from django.core import mail
 from django.urls import reverse
 
 from sentry.models.options.organization_option import OrganizationOption
+from sentry.models.organization import Organization
 from sentry.models.organizationmember import InviteStatus, OrganizationMember
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.testutils.cases import APITestCase, SlackActivityNotificationTest
@@ -17,7 +18,7 @@ class OrganizationInviteRequestListTest(APITestCase):
     endpoint = "sentry-api-0-organization-invite-request-index"
 
     @cached_property
-    def org(self):
+    def org(self) -> Organization:
         return self.create_organization(owner=self.user)
 
     def setUp(self) -> None:

--- a/tests/sentry/api/endpoints/test_organization_join_request.py
+++ b/tests/sentry/api/endpoints/test_organization_join_request.py
@@ -28,7 +28,7 @@ class OrganizationJoinRequestTest(APITestCase, SlackActivityNotificationTest, Hy
         self.email = "test@example.com"
 
     @cached_property
-    def owner(self):
+    def owner(self) -> OrganizationMember:
         return OrganizationMember.objects.get(user_id=self.user.id, organization=self.organization)
 
     def test_invalid_org_slug(self) -> None:

--- a/tests/sentry/api/endpoints/test_organization_metrics.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics.py
@@ -1,9 +1,11 @@
 import copy
 
 import pytest
+from django.http import HttpResponse
 from django.urls import reverse
 
 from sentry.models.apitoken import ApiToken
+from sentry.models.organization import Organization
 from sentry.silo.base import SiloMode
 from sentry.snuba.metrics import (
     DERIVED_METRICS,
@@ -43,7 +45,9 @@ class OrganizationMetricsPermissionTest(APITestCase):
     def setUp(self) -> None:
         self.create_project(name="Bar", slug="bar", teams=[self.team], fire_project_created=True)
 
-    def send_request(self, organization, token, method, endpoint, *args):
+    def send_request(
+        self, organization: Organization, token: ApiToken, method: str, endpoint: str, *args: str
+    ) -> HttpResponse:
         url = reverse(endpoint, args=(organization.slug,) + args)
         return getattr(self.client, method)(
             url, HTTP_AUTHORIZATION=f"Bearer {token.token}", format="json"

--- a/tests/sentry/api/endpoints/test_project_alert_rule_task_details.py
+++ b/tests/sentry/api/endpoints/test_project_alert_rule_task_details.py
@@ -31,7 +31,7 @@ class ProjectAlertRuleTaskDetailsTest(APITestCase):
             },
         )
 
-    def set_value(self, status, rule_id=None):
+    def set_value(self, status: str, rule_id: int | None = None) -> None:
         client = RedisRuleStatus(self.uuid)
         client.set_value(status, rule_id)
 

--- a/tests/sentry/api/endpoints/test_project_filters.py
+++ b/tests/sentry/api/endpoints/test_project_filters.py
@@ -1,3 +1,6 @@
+from collections.abc import Iterable
+from typing import Any
+
 from sentry.testutils.cases import APITestCase
 
 
@@ -8,7 +11,9 @@ class ProjectFiltersTest(APITestCase):
         super().setUp()
         self.login_as(user=self.user)
 
-    def get_filter_spec(self, response_data, spec_id):
+    def get_filter_spec(
+        self, response_data: Iterable[dict[str, Any]], spec_id: str
+    ) -> dict[str, Any]:
         """
         looks in a successful response data for the specified spec_id and returns it (if found)
         """

--- a/tests/sentry/api/endpoints/test_project_overview.py
+++ b/tests/sentry/api/endpoints/test_project_overview.py
@@ -1,14 +1,7 @@
 from __future__ import annotations
 
-import orjson
-
 from sentry.models.projectredirect import ProjectRedirect
 from sentry.testutils.cases import APITestCase
-
-
-def first_symbol_source_id(sources_json):
-    sources = orjson.loads(sources_json)
-    return sources[0]["id"]
 
 
 class ProjectOverviewTest(APITestCase):

--- a/tests/sentry/api/endpoints/test_project_plugins.py
+++ b/tests/sentry/api/endpoints/test_project_plugins.py
@@ -1,3 +1,4 @@
+from collections.abc import Container
 from unittest.mock import patch
 
 from django.urls import reverse
@@ -38,7 +39,7 @@ class ProjectPluginsTest(APITestCase):
         assert issues["isHidden"] is True
         self.assert_plugin_shape(issues)
 
-    def assert_plugin_shape(self, plugin):
+    def assert_plugin_shape(self, plugin: Container[str]) -> None:
         assert "id" in plugin
         assert "name" in plugin
         assert "shortName" in plugin

--- a/tests/sentry/api/endpoints/test_project_stacktrace_coverage.py
+++ b/tests/sentry/api/endpoints/test_project_stacktrace_coverage.py
@@ -32,7 +32,7 @@ class ProjectStacktraceLinkTestCodecov(BaseProjectStacktraceLink):
         self.organization.save()
 
     @pytest.fixture(autouse=True)
-    def inject_fixtures(self, caplog):
+    def inject_fixtures(self, caplog: pytest.LogCaptureFixture) -> None:
         self._caplog = caplog
 
     @patch.object(

--- a/tests/sentry/api/endpoints/test_project_tagkey_details.py
+++ b/tests/sentry/api/endpoints/test_project_tagkey_details.py
@@ -15,7 +15,7 @@ class ProjectTagKeyDetailsTest(APITestCase, SnubaTestCase):
     def test_simple(self) -> None:
         project = self.create_project()
 
-        def make_event(i):
+        def make_event(i: int) -> None:
             self.store_event(
                 data={
                     "tags": {"foo": f"val{i}"},

--- a/tests/sentry/api/endpoints/test_project_transaction_names.py
+++ b/tests/sentry/api/endpoints/test_project_transaction_names.py
@@ -40,17 +40,18 @@ class ProjectTransactionNamesClusterTest(APITestCase):
                 _get_redis_key(ClustererNamespace.TRANSACTIONS, self.project), transaction
             )
 
-    def _test_get(self, datasource):
+    def _test_get(self, datasource: str) -> None:
+        request_data: dict[str, str | int | bool | list[int]] = {
+            "datasource": datasource,
+            "project": [self.project.id],
+            "statsPeriod": "1h",
+            "limit": 5,
+            "threshold": 3,
+            "returnAllNames": True,
+        }
         response = self.client.get(
             self.url,
-            data={
-                "datasource": datasource,
-                "project": [self.project.id],
-                "statsPeriod": "1h",
-                "limit": 5,
-                "threshold": 3,
-                "returnAllNames": True,
-            },
+            data=request_data,
             format="json",
         )
 

--- a/tests/sentry/api/endpoints/test_relay_register.py
+++ b/tests/sentry/api/endpoints/test_relay_register.py
@@ -4,7 +4,7 @@ import orjson
 from django.conf import settings
 from django.urls import reverse
 from django.utils import timezone
-from sentry_relay.auth import generate_key_pair
+from sentry_relay.auth import PublicKey, SecretKey, generate_key_pair
 
 from sentry.models.relay import Relay, RelayUsage
 from sentry.testutils.cases import APITestCase
@@ -25,7 +25,9 @@ class RelayRegisterTest(APITestCase):
 
         self.path = reverse("sentry-api-0-relay-register-challenge")
 
-    def register_relay(self, key_pair, version, relay_id):
+    def register_relay(
+        self, key_pair: tuple[SecretKey, PublicKey], version: str, relay_id: str | int
+    ) -> None:
 
         private_key = key_pair[0]
         public_key = key_pair[1]

--- a/tests/sentry/api/endpoints/test_user_subscriptions.py
+++ b/tests/sentry/api/endpoints/test_user_subscriptions.py
@@ -1,3 +1,5 @@
+from collections.abc import Generator
+
 import pytest
 from django.conf import settings
 
@@ -18,7 +20,7 @@ class UserSubscriptionsNewsletterTest(APITestCase):
     method = "put"
 
     @pytest.fixture(autouse=True)
-    def enable_newsletter(self):
+    def enable_newsletter(self) -> Generator[None]:
         with newsletter.backend.test_only__downcast_to(DummyNewsletter).enable():
             yield
 

--- a/tests/sentry/api/helpers/test_group_index.py
+++ b/tests/sentry/api/helpers/test_group_index.py
@@ -1276,7 +1276,7 @@ class DeleteGroupsTest(TestCase):
     @patch("sentry.signals.issue_deleted.send_robust")
     def test_delete_groups_deletes_seer_records_by_hash(
         self, send_robust: Mock, mock_delete_seer_grouping_records_by_hash: MagicMock
-    ):
+    ) -> None:
         self.project.update_option("sentry:similarity_backfill_completed", int(time()))
 
         groups = [self.create_group(), self.create_group()]

--- a/tests/sentry/api/serializers/test_group_stream.py
+++ b/tests/sentry/api/serializers/test_group_stream.py
@@ -34,7 +34,7 @@ class StreamGroupSerializerTestCase(
             for args, kwargs in get_range.call_args_list:
                 assert kwargs["environment_ids"] == [environment.id]
 
-        def get_invalid_environment():
+        def get_invalid_environment() -> None:
             raise Environment.DoesNotExist()
 
         with mock.patch(

--- a/tests/sentry/api/serializers/test_organization_member.py
+++ b/tests/sentry/api/serializers/test_organization_member.py
@@ -9,6 +9,7 @@ from sentry.api.serializers.models.organization_member import (
 )
 from sentry.models.organizationmember import InviteStatus
 from sentry.testutils.cases import TestCase
+from sentry.users.models.user import User
 
 
 class OrganizationMemberSerializerTest(TestCase):
@@ -23,7 +24,7 @@ class OrganizationMemberSerializerTest(TestCase):
         self.project = self.create_project(teams=[self.team])
         self.project_2 = self.create_project(teams=[self.team_2])
 
-    def _get_org_members(self):
+    def _get_org_members(self) -> list[User]:
         return list(
             self.org.member_set.filter(user_id__in=[self.owner_user.id, self.user_2.id]).order_by(
                 "user_email"

--- a/tests/sentry/auth_v2/endpoints/test_auth_v2_permissions.py
+++ b/tests/sentry/auth_v2/endpoints/test_auth_v2_permissions.py
@@ -1,4 +1,5 @@
 from django.test import override_settings
+from rest_framework.request import Request
 from rest_framework.views import APIView
 
 from sentry.auth_v2.endpoints.base import AuthV2Permission
@@ -16,7 +17,7 @@ class AuthV2PermissionsTest(DRFPermissionTestCase):
         self.auth_v2_permission = AuthV2Permission()
         self.user = self.create_user(is_superuser=False, is_staff=False)
 
-    def _make_request(self):
+    def _make_request(self) -> Request:
         request = self.make_request(user=self.user)
         drf_request = drf_request_from_request(request)
         return drf_request

--- a/tests/sentry/core/endpoints/test_organization_environments.py
+++ b/tests/sentry/core/endpoints/test_organization_environments.py
@@ -2,6 +2,7 @@ from functools import cached_property
 
 from sentry.api.serializers import serialize
 from sentry.models.environment import Environment
+from sentry.models.project import Project
 from sentry.testutils.cases import APITestCase
 
 
@@ -12,7 +13,7 @@ class OrganizationEnvironmentsTest(APITestCase):
         self.login_as(user=self.user)
 
     @cached_property
-    def project(self):
+    def project(self) -> Project:
         return self.create_project()
 
     def test_simple(self) -> None:

--- a/tests/sentry/core/endpoints/test_project_index.py
+++ b/tests/sentry/core/endpoints/test_project_index.py
@@ -226,7 +226,7 @@ class ProjectsListTest(APITestCase):
             status_code=status.HTTP_401_UNAUTHORIZED,
         )
 
-    def get_installed_unpublished_sentry_app_access_token(self):
+    def get_installed_unpublished_sentry_app_access_token(self) -> ApiToken:
         self.project = self.create_project(organization=self.organization, teams=[self.team])
         sentry_app = self.create_sentry_app(
             scopes=("project:read",),

--- a/tests/sentry/db/models/fields/test_jsonfield.py
+++ b/tests/sentry/db/models/fields/test_jsonfield.py
@@ -30,7 +30,7 @@ class BlankJSONFieldTestModel(models.Model):
         app_label = "fixtures"
 
 
-def default():
+def default() -> dict[str, int]:
     return {"x": 2}
 
 

--- a/tests/sentry/digests/test_notifications.py
+++ b/tests/sentry/digests/test_notifications.py
@@ -59,7 +59,7 @@ class GroupRecordsTestCase(TestCase):
     notification_uuid = str(uuid.uuid4())
 
     @cached_property
-    def rule(self):
+    def rule(self) -> Rule:
         return self.project.rule_set.all()[0]
 
     def test_success(self) -> None:

--- a/tests/sentry/discover/test_dashboard_widget_split.py
+++ b/tests/sentry/discover/test_dashboard_widget_split.py
@@ -26,7 +26,7 @@ pytestmark = pytest.mark.sentry_metrics
 
 class DashboardWidgetDatasetSplitTestCase(BaseMetricsLayerTestCase, TestCase, SnubaTestCase):
     @property
-    def now(self):
+    def now(self) -> datetime:
         return before_now(minutes=10)
 
     def setUp(self) -> None:

--- a/tests/sentry/discover/test_dataset_split.py
+++ b/tests/sentry/discover/test_dataset_split.py
@@ -734,7 +734,7 @@ def project(organization: Organization) -> Project:
 @django_db_all
 def test_dataset_split_decision_inferred_from_query(
     query: str, selected_columns: list[str], expected_dataset: int | None, project: Project
-):
+) -> None:
     snuba_dataclass = SnubaParams(
         start=datetime.now() - timedelta(days=1),
         end=datetime.now(),

--- a/tests/sentry/dynamic_sampling/tasks/test_boost_low_volume_projects.py
+++ b/tests/sentry/dynamic_sampling/tasks/test_boost_low_volume_projects.py
@@ -1,4 +1,4 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import cast
 from unittest.mock import patch
 
@@ -35,7 +35,7 @@ MOCK_DATETIME = (timezone.now() - timedelta(days=1)).replace(
 @freeze_time(MOCK_DATETIME)
 class PrioritiseProjectsSnubaQueryTest(BaseMetricsLayerTestCase, TestCase, SnubaTestCase):
     @property
-    def now(self):
+    def now(self) -> datetime:
         return MOCK_DATETIME
 
     def test_simple_one_org_one_project(self) -> None:

--- a/tests/sentry/dynamic_sampling/tasks/test_custom_rule_notifications.py
+++ b/tests/sentry/dynamic_sampling/tasks/test_custom_rule_notifications.py
@@ -9,12 +9,13 @@ from sentry.dynamic_sampling.tasks.custom_rule_notifications import (
     get_num_samples,
 )
 from sentry.models.dynamicsampling import CustomDynamicSamplingRule
+from sentry.services.eventstore.models import Event
 from sentry.testutils.cases import SnubaTestCase, TestCase
 from sentry.utils.samples import load_data
 
 
 class CustomRuleNotificationsTest(TestCase, SnubaTestCase):
-    def create_transaction(self):
+    def create_transaction(self) -> Event:
         data = load_data("transaction")
         return self.store_event(data, project_id=self.project.id)
 

--- a/tests/sentry/dynamic_sampling/tasks/test_sliding_window.py
+++ b/tests/sentry/dynamic_sampling/tasks/test_sliding_window.py
@@ -1,4 +1,4 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 from django.utils import timezone
 
@@ -15,7 +15,7 @@ MOCK_DATETIME = (timezone.now() - timedelta(days=1)).replace(
 @freeze_time(MOCK_DATETIME)
 class SlidingWindowOrgSnubaQueryTest(BaseMetricsLayerTestCase, TestCase, SnubaTestCase):
     @property
-    def now(self):
+    def now(self) -> datetime:
         return MOCK_DATETIME
 
     def test_query_with_one_org_and_multiple_projects(self) -> None:

--- a/tests/sentry/event_manager/test_priority.py
+++ b/tests/sentry/event_manager/test_priority.py
@@ -34,7 +34,7 @@ class TestEventManagerPriority(TestCase):
     @patch("sentry.event_manager._get_priority_for_group", return_value=PriorityLevel.HIGH)
     def test_get_priority_for_group_not_called_on_second_event(
         self, mock_get_priority_for_group: MagicMock, mock_get_severity_score: MagicMock
-    ):
+    ) -> None:
         event = EventManager(make_event(level=logging.FATAL, platform="python")).save(
             self.project.id
         )

--- a/tests/sentry/event_manager/test_severity.py
+++ b/tests/sentry/event_manager/test_severity.py
@@ -27,7 +27,7 @@ from sentry.testutils.skips import requires_snuba
 pytestmark = [requires_snuba]
 
 
-def make_event(**kwargs) -> dict[str, Any]:
+def make_event(**kwargs: Any) -> dict[str, Any]:
     result: dict[str, Any] = {
         "event_id": uuid.uuid1().hex,
     }
@@ -362,7 +362,7 @@ class TestEventManagerSeverity(TestCase):
     @patch("sentry.event_manager._get_severity_score", return_value=(0.1121, "ml"))
     def test_get_severity_score_not_called_on_second_event(
         self, mock_get_severity_score: MagicMock
-    ):
+    ) -> None:
         nope_event = EventManager(
             make_event(
                 exception={"values": [{"type": "NopeError", "value": "Nopey McNopeface"}]},

--- a/tests/sentry/feedback/__init__.py
+++ b/tests/sentry/feedback/__init__.py
@@ -1,11 +1,12 @@
 import time
 from datetime import UTC, datetime
+from typing import Any
 
 from openai.types.chat.chat_completion import ChatCompletion, Choice
 from openai.types.chat.chat_completion_message import ChatCompletionMessage
 
 
-def create_dummy_openai_response(*args, **kwargs):
+def create_dummy_openai_response(*args, **kwargs) -> ChatCompletion:
     return ChatCompletion(
         id="test",
         choices=[
@@ -31,7 +32,7 @@ def create_dummy_openai_response(*args, **kwargs):
     )
 
 
-def mock_feedback_event(project_id: int, dt: datetime | None = None):
+def mock_feedback_event(project_id: int, dt: datetime | None = None) -> dict[str, Any]:
     if dt is None:
         dt = datetime.now(UTC)
 

--- a/tests/sentry/feedback/lib/test_feedback_query.py
+++ b/tests/sentry/feedback/lib/test_feedback_query.py
@@ -27,13 +27,13 @@ class FeedbackData(TypedDict):
 
 @django_db_all
 class TestFeedbackQuery(APITestCase, SnubaTestCase, SearchIssueTestMixin):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.project = self.create_project()
         self.organization = self.project.organization
         self._create_standard_feedbacks()
 
-    def _create_standard_feedbacks(self):
+    def _create_standard_feedbacks(self) -> None:
         """Create a standard set of feedbacks for all tests to use."""
         feedback_data: list[FeedbackData] = [
             {
@@ -100,7 +100,7 @@ class TestFeedbackQuery(APITestCase, SnubaTestCase, SearchIssueTestMixin):
                 override_occurrence_data={"type": FeedbackGroup.type_id},
             )
 
-    def test_get_ai_labels_from_tags_retrieves_labels_correctly(self):
+    def test_get_ai_labels_from_tags_retrieves_labels_correctly(self) -> None:
         # Create a query using the function to retrieve AI labels
         query = Query(
             match=Entity(Dataset.IssuePlatform.value),
@@ -138,7 +138,7 @@ class TestFeedbackQuery(APITestCase, SnubaTestCase, SearchIssueTestMixin):
         }
         assert all_labels == expected_labels
 
-    def test_query_top_ai_labels_by_feedback_count(self):
+    def test_query_top_ai_labels_by_feedback_count(self) -> None:
         result = query_top_ai_labels_by_feedback_count(
             organization_id=self.organization.id,
             project_ids=[self.project.id],
@@ -196,7 +196,7 @@ class TestFeedbackQuery(APITestCase, SnubaTestCase, SearchIssueTestMixin):
 
         assert len(result_no_project) == 0
 
-    def test_query_recent_feedbacks_with_ai_labels(self):
+    def test_query_recent_feedbacks_with_ai_labels(self) -> None:
         result = query_recent_feedbacks_with_ai_labels(
             organization_id=self.organization.id,
             project_ids=[self.project.id],
@@ -277,7 +277,7 @@ class TestFeedbackQuery(APITestCase, SnubaTestCase, SearchIssueTestMixin):
 
         assert len(result_no_project) == 0
 
-    def test_query_label_group_counts(self):
+    def test_query_label_group_counts(self) -> None:
         label_groups = [
             ["User Interface", "Performance"],
             ["Authentication", "Security"],

--- a/tests/sentry/flags/endpoints/test_hooks.py
+++ b/tests/sentry/flags/endpoints/test_hooks.py
@@ -23,7 +23,7 @@ class OrganizationFlagsHooksEndpointTestCase(APITestCase):
         self.url = reverse(self.endpoint, args=(self.organization.slug, "launchdarkly"))
 
     @property
-    def features(self):
+    def features(self) -> dict[str, bool]:
         return {}
 
     def test_generic_post_create(self, mock_incr: MagicMock) -> None:

--- a/tests/sentry/incidents/endpoints/serializers/test_alert_rule.py
+++ b/tests/sentry/incidents/endpoints/serializers/test_alert_rule.py
@@ -1,3 +1,4 @@
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 from sentry.api.serializers import serialize
@@ -82,7 +83,7 @@ class BaseAlertRuleSerializerTest:
         else:
             assert result["comparisonDelta"] is None
 
-    def create_issue_alert_rule(self, data):
+    def create_issue_alert_rule(self, data: dict[str, Any]) -> Rule:
         """data format
         {
             "project": project

--- a/tests/sentry/incidents/endpoints/test_organization_combined_rule_index_endpoint.py
+++ b/tests/sentry/incidents/endpoints/test_organization_combined_rule_index_endpoint.py
@@ -50,7 +50,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
         self.login_as(self.user)
         self.combined_rules_url = f"/api/0/organizations/{self.organization.slug}/combined-rules/"
 
-    def setup_rules(self):
+    def setup_rules(self) -> None:
         self.alert_rule = self.create_alert_rule(
             name="alert rule",
             organization=self.organization,

--- a/tests/sentry/incidents/endpoints/test_organization_ondemand_rule_stats_endpoint.py
+++ b/tests/sentry/incidents/endpoints/test_organization_ondemand_rule_stats_endpoint.py
@@ -37,7 +37,7 @@ class OrganizationOnDemandRuleStatsEndpointTest(BaseAlertRuleSerializerTest, API
 
         self.login_as(user=self.user)
 
-    def do_success_request(self, extra_features: dict[str, bool] | None = None):
+    def do_success_request(self, extra_features: dict[str, bool] | None = None) -> dict[str, int]:
         _features = {**self.features, **(extra_features or {})}
         with self.feature(_features):
             response = self.get_success_response(self.organization.slug, project_id=self.project.id)

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from sentry import audit_log
 from sentry.api.serializers import serialize
 from sentry.deletions.tasks.scheduled import run_scheduled_deletions
@@ -43,7 +45,7 @@ class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase):
 class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
     method = "put"
 
-    def get_serialized_alert_rule(self):
+    def get_serialized_alert_rule(self) -> dict[str, Any]:
         # Only call after calling self.alert_rule to create it.
         original_endpoint = self.endpoint
         original_method = self.method

--- a/tests/sentry/integrations/bitbucket/test_installed.py
+++ b/tests/sentry/integrations/bitbucket/test_installed.py
@@ -94,7 +94,7 @@ class BitbucketInstalledEndpointTest(APITestCase):
 
         plugins.register(BitbucketPlugin)
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         plugins.unregister(BitbucketPlugin)
         super().tearDown()
 

--- a/tests/sentry/integrations/bitbucket/test_issues.py
+++ b/tests/sentry/integrations/bitbucket/test_issues.py
@@ -50,7 +50,7 @@ class BitbucketIssueTest(APITestCase):
             ("myaccount/repo2", "myaccount/repo2"),
         ]
 
-    def build_autocomplete_url(self):
+    def build_autocomplete_url(self) -> str:
         return "/extensions/bitbucket/search/baz/%d/" % self.integration.id
 
     @responses.activate

--- a/tests/sentry/integrations/github/test_search.py
+++ b/tests/sentry/integrations/github/test_search.py
@@ -6,6 +6,7 @@ import responses
 from django.urls import reverse
 
 from sentry.integrations.github.integration import build_repository_query
+from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.source_code_management.metrics import SourceCodeSearchEndpointHaltReason
 from sentry.integrations.types import EventLifecycleOutcome
@@ -26,7 +27,7 @@ class GithubSearchTest(APITestCase):
     provider = "github"
     base_url = "https://api.github.com"
 
-    def _create_integration(self):
+    def _create_integration(self) -> Integration:
         future = datetime.now() + timedelta(hours=1)
         return self.create_provider_integration(
             provider=self.provider,

--- a/tests/sentry/integrations/github_enterprise/test_repository.py
+++ b/tests/sentry/integrations/github_enterprise/test_repository.py
@@ -25,7 +25,7 @@ class GitHubEnterpriseRepositoryTest(TestCase):
         )
 
     @cached_property
-    def provider(self):
+    def provider(self) -> GitHubEnterpriseRepositoryProvider:
         return GitHubEnterpriseRepositoryProvider("integrations:github_enterprise")
 
     @responses.activate
@@ -38,8 +38,8 @@ class GitHubEnterpriseRepositoryTest(TestCase):
             "external_id": "654321",
             "integration_id": self.integration.id,
         }
-        data = self.provider.build_repository_config(organization, data)
-        assert data == {
+        rc_data = self.provider.build_repository_config(organization, data)
+        assert rc_data == {
             "config": {"name": "getsentry/example-repo"},
             "external_id": "654321",
             "integration_id": self.integration.id,

--- a/tests/sentry/integrations/github_enterprise/test_search.py
+++ b/tests/sentry/integrations/github_enterprise/test_search.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta
 
+from sentry.integrations.models.integration import Integration
 from sentry.testutils.silo import control_silo_test
 
 from ..github import test_search
@@ -12,7 +13,7 @@ class GithubEnterpriseSearchTest(test_search.GithubSearchTest):
     provider = "github_enterprise"
     base_url = "https://github.example.org/api/v3"
 
-    def _create_integration(self):
+    def _create_integration(self) -> Integration:
         future = datetime.now() + timedelta(hours=1)
         return self.create_provider_integration(
             provider=self.provider,

--- a/tests/sentry/integrations/jira/test_client.py
+++ b/tests/sentry/integrations/jira/test_client.py
@@ -16,7 +16,7 @@ control_address = "http://controlserver"
 secret = "hush-hush-im-invisible"
 
 
-def mock_finalize_request(prepared_request: PreparedRequest):
+def mock_finalize_request(prepared_request: PreparedRequest) -> PreparedRequest:
     prepared_request.headers["Authorization"] = f"JWT {mock_jwt}"
     return prepared_request
 

--- a/tests/sentry/integrations/jira_server/test_webhooks.py
+++ b/tests/sentry/integrations/jira_server/test_webhooks.py
@@ -23,7 +23,7 @@ class JiraServerWebhookEndpointTest(APITestCase):
         self.integration = get_integration(self.organization, self.user)
 
     @property
-    def jwt_token(self):
+    def jwt_token(self) -> str:
         return jwt.encode(
             {"id": self.integration.external_id}, self.integration.metadata["webhook_secret"]
         )

--- a/tests/sentry/integrations/middleware/hybrid_cloud/test_base.py
+++ b/tests/sentry/integrations/middleware/hybrid_cloud/test_base.py
@@ -19,7 +19,7 @@ from sentry.testutils.cases import TestCase
 from sentry.types.region import Region, RegionCategory
 
 
-def error_regions(region: Region, invalid_region_names: Iterable[str]):
+def error_regions(region: Region, invalid_region_names: Iterable[str]) -> str:
     if region.name in invalid_region_names:
         raise SiloLimit.AvailabilityError("Region is offline!")
     return region.name

--- a/tests/sentry/integrations/msteams/test_webhook.py
+++ b/tests/sentry/integrations/msteams/test_webhook.py
@@ -1,3 +1,4 @@
+from collections.abc import Generator
 from copy import deepcopy
 from unittest import mock
 from unittest.mock import MagicMock, call
@@ -38,7 +39,7 @@ kid = "Su-pdZys9LJGhDVgah3UjfPouuc"
 
 class MsTeamsWebhookTest(APITestCase):
     @pytest.fixture(autouse=True)
-    def _setup_metric_patch(self):
+    def _setup_metric_patch(self) -> Generator[None]:
         with mock.patch("sentry.shared_integrations.client.base.metrics") as self.metrics:
             yield
 

--- a/tests/sentry/integrations/pagerduty/test_client.py
+++ b/tests/sentry/integrations/pagerduty/test_client.py
@@ -1,3 +1,4 @@
+from collections.abc import Generator
 from unittest import mock
 from unittest.mock import MagicMock, call, patch
 
@@ -35,7 +36,7 @@ class PagerDutyClientTest(APITestCase):
     provider = "pagerduty"
 
     @pytest.fixture(autouse=True)
-    def _setup_metric_patch(self):
+    def _setup_metric_patch(self) -> Generator[None]:
         with mock.patch("sentry.shared_integrations.client.base.metrics") as self.metrics:
             yield
 

--- a/tests/sentry/integrations/slack/message_builder/test_routing.py
+++ b/tests/sentry/integrations/slack/message_builder/test_routing.py
@@ -4,7 +4,7 @@ from sentry.testutils.cases import TestCase
 
 
 class SlackRequestRoutingTest(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.organization = self.create_organization()
         self.project = self.create_project(organization=self.organization)
 

--- a/tests/sentry/integrations/test_base.py
+++ b/tests/sentry/integrations/test_base.py
@@ -10,7 +10,7 @@ from sentry.users.models.identity import Identity
 
 
 class ExampleIntegration(IntegrationInstallation):
-    def get_client(self):
+    def get_client(self) -> None:
         raise NotImplementedError
 
 

--- a/tests/sentry/integrations/test_helpers.py
+++ b/tests/sentry/integrations/test_helpers.py
@@ -12,7 +12,7 @@ def add_control_silo_proxy_response(
     path: str | None,
     additional_matchers: list[Any] | None = None,
     **additional_response_kwargs: Any,
-):
+) -> responses.BaseResponse:
     if additional_matchers is None:
         additional_matchers = []
 

--- a/tests/sentry/integrations/test_notification_utilities.py
+++ b/tests/sentry/integrations/test_notification_utilities.py
@@ -38,7 +38,7 @@ class TestNotificationUtilities(TestCase):
         self,
         actual: Mapping[Actor, Mapping[str, RpcIntegration | Integration]],
         expected: Mapping[User, Mapping[str, RpcIntegration | Integration]],
-    ):
+    ) -> None:
         assert actual == {Actor.from_orm_user(k): v for (k, v) in expected.items()}
 
     def test_simple(self) -> None:

--- a/tests/sentry/integrations/utils/test_scope.py
+++ b/tests/sentry/integrations/utils/test_scope.py
@@ -92,7 +92,7 @@ class BindOrgContextFromIntegrationTest(TestCase):
         mock_check_tag_for_scope_bleed: MagicMock,
         mock_bind_org_context: MagicMock,
         mock_bind_ambiguous_org_context: MagicMock,
-    ):
+    ) -> None:
         with assume_test_silo_mode(SiloMode.CONTROL):
             integration = self.create_provider_integration(name="squirrelChasers")
 

--- a/tests/sentry/integrations/vsts/test_provider.py
+++ b/tests/sentry/integrations/vsts/test_provider.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Generator
 from time import time
 from typing import Any
 from unittest.mock import MagicMock, Mock, patch
@@ -305,7 +306,7 @@ class VstsIdentityProviderTest(TestCase):
         self.provider = VSTSIdentityProvider()
 
     @pytest.fixture(autouse=True)
-    def patch_get_oauth_client_secret(self):
+    def patch_get_oauth_client_secret(self) -> Generator[None]:
         with patch.object(
             VSTSIdentityProvider, "get_oauth_client_secret", return_value=self.client_secret
         ):

--- a/tests/sentry/issues/auto_source_code_config/test_code_mapping.py
+++ b/tests/sentry/issues/auto_source_code_config/test_code_mapping.py
@@ -95,7 +95,7 @@ def test_buckets_logic() -> None:
 
 class TestDerivedCodeMappings(TestCase):
     @pytest.fixture(autouse=True)
-    def inject_fixtures(self, caplog: Any) -> None:
+    def inject_fixtures(self, caplog: pytest.LogCaptureFixture) -> None:
         self._caplog = caplog
 
     def setUp(self) -> None:

--- a/tests/sentry/middleware/integrations/parsers/test_discord.py
+++ b/tests/sentry/middleware/integrations/parsers/test_discord.py
@@ -38,7 +38,7 @@ class DiscordRequestParserTest(TestCase):
             provider="discord",
         )
 
-    def get_parser(self, path: str, data: Mapping[str, Any] | None = None):
+    def get_parser(self, path: str, data: Mapping[str, Any] | None = None) -> DiscordRequestParser:
         if not data:
             data = {}
         self.request = self.factory.post(
@@ -60,6 +60,7 @@ class DiscordRequestParserTest(TestCase):
 
         response = parser.get_response()
         assert response.status_code == status.HTTP_200_OK
+        assert isinstance(response, HttpResponse)
         data = json.loads(response.content)
         assert data == {"type": 1}
         assert len(responses.calls) == 0
@@ -78,6 +79,7 @@ class DiscordRequestParserTest(TestCase):
 
         response = parser.get_response()
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        assert isinstance(response, HttpResponse)
         assert not response.content
         assert_no_webhook_payloads()
         assert len(responses.calls) == 0
@@ -94,6 +96,7 @@ class DiscordRequestParserTest(TestCase):
 
         response = parser.get_response()
         assert response.status_code == status.HTTP_200_OK
+        assert isinstance(response, HttpResponse)
         data = json.loads(response.content)
         assert data == {"type": 1}
         assert_no_webhook_payloads()
@@ -242,6 +245,7 @@ class DiscordRequestParserTest(TestCase):
             }
         )
         assert response.status_code == status.HTTP_200_OK
+        assert isinstance(response, HttpResponse)
         assert json.loads(response.content) == parser.async_response_data
 
 

--- a/tests/sentry/middleware/integrations/parsers/test_msteams.py
+++ b/tests/sentry/middleware/integrations/parsers/test_msteams.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+from typing import Any
 
 import responses
 from django.http import HttpRequest, HttpResponse
@@ -40,7 +41,7 @@ class MsTeamsRequestParserTest(TestCase):
     def get_response(self, request: HttpRequest) -> HttpResponse:
         return HttpResponse(status=200, content="passthrough")
 
-    def generate_card_response(self, integration_id: int):
+    def generate_card_response(self, integration_id: int) -> dict[str, Any]:
         return {
             "type": "message",
             "from": {"id": "user_id"},

--- a/tests/sentry/middleware/test_access_log_middleware.py
+++ b/tests/sentry/middleware/test_access_log_middleware.py
@@ -180,7 +180,7 @@ optional_access_log_fields = (
 @override_settings(LOG_API_ACCESS=True)
 class LogCaptureAPITestCase(APITestCase):
     @pytest.fixture(autouse=True)
-    def inject_fixtures(self, caplog):
+    def inject_fixtures(self, caplog: pytest.LogCaptureFixture):
         self._caplog = caplog
 
     def assert_access_log_recorded(self):

--- a/tests/sentry/migrations/test_0921_convert_org_saved_searches_to_views_rerevised.py
+++ b/tests/sentry/migrations/test_0921_convert_org_saved_searches_to_views_rerevised.py
@@ -12,7 +12,7 @@ class ConvertOrgSavedSearchesToViewsTest(TestMigrations):
     migrate_from = "0920_convert_org_saved_searches_to_views_revised"
     migrate_to = "0921_convert_org_saved_searches_to_views_rerevised"
 
-    def setup_initial_state(self):
+    def setup_initial_state(self) -> None:
         self.org = self.create_organization()
         self.user = self.create_user()
 

--- a/tests/sentry/models/releases/test_release_project.py
+++ b/tests/sentry/models/releases/test_release_project.py
@@ -27,7 +27,7 @@ class ReleaseProjectManagerTestCase(TransactionTestCase):
     @receivers_raise_on_send()
     def test_post_save_signal_runs_if_dynamic_sampling_is_enabled_and_latest_release_rule_does_not_exist(
         self,
-    ):
+    ) -> None:
         with Feature(
             {
                 "organizations:dynamic-sampling": True,
@@ -45,7 +45,7 @@ class ReleaseProjectManagerTestCase(TransactionTestCase):
     @receivers_raise_on_send()
     def test_post_save_signal_runs_if_dynamic_sampling_is_enabled_and_latest_release_rule_exists(
         self,
-    ):
+    ) -> None:
         with Feature(
             {
                 "organizations:dynamic-sampling": True,

--- a/tests/sentry/models/test_dashboard.py
+++ b/tests/sentry/models/test_dashboard.py
@@ -65,7 +65,7 @@ class IncrementalNameTest(TestCase):
 class DashboardFavoriteUserTest(TestCase):
     def create_dashboard_favorite_user(
         self, dashboard: Dashboard, user: User, organization: Organization, position: int | None
-    ):
+    ) -> DashboardFavoriteUser:
         return DashboardFavoriteUser.objects.create(
             dashboard=dashboard, user_id=user.id, organization=organization, position=position
         )

--- a/tests/sentry/models/test_groupowner.py
+++ b/tests/sentry/models/test_groupowner.py
@@ -6,7 +6,7 @@ from sentry.testutils.helpers.datetime import before_now
 
 
 class GroupOwnerTest(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
 
         self.timestamp = before_now(minutes=10)
@@ -37,14 +37,14 @@ class GroupOwnerTest(TestCase):
             "suspectCommitStrategy": SuspectCommitStrategy.RELEASE_BASED,
         }
 
-    def _make_scm_lookup_kwargs(self):
+    def _make_scm_lookup_kwargs(self) -> None:
         """
         scm_based lookup_kwargs include an additional filter: context__contains,
         release_based group owners don't have this field in context.
         """
         self.lookup_kwargs.update(self.scm_extra_lookup)
 
-    def test_update_or_create_and_preserve_context_create_then_update_scm(self):
+    def test_update_or_create_and_preserve_context_create_then_update_scm(self) -> None:
         assert GroupOwner.objects.filter(**self.lookup_kwargs).exists() is False
 
         self._make_scm_lookup_kwargs()
@@ -83,7 +83,7 @@ class GroupOwnerTest(TestCase):
         assert obj.date_added == now
         assert obj.context == self.scm_context_defaults
 
-    def test_update_or_create_and_preserve_context_update_scm(self):
+    def test_update_or_create_and_preserve_context_update_scm(self) -> None:
         original_obj = GroupOwner.objects.create(
             context={
                 "commitId": self.c.id,
@@ -114,7 +114,7 @@ class GroupOwnerTest(TestCase):
             "suspectCommitStrategy": SuspectCommitStrategy.SCM_BASED,
         }
 
-    def test_update_or_create_and_preserve_context_create_then_update_rb(self):
+    def test_update_or_create_and_preserve_context_create_then_update_rb(self) -> None:
         assert GroupOwner.objects.filter(**self.lookup_kwargs).exists() is False
 
         obj, created = GroupOwner.objects.update_or_create_and_preserve_context(

--- a/tests/sentry/models/test_manager.py
+++ b/tests/sentry/models/test_manager.py
@@ -8,7 +8,7 @@ class GetFromCacheTest(TestCase):
     def setUp(self) -> None:
         self.clear()
 
-    def clear(self):
+    def clear(self) -> None:
         cache.clear()
         flush_manager_local_cache()
 

--- a/tests/sentry/models/test_projectcodeowners.py
+++ b/tests/sentry/models/test_projectcodeowners.py
@@ -5,7 +5,7 @@ from sentry.utils.cache import cache
 
 
 class ProjectCodeOwnersTestCase(TestCase):
-    def tearDown(self):
+    def tearDown(self) -> None:
         cache.delete(ProjectCodeOwners.get_cache_key(self.project.id))
 
         super().tearDown()

--- a/tests/sentry/models/test_projecttemplate.py
+++ b/tests/sentry/models/test_projecttemplate.py
@@ -6,7 +6,7 @@ class ProjectTemplateTest(TestCase):
     def setUp(self) -> None:
         self.org = self.create_organization()
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         self.org.delete()
 
     def test_create_simple_project_template(self) -> None:

--- a/tests/sentry/models/test_projecttemplateoption.py
+++ b/tests/sentry/models/test_projecttemplateoption.py
@@ -138,7 +138,7 @@ class ProjectTemplateOptionTest(TestCase):
             name="test_project_template", organization=self.org
         )
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         self.org.delete()
         self.project_template.delete()
 

--- a/tests/sentry/monitors/consumers/test_clock_tasks_consumer.py
+++ b/tests/sentry/monitors/consumers/test_clock_tasks_consumer.py
@@ -25,7 +25,7 @@ def send_task(
     consumer: ProcessingStrategy[KafkaPayload],
     ts: datetime,
     task: MonitorsClockTasks,
-):
+) -> None:
     value = BrokerValue(
         KafkaPayload(b"fake-key", MONITORS_CLOCK_TASKS_CODEC.encode(task), []),
         partition,

--- a/tests/sentry/monitors/migrations/test_0008_fix_processing_error_keys.py
+++ b/tests/sentry/monitors/migrations/test_0008_fix_processing_error_keys.py
@@ -24,7 +24,7 @@ class FixProcessingErrorKeysTest(TestMigrations):
     app = "monitors"
     connection = "secondary"
 
-    def setup_initial_state(self):
+    def setup_initial_state(self) -> None:
         redis = _get_cluster()
         pipeline = redis.pipeline()
 
@@ -74,7 +74,7 @@ class FixProcessingErrorKeysTest(TestMigrations):
         assert project_errors[0].id != self.project_error_id
         assert monitor_errors[0].id != self.monitor_error_id
 
-    def test(self):
+    def test(self) -> None:
         monitor_errors = get_errors_for_monitor(self.monitor)
         assert monitor_errors[0].id == self.monitor_error_id
 

--- a/tests/sentry/monitors/test_models.py
+++ b/tests/sentry/monitors/test_models.py
@@ -285,7 +285,7 @@ class MonitorEnvironmentTestCase(TestCase):
 
 
 class CronMonitorDataSourceHandlerTest(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.monitor = self.create_monitor(
             project=self.project,
@@ -298,11 +298,11 @@ class CronMonitorDataSourceHandlerTest(TestCase):
             organization_id=self.organization.id,
         )
 
-    def test_bulk_get_query_object(self):
+    def test_bulk_get_query_object(self) -> None:
         result = CronMonitorDataSourceHandler.bulk_get_query_object([self.data_source])
         assert result[self.data_source.id] == self.monitor
 
-    def test_bulk_get_query_object__multiple_monitors(self):
+    def test_bulk_get_query_object__multiple_monitors(self) -> None:
         monitor2 = self.create_monitor(
             project=self.project,
             name="Test Monitor 2",
@@ -319,7 +319,7 @@ class CronMonitorDataSourceHandlerTest(TestCase):
         assert result[self.data_source.id] == self.monitor
         assert result[data_source2.id] == monitor2
 
-    def test_bulk_get_query_object__incorrect_data_source(self):
+    def test_bulk_get_query_object__incorrect_data_source(self) -> None:
         ds_with_invalid_monitor_id = DataSource.objects.create(
             type=DATA_SOURCE_CRON_MONITOR,
             source_id="not_an_int",
@@ -341,7 +341,7 @@ class CronMonitorDataSourceHandlerTest(TestCase):
                 },
             )
 
-    def test_bulk_get_query_object__missing_monitor(self):
+    def test_bulk_get_query_object__missing_monitor(self) -> None:
         ds_with_deleted_monitor = DataSource.objects.create(
             type=DATA_SOURCE_CRON_MONITOR,
             source_id="99999999",
@@ -354,11 +354,11 @@ class CronMonitorDataSourceHandlerTest(TestCase):
         assert result[self.data_source.id] == self.monitor
         assert result[ds_with_deleted_monitor.id] is None
 
-    def test_bulk_get_query_object__empty_list(self):
+    def test_bulk_get_query_object__empty_list(self) -> None:
         result = CronMonitorDataSourceHandler.bulk_get_query_object([])
         assert result == {}
 
-    def test_related_model(self):
+    def test_related_model(self) -> None:
         relations = CronMonitorDataSourceHandler.related_model(self.data_source)
         assert len(relations) == 1
         relation = relations[0]
@@ -366,9 +366,9 @@ class CronMonitorDataSourceHandlerTest(TestCase):
         assert relation.params["model"] == Monitor
         assert relation.params["query"] == {"id": self.data_source.source_id}
 
-    def test_get_instance_limit(self):
+    def test_get_instance_limit(self) -> None:
         assert CronMonitorDataSourceHandler.get_instance_limit(self.organization) is None
 
-    def test_get_current_instance_count(self):
+    def test_get_current_instance_count(self) -> None:
         with pytest.raises(NotImplementedError):
             CronMonitorDataSourceHandler.get_current_instance_count(self.organization)

--- a/tests/sentry/monitors/test_schedule.py
+++ b/tests/sentry/monitors/test_schedule.py
@@ -5,7 +5,7 @@ from sentry.monitors.schedule import get_next_schedule, get_prev_schedule
 from sentry.monitors.types import CrontabSchedule, IntervalSchedule
 
 
-def t(hour: int, minute: int):
+def t(hour: int, minute: int) -> datetime:
     return datetime(2019, 1, 1, hour, minute, 0, tzinfo=timezone.utc)
 
 

--- a/tests/sentry/monitors/test_utils.py
+++ b/tests/sentry/monitors/test_utils.py
@@ -10,11 +10,11 @@ from sentry.workflow_engine.models import DataSource, Detector
 
 
 class EnsureCronDetectorTest(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.monitor = self.create_monitor(owner_user_id=None)
 
-    def test_creates_data_source_and_detector_for_new_monitor(self):
+    def test_creates_data_source_and_detector_for_new_monitor(self) -> None:
         assert not get_detector_for_monitor(self.monitor)
         ensure_cron_detector(self.monitor)
         detector = get_detector_for_monitor(self.monitor)
@@ -25,7 +25,7 @@ class EnsureCronDetectorTest(TestCase):
         assert detector.owner_user_id == self.monitor.owner_user_id
         assert detector.owner_team_id == self.monitor.owner_team_id
 
-    def test_idempotent_for_existing_data_source(self):
+    def test_idempotent_for_existing_data_source(self) -> None:
         ensure_cron_detector(self.monitor)
         detector = get_detector_for_monitor(self.monitor)
         assert detector
@@ -34,7 +34,7 @@ class EnsureCronDetectorTest(TestCase):
         assert detector_after is not None
         assert detector.id == detector_after.id
 
-    def test_with_owner_user(self):
+    def test_with_owner_user(self) -> None:
         self.monitor.owner_user_id = self.user.id
         self.monitor.save()
         ensure_cron_detector(self.monitor)
@@ -45,7 +45,7 @@ class EnsureCronDetectorTest(TestCase):
         assert detector.owner_user_id == self.user.id
         assert detector.owner_team_id is None
 
-    def test_with_no_owner(self):
+    def test_with_no_owner(self) -> None:
         ensure_cron_detector(self.monitor)
 
         detector = Detector.objects.get(
@@ -55,7 +55,7 @@ class EnsureCronDetectorTest(TestCase):
         assert detector.owner_user_id is None
         assert detector.owner_team_id is None
 
-    def test_handles_database_errors_gracefully(self):
+    def test_handles_database_errors_gracefully(self) -> None:
         with (
             patch("sentry.monitors.utils.logger") as mock_logger,
             patch("sentry.monitors.utils.DataSource.objects.get_or_create") as mock_get_or_create,
@@ -68,7 +68,7 @@ class EnsureCronDetectorTest(TestCase):
             type=DATA_SOURCE_CRON_MONITOR, source_id=str(self.monitor.id)
         ).exists()
 
-    def test_atomic_transaction_rollback(self):
+    def test_atomic_transaction_rollback(self) -> None:
         with patch("sentry.monitors.utils.Detector.objects.create") as mock_create:
             mock_create.side_effect = IntegrityError("Cannot create detector")
 
@@ -79,15 +79,15 @@ class EnsureCronDetectorTest(TestCase):
 
 
 class GetDetectorForMonitorTest(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.monitor = self.create_monitor()
 
-    def test_returns_none_when_no_detector_exists(self):
+    def test_returns_none_when_no_detector_exists(self) -> None:
         detector = get_detector_for_monitor(self.monitor)
         assert detector is None
 
-    def test_returns_detector_when_exists(self):
+    def test_returns_detector_when_exists(self) -> None:
         ensure_cron_detector(self.monitor)
 
         detector = get_detector_for_monitor(self.monitor)
@@ -96,7 +96,7 @@ class GetDetectorForMonitorTest(TestCase):
         assert detector.project_id == self.monitor.project_id
         assert detector.name == self.monitor.name
 
-    def test_returns_correct_detector_for_specific_monitor(self):
+    def test_returns_correct_detector_for_specific_monitor(self) -> None:
         monitor1 = self.monitor
         monitor2 = self.create_monitor(name="Monitor 2")
 

--- a/tests/sentry/new_migrations/monkey/test_executor.py
+++ b/tests/sentry/new_migrations/monkey/test_executor.py
@@ -1,3 +1,4 @@
+from collections.abc import Generator
 from unittest.mock import patch
 
 import pytest
@@ -23,7 +24,7 @@ class DummyGetsentryAppConfig(AppConfig):
 
 class TestSentryMigrationExecutor:
     @pytest.fixture(autouse=True)
-    def _mock_getsentry_if_not_registered(self):
+    def _mock_getsentry_if_not_registered(self) -> Generator[None]:
         if "getsentry" in settings.INSTALLED_APPS:
             yield
             return

--- a/tests/sentry/notifications/models/test_notificationsettingoption.py
+++ b/tests/sentry/notifications/models/test_notificationsettingoption.py
@@ -7,7 +7,7 @@ from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.users.models.user import User
 
 
-def assert_no_notification_settings():
+def assert_no_notification_settings() -> None:
     assert NotificationSettingOption.objects.all().count() == 0
 
 

--- a/tests/sentry/notifications/models/test_notificationsettingprovider.py
+++ b/tests/sentry/notifications/models/test_notificationsettingprovider.py
@@ -7,7 +7,7 @@ from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.users.models.user import User
 
 
-def assert_no_notification_settings():
+def assert_no_notification_settings() -> None:
     assert NotificationSettingProvider.objects.all().count() == 0
 
 

--- a/tests/sentry/notifications/notifications/test_digests.py
+++ b/tests/sentry/notifications/notifications/test_digests.py
@@ -59,7 +59,7 @@ class DigestNotificationTest(TestCase, OccurrenceTestMixin, PerformanceIssueTest
         event_count: int,
         performance_issues: bool = False,
         generic_issues: bool = False,
-    ):
+    ) -> None:
         with patch.object(sentry, "digests") as digests:
             backend = RedisBackend()
             digests.backend.digest = backend.digest

--- a/tests/sentry/notifications/notifications/test_organization_request.py
+++ b/tests/sentry/notifications/notifications/test_organization_request.py
@@ -1,3 +1,5 @@
+from django.db.models.query import QuerySet
+
 from sentry.integrations.types import ExternalProviders
 from sentry.models.organizationmember import OrganizationMember
 from sentry.notifications.notifications.organization_request import OrganizationRequestNotification
@@ -9,7 +11,7 @@ from sentry.types.actor import Actor
 
 
 class DummyRoleBasedRecipientStrategy(RoleBasedRecipientStrategy):
-    def determine_member_recipients(self):
+    def determine_member_recipients(self) -> QuerySet[OrganizationMember, OrganizationMember]:
         return OrganizationMember.objects.filter(organization=self.organization)
 
 

--- a/tests/sentry/notifications/test_class_manager.py
+++ b/tests/sentry/notifications/test_class_manager.py
@@ -11,7 +11,7 @@ from sentry.testutils.helpers.notifications import AnotherDummyNotification
 
 
 class ClassManagerTest(TestCase):
-    def tearDown(self):
+    def tearDown(self) -> None:
         manager.classes.pop("AnotherDummyNotification", None)
 
     def test_register(self) -> None:

--- a/tests/sentry/notifications/utils/test_participants.py
+++ b/tests/sentry/notifications/utils/test_participants.py
@@ -654,7 +654,7 @@ class GetOwnersCase(_ParticipantsTest):
         self.rule_2 = Rule(Matcher("path", "*.js"), [Owner("team", self.team_2.slug)])
         self.rule_3 = Rule(Matcher("path", "*.js"), [Owner("user", self.user_1.email)])
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         cache.delete(ProjectOwnership.get_cache_key(self.project.id))
         super().tearDown()
 

--- a/tests/sentry/notifications/utils/test_tasks.py
+++ b/tests/sentry/notifications/utils/test_tasks.py
@@ -12,7 +12,7 @@ from sentry.users.services.user.serial import serialize_generic_user
 
 
 class NotificationTaskTests(TestCase):
-    def tearDown(self):
+    def tearDown(self) -> None:
         manager.classes.pop("AnotherDummyNotification", None)
 
     @patch(

--- a/tests/sentry/objectstore/test_objectstore.py
+++ b/tests/sentry/objectstore/test_objectstore.py
@@ -12,7 +12,7 @@ class Testserver:
     secret = ""
 
 
-def test_stores_uncompressed():
+def test_stores_uncompressed() -> None:
     server = Testserver()
     client = ClientBuilder(
         "test", {"base_url": server.url, "jwt_secret": server.secret}
@@ -28,7 +28,7 @@ def test_stores_uncompressed():
     assert result.payload.read() == b"oh hai!"
 
 
-def test_uses_zstd_by_default():
+def test_uses_zstd_by_default() -> None:
     server = Testserver()
     client = ClientBuilder(
         "test", {"base_url": server.url, "jwt_secret": server.secret}
@@ -51,7 +51,7 @@ def test_uses_zstd_by_default():
     assert result.payload.read() == b"oh hai!"
 
 
-def test_deletes_stored_stuff():
+def test_deletes_stored_stuff() -> None:
     server = Testserver()
     client = ClientBuilder(
         "test", {"base_url": server.url, "jwt_secret": server.secret}

--- a/tests/sentry/performance_issues/experiments/test_n_plus_one_db_span_detector.py
+++ b/tests/sentry/performance_issues/experiments/test_n_plus_one_db_span_detector.py
@@ -46,7 +46,7 @@ class NPlusOneDBSpanExperimentalDetectorTest(unittest.TestCase):
 
     def test_detects_n_plus_one_with_unparameterized_query(
         self,
-    ):
+    ) -> None:
         event = get_event("n-plus-one-in-django-index-view-unparameterized")
         assert self.find_problems(event) == [
             PerformanceProblem(
@@ -102,13 +102,13 @@ class NPlusOneDBSpanExperimentalDetectorTest(unittest.TestCase):
 
     def test_does_not_detect_n_plus_one_with_source_redis_query_with_noredis_detector(
         self,
-    ):
+    ) -> None:
         event = get_event("n-plus-one-in-django-index-view-source-redis")
         assert self.find_problems(event) == []
 
     def test_does_not_detect_n_plus_one_with_repeating_redis_query_with_noredis_detector(
         self,
-    ):
+    ) -> None:
         event = get_event("n-plus-one-in-django-index-view-repeating-redis")
         assert self.find_problems(event) == []
 
@@ -165,7 +165,7 @@ class NPlusOneDBSpanExperimentalDetectorTest(unittest.TestCase):
 
     def test_n_plus_one_db_detector_has_different_fingerprints_for_different_n_plus_one_events(
         self,
-    ):
+    ) -> None:
         index_n_plus_one_event = get_event("n-plus-one-in-django-index-view")
         new_n_plus_one_event = get_event("n-plus-one-in-django-new-view")
 

--- a/tests/sentry/performance_issues/test_n_plus_one_db_span_detector.py
+++ b/tests/sentry/performance_issues/test_n_plus_one_db_span_detector.py
@@ -42,7 +42,7 @@ class NPlusOneDbDetectorTest(unittest.TestCase):
 
     def test_detects_n_plus_one_with_unparameterized_query(
         self,
-    ):
+    ) -> None:
         event = get_event("n-plus-one-in-django-index-view-unparameterized")
         assert self.find_problems(event) == [
             PerformanceProblem(
@@ -98,13 +98,13 @@ class NPlusOneDbDetectorTest(unittest.TestCase):
 
     def test_does_not_detect_n_plus_one_with_source_redis_query_with_noredis_detector(
         self,
-    ):
+    ) -> None:
         event = get_event("n-plus-one-in-django-index-view-source-redis")
         assert self.find_problems(event) == []
 
     def test_does_not_detect_n_plus_one_with_repeating_redis_query_with_noredis_detector(
         self,
-    ):
+    ) -> None:
         event = get_event("n-plus-one-in-django-index-view-repeating-redis")
         assert self.find_problems(event) == []
 
@@ -161,7 +161,7 @@ class NPlusOneDbDetectorTest(unittest.TestCase):
 
     def test_n_plus_one_db_detector_has_different_fingerprints_for_different_n_plus_one_events(
         self,
-    ):
+    ) -> None:
         index_n_plus_one_event = get_event("n-plus-one-in-django-index-view")
         new_n_plus_one_event = get_event("n-plus-one-in-django-new-view")
 

--- a/tests/sentry/plugins/bases/test_issue.py
+++ b/tests/sentry/plugins/bases/test_issue.py
@@ -11,7 +11,7 @@ from social_auth.models import UserSocialAuth
 
 @control_silo_test
 class GetAuthForUserTest(TestCase):
-    def _get_mock_user(self):
+    def _get_mock_user(self) -> mock.Mock:
         user = mock.Mock(spec=User(id=1))
         user.is_authenticated = False
         return user

--- a/tests/sentry/plugins/sentry_webhooks/test_plugin.py
+++ b/tests/sentry/plugins/sentry_webhooks/test_plugin.py
@@ -16,7 +16,7 @@ pytestmark = [requires_snuba]
 
 class WebHooksPluginTest(TestCase):
     @cached_property
-    def plugin(self):
+    def plugin(self) -> WebHooksPlugin:
         return WebHooksPlugin()
 
     def setUp(self) -> None:

--- a/tests/sentry/preprod/api/endpoints/test_organization_preprod_artifact_assemble.py
+++ b/tests/sentry/preprod/api/endpoints/test_organization_preprod_artifact_assemble.py
@@ -187,7 +187,7 @@ class ProjectPreprodArtifactAssembleTest(APITestCase):
         self.feature_context = Feature("organizations:preprod-artifact-assemble")
         self.feature_context.__enter__()
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         self.feature_context.__exit__(None, None, None)
         super().tearDown()
 

--- a/tests/sentry/processing/backpressure/test_checking.py
+++ b/tests/sentry/processing/backpressure/test_checking.py
@@ -146,7 +146,7 @@ def test_backpressure_not_enabled(process_profile_task: MagicMock) -> None:
     process_profile_task.assert_called_once()
 
 
-def process_one_message(consumer_type: str, topic: str, payload: str):
+def process_one_message(consumer_type: str, topic: str, payload: str) -> None:
     if consumer_type == "profiles":
         processing_strategy = ProcessProfileStrategyFactory().create_with_partitions(
             commit=Mock(), partitions={}

--- a/tests/sentry/profiles/consumers/test_process.py
+++ b/tests/sentry/profiles/consumers/test_process.py
@@ -18,13 +18,13 @@ from sentry.utils import json
 
 class TestProcessProfileConsumerStrategy(TestCase):
     @staticmethod
-    def processing_factory():
+    def processing_factory() -> ProcessProfileStrategyFactory:
         return ProcessProfileStrategyFactory()
 
     @patch("sentry.profiles.consumers.process.factory.process_profile_task.delay")
     def test_basic_profile_to_celery(self, process_profile_task: MagicMock) -> None:
         processing_strategy = self.processing_factory().create_with_partitions(
-            commit=Mock(), partitions=None
+            commit=Mock(), partitions={}
         )
         message_dict = {
             "organization_id": 1,

--- a/tests/sentry/ratelimits/test_cardinality.py
+++ b/tests/sentry/ratelimits/test_cardinality.py
@@ -11,7 +11,7 @@ from sentry.ratelimits.cardinality import (
 
 
 @pytest.fixture
-def limiter():
+def limiter() -> RedisCardinalityLimiter:
     return RedisCardinalityLimiter()
 
 

--- a/tests/sentry/ratelimits/utils/test_above_rate_limit_check.py
+++ b/tests/sentry/ratelimits/utils/test_above_rate_limit_check.py
@@ -67,7 +67,7 @@ class RatelimitMiddlewareTest(TestCase):
             )
 
     def test_concurrent(self) -> None:
-        def do_request():
+        def do_request() -> RateLimitMeta:
             uid = uuid.uuid4().hex
             meta = above_rate_limit_check(
                 "foo", RateLimit(limit=10, window=1, concurrent_limit=3), uid, self.group

--- a/tests/sentry/receivers/test_transactions.py
+++ b/tests/sentry/receivers/test_transactions.py
@@ -18,7 +18,7 @@ pytestmark = [requires_snuba]
 
 class RecordFirstTransactionTest(TestCase):
     @cached_property
-    def min_ago(self):
+    def min_ago(self) -> str:
         return before_now(minutes=1).isoformat()
 
     def test_transaction_processed(self) -> None:

--- a/tests/sentry/release_health/test_tasks.py
+++ b/tests/sentry/release_health/test_tasks.py
@@ -114,7 +114,7 @@ class BaseTestReleaseMonitor(TestCase, BaseMetricsTestCase):
             group_id=self.event.group.id, project_id=self.project.id, release_id=self.release.id
         )
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         self.backend.__exit__(None, None, None)
 
     def test_simple(self) -> None:

--- a/tests/sentry/releases/endpoints/test_release_deploys.py
+++ b/tests/sentry/releases/endpoints/test_release_deploys.py
@@ -393,7 +393,7 @@ class ReleaseDeploysCreateTest(APITestCase):
         assert response.status_code == 400, response.content
         assert 0 == Deploy.objects.count()
 
-    def test_api_token_with_project_releases_scope(self):
+    def test_api_token_with_project_releases_scope(self) -> None:
         """
         Test that tokens with `project:releases` scope can create deploys for only one project
         when the release is associated with multiple projects.

--- a/tests/sentry/relocation/api/endpoints/artifacts/test_details.py
+++ b/tests/sentry/relocation/api/endpoints/artifacts/test_details.py
@@ -81,7 +81,7 @@ class GetRelocationArtifactDetailsGoodTest(GetRelocationArtifactDetailsTest):
                 ).getvalue()
                 self.relocation_storage.save(f"{dir}/encrypted/file.tar", BytesIO(self.tarball))
 
-    def mock_kms_client(self, fake_kms_client: mock.Mock):
+    def mock_kms_client(self, fake_kms_client: mock.Mock) -> None:
         unwrapped = unwrap_encrypted_export_tarball(BytesIO(self.tarball))
         plaintext_dek = LocalFileDecryptor.from_bytes(
             self.priv_key_pem

--- a/tests/sentry/relocation/api/endpoints/test_public_key.py
+++ b/tests/sentry/relocation/api/endpoints/test_public_key.py
@@ -22,7 +22,7 @@ class GetRelocationPublicKeyTest(APITestCase):
         (_, pub_key_pem) = generate_rsa_key_pair()
         self.pub_key_pem = pub_key_pem
 
-    def mock_kms_client(self, fake_kms_client: mock.Mock):
+    def mock_kms_client(self, fake_kms_client: mock.Mock) -> None:
         fake_kms_client.return_value.get_public_key.return_value = SimpleNamespace(
             pem=self.pub_key_pem.decode("utf-8")
         )

--- a/tests/sentry/relocation/test_utils.py
+++ b/tests/sentry/relocation/test_utils.py
@@ -30,7 +30,7 @@ class RelocationUtilsTestCase(TestCase):
         )
         self.uuid = self.relocation.uuid
 
-    def mock_message_builder(self, fake_message_builder: Mock):
+    def mock_message_builder(self, fake_message_builder: Mock) -> None:
         fake_message_builder.return_value.send_async.return_value = MagicMock()
 
 

--- a/tests/sentry/replays/endpoints/test_project_replay_recording_segment_details.py
+++ b/tests/sentry/replays/endpoints/test_project_replay_recording_segment_details.py
@@ -74,7 +74,7 @@ class EnvironmentBase(APITestCase):
 
 
 class FilestoreReplayRecordingSegmentDetailsTestCase(EnvironmentBase):
-    def init_environment(self):
+    def init_environment(self) -> None:
         metadata = RecordingSegmentStorageMeta(
             project_id=self.project.id,
             replay_id=self.replay_id,
@@ -87,7 +87,7 @@ class FilestoreReplayRecordingSegmentDetailsTestCase(EnvironmentBase):
 
 
 class StorageReplayRecordingSegmentDetailsTestCase(EnvironmentBase, ReplaysSnubaTestCase):
-    def init_environment(self):
+    def init_environment(self) -> None:
         metadata = RecordingSegmentStorageMeta(
             project_id=self.project.id,
             replay_id=self.replay_id,
@@ -110,7 +110,7 @@ class StorageReplayRecordingSegmentDetailsTestCase(EnvironmentBase, ReplaysSnuba
 
 
 class PackedStorageReplayRecordingSegmentDetailsTestCase(EnvironmentBase, ReplaysSnubaTestCase):
-    def init_environment(self):
+    def init_environment(self) -> None:
         metadata = RecordingSegmentStorageMeta(
             project_id=self.project.id,
             replay_id=self.replay_id,

--- a/tests/sentry/rules/actions/test_notify_event_sentry_app.py
+++ b/tests/sentry/rules/actions/test_notify_event_sentry_app.py
@@ -24,7 +24,7 @@ class NotifyEventSentryAppActionTest(RuleTestCase):
     ]
 
     @pytest.fixture(autouse=True)
-    def create_schema(self):
+    def create_schema(self) -> None:
         self.schema = {"elements": [self.create_alert_rule_action_schema()]}
 
     def test_applies_correctly_for_sentry_apps(self) -> None:

--- a/tests/sentry/rules/conditions/test_tagged_event.py
+++ b/tests/sentry/rules/conditions/test_tagged_event.py
@@ -1,5 +1,6 @@
 from sentry.rules.conditions.tagged_event import TaggedEventCondition
 from sentry.rules.match import MatchType
+from sentry.services.eventstore.models import Event
 from sentry.testutils.cases import RuleTestCase
 from sentry.testutils.skips import requires_snuba
 
@@ -9,7 +10,7 @@ pytestmark = [requires_snuba]
 class TaggedEventConditionTest(RuleTestCase):
     rule_cls = TaggedEventCondition
 
-    def get_event(self):
+    def get_event(self) -> Event:
         event = self.event
         event.data["tags"] = (
             ("logger", "sentry.example"),

--- a/tests/sentry/seer/endpoints/test_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_seer_rpc.py
@@ -64,7 +64,7 @@ class TestSeerRpcMethods(APITestCase):
         self.organization = self.create_organization(owner=self.user)
 
     @pytest.fixture(autouse=True)
-    def inject_fixtures(self, caplog):
+    def inject_fixtures(self, caplog: pytest.LogCaptureFixture):
         self._caplog = caplog
 
     def test_get_organization_seer_consent_by_org_name_no_integrations(self) -> None:

--- a/tests/sentry/seer/fetch_issues/test_more_parsing.py
+++ b/tests/sentry/seer/fetch_issues/test_more_parsing.py
@@ -7,7 +7,7 @@ from sentry.seer.fetch_issues import more_parsing
 
 class TestPythonParserMore:
     @pytest.fixture
-    def parser(self):
+    def parser(self) -> more_parsing.PythonParserMore:
         return cast(more_parsing.PythonParserMore, more_parsing.patch_parsers_more["py"])
 
     def test_python_motivating_example(self, parser: more_parsing.PythonParserMore) -> None:

--- a/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_components.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_components.py
@@ -13,7 +13,7 @@ from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import control_silo_test
 
 
-def get_sentry_app_avatars(sentry_app: SentryApp):
+def get_sentry_app_avatars(sentry_app: SentryApp) -> list[dict[str, str | bool | int]]:
     return [serialize(avatar) for avatar in sentry_app.avatar.all()]
 
 

--- a/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_publish_request.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_publish_request.py
@@ -10,10 +10,10 @@ from sentry.testutils.silo import control_silo_test
 
 @control_silo_test
 class SentryAppPublishRequestTest(APITestCase):
-    def upload_logo(self):
+    def upload_logo(self) -> None:
         SentryAppAvatar.objects.create(sentry_app=self.sentry_app, avatar_type=1, color=True)
 
-    def upload_issue_link_logo(self):
+    def upload_issue_link_logo(self) -> None:
         SentryAppAvatar.objects.create(sentry_app=self.sentry_app, avatar_type=1, color=False)
 
     def setUp(self) -> None:

--- a/tests/sentry/sentry_apps/api/endpoints/test_sentry_internal_app_tokens.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_sentry_internal_app_tokens.py
@@ -112,7 +112,7 @@ class GetSentryInternalAppTokenTest(SentryInternalAppTokenTest):
         assert len(response.data) == 1
         assert response.data[0]["id"] == str(self.token.id)
 
-    def no_access_for_members(self):
+    def no_access_for_members(self) -> None:
         user = self.create_user(email="meep@example.com")
         self.create_member(organization=self.org, user=user)
         self.login_as(user)

--- a/tests/sentry/test_constants.py
+++ b/tests/sentry/test_constants.py
@@ -8,7 +8,7 @@ from sentry.constants import (
 )
 
 
-def mock_integration_ids() -> AbstractContextManager:
+def mock_integration_ids() -> AbstractContextManager[object]:
     return mock.patch.dict(
         INTEGRATION_ID_TO_PLATFORM_DATA,
         {

--- a/tests/sentry/utils/test_event_frames.py
+++ b/tests/sentry/utils/test_event_frames.py
@@ -132,7 +132,7 @@ class JavaFilenameMungingTestCase(unittest.TestCase):
 
     def test_platform_java_do_not_follow_java_package_naming_convention_does_not_raise_exception(
         self,
-    ):
+    ) -> None:
         frame = {
             "abs_path": "gsp_arcus_drops_proofReadingmodecInspectionProofRead_gsp.groovy",
             "module": "gsp_arcus_drops_proofReadingmodecInspectionProofRead_gsp$_run_closure2",
@@ -454,7 +454,7 @@ class FlutterFilenameMungingTestCase(TestCase):
 class CocoaWaterFallTestCase(TestCase):
     def test_crashing_event_with_exception_interface_but_no_frame_should_waterfall_to_thread_frames(
         self,
-    ):
+    ) -> None:
         event = self.store_event(
             data={
                 "platform": "cocoa",

--- a/tests/sentry/workflow_engine/endpoints/test_organization_available_action_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_available_action_index.py
@@ -48,7 +48,7 @@ class OrganizationAvailableActionAPITestCase(APITestCase):
         self.registry_patcher.stop()
         self.plugins_registry_patcher.stop()
 
-    def setup_email(self):
+    def setup_email(self) -> None:
         @self.registry.register(Action.Type.EMAIL)
         @dataclass(frozen=True)
         class EmailActionHandler(ActionHandler):
@@ -56,7 +56,7 @@ class OrganizationAvailableActionAPITestCase(APITestCase):
             config_schema = {}
             data_schema = {}
 
-    def setup_integrations(self):
+    def setup_integrations(self) -> None:
         @self.registry.register(Action.Type.SLACK)
         @dataclass(frozen=True)
         class SlackActionHandler(IntegrationActionHandler):
@@ -100,7 +100,7 @@ class OrganizationAvailableActionAPITestCase(APITestCase):
             config_schema = {}
             data_schema = {}
 
-    def setup_integrations_with_services(self):
+    def setup_integrations_with_services(self) -> None:
         @self.registry.register(Action.Type.PAGERDUTY)
         @dataclass(frozen=True)
         class PagerdutyActionHandler(IntegrationActionHandler):
@@ -173,7 +173,7 @@ class OrganizationAvailableActionAPITestCase(APITestCase):
             self.org_integration.config = {"team_table": [self.og_team]}
             self.org_integration.save()
 
-    def setup_sentry_apps(self):
+    def setup_sentry_apps(self) -> None:
         @self.registry.register(Action.Type.SENTRY_APP)
         @dataclass(frozen=True)
         class SentryAppActionHandler(ActionHandler):
@@ -212,7 +212,7 @@ class OrganizationAvailableActionAPITestCase(APITestCase):
             is_alertable=True,
         )
 
-    def setup_webhooks(self):
+    def setup_webhooks(self) -> None:
         @self.registry.register(Action.Type.WEBHOOK)
         @dataclass(frozen=True)
         class WebhookActionHandler(ActionHandler):

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
@@ -670,7 +670,7 @@ class OrganizationWorkflowPutTest(OrganizationWorkflowAPITestCase):
             organization_id=self.organization.id, name="Third Workflow", enabled=False
         )
 
-    def test_bulk_enable_workflows_by_ids_success(self):
+    def test_bulk_enable_workflows_by_ids_success(self) -> None:
         response = self.get_success_response(
             self.organization.slug,
             qs_params=[("id", str(self.workflow.id)), ("id", str(self.workflow_two.id))],
@@ -693,7 +693,7 @@ class OrganizationWorkflowPutTest(OrganizationWorkflowAPITestCase):
         self.workflow_three.refresh_from_db()
         assert self.workflow_three.enabled is False
 
-    def test_bulk_disable_workflows_by_ids_success(self):
+    def test_bulk_disable_workflows_by_ids_success(self) -> None:
         self.workflow.update(enabled=True)
         self.workflow_two.update(enabled=True)
         self.workflow_three.update(enabled=True)
@@ -718,7 +718,7 @@ class OrganizationWorkflowPutTest(OrganizationWorkflowAPITestCase):
         self.workflow_three.refresh_from_db()
         assert self.workflow_three.enabled is True
 
-    def test_bulk_enable_workflows_by_query_success(self):
+    def test_bulk_enable_workflows_by_query_success(self) -> None:
         response = self.get_success_response(
             self.organization.slug,
             qs_params={"query": "test"},
@@ -740,7 +740,7 @@ class OrganizationWorkflowPutTest(OrganizationWorkflowAPITestCase):
         assert self.workflow_two.enabled is False
         assert self.workflow_three.enabled is False
 
-    def test_bulk_update_workflows_no_parameters_error(self):
+    def test_bulk_update_workflows_no_parameters_error(self) -> None:
         """Test error when no filtering parameters are provided"""
         response = self.get_error_response(
             self.organization.slug,
@@ -760,7 +760,7 @@ class OrganizationWorkflowPutTest(OrganizationWorkflowAPITestCase):
         assert self.workflow_two.enabled is False
         assert self.workflow_three.enabled is False
 
-    def test_bulk_update_workflows_missing_enabled_field_error(self):
+    def test_bulk_update_workflows_missing_enabled_field_error(self) -> None:
         response = self.get_error_response(
             self.organization.slug,
             qs_params={"id": str(self.workflow.id)},
@@ -774,7 +774,7 @@ class OrganizationWorkflowPutTest(OrganizationWorkflowAPITestCase):
         self.workflow.refresh_from_db()
         assert self.workflow.enabled is False
 
-    def test_bulk_update_no_matching_workflows(self):
+    def test_bulk_update_no_matching_workflows(self) -> None:
         # Test with non-existent ID
         response = self.get_success_response(
             self.organization.slug,

--- a/tests/sentry/workflow_engine/utils/test_log_context.py
+++ b/tests/sentry/workflow_engine/utils/test_log_context.py
@@ -113,12 +113,12 @@ class LogContextTest(TestCase):
         context_ids = set()
 
         @log_context.root()
-        def first_context():
+        def first_context() -> None:
             context = log_context._log_context_state.get()
             context_ids.add(context.extra["context_id"])
 
         @log_context.root()
-        def second_context():
+        def second_context() -> None:
             context = log_context._log_context_state.get()
             context_ids.add(context.extra["context_id"])
 

--- a/tests/snuba/api/endpoints/test_discover_key_transactions.py
+++ b/tests/snuba/api/endpoints/test_discover_key_transactions.py
@@ -14,7 +14,7 @@ from sentry.utils.samples import load_data
 
 
 class TeamKeyTransactionTestBase(APITestCase, SnubaTestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
 
         self.login_as(user=self.user, superuser=False)
@@ -32,7 +32,7 @@ class ClientCallable(Protocol):
 
 
 class TeamKeyTransactionTest(TeamKeyTransactionTestBase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.url = reverse("sentry-api-0-organization-key-transactions", args=[self.org.slug])
 
@@ -673,7 +673,7 @@ class TeamKeyTransactionTest(TeamKeyTransactionTestBase):
 
 
 class TeamKeyTransactionListTest(TeamKeyTransactionTestBase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.url = reverse("sentry-api-0-organization-key-transactions-list", args=[self.org.slug])
 

--- a/tests/snuba/api/endpoints/test_discover_saved_queries.py
+++ b/tests/snuba/api/endpoints/test_discover_saved_queries.py
@@ -6,7 +6,7 @@ from sentry.testutils.helpers.datetime import before_now
 
 
 class DiscoverSavedQueryBase(APITestCase, SnubaTestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.login_as(user=self.user)
         self.org = self.create_organization(owner=self.user)
@@ -32,7 +32,7 @@ class DiscoverSavedQueryBase(APITestCase, SnubaTestCase):
 class DiscoverSavedQueriesTest(DiscoverSavedQueryBase):
     feature_name = "organizations:discover"
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.url = reverse("sentry-api-0-discover-saved-queries", args=[self.org.slug])
 
@@ -358,7 +358,7 @@ class DiscoverSavedQueriesTest(DiscoverSavedQueryBase):
 class DiscoverSavedQueriesVersion2Test(DiscoverSavedQueryBase):
     feature_name = "organizations:discover-query"
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.url = reverse("sentry-api-0-discover-saved-queries", args=[self.org.slug])
 

--- a/tests/snuba/api/endpoints/test_organization_event_details.py
+++ b/tests/snuba/api/endpoints/test_organization_event_details.py
@@ -14,7 +14,7 @@ pytestmark = pytest.mark.sentry_metrics
 
 
 class OrganizationEventDetailsEndpointTest(APITestCase, SnubaTestCase, OccurrenceTestMixin):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         min_ago = before_now(minutes=1).isoformat()
         two_min_ago = before_now(minutes=2).isoformat()
@@ -310,7 +310,7 @@ class OrganizationEventDetailsEndpointTest(APITestCase, SnubaTestCase, Occurrenc
 class EventComparisonTest(MetricsEnhancedPerformanceTestCase):
     endpoint = "sentry-api-0-organization-event-details"
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.init_snuba()
         self.ten_mins_ago = before_now(minutes=10)
         self.transaction_data = load_data("transaction", timestamp=self.ten_mins_ago)

--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -60,7 +60,7 @@ class OrganizationEventsEndpointTestBase(
     viewname = "sentry-api-0-organization-events"
     referrer = "api.organization-events"
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.nine_mins_ago = before_now(minutes=9)
         self.ten_mins_ago = before_now(minutes=10)
@@ -68,7 +68,7 @@ class OrganizationEventsEndpointTestBase(
         self.eleven_mins_ago = before_now(minutes=11)
         self.eleven_mins_ago_iso = self.eleven_mins_ago.isoformat()
         self.transaction_data = load_data("transaction", timestamp=self.ten_mins_ago)
-        self.features = {}
+        self.features: dict[str, bool] = {}
 
     def client_get(self, *args, **kwargs):
         return self.client.get(*args, **kwargs)

--- a/tests/snuba/api/endpoints/test_organization_events_stats_span_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_span_metrics.py
@@ -18,7 +18,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(MetricsEnhancedPerformance
     ]
     features = {"organizations:discover-basic": True}
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.login_as(user=self.user)
         self.day_ago = before_now(days=1).replace(hour=10, minute=0, second=0, microsecond=0)
@@ -366,7 +366,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(MetricsEnhancedPerformance
 class OrganizationEventsStatsSpansMetricsEndpointTestWithMetricLayer(
     OrganizationEventsStatsSpansMetricsEndpointTest
 ):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.features["organizations:use-metrics-layer"] = True
 

--- a/tests/snuba/api/endpoints/test_organization_metrics_meta.py
+++ b/tests/snuba/api/endpoints/test_organization_metrics_meta.py
@@ -8,7 +8,7 @@ pytestmark = pytest.mark.sentry_metrics
 
 
 class OrganizationMetricsCompatiblity(MetricsEnhancedPerformanceTestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.min_ago = before_now(minutes=1)
         self.two_min_ago = before_now(minutes=2)
@@ -122,7 +122,7 @@ class OrganizationMetricsCompatiblity(MetricsEnhancedPerformanceTestCase):
 
 
 class OrganizationEventsMetricsSums(MetricsEnhancedPerformanceTestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.min_ago = before_now(minutes=1)
         self.two_min_ago = before_now(minutes=2)

--- a/tests/snuba/models/test_group.py
+++ b/tests/snuba/models/test_group.py
@@ -185,7 +185,7 @@ def _get_oldest(
 
 @freeze_time()
 class GroupTestSnubaErrorIssue(TestCase, SnubaTestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.project = self.create_project()
         self.event_a = self.store_event(
@@ -333,7 +333,7 @@ class GroupTestSnubaErrorIssue(TestCase, SnubaTestCase):
 
 @freeze_time()
 class GroupTestSnubaPerformanceIssue(TestCase, SnubaTestCase, PerformanceIssueTestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.project = self.create_project()
         group_fingerprint = f"{PerformanceNPlusOneGroupType.type_id}-group1"
@@ -481,7 +481,7 @@ class GroupTestSnubaPerformanceIssue(TestCase, SnubaTestCase, PerformanceIssueTe
 
 @freeze_time()
 class GroupTestSnubaOccurrenceIssue(TestCase, SnubaTestCase, OccurrenceTestMixin):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.project = self.create_project()
 

--- a/tests/tools/test_pin_github_action.py
+++ b/tests/tools/test_pin_github_action.py
@@ -13,7 +13,7 @@ from tools.pin_github_action import ACTION_VERSION_RE
         ("uses: actions/cache@v1.0.0 # after\n", ("actions/cache", "v1.0.0")),
     ),
 )
-def test_matches(s, expected) -> None:
+def test_matches(s: str, expected: str) -> None:
     match = ACTION_VERSION_RE.search(s)
     assert match
     assert (match[1], match[2]) == expected


### PR DESCRIPTION
# Summary

Developed a new pattern that let me run through some files I identified as low-lift quickly:
* Added `"sentry.*", "test.*"` to `pyproject.toml`
* Developed a list of expected-to-be-low-lift files from mypy output
  * Mostly files that were in test directory, only had one error, or only needed `None` return types
* Then repeatedly ran `mypy <big_list_of_files>` and whittled that down
* Before pushing the branch, I removed the changes to `pyproject.toml`

Result is that I can confidently say that this PR successfully types ~150 new files.

# Test Plan 
Reverted changes to `pyproject.toml` and ran `mypy` to ensure the new types had no effect on steady-state — no errors!