### PR TITLE
fix(ourlogs): Fix trace logs attrs

### DIFF
--- a/src/sentry/search/eap/common_columns.py
+++ b/src/sentry/search/eap/common_columns.py
@@ -32,7 +32,7 @@ COMMON_COLUMNS = [
         private=True,
     ),
     ResolvedAttribute(
-        public_alias="timestamp",
+        public_alias=constants.TIMESTAMP_ALIAS,
         internal_name="sentry.timestamp",
         internal_type=constants.DOUBLE,
         search_type="string",

--- a/src/sentry/search/eap/constants.py
+++ b/src/sentry/search/eap/constants.py
@@ -180,3 +180,8 @@ META_FIELD_PREFIX = f"{META_PREFIX}.fields"
 META_ATTRIBUTE_PREFIX = f"{META_FIELD_PREFIX}.attributes"
 
 SENTRY_INTERNAL_PREFIXES = ["__sentry_internal", "sentry._internal."]
+
+# public alias that we want to be sure are consistent
+TIMESTAMP_PRECISE_ALIAS = "timestamp_precise"
+TIMESTAMP_ALIAS = "timestamp"
+TRACE_ALIAS = "trace"

--- a/src/sentry/search/eap/ourlogs/attributes.py
+++ b/src/sentry/search/eap/ourlogs/attributes.py
@@ -167,3 +167,11 @@ def ourlog_column_to_custom_alias(column: str) -> str | None:
     if column.startswith("sentry.message.parameter."):
         return column[len("sentry.") :]
     return None
+
+
+def ourlog_attribute_map() -> dict[str, ResolvedAttribute]:
+    """Return all ResolvedAttribute objects keyed by their public alias"""
+    attribute_mapping = {}
+    for public_alias, definition in OURLOG_ATTRIBUTE_DEFINITIONS.items():
+        attribute_mapping[public_alias] = definition
+    return attribute_mapping

--- a/src/sentry/search/eap/ourlogs/attributes.py
+++ b/src/sentry/search/eap/ourlogs/attributes.py
@@ -37,13 +37,13 @@ OURLOG_ATTRIBUTE_DEFINITIONS = {
             search_type="string",
         ),
         ResolvedAttribute(
-            public_alias="trace",
+            public_alias=constants.TRACE_ALIAS,
             internal_name="sentry.trace_id",
             search_type="string",
             validator=is_event_id_or_list,
         ),
         ResolvedAttribute(
-            public_alias="timestamp_precise",
+            public_alias=constants.TIMESTAMP_PRECISE_ALIAS,
             internal_name="sentry.timestamp_precise",
             search_type="number",
         ),
@@ -96,6 +96,11 @@ OURLOG_ATTRIBUTE_DEFINITIONS = {
         ),
     ]
 }
+
+# Ensure that required fields are defined at runtime
+for field in {constants.TIMESTAMP_ALIAS, constants.TIMESTAMP_PRECISE_ALIAS, constants.TRACE_ALIAS}:
+    assert field in OURLOG_ATTRIBUTE_DEFINITIONS, f"{field} must be defined for ourlogs"
+
 
 OURLOG_VIRTUAL_CONTEXTS = {
     key: VirtualColumnDefinition(
@@ -167,11 +172,3 @@ def ourlog_column_to_custom_alias(column: str) -> str | None:
     if column.startswith("sentry.message.parameter."):
         return column[len("sentry.") :]
     return None
-
-
-def ourlog_attribute_map() -> dict[str, ResolvedAttribute]:
-    """Return all ResolvedAttribute objects keyed by their public alias"""
-    attribute_mapping = {}
-    for public_alias, definition in OURLOG_ATTRIBUTE_DEFINITIONS.items():
-        attribute_mapping[public_alias] = definition
-    return attribute_mapping

--- a/src/sentry/snuba/ourlogs.py
+++ b/src/sentry/snuba/ourlogs.py
@@ -3,7 +3,6 @@ from datetime import timedelta
 
 import sentry_sdk
 
-from sentry.search.eap.ourlogs.attributes import ourlog_attribute_map
 from sentry.search.eap.ourlogs.definitions import OURLOG_DEFINITIONS
 from sentry.search.eap.resolver import SearchResolver
 from sentry.search.eap.sampling import handle_downsample_meta
@@ -38,13 +37,11 @@ class OurLogs(rpc_dataset_common.RPCBase):
         search_resolver: SearchResolver | None = None,
         debug: bool = False,
     ) -> EAPResponse:
-        attribute_mapping = ourlog_attribute_map()
+        timestamp_attribute = cls.DEFINITIONS.columns["timestamp"]
+        timestamp_precise_attribute = cls.DEFINITIONS.columns["timestamp_precise"]
 
-        timestamp_attribute = attribute_mapping.get("timestamp")
-        timestamp_precise_attribute = attribute_mapping.get("timestamp_precise")
-        if timestamp_attribute is None or timestamp_precise_attribute is None:
-            raise ValueError("timestamp or timestamp_precise attribute not found")
-
+        """timestamp_precise is always displayed in the UI in lieu of timestamp but since the TraceItem table isn't a DateTime64
+        so we need to always order by it regardless of what is actually passed to the orderby"""
         timestamp_alias = timestamp_attribute.public_alias
         precise_timestamp_alias = timestamp_precise_attribute.public_alias
         if orderby == [f"-{timestamp_alias}"]:

--- a/src/sentry/snuba/ourlogs.py
+++ b/src/sentry/snuba/ourlogs.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 
 import sentry_sdk
 
+from sentry.search.eap.ourlogs.attributes import ourlog_attribute_map
 from sentry.search.eap.ourlogs.definitions import OURLOG_DEFINITIONS
 from sentry.search.eap.resolver import SearchResolver
 from sentry.search.eap.sampling import handle_downsample_meta
@@ -37,15 +38,23 @@ class OurLogs(rpc_dataset_common.RPCBase):
         search_resolver: SearchResolver | None = None,
         debug: bool = False,
     ) -> EAPResponse:
