### PR TITLE
fix(explorer): Don't normalize raw span data

### DIFF
--- a/src/sentry/seer/explorer/index_data.py
+++ b/src/sentry/seer/explorer/index_data.py
@@ -209,7 +209,7 @@ def get_trace_for_transaction(transaction_name: str, project_id: int) -> TraceDa
                     span_id=span_id,
                     parent_span_id=parent_span_id,
                     span_op=span_op,
-                    span_description=normalize_description(span_description or ""),
+                    span_description=span_description or "",
                 )
             )
 


### PR DESCRIPTION
We were normalizing span descriptions on the Sentry side, which broke normalization on the Seer side. We'll just do it all in Seer.