### PR TITLE
fix(setup-wizard): Org members without access should be able to create projects via experiment API

### DIFF
--- a/static/app/views/setupWizard/utils/useCreateProjectFromWizard.tsx
+++ b/static/app/views/setupWizard/utils/useCreateProjectFromWizard.tsx
@@ -1,3 +1,4 @@
+import ProjectsStore from 'sentry/stores/projectsStore';
 import type {Project} from 'sentry/types/project';
 import {useMutation} from 'sentry/utils/queryClient';
 import useApi from 'sentry/utils/useApi';
@@ -10,19 +11,26 @@ export function useCreateProjectFromWizard() {
       name: string;
       organization: OrganizationWithRegion;
       platform: string;
-      team: string;
+      team: string | null;
     }): Promise<Project> => {
-      const url = `/teams/${params.organization.slug}/${params.team}/projects/`;
-      return api.requestPromise(url, {
-        method: 'POST',
-        host: params.organization.region.url,
-        data: {
-          name: params.name,
-          platform: params.platform,
-          default_rules: true,
-          origin: 'wizard-ui',
-        },
-      });
+      return api.requestPromise(
+        params.team
+          ? `/teams/${params.organization.slug}/${params.team}/projects/`
+          : `/organizations/${params.organization.slug}/experimental/projects/`,
+        {
+          method: 'POST',
+          host: params.organization.region.url,
+          data: {
+            name: params.name,
+            platform: params.platform,
+            default_rules: true,
+            origin: 'wizard-ui',
+          },
+        }
+      );
+    },
+    onSuccess: (response, params) => {
+      ProjectsStore.onCreateSuccess(response, params.organization.slug);
     },
   });
 }

--- a/static/app/views/setupWizard/wizardProjectSelection.tsx
+++ b/static/app/views/setupWizard/wizardProjectSelection.tsx
@@ -265,6 +265,17 @@ export function WizardProjectSelection({
     emptyMessage = t('No projects matching search');
   }
 
+  const projectNameField = (
+    <FieldWrapper>
+      <label>{t('Project Name')}</label>
+      <Input
+        value={newProjectName}
+        onChange={event => setNewProjectName(event.target.value)}
+        placeholder={t('Enter a project name')}
+      />
+    </FieldWrapper>
+  );
+
   return (
     <StyledForm onSubmit={handleSubmit}>
       <Heading>{t('Select your Sentry project')}</Heading>
@@ -354,24 +365,10 @@ export function WizardProjectSelection({
       </FieldWrapper>
       {isCreateProjectSelected &&
         (isOrgMemberWithNoAccess ? (
-          <FieldWrapper>
-            <label>{t('Project Name')}</label>
-            <Input
-              value={newProjectName}
-              onChange={event => setNewProjectName(event.target.value)}
-              placeholder={t('Enter a project name')}
-            />
-          </FieldWrapper>
+          projectNameField
         ) : (
           <Columns>
-            <FieldWrapper>
-              <label>{t('Project Name')}</label>
-              <Input
-                value={newProjectName}
-                onChange={event => setNewProjectName(event.target.value)}
-                placeholder={t('Enter a project name')}
-              />
-            </FieldWrapper>
+            {projectNameField}
             <FieldWrapper>
               <label>{t('Team')}</label>
               <StyledCompactSelect

--- a/static/app/views/setupWizard/wizardProjectSelection.tsx
+++ b/static/app/views/setupWizard/wizardProjectSelection.tsx
@@ -114,10 +114,11 @@ export function WizardProjectSelection({
   const canUserCreateProject = orgDetailsRequest.data
     ? canCreateProject(orgDetailsRequest.data, selectableTeams)
     : false;
-
-  const isCreationEnabled = isOrgMemberWithNoAccess
-    ? canUserCreateProject && platformParam
-    : canUserCreateProject && platformParam && (selectableTeams ?? []).length > 0;
+  const hasSelectableTeams = (selectableTeams ?? []).length > 0;
+  const isCreationEnabled =
+    canUserCreateProject &&
+    platformParam &&
+    (isOrgMemberWithNoAccess || hasSelectableTeams);
 
   const updateWizardCacheMutation = useUpdateWizardCache(hash);
   const createProjectMutation = useCreateProjectFromWizard();

--- a/static/app/views/setupWizard/wizardProjectSelection.tsx
+++ b/static/app/views/setupWizard/wizardProjectSelection.tsx
@@ -94,9 +94,9 @@ export function WizardProjectSelection({
   const orgDetailsRequest = useOrganizationDetails({organization: selectedOrg});
   const teamsRequest = useOrganizationTeams({organization: selectedOrg});
 
-  const accessTeams = teamsRequest.data?.filter(team =>
-    team.access.includes('team:admin')
-  );
+  const accessTeams = useMemo(() => {
+    return teamsRequest.data?.filter(team => team.access.includes('team:admin'));
+  }, [teamsRequest.data]);
 
   const selectableTeams = useMemo(() => {
     if (orgDetailsRequest.data?.access.includes('org:admin')) {

--- a/static/app/views/setupWizard/wizardProjectSelection.tsx
+++ b/static/app/views/setupWizard/wizardProjectSelection.tsx
@@ -94,12 +94,16 @@ export function WizardProjectSelection({
   const orgDetailsRequest = useOrganizationDetails({organization: selectedOrg});
   const teamsRequest = useOrganizationTeams({organization: selectedOrg});
 
+  const accessTeams = teamsRequest.data?.filter(team =>
+    team.access.includes('team:admin')
+  );
+
   const selectableTeams = useMemo(() => {
     if (orgDetailsRequest.data?.access.includes('org:admin')) {
       return teamsRequest.data;
     }
-    return teamsRequest.data?.filter(team => team.teamRole === 'admin');
-  }, [orgDetailsRequest.data, teamsRequest.data]);
+    return accessTeams;
+  }, [orgDetailsRequest.data, teamsRequest.data, accessTeams]);
 
   const orgProjectsRequest = useOrganizationProjects({
     organization: selectedOrg,
@@ -107,9 +111,6 @@ export function WizardProjectSelection({
   });
 
   const canCreateTeam = orgDetailsRequest.data?.access.includes('project:admin') ?? false;
-  const accessTeams = teamsRequest.data?.filter(team =>
-    team.access.includes('team:admin')
-  );
   const isOrgMemberWithNoAccess = (accessTeams ?? []).length === 0 && !canCreateTeam;
   const canUserCreateProject = orgDetailsRequest.data
     ? canCreateProject(orgDetailsRequest.data, selectableTeams)


### PR DESCRIPTION
**Problem**
Right now, when creating a project in Sentry, even users without admin access or a team can still create a project. This happens because if no team is found (due to the team-admin check), the experiment API kicks in and creates a brand-new team for that user.

However, this flow doesn’t happen in the setup wizard.

**Solution**
Make the setup wizard behave the same way - i.e., mimic the existing project creation flow.

closes https://linear.app/getsentry/issue/TET-934/create-new-team-for-non-admin-users-in-setup-wizard-project-creation