### PR TITLE
fix(mcp-insights): Fix links to explore

### DIFF
--- a/static/app/views/insights/mcp/components/groupedDurationWidget.tsx
+++ b/static/app/views/insights/mcp/components/groupedDurationWidget.tsx
@@ -98,8 +98,7 @@ export default function GroupedDurationWidget(props: GroupedDurationWidgetProps)
         plottables: timeSeries.map(
           (ts, index) =>
             new Line(convertSeriesToTimeseries(ts), {
-              color:
-                ts.seriesName === 'Other' ? theme.chart.neutral : colorPalette[index],
+              color: ts.seriesName === 'Other' ? theme.chartOther : colorPalette[index],
               alias: ts.seriesName,
             })
         ),
@@ -142,7 +141,7 @@ export default function GroupedDurationWidget(props: GroupedDurationWidgetProps)
               mode: Mode.AGGREGATE,
               visualize: [
                 {
-                  chartType: ChartType.BAR,
+                  chartType: ChartType.LINE,
                   yAxes: ['avg(span.duration)'],
                 },
               ],

--- a/static/app/views/insights/mcp/components/groupedErrorRateWidget.tsx
+++ b/static/app/views/insights/mcp/components/groupedErrorRateWidget.tsx
@@ -6,7 +6,7 @@ import {ExternalLink} from 'sentry/components/core/link';
 import {t, tct} from 'sentry/locale';
 import {formatPercentage} from 'sentry/utils/number/formatPercentage';
 import useOrganization from 'sentry/utils/useOrganization';
-import {Bars} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/bars';
+import {Line} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/line';
 import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
@@ -97,11 +97,9 @@ export default function GroupedErrorRateWidget(props: GroupedErrorRateWidgetProp
         showLegend: 'never',
         plottables: timeSeries.map(
           (ts, index) =>
-            new Bars(convertSeriesToTimeseries(ts), {
-              color:
-                ts.seriesName === 'Other' ? theme.chart.neutral : colorPalette[index],
+            new Line(convertSeriesToTimeseries(ts), {
+              color: ts.seriesName === 'Other' ? theme.chartOther : colorPalette[index],
               alias: ts.seriesName,
-              stack: 'stack',
             })
         ),
       }}
@@ -143,7 +141,7 @@ export default function GroupedErrorRateWidget(props: GroupedErrorRateWidgetProp
               mode: Mode.AGGREGATE,
               visualize: [
                 {
-                  chartType: ChartType.BAR,
+                  chartType: ChartType.LINE,
                   yAxes: ['failure_rate()'],
                 },
               ],

--- a/static/app/views/insights/mcp/components/mcpPromptsTable.tsx
+++ b/static/app/views/insights/mcp/components/mcpPromptsTable.tsx
@@ -151,6 +151,7 @@ function McpPromptCell({prompt}: {prompt: string}) {
         yAxes: ['count(span.duration)'],
       },
     ],
+    field: ['span.description', 'span.status', 'span.duration', 'timestamp'],
     query: `span.op:mcp.server ${SpanFields.MCP_PROMPT_NAME}:"${prompt}"`,
     sort: `-count(span.duration)`,
   });

--- a/static/app/views/insights/mcp/components/mcpResourcesTable.tsx
+++ b/static/app/views/insights/mcp/components/mcpResourcesTable.tsx
@@ -151,6 +151,7 @@ function McpResourceCell({resource}: {resource: string}) {
         yAxes: ['count(span.duration)'],
       },
     ],
+    field: ['span.description', 'span.status', 'span.duration', 'timestamp'],
     query: `span.op:mcp.server ${SpanFields.MCP_RESOURCE_URI}:"${resource}"`,
     sort: `-count(span.duration)`,
   });

--- a/static/app/views/insights/pages/platform/shared/baseTrafficWidget.tsx
+++ b/static/app/views/insights/pages/platform/shared/baseTrafficWidget.tsx
@@ -106,7 +106,7 @@ export function BaseTrafficWidget({
             showCreateAlert
             referrer={referrer}
             exploreParams={{
-              mode: Mode.AGGREGATE,
+              mode: Mode.SAMPLES,
               visualize: [
                 {
                   chartType: ChartType.BAR,
@@ -115,6 +115,7 @@ export function BaseTrafficWidget({
               ],
               groupBy: ['trace.status'],
               sort: '-count(span.duration)',
+              field: ['span.description', 'trace.status', 'span.duration', 'timestamp'],
               query,
               interval: pageFilterChartParams.interval,
             }}


### PR DESCRIPTION
Switch grouped error rate widgets to use lines instead of bars.
Ensure line charts are are opened as line charts in explore.
Use darker color for other line series as it was barely visible before.
<img width="1048" height="273" alt="Screenshot 2025-09-02 at 14 09 25" src="https://github.com/user-attachments/assets/69403777-6186-47fb-be62-041e5399eba8" />
