### PR TITLE
feat(autofix): Send tags overview to Seer

### DIFF
--- a/src/sentry/seer/autofix/autofix.py
+++ b/src/sentry/seer/autofix/autofix.py
@@ -13,10 +13,11 @@ from django.contrib.auth.models import AnonymousUser
 from django.utils import timezone
 from rest_framework.response import Response
 
-from sentry import eventstore, features, quotas
+from sentry import eventstore, features, quotas, tagstore
 from sentry.api.endpoints.organization_trace import OrganizationTraceEndpoint
 from sentry.api.serializers import EventSerializer, serialize
 from sentry.constants import DataCategory, ObjectStatus
+from sentry.models.environment import Environment
 from sentry.models.group import Group
 from sentry.models.project import Project
 from sentry.search.eap.types import SearchResolverConfig
@@ -319,6 +320,105 @@ def _get_profile_from_trace_tree(
     return None
 
 
+def _get_all_tags_overview(group: Group) -> dict[str, Any] | None:
+    """
+    Get high-level overview of all tags for an issue.
+    Returns aggregated tag data with percentages for all tags.
+    """
+    environment_ids = list(
+        Environment.objects.filter(organization_id=group.project.organization_id).values_list(
+            "id", flat=True
+        )
+    )
+
+    tag_keys = tagstore.backend.get_group_tag_keys_and_top_values(
+        group,
+        environment_ids,
+        keys=None,  # Get all tags
+        value_limit=3,  # Get top 3 values per tag
+        tenant_ids={"organization_id": group.project.organization_id},
+    )
+
+    all_tags: list[dict] = []
+
+    KEYS_TO_EXCLUDE = ["release"]  # tags we think are useless for Autofix
+    for tag in tag_keys:
+        if tag.key in KEYS_TO_EXCLUDE:
+            continue
+
+        # Calculate percentages for each tag value
+        tag_data = {
+            "key": tag.key,
+            "name": tagstore.backend.get_tag_key_label(tag.key),
+            "total_values": tag.count,
+            "unique_values": getattr(tag, "values_seen", 0),
+            "top_values": [],
+        }
+
+        if hasattr(tag, "top_values") and tag.top_values:
+            # Calculate total from top values
+            top_values_total = sum(tag_value.times_seen for tag_value in tag.top_values)
+
+            for tag_value in tag.top_values:
+                percentage = round((tag_value.times_seen / tag.count) * 100) if tag.count > 0 else 0
+
+                # Ensure no single value shows 100% when there are multiple values
+                has_multiple_values = len(tag.top_values) > 1 or top_values_total < tag.count
+                if has_multiple_values and percentage >= 100:
+                    percentage = ">99"
+                elif percentage < 1:
+                    percentage = "<1"
+
+                tag_data["top_values"].append(
+                    {
+                        "value": tag_value.value,
+                        "count": tag_value.times_seen,
+                        "percentage": (
+                            f"{percentage}%" if isinstance(percentage, (int, float)) else percentage
+                        ),
+                    }
+                )
+
+            # Add "other" category if there are more values than the top values shown
+            if top_values_total < tag.count:
+                other_count = tag.count - top_values_total
+                other_percentage = round((other_count / tag.count) * 100) if tag.count > 0 else 0
+
+                # Apply the same percentage formatting rules
+                if other_percentage < 1:
+                    other_percentage_str = "<1%"
+                elif len(tag.top_values) > 0 and other_percentage >= 100:
+                    other_percentage_str = ">99%"
+                else:
+                    other_percentage_str = f"{other_percentage}%"
+
+                tag_data["top_values"].append(
+                    {
+                        "value": "other",
+                        "count": other_count,
+                        "percentage": other_percentage_str,
+                    }
+                )
+
+        if tag_data["top_values"]:  # Only include tags that have values
+            all_tags.append(tag_data)
+
+    logger.info(
+        "[Autofix] Retrieved all tags overview",
+        extra={
+            "group_id": group.id,
+            "org_slug": group.project.organization.slug,
+            "project_slug": group.project.slug,
+            "total_tags_count": len(all_tags),
+            "total_tags_checked": len(tag_keys),
+            "tag_overview": all_tags[:5],  # only log up to the first 5 results
+        },
+    )
+    return {
+        "tags_overview": all_tags,
+    }
+
+
 def _respond_with_error(reason: str, status: int):
     return Response(
         {
@@ -337,6 +437,7 @@ def _call_autofix(
     profile: dict[str, Any] | None,
     trace_tree: dict[str, Any] | None,
     logs: dict[str, list[dict]] | None,
+    tags_overview: dict[str, Any] | None,
     instruction: str | None = None,
     timeout_secs: int = TIMEOUT_SECONDS,
     pr_to_comment_on_url: str | None = None,
@@ -358,6 +459,7 @@ def _call_autofix(
             "profile": profile,
             "trace_tree": trace_tree,
             "logs": logs,
+            "tags_overview": tags_overview,
             "instruction": instruction,
             "timeout_secs": timeout_secs,
             "last_updated": datetime.now().isoformat(),
@@ -466,6 +568,13 @@ def trigger_autofix(
         logger.exception("Failed to get logs for event")
         logs = None
 
+    # get all tags overview for this issue
+    try:
+        tags_overview = _get_all_tags_overview(group)
+    except Exception:
+        logger.exception("Failed to get tags overview")
+        tags_overview = None
+
     try:
         run_id = _call_autofix(
             user=user,
@@ -475,6 +584,7 @@ def trigger_autofix(
             profile=profile,
             trace_tree=trace_tree,
             logs=logs,
+            tags_overview=tags_overview,
             instruction=instruction,
             timeout_secs=TIMEOUT_SECONDS,
             pr_to_comment_on_url=pr_to_comment_on_url,

--- a/tests/sentry/seer/autofix/test_autofix.py
+++ b/tests/sentry/seer/autofix/test_autofix.py
@@ -8,6 +8,7 @@ from django.contrib.auth.models import AnonymousUser
 from sentry.seer.autofix.autofix import (
     TIMEOUT_SECONDS,
     _call_autofix,
+    _get_all_tags_overview,
     _get_logs_for_event,
     _get_profile_from_trace_tree,
     _get_trace_tree_for_event,
@@ -593,6 +594,130 @@ class TestGetProfileFromTraceTree(APITestCase, SnubaTestCase):
         assert profile_result is None
 
 
+@pytest.mark.django_db
+class TestGetAllTagsOverview(TestCase, SnubaTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+
+        # Create events with real tag data
+        # Event 1: production environment with user_role admin
+        self.store_event(
+            data={
+                "fingerprint": ["group-1"],
+                "environment": "production",
+                "tags": {"user_role": "admin", "service": "api"},
+                "timestamp": before_now(minutes=1).isoformat(),
+            },
+            project_id=self.project.id,
+        )
+
+        # Event 2: production environment with user_role admin (duplicate to test counts)
+        event2 = self.store_event(
+            data={
+                "fingerprint": ["group-1"],
+                "environment": "production",
+                "tags": {"user_role": "admin", "service": "web"},
+                "timestamp": before_now(minutes=2).isoformat(),
+            },
+            project_id=self.project.id,
+        )
+
+        # Event 3: staging environment with user_role user
+        self.store_event(
+            data={
+                "fingerprint": ["group-1"],
+                "environment": "staging",
+                "tags": {"user_role": "user", "service": "api"},
+                "timestamp": before_now(minutes=3).isoformat(),
+            },
+            project_id=self.project.id,
+        )
+
+        # Event 4: development environment with user_role user
+        self.store_event(
+            data={
+                "fingerprint": ["group-1"],
+                "environment": "development",
+                "tags": {"user_role": "user", "service": "worker"},
+                "timestamp": before_now(minutes=4).isoformat(),
+            },
+            project_id=self.project.id,
+        )
+
+        self.group = event2.group
+
+    def test_get_all_tags_overview_basic(self) -> None:
+        """Test basic functionality of getting all tags overview with real data."""
+        result = _get_all_tags_overview(self.group)
+
+        assert result is not None
+        assert "tags_overview" in result
+
+        # Should have environment, user_role, service, and level tags at minimum
+        assert len(result["tags_overview"]) >= 4
+
+        # Find specific tags
+        tag_keys = {tag["key"]: tag for tag in result["tags_overview"]}
+
+        # Check environment tag (built-in Sentry tag)
+        assert "environment" in tag_keys
+        env_tag = tag_keys["environment"]
+        assert env_tag["name"] == "Environment"
+        assert env_tag["total_values"] == 4  # 4 events
+
+        # Should have production (2), staging (1), development (1)
+        env_values = {val["value"]: val for val in env_tag["top_values"]}
+        assert "production" in env_values
+        assert env_values["production"]["count"] == 2
+        assert env_values["production"]["percentage"] == "50%"
+
+        # Check custom tag
+        assert "user_role" in tag_keys
+        user_tag = tag_keys["user_role"]
+        assert user_tag["name"] == "User Role"  # Should get proper label
+        assert user_tag["total_values"] == 4
+
+        user_values = {val["value"]: val for val in user_tag["top_values"]}
+        assert "admin" in user_values
+        assert "user" in user_values
+        assert user_values["admin"]["count"] == 2
+        assert user_values["user"]["count"] == 2
+
+    def test_get_all_tags_overview_percentage_calculation(self) -> None:
+        """Test that percentage calculations work correctly."""
+        result = _get_all_tags_overview(self.group)
+
+        assert result is not None
+
+        # Find environment tag (we know this exists from setUp)
+        env_tag = next(
+            (tag for tag in result["tags_overview"] if tag["key"] == "environment"), None
+        )
+        assert env_tag is not None
+        assert env_tag["total_values"] == 4  # 4 events from setUp
+
+        # Check that percentages add up correctly
+        env_values = {val["value"]: val for val in env_tag["top_values"]}
+
+        # Verify percentage calculation for known values
+        # Production should be 2/4 = 50%
+        assert "production" in env_values
+        production_val = env_values["production"]
+        assert production_val["count"] == 2
+        assert production_val["percentage"] == "50%"
+
+        # Development and staging should each be 1/4 = 25%
+        assert "development" in env_values
+        dev_val = env_values["development"]
+        assert dev_val["count"] == 1
+        assert dev_val["percentage"] == "25%"
+
+        assert "staging" in env_values
+        staging_val = env_values["staging"]
+        assert staging_val["count"] == 1
+        assert staging_val["percentage"] == "25%"
+
+
 @requires_snuba
 @pytest.mark.django_db
 @with_feature("organizations:gen-ai-features")
@@ -603,6 +728,7 @@ class TestTriggerAutofix(APITestCase, SnubaTestCase):
 
         self.organization.update_option("sentry:gen_ai_consent_v2024_11_14", True)
 
+    @patch("sentry.seer.autofix.autofix._get_all_tags_overview")
     @patch("sentry.seer.autofix.autofix._get_profile_from_trace_tree")
     @patch("sentry.seer.autofix.autofix._get_trace_tree_for_event")
     @patch("sentry.seer.autofix.autofix._call_autofix")
@@ -613,12 +739,14 @@ class TestTriggerAutofix(APITestCase, SnubaTestCase):
         mock_call,
         mock_get_trace,
         mock_get_profile,
+        mock_get_tags,
         mock_get_seer_org_acknowledgement,
     ):
         """Tests triggering autofix with a specified event_id."""
         # Setup test data
         mock_get_profile.return_value = {"profile_data": "test"}
         mock_get_trace.return_value = {"trace_data": "test"}
+        mock_get_tags.return_value = {"tags_overview": [{"key": "test_tag", "top_values": []}]}
 
         # Create an event with a stacktrace
         data = load_data("python", timestamp=before_now(minutes=1))
@@ -658,6 +786,9 @@ class TestTriggerAutofix(APITestCase, SnubaTestCase):
         assert call_kwargs["group"] == group
         assert call_kwargs["profile"] == {"profile_data": "test"}
         assert call_kwargs["trace_tree"] == {"trace_data": "test"}
+        assert call_kwargs["tags_overview"] == {
+            "tags_overview": [{"key": "test_tag", "top_values": []}]
+        }
         assert call_kwargs["instruction"] == "Test instruction"
         assert call_kwargs["timeout_secs"] == TIMEOUT_SECONDS
         assert call_kwargs["pr_to_comment_on_url"] == "https://github.com/getsentry/sentry/pull/123"
@@ -804,6 +935,7 @@ class TestCallAutofix(TestCase):
         profile = {"profile_data": "test"}
         trace_tree = {"trace_data": "test"}
         logs = {"logs": [{"message": "test-log"}]}
+        tags_overview = {"tags": [{"key": "environment", "top_values": []}]}
         instruction = "Test instruction"
 
         # Call the function with keyword arguments
@@ -815,6 +947,7 @@ class TestCallAutofix(TestCase):
             profile=profile,
             trace_tree=trace_tree,
             logs=logs,
+            tags_overview=tags_overview,
             instruction=instruction,
             timeout_secs=TIMEOUT_SECONDS,
             pr_to_comment_on_url="https://github.com/getsentry/sentry/pull/123",
@@ -840,6 +973,8 @@ class TestCallAutofix(TestCase):
         assert body["issue"]["events"] == [serialized_event]
         assert body["profile"] == profile
         assert body["trace_tree"] == trace_tree
+        assert body["logs"] == logs
+        assert body["tags_overview"] == tags_overview
         assert body["instruction"] == "Test instruction"
         assert body["timeout_secs"] == TIMEOUT_SECONDS
         assert body["invoking_user"]["id"] == 123


### PR DESCRIPTION
Get a distribution (count + percentage) of values for each tag on an issue. Send this in the autofix request. Will follow up on the Seer side to include this data in the prompt.