### PR TITLE
fix(search-bar): Convert negated text input to filters

### DIFF
--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -1022,6 +1022,34 @@ describe('SearchQueryBuilder', () => {
       await screen.findByRole('row', {name: /or/});
       await screen.findByRole('row', {name: /b/});
     });
+
+    it('converts text to filter when typing <filter>:', async () => {
+      render(<SearchQueryBuilder {...defaultProps} />);
+      await userEvent.click(getLastInput());
+
+      await userEvent.type(
+        screen.getByRole('combobox', {name: 'Add a search term'}),
+        'browser.name:'
+      );
+
+      const browserNameFilter = await screen.findByRole('row', {name: 'browser.name:""'});
+      expect(browserNameFilter).toBeInTheDocument();
+    });
+
+    it('converts text to negated filter when typing !<filter>:', async () => {
+      render(<SearchQueryBuilder {...defaultProps} />);
+      await userEvent.click(getLastInput());
+
+      await userEvent.type(
+        screen.getByRole('combobox', {name: 'Add a search term'}),
+        '!browser.name:'
+      );
+
+      const browserNameFilter = await screen.findByRole('row', {
+        name: '!browser.name:""',
+      });
+      expect(browserNameFilter).toBeInTheDocument();
+    });
   });
 
   describe('filter key suggestions', () => {

--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -586,10 +586,11 @@ function SearchQueryBuilderInputInternal({
           }
 
           if (
-            parsedText?.some(
-              textToken =>
-                textToken.type === Token.FILTER && textToken.key.text === filterValue
-            )
+            parsedText?.some(textToken => {
+              if (textToken.type !== Token.FILTER) return false;
+              if (textToken.negated) return `!${textToken.key.text}` === filterValue;
+              return textToken.key.text === filterValue;
+            })
           ) {
             const filterKey = getSuggestedFilterKey(filterValue) ?? filterValue;
             const key = filterKeys[filterKey];


### PR DESCRIPTION
This PR makes a small tweak to the logic in `freeText` in `onInputChange` callback and the check for user inputting a valid filter key, and extends the check to also support negated values.

When users type in `!<filter>:` it will now convert that free text to a filter.

Ticket: EXP-476