### PR TITLE
feat(search): Add BE wildcard prefix ops

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -384,8 +384,10 @@ def get_operator_value(operator: Node | list[str] | tuple[str] | str) -> str:
 def has_wildcard_op(node: Node | tuple[Node]) -> bool:
     if isinstance(node, Node):
         return node.text in WILDCARD_PREFIX_OPERATOR_MAP.values()
-    elif isinstance(node, tuple) and len(node) > 0:
+    if isinstance(node, tuple) and len(node) > 0:
         return node[0].text in WILDCARD_PREFIX_OPERATOR_MAP.values()
+    # Ignoring mypy here because it doesn't think tuples can be empty
+    return False  # type: ignore[unreachable]
 
 
 def get_wildcard_op(node: Node | tuple[Node]) -> str:
@@ -393,21 +395,20 @@ def get_wildcard_op(node: Node | tuple[Node]) -> str:
         return node.text
     if isinstance(node, tuple) and len(node) > 0:
         return node[0].text
-    return ""
+    # Ignoring mypy here because it doesn't think tuples can be empty
+    return ""  # type: ignore[unreachable]
 
 
 def add_leading_wildcard(value: str) -> str:
     if value.startswith('"') and value.endswith('"'):
         return f"*{value[1:-1]}"
-    else:
-        return f"*{value}"
+    return f"*{value}"
 
 
 def add_trailing_wildcard(value: str) -> str:
     if value.startswith('"') and value.endswith('"'):
         return f"{value[1:-1]}*"
-    else:
-        return f"{value}*"
+    return f"{value}*"
 
 
 def gen_wildcard_value(value: str, wildcard_op: str) -> str:

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -394,15 +394,11 @@ def get_wildcard_op(node: Node | tuple[Node]) -> str:
 
 
 def add_leading_wildcard(value: str) -> str:
-    if value.startswith('"') and value.endswith('"'):
-        return f'"*{value[1:]}"'
-    return f"*{value}"
+    return f'"*{value[1:]}' if value.startswith('"') else f"*{value}"
 
 
 def add_trailing_wildcard(value: str) -> str:
-    if value.startswith('"') and value.endswith('"'):
-        return f'{value[:-1]}*"'
-    return f"{value}*"
+    return f'{value[:-1]}*"' if value.endswith('"') else f"{value}*"
 
 
 def gen_wildcard_value(value: str, wildcard_op: str) -> str:

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -1369,11 +1369,10 @@ class SearchVisitor(NodeVisitor[list[QueryToken]]):
 
         if has_wildcard_op(wildcard_op) and isinstance(search_value.raw_value, list):
             wildcarded_values = []
+            found_wildcard_op = get_wildcard_op(wildcard_op)
             for value in search_value.raw_value:
                 if isinstance(value, str):
