### PR TITLE
feat(dashboards): add cell actions to viewer modal

### DIFF
--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -108,11 +108,13 @@ import ReleaseWidgetQueries from 'sentry/views/dashboards/widgetCard/releaseWidg
 import {WidgetCardChartContainer} from 'sentry/views/dashboards/widgetCard/widgetCardChartContainer';
 import WidgetQueries from 'sentry/views/dashboards/widgetCard/widgetQueries';
 import type WidgetLegendSelectionState from 'sentry/views/dashboards/widgetLegendSelectionState';
+import {ALLOWED_CELL_ACTIONS} from 'sentry/views/dashboards/widgets/common/settings';
 import {TableWidgetVisualization} from 'sentry/views/dashboards/widgets/tableWidget/tableWidgetVisualization';
 import {
   convertTableDataToTabularData,
   decodeColumnAliases,
 } from 'sentry/views/dashboards/widgets/tableWidget/utils';
+import {Actions} from 'sentry/views/discover/table/cellAction';
 import {decodeColumnOrder} from 'sentry/views/discover/utils';
 import {MetricsDataSwitcher} from 'sentry/views/performance/landing/metricsDataSwitcher';
 
@@ -1373,6 +1375,14 @@ function ViewerTableV2({
     );
   }
 
+  let cellActions: Actions[] = [];
+  if (organization.features.includes('discover-cell-actions-v2')) {
+    cellActions =
+      tableWidget.widgetType === WidgetType.SPANS
+        ? [...ALLOWED_CELL_ACTIONS, Actions.OPEN_ROW_IN_EXPLORE]
+        : ALLOWED_CELL_ACTIONS;
+  }
+
   return (
     <Fragment>
       <TableWidgetVisualization
@@ -1402,7 +1412,7 @@ function ViewerTableV2({
             eventView,
           } satisfies RenderFunctionBaggage;
         }}
-        allowedCellActions={[]}
+        allowedCellActions={cellActions}
       />
       {!(
         tableWidget.queries[0]!.orderby.match(/^-?release$/) &&


### PR DESCRIPTION
### Changes

Add table cell actions to the table widget viewer modal. Only enabled if the `discover-cell-actions-v2` is on


<img width="1170" height="1198" alt="Screenshot 2025-08-25 at 9 27 52 AM" src="https://github.com/user-attachments/assets/1e8c17bb-eec5-48ba-990c-a5f28fc6cb73" />
