### PR TITLE
build(chartcuterie): Add loaders

### DIFF
--- a/config/build-chartcuterie.ts
+++ b/config/build-chartcuterie.ts
@@ -77,6 +77,24 @@ async function runEsbuild(commitHash: string): Promise<void> {
     minify: false,
     treeShaking: true,
     logLevel: 'info',
+    // Support loading most asset files, these should be tree-shaken, but
+    // esbuild might end up encountering them as we add and remove things from
+    // the dependency tree.
+    loader: {
+      '.svg': 'file',
+      '.png': 'file',
+      '.jpg': 'file',
+      '.jpeg': 'file',
+      '.gif': 'file',
+      '.ico': 'file',
+      '.webp': 'file',
+      '.mp4': 'file',
+      '.woff': 'file',
+      '.woff2': 'file',
+      '.ttf': 'file',
+      '.eot': 'file',
+      '.pegjs': 'text',
+    },
   });
 }
 


### PR DESCRIPTION
Brings this back https://github.com/getsentry/sentry/pull/98309

Originally we reverted Kevan's PR since we ideally don't want to end up
with a scenario where asset files are being pulled in, but this came up
again (and likely will come up more). We can definitely tease apart the
dependency tree each time it comes up, but these files will just end up
tree-shaken out so there's not really a huge need to optimize here.