### PR TITLE
fix(testing): Fix thread leak detection frame filtering regression

### DIFF
--- a/src/sentry/testutils/thread_leaks/_constants.py
+++ b/src/sentry/testutils/thread_leaks/_constants.py
@@ -1,0 +1,11 @@
+"""Shared constants for thread leak detection."""
+
+import os
+from pathlib import Path
+
+# Current working directory with trailing slash for path replacement
+CWD = os.getcwd() + "/"
+
+# Thread leaks package directory (normalized to relative path like "./src/...")
+HERE = str(Path(__file__).parent) + "/"
+HERE = HERE.replace(CWD, "./")

--- a/src/sentry/testutils/thread_leaks/assertion.py
+++ b/src/sentry/testutils/thread_leaks/assertion.py
@@ -45,7 +45,7 @@ def threading_remembers_where() -> Generator[None]:
 
 
 @contextmanager
-def assert_none(strict: bool = True) -> Generator[dict[str, Any]]:
+def assert_none(strict: bool = True, allowlisted: bool = False) -> Generator[dict[str, Any]]:
     """Assert no thread leaks occurred during context execution."""
 
     with threading_remembers_where():
@@ -58,6 +58,6 @@ def assert_none(strict: bool = True) -> Generator[dict[str, Any]]:
         if not thread_leaks:
             return
 
-        result["events"] = sentry.capture_event(thread_leaks, strict)
-        if strict:
+        result["events"] = sentry.capture_event(thread_leaks, strict, allowlisted)
+        if strict and not allowlisted:
             raise ThreadLeakAssertionError(diff(old=expected, new=actual))

