### PR TITLE
ref(analytics): introduce EventEnvelope class to store timestamp and UUID of an event to not clash with any fields

### DIFF
--- a/src/sentry/analytics/__init__.py
+++ b/src/sentry/analytics/__init__.py
@@ -35,7 +35,7 @@ backend = LazyServiceWrapper(
 )
 
 record = backend.record
-record_event = backend.record_event
+record_event_envelope = backend.record_event_envelope
 register = default_manager.register
 setup = backend.setup
 validate = backend.validate

--- a/src/sentry/analytics/base.py
+++ b/src/sentry/analytics/base.py
@@ -4,7 +4,7 @@ import abc
 from typing import Any, overload
 from warnings import deprecated
 
-from sentry.analytics.event import Event
+from sentry.analytics.event import Event, EventEnvelope
 from sentry.utils.services import Service
 
 from .event_manager import default_manager
@@ -18,7 +18,7 @@ class Analytics(Service, abc.ABC):
     event_manager = default_manager
 
     @overload
-    def record(self, event_or_type: Event) -> None:
+    def record(self, event_or_envelope_or_type: Event) -> None:
         """
         Record an event. Must be an instance of a subclass of `Event`.
 
@@ -32,8 +32,28 @@ class Analytics(Service, abc.ABC):
         ...
 
     @overload
+    def record(self, event_or_envelope_or_type: EventEnvelope) -> None:
+        """
+        Record an event. Must be an instance of a subclass of `Event`.
+
+        >>> analytics.record(
+        ...     EventEnvelope(
+        ...         event=MyEvent(
+        ...             some_id=123,
+        ...             some_prop="abc"
+        ...         ),
+        ...         datetime=datetime.now(),
+        ...         uuid=uuid.uuid4(),
+        ...     )
+        ... )
+        """
+        ...
+
+    @overload
     @deprecated("Use the `record` method with an event class instead.")
-    def record(self, event_or_type: str, instance: Any | None = None, **kwargs: Any) -> None:
+    def record(
+        self, event_or_envelope_or_type: str, instance: Any | None = None, **kwargs: Any
+    ) -> None:
         """
         Record an event, using its `type` name and kwargs. Deprecated, the version of this function
         where an event is directly passed is preferred, as it is more type-safe.
@@ -46,16 +66,29 @@ class Analytics(Service, abc.ABC):
         """
         ...
 
-    def record(self, event_or_type: Event | str, instance: Any = None, **kwargs: Any) -> None:
-        if isinstance(event_or_type, str):
-            event_cls = self.event_manager.get(event_or_type)
+    def record(
+        self,
+        event_or_envelope_or_type: EventEnvelope | Event | str,
+        instance: Any = None,
+        **kwargs: Any,
+    ) -> None:
+        envelope: EventEnvelope | None = None
+        if isinstance(event_or_envelope_or_type, str):
+            event_cls = self.event_manager.get(event_or_envelope_or_type)
             event = event_cls.from_instance(instance, **kwargs)
+        elif isinstance(event_or_envelope_or_type, Event):
+            event = event_or_envelope_or_type
+        elif isinstance(event_or_envelope_or_type, EventEnvelope):
+            envelope = event_or_envelope_or_type
         else:
-            event = event_or_type
+            raise ValueError("Invalid event or type")
 
-        self.record_event(event)
+        if envelope is None:
+            envelope = EventEnvelope(event=event)
 
-    def record_event(self, event: Event) -> None:
+        self.record_event_envelope(envelope)
+
+    def record_event_envelope(self, envelope: EventEnvelope) -> None:
         pass
 
     def setup(self) -> None:

--- a/src/sentry/analytics/base.py
+++ b/src/sentry/analytics/base.py
@@ -18,7 +18,7 @@ class Analytics(Service, abc.ABC):
     event_manager = default_manager
 
     @overload
-    def record(self, event_or_envelope_or_type: Event) -> None:
+    def record(self, event_or_type: Event) -> None:
         """
         Record an event. Must be an instance of a subclass of `Event`.
 
@@ -32,28 +32,8 @@ class Analytics(Service, abc.ABC):
         ...
 
     @overload
