### PR TITLE
Support dealing with already stored attachments

### DIFF
--- a/src/sentry/attachments/base.py
+++ b/src/sentry/attachments/base.py
@@ -27,6 +27,7 @@ class CachedAttachment:
         type=None,
         chunks=None,
         data=UNINITIALIZED_DATA,
+        stored_id=None,
         cache=None,
         rate_limited=None,
         size=None,
@@ -50,6 +51,7 @@ class CachedAttachment:
 
         self.chunks = chunks
         self._data = data
+        self.stored_id = stored_id
         self._cache = cache
         self._has_initial_data = data is not UNINITIALIZED_DATA
 
@@ -61,6 +63,10 @@ class CachedAttachment:
 
     @property
     def data(self) -> bytes:
+        if self.stored_id:
+            # TODO: fetch the contents based on `stored_id`
+            raise NotImplementedError()
+
         if self._data is UNINITIALIZED_DATA and self._cache is not None:
             self._data = self._cache.get_data(self)
 
@@ -68,6 +74,10 @@ class CachedAttachment:
         return self._data
 
     def delete(self):
+        if self.stored_id:
+            # TODO: delete the stored file
+            raise NotImplementedError()
+
         for key in self.chunk_keys:
             self._cache.inner.delete(key)
 
@@ -76,7 +86,7 @@ class CachedAttachment:
         assert self.key is not None
         assert self.id is not None
 
-        if self._has_initial_data:
+        if self.stored_id or self._has_initial_data:
             return
 
         if self.chunks is None:
@@ -98,6 +108,7 @@ class CachedAttachment:
                 "type": self.type,
                 "size": self.size or None,  # None for backwards compatibility
                 "chunks": self.chunks,
+                "stored_id": self.stored_id,
             }
         )
 
@@ -108,7 +119,7 @@ class BaseAttachmentCache:
 
     def set(self, key: str, attachments: list[CachedAttachment], timeout=None):
         for id, attachment in enumerate(attachments):
-            if attachment.chunks is not None:
+            if attachment.chunks is not None or attachment.stored_id is not None:
                 continue
 
             # TODO(markus): We need to get away from sequential IDs, they

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -548,6 +548,7 @@ class EventManager:
                 increment_group_tombstone_hit_counter(
                     getattr(e, "tombstone_id", None), job["event"]
                 )
+            # TODO: make sure that already stored attachments are deleted
             discard_event(job, attachments)
             raise
 
@@ -566,6 +567,7 @@ class EventManager:
         _tsdb_record_all_metrics(jobs)
 
         if attachments:
+            # TODO: make sure that already stored attachments are deleted
             attachments = filter_attachments_for_group(attachments, job)
 
         # XXX: DO NOT MUTATE THE EVENT PAYLOAD AFTER THIS POINT
@@ -2315,9 +2317,6 @@ def filter_attachments_for_group(attachments: list[Attachment], job: Job) -> lis
     :param attachments: The full list of attachments to filter.
     :param job:         The job context container.
     """
-    if not attachments:
-        return attachments
-
     event = job["event"]
     project = event.project
 
@@ -2429,7 +2428,7 @@ def save_attachment(
         timestamp = datetime.now(timezone.utc)
 
     try:
-        attachment.data
+        attachment.stored_id or attachment.data
     except MissingAttachmentChunks:
         track_outcome(
             org_id=project.organization_id,

--- a/src/sentry/ingest/consumer/processors.py
+++ b/src/sentry/ingest/consumer/processors.py
@@ -378,7 +378,8 @@ def process_individual_attachment(message: IngestMessage, project: Project) -> N
     attachment_msg = message["attachment"]
     attachment_type = attachment_msg.pop("attachment_type")
 
-    # NOTE: `get_from_chunks` will avoid the cache if `attachment_msg` contains `data` inline
+    # NOTE: `get_from_chunks` will avoid the cache if `attachment_msg` contains `data` inline,
+    # or if the attachment has already been stored with a `stored_id`.
     attachment = attachment_cache.get_from_chunks(
         key=cache_key, type=attachment_type, **attachment_msg
     )

--- a/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py
+++ b/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py
@@ -282,7 +282,6 @@ def test_with_attachments(default_project, task_runner, missing_chunks, django_c
                     "chunk_index": 0,
                 }
             )
-
             process_attachment_chunk(
                 {
                     "payload": b"World!",
@@ -308,6 +307,7 @@ def test_with_attachments(default_project, task_runner, missing_chunks, django_c
                             "name": "lol.txt",
                             "content_type": "text/plain",
                             "attachment_type": "custom.attachment",
+                            "size": len(b"Hello World!"),
                             "chunks": 2,
                         }
                     ],
@@ -370,10 +370,11 @@ def test_deobfuscate_view_hierarchy(
                 }
             ],
         }
+        attachment_payload = orjson.dumps(obfuscated_view_hierarchy)
 
         process_attachment_chunk(
             {
-                "payload": orjson.dumps(obfuscated_view_hierarchy),
+                "payload": attachment_payload,
                 "event_id": event_id,
                 "project_id": project_id,
                 "id": attachment_id,
@@ -397,6 +398,7 @@ def test_deobfuscate_view_hierarchy(
                             "content_type": "application/json",
                             "attachment_type": "event.view_hierarchy",
                             "chunks": 1,
+                            "size": len(attachment_payload),
                         }
                     ],
                 },
@@ -450,11 +452,11 @@ def test_individual_attachments(
 
         chunks, attachment_type, content_type = attachment
         attachment_meta = {
-            "attachment_type": attachment_type,
-            "chunks": len(chunks),
-            "content_type": content_type,
             "id": attachment_id,
             "name": "foo.txt",
+            "content_type": content_type,
+            "attachment_type": attachment_type,
+            "chunks": len(chunks),
         }
         if isinstance(chunks, bytes):
             attachment_meta["data"] = chunks
@@ -471,6 +473,7 @@ def test_individual_attachments(
                     }
                 )
             expected_content = b"".join(chunks)
+        attachment_meta["size"] = len(expected_content)
 
         process_individual_attachment(
             {


### PR DESCRIPTION
This changes the ingest consumer code to properly deal with already stored attachments, at least halfway.

Attachments used for processing via the `CachedAttachment` do not yet fully support stored attachments.

---

Ref FS-104