### PR TITLE
fix: Add node-hapi and node-hapi to feedbackCrashApiPlatforms

### DIFF
--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -664,6 +664,8 @@ export const feedbackCrashApiPlatforms: readonly PlatformKey[] = [
   'java-logback',
   'kotlin',
   'node-koa',
+  'node-hapi',
+  'node-hono',
   'unity',
   'unreal',
 ];


### PR DESCRIPTION
**Problem**
Although hapi.tsx and hono.tsx include instructions for userFeedback, when accessing the userFeedback feature with these projects selected, nothing appears. This happens because they are missing from one of the lists used to display the user feedback instructions.

**Solution**
I wasn’t sure which list they should go in, but since their instructions are similar to `node-koa`, I added them to the same list.