### PR TITLE
feat(go): Add logs empty state for go sdk

### DIFF
--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -306,6 +306,15 @@ export const withoutPerformanceSupport: Set<PlatformKey> = new Set([
 
 // List of platforms that have logging onboarding checklist content
 export const withLoggingOnboarding: Set<PlatformKey> = new Set([
+  'go',
+  'go-echo',
+  'go-fasthttp',
+  'go-fiber',
+  'go-gin',
+  'go-http',
+  'go-iris',
+  'go-martini',
+  'go-negroni',
   'javascript',
   'javascript-angular',
   'javascript-astro',

--- a/static/app/gettingStartedDocs/go/echo.tsx
+++ b/static/app/gettingStartedDocs/go/echo.tsx
@@ -18,6 +18,7 @@ import {
   replayOnboardingJsLoader,
 } from 'sentry/gettingStartedDocs/javascript/jsLoader/jsLoader';
 import {t, tct} from 'sentry/locale';
+import {getGoLogsOnboarding} from 'sentry/utils/gettingStartedDocs/go';
 
 type Params = DocsParams;
 
@@ -35,18 +36,18 @@ import (
 // To initialize Sentry's handler, you need to initialize Sentry itself beforehand
 if err := sentry.Init(sentry.ClientOptions{
   Dsn: "${params.dsn.public}",${
+    params.isLogsSelected
+      ? `
+  // Enable structured logs to Sentry
+  EnableLogs: true,`
+      : ''
+  }${
     params.isPerformanceSelected
       ? `
   // Set TracesSampleRate to 1.0 to capture 100%
   // of transactions for tracing.
   // We recommend adjusting this value in production,
   TracesSampleRate: 1.0,`
-      : ''
-  }${
-    params.isLogsSelected
-      ? `
-  // Enable structured logs to Sentry
-  EnableLogs: true,`
       : ''
   }
 }); err != nil {
@@ -257,6 +258,9 @@ const docs: Docs = {
   replayOnboardingJsLoader,
   crashReportOnboarding,
   feedbackOnboardingJsLoader,
+  logsOnboarding: getGoLogsOnboarding({
+    docsPlatform: 'echo',
+  }),
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/go/fasthttp.tsx
+++ b/static/app/gettingStartedDocs/go/fasthttp.tsx
@@ -18,6 +18,7 @@ import {
   replayOnboardingJsLoader,
 } from 'sentry/gettingStartedDocs/javascript/jsLoader/jsLoader';
 import {t, tct} from 'sentry/locale';
+import {getGoLogsOnboarding} from 'sentry/utils/gettingStartedDocs/go';
 
 type Params = DocsParams;
 
@@ -262,6 +263,9 @@ const docs: Docs = {
   replayOnboardingJsLoader,
   crashReportOnboarding,
   feedbackOnboardingJsLoader,
+  logsOnboarding: getGoLogsOnboarding({
+    docsPlatform: 'fasthttp',
+  }),
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/go/fiber.tsx
+++ b/static/app/gettingStartedDocs/go/fiber.tsx
@@ -18,6 +18,7 @@ import {
   replayOnboardingJsLoader,
 } from 'sentry/gettingStartedDocs/javascript/jsLoader/jsLoader';
 import {t, tct} from 'sentry/locale';
+import {getGoLogsOnboarding} from 'sentry/utils/gettingStartedDocs/go';
 
 type Params = DocsParams;
 
@@ -271,6 +272,9 @@ const docs: Docs = {
   replayOnboardingJsLoader,
   crashReportOnboarding,
   feedbackOnboardingJsLoader,
+  logsOnboarding: getGoLogsOnboarding({
+    docsPlatform: 'fiber',
+  }),
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/go/gin.tsx
+++ b/static/app/gettingStartedDocs/go/gin.tsx
@@ -18,6 +18,7 @@ import {
   replayOnboardingJsLoader,
 } from 'sentry/gettingStartedDocs/javascript/jsLoader/jsLoader';
 import {t, tct} from 'sentry/locale';
+import {getGoLogsOnboarding} from 'sentry/utils/gettingStartedDocs/go';
 
 type Params = DocsParams;
 
@@ -249,6 +250,9 @@ const docs: Docs = {
   replayOnboardingJsLoader,
   crashReportOnboarding,
   feedbackOnboardingJsLoader,
+  logsOnboarding: getGoLogsOnboarding({
+    docsPlatform: 'gin',
+  }),
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/go/go.tsx
+++ b/static/app/gettingStartedDocs/go/go.tsx
@@ -14,6 +14,7 @@ import {
   replayOnboardingJsLoader,
 } from 'sentry/gettingStartedDocs/javascript/jsLoader/jsLoader';
 import {t, tct} from 'sentry/locale';
+import {getGoLogsOnboarding} from 'sentry/utils/gettingStartedDocs/go';
 
 type Params = DocsParams;
 
@@ -29,18 +30,18 @@ import (
 func main() {
   err := sentry.Init(sentry.ClientOptions{
     Dsn: "${params.dsn.public}",${
+      params.isLogsSelected
+        ? `
+    // Enable logs to be sent to Sentry
+    EnableLogs: true,`
+        : ''
+    }${
       params.isPerformanceSelected
         ? `
     // Set TracesSampleRate to 1.0 to capture 100%
     // of transactions for tracing.
     // We recommend adjusting this value in production,
     TracesSampleRate: 1.0,`
-        : ''
-    }${
-      params.isLogsSelected
-        ? `
-    // Enable structured logs to Sentry
-    EnableLogs: true,`
         : ''
     }
   })
@@ -62,18 +63,18 @@ import (
 func main() {
   err := sentry.Init(sentry.ClientOptions{
     Dsn: "${params.dsn.public}",${
+      params.isLogsSelected
+        ? `
+    // Enable logs to be sent to Sentry
+    EnableLogs: true,`
+        : ''
+    }${
       params.isPerformanceSelected
         ? `
     // Set TracesSampleRate to 1.0 to capture 100%
     // of transactions for tracing.
     // We recommend adjusting this value in production,
     TracesSampleRate: 1.0,`
-        : ''
-    }${
-      params.isLogsSelected
-        ? `
-    // Enable structured logs to Sentry
-    EnableLogs: true,`
         : ''
     }
   })
@@ -167,6 +168,9 @@ const docs: Docs = {
   replayOnboardingJsLoader,
   crashReportOnboarding,
   feedbackOnboardingJsLoader,
+  logsOnboarding: getGoLogsOnboarding({
+    docsPlatform: 'go',
+  }),
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/go/http.tsx
+++ b/static/app/gettingStartedDocs/go/http.tsx
@@ -18,6 +18,7 @@ import {
   replayOnboardingJsLoader,
 } from 'sentry/gettingStartedDocs/javascript/jsLoader/jsLoader';
 import {t, tct} from 'sentry/locale';
+import {getGoLogsOnboarding} from 'sentry/utils/gettingStartedDocs/go';
 
 type Params = DocsParams;
 
@@ -257,6 +258,9 @@ const docs: Docs = {
   replayOnboardingJsLoader,
   crashReportOnboarding,
   feedbackOnboardingJsLoader,
+  logsOnboarding: getGoLogsOnboarding({
+    docsPlatform: 'http',
+  }),
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/go/iris.tsx
+++ b/static/app/gettingStartedDocs/go/iris.tsx
@@ -18,6 +18,7 @@ import {
   replayOnboardingJsLoader,
 } from 'sentry/gettingStartedDocs/javascript/jsLoader/jsLoader';
 import {t, tct} from 'sentry/locale';
+import {getGoLogsOnboarding} from 'sentry/utils/gettingStartedDocs/go';
 
 type Params = DocsParams;
 
@@ -246,6 +247,9 @@ const docs: Docs = {
   replayOnboardingJsLoader,
   crashReportOnboarding,
   feedbackOnboardingJsLoader,
+  logsOnboarding: getGoLogsOnboarding({
+    docsPlatform: 'iris',
+  }),
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/go/martini.tsx
+++ b/static/app/gettingStartedDocs/go/martini.tsx
@@ -18,6 +18,7 @@ import {
   replayOnboardingJsLoader,
 } from 'sentry/gettingStartedDocs/javascript/jsLoader/jsLoader';
 import {t, tct} from 'sentry/locale';
+import {getGoLogsOnboarding} from 'sentry/utils/gettingStartedDocs/go';
 
 type Params = DocsParams;
 
@@ -244,6 +245,9 @@ const docs: Docs = {
   replayOnboardingJsLoader,
   crashReportOnboarding,
   feedbackOnboardingJsLoader,
+  logsOnboarding: getGoLogsOnboarding({
+    docsPlatform: 'martini',
+  }),
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/go/negroni.tsx
+++ b/static/app/gettingStartedDocs/go/negroni.tsx
@@ -18,6 +18,7 @@ import {
   replayOnboardingJsLoader,
 } from 'sentry/gettingStartedDocs/javascript/jsLoader/jsLoader';
 import {t, tct} from 'sentry/locale';
+import {getGoLogsOnboarding} from 'sentry/utils/gettingStartedDocs/go';
 
 type Params = DocsParams;
 
@@ -308,6 +309,9 @@ const docs: Docs = {
   replayOnboardingJsLoader,
   crashReportOnboarding,
   feedbackOnboardingJsLoader,
+  logsOnboarding: getGoLogsOnboarding({
+    docsPlatform: 'negroni',
+  }),
 };
 
 export default docs;

--- a/static/app/utils/gettingStartedDocs/go.tsx
+++ b/static/app/utils/gettingStartedDocs/go.tsx
@@ -1,0 +1,115 @@
+import {ExternalLink} from 'sentry/components/core/link';
+import {
+  StepType,
+  type BasePlatformOptions,
+  type OnboardingConfig,
+} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {t, tct} from 'sentry/locale';
+
+export const getGoLogsOnboarding = <
+  PlatformOptions extends BasePlatformOptions = BasePlatformOptions,
+>({
+  docsPlatform,
+}: {
+  docsPlatform: string;
+}): OnboardingConfig<PlatformOptions> => ({
+  install: () => [
+    {
+      type: StepType.INSTALL,
+      description: tct(
+        'Install our Go SDK using [code:go get]. The minimum version of the SDK that supports logs is [code:0.33.0].',
+        {
+          code: <code />,
+        }
+      ),
+      configurations: [
+        {
+          language: 'bash',
+          code: 'go get github.com/getsentry/sentry-go',
+        },
+      ],
+    },
+  ],
+  configure: params => [
+    {
+      type: StepType.CONFIGURE,
+      content: [
+        {
+          type: 'text',
+          text: t(
+            "Import and initialize the Sentry SDK early in your application's setup:"
+          ),
+        },
+        {
+          type: 'code',
+          language: 'go',
+          code: `package main
+
+import (
+  "github.com/getsentry/sentry-go"
+)
+
+func main() {
+  err := sentry.Init(sentry.ClientOptions{
+    Dsn: "${params.dsn.public}",
+    EnableLogs: true,
+  })
+  if err != nil {
+    log.Fatalf("sentry.Init: %s", err)
+  }
+  // Flush buffered events before the program terminates.
+  // Set the timeout to the maximum duration the program can afford to wait.
+  defer sentry.Flush(2 * time.Second)
+}`,
+        },
+        {
+          type: 'text',
+          text: tct(
+            'You can also add [link:logging integrations] to automatically capture logs from your application from libraries like [code:slog], [code:logrus], or [code:zerolog].',
+            {
+              link: (
+                <ExternalLink
+                  href={
+                    docsPlatform === 'go'
+                      ? `https://docs.sentry.io/platforms/go/logs/#integrations`
+                      : `https://docs.sentry.io/platforms/go/guides/${docsPlatform}/logs/#integrations`
+                  }
+                />
+              ),
+              code: <code />,
+            }
+          ),
+        },
+      ],
+    },
+  ],
+  verify: () => [
+    {
+      type: StepType.VERIFY,
+      content: [
+        {
+          type: 'text',
+          text: t('Send a test log from your app to verify logs are arriving in Sentry.'),
+        },
+        {
+          type: 'code',
+          language: 'go',
+          code: `// The SentryLogger requires context, to link logs with the appropriate traces. You can either create a new logger
+// by providing the context, or use WithCtx() to pass the context inline.
+ctx := context.Background()
+logger := sentry.NewLogger(ctx)
+
+// Or inline using WithCtx()
+newCtx := context.Background()
+// WithCtx() does not modify the original context attached on the logger.
+logger.Info().WithCtx(newCtx).Emit("context passed")
+
+// You can use the logger like [fmt.Print]
+logger.Info().Emit("Hello ", "world!")
+// Or like [fmt.Printf]
+logger.Info().Emitf("Hello %v!", "world")`,
+        },
+      ],
+    },
+  ],
+});

--- a/static/app/utils/gettingStartedDocs/go.tsx
+++ b/static/app/utils/gettingStartedDocs/go.tsx
@@ -65,7 +65,7 @@ func main() {
         {
           type: 'text',
           text: tct(
-            'You can also add [link:logging integrations] to automatically capture logs from your application from libraries like [code:slog], [code:logrus], or [code:zerolog].',
+            'You can also add [link:logging integrations] to automatically capture logs from your application from libraries like [code:slog] or [code:logrus].',
             {
               link: (
                 <ExternalLink


### PR DESCRIPTION
resolves https://linear.app/getsentry/issue/LOGS-312/add-empty-state-logs-onboarding-for-go-sdks

<img width="1187" height="729" alt="image" src="https://github.com/user-attachments/assets/c54d7279-4eef-4a4b-8461-ebb171d69679" />
