### PR TITLE
fix(workflow_engine): Fix timeout on `0082_disconnect_error_detector_cron_workflows`

### DIFF
--- a/src/sentry/workflow_engine/migrations/0082_disconnect_error_detector_cron_workflows.py
+++ b/src/sentry/workflow_engine/migrations/0082_disconnect_error_detector_cron_workflows.py
@@ -7,7 +7,6 @@ from django.db import migrations
 from django.db.backends.base.schema import BaseDatabaseSchemaEditor
 
 from sentry.new_migrations.migrations import CheckedMigration
-from sentry.utils.query import RangeQuerySetWrapper
 
 logger = logging.getLogger(__name__)
 
@@ -19,7 +18,7 @@ def disconnect_error_detector_cron_workflows(
     AlertRuleWorkflow = apps.get_model("workflow_engine", "AlertRuleWorkflow")
     DetectorWorkflow = apps.get_model("workflow_engine", "DetectorWorkflow")
 
-    for rule in RangeQuerySetWrapper(Rule.objects.filter(source=1)):
+    for rule in Rule.objects.filter(source=1):
         arw = AlertRuleWorkflow.objects.filter(rule_id=rule.id).select_related("workflow").first()
         if not arw:
             logger.info(


### PR DESCRIPTION
Since we use `source=1` with the range wrapper this ends up timing out. There are 10k max rows that we care about here, so we can just bring them all into memory

<!-- Describe your PR here. -->