### PR TITLE
feat(logs): Remove sentry prefix on log parameters

### DIFF
--- a/src/sentry/search/eap/columns.py
+++ b/src/sentry/search/eap/columns.py
@@ -498,3 +498,5 @@ class ColumnDefinitions:
     contexts: dict[str, VirtualColumnDefinition]
     trace_item_type: TraceItemType.ValueType
     filter_aliases: Mapping[str, Callable[[SnubaParams, SearchFilter], list[SearchFilter]]]
+    alias_to_column: Callable[[str], str | None] | None
+    column_to_alias: Callable[[str], str | None] | None

--- a/src/sentry/search/eap/ourlogs/attributes.py
+++ b/src/sentry/search/eap/ourlogs/attributes.py
@@ -155,3 +155,15 @@ for definition in OURLOG_ATTRIBUTE_DEFINITIONS.values():
     )
     secondary_aliases.add(definition.public_alias)
     LOGS_INTERNAL_TO_SECONDARY_ALIASES_MAPPING[definition.internal_name] = secondary_aliases
+
+
+def ourlog_custom_alias_to_column(alias: str) -> str | None:
+    if alias.startswith("message.parameters."):
+        return f"sentry.{alias}"
+    return None
+
+
+def ourlog_column_to_custom_alias(column: str) -> str | None:
+    if column.startswith("sentry.message.parameters."):
+        return column[len("sentry.") :]
+    return None

--- a/src/sentry/search/eap/ourlogs/definitions.py
+++ b/src/sentry/search/eap/ourlogs/definitions.py
@@ -4,6 +4,8 @@ from sentry.search.eap.columns import ColumnDefinitions
 from sentry.search.eap.ourlogs.attributes import (
     OURLOG_ATTRIBUTE_DEFINITIONS,
     OURLOG_VIRTUAL_CONTEXTS,
+    ourlog_column_to_custom_alias,
+    ourlog_custom_alias_to_column,
 )
 from sentry.search.eap.spans.aggregates import LOG_AGGREGATE_DEFINITIONS
 
@@ -15,4 +17,6 @@ OURLOG_DEFINITIONS = ColumnDefinitions(
     contexts=OURLOG_VIRTUAL_CONTEXTS,
     trace_item_type=TraceItemType.TRACE_ITEM_TYPE_LOG,
     filter_aliases={},
+    alias_to_column=ourlog_custom_alias_to_column,
+    column_to_alias=ourlog_column_to_custom_alias,
 )

--- a/src/sentry/search/eap/resolver.py
+++ b/src/sentry/search/eap/resolver.py
@@ -56,9 +56,9 @@ from sentry.search.eap.columns import (
     ValueArgumentDefinition,
     VirtualColumnDefinition,
 )
+from sentry.search.eap.sampling import validate_sampling
 from sentry.search.eap.spans.attributes import SPANS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS
 from sentry.search.eap.types import EAPResponse, SearchResolverConfig
-from sentry.search.eap.utils import validate_sampling
 from sentry.search.events import constants as qb_constants
 from sentry.search.events import fields
 from sentry.search.events import filter as event_filter
@@ -862,6 +862,11 @@ class SearchResolver:
                     search_type=column_definition.search_type,
                 )
         else:
