### PR TITLE
fix(crons): Fix de-dupe migration

### DIFF
--- a/src/sentry/workflow_engine/migrations/0084_crons_dedupe_workflows.py
+++ b/src/sentry/workflow_engine/migrations/0084_crons_dedupe_workflows.py
@@ -95,6 +95,6 @@ class Migration(CheckedMigration):
         migrations.RunPython(
             dedupe_cron_shadow_workflows,
             migrations.RunPython.noop,
-            hints={"tables": ["sentry_rule"]},
+            hints={"tables": ["sentry_rule", "sentry_monitor"]},
         ),
     ]

--- a/src/sentry/workflow_engine/migrations/0084_crons_dedupe_workflows.py
+++ b/src/sentry/workflow_engine/migrations/0084_crons_dedupe_workflows.py
@@ -89,12 +89,13 @@ class Migration(CheckedMigration):
 
     dependencies = [
         ("workflow_engine", "0083_add_status_to_action"),
+        ("monitors", "0009_backfill_monitor_detectors"),
     ]
 
     operations = [
         migrations.RunPython(
             dedupe_cron_shadow_workflows,
             migrations.RunPython.noop,
-            hints={"tables": ["sentry_rule", "sentry_monitor"]},
+            hints={"tables": ["sentry_rule"]},
         ),
     ]


### PR DESCRIPTION
This migration runs in ci but fails when using the tool, with `LookupError: No installed app with label 'monitors'.`. Add a dependency on the monitors project so that we know the monitor models will be loaded.
<!-- Describe your PR here. -->