### PR TITLE
feat(dashboards-limit): Update message to include link to billing

### DIFF
--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
@@ -264,7 +264,7 @@ function AddToDashboardModal({
           value: 'new',
           disabled: hasReachedDashboardLimit || isLoading,
           tooltip: hasReachedDashboardLimit ? limitMessage : undefined,
-          tooltipOptions: {position: 'right'},
+          tooltipOptions: {position: 'right', isHoverable: true},
         },
         ...dashboards
           .filter(dashboard =>

--- a/static/app/views/dashboards/controls.tsx
+++ b/static/app/views/dashboards/controls.tsx
@@ -23,6 +23,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {useUser} from 'sentry/utils/useUser';
 import {useUserTeams} from 'sentry/utils/useUserTeams';
 import {DASHBOARD_SAVING_MESSAGE} from 'sentry/views/dashboards/constants';
+import {DashboardCreateLimitWrapper} from 'sentry/views/dashboards/createLimitWrapper';
 import EditAccessSelector from 'sentry/views/dashboards/editAccessSelector';
 import {DataSet} from 'sentry/views/dashboards/widgetBuilder/utils';
 
@@ -134,17 +135,31 @@ function Controls({
     return (
       <StyledButtonBar key="preview-controls">
         {renderCancelButton(t('Go Back'))}
-        <Button
-          data-test-id="dashboard-commit"
-          size="sm"
-          onClick={e => {
-            e.preventDefault();
-            onCommit();
-          }}
-          priority="primary"
-        >
-          {t('Add Dashboard')}
-        </Button>
+
+        <DashboardCreateLimitWrapper>
+          {({
+            hasReachedDashboardLimit,
+            isLoading: isLoadingDashboardsLimit,
+            limitMessage,
+          }) => (
+            <Button
+              data-test-id="dashboard-commit"
+              size="sm"
+              onClick={e => {
+                e.preventDefault();
+                onCommit();
+              }}
+              priority="primary"
+              disabled={hasReachedDashboardLimit || isLoadingDashboardsLimit}
+              title={limitMessage}
+              tooltipProps={{
+                isHoverable: true,
+              }}
+            >
+              {t('Add Dashboard')}
+            </Button>
+          )}
+        </DashboardCreateLimitWrapper>
       </StyledButtonBar>
     );
   }

--- a/static/app/views/dashboards/manage/index.tsx
+++ b/static/app/views/dashboards/manage/index.tsx
@@ -582,6 +582,9 @@ function ManageDashboards() {
                               hasReachedDashboardLimit || isLoadingDashboardsLimit
                             }
                             title={limitMessage}
+                            tooltipProps={{
+                              isHoverable: true,
+                            }}
                           >
                             {t('Create Dashboard')}
                           </Button>

--- a/static/app/views/dashboards/manage/templateCard.tsx
+++ b/static/app/views/dashboards/manage/templateCard.tsx
@@ -45,6 +45,9 @@ function TemplateCard({title, description, onPreview, onAdd}: Props) {
               busy={isAddingDashboardTemplate}
               disabled={hasReachedDashboardLimit || isLoadingDashboardsLimit}
               title={limitMessage}
+              tooltipProps={{
+                isHoverable: true,
+              }}
             >
               {t('Add Dashboard')}
             </StyledButton>

--- a/static/gsApp/hooks/dashboardsLimit.spec.tsx
+++ b/static/gsApp/hooks/dashboardsLimit.spec.tsx
@@ -115,7 +115,7 @@ describe('useDashboardsLimit', () => {
     expect(
       screen.getByText(
         textWithMarkupMatcher(
-          'You have reached the dashboard limit (0) for your plan. Upgrade to create more dashboards.'
+          'You have reached the maximum number of Dashboards available on your plan. To add more, upgrade your plan'
         )
       )
     ).toBeInTheDocument();
@@ -206,7 +206,7 @@ describe('useDashboardsLimit', () => {
     expect(
       screen.getByText(
         textWithMarkupMatcher(
-          'You have reached the dashboard limit (3) for your plan. Upgrade to create more dashboards.'
+          'You have reached the maximum number of Dashboards available on your plan. To add more, upgrade your plan'
         )
       )
     ).toBeInTheDocument();
@@ -252,7 +252,7 @@ describe('useDashboardsLimit', () => {
     expect(
       screen.getByText(
         textWithMarkupMatcher(
-          'You have reached the dashboard limit (2) for your plan. Upgrade to create more dashboards.'
+          'You have reached the maximum number of Dashboards available on your plan. To add more, upgrade your plan'
         )
       )
     ).toBeInTheDocument();
@@ -356,7 +356,7 @@ describe('useDashboardsLimit', () => {
     expect(
       screen.getByText(
         textWithMarkupMatcher(
-          'You have reached the dashboard limit (0) for your plan. Upgrade to create more dashboards.'
+          'You have reached the maximum number of Dashboards available on your plan. To add more, upgrade your plan'
         )
       )
     ).toBeInTheDocument();

--- a/static/gsApp/hooks/dashboardsLimit.tsx
+++ b/static/gsApp/hooks/dashboardsLimit.tsx
@@ -1,6 +1,7 @@
 import {Fragment} from 'react';
+import {Link} from 'react-router-dom';
 
-import {tct} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import type {DashboardListItem} from 'sentry/views/dashboards/types';
@@ -63,8 +64,10 @@ export function useDashboardsLimit(): UseDashboardsLimitResult {
     dashboardsLimit === 0;
   const limitMessage = hasReachedDashboardLimit
     ? tct(
-        'You have reached the dashboard limit ([dashboardsLimit]) for your plan. Upgrade to create more dashboards.',
-        {dashboardsLimit}
+        'You have reached the maximum number of Dashboards available on your plan. To add more, [link:upgrade your plan]',
+        {
+          link: <Link to={`/settings/billing/checkout/`}>{t('upgrade your plan')}</Link>,
+        }
       )
     : null;
 


### PR DESCRIPTION
Updates the message, as well as wraps an "Add Dashboard" button that I missed with the limit wrapper.