### PR TITLE
spike(aci milestone 3): incident creation based on open period creation

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -101,7 +101,6 @@ from sentry.utils.audit import create_audit_entry_from_user
 from sentry.utils.not_set import NOT_SET, NotSet
 from sentry.utils.snuba import is_measurement
 from sentry.workflow_engine.endpoints.validators.utils import toggle_detector
-from sentry.workflow_engine.models import IncidentGroupOpenPeriod
 from sentry.workflow_engine.models.detector import Detector
 
 # We can return an incident as "windowed" which returns a range of points around the start of the incident
@@ -181,14 +180,6 @@ def create_incident(
             organization_id=incident.organization_id,
             incident_type=incident_type.value,
         )
-
-        # If this is a metric alert incident, check for pending group relationships
-        if (
-            alert_rule
-            and incident_type == IncidentType.ALERT_TRIGGERED
-            and features.has("organizations:incident-group-open-period-write", organization)
-        ):
-            IncidentGroupOpenPeriod.create_pending_relationships_for_incident(incident, alert_rule)
 
     return incident
 

--- a/src/sentry/issues/ingest.py
+++ b/src/sentry/issues/ingest.py
@@ -73,8 +73,9 @@ def save_issue_occurrence(
         _get_or_create_group_release(environment, release, event, [group_info])
 
         # Create IncidentGroupOpenPeriod relationship for metric issues
+        # Only necessary if the organization is flagged into metric issue single processing
         if occurrence.type == MetricIssue and features.has(
-            "organizations:incident-group-open-period-write", event.organization
+            "organizations:workflow-engine-single-process-metric-issues", event.organization
         ):
             open_period = get_latest_open_period(group_info.group)
             if open_period:

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -35,6 +35,7 @@ from sentry.db.models import (
 )
 from sentry.db.models.fields.jsonfield import LegacyTextJSONField
 from sentry.db.models.manager.base import BaseManager
+from sentry.incidents.grouptype import MetricIssue
 from sentry.issues.grouptype import GroupCategory, get_group_type_by_type_id
 from sentry.issues.priority import (
     PRIORITY_TO_GROUP_HISTORY_STATUS,
@@ -503,7 +504,8 @@ class GroupManager(BaseManager["Group"]):
                     },
                 )
                 # if the group has an open period (is for a metric issue), then update its incident activity
-                update_incident_activity_based_on_group_activity(group, new_priority)
+                if group.type == MetricIssue.type_id:
+                    update_incident_activity_based_on_group_activity(group, new_priority)
                 record_group_history(group, PRIORITY_TO_GROUP_HISTORY_STATUS[new_priority])
 
             # The open period is only updated when a group is resolved or reopened. We don't want to

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -43,6 +43,7 @@ from sentry.issues.priority import (
 )
 from sentry.models.commit import Commit
 from sentry.models.grouphistory import record_group_history, record_group_history_from_activity_type
+from sentry.models.groupopenperiod import update_incident_activity_based_on_group_activity
 from sentry.models.organization import Organization
 from sentry.services.eventstore.models import GroupEvent
 from sentry.snuba.dataset import Dataset
@@ -501,6 +502,8 @@ class GroupManager(BaseManager["Group"]):
                         "reason": PriorityChangeReason.ONGOING,
                     },
                 )
+                # if the group has an open period (is for a metric issue), then update its incident activity
+                update_incident_activity_based_on_group_activity(group, new_priority)
                 record_group_history(group, PRIORITY_TO_GROUP_HISTORY_STATUS[new_priority])
 
             # The open period is only updated when a group is resolved or reopened. We don't want to


### PR DESCRIPTION
- For the purposes of <new system, old models>, we only need to create an `IncidentGroupOpenPeriod` relationship if an org is single processing metric issues through the workflow engine. Otherwise, the incidents and open periods are created independently. 
- If an org is single processing, then we need to create and update the incidents based on group creation and status update, as we will no longer be creating incidents through the subscription processor.
    - Create: if a group belongs to a metric issue, create a corresponding incident and IGOP.
    - Update: if a group belongs to a metric issue, update the created incident activity on group status change activity update.
    - Close: if a group belongs to a metric issue, update the created incident activity.

### To address in the real implementation:
- Verify that we're creating the incident/IGOP in the right place. 
- Verify that we see all the incident status updates that we expect.
- Verify that this works when a group is created for the first time.
- I did not test this so it's most definitely broken.