### PR TITLE
feat(prevent): send consent URL when no-consent

### DIFF
--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -279,20 +279,25 @@ def get_organization_autofix_consent(*, org_id: int) -> dict:
 # Used by the seer GH app to check for permissions before posting to an org
 def get_organization_seer_consent_by_org_name(
     *, org_name: str, provider: str = "github"
-) -> dict[str, bool]:
+) -> dict[str, bool | str | None]:
     org_integrations = integration_service.get_organization_integrations(
         providers=[provider], name=org_name
     )
 
+    # The URL where an org admin can enable Prevent-AI features
+    # Only returned if the org is not already consented
+    consent_url = None
     for org_integration in org_integrations:
         try:
             org = Organization.objects.get(id=org_integration.organization_id)
             if _can_use_prevent_ai_features(org):
                 return {"consent": True}
+            # If this is the last org we will return this URL as the consent URL
+            consent_url = org.absolute_url("/settings/organization/")
         except Organization.DoesNotExist:
             continue
 
-    return {"consent": False}
+    return {"consent": False, "consent_url": consent_url}
 
 
 def get_attribute_names(*, org_id: int, project_ids: list[int], stats_period: str) -> dict:


### PR DESCRIPTION
ticket: prevent-275

There are some assumptions in these changes:
1. The URL for the settings of an org depends on the `sentry_org.slug`.
2. `github_org_name` is not necessarily the same as `sentry_org.slug`
3. Constructing such URL is non-trivial without the base URL for the Sentry instance
4. It's OK to return _any_ of the valid sentry orgs for a prevent-AI request

So based on those assumptions these changes include the URL for the org settings such that we can slap that URL in the "no consent given" message - that appears if you request `@sentry review` in a PR without giving the consent. We want this to add a clearer Call To Action in that message, making it more useful

**Note:** Point 4 in particular means that we might want to limit the `consent_url` return to cases where there's exactly 1 org found.