### PR TITLE
improve plugin tests to not need explicit mocks

### DIFF
--- a/tests/sentry_plugins/bitbucket/test_plugin.py
+++ b/tests/sentry_plugins/bitbucket/test_plugin.py
@@ -1,12 +1,13 @@
 from functools import cached_property
-from unittest.mock import MagicMock
 
 import pytest
 import responses
 from django.contrib.auth.models import AnonymousUser
+from django.test import RequestFactory
 
 from sentry.exceptions import PluginError
 from sentry.testutils.cases import PluginTestCase
+from sentry.testutils.requests import drf_request_from_request
 from sentry_plugins.bitbucket.plugin import BitbucketPlugin
 
 
@@ -18,6 +19,10 @@ class BitbucketPluginTest(PluginTestCase):
     @cached_property
     def plugin(self) -> BitbucketPlugin:
         return BitbucketPlugin()
+
+    @cached_property
+    def request(self) -> RequestFactory:
+        return RequestFactory()
 
     def test_get_issue_label(self) -> None:
         group = self.create_group(message="Hello world", culprit="foo.bar")
@@ -47,7 +52,7 @@ class BitbucketPluginTest(PluginTestCase):
         self.plugin.set_option("repo", "maxbittker/newsdiffs", self.project)
         group = self.create_group(message="Hello world", culprit="foo.bar")
 
