### PR TITLE
ref(uptime): Support detector IDs in uptime stats + summary

### DIFF
--- a/src/sentry/uptime/endpoints/utils.py
+++ b/src/sentry/uptime/endpoints/utils.py
@@ -1,7 +1,12 @@
 from collections.abc import Callable
 
 from sentry.models.project import Project
-from sentry.uptime.models import ProjectUptimeSubscription
+from sentry.uptime.models import ProjectUptimeSubscription, UptimeSubscription
+from sentry.uptime.types import (
+    DATA_SOURCE_UPTIME_SUBSCRIPTION,
+    GROUP_TYPE_UPTIME_DOMAIN_CHECK_FAILURE,
+)
+from sentry.workflow_engine.models import Detector
 
 MAX_UPTIME_SUBSCRIPTION_IDS = 100
 """
@@ -59,3 +64,81 @@ def authorize_and_map_project_uptime_subscription_ids(
     ]
 
     return subscription_id_to_project_uptime_subscription_id, validated_subscription_ids
+
+
+def authorize_and_map_uptime_detector_subscription_ids(
+    detector_ids: list[str],
+    projects: list[Project],
+    sub_id_formatter: Callable[[str], str],
+) -> tuple[dict[str, int], list[str]]:
+    """
+    Authorize the detector ids and return their corresponding subscription ids.
+
+    For uptime detectors, we need to map detector -> data_source -> uptime_subscription.
+
+    Args:
+        detector_ids: List of Detector IDs as strings
+        projects: List of Project objects the user has access to
+        sub_id_formatter: Function to format subscription IDs (e.g., hex vs string format)
+
+    Returns:
+        Tuple of:
+        - Mapping from formatted subscription_id to detector_id
+        - List of formatted subscription IDs for use in Snuba queries
+
+    Raises:
+        ValueError: If any of the provided IDs are invalid or unauthorized
+    """
+    detector_ids_ints = [int(id) for id in detector_ids]
+
+    # First get detector -> uptime_subscription_id mapping
+    detector_to_uptime_sub_id: dict[int, int] = {}
+    for detector in Detector.objects.filter(
+        project_id__in=[project.id for project in projects],
+        id__in=detector_ids_ints,
+        type=GROUP_TYPE_UPTIME_DOMAIN_CHECK_FAILURE,
+        data_sources__type=DATA_SOURCE_UPTIME_SUBSCRIPTION,
+    ).values("id", "data_sources__source_id"):
+        try:
+            uptime_sub_id = int(detector["data_sources__source_id"])
+            detector_to_uptime_sub_id[detector["id"]] = uptime_sub_id
+        except (ValueError, TypeError):
+            continue
+
+    # Get all the uptime subscription IDs we found and their subscription_ids
+    uptime_sub_ids: list[int] = list(detector_to_uptime_sub_id.values())
+    uptime_id_to_subscription_id: dict[int, str | None] = dict(
+        UptimeSubscription.objects.filter(id__in=uptime_sub_ids).values_list(
+            "id", "subscription_id"
+        )[:]
+    )
+
+    # Build the final mapping: detector_id -> subscription_id
+    detectors_with_data_sources: list[tuple[int, str]] = []
+    for detector_id, uptime_sub_id in detector_to_uptime_sub_id.items():
+        subscription_id = uptime_id_to_subscription_id.get(uptime_sub_id)
+        if subscription_id:
+            detectors_with_data_sources.append((detector_id, subscription_id))
+
+    validated_detector_ids = {
+        detector_data[0]
+        for detector_data in detectors_with_data_sources
+        if detector_data[0] is not None
+    }
+
+    if set(detector_ids_ints) != validated_detector_ids:
+        raise ValueError("Invalid detector ids provided")
+
+    subscription_id_to_detector_id = {
+        sub_id_formatter(detector_data[1]): detector_data[0]
+        for detector_data in detectors_with_data_sources
+        if detector_data[0] is not None and detector_data[1] is not None
+    }
+
+    validated_subscription_ids = [
+        sub_id_formatter(detector_data[1])
+        for detector_data in detectors_with_data_sources
+        if detector_data[1] is not None
+    ]
+
+    return subscription_id_to_detector_id, validated_subscription_ids

--- a/tests/sentry/uptime/endpoints/test_organization_uptime_stats.py
+++ b/tests/sentry/uptime/endpoints/test_organization_uptime_stats.py
@@ -5,6 +5,7 @@ from sentry.testutils.cases import APITestCase, UptimeCheckSnubaTestCase
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.helpers.options import override_options
 from sentry.uptime.endpoints.organization_uptime_stats import add_extra_buckets_for_epoch_cutoff
+from sentry.uptime.models import get_detector
 from sentry.uptime.types import IncidentStatus
 from sentry.utils import json
 from tests.sentry.uptime.endpoints.test_base import UptimeResultEAPTestCase
@@ -27,6 +28,8 @@ class OrganizationUptimeStatsBaseTest(APITestCase):
         self.project_uptime_subscription = self.create_project_uptime_subscription(
             uptime_subscription=self.subscription
         )
+        self.detector = get_detector(self.subscription)
+
         scenarios: list[dict] = [
             {"check_status": "success"},
             {"check_status": "failure"},
@@ -52,27 +55,27 @@ class OrganizationUptimeStatsBaseTest(APITestCase):
         raise NotImplementedError("Subclasses must implement store_uptime_data")
 
     def test_simple(self) -> None:
-        """Test that the endpoint returns data for a simple uptime check."""
+        """Test that the endpoint returns data for a simple uptime check using detector IDs."""
 
         with self.feature(self.features):
             response = self.get_success_response(
                 self.organization.slug,
                 project=[self.project.id],
-                projectUptimeSubscriptionId=[str(self.project_uptime_subscription.id)],
+                uptimeDetectorId=[str(self.detector.id)],
                 since=(datetime.now(timezone.utc) - timedelta(days=7)).timestamp(),
                 until=datetime.now(timezone.utc).timestamp(),
                 resolution="1d",
             )
             assert response.data is not None
             data = json.loads(json.dumps(response.data))
-            assert len(data[str(self.project_uptime_subscription.id)]) == 7
-            assert data[str(self.project_uptime_subscription.id)][-1][1] == {
+            assert len(data[str(self.detector.id)]) == 7
+            assert data[str(self.detector.id)][-1][1] == {
                 "failure": 4,
                 "failure_incident": 1,
                 "success": 3,
                 "missed_window": 0,
             }
-            assert data[str(self.project_uptime_subscription.id)][0][1] == {
+            assert data[str(self.detector.id)][0][1] == {
                 "failure": 0,
                 "failure_incident": 0,
                 "success": 0,
@@ -83,39 +86,39 @@ class OrganizationUptimeStatsBaseTest(APITestCase):
         {"uptime.date_cutoff_epoch_seconds": (MOCK_DATETIME - timedelta(days=1)).timestamp()}
     )
     def test_simple_with_date_cutoff(self) -> None:
-        """Test that the endpoint returns data for a simple uptime check."""
+        """Test that the endpoint returns data with date cutoff using detector IDs."""
 
         with self.feature(self.features):
             response = self.get_success_response(
                 self.organization.slug,
                 project=[self.project.id],
-                projectUptimeSubscriptionId=[str(self.project_uptime_subscription.id)],
+                uptimeDetectorId=[str(self.detector.id)],
                 since=(datetime.now(timezone.utc) - timedelta(days=90)).timestamp(),
                 until=datetime.now(timezone.utc).timestamp(),
                 resolution="1d",
             )
             assert response.data is not None
             data = json.loads(json.dumps(response.data))
-            assert len(data[str(self.project_uptime_subscription.id)]) == 90
+            assert len(data[str(self.detector.id)]) == 90
 
     @override_options(
         {"uptime.date_cutoff_epoch_seconds": (MOCK_DATETIME - timedelta(days=1)).timestamp()}
     )
     def test_simple_with_date_cutoff_rounded_resolution(self) -> None:
-        """Test that the endpoint returns data for a simple uptime check."""
+        """Test that the endpoint returns data with rounded resolution using detector IDs."""
 
         with self.feature(self.features):
             response = self.get_success_response(
                 self.organization.slug,
                 project=[self.project.id],
-                projectUptimeSubscriptionId=[str(self.project_uptime_subscription.id)],
+                uptimeDetectorId=[str(self.detector.id)],
                 since=(datetime.now(timezone.utc) - timedelta(days=89, hours=1)).timestamp(),
                 until=datetime.now(timezone.utc).timestamp(),
                 resolution="1d",
             )
             assert response.data is not None
             data = json.loads(json.dumps(response.data))
-            assert len(data[str(self.project_uptime_subscription.id)]) == 89
+            assert len(data[str(self.detector.id)]) == 89
 
     @override_options(
         {"uptime.date_cutoff_epoch_seconds": (MOCK_DATETIME - timedelta(days=1)).timestamp()}
@@ -126,9 +129,7 @@ class OrganizationUptimeStatsBaseTest(APITestCase):
         subscription = self.create_uptime_subscription(
             url="https://santry.io/test", subscription_id=subscription_id
         )
-        project_uptime_subscription = self.create_project_uptime_subscription(
-            uptime_subscription=subscription
-        )
+        self.create_project_uptime_subscription(uptime_subscription=subscription)
 
         # Store data for the cutoff test scenario
         self.store_uptime_data(
@@ -141,11 +142,13 @@ class OrganizationUptimeStatsBaseTest(APITestCase):
             subscription_id, "failure", scheduled_check_time=MOCK_DATETIME - timedelta(hours=2)
         )
 
+        detector = get_detector(subscription)
+
         with self.feature(self.features):
             response = self.get_success_response(
                 self.organization.slug,
                 project=[self.project.id],
-                projectUptimeSubscriptionId=[str(project_uptime_subscription.id)],
+                uptimeDetectorId=[str(detector.id)],
                 since=(datetime.now(timezone.utc) - timedelta(days=89, hours=1)).timestamp(),
                 until=datetime.now(timezone.utc).timestamp(),
                 resolution="1d",
@@ -154,8 +157,8 @@ class OrganizationUptimeStatsBaseTest(APITestCase):
         data = json.loads(json.dumps(response.data))
         # check that we return all the intervals,
         # but the last one is the failure
-        assert len(data[str(project_uptime_subscription.id)]) == 89
-        assert data[str(project_uptime_subscription.id)][-1][1] == {
+        assert len(data[str(detector.id)]) == 89
+        assert data[str(detector.id)][-1][1] == {
             "failure": 1,
             "failure_incident": 0,
             "success": 0,
@@ -163,56 +166,53 @@ class OrganizationUptimeStatsBaseTest(APITestCase):
         }
         # make sure the rest of the intervals are empty
         for i in range(88):
-            assert data[str(project_uptime_subscription.id)][i][1] == {
+            assert data[str(detector.id)][i][1] == {
                 "failure": 0,
                 "failure_incident": 0,
                 "success": 0,
                 "missed_window": 0,
             }
 
-    def test_invalid_uptime_subscription_id(self) -> None:
+    def test_invalid_detector_id(self) -> None:
         """
