### PR TITLE
feat(explore): Set up explore for multi param functions

### DIFF
--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -1024,6 +1024,29 @@ export const AGGREGATION_FIELDS: Record<AggregationKey, FieldDefinition> = {
   },
 };
 
+// TODO: Extend the two lists below with more options upon backend support
+export const ALLOWED_EXPLORE_VISUALIZE_FIELDS: SpanFields[] = [
+  SpanFields.SPAN_DURATION, // DO NOT RE-ORDER: the first element is used as the default
+  SpanFields.SPAN_SELF_TIME,
+];
+
+export const ALLOWED_EXPLORE_VISUALIZE_AGGREGATES: AggregationKey[] = [
+  AggregationKey.COUNT, // DO NOT RE-ORDER: the first element is used as the default
+  AggregationKey.AVG,
+  AggregationKey.P50,
+  AggregationKey.P75,
+  AggregationKey.P90,
+  AggregationKey.P95,
+  AggregationKey.P99,
+  AggregationKey.P100,
+  AggregationKey.SUM,
+  AggregationKey.MIN,
+  AggregationKey.MAX,
+  AggregationKey.COUNT_UNIQUE,
+  AggregationKey.EPM,
+  AggregationKey.FAILURE_RATE,
+];
+
 const SPAN_AGGREGATION_FIELDS: Record<AggregationKey, FieldDefinition> = {
   ...AGGREGATION_FIELDS,
   [AggregationKey.COUNT]: {
@@ -1228,48 +1251,6 @@ export const NO_ARGUMENT_SPAN_AGGREGATES: AggregationKey[] = Object.entries(
 )
   .filter(([_, field]) => field.parameters?.length === 0)
   .map(([key]) => key as AggregationKey);
-
-// TODO: Extend the two lists below with more options upon backend support
-export const ALLOWED_EXPLORE_VISUALIZE_FIELDS: SpanFields[] = [
-  SpanFields.SPAN_DURATION, // DO NOT RE-ORDER: the first element is used as the default
-  SpanFields.SPAN_SELF_TIME,
-];
-
-export const ALLOWED_EXPLORE_VISUALIZE_AGGREGATES: AggregationKey[] = [
-  AggregationKey.COUNT, // DO NOT RE-ORDER: the first element is used as the default
-  AggregationKey.AVG,
-  AggregationKey.P50,
-  AggregationKey.P75,
-  AggregationKey.P90,
-  AggregationKey.P95,
-  AggregationKey.P99,
-  AggregationKey.P100,
-  AggregationKey.SUM,
-  AggregationKey.MIN,
-  AggregationKey.MAX,
-  AggregationKey.COUNT_UNIQUE,
-  AggregationKey.EPM,
-  AggregationKey.FAILURE_RATE,
-];
-
-export const ALLOWED_EXPLORE_VISUALIZE_AGGREGATE_DEFINITIONS: Readonly<
-  Partial<Record<AggregationKey, FieldDefinition>>
-> = {
-  [AggregationKey.COUNT]: SPAN_AGGREGATION_FIELDS[AggregationKey.COUNT],
-  [AggregationKey.AVG]: SPAN_AGGREGATION_FIELDS[AggregationKey.AVG],
-  [AggregationKey.P50]: SPAN_AGGREGATION_FIELDS[AggregationKey.P50],
-  [AggregationKey.P75]: SPAN_AGGREGATION_FIELDS[AggregationKey.P75],
-  [AggregationKey.P90]: SPAN_AGGREGATION_FIELDS[AggregationKey.P90],
-  [AggregationKey.P95]: SPAN_AGGREGATION_FIELDS[AggregationKey.P95],
-  [AggregationKey.P99]: SPAN_AGGREGATION_FIELDS[AggregationKey.P99],
-  [AggregationKey.P100]: SPAN_AGGREGATION_FIELDS[AggregationKey.P100],
-  [AggregationKey.SUM]: SPAN_AGGREGATION_FIELDS[AggregationKey.SUM],
-  [AggregationKey.MIN]: SPAN_AGGREGATION_FIELDS[AggregationKey.MIN],
-  [AggregationKey.MAX]: SPAN_AGGREGATION_FIELDS[AggregationKey.MAX],
-  [AggregationKey.COUNT_UNIQUE]: SPAN_AGGREGATION_FIELDS[AggregationKey.COUNT_UNIQUE],
-  [AggregationKey.EPM]: SPAN_AGGREGATION_FIELDS[AggregationKey.EPM],
-  [AggregationKey.FAILURE_RATE]: SPAN_AGGREGATION_FIELDS[AggregationKey.FAILURE_RATE],
-};
 
 export const MEASUREMENT_FIELDS: Record<WebVital | MobileVital, FieldDefinition> = {
   [WebVital.FP]: {

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -1024,29 +1024,6 @@ export const AGGREGATION_FIELDS: Record<AggregationKey, FieldDefinition> = {
   },
 };
 
-// TODO: Extend the two lists below with more options upon backend support
-export const ALLOWED_EXPLORE_VISUALIZE_FIELDS: SpanFields[] = [
-  SpanFields.SPAN_DURATION, // DO NOT RE-ORDER: the first element is used as the default
-  SpanFields.SPAN_SELF_TIME,
-];
-
-export const ALLOWED_EXPLORE_VISUALIZE_AGGREGATES: AggregationKey[] = [
-  AggregationKey.COUNT, // DO NOT RE-ORDER: the first element is used as the default
-  AggregationKey.AVG,
-  AggregationKey.P50,
-  AggregationKey.P75,
-  AggregationKey.P90,
-  AggregationKey.P95,
-  AggregationKey.P99,
-  AggregationKey.P100,
-  AggregationKey.SUM,
-  AggregationKey.MIN,
-  AggregationKey.MAX,
-  AggregationKey.COUNT_UNIQUE,
-  AggregationKey.EPM,
-  AggregationKey.FAILURE_RATE,
-];
-
 const SPAN_AGGREGATION_FIELDS: Record<AggregationKey, FieldDefinition> = {
   ...AGGREGATION_FIELDS,
   [AggregationKey.COUNT]: {
@@ -1251,6 +1228,48 @@ export const NO_ARGUMENT_SPAN_AGGREGATES: AggregationKey[] = Object.entries(
 )
   .filter(([_, field]) => field.parameters?.length === 0)
   .map(([key]) => key as AggregationKey);
+
+// TODO: Extend the two lists below with more options upon backend support
+export const ALLOWED_EXPLORE_VISUALIZE_FIELDS: SpanFields[] = [
+  SpanFields.SPAN_DURATION, // DO NOT RE-ORDER: the first element is used as the default
+  SpanFields.SPAN_SELF_TIME,
+];
+
+export const ALLOWED_EXPLORE_VISUALIZE_AGGREGATES: AggregationKey[] = [
+  AggregationKey.COUNT, // DO NOT RE-ORDER: the first element is used as the default
+  AggregationKey.AVG,
+  AggregationKey.P50,
+  AggregationKey.P75,
+  AggregationKey.P90,
+  AggregationKey.P95,
+  AggregationKey.P99,
+  AggregationKey.P100,
+  AggregationKey.SUM,
+  AggregationKey.MIN,
+  AggregationKey.MAX,
+  AggregationKey.COUNT_UNIQUE,
+  AggregationKey.EPM,
+  AggregationKey.FAILURE_RATE,
+];
+
+export const ALLOWED_EXPLORE_VISUALIZE_AGGREGATE_DEFINITIONS: Readonly<
+  Partial<Record<AggregationKey, FieldDefinition>>
+> = {
+  [AggregationKey.COUNT]: SPAN_AGGREGATION_FIELDS[AggregationKey.COUNT],
+  [AggregationKey.AVG]: SPAN_AGGREGATION_FIELDS[AggregationKey.AVG],
+  [AggregationKey.P50]: SPAN_AGGREGATION_FIELDS[AggregationKey.P50],
+  [AggregationKey.P75]: SPAN_AGGREGATION_FIELDS[AggregationKey.P75],
+  [AggregationKey.P90]: SPAN_AGGREGATION_FIELDS[AggregationKey.P90],
+  [AggregationKey.P95]: SPAN_AGGREGATION_FIELDS[AggregationKey.P95],
+  [AggregationKey.P99]: SPAN_AGGREGATION_FIELDS[AggregationKey.P99],
+  [AggregationKey.P100]: SPAN_AGGREGATION_FIELDS[AggregationKey.P100],
+  [AggregationKey.SUM]: SPAN_AGGREGATION_FIELDS[AggregationKey.SUM],
+  [AggregationKey.MIN]: SPAN_AGGREGATION_FIELDS[AggregationKey.MIN],
+  [AggregationKey.MAX]: SPAN_AGGREGATION_FIELDS[AggregationKey.MAX],
+  [AggregationKey.COUNT_UNIQUE]: SPAN_AGGREGATION_FIELDS[AggregationKey.COUNT_UNIQUE],
+  [AggregationKey.EPM]: SPAN_AGGREGATION_FIELDS[AggregationKey.EPM],
+  [AggregationKey.FAILURE_RATE]: SPAN_AGGREGATION_FIELDS[AggregationKey.FAILURE_RATE],
+};
 
 export const MEASUREMENT_FIELDS: Record<WebVital | MobileVital, FieldDefinition> = {
   [WebVital.FP]: {

--- a/static/app/views/alerts/rules/metric/eapField.tsx
+++ b/static/app/views/alerts/rules/metric/eapField.tsx
@@ -150,7 +150,7 @@ function EAPField({aggregate, onChange, eventTypes}: Props) {
         newAggregate = updateVisualizeAggregate({
           newAggregate: option.value,
           oldAggregate: aggregation || DEFAULT_EAP_AGGREGATION,
-          oldArgument: field || DEFAULT_EAP_FIELD,
+          oldArguments: field ? [field] : [DEFAULT_EAP_FIELD],
         });
       }
       onChange(newAggregate, {});

--- a/static/app/views/explore/components/toolbar/toolbarVisualize/index.tsx
+++ b/static/app/views/explore/components/toolbar/toolbarVisualize/index.tsx
@@ -8,10 +8,7 @@ import {IconAdd} from 'sentry/icons';
 import {IconDelete} from 'sentry/icons/iconDelete';
 import {t} from 'sentry/locale';
 import type {ParsedFunction} from 'sentry/utils/discover/fields';
-import {
-  AggregationKey,
-  ALLOWED_EXPLORE_VISUALIZE_AGGREGATE_DEFINITIONS,
-} from 'sentry/utils/fields';
+import {getFieldDefinition} from 'sentry/utils/fields';
 import {
   ToolbarFooterButton,
   ToolbarHeader,
@@ -55,7 +52,7 @@ export function ToolbarVisualizeDropdown({
 }: ToolbarVisualizeDropdownProps) {
   const aggregateFunc = parsedFunction?.name;
   const aggregateDefinition = aggregateFunc
-    ? ALLOWED_EXPLORE_VISUALIZE_AGGREGATE_DEFINITIONS[aggregateFunc as AggregationKey]
+    ? getFieldDefinition(aggregateFunc, 'span')
     : undefined;
 
   return (
@@ -78,6 +75,15 @@ export function ToolbarVisualizeDropdown({
           />
         );
       })}
+      {aggregateDefinition?.parameters?.length === 0 && ( // for parameterless functions, we want to still show show greyed out spans
+        <FieldCompactSelect
+          searchable
+          options={fieldOptions}
+          value={parsedFunction?.arguments[0] ?? ''}
+          onChange={option => onChangeArgument(0, option)}
+          disabled
+        />
+      )}
       {canDelete ? (
         <Button
           borderless

--- a/static/app/views/explore/components/toolbar/toolbarVisualize/index.tsx
+++ b/static/app/views/explore/components/toolbar/toolbarVisualize/index.tsx
@@ -72,7 +72,7 @@ export function ToolbarVisualizeDropdown({
             key={param.name}
             searchable
             options={fieldOptions}
-            value={parsedFunction?.arguments[0] ?? ''}
+            value={parsedFunction?.arguments[index] ?? param.defaultValue ?? ''}
             onChange={option => onChangeArgument(index, option)}
             disabled={fieldOptions.length === 1}
           />

--- a/static/app/views/explore/components/toolbar/toolbarVisualize/index.tsx
+++ b/static/app/views/explore/components/toolbar/toolbarVisualize/index.tsx
@@ -9,6 +9,10 @@ import {IconDelete} from 'sentry/icons/iconDelete';
 import {t} from 'sentry/locale';
 import type {ParsedFunction} from 'sentry/utils/discover/fields';
 import {
+  AggregationKey,
+  ALLOWED_EXPLORE_VISUALIZE_AGGREGATE_DEFINITIONS,
+} from 'sentry/utils/fields';
+import {
   ToolbarFooterButton,
   ToolbarHeader,
   ToolbarLabel,
@@ -35,7 +39,7 @@ interface ToolbarVisualizeDropdownProps {
   canDelete: boolean;
   fieldOptions: Array<SelectOption<SelectKey>>;
   onChangeAggregate: (option: SelectOption<SelectKey>) => void;
-  onChangeArgument: (option: SelectOption<SelectKey>) => void;
+  onChangeArgument: (index: number, option: SelectOption<SelectKey>) => void;
   onDelete: () => void;
   parsedFunction: ParsedFunction | null;
 }
@@ -49,6 +53,11 @@ export function ToolbarVisualizeDropdown({
   onDelete,
   parsedFunction,
 }: ToolbarVisualizeDropdownProps) {
+  const aggregateFunc = parsedFunction?.name;
+  const aggregateDefinition = aggregateFunc
+    ? ALLOWED_EXPLORE_VISUALIZE_AGGREGATE_DEFINITIONS[aggregateFunc as AggregationKey]
+    : undefined;
+
   return (
     <ToolbarRow>
       <AggregateCompactSelect
@@ -57,13 +66,18 @@ export function ToolbarVisualizeDropdown({
         value={parsedFunction?.name ?? ''}
         onChange={onChangeAggregate}
       />
-      <FieldCompactSelect
-        searchable
-        options={fieldOptions}
-        value={parsedFunction?.arguments[0] ?? ''}
-        onChange={onChangeArgument}
-        disabled={fieldOptions.length === 1}
-      />
+      {aggregateDefinition?.parameters?.map((param, index) => {
+        return (
+          <FieldCompactSelect
+            key={param.name}
+            searchable
+            options={fieldOptions}
+            value={parsedFunction?.arguments[0] ?? ''}
+            onChange={option => onChangeArgument(index, option)}
+            disabled={fieldOptions.length === 1}
+          />
+        );
+      })}
       {canDelete ? (
         <Button
           borderless

--- a/static/app/views/explore/contexts/pageParamsContext/visualizes.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/visualizes.tsx
@@ -151,11 +151,11 @@ export function parseBaseVisualize(
 export function updateVisualizeAggregate({
   newAggregate,
   oldAggregate,
-  oldArgument,
+  oldArguments,
 }: {
   newAggregate: string;
   oldAggregate?: string;
-  oldArgument?: string;
+  oldArguments?: string[];
 }): string {
   // the default aggregate only has 1 allowed field
   if (newAggregate === DEFAULT_VISUALIZATION_AGGREGATE) {
@@ -183,7 +183,7 @@ export function updateVisualizeAggregate({
     return `${newAggregate}(${DEFAULT_VISUALIZATION_FIELD})`;
   }
 
-  return `${newAggregate}(${oldArgument})`;
+  return `${newAggregate}(${oldArguments?.join(',')})`;
 }
 
 const FUNCTION_TO_CHART_TYPE: Record<string, ChartType> = {

--- a/static/app/views/explore/contexts/pageParamsContext/visualizes.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/visualizes.tsx
@@ -183,7 +183,9 @@ export function updateVisualizeAggregate({
     return `${newAggregate}(${DEFAULT_VISUALIZATION_FIELD})`;
   }
 
-  return `${newAggregate}(${oldArguments?.join(',')})`;
+  return oldArguments
+    ? `${newAggregate}(${oldArguments?.join(',')})`
+    : `${newAggregate}()`;
 }
 
 const FUNCTION_TO_CHART_TYPE: Record<string, ChartType> = {

--- a/static/app/views/explore/logs/logsToolbar.tsx
+++ b/static/app/views/explore/logs/logsToolbar.tsx
@@ -254,7 +254,7 @@ function VisualizeDropdown({
   );
 
   const onChangeArgument = useCallback(
-    (option: SelectOption<SelectKey>) => {
+    (_index: number, option: SelectOption<SelectKey>) => {
       if (typeof option.value === 'string') {
         const yAxis = `${aggregateFunction}(${option.value})`;
         onReplace(visualize.replace({yAxis}));

--- a/static/app/views/explore/multiQueryMode/queryConstructors/visualize.tsx
+++ b/static/app/views/explore/multiQueryMode/queryConstructors/visualize.tsx
@@ -73,7 +73,7 @@ export function VisualizeSection({query, index}: Props) {
               const newYAxis = updateVisualizeAggregate({
                 newAggregate: newAggregate.value,
                 oldAggregate: parsedFunction!.name,
-                oldArgument: parsedFunction!.arguments[0]!,
+                oldArguments: parsedFunction!.arguments,
               });
               updateYAxis({yAxes: [newYAxis]});
             }}

--- a/static/app/views/explore/tables/aggregateColumnEditorModal.tsx
+++ b/static/app/views/explore/tables/aggregateColumnEditorModal.tsx
@@ -391,7 +391,7 @@ function AggregateSelector({
             key={param.name}
             data-test-id="editor-visualize-argument"
             options={argumentOptions}
-            value={parsedFunction?.arguments[0] ?? ''}
+            value={parsedFunction?.arguments[index] ?? param.defaultValue ?? ''}
             onChange={option => handleArgumentChange(index, option)}
             searchable
             disabled={argumentOptions.length === 1}

--- a/static/app/views/explore/tables/aggregateColumnEditorModal.tsx
+++ b/static/app/views/explore/tables/aggregateColumnEditorModal.tsx
@@ -2,6 +2,7 @@ import {Fragment, useCallback, useMemo, useState} from 'react';
 import {useSortable} from '@dnd-kit/sortable';
 import {CSS} from '@dnd-kit/utilities';
 import styled from '@emotion/styled';
+import cloneDeep from 'lodash/cloneDeep';
 
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {ArithmeticBuilder} from 'sentry/components/arithmeticBuilder';
@@ -27,6 +28,8 @@ import {
   stripEquationPrefix,
 } from 'sentry/utils/discover/fields';
 import {
+  AggregationKey,
+  ALLOWED_EXPLORE_VISUALIZE_AGGREGATE_DEFINITIONS,
   ALLOWED_EXPLORE_VISUALIZE_AGGREGATES,
   FieldKind,
   getFieldDefinition,
@@ -317,6 +320,10 @@ function AggregateSelector({
 }: VisualizeSelectorProps) {
   const yAxis = visualize.yAxis;
   const parsedFunction = useMemo(() => parseFunction(yAxis), [yAxis]);
+  const aggregateFunc = parsedFunction?.name;
+  const aggregateDefinition = aggregateFunc
+    ? ALLOWED_EXPLORE_VISUALIZE_AGGREGATE_DEFINITIONS[aggregateFunc as AggregationKey]
+    : undefined;
 
   const aggregateOptions: Array<SelectOption<string>> = useMemo(() => {
     return ALLOWED_EXPLORE_VISUALIZE_AGGREGATES.map(aggregate => {
@@ -340,7 +347,7 @@ function AggregateSelector({
       const newYAxis = updateVisualizeAggregate({
         newAggregate: option.value as string,
         oldAggregate: parsedFunction?.name,
-        oldArgument: parsedFunction?.arguments[0]!,
+        oldArguments: parsedFunction?.arguments,
       });
       onChange(visualize.replace({yAxis: newYAxis}));
     },
@@ -348,9 +355,17 @@ function AggregateSelector({
   );
 
   const handleArgumentChange = useCallback(
-    (option: SelectOption<SelectKey>) => {
-      const newYAxis = `${parsedFunction?.name}(${option.value})`;
-      onChange(visualize.replace({yAxis: newYAxis}));
+    (index: number, option: SelectOption<SelectKey>) => {
+      if (typeof option.value === 'string') {
+        let args = cloneDeep(parsedFunction?.arguments);
+        if (args) {
+          args[index] = option.value;
+        } else {
+          args = [option.value];
+        }
+        const newYAxis = `${parsedFunction?.name}(${args.join(',')})`;
+        onChange(visualize.replace({yAxis: newYAxis}));
+      }
     },
     [parsedFunction, onChange, visualize]
   );
@@ -370,19 +385,24 @@ function AggregateSelector({
           },
         }}
       />
-      <DoubleWidthCompactSelect
-        data-test-id="editor-visualize-argument"
-        options={argumentOptions}
-        value={parsedFunction?.arguments[0] ?? ''}
-        onChange={handleArgumentChange}
-        searchable
-        disabled={argumentOptions.length === 1}
-        triggerProps={{
-          style: {
-            width: '100%',
-          },
-        }}
-      />
+      {aggregateDefinition?.parameters?.map((param, index) => {
+        return (
+          <DoubleWidthCompactSelect
+            key={param.name}
+            data-test-id="editor-visualize-argument"
+            options={argumentOptions}
+            value={parsedFunction?.arguments[0] ?? ''}
+            onChange={option => handleArgumentChange(index, option)}
+            searchable
+            disabled={argumentOptions.length === 1}
+            triggerProps={{
+              style: {
+                width: '100%',
+              },
+            }}
+          />
+        );
+      })}
     </Fragment>
   );
 }

--- a/static/app/views/explore/tables/aggregateColumnEditorModal.tsx
+++ b/static/app/views/explore/tables/aggregateColumnEditorModal.tsx
@@ -28,8 +28,6 @@ import {
   stripEquationPrefix,
 } from 'sentry/utils/discover/fields';
 import {
-  AggregationKey,
-  ALLOWED_EXPLORE_VISUALIZE_AGGREGATE_DEFINITIONS,
   ALLOWED_EXPLORE_VISUALIZE_AGGREGATES,
   FieldKind,
   getFieldDefinition,
@@ -322,7 +320,7 @@ function AggregateSelector({
   const parsedFunction = useMemo(() => parseFunction(yAxis), [yAxis]);
   const aggregateFunc = parsedFunction?.name;
   const aggregateDefinition = aggregateFunc
-    ? ALLOWED_EXPLORE_VISUALIZE_AGGREGATE_DEFINITIONS[aggregateFunc as AggregationKey]
+    ? getFieldDefinition(aggregateFunc, 'span')
     : undefined;
 
   const aggregateOptions: Array<SelectOption<string>> = useMemo(() => {
@@ -403,6 +401,21 @@ function AggregateSelector({
           />
         );
       })}
+      {aggregateDefinition?.parameters?.length === 0 && (
+        <DoubleWidthCompactSelect
+          data-test-id="editor-visualize-argument"
+          options={argumentOptions}
+          value={parsedFunction?.arguments[0] ?? ''}
+          onChange={option => handleArgumentChange(0, option)}
+          searchable
+          disabled
+          triggerProps={{
+            style: {
+              width: '100%',
+            },
+          }}
+        />
+      )}
     </Fragment>
   );
 }

--- a/static/app/views/explore/toolbar/toolbarVisualize.tsx
+++ b/static/app/views/explore/toolbar/toolbarVisualize.tsx
@@ -1,4 +1,5 @@
 import {useCallback, useMemo} from 'react';
+import cloneDeep from 'lodash/cloneDeep';
 
 import type {SelectKey, SelectOption} from 'sentry/components/core/compactSelect';
 import {EQUATION_PREFIX, parseFunction} from 'sentry/utils/discover/fields';
@@ -159,7 +160,7 @@ function VisualizeDropdown({
         const yAxis = updateVisualizeAggregate({
           newAggregate: option.value,
           oldAggregate: parsedFunction?.name,
-          oldArgument: parsedFunction?.arguments[0],
+          oldArguments: parsedFunction?.arguments,
         });
         onReplace(visualize.replace({yAxis}));
       }
@@ -168,9 +169,15 @@ function VisualizeDropdown({
   );
 
   const onChangeArgument = useCallback(
-    (option: SelectOption<SelectKey>) => {
+    (index: number, option: SelectOption<SelectKey>) => {
       if (typeof option.value === 'string') {
-        const yAxis = `${parsedFunction?.name}(${option.value})`;
+        let args = cloneDeep(parsedFunction?.arguments);
+        if (args) {
+          args[index] = option.value;
+        } else {
+          args = [option.value];
+        }
+        const yAxis = `${parsedFunction?.name}(${args.join(',')})`;
         onReplace(visualize.replace({yAxis}));
       }
     },


### PR DESCRIPTION
We want to start adding support for functions like count_if and apdex that take in
multiple arguments. Explore currently assumes single argument functions only.
We're starting to set it up to accept multiple args. 

No new multi-arg functions are introduced in this PR so everything in the UI should
work and feel the same.