### PR TITLE
fix(trace-eap-waterfall): Don't render JSON btn if transactionid is not defined

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -1072,7 +1072,8 @@ function NodeActions(props: {
           icon={<IconFocus />}
         />
       </Tooltip>
-      {isTransactionNode(props.node) || isEAPTransactionNode(props.node) ? (
+      {transactionId &&
+      (isTransactionNode(props.node) || isEAPTransactionNode(props.node)) ? (
         <Tooltip title={t('JSON')} skipWrapper>
           <ActionLinkButton
             onClick={() => traceAnalytics.trackViewEventJSON(props.organization)}


### PR DESCRIPTION

<img width="802" height="276" alt="Screenshot 2025-09-02 at 12 08 28 PM" src="https://github.com/user-attachments/assets/38fe4987-3fc7-44d9-9687-5cddbdf775de" />

