### PR TITLE
chore(blame): Add hackweek-typing revs to blocklist

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -106,3 +106,8 @@ b4914e559b6e70675452d8ed750fbf70ec703f27
 7dcda5dd9a861130d657ccc2468eb61f55be76b9
 # feat(dx): Move various organization endpoints to "core" (#97407)
 8592e74bbd014d1d44b7cd973379e5278ceb5b41
+
+# fix(typing): Fix typing in 561 files
+6306803deffe6eb3d417250007747ad0f44bfc73
+e4e3a2d994deed4cfd3a30bce8ae2cae80086fa3
+a888a91ddc8e29e59656095a492915c5ee480577


### PR DESCRIPTION
The hackweek typing revs touched a lot of files and, now that we don't see any more issues, will likely be blame-fracturing. Let's add them to the blocklist.