-                    wildcarded_values.append(
-                        gen_wildcard_value(value, get_wildcard_op(wildcard_op))
-                    )
+                    wildcarded_values.append(gen_wildcard_value(value, found_wildcard_op))
 
             search_value = search_value._replace(raw_value=wildcarded_values)
 

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -167,7 +167,7 @@ numeric_value          = "-"? numeric numeric_unit? &(end_value / comma / closed
 boolean_value          = ~r"(true|1|false|0)"i &end_value
 text_in_list           = open_bracket text_in_value (spaces comma spaces !comma text_in_value?)* closed_bracket &end_value
 numeric_in_list        = open_bracket numeric_value (spaces comma spaces !comma numeric_value?)* closed_bracket &end_value
-wildcard_op            = wildcard_unicode (contains / starts_with / ends_with / does_not_contain / does_not_start_with / does_not_end_with) wildcard_unicode
+wildcard_op            = wildcard_unicode (contains / starts_with / ends_with) wildcard_unicode
 
 # See: https://stackoverflow.com/a/39617181/790169
 in_value_termination = in_value_char (!in_value_end in_value_char)* in_value_end
@@ -207,11 +207,8 @@ negation             = "!"
 # Note: wildcard unicode is defined in src/sentry/search/events/constants.py
 wildcard_unicode     = "\uF00D"
 contains             = "contains"
-does_not_contain     = "does not contain"
 starts_with          = "starts with"
-does_not_start_with  = "does not start with"
 ends_with            = "ends with"
-does_not_end_with    = "does not end with"
 comma                = ","
 spaces               = " "*
 
@@ -413,21 +410,12 @@ def gen_wildcard_value(value: str, wildcard_op: str) -> str:
     if value == "" or wildcard_op == "":
         return value
     value = re.sub(r"(?<!\\)\*", r"\\*", value)
-    if wildcard_op in [
-        WILDCARD_OPERATOR_MAP["contains"],
-        WILDCARD_OPERATOR_MAP["does_not_contain"],
-    ]:
+    if wildcard_op == WILDCARD_OPERATOR_MAP["contains"]:
         value = add_leading_wildcard(value)
         value = add_trailing_wildcard(value)
-    elif wildcard_op in [
-        WILDCARD_OPERATOR_MAP["starts_with"],
-        WILDCARD_OPERATOR_MAP["does_not_start_with"],
-    ]:
+    elif wildcard_op == WILDCARD_OPERATOR_MAP["starts_with"]:
         value = add_trailing_wildcard(value)
-    elif wildcard_op in [
-        WILDCARD_OPERATOR_MAP["ends_with"],
-        WILDCARD_OPERATOR_MAP["does_not_end_with"],
-    ]:
+    elif wildcard_op == WILDCARD_OPERATOR_MAP["ends_with"]:
         value = add_leading_wildcard(value)
     return value
 

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -377,33 +377,27 @@ def get_operator_value(operator: Node | list[str] | tuple[str] | str) -> str:
 
 
 def has_wildcard_op(node: Node | tuple[Node]) -> bool:
-    wildcard_check_position = 1 if is_negated(node) else 0
     if isinstance(node, Node):
         return node.text in {"%", "^", "$"}
-    else:
-        return node[wildcard_check_position].text in {"%", "^", "$"}
+    return node[0].text in {"%", "^", "$"}
 
 
 def get_wildcard_op(node: Node | tuple[Node]) -> str:
-    wildcard_check_position = 1 if is_negated(node) else 0
     if isinstance(node, Node):
         return node.text
-    else:
-        return node[wildcard_check_position].text
+    return node[0].text
 
 
 def add_leading_wildcard(value: str) -> str:
     if value.startswith('"') and value.endswith('"'):
-        return f'"*{value[1:]}' if not value.startswith('"*') else value
-    else:
-        return f"*{value}" if not value.startswith("*") else value
+        return f'"*{value[1:]}"' if not value.startswith('"*') else value
+    return f"*{value}" if not value.startswith("*") else value
 
 
 def add_trailing_wildcard(value: str) -> str:
     if value.startswith('"') and value.endswith('"'):
         return f'{value[:-1]}*"' if not value.endswith('*"') else value
-    else:
-        return f"{value}*" if not value.endswith("*") else value
+    return f"{value}*" if not value.endswith("*") else value
 
 
 def gen_wildcard_value(value: str, wildcard_op: str) -> str:

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -23,7 +23,7 @@ from sentry.search.events.constants import (
     SIZE_UNITS,
     TAG_KEY_RE,
     TEAM_KEY_TRANSACTION_ALIAS,
-    WILDCARD_PREFIX_OPERATOR_MAP,
+    WILDCARD_OPERATOR_MAP,
 )
 from sentry.search.events.fields import FIELD_ALIASES, FUNCTIONS
 from sentry.search.events.types import ParamsType, QueryBuilderConfig
@@ -383,9 +383,9 @@ def get_operator_value(operator: Node | list[str] | tuple[str] | str) -> str:
 
 def has_wildcard_op(node: Node | Sequence[Node]) -> bool:
     if isinstance(node, Node):
-        return node.text in WILDCARD_PREFIX_OPERATOR_MAP.values()
+        return node.text in WILDCARD_OPERATOR_MAP.values()
     if isinstance(node, Sequence) and len(node) > 0:
-        return node[0].text in WILDCARD_PREFIX_OPERATOR_MAP.values()
+        return node[0].text in WILDCARD_OPERATOR_MAP.values()
     return False
 
 
@@ -412,21 +412,21 @@ def add_trailing_wildcard(value: str) -> str:
 def gen_wildcard_value(value: str, wildcard_op: str) -> str:
     if value == "" or wildcard_op == "":
         return value
-    value = value.replace("*", "\\*")
+    value = re.sub(r"(?<!\\)\*", r"\\*", value)
     if wildcard_op in [
-        WILDCARD_PREFIX_OPERATOR_MAP["contains"],
-        WILDCARD_PREFIX_OPERATOR_MAP["does_not_contain"],
+        WILDCARD_OPERATOR_MAP["contains"],
+        WILDCARD_OPERATOR_MAP["does_not_contain"],
     ]:
         value = add_leading_wildcard(value)
         value = add_trailing_wildcard(value)
     elif wildcard_op in [
-        WILDCARD_PREFIX_OPERATOR_MAP["starts_with"],
-        WILDCARD_PREFIX_OPERATOR_MAP["does_not_start_with"],
+        WILDCARD_OPERATOR_MAP["starts_with"],
+        WILDCARD_OPERATOR_MAP["does_not_start_with"],
     ]:
         value = add_trailing_wildcard(value)
     elif wildcard_op in [
-        WILDCARD_PREFIX_OPERATOR_MAP["ends_with"],
-        WILDCARD_PREFIX_OPERATOR_MAP["does_not_end_with"],
+        WILDCARD_OPERATOR_MAP["ends_with"],
+        WILDCARD_OPERATOR_MAP["does_not_end_with"],
     ]:
         value = add_leading_wildcard(value)
     return value

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -396,8 +396,16 @@ def add_leading_wildcard(value: str) -> str:
     return f"*{value}" if not value.startswith("*") else value
 
 
+def remove_leading_wildcard(value: str) -> str:
+    return value[1:] if value.startswith("*") else value
+
+
 def add_trailing_wildcard(value: str) -> str:
     return f"{value}*" if not value.endswith("*") else value
+
+
+def remove_trailing_wildcard(value: str) -> str:
+    return value[:-1] if value.endswith("*") else value
 
 
 def gen_wildcard_value(value: str, wildcard_op: str) -> str:
@@ -405,8 +413,10 @@ def gen_wildcard_value(value: str, wildcard_op: str) -> str:
         value = add_leading_wildcard(value)
         value = add_trailing_wildcard(value)
     elif wildcard_op == WILDCARD_PREFIX_OPERATOR_MAP["starts_with"]:
+        value = remove_leading_wildcard(value)
         value = add_trailing_wildcard(value)
     elif wildcard_op == WILDCARD_PREFIX_OPERATOR_MAP["ends_with"]:
+        value = remove_trailing_wildcard(value)
         value = add_leading_wildcard(value)
     return value
 

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -395,19 +395,20 @@ def get_wildcard_op(node: Node | tuple[Node]) -> str:
 
 def add_leading_wildcard(value: str) -> str:
     if value.startswith('"') and value.endswith('"'):
-        return f'"*{value[1:]}"' if not value.startswith('"*') else value
-    return f"*{value}" if not value.startswith("*") else value
+        return f'"*{value[1:]}"'
+    return f"*{value}"
 
 
 def add_trailing_wildcard(value: str) -> str:
     if value.startswith('"') and value.endswith('"'):
-        return f'{value[:-1]}*"' if not value.endswith('*"') else value
-    return f"{value}*" if not value.endswith("*") else value
+        return f'{value[:-1]}*"'
+    return f"{value}*"
 
 
 def gen_wildcard_value(value: str, wildcard_op: str) -> str:
     if value == "":
         return value
+    value = value.replace("*", "\\*")
     if wildcard_op in [
         WILDCARD_PREFIX_OPERATOR_MAP["contains"],
         WILDCARD_PREFIX_OPERATOR_MAP["does_not_contain"],

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -401,7 +401,7 @@ def add_leading_wildcard(value: str) -> str:
 
 def add_trailing_wildcard(value: str) -> str:
     if value.startswith('"') and value.endswith('"'):
-        return f'{value}*"' if not value.endswith('*"') else value
+        return f'{value[:-1]}*"' if not value.endswith('*"') else value
     else:
         return f"{value}*" if not value.endswith("*") else value
 

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -1355,6 +1355,7 @@ class SearchVisitor(NodeVisitor[list[QueryToken]]):
         node: Node,
         children: tuple[
             Node | tuple[Node],  # ! if present
+            Node | tuple[Node],  # wildcard_op if present
             SearchKey,
             Node,  # :
             list[str],

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -1357,12 +1357,15 @@ class SearchVisitor(NodeVisitor[list[QueryToken]]):
 
         operator = handle_negation(negation, operator)
 
-        if has_wildcard_op(wildcard_op):
-            search_value_s = []
+        if has_wildcard_op(wildcard_op) and isinstance(search_value.raw_value, list):
+            wildcarded_values = []
             for value in search_value.raw_value:
-                search_value_s.append(gen_wildcard_value(value, get_wildcard_op(wildcard_op)))
+                if isinstance(value, str):
+                    wildcarded_values.append(
+                        gen_wildcard_value(value, get_wildcard_op(wildcard_op))
+                    )
 
-            search_value = search_value._replace(raw_value=search_value_s)
+            search_value = search_value._replace(raw_value=wildcarded_values)
 
         return self._handle_basic_filter(search_key, operator, search_value)
 
@@ -1394,11 +1397,11 @@ class SearchVisitor(NodeVisitor[list[QueryToken]]):
 
         operator_s = handle_negation(negation, operator_s)
 
-        if has_wildcard_op(wildcard_op):
-            search_value_s = gen_wildcard_value(
+        if has_wildcard_op(wildcard_op) and isinstance(search_value.raw_value, str):
+            wildcarded_value = gen_wildcard_value(
                 search_value.raw_value, get_wildcard_op(wildcard_op)
             )
-            search_value = search_value._replace(raw_value=search_value_s)
+            search_value = search_value._replace(raw_value=wildcarded_value)
 
         return self._handle_basic_filter(search_key, operator_s, search_value)
 

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -381,22 +381,20 @@ def get_operator_value(operator: Node | list[str] | tuple[str] | str) -> str:
         return operator
 
 
-def has_wildcard_op(node: Node | tuple[Node]) -> bool:
+def has_wildcard_op(node: Node | Sequence[Node]) -> bool:
     if isinstance(node, Node):
         return node.text in WILDCARD_PREFIX_OPERATOR_MAP.values()
-    if isinstance(node, tuple) and len(node) > 0:
+    if isinstance(node, Sequence) and len(node) > 0:
         return node[0].text in WILDCARD_PREFIX_OPERATOR_MAP.values()
-    # Ignoring mypy here because it doesn't think tuples can be empty
-    return False  # type: ignore[unreachable]
+    return False
 
 
-def get_wildcard_op(node: Node | tuple[Node]) -> str:
+def get_wildcard_op(node: Node | Sequence[Node]) -> str:
     if isinstance(node, Node):
         return node.text
-    if isinstance(node, tuple) and len(node) > 0:
+    if isinstance(node, Sequence) and len(node) > 0:
         return node[0].text
-    # Ignoring mypy here because it doesn't think tuples can be empty
-    return ""  # type: ignore[unreachable]
+    return ""
 
 
 def add_leading_wildcard(value: str) -> str:
@@ -1371,7 +1369,7 @@ class SearchVisitor(NodeVisitor[list[QueryToken]]):
             Node | tuple[Node],  # ! if present
             SearchKey,
             Node,  # :
-            Node | tuple[Node],  # wildcard_op if present
+            Node | Sequence[Node],  # wildcard_op if present
             list[str],
         ],
     ) -> SearchFilter:
@@ -1400,7 +1398,7 @@ class SearchVisitor(NodeVisitor[list[QueryToken]]):
             Node | tuple[Node],  # ! if present
             SearchKey,
             Node,  # :
-            Node | tuple[Node],  # wildcard_op if present
+            Node | Sequence[Node],  # wildcard_op if present
             Node | tuple[str],  # operator if present
             SearchValue,
         ],

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -393,30 +393,29 @@ def get_wildcard_op(node: Node | tuple[Node]) -> str:
 
 
 def add_leading_wildcard(value: str) -> str:
-    return f"*{value}" if not value.startswith("*") else value
-
-
-def remove_leading_wildcard(value: str) -> str:
-    return value[1:] if value.startswith("*") else value
+    if value.startswith('"') and value.endswith('"'):
+        return f'"*{value[1:]}' if not value.startswith('"*') else value
+    else:
+        return f"*{value}" if not value.startswith("*") else value
 
 
 def add_trailing_wildcard(value: str) -> str:
-    return f"{value}*" if not value.endswith("*") else value
-
-
-def remove_trailing_wildcard(value: str) -> str:
-    return value[:-1] if value.endswith("*") else value
+    if value.startswith('"') and value.endswith('"'):
+        return f'{value}*"' if not value.endswith('*"') else value
+    else:
+        return f"{value}*" if not value.endswith("*") else value
 
 
 def gen_wildcard_value(value: str, wildcard_op: str) -> str:
+    if value == "":
+        return value
+
     if wildcard_op == WILDCARD_PREFIX_OPERATOR_MAP["contains"]:
         value = add_leading_wildcard(value)
         value = add_trailing_wildcard(value)
     elif wildcard_op == WILDCARD_PREFIX_OPERATOR_MAP["starts_with"]:
-        value = remove_leading_wildcard(value)
         value = add_trailing_wildcard(value)
     elif wildcard_op == WILDCARD_PREFIX_OPERATOR_MAP["ends_with"]:
-        value = remove_trailing_wildcard(value)
         value = add_leading_wildcard(value)
     return value
 
@@ -1396,7 +1395,7 @@ class SearchVisitor(NodeVisitor[list[QueryToken]]):
 
         # XXX: We check whether the text in the node itself is actually empty, so
         # we can tell the difference between an empty quoted string and no string
-        if not search_value.raw_value and not node.children[4].text:
+        if not search_value.raw_value and not node.children[5].text:
             raise InvalidSearchQuery(f"Empty string after '{search_key.name}:'")
 
         if operator_s not in ("=", "!=") and search_key.name not in self.config.text_operator_keys:

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -384,25 +384,34 @@ def get_operator_value(operator: Node | list[str] | tuple[str] | str) -> str:
 def has_wildcard_op(node: Node | tuple[Node]) -> bool:
     if isinstance(node, Node):
         return node.text in WILDCARD_PREFIX_OPERATOR_MAP.values()
-    return node[0].text in WILDCARD_PREFIX_OPERATOR_MAP.values()
+    elif isinstance(node, tuple) and len(node) > 0:
+        return node[0].text in WILDCARD_PREFIX_OPERATOR_MAP.values()
 
 
 def get_wildcard_op(node: Node | tuple[Node]) -> str:
     if isinstance(node, Node):
         return node.text
-    return node[0].text
+    if isinstance(node, tuple) and len(node) > 0:
+        return node[0].text
+    return ""
 
 
 def add_leading_wildcard(value: str) -> str:
-    return f'"*{value[1:]}' if value.startswith('"') else f"*{value}"
+    if value.startswith('"') and value.endswith('"'):
+        return f"*{value[1:-1]}"
+    else:
+        return f"*{value}"
 
 
 def add_trailing_wildcard(value: str) -> str:
-    return f'{value[:-1]}*"' if value.endswith('"') else f"{value}*"
+    if value.startswith('"') and value.endswith('"'):
+        return f"{value[1:-1]}*"
+    else:
+        return f"{value}*"
 
 
 def gen_wildcard_value(value: str, wildcard_op: str) -> str:
-    if value == "":
+    if value == "" or wildcard_op == "":
         return value
     value = value.replace("*", "\\*")
     if wildcard_op in [

--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -301,6 +301,12 @@ OPERATOR_NEGATION_MAP = {
 }
 OPERATOR_TO_DJANGO = {">=": "gte", "<=": "lte", ">": "gt", "<": "lt", "=": "exact"}
 
+WILDCARD_PREFIX_OPERATOR_MAP = {
+    "contains": "%",
+    "starts_with": "^",
+    "ends_with": "$",
+}
+
 MAX_SEARCH_RELEASES = 1000
 SEMVER_EMPTY_RELEASE = "____SENTRY_EMPTY_RELEASE____"
 SEMVER_WILDCARDS = frozenset(["X", "*"])

--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -303,7 +303,7 @@ OPERATOR_TO_DJANGO = {">=": "gte", "<=": "lte", ">": "gt", "<": "lt", "=": "exac
 
 WILDCARD_UNICODE = "\uf00d"
 
-WILDCARD_PREFIX_OPERATOR_MAP = {
+WILDCARD_OPERATOR_MAP = {
     "contains": f"{WILDCARD_UNICODE}contains{WILDCARD_UNICODE}",
     "does_not_contain": f"{WILDCARD_UNICODE}does not contain{WILDCARD_UNICODE}",
     "starts_with": f"{WILDCARD_UNICODE}starts with{WILDCARD_UNICODE}",

--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -301,6 +301,12 @@ OPERATOR_NEGATION_MAP = {
 }
 OPERATOR_TO_DJANGO = {">=": "gte", "<=": "lte", ">": "gt", "<": "lt", "=": "exact"}
 
+# This is a unicode character from the reserved space of unicode characters, see:
+# https://en.wikipedia.org/wiki/Private_Use_Areas for more details.
+#
+# We use this character as a prefix and suffix with our wildcard operators to avoid
+# introducing breaking changes, and leave the possibility open down to the road to add in
+# new operators.
 WILDCARD_UNICODE = "\uf00d"
 
 WILDCARD_OPERATOR_MAP = {

--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -305,11 +305,8 @@ WILDCARD_UNICODE = "\uf00d"
 
 WILDCARD_OPERATOR_MAP = {
     "contains": f"{WILDCARD_UNICODE}contains{WILDCARD_UNICODE}",
-    "does_not_contain": f"{WILDCARD_UNICODE}does not contain{WILDCARD_UNICODE}",
     "starts_with": f"{WILDCARD_UNICODE}starts with{WILDCARD_UNICODE}",
-    "does_not_start_with": f"{WILDCARD_UNICODE}does not start with{WILDCARD_UNICODE}",
     "ends_with": f"{WILDCARD_UNICODE}ends with{WILDCARD_UNICODE}",
-    "does_not_end_with": f"{WILDCARD_UNICODE}does not end with{WILDCARD_UNICODE}",
 }
 
 MAX_SEARCH_RELEASES = 1000

--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -301,10 +301,15 @@ OPERATOR_NEGATION_MAP = {
 }
 OPERATOR_TO_DJANGO = {">=": "gte", "<=": "lte", ">": "gt", "<": "lt", "=": "exact"}
 
+WILDCARD_UNICODE = "\uf00d"
+
 WILDCARD_PREFIX_OPERATOR_MAP = {
-    "contains": "%",
-    "starts_with": "^",
-    "ends_with": "$",
+    "contains": f"{WILDCARD_UNICODE}contains{WILDCARD_UNICODE}",
+    "does_not_contain": f"{WILDCARD_UNICODE}does not contain{WILDCARD_UNICODE}",
+    "starts_with": f"{WILDCARD_UNICODE}starts with{WILDCARD_UNICODE}",
+    "does_not_start_with": f"{WILDCARD_UNICODE}does not start with{WILDCARD_UNICODE}",
+    "ends_with": f"{WILDCARD_UNICODE}ends with{WILDCARD_UNICODE}",
+    "does_not_end_with": f"{WILDCARD_UNICODE}does not end with{WILDCARD_UNICODE}",
 }
 
 MAX_SEARCH_RELEASES = 1000

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1099,3 +1099,31 @@ def test_handles_special_character_in_tags_and_flags(query, key, value) -> None:
 def test_handles_has_tags_and_flags(query, key) -> None:
     parsed = parse_search_query(query)
     assert parsed == [SearchFilter(SearchKey(key), "!=", SearchValue(""))]
+
+
+@pytest.mark.parametrize(
+    ["query", "expected"],
+    [
+        # --- contains ---
+        pytest.param("%span.description:test", "span.description:=^.*test.*$"),
+        pytest.param("%span.description:*test*", "span.description:=^.*test.*$"),
+        pytest.param("%span.description:test*", "span.description:=^.*test.*$"),
+        pytest.param("%span.description:*test", "span.description:=^.*test.*$"),
+        # --- starts with ---
+        pytest.param("^span.description:test", "span.description:=^test.*$"),
+        pytest.param("^span.description:test*", "span.description:=^test.*$"),
+        pytest.param("^span.description:*test", "span.description:=^test.*$"),
+        pytest.param("^span.description:*test*", "span.description:=^test.*$"),
+        # --- ends with ---
+        pytest.param("$span.description:test", "span.description:=^.*test$"),
+        pytest.param("$span.description:*test", "span.description:=^.*test$"),
+        pytest.param("$span.description:test*", "span.description:=^.*test$"),
+        pytest.param("$span.description:*test*", "span.description:=^.*test$"),
+    ],
+)
+def test_handles_wildcard_op_translations(query, expected) -> None:
+    filters = parse_search_query(query)
+    assert len(filters) == 1
+    assert isinstance(filters[0], SearchFilter)
+    actual = filters[0].to_query_string()
+    assert actual == expected

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1106,22 +1106,118 @@ def test_handles_has_tags_and_flags(query, key) -> None:
     [
         # --- contains ---
         pytest.param("%span.description:test", "span.description:=^.*test.*$"),
-        pytest.param("%span.description:*test*", "span.description:=^.*test.*$"),
-        pytest.param("%span.description:test*", "span.description:=^.*test.*$"),
         pytest.param("%span.description:*test", "span.description:=^.*test.*$"),
+        pytest.param("%span.description:test*", "span.description:=^.*test.*$"),
+        pytest.param("%span.description:*test*", "span.description:=^.*test.*$"),
+        # --- contains quoted text ---
+        pytest.param('%span.description:"test 1"', "span.description:=^.*test\\ 1.*$"),
+        pytest.param('%span.description:"*test 1"', "span.description:=^.*test\\ 1.*$"),
+        pytest.param('%span.description:"test 1*"', "span.description:=^.*test\\ 1.*$"),
+        pytest.param('%span.description:"*test 1*"', "span.description:=^.*test\\ 1.*$"),
+        # --- contains text list ---
+        pytest.param("%span.description:[test, test2]", "span.description:[*test*, *test2*]"),
+        pytest.param("%span.description:[*test, *test2]", "span.description:[*test*, *test2*]"),
+        pytest.param("%span.description:[test*, test2*]", "span.description:[*test*, *test2*]"),
+        pytest.param("%span.description:[*test*, *test2*]", "span.description:[*test*, *test2*]"),
+        # --- contains quoted text list ---
+        pytest.param(
+            '%span.description:["test 1", "test 2"]', "span.description:[*test 1*, *test 2*]"
+        ),
+        pytest.param(
+            '%span.description:["*test 1", "*test 2"]', "span.description:[*test 1*, *test 2*]"
+        ),
+        pytest.param(
+            '%span.description:["test 1*", "test 2*"]', "span.description:[*test 1*, *test 2*]"
+        ),
+        pytest.param(
+            '%span.description:["*test 1*", "*test 2*"]',
+            "span.description:[*test 1*, *test 2*]",
+        ),
+    ],
+)
+def test_handles_contains_wildcard_op_translations(query, expected) -> None:
+    filters = parse_search_query(query)
+    assert len(filters) == 1
+    assert isinstance(filters[0], SearchFilter)
+    actual = filters[0].to_query_string()
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    ["query", "expected"],
+    [
         # --- starts with ---
         pytest.param("^span.description:test", "span.description:=^test.*$"),
+        pytest.param("^span.description:*test", "span.description:=^.*test.*$"),
         pytest.param("^span.description:test*", "span.description:=^test.*$"),
-        pytest.param("^span.description:*test", "span.description:=^test.*$"),
-        pytest.param("^span.description:*test*", "span.description:=^test.*$"),
+        pytest.param("^span.description:*test*", "span.description:=^.*test.*$"),
+        # --- starts with quoted text ---
+        pytest.param('^span.description:"test 1"', "span.description:=^test\\ 1.*$"),
+        pytest.param('^span.description:"*test 1"', "span.description:=^.*test\\ 1.*$"),
+        pytest.param('^span.description:"test 1*"', "span.description:=^test\\ 1.*$"),
+        pytest.param('^span.description:"*test 1*"', "span.description:=^.*test\\ 1.*$"),
+        # --- starts with text list ---
+        pytest.param("^span.description:[test, test2]", "span.description:[test*, test2*]"),
+        pytest.param("^span.description:[*test, *test2]", "span.description:[*test*, *test2*]"),
+        pytest.param("^span.description:[test*, test2*]", "span.description:[test*, test2*]"),
+        pytest.param("^span.description:[*test*, *test2*]", "span.description:[*test*, *test2*]"),
+        # --- starts with quoted text list ---
+        pytest.param(
+            '^span.description:["test 1", "test 2"]', "span.description:[test 1*, test 2*]"
+        ),
+        pytest.param(
+            '^span.description:["*test 1", "*test 2"]', "span.description:[*test 1*, *test 2*]"
+        ),
+        pytest.param(
+            '^span.description:["test 1*", "test 2*"]', "span.description:[test 1*, test 2*]"
+        ),
+        pytest.param(
+            '^span.description:["*test 1*", "*test 2*"]', "span.description:[*test 1*, *test 2*]"
+        ),
+    ],
+)
+def test_handles_starts_with_wildcard_op_translations(query, expected) -> None:
+    filters = parse_search_query(query)
+    assert len(filters) == 1
+    assert isinstance(filters[0], SearchFilter)
+    actual = filters[0].to_query_string()
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    ["query", "expected"],
+    [
         # --- ends with ---
         pytest.param("$span.description:test", "span.description:=^.*test$"),
         pytest.param("$span.description:*test", "span.description:=^.*test$"),
-        pytest.param("$span.description:test*", "span.description:=^.*test$"),
-        pytest.param("$span.description:*test*", "span.description:=^.*test$"),
+        pytest.param("$span.description:test*", "span.description:=^.*test.*$"),
+        pytest.param("$span.description:*test*", "span.description:=^.*test.*$"),
+        # --- ends with quoted text ---
+        pytest.param('$span.description:"test 1"', "span.description:=^.*test\\ 1$"),
+        pytest.param('$span.description:"*test 1"', "span.description:=^.*test\\ 1$"),
+        pytest.param('$span.description:"test 1*"', "span.description:=^.*test\\ 1.*$"),
+        pytest.param('$span.description:"*test 1*"', "span.description:=^.*test\\ 1.*$"),
+        # --- ends with text list ---
+        pytest.param("$span.description:[test, test2]", "span.description:[*test, *test2]"),
+        pytest.param("$span.description:[*test, *test2]", "span.description:[*test, *test2]"),
+        pytest.param("$span.description:[test*, test2*]", "span.description:[*test*, *test2*]"),
+        pytest.param("$span.description:[*test*, *test2*]", "span.description:[*test*, *test2*]"),
+        # --- ends with quoted text list ---
+        pytest.param(
+            '$span.description:["test 1", "test 2"]', "span.description:[*test 1, *test 2]"
+        ),
+        pytest.param(
+            '$span.description:["*test 1", "*test 2"]', "span.description:[*test 1, *test 2]"
+        ),
+        pytest.param(
+            '$span.description:["test 1*", "test 2*"]', "span.description:[*test 1*, *test 2*]"
+        ),
+        pytest.param(
+            '$span.description:["*test 1*", "*test 2*"]', "span.description:[*test 1*, *test 2*]"
+        ),
     ],
 )
-def test_handles_wildcard_op_translations(query, expected) -> None:
+def test_handles_ends_with_wildcard_op_translations(query, expected) -> None:
     filters = parse_search_query(query)
     assert len(filters) == 1
     assert isinstance(filters[0], SearchFilter)

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -18,12 +18,13 @@ from sentry.api.event_search import (
     _RecursiveList,
     default_config,
     flatten,
+    gen_wildcard_value,
     parse_search_query,
     translate_wildcard_as_clickhouse_pattern,
 )
 from sentry.constants import MODULE_ROOT
 from sentry.exceptions import InvalidSearchQuery
-from sentry.search.events.constants import WILDCARD_UNICODE
+from sentry.search.events.constants import WILDCARD_OPERATOR_MAP, WILDCARD_UNICODE
 from sentry.search.utils import parse_datetime_string, parse_duration, parse_numeric_value
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.utils import json
@@ -1100,6 +1101,20 @@ def test_handles_special_character_in_tags_and_flags(query, key, value) -> None:
 def test_handles_has_tags_and_flags(query, key) -> None:
     parsed = parse_search_query(query)
     assert parsed == [SearchFilter(SearchKey(key), "!=", SearchValue(""))]
+
+
+@pytest.mark.parametrize(
+    ["value", "wildcard_op", "expected"],
+    [
+        # testing basic cases
+        pytest.param("test", "", "test"),
+        pytest.param("", WILDCARD_OPERATOR_MAP["contains"], ""),
+        pytest.param("*test*", WILDCARD_OPERATOR_MAP["contains"], "*\\*test\\**"),
+        pytest.param("\\*test\\*", WILDCARD_OPERATOR_MAP["contains"], "*\\*test\\**"),
+    ],
+)
+def test_gen_wildcard_value(value, wildcard_op, expected) -> None:
+    assert gen_wildcard_value(value, wildcard_op) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1105,33 +1105,27 @@ def test_handles_has_tags_and_flags(query, key) -> None:
     ["query", "expected"],
     [
         # --- contains ---
-        pytest.param("%span.description:test", "span.description:=^.*test.*$"),
-        pytest.param("%span.description:*test", "span.description:=^.*test.*$"),
-        pytest.param("%span.description:test*", "span.description:=^.*test.*$"),
-        pytest.param("%span.description:*test*", "span.description:=^.*test.*$"),
+        pytest.param("%span.op:test", "span.op:=^.*test.*$"),
+        pytest.param("%span.op:*test", "span.op:=^.*test.*$"),
+        pytest.param("%span.op:test*", "span.op:=^.*test.*$"),
+        pytest.param("%span.op:*test*", "span.op:=^.*test.*$"),
         # --- contains quoted text ---
-        pytest.param('%span.description:"test 1"', "span.description:=^.*test\\ 1.*$"),
-        pytest.param('%span.description:"*test 1"', "span.description:=^.*test\\ 1.*$"),
-        pytest.param('%span.description:"test 1*"', "span.description:=^.*test\\ 1.*$"),
-        pytest.param('%span.description:"*test 1*"', "span.description:=^.*test\\ 1.*$"),
+        pytest.param('%span.op:"test 1"', "span.op:=^.*test\\ 1.*$"),
+        pytest.param('%span.op:"*test 1"', "span.op:=^.*test\\ 1.*$"),
+        pytest.param('%span.op:"test 1*"', "span.op:=^.*test\\ 1.*$"),
+        pytest.param('%span.op:"*test 1*"', "span.op:=^.*test\\ 1.*$"),
         # --- contains text list ---
-        pytest.param("%span.description:[test, test2]", "span.description:[*test*, *test2*]"),
-        pytest.param("%span.description:[*test, *test2]", "span.description:[*test*, *test2*]"),
-        pytest.param("%span.description:[test*, test2*]", "span.description:[*test*, *test2*]"),
-        pytest.param("%span.description:[*test*, *test2*]", "span.description:[*test*, *test2*]"),
+        pytest.param("%span.op:[test, test2]", "span.op:[*test*, *test2*]"),
+        pytest.param("%span.op:[*test, *test2]", "span.op:[*test*, *test2*]"),
+        pytest.param("%span.op:[test*, test2*]", "span.op:[*test*, *test2*]"),
+        pytest.param("%span.op:[*test*, *test2*]", "span.op:[*test*, *test2*]"),
         # --- contains quoted text list ---
+        pytest.param('%span.op:["test 1", "test 2"]', "span.op:[*test 1*, *test 2*]"),
+        pytest.param('%span.op:["*test 1", "*test 2"]', "span.op:[*test 1*, *test 2*]"),
+        pytest.param('%span.op:["test 1*", "test 2*"]', "span.op:[*test 1*, *test 2*]"),
         pytest.param(
-            '%span.description:["test 1", "test 2"]', "span.description:[*test 1*, *test 2*]"
-        ),
-        pytest.param(
-            '%span.description:["*test 1", "*test 2"]', "span.description:[*test 1*, *test 2*]"
-        ),
-        pytest.param(
-            '%span.description:["test 1*", "test 2*"]', "span.description:[*test 1*, *test 2*]"
-        ),
-        pytest.param(
-            '%span.description:["*test 1*", "*test 2*"]',
-            "span.description:[*test 1*, *test 2*]",
+            '%span.op:["*test 1*", "*test 2*"]',
+            "span.op:[*test 1*, *test 2*]",
         ),
     ],
 )
@@ -1147,33 +1141,25 @@ def test_handles_contains_wildcard_op_translations(query, expected) -> None:
     ["query", "expected"],
     [
         # --- starts with ---
-        pytest.param("^span.description:test", "span.description:=^test.*$"),
-        pytest.param("^span.description:*test", "span.description:=^.*test.*$"),
-        pytest.param("^span.description:test*", "span.description:=^test.*$"),
-        pytest.param("^span.description:*test*", "span.description:=^.*test.*$"),
+        pytest.param("^span.op:test", "span.op:=^test.*$"),
+        pytest.param("^span.op:*test", "span.op:=^.*test.*$"),
+        pytest.param("^span.op:test*", "span.op:=^test.*$"),
+        pytest.param("^span.op:*test*", "span.op:=^.*test.*$"),
         # --- starts with quoted text ---
-        pytest.param('^span.description:"test 1"', "span.description:=^test\\ 1.*$"),
-        pytest.param('^span.description:"*test 1"', "span.description:=^.*test\\ 1.*$"),
-        pytest.param('^span.description:"test 1*"', "span.description:=^test\\ 1.*$"),
-        pytest.param('^span.description:"*test 1*"', "span.description:=^.*test\\ 1.*$"),
+        pytest.param('^span.op:"test 1"', "span.op:=^test\\ 1.*$"),
+        pytest.param('^span.op:"*test 1"', "span.op:=^.*test\\ 1.*$"),
+        pytest.param('^span.op:"test 1*"', "span.op:=^test\\ 1.*$"),
+        pytest.param('^span.op:"*test 1*"', "span.op:=^.*test\\ 1.*$"),
         # --- starts with text list ---
-        pytest.param("^span.description:[test, test2]", "span.description:[test*, test2*]"),
-        pytest.param("^span.description:[*test, *test2]", "span.description:[*test*, *test2*]"),
-        pytest.param("^span.description:[test*, test2*]", "span.description:[test*, test2*]"),
-        pytest.param("^span.description:[*test*, *test2*]", "span.description:[*test*, *test2*]"),
+        pytest.param("^span.op:[test, test2]", "span.op:[test*, test2*]"),
+        pytest.param("^span.op:[*test, *test2]", "span.op:[*test*, *test2*]"),
+        pytest.param("^span.op:[test*, test2*]", "span.op:[test*, test2*]"),
+        pytest.param("^span.op:[*test*, *test2*]", "span.op:[*test*, *test2*]"),
         # --- starts with quoted text list ---
-        pytest.param(
-            '^span.description:["test 1", "test 2"]', "span.description:[test 1*, test 2*]"
-        ),
-        pytest.param(
-            '^span.description:["*test 1", "*test 2"]', "span.description:[*test 1*, *test 2*]"
-        ),
-        pytest.param(
-            '^span.description:["test 1*", "test 2*"]', "span.description:[test 1*, test 2*]"
-        ),
-        pytest.param(
-            '^span.description:["*test 1*", "*test 2*"]', "span.description:[*test 1*, *test 2*]"
-        ),
+        pytest.param('^span.op:["test 1", "test 2"]', "span.op:[test 1*, test 2*]"),
+        pytest.param('^span.op:["*test 1", "*test 2"]', "span.op:[*test 1*, *test 2*]"),
+        pytest.param('^span.op:["test 1*", "test 2*"]', "span.op:[test 1*, test 2*]"),
+        pytest.param('^span.op:["*test 1*", "*test 2*"]', "span.op:[*test 1*, *test 2*]"),
     ],
 )
 def test_handles_starts_with_wildcard_op_translations(query, expected) -> None:
@@ -1188,33 +1174,25 @@ def test_handles_starts_with_wildcard_op_translations(query, expected) -> None:
     ["query", "expected"],
     [
         # --- ends with ---
-        pytest.param("$span.description:test", "span.description:=^.*test$"),
-        pytest.param("$span.description:*test", "span.description:=^.*test$"),
-        pytest.param("$span.description:test*", "span.description:=^.*test.*$"),
-        pytest.param("$span.description:*test*", "span.description:=^.*test.*$"),
+        pytest.param("$span.op:test", "span.op:=^.*test$"),
+        pytest.param("$span.op:*test", "span.op:=^.*test$"),
+        pytest.param("$span.op:test*", "span.op:=^.*test.*$"),
+        pytest.param("$span.op:*test*", "span.op:=^.*test.*$"),
         # --- ends with quoted text ---
-        pytest.param('$span.description:"test 1"', "span.description:=^.*test\\ 1$"),
-        pytest.param('$span.description:"*test 1"', "span.description:=^.*test\\ 1$"),
-        pytest.param('$span.description:"test 1*"', "span.description:=^.*test\\ 1.*$"),
-        pytest.param('$span.description:"*test 1*"', "span.description:=^.*test\\ 1.*$"),
+        pytest.param('$span.op:"test 1"', "span.op:=^.*test\\ 1$"),
+        pytest.param('$span.op:"*test 1"', "span.op:=^.*test\\ 1$"),
+        pytest.param('$span.op:"test 1*"', "span.op:=^.*test\\ 1.*$"),
+        pytest.param('$span.op:"*test 1*"', "span.op:=^.*test\\ 1.*$"),
         # --- ends with text list ---
-        pytest.param("$span.description:[test, test2]", "span.description:[*test, *test2]"),
-        pytest.param("$span.description:[*test, *test2]", "span.description:[*test, *test2]"),
-        pytest.param("$span.description:[test*, test2*]", "span.description:[*test*, *test2*]"),
-        pytest.param("$span.description:[*test*, *test2*]", "span.description:[*test*, *test2*]"),
+        pytest.param("$span.op:[test, test2]", "span.op:[*test, *test2]"),
+        pytest.param("$span.op:[*test, *test2]", "span.op:[*test, *test2]"),
+        pytest.param("$span.op:[test*, test2*]", "span.op:[*test*, *test2*]"),
+        pytest.param("$span.op:[*test*, *test2*]", "span.op:[*test*, *test2*]"),
         # --- ends with quoted text list ---
-        pytest.param(
-            '$span.description:["test 1", "test 2"]', "span.description:[*test 1, *test 2]"
-        ),
-        pytest.param(
-            '$span.description:["*test 1", "*test 2"]', "span.description:[*test 1, *test 2]"
-        ),
-        pytest.param(
-            '$span.description:["test 1*", "test 2*"]', "span.description:[*test 1*, *test 2*]"
-        ),
-        pytest.param(
-            '$span.description:["*test 1*", "*test 2*"]', "span.description:[*test 1*, *test 2*]"
-        ),
+        pytest.param('$span.op:["test 1", "test 2"]', "span.op:[*test 1, *test 2]"),
+        pytest.param('$span.op:["*test 1", "*test 2"]', "span.op:[*test 1, *test 2]"),
+        pytest.param('$span.op:["test 1*", "test 2*"]', "span.op:[*test 1*, *test 2*]"),
+        pytest.param('$span.op:["*test 1*", "*test 2*"]', "span.op:[*test 1*, *test 2*]"),
     ],
 )
 def test_handles_ends_with_wildcard_op_translations(query, expected) -> None:

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -23,6 +23,7 @@ from sentry.api.event_search import (
 )
 from sentry.constants import MODULE_ROOT
 from sentry.exceptions import InvalidSearchQuery
