### PR TITLE
feat(aci): Update cron monitors to use correct config shape

### DIFF
--- a/static/app/views/detectors/components/details/cron/index.tsx
+++ b/static/app/views/detectors/components/details/cron/index.tsx
@@ -19,7 +19,7 @@ type CronDetectorDetailsProps = {
 export function CronDetectorDetails({detector, project}: CronDetectorDetailsProps) {
   const dataSource = detector.dataSources[0];
 
-  const {failureIssueThreshold, recoveryThreshold} = dataSource.queryObj;
+  const {failure_issue_threshold, recovery_threshold} = dataSource.queryObj.config;
 
   return (
     <DetailLayout>
@@ -37,21 +37,24 @@ export function CronDetectorDetails({detector, project}: CronDetectorDetailsProp
             {tn(
               'One failed check-in.',
               '%s consecutive failed check-ins.',
-              failureIssueThreshold
+              failure_issue_threshold ?? 1
             )}
           </Section>
           <Section title={t('Resolve')}>
             {tn(
               'One successful check-in.',
               '%s consecutive successful check-ins.',
-              recoveryThreshold
+              recovery_threshold ?? 1
             )}
           </Section>
           <DetectorDetailsAssignee owner={detector.owner} />
           <DetectorExtraDetails>
+            <KeyValueTableRow
+              keyName={t('Monitor slug')}
+              value={dataSource.queryObj.slug}
+            />
             <KeyValueTableRow keyName={t('Next check-in')} value="TODO" />
             <KeyValueTableRow keyName={t('Last check-in')} value="TODO" />
-            <DetectorExtraDetails.Environment detector={detector} />
             <DetectorExtraDetails.DateCreated detector={detector} />
             <DetectorExtraDetails.CreatedBy detector={detector} />
             <DetectorExtraDetails.LastModified detector={detector} />

--- a/static/app/views/detectors/components/detectorLink.tsx
+++ b/static/app/views/detectors/components/detectorLink.tsx
@@ -12,6 +12,7 @@ import {
   DetectorPriorityLevel,
 } from 'sentry/types/workflowEngine/dataConditions';
 import type {
+  CronDetector,
   Detector,
   MetricDetector,
   UptimeDetector,
@@ -28,6 +29,7 @@ import {getDatasetConfig} from 'sentry/views/detectors/datasetConfig/getDatasetC
 import {makeMonitorDetailsPathname} from 'sentry/views/detectors/pathnames';
 import {detectorTypeIsUserCreateable} from 'sentry/views/detectors/utils/detectorTypeConfig';
 import {getMetricDetectorSuffix} from 'sentry/views/detectors/utils/metricDetectorSuffix';
+import {scheduleAsText} from 'sentry/views/insights/crons/utils/scheduleAsText';
 
 type DetectorLinkProps = {
   detector: Detector;
@@ -170,6 +172,12 @@ function UptimeDetectorDetails({detector}: {detector: UptimeDetector}) {
   );
 }
 
+function CronDetectorDetails({detector}: {detector: CronDetector}) {
+  const config = detector.dataSources[0].queryObj.config;
+
+  return <DetailItem>{scheduleAsText(config)}</DetailItem>;
+}
+
 function Details({detector}: {detector: Detector}) {
   const detectorType = detector.type;
   switch (detectorType) {
@@ -179,6 +187,7 @@ function Details({detector}: {detector: Detector}) {
       return <UptimeDetectorDetails detector={detector} />;
     // TODO: Implement details for Cron detectors
     case 'monitor_check_in_failure':
+      return <CronDetectorDetails detector={detector} />;
     case 'error':
       return null;
     default:

--- a/static/app/views/detectors/components/forms/cron/fields.tsx
+++ b/static/app/views/detectors/components/forms/cron/fields.tsx
@@ -3,9 +3,13 @@ import type {
   CronDetector,
   CronDetectorUpdatePayload,
 } from 'sentry/types/workflowEngine/detectors';
-import {getDetectorEnvironment} from 'sentry/views/detectors/utils/getDetectorEnvironment';
-import {ScheduleType} from 'sentry/views/insights/crons/types';
+import {
+  ScheduleType,
+  type MonitorConfig,
+  type MonitorIntervalUnit,
+} from 'sentry/views/insights/crons/types';
 
+const CRON_DEFAULT_TIMEZONE = 'UTC';
 export const CRON_DEFAULT_SCHEDULE_TYPE = ScheduleType.CRONTAB;
 export const DEFAULT_CRONTAB = '0 0 * * *';
 export const CRON_DEFAULT_SCHEDULE_INTERVAL_VALUE = 1;
@@ -20,7 +24,6 @@ export const CRON_DEFAULT_MAX_RUNTIME = 30;
 
 interface CronDetectorFormData {
   checkinMargin: number | null;
-  environment: string;
   failureIssueThreshold: number;
   maxRuntime: number | null;
   name: string;
@@ -29,7 +32,7 @@ interface CronDetectorFormData {
   projectId: string;
   recoveryThreshold: number;
   scheduleCrontab: string;
-  scheduleIntervalUnit: string;
+  scheduleIntervalUnit: MonitorIntervalUnit;
   scheduleIntervalValue: number;
   scheduleType: 'crontab' | 'interval';
   timezone: string;
@@ -51,6 +54,27 @@ export function useCronDetectorFormField<T extends CronDetectorFormFieldName>(
 export function cronFormDataToEndpointPayload(
   data: CronDetectorFormData
 ): CronDetectorUpdatePayload {
+  const commonConfig = {
+    checkin_margin: data.checkinMargin,
+    failure_issue_threshold: data.failureIssueThreshold,
+    max_runtime: data.maxRuntime,
+    recovery_threshold: data.recoveryThreshold,
+    timezone: data.timezone,
+  };
+
+  const config: MonitorConfig =
+    data.scheduleType === 'crontab'
+      ? {
+          ...commonConfig,
+          schedule: data.scheduleCrontab,
+          schedule_type: ScheduleType.CRONTAB,
+        }
+      : {
+          ...commonConfig,
+          schedule: [data.scheduleIntervalValue, data.scheduleIntervalUnit] as const,
+          schedule_type: ScheduleType.INTERVAL,
+        };
+
   return {
     type: 'monitor_check_in_failure',
     name: data.name,
@@ -58,19 +82,8 @@ export function cronFormDataToEndpointPayload(
     projectId: data.projectId,
     workflowIds: data.workflowIds,
     dataSource: {
-      checkinMargin: data.checkinMargin,
-      failureIssueThreshold: data.failureIssueThreshold,
-      maxRuntime: data.maxRuntime,
-      recoveryThreshold: data.recoveryThreshold,
-      schedule:
-        data.scheduleType === 'crontab'
-          ? data.scheduleCrontab
-          : [data.scheduleIntervalValue, data.scheduleIntervalUnit],
-      scheduleType: data.scheduleType,
-      timezone: data.timezone,
-    },
-    config: {
-      environment: data.environment,
+      name: data.name,
+      config,
     },
   };
 }
@@ -79,32 +92,30 @@ export function cronSavedDetectorToFormData(
   detector: CronDetector
 ): CronDetectorFormData {
   const dataSource = detector.dataSources?.[0];
-  const environment = getDetectorEnvironment(detector) ?? '';
 
   const common = {
     name: detector.name,
-    environment,
     owner: detector.owner || '',
     projectId: detector.projectId,
   };
 
+  const config = dataSource.queryObj.config;
+
   return {
     ...common,
-    checkinMargin: dataSource.queryObj.checkinMargin,
-    failureIssueThreshold: dataSource.queryObj.failureIssueThreshold ?? 1,
-    recoveryThreshold: dataSource.queryObj.recoveryThreshold ?? 1,
-    maxRuntime: dataSource.queryObj.maxRuntime,
-    scheduleCrontab: Array.isArray(dataSource.queryObj.schedule)
-      ? DEFAULT_CRONTAB
-      : dataSource.queryObj.schedule,
-    scheduleIntervalValue: Array.isArray(dataSource.queryObj.schedule)
-      ? dataSource.queryObj.schedule[0]
+    checkinMargin: config.checkin_margin,
+    failureIssueThreshold: config.failure_issue_threshold ?? 1,
+    recoveryThreshold: config.recovery_threshold ?? 1,
+    maxRuntime: config.max_runtime,
+    scheduleCrontab: Array.isArray(config.schedule) ? DEFAULT_CRONTAB : config.schedule,
+    scheduleIntervalValue: Array.isArray(config.schedule)
+      ? config.schedule[0]
       : CRON_DEFAULT_SCHEDULE_INTERVAL_VALUE,
-    scheduleIntervalUnit: Array.isArray(dataSource.queryObj.schedule)
-      ? dataSource.queryObj.schedule[1]
+    scheduleIntervalUnit: Array.isArray(config.schedule)
+      ? config.schedule[1]
       : CRON_DEFAULT_SCHEDULE_INTERVAL_UNIT,
-    scheduleType: dataSource.queryObj.scheduleType,
-    timezone: dataSource.queryObj.timezone,
+    scheduleType: config.schedule_type ?? CRON_DEFAULT_SCHEDULE_TYPE,
+    timezone: config.timezone ?? CRON_DEFAULT_TIMEZONE,
     workflowIds: detector.workflowIds,
   };
 }

--- a/static/app/views/detectors/detail.spec.tsx
+++ b/static/app/views/detectors/detail.spec.tsx
@@ -283,8 +283,6 @@ describe('DetectorDetails', () => {
       expect(screen.getByText('One failed check-in.')).toBeInTheDocument();
       // Recovery threshold: 2
       expect(screen.getByText('2 consecutive successful check-ins.')).toBeInTheDocument();
-      // Environment: production
-      expect(screen.getByText('production')).toBeInTheDocument();
 
       // Connected automation
       expect(await screen.findByText('Automation 1')).toBeInTheDocument();

--- a/static/app/views/detectors/utils/getDetectorEnvironment.tsx
+++ b/static/app/views/detectors/utils/getDetectorEnvironment.tsx
@@ -12,7 +12,8 @@ export function getDetectorEnvironment(detector: Detector): string | null {
     case 'uptime_domain_failure':
       return detector.config.environment ?? null;
     case 'monitor_check_in_failure':
-      return detector.config.environment ?? null;
+      // Crons can have multiple environments
+      return null;
     case 'error':
       return null;
     default:

--- a/static/app/views/insights/crons/types.tsx
+++ b/static/app/views/insights/crons/types.tsx
@@ -73,6 +73,8 @@ interface CrontabConfig extends BaseConfig {
   schedule_type: ScheduleType.CRONTAB | LegacyDefaultSchedule;
 }
 
+export type MonitorIntervalUnit = 'year' | 'month' | 'week' | 'day' | 'hour' | 'minute';
+
 /**
  * The configuration object used when the schedule is an INTERVAL
  */
@@ -80,10 +82,7 @@ export interface IntervalConfig extends BaseConfig {
   /**
    * The interval style schedule
    */
-  schedule: [
-    value: number,
-    interval: 'year' | 'month' | 'week' | 'day' | 'hour' | 'minute',
-  ];
+  schedule: [value: number, interval: MonitorIntervalUnit];
   schedule_type: ScheduleType.INTERVAL;
 }
 

--- a/tests/js/fixtures/detectors.ts
+++ b/tests/js/fixtures/detectors.ts
@@ -4,7 +4,7 @@ import {UserFixture} from 'sentry-fixture/user';
 
 import type {
   CronDetector,
-  CronSubscriptionDataSource,
+  CronMonitorDataSource,
   ErrorDetector,
   MetricDetector,
   SnubaQueryDataSource,
@@ -12,6 +12,7 @@ import type {
   UptimeSubscriptionDataSource,
 } from 'sentry/types/workflowEngine/detectors';
 import {Dataset, EventTypes} from 'sentry/views/alerts/rules/metric/types';
+import {ScheduleType} from 'sentry/views/insights/crons/types';
 
 const BASE_DETECTOR = {
   workflowIds: [],
@@ -124,30 +125,34 @@ export function CronDetectorFixture(params: Partial<CronDetector> = {}): CronDet
     name: 'Cron Detector',
     id: '3',
     type: 'monitor_check_in_failure',
-    config: {
-      environment: 'production',
-    },
-    dataSources: [CronSubscriptionDataSourceFixture()],
+    dataSources: [CronMonitorDataSourceFixture()],
     ...params,
   };
 }
 
-function CronSubscriptionDataSourceFixture(
-  params: Partial<CronSubscriptionDataSource> = {}
-): CronSubscriptionDataSource {
+function CronMonitorDataSourceFixture(
+  params: Partial<CronMonitorDataSource> = {}
+): CronMonitorDataSource {
   return {
     id: '1',
     organizationId: '1',
     sourceId: '1',
-    type: 'cron_subscription',
+    type: 'cron_monitor',
     queryObj: {
-      checkinMargin: null,
-      failureIssueThreshold: 1,
-      recoveryThreshold: 2,
-      maxRuntime: null,
-      schedule: '0 0 * * *',
-      scheduleType: 'crontab',
-      timezone: 'UTC',
+      config: {
+        checkin_margin: null,
+        failure_issue_threshold: 1,
+        recovery_threshold: 2,
+        max_runtime: null,
+        timezone: 'UTC',
+        schedule: '0 0 * * *',
+        schedule_type: ScheduleType.CRONTAB,
+      },
+      isMuted: false,
+      status: 'active',
+      environments: [],
+      isUpserting: false,
+      slug: 'test-monitor',
     },
     ...params,
   };


### PR DESCRIPTION
Modifies the types to use the correct config shape now that the backend has some examples to look at.

There are still quite a few places that need to be updated to use the new data correctly, but I'll leave that for further PRs. You also can't quite create a cron monitor successfully with the API (made a ticket to fix this)

<img width="548" height="342" alt="CleanShot 2025-08-27 at 15 18 04@2x" src="https://github.com/user-attachments/assets/827fb2f5-654f-41b1-ae52-fca3a37a42a0" />
