### PR TITLE
ref(grouping): make FE only accept underscores for EventGroupVariantType

### DIFF
--- a/static/app/components/events/groupingInfo/useEventGroupingInfo.tsx
+++ b/static/app/components/events/groupingInfo/useEventGroupingInfo.tsx
@@ -1,8 +1,6 @@
 import {t} from 'sentry/locale';
 import {
-  convertVariantFromBackend,
   EventGroupVariantType,
-  isEventGroupVariantType,
   type Event,
   type EventGroupVariant,
 } from 'sentry/types/event';
@@ -68,16 +66,7 @@ export function useEventGroupingInfo({
 
   const groupInfo = hasPerformanceGrouping
     ? generatePerformanceGroupInfo({group, event})
-    : data
-      ? Object.fromEntries(
-          Object.entries(data).map(([key, variant]) => [
-            key,
-            isEventGroupVariantType(variant.type)
-              ? convertVariantFromBackend(variant)
-              : variant,
-          ])
-        )
-      : null;
+    : (data ?? null);
 
   return {groupInfo, isPending, isError, isSuccess, hasPerformanceGrouping};
 }

--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -57,33 +57,6 @@ export const enum EventGroupVariantType {
   PERFORMANCE_PROBLEM = 'performance_problem',
 }
 
-function convertVariantTypeToUnderscore(type: string): EventGroupVariantType {
-  const converted = type.replace(/-/g, '_');
-  return converted as EventGroupVariantType;
-}
-
-export function isEventGroupVariantType(value: string): value is EventGroupVariantType {
-  const eventGroupVariantTypes = new Set<string>([
-    'checksum',
-    'fallback',
-    'custom-fingerprint',
-    'built-in-fingerprint',
-    'component',
-    'salted-component',
-    'performance-problem',
-  ]);
-  return eventGroupVariantTypes.has(value);
-}
-
-export function convertVariantFromBackend(variant: any): EventGroupVariant {
-  const convertedVariant = {
-    ...variant,
-    type: convertVariantTypeToUnderscore(variant.type),
-  };
-
-  return convertedVariant as EventGroupVariant;
-}
-
 interface BaseVariant {
   description: string | null;
   hash: string | null;


### PR DESCRIPTION
Continuation of #97426. 

Remove functions added in #97683 now that the back end sends event group variants with underscores. 
