### PR TITLE
ref(insights): replace `insight-entry-points` with `insight-modules`

### DIFF
--- a/static/app/components/sidebar/index.spec.tsx
+++ b/static/app/components/sidebar/index.spec.tsx
@@ -33,7 +33,7 @@ jest.mock('sentry/utils/useLocation');
 const mockUseLocation = jest.mocked(useLocation);
 
 const ALL_AVAILABLE_FEATURES = [
-  'insights-entry-points',
+  'insight-modules',
   'discover',
   'discover-basic',
   'discover-query',

--- a/static/app/views/insights/common/components/moduleUpsellHookWrapper.spec.tsx
+++ b/static/app/views/insights/common/components/moduleUpsellHookWrapper.spec.tsx
@@ -19,7 +19,7 @@ describe('ModulePageProviders', () => {
       </ModuleBodyUpsellHook>,
       {
         organization: OrganizationFixture({
-          features: ['insights-entry-points'],
+          features: [''],
         }),
       }
     );

--- a/static/app/views/insights/http/views/httpLandingPage.spec.tsx
+++ b/static/app/views/insights/http/views/httpLandingPage.spec.tsx
@@ -18,7 +18,7 @@ jest.mock('sentry/utils/useReleaseStats');
 
 describe('HTTPLandingPage', () => {
   const organization = OrganizationFixture({
-    features: ['insight-modules', 'insights-entry-points'],
+    features: ['insight-modules'],
   });
 
   let throughputRequestMock!: jest.Mock;

--- a/static/app/views/insights/mobile/screens/views/screensLandingPage.spec.tsx
+++ b/static/app/views/insights/mobile/screens/views/screensLandingPage.spec.tsx
@@ -216,7 +216,7 @@ describe('Screens Landing Page', () => {
     });
 
     it('shows content if permission is there', async () => {
-      organization.features = [MODULE_FEATURE, 'insights-entry-points'];
+      organization.features = [MODULE_FEATURE];
       render(<ScreensLandingPage />, {organization, deprecatedRouterMocks: true});
       expect(await screen.findAllByText('Mobile Vitals')).toHaveLength(2);
     });

--- a/static/app/views/insights/pages/domainViewHeader.spec.tsx
+++ b/static/app/views/insights/pages/domainViewHeader.spec.tsx
@@ -13,7 +13,7 @@ const useLocationMock = jest.mocked(useLocation);
 
 describe('DomainViewHeader', () => {
   const organization = OrganizationFixture({
-    features: ['insights-entry-points'],
+    features: ['insight-modules'],
   });
 
   beforeEach(() => {

--- a/static/app/views/insights/settings.ts
+++ b/static/app/views/insights/settings.ts
@@ -215,21 +215,21 @@ export const MODULE_FEATURE_MAP: Record<ModuleName, string[]> = {
  * Features that control the visibility of modules.
  */
 export const MODULE_FEATURE_VISIBLE_MAP: Record<ModuleName, string[]> = {
-  [ModuleName.DB]: ['insights-entry-points'],
-  [ModuleName.APP_START]: ['insights-entry-points'],
-  [ModuleName.HTTP]: ['insights-entry-points'],
-  [ModuleName.RESOURCE]: ['insights-entry-points'],
-  [ModuleName.VITAL]: ['insights-entry-points'],
-  [ModuleName.CACHE]: ['insights-entry-points'],
-  [ModuleName.QUEUE]: ['insights-entry-points'],
-  [ModuleName.AGENTS]: ['insights-entry-points'],
-  [ModuleName.SCREEN_LOAD]: ['insights-entry-points'],
-  [ModuleName.MCP]: ['insights-entry-points', 'mcp-insights'],
-  [ModuleName.MOBILE_UI]: ['insights-entry-points'],
-  [ModuleName.MOBILE_VITALS]: ['insights-entry-points'],
-  [ModuleName.SCREEN_RENDERING]: ['insights-entry-points'],
-  [ModuleName.SESSIONS]: ['insights-entry-points', ...SESSIONS_MODULE_VISIBLE_FEATURES],
-  [ModuleName.OTHER]: ['insights-entry-points'],
+  [ModuleName.DB]: ['insight-modules'],
+  [ModuleName.APP_START]: ['insight-modules'],
+  [ModuleName.HTTP]: ['insight-modules'],
+  [ModuleName.RESOURCE]: ['insight-modules'],
+  [ModuleName.VITAL]: ['insight-modules'],
+  [ModuleName.CACHE]: ['insight-modules'],
+  [ModuleName.QUEUE]: ['insight-modules'],
+  [ModuleName.AGENTS]: ['insight-modules'],
+  [ModuleName.SCREEN_LOAD]: ['insight-modules'],
+  [ModuleName.MCP]: ['insight-modules', 'mcp-insights'],
+  [ModuleName.MOBILE_UI]: ['insight-modules'],
+  [ModuleName.MOBILE_VITALS]: ['insight-modules'],
+  [ModuleName.SCREEN_RENDERING]: ['insight-modules'],
+  [ModuleName.SESSIONS]: ['insight-modules', ...SESSIONS_MODULE_VISIBLE_FEATURES],
+  [ModuleName.OTHER]: ['insight-modules'],
 };
 
 /**

--- a/static/app/views/nav/index.spec.tsx
+++ b/static/app/views/nav/index.spec.tsx
@@ -24,7 +24,7 @@ jest.mock('sentry/utils/analytics', () => ({
 }));
 
 const ALL_AVAILABLE_FEATURES = [
-  'insights-entry-points',
+  'insight-modules',
   'discover',
   'discover-basic',
   'discover-query',


### PR DESCRIPTION
Insights is now released to everyone! this means we no longer need separate flags to handle insight visibility and insight access.