### PR TITLE
feat(logs): Add empty state onboarding for ruby sdks

### DIFF
--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -367,6 +367,9 @@ export const withLoggingOnboarding: Set<PlatformKey> = new Set([
   'python-tornado',
   'python-tryton',
   'python-wsgi',
+  'ruby',
+  'ruby-rack',
+  'ruby-rails',
 ]);
 
 // List of platforms that do not have logging support. We make use of this list in the product to not provide any Logging

--- a/static/app/gettingStartedDocs/ruby/rack.tsx
+++ b/static/app/gettingStartedDocs/ruby/rack.tsx
@@ -8,6 +8,7 @@ import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {CrashReportWebApiOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
 import {getRubyProfilingOnboarding} from 'sentry/gettingStartedDocs/ruby/ruby';
 import {t, tct} from 'sentry/locale';
+import {getRubyLogsOnboarding} from 'sentry/utils/gettingStartedDocs/ruby';
 
 type Params = DocsParams;
 
@@ -144,6 +145,9 @@ const docs: Docs = {
   onboarding,
   crashReportOnboarding: CrashReportWebApiOnboarding,
   profilingOnboarding: getRubyProfilingOnboarding(),
+  logsOnboarding: getRubyLogsOnboarding({
+    docsPlatform: 'rack',
+  }),
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/ruby/rails.tsx
+++ b/static/app/gettingStartedDocs/ruby/rails.tsx
@@ -16,6 +16,7 @@ import {
 } from 'sentry/gettingStartedDocs/javascript/jsLoader/jsLoader';
 import {getRubyProfilingOnboarding} from 'sentry/gettingStartedDocs/ruby/ruby';
 import {t, tct} from 'sentry/locale';
+import {getRubyLogsOnboarding} from 'sentry/utils/gettingStartedDocs/ruby';
 
 type Params = DocsParams;
 
@@ -216,6 +217,9 @@ const docs: Docs = {
   crashReportOnboarding,
   feedbackOnboardingJsLoader,
   profilingOnboarding: getRubyProfilingOnboarding({frameworkPackage: 'sentry-rails'}),
+  logsOnboarding: getRubyLogsOnboarding({
+    docsPlatform: 'rails',
+  }),
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/ruby/ruby.tsx
+++ b/static/app/gettingStartedDocs/ruby/ruby.tsx
@@ -7,6 +7,7 @@ import type {
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {CrashReportWebApiOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
 import {t, tct} from 'sentry/locale';
+import {getRubyLogsOnboarding} from 'sentry/utils/gettingStartedDocs/ruby';
 
 type Params = DocsParams;
 
@@ -199,6 +200,9 @@ const docs: Docs = {
   onboarding,
   crashReportOnboarding: CrashReportWebApiOnboarding,
   profilingOnboarding: getRubyProfilingOnboarding(),
+  logsOnboarding: getRubyLogsOnboarding({
+    docsPlatform: 'ruby',
+  }),
 };
 
 export default docs;

--- a/static/app/utils/gettingStartedDocs/ruby.tsx
+++ b/static/app/utils/gettingStartedDocs/ruby.tsx
@@ -82,7 +82,9 @@ end`,
         {
           type: 'code',
           language: 'ruby',
-          code: `logger = Logger.new($stdout)
+          code: `require 'logger'
+
+logger = Logger.new($stdout)
 logger.info("Sentry test log from stdlib logger")`,
         },
         {

--- a/static/app/utils/gettingStartedDocs/ruby.tsx
+++ b/static/app/utils/gettingStartedDocs/ruby.tsx
@@ -1,0 +1,100 @@
+import {ExternalLink} from 'sentry/components/core/link';
+import {
+  StepType,
+  type BasePlatformOptions,
+  type OnboardingConfig,
+} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {t, tct} from 'sentry/locale';
+
+export const getRubyLogsOnboarding = <
+  PlatformOptions extends BasePlatformOptions = BasePlatformOptions,
+>({
+  docsPlatform,
+}: {
+  docsPlatform: string;
+}): OnboardingConfig<PlatformOptions> => ({
+  install: () => [
+    {
+      type: StepType.INSTALL,
+      content: [
+        {
+          type: 'text',
+          text: tct(
+            "To start using logs, make sure your Sentry Ruby SDK version is [code:5.24.0] or higher. If you're on an older major version of the SDK, follow our [link:migration guide] to upgrade.",
+            {
+              code: <code />,
+              link: (
+                <ExternalLink
+                  href={
+                    docsPlatform === 'ruby'
+                      ? 'https://docs.sentry.io/platforms/ruby/migration/'
+                      : `https://docs.sentry.io/platforms/ruby/guides/${docsPlatform}/migration/`
+                  }
+                />
+              ),
+            }
+          ),
+        },
+        {
+          type: 'code',
+          language: 'bash',
+          code: 'gem install sentry-ruby',
+        },
+      ],
+    },
+  ],
+  configure: () => [
+    {
+      type: StepType.CONFIGURE,
+      content: [
+        {
+          type: 'text',
+          text: tct(
+            'To enable logging, you need to initialize the SDK with the [code:enable_logs] option set to [code:true]. You can also patch the Ruby logger to forward logs to Sentry.',
+            {
+              code: <code />,
+            }
+          ),
+        },
+        {
+          type: 'code',
+          language: 'ruby',
+          code: `require 'sentry-ruby'
+
+Sentry.init do |config|
+  # Enable sending logs to Sentry
+  config.enable_logs = true
+  # Patch Ruby logger to forward logs
+  config.enabled_patches = [:logger]
+end`,
+        },
+      ],
+    },
+  ],
+  verify: () => [
+    {
+      type: StepType.VERIFY,
+      content: [
+        {
+          type: 'text',
+          text: t('You can use the Ruby stdlib logger to test sending logs to Sentry.'),
+        },
+        {
+          type: 'code',
+          language: 'ruby',
+          code: `logger = Logger.new($stdout)
+logger.info("Sentry test log from stdlib logger")`,
+        },
+        {
+          type: 'text',
+          text: t('You can also use the Sentry logger APIs to send logs to Sentry.'),
+        },
+        {
+          type: 'code',
+          language: 'ruby',
+          code: `Sentry.logger.info("Test log from %{test_source}", test_source: "Sentry")`,
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
resolves https://linear.app/getsentry/issue/LOGS-318/add-empty-state-onboarding-for-ruby-sdks

<img width="1216" height="788" alt="image" src="https://github.com/user-attachments/assets/0c26339c-8602-43b9-9421-1b861932a76c" />