### PR TITLE
feat(spans): Expose client/server sample rates for spans

### DIFF
--- a/src/sentry/search/eap/columns.py
+++ b/src/sentry/search/eap/columns.py
@@ -423,16 +423,21 @@ class FormulaDefinition(FunctionDefinition):
         )
 
 
-def simple_sentry_field(field) -> ResolvedAttribute:
+def simple_sentry_field(
+    field: str,
+    search_type: constants.SearchType = "string",
+) -> ResolvedAttribute:
     """For a good number of fields, the public alias matches the internal alias
     without the `sentry.` suffix. This helper functions makes defining them easier"""
     return ResolvedAttribute(
-        public_alias=field, internal_name=f"sentry.{field}", search_type="string"
+        public_alias=field,
+        internal_name=f"sentry.{field}",
+        search_type=search_type,
     )
 
 
 def simple_measurements_field(
-    field,
+    field: str,
     search_type: constants.SearchType = "number",
     secondary_alias: bool = False,
 ) -> ResolvedAttribute:

--- a/src/sentry/search/eap/spans/attributes.py
+++ b/src/sentry/search/eap/spans/attributes.py
@@ -34,6 +34,8 @@ SPAN_ATTRIBUTE_DEFINITIONS = {
     column.public_alias: column
     for column in COMMON_COLUMNS
     + [
+        simple_sentry_field("client_sample_rate", search_type="number"),
+        simple_sentry_field("server_sample_rate", search_type="number"),
         ResolvedAttribute(
             public_alias="id",
             internal_name="sentry.item_id",


### PR DESCRIPTION
Only available on spans but we should think about exposing this on all eap items