### PR TITLE
feat(onboarding): Simplify Node AWS Lambda onboarding docs

### DIFF
--- a/static/app/gettingStartedDocs/node/awslambda.spec.tsx
+++ b/static/app/gettingStartedDocs/node/awslambda.spec.tsx
@@ -91,7 +91,7 @@ describe('awslambda onboarding docs', () => {
     });
 
     it('displays sample rates by default', () => {
-      renderWithOnboardingLayout(docs, {
+      renderWithOnboardingLayout(npmDocs, {
         selectedProducts: [
           ProductSolution.ERROR_MONITORING,
           ProductSolution.PERFORMANCE_MONITORING,
@@ -108,7 +108,7 @@ describe('awslambda onboarding docs', () => {
     });
 
     it('enables performance setting the sample rate set to 1', () => {
-      renderWithOnboardingLayout(docs, {
+      renderWithOnboardingLayout(npmDocs, {
         selectedProducts: [
           ProductSolution.ERROR_MONITORING,
           ProductSolution.PERFORMANCE_MONITORING,

--- a/static/app/gettingStartedDocs/node/awslambda.spec.tsx
+++ b/static/app/gettingStartedDocs/node/awslambda.spec.tsx
@@ -1,19 +1,18 @@
-import {OrganizationFixture} from 'sentry-fixture/organization';
-
 import {renderWithOnboardingLayout} from 'sentry-test/onboarding/renderWithOnboardingLayout';
 import {screen} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs, {ModuleFormat} from './awslambda';
+import docs, {InstallationMethod} from './awslambda';
 
 describe('awslambda onboarding docs', () => {
-  describe('CJS: Lambda Layer', () => {
+  describe('Lambda Layer', () => {
     it('renders onboarding docs correctly', () => {
       renderWithOnboardingLayout(docs);
 
       expect(screen.getByRole('heading', {name: 'Install'})).toBeInTheDocument();
+      expect(screen.getByText(textWithMarkupMatcher('ARN'))).toBeInTheDocument();
       expect(screen.getByRole('heading', {name: 'Configure SDK'})).toBeInTheDocument();
       expect(
         screen.getByRole('heading', {name: /Upload Source Maps/i})
@@ -22,7 +21,9 @@ describe('awslambda onboarding docs', () => {
 
       expect(
         screen.getByText(
-          textWithMarkupMatcher('NODE_OPTIONS="-r @sentry/aws-serverless/awslambda-auto"')
+          textWithMarkupMatcher(
+            'NODE_OPTIONS="--import @sentry/aws-serverless/awslambda-auto"'
+          )
         )
       ).toBeInTheDocument();
     });
@@ -58,80 +59,64 @@ describe('awslambda onboarding docs', () => {
     ).toBeInTheDocument();
   });
 
-  describe('ESM: NPM Package', () => {
-    let esmDocs: typeof docs;
+  describe('NPM Package', () => {
+    let npmDocs: typeof docs;
     beforeAll(() => {
-      esmDocs = {
+      npmDocs = {
         ...docs,
         platformOptions: {
           ...docs.platformOptions,
-          moduleFormat: {
-            ...docs.platformOptions!.moduleFormat,
-            defaultValue: ModuleFormat.ESM,
+          installationMethod: {
+            ...docs.platformOptions!.installationMethod,
+            defaultValue: InstallationMethod.NPM_PACKAGE,
           },
         },
       };
     });
 
     it('renders onboarding docs correctly', () => {
-      renderWithOnboardingLayout(esmDocs);
+      renderWithOnboardingLayout(npmDocs);
 
       expect(screen.getByRole('heading', {name: 'Install'})).toBeInTheDocument();
       expect(screen.getByRole('heading', {name: 'Configure SDK'})).toBeInTheDocument();
       expect(screen.getByRole('heading', {name: 'Verify'})).toBeInTheDocument();
 
-      const allMatches = screen.getAllByText(
-        textWithMarkupMatcher(/import \* as Sentry from "@sentry\/aws-serverless"/)
-      );
-      allMatches.forEach(match => {
-        expect(match).toBeInTheDocument();
-      });
-    });
-
-    it('enables profiling by setting profiling samplerates', () => {
-      renderWithOnboardingLayout(esmDocs, {
-        selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.PROFILING],
-      });
-
       expect(
         screen.getByText(
           textWithMarkupMatcher(
-            /import { nodeProfilingIntegration } from "@sentry\/profiling-node"/
+            'NODE_OPTIONS="--import @sentry/aws-serverless/awslambda-auto"'
           )
         )
-      ).toBeInTheDocument();
-
-      expect(
-        screen.getByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
       ).toBeInTheDocument();
     });
 
-    it('continuous profiling', () => {
-      const organization = OrganizationFixture({
-        features: ['continuous-profiling'],
+    it('displays sample rates by default', () => {
+      renderWithOnboardingLayout(docs, {
+        selectedProducts: [
+          ProductSolution.ERROR_MONITORING,
+          ProductSolution.PERFORMANCE_MONITORING,
+          ProductSolution.PROFILING,
+        ],
       });
 
-      renderWithOnboardingLayout(
-        esmDocs,
-        {},
-        {
-          organization,
-        }
-      );
-
       expect(
-        screen.getByText(
-          textWithMarkupMatcher(
-            /import { nodeProfilingIntegration } from "@sentry\/profiling-node"/
-          )
-        )
-      ).toBeInTheDocument();
-
-      expect(
-        screen.getByText(textWithMarkupMatcher(/profileLifecycle: 'trace'/))
+        screen.getByText(textWithMarkupMatcher(/SENTRY_TRACES_SAMPLE_RATE/))
       ).toBeInTheDocument();
       expect(
-        screen.getByText(textWithMarkupMatcher(/profileSessionSampleRate: 1\.0/))
+        screen.getByText(textWithMarkupMatcher(/SENTRY_TRACES_SAMPLE_RATE=1\.0/))
+      ).toBeInTheDocument();
+    });
+
+    it('enables performance setting the sample rate set to 1', () => {
+      renderWithOnboardingLayout(docs, {
+        selectedProducts: [
+          ProductSolution.ERROR_MONITORING,
+          ProductSolution.PERFORMANCE_MONITORING,
+        ],
+      });
+
+      expect(
+        screen.getByText(textWithMarkupMatcher(/SENTRY_TRACES_SAMPLE_RATE=1\.0/))
       ).toBeInTheDocument();
     });
   });

--- a/static/app/gettingStartedDocs/node/awslambda.tsx
+++ b/static/app/gettingStartedDocs/node/awslambda.tsx
@@ -20,28 +20,27 @@ import {
   getNodeLogsOnboarding,
   getNodeMcpOnboarding,
   getNodeProfilingOnboarding,
-  getSdkInitSnippet,
 } from 'sentry/utils/gettingStartedDocs/node';
 
-export enum ModuleFormat {
-  CJS = 'cjs',
-  ESM = 'esm',
+export enum InstallationMethod {
+  LAMBDA_LAYER = 'lambdaLayer',
+  NPM_PACKAGE = 'npmPackage',
 }
 
 export const platformOptions = {
-  moduleFormat: {
-    label: t('Module Format'),
+  installationMethod: {
+    label: t('Installation Method'),
     items: [
       {
-        label: t('CJS: Lambda Layer'),
-        value: ModuleFormat.CJS,
+        label: t('Lambda Layer'),
+        value: InstallationMethod.LAMBDA_LAYER,
       },
       {
-        label: t('ESM: NPM Package'),
-        value: ModuleFormat.ESM,
+        label: t('NPM Package'),
+        value: InstallationMethod.NPM_PACKAGE,
       },
     ],
-    defaultValue: ModuleFormat.CJS,
+    defaultValue: InstallationMethod.LAMBDA_LAYER,
   },
 } satisfies BasePlatformOptions;
 
@@ -49,28 +48,67 @@ type PlatformOptions = typeof platformOptions;
 type Params = DocsParams<PlatformOptions>;
 
 const getEnvSetupSnippet = (params: Params) => `
-NODE_OPTIONS="-r @sentry/aws-serverless/awslambda-auto"
+NODE_OPTIONS="--import @sentry/aws-serverless/awslambda-auto"
 SENTRY_DSN="${params.dsn.public}"
 ${params.isPerformanceSelected ? 'SENTRY_TRACES_SAMPLE_RATE=1.0' : ''}
 `;
 
-const getSdkSetupSnippet = (params: Params) => `
-// IMPORTANT: Make sure to import and initialize Sentry at the top of your file.
-${getSdkInitSnippet(params, 'aws', 'esm')}
-// Place any other require/import statements here
+const commonOnboarding = {
+  configure: params => [
+    {
+      type: StepType.CONFIGURE,
+      description: tct(
+        'To set environment variables, navigate to your Lambda function, select [strong:Configuration], then [strong:Environment variables]:',
+        {
+          strong: <strong />,
+        }
+      ),
+      configurations: [
+        {
+          language: 'bash',
+          code: getEnvSetupSnippet(params),
+        },
+      ],
+    },
+    getUploadSourceMapsStep({
+      description: tct(
+        'If you want to upload source maps for your Lambda function, you can do so by running the following command and following the instructions. If you prefer to manually set up source maps, please follow [guideLink:this guide].',
+        {
+          guideLink: (
+            <ExternalLink href="https://docs.sentry.io/platforms/javascript/guides/aws-lambda/sourcemaps/" />
+          ),
+        }
+      ),
+      ...params,
+    }),
+  ],
+  verify: () => [
+    {
+      type: StepType.VERIFY,
+      description: t(
+        "This snippet contains an intentional error and can be used as a test to make sure that everything's working as expected."
+      ),
+      configurations: [
+        {
+          language: 'javascript',
+          code: `throw new Error("This should show up in Sentry!");`,
+        },
+      ],
+    },
+  ],
+} satisfies Partial<OnboardingConfig<PlatformOptions>>;
 
-exports.handler = Sentry.wrapHandler(async (event, context) => {
-  // Your handler code
-});`;
-
-const moduleFormatOnboarding: Record<ModuleFormat, OnboardingConfig<PlatformOptions>> = {
-  [ModuleFormat.CJS]: {
+const installationMethodOnboarding: Record<
+  InstallationMethod,
+  OnboardingConfig<PlatformOptions>
+> = {
+  [InstallationMethod.LAMBDA_LAYER]: {
     introduction: () =>
       tct(
         "In this quick guide you'll use set up Sentry for your AWS Lambda function. For more information visit [link:docs].",
         {
           link: (
-            <ExternalLink href="https://docs.sentry.io/platforms/javascript/guides/aws-lambda/install/cjs-layer/" />
+            <ExternalLink href="https://docs.sentry.io/platforms/javascript/guides/aws-lambda/install/layer/" />
           ),
           strong: <strong />,
         }
@@ -96,56 +134,16 @@ const moduleFormatOnboarding: Record<ModuleFormat, OnboardingConfig<PlatformOpti
         ],
       },
     ],
-    configure: params => [
-      {
-        type: StepType.CONFIGURE,
-        description: tct(
-          'To set environment variables, navigate to your Lambda function, select [strong:Configuration], then [strong:Environment variables]:',
-          {
-            strong: <strong />,
-          }
-        ),
-        configurations: [
-          {
-            language: 'bash',
-            code: getEnvSetupSnippet(params),
-          },
-        ],
-      },
-      getUploadSourceMapsStep({
-        description: tct(
-          'If you want to upload source maps for your Lambda function, you can do so by running the following command and following the instructions. If you prefer to manually set up source maps, please follow [guideLink:this guide].',
-          {
-            guideLink: (
-              <ExternalLink href="https://docs.sentry.io/platforms/javascript/guides/aws-lambda/sourcemaps/" />
-            ),
-          }
-        ),
-        ...params,
-      }),
-    ],
-    verify: () => [
-      {
-        type: StepType.VERIFY,
-        description: t(
-          "This snippet contains an intentional error and can be used as a test to make sure that everything's working as expected."
-        ),
-        configurations: [
-          {
-            language: 'javascript',
-            code: `throw new Error("This should show up in Sentry!");`,
-          },
-        ],
-      },
-    ],
+    configure: commonOnboarding.configure,
+    verify: commonOnboarding.verify,
   },
-  [ModuleFormat.ESM]: {
+  [InstallationMethod.NPM_PACKAGE]: {
     introduction: () =>
       tct(
         'In this quick guide you’ll use set up Sentry for your AWS Lambda function. For more information visit [link:docs].',
         {
           link: (
-            <ExternalLink href="https://docs.sentry.io/platforms/javascript/guides/aws-lambda/install/esm-npm/" />
+            <ExternalLink href="https://docs.sentry.io/platforms/javascript/guides/aws-lambda/install/npm/" />
           ),
           strong: <strong />,
         }
@@ -159,52 +157,28 @@ const moduleFormatOnboarding: Record<ModuleFormat, OnboardingConfig<PlatformOpti
         }),
       },
     ],
-    configure: (params: Params) => [
-      {
-        type: StepType.CONFIGURE,
-        description: tct(
-          "Ensure that Sentry is imported and initialized at the beginning of your file, prior to any other [code:require] or [code:import] statements. Then, wrap your lambda handler with Sentry's [code:wrapHandler] function:",
-          {
-            code: <code />,
-          }
-        ),
-        configurations: [
-          {
-            language: 'javascript',
-            code: getSdkSetupSnippet(params),
-          },
-        ],
-      },
-    ],
-    verify: () => [
-      {
-        type: StepType.VERIFY,
-        description: t(
-          "This snippet contains an intentional error and can be used as a test to make sure that everything's working as expected."
-        ),
-        configurations: [
-          {
-            language: 'javascript',
-            code: `
-export const handler = Sentry.wrapHandler(async (event, context) => {
-  throw new Error("This should show up in Sentry!")
-});`,
-          },
-        ],
-      },
-    ],
+    configure: commonOnboarding.configure,
+    verify: commonOnboarding.verify,
   },
 };
 
 const onboarding: OnboardingConfig<PlatformOptions> = {
   introduction: (params: Params) =>
-    moduleFormatOnboarding[params.platformOptions.moduleFormat].introduction?.(params),
+    installationMethodOnboarding[
+      params.platformOptions.installationMethod
+    ].introduction?.(params),
   install: (params: Params) =>
-    moduleFormatOnboarding[params.platformOptions.moduleFormat].install(params),
+    installationMethodOnboarding[params.platformOptions.installationMethod].install(
+      params
+    ),
   configure: (params: Params) =>
-    moduleFormatOnboarding[params.platformOptions.moduleFormat].configure(params),
+    installationMethodOnboarding[params.platformOptions.installationMethod].configure(
+      params
+    ),
   verify: (params: Params) =>
-    moduleFormatOnboarding[params.platformOptions.moduleFormat].verify(params),
+    installationMethodOnboarding[params.platformOptions.installationMethod].verify(
+      params
+    ),
 };
 
 const crashReportOnboarding: OnboardingConfig<PlatformOptions> = {


### PR DESCRIPTION
Simplifies and refactors the Node AWS Lambda onboarding docs to reflect that:
- The Lambda layer supports both ESM and CJS, no need to differentiate based on this anymore
- The SDK supports automatic wrapping for both ESM and CJS, no need to show manual setup in onboarding anymore

closes https://linear.app/getsentry/issue/FE-592/update-aws-onboarding-docs