### PR TITLE
feat(logs): Use query params to write cursors

### DIFF
--- a/static/app/views/explore/contexts/logs/logsPageParams.tsx
+++ b/static/app/views/explore/contexts/logs/logsPageParams.tsx
@@ -113,7 +113,12 @@ interface LogsPageParams {
 type NullablePartial<T> = {
   [P in keyof T]?: T[P] | null;
 };
-type NonUpdatableParams = 'aggregateFn' | 'aggregateParam' | 'groupBy';
+type NonUpdatableParams =
+  | 'aggregateCursor'
+  | 'aggregateFn'
+  | 'aggregateParam'
+  | 'cursor'
+  | 'groupBy';
 type LogPageParamsUpdate = NullablePartial<Omit<LogsPageParams, NonUpdatableParams>>;
 
 const [_LogsPageParamsProvider, _useLogsPageParams, LogsPageParamsContext] =
@@ -251,8 +256,6 @@ const decodeLogsQuery = (location: Location): string => {
 export function setLogsPageParams(location: Location, pageParams: LogPageParamsUpdate) {
   const target: Location = {...location, query: {...location.query}};
   updateNullableLocation(target, LOGS_QUERY_KEY, pageParams.search?.formatString());
-  updateNullableLocation(target, LOGS_CURSOR_KEY, pageParams.cursor);
-  updateNullableLocation(target, LOGS_AGGREGATE_CURSOR_KEY, pageParams.aggregateCursor);
   updateNullableLocation(target, LOGS_FIELDS_KEY, pageParams.fields);
   updateLocationWithMode(target, pageParams.mode); // Can be swapped with updateNullableLocation if we merge page params.
   if (!pageParams.isTableFrozen) {
@@ -349,11 +352,6 @@ export function useSetLogsSearch() {
   return setPageParamsCallback;
 }
 
-export function useLogsCursor() {
-  const {cursor} = useLogsPageParams();
-  return cursor;
-}
-
 export function useLogsLimitToTraceId() {
   const {limitToTraceId} = useLogsPageParams();
   return limitToTraceId;
@@ -378,11 +376,6 @@ export function usePersistedLogsPageParams() {
     fields: defaultLogFields() as string[],
     sortBys: [logsTimestampDescendingSortBy],
   });
-}
-
-export function useLogsAggregateCursor() {
-  const {aggregateCursor} = useLogsPageParams();
-  return aggregateCursor;
 }
 
 export function useLogsSortBys() {

--- a/static/app/views/explore/logs/logsQueryParams.tsx
+++ b/static/app/views/explore/logs/logsQueryParams.tsx
@@ -81,8 +81,13 @@ export function getTargetWithReadableQueryParams(
 ): Location {
   const target: Location = {...location, query: {...location.query}};
 
+  updateNullableLocation(target, LOGS_CURSOR_KEY, writableQueryParams.cursor);
   updateNullableLocation(target, LOGS_MODE_KEY, writableQueryParams.mode);
-
+  updateNullableLocation(
+    target,
+    LOGS_AGGREGATE_CURSOR_KEY,
+    writableQueryParams.aggregateCursor
+  );
   updateNullableLocation(
     target,
     LOGS_AGGREGATE_FIELD_KEY,

--- a/static/app/views/explore/logs/tables/logsAggregateTable.tsx
+++ b/static/app/views/explore/logs/tables/logsAggregateTable.tsx
@@ -20,7 +20,6 @@ import {
   useLogsFields,
   useLogsSearch,
   useLogsSortBys,
-  useSetLogsPageParams,
 } from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {LOGS_AGGREGATE_SORT_BYS_KEY} from 'sentry/views/explore/contexts/logs/sortBys';
 import type {RendererExtra} from 'sentry/views/explore/logs/fieldRenderers';
@@ -33,6 +32,7 @@ import {
   useQueryParamsGroupBys,
   useQueryParamsTopEventsLimit,
   useQueryParamsVisualizes,
+  useSetQueryParamsAggregateCursor,
 } from 'sentry/views/explore/queryParams/context';
 
 export function LogsAggregateTable() {
@@ -40,9 +40,9 @@ export function LogsAggregateTable() {
     limit: 50,
   });
 
-  const setLogsPageParams = useSetLogsPageParams();
   const groupBys = useQueryParamsGroupBys();
   const visualizes = useQueryParamsVisualizes();
+  const setAggregateCursor = useSetQueryParamsAggregateCursor();
   const aggregateSortBys = useQueryParamsAggregateSortBys();
   const topEventsLimit = useQueryParamsTopEventsLimit();
   const search = useLogsSearch();
@@ -177,10 +177,7 @@ export function LogsAggregateTable() {
           },
         }}
       />
-      <Pagination
-        pageLinks={pageLinks}
-        onCursor={cursor => setLogsPageParams({aggregateCursor: cursor})}
-      />
+      <Pagination pageLinks={pageLinks} onCursor={cursor => setAggregateCursor(cursor)} />
     </TableContainer>
   );
 }

--- a/static/app/views/explore/logs/useLogsQuery.tsx
+++ b/static/app/views/explore/logs/useLogsQuery.tsx
@@ -20,9 +20,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {useLogsAutoRefreshEnabled} from 'sentry/views/explore/contexts/logs/logsAutoRefreshContext';
 import {
-  useLogsAggregateCursor,
   useLogsBaseSearch,
-  useLogsCursor,
   useLogsFields,
   useLogsLimitToTraceId,
   useLogsProjectIds,
@@ -47,7 +45,9 @@ import {
 } from 'sentry/views/explore/logs/useVirtualStreaming';
 import {getTimeBasedSortBy} from 'sentry/views/explore/logs/utils';
 import {
+  useQueryParamsAggregateCursor,
   useQueryParamsAggregateSortBys,
+  useQueryParamsCursor,
   useQueryParamsGroupBys,
   useQueryParamsVisualizes,
 } from 'sentry/views/explore/queryParams/context';
@@ -88,7 +88,7 @@ function useLogsAggregatesQueryKey({
   const groupBys = useQueryParamsGroupBys();
   const visualizes = useQueryParamsVisualizes();
   const aggregateSortBys = useQueryParamsAggregateSortBys();
-  const aggregateCursor = useLogsAggregateCursor();
+  const aggregateCursor = useQueryParamsAggregateCursor();
   const fields: string[] = [];
   fields.push(...groupBys.filter(Boolean));
   fields.push(...visualizes.map(visualize => visualize.yAxis));
@@ -162,7 +162,7 @@ function useLogsQueryKey({limit, referrer}: {referrer: string; limit?: number}) 
   const organization = useOrganization();
   const _search = useLogsSearch();
   const baseSearch = useLogsBaseSearch();
-  const cursor = useLogsCursor();
+  const cursor = useQueryParamsCursor();
   const _fields = useLogsFields();
   const sortBys = useLogsSortBys();
   const limitToTraceId = useLogsLimitToTraceId();

--- a/static/app/views/explore/queryParams/context.tsx
+++ b/static/app/views/explore/queryParams/context.tsx
@@ -184,3 +184,19 @@ export function useQueryParamsAggregateCursor(): string {
   const queryParams = useQueryParams();
   return queryParams.aggregateCursor;
 }
+
+export function useSetQueryParamsAggregateCursor() {
+  const setQueryParams = useSetQueryParams();
+
+  return useCallback(
+    (aggregateCursor: string | undefined) => {
+      setQueryParams({aggregateCursor});
+    },
+    [setQueryParams]
+  );
+}
+
+export function useQueryParamsCursor(): string {
+  const queryParams = useQueryParams();
+  return queryParams.cursor;
+}


### PR DESCRIPTION
This moves cursors in log pages to use query params.