### PR TITLE
fix(dynamic-sampling): query project transaction totals with 60s granularity

### DIFF
--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
@@ -317,6 +317,11 @@ class FetchProjectTransactionTotals:
         if not self._cache_empty():
             return self._get_from_cache()
 
+        if options.get("dynamic-sampling.query-granularity-60s.fetch-transaction-totals", None):
+            granularity = Granularity(60)
+        else:
+            granularity = Granularity(3600)
+
         if self.has_more_results:
             query = (
                 Query(
@@ -341,7 +346,7 @@ class FetchProjectTransactionTotals:
                         Condition(Column("metric_id"), Op.EQ, self.metric_id),
                         Condition(Column("org_id"), Op.IN, self.org_ids),
                     ],
-                    granularity=Granularity(3600),
+                    granularity=granularity,
                     orderby=[
                         OrderBy(Column("org_id"), Direction.ASC),
                         OrderBy(Column("project_id"), Direction.ASC),
@@ -490,6 +495,11 @@ class FetchProjectTransactionVolumes:
             # data in cache no need to go to the db
             return self._get_from_cache()
 
+        if options.get("dynamic-sampling.query-granularity-60s.fetch-transaction-volumes", None):
+            granularity = Granularity(60)
+        else:
+            granularity = Granularity(3600)
+
         if self.has_more_results:
             # still data in the db, load cache
             query = (
@@ -516,7 +526,7 @@ class FetchProjectTransactionVolumes:
                         Condition(Column("metric_id"), Op.EQ, self.metric_id),
                         Condition(Column("org_id"), Op.IN, self.org_ids),
                     ],
-                    granularity=Granularity(3600),
+                    granularity=granularity,
                     orderby=[
                         OrderBy(Column("org_id"), Direction.ASC),
                         OrderBy(Column("project_id"), Direction.ASC),

--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
@@ -495,7 +495,7 @@ class FetchProjectTransactionVolumes:
             # data in cache no need to go to the db
             return self._get_from_cache()
 
-        if options.get("dynamic-sampling.query-granularity-60s.fetch-transaction-volumes", None):
+        if options.get("dynamic-sampling.query-granularity-60s.fetch-transaction-totals", None):
             granularity = Granularity(60)
         else:
             granularity = Granularity(3600)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3498,3 +3498,10 @@ register(
     default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+register(
+    "dynamic-sampling.query-granularity-60s.fetch-transaction-totals",
+    type=Bool,
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)


### PR DESCRIPTION
- Before activating https://github.com/getsentry/sentry/pull/97836, we should move all the sub-tasks to 60s granularity as well, otherwise we risk making the balancing worse at full hours. 

Contributes to TET-1018
