### PR TITLE
feat(prevent): passing branch param to test result aggregate endpoint

### DIFF
--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -1066,7 +1066,7 @@ Available fields are:
         location="query",
         required=False,
         type=str,
-        description="""The branch to search for results by. If not specified, the default is `main`.
+        description="""The branch to search for results by. If not specified, the default is all branches.
         """,
     )
     TEST_RESULTS_FILTER_BY = OpenApiParameter(

--- a/src/sentry/codecov/endpoints/test_results_aggregates/query.py
+++ b/src/sentry/codecov/endpoints/test_results_aggregates/query.py
@@ -21,7 +21,7 @@ query = """query GetTestResultsAggregates(
                         totalSkips
                         totalSkipsPercentChange
                     }
-                    flakeAggregates(interval: $interval) {
+                    flakeAggregates(branch: $branch, interval: $interval) {
                         flakeCount
                         flakeCountPercentChange
                         flakeRate

--- a/src/sentry/codecov/endpoints/test_results_aggregates/query.py
+++ b/src/sentry/codecov/endpoints/test_results_aggregates/query.py
@@ -1,6 +1,7 @@
 query = """query GetTestResultsAggregates(
     $owner: String!
     $repo: String!
+    $branch: String
     $interval: MeasurementInterval
 ) {
     owner(username: $owner) {
@@ -8,7 +9,7 @@ query = """query GetTestResultsAggregates(
             __typename
             ... on Repository {
                 testAnalytics {
-                    testResultsAggregates(interval: $interval) {
+                    testResultsAggregates(branch: $branch, interval: $interval) {
                         totalDuration
                         totalDurationPercentChange
                         slowestTestsDuration

--- a/src/sentry/codecov/endpoints/test_results_aggregates/test_results_aggregates.py
+++ b/src/sentry/codecov/endpoints/test_results_aggregates/test_results_aggregates.py
@@ -33,8 +33,8 @@ class TestResultsAggregatesEndpoint(CodecovEndpoint):
             GlobalParams.ORG_ID_OR_SLUG,
             PreventParams.OWNER,
             PreventParams.REPOSITORY,
-            PreventParams.BRANCH,
             PreventParams.INTERVAL,
+            PreventParams.BRANCH,
         ],
         request=None,
         responses={

--- a/src/sentry/codecov/endpoints/test_results_aggregates/test_results_aggregates.py
+++ b/src/sentry/codecov/endpoints/test_results_aggregates/test_results_aggregates.py
@@ -33,6 +33,7 @@ class TestResultsAggregatesEndpoint(CodecovEndpoint):
             GlobalParams.ORG_ID_OR_SLUG,
             PreventParams.OWNER,
             PreventParams.REPOSITORY,
+            PreventParams.BRANCH,
             PreventParams.INTERVAL,
         ],
         request=None,

--- a/src/sentry/codecov/endpoints/test_results_aggregates/test_results_aggregates.py
+++ b/src/sentry/codecov/endpoints/test_results_aggregates/test_results_aggregates.py
@@ -54,6 +54,7 @@ class TestResultsAggregatesEndpoint(CodecovEndpoint):
         variables = {
             "owner": owner_slug,
             "repo": repository,
+            "branch": request.query_params.get("branch"),
             "interval": request.query_params.get(
                 "interval", MeasurementInterval.INTERVAL_30_DAY.value
             ),

--- a/tests/sentry/codecov/endpoints/test_test_result_aggregates.py
+++ b/tests/sentry/codecov/endpoints/test_test_result_aggregates.py
@@ -134,7 +134,7 @@ class TestResultsAggregatesEndpointTest(APITestCase):
         mock_codecov_client_class.return_value = mock_codecov_client_instance
 
         url = self.reverse_url()
-        response = self.client.get(url, {"interval": "INTERVAL_7_DAY"})
+        response = self.client.get(url, {"interval": "INTERVAL_7_DAY", "branch": "main"})
 
         assert response.status_code == 200
         mock_codecov_client_class.assert_called_once_with(git_provider_org="testowner")
@@ -143,6 +143,7 @@ class TestResultsAggregatesEndpointTest(APITestCase):
             variables={
                 "owner": "testowner",
                 "repo": "testrepo",
+                "branch": "main",
                 "interval": "INTERVAL_7_DAY",
             },
         )


### PR DESCRIPTION
This PR passes the "branch" parameter to the test_test_result_aggregates endpoint. This is a parameter the frontend already sends and should be accepted by this endpoint.

Closes https://linear.app/getsentry/issue/CCMRG-1596/gazebo-add-all-branches-to-ta-page