### PR TITLE
fix(widget-builder): Thresholds should update to null when wiped

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/thresholds.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/thresholds.tsx
@@ -64,7 +64,7 @@ function ThresholdsSection({
               nextMaxValue => !defined(nextMaxValue)
             )
           ) {
-            newThresholds = undefined;
+            newThresholds = null;
           }
 
           setError?.({...error, thresholds: {[maxKey]: ''}});

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -28,7 +28,6 @@ import {
   DEFAULT_RESULTS_LIMIT,
   getResultsLimit,
 } from 'sentry/views/dashboards/widgetBuilder/utils';
-import type {Thresholds} from 'sentry/views/dashboards/widgets/common/types';
 import {FieldValueKind} from 'sentry/views/discover/table/types';
 
 // For issues dataset, events and users are sorted descending and do not use '-'
@@ -82,7 +81,7 @@ type WidgetAction =
   | {payload: number | undefined; type: typeof BuilderStateAction.SET_SELECTED_AGGREGATE}
   | {payload: WidgetBuilderStateQueryParams; type: typeof BuilderStateAction.SET_STATE}
   | {
-      payload: ThresholdsConfig | undefined;
+      payload: ThresholdsConfig | null | undefined;
       type: typeof BuilderStateAction.SET_THRESHOLDS;
     };
 
@@ -96,7 +95,7 @@ export interface WidgetBuilderState {
   query?: string[];
   selectedAggregate?: number;
   sort?: Sort[];
-  thresholds?: Thresholds;
+  thresholds?: ThresholdsConfig | null;
   title?: string;
   yAxis?: Column[];
 }
@@ -154,7 +153,7 @@ function useWidgetBuilderState(): {
     decoder: decodeScalar,
     deserializer: deserializeSelectedAggregate,
   });
-  const [thresholds, setThresholds] = useQueryParamState<ThresholdsConfig>({
+  const [thresholds, setThresholds] = useQueryParamState<ThresholdsConfig | null>({
     fieldName: 'thresholds',
     decoder: decodeScalar,
     deserializer: deserializeThresholds,
@@ -676,7 +675,7 @@ function deserializeThresholds(value: string): ThresholdsConfig | undefined {
   return JSON.parse(value);
 }
 
-export function serializeThresholds(thresholds: ThresholdsConfig): string {
+export function serializeThresholds(thresholds: ThresholdsConfig | null): string {
   return JSON.stringify(thresholds);
 }
 


### PR DESCRIPTION
If they are updated to `undefined`, then they just get ignored in the PUT request. If we explicitly set them to `null` then they'll be sent as `null` which resets the thresholds in the endpoint properly.