+from sentry.search.events.constants import WILDCARD_UNICODE
 from sentry.search.utils import parse_datetime_string, parse_duration, parse_numeric_value
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.utils import json
@@ -1105,26 +1106,67 @@ def test_handles_has_tags_and_flags(query, key) -> None:
     ["query", "expected"],
     [
         # --- contains ---
-        pytest.param("%span.op:test", "span.op:=^.*test.*$"),
-        pytest.param("%span.op:*test", "span.op:=^.*test.*$"),
-        pytest.param("%span.op:test*", "span.op:=^.*test.*$"),
-        pytest.param("%span.op:*test*", "span.op:=^.*test.*$"),
-        # --- contains quoted text ---
-        pytest.param('%span.op:"test 1"', "span.op:=^.*test\\ 1.*$"),
-        pytest.param('%span.op:"*test 1"', "span.op:=^.*test\\ 1.*$"),
-        pytest.param('%span.op:"test 1*"', "span.op:=^.*test\\ 1.*$"),
-        pytest.param('%span.op:"*test 1*"', "span.op:=^.*test\\ 1.*$"),
-        # --- contains text list ---
-        pytest.param("%span.op:[test, test2]", "span.op:[*test*, *test2*]"),
-        pytest.param("%span.op:[*test, *test2]", "span.op:[*test*, *test2*]"),
-        pytest.param("%span.op:[test*, test2*]", "span.op:[*test*, *test2*]"),
-        pytest.param("%span.op:[*test*, *test2*]", "span.op:[*test*, *test2*]"),
-        # --- contains quoted text list ---
-        pytest.param('%span.op:["test 1", "test 2"]', "span.op:[*test 1*, *test 2*]"),
-        pytest.param('%span.op:["*test 1", "*test 2"]', "span.op:[*test 1*, *test 2*]"),
-        pytest.param('%span.op:["test 1*", "test 2*"]', "span.op:[*test 1*, *test 2*]"),
         pytest.param(
-            '%span.op:["*test 1*", "*test 2*"]',
+            f"span.op:{WILDCARD_UNICODE}contains{WILDCARD_UNICODE}test", "span.op:=^.*test.*$"
+        ),
+        pytest.param(
+            f"span.op:{WILDCARD_UNICODE}contains{WILDCARD_UNICODE}*test", "span.op:=^.*test.*$"
+        ),
+        pytest.param(
+            f"span.op:{WILDCARD_UNICODE}contains{WILDCARD_UNICODE}test*", "span.op:=^.*test.*$"
+        ),
+        pytest.param(
+            f"span.op:{WILDCARD_UNICODE}contains{WILDCARD_UNICODE}*test*", "span.op:=^.*test.*$"
+        ),
+        # --- contains quoted text ---
+        pytest.param(
+            f'span.op:{WILDCARD_UNICODE}contains{WILDCARD_UNICODE}"test 1"',
+            "span.op:=^.*test\\ 1.*$",
+        ),
+        pytest.param(
+            f'span.op:{WILDCARD_UNICODE}contains{WILDCARD_UNICODE}"*test 1"',
+            "span.op:=^.*test\\ 1.*$",
+        ),
+        pytest.param(
+            f'span.op:{WILDCARD_UNICODE}contains{WILDCARD_UNICODE}"test 1*"',
+            "span.op:=^.*test\\ 1.*$",
+        ),
+        pytest.param(
+            f'span.op:{WILDCARD_UNICODE}contains{WILDCARD_UNICODE}"*test 1*"',
+            "span.op:=^.*test\\ 1.*$",
+        ),
+        # --- contains text list ---
+        pytest.param(
+            f"span.op:{WILDCARD_UNICODE}contains{WILDCARD_UNICODE}[test, test2]",
+            "span.op:[*test*, *test2*]",
+        ),
+        pytest.param(
+            f"span.op:{WILDCARD_UNICODE}contains{WILDCARD_UNICODE}[*test, *test2]",
+            "span.op:[*test*, *test2*]",
+        ),
+        pytest.param(
+            f"span.op:{WILDCARD_UNICODE}contains{WILDCARD_UNICODE}[test*, test2*]",
+            "span.op:[*test*, *test2*]",
+        ),
+        pytest.param(
+            f"span.op:{WILDCARD_UNICODE}contains{WILDCARD_UNICODE}[*test*, *test2*]",
+            "span.op:[*test*, *test2*]",
+        ),
+        # --- contains quoted text list ---
+        pytest.param(
+            f'span.op:{WILDCARD_UNICODE}contains{WILDCARD_UNICODE}["test 1", "test 2"]',
+            "span.op:[*test 1*, *test 2*]",
+        ),
+        pytest.param(
+            f'span.op:{WILDCARD_UNICODE}contains{WILDCARD_UNICODE}["*test 1", "*test 2"]',
+            "span.op:[*test 1*, *test 2*]",
+        ),
+        pytest.param(
+            f'span.op:{WILDCARD_UNICODE}contains{WILDCARD_UNICODE}["test 1*", "test 2*"]',
+            "span.op:[*test 1*, *test 2*]",
+        ),
+        pytest.param(
+            f'span.op:{WILDCARD_UNICODE}contains{WILDCARD_UNICODE}["*test 1*", "*test 2*"]',
             "span.op:[*test 1*, *test 2*]",
         ),
     ],
