### PR TITLE
fix(insights): ensure span.op filter is respected by the frontend overview table

### DIFF
--- a/static/app/views/insights/pages/frontend/frontendOverviewTable.tsx
+++ b/static/app/views/insights/pages/frontend/frontendOverviewTable.tsx
@@ -117,6 +117,7 @@ const SORTABLE_FIELDS = [
   'p50_if(span.duration,is_transaction,equals,true)',
   'p75_if(span.duration,is_transaction,equals,true)',
   'p95_if(span.duration,is_transaction,equals,true)',
+  'failure_rate_if(is_transaction,equals,true)',
   'count_unique(user)',
   'sum_if(span.duration,is_transaction,equals,true)',
   'performance_score(measurements.score.total)',

--- a/static/app/views/insights/pages/frontend/frontendOverviewTable.tsx
+++ b/static/app/views/insights/pages/frontend/frontendOverviewTable.tsx
@@ -25,7 +25,7 @@ import {SPAN_OP_QUERY_PARAM} from 'sentry/views/insights/pages/frontend/settings
 import {TransactionCell} from 'sentry/views/insights/pages/transactionCell';
 import type {SpanResponse} from 'sentry/views/insights/types';
 
-type Row = Pick<
+export type Row = Pick<
   SpanResponse,
   | 'is_starred_transaction'
   | 'transaction'
@@ -117,7 +117,6 @@ const SORTABLE_FIELDS = [
   'p50_if(span.duration,is_transaction,equals,true)',
   'p75_if(span.duration,is_transaction,equals,true)',
   'p95_if(span.duration,is_transaction,equals,true)',
-  'failure_rate_if(is_transaction,equals,true)',
   'count_unique(user)',
   'sum_if(span.duration,is_transaction,equals,true)',
   'performance_score(measurements.score.total)',

--- a/static/app/views/insights/pages/frontend/newFrontendOverviewPage.tsx
+++ b/static/app/views/insights/pages/frontend/newFrontendOverviewPage.tsx
@@ -25,12 +25,10 @@ import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLay
 import {OverviewIssuesWidget} from 'sentry/views/insights/common/components/overviewIssuesWidget';
 import {InsightsProjectSelector} from 'sentry/views/insights/common/components/projectSelector';
 import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
-import {STARRED_SEGMENT_TABLE_QUERY_KEY} from 'sentry/views/insights/common/components/tableCells/starredSegmentCell';
 import OverviewAssetsByTimeSpentWidget from 'sentry/views/insights/common/components/widgets/overviewSlowAssetsWidget';
 import OverviewTimeConsumingRequestsWidget from 'sentry/views/insights/common/components/widgets/overviewTimeConsumingRequestsWidget';
 import OverviewTransactionDurationChartWidget from 'sentry/views/insights/common/components/widgets/overviewTransactionDurationChartWidget';
 import OverviewTransactionThroughputChartWidget from 'sentry/views/insights/common/components/widgets/overviewTransactionThroughputChartWidget';
-import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
 import {QueryParameterNames} from 'sentry/views/insights/common/views/queryParameters';
 import {TripleRowWidgetWrapper} from 'sentry/views/insights/pages/backend/backendOverviewPage';
@@ -40,7 +38,7 @@ import {
   type ValidSort,
 } from 'sentry/views/insights/pages/frontend/frontendOverviewTable';
 import {FrontendHeader} from 'sentry/views/insights/pages/frontend/frontendPageHeader';
-import {Referrer} from 'sentry/views/insights/pages/frontend/referrers';
+import {useFrontendTableData} from 'sentry/views/insights/pages/frontend/queries/useFrontendTableData';
 import type {PageSpanOps} from 'sentry/views/insights/pages/frontend/settings';
 import {
   DEFAULT_SORT,
@@ -124,30 +122,7 @@ export function NewFrontendOverviewPage() {
 
   const displayPerfScore = ['pageload', 'all'].includes(spanOp);
 
-  const response = useSpans(
-    {
-      search,
-      sorts,
-      cursor,
-      useQueryOptions: {additonalQueryKey: STARRED_SEGMENT_TABLE_QUERY_KEY},
-      fields: [
-        'is_starred_transaction',
-        'transaction',
-        'project',
-        'tpm()',
-        'p50_if(span.duration,is_transaction,equals,true)',
-        'p75_if(span.duration,is_transaction,equals,true)',
-        'p95_if(span.duration,is_transaction,equals,true)',
-        'failure_rate_if(is_transaction,equals,true)',
-        ...(displayPerfScore
-          ? (['performance_score(measurements.score.total)'] as const)
-          : []),
-        'count_unique(user)',
-        'sum_if(span.duration,is_transaction,equals,true)',
-      ],
-    },
-    Referrer.FRONTEND_LANDING_TABLE
-  );
+  const response = useFrontendTableData(search, sorts, displayPerfScore, spanOp, cursor);
 
   const searchBarProjectsIds = [
     ...selectedFrontendProjects,

--- a/static/app/views/insights/pages/frontend/queries/useFrontendTableData.tsx
+++ b/static/app/views/insights/pages/frontend/queries/useFrontendTableData.tsx
@@ -1,0 +1,99 @@
+import type {Sort} from 'sentry/utils/discover/fields';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {STARRED_SEGMENT_TABLE_QUERY_KEY} from 'sentry/views/insights/common/components/tableCells/starredSegmentCell';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import {
+  type Row,
+  type ValidSort,
+} from 'sentry/views/insights/pages/frontend/frontendOverviewTable';
+import type {PageSpanOps} from 'sentry/views/insights/pages/frontend/settings';
+
+export const useFrontendTableData = (
+  search: MutableSearch,
+  sorts: [ValidSort, ValidSort],
+  displayPerfScore: boolean,
+  spanOpFilter?: PageSpanOps,
+  cursor?: string
+) => {
+  let transactionFilter: `${string},equals,${string}` = 'is_transaction,equals,true';
+  if (spanOpFilter === 'pageload') {
+    transactionFilter = 'span.op,equals,pageload';
+  } else if (spanOpFilter === 'navigation') {
+    transactionFilter = 'span.op,equals,navigation';
+  }
+
+  const newSorts: Sort[] = sorts.map(sort => ({
+    ...sort,
+    field: sort.field.replace('is_transaction,equals,true', transactionFilter),
+  }));
+
+  const response = useSpans(
+    {
+      search,
+      sorts: newSorts,
+      cursor,
+      useQueryOptions: {additonalQueryKey: STARRED_SEGMENT_TABLE_QUERY_KEY},
+      fields: [
+        'is_starred_transaction',
+        'transaction',
+        'project',
+        'tpm()', // TODO: replace with `tpm_if`
+        `p50_if(span.duration,${transactionFilter})`,
+        `p75_if(span.duration,${transactionFilter})`,
+        `p95_if(span.duration,${transactionFilter})`,
+        `failure_rate_if(${transactionFilter})`,
+        ...(displayPerfScore
+          ? (['performance_score(measurements.score.total)'] as const)
+          : []),
+        'count_unique(user)',
+        `sum_if(span.duration,${transactionFilter})`,
+      ],
+    },
+    'api.insights.frontend.landing-table'
+  );
+
+  const newData: Row[] = response.data.map(row => {
+    return {
+      ...row,
+      'p50_if(span.duration,is_transaction,equals,true)':
+        row[`p50_if(span.duration,${transactionFilter})`] ?? 0,
+      'p75_if(span.duration,is_transaction,equals,true)':
+        row[`p75_if(span.duration,${transactionFilter})`] ?? 0,
+      'p95_if(span.duration,is_transaction,equals,true)':
+        row[`p95_if(span.duration,${transactionFilter})`] ?? 0,
+      'failure_rate_if(is_transaction,equals,true)':
+        row[`failure_rate_if(${transactionFilter})`] ?? 0,
+      'sum_if(span.duration,is_transaction,equals,true)':
+        row[`sum_if(span.duration,${transactionFilter})`] ?? 0,
+    };
+  });
+
+  const updateMetaIfExists = (oldField: string, newField: string) => {
+    if (response?.meta?.fields[oldField]) {
+      response.meta.fields[newField] = response?.meta?.fields[oldField];
+    }
+  };
+
+  updateMetaIfExists(
+    `p50_if(span.duration,${transactionFilter})`,
+    'p50_if(span.duration,is_transaction,equals,true)'
+  );
+  updateMetaIfExists(
+    `p75_if(span.duration,${transactionFilter})`,
+    'p75_if(span.duration,is_transaction,equals,true)'
+  );
+  updateMetaIfExists(
+    `p95_if(span.duration,${transactionFilter})`,
+    'p95_if(span.duration,is_transaction,equals,true)'
+  );
+  updateMetaIfExists(
+    `failure_rate_if(${transactionFilter})`,
+    'failure_rate_if(is_transaction,equals,true)'
+  );
+  updateMetaIfExists(
+    `sum_if(span.duration,${transactionFilter})`,
+    'sum_if(span.duration,is_transaction,equals,true)'
+  );
+
+  return {...response, data: newData};
+};


### PR DESCRIPTION
When the user filters by span.op in the frontend overview page, there's an edge case where interaction and click transactions are included in the percentile/failure_rate calculation in the table. This is because the table simply does `p95_if(is_transaction,true)` and the query includes interaction and click transactions.

This PR updates the query to do `percentile_if(span.op,equals,pageload)` so that this is no longer possible. I had to do some wacky stuff to get sort to work, if there's any less hacky way you can think of lmk!