### PR TITLE
Improve attachment cache typing

### DIFF
--- a/src/sentry/attachments/__init__.py
+++ b/src/sentry/attachments/__init__.py
@@ -4,6 +4,8 @@ from django.conf import settings
 
 from sentry.utils.imports import import_string
 
-from .base import CachedAttachment, MissingAttachmentChunks  # noqa
+from .base import BaseAttachmentCache, CachedAttachment, MissingAttachmentChunks
 
-attachment_cache = import_string(settings.SENTRY_ATTACHMENTS)(**settings.SENTRY_ATTACHMENTS_OPTIONS)
+attachment_cache: BaseAttachmentCache = import_string(settings.SENTRY_ATTACHMENTS)(
+    **settings.SENTRY_ATTACHMENTS_OPTIONS
+)

--- a/src/sentry/attachments/base.py
+++ b/src/sentry/attachments/base.py
@@ -1,4 +1,4 @@
-import zlib
+from collections.abc import Generator
 
 import sentry_sdk
 import zstandard
@@ -25,8 +25,8 @@ class CachedAttachment:
         name=None,
         content_type=None,
         type=None,
-        data=UNINITIALIZED_DATA,
         chunks=None,
+        data=UNINITIALIZED_DATA,
         cache=None,
         rate_limited=None,
         size=None,
@@ -48,8 +48,8 @@ class CachedAttachment:
         else:
             self.size = 0
 
-        self._data = data
         self.chunks = chunks
+        self._data = data
         self._cache = cache
         self._has_initial_data = data is not UNINITIALIZED_DATA
 
@@ -60,7 +60,7 @@ class CachedAttachment:
         )
 
     @property
-    def data(self):
+    def data(self) -> bytes:
         if self._data is UNINITIALIZED_DATA and self._cache is not None:
             self._data = self._cache.get_data(self)
 
@@ -72,7 +72,7 @@ class CachedAttachment:
             self._cache.inner.delete(key)
 
     @property
-    def chunk_keys(self):
+    def chunk_keys(self) -> Generator[str]:
         assert self.key is not None
         assert self.id is not None
 
@@ -88,16 +88,16 @@ class CachedAttachment:
                 key=self.key, id=self.id, chunk_index=chunk_index
             )
 
-    def meta(self):
+    def meta(self) -> dict:
         return prune_empty_keys(
             {
                 "id": self.id,
                 "name": self.name,
+                "rate_limited": self.rate_limited,
                 "content_type": self.content_type,
                 "type": self.type,
-                "chunks": self.chunks,
                 "size": self.size or None,  # None for backwards compatibility
-                "rate_limited": self.rate_limited,
+                "chunks": self.chunks,
             }
         )
 
@@ -106,15 +106,15 @@ class BaseAttachmentCache:
     def __init__(self, inner):
         self.inner = inner
 
-    def set(self, key, attachments, timeout=None):
+    def set(self, key: str, attachments: list[CachedAttachment], timeout=None):
         for id, attachment in enumerate(attachments):
             if attachment.chunks is not None:
                 continue
+
             # TODO(markus): We need to get away from sequential IDs, they
             # are risking collision when using Relay.
             if attachment.id is None:
                 attachment.id = id
-
             if attachment.key is None:
                 attachment.key = key
 
@@ -128,21 +128,20 @@ class BaseAttachmentCache:
             )
 
         meta = []
-
         for attachment in attachments:
             attachment._cache = self
             meta.append(attachment.meta())
 
         self.inner.set(ATTACHMENT_META_KEY.format(key=key), meta, timeout, raw=False)
 
-    def set_chunk(self, key, id, chunk_index, chunk_data, timeout=None):
+    def set_chunk(self, key: str, id: int, chunk_index: int, chunk_data: bytes, timeout=None):
         key = ATTACHMENT_DATA_CHUNK_KEY.format(key=key, id=id, chunk_index=chunk_index)
-        compressed = compress_chunk(chunk_data)
+        compressed = zstandard.compress(chunk_data)
         self.inner.set(key, compressed, timeout, raw=True)
 
-    def set_unchunked_data(self, key, id, data, timeout=None, metrics_tags=None):
+    def set_unchunked_data(self, key: str, id: int, data: bytes, timeout=None, metrics_tags=None):
         key = ATTACHMENT_UNCHUNKED_DATA_KEY.format(key=key, id=id)
