### PR TITLE
feat(jira): control endpoint for fetching issue summaries

### DIFF
--- a/src/sentry/integrations/jira/urls.py
+++ b/src/sentry/integrations/jira/urls.py
@@ -1,11 +1,10 @@
 from django.urls import re_path
 
-from sentry.integrations.jira.views.sentry_issue_details import JiraSentryIssueDetailsControlView
-
 from .endpoints import JiraDescriptorEndpoint, JiraSearchEndpoint
 from .views import (
     JiraExtensionConfigurationView,
     JiraSentryInstallationView,
+    JiraSentryIssueDetailsControlView,
     JiraSentryIssueDetailsView,
 )
 from .webhooks import (

--- a/src/sentry/integrations/jira/urls.py
+++ b/src/sentry/integrations/jira/urls.py
@@ -1,5 +1,7 @@
 from django.urls import re_path
 
+from sentry.integrations.jira.views.sentry_issue_details import JiraSentryIssueDetailsControlView
+
 from .endpoints import JiraDescriptorEndpoint, JiraSearchEndpoint
 from .views import (
     JiraExtensionConfigurationView,
@@ -52,5 +54,10 @@ urlpatterns = [
         r"^issue/(?P<issue_key>[^/]+)/$",
         JiraSentryIssueDetailsView.as_view(),
         name="sentry-extensions-jira-issue-hook",
+    ),
+    re_path(
+        r"^issue-details/(?P<issue_key>[^/]+)/$",
+        JiraSentryIssueDetailsControlView.as_view(),
+        name="sentry-extensions-jira-issue-hook-control",
     ),
 ]

--- a/src/sentry/integrations/jira/views/__init__.py
+++ b/src/sentry/integrations/jira/views/__init__.py
@@ -4,12 +4,13 @@ UNABLE_TO_VERIFY_INSTALLATION = "Unable to verify installation"
 from .base import JiraSentryUIBaseView
 from .extension_configuration import JiraExtensionConfigurationView
 from .sentry_installation import JiraSentryInstallationView
-from .sentry_issue_details import JiraSentryIssueDetailsView
+from .sentry_issue_details import JiraSentryIssueDetailsControlView, JiraSentryIssueDetailsView
 
 __all__ = (
     "JiraSentryUIBaseView",
     "JiraExtensionConfigurationView",
     "JiraSentryIssueDetailsView",
     "JiraSentryInstallationView",
+    "JiraSentryIssueDetailsControlView",
     "UNABLE_TO_VERIFY_INSTALLATION",
 )

--- a/src/sentry/integrations/jira/views/sentry_issue_details.py
+++ b/src/sentry/integrations/jira/views/sentry_issue_details.py
@@ -190,7 +190,7 @@ class JiraSentryIssueDetailsControlView(JiraSentryUIBaseView):
     Fans the request to all regions and returns the groups from all regions.
     """
 
-    html_file = "sentry/integrations/jira-issue.html"
+    html_file = "sentry/integrations/jira-issue-list.html"
 
     def handle_groups(self, groups: list[RpcExternalIssueGroupMetadata]) -> Response:
         response_context = {"groups": [dict(group) for group in groups]}

--- a/src/sentry/integrations/jira/views/sentry_issue_details.py
+++ b/src/sentry/integrations/jira/views/sentry_issue_details.py
@@ -22,11 +22,14 @@ from sentry.integrations.utils.atlassian_connect import (
     AtlassianConnectValidationError,
     get_integration_from_request,
 )
+from sentry.issues.services.issue import issue_service
+from sentry.issues.services.issue.model import RpcExternalIssueGroupMetadata
 from sentry.models.group import Group
 from sentry.models.organization import Organization
 from sentry.shared_integrations.exceptions import ApiError
+from sentry.types.region import find_all_region_names
 from sentry.utils.http import absolute_uri
-from sentry.web.frontend.base import region_silo_view
+from sentry.web.frontend.base import control_silo_view, region_silo_view
 
 from ..utils import handle_jira_api_error, set_badge
 from . import UNABLE_TO_VERIFY_INSTALLATION, JiraSentryUIBaseView
@@ -172,6 +175,76 @@ class JiraSentryIssueDetailsView(JiraSentryUIBaseView):
             return self.get_response({"issue_not_linked": True})
 
         scope.set_tag("organization.slug", organization.slug)
+        response = self.handle_groups(groups)
+        scope.set_tag("status_code", response.status_code)
+
+        set_badge(integration, issue_key, len(groups))
+        return response
+
+
+@control_silo_view
+class JiraSentryIssueDetailsControlView(JiraSentryUIBaseView):
+    """
+    Handles requests (from the Sentry integration in Jira) for HTML to display when you
+    click on "Sentry -> Linked Issues" in the RH sidebar of an issue in the Jira UI.
+    Fans the request to all regions and returns the groups from all regions.
+    """
+
+    html_file = "sentry/integrations/jira-issue.html"
+
+    def handle_groups(self, groups: list[RpcExternalIssueGroupMetadata]) -> Response:
+        response_context = {"groups": [dict(group) for group in groups]}
+
+        logger.info(
+            "issue_hook.response",
+            extra={"issue_count": len(groups)},
+        )
+
+        return self.get_response(response_context)
+
+    def dispatch(self, request: HttpRequest, *args, **kwargs) -> HttpResponseBase:
+        try:
+            return super().dispatch(request, *args, **kwargs)
+        except ApiError as exc:
+            # Sometime set_badge() will fail to connect.
+            response_option = handle_jira_api_error(exc, " to set badge")
+            if response_option:
+                return self.get_response(response_option)
+            raise
+
+    def get(self, request: Request, issue_key, *args, **kwargs) -> Response:
+        scope = sentry_sdk.get_isolation_scope()
+
+        try:
+            integration = get_integration_from_request(request, "jira")
+        except AtlassianConnectValidationError as e:
+            scope.set_tag("failure", "AtlassianConnectValidationError")
+            logger.info(
+                "issue_hook.validation_error",
+                extra={
+                    "issue_key": issue_key,
+                    "error": str(e),
+                },
+            )
+            return self.get_response({"error_message": UNABLE_TO_VERIFY_INSTALLATION})
+        except ExpiredSignatureError:
+            scope.set_tag("failure", "ExpiredSignatureError")
+            return self.get_response({"refresh_required": True})
+
+        has_groups = False
+        groups = []
+        for region_name in find_all_region_names():
+            region_groups = issue_service.get_external_issue_groups(
+                region_name=region_name, external_issue_key=issue_key, integration_id=integration.id
+            )
+            if region_groups is not None:
+                groups.extend(region_groups)
+                has_groups = True
+
+        if not has_groups:
+            set_badge(integration, issue_key, 0)
+            return self.get_response({"issue_not_linked": True})
+
         response = self.handle_groups(groups)
         scope.set_tag("status_code", response.status_code)
 

--- a/src/sentry/issues/services/issue/impl.py
+++ b/src/sentry/issues/services/issue/impl.py
@@ -25,12 +25,23 @@ class DatabaseBackedIssueService(IssueService):
         )
 
         if not external_issues.exists():
+<<<<<<< HEAD
             return None
 
         if integration_service.get_integration(integration_id=integration_id) is None:
             return None
 
         if (
+=======
+            return None
+
+        if (
+            integration := integration_service.get_integration(integration_id=integration_id)
+        ) is None:
+            return None
+
+        if (
+>>>>>>> e252b9580bc (search for all external issues for the integration in the region)
             organization_integrations := integration_service.get_organization_integrations(
                 organization_ids={
                     external_issue.organization_id for external_issue in external_issues
@@ -43,15 +54,27 @@ class DatabaseBackedIssueService(IssueService):
         org_integration_org_ids = {
             org_integration.organization_id for org_integration in organization_integrations
         }
+<<<<<<< HEAD
+=======
+
+        organization = Organization.objects.filter(id__in=org_integration_org_ids)
+>>>>>>> e252b9580bc (search for all external issues for the integration in the region)
 
         organization = Organization.objects.filter(id__in=org_integration_org_ids)
 
+<<<<<<< HEAD
         external_issue_ids = external_issues.values_list("id", flat=True)
 
         # get the latest group link date for each group
         group_link_subquery = dict(
             GroupLink.objects.filter(
                 linked_id__in=external_issue_ids,
+=======
+        # get the latest group link date for each group
+        group_link_subquery: dict[int, datetime] = dict(
+            GroupLink.objects.filter(
+                linked_id__in=external_issue_subquery,
+>>>>>>> e252b9580bc (search for all external issues for the integration in the region)
                 project__organization__in=organization,
             )
             .values("group_id")

--- a/src/sentry/issues/services/issue/impl.py
+++ b/src/sentry/issues/services/issue/impl.py
@@ -25,21 +25,12 @@ class DatabaseBackedIssueService(IssueService):
         )
 
         if not external_issues.exists():
-<<<<<<< HEAD
             return None
 
         if integration_service.get_integration(integration_id=integration_id) is None:
             return None
 
         if (
-=======
-            return None
-
-        if integration_service.get_integration(integration_id=integration_id) is None:
-            return None
-
-        if (
->>>>>>> e252b9580bc (search for all external issues for the integration in the region)
             organization_integrations := integration_service.get_organization_integrations(
                 organization_ids={
                     external_issue.organization_id for external_issue in external_issues
@@ -52,35 +43,15 @@ class DatabaseBackedIssueService(IssueService):
         org_integration_org_ids = {
             org_integration.organization_id for org_integration in organization_integrations
         }
-<<<<<<< HEAD
-=======
-
-        organization = Organization.objects.filter(id__in=org_integration_org_ids)
->>>>>>> e252b9580bc (search for all external issues for the integration in the region)
 
         organization = Organization.objects.filter(id__in=org_integration_org_ids)
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> 2a6b812155d (refactor again)
         external_issue_ids = external_issues.values_list("id", flat=True)
 
         # get the latest group link date for each group
         group_link_subquery = dict(
-<<<<<<< HEAD
             GroupLink.objects.filter(
                 linked_id__in=external_issue_ids,
-=======
-        # get the latest group link date for each group
-        group_link_subquery: dict[int, datetime] = dict(
-            GroupLink.objects.filter(
-                linked_id__in=external_issue_subquery,
->>>>>>> e252b9580bc (search for all external issues for the integration in the region)
-=======
-            GroupLink.objects.filter(
-                linked_id__in=external_issue_ids,
->>>>>>> 2a6b812155d (refactor again)
                 project__organization__in=organization,
             )
             .values("group_id")

--- a/src/sentry/issues/services/issue/impl.py
+++ b/src/sentry/issues/services/issue/impl.py
@@ -35,9 +35,7 @@ class DatabaseBackedIssueService(IssueService):
 =======
             return None
 
-        if (
-            integration := integration_service.get_integration(integration_id=integration_id)
-        ) is None:
+        if integration_service.get_integration(integration_id=integration_id) is None:
             return None
 
         if (
@@ -63,10 +61,14 @@ class DatabaseBackedIssueService(IssueService):
         organization = Organization.objects.filter(id__in=org_integration_org_ids)
 
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> 2a6b812155d (refactor again)
         external_issue_ids = external_issues.values_list("id", flat=True)
 
         # get the latest group link date for each group
         group_link_subquery = dict(
+<<<<<<< HEAD
             GroupLink.objects.filter(
                 linked_id__in=external_issue_ids,
 =======
@@ -75,6 +77,10 @@ class DatabaseBackedIssueService(IssueService):
             GroupLink.objects.filter(
                 linked_id__in=external_issue_subquery,
 >>>>>>> e252b9580bc (search for all external issues for the integration in the region)
+=======
+            GroupLink.objects.filter(
+                linked_id__in=external_issue_ids,
+>>>>>>> 2a6b812155d (refactor again)
                 project__organization__in=organization,
             )
             .values("group_id")

--- a/src/sentry/middleware/integrations/parsers/jira.py
+++ b/src/sentry/middleware/integrations/parsers/jira.py
@@ -12,6 +12,7 @@ from sentry.integrations.jira.views import (
     JiraSentryInstallationView,
     JiraSentryIssueDetailsView,
 )
+from sentry.integrations.jira.views.sentry_issue_details import JiraSentryIssueDetailsControlView
 from sentry.integrations.jira.webhooks import (
     JiraIssueUpdatedWebhook,
     JiraSentryInstalledWebhook,
@@ -40,6 +41,7 @@ class JiraRequestParser(BaseRequestParser):
         JiraSentryUninstalledWebhook,
         JiraExtensionConfigurationView,
         JiraSearchEndpoint,
+        JiraSentryIssueDetailsControlView,
     ]
 
     immediate_response_region_classes = [JiraSentryIssueDetailsView]

--- a/src/sentry/templates/sentry/integrations/jira-issue-list.html
+++ b/src/sentry/templates/sentry/integrations/jira-issue-list.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+{% load i18n %}
+{% load sentry_assets %}
+<html lang="en">
+  <head>
+    <meta charset="utf-8"/>
+    {% script src=ac_js_src %}{% endscript %}
+    <style>
+      {% include 'sentry/integrations/jira/aui-prototyping.9.1.5.css' %}
+      body {
+        background: transparent;
+      }
+      .container {
+        padding: 30px;
+      }
+      .aui-message::after {
+        font-family: arial, sans-serif;
+        content: 'i';
+        font-size: 13px;
+        line-height: 16px;
+        width: 16px;
+        height: 16px;
+        text-align: center;
+        border-radius: 50%;
+
+        color: #fff;
+        font-weight: bold;
+        background: var(--aui-message-info-icon-color);
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      {% if error_message %}
+      <div class="aui-message aui-message-info">
+        <h2>Error</h2>
+        <p>{{ error_message }}</p>
+      </div>
+
+      {% elif refresh_required %}
+      <div class="aui-message aui-message-info">
+        <h2>Error</h2>
+        <p>
+          {% trans "This page has expired, please refresh to view the Sentry issue" %}
+        </p>
+      </div>
+
+      {% elif issue_not_linked %}
+      <div class="aui-message aui-message-info">
+        <h2>Issue not linked</h2>
+        <p>{% trans "This Sentry issue is not linked to a Jira issue" %}</p>
+      </div>
+      {% else %}
+
+      {% for group in groups %}
+      <div>
+        <p><a href="{{ group.title_url }}" target="_blank">{{ group.title }}</a> - last linked {{ group.link_date|date:"Y-m-d H:i:s" }}</p>
+      </div>
+      <br/>
+      {% if not forloop.last %}
+      <hr style="opacity:0.5;" />
+      {% endif %}
+
+      {% endfor %}
+      {% endif %}
+    </div>
+  </body>
+</html>

--- a/static/app/data/controlsiloUrlPatterns.ts
+++ b/static/app/data/controlsiloUrlPatterns.ts
@@ -189,6 +189,7 @@ const patterns: RegExp[] = [
   new RegExp('^extensions/jira/uninstalled/$'),
   new RegExp('^extensions/jira/search/[^/]+/[^/]+/$'),
   new RegExp('^extensions/jira/configure/$'),
+  new RegExp('^extensions/jira/issue-details/[^/]+/$'),
   new RegExp('^extensions/jira-server/search/[^/]+/[^/]+/$'),
   new RegExp('^extensions/slack/event/$'),
   new RegExp('^extensions/slack/link-identity/[^/]+/$'),

--- a/tests/sentry/integrations/jira/test_sentry_issue_details.py
+++ b/tests/sentry/integrations/jira/test_sentry_issue_details.py
@@ -259,13 +259,11 @@ class JiraIssueHookControlTest(APITestCase):
         assert UNABLE_TO_VERIFY_INSTALLATION.encode() in response.content
 
     @patch.object(ExternalIssue.objects, "get")
-    @patch.object(Group, "get_last_release")
     @patch("sentry.integrations.jira.views.sentry_issue_details.get_integration_from_request")
     @responses.activate
     def test_simple_get(
         self,
         mock_get_integration_from_request: MagicMock,
-        mock_get_last_release: MagicMock,
         mock_get_external_issue: MagicMock,
     ) -> None:
         responses.add(
@@ -274,20 +272,13 @@ class JiraIssueHookControlTest(APITestCase):
 
         mock_get_external_issue.side_effect = [self.de_external_issue, self.us_external_issue]
 
-        mock_get_last_release.return_value = self.last_release.version
         mock_get_integration_from_request.return_value = self.integration
         response = self.client.get(self.path)
         assert response.status_code == 200
         resp_content = response.content.decode()
 
         for group in [self.us_group, self.de_group]:
-            assert group.title in resp_content
             assert group.get_absolute_url() in resp_content
-            assert group.first_seen.strftime("%b. %d, %Y") in resp_content
-            assert group.last_seen.strftime("%b. %d, %Y") in resp_content
-
-        assert self.first_release.version in resp_content
-        assert self.last_release.version in resp_content
 
     @patch("sentry.integrations.jira.views.sentry_issue_details.get_integration_from_request")
     @responses.activate

--- a/tests/sentry/integrations/jira/test_sentry_issue_details.py
+++ b/tests/sentry/integrations/jira/test_sentry_issue_details.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 import responses
@@ -7,13 +7,15 @@ from jwt import ExpiredSignatureError
 from sentry.integrations.jira import JIRA_KEY
 from sentry.integrations.jira.views import UNABLE_TO_VERIFY_INSTALLATION
 from sentry.integrations.models.external_issue import ExternalIssue
-from sentry.integrations.models.integration import Integration
 from sentry.integrations.utils.atlassian_connect import AtlassianConnectValidationError
 from sentry.models.group import Group
 from sentry.models.grouplink import GroupLink
+from sentry.models.project import Project
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.silo import assume_test_silo_mode_of
+from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.testutils.skips import requires_snuba
+from sentry.types.region import Region, RegionCategory
 from sentry.utils.http import absolute_uri
 
 pytestmark = [requires_snuba]
@@ -22,30 +24,165 @@ pytestmark = [requires_snuba]
 REFRESH_REQUIRED = b"This page has expired, please refresh to view the Sentry issue"
 CLICK_TO_FINISH = b"Click to Finish Installation"
 
+us = Region("us", 1, "https://us.testserver", RegionCategory.MULTI_TENANT)
+de = Region("de", 2, "https://de.testserver", RegionCategory.MULTI_TENANT)
+region_config = (us, de)
 
-class JiraIssueHookTest(APITestCase):
+
+# class JiraIssueHookTest(APITestCase):
+#     def setUp(self) -> None:
+#         super().setUp()
+#         self.first_seen = datetime(2015, 8, 13, 3, 8, 25, tzinfo=timezone.utc)
+#         self.last_seen = datetime(2016, 1, 13, 3, 8, 25, tzinfo=timezone.utc)
+#         self.first_release = self.create_release(
+#             project=self.project, version="v1.0", date_added=self.first_seen
+#         )
+#         self.last_release = self.create_release(
+#             project=self.project, version="v1.1", date_added=self.last_seen
+#         )
+
+#         self.group = self.create_group(
+#             self.project,
+#             message="Sentry Error",
+#             first_seen=self.first_seen,
+#             last_seen=self.last_seen,
+#             first_release=self.first_release,
+#         )
+#         group = self.group
+#         self.issue_key = "APP-123"
+#         self.path = absolute_uri(f"extensions/jira/issue/{self.issue_key}/") + "?xdm_e=base_url"
+
+#         self.integration = self.create_provider_integration(
+#             provider="jira",
+#             name="Example Jira",
+#             metadata={
+#                 "base_url": "https://getsentry.atlassian.net",
+#                 "shared_secret": "a-super-secret-key-from-atlassian",
+#             },
+#         )
+#         with assume_test_silo_mode_of(Integration):
+#             self.integration.add_organization(self.organization, self.user)
+
+#         self.external_issue = ExternalIssue.objects.create(
+#             organization_id=group.organization.id,
+#             integration_id=self.integration.id,
+#             key=self.issue_key,
+#         )
+
+#         GroupLink.objects.create(
+#             group_id=group.id,
+#             project_id=group.project_id,
+#             linked_type=GroupLink.LinkedType.issue,
+#             linked_id=self.external_issue.id,
+#             relationship=GroupLink.Relationship.references,
+#         )
+
+#         self.login_as(self.user)
+
+#         self.properties_key = f"com.atlassian.jira.issue:{JIRA_KEY}:sentry-issues-glance:status"
+#         self.properties_url = "https://getsentry.atlassian.net/rest/api/3/issue/%s/properties/%s"
+
+#     @patch(
+#         "sentry.integrations.jira.views.sentry_issue_details.get_integration_from_request",
+#         side_effect=ExpiredSignatureError(),
+#     )
+#     def test_expired_signature_error(self, mock_get_integration_from_request: MagicMock) -> None:
+#         response = self.client.get(self.path)
+#         assert response.status_code == 200
+#         assert REFRESH_REQUIRED in response.content
+
+#     @patch(
+#         "sentry.integrations.jira.views.sentry_issue_details.get_integration_from_request",
+#         side_effect=AtlassianConnectValidationError(),
+#     )
+#     def test_expired_invalid_installation_error(
+#         self, mock_get_integration_from_request: MagicMock
+#     ) -> None:
+#         response = self.client.get(self.path)
+#         assert response.status_code == 200
+#         assert UNABLE_TO_VERIFY_INSTALLATION.encode() in response.content
+
+#     @patch.object(Group, "get_last_release")
+#     @patch("sentry.integrations.jira.views.sentry_issue_details.get_integration_from_request")
+#     @responses.activate
+#     def test_simple_get(
+#         self, mock_get_integration_from_request: MagicMock, mock_get_last_release: MagicMock
+#     ) -> None:
+#         responses.add(
+#             responses.PUT, self.properties_url % (self.issue_key, self.properties_key), json={}
+#         )
+
+#         mock_get_last_release.return_value = self.last_release.version
+#         mock_get_integration_from_request.return_value = self.integration
+#         response = self.client.get(self.path)
+#         assert response.status_code == 200
+#         resp_content = response.content.decode()
+#         assert self.group.title in resp_content
+#         assert self.group.get_absolute_url() in resp_content
+#         assert self.first_seen.strftime("%b. %d, %Y") in resp_content
+#         assert self.last_seen.strftime("%b. %d, %Y") in resp_content
+#         assert self.first_release.version in resp_content
+#         assert self.last_release.version in resp_content
+
+#     @patch.object(Group, "get_last_release")
+#     @patch("sentry.integrations.jira.views.sentry_issue_details.get_integration_from_request")
+#     @responses.activate
+#     def test_multiple_issues(
+#         self, mock_get_integration_from_request: MagicMock, mock_get_last_release: MagicMock
+#     ) -> None:
+#         responses.add(
+#             responses.PUT, self.properties_url % (self.issue_key, self.properties_key), json={}
+#         )
+#         mock_get_integration_from_request.return_value = self.integration
+#         mock_get_last_release.return_value = self.last_release.version
+
+#         new_group = self.create_group()
+
+#         GroupLink.objects.create(
+#             group_id=new_group.id,
+#             project_id=new_group.project_id,
+#             linked_type=GroupLink.LinkedType.issue,
+#             linked_id=self.external_issue.id,
+#             relationship=GroupLink.Relationship.references,
+#         )
+
+#         response = self.client.get(self.path)
+
+#         assert response.status_code == 200
+#         resp_content = response.content.decode()
+#         group_url = self.group.get_absolute_url()
+#         new_group_url = new_group.get_absolute_url()
+
+#         assert group_url != new_group_url
+#         assert group_url in resp_content
+#         assert new_group_url in resp_content
+
+#     @patch("sentry.integrations.jira.views.sentry_issue_details.get_integration_from_request")
+#     @responses.activate
+#     def test_simple_not_linked(self, mock_get_integration_from_request: MagicMock) -> None:
+#         issue_key = "bad-key"
+#         responses.add(
+#             responses.PUT, self.properties_url % (issue_key, self.properties_key), json={}
+#         )
+
+#         mock_get_integration_from_request.return_value = self.integration
+#         path = absolute_uri("extensions/jira/issue/bad-key/") + "?xdm_e=base_url"
+#         response = self.client.get(path)
+#         assert response.status_code == 200
+#         assert b"This Sentry issue is not linked to a Jira issue" in response.content
+
+
+@control_silo_test(regions=region_config)
+class JiraIssueHookControlTest(APITestCase):
     def setUp(self) -> None:
         super().setUp()
         self.first_seen = datetime(2015, 8, 13, 3, 8, 25, tzinfo=timezone.utc)
         self.last_seen = datetime(2016, 1, 13, 3, 8, 25, tzinfo=timezone.utc)
-        self.first_release = self.create_release(
-            project=self.project, version="v1.0", date_added=self.first_seen
-        )
-        self.last_release = self.create_release(
-            project=self.project, version="v1.1", date_added=self.last_seen
-        )
 
-        self.group = self.create_group(
-            self.project,
-            message="Sentry Error",
-            first_seen=self.first_seen,
-            last_seen=self.last_seen,
-            first_release=self.first_release,
-        )
-        group = self.group
         self.issue_key = "APP-123"
-        self.path = absolute_uri(f"extensions/jira/issue/{self.issue_key}/") + "?xdm_e=base_url"
-
+        self.path = (
+            absolute_uri(f"extensions/jira/issue-details/{self.issue_key}/") + "?xdm_e=base_url"
+        )
         self.integration = self.create_provider_integration(
             provider="jira",
             name="Example Jira",
@@ -54,22 +191,60 @@ class JiraIssueHookTest(APITestCase):
                 "shared_secret": "a-super-secret-key-from-atlassian",
             },
         )
-        with assume_test_silo_mode_of(Integration):
-            self.integration.add_organization(self.organization, self.user)
 
-        self.external_issue = ExternalIssue.objects.create(
-            organization_id=group.organization.id,
-            integration_id=self.integration.id,
-            key=self.issue_key,
-        )
+        with assume_test_silo_mode(SiloMode.REGION, region_name="us"):
+            self.us_org = self.create_organization(region="us")
+            self.us_project = Project.objects.create(organization=self.us_org)
+            self.first_release = self.create_release(
+                project=self.us_project, version="v1.0", date_added=self.first_seen
+            )
+            self.last_release = self.create_release(
+                project=self.us_project, version="v1.1", date_added=self.last_seen
+            )
 
-        GroupLink.objects.create(
-            group_id=group.id,
-            project_id=group.project_id,
-            linked_type=GroupLink.LinkedType.issue,
-            linked_id=self.external_issue.id,
-            relationship=GroupLink.Relationship.references,
-        )
+            self.us_group = Group.objects.create(
+                project=self.us_project,
+                message="Sentry Error US",
+                first_seen=self.first_seen,
+                last_seen=self.last_seen,
+                first_release=self.first_release,
+            )
+            self.us_external_issue = ExternalIssue.objects.create(
+                organization_id=self.us_group.organization.id,
+                integration_id=self.integration.id,
+                key=self.issue_key,
+            )
+            GroupLink.objects.create(
+                group_id=self.us_group.id,
+                project_id=self.us_group.project_id,
+                linked_type=GroupLink.LinkedType.issue,
+                linked_id=self.us_external_issue.id,
+                relationship=GroupLink.Relationship.references,
+            )
+        with assume_test_silo_mode(SiloMode.REGION, region_name="de"):
+            self.de_org = self.create_organization(region="de")
+            self.de_project = Project.objects.create(organization=self.de_org)
+            self.de_group = Group.objects.create(
+                project=self.de_project,
+                message="Sentry Error DE",
+                first_seen=self.first_seen + timedelta(hours=1),
+                last_seen=self.last_seen + timedelta(hours=1),
+            )
+            self.de_external_issue = ExternalIssue.objects.create(
+                organization_id=self.de_group.organization.id,
+                integration_id=self.integration.id,
+                key=self.issue_key,
+            )
+            GroupLink.objects.create(
+                group_id=self.de_group.id,
+                project_id=self.de_group.project_id,
+                linked_type=GroupLink.LinkedType.issue,
+                linked_id=self.de_external_issue.id,
+                relationship=GroupLink.Relationship.references,
+            )
+
+        self.integration.add_organization(self.us_org, self.user)
+        self.integration.add_organization(self.de_org, self.user)
 
         self.login_as(self.user)
 
@@ -111,12 +286,16 @@ class JiraIssueHookTest(APITestCase):
         response = self.client.get(self.path)
         assert response.status_code == 200
         resp_content = response.content.decode()
-        assert self.group.title in resp_content
-        assert self.group.get_absolute_url() in resp_content
-        assert self.first_seen.strftime("%b. %d, %Y") in resp_content
-        assert self.last_seen.strftime("%b. %d, %Y") in resp_content
-        assert self.first_release.version in resp_content
-        assert self.last_release.version in resp_content
+
+        for group in [self.us_group, self.de_group]:
+            assert group.title in resp_content
+            assert group.get_absolute_url() in resp_content
+            assert group.first_seen.strftime("%b. %d, %Y") in resp_content
+            assert group.last_seen.strftime("%b. %d, %Y") in resp_content
+            if group.first_release:
+                assert group.first_release.version in resp_content
+            if group.last_release:
+                assert group.last_release.version in resp_content
 
     @patch.object(Group, "get_last_release")
     @patch("sentry.integrations.jira.views.sentry_issue_details.get_integration_from_request")
@@ -130,13 +309,13 @@ class JiraIssueHookTest(APITestCase):
         mock_get_integration_from_request.return_value = self.integration
         mock_get_last_release.return_value = self.last_release.version
 
-        new_group = self.create_group()
+        new_group = self.create_group(project=self.us_project)
 
         GroupLink.objects.create(
             group_id=new_group.id,
             project_id=new_group.project_id,
             linked_type=GroupLink.LinkedType.issue,
-            linked_id=self.external_issue.id,
+            linked_id=self.us_external_issue.id,
             relationship=GroupLink.Relationship.references,
         )
 
@@ -144,7 +323,7 @@ class JiraIssueHookTest(APITestCase):
 
         assert response.status_code == 200
         resp_content = response.content.decode()
-        group_url = self.group.get_absolute_url()
+        group_url = self.us_group.get_absolute_url()
         new_group_url = new_group.get_absolute_url()
 
         assert group_url != new_group_url


### PR DESCRIPTION
For [RTC-43](https://linear.app/getsentry/issue/RTC-43/unable-to-install-jira-in-an-organisation-in-the-eu-region)

Implement a new Control-Silo endpoint for Jira to use which will perform region fanouts for issue data.