### PR TITLE
feat(releases): Add a tooltip to Release Details to help users arrive at proper semver release names

### DIFF
--- a/static/app/views/releases/detail/overview/index.tsx
+++ b/static/app/views/releases/detail/overview/index.tsx
@@ -528,7 +528,7 @@ function ReleaseOverview() {
           <ProjectReleaseDetails
             release={release}
             releaseMeta={releaseMeta}
-            projectSlug={project.slug}
+            project={project}
           />
           {commitCount > 0 && (
             <CommitAuthorBreakdown

--- a/static/app/views/releases/detail/overview/sidebar/projectReleaseDetails.spec.tsx
+++ b/static/app/views/releases/detail/overview/sidebar/projectReleaseDetails.spec.tsx
@@ -1,3 +1,4 @@
+import {ProjectFixture} from 'sentry-fixture/project';
 import {ReleaseFixture} from 'sentry-fixture/release';
 import {ReleaseMetaFixture} from 'sentry-fixture/releaseMeta';
 
@@ -9,9 +10,10 @@ describe('ProjectReleaseDetails', () => {
   it('should dislay if the release is using semver', () => {
     const release = ReleaseFixture();
     const releaseMeta = ReleaseMetaFixture();
+    const project = ProjectFixture();
     const {container} = render(
       <ProjectReleaseDetails
-        projectSlug="project-slug"
+        project={project}
         release={release}
         releaseMeta={releaseMeta}
       />

--- a/static/app/views/releases/detail/overview/sidebar/projectReleaseDetails.tsx
+++ b/static/app/views/releases/detail/overview/sidebar/projectReleaseDetails.tsx
@@ -15,6 +15,7 @@ import Version from 'sentry/components/version';
 import {IconInfo} from 'sentry/icons/iconInfo';
 import {t, tct, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import type {AvatarProject} from 'sentry/types/project';
 import type {ReleaseMeta, ReleaseWithHealth} from 'sentry/types/release';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useUser} from 'sentry/utils/useUser';
@@ -22,12 +23,12 @@ import useFinalizeRelease from 'sentry/views/releases/components/useFinalizeRele
 import {isVersionInfoSemver} from 'sentry/views/releases/utils';
 
 type Props = {
-  projectSlug: string;
+  project: AvatarProject;
   release: ReleaseWithHealth;
   releaseMeta: ReleaseMeta;
 };
 
-function ProjectReleaseDetails({release, releaseMeta, projectSlug}: Props) {
+function ProjectReleaseDetails({release, releaseMeta, project}: Props) {
   const organization = useOrganization();
   const orgSlug = organization.slug;
 
@@ -117,7 +118,26 @@ function ProjectReleaseDetails({release, releaseMeta, projectSlug}: Props) {
             }
           />
           <KeyValueTableRow
-            keyName={t('Semver')}
+            keyName={
+              <Flex gap="sm" align="center">
+                {t('Semver')}
+                <Tooltip
+                  skipWrapper
+                  isHoverable
+                  title={tct(
+                    'Semver packages format their versions as [code:package@version] or [code:package@version+build]. [cliDocs:Read more].',
+                    {
+                      code: <code />,
+                      docs: (
+                        <ExternalLink href="https://docs.sentry.io/cli/releases/#creating-releases" />
+                      ),
+                    }
+                  )}
+                >
+                  <IconInfo />
+                </Tooltip>
+              </Flex>
+            }
             value={isVersionInfoSemver(versionInfo.version) ? t('Yes') : t('No')}
           />
           <KeyValueTableRow
@@ -142,10 +162,10 @@ function ProjectReleaseDetails({release, releaseMeta, projectSlug}: Props) {
               <Link
                 to={
                   isArtifactBundle
-                    ? `/settings/${orgSlug}/projects/${projectSlug}/source-maps/?query=${encodeURIComponent(
+                    ? `/settings/${orgSlug}/projects/${project.slug}/source-maps/?query=${encodeURIComponent(
                         version
                       )}`
-                    : `/settings/${orgSlug}/projects/${projectSlug}/source-maps/${encodeURIComponent(
+                    : `/settings/${orgSlug}/projects/${project.slug}/source-maps/${encodeURIComponent(
                         version
                       )}/`
                 }

--- a/static/app/views/releases/detail/overview/sidebar/projectReleaseDetails.tsx
+++ b/static/app/views/releases/detail/overview/sidebar/projectReleaseDetails.tsx
@@ -125,7 +125,7 @@ function ProjectReleaseDetails({release, releaseMeta, project}: Props) {
                   skipWrapper
                   isHoverable
                   title={tct(
-                    'Semver packages format their versions as [code:package@version] or [code:package@version+build]. [cliDocs:Read more].',
+                    'Semver packages format their versions as [code:package@version] or [code:package@version+build]. [docs:Read more].',
                     {
                       code: <code />,
                       docs: (


### PR DESCRIPTION
<img width="378" height="289" alt="SCR-20250826-jarl" src="https://github.com/user-attachments/assets/23358acf-9cad-4f2d-b3d8-08d38b958979" />


Fixes REPLAY-647
