### PR TITLE
chore(aci): Track when RuleProcessor is used in post_process

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1068,6 +1068,10 @@ def process_rules(job: PostProcessJob) -> None:
         # we are only processing through the workflow engine
         return
 
+    metrics.incr(
+        "post_process.rules_processor_events", tags={"group_type": job["event"].group.type}
+    )
+
     from sentry.rules.processing.processor import RuleProcessor
 
     group_event = job["event"]


### PR DESCRIPTION
As we gradually move traffic off of dual processing and into single processing, it'd be nice to be able to monitor what % of event traffic is going through the old RuleProcessor flow.
