### PR TITLE
feat(timeseries): Allow more options for `useFetchEventsTimeSeries`

### DIFF
--- a/static/app/utils/timeSeries/useFetchEventsTimeSeries.spec.tsx
+++ b/static/app/utils/timeSeries/useFetchEventsTimeSeries.spec.tsx
@@ -171,6 +171,61 @@ describe('useFetchEventsTimeSeries', () => {
     );
   });
 
+  it('allows overrides for default parameters', async () => {
+    const request = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events-timeseries/`,
+      method: 'GET',
+      body: [],
+    });
+
+    const {result} = renderHook(
+      () =>
+        useFetchEventsTimeSeries(
+          DiscoverDatasets.SPANS,
+          {
+            yAxis: 'p50(span.duration)',
+            interval: '2h',
+            pageFilters: {
+              environments: ['dev'],
+              projects: [420],
+              datetime: {
+                start: '2020-01-01',
+                end: '2020-01-02',
+                period: null,
+                utc: true,
+              },
+            },
+          },
+          REFERRER
+        ),
+      hookOptions
+    );
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(request).toHaveBeenCalledWith(
+      '/organizations/org-slug/events-timeseries/',
+      expect.objectContaining({
+        method: 'GET',
+        query: {
+          excludeOther: 0,
+          partial: 1,
+          referrer: 'test-query',
+          dataset: 'spans',
+          start: '2020-01-01T00:00:00.000',
+          end: '2020-01-02T00:00:00.000',
+          utc: 'true',
+          yAxis: 'p50(span.duration)',
+          environment: ['dev'],
+          project: [420],
+          interval: '2h',
+          sampling: 'NORMAL',
+        },
+      })
+    );
+  });
+
   it('makes top N requests', async () => {
     const request = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events-timeseries/`,

--- a/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
+++ b/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
@@ -20,8 +20,8 @@ interface UseFetchEventsTimeSeriesOptions<Field> {
   yAxis: Field | Field[];
   enabled?: boolean;
   groupBy?: Field[];
-  query?: MutableSearch;
   interval?: string;
+  query?: MutableSearch | string;
   sampling?: SamplingMode;
   sort?: Sort;
   topEvents?: number;
@@ -68,7 +68,11 @@ export function useFetchEventsTimeSeries<T extends string>(
           project: selection.projects,
           environment: selection.environments,
           interval: interval ?? getIntervalForTimeSeriesQuery(yAxis, selection.datetime),
-          query: query ? query.formatString() : undefined,
+          query: query
+            ? typeof query === 'string'
+              ? query
+              : query.formatString()
+            : undefined,
           sampling: sampling ?? DEFAULT_SAMPLING_MODE,
           topEvents,
           groupBy,

--- a/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
+++ b/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
@@ -34,13 +34,13 @@ export function useFetchEventsTimeSeries<T extends string>(
   dataset: DiscoverDatasets,
   {
     yAxis,
+    enabled,
+    groupBy,
     interval,
     query,
     sampling,
-    topEvents,
-    groupBy,
     sort,
-    enabled,
+    topEvents,
   }: UseFetchEventsTimeSeriesOptions<T>,
   referrer: string
 ) {

--- a/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
+++ b/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
@@ -21,6 +21,7 @@ interface UseFetchEventsTimeSeriesOptions<Field> {
   enabled?: boolean;
   groupBy?: Field[];
   query?: MutableSearch;
+  interval?: string;
   sampling?: SamplingMode;
   sort?: Sort;
   topEvents?: number;
@@ -33,6 +34,7 @@ export function useFetchEventsTimeSeries<T extends string>(
   dataset: DiscoverDatasets,
   {
     yAxis,
+    interval,
     query,
     sampling,
     topEvents,
@@ -65,7 +67,7 @@ export function useFetchEventsTimeSeries<T extends string>(
           ...normalizeDateTimeParams(selection.datetime),
           project: selection.projects,
           environment: selection.environments,
-          interval: getIntervalForTimeSeriesQuery(yAxis, selection.datetime),
+          interval: interval ?? getIntervalForTimeSeriesQuery(yAxis, selection.datetime),
           query: query ? query.formatString() : undefined,
           sampling: sampling ?? DEFAULT_SAMPLING_MODE,
           topEvents,


### PR DESCRIPTION
We needed this earlier than I thought!

- allows overriding `interval`
- allows overriding `pageFilters`
- allows string `query`
