### PR TITLE
feat(prevent): adjust all branches behavior

### DIFF
--- a/static/app/components/prevent/branchSelector/branchSelector.tsx
+++ b/static/app/components/prevent/branchSelector/branchSelector.tsx
@@ -14,7 +14,7 @@ import {space} from 'sentry/styles/space';
 
 import {IconBranch} from './iconBranch';
 
-export const ALL_BRANCHES = 'All Branches';
+const ALL_BRANCHES = 'All Branches';
 
 export function BranchSelector() {
   const {branch, integratedOrgId, repository, preventPeriod, changeContextValue} =
@@ -30,11 +30,13 @@ export function BranchSelector() {
 
   const handleChange = useCallback(
     (selectedOption: SelectOption<string>) => {
+      const newBranch =
+        selectedOption.value === ALL_BRANCHES ? null : selectedOption.value;
       changeContextValue({
         integratedOrgId,
         repository,
         preventPeriod,
-        branch: selectedOption.value,
+        branch: newBranch,
       });
     },
     [changeContextValue, integratedOrgId, repository, preventPeriod]
@@ -140,7 +142,7 @@ export function BranchSelector() {
       disableSearchFilter
       searchPlaceholder={t('search by branch name')}
       options={options}
-      value={branch ?? ''}
+      value={branch ?? ALL_BRANCHES}
       onChange={handleChange}
       onOpenChange={_ => setSearchValue(undefined)}
       menuHeaderTrailingItems={branchResetButton}

--- a/static/app/components/prevent/container/preventParamsProvider.tsx
+++ b/static/app/components/prevent/container/preventParamsProvider.tsx
@@ -1,7 +1,6 @@
 import {useCallback} from 'react';
 import {useSearchParams} from 'react-router-dom';
 
-import {ALL_BRANCHES} from 'sentry/components/prevent/branchSelector/branchSelector';
 import type {
   PreventContextData,
   PreventContextDataParams,
@@ -51,7 +50,7 @@ export default function PreventQueryParamsProvider({
     const branch =
       (integratedOrgId ? localStorageState?.[integratedOrgId]?.branch : null) ||
       currentParams?.branch ||
-      'All Branches';
+      null;
     const preventPeriod =
       currentParams?.preventPeriod || localStorageState.preventPeriod || '24h';
 
@@ -81,7 +80,8 @@ export default function PreventQueryParamsProvider({
           const orgId = input.integratedOrgId;
 
           if (orgId) {
-            const branch = input.branch ? input.branch : ALL_BRANCHES;
+            const branch = input.branch ?? null;
+
             newState[orgId] = {repository: input.repository, branch};
             newState.lastVisitedOrgId = orgId;
           }
@@ -97,7 +97,11 @@ export default function PreventQueryParamsProvider({
         ...input,
       };
 
-      setSearchParams(updatedParams);
+      if (updatedParams.branch === null) {
+        delete updatedParams.branch;
+      }
+
+      setSearchParams(updatedParams as Record<string, string>);
     },
     [searchParams, setLocalStorageState, setSearchParams]
   );
@@ -107,7 +111,7 @@ export default function PreventQueryParamsProvider({
   const params: PreventContextData = {
     ...(repository ? {repository} : {}),
     ...(integratedOrgId ? {integratedOrgId} : {}),
-    ...(branch ? {branch} : {}),
+    branch,
     preventPeriod,
     changeContextValue,
   };

--- a/static/app/components/prevent/context/preventContext.tsx
+++ b/static/app/components/prevent/context/preventContext.tsx
@@ -3,7 +3,7 @@ import {createContext, useContext} from 'react';
 export type PreventContextData = {
   changeContextValue: (value: Partial<PreventContextDataParams>) => void;
   preventPeriod: string;
-  branch?: string;
+  branch?: string | null;
   integratedOrgId?: string;
   lastVisitedOrgId?: string;
   repository?: string;

--- a/static/app/views/prevent/tests/queries/useGetTestResults.ts
+++ b/static/app/views/prevent/tests/queries/useGetTestResults.ts
@@ -2,7 +2,6 @@ import {useMemo} from 'react';
 import {useSearchParams} from 'react-router-dom';
 
 import type {ApiResult} from 'sentry/api';
-import {ALL_BRANCHES} from 'sentry/components/prevent/branchSelector/branchSelector';
 import {usePreventContext} from 'sentry/components/prevent/context/preventContext';
 import {
   fetchDataQuery,
@@ -75,8 +74,6 @@ export function useInfiniteTestResults({
   const organization = useOrganization();
   const [searchParams] = useSearchParams();
 
-  const filterBranch = branch === ALL_BRANCHES ? null : branch;
-
   const sortBy = searchParams.get('sort') || '-commitsFailed';
   const signedSortBy = sortValueToSortKey(sortBy);
 
@@ -101,7 +98,7 @@ export function useInfiniteTestResults({
       `/organizations/${organization.slug}/prevent/owner/${integratedOrgId}/repository/${repository}/test-results/`,
       {
         query: {
-          branch: filterBranch,
+          branch,
           preventPeriod,
           signedSortBy,
           mappedFilterBy,
@@ -129,7 +126,7 @@ export function useInfiniteTestResults({
                 ],
               sortBy: signedSortBy,
               term,
-              branch: filterBranch,
+              branch,
               ...(mappedFilterBy ? {filterBy: mappedFilterBy} : {}),
               ...(testSuites ? {testSuites} : {}),
               ...(cursor ? {cursor} : {}),
@@ -153,7 +150,7 @@ export function useInfiniteTestResults({
         : undefined;
     },
     initialPageParam: null,
-    enabled: !!(integratedOrgId && repository && branch && preventPeriod),
+    enabled: !!(integratedOrgId && repository && preventPeriod),
   });
 
   const memoizedData = useMemo(

--- a/static/app/views/prevent/tests/queries/useTestResultsAggregates.ts
+++ b/static/app/views/prevent/tests/queries/useTestResultsAggregates.ts
@@ -29,7 +29,7 @@ type QueryKey = [url: string, endpointOptions: QueryKeyEndpointOptions];
 export function useTestResultsAggregates() {
   const api = useApi();
   const organization = useOrganization();
-  const {integratedOrgId, repository, preventPeriod} = usePreventContext();
+  const {integratedOrgId, repository, branch, preventPeriod} = usePreventContext();
 
   const {data, ...rest} = useQuery<
     TestResultAggregate,
@@ -39,12 +39,13 @@ export function useTestResultsAggregates() {
   >({
     queryKey: [
       `/organizations/${organization.slug}/prevent/owner/${integratedOrgId}/repository/${repository}/test-results-aggregates/`,
-      {query: {preventPeriod}},
+      {query: {preventPeriod, branch}},
     ],
     queryFn: async ({queryKey: [url]}): Promise<TestResultAggregate> => {
       const result = await api.requestPromise(url, {
         method: 'GET',
         query: {
+          branch,
           interval:
             DATE_TO_QUERY_INTERVAL[preventPeriod as keyof typeof DATE_TO_QUERY_INTERVAL],
         },

--- a/static/app/views/prevent/tests/tests.tsx
+++ b/static/app/views/prevent/tests/tests.tsx
@@ -3,10 +3,7 @@ import styled from '@emotion/styled';
 
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import Pagination from 'sentry/components/pagination';
-import {
-  ALL_BRANCHES,
-  BranchSelector,
-} from 'sentry/components/prevent/branchSelector/branchSelector';
+import {BranchSelector} from 'sentry/components/prevent/branchSelector/branchSelector';
 import {usePreventContext} from 'sentry/components/prevent/context/preventContext';
 import {DateSelector} from 'sentry/components/prevent/dateSelector/dateSelector';
 import {IntegratedOrgSelector} from 'sentry/components/prevent/integratedOrgSelector/integratedOrgSelector';
@@ -51,10 +48,9 @@ export default function TestsPage() {
     navigation: location.query?.navigation as 'next' | 'prev' | undefined,
   });
   const defaultBranch = response.data?.defaultBranch;
-  const shouldDisplayTestSuiteDropdown =
-    branch === ALL_BRANCHES || branch === defaultBranch;
+  const shouldDisplayTestSuiteDropdown = branch === null || branch === defaultBranch;
 
-  const shouldDisplayContent = integratedOrgId && repository && branch && preventPeriod;
+  const shouldDisplayContent = integratedOrgId && repository && preventPeriod;
 
   return (
     <LayoutGap>
@@ -91,7 +87,7 @@ function Content({response}: TestResultsContentData) {
   ];
   const defaultBranch = response.data?.defaultBranch;
   const shouldDisplaySummaries =
-    selectedBranch === ALL_BRANCHES || selectedBranch === defaultBranch;
+    selectedBranch === null || selectedBranch === defaultBranch;
 
   const handleCursor = useCallback(
     (


### PR DESCRIPTION
This PR adjusts the behavior of how "All branches" selection works. Originally, it sent "all branches" in the request parameter, but we're adjusting the behavior to have it be null if that's the case.

Additionally, I'm passing the `branch` parameter in the `useTestResultsAggregates.ts` hook.

Closes https://linear.app/getsentry/issue/CCMRG-1597/ta-add-all-branches-to-ta-page-api-calls