### PR TITLE
feat(feedback): feedback and categories experimental badge

### DIFF
--- a/static/app/components/feedback/summaryCategories/feedbackSummaryCategories.tsx
+++ b/static/app/components/feedback/summaryCategories/feedbackSummaryCategories.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 
+import {Badge} from 'sentry/components/core/badge';
 import {Button} from 'sentry/components/core/button';
 import {Flex} from 'sentry/components/core/layout';
 import FeedbackCategories from 'sentry/components/feedback/summaryCategories/feedbackCategories';
@@ -53,7 +54,9 @@ export default function FeedbackSummaryCategories() {
       <IconSeer size="xs" />
       <SummaryContainer>
         <Flex justify="between" align="center">
-          <SummaryHeader>{t('Summary')}</SummaryHeader>
+          <SummaryHeader>
+            {t('Summary')} <Badge type="experimental">{t('Experimental')}</Badge>
+          </SummaryHeader>
           <Flex gap="xs">
             {feedbackButton({type: 'positive'})}
             {feedbackButton({type: 'negative'})}


### PR DESCRIPTION
Looks like this:
<img width="417" height="133" alt="image" src="https://github.com/user-attachments/assets/5b718288-5ae5-4cde-b91a-fb28ce9ea39b" />

Uses the same component as for the replay AI summary
