### PR TITLE
ref: Remove project-creation-games-tab feature flag checks BE

### DIFF
--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -770,11 +770,10 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
                 INGEST_THROUGH_TRUSTED_RELAYS_ONLY_DEFAULT,
             )
 
-        if features.has("organizations:project-creation-games-tab", obj):
-            context["enabledConsolePlatforms"] = obj.get_option(
-                "sentry:enabled_console_platforms",
-                ENABLED_CONSOLE_PLATFORMS_DEFAULT,
-            )
+        context["enabledConsolePlatforms"] = obj.get_option(
+            "sentry:enabled_console_platforms",
+            ENABLED_CONSOLE_PLATFORMS_DEFAULT,
+        )
 
         if access.role is not None:
             context["role"] = access.role  # Deprecated

--- a/src/sentry/core/endpoints/organization_details.py
+++ b/src/sentry/core/endpoints/organization_details.py
@@ -452,18 +452,10 @@ class OrganizationSerializer(BaseOrganizationSerializer):
         return value
 
     def validate_enabledConsolePlatforms(self, value):
-        organization = self.context["organization"]
         request = self.context["request"]
 
         if not is_active_staff(request):
             raise serializers.ValidationError("Only staff members can toggle console platforms.")
-
-        if not features.has(
-            "organizations:project-creation-games-tab", organization, actor=request.user
-        ):
-            raise serializers.ValidationError(
-                "Organization does not have the project creation games tab feature enabled."
-            )
 
         # Remove duplicates by converting to set and back to list
         if value is not None:

--- a/src/sentry/tempest/utils.py
+++ b/src/sentry/tempest/utils.py
@@ -10,11 +10,8 @@ def has_tempest_access(
     organization: Organization | None, actor: User | RpcUser | AnonymousUser | None = None
 ) -> bool:
     has_tempest_feature = features.has("organizations:tempest-access", organization, actor=actor)
-    has_gaming_feature = features.has(
-        "organizations:project-creation-games-tab", organization, actor=actor
-    )
 
-    if has_gaming_feature and organization:
+    if organization:
         enabled_platforms = organization.get_option("sentry:enabled_console_platforms", [])
         has_playstation_access = "playstation" in enabled_platforms
 

--- a/tests/sentry/core/endpoints/test_organization_details.py
+++ b/tests/sentry/core/endpoints/test_organization_details.py
@@ -1359,28 +1359,11 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
         self.get_success_response(self.organization.slug, **data)
         assert self.organization.get_option("sentry:default_seer_scanner_automation") is True
 
-    @with_feature({"organizations:project-creation-games-tab": False})
-    def test_enabled_console_platforms_feature_not_enabled(self) -> None:
-        staff_user = self.create_user(is_staff=True)
-        self.create_member(organization=self.organization, user=staff_user, role="owner")
-        self.login_as(user=staff_user, staff=True)
-
-        data = {"enabledConsolePlatforms": ["playstation", "xbox"]}
-        response = self.get_error_response(self.organization.slug, status_code=400, **data)
-        assert response.data["enabledConsolePlatforms"] == [
-            "Organization does not have the project creation games tab feature enabled."
-        ]
-
-        response = self.get_success_response(self.organization.slug)
-        assert "enabledConsolePlatforms" not in response.data
-
-    @with_feature({"organizations:project-creation-games-tab": True})
-    def test_enabled_console_platforms_feature_enabled(self) -> None:
+    def test_enabled_console_platforms_present_in_response(self) -> None:
         response = self.get_success_response(self.organization.slug)
         assert "enabledConsolePlatforms" in response.data
         assert response.data["enabledConsolePlatforms"] == []
 
-    @with_feature({"organizations:project-creation-games-tab": False})
     def test_enabled_console_platforms_no_staff_member(self) -> None:
         data = {"enabledConsolePlatforms": ["playstation", "xbox"]}
         response = self.get_error_response(self.organization.slug, status_code=400, **data)
@@ -1388,7 +1371,6 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
             "Only staff members can toggle console platforms."
         ]
 
