### PR TITLE
feat(ai-trace): Allow collapsing transactions

### DIFF
--- a/static/app/views/insights/agents/components/aiSpanList.tsx
+++ b/static/app/views/insights/agents/components/aiSpanList.tsx
@@ -1,8 +1,9 @@
-import {Fragment, memo, useMemo} from 'react';
+import {Fragment, memo, useMemo, useState} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Flex} from 'sentry/components/core/layout';
+import {Tooltip} from 'sentry/components/core/tooltip';
 import Count from 'sentry/components/count';
 import {IconChevron, IconCode, IconFire} from 'sentry/icons';
 import {IconBot} from 'sentry/icons/iconBot';
@@ -85,18 +86,56 @@ export function AISpanList({
   onSelectNode: (node: AITraceSpanNode) => void;
   selectedNodeKey: string | null;
 }) {
+  const nodesByTransaction = useMemo(() => {
+    const result: Map<
+      TraceTreeNode<TraceTree.Transaction | TraceTree.EAPSpan>,
+      AITraceSpanNode[]
+    > = new Map();
+    for (const node of nodes) {
+      const transaction = getClosestNode(node, isTransactionNodeEquivalent);
+      if (!transaction) {
+        continue;
+      }
+      const transactionNodes = result.get(transaction) || [];
+      result.set(transaction, [...transactionNodes, node]);
+    }
+    return result;
+  }, [nodes]);
+
+  return (
+    <TraceListContainer>
+      {nodesByTransaction.entries().map(([transaction, transactionNodes]) => (
+        <Fragment key={getNodeId(transaction)}>
+          <TransactionWrapper
+            canCollapse={nodesByTransaction.size > 1}
+            transaction={transaction}
+            nodes={transactionNodes}
+            onSelectNode={onSelectNode}
+            selectedNodeKey={selectedNodeKey}
+          />
+        </Fragment>
+      ))}
+    </TraceListContainer>
+  );
+}
+
+function TransactionWrapper({
+  canCollapse,
+  nodes,
+  onSelectNode,
+  selectedNodeKey,
+  transaction,
+}: {
+  canCollapse: boolean;
+  nodes: AITraceSpanNode[];
+  onSelectNode: (node: AITraceSpanNode) => void;
+  selectedNodeKey: string | null;
+  transaction: TraceTreeNode<TraceTree.Transaction | TraceTree.EAPSpan>;
+}) {
+  const [isExpanded, setIsExpanded] = useState(true);
   const theme = useTheme();
   const colors = [...theme.chart.getColorPalette(5), theme.red300];
-
-  let currentTransaction: TraceTreeNode<
-    TraceTree.Transaction | TraceTree.EAPSpan
-  > | null = null;
-  let currentAiRunNode: AITraceSpanNode | undefined | null = null;
-  let currentTimeBounds: TraceBounds = {
-    startTime: 0,
-    endTime: 0,
-    duration: 0,
-  };
+  const timeBounds = getNodeTimeBounds(nodes);
 
   const nodeAiRunParentsMap = useMemo<Record<string, AITraceSpanNode>>(() => {
     const parents: Record<string, AITraceSpanNode> = {};
@@ -109,74 +148,46 @@ export function AISpanList({
     return parents;
   }, [nodes]);
 
-  const nextNodeMap = useMemo<Record<string, AITraceSpanNode>>(() => {
-    const nextNodes: Record<string, AITraceSpanNode> = {};
-    for (let i = 0; i < nodes.length - 1; i++) {
-      const node = nodes[i];
-      const nextNode = nodes[i + 1];
-      if (node && nextNode) {
-        nextNodes[getNodeId(node)] = nextNode;
-      }
-    }
-    return nextNodes;
-  }, [nodes]);
-
-  function getOrphanedSiblings(node: AITraceSpanNode) {
-    const siblings: AITraceSpanNode[] = [];
-    let currentNode: AITraceSpanNode | undefined = node;
-    while (currentNode && !nodeAiRunParentsMap[getNodeId(currentNode)]) {
-      siblings.push(currentNode);
-      currentNode = nextNodeMap[getNodeId(currentNode)];
-    }
-    return siblings;
-  }
+  const handleCollapse = () => {
+    setIsExpanded(prevValue => !prevValue);
+  };
 
   return (
-    <TraceListContainer>
-      {nodes.map(node => {
-        // find the closest transaction node
-        const transactionNode = getClosestNode(node, isTransactionNodeEquivalent);
-        const aiRunNode = nodeAiRunParentsMap[getNodeId(node)];
+    <Fragment>
+      <TransactionButton type="button" disabled={!canCollapse} onClick={handleCollapse}>
+        {canCollapse ? (
+          <StyledIconChevron direction={isExpanded ? 'down' : 'right'} />
+        ) : null}
+        <Tooltip
+          title={transaction.value.transaction}
+          showOnlyOnOverflow
+          skipWrapper
+          delay={500}
+        >
+          <span>{transaction.value.transaction}</span>
+        </Tooltip>
+      </TransactionButton>
+      {isExpanded &&
+        nodes.map(node => {
+          const aiRunNode = nodeAiRunParentsMap[getNodeId(node)];
 
-        if (aiRunNode !== currentAiRunNode) {
-          currentAiRunNode = aiRunNode;
-          currentTimeBounds = aiRunNode
-            ? getNodeTimeBounds(aiRunNode)
-            : getNodeTimeBounds(getOrphanedSiblings(node));
-        }
+          // Only indent if the node is not the ai run node
+          const shouldIndent = aiRunNode && aiRunNode !== node;
 
-        let transactionName: string | null = null;
-        if (transactionNode !== currentTransaction) {
-          currentTransaction = transactionNode;
-          if (
-            transactionNode &&
-            (isTransactionNode(transactionNode) || isEAPSpanNode(transactionNode))
-          ) {
-            transactionName = transactionNode.value.transaction;
-          }
-        }
-
-        // Only indent if the node is a child of the last ai run node
-        const shouldIndent =
-          aiRunNode && !!TraceTree.ParentNode(node, n => n === aiRunNode);
-
-        const uniqueKey = getNodeId(node);
-        return (
-          <Fragment key={uniqueKey}>
-            {transactionName && <TransactionItem>{transactionName}</TransactionItem>}
+          const uniqueKey = getNodeId(node);
+          return (
             <TraceListItem
               indent={shouldIndent ? 1 : 0}
-              traceBounds={currentTimeBounds}
+              traceBounds={timeBounds}
               key={uniqueKey}
               node={node}
               onClick={() => onSelectNode(node)}
               isSelected={uniqueKey === selectedNodeKey}
               colors={colors}
             />
-          </Fragment>
-        );
-      })}
-    </TraceListContainer>
+          );
+        })}
+    </Fragment>
   );
 }
 
@@ -479,18 +490,40 @@ const DurationText = styled('div')`
   color: ${p => p.theme.subText};
 `;
 
-const TransactionItem = styled('div')`
-  font-size: ${p => p.theme.fontSize.sm};
-  color: ${p => p.theme.subText};
-  padding: ${space(2)} ${space(0.5)} 0;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+const TransactionButton = styled('button')`
+  position: relative;
   display: flex;
-  min-width: 0;
-  &:first-child {
-    padding-top: 0;
+  align-items: center;
+  font-size: ${p => p.theme.fontSize.sm};
+  padding: ${p => p.theme.space.xs} ${p => p.theme.space.sm};
+  margin-top: ${p => p.theme.space.md};
+  gap: ${p => p.theme.space.xs};
+  border-radius: ${p => p.theme.borderRadius};
+  background: transparent;
+  border: none;
+  outline: none;
+  justify-content: flex-start;
+  color: ${p => p.theme.subText};
+  font-weight: ${p => p.theme.fontWeight.normal};
+
+  &:hover:not(:disabled) {
+    background-color: ${p => p.theme.backgroundSecondary};
   }
+
+  &:first-child {
+    margin-top: 0;
+  }
+
+  & > span {
+    ${p => p.theme.overflowEllipsis};
+    flex: 1;
+    min-width: 0;
+    text-align: left;
+  }
+`;
+
+const StyledIconChevron = styled(IconChevron)`
+  flex-shrink: 0;
 `;
 
 const FlexSpacer = styled('div')`


### PR DESCRIPTION
Allow collapsing transactions when multiple are displayed.
Updated the span timeline to be transaction scope instead of agent span scoped. This means that invoke_agent spans will not take up 100% of the width anymore and therefore can be compared with other spans inside the same transaction.

#### Collapsing feature

https://github.com/user-attachments/assets/e36d15f8-5471-4d4d-a2cb-7b9cb665ae30


#### Single transaction with multiple agent spans
<img width="401" height="646" alt="Screenshot 2025-09-03 at 09 21 53" src="https://github.com/user-attachments/assets/459a0b79-9fc3-498e-8217-188de8819255" />
