### PR TITLE
fix(aci): Don't retry event /group not found in process_workflows_event

### DIFF
--- a/src/sentry/workflow_engine/tasks/utils.py
+++ b/src/sentry/workflow_engine/tasks/utils.py
@@ -46,6 +46,12 @@ def fetch_event(event_id: str, project_id: int) -> Event | None:
     )
 
 
+class EventNotFoundError(Exception):
+    def __init__(self, event_id: str, project_id: int):
+        msg = f"Event not found: event_id={event_id}, project_id={project_id}"
+        super().__init__(msg)
+
+
 def build_workflow_event_data_from_event(
     project_id: int,
     event_id: str,
@@ -59,11 +65,12 @@ def build_workflow_event_data_from_event(
     """
     Build a WorkflowEventData object from individual parameters.
     This method handles all the database fetching and object construction logic.
+    Raises EventNotFoundError if the event is not found.
     """
 
     event = fetch_event(event_id, project_id)
     if event is None:
-        raise ValueError(f"Event not found: event_id={event_id}, project_id={project_id}")
+        raise EventNotFoundError(event_id, project_id)
 
     occurrence = IssueOccurrence.fetch(occurrence_id, project_id) if occurrence_id else None
     # TODO(iamrajjoshi): Should we use get_from_cache here?

--- a/src/sentry/workflow_engine/tasks/workflows.py
+++ b/src/sentry/workflow_engine/tasks/workflows.py
@@ -14,7 +14,10 @@ from sentry.taskworker.retry import Retry, retry_task
 from sentry.utils import metrics
 from sentry.workflow_engine.models import Detector
 from sentry.workflow_engine.processors.workflow import process_workflows
-from sentry.workflow_engine.tasks.utils import build_workflow_event_data_from_event
+from sentry.workflow_engine.tasks.utils import (
+    EventNotFoundError,
+    build_workflow_event_data_from_event,
+)
 from sentry.workflow_engine.types import WorkflowEventData
 from sentry.workflow_engine.utils import log_context
 
@@ -94,7 +97,7 @@ def process_workflow_activity(activity_id: int, group_id: int, detector_id: int)
         ),
     ),
 )
-@retry(timeouts=True)
+@retry(timeouts=True, exclude=(EventNotFoundError,))
 def process_workflows_event(
     project_id: int,
     event_id: str,

--- a/src/sentry/workflow_engine/tasks/workflows.py
+++ b/src/sentry/workflow_engine/tasks/workflows.py
@@ -97,7 +97,7 @@ def process_workflow_activity(activity_id: int, group_id: int, detector_id: int)
         ),
     ),
 )
-@retry(timeouts=True, exclude=(EventNotFoundError,))
+@retry(timeouts=True, exclude=(EventNotFoundError, Group.DoesNotExist))
 def process_workflows_event(
     project_id: int,
     event_id: str,


### PR DESCRIPTION
These are real failures, but they're quite rare and best handled at the moment for monitoring for escalation.
Rather than retrying them 3 times and ending up with a NoMoreRetriesError (which is signals that we failed unexpectedly even after trying again), just failing immediately and explicitly allows us to precisely use archiving for noise management.