### PR TITLE
ref(grouping): Add note for issues on unsupported platforms

### DIFF
--- a/static/app/views/issueDetails/groupSimilarIssues/similarIssues.spec.tsx
+++ b/static/app/views/issueDetails/groupSimilarIssues/similarIssues.spec.tsx
@@ -66,7 +66,7 @@ describe('Issues Similar View', () => {
     });
     MockApiClient.addMockResponse({
       url: `/organizations/org-slug/issues/${group.id}/events/latest/`,
-      body: {},
+      body: {platform: 'python'},
     });
     ProjectsStore.init();
     ProjectsStore.loadInitialData([project]);
@@ -163,10 +163,13 @@ describe('Issues Similar View', () => {
     await waitFor(() => expect(mock).toHaveBeenCalled());
 
     expect(
-      await screen.findByText(
-        "There don't seem to be any similar issues. This can occur when the issue has no stacktrace or in-app frames, or when the issue has over 30 frames."
-      )
+      await screen.findByText("There don't seem to be any similar issues.")
     ).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        'This can occur when the issue has no stacktrace or in-app frames.'
+      )
+    ).not.toBeInTheDocument();
   });
 });
 
@@ -219,7 +222,7 @@ describe('Issues Similar Embeddings View', () => {
     });
     MockApiClient.addMockResponse({
       url: `/organizations/org-slug/issues/${group.id}/events/latest/`,
-      body: {},
+      body: {platform: 'python'},
     });
     ProjectsStore.init();
     ProjectsStore.loadInitialData([project]);
@@ -315,7 +318,7 @@ describe('Issues Similar Embeddings View', () => {
 
     expect(
       await screen.findByText(
-        "There don't seem to be any similar issues. This can occur when the issue has no stacktrace or in-app frames, or when the issue has over 30 frames."
+        "There don't seem to be any similar issues. This can occur when the issue has no stacktrace or in-app frames."
       )
     ).toBeInTheDocument();
   });

--- a/static/app/views/issueDetails/groupSimilarIssues/similarIssues.spec.tsx
+++ b/static/app/views/issueDetails/groupSimilarIssues/similarIssues.spec.tsx
@@ -60,6 +60,14 @@ describe('Issues Similar View', () => {
       url: `/issues/${group.id}/related-issues/`,
       body: {data: [], type: 'same_root_cause'},
     });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/issues/${group.id}/tags/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/issues/${group.id}/events/latest/`,
+      body: {},
+    });
     ProjectsStore.init();
     ProjectsStore.loadInitialData([project]);
   });
@@ -155,13 +163,10 @@ describe('Issues Similar View', () => {
     await waitFor(() => expect(mock).toHaveBeenCalled());
 
     expect(
-      await screen.findByText("There don't seem to be any similar issues.")
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByText(
-        'This can occur when the issue has no stacktrace or in-app frames.'
+      await screen.findByText(
+        "There don't seem to be any similar issues. This can occur when the issue has no stacktrace or in-app frames, or when the issue has over 30 frames."
       )
-    ).not.toBeInTheDocument();
+    ).toBeInTheDocument();
   });
 });
 
@@ -207,6 +212,14 @@ describe('Issues Similar Embeddings View', () => {
     MockApiClient.addMockResponse({
       url: `/issues/${group.id}/related-issues/`,
       body: {data: [], type: 'same_root_cause'},
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/issues/${group.id}/tags/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/issues/${group.id}/events/latest/`,
+      body: {},
     });
     ProjectsStore.init();
     ProjectsStore.loadInitialData([project]);
@@ -302,7 +315,7 @@ describe('Issues Similar Embeddings View', () => {
 
     expect(
       await screen.findByText(
-        "There don't seem to be any similar issues. This can occur when the issue has no stacktrace or in-app frames."
+        "There don't seem to be any similar issues. This can occur when the issue has no stacktrace or in-app frames, or when the issue has over 30 frames."
       )
     ).toBeInTheDocument();
   });