@@ -1141,25 +1183,69 @@ def test_handles_contains_wildcard_op_translations(query, expected) -> None:
     ["query", "expected"],
     [
         # --- starts with ---
-        pytest.param("^span.op:test", "span.op:=^test.*$"),
-        pytest.param("^span.op:*test", "span.op:=^.*test.*$"),
-        pytest.param("^span.op:test*", "span.op:=^test.*$"),
-        pytest.param("^span.op:*test*", "span.op:=^.*test.*$"),
+        pytest.param(
+            f"span.op:{WILDCARD_UNICODE}starts with{WILDCARD_UNICODE}test", "span.op:=^test.*$"
+        ),
+        pytest.param(
+            f"span.op:{WILDCARD_UNICODE}starts with{WILDCARD_UNICODE}*test", "span.op:=^.*test.*$"
+        ),
+        pytest.param(
+            f"span.op:{WILDCARD_UNICODE}starts with{WILDCARD_UNICODE}test*", "span.op:=^test.*$"
+        ),
+        pytest.param(
+            f"span.op:{WILDCARD_UNICODE}starts with{WILDCARD_UNICODE}*test*", "span.op:=^.*test.*$"
+        ),
         # --- starts with quoted text ---
-        pytest.param('^span.op:"test 1"', "span.op:=^test\\ 1.*$"),
-        pytest.param('^span.op:"*test 1"', "span.op:=^.*test\\ 1.*$"),
-        pytest.param('^span.op:"test 1*"', "span.op:=^test\\ 1.*$"),
-        pytest.param('^span.op:"*test 1*"', "span.op:=^.*test\\ 1.*$"),
+        pytest.param(
+            f'span.op:{WILDCARD_UNICODE}starts with{WILDCARD_UNICODE}"test 1"',
+            "span.op:=^test\\ 1.*$",
+        ),
+        pytest.param(
+            f'span.op:{WILDCARD_UNICODE}starts with{WILDCARD_UNICODE}"*test 1"',
+            "span.op:=^.*test\\ 1.*$",
+        ),
+        pytest.param(
+            f'span.op:{WILDCARD_UNICODE}starts with{WILDCARD_UNICODE}"test 1*"',
+            "span.op:=^test\\ 1.*$",
+        ),
+        pytest.param(
+            f'span.op:{WILDCARD_UNICODE}starts with{WILDCARD_UNICODE}"*test 1*"',
+            "span.op:=^.*test\\ 1.*$",
+        ),
         # --- starts with text list ---
-        pytest.param("^span.op:[test, test2]", "span.op:[test*, test2*]"),
-        pytest.param("^span.op:[*test, *test2]", "span.op:[*test*, *test2*]"),
-        pytest.param("^span.op:[test*, test2*]", "span.op:[test*, test2*]"),
-        pytest.param("^span.op:[*test*, *test2*]", "span.op:[*test*, *test2*]"),
+        pytest.param(
+            f"span.op:{WILDCARD_UNICODE}starts with{WILDCARD_UNICODE}[test, test2]",
+            "span.op:[test*, test2*]",
+        ),
+        pytest.param(
+            f"span.op:{WILDCARD_UNICODE}starts with{WILDCARD_UNICODE}[*test, *test2]",
+            "span.op:[*test*, *test2*]",
+        ),
+        pytest.param(
+            f"span.op:{WILDCARD_UNICODE}starts with{WILDCARD_UNICODE}[test*, test2*]",
+            "span.op:[test*, test2*]",
+        ),
+        pytest.param(
+            f"span.op:{WILDCARD_UNICODE}starts with{WILDCARD_UNICODE}[*test*, *test2*]",
+            "span.op:[*test*, *test2*]",
+        ),
         # --- starts with quoted text list ---
-        pytest.param('^span.op:["test 1", "test 2"]', "span.op:[test 1*, test 2*]"),
-        pytest.param('^span.op:["*test 1", "*test 2"]', "span.op:[*test 1*, *test 2*]"),
-        pytest.param('^span.op:["test 1*", "test 2*"]', "span.op:[test 1*, test 2*]"),
-        pytest.param('^span.op:["*test 1*", "*test 2*"]', "span.op:[*test 1*, *test 2*]"),
+        pytest.param(
+            f'span.op:{WILDCARD_UNICODE}starts with{WILDCARD_UNICODE}["test 1", "test 2"]',
+            "span.op:[test 1*, test 2*]",
+        ),
+        pytest.param(
+            f'span.op:{WILDCARD_UNICODE}starts with{WILDCARD_UNICODE}["*test 1", "*test 2"]',
+            "span.op:[*test 1*, *test 2*]",
+        ),
+        pytest.param(
+            f'span.op:{WILDCARD_UNICODE}starts with{WILDCARD_UNICODE}["test 1*", "test 2*"]',
+            "span.op:[test 1*, test 2*]",
+        ),
+        pytest.param(
+            f'span.op:{WILDCARD_UNICODE}starts with{WILDCARD_UNICODE}["*test 1*", "*test 2*"]',
+            "span.op:[*test 1*, *test 2*]",
+        ),
     ],
 )
 def test_handles_starts_with_wildcard_op_translations(query, expected) -> None:
@@ -1174,25 +1260,69 @@ def test_handles_starts_with_wildcard_op_translations(query, expected) -> None:
     ["query", "expected"],
     [
         # --- ends with ---
-        pytest.param("$span.op:test", "span.op:=^.*test$"),
-        pytest.param("$span.op:*test", "span.op:=^.*test$"),
-        pytest.param("$span.op:test*", "span.op:=^.*test.*$"),
-        pytest.param("$span.op:*test*", "span.op:=^.*test.*$"),
+        pytest.param(
+            f"span.op:{WILDCARD_UNICODE}ends with{WILDCARD_UNICODE}test", "span.op:=^.*test$"
+        ),
+        pytest.param(
+            f"span.op:{WILDCARD_UNICODE}ends with{WILDCARD_UNICODE}*test", "span.op:=^.*test$"
+        ),
+        pytest.param(
+            f"span.op:{WILDCARD_UNICODE}ends with{WILDCARD_UNICODE}test*", "span.op:=^.*test.*$"
+        ),
+        pytest.param(
+            f"span.op:{WILDCARD_UNICODE}ends with{WILDCARD_UNICODE}*test*", "span.op:=^.*test.*$"
+        ),
         # --- ends with quoted text ---
-        pytest.param('$span.op:"test 1"', "span.op:=^.*test\\ 1$"),
-        pytest.param('$span.op:"*test 1"', "span.op:=^.*test\\ 1$"),
-        pytest.param('$span.op:"test 1*"', "span.op:=^.*test\\ 1.*$"),
-        pytest.param('$span.op:"*test 1*"', "span.op:=^.*test\\ 1.*$"),
+        pytest.param(
+            f'span.op:{WILDCARD_UNICODE}ends with{WILDCARD_UNICODE}"test 1"',
+            "span.op:=^.*test\\ 1$",
+        ),
+        pytest.param(
+            f'span.op:{WILDCARD_UNICODE}ends with{WILDCARD_UNICODE}"*test 1"',
+            "span.op:=^.*test\\ 1$",
+        ),
+        pytest.param(
+            f'span.op:{WILDCARD_UNICODE}ends with{WILDCARD_UNICODE}"test 1*"',
+            "span.op:=^.*test\\ 1.*$",
+        ),
+        pytest.param(
+            f'span.op:{WILDCARD_UNICODE}ends with{WILDCARD_UNICODE}"*test 1*"',
+            "span.op:=^.*test\\ 1.*$",
+        ),
         # --- ends with text list ---
-        pytest.param("$span.op:[test, test2]", "span.op:[*test, *test2]"),
-        pytest.param("$span.op:[*test, *test2]", "span.op:[*test, *test2]"),
-        pytest.param("$span.op:[test*, test2*]", "span.op:[*test*, *test2*]"),
-        pytest.param("$span.op:[*test*, *test2*]", "span.op:[*test*, *test2*]"),
+        pytest.param(
+            f"span.op:{WILDCARD_UNICODE}ends with{WILDCARD_UNICODE}[test, test2]",
+            "span.op:[*test, *test2]",
+        ),
+        pytest.param(
+            f"span.op:{WILDCARD_UNICODE}ends with{WILDCARD_UNICODE}[*test, *test2]",
+            "span.op:[*test, *test2]",
+        ),
+        pytest.param(
+            f"span.op:{WILDCARD_UNICODE}ends with{WILDCARD_UNICODE}[test*, test2*]",
+            "span.op:[*test*, *test2*]",
+        ),
+        pytest.param(
+            f"span.op:{WILDCARD_UNICODE}ends with{WILDCARD_UNICODE}[*test*, *test2*]",
+            "span.op:[*test*, *test2*]",
+        ),
         # --- ends with quoted text list ---
-        pytest.param('$span.op:["test 1", "test 2"]', "span.op:[*test 1, *test 2]"),
-        pytest.param('$span.op:["*test 1", "*test 2"]', "span.op:[*test 1, *test 2]"),
-        pytest.param('$span.op:["test 1*", "test 2*"]', "span.op:[*test 1*, *test 2*]"),
-        pytest.param('$span.op:["*test 1*", "*test 2*"]', "span.op:[*test 1*, *test 2*]"),
+        pytest.param(
+            f'span.op:{WILDCARD_UNICODE}ends with{WILDCARD_UNICODE}["test 1", "test 2"]',
+            "span.op:[*test 1, *test 2]",
+        ),
+        pytest.param(
+            f'span.op:{WILDCARD_UNICODE}ends with{WILDCARD_UNICODE}["*test 1", "*test 2"]',
+            "span.op:[*test 1, *test 2]",
+        ),
+        pytest.param(
+            f'span.op:{WILDCARD_UNICODE}ends with{WILDCARD_UNICODE}["test 1*", "test 2*"]',
+            "span.op:[*test 1*, *test 2*]",
+        ),
+        pytest.param(
+            f'span.op:{WILDCARD_UNICODE}ends with{WILDCARD_UNICODE}["*test 1*", "*test 2*"]',
+            "span.op:[*test 1*, *test 2*]",
+        ),
     ],
 )
 def test_handles_ends_with_wildcard_op_translations(query, expected) -> None:

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1110,13 +1110,14 @@ def test_handles_has_tags_and_flags(query, key) -> None:
             f"span.op:{WILDCARD_UNICODE}contains{WILDCARD_UNICODE}test", "span.op:=^.*test.*$"
         ),
         pytest.param(
-            f"span.op:{WILDCARD_UNICODE}contains{WILDCARD_UNICODE}*test", "span.op:=^.*test.*$"
+            f"span.op:{WILDCARD_UNICODE}contains{WILDCARD_UNICODE}*test", "span.op:=^.*\\*test.*$"
         ),
         pytest.param(
-            f"span.op:{WILDCARD_UNICODE}contains{WILDCARD_UNICODE}test*", "span.op:=^.*test.*$"
+            f"span.op:{WILDCARD_UNICODE}contains{WILDCARD_UNICODE}test*", "span.op:=^.*test\\*.*$"
         ),
         pytest.param(
-            f"span.op:{WILDCARD_UNICODE}contains{WILDCARD_UNICODE}*test*", "span.op:=^.*test.*$"
+            f"span.op:{WILDCARD_UNICODE}contains{WILDCARD_UNICODE}*test*",
+            "span.op:=^.*\\*test\\*.*$",
         ),
         # --- contains quoted text ---
         pytest.param(
@@ -1125,15 +1126,15 @@ def test_handles_has_tags_and_flags(query, key) -> None:
         ),
         pytest.param(
             f'span.op:{WILDCARD_UNICODE}contains{WILDCARD_UNICODE}"*test 1"',
-            "span.op:=^.*test\\ 1.*$",
+            "span.op:=^.*\\*test\\ 1.*$",
         ),
         pytest.param(
             f'span.op:{WILDCARD_UNICODE}contains{WILDCARD_UNICODE}"test 1*"',
-            "span.op:=^.*test\\ 1.*$",
+            "span.op:=^.*test\\ 1\\*.*$",
         ),
         pytest.param(
             f'span.op:{WILDCARD_UNICODE}contains{WILDCARD_UNICODE}"*test 1*"',
-            "span.op:=^.*test\\ 1.*$",
+            "span.op:=^.*\\*test\\ 1\\*.*$",
         ),
         # --- contains text list ---
         pytest.param(
@@ -1142,15 +1143,15 @@ def test_handles_has_tags_and_flags(query, key) -> None:
         ),
         pytest.param(
             f"span.op:{WILDCARD_UNICODE}contains{WILDCARD_UNICODE}[*test, *test2]",
-            "span.op:[*test*, *test2*]",
+            "span.op:[*\\*test*, *\\*test2*]",
         ),
         pytest.param(
             f"span.op:{WILDCARD_UNICODE}contains{WILDCARD_UNICODE}[test*, test2*]",
-            "span.op:[*test*, *test2*]",
+            "span.op:[*test\\**, *test2\\**]",
         ),
         pytest.param(
             f"span.op:{WILDCARD_UNICODE}contains{WILDCARD_UNICODE}[*test*, *test2*]",
-            "span.op:[*test*, *test2*]",
+            "span.op:[*\\*test\\**, *\\*test2\\**]",
         ),
         # --- contains quoted text list ---
         pytest.param(
@@ -1159,15 +1160,15 @@ def test_handles_has_tags_and_flags(query, key) -> None:
         ),
         pytest.param(
             f'span.op:{WILDCARD_UNICODE}contains{WILDCARD_UNICODE}["*test 1", "*test 2"]',
-            "span.op:[*test 1*, *test 2*]",
+            "span.op:[*\\*test 1*, *\\*test 2*]",
         ),
         pytest.param(
             f'span.op:{WILDCARD_UNICODE}contains{WILDCARD_UNICODE}["test 1*", "test 2*"]',
-            "span.op:[*test 1*, *test 2*]",
+            "span.op:[*test 1\\**, *test 2\\**]",
         ),
         pytest.param(
             f'span.op:{WILDCARD_UNICODE}contains{WILDCARD_UNICODE}["*test 1*", "*test 2*"]',
-            "span.op:[*test 1*, *test 2*]",
+            "span.op:[*\\*test 1\\**, *\\*test 2\\**]",
         ),
     ],
 )
