### PR TITLE
ref(suspect commits): Simplify event file committers to GroupOwner-only behavior

### DIFF
--- a/src/sentry/api/endpoints/event_file_committers.py
+++ b/src/sentry/api/endpoints/event_file_committers.py
@@ -36,9 +36,7 @@ class EventFileCommittersEndpoint(ProjectEndpoint):
         elif event.group_id is None:
             raise NotFound(detail="Issue not found")
 
-        committers = get_serialized_event_file_committers(
-            project, event, frame_limit=int(request.GET.get("frameLimit", 25))
-        )
+        committers = get_serialized_event_file_committers(project, event)
 
         if not committers:
             raise NotFound(detail="No committers found")

--- a/src/sentry/api/endpoints/event_file_committers.py
+++ b/src/sentry/api/endpoints/event_file_committers.py
@@ -6,9 +6,6 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
-from sentry.models.commit import Commit
-from sentry.models.group import Group
-from sentry.models.release import Release
 from sentry.services import eventstore
 from sentry.utils.committers import get_serialized_event_file_committers
 
@@ -39,18 +36,12 @@ class EventFileCommittersEndpoint(ProjectEndpoint):
         elif event.group_id is None:
             raise NotFound(detail="Issue not found")
 
-        try:
-            committers = get_serialized_event_file_committers(
-                project, event, frame_limit=int(request.GET.get("frameLimit", 25))
-            )
+        committers = get_serialized_event_file_committers(
+            project, event, frame_limit=int(request.GET.get("frameLimit", 25))
+        )
 
