### PR TITLE
ref(uptime): Stop writing uptime_rule

### DIFF
--- a/src/sentry/uptime/grouptype.py
+++ b/src/sentry/uptime/grouptype.py
@@ -16,7 +16,7 @@ from sentry.issues.status_change_message import StatusChangeMessage
 from sentry.models.group import GroupStatus
 from sentry.ratelimits.sliding_windows import Quota
 from sentry.types.group import PriorityLevel
-from sentry.uptime.models import UptimeStatus, UptimeSubscription, get_project_subscription
+from sentry.uptime.models import UptimeStatus, UptimeSubscription
 from sentry.uptime.types import GROUP_TYPE_UPTIME_DOMAIN_CHECK_FAILURE, UptimeMonitorMode
 from sentry.utils import metrics
 from sentry.workflow_engine.handlers.detector.base import DetectorOccurrence, EventData
@@ -131,19 +131,12 @@ def build_event_data(result: CheckResult, detector: Detector) -> EventData:
     # Received time is the actual time the check was performed.
     received = datetime.fromtimestamp(result["actual_check_time_ms"] / 1000)
 
-    # XXX(epurkhiser): This can be changed over to using the detector ID in the
-    # future once we're no longer using the ProjectUptimeSubscription.id as a tag.
-    project_subscription = get_project_subscription(detector)
-
     return {
         "project_id": detector.project_id,
         "environment": env,
         "received": received,
         "platform": "other",
         "sdk": None,
-        "tags": {
-            "uptime_rule": str(project_subscription.id),
-        },
         "contexts": {
             "trace": {"trace_id": result["trace_id"], "span_id": result.get("span_id")},
         },

--- a/tests/sentry/uptime/test_grouptype.py
+++ b/tests/sentry/uptime/test_grouptype.py
@@ -124,7 +124,6 @@ class BuildEventDataTest(UptimeTestCase):
             "project_id": detector.project_id,
             "received": datetime.now().replace(microsecond=0),
             "sdk": None,
-            "tags": {"uptime_rule": str(project_subscription.id)},
             "contexts": {
                 "trace": {"trace_id": result["trace_id"], "span_id": result.get("span_id")}
             },


### PR DESCRIPTION
We don't need this anymore to link back to the uptime monitor, we'll be
using the detector ID, which is part of the occurrence evidence data.

Should not merge until after we've cut-over the UI to only using
detector IDs.