### PR TITLE
feat(taskworker): add grpc healthcheck for worker 

### DIFF
--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -333,6 +333,15 @@ def taskworker_scheduler(redis_cluster: str, **options: Any) -> None:
     help="The name of the processing pool being used",
     default="unknown",
 )
+@click.option(
+    "--health-check-file-path",
+    help="Full path of the health check file if health check is to be enabled",
+)
+@click.option(
+    "--health-check-req-per-touch",
+    help="The number of gRPC requests before touching the health check file",
+    default=taskworker_constants.DEFAULT_WORKER_HEALTH_CHECK_REQ_PER_TOUCH,
+)
 @log_options()
 @configuration
 def taskworker(**options: Any) -> None:
@@ -355,6 +364,8 @@ def run_taskworker(
     result_queue_maxsize: int,
     rebalance_after: int,
     processing_pool_name: str,
+    health_check_file_path: str | None,
+    health_check_req_per_touch: int,
     **options: Any,
 ) -> None:
     """
@@ -375,6 +386,8 @@ def run_taskworker(
             result_queue_maxsize=result_queue_maxsize,
             rebalance_after=rebalance_after,
             processing_pool_name=processing_pool_name,
+            health_check_file_path=health_check_file_path,
+            health_check_req_per_touch=health_check_req_per_touch,
             **options,
         )
         exitcode = worker.start()

--- a/src/sentry/taskworker/client/client.py
+++ b/src/sentry/taskworker/client/client.py
@@ -2,6 +2,7 @@ import hashlib
 import hmac
 import logging
 import random
+import threading
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -166,6 +167,7 @@ class TaskworkerClient:
         self._temporary_unavailable_host_timeout = temporary_unavailable_host_timeout
 
         self._health_check_settings = health_check_settings
+        self._requests_since_touch_lock = threading.Lock()
         self._requests_since_touch = (
             0 if health_check_settings is None else health_check_settings.requests_per_touch
         )
@@ -174,12 +176,13 @@ class TaskworkerClient:
         if self._health_check_settings is None:
             return
 
-        self._requests_since_touch += 1
-        if self._requests_since_touch < self._health_check_settings.requests_per_touch:
-            return
+        with self._requests_since_touch_lock:
+            self._requests_since_touch += 1
+            if self._requests_since_touch < self._health_check_settings.requests_per_touch:
+                return
 
-        self._health_check_settings.file_path.touch()
-        self._requests_since_touch = 0
+            self._health_check_settings.file_path.touch()
+            self._requests_since_touch = 0
 
     def _connect_to_host(self, host: str) -> ConsumerServiceStub:
         logger.info("taskworker.client.connect", extra={"host": host})

--- a/src/sentry/taskworker/constants.py
+++ b/src/sentry/taskworker/constants.py
@@ -46,6 +46,11 @@ MAX_PARAMETER_BYTES_BEFORE_COMPRESSION = 3000000  # 3MB
 The maximum number of bytes before a task parameter is compressed.
 """
 
