### PR TITLE
fix(member-delete): prevent last owner or manager from being removed from org

### DIFF
--- a/src/sentry/api/endpoints/organization_member/details.py
+++ b/src/sentry/api/endpoints/organization_member/details.py
@@ -48,7 +48,9 @@ ERR_MEMBER_INVITE = "You cannot modify invitations sent by someone else."
 ERR_EDIT_WHEN_REINVITING = (
     "You cannot modify member details when resending an invitation. Separate requests are required."
 )
-ERR_ONLY_OWNER = "You cannot remove the only remaining owner of the organization."
+ERR_ONLY_OWNER_OR_MANAGER = (
+    "You cannot remove the only remaining owner or manager of the organization."
+)
 ERR_UNINVITABLE = "You cannot send an invitation to a user who is already a full member."
 ERR_EXPIRED = "You cannot resend an expired invitation without regenerating the token."
 ERR_RATE_LIMITED = "You are being rate limited for too many invitations."
@@ -479,8 +481,8 @@ class OrganizationMemberDetailsEndpoint(OrganizationMemberEndpoint):
         elif not request.access.has_scope("member:admin"):
             return Response({"detail": ERR_INSUFFICIENT_SCOPE}, status=400)
 
-        if member.is_only_owner():
-            return Response({"detail": ERR_ONLY_OWNER}, status=403)
+        if member.is_only_member_with_org_write():
+            return Response({"detail": ERR_ONLY_OWNER_OR_MANAGER}, status=403)
 
         if getattr(member.flags, "idp:provisioned"):
             return Response(

--- a/src/sentry/api/endpoints/organization_member/details.py
+++ b/src/sentry/api/endpoints/organization_member/details.py
@@ -48,6 +48,7 @@ ERR_MEMBER_INVITE = "You cannot modify invitations sent by someone else."
 ERR_EDIT_WHEN_REINVITING = (
     "You cannot modify member details when resending an invitation. Separate requests are required."
 )
+ERR_ONLY_OWNER = "You cannot remove the only remaining owner of the organization."
 ERR_ONLY_OWNER_OR_MANAGER = (
     "You cannot remove the only remaining owner or manager of the organization."
 )

--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -628,6 +628,19 @@ class OrganizationMember(ReplicatedRegionModel):
         )
         return is_only_owner
 
+    def is_only_member_with_org_write(self) -> bool:
+        roles_with_org_write = [r.id for r in roles.with_scope("org:write")]
+
+        if self.role not in roles_with_org_write:
+            return False
+
+        is_only_member_with_org_write = not (
+            self.organization.get_members_with_org_roles(roles=roles_with_org_write)
+            .exclude(id=self.id)
+            .exists()
+        )
+        return is_only_member_with_org_write
+
     @classmethod
     def handle_async_deletion(
         cls, identifier: int, shard_identifier: int, payload: Mapping[str, Any] | None


### PR DESCRIPTION
if there are no org owners, we also want to prevent the last org manager from being removed

fixes https://linear.app/getsentry/issue/RTC-1117/manager-role-user-can-reset-owners-2fa-and-enforce-2fa-for-org-leads