### PR TITLE
chore(autofix): Remove another tag

### DIFF
--- a/src/sentry/seer/autofix/autofix.py
+++ b/src/sentry/seer/autofix/autofix.py
@@ -347,6 +347,7 @@ def _get_all_tags_overview(group: Group) -> dict[str, Any] | None:
         "device.class",
         "mechanism",
         "os.name",  # the 'os' tag is better
+        "runtime.name",  # the 'runtime' tag is better
         "replay_id",
         "replayid",
         "level",


### PR DESCRIPTION
Remove another redundant tag from the context we send to seer