### PR TITLE
:bug: fix(aci): fix slack interactions during rollout

### DIFF
--- a/tests/sentry/integrations/slack/webhooks/actions/__init__.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/__init__.py
@@ -130,6 +130,7 @@ class BaseEventTest(APITestCase):
         selected_option=None,
         view=None,
         private_metadata=None,
+        callback_id=None,
     ):
         """Respond as if we were Slack"""
         if slack_user is None:
@@ -142,6 +143,9 @@ class BaseEventTest(APITestCase):
 
         if original_message is None:
             original_message = {}
+
+        if callback_id is None:
+            callback_id = orjson.dumps({"issue": self.group.id, "rule": self.rule.id}).decode()
 
         payload = {
             "type": type,
@@ -157,6 +161,7 @@ class BaseEventTest(APITestCase):
             "response_urls": [],
             "enterprise": None,
             "is_enterprise_install": False,
+            "callback_id": callback_id,
         }
 
         if type == "view_submission":

--- a/tests/sentry/integrations/slack/webhooks/actions/test_status.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/test_status.py
@@ -29,6 +29,8 @@ from sentry.silo.base import SiloMode
 from sentry.silo.safety import unguarded_write
 from sentry.testutils.cases import PerformanceIssueTestCase
 from sentry.testutils.helpers.datetime import before_now, freeze_time
+from sentry.testutils.helpers.features import with_feature
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
@@ -720,6 +722,28 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     @patch("sentry.integrations.slack.message_builder.issues.get_tags", return_value=[])
     def test_resolve_issue(self, mock_tags: MagicMock, mock_record: MagicMock) -> None:
+        original_message = self.get_original_message(self.group.id)
+        self.resolve_issue(original_message, "resolved", mock_record)
+
+        self.group = Group.objects.get(id=self.group.id)
+        assert self.group.get_status() == GroupStatus.RESOLVED
+        assert not GroupResolution.objects.filter(group=self.group)
+
+        blocks = self.mock_post.call_args.kwargs["blocks"]
+        assert mock_tags.call_args.kwargs["tags"] == self.tags
+
+        expect_status = f"*Issue resolved by <@{self.external_id}>*"
+        assert self.notification_text in blocks[1]["text"]["text"]
+        assert blocks[2]["text"]["text"] == expect_status
+        assert "white_circle" in blocks[0]["elements"][0]["elements"][0]["name"]
+
+    @with_feature("organizations:workflow-engine-single-process-workflows")
+    @override_options({"workflow_engine.issue_alert.group.type_id.rollout": [1]})
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    @patch("sentry.integrations.slack.message_builder.issues.get_tags", return_value=[])
+    def test_resolve_issue_during_aci_rollout(
+        self, mock_tags: MagicMock, mock_record: MagicMock
+    ) -> None:
         original_message = self.get_original_message(self.group.id)
         self.resolve_issue(original_message, "resolved", mock_record)
 


### PR DESCRIPTION
resolves SENTRY-48VA

basically because we are rolling out ACI, when we try to build a notification using Rules, we must populate the "legacy_rule_id" field. we weren't doing that so when we went to send a notification, we were erroring out (since we were going down the aci backend rollout path).

this pr fixes it by correctly inserting the `legacy_rule_id` key, similar to
https://github.com/getsentry/sentry/blob/db7de1eee6c276b077e2e1c9a6cd59a041f34c83/src/sentry/notifications/notification_action/types.py#L168

also wrote a test to verify this behavior.