### PR TITLE
feat: Add origin to gaming related analytics

### DIFF
--- a/static/app/actionCreators/modal.tsx
+++ b/static/app/actionCreators/modal.tsx
@@ -426,6 +426,7 @@ export async function openInsightChartModal(options: InsightChartModalOptions) {
 
 export async function openAddTempestCredentialsModal(options: {
   organization: Organization;
+  origin: 'onboarding' | 'project-creation' | 'project-settings';
   project: Project;
 }) {
   const {default: Modal} = await import(

--- a/static/app/components/modals/addTempestCredentialsModal.tsx
+++ b/static/app/components/modals/addTempestCredentialsModal.tsx
@@ -11,11 +11,12 @@ import {useFetchTempestCredentials} from 'sentry/views/settings/project/tempest/
 
 interface Props extends ModalRenderProps {
   organization: Organization;
+  origin: 'onboarding' | 'project-creation' | 'project-settings';
   project: Project;
 }
 
 export default function AddCredentialsModal({Body, Header, ...props}: Props) {
-  const {closeModal, organization, project} = props;
+  const {closeModal, organization, project, origin} = props;
   const {invalidateCredentialsCache} = useFetchTempestCredentials(organization, project);
 
   const onSuccess = () => {
@@ -25,6 +26,7 @@ export default function AddCredentialsModal({Body, Header, ...props}: Props) {
     trackAnalytics('tempest.credentials.added', {
       organization,
       project_slug: project.slug,
+      origin,
     });
   };
 

--- a/static/app/components/modals/privateGamingSdkAccessModal.tsx
+++ b/static/app/components/modals/privateGamingSdkAccessModal.tsx
@@ -24,6 +24,7 @@ type GamingPlatform = (typeof PRIVATE_GAMING_SDK_OPTIONS)[number]['value'];
 
 export interface PrivateGamingSdkAccessModalProps {
   organization: Organization;
+  origin: 'onboarding' | 'project-creation' | 'project-settings';
   projectId: string;
   projectSlug: string;
   sdkName: string;
@@ -42,6 +43,7 @@ export function PrivateGamingSdkAccessModal({
   gamingPlatform,
   projectId,
   onSubmit,
+  origin,
 }: PrivateGamingSdkAccessModalProps & ModalRenderProps) {
   const user = useUser();
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -58,8 +60,9 @@ export function PrivateGamingSdkAccessModal({
       platform: gamingPlatform,
       project_id: projectId,
       organization,
+      origin,
     });
-  }, [gamingPlatform, organization, projectId]);
+  }, [gamingPlatform, organization, projectId, origin]);
 
   async function handleSubmit() {
     if (!isFormValid) {
@@ -74,6 +77,7 @@ export function PrivateGamingSdkAccessModal({
       project_id: projectId,
       platform: gamingPlatform,
       organization,
+      origin,
     });
 
     onSubmit?.();

--- a/static/app/components/modals/projectCreationModal.tsx
+++ b/static/app/components/modals/projectCreationModal.tsx
@@ -75,6 +75,7 @@ export default function ProjectCreationModal({
           ...selectedPlatform,
           key: selectedPlatform.id,
         },
+        origin: 'project-creation',
         onClose: () => {
           openProjectCreationModal({
             defaultCategory: selectedPlatform.category,

--- a/static/app/components/onboarding/consoleModal.tsx
+++ b/static/app/components/onboarding/consoleModal.tsx
@@ -89,6 +89,7 @@ export const CONSOLE_PLATFORM_INSTRUCTIONS = {
 
 export interface ConsoleModalProps {
   organization: Organization;
+  origin: 'onboarding' | 'project-creation';
   selectedPlatform: OnboardingSelectedSDK;
 }
 
@@ -99,6 +100,7 @@ export function ConsoleModal({
   selectedPlatform,
   closeModal,
   organization,
+  origin,
 }: ConsoleModalProps & ModalRenderProps) {
   const platformKey = selectedPlatform.key;
   const config = CONSOLE_PLATFORM_INSTRUCTIONS[platformKey as ConsolePlatform];
@@ -107,8 +109,9 @@ export function ConsoleModal({
     trackAnalytics('gaming.partner_request_access_guidance_modal_opened', {
       platform: selectedPlatform.key,
       organization,
+      origin,
     });
-  }, [selectedPlatform.key, organization]);
+  }, [selectedPlatform.key, organization, origin]);
 
   if (!config) {
     return null;
@@ -132,6 +135,7 @@ export function ConsoleModal({
               {
                 platform: selectedPlatform.key,
                 organization,
+                origin,
               }
             );
             closeModal();

--- a/static/app/components/onboarding/gettingStartedDoc/utils/consoleExtensions.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/utils/consoleExtensions.tsx
@@ -85,6 +85,7 @@ function getEnabledPlayStationContent(params: DocsParams): ContentBlock[] {
         <RequestSdkAccessButton
           organization={params.organization}
           project={params.project}
+          origin={params.newOrg ? 'onboarding' : 'project-creation'}
         />
       ),
     },
@@ -128,6 +129,7 @@ function getEnabledNintendoSwitchContent(params: DocsParams): ContentBlock[] {
               projectSlug: params.project.slug,
               sdkName: metadata.displayName,
               gamingPlatform: 'nintendo-switch',
+              origin: params.newOrg ? 'onboarding' : 'project-creation',
             })
           }
         >
@@ -184,6 +186,7 @@ function getEnabledXboxContent(params: DocsParams): ContentBlock[] {
               projectSlug: params.project.slug,
               sdkName: metadata.displayName,
               gamingPlatform: 'xbox',
+              origin: params.newOrg ? 'onboarding' : 'project-creation',
             })
           }
         >

--- a/static/app/gettingStartedDocs/console/nintendo-switch.tsx
+++ b/static/app/gettingStartedDocs/console/nintendo-switch.tsx
@@ -52,6 +52,7 @@ const onboarding: OnboardingConfig = {
                   projectId: params.project.id,
                   sdkName: 'Nintendo Switch',
                   gamingPlatform: 'nintendo-switch',
+                  origin: params.newOrg ? 'onboarding' : 'project-creation',
                 });
               }}
             >

--- a/static/app/gettingStartedDocs/console/playstation.tsx
+++ b/static/app/gettingStartedDocs/console/playstation.tsx
@@ -78,7 +78,12 @@ const onboardingRetail: OnboardingConfig = {
         },
         {
           type: 'custom',
-          content: <AddCredentialsButton project={params.project} />,
+          content: (
+            <AddCredentialsButton
+              project={params.project}
+              origin={params.newOrg ? 'onboarding' : 'project-creation'}
+            />
+          ),
         },
         {
           type: 'text',
@@ -87,7 +92,7 @@ const onboardingRetail: OnboardingConfig = {
             {
               projectSettingsLink: (
                 <ExternalLink
-                  href={`/settings/projects/${params.project.slug}/playstation/`}
+                  href={`/settings/projects/${params.project.slug}/playstation/?tab=playstation`}
                   openInNewTab
                 />
               ),
@@ -291,6 +296,7 @@ const onboarding: OnboardingConfig = {
             <RequestSdkAccessButton
               organization={params.organization}
               project={params.project}
+              origin={params.newOrg ? 'onboarding' : 'project-creation'}
             />
           ),
         },

--- a/static/app/gettingStartedDocs/console/xbox.tsx
+++ b/static/app/gettingStartedDocs/console/xbox.tsx
@@ -54,6 +54,7 @@ const onboarding: OnboardingConfig = {
                   projectId: params.project.id,
                   sdkName: 'Xbox',
                   gamingPlatform: 'xbox',
+                  origin: params.newOrg ? 'onboarding' : 'project-creation',
                 });
               }}
             >

--- a/static/app/utils/analytics/gamingAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/gamingAnalyticsEvents.tsx
@@ -1,18 +1,17 @@
+type GamingPlatformBase = {
+  origin: 'onboarding' | 'project-creation' | 'project-settings';
+  platform?: string;
+};
+
 export type GamingAnalyticsEventParameters = {
-  'gaming.partner_request_access_guidance_modal_button_got_it_clicked': {
-    platform: string;
-  };
-  'gaming.partner_request_access_guidance_modal_opened': {
-    platform: string;
-  };
-  'gaming.private_sdk_access_modal_opened': {
+  'gaming.partner_request_access_guidance_modal_button_got_it_clicked': GamingPlatformBase;
+  'gaming.partner_request_access_guidance_modal_opened': GamingPlatformBase;
+  'gaming.private_sdk_access_modal_opened': GamingPlatformBase & {
     project_id: string;
-    platform?: string;
   };
-  'gaming.private_sdk_access_modal_submitted': {
+  'gaming.private_sdk_access_modal_submitted': GamingPlatformBase & {
     platforms: string[];
     project_id: string;
-    platform?: string;
   };
 };
 

--- a/static/app/utils/analytics/tempestAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/tempestAnalyticsEvents.tsx
@@ -1,31 +1,23 @@
 import type {Organization} from 'sentry/types/organization';
 
+type TempestEventBase = {
+  organization: Organization;
+  project_slug: string;
+};
+
+type TempestEventBaseWithOrigin = TempestEventBase & {
+  origin: 'onboarding' | 'project-creation' | 'project-settings';
+};
+
 export type TempestEventParameters = {
-  'tempest.credentials.add_modal_opened': {
-    organization: Organization;
-    project_slug: string;
-  };
-  'tempest.credentials.added': {
-    organization: Organization;
-    project_slug: string;
-  };
-  'tempest.credentials.error_displayed': {
+  'tempest.credentials.add_modal_opened': TempestEventBaseWithOrigin;
+  'tempest.credentials.added': TempestEventBaseWithOrigin;
+  'tempest.credentials.error_displayed': TempestEventBase & {
     error_count: number;
-    organization: Organization;
-    project_slug: string;
   };
-  'tempest.credentials.removed': {
-    organization: Organization;
-    project_slug: string;
-  };
-  'tempest.sdk_access_modal_opened': {
-    organization: Organization;
-    project_slug: string;
-  };
-  'tempest.sdk_access_modal_submitted': {
-    organization: Organization;
-    project_slug: string;
-  };
+  'tempest.credentials.removed': TempestEventBase;
+  'tempest.sdk_access_modal_opened': TempestEventBaseWithOrigin;
+  'tempest.sdk_access_modal_submitted': TempestEventBaseWithOrigin;
 };
 
 type TempestEventKey = keyof TempestEventParameters;

--- a/static/app/views/onboarding/useConfigureSdk.tsx
+++ b/static/app/views/onboarding/useConfigureSdk.tsx
@@ -106,6 +106,7 @@ export function useConfigureSdk({
         openConsoleModal({
           organization,
           selectedPlatform,
+          origin: 'onboarding',
         });
         return;
       }

--- a/static/app/views/projectInstall/createProject.tsx
+++ b/static/app/views/projectInstall/createProject.tsx
@@ -458,6 +458,7 @@ export function CreateProject() {
             category: value.category,
             link: value.link,
           },
+          origin: 'project-creation',
         });
         return;
       }

--- a/static/app/views/settings/project/tempest/EmptyState.tsx
+++ b/static/app/views/settings/project/tempest/EmptyState.tsx
@@ -94,7 +94,9 @@ export default function EmptyState({
                   ]}
                   isEmpty={!tempestCredentials?.length}
                   emptyMessage={t('No credentials found')}
-                  emptyAction={<AddCredentialsButton project={project} />}
+                  emptyAction={
+                    <AddCredentialsButton project={project} origin="project-settings" />
+                  }
                 >
                   {tempestCredentials?.map(credential => (
                     <CredentialRow

--- a/static/app/views/settings/project/tempest/PlayStationSettings.tsx
+++ b/static/app/views/settings/project/tempest/PlayStationSettings.tsx
@@ -133,7 +133,7 @@ export default function PlayStationSettings({organization, project}: Props) {
                   : t('Open Setup Instructions')}
               </Button>
             )}
-            <AddCredentialsButton project={project} />
+            <AddCredentialsButton project={project} origin="project-settings" />
           </ButtonBar>
           {showEmptyState ? (
             <FullWidthPanel>

--- a/static/app/views/settings/project/tempest/RequestSdkAccessButton.tsx
+++ b/static/app/views/settings/project/tempest/RequestSdkAccessButton.tsx
@@ -8,12 +8,14 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 
 interface RequestSdkAccessButtonProps {
   organization: Organization;
+  origin: 'onboarding' | 'project-creation' | 'project-settings';
   project: Project;
 }
 
 export function RequestSdkAccessButton({
   organization,
   project,
+  origin,
 }: RequestSdkAccessButtonProps) {
   return (
     <Button
@@ -28,16 +30,19 @@ export function RequestSdkAccessButton({
           projectId: project.id,
           sdkName: 'PlayStation',
           gamingPlatform: 'playstation',
+          origin,
           onSubmit: () => {
             trackAnalytics('tempest.sdk_access_modal_submitted', {
               organization,
               project_slug: project.slug,
+              origin,
             });
           },
         });
         trackAnalytics('tempest.sdk_access_modal_opened', {
           organization,
           project_slug: project.slug,
+          origin,
         });
       }}
     >

--- a/static/app/views/settings/project/tempest/addCredentialsButton.tsx
+++ b/static/app/views/settings/project/tempest/addCredentialsButton.tsx
@@ -9,10 +9,11 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {useHasTempestWriteAccess} from 'sentry/views/settings/project/tempest/utils/access';
 
 interface AddCredentialsButtonProps {
+  origin: 'onboarding' | 'project-creation' | 'project-settings';
   project: Project;
 }
 
-export function AddCredentialsButton({project}: AddCredentialsButtonProps) {
+export function AddCredentialsButton({project, origin}: AddCredentialsButtonProps) {
   const organization = useOrganization();
   const hasWriteAccess = useHasTempestWriteAccess();
 
@@ -28,10 +29,11 @@ export function AddCredentialsButton({project}: AddCredentialsButtonProps) {
         disabled={!hasWriteAccess}
         icon={<IconAdd isCircled />}
         onClick={() => {
-          openAddTempestCredentialsModal({organization, project});
+          openAddTempestCredentialsModal({organization, project, origin});
           trackAnalytics('tempest.credentials.add_modal_opened', {
             organization,
             project_slug: project.slug,
+            origin,
           });
         }}
       >

--- a/static/app/views/settings/project/tempest/index.tsx
+++ b/static/app/views/settings/project/tempest/index.tsx
@@ -116,7 +116,11 @@ export default function TempestSettings({organization, project}: Props) {
         action={
           <ButtonBar gap="lg">
             <FeedbackWidgetButton />
-            <RequestSdkAccessButton organization={organization} project={project} />
+            <RequestSdkAccessButton
+              organization={organization}
+              project={project}
+              origin="project-settings"
+            />
           </ButtonBar>
         }
       />


### PR DESCRIPTION
We track analytics for various gaming-related activities and want to know whether the event originated during the main onboarding or later, such as during project creation or in project settings

closes https://linear.app/getsentry/issue/TET-1009/add-origin-to-all-console-analytics-events