### PR TITLE
feat(timeseries): Return data scanned info with series meta

### DIFF
--- a/src/sentry/api/endpoints/organization_events_timeseries.py
+++ b/src/sentry/api/endpoints/organization_events_timeseries.py
@@ -63,6 +63,7 @@ class SeriesMeta(TypedDict):
     order: NotRequired[int]
     isOther: NotRequired[str]
     valueUnit: NotRequired[str]
+    dataScanned: NotRequired[Literal["partial", "full"]]
     valueType: str
     interval: float
 
@@ -345,6 +346,8 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsV2EndpointBase):
             series_meta["isOther"] = result.data["is_other"]
         if "order" in result.data:
             series_meta["order"] = result.data["order"]
+        if "full_scan" in result.data["meta"]:
+            series_meta["dataScanned"] = "full" if result.data["meta"]["full_scan"] else "partial"
 
         timeseries = TimeSeries(
             values=[],

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries_logs.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries_logs.py
@@ -81,6 +81,7 @@ class OrganizationEventsStatsOurlogsMetricsEndpointTest(OrganizationEventsEndpoi
             confidence=[any_confidence if val else None for val in event_counts],
         )
         assert timeseries["meta"] == {
+            "dataScanned": "full",
             "valueType": "integer",
             "interval": 3_600_000,
         }

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries_spans.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries_spans.py
@@ -129,6 +129,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             confidence=[any_confidence if val else None for val in event_counts],
         )
         assert timeseries["meta"] == {
+            "dataScanned": "full",
             "valueType": "integer",
             "interval": 3_600_000,
         }
@@ -208,6 +209,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         )
         assert timeseries["groupBy"] == [{"key": "span.description", "value": "bar"}]
         assert timeseries["meta"] == {
+            "dataScanned": "full",
             "valueUnit": "millisecond",
             "valueType": "duration",
             "interval": interval,
@@ -223,6 +225,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         )
         assert timeseries["groupBy"] == [{"key": "span.description", "value": "bar"}]
         assert timeseries["meta"] == {
+            "dataScanned": "full",
             "valueUnit": "millisecond",
             "valueType": "duration",
             "interval": interval,
@@ -238,6 +241,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         )
         assert timeseries["groupBy"] is None
         assert timeseries["meta"] == {
+            "dataScanned": "full",
             "valueUnit": "millisecond",
             "valueType": "duration",
             "interval": interval,
@@ -253,6 +257,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         )
         assert timeseries["groupBy"] is None
         assert timeseries["meta"] == {
+            "dataScanned": "full",
             "valueUnit": "millisecond",
             "valueType": "duration",
             "interval": interval,
@@ -304,6 +309,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             self.start, 3_600_000, event_counts, ignore_accuracy=True
         )
         assert timeseries["meta"] == {
+            "dataScanned": "full",
             "valueType": "integer",
             "interval": 3_600_000,
         }
@@ -347,6 +353,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             self.start, 3_600_000, event_durations, ignore_accuracy=True
         )
         assert timeseries["meta"] == {
+            "dataScanned": "full",
             "valueUnit": "millisecond",
             "valueType": "duration",
             "interval": 3_600_000,
@@ -397,6 +404,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             self.start, 3_600_000, event_counts, ignore_accuracy=True
         )
         assert timeseries["meta"] == {
+            "dataScanned": "full",
             "valueType": "integer",
             "interval": 3_600_000,
         }
