### PR TITLE
ref(grouping): Rename grouping ruleset classes

### DIFF
--- a/src/sentry/core/endpoints/project_details.py
+++ b/src/sentry/core/endpoints/project_details.py
@@ -38,7 +38,7 @@ from sentry.dynamic_sampling.types import DynamicSamplingMode
 from sentry.dynamic_sampling.utils import has_custom_dynamic_sampling, has_dynamic_sampling
 from sentry.grouping.enhancer import Enhancements
 from sentry.grouping.enhancer.exceptions import InvalidEnhancerConfig
-from sentry.grouping.fingerprinting import FingerprintingRules
+from sentry.grouping.fingerprinting import FingerprintingConfig
 from sentry.grouping.fingerprinting.exceptions import InvalidFingerprintingConfig
 from sentry.ingest.inbound_filters import FilterTypes
 from sentry.issues.highlights import HighlightContextField
@@ -378,7 +378,7 @@ E.g. `['release', 'environment']`""",
             return value
 
         try:
-            FingerprintingRules.from_config_string(value)
+            FingerprintingConfig.from_config_string(value)
         except InvalidFingerprintingConfig as e:
             raise serializers.ValidationError(str(e))
 

--- a/src/sentry/core/endpoints/project_details.py
+++ b/src/sentry/core/endpoints/project_details.py
@@ -36,7 +36,7 @@ from sentry.deletions.models.scheduleddeletion import RegionScheduledDeletion
 from sentry.dynamic_sampling import get_supported_biases_ids, get_user_biases
 from sentry.dynamic_sampling.types import DynamicSamplingMode
 from sentry.dynamic_sampling.utils import has_custom_dynamic_sampling, has_dynamic_sampling
-from sentry.grouping.enhancer import Enhancements
+from sentry.grouping.enhancer import EnhancementsConfig
 from sentry.grouping.enhancer.exceptions import InvalidEnhancerConfig
 from sentry.grouping.fingerprinting import FingerprintingConfig
 from sentry.grouping.fingerprinting.exceptions import InvalidFingerprintingConfig
@@ -357,7 +357,7 @@ E.g. `['release', 'environment']`""",
             return value
 
         try:
-            Enhancements.from_rules_text(value)
+            EnhancementsConfig.from_rules_text(value)
         except InvalidEnhancerConfig as e:
             raise serializers.ValidationError(str(e))
 

--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -224,7 +224,7 @@ def load_grouping_config(config_dict: GroupingConfig | None = None) -> StrategyC
     if config_id not in GROUPING_CONFIG_CLASSES:
         config_dict = get_default_grouping_config_dict()
         config_id = config_dict["id"]
-    return GROUPING_CONFIG_CLASSES[config_id](enhancements=config_dict["enhancements"])
+    return GROUPING_CONFIG_CLASSES[config_id](base64_enhancements=config_dict["enhancements"])
 
 
 def _load_default_grouping_config() -> StrategyConfiguration:

--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -18,7 +18,7 @@ from sentry.grouping.component import (
 )
 from sentry.grouping.enhancer import (
     DEFAULT_ENHANCEMENTS_BASE,
-    Enhancements,
+    EnhancementsConfig,
     get_enhancements_version,
 )
 from sentry.grouping.enhancer.exceptions import InvalidEnhancerConfig
@@ -120,7 +120,7 @@ class GroupingConfigLoader:
                     if enhancements_string
                     else derived_enhancements
                 )
