### PR TITLE
fix(member-team-details): prevent role downgrade by low-privilege users

### DIFF
--- a/src/sentry/api/endpoints/organization_member/team_details.py
+++ b/src/sentry/api/endpoints/organization_member/team_details.py
@@ -409,7 +409,13 @@ class OrganizationMemberTeamDetailsEndpoint(OrganizationMemberEndpoint):
             except KeyError:
                 return Response(status=400)
 
-            if not can_set_team_role(request, team, new_role):
+            can_set_new_role = can_set_team_role(request, team, new_role)
+            can_set_old_role = (
+                can_set_team_role(request, team, team_roles.get(omt.role)) if omt.role else True
+            )
+
+            # Verify that the request is allowed to set both the old and new role to prevent role downgrades by low-privilege users
+            if not (can_set_new_role and can_set_old_role):
                 return Response({"detail": ERR_INSUFFICIENT_ROLE}, status=400)
 
             self._change_team_member_role(omt, new_role)

--- a/src/sentry/api/endpoints/organization_member/team_details.py
+++ b/src/sentry/api/endpoints/organization_member/team_details.py
@@ -406,9 +406,9 @@ class OrganizationMemberTeamDetailsEndpoint(OrganizationMemberEndpoint):
             new_role_id = result["teamRole"]
             try:
                 new_role = team_roles.get(new_role_id)
-                can_set_new_role = can_set_team_role(request, team, new_role)
             except KeyError:
                 return Response(status=400)
+            can_set_new_role = can_set_team_role(request, team, new_role)
 
             try:
                 old_role = team_roles.get(omt.role) if omt.role else None

--- a/src/sentry/api/endpoints/organization_member/team_details.py
+++ b/src/sentry/api/endpoints/organization_member/team_details.py
@@ -406,13 +406,12 @@ class OrganizationMemberTeamDetailsEndpoint(OrganizationMemberEndpoint):
             new_role_id = result["teamRole"]
             try:
                 new_role = team_roles.get(new_role_id)
+                can_set_new_role = can_set_team_role(request, team, new_role)
+                can_set_old_role = (
+                    can_set_team_role(request, team, team_roles.get(omt.role)) if omt.role else True
+                )
             except KeyError:
                 return Response(status=400)
-
-            can_set_new_role = can_set_team_role(request, team, new_role)
-            can_set_old_role = (
-                can_set_team_role(request, team, team_roles.get(omt.role)) if omt.role else True
-            )
 
             # Verify that the request is allowed to set both the old and new role to prevent role downgrades by low-privilege users
             if not (can_set_new_role and can_set_old_role):

--- a/src/sentry/api/endpoints/organization_member/team_details.py
+++ b/src/sentry/api/endpoints/organization_member/team_details.py
@@ -407,11 +407,14 @@ class OrganizationMemberTeamDetailsEndpoint(OrganizationMemberEndpoint):
             try:
                 new_role = team_roles.get(new_role_id)
                 can_set_new_role = can_set_team_role(request, team, new_role)
-                can_set_old_role = (
-                    can_set_team_role(request, team, team_roles.get(omt.role)) if omt.role else True
-                )
             except KeyError:
                 return Response(status=400)
+
+            try:
+                old_role = team_roles.get(omt.role) if omt.role else None
+            except KeyError:
+                old_role = None
+            can_set_old_role = can_set_team_role(request, team, old_role) if old_role else True
 
             # Verify that the request is allowed to set both the old and new role to prevent role downgrades by low-privilege users
             if not (can_set_new_role and can_set_old_role):

--- a/tests/sentry/api/endpoints/test_organization_member_team_details.py
+++ b/tests/sentry/api/endpoints/test_organization_member_team_details.py
@@ -1112,3 +1112,17 @@ class UpdateOrganizationMemberTeamTest(OrganizationMemberTeamTestBase):
 
         assert resp.status_code == 400
         assert resp.data["detail"] == ERR_INSUFFICIENT_ROLE
+
+    @with_feature("organizations:team-roles")
+    def test_team_contributor_cannot_downgrade_team_admin(self) -> None:
+        self.login_as(self.member)
+
+        resp = self.get_response(
+            self.org.slug,
+            self.team_admin.id,
+            self.team.slug,
+            teamRole="contributor",
+        )
+
+        assert resp.status_code == 400
+        assert resp.data["detail"] == ERR_INSUFFICIENT_ROLE


### PR DESCRIPTION
fixes a bug where team contributors could downgrade team admins to contributors via the API

fixes https://linear.app/getsentry/issue/RTC-1116/unauthorized-role-downgrade-by-low-privilege-users