### PR TITLE
feat(jira): RPC function for Jira issue summaries

### DIFF
--- a/src/sentry/issues/services/issue/impl.py
+++ b/src/sentry/issues/services/issue/impl.py
@@ -54,14 +54,15 @@ class DatabaseBackedIssueService(IssueService):
         ).values_list("id", flat=True)
 
         group_link_subquery: dict[int, datetime] = dict(
-            GroupLink.objects.filter(linked_id__in=external_issue_subquery).values_list(
-                "group_id", "datetime"
+            GroupLink.objects.filter(
+                linked_id__in=external_issue_subquery, project__organization_id=organization.id
             )
+            .order_by("datetime")
+            .values_list("group_id", "datetime")
         )
 
         groups = Group.objects.filter(
             id__in=group_link_subquery.keys(),
-            project__organization_id=organization.id,
         )
 
         return [

--- a/src/sentry/issues/services/issue/model.py
+++ b/src/sentry/issues/services/issue/model.py
@@ -9,14 +9,5 @@ class RpcGroupShareMetadata(RpcModel):
 
 
 class RpcExternalIssueGroupMetadata(RpcModel):
-    type: str
-    title: str
     title_url: str
-    first_seen: datetime | None
-    last_seen: datetime | None
-    first_release: str | None
-    first_release_url: str | None
-    last_release: str | None
-    last_release_url: str | None
-    stats_24hr: str
-    stats_14d: str
+    link_date: datetime

--- a/src/sentry/issues/services/issue/model.py
+++ b/src/sentry/issues/services/issue/model.py
@@ -1,6 +1,22 @@
+from datetime import datetime
+
 from sentry.hybridcloud.rpc import RpcModel
 
 
 class RpcGroupShareMetadata(RpcModel):
     title: str
     message: str
+
+
+class RpcExternalIssueGroupMetadata(RpcModel):
+    type: str
+    title: str
+    title_url: str
+    first_seen: datetime | None
+    last_seen: datetime | None
+    first_release: str | None
+    first_release_url: str | None
+    last_release: str | None
+    last_release_url: str | None
+    stats_24hr: str
+    stats_14d: str

--- a/src/sentry/issues/services/issue/service.py
+++ b/src/sentry/issues/services/issue/service.py
@@ -8,7 +8,7 @@ from abc import abstractmethod
 
 from sentry.hybridcloud.rpc.resolvers import ByOrganizationId, ByOrganizationSlug, ByRegionName
 from sentry.hybridcloud.rpc.service import RpcService, regional_rpc_method
-from sentry.issues.services.issue.model import RpcGroupShareMetadata
+from sentry.issues.services.issue.model import RpcExternalIssueGroupMetadata, RpcGroupShareMetadata
 from sentry.silo.base import SiloMode
 
 
@@ -34,6 +34,13 @@ class IssueService(RpcService):
         from sentry.issues.services.issue.impl import DatabaseBackedIssueService
 
         return DatabaseBackedIssueService()
+
+    @regional_rpc_method(resolve=ByRegionName(), return_none_if_mapping_not_found=True)
+    @abstractmethod
+    def get_external_issue_groups(
+        self, *, region_name: str, external_issue_key: str, integration_id: int
+    ) -> list[RpcExternalIssueGroupMetadata] | None:
+        pass
 
     @regional_rpc_method(resolve=ByOrganizationSlug(), return_none_if_mapping_not_found=True)
     @abstractmethod


### PR DESCRIPTION
For [RTC-43](https://linear.app/getsentry/issue/RTC-43/unable-to-install-jira-in-an-organisation-in-the-eu-region) to enable multi-region support for Jira.

Add new RPC method to surface issue summaries.

This takes the `JiraSentryIssueDetailsView` logic and moves it into an RPC function. We will eventually replace the logic from the region view with a control silo view that fans out to fetch groups for an external issue for all regions.