### PR TITLE
chore(aci): Make the delayed_workflows shim the only task

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3121,7 +3121,7 @@ register(
 register(
     "delayed_workflow.use_workflow_engine_pool",
     type=Bool,
-    default=False,
+    default=True,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(

--- a/src/sentry/workflow_engine/tasks/delayed_workflows.py
+++ b/src/sentry/workflow_engine/tasks/delayed_workflows.py
@@ -5,7 +5,6 @@ from typing import Any
 from celery import Task
 
 import sentry.workflow_engine.buffer as buffer
-from sentry import options
 from sentry.buffer.base import Buffer
 from sentry.rules.processing.buffer_processing import (
     BufferHashKeys,
@@ -49,7 +48,7 @@ def process_delayed_workflows_shim(
 ) -> None:
     from sentry.workflow_engine.processors.delayed_workflow import process_delayed_workflows
 
-    process_delayed_workflows(project_id, batch_key, *args, **kwargs)
+    process_delayed_workflows(project_id, batch_key)
 
 
 @delayed_processing_registry.register("delayed_workflow")
@@ -64,11 +63,7 @@ class DelayedWorkflow(DelayedProcessingBase):
 
     @property
     def processing_task(self) -> Task:
-        from sentry.workflow_engine.processors.delayed_workflow import process_delayed_workflows
-
-        if options.get("delayed_workflow.use_workflow_engine_pool"):
-            return process_delayed_workflows_shim
-        return process_delayed_workflows
+        return process_delayed_workflows_shim
 
     @staticmethod
     def buffer_backend() -> LazyServiceWrapper[Buffer]:

--- a/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
@@ -322,9 +322,7 @@ class TestDelayedWorkflowHelpers(TestDelayedWorkflowBase):
         for instance in event_data.events.values():
             assert instance.timestamp == timezone.now()
 
-    @override_options(
-        {"delayed_processing.batch_size": 1, "delayed_workflow.use_workflow_engine_pool": True}
-    )
+    @override_options({"delayed_processing.batch_size": 1})
     @patch(
         "sentry.workflow_engine.tasks.delayed_workflows.process_delayed_workflows_shim.apply_async"
     )
@@ -992,7 +990,7 @@ class TestCleanupRedisBuffer(TestDelayedWorkflowBase):
 
     @override_options({"delayed_processing.batch_size": 1})
     @patch(
-        "sentry.workflow_engine.processors.delayed_workflow.process_delayed_workflows.apply_async"
+        "sentry.workflow_engine.tasks.delayed_workflows.process_delayed_workflows_shim.apply_async"
     )
     def test_batched_cleanup(self, mock_process_delayed: MagicMock) -> None:
         self._push_base_events()


### PR DESCRIPTION
We only use the new location in production now, and the layers of celery task are creating problems for our error handling.
