### PR TITLE
fix(insights): fixes an issue with the frontend overview page using the wrong total score

### DIFF
--- a/static/app/views/insights/browser/webVitals/queries/storedScoreQueries/getWebVitalScoresFromTableDataRow.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/storedScoreQueries/getWebVitalScoresFromTableDataRow.tsx
@@ -23,14 +23,14 @@ type CountScores = Pick<
   | 'count_scores(measurements.score.total)'
 >;
 
-type TotalPerformanceScore = {'avg(measurements.score.total)': number};
+type TotalPerformanceScore = {'performance_score(measurements.score.total)': number};
 
 function getWebVitalScore(data: PerformanceScores, webVital: WebVitals): number {
   return data[`performance_score(measurements.score.${webVital})`] * 100;
 }
 
 function getTotalScore(data: TotalPerformanceScore): number {
-  return data[`avg(measurements.score.total)`] * 100;
+  return data[`performance_score(measurements.score.total)`] * 100;
 }
 
 function getWebVitalScoreCount(data: CountScores, webVital: WebVitals | 'total'): number {


### PR DESCRIPTION
Should be using `performance_score(measurements.score.total)` instead.