@@ -408,6 +416,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             self.start, 3_600_000, event_counts, ignore_accuracy=True
         )
         assert timeseries["meta"] == {
+            "dataScanned": "full",
             "valueUnit": "millisecond",
             "valueType": "duration",
             "interval": 3_600_000,
@@ -472,6 +481,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         )
         assert timeseries["groupBy"] == [{"key": "transaction", "value": "foo"}]
         assert timeseries["meta"] == {
+            "dataScanned": "full",
             "valueType": "integer",
             "interval": 60_000,
             "isOther": False,
@@ -486,6 +496,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         )
         assert timeseries["groupBy"] == [{"key": "transaction", "value": "bar"}]
         assert timeseries["meta"] == {
+            "dataScanned": "full",
             "valueType": "integer",
             "interval": 60_000,
             "isOther": False,
@@ -500,6 +511,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         )
         assert timeseries["groupBy"] is None
         assert timeseries["meta"] == {
+            "dataScanned": "full",
             "valueType": "integer",
             "interval": 60_000,
             "isOther": True,
@@ -551,6 +563,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         )
         assert timeseries["groupBy"] == [{"key": "transaction", "value": "foo"}]
         assert timeseries["meta"] == {
+            "dataScanned": "full",
             "valueType": "integer",
             "interval": 60_000,
             "isOther": False,
@@ -565,6 +578,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         )
         assert timeseries["groupBy"] == [{"key": "transaction", "value": "bar"}]
         assert timeseries["meta"] == {
+            "dataScanned": "full",
             "valueType": "integer",
             "interval": 60_000,
             "isOther": False,
@@ -616,6 +630,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         )
         assert timeseries["groupBy"] == [{"key": "transaction", "value": "bar"}]
         assert timeseries["meta"] == {
+            "dataScanned": "full",
             "valueType": "integer",
             "interval": 60_000,
             "isOther": False,
@@ -645,6 +660,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         )
         assert timeseries["groupBy"] == [{"key": "transaction", "value": "baz"}]
         assert timeseries["meta"] == {
+            "dataScanned": "full",
             "valueType": "integer",
             "interval": 60_000,
             "isOther": False,
@@ -659,6 +675,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         )
         assert timeseries["groupBy"] == [{"key": "transaction", "value": "baz"}]
         assert timeseries["meta"] == {
+            "dataScanned": "full",
             "valueUnit": "millisecond",
             "valueType": "duration",
             "interval": 60_000,
@@ -674,6 +691,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         )
         assert timeseries["groupBy"] is None
         assert timeseries["meta"] == {
+            "dataScanned": "full",
             "valueType": "integer",
             "interval": 60_000,
             "isOther": True,
@@ -688,6 +706,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         )
         assert timeseries["groupBy"] is None
         assert timeseries["meta"] == {
+            "dataScanned": "full",
             "valueUnit": "millisecond",
             "valueType": "duration",
             "interval": 60_000,
@@ -746,6 +765,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         )
         assert timeseries["groupBy"] == [{"key": "project", "value": projects[0].slug}]
         assert timeseries["meta"] == {
+            "dataScanned": "full",
             "valueType": "integer",
             "interval": 60_000,
             "isOther": False,
@@ -760,6 +780,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         )
         assert timeseries["groupBy"] == [{"key": "project", "value": projects[1].slug}]
         assert timeseries["meta"] == {
+            "dataScanned": "full",
             "valueType": "integer",
             "interval": 60_000,
             "isOther": False,
@@ -774,6 +795,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         )
         assert timeseries["groupBy"] is None
         assert timeseries["meta"] == {
+            "dataScanned": "full",
             "valueType": "integer",
             "interval": 60_000,
             "isOther": True,
@@ -832,6 +854,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             {"key": "project.id", "value": str(projects[0].id)},
         ]
         assert timeseries["meta"] == {
+            "dataScanned": "full",
             "valueType": "integer",
             "interval": 60_000,
             "isOther": False,
@@ -849,6 +872,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             {"key": "project.id", "value": str(projects[1].id)},
         ]
         assert timeseries["meta"] == {
+            "dataScanned": "full",
             "valueType": "integer",
             "interval": 60_000,
             "isOther": False,
@@ -863,6 +887,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         )
         assert timeseries["groupBy"] is None
         assert timeseries["meta"] == {
+            "dataScanned": "full",
             "valueType": "integer",
             "interval": 60_000,
             "isOther": True,
@@ -934,6 +959,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             confidence=["low" if val else None for val in event_counts],
         )
         assert timeseries["meta"] == {
+            "dataScanned": "full",
             "valueType": "integer",
             "interval": 3_600_000,
         }
@@ -1181,6 +1207,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             ignore_accuracy=True,
         )
         assert timeseries["meta"] == {
+            "dataScanned": "full",
             "valueType": "integer",
             "interval": 3_600_000,
         }
@@ -1226,6 +1253,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             self.start, 3_600_000, event_counts, [0] * len(event_counts), ignore_accuracy=True
         )
         assert timeseries["meta"] == {
+            "dataScanned": "full",
             "valueType": "integer",
             "interval": 3_600_000,
         }
@@ -1304,6 +1332,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
                 self.start, 3_600_000, event_counts, ignore_accuracy=True
             )
             assert timeseries["meta"] == {
+                "dataScanned": "full",
                 "valueType": "integer",
                 "interval": 3_600_000,
             }
@@ -1368,6 +1397,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
                 self.start, 3_600_000, event_counts, ignore_accuracy=True
             )
             assert timeseries["meta"] == {
+                "dataScanned": "full",
                 "valueType": "integer",
                 "interval": 3_600_000,
             }
