### PR TITLE
fix(releases): Optimize release stats query

### DIFF
--- a/src/sentry/releases/endpoints/project_release_stats.py
+++ b/src/sentry/releases/endpoints/project_release_stats.py
@@ -29,6 +29,8 @@ def upsert_missing_release(project, version) -> datetime | None:
             release = Release.get_or_create(project=project, version=version, date_added=oldest)
             release.add_project(project)
             return release.date_added
+        else:
+            return None
 
 
 @region_silo_endpoint

--- a/src/sentry/releases/endpoints/project_release_stats.py
+++ b/src/sentry/releases/endpoints/project_release_stats.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -8,22 +10,25 @@ from sentry.api.bases.project import ProjectEndpoint, ProjectEventsError, Projec
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
 from sentry.models.release import Release
-from sentry.models.releases.release_project import ReleaseProject
 from sentry.release_health.base import is_overview_stat
 from sentry.utils.dates import get_rollup_from_request
 
 
-def upsert_missing_release(project, version):
+def upsert_missing_release(project, version) -> datetime | None:
     """This adds a release to postgres if it should exist but does not do yet."""
     try:
-        return ReleaseProject.objects.get(project=project, release__version=version).release
-    except ReleaseProject.DoesNotExist:
+        return Release.objects.values_list("date_added", flat=True).get(
+            organization=project.organization,
+            projects=project,
+            version=version,
+        )
+    except Release.DoesNotExist:
         rows = release_health.backend.get_oldest_health_data_for_releases([(project.id, version)])
         if rows:
             oldest = next(iter(rows.values()))
             release = Release.get_or_create(project=project, version=version, date_added=oldest)
             release.add_project(project)
-            return release
+            return release.date_added
 
 
 @region_silo_endpoint
@@ -67,8 +72,8 @@ class ProjectReleaseStatsEndpoint(ProjectEndpoint):
         except ProjectEventsError as e:
             return Response({"detail": str(e)}, status=400)
 
-        release = upsert_missing_release(project, version)
-        if release is None:
+        release_date_added = upsert_missing_release(project, version)
+        if release_date_added is None:
             raise ResourceDoesNotExist
 
         stats, totals = release_health.backend.get_project_release_stats(
@@ -86,7 +91,7 @@ class ProjectReleaseStatsEndpoint(ProjectEndpoint):
             project_id=params["project_id"][0],
             release=version,
             environments=params.get("environment"),
-            start=release.date_added,
+            start=release_date_added,
         ):
             users_breakdown.append(
                 {

--- a/tests/sentry/releases/endpoints/test_project_release_stats.py
+++ b/tests/sentry/releases/endpoints/test_project_release_stats.py
@@ -34,3 +34,20 @@ class ProjectReleaseStatsTest(APITestCase):
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200, response.content
+
+    def test_simple_no_release(self) -> None:
+        """Minimal test to ensure code coverage of the endpoint"""
+        self.login_as(user=self.user)
+
+        project = self.create_project(name="foo")
+
+        url = reverse(
+            "sentry-api-0-project-release-stats",
+            kwargs={
+                "organization_id_or_slug": project.organization.slug,
+                "project_id_or_slug": project.slug,
+                "version": "1",
+            },
+        )
+        response = self.client.get(url, format="json")
+        assert response.status_code == 404, response.content


### PR DESCRIPTION
Resolves: https://sentry.sentry.io/issues/4495954544?project=1&statsPeriod=24h
Ref: https://linear.app/getsentry/issue/REPLAY-577/krakens-release-page-loading-slow-with-500-errors

## What it does

Narrows the selection set, utilizes the `(organization, version)` composite index, targets the release table directly, filters projects by a join rather than release by a join.

## Plan result

Original:

```
Nested Loop  (cost=0.15..21.34 rows=1 width=52)
  ->  Seq Scan on sentry_release  (cost=0.00..10.50 rows=1 width=8)
        Filter: ((version)::text = '1'::text)
  ->  Index Scan using sentry_release_project_project_id_release_id_44ff55de_uniq on sentry_release_project  (cost=0.15..8.17 rows=1 width=52)
        Index Cond: ((project_id = '4556659013779457'::bigint) AND (release_id = sentry_release.id))
```

New:

```
Nested Loop  (cost=0.29..19.00 rows=1 width=8)
  ->  Index Scan using sentry_rele_organiz_6975e7_idx on sentry_release  (cost=0.14..8.16 rows=1 width=16)
        Index Cond: (organization_id = '4556659068698624'::bigint)
        Filter: ((version)::text = '1'::text)
  ->  Index Only Scan using sentry_release_project_project_id_release_id_44ff55de_uniq on sentry_release_project  (cost=0.15..8.17 rows=1 width=8)
        Index Cond: ((project_id = '4556659068829696'::bigint) AND (release_id = sentry_release.id))
```

The plan shows modest cost improvements and some improvements to selection width. The sequential scan is gone though I can't find evidence of a sequential scan in datadog. If nothing else this PR improves test coverage and we can observe how these indices perform in practice.