-        # TODO(nisanthan): Remove the Group.DoesNotExist and Release.DoesNotExist once Commit Context goes GA
-        except Group.DoesNotExist:
-            raise NotFound(detail="Issue not found")
-        except Release.DoesNotExist:
-            raise NotFound(detail="Release not found")
-        except Commit.DoesNotExist:
-            raise NotFound(detail="No Commits found for Release")
+        if not committers:
+            raise NotFound(detail="No committers found")
 
         data = {
             "committers": committers,

--- a/src/sentry/integrations/utils/commit_context.py
+++ b/src/sentry/integrations/utils/commit_context.py
@@ -122,7 +122,7 @@ def find_commit_context_for_event_all_frames(
         has_too_recent_blames=has_too_recent_blames,
     )
 
-    return (selected_blame, selected_install)
+    return selected_blame, selected_install
 
 
 def get_or_create_commit_from_blame(

--- a/src/sentry/utils/committers.py
+++ b/src/sentry/utils/committers.py
@@ -367,7 +367,6 @@ def get_serialized_committers(project: Project, group_id: int) -> Sequence[Autho
 def get_serialized_event_file_committers(
     project: Project,
     event: Event | GroupEvent,
-    frame_limit: int = 25,
 ) -> Sequence[AuthorCommitsSerialized]:
     if event.group_id is None:
         return []

--- a/src/sentry/utils/committers.py
+++ b/src/sentry/utils/committers.py
@@ -16,14 +16,13 @@ from sentry.api.serializers.models.release import Author, NonMappableUser
 from sentry.models.commit import Commit
 from sentry.models.commitfilechange import CommitFileChange
 from sentry.models.group import Group
-from sentry.models.groupowner import GroupOwner, GroupOwnerType
+from sentry.models.groupowner import GroupOwner, GroupOwnerType, SuspectCommitStrategy
 from sentry.models.project import Project
 from sentry.models.release import Release
 from sentry.models.releasecommit import ReleaseCommit
 from sentry.services.eventstore.models import Event, GroupEvent
 from sentry.users.services.user.service import user_service
-from sentry.utils import metrics
-from sentry.utils.event_frames import find_stack_frames, get_sdk_name, munged_filename_and_frames
+from sentry.utils.event_frames import find_stack_frames, munged_filename_and_frames
 from sentry.utils.hashlib import hash_values
 
 PATH_SEPARATORS = frozenset(["/", "\\"])
@@ -188,6 +187,14 @@ def _get_serialized_committers_from_group_owners(
         if serialized_owners:
             author = serialized_owners[0]
 
+    # Map the suspect commit strategy to the appropriate type
+    strategy = owner.context.get("suspectCommitStrategy")
+    if strategy == SuspectCommitStrategy.RELEASE_BASED:
+        suspect_commit_type = SuspectCommitType.RELEASE_COMMIT.value
+    else:
+        # Default to SCM integration for SCM_BASED or any other/unknown strategy
+        suspect_commit_type = SuspectCommitType.INTEGRATION_COMMIT.value
+
     return [
         {
             "author": author,
@@ -196,7 +203,7 @@ def _get_serialized_committers_from_group_owners(
                     commit,
                     serializer=CommitSerializer(
                         exclude=["author"],
-                        type=SuspectCommitType.INTEGRATION_COMMIT.value,
+                        type=suspect_commit_type,
                     ),
                 )
             ],
@@ -367,52 +374,8 @@ def get_serialized_event_file_committers(
     result = _get_serialized_committers_from_group_owners(project, event.group_id)
     if result is not None:
         return result
-
-    # TODO(nisanthan): We create GroupOwner records for
-    # legacy Suspect Commits in process_suspect_commits task.
-    # We should refactor to query GroupOwner rather than recalculate.
-    # But we need to store the commitId and a way to differentiate
-    # if the Suspect Commit came from ReleaseCommits or CommitContext.
     else:
-        event_frames = get_frame_paths(event)
-        sdk_name = get_sdk_name(event.data)
-        committers = get_event_file_committers(
-            project,
-            event.group_id,
-            event_frames,
-            event.platform,
-            frame_limit=frame_limit,
-            sdk_name=sdk_name,
-        )
-        commits = [commit for committer in committers for commit in committer["commits"]]
-        serialized_commits: Sequence[MutableMapping[str, Any]] = serialize(
-            [c for (c, score) in commits],
-            serializer=CommitSerializer(
-                exclude=["author"],
-                type=SuspectCommitType.RELEASE_COMMIT.value,
-            ),
-        )
-
-        serialized_commits_by_id = {}
-
-        for (commit, score), serialized_commit in zip(commits, serialized_commits):
-            serialized_commit["score"] = score
-            serialized_commits_by_id[commit.id] = serialized_commit
-
-        serialized_committers: list[AuthorCommitsSerialized] = []
-        for committer in committers:
-            commit_ids = [commit.id for (commit, _) in committer["commits"]]
-            commits_result = [serialized_commits_by_id[commit_id] for commit_id in commit_ids]
-            serialized_committers.append(
-                {"author": committer["author"], "commits": dedupe_commits(commits_result)}
-            )
-
-        metrics.incr(
-            "feature.owners.has-committers",
-            instance="hit" if committers else "miss",
-            skip_internal=False,
-        )
-        return serialized_committers
+        return []
 
 
 def dedupe_commits(

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -23,7 +23,9 @@ from sentry.issues.ownership import grammar
 from sentry.issues.ownership.grammar import Matcher, Owner, dump_schema
 from sentry.mail import build_subject_prefix, mail_adapter
 from sentry.models.activity import Activity
-from sentry.models.grouprelease import GroupRelease
+from sentry.models.commit import Commit
+from sentry.models.commitauthor import CommitAuthor
+from sentry.models.groupowner import GroupOwner, GroupOwnerType, SuspectCommitStrategy
 from sentry.models.options.project_option import ProjectOption
 from sentry.models.organization import Organization
 from sentry.models.organizationmember import OrganizationMember
@@ -804,52 +806,39 @@ class MailAdapterNotifyTest(BaseMailAdapterTest):
             organization_id=self.organization.id, name=self.organization.id
         )
         ProjectOwnership.objects.create(project_id=self.project.id, fallthrough=True)
-        release = self.create_release(project=self.project, version="v12")
-        release.set_commits(
-            [
-                {
-                    "id": "a" * 40,
-                    "repository": repo.name,
-                    "author_email": "bob@example.com",
-                    "author_name": "Bob",
-                    "message": "i fixed a bug",
-                    "patch_set": [{"path": "src/sentry/models/release.py", "type": "M"}],
-                }
-            ]
-        )
 
         event = self.store_event(
             data={
                 "message": "Kaboom!",
                 "platform": "python",
                 "timestamp": before_now(seconds=1).isoformat(),
-                "stacktrace": {
-                    "frames": [
-                        {
-                            "function": "handle_set_commits",
-                            "abs_path": "/usr/src/sentry/src/sentry/tasks.py",
-                            "module": "sentry.tasks",
-                            "in_app": True,
-                            "lineno": 30,
-                            "filename": "sentry/tasks.py",
-                        },
-                        {
-                            "function": "set_commits",
-                            "abs_path": "/usr/src/sentry/src/sentry/models/release.py",
-                            "module": "sentry.models.release",
-                            "in_app": True,
-                            "lineno": 39,
-                            "filename": "sentry/models/release.py",
-                        },
-                    ]
-                },
-                "tags": {"sentry:release": release.version},
             },
             project_id=self.project.id,
         )
+
+        commit = Commit.objects.create(
+            organization_id=self.organization.id,
+            repository_id=repo.id,
+            key=uuid.uuid4().hex,
+            author=CommitAuthor.objects.create(
+                organization_id=self.organization.id,
+                name=self.user.name,
+                email=self.user.email,
+            ),
+        )
+
+        # create the suspect commit record
         assert event.group is not None
-        GroupRelease.objects.create(
-            group_id=event.group.id, project_id=self.project.id, release_id=self.release.id
+        GroupOwner.objects.create(
+            group_id=event.group.id,
+            project=self.project,
+            organization_id=self.organization.id,
+            type=GroupOwnerType.SUSPECT_COMMIT.value,
+            user_id=self.user.id,
+            context={
+                "commitId": commit.id,
+                "suspectCommitStrategy": SuspectCommitStrategy.SCM_BASED,
+            },
         )
 
         with self.tasks():
@@ -866,6 +855,8 @@ class MailAdapterNotifyTest(BaseMailAdapterTest):
         msg = mail.outbox[-1]
 
         assert "Suspect Commits" in msg.body
+        assert self.user.email in msg.body
+        assert commit.key[-7] in msg.body
 
     def test_notify_with_replay_id(self) -> None:
         project = self.project

--- a/tests/sentry/tasks/test_groupowner.py
+++ b/tests/sentry/tasks/test_groupowner.py
@@ -14,7 +14,7 @@ from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
-from sentry.utils.committers import get_frame_paths, get_serialized_event_file_committers
+from sentry.utils.committers import get_frame_paths
 
 pytestmark = [requires_snuba]
 
@@ -128,26 +128,6 @@ class TestGroupOwners(TestCase):
             schedule_hybrid_cloud_foreign_key_jobs()
 
         assert GroupOwner.objects.count() == 1
-
-    def test_no_matching_user(self) -> None:
-        self.set_release_commits("not@real.user")
-
-        result = get_serialized_event_file_committers(self.project, self.event)
-
-        assert len(result) == 1
-        assert "commits" in result[0]
-        assert len(result[0]["commits"]) == 1
-        assert result[0]["commits"][0]["id"] == "a" * 40
-        assert not GroupOwner.objects.filter(group=self.event.group).exists()
-        event_frames = get_frame_paths(self.event)
-        process_suspect_commits(
-            event_id=self.event.event_id,
-            event_platform=self.event.platform,
-            event_frames=event_frames,
-            group_id=self.event.group_id,
-            project_id=self.event.project_id,
-        )
-        assert not GroupOwner.objects.filter(group=self.event.group).exists()
 
     def test_delete_old_entries(self) -> None:
         # As new events come in associated with new owners, we should delete old ones.
@@ -492,3 +472,40 @@ class TestGroupOwners(TestCase):
         )
 
         assert owners.count() == 1
+
+    def test_external_author_no_user(self) -> None:
+        """
+        Test _process_suspect_commits with external commit author (no Sentry user).
+        TODO(nora): This test should FAIL until I update the code to handle external authors.
+        """
+        # Set up a commit with external author email (not a Sentry user)
+        external_email = "external@company.com"
+        self.set_release_commits(external_email)
+
+        assert not GroupOwner.objects.filter(group=self.event.group).exists()
+        event_frames = get_frame_paths(self.event)
+
+        # Test: process_suspect_commits should handle external authors.
+        # Currently this will NOT create a GroupOwner because the code
+        # only processes authors that have existing Sentry user accounts.
+        process_suspect_commits(
+            event_id=self.event.event_id,
+            event_platform=self.event.platform,
+            event_frames=event_frames,
+            group_id=self.event.group_id,
+            project_id=self.event.project_id,
+        )
+
+        # Once the code is updated, this should pass:
+        # group_owners = GroupOwner.objects.filter(
+        #     group=self.event.group,
+        #     project=self.event.project,
+        #     organization=self.event.project.organization,
+        #     type=GroupOwnerType.SUSPECT_COMMIT.value,
+        # )
+        # assert group_owners.count() == 1
+        # group_owner = group_owners[0]
+        # assert group_owner.user_id is None  # No Sentry user mapping
+        # assert (
+        #     group_owner.context.get("suspectCommitStrategy") == SuspectCommitStrategy.RELEASE_BASED
+        # )

--- a/tests/sentry/utils/test_committers.py
+++ b/tests/sentry/utils/test_committers.py
@@ -1,25 +1,17 @@
 import unittest
 from datetime import timedelta
-from typing import Any
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import Mock
 from uuid import uuid4
 
-import pytest
 from django.utils import timezone
 
-from sentry.integrations.github.integration import GitHubIntegration
-from sentry.integrations.models.integration import Integration
 from sentry.models.commit import Commit
+from sentry.models.commitauthor import CommitAuthor
 from sentry.models.commitfilechange import CommitFileChange
-from sentry.models.groupowner import GroupOwner, GroupOwnerType
-from sentry.models.grouprelease import GroupRelease
+from sentry.models.groupowner import GroupOwner, GroupOwnerType, SuspectCommitStrategy
 from sentry.models.release import Release
-from sentry.models.releasecommit import ReleaseCommit
 from sentry.models.repository import Repository
-from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers.datetime import before_now
-from sentry.testutils.silo import assume_test_silo_mode
 from sentry.utils.committers import (
     _get_commit_file_changes,
     _match_commits_path,
@@ -31,13 +23,18 @@ from sentry.utils.committers import (
     tokenize_path,
 )
 
-# TODO(lb): Tests are still needed for _get_committers and _get_event_file_commiters
-
 
 class CommitTestCase(TestCase):
     def setUp(self) -> None:
         self.repo = Repository.objects.create(
             organization_id=self.organization.id, name=self.organization.id
+        )
+
+    def create_commit_author(self, name=None, email=None):
+        return CommitAuthor.objects.create(
+            organization_id=self.organization.id,
+            name=name or f"Test Author {uuid4().hex[:8]}",
+            email=email or f"test{uuid4().hex[:8]}@example.com",
         )
 
     def create_commit(self, author=None):
@@ -234,794 +231,208 @@ class GetPreviousReleasesTestCase(TestCase):
         assert releases[1] == release1
 
 
-class GetEventFileCommitters(CommitTestCase):
+class GetSerializedEventFileCommitters(CommitTestCase):
+    """Tests for the GroupOwner-based committers functionality."""
+
     def setUp(self) -> None:
         super().setUp()
-        self.release = self.create_release(project=self.project, version="v12")
-        self.group = self.create_group(
-            project=self.project, message="Kaboom!", first_release=self.release
-        )
+        self.group = self.create_group(project=self.project, message="Kaboom!")
 
-    def test_java_sdk_path_mangling(self) -> None:
+    def test_with_scm_based_groupowner(self) -> None:
+        """Test that SCM-based GroupOwner returns expected commit data."""
         event = self.store_event(
-            data={
-                "message": "Kaboom!",
-                "platform": "java",
-                "stacktrace": {
-                    "frames": [
-                        {
-                            "function": "invoke0",
-                            "abs_path": "NativeMethodAccessorImpl.java",
-                            "in_app": False,
-                            "module": "jdk.internal.reflect.NativeMethodAccessorImpl",
-                            "filename": "NativeMethodAccessorImpl.java",
-                        },
-                        {
-                            "function": "home",
-                            "abs_path": "Application.java",
-                            "module": "io.sentry.example.Application",
-                            "in_app": True,
-                            "lineno": 30,
-                            "filename": "Application.java",
-                        },
-                        {
-                            "function": "handledError",
-                            "abs_path": "Application.java",
-                            "module": "io.sentry.example.Application",
-                            "in_app": True,
-                            "lineno": 39,
-                            "filename": "Application.java",
-                        },
-                    ]
-                },
-                "tags": {"sentry:release": self.release.version},
-            },
-            project_id=self.project.id,
-        )
-        self.release.set_commits(
-            [
-                {
-                    "id": "a" * 40,
-                    "repository": self.repo.name,
-                    "author_email": "bob@example.com",
-                    "author_name": "Bob",
-                    "message": "i fixed a bug",
-                    "patch_set": [
-                        {"path": "src/main/java/io/sentry/example/Application.java", "type": "M"}
-                    ],
-                }
-            ]
+            data={"message": "Kaboom!", "platform": "python"}, project_id=self.project.id
         )
         assert event.group is not None
-        GroupRelease.objects.create(
-            group_id=event.group.id, project_id=self.project.id, release_id=self.release.id
-        )
 
-        result = get_serialized_event_file_committers(self.project, event)
-        assert len(result) == 1
-        assert "commits" in result[0]
-        assert len(result[0]["commits"]) == 1
-        assert result[0]["commits"][0]["id"] == "a" * 40
-        assert result[0]["commits"][0]["suspectCommitType"] == "via commit in release"
-
-    def test_kotlin_java_sdk_path_mangling(self) -> None:
-        event = self.store_event(
-            data={
-                "message": "Kaboom!",
-                "platform": "java",
-                "exception": {
-                    "values": [
-                        {
-                            "type": "RuntimeException",
-                            "value": "button clicked",
-                            "module": "java.lang",
-                            "stacktrace": {
-                                "frames": [
-                                    {
-                                        "function": "main",
-                                        "module": "com.android.internal.os.ZygoteInit",
-                                        "filename": "ZygoteInit.java",
-                                        "abs_path": "ZygoteInit.java",
-                                        "lineno": 1003,
-                                        "in_app": False,
-                                    },
-                                    {
-                                        "function": "run",
-                                        "module": "com.android.internal.os.RuntimeInit$MethodAndArgsCaller",
-                                        "filename": "RuntimeInit.java",
-                                        "abs_path": "RuntimeInit.java",
-                                        "lineno": 548,
-                                        "in_app": False,
-                                    },
-                                    {
-                                        "function": "invoke",
-                                        "module": "java.lang.reflect.Method",
-                                        "filename": "Method.java",
-                                        "abs_path": "Method.java",
-                                        "in_app": False,
-                                    },
-                                    {
-                                        "function": "main",
-                                        "module": "android.app.ActivityThread",
-                                        "filename": "ActivityThread.java",
-                                        "abs_path": "ActivityThread.java",
-                                        "lineno": 7842,
-                                        "in_app": False,
-                                    },
-                                    {
-                                        "function": "loop",
-                                        "module": "android.os.Looper",
-                                        "filename": "Looper.java",
-                                        "abs_path": "Looper.java",
-                                        "lineno": 288,
-                                        "in_app": False,
-                                    },
-                                    {
-                                        "function": "loopOnce",
-                                        "module": "android.os.Looper",
-                                        "filename": "Looper.java",
-                                        "abs_path": "Looper.java",
-                                        "lineno": 201,
-                                        "in_app": False,
-                                    },
-                                    {
-                                        "function": "dispatchMessage",
-                                        "module": "android.os.Handler",
-                                        "filename": "Handler.java",
-                                        "abs_path": "Handler.java",
-                                        "lineno": 99,
-                                        "in_app": False,
-                                    },
-                                    {
-                                        "function": "handleCallback",
-                                        "module": "android.os.Handler",
-                                        "filename": "Handler.java",
-                                        "abs_path": "Handler.java",
-                                        "lineno": 938,
-                                        "in_app": False,
-                                    },
-                                    {
-                                        "function": "run",
-                                        "module": "android.view.View$PerformClick",
-                                        "filename": "View.java",
-                                        "abs_path": "View.java",
-                                        "lineno": 28810,
-                                        "in_app": False,
-                                    },
-                                    {
-                                        "function": "access$3700",
-                                        "module": "android.view.View",
-                                        "filename": "View.java",
-                                        "abs_path": "View.java",
-                                        "lineno": 835,
-                                        "in_app": False,
-                                    },
-                                    {
-                                        "function": "performClickInternal",
-                                        "module": "android.view.View",
-                                        "filename": "View.java",
-                                        "abs_path": "View.java",
-                                        "lineno": 7432,
-                                        "in_app": False,
-                                    },
-                                    {
-                                        "function": "performClick",
-                                        "module": "com.google.android.material.button.MaterialButton",
-                                        "filename": "MaterialButton.java",
-                                        "abs_path": "MaterialButton.java",
-                                        "lineno": 1119,
-                                        "in_app": False,
-                                    },
-                                    {
-                                        "function": "performClick",
-                                        "module": "android.view.View",
-                                        "filename": "View.java",
-                                        "abs_path": "View.java",
-                                        "lineno": 7455,
-                                        "in_app": False,
-                                    },
-                                    {
-                                        "function": "onClick",
-                                        "module": "com.jetbrains.kmm.androidApp.MainActivity$$ExternalSyntheticLambda0",
-                                        "lineno": 2,
-                                        "in_app": True,
-                                    },
-                                    {
-                                        "function": "$r8$lambda$hGNRcN3pFcj8CSoYZBi9fT_AXd0",
-                                        "module": "com.jetbrains.kmm.androidApp.MainActivity",
-                                        "lineno": 0,
-                                        "in_app": True,
-                                    },
-                                    {
-                                        "function": "onCreate$lambda-1",
-                                        "module": "com.jetbrains.kmm.androidApp.MainActivity",
-                                        "filename": "MainActivity.kt",
-                                        "abs_path": "MainActivity.kt",
-                                        "lineno": 55,
-                                        "in_app": True,
-                                    },
-                                ]
-                            },
-                            "thread_id": 2,
-                            "mechanism": {"type": "UncaughtExceptionHandler", "handled": False},
-                        }
-                    ]
-                },
-                "tags": {"sentry:release": self.release.version},
-            },
-            project_id=self.project.id,
-        )
-        self.release.set_commits(
-            [
-                {
-                    "id": "a" * 40,
-                    "repository": self.repo.name,
-                    "author_email": "bob@example.com",
-                    "author_name": "Bob",
-                    "message": "i fixed a bug",
-                    "patch_set": [
-                        {
-                            "path": "App/src/main/com/jetbrains/kmm/androidApp/MainActivity.kt",
-                            "type": "M",
-                        }
-                    ],
-                }
-            ]
-        )
-        assert event.group is not None
-        GroupRelease.objects.create(
-            group_id=event.group.id, project_id=self.project.id, release_id=self.release.id
-        )
-
-        result = get_serialized_event_file_committers(self.project, event)
-        assert len(result) == 1
-        assert "commits" in result[0]
-        assert len(result[0]["commits"]) == 1
-        assert result[0]["commits"][0]["id"] == "a" * 40
-        assert result[0]["commits"][0]["score"] > 1
-        assert result[0]["commits"][0]["suspectCommitType"] == "via commit in release"
-
-    def test_cocoa_swift_repo_relative_path(self) -> None:
-        event = self.store_event(
-            data={
-                "message": "Kaboom!",
-                "platform": "cocoa",
-                "exception": {
-                    "values": [
-                        {
-                            "type": "RuntimeException",
-                            "value": "button clicked",
-                            "module": "java.lang",
-                            "thread_id": 2,
-                            "mechanism": {"type": "UncaughtExceptionHandler", "handled": False},
-                            "stacktrace": {
-                                "frames": [
-                                    {
-                                        "in_app": False,
-                                        "image_addr": "0x0",
-                                        "instruction_addr": "0x1028d5aa4",
-                                        "symbol_addr": "0x0",
-                                    },
-                                    {
-                                        "package": "Runner",
-                                        "filename": "AppDelegate.swift",
-                                        "abs_path": "/Users/denis/Repos/sentry/sentry-mobile/ios/Runner/AppDelegate.swift",
-                                        "lineno": 5,
-                                        "in_app": True,
-                                    },
-                                ]
-                            },
-                        }
-                    ]
-                },
-                "tags": {"sentry:release": self.release.version},
-            },
-            project_id=self.project.id,
-        )
-        self.release.set_commits(
-            [
-                {
-                    "id": "a" * 40,
-                    "repository": self.repo.name,
-                    "author_email": "bob@example.com",
-                    "author_name": "Bob",
-                    "message": "i fixed a bug",
-                    "patch_set": [{"path": "Runner/AppDelegate.swift", "type": "M"}],
-                }
-            ]
-        )
-        assert event.group is not None
-        GroupRelease.objects.create(
-            group_id=event.group.id, project_id=self.project.id, release_id=self.release.id
-        )
-
-        result = get_serialized_event_file_committers(self.project, event)
-        assert len(result) == 1
-        assert "commits" in result[0]
-        assert len(result[0]["commits"]) == 1
-        assert result[0]["commits"][0]["id"] == "a" * 40
-        assert result[0]["commits"][0]["score"] > 1
-        assert result[0]["commits"][0]["suspectCommitType"] == "via commit in release"
-
-    def test_react_native_unchanged_frames(self) -> None:
-        event = self.store_event(
-            data={
-                "message": "Kaboom!",
-                "platform": "javascript",
-                "exception": {
-                    "values": [
-                        {
-                            "type": "unknown",
-                            "stacktrace": {
-                                "frames": [
-                                    {
-                                        "function": "callFunctionReturnFlushedQueue",
-                                        "module": "react-native/Libraries/BatchedBridge/MessageQueue",
-                                        "filename": "node_modules/react-native/Libraries/BatchedBridge/MessageQueue.js",
-                                        "abs_path": "app:///node_modules/react-native/Libraries/BatchedBridge/MessageQueue.js",
-                                        "lineno": 115,
-                                        "colno": 5,
-                                        "in_app": False,
-                                        "data": {"sourcemap": "app:///main.jsbundle.map"},
-                                    },
-                                    {
-                                        "function": "apply",
-                                        "filename": "native",
-                                        "abs_path": "native",
-                                        "in_app": True,
-                                    },
-                                    {
-                                        "function": "onPress",
-                                        "module": "src/screens/EndToEndTestsScreen",
-                                        "filename": "src/screens/EndToEndTestsScreen.tsx",
-                                        "abs_path": "app:///src/screens/EndToEndTestsScreen.tsx",
-                                        "lineno": 57,
-                                        "colno": 11,
-                                        "in_app": True,
-                                        "data": {"sourcemap": "app:///main.jsbundle.map"},
-                                    },
-                                ]
-                            },
-                        }
-                    ]
-                },
-                "tags": {"sentry:release": self.release.version},
-            },
-            project_id=self.project.id,
-        )
-        self.release.set_commits(
-            [
-                {
-                    "id": "a" * 40,
-                    "repository": self.repo.name,
-                    "author_email": "bob@example.com",
-                    "author_name": "Bob",
-                    "message": "i fixed a bug",
-                    "patch_set": [{"path": "src/screens/EndToEndTestsScreen.tsx", "type": "M"}],
-                }
-            ]
-        )
-        assert event.group is not None
-        GroupRelease.objects.create(
-            group_id=event.group.id, project_id=self.project.id, release_id=self.release.id
-        )
-
-        result = get_serialized_event_file_committers(self.project, event)
-        assert len(result) == 1
-        assert "commits" in result[0]
-        assert len(result[0]["commits"]) == 1
-        assert result[0]["commits"][0]["id"] == "a" * 40
-        assert result[0]["commits"][0]["score"] == 3
-        assert result[0]["commits"][0]["suspectCommitType"] == "via commit in release"
-
-    def test_flutter_munged_frames(self) -> None:
-        event = self.store_event(
-            data={
-                "platform": "other",
-                "sdk": {"name": "sentry.dart.flutter", "version": "1"},
-                "exception": {
-                    "values": [
-                        {
-                            "type": "StateError",
-                            "value": "Bad state: try catch",
-                            "stacktrace": {
-                                "frames": [
-                                    {
-                                        "function": "tryCatchModule",
-                                        "package": "sentry_flutter_example",
-                                        "filename": "test.dart",
-                                        "abs_path": "package:sentry_flutter_example/a/b/test.dart",
-                                        "lineno": 8,
-                                        "colno": 5,
-                                        "in_app": True,
-                                    },
-                                ]
-                            },
-                        }
-                    ]
-                },
-                "tags": {"sentry:release": self.release.version},
-            },
-            project_id=self.project.id,
-        )
-        self.release.set_commits(
-            [
-                {
-                    "id": "a" * 40,
-                    "repository": self.repo.name,
-                    "author_email": "bob@example.com",
-                    "author_name": "Bob",
-                    "message": "i fixed a bug",
-                    "patch_set": [{"path": "a/b/test.dart", "type": "M"}],
-                }
-            ]
-        )
-        assert event.group is not None
-        GroupRelease.objects.create(
-            group_id=event.group.id, project_id=self.project.id, release_id=self.release.id
-        )
-
-        result = get_serialized_event_file_committers(self.project, event)
-        assert len(result) == 1
-        assert "commits" in result[0]
-        assert len(result[0]["commits"]) == 1
-        assert result[0]["commits"][0]["id"] == "a" * 40
-        assert result[0]["commits"][0]["score"] == 3
-        assert result[0]["commits"][0]["suspectCommitType"] == "via commit in release"
-
-    def test_matching(self) -> None:
-        event = self.store_event(
-            data={
-                "message": "Kaboom!",
-                "platform": "python",
-                "timestamp": before_now(seconds=1).isoformat(),
-                "stacktrace": {
-                    "frames": [
-                        {
-                            "function": "handle_set_commits",
-                            "abs_path": "/usr/src/sentry/src/sentry/tasks.py",
-                            "module": "sentry.tasks",
-                            "in_app": True,
-                            "lineno": 30,
-                            "filename": "sentry/tasks.py",
-                        },
-                        {
-                            "function": "set_commits",
-                            "abs_path": "/usr/src/sentry/src/sentry/models/release.py",
-                            "module": "sentry.models.release",
-                            "in_app": True,
-                            "lineno": 39,
-                            "filename": "sentry/models/release.py",
-                        },
-                    ]
-                },
-                "tags": {"sentry:release": self.release.version},
-            },
-            project_id=self.project.id,
-        )
-        self.release.set_commits(
-            [
-                {
-                    "id": "a" * 40,
-                    "repository": self.repo.name,
-                    "author_email": "bob@example.com",
-                    "author_name": "Bob",
-                    "message": "i fixed a bug",
-                    "patch_set": [{"path": "src/sentry/models/release.py", "type": "M"}],
-                }
-            ]
-        )
-        assert event.group is not None
-        GroupRelease.objects.create(
-            group_id=event.group.id, project_id=self.project.id, release_id=self.release.id
-        )
-
-        result = get_serialized_event_file_committers(self.project, event)
-        assert len(result) == 1
-        assert "commits" in result[0]
-        assert len(result[0]["commits"]) == 1
-        assert result[0]["commits"][0]["id"] == "a" * 40
-        assert result[0]["commits"][0]["suspectCommitType"] == "via commit in release"
-
-    @patch("sentry.utils.committers.get_frame_paths")
-    def test_none_frame(self, mock_get_frame_paths: MagicMock) -> None:
-        """Test that if a frame is None, we skip over it"""
-        frames: list[Any] = [
-            {
-                "function": "handle_set_commits",
-                "abs_path": "/usr/src/sentry/src/sentry/tasks.py",
-                "module": "sentry.tasks",
-                "in_app": True,
-                "lineno": 30,
-                "filename": "sentry/tasks.py",
-            },
-            {
-                "function": "set_commits",
-                "abs_path": "/usr/src/sentry/src/sentry/models/release.py",
-                "module": "sentry.models.release",
-                "in_app": True,
-                "lineno": 39,
-                "filename": "sentry/models/release.py",
-            },
-        ]
-        event = self.store_event(
-            data={
-                "message": "Kaboom!",
-                "platform": "python",
-                "timestamp": before_now(seconds=1).isoformat(),
-                "stacktrace": {
-                    "frames": frames,
-                },
-                "tags": {"sentry:release": self.release.version},
-            },
-            project_id=self.project.id,
-        )
-        self.release.set_commits(
-            [
-                {
-                    "id": "a" * 40,
-                    "repository": self.repo.name,
-                    "author_email": "bob@example.com",
-                    "author_name": "Bob",
-                    "message": "i fixed a bug",
-                    "patch_set": [{"path": "src/sentry/models/release.py", "type": "M"}],
-                }
-            ]
-        )
-        assert event.group is not None
-        GroupRelease.objects.create(
-            group_id=event.group.id, project_id=self.project.id, release_id=self.release.id
-        )
-        frames.append(None)
-        mock_get_frame_paths.return_value = frames
-        result = get_serialized_event_file_committers(self.project, event)
-        assert len(result) == 1
-        assert "commits" in result[0]
-        assert len(result[0]["commits"]) == 1
-        assert result[0]["commits"][0]["id"] == "a" * 40
-        assert result[0]["commits"][0]["suspectCommitType"] == "via commit in release"
-
-    def test_no_author(self) -> None:
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            model = self.create_provider_integration(
-                provider="github", external_id="github_external_id", name="getsentry"
-            )
-            model.add_organization(self.organization, self.user)
-        GitHubIntegration(model, self.organization.id)
-        event = self.store_event(
-            data={
-                "message": "Kaboom!",
-                "platform": "python",
-                "timestamp": before_now(seconds=1).isoformat(),
-                "stacktrace": {
-                    "frames": [
-                        {
-                            "function": "handle_set_commits",
-                            "abs_path": "/usr/src/sentry/src/sentry/tasks.py",
-                            "module": "sentry.tasks",
-                            "in_app": True,
-                            "lineno": 30,
-                            "filename": "sentry/tasks.py",
-                        },
-                        {
-                            "function": "set_commits",
-                            "abs_path": "/usr/src/sentry/src/sentry/models/release.py",
-                            "module": "sentry.models.release",
-                            "in_app": True,
-                            "lineno": 39,
-                            "filename": "sentry/models/release.py",
-                        },
-                    ]
-                },
-                "tags": {"sentry:release": self.release.version},
-            },
-            project_id=self.project.id,
-        )
-        commit = self.create_commit()
-        ReleaseCommit.objects.create(
-            organization_id=self.organization.id, release=self.release, commit=commit, order=1
-        )
-        assert event.group is not None
-        GroupRelease.objects.create(
-            group_id=event.group.id, project_id=self.project.id, release_id=self.release.id
-        )
+        # Create commit author and commit with SCM strategy
+        author = self.create_commit_author()
+        commit = self.create_commit(author=author)
         GroupOwner.objects.create(
             group_id=event.group.id,
             project=self.project,
             organization_id=self.organization.id,
             type=GroupOwnerType.SUSPECT_COMMIT.value,
+            user_id=self.user.id,
+            context={
+                "commitId": commit.id,
+                "suspectCommitStrategy": SuspectCommitStrategy.SCM_BASED,
+            },
+        )
+
+        result = get_serialized_event_file_committers(self.project, event)
+        assert len(result) == 1
+        assert "commits" in result[0]
+        assert len(result[0]["commits"]) == 1
+        assert result[0]["commits"][0]["id"] == commit.key
+        assert result[0]["commits"][0]["suspectCommitType"] == "via SCM integration"
+
+    def test_with_release_based_groupowner(self) -> None:
+        """Test that release-based GroupOwner returns expected commit data."""
+        event = self.store_event(
+            data={"message": "Kaboom!", "platform": "python"}, project_id=self.project.id
+        )
+        assert event.group is not None
+
+        # Create commit author and commit with release strategy
+        author = self.create_commit_author()
+        commit = self.create_commit(author=author)
+        GroupOwner.objects.create(
+            group_id=event.group.id,
+            project=self.project,
+            organization_id=self.organization.id,
+            type=GroupOwnerType.SUSPECT_COMMIT.value,
+            user_id=self.user.id,
+            context={
+                "commitId": commit.id,
+                "suspectCommitStrategy": SuspectCommitStrategy.RELEASE_BASED,
+            },
+        )
+
+        result = get_serialized_event_file_committers(self.project, event)
+        assert len(result) == 1
+        assert "commits" in result[0]
+        assert len(result[0]["commits"]) == 1
+        assert result[0]["commits"][0]["id"] == commit.key
+        assert result[0]["commits"][0]["suspectCommitType"] == "via commit in release"
+
+    def test_with_multiple_groupowners(self) -> None:
+        """Test that multiple GroupOwners return the most recent one only."""
+        event = self.store_event(
+            data={"message": "Kaboom!", "platform": "python"}, project_id=self.project.id
+        )
+        assert event.group is not None
+
+        # Create multiple commits with authors
+        author1 = self.create_commit_author()
+        author2 = self.create_commit_author()
+        commit1 = self.create_commit(author=author1)
+        commit2 = self.create_commit(author=author2)
+
+        # Create first GroupOwner (older)
+        GroupOwner.objects.create(
+            group_id=event.group.id,
+            project=self.project,
+            organization_id=self.organization.id,
+            type=GroupOwnerType.SUSPECT_COMMIT.value,
+            user_id=self.user.id,
+            context={"commitId": commit1.id},
+            date_added=timezone.now() - timedelta(hours=2),
+        )
+
+        # Create second GroupOwner (newer)
+        GroupOwner.objects.create(
+            group_id=event.group.id,
+            project=self.project,
+            organization_id=self.organization.id,
+            type=GroupOwnerType.SUSPECT_COMMIT.value,
+            user_id=self.user.id,
+            context={"commitId": commit2.id},
+            date_added=timezone.now() - timedelta(hours=1),
+        )
+
+        result = get_serialized_event_file_committers(self.project, event)
+        # Should return the most recent one only
+        assert len(result) == 1
+        assert result[0]["commits"][0]["id"] == commit2.key
+
+    def test_no_groupowners(self) -> None:
+        """Test that no GroupOwners returns empty list."""
+        event = self.store_event(
+            data={"message": "Kaboom!", "platform": "python"}, project_id=self.project.id
+        )
+
+        result = get_serialized_event_file_committers(self.project, event)
+        assert len(result) == 0
+
+    def test_groupowner_without_commit_id(self) -> None:
+        """Test that GroupOwner without commitId returns empty list."""
+        event = self.store_event(
+            data={"message": "Kaboom!", "platform": "python"}, project_id=self.project.id
+        )
+        assert event.group is not None
+
+        # Create GroupOwner without commitId in context
+        GroupOwner.objects.create(
+            group_id=event.group.id,
+            project=self.project,
+            organization_id=self.organization.id,
+            type=GroupOwnerType.SUSPECT_COMMIT.value,
+            user_id=self.user.id,
+            context={"someOtherData": "value"},
+        )
+
+        result = get_serialized_event_file_committers(self.project, event)
+        assert len(result) == 0
+
+    def test_groupowner_with_nonexistent_commit(self) -> None:
+        """Test that GroupOwner with non-existent commit returns empty list."""
+        event = self.store_event(
+            data={"message": "Kaboom!", "platform": "python"}, project_id=self.project.id
+        )
+        assert event.group is not None
+
+        # Create GroupOwner with non-existent commit ID
+        GroupOwner.objects.create(
+            group_id=event.group.id,
+            project=self.project,
+            organization_id=self.organization.id,
+            type=GroupOwnerType.SUSPECT_COMMIT.value,
+            user_id=self.user.id,
+            context={"commitId": 99999},  # Non-existent commit ID
+        )
+
+        result = get_serialized_event_file_committers(self.project, event)
+        assert len(result) == 0
+
+    def test_groupowner_with_commit_without_author(self) -> None:
+        """Test that GroupOwner with commit that has no author returns empty list."""
+        event = self.store_event(
+            data={"message": "Kaboom!", "platform": "python"}, project_id=self.project.id
+        )
+        assert event.group is not None
+
+        # Create commit without author
+        commit = self.create_commit(author=None)
+        GroupOwner.objects.create(
+            group_id=event.group.id,
+            project=self.project,
+            organization_id=self.organization.id,
+            type=GroupOwnerType.SUSPECT_COMMIT.value,
+            user_id=self.user.id,
             context={"commitId": commit.id},
         )
 
         result = get_serialized_event_file_committers(self.project, event)
         assert len(result) == 0
 
-    def test_matching_case_insensitive(self) -> None:
-        event = self.store_event(
-            data={
-                "message": "Kaboom!",
-                "platform": "csp",
-                "stacktrace": {
-                    "frames": [
-                        {
-                            "function": "roar",
-                            "abs_path": "/usr/src/app/TigerMachine.cpp",
-                            "module": "",
-                            "in_app": True,
-                            "lineno": 30,
-                            "filename": "app/TigerMachine.cpp",
-                        }
-                    ]
-                },
-                "tags": {"sentry:release": self.release.version},
-            },
-            project_id=self.project.id,
-        )
-        self.release.set_commits(
-            [
-                {
-                    "id": "a" * 40,
-                    "repository": self.repo.name,
-                    "author_email": "bob@example.com",
-                    "author_name": "Bob",
-                    "message": "i fixed a bug",
-                    "patch_set": [{"path": "app/tigermachine.cpp", "type": "M"}],
-                }
-            ]
-        )
-        assert event.group is not None
-        GroupRelease.objects.create(
-            group_id=event.group.id, project_id=self.project.id, release_id=self.release.id
-        )
-
-        result = get_serialized_event_file_committers(self.project, event)
-        assert len(result) == 1
-        assert "commits" in result[0]
-        assert len(result[0]["commits"]) == 1
-        assert result[0]["commits"][0]["id"] == "a" * 40
-        assert result[0]["commits"][0]["suspectCommitType"] == "via commit in release"
-
-    def test_not_matching(self) -> None:
-        event = self.store_event(
-            data={
-                "message": "Kaboom!",
-                "platform": "python",
-                "stacktrace": {
-                    "frames": [
-                        {
-                            "function": "handle_set_commits",
-                            "abs_path": "/usr/src/sentry/src/sentry/tasks.py",
-                            "module": "sentry.tasks",
-                            "in_app": True,
-                            "lineno": 30,
-                            "filename": "sentry/tasks.py",
-                        },
-                        {
-                            "function": "set_commits",
-                            "abs_path": "/usr/src/sentry/src/sentry/models/release.py",
-                            "module": "sentry.models.release",
-                            "in_app": True,
-                            "lineno": 39,
-                            "filename": "sentry/models/release.py",
-                        },
-                    ]
-                },
-                "tags": {"sentry:release": self.release.version},
-            },
-            project_id=self.project.id,
-        )
-        self.release.set_commits(
-            [
-                {
-                    "id": "a" * 40,
-                    "repository": self.repo.name,
-                    "author_email": "bob@example.com",
-                    "author_name": "Bob",
-                    "message": "i fixed a bug",
-                    "patch_set": [{"path": "some/other/path.py", "type": "M"}],
-                }
-            ]
-        )
-        assert event.group is not None
-        GroupRelease.objects.create(
-            group_id=event.group.id, project_id=self.project.id, release_id=self.release.id
-        )
+    def test_event_without_group_id(self) -> None:
+        """Test that event without group_id returns empty list."""
+        event = Mock()
+        event.group_id = None
 
         result = get_serialized_event_file_committers(self.project, event)
         assert len(result) == 0
 
-    def test_no_commits(self) -> None:
+    def test_non_suspect_commit_groupowners_ignored(self) -> None:
+        """Test that non-suspect-commit GroupOwners are ignored."""
         event = self.store_event(
-            data={
-                "timestamp": before_now(seconds=1).isoformat(),
-                "message": "Kaboom!",
-                "stacktrace": {
-                    "frames": [
-                        {
-                            "function": "handle_set_commits",
-                            "abs_path": "/usr/src/sentry/src/sentry/tasks.py",
-                            "module": "sentry.tasks",
-                            "in_app": True,
-                            "lineno": 30,
-                            "filename": "sentry/tasks.py",
-                        },
-                        {
-                            "function": "set_commits",
-                            "abs_path": "/usr/src/sentry/src/sentry/models/release.py",
-                            "module": "sentry.models.release",
-                            "in_app": True,
-                            "lineno": 39,
-                            "filename": "sentry/models/release.py",
-                        },
-                    ]
-                },
-                "tags": {"sentry:release": self.release.version},
-            },
-            project_id=self.project.id,
+            data={"message": "Kaboom!", "platform": "python"}, project_id=self.project.id
         )
         assert event.group is not None
-        GroupRelease.objects.create(
-            group_id=event.group.id, project_id=self.project.id, release_id=self.release.id
-        )
 
-        with pytest.raises(Commit.DoesNotExist):
-            get_serialized_event_file_committers(self.project, event)
-
-    def test_commit_context_fallback(self) -> None:
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            Integration.objects.all().delete()
-        event = self.store_event(
-            data={
-                "message": "Kaboom!",
-                "platform": "python",
-                "timestamp": before_now(seconds=1).isoformat(),
-                "stacktrace": {
-                    "frames": [
-                        {
-                            "function": "handle_set_commits",
-                            "abs_path": "/usr/src/sentry/src/sentry/tasks.py",
-                            "module": "sentry.tasks",
-                            "in_app": True,
-                            "lineno": 30,
-                            "filename": "sentry/tasks.py",
-                        },
-                        {
-                            "function": "set_commits",
-                            "abs_path": "/usr/src/sentry/src/sentry/models/release.py",
-                            "module": "sentry.models.release",
-                            "in_app": True,
-                            "lineno": 39,
-                            "filename": "sentry/models/release.py",
-                        },
-                    ]
-                },
-                "tags": {"sentry:release": self.release.version},
-            },
-            project_id=self.project.id,
-        )
-        self.release.set_commits(
-            [
-                {
-                    "id": "a" * 40,
-                    "repository": self.repo.name,
-                    "author_email": "bob@example.com",
-                    "author_name": "Bob",
-                    "message": "i fixed a bug",
-                    "patch_set": [{"path": "src/sentry/models/release.py", "type": "M"}],
-                }
-            ]
-        )
-        assert event.group is not None
-        GroupRelease.objects.create(
-            group_id=event.group.id, project_id=self.project.id, release_id=self.release.id
+        # Create GroupOwner with different type (ownership rule)
+        GroupOwner.objects.create(
+            group_id=event.group.id,
+            project=self.project,
+            organization_id=self.organization.id,
+            type=GroupOwnerType.OWNERSHIP_RULE.value,
+            user_id=self.user.id,
+            context={"rule": "path:*.py"},
         )
 
         result = get_serialized_event_file_committers(self.project, event)
-        assert len(result) == 1
-        assert "commits" in result[0]
-        assert len(result[0]["commits"]) == 1
-        assert result[0]["commits"][0]["id"] == "a" * 40
-        assert result[0]["commits"][0]["suspectCommitType"] == "via commit in release"
+        assert len(result) == 0
 
 
 class DedupeCommits(CommitTestCase):


### PR DESCRIPTION
## Summary
Removes the legacy release-based fallback logic from the event file committers endpoint, simplifying it to use only GroupOwner-based suspect commit detection. 

Current behavior: If there are no suspect commits for the event, do a live analysis using the legacy strategy, do not save any of the commits it finds as suspect, return as many as it finds.

💡 : it was doing this because it was the only way to show a suspect commit if the Author was NOT a User of their org. The legacy strategy does not allow GroupOwner creation if there is not an associated User, it ignores those. This does not match the behavior of the non-legacy strategy, which allows GroupOwners with `user=None` and all serializers have fallback logic to display details from the `CommitAuthor` object if there is no `User`. The legacy method needs to be updated to allow GroupOwners with `user=None`.

Proposed changes: no live analysis - only GroupOwners created during original analysis will be retuned.

While my intention has been to create _fewer_ but _better_ suspect commits, with the logic in this flow meant I was actually displaying a lot more legacy strategy suspect commits, which is not what I want.

## Changes Made

### Core Logic Changes
- **Removed legacy fallback**: `get_serialized_event_file_committers` now only calls `_get_serialized_committers_from_group_owners`
- **Dynamic suspect commit type**: Uses `suspectCommitStrategy` from GroupOwner context instead of hardcoding `INTEGRATION_COMMIT`
  - `RELEASE_BASED` → `"via commit in release"`  
  - `SCM_BASED` → `"via SCM integration"`
- **Preserved API contract**: Still returns 404 when no committers found (not empty array)

## Behavior Changes

### Before
```python
# 1. Check GroupOwners first
# 2. If no GroupOwners, fall back to release-based analysis (legacy logic)
# 3. Analyze stacktrace frames against recent release commits  
# 4. Always returned "via SCM integration" regardless of actual strategy
# 5. Any number of suspect commits can be returned
```

### After  
```python
# 1. Check GroupOwners only - all suspect commit strategies create GroupOwners when the Issue is first processed
# 2. If no GroupOwners, return 404 "No committers found"
# 3. Use actual commit strategy from GroupOwner context
# 4. Only 1 suspect commit can be returned
```
