### PR TITLE
ref(hackweek): Remove compat code for frontend versions configmap

### DIFF
--- a/src/sentry/utils/assets.py
+++ b/src/sentry/utils/assets.py
@@ -11,12 +11,9 @@ from sentry.utils import json
 
 @dataclass
 class FrontendVersions:
-    commit_sha: str | None
+    commit_sha: str
     """
     The commit SHA of the currently deployed frontend version.
-
-    XXX(epuirkhiser): currently may be None while we transition to a
-    frontend-versions file that contains the version_sha.
     """
     entrypoints: dict[str, str]
     """
@@ -30,17 +27,9 @@ def _frontend_versions() -> FrontendVersions | None:
     config = os.path.join(settings.CONF_DIR, "settings", "frontend", "frontend-versions.json")
     try:
         with open(config) as f:
-            contents = json.load(f)  # getsentry path
+            return FrontendVersions(**json.load(f))  # getsentry path
     except OSError:
         return None  # common case for self-hosted
-
-    # XXX(epurkhiser): Shim code while we transition to a
-    # `frontend-versions.json` file that contains both a webpack entrypoint
-    # mapping as well as a commit SHA.
-    if "commit_sha" not in contents:
-        return FrontendVersions(commit_sha=None, entrypoints=contents)
-
-    return FrontendVersions(**contents)
 
 
 def get_frontend_commit_sha() -> str | None:

--- a/tests/sentry/utils/test_assets.py
+++ b/tests/sentry/utils/test_assets.py
@@ -54,23 +54,6 @@ def getsentry(tmp_path: pathlib.Path) -> Generator[None]:
             yield
 
 
-# XXX(epurkhiser): To be removed when the frontend-versions config map
-# consistently matches the FrontendVersions TypedDict.
-@pytest.fixture
-def getsentry_legacy(tmp_path: pathlib.Path) -> Generator[None]:
-    with mock.patch.object(
-        settings, "STATIC_FRONTEND_APP_URL", "https://static.example.com/_static/dist/"
-    ):
-        conf_dir = tmp_path.joinpath("conf")
-        conf_dir.mkdir()
-        conf_dir.joinpath("settings/frontend").mkdir(parents=True)
-        conf_dir.joinpath("settings/frontend/frontend-versions.json").write_text(
-            '{"app.js": "app-deadbeef.js", "app.css": "app-cafecafe.css"}'
-        )
-        with mock.patch.object(settings, "CONF_DIR", conf_dir):
-            yield
-
-
 @pytest.mark.usefixtures("self_hosted")
 def test_frontend_app_asset_url_self_hosted() -> None:
     ret = assets.get_frontend_app_asset_url("sentry", "entrypoints/app.js")
@@ -81,16 +64,6 @@ def test_frontend_app_asset_url_self_hosted() -> None:
 def test_frontend_app_asset_url_getsentry_no_configmap() -> None:
     ret = assets.get_frontend_app_asset_url("sentry", "entrypoints/app.js")
     assert ret == "https://static.example.com/_static/dist/sentry/entrypoints/app.js"
-
-
-# XXX(epurkhiser): To be removed when the frontend-versions config map
-# consistently matches the FrontendVersions TypedDict.
-@pytest.mark.usefixtures("getsentry_legacy")
-def test_frontend_app_asset_url_getsentry_legacy() -> None:
-    ret = assets.get_frontend_app_asset_url("sentry", "entrypoints/app.js")
-    assert (
-        ret == "https://static.example.com/_static/dist/sentry/entrypoints-hashed/app-deadbeef.js"
-    )
 
 
 @pytest.mark.usefixtures("getsentry")


### PR DESCRIPTION
Should NOT be merged until we've deployed the new `frontned-versions.json` file to all regions.