### PR TITLE
ref(spans): Separate span tree enrichment from shimming

### DIFF
--- a/src/sentry/spans/consumers/process_segments/convert.py
+++ b/src/sentry/spans/consumers/process_segments/convert.py
@@ -8,7 +8,7 @@ from sentry_kafka_schemas.schema_types.buffered_segments_v1 import SpanLink
 from sentry_protos.snuba.v1.request_common_pb2 import TraceItemType
 from sentry_protos.snuba.v1.trace_item_pb2 import AnyValue, TraceItem
 
-from sentry.spans.consumers.process_segments.enrichment import Span
+from sentry.spans.consumers.process_segments.types import CompatibleSpan
 
 I64_MAX = 2**63 - 1
 
@@ -31,7 +31,7 @@ FIELD_TO_ATTRIBUTE = {
 }
 
 
-def convert_span_to_item(span: Span) -> TraceItem:
+def convert_span_to_item(span: CompatibleSpan) -> TraceItem:
     attributes: MutableMapping[str, AnyValue] = {}  # TODO
 
     client_sample_rate = 1.0

--- a/src/sentry/spans/consumers/process_segments/factory.py
+++ b/src/sentry/spans/consumers/process_segments/factory.py
@@ -17,8 +17,8 @@ from arroyo.types import BrokerValue, Commit, FilteredPayload, Message, Partitio
 from sentry import options
 from sentry.conf.types.kafka_definition import Topic
 from sentry.spans.consumers.process_segments.convert import convert_span_to_item
-from sentry.spans.consumers.process_segments.enrichment import Span
 from sentry.spans.consumers.process_segments.message import process_segment
+from sentry.spans.consumers.process_segments.types import CompatibleSpan
 from sentry.utils.arroyo import MultiprocessingPool, run_task_with_multiprocessing
 from sentry.utils.arroyo_producer import get_arroyo_producer
 from sentry.utils.kafka_config import get_kafka_producer_cluster_options, get_topic_definition