+DEFAULT_WORKER_HEALTH_CHECK_REQ_PER_TOUCH = 2048
+"""
+The number of gRPC requests before touching the health check file
+"""
+
 
 class CompressionType(Enum):
     """

--- a/tests/sentry/taskworker/test_client.py
+++ b/tests/sentry/taskworker/test_client.py
@@ -171,27 +171,27 @@ def test_health_check_is_debounced() -> None:
             ["localhost-0:50051"],
             health_check_settings=HealthCheckSettings(health_check_path, 4),
         )
-        client._health_check_settings.file_path = Mock()
+        client._health_check_settings.file_path = Mock()  # type: ignore[union-attr]
 
         _ = client.get_task()
-        assert client._health_check_settings.file_path.touch.call_count == 1
+        assert client._health_check_settings.file_path.touch.call_count == 1  # type: ignore[union-attr]
 
         _ = client.get_task()
-        assert client._health_check_settings.file_path.touch.call_count == 1
+        assert client._health_check_settings.file_path.touch.call_count == 1  # type: ignore[union-attr]
         _ = client.update_task(
             ProcessingResult("", TASK_ACTIVATION_STATUS_RETRY, "localhost-0:50051", 0)
         )
-        assert client._health_check_settings.file_path.touch.call_count == 1
+        assert client._health_check_settings.file_path.touch.call_count == 1  # type: ignore[union-attr]
         _ = client.get_task()
-        assert client._health_check_settings.file_path.touch.call_count == 1
+        assert client._health_check_settings.file_path.touch.call_count == 1  # type: ignore[union-attr]
         _ = client.update_task(
             ProcessingResult("", TASK_ACTIVATION_STATUS_RETRY, "localhost-0:50051", 0)
         )
-        assert client._health_check_settings.file_path.touch.call_count == 2
+        assert client._health_check_settings.file_path.touch.call_count == 2  # type: ignore[union-attr]
         _ = client.update_task(
             ProcessingResult("", TASK_ACTIVATION_STATUS_RETRY, "localhost-0:50051", 0)
         )
-        assert client._health_check_settings.file_path.touch.call_count == 2
+        assert client._health_check_settings.file_path.touch.call_count == 2  # type: ignore[union-attr]
 
 
 @django_db_all

--- a/tests/sentry/taskworker/test_client.py
+++ b/tests/sentry/taskworker/test_client.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import grpc
 import pytest
@@ -171,28 +171,27 @@ def test_health_check_is_debounced() -> None:
             ["localhost-0:50051"],
             health_check_settings=HealthCheckSettings(health_check_path, 4),
         )
-        _ = client.get_task()
-        assert health_check_path.exists()
-        last_health_check_write = health_check_path.stat().st_mtime_ns
+        client._health_check_settings.file_path = Mock()
 
         _ = client.get_task()
-        assert health_check_path.stat().st_mtime_ns == last_health_check_write
-        _ = client.update_task(
-            ProcessingResult("", TASK_ACTIVATION_STATUS_RETRY, "localhost-0:50051", 0)
-        )
-        assert health_check_path.stat().st_mtime_ns == last_health_check_write
-        _ = client.get_task()
-        assert health_check_path.stat().st_mtime_ns == last_health_check_write
-        _ = client.update_task(
-            ProcessingResult("", TASK_ACTIVATION_STATUS_RETRY, "localhost-0:50051", 0)
-        )
-        assert health_check_path.stat().st_mtime_ns > last_health_check_write
-        last_health_check_write = health_check_path.stat().st_mtime_ns
+        assert client._health_check_settings.file_path.touch.call_count == 1
 
+        _ = client.get_task()
+        assert client._health_check_settings.file_path.touch.call_count == 1
         _ = client.update_task(
             ProcessingResult("", TASK_ACTIVATION_STATUS_RETRY, "localhost-0:50051", 0)
         )
-        assert health_check_path.stat().st_mtime_ns == last_health_check_write
+        assert client._health_check_settings.file_path.touch.call_count == 1
+        _ = client.get_task()
+        assert client._health_check_settings.file_path.touch.call_count == 1
+        _ = client.update_task(
+            ProcessingResult("", TASK_ACTIVATION_STATUS_RETRY, "localhost-0:50051", 0)
+        )
+        assert client._health_check_settings.file_path.touch.call_count == 2
+        _ = client.update_task(
+            ProcessingResult("", TASK_ACTIVATION_STATUS_RETRY, "localhost-0:50051", 0)
+        )
+        assert client._health_check_settings.file_path.touch.call_count == 2
 
 
 @django_db_all

--- a/tests/sentry/taskworker/test_client.py
+++ b/tests/sentry/taskworker/test_client.py
@@ -1,6 +1,9 @@
 import dataclasses
+import random
+import string
 from collections import defaultdict
 from collections.abc import Callable
+from pathlib import Path
 from typing import Any
 from unittest.mock import patch
 
@@ -18,11 +21,13 @@ from sentry_protos.taskbroker.v1.taskbroker_pb2 import (
 )
 
 from sentry.taskworker.client.client import (
+    HealthCheckSettings,
     HostTemporarilyUnavailable,
     TaskworkerClient,
     make_broker_hosts,
 )
 from sentry.taskworker.client.processing_result import ProcessingResult
+from sentry.taskworker.constants import DEFAULT_WORKER_HEALTH_CHECK_REQ_PER_TOUCH
 from sentry.testutils.pytest.fixtures import django_db_all
 
 
@@ -131,6 +136,66 @@ def test_init_no_hosts() -> None:
 
 
 @django_db_all
+def test_health_check_is_debounced() -> None:
+    channel = MockChannel()
+    channel.add_response(
+        "/sentry_protos.taskbroker.v1.ConsumerService/GetTask",
+        GetTaskResponse(
+            task=TaskActivation(
+                id="abc123",
+                namespace="testing",
+                taskname="do_thing",
+                parameters="",
+                headers={},
+                processing_deadline_duration=10,
+            )
+        ),
+    )
+    channel.add_response(
+        "/sentry_protos.taskbroker.v1.ConsumerService/SetTaskStatus",
+        SetTaskStatusResponse(
+            task=TaskActivation(
+                id="abc123",
+                namespace="testing",
+                taskname="do_thing",
+                parameters="",
+                headers={},
+                processing_deadline_duration=10,
+            )
+        ),
+    )
+    with patch("sentry.taskworker.client.client.grpc.insecure_channel") as mock_channel:
+        mock_channel.return_value = channel
+        health_check_path = Path(f"/tmp/{''.join(random.choices(string.ascii_letters, k=16))}")
+        client = TaskworkerClient(
+            ["localhost-0:50051"],
+            health_check_settings=HealthCheckSettings(health_check_path, 4),
+        )
+        _ = client.get_task()
+        assert health_check_path.exists()
+        last_health_check_write = health_check_path.stat().st_mtime_ns
+
+        _ = client.get_task()
+        assert health_check_path.stat().st_mtime_ns == last_health_check_write
+        _ = client.update_task(
+            ProcessingResult("", TASK_ACTIVATION_STATUS_RETRY, "localhost-0:50051", 0)
+        )
+        assert health_check_path.stat().st_mtime_ns == last_health_check_write
+        _ = client.get_task()
+        assert health_check_path.stat().st_mtime_ns == last_health_check_write
+        _ = client.update_task(
+            ProcessingResult("", TASK_ACTIVATION_STATUS_RETRY, "localhost-0:50051", 0)
+        )
+        assert health_check_path.stat().st_mtime_ns > last_health_check_write
+        last_health_check_write = health_check_path.stat().st_mtime_ns
+
+        _ = client.update_task(
+            ProcessingResult("", TASK_ACTIVATION_STATUS_RETRY, "localhost-0:50051", 0)
+        )
+        assert health_check_path.stat().st_mtime_ns == last_health_check_write
+
+
+@django_db_all
 def test_get_task_ok() -> None:
     channel = MockChannel()
     channel.add_response(
@@ -155,6 +220,34 @@ def test_get_task_ok() -> None:
         assert result.host == "localhost-0:50051"
         assert result.activation.id
         assert result.activation.namespace == "testing"
+
+
+@django_db_all
+def test_get_task_writes_to_health_check_file() -> None:
+    channel = MockChannel()
+    channel.add_response(
+        "/sentry_protos.taskbroker.v1.ConsumerService/GetTask",
+        GetTaskResponse(
+            task=TaskActivation(
+                id="abc123",
+                namespace="testing",
+                taskname="do_thing",
+                parameters="",
+                headers={},
+                processing_deadline_duration=10,
+            )
+        ),
+    )
+
+    with patch("sentry.taskworker.client.client.grpc.insecure_channel") as mock_channel:
+        mock_channel.return_value = channel
+        health_check_path = Path(f"/tmp/{''.join(random.choices(string.ascii_letters, k=16))}")
+        client = TaskworkerClient(
+            ["localhost-0:50051"],
+            health_check_settings=HealthCheckSettings(health_check_path, 3),
+        )
+        _ = client.get_task()
+        assert health_check_path.exists()
 
 
 @django_db_all
@@ -245,6 +338,38 @@ def test_get_task_failure() -> None:
         client = TaskworkerClient(["localhost:50051"])
         with pytest.raises(grpc.RpcError):
             client.get_task()
+
+
+@django_db_all
+def test_update_task_writes_to_health_check_file() -> None:
+    channel = MockChannel()
+    channel.add_response(
+        "/sentry_protos.taskbroker.v1.ConsumerService/SetTaskStatus",
+        SetTaskStatusResponse(
+            task=TaskActivation(
+                id="abc123",
+                namespace="testing",
+                taskname="do_thing",
+                parameters="",
+                headers={},
+                processing_deadline_duration=10,
+            )
+        ),
+    )
+    with patch("sentry.taskworker.client.client.grpc.insecure_channel") as mock_channel:
+        mock_channel.return_value = channel
+        health_check_path = Path(f"/tmp/{''.join(random.choices(string.ascii_letters, k=16))}")
+        client = TaskworkerClient(
+            make_broker_hosts("localhost:50051", num_brokers=1),
+            health_check_settings=HealthCheckSettings(
+                health_check_path, DEFAULT_WORKER_HEALTH_CHECK_REQ_PER_TOUCH
+            ),
+        )
+        _ = client.update_task(
+            ProcessingResult("abc123", TASK_ACTIVATION_STATUS_RETRY, "localhost-0:50051", 0),
+            FetchNextTask(namespace=None),
+        )
+        assert health_check_path.exists()
 
 
 @django_db_all


### PR DESCRIPTION
Let worker grpc client touch a healthcheck file every couple of requests. If the worker deadlocks, k8s will be able to recycle it.