### PR TITLE
feat(insights): add `open in issues` to frontend issues widget

### DIFF
--- a/static/app/views/insights/common/components/overviewIssuesWidget.tsx
+++ b/static/app/views/insights/common/components/overviewIssuesWidget.tsx
@@ -6,9 +6,9 @@ import {Tooltip} from 'sentry/components/core/tooltip';
 import {type MenuItemProps} from 'sentry/components/dropdownMenu';
 import TextOverflow from 'sentry/components/textOverflow';
 import TimeSince from 'sentry/components/timeSince';
-import {useOrganization} from 'sentry/contexts/organization';
 import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
+import useOrganization from 'sentry/utils/useOrganization';
 import {WidgetFrame} from 'sentry/views/dashboards/widgetCard/widgetFrame';
 import type {
   TabularColumn,

--- a/static/app/views/insights/common/components/overviewIssuesWidget.tsx
+++ b/static/app/views/insights/common/components/overviewIssuesWidget.tsx
@@ -83,7 +83,7 @@ export function OverviewIssuesWidget() {
 
   return (
     <WidgetFrame
-      title="Issues"
+      title="Recommended Issues"
       actions={menuItems}
       onFullScreenViewClick={handleFullScreenViewClick}
       noVisualizationPadding

--- a/static/app/views/insights/common/components/overviewIssuesWidget.tsx
+++ b/static/app/views/insights/common/components/overviewIssuesWidget.tsx
@@ -6,6 +6,7 @@ import {Tooltip} from 'sentry/components/core/tooltip';
 import {type MenuItemProps} from 'sentry/components/dropdownMenu';
 import TextOverflow from 'sentry/components/textOverflow';
 import TimeSince from 'sentry/components/timeSince';
+import {useOrganization} from 'sentry/contexts/organization';
 import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {WidgetFrame} from 'sentry/views/dashboards/widgetCard/widgetFrame';
@@ -34,6 +35,7 @@ const ALIASES: Record<string, string> = {
 const WIDGET_LIMIT = 4;
 
 export function OverviewIssuesWidget() {
+  const organization = useOrganization();
   const {data, meta, isLoading} = useErrors(
     {
       fields: [ErrorField.ISSUE_ID, ErrorField.TITLE, 'last_seen()', 'epm()'],
@@ -63,7 +65,7 @@ export function OverviewIssuesWidget() {
     {
       key: 'open-in-issues',
       label: 'Open in Issues',
-      to: '/organizations/sentry/issues/',
+      to: normalizeUrl(`/organizations/${organization.slug}/issues/`),
     },
   ];
 


### PR DESCRIPTION
Add `open in issues` and `fullscreen` button to issues widget on frontend overview
<img width="419" height="333" alt="image" src="https://github.com/user-attachments/assets/1161db7c-ed98-420a-b229-cd8d5fb10f4e" />
