### PR TITLE
feat(hackweek): Implement "New Frontend Version available"

### DIFF
--- a/src/sentry/api/endpoints/frontend_version.py
+++ b/src/sentry/api/endpoints/frontend_version.py
@@ -1,0 +1,17 @@
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import Endpoint, all_silo_endpoint
+from sentry.utils.assets import get_frontend_commit_sha
+
+
+@all_silo_endpoint
+class FrontendVersionEndpoint(Endpoint):
+    owner = ApiOwner.UNOWNED
+    publish_status = {"GET": ApiPublishStatus.PRIVATE}
+    permission_classes = ()
+
+    def get(self, request: Request) -> Response:
+        return Response({"version": get_frontend_commit_sha()})

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -608,6 +608,7 @@ from .endpoints.event_attachment_details import EventAttachmentDetailsEndpoint
 from .endpoints.event_attachments import EventAttachmentsEndpoint
 from .endpoints.event_file_committers import EventFileCommittersEndpoint
 from .endpoints.filechange import CommitFileChangeEndpoint
+from .endpoints.frontend_version import FrontendVersionEndpoint
 from .endpoints.index import IndexEndpoint
 from .endpoints.internal import (
     InternalBeaconEndpoint,
@@ -3302,6 +3303,11 @@ INTERNAL_URLS = [
         r"^beacon/$",
         InternalBeaconEndpoint.as_view(),
         name="sentry-api-0-internal-beacon",
+    ),
+    re_path(
+        r"^frontend-version/$",
+        FrontendVersionEndpoint.as_view(),
+        name="sentry-api-0-internal-frontend-version",
     ),
     re_path(
         r"^quotas/$",

--- a/src/sentry/utils/assets.py
+++ b/src/sentry/utils/assets.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os.path
+from typing import TypedDict, cast
 
 from cachetools.func import ttl_cache
 from django.conf import settings
@@ -8,15 +9,46 @@ from django.conf import settings
 from sentry.utils import json
 
 
+class FrontendVersions(TypedDict):
+    commit_sha: str | None
+    """
+    The commit SHA of the currently deployed frontend version.
+
+    XXX(epuirkhiser): currently may be None while we transition to a
+    frontend-versions file that contains the version_sha.
+    """
+    entrypoints: dict[str, str]
+    """
+    A mapping of unversioned entrypoint names to versioned entrypoints,
+    containing a content-hash suffix.
+    """
+
+
 @ttl_cache(ttl=60)
-def _frontend_versions() -> dict[str, str]:
+def _frontend_versions() -> FrontendVersions | None:
+    config = os.path.join(settings.CONF_DIR, "settings", "frontend", "frontend-versions.json")
     try:
-        with open(
-            os.path.join(settings.CONF_DIR, "settings", "frontend", "frontend-versions.json")
-        ) as f:
-            return json.load(f)  # getsentry path
+        with open(config) as f:
+            contents = json.load(f)  # getsentry path
     except OSError:
-        return {}  # common case for self-hosted
+        return None  # common case for self-hosted
+
+    # XXX(epurkhiser): Shim code while we transition to a
+    # `frontend-versions.json` file that contains both a webpack entrypoint
+    # mapping as well as a commit SHA.
+    if "commit_sha" not in contents:
+        return {"commit_sha": None, "entrypoints": contents}
+
+    return cast(FrontendVersions, contents)
+
+
+def get_frontend_commit_sha() -> str | None:
+    """
+    Returns the commit SHA of the currently configured frontend-versions.
+    """
+    if versions := _frontend_versions():
+        return versions["commit_sha"]
+    return None
 
 
 def get_frontend_app_asset_url(module: str, key: str) -> str:
@@ -32,17 +64,20 @@ def get_frontend_app_asset_url(module: str, key: str) -> str:
     if not key.startswith("entrypoints/"):
         raise AssertionError(f"unexpected key: {key}")
 
-    entrypoints, key = key.split("/", 1)
+    asset_path, key = key.split("/", 1)
     versions = _frontend_versions()
-    if versions:
-        entrypoints = "entrypoints-hashed"
-        key = versions[key]
+
+    # When a frontend entrypoint versions config is provided use to map the
+    # asset file to a hashed entrypoint
+    if versions and key in versions["entrypoints"]:
+        asset_path = "entrypoints-hashed"
+        key = versions["entrypoints"][key]
 
     return "/".join(
         (
             settings.STATIC_FRONTEND_APP_URL.rstrip("/"),
             module,
-            entrypoints,
+            asset_path,
             key,
         )
     )

--- a/static/app/components/core/link/link.spec.tsx
+++ b/static/app/components/core/link/link.spec.tsx
@@ -1,6 +1,7 @@
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {ExternalLink, Link} from 'sentry/components/core/link';
+import {FrontendVersionProvider} from 'sentry/components/frontendVersionContext';
 
 describe('Link', () => {
   // Note: Links should not support a disabled option, as disabled links are just text elements
@@ -18,6 +19,18 @@ describe('Link', () => {
   it('links render as <a> with href', () => {
     render(<Link to="https://www.sentry.io/">Link</Link>);
     expect(screen.getByText('Link')).toHaveAttribute('href', 'https://www.sentry.io/');
+  });
+
+  it('links render with reloadDocument=true when frontend is outdated', () => {
+    render(
+      <FrontendVersionProvider releaseVersion="frontend@abc123" forceStale>
+        <Link to="/issues/">Link</Link>
+      </FrontendVersionProvider>
+    );
+
+    const link = screen.getByRole('link');
+    // reloadDocument prop should be present when outdated
+    expect(link.closest('a')).toBeInTheDocument();
   });
 });
 

--- a/static/app/components/core/link/link.tsx
+++ b/static/app/components/core/link/link.tsx
@@ -7,6 +7,7 @@ import {css, type Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 import type {LocationDescriptor} from 'history';
 
+import {useFrontendVersion} from 'sentry/components/frontendVersionContext';
 import {locationDescriptorToTo} from 'sentry/utils/reactRouter6Compat/location';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -71,12 +72,20 @@ const Anchor = styled('a', {
 export const Link = styled(({disabled, to, ...props}: LinkProps) => {
   const location = useLocation();
 
+  // If the frontend app is stale we can force the link to reload the page,
+  // loading the new version of sentry.
+  const {stale: appStale} = useFrontendVersion();
+
   if (disabled || !location) {
     return <Anchor {...props} />;
   }
 
   return (
-    <RouterLink to={locationDescriptorToTo(normalizeUrl(to, location))} {...props} />
+    <RouterLink
+      reloadDocument={appStale}
+      to={locationDescriptorToTo(normalizeUrl(to, location))}
+      {...props}
+    />
   );
 })`
   ${getLinkStyles}

--- a/static/app/components/footer.tsx
+++ b/static/app/components/footer.tsx
@@ -1,13 +1,16 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
+import {Button} from 'sentry/components/core/button';
 import {ExternalLink} from 'sentry/components/core/link';
+import {useFrontendVersion} from 'sentry/components/frontendVersionContext';
 import Hook from 'sentry/components/hook';
 import {IconSentry, IconSentryPrideLogo} from 'sentry/icons';
 import type {SVGIconProps} from 'sentry/icons/svgIcon';
 import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
+import pulsingIndicatorStyles from 'sentry/styles/pulsingIndicator';
 import {space} from 'sentry/styles/space';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -33,6 +36,8 @@ type Props = {
 function BaseFooter({className}: Props) {
   const {isSelfHosted, version, privacyUrl, termsUrl, demoMode} =
     useLegacyStore(ConfigStore);
+
+  const {outdated: appOutdated} = useFrontendVersion();
   const organization = useOrganization({allowNull: true});
 
   return (
@@ -55,6 +60,19 @@ function BaseFooter({className}: Props) {
         />
       </SentryLogoLink>
       <RightLinks>
+        {appOutdated && (
+          <Button
+            borderless
+            size="xs"
+            onClick={() => window.location.reload()}
+            title={t(
+              "An improved version of Sentry's Frontend Application is now available. Click to update now."
+            )}
+            aria-label={t('Reload frontend')}
+          >
+            <WaitingIndicator />
+          </Button>
+        )}
         {!isSelfHosted && (
           <FooterLink href="https://status.sentry.io/">{t('Service Status')}</FooterLink>
         )}
@@ -71,6 +89,11 @@ function BaseFooter({className}: Props) {
     </footer>
   );
 }
+
+const WaitingIndicator = styled('div')`
+  --pulsingIndicatorColor: ${p => p.theme.gray300};
+  ${pulsingIndicatorStyles};
+`;
 
 const LeftLinks = styled('div')`
   display: grid;

--- a/static/app/components/frontendVersionContext.spec.tsx
+++ b/static/app/components/frontendVersionContext.spec.tsx
@@ -1,0 +1,90 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {FrontendVersionProvider, useFrontendVersion} from './frontendVersionContext';
+
+function TestComponent() {
+  const {stale, deployedVersion} = useFrontendVersion();
+
+  return (
+    <div>
+      <span data-test-id="stale">{stale.toString()}</span>
+      <span data-test-id="deployed-version">{deployedVersion || 'null'}</span>
+    </div>
+  );
+}
+
+describe('FrontendVersionProvider', () => {
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('provides stale=false when server version matches current version', async () => {
+    const commitSha = 'deadbeefcafebabe1234567890abcdef12345678';
+    const releaseVersion = `frontend@${commitSha}`;
+
+    MockApiClient.addMockResponse({
+      url: '/internal/frontend-version/',
+      body: {version: commitSha},
+    });
+
+    render(
+      <FrontendVersionProvider releaseVersion={releaseVersion}>
+        <TestComponent />
+      </FrontendVersionProvider>
+    );
+
+    expect(await screen.findByTestId('stale')).toHaveTextContent('false');
+    expect(await screen.findByTestId('deployed-version')).toHaveTextContent(commitSha);
+  });
+
+  it('provides stale=true when server version differs from current version', async () => {
+    const currentCommitSha = 'feedface123456789abcdef0fedcba9876543210';
+    const serverVersion = 'beefdead987654321fedcba0123456789abcdef0';
+    const releaseVersion = `frontend@${currentCommitSha}`;
+
+    MockApiClient.addMockResponse({
+      url: '/internal/frontend-version/',
+      body: {version: serverVersion},
+    });
+
+    render(
+      <FrontendVersionProvider releaseVersion={releaseVersion}>
+        <TestComponent />
+      </FrontendVersionProvider>
+    );
+
+    expect(await screen.findByTestId('stale')).toHaveTextContent('true');
+    expect(await screen.findByTestId('deployed-version')).toHaveTextContent(
+      serverVersion
+    );
+  });
+
+  it('provides stale=false when server returns null version', async () => {
+    const releaseVersion = 'frontend@c0ffee123456789abcdef0fedcba9876543210ab';
+
+    MockApiClient.addMockResponse({
+      url: '/internal/frontend-version/',
+      body: {version: null},
+    });
+
+    render(
+      <FrontendVersionProvider releaseVersion={releaseVersion}>
+        <TestComponent />
+      </FrontendVersionProvider>
+    );
+
+    expect(await screen.findByTestId('stale')).toHaveTextContent('false');
+    expect(await screen.findByTestId('deployed-version')).toHaveTextContent('null');
+  });
+
+  it('provides stale=true when forceStale prop is set', async () => {
+    render(
+      <FrontendVersionProvider releaseVersion="frontend@abc123" forceStale>
+        <TestComponent />
+      </FrontendVersionProvider>
+    );
+
+    expect(await screen.findByTestId('stale')).toHaveTextContent('true');
+    expect(await screen.findByTestId('deployed-version')).toHaveTextContent('null');
+  });
+});

--- a/static/app/components/frontendVersionContext.tsx
+++ b/static/app/components/frontendVersionContext.tsx
@@ -1,0 +1,77 @@
+import {createContext, useContext, type ReactNode} from 'react';
+
+import {useApiQuery} from 'sentry/utils/queryClient';
+
+interface FrontendVersionResponse {
+  /**
+   * The commit SHA of the latest version available on the server.
+   */
+  version: string | null;
+}
+
+interface VersionStatus {
+  /**
+   * The commit SHA of the latest version available on the server.
+   */
+  deployedVersion: string | null;
+  /**
+   * True if the server version differs from the currently running frontend
+   * version.
+   */
+  stale: boolean;
+}
+
+interface Props {
+  children: ReactNode;
+  /**
+   * The running frontend version. This is typically the SENTRY_RELEASE_VERSION
+   * constant. Should be in the format `package@<commit-sha>`.
+   */
+  releaseVersion: string | null;
+  /**
+   * Force the stale status to true. Typically used for testing purposes
+   * When enabled, disables the API query and sets stale=true,
+   * deployedVersion=null.
+   */
+  forceStale?: boolean;
+}
+
+const FrontendVersionContext = createContext<VersionStatus>({
+  stale: false,
+  deployedVersion: null,
+});
+
+/**
+ * Context provider that polls the frontend version endpoint every 5 minutes
+ * and on tab focus to detect if the frontend version has changed.
+ */
+export function FrontendVersionProvider({children, forceStale, releaseVersion}: Props) {
+  const {data: frontendVersionData} = useApiQuery<FrontendVersionResponse>(
+    ['/internal/frontend-version/'],
+    {
+      staleTime: 5 * 60 * 1000,
+      refetchInterval: 5 * 60 * 1000,
+      refetchIntervalInBackground: false,
+      refetchOnWindowFocus: true,
+      enabled: !forceStale,
+    }
+  );
+
+  const runningVersion = releaseVersion?.split('@').at(1) ?? null;
+  const deployedVersion = frontendVersionData?.version ?? null;
+
+  const stale = forceStale || (!!deployedVersion && deployedVersion !== runningVersion);
+
+  return (
+    <FrontendVersionContext.Provider value={{stale, deployedVersion}}>
+      {children}
+    </FrontendVersionContext.Provider>
+  );
+}
+
+/**
+ * Hook to access frontend version information.
+ */
+export function useFrontendVersion(): VersionStatus {
+  return useContext(FrontendVersionContext);
+}

--- a/static/app/main.tsx
+++ b/static/app/main.tsx
@@ -4,9 +4,10 @@ import {wrapCreateBrowserRouterV6} from '@sentry/react';
 import {ReactQueryDevtools} from '@tanstack/react-query-devtools';
 
 import {AppQueryClientProvider} from 'sentry/appQueryClient';
+import {FrontendVersionProvider} from 'sentry/components/frontendVersionContext';
 import {OnboardingContextProvider} from 'sentry/components/onboarding/onboardingContext';
 import {ThemeAndStyleProvider} from 'sentry/components/themeAndStyleProvider';
-import {USE_REACT_QUERY_DEVTOOL} from 'sentry/constants';
+import {SENTRY_RELEASE_VERSION, USE_REACT_QUERY_DEVTOOL} from 'sentry/constants';
 import {routes} from 'sentry/routes';
 import {SentryTrackingProvider} from 'sentry/tracking';
 import {DANGEROUS_SET_REACT_ROUTER_6_HISTORY} from 'sentry/utils/browserHistory';
@@ -24,16 +25,18 @@ function Main() {
 
   return (
     <AppQueryClientProvider>
-      <ThemeAndStyleProvider>
-        <OnboardingContextProvider>
-          <SentryTrackingProvider>
-            <RouterProvider router={router} />
-          </SentryTrackingProvider>
-        </OnboardingContextProvider>
-        {USE_REACT_QUERY_DEVTOOL && (
-          <ReactQueryDevtools initialIsOpen={false} buttonPosition="bottom-left" />
-        )}
-      </ThemeAndStyleProvider>
+      <FrontendVersionProvider releaseVersion={SENTRY_RELEASE_VERSION ?? null}>
+        <ThemeAndStyleProvider>
+          <OnboardingContextProvider>
+            <SentryTrackingProvider>
+              <RouterProvider router={router} />
+            </SentryTrackingProvider>
+          </OnboardingContextProvider>
+          {USE_REACT_QUERY_DEVTOOL && (
+            <ReactQueryDevtools initialIsOpen={false} buttonPosition="bottom-left" />
+          )}
+        </ThemeAndStyleProvider>
+      </FrontendVersionProvider>
     </AppQueryClientProvider>
   );
 }

--- a/static/app/styles/pulsingIndicator.tsx
+++ b/static/app/styles/pulsingIndicator.tsx
@@ -17,7 +17,7 @@ const pulsingIndicatorStyles = (p: {theme: Theme}) => css`
   height: 8px;
   width: 8px;
   border-radius: 50%;
-  background: ${p.theme.pink300};
+  background: var(--pulsingIndicatorColor, ${p.theme.pink300});
   position: relative;
 
   &:before {
@@ -29,9 +29,10 @@ const pulsingIndicatorStyles = (p: {theme: Theme}) => css`
     border-radius: 50%;
     top: -46px;
     left: -46px;
-    border: 4px solid ${p.theme.pink200};
+    border: 4px solid var(--pulsingIndicatorColor, ${p.theme.pink300});
     transform-origin: center;
     animation: ${pulse} 3s ease-out infinite;
+    pointer-events: none;
   }
 `;
 

--- a/tests/sentry/api/endpoints/test_frontend_version.py
+++ b/tests/sentry/api/endpoints/test_frontend_version.py
@@ -1,0 +1,31 @@
+from unittest.mock import patch
+
+from django.urls import reverse
+
+from sentry.testutils.cases import APITestCase
+
+
+class FrontendVersionTest(APITestCase):
+    def test_returns_frontend_commit_sha(self) -> None:
+        url = reverse("sentry-api-0-internal-frontend-version")
+
+        with patch("sentry.api.endpoints.frontend_version.get_frontend_commit_sha") as mock_get_sha:
+            mock_get_sha.return_value = "abc123def456"
+
+            response = self.client.get(url)
+
+            assert response.status_code == 200
+            assert response.data == {"version": "abc123def456"}
+            mock_get_sha.assert_called_once()
+
+    def test_returns_none_when_no_commit_sha(self) -> None:
+        url = reverse("sentry-api-0-internal-frontend-version")
+
+        with patch("sentry.api.endpoints.frontend_version.get_frontend_commit_sha") as mock_get_sha:
+            mock_get_sha.return_value = None
+
+            response = self.client.get(url)
+
+            assert response.status_code == 200
+            assert response.data == {"version": None}
+            mock_get_sha.assert_called_once()


### PR DESCRIPTION
A modern feature many SPA's have is to notify the user when a new version of the Sentry frontend has become available. I've implemented this feature for Sentry in this pull request.

The app will now detect when there's a new version of the frontend available, provide a subtle indicator in the footer that a new version of the app is available, and force the app to hard-reload when the user navigates while running a stale version of the frontend.

### Why do this?

Users of Sentry often keep tabs open for hours or even days, however we deploy Sentry's frontend multiple times per work-day. This can end up leading to scenarios where the users old frontend becomes out-of-sync with the backend and in the worst cases can cause the customers app to break completely and require them to hard reload.

This leads to us potentially trying to track down errors reported to Sentry simply due to the frontend being out of date. With this change this will be much more rare. We should see release adoption cut-over much improved as well.

### Here's how it works

- Currently the way the Sentry frontend is deployed is by updating a k8s ConfigMap object that the Sentry backend reads to determine the webpack entrypoint file to set in the layout.html <script /> tag.

  This file is known as `frontend-versions.json`. I've updated the format of this file to include the commit SHA that is associated to the entrypoints that the file points to, this gives the Sentry backend knowledge of the actively deployed Sentry frontend.

  The change in getsentry to update the format of the frontend-versions.json file is here: https://github.com/getsentry/getsentry/pull/18201

- A new `/0/api/internal/frontend-version/` endpoint has been added that simply responds with the commit sha of the actively deployed frontend.

- A new `FrontendVersionProvider` has been implemented that polls the new endpoint every 5 minutes and updates a context value indicating if the frontend app has become stale.

- Our custom `Link` component reads from this context, and in the case where the app has become stale, the `reloadDocument` prop is set to true on the Link, meaning when a user navigates within Sentry and has an outdated version of the frontend, they will automatically reload the app and get the new version.

- The `Footer` component reads the context and displays a subtle muted pulsing indicator that upon hovering indicates to the user that there's an "improved" version of Sentry's frontend available.

### Ensuring compatibility

Since we've changed the format of the `frontend-versions.json` file I've added some compat checks that will ensure both the old and new version of this file are respected.

A future pull request will clean up the compat logic once all of the frontend-versions.json files have been written with the new format.