### PR TITLE
ref(grouping): Make stacktrace order in issue diff reflect user setting

### DIFF
--- a/static/app/components/events/interfaces/crashContent/stackTrace/rawContent.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/rawContent.tsx
@@ -270,13 +270,7 @@ export default function displayRawContent(
     )
   );
 
-  const shouldReverse =
-    (platform !== 'python') !==
-    (issueDiff &&
-      ((!newestFirst && platform !== 'python') ||
-        (newestFirst && platform === 'python')));
-
-  if (shouldReverse) {
+  if ((platform !== 'python' && !issueDiff) || (issueDiff && newestFirst)) {
     frames.reverse();
   }
 

--- a/static/app/components/events/interfaces/crashContent/stackTrace/rawContent.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/rawContent.tsx
@@ -247,6 +247,7 @@ export default function displayRawContent(
   exception?: ExceptionValue,
   hasSimilarityEmbeddingsFeature = false,
   includeLocation = true,
+  newestFirst = false,
   includeJSContext = false
 ) {
   const rawFrames = data?.frames || [];
@@ -269,6 +270,10 @@ export default function displayRawContent(
   );
 
   if (platform !== 'python') {
+    frames.reverse();
+  }
+
+  if (newestFirst) {
     frames.reverse();
   }
 

--- a/static/app/components/events/interfaces/crashContent/stackTrace/rawContent.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/rawContent.tsx
@@ -248,6 +248,7 @@ export default function displayRawContent(
   hasSimilarityEmbeddingsFeature = false,
   includeLocation = true,
   newestFirst = false,
+  issueDiff = false,
   includeJSContext = false
 ) {
   const rawFrames = data?.frames || [];
@@ -269,7 +270,13 @@ export default function displayRawContent(
     )
   );
 
-  if (newestFirst) {
+  const shouldReverse =
+    (platform !== 'python') !==
+    (issueDiff &&
+      ((!newestFirst && platform !== 'python') ||
+        (newestFirst && platform === 'python')));
+
+  if (shouldReverse) {
     frames.reverse();
   }
 

--- a/static/app/components/events/interfaces/crashContent/stackTrace/rawContent.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/rawContent.tsx
@@ -269,10 +269,6 @@ export default function displayRawContent(
     )
   );
 
-  if (platform !== 'python') {
-    frames.reverse();
-  }
-
   if (newestFirst) {
     frames.reverse();
   }

--- a/static/app/components/issueDiff/index.tsx
+++ b/static/app/components/issueDiff/index.tsx
@@ -180,20 +180,21 @@ class IssueDiff extends Component<Props, State> {
         {loading && <LoadingIndicator />}
         {!loading &&
           DiffComponent &&
-          (this.state.newestFirst ? baseEvent.toReversed() : baseEvent).map(
-            (value, i) => (
+          (() => {
+            const baseArray = this.state.newestFirst ? baseEvent.toReversed() : baseEvent;
+            const targetArray = this.state.newestFirst
+              ? targetEvent.toReversed()
+              : targetEvent;
+
+            return baseArray.map((value, i) => (
               <DiffComponent
                 key={i}
                 base={value}
-                target={
-                  this.state.newestFirst
-                    ? (targetEvent[targetEvent.length - 1 - i] ?? '')
-                    : (targetEvent[i] ?? '')
-                }
+                target={targetArray[i] ?? ''}
                 type="lines"
               />
-            )
-          )}
+            ));
+          })()}
       </StyledIssueDiff>
     );
   }

--- a/static/app/components/issueDiff/index.tsx
+++ b/static/app/components/issueDiff/index.tsx
@@ -175,26 +175,22 @@ class IssueDiff extends Component<Props, State> {
     const {className} = this.props;
     const {SplitDiffAsync: DiffComponent, loading, baseEvent, targetEvent} = this.state;
 
+    const baseArray = this.state.newestFirst ? baseEvent.toReversed() : baseEvent;
+    const targetArray = this.state.newestFirst ? targetEvent.toReversed() : targetEvent;
+
     return (
       <StyledIssueDiff className={className} loading={loading}>
         {loading && <LoadingIndicator />}
         {!loading &&
           DiffComponent &&
-          (() => {
-            const baseArray = this.state.newestFirst ? baseEvent.toReversed() : baseEvent;
-            const targetArray = this.state.newestFirst
-              ? targetEvent.toReversed()
-              : targetEvent;
-
-            return baseArray.map((value, i) => (
-              <DiffComponent
-                key={i}
-                base={value}
-                target={targetArray[i] ?? ''}
-                type="lines"
-              />
-            ));
-          })()}
+          baseArray.map((value, i) => (
+            <DiffComponent
+              key={i}
+              base={value}
+              target={targetArray[i] ?? ''}
+              type="lines"
+            />
+          ))}
       </StyledIssueDiff>
     );
   }

