### PR TITLE
feat(releases): Add ability to filter deletions when performing bulk deletions in `ModelDeletionTask.chunk`, and filter `PullRequest` deletions

### DIFF
--- a/src/sentry/deletions/base.py
+++ b/src/sentry/deletions/base.py
@@ -103,7 +103,7 @@ class BaseDeletionTask(Generic[ModelT]):
             self.actor_id,
         )
 
-    def chunk(self) -> bool:
+    def chunk(self, apply_filter: bool = False) -> bool:
         """
         Deletes a chunk of this instance's data. Return ``True`` if there is
         more work, or ``False`` if the entity has been removed.
@@ -215,7 +215,7 @@ class ModelDeletionTask(BaseDeletionTask[ModelT]):
         """
         return None
 
-    def chunk(self) -> bool:
+    def chunk(self, apply_filter: bool = False) -> bool:
         """
         Deletes a chunk of this instance's data. Return ``True`` if there is
         more work, or ``False`` if all matching entities have been removed.
@@ -226,9 +226,10 @@ class ModelDeletionTask(BaseDeletionTask[ModelT]):
         while remaining >= 0:
             queryset = getattr(self.model, self.manager_name).filter(**self.query)
 
-            query_filter = self.get_query_filter()
-            if query_filter is not None:
-                queryset = queryset.filter(query_filter)
+            if apply_filter:
+                query_filter = self.get_query_filter()
+                if query_filter is not None:
+                    queryset = queryset.filter(query_filter)
 
             if self.order_by:
                 queryset = queryset.order_by(self.order_by)
@@ -284,7 +285,7 @@ class BulkModelDeletionTask(ModelDeletionTask[ModelT]):
 
     DEFAULT_CHUNK_SIZE = 10000
 
-    def chunk(self) -> bool:
+    def chunk(self, apply_filter: bool = False) -> bool:
         return self._delete_instance_bulk()
 
     def _delete_instance_bulk(self) -> bool:

--- a/src/sentry/deletions/defaults/group.py
+++ b/src/sentry/deletions/defaults/group.py
@@ -128,7 +128,7 @@ class EventsBaseDeletionTask(BaseDeletionTask[Group]):
             result["organization_id"] = self.groups[0].project.organization_id
         return result
 
-    def chunk(self) -> bool:
+    def chunk(self, apply_filter: bool = False) -> bool:
         """This method is called to delete chunks of data. It returns a boolean to say
         if the deletion has completed and if it needs to be called again."""
         if not options.get("deletions.nodestore.parallelization-task-enabled"):

--- a/src/sentry/deletions/defaults/grouphistory.py
+++ b/src/sentry/deletions/defaults/grouphistory.py
@@ -13,7 +13,7 @@ class GroupHistoryDeletionTask(ModelDeletionTask[GroupHistory]):
     span 10000 ID values.
     """
 
-    def chunk(self) -> bool:
+    def chunk(self, apply_filter: bool = False) -> bool:
         group_ids = self.query.get("group_id__in", [])
         if not group_ids:
             # If we don't have group_id conditions

--- a/src/sentry/deletions/defaults/pullrequest.py
+++ b/src/sentry/deletions/defaults/pullrequest.py
@@ -1,11 +1,19 @@
+from collections.abc import Sequence
+from datetime import datetime, timedelta, timezone
+
 from sentry.deletions.base import BaseRelation, ModelDeletionTask, ModelRelation
-from sentry.models.pullrequest import PullRequest
+from sentry.models.pullrequest import PullRequest, PullRequestComment, PullRequestCommit
 
 
 class PullRequestDeletionTask(ModelDeletionTask[PullRequest]):
-    def get_child_relations(self, instance: PullRequest) -> list[BaseRelation]:
-        from sentry.models.pullrequest import PullRequestComment
+    def filter_deletions_bulk(self, instances: Sequence[PullRequest]) -> Sequence[PullRequest]:
+        # This could be inefficient for a lot of pull requests, we can attempt to convert this to a bulk
+        # function if needed. But this table won't have a high rate of deletions, so this should be ok.
+        cutoff = datetime.now(timezone.utc) - timedelta(days=90)
+        return [instance for instance in instances if instance.is_unused(cutoff)]
 
+    def get_child_relations(self, instance: PullRequest) -> list[BaseRelation]:
         return [
             ModelRelation(PullRequestComment, {"pull_request_id": instance.id}),
+            ModelRelation(PullRequestCommit, {"pull_request_id": instance.id}),
         ]

--- a/src/sentry/runner/commands/cleanup.py
+++ b/src/sentry/runner/commands/cleanup.py
@@ -104,7 +104,7 @@ def multiprocess_worker(task_queue: _WorkQueue) -> None:
             )
 
             while True:
-                if not task.chunk():
+                if not task.chunk(apply_filter=True):
                     break
         except Exception as e:
             logger.exception(e)

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -995,6 +995,16 @@ class Factories:
         )
 
     @staticmethod
