### PR TITLE
feat(ourlogs): Add pii scrubbing reason tooltip to logs scrubbed fields

### DIFF
--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -57,6 +57,7 @@ import {decodeScalar} from 'sentry/utils/queryString';
 import {isUrl} from 'sentry/utils/string/isUrl';
 import {QuickContextHoverWrapper} from 'sentry/views/discover/table/quickContext/quickContextWrapper';
 import {ContextType} from 'sentry/views/discover/table/quickContext/utils';
+import type {TraceItemDetailsMeta} from 'sentry/views/explore/hooks/useTraceItemDetails';
 import {PerformanceBadge} from 'sentry/views/insights/browser/webVitals/components/performanceBadge';
 import {PercentChangeCell} from 'sentry/views/insights/common/components/tableCells/percentChangeCell';
 import {ResponseStatusCodeCell} from 'sentry/views/insights/common/components/tableCells/responseStatusCodeCell';
@@ -105,6 +106,11 @@ export type RenderFunctionBaggage = {
   disableLazyLoad?: boolean;
   eventView?: EventView;
   projectSlug?: string;
+  /**
+   * The trace item meta data for the trace item, which includes information needed to render annotated tooltip (eg. scrubbing reasons)
+   */
+  traceItemMeta?: TraceItemDetailsMeta;
+
   unit?: string;
 };
 

