### PR TITLE
feat(analytics): refactor integration notification analytics events (2)

### DIFF
--- a/src/sentry/analytics/events/inapp_request.py
+++ b/src/sentry/analytics/events/inapp_request.py
@@ -8,7 +8,7 @@ class InAppRequestSentEvent(analytics.Event, abc.ABC):
     organization_id: int
     user_id: int | None = None
     target_user_id: int
-    providers: list[str]
+    providers: str
     subtype: str | None = None
 
 

--- a/src/sentry/analytics/events/inapp_request.py
+++ b/src/sentry/analytics/events/inapp_request.py
@@ -3,26 +3,28 @@ import abc
 from sentry import analytics
 
 
+@analytics.eventclass()
 class InAppRequestSentEvent(analytics.Event, abc.ABC):
-    attributes = [
-        analytics.Attribute("organization_id"),
-        analytics.Attribute("user_id", required=False),
-        analytics.Attribute("target_user_id"),
-        analytics.Attribute("providers"),
-        analytics.Attribute("subtype", required=False),
-    ]
+    organization_id: int
+    user_id: int | None = None
+    target_user_id: int
+    providers: list[str]
+    subtype: str | None = None
 
 
+@analytics.eventclass()
 class InviteOrJoinRequest(InAppRequestSentEvent, abc.ABC):
-    attributes = InAppRequestSentEvent.attributes + [analytics.Attribute("invited_member_id")]
+    invited_member_id: int
 
 
+@analytics.eventclass("invite_request.sent")
 class InviteRequestSentEvent(InviteOrJoinRequest):
-    type = "invite_request.sent"
+    pass
 
 
+@analytics.eventclass("join_request.sent")
 class JoinRequestSentEvent(InviteOrJoinRequest):
-    type = "join_request.sent"
+    pass
 
 
 analytics.register(InviteRequestSentEvent)

--- a/src/sentry/analytics/events/integration_failed_to_fetch_commit_context.py
+++ b/src/sentry/analytics/events/integration_failed_to_fetch_commit_context.py
@@ -1,17 +1,14 @@
 from sentry import analytics
 
 
+@analytics.eventclass("integrations.failed_to_fetch_commit_context")
 class IntegrationsFailedToFetchCommitContext(analytics.Event):
-    type = "integrations.failed_to_fetch_commit_context"
-
-    attributes = (
-        analytics.Attribute("organization_id"),
-        analytics.Attribute("project_id"),
-        analytics.Attribute("code_mapping_id"),
-        analytics.Attribute("group_id"),
-        analytics.Attribute("provider", type=str),
-        analytics.Attribute("error_message", type=str),
-    )
+    organization_id: int
+    project_id: int
+    code_mapping_id: int
+    group_id: int
+    provider: str
+    error_message: str
 
 
 analytics.register(IntegrationsFailedToFetchCommitContext)

--- a/src/sentry/analytics/events/integration_pipeline_step.py
+++ b/src/sentry/analytics/events/integration_pipeline_step.py
@@ -1,16 +1,13 @@
 from sentry import analytics
 
 
+@analytics.eventclass("integrations.pipeline_step")
 class IntegrationPipelineStep(analytics.Event):
-    type = "integrations.pipeline_step"
-
-    attributes = (
-        analytics.Attribute("user_id"),
-        analytics.Attribute("organization_id"),
-        analytics.Attribute("integration"),
-        analytics.Attribute("step_index"),
-        analytics.Attribute("pipeline_type"),
-    )
+    user_id: int
+    organization_id: int
+    integration: str
+    step_index: int
+    pipeline_type: str
 
 
 analytics.register(IntegrationPipelineStep)

--- a/src/sentry/analytics/events/integration_pipeline_step.py
+++ b/src/sentry/analytics/events/integration_pipeline_step.py
@@ -3,7 +3,7 @@ from sentry import analytics
 
 @analytics.eventclass("integrations.pipeline_step")
 class IntegrationPipelineStep(analytics.Event):
-    user_id: int
+    user_id: int | None = None
     organization_id: int
     integration: str
     step_index: int

--- a/src/sentry/analytics/events/missing_members_nudge.py
+++ b/src/sentry/analytics/events/missing_members_nudge.py
@@ -1,13 +1,9 @@
-import abc
-
 from sentry import analytics
 
 
-class MissingMembersNudgeEvent(analytics.Event, abc.ABC):
-    type = "missing_members_nudge.sent"
-    attributes = [
-        analytics.Attribute("organization_id"),
-    ]
+@analytics.eventclass("missing_members_nudge.sent")
+class MissingMembersNudgeEvent(analytics.Event):
+    organization_id: int
 
 
 analytics.register(MissingMembersNudgeEvent)

--- a/src/sentry/integrations/discord/analytics.py
+++ b/src/sentry/integrations/discord/analytics.py
@@ -1,65 +1,50 @@
 from sentry import analytics
 
 
+@analytics.eventclass("integrations.discord.notification_sent")
 class DiscordIntegrationNotificationSent(analytics.Event):
