### PR TITLE
ref(grouping): Add context line to JS stacktrace diff 

### DIFF
--- a/static/app/components/events/interfaces/crashContent/stackTrace/rawContent.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/rawContent.tsx
@@ -3,7 +3,11 @@ import type {ExceptionValue, Frame} from 'sentry/types/event';
 import type {StacktraceType} from 'sentry/types/stacktrace';
 import {defined} from 'sentry/utils';
 
-function getJavaScriptFrame(frame: Frame, includeLocation: boolean): string {
+function getJavaScriptFrame(
+  frame: Frame,
+  includeLocation: boolean,
+  includeJSContext: boolean
+): string {
   let result = '';
   if (defined(frame.function)) {
     result += '\tat ' + frame.function + ' (';
@@ -22,7 +26,7 @@ function getJavaScriptFrame(frame: Frame, includeLocation: boolean): string {
     result += ':' + frame.colNo;
   }
   result += ')';
-  if (defined(frame.context)) {
+  if (defined(frame.context) && includeJSContext) {
     frame.context.forEach(item => {
       if (frame.lineNo === item[0]) {
         result += '\n    ' + item[1]?.trim();
@@ -207,14 +211,15 @@ function getFrame(
   frame: Frame,
   frameIdxFromEnd: number,
   platform: string | undefined,
-  includeLocation: boolean
+  includeLocation: boolean,
+  includeJSContext: boolean
 ): string {
   if (frame.platform) {
     platform = frame.platform;
   }
   switch (platform) {
     case 'javascript':
-      return getJavaScriptFrame(frame, includeLocation);
+      return getJavaScriptFrame(frame, includeLocation, includeJSContext);
     case 'ruby':
       return getRubyFrame(frame, includeLocation);
     case 'php':
@@ -241,7 +246,8 @@ export default function displayRawContent(
   platform?: string,
   exception?: ExceptionValue,
   hasSimilarityEmbeddingsFeature = false,
-  includeLocation = true
+  includeLocation = true,
+  includeJSContext = false
 ) {
   const rawFrames = data?.frames || [];
 
@@ -253,7 +259,13 @@ export default function displayRawContent(
     : rawFrames;
 
   const frames = framesToUse.map((frame, frameIdx) =>
-    getFrame(frame, framesToUse.length - frameIdx - 1, platform, includeLocation)
+    getFrame(
+      frame,
+      framesToUse.length - frameIdx - 1,
+      platform,
+      includeLocation,
+      includeJSContext
+    )
   );
 
   if (platform !== 'python') {

--- a/static/app/components/events/interfaces/crashContent/stackTrace/rawContent.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/rawContent.tsx
@@ -22,6 +22,14 @@ function getJavaScriptFrame(frame: Frame, includeLocation: boolean): string {
     result += ':' + frame.colNo;
   }
   result += ')';
+  if (defined(frame.context)) {
+    frame.context.forEach(item => {
+      if (frame.lineNo === item[0]) {
+        result += '\n    ' + item[1]?.trim();
+      }
+    });
+  }
+
   return result;
 }
 

--- a/static/app/components/issueDiff/index.tsx
+++ b/static/app/components/issueDiff/index.tsx
@@ -88,16 +88,19 @@ class IssueDiff extends Component<Props, State> {
           this.fetchEvent(targetIssueId, targetEventId ?? 'latest'),
         ]);
         const includeLocation = false;
+        const includeJSContext = true;
         const [baseEvent, targetEvent] = await Promise.all([
           getStacktraceBody(
             baseEventData,
             hasSimilarityEmbeddingsFeature,
-            includeLocation
+            includeLocation,
+            includeJSContext
           ),
           getStacktraceBody(
             targetEventData,
             hasSimilarityEmbeddingsFeature,
-            includeLocation
+            includeLocation,
+            includeJSContext
           ),
         ]);
 

--- a/static/app/utils/getStacktraceBody.tsx
+++ b/static/app/utils/getStacktraceBody.tsx
@@ -4,7 +4,8 @@ import type {Event} from 'sentry/types/event';
 export default function getStacktraceBody(
   event: Event,
   hasSimilarityEmbeddingsFeature = false,
-  includeLocation = true
+  includeLocation = true,
+  includeJSContext = false
 ) {
   if (!event?.entries) {
     return [];
@@ -42,7 +43,8 @@ export default function getStacktraceBody(
         event.platform,
         value,
         hasSimilarityEmbeddingsFeature,
-        includeLocation
+        includeLocation,
+        includeJSContext
       )
     )
     .reduce((acc: any, value: any) => acc.concat(value), []);


### PR DESCRIPTION
Previously, the context line was not included in JS stacktraces, leaving the stacktrace diff for some similar issues showing no differences. 
<img width="1462" height="736" alt="31AS-without-context" src="https://github.com/user-attachments/assets/ffb85187-40e3-449c-943c-8fd22639878f" />

Adding the context line shows the actual difference between these two stacktraces. 
<img width="1459" height="725" alt="31AS-with-context" src="https://github.com/user-attachments/assets/3021a658-cad0-4ad4-8bee-0f88d2980aac" />
