### PR TITLE
fix(releases): lower number of placeholder rows in new issues table in releases drawer

### DIFF
--- a/static/app/components/issues/groupList.tsx
+++ b/static/app/components/issues/groupList.tsx
@@ -59,6 +59,11 @@ type Props = WithRouterProps & {
    * Defaults to `/organizations/${orgSlug}/issues/`
    */
   endpointPath?: string;
+  /**
+   * Number of placeholder rows to show during loading
+   * Defaults to queryParams.limit or 4
+   */
+  numPlaceholderRows?: number;
   onFetchSuccess?: (
     groupListState: State,
     onCursor: (
@@ -68,11 +73,6 @@ type Props = WithRouterProps & {
       pageDiff: number
     ) => void
   ) => void;
-  /**
-   * Number of placeholder rows to show during loading
-   * Defaults to queryParams.limit or 4
-   */
-  placeholderRows?: number;
   /**
    * Use `query` within `queryParams` for passing the parameter to the endpoint
    */
@@ -268,7 +268,7 @@ class GroupList extends Component<Props, State> {
       queryFilterDescription,
       source,
       query,
-      placeholderRows,
+      numPlaceholderRows,
     } = this.props;
     const {loading, error, errorData, groups, memberList, pageLinks} = this.state;
 
@@ -314,7 +314,7 @@ class GroupList extends Component<Props, State> {
             {loading
               ? [
                   ...new Array(
-                    placeholderRows ??
+                    numPlaceholderRows ??
                       (typeof queryParams?.limit === 'number' ? queryParams?.limit : 4)
                   ),
                 ].map((_, i) => (

--- a/static/app/components/issues/groupList.tsx
+++ b/static/app/components/issues/groupList.tsx
@@ -52,6 +52,10 @@ export type GroupListColumn =
 
 type Props = WithRouterProps & {
   api: Client;
+  /**
+   * Number of placeholder rows to show during loading
+   */
+  numPlaceholderRows: number;
   organization: Organization;
   queryParams: Record<string, number | string | string[] | undefined | null>;
   customStatsPeriod?: TimePeriodType;
@@ -59,11 +63,6 @@ type Props = WithRouterProps & {
    * Defaults to `/organizations/${orgSlug}/issues/`
    */
   endpointPath?: string;
-  /**
-   * Number of placeholder rows to show during loading
-   * Defaults to queryParams.limit or 4
-   */
-  numPlaceholderRows?: number;
   onFetchSuccess?: (
     groupListState: State,
     onCursor: (
@@ -312,12 +311,7 @@ class GroupList extends Component<Props, State> {
           <GroupListHeader withChart={!!withChart} withColumns={columns} />
           <PanelBody>
             {loading
-              ? [
-                  ...new Array(
-                    numPlaceholderRows ??
-                      (typeof queryParams?.limit === 'number' ? queryParams?.limit : 4)
-                  ),
-                ].map((_, i) => (
+              ? [...new Array(numPlaceholderRows)].map((_, i) => (
                   <GroupPlaceholder key={i}>
                     <Placeholder height="50px" />
                   </GroupPlaceholder>

--- a/static/app/components/issues/groupList.tsx
+++ b/static/app/components/issues/groupList.tsx
@@ -69,6 +69,11 @@ type Props = WithRouterProps & {
     ) => void
   ) => void;
   /**
+   * Number of placeholder rows to show during loading
+   * Defaults to queryParams.limit or 4
+   */
+  placeholderRows?: number;
+  /**
    * Use `query` within `queryParams` for passing the parameter to the endpoint
    */
   query?: string;
@@ -263,6 +268,7 @@ class GroupList extends Component<Props, State> {
       queryFilterDescription,
       source,
       query,
+      placeholderRows,
     } = this.props;
     const {loading, error, errorData, groups, memberList, pageLinks} = this.state;
 
@@ -308,7 +314,8 @@ class GroupList extends Component<Props, State> {
             {loading
               ? [
                   ...new Array(
-                    typeof queryParams?.limit === 'number' ? queryParams?.limit : 4
+                    placeholderRows ??
+                      (typeof queryParams?.limit === 'number' ? queryParams?.limit : 4)
                   ),
                 ].map((_, i) => (
                   <GroupPlaceholder key={i}>

--- a/static/app/views/alerts/rules/metric/details/relatedIssues.tsx
+++ b/static/app/views/alerts/rules/metric/details/relatedIssues.tsx
@@ -131,6 +131,7 @@ function RelatedIssues({
           customStatsPeriod={timePeriod}
           useTintRow={false}
           source="alerts-related-issues"
+          numPlaceholderRows={queryParams.limit}
         />
       </TableWrapper>
     </Fragment>

--- a/static/app/views/alerts/rules/uptime/uptimeIssues.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeIssues.tsx
@@ -38,6 +38,7 @@ export function UptimeIssues({project, ruleId}: Props) {
         limit: 1,
       }}
       renderEmptyMessage={emptyMessage}
+      numPlaceholderRows={1}
     />
   );
 }

--- a/static/app/views/detectors/components/details/common/ongoingIssues.tsx
+++ b/static/app/views/detectors/components/details/common/ongoingIssues.tsx
@@ -74,6 +74,7 @@ export function DetectorDetailsOngoingIssues({detectorId, query}: Props) {
           withChart={false}
           renderEmptyMessage={EmptyMessage}
           source="detector-details"
+          numPlaceholderRows={queryParams.limit}
         />
       </ErrorBoundary>
     </Section>

--- a/static/app/views/insights/crons/components/monitorIssues.tsx
+++ b/static/app/views/insights/crons/components/monitorIssues.tsx
@@ -104,6 +104,7 @@ export function MonitorIssues({monitor, monitorEnvs}: Props) {
         withChart={false}
         useTintRow={false}
         source="monitors"
+        numPlaceholderRows={20}
       />
     </Fragment>
   );

--- a/static/app/views/issueDetails/groupRelatedIssues/index.tsx
+++ b/static/app/views/issueDetails/groupRelatedIssues/index.tsx
@@ -120,6 +120,7 @@ function RelatedIssuesSection({group, relationType}: RelatedIssuesSectionProps) 
             canSelectGroups={false}
             withChart={false}
             withColumns={['event']}
+            numPlaceholderRows={4}
           />
         </Fragment>
       ) : null}

--- a/static/app/views/performance/transactionSummary/transactionOverview/relatedIssues.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/relatedIssues.tsx
@@ -121,6 +121,7 @@ function RelatedIssues({
           withChart={false}
           withPagination={false}
           source="performance-related-issues"
+          numPlaceholderRows={queryParams.limit}
         />
       </TableWrapper>
     </Fragment>

--- a/static/app/views/projectDetail/projectIssues.tsx
+++ b/static/app/views/projectDetail/projectIssues.tsx
@@ -172,7 +172,7 @@ function ProjectIssues({organization, location, projectId, query, api}: Props) {
     : [`${IssuesQuery.ALL}`, query].join(' ').trim();
 
   const queryParams = {
-    limit: '5',
+    limit: 5,
     ...normalizeDateTimeParams(
       pick(location.query, [...Object.values(URL_PARAM), 'cursor'])
     ),
@@ -292,6 +292,7 @@ function ProjectIssues({organization, location, projectId, query, api}: Props) {
         withPagination={false}
         onFetchSuccess={handleFetchSuccess}
         source="project"
+        numPlaceholderRows={queryParams.limit}
       />
     </Fragment>
   );

--- a/static/app/views/releases/detail/overview/releaseIssues.tsx
+++ b/static/app/views/releases/detail/overview/releaseIssues.tsx
@@ -416,6 +416,7 @@ class ReleaseIssues extends Component<Props, State> {
             withPagination={false}
             onFetchSuccess={this.handleFetchSuccess}
             source="release"
+            numPlaceholderRows={queryParams.limit}
           />
         </div>
       </Fragment>

--- a/static/app/views/releases/drawer/newIssues.tsx
+++ b/static/app/views/releases/drawer/newIssues.tsx
@@ -52,7 +52,7 @@ export function NewIssues({release, projectId, withChart = false}: Props) {
       renderEmptyMessage={renderEmptyMessage}
       withPagination
       source="release-drawer"
-      placeholderRows={3}
+      numPlaceholderRows={3}
     />
   );
 }

--- a/static/app/views/releases/drawer/newIssues.tsx
+++ b/static/app/views/releases/drawer/newIssues.tsx
@@ -52,6 +52,7 @@ export function NewIssues({release, projectId, withChart = false}: Props) {
       renderEmptyMessage={renderEmptyMessage}
       withPagination
       source="release-drawer"
+      placeholderRows={3}
     />
   );
 }


### PR DESCRIPTION
fixes REPLAY-213

Previously, the new issues table in the releases drawer had an excessive amount of placeholders on load. Here we add a required `numPlaceholderRows` prop to the `GroupList` component so that a manual number must be set. For other instances using this component, we can pass the `queryParams.limit` (as was previously defaulted) or 4.

I have **3 rows** set as the number of placeholder rows in the new issues table right now (1 seems like not enough to denote that we're looking at a table; 2 feels weird), but open to feedback on this.

Before:
<img width="761" height="1095" alt="Screenshot 2025-08-28 at 3 05 40 PM" src="https://github.com/user-attachments/assets/ab95704f-602e-422f-8ce0-71201a47c6af" />

After:
<img width="761" height="641" alt="Screenshot 2025-08-28 at 3 05 13 PM" src="https://github.com/user-attachments/assets/4cdbc2bf-6ae3-41ae-8a4f-b56fa2580c37" />