--- a/src/sentry/testutils/thread_leaks/assertion.py
+++ b/src/sentry/testutils/thread_leaks/assertion.py
@@ -6,7 +6,6 @@ does a bit of work to record and show exactly where the Thread came from, which
 proved essential when working to fix these things.
 """
 
-import os
 import threading
 import traceback
 from collections.abc import Generator
@@ -17,17 +16,15 @@ from typing import Any
 from unittest import mock
 
 from . import sentry
+from ._constants import CWD
 from .diff import diff
-
-_cwd = os.getcwd() + "/"
-del os  # hygiene
 
 
 class ThreadLeakAssertionError(AssertionError):
     pass
 
 
-def _where(cwd: str = _cwd) -> StackSummary:
+def _where(cwd: str = CWD) -> StackSummary:
     stack = traceback.extract_stack()
     for frame in stack:
         frame.filename = frame.filename.replace(cwd, "./")  # for readability

--- a/src/sentry/testutils/thread_leaks/diff.py
+++ b/src/sentry/testutils/thread_leaks/diff.py
@@ -5,6 +5,7 @@ from collections.abc import Generator, Iterable
 from threading import Thread
 from traceback import FrameSummary, StackSummary
 
+from ._constants import HERE
 from ._threading import get_thread_function_name
 
 
@@ -20,7 +21,7 @@ def get_relevant_frames(stack: Iterable[FrameSummary]) -> StackSummary:
 
     # Apply each filter independently, reverting if it would remove all frames
     for filter in (
-        lambda frame: frame.filename == __file__,  # Remove this very file
+        lambda frame: frame.filename.startswith(HERE),  # Remove thread leak detection frames
         lambda frame: frame.line is None,  # Remove "frozen" stdlib modules
         lambda frame: stdlib_dir
         and frame.filename.startswith(stdlib_dir + "/"),  # Remove Python stdlib

--- a/src/sentry/testutils/thread_leaks/sentry.py
+++ b/src/sentry/testutils/thread_leaks/sentry.py
@@ -6,7 +6,7 @@ import functools
 from collections.abc import Iterable
 from threading import Thread
 from traceback import FrameSummary
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import sentry_sdk.scope
 
@@ -14,8 +14,8 @@ from ._threading import get_thread_function_name
 from .diff import get_relevant_frames
 
 if TYPE_CHECKING:
-    # this is *only* defined when TYPE_CHECKING =(
     from sentry_sdk._types import Event as SentryEvent
+    from sentry_sdk._types import LogLevelStr
 
 
 @functools.cache
@@ -53,14 +53,16 @@ def get_scope() -> sentry_sdk.scope.Scope:
     return scope
 
 
-def capture_event(thread_leaks: set[Thread], strict: bool) -> dict[str, SentryEvent]:
+def capture_event(
+    thread_leaks: set[Thread], strict: bool, allowlisted: bool
+) -> dict[str, SentryEvent]:
     """Report thread leaks to Sentry with proper event formatting."""
     # Report to Sentry
     scope = get_scope()
     events = {}
     with sentry_sdk.scope.use_scope(scope):
         for thread_leak in thread_leaks:
-            event = get_thread_leak_event(thread_leak, strict)
+            event = get_thread_leak_event(thread_leak, strict, allowlisted)
             event_id = scope.capture_event(event)
             if event_id is not None:
                 events[event_id] = event
@@ -68,24 +70,44 @@ def capture_event(thread_leaks: set[Thread], strict: bool) -> dict[str, SentryEv
     return events
 
 
-def get_thread_leak_event(thread: Thread, strict: bool = True) -> SentryEvent:
+def get_thread_leak_event(thread: Thread, strict: bool, allowlisted: bool) -> SentryEvent:
     """Create Sentry event from leaked thread."""
     stack: Iterable[FrameSummary] = getattr(thread, "_where", [])
-    return event_from_stack(thread, stack, strict)
+    return event_from_stack(thread, stack, strict, allowlisted)
 
 
-def event_from_stack(thread: Thread, stack: Iterable[FrameSummary], strict: bool) -> SentryEvent:
+def _mechanism_tags(mechanism_data: dict[str, Any]) -> dict[str, str]:
+    from sentry.utils import json
+
+    return {f"mechanism.{key}": json.dumps(val) for key, val in mechanism_data.items()}
+
+
+def event_from_stack(
+    thread: Thread, stack: Iterable[FrameSummary], strict: bool, allowlisted: bool
+) -> SentryEvent:
     relevant_frames = get_relevant_frames(stack)
 
+    level: LogLevelStr
+    if allowlisted:
+        level = "info"
+    elif strict:
+        level = "error"
+    else:
+        level = "warning"
+
+    # Mechanism data that will be both stored and converted to tags
     # https://develop.sentry.dev/sdk/data-model/event-payloads/exception/
+    mechanism_data = {
+        "version": 2,
+        "strict": strict,
+        "allowlisted": allowlisted,
+    }
     exception = {
         "mechanism": {
             "type": __name__,
             "handled": not strict,
             "help_link": "https://www.notion.so/sentry/How-To-Thread-Leaks-2488b10e4b5d8049965cc057b5fb5f6b",
-            "data": {
-                "version": 2,
-            },
+            "data": mechanism_data,
         },
         "type": "ThreadLeakAssertionError",
         "value": repr(thread),
@@ -103,12 +125,15 @@ def event_from_stack(thread: Thread, stack: Iterable[FrameSummary], strict: bool
             ]
         },
     }
+
+    tags = {
+        "thread.target": get_thread_function_name(thread),
+        **_mechanism_tags(mechanism_data),
+    }
+
     return {
-        "level": "error" if strict else "warning",
+        "level": level,
         "message": "Thread leak detected",
         "exception": {"values": [exception]},
-        "tags": {
-            "thread.target": get_thread_function_name(thread),
-            "mechanism.version": "2",
-        },
+        "tags": tags,
     }

--- a/src/sentry/testutils/thread_leaks/sentry.py
+++ b/src/sentry/testutils/thread_leaks/sentry.py
@@ -28,13 +28,18 @@ def get_scope() -> sentry_sdk.scope.Scope:
     if environ.get("GITHUB_ACTIONS") == "true":
         sha = environ["GITHUB_SHA"]
         branch = environ.get("GITHUB_HEAD_REF")
-        if branch:
+        repo = environ["GITHUB_REPOSITORY"]
+
+        if not repo.startswith("getsentry/"):
+            environment = "fork"
+        elif branch:
             environment = "PR"
         else:
             environment = "master"
             branch = environ["GITHUB_REF_NAME"]
     else:
         sha = branch = None
+        repo = "unknown"
         environment = "local"
 
     client = sentry_sdk.Client(
@@ -48,7 +53,7 @@ def get_scope() -> sentry_sdk.scope.Scope:
     scope.update_from_kwargs(
         # Don't set level - scope overrides event-level
         extras={"git-branch": branch, "git-sha": sha},
-        tags={"github.repo": environ.get("GITHUB_REPOSITORY", "unknown")},
+        tags={"github.repo": repo},
     )
     return scope
 

--- a/src/sentry/testutils/thread_leaks/sentry.py
+++ b/src/sentry/testutils/thread_leaks/sentry.py
@@ -83,6 +83,9 @@ def event_from_stack(thread: Thread, stack: Iterable[FrameSummary], strict: bool
             "type": __name__,
             "handled": not strict,
             "help_link": "https://www.notion.so/sentry/How-To-Thread-Leaks-2488b10e4b5d8049965cc057b5fb5f6b",
+            "data": {
+                "version": 2,
+            },
         },
         "type": "ThreadLeakAssertionError",
         "value": repr(thread),
@@ -104,5 +107,8 @@ def event_from_stack(thread: Thread, stack: Iterable[FrameSummary], strict: bool
         "level": "error" if strict else "warning",
         "message": "Thread leak detected",
         "exception": {"values": [exception]},
-        "tags": {"thread.target": get_thread_function_name(thread)},
+        "tags": {
+            "thread.target": get_thread_function_name(thread),
+            "mechanism.version": "2",
+        },
     }

--- a/tests/sentry/testutils/thread_leaks/test_sentry.py
+++ b/tests/sentry/testutils/thread_leaks/test_sentry.py
@@ -36,6 +36,9 @@ class TestEventFromStack:
                             "type": "sentry.testutils.thread_leaks.sentry",
                             "handled": False,
                             "help_link": "https://www.notion.so/sentry/How-To-Thread-Leaks-2488b10e4b5d8049965cc057b5fb5f6b",
+                            "data": {
+                                "version": 2,
+                            },
                         },
                         "type": "ThreadLeakAssertionError",
                         "value": "test",
@@ -62,7 +65,10 @@ class TestEventFromStack:
                     }
                 ]
             },
-            "tags": {"thread.target": "None"},
+            "tags": {
+                "thread.target": "None",
+                "mechanism.version": "2",
+            },
         }
 
     def test_empty_stack(self) -> None:

--- a/tests/sentry/testutils/thread_leaks/test_sentry.py
+++ b/tests/sentry/testutils/thread_leaks/test_sentry.py
@@ -9,13 +9,15 @@ from unittest.mock import Mock
 from sentry.testutils.thread_leaks.sentry import event_from_stack
 
 
-def dict_from_stack(value: str, stack: Iterable[FrameSummary], strict: bool) -> dict[str, Any]:
+def dict_from_stack(
+    value: str, stack: Iterable[FrameSummary], strict: bool, allowlisted: bool = False
+) -> dict[str, Any]:
     """Create Sentry event dict from stack (type-checker friendly wrapper)."""
     # Create mock thread with the desired repr and no target
     mock_thread = Mock(spec=Thread)
     mock_thread.configure_mock(__repr__=Mock(return_value=value))
     mock_thread.configure_mock(_target=None)
-    return dict(event_from_stack(mock_thread, stack, strict))
+    return dict(event_from_stack(mock_thread, stack, strict, allowlisted))
 
 
 class TestEventFromStack:
@@ -38,6 +40,8 @@ class TestEventFromStack:
                             "help_link": "https://www.notion.so/sentry/How-To-Thread-Leaks-2488b10e4b5d8049965cc057b5fb5f6b",
                             "data": {
                                 "version": 2,
+                                "strict": True,
+                                "allowlisted": False,
                             },
                         },
                         "type": "ThreadLeakAssertionError",
@@ -68,6 +72,8 @@ class TestEventFromStack:
             "tags": {
                 "thread.target": "None",
                 "mechanism.version": "2",
+                "mechanism.strict": "true",
+                "mechanism.allowlisted": "false",
             },
         }
 


### PR DESCRIPTION
## Summary

Fixes a regression in thread leak detection and adds three-level reporting system for better thread leak management.

## Problem 1: Frame Filtering Regression

When thread leak detection code was moved from a single `thread_leaks.py` file to a `thread_leaks/` package, the frame filtering logic broke:

- **Before**: `__file__` filter removed `thread_leaks.py` frames ✅
- **After**: `__file__` filter only removed `diff.py`, but left `assertion.py` frames ❌

This caused production thread leak events to show infrastructure code instead of the actual application code that created the leaked threads.

## Problem 2: Binary Thread Leak Handling

Previously, thread leaks were either ignored (allowlisted) or treated as errors. This made it hard to track progress on known issues.

## Solution

### Frame Filtering Fix
1. **Extract path constants** to `_constants.py` for consistent path handling
2. **Fix frame filtering** to remove entire `thread_leaks/` package directory instead of just one file
3. **Add regression test** to prevent future frame filtering issues

### Three-Level Reporting System
Add differentiated reporting for thread leaks with proper Sentry integration:

- **Error level**: `strict=True, allowlisted=False` (fails tests, handled=False)
- **Warning level**: `strict=False, allowlisted=False` (no test failure, handled=True) 
- **Info level**: `allowlisted=True` (no test failure, visible for tracking)

### Enhancements
- **Mechanism versioning** to distinguish events: `mechanism.data.version=2`
- **Filterable tags** for Sentry UI: `mechanism.strict`, `mechanism.allowlisted`
- **Fork environment detection** for non-getsentry repositories
- **Proper Sentry data model** using `mechanism.data` (not `meta`)

## Test Plan

- [x] New test verifies infrastructure frames are filtered out
- [x] All existing thread leak tests pass
- [x] Manual verification shows app code frames in Sentry events
- [x] Three-level reporting system works correctly
- [x] Versioning enables filtering: `mechanism.version=2`

## Example

**Before (broken):** Thread leak shows `assertion.py:43 patched__init__`  
**After (fixed):** Thread leak shows `my_app_code.py:100 business_logic`

**Before (binary):** Thread leaks either ignored or error  
**After (three-level):** Error/Warning/Info levels enable better tracking

This enables better thread leak detection accuracy and management for production debugging.