### PR TITLE
feat(ourlogs): Add aliasType field for trace item attribute keys

### DIFF
--- a/src/sentry/api/endpoints/organization_spans_fields.py
+++ b/src/sentry/api/endpoints/organization_spans_fields.py
@@ -35,7 +35,7 @@ from sentry.utils import snuba_rpc
 
 
 def as_tag_key(name: str, type: Literal["string", "number"]):
-    key = translate_internal_to_public_alias(name, type, SupportedTraceItemType.SPANS)
+    key, _ = translate_internal_to_public_alias(name, type, SupportedTraceItemType.SPANS)
 
     if key is not None:
         name = key

--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -63,7 +63,7 @@ class TraceItemAttributeKey(TypedDict):
     key: str
     name: str
     secondaryAliases: NotRequired[list[str]]
-    aliasType: NotRequired[str]
+    attributeSource: NotRequired[str]
 
 
 class TraceItemAttributesNamesPaginator:
@@ -161,7 +161,7 @@ def resolve_attribute_values_referrer(item_type: str) -> Referrer:
 def as_attribute_key(
     name: str, type: Literal["string", "number"], item_type: SupportedTraceItemType
 ) -> TraceItemAttributeKey:
-    key, alias_type = translate_internal_to_public_alias(name, type, item_type)
+    key, attribute_source = translate_internal_to_public_alias(name, type, item_type)
     secondary_aliases = get_secondary_aliases(name, item_type)
 
     if key is not None:
@@ -176,7 +176,7 @@ def as_attribute_key(
         "key": key,
         # name is what will be used to display the tag nicely in the UI
         "name": name,
-        "aliasType": alias_type.value,
+        "attributeSource": attribute_source.value,
     }
 
     if secondary_aliases:

--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -63,6 +63,7 @@ class TraceItemAttributeKey(TypedDict):
     key: str
     name: str
     secondaryAliases: NotRequired[list[str]]
+    aliasType: NotRequired[str]
 
 
 class TraceItemAttributesNamesPaginator:
@@ -160,7 +161,7 @@ def resolve_attribute_values_referrer(item_type: str) -> Referrer:
 def as_attribute_key(
     name: str, type: Literal["string", "number"], item_type: SupportedTraceItemType
 ) -> TraceItemAttributeKey:
-    key = translate_internal_to_public_alias(name, type, item_type)
+    key, alias_type = translate_internal_to_public_alias(name, type, item_type)
     secondary_aliases = get_secondary_aliases(name, item_type)
 
     if key is not None:
@@ -175,6 +176,7 @@ def as_attribute_key(
         "key": key,
         # name is what will be used to display the tag nicely in the UI
         "name": name,
+        "aliasType": alias_type.value,
     }
 
     if secondary_aliases:

--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -63,7 +63,7 @@ class TraceItemAttributeKey(TypedDict):
     key: str
     name: str
     secondaryAliases: NotRequired[list[str]]
-    attributeSource: NotRequired[str]
+    attributeSource: dict[str, str | bool]
 
 
 class TraceItemAttributesNamesPaginator:
@@ -171,12 +171,20 @@ def as_attribute_key(
     else:
         key = name
 
+    serialized_source: dict[str, str | bool] = {
+        "source_type": attribute_source["source_type"].value
+    }
+    if attribute_source.get("is_transformed_alias"):
+        serialized_source["is_transformed_alias"] = True
+
     attribute_key: TraceItemAttributeKey = {
         # key is what will be used to query the API
         "key": key,
         # name is what will be used to display the tag nicely in the UI
         "name": name,
-        "attributeSource": attribute_source.value,
+        # source of the attribute, used to determine whether to show the sentry icon etc. and helps delineate between sentry and user attributes when the names are identical
+        # eg. sentry.environment and environment set by the user both have the same alias (name).
+        "attributeSource": serialized_source,
     }
 
     if secondary_aliases:

--- a/src/sentry/api/endpoints/organization_trace_item_attributes_ranked.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes_ranked.py
@@ -160,7 +160,7 @@ class OrganizationTraceItemsAttributesRankedEndpoint(OrganizationEventsV2Endpoin
             distribution = {
                 "attributeName": translate_internal_to_public_alias(
                     attr, "string", SupportedTraceItemType.SPANS
-                )
+                )[0]
                 or attr,
                 "cohort1": cohort_1_distribution_map.get(attr),
                 "cohort2": cohort_2_distribution_map.get(attr),

--- a/src/sentry/api/endpoints/project_trace_item_details.py
+++ b/src/sentry/api/endpoints/project_trace_item_details.py
@@ -65,7 +65,7 @@ def convert_rpc_attribute_to_json(
                 else:
                     raise BadRequest(f"unknown column type in protobuf: {val_type}")
 
-                external_name = translate_internal_to_public_alias(
+                external_name, _ = translate_internal_to_public_alias(
                     internal_name, column_type, trace_item_type
                 )
 
@@ -148,7 +148,7 @@ def serialize_meta(
                     item_type = "number"
                 else:
                     item_type = "string"
-                external_name = translate_internal_to_public_alias(
+                external_name, _ = translate_internal_to_public_alias(
                     field_key, item_type, trace_item_type
                 )
                 if external_name:

--- a/src/sentry/search/eap/types.py
+++ b/src/sentry/search/eap/types.py
@@ -45,6 +45,11 @@ class SupportedTraceItemType(str, Enum):
     UPTIME_RESULTS = "uptime_results"
 
 
+class AliasType(str, Enum):
+    INTERNAL = "internal"
+    CUSTOM = "custom"
+
+
 class TraceItemAttribute(TypedDict):
     name: str
     type: Literal["string", "number"]

--- a/src/sentry/search/eap/types.py
+++ b/src/sentry/search/eap/types.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Literal, TypedDict
+from typing import Literal, NotRequired, TypedDict
 
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import Reliability
 
@@ -45,9 +45,14 @@ class SupportedTraceItemType(str, Enum):
     UPTIME_RESULTS = "uptime_results"
 
 
-class AttributeSource(str, Enum):
+class AttributeSourceType(str, Enum):
     SENTRY = "sentry"
     USER = "user"
+
+
+class AttributeSource(TypedDict):
+    source_type: AttributeSourceType
+    is_transformed_alias: NotRequired[bool]
 
 
 class TraceItemAttribute(TypedDict):

--- a/src/sentry/search/eap/types.py
+++ b/src/sentry/search/eap/types.py
@@ -45,9 +45,9 @@ class SupportedTraceItemType(str, Enum):
     UPTIME_RESULTS = "uptime_results"
 
 
-class AliasType(str, Enum):
-    INTERNAL = "internal"
-    CUSTOM = "custom"
+class AttributeSource(str, Enum):
+    SENTRY = "sentry"
+    USER = "user"
 
 
 class TraceItemAttribute(TypedDict):

--- a/src/sentry/search/eap/utils.py
+++ b/src/sentry/search/eap/utils.py
@@ -26,7 +26,7 @@ from sentry.search.eap.spans.attributes import (
     SPANS_REPLACEMENT_MAP,
 )
 from sentry.search.eap.spans.definitions import SPAN_DEFINITIONS
-from sentry.search.eap.types import AttributeSource, SupportedTraceItemType
+from sentry.search.eap.types import AttributeSource, AttributeSourceType, SupportedTraceItemType
 
 
 def add_start_end_conditions(
@@ -95,13 +95,13 @@ def translate_internal_to_public_alias(
     mapping = INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS.get(item_type, {}).get(type, {})
     public_alias = mapping.get(internal_alias)
     if public_alias is not None:
-        return public_alias, AttributeSource.SENTRY
+        return public_alias, {"source_type": AttributeSourceType.SENTRY}
 
     resolved_column = PUBLIC_ALIAS_TO_INTERNAL_MAPPING.get(item_type, {}).get(internal_alias)
     if resolved_column is not None:
         # if there is a known public alias with this exact name, it means we need to wrap
         # it in the explicitly typed tags syntax in order for it to reference the correct column
-        return f"tags[{internal_alias},{type}]", AttributeSource.SENTRY
+        return f"tags[{internal_alias},{type}]", {"source_type": AttributeSourceType.SENTRY}
 
     definitions = TRACE_ITEM_TYPE_DEFINITIONS.get(item_type)
     if definitions is not None:
@@ -109,10 +109,16 @@ def translate_internal_to_public_alias(
             column = definitions.column_to_alias(internal_alias)
             if column is not None:
                 if type == "string":
-                    return column, AttributeSource.SENTRY
-                return f"tags[{column},{type}]", AttributeSource.SENTRY
+                    return column, {
+                        "source_type": AttributeSourceType.SENTRY,
+                        "is_transformed_alias": True,
+                    }
+                return f"tags[{column},{type}]", {
+                    "source_type": AttributeSourceType.SENTRY,
+                    "is_transformed_alias": True,
+                }
 
-    return None, AttributeSource.USER
+    return None, {"source_type": AttributeSourceType.USER}
 
 
 def get_secondary_aliases(

--- a/src/sentry/search/eap/utils.py
+++ b/src/sentry/search/eap/utils.py
@@ -26,7 +26,7 @@ from sentry.search.eap.spans.attributes import (
     SPANS_REPLACEMENT_MAP,
 )
 from sentry.search.eap.spans.definitions import SPAN_DEFINITIONS
-from sentry.search.eap.types import AliasType, SupportedTraceItemType
+from sentry.search.eap.types import AttributeSource, SupportedTraceItemType
 
 
 def add_start_end_conditions(
@@ -91,17 +91,17 @@ def translate_internal_to_public_alias(
     internal_alias: str,
     type: Literal["string", "number"],
     item_type: SupportedTraceItemType,
-) -> tuple[str | None, AliasType]:
+) -> tuple[str | None, AttributeSource]:
     mapping = INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS.get(item_type, {}).get(type, {})
     public_alias = mapping.get(internal_alias)
     if public_alias is not None:
-        return public_alias, AliasType.INTERNAL
+        return public_alias, AttributeSource.SENTRY
 
     resolved_column = PUBLIC_ALIAS_TO_INTERNAL_MAPPING.get(item_type, {}).get(internal_alias)
     if resolved_column is not None:
         # if there is a known public alias with this exact name, it means we need to wrap
         # it in the explicitly typed tags syntax in order for it to reference the correct column
-        return f"tags[{internal_alias},{type}]", AliasType.INTERNAL
+        return f"tags[{internal_alias},{type}]", AttributeSource.SENTRY
 
     definitions = TRACE_ITEM_TYPE_DEFINITIONS.get(item_type)
     if definitions is not None:
@@ -109,10 +109,10 @@ def translate_internal_to_public_alias(
             column = definitions.column_to_alias(internal_alias)
             if column is not None:
                 if type == "string":
-                    return column, AliasType.INTERNAL
-                return f"tags[{column},{type}]", AliasType.INTERNAL
+                    return column, AttributeSource.SENTRY
+                return f"tags[{column},{type}]", AttributeSource.SENTRY
 
-    return None, AliasType.CUSTOM
+    return None, AttributeSource.USER
 
 
 def get_secondary_aliases(

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -3436,7 +3436,10 @@ class OurLogTestCase(BaseTestCase):
 
         timestamp_proto.FromDatetime(timestamp)
 
-        if "sentry.observed_timestamp_nanos" not in extra_data:
+        if (
+            "sentry.observed_timestamp_nanos" not in extra_data
+            and "sentry.observed_timestamp_nanos" not in attributes
+        ):
             attributes_proto["sentry.observed_timestamp_nanos"] = AnyValue(
                 int_value=int(timestamp.timestamp() * 1e9)
             )

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -3436,7 +3436,7 @@ class OurLogTestCase(BaseTestCase):
 
         timestamp_proto.FromDatetime(timestamp)
 
-        if "sentry.observed_timestamp_precise" not in extra_data:
+        if "sentry.observed_timestamp_nanos" not in extra_data:
             attributes_proto["sentry.observed_timestamp_nanos"] = AnyValue(
                 int_value=int(timestamp.timestamp() * 1e9)
             )

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -3436,9 +3436,10 @@ class OurLogTestCase(BaseTestCase):
 
         timestamp_proto.FromDatetime(timestamp)
 
-        attributes_proto["sentry.timestamp_nanos"] = AnyValue(
-            int_value=int(timestamp.timestamp() * 1e9)
-        )
+        if "sentry.observed_timestamp_precise" not in extra_data:
+            attributes_proto["sentry.observed_timestamp_nanos"] = AnyValue(
+                int_value=int(timestamp.timestamp() * 1e9)
+            )
         attributes_proto["sentry.timestamp_precise"] = AnyValue(
             int_value=int(timestamp.timestamp() * 1e9)
         )

--- a/tests/snuba/api/endpoints/test_organization_events_ourlogs.py
+++ b/tests/snuba/api/endpoints/test_organization_events_ourlogs.py
@@ -414,9 +414,7 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase):
                 "tags[sentry.timestamp_precise,number]": pytest.approx(
                     source.attributes["sentry.timestamp_precise"].int_value
                 ),
-                "observed_timestamp": source.attributes[
-                    "sentry.observed_timestamp_nanos"
-                ].string_value,
+                "observed_timestamp": None,
                 "message": source.attributes["sentry.body"].string_value,
             }
         assert meta["dataset"] == self.dataset

--- a/tests/snuba/api/endpoints/test_organization_events_ourlogs.py
+++ b/tests/snuba/api/endpoints/test_organization_events_ourlogs.py
@@ -364,12 +364,20 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase):
         logs = [
             self.create_ourlog(
                 {"body": "foo"},
-                attributes={"sentry.observed_timestamp_nanos": str(self.ten_mins_ago.timestamp())},
+                attributes={
+                    "sentry.observed_timestamp_nanos": str(
+                        self.ten_mins_ago.timestamp() * 1_000_000_000
+                    )
+                },
                 timestamp=self.ten_mins_ago,
             ),
             self.create_ourlog(
                 {"body": "bar"},
-                attributes={"sentry.observed_timestamp_nanos": str(self.nine_mins_ago.timestamp())},
+                attributes={
+                    "sentry.observed_timestamp_nanos": str(
+                        self.nine_mins_ago.timestamp() * 1_000_000_000
+                    ),
+                },
                 timestamp=self.nine_mins_ago,
             ),
         ]
@@ -414,7 +422,9 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase):
                 "tags[sentry.timestamp_precise,number]": pytest.approx(
                     source.attributes["sentry.timestamp_precise"].int_value
                 ),
-                "observed_timestamp": None,
+                "observed_timestamp": source.attributes[
+                    "sentry.observed_timestamp_nanos"
+                ].string_value,
                 "message": source.attributes["sentry.body"].string_value,
             }
         assert meta["dataset"] == self.dataset

--- a/tests/snuba/api/endpoints/test_organization_events_ourlogs.py
+++ b/tests/snuba/api/endpoints/test_organization_events_ourlogs.py
@@ -97,7 +97,7 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase):
             ts = datetime.fromisoformat(log["timestamp"])
             assert ts.tzinfo == timezone.utc
             timestamp_from_nanos = (
-                source.attributes["sentry.timestamp_nanos"].int_value / 1_000_000_000
+                source.attributes["sentry.observed_timestamp_nanos"].int_value / 1_000_000_000
             )
             assert ts.timestamp() == pytest.approx(timestamp_from_nanos, abs=5), "timestamp"
 
@@ -386,7 +386,7 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase):
                     "severity",
                     "timestamp",
                     "tags[sentry.timestamp_precise,number]",
-                    "sentry.observed_timestamp_nanos",
+                    "observed_timestamp",
                     "message",
                 ],
                 "per_page": 1000,
@@ -414,7 +414,7 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase):
                 "tags[sentry.timestamp_precise,number]": pytest.approx(
                     source.attributes["sentry.timestamp_precise"].int_value
                 ),
-                "sentry.observed_timestamp_nanos": source.attributes[
+                "observed_timestamp": source.attributes[
                     "sentry.observed_timestamp_nanos"
                 ].string_value,
                 "message": source.attributes["sentry.body"].string_value,

--- a/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
@@ -306,17 +306,17 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
         )
         assert response.status_code == 200, response.data
         expected: list[TraceItemAttributeKey] = [
-            {"key": "bar", "name": "bar", "aliasType": "custom"},
-            {"key": "baz", "name": "baz", "aliasType": "custom"},
-            {"key": "foo", "name": "foo", "aliasType": "custom"},
+            {"key": "bar", "name": "bar", "attributeSource": "user"},
+            {"key": "baz", "name": "baz", "attributeSource": "user"},
+            {"key": "foo", "name": "foo", "attributeSource": "user"},
             {
                 "key": "span.description",
                 "name": "span.description",
-                "aliasType": "internal",
+                "attributeSource": "sentry",
                 "secondaryAliases": ["description", "message"],
             },
-            {"key": "transaction", "name": "transaction", "aliasType": "internal"},
-            {"key": "project", "name": "project", "aliasType": "internal"},
+            {"key": "transaction", "name": "transaction", "attributeSource": "sentry"},
+            {"key": "project", "name": "project", "attributeSource": "sentry"},
         ]
         assert sorted(
             response.data,
@@ -360,27 +360,27 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
         )
         assert response.status_code == 200, response.data
         assert response.data == [
-            {"key": "tags[bar,number]", "name": "bar", "aliasType": "custom"},
-            {"key": "tags[baz,number]", "name": "baz", "aliasType": "custom"},
-            {"key": "measurements.fcp", "name": "measurements.fcp", "aliasType": "internal"},
-            {"key": "tags[foo,number]", "name": "foo", "aliasType": "custom"},
+            {"key": "tags[bar,number]", "name": "bar", "attributeSource": "user"},
+            {"key": "tags[baz,number]", "name": "baz", "attributeSource": "user"},
+            {"key": "measurements.fcp", "name": "measurements.fcp", "attributeSource": "sentry"},
+            {"key": "tags[foo,number]", "name": "foo", "attributeSource": "user"},
             {
                 "key": "http.decoded_response_content_length",
                 "name": "http.decoded_response_content_length",
-                "aliasType": "internal",
+                "attributeSource": "sentry",
             },
             {
                 "key": "http.response_content_length",
                 "name": "http.response_content_length",
-                "aliasType": "internal",
+                "attributeSource": "sentry",
             },
             {
                 "key": "http.response_transfer_size",
                 "name": "http.response_transfer_size",
-                "aliasType": "internal",
+                "attributeSource": "sentry",
             },
-            {"key": "measurements.lcp", "name": "measurements.lcp", "aliasType": "internal"},
-            {"key": "span.duration", "name": "span.duration", "aliasType": "internal"},
+            {"key": "measurements.lcp", "name": "measurements.lcp", "attributeSource": "sentry"},
+            {"key": "span.duration", "name": "span.duration", "attributeSource": "sentry"},
         ]
 
     @override_options({"explore.trace-items.keys.max": 3})
@@ -409,16 +409,16 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
         assert response.status_code == 200, response.data
 
         expected: list[TraceItemAttributeKey] = [
-            {"key": "bar", "name": "bar", "aliasType": "custom"},
-            {"key": "baz", "name": "baz", "aliasType": "custom"},
-            {"key": "foo", "name": "foo", "aliasType": "custom"},
+            {"key": "bar", "name": "bar", "attributeSource": "user"},
+            {"key": "baz", "name": "baz", "attributeSource": "user"},
+            {"key": "foo", "name": "foo", "attributeSource": "user"},
             {
                 "key": "span.description",
                 "name": "span.description",
-                "aliasType": "internal",
+                "attributeSource": "sentry",
                 "secondaryAliases": ["description", "message"],
             },
-            {"key": "project", "name": "project", "aliasType": "internal"},
+            {"key": "project", "name": "project", "attributeSource": "sentry"},
         ]
 
         assert sorted(
@@ -446,11 +446,11 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
             {
                 "key": "span.description",
                 "name": "span.description",
-                "aliasType": "internal",
+                "attributeSource": "sentry",
                 "secondaryAliases": ["description", "message"],
             },
-            {"key": "transaction", "name": "transaction", "aliasType": "internal"},
-            {"key": "project", "name": "project", "aliasType": "internal"},
+            {"key": "transaction", "name": "transaction", "attributeSource": "sentry"},
+            {"key": "project", "name": "project", "attributeSource": "sentry"},
         ]
         assert sorted(
             response.data,
@@ -474,16 +474,16 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
         assert response.status_code == 200, response.content
 
         expected_3: list[TraceItemAttributeKey] = [
-            {"key": "bar", "name": "bar", "aliasType": "custom"},
-            {"key": "baz", "name": "baz", "aliasType": "custom"},
-            {"key": "foo", "name": "foo", "aliasType": "custom"},
+            {"key": "bar", "name": "bar", "attributeSource": "user"},
+            {"key": "baz", "name": "baz", "attributeSource": "user"},
+            {"key": "foo", "name": "foo", "attributeSource": "user"},
             {
                 "key": "span.description",
                 "name": "span.description",
-                "aliasType": "internal",
+                "attributeSource": "sentry",
                 "secondaryAliases": ["description", "message"],
             },
-            {"key": "project", "name": "project", "aliasType": "internal"},
+            {"key": "project", "name": "project", "attributeSource": "sentry"},
         ]
         assert sorted(
             response.data,
@@ -532,27 +532,35 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
         assert response.status_code == 200, response.data
         assert sorted(response.data, key=itemgetter("key")) == sorted(
             [
-                {"key": "tags[bar,number]", "name": "bar", "aliasType": "custom"},
-                {"key": "tags[baz,number]", "name": "baz", "aliasType": "custom"},
-                {"key": "measurements.fcp", "name": "measurements.fcp", "aliasType": "internal"},
-                {"key": "tags[foo,number]", "name": "foo", "aliasType": "custom"},
+                {"key": "tags[bar,number]", "name": "bar", "attributeSource": "user"},
+                {"key": "tags[baz,number]", "name": "baz", "attributeSource": "user"},
+                {
+                    "key": "measurements.fcp",
+                    "name": "measurements.fcp",
+                    "attributeSource": "sentry",
+                },
+                {"key": "tags[foo,number]", "name": "foo", "attributeSource": "user"},
                 {
                     "key": "http.decoded_response_content_length",
                     "name": "http.decoded_response_content_length",
-                    "aliasType": "internal",
+                    "attributeSource": "sentry",
                 },
                 {
                     "key": "http.response.body.size",
                     "name": "http.response.body.size",
-                    "aliasType": "internal",
+                    "attributeSource": "sentry",
                 },
                 {
                     "key": "http.response.size",
                     "name": "http.response.size",
-                    "aliasType": "internal",
+                    "attributeSource": "sentry",
                 },
-                {"key": "measurements.lcp", "name": "measurements.lcp", "aliasType": "internal"},
-                {"key": "span.duration", "name": "span.duration", "aliasType": "internal"},
+                {
+                    "key": "measurements.lcp",
+                    "name": "measurements.lcp",
+                    "attributeSource": "sentry",
+                },
+                {"key": "span.duration", "name": "span.duration", "attributeSource": "sentry"},
             ],
             key=itemgetter("key"),
         )
@@ -582,20 +590,20 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
             {
                 "key": "span.description",
                 "name": "span.description",
-                "aliasType": "internal",
+                "attributeSource": "sentry",
                 "secondaryAliases": ["description", "message"],
             },
-            {"key": "project", "name": "project", "aliasType": "internal"},
-            {"key": "transaction", "name": "transaction", "aliasType": "internal"},
+            {"key": "project", "name": "project", "attributeSource": "sentry"},
+            {"key": "transaction", "name": "transaction", "attributeSource": "sentry"},
             {
                 "key": "tags[span.duration,string]",
                 "name": "tags[span.duration,string]",
-                "aliasType": "internal",
+                "attributeSource": "sentry",
             },
             {
                 "key": "tags[span.op,string]",
                 "name": "tags[span.op,string]",
-                "aliasType": "internal",
+                "attributeSource": "sentry",
             },
         ]
 

--- a/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
@@ -306,16 +306,17 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
         )
         assert response.status_code == 200, response.data
         expected: list[TraceItemAttributeKey] = [
-            {"key": "bar", "name": "bar"},
-            {"key": "baz", "name": "baz"},
-            {"key": "foo", "name": "foo"},
+            {"key": "bar", "name": "bar", "aliasType": "custom"},
+            {"key": "baz", "name": "baz", "aliasType": "custom"},
+            {"key": "foo", "name": "foo", "aliasType": "custom"},
             {
                 "key": "span.description",
                 "name": "span.description",
+                "aliasType": "internal",
                 "secondaryAliases": ["description", "message"],
             },
-            {"key": "transaction", "name": "transaction"},
-            {"key": "project", "name": "project"},
+            {"key": "transaction", "name": "transaction", "aliasType": "internal"},
+            {"key": "project", "name": "project", "aliasType": "internal"},
         ]
         assert sorted(
             response.data,
@@ -359,24 +360,27 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
         )
         assert response.status_code == 200, response.data
         assert response.data == [
-            {"key": "tags[bar,number]", "name": "bar"},
-            {"key": "tags[baz,number]", "name": "baz"},
-            {"key": "measurements.fcp", "name": "measurements.fcp"},
-            {"key": "tags[foo,number]", "name": "foo"},
+            {"key": "tags[bar,number]", "name": "bar", "aliasType": "custom"},
+            {"key": "tags[baz,number]", "name": "baz", "aliasType": "custom"},
+            {"key": "measurements.fcp", "name": "measurements.fcp", "aliasType": "internal"},
+            {"key": "tags[foo,number]", "name": "foo", "aliasType": "custom"},
             {
                 "key": "http.decoded_response_content_length",
                 "name": "http.decoded_response_content_length",
+                "aliasType": "internal",
             },
             {
                 "key": "http.response_content_length",
                 "name": "http.response_content_length",
+                "aliasType": "internal",
             },
             {
                 "key": "http.response_transfer_size",
                 "name": "http.response_transfer_size",
+                "aliasType": "internal",
             },
-            {"key": "measurements.lcp", "name": "measurements.lcp"},
-            {"key": "span.duration", "name": "span.duration"},
+            {"key": "measurements.lcp", "name": "measurements.lcp", "aliasType": "internal"},
+            {"key": "span.duration", "name": "span.duration", "aliasType": "internal"},
         ]
 
     @override_options({"explore.trace-items.keys.max": 3})
@@ -405,15 +409,16 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
         assert response.status_code == 200, response.data
 
         expected: list[TraceItemAttributeKey] = [
-            {"key": "bar", "name": "bar"},
-            {"key": "baz", "name": "baz"},
-            {"key": "foo", "name": "foo"},
+            {"key": "bar", "name": "bar", "aliasType": "custom"},
+            {"key": "baz", "name": "baz", "aliasType": "custom"},
+            {"key": "foo", "name": "foo", "aliasType": "custom"},
             {
                 "key": "span.description",
                 "name": "span.description",
+                "aliasType": "internal",
                 "secondaryAliases": ["description", "message"],
             },
-            {"key": "project", "name": "project"},
+            {"key": "project", "name": "project", "aliasType": "internal"},
         ]
 
         assert sorted(
@@ -441,10 +446,11 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
             {
                 "key": "span.description",
                 "name": "span.description",
+                "aliasType": "internal",
                 "secondaryAliases": ["description", "message"],
             },
-            {"key": "transaction", "name": "transaction"},
-            {"key": "project", "name": "project"},
+            {"key": "transaction", "name": "transaction", "aliasType": "internal"},
+            {"key": "project", "name": "project", "aliasType": "internal"},
         ]
         assert sorted(
             response.data,
@@ -468,15 +474,16 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
         assert response.status_code == 200, response.content
 
         expected_3: list[TraceItemAttributeKey] = [
-            {"key": "bar", "name": "bar"},
-            {"key": "baz", "name": "baz"},
-            {"key": "foo", "name": "foo"},
+            {"key": "bar", "name": "bar", "aliasType": "custom"},
+            {"key": "baz", "name": "baz", "aliasType": "custom"},
+            {"key": "foo", "name": "foo", "aliasType": "custom"},
             {
                 "key": "span.description",
                 "name": "span.description",
+                "aliasType": "internal",
                 "secondaryAliases": ["description", "message"],
             },
-            {"key": "project", "name": "project"},
+            {"key": "project", "name": "project", "aliasType": "internal"},
         ]
         assert sorted(
             response.data,
@@ -525,18 +532,27 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
         assert response.status_code == 200, response.data
         assert sorted(response.data, key=itemgetter("key")) == sorted(
             [
-                {"key": "tags[bar,number]", "name": "bar"},
-                {"key": "tags[baz,number]", "name": "baz"},
-                {"key": "measurements.fcp", "name": "measurements.fcp"},
-                {"key": "tags[foo,number]", "name": "foo"},
+                {"key": "tags[bar,number]", "name": "bar", "aliasType": "custom"},
+                {"key": "tags[baz,number]", "name": "baz", "aliasType": "custom"},
+                {"key": "measurements.fcp", "name": "measurements.fcp", "aliasType": "internal"},
+                {"key": "tags[foo,number]", "name": "foo", "aliasType": "custom"},
                 {
                     "key": "http.decoded_response_content_length",
                     "name": "http.decoded_response_content_length",
+                    "aliasType": "internal",
                 },
-                {"key": "http.response.body.size", "name": "http.response.body.size"},
-                {"key": "http.response.size", "name": "http.response.size"},
-                {"key": "measurements.lcp", "name": "measurements.lcp"},
-                {"key": "span.duration", "name": "span.duration"},
+                {
+                    "key": "http.response.body.size",
+                    "name": "http.response.body.size",
+                    "aliasType": "internal",
+                },
+                {
+                    "key": "http.response.size",
+                    "name": "http.response.size",
+                    "aliasType": "internal",
+                },
+                {"key": "measurements.lcp", "name": "measurements.lcp", "aliasType": "internal"},
+                {"key": "span.duration", "name": "span.duration", "aliasType": "internal"},
             ],
             key=itemgetter("key"),
         )
@@ -566,12 +582,21 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
             {
                 "key": "span.description",
                 "name": "span.description",
+                "aliasType": "internal",
                 "secondaryAliases": ["description", "message"],
             },
-            {"key": "project", "name": "project"},
-            {"key": "transaction", "name": "transaction"},
-            {"key": "tags[span.duration,string]", "name": "tags[span.duration,string]"},
-            {"key": "tags[span.op,string]", "name": "tags[span.op,string]"},
+            {"key": "project", "name": "project", "aliasType": "internal"},
+            {"key": "transaction", "name": "transaction", "aliasType": "internal"},
+            {
+                "key": "tags[span.duration,string]",
+                "name": "tags[span.duration,string]",
+                "aliasType": "internal",
+            },
+            {
+                "key": "tags[span.op,string]",
+                "name": "tags[span.op,string]",
+                "aliasType": "internal",
+            },
         ]
 
     def test_sentry_internal_attributes(self) -> None:

--- a/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
@@ -221,6 +221,15 @@ class OrganizationTraceItemAttributesEndpointLogsTest(
             "message.parameter.1",
         }
 
+        sources = {item["attributeSource"]["source_type"] for item in response.data}
+        assert sources == {"sentry"}
+
+        message_param_items = [
+            item for item in response.data if item["key"].startswith("message.parameter.")
+        ]
+        for item in message_param_items:
+            assert item["attributeSource"]["is_transformed_alias"] is True
+
         response = self.do_request(query={"attributeType": "number"})
 
         assert response.status_code == 200, response.content
@@ -233,8 +242,15 @@ class OrganizationTraceItemAttributesEndpointLogsTest(
             "observed_timestamp",
             "timestamp_precise",
         }
-        sources = {item["attributeSource"] for item in response.data}
+
+        sources = {item["attributeSource"]["source_type"] for item in response.data}
         assert sources == {"sentry"}
+
+        message_param_items = [
+            item for item in response.data if item["key"].startswith("tags[message.parameter.")
+        ]
+        for item in message_param_items:
+            assert item["attributeSource"]["is_transformed_alias"] is True
 
     def test_attribute_collision(self) -> None:
         logs = [
@@ -308,17 +324,21 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
         )
         assert response.status_code == 200, response.data
         expected: list[TraceItemAttributeKey] = [
-            {"key": "bar", "name": "bar", "attributeSource": "user"},
-            {"key": "baz", "name": "baz", "attributeSource": "user"},
-            {"key": "foo", "name": "foo", "attributeSource": "user"},
+            {"key": "bar", "name": "bar", "attributeSource": {"source_type": "user"}},
+            {"key": "baz", "name": "baz", "attributeSource": {"source_type": "user"}},
+            {"key": "foo", "name": "foo", "attributeSource": {"source_type": "user"}},
             {
                 "key": "span.description",
                 "name": "span.description",
-                "attributeSource": "sentry",
+                "attributeSource": {"source_type": "sentry"},
                 "secondaryAliases": ["description", "message"],
             },
-            {"key": "transaction", "name": "transaction", "attributeSource": "sentry"},
-            {"key": "project", "name": "project", "attributeSource": "sentry"},
+            {
+                "key": "transaction",
+                "name": "transaction",
+                "attributeSource": {"source_type": "sentry"},
+            },
+            {"key": "project", "name": "project", "attributeSource": {"source_type": "sentry"}},
         ]
         assert sorted(
             response.data,
@@ -362,27 +382,39 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
         )
         assert response.status_code == 200, response.data
         assert response.data == [
-            {"key": "tags[bar,number]", "name": "bar", "attributeSource": "user"},
-            {"key": "tags[baz,number]", "name": "baz", "attributeSource": "user"},
-            {"key": "measurements.fcp", "name": "measurements.fcp", "attributeSource": "sentry"},
-            {"key": "tags[foo,number]", "name": "foo", "attributeSource": "user"},
+            {"key": "tags[bar,number]", "name": "bar", "attributeSource": {"source_type": "user"}},
+            {"key": "tags[baz,number]", "name": "baz", "attributeSource": {"source_type": "user"}},
+            {
+                "key": "measurements.fcp",
+                "name": "measurements.fcp",
+                "attributeSource": {"source_type": "sentry"},
+            },
+            {"key": "tags[foo,number]", "name": "foo", "attributeSource": {"source_type": "user"}},
             {
                 "key": "http.decoded_response_content_length",
                 "name": "http.decoded_response_content_length",
-                "attributeSource": "sentry",
+                "attributeSource": {"source_type": "sentry"},
             },
             {
                 "key": "http.response_content_length",
                 "name": "http.response_content_length",
-                "attributeSource": "sentry",
+                "attributeSource": {"source_type": "sentry"},
             },
             {
                 "key": "http.response_transfer_size",
                 "name": "http.response_transfer_size",
-                "attributeSource": "sentry",
+                "attributeSource": {"source_type": "sentry"},
             },
-            {"key": "measurements.lcp", "name": "measurements.lcp", "attributeSource": "sentry"},
-            {"key": "span.duration", "name": "span.duration", "attributeSource": "sentry"},
+            {
+                "key": "measurements.lcp",
+                "name": "measurements.lcp",
+                "attributeSource": {"source_type": "sentry"},
+            },
+            {
+                "key": "span.duration",
+                "name": "span.duration",
+                "attributeSource": {"source_type": "sentry"},
+            },
         ]
 
     @override_options({"explore.trace-items.keys.max": 3})
@@ -411,16 +443,16 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
         assert response.status_code == 200, response.data
 
         expected: list[TraceItemAttributeKey] = [
-            {"key": "bar", "name": "bar", "attributeSource": "user"},
-            {"key": "baz", "name": "baz", "attributeSource": "user"},
-            {"key": "foo", "name": "foo", "attributeSource": "user"},
+            {"key": "bar", "name": "bar", "attributeSource": {"source_type": "user"}},
+            {"key": "baz", "name": "baz", "attributeSource": {"source_type": "user"}},
+            {"key": "foo", "name": "foo", "attributeSource": {"source_type": "user"}},
             {
                 "key": "span.description",
                 "name": "span.description",
-                "attributeSource": "sentry",
+                "attributeSource": {"source_type": "sentry"},
                 "secondaryAliases": ["description", "message"],
             },
-            {"key": "project", "name": "project", "attributeSource": "sentry"},
+            {"key": "project", "name": "project", "attributeSource": {"source_type": "sentry"}},
         ]
 
         assert sorted(
@@ -448,11 +480,15 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
             {
                 "key": "span.description",
                 "name": "span.description",
-                "attributeSource": "sentry",
+                "attributeSource": {"source_type": "sentry"},
                 "secondaryAliases": ["description", "message"],
             },
-            {"key": "transaction", "name": "transaction", "attributeSource": "sentry"},
-            {"key": "project", "name": "project", "attributeSource": "sentry"},
+            {
+                "key": "transaction",
+                "name": "transaction",
+                "attributeSource": {"source_type": "sentry"},
+            },
+            {"key": "project", "name": "project", "attributeSource": {"source_type": "sentry"}},
         ]
         assert sorted(
             response.data,
@@ -476,16 +512,16 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
         assert response.status_code == 200, response.content
 
         expected_3: list[TraceItemAttributeKey] = [
-            {"key": "bar", "name": "bar", "attributeSource": "user"},
-            {"key": "baz", "name": "baz", "attributeSource": "user"},
-            {"key": "foo", "name": "foo", "attributeSource": "user"},
+            {"key": "bar", "name": "bar", "attributeSource": {"source_type": "user"}},
+            {"key": "baz", "name": "baz", "attributeSource": {"source_type": "user"}},
+            {"key": "foo", "name": "foo", "attributeSource": {"source_type": "user"}},
             {
                 "key": "span.description",
                 "name": "span.description",
-                "attributeSource": "sentry",
+                "attributeSource": {"source_type": "sentry"},
                 "secondaryAliases": ["description", "message"],
             },
-            {"key": "project", "name": "project", "attributeSource": "sentry"},
+            {"key": "project", "name": "project", "attributeSource": {"source_type": "sentry"}},
         ]
         assert sorted(
             response.data,
@@ -534,35 +570,51 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
         assert response.status_code == 200, response.data
         assert sorted(response.data, key=itemgetter("key")) == sorted(
             [
-                {"key": "tags[bar,number]", "name": "bar", "attributeSource": "user"},
-                {"key": "tags[baz,number]", "name": "baz", "attributeSource": "user"},
+                {
+                    "key": "tags[bar,number]",
+                    "name": "bar",
+                    "attributeSource": {"source_type": "user"},
+                },
+                {
+                    "key": "tags[baz,number]",
+                    "name": "baz",
+                    "attributeSource": {"source_type": "user"},
+                },
                 {
                     "key": "measurements.fcp",
                     "name": "measurements.fcp",
-                    "attributeSource": "sentry",
+                    "attributeSource": {"source_type": "sentry"},
                 },
-                {"key": "tags[foo,number]", "name": "foo", "attributeSource": "user"},
+                {
+                    "key": "tags[foo,number]",
+                    "name": "foo",
+                    "attributeSource": {"source_type": "user"},
+                },
                 {
                     "key": "http.decoded_response_content_length",
                     "name": "http.decoded_response_content_length",
-                    "attributeSource": "sentry",
+                    "attributeSource": {"source_type": "sentry"},
                 },
                 {
                     "key": "http.response.body.size",
                     "name": "http.response.body.size",
-                    "attributeSource": "sentry",
+                    "attributeSource": {"source_type": "sentry"},
                 },
                 {
                     "key": "http.response.size",
                     "name": "http.response.size",
-                    "attributeSource": "sentry",
+                    "attributeSource": {"source_type": "sentry"},
                 },
                 {
                     "key": "measurements.lcp",
                     "name": "measurements.lcp",
-                    "attributeSource": "sentry",
+                    "attributeSource": {"source_type": "sentry"},
                 },
-                {"key": "span.duration", "name": "span.duration", "attributeSource": "sentry"},
+                {
+                    "key": "span.duration",
+                    "name": "span.duration",
+                    "attributeSource": {"source_type": "sentry"},
+                },
             ],
             key=itemgetter("key"),
         )
@@ -592,20 +644,24 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
             {
                 "key": "span.description",
                 "name": "span.description",
-                "attributeSource": "sentry",
+                "attributeSource": {"source_type": "sentry"},
                 "secondaryAliases": ["description", "message"],
             },
-            {"key": "project", "name": "project", "attributeSource": "sentry"},
-            {"key": "transaction", "name": "transaction", "attributeSource": "sentry"},
+            {"key": "project", "name": "project", "attributeSource": {"source_type": "sentry"}},
+            {
+                "key": "transaction",
+                "name": "transaction",
+                "attributeSource": {"source_type": "sentry"},
+            },
             {
                 "key": "tags[span.duration,string]",
                 "name": "tags[span.duration,string]",
-                "attributeSource": "sentry",
+                "attributeSource": {"source_type": "sentry"},
             },
             {
                 "key": "tags[span.op,string]",
                 "name": "tags[span.op,string]",
-                "attributeSource": "sentry",
+                "attributeSource": {"source_type": "sentry"},
             },
         ]
 

--- a/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
@@ -230,9 +230,11 @@ class OrganizationTraceItemAttributesEndpointLogsTest(
             "tags[message.parameter.1,number]",
             "tags[message.parameter.2,number]",
             "severity_number",
-            "tags[sentry.timestamp_nanos,number]",
+            "observed_timestamp",
             "timestamp_precise",
         }
+        sources = {item["attributeSource"] for item in response.data}
+        assert sources == {"sentry"}
 
     def test_attribute_collision(self) -> None:
         logs = [

--- a/tests/snuba/api/endpoints/test_project_trace_item_details.py
+++ b/tests/snuba/api/endpoints/test_project_trace_item_details.py
@@ -72,7 +72,7 @@ class ProjectTraceItemDetailsEndpointTest(APITestCase, SnubaTestCase, OurLogTest
             {"name": "severity_number", "type": "int", "value": "0"},
             {"name": "tags[int_attr,number]", "type": "int", "value": "2"},
             {
-                "name": "tags[sentry.timestamp_nanos,number]",
+                "name": "observed_timestamp",
                 "type": "int",
                 "value": str(timestamp_nanos),
             },
@@ -128,7 +128,7 @@ class ProjectTraceItemDetailsEndpointTest(APITestCase, SnubaTestCase, OurLogTest
                 {"name": "severity_number", "type": "int", "value": "0"},
                 {"name": "tags[int_attr,number]", "type": "int", "value": "2"},
                 {
-                    "name": "tags[sentry.timestamp_nanos,number]",
+                    "name": "observed_timestamp",
                     "type": "int",
                     "value": str(timestamp_nanos),
                 },
@@ -323,7 +323,7 @@ class ProjectTraceItemDetailsEndpointTest(APITestCase, SnubaTestCase, OurLogTest
                 {"name": "severity_number", "type": "int", "value": "0"},
                 {"name": "tags[int_attr,number]", "type": "int", "value": "2"},
                 {
-                    "name": "tags[sentry.timestamp_nanos,number]",
+                    "name": "observed_timestamp",
                     "type": "int",
                     "value": str(timestamp_nanos),
                 },
@@ -372,7 +372,7 @@ class ProjectTraceItemDetailsEndpointTest(APITestCase, SnubaTestCase, OurLogTest
                 {"name": "project_id", "type": "int", "value": str(self.project.id)},
                 {"name": "severity_number", "type": "int", "value": "0"},
                 {
-                    "name": "tags[sentry.timestamp_nanos,number]",
+                    "name": "observed_timestamp",
                     "type": "int",
                     "value": str(timestamp_nanos),
                 },

--- a/tests/snuba/api/endpoints/test_project_trace_item_details.py
+++ b/tests/snuba/api/endpoints/test_project_trace_item_details.py
@@ -68,14 +68,14 @@ class ProjectTraceItemDetailsEndpointTest(APITestCase, SnubaTestCase, OurLogTest
         assert trace_details_response.data["attributes"] == [
             {"name": "bool_attr", "type": "bool", "value": True},
             {"name": "tags[float_attr,number]", "type": "float", "value": 3.0},
-            {"name": "project_id", "type": "int", "value": str(self.project.id)},
-            {"name": "severity_number", "type": "int", "value": "0"},
-            {"name": "tags[int_attr,number]", "type": "int", "value": "2"},
             {
                 "name": "observed_timestamp",
                 "type": "int",
                 "value": str(timestamp_nanos),
             },
+            {"name": "project_id", "type": "int", "value": str(self.project.id)},
+            {"name": "severity_number", "type": "int", "value": "0"},
+            {"name": "tags[int_attr,number]", "type": "int", "value": "2"},
             {
                 "name": "timestamp_precise",
                 "type": "int",
@@ -124,14 +124,14 @@ class ProjectTraceItemDetailsEndpointTest(APITestCase, SnubaTestCase, OurLogTest
             "attributes": [
                 {"name": "bool_attr", "type": "bool", "value": True},
                 {"name": "tags[float_attr,number]", "type": "float", "value": 3.0},
-                {"name": "project_id", "type": "int", "value": str(self.project.id)},
-                {"name": "severity_number", "type": "int", "value": "0"},
-                {"name": "tags[int_attr,number]", "type": "int", "value": "2"},
                 {
                     "name": "observed_timestamp",
                     "type": "int",
                     "value": str(timestamp_nanos),
                 },
+                {"name": "project_id", "type": "int", "value": str(self.project.id)},
+                {"name": "severity_number", "type": "int", "value": "0"},
+                {"name": "tags[int_attr,number]", "type": "int", "value": "2"},
                 {
                     "name": "timestamp_precise",
                     "type": "int",
@@ -319,14 +319,14 @@ class ProjectTraceItemDetailsEndpointTest(APITestCase, SnubaTestCase, OurLogTest
             "attributes": [
                 {"name": "bool_attr", "type": "bool", "value": True},
                 {"name": "tags[float_attr,number]", "type": "float", "value": 3.0},
-                {"name": "project_id", "type": "int", "value": str(self.project.id)},
-                {"name": "severity_number", "type": "int", "value": "0"},
-                {"name": "tags[int_attr,number]", "type": "int", "value": "2"},
                 {
                     "name": "observed_timestamp",
                     "type": "int",
                     "value": str(timestamp_nanos),
                 },
+                {"name": "project_id", "type": "int", "value": str(self.project.id)},
+                {"name": "severity_number", "type": "int", "value": "0"},
+                {"name": "tags[int_attr,number]", "type": "int", "value": "2"},
                 {
                     "name": "timestamp_precise",
                     "type": "int",
@@ -369,13 +369,13 @@ class ProjectTraceItemDetailsEndpointTest(APITestCase, SnubaTestCase, OurLogTest
         timestamp_nanos = int(self.one_min_ago.timestamp() * 1_000_000_000)
         assert trace_details_response.data == {
             "attributes": [
-                {"name": "project_id", "type": "int", "value": str(self.project.id)},
-                {"name": "severity_number", "type": "int", "value": "0"},
                 {
                     "name": "observed_timestamp",
                     "type": "int",
                     "value": str(timestamp_nanos),
                 },
+                {"name": "project_id", "type": "int", "value": str(self.project.id)},
+                {"name": "severity_number", "type": "int", "value": "0"},
                 {
                     "name": "timestamp_precise",
                     "type": "int",


### PR DESCRIPTION
This returns whether the attribute hit a definition or not, marking it automatically as 'internal'. We can delineate specific non-internal definitions in the future if needed.

