### PR TITLE
 fix(insights): `transaction.op:all` filter applied from frontend

### DIFF
--- a/static/app/views/insights/pages/frontend/frontendOverviewTable.tsx
+++ b/static/app/views/insights/pages/frontend/frontendOverviewTable.tsx
@@ -21,6 +21,7 @@ import {StarredSegmentCell} from 'sentry/views/insights/common/components/tableC
 import {QueryParameterNames} from 'sentry/views/insights/common/views/queryParameters';
 import {DataTitles} from 'sentry/views/insights/common/views/spans/types';
 import {StyledIconStar} from 'sentry/views/insights/pages/backend/backendTable';
+import {getSpanOpFromQuery} from 'sentry/views/insights/pages/frontend/newFrontendOverviewPage';
 import {SPAN_OP_QUERY_PARAM} from 'sentry/views/insights/pages/frontend/settings';
 import {TransactionCell} from 'sentry/views/insights/pages/transactionCell';
 import type {SpanResponse} from 'sentry/views/insights/types';
@@ -226,7 +227,8 @@ function renderBodyCell(
   organization: Organization,
   theme: Theme
 ) {
-  const spanOp = decodeScalar(location.query?.[SPAN_OP_QUERY_PARAM]);
+  const spanOp = getSpanOpFromQuery(decodeScalar(location.query?.[SPAN_OP_QUERY_PARAM]));
+
   if (!meta?.fields) {
     return row[column.key];
   }
@@ -236,7 +238,7 @@ function renderBodyCell(
       <TransactionCell
         project={row.project}
         transaction={row.transaction}
-        transactionMethod={spanOp}
+        transactionMethod={spanOp === 'all' ? undefined : spanOp}
       />
     );
   }

--- a/static/app/views/insights/pages/frontend/frontendOverviewTable.tsx
+++ b/static/app/views/insights/pages/frontend/frontendOverviewTable.tsx
@@ -21,8 +21,8 @@ import {StarredSegmentCell} from 'sentry/views/insights/common/components/tableC
 import {QueryParameterNames} from 'sentry/views/insights/common/views/queryParameters';
 import {DataTitles} from 'sentry/views/insights/common/views/spans/types';
 import {StyledIconStar} from 'sentry/views/insights/pages/backend/backendTable';
-import {getSpanOpFromQuery} from 'sentry/views/insights/pages/frontend/newFrontendOverviewPage';
 import {SPAN_OP_QUERY_PARAM} from 'sentry/views/insights/pages/frontend/settings';
+import {getSpanOpFromQuery} from 'sentry/views/insights/pages/frontend/utils/pageSpanOp';
 import {TransactionCell} from 'sentry/views/insights/pages/transactionCell';
 import type {SpanResponse} from 'sentry/views/insights/types';
 

--- a/static/app/views/insights/pages/frontend/newFrontendOverviewPage.tsx
+++ b/static/app/views/insights/pages/frontend/newFrontendOverviewPage.tsx
@@ -229,7 +229,7 @@ const isPageSpanOp = (op?: string): op is PageSpanOps => {
   return PAGE_SPAN_OPS.includes(op as PageSpanOps);
 };
 
-const getSpanOpFromQuery = (op?: string): PageSpanOps => {
+export const getSpanOpFromQuery = (op?: string): PageSpanOps => {
   if (isPageSpanOp(op)) {
     return op;
   }

--- a/static/app/views/insights/pages/frontend/newFrontendOverviewPage.tsx
+++ b/static/app/views/insights/pages/frontend/newFrontendOverviewPage.tsx
@@ -42,12 +42,11 @@ import {useFrontendTableData} from 'sentry/views/insights/pages/frontend/queries
 import type {PageSpanOps} from 'sentry/views/insights/pages/frontend/settings';
 import {
   DEFAULT_SORT,
-  DEFAULT_SPAN_OP_SELECTION,
   FRONTEND_LANDING_TITLE,
-  PAGE_SPAN_OPS,
   SPAN_OP_QUERY_PARAM,
 } from 'sentry/views/insights/pages/frontend/settings';
 import {useFrontendQuery} from 'sentry/views/insights/pages/frontend/useFrontendQuery';
+import {getSpanOpFromQuery} from 'sentry/views/insights/pages/frontend/utils/pageSpanOp';
 import {InsightsSpanTagProvider} from 'sentry/views/insights/pages/insightsSpanTagProvider';
 import {WebVitalsWidget} from 'sentry/views/insights/pages/platform/nextjs/webVitalsWidget';
 import {TransactionNameSearchBar} from 'sentry/views/insights/pages/transactionNameSearchBar';
@@ -224,17 +223,6 @@ export function NewFrontendOverviewPage() {
     </Feature>
   );
 }
-
-const isPageSpanOp = (op?: string): op is PageSpanOps => {
-  return PAGE_SPAN_OPS.includes(op as PageSpanOps);
-};
-
-export const getSpanOpFromQuery = (op?: string): PageSpanOps => {
-  if (isPageSpanOp(op)) {
-    return op;
-  }
-  return DEFAULT_SPAN_OP_SELECTION;
-};
 
 const StyledTransactionNameSearchBar = styled(TransactionNameSearchBar)`
   flex: 2;

--- a/static/app/views/insights/pages/frontend/utils/pageSpanOp.ts
+++ b/static/app/views/insights/pages/frontend/utils/pageSpanOp.ts
@@ -4,7 +4,7 @@ import {
   type PageSpanOps,
 } from 'sentry/views/insights/pages/frontend/settings';
 
-export const isPageSpanOp = (op?: string): op is PageSpanOps => {
+const isPageSpanOp = (op?: string): op is PageSpanOps => {
   return PAGE_SPAN_OPS.includes(op as PageSpanOps);
 };
 

--- a/static/app/views/insights/pages/frontend/utils/pageSpanOp.ts
+++ b/static/app/views/insights/pages/frontend/utils/pageSpanOp.ts
@@ -1,0 +1,16 @@
+import {
+  DEFAULT_SPAN_OP_SELECTION,
+  PAGE_SPAN_OPS,
+  type PageSpanOps,
+} from 'sentry/views/insights/pages/frontend/settings';
+
+export const isPageSpanOp = (op?: string): op is PageSpanOps => {
+  return PAGE_SPAN_OPS.includes(op as PageSpanOps);
+};
+
+export const getSpanOpFromQuery = (op?: string): PageSpanOps => {
+  if (isPageSpanOp(op)) {
+    return op;
+  }
+  return DEFAULT_SPAN_OP_SELECTION;
+};


### PR DESCRIPTION
When you click `all transactions` in the frontend overview page
<img width="536" height="314" alt="image" src="https://github.com/user-attachments/assets/5d63b66b-9e08-46f1-96be-ea58dd73cf9a" />

and then navigate to any transaction in the table, the transaction summary would automatically include a `transaction.op:all` filter
<img width="577" height="170" alt="image" src="https://github.com/user-attachments/assets/a3e9ef6e-c080-439f-880c-5c23d63ae2cd" />

This Pr fixes that bug, and now no filter is applied in the transaction summary if `all transactions` was selected on the overview page.