### PR TITLE
feat(replays): query timestamp_ms from issuesPlatform

### DIFF
--- a/src/sentry/replays/endpoints/organization_replay_events_meta.py
+++ b/src/sentry/replays/endpoints/organization_replay_events_meta.py
@@ -12,7 +12,6 @@ from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
 from sentry.api.paginator import GenericOffsetPaginator
 from sentry.api.utils import reformat_timestamp_ms_to_isoformat
 from sentry.models.organization import Organization
-from sentry.snuba.dataset import Dataset
 
 
 @region_silo_endpoint
@@ -44,10 +43,8 @@ class OrganizationReplayEventsMetaEndpoint(OrganizationEventsV2EndpointBase):
             "timestamp",
             "title",
             "level",
+            "timestamp_ms",
         ]
-        dataset_label = request.GET.get("dataset", Dataset.Discover.value)
-        if dataset_label == Dataset.Discover.value:
-            fields.append("timestamp_ms")
 
         return fields
 

--- a/src/sentry/replays/endpoints/organization_replay_events_meta.py
+++ b/src/sentry/replays/endpoints/organization_replay_events_meta.py
@@ -103,7 +103,7 @@ class OrganizationReplayEventsMetaEndpoint(OrganizationEventsV2EndpointBase):
             request, organization, project_ids, results, standard_meta, dataset
         )
         for event in results["data"]:
-            if "timestamp_ms" in event and event["timestamp_ms"] is not None:
+            if "timestamp_ms" in event and event["timestamp_ms"]:
                 event["timestamp"] = reformat_timestamp_ms_to_isoformat(event["timestamp_ms"])
 
             if "timestamp_ms" in event:


### PR DESCRIPTION
We now have `timestamp_ms` on issue platform events (see https://github.com/getsentry/snuba/pull/7362). replay-events-meta only queries discover and issuesPlatform, so now that both datasets have `timestamp_ms`, we can add it as a selected field.

Follows up https://github.com/getsentry/sentry/pull/90987

Closes https://linear.app/getsentry/issue/ID-615/precise-error-timestamps-on-errors-returned-by-replay-events-meta