### PR TITLE
feat(uptime): Support detector IDs in API endpoints

### DIFF
--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -650,11 +650,11 @@ class MonitorParams:
 
 class UptimeParams:
     UPTIME_ALERT_ID = OpenApiParameter(
-        name="uptime_subscription_id",
+        name="uptime_project_subscription_id",
         location="path",
         required=True,
         type=int,
-        description="The ID of the uptime alert rule you'd like to query.",
+        description="The ID of the uptime alert rule you'd like to query. Can be either a project uptime subscription ID (default) or a detector ID (when useDetectorId=1 query parameter is provided).",
     )
     OWNER = OpenApiParameter(
         name="owner",

--- a/src/sentry/uptime/endpoints/bases.py
+++ b/src/sentry/uptime/endpoints/bases.py
@@ -3,7 +3,12 @@ from rest_framework.request import Request
 from sentry.api.api_owners import ApiOwner
 from sentry.api.bases.project import ProjectAlertRulePermission, ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
-from sentry.uptime.models import ProjectUptimeSubscription
+from sentry.uptime.models import ProjectUptimeSubscription, get_detector
+from sentry.uptime.types import (
+    DATA_SOURCE_UPTIME_SUBSCRIPTION,
+    GROUP_TYPE_UPTIME_DOMAIN_CHECK_FAILURE,
+)
+from sentry.workflow_engine.models import Detector
 
 
 class ProjectUptimeAlertEndpoint(ProjectEndpoint):
@@ -13,6 +18,9 @@ class ProjectUptimeAlertEndpoint(ProjectEndpoint):
     def convert_args(
         self,
         request: Request,
+        # XXX(epurkhiser): There's a getsentry test that depends on this
+        # argument name, when we change this over to purely detector_id we
+        # should make the effort to fix the parameter name then
         uptime_project_subscription_id: str,
         *args,
         **kwargs,
@@ -20,11 +28,41 @@ class ProjectUptimeAlertEndpoint(ProjectEndpoint):
         args, kwargs = super().convert_args(request, *args, **kwargs)
         project = kwargs["project"]
 
-        try:
-            kwargs["uptime_monitor"] = ProjectUptimeSubscription.objects.get(
-                project=project, id=uptime_project_subscription_id
-            )
-        except ProjectUptimeSubscription.DoesNotExist:
-            raise ResourceDoesNotExist
+        # Check query parameter to determine if ID should be treated as detector ID
+        use_detector_id = request.GET.get("useDetectorId") == "1"
+
+        # XXX(epurkhiser): We can remove this dual reading logic once all
+        # endpoints are using the Detector IDs over ProjectUptimeSubscription
+        # IDs.
+        if use_detector_id:
+            # Treat ID as detector ID - find detector and its associated subscription
+            try:
+                detector = Detector.objects.get(
+                    project=project,
+                    id=uptime_project_subscription_id,
+                    type=GROUP_TYPE_UPTIME_DOMAIN_CHECK_FAILURE,
+                    data_sources__type=DATA_SOURCE_UPTIME_SUBSCRIPTION,
+                )
+                # Get the uptime subscription from the detector's data source
+                data_source = detector.data_sources.get(type=DATA_SOURCE_UPTIME_SUBSCRIPTION)
+                uptime_subscription_id = data_source.source_id
+                uptime_monitor = ProjectUptimeSubscription.objects.get(
+                    project=project, uptime_subscription__id=uptime_subscription_id
+                )
+                kwargs["uptime_detector"] = detector
+                kwargs["uptime_monitor"] = uptime_monitor
+            except (Detector.DoesNotExist, ProjectUptimeSubscription.DoesNotExist, AttributeError):
+                raise ResourceDoesNotExist
+        else:
+            # Treat ID as project uptime subscription ID (legacy behavior)
+            try:
+                uptime_monitor = ProjectUptimeSubscription.objects.get(
+                    project=project, id=uptime_project_subscription_id
+                )
+                detector = get_detector(uptime_monitor.uptime_subscription)
+                kwargs["uptime_detector"] = detector
+                kwargs["uptime_monitor"] = uptime_monitor
+            except ProjectUptimeSubscription.DoesNotExist:
+                raise ResourceDoesNotExist
 
         return args, kwargs

--- a/src/sentry/uptime/endpoints/project_uptime_alert_checks_index.py
+++ b/src/sentry/uptime/endpoints/project_uptime_alert_checks_index.py
@@ -38,6 +38,7 @@ from sentry.uptime.endpoints.serializers import EapCheckEntrySerializerResponse
 from sentry.uptime.models import ProjectUptimeSubscription
 from sentry.uptime.types import EapCheckEntry, IncidentStatus
 from sentry.utils import snuba_rpc
+from sentry.workflow_engine.models import Detector
 
 logger = logging.getLogger(__name__)
 
@@ -55,6 +56,7 @@ class ProjectUptimeAlertCheckIndexEndpoint(ProjectUptimeAlertEndpoint):
         request: Request,
         project: Project,
         uptime_monitor: ProjectUptimeSubscription,
+        uptime_detector: Detector,
     ) -> Response:
 
         if uptime_monitor.uptime_subscription.subscription_id is None:

--- a/src/sentry/uptime/endpoints/project_uptime_alert_details.py
+++ b/src/sentry/uptime/endpoints/project_uptime_alert_details.py
@@ -22,9 +22,10 @@ from sentry.uptime.endpoints.serializers import (
     ProjectUptimeSubscriptionSerializerResponse,
 )
 from sentry.uptime.endpoints.validators import UptimeMonitorValidator
-from sentry.uptime.models import ProjectUptimeSubscription, get_detector
+from sentry.uptime.models import ProjectUptimeSubscription
 from sentry.uptime.subscriptions.subscriptions import delete_uptime_detector
 from sentry.utils.audit import create_audit_entry
+from sentry.workflow_engine.models import Detector
 
 
 @region_silo_endpoint
@@ -57,6 +58,7 @@ class ProjectUptimeAlertDetailsEndpoint(ProjectUptimeAlertEndpoint):
         request: Request,
         project: Project,
         uptime_monitor: ProjectUptimeSubscription,
+        uptime_detector: Detector,
     ) -> Response:
         serialized_uptime_alert: ProjectUptimeSubscriptionSerializerResponse = serialize(
             uptime_monitor,
@@ -81,7 +83,11 @@ class ProjectUptimeAlertDetailsEndpoint(ProjectUptimeAlertEndpoint):
         },
     )
     def put(
-        self, request: Request, project: Project, uptime_monitor: ProjectUptimeSubscription
+        self,
+        request: Request,
+        project: Project,
+        uptime_monitor: ProjectUptimeSubscription,
+        uptime_detector: Detector,
     ) -> Response:
         """
         Update an uptime monitor.
@@ -117,14 +123,17 @@ class ProjectUptimeAlertDetailsEndpoint(ProjectUptimeAlertEndpoint):
         },
     )
     def delete(
-        self, request: Request, project: Project, uptime_monitor: ProjectUptimeSubscription
+        self,
+        request: Request,
+        project: Project,
+        uptime_monitor: ProjectUptimeSubscription,
+        uptime_detector: Detector,
     ) -> Response:
         """
         Delete an uptime monitor.
         """
-        detector = get_detector(uptime_monitor.uptime_subscription)
         audit_log_data = uptime_monitor.get_audit_log_data()
-        delete_uptime_detector(detector)
+        delete_uptime_detector(uptime_detector)
         create_audit_entry(
             request=request,
             organization=project.organization,

--- a/tests/sentry/uptime/endpoints/test_project_uptime_alert_details.py
+++ b/tests/sentry/uptime/endpoints/test_project_uptime_alert_details.py
@@ -7,7 +7,7 @@ from sentry.api.serializers import serialize
 from sentry.constants import ObjectStatus
 from sentry.models.environment import Environment
 from sentry.quotas.base import SeatAssignmentResult
-from sentry.uptime.models import ProjectUptimeSubscription, UptimeSubscription
+from sentry.uptime.models import ProjectUptimeSubscription, UptimeSubscription, get_detector
 from tests.sentry.uptime.endpoints import UptimeAlertBaseEndpointTest
 
 
@@ -27,6 +27,21 @@ class ProjectUptimeAlertDetailsGetEndpointTest(ProjectUptimeAlertDetailsBaseEndp
     def test_not_found(self) -> None:
         resp = self.get_error_response(self.organization.slug, self.project.slug, 3)
         assert resp.status_code == 404
+
+    def test_detector_id_with_query_parameter(self) -> None:
+        """Test that endpoint works with detector ID when useDetectorId=true."""
+        uptime_subscription = self.create_project_uptime_subscription()
+        detector = get_detector(uptime_subscription.uptime_subscription)
+
+        # Test with detector ID and useDetectorId=1 query parameter
+        resp = self.get_success_response(
+            self.organization.slug,
+            uptime_subscription.project.slug,
+            detector.id,
+            useDetectorId="1",
+        )
+        # Should return the same data as the subscription ID test
+        assert resp.data == serialize(uptime_subscription, self.user)
 
 
 class ProjectUptimeAlertDetailsPutEndpointTest(ProjectUptimeAlertDetailsBaseEndpointTest):


### PR DESCRIPTION
Add detector ID support to uptime alert endpoints

This PR updates the `ProjectUptimeAlertEndpoint` base class to support both legacy project uptime subscription IDs and new detector IDs, enabling a gradual migration path from project uptime subscription ID based routing to detector ID based routing.

### Changes

- Base class updates: Modified `ProjectUptimeAlertEndpoint.convert_args()` to handle dual ID functionality

- Renamed URL parameter from `uptime_project_subscription_id` to `uptime_pro_sub_id_or_detector_id`

- Added `useDetectorId=1` query parameter to switch between ID interpretation modes

- Both `uptime_detector` and `uptime_monitor` objects are now injected into all endpoint methods

- Documentation: Updated OpenAPI parameter documentation to reflect dual ID support

### Behavior

Legacy mode (default):

`GET /api/0/projects/org/project/uptime/123/` Treats 123 as a project uptime subscription ID (existing behavior)

New detector mode:

`GET /api/0/projects/org/project/uptime/456/?useDetectorId=1` Treats 456 as a detector ID and resolves the associated uptime subscription

Both modes provide the same objects to endpoint methods, allowing us to transition off ProjectUptimeSubscription.

### Testing

Added test coverage for the new detector ID functionality while maintaining all existing tests to ensure backward compatibility. The implementation gracefully handles invalid IDs and cross-project access attempts.

This change enables the frontend to gradually migrate from using project uptime subscription IDs to detector IDs without breaking existing functionality.