-            base64_enhancements = Enhancements.from_rules_text(
+            base64_enhancements = EnhancementsConfig.from_rules_text(
                 enhancements_string,
                 bases=[enhancements_base] if enhancements_base else [],
                 version=enhancements_version,
@@ -186,7 +186,7 @@ def _get_default_base64_enhancements(config_id: str | None = None) -> str:
     base: str | None = DEFAULT_ENHANCEMENTS_BASE
     if config_id is not None and config_id in GROUPING_CONFIG_CLASSES.keys():
         base = GROUPING_CONFIG_CLASSES[config_id].enhancements_base
-    return Enhancements.from_rules_text("", bases=[base] if base else []).base64_string
+    return EnhancementsConfig.from_rules_text("", bases=[base] if base else []).base64_string
 
 
 def _get_default_fingerprinting_bases_for_project(

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -330,7 +330,7 @@ def get_enhancements_version(project: Project, grouping_config_id: str = "") -> 
     return DEFAULT_ENHANCEMENTS_VERSION
 
 
-class Enhancements:
+class EnhancementsConfig:
     # NOTE: You must add a version to ``VERSIONS`` any time attributes are added
     # to this class, s.t. no enhancements lacking these attributes are loaded
     # from cache.
@@ -557,8 +557,8 @@ class Enhancements:
     @classmethod
     def from_base64_string(
         cls, base64_string: str | bytes, referrer: str | None = None
-    ) -> Enhancements:
-        """Convert a base64 string into an `Enhancements` object"""
+    ) -> EnhancementsConfig:
+        """Convert a base64 string into an `EnhancementsConfig` object"""
 
         with metrics.timer("grouping.enhancements.creation") as metrics_timer_tags:
             metrics_timer_tags.update({"source": "base64_string", "referrer": referrer})
@@ -604,15 +604,15 @@ class Enhancements:
         id: str | None = None,
         version: int | None = None,
         referrer: str | None = None,
-    ) -> Enhancements:
-        """Create an `Enhancements` object from a text blob containing stacktrace rules"""
+    ) -> EnhancementsConfig:
+        """Create an `EnhancementsConfig` object from a text blob containing stacktrace rules"""
 
         with metrics.timer("grouping.enhancements.creation") as metrics_timer_tags:
             metrics_timer_tags.update(
                 {"split": version == 3, "source": "rules_text", "referrer": referrer}
             )
 
-            return Enhancements(
+            return EnhancementsConfig(
                 rules=parse_enhancements(rules_text),
                 version=version,
                 bases=bases,
@@ -620,7 +620,7 @@ class Enhancements:
             )
 
 
-def _load_configs() -> dict[str, Enhancements]:
+def _load_configs() -> dict[str, EnhancementsConfig]:
     enhancement_bases = {}
     configs_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), "enhancement-configs")
     for filename in os.listdir(configs_dir):
@@ -631,7 +631,7 @@ def _load_configs() -> dict[str, Enhancements]:
                 # We cannot use `:` in filenames on Windows but we already have ids with
                 # `:` in their names hence this trickery.
                 filename = filename.replace("@", ":")
