### PR TITLE
feat: Remove third add credentials button

### DIFF
--- a/static/app/views/settings/project/tempest/EmptyState.tsx
+++ b/static/app/views/settings/project/tempest/EmptyState.tsx
@@ -84,9 +84,6 @@ export default function EmptyState({
                 )}
               </DescriptionWrapper>
               <Flex direction="column" align="end" gap="xl">
-                {!tempestCredentials?.length && (
-                  <AddCredentialsButton project={project} />
-                )}
                 <StyledPanelTable
                   headers={[
                     t('Client ID'),


### PR DESCRIPTION
We already display this button 2x and we do not need an extra button as shown below:

<img width="1413" height="984" alt="Screenshot 2025-08-27 at 09 58 58" src="https://github.com/user-attachments/assets/fea13d64-ede0-4ad9-b280-7ea59fb4bc6d" />
