### PR TITLE
ref(kafka): Add get_arroyo_producer

### DIFF
--- a/src/sentry/issues/attributes.py
+++ b/src/sentry/issues/attributes.py
@@ -6,7 +6,7 @@ from enum import Enum
 
 import urllib3
 from arroyo import Topic as ArroyoTopic
-from arroyo.backends.kafka import KafkaPayload, KafkaProducer, build_kafka_configuration
+from arroyo.backends.kafka import KafkaPayload, KafkaProducer
 from django.conf import settings
 from django.db.models import F, Window
 from django.db.models.functions import Rank
@@ -20,8 +20,8 @@ from sentry.models.groupassignee import GroupAssignee
 from sentry.models.groupowner import GroupOwner, GroupOwnerType
 from sentry.signals import issue_assigned, issue_deleted, issue_unassigned, post_update
 from sentry.utils import json, metrics, snuba
-from sentry.utils.arroyo_producer import SingletonProducer
-from sentry.utils.kafka_config import get_kafka_producer_cluster_options, get_topic_definition
+from sentry.utils.arroyo_producer import SingletonProducer, get_arroyo_producer
+from sentry.utils.kafka_config import get_topic_definition
 from sentry.utils.snuba import _snuba_pool
 
 logger = logging.getLogger(__name__)
@@ -46,12 +46,11 @@ class GroupValues:
 
 
 def _get_attribute_snapshot_producer() -> KafkaProducer:
