### PR TITLE
fix: 421 misdirected status code when forwarding webhooks

### DIFF
--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -29,6 +29,7 @@ from sentry.shared_integrations.exceptions import (
 )
 from sentry.silo.base import SiloMode
 from sentry.silo.client import RegionSiloClient, SiloClientError
+from sentry.silo.util import clean_proxy_headers
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.config import TaskworkerConfig
 from sentry.taskworker.namespaces import hybridcloud_control_tasks
@@ -606,7 +607,7 @@ def perform_codecov_request(payload: WebhookPayload) -> None:
             response = client.post(
                 endpoint=endpoint,
                 data=payload.request_body,
-                headers=headers,
+                headers=clean_proxy_headers(headers),
             )
 
             if response.status_code != 200:


### PR DESCRIPTION
we're currently getting a 421 per the logs, and this is because we're not removing the host header from the request headers that we forward to codecov so codecov is getting this request with the host header set to sentry and at returns a 301, which then turns into a 421