-    type = "integrations.discord.notification_sent"
-
-    attributes = (
-        analytics.Attribute("organization_id"),
-        analytics.Attribute("project_id"),
-        analytics.Attribute("category"),
-        analytics.Attribute("group_id"),
-        analytics.Attribute("notification_uuid"),
-        analytics.Attribute("alert_id", required=False),
-    )
+    organization_id: int
+    project_id: int | None = None
+    category: str
+    group_id: int | None = None
+    notification_uuid: str
+    alert_id: int | None = None
 
 
+@analytics.eventclass("integrations.discord.command_interaction")
 class DiscordIntegrationCommandInteractionReceived(analytics.Event):
-    type = "integrations.discord.command_interaction"
-
-    attributes = (analytics.Attribute("command_name"),)
+    command_name: str
 
 
+@analytics.eventclass("integrations.discord.identity_linked")
 class DiscordIntegrationIdentityLinked(analytics.Event):
-    type = "integrations.discord.identity_linked"
-
-    attributes = (
-        analytics.Attribute("provider"),
-        analytics.Attribute("actor_id"),
-        analytics.Attribute("actor_type"),
-    )
+    provider: str
+    actor_id: int
+    actor_type: str
 
 
+@analytics.eventclass("integrations.discord.identity_unlinked")
 class DiscordIntegrationIdentityUnlinked(analytics.Event):
-    type = "integrations.discord.identity_unlinked"
-
-    attributes = (
-        analytics.Attribute("provider"),
-        analytics.Attribute("actor_id"),
-        analytics.Attribute("actor_type"),
-    )
+    provider: str
+    actor_id: int
+    actor_type: str
 
 
+@analytics.eventclass("integrations.discord.message_interaction")
 class DiscordIntegrationMessageInteractionReceived(analytics.Event):
-    type = "integrations.discord.message_interaction"
-
-    attributes = (analytics.Attribute("custom_id"),)
+    custom_id: str
 
 
+@analytics.eventclass("integrations.discord.assign")
 class DiscordIntegrationAssign(analytics.Event):
-    type = "integrations.discord.assign"
-
-    attributes = (analytics.Attribute("actor_id"),)
+    actor_id: int
 
 
+@analytics.eventclass("integrations.discord.status")
 class DiscordIntegrationStatus(analytics.Event):
-    type = "integrations.discord.status"
-
-    attributes = (
-        analytics.Attribute("organization_id"),
-        analytics.Attribute("user_id"),
-        analytics.Attribute("status"),
-    )
+    organization_id: int
+    user_id: int
+    status: str
 
 
 analytics.register(DiscordIntegrationCommandInteractionReceived)

--- a/src/sentry/integrations/discord/views/link_identity.py
+++ b/src/sentry/integrations/discord/views/link_identity.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from django.urls import reverse
 
+from sentry import analytics
 from sentry.integrations.discord.views.linkage import DiscordIdentityLinkageView
 from sentry.integrations.messaging.linkage import LinkIdentityView
 from sentry.integrations.models.integration import Integration
@@ -34,6 +35,13 @@ class DiscordLinkIdentityView(DiscordIdentityLinkageView, LinkIdentityView):
             "guild_id": integration.external_id,
         }
 
-    @property
-    def analytics_operation_key(self) -> str | None:
-        return "identity_linked"
+    def get_analytics_event(
+        self, provider: str, actor_id: int, actor_type: str
+    ) -> analytics.Event | None:
+        from sentry.integrations.discord.analytics import DiscordIntegrationIdentityLinked
+
+        return DiscordIntegrationIdentityLinked(
+            provider=provider,
+            actor_id=actor_id,
+            actor_type=actor_type,
+        )

--- a/src/sentry/integrations/discord/views/unlink_identity.py
+++ b/src/sentry/integrations/discord/views/unlink_identity.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from django.urls import reverse
 
+from sentry import analytics
 from sentry.integrations.discord.views.linkage import DiscordIdentityLinkageView
 from sentry.integrations.messaging.linkage import UnlinkIdentityView
 from sentry.integrations.models.integration import Integration
@@ -28,6 +29,13 @@ class DiscordUnlinkIdentityView(DiscordIdentityLinkageView, UnlinkIdentityView):
     ) -> tuple[str, dict[str, Any]]:
         return "sentry/integrations/discord/unlinked.html", {}
 
-    @property
-    def analytics_operation_key(self) -> str | None:
-        return "identity_unlinked"
+    def get_analytics_event(
+        self, provider: str, actor_id: int, actor_type: str
+    ) -> analytics.Event | None:
+        from sentry.integrations.discord.analytics import DiscordIntegrationIdentityUnlinked
+
+        return DiscordIntegrationIdentityUnlinked(
+            provider=provider,
+            actor_id=actor_id,
+            actor_type=actor_type,
+        )

--- a/src/sentry/integrations/discord/webhooks/message_component.py
+++ b/src/sentry/integrations/discord/webhooks/message_component.py
@@ -7,6 +7,7 @@ from rest_framework.response import Response
 
 from sentry import analytics
 from sentry.api.helpers.group_index.update import update_groups
