### PR TITLE
fix(codeowners): prevent duplicate ExternalActor creation for case-insensitive integrations

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -475,6 +475,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:uptime-eap-results", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable querying uptime data from EAP uptime_results instead of uptime_checks
     manager.add("organizations:uptime-eap-uptime-results-query", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable case-insensitive codeowners team matching
+    manager.add("organizations:use-case-insensitive-codeowners", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:use-metrics-layer", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     manager.add("organizations:user-feedback-ai-summaries", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable label generation at ingest time for user feedbacks

--- a/src/sentry/integrations/api/bases/external_actor.py
+++ b/src/sentry/integrations/api/bases/external_actor.py
@@ -42,6 +42,12 @@ STRICT_NAME_PROVIDERS = {
     ExternalProviders.GITLAB,
 }
 
+CASE_INSENSITIVE_PROVIDERS = {
+    ExternalProviders.GITHUB,
+    ExternalProviders.GITHUB_ENTERPRISE,
+    ExternalProviders.GITLAB,
+}
+
 
 class ExternalActorResponse(TypedDict):
     id: int
@@ -95,6 +101,18 @@ class ExternalActorSerializerBase(CamelSnakeModelSerializer):
 
     def create(self, validated_data: MutableMapping[str, Any]) -> tuple[ExternalActor, bool]:
         actor_params = self.get_actor_params(validated_data)
+
+        if features.has("organizations:use-case-insensitive-codeowners", self.organization):
+            if validated_data["provider"] in CASE_INSENSITIVE_PROVIDERS:
+                external_name = validated_data.pop("external_name")
+
+                return ExternalActor.objects.get_or_create(
+                    external_name__iexact=external_name,
+                    **validated_data,
+                    organization=self.organization,
+                    defaults={**actor_params, "external_name": external_name},
+                )
+
         return ExternalActor.objects.get_or_create(
             **validated_data,
             organization=self.organization,

--- a/tests/sentry/integrations/api/serializers/test_external_actor.py
+++ b/tests/sentry/integrations/api/serializers/test_external_actor.py
@@ -8,6 +8,7 @@ from sentry.integrations.models.external_actor import ExternalActor
 from sentry.integrations.types import ExternalProviders
 from sentry.integrations.utils.providers import get_provider_name
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.features import with_feature
 
 
 class ExternalActorSerializerTest(TestCase):
@@ -145,3 +146,70 @@ class ExternalActorSerializerTest(TestCase):
             context={"organization": self.organization},
         )
         assert serializer.is_valid() is True
+
+    @with_feature("organizations:use-case-insensitive-codeowners")
+    def test_create_case_insensitive_team(self) -> None:
+        sentry_team = self.create_team(organization=self.organization, members=[self.user])
+
+        external_actor_team_data = {
+            "provider": get_provider_name(ExternalProviders.GITHUB.value),
+            "external_name": "@getsentry/example-team",
+            "integrationId": self.integration.id,
+            "team_id": sentry_team.id,
+        }
+
+        serializer = ExternalTeamSerializer(
+            data=external_actor_team_data,
+            context={"organization": self.organization},
+        )
+        assert serializer.is_valid() is True
+        external_actor1, created1 = serializer.create(serializer.validated_data)
+        assert created1 is True
+        assert external_actor1.external_name == "@getsentry/example-team"
+
+        # Try to create another with different case but different team - should match existing one
+        external_actor_team_data["external_name"] = "@GETSENTRY/EXAMPLE-TEAM"
+        external_actor_team_data["team_id"] = sentry_team.id
+
+        serializer = ExternalTeamSerializer(
+            data=external_actor_team_data,
+            context={"organization": self.organization},
+        )
+        assert serializer.is_valid() is True
+        external_actor2, created2 = serializer.create(serializer.validated_data)
+
+        # We should not have created a new external actor - we should have returned the existing one
+        assert created2 is False
+        assert external_actor2.id == external_actor1.id
+        assert external_actor2.external_name == "@getsentry/example-team"
+
+    def test_create_case_sensitive_team(self) -> None:
+        sentry_team = self.create_team(organization=self.organization, members=[self.user])
+
+        external_actor_team_data = {
+            "provider": get_provider_name(ExternalProviders.GITHUB.value),
+            "external_name": "@getsentry/example-team",
+            "integrationId": self.integration.id,
+            "team_id": sentry_team.id,
+        }
+
+        serializer = ExternalTeamSerializer(
+            data=external_actor_team_data,
+            context={"organization": self.organization},
+        )
+        assert serializer.is_valid() is True
+        external_actor1, created1 = serializer.create(serializer.validated_data)
+        assert created1 is True
+        assert external_actor1.external_name == "@getsentry/example-team"
+
+        external_actor_team_data["external_name"] = "@GETSENTRY/EXAMPLE-TEAM"
+        external_actor_team_data["team_id"] = sentry_team.id
+
+        serializer = ExternalTeamSerializer(
+            data=external_actor_team_data,
+            context={"organization": self.organization},
+        )
+        assert serializer.is_valid() is True
+        external_actor2, created2 = serializer.create(serializer.validated_data)
+        assert created2 is True
+        assert external_actor2.external_name == "@GETSENTRY/EXAMPLE-TEAM"


### PR DESCRIPTION
GitHub teams and users in CODEOWNER files are case-insensitive — however, we treat them as case-sensitive, and thus allow for multiple ExternalActor objects that actually map to the same GitHub team:
<img width="1182" height="401" alt="Screenshot 2025-09-02 at 3 38 29 PM" src="https://github.com/user-attachments/assets/f139834f-b4fa-468e-8f56-1005fe63f1a5" />
in this case, @charlieluo/test and @charlieluo/Test are duplicates, and will map to the same GitHub team.

This prevents the creation of these duplicates, behind a feature flag. Next step (https://github.com/getsentry/sentry/pull/98668) is to read CODEOWNERs case-insensitively, so that users can create @charlieluo/TEST or @charlieluo/Test ExternalActors, and they will both correctly map to the GitHub team @charlieluo/test — feature flag will be used to sync these changes together, so that we go from all case-sensitive to all case-insensitive behavior together.


See https://linear.app/getsentry/issue/ID-97/github-code-owner-teams-should-be-case-insensitive and https://github.com/getsentry/sentry/issues/79296