@@ -1498,6 +1528,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             self.start, 60_000, [0.0, 1.0, 0.25], ignore_accuracy=True
         )
         assert timeseries["meta"] == {
+            "dataScanned": "full",
             "valueType": "percentage",
             "interval": 60_000,
         }
@@ -1559,6 +1590,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             self.start, 60_000, [0.0, 0.5, 0.75], ignore_accuracy=True
         )
         assert timeseries["meta"] == {
+            "dataScanned": "full",
             "valueType": "percentage",
             "interval": 60_000,
         }
@@ -1608,6 +1640,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             self.start, 60_000, [0.0, 2.0, 1.0], ignore_accuracy=True
         )
         assert timeseries["meta"] == {
+            "dataScanned": "full",
             "valueType": "integer",
             "interval": 60_000,
         }
@@ -1656,6 +1689,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             self.start, 60_000, [0, 512, 0], ignore_accuracy=True
         )
         assert timeseries["meta"] == {
+            "dataScanned": "full",
             "valueType": "integer",
             "interval": 60_000,
         }
@@ -1687,6 +1721,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             self.start, 60_000, [0, 1, 0], ignore_accuracy=True
         )
         assert timeseries["meta"] == {
+            "dataScanned": "full",
             "valueType": "integer",
             "interval": 60_000,
         }
@@ -1740,6 +1775,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             self.start, 60_000, [0, 512, 0], ignore_accuracy=True
         )
         assert timeseries["meta"] == {
+            "dataScanned": "full",
             "isOther": False,
             "order": 0,
             "valueType": "integer",
@@ -1777,6 +1813,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             self.start, 60_000, [0, 1, 0], ignore_accuracy=True
         )
         assert timeseries["meta"] == {
+            "dataScanned": "full",
             "isOther": False,
             "order": 0,
             "valueType": "integer",
@@ -1828,6 +1865,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             self.start, 60_000, [0.0, 4.0, 2.0], ignore_accuracy=True
         )
         assert timeseries["meta"] == {
+            "dataScanned": "full",
             "valueType": "number",
             "interval": 60_000,
         }
@@ -1878,6 +1916,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             self.start, 60_000, [0.0, 5.0, 3.0], ignore_accuracy=True
         )
         assert timeseries["meta"] == {
+            "dataScanned": "full",
             "valueType": "number",
             "interval": 60_000,
         }
@@ -1927,6 +1966,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             self.start, 60_000, [0.0, 4.0, 2.0], ignore_accuracy=True
         )
         assert timeseries["meta"] == {
+            "dataScanned": "full",
             "valueType": "number",
             "interval": 60_000,
         }
@@ -1938,6 +1978,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             self.start, 60_000, [0.0, 0.0, -1.0], ignore_accuracy=True
         )
         assert timeseries["meta"] == {
+            "dataScanned": "full",
             "valueType": "number",
             "interval": 60_000,
         }
@@ -2017,6 +2058,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             {"key": "description", "value": "foo"},
         ]
         assert timeseries["meta"] == {
+            "dataScanned": "full",
             "valueType": "number",
             "interval": 60_000,
             "isOther": False,
@@ -2033,6 +2075,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             {"key": "description", "value": "bar"},
         ]
         assert timeseries["meta"] == {
+            "dataScanned": "full",
             "valueType": "number",
             "interval": 60_000,
             "isOther": False,
@@ -2047,6 +2090,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         )
         assert timeseries["groupBy"] is None
         assert timeseries["meta"] == {
+            "dataScanned": "full",
             "valueType": "number",
             "interval": 60_000,
             "isOther": True,
@@ -2098,6 +2142,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             self.start, 3_600_000, event_counts, ignore_accuracy=True
         )
         assert timeseries["meta"] == {
+            "dataScanned": "full",
             "valueType": "integer",
             "interval": 3_600_000,
         }

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries_spans.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries_spans.py
@@ -645,6 +645,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         )
         assert timeseries["groupBy"] == [{"key": "transaction", "value": "bar"}]
         assert timeseries["meta"] == {
+            "dataScanned": "full",
             "valueUnit": "millisecond",
             "valueType": "duration",
             "interval": 60_000,


### PR DESCRIPTION
Used by the frontend to give information to the user in some cases. Add `"dataScanned"` to time series meta in the response. Is there a way to simulate a partial scan in the test suite? Is that necessary?