+from sentry.integrations.discord.analytics import DiscordIntegrationStatus
 from sentry.integrations.discord.message_builder.base.base import DiscordMessageBuilder
 from sentry.integrations.discord.message_builder.base.component import (
     DiscordComponentCustomIds as CustomIds,
@@ -241,10 +242,11 @@ class DiscordMessageComponentHandler(DiscordInteractionHandler):
     def update_group(self, data: Mapping[str, object]) -> None:
         if self.group:
             analytics.record(
-                "integrations.discord.status",
-                organization_id=self.group.organization.id,
-                user_id=self.user.id,
-                status=data,
+                DiscordIntegrationStatus(
+                    organization_id=self.group.organization.id,
+                    user_id=self.user.id,
+                    status=str(data),
+                )
             )
             update_groups(
                 request=self.request.request, groups=[self.group], user=self.user, data=data

--- a/src/sentry/integrations/messaging/linkage.py
+++ b/src/sentry/integrations/messaging/linkage.py
@@ -86,22 +86,14 @@ class LinkageView(BaseView, ABC):
         metrics.incr(event, tags=(tags or {}), sample_rate=1.0)
         return event
 
-    @property
-    def analytics_operation_key(self) -> str | None:
-        """Operation description to use in analytics. Return None to skip."""
+    def get_analytics_event(
+        self, provider: str, actor_id: int, actor_type: str
+    ) -> analytics.Event | None:
         return None
 
     def record_analytic(self, actor_id: int) -> None:
-        if self.analytics_operation_key is None:
-            # This preserves legacy differences between messaging integrations,
-            # in that some record analytics and some don't.
-            # TODO: Make consistent across all messaging integrations.
-            return
-
-        event = ".".join(("integrations", self.provider_slug, self.analytics_operation_key))
-        analytics.record(
-            event, provider=self.provider_slug, actor_id=actor_id, actor_type=ActorType.USER
-        )
+        if event := self.get_analytics_event(self.provider_slug, actor_id, ActorType.USER):
+            analytics.record(event)
 
     @staticmethod
     def render_error_page(request: HttpRequest, status: int, body_text: str) -> HttpResponse:
@@ -399,6 +391,7 @@ class LinkTeamView(TeamLinkageView, ABC):
     def execute(
         self, request: HttpRequest, integration: RpcIntegration, params: Mapping[str, Any]
     ) -> HttpResponseBase:
+        from sentry.integrations.slack.analytics import IntegrationIdentityLinked
         from sentry.integrations.slack.views.link_team import (
             SUCCESS_LINKED_MESSAGE,
             SUCCESS_LINKED_TITLE,
@@ -497,10 +490,11 @@ class LinkTeamView(TeamLinkageView, ABC):
         )
 
         analytics.record(
-            "integrations.identity_linked",
-            provider=self.provider_slug,
-            actor_id=team.id,
-            actor_type="team",
+            IntegrationIdentityLinked(
+                provider=self.provider_slug,
+                actor_id=team.id,
+                actor_type="team",
+            )
         )
 
         if not created:

--- a/src/sentry/integrations/msteams/analytics.py
+++ b/src/sentry/integrations/msteams/analytics.py
@@ -1,18 +1,15 @@
 from sentry import analytics
 
 
+@analytics.eventclass("integrations.msteams.notification_sent")
 class MSTeamsIntegrationNotificationSent(analytics.Event):
-    type = "integrations.msteams.notification_sent"
-
-    attributes = (
-        analytics.Attribute("organization_id"),
-        analytics.Attribute("project_id", required=False),
-        analytics.Attribute("category"),
-        analytics.Attribute("actor_id", required=False),
-        analytics.Attribute("user_id", required=False),
-        analytics.Attribute("notification_uuid"),
-        analytics.Attribute("alert_id", required=False),
-    )
+    organization_id: int
+    project_id: int | None = None
+    category: str
+    actor_id: int | None = None
+    user_id: int | None = None
+    notification_uuid: str
+    alert_id: int | None = None
 
 
 analytics.register(MSTeamsIntegrationNotificationSent)

--- a/src/sentry/integrations/opsgenie/analytics.py
+++ b/src/sentry/integrations/opsgenie/analytics.py
@@ -1,17 +1,14 @@
 from sentry import analytics
 
 
+@analytics.eventclass("integrations.opsgenie.notification_sent")
 class OpsgenieIntegrationNotificationSent(analytics.Event):
-    type = "integrations.opsgenie.notification_sent"
-
-    attributes = (
-        analytics.Attribute("organization_id"),
-        analytics.Attribute("project_id"),
-        analytics.Attribute("category"),
-        analytics.Attribute("group_id"),
-        analytics.Attribute("notification_uuid"),
-        analytics.Attribute("alert_id", required=False),
-    )
+    organization_id: int
+    project_id: int | None = None
+    category: str
+    group_id: int | None = None
+    notification_uuid: str
+    alert_id: int | None = None
 
 
 analytics.register(OpsgenieIntegrationNotificationSent)

--- a/src/sentry/integrations/pagerduty/analytics.py
+++ b/src/sentry/integrations/pagerduty/analytics.py
@@ -1,17 +1,14 @@
 from sentry import analytics
 
 
+@analytics.eventclass("integrations.pagerduty.notification_sent")
 class PagerdutyIntegrationNotificationSent(analytics.Event):
-    type = "integrations.pagerduty.notification_sent"
-
-    attributes = (
-        analytics.Attribute("organization_id"),
-        analytics.Attribute("project_id"),
-        analytics.Attribute("category"),
-        analytics.Attribute("group_id"),
-        analytics.Attribute("notification_uuid"),
-        analytics.Attribute("alert_id", required=False),
-    )
+    organization_id: int
+    project_id: int | None = None
+    category: str
+    group_id: int | None = None
+    notification_uuid: str
+    alert_id: int | None = None
 
 
 analytics.register(PagerdutyIntegrationNotificationSent)

--- a/src/sentry/integrations/slack/analytics.py
+++ b/src/sentry/integrations/slack/analytics.py
@@ -1,81 +1,63 @@
 from sentry import analytics
 
 
+@analytics.eventclass("integrations.slack.assign")
 class SlackIntegrationAssign(analytics.Event):
-    type = "integrations.slack.assign"
-
-    attributes = (analytics.Attribute("actor_id", required=False),)
+    actor_id: int | None = None
 
 
+@analytics.eventclass("integrations.slack.status")
 class SlackIntegrationStatus(analytics.Event):
-    type = "integrations.slack.status"
-
-    attributes = (
-        analytics.Attribute("organization_id"),
-        analytics.Attribute("status"),
-        analytics.Attribute("resolve_type", required=False),
-        analytics.Attribute("user_id", required=False),
-    )
+    organization_id: int
+    status: str
+    resolve_type: str | None = None
+    user_id: int | None = None
 
 
+@analytics.eventclass("integrations.slack.notification_sent")
 class SlackIntegrationNotificationSent(analytics.Event):
-    type = "integrations.slack.notification_sent"
-
-    attributes = (
-        analytics.Attribute("organization_id"),
-        analytics.Attribute("project_id", required=False),
-        analytics.Attribute("category"),
-        analytics.Attribute("actor_id", required=False),
-        analytics.Attribute("user_id", required=False),
-        analytics.Attribute("group_id", required=False),
-        analytics.Attribute("notification_uuid"),
-        analytics.Attribute("alert_id", required=False),
-        analytics.Attribute("actor_type", required=False),
-    )
+    organization_id: int
+    project_id: int | None = None
+    category: str
+    actor_id: int | None = None
+    user_id: int | None = None
+    group_id: int | None = None
+    notification_uuid: str
+    alert_id: int | None = None
+    actor_type: str | None = None
 
 
+@analytics.eventclass("integrations.slack.identity_linked")
 class IntegrationIdentityLinked(analytics.Event):
-    type = "integrations.identity_linked"
-
-    attributes = (
-        analytics.Attribute("provider"),
-        analytics.Attribute("actor_id"),
-        analytics.Attribute("actor_type"),
-    )
+    provider: str
+    actor_id: int
+    actor_type: str
 
 
+@analytics.eventclass("integrations.slack.chart_unfurl")
 class IntegrationSlackChartUnfurl(analytics.Event):
-    type = "integrations.slack.chart_unfurl"
-
-    attributes = (
-        analytics.Attribute("user_id", required=False),
-        analytics.Attribute("organization_id"),
-        analytics.Attribute("unfurls_count", type=int),
-    )
+    user_id: int | None = None
+    organization_id: int
+    unfurls_count: int
 
 
+@analytics.eventclass("integrations.slack.chart_unfurl_action")
 class IntegrationSlackLinkIdentity(analytics.Event):
-    type = "integrations.slack.chart_unfurl_action"
-
-    attributes = (
-        analytics.Attribute("organization_id"),
-        analytics.Attribute("action"),
-    )
+    organization_id: int
+    action: str
 
 
+@analytics.eventclass("integrations.slack.approve_member_invitation")
 class IntegrationSlackApproveMemberInvitation(analytics.Event):
-    type = "integrations.slack.approve_member_invitation"
-
-    attributes = (
-        analytics.Attribute("organization_id"),
-        analytics.Attribute("actor_id"),
-        analytics.Attribute("invitation_type"),
-        analytics.Attribute("invited_member_id"),
-    )
+    organization_id: int
+    actor_id: int
+    invitation_type: str
+    invited_member_id: int
 
 
+@analytics.eventclass("integrations.slack.reject_member_invitation")
 class IntegrationSlackRejectMemberInvitation(IntegrationSlackApproveMemberInvitation):
-    type = "integrations.slack.reject_member_invitation"
+    pass
 
 
 analytics.register(SlackIntegrationAssign)

--- a/src/sentry/mail/analytics.py
+++ b/src/sentry/mail/analytics.py
@@ -2,21 +2,18 @@ from sentry import analytics
 
 
 # TODO: should have same base class as SlackIntegrationNotificationSent
+@analytics.eventclass("integrations.email.notification_sent")
 class EmailNotificationSent(analytics.Event):
-    type = "integrations.email.notification_sent"
-
-    attributes = (
-        analytics.Attribute("organization_id"),
-        analytics.Attribute("project_id", required=False),
-        analytics.Attribute("category"),
-        analytics.Attribute("actor_id", required=False),
-        analytics.Attribute("user_id", required=False),
-        analytics.Attribute("group_id", required=False),
-        analytics.Attribute("id"),
-        analytics.Attribute("actor_type"),
-        analytics.Attribute("notification_uuid"),
-        analytics.Attribute("alert_id", required=False),
-    )
+    organization_id: int
+    project_id: int | None = None
+    category: str
+    actor_id: int | None = None
+    user_id: int | None = None
+    group_id: int | None = None
+    id: int
+    actor_type: str
+    notification_uuid: str
+    alert_id: int | None = None
 
 
 analytics.register(EmailNotificationSent)

--- a/src/sentry/notifications/notifications/activity/release.py
+++ b/src/sentry/notifications/notifications/activity/release.py
@@ -36,7 +36,6 @@ class ReleaseActivityNotification(ActivityNotification):
 
     def __init__(self, activity: Activity) -> None:
         super().__init__(activity)
-        self.group = None
         self.user_id_team_lookup: Mapping[int, list[int]] | None = None
         self.deploy = get_deploy(activity)
         self.release = get_release(activity, self.organization)

--- a/src/sentry/notifications/notifications/base.py
+++ b/src/sentry/notifications/notifications/base.py
@@ -10,7 +10,6 @@ import sentry_sdk
 
 from sentry import analytics
 from sentry.db.models import Model
-from sentry.integrations.msteams.analytics import MSTeamsIntegrationNotificationSent
 from sentry.integrations.types import EXTERNAL_PROVIDERS, ExternalProviders
 from sentry.mail.analytics import EmailNotificationSent
 from sentry.models.environment import Environment
@@ -177,6 +176,7 @@ class BaseNotification(abc.ABC):
 
     def record_notification_sent(self, recipient: Actor, provider: ExternalProviders) -> None:
         from sentry.integrations.discord.analytics import DiscordIntegrationNotificationSent
+        from sentry.integrations.msteams.analytics import MSTeamsIntegrationNotificationSent
         from sentry.integrations.opsgenie.analytics import OpsgenieIntegrationNotificationSent
         from sentry.integrations.pagerduty.analytics import PagerdutyIntegrationNotificationSent
         from sentry.integrations.slack.analytics import SlackIntegrationNotificationSent

--- a/src/sentry/notifications/notifications/base.py
+++ b/src/sentry/notifications/notifications/base.py
@@ -10,6 +10,7 @@ import sentry_sdk
 
 from sentry import analytics
 from sentry.db.models import Model
+from sentry.integrations.msteams.analytics import MSTeamsIntegrationNotificationSent
 from sentry.integrations.types import EXTERNAL_PROVIDERS, ExternalProviders
 from sentry.mail.analytics import EmailNotificationSent
 from sentry.models.environment import Environment
@@ -192,6 +193,7 @@ class BaseNotification(abc.ABC):
                 ExternalProviders.PAGERDUTY: PagerdutyIntegrationNotificationSent,
                 ExternalProviders.OPSGENIE: OpsgenieIntegrationNotificationSent,
                 ExternalProviders.DISCORD: DiscordIntegrationNotificationSent,
+                ExternalProviders.MSTEAMS: MSTeamsIntegrationNotificationSent,
             }
 
             try:

--- a/src/sentry/notifications/notifications/base.py
+++ b/src/sentry/notifications/notifications/base.py
@@ -10,10 +10,6 @@ import sentry_sdk
 
 from sentry import analytics
 from sentry.db.models import Model
-from sentry.integrations.discord.analytics import DiscordIntegrationNotificationSent
-from sentry.integrations.opsgenie.analytics import OpsgenieIntegrationNotificationSent
-from sentry.integrations.pagerduty.analytics import PagerdutyIntegrationNotificationSent
-from sentry.integrations.slack.analytics import SlackIntegrationNotificationSent
 from sentry.integrations.types import EXTERNAL_PROVIDERS, ExternalProviders
 from sentry.mail.analytics import EmailNotificationSent
 from sentry.models.environment import Environment
@@ -174,6 +170,11 @@ class BaseNotification(abc.ABC):
         analytics.record(event_name, *args, **kwargs)
 
     def record_notification_sent(self, recipient: Actor, provider: ExternalProviders) -> None:
+        from sentry.integrations.discord.analytics import DiscordIntegrationNotificationSent
+        from sentry.integrations.opsgenie.analytics import OpsgenieIntegrationNotificationSent
+        from sentry.integrations.pagerduty.analytics import PagerdutyIntegrationNotificationSent
+        from sentry.integrations.slack.analytics import SlackIntegrationNotificationSent
+
         with sentry_sdk.start_span(op="notification.send", name="record_notification_sent"):
 
             if provider == ExternalProviders.EMAIL:

--- a/src/sentry/notifications/notifications/missing_members_nudge.py
+++ b/src/sentry/notifications/notifications/missing_members_nudge.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from collections.abc import Iterable, Mapping, MutableMapping, Sequence
 from typing import Any
 
+from sentry import analytics
+from sentry.analytics.events.missing_members_nudge import MissingMembersNudgeEvent
 from sentry.db.models.base import Model
 from sentry.integrations.types import ExternalProviders, IntegrationProviderSlug
 from sentry.models.organization import Organization
@@ -18,8 +20,12 @@ PROVIDER_TO_URL = {IntegrationProviderSlug.GITHUB.value: "https://github.com/"}
 
 class MissingMembersNudgeNotification(BaseNotification):
     metrics_key = "missing_members_nudge"
-    analytics_event = "missing_members_nudge.sent"
     template_path = "sentry/emails/missing-members-nudge"
+
+    def get_specific_analytics_event(self, provider: ExternalProviders) -> analytics.Event | None:
+        return MissingMembersNudgeEvent(
+            organization_id=self.organization.id,
+        )
 
     RoleBasedRecipientStrategyClass = MemberWriteRoleRecipientStrategy
     notification_setting_type_enum = NotificationSettingEnum.APPROVAL

--- a/src/sentry/notifications/notifications/organization_request/invite_request.py
+++ b/src/sentry/notifications/notifications/organization_request/invite_request.py
@@ -22,7 +22,7 @@ class InviteRequestNotification(AbstractInviteRequestNotification):
             organization_id=self.organization.id,
             user_id=self.requester.id,
             target_user_id=self.pending_member.id,
-            providers=[provider.name.lower() if provider.name else ""],
+            providers=provider.name.lower() if provider.name else "",
             subtype=self.metrics_key,
             invited_member_id=self.pending_member.id,
         )

