### PR TITLE
:bug: fix(aci): update resolution activity ff check

### DIFF
--- a/src/sentry/notifications/notification_action/types.py
+++ b/src/sentry/notifications/notification_action/types.py
@@ -428,6 +428,13 @@ class BaseMetricAlertHandler(ABC):
         if isinstance(event, GroupEvent):
             evidence_data, priority = cls._extract_from_group_event(event)
         elif isinstance(event, Activity):
+            # we only want to fire resolution activities if we are single processing
+            if not features.has(
+                "organizations:workflow-engine-single-process-metric-issues",
+                event_data.group.organization,
+            ):
+                return
+
             evidence_data, priority = cls._extract_from_activity(event)
         else:
             raise ValueError(

--- a/src/sentry/workflow_engine/handlers/workflow/workflow_status_update_handler.py
+++ b/src/sentry/workflow_engine/handlers/workflow/workflow_status_update_handler.py
@@ -1,9 +1,15 @@
+import logging
+
+from sentry import features
 from sentry.issues.status_change_consumer import group_status_update_registry
 from sentry.issues.status_change_message import StatusChangeMessageData
 from sentry.models.activity import Activity
 from sentry.models.group import Group
 from sentry.types.activity import ActivityType
 from sentry.utils import metrics
+
+logger = logging.getLogger(__name__)
+
 
 SUPPORTED_ACTIVITIES = [ActivityType.SET_RESOLVED.value]
 
@@ -19,7 +25,6 @@ def workflow_status_update_handler(
     to queue a task to process workflows asynchronously.
     """
 
-    from sentry.notifications.notification_action.utils import should_fire_workflow_actions
     from sentry.workflow_engine.tasks.workflows import process_workflow_activity
 
     metrics.incr(
@@ -39,9 +44,30 @@ def workflow_status_update_handler(
         return
 
     # We should only fire actions for activity updates if we should be firing actions
-    if should_fire_workflow_actions(group.organization, group.type):
+    # if dual proccessing or single proccessing is enabled
+    if features.has(  # Metric issue single processing
+        "organizations:workflow-engine-single-process-metric-issues",
+        group.organization,
+    ) or (  # Metric dual processing
+        features.has(
+            "organizations:workflow-engine-metric-alert-processing",
+            group.organization,
+        )
+        and features.has(
+            "organizations:workflow-engine-process-metric-issue-workflows", group.organization
+        )
+    ):
         process_workflow_activity.delay(
             activity_id=activity.id,
             group_id=group.id,
             detector_id=detector_id,
+        )
+    else:
+        logger.info(
+            "workflow_engine.tasks.process_workflows.activity_update.skipped",
+            extra={
+                "activity_id": activity.id,
+                "group_id": group.id,
+                "detector_id": detector_id,
+            },
         )

--- a/src/sentry/workflow_engine/handlers/workflow/workflow_status_update_handler.py
+++ b/src/sentry/workflow_engine/handlers/workflow/workflow_status_update_handler.py
@@ -48,14 +48,9 @@ def workflow_status_update_handler(
     if features.has(  # Metric issue single processing
         "organizations:workflow-engine-single-process-metric-issues",
         group.organization,
-    ) or (  # Metric dual processing
-        features.has(
-            "organizations:workflow-engine-metric-alert-processing",
-            group.organization,
-        )
-        and features.has(
-            "organizations:workflow-engine-process-metric-issue-workflows", group.organization
-        )
+    ) or features.has(  # Metric dual processing
+        "organizations:workflow-engine-metric-alert-processing",
+        group.organization,
     ):
         process_workflow_activity.delay(
             activity_id=activity.id,

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_discord_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_discord_metric_alert_handler.py
@@ -18,6 +18,7 @@ from sentry.notifications.notification_action.metric_alert_registry.handlers.uti
     get_detailed_incident_serializer,
 )
 from sentry.testutils.helpers.datetime import freeze_time
+from sentry.testutils.helpers.features import with_feature
 from sentry.types.activity import ActivityType
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.types import DetectorPriorityLevel, WorkflowEventData
@@ -26,6 +27,7 @@ from tests.sentry.notifications.notification_action.test_metric_alert_registry_h
 )
 
 
+@with_feature("organizations:workflow-engine-single-process-metric-issues")
 class TestDiscordMetricAlertHandler(MetricAlertHandlerBase):
     def setUp(self) -> None:
         self.create_models()

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_email_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_email_metric_alert_handler.py
@@ -18,6 +18,7 @@ from sentry.notifications.notification_action.metric_alert_registry.handlers.uti
     get_detailed_incident_serializer,
 )
 from sentry.testutils.helpers.datetime import freeze_time
+from sentry.testutils.helpers.features import with_feature
 from sentry.types.activity import ActivityType
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.types import DetectorPriorityLevel, WorkflowEventData
@@ -26,6 +27,7 @@ from tests.sentry.notifications.notification_action.test_metric_alert_registry_h
 )
 
 
+@with_feature("organizations:workflow-engine-single-process-metric-issues")
 class TestEmailMetricAlertHandler(MetricAlertHandlerBase):
     def setUp(self) -> None:
         self.create_models()

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_msteams_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_msteams_metric_alert_handler.py
@@ -18,6 +18,7 @@ from sentry.notifications.notification_action.metric_alert_registry.handlers.uti
     get_detailed_incident_serializer,
 )
 from sentry.testutils.helpers.datetime import freeze_time
+from sentry.testutils.helpers.features import with_feature
 from sentry.types.activity import ActivityType
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.types import DetectorPriorityLevel, WorkflowEventData
@@ -26,6 +27,7 @@ from tests.sentry.notifications.notification_action.test_metric_alert_registry_h
 )
 
 
+@with_feature("organizations:workflow-engine-single-process-metric-issues")
 class TestMsteamsMetricAlertHandler(MetricAlertHandlerBase):
     def setUp(self) -> None:
         self.create_models()

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_opsgenie_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_opsgenie_metric_alert_handler.py
@@ -24,6 +24,7 @@ from tests.sentry.notifications.notification_action.test_metric_alert_registry_h
 )
 
 
+@with_feature("organizations:workflow-engine-single-process-metric-issues")
 @with_feature("organizations:issue-open-periods")
 class TestOpsgenieMetricAlertHandler(MetricAlertHandlerBase):
     def setUp(self) -> None:

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_pagerduty_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_pagerduty_metric_alert_handler.py
@@ -24,6 +24,7 @@ from tests.sentry.notifications.notification_action.test_metric_alert_registry_h
 )
 
 
+@with_feature("organizations:workflow-engine-single-process-metric-issues")
 @with_feature("organizations:issue-open-periods")
 class TestPagerDutyMetricAlertHandler(MetricAlertHandlerBase):
     def setUp(self) -> None:

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_sentry_app_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_sentry_app_metric_alert_handler.py
@@ -19,6 +19,7 @@ from sentry.notifications.notification_action.metric_alert_registry.handlers.uti
     get_incident_serializer,
 )
 from sentry.testutils.helpers.datetime import freeze_time
+from sentry.testutils.helpers.features import with_feature
 from sentry.types.activity import ActivityType
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.types import DetectorPriorityLevel, WorkflowEventData
@@ -28,6 +29,7 @@ from tests.sentry.notifications.notification_action.test_metric_alert_registry_h
 )
 
 
+@with_feature("organizations:workflow-engine-single-process-metric-issues")
 class TestSentryAppMetricAlertHandler(MetricAlertHandlerBase):
     def setUp(self) -> None:
         super().setUp()

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_slack_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_slack_metric_alert_handler.py
@@ -18,6 +18,7 @@ from sentry.notifications.notification_action.metric_alert_registry.handlers.uti
     get_detailed_incident_serializer,
 )
 from sentry.testutils.helpers.datetime import freeze_time
+from sentry.testutils.helpers.features import with_feature
 from sentry.types.activity import ActivityType
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.types import DetectorPriorityLevel, WorkflowEventData
@@ -26,6 +27,7 @@ from tests.sentry.notifications.notification_action.test_metric_alert_registry_h
 )
 
 
+@with_feature("organizations:workflow-engine-single-process-metric-issues")
 class TestSlackMetricAlertHandler(MetricAlertHandlerBase):
     def setUp(self) -> None:
         self.create_models()

--- a/tests/sentry/notifications/notification_action/test_metric_alert_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_metric_alert_registry_handlers.py
@@ -501,6 +501,33 @@ class TestBaseMetricAlertHandler(MetricAlertHandlerBase):
             )
 
     @mock.patch.object(TestHandler, "send_alert")
+    def test_invoke_legacy_registry_with_activity_ff_not_enabled(
+        self, mock_send_alert: mock.MagicMock
+    ) -> None:
+        # Create an Activity instance with evidence data and priority
+        activity_data = asdict(self.evidence_data)
+
+        activity = Activity(
+            project=self.project,
+            group=self.group,
+            type=ActivityType.SET_RESOLVED.value,
+            data=activity_data,
+        )
+        activity.save()
+
+        # Create event data with Activity instead of GroupEvent
+        event_data_with_activity = WorkflowEventData(
+            event=activity,
+            workflow_env=self.workflow.environment,
+            group=self.group,
+        )
+
+        self.handler.invoke_legacy_registry(event_data_with_activity, self.action, self.detector)
+
+        assert mock_send_alert.call_count == 0
+
+    @mock.patch.object(TestHandler, "send_alert")
+    @with_feature("organizations:workflow-engine-single-process-metric-issues")
     def test_invoke_legacy_registry_with_activity(self, mock_send_alert: mock.MagicMock) -> None:
         # Create an Activity instance with evidence data and priority
         activity_data = asdict(self.evidence_data)
@@ -566,6 +593,7 @@ class TestBaseMetricAlertHandler(MetricAlertHandlerBase):
         assert isinstance(notification_uuid, str)
 
     @mock.patch.object(TestHandler, "send_alert")
+    @with_feature("organizations:workflow-engine-single-process-metric-issues")
     def test_invoke_legacy_registry_with_activity_anomaly_detection(
         self, mock_send_alert: mock.MagicMock
     ) -> None:
@@ -632,6 +660,7 @@ class TestBaseMetricAlertHandler(MetricAlertHandlerBase):
         assert organization == self.detector.project.organization
         assert isinstance(notification_uuid, str)
 
+    @with_feature("organizations:workflow-engine-single-process-metric-issues")
     def test_invoke_legacy_registry_activity_missing_data(self) -> None:
         # Test with Activity that has no data field
         activity = Activity.objects.create(
@@ -652,6 +681,7 @@ class TestBaseMetricAlertHandler(MetricAlertHandlerBase):
                 event_data_with_activity, self.action, self.detector
             )
 
+    @with_feature("organizations:workflow-engine-single-process-metric-issues")
     def test_invoke_legacy_registry_activity_empty_data(self) -> None:
         # Test with Activity that has non-empty but insufficient data for MetricIssueEvidenceData
         activity = Activity(


### PR DESCRIPTION
so that we can do a 1:1 comparison between the old and new system for metric issues, updating the FF check so that we fire resolution updates when we are single/dual processing.

we will actually send the notification only when we are single processing.