@@ -1187,13 +1188,14 @@ def test_handles_contains_wildcard_op_translations(query, expected) -> None:
             f"span.op:{WILDCARD_UNICODE}starts with{WILDCARD_UNICODE}test", "span.op:=^test.*$"
         ),
         pytest.param(
-            f"span.op:{WILDCARD_UNICODE}starts with{WILDCARD_UNICODE}*test", "span.op:=^.*test.*$"
+            f"span.op:{WILDCARD_UNICODE}starts with{WILDCARD_UNICODE}*test", "span.op:=^\\*test.*$"
         ),
         pytest.param(
-            f"span.op:{WILDCARD_UNICODE}starts with{WILDCARD_UNICODE}test*", "span.op:=^test.*$"
+            f"span.op:{WILDCARD_UNICODE}starts with{WILDCARD_UNICODE}test*", "span.op:=^test\\*.*$"
         ),
         pytest.param(
-            f"span.op:{WILDCARD_UNICODE}starts with{WILDCARD_UNICODE}*test*", "span.op:=^.*test.*$"
+            f"span.op:{WILDCARD_UNICODE}starts with{WILDCARD_UNICODE}*test*",
+            "span.op:=^\\*test\\*.*$",
         ),
         # --- starts with quoted text ---
         pytest.param(
@@ -1202,15 +1204,15 @@ def test_handles_contains_wildcard_op_translations(query, expected) -> None:
         ),
         pytest.param(
             f'span.op:{WILDCARD_UNICODE}starts with{WILDCARD_UNICODE}"*test 1"',
-            "span.op:=^.*test\\ 1.*$",
+            "span.op:=^\\*test\\ 1.*$",
         ),
         pytest.param(
             f'span.op:{WILDCARD_UNICODE}starts with{WILDCARD_UNICODE}"test 1*"',
-            "span.op:=^test\\ 1.*$",
+            "span.op:=^test\\ 1\\*.*$",
         ),
         pytest.param(
             f'span.op:{WILDCARD_UNICODE}starts with{WILDCARD_UNICODE}"*test 1*"',
-            "span.op:=^.*test\\ 1.*$",
+            "span.op:=^\\*test\\ 1\\*.*$",
         ),
         # --- starts with text list ---
         pytest.param(
@@ -1219,15 +1221,15 @@ def test_handles_contains_wildcard_op_translations(query, expected) -> None:
         ),
         pytest.param(
             f"span.op:{WILDCARD_UNICODE}starts with{WILDCARD_UNICODE}[*test, *test2]",
-            "span.op:[*test*, *test2*]",
+            "span.op:[\\*test*, \\*test2*]",
         ),
         pytest.param(
             f"span.op:{WILDCARD_UNICODE}starts with{WILDCARD_UNICODE}[test*, test2*]",
-            "span.op:[test*, test2*]",
+            "span.op:[test\\**, test2\\**]",
         ),
         pytest.param(
             f"span.op:{WILDCARD_UNICODE}starts with{WILDCARD_UNICODE}[*test*, *test2*]",
-            "span.op:[*test*, *test2*]",
+            "span.op:[\\*test\\**, \\*test2\\**]",
         ),
         # --- starts with quoted text list ---
         pytest.param(
@@ -1236,15 +1238,15 @@ def test_handles_contains_wildcard_op_translations(query, expected) -> None:
         ),
         pytest.param(
             f'span.op:{WILDCARD_UNICODE}starts with{WILDCARD_UNICODE}["*test 1", "*test 2"]',
-            "span.op:[*test 1*, *test 2*]",
+            "span.op:[\\*test 1*, \\*test 2*]",
         ),
         pytest.param(
             f'span.op:{WILDCARD_UNICODE}starts with{WILDCARD_UNICODE}["test 1*", "test 2*"]',
-            "span.op:[test 1*, test 2*]",
+            "span.op:[test 1\\**, test 2\\**]",
         ),
         pytest.param(
             f'span.op:{WILDCARD_UNICODE}starts with{WILDCARD_UNICODE}["*test 1*", "*test 2*"]',
-            "span.op:[*test 1*, *test 2*]",
+            "span.op:[\\*test 1\\**, \\*test 2\\**]",
         ),
     ],
 )
