### PR TITLE
feat(hackweek): Implement "New Frontend Version available" (FE)

### DIFF
--- a/static/app/components/core/link/link.tsx
+++ b/static/app/components/core/link/link.tsx
@@ -7,6 +7,7 @@ import {css, type Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 import type {LocationDescriptor} from 'history';
 
+import {useFrontendVersion} from 'sentry/components/frontendVersionContext';
 import {locationDescriptorToTo} from 'sentry/utils/reactRouter6Compat/location';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -71,12 +72,20 @@ const Anchor = styled('a', {
 export const Link = styled(({disabled, to, ...props}: LinkProps) => {
   const location = useLocation();
 
+  // If the frontend app is stale we can force the link to reload the page,
+  // loading the new version of sentry.
+  const {state: appState} = useFrontendVersion();
+
   if (disabled || !location) {
     return <Anchor {...props} />;
   }
 
   return (
-    <RouterLink to={locationDescriptorToTo(normalizeUrl(to, location))} {...props} />
+    <RouterLink
+      reloadDocument={appState === 'stale'}
+      to={locationDescriptorToTo(normalizeUrl(to, location))}
+      {...props}
+    />
   );
 })`
   ${getLinkStyles}

--- a/static/app/components/footer.tsx
+++ b/static/app/components/footer.tsx
@@ -1,13 +1,16 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
+import {Button} from 'sentry/components/core/button';
 import {ExternalLink} from 'sentry/components/core/link';
+import {useFrontendVersion} from 'sentry/components/frontendVersionContext';
 import Hook from 'sentry/components/hook';
 import {IconSentry, IconSentryPrideLogo} from 'sentry/icons';
 import type {SVGIconProps} from 'sentry/icons/svgIcon';
 import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
+import pulsingIndicatorStyles from 'sentry/styles/pulsingIndicator';
 import {space} from 'sentry/styles/space';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -33,6 +36,8 @@ type Props = {
 function BaseFooter({className}: Props) {
   const {isSelfHosted, version, privacyUrl, termsUrl, demoMode} =
     useLegacyStore(ConfigStore);
+
+  const {state: appState} = useFrontendVersion();
   const organization = useOrganization({allowNull: true});
 
   return (
@@ -55,6 +60,19 @@ function BaseFooter({className}: Props) {
         />
       </SentryLogoLink>
       <RightLinks>
+        {appState === 'stale' && (
+          <Button
+            borderless
+            size="xs"
+            onClick={() => window.location.reload()}
+            title={t(
+              "An improved version of Sentry's Frontend Application is now available. Click to update now."
+            )}
+            aria-label={t('Reload frontend')}
+          >
+            <WaitingIndicator />
+          </Button>
+        )}
         {!isSelfHosted && (
           <FooterLink href="https://status.sentry.io/">{t('Service Status')}</FooterLink>
         )}
@@ -71,6 +89,11 @@ function BaseFooter({className}: Props) {
     </footer>
   );
 }
+
+const WaitingIndicator = styled('div')`
+  --pulsingIndicatorRing: ${p => p.theme.gray200};
+  ${pulsingIndicatorStyles};
+`;
 
 const LeftLinks = styled('div')`
   display: grid;

--- a/static/app/components/frontendVersionContext.spec.tsx
+++ b/static/app/components/frontendVersionContext.spec.tsx
@@ -1,0 +1,177 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import * as constants from 'sentry/constants';
+import ConfigStore from 'sentry/stores/configStore';
+
+import {FrontendVersionProvider, useFrontendVersion} from './frontendVersionContext';
+
+// Mock constants to control test environment, the FrontendVersionProvider ony
+// does anything in production SAAS.
+jest.mock('sentry/constants', () => ({
+  __esModule: true,
+  DEPLOY_PREVIEW_CONFIG: undefined,
+  NODE_ENV: 'production',
+}));
+
+function TestComponent() {
+  const {state, deployedVersion, runningVersion} = useFrontendVersion();
+
+  return (
+    <div>
+      <span data-test-id="state">{state}</span>
+      <span data-test-id="deployed-version">{deployedVersion || 'null'}</span>
+      <span data-test-id="running-version">{runningVersion || 'null'}</span>
+    </div>
+  );
+}
+
+describe('FrontendVersionProvider', () => {
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    ConfigStore.set('sentryMode', 'SAAS');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('provides state="current" when server version matches current version', async () => {
+    const commitSha = 'deadbeefcafebabe1234567890abcdef12345678';
+    const releaseVersion = `frontend@${commitSha}`;
+
+    MockApiClient.addMockResponse({
+      url: '/internal/frontend-version/',
+      body: {version: commitSha},
+    });
+
+    render(
+      <FrontendVersionProvider releaseVersion={releaseVersion}>
+        <TestComponent />
+      </FrontendVersionProvider>
+    );
+
+    expect(await screen.findByTestId('state')).toHaveTextContent('current');
+    expect(await screen.findByTestId('deployed-version')).toHaveTextContent(commitSha);
+    expect(await screen.findByTestId('running-version')).toHaveTextContent(commitSha);
+  });
+
+  it('provides state="stale" when server version differs from current version', async () => {
+    const currentCommitSha = 'feedface123456789abcdef0fedcba9876543210';
+    const serverVersion = 'beefdead987654321fedcba0123456789abcdef0';
+    const releaseVersion = `frontend@${currentCommitSha}`;
+
+    MockApiClient.addMockResponse({
+      url: '/internal/frontend-version/',
+      body: {version: serverVersion},
+    });
+
+    render(
+      <FrontendVersionProvider releaseVersion={releaseVersion}>
+        <TestComponent />
+      </FrontendVersionProvider>
+    );
+
+    expect(await screen.findByTestId('state')).toHaveTextContent('stale');
+    expect(await screen.findByTestId('deployed-version')).toHaveTextContent(
+      serverVersion
+    );
+    expect(await screen.findByTestId('running-version')).toHaveTextContent(
+      currentCommitSha
+    );
+  });
+
+  it('provides state="unknown" when server returns null version', async () => {
+    const commitSha = 'c0ffee123456789abcdef0fedcba9876543210ab';
+    const releaseVersion = `frontend@${commitSha}`;
+
+    MockApiClient.addMockResponse({
+      url: '/internal/frontend-version/',
+      body: {version: null},
+    });
+
+    render(
+      <FrontendVersionProvider releaseVersion={releaseVersion}>
+        <TestComponent />
+      </FrontendVersionProvider>
+    );
+
+    expect(await screen.findByTestId('state')).toHaveTextContent('unknown');
+    expect(await screen.findByTestId('deployed-version')).toHaveTextContent('null');
+    expect(await screen.findByTestId('running-version')).toHaveTextContent(commitSha);
+  });
+
+  it('provides forced state when force prop is set', async () => {
+    render(
+      <FrontendVersionProvider releaseVersion="frontend@abc123" force="stale">
+        <TestComponent />
+      </FrontendVersionProvider>
+    );
+
+    expect(await screen.findByTestId('state')).toHaveTextContent('stale');
+    expect(await screen.findByTestId('deployed-version')).toHaveTextContent('null');
+    expect(await screen.findByTestId('running-version')).toHaveTextContent('abc123');
+  });
+
+  it('provides state="disabled" when sentryMode is not SAAS', async () => {
+    MockApiClient.addMockResponse({
+      url: '/internal/frontend-version/',
+      body: {version: 'server-version'},
+    });
+
+    // Mock ConfigStore to simulate non-SAAS environment
+    ConfigStore.set('sentryMode', 'SELF_HOSTED');
+
+    render(
+      <FrontendVersionProvider releaseVersion="frontend@abc123">
+        <TestComponent />
+      </FrontendVersionProvider>
+    );
+
+    expect(await screen.findByTestId('state')).toHaveTextContent('disabled');
+    expect(await screen.findByTestId('deployed-version')).toHaveTextContent('null');
+    expect(await screen.findByTestId('running-version')).toHaveTextContent('abc123');
+  });
+
+  it('provides state="disabled" when NODE_ENV is not production', async () => {
+    jest.mocked(constants).NODE_ENV = 'development';
+
+    MockApiClient.addMockResponse({
+      url: '/internal/frontend-version/',
+      body: {version: 'server-version'},
+    });
+
+    render(
+      <FrontendVersionProvider releaseVersion="frontend@abc123">
+        <TestComponent />
+      </FrontendVersionProvider>
+    );
+
+    expect(await screen.findByTestId('state')).toHaveTextContent('disabled');
+    expect(await screen.findByTestId('deployed-version')).toHaveTextContent('null');
+    expect(await screen.findByTestId('running-version')).toHaveTextContent('abc123');
+  });
+
+  it('provides state="disabled" when DEPLOY_PREVIEW_CONFIG is defined', async () => {
+    jest.mocked(constants).DEPLOY_PREVIEW_CONFIG = {
+      branch: 'test-branch',
+      commitSha: 'abdc',
+      githubOrg: 'getsentry',
+      githubRepo: 'sentry',
+    };
+
+    MockApiClient.addMockResponse({
+      url: '/internal/frontend-version/',
+      body: {version: 'server-version'},
+    });
+
+    render(
+      <FrontendVersionProvider releaseVersion="frontend@abc123">
+        <TestComponent />
+      </FrontendVersionProvider>
+    );
+
+    expect(await screen.findByTestId('state')).toHaveTextContent('disabled');
+    expect(await screen.findByTestId('deployed-version')).toHaveTextContent('null');
+    expect(await screen.findByTestId('running-version')).toHaveTextContent('abc123');
+  });
+});

--- a/static/app/components/frontendVersionContext.tsx
+++ b/static/app/components/frontendVersionContext.tsx
@@ -1,0 +1,133 @@
+import {createContext, useContext} from 'react';
+
+import {DEPLOY_PREVIEW_CONFIG, NODE_ENV} from 'sentry/constants';
+import ConfigStore from 'sentry/stores/configStore';
+import {useLegacyStore} from 'sentry/stores/useLegacyStore';
+import {useApiQuery} from 'sentry/utils/queryClient';
+
+interface FrontendVersionResponse {
+  /**
+   * The commit SHA of the latest version available on the server.
+   */
+  version: string | null;
+}
+
+type State = 'unknown' | 'disabled' | 'stale' | 'current';
+
+interface VersionStatus {
+  /**
+   * The commit SHA of the latest version available on the server.
+   */
+  deployedVersion: string | null;
+  /**
+   * The running frontend version. This is typically the SENTRY_RELEASE_VERSION
+   * constant. Should be in the format `package@<commit-sha>`.
+   */
+  runningVersion: string | null;
+  /**
+   * Indicates the state of the running frontend version
+   *
+   * `current`  - The frontend app matches the version of the frontend the
+   *              backend is currently serving.
+   *
+   * `stale`    - The backend is reporting a different version SHA from the
+   *              version of the frontend app that is currently running.
+   *
+   * `disabled` - We explicitly are not checking if the frontend application is
+   *              up-to-date. We only typically know the
+   *
+   * `unknown`  - We don't know if the frontend is up-to-date. Typically this
+   *              is because we're waiting on the frontend-version request to
+   *              the backend to complete.
+   */
+  state: State;
+}
+
+interface Props {
+  children: React.ReactNode;
+  /**
+   * The running frontend version. This is typically the SENTRY_RELEASE_VERSION
+   * constant. Should be in the format `package@<commit-sha>`.
+   */
+  releaseVersion: string | null;
+  /**
+   * Force the status for testing purposes. When enabled, disables the API
+   * query and sets the forced state.
+   */
+  force?: State;
+}
+
+const FrontendVersionContext = createContext<VersionStatus>({
+  state: 'unknown',
+  deployedVersion: null,
+  runningVersion: null,
+});
+
+/**
+ * Context provider that polls the frontend version endpoint every 5 minutes
+ * and on tab focus to detect if the frontend version has changed.
+ */
+export function FrontendVersionProvider({children, force, releaseVersion}: Props) {
+  const {sentryMode} = useLegacyStore(ConfigStore);
+
+  const enabled =
+    !force &&
+    //
+    // We only make stale version assessments when talking to SAAS Sentry.
+    sentryMode === 'SAAS' &&
+    //
+    // We only make stale version assessments when the frontend is running a
+    // production build.
+    NODE_ENV === 'production' &&
+    //
+    // We do not make stale version assessments when running deployment
+    // previews, these are inherinetly a differning version from what is
+    // deployed in production SAAS.
+    DEPLOY_PREVIEW_CONFIG === undefined;
+
+  const {data: frontendVersionData} = useApiQuery<FrontendVersionResponse>(
+    ['/internal/frontend-version/'],
+    {
+      staleTime: 5 * 60 * 1000,
+      refetchInterval: 5 * 60 * 1000,
+      refetchIntervalInBackground: false,
+      refetchOnWindowFocus: true,
+      enabled,
+    }
+  );
+
+  const runningVersion = releaseVersion?.split('@').at(1) ?? null;
+  const deployedVersion = frontendVersionData?.version ?? null;
+
+  function getState(): State {
+    if (force) {
+      return force;
+    }
+    if (!enabled) {
+      return 'disabled';
+    }
+    if (deployedVersion === null) {
+      return 'unknown';
+    }
+
+    if (deployedVersion !== runningVersion) {
+      return 'stale';
+    }
+
+    return 'current';
+  }
+  const state = getState();
+
+  return (
+    <FrontendVersionContext.Provider value={{state, deployedVersion, runningVersion}}>
+      {children}
+    </FrontendVersionContext.Provider>
+  );
+}
+
+/**
+ * Hook to access frontend version information.
+ */
+export function useFrontendVersion(): VersionStatus {
+  return useContext(FrontendVersionContext);
+}

--- a/static/app/main.tsx
+++ b/static/app/main.tsx
@@ -4,9 +4,10 @@ import {wrapCreateBrowserRouterV6} from '@sentry/react';
 import {ReactQueryDevtools} from '@tanstack/react-query-devtools';
 
 import {AppQueryClientProvider} from 'sentry/appQueryClient';
+import {FrontendVersionProvider} from 'sentry/components/frontendVersionContext';
 import {OnboardingContextProvider} from 'sentry/components/onboarding/onboardingContext';
 import {ThemeAndStyleProvider} from 'sentry/components/themeAndStyleProvider';
-import {USE_REACT_QUERY_DEVTOOL} from 'sentry/constants';
+import {SENTRY_RELEASE_VERSION, USE_REACT_QUERY_DEVTOOL} from 'sentry/constants';
 import {routes} from 'sentry/routes';
 import {SentryTrackingProvider} from 'sentry/tracking';
 import {DANGEROUS_SET_REACT_ROUTER_6_HISTORY} from 'sentry/utils/browserHistory';
@@ -24,16 +25,18 @@ function Main() {
 
   return (
     <AppQueryClientProvider>
-      <ThemeAndStyleProvider>
-        <OnboardingContextProvider>
-          <SentryTrackingProvider>
-            <RouterProvider router={router} />
-          </SentryTrackingProvider>
-        </OnboardingContextProvider>
-        {USE_REACT_QUERY_DEVTOOL && (
-          <ReactQueryDevtools initialIsOpen={false} buttonPosition="bottom-left" />
-        )}
-      </ThemeAndStyleProvider>
+      <FrontendVersionProvider releaseVersion={SENTRY_RELEASE_VERSION ?? null}>
+        <ThemeAndStyleProvider>
+          <OnboardingContextProvider>
+            <SentryTrackingProvider>
+              <RouterProvider router={router} />
+            </SentryTrackingProvider>
+          </OnboardingContextProvider>
+          {USE_REACT_QUERY_DEVTOOL && (
+            <ReactQueryDevtools initialIsOpen={false} buttonPosition="bottom-left" />
+          )}
+        </ThemeAndStyleProvider>
+      </FrontendVersionProvider>
     </AppQueryClientProvider>
   );
 }

--- a/static/app/styles/pulsingIndicator.tsx
+++ b/static/app/styles/pulsingIndicator.tsx
@@ -17,7 +17,7 @@ const pulsingIndicatorStyles = (p: {theme: Theme}) => css`
   height: 8px;
   width: 8px;
   border-radius: 50%;
-  background: ${p.theme.pink300};
+  background: var(--pulsingIndicatorBg, ${p.theme.pink300});
   position: relative;
 
   &:before {
@@ -29,9 +29,10 @@ const pulsingIndicatorStyles = (p: {theme: Theme}) => css`
     border-radius: 50%;
     top: -46px;
     left: -46px;
-    border: 4px solid ${p.theme.pink200};
+    border: 4px solid var(--pulsingIndicatorRing, ${p.theme.pink200});
     transform-origin: center;
     animation: ${pulse} 3s ease-out infinite;
+    pointer-events: none;
   }
 `;
 


### PR DESCRIPTION
A modern feature many SPA's have is to notify the user when a new version of the Sentry frontend has become available. I've implemented this feature for Sentry in this pull request.

The app will now detect when there's a new version of the frontend available, provide a subtle indicator in the footer that a new version of the app is available, and force the app to hard-reload when the user navigates while running a stale version of the frontend.

Associated backend changes https://github.com/getsentry/sentry/pull/98030

### Why do this?

Users of Sentry often keep tabs open for hours or even days, however we deploy Sentry's frontend multiple times per work-day. This can end up leading to scenarios where the users old frontend becomes out-of-sync with the backend and in the worst cases can cause the customers app to break completely and require them to hard reload.

This leads to us potentially trying to track down errors reported to Sentry simply due to the frontend being out of date. With this change this will be much more rare. We should see release adoption cut-over much improved as well.

### Here's how it works

- Currently the way the Sentry frontend is deployed is by updating a k8s ConfigMap object that the Sentry backend reads to determine the webpack entrypoint file to set in the layout.html <script /> tag.

  This file is known as `frontend-versions.json`. I've updated the format of this file to include the commit SHA that is associated to the entrypoints that the file points to, this gives the Sentry backend knowledge of the actively deployed Sentry frontend.

  The change in getsentry to update the format of the frontend-versions.json file is here: https://github.com/getsentry/getsentry/pull/18201

- A new `/0/api/internal/frontend-version/` endpoint has been added that simply responds with the commit sha of the actively deployed frontend.

- A new `FrontendVersionProvider` has been implemented that polls the new endpoint every 5 minutes and updates a context value indicating if the frontend app has become stale.

- Our custom `Link` component reads from this context, and in the case where the app has become stale, the `reloadDocument` prop is set to true on the Link, meaning when a user navigates within Sentry and has an outdated version of the frontend, they will automatically reload the app and get the new version.

- The `Footer` component reads the context and displays a subtle muted pulsing indicator that upon hovering indicates to the user that there's an "improved" version of Sentry's frontend available.

### Ensuring compatibility

Since we've changed the format of the `frontend-versions.json` file I've added some compat checks that will ensure both the old and new version of this file are respected.

A future pull request will clean up the compat logic once all of the frontend-versions.json files have been written with the new format.

https://github.com/user-attachments/assets/e4a663eb-7785-4c29-b2d9-ffa149ce65ad