### PR TITLE
feat(trace-eap-waterfall): Decoupling analytic event from onTraceLoad

### DIFF
--- a/static/app/utils/analytics/tracingEventMap.tsx
+++ b/static/app/utils/analytics/tracingEventMap.tsx
@@ -70,7 +70,9 @@ export type TracingEventParameters = {
     source: TraceWaterFallSource;
   };
   'trace.load.error_state': {
+    error_status: number | null;
     source: TraceWaterFallSource;
+    span_count: number | null;
   };
   'trace.metadata': {
     eap_spans_count: number;

--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -106,7 +106,7 @@ function TraceViewImpl({traceSlug}: {traceSlug: string}) {
 
   const meta = useTraceMeta([{traceSlug, timestamp: queryParams.timestamp}]);
   const trace = useTrace({traceSlug, timestamp: queryParams.timestamp});
-  const tree = useTraceTree({traceSlug, trace, replay: null});
+  const tree = useTraceTree({traceSlug, trace, replay: null, meta});
   const rootEventResults = useTraceRootEvent({
     tree,
     logs: logsData,

--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -106,7 +106,7 @@ function TraceViewImpl({traceSlug}: {traceSlug: string}) {
 
   const meta = useTraceMeta([{traceSlug, timestamp: queryParams.timestamp}]);
   const trace = useTrace({traceSlug, timestamp: queryParams.timestamp});
-  const tree = useTraceTree({traceSlug, trace, replay: null, meta});
+  const tree = useTraceTree({traceSlug, trace, meta, replay: null});
   const rootEventResults = useTraceRootEvent({
     tree,
     logs: logsData,

--- a/static/app/views/performance/newTraceDetails/traceAnalytics.tsx
+++ b/static/app/views/performance/newTraceDetails/traceAnalytics.tsx
@@ -194,10 +194,17 @@ const trackTraceEmptyState = (organization: Organization, source: TraceWaterFall
     source,
   });
 
-const trackTraceErrorState = (organization: Organization, source: TraceWaterFallSource) =>
+const trackTraceErrorState = (
+  organization: Organization,
+  source: TraceWaterFallSource,
+  span_count: number | null,
+  error_status: number | null
+) =>
   trackAnalytics('trace.load.error_state', {
     organization,
     source,
+    span_count,
+    error_status,
   });
 
 const trackQuotaExceededLearnMoreClicked = (

--- a/static/app/views/performance/newTraceDetails/traceApi/useIssuesTraceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useIssuesTraceTree.tsx
@@ -57,7 +57,13 @@ export function useIssuesTraceTree({
               organization
             )
       );
-      traceAnalytics.trackTraceErrorState(organization, 'issue_details');
+      const errorStatus: number | null = trace.error?.status ?? null;
+      traceAnalytics.trackTraceErrorState(
+        organization,
+        'issue_details',
+        null,
+        errorStatus
+      );
       return;
     }
 

--- a/static/app/views/performance/newTraceDetails/traceApi/useTrace.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTrace.tsx
@@ -286,6 +286,7 @@ export function useTrace(
     ],
     {
       staleTime: Infinity,
+      retry: false,
       enabled: hasValidTrace && !isDemoMode && isEAPEnabled,
     }
   );

--- a/static/app/views/performance/newTraceDetails/traceApi/useTraceTree.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTraceTree.spec.tsx
@@ -45,6 +45,11 @@ describe('useTraceTree', () => {
           trace: getMockedTraceResults('error'),
           traceSlug: 'test-trace',
           replay: null,
+          meta: {
+            data: undefined,
+            errors: [],
+            status: 'success',
+          },
         }),
       {wrapper: contextWrapper(organization)}
     );
@@ -61,6 +66,11 @@ describe('useTraceTree', () => {
           trace: getMockedTraceResults('pending'),
           traceSlug: 'test-trace',
           replay: null,
+          meta: {
+            data: undefined,
+            errors: [],
+            status: 'success',
+          },
         }),
       {wrapper: contextWrapper(organization)}
     );
@@ -80,6 +90,11 @@ describe('useTraceTree', () => {
           }),
           traceSlug: 'test-trace',
           replay: null,
+          meta: {
+            data: undefined,
+            errors: [],
+            status: 'success',
+          },
         }),
       {wrapper: contextWrapper(organization)}
     );