-    def record(self, event_or_envelope_or_type: EventEnvelope) -> None:
-        """
-        Record an event. Must be an instance of a subclass of `Event`.
-
-        >>> analytics.record(
-        ...     EventEnvelope(
-        ...         event=MyEvent(
-        ...             some_id=123,
-        ...             some_prop="abc"
-        ...         ),
-        ...         datetime=datetime.now(),
-        ...         uuid=uuid.uuid4(),
-        ...     )
-        ... )
-        """
-        ...
-
-    @overload
     @deprecated("Use the `record` method with an event class instead.")
-    def record(
-        self, event_or_envelope_or_type: str, instance: Any | None = None, **kwargs: Any
-    ) -> None:
+    def record(self, event_or_type: str, instance: Any | None = None, **kwargs: Any) -> None:
         """
         Record an event, using its `type` name and kwargs. Deprecated, the version of this function
         where an event is directly passed is preferred, as it is more type-safe.
@@ -68,25 +48,17 @@ class Analytics(Service, abc.ABC):
 
     def record(
         self,
-        event_or_envelope_or_type: EventEnvelope | Event | str,
+        event_or_type: Event | str,
         instance: Any = None,
         **kwargs: Any,
     ) -> None:
-        envelope: EventEnvelope | None = None
-        if isinstance(event_or_envelope_or_type, str):
-            event_cls = self.event_manager.get(event_or_envelope_or_type)
+        if isinstance(event_or_type, str):
+            event_cls = self.event_manager.get(event_or_type)
             event = event_cls.from_instance(instance, **kwargs)
-        elif isinstance(event_or_envelope_or_type, Event):
-            event = event_or_envelope_or_type
-        elif isinstance(event_or_envelope_or_type, EventEnvelope):
-            envelope = event_or_envelope_or_type
         else:
-            raise ValueError("Invalid event or type")
+            event = event_or_type
 
-        if envelope is None:
-            envelope = EventEnvelope(event=event)
-
-        self.record_event_envelope(envelope)
+        self.record_event_envelope(EventEnvelope(event=event))
 
     def record_event_envelope(self, envelope: EventEnvelope) -> None:
         pass

--- a/src/sentry/analytics/event.py
+++ b/src/sentry/analytics/event.py
@@ -84,16 +84,14 @@ class Event:
     # the type of the event, used for serialization and matching. Can be None for abstract base event classes
     type: ClassVar[str | None]
 
-    # we use the _ postfix to avoid name conflicts inheritors fields
-    uuid_: UUID = Field(default_factory=lambda: uuid1())
-    datetime_: dt = Field(default_factory=timezone.now)
-
     # TODO: this is the "old-style" attributes and data. Will be removed once all events are migrated to the new style.
     attributes: ClassVar[Sequence[Attribute] | None] = None
     data: dict[str, Any] | None = field(repr=False, init=False, default=None)
 
     def serialize(self) -> dict[str, Any]:
-        return serialize_event(self)
+        if self.data is None:
+            self.data = {k: v for k, v in asdict(self).items() if k not in ("type", "data")}
+        return self.data
 
     @classmethod
     # @deprecated("This constructor function is discouraged, as it is not type-safe.")
@@ -112,29 +110,31 @@ class Event:
         attrs: dict[str, Any] = {
             f.name: kwargs.get(f.name, getattr(instance, f.name, None))
             for f in fields(cls)
-            if f.name
-            not in (
-                "type",
-                "uuid_",
-                "datetime_",
-                "data",  # TODO: remove this data field once migrated
-            )
+            if f.name not in ("type", "data")
         }
         return cls(**attrs)
 
 
-def serialize_event(event: Event) -> dict[str, Any]:
+@dataclass()
+class EventEnvelope:
+    """
+    An event envelope, adding an identifier and a timestamp for a recorded event
+    """
+
+    event: Event
+    uuid: UUID = Field(default_factory=lambda: uuid1())
+    datetime: dt = Field(default_factory=timezone.now)
+
+    def serialize(self) -> dict[str, Any]:
+        return serialize_event_envelope(self)
+
+
+def serialize_event_envelope(envelope: EventEnvelope) -> dict[str, Any]:
     # TODO: this is the "old-style" attributes based serializer. Once all events are migrated to the new style,
     # we can remove this.
-    if event.data is None:
-        event.data = {
-            k: v
-            for k, v in asdict(event).items()
-            if k not in ("type", "uuid_", "datetime_", "data")
-        }
     return {
-        "type": event.type,
-        "uuid": b64encode(event.uuid_.bytes),
-        "timestamp": event.datetime_.timestamp(),
-        "data": event.data,
+        "type": envelope.event.type,
+        "uuid": b64encode(envelope.uuid.bytes),
+        "timestamp": envelope.datetime.timestamp(),
+        "data": envelope.event.serialize(),
     }

--- a/src/sentry/analytics/pubsub.py
+++ b/src/sentry/analytics/pubsub.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from sentry.analytics.event import EventEnvelope
+
 __all__ = ("PubSubAnalytics",)
 
 import logging
@@ -9,7 +11,7 @@ from google.auth.exceptions import GoogleAuthError
 
 from sentry.utils.json import dumps
 
-from . import Analytics, Event
+from . import Analytics
 
 logger = logging.getLogger(__name__)
 
@@ -36,6 +38,6 @@ class PubSubAnalytics(Analytics):
         else:
             self.topic = self.publisher.topic_path(project, topic)
 
-    def record_event(self, event: Event) -> None:
+    def record_event_envelope(self, event: EventEnvelope) -> None:
         if self.publisher is not None:
             self.publisher.publish(self.topic, data=dumps(event.serialize()).encode("utf-8"))

--- a/src/sentry/testutils/helpers/analytics.py
+++ b/src/sentry/testutils/helpers/analytics.py
@@ -42,7 +42,7 @@ def assert_analytics_events_recorded(
     expected_events: list[Event],
     exclude_fields: list[str] | None = None,
 ) -> None:
-    recorded_events = [call.args[0] for call in mock_record.call_args_list]
+    recorded_events = get_all_analytics_events(mock_record)
     assert len(expected_events) == len(recorded_events)
     for expected_event, recorded_event in zip(expected_events, recorded_events):
         assert_event_equal(expected_event, recorded_event, exclude_fields)
@@ -82,7 +82,7 @@ def assert_not_analytics_event(
     exclude_fields: list[str] | None = None,
 ) -> None:
     """Assert that an analytics event (either specific instance or type) was not recorded"""
-    recorded_events = [call.args[0] for call in mock_record.call_args_list]
+    recorded_events = get_all_analytics_events(mock_record)
     for recorded_event in recorded_events:
         if isinstance(watched_event, type):
             if isinstance(recorded_event, watched_event):

--- a/src/sentry/testutils/helpers/analytics.py
+++ b/src/sentry/testutils/helpers/analytics.py
@@ -3,21 +3,15 @@ from collections.abc import Generator
 from dataclasses import fields
 from unittest.mock import MagicMock, patch
 
-from sentry.analytics.event import Event, EventEnvelope
-
-
-def maybe_unwrap_event_envelope(event_or_envelope: Event | EventEnvelope) -> Event:
-    if isinstance(event_or_envelope, EventEnvelope):
-        return event_or_envelope.event
-    return event_or_envelope
+from sentry.analytics.event import Event
 
 
 def get_last_analytics_event(mock_record: MagicMock) -> Event:
-    return maybe_unwrap_event_envelope(mock_record.call_args_list[-1].args[0])
+    return mock_record.call_args_list[-1].args[0].event
 
 
 def get_all_analytics_events(mock_record: MagicMock) -> list[Event]:
-    return [maybe_unwrap_event_envelope(call.args[0]) for call in mock_record.call_args_list]
+    return [call.args[0].event for call in mock_record.call_args_list]
 
 
 def assert_event_equal(

--- a/src/sentry/testutils/helpers/analytics.py
+++ b/src/sentry/testutils/helpers/analytics.py
@@ -7,11 +7,11 @@ from sentry.analytics.event import Event
 
 
 def get_last_analytics_event(mock_record: MagicMock) -> Event:
-    return mock_record.call_args_list[-1].args[0].event
+    return mock_record.call_args_list[-1].args[0]
 
 
 def get_all_analytics_events(mock_record: MagicMock) -> list[Event]:
-    return [call.args[0].event for call in mock_record.call_args_list]
+    return [call.args[0] for call in mock_record.call_args_list]
 
 
 def assert_event_equal(

--- a/src/sentry/testutils/helpers/analytics.py
+++ b/src/sentry/testutils/helpers/analytics.py
@@ -3,14 +3,26 @@ from collections.abc import Generator
 from dataclasses import fields
 from unittest.mock import MagicMock, patch
 
-from sentry.analytics.event import Event
+from sentry.analytics.event import Event, EventEnvelope
+
+
+def maybe_unwrap_event_envelope(event_or_envelope: Event | EventEnvelope) -> Event:
+    if isinstance(event_or_envelope, EventEnvelope):
+        return event_or_envelope.event
+    return event_or_envelope
+
+
+def get_last_analytics_event(mock_record: MagicMock) -> Event:
+    return maybe_unwrap_event_envelope(mock_record.call_args_list[-1].args[0])
+
+
+def get_all_analytics_events(mock_record: MagicMock) -> list[Event]:
+    return [maybe_unwrap_event_envelope(call.args[0]) for call in mock_record.call_args_list]
 
 
 def assert_event_equal(
     expected_event: Event,
     recorded_event: Event,
-    check_uuid: bool = False,
-    check_datetime: bool = False,
     exclude_fields: list[str] | None = None,
 ) -> None:
     if type(expected_event) is not type(recorded_event):
@@ -20,10 +32,6 @@ def assert_event_equal(
 
     assert expected_event.type == recorded_event.type
     for field in fields(expected_event):
-        if field.name == "uuid_" and not check_uuid:
-            continue
-        if field.name == "datetime_" and not check_datetime:
-            continue
         if exclude_fields and field.name in exclude_fields:
             continue
         assert getattr(expected_event, field.name) == getattr(recorded_event, field.name)
@@ -32,34 +40,22 @@ def assert_event_equal(
 def assert_analytics_events_recorded(
     mock_record: MagicMock,
     expected_events: list[Event],
-    check_uuid: bool = False,
-    check_datetime: bool = False,
     exclude_fields: list[str] | None = None,
 ) -> None:
     recorded_events = [call.args[0] for call in mock_record.call_args_list]
     assert len(expected_events) == len(recorded_events)
     for expected_event, recorded_event in zip(expected_events, recorded_events):
-        assert_event_equal(
-            expected_event, recorded_event, check_uuid, check_datetime, exclude_fields
-        )
-
-
-def get_last_analytics_event(mock_record: MagicMock) -> Event:
-    return mock_record.call_args_list[-1].args[0]
+        assert_event_equal(expected_event, recorded_event, exclude_fields)
 
 
 def assert_last_analytics_event(
     mock_record: MagicMock,
     expected_event: Event,
-    check_uuid: bool = False,
-    check_datetime: bool = False,
     exclude_fields: list[str] | None = None,
 ) -> None:
     assert_event_equal(
         expected_event,
         get_last_analytics_event(mock_record),
-        check_uuid,
-        check_datetime,
         exclude_fields,
     )
 
@@ -67,16 +63,12 @@ def assert_last_analytics_event(
 def assert_any_analytics_event(
     mock_record: MagicMock,
     expected_event: Event,
-    check_uuid: bool = False,
-    check_datetime: bool = False,
     exclude_fields: list[str] | None = None,
 ) -> None:
-    recorded_events = [call.args[0] for call in mock_record.call_args_list]
+    recorded_events = get_all_analytics_events(mock_record)
     for recorded_event in recorded_events:
         try:
-            assert_event_equal(
-                expected_event, recorded_event, check_uuid, check_datetime, exclude_fields
-            )
+            assert_event_equal(expected_event, recorded_event, exclude_fields)
             return
         except AssertionError:
             pass
@@ -87,8 +79,6 @@ def assert_any_analytics_event(
 def assert_not_analytics_event(
     mock_record: MagicMock,
     watched_event: Event | type[Event],
-    check_uuid: bool = False,
-    check_datetime: bool = False,
     exclude_fields: list[str] | None = None,
 ) -> None:
     """Assert that an analytics event (either specific instance or type) was not recorded"""
@@ -99,9 +89,7 @@ def assert_not_analytics_event(
                 raise AssertionError(f"Event {recorded_event} should not have been recorded")
         else:
             try:
-                assert_event_equal(
-                    watched_event, recorded_event, check_uuid, check_datetime, exclude_fields
-                )
+                assert_event_equal(watched_event, recorded_event, exclude_fields)
             except AssertionError:
                 pass
             else:
@@ -111,8 +99,6 @@ def assert_not_analytics_event(
 @contextlib.contextmanager
 def assert_analytics_events(
     expected_events: list[Event],
-    check_uuid: bool = False,
-    check_datetime: bool = False,
     exclude_fields: list[str] | None = None,
 ) -> Generator[None]:
     """
