### PR TITLE
ref(rules): Remove is_sample as an argument to RuleProcessor

### DIFF
--- a/src/sentry/rules/base.py
+++ b/src/sentry/rules/base.py
@@ -110,7 +110,6 @@ class RuleBase(object):
 
 
 class EventState(object):
-    def __init__(self, is_new, is_regression, is_sample):
+    def __init__(self, is_new, is_regression):
         self.is_new = is_new
         self.is_regression = is_regression
-        self.is_sample = is_sample,

--- a/src/sentry/rules/processor.py
+++ b/src/sentry/rules/processor.py
@@ -36,15 +36,13 @@ class EventCompatibilityProxy(object):
 class RuleProcessor(object):
     logger = logging.getLogger('sentry.rules')
 
-    def __init__(self, event, is_new, is_regression, is_sample):
+    def __init__(self, event, is_new, is_regression):
         self.event = EventCompatibilityProxy(event)
         self.group = event.group
         self.project = event.project
 
         self.is_new = is_new
         self.is_regression = is_regression
-        # TODO(dcramer): lets remove is_sample
-        self.is_sample = is_sample
 
         self.futures_by_cb = defaultdict(list)
 
@@ -75,7 +73,6 @@ class RuleProcessor(object):
         return EventState(
             is_new=self.is_new,
             is_regression=self.is_regression,
-            is_sample=self.is_sample,
         )
 
     def apply_rule(self, rule):

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -83,7 +83,7 @@ def post_process_group(event, is_new, is_regression, is_sample, **kwargs):
     # we process snoozes before rules as it might create a regression
     process_snoozes(event.group)
 
-    rp = RuleProcessor(event, is_new, is_regression, is_sample)
+    rp = RuleProcessor(event, is_new, is_regression)
     has_alert = False
     # TODO(dcramer): ideally this would fanout, but serializing giant
     # objects back and forth isn't super efficient

--- a/tests/sentry/rules/test_processor.py
+++ b/tests/sentry/rules/test_processor.py
@@ -32,7 +32,7 @@ class RuleProcessorTest(TestCase):
             }
         )
 
-        rp = RuleProcessor(event, is_new=True, is_regression=True, is_sample=False)
+        rp = RuleProcessor(event, is_new=True, is_regression=True)
         results = list(rp.apply())
         assert len(results) == 1
         callback, futures = results[0]


### PR DESCRIPTION
<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
