### PR TITLE
ref(feedback): Refactor `<MessageSection>` into two parts

### DIFF
--- a/static/app/components/feedback/feedbackItem/feedbackItem.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItem.tsx
@@ -13,6 +13,7 @@ import FeedbackItemSection from 'sentry/components/feedback/feedbackItem/feedbac
 import FeedbackReplay from 'sentry/components/feedback/feedbackItem/feedbackReplay';
 import FeedbackUrl from 'sentry/components/feedback/feedbackItem/feedbackUrl';
 import MessageSection from 'sentry/components/feedback/feedbackItem/messageSection';
+import MessageTitle from 'sentry/components/feedback/feedbackItem/messageTitle';
 import TraceDataSection from 'sentry/components/feedback/feedbackItem/traceDataSection';
 import {KeyValueData} from 'sentry/components/keyValueData';
 import PanelItem from 'sentry/components/panels/panelItem';
@@ -56,6 +57,7 @@ export default function FeedbackItem({feedbackItem, eventData}: Props) {
         <FeedbackItemHeader eventData={eventData} feedbackItem={feedbackItem} />
         <OverflowPanelItem ref={overflowRef}>
           <FeedbackItemSection sectionKey="message">
+            <MessageTitle eventData={eventData} feedbackItem={feedbackItem} />
             <MessageSection eventData={eventData} feedbackItem={feedbackItem} />
           </FeedbackItemSection>
 

--- a/static/app/components/feedback/feedbackItem/messageSection.tsx
+++ b/static/app/components/feedback/feedbackItem/messageSection.tsx
@@ -1,16 +1,7 @@
-import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {useRole} from 'sentry/components/acl/useRole';
-import {Tag} from 'sentry/components/core/badge/tag';
-import {Flex} from 'sentry/components/core/layout';
-import {ExternalLink} from 'sentry/components/core/link';
-import {Tooltip} from 'sentry/components/core/tooltip';
-import FeedbackItemUsername from 'sentry/components/feedback/feedbackItem/feedbackItemUsername';
-import FeedbackTimestampsTooltip from 'sentry/components/feedback/feedbackItem/feedbackTimestampsTooltip';
 import {ScreenshotSection} from 'sentry/components/feedback/feedbackItem/screenshotSection';
-import TimeSince from 'sentry/components/timeSince';
-import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
 import type {FeedbackIssue} from 'sentry/utils/feedback/types';
@@ -25,63 +16,21 @@ export default function MessageSection({eventData, feedbackItem}: Props) {
   const organization = useOrganization();
   const {hasRole} = useRole({role: 'attachmentsRole'});
   const project = feedbackItem.project;
-  const isSpam = eventData?.occurrence?.evidenceData.isSpam;
 
   return (
-    <Fragment>
-      <Flex wrap="wrap" flex="1 1 auto" gap="md" justify="between">
-        <FeedbackItemUsername feedbackIssue={feedbackItem} />
-        <Flex gap="md">
-          {isSpam ? (
-            <Tag key="spam" type="error">
-              <Tooltip
-                isHoverable
-                position="left"
-                title={tct(
-                  'This feedback was automatically marked as spam. Learn more by [link:reading our docs.]',
-                  {
-                    link: (
-                      <ExternalLink href="https://docs.sentry.io/product/user-feedback/#spam-detection-for-user-feedback" />
-                    ),
-                  }
-                )}
-              >
-                {t('spam')}
-              </Tooltip>
-            </Tag>
-          ) : null}
-          <StyledTimeSince
-            date={feedbackItem.firstSeen}
-            tooltipProps={{
-              title: eventData ? (
-                <FeedbackTimestampsTooltip feedbackItem={feedbackItem} />
-              ) : undefined,
-              overlayStyle: {maxWidth: 300},
-            }}
-          />
-        </Flex>
-      </Flex>
-      <Blockquote>
-        <pre>{feedbackItem.metadata.message}</pre>
+    <Blockquote>
+      <pre>{feedbackItem.metadata.message}</pre>
 
-        {eventData && project && hasRole ? (
-          <ScreenshotSection
-            event={eventData}
-            organization={organization}
-            projectSlug={project.slug}
-          />
-        ) : null}
-      </Blockquote>
-    </Fragment>
+      {eventData && project && hasRole ? (
+        <ScreenshotSection
+          event={eventData}
+          organization={organization}
+          projectSlug={project.slug}
+        />
+      ) : null}
+    </Blockquote>
   );
 }
-
-const StyledTimeSince = styled(TimeSince)`
-  color: ${p => p.theme.subText};
-  font-size: ${p => p.theme.fontSizeRelativeSmall};
-  align-self: center;
-  white-space: nowrap;
-`;
 
 const Blockquote = styled('blockquote')`
   margin: 0;

--- a/static/app/components/feedback/feedbackItem/messageTitle.tsx
+++ b/static/app/components/feedback/feedbackItem/messageTitle.tsx
@@ -1,0 +1,63 @@
+import styled from '@emotion/styled';
+
+import {Tag} from 'sentry/components/core/badge/tag';
+import {Flex} from 'sentry/components/core/layout';
+import {ExternalLink} from 'sentry/components/core/link';
+import {Tooltip} from 'sentry/components/core/tooltip';
+import FeedbackItemUsername from 'sentry/components/feedback/feedbackItem/feedbackItemUsername';
+import FeedbackTimestampsTooltip from 'sentry/components/feedback/feedbackItem/feedbackTimestampsTooltip';
+import TimeSince from 'sentry/components/timeSince';
+import {t, tct} from 'sentry/locale';
+import type {Event} from 'sentry/types/event';
+import type {FeedbackIssue} from 'sentry/utils/feedback/types';
+
+interface Props {
+  eventData: Event | undefined;
+  feedbackItem: FeedbackIssue;
+}
+
+export default function MessageTitle({feedbackItem, eventData}: Props) {
+  const isSpam = eventData?.occurrence?.evidenceData.isSpam;
+
+  return (
+    <Flex wrap="wrap" flex="1 1 auto" gap="md" justify="between">
+      <FeedbackItemUsername feedbackIssue={feedbackItem} />
+      <Flex gap="md">
+        {isSpam ? (
+          <Tag key="spam" type="error">
+            <Tooltip
+              isHoverable
+              position="left"
+              title={tct(
+                'This feedback was automatically marked as spam. Learn more by [link:reading our docs.]',
+                {
+                  link: (
+                    <ExternalLink href="https://docs.sentry.io/product/user-feedback/#spam-detection-for-user-feedback" />
+                  ),
+                }
+              )}
+            >
+              {t('spam')}
+            </Tooltip>
+          </Tag>
+        ) : null}
+        <StyledTimeSince
+          date={feedbackItem.firstSeen}
+          tooltipProps={{
+            title: eventData ? (
+              <FeedbackTimestampsTooltip feedbackItem={feedbackItem} />
+            ) : undefined,
+            overlayStyle: {maxWidth: 300},
+          }}
+        />
+      </Flex>
+    </Flex>
+  );
+}
+
+const StyledTimeSince = styled(TimeSince)`
+  color: ${p => p.theme.subText};
+  font-size: ${p => p.theme.fontSizeRelativeSmall};
+  align-self: center;
+  white-space: nowrap;
+`;


### PR DESCRIPTION
This should make it make more sense, easier to find things because its not intuitive that timeSince is inside the Message bit