@@ -131,6 +146,11 @@ describe('useTraceTree', () => {
           trace: getMockedTraceResults('success', mockedTrace),
           traceSlug: 'test-trace',
           replay: null,
+          meta: {
+            data: undefined,
+            errors: [],
+            status: 'success',
+          },
         }),
       {wrapper: contextWrapper(organization)}
     );

--- a/static/app/views/performance/newTraceDetails/traceApi/useTraceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTraceTree.tsx
@@ -13,9 +13,9 @@ import type {TraceMetaQueryResults} from './useTraceMeta';
 import {isEmptyTrace} from './utils';
 
 type UseTraceTreeParams = {
+  meta: TraceMetaQueryResults;
   replay: HydratedReplayRecord | null;
   trace: UseApiQueryResult<TraceTree.Trace | undefined, any>;
-  meta?: TraceMetaQueryResults;
   traceSlug?: string;
 };
 
@@ -54,8 +54,8 @@ export function useTraceTree({
       traceAnalytics.trackTraceErrorState(
         organization,
         traceWaterfallSource,
-        errorStatus,
-        metaSpansCount
+        metaSpansCount,
+        errorStatus
       );
       return;
     }

--- a/static/app/views/performance/newTraceDetails/traceApi/useTraceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTraceTree.tsx
@@ -9,15 +9,22 @@ import {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/tr
 import {useTraceState} from 'sentry/views/performance/newTraceDetails/traceState/traceStateProvider';
 import type {HydratedReplayRecord} from 'sentry/views/replays/types';
 
+import type {TraceMetaQueryResults} from './useTraceMeta';
 import {isEmptyTrace} from './utils';
 
 type UseTraceTreeParams = {
   replay: HydratedReplayRecord | null;
   trace: UseApiQueryResult<TraceTree.Trace | undefined, any>;
+  meta?: TraceMetaQueryResults;
   traceSlug?: string;
 };
 
-export function useTraceTree({trace, replay, traceSlug}: UseTraceTreeParams): TraceTree {
+export function useTraceTree({
+  trace,
+  replay,
+  traceSlug,
+  meta,
+}: UseTraceTreeParams): TraceTree {
   const api = useApi();
   const {projects} = useProjects();
   const organization = useOrganization();
@@ -40,7 +47,16 @@ export function useTraceTree({trace, replay, traceSlug}: UseTraceTreeParams): Tr
               organization
             )
       );
-      traceAnalytics.trackTraceErrorState(organization, traceWaterfallSource);
+
+      const errorStatus: number | null = trace.error?.status ?? null;
+      const metaSpansCount: number | null = meta?.data?.span_count ?? null;
+
+      traceAnalytics.trackTraceErrorState(
+        organization,
+        traceWaterfallSource,
+        errorStatus,
+        metaSpansCount
+      );
       return;
     }
 

--- a/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
+++ b/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
@@ -420,23 +420,12 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
     [onScrollToNode, setRowAsFocused]
   );
 
-  const {
-    data: {hasExceededPerformanceUsageLimit},
-    isLoading: isLoadingSubscriptionDetails,
-  } = usePerformanceSubscriptionDetails();
-
-  const source: TraceWaterFallSource = props.replay ? 'replay_details' : 'trace_view';
-
   useEffect(() => {
     if (props.tree.type !== 'trace' || props.meta.status !== 'success') {
       return;
     }
 
     const traceNode = props.tree.root.children[0];
-
-    if (!traceNode) {
-      throw new Error('Trace is initialized but no trace node is found');
-    }
 
     // TODO Abdullah Khan: Remove this once /trace-meta/ starts responding
     // with the correct spans count for EAP traces.
@@ -454,23 +443,27 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
     }
   }, [props.tree, props.meta]);
 
