### PR TITLE
feat(feedback): Move feedback summaries to new Seer pod

### DIFF
--- a/src/sentry/feedback/usecases/title_generation.py
+++ b/src/sentry/feedback/usecases/title_generation.py
@@ -14,6 +14,9 @@ logger = logging.getLogger(__name__)
 SEER_TITLE_GENERATION_ENDPOINT_PATH = "/v1/automation/summarize/feedback/title"
 
 seer_connection_pool = connection_from_url(
+    settings.SEER_SUMMARIZATION_URL, timeout=getattr(settings, "SEER_DEFAULT_TIMEOUT", 5)
+)
+fallback_connection_pool = connection_from_url(
     settings.SEER_AUTOFIX_URL, timeout=getattr(settings, "SEER_DEFAULT_TIMEOUT", 5)
 )
 
@@ -81,12 +84,25 @@ def get_feedback_title_from_seer(feedback_message: str, organization_id: int) ->
         )
         response_data = response.json()
     except Exception:
-        logger.exception("Seer title generation endpoint failed")
-        metrics.incr(
-            "feedback.ai_title_generation.error",
-            tags={"reason": "seer_response_failed"},
+        # If summarization pod fails, fall back to autofix pod
+        logger.warning(
+            "Summarization pod connection failed for title generation, falling back to autofix",
+            exc_info=True,
         )
-        return None
+        try:
+            response = make_signed_seer_api_request(
+                connection_pool=fallback_connection_pool,
+                path=SEER_TITLE_GENERATION_ENDPOINT_PATH,
+                body=json.dumps(seer_request).encode("utf-8"),
+            )
+            response_data = response.json()
+        except Exception:
+            logger.exception("Seer title generation endpoint failed on both pods")
+            metrics.incr(
+                "feedback.ai_title_generation.error",
+                tags={"reason": "seer_response_failed"},
+            )
+            return None
 
     if response.status < 200 or response.status >= 300:
         logger.error(

--- a/tests/sentry/feedback/endpoints/test_organization_feedback_summary.py
+++ b/tests/sentry/feedback/endpoints/test_organization_feedback_summary.py
@@ -255,6 +255,8 @@ class OrganizationFeedbackSummaryTest(APITestCase):
 
         assert response.status_code == 500
         assert response.data["detail"] == "Failed to generate a summary for a list of feedbacks"
+        # Should be called twice: once for summarization URL, once for autofix fallback
+        assert mock_make_seer_api_request.call_count == 2
 
     @patch("sentry.feedback.endpoints.organization_feedback_summary.make_signed_seer_api_request")
     def test_seer_http_errors(self, mock_make_seer_api_request: MagicMock) -> None:

--- a/tests/sentry/feedback/usecases/test_label_generation.py
+++ b/tests/sentry/feedback/usecases/test_label_generation.py
@@ -62,7 +62,8 @@ def test_generate_labels_network_error(mock_make_seer_request) -> None:
             "I don't like the new right sidebar, it makes navigating everywhere hard!", 1
         )
 
-    mock_make_seer_request.assert_called_once()
+    # Should be called twice: once for summarization URL, once for autofix fallback
+    assert mock_make_seer_request.call_count == 2
     request_body = json.loads(mock_make_seer_request.call_args[1]["body"].decode("utf-8"))
     expected_request = {
         "feedback_message": "I don't like the new right sidebar, it makes navigating everywhere hard!",

--- a/tests/sentry/feedback/usecases/test_title_generation.py
+++ b/tests/sentry/feedback/usecases/test_title_generation.py
@@ -66,7 +66,8 @@ def test_get_feedback_title_from_seer_exception(mock_make_seer_request):
     """Test the get_feedback_title_from_seer function with exception during API call."""
     mock_make_seer_request.side_effect = Exception("Network error")
     assert get_feedback_title_from_seer("Login button broken", 123) is None
-    mock_make_seer_request.assert_called_once()
+    # Should be called twice: once for summarization URL, once for autofix fallback
+    assert mock_make_seer_request.call_count == 2
 
 
 @patch("sentry.feedback.usecases.title_generation.make_signed_seer_api_request")


### PR DESCRIPTION
## PR Details
+ Switch feedback summaries to new Seer pod with fallback to the old one. 
+ Similar to this PR: https://github.com/getsentry/sentry/pull/98619 
