### PR TITLE
fix(ingest): relax HTTP method-prefixed transaction name clustering

### DIFF
--- a/src/sentry/ingest/transaction_clusterer/rule_validator.py
+++ b/src/sentry/ingest/transaction_clusterer/rule_validator.py
@@ -20,7 +20,7 @@ class RuleValidator:
         # middleware spans. Strip those prefixes so that validation only
         # considers the trailing URL/path.
         match = re.match(
-            "(middleware )?(GET|POST|PUT|DELETE|HEAD|OPTIONS) (.*)", rule, re.IGNORECASE
+            "(middleware )?(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS) (.*)", rule, re.IGNORECASE
         )
         if match:
             return ReplacementRule(match.groups()[2])

--- a/tests/sentry/ingest/test_transaction_clusterer.py
+++ b/tests/sentry/ingest/test_transaction_clusterer.py
@@ -86,6 +86,15 @@ def test_clusterer_doesnt_generate_invalid_rules() -> None:
     clusterer.add_input(scheme_stars)
     assert clusterer.get_rules() == []
 
+    clusterer = TreeClusterer(merge_threshold=2)
+    transaction_names = [
+        "GET /a/b1/c/",
+        "GET /b/b2/c/",
+        "GET /c/b3/c/",
+    ]
+    clusterer.add_input(transaction_names)
+    assert clusterer.get_rules() == []
+
 
 @mock.patch("sentry.ingest.transaction_clusterer.datasource.redis.MAX_SET_SIZE", 5)
 def test_collection() -> None:

--- a/tests/sentry/ingest/test_transaction_rule_validator.py
+++ b/tests/sentry/ingest/test_transaction_rule_validator.py
@@ -39,10 +39,20 @@ def test_schema_all_stars_invalid() -> None:
 
 
 def test_http_method_all_stars_invalid() -> None:
+    # all star paths prefixed with HTTP methods are invalid
     assert not RuleValidator(ReplacementRule("GET /*/*/**")).is_valid()
     assert not RuleValidator(ReplacementRule("POST /*/*/**")).is_valid()
-    assert not RuleValidator(ReplacementRule("FOO /*/*/**")).is_valid()
+    assert not RuleValidator(ReplacementRule("get /*/*/**")).is_valid()
 
+    # as long as one segment isn't a *, it's valid
     assert RuleValidator(ReplacementRule("GET /a/*/**")).is_valid()
-    assert RuleValidator(ReplacementRule("POST /a/*/**")).is_valid()
+    assert RuleValidator(ReplacementRule("POST /*/b/**")).is_valid()
+    assert RuleValidator(ReplacementRule("get /c/*/**")).is_valid()
+
+    # unknown HTTP methods aren't considered
+    assert RuleValidator(ReplacementRule("FOO /*/*/**")).is_valid()
     assert RuleValidator(ReplacementRule("FOO /a/*/**")).is_valid()
+
+    # works with a "middleware " prefix too (via Next.js SDK)
+    assert not RuleValidator(ReplacementRule("middleware GET /*/*/**")).is_valid()
+    assert RuleValidator(ReplacementRule("middleware GET /a/*/**")).is_valid()

--- a/tests/sentry/ingest/test_transaction_rule_validator.py
+++ b/tests/sentry/ingest/test_transaction_rule_validator.py
@@ -36,3 +36,13 @@ def test_schema_all_stars_invalid() -> None:
     assert not RuleValidator(ReplacementRule("ftp://*/*/*/**")).is_valid()
     assert RuleValidator(ReplacementRule("file:///example.txt")).is_valid()
     assert not RuleValidator(ReplacementRule("file:///*/*/**")).is_valid()
+
+
+def test_http_method_all_stars_invalid() -> None:
+    assert not RuleValidator(ReplacementRule("GET /*/*/**")).is_valid()
+    assert not RuleValidator(ReplacementRule("POST /*/*/**")).is_valid()
+    assert not RuleValidator(ReplacementRule("FOO /*/*/**")).is_valid()
+
+    assert RuleValidator(ReplacementRule("GET /a/*/**")).is_valid()
+    assert RuleValidator(ReplacementRule("POST /a/*/**")).is_valid()
+    assert RuleValidator(ReplacementRule("FOO /a/*/**")).is_valid()

--- a/tests/sentry/ingest/test_transaction_rule_validator.py
+++ b/tests/sentry/ingest/test_transaction_rule_validator.py
@@ -49,6 +49,10 @@ def test_http_method_all_stars_invalid() -> None:
     assert RuleValidator(ReplacementRule("POST /*/b/**")).is_valid()
     assert RuleValidator(ReplacementRule("get /c/*/**")).is_valid()
 
+    # works for URLs too
+    assert not RuleValidator(ReplacementRule("GET http://*/*/**")).is_valid()
+    assert RuleValidator(ReplacementRule("GET http://example.com/*/**")).is_valid()
+
     # unknown HTTP methods aren't considered
     assert RuleValidator(ReplacementRule("FOO /*/*/**")).is_valid()
     assert RuleValidator(ReplacementRule("FOO /a/*/**")).is_valid()


### PR DESCRIPTION
The transaction clusterer attempts to reduce cardinality of incoming transaction names by grouping high cardinality segments (when the SDK is not already performing parameterization).

```
/foo/1
/foo/2   ->   /foo/*
/foo/3
```

We recognize that clustering down to the root segment (e.g. `/*/*/**`) isn't helpful, and have [code to prevent it](https://github.com/getsentry/sentry/blob/e06a472f94ea070f437b36c6b7b7649a62308bbf/tests/sentry/ingest/test_transaction_rule_validator.py), but this doesn't consider an extremely common transaction name pattern of `{http_method} {path}`, e.g. `GET /foo/bar`. This made e.g. `GET /*/**` a valid clustering rule, resulting in all transaction names being clustered into a single group.

This PR considers HTTP method prefixes in transaction names so that our original intention, to not cluster the root path segment, is followed for such names. This should improve grouping for anyone affected. There is also already [a test confirming that existing rules, now considered invalid, will be removed on the next clusterer run](https://github.com/getsentry/sentry/blob/e06a472f94ea070f437b36c6b7b7649a62308bbf/tests/sentry/ingest/test_transaction_clusterer.py#L596-L612).

(See [ENG-5404](https://linear.app/getsentry/issue/ENG-5404/clustering-too-aggressive-on-common-http-method-path-name-pattern) for numbers.)