### PR TITLE
fix(dashboards): dashboard access dropdown being cut out when few dashboards exist

### DIFF
--- a/static/app/views/dashboards/editAccessSelector.tsx
+++ b/static/app/views/dashboards/editAccessSelector.tsx
@@ -366,6 +366,8 @@ function EditAccessSelector({
       }}
       menuFooter={dropdownFooterButtons}
       onSearch={debounce(val => void onSearch(val), DEFAULT_DEBOUNCE_DURATION)}
+      strategy="fixed"
+      preventOverflowOptions={{mainAxis: false}}
     />
   );
 


### PR DESCRIPTION
### Changes

Added strategy fixed to prevent dropdown cutting out when few dashboards exist

Also disabled overflow prevention because I think the library used for the dropdown has a bug with placing the dropdown. Not ideal, but the user would have to go out of their way to shrink the tab really small to notice this.

### Before
<img width="1492" height="196" alt="Screenshot 2025-08-29 at 10 10 34 AM" src="https://github.com/user-attachments/assets/95af02f1-ac11-48ce-8942-096d99a6d626" />

### After

<img width="1494" height="623" alt="Screenshot 2025-08-29 at 10 08 25 AM" src="https://github.com/user-attachments/assets/61ec7eb2-b094-415a-b394-b19fd7fb59bd" />