+            if self.definitions.alias_to_column is not None:
+                mapped_column = self.definitions.alias_to_column(column)
+                if mapped_column is not None:
+                    column = mapped_column
+
             if len(column) > qb_constants.MAX_TAG_KEY_LENGTH:
                 raise InvalidSearchQuery(
                     f"{column} is too long, can be a maximum of 200 characters"

--- a/src/sentry/search/eap/sampling.py
+++ b/src/sentry/search/eap/sampling.py
@@ -1,0 +1,21 @@
+from sentry_protos.snuba.v1.downsampled_storage_pb2 import (
+    DownsampledStorageConfig,
+    DownsampledStorageMeta,
+)
+
+from sentry.exceptions import InvalidSearchQuery
+from sentry.search.eap.constants import SAMPLING_MODE_MAP
+from sentry.search.events.types import SAMPLING_MODES
+
+
+def handle_downsample_meta(meta: DownsampledStorageMeta) -> bool:
+    return not meta.can_go_to_higher_accuracy_tier
+
+
+def validate_sampling(sampling_mode: SAMPLING_MODES | None) -> DownsampledStorageConfig:
+    if sampling_mode is None:
+        return DownsampledStorageConfig(mode=DownsampledStorageConfig.MODE_NORMAL)
+    if sampling_mode not in SAMPLING_MODE_MAP:
+        raise InvalidSearchQuery(f"sampling mode: {sampling_mode} is not supported")
+    else:
+        return DownsampledStorageConfig(mode=SAMPLING_MODE_MAP[sampling_mode])

--- a/src/sentry/search/eap/spans/aggregates.py
+++ b/src/sentry/search/eap/spans/aggregates.py
@@ -23,7 +23,7 @@ from sentry.search.eap.columns import (
     ValueArgumentDefinition,
 )
 from sentry.search.eap.spans.utils import WEB_VITALS_MEASUREMENTS, transform_vital_score_to_ratio
-from sentry.search.eap.utils import literal_validator, number_validator
+from sentry.search.eap.validator import literal_validator, number_validator
 
 
 def count_processor(count_value: int | None) -> int:

--- a/src/sentry/search/eap/spans/definitions.py
+++ b/src/sentry/search/eap/spans/definitions.py
@@ -17,4 +17,6 @@ SPAN_DEFINITIONS = ColumnDefinitions(
     contexts=SPAN_VIRTUAL_CONTEXTS,
     trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
     filter_aliases=SPAN_FILTER_ALIAS_DEFINITIONS,
+    column_to_alias=None,
+    alias_to_column=None,
 )

--- a/src/sentry/search/eap/spans/formulas.py
+++ b/src/sentry/search/eap/spans/formulas.py
@@ -35,7 +35,7 @@ from sentry.search.eap.spans.utils import (
     transform_vital_score_to_ratio,
 )
 from sentry.search.eap.types import SearchResolverConfig
-from sentry.search.eap.utils import literal_validator
+from sentry.search.eap.validator import literal_validator
 from sentry.search.events.constants import (
     MISERY_ALPHA,
     MISERY_BETA,

--- a/src/sentry/search/eap/uptime_checks/definitions.py
+++ b/src/sentry/search/eap/uptime_checks/definitions.py
@@ -14,4 +14,6 @@ UPTIME_CHECK_DEFINITIONS = ColumnDefinitions(
     contexts=UPTIME_CHECK_VIRTUAL_CONTEXTS,
     trace_item_type=TraceItemType.TRACE_ITEM_TYPE_UPTIME_CHECK,
     filter_aliases={},
+    alias_to_column=None,
+    column_to_alias=None,
 )

--- a/src/sentry/search/eap/uptime_results/definitions.py
+++ b/src/sentry/search/eap/uptime_results/definitions.py
@@ -11,4 +11,6 @@ UPTIME_RESULT_DEFINITIONS = ColumnDefinitions(
     contexts={},
     trace_item_type=TraceItemType.TRACE_ITEM_TYPE_UPTIME_RESULT,
     filter_aliases={},
+    alias_to_column=None,
+    column_to_alias=None,
 )

--- a/src/sentry/search/eap/utils.py
+++ b/src/sentry/search/eap/utils.py
@@ -1,21 +1,11 @@
-from collections.abc import Callable
 from datetime import datetime
-from typing import Any, Literal
+from typing import Literal
 
-from google.protobuf.json_format import MessageToJson
 from google.protobuf.timestamp_pb2 import Timestamp
-from sentry_protos.snuba.v1.downsampled_storage_pb2 import (
-    DownsampledStorageConfig,
-    DownsampledStorageMeta,
-)
-from sentry_protos.snuba.v1.endpoint_time_series_pb2 import Expression, TimeSeriesRequest
-from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import Column, TraceItemTableRequest
-from sentry_protos.snuba.v1.request_common_pb2 import ResponseMeta
-from sentry_protos.snuba.v1.trace_item_attribute_pb2 import Function
+from sentry_protos.snuba.v1.endpoint_time_series_pb2 import TimeSeriesRequest
 
-from sentry.exceptions import InvalidSearchQuery
-from sentry.search.eap.columns import ResolvedAttribute
-from sentry.search.eap.constants import SAMPLING_MODE_MAP, SENTRY_INTERNAL_PREFIXES
+from sentry.search.eap.columns import ColumnDefinitions, ResolvedAttribute
+from sentry.search.eap.constants import SENTRY_INTERNAL_PREFIXES
 from sentry.search.eap.ourlogs.attributes import (
     LOGS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS,
     LOGS_INTERNAL_TO_SECONDARY_ALIASES_MAPPING,
@@ -25,6 +15,7 @@ from sentry.search.eap.ourlogs.attributes import (
     LOGS_REPLACEMENT_MAP,
     OURLOG_ATTRIBUTE_DEFINITIONS,
 )
+from sentry.search.eap.ourlogs.definitions import OURLOG_DEFINITIONS
 from sentry.search.eap.spans.attributes import (
     SPAN_ATTRIBUTE_DEFINITIONS,
     SPAN_INTERNAL_TO_SECONDARY_ALIASES_MAPPING,
@@ -34,33 +25,8 @@ from sentry.search.eap.spans.attributes import (
     SPANS_REPLACEMENT_ATTRIBUTES,
     SPANS_REPLACEMENT_MAP,
 )
+from sentry.search.eap.spans.definitions import SPAN_DEFINITIONS
 from sentry.search.eap.types import SupportedTraceItemType
-from sentry.search.events.types import SAMPLING_MODES, EventsMeta
-from sentry.utils import json
-
-# TODO: Remove when https://github.com/getsentry/eap-planning/issues/206 is merged, since we can use formulas in both APIs at that point
-BINARY_FORMULA_OPERATOR_MAP = {
-    Column.BinaryFormula.OP_ADD: Expression.BinaryFormula.OP_ADD,
-    Column.BinaryFormula.OP_SUBTRACT: Expression.BinaryFormula.OP_SUBTRACT,
-    Column.BinaryFormula.OP_MULTIPLY: Expression.BinaryFormula.OP_MULTIPLY,
-    Column.BinaryFormula.OP_DIVIDE: Expression.BinaryFormula.OP_DIVIDE,
-    Column.BinaryFormula.OP_UNSPECIFIED: Expression.BinaryFormula.OP_UNSPECIFIED,
-}
-
-
-def literal_validator(values: list[Any]) -> Callable[[str], bool]:
-    def _validator(input: str) -> bool:
-        if input in values:
-            return True
-        raise InvalidSearchQuery(f"Invalid parameter {input}. Must be one of {values}")
-
-    return _validator
-
-
-def number_validator(input: str) -> bool:
-    if input.replace(".", "", 1).isdecimal():
-        return True
-    raise InvalidSearchQuery(f"Invalid parameter {input}. Must be numeric")
 
 
 def add_start_end_conditions(
@@ -74,53 +40,6 @@ def add_start_end_conditions(
     in_msg.meta.end_timestamp.CopyFrom(end_time_proto)
 
     return in_msg
-
-
-def transform_binary_formula_to_expression(
-    column: Column.BinaryFormula,
-) -> Expression.BinaryFormula:
-    """TODO: Remove when https://github.com/getsentry/eap-planning/issues/206 is merged, since we can use formulas in both APIs at that point"""
-    return Expression.BinaryFormula(
-        left=transform_column_to_expression(column.left),
-        right=transform_column_to_expression(column.right),
-        op=BINARY_FORMULA_OPERATOR_MAP[column.op],
-        default_value_double=column.default_value_double,
-    )
-
-
-def transform_column_to_expression(column: Column) -> Expression:
-    """TODO: Remove when https://github.com/getsentry/eap-planning/issues/206 is merged, since we can use formulas in both APIs at that point"""
-    if column.formula.op != Column.BinaryFormula.OP_UNSPECIFIED:
-        return Expression(
-            formula=transform_binary_formula_to_expression(column.formula),
-            label=column.label,
-        )
-
-    if column.aggregation.aggregate != Function.FUNCTION_UNSPECIFIED:
-        return Expression(
-            aggregation=column.aggregation,
-            label=column.label,
-        )
-
-    if column.conditional_aggregation.aggregate != Function.FUNCTION_UNSPECIFIED:
-        return Expression(
-            conditional_aggregation=column.conditional_aggregation,
-            label=column.label,
-        )
-
-    return Expression(
-        label=column.label,
-        literal=column.literal,
-    )
-
-
-def validate_sampling(sampling_mode: SAMPLING_MODES | None) -> DownsampledStorageConfig:
-    if sampling_mode is None:
-        return DownsampledStorageConfig(mode=DownsampledStorageConfig.MODE_NORMAL)
-    if sampling_mode not in SAMPLING_MODE_MAP:
-        raise InvalidSearchQuery(f"sampling mode: {sampling_mode} is not supported")
-    else:
-        return DownsampledStorageConfig(mode=SAMPLING_MODE_MAP[sampling_mode])
 
 
 INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS: dict[
@@ -162,6 +81,11 @@ INTERNAL_TO_SECONDARY_ALIASES: dict[SupportedTraceItemType, dict[str, set[str]]]
     SupportedTraceItemType.LOGS: LOGS_INTERNAL_TO_SECONDARY_ALIASES_MAPPING,
 }
 
+TRACE_ITEM_TYPE_DEFINITIONS: dict[SupportedTraceItemType, ColumnDefinitions] = {
+    SupportedTraceItemType.SPANS: SPAN_DEFINITIONS,
+    SupportedTraceItemType.LOGS: OURLOG_DEFINITIONS,
+}
+
 
 def translate_internal_to_public_alias(
     internal_alias: str,
@@ -178,6 +102,13 @@ def translate_internal_to_public_alias(
         # if there is a known public alias with this exact name, it means we need to wrap
         # it in the explicitly typed tags syntax in order for it to reference the correct column
         return f"tags[{internal_alias},{type}]"
+
+    definitions = TRACE_ITEM_TYPE_DEFINITIONS.get(item_type)
+    if definitions is not None:
+        if definitions.column_to_alias is not None:
+            column = definitions.column_to_alias(internal_alias)
+            if column is not None:
+                return column
 
     return None
 
@@ -205,24 +136,6 @@ def can_expose_attribute(
         return include_internal
 
     return True
-
-
-def handle_downsample_meta(meta: DownsampledStorageMeta) -> bool:
-    return not meta.can_go_to_higher_accuracy_tier
-
-
-def set_debug_meta(
-    events_meta: EventsMeta,
-    rpc_meta: ResponseMeta,
-    rpc_request: TraceItemTableRequest | TimeSeriesRequest,
-) -> None:
-    """Only done when debug is passed to the events endpoint"""
-    rpc_query = json.loads(MessageToJson(rpc_request))
-
-    events_meta["debug_info"] = {
-        "query.storage_meta.tier": rpc_meta.downsampled_storage_meta.tier,
-        "query": rpc_query,
-    }
 
 
 def is_sentry_convention_replacement_attribute(

--- a/src/sentry/search/eap/validator.py
+++ b/src/sentry/search/eap/validator.py
@@ -1,0 +1,19 @@
+from collections.abc import Callable
+from typing import Any
+
+from sentry.exceptions import InvalidSearchQuery
+
+
+def literal_validator(values: list[Any]) -> Callable[[str], bool]:
+    def _validator(input: str) -> bool:
+        if input in values:
+            return True
+        raise InvalidSearchQuery(f"Invalid parameter {input}. Must be one of {values}")
+
+    return _validator
+
+
+def number_validator(input: str) -> bool:
+    if input.replace(".", "", 1).isdecimal():
+        return True
+    raise InvalidSearchQuery(f"Invalid parameter {input}. Must be numeric")

--- a/src/sentry/snuba/ourlogs.py
+++ b/src/sentry/snuba/ourlogs.py
@@ -5,8 +5,8 @@ import sentry_sdk
 
 from sentry.search.eap.ourlogs.definitions import OURLOG_DEFINITIONS
 from sentry.search.eap.resolver import SearchResolver
+from sentry.search.eap.sampling import handle_downsample_meta
 from sentry.search.eap.types import EAPResponse, SearchResolverConfig
-from sentry.search.eap.utils import handle_downsample_meta
 from sentry.search.events.types import SAMPLING_MODES, EventsMeta, SnubaParams
 from sentry.snuba import rpc_dataset_common
 from sentry.snuba.discover import zerofill

--- a/src/sentry/snuba/rpc_dataset_common.py
+++ b/src/sentry/snuba/rpc_dataset_common.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta
 from typing import Any
 
 import sentry_sdk
+from google.protobuf.json_format import MessageToJson
 from sentry_protos.snuba.v1.downsampled_storage_pb2 import DownsampledStorageConfig
 from sentry_protos.snuba.v1.endpoint_time_series_pb2 import (
     Expression,
@@ -17,8 +18,8 @@ from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import (
     TraceItemTableRequest,
     TraceItemTableResponse,
 )
-from sentry_protos.snuba.v1.request_common_pb2 import PageToken
-from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey, AttributeValue
+from sentry_protos.snuba.v1.request_common_pb2 import PageToken, ResponseMeta
+from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey, AttributeValue, Function
 from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
     AndFilter,
     ComparisonFilter,
@@ -41,16 +42,12 @@ from sentry.search.eap.columns import (
 )
 from sentry.search.eap.constants import DOUBLE, MAX_ROLLUP_POINTS, VALID_GRANULARITIES
 from sentry.search.eap.resolver import SearchResolver
+from sentry.search.eap.sampling import handle_downsample_meta
 from sentry.search.eap.types import CONFIDENCES, ConfidenceData, EAPResponse, SearchResolverConfig
-from sentry.search.eap.utils import (
-    handle_downsample_meta,
-    set_debug_meta,
-    transform_binary_formula_to_expression,
-)
 from sentry.search.events.fields import get_function_alias, is_function
 from sentry.search.events.types import SAMPLING_MODES, EventsMeta, SnubaData, SnubaParams
 from sentry.snuba.discover import OTHER_KEY, create_groupby_dict, create_result_key
-from sentry.utils import snuba_rpc
+from sentry.utils import json, snuba_rpc
 from sentry.utils.snuba import SnubaTSResult, process_value
 
 logger = logging.getLogger("sentry.snuba.spans_rpc")
@@ -796,3 +793,65 @@ def has_top_level_trace_condition(
         return False
 
     return False
+
+
+def set_debug_meta(
+    events_meta: EventsMeta,
+    rpc_meta: ResponseMeta,
+    rpc_request: TraceItemTableRequest | TimeSeriesRequest,
+) -> None:
+    """Only done when debug is passed to the events endpoint"""
+    rpc_query = json.loads(MessageToJson(rpc_request))
+
+    events_meta["debug_info"] = {
+        "query.storage_meta.tier": rpc_meta.downsampled_storage_meta.tier,
+        "query": rpc_query,
+    }
+
+
+# TODO: Remove when https://github.com/getsentry/eap-planning/issues/206 is merged, since we can use formulas in both APIs at that point
+BINARY_FORMULA_OPERATOR_MAP = {
+    Column.BinaryFormula.OP_ADD: Expression.BinaryFormula.OP_ADD,
+    Column.BinaryFormula.OP_SUBTRACT: Expression.BinaryFormula.OP_SUBTRACT,
+    Column.BinaryFormula.OP_MULTIPLY: Expression.BinaryFormula.OP_MULTIPLY,
+    Column.BinaryFormula.OP_DIVIDE: Expression.BinaryFormula.OP_DIVIDE,
+    Column.BinaryFormula.OP_UNSPECIFIED: Expression.BinaryFormula.OP_UNSPECIFIED,
+}
+
+
+def transform_binary_formula_to_expression(
+    column: Column.BinaryFormula,
+) -> Expression.BinaryFormula:
+    """TODO: Remove when https://github.com/getsentry/eap-planning/issues/206 is merged, since we can use formulas in both APIs at that point"""
+    return Expression.BinaryFormula(
+        left=transform_column_to_expression(column.left),
+        right=transform_column_to_expression(column.right),
+        op=BINARY_FORMULA_OPERATOR_MAP[column.op],
+        default_value_double=column.default_value_double,
+    )
+
+
+def transform_column_to_expression(column: Column) -> Expression:
+    """TODO: Remove when https://github.com/getsentry/eap-planning/issues/206 is merged, since we can use formulas in both APIs at that point"""
+    if column.formula.op != Column.BinaryFormula.OP_UNSPECIFIED:
+        return Expression(
+            formula=transform_binary_formula_to_expression(column.formula),
+            label=column.label,
+        )
+
+    if column.aggregation.aggregate != Function.FUNCTION_UNSPECIFIED:
+        return Expression(
+            aggregation=column.aggregation,
+            label=column.label,
+        )
+
+    if column.conditional_aggregation.aggregate != Function.FUNCTION_UNSPECIFIED:
+        return Expression(
+            conditional_aggregation=column.conditional_aggregation,
+            label=column.label,
+        )
+
+    return Expression(
+        label=column.label,
+        literal=column.literal,
+    )

--- a/src/sentry/snuba/spans_rpc.py
+++ b/src/sentry/snuba/spans_rpc.py
@@ -9,12 +9,13 @@ from sentry_protos.snuba.v1.request_common_pb2 import TraceItemType
 from sentry.exceptions import InvalidSearchQuery
 from sentry.search.eap.constants import DOUBLE, INT, STRING
 from sentry.search.eap.resolver import SearchResolver
+from sentry.search.eap.sampling import handle_downsample_meta
 from sentry.search.eap.spans.definitions import SPAN_DEFINITIONS
 from sentry.search.eap.types import EAPResponse, SearchResolverConfig
-from sentry.search.eap.utils import handle_downsample_meta, set_debug_meta
 from sentry.search.events.types import SAMPLING_MODES, EventsMeta, SnubaParams
 from sentry.snuba import rpc_dataset_common
 from sentry.snuba.discover import zerofill
+from sentry.snuba.rpc_dataset_common import set_debug_meta
 from sentry.utils import snuba_rpc
 from sentry.utils.snuba import SnubaTSResult
 


### PR DESCRIPTION
Log parameters are currently queried as `sentry.message.parameter.*`. The `sentry.` prefix is throwing some people off so here we opt to remove it.

Closes LOGS-161