### PR TITLE
ref(uptime): Always query for uptime checks in trace endpoints

### DIFF
--- a/src/sentry/api/endpoints/organization_trace.py
+++ b/src/sentry/api/endpoints/organization_trace.py
@@ -55,11 +55,8 @@ class OrganizationTraceEndpoint(OrganizationEventsV2EndpointBase):
         trace_id: str,
         error_id: str | None = None,
         additional_attributes: list[str] | None = None,
-        include_uptime: bool = False,
     ) -> list[SerializedEvent]:
-        return query_trace_data(
-            snuba_params, trace_id, error_id, additional_attributes, include_uptime
-        )
+        return query_trace_data(snuba_params, trace_id, error_id, additional_attributes)
 
     def has_feature(self, organization: Organization, request: Request) -> bool:
         return bool(
@@ -76,7 +73,6 @@ class OrganizationTraceEndpoint(OrganizationEventsV2EndpointBase):
             return Response(status=404)
 
         additional_attributes = request.GET.getlist("additional_attributes", [])
-        include_uptime = request.GET.get("include_uptime", "0") == "1"
 
         error_id = request.GET.get("errorId")
         if error_id is not None and not is_event_id(error_id):
@@ -88,7 +84,7 @@ class OrganizationTraceEndpoint(OrganizationEventsV2EndpointBase):
                 update_snuba_params_with_timestamp(request, snuba_params)
 
                 spans = self.query_trace_data(
-                    snuba_params, trace_id, error_id, additional_attributes, include_uptime
+                    snuba_params, trace_id, error_id, additional_attributes
                 )
             return spans
 

--- a/tests/snuba/api/endpoints/test_organization_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_trace.py
@@ -583,7 +583,7 @@ class OrganizationEventsTraceEndpointTest(
         return span
 
     def test_with_uptime_results(self):
-        """Test that uptime results are included when include_uptime=1"""
+        """Test that uptime results are always included"""
         self.load_trace(is_eap=True)
 
         features = self.FEATURES + [
@@ -622,7 +622,7 @@ class OrganizationEventsTraceEndpointTest(
 
         with self.feature(features):
             response = self.client_get(
-                data={"timestamp": self.day_ago, "include_uptime": "1"},
+                data={"timestamp": self.day_ago},
             )
 
         assert response.status_code == 200, response.content
@@ -632,23 +632,9 @@ class OrganizationEventsTraceEndpointTest(
             data, [redirect_result, final_result], expected_children_ids=["root"]
         )
 
-    def test_without_uptime_results(self):
-        """Test that uptime results are not queried when include_uptime is not set"""
+    def test_trace_without_uptime_data(self):
+        """Test trace response when no uptime results exist for the trace"""
         self.load_trace(is_eap=True)
-        uptime_result = self._create_uptime_result_with_original_url(
-            organization=self.organization,
-            project=self.project,
-            trace_id=self.trace_id,
-            guid="check-456",
-            subscription_id="sub-789",
-            check_status="success",
-            http_status_code=200,
-            request_sequence=0,
-            request_url="https://test.com",
-            scheduled_check_time=self.day_ago,
-        )
-
-        self.store_uptime_results([uptime_result])
 
         with self.feature(self.FEATURES):
             response = self.client_get(
@@ -710,7 +696,7 @@ class OrganizationEventsTraceEndpointTest(
 
         with self.feature(features):
             response = self.client_get(
-                data={"timestamp": self.day_ago, "include_uptime": "1"},
+                data={"timestamp": self.day_ago},
             )
 
         assert response.status_code == 200, response.content
@@ -748,7 +734,7 @@ class OrganizationEventsTraceEndpointTest(
 
         with self.feature(features):
             response = self.client_get(
-                data={"timestamp": self.day_ago, "include_uptime": "1"},
+                data={"timestamp": self.day_ago},
             )
 
         assert response.status_code == 200, response.content


### PR DESCRIPTION
Removes the query parameter and just always tries to query for the
uptime check as the root trace item

Let's not merge this quiet yet since we should make sure the UI is in a good place to support this.