### PR TITLE
fix(releases): Fix 'Archive Release' modal title overflow

### DIFF
--- a/static/app/views/releases/detail/header/releaseActions.tsx
+++ b/static/app/views/releases/detail/header/releaseActions.tsx
@@ -99,7 +99,7 @@ function ReleaseActions({
 
   function getModalHeader(title: React.ReactNode) {
     return (
-      <h4>
+      <h4 style={{maxWidth: '100%'}}>
         <TextOverflow>{title}</TextOverflow>
       </h4>
     );

--- a/static/app/views/releases/detail/header/releaseActions.tsx
+++ b/static/app/views/releases/detail/header/releaseActions.tsx
@@ -99,9 +99,9 @@ function ReleaseActions({
 
   function getModalHeader(title: React.ReactNode) {
     return (
-      <h4 style={{maxWidth: '100%'}}>
+      <ModalHeaderContainer>
         <TextOverflow>{title}</TextOverflow>
-      </h4>
+      </ModalHeaderContainer>
     );
   }
 
@@ -244,6 +244,10 @@ const ProjectsWrapper = styled('div')`
     border: none !important;
     box-shadow: none !important;
   }
+`;
+
+const ModalHeaderContainer = styled('h4')`
+  max-width: 100%;
 `;
 
 export default ReleaseActions;


### PR DESCRIPTION
fixes REPLAY-221

Set the max width of the modal header container to 100% so that any overflow is handled by an ellipsis.

Before:
<img width="1088" height="370" alt="Screenshot 2025-08-28 at 1 41 20 PM" src="https://github.com/user-attachments/assets/bd762ae3-2736-4e42-9b25-cb19c00e4d2b" />

After:
<img width="1088" height="370" alt="Screenshot 2025-08-28 at 1 39 27 PM" src="https://github.com/user-attachments/assets/4ccf4228-369e-45c9-9b8c-ad087d8bf14c" />
