### PR TITLE
ref(api): clean up `global-views` from events API

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -250,12 +250,6 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
             snuba_params = self.get_snuba_params(
                 request,
                 organization,
-                # This is only temporary until we come to a decision on global views
-                # checking for referrer for an allowlist is a brittle check since referrer
-                # can easily be set by the caller
-                check_global_views=not (
-                    referrer in GLOBAL_VIEW_ALLOWLIST and bool(organization.flags.allow_joinleave)
-                ),
             )
         except NoProjects:
             return Response(

--- a/src/sentry/api/endpoints/organization_events_has_measurements.py
+++ b/src/sentry/api/endpoints/organization_events_has_measurements.py
@@ -61,11 +61,7 @@ class OrganizationEventsHasMeasurementsEndpoint(OrganizationEventsV2EndpointBase
 
         with sentry_sdk.start_span(op="discover.endpoint", name="parse params"):
             try:
-                # This endpoint only allows for a single project + transaction, so no need
-                # to check `global-views`.
-                snuba_params = self.get_snuba_params(
-                    request, organization, check_global_views=False
-                )
+                snuba_params = self.get_snuba_params(request, organization)
 
                 # Once an transaction begins containing measurement data, it is unlikely
                 # it will stop. So it makes more sense to always query the latest data.

--- a/src/sentry/api/endpoints/organization_events_meta.py
+++ b/src/sentry/api/endpoints/organization_events_meta.py
@@ -128,8 +128,7 @@ class OrganizationEventsRelatedIssuesEndpoint(OrganizationEventsEndpointBase):
 
     def get(self, request: Request, organization: Organization) -> Response:
         try:
-            # events-meta is still used by events v1 which doesn't require global views
-            snuba_params = self.get_snuba_params(request, organization, check_global_views=False)
+            snuba_params = self.get_snuba_params(request, organization)
         except NoProjects:
             return Response([])
 

--- a/src/sentry/api/endpoints/organization_events_spans_performance.py
+++ b/src/sentry/api/endpoints/organization_events_spans_performance.py
@@ -91,13 +91,11 @@ class OrganizationEventsSpansEndpointBase(OrganizationEventsV2EndpointBase):
         self,
         request: Request,
         organization: Organization,
-        check_global_views: bool = True,
         quantize_date_params: bool = True,
     ) -> SnubaParams:
         snuba_params = super().get_snuba_params(
             request,
             organization,
-            check_global_views=check_global_views,
             quantize_date_params=quantize_date_params,
         )
 

--- a/src/sentry/api/endpoints/organization_events_timeseries.py
+++ b/src/sentry/api/endpoints/organization_events_timeseries.py
@@ -164,11 +164,8 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsV2EndpointBase):
             sentry_sdk.set_tag("performance.metrics_enhanced", metrics_enhanced)
             try:
                 snuba_params = self.get_snuba_params(
-                    # old events-stats had global_check on False for v1, trying it off to see if that works for our
-                    # new usage
                     request,
                     organization,
-                    check_global_views=True,
                 )
             except NoProjects:
                 return Response([], status=200)

--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -844,8 +844,7 @@ class OrganizationEventsTraceEndpointBase(OrganizationEventsV2EndpointBase):
             return Response(status=404)
 
         try:
-            # The trace view isn't useful without global views, so skipping the check here
-            snuba_params = self.get_snuba_params(request, organization, check_global_views=False)
+            snuba_params = self.get_snuba_params(request, organization)
         except NoProjects:
             return Response(status=404)
 
@@ -1024,9 +1023,7 @@ class OrganizationEventsTraceLightEndpoint(OrganizationEventsTraceEndpointBase):
                     current_generation = 0
                     break
 
-            snuba_params = self.get_snuba_params(
-                self.request, self.request.organization, check_global_views=False
-            )
+            snuba_params = self.get_snuba_params(self.request, self.request.organization)
             if current_generation is None:
                 for root in roots:
                     # We might not be necessarily connected to the root if we're on an orphan event
@@ -1178,9 +1175,7 @@ class OrganizationEventsTraceEndpoint(OrganizationEventsTraceEndpointBase):
         parent_events: dict[str, TraceEvent] = {}
         results_map: dict[str | None, list[TraceEvent]] = defaultdict(list)
         to_check: Deque[SnubaTransaction] = deque()
-        snuba_params = self.get_snuba_params(
-            self.request, self.request.organization, check_global_views=False
-        )
+        snuba_params = self.get_snuba_params(self.request, self.request.organization)
         # The root of the orphan tree we're currently navigating through
         orphan_root: SnubaTransaction | None = None
         if roots:
@@ -1484,8 +1479,7 @@ class OrganizationEventsTraceMetaEndpoint(OrganizationEventsV2EndpointBase):
             return Response(status=404)
 
         try:
-            # The trace meta isn't useful without global views, so skipping the check here
-            snuba_params = self.get_snuba_params(request, organization, check_global_views=False)
+            snuba_params = self.get_snuba_params(request, organization)
         except NoProjects:
             return Response(status=404)
 

