### PR TITLE
feat(debug-files): Allow project override of organization option when downloading debug file

### DIFF
--- a/src/sentry/api/endpoints/debug_files.py
+++ b/src/sentry/api/endpoints/debug_files.py
@@ -70,7 +70,11 @@ def has_download_permission(request: Request, project: Project):
         return False
 
     organization = project.organization
-    required_role = organization.get_option("sentry:debug_files_role") or DEBUG_FILES_ROLE_DEFAULT
+    required_role = (
+        project.get_option("sentry:debug_files_role")
+        or organization.get_option("sentry:debug_files_role")
+        or DEBUG_FILES_ROLE_DEFAULT
+    )
 
     if request.user.is_sentry_app:
         if organization_roles.can_manage("member", required_role):


### PR DESCRIPTION
In API endpoint for downloading debug files, first check if the override setting for specific project exists.

This is a new feature which allows overrides of debugFileRole on project level (so far this was controlled only via Organization setting).
