### PR TITLE
ref(alerts): Move incident redirect off of router props

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1668,7 +1668,6 @@ function buildRoutes(): RouteObject[] {
     {
       path: ':alertId/',
       component: make(() => import('sentry/views/alerts/incidentRedirect')),
-      deprecatedRouteProps: true,
     },
     {
       path: ':projectId/',

--- a/static/app/utils/useParams.tsx
+++ b/static/app/utils/useParams.tsx
@@ -11,6 +11,7 @@ import {useTestRouteContext} from './useRouteContext';
  * Prevents misspelling of param keys
  */
 type ParamKeys =
+  | 'alertId'
   | 'apiKey'
   | 'appId'
   | 'appSlug'

--- a/static/app/views/alerts/incidentRedirect.spec.tsx
+++ b/static/app/views/alerts/incidentRedirect.spec.tsx
@@ -1,6 +1,6 @@
 import {IncidentFixture} from 'sentry-fixture/incident';
+import {ProjectFixture} from 'sentry-fixture/project';
 
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -10,12 +10,13 @@ import IncidentRedirect from './incidentRedirect';
 jest.mock('sentry/utils/analytics');
 
 describe('IncidentRedirect', () => {
-  const params = {alertId: '123'};
-  const {organization, project, router, routerProps} = initializeOrg({
-    router: {
-      params,
+  const initialRouterConfig = {
+    location: {
+      pathname: '/organizations/org-slug/alerts/123/',
     },
-  });
+    route: '/organizations/:orgId/alerts/:alertId/',
+  };
+  const project = ProjectFixture();
   const mockIncident = IncidentFixture({projects: [project.slug]});
 
   beforeEach(() => {
@@ -31,9 +32,8 @@ describe('IncidentRedirect', () => {
   });
 
   it('redirects to alert details page', async () => {
-    render(<IncidentRedirect organization={organization} {...routerProps} />, {
-      router,
-      deprecatedRouterMocks: true,
+    const {router} = render(<IncidentRedirect />, {
+      initialRouterConfig,
     });
 
     expect(trackAnalytics).toHaveBeenCalledWith(
@@ -44,12 +44,14 @@ describe('IncidentRedirect', () => {
     );
 
     await waitFor(() => {
-      expect(router.replace).toHaveBeenCalledWith({
-        pathname: '/organizations/org-slug/alerts/rules/details/4/',
-        query: {
-          alert: '123',
-        },
-      });
+      expect(router.location).toEqual(
+        expect.objectContaining({
+          pathname: '/organizations/org-slug/alerts/rules/details/4/',
+          query: {
+            alert: '123',
+          },
+        })
+      );
     });
   });
 });


### PR DESCRIPTION
Removes use of deprecated router props from incident redirect component