--- a/src/sentry/api/endpoints/organization_metrics_meta.py
+++ b/src/sentry/api/endpoints/organization_metrics_meta.py
@@ -31,8 +31,7 @@ class OrganizationMetricsCompatibility(OrganizationEventsEndpointBase):
             "compatible_projects": [],
         }
         try:
-            # This will be used on the perf homepage and contains preset queries, allow global views
-            snuba_params = self.get_snuba_params(request, organization, check_global_views=False)
+            snuba_params = self.get_snuba_params(request, organization)
         except NoProjects:
             return Response(data)
         original_project_ids = snuba_params.project_ids[:]
@@ -84,8 +83,7 @@ class OrganizationMetricsCompatibilitySums(OrganizationEventsEndpointBase):
             },
         }
         try:
-            # This will be used on the perf homepage and contains preset queries, allow global views
-            snuba_params = self.get_snuba_params(request, organization, check_global_views=False)
+            snuba_params = self.get_snuba_params(request, organization)
         except NoProjects:
             return Response(data)
 

--- a/src/sentry/api/endpoints/organization_tagkey_values.py
+++ b/src/sentry/api/endpoints/organization_tagkey_values.py
@@ -48,8 +48,7 @@ class OrganizationTagKeyValuesEndpoint(OrganizationEventsEndpointBase):
             sentry_sdk.set_tag("dataset", Dataset.Events.value)
 
         try:
-            # still used by events v1 which doesn't require global views
-            snuba_params = self.get_snuba_params(request, organization, check_global_views=False)
+            snuba_params = self.get_snuba_params(request, organization)
         except NoProjects:
             paginator: SequencePaginator[TagValue] = SequencePaginator([])
         else:

--- a/src/sentry/api/endpoints/organization_trace.py
+++ b/src/sentry/api/endpoints/organization_trace.py
@@ -71,8 +71,7 @@ class OrganizationTraceEndpoint(OrganizationEventsV2EndpointBase):
             return Response(status=404)
 
         try:
-            # The trace view isn't useful without global views, so skipping the check here
-            snuba_params = self.get_snuba_params(request, organization, check_global_views=False)
+            snuba_params = self.get_snuba_params(request, organization)
         except NoProjects:
             return Response(status=404)
 

--- a/src/sentry/api/endpoints/organization_trace_logs.py
+++ b/src/sentry/api/endpoints/organization_trace_logs.py
@@ -107,8 +107,7 @@ class OrganizationTraceLogsEndpoint(OrganizationEventsV2EndpointBase):
 
     def get(self, request: Request, organization: Organization) -> HttpResponse:
         try:
-            # The trace view isn't useful without global views, so skipping the check here
-            snuba_params = self.get_snuba_params(request, organization, check_global_views=False)
+            snuba_params = self.get_snuba_params(request, organization)
         except NoProjects:
             return Response(status=404)
 

--- a/src/sentry/api/endpoints/organization_trace_meta.py
+++ b/src/sentry/api/endpoints/organization_trace_meta.py
@@ -149,8 +149,7 @@ class OrganizationTraceMetaEndpoint(OrganizationEventsV2EndpointBase):
             return Response(status=404)
 
         try:
-            # The trace meta isn't useful without global views, so skipping the check here
-            snuba_params = self.get_snuba_params(request, organization, check_global_views=False)
+            snuba_params = self.get_snuba_params(request, organization)
         except NoProjects:
             return Response(status=404)
 

--- a/src/sentry/replays/endpoints/organization_replay_count.py
+++ b/src/sentry/replays/endpoints/organization_replay_count.py
@@ -83,7 +83,7 @@ class OrganizationReplayCountEndpoint(OrganizationEventsV2EndpointBase):
             return Response(status=404)
 
         try:
-            snuba_params = self.get_snuba_params(request, organization, check_global_views=False)
+            snuba_params = self.get_snuba_params(request, organization)
         except NoProjects:
             return Response({})
 

--- a/src/sentry/replays/endpoints/organization_replay_events_meta.py
+++ b/src/sentry/replays/endpoints/organization_replay_events_meta.py
@@ -53,7 +53,7 @@ class OrganizationReplayEventsMetaEndpoint(OrganizationEventsV2EndpointBase):
             return Response(status=404)
 
         try:
-            snuba_params = self.get_snuba_params(request, organization, check_global_views=False)
+            snuba_params = self.get_snuba_params(request, organization)
         except NoProjects:
             return Response({"count": 0})
 

--- a/tests/sentry/api/test_organization_events.py
+++ b/tests/sentry/api/test_organization_events.py
@@ -4,7 +4,6 @@ import pytest
 from django.http import HttpRequest
 from django.test import override_settings
 from django.urls import reverse
