### PR TITLE
ref(ourlogs): Bump sentry relay 0.9.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ dependencies = [
     "sentry-ophio>=1.1.3",
     "sentry-protos>=0.3.4",
     "sentry-redis-tools>=0.5.0",
-    "sentry-relay>=0.9.12",
+    "sentry-relay>=0.9.13",
     "sentry-sdk[http2]>=2.29.1",
     "sentry-usage-accountant>=0.0.10",
     # remove once there are no unmarked transitive dependencies on setuptools

--- a/uv.lock
+++ b/uv.lock
@@ -2170,7 +2170,7 @@ requires-dist = [
     { name = "sentry-ophio", specifier = ">=1.1.3" },
     { name = "sentry-protos", specifier = ">=0.3.4" },
     { name = "sentry-redis-tools", specifier = ">=0.5.0" },
-    { name = "sentry-relay", specifier = ">=0.9.12" },
+    { name = "sentry-relay", specifier = ">=0.9.13" },
     { name = "sentry-sdk", extras = ["http2"], specifier = ">=2.29.1" },
     { name = "sentry-usage-accountant", specifier = ">=0.0.10" },
     { name = "setuptools", specifier = ">=70.0.0" },
@@ -2388,16 +2388,16 @@ wheels = [
 
 [[package]]
 name = "sentry-relay"
-version = "0.9.12"
+version = "0.9.13"
 source = { registry = "https://pypi.devinfra.sentry.io/simple" }
 dependencies = [
     { name = "milksnake", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_relay-0.9.12-py2.py3-none-macosx_13_0_x86_64.whl", hash = "sha256:59614696691d9b93829e161dbb187224128f1c8a526c90cf3cd4f96f9ab7b2ce" },
-    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_relay-0.9.12-py2.py3-none-macosx_14_0_arm64.whl", hash = "sha256:0f7474f53e328c54583434dd252e94f9719bd462b734c1d342f30d57ab5b6bea" },
-    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_relay-0.9.12-py2.py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:291de5469e2c3a7add8756dd4af8f21ad44a858124a7da37af08fa221bf3c9a1" },
-    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_relay-0.9.12-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:2d41f3fee97c6d8048a45436e7e8671122a251fea13ce8618ab2fa89f89fdc5e" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_relay-0.9.13-py2.py3-none-macosx_13_0_x86_64.whl", hash = "sha256:7911d7f1be36f13b13357e12663e50fa4f1db34e2ee9fe3479cb036332f926f2" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_relay-0.9.13-py2.py3-none-macosx_14_0_arm64.whl", hash = "sha256:4293f868d55c2a9230d98827f3b858a20d7ded135ed0fe6b84113d02660a999c" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_relay-0.9.13-py2.py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:cb484eaf7aaae7e88c7b3e8d714f2cb32f3469a874b9189ddd9b213c05f37ef3" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_relay-0.9.13-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:8f952d8602dfc8998d281861fe47d91142866899967e43a90f4592cd9fe56e10" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Summary
This bumps the sentry relay package, including the change in PII scrubbing for logs to allow  being selected, etc.