-    @with_feature({"organizations:project-creation-games-tab": True})
     def test_enabled_console_platforms_multiple_platforms_parameter(self) -> None:
         staff_user = self.create_user(is_staff=True)
         self.create_member(organization=self.organization, user=staff_user, role="owner")
@@ -1416,7 +1398,6 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
             )
             assert org_edit_logs.count() == 0
 
-    @with_feature({"organizations:project-creation-games-tab": True})
     def test_enabled_console_platforms_empty_platforms_parameter(self) -> None:
         staff_user = self.create_user(is_staff=True)
         self.create_member(organization=self.organization, user=staff_user, role="owner")
@@ -1444,7 +1425,6 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
                 == "Disabled platforms: Nintendo Switch, PlayStation"
             )
 
-    @with_feature({"organizations:project-creation-games-tab": True})
     def test_enabled_console_platforms_duplicate_platform_parameter(self) -> None:
         staff_user = self.create_user(is_staff=True)
         self.create_member(organization=self.organization, user=staff_user, role="owner")
@@ -1465,7 +1445,6 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
             audit_log_event = audit_log.get(audit_entry.event)
             assert audit_log_event.render(audit_entry) == "Enabled platforms: PlayStation"
 
-    @with_feature({"organizations:project-creation-games-tab": True})
     def test_enabled_and_disabled_console_platforms(self) -> None:
         staff_user = self.create_user(is_staff=True)
         self.create_member(organization=self.organization, user=staff_user, role="owner")

--- a/tests/sentry/core/endpoints/test_project_details.py
+++ b/tests/sentry/core/endpoints/test_project_details.py
@@ -2079,7 +2079,6 @@ class TestTempestProjectDetails(TestProjectDetailsBase):
         assert response.data["tempestFetchScreenshots"] is True
         assert self.project.get_option("sentry:tempest_fetch_screenshots") is True
 
-    @with_feature("organizations:project-creation-games-tab")
     def test_put_tempest_fetch_screenshots_enabled_console_platforms(self) -> None:
         self.organization.update_option("sentry:enabled_console_platforms", ["playstation"])
         assert self.project.get_option("sentry:tempest_fetch_screenshots") is False
@@ -2102,7 +2101,6 @@ class TestTempestProjectDetails(TestProjectDetailsBase):
         assert "tempestFetchScreenshots" in response.data
         assert response.data["tempestFetchScreenshots"] is False
 