-        Test that an invalid uptime_subscription_id produces a 400 response.
+        Test that an invalid detector ID produces a 400 response.
         """
         with self.feature(self.features):
             response = self.get_response(
                 self.organization.slug,
                 project=[self.project.id],
-                projectUptimeSubscriptionId=[str(uuid.uuid4())],
+                uptimeDetectorId=["999999"],
                 since=(datetime.now(timezone.utc) - timedelta(days=7)).timestamp(),
                 until=datetime.now(timezone.utc).timestamp(),
                 resolution="1d",
             )
             assert response.status_code == 400
-            assert response.json() == "Invalid project uptime subscription ids provided"
+            assert response.json() == "Invalid uptime detector ids provided"
 
-    def test_no_uptime_subscription_id(self) -> None:
-        """
-        Test that not sending any uptime_subscription_id produces a 400
-        response.
-        """
+    def test_no_detector_id(self) -> None:
+        """Test that not sending any detector ID produces a 400 response."""
         with self.feature(self.features):
             response = self.get_response(
                 self.organization.slug,
                 project=[self.project.id],
-                projectUptimeSubscriptionId=[],
+                uptimeDetectorId=[],
                 since=(datetime.now(timezone.utc) - timedelta(days=7)).timestamp(),
                 until=datetime.now(timezone.utc).timestamp(),
                 resolution="1d",
             )
             assert response.status_code == 400
-            assert response.json() == "No project uptime subscription ids provided"
+            assert (
+                response.json()
+                == "Either project uptime subscription ids or uptime detector ids must be provided"
+            )
 
     def test_too_many_periods(self) -> None:
-        """
-        Test that requesting a high resolution across a large period of time
-        produces a 400 response.
-        """
+        """Test that requesting a high resolution across a large period of time produces a 400 response."""
         with self.feature(self.features):
             response = self.get_response(
                 self.organization.slug,
                 project=[self.project.id],
-                projectUptimeSubscriptionId=[str(self.project_uptime_subscription.id)],
+                uptimeDetectorId=[str(self.detector.id)],
                 since=(datetime.now(timezone.utc) - timedelta(days=90)).timestamp(),
                 until=datetime.now(timezone.utc).timestamp(),
                 resolution="1m",
@@ -220,25 +220,89 @@ class OrganizationUptimeStatsBaseTest(APITestCase):
             assert response.status_code == 400
             assert response.json() == "error making request"
 
-    def test_too_many_uptime_subscription_ids(self) -> None:
-        """
-        Test that sending a large number of subscription IDs produces a 400
-        """
-
+    def test_too_many_detector_ids_limit(self) -> None:
+        """Test that sending a large number of detector IDs produces a 400."""
         with self.feature(self.features):
             response = self.get_response(
                 self.organization.slug,
                 project=[self.project.id],
-                projectUptimeSubscriptionId=[str(uuid.uuid4()) for _ in range(101)],
+                uptimeDetectorId=[str(i) for i in range(101)],
                 since=(datetime.now(timezone.utc) - timedelta(days=90)).timestamp(),
                 until=datetime.now(timezone.utc).timestamp(),
                 resolution="1h",
             )
             assert response.status_code == 400
+            assert response.json() == "Too many uptime detector ids provided. Maximum is 100"
+
+    def test_both_ids_provided_error(self) -> None:
+        """Test that providing both ID types produces an error."""
+        with self.feature(self.features):
+            response = self.get_response(
+                self.organization.slug,
+                project=[self.project.id],
+                projectUptimeSubscriptionId=[str(self.project_uptime_subscription.id)],
+                uptimeDetectorId=["123"],
+                since=(datetime.now(timezone.utc) - timedelta(days=7)).timestamp(),
+                until=datetime.now(timezone.utc).timestamp(),
+                resolution="1d",
+            )
+            assert response.status_code == 400
             assert (
                 response.json()
-                == "Too many project uptime subscription ids provided. Maximum is 100"
+                == "Cannot provide both project uptime subscription ids and uptime detector ids"
             )
+
+    def test_no_ids_provided_error(self) -> None:
+        """Test that providing no IDs produces an error."""
+        with self.feature(self.features):
+            response = self.get_response(
+                self.organization.slug,
+                project=[self.project.id],
+                since=(datetime.now(timezone.utc) - timedelta(days=7)).timestamp(),
+                until=datetime.now(timezone.utc).timestamp(),
+                resolution="1d",
+            )
+            assert response.status_code == 400
+            assert (
+                response.json()
+                == "Either project uptime subscription ids or uptime detector ids must be provided"
+            )
+
+    def test_too_many_detector_ids(self) -> None:
+        """Test that sending too many detector IDs produces a 400."""
+        with self.feature(self.features):
+            response = self.get_response(
+                self.organization.slug,
+                project=[self.project.id],
+                uptimeDetectorId=[str(i) for i in range(101)],
+                since=(datetime.now(timezone.utc) - timedelta(days=7)).timestamp(),
+                until=datetime.now(timezone.utc).timestamp(),
+                resolution="1d",
+            )
+            assert response.status_code == 400
+            assert response.json() == "Too many uptime detector ids provided. Maximum is 100"
+
+    def test_backward_compatibility_with_subscription_ids(self) -> None:
+        """Test that the endpoint still works with legacy projectUptimeSubscriptionId."""
+        with self.feature(self.features):
+            response = self.get_success_response(
+                self.organization.slug,
+                project=[self.project.id],
+                projectUptimeSubscriptionId=[str(self.project_uptime_subscription.id)],
+                since=(datetime.now(timezone.utc) - timedelta(days=7)).timestamp(),
+                until=datetime.now(timezone.utc).timestamp(),
+                resolution="1d",
+            )
+            assert response.data is not None
+            data = json.loads(json.dumps(response.data))
+            assert len(data[str(self.project_uptime_subscription.id)]) == 7
+            # Should have the same data as the detector ID test
+            assert data[str(self.project_uptime_subscription.id)][-1][1] == {
+                "failure": 4,
+                "failure_incident": 1,
+                "success": 3,
+                "missed_window": 0,
+            }
 
 
 @freeze_time(MOCK_DATETIME)
@@ -338,3 +402,47 @@ class OrganizationUptimeStatsEndpointWithEAPTests(
             scheduled_check_time=scheduled_check_time,
         )
         self.store_uptime_results([uptime_result])
+
+    def test_detector_ids_with_eap(self) -> None:
+        """Test that the endpoint works with uptimeDetectorId parameters for EAP."""
+        # Create uptime subscription for EAP tests
+        detector_subscription_id = uuid.uuid4().hex
+        uptime_subscription = self.create_uptime_subscription(
+            url="https://detector-eap-test.com", subscription_id=detector_subscription_id
+        )
+        self.create_project_uptime_subscription(uptime_subscription=uptime_subscription)
+        detector = get_detector(uptime_subscription)
+
+        # Add some test data
+        for scenario in (
+            {"check_status": "success"},
+            {"check_status": "failure"},
+            {"check_status": "failure", "incident_status": IncidentStatus.IN_INCIDENT},
+        ):
+            uptime_result = self.create_eap_uptime_result(
+                subscription_id=uuid.UUID(detector_subscription_id).hex,
+                guid=uuid.UUID(detector_subscription_id).hex,
+                request_url="https://detector-eap-test.com",
+                **scenario,
+            )
+            self.store_uptime_results([uptime_result])
+
+        with self.feature(self.features):
+            response = self.get_success_response(
+                self.organization.slug,
+                project=[self.project.id],
+                uptimeDetectorId=[str(detector.id)],
+                since=(datetime.now(timezone.utc) - timedelta(days=7)).timestamp(),
+                until=datetime.now(timezone.utc).timestamp(),
+                resolution="1d",
+            )
+            assert response.data is not None
+            data = json.loads(json.dumps(response.data))
+            assert len(data[str(detector.id)]) == 7
+            # Should have the data we added
+            assert data[str(detector.id)][-1][1] == {
+                "failure": 1,
+                "failure_incident": 1,
+                "success": 1,
+                "missed_window": 0,
+            }

--- a/tests/sentry/uptime/endpoints/test_organization_uptime_summary.py
+++ b/tests/sentry/uptime/endpoints/test_organization_uptime_summary.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from sentry.testutils.cases import APITestCase, UptimeCheckSnubaTestCase
 from sentry.testutils.helpers.datetime import freeze_time
+from sentry.uptime.models import get_detector
 from sentry.uptime.types import IncidentStatus
 from tests.sentry.uptime.endpoints.test_base import UptimeResultEAPTestCase
 
@@ -25,6 +26,7 @@ class OrganizationUptimeSummaryBaseTest(APITestCase):
         self.project_uptime_subscription = self.create_project_uptime_subscription(
             uptime_subscription=self.subscription
         )
+        self.detector = get_detector(self.subscription)
 
         scenarios: list[dict] = [
             {"check_status": "success"},
@@ -54,14 +56,12 @@ class OrganizationUptimeSummaryBaseTest(APITestCase):
         raise NotImplementedError("Subclasses must implement store_uptime_data")
 
     def test_simple(self) -> None:
-        """
-        Test that the endpoint returns correct summary stats.
-        """
+        """Test that the endpoint returns correct summary stats using detector IDs."""
         with self.feature(self.features):
             response = self.get_success_response(
                 self.organization.slug,
                 project=[self.project.id],
-                projectUptimeSubscriptionId=[str(self.project_uptime_subscription.id)],
+                uptimeDetectorId=[str(self.detector.id)],
                 since=(datetime.now(timezone.utc) - timedelta(days=7)).timestamp(),
                 until=datetime.now(timezone.utc).timestamp(),
             )
@@ -69,8 +69,8 @@ class OrganizationUptimeSummaryBaseTest(APITestCase):
             data = response.data
 
             # Verify structure
-            assert self.project_uptime_subscription.id in data
-            stats = data[self.project_uptime_subscription.id]
+            assert self.detector.id in data
+            stats = data[self.detector.id]
 
             # Verify expected counts based on test scenarios
             assert stats["totalChecks"] == 8
@@ -79,18 +79,15 @@ class OrganizationUptimeSummaryBaseTest(APITestCase):
             assert stats["missedWindowChecks"] == 2
             assert "avgDurationUs" in stats
 
-    def test_multiple_subscriptions(self) -> None:
-        """
-        Test endpoint with multiple uptime subscriptions.
-        """
-        # Create second subscription
+    def test_multiple_detectors(self) -> None:
+        """Test endpoint with multiple uptime detectors."""
+        # Create second subscription and detector
         subscription_id2 = uuid.uuid4().hex
         subscription2 = self.create_uptime_subscription(
             url="https://example.com", subscription_id=subscription_id2
         )
-        project_uptime_subscription2 = self.create_project_uptime_subscription(
-            uptime_subscription=subscription2
-        )
+        self.create_project_uptime_subscription(uptime_subscription=subscription2)
+        detector2 = get_detector(subscription2)
 
         # Add data for second subscription
         scenarios2: list[dict[str, Any]] = [
@@ -104,9 +101,9 @@ class OrganizationUptimeSummaryBaseTest(APITestCase):
             response = self.get_success_response(
                 self.organization.slug,
                 project=[self.project.id],
-                projectUptimeSubscriptionId=[
-                    str(self.project_uptime_subscription.id),
-                    str(project_uptime_subscription2.id),
+                uptimeDetectorId=[
+                    str(self.detector.id),
+                    str(detector2.id),
                 ],
                 since=(datetime.now(timezone.utc) - timedelta(days=7)).timestamp(),
                 until=datetime.now(timezone.utc).timestamp(),
@@ -114,135 +111,122 @@ class OrganizationUptimeSummaryBaseTest(APITestCase):
             assert response.data is not None
             data = response.data
 
-            # Verify both subscriptions are present
-            assert self.project_uptime_subscription.id in data
-            assert project_uptime_subscription2.id in data
+            # Verify both detectors are present
+            assert self.detector.id in data
+            assert detector2.id in data
 
-            # Verify first subscription stats
-            stats1 = data[self.project_uptime_subscription.id]
+            # Verify first detector stats
+            stats1 = data[self.detector.id]
             assert stats1["totalChecks"] == 8
             assert stats1["failedChecks"] == 2
             assert stats1["downtimeChecks"] == 1
             assert stats1["missedWindowChecks"] == 2
 
-            # Verify second subscription stats
-            stats2 = data[project_uptime_subscription2.id]
+            # Verify second detector stats
+            stats2 = data[detector2.id]
             assert stats2["totalChecks"] == 2
             assert stats2["failedChecks"] == 0
             assert stats2["downtimeChecks"] == 1
             assert stats2["missedWindowChecks"] == 0
 
     def test_empty_results(self) -> None:
-        """
-        Test endpoint when no data exists for subscription
-        ."""
+        """Test endpoint when no data exists for detector."""
         # Create subscription with no data
         empty_subscription_id = uuid.uuid4().hex
         empty_subscription = self.create_uptime_subscription(
             url="https://empty.com", subscription_id=empty_subscription_id
         )
-        empty_project_uptime_subscription = self.create_project_uptime_subscription(
-            uptime_subscription=empty_subscription
-        )
+        self.create_project_uptime_subscription(uptime_subscription=empty_subscription)
+        empty_detector = get_detector(empty_subscription)
 
         with self.feature(self.features):
             response = self.get_success_response(
                 self.organization.slug,
                 project=[self.project.id],
-                projectUptimeSubscriptionId=[str(empty_project_uptime_subscription.id)],
+                uptimeDetectorId=[str(empty_detector.id)],
                 since=(datetime.now(timezone.utc) - timedelta(days=7)).timestamp(),
                 until=datetime.now(timezone.utc).timestamp(),
             )
             assert response.data is not None
             data = response.data
 
-            # Should return empty dict for subscriptions with no data
+            # Should return empty dict for detectors with no data
             assert data == {}
 
-    def test_invalid_uptime_subscription_id(self) -> None:
-        """
-        Test that an invalid uptime_subscription_id produces a 400 response.
-        """
+    def test_invalid_detector_id(self) -> None:
+        """Test that an invalid detector ID produces a 400 response."""
         with self.feature(self.features):
             response = self.get_response(
                 self.organization.slug,
                 project=[self.project.id],
-                projectUptimeSubscriptionId=[str(uuid.uuid4())],
+                uptimeDetectorId=["999999"],
                 since=(datetime.now(timezone.utc) - timedelta(days=7)).timestamp(),
                 until=datetime.now(timezone.utc).timestamp(),
             )
             assert response.status_code == 400
-            assert response.json() == "Invalid project uptime subscription ids provided"
+            assert response.json() == "Invalid uptime detector ids provided"
 
-    def test_no_uptime_subscription_id(self) -> None:
-        """
-        Test that not sending any uptime_subscription_id produces a 400 response.
-        """
+    def test_no_detector_id(self) -> None:
+        """Test that not sending any detector ID produces a 400 response."""
         with self.feature(self.features):
             response = self.get_response(
                 self.organization.slug,
                 project=[self.project.id],
-                projectUptimeSubscriptionId=[],
-                since=(datetime.now(timezone.utc) - timedelta(days=7)).timestamp(),
-                until=datetime.now(timezone.utc).timestamp(),
-            )
-            assert response.status_code == 400
-            assert response.json() == "No project uptime subscription ids provided"
-
-    def test_too_many_uptime_subscription_ids(self) -> None:
-        """
-        Test that sending too many subscription IDs produces a 400 response.
-        """
-        with self.feature(self.features):
-            response = self.get_response(
-                self.organization.slug,
-                project=[self.project.id],
-                projectUptimeSubscriptionId=[str(uuid.uuid4()) for _ in range(101)],
+                uptimeDetectorId=[],
                 since=(datetime.now(timezone.utc) - timedelta(days=7)).timestamp(),
                 until=datetime.now(timezone.utc).timestamp(),
             )
             assert response.status_code == 400
             assert (
                 response.json()
-                == "Too many project uptime subscription ids provided. Maximum is 100"
+                == "Either project uptime subscription ids or uptime detector ids must be provided"
             )
 
+    def test_too_many_detector_ids(self) -> None:
+        """Test that sending too many detector IDs produces a 400 response."""
+        with self.feature(self.features):
+            response = self.get_response(
+                self.organization.slug,
+                project=[self.project.id],
+                uptimeDetectorId=[str(i) for i in range(101)],
+                since=(datetime.now(timezone.utc) - timedelta(days=7)).timestamp(),
+                until=datetime.now(timezone.utc).timestamp(),
+            )
+            assert response.status_code == 400
+            assert response.json() == "Too many uptime detector ids provided. Maximum is 100"
+
     def test_cross_project_access_denied(self) -> None:
-        """
-        Test that cross-project access is properly restricted.
-        """
+        """Test that cross-project access is properly restricted."""
         # Create subscription in different project
         other_project = self.create_project(organization=self.organization)
         other_subscription_id = uuid.uuid4().hex
         other_subscription = self.create_uptime_subscription(
             url="https://other.com", subscription_id=other_subscription_id
         )
-        other_project_uptime_subscription = self.create_project_uptime_subscription(
+        self.create_project_uptime_subscription(
             uptime_subscription=other_subscription, project=other_project
         )
+        other_detector = get_detector(other_subscription)
 
         with self.feature(self.features):
             response = self.get_response(
                 self.organization.slug,
                 project=[self.project.id],  # Only include original project
-                projectUptimeSubscriptionId=[str(other_project_uptime_subscription.id)],
+                uptimeDetectorId=[str(other_detector.id)],
                 since=(datetime.now(timezone.utc) - timedelta(days=7)).timestamp(),
                 until=datetime.now(timezone.utc).timestamp(),
             )
             assert response.status_code == 400
-            assert response.json() == "Invalid project uptime subscription ids provided"
+            assert response.json() == "Invalid uptime detector ids provided"
 
     def test_success_only_scenario(self) -> None:
-        """
-        Test scenario with only successful checks.
-        """
+        """Test scenario with only successful checks."""
         success_subscription_id = uuid.uuid4().hex
         success_subscription = self.create_uptime_subscription(
             url="https://success.com", subscription_id=success_subscription_id
         )
-        success_project_uptime_subscription = self.create_project_uptime_subscription(
-            uptime_subscription=success_subscription
-        )
+        self.create_project_uptime_subscription(uptime_subscription=success_subscription)
+        success_detector = get_detector(success_subscription)
 
         # Only success checks
         for _ in range(5):
@@ -252,14 +236,14 @@ class OrganizationUptimeSummaryBaseTest(APITestCase):
             response = self.get_success_response(
                 self.organization.slug,
                 project=[self.project.id],
-                projectUptimeSubscriptionId=[str(success_project_uptime_subscription.id)],
+                uptimeDetectorId=[str(success_detector.id)],
                 since=(datetime.now(timezone.utc) - timedelta(days=7)).timestamp(),
                 until=datetime.now(timezone.utc).timestamp(),
             )
             assert response.data is not None
             data = response.data
 
-            stats = data[success_project_uptime_subscription.id]
+            stats = data[success_detector.id]
             assert stats["totalChecks"] == 5
             assert stats["failedChecks"] == 0
             assert stats["downtimeChecks"] == 0
@@ -267,16 +251,13 @@ class OrganizationUptimeSummaryBaseTest(APITestCase):
             assert "avgDurationUs" in stats
 
     def test_time_range_filtering(self) -> None:
-        """
-        Test that the endpoint accepts time range parameters and filters summary stats.
-        """
+        """Test that the endpoint accepts time range parameters and filters summary stats."""
         filter_subscription_id = uuid.uuid4().hex
         filter_subscription = self.create_uptime_subscription(
             url="https://filter-test.com", subscription_id=filter_subscription_id
         )
-        filter_project_uptime_subscription = self.create_project_uptime_subscription(
-            uptime_subscription=filter_subscription
-        )
+        self.create_project_uptime_subscription(uptime_subscription=filter_subscription)
+        filter_detector = get_detector(filter_subscription)
 
         for i in range(10):
             check_time = datetime.now(timezone.utc) - timedelta(minutes=i * 5)
@@ -295,19 +276,75 @@ class OrganizationUptimeSummaryBaseTest(APITestCase):
             response = self.get_success_response(
                 self.organization.slug,
                 project=[self.project.id],
-                projectUptimeSubscriptionId=[str(filter_project_uptime_subscription.id)],
+                uptimeDetectorId=[str(filter_detector.id)],
                 start=filter_start.isoformat(),
                 end=filter_end.isoformat(),
             )
             assert response.data is not None
             data = response.data
 
-            assert filter_project_uptime_subscription.id in data
-            stats = data[filter_project_uptime_subscription.id]
+            assert filter_detector.id in data
+            stats = data[filter_detector.id]
             assert stats["totalChecks"] == 4
             assert stats["failedChecks"] == 0
             assert stats["downtimeChecks"] == 0
             assert stats["missedWindowChecks"] == 0
+
+    def test_both_ids_provided_error(self) -> None:
+        """Test that providing both ID types produces an error."""
+        with self.feature(self.features):
+            response = self.get_response(
+                self.organization.slug,
+                project=[self.project.id],
+                projectUptimeSubscriptionId=[str(self.project_uptime_subscription.id)],
+                uptimeDetectorId=[str(self.detector.id)],
+                since=(datetime.now(timezone.utc) - timedelta(days=7)).timestamp(),
+                until=datetime.now(timezone.utc).timestamp(),
+            )
+            assert response.status_code == 400
+            assert (
+                response.json()
+                == "Cannot provide both project uptime subscription ids and uptime detector ids"
+            )
+
+    def test_no_ids_provided_error(self) -> None:
+        """Test that providing no IDs produces an error."""
+        with self.feature(self.features):
+            response = self.get_response(
+                self.organization.slug,
+                project=[self.project.id],
+                since=(datetime.now(timezone.utc) - timedelta(days=7)).timestamp(),
+                until=datetime.now(timezone.utc).timestamp(),
+            )
+            assert response.status_code == 400
+            assert (
+                response.json()
+                == "Either project uptime subscription ids or uptime detector ids must be provided"
+            )
+
+    def test_backward_compatibility_with_subscription_ids(self) -> None:
+        """Test that the endpoint still works with legacy projectUptimeSubscriptionId."""
+        with self.feature(self.features):
+            response = self.get_success_response(
+                self.organization.slug,
+                project=[self.project.id],
+                projectUptimeSubscriptionId=[str(self.project_uptime_subscription.id)],
+                since=(datetime.now(timezone.utc) - timedelta(days=7)).timestamp(),
+                until=datetime.now(timezone.utc).timestamp(),
+            )
+            assert response.data is not None
+            data = response.data
+
+            # Verify structure using subscription ID
+            assert self.project_uptime_subscription.id in data
+            stats = data[self.project_uptime_subscription.id]
+
+            # Should have the same data as the detector ID test
+            assert stats["totalChecks"] == 8
+            assert stats["failedChecks"] == 2
+            assert stats["downtimeChecks"] == 1
+            assert stats["missedWindowChecks"] == 2
+            assert "avgDurationUs" in stats
 
 
 @freeze_time(MOCK_DATETIME)
@@ -388,16 +425,13 @@ class OrganizationUptimeSummaryEAPTest(OrganizationUptimeSummaryBaseTest, Uptime
         self.store_uptime_results([uptime_result])
 
     def test_average_duration_available(self) -> None:
-        """
-        Test that average duration is available and correctly calculated for EAP uptime results.
-        """
+        """Test that average duration is available and correctly calculated for EAP uptime results."""
         duration_subscription_id = uuid.uuid4().hex
         duration_subscription = self.create_uptime_subscription(
             url="https://duration-test.com", subscription_id=duration_subscription_id
         )
-        duration_project_uptime_subscription = self.create_project_uptime_subscription(
-            uptime_subscription=duration_subscription
-        )
+        self.create_project_uptime_subscription(uptime_subscription=duration_subscription)
+        duration_detector = get_detector(duration_subscription)
 
         # Store checks with specific durations
         durations = [100000, 200000, 300000]  # 100ms, 200ms, 300ms in microseconds
@@ -412,14 +446,14 @@ class OrganizationUptimeSummaryEAPTest(OrganizationUptimeSummaryBaseTest, Uptime
             response = self.get_success_response(
                 self.organization.slug,
                 project=[self.project.id],
-                projectUptimeSubscriptionId=[str(duration_project_uptime_subscription.id)],
+                uptimeDetectorId=[str(duration_detector.id)],
                 since=(datetime.now(timezone.utc) - timedelta(days=7)).timestamp(),
                 until=datetime.now(timezone.utc).timestamp(),
             )
             assert response.data is not None
             data = response.data
 
-            stats = data[duration_project_uptime_subscription.id]
+            stats = data[duration_detector.id]
             assert stats["totalChecks"] == 3
             # Average should be (100000 + 200000 + 300000) / 3 = 200000
             assert stats["avgDurationUs"] == 200000.0

--- a/tests/sentry/uptime/endpoints/test_utils.py
+++ b/tests/sentry/uptime/endpoints/test_utils.py
@@ -3,7 +3,11 @@ import uuid
 from pytest import raises
 
 from sentry.testutils.cases import TestCase
-from sentry.uptime.endpoints.utils import authorize_and_map_project_uptime_subscription_ids
+from sentry.uptime.endpoints.utils import (
+    authorize_and_map_project_uptime_subscription_ids,
+    authorize_and_map_uptime_detector_subscription_ids,
+)
+from sentry.uptime.models import get_detector
 
 
 class AuthorizeAndMapProjectUptimeSubscriptionIdsTest(TestCase):
@@ -105,3 +109,102 @@ class AuthorizeAndMapProjectUptimeSubscriptionIdsTest(TestCase):
         assert expected_str_id2 in mapping
         assert mapping[expected_str_id1] == project_uptime_subscription1.id
         assert mapping[expected_str_id2] == project_uptime_subscription2.id
+
+
+class AuthorizeAndMapUptimeDetectorSubscriptionIdsTest(TestCase):
+    def test_successful_authorization_and_mapping(self) -> None:
+        """Test successful authorization and mapping of detector subscription IDs."""
+        subscription_id = uuid.uuid4().hex
+        subscription = self.create_uptime_subscription(
+            url="https://example.com", subscription_id=subscription_id
+        )
+        self.create_project_uptime_subscription(
+            uptime_subscription=subscription, project=self.project
+        )
+        detector = get_detector(subscription)
+
+        hex_formatter = lambda sub_id: uuid.UUID(sub_id).hex
+
+        mapping, subscription_ids = authorize_and_map_uptime_detector_subscription_ids(
+            detector_ids=[str(detector.id)],
+            projects=[self.project],
+            sub_id_formatter=hex_formatter,
+        )
+
+        expected_hex_id = uuid.UUID(subscription_id).hex
+        assert expected_hex_id in mapping
+        assert mapping[expected_hex_id] == detector.id
+
+        assert subscription_ids == [expected_hex_id]
+
+    def test_invalid_detector_id_raises_error(self) -> None:
+        """Test that invalid detector IDs raise ValueError."""
+        invalid_id = "999999"
+
+        with raises(ValueError):
+            authorize_and_map_uptime_detector_subscription_ids(
+                detector_ids=[invalid_id],
+                projects=[self.project],
+                sub_id_formatter=str,
+            )
+
+    def test_cross_project_access_denied(self) -> None:
+        """Test that cross-project detector access is denied."""
+        other_project = self.create_project(organization=self.organization)
+        subscription_id = uuid.uuid4().hex
+        subscription = self.create_uptime_subscription(
+            url="https://example.com", subscription_id=subscription_id
+        )
+        self.create_project_uptime_subscription(
+            uptime_subscription=subscription, project=other_project
+        )
+        other_detector = get_detector(subscription)
+
+        # Try to authorize with original project, should fail
+        with raises(ValueError):
+            authorize_and_map_uptime_detector_subscription_ids(
+                detector_ids=[str(other_detector.id)],
+                projects=[self.project],
+                sub_id_formatter=str,
+            )
+
+    def test_multiple_detectors(self) -> None:
+        """Test authorization with multiple detector IDs."""
+        subscription_id1 = uuid.uuid4().hex
+        subscription_id2 = uuid.uuid4().hex
+
+        subscription1 = self.create_uptime_subscription(
+            url="https://example1.com", subscription_id=subscription_id1
+        )
+        subscription2 = self.create_uptime_subscription(
+            url="https://example2.com", subscription_id=subscription_id2
+        )
+
+        self.create_project_uptime_subscription(
+            uptime_subscription=subscription1, project=self.project
+        )
+        self.create_project_uptime_subscription(
+            uptime_subscription=subscription2, project=self.project
+        )
+        detector1 = get_detector(subscription1)
+        detector2 = get_detector(subscription2)
+
+        string_formatter = lambda sub_id: str(uuid.UUID(sub_id))
+
+        mapping, subscription_ids = authorize_and_map_uptime_detector_subscription_ids(
+            detector_ids=[str(detector1.id), str(detector2.id)],
+            projects=[self.project],
+            sub_id_formatter=string_formatter,
+        )
+
+        # Verify both detectors are mapped
+        assert len(mapping) == 2
+        assert len(subscription_ids) == 2
+
+        expected_str_id1 = str(uuid.UUID(subscription_id1))
+        expected_str_id2 = str(uuid.UUID(subscription_id2))
+
+        assert expected_str_id1 in mapping
+        assert expected_str_id2 in mapping
+        assert mapping[expected_str_id1] == detector1.id
+        assert mapping[expected_str_id2] == detector2.id


### PR DESCRIPTION
Support detector IDs in uptime stats and summary endpoints

This PR extends the organization-level uptime stats and summary endpoints to support both legacy project uptime subscription IDs and new detector IDs, enabling a smooth migration path while maintaining backward compatibility.

### Changes

#### Stats endpoint (`OrganizationUptimeStatsEndpoint`):

- Added support for uptimeDetectorId query parameter alongside existing projectUptimeSubscriptionId

- Implemented mutual exclusion validation - exactly one ID type must be provided.

- Updated error messages to reflect which ID type is being validated

- Refactored internal mapping logic to handle both ID types generically.

#### Summary endpoint (`OrganizationUptimeSummaryEndpoint`):

- Mirror changes from stats endpoint for consistent API behavior

- Added detector ID support with same validation rules

- Updated response mapping to work with either ID type

#### Utility functions (`endpoints/utils.py`):

- Added `authorize_and_map_uptime_detector_subscription_ids` function

- Handles the complex detector → data_source → uptime_subscription
  mapping

- Validates detector authorization against user's accessible projects

- Maintains same interface as existing subscription ID mapping function

### API Behavior

#### Legacy usage (backward compatible):

```http
GET /api/0/organizations/org/uptime/stats/?projectUptimeSubscriptionId=123
```

#### New detector-based usage:

```http
GET /api/0/organizations/org/uptime/stats/?uptimeDetectorId=456
```

### Validation rules:

- Exactly one ID type must be provided (mutual exclusion)
- Maximum 100 IDs per request for either type
- All provided IDs must be valid and authorized for the user's projects

### Testing

Comprehensive test coverage added for both endpoints including:

- Detector ID functionality validation
- Error cases (invalid IDs, mixing ID types, etc.)
- Backward compatibility verification with existing subscription ID usage
- Edge cases like rate limiting and authorization failures

The changes enable frontend teams to gradually migrate from subscription-based to detector-based uptime monitoring while keeping all existing functionality intact.