### PR TITLE
chore(aci): Collect request metrics for workflow engine endpoints

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3618,6 +3618,7 @@ SENTRY_REQUEST_METRIC_ALLOWED_PATHS = (
     "sentry.users.api.endpoints",
     "sentry.sentry_apps.api.endpoints",
     "sentry.preprod.api.endpoints",
+    "sentry.workflow_engine.endpoints",
 )
 SENTRY_MAIL_ADAPTER_BACKEND = "sentry.mail.adapter.MailAdapter"
 


### PR DESCRIPTION
I went looking for some request metrics for workflow engine endpoints and couldn't find them. Looks like we need to opt in to get these tracked.