-        precise_timestamp = "tags[sentry.timestamp_precise,number]"
-        if orderby == ["-timestamp"]:
-            orderby = ["-timestamp", f"-{precise_timestamp}"]
-            if precise_timestamp not in selected_columns:
-                selected_columns.append(precise_timestamp)
-        if orderby == ["timestamp"]:
-            orderby = ["timestamp", precise_timestamp]
-            if precise_timestamp not in selected_columns:
-                selected_columns.append(precise_timestamp)
+        attribute_mapping = ourlog_attribute_map()
+
+        timestamp_attribute = attribute_mapping.get("timestamp")
+        timestamp_precise_attribute = attribute_mapping.get("timestamp_precise")
+        if timestamp_attribute is None or timestamp_precise_attribute is None:
+            raise ValueError("timestamp or timestamp_precise attribute not found")
+
+        timestamp_alias = timestamp_attribute.public_alias
+        precise_timestamp_alias = timestamp_precise_attribute.public_alias
+        if orderby == [f"-{timestamp_alias}"]:
+            orderby = [f"-{timestamp_alias}", f"-{precise_timestamp_alias}"]
+            if precise_timestamp_alias not in selected_columns:
+                selected_columns.append(precise_timestamp_alias)
+        if orderby == [timestamp_alias]:
+            orderby = [timestamp_alias, precise_timestamp_alias]
+            if precise_timestamp_alias not in selected_columns:
+                selected_columns.append(precise_timestamp_alias)
 
         return cls._run_table_query(
             rpc_dataset_common.TableQuery(

--- a/src/sentry/snuba/ourlogs.py
+++ b/src/sentry/snuba/ourlogs.py
@@ -45,7 +45,7 @@ class OurLogs(rpc_dataset_common.RPCBase):
             and len(orderby) == 1
             and orderby[0].lstrip("-") == constants.TIMESTAMP_ALIAS
         ):
-            desc = orderby[0] == "-"
+            desc = orderby[0][0] == "-"
             orderby.append(("-" if desc else "") + constants.TIMESTAMP_PRECISE_ALIAS)
             if constants.TIMESTAMP_PRECISE_ALIAS not in selected_columns:
                 selected_columns.append(constants.TIMESTAMP_PRECISE_ALIAS)

--- a/src/sentry/snuba/ourlogs.py
+++ b/src/sentry/snuba/ourlogs.py
@@ -46,7 +46,7 @@ class OurLogs(rpc_dataset_common.RPCBase):
             and orderby[0].lstrip("-") == constants.TIMESTAMP_ALIAS
         ):
             desc = orderby[0] == "-"
-            orderby.append("-" if desc else "" + constants.TIMESTAMP_PRECISE_ALIAS)
+            orderby.append(("-" if desc else "") + constants.TIMESTAMP_PRECISE_ALIAS)
             if constants.TIMESTAMP_PRECISE_ALIAS not in selected_columns:
                 selected_columns.append(constants.TIMESTAMP_PRECISE_ALIAS)
 

--- a/tests/snuba/api/endpoints/test_organization_events_ourlogs.py
+++ b/tests/snuba/api/endpoints/test_organization_events_ourlogs.py
@@ -3,6 +3,7 @@ from uuid import UUID
 
 import pytest
 
