### PR TITLE
fix(nav): Use mode='popLayout' for nav preview animation

### DIFF
--- a/static/app/views/nav/secondary/secondarySidebar.tsx
+++ b/static/app/views/nav/secondary/secondarySidebar.tsx
@@ -64,12 +64,12 @@ export function SecondarySidebar() {
           [NAV_SECONDARY_SIDEBAR_DATA_ATTRIBUTE]: true,
         }}
       >
-        <AnimatePresence mode="wait" initial={false}>
+        <AnimatePresence mode="popLayout" initial={false}>
           <MotionDiv
             key={activeNavGroup}
-            initial={{x: -4, opacity: 0}}
+            initial={{x: -6, opacity: 0}}
             animate={{x: 0, opacity: 1}}
-            exit={{x: 4, opacity: 0}}
+            exit={{x: 6, opacity: 0}}
             transition={{duration: 0.06}}
           >
             <SecondarySidebarInner>


### PR DESCRIPTION
Changes the AnimatePresence mode from `wait` to `popLayout`. This should fix some rare issues where AnimatePresence gets "stuck", which seemed to occur when quickly previewing other nav items. `popLayout` will animate the new sidebar content immediately so it works a bit better for high frequency updates.

I also think it looks a bit better, so double win.

Before:

https://github.com/user-attachments/assets/fee4ca82-700b-4c23-8f6b-71699b752431


After:

https://github.com/user-attachments/assets/fab5014a-815b-49ac-adf0-e32ada5c1d32

