### PR TITLE
feat(playstation): Add user to tasks 

### DIFF
--- a/src/sentry/tempest/tasks.py
+++ b/src/sentry/tempest/tasks.py
@@ -55,6 +55,8 @@ def fetch_latest_item_id(credentials_id: int, **kwargs) -> None:
     org_id = credentials.project.organization_id
     client_id = credentials.client_id
 
+    sentry_sdk.set_user({"id": f"{org_id}-{project_id}"})
+
     try:
         response = fetch_latest_id_from_tempest(
             org_id=org_id,
@@ -130,6 +132,8 @@ def poll_tempest_crashes(credentials_id: int, **kwargs) -> None:
     project_id = credentials.project.id
     org_id = credentials.project.organization_id
     client_id = credentials.client_id
+
+    sentry_sdk.set_user({"id": f"{org_id}-{project_id}"})
 
     try:
         if credentials.latest_fetched_item_id is not None:


### PR DESCRIPTION
Currently there are no "users" for these tasks which causes errors that happen to have an impact of 0.
To get a better idea of how widespread an issue is this sets the user id so that Sentry can derive the impact.