### PR TITLE
feat(agent-monitoring): don't restrict message role names

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
@@ -66,6 +66,16 @@ function parseAIMessages(messages: string): AIMessage[] | string {
               role: 'user' as const,
               content: renderTextMessages(message.content),
             };
+          case 'human':
+            return {
+              role: 'user' as const,
+              content: renderTextMessages(message.content),
+            };
+          case 'ai':
+            return {
+              role: 'assistant' as const,
+              content: renderTextMessages(message.content),
+            };
           case 'assistant':
             return {
               role: 'assistant' as const,

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
@@ -210,14 +210,9 @@ function MessagesArrayRenderer({messages}: {messages: AIMessage[]}) {
   }, [messages.length, previousMessagesLength]);
 
   const renderMessage = (message: AIMessage, index: number) => {
-    // Capitalize first letter of the role
-    const displayRole = message.role.charAt(0).toUpperCase() + message.role.slice(1);
-
     return (
       <Fragment key={index}>
-        <TraceDrawerComponents.MultilineTextLabel>
-          {displayRole}
-        </TraceDrawerComponents.MultilineTextLabel>
+        <RoleLabel>{message.role}</RoleLabel>
         {typeof message.content === 'string' ? (
           <TraceDrawerComponents.MultilineText>
             {message.content}
@@ -248,6 +243,12 @@ function MessagesArrayRenderer({messages}: {messages: AIMessage[]}) {
     </Fragment>
   );
 }
+
+const RoleLabel = styled(TraceDrawerComponents.MultilineTextLabel)`
+  &::first-letter {
+    text-transform: capitalize;
+  }
+`;
 
 const ButtonDivider = styled('div')`
   height: 1px;

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
@@ -21,11 +21,9 @@ import {TraceDrawerComponents} from 'sentry/views/performance/newTraceDetails/tr
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import type {TraceTreeNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode';
 
-type AIMessageRole = string;
-
 interface AIMessage {
   content: React.ReactNode;
-  role: AIMessageRole;
+  role: string;
 }
 
 function renderTextMessages(content: any) {

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
@@ -22,6 +22,14 @@ import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceMode
 import type {TraceTreeNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode';
 
 type AIMessageRole = 'system' | 'user' | 'assistant' | 'tool';
+const roleMapping: Record<string, AIMessageRole> = {
+  ai: 'assistant',
+  human: 'user',
+  assistant: 'assistant',
+  user: 'user',
+  system: 'system',
+  tool: 'tool',
+};
 
 interface AIMessage {
   content: React.ReactNode;
@@ -236,10 +244,11 @@ function MessagesArrayRenderer({messages}: {messages: AIMessage[]}) {
   }, [messages.length, previousMessagesLength]);
 
   const renderMessage = (message: AIMessage, index: number) => {
+    const normalizedRole = roleMapping[message.role] || message.role;
     return (
       <Fragment key={index}>
         <TraceDrawerComponents.MultilineTextLabel>
-          {roleHeadings[message.role]}
+          {roleHeadings[normalizedRole]}
         </TraceDrawerComponents.MultilineTextLabel>
         {typeof message.content === 'string' ? (
           <TraceDrawerComponents.MultilineText>


### PR DESCRIPTION
- Not all tools use the same names for roles in messages (like `user`, `assistant`, `ai`)
- SDKs prefer this to be handled in-product
- This PR adds a normalization of role names to conform with the standard names used in product for consistency reason. 
- Possible negative side effects:
    - Data in Trace view will retain the original name and therefore possibly differ from the AI Agents view
