### PR TITLE
feat(sentry apps): Add HC methods to fetch sentry apps for an org and update a sentry app

### DIFF
--- a/src/sentry/sentry_apps/services/app/impl.py
+++ b/src/sentry/sentry_apps/services/app/impl.py
@@ -350,7 +350,7 @@ class DatabaseBackedAppService(AppService):
         attrs: SentryAppUpdateArgs,
     ) -> Any:
         try:
-            sentry_app = SentryApp.objects.using_replica().get(id=id)
+            sentry_app = SentryApp.objects.get(id=id)
         except SentryApp.DoesNotExist:
             return None
 

--- a/src/sentry/sentry_apps/services/app/impl.py
+++ b/src/sentry/sentry_apps/services/app/impl.py
@@ -348,7 +348,7 @@ class DatabaseBackedAppService(AppService):
         *,
         id: int,
         attrs: SentryAppUpdateArgs,
-    ) -> Any:
+    ) -> RpcSentryApp | None:
         try:
             sentry_app = SentryApp.objects.get(id=id)
         except SentryApp.DoesNotExist:

--- a/src/sentry/sentry_apps/services/app/impl.py
+++ b/src/sentry/sentry_apps/services/app/impl.py
@@ -340,7 +340,7 @@ class DatabaseBackedAppService(AppService):
         """
         sentry_apps = SentryApp.objects.filter(
             owner_id=organization_id, application__isnull=False
-        ).exclude(status=SentryAppStatus.PUBLISHED)
+        ).exclude(status=SentryAppStatus.DELETION_IN_PROGRESS)
         return [serialize_sentry_app(app) for app in sentry_apps]
 
     def update_sentry_app(

--- a/src/sentry/sentry_apps/services/app/impl.py
+++ b/src/sentry/sentry_apps/services/app/impl.py
@@ -359,7 +359,7 @@ class DatabaseBackedAppService(AppService):
                 setattr(sentry_app, k, v)
             sentry_app.save()
 
-        return serialize(sentry_app)
+        return serialize_sentry_app(sentry_app)
 
     def get_internal_integrations(
         self, *, organization_id: int, integration_name: str

--- a/src/sentry/sentry_apps/services/app/impl.py
+++ b/src/sentry/sentry_apps/services/app/impl.py
@@ -333,6 +333,15 @@ class DatabaseBackedAppService(AppService):
         )
         return [serialize_sentry_app(app) for app in published_apps]
 
+    def get_sentry_apps_for_organization(self, *, organization_id: int) -> list[RpcSentryApp]:
+        """
+        Get active Sentry Apps for a given organization
+        """
+        sentry_apps = SentryApp.objects.filter(
+            owner_id=organization_id, application__isnull=False
+        ).exclude(status=SentryAppStatus.PUBLISHED)
+        return [serialize_sentry_app(app) for app in sentry_apps]
+
     def get_internal_integrations(
         self, *, organization_id: int, integration_name: str
     ) -> list[RpcSentryApp]:

--- a/src/sentry/sentry_apps/services/app/model.py
+++ b/src/sentry/sentry_apps/services/app/model.py
@@ -196,3 +196,9 @@ class SentryAppInstallationFilterArgs(TypedDict, total=False):
     status: int
     api_token_id: int
     api_installation_token_id: str
+
+
+class SentryAppUpdateArgs(TypedDict, total=False):
+    events: list[str]
+    name: str
+    # TODO add whatever else as needed

--- a/src/sentry/sentry_apps/services/app/service.py
+++ b/src/sentry/sentry_apps/services/app/service.py
@@ -199,7 +199,7 @@ class AppService(RpcService):
 
     @rpc_method
     @abc.abstractmethod
-    def update_sentry_app(self, *, id: int, attrs: SentryAppUpdateArgs) -> RpcSentryApp:
+    def update_sentry_app(self, *, id: int, attrs: SentryAppUpdateArgs) -> RpcSentryApp | None:
         pass
 
     @rpc_method

--- a/src/sentry/sentry_apps/services/app/service.py
+++ b/src/sentry/sentry_apps/services/app/service.py
@@ -194,6 +194,11 @@ class AppService(RpcService):
 
     @rpc_method
     @abc.abstractmethod
+    def get_sentry_apps_for_organization(self, *, organization_id: int) -> list[RpcSentryApp]:
+        pass
+
+    @rpc_method
+    @abc.abstractmethod
     def get_internal_integrations(
         self, *, organization_id: int, integration_name: str
     ) -> list[RpcSentryApp]:

--- a/src/sentry/sentry_apps/services/app/service.py
+++ b/src/sentry/sentry_apps/services/app/service.py
@@ -199,7 +199,7 @@ class AppService(RpcService):
 
     @rpc_method
     @abc.abstractmethod
-    def update_sentry_app(self, *, id: int, attrs: SentryAppUpdateArgs) -> list[RpcSentryApp]:
+    def update_sentry_app(self, *, id: int, attrs: SentryAppUpdateArgs) -> RpcSentryApp:
         pass
 
     @rpc_method

--- a/src/sentry/sentry_apps/services/app/service.py
+++ b/src/sentry/sentry_apps/services/app/service.py
@@ -20,7 +20,7 @@ from sentry.sentry_apps.services.app import (
     RpcSentryAppService,
     SentryAppInstallationFilterArgs,
 )
-from sentry.sentry_apps.services.app.model import RpcSentryAppComponentContext
+from sentry.sentry_apps.services.app.model import RpcSentryAppComponentContext, SentryAppUpdateArgs
 from sentry.silo.base import SiloMode
 from sentry.users.services.user import RpcUser
 
@@ -195,6 +195,11 @@ class AppService(RpcService):
     @rpc_method
     @abc.abstractmethod
     def get_sentry_apps_for_organization(self, *, organization_id: int) -> list[RpcSentryApp]:
+        pass
+
+    @rpc_method
+    @abc.abstractmethod
+    def update_sentry_app(self, *, id: int, attrs: SentryAppUpdateArgs) -> list[RpcSentryApp]:
         pass
 
     @rpc_method

--- a/tests/sentry/sentry_apps/services/test_app.py
+++ b/tests/sentry/sentry_apps/services/test_app.py
@@ -240,6 +240,26 @@ def test_get_installation_org_id_by_token_id() -> None:
 
 @django_db_all(transaction=True)
 @all_silo_test
+def test_get_sentry_apps_for_organization() -> None:
+    org = Factories.create_organization()
+    other_org = Factories.create_organization()
+
+    # Create internal integrations
+    Factories.create_internal_integration(
+        name="Test Integration",
+        organization_id=org.id,
+    )
+    Factories.create_internal_integration(
+        name="Test Integration",
+        organization_id=other_org.id,
+    )
+    result = app_service.get_sentry_apps_for_organization(organization_id=org.id)
+    assert len(result) == 1
+    assert result[0].owner_id == org.id
+
+
+@django_db_all(transaction=True)
+@all_silo_test
 def test_get_internal_integrations() -> None:
     org = Factories.create_organization()
     other_org = Factories.create_organization()

--- a/tests/sentry/sentry_apps/services/test_app.py
+++ b/tests/sentry/sentry_apps/services/test_app.py
@@ -260,6 +260,26 @@ def test_get_sentry_apps_for_organization() -> None:
 
 @django_db_all(transaction=True)
 @all_silo_test
+def test_update_sentry_app() -> None:
+    org = Factories.create_organization()
+
+    sentry_app = Factories.create_internal_integration(
+        name="Test Integration",
+        organization_id=org.id,
+        events=[
+            "issue.resolved",
+            "issue.unresolved",
+            "issue.ignored",
+            "issue.assigned",
+            "error.created",
+        ],
+    )
+    result = app_service.update_sentry_app(id=sentry_app.id, attrs=dict(events=["error.created"]))
+    assert result["events"] == ["error.created"]
+
+
+@django_db_all(transaction=True)
+@all_silo_test
 def test_get_internal_integrations() -> None:
     org = Factories.create_organization()
     other_org = Factories.create_organization()

--- a/tests/sentry/sentry_apps/services/test_app.py
+++ b/tests/sentry/sentry_apps/services/test_app.py
@@ -275,7 +275,7 @@ def test_update_sentry_app() -> None:
         ],
     )
     result = app_service.update_sentry_app(id=sentry_app.id, attrs=dict(events=["error.created"]))
-    assert result["events"] == ["error.created"]
+    assert result.events == ["error.created"]
 
 
 @django_db_all(transaction=True)

--- a/tests/sentry/sentry_apps/services/test_app.py
+++ b/tests/sentry/sentry_apps/services/test_app.py
@@ -275,6 +275,7 @@ def test_update_sentry_app() -> None:
         ],
     )
     result = app_service.update_sentry_app(id=sentry_app.id, attrs=dict(events=["error.created"]))
+    assert result
     assert result.events == ["error.created"]
 
 


### PR DESCRIPTION
Add a method to `app_service` to fetch all active (not pending deletion) sentry apps for an organization and a method to update a sentry app. Used for https://github.com/getsentry/getsentry/pull/18204