### PR TITLE
feat(insights): Web Vitals initiate Seer Suggestions flow

### DIFF
--- a/static/app/views/insights/browser/webVitals/components/pageOverviewSidebar.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/components/pageOverviewSidebar.spec.tsx
@@ -114,7 +114,7 @@ describe('PageOverviewSidebar', () => {
     expect(screen.getByText('View Suggestion')).toBeInTheDocument();
   });
 
-  it('should create issues run seer analysis button is clicked', async () => {
+  it('should create issues when run seer analysis button is clicked', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/issues/`,
       body: [],

--- a/static/app/views/insights/browser/webVitals/components/pageOverviewSidebar.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/components/pageOverviewSidebar.spec.tsx
@@ -1,15 +1,8 @@
-import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-import {useLocation} from 'sentry/utils/useLocation';
-import usePageFilters from 'sentry/utils/usePageFilters';
 import {PageOverviewSidebar} from 'sentry/views/insights/browser/webVitals/components/pageOverviewSidebar';
-
-jest.mock('sentry/utils/useLocation');
-jest.mock('sentry/utils/usePageFilters');
 
 const TRANSACTION_NAME = 'transaction';
 
@@ -19,10 +12,6 @@ describe('PageOverviewSidebar', () => {
   });
 
   beforeEach(() => {
-    jest.mocked(useLocation).mockReturnValue(LocationFixture());
-
-    jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture());
-
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events-stats/`,
       body: {
@@ -100,12 +89,12 @@ describe('PageOverviewSidebar', () => {
     render(<PageOverviewSidebar transaction={TRANSACTION_NAME} />, {organization});
 
     expect(await screen.findByText('Seer Suggestions')).toBeInTheDocument();
-    expect(screen.getByText('LCP score needs improvement')).toBeInTheDocument();
+    expect(await screen.findByText('LCP score needs improvement')).toBeInTheDocument();
     expect(
-      screen.getByText(
+      await screen.findByText(
         'Unoptimized screenshot images are directly embedded, causing large downloads and delaying Largest Contentful Paint on issue detail pages.'
       )
     ).toBeInTheDocument();
-    expect(screen.getByText('View Suggestion')).toBeInTheDocument();
+    expect(await screen.findByText('View Suggestion')).toBeInTheDocument();
   });
 });

--- a/static/app/views/insights/browser/webVitals/components/pageOverviewSidebar.tsx
+++ b/static/app/views/insights/browser/webVitals/components/pageOverviewSidebar.tsx
@@ -154,12 +154,13 @@ export function PageOverviewSidebar({
     eventIds: newlyCreatedIssueEventIds,
   });
 
+  // Creates a new issue for each web vital that has a score under 90 and runs seer autofix for each of them
+  // TODO: Add logic to actually initiate running autofix for each issue. Right now we rely on the project config to automatically run autofix for each issue.
   const runSeerAnalysis = useCallback(async () => {
     if (!projectScore) {
       return;
     }
     setIsCreatingIssues(true);
-    // Creates a new issue for each web vital that has a score under 90
     const underPerformingWebVitals = ORDER.filter(webVital => {
       const score = projectScore[`${webVital}Score`];
       return score && score < 90;

--- a/static/app/views/insights/browser/webVitals/components/pageOverviewSidebar.tsx
+++ b/static/app/views/insights/browser/webVitals/components/pageOverviewSidebar.tsx
@@ -412,7 +412,9 @@ function SeerSuggestion({issue}: {issue: Group}) {
       </CardTitle>
       <CardContentContainer>
         <CardContent>
-          {isLoadingAutofix || autofixData === undefined ? (
+          {isLoadingAutofix ||
+          autofixData === undefined ||
+          rootCauseDescription === null ? (
             <Placeholder height="1.5rem" width="100%" />
           ) : (
             <AutofixSummary

--- a/static/app/views/insights/browser/webVitals/components/pageOverviewWebVitalsDetailPanel.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/components/pageOverviewWebVitalsDetailPanel.spec.tsx
@@ -3,12 +3,7 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
 
-import {
-  render,
-  screen,
-  userEvent,
-  waitForElementToBeRemoved,
-} from 'sentry-test/reactTestingLibrary';
+import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
 
 import ProjectsStore from 'sentry/stores/projectsStore';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -29,7 +24,6 @@ describe('PageOverviewWebVitalsDetailPanel', () => {
       transaction: 'test-transaction',
     },
   });
-  let userIssueEndpoint: jest.Mock;
 
   beforeEach(() => {
     jest.mocked(useLocation).mockReturnValue(location);
@@ -74,12 +68,6 @@ describe('PageOverviewWebVitalsDetailPanel', () => {
         ],
       },
     });
-
-    userIssueEndpoint = MockApiClient.addMockResponse({
-      url: `/projects/${organization.slug}/${project.slug}/user-issue/`,
-      method: 'POST',
-      body: {},
-    });
   });
 
   afterEach(() => {
@@ -99,28 +87,5 @@ describe('PageOverviewWebVitalsDetailPanel', () => {
     expect(screen.getByText('Replay')).toBeInTheDocument();
     expect(screen.getByText('lcp')).toBeInTheDocument();
     expect(screen.getByText('lcp Score')).toBeInTheDocument();
-  });
-
-  it('renders create issue button and calls endpoint to create issue when clicked', async () => {
-    render(<PageOverviewWebVitalsDetailPanel webVital="lcp" />, {
-      organization,
-    });
-
-    await waitForElementToBeRemoved(() => screen.queryAllByTestId('loading-indicator'));
-
-    expect(screen.getByText('Create Issue')).toBeInTheDocument();
-    await userEvent.click(screen.getByText('Create Issue'));
-
-    expect(userIssueEndpoint).toHaveBeenCalledWith(
-      '/projects/org-slug/project-slug/user-issue/',
-      expect.objectContaining({
-        data: expect.objectContaining({
-          issueType: 'web_vitals',
-          vital: 'lcp',
-          score: 80,
-          transaction: 'test-transaction',
-        }),
-      })
-    );
   });
 });

--- a/static/app/views/insights/browser/webVitals/components/pageOverviewWebVitalsDetailPanel.tsx
+++ b/static/app/views/insights/browser/webVitals/components/pageOverviewWebVitalsDetailPanel.tsx
@@ -310,7 +310,6 @@ export function PageOverviewWebVitalsDetailPanel({
             }
             webVital={webVital}
             score={webVitalScore}
-            transaction={transaction}
           />
         )}
         <ChartContainer>

--- a/static/app/views/insights/browser/webVitals/components/webVitalDescription.tsx
+++ b/static/app/views/insights/browser/webVitals/components/webVitalDescription.tsx
@@ -1,28 +1,21 @@
 import styled from '@emotion/styled';
 
-import {addSuccessMessage} from 'sentry/actionCreators/indicator';
-import {FeatureBadge} from 'sentry/components/core/badge/featureBadge';
-import {Button} from 'sentry/components/core/button';
 import {Flex} from 'sentry/components/core/layout';
 import {ExternalLink} from 'sentry/components/core/link';
 import {IconCheckmark} from 'sentry/icons/iconCheckmark';
 import {IconClose} from 'sentry/icons/iconClose';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {IssueType} from 'sentry/types/group';
 import {WebVital} from 'sentry/utils/fields';
 import {Browser} from 'sentry/utils/performance/vitals/constants';
 import {PerformanceBadge} from 'sentry/views/insights/browser/webVitals/components/performanceBadge';
 import type {WebVitals} from 'sentry/views/insights/browser/webVitals/types';
 import {scoreToStatus} from 'sentry/views/insights/browser/webVitals/utils/scoreToStatus';
-import {useCreateIssue} from 'sentry/views/insights/browser/webVitals/utils/useCreateIssue';
-import {useHasSeerWebVitalsSuggestions} from 'sentry/views/insights/browser/webVitals/utils/useHasSeerWebVitalsSuggestions';
 import {vitalSupportedBrowsers} from 'sentry/views/performance/vitalDetail/utils';
 
 type Props = {
   webVital: WebVitals;
   score?: number;
-  transaction?: string;
   value?: string;
 };
 
@@ -119,11 +112,9 @@ export const VITAL_DESCRIPTIONS: Partial<
   },
 };
 
-export function WebVitalDetailHeader({score, value, webVital, transaction}: Props) {
-  const hasSeerWebVitalsSuggestions = useHasSeerWebVitalsSuggestions();
+export function WebVitalDetailHeader({score, value, webVital}: Props) {
   const status = score === undefined ? undefined : scoreToStatus(score);
 
-  const {mutate: createIssue} = useCreateIssue();
   return (
     <Flex justify="between">
       <div>
@@ -133,44 +124,6 @@ export function WebVitalDetailHeader({score, value, webVital, transaction}: Prop
           {status && score && <PerformanceBadge score={score} />}
         </WebVitalScore>
       </div>
-      {hasSeerWebVitalsSuggestions && transaction && score && score < 90 && (
-        <div>
-          <Button
-            title={
-              <div>
-                <FeatureBadge type="experimental" />
-                <div>
-                  {tct(
-                    'Your [webVital] metric is below the recommended threshold. Create an issue to investigate.',
-                    {
-                      webVital: webVital.toUpperCase(),
-                    }
-                  )}
-                </div>
-              </div>
-            }
-            onClick={() => {
-              createIssue(
-                {
-                  issueType: IssueType.WEB_VITALS,
-                  vital: webVital,
-                  score,
-                  transaction,
-                },
-                {
-                  onSuccess: () => {
-                    // TODO: The issue actually doesn't get created here immediately.
-                    // Issue creation is async, so we need to poll for the issue by event ID to confirm success.
-                    addSuccessMessage(t('Issue created successfully'));
-                  },
-                }
-              );
-            }}
-          >
-            {t('Create Issue')}
-          </Button>
-        </div>
-      )}
     </Flex>
   );
 }

--- a/static/app/views/insights/browser/webVitals/queries/useWebVitalsIssuesQuery.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/useWebVitalsIssuesQuery.tsx
@@ -70,7 +70,7 @@ export function useWebVitalsIssuesQuery({
     staleTime: 0,
     enabled: Boolean(issueTypes?.length) && enabled,
     refetchInterval: query => {
-      // Only refetch if we have a pollInterval, a list of expected eventIds, and we do not have all results yet
+      // Poll until the number of issues in the results array matches the number of expected eventIds.
       if (!pollInterval || !eventIds) {
         return false;
       }

--- a/static/app/views/insights/browser/webVitals/queries/useWebVitalsIssuesQuery.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/useWebVitalsIssuesQuery.tsx
@@ -1,47 +1,82 @@
+import {useCallback} from 'react';
+
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
-import type {Group, ISSUE_TYPE_TO_ISSUE_TITLE} from 'sentry/types/group';
+import {IssueType, type Group, type ISSUE_TYPE_TO_ISSUE_TITLE} from 'sentry/types/group';
 import {defined} from 'sentry/utils';
-import {useApiQuery} from 'sentry/utils/queryClient';
+import {useApiQuery, useQueryClient, type ApiQueryKey} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 
-export function getIssueQueryFilter({
-  issueTypes,
-  transaction,
-}: {
-  issueTypes: Array<keyof typeof ISSUE_TYPE_TO_ISSUE_TITLE>;
+export const POLL_INTERVAL = 1000;
+
+const DEFAULT_ISSUE_TYPES = [IssueType.WEB_VITALS];
+
+type QueryProps = {
+  issueTypes?: Array<keyof typeof ISSUE_TYPE_TO_ISSUE_TITLE>;
   transaction?: string;
-}) {
+};
+
+export function getIssueQueryFilter({
+  issueTypes = DEFAULT_ISSUE_TYPES,
+  transaction,
+}: QueryProps) {
   return `is:unresolved issue.type:[${issueTypes?.join(',')}]${defined(transaction) ? ` transaction:${transaction}` : ''}`;
 }
 
-export function useWebVitalsIssuesQuery({
-  issueTypes,
+export function useWebVitalsIssuesQueryKey({
+  issueTypes = DEFAULT_ISSUE_TYPES,
   transaction,
-  enabled = true,
-}: {
-  issueTypes: Array<keyof typeof ISSUE_TYPE_TO_ISSUE_TITLE>;
-  enabled?: boolean;
-  transaction?: string;
-}) {
+}: QueryProps): ApiQueryKey {
   const organization = useOrganization();
   const {selection} = usePageFilters();
-  return useApiQuery<Group[]>(
-    [
-      `/organizations/${organization.slug}/issues/`,
-      {
-        query: {
-          query: getIssueQueryFilter({issueTypes, transaction}),
-          project: selection.projects,
-          environment: selection.environments,
-          ...normalizeDateTimeParams(selection.datetime),
-          per_page: 6,
-        },
-      },
-    ],
+  return [
+    `/organizations/${organization.slug}/issues/`,
     {
-      staleTime: 0,
-      enabled: Boolean(issueTypes?.length) && enabled,
-    }
-  );
+      query: {
+        query: getIssueQueryFilter({issueTypes, transaction}),
+        project: selection.projects,
+        environment: selection.environments,
+        ...normalizeDateTimeParams(selection.datetime),
+        per_page: 6,
+      },
+    },
+  ];
+}
+
+export function useInvalidateWebVitalsIssuesQuery({
+  issueTypes = DEFAULT_ISSUE_TYPES,
+  transaction,
+}: QueryProps) {
+  const queryClient = useQueryClient();
+  const queryKey = useWebVitalsIssuesQueryKey({issueTypes, transaction});
+  return useCallback(() => {
+    queryClient.invalidateQueries({queryKey});
+  }, [queryClient, queryKey]);
+}
+
+export function useWebVitalsIssuesQuery({
+  issueTypes = DEFAULT_ISSUE_TYPES,
+  transaction,
+  enabled = true,
+  pollInterval,
+  eventIds,
+}: QueryProps & {
+  enabled?: boolean;
+  eventIds?: string[];
+  pollInterval?: number;
+}) {
+  return useApiQuery<Group[]>(useWebVitalsIssuesQueryKey({issueTypes, transaction}), {
+    staleTime: 0,
+    enabled: Boolean(issueTypes?.length) && enabled,
+    refetchInterval: query => {
+      if (!pollInterval || !eventIds) {
+        return false;
+      }
+      const result = query.state.data?.[0];
+      // Only refetch if we have a pollInterval and we do not have all results yet
+      return result && Array.isArray(result) && result.length < eventIds.length
+        ? pollInterval
+        : false;
+    },
+  });
 }

--- a/static/app/views/insights/browser/webVitals/queries/useWebVitalsIssuesQuery.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/useWebVitalsIssuesQuery.tsx
@@ -50,6 +50,7 @@ export function useInvalidateWebVitalsIssuesQuery({
   const queryClient = useQueryClient();
   const queryKey = useWebVitalsIssuesQueryKey({issueTypes, transaction});
   return useCallback(() => {
+    queryClient.setQueryData(queryKey, undefined);
     queryClient.invalidateQueries({queryKey});
   }, [queryClient, queryKey]);
 }
@@ -69,11 +70,11 @@ export function useWebVitalsIssuesQuery({
     staleTime: 0,
     enabled: Boolean(issueTypes?.length) && enabled,
     refetchInterval: query => {
+      // Only refetch if we have a pollInterval, a list of expected eventIds, and we do not have all results yet
       if (!pollInterval || !eventIds) {
         return false;
       }
       const result = query.state.data?.[0];
-      // Only refetch if we have a pollInterval and we do not have all results yet
       return result && Array.isArray(result) && result.length < eventIds.length
         ? pollInterval
         : false;

--- a/static/app/views/insights/browser/webVitals/queries/useWebVitalsIssuesQuery.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/useWebVitalsIssuesQuery.tsx
@@ -23,7 +23,7 @@ export function getIssueQueryFilter({
   return `is:unresolved issue.type:[${issueTypes?.join(',')}]${defined(transaction) ? ` transaction:${transaction}` : ''}`;
 }
 
-export function useWebVitalsIssuesQueryKey({
+function useWebVitalsIssuesQueryKey({
   issueTypes = DEFAULT_ISSUE_TYPES,
   transaction,
 }: QueryProps): ApiQueryKey {

--- a/static/app/views/insights/browser/webVitals/utils/useCreateIssue.tsx
+++ b/static/app/views/insights/browser/webVitals/utils/useCreateIssue.tsx
@@ -6,7 +6,9 @@ import useProjects from 'sentry/utils/useProjects';
 
 type CreateIssueData = Record<string, any>;
 
-interface CreateIssueResponse {} // Endpoint currently returns 200 with no data
+interface CreateIssueResponse {
+  event_id: string;
+}
 
 export function useCreateIssue() {
   const organization = useOrganization();

--- a/static/app/views/insights/browser/webVitals/utils/useRunSeerAnalysis.tsx
+++ b/static/app/views/insights/browser/webVitals/utils/useRunSeerAnalysis.tsx
@@ -12,8 +12,8 @@ export function useRunSeerAnalysis({
   projectScore,
   transaction,
 }: {
-  projectScore: ProjectScore;
   transaction: string;
+  projectScore?: ProjectScore;
 }) {
   const {mutateAsync: createIssueAsync} = useCreateIssue();
   const invalidateWebVitalsIssuesQuery = useInvalidateWebVitalsIssuesQuery({

--- a/static/app/views/insights/browser/webVitals/utils/useRunSeerAnalysis.tsx
+++ b/static/app/views/insights/browser/webVitals/utils/useRunSeerAnalysis.tsx
@@ -1,0 +1,52 @@
+import {useCallback} from 'react';
+
+import {IssueType} from 'sentry/types/group';
+import {ORDER} from 'sentry/views/insights/browser/webVitals/components/charts/performanceScoreChart';
+import {useInvalidateWebVitalsIssuesQuery} from 'sentry/views/insights/browser/webVitals/queries/useWebVitalsIssuesQuery';
+import type {ProjectScore} from 'sentry/views/insights/browser/webVitals/types';
+import {useCreateIssue} from 'sentry/views/insights/browser/webVitals/utils/useCreateIssue';
+
+// Creates a new issue for each web vital that has a score under 90 and runs seer autofix for each of them
+// TODO: Add logic to actually initiate running autofix for each issue. Right now we rely on the project config to automatically run autofix for each issue.
+export function useRunSeerAnalysis({
+  projectScore,
+  transaction,
+}: {
+  projectScore: ProjectScore;
+  transaction: string;
+}) {
+  const {mutateAsync: createIssueAsync} = useCreateIssue();
+  const invalidateWebVitalsIssuesQuery = useInvalidateWebVitalsIssuesQuery({
+    transaction,
+  });
+
+  const runSeerAnalysis = useCallback(async (): Promise<string[]> => {
+    if (!projectScore) {
+      return [];
+    }
+    const underPerformingWebVitals = ORDER.filter(webVital => {
+      const score = projectScore[`${webVital}Score`];
+      return score && score < 90;
+    });
+    const promises = underPerformingWebVitals.map(async webVital => {
+      try {
+        const result = await createIssueAsync({
+          issueType: IssueType.WEB_VITALS,
+          vital: webVital,
+          score: projectScore[`${webVital}Score`],
+          transaction,
+        });
+        return result.event_id;
+      } catch (error) {
+        // If the issue creation fails, we don't want to fail the entire operation for the rest of the vitals
+        return null;
+      }
+    });
+
+    const results = await Promise.all(promises);
+    invalidateWebVitalsIssuesQuery();
+    return results.filter(id => id !== null);
+  }, [createIssueAsync, projectScore, transaction, invalidateWebVitalsIssuesQuery]);
+
+  return runSeerAnalysis;
+}


### PR DESCRIPTION
Updates the Web Vitals Page Overview sidebar to include a "Run Seer Analysis" button when there is no issue/autofix run created for the page. The button creates an issue for each Web Vital with a score under 90 and runs autofix on them:
- Deletes deprecated "Create Issue" button in individual Web Vital slideouts
- Updates data querying logic for fetching Issues and Autofix runs. The data querying logic now handles two scenarios:
    - Scenario A: When the user clicks the "Run Seer Analysis" to create new issues/autofix run
        - The `/issues` api call now polls until the number of issue results matches the expected number of created issues. (We use polling because issue creation is async)
        - Once all issues are fetched, we start polling `/autofix` for each issue until we reach a non `PROCESSING` state (indicating the autofix run has stopped/finished). We display a root cause description if available during polling.

    - Scenario B: When a user visits the Page Overview page and at least one unresolved web vital issue has been created.
        - `/issues` is only called once.
        - We poll `/autofix` for each existing issue until we reach a non `PROCESSING` state, same as in Scenario A. 

    


<img width="207" height="121" alt="image" src="https://github.com/user-attachments/assets/de6b6dcc-7cb4-44b6-886d-c782e7fd67fb" />
