### PR TITLE
ref(replay): hide ai tab for mobile platforms

### DIFF
--- a/static/app/utils/replays/hooks/useActiveReplayTab.tsx
+++ b/static/app/utils/replays/hooks/useActiveReplayTab.tsx
@@ -16,7 +16,6 @@ export enum TabKey {
 
 function isReplayTab({tab, isVideoReplay}: {isVideoReplay: boolean; tab: string}) {
   const supportedVideoTabs = [
-    TabKey.AI,
     TabKey.TAGS,
     TabKey.ERRORS,
     TabKey.BREADCRUMBS,

--- a/static/app/views/replays/detail/ai/replaySummaryContext.tsx
+++ b/static/app/views/replays/detail/ai/replaySummaryContext.tsx
@@ -33,6 +33,7 @@ export function ReplaySummaryContextProvider({
 }) {
   const organization = useOrganization();
   const {areAiFeaturesAllowed, setupAcknowledgement} = useOrganizationSeerSetup();
+  const mobileProject = replay.isVideoReplay();
 
   const summaryResult = useFetchReplaySummary(replay, {
     staleTime: 0,
@@ -41,7 +42,8 @@ export function ReplaySummaryContextProvider({
         projectSlug &&
         organization.features.includes('replay-ai-summaries') &&
         areAiFeaturesAllowed &&
-        setupAcknowledgement.orgHasAcknowledged
+        setupAcknowledgement.orgHasAcknowledged &&
+        !mobileProject
     ),
   });
   useEmitTimestampChanges();


### PR DESCRIPTION
closes https://linear.app/getsentry/issue/REPLAY-658/hide-summary-tab-for-mobile-platforms

verified the summarize endpoint doesn't get called:

https://github.com/user-attachments/assets/82c1a33f-3155-4f62-a22c-beac75815f99

