### PR TITLE
ref(ui): Remove DropdownAutoCompleteMenu from settings breadcrumbs

### DIFF
--- a/static/app/views/settings/components/settingsBreadcrumb/breadcrumbDropdown.tsx
+++ b/static/app/views/settings/components/settingsBreadcrumb/breadcrumbDropdown.tsx
@@ -1,22 +1,20 @@
-import {useState} from 'react';
+import {useCallback, useContext, useEffect, useRef} from 'react';
+import {useHover} from '@react-aria/interactions';
+import {type OverlayTriggerState} from '@react-stately/overlays';
 
-import DropdownAutoCompleteMenu from 'sentry/components/dropdownAutoComplete/menu';
-import type {Item} from 'sentry/components/dropdownAutoComplete/types';
+import {
+  CompactSelect,
+  type SingleSelectProps,
+} from 'sentry/components/core/compactSelect';
+import {SelectContext} from 'sentry/components/core/compactSelect/control';
 
 import Crumb from './crumb';
 import Divider from './divider';
 import type {RouteWithName} from './types';
 
-interface AdditionalDropdownProps
-  extends Pick<
-    React.ComponentProps<typeof DropdownAutoCompleteMenu>,
-    'onChange' | 'busyItemsStillVisible'
-  > {}
-
-interface BreadcrumbDropdownProps extends AdditionalDropdownProps {
-  items: Item[];
+interface BreadcrumbDropdownProps extends SingleSelectProps<string> {
   name: React.ReactNode;
-  onSelect: (item: Item) => void;
+  onCrumbSelect: (value: string) => void;
   route: RouteWithName;
   hasMenu?: boolean;
   isLast?: boolean;
@@ -27,39 +25,104 @@ function BreadcrumbDropdown({
   route,
   isLast,
   name,
-  onSelect,
-  ...dropdownProps
+  onCrumbSelect,
+  options,
+  value,
+  ...props
 }: BreadcrumbDropdownProps) {
-  const [isActive, setIsActive] = useState(false);
+  const {
+    hoverProps: {onPointerEnter, onPointerLeave},
+    isHovered,
+  } = useHover({});
+
+  if (!hasMenu) {
+    return (
+      <Crumb>
+        <span>{name || route.name} </span>
+        {isLast ? null : <Divider />}
+      </Crumb>
+    );
+  }
 
   return (
-    <DropdownAutoCompleteMenu
-      blendCorner={false}
-      isOpen={isActive}
-      virtualizedHeight={41}
-      onSelect={item => {
-        setIsActive(false);
-        onSelect(item);
+    <CompactSelect<string>
+      searchable
+      options={options.map(item => ({...item, hideCheck: true}))}
+      onChange={selected => {
+        onCrumbSelect(selected.value);
       }}
-      menuProps={{
-        onMouseEnter: () => setIsActive(true),
-        onMouseLeave: () => setIsActive(false),
-      }}
-      {...dropdownProps}
-    >
-      {({getActorProps, isOpen}) => (
-        <Crumb
-          {...getActorProps({
-            onClick: () => setIsActive(false),
-            onMouseEnter: () => setIsActive(true),
-            onMouseLeave: () => setIsActive(false),
-          })}
-        >
-          <span>{name || route.name} </span>
-          {isLast ? null : <Divider isHover={hasMenu && isOpen} />}
-        </Crumb>
+      closeOnSelect
+      onPointerEnter={onPointerEnter}
+      onPointerLeave={onPointerLeave}
+      value={value}
+      trigger={triggerProps => (
+        <MenuCrumb
+          crumbLabel={name || route.name}
+          menuHasHover={isHovered}
+          {...triggerProps}
+        />
       )}
-    </DropdownAutoCompleteMenu>
+      {...props}
+    />
+  );
+}
+
+interface MenuCrumbProps extends React.ComponentProps<typeof Crumb> {
+  crumbLabel: React.ReactNode;
+  menuHasHover: boolean;
+  isLast?: boolean;
+}
+
+// XXX(epurkhiser): We have a couple hacks in place to get hover-activation of
+// our CompactSelect working well for these breadcrumbs.
+//
+// 1. We're using the SelectContext to retrieve the OverlayTriggerState object
+//    for the CompactSelect that will be rendered upon hover. We need this so
+//    we can activate the menu. Using the `isOpen` controlled prop on
+//    CompactSelect does not work since it will not actually focus the menu.
+//
+// 2. We track the active crumb OverlayTriggerState objects so that when
+//    activating a second crumb the first one can be immediately closed,
+//    instead of being closed after the PointerLeave timemout.
+const activeCrumbStates = new Set<OverlayTriggerState | undefined>();
+
+const CLOSE_MENU_TIMEOUT = 250;
+
+function MenuCrumb({crumbLabel, menuHasHover, isLast, ...props}: MenuCrumbProps) {
+  const {overlayState, overlayIsOpen} = useContext(SelectContext);
+  const {open, close} = overlayState ?? {};
+
+  const closeTimeoutRef = useRef<number>(undefined);
+
+  useEffect(() => {
+    activeCrumbStates.add(overlayState);
+    return () => void activeCrumbStates.delete(overlayState);
+  }, [overlayState]);
+
+  const queueMenuClose = useCallback(() => {
+    window.clearTimeout(closeTimeoutRef.current);
+    closeTimeoutRef.current = window.setTimeout(() => close?.(), CLOSE_MENU_TIMEOUT);
+  }, [close]);
+
+  const handleOpen = useCallback(() => {
+    activeCrumbStates.forEach(state => state?.close());
+    window.clearTimeout(closeTimeoutRef.current);
+    open?.();
+  }, [open]);
+
+  useEffect(() => {
+    if (menuHasHover) {
+      window.clearTimeout(closeTimeoutRef.current);
+    } else {
+      queueMenuClose();
+    }
+  }, [menuHasHover, queueMenuClose]);
+
+  return (
+    <Crumb {...props} onPointerEnter={handleOpen} onPointerLeave={queueMenuClose}>
+      <span>{crumbLabel} </span>
+      {isLast ? null : <Divider isHover={overlayIsOpen} />}
+    </Crumb>
   );
 }
 

--- a/static/app/views/settings/components/settingsBreadcrumb/menuItem.tsx
+++ b/static/app/views/settings/components/settingsBreadcrumb/menuItem.tsx
@@ -1,8 +1,0 @@
-import styled from '@emotion/styled';
-
-const MenuItem = styled('div')`
-  font-size: 14px;
-  ${p => p.theme.overflowEllipsis};
-`;
-
-export default MenuItem;

--- a/static/app/views/settings/components/settingsBreadcrumb/projectCrumb.tsx
+++ b/static/app/views/settings/components/settingsBreadcrumb/projectCrumb.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 
+import {ProjectAvatar} from 'sentry/components/core/avatar/projectAvatar';
 import IdBadge from 'sentry/components/idBadge';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {space} from 'sentry/styles/space';
@@ -13,7 +14,6 @@ import type {SettingsBreadcrumbProps} from 'sentry/views/settings/components/set
 
 import BreadcrumbDropdown from './breadcrumbDropdown';
 import findFirstRouteWithoutRouteParam from './findFirstRouteWithoutRouteParam';
-import MenuItem from './menuItem';
 import {CrumbLink} from '.';
 
 function ProjectCrumb({routes, route, ...props}: SettingsBreadcrumbProps) {
@@ -21,7 +21,7 @@ function ProjectCrumb({routes, route, ...props}: SettingsBreadcrumbProps) {
   const {projects} = useProjects();
   const organization = useOrganization();
   const params = useParams();
-  const handleSelect = (item: {value: string}) => {
+  const handleSelect = (projectSlug: string) => {
     // We have to make exceptions for routes like "Project Alerts Rule Edit" or "Client Key Details"
     // Since these models are project specific, we need to traverse up a route when switching projects
     //
@@ -37,7 +37,7 @@ function ProjectCrumb({routes, route, ...props}: SettingsBreadcrumbProps) {
     }
 
     navigate(
-      recreateRoute(returnTo, {routes, params: {...params, projectId: item.value}})
+      recreateRoute(returnTo, {routes, params: {...params, projectId: projectSlug}})
     );
   };
 
@@ -63,20 +63,12 @@ function ProjectCrumb({routes, route, ...props}: SettingsBreadcrumbProps) {
           )}
         </ProjectName>
       }
-      onSelect={handleSelect}
-      items={projects.map((project, index) => ({
-        index,
+      value={activeProject?.slug ?? ''}
+      onCrumbSelect={handleSelect}
+      options={projects.map(project => ({
         value: project.slug,
-        label: (
-          <MenuItem>
-            <IdBadge
-              project={project}
-              avatarProps={{consistentWidth: true}}
-              avatarSize={18}
-              disableLink
-            />
-          </MenuItem>
-        ),
+        leadingItems: <ProjectAvatar project={project} size={20} />,
+        label: project.name,
       }))}
       {...props}
     />

--- a/static/app/views/settings/components/settingsBreadcrumb/teamCrumb.tsx
+++ b/static/app/views/settings/components/settingsBreadcrumb/teamCrumb.tsx
@@ -1,7 +1,6 @@
-import debounce from 'lodash/debounce';
-
+import {TeamAvatar} from 'sentry/components/core/avatar/teamAvatar';
 import IdBadge from 'sentry/components/idBadge';
-import {DEFAULT_DEBOUNCE_DURATION} from 'sentry/constants';
+import {t} from 'sentry/locale';
 import recreateRoute from 'sentry/utils/recreateRoute';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useParams} from 'sentry/utils/useParams';
@@ -9,7 +8,6 @@ import {useTeams} from 'sentry/utils/useTeams';
 import type {SettingsBreadcrumbProps} from 'sentry/views/settings/components/settingsBreadcrumb/types';
 
 import BreadcrumbDropdown from './breadcrumbDropdown';
-import MenuItem from './menuItem';
 import {CrumbLink} from '.';
 
 function TeamCrumb({routes, route, ...props}: SettingsBreadcrumbProps) {
@@ -19,11 +17,6 @@ function TeamCrumb({routes, route, ...props}: SettingsBreadcrumbProps) {
 
   const team = teams.find(({slug}) => slug === params.teamId);
   const hasMenu = teams.length > 1;
-
-  const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    onSearch(e.target.value);
-  };
-  const debouncedHandleSearch = debounce(handleSearchChange, DEFAULT_DEBOUNCE_DURATION);
 
   if (!team) {
     return null;
@@ -37,27 +30,25 @@ function TeamCrumb({routes, route, ...props}: SettingsBreadcrumbProps) {
           <IdBadge avatarSize={18} team={team} />
         </CrumbLink>
       }
-      onSelect={item => {
+      onCrumbSelect={teamSlug => {
         navigate(
           recreateRoute('', {
             routes,
-            params: {...params, teamId: item.value},
+            params: {...params, teamId: teamSlug},
           })
         );
       }}
       hasMenu={hasMenu}
       route={route}
-      items={teams.map((teamItem, index) => ({
-        index,
+      value={team.slug}
+      searchPlaceholder={t('Search Teams')}
+      options={teams.map(teamItem => ({
         value: teamItem.slug,
-        label: (
-          <MenuItem>
-            <IdBadge team={teamItem} />
-          </MenuItem>
-        ),
+        leadingItems: <TeamAvatar team={teamItem} size={16} />,
+        label: `#${teamItem.slug}`,
       }))}
-      onChange={debouncedHandleSearch}
-      busyItemsStillVisible={fetching}
+      onSearch={onSearch}
+      loading={fetching}
       {...props}
     />
   );


### PR DESCRIPTION
The dropdowns are replaced with the CompactSelect component.

There are a couple hacks in here necessary to make hover activation a
good experience. In the future we'll probably want to refactor this
along with our compact select component to natively support some type of
accessible hover activation.

See it in action here https://sentry-nqi0z0e0z.sentry.dev/settings/organization/