### PR TITLE
feat(issues): Indicate the number of items truncated by sdk

### DIFF
--- a/static/app/components/events/eventExtraData/index.spec.tsx
+++ b/static/app/components/events/eventExtraData/index.spec.tsx
@@ -178,8 +178,14 @@ describe('EventExtraData', () => {
       },
     });
 
+    // Before expanding, number of items is 14 because 4 items are redacted
+    expect(screen.getByText(/14 items/)).toBeInTheDocument();
+
     await userEvent.click(screen.getByRole('button', {name: 'Expand'}));
     expect(await screen.findAllByText(/redacted/)).toHaveLength(10);
+
+    // After expanding, indicate that some items were truncated
+    expect(screen.getByText(/\(4 items truncated\)/)).toBeInTheDocument();
 
     await userEvent.hover(screen.getAllByText(/redacted/)[0]!);
 

--- a/static/app/components/structuredEventData/collapsibleValue.tsx
+++ b/static/app/components/structuredEventData/collapsibleValue.tsx
@@ -23,10 +23,6 @@ interface Props {
   totalChildren?: number;
 }
 
-const truncatedText = (hiddenCount: number) => {
-  return tn('%s item truncated', '%s items truncated', hiddenCount);
-};
-
 export function CollapsibleValue({
   children,
   closeTag,
@@ -91,7 +87,10 @@ export function CollapsibleValue({
       ) : null}
       <span>{closeTag}</span>
       {isExpanded && hiddenCount > 0 ? (
-        <Text variant="muted" size="xs">{` (${truncatedText(hiddenCount)})`}</Text>
+        <Text
+          variant="muted"
+          size="xs"
+        >{` (${tn('%s item truncated', '%s items truncated', hiddenCount)})`}</Text>
       ) : null}
     </CollapsibleDataContainer>
   );

--- a/static/app/components/structuredEventData/recursiveStructuredData.tsx
+++ b/static/app/components/structuredEventData/recursiveStructuredData.tsx
@@ -32,6 +32,14 @@ interface Props {
   withOnlyFormattedText?: boolean;
 }
 
+function getTotalChildrenFromMeta(m: Record<any, any> | undefined): number | undefined {
+  if (!m) {
+    return undefined;
+  }
+  const rootMeta = m[''] ?? m;
+  return typeof rootMeta?.len === 'number' ? rootMeta.len : undefined;
+}
+
 export function RecursiveStructuredData({
   config,
   meta,
@@ -179,6 +187,7 @@ export function RecursiveStructuredData({
   const children: React.ReactNode[] = [];
 
   if (Array.isArray(value)) {
+    const containerLen = getTotalChildrenFromMeta(meta);
     for (i = 0; i < value.length; i++) {
       children.push(
         <div key={i}>
@@ -194,7 +203,13 @@ export function RecursiveStructuredData({
       );
     }
     return (
-      <CollapsibleValue closeTag="]" openTag="[" path={path} prefix={formattedObjectKey}>
+      <CollapsibleValue
+        closeTag="]"
+        openTag="["
+        path={path}
+        prefix={formattedObjectKey}
+        totalChildren={containerLen}
+      >
         {children}
       </CollapsibleValue>
     );
@@ -224,8 +239,16 @@ export function RecursiveStructuredData({
     );
   }
 
+  const objectLen = getTotalChildrenFromMeta(meta);
+
   return (
-    <CollapsibleValue closeTag="}" openTag="{" path={path} prefix={formattedObjectKey}>
+    <CollapsibleValue
+      closeTag="}"
+      openTag="{"
+      path={path}
+      prefix={formattedObjectKey}
+      totalChildren={objectLen}
+    >
       {children}
     </CollapsibleValue>
   );

--- a/static/app/components/structuredEventData/recursiveStructuredData.tsx
+++ b/static/app/components/structuredEventData/recursiveStructuredData.tsx
@@ -33,10 +33,7 @@ interface Props {
 }
 
 function getTotalChildrenFromMeta(m: Record<any, any> | undefined): number | undefined {
-  if (!m) {
-    return undefined;
-  }
-  const rootMeta = m[''] ?? m;
+  const rootMeta = m?.[''];
   return typeof rootMeta?.len === 'number' ? rootMeta.len : undefined;
 }
 


### PR DESCRIPTION
The python sdk (and others) truncate arrays by default to 10 items. We can indicate in the ui how many are not shown.

part of #98652 

before
<img width="532" height="243" alt="image" src="https://github.com/user-attachments/assets/7c3f9628-ddb9-41e6-b169-11e4f01de615" />
<img width="420" height="306" alt="image" src="https://github.com/user-attachments/assets/432c2839-5119-4ec2-9b25-b732951ce8eb" />

after
<img width="454" height="211" alt="image" src="https://github.com/user-attachments/assets/34963377-dac5-40d7-8bd5-f029c4a322d9" />
<img width="432" height="299" alt="image" src="https://github.com/user-attachments/assets/61762799-7c86-4e06-9759-e7c760055f01" />
