### PR TITLE
fix(build): Add missing asset loaders to chartcuterie build config

### DIFF
--- a/config/build-chartcuterie.ts
+++ b/config/build-chartcuterie.ts
@@ -77,6 +77,21 @@ async function runEsbuild(commitHash: string): Promise<void> {
     minify: false,
     treeShaking: true,
     logLevel: 'info',
+    loader: {
+      '.svg': 'file',
+      '.png': 'file',
+      '.jpg': 'file',
+      '.jpeg': 'file',
+      '.gif': 'file',
+      '.ico': 'file',
+      '.webp': 'file',
+      '.mp4': 'file',
+      '.woff': 'file',
+      '.woff2': 'file',
+      '.ttf': 'file',
+      '.eot': 'file',
+      '.pegjs': 'text',
+    },
   });
 }
 


### PR DESCRIPTION
### Summary
The recent frontend feature flag cleanup for logs exposed new dependencies in the chartcuterie bundle that require asset loaders for .svg, .png etc. but seem to missing now, possibly due to tree-shaking.

Adding these loaders to the esbuild config to resolve build failures, most it shouldn't affect chartcuterie since we don't use pegparse, svgs etc directly. 

See https://github.com/getsentry/sentry/actions/runs/17251554956/job/48954786366?pr=98296 for original failure

