### PR TITLE
feat(search): add occurrence_type_id and subtitle to issue platform snuba config

### DIFF
--- a/src/sentry/snuba/events.py
+++ b/src/sentry/snuba/events.py
@@ -63,6 +63,14 @@ class Columns(Enum):
         issue_platform_name="occurrence_id",
         alias="occurrence_id",
     )
+    OCCURRENCE_TYPE_ID = Column(
+        group_name=None,
+        event_name=None,
+        transaction_name=None,
+        discover_name=None,
+        issue_platform_name="occurrence_type_id",
+        alias="occurrence_type_id",
+    )
     PROJECT_ID = Column(
         group_name="events.project_id",
         event_name="project_id",
@@ -149,6 +157,14 @@ class Columns(Enum):
         discover_name="title",
         issue_platform_name="search_title",
         alias="title",
+    )
+    SUBTITLE = Column(
+        group_name=None,
+        event_name=None,
+        transaction_name=None,
+        discover_name=None,
+        issue_platform_name="subtitle",
+        alias="subtitle",
     )
     TYPE = Column(
         group_name="events.type",


### PR DESCRIPTION
For replay summaries we are writing a query that selects columns `occurrence_type_id` and `subtitle` from issue platform dataset. I found from local testing that these are resolved to tags:
<img width="1366" height="408" alt="image" src="https://github.com/user-attachments/assets/a4a304f9-6d9f-45d5-96dc-08959f4fb137" />

Adding these to the `Columns` enum will cause them to resolve correctly.