### PR TITLE
fix(notifications): Honor recipient timezone prefs for digest emails

### DIFF
--- a/fixtures/emails/digest.txt
+++ b/fixtures/emails/digest.txt
@@ -1,3 +1,4 @@
+
 Notifications for example
 June 22, 2016, 4:16 p.m. UTC to June 22, 2016, 4:16 p.m. UTC
 

--- a/src/sentry/notifications/notifications/digest.py
+++ b/src/sentry/notifications/notifications/digest.py
@@ -81,7 +81,9 @@ class DigestNotification(ProjectNotification):
             # This shouldn't be possible but adding a message just in case.
             return "Digest Report"
 
-        return get_digest_subject(context["group"], context["counts"], context["start"])
+        # Use timezone from context if available (added by get_recipient_context)
+        timezone = context.get("timezone")
+        return get_digest_subject(context["group"], context["counts"], context["start"], timezone)
 
     def get_notification_title(
         self, provider: ExternalProviders, context: Mapping[str, Any] | None = None

--- a/src/sentry/notifications/notifications/digest.py
+++ b/src/sentry/notifications/notifications/digest.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import logging
+import zoneinfo
 from collections import defaultdict
 from collections.abc import Mapping, MutableMapping, Sequence
+from datetime import UTC, tzinfo
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlencode
 
@@ -36,6 +38,8 @@ from sentry.notifications.utils.links import (
 from sentry.services.eventstore.models import Event, GroupEvent
 from sentry.types.actor import Actor
 from sentry.types.rules import NotificationRuleDetails
+from sentry.users.services.user_option import user_option_service
+from sentry.users.services.user_option.service import get_option_from_list
 
 if TYPE_CHECKING:
     from sentry.models.organization import Organization
@@ -107,6 +111,24 @@ class DigestNotification(ProjectNotification):
     @property
     def reference(self) -> Model | None:
         return self.project
+
+    def get_recipient_context(
+        self, recipient: Actor, extra_context: Mapping[str, Any]
+    ) -> MutableMapping[str, Any]:
+        tz: tzinfo = UTC
+        if recipient.is_user:
+            user_options = user_option_service.get_many(
+                filter={"user_ids": [recipient.id], "keys": ["timezone"]}
+            )
+            user_tz = get_option_from_list(user_options, key="timezone", default="UTC")
+            try:
+                tz = zoneinfo.ZoneInfo(user_tz)
+            except (ValueError, zoneinfo.ZoneInfoNotFoundError):
+                pass
+        return {
+            **super().get_recipient_context(recipient, extra_context),
+            "timezone": tz,
+        }
 
     def get_context(self) -> MutableMapping[str, Any]:
         rule_details = get_rules(

--- a/src/sentry/notifications/utils/digest.py
+++ b/src/sentry/notifications/utils/digest.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import itertools
 from collections import Counter
 from collections.abc import Mapping
-from datetime import datetime
+from datetime import datetime, tzinfo
 from typing import TYPE_CHECKING, Any
 
 from django.utils import dateformat
@@ -15,7 +15,13 @@ if TYPE_CHECKING:
     from sentry.models.group import Group
 
 
-def get_digest_subject(group: Group, counts: Counter[Group], date: datetime) -> str:
+def get_digest_subject(
+    group: Group, counts: Counter[Group], date: datetime, timezone: tzinfo | None = None
+) -> str:
+    # Convert date to user's timezone if provided
+    if timezone:
+        date = date.astimezone(timezone)
+
     return "{short_id} - {count} new {noun} since {date}".format(
         short_id=group.qualified_short_id,
         count=len(counts),

--- a/src/sentry/templates/sentry/emails/digests/body.html
+++ b/src/sentry/templates/sentry/emails/digests/body.html
@@ -1,5 +1,6 @@
 {% extends "sentry/emails/base.html" %}
 
+{% load timezone from tz %}
 {% load sentry_helpers %}
 {% load sentry_assets %}
 
@@ -23,9 +24,15 @@
 
 <div class="container" style="padding-top: 30px;">
   <h2>{{ counts|length }} new alert{{ counts|pluralize }} from <a href="{{ project.get_absolute_url }}">{{ project.slug }}</a></h2>
-  {% with start=start|date:"N j, Y, P e" end=end|date:"N j, Y, P e" %}
-    <div class="dateline">{{ start }}{% if start != end %} to {{ end }}{% endif %}</div>
-  {% endwith %}
+  {% if timezone %}
+    {% with start=start|timezone:timezone|date:"N j, Y, P e" end=end|timezone:timezone|date:"N j, Y, P e" %}
+      <div class="dateline">{{ start }}{% if start != end %} to {{ end }}{% endif %}</div>
+    {% endwith %}
+  {% else %}
+    {% with start=start|date:"N j, Y, P e" end=end|date:"N j, Y, P e" %}
+      <div class="dateline">{{ start }}{% if start != end %} to {{ end }}{% endif %}</div>
+    {% endwith %}
+  {% endif %}
 </div>
 
 {% for rule, groups in digest.items %}
@@ -55,7 +62,11 @@
                   <td class="event-detail">
                       {% include "sentry/emails/_group.html" %}
                       <div>
-                        <small>{{ records.0.datetime|date:"N j, Y, g:i:s a e" }}</small>
+                        {% if timezone %}
+                          <small>{{ records.0.datetime|timezone:timezone|date:"N j, Y, g:i:s a e" }}</small>
+                        {% else %}
+                          <small>{{ records.0.datetime|date:"N j, Y, g:i:s a e" }}</small>
+                        {% endif %}
                         {% if show_replay_links and group.has_replays %}
                           <span class="replay-link">
                             <a href="{{ group.get_absolute_url }}replays?referrer=alert_email">

--- a/src/sentry/templates/sentry/emails/digests/body.txt
+++ b/src/sentry/templates/sentry/emails/digests/body.txt
@@ -1,6 +1,7 @@
+{% load timezone from tz %}
 {% load sentry_helpers %}
 {% load sentry_features %}Notifications for {{ project.slug }}
-{{ start|date:"N j, Y, P e" }} to {{ end|date:"N j, Y, P e" }}
+{% if timezone %}{{ start|timezone:timezone|date:"N j, Y, P e" }} to {{ end|timezone:timezone|date:"N j, Y, P e" }}{% else %}{{ start|date:"N j, Y, P e" }} to {{ end|date:"N j, Y, P e" }}{% endif %}
 
 {% for rule, groups in digest.items %}{{ rule.label }}
 {% for group, records in groups.items %}{% with event_count=event_counts|get_item:group.id user_count=user_counts|get_item:group.id %}

--- a/tests/sentry/notifications/notifications/test_digests.py
+++ b/tests/sentry/notifications/notifications/test_digests.py
@@ -230,6 +230,20 @@ class DigestNotificationTest(TestCase, OccurrenceTestMixin, PerformanceIssueTest
         # UTC email should show UTC timezone
         assert "UTC" in utc_body, f"UTC email should show UTC timezone, but body was: {utc_body}"
 
+        # Check that subjects are also timezone-aware
+        pacific_subject = pacific_email.subject
+        utc_subject = utc_email.subject
+
+        # The subjects should be different due to timezone formatting
+        # (though the time difference might be small depending on when the test runs)
+        # At minimum, they should both contain readable date information
+        assert (
+            "new alert" in pacific_subject.lower()
+        ), f"Pacific subject should contain alert text: {pacific_subject}"
+        assert (
+            "new alert" in utc_subject.lower()
+        ), f"UTC subject should contain alert text: {utc_subject}"
+
 
 class DigestSlackNotification(SlackActivityNotificationTest):
     @mock.patch.object(sentry, "digests")

--- a/tests/sentry/notifications/notifications/test_digests.py
+++ b/tests/sentry/notifications/notifications/test_digests.py
@@ -20,7 +20,9 @@ from sentry.testutils.helpers.analytics import (
     assert_last_analytics_event,
 )
 from sentry.testutils.helpers.datetime import before_now
+from sentry.testutils.silo import assume_test_silo_mode_of
 from sentry.testutils.skips import requires_snuba
+from sentry.users.models.user_option import UserOption
 from tests.sentry.issues.test_utils import OccurrenceTestMixin
 
 pytestmark = [requires_snuba]
@@ -170,6 +172,63 @@ class DigestNotificationTest(TestCase, OccurrenceTestMixin, PerformanceIssueTest
         assert isinstance(message, EmailMultiAlternatives)
         assert isinstance(message.alternatives[0][0], str)
         assert "notification_uuid" in message.alternatives[0][0]
+
+    def test_digest_email_uses_user_timezone(self) -> None:
+        self.organization.member_set.exclude(user_id=self.user.id).delete()
+
+        # Create a user with Pacific timezone
+        pacific_user = self.create_user(email="pacific@example.com")
+        with assume_test_silo_mode_of(UserOption):
+            UserOption.objects.create(
+                user=pacific_user, key="timezone", value="America/Los_Angeles"
+            )
+
+        # Create member with this user
+        self.create_member(
+            organization=self.organization,
+            user=pacific_user,
+            role="member",
+            teams=[self.team],
+        )
+
+        # Create events and send digest
+        with patch.object(sentry, "digests") as digests:
+            backend = RedisBackend()
+            digests.backend.digest = backend.digest
+
+            # Add 2 events
+            for i in range(2):
+                self.add_event(f"group-{i}", backend, "error")
+
+            with self.tasks():
+                deliver_digest(self.key)
+
+        # Should have emails for both users (original self.user + pacific_user)
+        assert len(mail.outbox) == 2
+
+        # Find the email sent to our Pacific timezone user
+        pacific_email = None
+        utc_email = None
+        for email in mail.outbox:
+            if pacific_user.email in email.to:
+                pacific_email = email
+            elif self.user.email in email.to:
+                utc_email = email
+
+        assert pacific_email is not None, "Should have sent email to Pacific timezone user"
+        assert utc_email is not None, "Should have sent email to UTC user"
+
+        # Check that the Pacific timezone email uses PST/PDT formatting
+        pacific_body = pacific_email.body
+        utc_body = utc_email.body
+
+        # Pacific email should show PST/PDT timezone
+        assert (
+            "PST" in pacific_body or "PDT" in pacific_body
+        ), f"Pacific email should use Pacific timezone, but body was: {pacific_body}"
+
+        # UTC email should show UTC timezone
+        assert "UTC" in utc_body, f"UTC email should show UTC timezone, but body was: {utc_body}"
 
 
 class DigestSlackNotification(SlackActivityNotificationTest):


### PR DESCRIPTION
This makes digest emails consistent with Alert Notification emails by using user pref time zones where appropriate.

Fixes https://github.com/getsentry/sentry/issues/95507