### PR TITLE
fix(insights): ensure pageload/navigation filter is respected on throughput/duration chart

### DIFF
--- a/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
+++ b/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
@@ -48,10 +48,10 @@ import type {PageSpanOps} from 'sentry/views/insights/pages/frontend/settings';
 import {
   DEFAULT_SORT,
   DEFAULT_SPAN_OP_SELECTION,
-  EAP_OVERVIEW_PAGE_ALLOWED_OPS,
   FRONTEND_LANDING_TITLE,
   PAGE_SPAN_OPS,
   SPAN_OP_QUERY_PARAM,
+  WEB_VITALS_OPS,
 } from 'sentry/views/insights/pages/frontend/settings';
 import {InsightsSpanTagProvider} from 'sentry/views/insights/pages/insightsSpanTagProvider';
 import {NextJsOverviewPage} from 'sentry/views/insights/pages/platform/nextjs';
@@ -129,7 +129,7 @@ function EAPOverviewPage() {
   existingQuery.addOp('(');
 
   if (spanOp === 'all') {
-    const spanOps = [...EAP_OVERVIEW_PAGE_ALLOWED_OPS, 'pageload', 'navigation'];
+    const spanOps = [...WEB_VITALS_OPS, 'navigation'];
     existingQuery.addFilterValue('span.op', `[${spanOps.join(',')}]`);
     // add disjunction filter creates a very long query as it seperates conditions with OR, project ids are numeric with no spaces, so we can use a comma seperated list
     if (selectedFrontendProjects.length > 0) {
@@ -140,7 +140,7 @@ function EAPOverviewPage() {
       );
     }
   } else if (spanOp === 'pageload') {
-    const spanOps = [...EAP_OVERVIEW_PAGE_ALLOWED_OPS, 'pageload'];
+    const spanOps = [...WEB_VITALS_OPS];
     existingQuery.addFilterValue('span.op', `[${spanOps.join(',')}]`);
   } else if (spanOp === 'navigation') {
     // navigation span ops doesn't work for web vitals, so we do need to filter for web vital spans

--- a/static/app/views/insights/pages/frontend/newFrontendOverviewPage.tsx
+++ b/static/app/views/insights/pages/frontend/newFrontendOverviewPage.tsx
@@ -66,7 +66,7 @@ export function NewFrontendOverviewPage() {
   const onboardingProject = useOnboardingProject();
   const navigate = useNavigate();
   const {selection} = usePageFilters();
-  const search = useFrontendQuery();
+  const search = useFrontendQuery({includeWebVitalOps: true});
 
   const cursor = decodeScalar(location.query?.[QueryParameterNames.PAGES_CURSOR]);
   const spanOp: PageSpanOps = getSpanOpFromQuery(

--- a/static/app/views/insights/pages/frontend/settings.ts
+++ b/static/app/views/insights/pages/frontend/settings.ts
@@ -8,7 +8,8 @@ export const FRONTEND_LANDING_SUB_PATH = 'frontend';
 export const FRONTEND_LANDING_TITLE = t('Frontend');
 export const FRONTEND_SIDEBAR_LABEL = t('Frontend');
 
-export const EAP_OVERVIEW_PAGE_ALLOWED_OPS = [
+// span.ops required to compute web vitals score
+export const WEB_VITALS_OPS = [
   'ui.render',
   'interaction',
   'ui.interaction',
@@ -18,6 +19,7 @@ export const EAP_OVERVIEW_PAGE_ALLOWED_OPS = [
   'ui.interaction.press',
   'ui.webvital.cls',
   'ui.webvital.fcp',
+  'pageload',
 ];
 
 export const OVERVIEW_PAGE_ALLOWED_OPS = [

--- a/static/app/views/insights/pages/frontend/useFrontendQuery.tsx
+++ b/static/app/views/insights/pages/frontend/useFrontendQuery.tsx
@@ -8,14 +8,22 @@ import useProjects from 'sentry/utils/useProjects';
 import {OVERVIEW_PAGE_ALLOWED_OPS as BACKEND_OVERVIEW_PAGE_ALLOWED_OPS} from 'sentry/views/insights/pages/backend/settings';
 import {
   DEFAULT_SPAN_OP_SELECTION,
-  EAP_OVERVIEW_PAGE_ALLOWED_OPS,
   PAGE_SPAN_OPS,
   SPAN_OP_QUERY_PARAM,
+  WEB_VITALS_OPS,
   type PageSpanOps,
 } from 'sentry/views/insights/pages/frontend/settings';
 import {categorizeProjects} from 'sentry/views/insights/pages/utils';
 
-export function useFrontendQuery() {
+type Props = {
+  includeWebVitalOps: boolean;
+};
+
+export function useFrontendQuery(
+  {includeWebVitalOps}: Props = {
+    includeWebVitalOps: false,
+  }
+) {
   const {projects} = useProjects();
   const {selection} = usePageFilters();
   const location = useLocation();
@@ -40,7 +48,9 @@ export function useFrontendQuery() {
   query.addOp('(');
 
   if (spanOp === 'all') {
-    const spanOps = [...EAP_OVERVIEW_PAGE_ALLOWED_OPS, 'pageload', 'navigation'];
+    const spanOps = includeWebVitalOps
+      ? [...WEB_VITALS_OPS, 'navigation'] // web vitals ops includes pageload
+      : ['pageload', 'navigation'];
     query.addFilterValue('span.op', `[${spanOps.join(',')}]`);
     // add disjunction filter creates a very long query as it seperates conditions with OR, project ids are numeric with no spaces, so we can use a comma seperated list
     if (frontendProjects.length > 0) {
@@ -51,7 +61,7 @@ export function useFrontendQuery() {
       );
     }
   } else if (spanOp === 'pageload') {
-    const spanOps = [...EAP_OVERVIEW_PAGE_ALLOWED_OPS, 'pageload'];
+    const spanOps = includeWebVitalOps ? [...WEB_VITALS_OPS] : ['pageload'];
     query.addFilterValue('span.op', `[${spanOps.join(',')}]`);
   } else if (spanOp === 'navigation') {
     // navigation span ops doesn't work for web vitals, so we do need to filter for web vital spans
@@ -60,7 +70,9 @@ export function useFrontendQuery() {
 
   query.addOp(')');
 
-  query.addFilterValues('!span.op', BACKEND_OVERVIEW_PAGE_ALLOWED_OPS);
+  if (spanOp === 'all') {
+    query.addFilterValues('!span.op', BACKEND_OVERVIEW_PAGE_ALLOWED_OPS);
+  }
 
   return query;
 }

--- a/static/app/views/insights/pages/platform/nextjs/clientTable.tsx
+++ b/static/app/views/insights/pages/platform/nextjs/clientTable.tsx
@@ -14,7 +14,7 @@ import {HeadSortCell} from 'sentry/views/insights/agents/components/headSortCell
 import {PerformanceBadge} from 'sentry/views/insights/browser/webVitals/components/performanceBadge';
 import {useModuleURL} from 'sentry/views/insights/common/utils/useModuleURL';
 import {OVERVIEW_PAGE_ALLOWED_OPS as BACKEND_OVERVIEW_PAGE_ALLOWED_OPS} from 'sentry/views/insights/pages/backend/settings';
-import {EAP_OVERVIEW_PAGE_ALLOWED_OPS} from 'sentry/views/insights/pages/frontend/settings';
+import {WEB_VITALS_OPS} from 'sentry/views/insights/pages/frontend/settings';
 import {Referrer} from 'sentry/views/insights/pages/platform/laravel/referrers';
 import {PlatformInsightsTable} from 'sentry/views/insights/pages/platform/shared/table';
 import {DurationCell} from 'sentry/views/insights/pages/platform/shared/table/DurationCell';
@@ -62,7 +62,7 @@ export function ClientTable() {
   const hasWebVitalsFlag = organization.features.includes('insight-modules');
   const webVitalsUrl = useModuleURL(ModuleName.VITAL, false, 'frontend');
 
-  const spanOps = [...EAP_OVERVIEW_PAGE_ALLOWED_OPS, 'pageload', 'navigation', 'default'];
+  const spanOps = [...WEB_VITALS_OPS, 'navigation', 'default'];
 
   const existingQuery = new MutableSearch('');
   existingQuery.addFilterValue('span.op', `[${spanOps.join(',')}]`);


### PR DESCRIPTION
Greatly simplifies the frontend overview throughput and duration query, which also ensure the `pageload/navigation` filter is respected.
Old filter
`( span.op:[ui.render,interaction,ui.interaction,ui.interaction.click,ui.interaction.hover,ui.interaction.drag,ui.interaction.press,ui.webvital.cls,ui.webvital.fcp,pageload,navigation] OR project.id:[11276] ) !span.op:http.server is_transaction:true`

new filter
`( span.op:[pageload,navigation] OR project.id:[11276] ) !span.op:http.server is_transaction:true`

The reason this issue occured is because it's possible that an interaction or click span has `is_transaction=true`