### PR TITLE
fix(dashboards): misalignment of issues context card trigger

### DIFF
--- a/static/app/utils/dashboards/issueFieldRenderers.tsx
+++ b/static/app/utils/dashboards/issueFieldRenderers.tsx
@@ -79,17 +79,15 @@ const SPECIAL_FIELDS: SpecialFields = {
       };
 
       return (
-        <Container>
-          <QuickContextHoverWrapper
-            dataRow={data}
-            contextType={ContextType.ISSUE}
-            organization={organization}
-          >
-            <OverflowLink to={target} aria-label={issueID}>
-              <FieldShortId shortId={`${data.issue}`} />
-            </OverflowLink>
-          </QuickContextHoverWrapper>
-        </Container>
+        <QuickContextHoverWrapper
+          dataRow={data}
+          contextType={ContextType.ISSUE}
+          organization={organization}
+        >
+          <OverflowLink to={target} aria-label={issueID}>
+            <FieldShortId shortId={`${data.issue}`} />
+          </OverflowLink>
+        </QuickContextHoverWrapper>
       );
     },
   },

--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -625,17 +625,15 @@ const SPECIAL_FIELDS: Record<string, SpecialField> = {
       };
 
       return (
-        <Container>
-          <QuickContextHoverWrapper
-            dataRow={data}
-            contextType={ContextType.ISSUE}
-            organization={organization}
-          >
-            <StyledLink to={target} aria-label={issueID}>
-              <OverflowFieldShortId shortId={`${data.issue}`} />
-            </StyledLink>
-          </QuickContextHoverWrapper>
-        </Container>
+        <QuickContextHoverWrapper
+          dataRow={data}
+          contextType={ContextType.ISSUE}
+          organization={organization}
+        >
+          <StyledLink to={target} aria-label={issueID}>
+            <OverflowFieldShortId shortId={`${data.issue}`} />
+          </StyledLink>
+        </QuickContextHoverWrapper>
       );
     },
   },


### PR DESCRIPTION
### Changes

This PR: https://github.com/getsentry/sentry/pull/98462 added a style applied to all span tags because table cells were not vertically aligned. However, this is causing a the issue column to render with the text intersecting with the underline.

So, this PR removed `Container` around the card as it doesn't add any styles needed to render it correctly

### Before
<img width="113" height="27" alt="Screenshot 2025-08-29 at 9 37 00 AM" src="https://github.com/user-attachments/assets/ad3386b2-ea8b-4ff4-acc4-e78d620d8672" />


### After 
<img width="93" height="45" alt="Screenshot 2025-08-29 at 9 36 44 AM" src="https://github.com/user-attachments/assets/468423b1-f6ad-4c9c-a444-59a67f3705a4" />
