### PR TITLE
fix(ui): Hide consoles from platforms if not available

### DIFF
--- a/static/app/views/settings/projectGeneralSettings/index.tsx
+++ b/static/app/views/settings/projectGeneralSettings/index.tsx
@@ -308,6 +308,25 @@ function ProjectGeneralSettings({onChangeSlug}: Props) {
     help: t('The unique identifier for this project. It cannot be modified.'),
   };
 
+  const consolePlatforms: ReadonlySet<string> = new Set([
+    'nintendo-switch',
+    'playstation',
+    'xbox',
+  ] as const);
+
+  // Create filtered platform field without mutating the shared fields object
+  const platformField = {
+    ...fields.platform,
+    options: fields.platform.options.filter(({value}) => {
+      if (!consolePlatforms.has(value)) return true;
+
+      return (
+        organization.features?.includes('project-creation-games-tab') &&
+        organization.enabledConsolePlatforms?.includes(value)
+      );
+    }),
+  };
+
   return (
     <div>
       <SentryDocumentTitle title={t('Project Settings')} projectSlug={project.slug} />
@@ -317,7 +336,7 @@ function ProjectGeneralSettings({onChangeSlug}: Props) {
         <JsonForm
           {...jsonFormProps}
           title={t('Project Details')}
-          fields={[fields.name, projectIdField, fields.platform]}
+          fields={[fields.name, projectIdField, platformField]}
         />
         <JsonForm {...jsonFormProps} title={t('Email')} fields={[fields.subjectPrefix]} />
       </Form>


### PR DESCRIPTION
# Motivation
- There was a bug where a user would be able to switch a project's platform to any game consoles, regardless of permission they got from the `admin` page

# Cause
- We did not filter projects by an org's permission.

# Fix
- Filter using org's `enabledConsolePlatforms` to check if we allowed the org to make certain game console projects.
- Only show platforms that they can create.
- Made tests that will test:
  - An org with access to all console platforms
  - An org with no access to any consoles
  - An org with access to just a single console

# Showcase:

Project Settings page > Project Details > platform

Screenshots taken with an org with NO console access.

Before - shows xbox:
<img width="1072" height="692" alt="image" src="https://github.com/user-attachments/assets/7198f7d3-0c15-4724-9fb4-a0df5c03e9e9" />

After - removes xbox:
<img width="1114" height="706" alt="image" src="https://github.com/user-attachments/assets/369f7aa7-3fea-45a8-9bfb-3f81c50caefd" />