### PR TITLE
feat(explore): Add support for non-string count_if

### DIFF
--- a/src/sentry/search/eap/constants.py
+++ b/src/sentry/search/eap/constants.py
@@ -27,6 +27,14 @@ OPERATOR_MAP = {
     ">=": ComparisonFilter.OP_GREATER_THAN_OR_EQUALS,
     "<=": ComparisonFilter.OP_LESS_THAN_OR_EQUALS,
 }
+LITERAL_OPERATOR_MAP = {
+    "equals": ComparisonFilter.OP_EQUALS,
+    "notEquals": ComparisonFilter.OP_NOT_EQUALS,
+    "greater": ComparisonFilter.OP_GREATER_THAN,
+    "less": ComparisonFilter.OP_LESS_THAN,
+    "greaterOrEquals": ComparisonFilter.OP_GREATER_THAN_OR_EQUALS,
+    "lessOrEquals": ComparisonFilter.OP_LESS_THAN_OR_EQUALS,
+}
 IN_OPERATORS = ["IN", "NOT IN"]
 
 AGGREGATION_OPERATOR_MAP = {

--- a/src/sentry/search/eap/spans/aggregates.py
+++ b/src/sentry/search/eap/spans/aggregates.py
@@ -60,19 +60,19 @@ def resolve_key_eq_value_filter(args: ResolvedArguments) -> tuple[AttributeKey, 
     )  # This should always be a string. Assertion to deal with typing errors.
 
     try:
-        if key.type == AttributeKey.Type.TYPE_DOUBLE:
+        if key.type == AttributeKey.TYPE_DOUBLE:
             attr_value = AttributeValue(val_double=float(value))
-        elif key.type == AttributeKey.Type.TYPE_FLOAT:
+        elif key.type == AttributeKey.TYPE_FLOAT:
             attr_value = AttributeValue(val_float=float(value))
-        elif key.type == AttributeKey.Type.TYPE_INT:
+        elif key.type == AttributeKey.TYPE_INT:
             attr_value = AttributeValue(val_int=int(value))
         else:
             attr_value = AttributeValue(val_str=value)
     except ValueError:
         expected_type = "string"
-        if key.type in [AttributeKey.Type.TYPE_FLOAT, AttributeKey.Type.TYPE_DOUBLE]:
+        if key.type in [AttributeKey.TYPE_FLOAT, AttributeKey.TYPE_DOUBLE]:
             expected_type = "number"
-        if key.type == AttributeKey.Type.TYPE_INT:
+        if key.type == AttributeKey.TYPE_INT:
             expected_type = "integer"
         raise InvalidSearchQuery(f"Invalid parameter '{value}'. Must be of type {expected_type}.")
 

--- a/src/sentry/search/eap/spans/aggregates.py
+++ b/src/sentry/search/eap/spans/aggregates.py
@@ -87,11 +87,7 @@ def resolve_key_eq_value_filter(args: ResolvedArguments) -> tuple[AttributeKey, 
     trace_filter = TraceItemFilter(
         comparison_filter=ComparisonFilter(
             key=key,
-            op=(
-                ComparisonFilter.OP_EQUALS
-                if operator == "equals"
-                else ComparisonFilter.OP_NOT_EQUALS
-            ),
+            op=constants.LITERAL_OPERATOR_MAP[operator],
             value=attr_value,
         )
     )

--- a/src/sentry/search/eap/spans/aggregates.py
+++ b/src/sentry/search/eap/spans/aggregates.py
@@ -57,7 +57,7 @@ def resolve_key_eq_value_filter(args: ResolvedArguments) -> tuple[AttributeKey, 
     value = args[3]
     assert isinstance(
         value, str
-    )  # This should always be a string. Assertion to deal with typing errors.
+    ), "Value must be a String"  # This should always be a string. Assertion to deal with typing errors.
 
     try:
         if key.type == AttributeKey.TYPE_DOUBLE:

--- a/src/sentry/search/eap/spans/aggregates.py
+++ b/src/sentry/search/eap/spans/aggregates.py
@@ -54,18 +54,19 @@ def resolve_key_eq_value_filter(args: ResolvedArguments) -> tuple[AttributeKey, 
     key = cast(AttributeKey, args[1])
     operator = cast(str, args[2])
 
+    value = args[3]
+    assert isinstance(
+        value, str
+    )  # This should always be a string. Assertion to deal with typing errors.
+
     try:
         if key.type == AttributeKey.Type.TYPE_DOUBLE:
-            value = float(args[3])
-            attr_value = AttributeValue(val_double=value)
+            attr_value = AttributeValue(val_double=float(value))
         elif key.type == AttributeKey.Type.TYPE_FLOAT:
-            value = float(args[3])
-            attr_value = AttributeValue(val_float=value)
+            attr_value = AttributeValue(val_float=float(value))
         elif key.type == AttributeKey.Type.TYPE_INT:
-            value = int(args[3])
-            attr_value = AttributeValue(val_int=value)
+            attr_value = AttributeValue(val_int=int(value))
         else:
-            value = cast(str, args[3])
             attr_value = AttributeValue(val_str=value)
     except ValueError:
         expected_type = "string"
@@ -73,7 +74,7 @@ def resolve_key_eq_value_filter(args: ResolvedArguments) -> tuple[AttributeKey, 
             expected_type = "number"
         if key.type == AttributeKey.Type.TYPE_INT:
             expected_type = "integer"
-        raise InvalidSearchQuery(f"Invalid parameter '{args[3]}'. Must be of type {expected_type}.")
+        raise InvalidSearchQuery(f"Invalid parameter '{value}'. Must be of type {expected_type}.")
 
     if key.type == AttributeKey.TYPE_BOOLEAN:
         lower_value = value.lower()

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -2847,10 +2847,7 @@ class OrganizationEventsSpansEndpointTest(OrganizationEventsEndpointTestBase):
         )
 
         assert response.status_code == 400, response.content
-        assert (
-            "Invalid parameter snequals. Must be one of ['equals', 'notEquals']"
-            == response.data["detail"]
-        )
+        assert "Invalid parameter snequals" in response.data["detail"]
 
     def test_ttif_ttfd_contribution_rate(self) -> None:
         spans = []
@@ -5713,7 +5710,7 @@ class OrganizationEventsSpansEndpointTest(OrganizationEventsEndpointTestBase):
         )
 
         assert response.status_code == 400, response.content
-        assert "Invalid parameter " in response.data["detail"].title()
+        assert "Invalid Parameter " in response.data["detail"].title()
 
     def test_apdex_function(self) -> None:
         """Test the apdex function with span.duration and threshold."""

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -5649,6 +5649,11 @@ class OrganizationEventsSpansEndpointTest(OrganizationEventsEndpointTestBase):
                     duration=400,
                 ),
                 self.create_span(
+                    {"description": "foo", "sentry_tags": {"status": "success"}},
+                    start_ts=self.ten_mins_ago,
+                    duration=400,
+                ),
+                self.create_span(
                     {
                         "description": "bar",
                         "sentry_tags": {"status": "invalid_argument"},
@@ -5681,24 +5686,6 @@ class OrganizationEventsSpansEndpointTest(OrganizationEventsEndpointTestBase):
         assert meta["dataset"] == "spans"
 
     def test_count_if_numeric_raises_invalid_search_query_with_bad_value(self) -> None:
-        self.store_spans(
-            [
-                self.create_span(
-                    {"description": "foo", "sentry_tags": {"status": "success"}},
-                    start_ts=self.ten_mins_ago,
-                    duration=400,
-                ),
-                self.create_span(
-                    {
-                        "description": "bar",
-                        "sentry_tags": {"status": "invalid_argument"},
-                    },
-                    start_ts=self.ten_mins_ago,
-                    duration=200,
-                ),
-            ],
-            is_eap=True,
-        )
         response = self.do_request(
             {
                 "field": ["count_if(span.duration,greater,three)"],


### PR DESCRIPTION
Counting attrs on count_if is currently only restricted to string attrs.
We want to allow all numeric attrs since `count_if('span.duration',greater,300)`
for example is a valid count if. 

We need to validate that `AttributeValue` is constructed with the correct
type based on the `AttributeKey`, so I'm doing this inside `resolve_key_eq_value_filter` 