-from rest_framework.exceptions import ErrorDetail
 from rest_framework.request import Request
 
 from sentry.api.endpoints.organization_events import (
@@ -76,44 +75,6 @@ class OrganizationEventsEndpointTest(APITestCase):
         assert response.status_code == 200, response.content
         assert len(response.data["data"]) == 1
         assert response.data["data"][0]["project.name"] == self.project.slug
-
-    def test_multiple_projects_open_membership(self) -> None:
-        assert bool(self.organization.flags.allow_joinleave)
-        self.store_event(
-            data={
-                "event_id": "a" * 32,
-                "timestamp": self.ten_mins_ago_iso,
-            },
-            project_id=self.project.id,
-        )
-        project2 = self.create_project()
-        self.store_event(
-            data={
-                "event_id": "b" * 32,
-                "timestamp": self.ten_mins_ago_iso,
-            },
-            project_id=project2.id,
-        )
-        response = self.do_request(
-            {"field": ["project"], "project": -1, "referrer": "api.issues.issue_events"}
-        )
-        assert response.status_code == 200, response.content
-        assert len(response.data["data"]) == 2
-
-        # The test will now not work since the membership is closed
-        self.organization.flags.allow_joinleave = False
-        self.organization.save()
-        assert bool(self.organization.flags.allow_joinleave) is False
-        response = self.do_request(
-            {"field": ["project"], "project": -1, "referrer": "api.issues.issue_events"}
-        )
-
-        assert response.status_code == 400, response.content
-        assert response.data == {
-            "detail": ErrorDetail(
-                string="You cannot view events from multiple projects.", code="parse_error"
-            )
-        }
 
     @mock.patch("sentry.snuba.discover.query")
     def test_api_token_referrer(self, mock: mock.MagicMock) -> None:

--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -174,27 +174,6 @@ class OrganizationEventsEndpointTest(OrganizationEventsEndpointTestBase, Perform
         assert response.status_code == 200
         assert len(response.data["data"]) == 1
 
-    def test_multi_project_feature_gate_rejection(self) -> None:
-        team = self.create_team(organization=self.organization, members=[self.user])
-
-        project = self.create_project(organization=self.organization, teams=[team])
-        project2 = self.create_project(organization=self.organization, teams=[team])
-
-        query = {"field": ["id", "project.id"], "project": [project.id, project2.id]}
-        response = self.do_request(query)
-        assert response.status_code == 400
-        assert "events from multiple projects" in response.data["detail"]
-
-    def test_multi_project_feature_gate_replays(self) -> None:
-        team = self.create_team(organization=self.organization, members=[self.user])
-
-        project = self.create_project(organization=self.organization, teams=[team])
-        project2 = self.create_project(organization=self.organization, teams=[team])
-
-        query = {"field": ["id", "project.id"], "project": [project.id, project2.id]}
-        response = self.do_request(query, **{"HTTP_X-Sentry-Replay-Request": "1"})
-        assert response.status_code == 200
-
     def test_invalid_search_terms(self) -> None:
         self.create_project()
 

--- a/tests/snuba/api/endpoints/test_organization_events_facets.py
+++ b/tests/snuba/api/endpoints/test_organization_events_facets.py
@@ -337,15 +337,6 @@ class OrganizationEventsFacetsEndpointTest(SnubaTestCase, APITestCase):
         assert response.status_code == 200, response.content
         assert response.data == []
 
-    def test_multiple_projects_without_global_view(self) -> None:
-        self.store_event(data={"event_id": uuid4().hex}, project_id=self.project.id)
-        self.store_event(data={"event_id": uuid4().hex}, project_id=self.project2.id)
-
-        with self.feature("organizations:discover-basic"):
-            response = self.client.get(self.url, format="json")
-        assert response.status_code == 400, response.content
-        assert response.data == {"detail": "You cannot view events from multiple projects."}
-
     def test_project_selected(self) -> None:
         self.store_event(
             data={

--- a/tests/snuba/api/endpoints/test_organization_events_meta.py
+++ b/tests/snuba/api/endpoints/test_organization_events_meta.py
@@ -82,23 +82,6 @@ class OrganizationEventsMetaEndpoint(
         assert response.status_code == 200, response.content
         assert response.data["count"] == 2
 
-    def test_multiple_projects(self) -> None:
-        project2 = self.create_project()
-
-        self.store_event(data={"timestamp": self.min_ago.isoformat()}, project_id=self.project.id)
-        self.store_event(data={"timestamp": self.min_ago.isoformat()}, project_id=project2.id)
-
-        response = self.client.get(self.url, format="json")
-
-        assert response.status_code == 400, response.content
-
-        self.features["organizations:global-views"] = True
-        with self.feature(self.features):
-            response = self.client.get(self.url, format="json")
-
-        assert response.status_code == 200, response.content
-        assert response.data["count"] == 2
-
     def test_search(self) -> None:
         self.store_event(
             data={"timestamp": self.min_ago.isoformat(), "message": "how to make fast"},


### PR DESCRIPTION
Clean up `global-views` check in `get_snuba_params` since `global-views` (cross-project selection) is now available for all plans.