### PR TITLE
fix(ourlogs): Manual refresh should update delay

### DIFF
--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -209,6 +209,7 @@ export function LogsTabContent({
   }, []);
 
   const refreshTable = useCallback(async () => {
+    setTimeseriesIngestDelay(getMaxIngestDelayTimestamp());
     queryClient.setQueryData(
       tableData.queryKey,
       (data: InfiniteData<OurLogsResponseItem[]>) => {


### PR DESCRIPTION
### Summary
The manual refresh button should update the max ingest delay as well, otherwise the chart and table will become out of sync.

Fixes #97826
