### PR TITLE
ref(timeseries): Add `useFetchEventsTimeSeries` hook

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -55,6 +55,8 @@ const config: KnipConfig = {
     // helper files for stories - it's fine that they are only used in tests
     '!static/app/**/__stories__/*.{js,mjs,ts,tsx}!',
     '!static/app/stories/**/*.{js,mjs,ts,tsx}!',
+    // TEMPORARY!
+    '!static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx',
   ],
   compilers: {
     mdx: async text => String(await compile(text)),

--- a/static/app/utils/timeSeries/getIntervalForTimeSeriesQuery.tsx
+++ b/static/app/utils/timeSeries/getIntervalForTimeSeriesQuery.tsx
@@ -1,0 +1,32 @@
+import sortBy from 'lodash/sortBy';
+
+import type {DateTimeObject} from 'sentry/components/charts/utils';
+import {parseFunction} from 'sentry/utils/discover/fields';
+import {intervalToMilliseconds} from 'sentry/utils/duration/intervalToMilliseconds';
+import {getIntervalForMetricFunction} from 'sentry/views/insights/database/utils/getIntervalForMetricFunction';
+
+// TODO: Add some documentation
+// Pick the highest possible interval for the given yAxis selection. Find the ideal interval for each function, then choose the largest one. This results in the lowest granularity, but best performance.
+export function getIntervalForTimeSeriesQuery(
+  yAxis: string | string[],
+  datetime: DateTimeObject
+): string {
+  if (yAxis.length === 0) {
+    return DEFAULT_INTERVAL;
+  }
+
+  return sortBy(
+    (Array.isArray(yAxis) ? yAxis : [yAxis]).map(yAxisFunctionName => {
+      const parseResult = parseFunction(yAxisFunctionName);
+
+      if (!parseResult) {
+        return DEFAULT_INTERVAL;
+      }
+
+      return getIntervalForMetricFunction(parseResult.name, datetime);
+    }),
+    intervalToMilliseconds
+  ).at(-1)!; // NOTE: Non-null assertion because we check the length at the start of the function!
+}
+
+const DEFAULT_INTERVAL = '10m';

--- a/static/app/utils/timeSeries/getIntervalForTimeSeriesQuery.tsx
+++ b/static/app/utils/timeSeries/getIntervalForTimeSeriesQuery.tsx
@@ -5,8 +5,11 @@ import {parseFunction} from 'sentry/utils/discover/fields';
 import {intervalToMilliseconds} from 'sentry/utils/duration/intervalToMilliseconds';
 import {getIntervalForMetricFunction} from 'sentry/views/insights/database/utils/getIntervalForMetricFunction';
 
-// TODO: Add some documentation
-// Pick the highest possible interval for the given yAxis selection. Find the ideal interval for each function, then choose the largest one. This results in the lowest granularity, but best performance.
+/**
+ * Given a list of requested Y axes and a date range, figures out the most appropriate interval.
+ *
+ * This is a legacy function that was useful in the days of span metrics, where some metrics were much more expensive to query than others. In the age of EAP, this is not needed anymore. In EAP, granularity is _very cheap_, and we can be more generous with it regardless of the specific metric being queried.
+ */
 export function getIntervalForTimeSeriesQuery(
   yAxis: string | string[],
   datetime: DateTimeObject

--- a/static/app/utils/timeSeries/getIntervalForTimeSeriesQuery.tsx
+++ b/static/app/utils/timeSeries/getIntervalForTimeSeriesQuery.tsx
@@ -4,6 +4,7 @@ import type {DateTimeObject} from 'sentry/components/charts/utils';
 import {parseFunction} from 'sentry/utils/discover/fields';
 import {intervalToMilliseconds} from 'sentry/utils/duration/intervalToMilliseconds';
 import {getIntervalForMetricFunction} from 'sentry/views/insights/database/utils/getIntervalForMetricFunction';
+import {DEFAULT_INTERVAL} from 'sentry/views/insights/settings';
 
 /**
  * Given a list of requested Y axes and a date range, figures out the most appropriate interval.
@@ -31,5 +32,3 @@ export function getIntervalForTimeSeriesQuery(
     intervalToMilliseconds
   ).at(-1)!; // NOTE: Non-null assertion because we check the length at the start of the function!
 }
-
-const DEFAULT_INTERVAL = '10m';

--- a/static/app/utils/timeSeries/useFetchEventsTimeSeries.spec.tsx
+++ b/static/app/utils/timeSeries/useFetchEventsTimeSeries.spec.tsx
@@ -7,6 +7,7 @@ import {makeTestQueryClient} from 'sentry-test/queryClient';
 import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {OrganizationContext} from 'sentry/views/organizationContext';
 
@@ -139,6 +140,7 @@ describe('useFetchEventsTimeSeries', () => {
           DiscoverDatasets.SPANS,
           {
             yAxis: 'p50(span.duration)',
+            search: new MutableSearch('span.op:db*'),
           },
           REFERRER
         ),
@@ -162,6 +164,7 @@ describe('useFetchEventsTimeSeries', () => {
           environment: ['prod'],
           project: [42],
           interval: '1h',
+          search: 'span.op:db*',
         },
       })
     );

--- a/static/app/utils/timeSeries/useFetchEventsTimeSeries.spec.tsx
+++ b/static/app/utils/timeSeries/useFetchEventsTimeSeries.spec.tsx
@@ -165,6 +165,7 @@ describe('useFetchEventsTimeSeries', () => {
           project: [42],
           interval: '1h',
           search: 'span.op:db*',
+          sampling: 'NORMAL',
         },
       })
     );

--- a/static/app/utils/timeSeries/useFetchEventsTimeSeries.spec.tsx
+++ b/static/app/utils/timeSeries/useFetchEventsTimeSeries.spec.tsx
@@ -29,7 +29,14 @@ describe('useFetchEventsTimeSeries', () => {
     });
 
     const {result} = renderHook(
-      () => useFetchEventsTimeSeries({}, DiscoverDatasets.SPANS, REFERRER),
+      () =>
+        useFetchEventsTimeSeries(
+          {
+            yAxis: 'epm()',
+          },
+          DiscoverDatasets.SPANS,
+          REFERRER
+        ),
       {
         wrapper: Wrapper,
       }
@@ -47,6 +54,46 @@ describe('useFetchEventsTimeSeries', () => {
           partial: 1,
           referrer: 'test-query',
           dataset: 'spans',
+          yAxis: 'epm()',
+        },
+      })
+    );
+  });
+
+  it('fetches multiple Y axes', async () => {
+    const request = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events-timeseries/`,
+      method: 'GET',
+      body: {},
+    });
+
+    const {result} = renderHook(
+      () =>
+        useFetchEventsTimeSeries(
+          {
+            yAxis: ['count(span.duration)', 'p50(span.duration)'],
+          },
+          DiscoverDatasets.SPANS,
+          REFERRER
+        ),
+      {
+        wrapper: Wrapper,
+      }
+    );
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(request).toHaveBeenCalledWith(
+      '/organizations/org-slug/events-timeseries/',
+      expect.objectContaining({
+        method: 'GET',
+        query: {
+          excludeOther: 0,
+          partial: 1,
+          referrer: 'test-query',
+          dataset: 'spans',
+          yAxis: ['count(span.duration)', 'p50(span.duration)'],
         },
       })
     );
@@ -63,6 +110,7 @@ describe('useFetchEventsTimeSeries', () => {
       () =>
         useFetchEventsTimeSeries(
           {
+            yAxis: ['epm()'],
             enabled: false,
           },
           DiscoverDatasets.SPANS,
@@ -85,6 +133,7 @@ describe('useFetchEventsTimeSeries', () => {
         () =>
           useFetchEventsTimeSeries(
             {
+              yAxis: ['epm()'],
               enabled: false,
             },
             DiscoverDatasets.SPANS,

--- a/static/app/utils/timeSeries/useFetchEventsTimeSeries.spec.tsx
+++ b/static/app/utils/timeSeries/useFetchEventsTimeSeries.spec.tsx
@@ -45,4 +45,27 @@ describe('useFetchEventsTimeSeries', () => {
       })
     );
   });
+
+  it('can be disabled', async () => {
+    const request = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events-timeseries/`,
+      method: 'GET',
+      body: {},
+    });
+
+    const {result} = renderHook(
+      () =>
+        useFetchEventsTimeSeries({
+          enabled: false,
+        }),
+      {
+        wrapper: Wrapper,
+      }
+    );
+
+    await waitFor(() => expect(result.current.isPending).toBe(true));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(request).toHaveBeenCalledTimes(0);
+  });
 });

--- a/static/app/utils/timeSeries/useFetchEventsTimeSeries.spec.tsx
+++ b/static/app/utils/timeSeries/useFetchEventsTimeSeries.spec.tsx
@@ -31,10 +31,10 @@ describe('useFetchEventsTimeSeries', () => {
     const {result} = renderHook(
       () =>
         useFetchEventsTimeSeries(
+          DiscoverDatasets.SPANS,
           {
             yAxis: 'epm()',
           },
-          DiscoverDatasets.SPANS,
           REFERRER
         ),
       {
@@ -70,10 +70,10 @@ describe('useFetchEventsTimeSeries', () => {
     const {result} = renderHook(
       () =>
         useFetchEventsTimeSeries(
+          DiscoverDatasets.SPANS,
           {
             yAxis: ['count(span.duration)', 'p50(span.duration)'],
           },
-          DiscoverDatasets.SPANS,
           REFERRER
         ),
       {
@@ -93,7 +93,7 @@ describe('useFetchEventsTimeSeries', () => {
           partial: 1,
           referrer: 'test-query',
           dataset: 'spans',
-          yAxis: ['count(span.duration)', 'p50(span.duration)'],
+          yAxis: 'epm()',
         },
       })
     );
@@ -109,11 +109,11 @@ describe('useFetchEventsTimeSeries', () => {
     const {result} = renderHook(
       () =>
         useFetchEventsTimeSeries(
+          DiscoverDatasets.SPANS,
           {
             yAxis: ['epm()'],
             enabled: false,
           },
-          DiscoverDatasets.SPANS,
           REFERRER
         ),
       {
@@ -132,11 +132,11 @@ describe('useFetchEventsTimeSeries', () => {
       renderHook(
         () =>
           useFetchEventsTimeSeries(
+            DiscoverDatasets.SPANS,
             {
               yAxis: ['epm()'],
               enabled: false,
             },
-            DiscoverDatasets.SPANS,
             ''
           ),
         {

--- a/static/app/utils/timeSeries/useFetchEventsTimeSeries.spec.tsx
+++ b/static/app/utils/timeSeries/useFetchEventsTimeSeries.spec.tsx
@@ -21,11 +21,19 @@ describe('useFetchEventsTimeSeries', () => {
     );
   }
 
+  const hookOptions = {
+    wrapper: Wrapper,
+  };
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
   it('fetches from `/events-timeseries`', async () => {
     const request = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events-timeseries/`,
       method: 'GET',
-      body: {},
+      body: [],
     });
 
     const {result} = renderHook(
@@ -37,9 +45,7 @@ describe('useFetchEventsTimeSeries', () => {
           },
           REFERRER
         ),
-      {
-        wrapper: Wrapper,
-      }
+      hookOptions
     );
 
     await waitFor(() => expect(result.current.isPending).toBe(false));
@@ -49,52 +55,7 @@ describe('useFetchEventsTimeSeries', () => {
       '/organizations/org-slug/events-timeseries/',
       expect.objectContaining({
         method: 'GET',
-        query: {
-          excludeOther: 0,
-          partial: 1,
-          referrer: 'test-query',
-          dataset: 'spans',
-          yAxis: 'epm()',
-        },
-      })
-    );
-  });
-
-  it('fetches multiple Y axes', async () => {
-    const request = MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/events-timeseries/`,
-      method: 'GET',
-      body: {},
-    });
-
-    const {result} = renderHook(
-      () =>
-        useFetchEventsTimeSeries(
-          DiscoverDatasets.SPANS,
-          {
-            yAxis: ['count(span.duration)', 'p50(span.duration)'],
-          },
-          REFERRER
-        ),
-      {
-        wrapper: Wrapper,
-      }
-    );
-
-    await waitFor(() => expect(result.current.isPending).toBe(false));
-
-    expect(request).toHaveBeenCalledTimes(1);
-    expect(request).toHaveBeenCalledWith(
-      '/organizations/org-slug/events-timeseries/',
-      expect.objectContaining({
-        method: 'GET',
-        query: {
-          excludeOther: 0,
-          partial: 1,
-          referrer: 'test-query',
-          dataset: 'spans',
-          yAxis: 'epm()',
-        },
+        query: expect.anything(),
       })
     );
   });
@@ -103,7 +64,7 @@ describe('useFetchEventsTimeSeries', () => {
     const request = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events-timeseries/`,
       method: 'GET',
-      body: {},
+      body: [],
     });
 
     const {result} = renderHook(
@@ -116,9 +77,7 @@ describe('useFetchEventsTimeSeries', () => {
           },
           REFERRER
         ),
-      {
-        wrapper: Wrapper,
-      }
+      hookOptions
     );
 
     await waitFor(() => expect(result.current.isPending).toBe(true));
@@ -144,6 +103,43 @@ describe('useFetchEventsTimeSeries', () => {
         }
       );
     }).toThrow();
+  });
+
+  it('makes requests for multiple Y axes', async () => {
+    const request = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events-timeseries/`,
+      method: 'GET',
+      body: [],
+    });
+
+    const {result} = renderHook(
+      () =>
+        useFetchEventsTimeSeries(
+          DiscoverDatasets.SPANS,
+          {
+            yAxis: ['count(span.duration)', 'p50(span.duration)'],
+          },
+          REFERRER
+        ),
+      hookOptions
+    );
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(request).toHaveBeenCalledWith(
+      '/organizations/org-slug/events-timeseries/',
+      expect.objectContaining({
+        method: 'GET',
+        query: {
+          excludeOther: 0,
+          partial: 1,
+          referrer: 'test-query',
+          dataset: 'spans',
+          yAxis: ['count(span.duration)', 'p50(span.duration)'],
+        },
+      })
+    );
   });
 });
 

--- a/static/app/utils/timeSeries/useFetchEventsTimeSeries.spec.tsx
+++ b/static/app/utils/timeSeries/useFetchEventsTimeSeries.spec.tsx
@@ -38,6 +38,10 @@ describe('useFetchEventsTimeSeries', () => {
       '/organizations/org-slug/events-timeseries/',
       expect.objectContaining({
         method: 'GET',
+        query: {
+          excludeOther: 0,
+          partial: 1,
+        },
       })
     );
   });

--- a/static/app/utils/timeSeries/useFetchEventsTimeSeries.spec.tsx
+++ b/static/app/utils/timeSeries/useFetchEventsTimeSeries.spec.tsx
@@ -27,7 +27,7 @@ describe('useFetchEventsTimeSeries', () => {
       body: {},
     });
 
-    const {result} = renderHook(() => useFetchEventsTimeSeries(), {
+    const {result} = renderHook(() => useFetchEventsTimeSeries({}, REFERRER), {
       wrapper: Wrapper,
     });
 
@@ -41,6 +41,7 @@ describe('useFetchEventsTimeSeries', () => {
         query: {
           excludeOther: 0,
           partial: 1,
+          referrer: 'test-query',
         },
       })
     );
@@ -55,9 +56,12 @@ describe('useFetchEventsTimeSeries', () => {
 
     const {result} = renderHook(
       () =>
-        useFetchEventsTimeSeries({
-          enabled: false,
-        }),
+        useFetchEventsTimeSeries(
+          {
+            enabled: false,
+          },
+          REFERRER
+        ),
       {
         wrapper: Wrapper,
       }
@@ -68,4 +72,23 @@ describe('useFetchEventsTimeSeries', () => {
 
     expect(request).toHaveBeenCalledTimes(0);
   });
+
+  it('requires a referrer', () => {
+    expect(() => {
+      renderHook(
+        () =>
+          useFetchEventsTimeSeries(
+            {
+              enabled: false,
+            },
+            ''
+          ),
+        {
+          wrapper: Wrapper,
+        }
+      );
+    }).toThrow();
+  });
 });
+
+const REFERRER = 'test-query';

--- a/static/app/utils/timeSeries/useFetchEventsTimeSeries.spec.tsx
+++ b/static/app/utils/timeSeries/useFetchEventsTimeSeries.spec.tsx
@@ -5,6 +5,7 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {makeTestQueryClient} from 'sentry-test/queryClient';
 import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
 
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {OrganizationContext} from 'sentry/views/organizationContext';
 
 import {useFetchEventsTimeSeries} from './useFetchEventsTimeSeries';
@@ -27,9 +28,12 @@ describe('useFetchEventsTimeSeries', () => {
       body: {},
     });
 
-    const {result} = renderHook(() => useFetchEventsTimeSeries({}, REFERRER), {
-      wrapper: Wrapper,
-    });
+    const {result} = renderHook(
+      () => useFetchEventsTimeSeries({}, DiscoverDatasets.SPANS, REFERRER),
+      {
+        wrapper: Wrapper,
+      }
+    );
 
     await waitFor(() => expect(result.current.isPending).toBe(false));
 
@@ -42,6 +46,7 @@ describe('useFetchEventsTimeSeries', () => {
           excludeOther: 0,
           partial: 1,
           referrer: 'test-query',
+          dataset: 'spans',
         },
       })
     );
@@ -60,6 +65,7 @@ describe('useFetchEventsTimeSeries', () => {
           {
             enabled: false,
           },
+          DiscoverDatasets.SPANS,
           REFERRER
         ),
       {
@@ -81,6 +87,7 @@ describe('useFetchEventsTimeSeries', () => {
             {
               enabled: false,
             },
+            DiscoverDatasets.SPANS,
             ''
           ),
         {

--- a/static/app/utils/timeSeries/useFetchEventsTimeSeries.spec.tsx
+++ b/static/app/utils/timeSeries/useFetchEventsTimeSeries.spec.tsx
@@ -1,0 +1,44 @@
+import type {ReactNode} from 'react';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {makeTestQueryClient} from 'sentry-test/queryClient';
+import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {OrganizationContext} from 'sentry/views/organizationContext';
+
+import {useFetchEventsTimeSeries} from './useFetchEventsTimeSeries';
+
+describe('useFetchEventsTimeSeries', () => {
+  const organization = OrganizationFixture();
+
+  function Wrapper({children}: {children?: ReactNode}) {
+    return (
+      <QueryClientProvider client={makeTestQueryClient()}>
+        <OrganizationContext value={organization}>{children}</OrganizationContext>
+      </QueryClientProvider>
+    );
+  }
+
+  it('fetches from `/events-timeseries`', async () => {
+    const request = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events-timeseries/`,
+      method: 'GET',
+      body: {},
+    });
+
+    const {result} = renderHook(() => useFetchEventsTimeSeries(), {
+      wrapper: Wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(request).toHaveBeenCalledWith(
+      '/organizations/org-slug/events-timeseries/',
+      expect.objectContaining({
+        method: 'GET',
+      })
+    );
+  });
+});

--- a/static/app/utils/timeSeries/useFetchEventsTimeSeries.spec.tsx
+++ b/static/app/utils/timeSeries/useFetchEventsTimeSeries.spec.tsx
@@ -161,6 +161,7 @@ describe('useFetchEventsTimeSeries', () => {
           yAxis: 'p50(span.duration)',
           environment: ['prod'],
           project: [42],
+          interval: '1h',
         },
       })
     );

--- a/static/app/utils/timeSeries/useFetchEventsTimeSeries.spec.tsx
+++ b/static/app/utils/timeSeries/useFetchEventsTimeSeries.spec.tsx
@@ -140,7 +140,7 @@ describe('useFetchEventsTimeSeries', () => {
           DiscoverDatasets.SPANS,
           {
             yAxis: 'p50(span.duration)',
-            search: new MutableSearch('span.op:db*'),
+            query: new MutableSearch('span.op:db*'),
           },
           REFERRER
         ),
@@ -164,7 +164,7 @@ describe('useFetchEventsTimeSeries', () => {
           environment: ['prod'],
           project: [42],
           interval: '1h',
-          search: 'span.op:db*',
+          query: 'span.op:db*',
           sampling: 'NORMAL',
         },
       })

--- a/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
+++ b/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
@@ -1,3 +1,4 @@
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
@@ -10,8 +11,10 @@ interface UseFetchEventsTimeSeriesOptions {
   enabled?: boolean;
 }
 
+// TODO: This hook's interface is compatible with `useDiscoverSeries` for easier interoperability. Once we eliminate `useDiscoverSeries`, we can make changes here as appropriate
 export function useFetchEventsTimeSeries(
-  {enabled}: UseFetchEventsTimeSeriesOptions = {},
+  {enabled}: UseFetchEventsTimeSeriesOptions,
+  dataset: DiscoverDatasets,
   referrer: string
 ) {
   const organization = useOrganization();
@@ -29,6 +32,7 @@ export function useFetchEventsTimeSeries(
         query: {
           partial: 1,
           excludeOther: 0,
+          dataset,
           referrer,
         },
       },

--- a/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
+++ b/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
@@ -34,12 +34,10 @@ export function useFetchEventsTimeSeries(
       },
     ],
     {
-      staleTime: DEFAULT_STALE_TIME,
+      staleTime: Infinity,
       retry: shouldRetryHandler,
       retryDelay: getRetryDelay,
       enabled,
     }
   );
 }
-
-const DEFAULT_STALE_TIME = 60_000;

--- a/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
+++ b/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
@@ -1,6 +1,10 @@
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
+import {
+  getRetryDelay,
+  shouldRetryHandler,
+} from 'sentry/views/insights/common/utils/retryHandlers';
 
 interface UseFetchEventsTimeSeriesOptions {
   enabled?: boolean;
@@ -31,6 +35,8 @@ export function useFetchEventsTimeSeries(
     ],
     {
       staleTime: DEFAULT_STALE_TIME,
+      retry: shouldRetryHandler,
+      retryDelay: getRetryDelay,
       enabled,
     }
   );

--- a/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
+++ b/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
@@ -1,6 +1,8 @@
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
 import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
 import {
   getRetryDelay,
@@ -19,6 +21,8 @@ export function useFetchEventsTimeSeries<T extends string>(
 ) {
   const organization = useOrganization();
 
+  const {isReady: arePageFiltersReady, selection} = usePageFilters();
+
   if (!referrer) {
     throw new Error(
       '`useFetchEventsTimeSeries` cannot accept an empty referrer string, please specify a referrer!'
@@ -35,6 +39,9 @@ export function useFetchEventsTimeSeries<T extends string>(
           dataset,
           referrer,
           yAxis,
+          ...normalizeDateTimeParams(selection.datetime),
+          project: selection.projects,
+          environment: selection.environments,
         },
       },
     ],
@@ -43,7 +50,7 @@ export function useFetchEventsTimeSeries<T extends string>(
       retry: shouldRetryHandler,
       retryDelay: getRetryDelay,
       refetchOnWindowFocus: false,
-      enabled,
+      enabled: enabled && arePageFiltersReady,
     }
   );
 }

--- a/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
+++ b/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
@@ -6,10 +6,17 @@ interface UseFetchEventsTimeSeriesOptions {
   enabled?: boolean;
 }
 
-export function useFetchEventsTimeSeries({
-  enabled,
-}: UseFetchEventsTimeSeriesOptions = {}) {
+export function useFetchEventsTimeSeries(
+  {enabled}: UseFetchEventsTimeSeriesOptions = {},
+  referrer: string
+) {
   const organization = useOrganization();
+
+  if (!referrer) {
+    throw new Error(
+      '`useFetchEventsTimeSeries` cannot accept an empty referrer string, please specify a referrer!'
+    );
+  }
 
   return useApiQuery<TimeSeries[]>(
     [
@@ -18,6 +25,7 @@ export function useFetchEventsTimeSeries({
         query: {
           partial: 1,
           excludeOther: 0,
+          referrer,
         },
       },
     ],

--- a/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
+++ b/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
@@ -12,10 +12,9 @@ interface UseFetchEventsTimeSeriesOptions<Field> {
   enabled?: boolean;
 }
 
-// TODO: This hook's interface is mostly compatible with `useDiscoverSeries` for easier interoperability. Once we eliminate `useDiscoverSeries`, we can make changes here as appropriate
 export function useFetchEventsTimeSeries<T extends string>(
-  {yAxis, enabled}: UseFetchEventsTimeSeriesOptions<T>,
   dataset: DiscoverDatasets,
+  {yAxis, enabled}: UseFetchEventsTimeSeriesOptions<T>,
   referrer: string
 ) {
   const organization = useOrganization();

--- a/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
+++ b/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
@@ -90,5 +90,5 @@ type EventsTimeSeriesResponse = {
     end: number;
     start: number;
   };
-  timeseries: TimeSeries[];
+  timeSeries: TimeSeries[];
 };

--- a/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
+++ b/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
@@ -7,13 +7,14 @@ import {
   shouldRetryHandler,
 } from 'sentry/views/insights/common/utils/retryHandlers';
 
-interface UseFetchEventsTimeSeriesOptions {
+interface UseFetchEventsTimeSeriesOptions<Field> {
+  yAxis: Field | Field[];
   enabled?: boolean;
 }
 
-// TODO: This hook's interface is compatible with `useDiscoverSeries` for easier interoperability. Once we eliminate `useDiscoverSeries`, we can make changes here as appropriate
-export function useFetchEventsTimeSeries(
-  {enabled}: UseFetchEventsTimeSeriesOptions,
+// TODO: This hook's interface is mostly compatible with `useDiscoverSeries` for easier interoperability. Once we eliminate `useDiscoverSeries`, we can make changes here as appropriate
+export function useFetchEventsTimeSeries<T extends string>(
+  {yAxis, enabled}: UseFetchEventsTimeSeriesOptions<T>,
   dataset: DiscoverDatasets,
   referrer: string
 ) {
@@ -34,6 +35,7 @@ export function useFetchEventsTimeSeries(
           excludeOther: 0,
           dataset,
           referrer,
+          yAxis,
         },
       },
     ],

--- a/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
+++ b/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
@@ -2,7 +2,13 @@ import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
 
-export function useFetchEventsTimeSeries() {
+interface UseFetchEventsTimeSeriesOptions {
+  enabled?: boolean;
+}
+
+export function useFetchEventsTimeSeries({
+  enabled,
+}: UseFetchEventsTimeSeriesOptions = {}) {
   const organization = useOrganization();
 
   return useApiQuery<TimeSeries[]>(
@@ -17,6 +23,7 @@ export function useFetchEventsTimeSeries() {
     ],
     {
       staleTime: DEFAULT_STALE_TIME,
+      enabled,
     }
   );
 }

--- a/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
+++ b/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
@@ -1,0 +1,16 @@
+import {useApiQuery} from 'sentry/utils/queryClient';
+import useOrganization from 'sentry/utils/useOrganization';
+import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
+
+export function useFetchEventsTimeSeries() {
+  const organization = useOrganization();
+
+  return useApiQuery<TimeSeries[]>(
+    [`/organizations/${organization.slug}/events-timeseries/`],
+    {
+      staleTime: DEFAULT_STALE_TIME,
+    }
+  );
+}
+
+const DEFAULT_STALE_TIME = 60_000;

--- a/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
+++ b/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
@@ -13,6 +13,7 @@ import {
   getRetryDelay,
   shouldRetryHandler,
 } from 'sentry/views/insights/common/utils/retryHandlers';
+import type {SpanProperty} from 'sentry/views/insights/types';
 
 import {getIntervalForTimeSeriesQuery} from './getIntervalForTimeSeriesQuery';
 
@@ -24,6 +25,13 @@ interface UseFetchEventsTimeSeriesOptions<Field> {
   search?: MutableSearch;
   sort?: Sort;
   topEvents?: number;
+}
+
+export function useSpanSeries<Field extends SpanProperty>(
+  options: UseFetchEventsTimeSeriesOptions<Field>,
+  referrer: string
+) {
+  return useFetchEventsTimeSeries(DiscoverDatasets.SPANS, options, referrer);
 }
 
 export function useFetchEventsTimeSeries<T extends string>(

--- a/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
+++ b/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
@@ -1,6 +1,7 @@
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {useApiQuery} from 'sentry/utils/queryClient';
+import type {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
@@ -14,11 +15,12 @@ import {getIntervalForTimeSeriesQuery} from './getIntervalForTimeSeriesQuery';
 interface UseFetchEventsTimeSeriesOptions<Field> {
   yAxis: Field | Field[];
   enabled?: boolean;
+  search?: MutableSearch;
 }
 
 export function useFetchEventsTimeSeries<T extends string>(
   dataset: DiscoverDatasets,
-  {yAxis, enabled}: UseFetchEventsTimeSeriesOptions<T>,
+  {yAxis, search, enabled}: UseFetchEventsTimeSeriesOptions<T>,
   referrer: string
 ) {
   const organization = useOrganization();
@@ -45,6 +47,7 @@ export function useFetchEventsTimeSeries<T extends string>(
           project: selection.projects,
           environment: selection.environments,
           interval: getIntervalForTimeSeriesQuery(yAxis, selection.datetime),
+          search: search ? search.formatString() : undefined,
         },
       },
     ],

--- a/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
+++ b/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
@@ -21,8 +21,8 @@ interface UseFetchEventsTimeSeriesOptions<Field> {
   yAxis: Field | Field[];
   enabled?: boolean;
   groupBy?: Field[];
+  query?: MutableSearch;
   sampling?: SamplingMode;
-  search?: MutableSearch;
   sort?: Sort;
   topEvents?: number;
 }
@@ -41,7 +41,7 @@ export function useFetchEventsTimeSeries<T extends string>(
   dataset: DiscoverDatasets,
   {
     yAxis,
-    search,
+    query,
     sampling,
     topEvents,
     groupBy,
@@ -74,7 +74,7 @@ export function useFetchEventsTimeSeries<T extends string>(
           project: selection.projects,
           environment: selection.environments,
           interval: getIntervalForTimeSeriesQuery(yAxis, selection.datetime),
-          search: search ? search.formatString() : undefined,
+          query: query ? query.formatString() : undefined,
           sampling: sampling ?? DEFAULT_SAMPLING_MODE,
           topEvents,
           groupBy,

--- a/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
+++ b/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
@@ -49,7 +49,7 @@ export function useFetchEventsTimeSeries<T extends string>(
     );
   }
 
-  return useApiQuery<TimeSeries[]>(
+  return useApiQuery<EventsTimeSeriesResponse>(
     [
       `/organizations/${organization.slug}/events-timeseries/`,
       {
@@ -80,3 +80,12 @@ export function useFetchEventsTimeSeries<T extends string>(
     }
   );
 }
+
+type EventsTimeSeriesResponse = {
+  meta: {
+    dataset: DiscoverDatasets;
+    end: number;
+    start: number;
+  };
+  timeseries: TimeSeries[];
+};

--- a/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
+++ b/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
@@ -13,7 +13,6 @@ import {
   getRetryDelay,
   shouldRetryHandler,
 } from 'sentry/views/insights/common/utils/retryHandlers';
-import type {SpanProperty} from 'sentry/views/insights/types';
 
 import {getIntervalForTimeSeriesQuery} from './getIntervalForTimeSeriesQuery';
 
@@ -25,13 +24,6 @@ interface UseFetchEventsTimeSeriesOptions<Field> {
   sampling?: SamplingMode;
   sort?: Sort;
   topEvents?: number;
-}
-
-export function useSpanSeries<Field extends SpanProperty>(
-  options: UseFetchEventsTimeSeriesOptions<Field>,
-  referrer: string
-) {
-  return useFetchEventsTimeSeries(DiscoverDatasets.SPANS, options, referrer);
 }
 
 /**

--- a/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
+++ b/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
@@ -34,6 +34,9 @@ export function useSpanSeries<Field extends SpanProperty>(
   return useFetchEventsTimeSeries(DiscoverDatasets.SPANS, options, referrer);
 }
 
+/**
+ * Fetch time series data from the `/events-timeseries/` endpoint. Returns an array of `TimeSeries` objects.
+ */
 export function useFetchEventsTimeSeries<T extends string>(
   dataset: DiscoverDatasets,
   {

--- a/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
+++ b/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
@@ -37,6 +37,7 @@ export function useFetchEventsTimeSeries(
       staleTime: Infinity,
       retry: shouldRetryHandler,
       retryDelay: getRetryDelay,
+      refetchOnWindowFocus: false,
       enabled,
     }
   );

--- a/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
+++ b/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
@@ -1,4 +1,6 @@
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
+import {encodeSort} from 'sentry/utils/discover/eventView';
+import type {Sort} from 'sentry/utils/discover/fields';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import type {MutableSearch} from 'sentry/utils/tokenizeSearch';
@@ -17,13 +19,24 @@ import {getIntervalForTimeSeriesQuery} from './getIntervalForTimeSeriesQuery';
 interface UseFetchEventsTimeSeriesOptions<Field> {
   yAxis: Field | Field[];
   enabled?: boolean;
+  groupBy?: Field[];
   sampling?: SamplingMode;
   search?: MutableSearch;
+  sort?: Sort;
+  topEvents?: number;
 }
 
 export function useFetchEventsTimeSeries<T extends string>(
   dataset: DiscoverDatasets,
-  {yAxis, search, sampling, enabled}: UseFetchEventsTimeSeriesOptions<T>,
+  {
+    yAxis,
+    search,
+    sampling,
+    topEvents,
+    groupBy,
+    sort,
+    enabled,
+  }: UseFetchEventsTimeSeriesOptions<T>,
   referrer: string
 ) {
   const organization = useOrganization();
@@ -52,6 +65,9 @@ export function useFetchEventsTimeSeries<T extends string>(
           interval: getIntervalForTimeSeriesQuery(yAxis, selection.datetime),
           search: search ? search.formatString() : undefined,
           sampling: sampling ?? DEFAULT_SAMPLING_MODE,
+          topEvents,
+          groupBy,
+          sort: sort ? encodeSort(sort) : undefined,
         },
       },
     ],

--- a/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
+++ b/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
@@ -6,7 +6,15 @@ export function useFetchEventsTimeSeries() {
   const organization = useOrganization();
 
   return useApiQuery<TimeSeries[]>(
-    [`/organizations/${organization.slug}/events-timeseries/`],
+    [
+      `/organizations/${organization.slug}/events-timeseries/`,
+      {
+        query: {
+          partial: 1,
+          excludeOther: 0,
+        },
+      },
+    ],
     {
       staleTime: DEFAULT_STALE_TIME,
     }

--- a/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
+++ b/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
@@ -9,6 +9,8 @@ import {
   shouldRetryHandler,
 } from 'sentry/views/insights/common/utils/retryHandlers';
 
+import {getIntervalForTimeSeriesQuery} from './getIntervalForTimeSeriesQuery';
+
 interface UseFetchEventsTimeSeriesOptions<Field> {
   yAxis: Field | Field[];
   enabled?: boolean;
@@ -42,6 +44,7 @@ export function useFetchEventsTimeSeries<T extends string>(
           ...normalizeDateTimeParams(selection.datetime),
           project: selection.projects,
           environment: selection.environments,
+          interval: getIntervalForTimeSeriesQuery(yAxis, selection.datetime),
         },
       },
     ],

--- a/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
+++ b/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
@@ -5,6 +5,8 @@ import type {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
+import type {SamplingMode} from 'sentry/views/explore/hooks/useProgressiveQuery';
+import {DEFAULT_SAMPLING_MODE} from 'sentry/views/insights/common/queries/useDiscover';
 import {
   getRetryDelay,
   shouldRetryHandler,
@@ -15,12 +17,13 @@ import {getIntervalForTimeSeriesQuery} from './getIntervalForTimeSeriesQuery';
 interface UseFetchEventsTimeSeriesOptions<Field> {
   yAxis: Field | Field[];
   enabled?: boolean;
+  sampling?: SamplingMode;
   search?: MutableSearch;
 }
 
 export function useFetchEventsTimeSeries<T extends string>(
   dataset: DiscoverDatasets,
-  {yAxis, search, enabled}: UseFetchEventsTimeSeriesOptions<T>,
+  {yAxis, search, sampling, enabled}: UseFetchEventsTimeSeriesOptions<T>,
   referrer: string
 ) {
   const organization = useOrganization();
@@ -48,6 +51,7 @@ export function useFetchEventsTimeSeries<T extends string>(
           environment: selection.environments,
           interval: getIntervalForTimeSeriesQuery(yAxis, selection.datetime),
           search: search ? search.formatString() : undefined,
+          sampling: sampling ?? DEFAULT_SAMPLING_MODE,
         },
       },
     ],

--- a/static/app/views/dashboards/widgets/common/types.tsx
+++ b/static/app/views/dashboards/widgets/common/types.tsx
@@ -58,6 +58,9 @@ type TimeSeriesGroupBy = {
   value: string | Array<string | null> | Array<number | null>;
 };
 
+/**
+ * Time series data. Unlike other time series abstractions, this is tightly supported by both the backend and the frontend. The `/events-timeseries/` endpoint uses this as the respone data, and `TimeSeriesWidgetVisualization` plottable objects accept this as the backing data.
+ */
 export type TimeSeries = {
   meta: TimeSeriesMeta;
   values: TimeSeriesItem[];

--- a/static/app/views/insights/common/queries/getSeriesEventView.tsx
+++ b/static/app/views/insights/common/queries/getSeriesEventView.tsx
@@ -1,13 +1,8 @@
-import sortBy from 'lodash/sortBy';
-
 import type {PageFilters} from 'sentry/types/core';
 import EventView from 'sentry/utils/discover/eventView';
-import {parseFunction} from 'sentry/utils/discover/fields';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
-import {intervalToMilliseconds} from 'sentry/utils/duration/intervalToMilliseconds';
+import {getIntervalForTimeSeriesQuery} from 'sentry/utils/timeSeries/getIntervalForTimeSeriesQuery';
 import type {MutableSearch} from 'sentry/utils/tokenizeSearch';
-import {getIntervalForMetricFunction} from 'sentry/views/insights/database/utils/getIntervalForMetricFunction';
-import {DEFAULT_INTERVAL} from 'sentry/views/insights/settings';
 
 export function getSeriesEventView(
   search: MutableSearch | string | undefined,
@@ -18,21 +13,7 @@ export function getSeriesEventView(
   dataset?: DiscoverDatasets,
   orderby?: string | string[]
 ) {
-  // Pick the highest possible interval for the given yAxis selection. Find the ideal interval for each function, then choose the largest one. This results in the lowest granularity, but best performance.
-  const interval = sortBy(
-    yAxis.map(yAxisFunctionName => {
-      const parseResult = parseFunction(yAxisFunctionName);
-
-      if (!parseResult) {
-        return DEFAULT_INTERVAL;
-      }
-
-      return getIntervalForMetricFunction(parseResult.name, pageFilters.datetime);
-    }),
-    result => {
-      return intervalToMilliseconds(result);
-    }
-  ).at(-1);
+  const interval = getIntervalForTimeSeriesQuery(yAxis, pageFilters.datetime);
 
   return EventView.fromNewQueryWithPageFilters(
     {

--- a/static/app/views/insights/common/queries/useDiscoverSeries.ts
+++ b/static/app/views/insights/common/queries/useDiscoverSeries.ts
@@ -50,6 +50,9 @@ export const useSpanSeries = <Fields extends SpanProperty[]>(
   );
 };
 
+/**
+ * Fetch time series data from the `/events-stats/` endpoint. Consider using `useFetchEventsTimeSeries` instead, if you are able to. `useFetchEventsTimeSeries` uses the more modern `/events-timeseries/` API, which has a friendlier response format.
+ */
 const useDiscoverSeries = <T extends string[]>(
   options: UseMetricsSeriesOptions<T> = {},
   dataset: DiscoverDatasets,


### PR DESCRIPTION
A new data fetching hook, slate to replace `useDiscoverSeries` and its siblings. This has a very similar API to `useDiscoverSeries` and returns very similar data, but with some major differences:

1. Uses the `/events-timeseries/` endpoint. This returns `TimeSeries` objects directly, which can be passed to `TimeSeriesWidgetVisualization` plottables as-is, without transformation
2. Bypasses `EventView` creation, which is a little simpler
3. Bypasses `doDiscoverQuery`, and uses `useApiQuery` directly, which is a little simpler

The plan is to add this hook, and gradually replace the use of `useDiscoverSeries` et al as we go, while verifying that the data is correct.