-  // Callback that is invoked when the trace loads and reaches its initialied state,
-  // that is when the trace tree data and any data that the trace depends on is loaded,
-  // but the trace is not yet rendered in the view.
-  const onTraceLoad = useCallback(() => {
-    const traceNode = props.tree.root.children[0];
+  const {
+    data: {hasExceededPerformanceUsageLimit},
+    isLoading: isLoadingSubscriptionDetails,
+  } = usePerformanceSubscriptionDetails();
 
-    if (!traceNode) {
-      throw new Error('Trace is initialized but no trace node is found');
+  const source: TraceWaterFallSource = props.replay ? 'replay_details' : 'trace_view';
+
+  useEffect(() => {
+    if (props.tree.type !== 'trace') {
+      return;
     }
 
-    const traceTimestamp = traceNode?.space?.[0] ?? (timestamp ? timestamp * 1000 : null);
-    const traceAge = defined(traceTimestamp)
-      ? getRelativeDate(traceTimestamp, 'ago')
-      : 'unknown';
-    const issuesCount = TraceTree.UniqueIssues(traceNode).length;
+    const traceNode = props.tree.root.children[0];
 
-    if (!isLoadingSubscriptionDetails) {
+    if (traceNode && !isLoadingSubscriptionDetails) {
+      const traceTimestamp = traceNode.space[0] ?? (timestamp ? timestamp * 1000 : null);
+      const traceAge = defined(traceTimestamp)
+        ? getRelativeDate(traceTimestamp, 'ago')
+        : 'unknown';
+      const issuesCount = TraceTree.UniqueIssues(traceNode).length;
+
       traceAnalytics.trackTraceShape(
         props.tree,
         projectsRef.current,
@@ -481,6 +474,24 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
         issuesCount,
         props.tree.eap_spans_count
       );
+    }
+  }, [
+    props.tree,
+    hasExceededPerformanceUsageLimit,
+    source,
+    isLoadingSubscriptionDetails,
+    timestamp,
+    props.organization,
+  ]);
+
+  // Callback that is invoked when the trace loads and reaches its initialied state,
+  // that is when the trace tree data and any data that the trace depends on is loaded,
+  // but the trace is not yet rendered in the view.
+  const onTraceLoad = useCallback(() => {
+    const traceNode = props.tree.root.children[0];
+
+    if (!traceNode) {
+      throw new Error('Trace is initialized but no trace node is found');
     }
 
     // The tree has the data fetched, but does not yet respect the user preferences.
@@ -578,10 +589,6 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
     scrollQueueRef,
     props.tree,
     props.organization,
-    hasExceededPerformanceUsageLimit,
-    source,
-    isLoadingSubscriptionDetails,
-    timestamp,
   ]);
 
   // Setup the middleware for the trace reducer

--- a/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
+++ b/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
@@ -579,7 +579,6 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
         action_source: 'load',
       });
     });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     setRowAsFocused,
     traceDispatch,

--- a/static/app/views/replays/detail/trace/trace.tsx
+++ b/static/app/views/replays/detail/trace/trace.tsx
@@ -95,6 +95,7 @@ function NewTraceViewImpl({replay}: {replay: undefined | HydratedReplayRecord}) 
   const meta = useReplayTraceMeta(replay);
   const tree = useTraceTree({
     trace,
+    meta,
     replay: replay ?? null,
   });
   const rootEvent = useTraceRootEvent({


### PR DESCRIPTION
This PR decouples the analytics events from the onTraceLoad, since we don't want the callback to run again when analytics dependencies change.

Adds error status and spans count to the trace error analytics event