### PR TITLE
chore(ui): Disallow IIFEs inside jsx

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -348,6 +348,12 @@ export default typescript.config([
             'VariableDeclaration[kind = "let"]:not(ForOfStatement > VariableDeclaration, ForInStatement > VariableDeclaration) > VariableDeclarator[init = null]:not([id.typeAnnotation])',
           message: 'Provide a type annotation',
         },
+        {
+          // Disallow IIFEs inside JSX (children, attribute values, and spreads)
+          selector:
+            'JSXExpressionContainer > CallExpression[callee.type="ArrowFunctionExpression"], JSXExpressionContainer > CallExpression[callee.type="FunctionExpression"], JSXSpreadAttribute > CallExpression[callee.type="ArrowFunctionExpression"], JSXSpreadAttribute > CallExpression[callee.type="FunctionExpression"]',
+          message: 'Do not use IIFEs inside JSX.',
+        },
       ],
       'no-return-assign': 'error',
       'no-script-url': 'error',


### PR DESCRIPTION
Ai coding assistants really want to put an IIFE directly inside your jsx because that makes the changeset smaller and easier for them. However, no human would do this so lets use a lint rule to avoid them.

example of code that would be an 🚫 error
```tsx
function Bad() {
  return (
    <ul>
      {(() => {
        const items = [1, 2, 3];
        return items.map(n => <li key={n}>{n}</li>);
      })()}
    </ul>
  );
}
```

instead use
```tsx
function SlightlyBetter() {
  const items = [1, 2, 3];
  return (
    <ul>
      {items.map(n => <li key={n}>{n}</li>)}
    </ul>
  );
}
```