-        request = MagicMock()
+        request = drf_request_from_request(self.request.get("/"))
         request.user = AnonymousUser()
         form_data = {
             "title": "Hello",
@@ -93,7 +98,7 @@ class BitbucketPluginTest(PluginTestCase):
         self.plugin.set_option("repo", "maxbittker/newsdiffs", self.project)
         group = self.create_group(message="Hello world", culprit="foo.bar")
 
-        request = MagicMock()
+        request = drf_request_from_request(self.request.get("/"))
         request.user = AnonymousUser()
         form_data = {"comment": "Hello", "issue_id": "1"}
         with pytest.raises(PluginError):

--- a/tests/sentry_plugins/github/test_plugin.py
+++ b/tests/sentry_plugins/github/test_plugin.py
@@ -1,13 +1,14 @@
 from functools import cached_property
-from unittest.mock import MagicMock
 
 import orjson
 import pytest
 import responses
 from django.contrib.auth.models import AnonymousUser
+from django.test import RequestFactory
 
 from sentry.exceptions import PluginError
 from sentry.testutils.cases import PluginTestCase
+from sentry.testutils.requests import drf_request_from_request
 from sentry_plugins.github.plugin import GitHubPlugin
 
 
@@ -19,6 +20,10 @@ class GitHubPluginTest(PluginTestCase):
     @cached_property
     def plugin(self) -> GitHubPlugin:
         return GitHubPlugin()
+
+    @cached_property
+    def request(self) -> RequestFactory:
+        return RequestFactory()
 
     def test_get_issue_label(self) -> None:
         group = self.create_group(message="Hello world", culprit="foo.bar")
@@ -47,7 +52,7 @@ class GitHubPluginTest(PluginTestCase):
         self.plugin.set_option("repo", "getsentry/sentry", self.project)
         group = self.create_group(message="Hello world", culprit="foo.bar")
 
-        request = MagicMock()
+        request = drf_request_from_request(self.request.get("/"))
         request.user = AnonymousUser()
         form_data = {"title": "Hello", "description": "Fix this."}
         with pytest.raises(PluginError):
@@ -81,7 +86,7 @@ class GitHubPluginTest(PluginTestCase):
         self.plugin.set_option("repo", "getsentry/sentry", self.project)
         group = self.create_group(message="Hello world", culprit="foo.bar")
 
-        request = MagicMock()
+        request = drf_request_from_request(self.request.get("/"))
         request.user = AnonymousUser()
         form_data = {"comment": "Hello", "issue_id": "1"}
         with pytest.raises(PluginError):

--- a/tests/sentry_plugins/gitlab/test_plugin.py
+++ b/tests/sentry_plugins/gitlab/test_plugin.py
@@ -1,11 +1,12 @@
 from functools import cached_property
-from unittest.mock import MagicMock
 
 import orjson
 import responses
+from django.test import RequestFactory
 from django.urls import reverse
 
 from sentry.testutils.cases import PluginTestCase
+from sentry.testutils.requests import drf_request_from_request
 from sentry_plugins.gitlab.plugin import GitLabPlugin
 
 
@@ -17,6 +18,10 @@ class GitLabPluginTest(PluginTestCase):
     @cached_property
     def plugin(self) -> GitLabPlugin:
         return GitLabPlugin()
+
+    @cached_property
+    def request(self) -> RequestFactory:
+        return RequestFactory()
 
     def test_get_issue_label(self) -> None:
         group = self.create_group(message="Hello world", culprit="foo.bar")
@@ -53,7 +58,7 @@ class GitLabPluginTest(PluginTestCase):
         self.plugin.set_option("gitlab_token", "abcdefg", self.project)
         group = self.create_group(message="Hello world", culprit="foo.bar")
 
-        request = MagicMock()
+        request = drf_request_from_request(self.request.get("/"))
         request.user = self.user
         form_data = {"title": "Hello", "description": "Fix this."}
 
@@ -87,7 +92,7 @@ class GitLabPluginTest(PluginTestCase):
         self.plugin.set_option("gitlab_token", "abcdefg", self.project)
         group = self.create_group(message="Hello world", culprit="foo.bar")
 
-        request = MagicMock()
+        request = drf_request_from_request(self.request.get("/"))
         request.user = self.user
         form_data = {"comment": "Hello", "issue_id": "1"}
 

--- a/tests/sentry_plugins/jira/test_plugin.py
+++ b/tests/sentry_plugins/jira/test_plugin.py
@@ -2,14 +2,15 @@ from __future__ import annotations
 
 from functools import cached_property
 from typing import Any
-from unittest.mock import MagicMock
 
 import orjson
 import responses
 from django.contrib.auth.models import AnonymousUser
+from django.test import RequestFactory
 from django.urls import reverse
 
 from sentry.testutils.cases import TestCase
+from sentry.testutils.requests import drf_request_from_request
 from sentry_plugins.jira.plugin import JiraPlugin
 
 create_meta_response = {
@@ -216,6 +217,10 @@ class JiraPluginTest(TestCase):
     def plugin(self) -> JiraPlugin:
         return JiraPlugin()
 
+    @cached_property
+    def request(self) -> RequestFactory:
+        return RequestFactory()
+
     def test_conf_key(self) -> None:
         assert self.plugin.conf_key == "jira"
 
@@ -251,7 +256,7 @@ class JiraPluginTest(TestCase):
         self.plugin.set_option("instance_url", "https://getsentry.atlassian.net", self.project)
         group = self.create_group(message="Hello world", culprit="foo.bar")
 
-        request = MagicMock()
+        request = drf_request_from_request(self.request.get("/"))
         request.user = AnonymousUser()
         form_data = {
             "title": "Hello",
@@ -271,7 +276,7 @@ class JiraPluginTest(TestCase):
         self.plugin.set_option("instance_url", "https://getsentry.atlassian.net", self.project)
         group = self.create_group(message="Hello world", culprit="foo.bar")
 
-        request = MagicMock()
+        request = drf_request_from_request(self.request.get("/"))
         request.user = AnonymousUser()
         form_data = {"issue_id": "SEN-19"}
         assert (

--- a/tests/sentry_plugins/trello/test_plugin.py
+++ b/tests/sentry_plugins/trello/test_plugin.py
@@ -1,11 +1,11 @@
 from functools import cached_property
-from unittest.mock import MagicMock
 from urllib.parse import parse_qsl, urlparse
 
 import orjson
 import responses
 
 from sentry.testutils.cases import PluginTestCase
+from sentry.testutils.requests import drf_request_from_request
 from sentry_plugins.trello.plugin import TrelloPlugin
 
 
@@ -123,9 +123,7 @@ class TrelloPluginApiTests(TrelloPluginTestBase):
             "board": "ads23f",
             "list": "23tds",
         }
-        request = MagicMock()
-        request.user = self.user
-        request.method = "POST"
+        request = drf_request_from_request(self.make_request(user=self.user, method="POST"))
 
         assert self.plugin.create_issue(request, self.group, form_data) == "rds43"
         responses_request = responses.calls[0].request
@@ -145,9 +143,7 @@ class TrelloPluginApiTests(TrelloPluginTestBase):
         )
 
         form_data = {"comment": "please fix this", "issue_id": "SstgnBIQ"}
-        request = MagicMock()
-        request.user = self.user
-        request.method = "POST"
+        request = drf_request_from_request(self.make_request(user=self.user, method="POST"))
 
         assert self.plugin.link_issue(request, self.group, form_data) == {
             "title": "MyTitle",
@@ -174,10 +170,11 @@ class TrelloPluginApiTests(TrelloPluginTestBase):
             json=[{"id": "8f3", "name": "list 1"}, {"id": "j8f", "name": "list 2"}],
         )
 
-        request = MagicMock()
-        request.user = self.user
-        request.method = "GET"
-        request.GET = {"option_field": "list", "board": "f34"}
+        request = drf_request_from_request(
+            self.make_request(
+                user=self.user, method="GET", GET={"option_field": "list", "board": "f34"}
+            )
+        )
 
         response = self.plugin.view_options(request, self.group)
         assert response.data == {"list": [("8f3", "list 1"), ("j8f", "list 2")]}
@@ -201,11 +198,13 @@ class TrelloPluginApiTests(TrelloPluginTestBase):
             },
         )
 
-        request = MagicMock()
-        request.user = self.user
-        request.method = "GET"
-        request.GET = {"autocomplete_field": "issue_id", "autocomplete_query": "Key"}
-
+        request = drf_request_from_request(
+            self.make_request(
+                user=self.user,
+                method="GET",
+                GET={"autocomplete_field": "issue_id", "autocomplete_query": "Key"},
+            )
+        )
         response = self.plugin.view_autocomplete(request, self.group)
         assert response.data == {
             "issue_id": [
@@ -245,11 +244,13 @@ class TrelloPluginApiTests(TrelloPluginTestBase):
             },
         )
 
-        request = MagicMock()
-        request.user = self.user
-        request.method = "GET"
-        request.GET = {"autocomplete_field": "issue_id", "autocomplete_query": "Key"}
-
+        request = drf_request_from_request(
+            self.make_request(
+                user=self.user,
+                method="GET",
+                GET={"autocomplete_field": "issue_id", "autocomplete_query": "Key"},
+            )
+        )
         response = self.plugin.view_autocomplete(request, self.group)
         assert response.data == {
             "issue_id": [


### PR DESCRIPTION
Follows #97998

Turns out there's a utility function to convert `HttpRequest` to `Request`! Better to use the normal requests than full mocks.