### PR TITLE
feat(agent-monitoring): Use dropdown for platform options

### DIFF
--- a/static/app/components/feedback/feedbackOnboarding/sidebar.tsx
+++ b/static/app/components/feedback/feedbackOnboarding/sidebar.tsx
@@ -16,7 +16,8 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {FeedbackOnboardingWebApiBanner} from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
 import useCurrentProjectState from 'sentry/components/onboarding/gettingStartedDoc/utils/useCurrentProjectState';
 import {useLoadGettingStarted} from 'sentry/components/onboarding/gettingStartedDoc/utils/useLoadGettingStarted';
-import {PlatformOptionDropdown} from 'sentry/components/replaysOnboarding/platformOptionDropdown';
+import {PlatformOptionDropdown} from 'sentry/components/onboarding/platformOptionDropdown';
+import {pickPlatformOptions} from 'sentry/components/replaysOnboarding/pickPlatformOptions';
 import {replayJsFrameworkOptions} from 'sentry/components/replaysOnboarding/utils';
 import SidebarPanel from 'sentry/components/sidebar/sidebarPanel';
 import type {CommonSidebarProps} from 'sentry/components/sidebar/types';
@@ -325,7 +326,9 @@ function OnboardingContent({currentProject}: {currentProject: Project}) {
           <PlatformSelect>
             {tct("I'm using [platformSelect]", {
               platformSelect: (
-                <PlatformOptionDropdown platformOptions={newDocs?.platformOptions} />
+                <PlatformOptionDropdown
+                  platformOptions={pickPlatformOptions(newDocs?.platformOptions)}
+                />
               ),
             })}
           </PlatformSelect>

--- a/static/app/components/onboarding/platformOptionDropdown.tsx
+++ b/static/app/components/onboarding/platformOptionDropdown.tsx
@@ -69,22 +69,22 @@ export function PlatformOptionDropdown({
     });
   };
 
-  const platforms = platformOptions.siblingOption ?? platformOptions.packageManager;
-
-  if (!platforms) {
+  if (Object.keys(platformOptions).length === 0) {
     return null;
   }
 
   return (
     <Fragment>
       {t('with')}
-      <OptionControl
-        key="platformOption"
-        option={platforms}
-        value={urlOptionValues.siblingOption ?? platforms.items[0]?.label!}
-        onChange={v => handleChange('siblingOption', v.value)}
-        disabled={disabled}
-      />
+      {Object.keys(platformOptions).map(key => (
+        <OptionControl
+          key={key}
+          option={platformOptions[key]!}
+          value={urlOptionValues[key]!}
+          onChange={v => handleChange(key, v.value)}
+          disabled={disabled}
+        />
+      ))}
     </Fragment>
   );
 }

--- a/static/app/components/replaysOnboarding/pickPlatformOptions.tsx
+++ b/static/app/components/replaysOnboarding/pickPlatformOptions.tsx
@@ -1,0 +1,24 @@
+import type {PlatformOption} from 'sentry/components/onboarding/gettingStartedDoc/types';
+
+/**
+ * Pick the platform options to display in the onboarding UI.
+ * Returns siblingOption if it exists, otherwise packageManager.
+ */
+export function pickPlatformOptions(
+  platformOptions?: Record<string, PlatformOption<any>>
+):
+  | Record<string, never>
+  | {siblingOption: PlatformOption<any>}
+  | {packageManager: PlatformOption<any>} {
+  const {siblingOption, packageManager} = platformOptions || {};
+
+  if (siblingOption) {
+    return {siblingOption};
+  }
+
+  if (packageManager) {
+    return {packageManager};
+  }
+
+  return {};
+}

--- a/static/app/components/replaysOnboarding/sidebar.tsx
+++ b/static/app/components/replaysOnboarding/sidebar.tsx
@@ -13,7 +13,8 @@ import IdBadge from 'sentry/components/idBadge';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import useCurrentProjectState from 'sentry/components/onboarding/gettingStartedDoc/utils/useCurrentProjectState';
 import {useLoadGettingStarted} from 'sentry/components/onboarding/gettingStartedDoc/utils/useLoadGettingStarted';
-import {PlatformOptionDropdown} from 'sentry/components/replaysOnboarding/platformOptionDropdown';
+import {PlatformOptionDropdown} from 'sentry/components/onboarding/platformOptionDropdown';
+import {pickPlatformOptions} from 'sentry/components/replaysOnboarding/pickPlatformOptions';
 import {ReplayOnboardingLayout} from 'sentry/components/replaysOnboarding/replayOnboardingLayout';
 import {replayJsFrameworkOptions} from 'sentry/components/replaysOnboarding/utils';
 import SidebarPanel from 'sentry/components/sidebar/sidebarPanel';
@@ -328,7 +329,9 @@ function OnboardingContent({
           <PlatformSelect>
             {tct("I'm using [platformSelect]", {
               platformSelect: (
-                <PlatformOptionDropdown platformOptions={docs?.platformOptions} />
+                <PlatformOptionDropdown
+                  platformOptions={pickPlatformOptions(docs?.platformOptions)}
+                />
               ),
             })}
           </PlatformSelect>

--- a/static/app/views/insights/agents/views/onboarding.tsx
+++ b/static/app/views/insights/agents/views/onboarding.tsx
@@ -25,10 +25,8 @@ import {
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {useSourcePackageRegistries} from 'sentry/components/onboarding/gettingStartedDoc/useSourcePackageRegistries';
 import {useLoadGettingStarted} from 'sentry/components/onboarding/gettingStartedDoc/utils/useLoadGettingStarted';
-import {
-  PlatformOptionsControl,
-  useUrlPlatformOptions,
-} from 'sentry/components/onboarding/platformOptionsControl';
+import {PlatformOptionDropdown} from 'sentry/components/onboarding/platformOptionDropdown';
+import {useUrlPlatformOptions} from 'sentry/components/onboarding/platformOptionsControl';
 import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
 import {SetupTitle} from 'sentry/components/updatedEmptyState';
@@ -361,7 +359,7 @@ export function Onboarding() {
     <OnboardingPanel project={project}>
       <SetupTitle project={project} />
       <OptionsWrapper>
-        <PlatformOptionsControl platformOptions={integrationOptions} />
+        <PlatformOptionDropdown platformOptions={integrationOptions} />
       </OptionsWrapper>
       {introduction && <DescriptionWrapper>{introduction}</DescriptionWrapper>}
       <GuidedSteps>
@@ -541,5 +539,9 @@ const AdditionalInfo = styled(DescriptionWrapper)`
 `;
 
 const OptionsWrapper = styled('div')`
-  margin: ${space(2)} 0;
+  display: flex;
+  gap: ${p => p.theme.space.md};
+  align-items: center;
+  flex-wrap: wrap;
+  padding-bottom: ${p => p.theme.space.md};
 `;


### PR DESCRIPTION
Make `PlatformOptionDropdown` a generic component and re-use it in the agent monitoring onboarding.
Add a util to handle the profiling and user feedback specific logic. 

https://github.com/user-attachments/assets/76212d8c-e841-472c-be0d-1a19bf308ae8




- closes [TET-1023: Add integration dropdown for in-product onboarding](https://linear.app/getsentry/issue/TET-1023/add-integration-dropdown-for-in-product-onboarding)