-    cluster_name = get_topic_definition(Topic.GROUP_ATTRIBUTES)["cluster"]
-    producer_config = get_kafka_producer_cluster_options(cluster_name)
-    producer_config.pop("compression.type", None)
-    producer_config.pop("message.max.bytes", None)
-    producer_config["client.id"] = "sentry.issues.attributes"
-    return KafkaProducer(build_kafka_configuration(default_config=producer_config))
+    return get_arroyo_producer(
+        "sentry.issues.attributes",
+        Topic.GROUP_ATTRIBUTES,
+        exclude_config_keys=["compression.type", "message.max.bytes"],
+    )
 
 
 _attribute_snapshot_producer = SingletonProducer(

--- a/src/sentry/issues/attributes.py
+++ b/src/sentry/issues/attributes.py
@@ -6,7 +6,7 @@ from enum import Enum
 
 import urllib3
 from arroyo import Topic as ArroyoTopic
-from arroyo.backends.kafka import KafkaPayload, KafkaProducer
+from arroyo.backends.kafka import KafkaPayload, KafkaProducer, build_kafka_configuration
 from django.conf import settings
 from django.db.models import F, Window
 from django.db.models.functions import Rank
@@ -21,7 +21,7 @@ from sentry.models.groupowner import GroupOwner, GroupOwnerType
 from sentry.signals import issue_assigned, issue_deleted, issue_unassigned, post_update
 from sentry.utils import json, metrics, snuba
 from sentry.utils.arroyo_producer import SingletonProducer, get_arroyo_producer
-from sentry.utils.kafka_config import get_topic_definition
+from sentry.utils.kafka_config import get_kafka_producer_cluster_options, get_topic_definition
 from sentry.utils.snuba import _snuba_pool
 
 logger = logging.getLogger(__name__)
@@ -46,11 +46,22 @@ class GroupValues:
 
 
 def _get_attribute_snapshot_producer() -> KafkaProducer:
-    return get_arroyo_producer(
+    producer = get_arroyo_producer(
         "sentry.issues.attributes",
         Topic.GROUP_ATTRIBUTES,
         exclude_config_keys=["compression.type", "message.max.bytes"],
     )
+
+    # Fallback to legacy producer creation if not rolled out
+    if producer is None:
+        cluster_name = get_topic_definition(Topic.GROUP_ATTRIBUTES)["cluster"]
+        producer_config = get_kafka_producer_cluster_options(cluster_name)
+        producer_config.pop("compression.type", None)
+        producer_config.pop("message.max.bytes", None)
+        producer_config["client.id"] = "sentry.issues.attributes"
+        producer = KafkaProducer(build_kafka_configuration(default_config=producer_config))
+
+    return producer
 
 
 _attribute_snapshot_producer = SingletonProducer(

--- a/src/sentry/issues/producer.py
+++ b/src/sentry/issues/producer.py
@@ -5,7 +5,7 @@ from collections.abc import MutableMapping
 from typing import Any, cast
 
 from arroyo import Topic as ArroyoTopic
-from arroyo.backends.kafka import KafkaPayload, KafkaProducer, build_kafka_configuration
+from arroyo.backends.kafka import KafkaPayload, KafkaProducer
 from arroyo.types import Message, Value
 from confluent_kafka import KafkaException
 from django.conf import settings
@@ -16,8 +16,8 @@ from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.issues.run import process_message
 from sentry.issues.status_change_message import StatusChangeMessage
 from sentry.utils import json
-from sentry.utils.arroyo_producer import SingletonProducer
-from sentry.utils.kafka_config import get_kafka_producer_cluster_options, get_topic_definition
+from sentry.utils.arroyo_producer import SingletonProducer, get_arroyo_producer
+from sentry.utils.kafka_config import get_topic_definition
 
 logger = logging.getLogger(__name__)
 
@@ -35,12 +35,11 @@ class PayloadType(ValueEqualityEnum):
 
 
 def _get_occurrence_producer() -> KafkaProducer:
-    cluster_name = get_topic_definition(Topic.INGEST_OCCURRENCES)["cluster"]
-    producer_config = get_kafka_producer_cluster_options(cluster_name)
-    producer_config.pop("compression.type", None)
-    producer_config.pop("message.max.bytes", None)
-    producer_config["client.id"] = "sentry.issues.producer"
-    return KafkaProducer(build_kafka_configuration(default_config=producer_config))
+    return get_arroyo_producer(
+        "sentry.issues.producer",
+        Topic.INGEST_OCCURRENCES,
+        exclude_config_keys=["compression.type", "message.max.bytes"],
+    )
 
 
 _occurrence_producer = SingletonProducer(

--- a/src/sentry/issues/producer.py
+++ b/src/sentry/issues/producer.py
@@ -5,7 +5,7 @@ from collections.abc import MutableMapping
 from typing import Any, cast
 
 from arroyo import Topic as ArroyoTopic
-from arroyo.backends.kafka import KafkaPayload, KafkaProducer
+from arroyo.backends.kafka import KafkaPayload, KafkaProducer, build_kafka_configuration
 from arroyo.types import Message, Value
 from confluent_kafka import KafkaException
 from django.conf import settings
@@ -17,7 +17,7 @@ from sentry.issues.run import process_message
 from sentry.issues.status_change_message import StatusChangeMessage
 from sentry.utils import json
 from sentry.utils.arroyo_producer import SingletonProducer, get_arroyo_producer
-from sentry.utils.kafka_config import get_topic_definition
+from sentry.utils.kafka_config import get_kafka_producer_cluster_options, get_topic_definition
 
 logger = logging.getLogger(__name__)
 
@@ -35,11 +35,22 @@ class PayloadType(ValueEqualityEnum):
 
 
 def _get_occurrence_producer() -> KafkaProducer:
-    return get_arroyo_producer(
+    producer = get_arroyo_producer(
         "sentry.issues.producer",
         Topic.INGEST_OCCURRENCES,
         exclude_config_keys=["compression.type", "message.max.bytes"],
     )
+
+    # Fallback to legacy producer creation if not rolled out
+    if producer is None:
+        cluster_name = get_topic_definition(Topic.INGEST_OCCURRENCES)["cluster"]
+        producer_config = get_kafka_producer_cluster_options(cluster_name)
+        producer_config.pop("compression.type", None)
+        producer_config.pop("message.max.bytes", None)
+        producer_config["client.id"] = "sentry.issues.producer"
+        producer = KafkaProducer(build_kafka_configuration(default_config=producer_config))
+
+    return producer
 
 
 _occurrence_producer = SingletonProducer(

--- a/src/sentry/monitors/clock_dispatch.py
+++ b/src/sentry/monitors/clock_dispatch.py
@@ -4,15 +4,15 @@ import logging
 from datetime import datetime, timedelta, timezone
 
 from arroyo import Topic as ArroyoTopic
-from arroyo.backends.kafka import KafkaPayload, KafkaProducer, build_kafka_configuration
+from arroyo.backends.kafka import KafkaPayload
 from django.conf import settings
 from sentry_kafka_schemas.codecs import Codec
 from sentry_kafka_schemas.schema_types.monitors_clock_tick_v1 import ClockTick
 
 from sentry.conf.types.kafka_definition import Topic, get_topic_codec
 from sentry.utils import metrics, redis
-from sentry.utils.arroyo_producer import SingletonProducer
-from sentry.utils.kafka_config import get_kafka_producer_cluster_options, get_topic_definition
+from sentry.utils.arroyo_producer import SingletonProducer, get_arroyo_producer
+from sentry.utils.kafka_config import get_topic_definition
 
 logger = logging.getLogger("sentry")
 
@@ -32,13 +32,12 @@ def _int_or_none(s: str | None) -> int | None:
         return int(s)
 
 
-def _get_producer() -> KafkaProducer:
-    cluster_name = get_topic_definition(Topic.MONITORS_CLOCK_TICK)["cluster"]
-    producer_config = get_kafka_producer_cluster_options(cluster_name)
-    producer_config.pop("compression.type", None)
-    producer_config.pop("message.max.bytes", None)
-    producer_config["client.id"] = "sentry.monitors.clock_dispatch"
-    return KafkaProducer(build_kafka_configuration(default_config=producer_config))
+def _get_producer():
+    return get_arroyo_producer(
+        name="sentry.monitors.clock_dispatch",
+        topic=Topic.MONITORS_CLOCK_TICK,
+        exclude_config_keys=["compression.type", "message.max.bytes"],
+    )
 
 
 _clock_tick_producer = SingletonProducer(_get_producer)

--- a/src/sentry/monitors/clock_tasks/producer.py
+++ b/src/sentry/monitors/clock_tasks/producer.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from arroyo import Topic as ArroyoTopic
-from arroyo.backends.kafka import KafkaPayload
+from arroyo.backends.kafka import KafkaPayload, KafkaProducer
 from sentry_kafka_schemas.codecs import Codec
 from sentry_kafka_schemas.schema_types.monitors_clock_tasks_v1 import MonitorsClockTasks
 
@@ -12,7 +12,7 @@ from sentry.utils.kafka_config import get_topic_definition
 MONITORS_CLOCK_TASKS_CODEC: Codec[MonitorsClockTasks] = get_topic_codec(Topic.MONITORS_CLOCK_TASKS)
 
 
-def _get_producer():
+def _get_producer() -> KafkaProducer:
     return get_arroyo_producer(
         name="sentry.monitors.clock_tasks.producer",
         topic=Topic.MONITORS_CLOCK_TASKS,

--- a/src/sentry/monitors/clock_tasks/producer.py
+++ b/src/sentry/monitors/clock_tasks/producer.py
@@ -1,23 +1,34 @@
 from __future__ import annotations
 
 from arroyo import Topic as ArroyoTopic
-from arroyo.backends.kafka import KafkaPayload, KafkaProducer
+from arroyo.backends.kafka import KafkaPayload, KafkaProducer, build_kafka_configuration
 from sentry_kafka_schemas.codecs import Codec
 from sentry_kafka_schemas.schema_types.monitors_clock_tasks_v1 import MonitorsClockTasks
 
 from sentry.conf.types.kafka_definition import Topic, get_topic_codec
 from sentry.utils.arroyo_producer import SingletonProducer, get_arroyo_producer
-from sentry.utils.kafka_config import get_topic_definition
+from sentry.utils.kafka_config import get_kafka_producer_cluster_options, get_topic_definition
 
 MONITORS_CLOCK_TASKS_CODEC: Codec[MonitorsClockTasks] = get_topic_codec(Topic.MONITORS_CLOCK_TASKS)
 
 
 def _get_producer() -> KafkaProducer:
-    return get_arroyo_producer(
+    producer = get_arroyo_producer(
         name="sentry.monitors.clock_tasks.producer",
         topic=Topic.MONITORS_CLOCK_TASKS,
         exclude_config_keys=["compression.type", "message.max.bytes"],
     )
+
+    # Fallback to legacy producer creation if not rolled out
+    if producer is None:
+        cluster_name = get_topic_definition(Topic.MONITORS_CLOCK_TASKS)["cluster"]
+        producer_config = get_kafka_producer_cluster_options(cluster_name)
+        producer_config.pop("compression.type", None)
+        producer_config.pop("message.max.bytes", None)
+        producer_config["client.id"] = "sentry.monitors.clock_tasks.producer"
+        producer = KafkaProducer(build_kafka_configuration(default_config=producer_config))
+
+    return producer
 
 
 _clock_task_producer = SingletonProducer(_get_producer)

--- a/src/sentry/monitors/clock_tasks/producer.py
+++ b/src/sentry/monitors/clock_tasks/producer.py
@@ -1,24 +1,23 @@
 from __future__ import annotations
 
 from arroyo import Topic as ArroyoTopic
-from arroyo.backends.kafka import KafkaPayload, KafkaProducer, build_kafka_configuration
+from arroyo.backends.kafka import KafkaPayload
 from sentry_kafka_schemas.codecs import Codec
 from sentry_kafka_schemas.schema_types.monitors_clock_tasks_v1 import MonitorsClockTasks
 
 from sentry.conf.types.kafka_definition import Topic, get_topic_codec
-from sentry.utils.arroyo_producer import SingletonProducer
-from sentry.utils.kafka_config import get_kafka_producer_cluster_options, get_topic_definition
+from sentry.utils.arroyo_producer import SingletonProducer, get_arroyo_producer
+from sentry.utils.kafka_config import get_topic_definition
 
 MONITORS_CLOCK_TASKS_CODEC: Codec[MonitorsClockTasks] = get_topic_codec(Topic.MONITORS_CLOCK_TASKS)
 
 
-def _get_producer() -> KafkaProducer:
-    cluster_name = get_topic_definition(Topic.MONITORS_CLOCK_TASKS)["cluster"]
-    producer_config = get_kafka_producer_cluster_options(cluster_name)
-    producer_config.pop("compression.type", None)
-    producer_config.pop("message.max.bytes", None)
-    producer_config["client.id"] = "sentry.monitors.clock_tasks.producer"
-    return KafkaProducer(build_kafka_configuration(default_config=producer_config))
+def _get_producer():
+    return get_arroyo_producer(
+        name="sentry.monitors.clock_tasks.producer",
+        topic=Topic.MONITORS_CLOCK_TASKS,
+        exclude_config_keys=["compression.type", "message.max.bytes"],
+    )
 
 
 _clock_task_producer = SingletonProducer(_get_producer)

--- a/src/sentry/monitors/logic/incident_occurrence.py
+++ b/src/sentry/monitors/logic/incident_occurrence.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
 from arroyo import Topic as ArroyoTopic
-from arroyo.backends.kafka import KafkaPayload, KafkaProducer, build_kafka_configuration
+from arroyo.backends.kafka import KafkaPayload
 from django.utils.text import get_text_list
 from django.utils.translation import gettext_lazy as _
 from sentry_kafka_schemas.codecs import Codec
@@ -28,7 +28,7 @@ from sentry.monitors.models import (
     MonitorIncident,
 )
 from sentry.monitors.utils import get_detector_for_monitor
-from sentry.utils.arroyo_producer import SingletonProducer
+from sentry.utils.arroyo_producer import SingletonProducer, get_arroyo_producer
 from sentry.utils.kafka_config import get_kafka_producer_cluster_options, get_topic_definition
 
 if TYPE_CHECKING:
@@ -41,13 +41,12 @@ MONITORS_INCIDENT_OCCURRENCES: Codec[IncidentOccurrence] = get_topic_codec(
 )
 
 
-def _get_producer() -> KafkaProducer:
-    cluster_name = get_topic_definition(Topic.MONITORS_INCIDENT_OCCURRENCES)["cluster"]
-    producer_config = get_kafka_producer_cluster_options(cluster_name)
-    producer_config.pop("compression.type", None)
-    producer_config.pop("message.max.bytes", None)
-    producer_config["client.id"] = "sentry.monitors.logic.incident_occurrence"
-    return KafkaProducer(build_kafka_configuration(default_config=producer_config))
+def _get_producer():
+    return get_arroyo_producer(
+        name="sentry.monitors.logic.incident_occurrence",
+        topic=Topic.MONITORS_INCIDENT_OCCURRENCES,
+        exclude_config_keys=["compression.type", "message.max.bytes"],
+    )
 
 
 _incident_occurrence_producer = SingletonProducer(_get_producer)

--- a/src/sentry/monitors/tasks/clock_pulse.py
+++ b/src/sentry/monitors/tasks/clock_pulse.py
@@ -7,7 +7,7 @@ from functools import lru_cache
 
 from arroyo import Partition
 from arroyo import Topic as ArroyoTopic
-from arroyo.backends.kafka import KafkaPayload, KafkaProducer, build_kafka_configuration
+from arroyo.backends.kafka import KafkaPayload
 from confluent_kafka.admin import AdminClient, PartitionMetadata
 from django.conf import settings
 from sentry_kafka_schemas.codecs import Codec
@@ -19,25 +19,20 @@ from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.config import TaskworkerConfig
 from sentry.taskworker.namespaces import crons_tasks
-from sentry.utils.arroyo_producer import SingletonProducer
-from sentry.utils.kafka_config import (
-    get_kafka_admin_cluster_options,
-    get_kafka_producer_cluster_options,
-    get_topic_definition,
-)
+from sentry.utils.arroyo_producer import SingletonProducer, get_arroyo_producer
+from sentry.utils.kafka_config import get_kafka_admin_cluster_options, get_topic_definition
 
 logger = logging.getLogger("sentry")
 
 MONITOR_CODEC: Codec[IngestMonitorMessage] = get_topic_codec(Topic.INGEST_MONITORS)
 
 
-def _get_producer() -> KafkaProducer:
-    cluster_name = get_topic_definition(Topic.INGEST_MONITORS)["cluster"]
-    producer_config = get_kafka_producer_cluster_options(cluster_name)
-    producer_config.pop("compression.type", None)
-    producer_config.pop("message.max.bytes", None)
-    producer_config["client.id"] = "sentry.monitors.tasks.clock_pulse"
-    return KafkaProducer(build_kafka_configuration(default_config=producer_config))
+def _get_producer():
+    return get_arroyo_producer(
+        name="sentry.monitors.tasks.clock_pulse",
+        topic=Topic.INGEST_MONITORS,
+        exclude_config_keys=["compression.type", "message.max.bytes"],
+    )
 
 
 _checkin_producer = SingletonProducer(_get_producer)

--- a/src/sentry/monitors/tasks/clock_pulse.py
+++ b/src/sentry/monitors/tasks/clock_pulse.py
@@ -7,7 +7,7 @@ from functools import lru_cache
 
 from arroyo import Partition
 from arroyo import Topic as ArroyoTopic
-from arroyo.backends.kafka import KafkaPayload
+from arroyo.backends.kafka import KafkaPayload, KafkaProducer, build_kafka_configuration
 from confluent_kafka.admin import AdminClient, PartitionMetadata
 from django.conf import settings
 from sentry_kafka_schemas.codecs import Codec
@@ -20,7 +20,11 @@ from sentry.tasks.base import instrumented_task
 from sentry.taskworker.config import TaskworkerConfig
 from sentry.taskworker.namespaces import crons_tasks
 from sentry.utils.arroyo_producer import SingletonProducer, get_arroyo_producer
-from sentry.utils.kafka_config import get_kafka_admin_cluster_options, get_topic_definition
+from sentry.utils.kafka_config import (
+    get_kafka_admin_cluster_options,
+    get_kafka_producer_cluster_options,
+    get_topic_definition,
+)
 
 logger = logging.getLogger("sentry")
 
@@ -28,11 +32,22 @@ MONITOR_CODEC: Codec[IngestMonitorMessage] = get_topic_codec(Topic.INGEST_MONITO
 
 
 def _get_producer():
-    return get_arroyo_producer(
+    producer = get_arroyo_producer(
         name="sentry.monitors.tasks.clock_pulse",
         topic=Topic.INGEST_MONITORS,
         exclude_config_keys=["compression.type", "message.max.bytes"],
     )
+
+    # Fallback to legacy producer creation if not rolled out
+    if producer is None:
+        cluster_name = get_topic_definition(Topic.INGEST_MONITORS)["cluster"]
+        producer_config = get_kafka_producer_cluster_options(cluster_name)
+        producer_config.pop("compression.type", None)
+        producer_config.pop("message.max.bytes", None)
+        producer_config["client.id"] = "sentry.monitors.tasks.clock_pulse"
+        producer = KafkaProducer(build_kafka_configuration(default_config=producer_config))
+
+    return producer
 
 
 _checkin_producer = SingletonProducer(_get_producer)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1350,6 +1350,10 @@ register(
 # Write new kafka headers in eventstream
 register("eventstream:kafka-headers", default=True, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
+# Arroyo producer factory rollout configuration
+# Controls the rollout of individual Kafka producers by name
+register("arroyo.producer.factory-rollout", default={}, flags=FLAG_AUTOMATOR_MODIFIABLE)
+
 # Post process forwarder options
 # Gets data from Kafka headers
 register(

--- a/src/sentry/preprod/producer.py
+++ b/src/sentry/preprod/producer.py
@@ -4,25 +4,24 @@ import logging
 from typing import Any
 
 from arroyo import Topic as ArroyoTopic
-from arroyo.backends.kafka import KafkaPayload, KafkaProducer, build_kafka_configuration
+from arroyo.backends.kafka import KafkaPayload, KafkaProducer
 from confluent_kafka import KafkaException
 from django.conf import settings
 
 from sentry.conf.types.kafka_definition import Topic
 from sentry.utils import json
-from sentry.utils.arroyo_producer import SingletonProducer
-from sentry.utils.kafka_config import get_kafka_producer_cluster_options, get_topic_definition
+from sentry.utils.arroyo_producer import SingletonProducer, get_arroyo_producer
+from sentry.utils.kafka_config import get_topic_definition
 
 logger = logging.getLogger(__name__)
 
 
 def _get_preprod_producer() -> KafkaProducer:
-    cluster_name = get_topic_definition(Topic.PREPROD_ARTIFACT_EVENTS)["cluster"]
-    producer_config = get_kafka_producer_cluster_options(cluster_name)
-    producer_config.pop("compression.type", None)
-    producer_config.pop("message.max.bytes", None)
-    producer_config["client.id"] = "sentry.preprod.producer"
-    return KafkaProducer(build_kafka_configuration(default_config=producer_config))
+    return get_arroyo_producer(
+        "sentry.preprod.producer",
+        Topic.PREPROD_ARTIFACT_EVENTS,
+        exclude_config_keys=["compression.type", "message.max.bytes"],
+    )
 
 
 _preprod_producer = SingletonProducer(

--- a/src/sentry/preprod/producer.py
+++ b/src/sentry/preprod/producer.py
@@ -4,24 +4,35 @@ import logging
 from typing import Any
 
 from arroyo import Topic as ArroyoTopic
-from arroyo.backends.kafka import KafkaPayload, KafkaProducer
+from arroyo.backends.kafka import KafkaPayload, KafkaProducer, build_kafka_configuration
 from confluent_kafka import KafkaException
 from django.conf import settings
 
 from sentry.conf.types.kafka_definition import Topic
 from sentry.utils import json
 from sentry.utils.arroyo_producer import SingletonProducer, get_arroyo_producer
-from sentry.utils.kafka_config import get_topic_definition
+from sentry.utils.kafka_config import get_kafka_producer_cluster_options, get_topic_definition
 
 logger = logging.getLogger(__name__)
 
 
 def _get_preprod_producer() -> KafkaProducer:
-    return get_arroyo_producer(
+    producer = get_arroyo_producer(
         "sentry.preprod.producer",
         Topic.PREPROD_ARTIFACT_EVENTS,
         exclude_config_keys=["compression.type", "message.max.bytes"],
     )
+
+    # Fallback to legacy producer creation if not rolled out
+    if producer is None:
+        cluster_name = get_topic_definition(Topic.PREPROD_ARTIFACT_EVENTS)["cluster"]
+        producer_config = get_kafka_producer_cluster_options(cluster_name)
+        producer_config.pop("compression.type", None)
+        producer_config.pop("message.max.bytes", None)
+        producer_config["client.id"] = "sentry.preprod.producer"
+        producer = KafkaProducer(build_kafka_configuration(default_config=producer_config))
+
+    return producer
 
 
 _preprod_producer = SingletonProducer(

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -15,7 +15,7 @@ import msgpack
 import sentry_sdk
 import vroomrs
 from arroyo import Topic as ArroyoTopic
-from arroyo.backends.kafka import KafkaPayload
+from arroyo.backends.kafka import KafkaPayload, KafkaProducer
 from django.conf import settings
 from packaging.version import InvalidVersion
 from packaging.version import parse as parse_version
@@ -75,7 +75,7 @@ UI_PROFILE_PLATFORMS = {"cocoa", "android", "javascript"}
 UNSAMPLED_PROFILE_ID = "00000000000000000000000000000000"
 
 
-def _get_profiles_producer_from_topic(topic: Topic):
+def _get_profiles_producer_from_topic(topic: Topic) -> KafkaProducer:
     return get_arroyo_producer(
         name="sentry.profiles.task",
         topic=topic,

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -15,7 +15,7 @@ import msgpack
 import sentry_sdk
 import vroomrs
 from arroyo import Topic as ArroyoTopic
-from arroyo.backends.kafka import KafkaPayload, KafkaProducer
+from arroyo.backends.kafka import KafkaPayload, KafkaProducer, build_kafka_configuration
 from django.conf import settings
 from packaging.version import InvalidVersion
 from packaging.version import parse as parse_version
@@ -59,7 +59,7 @@ from sentry.taskworker.namespaces import ingest_profiling_tasks
 from sentry.taskworker.retry import Retry
 from sentry.utils import json, metrics
 from sentry.utils.arroyo_producer import SingletonProducer, get_arroyo_producer
-from sentry.utils.kafka_config import get_topic_definition
+from sentry.utils.kafka_config import get_kafka_producer_cluster_options, get_topic_definition
 from sentry.utils.locking import UnableToAcquireLock
 from sentry.utils.outcomes import Outcome, track_outcome
 from sentry.utils.projectflags import set_project_flag_and_signal
@@ -76,11 +76,22 @@ UNSAMPLED_PROFILE_ID = "00000000000000000000000000000000"
 
 
 def _get_profiles_producer_from_topic(topic: Topic) -> KafkaProducer:
-    return get_arroyo_producer(
+    producer = get_arroyo_producer(
         name="sentry.profiles.task",
         topic=topic,
         exclude_config_keys=["compression.type", "message.max.bytes"],
     )
+
+    # Fallback to legacy producer creation if not rolled out
+    if producer is None:
+        cluster_name = get_topic_definition(topic)["cluster"]
+        producer_config = get_kafka_producer_cluster_options(cluster_name)
+        producer_config.pop("compression.type", None)
+        producer_config.pop("message.max.bytes", None)
+        producer_config["client.id"] = "sentry.profiles.task"
+        producer = KafkaProducer(build_kafka_configuration(default_config=producer_config))
+
+    return producer
 
 
 processed_profiles_producer = SingletonProducer(

--- a/src/sentry/replays/lib/kafka.py
+++ b/src/sentry/replays/lib/kafka.py
@@ -1,4 +1,4 @@
-from arroyo.backends.kafka import KafkaPayload
+from arroyo.backends.kafka import KafkaPayload, KafkaProducer, build_kafka_configuration
 from arroyo.types import Topic as ArroyoTopic
 from sentry_kafka_schemas.codecs import Codec
 from sentry_protos.snuba.v1.trace_item_pb2 import TraceItem
@@ -18,10 +18,19 @@ EAP_ITEMS_CODEC: Codec[TraceItem] = get_topic_codec(Topic.SNUBA_ITEMS)
 
 def _get_eap_items_producer():
     """Get a Kafka producer for EAP TraceItems."""
-    return get_arroyo_producer(
+    producer = get_arroyo_producer(
         name="sentry.replays.lib.kafka.eap_items",
         topic=Topic.SNUBA_ITEMS,
     )
+
+    # Fallback to legacy producer creation if not rolled out
+    if producer is None:
+        cluster_name = get_topic_definition(Topic.SNUBA_ITEMS)["cluster"]
+        producer_config = get_kafka_producer_cluster_options(cluster_name)
+        producer_config["client.id"] = "sentry.replays.lib.kafka.eap_items"
+        producer = KafkaProducer(build_kafka_configuration(default_config=producer_config))
+
+    return producer
 
 
 eap_producer = SingletonProducer(_get_eap_items_producer)
@@ -33,10 +42,19 @@ eap_producer = SingletonProducer(_get_eap_items_producer)
 
 
 def _get_ingest_replay_events_producer():
-    return get_arroyo_producer(
+    producer = get_arroyo_producer(
         name="sentry.replays.lib.kafka.ingest_replay_events",
         topic=Topic.INGEST_REPLAY_EVENTS,
     )
+
+    # Fallback to legacy producer creation if not rolled out
+    if producer is None:
+        config = get_topic_definition(Topic.INGEST_REPLAY_EVENTS)
+        producer_config = get_kafka_producer_cluster_options(config["cluster"])
+        producer_config["client.id"] = "sentry.replays.lib.kafka.ingest_replay_events"
+        producer = KafkaProducer(build_kafka_configuration(default_config=producer_config))
+
+    return producer
 
 
 ingest_replay_events_producer = SingletonProducer(_get_ingest_replay_events_producer)

--- a/src/sentry/replays/lib/kafka.py
+++ b/src/sentry/replays/lib/kafka.py
@@ -1,10 +1,10 @@
-from arroyo.backends.kafka import KafkaPayload, KafkaProducer, build_kafka_configuration
+from arroyo.backends.kafka import KafkaPayload
 from arroyo.types import Topic as ArroyoTopic
 from sentry_kafka_schemas.codecs import Codec
 from sentry_protos.snuba.v1.trace_item_pb2 import TraceItem
 
 from sentry.conf.types.kafka_definition import Topic, get_topic_codec
-from sentry.utils.arroyo_producer import SingletonProducer
+from sentry.utils.arroyo_producer import SingletonProducer, get_arroyo_producer
 from sentry.utils.kafka_config import get_kafka_producer_cluster_options, get_topic_definition
 from sentry.utils.pubsub import KafkaPublisher
 
@@ -16,12 +16,12 @@ from sentry.utils.pubsub import KafkaPublisher
 EAP_ITEMS_CODEC: Codec[TraceItem] = get_topic_codec(Topic.SNUBA_ITEMS)
 
 
-def _get_eap_items_producer() -> KafkaProducer:
+def _get_eap_items_producer():
     """Get a Kafka producer for EAP TraceItems."""
-    cluster_name = get_topic_definition(Topic.SNUBA_ITEMS)["cluster"]
-    producer_config = get_kafka_producer_cluster_options(cluster_name)
-    producer_config["client.id"] = "sentry.replays.lib.kafka.eap_items"
-    return KafkaProducer(build_kafka_configuration(default_config=producer_config))
+    return get_arroyo_producer(
+        name="sentry.replays.lib.kafka.eap_items",
+        topic=Topic.SNUBA_ITEMS,
+    )
 
 
 eap_producer = SingletonProducer(_get_eap_items_producer)
@@ -32,11 +32,11 @@ eap_producer = SingletonProducer(_get_eap_items_producer)
 #
 
 
-def _get_ingest_replay_events_producer() -> KafkaProducer:
-    config = get_topic_definition(Topic.INGEST_REPLAY_EVENTS)
-    producer_config = get_kafka_producer_cluster_options(config["cluster"])
-    producer_config["client.id"] = "sentry.replays.lib.kafka.ingest_replay_events"
-    return KafkaProducer(build_kafka_configuration(default_config=producer_config))
+def _get_ingest_replay_events_producer():
+    return get_arroyo_producer(
+        name="sentry.replays.lib.kafka.ingest_replay_events",
+        topic=Topic.INGEST_REPLAY_EVENTS,
+    )
 
 
 ingest_replay_events_producer = SingletonProducer(_get_ingest_replay_events_producer)

--- a/src/sentry/sentry_metrics/client/kafka.py
+++ b/src/sentry/sentry_metrics/client/kafka.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 from arroyo import Topic as ArroyoTopic
 from arroyo.backends.abstract import Producer
-from arroyo.backends.kafka import KafkaPayload, KafkaProducer, build_kafka_configuration
+from arroyo.backends.kafka import KafkaPayload
 from django.core.cache import cache
 from sentry_kafka_schemas.codecs import Codec
 from sentry_kafka_schemas.schema_types.ingest_metrics_v1 import IngestMetric
@@ -14,7 +14,8 @@ from sentry.conf.types.kafka_definition import Topic, get_topic_codec
 from sentry.sentry_metrics.client.base import GenericMetricsBackend
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 from sentry.utils import json
-from sentry.utils.kafka_config import get_kafka_producer_cluster_options, get_topic_definition
+from sentry.utils.arroyo_producer import get_arroyo_producer
+from sentry.utils.kafka_config import get_topic_definition
 
 INGEST_CODEC: Codec[IngestMetric] = get_topic_codec(Topic.INGEST_METRICS)
 
@@ -50,11 +51,9 @@ class KafkaMetricsBackend(GenericMetricsBackend):
         logical_topic = Topic.INGEST_PERFORMANCE_METRICS
         topic_defn = get_topic_definition(logical_topic)
         self.kafka_topic = ArroyoTopic(topic_defn["real_topic_name"])
-        cluster_name = topic_defn["cluster"]
-        producer_config = get_kafka_producer_cluster_options(cluster_name)
-        producer_config["client.id"] = "sentry.sentry_metrics.client.kafka"
-        self.producer: Producer = KafkaProducer(
-            build_kafka_configuration(default_config=producer_config)
+        self.producer: Producer = get_arroyo_producer(
+            name="sentry.sentry_metrics.client.kafka",
+            topic=logical_topic,
         )
 
     def counter(

--- a/src/sentry/sentry_metrics/client/kafka.py
+++ b/src/sentry/sentry_metrics/client/kafka.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 from arroyo import Topic as ArroyoTopic
 from arroyo.backends.abstract import Producer
-from arroyo.backends.kafka import KafkaPayload
+from arroyo.backends.kafka import KafkaPayload, KafkaProducer, build_kafka_configuration
 from django.core.cache import cache
 from sentry_kafka_schemas.codecs import Codec
 from sentry_kafka_schemas.schema_types.ingest_metrics_v1 import IngestMetric
@@ -15,7 +15,7 @@ from sentry.sentry_metrics.client.base import GenericMetricsBackend
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 from sentry.utils import json
 from sentry.utils.arroyo_producer import get_arroyo_producer
-from sentry.utils.kafka_config import get_topic_definition
+from sentry.utils.kafka_config import get_kafka_producer_cluster_options, get_topic_definition
 
 INGEST_CODEC: Codec[IngestMetric] = get_topic_codec(Topic.INGEST_METRICS)
 
@@ -51,10 +51,20 @@ class KafkaMetricsBackend(GenericMetricsBackend):
         logical_topic = Topic.INGEST_PERFORMANCE_METRICS
         topic_defn = get_topic_definition(logical_topic)
         self.kafka_topic = ArroyoTopic(topic_defn["real_topic_name"])
-        self.producer: Producer = get_arroyo_producer(
+
+        producer = get_arroyo_producer(
             name="sentry.sentry_metrics.client.kafka",
             topic=logical_topic,
         )
+
+        # Fallback to legacy producer creation if not rolled out
+        if producer is None:
+            cluster_name = topic_defn["cluster"]
+            producer_config = get_kafka_producer_cluster_options(cluster_name)
+            producer_config["client.id"] = "sentry.sentry_metrics.client.kafka"
+            producer = KafkaProducer(build_kafka_configuration(default_config=producer_config))
+
+        self.producer: Producer = producer
 
     def counter(
         self,

--- a/src/sentry/spans/consumers/process/flusher.py
+++ b/src/sentry/spans/consumers/process/flusher.py
@@ -10,7 +10,7 @@ import orjson
 import sentry_sdk
 from arroyo import Topic as ArroyoTopic
 from arroyo.backends.abstract import Producer
-from arroyo.backends.kafka import KafkaPayload, KafkaProducer, build_kafka_producer_configuration
+from arroyo.backends.kafka import KafkaPayload, KafkaProducer
 from arroyo.processing.strategies.abstract import MessageRejected, ProcessingStrategy
 from arroyo.types import FilteredPayload, Message
 from django.conf import settings
@@ -21,7 +21,11 @@ from sentry.processing.backpressure.memory import ServiceMemory
 from sentry.spans.buffer import SpansBuffer
 from sentry.utils import metrics
 from sentry.utils.arroyo import run_with_initialized_sentry
-from sentry.utils.kafka_config import get_kafka_producer_cluster_options, get_topic_definition
+from sentry.utils.kafka_config import (
+    build_kafka_producer_configuration,
+    get_kafka_producer_cluster_options,
+    get_topic_definition,
+)
 
 MAX_PROCESS_RESTARTS = 10
 
@@ -80,10 +84,10 @@ class MultiProducer:
                 self.topics.append(topic)
         else:
             # Single producer (backward compatibility)
-            cluster_name = get_topic_definition(self.topic)["cluster"]
-            producer_config = get_kafka_producer_cluster_options(cluster_name)
+            topic_def = get_topic_definition(self.topic)
+            producer_config = get_kafka_producer_cluster_options(topic_def["cluster"])
             producer = self.producer_factory(producer_config)
-            topic = ArroyoTopic(get_topic_definition(self.topic)["real_topic_name"])
+            topic = ArroyoTopic(topic_def["real_topic_name"])
 
             self.producers.append(producer)
             self.topics.append(topic)

--- a/src/sentry/spans/consumers/process/flusher.py
+++ b/src/sentry/spans/consumers/process/flusher.py
@@ -10,7 +10,7 @@ import orjson
 import sentry_sdk
 from arroyo import Topic as ArroyoTopic
 from arroyo.backends.abstract import Producer
-from arroyo.backends.kafka import KafkaPayload, KafkaProducer
+from arroyo.backends.kafka import KafkaPayload, KafkaProducer, build_kafka_producer_configuration
 from arroyo.processing.strategies.abstract import MessageRejected, ProcessingStrategy
 from arroyo.types import FilteredPayload, Message
 from django.conf import settings
@@ -21,11 +21,7 @@ from sentry.processing.backpressure.memory import ServiceMemory
 from sentry.spans.buffer import SpansBuffer
 from sentry.utils import metrics
 from sentry.utils.arroyo import run_with_initialized_sentry
-from sentry.utils.kafka_config import (
-    build_kafka_producer_configuration,
-    get_kafka_producer_cluster_options,
-    get_topic_definition,
-)
+from sentry.utils.kafka_config import get_kafka_producer_cluster_options, get_topic_definition
 
 MAX_PROCESS_RESTARTS = 10
 
@@ -84,10 +80,10 @@ class MultiProducer:
                 self.topics.append(topic)
         else:
             # Single producer (backward compatibility)
-            topic_def = get_topic_definition(self.topic)
-            producer_config = get_kafka_producer_cluster_options(topic_def["cluster"])
+            cluster_name = get_topic_definition(self.topic)["cluster"]
+            producer_config = get_kafka_producer_cluster_options(cluster_name)
             producer = self.producer_factory(producer_config)
-            topic = ArroyoTopic(topic_def["real_topic_name"])
+            topic = ArroyoTopic(get_topic_definition(self.topic)["real_topic_name"])
 
             self.producers.append(producer)
             self.topics.append(topic)

--- a/src/sentry/spans/consumers/process_segments/factory.py
+++ b/src/sentry/spans/consumers/process_segments/factory.py
@@ -5,7 +5,6 @@ from functools import partial
 
 import orjson
 from arroyo import Topic as ArroyoTopic
-from arroyo.backends.kafka import KafkaProducer, build_kafka_producer_configuration
 from arroyo.backends.kafka.consumer import KafkaPayload
 from arroyo.dlq import InvalidMessage
 from arroyo.processing.strategies.abstract import ProcessingStrategy, ProcessingStrategyFactory
@@ -20,7 +19,8 @@ from sentry.spans.consumers.process_segments.convert import convert_span_to_item
 from sentry.spans.consumers.process_segments.enrichment import Span
 from sentry.spans.consumers.process_segments.message import process_segment
 from sentry.utils.arroyo import MultiprocessingPool, run_task_with_multiprocessing
-from sentry.utils.kafka_config import get_kafka_producer_cluster_options, get_topic_definition
+from sentry.utils.arroyo_producer import get_arroyo_producer
+from sentry.utils.kafka_config import get_topic_definition
 
 logger = logging.getLogger(__name__)
 
@@ -53,7 +53,6 @@ class DetectPerformanceIssuesStrategyFactory(ProcessingStrategyFactory[KafkaPayl
         self.pool = MultiprocessingPool(num_processes)
 
         topic_definition = get_topic_definition(Topic.SNUBA_ITEMS)
-        producer_config = get_kafka_producer_cluster_options(topic_definition["cluster"])
 
         # Due to the unfold step that precedes the producer, this pipeline
         # writes large bursts of spans at once when a batch of segments is
@@ -61,11 +60,11 @@ class DetectPerformanceIssuesStrategyFactory(ProcessingStrategyFactory[KafkaPayl
         # so that it can accommodate batches from all subprocesses at the
         # sime time, assuming some upper bound of spans per segment.
         self.kafka_queue_size = self.max_batch_size * self.num_processes * SPANS_PER_SEG_P95
-        producer_config["queue.buffering.max.messages"] = self.kafka_queue_size
-        producer_config["client.id"] = "sentry.spans.consumers.process_segments"
 
-        self.producer = KafkaProducer(
-            build_kafka_producer_configuration(default_config=producer_config),
+        self.producer = get_arroyo_producer(
+            "sentry.spans.consumers.process_segments",
+            Topic.SNUBA_ITEMS,
+            additional_config={"queue.buffering.max.messages": self.kafka_queue_size},
             use_simple_futures=True,
         )
         self.output_topic = ArroyoTopic(topic_definition["real_topic_name"])

--- a/src/sentry/spans/consumers/process_segments/factory.py
+++ b/src/sentry/spans/consumers/process_segments/factory.py
@@ -5,6 +5,7 @@ from functools import partial
 
 import orjson
 from arroyo import Topic as ArroyoTopic
+from arroyo.backends.kafka import KafkaProducer, build_kafka_producer_configuration
 from arroyo.backends.kafka.consumer import KafkaPayload
 from arroyo.dlq import InvalidMessage
 from arroyo.processing.strategies.abstract import ProcessingStrategy, ProcessingStrategyFactory
@@ -20,7 +21,7 @@ from sentry.spans.consumers.process_segments.enrichment import Span
 from sentry.spans.consumers.process_segments.message import process_segment
 from sentry.utils.arroyo import MultiprocessingPool, run_task_with_multiprocessing
 from sentry.utils.arroyo_producer import get_arroyo_producer
-from sentry.utils.kafka_config import get_topic_definition
+from sentry.utils.kafka_config import get_kafka_producer_cluster_options, get_topic_definition
 
 logger = logging.getLogger(__name__)
 
@@ -61,12 +62,24 @@ class DetectPerformanceIssuesStrategyFactory(ProcessingStrategyFactory[KafkaPayl
         # sime time, assuming some upper bound of spans per segment.
         self.kafka_queue_size = self.max_batch_size * self.num_processes * SPANS_PER_SEG_P95
 
-        self.producer = get_arroyo_producer(
+        producer = get_arroyo_producer(
             "sentry.spans.consumers.process_segments",
             Topic.SNUBA_ITEMS,
             additional_config={"queue.buffering.max.messages": self.kafka_queue_size},
             use_simple_futures=True,
         )
+
+        # Fallback to legacy producer creation if not rolled out
+        if producer is None:
+            producer_config = get_kafka_producer_cluster_options(topic_definition["cluster"])
+            producer_config["queue.buffering.max.messages"] = self.kafka_queue_size
+            producer_config["client.id"] = "sentry.spans.consumers.process_segments"
+            producer = KafkaProducer(
+                build_kafka_producer_configuration(default_config=producer_config),
+                use_simple_futures=True,
+            )
+
+        self.producer = producer
         self.output_topic = ArroyoTopic(topic_definition["real_topic_name"])
 
     def create_with_partitions(

--- a/src/sentry/taskworker/registry.py
+++ b/src/sentry/taskworker/registry.py
@@ -20,9 +20,8 @@ from sentry.taskworker.retry import Retry
 from sentry.taskworker.router import TaskRouter
 from sentry.taskworker.task import P, R, Task
 from sentry.utils import metrics
-from sentry.utils.arroyo_producer import SingletonProducer
+from sentry.utils.arroyo_producer import SingletonProducer, get_arroyo_producer
 from sentry.utils.imports import import_string
-from sentry.utils.kafka_config import get_kafka_producer_cluster_options, get_topic_definition
 
 logger = logging.getLogger(__name__)
 
@@ -193,9 +192,7 @@ class TaskNamespace:
         if topic not in self._producers:
 
             def factory() -> KafkaProducer:
-                cluster_name = get_topic_definition(topic)["cluster"]
-                producer_config = get_kafka_producer_cluster_options(cluster_name)
-                return KafkaProducer(producer_config)
+                return get_arroyo_producer(f"sentry.taskworker.{topic.value}", topic)
 
             self._producers[topic] = SingletonProducer(factory, max_futures=1000)
         return self._producers[topic]

--- a/src/sentry/uptime/consumers/eap_producer.py
+++ b/src/sentry/uptime/consumers/eap_producer.py
@@ -1,7 +1,7 @@
 import logging
 
 from arroyo import Topic as ArroyoTopic
-from arroyo.backends.kafka import KafkaPayload, KafkaProducer, build_kafka_configuration
+from arroyo.backends.kafka import KafkaPayload, KafkaProducer
 from sentry_kafka_schemas.codecs import Codec
 from sentry_kafka_schemas.schema_types.uptime_results_v1 import CheckResult
 from sentry_protos.snuba.v1.trace_item_pb2 import TraceItem
@@ -12,8 +12,8 @@ from sentry.uptime.consumers.eap_converter import convert_uptime_result_to_trace
 from sentry.uptime.models import UptimeStatus, UptimeSubscription
 from sentry.uptime.types import IncidentStatus
 from sentry.utils import metrics
-from sentry.utils.arroyo_producer import SingletonProducer
-from sentry.utils.kafka_config import get_kafka_producer_cluster_options, get_topic_definition
+from sentry.utils.arroyo_producer import SingletonProducer, get_arroyo_producer
+from sentry.utils.kafka_config import get_topic_definition
 
 logger = logging.getLogger(__name__)
 
@@ -22,12 +22,11 @@ EAP_ITEMS_CODEC: Codec[TraceItem] = get_topic_codec(Topic.SNUBA_ITEMS)
 
 def _get_eap_items_producer() -> KafkaProducer:
     """Get a Kafka producer for EAP TraceItems."""
-    cluster_name = get_topic_definition(Topic.SNUBA_ITEMS)["cluster"]
-    producer_config = get_kafka_producer_cluster_options(cluster_name)
-    producer_config.pop("compression.type", None)
-    producer_config.pop("message.max.bytes", None)
-    producer_config["client.id"] = "sentry.uptime.consumers.eap_producer"
-    return KafkaProducer(build_kafka_configuration(default_config=producer_config))
+    return get_arroyo_producer(
+        "sentry.uptime.consumers.eap_producer",
+        Topic.SNUBA_ITEMS,
+        exclude_config_keys=["compression.type", "message.max.bytes"],
+    )
 
 
 _eap_items_producer = SingletonProducer(_get_eap_items_producer)

--- a/src/sentry/uptime/consumers/eap_producer.py
+++ b/src/sentry/uptime/consumers/eap_producer.py
@@ -1,7 +1,7 @@
 import logging
 
 from arroyo import Topic as ArroyoTopic
-from arroyo.backends.kafka import KafkaPayload, KafkaProducer
+from arroyo.backends.kafka import KafkaPayload, KafkaProducer, build_kafka_configuration
 from sentry_kafka_schemas.codecs import Codec
 from sentry_kafka_schemas.schema_types.uptime_results_v1 import CheckResult
 from sentry_protos.snuba.v1.trace_item_pb2 import TraceItem
@@ -13,7 +13,7 @@ from sentry.uptime.models import UptimeStatus, UptimeSubscription
 from sentry.uptime.types import IncidentStatus
 from sentry.utils import metrics
 from sentry.utils.arroyo_producer import SingletonProducer, get_arroyo_producer
-from sentry.utils.kafka_config import get_topic_definition
+from sentry.utils.kafka_config import get_kafka_producer_cluster_options, get_topic_definition
 
 logger = logging.getLogger(__name__)
 
@@ -22,11 +22,22 @@ EAP_ITEMS_CODEC: Codec[TraceItem] = get_topic_codec(Topic.SNUBA_ITEMS)
 
 def _get_eap_items_producer() -> KafkaProducer:
     """Get a Kafka producer for EAP TraceItems."""
-    return get_arroyo_producer(
+    producer = get_arroyo_producer(
         "sentry.uptime.consumers.eap_producer",
         Topic.SNUBA_ITEMS,
         exclude_config_keys=["compression.type", "message.max.bytes"],
     )
+
+    # Fallback to legacy producer creation if not rolled out
+    if producer is None:
+        cluster_name = get_topic_definition(Topic.SNUBA_ITEMS)["cluster"]
+        producer_config = get_kafka_producer_cluster_options(cluster_name)
+        producer_config.pop("compression.type", None)
+        producer_config.pop("message.max.bytes", None)
+        producer_config["client.id"] = "sentry.uptime.consumers.eap_producer"
+        producer = KafkaProducer(build_kafka_configuration(default_config=producer_config))
+
+    return producer
 
 
 _eap_items_producer = SingletonProducer(_get_eap_items_producer)

--- a/src/sentry/uptime/consumers/results_consumer.py
+++ b/src/sentry/uptime/consumers/results_consumer.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta, timezone
 from uuid import UUID
 
 from arroyo import Topic as ArroyoTopic
-from arroyo.backends.kafka import KafkaPayload, KafkaProducer
+from arroyo.backends.kafka import KafkaPayload, KafkaProducer, build_kafka_configuration
 from sentry_kafka_schemas.codecs import Codec
 from sentry_kafka_schemas.schema_types.snuba_uptime_results_v1 import SnubaUptimeResult
 from sentry_kafka_schemas.schema_types.uptime_results_v1 import (
@@ -44,7 +44,7 @@ from sentry.uptime.subscriptions.tasks import (
 from sentry.uptime.types import IncidentStatus, UptimeMonitorMode
 from sentry.utils import metrics
 from sentry.utils.arroyo_producer import SingletonProducer, get_arroyo_producer
-from sentry.utils.kafka_config import get_topic_definition
+from sentry.utils.kafka_config import get_kafka_producer_cluster_options, get_topic_definition
 from sentry.workflow_engine.models.data_source import DataPacket
 from sentry.workflow_engine.models.detector import Detector
 from sentry.workflow_engine.processors.detector import process_detectors
@@ -67,11 +67,22 @@ TOTAL_PROVIDERS_TO_INCLUDE_AS_TAGS = 30
 
 
 def _get_snuba_uptime_checks_producer() -> KafkaProducer:
-    return get_arroyo_producer(
+    producer = get_arroyo_producer(
         "sentry.uptime.consumers.results_consumer",
         Topic.SNUBA_UPTIME_RESULTS,
         exclude_config_keys=["compression.type", "message.max.bytes"],
     )
+
+    # Fallback to legacy producer creation if not rolled out
+    if producer is None:
+        cluster_name = get_topic_definition(Topic.SNUBA_UPTIME_RESULTS)["cluster"]
+        producer_config = get_kafka_producer_cluster_options(cluster_name)
+        producer_config.pop("compression.type", None)
+        producer_config.pop("message.max.bytes", None)
+        producer_config["client.id"] = "sentry.uptime.consumers.results_consumer"
+        producer = KafkaProducer(build_kafka_configuration(default_config=producer_config))
+
+    return producer
 
 
 _snuba_uptime_checks_producer = SingletonProducer(_get_snuba_uptime_checks_producer)

--- a/src/sentry/uptime/consumers/results_consumer.py
+++ b/src/sentry/uptime/consumers/results_consumer.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta, timezone
 from uuid import UUID
 
 from arroyo import Topic as ArroyoTopic
-from arroyo.backends.kafka import KafkaPayload, KafkaProducer, build_kafka_configuration
+from arroyo.backends.kafka import KafkaPayload, KafkaProducer
 from sentry_kafka_schemas.codecs import Codec
 from sentry_kafka_schemas.schema_types.snuba_uptime_results_v1 import SnubaUptimeResult
 from sentry_kafka_schemas.schema_types.uptime_results_v1 import (
@@ -43,8 +43,8 @@ from sentry.uptime.subscriptions.tasks import (
 )
 from sentry.uptime.types import IncidentStatus, UptimeMonitorMode
 from sentry.utils import metrics
-from sentry.utils.arroyo_producer import SingletonProducer
-from sentry.utils.kafka_config import get_kafka_producer_cluster_options, get_topic_definition
+from sentry.utils.arroyo_producer import SingletonProducer, get_arroyo_producer
+from sentry.utils.kafka_config import get_topic_definition
 from sentry.workflow_engine.models.data_source import DataPacket
 from sentry.workflow_engine.models.detector import Detector
 from sentry.workflow_engine.processors.detector import process_detectors
@@ -67,12 +67,11 @@ TOTAL_PROVIDERS_TO_INCLUDE_AS_TAGS = 30
 
 
 def _get_snuba_uptime_checks_producer() -> KafkaProducer:
-    cluster_name = get_topic_definition(Topic.SNUBA_UPTIME_RESULTS)["cluster"]
-    producer_config = get_kafka_producer_cluster_options(cluster_name)
-    producer_config.pop("compression.type", None)
-    producer_config.pop("message.max.bytes", None)
-    producer_config["client.id"] = "sentry.uptime.consumers.results_consumer"
-    return KafkaProducer(build_kafka_configuration(default_config=producer_config))
+    return get_arroyo_producer(
+        "sentry.uptime.consumers.results_consumer",
+        Topic.SNUBA_UPTIME_RESULTS,
+        exclude_config_keys=["compression.type", "message.max.bytes"],
+    )
 
 
 _snuba_uptime_checks_producer = SingletonProducer(_get_snuba_uptime_checks_producer)

--- a/src/sentry/usage_accountant/accountant.py
+++ b/src/sentry/usage_accountant/accountant.py
@@ -10,12 +10,11 @@ and the producer needs to be flushed to avoid loosing data.
 import atexit
 import logging
 
-from arroyo.backends.kafka import KafkaProducer, build_kafka_configuration
 from usageaccountant import UsageAccumulator, UsageUnit
 
 from sentry.conf.types.kafka_definition import Topic
 from sentry.options import get
-from sentry.utils.kafka_config import get_kafka_producer_cluster_options, get_topic_definition
+from sentry.utils.arroyo_producer import get_arroyo_producer
 
 logger = logging.getLogger(__name__)
 
@@ -47,16 +46,7 @@ def record(
         return
 
     if _accountant_backend is None:
-        cluster_name = get_topic_definition(
-            Topic.SHARED_RESOURCES_USAGE,
-        )["cluster"]
-        producer_config = get_kafka_producer_cluster_options(cluster_name)
-        producer_config["client.id"] = "sentry.usage_accountant"
-        producer = KafkaProducer(
-            build_kafka_configuration(
-                default_config=producer_config,
-            )
-        )
+        producer = get_arroyo_producer("sentry.usage_accountant", Topic.SHARED_RESOURCES_USAGE)
 
         _accountant_backend = UsageAccumulator(producer=producer)
         atexit.register(_shutdown)

--- a/src/sentry/usage_accountant/accountant.py
+++ b/src/sentry/usage_accountant/accountant.py
@@ -10,11 +10,13 @@ and the producer needs to be flushed to avoid loosing data.
 import atexit
 import logging
 
+from arroyo.backends.kafka import KafkaProducer, build_kafka_configuration
 from usageaccountant import UsageAccumulator, UsageUnit
 
 from sentry.conf.types.kafka_definition import Topic
 from sentry.options import get
 from sentry.utils.arroyo_producer import get_arroyo_producer
+from sentry.utils.kafka_config import get_kafka_producer_cluster_options, get_topic_definition
 
 logger = logging.getLogger(__name__)
 
@@ -47,6 +49,19 @@ def record(
 
     if _accountant_backend is None:
         producer = get_arroyo_producer("sentry.usage_accountant", Topic.SHARED_RESOURCES_USAGE)
+
+        # Fallback to legacy producer creation if not rolled out
+        if producer is None:
+            cluster_name = get_topic_definition(
+                Topic.SHARED_RESOURCES_USAGE,
+            )["cluster"]
+            producer_config = get_kafka_producer_cluster_options(cluster_name)
+            producer_config["client.id"] = "sentry.usage_accountant"
+            producer = KafkaProducer(
+                build_kafka_configuration(
+                    default_config=producer_config,
+                )
+            )
 
         _accountant_backend = UsageAccumulator(producer=producer)
         atexit.register(_shutdown)

--- a/src/sentry/utils/arroyo_producer.py
+++ b/src/sentry/utils/arroyo_producer.py
@@ -6,8 +6,12 @@ from collections.abc import Callable
 from typing import Deque
 
 from arroyo.backends.abstract import ProducerFuture
-from arroyo.backends.kafka import KafkaPayload, KafkaProducer
-from arroyo.types import BrokerValue, Partition, Topic
+from arroyo.backends.kafka import KafkaPayload, KafkaProducer, build_kafka_producer_configuration
+from arroyo.types import BrokerValue, Partition
+from arroyo.types import Topic as ArroyoTopic
+
+from sentry.conf.types.kafka_definition import Topic
+from sentry.utils.kafka_config import get_kafka_producer_cluster_options, get_topic_definition
 
 _ProducerFuture = ProducerFuture[BrokerValue[KafkaPayload]]
 
@@ -29,7 +33,9 @@ class SingletonProducer:
         self._futures: Deque[_ProducerFuture] = deque()
         self.max_futures = max_futures
 
-    def produce(self, destination: Topic | Partition, payload: KafkaPayload) -> _ProducerFuture:
+    def produce(
+        self, destination: ArroyoTopic | Partition, payload: KafkaPayload
+    ) -> _ProducerFuture:
         future = self._get().produce(destination, payload)
         self._track_futures(future)
         return future
@@ -60,3 +66,30 @@ class SingletonProducer:
 
         if self._producer:
             self._producer.close()
+
+
+def get_arroyo_producer(
+    name: str,
+    topic: Topic,
+    additional_config: dict | None = None,
+    exclude_config_keys: list[str] | None = None,
+    **kafka_producer_kwargs,
+) -> KafkaProducer:
+    topic_definition = get_topic_definition(topic)
+
+    producer_config = get_kafka_producer_cluster_options(topic_definition["cluster"])
+
+    # Remove any excluded config keys
+    if exclude_config_keys:
+        for key in exclude_config_keys:
+            producer_config.pop(key, None)
+
+    # Apply additional config
+    if additional_config:
+        producer_config.update(additional_config)
+
+    producer_config["client.id"] = name
+
+    return KafkaProducer(
+        build_kafka_producer_configuration(default_config=producer_config), **kafka_producer_kwargs
+    )

--- a/src/sentry/utils/arroyo_producer.py
+++ b/src/sentry/utils/arroyo_producer.py
@@ -77,21 +77,10 @@ def get_arroyo_producer(
     **kafka_producer_kwargs,
 ) -> KafkaProducer | None:
     """
-    Factory function for creating Arroyo Kafka producers with consistent configuration
-    and metrics tracking.
-
-    This function provides a centralized way to create Kafka producers with:
-    - Automatic cluster configuration based on the topic
-    - Consistent client.id naming for metrics
-    - Support for config customization and exclusion
-    - Feature flag-based rollout control for safe migration
-
-    The rollout is controlled via the "arroyo.producer.factory-rollout" option, which
-    should be a dictionary mapping producer names to booleans indicating rollout status.
-    When disabled, returns None to allow callers to fall back to legacy producer creation.
+    Get an arroyo producer for a given topic.
 
     Args:
-        name: Unique identifier for this producer (used as client.id and for rollout control)
+        name: Unique identifier for this producer (used as client.id, for metrics and killswitches)
         topic: The Kafka topic this producer will write to
         additional_config: Additional Kafka configuration to merge with defaults
         exclude_config_keys: List of config keys to exclude from the default configuration

--- a/tests/sentry/replays/unit/test_event_logger.py
+++ b/tests/sentry/replays/unit/test_event_logger.py
@@ -12,6 +12,7 @@ from sentry.replays.usecases.ingest.event_logger import (
     gen_rage_clicks,
 )
 from sentry.replays.usecases.ingest.event_parser import ClickEvent, ParsedEventMeta
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.thread_leaks.pytest import thread_leak_allowlist
 
 
@@ -42,6 +43,7 @@ def test_gen_rage_clicks() -> None:
 
 
 @thread_leak_allowlist(reason="replays", issue=97033)
+@override_options({"arroyo.producer.factory-rollout": {}})
 def test_emit_click_events_environment_handling() -> None:
     click_events = [
         ClickEvent(
@@ -80,6 +82,7 @@ def test_emit_click_events_environment_handling() -> None:
 
 
 @thread_leak_allowlist(reason="replays", issue=97033)
+@override_options({"arroyo.producer.factory-rollout": {}})
 @mock.patch("arroyo.backends.kafka.consumer.KafkaProducer.produce")
 def test_emit_trace_items_to_eap(producer: mock.MagicMock) -> None:
     timestamp = Timestamp()

--- a/tests/sentry/spans/consumers/process_segments/test_factory.py
+++ b/tests/sentry/spans/consumers/process_segments/test_factory.py
@@ -23,7 +23,9 @@ def build_mock_message(data, topic=None):
     return message
 
 
-@override_options({"spans.process-segments.consumer.enable": True})
+@override_options(
+    {"spans.process-segments.consumer.enable": True, "arroyo.producer.factory-rollout": {}}
+)
 @mock.patch(
     "sentry.spans.consumers.process_segments.factory.process_segment",
     side_effect=lambda x, **kwargs: x,


### PR DESCRIPTION
Producers are currently creating KafkaProducer in inconsistent ways,
meaning that producer metrics are sometimes available and sometimes not.
Fix that by forcing everything through the same factory function.

ref STREAM-324