--- a/src/sentry/notifications/notifications/organization_request/invite_request.py
+++ b/src/sentry/notifications/notifications/organization_request/invite_request.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from sentry import analytics
+from sentry.analytics.events.inapp_request import InviteRequestSentEvent
 from sentry.integrations.types import ExternalProviders
 from sentry.notifications.class_manager import register
 from sentry.types.actor import Actor
@@ -9,9 +11,21 @@ from .abstract_invite_request import AbstractInviteRequestNotification
 
 @register()
 class InviteRequestNotification(AbstractInviteRequestNotification):
-    analytics_event = "invite_request.sent"
     metrics_key = "invite_request"
     template_path = "sentry/emails/organization-invite-request"
+
+    def get_specific_analytics_event(self, provider: ExternalProviders) -> analytics.Event | None:
+        """
+        Returns the specific analytics event for the provider.
+        """
+        return InviteRequestSentEvent(
+            organization_id=self.organization.id,
+            user_id=self.requester.id,
+            target_user_id=self.pending_member.id,
+            providers=[provider.name.lower() if provider.name else ""],
+            subtype=self.metrics_key,
+            invited_member_id=self.pending_member.id,
+        )
 
     def build_attachment_title(self, recipient: Actor) -> str:
         return "Request to Invite"

--- a/src/sentry/notifications/notifications/organization_request/join_request.py
+++ b/src/sentry/notifications/notifications/organization_request/join_request.py
@@ -22,7 +22,7 @@ class JoinRequestNotification(AbstractInviteRequestNotification):
             organization_id=self.organization.id,
             user_id=self.requester.id,
             target_user_id=self.pending_member.id,
