### PR TITLE
ref(issues): stop forcing `global-views` into plans

### DIFF
--- a/static/gsApp/components/features/planFeature.spec.tsx
+++ b/static/gsApp/components/features/planFeature.spec.tsx
@@ -171,46 +171,6 @@ describe('PlanFeature', () => {
     });
   });
 
-  it('returns global-views in business plan even if response does not include it', async () => {
-    const mockFn = jest.fn(() => null);
-
-    const sub = SubscriptionFixture({organization, planTier: PlanTier.MM2});
-    SubscriptionStore.set(organization.slug, sub);
-
-    render(
-      <PlanFeature organization={organization} features={['global-views']}>
-        {mockFn}
-      </PlanFeature>
-    );
-
-    await waitFor(() => {
-      expect(mockFn).toHaveBeenCalledWith({
-        plan: PlanDetailsLookupFixture('am2_business'),
-        tierChange: 'am2',
-      });
-    });
-  });
-
-  it('returns business plan with other features including global-views', async () => {
-    const mockFn = jest.fn(() => null);
-
-    const sub = SubscriptionFixture({organization, planTier: PlanTier.MM2});
-    SubscriptionStore.set(organization.slug, sub);
-
-    render(
-      <PlanFeature organization={organization} features={['global-views', 'sso-basic']}>
-        {mockFn}
-      </PlanFeature>
-    );
-
-    await waitFor(() => {
-      expect(mockFn).toHaveBeenCalledWith({
-        plan: PlanDetailsLookupFixture('am2_business'),
-        tierChange: 'am2',
-      });
-    });
-  });
-
   it('returns dashboards-basic in team plan even if response does not include it', async () => {
     const mockFn = jest.fn(() => null);
 

--- a/static/gsApp/components/features/planFeature.tsx
+++ b/static/gsApp/components/features/planFeature.tsx
@@ -7,7 +7,6 @@ import withSubscription from 'getsentry/components/withSubscription';
 import {useBillingConfig} from 'getsentry/hooks/useBillingConfig';
 import type {Plan, Subscription} from 'getsentry/types';
 import {
-  isAmEnterprisePlan,
   isBizPlanFamily,
   isDeveloperPlan,
   isTeamPlanFamily,
@@ -110,16 +109,11 @@ function PlanFeature({subscription, features, organization, children}: Props) {
     plans = billingConfig.planList;
   }
 
-  // HACK: we want to remove `global-views` from getsentry and move it to flagpole,
+  // HACK: we want to remove certain flags from getsentry and move them to flagpole,
   // but since PlanFeature hooks into getsentry to determine which plan
-  // `global-views` is in, we need to hardcode it into the plans here
+  // has which features, we need to hardcode it into the plans here
   // TODO: remove this
   for (const plan of plans) {
-    if (isBizPlanFamily(plan) || isAmEnterprisePlan(plan.id)) {
-      if (!plan.features.includes('global-views')) {
-        plan.features.push('global-views');
-      }
-    }
     if (isBizPlanFamily(plan)) {
       if (!plan.features.includes('dashboards-edit')) {
         plan.features.push('dashboards-edit');


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/97148 — we had to do some hacky things so that upsell banners worked properly while moving features to flagpole. Now that cross-project selection (aka `global-views`) is enabled for all plans, we need to clean up this workaround. Next steps are to deprecate `global-views` entirely.

Closes https://linear.app/getsentry/issue/ID-861/remove-global-views-hovercard-hack-once-logs-launches

