### PR TITLE
fix(aci): Retry sentry.workflow_engine.tasks.trigger_action timeouts

### DIFF
--- a/src/sentry/workflow_engine/tasks/actions.py
+++ b/src/sentry/workflow_engine/tasks/actions.py
@@ -74,7 +74,7 @@ def build_trigger_action_task_params(
         ),
     ),
 )
-@retry
+@retry(timeouts=True)
 def trigger_action(
     action_id: int,
     detector_id: int,


### PR DESCRIPTION
Action timeouts are rare, but in most cases we'd prefer to try again.
