### PR TITLE
ref(grouping): Make fingerprint visitor return rules

### DIFF
--- a/src/sentry/grouping/fingerprinting/__init__.py
+++ b/src/sentry/grouping/fingerprinting/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Generator, Mapping, Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, NamedTuple, NotRequired, Self, TypedDict, TypeVar
+from typing import Any, NamedTuple, NotRequired, Self, TypedDict, TypeVar
 
 from django.conf import settings
 from parsimonious.exceptions import ParseError
@@ -326,12 +326,6 @@ class FingerprintingRules:
         return FingerprintingVisitor(bases=bases).visit(tree)
 
 
-if TYPE_CHECKING:
-    NodeVisitorBase = NodeVisitor[FingerprintingRules]
-else:
-    NodeVisitorBase = NodeVisitor
-
-
 class BuiltInFingerprintingRules(FingerprintingRules):
     """
     A FingerprintingRules object that marks all of its rules as built-in
@@ -561,7 +555,7 @@ class FingerprintRule:
         ).rstrip()
 
 
-class FingerprintingVisitor(NodeVisitorBase):
+class FingerprintingVisitor(NodeVisitor[list[FingerprintRule]]):
     visit_empty = lambda *a: None
     unwrapped_exceptions = (InvalidFingerprintingConfig,)
 
@@ -577,11 +571,8 @@ class FingerprintingVisitor(NodeVisitorBase):
 
     def visit_fingerprinting_rules(
         self, _: object, children: list[str | FingerprintRule | None]
-    ) -> FingerprintingRules:
-        return FingerprintingRules(
-            rules=[child for child in children if not isinstance(child, str) and child is not None],
-            bases=self.bases,
-        )
+    ) -> list[FingerprintRule]:
+        return [child for child in children if not isinstance(child, str) and child is not None]
 
     def visit_line(
         self, _: object, children: tuple[object, list[FingerprintRule | str | None], object]

--- a/src/sentry/grouping/fingerprinting/__init__.py
+++ b/src/sentry/grouping/fingerprinting/__init__.py
@@ -312,8 +312,8 @@ class FingerprintingRules:
         except (LookupError, AttributeError, TypeError, ValueError) as e:
             raise ValueError("invalid fingerprinting config: %s" % e)
 
-    @staticmethod
-    def from_config_string(s: Any, bases: Sequence[str] | None = None) -> Any:
+    @classmethod
+    def from_config_string(cls, s: Any, bases: Sequence[str] | None = None) -> FingerprintingRules:
         try:
             tree = fingerprinting_grammar.parse(s)
         except ParseError as e:
@@ -323,7 +323,10 @@ class FingerprintingRules:
             raise InvalidFingerprintingConfig(
                 f'Invalid syntax near "{context}" (line {e.line()}, column {e.column()})'
             )
-        return FingerprintingVisitor(bases=bases).visit(tree)
+
+        rules = FingerprintingVisitor().visit(tree)
+
+        return cls(rules=rules, bases=bases)
 
 
 class BuiltInFingerprintingRules(FingerprintingRules):
@@ -331,8 +334,8 @@ class BuiltInFingerprintingRules(FingerprintingRules):
     A FingerprintingRules object that marks all of its rules as built-in
     """
 
-    @staticmethod
-    def from_config_string(s: str, bases: Sequence[str] | None = None) -> FingerprintingRules:
+    @classmethod
+    def from_config_string(cls, s: str, bases: Sequence[str] | None = None) -> FingerprintingRules:
         fingerprinting_rules = FingerprintingRules.from_config_string(s, bases=bases)
         for r in fingerprinting_rules.rules:
             r.is_builtin = True

--- a/src/sentry/grouping/fingerprinting/__init__.py
+++ b/src/sentry/grouping/fingerprinting/__init__.py
@@ -559,9 +559,6 @@ class FingerprintingVisitor(NodeVisitor[list[FingerprintRule]]):
     visit_empty = lambda *a: None
     unwrapped_exceptions = (InvalidFingerprintingConfig,)
 
-    def __init__(self, bases: Sequence[str] | None) -> None:
-        self.bases = bases
-
     # a note on the typing of `children`
     # these are actually lists of sub-lists of the various types
     # so instead typed as tuples so unpacking works


### PR DESCRIPTION
This is a small refactor to bring our fingerprint rule parsing in line with our enhancement rule parsing.

With enhancements, the parser's tree visitor returns the rules, and then the rule-set object (an `Enhancements` instance) uses them, which makes sense - the parser shouldn't have to know about things the `Enhancements` object cares about, like which built-in rule set we're using alongside the custom rules the parser has just parsed. 

The same is not true of our fingerprint parsing, however. There, the parser actually creates the rule-set object (a `FingerprintingRules` instance), and therefore has to know about the bases. This is not ideal because: 

a) the code's easier to understand if both kinds of rules work the same way, 
b) doing it the enhancements' way follows the principle of separation of concerns better, and 
c) (the current motivation) the way the fingerprinting rules currently work creates a circular dependency between the rule-set class `FingerprintingRules` and the parser class `FingerprintingVisitor`, meaning they can't be split into separate modules (which is about to happen).

This PR therefore switches the fingerprinting rule visitor to match the enhancements visitor.