### PR TITLE
fix(asana): filter out unsafe query strings in oauth initiation request

### DIFF
--- a/src/social_auth/backends/__init__.py
+++ b/src/social_auth/backends/__init__.py
@@ -65,6 +65,8 @@ PIPELINE = setting(
     ),
 )
 
+UNSAFE_QUERY_PARAMS = ["client_id", "redirect_uri", "state", "response_type"]
+
 logger = logging.getLogger("social_auth")
 
 
@@ -596,7 +598,7 @@ class BaseOAuth2(OAuthAuth):
 
         for param_name, param_value in parsed_params:
             # Remove client_id parameter
-            if param_name.lower() != "client_id":
+            if param_name.lower() not in UNSAFE_QUERY_PARAMS:
                 safe_params.append((param_name, param_value))
 
         if safe_params:

--- a/src/social_auth/backends/__init__.py
+++ b/src/social_auth/backends/__init__.py
@@ -16,7 +16,7 @@ import logging
 import threading
 from typing import Any
 from urllib.error import HTTPError
-from urllib.parse import urlencode
+from urllib.parse import parse_qsl, urlencode
 from urllib.request import Request
 
 import requests
@@ -579,11 +579,30 @@ class BaseOAuth2(OAuthAuth):
         params.update(self.get_scope_argument())
         params.update(self.auth_extra_arguments())
 
-        if self.request.META.get("QUERY_STRING"):
-            query_string = "&" + self.request.META["QUERY_STRING"]
-        else:
-            query_string = ""
+        query_string = self._get_safe_query_string()
         return self.AUTHORIZATION_URL + "?" + urlencode(params) + query_string
+
+    def _get_safe_query_string(self):
+        """
+        Returns filtered query string without client_id parameter.
+        """
+
+        query_string = self.request.META.get("QUERY_STRING", "")
+        if not query_string:
+            return ""
+
+        parsed_params = parse_qsl(query_string, keep_blank_values=True)
+        safe_params = []
+
+        for param_name, param_value in parsed_params:
+            # Remove client_id parameter
+            if param_name.lower() != "client_id":
+                safe_params.append((param_name, param_value))
+
+        if safe_params:
+            return "&" + urlencode(safe_params)
+        else:
+            return ""
 
     def validate_state(self):
         """Validate state value. Raises exception on error, returns state

--- a/src/social_auth/backends/asana.py
+++ b/src/social_auth/backends/asana.py
@@ -4,8 +4,6 @@ ASANA_CLIENT_ID & ASANA_CLIENT_SECRET
 and put into sentry.conf.py
 """
 
-from urllib.parse import parse_qsl, urlencode
-
 import requests
 
 from social_auth.backends import BaseOAuth2, OAuthBackend
@@ -57,48 +55,6 @@ class AsanaAuth(BaseOAuth2):
             return resp.json()["data"]
         except ValueError:
             return None
-
-    def auth_url(self):
-        if self.STATE_PARAMETER or self.REDIRECT_STATE:
-            # Store state in session for further request validation. The state
-            # value is passed as state parameter (as specified in OAuth2 spec),
-            # but also added to redirect_uri, that way we can still verify the
-            # request if the provider doesn't implement the state parameter.
-            # Reuse token if any.
-            name = self.AUTH_BACKEND.name + "_state"
-            state = self.request.session.get(name) or self.state_token()
-            self.request.session[self.AUTH_BACKEND.name + "_state"] = state
-        else:
-            state = None
-
-        params = self.auth_params(state)
-        params.update(self.get_scope_argument())
-        params.update(self.auth_extra_arguments())
-
-        query_string = self._get_safe_query_string()
-        return self.AUTHORIZATION_URL + "?" + urlencode(params) + query_string
-
-    def _get_safe_query_string(self):
-        """
-        Returns filtered query string without client_id parameter.
-        """
-
-        query_string = self.request.META.get("QUERY_STRING", "")
-        if not query_string:
-            return ""
-
-        parsed_params = parse_qsl(query_string, keep_blank_values=True)
-        safe_params = []
-
-        for param_name, param_value in parsed_params:
-            # Remove client_id parameter
-            if param_name.lower() != "client_id":
-                safe_params.append((param_name, param_value))
-
-        if safe_params:
-            return "&" + urlencode(safe_params)
-        else:
-            return ""
 
     def auth_complete(self, *args, **kwargs):
         """Completes logging process, must return user instance"""


### PR DESCRIPTION
updates the `auth_url` method in the `baseOAuth2` class to filter out the unsafe `client_id` query string

fixes https://linear.app/getsentry/issue/RTC-1114/oauth-manipulation-in-sentrys-asana-integration-leading-to-account

i tested the identity linking locally and the UI flow still works as normal