### PR TITLE
test(relay): Add current timestamp to better understand flakiness

### DIFF
--- a/src/sentry/testutils/pytest/relay.py
+++ b/src/sentry/testutils/pytest/relay.py
@@ -148,7 +148,7 @@ def relay_server(relay_server_setup, settings):
             if i == 7:
                 _log.exception(str(ex))
                 raise ValueError(
-                    f"relay did not start in time {url}:\n{container.logs().decode()}"
+                    f"relay did not start in time (now: {datetime.datetime.now(datetime.UTC).strftime('%Y-%m-%dT%H:%M:%S.%f')}) {url}:\n{container.logs().decode()}"
                 ) from ex
             time.sleep(0.1 * 2**i)
     else:

--- a/src/sentry/testutils/pytest/relay.py
+++ b/src/sentry/testutils/pytest/relay.py
@@ -148,7 +148,7 @@ def relay_server(relay_server_setup, settings):
             if i == 7:
                 _log.exception(str(ex))
                 raise ValueError(
-                    f"relay did not start in time (now: {datetime.datetime.now(datetime.UTC).strftime('%Y-%m-%dT%H:%M:%S.%f')}) {url}:\n{container.logs().decode()}"
+                    f"relay did not start in time (now: {datetime.datetime.now().isoformat()}) {url}:\n{container.logs().decode()}"
                 ) from ex
             time.sleep(0.1 * 2**i)
     else:


### PR DESCRIPTION
The logs of the container are already printed, however they only have limited usefulness if we don't know the current time since it could be that the logs 'just stopped' in which case the container was still doing something or  the logs stopped seconds ago in which case something is hanging. (Example of a [log output](https://github.com/getsentry/sentry/actions/runs/16482705023/job/46600814962) which is unclear)

Part of the investigation into: https://linear.app/getsentry/issue/INGEST-505/flaky-test-test-adds-contexts-with-ps4-device
