### PR TITLE
:sparkles: feat(aci): default to issue alert handler in NOA if grouptype is not registered

### DIFF
--- a/src/sentry/notifications/notification_action/utils.py
+++ b/src/sentry/notifications/notification_action/utils.py
@@ -72,12 +72,10 @@ def execute_via_group_type_registry(
         handler = group_type_notification_registry.get(detector.type)
         handler.handle_workflow_action(event_data, action, detector)
     except NoRegistrationExistsError:
-        logger.exception(
-            "No notification handler found for detector type: %s",
-            detector.type,
-            extra={"detector_id": detector.id, "action_id": action.id},
-        )
-        raise
+        # If the grouptype is not registered, we can just use the issue alert handler
+        # This is so that notifications will still be sent for that group type if we forget to register a handler
+        # Most grouptypes are sent to issue alert handlers'
+        return execute_via_issue_alert_handler(event_data, action, detector)
     except Exception:
         logger.exception(
             "Error executing via group type registry",

--- a/src/sentry/notifications/notification_action/utils.py
+++ b/src/sentry/notifications/notification_action/utils.py
@@ -74,7 +74,12 @@ def execute_via_group_type_registry(
     except NoRegistrationExistsError:
         # If the grouptype is not registered, we can just use the issue alert handler
         # This is so that notifications will still be sent for that group type if we forget to register a handler
-        # Most grouptypes are sent to issue alert handlers'
+        # Most grouptypes are sent to issue alert handlers
+        logger.warning(
+            "group_type_notification_registry.get.NoRegistrationExistsError",
+            detector.type,
+            extra={"detector_id": detector.id, "action_id": action.id},
+        )
         return execute_via_issue_alert_handler(event_data, action, detector)
     except Exception:
         logger.exception(

--- a/src/sentry/notifications/notification_action/utils.py
+++ b/src/sentry/notifications/notification_action/utils.py
@@ -77,7 +77,6 @@ def execute_via_group_type_registry(
         # Most grouptypes are sent to issue alert handlers
         logger.warning(
             "group_type_notification_registry.get.NoRegistrationExistsError",
-            detector.type,
             extra={"detector_id": detector.id, "action_id": action.id},
         )
         return execute_via_issue_alert_handler(event_data, action, detector)

--- a/tests/sentry/notifications/notification_action/test_group_type_notification_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_group_type_notification_registry_handlers.py
@@ -9,6 +9,7 @@ from sentry.notifications.notification_action.group_type_notification_registry.h
 from sentry.notifications.notification_action.group_type_notification_registry.handlers.metric_alert_registry_handler import (
     MetricAlertRegistryHandler,
 )
+from sentry.notifications.notification_action.grouptype import SendTestNotification
 from sentry.notifications.notification_action.utils import execute_via_group_type_registry
 from sentry.types.activity import ActivityType
 from sentry.utils.registry import NoRegistrationExistsError
@@ -52,7 +53,7 @@ class TestMetricAlertRegistryInvoker(BaseWorkflowTest):
         "sentry.notifications.notification_action.registry.metric_alert_handler_registry.get"
     )
     def test_handle_workflow_action_no_handler(self, mock_registry_get: mock.MagicMock) -> None:
-        """Test that handle_workflow_action raises NoRegistrationExistsError when no handler exists"""
+        """Test that handle_workflow_action invokes the when no handler exists"""
         mock_registry_get.side_effect = NoRegistrationExistsError()
 
         with pytest.raises(NoRegistrationExistsError):
@@ -78,5 +79,28 @@ class TestMetricAlertRegistryInvoker(BaseWorkflowTest):
 
         execute_via_group_type_registry(self.event_data, self.action, self.detector)
         mock_execute_metric_alert_handler.assert_called_once_with(
+            self.event_data, self.action, self.detector
+        )
+
+
+class TestGroupTypeNotificationRegistryHandler(BaseWorkflowTest):
+    def setUp(self) -> None:
+        super().setUp()
+        self.project = self.create_project()
+        self.detector = self.create_detector(project=self.project, type=SendTestNotification.slug)
+        self.action = Action(type=Action.Type.DISCORD)
+        self.group, self.event, self.group_event = self.create_group_event(
+            group_type_id=SendTestNotification.type_id
+        )
+        self.event_data = WorkflowEventData(event=self.group_event, group=self.group)
+
+    @mock.patch("sentry.notifications.notification_action.utils.execute_via_issue_alert_handler")
+    def test_handle_workflow_action_no_handler(
+        self, mock_execute_via_issue_alert_handler: mock.MagicMock
+    ) -> None:
+        """Test that handle_workflow_action raises NoRegistrationExistsError when no handler exists"""
+
+        execute_via_group_type_registry(self.event_data, self.action, self.detector)
+        mock_execute_via_issue_alert_handler.assert_called_once_with(
             self.event_data, self.action, self.detector
         )

--- a/tests/sentry/notifications/notification_action/test_group_type_notification_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_group_type_notification_registry_handlers.py
@@ -98,7 +98,7 @@ class TestGroupTypeNotificationRegistryHandler(BaseWorkflowTest):
     def test_handle_workflow_action_no_handler(
         self, mock_execute_via_issue_alert_handler: mock.MagicMock
     ) -> None:
-        """Test that handle_workflow_action raises NoRegistrationExistsError when no handler exists"""
+        """Test that handle_workflow_action invokes the when no handler exists"""
 
         execute_via_group_type_registry(self.event_data, self.action, self.detector)
         mock_execute_via_issue_alert_handler.assert_called_once_with(

--- a/tests/sentry/notifications/notification_action/test_group_type_notification_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_group_type_notification_registry_handlers.py
@@ -53,7 +53,7 @@ class TestMetricAlertRegistryInvoker(BaseWorkflowTest):
         "sentry.notifications.notification_action.registry.metric_alert_handler_registry.get"
     )
     def test_handle_workflow_action_no_handler(self, mock_registry_get: mock.MagicMock) -> None:
-        """Test that handle_workflow_action invokes the when no handler exists"""
+        """Test that handle_workflow_action raises NoRegistrationExistsError when no handler exists"""
         mock_registry_get.side_effect = NoRegistrationExistsError()
 
         with pytest.raises(NoRegistrationExistsError):

--- a/tests/sentry/workflow_engine/handlers/action/test_action_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/action/test_action_handlers.py
@@ -1,7 +1,5 @@
 from unittest import mock
 
-import pytest
-
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.incidents.grouptype import MetricIssue
 from sentry.utils.registry import NoRegistrationExistsError
@@ -19,12 +17,17 @@ class TestNotificationActionHandler(BaseWorkflowTest):
         self.group, self.event, self.group_event = self.create_group_event()
         self.event_data = WorkflowEventData(event=self.group_event, group=self.group)
 
-    def test_execute_without_group_type(self) -> None:
+    @mock.patch("sentry.notifications.notification_action.utils.execute_via_issue_alert_handler")
+    def test_execute_without_group_type(
+        self, mock_execute_via_issue_alert_handler: mock.MagicMock
+    ) -> None:
         """Test that execute does nothing when detector has no group_type"""
         self.detector.type = ""
-        with pytest.raises(NoRegistrationExistsError):
-            self.action.trigger(self.event_data, self.detector)
-        # Test passes if no exception is raised
+        self.action.trigger(self.event_data, self.detector)
+
+        mock_execute_via_issue_alert_handler.assert_called_once_with(
+            self.event_data, self.action, self.detector
+        )
 
     @mock.patch(
         "sentry.notifications.notification_action.registry.group_type_notification_registry.get"
@@ -63,20 +66,23 @@ class TestNotificationActionHandler(BaseWorkflowTest):
             self.event_data, self.action, self.detector
         )
 
+    @mock.patch("sentry.notifications.notification_action.utils.execute_via_issue_alert_handler")
     @mock.patch(
         "sentry.notifications.notification_action.registry.group_type_notification_registry.get",
         side_effect=NoRegistrationExistsError,
     )
     @mock.patch("sentry.notifications.notification_action.utils.logger")
     def test_execute_unknown_group_type(
-        self, mock_logger: mock.MagicMock, mock_registry_get: mock.MagicMock
+        self,
+        mock_logger: mock.MagicMock,
+        mock_registry_get: mock.MagicMock,
+        mock_execute_via_issue_alert_handler: mock.MagicMock,
     ) -> None:
         """Test that execute does nothing when detector has no group_type"""
-        with pytest.raises(NoRegistrationExistsError):
-            self.action.trigger(self.event_data, self.detector)
 
-        mock_logger.exception.assert_called_once_with(
-            "No notification handler found for detector type: %s",
-            self.detector.type,
+        self.action.trigger(self.event_data, self.detector)
+
+        mock_logger.warning.assert_called_once_with(
+            "group_type_notification_registry.get.NoRegistrationExistsError",
             extra={"detector_id": self.detector.id, "action_id": self.action.id},
         )


### PR DESCRIPTION
When we rollout the Error detector to other groups, we might forget to register those groups to the `group_type_registry`, so going to add a fallback here to go to the issue alert registry if nothing is registered.

emitting a warning log so we know if we are missing something.