### PR TITLE
feat(insights): User Issue creation scope and response

### DIFF
--- a/src/sentry/issues/endpoints/project_user_issue.py
+++ b/src/sentry/issues/endpoints/project_user_issue.py
@@ -9,7 +9,7 @@ from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
-from sentry.api.bases.project import ProjectEndpoint
+from sentry.api.bases.project import ProjectEndpoint, ProjectEventPermission, ProjectPermission
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.issues.grouptype import GroupType, WebVitalsGroup
 from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence
@@ -150,8 +150,15 @@ class WebVitalsIssueDataSerializer(ProjectUserIssueRequestSerializer):
     vital = serializers.ChoiceField(required=True, choices=["lcp", "fcp", "cls", "inp", "ttfb"])
 
 
+class ProjectUserIssuePermission(ProjectPermission):
+    scope_map = {
+        "POST": ["event:read", "event:write", "event:admin"],
+    }
+
+
 @region_silo_endpoint
 class ProjectUserIssueEndpoint(ProjectEndpoint):
+    permission_classes = (ProjectEventPermission,)
     publish_status = {
         "POST": ApiPublishStatus.EXPERIMENTAL,
     }

--- a/src/sentry/issues/endpoints/project_user_issue.py
+++ b/src/sentry/issues/endpoints/project_user_issue.py
@@ -9,7 +9,7 @@ from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
-from sentry.api.bases.project import ProjectEndpoint, ProjectEventPermission, ProjectPermission
+from sentry.api.bases.project import ProjectEndpoint, ProjectPermission
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.issues.grouptype import GroupType, WebVitalsGroup
 from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence
@@ -152,13 +152,16 @@ class WebVitalsIssueDataSerializer(ProjectUserIssueRequestSerializer):
 
 class ProjectUserIssuePermission(ProjectPermission):
     scope_map = {
+        "GET": [],
         "POST": ["event:read", "event:write", "event:admin"],
+        "PUT": [],
+        "DELETE": [],
     }
 
 
 @region_silo_endpoint
 class ProjectUserIssueEndpoint(ProjectEndpoint):
-    permission_classes = (ProjectEventPermission,)
+    permission_classes = (ProjectUserIssuePermission,)
     publish_status = {
         "POST": ApiPublishStatus.EXPERIMENTAL,
     }

--- a/src/sentry/issues/endpoints/project_user_issue.py
+++ b/src/sentry/issues/endpoints/project_user_issue.py
@@ -1,6 +1,7 @@
 from datetime import UTC, datetime
 from uuid import uuid4
 
+from drf_spectacular.utils import extend_schema
 from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -10,6 +11,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectPermission
+from sentry.apidocs.parameters import GlobalParams
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.issues.grouptype import GroupType, WebVitalsGroup
 from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence
@@ -159,6 +161,10 @@ class ProjectUserIssuePermission(ProjectPermission):
     }
 
 
+class ProjectUserIssueResponseSerializer(serializers.Serializer):
+    event_id = serializers.CharField(required=True)
+
+
 @region_silo_endpoint
 class ProjectUserIssueEndpoint(ProjectEndpoint):
     permission_classes = (ProjectUserIssuePermission,)
@@ -186,6 +192,14 @@ class ProjectUserIssueEndpoint(ProjectEndpoint):
             "organizations:issue-web-vitals-ingest", organization, actor=request.user
         )
 
+    @extend_schema(
+        operation_id="Create a user defined issue",
+        parameters=[GlobalParams.ORG_ID_OR_SLUG, GlobalParams.PROJECT_ID_OR_SLUG],
+        request=ProjectUserIssueRequestSerializer,
+        responses={
+            200: ProjectUserIssueResponseSerializer,
+        },
+    )
     def post(self, request: Request, project: Project) -> Response:
         """
         Create a user defined issue.
@@ -246,4 +260,4 @@ class ProjectUserIssueEndpoint(ProjectEndpoint):
             payload_type=PayloadType.OCCURRENCE, occurrence=occurence, event_data=event_data
         )
 
-        return Response(status=200)
+        return Response({"event_id": event_id}, status=200)

--- a/tests/sentry/issues/endpoints/test_project_user_issue.py
+++ b/tests/sentry/issues/endpoints/test_project_user_issue.py
@@ -52,6 +52,7 @@ class ProjectUserIssueEndpointTest(APITestCase):
             )
 
         assert response.status_code == 200
+        assert response.data == {"event_id": mock_produce.call_args[1]["occurrence"].event_id}
         mock_produce.assert_called_once()
 
         call_args = mock_produce.call_args


### PR DESCRIPTION
Two minor changes: 
- Updates the `user-issue` endpoint permissions to check for `event` scopes instead of `project` scopes
- Also updates the response payload to include the created event id.