### PR TITLE
ref(metric-stats): Remove now unused metric stats option

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1347,9 +1347,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Controls the rollout rate in percent (`0.0` to `1.0`) for metric stats.
-register("relay.metric-stats.rollout-rate", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
-
 # Write new kafka headers in eventstream
 register("eventstream:kafka-headers", default=True, flags=FLAG_AUTOMATOR_MODIFIABLE)
 

--- a/src/sentry/relay/globalconfig.py
+++ b/src/sentry/relay/globalconfig.py
@@ -20,7 +20,6 @@ RELAY_OPTIONS: list[str] = [
     "relay.cardinality-limiter.error-sample-rate",
     "relay.metric-bucket-set-encodings",
     "relay.metric-bucket-distribution-encodings",
-    "relay.metric-stats.rollout-rate",
     "relay.ourlogs-ingestion.sample-rate",
     "relay.span-extraction.sample-rate",
     "relay.span-normalization.allowed_hosts",

--- a/tests/sentry/api/endpoints/test_relay_globalconfig_v3.py
+++ b/tests/sentry/api/endpoints/test_relay_globalconfig_v3.py
@@ -36,7 +36,6 @@ def call_endpoint(client, relay, private_key):
     {
         # Set options to Relay's non-default values to avoid Relay skipping deserialization
         "relay.cardinality-limiter.error-sample-rate": 1.0,
-        "relay.metric-stats.rollout-rate": 0.5,
         "profiling.profile_metrics.unsampled_profiles.enabled": True,
         "profiling.profile_metrics.unsampled_profiles.platforms": ["fake-platform"],
         "profiling.profile_metrics.unsampled_profiles.sample_rate": 1.0,


### PR DESCRIPTION
Relay PR: https://github.com/getsentry/relay/pull/5097