-            providers=[provider.name.lower() if provider.name else ""],
+            providers=provider.name.lower() if provider.name else "",
             subtype=self.metrics_key,
             invited_member_id=self.pending_member.id,
         )

--- a/src/sentry/notifications/notifications/organization_request/join_request.py
+++ b/src/sentry/notifications/notifications/organization_request/join_request.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from sentry import analytics
+from sentry.analytics.events.inapp_request import JoinRequestSentEvent
 from sentry.integrations.types import ExternalProviders
 from sentry.notifications.class_manager import register
 from sentry.types.actor import Actor
@@ -9,9 +11,21 @@ from .abstract_invite_request import AbstractInviteRequestNotification
 
 @register()
 class JoinRequestNotification(AbstractInviteRequestNotification):
-    analytics_event = "join_request.sent"
     metrics_key = "join_request"
     template_path = "sentry/emails/organization-join-request"
+
+    def get_specific_analytics_event(self, provider: ExternalProviders) -> analytics.Event | None:
+        """
+        Returns the specific analytics event for the provider.
+        """
+        return JoinRequestSentEvent(
+            organization_id=self.organization.id,
+            user_id=self.requester.id,
+            target_user_id=self.pending_member.id,
+            providers=[provider.name.lower() if provider.name else ""],
+            subtype=self.metrics_key,
+            invited_member_id=self.pending_member.id,
+        )
 
     def build_attachment_title(self, recipient: Actor) -> str:
         return "Request to Join"

