### PR TITLE
chore(deletions): Remove metric + update comments

### DIFF
--- a/src/sentry/deletions/tasks/nodestore.py
+++ b/src/sentry/deletions/tasks/nodestore.py
@@ -73,7 +73,7 @@ def delete_events_for_groups_from_nodestore_and_eventstore(
         project_id:             Project ID that all groups belong to
         group_ids:              List of group IDs to delete events for
         transaction_id:         Unique identifier to help debug deletion tasks
-        dataset:                Dataset to delete events from
+        dataset_str:            Dataset string to delete events from
         referrer:               Referrer for the task
         last_event_id:          Event ID of the last processed event (for pagination)
         last_event_timestamp:   Timestamp of the last processed event (for pagination)
@@ -128,7 +128,7 @@ def delete_events_for_groups_from_nodestore_and_eventstore(
                 organization_id, project_id, group_ids, Dataset(dataset_str)
             )
 
-    # XXX: Once we find errors that should be retried add a new section and raise a RetryTask
+    # TODO: Add specific error handling for retryable errors and raise RetryTask when appropriate
     except Exception:
         metrics.incr(f"{prefix}.error", tags={"type": "non-retryable"}, sample_rate=1)
         # Report to Sentry without blocking deployments

--- a/tests/sentry/deletions/tasks/test_nodestore.py
+++ b/tests/sentry/deletions/tasks/test_nodestore.py
@@ -54,6 +54,6 @@ class NodestoreDeletionTaskTest(TestCase):
                 },
             )
 
-        # Events should still exist in eventstore/snuba (that's handled by a different task)
+        # Events should be deleted from eventstore after nodestore deletion
         events_after = self.fetch_events_from_eventstore(group_ids, dataset=Dataset.Events)
         assert len(events_after) == 0

--- a/tests/sentry/deletions/test_group.py
+++ b/tests/sentry/deletions/test_group.py
@@ -287,7 +287,7 @@ class DeleteIssuePlatformTest(TestCase, SnubaTestCase, OccurrenceTestMixin):
             project_id=self.project.id,
             event_id=event.event_id,
             type=type_id,
-            # XXX: Is event.data correct?
+            # Convert event data dict for occurrence processing
             event_data=dict(event.data),
         )
         assert group_info is not None
@@ -317,7 +317,7 @@ class DeleteIssuePlatformTest(TestCase, SnubaTestCase, OccurrenceTestMixin):
         ]
         query = Query(match=entity, select=select, where=where)
         request = Request(
-            # XXX: Double check this
+            # Using IssuePlatform dataset for occurrence queries
             dataset=Dataset.IssuePlatform.value,
             app_id=self.referrer,
             query=query,
@@ -413,7 +413,9 @@ class DeleteIssuePlatformTest(TestCase, SnubaTestCase, OccurrenceTestMixin):
                     project_id=self.project.id,
                 )
 
-            # There should be two batches: [group3, group1] (2+3=5 > 5, so group2 starts new batch), [group2]
+            # There should be two batches with max_rows_to_delete=6
+            # First batch: [group2, group1] (1+3=4 events, under limit)
+            # Second batch: [group3, group4] (3+3=6 events, at limit)
             assert mock_bulk_snuba_queries.call_count == 1
             requests = mock_bulk_snuba_queries.call_args[0][0]
             assert len(requests) == 2


### PR DESCRIPTION
I have been investigating a metric I introduced and it doesn't make sense since it tracks the deletion of children relationships besides number of groups.

I'm also updating some comments to be more accurate.