### PR TITLE
ref(grouping): Handle built-in fingerprinting rules in base class

### DIFF
--- a/src/sentry/grouping/fingerprinting/__init__.py
+++ b/src/sentry/grouping/fingerprinting/__init__.py
@@ -156,7 +156,7 @@ def _load_configs() -> dict[str, list[FingerprintRule]]:
             with open(config_file_path) as config_file:
                 str_conf = config_file.read().rstrip()
                 configs[config_name].extend(
-                    BuiltInFingerprintingRules.from_config_string(str_conf).rules
+                    FingerprintingRules.from_config_string(str_conf, mark_as_built_in=True).rules
                 )
         except InvalidFingerprintingConfig:
             logger.exception(

--- a/src/sentry/grouping/fingerprinting/__init__.py
+++ b/src/sentry/grouping/fingerprinting/__init__.py
@@ -113,28 +113,6 @@ class FingerprintingRules:
         return cls(rules=rules, bases=bases)
 
 
-class BuiltInFingerprintingRules(FingerprintingRules):
-    """
-    A FingerprintingRules object that marks all of its rules as built-in
-    """
-
-    @classmethod
-    def from_config_string(cls, s: str, bases: Sequence[str] | None = None) -> FingerprintingRules:
-        fingerprinting_rules = FingerprintingRules.from_config_string(s, bases=bases)
-        for r in fingerprinting_rules.rules:
-            r.is_builtin = True
-        return fingerprinting_rules
-
-    @classmethod
-    def _from_config_structure(
-        cls, data: dict[str, object], bases: Sequence[str] | None = None
-    ) -> Self:
-        fingerprinting_rules = super()._from_config_structure(data, bases=bases)
-        for r in fingerprinting_rules.rules:
-            r.is_builtin = True
-        return fingerprinting_rules
-
-
 def _load_configs() -> dict[str, list[FingerprintRule]]:
     if not CONFIGS_DIR.exists():
         logger.error(

--- a/src/sentry/grouping/fingerprinting/__init__.py
+++ b/src/sentry/grouping/fingerprinting/__init__.py
@@ -56,11 +56,19 @@ class FingerprintingRules:
 
     @classmethod
     def _from_config_structure(
-        cls, data: dict[str, Any], bases: Sequence[str] | None = None
+        cls,
+        data: dict[str, Any],
+        bases: Sequence[str] | None = None,
+        mark_as_built_in: bool = False,
     ) -> Self:
         version = data.get("version", VERSION)
         if version != VERSION:
             raise ValueError("Unknown version")
+
+        if mark_as_built_in:
+            for rule_config in data["rules"]:
+                rule_config["is_builtin"] = True
+
         return cls(
             rules=[FingerprintRule._from_config_structure(x) for x in data["rules"]],
             version=version,
@@ -83,7 +91,9 @@ class FingerprintingRules:
             raise ValueError("invalid fingerprinting config: %s" % e)
 
     @classmethod
-    def from_config_string(cls, s: Any, bases: Sequence[str] | None = None) -> FingerprintingRules:
+    def from_config_string(
+        cls, s: Any, bases: Sequence[str] | None = None, mark_as_built_in: bool = False
+    ) -> FingerprintingRules:
         try:
             tree = fingerprinting_grammar.parse(s)
         except ParseError as e:
@@ -95,6 +105,10 @@ class FingerprintingRules:
             )
 
         rules = FingerprintingVisitor().visit(tree)
+
+        if mark_as_built_in:
+            for rule in rules:
+                rule.is_builtin = True
 
         return cls(rules=rules, bases=bases)
 

--- a/tests/sentry/grouping/test_builtin_fingerprinting.py
+++ b/tests/sentry/grouping/test_builtin_fingerprinting.py
@@ -12,12 +12,7 @@ from sentry.grouping.api import (
     get_default_grouping_config_dict,
     get_fingerprinting_config_for_project,
 )
-from sentry.grouping.fingerprinting import (
-    FINGERPRINTING_BASES,
-    BuiltInFingerprintingRules,
-    FingerprintingRules,
-    _load_configs,
-)
+from sentry.grouping.fingerprinting import FINGERPRINTING_BASES, FingerprintingRules, _load_configs
 from sentry.services import eventstore
 from sentry.services.eventstore.models import Event
 from sentry.testutils.cases import TestCase
@@ -462,7 +457,7 @@ def test_load_configs_borked_file_doesnt_blow_up(tmp_path: Path) -> None:
 def test_builtinfingerprinting_rules_from_config_structure_overrides_is_builtin(
     is_builtin: bool | None,
 ) -> None:
-    rules = BuiltInFingerprintingRules._from_config_structure(
+    rules = FingerprintingRules._from_config_structure(
         {
             "rules": [
                 {
@@ -474,6 +469,7 @@ def test_builtinfingerprinting_rules_from_config_structure_overrides_is_builtin(
             ],
         },
         bases=[],
+        mark_as_built_in=True,
     )
 
     assert rules.rules[0].is_builtin is True


### PR DESCRIPTION
This is a small simplification of the fingerprinting code, to allow the regular `FingerprintingRules` class to handle built-in rules rather than have an entirely separate class for them.