### PR TITLE
fix(dashboards): incorrect alignment for dashboard table cells

### DIFF
--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -676,14 +676,14 @@ const SPECIAL_FIELDS: Record<string, SpecialField> = {
     sortField: 'project_id',
     renderFunc: (data, baggage) => {
       const projectId = data.project_id;
-      return getProjectIdLink(projectId, baggage);
+      return <NumberContainer>{getProjectIdLink(projectId, baggage)}</NumberContainer>;
     },
   },
   'project.id': {
     sortField: 'project.id',
     renderFunc: (data, baggage) => {
       const projectId = data['project.id'];
-      return getProjectIdLink(projectId, baggage);
+      return <Container>{getProjectIdLink(projectId, baggage)}</Container>;
     },
   },
   user: {
@@ -1000,27 +1000,25 @@ const getProjectIdLink = (
 ) => {
   const parsedId = typeof projectId === 'string' ? parseInt(projectId, 10) : projectId;
   if (!defined(parsedId) || isNaN(parsedId)) {
-    return <NumberContainer>{emptyValue}</NumberContainer>;
+    return emptyValue;
   }
 
   // TODO: Component has been deprecated in favour of hook, need to refactor this
   return (
-    <NumberContainer>
-      <Projects orgId={organization.slug} slugs={[]} projectIds={[parsedId]}>
-        {({projects}) => {
-          const project = projects.find(p => p.id === parsedId?.toString());
-          if (!project) {
-            return emptyValue;
-          }
-          const target = makeProjectsPathname({
-            path: `/${project?.slug}/?project=${parsedId}/`,
-            organization,
-          });
+    <Projects orgId={organization.slug} slugs={[]} projectIds={[parsedId]}>
+      {({projects}) => {
+        const project = projects.find(p => p.id === parsedId?.toString());
+        if (!project) {
+          return emptyValue;
+        }
+        const target = makeProjectsPathname({
+          path: `/${project?.slug}/?project=${parsedId}/`,
+          organization,
+        });
 
-          return <Link to={target}>{parsedId}</Link>;
-        }}
-      </Projects>
-    </NumberContainer>
+        return <Link to={target}>{parsedId}</Link>;
+      }}
+    </Projects>
   );
 };
 

--- a/static/app/utils/discover/styles.tsx
+++ b/static/app/utils/discover/styles.tsx
@@ -9,6 +9,9 @@ import {IconUser} from 'sentry/icons/iconUser';
 
 export const Container = styled('div')`
   ${p => p.theme.overflowEllipsis};
+  span {
+    vertical-align: middle;
+  }
 `;
 
 export const VersionContainer = styled('div')`
@@ -20,6 +23,9 @@ export const NumberContainer = styled('div')`
   text-align: right;
   font-variant-numeric: tabular-nums;
   ${p => p.theme.overflowEllipsis};
+  span {
+    vertical-align: middle;
+  }
 `;
 
 export const FieldDateTime = styled(DateTime)`


### PR DESCRIPTION
### Changes

Fixes some alignment issues in table cells:
- Content in <span> tags are now vertically aligned to the middle
- Fixes `project.id` being misaligned with the column name

### Before
<img width="153" height="81" alt="Screenshot 2025-08-28 at 2 32 47 PM" src="https://github.com/user-attachments/assets/74841565-8a98-4bad-bdfd-5459503c26ee" />


<img width="347" height="62" alt="Screenshot 2025-08-28 at 2 33 14 PM" src="https://github.com/user-attachments/assets/0c6b8273-b20a-43f3-b5a3-1ecd89268ad5" />


### After
<img width="104" height="76" alt="Screenshot 2025-08-28 at 2 32 58 PM" src="https://github.com/user-attachments/assets/d5a4e3f2-0574-47f0-9538-d3f4066f1f2d" />

<img width="343" height="85" alt="Screenshot 2025-08-28 at 2 33 30 PM" src="https://github.com/user-attachments/assets/cbb73445-7907-497a-b331-5ac08389ce32" />