+from sentry.search.eap import constants
 from sentry.testutils.helpers.datetime import before_now
 from sentry.utils.cursors import Cursor
 from tests.snuba.api.endpoints.test_organization_events import OrganizationEventsEndpointTestBase
@@ -93,8 +94,8 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase):
         for log, source in zip(data, logs):
             assert log["log.body"] == source.attributes["sentry.body"].string_value
             assert "tags[sentry.timestamp_precise,number]" not in log
-            assert "timestamp_precise" in log
-            assert "timestamp" in log
+            assert constants.TIMESTAMP_PRECISE_ALIAS in log
+            assert constants.TIMESTAMP_ALIAS in log
             ts = datetime.fromisoformat(log["timestamp"])
             assert ts.tzinfo == timezone.utc
             timestamp_from_nanos = (
@@ -419,7 +420,7 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase):
                 "timestamp": datetime.fromtimestamp(source.timestamp.seconds)
                 .replace(tzinfo=timezone.utc)
                 .isoformat(),
-                "timestamp_precise": pytest.approx(
+                constants.TIMESTAMP_PRECISE_ALIAS: pytest.approx(
                     source.attributes["sentry.timestamp_precise"].int_value
                 ),
                 "observed_timestamp": source.attributes[

--- a/tests/snuba/api/endpoints/test_organization_events_ourlogs.py
+++ b/tests/snuba/api/endpoints/test_organization_events_ourlogs.py
@@ -92,7 +92,8 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase):
 
         for log, source in zip(data, logs):
             assert log["log.body"] == source.attributes["sentry.body"].string_value
-            assert "tags[sentry.timestamp_precise,number]" in log
+            assert "tags[sentry.timestamp_precise,number]" not in log
+            assert "timestamp_precise" in log
             assert "timestamp" in log
             ts = datetime.fromisoformat(log["timestamp"])
             assert ts.tzinfo == timezone.utc
@@ -393,7 +394,6 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase):
                     "severity_number",
                     "severity",
                     "timestamp",
-                    "tags[sentry.timestamp_precise,number]",
                     "observed_timestamp",
                     "message",
                 ],
@@ -419,7 +419,7 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase):
                 "timestamp": datetime.fromtimestamp(source.timestamp.seconds)
                 .replace(tzinfo=timezone.utc)
                 .isoformat(),
-                "tags[sentry.timestamp_precise,number]": pytest.approx(
+                "timestamp_precise": pytest.approx(
                     source.attributes["sentry.timestamp_precise"].int_value
                 ),
                 "observed_timestamp": source.attributes[

--- a/tests/snuba/api/endpoints/test_organization_trace_logs.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_logs.py
@@ -1,4 +1,5 @@
 import logging
+from unittest.mock import patch
 from uuid import uuid4
 
 from django.urls import reverse
@@ -171,6 +172,7 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsEndpointTestBase):
             format="json",
         )
         assert response.status_code == 400, response.content
+        assert "foobar must be one of" in response.data["detail"]
 
     def test_cross_project_query(self) -> None:
         trace_id_1 = "1" * 32
@@ -266,3 +268,42 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsEndpointTestBase):
         )
         assert response.status_code == 400
         assert response.data["detail"] == "Invalid per_page value. Must be between 1 and 9999."
+
+    def test_timestamp_precise_alias_and_orderby(self) -> None:
+        trace_id = "1" * 32
+        logs = [
+            self.create_ourlog(
+                {"body": "foo", "trace_id": trace_id},
+                timestamp=self.ten_mins_ago,
+            )
+        ]
+        self.store_ourlogs(logs)
+
+        with patch("sentry.snuba.ourlogs.OurLogs.run_table_query") as mock_run_query:
+            mock_run_query.return_value = {
+                "data": [
+                    {
+                        # Data not relevant for this test
+                    }
+                ],
+                "meta": {"fields": {}, "units": {}},
+            }
+
+            response = self.client.get(
+                self.url,
+                data={"traceId": trace_id, "orderby": "-timestamp"},
+                format="json",
+            )
+
+            assert response.status_code == 200, response.content
+            mock_run_query.assert_called_once()
+
+            call_args = mock_run_query.call_args
+            selected_columns = call_args.kwargs["selected_columns"]
+            orderby = call_args.kwargs["orderby"]
+
+            assert "sentry.timestamp_precise" in selected_columns
+            assert orderby == [
+                "-sentry.timestamp",
+                "-sentry.timestamp_precise",
+            ]


### PR DESCRIPTION
Attribute strings were previously hardcoded, leading to subtle bugs such as when we changed the timestamp aliases. This change re-uses the attribute definitions to only allow selection via valid (known) attributes, which we'll hopefully capture in tests.