### PR TITLE
ref(feedback): add org id to seer request params for langfuse sampling

### DIFF
--- a/src/sentry/feedback/usecases/ingest/create_feedback.py
+++ b/src/sentry/feedback/usecases/ingest/create_feedback.py
@@ -310,7 +310,7 @@ def create_feedback_issue(
     use_ai_title = should_query_seer and features.has(
         "organizations:user-feedback-ai-titles", project.organization
     )
-    title = get_feedback_title(feedback_message, use_ai_title)
+    title = get_feedback_title(feedback_message, project.organization_id, use_ai_title)
 
     occurrence = IssueOccurrence(
         id=uuid4().hex,
@@ -343,7 +343,7 @@ def create_feedback_issue(
         "organizations:user-feedback-ai-categorization", project.organization
     ):
         try:
-            labels = generate_labels(feedback_message)
+            labels = generate_labels(feedback_message, project.organization_id)
             # This will rarely happen unless the user writes a really long feedback message
             if len(labels) > MAX_AI_LABELS:
                 logger.info(

--- a/src/sentry/feedback/usecases/label_generation.py
+++ b/src/sentry/feedback/usecases/label_generation.py
@@ -26,7 +26,7 @@ SEER_GENERATE_LABELS_URL = f"{settings.SEER_AUTOFIX_URL}/v1/automation/summarize
 
 
 @metrics.wraps("feedback.generate_labels")
-def generate_labels(feedback_message: str) -> list[str]:
+def generate_labels(feedback_message: str, organization_id: int) -> list[str]:
     """
     Generate labels for a feedback message.
 
@@ -38,6 +38,7 @@ def generate_labels(feedback_message: str) -> list[str]:
     """
     request = LabelRequest(
         feedback_message=feedback_message,
+        organization_id=organization_id,
     )
 
     serialized_request = json.dumps(request)

--- a/src/sentry/feedback/usecases/label_generation.py
+++ b/src/sentry/feedback/usecases/label_generation.py
@@ -13,6 +13,7 @@ logger = logging.getLogger(__name__)
 class LabelRequest(TypedDict):
     """Corresponds to GenerateFeedbackLabelsRequest in Seer."""
 
+    organization_id: int
     feedback_message: str
 
 

--- a/src/sentry/feedback/usecases/title_generation.py
+++ b/src/sentry/feedback/usecases/title_generation.py
@@ -17,6 +17,7 @@ SEER_GENERATE_TITLE_URL = f"{settings.SEER_AUTOFIX_URL}/v1/automation/summarize/
 class GenerateFeedbackTitleRequest(TypedDict):
     """Corresponds to GenerateFeedbackTitleRequest in Seer."""
 
+    organization_id: int
     feedback_message: str
 
 
@@ -54,7 +55,7 @@ def format_feedback_title(title: str, max_words: int = 10) -> str:
 
 
 @metrics.wraps("feedback.ai_title_generation")
-def get_feedback_title_from_seer(feedback_message: str) -> str | None:
+def get_feedback_title_from_seer(feedback_message: str, organization_id: int) -> str | None:
     """
     Generate an AI-powered title for user feedback using Seer, or None if generation fails.
 
@@ -68,6 +69,7 @@ def get_feedback_title_from_seer(feedback_message: str) -> str | None:
     """
     seer_request = GenerateFeedbackTitleRequest(
         feedback_message=feedback_message,
+        organization_id=organization_id,
     )
 
     try:
@@ -120,10 +122,12 @@ def make_seer_request(request: GenerateFeedbackTitleRequest) -> bytes:
     return response.content
 
 
-def get_feedback_title(feedback_message: str, use_seer: bool) -> str:
+def get_feedback_title(feedback_message: str, organization_id: int, use_seer: bool) -> str:
     if use_seer:
         # Message is fallback if Seer fails.
-        raw_title = get_feedback_title_from_seer(feedback_message) or feedback_message
+        raw_title = (
+            get_feedback_title_from_seer(feedback_message, organization_id) or feedback_message
+        )
     else:
         raw_title = feedback_message
 

--- a/tests/sentry/feedback/usecases/test_label_generation.py
+++ b/tests/sentry/feedback/usecases/test_label_generation.py
@@ -25,7 +25,7 @@ class TestGenerateLabels(TestCase):
         )
 
         labels = generate_labels(
-            "I don't like the new right sidebar, it makes navigating everywhere hard!"
+            "I don't like the new right sidebar, it makes navigating everywhere hard!", 1
         )
 
         test_request = responses.calls[0].request
@@ -34,6 +34,7 @@ class TestGenerateLabels(TestCase):
         assert labels == ["User Interface", "Navigation", "Right Sidebar"]
         assert json.loads(test_request.body) == {
             "feedback_message": "I don't like the new right sidebar, it makes navigating everywhere hard!",
+            "organization_id": 1,
         }
         assert test_response.status_code == 200
 
@@ -46,7 +47,7 @@ class TestGenerateLabels(TestCase):
 
         with pytest.raises(requests.exceptions.HTTPError):
             generate_labels(
-                "I don't like the new right sidebar, it makes navigating everywhere hard!"
+                "I don't like the new right sidebar, it makes navigating everywhere hard!", 1
             )
 
         test_request = responses.calls[0].request
@@ -55,6 +56,7 @@ class TestGenerateLabels(TestCase):
         assert test_response.status_code == 500
         assert json.loads(test_request.body) == {
             "feedback_message": "I don't like the new right sidebar, it makes navigating everywhere hard!",
+            "organization_id": 1,
         }
 
     @responses.activate
@@ -63,7 +65,7 @@ class TestGenerateLabels(TestCase):
 
         with pytest.raises(requests.exceptions.Timeout):
             generate_labels(
-                "I don't like the new right sidebar, it makes navigating everywhere hard!"
+                "I don't like the new right sidebar, it makes navigating everywhere hard!", 1
             )
 
         test_request = responses.calls[0].request
@@ -71,4 +73,5 @@ class TestGenerateLabels(TestCase):
         assert len(responses.calls) == 1
         assert json.loads(test_request.body) == {
             "feedback_message": "I don't like the new right sidebar, it makes navigating everywhere hard!",
+            "organization_id": 1,
         }

--- a/tests/sentry/feedback/usecases/test_title_generation.py
+++ b/tests/sentry/feedback/usecases/test_title_generation.py
@@ -29,7 +29,10 @@ class TestTitleGeneration(TestCase):
     @responses.activate
     def test_make_seer_request(self):
         """Test the make_seer_request function with successful response."""
-        request = GenerateFeedbackTitleRequest(feedback_message="Test feedback message")
+        request = GenerateFeedbackTitleRequest(
+            feedback_message="Test feedback message",
+            organization_id=1,
+        )
 
         mock_seer_response(
             status=200,
@@ -57,7 +60,10 @@ class TestTitleGeneration(TestCase):
     @responses.activate
     def test_make_seer_request_http_error(self):
         """Test the make_seer_request function with HTTP error."""
-        request = GenerateFeedbackTitleRequest(feedback_message="Test feedback message")
+        request = GenerateFeedbackTitleRequest(
+            feedback_message="Test feedback message",
+            organization_id=1,
+        )
 
         mock_seer_response(status=500, body="Internal Server Error")
 
@@ -107,7 +113,7 @@ class TestTitleGeneration(TestCase):
             status=200,
             body='{"invalid": "response"}',
         )
-        assert get_feedback_title_from_seer("Login button broken") is None
+        assert get_feedback_title_from_seer("Login button broken", 1) is None
 
     @responses.activate
     def test_get_feedback_title_from_seer_empty_title(self):
@@ -116,7 +122,7 @@ class TestTitleGeneration(TestCase):
             status=200,
             body='{"title": ""}',
         )
-        assert get_feedback_title_from_seer("Login button broken") is None
+        assert get_feedback_title_from_seer("Login button broken", 1) is None
 
     @responses.activate
     def test_get_feedback_title_from_seer_whitespace_only_title(self):
@@ -125,7 +131,7 @@ class TestTitleGeneration(TestCase):
             status=200,
             body='{"title": "   "}',
         )
