### PR TITLE
chore(integrations): Pass `installableOnly` option from frontend when adding a repository

### DIFF
--- a/static/app/views/settings/organizationIntegrations/integrationReposAddRepository.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationReposAddRepository.tsx
@@ -44,7 +44,7 @@ export function IntegrationReposAddRepository({
   const query = useQuery({
     queryKey: [
       `/organizations/${organization.slug}/integrations/${integration.id}/repos/`,
-      {method: 'GET', query: {search: debouncedSearch}},
+      {method: 'GET', query: {search: debouncedSearch, installableOnly: true}},
     ] as const,
     queryFn: async context => {
       try {


### PR DESCRIPTION
Part of [ID-125](https://linear.app/getsentry/issue/ID-125/when-creating-a-code-mapping-pre-load-the-default-branch).

`OrganizationIntegrationReposEndpoint` currently returns only installable repositories, but it should return *all* repositories which are made available by the integration. We should preserve the behavior of returning only installable repositories in the case of adding a repository, so we're adding this param to this request before changing backend behavior.

Next step will be to update the endpoint to check the param's value and return only installable repositories if true.