### PR TITLE
fix(aci): Report Snuba errors in delayed_workflows to Sentry as info

### DIFF
--- a/src/sentry/workflow_engine/tasks/delayed_workflows.py
+++ b/src/sentry/workflow_engine/tasks/delayed_workflows.py
@@ -879,8 +879,8 @@ def process_delayed_workflows(
     try:
         condition_group_results = get_condition_group_results(condition_groups)
     except SnubaError:
-        # We expect occasional errors, so we report as warning and retry.
-        logger.warning("delayed_workflow.snuba_error", exc_info=True)
+        # We expect occasional errors, so we report as info and retry.
+        sentry_sdk.capture_exception(level="info")
         retry_task()
 
     logger.debug(


### PR DESCRIPTION
Going only to logging makes them a bit too hard to diagnose and track.
