### PR TITLE
feat(metric-alerts): Add count_hits to metric alert rule endpoint

### DIFF
--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -170,6 +170,7 @@ class AlertRuleIndexMixin(Endpoint):
                 paginator_cls=OffsetPaginator,
                 on_results=lambda x: serialize(x, request.user, WorkflowEngineDetectorSerializer()),
                 default_per_page=25,
+                count_hits=True,
             )
         else:
             response = self.paginate(
@@ -179,6 +180,7 @@ class AlertRuleIndexMixin(Endpoint):
                 paginator_cls=OffsetPaginator,
                 on_results=lambda x: serialize(x, request.user),
                 default_per_page=25,
+                count_hits=True,
             )
         response[ALERT_RULES_COUNT_HEADER] = len(alert_rules)
         response[MAX_QUERY_SUBSCRIPTIONS_HEADER] = settings.MAX_QUERY_SUBSCRIPTIONS_PER_ORG


### PR DESCRIPTION
We need to count the number of metric alerts to determine whether or not to let users create more