### PR TITLE
feat(aws-lambda-integration): Update `NODE_OPTIONS` for v10.6+ SDK

### DIFF
--- a/src/sentry/integrations/aws_lambda/integration.py
+++ b/src/sentry/integrations/aws_lambda/integration.py
@@ -55,7 +55,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger("sentry.integrations.aws_lambda")
 
 DESCRIPTION = """
-The AWS Lambda integration will automatically instrument your Lambda functions without any code changes. We use CloudFormation Stack ([Learn more about CloudFormation](https://aws.amazon.com/cloudformation/)) to create Sentry role and enable errors and transactions capture from your Lambda functions.
+The AWS Lambda integration will automatically instrument your Lambda functions without any code changes. We use a CloudFormation Stack ([learn more about CloudFormation](https://aws.amazon.com/cloudformation/)) to create a Sentry role and enable error and transaction capture from your Lambda functions.
 """
 
 

--- a/src/sentry/integrations/aws_lambda/utils.py
+++ b/src/sentry/integrations/aws_lambda/utils.py
@@ -234,7 +234,25 @@ def get_node_options_for_layer(layer_name: str, layer_version: int | None) -> st
     # - `SentryNodeServerlessSDKv8`
     # - and any other layer with a version suffix above, e.g.
     #   `SentryNodeServerlessSDKv9`
-    return "-r @sentry/aws-serverless/awslambda-auto"
+    if (
+        layer_name == "SentryNodeServerlessSDK"
+        or layer_name == "SentryNodeServerlessSDKv8"
+        or layer_name == "SentryNodeServerlessSDKv9"
+        or (
+            layer_name == "SentryNodeServerlessSDKv10"
+            and layer_version is not None
+            and layer_version <= 13
+        )
+    ):
+        return "-r @sentry/aws-serverless/awslambda-auto"
+
+    # Lambda layers for v10.6.0 and above can use `--import` for auto-instrumentation
+    #
+    # These are specifically
+    # - `SentryNodeServerlessSDKv10:14` and above
+    # - and any other layer with a version suffix above, e.g.
+    #   `SentryNodeServerlessSDKv11`
+    return "--import @sentry/aws-serverless/awslambda-auto"
 
 
 def enable_single_lambda(lambda_client, function, sentry_project_dsn, retries_left=3):

--- a/tests/sentry/integrations/api/endpoints/test_organization_integration_serverless_functions.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_integration_serverless_functions.py
@@ -259,7 +259,7 @@ class OrganizationIntegrationServerlessFunctionsPostTest(AbstractServerlessTest)
             ],
             "Environment": {
                 "Variables": {
-                    "NODE_OPTIONS": "-r @sentry/aws-serverless/awslambda-auto",
+                    "NODE_OPTIONS": "--import @sentry/aws-serverless/awslambda-auto",
                     "SENTRY_DSN": self.sentry_dsn,
                     "SENTRY_TRACES_SAMPLE_RATE": "1.0",
                 }
@@ -292,7 +292,7 @@ class OrganizationIntegrationServerlessFunctionsPostTest(AbstractServerlessTest)
             ],
             Environment={
                 "Variables": {
-                    "NODE_OPTIONS": "-r @sentry/aws-serverless/awslambda-auto",
+                    "NODE_OPTIONS": "--import @sentry/aws-serverless/awslambda-auto",
                     "SENTRY_DSN": self.sentry_dsn,
                     "SENTRY_TRACES_SAMPLE_RATE": "1.0",
                 }

--- a/tests/sentry/integrations/aws_lambda/test_utils.py
+++ b/tests/sentry/integrations/aws_lambda/test_utils.py
@@ -12,6 +12,7 @@ from sentry.integrations.aws_lambda.utils import (
     get_index_of_sentry_layer,
     get_latest_layer_for_function,
     get_latest_layer_version,
+    get_node_options_for_layer,
     get_option_value,
     get_supported_functions,
     get_version_of_arn,
@@ -199,3 +200,37 @@ class GetOptionValueTest(TestCase):
                 match="Could not find cache value with key aws-layer:node",
             ):
                 get_option_value(self.node_fn, OPTION_VERSION)
+
+
+class GetNodeOptionsForLayerTest(TestCase):
+    """Test the get_node_options_for_layer function for different layer scenarios."""
+
+    def test_v7_layer_name(self) -> None:
+        """Test SentryNodeServerlessSDKv7 returns v7 SDK options."""
+        result = get_node_options_for_layer("SentryNodeServerlessSDKv7", None)
+        assert result == "-r @sentry/serverless/dist/awslambda-auto"
+
+    def test_sentry_node_serverless_sdk_version_236_boundary(self) -> None:
+        """Test SentryNodeServerlessSDK at version boundary 236 returns v8 SDK options."""
+        result = get_node_options_for_layer("SentryNodeServerlessSDK", 236)
+        assert result == "-r @sentry/aws-serverless/awslambda-auto"
+
+    def test_v8_layer_name(self) -> None:
+        """Test SentryNodeServerlessSDKv8 returns v8 SDK options with -r."""
+        result = get_node_options_for_layer("SentryNodeServerlessSDKv8", None)
+        assert result == "-r @sentry/aws-serverless/awslambda-auto"
+
+    def test_v10_layer_name(self) -> None:
+        """Test SentryNodeServerlessSDKv10 at version boundary 13 returns v8 SDK options with -r."""
+        result = get_node_options_for_layer("SentryNodeServerlessSDKv10", 13)
+        assert result == "-r @sentry/aws-serverless/awslambda-auto"
+
+    def test_v10_layer_version_14_boundary(self) -> None:
+        """Test SentryNodeServerlessSDKv10 at version boundary 14 returns v10+ SDK options with --import."""
+        result = get_node_options_for_layer("SentryNodeServerlessSDKv10", 14)
+        assert result == "--import @sentry/aws-serverless/awslambda-auto"
+
+    def test_v11_layer_name(self) -> None:
+        """Test SentryNodeServerlessSDKv11 returns v10+ SDK options with --import."""
+        result = get_node_options_for_layer("SentryNodeServerlessSDKv11", None)
+        assert result == "--import @sentry/aws-serverless/awslambda-auto"


### PR DESCRIPTION
Enables the AWS Lambda integration to be used with both ESM and CJS Lambda functions by using `--import @sentry/aws-serverless/awslambda-auto` for the Node layer with SDK versions 10.6.0 and above, where we introduced auto-instrumentation for ESM.
