### PR TITLE
build(rspack): Add proxy for localhost

### DIFF
--- a/rspack.config.ts
+++ b/rspack.config.ts
@@ -746,6 +746,12 @@ if (IS_UI_DEV_ONLY) {
     },
     proxy: [
       {
+        context: ['/outages/'],
+        target: 'http://localhost:8787',
+        secure: false,
+        changeOrigin: true,
+      },
+      {
         context: ['/api/', '/avatar/', '/organization-avatar/', '/extensions/'],
         target: 'https://sentry.io',
         secure: false,


### PR DESCRIPTION
This PR adds in a proxy when making calls to `/outages` to a locally running api.