### PR TITLE
ref(spans): Temporarily move indexed span outcomes back to Relay

### DIFF
--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -60,9 +60,10 @@ def process_segment(unprocessed_spans: list[SegmentSpan], skip_produce: bool = F
     _detect_performance_problems(segment_span, spans, project)
     _record_signals(segment_span, spans, project)
 
+    # XXX: This is disabled until the outcomes consumer can be scaled.
     # Only track outcomes if we're actually producing the spans
-    if not skip_produce:
-        _track_outcomes(segment_span, spans)
+    # if not skip_produce:
+    #     _track_outcomes(segment_span, spans)
 
     return spans
 

--- a/tests/sentry/spans/consumers/process_segments/test_message.py
+++ b/tests/sentry/spans/consumers/process_segments/test_message.py
@@ -203,6 +203,7 @@ class TestSpansTask(TestCase):
         assert performance_problem.type == PerformanceStreamedSpansGroupTypeExperimental
 
     @mock.patch("sentry.spans.consumers.process_segments.message.track_outcome")
+    @pytest.mark.skip("temporarily disabled")
     def test_skip_produce_does_not_track_outcomes(self, mock_track_outcome: mock.MagicMock) -> None:
         """Test that outcomes are not tracked when skip_produce=True"""
         spans = self.generate_basic_spans()


### PR DESCRIPTION
Temporarily reverts to tracking accepted outcomes for indexed spans that are sent into the new spans pipeline directly in Relay, instead of tracking them in the segments consumer. This is done to improve aggregation of these outcomes.

See also https://github.com/getsentry/sentry/pull/98584
Requires https://github.com/getsentry/ops/pull/16981