### PR TITLE
:bug: fix: stop sentry app tasks from emitting NoRetriesRemainingErrors

### DIFF
--- a/src/sentry/sentry_apps/tasks/sentry_apps.py
+++ b/src/sentry/sentry_apps/tasks/sentry_apps.py
@@ -103,6 +103,7 @@ retry_decorator = retry(
         NoRetriesRemainingError,
     ),
     ignore_and_capture=(),
+    raise_on_no_retries=False,
 )
 
 # We call some models by a different name, publicly, than their class name.

--- a/src/sentry/tasks/base.py
+++ b/src/sentry/tasks/base.py
@@ -221,6 +221,7 @@ def retry(
     ignore: type[Exception] | tuple[type[Exception], ...] = (),
     ignore_and_capture: type[Exception] | tuple[type[Exception], ...] = (),
     timeouts: bool = False,
+    raise_on_no_retries: bool = True,
 ) -> Callable[..., Callable[..., Any]]:
     """
     >>> @retry(on=(Exception,), exclude=(AnotherException,), ignore=(IgnorableException,))
@@ -261,7 +262,7 @@ def retry(
                                 task_state.taskname,
                             ]
                         sentry_sdk.capture_exception(level="info")
-                    retry_task()
+                    retry_task(raise_on_no_retries=raise_on_no_retries)
                 else:
                     raise
             except ignore_and_capture:
@@ -271,10 +272,10 @@ def retry(
                 raise
             except on_silent as exc:
                 logger.info("silently retrying %s due to %s", func.__name__, exc)
-                retry_task(exc)
+                retry_task(exc, raise_on_no_retries=raise_on_no_retries)
             except on as exc:
                 sentry_sdk.capture_exception()
-                retry_task(exc)
+                retry_task(exc, raise_on_no_retries=raise_on_no_retries)
 
         return wrapped
 

--- a/src/sentry/taskworker/retry.py
+++ b/src/sentry/taskworker/retry.py
@@ -59,9 +59,12 @@ def retry_task(exc: Exception | None = None, raise_on_no_retries: bool = True) -
         assert False, "unreachable"
     else:
         current = taskworker_current_task()
-        if current and not current.retries_remaining and raise_on_no_retries:
+        if current and not current.retries_remaining:
             metrics.incr("taskworker.retry.no_retries_remaining")
-            raise NoRetriesRemainingError()
+            if raise_on_no_retries:
+                raise NoRetriesRemainingError()
+            else:
+                return
         raise RetryError()
 
 

--- a/src/sentry/taskworker/retry.py
+++ b/src/sentry/taskworker/retry.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from enum import Enum
 from multiprocessing.context import TimeoutError
-from typing import NoReturn
 
 from celery import current_task
 from sentry_protos.taskbroker.v1.taskbroker_pb2 import (
@@ -42,7 +41,7 @@ class LastAction(Enum):
         raise ValueError(f"Unknown LastAction: {self}")
 
 
-def retry_task(exc: Exception | None = None, raise_on_no_retries: bool = True) -> NoReturn:
+def retry_task(exc: Exception | None = None, raise_on_no_retries: bool = True) -> None:
     """
     Helper for triggering retry errors.
     If all retries have been consumed, this will raise a
@@ -64,7 +63,7 @@ def retry_task(exc: Exception | None = None, raise_on_no_retries: bool = True) -
             if raise_on_no_retries:
                 raise NoRetriesRemainingError()
             else:
-                pass
+                return
         raise RetryError()
 
 

--- a/src/sentry/taskworker/retry.py
+++ b/src/sentry/taskworker/retry.py
@@ -64,7 +64,7 @@ def retry_task(exc: Exception | None = None, raise_on_no_retries: bool = True) -
             if raise_on_no_retries:
                 raise NoRetriesRemainingError()
             else:
-                return
+                pass
         raise RetryError()
 
 

--- a/src/sentry/taskworker/retry.py
+++ b/src/sentry/taskworker/retry.py
@@ -42,7 +42,7 @@ class LastAction(Enum):
         raise ValueError(f"Unknown LastAction: {self}")
 
 
-def retry_task(exc: Exception | None = None) -> NoReturn:
+def retry_task(exc: Exception | None = None, raise_on_no_retries: bool = True) -> NoReturn:
     """
     Helper for triggering retry errors.
     If all retries have been consumed, this will raise a
@@ -59,7 +59,7 @@ def retry_task(exc: Exception | None = None) -> NoReturn:
         assert False, "unreachable"
     else:
         current = taskworker_current_task()
-        if current and not current.retries_remaining:
+        if current and not current.retries_remaining and raise_on_no_retries:
             metrics.incr("taskworker.retry.no_retries_remaining")
             raise NoRetriesRemainingError()
         raise RetryError()


### PR DESCRIPTION
these sentry app tasks are "fire and forget"/ best effort tasks to send a payload to a sentry app. if the service on the sentry app side is down, we can't do much and emitting the exception causes extra noise we don't need.

lets ignore them.