-        assert get_feedback_title_from_seer("Login button broken") is None
+        assert get_feedback_title_from_seer("Login button broken", 1) is None
 
     @responses.activate
     def test_get_feedback_title_from_seer_non_string_title(self):
@@ -134,7 +140,7 @@ class TestTitleGeneration(TestCase):
             status=200,
             body='{"title": 123}',
         )
-        assert get_feedback_title_from_seer("Login button broken") is None
+        assert get_feedback_title_from_seer("Login button broken", 1) is None
 
     @responses.activate
     def test_get_feedback_title_from_seer_invalid_json(self):
@@ -143,7 +149,7 @@ class TestTitleGeneration(TestCase):
             status=200,
             body='{"invalid": json}',
         )
-        assert get_feedback_title_from_seer("Login button broken") is None
+        assert get_feedback_title_from_seer("Login button broken", 1) is None
 
     @responses.activate
     def test_get_feedback_title_from_seer_http_error(self):
@@ -152,13 +158,13 @@ class TestTitleGeneration(TestCase):
             status=500,
             body="Internal Server Error",
         )
-        assert get_feedback_title_from_seer("Login button broken") is None
+        assert get_feedback_title_from_seer("Login button broken", 1) is None
 
     @responses.activate
     def test_get_feedback_title_from_seer_network_error(self):
         """Test the get_feedback_title_from_seer function with network error."""
         mock_seer_response(body=Exception("Network error"))
-        assert get_feedback_title_from_seer("Login button broken") is None
+        assert get_feedback_title_from_seer("Login button broken", 1) is None
 
     @responses.activate
     def test_get_feedback_title_from_seer_success(self):
@@ -167,4 +173,4 @@ class TestTitleGeneration(TestCase):
             status=200,
             body='{"title": "Login Button Issue"}',
         )
-        assert get_feedback_title_from_seer("Login button broken") == "Login Button Issue"
+        assert get_feedback_title_from_seer("Login button broken", 1) == "Login Button Issue"


### PR DESCRIPTION
- Must merge and deploy before the respective PR in Seer (https://github.com/getsentry/seer/pull/3201)