### PR TITLE
feat(dashboards): Add support for array `groupBy` values in `TimeSeries`

### DIFF
--- a/static/app/views/dashboards/widgets/common/types.tsx
+++ b/static/app/views/dashboards/widgets/common/types.tsx
@@ -48,7 +48,10 @@ export type TimeSeriesItem = {
 
 type TimeSeriesGroupBy = {
   key: string;
-  value: string;
+  /**
+   * The `value` of a `groupBy` can sometimes surprisingly be an array, because some datasets support array values. e.g., in the error dataset, the error type could be an array that looks like `["Exception", null, "TypeError"]`
+   */
+  value: string | Array<string | null> | Array<number | null>;
 };
 
 export type TimeSeries = {

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatTimeSeriesName.spec.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatTimeSeriesName.spec.tsx
@@ -104,6 +104,41 @@ describe('formatSeriesName', () => {
         [{key: 'release', value: 'frontend@31804d9a5f0b5e4f53055467cd258e1c'}],
         '31804d9a5f0b',
       ],
+      [
+        'p95(span.duration)',
+        [{key: 'error.type', value: ['Exception', 'TypeError']}],
+        '["Exception","TypeError"]',
+      ],
+      [
+        'p95(span.duration)',
+        [{key: 'error.type', value: ['Exception', null, 'TypeError']}],
+        '["Exception",null,"TypeError"]',
+      ],
+      ['p95(span.duration)', [{key: 'error.type', value: [null]}], '[null]'],
+      ['p95(span.duration)', [{key: 'error.type', value: []}], '[]'],
+      [
+        'p95(span.duration)',
+        [
+          {key: 'error.type', value: ['Exception', null]},
+          {key: 'env', value: 'prod'},
+        ],
+        '["Exception",null],prod',
+      ],
+      [
+        'p95(span.duration)',
+        [
+          {key: 'release', value: 'v0.0.2'},
+          {key: 'error.type', value: ['Exception', 'TypeError']},
+        ],
+        'v0.0.2,["Exception","TypeError"]',
+      ],
+      ['p95(span.duration)', [{key: 'counts', value: [1, 2, 3]}], '[1,2,3]'],
+      ['p95(span.duration)', [{key: 'counts', value: [1, null, 3]}], '[1,null,3]'],
+      [
+        'p95(span.duration)',
+        [{key: 'mixed', value: [null, null, null]}],
+        '[null,null,null]',
+      ],
     ])('Formats %s with groupBy %s as %s', (name, groupBy, result) => {
       const timeSeries = TimeSeriesFixture({
         yAxis: name,

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatTimeSeriesName.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatTimeSeriesName.tsx
@@ -15,6 +15,10 @@ export function formatTimeSeriesName(timeSeries: TimeSeries): string {
   if (timeSeries.groupBy?.length && timeSeries.groupBy.length > 0) {
     return `${timeSeries.groupBy
       ?.map(groupBy => {
+        if (Array.isArray(groupBy.value)) {
+          return JSON.stringify(groupBy.value);
+        }
+
         if (groupBy.key === 'release') {
           return formatVersion(groupBy.value);
         }


### PR DESCRIPTION
This is totally a thing that happens! The `groupBy` value might be an array of strings or numbers, and there might be nulls in there! This is not common, but it happens sometimes so we should handle it. For now, just JSON-encode them, so it's clear to the user what's going on. This values appears in the chart legend.
