### PR TITLE
fix(codeowners): parse CODEOWNERs associations case-insensitively

### DIFF
--- a/src/sentry/api/validators/project_codeowners.py
+++ b/src/sentry/api/validators/project_codeowners.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
 from collections.abc import Collection, Iterable, Mapping
+from functools import reduce
+from operator import or_
 from typing import Any
 
 from django.db.models import Subquery
+from django.db.models.query_utils import Q
 
+from sentry import features
 from sentry.integrations.models.external_actor import ExternalActor
 from sentry.integrations.types import ExternalProviders
 from sentry.issues.ownership.grammar import parse_code_owners
@@ -24,11 +28,10 @@ def validate_association_emails(
 
 def validate_association_actors(
     raw_items: Collection[str],
-    associations: Iterable[ExternalActor],
+    associations: Iterable[str],
 ) -> list[str]:
     raw_items_set = {str(item) for item in raw_items}
-    # associations are ExternalActor objects
-    sentry_items = {item.external_name for item in associations}
+    sentry_items = {item for item in associations}
     return list(raw_items_set.difference(sentry_items))
 
 
@@ -43,16 +46,32 @@ def validate_codeowners_associations(
         filter=dict(emails=emails, organization_id=project.organization_id)
     )
 
-    # Check if the usernames/teamnames have an association
-    external_actors = ExternalActor.objects.filter(
-        external_name__in=usernames + team_names,
-        organization_id=project.organization_id,
-        provider__in=[
-            ExternalProviders.GITHUB.value,
-            ExternalProviders.GITHUB_ENTERPRISE.value,
-            ExternalProviders.GITLAB.value,
-        ],
-    )
+    external_actors = []
+
+    if features.has("organizations:use-case-insensitive-codeowners", project.organization):
+        query = map(lambda xname: Q(external_name__iexact=xname), usernames + team_names)
+        query = reduce(or_, query, Q())
+        # GitHub team and user names are case-insensitive
+        external_actors = ExternalActor.objects.filter(
+            query,
+            organization_id=project.organization_id,
+            provider__in=[
+                ExternalProviders.GITHUB.value,
+                ExternalProviders.GITHUB_ENTERPRISE.value,
+                ExternalProviders.GITLAB.value,
+            ],
+        )
+    else:
+        # Check if the usernames/teamnames have an association
+        external_actors = ExternalActor.objects.filter(
+            external_name__in=usernames + team_names,
+            organization_id=project.organization_id,
+            provider__in=[
+                ExternalProviders.GITHUB.value,
+                ExternalProviders.GITHUB_ENTERPRISE.value,
+                ExternalProviders.GITLAB.value,
+            ],
+        )
 
     # Convert CODEOWNERS into IssueOwner syntax
     users_dict = {}
@@ -60,11 +79,19 @@ def validate_codeowners_associations(
     teams_without_access = []
     users_without_access = []
 
-    team_ids_to_external_names: Mapping[int, str] = {
-        xa.team_id: xa.external_name for xa in external_actors if xa.team_id is not None
+    team_ids_to_external_names: Mapping[int, list[str]] = {
+        xa.team_id: [
+            team_name for team_name in team_names if team_name.lower() == xa.external_name.lower()
+        ]
+        for xa in external_actors
+        if xa.team_id is not None
     }
-    user_ids_to_external_names: Mapping[int, str] = {
-        xa.user_id: xa.external_name for xa in external_actors if xa.user_id is not None
+    user_ids_to_external_names: Mapping[int, list[str]] = {
+        xa.user_id: [
+            username for username in usernames if username.lower() == xa.external_name.lower()
+        ]
+        for xa in external_actors
+        if xa.user_id is not None
     }
 
     for user in user_service.get_many(
@@ -79,17 +106,21 @@ def validate_codeowners_associations(
         projects = Project.objects.get_for_team_ids(Subquery(team_ids))
 
         if project in projects:
-            users_dict[user_ids_to_external_names[user.id]] = user.email
+            for external_name in user_ids_to_external_names[user.id]:
+                users_dict[external_name] = user.email
         else:
-            users_without_access.append(f"{user.get_display_name()}")
+            users_without_access.append(
+                (f"{user.get_display_name()}", user_ids_to_external_names[user.id])
+            )
 
     for team in Team.objects.filter(id__in=list(team_ids_to_external_names.keys())):
         # make sure the sentry team has access to the project
         # tied to the codeowner
         if project in team.get_projects():
-            teams_dict[team_ids_to_external_names[team.id]] = f"#{team.slug}"
+            for external_name in team_ids_to_external_names[team.id]:
+                teams_dict[external_name] = f"#{team.slug}"
         else:
-            teams_without_access.append(f"#{team.slug}")
+            teams_without_access.append((f"#{team.slug}", team_ids_to_external_names[team.id]))
 
     emails_dict = {}
     user_emails = set()
@@ -102,9 +133,15 @@ def validate_codeowners_associations(
 
     errors = {
         "missing_user_emails": validate_association_emails(emails, user_emails),
-        "missing_external_users": validate_association_actors(usernames, external_actors),
-        "missing_external_teams": validate_association_actors(team_names, external_actors),
-        "teams_without_access": teams_without_access,
-        "users_without_access": users_without_access,
+        "missing_external_users": validate_association_actors(
+            usernames,
+            list(associations.keys()) + [name for user in users_without_access for name in user[1]],
+        ),
+        "missing_external_teams": validate_association_actors(
+            team_names,
+            list(associations.keys()) + [name for team in teams_without_access for name in team[1]],
+        ),
+        "teams_without_access": list(map(lambda x: x[0], teams_without_access)),
+        "users_without_access": list(map(lambda x: x[0], users_without_access)),
     }
     return associations, errors

--- a/src/sentry/api/validators/project_codeowners.py
+++ b/src/sentry/api/validators/project_codeowners.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Collection, Iterable, Mapping
+from collections.abc import Collection, Mapping, Sequence
 from functools import reduce
 from operator import or_
 from typing import Any
@@ -27,12 +27,10 @@ def validate_association_emails(
 
 
 def validate_association_actors(
-    raw_items: list[str],
-    associations: Iterable[str],
+    raw_items: Sequence[str],
+    associations: Sequence[str],
 ) -> list[str]:
-    raw_items_set = {str(item) for item in raw_items}
-    sentry_items = {item for item in associations}
-    return list(raw_items_set.difference(sentry_items))
+    return list(set(raw_items).difference(associations))
 
 
 def validate_codeowners_associations(

--- a/tests/sentry/issues/endpoints/test_project_codeowners_index.py
+++ b/tests/sentry/issues/endpoints/test_project_codeowners_index.py
@@ -4,6 +4,7 @@ from django.urls import reverse
 
 from sentry.models.projectcodeowners import ProjectCodeOwners
 from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers import with_feature
 
 
 class ProjectCodeOwnersEndpointTestCase(APITestCase):
@@ -272,6 +273,37 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
                 }
             ],
         }
+
+    @patch(
+        "sentry.integrations.source_code_management.repository.RepositoryIntegration.get_codeowner_file",
+        return_value={"html_url": "https://github.com/test/CODEOWNERS"},
+    )
+    @with_feature("organizations:use-case-insensitive-codeowners")
+    def test_case_insensitive_team_matching(self, get_codeowner_mock_file: MagicMock) -> None:
+        """Test that team names are matched case-insensitively in CODEOWNERS files."""
+
+        external_team_name = self.external_team.external_name
+        capitalized_external_team_name = external_team_name.swapcase()
+
+        self.data[
+            "raw"
+        ] = f"""
+        src/frontend/* {external_team_name}
+        src/frontend2/* {capitalized_external_team_name}
+        """
+
+        with self.feature({"organizations:integrations-codeowners": True}):
+            response = self.client.post(self.url, self.data)
+
+        assert response.status_code == 201, response.content
+
+        assert (
+            response.data["ownershipSyntax"]
+            == f"codeowners:src/frontend/* #{self.team.slug}\ncodeowners:src/frontend2/* #{self.team.slug}\n"
+        )
+
+        errors = response.data["errors"]
+        assert errors["missing_external_teams"] == []
 
     @patch(
         "sentry.integrations.source_code_management.repository.RepositoryIntegration.get_codeowner_file",


### PR DESCRIPTION
Parse CODEOWNERs case-insensitively for SCM providers, behind a feature flag. We do this by constructing a mapping of all user/team ids -> possible external names (ex. `team_id_123: [@cvxluo, @CVXLUO, @cvxLUO]`) and then returning the reverse mapping (`{"@cvxluo" : team_id_123, "@CVXLUO": team_id_123}`) as `associations`. 

This is notably a breaking change for a subset of customers that have bad mappings. For example, right now I have the following ExternalActors:
`@charlieluo/test` maps to #charlie-test-team and `@charlieluo/TEST` maps to #another-charlie-test-team. If we run this new logic on my org, then we'll map both teams to the external team. Thus, to roll this out, we'll set the feature flag on all orgs but the ones with broken mappings (see [query](https://redash.getsentry.net/queries/9433/source)), fix those manually, then remove the feature flag.

Follow up of https://github.com/getsentry/sentry/pull/98667. 


Refs https://linear.app/getsentry/issue/ID-97/github-code-owner-teams-should-be-case-insensitive and https://github.com/getsentry/sentry/issues/79296