### PR TITLE
ref(issues): Refactor frame variables memo

### DIFF
--- a/static/app/components/events/interfaces/frame/context.tsx
+++ b/static/app/components/events/interfaces/frame/context.tsx
@@ -186,11 +186,7 @@ function Context({
 
       {hasContextVars && (
         <StyledClippedBox clipHeight={100}>
-          <FrameVariables
-            platform={platform}
-            data={frame.vars ?? {}}
-            meta={frameMeta?.vars}
-          />
+          <FrameVariables platform={platform} data={frame.vars} meta={frameMeta?.vars} />
         </StyledClippedBox>
       )}
 

--- a/static/app/components/events/interfaces/frame/frameVariables.spec.tsx
+++ b/static/app/components/events/interfaces/frame/frameVariables.spec.tsx
@@ -1,7 +1,7 @@
 import {DataScrubbingRelayPiiConfigFixture} from 'sentry-fixture/dataScrubbingRelayPiiConfig';
+import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
@@ -10,23 +10,24 @@ import ProjectsStore from 'sentry/stores/projectsStore';
 
 describe('Frame Variables', () => {
   it('renders', async () => {
+    const organization = OrganizationFixture();
     const project = ProjectFixture({id: '0'});
     const projectDetails = ProjectFixture({
       ...project,
       relayPiiConfig: JSON.stringify(DataScrubbingRelayPiiConfigFixture()),
     });
+    const initialRouterConfig = {
+      location: {
+        pathname: `/organizations/org-slug/issues/1/`,
+        query: {project: project.id},
+      },
+      route: '/organizations/:orgId/issues/:groupId/',
+    };
     MockApiClient.addMockResponse({
       url: `/projects/org-slug/${project.slug}/`,
       body: projectDetails,
     });
     ProjectsStore.loadInitialData([project]);
-
-    const {organization, router} = initializeOrg({
-      router: {
-        location: {query: {project: project.id}},
-      },
-      projects: [project],
-    });
 
     render(
       <FrameVariables
@@ -72,8 +73,7 @@ describe('Frame Variables', () => {
       />,
       {
         organization,
-        router,
-        deprecatedRouterMocks: true,
+        initialRouterConfig,
       }
     );
 
@@ -149,10 +149,7 @@ describe('Frame Variables', () => {
           str: 'string',
         }}
         platform="node"
-      />,
-      {
-        deprecatedRouterMocks: true,
-      }
+      />
     );
 
     const nullValues = screen.getAllByTestId('value-null');
@@ -179,10 +176,7 @@ describe('Frame Variables', () => {
           str: 'string',
         }}
         platform="ruby"
-      />,
-      {
-        deprecatedRouterMocks: true,
-      }
+      />
     );
 
     expect(within(screen.getByTestId('value-null')).getByText('nil')).toBeInTheDocument();
@@ -203,10 +197,7 @@ describe('Frame Variables', () => {
           str: 'string',
         }}
         platform="php"
-      />,
-      {
-        deprecatedRouterMocks: true,
-      }
+      />
     );
 
     expect(

--- a/static/app/components/events/interfaces/keyValueList/index.tsx
+++ b/static/app/components/events/interfaces/keyValueList/index.tsx
@@ -15,7 +15,6 @@ interface Props extends Pick<ValueProps, 'raw' | 'isContextData'> {
   className?: string;
   data?: KeyValueListData;
   longKeys?: boolean;
-  onClick?: () => void;
   shouldSort?: boolean;
 }
 
@@ -25,7 +24,6 @@ function KeyValueList({
   shouldSort = true,
   raw = false,
   longKeys = false,
-  onClick,
   className,
   ...props
 }: Props) {
@@ -36,11 +34,7 @@ function KeyValueList({
   const keyValueData = shouldSort ? sortBy(data, [({key}) => key?.toLowerCase()]) : data;
 
   return (
-    <Table
-      className={classNames('table key-value', className)}
-      onClick={onClick}
-      {...props}
-    >
+    <Table className={classNames('table key-value', className)} {...props}>
       <tbody>
         {keyValueData.map(
           (


### PR DESCRIPTION
- Removes onClick that didn't do anything because it was defined as `() => () => {}`
- Memo the thing that is actually passed down to the child component
- remove deprecated test router
