### PR TITLE
feat(trace-eap-waterfall): Relocating tracewaterfall models instantiation

### DIFF
--- a/static/app/components/events/interfaces/performance/eventTraceView.tsx
+++ b/static/app/components/events/interfaces/performance/eventTraceView.tsx
@@ -31,7 +31,6 @@ import {TraceStateProvider} from 'sentry/views/performance/newTraceDetails/trace
 import {useTraceEventView} from 'sentry/views/performance/newTraceDetails/useTraceEventView';
 import {useTraceQueryParams} from 'sentry/views/performance/newTraceDetails/useTraceQueryParams';
 import useTraceStateAnalytics from 'sentry/views/performance/newTraceDetails/useTraceStateAnalytics';
-import {useTraceWaterfallModels} from 'sentry/views/performance/newTraceDetails/useTraceWaterfallModels';
 
 const DEFAULT_ISSUE_DETAILS_TRACE_VIEW_PREFERENCES: TracePreferencesState = {
   drawer: {
@@ -89,8 +88,6 @@ function EventTraceViewInner({event, organization, traceId}: EventTraceViewInner
 
   const traceEventView = useTraceEventView(traceId, params);
 
-  const traceWaterfallModels = useTraceWaterfallModels();
-
   if (!traceId) {
     return null;
   }
@@ -107,7 +104,6 @@ function EventTraceViewInner({event, organization, traceId}: EventTraceViewInner
         source="issues"
         replay={null}
         event={event}
-        traceWaterfallModels={traceWaterfallModels}
       />
     </IssuesTraceContainer>
   );

--- a/static/app/components/events/interfaces/performance/spanEvidenceTraceView.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceTraceView.tsx
@@ -16,7 +16,6 @@ import {TraceStateProvider} from 'sentry/views/performance/newTraceDetails/trace
 import {useTraceEventView} from 'sentry/views/performance/newTraceDetails/useTraceEventView';
 import {useTraceQueryParams} from 'sentry/views/performance/newTraceDetails/useTraceQueryParams';
 import useTraceStateAnalytics from 'sentry/views/performance/newTraceDetails/useTraceStateAnalytics';
-import {useTraceWaterfallModels} from 'sentry/views/performance/newTraceDetails/useTraceWaterfallModels';
 
 const LazyIssuesTraceWaterfall = lazy(() =>
   import('sentry/views/performance/newTraceDetails/issuesTraceWaterfall').then(
@@ -102,8 +101,6 @@ function SpanEvidenceTraceViewImpl({
   const params = useTraceQueryParams({timestamp});
   const traceEventView = useTraceEventView(traceId, params);
 
-  const traceWaterfallModels = useTraceWaterfallModels();
-
   if (!traceId) {
     return null;
   }
@@ -121,7 +118,6 @@ function SpanEvidenceTraceViewImpl({
           source="issues"
           replay={null}
           event={event}
-          traceWaterfallModels={traceWaterfallModels}
         />
       </Suspense>
     </IssuesTraceContainer>

--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -158,7 +158,7 @@ function TraceViewImpl({traceSlug}: {traceSlug: string}) {
               rootEventResults={rootEventResults}
               tree={tree}
             />
-            <TabsWaterfallWrapper visible={currentTab === TraceLayoutTabKeys.WATERFALL}>
+            {currentTab === TraceLayoutTabKeys.WATERFALL ? (
               <TraceWaterfall
                 tree={tree}
                 trace={trace}
@@ -171,7 +171,7 @@ function TraceViewImpl({traceSlug}: {traceSlug: string}) {
                 organization={organization}
                 hideIfNoData={hideTraceWaterfallIfEmpty}
               />
-            </TabsWaterfallWrapper>
+            ) : null}
             {currentTab === TraceLayoutTabKeys.PROFILES ? (
               <TraceProfiles tree={tree} />
             ) : null}
@@ -190,12 +190,6 @@ function TraceViewImpl({traceSlug}: {traceSlug: string}) {
     </SentryDocumentTitle>
   );
 }
-
-const TabsWaterfallWrapper = styled('div')<{visible: boolean}>`
-  display: ${p => (p.visible ? 'flex' : 'none')};
-  flex-direction: column;
-  flex: 1 1 100%;
-`;
 
 const TraceExternalLayout = styled('div')`
   display: flex;

--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -23,8 +23,6 @@ import {
   TraceLayoutTabKeys,
   useTraceLayoutTabs,
 } from 'sentry/views/performance/newTraceDetails/useTraceLayoutTabs';
-import {useTraceWaterfallModels} from 'sentry/views/performance/newTraceDetails/useTraceWaterfallModels';
-import {useTraceWaterfallScroll} from 'sentry/views/performance/newTraceDetails/useTraceWaterfallScroll';
 
 import {useTrace} from './traceApi/useTrace';
 import {useTraceMeta} from './traceApi/useTraceMeta';
@@ -124,13 +122,6 @@ function TraceViewImpl({traceSlug}: {traceSlug: string}) {
   });
   const traceInnerLayoutRef = useRef<HTMLDivElement>(null);
 
-  const traceWaterfallModels = useTraceWaterfallModels();
-  const traceWaterfallScroll = useTraceWaterfallScroll({
-    organization,
-    tree,
-    viewManager: traceWaterfallModels.viewManager,
-  });
-
   const {tabOptions, currentTab, onTabChange} = useTraceLayoutTabs({
     tree,
     logs: logsData,
@@ -179,8 +170,6 @@ function TraceViewImpl({traceSlug}: {traceSlug: string}) {
                 traceEventView={traceEventView}
                 organization={organization}
                 hideIfNoData={hideTraceWaterfallIfEmpty}
-                traceWaterfallScrollHandlers={traceWaterfallScroll}
-                traceWaterfallModels={traceWaterfallModels}
               />
             </TabsWaterfallWrapper>
             {currentTab === TraceLayoutTabKeys.PROFILES ? (
@@ -193,10 +182,7 @@ function TraceViewImpl({traceSlug}: {traceSlug: string}) {
               <TraceSummarySection traceSlug={traceSlug} />
             ) : null}
             {currentTab === TraceLayoutTabKeys.AI_SPANS ? (
-              <TraceAiSpans
-                traceSlug={traceSlug}
-                viewManager={traceWaterfallModels.viewManager}
-              />
+              <TraceAiSpans traceSlug={traceSlug} />
             ) : null}
           </TraceInnerLayout>
         </TraceExternalLayout>

--- a/static/app/views/performance/newTraceDetails/issuesTraceWaterfall.tsx
+++ b/static/app/views/performance/newTraceDetails/issuesTraceWaterfall.tsx
@@ -47,6 +47,7 @@ import {TraceGrid} from './traceWaterfall';
 import {TraceWaterfallState} from './traceWaterfallState';
 import {useTraceIssuesOnLoad} from './useTraceOnLoad';
 import {useTraceTimelineChangeSync} from './useTraceTimelineChangeSync';
+import {useTraceWaterfallModels} from './useTraceWaterfallModels';
 
 const noopTraceSearch = () => {};
 
@@ -87,7 +88,7 @@ export function IssuesTraceWaterfall(props: IssuesTraceWaterfallProps) {
     null
   );
 
-  const {viewManager, traceScheduler, traceView} = props.traceWaterfallModels;
+  const {viewManager, traceScheduler, traceView} = useTraceWaterfallModels();
 
   // Initialize the tabs reducer when the tree initializes
   useLayoutEffect(() => {

--- a/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceAiSpans.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceAiSpans.tsx
@@ -17,16 +17,10 @@ import {getNodeId} from 'sentry/views/insights/agents/utils/getNodeId';
 import type {AITraceSpanNode} from 'sentry/views/insights/agents/utils/types';
 import {TraceTreeNodeDetails} from 'sentry/views/performance/newTraceDetails/traceDrawer/tabs/traceTreeNodeDetails';
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
-import type {VirtualizedViewManager} from 'sentry/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager';
 import {TraceLayoutTabKeys} from 'sentry/views/performance/newTraceDetails/useTraceLayoutTabs';
 import {getScrollToPath} from 'sentry/views/performance/newTraceDetails/useTraceScrollToPath';
 
-function TraceAiSpans({
-  traceSlug,
-}: {
-  traceSlug: string;
-  viewManager: VirtualizedViewManager;
-}) {
+function TraceAiSpans({traceSlug}: {traceSlug: string}) {
   const organization = useOrganization();
   const navigate = useNavigate();
   const location = useLocation();

--- a/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
+++ b/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
@@ -47,8 +47,8 @@ import {traceGridCssVariables} from 'sentry/views/performance/newTraceDetails/tr
 import {useDividerResizeSync} from 'sentry/views/performance/newTraceDetails/useDividerResizeSync';
 import {useIsEAPTraceEnabled} from 'sentry/views/performance/newTraceDetails/useIsEAPTraceEnabled';
 import {useTraceSpaceListeners} from 'sentry/views/performance/newTraceDetails/useTraceSpaceListeners';
-import type {useTraceWaterfallModels} from 'sentry/views/performance/newTraceDetails/useTraceWaterfallModels';
-import type {useTraceWaterfallScroll} from 'sentry/views/performance/newTraceDetails/useTraceWaterfallScroll';
+import {useTraceWaterfallModels} from 'sentry/views/performance/newTraceDetails/useTraceWaterfallModels';
+import {useTraceWaterfallScroll} from 'sentry/views/performance/newTraceDetails/useTraceWaterfallScroll';
 import type {ReplayTrace} from 'sentry/views/replays/detail/trace/useReplayTraces';
 import type {ReplayRecord} from 'sentry/views/replays/types';
 
@@ -102,8 +102,6 @@ export interface TraceWaterfallProps {
   trace: UseApiQueryResult<TraceTree.Trace, RequestError>;
   traceEventView: EventView;
   traceSlug: string;
-  traceWaterfallModels: ReturnType<typeof useTraceWaterfallModels>;
-  traceWaterfallScrollHandlers: ReturnType<typeof useTraceWaterfallScroll>;
   tree: TraceTree;
   // If set to true, the entire waterfall will not render if it is empty.
   hideIfNoData?: boolean;
@@ -126,8 +124,12 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
   const traceStateRef = useRef<TraceReducerState>(traceState);
   traceStateRef.current = traceState;
 
-  const {viewManager, traceScheduler, traceView} = props.traceWaterfallModels;
-  const {onScrollToNode, scrollRowIntoView} = props.traceWaterfallScrollHandlers;
+  const {viewManager, traceScheduler, traceView} = useTraceWaterfallModels();
+  const {onScrollToNode, scrollRowIntoView} = useTraceWaterfallScroll({
+    organization,
+    tree: props.tree,
+    viewManager,
+  });
 
   const [forceRender, rerender] = useReducer(x => (x + 1) % Number.MAX_SAFE_INTEGER, 0);
 

--- a/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
+++ b/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
@@ -136,7 +136,7 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
   const projectsRef = useRef<Project[]>(projects);
   projectsRef.current = projects;
 
-  const scrollQueueRef = useTraceScrollToPath();
+  const scrollQueueRef = useTraceScrollToPath({traceSlug: props.traceSlug});
   const forceRerender = useCallback(() => {
     flushSync(rerender);
   }, []);
@@ -449,6 +449,13 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
       throw new Error('Trace is initialized but no trace node is found');
     }
 
+    traceScheduler.dispatch('initialize trace space', [
+      props.tree.root.space[0],
+      0,
+      props.tree.root.space[1],
+      1,
+    ]);
+
     // The tree has the data fetched, but does not yet respect the user preferences.
     // We will autogroup and inject missing instrumentation if the preferences are set.
     // and then we will perform a search to find the node the user is interested in.
@@ -526,6 +533,7 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
       viewManager.row_measurer.on('row measure end', onTargetRowMeasure);
       previouslyScrolledToNodeRef.current = node;
 
+      traceDispatch({type: 'minimize drawer', payload: false});
       setRowAsFocused(node, null, traceStateRef.current.search.resultsLookup, index);
       traceDispatch({
         type: 'set roving index',

--- a/static/app/views/performance/newTraceDetails/useTraceOnLoad.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceOnLoad.tsx
@@ -82,7 +82,6 @@ export function useTraceOnLoad(
 ): 'success' | 'error' | 'pending' | 'idle' {
   const api = useApi();
   const organization = useOrganization();
-  const initializedRef = useRef<boolean>(false);
   const {tree, pathToNodeOrEventId, onTraceLoad} = options;
 
   const [status, setStatus] = useState<'success' | 'error' | 'pending' | 'idle'>('idle');
@@ -97,17 +96,12 @@ export function useTraceOnLoad(
   traceStatePreferencesRef.current = traceState.preferences;
 
   useLayoutEffect(() => {
-    if (initializedRef.current) {
-      return undefined;
-    }
-
     if (tree.type !== 'trace') {
       return undefined;
     }
 
     let cancel = false;
     setStatus('pending');
-    initializedRef.current = true;
 
     const expandOptions = {
       api,
@@ -167,7 +161,6 @@ export function useTraceIssuesOnLoad(
 ): 'success' | 'error' | 'pending' | 'idle' {
   const api = useApi();
   const organization = useOrganization();
-  const initializedRef = useRef<boolean>(false);
   const {tree, onTraceLoad} = options;
 
   const [status, setStatus] = useState<'success' | 'error' | 'pending' | 'idle'>('idle');
@@ -182,10 +175,6 @@ export function useTraceIssuesOnLoad(
   traceStatePreferencesRef.current = traceState.preferences;
 
   useLayoutEffect(() => {
-    if (initializedRef.current) {
-      return undefined;
-    }
-
     if (tree.type !== 'trace') {
       return undefined;
     }
@@ -193,7 +182,6 @@ export function useTraceIssuesOnLoad(
     let cancel = false;
 
     setStatus('pending');
-    initializedRef.current = true;
 
     const expandOptions = {
       api,

--- a/static/app/views/performance/newTraceDetails/useTraceScrollToPath.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceScrollToPath.tsx
@@ -1,4 +1,4 @@
-import {useRef} from 'react';
+import {useEffect, useRef} from 'react';
 import * as qs from 'query-string';
 
 import type {TraceTree} from './traceModels/traceTree';
@@ -37,15 +37,22 @@ export function getScrollToPath(): UseTraceScrollToPath {
   return null;
 }
 
-export function useTraceScrollToPath(): React.MutableRefObject<UseTraceScrollToPath> {
+export function useTraceScrollToPath({
+  traceSlug,
+}: {
+  traceSlug: string;
+}): React.MutableRefObject<UseTraceScrollToPath> {
   const scrollQueueRef = useRef<
     {eventId?: string; path?: TraceTree.NodePath[]} | null | undefined
   >(undefined);
 
-  // If we havent decoded anything yet, then decode the path
-  if (scrollQueueRef.current === undefined) {
+  useEffect(() => {
     scrollQueueRef.current = getScrollToPath();
-  }
+
+    // Only re-run this effect when the traceSlug changes, not on every render since we manage
+    // scroll internally in the traceWaterfall component, and only update the url for state consistency across
+    // subsequent loads
+  }, [traceSlug]);
 
   return scrollQueueRef;
 }

--- a/static/app/views/performance/newTraceDetails/useTraceScrollToPath.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceScrollToPath.tsx
@@ -1,4 +1,4 @@
-import {useRef} from 'react';
+import {useEffect, useRef} from 'react';
 import * as qs from 'query-string';
 
 import type {TraceTree} from './traceModels/traceTree';
@@ -42,10 +42,10 @@ export function useTraceScrollToPath(): React.MutableRefObject<UseTraceScrollToP
     {eventId?: string; path?: TraceTree.NodePath[]} | null | undefined
   >(undefined);
 
-  // If we havent decoded anything yet, then decode the path
-  if (scrollQueueRef.current === undefined) {
+  useEffect(() => {
     scrollQueueRef.current = getScrollToPath();
-  }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [location.search]);
 
   return scrollQueueRef;
 }

--- a/static/app/views/performance/newTraceDetails/useTraceScrollToPath.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceScrollToPath.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useRef} from 'react';
+import {useRef} from 'react';
 import * as qs from 'query-string';
 
 import type {TraceTree} from './traceModels/traceTree';
@@ -42,10 +42,10 @@ export function useTraceScrollToPath(): React.MutableRefObject<UseTraceScrollToP
     {eventId?: string; path?: TraceTree.NodePath[]} | null | undefined
   >(undefined);
 
-  useEffect(() => {
+  // If we havent decoded anything yet, then decode the path
+  if (scrollQueueRef.current === undefined) {
     scrollQueueRef.current = getScrollToPath();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [location.search]);
+  }
 
   return scrollQueueRef;
 }

--- a/static/app/views/replays/detail/trace/trace.tsx
+++ b/static/app/views/replays/detail/trace/trace.tsx
@@ -17,8 +17,6 @@ import {getInitialTracePreferences} from 'sentry/views/performance/newTraceDetai
 import {TraceStateProvider} from 'sentry/views/performance/newTraceDetails/traceState/traceStateProvider';
 import {TraceWaterfall} from 'sentry/views/performance/newTraceDetails/traceWaterfall';
 import useTraceStateAnalytics from 'sentry/views/performance/newTraceDetails/useTraceStateAnalytics';
-import {useTraceWaterfallModels} from 'sentry/views/performance/newTraceDetails/useTraceWaterfallModels';
-import {useTraceWaterfallScroll} from 'sentry/views/performance/newTraceDetails/useTraceWaterfallScroll';
 import EmptyState from 'sentry/views/replays/detail/emptyState';
 import FluidHeight from 'sentry/views/replays/detail/layout/fluidHeight';
 import type {HydratedReplayRecord} from 'sentry/views/replays/types';
@@ -113,13 +111,6 @@ function NewTraceViewImpl({replay}: {replay: undefined | HydratedReplayRecord}) 
     traceId: firstTrace?.traceSlug ?? '',
   });
 
-  const traceWaterfallModels = useTraceWaterfallModels();
-  const traceWaterfallScroll = useTraceWaterfallScroll({
-    organization,
-    tree,
-    viewManager: traceWaterfallModels.viewManager,
-  });
-
   const otherReplayTraces = useMemo(() => {
     if (!replayTraces) {
       return [];
@@ -170,8 +161,6 @@ function NewTraceViewImpl({replay}: {replay: undefined | HydratedReplayRecord}) 
         meta={meta}
         source="replay"
         replay={replay}
-        traceWaterfallScrollHandlers={traceWaterfallScroll}
-        traceWaterfallModels={traceWaterfallModels}
       />
     </TraceViewWaterfallWrapper>
   );


### PR DESCRIPTION
This is prep work for trace to trace navigations and preserving trace view scrolled/highlighted row state on re-renders (for example: from tabs switches)

We want the models responsible for rendering, to be instantiated on load. The PR makes sure that this happens at the trace waterfall layer and not a layer above anymore.