### PR TITLE
chore(preprod): Add back preprod upload endpoint rate limiting

### DIFF
--- a/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
+++ b/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
@@ -22,6 +22,7 @@ from sentry.preprod.analytics import PreprodArtifactApiAssembleEvent
 from sentry.preprod.tasks import assemble_preprod_artifact, create_preprod_artifact
 from sentry.preprod.url_utils import get_preprod_artifact_url
 from sentry.preprod.vcs.status_checks.size.tasks import create_preprod_status_check_task
+from sentry.ratelimits.config import RateLimitConfig
 from sentry.tasks.assemble import ChunkFileState
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
@@ -104,14 +105,13 @@ class ProjectPreprodArtifactAssembleEndpoint(ProjectEndpoint):
     }
     permission_classes = (ProjectReleasePermission,)
 
-    enforce_rate_limit = True
-    rate_limits = {
-        "POST": {
-            RateLimitCategory.ORGANIZATION: RateLimit(
-                limit=100, window=60
-            ),  # 100 requests per minute per org
+    rate_limits = RateLimitConfig(
+        limit_overrides={
+            "POST": {
+                RateLimitCategory.ORGANIZATION: RateLimit(limit=100, window=60),
+            }
         }
-    }
+    )
 
     def post(self, request: Request, project: Project) -> Response:
         """

--- a/src/sentry/preprod/api/endpoints/project_preprod_check_for_updates.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_check_for_updates.py
@@ -47,13 +47,10 @@ class ProjectPreprodArtifactCheckForUpdatesEndpoint(ProjectEndpoint):
     }
     permission_classes = (ProjectReleasePermission,)
 
-    enforce_rate_limit = True
     rate_limits = RateLimitConfig(
         limit_overrides={
             "GET": {
-                RateLimitCategory.ORGANIZATION: RateLimit(
-                    limit=100, window=60
-                ),  # 100 requests per minute per org
+                RateLimitCategory.ORGANIZATION: RateLimit(limit=100, window=60),
             }
         }
     )


### PR DESCRIPTION
now that load testing has completed

Revert "chore(preprod): Temporarily remove rate limiting for artifact upload (#98260)"

This reverts commit 07c6926a6b2aeb350f022c640569e3786b388243.

<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
