### PR TITLE
ref(spans): Future proof insight module project flags

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -652,43 +652,6 @@ class InsightModules(Enum):
     MCP = "mcp"
 
 
-INSIGHT_MODULE_FILTERS = {
-    InsightModules.HTTP: lambda spans: any(
-        span.get("sentry_tags", {}).get("category") == "http" and span.get("op") == "http.client"
-        for span in spans
-    ),
-    InsightModules.DB: lambda spans: any(
-        span.get("sentry_tags", {}).get("category") == "db" and "description" in span.keys()
-        for span in spans
-    ),
-    InsightModules.ASSETS: lambda spans: any(
-        span.get("op") in ["resource.script", "resource.css", "resource.font", "resource.img"]
-        for span in spans
-    ),
-    InsightModules.APP_START: lambda spans: any(
-        span.get("op").startswith("app.start.") for span in spans
-    ),
-    InsightModules.SCREEN_LOAD: lambda spans: any(
-        span.get("sentry_tags", {}).get("transaction.op") == "ui.load" for span in spans
-    ),
-    InsightModules.VITAL: lambda spans: any(
-        span.get("sentry_tags", {}).get("transaction.op") == "pageload" for span in spans
-    ),
-    InsightModules.CACHE: lambda spans: any(
-        span.get("op") in ["cache.get_item", "cache.get", "cache.put"] for span in spans
-    ),
-    InsightModules.QUEUE: lambda spans: any(
-        span.get("op") in ["queue.process", "queue.publish"] for span in spans
-    ),
-    InsightModules.LLM_MONITORING: lambda spans: any(
-        span.get("op").startswith("ai.pipeline") for span in spans
-    ),
-    InsightModules.AGENTS: lambda spans: any(
-        span.get("op").startswith("gen_ai.") for span in spans
-    ),
-    InsightModules.MCP: lambda spans: any(span.get("op").startswith("mcp.") for span in spans),
-}
-
 StatsPeriod = namedtuple("StatsPeriod", ("segments", "interval"))
 
 LEGACY_RATE_LIMIT_OPTIONS = frozenset(("sentry:project-rate-limit", "sentry:account-rate-limit"))

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2626,7 +2626,6 @@ def _record_transaction_info(
                 )
 
             spans = [FilterSpan.from_span_v1(span) for span in job["data"]["spans"]]
