### PR TITLE
feat(billing): Update quota docs link for Logs

### DIFF
--- a/static/app/views/settings/account/notifications/utils.tsx
+++ b/static/app/views/settings/account/notifications/utils.tsx
@@ -56,6 +56,9 @@ export function getPricingDocsLinkForEventType(event: DataCategoryExact) {
     case DataCategoryExact.SEER_AUTOFIX:
     case DataCategoryExact.SEER_SCANNER:
       return 'https://docs.sentry.io/pricing/quotas/manage-seer-budget/';
+    case DataCategoryExact.LOG_BYTE:
+    case DataCategoryExact.LOG_ITEM:
+      return 'https://docs.sentry.io/pricing/quotas/manage-logs-quota/';
     default:
       return 'https://docs.sentry.io/pricing/quotas/manage-event-stream-guide/';
   }


### PR DESCRIPTION
Closes: https://linear.app/getsentry/issue/BIL-1128/update-getpricingdocslinkforeventtype

This PR adds the quota management docs link for Logs. 

NOTE: Both `LOG_BYTE` and `LOG_ITEM` are intentionally included in the category match.