### PR TITLE
fix(notif-platform): Allow debugger to load in production

### DIFF
--- a/src/sentry/web/debug_urls.py
+++ b/src/sentry/web/debug_urls.py
@@ -72,7 +72,6 @@ from sentry.web.frontend.debug.debug_unable_to_fetch_commits_email import (
 )
 from sentry.web.frontend.debug.debug_unassigned_email import DebugUnassignedEmailView
 from sentry.web.frontend.debug.debug_weekly_report import DebugWeeklyReportView
-from sentry.web.frontend.react_page import ReactPageView
 
 urlpatterns = [
     re_path(r"^debug/mail/error-alert/$", sentry.web.frontend.debug.mail.alert),
@@ -159,6 +158,4 @@ urlpatterns = [
     re_path(r"^debug/chart-renderer/$", DebugChartRendererView.as_view()),
     re_path(r"^debug/mail/cron-broken-monitor-email/$", DebugCronBrokenMonitorEmailView.as_view()),
     re_path(r"^debug/mail/cron-muted-monitor-email/$", DebugCronMutedMonitorEmailView.as_view()),
-    # Notifications Debugger
-    re_path(r"^debug/notifications/", ReactPageView.as_view(), name="debug-notifications"),
 ]

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -487,6 +487,12 @@ urlpatterns += [
         react_page_view,
         name="stories",
     ),
+    # Notification Debugger
+    re_path(
+        r"^debug/notifications/",
+        react_page_view,
+        name="debug-notifications",
+    ),
     # Rollback
     re_path(
         r"^rollback/",


### PR DESCRIPTION
The DEBUG urls were exempt from loading in the main app, but if were emulating stories, we want it to load anyway for convenience. No user data will be surfaced here anyway.