### PR TITLE
fix(dashboards): Ensure general overview shows up if no other dashboards

### DIFF
--- a/src/sentry/dashboards/endpoints/organization_dashboards.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboards.py
@@ -290,13 +290,12 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
             return serialized
 
         render_pre_built_dashboard = True
-        if (
-            filter_by
-            and filter_by in {"onlyFavorites", "owned"}
-            or pin_by
-            and pin_by == "favorites"
-        ):
+        if filter_by and filter_by in {"onlyFavorites", "owned"}:
             render_pre_built_dashboard = False
+        elif pin_by and pin_by == "favorites":
+            # Only hide prebuilt dashboard when pinning favorites if there are actual dashboards to show
+            # This allows the prebuilt dashboard to appear when users have no dashboards yet
+            render_pre_built_dashboard = not dashboards.exists()
 
         return self.paginate(
             request=request,

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboards.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboards.py
@@ -1893,3 +1893,21 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
         with self.feature("organizations:dashboards-plan-limits"):
             response = self.do_request("post", self.url, data={"title": "New Dashboard w/ Limit"})
         assert response.status_code == 201
+
+    def test_prebuilt_dashboard_is_shown_when_favorites_pinned_and_no_dashboards(self) -> None:
+        # The prebuilt dashboard should not show up when filtering by owned dashboards
+        # because it is not created by the user
+        response = self.do_request("get", self.url, {"pin": "favorites", "filter": "owned"})
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 2
+        assert not any(
+            dashboard["title"] == "General" and dashboard["id"] == "default-overview"
+            for dashboard in response.data
+        )
+
+        # If there are no other dashboards when fetching with pinned dashboards
+        # the prebuilt dashboard should show up
+        response = self.do_request("get", self.url, {"pin": "favorites", "filter": "shared"})
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 1
+        assert response.data[0]["title"] == "General"


### PR DESCRIPTION
With starred dashboards, we make a request pinning the starred dashboards at the top of the list. The problem was that the General Overview, because it's hardcoded we don't get it from Django, would always append to the front of the list. This makes pagination difficult so we have to use a special paginator to merge two types of data together (prebuilt, then the dashboards we queried) and when we asked for pinned dashboards we would remove this prebuilt one since it was always at the front of the list.

The frontend **always** makes the request for pinned dashboards, and that was dropping the prebuilt dashboard. So if a user went to the dashboards page with no dashboards created for the org, they'd see an empty state. This at least shows the dashboard if we make a pinned request and there are no dashboards available otherwise.