--- a/src/sentry/users/models/identity.py
+++ b/src/sentry/users/models/identity.py
@@ -89,6 +89,8 @@ class IdentityManager(BaseManager["Identity"]):
         the case where the user is linked to a different identity or the
         identity is linked to a different user.
         """
+        from sentry.integrations.slack.analytics import IntegrationIdentityLinked
+
         defaults = {
             **(defaults or {}),
             "status": IdentityStatus.VALID,
@@ -106,12 +108,13 @@ class IdentityManager(BaseManager["Identity"]):
             return self.reattach(idp, external_id, user, defaults)
 
         analytics.record(
-            "integrations.identity_linked",
-            provider=IntegrationProviderSlug.SLACK.value,
-            # Note that prior to circa March 2023 this was user.actor_id. It changed
-            # when actor ids were no longer stable between regions for the same user
-            actor_id=user.id,
-            actor_type="user",
+            IntegrationIdentityLinked(
+                provider=IntegrationProviderSlug.SLACK.value,
+                # Note that prior to circa March 2023 this was user.actor_id. It changed
+                # when actor ids were no longer stable between regions for the same user
+                actor_id=user.id,
+                actor_type="user",
+            )
         )
         return identity
 

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -5,7 +5,7 @@ from collections.abc import Mapping, Sequence
 from datetime import UTC, datetime, timedelta
 from functools import cached_property
 from unittest import mock
-from unittest.mock import ANY, MagicMock
+from unittest.mock import MagicMock
 
 from django.contrib.auth.models import AnonymousUser
 from django.core import mail
@@ -22,6 +22,7 @@ from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence
 from sentry.issues.ownership import grammar
 from sentry.issues.ownership.grammar import Matcher, Owner, dump_schema
 from sentry.mail import build_subject_prefix, mail_adapter
+from sentry.mail.analytics import EmailNotificationSent
 from sentry.models.activity import Activity
 from sentry.models.grouprelease import GroupRelease
 from sentry.models.options.project_option import ProjectOption
@@ -43,7 +44,10 @@ from sentry.plugins.base import Notification
 from sentry.replays.testutils import mock_replay
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import PerformanceIssueTestCase, ReplaysSnubaTestCase, TestCase
-from sentry.testutils.helpers.analytics import assert_last_analytics_event
+from sentry.testutils.helpers.analytics import (
+    assert_any_analytics_event,
+    assert_last_analytics_event,
+)
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import assume_test_silo_mode
@@ -181,19 +185,27 @@ class MailAdapterNotifyTest(BaseMailAdapterTest):
         assert isinstance(msg.alternatives[0][0], str)
         assert "my rule" in msg.alternatives[0][0]
         assert "notification_uuid" in msg.body
-        mock_record.assert_any_call(
-            "integrations.email.notification_sent",
-            category="issue_alert",
-            target_type=ANY,
-            target_identifier=None,
-            project_id=self.project.id,
-            organization_id=self.organization.id,
-            group_id=event.group_id,
-            user_id=ANY,
-            id=ANY,
-            actor_type="User",
-            notification_uuid=ANY,
-            alert_id=rule.id,
+        assert_any_analytics_event(
+            mock_record,
+            EmailNotificationSent(
+                organization_id=self.organization.id,
+                project_id=self.project.id,
+                category="issue_alert",
+                group_id=event.group_id,
+                user_id=0,
+                id=0,
+                actor_type="User",
+                notification_uuid="",
+                alert_id=rule.id,
+            ),
+            exclude_fields=[
+                "id",
+                "project_id",
+                "actor_id",
+                "user_id",
+                "notification_uuid",
+                "alert_id",
+            ],
         )
         assert_last_analytics_event(
             mock_record,

--- a/tests/sentry/notifications/test_notifications.py
+++ b/tests/sentry/notifications/test_notifications.py
@@ -15,6 +15,8 @@ from slack_sdk.web import SlackResponse
 
 from sentry.event_manager import EventManager
 from sentry.eventstream.types import EventStreamEventType
+from sentry.integrations.slack.analytics import SlackIntegrationNotificationSent
+from sentry.mail.analytics import EmailNotificationSent
 from sentry.models.activity import Activity
 from sentry.models.group import Group, GroupStatus
 from sentry.models.groupassignee import GroupAssignee
@@ -25,6 +27,7 @@ from sentry.notifications.notifications.activity.regression import RegressionAct
 from sentry.silo.base import SiloMode
 from sentry.tasks.post_process import post_process_group
 from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers.analytics import assert_any_analytics_event
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.helpers.eventprocessing import write_event_to_cache
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
@@ -264,22 +267,30 @@ class ActivityNotificationTest(APITestCase):
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=resolved_activity-slack-user&notification_uuid={notification_uuid}&organizationId={self.organization.id}|Notification Settings>"
         )
 
-        assert self.analytics_called_with_args(
+        assert_any_analytics_event(
             record_analytics,
-            "integrations.email.notification_sent",
-            user_id=self.user.id,
-            organization_id=self.organization.id,
-            group_id=self.group.id,
-            notification_uuid=notification_uuid,
+            EmailNotificationSent(
+                user_id=self.user.id,
+                organization_id=self.organization.id,
+                group_id=self.group.id,
+                notification_uuid=notification_uuid,
+                category="",
+                id=0,
+                actor_type="User",
+            ),
+            exclude_fields=["category", "id", "project_id", "actor_id", "actor_type"],
         )
-        assert self.analytics_called_with_args(
+        assert_any_analytics_event(
             record_analytics,
-            "integrations.slack.notification_sent",
-            user_id=self.user.id,
-            organization_id=self.organization.id,
-            group_id=self.group.id,
-            notification_uuid=notification_uuid,
-            actor_type="User",
+            SlackIntegrationNotificationSent(
+                user_id=self.user.id,
+                organization_id=self.organization.id,
+                group_id=self.group.id,
+                notification_uuid=notification_uuid,
+                actor_type="User",
+                category="",
+            ),
+            exclude_fields=["category", "project_id", "actor_id", "actor_type"],
         )
 
     @patch("sentry.analytics.record")
@@ -331,22 +342,30 @@ class ActivityNotificationTest(APITestCase):
             footer
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/deploy/?referrer=release_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
         )
-        assert self.analytics_called_with_args(
+        assert_any_analytics_event(
             record_analytics,
-            "integrations.email.notification_sent",
-            user_id=self.user.id,
-            organization_id=self.organization.id,
-            group_id=None,
-            notification_uuid=notification_uuid,
+            EmailNotificationSent(
+                user_id=self.user.id,
+                organization_id=self.organization.id,
+                group_id=None,
+                notification_uuid=notification_uuid,
+                category="",
+                id=0,
+                actor_type="User",
+            ),
+            exclude_fields=["category", "id", "project_id", "actor_id", "actor_type"],
         )
-        assert self.analytics_called_with_args(
+        assert_any_analytics_event(
             record_analytics,
-            "integrations.slack.notification_sent",
-            user_id=self.user.id,
-            organization_id=self.organization.id,
-            group_id=None,
-            notification_uuid=notification_uuid,
-            actor_type="User",
+            SlackIntegrationNotificationSent(
+                user_id=self.user.id,
+                organization_id=self.organization.id,
+                group_id=None,
+                notification_uuid=notification_uuid,
+                actor_type="User",
+                category="",
+            ),
+            exclude_fields=["category", "project_id", "actor_id", "actor_type"],
         )
 
     @patch("sentry.analytics.record")
@@ -399,22 +418,30 @@ class ActivityNotificationTest(APITestCase):
             footer
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=regression_activity-slack-user&notification_uuid={notification_uuid}&organizationId={self.organization.id}|Notification Settings>"
         )
-        assert self.analytics_called_with_args(
+        assert_any_analytics_event(
             record_analytics,
-            "integrations.email.notification_sent",
-            user_id=self.user.id,
-            organization_id=self.organization.id,
-            group_id=group.id,
-            notification_uuid=notification_uuid,
+            EmailNotificationSent(
+                user_id=self.user.id,
+                organization_id=self.organization.id,
+                group_id=group.id,
+                notification_uuid=notification_uuid,
+                category="",
+                id=0,
+                actor_type="User",
+            ),
+            exclude_fields=["category", "id", "project_id", "actor_id", "actor_type"],
         )
-        assert self.analytics_called_with_args(
+        assert_any_analytics_event(
             record_analytics,
-            "integrations.slack.notification_sent",
-            user_id=self.user.id,
-            organization_id=self.organization.id,
-            group_id=group.id,
-            notification_uuid=notification_uuid,
-            actor_type="User",
+            SlackIntegrationNotificationSent(
+                user_id=self.user.id,
+                organization_id=self.organization.id,
+                group_id=group.id,
+                notification_uuid=notification_uuid,
+                actor_type="User",
+                category="",
+            ),
+            exclude_fields=["category", "project_id", "actor_id", "actor_type"],
         )
 
     @patch("sentry.analytics.record")
@@ -462,22 +489,30 @@ class ActivityNotificationTest(APITestCase):
             footer
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=resolved_in_release_activity-slack-user&notification_uuid={notification_uuid}&organizationId={self.organization.id}|Notification Settings>"
         )
-        assert self.analytics_called_with_args(
+        assert_any_analytics_event(
             record_analytics,
-            "integrations.email.notification_sent",
-            user_id=self.user.id,
-            organization_id=self.organization.id,
-            group_id=self.group.id,
-            notification_uuid=notification_uuid,
+            EmailNotificationSent(
+                user_id=self.user.id,
+                organization_id=self.organization.id,
+                group_id=self.group.id,
+                notification_uuid=notification_uuid,
+                category="",
+                id=0,
+                actor_type="User",
+            ),
+            exclude_fields=["category", "id", "project_id", "actor_id", "actor_type"],
         )
-        assert self.analytics_called_with_args(
+        assert_any_analytics_event(
             record_analytics,
-            "integrations.slack.notification_sent",
-            user_id=self.user.id,
-            organization_id=self.organization.id,
-            group_id=self.group.id,
-            notification_uuid=notification_uuid,
-            actor_type="User",
+            SlackIntegrationNotificationSent(
+                user_id=self.user.id,
+                organization_id=self.organization.id,
+                group_id=self.group.id,
+                notification_uuid=notification_uuid,
+                actor_type="User",
+                category="",
+            ),
+            exclude_fields=["category", "project_id", "actor_id", "actor_type"],
         )
 
     def test_sends_processing_issue_notification(self, mock_post: MagicMock) -> None:
@@ -547,20 +582,28 @@ class ActivityNotificationTest(APITestCase):
             footer
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/alerts/?referrer=issue_alert-slack-user&notification_uuid={notification_uuid}&organizationId={self.organization.id}|Notification Settings>"
         )
-        assert self.analytics_called_with_args(
+        assert_any_analytics_event(
             record_analytics,
-            "integrations.email.notification_sent",
-            user_id=self.user.id,
-            organization_id=self.organization.id,
-            group_id=event.group_id,
-            notification_uuid=notification_uuid,
+            EmailNotificationSent(
+                user_id=self.user.id,
+                organization_id=self.organization.id,
+                group_id=event.group_id,
+                notification_uuid=notification_uuid,
+                category="",
+                id=0,
+                actor_type="User",
+            ),
+            exclude_fields=["category", "id", "project_id", "actor_id", "actor_type"],
         )
-        assert self.analytics_called_with_args(
+        assert_any_analytics_event(
             record_analytics,
-            "integrations.slack.notification_sent",
-            user_id=self.user.id,
-            organization_id=self.organization.id,
-            group_id=event.group_id,
-            notification_uuid=notification_uuid,
-            actor_type="User",
+            SlackIntegrationNotificationSent(
+                user_id=self.user.id,
+                organization_id=self.organization.id,
+                group_id=event.group_id,
+                notification_uuid=notification_uuid,
+                actor_type="User",
+                category="",
+            ),
+            exclude_fields=["category", "project_id", "actor_id", "actor_type"],
         )


### PR DESCRIPTION
Refactored the analytics events management for integration notifications to the new dataclass based solution.

Closes linear.app/getsentry/issue/TET-982/analytics-events-associated-with-integrations

Replaces https://github.com/getsentry/sentry/pull/98328 because of a botched merge