### PR TITLE
codemod returns to `setup` and `teardown`

### DIFF
--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -13,7 +13,7 @@ pytestmark = [requires_snuba]
 
 # TODO: move these into the tests/sentry/auth directory and remove deprecated logic
 class AuthenticationTest(AuthProviderTestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.organization = self.create_organization(name="foo")
         self.user = self.create_user("foobar@example.com", is_superuser=False)
         team = self.create_team(name="bar", organization=self.organization)

--- a/tests/sentry/identity/test_oauth2.py
+++ b/tests/sentry/identity/test_oauth2.py
@@ -29,7 +29,7 @@ class OAuth2CallbackViewTest(TestCase):
         self.request = RequestFactory().get("/")
         self.request.subdomain = None
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         super().tearDown()
         sentry.identity.unregister(DummyProvider)
 
@@ -167,7 +167,7 @@ class OAuth2LoginViewTest(TestCase):
         self.request.session = Client().session
         self.request.subdomain = None
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         super().tearDown()
         sentry.identity.unregister(DummyProvider)
 

--- a/tests/sentry/incidents/models/test_alert_rule.py
+++ b/tests/sentry/incidents/models/test_alert_rule.py
@@ -242,7 +242,7 @@ class AlertRuleTriggerActionActivateBaseTest:
     def setUp(self) -> None:
         self.suspended_registry = TemporaryAlertRuleTriggerActionRegistry.suspend()
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         self.suspended_registry.restore()
 
     def test_no_handler(self) -> None:
@@ -289,7 +289,7 @@ class AlertRuleTriggerActionActivateTest(TestCase):
     def setUp(self) -> None:
         self.suspended_registry = TemporaryAlertRuleTriggerActionRegistry.suspend()
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         self.suspended_registry.restore()
 
     def test_unhandled(self) -> None:

--- a/tests/sentry/incidents/subscription_processor/test_subscription_processor.py
+++ b/tests/sentry/incidents/subscription_processor/test_subscription_processor.py
@@ -93,7 +93,7 @@ class ProcessUpdateBaseClass(TestCase, SpanTestCase, SnubaTestCase):
         self._run_tasks = self.tasks()
         self._run_tasks.__enter__()
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         super().tearDown()
         self.suspended_registry.restore()
         self._run_tasks.__exit__(None, None, None)

--- a/tests/sentry/incidents/subscription_processor/test_subscription_processor_base.py
+++ b/tests/sentry/incidents/subscription_processor/test_subscription_processor_base.py
@@ -33,12 +33,12 @@ class ProcessUpdateBaseClass(TestCase, SpanTestCase, SnubaTestCase):
         with mock.patch("sentry.incidents.subscription_processor.metrics") as self.metrics:
             yield
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self._run_tasks = self.tasks()
         self._run_tasks.__enter__()
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         super().tearDown()
         self._run_tasks.__exit__(None, None, None)
 

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -118,7 +118,7 @@ class GitHubIntegrationTest(IntegrationTestCase):
         self._stub_github()
         plugins.register(GitHubPlugin)
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         responses.reset()
         plugins.unregister(GitHubPlugin)
         super().tearDown()

--- a/tests/sentry/integrations/github/test_repository.py
+++ b/tests/sentry/integrations/github/test_repository.py
@@ -35,7 +35,7 @@ class GitHubAppsProviderTest(TestCase):
             },
         )
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         super().tearDown()
         responses.reset()
 

--- a/tests/sentry/integrations/gitlab/test_client.py
+++ b/tests/sentry/integrations/gitlab/test_client.py
@@ -58,7 +58,7 @@ class GitlabRefreshAuthTest(GitLabClientTest):
     def setUp(self) -> None:
         super().setUp()
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         responses.reset()
 
     def make_users_request(self):

--- a/tests/sentry/integrations/gitlab/test_repository.py
+++ b/tests/sentry/integrations/gitlab/test_repository.py
@@ -58,7 +58,7 @@ class GitLabRepositoryProviderTest(IntegrationRepositoryTestCase):
     def provider(self):
         return GitlabRepositoryProvider("gitlab")
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         super().tearDown()
         responses.reset()
 

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -202,7 +202,7 @@ class UnfurlTest(TestCase):
         self.frozen_time = freeze_time(datetime.now() - timedelta(days=1))
         self.frozen_time.start()
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         self.frozen_time.stop()
 
     def test_unfurl_issues(self) -> None:

--- a/tests/sentry/integrations/vercel/test_webhook.py
+++ b/tests/sentry/integrations/vercel/test_webhook.py
@@ -93,7 +93,7 @@ class VercelReleasesTest(APITestCase):
             provider="vercel",
         )
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         responses.reset()
 
     @responses.activate

--- a/tests/sentry/integrations/vsts/test_issues.py
+++ b/tests/sentry/integrations/vsts/test_issues.py
@@ -163,7 +163,7 @@ class VstsIssueBase(TestCase):
 )
 @region_silo_test(include_monolith_run=True)
 class VstsIssueSyncTest(VstsIssueBase):
-    def tearDown(self):
+    def tearDown(self) -> None:
         responses.reset()
 
     @responses.activate
@@ -570,7 +570,7 @@ class VstsIssueFormTest(VstsIssueBase):
         )
         self.group = event.group
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         responses.reset()
 
     def update_issue_defaults(self, defaults):

--- a/tests/sentry/integrations/vsts/test_repository.py
+++ b/tests/sentry/integrations/vsts/test_repository.py
@@ -170,7 +170,7 @@ class AzureDevOpsRepositoryProviderTest(IntegrationRepositoryTestCase):
         }
         self.login_as(self.user)
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         super().tearDown()
         responses.reset()
 

