### PR TITLE
fix(logs): Breakpoint for sidebar styles

### DIFF
--- a/static/app/views/explore/logs/styles.tsx
+++ b/static/app/views/explore/logs/styles.tsx
@@ -409,7 +409,7 @@ export const LogsSidebarCollapseButton = withChonk(
     margin-left: -31px;
     display: none;
 
-    @media (min-width: ${p => p.theme.breakpoints.md}) {
+    @media (min-width: ${p => p.theme.breakpoints.lg}) {
       display: block;
     }
   `,
@@ -418,7 +418,7 @@ export const LogsSidebarCollapseButton = withChonk(
     display: none;
     margin-left: -31px;
 
-    @media (min-width: ${p => p.theme.breakpoints.md}) {
+    @media (min-width: ${p => p.theme.breakpoints.lg}) {
       display: inline-flex;
     }
 

--- a/static/app/views/explore/logs/styles.tsx
+++ b/static/app/views/explore/logs/styles.tsx
@@ -380,7 +380,7 @@ export const ToolbarContainer = styled('div')<{sidebarOpen: boolean}>`
   border-right: 1px solid ${p => p.theme.border};
   border-top: 1px solid ${p => p.theme.border};
 
-  @media (min-width: ${p => p.theme.breakpoints.md}) {
+  @media (min-width: ${p => p.theme.breakpoints.lg}) {
     border-bottom: none;
     ${p =>
       p.sidebarOpen


### PR DESCRIPTION
The breakpoint here is wrong and needs to be lg to be in sync with when the page layout shifts to accomodate for smaller screens.