### PR TITLE
feat(trace-eap-waterfall): Ensuring onTraceLoad runs on re-renders

### DIFF
--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -158,7 +158,7 @@ function TraceViewImpl({traceSlug}: {traceSlug: string}) {
               rootEventResults={rootEventResults}
               tree={tree}
             />
-            <TabsWaterfallWrapper visible={currentTab === TraceLayoutTabKeys.WATERFALL}>
+            {currentTab === TraceLayoutTabKeys.WATERFALL ? (
               <TraceWaterfall
                 tree={tree}
                 trace={trace}
@@ -171,7 +171,7 @@ function TraceViewImpl({traceSlug}: {traceSlug: string}) {
                 organization={organization}
                 hideIfNoData={hideTraceWaterfallIfEmpty}
               />
-            </TabsWaterfallWrapper>
+            ) : null}
             {currentTab === TraceLayoutTabKeys.PROFILES ? (
               <TraceProfiles tree={tree} />
             ) : null}
@@ -190,12 +190,6 @@ function TraceViewImpl({traceSlug}: {traceSlug: string}) {
     </SentryDocumentTitle>
   );
 }
-
-const TabsWaterfallWrapper = styled('div')<{visible: boolean}>`
-  display: ${p => (p.visible ? 'flex' : 'none')};
-  flex-direction: column;
-  flex: 1 1 100%;
-`;
 
 const TraceExternalLayout = styled('div')`
   display: flex;

--- a/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
+++ b/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
@@ -136,7 +136,7 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
   const projectsRef = useRef<Project[]>(projects);
   projectsRef.current = projects;
 
-  const scrollQueueRef = useTraceScrollToPath();
+  const scrollQueueRef = useTraceScrollToPath({traceSlug: props.traceSlug});
   const forceRerender = useCallback(() => {
     flushSync(rerender);
   }, []);
@@ -449,6 +449,13 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
       throw new Error('Trace is initialized but no trace node is found');
     }
 
+    traceScheduler.dispatch('initialize trace space', [
+      props.tree.root.space[0],
+      0,
+      props.tree.root.space[1],
+      1,
+    ]);
+
     // The tree has the data fetched, but does not yet respect the user preferences.
     // We will autogroup and inject missing instrumentation if the preferences are set.
     // and then we will perform a search to find the node the user is interested in.
@@ -526,6 +533,7 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
       viewManager.row_measurer.on('row measure end', onTargetRowMeasure);
       previouslyScrolledToNodeRef.current = node;
 
+      traceDispatch({type: 'minimize drawer', payload: false});
       setRowAsFocused(node, null, traceStateRef.current.search.resultsLookup, index);
       traceDispatch({
         type: 'set roving index',

--- a/static/app/views/performance/newTraceDetails/useTraceOnLoad.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceOnLoad.tsx
@@ -82,7 +82,6 @@ export function useTraceOnLoad(
 ): 'success' | 'error' | 'pending' | 'idle' {
   const api = useApi();
   const organization = useOrganization();
-  const initializedRef = useRef<boolean>(false);
   const {tree, pathToNodeOrEventId, onTraceLoad} = options;
 
   const [status, setStatus] = useState<'success' | 'error' | 'pending' | 'idle'>('idle');
@@ -97,17 +96,12 @@ export function useTraceOnLoad(
   traceStatePreferencesRef.current = traceState.preferences;
 
   useLayoutEffect(() => {
-    if (initializedRef.current) {
-      return undefined;
-    }
-
     if (tree.type !== 'trace') {
       return undefined;
     }
 
     let cancel = false;
     setStatus('pending');
-    initializedRef.current = true;
 
     const expandOptions = {
       api,
@@ -167,7 +161,6 @@ export function useTraceIssuesOnLoad(
 ): 'success' | 'error' | 'pending' | 'idle' {
   const api = useApi();
   const organization = useOrganization();
-  const initializedRef = useRef<boolean>(false);
   const {tree, onTraceLoad} = options;
 
   const [status, setStatus] = useState<'success' | 'error' | 'pending' | 'idle'>('idle');
@@ -182,10 +175,6 @@ export function useTraceIssuesOnLoad(
   traceStatePreferencesRef.current = traceState.preferences;
 
   useLayoutEffect(() => {
-    if (initializedRef.current) {
-      return undefined;
-    }
-
     if (tree.type !== 'trace') {
       return undefined;
     }
@@ -193,7 +182,6 @@ export function useTraceIssuesOnLoad(
     let cancel = false;
 
     setStatus('pending');
-    initializedRef.current = true;
 
     const expandOptions = {
       api,

--- a/static/app/views/performance/newTraceDetails/useTraceScrollToPath.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceScrollToPath.tsx
@@ -1,4 +1,4 @@
-import {useRef} from 'react';
+import {useEffect, useRef} from 'react';
 import * as qs from 'query-string';
 
 import type {TraceTree} from './traceModels/traceTree';
@@ -37,15 +37,23 @@ export function getScrollToPath(): UseTraceScrollToPath {
   return null;
 }
 
-export function useTraceScrollToPath(): React.MutableRefObject<UseTraceScrollToPath> {
+export function useTraceScrollToPath({
+  traceSlug,
+}: {
+  traceSlug: string;
+}): React.MutableRefObject<UseTraceScrollToPath> {
   const scrollQueueRef = useRef<
     {eventId?: string; path?: TraceTree.NodePath[]} | null | undefined
   >(undefined);
 
-  // If we havent decoded anything yet, then decode the path
-  if (scrollQueueRef.current === undefined) {
+  useEffect(() => {
     scrollQueueRef.current = getScrollToPath();
-  }
+
+    // Only re-run this effect when the traceSlug changes, not on every render since we manage
+    // scroll internally in the traceWaterfall component, and only update the url for state consistency across
+    // subsequent loads
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [traceSlug]);
 
   return scrollQueueRef;
 }

--- a/static/app/views/performance/newTraceDetails/useTraceScrollToPath.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceScrollToPath.tsx
@@ -52,7 +52,6 @@ export function useTraceScrollToPath({
     // Only re-run this effect when the traceSlug changes, not on every render since we manage
     // scroll internally in the traceWaterfall component, and only update the url for state consistency across
     // subsequent loads
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [traceSlug]);
 
   return scrollQueueRef;


### PR DESCRIPTION
This is prep work for trace to trace navigations and preserving trace view scrolled/highlighted row state on re-renders (for example: from tabs switches)

Stacked over:
https://github.com/getsentry/sentry/pull/98580 : Ensures that we don't trigger analytics on re-renders
https://github.com/getsentry/sentry/pull/98604 : Ensures that we preserve trace waterfall state on re-renders

With this merged, we will be able to scroll and highlight nodes on:
- prev/next trace links
- scroll to row viewed in ai spans tab

 https://github.com/user-attachments/assets/3d8b8feb-155a-4b23-9e47-67fcf6ede7c8


