### PR TITLE
feat(upsampling) - Discover Error Upsampling sorting fix

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -15,6 +15,7 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
 from sentry.api.helpers.error_upsampling import (
     is_errors_query_for_error_upsampled_projects,
+    transform_orderby_for_error_upsampling,
     transform_query_columns_for_error_upsampling,
 )
 from sentry.api.paginator import GenericOffsetPaginator
@@ -321,19 +322,22 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
             query: str | None,
         ):
             selected_columns = self.get_field_list(organization, request)
+            orderby = self.get_orderby(request)
             if is_errors_query_for_error_upsampled_projects(
                 snuba_params, organization, dataset, request
             ):
                 selected_columns = transform_query_columns_for_error_upsampling(
                     selected_columns, False
                 )
+                if orderby:
+                    orderby = transform_orderby_for_error_upsampling(orderby)
             query_source = self.get_request_source(request)
             return dataset_query(
                 selected_columns=selected_columns,
                 query=query or "",
                 snuba_params=snuba_params,
                 equations=self.get_equation_list(organization, request),
-                orderby=self.get_orderby(request),
+                orderby=orderby,
                 offset=offset,
                 limit=limit,
                 referrer=referrer,

--- a/src/sentry/api/helpers/error_upsampling.py
+++ b/src/sentry/api/helpers/error_upsampling.py
@@ -126,6 +126,44 @@ def transform_query_columns_for_error_upsampling(
     return transformed_columns
 
 
+def transform_orderby_for_error_upsampling(orderby: list[str]) -> list[str]:
+    """
+    Transform orderby fields to use upsampled aggregation functions instead of raw ones
+    for error upsampling.
+
+    Args:
+        orderby: List of orderby strings like ["-count", "eps"]
+
+    Returns:
+        List of transformed orderby strings like ["-upsampled_count", "upsampled_eps"]
+    """
+    orderby_conversions = {
+        "count": "upsampled_count",
+        "eps": "upsampled_eps",
+        "epm": "upsampled_epm",
+        "sample_count": "count",
+        "sample_eps": "eps",
+        "sample_epm": "epm",
+    }
+
+    transformed_orderby = []
+    for order_field in orderby:
+        if order_field.startswith("-"):
+            direction = "-"
+            field = order_field[1:]
+        else:
+            direction = ""
+            field = order_field
+
+        # Apply transformation if field needs it
+        if field in orderby_conversions:
+            field = orderby_conversions[field]
+
+        transformed_orderby.append(f"{direction}{field}")
+
+    return transformed_orderby
+
+
 def _should_apply_sample_weight_transform(dataset: Any, request: Request) -> bool:
     """
     Determine if we should apply sample_weight transformations based on the dataset


### PR DESCRIPTION
Convert columns on orderby queries for error upsampled projects on the Events API call, fixing an issue when sortting count columns in Discover
