### PR TITLE
test(aci): Reduce flakes from event.type:error test

### DIFF
--- a/static/app/views/detectors/new-setting.spec.tsx
+++ b/static/app/views/detectors/new-setting.spec.tsx
@@ -186,8 +186,8 @@ describe('DetectorEdit', () => {
 
       await userEvent.type(screen.getByRole('spinbutton', {name: 'Threshold'}), '100');
 
-      await userEvent.type(
-        screen.getByLabelText('Add a search term'),
+      await userEvent.click(screen.getByLabelText('Add a search term'));
+      await userEvent.paste(
         // Filter to a specific event type
         'event.type:error'
       );
@@ -223,6 +223,6 @@ describe('DetectorEdit', () => {
           })
         );
       });
-    });
+    }, 10_000);
   });
 });


### PR DESCRIPTION
Use paste instead of type. Takes test time locally to 569ms from 1100ms. Our search bar has a fairly expensive rerender.