### PR TITLE
feat(prevent): Update Repo Token header to sort by name (and no other columns)

### DIFF
--- a/src/sentry/codecov/endpoints/repository_tokens/repository_tokens.py
+++ b/src/sentry/codecov/endpoints/repository_tokens/repository_tokens.py
@@ -55,11 +55,25 @@ class RepositoryTokensEndpoint(CodecovEndpoint):
 
         sort_by = request.query_params.get("sortBy", "-COMMIT_DATE")
 
+        # Validate sort parameters
+        valid_sort_fields = {"COMMIT_DATE", "NAME"}
+
         if sort_by.startswith("-"):
-            sort_by = sort_by[1:]
+            sort_field = sort_by[1:]
             ordering_direction = OrderingDirection.DESC.value
         else:
+            sort_field = sort_by
             ordering_direction = OrderingDirection.ASC.value
+
+        if sort_field not in valid_sort_fields:
+            return Response(
+                status=status.HTTP_400_BAD_REQUEST,
+                data={
+                    "details": f"Invalid sortBy parameter. Allowed values: {', '.join(sorted(valid_sort_fields))}"
+                },
+            )
+
+        sort_by = sort_field
 
         owner_slug = owner.name
 

--- a/static/app/views/prevent/tests/testAnalyticsTable/sortableHeader.tsx
+++ b/static/app/views/prevent/tests/testAnalyticsTable/sortableHeader.tsx
@@ -15,7 +15,7 @@ type HeaderParams = {
   enableToggle: boolean;
   fieldName: string;
   label: string;
-  sort: undefined | Sort;
+  sort?: Sort;
   tooltip?: string | ReactNode;
 };
 

