### PR TITLE
feat: Show delete loading state in a single row

### DIFF
--- a/static/app/views/settings/project/tempest/CredentialRow.tsx
+++ b/static/app/views/settings/project/tempest/CredentialRow.tsx
@@ -14,14 +14,13 @@ import {MessageType, type TempestCredentials} from './types';
 
 export function CredentialRow({
   credential,
-  removingCredentialId,
+  isRemoving,
   removeCredential,
 }: {
   credential: TempestCredentials;
+  isRemoving: boolean;
   removeCredential?: (data: {id: number}) => void;
-  removingCredentialId?: number;
 }) {
-  const isRemoving = removingCredentialId === credential.id;
   return (
     <Fragment>
       <Flex align="center" gap="md">

--- a/static/app/views/settings/project/tempest/CredentialRow.tsx
+++ b/static/app/views/settings/project/tempest/CredentialRow.tsx
@@ -14,13 +14,14 @@ import {MessageType, type TempestCredentials} from './types';
 
 export function CredentialRow({
   credential,
-  isRemoving,
+  removingCredentialId,
   removeCredential,
 }: {
   credential: TempestCredentials;
-  isRemoving: boolean;
   removeCredential?: (data: {id: number}) => void;
+  removingCredentialId?: number;
 }) {
+  const isRemoving = removingCredentialId === credential.id;
   return (
     <Fragment>
       <Flex align="center" gap="md">

--- a/static/app/views/settings/project/tempest/PlayStationSettings.tsx
+++ b/static/app/views/settings/project/tempest/PlayStationSettings.tsx
@@ -35,15 +35,14 @@ export default function PlayStationSettings({organization, project}: Props) {
   const {
     data: tempestCredentials,
     isLoading,
-    isPending: isRemoving,
     invalidateCredentialsCache,
   } = useFetchTempestCredentials(organization, project);
 
-  const {mutate: handleRemoveCredential, variables: removingCredential} = useMutation<
-    unknown,
-    RequestError,
-    {id: number}
-  >({
+  const {
+    mutate: handleRemoveCredential,
+    isPending: isRemoving,
+    variables: removingCredential,
+  } = useMutation<unknown, RequestError, {id: number}>({
     mutationFn: ({id}) =>
       fetchMutation({
         method: 'DELETE',

--- a/static/app/views/settings/project/tempest/PlayStationSettings.tsx
+++ b/static/app/views/settings/project/tempest/PlayStationSettings.tsx
@@ -38,11 +38,11 @@ export default function PlayStationSettings({organization, project}: Props) {
     invalidateCredentialsCache,
   } = useFetchTempestCredentials(organization, project);
 
-  const {
-    mutate: handleRemoveCredential,
-    isPending: isRemoving,
-    variables: removingCredential,
-  } = useMutation<unknown, RequestError, {id: number}>({
+  const {mutate: handleRemoveCredential, variables: removingCredential} = useMutation<
+    unknown,
+    RequestError,
+    {id: number}
+  >({
     mutationFn: ({id}) =>
       fetchMutation({
         method: 'DELETE',
@@ -115,7 +115,7 @@ export default function PlayStationSettings({organization, project}: Props) {
             <CredentialRow
               key={credential.id}
               credential={credential}
-              removingCredentialId={isRemoving ? removingCredential?.id : undefined}
+              isRemoving={removingCredential?.id === credential.id}
               removeCredential={hasWriteAccess ? handleRemoveCredential : undefined}
             />
           ))}

--- a/static/app/views/settings/project/tempest/PlayStationSettings.tsx
+++ b/static/app/views/settings/project/tempest/PlayStationSettings.tsx
@@ -38,11 +38,11 @@ export default function PlayStationSettings({organization, project}: Props) {
     invalidateCredentialsCache,
   } = useFetchTempestCredentials(organization, project);
 
-  const {mutate: handleRemoveCredential, isPending: isRemoving} = useMutation<
-    unknown,
-    RequestError,
-    {id: number}
-  >({
+  const {
+    mutate: handleRemoveCredential,
+    isPending: isRemoving,
+    variables: removingCredential,
+  } = useMutation<unknown, RequestError, {id: number}>({
     mutationFn: ({id}) =>
       fetchMutation({
         method: 'DELETE',
@@ -115,7 +115,7 @@ export default function PlayStationSettings({organization, project}: Props) {
             <CredentialRow
               key={credential.id}
               credential={credential}
-              isRemoving={isRemoving}
+              removingCredentialId={isRemoving ? removingCredential?.id : undefined}
               removeCredential={hasWriteAccess ? handleRemoveCredential : undefined}
             />
           ))}

--- a/static/app/views/settings/project/tempest/PlayStationSettings.tsx
+++ b/static/app/views/settings/project/tempest/PlayStationSettings.tsx
@@ -35,6 +35,7 @@ export default function PlayStationSettings({organization, project}: Props) {
   const {
     data: tempestCredentials,
     isLoading,
+    isPending: isRemoving,
     invalidateCredentialsCache,
   } = useFetchTempestCredentials(organization, project);
 
@@ -115,7 +116,7 @@ export default function PlayStationSettings({organization, project}: Props) {
             <CredentialRow
               key={credential.id}
               credential={credential}
-              isRemoving={removingCredential?.id === credential.id}
+              isRemoving={isRemoving && removingCredential?.id === credential.id}
               removeCredential={hasWriteAccess ? handleRemoveCredential : undefined}
             />
           ))}


### PR DESCRIPTION
**Problem**
When deleting a single credential, all the buttons in the table row display a loading state, which can be confusing for users.

**Solution**
Only display the loading state on the delete button of the row that is being deleted.