### PR TITLE
feat(debug-files): Add debugFilesRole project option

### DIFF
--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -957,6 +957,7 @@ class DetailedProjectResponse(ProjectWithTeamResponseDict):
     tempestFetchDumps: NotRequired[bool]
     autofixAutomationTuning: NotRequired[str]
     seerScannerAutomation: NotRequired[bool]
+    debugFilesRole: NotRequired[str | None]
 
 
 class DetailedProjectSerializer(ProjectWithTeamSerializer):
@@ -1105,6 +1106,7 @@ class DetailedProjectSerializer(ProjectWithTeamSerializer):
             "seerScannerAutomation": self.get_value_with_default(
                 attrs, "sentry:seer_scanner_automation"
             ),
+            "debugFilesRole": attrs["options"].get("sentry:debug_files_role"),
         }
 
         if has_tempest_access(obj.organization, user):

--- a/src/sentry/apidocs/examples/project_examples.py
+++ b/src/sentry/apidocs/examples/project_examples.py
@@ -264,6 +264,7 @@ DETAILED_PROJECT = {
     "symbolSources": "[]",
     "tempestFetchScreenshots": False,
     "tempestFetchDumps": False,
+    "debugFilesRole": None,
     "isDynamicallySampled": True,
     "autofixAutomationTuning": "off",
     "seerScannerAutomation": True,

--- a/src/sentry/core/endpoints/project_details.py
+++ b/src/sentry/core/endpoints/project_details.py
@@ -11,7 +11,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.serializers import ListField
 
-from sentry import audit_log, features
+from sentry import audit_log, features, roles
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectPermission
@@ -137,6 +137,7 @@ class ProjectMemberSerializer(serializers.Serializer):
         "tempestFetchDumps",
         "autofixAutomationTuning",
         "seerScannerAutomation",
+        "debugFilesRole",
     ]
 )
 class ProjectAdminSerializer(ProjectMemberSerializer):
@@ -234,6 +235,12 @@ E.g. `['release', 'environment']`""",
     # Keeping options here for backward compatibility but removing it from documentation.
     options = serializers.DictField(
         required=False,
+    )
+    debugFilesRole = serializers.ChoiceField(
+        choices=roles.get_choices(),
+        required=False,
+        allow_null=True,
+        help_text="The role required to download debug information files, ProGuard mappings and source maps. If not set, inherits from organization setting.",
     )
 
     def validate(self, data):
@@ -446,6 +453,16 @@ E.g. `['release', 'environment']`""",
             raise serializers.ValidationError(
                 "Organization does not have the tempest feature enabled."
             )
+        return value
+
+    def validate_debugFilesRole(self, value):
+        if value is None:
+            return value
+
+        try:
+            roles.get(value)
+        except KeyError:
+            raise serializers.ValidationError("Invalid role")
         return value
 
 
@@ -753,6 +770,9 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
                 changed_proj_settings["sentry:seer_scanner_automation"] = result[
                     "seerScannerAutomation"
                 ]
+        if "debugFilesRole" in result:
+            if project.update_option("sentry:debug_files_role", result["debugFilesRole"]):
+                changed_proj_settings["sentry:debug_files_role"] = result["debugFilesRole"]
 
         if has_elevated_scopes:
             options = result.get("options", {})

--- a/src/sentry/core/endpoints/project_details.py
+++ b/src/sentry/core/endpoints/project_details.py
@@ -771,8 +771,12 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
                     "seerScannerAutomation"
                 ]
         if "debugFilesRole" in result:
-            if project.update_option("sentry:debug_files_role", result["debugFilesRole"]):
-                changed_proj_settings["sentry:debug_files_role"] = result["debugFilesRole"]
+            if result["debugFilesRole"] is None:
+                project.delete_option("sentry:debug_files_role")
+                changed_proj_settings["sentry:debug_files_role"] = None
+            else:
+                if project.update_option("sentry:debug_files_role", result["debugFilesRole"]):
+                    changed_proj_settings["sentry:debug_files_role"] = result["debugFilesRole"]
 
         if has_elevated_scopes:
             options = result.get("options", {})

--- a/src/sentry/models/options/project_option.py
+++ b/src/sentry/models/options/project_option.py
@@ -67,6 +67,7 @@ OPTION_KEYS = frozenset(
         "sentry:uptime_autodetection",
         "sentry:autofix_automation_tuning",
         "sentry:seer_scanner_automation",
+        "sentry:debug_files_role",
         "quotas:spike-protection-disabled",
         "feedback:branding",
         "digests:mail:minimum_delay",

--- a/tests/sentry/core/endpoints/test_project_details.py
+++ b/tests/sentry/core/endpoints/test_project_details.py
@@ -1027,6 +1027,29 @@ class ProjectUpdateTest(APITestCase):
         assert self.project.get_option("sentry:store_crash_reports") is None
         assert resp.data["storeCrashReports"] is None
 
+    def test_debug_files_role(self) -> None:
+        # Test setting a valid role
+        resp = self.get_success_response(self.org_slug, self.proj_slug, debugFilesRole="admin")
+        assert self.project.get_option("sentry:debug_files_role") == "admin"
+        assert resp.data["debugFilesRole"] == "admin"
+
+        # Test setting another valid role
+        resp = self.get_success_response(self.org_slug, self.proj_slug, debugFilesRole="member")
+        assert self.project.get_option("sentry:debug_files_role") == "member"
+        assert resp.data["debugFilesRole"] == "member"
+
+        # Test setting to None (inherit from organization)
+        resp = self.get_success_response(self.org_slug, self.proj_slug, debugFilesRole=None)
+        assert self.project.get_option("sentry:debug_files_role") is None
+        assert resp.data["debugFilesRole"] is None
+
+    def test_debug_files_role_invalid(self) -> None:
+        # Test with invalid role
+        self.get_error_response(
+            self.org_slug, self.proj_slug, debugFilesRole="invalid_role", status_code=400
+        )
+        assert self.project.get_option("sentry:debug_files_role") is None
+
     def test_react_hydration_errors(self) -> None:
         options = {"filters:react-hydration-errors": False}
         resp = self.get_success_response(self.org_slug, self.proj_slug, options=options)


### PR DESCRIPTION
Introduces new project option `debugFilesRole` which can be used to override organization setting for minimal role required to download debug files. 

This will allow more granular permission control, as it will allow users to set this on per project basis. If this is not set on project, it will inherit from organization options.

This is first of a couple of PRs that will introduce this functionality
