### PR TITLE
feat(uptime): Improve uptime check trace view

### DIFF
--- a/static/app/views/alerts/rules/uptime/uptimeChecksGrid.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeChecksGrid.tsx
@@ -189,7 +189,15 @@ function CheckInBodyCell({
       return (
         <TraceCell>
           {alwaysShowTraceLink || spanCount ? (
-            <Link to={`/performance/trace/${traceId}/?includeUptime=1`}>
+            <Link
+              to={{
+                pathname: `/performance/trace/${traceId}/`,
+                query: {
+                  includeUptime: '1',
+                  timestamp: new Date(timestamp).getTime() / 1000,
+                },
+              }}
+            >
               {getShortEventId(traceId)}
             </Link>
           ) : (

--- a/static/app/views/performance/newTraceDetails/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.tsx
@@ -73,6 +73,8 @@ import {
   isTraceErrorNode,
   isTraceNode,
   isTransactionNode,
+  isUptimeCheckNode,
+  isUptimeCheckTimingNode,
 } from './traceGuards';
 import type {TraceReducerState} from './traceState';
 
@@ -657,7 +659,12 @@ function RenderTraceRow(props: {
     return <TraceTransactionRow {...rowProps} node={node} />;
   }
 
-  if (isSpanNode(node) || isEAPSpanNode(node)) {
+  if (
+    isSpanNode(node) ||
+    isEAPSpanNode(node) ||
+    isUptimeCheckNode(node) ||
+    isUptimeCheckTimingNode(node)
+  ) {
     return <TraceSpanRow {...rowProps} node={node} />;
   }
 

--- a/static/app/views/performance/newTraceDetails/traceApi/types.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/types.tsx
@@ -105,4 +105,5 @@ export type EAPTraceMeta = {
   span_count: number;
   span_count_map: Record<string, number>;
   transaction_child_count_map: Record<string, number>;
+  uptime_checks: number;
 };

--- a/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.spec.tsx
@@ -143,6 +143,7 @@ describe('useTraceMeta', () => {
         span_count_map: {
           op1: 1,
         },
+        uptime_checks: 0,
         transaction_child_count_map: [{'transaction.id': '1', count: 1}],
       },
     });
@@ -158,6 +159,7 @@ describe('useTraceMeta', () => {
           op1: 1,
           op2: 1,
         },
+        uptime_checks: 0,
         transaction_child_count_map: [{'transaction.id': '2', count: 2}],
       },
     });
@@ -172,6 +174,7 @@ describe('useTraceMeta', () => {
         span_count_map: {
           op3: 1,
         },
+        uptime_checks: 1,
         transaction_child_count_map: [{'transaction.id': '3', count: 1}],
       },
     });
@@ -208,6 +211,7 @@ describe('useTraceMeta', () => {
           '2': 2,
           '3': 1,
         },
+        uptime_checks: 0,
       },
       errors: [],
       status: 'success',

--- a/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.tsx
@@ -24,6 +24,7 @@ type TraceMetaQueryParams =
       statsPeriod: string;
     }
   | {
+      include_uptime: string;
       timestamp: number;
     };
 
@@ -35,7 +36,10 @@ function getMetaQueryParams(
   const statsPeriod = decodeScalar(normalizedParams.statsPeriod);
 
   if (row.timestamp) {
-    return {timestamp: row.timestamp};
+    return {
+      include_uptime: normalizedParams.includeUptime,
+      timestamp: row.timestamp,
+    };
   }
 
   return {
@@ -80,6 +84,7 @@ async function fetchTraceMetaInBatches(
           span_count: 0,
           span_count_map: {},
           transaction_child_count_map: {},
+          uptime_checks: 0,
         }
       : {
           errors: 0,
@@ -155,11 +160,9 @@ export function useTraceMeta(replayTraces: ReplayTrace[]): TraceMetaQueryResults
 
   const normalizedParams = useMemo(() => {
     const query = qs.parse(location.search);
-    const params = normalizeDateTimeParams(query, {
+    return normalizeDateTimeParams(query, {
       allowAbsolutePageDatetime: true,
     });
-
-    return {...params, include_uptime: query.includeUptime} as Record<string, any>;
   }, []);
 
   // demo has the format ${projectSlug}:${eventId}
@@ -213,6 +216,7 @@ export function useTraceMeta(replayTraces: ReplayTrace[]): TraceMetaQueryResults
             span_count: 0,
             span_count_map: {},
             transaction_child_count_map: {},
+            uptime_checks: 0,
           }
         : {
             errors: 0,

--- a/static/app/views/performance/newTraceDetails/traceApi/useTraceRootEvent.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTraceRootEvent.tsx
@@ -80,11 +80,17 @@ export function useTraceRootEvent({
       : rep.event.event_id
     : '';
 
+  const itemTypes = {
+    log: TraceItemDataset.LOGS,
+    span: TraceItemDataset.SPANS,
+    uptime_check: TraceItemDataset.UPTIME_RESULTS,
+  };
+
   const rootEvent = useTraceItemDetails({
     traceItemId: String(eventId),
     projectId: String(projectId),
     traceId,
-    traceItemType: rep?.type === 'log' ? TraceItemDataset.LOGS : TraceItemDataset.SPANS,
+    traceItemType: itemTypes[rep.type],
     referrer: 'api.explore.log-item-details',
     enabled: enabledBase && isEAPQueryEnabled,
   });

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/uptime/timing.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/uptime/timing.tsx
@@ -1,0 +1,100 @@
+import {useTheme} from '@emotion/react';
+
+import {Text} from 'sentry/components/core/text';
+import {t} from 'sentry/locale';
+import getDuration from 'sentry/utils/duration/getDuration';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import {AttributesTree} from 'sentry/views/explore/components/traceItemAttributes/attributesTree';
+import type {TraceItemResponseAttribute} from 'sentry/views/explore/hooks/useTraceItemDetails';
+import {TraceDrawerComponents} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/styles';
+import type {TraceTreeNodeDetailsProps} from 'sentry/views/performance/newTraceDetails/traceDrawer/tabs/traceTreeNodeDetails';
+import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
+import type {TraceTreeNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode';
+
+const UPTIME_PHASE_DESCRIPTIONS = {
+  'dns.lookup.duration': t(
+    "DNS Lookup. The Uptime Checker is resolving the request's IP address."
+  ),
+  'http.tcp_connection.duration': t(
+    'Initial connection. The Uptime Checker is establishing a connection, including TCP handshakes or retries and negotiating an SSL.'
+  ),
+  'tls.handshake.duration': t(
+    'TLS negotiation. The Uptime Checker is performing the TLS handshake to establish a secure connection.'
+  ),
+  'http.client.request.duration': t('Request sent. The request is being sent.'),
+  'http.server.time_to_first_byte': t(
+    'Waiting (TTFB). The Uptime Checker is waiting for the first byte of a response. TTFB stands for Time To First Byte. This timing includes 1 round trip of latency and the time the server took to prepare the response.'
+  ),
+  'http.client.response.duration': t(
+    'Content Download. The Uptime Checker is receiving the response directly from the network. This value is the total amount of time spent reading the response body. Larger than expected values could indicate a slow network.'
+  ),
+};
+
+export function UptimeTimingDetails(
+  props: TraceTreeNodeDetailsProps<TraceTreeNode<TraceTree.UptimeCheckTiming>>
+) {
+  const {node} = props;
+  const {op, description, duration, start_timestamp, end_timestamp} = node.value;
+
+  const location = useLocation();
+  const organization = useOrganization();
+  const theme = useTheme();
+
+  const phaseDescription =
+    UPTIME_PHASE_DESCRIPTIONS[op as keyof typeof UPTIME_PHASE_DESCRIPTIONS];
+
+  const attributes: TraceItemResponseAttribute[] = [
+    {
+      name: 'operation',
+      type: 'str',
+      value: op,
+    },
+    {
+      name: 'duration',
+      type: 'str',
+      value: getDuration(duration, 2, true),
+    },
+    {
+      name: 'start_timestamp',
+      type: 'float',
+      value: start_timestamp,
+    },
+    {
+      name: 'end_timestamp',
+      type: 'float',
+      value: end_timestamp,
+    },
+  ];
+
+  return (
+    <TraceDrawerComponents.DetailContainer>
+      <TraceDrawerComponents.HeaderContainer>
+        <TraceDrawerComponents.Title>
+          <TraceDrawerComponents.TitleText>
+            {description || op}
+          </TraceDrawerComponents.TitleText>
+        </TraceDrawerComponents.Title>
+      </TraceDrawerComponents.HeaderContainer>
+      <TraceDrawerComponents.BodyContainer>
+        <Text density="comfortable" style={{marginBottom: theme.space.xl}}>
+          {phaseDescription}
+        </Text>
+
+        <AttributesTree
+          attributes={attributes}
+          rendererExtra={{
+            location,
+            organization,
+            theme,
+          }}
+          columnCount={1}
+          config={{
+            disableActions: true,
+            disableRichValue: true,
+          }}
+        />
+      </TraceDrawerComponents.BodyContainer>
+    </TraceDrawerComponents.DetailContainer>
+  );
+}

--- a/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceTreeNodeDetails.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceTreeNodeDetails.tsx
@@ -5,6 +5,7 @@ import {MissingInstrumentationNodeDetails} from 'sentry/views/performance/newTra
 import {SpanNodeDetails} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/span/index';
 import {TransactionNodeDetails} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/transaction/index';
 import {UptimeNodeDetails} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/uptime/index';
+import {UptimeTimingDetails} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/uptime/timing';
 import {
   isAutogroupedNode,
   isEAPErrorNode,
@@ -14,6 +15,7 @@ import {
   isTraceErrorNode,
   isTransactionNode,
   isUptimeCheckNode,
+  isUptimeCheckTimingNode,
 } from 'sentry/views/performance/newTraceDetails/traceGuards';
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import type {TraceTreeNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode';
@@ -38,6 +40,10 @@ export function TraceTreeNodeDetails(props: TraceTreeNodeDetailsProps<any>) {
 
   if (isUptimeCheckNode(props.node)) {
     return <UptimeNodeDetails {...props} />;
+  }
+
+  if (isUptimeCheckTimingNode(props.node)) {
+    return <UptimeTimingDetails {...props} />;
   }
 
   if (isSpanNode(props.node) || isEAPSpanNode(props.node)) {

--- a/static/app/views/performance/newTraceDetails/traceGuards.tsx
+++ b/static/app/views/performance/newTraceDetails/traceGuards.tsx
@@ -47,10 +47,16 @@ export function isEAPSpanNode(
 export function isUptimeCheckNode(
   node: TraceTreeNode<TraceTree.NodeValue>
 ): node is TraceTreeNode<TraceTree.UptimeCheck> {
+  return isUptimeCheck(node.value);
+}
+
+export function isUptimeCheckTimingNode(
+  node: TraceTreeNode<TraceTree.NodeValue>
+): node is TraceTreeNode<TraceTree.UptimeCheckTiming> {
   return !!(
     node.value &&
     'event_type' in node.value &&
-    node.value.event_type === 'uptime'
+    node.value.event_type === 'uptime_check_timing'
   );
 }
 
@@ -67,8 +73,16 @@ export function isTransactionNode(
     !!(node.value && 'transaction' in node.value) &&
     !isAutogroupedNode(node) &&
     !isEAPSpanNode(node) &&
+    !isUptimeCheckNode(node) &&
+    !isUptimeCheckTimingNode(node) &&
     !isEAPErrorNode(node)
   );
+}
+
+export function isUptimeCheck(
+  value: TraceTree.NodeValue
+): value is TraceTree.UptimeCheck {
+  return !!(value && 'event_type' in value && value.event_type === 'uptime_check');
 }
 
 export function isEAPError(value: TraceTree.NodeValue): value is TraceTree.EAPError {

--- a/static/app/views/performance/newTraceDetails/traceHeader/highlights.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/highlights.tsx
@@ -8,6 +8,7 @@ import {HighlightsIconSummary as TransactionEventHighlights} from 'sentry/compon
 import {ScrollCarousel} from 'sentry/components/scrollCarousel';
 import Version from 'sentry/components/version';
 import VersionHoverCard from 'sentry/components/versionHoverCard';
+import {IconGlobe} from 'sentry/icons';
 import {IconReleases} from 'sentry/icons/iconReleases';
 import {IconWindow} from 'sentry/icons/iconWindow';
 import {t} from 'sentry/locale';
@@ -229,6 +230,21 @@ function AttributesHighlights({
       },
     },
     {
+      key: 'uptime-check-region',
+      getSummary: () => {
+        const region = findSpanAttributeValue(attributes, 'region');
+
+        if (!region) {
+          return null;
+        }
+
+        return {
+          icon: <IconGlobe size="sm" color="subText" />,
+          description: t('Check from %s', region),
+        };
+      },
+    },
+    {
       key: 'environment',
       getSummary: () => {
         const environment = findSpanAttributeValue(attributes, 'environment');
@@ -276,6 +292,8 @@ const HighlightsDescription = styled('div')`
 `;
 
 const HighlightsIconWrapper = styled('div')`
+  display: flex;
+  align-items: center;
   flex: none;
   line-height: 1;
 `;

--- a/static/app/views/performance/newTraceDetails/traceHeader/index.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/index.spec.tsx
@@ -13,6 +13,8 @@ import {
 } from 'sentry/views/performance/newTraceDetails/traceHeader';
 import {TraceViewSources} from 'sentry/views/performance/newTraceDetails/traceHeader/breadcrumbs';
 import {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
+import {TraceTreeNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode';
+import {makeUptimeCheck} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeTestUtils';
 
 jest.mock('sentry/views/performance/newTraceDetails/traceState/traceStateProvider');
 jest.mock('sentry/utils/useLocation');
@@ -163,6 +165,67 @@ describe('TraceMetaDataHeader', () => {
       expect(breadcrumbsLinks[1]).toHaveTextContent('Transaction Summary');
       expect(breadcrumbsItems).toHaveLength(1);
       expect(breadcrumbsItems[0]).toHaveTextContent(/trace-slug/);
+    });
+  });
+
+  describe('uptime check header', () => {
+    it('should render uptime check header with title and subtitle', () => {
+      useLocationMock.mockReturnValue(
+        LocationFixture({
+          pathname: '/organizations/org-slug/traces/trace/trace-slug',
+        })
+      );
+
+      // Create uptime check using test utility
+      const uptimeCheckEvent = makeUptimeCheck({
+        additional_attributes: {
+          method: 'GET',
+          request_url: 'https://example.com',
+        },
+      });
+
+      const uptimeCheckWithContexts = {...uptimeCheckEvent, contexts: {}};
+
+      // Create a tree structure that matches getRepresentativeTraceEvent expectations
+      const tree = new TraceTree();
+
+      // Create the tree root (this is tree.root)
+      const treeRoot = new TraceTreeNode(null, null, {
+        project_slug: 'test-project',
+        event_id: 'tree-root',
+      });
+      tree.root = treeRoot;
+
+      // Create a mock trace node as first child of root
+      const traceNodeValue = {
+        transactions: [],
+        orphan_errors: [],
+      };
+      const traceNode = new TraceTreeNode(treeRoot, traceNodeValue, {
+        project_slug: 'test-project',
+        event_id: 'trace-node',
+      });
+      treeRoot.children.push(traceNode);
+
+      // Add uptime check as first child of trace node
+      const uptimeCheckNode = new TraceTreeNode(traceNode, uptimeCheckEvent, {
+        project_slug: 'test-project',
+        event_id: 'uptime-event-id',
+      });
+      traceNode.children.push(uptimeCheckNode);
+
+      const props = {
+        ...baseProps,
+        tree,
+        rootEventResults: {data: uptimeCheckWithContexts} as any,
+      } as TraceMetadataHeaderProps;
+
+      render(<TraceMetaDataHeader {...props} organization={organization} />);
+
+      // Check for uptime monitor title
+      expect(screen.getByText('Uptime Monitor Check')).toBeInTheDocument();
+      // Check for subtitle with method and URL
+      expect(screen.getByText('GET https://example.com')).toBeInTheDocument();
     });
   });
 });

--- a/static/app/views/performance/newTraceDetails/traceHeader/title.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/title.tsx
@@ -19,6 +19,7 @@ import {findSpanAttributeValue} from 'sentry/views/performance/newTraceDetails/t
 import {
   isEAPError,
   isTraceError,
+  isUptimeCheck,
 } from 'sentry/views/performance/newTraceDetails/traceGuards';
 import {makeReplaysPathname} from 'sentry/views/replays/pathnames';
 
@@ -51,6 +52,14 @@ function getTitle(representativeEvent: RepresentativeTraceEvent): {
     return {
       title: t('Trace'),
       subtitle,
+    };
+  }
+
+  // Handle uptime check traces
+  if (isUptimeCheck(event)) {
+    return {
+      title: t('Uptime Monitor Check'),
+      subtitle: `${event.additional_attributes?.method} ${event.additional_attributes?.request_url}`,
     };
   }
 

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
@@ -4,8 +4,10 @@ import * as qs from 'query-string';
 
 import type {Client} from 'sentry/api';
 import type {RawSpanType} from 'sentry/components/events/interfaces/spans/types';
+import {t} from 'sentry/locale';
 import type {Event, EventTransaction, Level, Measurement} from 'sentry/types/event';
 import type {Organization} from 'sentry/types/organization';
+import {uniqueId} from 'sentry/utils/guid';
 import type {
   TraceError as TraceErrorType,
   TraceFullDetailed,
@@ -40,6 +42,8 @@ import {
   isTraceNode,
   isTraceSplitResult,
   isTransactionNode,
+  isUptimeCheckNode,
+  isUptimeCheckTimingNode,
   shouldAddMissingInstrumentationSpan,
 } from 'sentry/views/performance/newTraceDetails/traceGuards';
 import {
@@ -184,14 +188,14 @@ export declare namespace TraceTree {
   };
 
   type UptimeCheck = {
-    children: Array<UptimeCheck | EAPSpan>;
+    children: EAPSpan[];
     duration: number;
     end_timestamp: number;
     errors: EAPError[];
     event_id: string;
-    event_type: 'uptime';
-    is_transaction: false;
+    event_type: 'uptime_check';
     name: string;
+    occurrences: EAPOccurrence[];
     op: string;
     project_id: number;
     project_slug: string;
@@ -199,6 +203,16 @@ export declare namespace TraceTree {
     transaction: string;
     transaction_id: string;
     additional_attributes?: Record<string, number | string>;
+    description?: string;
+  };
+
+  type UptimeCheckTiming = {
+    duration: number;
+    end_timestamp: number;
+    event_id: string;
+    event_type: 'uptime_check_timing';
+    op: string;
+    start_timestamp: number;
     description?: string;
   };
 
@@ -212,13 +226,14 @@ export declare namespace TraceTree {
     sdk_name: string;
   }
 
-  type EAPTrace = Array<EAPSpan | EAPError>;
+  type EAPTrace = Array<EAPSpan | EAPError | UptimeCheck>;
 
   type Trace = TraceSplitResults<Transaction> | EAPTrace;
 
-  // Represents events that we get from the trace endpoints and render an individual row for in the trace waterfall, on load.
-  // This excludes spans as they are rendered on-demand as the user zooms in.
-  type TraceEvent = Transaction | TraceError | EAPSpan | EAPError;
+  // Represents events that we get from the trace endpoints and render an
+  // individual row for in the trace waterfall, on load. This excludes spans as
+  // they are rendered on-demand as the user zooms in.
+  type TraceEvent = Transaction | TraceError | EAPSpan | EAPError | UptimeCheck;
 
   type TraceError = TraceErrorType;
   type TraceErrorIssue = TraceError | EAPError;
@@ -243,6 +258,7 @@ export declare namespace TraceTree {
     | Span
     | EAPSpan
     | UptimeCheck
+    | UptimeCheckTiming
     | MissingInstrumentationSpan
     | SiblingAutogroup
     | ChildrenAutogroup
@@ -287,7 +303,7 @@ export declare namespace TraceTree {
     | MissingInstrumentationNode;
 
   type NodePath =
-    `${'txn' | 'span' | 'ag' | 'trace' | 'ms' | 'error' | 'empty'}-${string}`;
+    `${'txn' | 'span' | 'ag' | 'trace' | 'ms' | 'error' | 'empty' | 'uptime-check' | 'uptime-check-timing'}-${string}`;
 
   type Metadata = {
     event_id: string | undefined;
@@ -414,6 +430,94 @@ export class TraceTree extends TraceTreeEventDispatcher {
     }
   }
 
+  /**
+   * Generate uptime metric nodes for uptime check requests to show DNS, TCP,
+   * TLS, Request, Waiting, and Response phases in the trace waterfall.
+   */
+  static CreateUptimeCheckTimingNodes(
+    uptimeNode: TraceTreeNode<TraceTree.UptimeCheck>
+  ): Array<TraceTreeNode<TraceTree.UptimeCheckTiming>> {
+    const uptimeCheck = uptimeNode.value;
+    const attrs = uptimeCheck.additional_attributes || {};
+
+    // Create fake spans for each timing phase
+    const phases: Array<{
+      description: string;
+      durationUs: number;
+      op: string;
+      startUs: number;
+    }> = [
+      {
+        op: 'dns.lookup.duration',
+        description: t('DNS lookup'),
+        durationUs: Number(attrs.dns_lookup_duration_us || 0),
+        startUs: Number(attrs.dns_lookup_start_us || 0),
+      },
+      {
+        op: 'http.tcp_connection.duration',
+        description: t('TCP connect'),
+        durationUs: Number(attrs.tcp_connection_duration_us || 0),
+        startUs: Number(attrs.tcp_connection_start_us || 0),
+      },
+      {
+        op: 'tls.handshake.duration',
+        description: t('TLS handshake'),
+        durationUs: Number(attrs.tls_handshake_duration_us || 0),
+        startUs: Number(attrs.tls_handshake_start_us || 0),
+      },
+      {
+        op: 'http.client.request.duration',
+        description: t('Send request'),
+        durationUs: Number(attrs.send_request_duration_us || 0),
+        startUs: Number(attrs.send_request_start_us || 0),
+      },
+      {
+        op: 'http.server.time_to_first_byte',
+        description: t('Waiting for response'),
+        durationUs: Number(attrs.time_to_first_byte_duration_us || 0),
+        startUs: Number(attrs.time_to_first_byte_start_us || 0),
+      },
+      {
+        op: 'http.client.response.duration',
+        description: t('Receive response'),
+        durationUs: Number(attrs.receive_response_duration_us || 0),
+        startUs: Number(attrs.receive_response_start_us || 0),
+      },
+    ];
+
+    const fakeSpans = phases.map(phase => {
+      const startTimestamp = phase.startUs / 1_000_000;
+      const duration = phase.durationUs / 1_000_000;
+
+      const fakeSpan: TraceTree.UptimeCheckTiming = {
+        event_type: 'uptime_check_timing',
+        event_id: uniqueId(),
+        start_timestamp: startTimestamp,
+        end_timestamp: startTimestamp + duration,
+        duration,
+        op: phase.op,
+        description: phase.description,
+      };
+
+      const timingNode = new TraceTreeNode(uptimeNode, fakeSpan, {
+        project_slug: uptimeCheck.project_slug,
+        event_id: undefined,
+      });
+
+      // Calculate space bounds for the waterfall (start time in ms, duration in ms)
+      const startMs = startTimestamp * 1000;
+      const durationMs = duration * 1000;
+      timingNode.space = [startMs, durationMs];
+
+      return timingNode;
+    });
+
+    // Sort spans chronologically
+    fakeSpans.sort((a, b) => a.value.start_timestamp - b.value.start_timestamp);
+
+    return fakeSpans;
+  }
+
   static FromTrace(
     trace: TraceTree.Trace,
     options: {
@@ -444,6 +548,7 @@ export class TraceTree extends TraceTreeEventDispatcher {
         | TraceTree.TraceError
         | TraceTree.EAPSpan
         | TraceTree.EAPError
+        | TraceTree.UptimeCheck
     ) {
       tree.projects.set(value.project_id, {
         slug: value.project_slug,
@@ -490,6 +595,12 @@ export class TraceTree extends TraceTreeEventDispatcher {
       }
 
       parentNode.children.push(node);
+
+      // Inject fake timing spans for uptime check nodes
+      if (isUptimeCheckNode(node)) {
+        const timingNodes = TraceTree.CreateUptimeCheckTimingNodes(node);
+        timingNodes.forEach(timingNode => node.children.push(timingNode));
+      }
 
       // Since we are reparenting EAP transactions at this stage, we need to sort the children
       if (isEAPTransactionNode(node)) {
@@ -2408,6 +2519,14 @@ function nodeToId(n: TraceTreeNode<TraceTree.NodeValue>): TraceTree.NodePath {
   if (isRootNode(n)) {
     throw new Error('A path to root node does not exist as the node is virtual');
   }
+  if (isUptimeCheckNode(n)) {
+    const checkId = n.value.event_id;
+    return `uptime-check-${checkId}`;
+  }
+  if (isUptimeCheckTimingNode(n)) {
+    const checkId = n.value.event_id;
+    return `uptime-check-timing-${checkId}`;
+  }
 
   if (isMissingInstrumentationNode(n)) {
     const previousSpanId = isSpanNode(n.previous)
@@ -2494,6 +2613,7 @@ function traceQueueIterator(
       | TraceTree.TraceError
       | TraceTree.EAPSpan
       | TraceTree.EAPError
+      | TraceTree.UptimeCheck
   ) => void
 ) {
   if (!isTraceSplitResult(trace)) {
@@ -2592,7 +2712,11 @@ function getRelatedPerformanceIssuesFromTransaction(
 }
 
 export function getNodeDescriptionPrefix(
-  node: TraceTreeNode<TraceTree.EAPSpan> | TraceTreeNode<TraceTree.Span>
+  node:
+    | TraceTreeNode<TraceTree.EAPSpan>
+    | TraceTreeNode<TraceTree.Span>
+    | TraceTreeNode<TraceTree.UptimeCheck>
+    | TraceTreeNode<TraceTree.UptimeCheckTiming>
 ) {
   // Check if span has http.request.prefetch attribute and add prefix if it does
   const isPrefetch =

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeTestUtils.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeTestUtils.tsx
@@ -209,6 +209,41 @@ export function assertEAPSpanNode(
   }
 }
 
+export function makeUptimeCheck(
+  overrides: Partial<TraceTree.UptimeCheck> = {}
+): TraceTree.UptimeCheck {
+  return {
+    event_id: overrides.event_id ?? uuid4(),
+    event_type: 'uptime_check',
+    op: 'uptime.check',
+    name: 'GET https://example.com',
+    description: 'Uptime check for example.com',
+    start_timestamp: 0,
+    end_timestamp: 1,
+    duration: 1,
+    project_id: 1,
+    project_slug: 'project_slug',
+    children: [],
+    errors: [],
+    occurrences: [],
+    additional_attributes: {
+      dns_lookup_duration_us: '50000',
+      dns_lookup_start_us: '0',
+      tcp_connection_duration_us: '100000',
+      tcp_connection_start_us: '50000',
+      tls_handshake_duration_us: '200000',
+      tls_handshake_start_us: '150000',
+      send_request_duration_us: '25000',
+      send_request_start_us: '350000',
+      time_to_first_byte_duration_us: '500000',
+      time_to_first_byte_start_us: '375000',
+      receive_response_duration_us: '100000',
+      receive_response_start_us: '875000',
+    },
+    ...overrides,
+  } as TraceTree.UptimeCheck;
+}
+
 export function makeNodeMetadata(
   overrides: Partial<TraceTree.Metadata> = {}
 ): TraceTree.Metadata {

--- a/static/app/views/performance/newTraceDetails/traceRow/traceSpanRow.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceSpanRow.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import {PlatformIcon} from 'platformicons';
 
+import {IconSentry, IconTimer} from 'sentry/icons';
 import {ellipsize} from 'sentry/utils/string/ellipsize';
 import {
   isEAPSpanNode,
   isEAPTransactionNode,
+  isUptimeCheckNode,
+  isUptimeCheckTimingNode,
 } from 'sentry/views/performance/newTraceDetails/traceGuards';
 import {TraceIcons} from 'sentry/views/performance/newTraceDetails/traceIcons';
 import {
@@ -28,14 +31,32 @@ import {useOTelFriendlyUI} from 'sentry/views/performance/otlp/useOTelFriendlyUI
 const NO_PROFILES: any = [];
 
 export function TraceSpanRow(
-  props: TraceRowProps<TraceTreeNode<TraceTree.Span> | TraceTreeNode<TraceTree.EAPSpan>>
+  props: TraceRowProps<
+    | TraceTreeNode<TraceTree.Span>
+    | TraceTreeNode<TraceTree.EAPSpan>
+    | TraceTreeNode<TraceTree.UptimeCheck>
+    | TraceTreeNode<TraceTree.UptimeCheckTiming>
+  >
 ) {
-  const spanId = isEAPSpanNode(props.node)
-    ? props.node.value.event_id
-    : props.node.value.span_id;
+  const spanId =
+    isEAPSpanNode(props.node) ||
+    isUptimeCheckNode(props.node) ||
+    isUptimeCheckTimingNode(props.node)
+      ? props.node.value.event_id
+      : props.node.value.span_id;
 
   const shouldUseOTelFriendlyUI = useOTelFriendlyUI();
   const childrenCount = getChildrenCount(props.node);
+
+  const icon = isUptimeCheckNode(props.node) ? (
+    <IconSentry size="xs" />
+  ) : isUptimeCheckTimingNode(props.node) ? (
+    <IconTimer size="xs" />
+  ) : (
+    <PlatformIcon
+      platform={props.projects[props.node.metadata.project_slug ?? ''] ?? 'default'}
+    />
+  );
 
   return (
     <div
@@ -79,9 +100,7 @@ export function TraceSpanRow(
               </TraceChildrenButton>
             ) : null}
           </div>
-          <PlatformIcon
-            platform={props.projects[props.node.metadata.project_slug ?? ''] ?? 'default'}
-          />
+          {icon}
           <React.Fragment>
             {props.node.value.op && props.node.value.op !== 'default' && (
               <React.Fragment>
@@ -136,8 +155,16 @@ export function TraceSpanRow(
 }
 
 function getChildrenCount(
-  node: TraceTreeNode<TraceTree.Span> | TraceTreeNode<TraceTree.EAPSpan>
+  node:
+    | TraceTreeNode<TraceTree.Span>
+    | TraceTreeNode<TraceTree.EAPSpan>
+    | TraceTreeNode<TraceTree.UptimeCheck>
+    | TraceTreeNode<TraceTree.UptimeCheckTiming>
 ) {
+  if (isUptimeCheckTimingNode(node)) {
+    return 0;
+  }
+
   if (isEAPTransactionNode(node) && !node.expanded) {
     return node.children.length - TraceTree.DirectVisibleChildren(node).length;
   }


### PR DESCRIPTION
- Now includes request timing details as part of the waterfall itself
 - The header is specialized for uptime checks and includes the
   requested URL and check region (we can improve this by including the
   human readable region name in the attributes)

Looks like this

<img alt="clipboard.png" width="1629" src="https://i.imgur.com/eLvKl2J.png" />