### PR TITLE
feat(ai): Handle create agent spans in trace view

### DIFF
--- a/static/app/views/insights/agents/components/aiSpanList.tsx
+++ b/static/app/views/insights/agents/components/aiSpanList.tsx
@@ -14,6 +14,7 @@ import {LLMCosts} from 'sentry/views/insights/agents/components/llmCosts';
 import {getIsAiRunNode} from 'sentry/views/insights/agents/utils/aiTraceNodes';
 import {getNodeId} from 'sentry/views/insights/agents/utils/getNodeId';
 import {
+  getIsAiCreateAgentSpan,
   getIsAiGenerationSpan,
   getIsAiRunSpan,
 } from 'sentry/views/insights/agents/utils/query';
@@ -324,6 +325,10 @@ function getNodeInfo(node: AITraceSpanNode, colors: readonly string[]) {
         model
       );
     }
+    nodeInfo.color = colors[0];
+  } else if (getIsAiCreateAgentSpan({op})) {
+    nodeInfo.icon = <IconBot size="md" />;
+    nodeInfo.subtitle = getNodeAttribute('gen_ai.agent.name') || '';
     nodeInfo.color = colors[0];
   } else if (getIsAiGenerationSpan({op})) {
     const tokens = getNodeAttribute(SpanFields.GEN_AI_USAGE_TOTAL_TOKENS);

--- a/static/app/views/insights/agents/utils/query.tsx
+++ b/static/app/views/insights/agents/utils/query.tsx
@@ -27,7 +27,14 @@ export const AI_GENERATION_OPS = [
   'gen_ai.responses',
 ];
 
-const NON_GENERATION_OPS = [...AI_RUN_OPS, 'gen_ai.execute_tool', 'gen_ai.handoff'];
+export const AI_CREATE_AGENT_OPS = ['gen_ai.create_agent'];
+
+const NON_GENERATION_OPS = [
+  ...AI_RUN_OPS,
+  ...AI_CREATE_AGENT_OPS,
+  'gen_ai.execute_tool',
+  'gen_ai.handoff',
+];
 
 export function getIsAiSpan({op = 'default'}: {op?: string}) {
   return op.startsWith('gen_ai.');
@@ -40,6 +47,10 @@ export function getIsAiRunSpan({op = 'default'}: {op?: string}) {
 // All of the gen_ai.* spans that are not agent invocations, handoffs, or tool calls are considered generation spans
 export function getIsAiGenerationSpan({op = 'default'}: {op?: string}) {
   return op.startsWith('gen_ai.') && !NON_GENERATION_OPS.includes(op);
+}
+
+export function getIsAiCreateAgentSpan({op = 'default'}: {op?: string}) {
+  return AI_CREATE_AGENT_OPS.includes(op);
 }
 
 function joinValues(values: string[]) {

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/react';
 
 import {Tooltip} from 'sentry/components/core/tooltip';
 import Count from 'sentry/components/count';
+import {StructuredData} from 'sentry/components/structuredEventData';
 import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import {prettifyAttributeName} from 'sentry/views/explore/components/traceItemAttributes/utils';
@@ -13,12 +14,20 @@ import {
   hasAgentInsightsFeature,
   hasMCPInsightsFeature,
 } from 'sentry/views/insights/agents/utils/features';
-import {getIsAiSpan} from 'sentry/views/insights/agents/utils/query';
+import {AI_CREATE_AGENT_OPS, getIsAiSpan} from 'sentry/views/insights/agents/utils/query';
 
 type HighlightedAttribute = {
   name: string;
   value: React.ReactNode;
 };
+
+function tryParseJson(value: string) {
+  try {
+    return JSON.parse(value);
+  } catch (error) {
+    return value;
+  }
+}
 
 export function getHighlightedSpanAttributes({
   op,
@@ -65,6 +74,14 @@ function getAISpanAttributes(
   op?: string
 ) {
   const highlightedAttributes = [];
+
+  const agentName = attributes['gen_ai.agent.name'];
+  if (agentName) {
+    highlightedAttributes.push({
+      name: t('Agent Name'),
+      value: agentName,
+    });
+  }
 
   const model = attributes['gen_ai.response.model'] || attributes['gen_ai.request.model'];
   if (model) {
@@ -128,6 +145,20 @@ function getAISpanAttributes(
     highlightedAttributes.push({
       name: t('Tool Name'),
       value: toolName,
+    });
+  }
+
+  const availableTools = attributes['gen_ai.request.available_tools'];
+  if (availableTools && AI_CREATE_AGENT_OPS.includes(op!)) {
+    highlightedAttributes.push({
+      name: t('Available Tools'),
+      value: (
+        <StructuredData
+          value={tryParseJson(availableTools.toString())}
+          withAnnotatedText
+          maxDefaultDepth={0}
+        />
+      ),
     });
   }
 


### PR DESCRIPTION
Add handling for `gen_ai.create_agent` spans in agent monitoring.
Highlight agent name and available tools in span details.
Exclude `gen_ai.create_agent` when querying generations.

<img width="1039" height="779" alt="Screenshot 2025-09-02 at 10 15 29" src="https://github.com/user-attachments/assets/3485b414-af6f-431c-8f86-6403bc961eb7" />
