### PR TITLE
chore(ACI): Add logging to investigate metric issue resolve bug

### DIFF
--- a/src/sentry/issues/status_change_consumer.py
+++ b/src/sentry/issues/status_change_consumer.py
@@ -270,7 +270,7 @@ def process_status_change_message(
     ):
         logger.info(
             "status_change.kwargs",
-            extra=kwargs,
+            extra=kwargs["status_change"],
         )
 
     txn.set_tag("organization_id", organization.id)

--- a/src/sentry/issues/status_change_consumer.py
+++ b/src/sentry/issues/status_change_consumer.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from sentry_sdk.tracing import NoOpSpan, Span, Transaction
 
+from sentry import features
 from sentry.integrations.tasks.kick_off_status_syncs import kick_off_status_syncs
 from sentry.issues.escalating.escalating import manage_issue_states
 from sentry.issues.status_change_message import StatusChangeMessageData
@@ -262,6 +263,15 @@ def process_status_change_message(
 
     project = Project.objects.get_from_cache(id=status_change_data["project_id"])
     organization = Organization.objects.get_from_cache(id=project.organization_id)
+
+    if features.has(
+        "organizations:workflow-engine-metric-alert-dual-processing-logs",
+        organization,
+    ):
+        logger.info(
+            "status_change.kwargs",
+            extra=kwargs,
+        )
 
     txn.set_tag("organization_id", organization.id)
     txn.set_tag("organization_slug", organization.slug)

--- a/src/sentry/workflow_engine/handlers/workflow/workflow_status_update_handler.py
+++ b/src/sentry/workflow_engine/handlers/workflow/workflow_status_update_handler.py
@@ -38,7 +38,7 @@ def workflow_status_update_handler(
     detector_id = status_change_message.get("detector_id")
 
     if detector_id is None:
-        # We should not hit this case, i should only occur if there is a bug
+        # We should not hit this case, it should only occur if there is a bug
         # passing it from the workflow_engine to the issue platform.
         metrics.incr("workflow_engine.tasks.error.no_detector_id")
         if features.has(

--- a/tests/sentry/workflow_engine/test_task.py
+++ b/tests/sentry/workflow_engine/test_task.py
@@ -65,7 +65,7 @@ class WorkflowStatusUpdateHandlerTests(TestCase):
 
         with mock.patch("sentry.workflow_engine.tasks.workflows.metrics.incr") as mock_incr:
             workflow_status_update_handler(group, message, activity)
-            mock_incr.assert_called_with("workflow_engine.tasks.error.no_detector_id")
+            mock_incr.assert_any_call("workflow_engine.tasks.error.no_detector_id")
 
     def test__feature_flag(self) -> None:
         detector = self.create_detector(project=self.project)


### PR DESCRIPTION
We have entries for this [metric that shouldn't happen](https://github.com/getsentry/sentry/blob/master/src/sentry/workflow_engine/handlers/workflow/workflow_status_update_handler.py#L35-L38) and aren't sure how it's getting into that state. Add logging to help understand where the detector ID might be dropping off. 