--- a/static/app/views/explore/components/annotatedAttributeTooltip.tsx
+++ b/static/app/views/explore/components/annotatedAttributeTooltip.tsx
@@ -23,7 +23,7 @@ export function AnnotatedAttributeTooltip({
     {
       staleTime: Infinity,
       retry: false,
-      enabled: !!extra.project?.slug && !!fieldKey && !!extra.meta,
+      enabled: !!extra.project?.slug && !!fieldKey && !!extra.traceItemMeta,
       notifyOnChangeProps: ['data'],
     }
   );

--- a/static/app/views/explore/components/annotatedAttributeTooltip.tsx
+++ b/static/app/views/explore/components/annotatedAttributeTooltip.tsx
@@ -4,7 +4,7 @@ import {Tooltip} from 'sentry/components/core/tooltip';
 import type {Project} from 'sentry/types/project';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import type {RendererExtra} from 'sentry/views/explore/logs/fieldRenderers';
-import {TraceItemMetaInfo} from 'sentry/views/explore/logs/utils';
+import {TraceItemMetaInfo} from 'sentry/views/explore/utils';
 
 export function AnnotatedAttributeTooltip({
   children,
@@ -12,7 +12,7 @@ export function AnnotatedAttributeTooltip({
   fieldKey,
 }: {
   children: React.ReactNode;
-  extra: RendererExtra;
+  extra: Pick<RendererExtra, 'traceItemMeta' | 'organization' | 'project'>;
   fieldKey?: string;
 }) {
   // Fetch full project details including `project.relayPiiConfig`

--- a/static/app/views/explore/components/annotatedAttributeTooltip.tsx
+++ b/static/app/views/explore/components/annotatedAttributeTooltip.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+
+import {Tooltip} from 'sentry/components/core/tooltip';
+import type {Project} from 'sentry/types/project';
+import {useApiQuery} from 'sentry/utils/queryClient';
+import type {RendererExtra} from 'sentry/views/explore/logs/fieldRenderers';
+import {TraceItemMetaInfo} from 'sentry/views/explore/logs/utils';
+
+export function AnnotatedAttributeTooltip({
+  children,
+  extra,
+  fieldKey,
+}: {
+  children: React.ReactNode;
+  extra: RendererExtra;
+  fieldKey?: string;
+}) {
+  // Fetch full project details including `project.relayPiiConfig`
+  // That property is not normally available in the store.
+  // Taken from FilteredAnnotatedTextValue.tsx
+  const {data: projectDetails} = useApiQuery<Project>(
+    [`/projects/${extra.organization.slug}/${extra.project?.slug}/`],
+    {
+      staleTime: Infinity,
+      retry: false,
+      enabled: !!extra.project?.slug && !!fieldKey && !!extra.meta,
+      notifyOnChangeProps: ['data'],
+    }
+  );
+
+  // Check if there's meta information for this field
+  if (!fieldKey || !extra.traceItemMeta) {
+    return <React.Fragment>{children}</React.Fragment>;
+  }
+
+  const metaTooltip = TraceItemMetaInfo.getTooltipText(
+    fieldKey,
+    extra.traceItemMeta,
+    extra.organization,
+    projectDetails
+  );
+
+  if (!metaTooltip) {
+    return <React.Fragment>{children}</React.Fragment>;
+  }
+
+  return (
+    <Tooltip title={metaTooltip} isHoverable>
+      {children}
+    </Tooltip>
+  );
+}

--- a/static/app/views/explore/components/traceItemAttributes/attributesTreeValue.tsx
+++ b/static/app/views/explore/components/traceItemAttributes/attributesTreeValue.tsx
@@ -7,7 +7,7 @@ import {type RenderFunctionBaggage} from 'sentry/utils/discover/fieldRenderers';
 import {isUrl} from 'sentry/utils/string/isUrl';
 import {AnnotatedAttributeTooltip} from 'sentry/views/explore/components/annotatedAttributeTooltip';
 import {getAttributeItem} from 'sentry/views/explore/components/traceItemAttributes/utils';
-import {TraceItemMetaInfo} from 'sentry/views/explore/logs/utils';
+import {TraceItemMetaInfo} from 'sentry/views/explore/utils';
 
 import type {
   AttributesFieldRender,

--- a/static/app/views/explore/components/traceItemAttributes/attributesTreeValue.tsx
+++ b/static/app/views/explore/components/traceItemAttributes/attributesTreeValue.tsx
@@ -5,7 +5,9 @@ import {openNavigateToExternalLinkModal} from 'sentry/actionCreators/modal';
 import ExternalLink from 'sentry/components/links/externalLink';
 import {type RenderFunctionBaggage} from 'sentry/utils/discover/fieldRenderers';
 import {isUrl} from 'sentry/utils/string/isUrl';
+import {AnnotatedAttributeTooltip} from 'sentry/views/explore/components/annotatedAttributeTooltip';
 import {getAttributeItem} from 'sentry/views/explore/components/traceItemAttributes/utils';
+import {TraceItemMetaInfo} from 'sentry/views/explore/logs/utils';
 
 import type {
   AttributesFieldRender,
@@ -45,6 +47,16 @@ export function AttributesTreeValue<RendererExtra extends RenderFunctionBaggage>
     });
   }
 
+  if (renderExtra.traceItemMeta) {
+    const metaInfo = new TraceItemMetaInfo(renderExtra.traceItemMeta);
+    if (metaInfo.hasRemarks(attributeKey)) {
+      return (
+        <AnnotatedAttributeTooltip fieldKey={attributeKey} extra={renderExtra}>
+          {defaultValue}
+        </AnnotatedAttributeTooltip>
+      );
+    }
+  }
   return isUrl(String(content.value)) ? (
     <AttributeLinkText>
       <ExternalLink

--- a/static/app/views/explore/hooks/useTraceItemDetails.tsx
+++ b/static/app/views/explore/hooks/useTraceItemDetails.tsx
@@ -2,6 +2,7 @@ import {useState} from 'react';
 import {useHover} from '@react-aria/interactions';
 import {captureException} from '@sentry/react';
 
+import type {Meta} from 'sentry/types/group';
 import {useApiQuery, type ApiQueryKey} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjectFromId from 'sentry/utils/useProjectFromId';
@@ -39,10 +40,21 @@ interface UseTraceItemDetailsProps {
   enabled?: boolean;
 }
 
+export type TraceItemAttributeMeta = Pick<Meta, 'len' | 'rem'>;
+interface TraceItemDetailsMetaRecord {
+  meta: {
+    value: {
+      '': TraceItemAttributeMeta;
+    };
+  };
+}
+
+export type TraceItemDetailsMeta = Record<string, TraceItemDetailsMetaRecord>;
+
 export interface TraceItemDetailsResponse {
   attributes: TraceItemResponseAttribute[];
   itemId: string;
-  meta: Record<string, any>;
+  meta: TraceItemDetailsMeta;
   timestamp: string;
   links?: TraceItemResponseLink[];
 }

--- a/static/app/views/explore/logs/fieldRenderers.tsx
+++ b/static/app/views/explore/logs/fieldRenderers.tsx
@@ -7,6 +7,7 @@ import {DateTime} from 'sentry/components/dateTime';
 import useStacktraceLink from 'sentry/components/events/interfaces/frame/useStacktraceLink';
 import Version from 'sentry/components/version';
 import {tct} from 'sentry/locale';
+import type {Project} from 'sentry/types/project';
 import {defined} from 'sentry/utils';
 import {stripAnsi} from 'sentry/utils/ansiEscapeCodes';
 import type {EventsMetaType} from 'sentry/utils/discover/eventView';
@@ -20,9 +21,13 @@ import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useRelease} from 'sentry/utils/useRelease';
 import {QuickContextHoverWrapper} from 'sentry/views/discover/table/quickContext/quickContextWrapper';
 import {ContextType} from 'sentry/views/discover/table/quickContext/utils';
+import {AnnotatedAttributeTooltip} from 'sentry/views/explore/components/annotatedAttributeTooltip';
 import type {AttributesFieldRendererProps} from 'sentry/views/explore/components/traceItemAttributes/attributesTree';
 import {stripLogParamsFromLocation} from 'sentry/views/explore/contexts/logs/logsPageParams';
-import type {TraceItemResponseAttribute} from 'sentry/views/explore/hooks/useTraceItemDetails';
+import type {
+  TraceItemDetailsResponse,
+  TraceItemResponseAttribute,
+} from 'sentry/views/explore/hooks/useTraceItemDetails';
 import {LOG_ATTRIBUTE_LAZY_LOAD_HOVER_TIMEOUT} from 'sentry/views/explore/logs/constants';
 import LogsTimestampTooltip from 'sentry/views/explore/logs/logsTimeTooltip';
 import {
@@ -47,6 +52,7 @@ import {
   logsFieldAlignment,
   SeverityLevel,
   severityLevelToText,
+  TraceItemMetaInfo,
 } from 'sentry/views/explore/logs/utils';
 import {TraceViewSources} from 'sentry/views/performance/newTraceDetails/traceHeader/breadcrumbs';
 import {getTraceDetailsUrl} from 'sentry/views/performance/traceDetails/utils';
@@ -62,8 +68,11 @@ export interface RendererExtra extends RenderFunctionBaggage {
   highlightTerms: string[];
   logColors: ReturnType<typeof getLogColors>;
   align?: 'left' | 'center' | 'right';
+  meta?: EventsMetaType;
+  project?: Project;
   projectSlug?: string;
   shouldRenderHoverElements?: boolean;
+  traceItemMeta?: TraceItemDetailsResponse['meta'];
   useFullSeverityText?: boolean;
   wrapBody?: true;
 }
@@ -250,6 +259,11 @@ function useLazyLoadAttributeOnHover(hoverTimeout: number, props: LogFieldRender
   };
 }
 
+/**
+ * This should only wrap the 'body' attribute as it is the only 'field' that is not returned by the trace-items endpoint (since it is not an attribute but rather a field).
+ *
+ * Once the trace-items endpoint returns 'body', we can remove this component.
+ */
 function FilteredTooltip({
   value,
   children,
@@ -346,13 +360,11 @@ export function LogBodyRenderer(props: LogFieldRendererProps) {
 
 function LogTemplateRenderer(props: LogFieldRendererProps) {
   return (
-    <FilteredTooltip value={props.item.value} extra={props.extra}>
-      <span>
-        {typeof props.item.value === 'string'
-          ? stripAnsi(props.item.value)
-          : props.basicRendered}
-      </span>
-    </FilteredTooltip>
+    <span>
+      {typeof props.item.value === 'string'
+        ? stripAnsi(props.item.value)
+        : props.basicRendered}
+    </span>
   );
 }
 
@@ -399,14 +411,38 @@ export function LogFieldRenderer(props: LogFieldRendererProps) {
   const align = logsFieldAlignment(adjustedFieldKey, type);
 
   if (!customRenderer) {
-    return <Fragment>{basicRendered}</Fragment>;
+    return (
+      <AnnotatedAttributeWrapper extra={props.extra} fieldKey={props.item.fieldKey}>
+        {basicRendered}
+      </AnnotatedAttributeWrapper>
+    );
   }
 
   return (
-    <AlignedCellContent align={align}>
-      {customRenderer({...props, basicRendered})}
-    </AlignedCellContent>
+    <AnnotatedAttributeWrapper extra={props.extra} fieldKey={props.item.fieldKey}>
+      <AlignedCellContent align={align}>
+        {customRenderer({...props, basicRendered})}
+      </AlignedCellContent>
+    </AnnotatedAttributeWrapper>
   );
+}
+
+function AnnotatedAttributeWrapper(props: {
+  children: React.ReactNode;
+  extra: RendererExtra;
+  fieldKey: string;
+}) {
+  if (props.extra.traceItemMeta) {
+    const metaInfo = new TraceItemMetaInfo(props.extra.traceItemMeta);
+    if (metaInfo.hasRemarks(props.fieldKey)) {
+      return (
+        <AnnotatedAttributeTooltip extra={props.extra} fieldKey={props.fieldKey}>
+          {props.children}
+        </AnnotatedAttributeTooltip>
+      );
+    }
+  }
+  return props.children;
 }
 
 /**

--- a/static/app/views/explore/logs/fieldRenderers.tsx
+++ b/static/app/views/explore/logs/fieldRenderers.tsx
@@ -49,6 +49,7 @@ import {
 import {
   adjustLogTraceID,
   getLogSeverityLevel,
+  logOnceFactory,
   logsFieldAlignment,
   SeverityLevel,
   severityLevelToText,
@@ -427,6 +428,8 @@ export function LogFieldRenderer(props: LogFieldRendererProps) {
   );
 }
 
+const logInfoOnceHasRemarks = logOnceFactory('info');
+
 function AnnotatedAttributeWrapper(props: {
   children: React.ReactNode;
   extra: RendererExtra;
@@ -435,6 +438,23 @@ function AnnotatedAttributeWrapper(props: {
   if (props.extra.traceItemMeta) {
     const metaInfo = new TraceItemMetaInfo(props.extra.traceItemMeta);
     if (metaInfo.hasRemarks(props.fieldKey)) {
+      try {
+        logInfoOnceHasRemarks(
+          `AnnotatedAttributeWrapper: ${props.fieldKey} has remarks, rendering tooltip`,
+          {
+            organization: props.extra.organization,
+            project: props.extra.project,
+            text: TraceItemMetaInfo.getTooltipText(
+              props.fieldKey,
+              props.extra.traceItemMeta,
+              props.extra.organization,
+              props.extra.project
+            ),
+          }
+        );
+      } catch {
+        // defensive
+      }
       return (
         <AnnotatedAttributeTooltip extra={props.extra} fieldKey={props.fieldKey}>
           {props.children}

--- a/static/app/views/explore/logs/fieldRenderers.tsx
+++ b/static/app/views/explore/logs/fieldRenderers.tsx
@@ -52,8 +52,8 @@ import {
   logsFieldAlignment,
   SeverityLevel,
   severityLevelToText,
-  TraceItemMetaInfo,
 } from 'sentry/views/explore/logs/utils';
+import {TraceItemMetaInfo} from 'sentry/views/explore/utils';
 import {TraceViewSources} from 'sentry/views/performance/newTraceDetails/traceHeader/breadcrumbs';
 import {getTraceDetailsUrl} from 'sentry/views/performance/traceDetails/utils';
 

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.spec.tsx
@@ -5,6 +5,7 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {
+  act,
   render,
   screen,
   userEvent,
@@ -254,7 +255,9 @@ describe('LogsInfiniteTable', () => {
     for (const row of allTreeRows) {
       for (const field of visibleColumnFields) {
         await userEvent.hover(row, {delay: null});
-        jest.advanceTimersByTime(DEFAULT_TRACE_ITEM_HOVER_TIMEOUT + 1);
+        act(() => {
+          jest.advanceTimersByTime(DEFAULT_TRACE_ITEM_HOVER_TIMEOUT + 1);
+        });
         const cell = await within(row).findByTestId(`log-table-cell-${field}`);
         const actionsButton = within(cell).queryByRole('button', {
           name: 'Actions',

--- a/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
@@ -4,7 +4,7 @@ import {ProjectFixture} from 'sentry-fixture/project';
 import {ReleaseFixture} from 'sentry-fixture/release';
 import {UserFixture} from 'sentry-fixture/user';
 
-import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
@@ -85,6 +85,14 @@ describe('logsTableRow', () => {
     [OurLogKnownFieldKey.RELEASE]: release.version, // Needed otherwise stacktrace link will also not load
   });
 
+  const rowDataWithScrubbedFields = LogFixture({
+    [OurLogKnownFieldKey.ID]: '3',
+    [OurLogKnownFieldKey.PROJECT_ID]: project.id,
+    [OurLogKnownFieldKey.ORGANIZATION_ID]: Number(organization.id),
+    password: '[Filtered]',
+    not_zzz_not_exact_match: 'redacted2',
+  });
+
   const initialRouterConfig = {
     location: {
       pathname: `/organizations/${organization.slug}/explore/logs/`,
@@ -102,6 +110,22 @@ describe('logsTableRow', () => {
       ...initialRouterConfig.location,
       query: {
         [LOGS_FIELDS_KEY]: ['timestamp', 'message', OurLogKnownFieldKey.CODE_FILE_PATH],
+        [LOGS_SORT_BYS_KEY]: '-timestamp',
+      },
+    },
+  };
+
+  const initialRouterConfigWithScrubbedFields = {
+    ...initialRouterConfig,
+    location: {
+      ...initialRouterConfig.location,
+      query: {
+        [LOGS_FIELDS_KEY]: [
+          'timestamp',
+          'message',
+          'password',
+          'not_zzz_not_exact_match',
+        ],
         [LOGS_SORT_BYS_KEY]: '-timestamp',
       },
     },
@@ -173,6 +197,21 @@ describe('logsTableRow', () => {
         ),
       },
     });
+
+    // Mock for project details needed by AnnotatedAttributeTooltip (pii config)
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/`,
+      method: 'GET',
+      body: {
+        ...project,
+        relayPiiConfig: JSON.stringify({
+          rules: {
+            0: {type: 'mac', redaction: {method: 'replace', text: 'ITS_GONE'}},
+          },
+          applications: {not_zzz_not_exact_match: ['0']},
+        }),
+      },
+    });
   });
 
   it('hovering the row causes prefetching of the row details', async () => {
@@ -200,7 +239,10 @@ describe('logsTableRow', () => {
     expect(rowDetailsMock).toHaveBeenCalledTimes(0);
     expect(screen.getByLabelText('Toggle trace details')).toBeInTheDocument(); // Real button immediately rendered
 
-    jest.advanceTimersByTime(DEFAULT_TRACE_ITEM_HOVER_TIMEOUT + 1);
+    // Wrap timer advancement in act to avoid warnings
+    act(() => {
+      jest.advanceTimersByTime(DEFAULT_TRACE_ITEM_HOVER_TIMEOUT + 1);
+    });
 
     await waitFor(() => {
       // Prefetching is triggered after the hover timeout
@@ -453,5 +495,102 @@ describe('logsTableRow', () => {
     expect(parsedData).toHaveProperty('item_id', '1');
     expect(parsedData[OurLogKnownFieldKey.TIMESTAMP_PRECISE]).toBeDefined();
     expect(parsedData).not.toHaveProperty('sentry.item_id');
+  });
+
+  it('renders fields with data scrubbing meta information', async () => {
+    const traceItemMock = MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/trace-items/${rowDataWithScrubbedFields[OurLogKnownFieldKey.ID]}/`,
+      method: 'GET',
+      body: {
+        itemId: rowDataWithScrubbedFields[OurLogKnownFieldKey.ID],
+        links: null,
+        timestamp: rowDataWithScrubbedFields[OurLogKnownFieldKey.TIMESTAMP],
+        attributes: Object.entries(rowDataWithScrubbedFields).map(
+          ([k, v]) =>
+            ({
+              name: k,
+              value: v,
+              type: typeof v === 'string' ? 'str' : 'float',
+            }) as TraceItemResponseAttribute
+        ),
+        meta: {
+          password: {
+            meta: {
+              value: {
+                '': {
+                  rem: [['@password:filter', 's', 0, 10]],
+                  len: 9,
+                },
+              },
+            },
+          },
+          not_zzz_not_exact_match: {
+            meta: {
+              value: {
+                '': {
+                  rem: [['project:0', 's', 0, 10]],
+                  len: 15,
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    render(
+      <ProviderWrapper>
+        <LogRowContent
+          dataRow={rowDataWithScrubbedFields}
+          highlightTerms={[]}
+          meta={LogFixtureMeta(rowDataWithScrubbedFields)}
+          sharedHoverTimeoutRef={
+            {
+              current: null,
+            } as React.MutableRefObject<NodeJS.Timeout | null>
+          }
+          canDeferRenderElements={false}
+        />
+      </ProviderWrapper>,
+      {organization, initialRouterConfig: initialRouterConfigWithScrubbedFields}
+    );
+
+    const logTableRow = await screen.findByTestId('log-table-row');
+    expect(logTableRow).toBeInTheDocument();
+
+    expect(traceItemMock).toHaveBeenCalledTimes(0);
+    await userEvent.hover(logTableRow);
+
+    await waitFor(() => {
+      expect(traceItemMock).toHaveBeenCalledTimes(1);
+    });
+
+    const passwordCell = screen.getByTestId('log-table-cell-password');
+    const customRuleCell = screen.getByTestId('log-table-cell-not_zzz_not_exact_match');
+
+    expect(passwordCell).toBeInTheDocument();
+    expect(passwordCell).toHaveTextContent('[Filtered]');
+    expect(customRuleCell).toBeInTheDocument();
+    expect(customRuleCell).toHaveTextContent('redacted2');
+
+    const filteredText = screen.getByText(/Filtered/);
+    await userEvent.hover(filteredText);
+
+    expect(
+      await screen.findByText(
+        /because of a data scrubbing rule in the settings of the project/
+      )
+    ).toBeInTheDocument();
+
+    await userEvent.unhover(filteredText);
+
+    const redactedText = screen.getByText(/redacted2/);
+    await userEvent.hover(redactedText);
+
+    expect(
+      await screen.findByText(
+        /\[Replace\] \[MAC addresses\] with \[ITS_GONE\] from \[not_zzz_not_exact_match\]/
+      )
+    ).toBeInTheDocument();
   });
 });

--- a/static/app/views/explore/logs/useLogsQuery.tsx
+++ b/static/app/views/explore/logs/useLogsQuery.tsx
@@ -31,10 +31,7 @@ import {
   useLogsSearch,
   useLogsSortBys,
 } from 'sentry/views/explore/contexts/logs/logsPageParams';
-import {
-  usePrefetchTraceItemDetailsOnHover,
-  useTraceItemDetails,
-} from 'sentry/views/explore/hooks/useTraceItemDetails';
+import {useTraceItemDetails} from 'sentry/views/explore/hooks/useTraceItemDetails';
 import {
   AlwaysPresentLogFields,
   MAX_LOG_INGEST_DELAY,
@@ -74,33 +71,6 @@ export function useExploreLogsTableRow(props: {
     traceItemType: TraceItemDataset.LOGS,
     referrer: 'api.explore.log-item-details',
     enabled: props.enabled && pageFiltersReady,
-  });
-}
-
-export function usePrefetchLogTableRowOnHover({
-  logId,
-  projectId,
-  traceId,
-  hoverPrefetchDisabled,
-  sharedHoverTimeoutRef,
-  timeout,
-}: {
-  logId: string | number;
-  projectId: string;
-  sharedHoverTimeoutRef: React.MutableRefObject<NodeJS.Timeout | null>;
-  timeout: number;
-  traceId: string;
-  hoverPrefetchDisabled?: boolean;
-}) {
-  return usePrefetchTraceItemDetailsOnHover({
-    traceItemId: String(logId),
-    projectId,
-    traceId,
-    traceItemType: TraceItemDataset.LOGS,
-    hoverPrefetchDisabled,
-    sharedHoverTimeoutRef,
-    timeout,
-    referrer: 'api.explore.log-item-details',
   });
 }
 

--- a/static/app/views/explore/logs/utils.tsx
+++ b/static/app/views/explore/logs/utils.tsx
@@ -504,3 +504,19 @@ export function ourlogToJson(ourlog: TraceItemDetailsResponse | undefined): stri
   }
   return JSON.stringify(copy, null, 2);
 }
+
+export const logOnceFactory = (logSeverity: 'info' | 'warn') => {
+  let fired = false;
+  return (...args: Parameters<(typeof Sentry.logger)[typeof logSeverity]>) => {
+    if (!fired) {
+      fired = true;
+      if (logSeverity === 'info') {
+        return Sentry.logger.info(args[0], args[1]);
+      }
+      return Sentry.logger.warn(args[0], args[1]);
+    }
+    return () => {
+      // Do nothing
+    };
+  };
+};

--- a/static/app/views/explore/types.tsx
+++ b/static/app/views/explore/types.tsx
@@ -20,10 +20,3 @@ export interface UseTraceItemAttributeBaseProps {
    */
   projects?: Project[];
 }
-
-export interface TraceItemMetaRemark {
-  ruleId: string;
-  type: string;
-  rangeEnd?: number;
-  rangeStart?: number;
-}

--- a/static/app/views/explore/types.tsx
+++ b/static/app/views/explore/types.tsx
@@ -20,3 +20,10 @@ export interface UseTraceItemAttributeBaseProps {
    */
   projects?: Project[];
 }
+
+export interface TraceItemMetaRemark {
+  ruleId: string;
+  type: string;
+  rangeEnd?: number;
+  rangeStart?: number;
+}


### PR DESCRIPTION
### Summary
This adds the scrubbing reason as a tooltip when hovering the 'Filtered' etc. scrubbed text

#### Screenshots
<img width="431" height="243" alt="Screenshot 2025-08-21 at 6 38 54 PM" src="https://github.com/user-attachments/assets/7a4a1bb5-bbda-4df0-84ca-84042124c630" />


Closes LOGS-81