### PR TITLE
ref(groupingInfo): Fix contributing frame hidden when showing all values

### DIFF
--- a/static/app/components/events/groupingInfo/groupingComponentFrames.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponentFrames.tsx
@@ -22,7 +22,6 @@ function GroupingComponentFrames({
   const [collapsed, setCollapsed] = useState(initialCollapsed);
   const isCollapsible = items.length > maxVisibleItems;
 
-  // Update collapsed state when initialCollapsed prop changes
   useEffect(() => {
     setCollapsed(initialCollapsed);
   }, [initialCollapsed]);

--- a/static/app/components/events/groupingInfo/groupingComponentFrames.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponentFrames.tsx
@@ -9,15 +9,15 @@ import {space} from 'sentry/styles/space';
 import {GroupingComponentListItem} from './groupingComponent';
 
 interface GroupingComponentFramesProps {
+  initialCollapsed: boolean;
   items: React.ReactNode[];
-  initialCollapsed?: boolean;
   maxVisibleItems?: number;
 }
 
 function GroupingComponentFrames({
   items,
   maxVisibleItems = 2,
-  initialCollapsed = true,
+  initialCollapsed,
 }: GroupingComponentFramesProps) {
   const [collapsed, setCollapsed] = useState(initialCollapsed);
   const isCollapsible = items.length > maxVisibleItems;

--- a/static/app/components/events/groupingInfo/groupingComponentFrames.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponentFrames.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useState} from 'react';
+import {Fragment, useEffect, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/core/button';
@@ -10,15 +10,22 @@ import {GroupingComponentListItem} from './groupingComponent';
 
 interface GroupingComponentFramesProps {
   items: React.ReactNode[];
+  initialCollapsed?: boolean;
   maxVisibleItems?: number;
 }
 
 function GroupingComponentFrames({
   items,
   maxVisibleItems = 2,
+  initialCollapsed = true,
 }: GroupingComponentFramesProps) {
-  const [collapsed, setCollapsed] = useState(true);
+  const [collapsed, setCollapsed] = useState(initialCollapsed);
   const isCollapsible = items.length > maxVisibleItems;
+
+  // Update collapsed state when initialCollapsed prop changes
+  useEffect(() => {
+    setCollapsed(initialCollapsed);
+  }, [initialCollapsed]);
 
   return (
     <Fragment>

--- a/static/app/components/events/groupingInfo/groupingComponentStacktrace.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponentStacktrace.tsx
@@ -46,7 +46,6 @@ function GroupingComponentStacktrace({component, showNonContributing}: Props) {
       {getFrameGroups().map((group, index) => (
         <GroupingComponentFrames
           key={index}
-          maxVisibleItems={2}
           items={group.data.map((v, idx) => (
             <GroupingComponent
               key={idx}

--- a/static/app/components/events/groupingInfo/groupingComponentStacktrace.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponentStacktrace.tsx
@@ -46,6 +46,7 @@ function GroupingComponentStacktrace({component, showNonContributing}: Props) {
       {getFrameGroups().map((group, index) => (
         <GroupingComponentFrames
           key={index}
+          maxVisibleItems={2}
           items={group.data.map((v, idx) => (
             <GroupingComponent
               key={idx}
@@ -53,6 +54,7 @@ function GroupingComponentStacktrace({component, showNonContributing}: Props) {
               showNonContributing={showNonContributing}
             />
           ))}
+          initialCollapsed={!showNonContributing}
         />
       ))}
     </Fragment>


### PR DESCRIPTION
For #74977.

Sometimes contributing values get hidden(collapsed) under non-contributing values when switched to 'All Values'. This sets the default to expand the 'All Values' stacktrace so nothing is hidden.

