### PR TITLE
feat(grouping): Exclude RxJava framework exceptions from determining main_exception_id

### DIFF
--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -890,7 +890,11 @@ def react_error_with_cause(exceptions: list[SingleException]) -> int | None:
     return main_exception_id
 
 
-JAVA_RXJAVA_FRAMEWORK_EXCEPTION_TYPES = ["OnErrorNotImplementedException", "CompositeException"]
+JAVA_RXJAVA_FRAMEWORK_EXCEPTION_TYPES = [
+    "OnErrorNotImplementedException",
+    "CompositeException",
+    "UndeliverableException",
+]
 
 
 def java_rxjava_framework_exceptions(exceptions: list[SingleException]) -> int | None:

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -890,8 +890,41 @@ def react_error_with_cause(exceptions: list[SingleException]) -> int | None:
     return main_exception_id
 
 
+JAVA_RXJAVA_FRAMEWORK_EXCEPTION_TYPES = ["OnErrorNotImplementedException", "CompositeException"]
+
+
+def java_rxjava_framework_exceptions(exceptions: list[SingleException]) -> int | None:
+    if len(exceptions) < 2:
+        return None
+
+    # find the wrapped RxJava exception
+    rxjava_exception_id = None
+    for exception in exceptions:
+        if (
+            exception.module == "io.reactivex.rxjava3.exceptions"
+            and exception.type in JAVA_RXJAVA_FRAMEWORK_EXCEPTION_TYPES
+            and exception.mechanism
+            and exception.mechanism.type == "UncaughtExceptionHandler"
+        ):
+            rxjava_exception_id = exception.mechanism.exception_id
+            break
+
+    # return the inner exception, if any
+    if rxjava_exception_id is not None:
+        for exception in exceptions:
+            if (
+                exception.mechanism
+                and exception.mechanism.parent_id == rxjava_exception_id
+                and exception.mechanism.exception_id is not None
+            ):
+                return exception.mechanism.exception_id
+
+    return None
+
+
 MAIN_EXCEPTION_ID_FUNCS = [
     react_error_with_cause,
+    java_rxjava_framework_exceptions,
 ]
 
 

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -251,6 +251,78 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         assert event.group is not None
         assert event.group.title == f"TypeError: {cause_error_value}"
 
+    def test_java_rxjava_on_error_not_implemented_correct_error_title_subtitle(self) -> None:
+        manager = EventManager(
+            make_event(
+                exception={
+                    "values": [
+                        {
+                            "type": "NullPointerException",
+                            "value": "Attempt to read from field 'a.b.c' on a null object",
+                            "module": "java.lang",
+                            "mechanism": {"type": "chained", "exception_id": 1, "parent_id": 0},
+                        },
+                        {
+                            "type": "OnErrorNotImplementedException",
+                            "value": "The exception was not handled due to missing onError handler in the subscribe() method call.",
+                            "module": "io.reactivex.rxjava3.exceptions",
+                            "mechanism": {
+                                "type": "UncaughtExceptionHandler",
+                                "handled": False,
+                                "exception_id": 0,
+                            },
+                        },
+                    ]
+                },
+            )
+        )
+        event = manager.save(self.project.id)
+        assert event.data["metadata"]["type"] == "NullPointerException"
+        assert (
+            event.data["metadata"]["value"] == "Attempt to read from field 'a.b.c' on a null object"
+        )
+        assert event.group is not None
+        assert (
+            event.group.title
+            == "NullPointerException: Attempt to read from field 'a.b.c' on a null object"
+        )
+
+    def test_java_rxjava_composite_exception_correct_error_title_subtitle(self) -> None:
+        manager = EventManager(
+            make_event(
+                exception={
+                    "values": [
+                        {
+                            "type": "NullPointerException",
+                            "value": "Attempt to read from field 'a.b.c' on a null object",
+                            "module": "java.lang",
+                            "mechanism": {"type": "chained", "exception_id": 1, "parent_id": 0},
+                        },
+                        {
+                            "type": "CompositeException",
+                            "value": "Can't call onError because the actual's state may be corrupt at this point.",
+                            "module": "io.reactivex.rxjava3.exceptions",
+                            "mechanism": {
+                                "type": "UncaughtExceptionHandler",
+                                "handled": False,
+                                "exception_id": 0,
+                            },
+                        },
+                    ]
+                },
+            )
+        )
+        event = manager.save(self.project.id)
+        assert event.data["metadata"]["type"] == "NullPointerException"
+        assert (
+            event.data["metadata"]["value"] == "Attempt to read from field 'a.b.c' on a null object"
+        )
+        assert event.group is not None
+        assert (
+            event.group.title
+            == "NullPointerException: Attempt to read from field 'a.b.c' on a null object"
+        )
+
     @mock.patch("sentry.signals.issue_unresolved.send_robust")
     @with_feature("organizations:issue-open-periods")
     def test_unresolve_auto_resolved_group(self, send_robust: mock.MagicMock) -> None:


### PR DESCRIPTION
Similar to RN, the RxJava framework wraps exceptions, hiding the underlying root cause. This special cases two main exceptions and selects the wrapped "inner" exception as the main exception.

Relevant RxJava docs: https://reactivex.io/RxJava/3.x/javadoc/

Other ways to solve this problem would be:
- to allow SDKs to set the `event.main_exception_id` (which SDKs shouldn't do, and it's scrubbed by relay anyway)
- to let the SDK apply the `is_exception_group=true` property on the wrapping exception, although that's probably a mis-use of the property