### PR TITLE
chore: Add Visibility as owners of `TimeSeries` utils

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -287,6 +287,7 @@ pnpm-lock.yaml                                           @getsentry/owners-js-de
 
 /static/app/views/discover/                                               @getsentry/explore
 /static/app/utils/discover/                                               @getsentry/explore
+/static/app/utils/timeSeries/                                             @getsentry/visibility
 ## Endof Visibility
 
 


### PR DESCRIPTION
It's for all of us, really!
