### PR TITLE
chore(logs): Add logs to top events tests

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_events_stats_ourlogs.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_ourlogs.py
@@ -287,7 +287,7 @@ class OrganizationEventsStatsOurlogsEndpointTest(OrganizationEventsEndpointTestB
             rows = response.data[key]["data"][0:6]
             for expected, result in zip([0, 1, 0, 0, 0, 0], rows):
                 assert result[1][0]["count"] == expected, key
-            assert response.data[projects[0].slug]["meta"]["dataset"] == "logs"
+            assert response.data[key]["meta"]["dataset"] == "logs"
 
     def test_top_events_with_project_and_project_id(self) -> None:
         projects = [self.create_project(), self.create_project()]

--- a/tests/snuba/api/endpoints/test_organization_events_stats_ourlogs.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_ourlogs.py
@@ -97,3 +97,249 @@ class OrganizationEventsStatsOurlogsEndpointTest(OrganizationEventsEndpointTestB
         )
         assert response.status_code == 200, response.content
         assert [attrs for time, attrs in response.data["data"]] == [[{"count": 0}]] * 338
+
+    def test_top_events(self) -> None:
+        event_counts = [6, 0, 6, 3, 0, 3]
+        logs = [
+            self.create_ourlog(
+                {"body": "baz"},
+                timestamp=self.start + timedelta(hours=1),
+                attributes={"status": {"string_value": "success"}},
+            )
+        ]
+        for hour, count in enumerate(event_counts):
+            logs.extend(
+                [
+                    self.create_ourlog(
+                        {"body": "foo"},
+                        timestamp=self.start + timedelta(hours=hour, minutes=minute),
+                        attributes={"status": {"string_value": "success"}},
+                    )
+                    for minute in range(count)
+                ],
+            )
+            logs.extend(
+                [
+                    self.create_ourlog(
+                        {"body": "bar"},
+                        timestamp=self.start + timedelta(hours=hour, minutes=minute),
+                        attributes={"status": {"string_value": "success"}},
+                    )
+                    for minute in range(count)
+                ],
+            )
+        self.store_ourlogs(logs)
+
+        response = self._do_request(
+            data={
+                "start": self.day_ago,
+                "end": self.day_ago + timedelta(hours=6),
+                "interval": "1h",
+                "yAxis": "count()",
+                "field": ["message", "count(message)"],
+                "orderby": ["-count_message"],
+                "project": self.project.id,
+                "dataset": "logs",
+                "excludeOther": 0,
+                "topEvents": 2,
+            },
+        )
+        assert response.status_code == 200, response.content
+        assert "Other" in response.data
+        assert "foo" in response.data
+        assert "bar" in response.data
+
+        for key in ["foo", "bar"]:
+            rows = response.data[key]["data"][0:6]
+            for expected, result in zip(event_counts, rows):
+                assert result[1][0]["count"] == expected, key
+
+            assert response.data[key]["meta"]["dataset"] == "logs"
+
+        rows = response.data["Other"]["data"][0:6]
+        for expected, result in zip([0, 1, 0, 0, 0, 0], rows):
+            assert result[1][0]["count"] == expected, "Other"
+
+    def test_top_events_empty_other(self) -> None:
+        event_counts = [6, 0, 6, 3, 0, 3]
+        logs = []
+        for hour, count in enumerate(event_counts):
+            logs.extend(
+                [
+                    self.create_ourlog(
+                        {"body": "foo"},
+                        timestamp=self.start + timedelta(hours=hour, minutes=minute),
+                        attributes={"status": {"string_value": "success"}},
+                    )
+                    for minute in range(count)
+                ],
+            )
+            logs.extend(
+                [
+                    self.create_ourlog(
+                        {"body": "bar"},
+                        timestamp=self.start + timedelta(hours=hour, minutes=minute),
+                        attributes={"status": {"string_value": "success"}},
+                    )
+                    for minute in range(count)
+                ],
+            )
+        self.store_ourlogs(logs)
+
+        response = self._do_request(
+            data={
+                "start": self.day_ago,
+                "end": self.day_ago + timedelta(hours=6),
+                "interval": "1h",
+                "yAxis": "count()",
+                "field": ["message", "count(message)"],
+                "orderby": ["-count_message"],
+                "project": self.project.id,
+                "dataset": "logs",
+                "excludeOther": 0,
+                "topEvents": 2,
+            },
+        )
+        assert response.status_code == 200, response.content
+        assert "Other" not in response.data
+        assert "foo" in response.data
+        assert "bar" in response.data
+
+        for key in ["foo", "bar"]:
+            rows = response.data[key]["data"][0:6]
+            for expected, result in zip(event_counts, rows):
+                assert result[1][0]["count"] == expected, key
+
+            assert response.data[key]["meta"]["dataset"] == "logs"
+
+    def test_top_events_multi_y_axis(self) -> None:
+        self.store_ourlogs(
+            [
+                self.create_ourlog(
+                    {"body": message},
+                    attributes={"user": "foo"},
+                    timestamp=self.day_ago + timedelta(minutes=1),
+                )
+                for message in ["foo", "bar", "baz"]
+            ],
+        )
+
+        response = self._do_request(
+            data={
+                "start": self.day_ago,
+                "end": self.day_ago + timedelta(minutes=6),
+                "interval": "1m",
+                "yAxis": ["count()", "count_unique(user)"],
+                "field": ["message", "count()"],
+                "orderby": ["message"],
+                "project": self.project.id,
+                "dataset": "logs",
+                "excludeOther": 0,
+                "topEvents": 2,
+            },
+        )
+        assert response.status_code == 200, response.content
+
+        for key in ["Other", "bar", "baz"]:
+            assert key in response.data
+            for y_axis in ["count()", "count_unique(user)"]:
+                assert y_axis in response.data[key]
+                assert response.data[key][y_axis]["meta"]["dataset"] == "logs"
+            counts = response.data[key]["count()"]["data"][0:6]
+            for expected, result in zip([0, 1, 0, 0, 0, 0], counts):
+                assert result[1][0]["count"] == expected, key
+            uniqs = response.data[key]["count_unique(user)"]["data"][0:6]
+            for expected, result in zip([0, 1, 0, 0, 0, 0], uniqs):
+                assert result[1][0]["count"] == expected, key
+
+    def test_top_events_with_project(self) -> None:
+        projects = [self.create_project(), self.create_project()]
+        self.store_ourlogs(
+            [
+                self.create_ourlog(
+                    {"body": "foo"},
+                    timestamp=self.start + timedelta(minutes=1),
+                    attributes={"status": {"string_value": "success"}},
+                    project=project,
+                )
+                for project in projects
+            ],
+        )
+
+        response = self._do_request(
+            data={
+                "start": self.day_ago,
+                "end": self.day_ago + timedelta(minutes=6),
+                "interval": "1m",
+                "yAxis": "count()",
+                "field": ["project", "count()"],
+                "orderby": ["-count"],
+                "dataset": "logs",
+                "excludeOther": 0,
+                "topEvents": 2,
+            },
+        )
+        assert response.status_code == 200, response.content
+        assert "Other" not in response.data
+        assert projects[0].slug in response.data
+        assert projects[1].slug in response.data
+        for key in [projects[0].slug, projects[1].slug]:
+            rows = response.data[key]["data"][0:6]
+            for expected, result in zip([0, 1, 0, 0, 0, 0], rows):
+                assert result[1][0]["count"] == expected, key
+            assert response.data[projects[0].slug]["meta"]["dataset"] == "logs"
+
+    def test_top_events_with_project_and_project_id(self) -> None:
+        projects = [self.create_project(), self.create_project()]
+        self.store_ourlogs(
+            [
+                self.create_ourlog(
+                    {"body": "foo"},
+                    timestamp=self.start + timedelta(minutes=1),
+                    attributes={"status": {"string_value": "success"}},
+                    project=project,
+                )
+                for project in projects
+            ],
+        )
+
+        response = self._do_request(
+            data={
+                "start": self.day_ago,
+                "end": self.day_ago + timedelta(minutes=6),
+                "interval": "1m",
+                "yAxis": "count()",
+                "field": ["project", "project.id", "count()"],
+                "orderby": ["-count"],
+                "dataset": "logs",
+                "excludeOther": 0,
+                "topEvents": 2,
+            },
+        )
+        assert response.status_code == 200, response.content
+        assert "Other" not in response.data
+        key1 = f"{projects[0].slug},{projects[0].id}"
+        key2 = f"{projects[1].slug},{projects[1].id}"
+        assert key1 in response.data
+        assert key2 in response.data
+        for key in [key1, key2]:
+            rows = response.data[key]["data"][0:6]
+            for expected, result in zip([0, 1, 0, 0, 0, 0], rows):
+                assert result[1][0]["count"] == expected, key
+            assert response.data[key]["meta"]["dataset"] == "logs"
+
+    def test_top_events_with_no_data(self) -> None:
+        response = self._do_request(
+            data={
+                "start": self.day_ago,
+                "end": self.day_ago + timedelta(minutes=6),
+                "interval": "1m",
+                "yAxis": "count()",
+                "field": ["project", "count()"],
+                "orderby": ["-count"],
+                "dataset": "logs",
+                "excludeOther": 0,
+                "topEvents": 2,
+            },
+        )
+        assert response.status_code == 200, response.content

--- a/tests/snuba/api/endpoints/test_organization_events_stats_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_span_indexed.py
@@ -500,7 +500,6 @@ class OrganizationEventsStatsSpansEndpointTest(OrganizationEventsEndpointTestBas
         assert response.data["foo"]["meta"]["dataset"] == "spans"
 
     def test_top_events_multi_y_axis(self) -> None:
-        # Each of these denotes how many events to create in each minute
         self.store_spans(
             [
                 self.create_span(
@@ -542,7 +541,6 @@ class OrganizationEventsStatsSpansEndpointTest(OrganizationEventsEndpointTestBas
                 assert result[1][0]["count"] == expected, key
 
     def test_top_events_with_project(self) -> None:
-        # Each of these denotes how many events to create in each minute
         projects = [self.create_project(), self.create_project()]
         self.store_spans(
             [
@@ -591,7 +589,6 @@ class OrganizationEventsStatsSpansEndpointTest(OrganizationEventsEndpointTestBas
         assert response.data["Other"]["meta"]["dataset"] == "spans"
 
     def test_top_events_with_project_and_project_id(self) -> None:
-        # Each of these denotes how many events to create in each minute
         projects = [self.create_project(), self.create_project()]
         self.store_spans(
             [
@@ -642,7 +639,6 @@ class OrganizationEventsStatsSpansEndpointTest(OrganizationEventsEndpointTestBas
         assert response.data["Other"]["meta"]["dataset"] == "spans"
 
     def test_top_events_with_no_data(self) -> None:
-        # Each of these denotes how many events to create in each minute
         response = self._do_request(
             data={
                 "start": self.day_ago,


### PR DESCRIPTION
- This adds some tests for top events on the logs dataset
- Also removes some redundant comments from span indexed tests
- Tests are just copied from span indexed over