@@ -125,6 +111,4 @@ def assert_analytics_events(
     """
     with patch("sentry.analytics.record") as mock_record:
         yield
-        assert_analytics_events_recorded(
-            mock_record, expected_events, check_uuid, check_datetime, exclude_fields
-        )
+        assert_analytics_events_recorded(mock_record, expected_events, exclude_fields)

--- a/tests/sentry/analytics/test_base.py
+++ b/tests/sentry/analytics/test_base.py
@@ -1,14 +1,17 @@
 from sentry.analytics import Analytics
+from sentry.analytics.event import EventEnvelope
 from sentry.testutils.cases import TestCase
 
 
 class DummyAnalytics(Analytics):
     def __init__(self):
         self.events = []
+        self.event_envelopes = []
         super().__init__()
 
-    def record_event(self, event):
-        self.events.append(event)
+    def record_event_envelope(self, envelope: EventEnvelope):
+        self.event_envelopes.append(envelope)
+        self.events.append(envelope.event)
 
 
 class AnalyticsTest(TestCase):
@@ -18,10 +21,11 @@ class AnalyticsTest(TestCase):
         provider.record("organization.created", organization)
         assert len(provider.events) == 1
         event = provider.events.pop(0)
+        envelope = provider.event_envelopes.pop(0)
+        assert envelope.datetime
         assert event.type == "organization.created"
-        assert event.datetime_
-        assert event.serialize()["data"]["slug"] == organization.slug
-        assert not event.serialize()["data"]["actor_id"]
+        assert event.slug == organization.slug
+        assert not event.actor_id
 
     def test_record_with_attrs(self) -> None:
         organization = self.create_organization()
@@ -29,7 +33,8 @@ class AnalyticsTest(TestCase):
         provider.record("organization.created", organization, actor_id=1)
         assert len(provider.events) == 1
         event = provider.events.pop(0)
+        envelope = provider.event_envelopes.pop(0)
         assert event.type == "organization.created"
-        assert event.datetime_
-        assert event.serialize()["data"]["slug"] == organization.slug
-        assert event.serialize()["data"]["actor_id"] == 1
+        assert envelope.datetime
+        assert event.slug == organization.slug
+        assert event.actor_id == 1

--- a/tests/sentry/analytics/test_event.py
+++ b/tests/sentry/analytics/test_event.py
@@ -6,6 +6,7 @@ import pytest
 
 from sentry.analytics import Event, eventclass
 from sentry.analytics.attribute import Attribute
+from sentry.analytics.event import EventEnvelope
 from sentry.testutils.cases import TestCase
 
 
@@ -35,12 +36,16 @@ class EventTest(TestCase):
     def test_simple(self, mock_uuid1: MagicMock) -> None:
         mock_uuid1.return_value = self.get_mock_uuid()
 
-        result = ExampleEvent(
-            id="1",  # type: ignore[arg-type]
-            map={"key": "value"},
-            optional=False,
+        result = EventEnvelope(
+            event=ExampleEvent(
+                id="1",  # type: ignore[arg-type]
+                map={"key": "value"},
+                optional=False,
+            ),
+            datetime=datetime(2001, 4, 18, tzinfo=timezone.utc),
         )
-        result.datetime_ = datetime(2001, 4, 18, tzinfo=timezone.utc)
+
+        result.datetime = datetime(2001, 4, 18, tzinfo=timezone.utc)
 
         assert result.serialize() == {
             "data": {
@@ -57,13 +62,15 @@ class EventTest(TestCase):
     def test_simple_from_instance(self, mock_uuid1: MagicMock) -> None:
         mock_uuid1.return_value = self.get_mock_uuid()
 
-        result = ExampleEvent.from_instance(
-            None,
-            id="1",
-            map={"key": "value"},
-            optional=False,
+        result = EventEnvelope(
+            ExampleEvent.from_instance(
+                None,
+                id="1",
+                map={"key": "value"},
+                optional=False,
+            )
         )
-        result.datetime_ = datetime(2001, 4, 18, tzinfo=timezone.utc)
+        result.datetime = datetime(2001, 4, 18, tzinfo=timezone.utc)
 
         assert result.serialize() == {
             "data": {
@@ -80,13 +87,15 @@ class EventTest(TestCase):
     def test_simple_old_style(self, mock_uuid1: MagicMock) -> None:
         mock_uuid1.return_value = self.get_mock_uuid()
 
-        result = ExampleEventOldStyle.from_instance(
-            None,
-            id="1",
-            map={"key": "value"},
-            optional=False,
+        result = EventEnvelope(
+            ExampleEventOldStyle.from_instance(
+                None,
+                id="1",
+                map={"key": "value"},
+                optional=False,
+            )
         )
-        result.datetime_ = datetime(2001, 4, 18, tzinfo=timezone.utc)
+        result.datetime = datetime(2001, 4, 18, tzinfo=timezone.utc)
 
         assert result.serialize() == {
             "data": {
@@ -101,7 +110,7 @@ class EventTest(TestCase):
 
     def test_optional_is_optional(self) -> None:
         result = ExampleEvent(id="1", map={"key": "value"})  # type: ignore[arg-type]
-        assert result.serialize()["data"] == {"id": 1, "map": {"key": "value"}, "optional": None}
+        assert result.serialize() == {"id": 1, "map": {"key": "value"}, "optional": None}
 
     def test_required_cannot_be_none(self) -> None:
         with pytest.raises(TypeError):
@@ -113,4 +122,4 @@ class EventTest(TestCase):
 
     def test_map_with_instance(self) -> None:
         result = ExampleEvent(id="1", map=DummyType())  # type: ignore[arg-type]
-        assert result.serialize()["data"]["map"] == {"key": "value"}
+        assert result.serialize()["map"] == {"key": "value"}

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -105,7 +105,9 @@ pytestmark = [pytest.mark.sentry_metrics]
 class CreateIncidentTest(TestCase):
     @pytest.fixture(autouse=True)
     def _patch_record_event(self):
-        with mock.patch("sentry.analytics.base.Analytics.record_event") as self.record_event:
+        with mock.patch(
+            "sentry.analytics.base.Analytics.record_event_envelope"
+        ) as self.record_event:
             yield
 
     def test_simple(self) -> None:
@@ -150,7 +152,7 @@ class CreateIncidentTest(TestCase):
             == 1
         )
         assert len(self.record_event.call_args_list) == 1
-        event = self.record_event.call_args[0][0]
+        event = self.record_event.call_args[0][0].event
         assert isinstance(event, IncidentCreatedEvent)
         assert event.data == {
             "organization_id": str(self.organization.id),
@@ -163,7 +165,9 @@ class CreateIncidentTest(TestCase):
 class UpdateIncidentStatus(TestCase):
     @pytest.fixture(autouse=True)
     def _patch_record_event(self):
-        with mock.patch("sentry.analytics.base.Analytics.record_event") as self.record_event:
+        with mock.patch(
+            "sentry.analytics.base.Analytics.record_event_envelope"
+        ) as self.record_event:
             yield
 
     def get_most_recent_incident_activity(self, incident):
@@ -194,7 +198,7 @@ class UpdateIncidentStatus(TestCase):
         assert activity.previous_value == str(prev_status)
 
         assert len(self.record_event.call_args_list) == 1
-        event = self.record_event.call_args[0][0]
+        event = self.record_event.call_args[0][0].event
         assert isinstance(event, IncidentStatusUpdatedEvent)
         assert event.data == {
             "organization_id": str(self.organization.id),


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/TET-809/analytics-investigate-potential-attribute-clash-with-baseinherited