### PR TITLE
feat(aci): Fetch and display open periods in metric detector details chart

### DIFF
--- a/static/app/views/detectors/components/details/metric/chart.tsx
+++ b/static/app/views/detectors/components/details/metric/chart.tsx
@@ -17,6 +17,7 @@ import {getDatasetConfig} from 'sentry/views/detectors/datasetConfig/getDatasetC
 import {useIncidentMarkers} from 'sentry/views/detectors/hooks/useIncidentMarkers';
 import {useMetricDetectorSeries} from 'sentry/views/detectors/hooks/useMetricDetectorSeries';
 import {useMetricDetectorThresholdSeries} from 'sentry/views/detectors/hooks/useMetricDetectorThresholdSeries';
+import {useOpenPeriods} from 'sentry/views/detectors/hooks/useOpenPeriods';
 
 interface MetricDetectorDetailsChartProps {
   detector: MetricDetector;
@@ -66,10 +67,29 @@ function MetricDetectorChart({
       comparisonSeries,
     });
 
-  // TODO: Fetch open periods and transform them into the right format
-  const openPeriods: any[] = [];
+  const {data: openPeriods = []} = useOpenPeriods({
+    detectorId: detector.id,
+    start,
+    end,
+    statsPeriod,
+  });
+
+  const incidentPeriods = useMemo(() => {
+    const endDate = end ? new Date(end).getTime() : Date.now();
+
+    return openPeriods.map(period => ({
+      ...period,
+      // TODO: When open periods return a priority, use that to determine the color
+      color: 'red',
+      name: t('Open Periods'),
+      type: 'openPeriod',
+      end: period.end ? new Date(period.end).getTime() : endDate,
+      start: new Date(period.start).getTime(),
+    }));
+  }, [openPeriods, end]);
+
   const openPeriodMarkerResult = useIncidentMarkers({
-    incidents: openPeriods,
+    incidents: incidentPeriods,
     seriesName: t('Open Periods'),
     seriesId: '__incident_marker__',
     yAxisIndex: 1, // Use index 1 to avoid conflict with main chart axis

--- a/static/app/views/detectors/detail.spec.tsx
+++ b/static/app/views/detectors/detail.spec.tsx
@@ -71,6 +71,10 @@ describe('DetectorDetails', () => {
       url: '/organizations/org-slug/issues/?limit=5&query=is%3Aunresolved%20detector%3A1&statsPeriod=14d',
       body: [GroupFixture()],
     });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/open-periods/',
+      body: [],
+    });
   });
 
   describe('metric detectors', () => {

--- a/static/app/views/detectors/hooks/useOpenPeriods.tsx
+++ b/static/app/views/detectors/hooks/useOpenPeriods.tsx
@@ -22,7 +22,7 @@ type UseOpenPeriodsParams =
       groupId: string;
     } & CommonParams);
 
-export function makeOpenPeriodsQueryKey({
+function makeOpenPeriodsQueryKey({
   orgSlug,
   ...params
 }: UseOpenPeriodsParams & {orgSlug: string}): ApiQueryKey {

--- a/static/app/views/detectors/hooks/useOpenPeriods.tsx
+++ b/static/app/views/detectors/hooks/useOpenPeriods.tsx
@@ -1,0 +1,50 @@
+import type {GroupOpenPeriod} from 'sentry/types/group';
+import {
+  useApiQuery,
+  type ApiQueryKey,
+  type UseApiQueryOptions,
+} from 'sentry/utils/queryClient';
+import useOrganization from 'sentry/utils/useOrganization';
+
+type CommonParams = {
+  cursor?: string;
+  end?: string;
+  limit?: number;
+  start?: string;
+  statsPeriod?: string;
+};
+
+type UseOpenPeriodsParams =
+  | ({
+      detectorId: string;
+    } & CommonParams)
+  | ({
+      groupId: string;
+    } & CommonParams);
+
+export function makeOpenPeriodsQueryKey({
+  orgSlug,
+  ...params
+}: UseOpenPeriodsParams & {orgSlug: string}): ApiQueryKey {
+  return [
+    `/organizations/${orgSlug}/open-periods/`,
+    {
+      query: params,
+    },
+  ];
+}
+
+export function useOpenPeriods(
+  params: UseOpenPeriodsParams,
+  options: Partial<UseApiQueryOptions<GroupOpenPeriod[]>> = {}
+) {
+  const organization = useOrganization();
+
+  return useApiQuery<GroupOpenPeriod[]>(
+    makeOpenPeriodsQueryKey({orgSlug: organization.slug, ...params}),
+    {
+      staleTime: 0,
+      ...options,
+    }
+  );
+}


### PR DESCRIPTION
Simple addition, calls the new API and uses useIncidentMarkers to display the open periods. I'm not sure if there is a good way to write a test for this :/

Still todo:

- Open periods do not yet track the priority so everything is marked in red (work in currently in progress to get open periods separated by priority)
- Tiny open periods aren't displayed correctly - this may be something that we need to discuss with design about

<img width="1990" height="740" alt="CleanShot 2025-08-27 at 10 01 02@2x" src="https://github.com/user-attachments/assets/83aafb36-3d21-4f16-a143-fe679bdf6328" />