-    @with_feature("organizations:project-creation-games-tab")
     def test_get_tempest_fetch_screenshots_options_enabled_console_platforms(self) -> None:
         self.organization.update_option("sentry:enabled_console_platforms", ["playstation"])
         response = self.get_success_response(
@@ -2127,7 +2125,6 @@ class TestTempestProjectDetails(TestProjectDetailsBase):
         assert response.data["tempestFetchDumps"] is True
         assert self.project.get_option("sentry:tempest_fetch_dumps") is True
 
-    @with_feature("organizations:project-creation-games-tab")
     def test_put_tempest_fetch_dumps_enabled_console_platforms(self) -> None:
         self.organization.update_option("sentry:enabled_console_platforms", ["playstation"])
         assert self.project.get_option("sentry:tempest_fetch_dumps") is False
@@ -2150,7 +2147,6 @@ class TestTempestProjectDetails(TestProjectDetailsBase):
         assert "tempestFetchDumps" in response.data
         assert response.data["tempestFetchDumps"] is False
 
-    @with_feature("organizations:project-creation-games-tab")
     def test_get_tempest_fetch_dumps_options_enabled_console_platforms(self) -> None:
         self.organization.update_option("sentry:enabled_console_platforms", ["playstation"])
         response = self.get_success_response(

--- a/tests/sentry/tempest/endpoints/test_tempest_credentials.py
+++ b/tests/sentry/tempest/endpoints/test_tempest_credentials.py
@@ -26,20 +26,19 @@ class TestTempestCredentials(APITestCase):
             assert {cred.id for cred in credentials} == {item["id"] for item in response.data}
 
     def test_get_tempest_credentials_enabled_console_platforms(self) -> None:
-        with Feature({"organizations:project-creation-games-tab": True}):
-            self.organization.update_option("sentry:enabled_console_platforms", ["playstation"])
-            credentials = [self.create_tempest_credentials(self.project) for _ in range(5)]
+        self.organization.update_option("sentry:enabled_console_platforms", ["playstation"])
+        credentials = [self.create_tempest_credentials(self.project) for _ in range(5)]
 
-            other_project = self.create_project(organization=self.organization)
-            # credentials connected to other project which should not be included in the response
-            for _ in range(5):
-                self.create_tempest_credentials(other_project)
+        other_project = self.create_project(organization=self.organization)
+        # credentials connected to other project which should not be included in the response
+        for _ in range(5):
+            self.create_tempest_credentials(other_project)
 
-            self.login_as(self.user)
-            response = self.get_success_response(self.project.organization.slug, self.project.slug)
+        self.login_as(self.user)
+        response = self.get_success_response(self.project.organization.slug, self.project.slug)
 
-            assert len(response.data) == 5
-            assert {cred.id for cred in credentials} == {item["id"] for item in response.data}
+        assert len(response.data) == 5
+        assert {cred.id for cred in credentials} == {item["id"] for item in response.data}
 
     def test_endpoint_returns_404_if_feature_flag_is_disabled(self) -> None:
         self.login_as(self.user)
@@ -54,12 +53,11 @@ class TestTempestCredentials(APITestCase):
             assert response.data[0]["clientSecret"] == "*" * len(credentials.client_secret)
 
     def test_client_secret_is_obfuscated_enabled_console_platforms(self) -> None:
-        with Feature({"organizations:project-creation-games-tab": True}):
-            self.organization.update_option("sentry:enabled_console_platforms", ["playstation"])
-            credentials = self.create_tempest_credentials(self.project)
-            self.login_as(self.user)
-            response = self.get_success_response(self.project.organization.slug, self.project.slug)
-            assert response.data[0]["clientSecret"] == "*" * len(credentials.client_secret)
+        self.organization.update_option("sentry:enabled_console_platforms", ["playstation"])
+        credentials = self.create_tempest_credentials(self.project)
+        self.login_as(self.user)
+        response = self.get_success_response(self.project.organization.slug, self.project.slug)
+        assert response.data[0]["clientSecret"] == "*" * len(credentials.client_secret)
 
     def test_unauthenticated_user_cant_access_endpoint(self) -> None:
         self.get_error_response(self.project.organization.slug, self.project.slug)
@@ -91,23 +89,22 @@ class TestTempestCredentials(APITestCase):
     def test_create_tempest_credentials_enabled_console_platforms(
         self, create_audit_entry: MagicMock
     ) -> None:
-        with Feature({"organizations:project-creation-games-tab": True}):
-            self.organization.update_option("sentry:enabled_console_platforms", ["playstation"])
-            self.login_as(self.user)
-            response = self.get_success_response(
-                self.project.organization.slug,
-                self.project.slug,
-                method="POST",
-                **self.valid_credentials_data,
-            )
-            assert response.status_code == 201
-            creds_obj = TempestCredentials.objects.get(project=self.project)
-            assert creds_obj.client_id == self.valid_credentials_data["clientId"]
-            assert creds_obj.client_secret == self.valid_credentials_data["clientSecret"]
-            assert creds_obj.project == self.project
-            assert creds_obj.created_by_id == self.user.id
+        self.organization.update_option("sentry:enabled_console_platforms", ["playstation"])
+        self.login_as(self.user)
+        response = self.get_success_response(
+            self.project.organization.slug,
+            self.project.slug,
+            method="POST",
+            **self.valid_credentials_data,
+        )
+        assert response.status_code == 201
+        creds_obj = TempestCredentials.objects.get(project=self.project)
+        assert creds_obj.client_id == self.valid_credentials_data["clientId"]
+        assert creds_obj.client_secret == self.valid_credentials_data["clientSecret"]
+        assert creds_obj.project == self.project
+        assert creds_obj.created_by_id == self.user.id
 
-            create_audit_entry.assert_called()
+        create_audit_entry.assert_called()
 
     def test_create_tempest_credentials_without_feature_flag(self) -> None:
         self.login_as(self.user)
@@ -148,16 +145,15 @@ class TestTempestCredentials(APITestCase):
         self.create_member(
             user=non_admin_user, organization=self.project.organization, role="member"
         )
-        with Feature({"organizations:project-creation-games-tab": True}):
-            self.organization.update_option("sentry:enabled_console_platforms", ["playstation"])
-            self.login_as(non_admin_user)
-            response = self.get_error_response(
-                self.project.organization.slug,
-                self.project.slug,
-                method="POST",
-                **self.valid_credentials_data,
-            )
-            assert response.status_code == 403
+        self.organization.update_option("sentry:enabled_console_platforms", ["playstation"])
+        self.login_as(non_admin_user)
+        response = self.get_error_response(
+            self.project.organization.slug,
+            self.project.slug,
+            method="POST",
+            **self.valid_credentials_data,
+        )
+        assert response.status_code == 403
 
     def test_create_tempest_credentials_with_invalid_data(self) -> None:
         with Feature({"organizations:tempest-access": True}):
@@ -179,24 +175,23 @@ class TestTempestCredentials(APITestCase):
             assert response2.status_code == 400
 
     def test_create_tempest_credentials_with_invalid_data_enabled_console_platforms(self) -> None:
-        with Feature({"organizations:project-creation-games-tab": True}):
-            self.organization.update_option("sentry:enabled_console_platforms", ["playstation"])
-            self.login_as(self.user)
-            response = self.get_error_response(
-                self.project.organization.slug,
-                self.project.slug,
-                method="POST",
-                **{"clientId": "test"},
-            )
-            assert response.status_code == 400
+        self.organization.update_option("sentry:enabled_console_platforms", ["playstation"])
+        self.login_as(self.user)
+        response = self.get_error_response(
+            self.project.organization.slug,
+            self.project.slug,
+            method="POST",
+            **{"clientId": "test"},
+        )
+        assert response.status_code == 400
 
-            response2 = self.get_error_response(
-                self.project.organization.slug,
-                self.project.slug,
-                method="POST",
-                **{"clientSecret": "test"},
-            )
-            assert response2.status_code == 400
+        response2 = self.get_error_response(
+            self.project.organization.slug,
+            self.project.slug,
+            method="POST",
+            **{"clientSecret": "test"},
+        )
+        assert response2.status_code == 400
 
     def test_cant_create_tempest_credentials_with_duplicate_client_id(self) -> None:
         with Feature({"organizations:tempest-access": True}):
@@ -217,21 +212,20 @@ class TestTempestCredentials(APITestCase):
     def test_cant_create_tempest_credentials_with_duplicate_client_id_enabled_console_platforms(
         self,
     ) -> None:
-        with Feature({"organizations:project-creation-games-tab": True}):
-            self.organization.update_option("sentry:enabled_console_platforms", ["playstation"])
-            self.login_as(self.user)
-            self.create_tempest_credentials(
-                self.project, client_id=self.valid_credentials_data["clientId"]
-            )
-            response = self.get_error_response(
-                self.project.organization.slug,
-                self.project.slug,
-                method="POST",
-                **self.valid_credentials_data,
-            )
-            # database constraint violation
-            assert response.status_code == 400
-            assert response.data["detail"] == "A credential with this client ID already exists."
+        self.organization.update_option("sentry:enabled_console_platforms", ["playstation"])
+        self.login_as(self.user)
+        self.create_tempest_credentials(
+            self.project, client_id=self.valid_credentials_data["clientId"]
+        )
+        response = self.get_error_response(
+            self.project.organization.slug,
+            self.project.slug,
+            method="POST",
+            **self.valid_credentials_data,
+        )
+        # database constraint violation
+        assert response.status_code == 400
+        assert response.data["detail"] == "A credential with this client ID already exists."
 
     def test_user_email_in_response(self) -> None:
         with Feature({"organizations:tempest-access": True}):
@@ -241,9 +235,8 @@ class TestTempestCredentials(APITestCase):
             assert response.data[0]["createdByEmail"] == self.user.email
 
     def test_user_email_in_response_enabled_console_platforms(self) -> None:
-        with Feature({"organizations:project-creation-games-tab": True}):
-            self.organization.update_option("sentry:enabled_console_platforms", ["playstation"])
-            self.login_as(self.user)
-            self.create_tempest_credentials(self.project, created_by=self.user)
-            response = self.get_success_response(self.project.organization.slug, self.project.slug)
-            assert response.data[0]["createdByEmail"] == self.user.email
+        self.organization.update_option("sentry:enabled_console_platforms", ["playstation"])
+        self.login_as(self.user)
+        self.create_tempest_credentials(self.project, created_by=self.user)
+        response = self.get_success_response(self.project.organization.slug, self.project.slug)
+        assert response.data[0]["createdByEmail"] == self.user.email

--- a/tests/sentry/tempest/endpoints/test_tempest_credentials_details.py
+++ b/tests/sentry/tempest/endpoints/test_tempest_credentials_details.py
@@ -54,19 +54,18 @@ class TestTempestCredentialsDetails(APITestCase):
     def test_delete_tempest_credentials_as_org_admin_enabled_console_platforms(
         self, create_audit_entry
     ):
-        with Feature({"organizations:project-creation-games-tab": True}):
-            self.organization.update_option("sentry:enabled_console_platforms", ["playstation"])
-            self.login_as(self.user)
-            response = self.get_response(
-                self.project.organization.slug,
-                self.project.slug,
-                self.tempest_credentials.id,
-                method="DELETE",
-            )
+        self.organization.update_option("sentry:enabled_console_platforms", ["playstation"])
+        self.login_as(self.user)
+        response = self.get_response(
+            self.project.organization.slug,
+            self.project.slug,
+            self.tempest_credentials.id,
+            method="DELETE",
+        )
 
-            assert response.status_code == 204
-            assert not TempestCredentials.objects.filter(id=self.tempest_credentials.id).exists()
-            create_audit_entry.assert_called()
+        assert response.status_code == 204
+        assert not TempestCredentials.objects.filter(id=self.tempest_credentials.id).exists()
+        create_audit_entry.assert_called()
 
     def test_non_admin_cant_delete_credentials(self) -> None:
         non_admin_user = self.create_user()
@@ -90,15 +89,13 @@ class TestTempestCredentialsDetails(APITestCase):
         self.create_member(
             user=non_admin_user, organization=self.project.organization, role="member"
         )
-        with Feature({"organizations:project-creation-games-tab": True}):
-            self.organization.update_option("sentry:enabled_console_platforms", ["playstation"])
-            self.login_as(non_admin_user)
-            response = self.get_response(
-                self.project.organization.slug,
-                self.project.slug,
-                self.tempest_credentials.id,
-                method="DELETE",
-            )
-
+        self.organization.update_option("sentry:enabled_console_platforms", ["playstation"])
+        self.login_as(non_admin_user)
+        response = self.get_response(
+            self.project.organization.slug,
+            self.project.slug,
+            self.tempest_credentials.id,
+            method="DELETE",
+        )
         assert response.status_code == 403
         assert TempestCredentials.objects.filter(id=self.tempest_credentials.id).exists()


### PR DESCRIPTION
**Background**
We want to release this feature as soon as possible, so we don't need to always create a new Pull Request to add customers to the tempest-access feature flag. Since we already check that anyone toggling organization options is a staff member, it’s safe to remove the feature flag checks from the backend.

**What’s remaining**
The Gaming tab in project creation still has the feature flag check (FE). This will remain until we can do a small bug bash session, which will likely happen next week.