--- a/tests/sentry/integrations/vsts/test_webhooks.py
+++ b/tests/sentry/integrations/vsts/test_webhooks.py
@@ -68,7 +68,7 @@ class VstsWebhookWorkItemTest(APITestCase):
 
         self.user_to_assign = self.create_user("sentryuseremail@email.com")
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         responses.reset()
 
     def create_linked_group(self, external_issue, project, status):

--- a/tests/sentry/models/test_project.py
+++ b/tests/sentry/models/test_project.py
@@ -461,7 +461,7 @@ class ProjectOptionsTests(TestCase):
         self.project_template = self.create_project_template(organization=self.project.organization)
         self.project.template = self.project_template
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         super().tearDown()
 
         self.project_template.delete()

--- a/tests/sentry/monitors/tasks/test_detect_broken_monitor_envs.py
+++ b/tests/sentry/monitors/tasks/test_detect_broken_monitor_envs.py
@@ -33,7 +33,7 @@ class MonitorDetectBrokenMonitorEnvTaskTest(TestCase):
         self._run_tasks = self.tasks()
         self._run_tasks.__enter__()
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         super().tearDown()
         self._run_tasks.__exit__(None, None, None)
 

--- a/tests/sentry/monitors/test_validators.py
+++ b/tests/sentry/monitors/test_validators.py
@@ -15,7 +15,7 @@ from sentry.utils.slug import DEFAULT_SLUG_ERROR_MESSAGE
 
 
 class MonitorValidatorCreateTest(MonitorTestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.login_as(self.user)
 

--- a/tests/sentry/notifications/notifications/test_suspect_commits_activity.py
+++ b/tests/sentry/notifications/notifications/test_suspect_commits_activity.py
@@ -18,7 +18,7 @@ pytestmark = [requires_snuba]
 
 
 class SuspectCommitsInActivityNotificationsTest(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.login_as(self.user)
 

--- a/tests/sentry/preprod/api/endpoints/test_project_preprod_build_details.py
+++ b/tests/sentry/preprod/api/endpoints/test_project_preprod_build_details.py
@@ -48,7 +48,7 @@ class ProjectPreprodBuildDetailsEndpointTest(APITestCase):
         self.feature_context = self.feature({"organizations:preprod-frontend-routes": True})
         self.feature_context.__enter__()
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         # Exit the feature flag context manager
         self.feature_context.__exit__(None, None, None)
         super().tearDown()

--- a/tests/sentry/preprod/api/endpoints/test_project_preprod_check_for_updates.py
+++ b/tests/sentry/preprod/api/endpoints/test_project_preprod_check_for_updates.py
@@ -21,7 +21,7 @@ class ProjectPreprodCheckForUpdatesEndpointTest(APITestCase):
         self.feature_context = self.feature({"organizations:preprod-frontend-routes": True})
         self.feature_context.__enter__()
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         # Exit the feature flag context manager
         self.feature_context.__exit__(None, None, None)
         super().tearDown()

--- a/tests/sentry/preprod/api/endpoints/test_project_preprod_list_builds.py
+++ b/tests/sentry/preprod/api/endpoints/test_project_preprod_list_builds.py
@@ -77,7 +77,7 @@ class ProjectPreprodListBuildsEndpointTest(APITestCase):
         self.feature_context = self.feature({"organizations:preprod-frontend-routes": True})
         self.feature_context.__enter__()
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         # Exit the feature flag context manager
         self.feature_context.__exit__(None, None, None)
         super().tearDown()

--- a/tests/sentry/preprod/test_tasks.py
+++ b/tests/sentry/preprod/test_tasks.py
@@ -26,7 +26,7 @@ from tests.sentry.tasks.test_assemble import BaseAssembleTest
 
 
 class AssemblePreprodArtifactTest(BaseAssembleTest):
-    def tearDown(self):
+    def tearDown(self) -> None:
         """Clean up assembly status and force garbage collection to close unclosed files"""
         import gc
 

--- a/tests/sentry/rules/processing/test_buffer_processing.py
+++ b/tests/sentry/rules/processing/test_buffer_processing.py
@@ -37,7 +37,7 @@ class CreateEventTestCase(TestCase, BaseEventFrequencyPercentTest):
         self.mock_redis_buffer = mock_redis_buffer()
         self.mock_redis_buffer.__enter__()
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         self.mock_redis_buffer.__exit__(None, None, None)
 
     def push_to_hash(self, project_id, rule_id, group_id, event_id=None, occurrence_id=None):

--- a/tests/sentry/rules/processing/test_delayed_processing.py
+++ b/tests/sentry/rules/processing/test_delayed_processing.py
@@ -560,7 +560,7 @@ class GetRulesToFireTest(TestCase):
         self.patcher = patch("sentry.rules.processing.delayed_processing.passes_comparison")
         self.mock_passes_comparison = self.patcher.start()
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         self.patcher.stop()
 
     def test_comparison(self) -> None:

--- a/tests/sentry/seer/autofix/test_issue_summary.py
+++ b/tests/sentry/seer/autofix/test_issue_summary.py
@@ -33,7 +33,7 @@ class IssueSummaryTest(APITestCase, SnubaTestCase):
         self.group = self.create_group()
         self.login_as(user=self.user)
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         super().tearDown()
         # Clear the cache after each test
         cache.delete(f"ai-group-summary-v2:{self.group.id}")

--- a/tests/sentry/seer/test_page_web_vitals_summary.py
+++ b/tests/sentry/seer/test_page_web_vitals_summary.py
@@ -86,7 +86,7 @@ class PageWebVitalsSummaryTest(TestCase, SnubaTestCase):
 
         cache.clear()
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         super().tearDown()
         # Clear the cache with the correct key format
         cache.delete("ai-page-web-vitals-summary:" + "-".join(sorted([self.trace_id])))

--- a/tests/sentry/seer/test_trace_summary.py
+++ b/tests/sentry/seer/test_trace_summary.py
@@ -86,7 +86,7 @@ class TraceSummaryTest(TestCase, SnubaTestCase):
 
         cache.clear()
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         super().tearDown()
         cache.delete(f"ai-trace-summary:{self.trace_id}")
 

--- a/tests/sentry/sentry_apps/test_webhooks.py
+++ b/tests/sentry/sentry_apps/test_webhooks.py
@@ -11,7 +11,7 @@ from sentry.testutils.silo import region_silo_test
 
 @region_silo_test
 class BroadcastWebhooksForOrganizationTest(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.organization = self.create_organization()
         self.project = self.create_project(organization=self.organization)
 

--- a/tests/sentry/sentry_metrics/consumers/test_last_seen_updater.py
+++ b/tests/sentry/sentry_metrics/consumers/test_last_seen_updater.py
@@ -114,7 +114,7 @@ class TestLastSeenUpdaterEndToEnd(TestCase):
             last_seen=self.fresh_last_seen,
         )
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         self.table.objects.filter(id=self.fresh_id).delete()
         self.table.objects.filter(id=self.stale_id).delete()
 

--- a/tests/sentry/snuba/test_query_subscription_consumer.py
+++ b/tests/sentry/snuba/test_query_subscription_consumer.py
@@ -190,7 +190,7 @@ class RegisterSubscriberTest(unittest.TestCase):
     def setUp(self) -> None:
         self.orig_registry = deepcopy(subscriber_registry)
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         subscriber_registry.clear()
         subscriber_registry.update(self.orig_registry)
 

--- a/tests/sentry/tsdb/test_redis.py
+++ b/tests/sentry/tsdb/test_redis.py
@@ -48,7 +48,7 @@ class RedisTSDBTest(TestCase):
         # the point of this test is to demonstrate behaviour with a multi-host cluster
         assert len(self.db.cluster.hosts) == 3
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         with self.db.cluster.all() as client:
             client.flushdb()
 

--- a/tests/sentry/utils/test_snuba.py
+++ b/tests/sentry/utils/test_snuba.py
@@ -452,7 +452,7 @@ def test_retries() -> None:
 
 
 class SnubaQueryRateLimitTest(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         mock_request = Request(
             dataset="events",
             app_id="test",

--- a/tests/sentry/web/frontend/test_auth_saml2.py
+++ b/tests/sentry/web/frontend/test_auth_saml2.py
@@ -74,7 +74,7 @@ class AuthSAML2Test(AuthProviderTestCase):
 
         super().setUp()
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         # restore url-prefix config
         settings.SENTRY_OPTIONS.update({"system.url-prefix": self.url_prefix})
 

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_types.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_types.py
@@ -112,7 +112,7 @@ class OrganizationDetectorTypesAPITestCase(APITestCase):
             category_v2 = GroupCategory.DB_QUERY.value
             released = True
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         super().tearDown()
         self.registry_patcher.stop()
 

--- a/tests/sentry/workflow_engine/handlers/detector/test_base.py
+++ b/tests/sentry/workflow_engine/handlers/detector/test_base.py
@@ -181,7 +181,7 @@ class BaseDetectorHandlerTest(BaseGroupTypeTest):
         self.handler_state_type = HandlerStateGroupType
         self.update_handler_type = HandlerUpdateGroupType
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         super().tearDown()
         self.uuid_patcher.stop()
         self.sm_comp_patcher.stop()

--- a/tests/sentry/workflow_engine/processors/contexts/test_workflow_event_context.py
+++ b/tests/sentry/workflow_engine/processors/contexts/test_workflow_event_context.py
@@ -12,7 +12,7 @@ class WorkflowEventContextTestCase(TestCase):
         super().setUp()
         self.ctx_token: Token[WorkflowEventContextData] | None = None
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         if self.ctx_token:
             WorkflowEventContext.reset(self.ctx_token)
             self.ctx_token = None

--- a/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
@@ -122,7 +122,7 @@ class TestDelayedWorkflowBase(BaseWorkflowTest, BaseEventFrequencyPercentTest):
         buffer.backend.push_to_sorted_set(key=DelayedWorkflow.buffer_key, value=self.project.id)
         buffer.backend.push_to_sorted_set(key=DelayedWorkflow.buffer_key, value=self.project2.id)
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         self.mock_redis_buffer.__exit__(None, None, None)
 
     def create_project_event_freq_workflow(
@@ -512,7 +512,7 @@ class TestDelayedWorkflowQueries(BaseWorkflowTest):
 
 @freeze_time(FROZEN_TIME)
 class TestGetSnubaResults(BaseWorkflowTest):
-    def tearDown(self):
+    def tearDown(self) -> None:
         super().tearDown()
 
     def create_events(self, comparison_type: ComparisonType) -> Event:

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -472,7 +472,7 @@ class TestWorkflowEnqueuing(BaseWorkflowTest):
         self.mock_redis_buffer = mock_redis_buffer()
         self.mock_redis_buffer.__enter__()
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         self.mock_redis_buffer.__exit__(None, None, None)
 
     def test_enqueues_workflow_all_logic_type(self) -> None:

--- a/tests/snuba/api/endpoints/test_discover_saved_query_detail.py
+++ b/tests/snuba/api/endpoints/test_discover_saved_query_detail.py
@@ -13,7 +13,7 @@ from sentry.testutils.helpers.datetime import before_now
 class DiscoverSavedQueryDetailTest(APITestCase, SnubaTestCase):
     feature_name = "organizations:discover"
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.login_as(user=self.user)
         self.org = self.create_organization(owner=self.user)
@@ -504,7 +504,7 @@ class DiscoverSavedQueryDetailTest(APITestCase, SnubaTestCase):
 
 
 class OrganizationDiscoverQueryVisitTest(APITestCase, SnubaTestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.login_as(user=self.user)
         self.org = self.create_organization(owner=self.user)

--- a/tests/snuba/api/endpoints/test_organization_events_facets.py
+++ b/tests/snuba/api/endpoints/test_organization_events_facets.py
@@ -12,7 +12,7 @@ from sentry.testutils.helpers.datetime import before_now
 
 
 class OrganizationEventsFacetsEndpointTest(SnubaTestCase, APITestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.min_ago = before_now(minutes=1).replace(microsecond=0)
         self.day_ago = before_now(days=1).replace(microsecond=0)

--- a/tests/snuba/api/endpoints/test_organization_events_facets_performance.py
+++ b/tests/snuba/api/endpoints/test_organization_events_facets_performance.py
@@ -15,7 +15,7 @@ class BaseOrganizationEventsFacetsPerformanceEndpointTest(SnubaTestCase, APITest
         "organizations:performance-view",
     )
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.min_ago = before_now(minutes=1).replace(microsecond=0)
         self.two_mins_ago = before_now(minutes=2).replace(microsecond=0)
@@ -38,7 +38,7 @@ class BaseOrganizationEventsFacetsPerformanceEndpointTest(SnubaTestCase, APITest
 class OrganizationEventsFacetsPerformanceEndpointTest(
     BaseOrganizationEventsFacetsPerformanceEndpointTest
 ):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
 
         self._transaction_count = 0

--- a/tests/snuba/api/endpoints/test_organization_events_facets_performance_histogram.py
+++ b/tests/snuba/api/endpoints/test_organization_events_facets_performance_histogram.py
@@ -18,7 +18,7 @@ class OrganizationEventsFacetsPerformanceHistogramEndpointTest(
         "organizations:performance-view",
     )
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
 
         self._transaction_count = 0

--- a/tests/snuba/api/endpoints/test_organization_events_has_measurements.py
+++ b/tests/snuba/api/endpoints/test_organization_events_has_measurements.py
@@ -12,7 +12,7 @@ class OrganizationEventsHasMeasurementsTest(APITestCase, SnubaTestCase):
         self.min_ago = before_now(minutes=1)
         self.two_min_ago = before_now(minutes=2)
         self.transaction_data = load_data("transaction", timestamp=before_now(minutes=1))
-        self.features = {}
+        self.features: dict[str, bool] = {}
 
     def do_request(self, query, features=None):
         if features is None:

--- a/tests/snuba/api/endpoints/test_organization_events_has_measurements.py
+++ b/tests/snuba/api/endpoints/test_organization_events_has_measurements.py
@@ -7,7 +7,7 @@ from sentry.utils.samples import load_data
 
 
 class OrganizationEventsHasMeasurementsTest(APITestCase, SnubaTestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.min_ago = before_now(minutes=1)
         self.two_min_ago = before_now(minutes=2)

--- a/tests/snuba/api/endpoints/test_organization_events_histogram.py
+++ b/tests/snuba/api/endpoints/test_organization_events_histogram.py
@@ -25,7 +25,7 @@ ARRAY_COLUMNS = ["measurements", "span_op_breakdowns"]
 
 
 class OrganizationEventsHistogramEndpointTest(APITestCase, SnubaTestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.min_ago = before_now(minutes=1)
         self.data = load_data("transaction")
@@ -1030,7 +1030,7 @@ class OrganizationEventsHistogramEndpointTest(APITestCase, SnubaTestCase):
 class OrganizationEventsMetricsEnhancedPerformanceHistogramEndpointTest(
     MetricsEnhancedPerformanceTestCase
 ):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.min_ago = before_now(minutes=1)
         self.features = {}
@@ -1162,6 +1162,6 @@ class OrganizationEventsMetricsEnhancedPerformanceHistogramEndpointTest(
 class OrganizationEventsMetricsEnhancedPerformanceHistogramEndpointTestWithMetricLayer(
     OrganizationEventsMetricsEnhancedPerformanceHistogramEndpointTest
 ):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.features["organizations:use-metrics-layer"] = True

--- a/tests/snuba/api/endpoints/test_organization_events_histogram.py
+++ b/tests/snuba/api/endpoints/test_organization_events_histogram.py
@@ -29,7 +29,7 @@ class OrganizationEventsHistogramEndpointTest(APITestCase, SnubaTestCase):
         super().setUp()
         self.min_ago = before_now(minutes=1)
         self.data = load_data("transaction")
-        self.features = {}
+        self.features: dict[str, bool] = {}
 
     def populate_events(self, specs):
         start = before_now(minutes=5)
@@ -1033,7 +1033,7 @@ class OrganizationEventsMetricsEnhancedPerformanceHistogramEndpointTest(
     def setUp(self) -> None:
         super().setUp()
         self.min_ago = before_now(minutes=1)
-        self.features = {}
+        self.features: dict[str, bool] = {}
 
     def populate_events(self, specs):
         start = before_now(minutes=5)

--- a/tests/snuba/api/endpoints/test_organization_events_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_mep.py
@@ -55,7 +55,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         "d:transactions/measurements.custom_type@somethingcustom",
     ]
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.transaction_data = load_data("transaction", timestamp=before_now(minutes=1))
         self.features = {
@@ -4070,7 +4070,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithOnDemandMetric
 class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithMetricLayer(
     OrganizationEventsMetricsEnhancedPerformanceEndpointTest
 ):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.features["organizations:use-metrics-layer"] = True
 

--- a/tests/snuba/api/endpoints/test_organization_events_meta.py
+++ b/tests/snuba/api/endpoints/test_organization_events_meta.py
@@ -28,7 +28,7 @@ class OrganizationEventsMetaEndpoint(
     SpanTestCase,
     OurLogTestCase,
 ):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.min_ago = before_now(minutes=1)
         self.login_as(user=self.user)
@@ -317,7 +317,7 @@ class OrganizationEventsMetaEndpoint(
 
 
 class OrganizationEventsRelatedIssuesEndpoint(APITestCase, SnubaTestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
 
     def test_find_related_issue(self) -> None:

--- a/tests/snuba/api/endpoints/test_organization_events_ourlogs.py
+++ b/tests/snuba/api/endpoints/test_organization_events_ourlogs.py
@@ -14,7 +14,7 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase):
     def do_request(self, query, features=None, **kwargs):
         return super().do_request(query, features, **kwargs)
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.features = {
             "organizations:ourlogs-enabled": True,

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -22,7 +22,7 @@ class OrganizationEventsSpansEndpointTest(OrganizationEventsEndpointTestBase):
     def do_request(self, query, features=None, **kwargs):
         return super().do_request(query, features, **kwargs)
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.features = {
             "organizations:starfish-view": True,

--- a/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
@@ -22,7 +22,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         "bar_transaction",
     ]
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.min_ago = before_now(minutes=1)
         self.six_min_ago = before_now(minutes=6)
@@ -2354,7 +2354,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
 class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithMetricLayer(
     OrganizationEventsMetricsEnhancedPerformanceEndpointTest
 ):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.features["organizations:use-metrics-layer"] = True
 

--- a/tests/snuba/api/endpoints/test_organization_events_span_ops.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_ops.py
@@ -9,7 +9,7 @@ from sentry.utils.samples import load_data
 
 
 class OrganizationEventsSpanOpsEndpointBase(APITestCase, SnubaTestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.login_as(user=self.user)
 

--- a/tests/snuba/api/endpoints/test_organization_events_spans_histogram.py
+++ b/tests/snuba/api/endpoints/test_organization_events_spans_histogram.py
@@ -14,7 +14,7 @@ class OrganizationEventsSpansHistogramEndpointTest(APITestCase, SnubaTestCase):
 
     def setUp(self) -> None:
         super().setUp()
-        self.features = {}
+        self.features: dict[str, bool] = {}
         self.login_as(user=self.user)
         self.org = self.create_organization(owner=self.user)
         self.project = self.create_project(organization=self.org)

--- a/tests/snuba/api/endpoints/test_organization_events_spans_histogram.py
+++ b/tests/snuba/api/endpoints/test_organization_events_spans_histogram.py
@@ -12,7 +12,7 @@ class OrganizationEventsSpansHistogramEndpointTest(APITestCase, SnubaTestCase):
     FEATURES = ["organizations:performance-span-histogram-view"]
     URL = "sentry-api-0-organization-events-spans-histogram"
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.features = {}
         self.login_as(user=self.user)

--- a/tests/snuba/api/endpoints/test_organization_events_spans_performance.py
+++ b/tests/snuba/api/endpoints/test_organization_events_spans_performance.py
@@ -20,7 +20,7 @@ class OrganizationEventsSpansEndpointTestBase(APITestCase, SnubaTestCase):
         "organizations:global-views",
     ]
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.login_as(user=self.user)
 

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -36,7 +36,7 @@ class _EventDataDict(TypedDict):
 class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
     endpoint = "sentry-api-0-organization-events-stats"
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.login_as(user=self.user)
         self.authed_user = self.user
@@ -1248,7 +1248,7 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase, SearchIssu
 
 
 class OrganizationEventsStatsTopNEventsSpans(APITestCase, SnubaTestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.login_as(user=self.user)
 
@@ -2827,7 +2827,7 @@ class OrganizationEventsStatsProfileFunctionDatasetEndpointTest(
 ):
     endpoint = "sentry-api-0-organization-events-stats"
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.login_as(user=self.user)
 
@@ -2934,7 +2934,7 @@ class OrganizationEventsStatsTopNEventsProfileFunctionDatasetEndpointTest(
 ):
     endpoint = "sentry-api-0-organization-events-stats"
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.login_as(user=self.user)
 
@@ -3020,7 +3020,7 @@ class OrganizationEventsStatsTopNEventsProfileFunctionDatasetEndpointTest(
 
 class OrganizationEventsStatsTopNEventsLogs(APITestCase, SnubaTestCase, OurLogTestCase):
     # This is implemented almost exactly the same as spans, add a simple test case for a sanity check
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.login_as(user=self.user)
 
@@ -3125,7 +3125,7 @@ class OrganizationEventsStatsTopNEventsLogs(APITestCase, SnubaTestCase, OurLogTe
 
 
 class OrganizationEventsStatsTopNEventsErrors(APITestCase, SnubaTestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.login_as(user=self.user)
 
@@ -3577,7 +3577,7 @@ class OrganizationEventsStatsTopNEventsErrors(APITestCase, SnubaTestCase):
 class OrganizationEventsStatsErrorUpsamplingTest(APITestCase, SnubaTestCase):
     endpoint = "sentry-api-0-organization-events-stats"
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.login_as(user=self.user)
         self.authed_user = self.user

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -81,7 +81,7 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase, SearchIssu
             "sentry-api-0-organization-events-stats",
             kwargs={"organization_id_or_slug": self.project.organization.slug},
         )
-        self.features = {}
+        self.features: dict[str, bool] = {}
 
     def do_request(self, data, url=None, features=None):
         if features is None:

--- a/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
@@ -43,7 +43,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
             "organizations:performance-use-metrics": True,
         }
 
-        self.additional_params = dict()
+        self.additional_params: dict[str, Any] = dict()
 
     # These throughput tests should roughly match the ones in OrganizationEventsStatsEndpointTest
     @pytest.mark.querybuilder

--- a/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
@@ -29,7 +29,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
         "d:transactions/measurements.datacenter_memory@pebibyte",
     ]
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.login_as(user=self.user)
         self.day_ago = before_now(days=1).replace(hour=10, minute=0, second=0, microsecond=0)
@@ -1126,7 +1126,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithOnDemandW
 ):
     endpoint = "sentry-api-0-organization-events-stats"
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.login_as(user=self.user)
         self.day_ago = before_now(days=1).replace(hour=10, minute=0, second=0, microsecond=0)

--- a/tests/snuba/api/endpoints/test_organization_events_stats_ourlogs.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_ourlogs.py
@@ -9,7 +9,7 @@ from tests.snuba.api.endpoints.test_organization_events import OrganizationEvent
 class OrganizationEventsStatsOurlogsEndpointTest(OrganizationEventsEndpointTestBase):
     endpoint = "sentry-api-0-organization-events-stats"
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.login_as(user=self.user)
         self.start = self.day_ago = before_now(days=1).replace(

--- a/tests/snuba/api/endpoints/test_organization_events_stats_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_span_indexed.py
@@ -14,7 +14,7 @@ pytestmark = pytest.mark.sentry_metrics
 class OrganizationEventsStatsSpansEndpointTest(OrganizationEventsEndpointTestBase):
     endpoint = "sentry-api-0-organization-events-stats"
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.login_as(user=self.user)
         self.day_ago = before_now(days=1).replace(hour=10, minute=0, second=0, microsecond=0)

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries.py
@@ -14,7 +14,7 @@ from tests.sentry.issues.test_utils import SearchIssueTestMixin
 class OrganizationEventsTimeseriesEndpointTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
     endpoint = "sentry-api-0-organization-events-timeseries"
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.login_as(user=self.user)
         self.authed_user = self.user

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries_logs.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries_logs.py
@@ -15,7 +15,7 @@ any_confidence = AnyConfidence()
 class OrganizationEventsStatsOurlogsMetricsEndpointTest(OrganizationEventsEndpointTestBase):
     endpoint = "sentry-api-0-organization-events-timeseries"
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.login_as(user=self.user)
         self.start = self.day_ago = before_now(days=1).replace(

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries_spans.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries_spans.py
@@ -64,7 +64,7 @@ any_confidence = AnyConfidence()
 class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpointTestBase):
     endpoint = "sentry-api-0-organization-events-timeseries"
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.login_as(user=self.user)
         self.start = self.day_ago = before_now(days=1).replace(

--- a/tests/snuba/api/endpoints/test_organization_events_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trace.py
@@ -18,7 +18,7 @@ class OrganizationEventsTraceEndpointBase(OrganizationEventsEndpointTestBase, Tr
         "organizations:trace-view-load-more",
     ]
 
-    def setUp(self):
+    def setUp(self) -> None:
         """
         Span structure:
 

--- a/tests/snuba/api/endpoints/test_organization_events_trends.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trends.py
@@ -9,7 +9,7 @@ from sentry.utils.samples import load_data
 
 
 class OrganizationEventsTrendsBase(APITestCase, SnubaTestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.login_as(user=self.user)
 
@@ -48,7 +48,7 @@ class OrganizationEventsTrendsBase(APITestCase, SnubaTestCase):
 
 
 class OrganizationEventsTrendsEndpointTest(OrganizationEventsTrendsBase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.url = reverse(
             "sentry-api-0-organization-events-trends",
@@ -401,7 +401,7 @@ class OrganizationEventsTrendsEndpointTest(OrganizationEventsTrendsBase):
 
 
 class OrganizationEventsTrendsStatsEndpointTest(OrganizationEventsTrendsBase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.url = reverse(
             "sentry-api-0-organization-events-trends-stats",
@@ -830,7 +830,7 @@ class OrganizationEventsTrendsStatsEndpointTest(OrganizationEventsTrendsBase):
 
 
 class OrganizationEventsTrendsPagingTest(APITestCase, SnubaTestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.login_as(user=self.user)
         self.url = reverse(

--- a/tests/snuba/api/endpoints/test_organization_events_uptime_results.py
+++ b/tests/snuba/api/endpoints/test_organization_events_uptime_results.py
@@ -12,7 +12,7 @@ class OrganizationEventsUptimeResultsEndpointTest(
 ):
     dataset = "uptime_results"
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.features = {
             "organizations:uptime-eap-enabled": True,

--- a/tests/snuba/api/endpoints/test_organization_events_vitals.py
+++ b/tests/snuba/api/endpoints/test_organization_events_vitals.py
@@ -12,7 +12,7 @@ pytestmark = pytest.mark.sentry_metrics
 
 
 class OrganizationEventsVitalsEndpointTest(APITestCase, SnubaTestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.start = before_now(days=1).replace(hour=10, minute=0, second=0, microsecond=0)
         self.end = self.start + timedelta(hours=6)
@@ -303,7 +303,7 @@ class OrganizationEventsVitalsEndpointTest(APITestCase, SnubaTestCase):
 class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPerformanceTestCase):
     METRIC_STRINGS = ["measurement_rating"]
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.start = before_now(days=1).replace(hour=10, minute=0, second=0, microsecond=0)
         self.end = self.start + timedelta(hours=6)

--- a/tests/snuba/api/endpoints/test_organization_events_vitals.py
+++ b/tests/snuba/api/endpoints/test_organization_events_vitals.py
@@ -22,7 +22,7 @@ class OrganizationEventsVitalsEndpointTest(APITestCase, SnubaTestCase):
             "start": self.start.isoformat(),
             "end": self.end.isoformat(),
         }
-        self.features = {}
+        self.features: dict[str, bool] = {}
 
     def store_event(self, data, measurements=None, **kwargs):
         if measurements:

--- a/tests/snuba/api/endpoints/test_organization_group_index_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index_stats.py
@@ -9,7 +9,7 @@ from tests.sentry.issues.test_utils import OccurrenceTestMixin
 class GroupListTest(APITestCase, SnubaTestCase, OccurrenceTestMixin):
     endpoint = "sentry-api-0-organization-group-index-stats"
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.min_ago = before_now(minutes=1)
 

--- a/tests/snuba/api/endpoints/test_organization_issues_resolved_in_release.py
+++ b/tests/snuba/api/endpoints/test_organization_issues_resolved_in_release.py
@@ -12,7 +12,7 @@ class OrganizationIssuesResolvedInReleaseEndpointTest(APITestCase, SnubaTestCase
     endpoint = "sentry-api-0-organization-release-resolved"
     method = "get"
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.user = self.create_user()
         self.org = self.create_organization()

--- a/tests/snuba/api/endpoints/test_organization_sessions.py
+++ b/tests/snuba/api/endpoints/test_organization_sessions.py
@@ -86,7 +86,7 @@ def adjust_end(end: datetime.datetime, interval: int) -> datetime.datetime:
 
 
 class OrganizationSessionsEndpointTest(APITestCase, BaseMetricsTestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.setup_fixture()
 

--- a/tests/snuba/api/endpoints/test_organization_stats_summary.py
+++ b/tests/snuba/api/endpoints/test_organization_stats_summary.py
@@ -16,7 +16,7 @@ from sentry.utils.outcomes import Outcome
 class OrganizationStatsSummaryTest(APITestCase, OutcomesSnubaTest):
     _now = datetime.now(UTC).replace(hour=12, minute=27, second=28, microsecond=0)
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
 
         self.login_as(user=self.user)

--- a/tests/snuba/api/endpoints/test_organization_stats_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_stats_v2.py
@@ -12,7 +12,7 @@ class OrganizationStatsTestV2(APITestCase, OutcomesSnubaTest):
 
     _now = datetime.now(UTC).replace(hour=12, minute=27, second=28, microsecond=0)
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
 
         self.login_as(user=self.user)

--- a/tests/snuba/api/endpoints/test_organization_tagkey_values.py
+++ b/tests/snuba/api/endpoints/test_organization_tagkey_values.py
@@ -17,7 +17,7 @@ from tests.sentry.issues.test_utils import OccurrenceTestMixin
 class OrganizationTagKeyTestCase(APITestCase, SnubaTestCase):
     endpoint = "sentry-api-0-organization-tagkey-values"
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.min_ago = before_now(minutes=1)
         self.day_ago = before_now(days=1)
@@ -491,7 +491,7 @@ class OrganizationTagKeyValuesTest(OrganizationTagKeyTestCase):
 
 
 class TransactionTagKeyValues(OrganizationTagKeyTestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         data = load_data("transaction", timestamp=before_now(minutes=1))
         data.update(
@@ -591,7 +591,7 @@ class TransactionTagKeyValues(OrganizationTagKeyTestCase):
 
 
 class ReplayOrganizationTagKeyValuesTest(OrganizationTagKeyTestCase, ReplaysSnubaTestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         replay1_id = uuid.uuid4().hex
         replay2_id = uuid.uuid4().hex
@@ -839,7 +839,7 @@ class ReplayOrganizationTagKeyValuesTest(OrganizationTagKeyTestCase, ReplaysSnub
 
 
 class DatasetParamOrganizationTagKeyValuesTest(OrganizationTagKeyTestCase, OccurrenceTestMixin):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
 
     def run_dataset_test(self, key, expected, dataset: Dataset, **kwargs):

--- a/tests/snuba/api/endpoints/test_organization_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_trace.py
@@ -24,7 +24,7 @@ from sentry.testutils.cases import TestCase
 class TestSerializeColumnarUptimeItem(TestCase):
     """Test serialization of columnar uptime data to span format."""
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.project_slugs = {1: "test-project", 2: "another-project"}
         self.snuba_params = mock.MagicMock(spec=SnubaParams)

--- a/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
@@ -26,7 +26,7 @@ class OrganizationTraceItemAttributesEndpointTestBase(APITestCase, SnubaTestCase
 
     viewname = "sentry-api-0-organization-trace-item-attributes"
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.login_as(user=self.user)
 
@@ -565,7 +565,7 @@ class OrganizationTraceItemAttributeValuesEndpointBaseTest(APITestCase, SnubaTes
 
     viewname = "sentry-api-0-organization-trace-item-attribute-values"
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.login_as(user=self.user)
 

--- a/tests/snuba/api/endpoints/test_organization_trace_item_attributes_ranked.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attributes_ranked.py
@@ -11,7 +11,7 @@ class OrganizationTraceItemsAttributesRankedEndpointTest(
 ):
     view = "sentry-api-0-organization-trace-item-attributes-ranked"
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.login_as(user=self.user)
         self.features = {

--- a/tests/snuba/api/endpoints/test_project_event_details.py
+++ b/tests/snuba/api/endpoints/test_project_event_details.py
@@ -7,7 +7,7 @@ from tests.sentry.issues.test_utils import OccurrenceTestMixin
 
 
 class ProjectEventDetailsTest(APITestCase, SnubaTestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.login_as(user=self.user)
         self.setup_data()
@@ -238,7 +238,7 @@ class ProjectEventDetailsGenericTest(OccurrenceTestMixin, ProjectEventDetailsTes
 
 
 class ProjectEventDetailsTransactionTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.login_as(user=self.user)
         project = self.create_project()
@@ -362,7 +362,7 @@ class ProjectEventDetailsTransactionTest(APITestCase, SnubaTestCase, Performance
 
 
 class ProjectEventJsonEndpointTest(APITestCase, SnubaTestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.login_as(user=self.user)
         self.event_id = "c" * 32
@@ -434,7 +434,7 @@ class ProjectEventJsonEndpointTest(APITestCase, SnubaTestCase):
 
 
 class ProjectEventDetailsTransactionTestScrubbed(APITestCase, SnubaTestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.login_as(user=self.user)
         data = load_data("transaction")

--- a/tests/snuba/api/endpoints/test_project_group_index.py
+++ b/tests/snuba/api/endpoints/test_project_group_index.py
@@ -43,7 +43,7 @@ from sentry.utils import json
 
 
 class GroupListTest(APITestCase, SnubaTestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.min_ago = before_now(minutes=1)
 
@@ -395,7 +395,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
 
 
 class GroupUpdateTest(APITestCase, SnubaTestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.min_ago = timezone.now() - timedelta(minutes=1)
 

--- a/tests/snuba/api/endpoints/test_project_trace_item_details.py
+++ b/tests/snuba/api/endpoints/test_project_trace_item_details.py
@@ -8,7 +8,7 @@ from sentry.testutils.helpers.datetime import before_now
 
 
 class ProjectTraceItemDetailsEndpointTest(APITestCase, SnubaTestCase, OurLogTestCase, SpanTestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.login_as(user=self.user)
         self.features = {

--- a/tests/snuba/incidents/test_tasks.py
+++ b/tests/snuba/incidents/test_tasks.py
@@ -43,7 +43,7 @@ pytestmark = [requires_kafka]
 
 @freeze_time()
 class HandleSnubaQueryUpdateTest(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.topic = Topic.METRICS_SUBSCRIPTIONS_RESULTS
         self.orig_registry = deepcopy(subscriber_registry)
@@ -59,7 +59,7 @@ class HandleSnubaQueryUpdateTest(TestCase):
 
         create_topics(self.cluster, [self.real_topic])
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         super().tearDown()
         subscriber_registry.clear()
         subscriber_registry.update(self.orig_registry)

--- a/tests/snuba/rules/conditions/test_event_frequency.py
+++ b/tests/snuba/rules/conditions/test_event_frequency.py
@@ -68,7 +68,7 @@ class BaseEventFrequencyPercentTest(BaseMetricsTestCase):
 
 
 class EventFrequencyQueryTestBase(SnubaTestCase, RuleTestCase, PerformanceIssueTestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
 
         self.start = before_now(minutes=1)

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -110,7 +110,7 @@ class EventsDatasetTestSetup(SharedSnubaMixin):
     def backend(self):
         return EventsDatasetSnubaSearchBackend()
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.base_datetime = before_now(days=3).replace(microsecond=0)
 
@@ -3009,7 +3009,7 @@ class EventsTransactionsSnubaSearchTest(TestCase, SharedSnubaMixin):
     def backend(self):
         return EventsDatasetSnubaSearchBackend()
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.base_datetime = before_now(days=3)
 
@@ -3376,7 +3376,7 @@ class EventsGenericSnubaSearchTest(TestCase, SharedSnubaMixin, OccurrenceTestMix
     def backend(self):
         return EventsDatasetSnubaSearchBackend()
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.base_datetime = before_now(days=3)
 

--- a/tests/snuba/sessions/test_sessions.py
+++ b/tests/snuba/sessions/test_sessions.py
@@ -1030,7 +1030,7 @@ class GetCrashFreeRateTestCase(TestCase, BaseMetricsTestCase):
 
     backend = MetricsReleaseHealthBackend()
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.session_started = time.time() // 60 * 60
         self.session_started_gt_24_lt_48 = self.session_started - 30 * 60 * 60
@@ -1312,7 +1312,7 @@ class CheckReleasesHaveHealthDataTest(TestCase, BaseMetricsTestCase):
 class CheckNumberOfSessions(TestCase, BaseMetricsTestCase):
     backend = MetricsReleaseHealthBackend()
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         # now_dt should be set to 17:40 of some day not in the future and (system time - now_dt)
         # must be less than 90 days for the metrics DB TTL

--- a/tests/snuba/tagstore/test_tagstore_backend.py
+++ b/tests/snuba/tagstore/test_tagstore_backend.py
@@ -46,7 +46,7 @@ exception = {
 
 
 class TagStorageTest(TestCase, SnubaTestCase, SearchIssueTestMixin, PerformanceIssueTestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
 
         self.ts = SnubaTagStorage()
@@ -1195,7 +1195,7 @@ class TagStorageTest(TestCase, SnubaTestCase, SearchIssueTestMixin, PerformanceI
 
 
 class ProfilingTagStorageTest(TestCase, SnubaTestCase, SearchIssueTestMixin):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.ts = SnubaTagStorage()
 
@@ -1311,7 +1311,7 @@ class BaseSemverTest(TestCase, SnubaTestCase):
 
     KEY: str
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.ts = SnubaTagStorage()
 
@@ -1463,7 +1463,7 @@ class GetTagValuePaginatorForProjectsSemverPackageTest(BaseSemverTest):
 
 
 class GetTagValuePaginatorForProjectsReleaseStageTest(TestCase, SnubaTestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.ts = SnubaTagStorage()
 

--- a/tests/snuba/tsdb/test_tsdb_backend.py
+++ b/tests/snuba/tsdb/test_tsdb_backend.py
@@ -52,7 +52,7 @@ def has_shape(data, shape):
 
 
 class SnubaTSDBTest(TestCase, SnubaTestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
 
         self.db = SnubaTSDB()
@@ -606,7 +606,7 @@ class SnubaTSDBTest(TestCase, SnubaTestCase):
 
 
 class SnubaTSDBGroupProfilingTest(TestCase, SnubaTestCase, SearchIssueTestMixin):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
 
         self.db = SnubaTSDB()
@@ -884,7 +884,7 @@ class SnubaTSDBGroupProfilingTest(TestCase, SnubaTestCase, SearchIssueTestMixin)
 
 
 class AddJitterToSeriesTest(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.db = SnubaTSDB()
 
     def run_test(self, end, interval, jitter, expected_start, expected_end):


### PR DESCRIPTION
These magic test functions always have the same returns! I already messed with some in `tests/sentry`; worth expanding to all of `tests`

```
rg 'def tearDown' tests -ls | xargs sed -i '' 's/def tearDown(self):/def tearDown(self) -> None:/'
rg 'def setUp' tests -ls | xargs sed -i '' 's/def setUp(self):/def setUp(self) -> None:/'
```