--- a/static/app/views/issueDetails/groupSimilarIssues/similarIssuesDrawer.spec.tsx
+++ b/static/app/views/issueDetails/groupSimilarIssues/similarIssuesDrawer.spec.tsx
@@ -40,6 +40,14 @@ describe('SimilarIssuesDrawer', () => {
       url: `/issues/${group.id}/related-issues/`,
       body: {data: [], type: 'same_root_cause'},
     });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/${group.id}/tags/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/${group.id}/events/latest/`,
+      body: {},
+    });
   });
 
   it('renders the content as expected', async () => {

--- a/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/index.tsx
+++ b/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/index.tsx
@@ -234,7 +234,7 @@ function SimilarStackTrace({project}: Props) {
           <EmptyStateWarning>
             <p>
               {t(
-                "There don't seem to be any similar issues. This can occur when the issue has no stacktrace or in-app frames, or when the issue has over 30 frames."
+                "There don't seem to be any similar issues. This can occur when the issue has no stacktrace or in-app frames, or when the stacktrace has over 30 frames."
               )}
             </p>
           </EmptyStateWarning>

--- a/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/index.tsx
+++ b/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/index.tsx
@@ -174,14 +174,12 @@ function SimilarStackTrace({project}: Props) {
     (hasSimilarityFeature || hasSimilarityEmbeddingsFeature) &&
     (items.similar.length > 0 || items.filtered.length > 0);
 
-  // Get the original issue's event data to check frame count
   const {data: event} = useGroupEvent({
     groupId: params.groupId,
     eventId: 'latest',
   });
 
-  // Check if this is a native issue with too many frames
-  const isNativeWithTooManyFrames = ![
+  const isNotSupportedPlatform = ![
     'go',
     'javascript',
     'node',
@@ -210,7 +208,7 @@ function SimilarStackTrace({project}: Props) {
       {status === 'ready' &&
         !hasSimilarItems &&
         !hasSimilarityEmbeddingsFeature &&
-        !isNativeWithTooManyFrames && (
+        !isNotSupportedPlatform && (
           <Panel>
             <EmptyStateWarning>
               <Title>{t("There don't seem to be any similar issues.")}</Title>
@@ -220,7 +218,7 @@ function SimilarStackTrace({project}: Props) {
       {status === 'ready' &&
         !hasSimilarItems &&
         hasSimilarityEmbeddingsFeature &&
-        !isNativeWithTooManyFrames && (
+        !isNotSupportedPlatform && (
           <Panel>
             <EmptyStateWarning>
               <p>
@@ -231,17 +229,7 @@ function SimilarStackTrace({project}: Props) {
             </EmptyStateWarning>
           </Panel>
         )}
-      {status === 'ready' &&
-        !hasSimilarItems &&
-        !hasSimilarityEmbeddingsFeature &&
-        !isNativeWithTooManyFrames && (
-          <Panel>
-            <EmptyStateWarning>
-              <Title>{t("There don't seem to be any similar issues.")}</Title>
-            </EmptyStateWarning>
-          </Panel>
-        )}
-      {status === 'ready' && !hasSimilarItems && isNativeWithTooManyFrames && (
+      {status === 'ready' && !hasSimilarItems && isNotSupportedPlatform && (
         <Panel>
           <EmptyStateWarning>
             <p>

--- a/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/index.tsx
+++ b/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/index.tsx
@@ -179,7 +179,7 @@ function SimilarStackTrace({project}: Props) {
     eventId: 'latest',
   });
 
-  const isNotSupportedPlatform = ![
+  const platformSupportsLongStacktraces = [
     'go',
     'javascript',
     'node',
@@ -187,6 +187,28 @@ function SimilarStackTrace({project}: Props) {
     'python',
     'ruby',
   ].includes(event?.platform ?? '');
+
+  function getEmptyStateWarning() {
+    let message = '';
+    if (!hasSimilarityEmbeddingsFeature && platformSupportsLongStacktraces) {
+      message = t("There don't seem to be any similar issues.");
+    } else if (hasSimilarityEmbeddingsFeature && platformSupportsLongStacktraces) {
+      message = t(
+        "There don't seem to be any similar issues. This can occur when the issue has no stacktrace or in-app frames."
+      );
+    } else if (!platformSupportsLongStacktraces) {
+      message = t(
+        "There don't seem to be any similar issues. This can occur when the issue has no stacktrace or in-app frames, or when the stacktrace has over 30 frames."
+      );
+    }
+    return (
+      <Panel>
+        <EmptyStateWarning>
+          <p>{message}</p>
+        </EmptyStateWarning>
+      </Panel>
+    );
+  }
 
   return (
     <Fragment>
@@ -205,41 +227,7 @@ function SimilarStackTrace({project}: Props) {
           onRetry={fetchData}
         />
       )}
-      {status === 'ready' &&
-        !hasSimilarItems &&
-        !hasSimilarityEmbeddingsFeature &&
-        !isNotSupportedPlatform && (
-          <Panel>
-            <EmptyStateWarning>
-              <Title>{t("There don't seem to be any similar issues.")}</Title>
-            </EmptyStateWarning>
-          </Panel>
-        )}
-      {status === 'ready' &&
-        !hasSimilarItems &&
-        hasSimilarityEmbeddingsFeature &&
-        !isNotSupportedPlatform && (
-          <Panel>
-            <EmptyStateWarning>
-              <p>
-                {t(
-                  "There don't seem to be any similar issues. This can occur when the issue has no stacktrace or in-app frames."
-                )}
-              </p>
-            </EmptyStateWarning>
-          </Panel>
-        )}
-      {status === 'ready' && !hasSimilarItems && isNotSupportedPlatform && (
-        <Panel>
-          <EmptyStateWarning>
-            <p>
-              {t(
-                "There don't seem to be any similar issues. This can occur when the issue has no stacktrace or in-app frames, or when the stacktrace has over 30 frames."
-              )}
-            </p>
-          </EmptyStateWarning>
-        </Panel>
-      )}
+      {status === 'ready' && !hasSimilarItems && getEmptyStateWarning()}
       {status === 'ready' && hasSimilarItems && !hasSimilarityEmbeddingsFeature && (
         <List
           items={items.similar}


### PR DESCRIPTION
Added new `EmptyStateWarning` for issues on platforms where no similar issues will be found if the stacktrace has more than 30 frames. 

<img width="754" height="447" alt="image" src="https://github.com/user-attachments/assets/f2c4d5a3-f165-4da8-add6-3e62ac1ae103" />