--- a/static/app/views/prevent/tokens/repoTokenTable/repoTokenTable.spec.tsx
+++ b/static/app/views/prevent/tokens/repoTokenTable/repoTokenTable.spec.tsx
@@ -9,7 +9,7 @@ import {
 import {openTokenRegenerationConfirmationModal} from 'sentry/actionCreators/modal';
 import PreventQueryParamsProvider from 'sentry/components/prevent/container/preventParamsProvider';
 
-import RepoTokenTable, {DEFAULT_SORT} from './repoTokenTable';
+import RepoTokenTable, {type ValidSort} from './repoTokenTable';
 
 jest.mock('sentry/actionCreators/modal');
 jest.mock('sentry/components/confirm', () => {
@@ -44,7 +44,7 @@ const defaultProps = {
     isLoading: false,
     error: null,
   },
-  sort: DEFAULT_SORT,
+  sort: {field: 'name', kind: 'desc'} as ValidSort,
 };
 
 describe('RepoTokenTable', () => {
@@ -145,6 +145,73 @@ describe('RepoTokenTable', () => {
     // Verify that the modal is opened with the correct token
     expect(mockOpenTokenRegenerationConfirmationModal).toHaveBeenCalledWith({
       token: mockToken,
+    });
+  });
+
+  describe('Sorting functionality', () => {
+    it('renders with sort indicators when sort is provided', () => {
+      const sortedProps = {
+        ...defaultProps,
+        sort: {field: 'name', kind: 'desc'} as const,
+      };
+
+      renderWithContext(sortedProps);
+
+      expect(screen.getByRole('img')).toBeInTheDocument();
+      expect(
+        screen.getAllByRole('columnheader', {name: /repository name/i})[1]
+      ).toHaveAttribute('aria-sort', 'descending');
+    });
+
+    it('renders without sort indicators when no sort is provided', () => {
+      const unsortedProps = {
+        ...defaultProps,
+        sort: undefined as unknown as ValidSort,
+      };
+
+      renderWithContext(unsortedProps);
+
+      expect(screen.queryByRole('img')).not.toBeInTheDocument();
+      expect(
+        screen.getAllByRole('columnheader', {name: /repository name/i})[1]
+      ).toHaveAttribute('aria-sort', 'none');
+    });
+
+    it('shows ascending sort indicator correctly', () => {
+      const ascendingProps = {
+        ...defaultProps,
+        sort: {field: 'name', kind: 'asc'} as const,
+      };
+
+      renderWithContext(ascendingProps);
+
+      expect(screen.getByRole('img')).toBeInTheDocument();
+      expect(
+        screen.getAllByRole('columnheader', {name: /repository name/i})[1]
+      ).toHaveAttribute('aria-sort', 'ascending');
+    });
+
+    it('makes repository name column clickable for sorting', () => {
+      const unsortedProps = {
+        ...defaultProps,
+        sort: undefined as unknown as ValidSort,
+      };
+
+      renderWithContext(unsortedProps);
+
+      const nameHeader = screen.getAllByRole('columnheader', {
+        name: /repository name/i,
+      })[1];
+      expect(nameHeader).toHaveAttribute('href');
+      expect(nameHeader).toHaveAttribute('href', expect.stringContaining('sort=name'));
+    });
+
+    it('does not make token column clickable', () => {
+      renderWithContext();
+
+      const tokenHeader = screen.getByText('Token');
+      expect(tokenHeader.tagName).toBe('SPAN');
+      expect(tokenHeader).not.toHaveAttribute('href');
     });
   });
 });

--- a/static/app/views/prevent/tokens/repoTokenTable/repoTokenTable.tsx
+++ b/static/app/views/prevent/tokens/repoTokenTable/repoTokenTable.tsx
@@ -31,12 +31,7 @@ const COLUMNS_ORDER: Column[] = [
   {key: 'regenerateToken', name: '', width: 100},
 ];
 
-const SORTABLE_FIELDS = ['name'] as const;
-
-export const DEFAULT_SORT: ValidSort = {
-  field: 'name',
-  kind: 'desc',
-};
+export const SORTABLE_FIELDS = ['name'] as const;
 
 interface Props {
   response: {
@@ -44,7 +39,7 @@ interface Props {
     isLoading: boolean;
     error?: Error | null;
   };
-  sort: ValidSort;
+  sort?: ValidSort; // undefined when no visible column is sorted
 }
 
 export default function RepoTokenTable({response, sort}: Props) {
@@ -57,21 +52,25 @@ export default function RepoTokenTable({response, sort}: Props) {
       error={response.error}
       data={data}
       columnOrder={COLUMNS_ORDER}
-      columnSortBy={[
-        {
-          key: sort.field,
-          order: sort.kind,
-        },
-      ]}
+      columnSortBy={
+        sort
+          ? [
+              {
+                key: sort.field,
+                order: sort.kind,
+              },
+            ]
+          : []
+      }
       grid={{
-        renderHeadCell: (column: Column) =>
+        renderHeadCell: column =>
           renderTableHeader({
-            column,
+            column: column as Column,
             sort,
           }),
-        renderBodyCell: (column: Column, row: Row) =>
+        renderBodyCell: (column, row) =>
           renderTableBody({
-            column,
+            column: column as Column,
             row,
           }),
       }}

--- a/static/app/views/prevent/tokens/repoTokenTable/repoTokenTable.tsx
+++ b/static/app/views/prevent/tokens/repoTokenTable/repoTokenTable.tsx
@@ -17,7 +17,11 @@ export type Column = GridColumnHeader<'name' | 'token' | 'regenerateToken'>;
 
 type ValidField = (typeof SORTABLE_FIELDS)[number];
 
-export function isAValidSort(sort: Sort): sort is ValidSort {
+export function isAValidSort(sort?: Sort): sort is ValidSort {
+  if (!sort) {
+    return false;
+  }
+
   return SORTABLE_FIELDS.includes(sort.field as ValidField);
 }
 

--- a/static/app/views/prevent/tokens/repoTokenTable/tableHeader.tsx
+++ b/static/app/views/prevent/tokens/repoTokenTable/tableHeader.tsx
@@ -1,6 +1,11 @@
+import {Flex} from 'sentry/components/core/layout';
+import {Text} from 'sentry/components/core/text';
 import type {Sort} from 'sentry/utils/discover/fields';
-import SortableHeader from 'sentry/views/prevent/tests/testAnalyticsTable/sortableHeader';
-import type {Column} from 'sentry/views/prevent/tokens/repoTokenTable/repoTokenTable';
+import {
+  SORTABLE_FIELDS,
+  type Column,
+} from 'sentry/views/prevent/tokens/repoTokenTable/repoTokenTable';
+import TokensSortableHeader from 'sentry/views/prevent/tokens/repoTokenTable/tokensSortableHeader';
 
 type TableHeaderParams = {
   column: Column;
@@ -9,14 +14,17 @@ type TableHeaderParams = {
 
 export const renderTableHeader = ({column, sort}: TableHeaderParams) => {
   const {key, name} = column;
+  const isSortable = SORTABLE_FIELDS.includes(key as (typeof SORTABLE_FIELDS)[number]);
+
+  if (isSortable) {
+    return <TokensSortableHeader sort={sort} fieldName={key} label={name} />;
+  }
 
   return (
-    <SortableHeader
-      alignment={key === 'token' ? 'right' : 'left'}
-      sort={sort}
-      fieldName={key}
-      label={name}
-      enableToggle={false}
-    />
+    <Flex justify="end" width="100%">
+      <Text as="span" size="sm">
+        {name}
+      </Text>
+    </Flex>
   );
 };

--- a/static/app/views/prevent/tokens/repoTokenTable/tokensSortableHeader.spec.tsx
+++ b/static/app/views/prevent/tokens/repoTokenTable/tokensSortableHeader.spec.tsx
@@ -1,0 +1,118 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import TokensSortableHeader from './tokensSortableHeader';
+
+const mockLocation = {
+  pathname: '/prevent/tokens/',
+  query: {},
+  search: '',
+  hash: '',
+  state: undefined,
+  action: 'POP' as const,
+  key: 'test',
+};
+
+jest.mock('sentry/utils/useLocation', () => ({
+  useLocation: () => mockLocation,
+}));
+
+describe('TokensSortableHeader', () => {
+  const defaultProps = {
+    fieldName: 'name',
+    label: 'Repository Name',
+    alignment: 'left',
+    sort: undefined,
+  };
+
+  const renderHeader = (props = {}) => {
+    return render(<TokensSortableHeader {...defaultProps} {...props} />);
+  };
+
+  beforeEach(() => {
+    // Reset mock location before each test
+    mockLocation.query = {};
+  });
+
+  it('renders with correct label', () => {
+    renderHeader();
+    expect(screen.getByRole('columnheader')).toBeInTheDocument();
+    expect(screen.getByText('Repository Name')).toBeInTheDocument();
+  });
+
+  it('shows no sort arrow when not sorted', () => {
+    renderHeader({sort: undefined});
+    expect(screen.queryByRole('img')).not.toBeInTheDocument();
+    expect(screen.getByRole('columnheader')).toHaveAttribute('aria-sort', 'none');
+  });
+
+  it('shows ascending arrow when sorted ascending', () => {
+    renderHeader({
+      sort: {field: 'name', kind: 'asc'},
+    });
+    expect(screen.getByRole('img')).toBeInTheDocument();
+    expect(screen.getByRole('columnheader')).toHaveAttribute('aria-sort', 'ascending');
+  });
+
+  it('shows descending arrow when sorted descending', () => {
+    renderHeader({
+      sort: {field: 'name', kind: 'desc'},
+    });
+    expect(screen.getByRole('img')).toBeInTheDocument();
+    expect(screen.getByRole('columnheader')).toHaveAttribute('aria-sort', 'descending');
+  });
+
+  it('generates correct link for first click (no sort → ascending)', () => {
+    renderHeader();
+    const link = screen.getByRole('columnheader');
+    expect(link).toHaveAttribute('href', '/prevent/tokens/?sort=name');
+  });
+
+  it('generates correct link for second click (ascending → descending)', () => {
+    renderHeader({
+      sort: {field: 'name', kind: 'asc'},
+    });
+    const link = screen.getByRole('columnheader');
+    expect(link).toHaveAttribute('href', '/prevent/tokens/?sort=-name');
+  });
+
+  it('generates correct link for third click (descending → no sort)', () => {
+    renderHeader({
+      sort: {field: 'name', kind: 'desc'},
+    });
+    const link = screen.getByRole('columnheader');
+    expect(link).toHaveAttribute('href', '/prevent/tokens/');
+  });
+
+  it('preserves other query parameters when changing sort', () => {
+    mockLocation.query = {
+      cursor: 'abc123',
+      integratedOrgId: 'org-123',
+      someOtherParam: 'value',
+    };
+
+    renderHeader();
+    const link = screen.getByRole('columnheader');
+    expect(link).toHaveAttribute(
+      'href',
+      '/prevent/tokens/?integratedOrgId=org-123&someOtherParam=value&sort=name'
+    );
+  });
+
+  it('removes cursor and navigation params when sorting', () => {
+    mockLocation.query = {
+      cursor: 'abc123',
+      navigation: 'next',
+      integratedOrgId: 'org-123',
+      sort: '-name',
+    };
+
+    renderHeader({
+      sort: {field: 'name', kind: 'desc'},
+    });
+
+    const link = screen.getByRole('columnheader');
+    expect(link.getAttribute('href')).not.toContain('cursor');
+    expect(link.getAttribute('href')).not.toContain('navigation');
+    expect(link).toHaveAttribute('href', '/prevent/tokens/?integratedOrgId=org-123');
+  });
+});

--- a/static/app/views/prevent/tokens/repoTokenTable/tokensSortableHeader.tsx
+++ b/static/app/views/prevent/tokens/repoTokenTable/tokensSortableHeader.tsx
@@ -1,0 +1,84 @@
+import styled from '@emotion/styled';
+
+import {Flex} from 'sentry/components/core/layout';
+import {Link} from 'sentry/components/core/link';
+import {IconArrow} from 'sentry/icons';
+import type {Sort} from 'sentry/utils/discover/fields';
+import {useLocation} from 'sentry/utils/useLocation';
+
+type HeaderParams = {
+  fieldName: string;
+  label: string;
+  sort: undefined | Sort;
+};
+
+function TokensSortableHeader({fieldName, label, sort}: HeaderParams) {
+  const location = useLocation();
+
+  const arrowDirection = sort?.kind === 'asc' ? 'up' : 'down';
+  const sortArrow = <IconArrow size="xs" direction={arrowDirection} />;
+
+  const {
+    cursor: _cursor,
+    navigation: _navigation,
+    ...queryWithoutPagination
+  } = location.query;
+
+  const getNextSortState = () => {
+    const currentSort = sort?.field === fieldName ? sort : undefined;
+
+    if (!currentSort) {
+      return fieldName;
+    }
+
+    if (currentSort.kind === 'asc') {
+      return '-' + fieldName;
+    }
+
+    return undefined;
+  };
+
+  const nextSort = getNextSortState();
+
+  const nextQuery = {...queryWithoutPagination};
+  if (nextSort) {
+    nextQuery.sort = nextSort;
+  } else {
+    delete nextQuery.sort;
+  }
+
+  return (
+    <Flex align="center" gap="sm" justify="start" width="100%">
+      <StyledLink
+        role="columnheader"
+        aria-sort={
+          sort?.field === fieldName
+            ? sort?.kind === 'asc'
+              ? 'ascending'
+              : 'descending'
+            : 'none'
+        }
+        to={{
+          pathname: location.pathname,
+          query: nextQuery,
+        }}
+      >
+        {label} {sort?.field === fieldName && sortArrow}
+      </StyledLink>
+    </Flex>
+  );
+}
+
+const StyledLink = styled(Link)`
+  color: inherit;
+
+  :hover {
+    color: inherit;
+  }
+
+  svg {
+    vertical-align: top;
+  }
+`;
+
+export default TokensSortableHeader;

--- a/static/app/views/prevent/tokens/repoTokenTable/tokensSortableHeader.tsx
+++ b/static/app/views/prevent/tokens/repoTokenTable/tokensSortableHeader.tsx
@@ -9,7 +9,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 type HeaderParams = {
   fieldName: string;
   label: string;
-  sort: undefined | Sort;
+  sort?: Sort;
 };
 
 function TokensSortableHeader({fieldName, label, sort}: HeaderParams) {

--- a/static/app/views/prevent/tokens/tokens.spec.tsx
+++ b/static/app/views/prevent/tokens/tokens.spec.tsx
@@ -240,5 +240,130 @@ describe('TokensPage', () => {
 
       expect(screen.getByRole('button', {name: 'Done'})).toBeInTheDocument();
     });
+
+    describe('Sorting integration', () => {
+      it('renders with correct sort state when sort parameter is in URL', async () => {
+        mockApiCall();
+        render(
+          <PreventQueryParamsProvider>
+            <TokensPage />
+          </PreventQueryParamsProvider>,
+          {
+            initialRouterConfig: {
+              location: {
+                pathname: '/prevent/tokens/',
+                query: {
+                  integratedOrgId: '1',
+                  sort: 'name', // ascending sort
+                },
+              },
+            },
+          }
+        );
+
+        expect(await screen.findByRole('table')).toBeInTheDocument();
+
+        expect(
+          screen.getAllByRole('columnheader', {name: /repository name/i})[1]
+        ).toHaveAttribute('aria-sort', 'ascending');
+      });
+
+      it('renders with descending sort state when negative sort parameter is in URL', async () => {
+        mockApiCall();
+        render(
+          <PreventQueryParamsProvider>
+            <TokensPage />
+          </PreventQueryParamsProvider>,
+          {
+            initialRouterConfig: {
+              location: {
+                pathname: '/prevent/tokens/',
+                query: {
+                  integratedOrgId: '1',
+                  sort: '-name', // descending sort
+                },
+              },
+            },
+          }
+        );
+
+        expect(await screen.findByRole('table')).toBeInTheDocument();
+
+        expect(
+          screen.getAllByRole('columnheader', {name: /repository name/i})[1]
+        ).toHaveAttribute('aria-sort', 'descending');
+      });
+
+      it('renders with no sort state when no sort parameter is in URL', async () => {
+        mockApiCall();
+        render(
+          <PreventQueryParamsProvider>
+            <TokensPage />
+          </PreventQueryParamsProvider>,
+          {
+            initialRouterConfig: {
+              location: {
+                pathname: '/prevent/tokens/',
+                query: {
+                  integratedOrgId: '1',
+                  // no sort parameter
+                },
+              },
+            },
+          }
+        );
+
+        expect(await screen.findByRole('table')).toBeInTheDocument();
+
+        expect(
+          screen.getAllByRole('columnheader', {name: /repository name/i})[1]
+        ).toHaveAttribute('aria-sort', 'none');
+      });
+
+      it('passes sortBy parameter to API when valid sort is provided', async () => {
+        MockApiClient.addMockResponse({
+          url: `/organizations/org-slug/integrations/`,
+          method: 'GET',
+          body: mockIntegrations,
+        });
+
+        const mockTokensCall = MockApiClient.addMockResponse({
+          url: `/organizations/org-slug/prevent/owner/1/repositories/tokens/`,
+          method: 'GET',
+          body: mockRepositoryTokensResponse,
+        });
+
+        render(
+          <PreventQueryParamsProvider>
+            <TokensPage />
+          </PreventQueryParamsProvider>,
+          {
+            initialRouterConfig: {
+              location: {
+                pathname: '/prevent/tokens/',
+                query: {
+                  integratedOrgId: '1',
+                  sort: '-name', // descending name sort
+                },
+              },
+            },
+          }
+        );
+
+        await screen.findByRole('table');
+
+        // API should be called with sortBy parameter
+        await waitFor(() => {
+          expect(mockTokensCall).toHaveBeenCalledWith(
+            '/organizations/org-slug/prevent/owner/1/repositories/tokens/',
+            expect.objectContaining({
+              query: expect.objectContaining({
+                sortBy: '-NAME',
+              }),
+            })
+          );
+        });
+      });
+    });
   });
 });

--- a/static/app/views/prevent/tokens/tokens.tsx
+++ b/static/app/views/prevent/tokens/tokens.tsx
@@ -16,11 +16,7 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 
 import {useInfiniteRepositoryTokens} from './repoTokenTable/hooks/useInfiniteRepositoryTokens';
-import type {ValidSort} from './repoTokenTable/repoTokenTable';
-import RepoTokenTable, {
-  DEFAULT_SORT,
-  isAValidSort,
-} from './repoTokenTable/repoTokenTable';
+import RepoTokenTable, {isAValidSort} from './repoTokenTable/repoTokenTable';
 
 export default function TokensPage() {
   const {integratedOrgId} = usePreventContext();
@@ -35,12 +31,12 @@ export default function TokensPage() {
   );
   const location = useLocation();
 
-  const sorts: [ValidSort] = [
-    decodeSorts(location.query?.sort).find(isAValidSort) ?? DEFAULT_SORT,
-  ];
+  const sort = decodeSorts(location.query?.sort).find(isAValidSort);
+
   const response = useInfiniteRepositoryTokens({
     cursor: location.query?.cursor as string | undefined,
     navigation: location.query?.navigation as 'next' | 'prev' | undefined,
+    sort,
   });
 
   const handleCursor = useCallback(
@@ -83,7 +79,7 @@ export default function TokensPage() {
           }
         )}
       </Text>
-      <RepoTokenTable response={response} sort={sorts[0]} />
+      <RepoTokenTable response={response} sort={sort} />
       {/* We don't need to use the pageLinks prop because Codecov handles pagination using our own cursor implementation. But we need to
           put a dummy value here because otherwise the component wouldn't render. */}
       <StyledPagination pageLinks="showComponent" onCursor={handleCursor} />

--- a/tests/sentry/codecov/endpoints/test_repository_tokens.py
+++ b/tests/sentry/codecov/endpoints/test_repository_tokens.py
@@ -177,3 +177,14 @@ class RepositoryTokensEndpointTest(APITestCase):
 
         assert response.status_code == 400
         assert response.data == {"details": "provided `limit` parameter must be a positive integer"}
+
+    def test_get_with_invalid_sort_field_returns_bad_request(self) -> None:
+        """Test that invalid sort fields return 400 error."""
+        url = self.reverse_url()
+        query_params = {"sortBy": "INVALID_FIELD"}
+        response = self.client.get(url, query_params)
+
+        assert response.status_code == 400
+        assert response.data == {
+            "details": "Invalid sortBy parameter. Allowed values: COMMIT_DATE, NAME"
+        }


### PR DESCRIPTION
This PR does a couple things:

- BE validation for repo token sortBy to only accept "COMMIT_DATE" and "NAME" as sortBy params
- Creates a new version of the header component which is meant for the repo token table, so you can only sort on the name column
- And then if you click the name column 3 times it goes back to the default sort on the BE (COMMIT_DATE, which is not a column on the table)

Most of the additions are just tests

Closes https://linear.app/getsentry/issue/CCMRG-1500/fix-ui-query-params-for-name-and-remove-for-other-fields


https://github.com/user-attachments/assets/4c29319e-a136-485a-9118-04482e3cbb79



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
