### PR TITLE
fix(aci): Fix casing for open periods query params

### DIFF
--- a/src/sentry/workflow_engine/endpoints/organization_open_periods.py
+++ b/src/sentry/workflow_engine/endpoints/organization_open_periods.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework.exceptions import ParseError, ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -12,6 +13,14 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import OrganizationDetectorPermission, OrganizationEndpoint
 from sentry.api.paginator import GenericOffsetPaginator
 from sentry.api.utils import get_date_range_from_params
+from sentry.apidocs.constants import (
+    RESPONSE_BAD_REQUEST,
+    RESPONSE_FORBIDDEN,
+    RESPONSE_NOT_FOUND,
+    RESPONSE_UNAUTHORIZED,
+)
+from sentry.apidocs.parameters import CursorQueryParam, GlobalParams, VisibilityParams
+from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.exceptions import InvalidParams
 from sentry.models.group import Group
 from sentry.models.groupopenperiod import OpenPeriod, get_open_periods_for_group
@@ -21,6 +30,7 @@ from sentry.workflow_engine.models.detector_group import DetectorGroup
 
 
 @region_silo_endpoint
+@extend_schema(tags=["Workflows"])
 class OrganizationOpenPeriodsEndpoint(OrganizationEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
@@ -35,10 +45,10 @@ class OrganizationOpenPeriodsEndpoint(OrganizationEndpoint):
         try:
             detector = Detector.objects.select_related("project").get(id=detector_id)
         except (Detector.DoesNotExist, ValueError):
-            raise ValidationError({"detector_id": "Detector not found"})
+            raise ValidationError({"detectorId": "Detector not found"})
 
         if detector.project.organization_id != organization.id:
-            raise ValidationError({"detector_id": "Detector not found"})
+            raise ValidationError({"detectorId": "Detector not found"})
 
         detector_group = (
             DetectorGroup.objects.filter(detector=detector).order_by("-date_added").first()
@@ -50,13 +60,45 @@ class OrganizationOpenPeriodsEndpoint(OrganizationEndpoint):
         try:
             group = Group.objects.select_related("project").get(id=group_id)
         except (Group.DoesNotExist, ValueError):
-            raise ValidationError({"group_id": "Group not found"})
+            raise ValidationError({"groupId": "Group not found"})
 
         if group.project.organization_id != organization.id:
-            raise ValidationError({"group_id": "Group not found"})
+            raise ValidationError({"groupId": "Group not found"})
 
         return group
 
+    @extend_schema(
+        operation_id="Fetch Group Open Periods",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            GlobalParams.START,
+            GlobalParams.END,
+            GlobalParams.STATS_PERIOD,
+            VisibilityParams.PER_PAGE,
+            CursorQueryParam,
+            OpenApiParameter(
+                name="detectorId",
+                location="query",
+                required=False,
+                type=str,
+                description="ID of the detector which is associated with the issue group.",
+            ),
+            OpenApiParameter(
+                name="groupId",
+                location="query",
+                required=False,
+                type=str,
+                description="ID of the issue group.",
+            ),
+        ],
+        responses={
+            200: inline_sentry_response_serializer("ListOpenPeriods", list[OpenPeriod]),
+            400: RESPONSE_BAD_REQUEST,
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
     def get(self, request: Request, organization: Organization) -> Response:
         """
         Return a list of open periods for a group, identified by either detector_id or group_id.
@@ -66,13 +108,13 @@ class OrganizationOpenPeriodsEndpoint(OrganizationEndpoint):
         except InvalidParams:
             raise ParseError(detail="Invalid date range")
 
-        detector_id_param = request.GET.get("detector_id")
-        group_id_param = request.GET.get("group_id")
+        detector_id_param = request.GET.get("detectorId")
+        group_id_param = request.GET.get("groupId")
 
         if not detector_id_param and not group_id_param:
-            raise ValidationError({"detail": "Must provide either detector_id or group_id"})
+            raise ValidationError({"detail": "Must provide either detectorId or groupId"})
         if detector_id_param and group_id_param:
-            raise ValidationError({"detail": "Must provide only one of detector_id or group_id"})
+            raise ValidationError({"detail": "Must provide only one of detectorId or groupId"})
 
         target_group: Group | None = (
             self.get_group_from_detector_id(detector_id_param, organization)

--- a/tests/sentry/workflow_engine/endpoints/test_organization_open_periods.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_open_periods.py
@@ -37,14 +37,14 @@ class OrganizationOpenPeriodsTest(APITestCase):
         # Create a new detector with no linked group
         detector = self.create_detector()
         resp = self.get_success_response(
-            self.organization.slug, qs_params={"detector_id": detector.id}
+            self.organization.slug, qs_params={"detectorId": detector.id}
         )
         assert resp.data == []
 
     @with_feature("organizations:issue-open-periods")
     def test_open_period_linked_to_group(self) -> None:
         response = self.get_success_response(
-            *self.get_url_args(), qs_params={"detector_id": self.detector.id}
+            *self.get_url_args(), qs_params={"detectorId": self.detector.id}
         )
         assert len(response.data) == 1
         open_period = response.data[0]
@@ -56,7 +56,7 @@ class OrganizationOpenPeriodsTest(APITestCase):
     @with_feature("organizations:issue-open-periods")
     def test_open_periods_group_id(self) -> None:
         response = self.get_success_response(
-            *self.get_url_args(), qs_params={"group_id": self.group.id}
+            *self.get_url_args(), qs_params={"groupId": self.group.id}
         )
         assert len(response.data) == 1
 
@@ -73,7 +73,7 @@ class OrganizationOpenPeriodsTest(APITestCase):
         last_checked = timezone.now() - timedelta(seconds=alert_rule.snuba_query.time_window)
 
         response = self.get_success_response(
-            *self.get_url_args(), qs_params={"group_id": self.group.id}
+            *self.get_url_args(), qs_params={"groupId": self.group.id}
         )
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
@@ -97,7 +97,7 @@ class OrganizationOpenPeriodsTest(APITestCase):
         )
 
         response = self.get_success_response(
-            *self.get_url_args(), qs_params={"group_id": self.group.id}
+            *self.get_url_args(), qs_params={"groupId": self.group.id}
         )
         assert response.status_code == 200, response.content
         assert response.data == [
@@ -143,7 +143,7 @@ class OrganizationOpenPeriodsTest(APITestCase):
         )
 
         response = self.get_success_response(
-            *self.get_url_args(), qs_params={"group_id": self.group.id}
+            *self.get_url_args(), qs_params={"groupId": self.group.id}
         )
         assert response.status_code == 200, response.content
         assert response.data == [
@@ -196,7 +196,7 @@ class OrganizationOpenPeriodsTest(APITestCase):
         )
 
         response = self.get_success_response(
-            *self.get_url_args(), qs_params={"group_id": self.group.id, "per_page": 1}
+            *self.get_url_args(), qs_params={"groupId": self.group.id, "per_page": 1}
         )
         assert response.status_code == 200, response.content
         assert len(response.data) == 1


### PR DESCRIPTION
- Fixes casing for query params on open periods endpoint (`detectorId` vs `detector_id`)
- Adds doc decorators