### PR TITLE
feat(dashboards): add open in explore referrer query parameter

### DIFF
--- a/static/app/views/dashboards/utils/getWidgetExploreUrl.spec.tsx
+++ b/static/app/views/dashboards/utils/getWidgetExploreUrl.spec.tsx
@@ -259,6 +259,48 @@ describe('getWidgetExploreUrl', () => {
     expect(query2.groupBys).toEqual(['span.description']);
     expect(query2.query).toBe('is_transaction:false');
   });
+
+  it('adds referrer query parameter if provided', () => {
+    const widget = WidgetFixture({
+      displayType: DisplayType.LINE,
+      queries: [
+        {
+          fields: [],
+          aggregates: ['avg(span.duration)'],
+          columns: ['span.description'],
+          conditions: 'span.description:test',
+          orderby: '-avg(span.duration)',
+          name: '',
+        },
+      ],
+    });
+
+    const url = getWidgetExploreUrl(
+      widget,
+      {},
+      selection,
+      organization,
+      undefined,
+      'test-referrer'
+    );
+
+    // Assert that the query contains the dashboard filters in its resulting URL
+    expectUrl(url).toMatch({
+      path: '/organizations/org-slug/traces/',
+      params: [
+        ['field', 'span.description'],
+        ['field', 'span.duration'],
+        ['groupBy', 'span.description'],
+        ['interval', '30m'],
+        ['mode', 'aggregate'],
+        ['query', 'span.description:test'],
+        ['sort', '-avg(span.duration)'],
+        ['statsPeriod', '14d'],
+        ['visualize', JSON.stringify({chartType: 1, yAxes: ['avg(span.duration)']})],
+        ['referrer', 'test-referrer'],
+      ],
+    });
+  });
 });
 
 function expectUrl(url: string) {

--- a/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
@@ -19,7 +19,7 @@ import {DEFAULT_TABLE_LIMIT, DisplayType} from 'sentry/views/dashboards/types';
 import {dashboardFiltersToString} from 'sentry/views/dashboards/utils';
 import type {SamplingMode} from 'sentry/views/explore/hooks/useProgressiveQuery';
 
-function getReferrer(displayType: DisplayType) {
+export function getReferrer(displayType: DisplayType) {
   let referrer = '';
 
   if (displayType === DisplayType.TABLE) {

--- a/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
@@ -41,6 +41,7 @@ import {
   getWidgetExploreUrl,
   getWidgetLogURL,
 } from 'sentry/views/dashboards/utils/getWidgetExploreUrl';
+import {getReferrer} from 'sentry/views/dashboards/widgetCard/genericWidgetQueries';
 import {WidgetViewerContext} from 'sentry/views/dashboards/widgetViewer/widgetViewerContext';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 
@@ -369,7 +370,8 @@ export function getMenuOptions(
         dashboardFilters,
         selection,
         organization,
-        Mode.SAMPLES
+        Mode.SAMPLES,
+        getReferrer(widget.displayType)
       ),
     });
   }
@@ -378,7 +380,13 @@ export function getMenuOptions(
     menuOptions.push({
       key: 'open-in-explore',
       label: t('Open in Explore'),
-      to: getWidgetLogURL(widget, dashboardFilters, selection, organization),
+      to: getWidgetLogURL(
+        widget,
+        dashboardFilters,
+        selection,
+        organization,
+        getReferrer(widget.displayType)
+      ),
     });
   }
 

--- a/static/app/views/explore/utils.tsx
+++ b/static/app/views/explore/utils.tsx
@@ -193,12 +193,14 @@ export function getExploreMultiQueryUrl({
   queries,
   title,
   id,
+  referrer,
 }: {
   interval: string;
   organization: Organization;
   queries: ReadableExploreQueryParts[];
   selection: PageFilters;
   id?: number;
+  referrer?: string;
   title?: string;
 }) {
   const {start, end, period: statsPeriod, utc} = selection.datetime;
@@ -223,6 +225,7 @@ export function getExploreMultiQueryUrl({
     title,
     id,
     utc,
+    referrer,
   };
 
   return `/organizations/${organization.slug}/explore/traces/compare/?${qs.stringify(queryParams, {skipNull: true})}`;


### PR DESCRIPTION
### Changes

Adds a `referrer` query parameter when a user goes from dashboards -> explore from the dropdown menu. No visual changes.