-        compressed = compress_chunk(data)
+        compressed = zstandard.compress(data)
         metrics.distribution("attachments.blob-size.raw", len(data), tags=metrics_tags, unit="byte")
         metrics.distribution(
             "attachments.blob-size.compressed", len(compressed), tags=metrics_tags, unit="byte"
@@ -150,10 +149,10 @@ class BaseAttachmentCache:
         metrics.incr("attachments.received", tags=metrics_tags, skip_internal=False)
         self.inner.set(key, compressed, timeout, raw=True)
 
-    def get_from_chunks(self, key, **attachment):
+    def get_from_chunks(self, key: str, **attachment) -> CachedAttachment:
         return CachedAttachment(key=key, cache=self, **attachment)
 
-    def get(self, key):
+    def get(self, key: str) -> Generator[CachedAttachment]:
         result = self.inner.get(ATTACHMENT_META_KEY.format(key=key), raw=False)
 
         for id, attachment in enumerate(result or ()):
@@ -161,28 +160,21 @@ class BaseAttachmentCache:
             attachment.setdefault("key", key)
             yield CachedAttachment(cache=self, **attachment)
 
-    def get_data(self, attachment) -> bytes:
+    def get_data(self, attachment: CachedAttachment) -> bytes:
         data = bytearray()
 
         for key in attachment.chunk_keys:
             raw_data = self.inner.get(key, raw=True)
             if raw_data is None:
                 raise MissingAttachmentChunks()
-            if raw_data.startswith(b"\x28\xb5\x2f\xfd"):
-                decompressed = zstandard.decompress(raw_data)
-            else:
-                decompressed = zlib.decompress(raw_data)
+            decompressed = zstandard.decompress(raw_data)
             data.extend(decompressed)
 
         return bytes(data)
 
     @sentry_sdk.tracing.trace
-    def delete(self, key):
+    def delete(self, key: str):
         for attachment in self.get(key):
             attachment.delete()
 
         self.inner.delete(ATTACHMENT_META_KEY.format(key=key))
-
-
-def compress_chunk(chunk_data: bytes) -> bytes:
-    return zstandard.compress(chunk_data)

--- a/tests/sentry/attachments/test_redis.py
+++ b/tests/sentry/attachments/test_redis.py
@@ -1,7 +1,7 @@
-import zlib
 from unittest import mock
 
 import pytest
+import zstandard
 
 from sentry.attachments.redis import RedisClusterAttachmentCache
 from sentry.cache.redis import RedisClusterCache
@@ -42,7 +42,7 @@ def mocked_attachment_cache(request, mock_client):
 
 def test_process_pending_one_batch(mocked_attachment_cache, mock_client) -> None:
     mock_client.data[KEY_FMT % "foo:a"] = '[{"name":"foo.txt","content_type":"text/plain"}]'
-    mock_client.data[KEY_FMT % "foo:a:0"] = zlib.compress(b"Hello World!")
+    mock_client.data[KEY_FMT % "foo:a:0"] = zstandard.compress(b"Hello World!")
 
     (attachment,) = mocked_attachment_cache.get("foo")
     assert attachment.meta() == {
@@ -58,9 +58,9 @@ def test_chunked(mocked_attachment_cache, mock_client) -> None:
     mock_client.data[KEY_FMT % "foo:a"] = (
         '[{"name":"foo.txt","content_type":"text/plain","chunks":3}]'
     )
-    mock_client.data[KEY_FMT % "foo:a:0:0"] = zlib.compress(b"Hello World!")
-    mock_client.data[KEY_FMT % "foo:a:0:1"] = zlib.compress(b" This attachment is ")
-    mock_client.data[KEY_FMT % "foo:a:0:2"] = zlib.compress(b"chunked up.")
+    mock_client.data[KEY_FMT % "foo:a:0:0"] = zstandard.compress(b"Hello World!")
+    mock_client.data[KEY_FMT % "foo:a:0:1"] = zstandard.compress(b" This attachment is ")
+    mock_client.data[KEY_FMT % "foo:a:0:2"] = zstandard.compress(b"chunked up.")
 
     (attachment,) = mocked_attachment_cache.get("foo")
     assert attachment.meta() == {


### PR DESCRIPTION
This adds a bunch of type annotations to the attachment cache code, as well as actually exposing that type on the global `attachment_cache` singleton.

As a drive-by change, this also removes the backwards compatibility code supporting `zlib`-compressed attachment cache chunks, as we have been unconditionally using `zstd` compression for years already.