### PR TITLE
ref(dashboards): Move `TimeSeries` confidence properties

### DIFF
--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -311,7 +311,7 @@ type AccuracyStatsItem<T> = {
   value: T;
 };
 
-export type AccuracyStats<T> = Array<AccuracyStatsItem<T>>;
+type AccuracyStats<T> = Array<AccuracyStatsItem<T>>;
 
 // API response for a single Discover timeseries
 export type EventsStats = {

--- a/static/app/views/alerts/rules/metric/utils/determineSeriesConfidence.spec.tsx
+++ b/static/app/views/alerts/rules/metric/utils/determineSeriesConfidence.spec.tsx
@@ -1,159 +1,121 @@
-import {determineSeriesConfidence} from 'sentry/views/alerts/rules/metric/utils/determineSeriesConfidence';
+import {TimeSeriesFixture} from 'sentry-fixture/timeSeries';
 
-describe('determineSeriesConfidence', () => {
+import {determineTimeSeriesConfidence} from 'sentry/views/alerts/rules/metric/utils/determineSeriesConfidence';
+
+describe('determineTimeSeriesConfidence', () => {
   it('equal null if no data', () => {
-    const confidence = determineSeriesConfidence({
-      data: [],
-    });
+    const confidence = determineTimeSeriesConfidence(
+      TimeSeriesFixture({
+        values: [],
+      })
+    );
     expect(confidence).toBeNull();
   });
 
   it('equal null if no confidence found', () => {
-    const confidence = determineSeriesConfidence({
-      data: [
-        [100, [{count: 100}]],
-        [200, [{count: 200}]],
-      ],
-    });
+    const confidence = determineTimeSeriesConfidence(
+      TimeSeriesFixture({
+        values: [
+          {timestamp: 100, value: 100},
+          {timestamp: 200, value: 200},
+        ],
+      })
+    );
     expect(confidence).toBeNull();
   });
 
-  it('equal null if confidence is empty', () => {
-    const confidence = determineSeriesConfidence({
-      data: [
-        [100, [{count: 100}]],
-        [200, [{count: 200}]],
-      ],
-      confidence: [],
-    });
+  it('equal null if confidence is undefined', () => {
+    const confidence = determineTimeSeriesConfidence(
+      TimeSeriesFixture({
+        values: [
+          {timestamp: 100, value: 100, confidence: undefined},
+          {timestamp: 200, value: 200, confidence: undefined},
+        ],
+      })
+    );
     expect(confidence).toBeNull();
   });
 
   it('equal null if all confidence null', () => {
-    const confidence = determineSeriesConfidence({
-      data: [
-        [100, [{count: 100}]],
-        [200, [{count: 200}]],
-      ],
-      confidence: [
-        [100, [{count: null}]],
-        [200, [{count: null}]],
-      ],
-    });
+    const confidence = determineTimeSeriesConfidence(
+      TimeSeriesFixture({
+        values: [
+          {timestamp: 100, value: 100, confidence: null},
+          {timestamp: 200, value: 200, confidence: null},
+        ],
+      })
+    );
     expect(confidence).toBeNull();
   });
 
   it('equal high if all confidence high', () => {
-    const confidence = determineSeriesConfidence({
-      data: [
-        [100, [{count: 100}]],
-        [200, [{count: 200}]],
-      ],
-      confidence: [
-        [100, [{count: 'high'}]],
-        [200, [{count: 'high'}]],
-      ],
-    });
+    const confidence = determineTimeSeriesConfidence(
+      TimeSeriesFixture({
+        values: [
+          {timestamp: 100, value: 100, confidence: 'high'},
+          {timestamp: 200, value: 200, confidence: 'high'},
+        ],
+      })
+    );
     expect(confidence).toBe('high');
   });
 
   it('equal high if all confidence high or null', () => {
-    const confidence = determineSeriesConfidence({
-      data: [
-        [100, [{count: 100}]],
-        [200, [{count: 200}]],
-      ],
-      confidence: [
-        [100, [{count: 'high'}]],
-        [200, [{count: null}]],
-      ],
-    });
+    const confidence = determineTimeSeriesConfidence(
+      TimeSeriesFixture({
+        values: [
+          {timestamp: 100, value: 100, confidence: 'high'},
+          {timestamp: 200, value: 200, confidence: null},
+        ],
+      })
+    );
     expect(confidence).toBe('high');
   });
 
   it('equal high if <25% is low', () => {
-    const confidence = determineSeriesConfidence({
-      data: [
-        [100, [{count: 100}]],
-        [200, [{count: 200}]],
-        [300, [{count: 300}]],
-        [400, [{count: 400}]],
-        [500, [{count: 500}]],
-        [600, [{count: 600}]],
-        [700, [{count: 700}]],
-      ],
-      confidence: [
-        [100, [{count: 'high'}]],
-        [200, [{count: 'high'}]],
-        [300, [{count: 'high'}]],
-        [400, [{count: 'high'}]],
-        [500, [{count: 'low'}]],
-        [600, [{count: 'high'}]],
-        [700, [{count: null}]],
-      ],
-    });
+    const confidence = determineTimeSeriesConfidence(
+      TimeSeriesFixture({
+        values: [
+          {timestamp: 100, value: 100, confidence: 'high'},
+          {timestamp: 200, value: 200, confidence: 'high'},
+          {timestamp: 300, value: 300, confidence: 'high'},
+          {timestamp: 400, value: 400, confidence: 'high'},
+          {timestamp: 500, value: 500, confidence: 'low'},
+          {timestamp: 600, value: 600, confidence: 'high'},
+          {timestamp: 700, value: 700, confidence: null},
+        ],
+      })
+    );
     expect(confidence).toBe('high');
   });
 
   it('equal low if >25% is low', () => {
-    const confidence = determineSeriesConfidence({
-      data: [
-        [100, [{count: 100}]],
-        [200, [{count: 200}]],
-        [300, [{count: 300}]],
-        [400, [{count: 400}]],
-        [500, [{count: 500}]],
-      ],
-      confidence: [
-        [100, [{count: 'high'}]],
-        [200, [{count: null}]],
-        [300, [{count: null}]],
-        [400, [{count: 'low'}]],
-        [500, [{count: 'low'}]],
-      ],
-    });
+    const confidence = determineTimeSeriesConfidence(
+      TimeSeriesFixture({
+        values: [
+          {timestamp: 100, value: 100, confidence: 'high'},
+          {timestamp: 200, value: 200, confidence: null},
+          {timestamp: 300, value: 300, confidence: null},
+          {timestamp: 400, value: 400, confidence: 'low'},
+          {timestamp: 500, value: 500, confidence: 'low'},
+        ],
+      })
+    );
     expect(confidence).toBe('low');
   });
 
   it('equal low if all low', () => {
-    const confidence = determineSeriesConfidence({
-      data: [
-        [100, [{count: 100}]],
-        [200, [{count: 200}]],
-        [300, [{count: 300}]],
-        [400, [{count: 400}]],
-        [500, [{count: 500}]],
-      ],
-      confidence: [
-        [100, [{count: 'low'}]],
-        [200, [{count: 'low'}]],
-        [300, [{count: 'low'}]],
-        [400, [{count: 'low'}]],
-        [500, [{count: 'low'}]],
-      ],
-    });
+    const confidence = determineTimeSeriesConfidence(
+      TimeSeriesFixture({
+        values: [
+          {timestamp: 100, value: 100, confidence: 'low'},
+          {timestamp: 200, value: 200, confidence: 'low'},
+          {timestamp: 300, value: 300, confidence: 'low'},
+          {timestamp: 400, value: 400, confidence: 'low'},
+          {timestamp: 500, value: 500, confidence: 'low'},
+        ],
+      })
+    );
     expect(confidence).toBe('low');
-  });
-
-  it('equals low if any in bucket is low', () => {
-    const confidence = determineSeriesConfidence({
-      data: [[200, [{count: 100}]]],
-      confidence: [
-        [100, [{count: 'high'}, {count: 'low'}, {count: null}]],
-        [200, [{count: null}, {count: 'low'}, {count: 'high'}]],
-      ],
-    });
-    expect(confidence).toBe('low');
-  });
-
-  it('equals high if no lows in bucket', () => {
-    const confidence = determineSeriesConfidence({
-      data: [[200, [{count: 100}]]],
-      confidence: [
-        [100, [{count: 'high'}, {count: 'high'}, {count: null}]],
-        [200, [{count: null}, {count: null}, {count: 'high'}]],
-      ],
-    });
-    expect(confidence).toBe('high');
   });
 });

--- a/static/app/views/alerts/rules/metric/utils/determineSeriesConfidence.tsx
+++ b/static/app/views/alerts/rules/metric/utils/determineSeriesConfidence.tsx
@@ -1,61 +1,18 @@
-import type {Confidence, EventsStats} from 'sentry/types/organization';
-import {defined} from 'sentry/utils';
+import type {Confidence} from 'sentry/types/organization';
+import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
 
 // Timeseries with more than this ratio of low confidence intervals will be considered low confidence
 const LOW_CONFIDENCE_THRESHOLD = 0.25;
 
-export function determineSeriesConfidence(
-  data: EventsStats,
+export function determineTimeSeriesConfidence(
+  timeSeries: TimeSeries,
   threshold = LOW_CONFIDENCE_THRESHOLD
 ): Confidence {
-  if (
-    !defined(data.meta?.accuracy?.confidence) ||
-    data.meta.accuracy.confidence.length < 1
-  ) {
-    // for back compat but this code path should always return null because top
-    // level confidence should be returned in the same cases as the confidence
-    // inside the accuracy object
-    return determineSeriesConfidenceDeprecated(data, threshold);
-  }
-
-  const {lowConfidence, highConfidence, nullConfidence} =
-    data.meta.accuracy.confidence.reduce(
-      (acc, item) => {
-        if (item.value === 'low') {
-          acc.lowConfidence += 1;
-        } else if (item.value === 'high') {
-          acc.highConfidence += 1;
-        } else {
-          acc.nullConfidence += 1;
-        }
-        return acc;
-      },
-      {lowConfidence: 0, highConfidence: 0, nullConfidence: 0}
-    );
-
-  return finalConfidence(lowConfidence, highConfidence, nullConfidence, threshold);
-}
-
-function determineSeriesConfidenceDeprecated(
-  data: EventsStats,
-  threshold: number
-): Confidence {
-  if (!defined(data.confidence) || data.confidence.length < 1) {
-    return null;
-  }
-
-  const perDataUnitConfidence: Confidence[] = data.confidence.map(unit => {
-    return unit[1].reduce(
-      (acc, entry) => combineConfidence(acc, entry.count),
-      null as Confidence
-    );
-  });
-
-  const {lowConfidence, highConfidence, nullConfidence} = perDataUnitConfidence.reduce(
-    (acc, confidence) => {
-      if (confidence === 'low') {
+  const {lowConfidence, highConfidence, nullConfidence} = timeSeries.values.reduce(
+    (acc, item) => {
+      if (item.confidence === 'low') {
         acc.lowConfidence += 1;
-      } else if (confidence === 'high') {
+      } else if (item.confidence === 'high') {
         acc.highConfidence += 1;
       } else {
         acc.nullConfidence += 1;
@@ -80,22 +37,6 @@ function finalConfidence(
 
   // Do not divide by (low + high + null) because nulls then can then heavily influence the final confidence
   if (lowConfidence / (lowConfidence + highConfidence) > threshold) {
-    return 'low';
-  }
-
-  return 'high';
-}
-
-function combineConfidence(a: Confidence, b: Confidence): Confidence {
-  if (!defined(a)) {
-    return b;
-  }
-
-  if (!defined(b)) {
-    return a;
-  }
-
-  if (a === 'low' || b === 'low') {
     return 'low';
   }
 

--- a/static/app/views/alerts/rules/metric/utils/determineSeriesSampleCount.tsx
+++ b/static/app/views/alerts/rules/metric/utils/determineSeriesSampleCount.tsx
@@ -53,9 +53,9 @@ export function determineSeriesSampleCountAndIsSampled(
 
     if (!dataScanned) {
       // Take one entry of dataScanned, they should all be the same
-      if (data[i]?.dataScanned === 'partial') {
+      if (data[i]?.meta.dataScanned === 'partial') {
         dataScanned = 'partial';
-      } else if (data[i]?.dataScanned === 'full') {
+      } else if (data[i]?.meta.dataScanned === 'full') {
         dataScanned = 'full';
       }
     }

--- a/static/app/views/alerts/rules/metric/utils/determineSeriesSampleCount.tsx
+++ b/static/app/views/alerts/rules/metric/utils/determineSeriesSampleCount.tsx
@@ -35,22 +35,22 @@ export function determineSeriesSampleCountAndIsSampled(
   let hasUnsampledInterval = false;
   let dataScanned: 'full' | 'partial' | undefined;
 
-  const series: number[] = data[0]?.sampleCount?.map(item => item.value) ?? [];
+  const series: number[] = data[0]?.values?.map(item => item.sampleCount ?? 0) ?? [];
 
   for (let i = 0; i < data.length; i++) {
-    if (defined(data[i]?.sampleCount)) {
-      for (let j = 0; j < data[i]!.sampleCount!.length; j++) {
-        if (i > 0) {
-          series[j] = merge(series[j] || 0, data[i]!.sampleCount![j]!.value);
-        }
-        const sampleRate = data[i]?.samplingRate?.[j]?.value;
-        if (sampleRate === 1) {
-          hasUnsampledInterval = true;
-        } else if (defined(sampleRate) && sampleRate < 1) {
-          hasSampledInterval = true;
-        }
+    for (let j = 0; j < data[i]!.values.length; j++) {
+      if (i > 0) {
+        series[j] = merge(series[j] || 0, data[i]!.values[j]!.sampleCount || 0);
+      }
+
+      const sampleRate = data[i]!.values[j]!.sampleRate;
+      if (sampleRate === 1) {
+        hasUnsampledInterval = true;
+      } else if (defined(sampleRate) && sampleRate < 1) {
+        hasSampledInterval = true;
       }
     }
+
     if (!dataScanned) {
       // Take one entry of dataScanned, they should all be the same
       if (data[i]?.dataScanned === 'partial') {

--- a/static/app/views/dashboards/widgetCard/spansWidgetQueries.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/spansWidgetQueries.spec.tsx
@@ -23,12 +23,20 @@ describe('spansWidgetQueries', () => {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events-stats/',
       body: {
-        confidence: [
-          [1, [{count: 'low'}]],
-          [2, [{count: 'low'}]],
-          [3, [{count: 'low'}]],
+        data: [
+          [1, [{count: 1}]],
+          [2, [{count: 2}]],
+          [3, [{count: 3}]],
         ],
-        data: [],
+        meta: {
+          accuracy: {
+            confidence: [
+              {timestamp: 1, value: 'low'},
+              {timestamp: 2, value: 'low'},
+              {timestamp: 3, value: 'low'},
+            ],
+          },
+        },
       },
     });
 
@@ -63,20 +71,36 @@ describe('spansWidgetQueries', () => {
       url: '/organizations/org-slug/events-stats/',
       body: {
         a: {
-          confidence: [
-            [1, [{count: 'high'}]],
-            [2, [{count: 'high'}]],
-            [3, [{count: 'high'}]],
+          meta: {
+            accuracy: {
+              confidence: [
+                {timestamp: 1, value: 'high'},
+                {timestamp: 2, value: 'high'},
+                {timestamp: 3, value: 'high'},
+              ],
+            },
+          },
+          data: [
+            [1, [{count: 1}]],
+            [2, [{count: 2}]],
+            [3, [{count: 3}]],
           ],
-          data: [],
         },
         b: {
-          confidence: [
-            [1, [{count: 'high'}]],
-            [2, [{count: 'high'}]],
-            [3, [{count: 'high'}]],
+          meta: {
+            accuracy: {
+              confidence: [
+                {timestamp: 1, value: 'high'},
+                {timestamp: 2, value: 'high'},
+                {timestamp: 3, value: 'high'},
+              ],
+            },
+          },
+          data: [
+            [1, [{count: 1}]],
+            [2, [{count: 2}]],
+            [3, [{count: 3}]],
           ],
-          data: [],
         },
       },
     });

--- a/static/app/views/dashboards/widgetCard/spansWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/spansWidgetQueries.tsx
@@ -13,7 +13,7 @@ import {dedupeArray} from 'sentry/utils/dedupeArray';
 import type {EventsTableData, TableData} from 'sentry/utils/discover/discoverQuery';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import useOrganization from 'sentry/utils/useOrganization';
-import {determineSeriesConfidence} from 'sentry/views/alerts/rules/metric/utils/determineSeriesConfidence';
+import {determineTimeSeriesConfidence} from 'sentry/views/alerts/rules/metric/utils/determineSeriesConfidence';
 import {determineSeriesSampleCountAndIsSampled} from 'sentry/views/alerts/rules/metric/utils/determineSeriesSampleCount';
 import {SpansConfig} from 'sentry/views/dashboards/datasetConfig/spans';
 import type {DashboardFilters, Widget} from 'sentry/views/dashboards/types';
@@ -63,17 +63,15 @@ function SpansWidgetQueries(props: SpansWidgetQueriesProps) {
       let seriesIsSampled: boolean | null;
 
       if (isEventsStats(result)) {
-        seriesConfidence = determineSeriesConfidence(result);
+        const [_order, timeSeries] = convertEventsStatsToTimeSeriesData(
+          props.widget.queries[0]?.aggregates[0] ?? '',
+          result
+        );
+
+        seriesConfidence = determineTimeSeriesConfidence(timeSeries);
+
         const {sampleCount: calculatedSampleCount, isSampled: calculatedIsSampled} =
-          determineSeriesSampleCountAndIsSampled(
-            [
-              convertEventsStatsToTimeSeriesData(
-                props.widget.queries[0]?.aggregates[0] ?? '',
-                result
-              )[1],
-            ],
-            false
-          );
+          determineSeriesSampleCountAndIsSampled([timeSeries], false);
         seriesSampleCount = calculatedSampleCount;
         seriesIsSampled = calculatedIsSampled;
       } else {

--- a/static/app/views/dashboards/widgets/common/types.tsx
+++ b/static/app/views/dashboards/widgets/common/types.tsx
@@ -58,7 +58,6 @@ export type TimeSeries = {
   meta: TimeSeriesMeta;
   values: TimeSeriesItem[];
   yAxis: string;
-  confidence?: Confidence;
   dataScanned?: 'full' | 'partial';
   groupBy?: TimeSeriesGroupBy[];
   sampleCount?: AccuracyStats<number>;

--- a/static/app/views/dashboards/widgets/common/types.tsx
+++ b/static/app/views/dashboards/widgets/common/types.tsx
@@ -27,6 +27,7 @@ export type TimeSeriesMeta = {
   interval: number;
   valueType: TimeSeriesValueType;
   valueUnit: TimeSeriesValueUnit;
+  dataScanned?: 'partial' | 'full';
   isOther?: boolean;
   /**
    * For a top N request, the order is the position of this `TimeSeries` within the respective yAxis.
@@ -58,7 +59,6 @@ export type TimeSeries = {
   meta: TimeSeriesMeta;
   values: TimeSeriesItem[];
   yAxis: string;
-  dataScanned?: 'full' | 'partial';
   groupBy?: TimeSeriesGroupBy[];
 };
 

--- a/static/app/views/dashboards/widgets/common/types.tsx
+++ b/static/app/views/dashboards/widgets/common/types.tsx
@@ -40,10 +40,13 @@ export type TimeSeriesItem = {
    */
   timestamp: number;
   value: number | null;
+  confidence?: Confidence;
   /**
    * A data point might be incomplete for a few reasons. One possible reason is that it's too new, and the ingestion of data for this time bucket is still going. Another reason is that it's truncated. For example, if we're plotting a data bucket from 1:00pm to 2:00pm, but the data set only includes data from 1:15pm and on, the bucket is incomplete.
    */
   incomplete?: boolean;
+  sampleCount?: number;
+  sampleRate?: number;
 };
 
 type TimeSeriesGroupBy = {

--- a/static/app/views/dashboards/widgets/common/types.tsx
+++ b/static/app/views/dashboards/widgets/common/types.tsx
@@ -60,7 +60,6 @@ export type TimeSeries = {
   yAxis: string;
   dataScanned?: 'full' | 'partial';
   groupBy?: TimeSeriesGroupBy[];
-  sampleCount?: AccuracyStats<number>;
   samplingRate?: AccuracyStats<number | null>;
 };
 

--- a/static/app/views/dashboards/widgets/common/types.tsx
+++ b/static/app/views/dashboards/widgets/common/types.tsx
@@ -1,4 +1,4 @@
-import type {AccuracyStats, Confidence} from 'sentry/types/organization';
+import type {Confidence} from 'sentry/types/organization';
 import type {DataUnit} from 'sentry/utils/discover/fields';
 import type {ThresholdsConfig} from 'sentry/views/dashboards/widgetBuilder/buildSteps/thresholdsStep/thresholdsStep';
 
@@ -60,7 +60,6 @@ export type TimeSeries = {
   yAxis: string;
   dataScanned?: 'full' | 'partial';
   groupBy?: TimeSeriesGroupBy[];
-  samplingRate?: AccuracyStats<number | null>;
 };
 
 export type TabularValueType = AttributeValueType;

--- a/static/app/views/explore/multiQueryMode/hooks/useMultiQueryTimeseries.tsx
+++ b/static/app/views/explore/multiQueryMode/hooks/useMultiQueryTimeseries.tsx
@@ -41,7 +41,7 @@ export function useMultiQueryTimeseries({
       });
       const canGetMoreData = Object.values(results.data).some(result => {
         return Object.values(result).some(series => {
-          return series.dataScanned === 'partial';
+          return series.meta.dataScanned === 'partial';
         });
       });
 

--- a/static/app/views/explore/multiQueryMode/hooks/useMultiQueryTimeseries.tsx
+++ b/static/app/views/explore/multiQueryMode/hooks/useMultiQueryTimeseries.tsx
@@ -34,8 +34,8 @@ export function useMultiQueryTimeseries({
     (results: ReturnType<typeof useMultiQueryTimeseriesImpl>['result']) => {
       const hasData = Object.values(results.data).some(result => {
         return Object.values(result).some(series => {
-          return series.sampleCount?.some(({value}) => {
-            return value > 0;
+          return series.values.some(value => {
+            return (value.sampleCount ?? 0) > 0;
           });
         });
       });

--- a/static/app/views/explore/utils.tsx
+++ b/static/app/views/explore/utils.tsx
@@ -27,6 +27,7 @@ import {
 } from 'sentry/utils/discover/fields';
 import {decodeSorts} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {determineTimeSeriesConfidence} from 'sentry/views/alerts/rules/metric/utils/determineSeriesConfidence';
 import {determineSeriesSampleCountAndIsSampled} from 'sentry/views/alerts/rules/metric/utils/determineSeriesSampleCount';
 import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
 import {newExploreTarget} from 'sentry/views/explore/contexts/pageParamsContext';
@@ -228,17 +229,16 @@ export function getExploreMultiQueryUrl({
   return `/organizations/${organization.slug}/explore/traces/compare/?${qs.stringify(queryParams, {skipNull: true})}`;
 }
 
-export function combineConfidenceForSeries(
-  series: Array<Pick<TimeSeries, 'confidence'>>
-): Confidence {
+export function combineConfidenceForSeries(series: TimeSeries[]): Confidence {
   let lows = 0;
   let highs = 0;
   let nulls = 0;
 
   for (const s of series) {
-    if (s.confidence === 'low') {
+    const confidence = determineTimeSeriesConfidence(s);
+    if (confidence === 'low') {
       lows += 1;
-    } else if (s.confidence === 'high') {
+    } else if (confidence === 'high') {
       highs += 1;
     } else {
       nulls += 1;

--- a/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
+++ b/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
@@ -262,7 +262,6 @@ export function convertEventsStatsToTimeSeriesData(
       valueUnit: seriesData.meta?.units?.[seriesName] as DataUnit,
       interval,
     },
-    sampleCount: seriesData.meta?.accuracy?.sampleCount,
     samplingRate: seriesData.meta?.accuracy?.samplingRate,
     dataScanned: seriesData.meta?.dataScanned,
   };

--- a/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
+++ b/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
@@ -19,12 +19,14 @@ import type {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import {determineSeriesConfidence} from 'sentry/views/alerts/rules/metric/utils/determineSeriesConfidence';
 import {
   isEventsStats,
   isMultiSeriesEventsStats,
 } from 'sentry/views/dashboards/utils/isEventsStats';
-import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
+import type {
+  TimeSeries,
+  TimeSeriesItem,
+} from 'sentry/views/dashboards/widgets/common/types';
 import type {SamplingMode} from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {FALLBACK_SERIES_NAME} from 'sentry/views/explore/settings';
 import {getSeriesEventView} from 'sentry/views/insights/common/queries/getSeriesEventView';
@@ -240,10 +242,15 @@ export function convertEventsStatsToTimeSeriesData(
 ): [number, TimeSeries] {
   const label = alias ?? (seriesName || FALLBACK_SERIES_NAME);
 
-  const values = seriesData.data.map(([timestamp, countsForTimestamp]) => ({
-    timestamp: timestamp * 1000,
-    value: countsForTimestamp.reduce((acc, {count}) => acc + count, 0),
-  }));
+  const values: TimeSeriesItem[] = seriesData.data.map(
+    ([timestamp, countsForTimestamp], index) => ({
+      timestamp: timestamp * 1000,
+      value: countsForTimestamp.reduce((acc, {count}) => acc + count, 0),
+      confidence: seriesData.meta?.accuracy?.confidence?.[index]?.value ?? null,
+      sampleCount: seriesData.meta?.accuracy?.sampleCount?.[index]?.value ?? undefined,
+      sampleRate: seriesData.meta?.accuracy?.samplingRate?.[index]?.value ?? undefined,
+    })
+  );
 
   const interval = getTimeSeriesInterval(values);
 

--- a/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
+++ b/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
@@ -262,7 +262,6 @@ export function convertEventsStatsToTimeSeriesData(
       valueUnit: seriesData.meta?.units?.[seriesName] as DataUnit,
       interval,
     },
-    confidence: determineSeriesConfidence(seriesData),
     sampleCount: seriesData.meta?.accuracy?.sampleCount,
     samplingRate: seriesData.meta?.accuracy?.samplingRate,
     dataScanned: seriesData.meta?.dataScanned,

--- a/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
+++ b/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
@@ -262,7 +262,6 @@ export function convertEventsStatsToTimeSeriesData(
       valueUnit: seriesData.meta?.units?.[seriesName] as DataUnit,
       interval,
     },
-    samplingRate: seriesData.meta?.accuracy?.samplingRate,
     dataScanned: seriesData.meta?.dataScanned,
   };
 

--- a/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
+++ b/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
@@ -243,13 +243,28 @@ export function convertEventsStatsToTimeSeriesData(
   const label = alias ?? (seriesName || FALLBACK_SERIES_NAME);
 
   const values: TimeSeriesItem[] = seriesData.data.map(
-    ([timestamp, countsForTimestamp], index) => ({
-      timestamp: timestamp * 1000,
-      value: countsForTimestamp.reduce((acc, {count}) => acc + count, 0),
-      confidence: seriesData.meta?.accuracy?.confidence?.[index]?.value ?? null,
-      sampleCount: seriesData.meta?.accuracy?.sampleCount?.[index]?.value ?? undefined,
-      sampleRate: seriesData.meta?.accuracy?.samplingRate?.[index]?.value ?? undefined,
-    })
+    ([timestamp, countsForTimestamp], index) => {
+      const item: TimeSeriesItem = {
+        timestamp: timestamp * 1000,
+        value: countsForTimestamp.reduce((acc, {count}) => acc + count, 0),
+      };
+
+      if (seriesData.meta?.accuracy?.confidence) {
+        item.confidence = seriesData.meta?.accuracy?.confidence?.[index]?.value ?? null;
+      }
+
+      if (seriesData.meta?.accuracy?.sampleCount) {
+        item.sampleCount =
+          seriesData.meta?.accuracy?.sampleCount?.[index]?.value ?? undefined;
+      }
+
+      if (seriesData.meta?.accuracy?.samplingRate) {
+        item.sampleRate =
+          seriesData.meta?.accuracy?.samplingRate?.[index]?.value ?? undefined;
+      }
+
+      return item;
+    }
   );
 
   const interval = getTimeSeriesInterval(values);

--- a/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
+++ b/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
@@ -261,8 +261,8 @@ export function convertEventsStatsToTimeSeriesData(
       valueType: seriesData.meta?.fields?.[seriesName]!,
       valueUnit: seriesData.meta?.units?.[seriesName] as DataUnit,
       interval,
+      dataScanned: seriesData.meta?.dataScanned,
     },
-    dataScanned: seriesData.meta?.dataScanned,
   };
 
   if (defined(order)) {


### PR DESCRIPTION
Continuing work to make the `TimeSeries` type match the response format of `/events-timeseries` endpoint. This is one of the last steps, which is moving the confidence information around to match reality.

The current definition of `TimeSeries` has `confidence`, `sampleCount` and `samplingRate` as separate series that live in parallel to the `values`. `dataScanned` is on the time series. The response from `/events-timeseries` is different!

- `confidence`, `sampleCount` and `samplingRate` are properties on _each datapoint_ in `values`
- `dataScanned` lives on the time series _meta_

This PR makes three changes:

1. Updates the `TimeSeries` type to match the server response, by putting all those confidence properties in the correct spots, according to [the spec](https://www.notion.so/sentry/Events-stats-rewrite-1af8b10e4b5d802d9d84fdd46522196f?source=copy_link)
2. Updates code that creates `TimeSeries` objects where the confidence information matters to put confidence information into the right place
3. Updates all `TimeSeries` usage that checks confidence information to pull it from the new locations

This should not result in any UI changes.
