### PR TITLE
feat(dashboards): Add warning message when querying out of retention period

### DIFF
--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -9,6 +9,7 @@ import type {SentryRouteObject} from 'sentry/components/route';
 import type SidebarItem from 'sentry/components/sidebar/sidebarItem';
 import type DateRange from 'sentry/components/timeRangeSelector/dateRange';
 import type SelectorItems from 'sentry/components/timeRangeSelector/selectorItems';
+import type {WidgetType} from 'sentry/views/dashboards/types';
 import type {TitleableModuleNames} from 'sentry/views/insights/common/components/modulePageProviders';
 import type {OrganizationStatsProps} from 'sentry/views/organizationStats';
 import type {RouteAnalyticsContext} from 'sentry/views/routeAnalyticsContextProvider';
@@ -328,6 +329,9 @@ type ReactHooks = {
     props: RouteContextInterface
   ) => React.ContextType<typeof RouteAnalyticsContext>;
   'react-hook:use-button-tracking': (props: ButtonProps) => () => void;
+  'react-hook:use-dashboard-dataset-retention-limit': (props: {
+    dataset: WidgetType;
+  }) => [Date, string];
   'react-hook:use-get-max-retention-days': () => number | undefined;
   'react-hook:use-metric-detector-limit': () => {
     detectorCount: number;

--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -331,7 +331,7 @@ type ReactHooks = {
   'react-hook:use-button-tracking': (props: ButtonProps) => () => void;
   'react-hook:use-dashboard-dataset-retention-limit': (props: {
     dataset: WidgetType;
-  }) => [Date, string];
+  }) => number;
   'react-hook:use-get-max-retention-days': () => number | undefined;
   'react-hook:use-metric-detector-limit': () => {
     detectorCount: number;

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -414,7 +414,7 @@ function useTimeRangeWarning({widget}: {widget: Widget}) {
     (retentionLimitDate && statsPeriodToEnd && retentionLimitDate > statsPeriodToEnd)
   ) {
     return tct(
-      `This widget is querying more data than the retention limit on the dataset allows. The data may be incomplete before [numDays] days.`,
+      `You've selected a time range longer than the retention period for this dataset. Data older than [numDays] days may be unavailable.`,
       {
         numDays: retentionLimitDays,
       }

--- a/static/gsApp/hooks/useDashboardDatasetRetentionLimit.tsx
+++ b/static/gsApp/hooks/useDashboardDatasetRetentionLimit.tsx
@@ -1,0 +1,42 @@
+import {WidgetType} from 'sentry/views/dashboards/types';
+
+import useSubscription from 'getsentry/hooks/useSubscription';
+import {isBizPlanFamily} from 'getsentry/utils/billing';
+
+const THIRTY_DAYS = 30 * 24 * 60 * 60 * 1000;
+const NINETY_DAYS = 90 * 24 * 60 * 60 * 1000;
+
+/**
+ * Returns the retention limit for a given dataset.
+ *
+ * The retention limit is in relation to the organization's plan.
+ *
+ * @param dataset - The dataset to get the retention limit for.
+ * @returns The date of the last data point that can be displayed in the dashboard and the number of days of retention.
+ */
+export function useDashboardDatasetRetentionLimit({
+  dataset,
+}: {
+  dataset: WidgetType;
+}): [Date, string] {
+  const subscription = useSubscription();
+  let retentionLimit = NINETY_DAYS;
+
+  switch (dataset) {
+    case WidgetType.LOGS:
+      retentionLimit = THIRTY_DAYS;
+      break;
+    case WidgetType.SPANS:
+      if (subscription?.planDetails && !isBizPlanFamily(subscription.planDetails)) {
+        retentionLimit = THIRTY_DAYS;
+      }
+      break;
+    default:
+      break;
+  }
+
+  return [
+    new Date(Date.now() - retentionLimit),
+    retentionLimit === NINETY_DAYS ? '90' : '30',
+  ];
+}

--- a/static/gsApp/hooks/useDashboardDatasetRetentionLimit.tsx
+++ b/static/gsApp/hooks/useDashboardDatasetRetentionLimit.tsx
@@ -3,8 +3,8 @@ import {WidgetType} from 'sentry/views/dashboards/types';
 import useSubscription from 'getsentry/hooks/useSubscription';
 import {isBizPlanFamily} from 'getsentry/utils/billing';
 
-const THIRTY_DAYS = 30 * 24 * 60 * 60 * 1000;
-const NINETY_DAYS = 90 * 24 * 60 * 60 * 1000;
+const THIRTY_DAYS = 30;
+const NINETY_DAYS = 90;
 
 /**
  * Returns the retention limit for a given dataset.
@@ -12,13 +12,13 @@ const NINETY_DAYS = 90 * 24 * 60 * 60 * 1000;
  * The retention limit is in relation to the organization's plan.
  *
  * @param dataset - The dataset to get the retention limit for.
- * @returns The date of the last data point that can be displayed in the dashboard and the number of days of retention.
+ * @returns The number of days of retention from now.
  */
 export function useDashboardDatasetRetentionLimit({
   dataset,
 }: {
   dataset: WidgetType;
-}): [Date, string] {
+}): number {
   const subscription = useSubscription();
   let retentionLimit = NINETY_DAYS;
 
@@ -35,8 +35,5 @@ export function useDashboardDatasetRetentionLimit({
       break;
   }
 
-  return [
-    new Date(Date.now() - retentionLimit),
-    retentionLimit === NINETY_DAYS ? '90' : '30',
-  ];
+  return retentionLimit;
 }

--- a/static/gsApp/registerHooks.tsx
+++ b/static/gsApp/registerHooks.tsx
@@ -72,6 +72,7 @@ import EnhancedOrganizationStats from 'getsentry/hooks/spendVisibility/enhancedI
 import SpikeProtectionProjectSettings from 'getsentry/hooks/spendVisibility/spikeProtectionProjectSettings';
 import SuperuserAccessCategory from 'getsentry/hooks/superuserAccessCategory';
 import TargetedOnboardingHeader from 'getsentry/hooks/targetedOnboardingHeader';
+import {useDashboardDatasetRetentionLimit} from 'getsentry/hooks/useDashboardDatasetRetentionLimit';
 import {useMetricDetectorLimit} from 'getsentry/hooks/useMetricDetectorLimit';
 import rawTrackAnalyticsEvent from 'getsentry/utils/rawTrackAnalyticsEvent';
 import trackMetric from 'getsentry/utils/trackMetric';
@@ -248,6 +249,7 @@ const GETSENTRY_HOOKS: Partial<Hooks> = {
   'react-hook:use-button-tracking': useButtonTracking,
   'react-hook:use-get-max-retention-days': useGetMaxRetentionDays,
   'react-hook:use-metric-detector-limit': useMetricDetectorLimit,
+  'react-hook:use-dashboard-dataset-retention-limit': useDashboardDatasetRetentionLimit,
   'component:partnership-agreement': p => (
     <LazyLoad LazyComponent={PartnershipAgreement} {...p} />
   ),


### PR DESCRIPTION
Adds a warning message to widgets if the user is querying outside of the dataset's retention period.

For logs, the retention is 30d for all plans.
Spans, the retantion is 90d on business, 30d otherwise.
Everything else (errors, issues, transactions, release), is 90d.

<img width="317" height="182" alt="Screenshot 2025-08-27 at 2 09 06 PM" src="https://github.com/user-attachments/assets/eff397e9-f962-44e3-9f84-4bdca31e4cd2" />
