### PR TITLE
feat(debug-files): Setting to manage debug files permissions on project level

### DIFF
--- a/static/app/data/forms/projectGeneralSettings.tsx
+++ b/static/app/data/forms/projectGeneralSettings.tsx
@@ -220,8 +220,12 @@ export const fields = {
       const value = model.getValue(name);
       // empty value means that this project should inherit organization settings
       if (value === null || value === undefined) {
+        const orgRoleName =
+          organization.orgRoleList?.find(
+            (r: {id: string; name: string}) => r.id === organization.debugFilesRole
+          )?.name || organization.debugFilesRole;
         return tct('Inherit organization setting ([organizationValue])', {
-          organizationValue: organization.debugFilesRole,
+          organizationValue: orgRoleName,
         });
       }
       return value;
@@ -230,7 +234,10 @@ export const fields = {
       [
         '',
         tct('Inherit organization setting ([organizationValue])', {
-          organizationValue: organization.debugFilesRole,
+          organizationValue:
+            organization.orgRoleList?.find(
+              (r: {id: string; name: string}) => r.id === organization.debugFilesRole
+            )?.name || organization.debugFilesRole,
         }),
       ],
       ...(organization?.orgRoleList?.map((r: {id: string; name: string}) => [

--- a/static/app/data/forms/projectGeneralSettings.tsx
+++ b/static/app/data/forms/projectGeneralSettings.tsx
@@ -4,6 +4,7 @@ import {PlatformIcon} from 'platformicons';
 import {hasEveryAccess} from 'sentry/components/acl/access';
 import {CodeSnippet} from 'sentry/components/codeSnippet';
 import {Button} from 'sentry/components/core/button';
+import {Link} from 'sentry/components/core/link';
 import {createFilter} from 'sentry/components/forms/controls/reactSelectWrapper';
 import type {Field} from 'sentry/components/forms/types';
 import {Hovercard} from 'sentry/components/hovercard';
@@ -200,5 +201,49 @@ export const fields = {
     type: 'boolean',
     label: t('Verify TLS/SSL'),
     help: t('Outbound requests will verify TLS (sometimes known as SSL) connections'),
+  },
+  debugFilesRole: {
+    name: 'debugFilesRole',
+    type: 'select',
+    label: t('Debug Files Access'),
+    visible: ({features}) => features.has('organizations:debug-files-role-management'),
+    help: ({organization}) =>
+      tct(
+        'Role required to download debug information files, proguard mappings and source maps. Overrides [organizationSettingsLink: organization settings].',
+        {
+          organizationSettingsLink: (
+            <Link to={`/settings/${organization.slug}/#debugFilesRole`} />
+          ),
+        }
+      ),
+    placeholder: ({organization, name, model}) => {
+      const value = model.getValue(name);
+      // empty value means that this project should inherit organization settings
+      if (value === null || value === undefined) {
+        return tct('Inherit organization setting ([organizationValue])', {
+          organizationValue: organization.debugFilesRole,
+        });
+      }
+      return value;
+    },
+    choices: ({organization}) => [
+      [
+        '',
+        tct('Inherit organization setting ([organizationValue])', {
+          organizationValue: organization.debugFilesRole,
+        }),
+      ],
+      ...(organization?.orgRoleList?.map((r: {id: string; name: string}) => [
+        r.id,
+        r.name,
+      ]) ?? []),
+    ],
+    setValue: val => {
+      // If empty string is selected, return null to inherit from organization
+      if (val === '') {
+        return null;
+      }
+      return val;
+    },
   },
 } satisfies Record<string, Field>;

--- a/static/app/types/project.tsx
+++ b/static/app/types/project.tsx
@@ -69,6 +69,7 @@ export type Project = {
   verifySSL: boolean;
   autofixAutomationTuning?: 'off' | 'super_low' | 'low' | 'medium' | 'high' | 'always';
   builtinSymbolSources?: string[];
+  debugFilesRole?: string | null;
   defaultEnvironment?: string;
   hasUserReports?: boolean;
   highlightContext?: Record<string, string[]>;

--- a/static/app/views/settings/projectGeneralSettings/index.tsx
+++ b/static/app/views/settings/projectGeneralSettings/index.tsx
@@ -331,6 +331,12 @@ function ProjectGeneralSettings({onChangeSlug}: Props) {
 
         <JsonForm
           {...jsonFormProps}
+          title={t('Membership')}
+          fields={[fields.debugFilesRole]}
+        />
+
+        <JsonForm
+          {...jsonFormProps}
           title={t('Client Security')}
           fields={[
             fields.allowedDomains,


### PR DESCRIPTION
Adds a new section in project settings for controlling access to debug files:

<img width="801" height="363" alt="image" src="https://github.com/user-attachments/assets/e9f70272-9b21-4866-b80d-2e952da7436e" />
