### PR TITLE
chore(autofix): Exclude more useless tags

### DIFF
--- a/src/sentry/seer/autofix/autofix.py
+++ b/src/sentry/seer/autofix/autofix.py
@@ -341,9 +341,18 @@ def _get_all_tags_overview(group: Group) -> dict[str, Any] | None:
 
     all_tags: list[dict] = []
 
-    KEYS_TO_EXCLUDE = ["release"]  # tags we think are useless for Autofix
+    KEYS_TO_EXCLUDE = {
+        "release",
+        "browser.name",  # the 'browser' tag is better
+        "device.class",
+        "mechanism",  # the 'os' tag is better
+        "os.name",
+        "replay_id",
+        "replayid",
+        "level",
+    }  # tags we think are useless for Autofix
     for tag in tag_keys:
-        if tag.key in KEYS_TO_EXCLUDE:
+        if tag.key.lower() in KEYS_TO_EXCLUDE:
             continue
 
         # Calculate percentages for each tag value

--- a/src/sentry/seer/autofix/autofix.py
+++ b/src/sentry/seer/autofix/autofix.py
@@ -345,8 +345,8 @@ def _get_all_tags_overview(group: Group) -> dict[str, Any] | None:
         "release",
         "browser.name",  # the 'browser' tag is better
         "device.class",
-        "mechanism",  # the 'os' tag is better
-        "os.name",
+        "mechanism",
+        "os.name",  # the 'os' tag is better
         "replay_id",
         "replayid",
         "level",

--- a/tests/sentry/seer/autofix/test_autofix.py
+++ b/tests/sentry/seer/autofix/test_autofix.py
@@ -653,8 +653,8 @@ class TestGetAllTagsOverview(TestCase, SnubaTestCase):
         assert result is not None
         assert "tags_overview" in result
 
-        # Should have environment, user_role, service, and level tags at minimum
-        assert len(result["tags_overview"]) >= 4
+        # Should have environment, user_role, and service tags, but not level since it's excluded
+        assert len(result["tags_overview"]) >= 3
 
         # Find specific tags
         tag_keys = {tag["key"]: tag for tag in result["tags_overview"]}


### PR DESCRIPTION
Excluding a few more tags from the distributions we send to Autofix