### PR TITLE
ref(groupingInfo): Only show grouping variant if it contributes for Contributing Values

### DIFF
--- a/static/app/components/events/groupingInfo/groupingInfo.tsx
+++ b/static/app/components/events/groupingInfo/groupingInfo.tsx
@@ -102,12 +102,15 @@ export default function GroupingInfo({
       {hasPerformanceGrouping || isSuccess
         ? variants.map((variant, index) => (
             <Fragment key={variant.key}>
-              <GroupingVariant
-                event={event}
-                variant={variant}
-                showNonContributing={showNonContributing}
-              />
-              {index < variants.length - 1 && <VariantDivider />}
+              {(variant.hash !== null || showNonContributing) && (
+                <GroupingVariant
+                  event={event}
+                  variant={variant}
+                  showNonContributing={showNonContributing}
+                />
+              )}
+              {(variant.hash !== null || showNonContributing) &&
+                index < variants.length - 1 && <VariantDivider />}
             </Fragment>
           ))
         : null}

--- a/static/app/components/events/groupingInfo/groupingInfo.tsx
+++ b/static/app/components/events/groupingInfo/groupingInfo.tsx
@@ -100,19 +100,18 @@ export default function GroupingInfo({
       {isError ? <LoadingError message={t('Failed to fetch grouping info.')} /> : null}
       {isPending && !hasPerformanceGrouping ? <LoadingIndicator /> : null}
       {hasPerformanceGrouping || isSuccess
-        ? variants.map((variant, index) => (
-            <Fragment key={variant.key}>
-              {(variant.hash !== null || showNonContributing) && (
+        ? variants
+            .filter(variant => variant.hash !== null || showNonContributing)
+            .map((variant, index, filteredVariants) => (
+              <Fragment key={variant.key}>
                 <GroupingVariant
                   event={event}
                   variant={variant}
                   showNonContributing={showNonContributing}
                 />
-              )}
-              {(variant.hash !== null || showNonContributing) &&
-                index < variants.length - 1 && <VariantDivider />}
-            </Fragment>
-          ))
+                {index < filteredVariants.length - 1 && <VariantDivider />}
+              </Fragment>
+            ))
         : null}
     </Fragment>
   );


### PR DESCRIPTION
Non-contributing grouping variants should only be shown if 'All Values' is set. 

Before: 
<img width="906" height="510" alt="non-contributing-showing-up" src="https://github.com/user-attachments/assets/8a4e0f13-2b82-4b9a-9271-652f58e9ed52" />

After: 
<img width="904" height="358" alt="image" src="https://github.com/user-attachments/assets/a606b442-087a-4be6-9117-a9a1b366c3eb" />

