### PR TITLE
ref(settings): Remove router props from audit log

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -935,7 +935,6 @@ function buildRoutes(): RouteObject[] {
       path: 'audit-log/',
       name: t('Audit Log'),
       component: make(() => import('sentry/views/settings/organizationAuditLog')),
-      deprecatedRouteProps: true,
     },
     {
       path: 'auth/',

--- a/static/app/views/settings/organizationAuditLog/auditLogView.spec.tsx
+++ b/static/app/views/settings/organizationAuditLog/auditLogView.spec.tsx
@@ -1,8 +1,8 @@
 import {AuditLogsFixture} from 'sentry-fixture/auditLogs';
 import {AuditLogsApiEventNamesFixture} from 'sentry-fixture/auditLogsApiEventNames';
+import {OrganizationFixture} from 'sentry-fixture/organization';
 import {UserFixture} from 'sentry-fixture/user';
 
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {
   render,
   screen,
@@ -15,12 +15,7 @@ import OrganizationAuditLog from 'sentry/views/settings/organizationAuditLog';
 // XXX(epurkhiser): This appears to also be tested by ./index.spec.tsx
 
 describe('OrganizationAuditLog', () => {
-  const {organization, router} = initializeOrg({
-    projects: [],
-    router: {
-      params: {orgId: 'org-slug'},
-    },
-  });
+  const organization = OrganizationFixture();
   const ENDPOINT = `/organizations/${organization.slug}/audit-logs/`;
 
   beforeEach(() => {
@@ -32,7 +27,7 @@ describe('OrganizationAuditLog', () => {
   });
 
   it('renders', async () => {
-    render(<OrganizationAuditLog location={router.location} />);
+    render(<OrganizationAuditLog />);
 
     expect(await screen.findByRole('heading')).toHaveTextContent('Audit Log');
     // Check that both textboxes are present (date selector search and event selector)
@@ -52,13 +47,13 @@ describe('OrganizationAuditLog', () => {
       body: {rows: [], options: AuditLogsApiEventNamesFixture()},
     });
 
-    render(<OrganizationAuditLog location={router.location} />);
+    render(<OrganizationAuditLog />);
 
     expect(await screen.findByText('No audit entries available')).toBeInTheDocument();
   });
 
   it('displays whether an action was done by a superuser', async () => {
-    render(<OrganizationAuditLog location={router.location} />);
+    render(<OrganizationAuditLog />);
 
     expect(await screen.findByText('Sentry Staff')).toBeInTheDocument();
     expect(screen.getAllByText('Foo Bar')).toHaveLength(2);
@@ -74,7 +69,7 @@ describe('OrganizationAuditLog', () => {
       },
     });
 
-    render(<OrganizationAuditLog location={router.location} />);
+    render(<OrganizationAuditLog />);
 
     await userEvent.click(screen.getByText('Select Action:'));
 
@@ -115,7 +110,7 @@ describe('OrganizationAuditLog', () => {
       },
     });
 
-    render(<OrganizationAuditLog location={router.location} />);
+    render(<OrganizationAuditLog />);
 
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
 

--- a/static/app/views/settings/organizationAuditLog/index.spec.tsx
+++ b/static/app/views/settings/organizationAuditLog/index.spec.tsx
@@ -20,14 +20,7 @@ describe('OrganizationAuditLog', () => {
       },
     });
 
-    const {router} = initializeOrg({
-      projects: [],
-      router: {
-        params: {orgId: 'org-slug'},
-      },
-    });
-
-    render(<OrganizationAuditLog location={router.location} />);
+    render(<OrganizationAuditLog />);
 
     expect(await screen.findByText('project.edit')).toBeInTheDocument();
     expect(screen.getByText('org.edit')).toBeInTheDocument();
@@ -43,11 +36,7 @@ describe('OrganizationAuditLog', () => {
   });
 
   it('Displays pretty dynamic sampling logs', async () => {
-    const {router, project, projects, organization} = initializeOrg({
-      router: {
-        params: {orgId: 'org-slug'},
-      },
-    });
+    const {project, projects, organization} = initializeOrg();
 
     ProjectsStore.loadInitialData(projects);
 
@@ -93,7 +82,7 @@ describe('OrganizationAuditLog', () => {
       },
     });
 
-    render(<OrganizationAuditLog location={router.location} />);
+    render(<OrganizationAuditLog />);
 
     // Enabled dynamic sampling priority
     expect(await screen.findByText('sampling_priority.enabled')).toBeInTheDocument();
@@ -134,20 +123,18 @@ describe('OrganizationAuditLog', () => {
       },
     });
 
-    const {router} = initializeOrg({
-      projects: [],
-      router: {
-        params: {orgId: 'org-slug'},
+    render(<OrganizationAuditLog />, {
+      initialRouterConfig: {
         location: {
+          pathname: '/organizations/org-slug/audit-logs/',
           query: {
             start: '2018-02-01T00:00:00.000Z',
             end: '2018-02-28T23:59:59.999Z',
           },
         },
+        route: '/organizations/:orgId/audit-logs/',
       },
     });
-
-    render(<OrganizationAuditLog location={router.location} />);
 
     await waitFor(() => {
       expect(absoluteDateMockResponse).toHaveBeenCalledWith(

--- a/static/app/views/settings/organizationAuditLog/index.spec.tsx
+++ b/static/app/views/settings/organizationAuditLog/index.spec.tsx
@@ -126,13 +126,13 @@ describe('OrganizationAuditLog', () => {
     render(<OrganizationAuditLog />, {
       initialRouterConfig: {
         location: {
-          pathname: '/organizations/org-slug/audit-logs/',
+          pathname: '/organizations/org-slug/audit-log/',
           query: {
             start: '2018-02-01T00:00:00.000Z',
             end: '2018-02-28T23:59:59.999Z',
           },
         },
-        route: '/organizations/:orgId/audit-logs/',
+        route: '/organizations/:orgId/audit-log/',
       },
     });
 

--- a/static/app/views/settings/organizationAuditLog/index.tsx
+++ b/static/app/views/settings/organizationAuditLog/index.tsx
@@ -1,6 +1,5 @@
 import {Fragment, useCallback, useEffect, useState} from 'react';
 import * as Sentry from '@sentry/react';
-import type {Location} from 'history';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {normalizeDateTimeString} from 'sentry/components/organizations/pageFilters/parse';
@@ -13,14 +12,11 @@ import {getDateWithTimezoneInUtc, getUserTimezone} from 'sentry/utils/dates';
 import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
 import {decodeScalar} from 'sentry/utils/queryString';
 import useApi from 'sentry/utils/useApi';
+import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {OrganizationPermissionAlert} from 'sentry/views/settings/organization/organizationPermissionAlert';
 
 import AuditLogList from './auditLogList';
-
-type Props = {
-  location: Location;
-};
 
 type State = {
   entryList: AuditLog[] | null;
@@ -35,7 +31,8 @@ type State = {
   start?: DateString;
 };
 
-function OrganizationAuditLog({location}: Props) {
+function OrganizationAuditLog() {
+  const location = useLocation();
   const [state, setState] = useState<State>({
     entryList: [],
     entryListPageLinks: null,


### PR DESCRIPTION
Moves audit log to use location from hook instead of deprecated props
