### PR TITLE
chore(prevent-ai): Fix prevent AI toggle copy

### DIFF
--- a/static/app/data/forms/organizationGeneralSettings.tsx
+++ b/static/app/data/forms/organizationGeneralSettings.tsx
@@ -52,11 +52,11 @@ const formGroups: JsonFormObject[] = [
       {
         name: 'enablePrReviewTestGeneration',
         type: 'boolean',
-        label: tct('Enable PR Review and Test Generation [badge]', {
+        label: tct('Enable Prevent AI [badge]', {
           badge: <FeatureBadge type="beta" style={{marginBottom: '2px'}} />,
         }),
         help: tct(
-          'Use AI to generate feedback and tests in pull requests [link:Learn more]',
+          'Use AI to review, find bugs, and generate tests in pull requests [link:Learn more]',
           {
             link: (
               <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/sentry-prevent-ai/" />

--- a/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.spec.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.spec.tsx
@@ -249,7 +249,7 @@ describe('OrganizationSettingsForm', () => {
     expect(toggle).toBeEnabled();
   });
 
-  it('renders PR Review and Test Generation field', () => {
+  it('renders Prevent AI field', () => {
     render(
       <OrganizationSettingsForm
         {...routerProps}
@@ -258,12 +258,12 @@ describe('OrganizationSettingsForm', () => {
       />
     );
 
-    expect(screen.getByText('Enable PR Review and Test Generation')).toBeInTheDocument();
+    expect(screen.getByText('Enable Prevent AI')).toBeInTheDocument();
 
     expect(screen.getByText('beta')).toBeInTheDocument();
 
     expect(
-      screen.getByText('Use AI to generate feedback and tests in pull requests')
+      screen.getByText('Use AI to review, find bugs, and generate tests in pull requests')
     ).toBeInTheDocument();
 
     const learnMoreLink = screen.getByRole('link', {name: 'Learn more'});
@@ -274,7 +274,7 @@ describe('OrganizationSettingsForm', () => {
     );
   });
 
-  it('hides PR Review and Test Generation field when AI features are disabled', () => {
+  it('hides Prevent AI field when AI features are disabled', () => {
     render(
       <OrganizationSettingsForm
         {...routerProps}
@@ -285,10 +285,10 @@ describe('OrganizationSettingsForm', () => {
     );
 
     expect(
-      screen.queryByText('Enable PR Review and Test Generation')
+      screen.queryByText('Enable Prevent AI')
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByText('Use AI to generate feedback and tests in pull requests')
+      screen.queryByText('Use AI to review, find bugs, and generate tests in pull requests')
     ).not.toBeInTheDocument();
   });
 
@@ -301,9 +301,9 @@ describe('OrganizationSettingsForm', () => {
       />
     );
 
-    expect(screen.getByText('Enable PR Review and Test Generation')).toBeInTheDocument();
+    expect(screen.getByText('Enable Prevent AI')).toBeInTheDocument();
     expect(
-      screen.getByText('Use AI to generate feedback and tests in pull requests')
+      screen.getByText('Use AI to review, find bugs, and generate tests in pull requests')
     ).toBeInTheDocument();
   });
 
@@ -323,20 +323,20 @@ describe('OrganizationSettingsForm', () => {
 
     // Initially AI features are disabled, so PR Review field should be hidden
     expect(
-      screen.queryByText('Enable PR Review and Test Generation')
+      screen.queryByText('Enable Prevent AI')
     ).not.toBeInTheDocument();
 
     const aiToggle = screen.getByRole('checkbox', {name: 'Show Generative AI Features'});
     await userEvent.click(aiToggle);
 
     // PR Review field should now be visible
-    expect(screen.getByText('Enable PR Review and Test Generation')).toBeInTheDocument();
+    expect(screen.getByText('Enable Prevent AI')).toBeInTheDocument();
 
     await userEvent.click(aiToggle);
 
     // PR Review field should be hidden again
     expect(
-      screen.queryByText('Enable PR Review and Test Generation')
+      screen.queryByText('Enable Prevent AI')
     ).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.spec.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.spec.tsx
@@ -284,11 +284,11 @@ describe('OrganizationSettingsForm', () => {
       />
     );
 
+    expect(screen.queryByText('Enable Prevent AI')).not.toBeInTheDocument();
     expect(
-      screen.queryByText('Enable Prevent AI')
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByText('Use AI to review, find bugs, and generate tests in pull requests')
+      screen.queryByText(
+        'Use AI to review, find bugs, and generate tests in pull requests'
+      )
     ).not.toBeInTheDocument();
   });
 
@@ -322,9 +322,7 @@ describe('OrganizationSettingsForm', () => {
     });
 
     // Initially AI features are disabled, so PR Review field should be hidden
-    expect(
-      screen.queryByText('Enable Prevent AI')
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText('Enable Prevent AI')).not.toBeInTheDocument();
 
     const aiToggle = screen.getByRole('checkbox', {name: 'Show Generative AI Features'});
     await userEvent.click(aiToggle);
@@ -335,8 +333,6 @@ describe('OrganizationSettingsForm', () => {
     await userEvent.click(aiToggle);
 
     // PR Review field should be hidden again
-    expect(
-      screen.queryByText('Enable Prevent AI')
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText('Enable Prevent AI')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Update the copy on the Prevent AI toggle on the Settings page

See [here](https://github.com/getsentry/sentry/pull/98646#issuecomment-3247002971) for desired copy from Product Design

<img width="1228" height="805" alt="Screenshot 2025-09-02 at 4 39 56 PM" src="https://github.com/user-attachments/assets/b8ab1e9c-a166-4e82-9033-05e11aedd204" />

OLD VERSION:
<img width="576" height="111" alt="Screenshot 2025-09-02 at 4 40 59 PM" src="https://github.com/user-attachments/assets/b3785a81-eb1a-4a5f-a99e-f84224155943" />

Closes https://linear.app/getsentry/issue/PREVENT-285