@@ -135,7 +135,7 @@ def _process_message(
         raise InvalidMessage(message.value.partition, message.value.offset)
 
 
-def _serialize_payload(span: Span, timestamp: datetime | None) -> Value[KafkaPayload]:
+def _serialize_payload(span: CompatibleSpan, timestamp: datetime | None) -> Value[KafkaPayload]:
     item = convert_span_to_item(span)
     return Value(
         KafkaPayload(

--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -1,8 +1,8 @@
 import logging
 import types
 import uuid
-from copy import deepcopy
-from typing import Any, cast
+from collections.abc import Sequence
+from typing import cast
 
 from django.core.exceptions import ValidationError
 from sentry_kafka_schemas.schema_types.buffered_segments_v1 import SegmentSpan
@@ -26,7 +26,9 @@ from sentry.performance_issues.performance_detection import detect_performance_p
 from sentry.receivers.features import record_generic_event_processed
 from sentry.receivers.onboarding import record_release_received
 from sentry.signals import first_insight_span_received, first_transaction_received
-from sentry.spans.consumers.process_segments.enrichment import Enricher, Span, compute_breakdowns
+from sentry.spans.consumers.process_segments.enrichment import TreeEnricher, compute_breakdowns
+from sentry.spans.consumers.process_segments.shim import build_shim_event_data, make_compatible
+from sentry.spans.consumers.process_segments.types import CompatibleSpan
 from sentry.spans.grouping.api import load_span_grouping_config
 from sentry.utils import metrics
 from sentry.utils.dates import to_datetime
@@ -39,7 +41,9 @@ outcome_aggregator = OutcomeAggregator()
 
 
 @metrics.wraps("spans.consumers.process_segments.process_segment")
-def process_segment(unprocessed_spans: list[SegmentSpan], skip_produce: bool = False) -> list[Span]:
+def process_segment(
+    unprocessed_spans: list[SegmentSpan], skip_produce: bool = False
+) -> list[CompatibleSpan]:
     segment_span, spans = _enrich_spans(unprocessed_spans)
     if segment_span is None:
         return spans
@@ -69,7 +73,9 @@ def process_segment(unprocessed_spans: list[SegmentSpan], skip_produce: bool = F
 
 
 @metrics.wraps("spans.consumers.process_segments.enrich_spans")
-def _enrich_spans(unprocessed_spans: list[SegmentSpan]) -> tuple[Span | None, list[Span]]:
+def _enrich_spans(
+    unprocessed_spans: list[SegmentSpan],
+) -> tuple[CompatibleSpan | None, list[CompatibleSpan]]:
     """
     Enriches all spans with data derived from the span tree and the segment.
 
@@ -80,7 +86,11 @@ def _enrich_spans(unprocessed_spans: list[SegmentSpan]) -> tuple[Span | None, li
     Returns the segment span, if any, and the list of enriched spans.
     """
 
-    segment, spans = Enricher.enrich_spans(unprocessed_spans)
+    segment_idx, tree_spans = TreeEnricher.enrich_spans(unprocessed_spans)
+
+    # Set attributes that are needed by logic shared with the event processing pipeline
+    spans = [make_compatible(span) for span in tree_spans]
+    segment = spans[segment_idx] if segment_idx is not None else None
 
     # Calculate grouping hashes for performance issue detection
     config = load_span_grouping_config()
@@ -91,14 +101,16 @@ def _enrich_spans(unprocessed_spans: list[SegmentSpan]) -> tuple[Span | None, li
 
 
 @metrics.wraps("spans.consumers.process_segments.compute_breakdowns")
-def _compute_breakdowns(segment: Span, spans: list[Span], project: Project) -> None:
+def _compute_breakdowns(
+    segment: CompatibleSpan, spans: Sequence[CompatibleSpan], project: Project
+) -> None:
     config = project.get_option("sentry:breakdowns")
     breakdowns = compute_breakdowns(spans, config)
     segment.setdefault("data", {}).update(breakdowns)
 
 
 @metrics.wraps("spans.consumers.process_segments.create_models")
-def _create_models(segment: Span, project: Project) -> None:
+def _create_models(segment: CompatibleSpan, project: Project) -> None:
     """
     Creates the Environment and Release models, along with the necessary
     relationships between them and the Project model.
@@ -144,11 +156,13 @@ def _create_models(segment: Span, project: Project) -> None:
 
 
 @metrics.wraps("spans.consumers.process_segments.detect_performance_problems")
-def _detect_performance_problems(segment_span: Span, spans: list[Span], project: Project) -> None:
+def _detect_performance_problems(
+    segment_span: CompatibleSpan, spans: list[CompatibleSpan], project: Project
+) -> None:
     if not options.get("spans.process-segments.detect-performance-problems.enable"):
         return
 
-    event_data = _build_shim_event_data(segment_span, spans)
+    event_data = build_shim_event_data(segment_span, spans)
     performance_problems = detect_performance_problems(event_data, project, standalone=True)
 
     if not segment_span.get("_performance_issues_spans"):
@@ -191,55 +205,10 @@ def _detect_performance_problems(segment_span: Span, spans: list[Span], project:
         )
 
 
-def _build_shim_event_data(segment_span: Span, spans: list[Span]) -> dict[str, Any]:
-    data = segment_span.get("data", {})
-
-    event: dict[str, Any] = {
-        "type": "transaction",
-        "level": "info",
-        "contexts": {
-            "trace": {
-                "trace_id": segment_span["trace_id"],
-                "type": "trace",
-                "op": data.get("sentry.transaction.op"),
-                "span_id": segment_span["span_id"],
-                "hash": segment_span["hash"],
-            },
-        },
-        "event_id": uuid.uuid4().hex,
-        "project_id": segment_span["project_id"],
-        "transaction": data.get("sentry.transaction"),
-        "release": data.get("sentry.release"),
-        "dist": data.get("sentry.dist"),
-        "environment": data.get("sentry.environment"),
-        "platform": data.get("sentry.platform"),
-        "tags": [["environment", data.get("sentry.environment")]],
-        "received": segment_span["received"],
-        "timestamp": segment_span["end_timestamp_precise"],
-        "start_timestamp": segment_span["start_timestamp_precise"],
-        "datetime": to_datetime(segment_span["end_timestamp_precise"]).strftime(
-            "%Y-%m-%dT%H:%M:%SZ"
-        ),
-        "spans": [],
-    }
-
-    if (profile_id := segment_span.get("profile_id")) is not None:
-        event["contexts"]["profile"] = {"profile_id": profile_id, "type": "profile"}
-
-    # Add legacy span attributes required only by issue detectors. As opposed to
-    # real event payloads, this also adds the segment span so detectors can run
-    # topological sorting on the span tree.
-    for span in spans:
-        event_span = cast(dict[str, Any], deepcopy(span))
-        event_span["start_timestamp"] = span["start_timestamp_precise"]
-        event_span["timestamp"] = span["end_timestamp_precise"]
-        event["spans"].append(event_span)
-
-    return event
-
-
 @metrics.wraps("spans.consumers.process_segments.record_signals")
-def _record_signals(segment_span: Span, spans: list[Span], project: Project) -> None:
+def _record_signals(
+    segment_span: CompatibleSpan, spans: list[CompatibleSpan], project: Project
+) -> None:
     data = segment_span.get("data", {})
 
     record_generic_event_processed(
@@ -271,7 +240,7 @@ def _record_signals(segment_span: Span, spans: list[Span], project: Project) -> 
 
 
 @metrics.wraps("spans.consumers.process_segments.record_outcomes")
-def _track_outcomes(segment_span: Span, spans: list[Span]) -> None:
+def _track_outcomes(segment_span: CompatibleSpan, spans: list[CompatibleSpan]) -> None:
     if options.get("spans.process-segments.outcome-aggregator.enable"):
         outcome_aggregator.track_outcome_aggregated(
             org_id=segment_span["organization_id"],

--- a/src/sentry/spans/consumers/process_segments/shim.py
+++ b/src/sentry/spans/consumers/process_segments/shim.py
@@ -1,0 +1,103 @@
+"""Functions for making span data compatible with the old event processing pipeline.
+
+This is only necessary for logic thatis shared between the event processing pipeline and the span processing pipeline,
+and thus cannot (yet) be refactored to use the new span schema.
+"""
+
+import uuid
+from copy import deepcopy
+from typing import Any, cast
+
+from sentry_kafka_schemas.schema_types.buffered_segments_v1 import _SentryExtractedTags
+
+from sentry.performance_issues.types import SentryTags as PerformanceIssuesSentryTags
+from sentry.spans.consumers.process_segments.types import CompatibleSpan, TreeSpan, get_span_op
+from sentry.utils.dates import to_datetime
+
+
+def make_compatible(span: TreeSpan) -> CompatibleSpan:
+    # Creates attributes for EAP spans that are required by logic shared with the
+    # event pipeline.
+    #
+    # Spans in the transaction event protocol had a slightly different schema
+    # compared to raw spans on the EAP topic. This function adds the missing
+    # attributes to the spans to make them compatible with the event pipeline
+    # logic.
+    ret = CompatibleSpan(
+        **span,
+        sentry_tags=_sentry_tags(span.get("data") or {}),
+        op=get_span_op(span),
+        # Note: Event protocol spans expect `exclusive_time` while EAP expects
+        # `exclusive_time_ms`. Both are the same value in milliseconds
+        exclusive_time=span["exclusive_time_ms"],
+    )
+
+    return ret
+
+
+def _sentry_tags(data: dict[str, Any]) -> _SentryExtractedTags:
+    """Backfill sentry tags used in performance issue detection.
+
+    Once performance issue detection is only called from process_segments,
+    (not from event_manager), the performance issues code can be refactored to access
+    span attributes instead of sentry_tags.
+    """
+    sentry_tags: _SentryExtractedTags = {}
+    for tag_key in PerformanceIssuesSentryTags.__mutable_keys__:
+        data_key = (
+            "sentry.normalized_description" if tag_key == "description" else f"sentry.{tag_key}"
+        )
+        if data_key in data:
+            sentry_tags[tag_key] = data[data_key]  # type: ignore[literal-required]
+
+    return sentry_tags
+
+
+def build_shim_event_data(
+    segment_span: CompatibleSpan, spans: list[CompatibleSpan]
+) -> dict[str, Any]:
+    """Create a shimmed event payload for performance issue detection."""
+    data = segment_span.get("data", {})
+
+    event: dict[str, Any] = {
+        "type": "transaction",
+        "level": "info",
+        "contexts": {
+            "trace": {
+                "trace_id": segment_span["trace_id"],
+                "type": "trace",
+                "op": data.get("sentry.transaction.op"),
+                "span_id": segment_span["span_id"],
+                "hash": segment_span["hash"],
+            },
+        },
+        "event_id": uuid.uuid4().hex,
+        "project_id": segment_span["project_id"],
+        "transaction": data.get("sentry.transaction"),
+        "release": data.get("sentry.release"),
+        "dist": data.get("sentry.dist"),
+        "environment": data.get("sentry.environment"),
+        "platform": data.get("sentry.platform"),
+        "tags": [["environment", data.get("sentry.environment")]],
+        "received": segment_span["received"],
+        "timestamp": segment_span["end_timestamp_precise"],
+        "start_timestamp": segment_span["start_timestamp_precise"],
+        "datetime": to_datetime(segment_span["end_timestamp_precise"]).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        ),
+        "spans": [],
+    }
+
+    if (profile_id := segment_span.get("profile_id")) is not None:
+        event["contexts"]["profile"] = {"profile_id": profile_id, "type": "profile"}
+
+    # Add legacy span attributes required only by issue detectors. As opposed to
+    # real event payloads, this also adds the segment span so detectors can run
+    # topological sorting on the span tree.
+    for span in spans:
+        event_span = cast(dict[str, Any], deepcopy(span))
+        event_span["start_timestamp"] = span["start_timestamp_precise"]
+        event_span["timestamp"] = span["end_timestamp_precise"]
+        event["spans"].append(event_span)
+
+    return event

--- a/src/sentry/spans/consumers/process_segments/types.py
+++ b/src/sentry/spans/consumers/process_segments/types.py
@@ -1,0 +1,31 @@
+from typing import NotRequired
+
+from sentry_kafka_schemas.schema_types.buffered_segments_v1 import SegmentSpan
+
+# The default span.op to assume if it is missing on the span. This should be
+# normalized by Relay, but we defensively apply the same fallback as the op is
+# not guaranteed in typing.
+DEFAULT_SPAN_OP = "default"
+
+
+def get_span_op(span: SegmentSpan) -> str:
+    return span.get("data", {}).get("sentry.op") or DEFAULT_SPAN_OP
+
+
+class TreeSpan(SegmentSpan, total=True):
+    """
+    Enriched version of the incoming span payload that has additional attributes
+    extracted from its child spans and/or inherited from its parent span.
+    """
+
+    exclusive_time_ms: float
+
+
+class CompatibleSpan(TreeSpan, total=True):
+    """A span that has the same fields as a kafka span, plus shimming for logic shared with the event pipeline"""
+
+    exclusive_time: float
+    op: str
+
+    # Added by `SpanGroupingResults.write_to_spans` in `_enrich_spans`
+    hash: NotRequired[str]

--- a/tests/sentry/spans/consumers/process_segments/test_convert.py
+++ b/tests/sentry/spans/consumers/process_segments/test_convert.py
@@ -5,7 +5,7 @@ from sentry_protos.snuba.v1.request_common_pb2 import TraceItemType
 from sentry_protos.snuba.v1.trace_item_pb2 import AnyValue
 
 from sentry.spans.consumers.process_segments.convert import convert_span_to_item
-from sentry.spans.consumers.process_segments.enrichment import Span
+from sentry.spans.consumers.process_segments.types import CompatibleSpan
 
 ###############################################
 # Test ported from Snuba's `eap_items_span`. #
@@ -76,7 +76,7 @@ SPAN_KAFKA_MESSAGE = {
 
 def test_convert_span_to_item() -> None:
     # Cast since the above payload does not conform to the strict schema
-    item = convert_span_to_item(cast(Span, SPAN_KAFKA_MESSAGE))
+    item = convert_span_to_item(cast(CompatibleSpan, SPAN_KAFKA_MESSAGE))
 
     assert item.organization_id == 1
     assert item.project_id == 1
@@ -149,7 +149,7 @@ def test_convert_span_to_item() -> None:
 def test_convert_falsy_fields() -> None:
     message = {**SPAN_KAFKA_MESSAGE, "duration_ms": 0, "is_segment": False}
 
-    item = convert_span_to_item(cast(Span, message))
+    item = convert_span_to_item(cast(CompatibleSpan, message))
 
     assert item.attributes.get("sentry.duration_ms") == AnyValue(int_value=0)
     assert item.attributes.get("sentry.is_segment") == AnyValue(bool_value=False)
@@ -179,7 +179,7 @@ def test_convert_span_links_to_json() -> None:
         ],
     }
 
-    item = convert_span_to_item(cast(Span, message))
+    item = convert_span_to_item(cast(CompatibleSpan, message))
 
     assert item.attributes.get("sentry.links") == AnyValue(
         string_value='[{"trace_id":"d099bf9ad5a143cf8f83a98081d0ed3b","span_id":"8873a98879faf06d","sampled":true,"attributes":{"sentry.link.type":"parent","sentry.dropped_attributes_count":4}},{"trace_id":"d099bf9ad5a143cf8f83a98081d0ed3b","span_id":"873a988879faf06d"}]'


### PR DESCRIPTION
This PR contains no functional changes. Its only purpose is to clearly separate two enrichment steps in the segment consumer:

1. Enrich spans with information from the span tree (inherit from segment, exclusive time from children, etc.)
2. Shim the Span V1 format to be compatible with the events processing pipeline, for logic that is shared between the two pipelines.

ref: INGEST-533