### PR TITLE
fix(autofix): Remove unnecessary environment filter when fetching tags

### DIFF
--- a/src/sentry/seer/autofix/autofix.py
+++ b/src/sentry/seer/autofix/autofix.py
@@ -17,7 +17,6 @@ from sentry import eventstore, features, quotas, tagstore
 from sentry.api.endpoints.organization_trace import OrganizationTraceEndpoint
 from sentry.api.serializers import EventSerializer, serialize
 from sentry.constants import DataCategory, ObjectStatus
-from sentry.models.environment import Environment
 from sentry.models.group import Group
 from sentry.models.project import Project
 from sentry.search.eap.types import SearchResolverConfig
@@ -325,15 +324,9 @@ def _get_all_tags_overview(group: Group) -> dict[str, Any] | None:
     Get high-level overview of all tags for an issue.
     Returns aggregated tag data with percentages for all tags.
     """
-    environment_ids = list(
-        Environment.objects.filter(organization_id=group.project.organization_id).values_list(
-            "id", flat=True
-        )
-    )
-
     tag_keys = tagstore.backend.get_group_tag_keys_and_top_values(
         group,
-        environment_ids,
+        [],  # all environments
         keys=None,  # Get all tags
         value_limit=3,  # Get top 3 values per tag
         tenant_ids={"organization_id": group.project.organization_id},


### PR DESCRIPTION
Instead of fetching a list of all environment ids to filter on, we can just pass an empty list to get results for all environments.