### PR TITLE
fix(issues): Remove dead discover link from old issue details

### DIFF
--- a/static/app/utils/analytics/issueAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/issueAnalyticsEvents.tsx
@@ -148,7 +148,6 @@ export type IssueEventParameters = {
     should_be_escalating: boolean;
     reason?: string;
   };
-  'issue_details.event_details_clicked': GroupEventParams;
   'issue_details.event_dropdown_option_selected': EventDropdownParams;
   'issue_details.event_navigation_selected': {
     content: string;
@@ -581,7 +580,6 @@ export const issueEventMap: Record<IssueEventKey, string | null> = {
   'actionable_items.expand_clicked': 'Actionable Item: Expand Clicked',
   'issue_details.copy_event_link_clicked': 'Issue Details: Copy Event Link Clicked',
   'issue_details.copy_event_id_clicked': 'Issue Details: Copy Event ID Clicked',
-  'issue_details.event_details_clicked': 'Issue Details: Full Event Details Clicked',
   'issue_details.event_dropdown_option_selected':
     'Issue Details: Event Dropdown Option Selected',
   'issue_details.header_view_replay_clicked': 'Issue Details: Header View Replay Clicked',

--- a/static/app/utils/discover/urls.tsx
+++ b/static/app/utils/discover/urls.tsx
@@ -25,7 +25,7 @@ export function generateEventSlug(eventData: EventData): string {
 /**
  * Create a URL to an event details view.
  */
-export function eventDetailsRoute({
+function eventDetailsRoute({
   eventSlug,
   organization,
 }: {

--- a/static/app/views/issueDetails/groupEventCarousel.spec.tsx
+++ b/static/app/views/issueDetails/groupEventCarousel.spec.tsx
@@ -1,7 +1,6 @@
 import {ConfigFixture} from 'sentry-fixture/config';
 import {EventFixture} from 'sentry-fixture/event';
 import {GroupFixture} from 'sentry-fixture/group';
-import {OrganizationFixture} from 'sentry-fixture/organization';
 import {RouterFixture} from 'sentry-fixture/routerFixture';
 import {UserFixture} from 'sentry-fixture/user';
 
@@ -199,19 +198,6 @@ describe('GroupEventCarousel', () => {
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
       `http://localhost/organizations/org-slug/issues/group-id/events/event-id/`
     );
-  });
-
-  it('links to full event details when org has discover', async () => {
-    render(<GroupEventCarousel {...defaultProps} />, {
-      organization: OrganizationFixture({features: ['discover-basic']}),
-      deprecatedRouterMocks: true,
-    });
-
-    await userEvent.click(screen.getByRole('button', {name: /event actions/i}));
-
-    expect(
-      screen.getByRole('menuitemradio', {name: /full event details/i})
-    ).toHaveAttribute('href', `/organizations/org-slug/discover/project-slug:event-id/`);
   });
 
   it('can open event JSON', async () => {

--- a/static/app/views/issueDetails/groupEventCarousel.tsx
+++ b/static/app/views/issueDetails/groupEventCarousel.tsx
@@ -28,7 +28,6 @@ import type {Organization} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {formatBytesBase2} from 'sentry/utils/bytes/formatBytesBase2';
-import {eventDetailsRoute, generateEventSlug} from 'sentry/utils/discover/urls';
 import {
   getAnalyticsDataForEvent,
   getAnalyticsDataForGroup,
@@ -314,22 +313,6 @@ function GroupEventActions({event, group, projectSlug}: GroupEventActionsProps) 
             label: `JSON (${formatBytesBase2(event.size)})`,
             onAction: downloadJson,
             hidden: xlargeViewport,
-          },
-          {
-            key: 'full-event-discover',
-            label: t('Full Event Details'),
-            hidden: !organization.features.includes('discover-basic'),
-            to: eventDetailsRoute({
-              eventSlug: generateEventSlug({project: projectSlug, id: event.id}),
-              organization,
-            }),
-            onAction: () => {
-              trackAnalytics('issue_details.event_details_clicked', {
-                organization,
-                ...getAnalyticsDataForGroup(group),
-                ...getAnalyticsDataForEvent(event),
-              });
-            },
           },
           {
             key: 'replay',


### PR DESCRIPTION
"Full event details" took you to the discover event details page that no longer exists.

fixes JAVASCRIPT-2WH1

where this link lived
<img width="598" height="315" alt="image" src="https://github.com/user-attachments/assets/85684e54-5e75-47cc-9283-19d2cbaad5b6" />