+    @assume_test_silo_mode(SiloMode.REGION)
+    def create_release_commit(release, commit, order=1):
+        return ReleaseCommit.objects.create(
+            organization_id=release.organization_id,
+            release=release,
+            commit=commit,
+            order=order,
+        )
+
+    @staticmethod
     @assume_test_silo_mode(SiloMode.CONTROL)
     def create_user(
         email=None, is_superuser=False, is_staff=False, is_active=True, **kwargs

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -288,6 +288,9 @@ class Fixtures:
     def create_pull_request_commit(self, *args, **kwargs):
         return Factories.create_pull_request_commit(*args, **kwargs)
 
+    def create_release_commit(self, *args, **kwargs):
+        return Factories.create_release_commit(*args, **kwargs)
+
     def create_user(self, *args, **kwargs) -> User:
         return Factories.create_user(*args, **kwargs)
 

--- a/tests/sentry/deletions/test_pullrequest.py
+++ b/tests/sentry/deletions/test_pullrequest.py
@@ -179,7 +179,7 @@ class PullRequestDeletionTaskTest(TestCase):
         self.create_pull_request_commit(pr_with_release, release_commit)
         release = self.create_release(project=self.project)
         self.create_release_commit(release, release_commit)
-        self.task.chunk()
+        self.task.chunk(apply_filter=True)
 
         assert not PullRequest.objects.filter(id=pr_old_unused.id).exists()
         assert not PullRequestComment.objects.filter(id=comment.id).exists()

--- a/tests/sentry/deletions/test_pullrequest.py
+++ b/tests/sentry/deletions/test_pullrequest.py
@@ -1,0 +1,193 @@
+from datetime import timedelta
+
+from django.utils import timezone
+
+from sentry.deletions import get_manager
+from sentry.deletions.defaults.pullrequest import PullRequestDeletionTask
+from sentry.models.commit import Commit
+from sentry.models.grouplink import GroupLink
+from sentry.models.pullrequest import PullRequest, PullRequestComment, PullRequestCommit
+from sentry.testutils.cases import TestCase
+
+
+class PullRequestDeletionTaskTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.repo = self.create_repo(project=self.project, name="test-repo")
+        self.author = self.create_commit_author(project=self.project, email="test@example.com")
+        self.now = timezone.now()
+        self.old_date = self.now - timedelta(days=100)
+        self.recent_date = self.now - timedelta(days=10)
+        self.task = PullRequestDeletionTask(manager=get_manager(), model=PullRequest, query={})
+
+    def create_pr(self, key, date_added=None):
+        if date_added is None:
+            date_added = self.old_date
+        pr = PullRequest.objects.create(
+            repository_id=self.repo.id,
+            organization_id=self.organization.id,
+            key=key,
+            title="Test PR",
+            author=self.author,
+        )
+        PullRequest.objects.filter(id=pr.id).update(date_added=date_added)
+        pr.refresh_from_db()
+        return pr
+
+    def create_old_commit(self):
+        commit = self.create_commit(
+            project=self.project,
+            repo=self.repo,
+            author=self.author,
+        )
+        Commit.objects.filter(id=commit.id).update(date_added=self.old_date)
+        return commit
+
+    def create_pull_request_comment(
+        self, pull_request, created_at=None, updated_at=None, group_ids=None, external_id=None
+    ):
+        if external_id is None:
+            external_id = PullRequestComment.objects.filter(pull_request=pull_request).count() + 1
+        return PullRequestComment.objects.create(
+            pull_request=pull_request,
+            external_id=external_id,
+            created_at=created_at or self.old_date,
+            updated_at=updated_at or self.old_date,
+            group_ids=group_ids or [],
+        )
+
+    def test_filter_deletions_bulk_removes_unused_prs(self):
+        pr_old_unused = self.create_pr("pr1", self.old_date)
+        pr_recent = self.create_pr("pr2", self.recent_date)
+        pr_with_recent_comment = self.create_pr("pr3", self.old_date)
+
+        self.create_pull_request_comment(
+            pull_request=pr_with_recent_comment,
+            created_at=self.recent_date,
+            updated_at=self.old_date,
+        )
+
+        instances = [pr_old_unused, pr_recent, pr_with_recent_comment]
+        filtered = self.task.filter_deletions_bulk(instances)
+
+        assert len(filtered) == 1
+        assert filtered[0].id == pr_old_unused.id
+
+    def test_filter_deletions_bulk_keeps_pr_with_release_commit(self):
+        pr = self.create_pr("pr_release", self.old_date)
+        commit = self.create_old_commit()
+        self.create_pull_request_commit(pr, commit)
+
+        release = self.create_release(project=self.project)
+        self.create_release_commit(release, commit)
+
+        filtered = self.task.filter_deletions_bulk([pr])
+        assert len(filtered) == 0
+
+    def test_filter_deletions_bulk_keeps_pr_with_valid_group_link(self):
+        pr = self.create_pr("pr_group", self.old_date)
+        group = self.create_group(project=self.project)
+        GroupLink.objects.create(
+            group=group,
+            project=self.project,
+            linked_type=GroupLink.LinkedType.pull_request,
+            linked_id=pr.id,
+            relationship=GroupLink.Relationship.resolves,
+        )
+
+        filtered = self.task.filter_deletions_bulk([pr])
+        assert len(filtered) == 0
+
+    def test_filter_deletions_bulk_deletes_pr_with_invalid_group_link(self):
+        pr = self.create_pr("pr_invalid_group", self.old_date)
+        GroupLink.objects.create(
+            group_id=999999,  # Non-existent group
+            project=self.project,
+            linked_type=GroupLink.LinkedType.pull_request,
+            linked_id=pr.id,
+            relationship=GroupLink.Relationship.resolves,
+        )
+
+        filtered = self.task.filter_deletions_bulk([pr])
+        assert len(filtered) == 1
+        assert filtered[0].id == pr.id
+
+    def test_filter_deletions_bulk_with_comment_group_ids(self):
+        pr_valid_group = self.create_pr("pr_valid", self.old_date)
+        group = self.create_group(project=self.project)
+        self.create_pull_request_comment(
+            pull_request=pr_valid_group,
+            group_ids=[group.id],
+        )
+
+        pr_invalid_group = self.create_pr("pr_invalid", self.old_date)
+        self.create_pull_request_comment(
+            pull_request=pr_invalid_group,
+            group_ids=[999999],  # Non-existent
+        )
+
+        filtered = self.task.filter_deletions_bulk([pr_valid_group, pr_invalid_group])
+        assert len(filtered) == 1
+        assert filtered[0].id == pr_invalid_group.id
+
+    def test_get_child_relations_includes_comments_and_commits(self):
+        pr = self.create_pr("pr_children", self.old_date)
+        self.create_pull_request_comment(pr)
+        commit = self.create_old_commit()
+        self.create_pull_request_commit(pr, commit)
+
+        relations = self.task.get_child_relations(pr)
+
+        assert len(relations) == 2
+        relation_models = {r.params["model"] for r in relations}
+        assert PullRequestComment in relation_models
+        assert PullRequestCommit in relation_models
+
+        for relation in relations:
+            assert relation.params["query"] == {"pull_request_id": pr.id}
+
+    def test_deletion_cascades_to_children(self):
+        pr = self.create_pr("pr_cascade", self.old_date)
+        comment = self.create_pull_request_comment(pr)
+        commit = self.create_old_commit()
+        pr_commit = self.create_pull_request_commit(pr, commit)
+
+        pr.delete()
+
+        assert not PullRequestComment.objects.filter(id=comment.id).exists()
+        assert not PullRequestCommit.objects.filter(id=pr_commit.id).exists()
+        assert Commit.objects.filter(id=commit.id).exists()
+
+    def test_filter_deletions_with_empty_list(self):
+        filtered = self.task.filter_deletions_bulk([])
+        assert filtered == []
+
+    def test_cutoff_date_is_90_days(self):
+        pr_89_days = self.create_pr("pr_89", self.now - timedelta(days=89))
+        pr_91_days = self.create_pr("pr_91", self.now - timedelta(days=91))
+        filtered = self.task.filter_deletions_bulk([pr_89_days, pr_91_days])
+        assert len(filtered) == 1
+        assert filtered[0].id == pr_91_days.id
+
+    def test_actual_deletion_execution(self):
+        # Create a mix of PRs that should and shouldn't be deleted
+        pr_old_unused = self.create_pr("old_unused", self.old_date)
+        pr_recent = self.create_pr("recent", self.recent_date)
+        pr_with_release = self.create_pr("with_release", self.old_date)
+        comment = self.create_pull_request_comment(pr_old_unused)
+        commit = self.create_old_commit()
+        pr_commit = self.create_pull_request_commit(pr_old_unused, commit)
+        release_commit = self.create_old_commit()
+        self.create_pull_request_commit(pr_with_release, release_commit)
+        release = self.create_release(project=self.project)
+        self.create_release_commit(release, release_commit)
+        self.task.chunk()
+
+        assert not PullRequest.objects.filter(id=pr_old_unused.id).exists()
+        assert not PullRequestComment.objects.filter(id=comment.id).exists()
+        assert not PullRequestCommit.objects.filter(id=pr_commit.id).exists()
+
+        assert PullRequest.objects.filter(id=pr_recent.id).exists()
+        assert PullRequest.objects.filter(id=pr_with_release.id).exists()
+        assert Commit.objects.filter(id=commit.id).exists()
+        assert Commit.objects.filter(id=release_commit.id).exists()


### PR DESCRIPTION
This adds in the ability to filter out deletions based on arbitrary criteria. This helps us with some more complex deletion types, where we want to delete a row when it's unused, but unused is defined by whether other rows are stil using it.

We also add in this filtering when deleting `PullRequest` rows, so that we'll only remove unused rows when deleting them for retention purposes.

<!-- Describe your PR here. -->