### PR TITLE
chore(contextIcon): add more mappings for browser

### DIFF
--- a/static/app/components/events/contexts/contextIcon.tsx
+++ b/static/app/components/events/contexts/contextIcon.tsx
@@ -53,18 +53,17 @@ import type {IconSize} from 'sentry/utils/theme';
 const LOGO_MAPPING = {
   'android-phone': logoAndroidPhone,
   'android-tablet': logoAndroidTablet,
-  'chrome-mobile-ios': logoChrome,
   'google-chrome': logoChrome,
   'internet-explorer': logoIe,
   'legacy-edge': logoEdgeOld,
   'mac-os-x': logoApple,
-  'chrome-os': logoChrome,
   'mobile-safari': logoSafari,
   'nintendo-switch': logoNintendoSwitch,
   'nintendo-switch-2': logoNintendoSwitch2,
   'net-core': logoNetcore,
   'net-framework': logoNetframework,
   'qq-browser': logoQq,
+  'microsoft-edge': logoEdgeNew,
   amazon: logoAmazon,
   amd: logoAmd,
   android: logoAndroid,
@@ -143,6 +142,14 @@ export function getLogoImage(name: string) {
 
   if (name.startsWith('nintendo-')) {
     return logoNintendoSwitch;
+  }
+
+  if (name.startsWith('chrome-')) {
+    return logoChrome;
+  }
+
+  if (name.startsWith('firefox-')) {
+    return logoFirefox;
   }
 
   // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message


### PR DESCRIPTION
### Changes

Add a few more mappings for browser to handle some edge cases (pun not intended)

### Before
<img width="186" height="89" alt="Screenshot 2025-08-25 at 9 50 21 AM" src="https://github.com/user-attachments/assets/a24eb63f-cd79-4441-854b-14687a36d9c7" />

### After
<img width="203" height="92" alt="Screenshot 2025-08-25 at 9 43 23 AM" src="https://github.com/user-attachments/assets/aed18ecd-36ee-4881-908e-1ca4de9c7d2f" />

