### PR TITLE
fix(issues-onboarding): Hide optional steps

### DIFF
--- a/static/app/components/updatedEmptyState.tsx
+++ b/static/app/components/updatedEmptyState.tsx
@@ -146,12 +146,21 @@ export default function UpdatedEmptyState({project}: {project?: Project}) {
     };
   }
 
+  if (currentPlatformKey === 'javascript') {
+    docParams.platformOptions = {
+      ...docParams.platformOptions,
+      installationMode: 'manual',
+    };
+  }
+
   const install = loadGettingStarted.docs.onboarding.install(docParams);
   const configure = loadGettingStarted.docs.onboarding.configure(docParams);
   const verify = loadGettingStarted.docs.onboarding.verify(docParams);
 
   // TODO: Is there a reason why we are only selecting a few steps?
-  const steps = [install[0], configure[0], configure[1], verify[0]].filter(Boolean);
+  const steps = [install[0], configure[0], configure[1], verify[0]]
+    // Filter optional steps
+    .filter(step => !!step && !step.collapsible);
 
   return (
     <AuthTokenGeneratorProvider projectSlug={project?.slug}>


### PR DESCRIPTION
Hide optional steps during onboarding as the stepper flow does not allow for keeping sections collapsed (see AI editor rules that take a ton of space).

Ensure that the `javascript` platform uses the package manager install & configure snippets instead of the loader script.
This regressed when the loader script onboarding was refactored to utilize the package options.

- closes [TET-1011: Optional editor rules are cluttering onboarding](https://linear.app/getsentry/issue/TET-1011/optional-editor-rules-are-cluttering-onboarding)