@@ -1264,13 +1266,14 @@ def test_handles_starts_with_wildcard_op_translations(query, expected) -> None:
             f"span.op:{WILDCARD_UNICODE}ends with{WILDCARD_UNICODE}test", "span.op:=^.*test$"
         ),
         pytest.param(
-            f"span.op:{WILDCARD_UNICODE}ends with{WILDCARD_UNICODE}*test", "span.op:=^.*test$"
+            f"span.op:{WILDCARD_UNICODE}ends with{WILDCARD_UNICODE}*test", "span.op:=^.*\\*test$"
         ),
         pytest.param(
-            f"span.op:{WILDCARD_UNICODE}ends with{WILDCARD_UNICODE}test*", "span.op:=^.*test.*$"
+            f"span.op:{WILDCARD_UNICODE}ends with{WILDCARD_UNICODE}test*", "span.op:=^.*test\\*$"
         ),
         pytest.param(
-            f"span.op:{WILDCARD_UNICODE}ends with{WILDCARD_UNICODE}*test*", "span.op:=^.*test.*$"
+            f"span.op:{WILDCARD_UNICODE}ends with{WILDCARD_UNICODE}*test*",
+            "span.op:=^.*\\*test\\*$",
         ),
         # --- ends with quoted text ---
         pytest.param(
@@ -1279,15 +1282,15 @@ def test_handles_starts_with_wildcard_op_translations(query, expected) -> None:
         ),
         pytest.param(
             f'span.op:{WILDCARD_UNICODE}ends with{WILDCARD_UNICODE}"*test 1"',
-            "span.op:=^.*test\\ 1$",
+            "span.op:=^.*\\*test\\ 1$",
         ),
         pytest.param(
             f'span.op:{WILDCARD_UNICODE}ends with{WILDCARD_UNICODE}"test 1*"',
-            "span.op:=^.*test\\ 1.*$",
+            "span.op:=^.*test\\ 1\\*$",
         ),
         pytest.param(
             f'span.op:{WILDCARD_UNICODE}ends with{WILDCARD_UNICODE}"*test 1*"',
-            "span.op:=^.*test\\ 1.*$",
+            "span.op:=^.*\\*test\\ 1\\*$",
         ),
         # --- ends with text list ---
         pytest.param(
@@ -1296,15 +1299,15 @@ def test_handles_starts_with_wildcard_op_translations(query, expected) -> None:
         ),
         pytest.param(
             f"span.op:{WILDCARD_UNICODE}ends with{WILDCARD_UNICODE}[*test, *test2]",
-            "span.op:[*test, *test2]",
+            "span.op:[*\\*test, *\\*test2]",
         ),
         pytest.param(
             f"span.op:{WILDCARD_UNICODE}ends with{WILDCARD_UNICODE}[test*, test2*]",
-            "span.op:[*test*, *test2*]",
+            "span.op:[*test\\*, *test2\\*]",
         ),
         pytest.param(
             f"span.op:{WILDCARD_UNICODE}ends with{WILDCARD_UNICODE}[*test*, *test2*]",
-            "span.op:[*test*, *test2*]",
+            "span.op:[*\\*test\\*, *\\*test2\\*]",
         ),
         # --- ends with quoted text list ---
         pytest.param(
@@ -1313,15 +1316,15 @@ def test_handles_starts_with_wildcard_op_translations(query, expected) -> None:
         ),
         pytest.param(
             f'span.op:{WILDCARD_UNICODE}ends with{WILDCARD_UNICODE}["*test 1", "*test 2"]',
-            "span.op:[*test 1, *test 2]",
+            "span.op:[*\\*test 1, *\\*test 2]",
         ),
         pytest.param(
             f'span.op:{WILDCARD_UNICODE}ends with{WILDCARD_UNICODE}["test 1*", "test 2*"]',
-            "span.op:[*test 1*, *test 2*]",
+            "span.op:[*test 1\\*, *test 2\\*]",
         ),
         pytest.param(
             f'span.op:{WILDCARD_UNICODE}ends with{WILDCARD_UNICODE}["*test 1*", "*test 2*"]',
-            "span.op:[*test 1*, *test 2*]",
+            "span.op:[*\\*test 1\\*, *\\*test 2\\*]",
         ),
     ],
 )


### PR DESCRIPTION
This PR adds in three new wildcard specific operators to the event search grammar:
- `\uf00dcontains\uf00d`
- `\uf00dstarts with\uf00d`
- `\uf00dends with\uf00d`

These wildcard operators live between the `:` (separator), and the search value. Ideally, users will not manually enter these values, they will all be handled through the filter operator dropdown, hidden behind the scenes, and if a user wants to manually type these style of queries for querying the API directly they should revert to using `*`.

To remove ambiguity regarding adding `*` (wildcards) being apart of the search value and causing odd behaviour, we are escaping them before applying the search query. e.g. `span.op:\uf00dcontains\uf00dhttp.*` translates to `span.op:*http.\\**`.

Ticket: EXP-489
