### PR TITLE
feat(checkout v3): Build your plan step

### DIFF
--- a/static/gsApp/types/index.tsx
+++ b/static/gsApp/types/index.tsx
@@ -229,7 +229,7 @@ export enum OnDemandBudgetMode {
   PER_CATEGORY = 'per_category',
 }
 
-export type SharedOnDemandBudget = {
+type SharedOnDemandBudget = {
   budgetMode: OnDemandBudgetMode.SHARED;
   sharedMaxBudget: number;
 };

--- a/static/gsApp/utils/billing.tsx
+++ b/static/gsApp/utils/billing.tsx
@@ -6,6 +6,7 @@ import {DataCategory} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
 import getDaysSinceDate from 'sentry/utils/getDaysSinceDate';
+import type {IconSize} from 'sentry/utils/theme';
 
 import {
   BILLION,
@@ -553,10 +554,10 @@ export function getPlanIcon(plan: Plan) {
   return <IconUser />;
 }
 
-export function getProductIcon(product: SelectableProduct) {
+export function getProductIcon(product: SelectableProduct, size?: IconSize) {
   switch (product) {
     case SelectableProduct.SEER:
-      return <IconSeer />;
+      return <IconSeer size={size} />;
     default:
       return null;
   }

--- a/static/gsApp/views/amCheckout/index.tsx
+++ b/static/gsApp/views/amCheckout/index.tsx
@@ -1,4 +1,5 @@
 import {Component, Fragment} from 'react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 import type {QueryObserverResult} from '@tanstack/react-query';
@@ -15,7 +16,6 @@ import Panel from 'sentry/components/panels/panel';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import TextOverflow from 'sentry/components/textOverflow';
 import {t, tct} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import type {DataCategory} from 'sentry/types/core';
 import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import type {Organization} from 'sentry/types/organization';
@@ -66,6 +66,7 @@ import CheckoutOverviewV2 from 'getsentry/views/amCheckout/checkoutOverviewV2';
 import AddBillingDetails from 'getsentry/views/amCheckout/steps/addBillingDetails';
 import AddDataVolume from 'getsentry/views/amCheckout/steps/addDataVolume';
 import AddPaymentMethod from 'getsentry/views/amCheckout/steps/addPaymentMethod';
+import BuildYourPlan from 'getsentry/views/amCheckout/steps/checkoutV3/buildYourPlan';
 import ContractSelect from 'getsentry/views/amCheckout/steps/contractSelect';
 import OnDemandBudgetsStep from 'getsentry/views/amCheckout/steps/onDemandBudgets';
 import OnDemandSpend from 'getsentry/views/amCheckout/steps/onDemandSpend';
@@ -261,6 +262,10 @@ class AMCheckout extends Component<Props, State> {
     const OnDemandStep = hasOnDemandBudgetsFeature(organization, subscription)
       ? OnDemandBudgetsStep
       : OnDemandSpend;
+
+    if (isNewCheckout) {
+      return [BuildYourPlan];
+    }
 
     const preAM3Tiers = [PlanTier.AM1, PlanTier.AM2];
     const notAMTier = !isAmPlan(checkoutTier);
@@ -786,19 +791,21 @@ class AMCheckout extends Component<Props, State> {
             <Alert type="info">{promotionDisclaimerText}</Alert>
           </Alert.Container>
         )}
-        <SettingsPageHeader
-          title="Change Subscription"
-          colorSubtitle={subscriptionDiscountInfo}
-          data-test-id="change-subscription"
-        />
+        {!isNewCheckout && (
+          <SettingsPageHeader
+            title="Change Subscription"
+            colorSubtitle={subscriptionDiscountInfo}
+            data-test-id="change-subscription"
+          />
+        )}
 
-        <CheckoutContainer>
+        <CheckoutContainer isNewCheckout={!!isNewCheckout}>
           <CheckoutMain>
             {this.renderPartnerAlert()}
             <div data-test-id="checkout-steps">{this.renderSteps()}</div>
           </CheckoutMain>
           <SidePanel>
-            <OverviewContainer>
+            <OverviewContainer isNewCheckout={!!isNewCheckout}>
               {isNewCheckout ? (
                 <Cart
                   {...overviewProps}
@@ -854,12 +861,13 @@ class AMCheckout extends Component<Props, State> {
   }
 }
 
-const CheckoutContainer = styled('div')`
+const CheckoutContainer = styled('div')<{isNewCheckout: boolean}>`
   display: grid;
-  gap: ${space(3)};
-  grid-template-columns: 58% auto;
+  gap: ${p => p.theme.space['2xl']};
+  grid-template-columns: 3fr 2fr;
 
-  @media (max-width: ${p => p.theme.breakpoints.lg}) {
+  @media (max-width: ${p =>
+      p.isNewCheckout ? p.theme.breakpoints.md : p.theme.breakpoints.lg}) {
     grid-template-columns: auto;
   }
 `;
@@ -872,21 +880,26 @@ const SidePanel = styled('div')`
 `;
 
 /**
- * Hide overview at smaller screen sizes
- * but keep cancel subscription button
+ * Hide overview at smaller screen sizes in old checkout
+ * Bring overview to bottom at smaller screen sizes in new checkout
+ * Cancel subscription button is always visible
  */
-const OverviewContainer = styled('div')`
-  @media (max-width: ${p => p.theme.breakpoints.lg}) {
-    display: none;
-  }
+const OverviewContainer = styled('div')<{isNewCheckout: boolean}>`
+  ${p =>
+    !p.isNewCheckout &&
+    css`
+      @media (max-width: ${p.theme.breakpoints.lg}) {
+        display: none;
+      }
+    `}
 `;
 
 const SupportPrompt = styled(Panel)`
   display: grid;
   grid-template-columns: repeat(2, auto);
   justify-content: space-between;
-  gap: ${space(1)};
-  padding: ${space(2)};
+  gap: ${p => p.theme.space.md};
+  padding: ${p => p.theme.space.xl};
   font-size: ${p => p.theme.fontSize.md};
   color: ${p => p.theme.subText};
   align-items: center;
@@ -895,14 +908,14 @@ const SupportPrompt = styled(Panel)`
 const CancelSubscription = styled('div')`
   display: grid;
   justify-items: center;
-  margin-bottom: ${space(3)};
+  margin-bottom: ${p => p.theme.space['2xl']};
 `;
 
 const DisclaimerText = styled('div')`
   font-size: ${p => p.theme.fontSize.md};
   color: ${p => p.theme.subText};
   text-align: center;
-  margin-bottom: ${space(1)};
+  margin-bottom: ${p => p.theme.space.md};
 `;
 
 const PartnerAlertContent = styled('div')`
@@ -912,7 +925,7 @@ const PartnerAlertContent = styled('div')`
 
 const PartnerAlertTitle = styled('div')`
   font-weight: ${p => p.theme.fontWeight.bold};
-  margin-bottom: ${space(1)};
+  margin-bottom: ${p => p.theme.space.md};
 `;
 
 const AnnualTerms = styled(TextBlock)`

--- a/static/gsApp/views/amCheckout/reserveAdditionalVolume.tsx
+++ b/static/gsApp/views/amCheckout/reserveAdditionalVolume.tsx
@@ -41,7 +41,7 @@ function ReserveAdditionalVolume({
     }, 0);
   }, [formData.reserved, activePlan]);
 
-  // TODO(checkout-v3): correct math
+  // TODO(checkout v3): correct math
   const savings = useMemo(() => {
     return reservedVolumeTotal * 1.2 - reservedVolumeTotal;
   }, [reservedVolumeTotal]);
@@ -52,7 +52,7 @@ function ReserveAdditionalVolume({
     [PlanTier.AM2, PlanTier.AM1].includes(checkoutTier ?? PlanTier.AM3);
 
   return (
-    <Container padding="xl">
+    <ReserveAdditionalVolumeContainer>
       <Flex justify="between">
         <Flex direction="column" gap="md" align="start">
           <RowWithTag>
@@ -117,11 +117,18 @@ function ReserveAdditionalVolume({
           )}
         </Fragment>
       )}
-    </Container>
+    </ReserveAdditionalVolumeContainer>
   );
 }
 
 export default ReserveAdditionalVolume;
+
+const ReserveAdditionalVolumeContainer = styled(Container)`
+  padding: ${p => p.theme.space.xl};
+  background: ${p => p.theme.background};
+  border-radius: ${p => p.theme.borderRadius};
+  border: 1px solid ${p => p.theme.border};
+`;
 
 const RowWithTag = styled('div')`
   display: flex;

--- a/static/gsApp/views/amCheckout/steps/addDataVolume.tsx
+++ b/static/gsApp/views/amCheckout/steps/addDataVolume.tsx
@@ -13,7 +13,6 @@ import TextBlock from 'sentry/views/settings/components/text/textBlock';
 import {PlanTier} from 'getsentry/types';
 import {isAmPlan} from 'getsentry/utils/billing';
 import trackGetsentryAnalytics from 'getsentry/utils/trackGetsentryAnalytics';
-import ReserveAdditionalVolume from 'getsentry/views/amCheckout/reserveAdditionalVolume';
 import StepHeader from 'getsentry/views/amCheckout/steps/stepHeader';
 import VolumeSliders from 'getsentry/views/amCheckout/steps/volumeSliders';
 import type {StepProps} from 'getsentry/views/amCheckout/types';
@@ -30,7 +29,6 @@ function AddDataVolume({
   onEdit,
   onUpdate,
   onCompleteStep,
-  isNewCheckout,
 }: StepProps) {
   useEffect(() => {
     if (organization && isActive) {
@@ -105,24 +103,12 @@ function AddDataVolume({
         isCompleted={isCompleted}
         onEdit={onEdit}
       />
-      {/* TODO(checkout-v3): Remove this once the new plan step has been built */}
-      {isNewCheckout && isActive ? (
-        <ReserveAdditionalVolume
-          organization={organization}
-          subscription={subscription}
-          activePlan={activePlan}
-          checkoutTier={checkoutTier}
-          formData={formData}
-          onUpdate={onUpdate}
-        />
-      ) : (
-        isActive && (
-          <Fragment>
-            {renderInfo()}
-            {renderBody()}
-            {renderFooter()}
-          </Fragment>
-        )
+      {isActive && (
+        <Fragment>
+          {renderInfo()}
+          {renderBody()}
+          {renderFooter()}
+        </Fragment>
       )}
     </Panel>
   );

--- a/static/gsApp/views/amCheckout/steps/checkoutV3/buildYourPlan.spec.tsx
+++ b/static/gsApp/views/amCheckout/steps/checkoutV3/buildYourPlan.spec.tsx
@@ -1,0 +1,287 @@
+import {LocationFixture} from 'sentry-fixture/locationFixture';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {RouteComponentPropsFixture} from 'sentry-fixture/routeComponentPropsFixture';
+
+import {BillingConfigFixture} from 'getsentry-test/fixtures/billingConfig';
+import {PlanDetailsLookupFixture} from 'getsentry-test/fixtures/planDetailsLookup';
+import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
+import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
+import {resetMockDate, setMockDate, textWithMarkupMatcher} from 'sentry-test/utils';
+
+import SubscriptionStore from 'getsentry/stores/subscriptionStore';
+import {PlanTier} from 'getsentry/types';
+import AMCheckout from 'getsentry/views/amCheckout/';
+
+describe('BuildYourPlan', () => {
+  const api = new MockApiClient();
+  const organization = OrganizationFixture();
+  const subscription = SubscriptionFixture({organization, plan: 'am3_f'});
+
+  beforeEach(() => {
+    api.clear();
+    MockApiClient.clearMockResponses();
+    SubscriptionStore.set(organization.slug, subscription);
+
+    MockApiClient.addMockResponse({
+      url: `/subscriptions/${organization.slug}/`,
+      method: 'GET',
+      body: {},
+    });
+    MockApiClient.addMockResponse({
+      url: `/customers/${organization.slug}/billing-config/`,
+      method: 'GET',
+      body: BillingConfigFixture(PlanTier.AM3),
+    });
+    MockApiClient.addMockResponse({
+      method: 'POST',
+      url: '/_experiment/log_exposure/',
+      body: {},
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/promotions/trigger-check/`,
+      method: 'POST',
+      body: {},
+    });
+    MockApiClient.addMockResponse({
+      url: `/customers/${organization.slug}/plan-migrations/?applied=0`,
+      method: 'GET',
+      body: {},
+    });
+    MockApiClient.addMockResponse({
+      url: `/customers/${organization.slug}/subscription/preview/`,
+      method: 'GET',
+      body: {
+        invoiceItems: [],
+      },
+    });
+  });
+
+  function assertAllSubsteps(isNewCheckout: boolean) {
+    const substepTitles = ['Choose one', 'Select additional products', 'Billing cycle'];
+
+    if (isNewCheckout) {
+      substepTitles.forEach(title => {
+        expect(screen.getByText(title)).toBeInTheDocument();
+      });
+    } else {
+      substepTitles.forEach(title => {
+        expect(screen.queryByText(title)).not.toBeInTheDocument();
+      });
+    }
+  }
+
+  function renderCheckout(isNewCheckout: boolean, referrer?: string) {
+    let location = LocationFixture();
+    if (referrer) {
+      location = LocationFixture({
+        query: {
+          referrer,
+        },
+      });
+    }
+    render(
+      <AMCheckout
+        {...RouteComponentPropsFixture()}
+        api={api}
+        onToggleLegacy={jest.fn()}
+        checkoutTier={PlanTier.AM3}
+        isNewCheckout={isNewCheckout}
+        location={location}
+      />,
+      {organization}
+    );
+  }
+
+  it('renders for checkout v3', async () => {
+    renderCheckout(true);
+
+    expect(await screen.findByText('Build your plan')).toBeInTheDocument();
+    expect(screen.queryByTestId('body-choose-your-plan')).not.toBeInTheDocument();
+    assertAllSubsteps(true);
+  });
+
+  it('does not render for old checkout', async () => {
+    renderCheckout(false);
+
+    expect(await screen.findByTestId('body-choose-your-plan')).toBeInTheDocument();
+    expect(screen.queryByText('Build your plan')).not.toBeInTheDocument();
+    assertAllSubsteps(false);
+  });
+
+  describe('PlanSubstep', () => {
+    it('can toggle volume sliders', async () => {
+      renderCheckout(true);
+      expect(await screen.findByText('Reserve additional volume')).toBeInTheDocument();
+      expect(screen.queryByRole('slider')).not.toBeInTheDocument();
+
+      await userEvent.click(
+        screen.getByRole('button', {name: 'Show reserved volume sliders'})
+      );
+      expect(screen.getAllByRole('slider').length).toBeGreaterThan(0);
+
+      await userEvent.click(
+        screen.getByRole('button', {name: 'Hide reserved volume sliders'})
+      );
+      expect(screen.queryByRole('slider')).not.toBeInTheDocument();
+    });
+
+    it('annotates the current plan', async () => {
+      const bizOrg = OrganizationFixture();
+      const businessSubscription = SubscriptionFixture({
+        organization: bizOrg,
+        plan: 'am3_business',
+      });
+      SubscriptionStore.set(bizOrg.slug, businessSubscription);
+
+      renderCheckout(true);
+
+      const businessPlan = await screen.findByTestId('plan-option-am3_business');
+      expect(businessPlan).toBeInTheDocument();
+      expect(within(businessPlan).getByText('Current')).toBeInTheDocument();
+      const teamPlan = screen.getByTestId('plan-option-am3_team');
+      expect(within(teamPlan).queryByText('Current')).not.toBeInTheDocument();
+    });
+
+    it('renders targeted features when there is a referrer', async () => {
+      renderCheckout(true, 'upgrade-business-landing.relay');
+
+      const businessPlan = await screen.findByTestId('plan-option-am3_business');
+      const teamPlan = screen.getByTestId('plan-option-am3_team');
+      const warningText = textWithMarkupMatcher(
+        'This plan does not include Advanced server-side filtering'
+      );
+
+      await userEvent.click(businessPlan); // ensure we're on the business plan
+      expect(within(businessPlan).getByRole('radio')).toBeChecked();
+
+      // We don't nudge the user for features if they're already
+      // choosing that plan
+      const advancedFiltering = within(businessPlan)
+        .getByText('Advanced server-side filtering')
+        .closest('div')!;
+      await userEvent.click(businessPlan);
+      expect(
+        within(advancedFiltering).queryByText('Looking for this?')
+      ).not.toBeInTheDocument();
+      expect(within(teamPlan).queryByText(warningText)).not.toBeInTheDocument();
+
+      // Clicking Team shows all the warnings and nudges
+      await userEvent.click(teamPlan);
+      expect(within(teamPlan).getByRole('radio')).toBeChecked();
+      expect(
+        within(advancedFiltering).getByText('Looking for this?')
+      ).toBeInTheDocument();
+      expect(within(teamPlan).getByText(warningText)).toBeInTheDocument();
+    });
+
+    it('can select plan', async () => {
+      renderCheckout(true);
+
+      const teamPlan = await screen.findByTestId('plan-option-am3_team');
+      const businessPlan = screen.getByTestId('plan-option-am3_business');
+
+      expect(within(teamPlan).getByRole('radio')).not.toBeChecked();
+      expect(within(businessPlan).getByRole('radio')).toBeChecked();
+
+      await userEvent.click(teamPlan);
+      expect(within(teamPlan).getByRole('radio')).toBeChecked();
+      expect(within(businessPlan).getByRole('radio')).not.toBeChecked();
+    });
+  });
+
+  describe('BillingCycleSubstep', () => {
+    beforeEach(() => {
+      setMockDate(new Date('2025-08-13'));
+    });
+
+    afterEach(() => {
+      resetMockDate();
+      organization.features = [];
+    });
+
+    async function assertCycleText({
+      monthlyInfo,
+      yearlyInfo,
+    }: {
+      monthlyInfo: string | RegExp;
+      yearlyInfo: string | RegExp;
+    }) {
+      expect(await screen.findByText('Billing cycle')).toBeInTheDocument();
+
+      const monthlyOption = screen.getByTestId('billing-cycle-option-monthly');
+      expect(within(monthlyOption).getByText('Monthly')).toBeInTheDocument();
+      expect(within(monthlyOption).queryByText('save 10%')).not.toBeInTheDocument();
+      expect(within(monthlyOption).getByText(monthlyInfo)).toBeInTheDocument();
+      expect(within(monthlyOption).getByText('Cancel anytime')).toBeInTheDocument();
+
+      const yearlyOption = screen.getByTestId('billing-cycle-option-annual');
+      expect(within(yearlyOption).getByText('Yearly')).toBeInTheDocument();
+      expect(within(yearlyOption).getByText('save 10%')).toBeInTheDocument();
+      expect(within(yearlyOption).getByText(yearlyInfo)).toBeInTheDocument();
+      expect(
+        within(yearlyOption).getByText("Discount doesn't apply to pay-as-you-go usage")
+      ).toBeInTheDocument();
+    }
+
+    it('renders for coterm upgrade', async () => {
+      renderCheckout(true);
+      await assertCycleText({
+        monthlyInfo: /Billed monthly starting on August 13/,
+        yearlyInfo: /Billed every 12 months on the 13th of August/,
+      });
+    });
+
+    it('renders for monthly downgrade', async () => {
+      const annualSub = SubscriptionFixture({
+        planDetails: PlanDetailsLookupFixture('am2_business_auf'),
+        contractPeriodStart: '2025-07-16',
+        contractPeriodEnd: '2026-07-15',
+        organization,
+      });
+      SubscriptionStore.set(organization.slug, annualSub);
+      renderCheckout(true);
+      await assertCycleText({
+        monthlyInfo: /Billed monthly starting on July 16/,
+        yearlyInfo: /Billed every 12 months on the 13th of August/, // annual can be applied immediately
+      });
+    });
+
+    it('renders for migrating partner customers', async () => {
+      const partnerSub = SubscriptionFixture({
+        contractInterval: 'annual',
+        sponsoredType: 'FOO',
+        partner: {
+          isActive: true,
+          externalId: 'foo',
+          partnership: {
+            id: 'foo',
+            displayName: 'FOO',
+            supportNote: '',
+          },
+          name: '',
+        },
+        organization,
+      });
+      SubscriptionStore.set(organization.slug, partnerSub);
+      renderCheckout(true);
+      await assertCycleText({
+        monthlyInfo: /Billed monthly starting on your selected start date on submission/,
+        yearlyInfo: /Billed every 12 months from your selected start date on submission/,
+      });
+    });
+
+    it('can select billing cycle', async () => {
+      renderCheckout(true);
+
+      const monthly = await screen.findByTestId('billing-cycle-option-monthly');
+      const annual = screen.getByTestId('billing-cycle-option-annual');
+
+      expect(within(monthly).getByRole('radio')).toBeChecked();
+      expect(within(annual).getByRole('radio')).not.toBeChecked();
+
+      await userEvent.click(annual);
+      expect(within(monthly).getByRole('radio')).not.toBeChecked();
+      expect(within(annual).getByRole('radio')).toBeChecked();
+    });
+  });
+});

--- a/static/gsApp/views/amCheckout/steps/checkoutV3/buildYourPlan.tsx
+++ b/static/gsApp/views/amCheckout/steps/checkoutV3/buildYourPlan.tsx
@@ -67,8 +67,8 @@ function PlanSubstep({
       ({contractInterval}) => contractInterval === activePlan.contractInterval
     );
 
-    if (!plans) {
-      throw new Error('Cannot get plan options by interval');
+    if (plans.length === 0) {
+      throw new Error('Cannot get plan options');
     }
 
     // sort by price ascending
@@ -213,7 +213,7 @@ function BillingCycleSubstep({
     const basePlan = formData.plan.replace('_auf', '');
     const plans = billingConfig.planList.filter(({id}) => id.indexOf(basePlan) === 0);
 
-    if (!plans) {
+    if (plans.length === 0) {
       throw new Error('Cannot get billing interval options');
     }
 

--- a/static/gsApp/views/amCheckout/steps/checkoutV3/buildYourPlan.tsx
+++ b/static/gsApp/views/amCheckout/steps/checkoutV3/buildYourPlan.tsx
@@ -1,0 +1,354 @@
+import {useMemo} from 'react';
+import styled from '@emotion/styled';
+import cloneDeep from 'lodash/cloneDeep';
+import moment from 'moment-timezone';
+
+import {Tag} from 'sentry/components/core/badge/tag';
+import {t, tct} from 'sentry/locale';
+import type {Organization} from 'sentry/types/organization';
+import getDaysSinceDate from 'sentry/utils/getDaysSinceDate';
+
+import {ANNUAL} from 'getsentry/constants';
+import type {BillingConfig, Plan, PlanTier, Subscription} from 'getsentry/types';
+import {
+  getPlanIcon,
+  isBizPlanFamily,
+  isDeveloperPlan,
+  isNewPayingCustomer,
+  isTeamPlanFamily,
+  isTrialPlan,
+} from 'getsentry/utils/billing';
+import BillingCycleSelectCard from 'getsentry/views/amCheckout/billingCycleSelectCard';
+import ReserveAdditionalVolume from 'getsentry/views/amCheckout/reserveAdditionalVolume';
+import {getHighlightedFeatures} from 'getsentry/views/amCheckout/steps/planSelect';
+import PlanSelectCard from 'getsentry/views/amCheckout/steps/planSelectCard';
+import ProductSelect from 'getsentry/views/amCheckout/steps/productSelect';
+import StepHeader from 'getsentry/views/amCheckout/steps/stepHeader';
+import type {
+  CheckoutFormData,
+  CheckoutV3StepProps,
+  PlanContent,
+} from 'getsentry/views/amCheckout/types';
+import * as utils from 'getsentry/views/amCheckout/utils';
+
+interface BaseSubstepProps {
+  activePlan: Plan;
+  formData: CheckoutFormData;
+  onUpdate: (data: Partial<CheckoutFormData>) => void;
+}
+
+interface PlanSubstepProps extends BaseSubstepProps {
+  billingConfig: BillingConfig;
+  organization: Organization;
+  subscription: Subscription;
+  checkoutTier?: PlanTier;
+  referrer?: string;
+}
+
+interface AdditionalProductsSubstepProps extends BaseSubstepProps {}
+
+interface BillingCycleSubstepProps extends BaseSubstepProps {
+  billingConfig: BillingConfig;
+  subscription: Subscription;
+}
+
+function PlanSubstep({
+  billingConfig,
+  activePlan,
+  formData,
+  subscription,
+  organization,
+  referrer,
+  checkoutTier,
+  onUpdate,
+}: PlanSubstepProps) {
+  const planOptions = useMemo(() => {
+    const plans = billingConfig.planList.filter(
+      ({contractInterval}) => contractInterval === activePlan.contractInterval
+    );
+
+    if (!plans) {
+      throw new Error('Cannot get plan options by interval');
+    }
+
+    // sort by price ascending
+    return plans.sort((a, b) => a.basePrice - b.basePrice);
+  }, [billingConfig, activePlan.contractInterval]);
+
+  const bizPlanContent: PlanContent = useMemo(() => {
+    const bizPlan = billingConfig.planList.find(p => isBizPlanFamily(p));
+    if (!bizPlan) {
+      return {
+        description: '',
+        features: {},
+      };
+    }
+    return utils.getContentForPlan(bizPlan);
+  }, [billingConfig]);
+
+  const getBadge = (plan: Plan): React.ReactNode | undefined => {
+    if (
+      plan.id === subscription.plan ||
+      // TODO(checkout v3): Test this once Developer is surfaced
+      (isTrialPlan(subscription.plan) && isDeveloperPlan(plan))
+    ) {
+      // TODO(checkout v3): Replace with custom badge
+      const copy = t('Current');
+      return <Tag type="info">{copy}</Tag>;
+    }
+
+    if (
+      isBizPlanFamily(plan) &&
+      subscription.lastTrialEnd &&
+      !isBizPlanFamily(subscription.planDetails)
+    ) {
+      const lastTrialEnd = moment(subscription.lastTrialEnd).utc().fromNow();
+      const trialExpired: boolean = getDaysSinceDate(subscription.lastTrialEnd) > 0;
+      return (
+        <Tag type="info">
+          {subscription.isTrial && !trialExpired
+            ? tct('Trial expires [lastTrialEnd]', {lastTrialEnd})
+            : t('You trialed this plan')}
+        </Tag>
+      );
+    }
+    return undefined;
+  };
+
+  return (
+    <Substep>
+      <SubstepTitle>{t('Choose one')}</SubstepTitle>
+      <OptionGrid columns={planOptions.length}>
+        {planOptions.map(plan => {
+          const isSelected = plan.id === formData.plan;
+          const shouldShowDefaultPayAsYouGo = isNewPayingCustomer(
+            subscription,
+            organization
+          );
+          const planIndex = planOptions.indexOf(plan);
+          const priorPlan = planIndex > 0 ? planOptions[planIndex - 1] : undefined;
+          const basePrice = utils.formatPrice({cents: plan.basePrice}); // TODO(isabella): confirm discountInfo is no longer used
+
+          let planContent = utils.getContentForPlan(plan);
+          const highlightedFeatures = getHighlightedFeatures(referrer);
+
+          // Additional members is available on any paid plan
+          // but it's so impactful it doesn't hurt to add it in for the business plan
+          // if the user is coming from a deactivated member header CTA
+          if (isBizPlanFamily(plan) && referrer === 'deactivated_member_header') {
+            highlightedFeatures.push('deactivated_member_header');
+            planContent = cloneDeep(planContent);
+            planContent.features.deactivated_member_header = t('Unlimited members');
+          }
+
+          let missingFeatures: string[] = [];
+          if (isTeamPlanFamily(plan) && isSelected) {
+            missingFeatures = getHighlightedFeatures(referrer).filter(
+              feature => !planContent.features[feature]
+            );
+          }
+
+          const planIcon = getPlanIcon(plan);
+          const badge = getBadge(plan);
+
+          return (
+            <PlanSelectCard
+              key={plan.id}
+              plan={plan}
+              isSelected={isSelected}
+              onUpdate={onUpdate}
+              planValue={plan.name}
+              planName={plan.name}
+              price={basePrice}
+              planContent={planContent}
+              highlightedFeatures={highlightedFeatures}
+              planIcon={planIcon}
+              shouldShowDefaultPayAsYouGo={shouldShowDefaultPayAsYouGo}
+              shouldShowEventPrice={!!isBizPlanFamily(plan)}
+              priorPlan={priorPlan}
+              badge={badge}
+              missingFeatures={missingFeatures}
+              upsellPlanContent={bizPlanContent}
+            />
+          );
+        })}
+      </OptionGrid>
+      <ReserveAdditionalVolume
+        activePlan={activePlan}
+        formData={formData}
+        onUpdate={onUpdate}
+        organization={organization}
+        subscription={subscription}
+        checkoutTier={checkoutTier}
+      />
+    </Substep>
+  );
+}
+
+function AdditionalProductsSubstep({
+  activePlan,
+  formData,
+  onUpdate,
+}: AdditionalProductsSubstepProps) {
+  return (
+    <Substep>
+      <SubstepTitle>{t('Select additional products')}</SubstepTitle>
+      <ProductSelect
+        activePlan={activePlan}
+        formData={formData}
+        onUpdate={onUpdate}
+        isNewCheckout
+      />
+    </Substep>
+  );
+}
+
+function BillingCycleSubstep({
+  formData,
+  onUpdate,
+  subscription,
+  billingConfig,
+}: BillingCycleSubstepProps) {
+  const intervalOptions = useMemo(() => {
+    const basePlan = formData.plan.replace('_auf', '');
+    const plans = billingConfig.planList.filter(({id}) => id.indexOf(basePlan) === 0);
+
+    if (!plans) {
+      throw new Error('Cannot get billing interval options');
+    }
+
+    return plans;
+  }, [billingConfig, formData.plan]);
+
+  let previousPlanPrice = 0;
+  return (
+    <Substep>
+      <SubstepHeader>
+        <SubstepTitle>{t('Billing cycle')}</SubstepTitle>
+        <SubstepDescription>
+          {t('Additional usage is billed separately, at the start of the next cycle')}
+        </SubstepDescription>
+      </SubstepHeader>
+      <OptionGrid columns={intervalOptions.length}>
+        {intervalOptions.map(plan => {
+          const isSelected = plan.id === formData.plan;
+          const isAnnual = plan.contractInterval === ANNUAL;
+          const priceAfterDiscount = utils.getReservedPriceCents({
+            plan,
+            reserved: formData.reserved,
+            selectedProducts: formData.selectedProducts,
+          });
+          const formattedPriceAfterDiscount = utils.formatPrice({
+            cents: priceAfterDiscount,
+          });
+
+          const priceBeforeDiscount = isAnnual ? previousPlanPrice * 12 : 0;
+          const formattedPriceBeforeDiscount = previousPlanPrice
+            ? utils.formatPrice({cents: priceBeforeDiscount})
+            : '';
+          previousPlanPrice = priceAfterDiscount;
+
+          return (
+            <BillingCycleSelectCard
+              key={plan.id}
+              plan={plan}
+              isSelected={isSelected}
+              onUpdate={onUpdate}
+              subscription={subscription}
+              formattedPriceAfterDiscount={formattedPriceAfterDiscount}
+              formattedPriceBeforeDiscount={formattedPriceBeforeDiscount}
+              priceAfterDiscount={priceAfterDiscount}
+            />
+          );
+        })}
+      </OptionGrid>
+    </Substep>
+  );
+}
+
+function BuildYourPlan({
+  activePlan,
+  billingConfig,
+  organization,
+  subscription,
+  formData,
+  referrer,
+  onEdit,
+  onUpdate,
+  stepNumber,
+  checkoutTier,
+}: CheckoutV3StepProps) {
+  return (
+    <BuildYourPlanContainer>
+      <StepHeader
+        isActive
+        isCompleted={false}
+        onEdit={onEdit}
+        stepNumber={stepNumber}
+        title={t('Build your plan')}
+        isNewCheckout
+      />
+      <PlanSubstep
+        activePlan={activePlan}
+        billingConfig={billingConfig}
+        formData={formData}
+        onUpdate={onUpdate}
+        organization={organization}
+        referrer={referrer}
+        subscription={subscription}
+        checkoutTier={checkoutTier}
+      />
+      <AdditionalProductsSubstep
+        activePlan={activePlan}
+        formData={formData}
+        onUpdate={onUpdate}
+      />
+      <BillingCycleSubstep
+        activePlan={activePlan}
+        formData={formData}
+        onUpdate={onUpdate}
+        subscription={subscription}
+        billingConfig={billingConfig}
+      />
+    </BuildYourPlanContainer>
+  );
+}
+
+export default BuildYourPlan;
+
+const BuildYourPlanContainer = styled('div')``;
+
+const Substep = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: ${p => p.theme.space.xl};
+  margin-bottom: ${p => p.theme.space.xl};
+`;
+
+const SubstepTitle = styled('h2')`
+  font-size: ${p => p.theme.fontSize.md};
+  margin-top: ${p => p.theme.space['2xl']};
+  margin-bottom: 0;
+`;
+
+const SubstepDescription = styled('p')`
+  margin: 0;
+  color: ${p => p.theme.subText};
+`;
+
+const SubstepHeader = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: ${p => p.theme.space.xs};
+`;
+
+const OptionGrid = styled('div')<{columns: number}>`
+  display: grid;
+  grid-template-columns: repeat(${p => p.columns}, 1fr);
+  column-gap: ${p => p.theme.space.xl};
+
+  @media (max-width: ${p => p.theme.breakpoints.md}) {
+    grid-template-columns: repeat(1, 1fr);
+    row-gap: ${p => p.theme.space.xl};
+  }
+`;

--- a/static/gsApp/views/amCheckout/steps/contractSelect.spec.tsx
+++ b/static/gsApp/views/amCheckout/steps/contractSelect.spec.tsx
@@ -2,7 +2,6 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {RouteComponentPropsFixture} from 'sentry-fixture/routeComponentPropsFixture';
 
 import {BillingConfigFixture} from 'getsentry-test/fixtures/billingConfig';
-import {PlanDetailsLookupFixture} from 'getsentry-test/fixtures/planDetailsLookup';
 import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
 import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
 import {resetMockDate, setMockDate} from 'sentry-test/utils';
@@ -24,7 +23,7 @@ describe('ContractSelect', () => {
 
   const warningText = /You are currently on an annual contract/;
 
-  function renderView({isNewCheckout}: {isNewCheckout?: boolean} = {}) {
+  function renderView() {
     return render(
       <AMCheckout
         {...RouteComponentPropsFixture()}
@@ -33,7 +32,6 @@ describe('ContractSelect', () => {
         onToggleLegacy={jest.fn()}
         checkoutTier={PlanTier.AM2}
         organization={organization}
-        isNewCheckout={isNewCheckout}
       />
     );
   }
@@ -75,7 +73,7 @@ describe('ContractSelect', () => {
     organization.features = [];
   });
 
-  async function assertAndOpenPanel({isNewCheckout}: {isNewCheckout: boolean}) {
+  async function assertAndOpenPanel() {
     const header = await screen.findByTestId('header-contract-term-discounts');
     expect(within(header).getByText('Contract Term & Discounts')).toBeInTheDocument();
     // Panel starts off closed.
@@ -86,92 +84,18 @@ describe('ContractSelect', () => {
 
     // Panel should be open and options visible.
     expect(screen.getByText('Monthly')).toBeInTheDocument();
-    expect(
-      screen.getByText(isNewCheckout ? 'Yearly' : 'Annual Contract')
-    ).toBeInTheDocument();
+    expect(screen.getByText('Annual Contract')).toBeInTheDocument();
     expect(screen.getByDisplayValue('monthly')).toBeInTheDocument();
     expect(screen.getByDisplayValue('annual')).toBeInTheDocument();
   }
 
-  function assertCheckoutV3Text({
-    monthlyInfo,
-    yearlyInfo,
-  }: {
-    monthlyInfo: string | RegExp;
-    yearlyInfo: string | RegExp;
-  }) {
-    const monthlyOption = screen.getByTestId('billing-cycle-option-monthly');
-    expect(within(monthlyOption).getByText('Monthly')).toBeInTheDocument();
-    expect(within(monthlyOption).queryByText('save 10%')).not.toBeInTheDocument();
-    expect(within(monthlyOption).getByText(monthlyInfo)).toBeInTheDocument();
-    expect(within(monthlyOption).getByText('Cancel anytime')).toBeInTheDocument();
-
-    const yearlyOption = screen.getByTestId('billing-cycle-option-annual');
-    expect(within(yearlyOption).getByText('Yearly')).toBeInTheDocument();
-    expect(within(yearlyOption).getByText('save 10%')).toBeInTheDocument();
-    expect(within(yearlyOption).getByText(yearlyInfo)).toBeInTheDocument();
-    expect(
-      within(yearlyOption).getByText("Discount doesn't apply to on-demand usage")
-    ).toBeInTheDocument();
-  }
-
   it('renders', async () => {
     renderView();
-    await assertAndOpenPanel({isNewCheckout: false});
+    await assertAndOpenPanel();
 
     // does not show event price tags
     expect(screen.queryByText(/\ error/)).not.toBeInTheDocument();
     expect(screen.queryByText(/\ span/)).not.toBeInTheDocument();
-  });
-
-  it('renders for coterm upgrade for checkout v3', async () => {
-    renderView({isNewCheckout: true});
-    await assertAndOpenPanel({isNewCheckout: true});
-    assertCheckoutV3Text({
-      monthlyInfo: /Billed monthly starting on August 13/,
-      yearlyInfo: /Billed every 12 months on the 13th of August/,
-    });
-  });
-
-  it('renders for monthly downgrade for checkout v3', async () => {
-    const annualSub = SubscriptionFixture({
-      planDetails: PlanDetailsLookupFixture('am2_business_auf'),
-      contractPeriodStart: '2025-07-16',
-      contractPeriodEnd: '2026-07-15',
-      organization,
-    });
-    SubscriptionStore.set(organization.slug, annualSub);
-    renderView({isNewCheckout: true});
-    await assertAndOpenPanel({isNewCheckout: true});
-    assertCheckoutV3Text({
-      monthlyInfo: /Billed monthly starting on July 16/,
-      yearlyInfo: /Billed every 12 months on the 13th of August/, // annual can be applied immediately
-    });
-  });
-
-  it('renders for partner migration for checkout v3', async () => {
-    const partnerSub = SubscriptionFixture({
-      contractInterval: 'annual',
-      sponsoredType: 'FOO',
-      partner: {
-        isActive: true,
-        externalId: 'foo',
-        partnership: {
-          id: 'foo',
-          displayName: 'FOO',
-          supportNote: '',
-        },
-        name: '',
-      },
-      organization,
-    });
-    SubscriptionStore.set(organization.slug, partnerSub);
-    renderView({isNewCheckout: true});
-    await assertAndOpenPanel({isNewCheckout: true});
-    assertCheckoutV3Text({
-      monthlyInfo: /Billed monthly starting on your selected start date on submission/,
-      yearlyInfo: /Billed every 12 months from your selected start date on submission/,
-    });
   });
 
   it('can select contract term', async () => {

--- a/static/gsApp/views/amCheckout/steps/contractSelect.tsx
+++ b/static/gsApp/views/amCheckout/steps/contractSelect.tsx
@@ -11,7 +11,6 @@ import {space} from 'sentry/styles/space';
 
 import {ANNUAL, MONTHLY} from 'getsentry/constants';
 import type {Plan} from 'getsentry/types';
-import BillingCycleSelectCard from 'getsentry/views/amCheckout/billingCycleSelectCard';
 import PlanSelectRow from 'getsentry/views/amCheckout/steps/planSelectRow';
 import StepHeader from 'getsentry/views/amCheckout/steps/stepHeader';
 import type {StepProps} from 'getsentry/views/amCheckout/types';
@@ -75,8 +74,7 @@ class ContractSelect extends Component<Props> {
   }
 
   renderBody = () => {
-    const {onUpdate, formData, subscription, promotion, isNewCheckout} = this.props;
-    let previousPlanPrice = 0;
+    const {onUpdate, formData, subscription, promotion} = this.props;
 
     return (
       <PanelBody data-test-id={this.title}>
@@ -116,35 +114,12 @@ class ContractSelect extends Component<Props> {
           });
           const formattedPriceAfterDiscount = formatPrice({cents: priceAfterDiscount});
 
-          const priceBeforeDiscount = isAnnual ? previousPlanPrice * 12 : 0;
-          const formattedPriceBeforeDiscount = previousPlanPrice
-            ? formatPrice({cents: priceBeforeDiscount})
-            : '';
-          previousPlanPrice = priceAfterDiscount;
-
-          const commonProps = {
-            plan,
-            isSelected,
-            onUpdate,
-          };
-
-          if (isNewCheckout) {
-            // TODO(checkout v3): take this out when the new plan step is implemented
-            return (
-              <BillingCycleSelectCard
-                key={plan.id}
-                subscription={subscription}
-                priceAfterDiscount={priceAfterDiscount}
-                formattedPriceAfterDiscount={formattedPriceAfterDiscount}
-                formattedPriceBeforeDiscount={formattedPriceBeforeDiscount}
-                {...commonProps}
-              />
-            );
-          }
-
           return (
             <PlanSelectRow
               key={plan.id}
+              plan={plan}
+              isSelected={isSelected}
+              onUpdate={onUpdate}
               planName={name}
               planValue={plan.billingInterval}
               planContent={{description, features: {}}}
@@ -153,7 +128,6 @@ class ContractSelect extends Component<Props> {
               shouldShowDefaultPayAsYouGo={false}
               shouldShowEventPrice={false}
               price={formattedPriceAfterDiscount}
-              {...commonProps}
             />
           );
         })}

--- a/static/gsApp/views/amCheckout/steps/planSelect.spec.tsx
+++ b/static/gsApp/views/amCheckout/steps/planSelect.spec.tsx
@@ -79,48 +79,6 @@ describe('PlanSelect', () => {
     expect(screen.getByTestId('footer-choose-your-plan')).toBeInTheDocument();
   });
 
-  it('renders for checkout v3', async () => {
-    MockApiClient.addMockResponse({
-      url: `/customers/${organization.slug}/billing-config/`,
-      method: 'GET',
-      body: BillingConfigFixture(PlanTier.AM3),
-    });
-    const freeSubscription = SubscriptionFixture({
-      organization,
-      plan: 'am3_f',
-      isFree: true,
-    });
-    SubscriptionStore.set(organization.slug, freeSubscription);
-
-    render(
-      <AMCheckout
-        {...RouteComponentPropsFixture()}
-        params={params}
-        api={api}
-        onToggleLegacy={jest.fn()}
-        checkoutTier={PlanTier.AM3}
-        isNewCheckout
-      />,
-      {organization}
-    );
-
-    expect(await screen.findByTestId('body-choose-your-plan')).toBeInTheDocument();
-    expect(screen.getByTestId('footer-choose-your-plan')).toBeInTheDocument();
-
-    const teamPlan = await screen.findByTestId('plan-option-am3_team');
-    const businessPlan = screen.getByTestId('plan-option-am3_business');
-
-    // no longer use lightning icon for business plan
-    expect(within(teamPlan).getAllByTestId('icon-check-mark').length).toBeGreaterThan(0);
-    expect(within(businessPlan).getAllByTestId('icon-check-mark').length).toBeGreaterThan(
-      0
-    );
-
-    // new excess usage pricing warning
-    expect(within(teamPlan).queryByText(/Excess usage/)).not.toBeInTheDocument();
-    expect(within(businessPlan).getByText(/Excess usage/)).toBeInTheDocument();
-  });
-
   it('renders checkmarks on team plan', async () => {
     const org = OrganizationFixture();
     const teamSubscription = SubscriptionFixture({

--- a/static/gsApp/views/amCheckout/steps/planSelect.tsx
+++ b/static/gsApp/views/amCheckout/steps/planSelect.tsx
@@ -30,7 +30,7 @@ import usePromotionTriggerCheck from 'getsentry/utils/usePromotionTriggerCheck';
 import PlanSelectRow from 'getsentry/views/amCheckout/steps/planSelectRow';
 import ProductSelect from 'getsentry/views/amCheckout/steps/productSelect';
 import StepHeader from 'getsentry/views/amCheckout/steps/stepHeader';
-import type {StepProps} from 'getsentry/views/amCheckout/types';
+import type {PlanContent, StepProps} from 'getsentry/views/amCheckout/types';
 import {
   formatPrice,
   getContentForPlan,
@@ -205,8 +205,10 @@ function PlanSelect({
     const bizPlan = getPlanOptions({
       billingConfig,
       activePlan,
-    }).find(plan => isBizPlanFamily(plan))!;
-    const bizPlanContent = getContentForPlan(bizPlan);
+    }).find(plan => isBizPlanFamily(plan));
+    const bizPlanContent: PlanContent = bizPlan
+      ? getContentForPlan(bizPlan)
+      : {features: {}, description: ''};
 
     let missingFeatures: string[] = [];
 
@@ -220,7 +222,7 @@ function PlanSelect({
     return (
       <StepFooter data-test-id="footer-choose-your-plan">
         <div>
-          {missingFeatures.length > 0 ? (
+          {bizPlanContent.features && missingFeatures.length > 0 ? (
             <FooterWarningWrapper>
               <IconWarning />
               {tct('This plan does not include [missingFeatures]', {

--- a/static/gsApp/views/amCheckout/steps/planSelect.tsx
+++ b/static/gsApp/views/amCheckout/steps/planSelect.tsx
@@ -16,7 +16,6 @@ import {Oxfordize} from 'sentry/utils/oxfordizeArray';
 import {PlanTier, type Plan} from 'getsentry/types';
 import {
   getBusinessPlanOfTier,
-  getPlanIcon,
   isBizPlanFamily,
   isNewPayingCustomer,
   isTeamPlan,
@@ -28,51 +27,15 @@ import {
 } from 'getsentry/utils/promotionUtils';
 import trackGetsentryAnalytics from 'getsentry/utils/trackGetsentryAnalytics';
 import usePromotionTriggerCheck from 'getsentry/utils/usePromotionTriggerCheck';
-import PlanSelectCard from 'getsentry/views/amCheckout/steps/planSelectCard';
 import PlanSelectRow from 'getsentry/views/amCheckout/steps/planSelectRow';
 import ProductSelect from 'getsentry/views/amCheckout/steps/productSelect';
 import StepHeader from 'getsentry/views/amCheckout/steps/stepHeader';
 import type {StepProps} from 'getsentry/views/amCheckout/types';
-import {formatPrice, getDiscountedPrice} from 'getsentry/views/amCheckout/utils';
-
-export type PlanContent = {
-  description: React.ReactNode;
-  features: Record<string, React.ReactNode>;
-  hasMoreLink?: boolean;
-};
-
-function getContentForPlan(
-  plan: 'team' | 'business',
-  checkoutTier?: PlanTier
-): PlanContent {
-  if (plan === 'team') {
-    return {
-      description: t('Resolve errors and track application performance as a team.'),
-      features: {
-        unlimited_members: t('Unlimited members'),
-        integrations: t('Third-party integrations'),
-        metric_alerts: t('Metric alerts'),
-      },
-    };
-  }
-
-  return {
-    description: t(
-      'Everything in the Team plan + deeper insight into your application health.'
-    ),
-    features: {
-      discover: t('Advanced analytics with Discover'),
-      enhanced_priority_alerts: t('Enhanced issue priority and alerting'),
-      dashboard: t('Unlimited custom dashboards'),
-      ...(checkoutTier === PlanTier.AM3 && {
-        application_insights: t('Application Insights'),
-      }),
-      advanced_filtering: t('Advanced server-side filtering'),
-      saml: t('SAML support'),
-    },
-    hasMoreLink: true,
-  };
-}
+import {
+  formatPrice,
+  getContentForPlan,
+  getDiscountedPrice,
+} from 'getsentry/views/amCheckout/utils';
 
 const REFERRER_FEATURE_HIGHLIGHTS = {
   'upgrade-business-landing.sso': ['saml'],
@@ -88,9 +51,12 @@ const REFERRER_FEATURE_HIGHLIGHTS = {
   'upsell-discover2': ['discover'],
 };
 
-function getHighlightedFeatures(referrer?: string): string[] {
-  // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-  return referrer ? (REFERRER_FEATURE_HIGHLIGHTS[referrer] ?? []) : [];
+export function getHighlightedFeatures(referrer?: string): string[] {
+  return referrer
+    ? (REFERRER_FEATURE_HIGHLIGHTS[
+        referrer as keyof typeof REFERRER_FEATURE_HIGHLIGHTS
+      ] ?? [])
+    : [];
 }
 
 /**
@@ -129,7 +95,6 @@ function PlanSelect({
   subscription,
   formData,
   referrer,
-  isNewCheckout,
   onEdit,
   onToggleLegacy,
   onUpdate,
@@ -152,9 +117,7 @@ function PlanSelect({
 
   const getBadge = (plan: Plan): React.ReactNode | undefined => {
     if (plan.id === subscription.plan) {
-      // TODO(checkout v3): Replace with custom badge
-      const copy = isNewCheckout ? t('Current') : t('Current plan');
-      return <Tag type="info">{copy}</Tag>;
+      return <Tag type="info">{t('Current plan')}</Tag>;
     }
 
     if (
@@ -180,23 +143,10 @@ function PlanSelect({
       isNewPayingCustomer(subscription, organization) && checkoutTier === PlanTier.AM3; // TODO(isabella): Test if this behavior works as expected on older tiers
 
     const planOptions = getPlanOptions({billingConfig, activePlan});
-    const planToPriorPlan = planOptions.reduce(
-      (acc, plan, i) => {
-        if (i > 0) {
-          const nextPlan = planOptions[i - 1];
-          if (nextPlan) {
-            acc[nextPlan.id] = plan;
-          }
-        }
-        return acc;
-      },
-      {} as Record<string, Plan>
-    );
     return (
       <PanelBody data-test-id="body-choose-your-plan">
         {planOptions.map(plan => {
           const isSelected = plan.id === formData.plan;
-          const priorPlan = planToPriorPlan[plan.id];
 
           // calculate the price with discount
           const cents =
@@ -210,10 +160,7 @@ function PlanSelect({
               : plan.basePrice;
           const basePrice = formatPrice({cents});
 
-          let planContent = getContentForPlan(
-            isTeamPlanFamily(plan) ? 'team' : 'business',
-            checkoutTier
-          );
+          let planContent = getContentForPlan(plan);
           const highlightedFeatures = getHighlightedFeatures(referrer);
           const isFeaturesCheckmarked = !subscription.isFree && isTeamPlanFamily(plan);
 
@@ -226,34 +173,6 @@ function PlanSelect({
             planContent.features.deactivated_member_header = t('Unlimited members');
           }
 
-          const planIcon = getPlanIcon(plan);
-
-          const commonProps = {
-            plan,
-            isSelected,
-            badge: getBadge(plan),
-            onUpdate,
-            planValue: plan.name,
-            planName: plan.name,
-            priceHeader: t('Starts At'),
-            price: basePrice,
-            planContent,
-            highlightedFeatures,
-            shouldShowDefaultPayAsYouGo,
-          };
-
-          if (isNewCheckout) {
-            return (
-              <PlanSelectCard
-                key={plan.id}
-                planIcon={planIcon}
-                priorPlan={priorPlan}
-                shouldShowEventPrice={!!isBizPlanFamily(plan)}
-                {...commonProps}
-              />
-            );
-          }
-
           return (
             <PlanSelectRow
               key={plan.id}
@@ -264,7 +183,17 @@ function PlanSelect({
                   : undefined
               }
               shouldShowEventPrice
-              {...commonProps}
+              plan={plan}
+              isSelected={isSelected}
+              badge={getBadge(plan)}
+              onUpdate={onUpdate}
+              planValue={plan.name}
+              planName={plan.name}
+              priceHeader={t('Starts At')}
+              price={basePrice}
+              planContent={planContent}
+              highlightedFeatures={highlightedFeatures}
+              shouldShowDefaultPayAsYouGo={shouldShowDefaultPayAsYouGo}
             />
           );
         })}
@@ -273,11 +202,16 @@ function PlanSelect({
   };
 
   const renderFooter = () => {
-    const bizPlanContent = getContentForPlan('business', checkoutTier);
+    const bizPlan = getPlanOptions({
+      billingConfig,
+      activePlan,
+    }).find(plan => isBizPlanFamily(plan))!;
+    const bizPlanContent = getContentForPlan(bizPlan);
+
     let missingFeatures: string[] = [];
 
     if (isTeamPlanFamily(activePlan)) {
-      const selectedPlanContent = getContentForPlan('team', checkoutTier);
+      const selectedPlanContent = getContentForPlan(activePlan);
       missingFeatures = getHighlightedFeatures(referrer).filter(
         feature => !selectedPlanContent.features[feature]
       );
@@ -364,12 +298,7 @@ function PlanSelect({
       />
       {isActive && renderBody()}
       {isActive && (
-        <ProductSelect
-          activePlan={activePlan}
-          formData={formData}
-          onUpdate={onUpdate}
-          isNewCheckout={isNewCheckout}
-        />
+        <ProductSelect activePlan={activePlan} formData={formData} onUpdate={onUpdate} />
       )}
       {isActive && renderFooter()}
     </Panel>

--- a/static/gsApp/views/amCheckout/steps/planSelectRow.tsx
+++ b/static/gsApp/views/amCheckout/steps/planSelectRow.tsx
@@ -11,30 +11,19 @@ import {space} from 'sentry/styles/space';
 import TextBlock from 'sentry/views/settings/components/text/textBlock';
 
 import {PAYG_BUSINESS_DEFAULT, PAYG_TEAM_DEFAULT} from 'getsentry/constants';
-import {
-  OnDemandBudgetMode,
-  type Plan,
-  type Promotion,
-  type SharedOnDemandBudget,
-} from 'getsentry/types';
+import {OnDemandBudgetMode, type Plan, type Promotion} from 'getsentry/types';
 import {isBizPlanFamily} from 'getsentry/utils/billing';
 import MoreFeaturesLink from 'getsentry/views/amCheckout/moreFeaturesLink';
-import type {PlanContent} from 'getsentry/views/amCheckout/steps/planSelect';
+import type {CheckoutFormData, PlanContent} from 'getsentry/views/amCheckout/types';
 import {
   displayUnitPrice,
   formatPrice,
   getShortInterval,
 } from 'getsentry/views/amCheckout/utils';
 
-export type PlanUpdateData = {
-  plan: string;
-  onDemandBudget?: SharedOnDemandBudget;
-  onDemandMaxSpend?: number;
-};
-
 export type PlanSelectRowProps = {
   isSelected: boolean;
-  onUpdate: (data: PlanUpdateData) => void;
+  onUpdate: (data: Partial<CheckoutFormData>) => void;
   plan: Plan;
   planContent: PlanContent;
   planName: string;
@@ -113,7 +102,7 @@ function PlanSelectRow({
               value={planValue}
               checked={isSelected}
               onClick={() => {
-                const data: PlanUpdateData = {plan: plan.id};
+                const data: Partial<CheckoutFormData> = {plan: plan.id};
                 if (shouldShowDefaultPayAsYouGo) {
                   data.onDemandMaxSpend = isBizPlanFamily(plan)
                     ? PAYG_BUSINESS_DEFAULT

--- a/static/gsApp/views/amCheckout/steps/productSelect.spec.tsx
+++ b/static/gsApp/views/amCheckout/steps/productSelect.spec.tsx
@@ -108,7 +108,6 @@ describe('ProductSelect', () => {
     expect(
       screen.getByRole('checkbox', {name: /Add seer AI agent to plan/})
     ).toBeInTheDocument();
-    expect(screen.getByTestId('footer-choose-your-plan')).toBeInTheDocument();
   });
 
   it('does not render products if flags are missing', async () => {

--- a/static/gsApp/views/amCheckout/steps/productSelect.tsx
+++ b/static/gsApp/views/amCheckout/steps/productSelect.tsx
@@ -82,7 +82,7 @@ function ProductSelect({
 
   return (
     <Fragment>
-      <Separator />
+      {!isNewCheckout && <Separator />}
       {availableProducts.map(productInfo => {
         const checkoutInfo =
           PRODUCT_CHECKOUT_INFO[productInfo.apiName as string as SelectableProduct];
@@ -91,7 +91,8 @@ function ProductSelect({
         }
 
         const productIcon = getProductIcon(
-          productInfo.apiName as string as SelectableProduct
+          productInfo.apiName as string as SelectableProduct,
+          'lg'
         );
 
         // how much the customer is paying for the product
@@ -133,6 +134,7 @@ function ProductSelect({
               aria-label={ariaLabel}
               data-test-id={`product-option-${productInfo.apiName}`}
               onClick={toggleProductOption}
+              isNewCheckout={isNewCheckout}
             >
               <ProductOptionContent isSelected={isSelected} isNewCheckout>
                 <Column>
@@ -329,8 +331,8 @@ const Separator = styled('div')`
   margin: 0;
 `;
 
-const ProductOption = styled(PanelItem)<{isSelected?: boolean}>`
-  margin: ${p => p.theme.space.lg};
+const ProductOption = styled(PanelItem)<{isNewCheckout?: boolean; isSelected?: boolean}>`
+  margin: ${p => (p.isNewCheckout ? '0' : p.theme.space.lg)};
   padding: 0;
   display: inherit;
   cursor: pointer;
@@ -346,6 +348,14 @@ const ProductOptionContent = styled('div')<{
   justify-content: ${p => (p.isNewCheckout ? 'space-between' : 'flex-start')};
   border-radius: ${p => p.theme.borderRadius};
   border: 1px solid ${p => p.theme.innerBorder};
+  width: 100%;
+
+  ${p =>
+    p.isNewCheckout &&
+    !p.isSelected &&
+    css`
+      background-color: ${p.theme.background};
+    `}
 
   ${p =>
     p.isNewCheckout &&

--- a/static/gsApp/views/amCheckout/types.tsx
+++ b/static/gsApp/views/amCheckout/types.tsx
@@ -39,26 +39,37 @@ export type CheckoutAPIData = Omit<BaseCheckoutData, 'selectedProducts'> & {
   seer?: boolean; // TODO: in future, we should just use selectedProducts
 } & Partial<Record<`reserved${Capitalize<DataCategory>}`, number>>;
 
-export type StepProps = {
+type BaseStepProps = {
   activePlan: Plan;
   billingConfig: BillingConfig;
   formData: CheckoutFormData;
-  isActive: boolean;
-  isCompleted: boolean;
-  onCompleteStep: (stepNumber: number) => void;
   onEdit: (stepNumber: number) => void;
   onUpdate: (data: any) => void;
   organization: Organization;
-  prevStepCompleted: boolean;
   stepNumber: number;
   subscription: Subscription;
   checkoutTier?: PlanTier;
+  referrer?: string;
+};
+
+export type StepProps = BaseStepProps & {
+  isActive: boolean;
+  isCompleted: boolean;
+  onCompleteStep: (stepNumber: number) => void;
+  prevStepCompleted: boolean;
   isNewCheckout?: boolean;
   onToggleLegacy?: (tier: string) => void;
   promotion?: Promotion;
-  referrer?: string;
 };
 
 export interface StepPropsWithApi extends StepProps {
   api: Client;
 }
+
+export type CheckoutV3StepProps = BaseStepProps;
+
+export type PlanContent = {
+  description: React.ReactNode;
+  features: Record<string, React.ReactNode>;
+  hasMoreLink?: boolean;
+};

--- a/static/gsApp/views/amCheckout/utils.tsx
+++ b/static/gsApp/views/amCheckout/utils.tsx
@@ -897,8 +897,8 @@ export function getContentForPlan(plan: Plan): PlanContent {
       spans: t('5M Spans'),
       attachments: t('1GB Attachments'),
       monitorSeats: t('1 Cron Monitor'),
-      upttime: t('1 Uptime Monitor'),
-      logs: t('5GB Logs'),
+      uptime: t('1 Uptime Monitor'),
+      logBytes: t('5GB Logs'),
     },
   };
 }

--- a/static/gsApp/views/amCheckout/utils.tsx
+++ b/static/gsApp/views/amCheckout/utils.tsx
@@ -25,17 +25,23 @@ import {
   SUPPORTED_TIERS,
 } from 'getsentry/constants';
 import SubscriptionStore from 'getsentry/stores/subscriptionStore';
-import type {
-  EventBucket,
-  OnDemandBudgets,
-  Plan,
+import {
+  InvoiceItemType,
   PlanTier,
-  PreviewData,
-  ReservedBudgetCategoryType,
-  Subscription,
+  type EventBucket,
+  type OnDemandBudgets,
+  type Plan,
+  type PreviewData,
+  type ReservedBudgetCategoryType,
+  type Subscription,
 } from 'getsentry/types';
-import {InvoiceItemType} from 'getsentry/types';
-import {getSlot, isTrialPlan} from 'getsentry/utils/billing';
+import {
+  getAmPlanTier,
+  getSlot,
+  isBizPlanFamily,
+  isTeamPlanFamily,
+  isTrialPlan,
+} from 'getsentry/utils/billing';
 import {isByteCategory} from 'getsentry/utils/dataCategory';
 import trackGetsentryAnalytics from 'getsentry/utils/trackGetsentryAnalytics';
 import trackMarketingEvent from 'getsentry/utils/trackMarketingEvent';
@@ -43,6 +49,7 @@ import {
   SelectableProduct,
   type CheckoutAPIData,
   type CheckoutFormData,
+  type PlanContent,
   type SelectedProductData,
 } from 'getsentry/views/amCheckout/types';
 import {
@@ -848,4 +855,50 @@ export function getToggleTier(checkoutTier: PlanTier | undefined) {
 
 export function hasCheckoutV3(organization: Organization) {
   return organization.features.includes('checkout-v3');
+}
+
+export function getContentForPlan(plan: Plan): PlanContent {
+  if (isBizPlanFamily(plan)) {
+    return {
+      description: t(
+        'Everything in the Team plan + deeper insight into your application health.'
+      ),
+      features: {
+        discover: t('Advanced analytics with Discover'),
+        enhanced_priority_alerts: t('Enhanced issue priority and alerting'),
+        dashboard: t('Unlimited custom dashboards'),
+        ...(getAmPlanTier(plan.id) === PlanTier.AM3 && {
+          application_insights: t('Application Insights'),
+        }),
+        advanced_filtering: t('Advanced server-side filtering'),
+        saml: t('SAML support'),
+      },
+      hasMoreLink: true,
+    };
+  }
+
+  if (isTeamPlanFamily(plan)) {
+    return {
+      description: t('Resolve errors and track application performance as a team.'),
+      features: {
+        unlimited_members: t('Unlimited members'),
+        integrations: t('Third-party integrations'),
+        metric_alerts: t('Metric alerts'),
+      },
+    };
+  }
+
+  // TODO(checkout v3): update copy
+  return {
+    description: t('For solo devs working on small projects'),
+    features: {
+      errors: t('5K Errors'),
+      replays: t('50 Replays'),
+      spans: t('5M Spans'),
+      attachments: t('1GB Attachments'),
+      monitorSeats: t('1 Cron Monitor'),
+      upttime: t('1 Uptime Monitor'),
+      logs: t('5GB Logs'),
+    },
+  };
 }


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/BIL-1207/create-new-build-a-plan-step

This includes:
- Creating the new `Build your plan` step
- Cleaning up places where we only used the new checkout components so that knip would be happy 
- Porting over  referrer upsell logic that I missed when I first made the new plan select cards
- Product select icon size
- New checkout breakpoints

<img width="729" height="597" alt="Screenshot 2025-08-28 at 2 19 51 PM" src="https://github.com/user-attachments/assets/69c81b4b-9dae-43da-aafc-9458d2ea879e" />

### referrer upsell logic
<img width="835" height="465" alt="Screenshot 2025-08-28 at 12 49 10 PM" src="https://github.com/user-attachments/assets/eaf101ae-57a0-48f3-94bb-c76521b4a6c9" />