-                enhancements = Enhancements.from_rules_text(
+                enhancements = EnhancementsConfig.from_rules_text(
                     f.read(), id=filename, referrer="default_rules"
                 )
                 enhancement_bases[filename] = enhancements

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -58,7 +58,7 @@ VALID_PROFILING_ACTIONS_SET = frozenset(["+app", "-app"])
 
 
 @dataclass
-class EnhancementsConfig:
+class EnhancementsConfigData:
     rules: list[EnhancementRule]
     rust_enhancements: RustEnhancements
     version: int | None = None
@@ -214,7 +214,7 @@ def _get_hint_for_frame(
 
 def _split_rules(
     rules: list[EnhancementRule],
-) -> tuple[EnhancementsConfig, EnhancementsConfig]:
+) -> tuple[EnhancementsConfigData, EnhancementsConfigData]:
     """
     Given a list of EnhancementRules, each of which may have both classifier and contributes
     actions, split the rules into separate classifier and contributes rule lists, and return them
@@ -249,8 +249,8 @@ def _split_rules(
     contributes_rust_enhancements = _get_rust_enhancements("config_string", contributes_rules_text)
 
     return (
-        EnhancementsConfig(classifier_rules, classifier_rust_enhancements),
-        EnhancementsConfig(contributes_rules, contributes_rust_enhancements),
+        EnhancementsConfigData(classifier_rules, classifier_rust_enhancements),
+        EnhancementsConfigData(contributes_rules, contributes_rust_enhancements),
     )
 
 
@@ -339,7 +339,9 @@ class Enhancements:
     def __init__(
         self,
         rules: list[EnhancementRule],
-        split_enhancement_configs: tuple[EnhancementsConfig, EnhancementsConfig] | None = None,
+        split_enhancement_configs: (
+            tuple[EnhancementsConfigData, EnhancementsConfigData] | None
+        ) = None,
         version: int | None = None,
         bases: list[str] | None = None,
         id: str | None = None,
@@ -528,7 +530,7 @@ class Enhancements:
         return base64_str
 
     @classmethod
-    def _get_config_from_base64_bytes(cls, bytes_str: bytes) -> EnhancementsConfig:
+    def _get_config_from_base64_bytes(cls, bytes_str: bytes) -> EnhancementsConfigData:
         padded_bytes = bytes_str + b"=" * (4 - (len(bytes_str) % 4))
 
         try:
@@ -550,7 +552,7 @@ class Enhancements:
         except (LookupError, AttributeError, TypeError, ValueError) as e:
             raise ValueError("invalid stack trace rule config: %s" % e)
 
-        return EnhancementsConfig(rules, rust_enhancements, version, bases)
+        return EnhancementsConfigData(rules, rust_enhancements, version, bases)
 
     @classmethod
     def from_base64_string(

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -321,8 +321,8 @@ def keep_profiling_rules(config: str) -> str:
 
 def get_enhancements_version(project: Project, grouping_config_id: str = "") -> int:
     """
-    Decide whether the Enhancements should be from the latest version or the version before. Useful
-    when transitioning between versions.
+    Decide whether the enhancements config should be from the latest version or the version before.
+    Useful when transitioning between versions.
 
     See https://github.com/getsentry/sentry/pull/91695 for a version of this function which
     incorporates sampling.

--- a/src/sentry/grouping/fingerprinting/__init__.py
+++ b/src/sentry/grouping/fingerprinting/__init__.py
@@ -21,7 +21,7 @@ CONFIGS_DIR: Path = Path(__file__).with_name("configs")
 DEFAULT_GROUPING_FINGERPRINTING_BASES: list[str] = []
 
 
-class FingerprintingRules:
+class FingerprintingConfig:
     def __init__(
         self,
         rules: Sequence[FingerprintRule],
@@ -93,7 +93,7 @@ class FingerprintingRules:
     @classmethod
     def from_config_string(
         cls, s: Any, bases: Sequence[str] | None = None, mark_as_built_in: bool = False
-    ) -> FingerprintingRules:
+    ) -> FingerprintingConfig:
         try:
             tree = fingerprinting_grammar.parse(s)
         except ParseError as e:
@@ -134,7 +134,7 @@ def _load_configs() -> dict[str, list[FingerprintRule]]:
             with open(config_file_path) as config_file:
                 str_conf = config_file.read().rstrip()
                 configs[config_name].extend(
-                    FingerprintingRules.from_config_string(str_conf, mark_as_built_in=True).rules
+                    FingerprintingConfig.from_config_string(str_conf, mark_as_built_in=True).rules
                 )
         except InvalidFingerprintingConfig:
             logger.exception(

--- a/src/sentry/grouping/strategies/base.py
+++ b/src/sentry/grouping/strategies/base.py
@@ -326,8 +326,8 @@ class StrategyConfiguration:
     enhancements_base: str | None = DEFAULT_ENHANCEMENTS_BASE
     fingerprinting_bases: Sequence[str] | None = DEFAULT_GROUPING_FINGERPRINTING_BASES
 
-    def __init__(self, enhancements: str | None = None):
-        if enhancements is None:
+    def __init__(self, base64_enhancements: str | None = None):
+        if base64_enhancements is None:
             enhancements_config = EnhancementsConfig.from_rules_text("", referrer="strategy_config")
         else:
             # If the enhancements string has been loaded from an existing event, it may be from an
@@ -335,7 +335,7 @@ class StrategyConfiguration:
             # this grouping config
             try:
                 enhancements_config = EnhancementsConfig.from_base64_string(
-                    enhancements, referrer="strategy_config"
+                    base64_enhancements, referrer="strategy_config"
                 )
             except InvalidEnhancerConfig:
                 enhancements_config = ENHANCEMENT_BASES[

--- a/src/sentry/grouping/strategies/base.py
+++ b/src/sentry/grouping/strategies/base.py
@@ -328,23 +328,21 @@ class StrategyConfiguration:
 
     def __init__(self, enhancements: str | None = None):
         if enhancements is None:
-            enhancements_instance = EnhancementsConfig.from_rules_text(
-                "", referrer="strategy_config"
-            )
+            enhancements_config = EnhancementsConfig.from_rules_text("", referrer="strategy_config")
         else:
             # If the enhancements string has been loaded from an existing event, it may be from an
             # obsolete enhancements version, in which case we just use the default enhancements for
             # this grouping config
             try:
-                enhancements_instance = EnhancementsConfig.from_base64_string(
+                enhancements_config = EnhancementsConfig.from_base64_string(
                     enhancements, referrer="strategy_config"
                 )
             except InvalidEnhancerConfig:
-                enhancements_instance = ENHANCEMENT_BASES[
+                enhancements_config = ENHANCEMENT_BASES[
                     self.enhancements_base or DEFAULT_ENHANCEMENTS_BASE
                 ]
 
-        self.enhancements = enhancements_instance
+        self.enhancements = enhancements_config
 
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__} {self.id!r}>"

--- a/src/sentry/grouping/strategies/base.py
+++ b/src/sentry/grouping/strategies/base.py
@@ -9,7 +9,11 @@ from sentry.grouping.component import (
     FrameGroupingComponent,
     StacktraceGroupingComponent,
 )
-from sentry.grouping.enhancer import DEFAULT_ENHANCEMENTS_BASE, ENHANCEMENT_BASES, Enhancements
+from sentry.grouping.enhancer import (
+    DEFAULT_ENHANCEMENTS_BASE,
+    ENHANCEMENT_BASES,
+    EnhancementsConfig,
+)
 from sentry.grouping.enhancer.exceptions import InvalidEnhancerConfig
 from sentry.grouping.fingerprinting import DEFAULT_GROUPING_FINGERPRINTING_BASES
 from sentry.interfaces.base import Interface
@@ -324,13 +328,15 @@ class StrategyConfiguration:
 
     def __init__(self, enhancements: str | None = None):
         if enhancements is None:
-            enhancements_instance = Enhancements.from_rules_text("", referrer="strategy_config")
+            enhancements_instance = EnhancementsConfig.from_rules_text(
+                "", referrer="strategy_config"
+            )
         else:
             # If the enhancements string has been loaded from an existing event, it may be from an
             # obsolete enhancements version, in which case we just use the default enhancements for
             # this grouping config
             try:
-                enhancements_instance = Enhancements.from_base64_string(
+                enhancements_instance = EnhancementsConfig.from_base64_string(
                     enhancements, referrer="strategy_config"
                 )
             except InvalidEnhancerConfig:

--- a/src/sentry/profiles/utils.py
+++ b/src/sentry/profiles/utils.py
@@ -12,7 +12,7 @@ from django.http import HttpResponse as SentryResponse
 from urllib3.connectionpool import ConnectionPool
 from urllib3.response import HTTPResponse as VroomResponse
 
-from sentry.grouping.enhancer import Enhancements, keep_profiling_rules
+from sentry.grouping.enhancer import EnhancementsConfig, keep_profiling_rules
 from sentry.net.http import connection_from_url
 from sentry.utils import json, metrics
 from sentry.utils.sdk import set_span_attribute
@@ -175,7 +175,7 @@ def apply_stack_trace_rules_to_profile(profile: Profile, rules_config: str) -> N
     profiling_rules = keep_profiling_rules(rules_config)
     if profiling_rules == "":
         return
-    enhancements = Enhancements.from_rules_text(profiling_rules, referrer="profiling")
+    enhancements = EnhancementsConfig.from_rules_text(profiling_rules, referrer="profiling")
     if "version" in profile:
         enhancements.apply_category_and_updated_in_app_to_frames(
             profile["profile"]["frames"], profile["platform"], {}

--- a/src/sentry/workflow_engine/endpoints/validators/error_detector.py
+++ b/src/sentry/workflow_engine/endpoints/validators/error_detector.py
@@ -3,7 +3,7 @@ from rest_framework import serializers
 
 from sentry import audit_log
 from sentry.api.fields.empty_integer import EmptyIntegerField
-from sentry.grouping.fingerprinting import FingerprintingRules
+from sentry.grouping.fingerprinting import FingerprintingConfig
 from sentry.grouping.fingerprinting.exceptions import InvalidFingerprintingConfig
 from sentry.models.project import Project
 from sentry.utils.audit import create_audit_entry
@@ -38,7 +38,7 @@ class ErrorDetectorValidator(BaseDetectorTypeValidator):
             return value
 
         try:
-            FingerprintingRules.from_config_string(value)
+            FingerprintingConfig.from_config_string(value)
         except InvalidFingerprintingConfig as e:
             raise serializers.ValidationError(str(e))
 

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -1235,9 +1235,9 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         assert event1.culprit == "foobar"
 
     def test_culprit_after_stacktrace_processing(self) -> None:
-        from sentry.grouping.enhancer import Enhancements
+        from sentry.grouping.enhancer import EnhancementsConfig
 
-        enhancements_str = Enhancements.from_rules_text(
+        enhancements_str = EnhancementsConfig.from_rules_text(
             """
             function:in_app_function +app
             function:not_in_app_function -app
@@ -2603,9 +2603,9 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         Regression test to ensure that grouping in-app enhancements work in
         principle.
         """
-        from sentry.grouping.enhancer import Enhancements
+        from sentry.grouping.enhancer import EnhancementsConfig
 
-        enhancements_str = Enhancements.from_rules_text(
+        enhancements_str = EnhancementsConfig.from_rules_text(
             """
             function:foo category=bar
             function:foo2 category=bar
@@ -2679,9 +2679,9 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         Regression test to ensure categories are applied consistently and don't
         produce hash mismatches.
         """
-        from sentry.grouping.enhancer import Enhancements
+        from sentry.grouping.enhancer import EnhancementsConfig
 
-        enhancements_str = Enhancements.from_rules_text(
+        enhancements_str = EnhancementsConfig.from_rules_text(
             """
             function:foo category=foo_like
             category:foo_like -group

--- a/tests/sentry/grouping/__init__.py
+++ b/tests/sentry/grouping/__init__.py
@@ -20,7 +20,7 @@ from sentry.grouping.api import (
     load_grouping_config,
 )
 from sentry.grouping.component import BaseGroupingComponent
-from sentry.grouping.enhancer import Enhancements
+from sentry.grouping.enhancer import EnhancementsConfig
 from sentry.grouping.fingerprinting import FingerprintingConfig
 from sentry.grouping.strategies.configurations import (
     GROUPING_CONFIG_CLASSES,
@@ -126,9 +126,9 @@ class GroupingInput:
         grouping_config = get_default_grouping_config_dict(config_name)
 
         # Add in any extra grouping configuration from the input data
-        grouping_config["enhancements"] = Enhancements.from_rules_text(
+        grouping_config["enhancements"] = EnhancementsConfig.from_rules_text(
             self.data.get("_grouping", {}).get("enhancements", ""),
-            bases=Enhancements.from_base64_string(grouping_config["enhancements"]).bases,
+            bases=EnhancementsConfig.from_base64_string(grouping_config["enhancements"]).bases,
         ).base64_string
         fingerprinting_config = FingerprintingConfig.from_json(
             {"rules": self.data.get("_fingerprinting_rules", [])},

--- a/tests/sentry/grouping/__init__.py
+++ b/tests/sentry/grouping/__init__.py
@@ -21,7 +21,7 @@ from sentry.grouping.api import (
 )
 from sentry.grouping.component import BaseGroupingComponent
 from sentry.grouping.enhancer import Enhancements
-from sentry.grouping.fingerprinting import FingerprintingRules
+from sentry.grouping.fingerprinting import FingerprintingConfig
 from sentry.grouping.strategies.configurations import (
     GROUPING_CONFIG_CLASSES,
     register_grouping_config,
@@ -72,7 +72,7 @@ class GroupingInput:
             self.data = json.load(f)
 
     def _manually_save_event(
-        self, grouping_config: GroupingConfig, fingerprinting_config: FingerprintingRules
+        self, grouping_config: GroupingConfig, fingerprinting_config: FingerprintingConfig
     ) -> Event:
         """
         Manually complete the steps to save an event, in such a way as to not touch postgres (which
@@ -102,7 +102,7 @@ class GroupingInput:
     def _save_event_with_pipeline(
         self,
         grouping_config: GroupingConfig,
-        fingerprinting_config: FingerprintingRules,
+        fingerprinting_config: FingerprintingConfig,
         project: Project,
     ) -> Event:
         with (
@@ -130,7 +130,7 @@ class GroupingInput:
             self.data.get("_grouping", {}).get("enhancements", ""),
             bases=Enhancements.from_base64_string(grouping_config["enhancements"]).bases,
         ).base64_string
-        fingerprinting_config = FingerprintingRules.from_json(
+        fingerprinting_config = FingerprintingConfig.from_json(
             {"rules": self.data.get("_fingerprinting_rules", [])},
             bases=GROUPING_CONFIG_CLASSES[config_name].fingerprinting_bases,
         )
@@ -302,8 +302,8 @@ class FingerprintInput:
         with open(path.join(FINGERPRINT_INPUTS_DIR, self.filename)) as f:
             return json.load(f)
 
-    def create_event(self) -> tuple[FingerprintingRules, Event]:
-        config = FingerprintingRules.from_json(
+    def create_event(self) -> tuple[FingerprintingConfig, Event]:
+        config = FingerprintingConfig.from_json(
             {"rules": self.data.get("_fingerprinting_rules", [])},
             bases=GROUPING_CONFIG_CLASSES[DEFAULT_GROUPING_CONFIG].fingerprinting_bases,
         )

--- a/tests/sentry/grouping/test_builtin_fingerprinting.py
+++ b/tests/sentry/grouping/test_builtin_fingerprinting.py
@@ -12,7 +12,7 @@ from sentry.grouping.api import (
     get_default_grouping_config_dict,
     get_fingerprinting_config_for_project,
 )
-from sentry.grouping.fingerprinting import FINGERPRINTING_BASES, FingerprintingRules, _load_configs
+from sentry.grouping.fingerprinting import FINGERPRINTING_BASES, FingerprintingConfig, _load_configs
 from sentry.services import eventstore
 from sentry.services.eventstore.models import Event
 from sentry.testutils.cases import TestCase
@@ -119,7 +119,7 @@ def test_default_bases(default_bases: list[str]) -> None:
 
 
 def test_built_in_nextjs_rules_base(default_bases: list[str]) -> None:
-    rules = FingerprintingRules(rules=[], bases=default_bases)
+    rules = FingerprintingConfig(rules=[], bases=default_bases)
 
     assert rules._to_config_structure() == {"rules": [], "version": 1}
     assert rules._to_config_structure(include_builtin=True) == {
@@ -213,7 +213,7 @@ def test_built_in_nextjs_rules_base(default_bases: list[str]) -> None:
 def test_built_in_nextjs_rules_from_empty_config_string(
     default_bases: list[str],
 ) -> None:
-    rules = FingerprintingRules.from_config_string("", bases=default_bases)
+    rules = FingerprintingConfig.from_config_string("", bases=default_bases)
 
     assert rules._to_config_structure() == {"rules": [], "version": 1}
     assert rules._to_config_structure(include_builtin=True) == {
@@ -307,7 +307,7 @@ def test_built_in_nextjs_rules_from_empty_config_string(
 def test_built_in_nextjs_rules_from_config_string_with_custom(
     default_bases: list[str],
 ) -> None:
-    rules = FingerprintingRules.from_config_string(
+    rules = FingerprintingConfig.from_config_string(
         "error.type:DatabaseUnavailable -> DatabaseUnavailable",
         bases=default_bases,
     )
@@ -457,7 +457,7 @@ def test_load_configs_borked_file_doesnt_blow_up(tmp_path: Path) -> None:
 def test_builtinfingerprinting_rules_from_config_structure_overrides_is_builtin(
     is_builtin: bool | None,
 ) -> None:
-    rules = FingerprintingRules._from_config_structure(
+    rules = FingerprintingConfig._from_config_structure(
         {
             "rules": [
                 {
@@ -479,7 +479,7 @@ def test_builtinfingerprinting_rules_from_config_structure_overrides_is_builtin(
 def test_fingerprinting_rules_from_config_structure_preserves_is_builtin(
     is_builtin: bool | None,
 ) -> None:
-    rules = FingerprintingRules._from_config_structure(
+    rules = FingerprintingConfig._from_config_structure(
         {
             "rules": [
                 {
@@ -727,7 +727,7 @@ class BuiltInFingerprintingTest(TestCase):
         mgr.normalize()
         data = mgr.get_data()
         data.setdefault("fingerprint", ["{{ default }}"])
-        fingerprinting_config = FingerprintingRules.from_config_string(
+        fingerprinting_config = FingerprintingConfig.from_config_string(
             'family:javascript tags.transaction:"*" message:"Text content does not match server-rendered HTML." -> hydrationerror, {{tags.transaction}}'
         )
         apply_server_side_fingerprinting(data, fingerprinting_config)

--- a/tests/sentry/grouping/test_fingerprinting.py
+++ b/tests/sentry/grouping/test_fingerprinting.py
@@ -4,7 +4,7 @@ import pytest
 
 from sentry.db.models.fields.node import NodeData
 from sentry.grouping.api import get_default_grouping_config_dict
-from sentry.grouping.fingerprinting import FingerprintingRules
+from sentry.grouping.fingerprinting import FingerprintingConfig
 from sentry.grouping.fingerprinting.exceptions import InvalidFingerprintingConfig
 from sentry.grouping.utils import resolve_fingerprint_values
 from sentry.grouping.variants import BaseVariant
@@ -15,7 +15,7 @@ GROUPING_CONFIG = get_default_grouping_config_dict()
 
 
 def test_basic_parsing() -> None:
-    rules = FingerprintingRules.from_config_string(
+    rules = FingerprintingConfig.from_config_string(
         """
 # This is a config
 type:DatabaseUnavailable                        -> DatabaseUnavailable
@@ -139,7 +139,7 @@ logger:sentry.*                                 -> logger-{{ logger }} title="Me
     }
 
     assert (
-        FingerprintingRules._from_config_structure(
+        FingerprintingConfig._from_config_structure(
             rules._to_config_structure()
         )._to_config_structure()
         == rules._to_config_structure()
@@ -147,7 +147,7 @@ logger:sentry.*                                 -> logger-{{ logger }} title="Me
 
 
 def test_rule_export() -> None:
-    rules = FingerprintingRules.from_config_string(
+    rules = FingerprintingConfig.from_config_string(
         """
 logger:sentry.*                                 -> logger, {{ logger }}, title="Message from {{ logger }}"
 """
@@ -162,11 +162,11 @@ logger:sentry.*                                 -> logger, {{ logger }}, title="
 
 def test_parsing_errors() -> None:
     with pytest.raises(InvalidFingerprintingConfig):
-        FingerprintingRules.from_config_string("invalid.message:foo -> bar")
+        FingerprintingConfig.from_config_string("invalid.message:foo -> bar")
 
 
 def test_automatic_argument_splitting() -> None:
-    rules = FingerprintingRules.from_config_string(
+    rules = FingerprintingConfig.from_config_string(
         """
 logger:test -> logger-{{ logger }}
 logger:test -> logger-, {{ logger }}
@@ -206,7 +206,7 @@ logger:test2 -> logger-, {{ logger }}, -, {{ level }}
 
 
 def test_discover_field_parsing() -> None:
-    rules = FingerprintingRules.from_config_string(
+    rules = FingerprintingConfig.from_config_string(
         """
 # This is a config
 error.type:DatabaseUnavailable                        -> DatabaseUnavailable
@@ -253,7 +253,7 @@ release:foo                                     -> release-foo
     }
 
     assert (
-        FingerprintingRules._from_config_structure(
+        FingerprintingConfig._from_config_structure(
             rules._to_config_structure()
         )._to_config_structure()
         == rules._to_config_structure()

--- a/tests/sentry/services/eventstore/test_models.py
+++ b/tests/sentry/services/eventstore/test_models.py
@@ -7,7 +7,7 @@ from sentry import eventstore, nodestore
 from sentry.conf.server import DEFAULT_GROUPING_CONFIG
 from sentry.db.models.fields.node import NodeData, NodeIntegrityFailure
 from sentry.grouping.api import GroupingConfig, get_grouping_variants_for_event
-from sentry.grouping.enhancer import Enhancements
+from sentry.grouping.enhancer import EnhancementsConfig
 from sentry.grouping.utils import hash_from_values
 from sentry.grouping.variants import ComponentVariant
 from sentry.interfaces.user import User
@@ -369,7 +369,7 @@ class EventTest(TestCase, PerformanceIssueTestCase):
             },
         }
 
-        enhancements = Enhancements.from_rules_text(
+        enhancements = EnhancementsConfig.from_rules_text(
             """
             function:foo category=foo_like
             category:foo_like -group

--- a/tests/sentry/tasks/test_reprocessing2.py
+++ b/tests/sentry/tasks/test_reprocessing2.py
@@ -9,7 +9,7 @@ import pytest
 from sentry.attachments import attachment_cache
 from sentry.conf.server import DEFAULT_GROUPING_CONFIG
 from sentry.event_manager import EventManager
-from sentry.grouping.enhancer import Enhancements
+from sentry.grouping.enhancer import EnhancementsConfig
 from sentry.grouping.fingerprinting import FingerprintingConfig
 from sentry.models.activity import Activity
 from sentry.models.eventattachment import EventAttachment
@@ -630,7 +630,7 @@ def test_apply_new_stack_trace_rules(
         "sentry.grouping.ingest.hashing.get_grouping_config_dict_for_project",
         return_value={
             "id": DEFAULT_GROUPING_CONFIG,
-            "enhancements": Enhancements.from_rules_text(
+            "enhancements": EnhancementsConfig.from_rules_text(
                 "function:c -group",
                 bases=[],
             ).base64_string,

--- a/tests/sentry/tasks/test_reprocessing2.py
+++ b/tests/sentry/tasks/test_reprocessing2.py
@@ -10,7 +10,7 @@ from sentry.attachments import attachment_cache
 from sentry.conf.server import DEFAULT_GROUPING_CONFIG
 from sentry.event_manager import EventManager
 from sentry.grouping.enhancer import Enhancements
-from sentry.grouping.fingerprinting import FingerprintingRules
+from sentry.grouping.fingerprinting import FingerprintingConfig
 from sentry.models.activity import Activity
 from sentry.models.eventattachment import EventAttachment
 from sentry.models.group import Group
@@ -522,7 +522,7 @@ def test_apply_new_fingerprinting_rules(
     assert event1.group.message == "hello world 2"
 
     # Change fingerprinting rules
-    new_rules = FingerprintingRules.from_config_string(
+    new_rules = FingerprintingConfig.from_config_string(
         """
     message:"hello world 1" -> hw1 title="HW1"
     """


### PR DESCRIPTION
This contains a number of renamings for clarity, all having to do with grouping rules. Key changes:

- `FingerprintingRules` is now `FingerprintingConfig` to better distinguish it from `FingerprintingRule`.
- `EnhancementsConfig` (which is used as input to the current `Enhancements` constructor) is now `EnhancementsConfigData`, to make it clearer it's not the fully-formed enhancement config (and to clear the way for the next change).
- `Enhancements` is now `EnhancementsConfig`, to match `FingerprintingConfig`.