### PR TITLE
feat(explore): Open explore spans toolbar when using aggregates mode

### DIFF
--- a/static/app/views/explore/spans/spansTab.spec.tsx
+++ b/static/app/views/explore/spans/spansTab.spec.tsx
@@ -200,7 +200,45 @@ describe('SpansTabContent', () => {
       'timestamp',
       'project',
     ]);
-  }, 20_000);
+  });
+
+  it('opens toolbar when switching to aggregates tab', async () => {
+    render(
+      <Wrapper>
+        <SpansTabContent datePageFilterProps={datePageFilterProps} />
+      </Wrapper>,
+      {organization}
+    );
+
+    // by default the toolbar should be visible
+    expect(screen.getByTestId('explore-span-toolbar')).toBeInTheDocument();
+    expect(screen.getByLabelText('Collapse sidebar')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Expand sidebar')).not.toBeInTheDocument();
+
+    // collapse the toolbar
+    await userEvent.click(screen.getByLabelText('Collapse sidebar'));
+    expect(screen.queryByTestId('explore-span-toolbar')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Collapse sidebar')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Expand sidebar')).toBeInTheDocument();
+
+    // switching to the aggregates tab should expand the toolbar
+    await userEvent.click(await screen.findByRole('tab', {name: 'Aggregates'}));
+    expect(screen.getByTestId('explore-span-toolbar')).toBeInTheDocument();
+    expect(screen.getByLabelText('Collapse sidebar')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Expand sidebar')).not.toBeInTheDocument();
+
+    // collapse the toolbar
+    await userEvent.click(screen.getByLabelText('Collapse sidebar'));
+    expect(screen.queryByTestId('explore-span-toolbar')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Collapse sidebar')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Expand sidebar')).toBeInTheDocument();
+
+    // switching to the span samples tab should NOT expand the toolbar
+    await userEvent.click(await screen.findByRole('tab', {name: 'Span Samples'}));
+    expect(screen.queryByTestId('explore-span-toolbar')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Collapse sidebar')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Expand sidebar')).toBeInTheDocument();
+  });
 
   describe('schema hints', () => {
     let spies: jest.SpyInstance[];

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -351,7 +351,7 @@ function SpanTabControlSection({
         position="right"
         margin={-8}
       >
-        <ExploreToolbar width={300} extras={toolbarExtras} />
+        {controlSectionExpanded && <ExploreToolbar width={300} extras={toolbarExtras} />}
       </TourElement>
     </ControlSection>
   );
@@ -369,19 +369,14 @@ function SpanTabContentSection({
   setControlSectionExpanded,
 }: SpanTabContentSectionProps) {
   const {selection} = usePageFilters();
-  const mode = useQueryParamsMode();
   const visualizes = useExploreVisualizes();
   const setVisualizes = useSetExploreVisualizes();
-  const [samplesTab, setSamplesTab] = useTab();
+  const [tab, setTab] = useTab();
 
   const query = useExploreQuery();
 
   const queryType: 'aggregate' | 'samples' | 'traces' =
-    mode === Mode.AGGREGATE
-      ? 'aggregate'
-      : samplesTab === Tab.TRACE
-        ? 'traces'
-        : 'samples';
+    tab === Mode.AGGREGATE ? 'aggregate' : tab === Tab.TRACE ? 'traces' : 'samples';
 
   const limit = 50;
 
@@ -505,8 +500,13 @@ function SpanTabContentSection({
           spansTableResult={spansTableResult}
           tracesTableResult={tracesTableResult}
           confidences={confidences}
-          samplesTab={samplesTab}
-          setSamplesTab={setSamplesTab}
+          tab={tab}
+          setTab={(newTab: Mode | Tab) => {
+            if (newTab === Mode.AGGREGATE) {
+              setControlSectionExpanded(true);
+            }
+            setTab(newTab);
+          }}
         />
       </TourElement>
     </ContentSection>

--- a/static/app/views/explore/tables/index.tsx
+++ b/static/app/views/explore/tables/index.tsx
@@ -15,7 +15,6 @@ import {
   useExploreFields,
   useSetExploreAggregateFields,
   useSetExploreFields,
-  useSetExploreMode,
 } from 'sentry/views/explore/contexts/pageParamsContext';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {useTraceItemTags} from 'sentry/views/explore/contexts/spanTagsContext';
@@ -23,7 +22,6 @@ import type {AggregatesTableResult} from 'sentry/views/explore/hooks/useExploreA
 import type {SpansTableResult} from 'sentry/views/explore/hooks/useExploreSpansTable';
 import type {TracesTableResult} from 'sentry/views/explore/hooks/useExploreTracesTable';
 import {Tab} from 'sentry/views/explore/hooks/useTab';
-import {useQueryParamsMode} from 'sentry/views/explore/queryParams/context';
 import {AggregateColumnEditorModal} from 'sentry/views/explore/tables/aggregateColumnEditorModal';
 import {AggregatesTable} from 'sentry/views/explore/tables/aggregatesTable';
 import {ColumnEditorModal} from 'sentry/views/explore/tables/columnEditorModal';
@@ -32,8 +30,8 @@ import {TracesTable} from 'sentry/views/explore/tables/tracesTable/index';
 
 interface BaseExploreTablesProps {
   confidences: Confidence[];
-  samplesTab: Tab;
-  setSamplesTab: (tab: Tab) => void;
+  setTab: (tab: Mode | Tab) => void;
+  tab: Mode | Tab;
 }
 
 interface ExploreTablesProps extends BaseExploreTablesProps {
@@ -47,9 +45,6 @@ export function ExploreTables(props: ExploreTablesProps) {
 
   const aggregateFields = useExploreAggregateFields();
   const setAggregateFields = useSetExploreAggregateFields();
-
-  const mode = useQueryParamsMode();
-  const setMode = useSetExploreMode();
 
   const fields = useExploreFields();
   const setFields = useSetExploreFields();
@@ -87,37 +82,21 @@ export function ExploreTables(props: ExploreTablesProps) {
     );
   }, [aggregateFields, setAggregateFields, stringTags, numberTags]);
 
-  // HACK: This is pretty gross but to not break anything in the
-  // short term, we avoid introducing/removing any fields on the
-  // query. So we continue using the existing `mode` value and
-  // coalesce it with the `tab` value` to create a single tab.
-  const tab = mode === Mode.AGGREGATE ? mode : props.samplesTab;
-  const setTab = useCallback(
-    (option: Tab | Mode) => {
-      if (option === Mode.AGGREGATE) {
-        setMode(Mode.AGGREGATE);
-      } else if (option === Tab.SPAN || option === Tab.TRACE) {
-        props.setSamplesTab(option);
-      }
-    },
-    [setMode, props]
-  );
-
   return (
     <Fragment>
       <SamplesTableHeader>
-        <Tabs value={tab} onChange={setTab} size="sm">
+        <Tabs value={props.tab} onChange={props.setTab} size="sm">
           <TabList hideBorder variant="floating">
             <TabList.Item key={Tab.SPAN}>{t('Span Samples')}</TabList.Item>
             <TabList.Item key={Tab.TRACE}>{t('Trace Samples')}</TabList.Item>
             <TabList.Item key={Mode.AGGREGATE}>{t('Aggregates')}</TabList.Item>
           </TabList>
         </Tabs>
-        {tab === Tab.SPAN ? (
+        {props.tab === Tab.SPAN ? (
           <Button onClick={openColumnEditor} icon={<IconTable />} size="sm">
             {t('Edit Table')}
           </Button>
-        ) : tab === Mode.AGGREGATE &&
+        ) : props.tab === Mode.AGGREGATE &&
           organization.features.includes('visibility-explore-aggregate-editor') ? (
           <Button onClick={openAggregateColumnEditor} icon={<IconTable />} size="sm">
             {t('Edit Table')}
@@ -125,7 +104,7 @@ export function ExploreTables(props: ExploreTablesProps) {
         ) : (
           <Tooltip
             title={
-              tab === Tab.TRACE
+              props.tab === Tab.TRACE
                 ? t('Editing columns is available for span samples only')
                 : t('Use the Group By and Visualize controls to change table columns')
             }
@@ -136,9 +115,9 @@ export function ExploreTables(props: ExploreTablesProps) {
           </Tooltip>
         )}
       </SamplesTableHeader>
-      {tab === Tab.SPAN && <SpansTable {...props} />}
-      {tab === Tab.TRACE && <TracesTable {...props} />}
-      {tab === Mode.AGGREGATE && <AggregatesTable {...props} />}
+      {props.tab === Tab.SPAN && <SpansTable {...props} />}
+      {props.tab === Tab.TRACE && <TracesTable {...props} />}
+      {props.tab === Mode.AGGREGATE && <AggregatesTable {...props} />}
     </Fragment>
   );
 }

--- a/static/app/views/explore/toolbar/index.tsx
+++ b/static/app/views/explore/toolbar/index.tsx
@@ -27,7 +27,7 @@ export function ExploreToolbar({extras, width}: ExploreToolbarProps) {
   const setGroupBys = useSetExploreGroupBys();
 
   return (
-    <Container width={width}>
+    <Container data-test-id="explore-span-toolbar" width={width}>
       <ToolbarVisualize
         visualizes={visualizes}
         setVisualizes={setVisualizes}


### PR DESCRIPTION
This ensures the toolbar is open whenever the user switches to the aggregates tab.