--- a/static/app/components/issueDiff/index.tsx
+++ b/static/app/components/issueDiff/index.tsx
@@ -180,7 +180,7 @@ class IssueDiff extends Component<Props, State> {
         {loading && <LoadingIndicator />}
         {!loading &&
           DiffComponent &&
-          (this.state.newestFirst ? [...baseEvent].reverse() : baseEvent).map(
+          (this.state.newestFirst ? baseEvent.toReversed() : baseEvent).map(
             (value, i) => (
               <DiffComponent
                 key={i}

--- a/static/app/components/issueDiff/index.tsx
+++ b/static/app/components/issueDiff/index.tsx
@@ -42,6 +42,7 @@ type Props = {
 type State = {
   baseEvent: string[];
   loading: boolean;
+  newestFirst: boolean;
   targetEvent: string[];
   SplitDiffAsync?: typeof SplitDiff;
 };
@@ -52,6 +53,7 @@ class IssueDiff extends Component<Props, State> {
   state: State = {
     loading: true,
     baseEvent: [],
+    newestFirst: false,
     targetEvent: [],
 
     // `SplitDiffAsync` is an async-loaded component
@@ -112,6 +114,7 @@ class IssueDiff extends Component<Props, State> {
           SplitDiffAsync,
           baseEvent,
           targetEvent,
+          newestFirst,
           loading: false,
         });
         if (organization && hasSimilarityEmbeddingsFeature) {
@@ -174,14 +177,20 @@ class IssueDiff extends Component<Props, State> {
         {loading && <LoadingIndicator />}
         {!loading &&
           DiffComponent &&
-          baseEvent.map((value, i) => (
-            <DiffComponent
-              key={i}
-              base={value}
-              target={targetEvent[i] ?? ''}
-              type="lines"
-            />
-          ))}
+          (this.state.newestFirst ? [...baseEvent].reverse() : baseEvent).map(
+            (value, i) => (
+              <DiffComponent
+                key={i}
+                base={value}
+                target={
+                  this.state.newestFirst
+                    ? (targetEvent[targetEvent.length - 1 - i] ?? '')
+                    : (targetEvent[i] ?? '')
+                }
+                type="lines"
+              />
+            )
+          )}
       </StyledIssueDiff>
     );
   }

--- a/static/app/components/issueDiff/index.tsx
+++ b/static/app/components/issueDiff/index.tsx
@@ -92,6 +92,7 @@ class IssueDiff extends Component<Props, State> {
         ]);
         const includeLocation = false;
         const newestFirst = isStacktraceNewestFirst();
+        const issueDiff = true;
         const includeJSContext = true;
         const [baseEvent, targetEvent] = await Promise.all([
           getStacktraceBody(
@@ -99,6 +100,7 @@ class IssueDiff extends Component<Props, State> {
             hasSimilarityEmbeddingsFeature,
             includeLocation,
             newestFirst,
+            issueDiff,
             includeJSContext
           ),
           getStacktraceBody(
@@ -106,6 +108,7 @@ class IssueDiff extends Component<Props, State> {
             hasSimilarityEmbeddingsFeature,
             includeLocation,
             newestFirst,
+            issueDiff,
             includeJSContext
           ),
         ]);

--- a/static/app/components/issueDiff/index.tsx
+++ b/static/app/components/issueDiff/index.tsx
@@ -6,6 +6,7 @@ import type {Location} from 'history';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import type {Client} from 'sentry/api';
+import {isStacktraceNewestFirst} from 'sentry/components/events/interfaces/utils';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import type SplitDiff from 'sentry/components/splitDiff';
 import {t} from 'sentry/locale';
@@ -88,18 +89,21 @@ class IssueDiff extends Component<Props, State> {
           this.fetchEvent(targetIssueId, targetEventId ?? 'latest'),
         ]);
         const includeLocation = false;
+        const newestFirst = isStacktraceNewestFirst();
         const includeJSContext = true;
         const [baseEvent, targetEvent] = await Promise.all([
           getStacktraceBody(
             baseEventData,
             hasSimilarityEmbeddingsFeature,
             includeLocation,
+            newestFirst,
             includeJSContext
           ),
           getStacktraceBody(
             targetEventData,
             hasSimilarityEmbeddingsFeature,
             includeLocation,
+            newestFirst,
             includeJSContext
           ),
         ]);

--- a/static/app/utils/getStacktraceBody.tsx
+++ b/static/app/utils/getStacktraceBody.tsx
@@ -46,9 +46,9 @@ export default function getStacktraceBody(
         value,
         hasSimilarityEmbeddingsFeature,
         includeLocation,
-        includeJSContext,
         newestFirst,
-        issueDiff
+        issueDiff,
+        includeJSContext
       )
     )
     .reduce((acc: any, value: any) => acc.concat(value), []);

--- a/static/app/utils/getStacktraceBody.tsx
+++ b/static/app/utils/getStacktraceBody.tsx
@@ -6,6 +6,7 @@ export default function getStacktraceBody(
   hasSimilarityEmbeddingsFeature = false,
   includeLocation = true,
   newestFirst = false,
+  issueDiff = false,
   includeJSContext = false
 ) {
   if (!event?.entries) {
@@ -46,7 +47,8 @@ export default function getStacktraceBody(
         hasSimilarityEmbeddingsFeature,
         includeLocation,
         includeJSContext,
-        newestFirst
+        newestFirst,
+        issueDiff
       )
     )
     .reduce((acc: any, value: any) => acc.concat(value), []);

--- a/static/app/utils/getStacktraceBody.tsx
+++ b/static/app/utils/getStacktraceBody.tsx
@@ -38,8 +38,8 @@ export default function getStacktraceBody(
   // TODO(ts): This should be verified when EntryData has the correct type
   return exc.data.values
     .filter((value: any) => !!value.stacktrace)
-    .map((value: any) => {
-      const result = rawStacktraceContent(
+    .map((value: any) =>
+      rawStacktraceContent(
         value.stacktrace,
         event.platform,
         value,
@@ -47,9 +47,7 @@ export default function getStacktraceBody(
         includeLocation,
         includeJSContext,
         newestFirst
-      );
-
-      return result;
-    })
+      )
+    )
     .reduce((acc: any, value: any) => acc.concat(value), []);
 }

--- a/static/app/utils/getStacktraceBody.tsx
+++ b/static/app/utils/getStacktraceBody.tsx
@@ -1,11 +1,11 @@
 import rawStacktraceContent from 'sentry/components/events/interfaces/crashContent/stackTrace/rawContent';
-import {isStacktraceNewestFirst} from 'sentry/components/events/interfaces/utils';
 import type {Event} from 'sentry/types/event';
 
 export default function getStacktraceBody(
   event: Event,
   hasSimilarityEmbeddingsFeature = false,
   includeLocation = true,
+  newestFirst = false,
   includeJSContext = false
 ) {
   if (!event?.entries) {
@@ -45,16 +45,9 @@ export default function getStacktraceBody(
         value,
         hasSimilarityEmbeddingsFeature,
         includeLocation,
-        includeJSContext
+        includeJSContext,
+        newestFirst
       );
-
-      if (isStacktraceNewestFirst()) {
-        const lines = result.split('\n');
-        const exceptionLine = lines[0];
-        const frameLines = lines.slice(1);
-        frameLines.reverse();
-        return [exceptionLine, ...frameLines].join('\n');
-      }
 
       return result;
     })


### PR DESCRIPTION
Make issue diff stacktrace order reflect user preference.

newest first:
<img width="1471" height="155" alt="image" src="https://github.com/user-attachments/assets/2211bbb2-57d4-4127-9e54-c69d2380a1f1" />

oldest first:
<img width="1446" height="221" alt="image" src="https://github.com/user-attachments/assets/22f3a3df-e049-45cc-8566-73ba0eeb0cfb" />

