### PR TITLE
feat(logs): Add apple empty state logs onboarding

### DIFF
--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -307,6 +307,9 @@ export const withoutPerformanceSupport: Set<PlatformKey> = new Set([
 // List of platforms that have logging onboarding checklist content
 export const withLoggingOnboarding: Set<PlatformKey> = new Set([
   'android',
+  'apple',
+  'apple-ios',
+  'apple-macos',
   'dart',
   'flutter',
   'go',

--- a/static/app/gettingStartedDocs/apple/ios.tsx
+++ b/static/app/gettingStartedDocs/apple/ios.tsx
@@ -570,6 +570,138 @@ const replayOnboarding: OnboardingConfig<PlatformOptions> = {
   nextSteps: () => [],
 };
 
+const logsOnboarding: OnboardingConfig<PlatformOptions> = {
+  install: params => [
+    {
+      type: StepType.INSTALL,
+      content: [
+        {
+          type: 'text',
+          text: tct(
+            'Logs for Apple platforms are supported in Sentry Cocoa SDK version [code:8.55.0] and above. If you are using an older major version of the SDK, follow our [link:migration guide] to upgrade.',
+            {
+              code: <code />,
+              link: (
+                <ExternalLink href="https://docs.sentry.io/platforms/apple/guides/ios/migration/" />
+              ),
+            }
+          ),
+        },
+        {
+          type: 'code',
+          tabs: [
+            {
+              label: 'SPM',
+              language: 'swift',
+              code: `.package(url: "https://github.com/getsentry/sentry-cocoa", from: "${getPackageVersion(
+                params,
+                'sentry.cocoa',
+                '8.55.0'
+              )}"),`,
+            },
+            {
+              label: 'CocoaPods',
+              language: 'ruby',
+              code: `pod update`,
+            },
+            {
+              label: 'Carthage',
+              language: 'swift',
+              code: `github "getsentry/sentry-cocoa" "${getPackageVersion(
+                params,
+                'sentry.cocoa',
+                '8.55.0'
+              )}"`,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  configure: params => [
+    {
+      type: StepType.CONFIGURE,
+      content: [
+        {
+          type: 'text',
+          text: tct(
+            'To enable logging, you need to initialize the SDK with the [code:enableLogs] option set to true.',
+            {
+              code: <code />,
+            }
+          ),
+        },
+        {
+          type: 'code',
+          tabs: [
+            {
+              label: 'Swift',
+              language: 'swift',
+              code: `import Sentry
+
+SentrySDK.start { options in
+    options.dsn = "${params.dsn.public}"
+    // Enable logs to be sent to Sentry
+    options.experimental.enableLogs = true
+}`,
+            },
+            {
+              label: 'Objective-C',
+              language: 'objc',
+              code: `@import Sentry;
+
+[SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
+    options.dsn = @"${params.dsn.public}";
+    // Enable logs to be sent to Sentry
+    options.experimental.enableLogs = YES;
+}];`,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  verify: () => [
+    {
+      type: StepType.VERIFY,
+      content: [
+        {
+          type: 'text',
+          text: t('Send a test log from your app to verify logs are arriving in Sentry.'),
+        },
+        {
+          type: 'code',
+          tabs: [
+            {
+              label: 'Swift',
+              language: 'swift',
+              code: `import Sentry
+
+let logger = SentrySDK.logger
+
+logger.info("Sending a test info log")
+
+logger.warn("Sending a test warning log", attributes: [
+    "log_type": "test",
+])`,
+            },
+            {
+              label: 'Objective-C',
+              language: 'objc',
+              code: `@import Sentry;
+
+SentryLogger *logger = SentrySDK.logger;
+
+[logger info:@"Sending a test info log"];
+[logger warn:@"Sending a test warning log" attributes:@{@"log_type": @"test"}];`,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
 const docs: Docs<PlatformOptions> = {
   onboarding,
   feedbackOnboardingCrashApi: appleFeedbackOnboarding,
@@ -577,6 +709,7 @@ const docs: Docs<PlatformOptions> = {
   platformOptions,
   replayOnboarding,
   profilingOnboarding: appleProfilingOnboarding,
+  logsOnboarding,
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/apple/macos.tsx
+++ b/static/app/gettingStartedDocs/apple/macos.tsx
@@ -336,11 +336,144 @@ SentrySDK.start { options in
   nextSteps: () => [],
 };
 
+const logsOnboarding: OnboardingConfig = {
+  install: params => [
+    {
+      type: StepType.INSTALL,
+      content: [
+        {
+          type: 'text',
+          text: tct(
+            'Logs for Apple platforms are supported in Sentry Cocoa SDK version [code:8.55.0] and above. If you are using an older major version of the SDK, follow our [link:migration guide] to upgrade.',
+            {
+              code: <code />,
+              link: (
+                <ExternalLink href="https://docs.sentry.io/platforms/apple/guides/macos/migration/" />
+              ),
+            }
+          ),
+        },
+        {
+          type: 'code',
+          tabs: [
+            {
+              label: 'SPM',
+              language: 'swift',
+              code: `.package(url: "https://github.com/getsentry/sentry-cocoa", from: "${getPackageVersion(
+                params,
+                'sentry.cocoa',
+                '8.55.0'
+              )}"),`,
+            },
+            {
+              label: 'CocoaPods',
+              language: 'ruby',
+              code: `pod update`,
+            },
+            {
+              label: 'Carthage',
+              language: 'swift',
+              code: `github "getsentry/sentry-cocoa" "${getPackageVersion(
+                params,
+                'sentry.cocoa',
+                '8.55.0'
+              )}"`,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  configure: params => [
+    {
+      type: StepType.CONFIGURE,
+      content: [
+        {
+          type: 'text',
+          text: tct(
+            'To enable logging, you need to initialize the SDK with the [code:enableLogs] option set to true.',
+            {
+              code: <code />,
+            }
+          ),
+        },
+        {
+          type: 'code',
+          tabs: [
+            {
+              label: 'Swift',
+              language: 'swift',
+              code: `import Sentry
+
+SentrySDK.start { options in
+    options.dsn = "${params.dsn.public}"
+    // Enable logs to be sent to Sentry
+    options.experimental.enableLogs = true
+}`,
+            },
+            {
+              label: 'Objective-C',
+              language: 'objc',
+              code: `@import Sentry;
+
+[SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
+    options.dsn = @"${params.dsn.public}";
+    // Enable logs to be sent to Sentry
+    options.experimental.enableLogs = YES;
+}];`,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  verify: () => [
+    {
+      type: StepType.VERIFY,
+      content: [
+        {
+          type: 'text',
+          text: t('Send a test log from your app to verify logs are arriving in Sentry.'),
+        },
+        {
+          type: 'code',
+          tabs: [
+            {
+              label: 'Swift',
+              language: 'swift',
+              code: `import Sentry
+
+let logger = SentrySDK.logger
+
+logger.info("Sending a test info log")
+
+logger.warn("Sending a test warning log", attributes: [
+    "log_type": "test",
+])`,
+            },
+            {
+              label: 'Objective-C',
+              language: 'objc',
+              code: `@import Sentry;
+
+SentryLogger *logger = SentrySDK.logger;
+
+[logger info:@"Sending a test info log"];
+[logger warn:@"Sending a test warning log" attributes:@{@"log_type": @"test"}];`,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
 const docs: Docs = {
   onboarding,
   feedbackOnboardingCrashApi: appleFeedbackOnboarding,
   crashReportOnboarding: appleFeedbackOnboarding,
   profilingOnboarding: appleProfilingOnboarding,
+  logsOnboarding,
 };
 
 export default docs;


### PR DESCRIPTION
resolves https://linear.app/getsentry/issue/LOGS-320/add-empty-state-onboarding-for-apple-sdks

<img width="1222" height="795" alt="image" src="https://github.com/user-attachments/assets/b97055a8-586a-47ee-9c75-210012b2cff4" />
