### PR TITLE
fix(ourlogs): Fix logs widget viewer link

### DIFF
--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -1181,6 +1181,10 @@ function OpenButton({
       openLabel = t('Open in Explore');
       path = getWidgetExploreUrl(widget, dashboardFilters, selection, organization);
       break;
+    case WidgetType.LOGS:
+      openLabel = t('Open in Explore');
+      path = getWidgetExploreUrl(widget, dashboardFilters, selection, organization);
+      break;
     case WidgetType.DISCOVER:
     default:
       openLabel = t('Open in Discover');


### PR DESCRIPTION
### Summary
Should say 'open in explore' and link to the correct logs page

#### Screenshots
<img width="1145" height="555" alt="Screenshot 2025-08-22 at 12 03 12 PM" src="https://github.com/user-attachments/assets/1750a00f-7022-4dcc-ba25-115958958776" />
