### PR TITLE
feat(feedback): Show event evidence inside the Feedback Details > Context section

### DIFF
--- a/static/app/components/feedback/feedbackItem/feedbackItem.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItem.tsx
@@ -156,14 +156,16 @@ function FeedbackItemContexts({
   project: undefined | Project;
 }) {
   const evidenceObject = Object.fromEntries(
-    eventData.occurrence?.evidenceDisplay.map(({name, value}) => {
+    eventData.occurrence?.evidenceDisplay?.map(({name, value}) => {
       return [name, value];
     }) ?? []
   );
+  eventData.contexts = eventData.contexts ?? {};
   eventData.contexts.feedback = eventData.contexts.feedback ?? {};
-  eventData.contexts.feedback['spam.detection_enabled'] =
+  eventData.contexts.feedback['auto_spam.detection_enabled'] =
     evidenceObject.spam_detection_enabled;
-  eventData.contexts.feedback['spam.is_spam'] = evidenceObject.is_spam;
+  eventData.contexts.feedback['auto_spam.is_spam'] = evidenceObject.is_spam;
+
   const cards = getOrderedContextItems(eventData).map(
     ({alias, type, value: contextValue}) => (
       <ContextCard

--- a/static/app/components/feedback/feedbackItem/feedbackItem.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItem.tsx
@@ -169,6 +169,25 @@ function FeedbackItemContexts({
     )
   );
 
+  if (eventData.occurrence?.evidenceDisplay.length) {
+    const evidenceContext = Object.fromEntries(
+      eventData.occurrence.evidenceDisplay.map(({name, value}) => {
+        return [name, value];
+      })
+    );
+    cards.push(
+      <ContextCard
+        key={'evidence'}
+        type={'Event Occurance'}
+        alias={'evidence'}
+        value={evidenceContext}
+        event={eventData}
+        group={feedbackItem as unknown as Group}
+        project={project}
+      />
+    );
+  }
+
   if (!cards.length) {
     return null;
   }

--- a/static/app/components/feedback/feedbackItem/feedbackItem.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItem.tsx
@@ -178,7 +178,7 @@ function FeedbackItemContexts({
     cards.push(
       <ContextCard
         key={'evidence'}
-        type={'Event Occurance'}
+        type={'Event Occurrence'}
         alias={'evidence'}
         value={evidenceContext}
         event={eventData}

--- a/static/app/components/feedback/feedbackItem/feedbackItem.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItem.tsx
@@ -155,6 +155,15 @@ function FeedbackItemContexts({
   feedbackItem: FeedbackIssue;
   project: undefined | Project;
 }) {
+  const evidenceObject = Object.fromEntries(
+    eventData.occurrence?.evidenceDisplay.map(({name, value}) => {
+      return [name, value];
+    }) ?? []
+  );
+  eventData.contexts.feedback = eventData.contexts.feedback ?? {};
+  eventData.contexts.feedback['spam.detection_enabled'] =
+    evidenceObject.spam_detection_enabled;
+  eventData.contexts.feedback['spam.is_spam'] = evidenceObject.is_spam;
   const cards = getOrderedContextItems(eventData).map(
     ({alias, type, value: contextValue}) => (
       <ContextCard
@@ -168,25 +177,6 @@ function FeedbackItemContexts({
       />
     )
   );
-
-  if (eventData.occurrence?.evidenceDisplay.length) {
-    const evidenceContext = Object.fromEntries(
-      eventData.occurrence.evidenceDisplay.map(({name, value}) => {
-        return [name, value];
-      })
-    );
-    cards.push(
-      <ContextCard
-        key={'evidence'}
-        type={'Event Occurrence'}
-        alias={'evidence'}
-        value={evidenceContext}
-        event={eventData}
-        group={feedbackItem as unknown as Group}
-        project={project}
-      />
-    );
-  }
 
   if (!cards.length) {
     return null;


### PR DESCRIPTION
Show feedback event evidence inside the 'Context > Feedback' section of the Feedback Details page.

Followup to https://github.com/getsentry/sentry/pull/97452
Relates to https://linear.app/getsentry/issue/REPLAY-602/user-feedback-unhelpful-feedback-and-profanity-should-be-detected-as

<img width="454" height="324" alt="SCR-20250902-ohdq" src="https://github.com/user-attachments/assets/9089f2f8-aea9-45dd-85d6-6f5986e6acc2" />

I added both `auto_spam.detection_enabled` and `auto_spam.is_spam` to group both fields together, and indicate that they're automatically added fields, because someone might manually change the current state of things. The 'auto' part is meant to relate to the tooltip: 
> This feedback was automatically marked as spam. Learn more by reading our docs.