### PR TITLE
feat(Prevent): adjust what data we show while we fetch

### DIFF
--- a/static/app/components/prevent/branchSelector/branchSelector.tsx
+++ b/static/app/components/prevent/branchSelector/branchSelector.tsx
@@ -49,6 +49,10 @@ export function BranchSelector() {
   );
 
   const options = useMemo((): Array<SelectOption<string>> => {
+    if (isFetching) {
+      return [];
+    }
+
     const optionSet = new Set<string>([
       ALL_BRANCHES,
       ...(branch ? [branch] : []),
@@ -64,7 +68,7 @@ export function BranchSelector() {
     };
 
     return [...optionSet].map(makeOption);
-  }, [branch, displayedBranches]);
+  }, [branch, displayedBranches, isFetching]);
 
   useEffect(() => {
     // Only update displayedBranches if the hook returned something non-empty


### PR DESCRIPTION
This PR adjusts the branch selector to display placeholder text while loading for branches, which it didn't before.

Closes [this](https://linear.app/getsentry/issue/CCMRG-1594/ta-ux-improvement-branch-selector)

https://github.com/user-attachments/assets/55ea3bd3-d005-48c3-bb67-6a09d62f4218