-
             for module in insights_modules(spans):
                 set_project_flag_and_signal(
                     project,

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -76,7 +76,7 @@ from sentry.ingest.inbound_filters import FilterStatKeys
 from sentry.ingest.transaction_clusterer.datasource.redis import (
     record_transaction_name as record_transaction_name_for_clustering,
 )
-from sentry.insights import ClassifiableSpan
+from sentry.insights import FilterSpan
 from sentry.insights import modules as insights_modules
 from sentry.integrations.tasks.kick_off_status_syncs import kick_off_status_syncs
 from sentry.issues.issue_occurrence import IssueOccurrence
@@ -2625,15 +2625,7 @@ def _record_transaction_info(
                     event=event,
                 )
 
-            spans = [
-                ClassifiableSpan(
-                    op=span.get("op"),
-                    category=span.get("sentry_tags", {}).get("category"),
-                    description=span.get("description"),
-                    transaction_op=span.get("sentry_tags", {}).get("transaction.op"),
-                )
-                for span in job["data"]["spans"]
-            ]
+            spans = [FilterSpan.from_span_v1(span) for span in job["data"]["spans"]]
 
             for module in insights_modules(spans):
                 set_project_flag_and_signal(

--- a/src/sentry/insights/__init__.py
+++ b/src/sentry/insights/__init__.py
@@ -55,7 +55,7 @@ def is_app_start(span: FilterSpan) -> bool:
 
 
 def is_screen_load(span: FilterSpan) -> bool:
-    return span.category == "ui" and span.transaction_op == "ui.load"
+    return span.transaction_op == "ui.load"
 
 
 def is_vital(span: FilterSpan) -> bool:

--- a/src/sentry/insights/__init__.py
+++ b/src/sentry/insights/__init__.py
@@ -1,0 +1,83 @@
+from typing import NamedTuple
+
+from sentry.constants import InsightModules
+
+
+class ClassifiableSpan(NamedTuple):
+    """Interface for detecting relevant Insights modules for a span.
+
+    Spans in transactions have a different schema than spans from Kafka. Going through this interface
+    makes the classification schema-agnostic.
+    """
+
+    op: str | None
+    category: str | None
+    description: str | None
+    transaction_op: str | None
+
+
+def is_http(span: ClassifiableSpan) -> bool:
+    return span.category == "http" and span.op == "http.client"
+
+
+def is_db(span: ClassifiableSpan) -> bool:
+    return span.category == "db" and span.description is not None
+
+
+def is_assets(span: ClassifiableSpan) -> bool:
+    return span.op in ["resource.script", "resource.css", "resource.font", "resource.img"]
+
+
+def is_app_start(span: ClassifiableSpan) -> bool:
+    return span.op is not None and span.op.startswith("app.start.")
+
+
+def is_screen_load(span: ClassifiableSpan) -> bool:
+    return span.category == "ui" and span.transaction_op == "ui.load"
+
+
+def is_vital(span: ClassifiableSpan) -> bool:
+    return span.transaction_op == "pageload"
+
+
+def is_cache(span: ClassifiableSpan) -> bool:
+    return span.op in ["cache.get_item", "cache.get", "cache.put"]
+
+
+def is_queue(span: ClassifiableSpan) -> bool:
+    return span.op in ["queue.process", "queue.publish"]
+
+
+def is_llm_monitoring(span: ClassifiableSpan) -> bool:
+    return span.op is not None and span.op.startswith("ai.pipeline")
+
+
+def is_agents(span: ClassifiableSpan) -> bool:
+    return span.op is not None and span.op.startswith("gen_ai.")
+
+
+def is_mcp(span: ClassifiableSpan) -> bool:
+    return span.op is not None and span.op.startswith("mcp.")
+
+
+INSIGHT_MODULE_CLASSIFIERS = {
+    InsightModules.HTTP: is_http,
+    InsightModules.DB: is_db,
+    InsightModules.ASSETS: is_assets,
+    InsightModules.APP_START: is_app_start,
+    InsightModules.SCREEN_LOAD: is_screen_load,
+    InsightModules.VITAL: is_vital,
+    InsightModules.CACHE: is_cache,
+    InsightModules.QUEUE: is_queue,
+    InsightModules.LLM_MONITORING: is_llm_monitoring,
+    InsightModules.AGENTS: is_agents,
+    InsightModules.MCP: is_mcp,
+}
+
+
+def modules(spans: list[ClassifiableSpan]) -> set[InsightModules]:
+    return {
+        module
+        for module, is_module in INSIGHT_MODULE_CLASSIFIERS.items()
+        if any(is_module(span) for span in spans)
+    }

--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -261,15 +261,7 @@ def _record_signals(segment_span: Span, spans: list[Span], project: Project) -> 
     )
 
     for module in insights_modules(
-        [
-            FilterSpan(
-                op=span.get("data", {}).get("sentry.op"),
-                category=span.get("data", {}).get("sentry.category"),
-                description=span.get("data", {}).get("sentry.normalized_description"),
-                transaction_op=span.get("data", {}).get("sentry.transaction_op"),
-            )
-            for span in spans
-        ]
+        [FilterSpan.from_span_data(span.get("data", {})) for span in spans]
     ):
         set_project_flag_and_signal(
             project,

--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -8,9 +8,11 @@ from django.core.exceptions import ValidationError
 from sentry_kafka_schemas.schema_types.buffered_segments_v1 import SegmentSpan
 
 from sentry import options
-from sentry.constants import INSIGHT_MODULE_FILTERS, DataCategory
+from sentry.constants import DataCategory
 from sentry.dynamic_sampling.rules.helpers.latest_releases import record_latest_release
 from sentry.event_manager import INSIGHT_MODULE_TO_PROJECT_FLAG_NAME
+from sentry.insights import ClassifiableSpan
+from sentry.insights import modules as insights_modules
 from sentry.issues.grouptype import PerformanceStreamedSpansGroupTypeExperimental
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.issues.producer import PayloadType, produce_occurrence_to_kafka
@@ -258,14 +260,23 @@ def _record_signals(segment_span: Span, spans: list[Span], project: Project) -> 
         event=event_like,
     )
 
-    for module, is_module in INSIGHT_MODULE_FILTERS.items():
-        if is_module(spans):
-            set_project_flag_and_signal(
-                project,
-                INSIGHT_MODULE_TO_PROJECT_FLAG_NAME[module],
-                first_insight_span_received,
-                module=module,
+    for module in insights_modules(
+        [
+            ClassifiableSpan(
+                op=span.get("data", {}).get("sentry.op"),
+                category=span.get("data", {}).get("sentry.category"),
+                description=span.get("data", {}).get("sentry.normalized_description"),
+                transaction_op=span.get("data", {}).get("sentry.transaction_op"),
             )
+            for span in spans
+        ]
+    ):
+        set_project_flag_and_signal(
+            project,
+            INSIGHT_MODULE_TO_PROJECT_FLAG_NAME[module],
+            first_insight_span_received,
+            module=module,
+        )
 
 
 @metrics.wraps("spans.consumers.process_segments.record_outcomes")

--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -11,7 +11,7 @@ from sentry import options
 from sentry.constants import DataCategory
 from sentry.dynamic_sampling.rules.helpers.latest_releases import record_latest_release
 from sentry.event_manager import INSIGHT_MODULE_TO_PROJECT_FLAG_NAME
-from sentry.insights import ClassifiableSpan
+from sentry.insights import FilterSpan
 from sentry.insights import modules as insights_modules
 from sentry.issues.grouptype import PerformanceStreamedSpansGroupTypeExperimental
 from sentry.issues.issue_occurrence import IssueOccurrence
@@ -262,7 +262,7 @@ def _record_signals(segment_span: Span, spans: list[Span], project: Project) -> 
 
     for module in insights_modules(
         [
-            ClassifiableSpan(
+            FilterSpan(
                 op=span.get("data", {}).get("sentry.op"),
                 category=span.get("data", {}).get("sentry.category"),
                 description=span.get("data", {}).get("sentry.normalized_description"),

--- a/tests/sentry/spans/consumers/process_segments/test_message.py
+++ b/tests/sentry/spans/consumers/process_segments/test_message.py
@@ -226,6 +226,10 @@ class TestSpansTask(TestCase):
             is_segment=True,
             span_op="http.client",
             sentry_tags={"category": "http"},
+            data={
+                "sentry.op": "http.client",
+                "sentry.category": "http",
+            },
         )
         spans = process_segment([span])
         assert len(spans) == 1

--- a/tests/sentry/spans/consumers/process_segments/test_message.py
+++ b/tests/sentry/spans/consumers/process_segments/test_message.py
@@ -218,3 +218,17 @@ class TestSpansTask(TestCase):
 
         # Verify track_outcome was called once
         mock_track_outcome.assert_called_once()
+
+    @mock.patch("sentry.spans.consumers.process_segments.message.set_project_flag_and_signal")
+    def test_record_signals(self, mock_track):
+        span = build_mock_span(
+            project_id=self.project.id,
+            is_segment=True,
+            span_op="http.client",
+            sentry_tags={"category": "http"},
+        )
+        spans = process_segment([span])
+        assert len(spans) == 1
+
+        signals = [args[0][1] for args in mock_track.call_args_list]
+        assert signals == ["has_transactions", "has_insights_http"]


### PR DESCRIPTION
We're in the process of aligning the span Kafka schema (`relay -> span buffer`) with the new span V2 schema. To make sure we do not accidentally break signals when the schema changes, introduce an explicit datatype for insight module detection. 

ref: INGEST-530