### PR TITLE
chore(ACI): Downgrade logger.exception to logger.info for missing detectors

### DIFF
--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -315,9 +315,7 @@ class SubscriptionProcessor:
                     data_sources__type=DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION,
                 )
             except Detector.DoesNotExist:
-                logger.exception(
-                    "Detector not found", extra={"subscription_id": self.subscription.id}
-                )
+                logger.info("Detector not found", extra={"subscription_id": self.subscription.id})
         return detector
 
     def handle_trigger_alerts(

--- a/tests/sentry/incidents/subscription_processor/test_subscription_processor_workflow_engine.py
+++ b/tests/sentry/incidents/subscription_processor/test_subscription_processor_workflow_engine.py
@@ -67,7 +67,7 @@ class ProcessUpdateWorkflowEngineTest(ProcessUpdateComparisonAlertTest):
             "value": trigger.alert_threshold + 1,
             "rule_id": rule.id,
         }
-        assert mock_logger.info.call_count == 1
+        assert mock_logger.info.call_count == 2
         mock_logger.info.assert_called_with(
             "dual processing results for alert rule",
             extra=logger_extra,


### PR DESCRIPTION
Downgrade the logger since it's creating noise in Sentry and it appears to be a really small number of query subscription outliers.