### PR TITLE
fix(pr comment reactions): Add safety and logs

### DIFF
--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -535,10 +535,13 @@ class GitHubBaseClient(
         return self.update_comment(repo.name, pr.key, pr_comment.external_id, data)
 
     def get_comment_reactions(self, repo: str, comment_id: str) -> Any:
+        """
+        https://docs.github.com/en/rest/issues/comments?#get-an-issue-comment
+        """
         endpoint = f"/repos/{repo}/issues/comments/{comment_id}"
         response = self.get(endpoint)
-        reactions = response["reactions"]
-        del reactions["url"]
+        reactions = response.get("reactions", {})
+        reactions.pop("url", None)
         return reactions
 
     def get_user(self, gh_username: str) -> Any:

--- a/src/sentry/integrations/github/tasks/pr_comment.py
+++ b/src/sentry/integrations/github/tasks/pr_comment.py
@@ -41,6 +41,7 @@ def github_comment_workflow(pullrequest_id: int, project_id: int) -> None:
     silo_mode=SiloMode.REGION,
     taskworker_config=TaskworkerConfig(
         namespace=integrations_tasks,
+        processing_deadline_duration=1800,  # 30 minutes
     ),
 )
 def github_comment_reactions() -> None:

--- a/src/sentry/integrations/github/tasks/pr_comment.py
+++ b/src/sentry/integrations/github/tasks/pr_comment.py
@@ -106,6 +106,7 @@ def github_comment_reactions() -> None:
             continue
 
         comment_count += 1
+        # TODO (nora): temporary log - remove after investigating bug
         if comment_count % 1000 == 0:
             logger.info("pr_comment.comment_reactions.progress", extra={"count": comment_count})
 

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -400,7 +400,7 @@ class GitHubApiClientTest(TestCase):
     @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
     def test_get_comment_reactions_missing_reactions(self, get_jwt) -> None:
-        comment_reactions = {}
+        comment_reactions = {"other": "stuff"}
         responses.add(
             responses.GET,
             f"https://api.github.com/repos/{self.repo.name}/issues/comments/2",

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -399,6 +399,19 @@ class GitHubApiClientTest(TestCase):
 
     @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
+    def test_get_comment_reactions_missing_reactions(self, get_jwt) -> None:
+        comment_reactions = {}
+        responses.add(
+            responses.GET,
+            f"https://api.github.com/repos/{self.repo.name}/issues/comments/2",
+            json=comment_reactions,
+        )
+
+        reactions = self.github_client.get_comment_reactions(repo=self.repo.name, comment_id="2")
+        assert reactions == {}
+
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    @responses.activate
     def test_get_merge_commit_sha_from_commit(self, get_jwt) -> None:
         merge_commit_sha = "jkl123"
         pull_requests = [{"merge_commit_sha": merge_commit_sha, "state": "closed"}]


### PR DESCRIPTION
We have stopped collecting pr comment reactions!
If you look at `pr_comment.comment_reactions.success` metric we are down to single digits since ~6/30
previous traffic and current traffic charted here for suspect commit comments https://redash.getsentry.net/queries/9353#12171

here are my observations:
- we log `github.pr_comment.reactions_task` every night --> task is being called
- we have not logged `pr_comment.comment_reactions.total_collected` in the last 3 months --> is the task timing out? we were successfully collecting reactions without logging this line.
- according to gh docs, `reactions` is not `required` on the response from this endpoint --> is it failing with a keyerror and quitting mid task?

in this pr:
- use safe dict methods to handle response
- only do comment.save() if there is a change to save
- add some logs for debugging