### PR TITLE
feat(uptime): Add validator for UptimeDomainCheckFailure grouptype.

### DIFF
--- a/src/sentry/uptime/endpoints/validators.py
+++ b/src/sentry/uptime/endpoints/validators.py
@@ -376,7 +376,6 @@ class UptimeMonitorDataSourceValidator(BaseDataSourceValidator[UptimeSubscriptio
         max_value=60_000,
         help_text="The number of milliseconds the request will wait for a response before timing-out.",
     )
-    mode = serializers.IntegerField(required=False)
     method = serializers.ChoiceField(
         required=False,
         choices=UptimeSubscription.SupportedHTTPMethods.choices,
@@ -402,8 +401,6 @@ class UptimeMonitorDataSourceValidator(BaseDataSourceValidator[UptimeSubscriptio
         fields = [
             "url",
             "headers",
-            "status",
-            "mode",
             "timeout_ms",
             "method",
             "trace_sampling",
@@ -416,9 +413,6 @@ class UptimeMonitorDataSourceValidator(BaseDataSourceValidator[UptimeSubscriptio
 
     def validate_headers(self, headers):
         return _validate_headers(headers)
-
-    def validate_status(self, value):
-        return _validate_monitor_status(value)
 
     def validate_mode(self, mode):
         return _validate_mode(mode, self.context["request"])
@@ -474,8 +468,6 @@ class UptimeDomainCheckFailureValidator(BaseDetectorTypeValidator):
         return instance
 
     def update_data_source(self, instance: Detector, data_source: dict[str, Any]):
-        # data_source will have some extra Detector-related in it, so cull them before
-        # calling update_project_uptime_subscription
         subscription = get_uptime_subscription(instance)
         update_uptime_subscription(
             subscription=subscription,

--- a/src/sentry/uptime/endpoints/validators.py
+++ b/src/sentry/uptime/endpoints/validators.py
@@ -373,17 +373,6 @@ class UptimeMonitorDataSourceValidator(BaseDataSourceValidator[UptimeSubscriptio
         default="active",
         help_text="Status of the uptime monitor. Disabled uptime monitors will not perform checks and do not count against the uptime monitor quota.",
     )
-    owner = ActorField(
-        required=False,
-        allow_null=True,
-        help_text="The ID of the team or user that owns the uptime monitor. (eg. user:51 or team:6)",
-    )
-    environment = serializers.CharField(
-        max_length=64,
-        required=False,
-        allow_null=True,
-        help_text="Name of the environment to create uptime issues in.",
-    )
     url = URLField(required=True, max_length=255)
     interval_seconds = serializers.ChoiceField(
         required=True,

--- a/src/sentry/uptime/grouptype.py
+++ b/src/sentry/uptime/grouptype.py
@@ -11,12 +11,12 @@ from sentry_kafka_schemas.schema_types.uptime_results_v1 import CheckResult, Che
 from sentry import features, options
 from sentry.issues.grouptype import GroupCategory, GroupType
 from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence
-from sentry.issues.producer import PayloadType, produce_occurrence_to_kafka
 from sentry.issues.status_change_message import StatusChangeMessage
-from sentry.models.group import GroupStatus
 from sentry.ratelimits.sliding_windows import Quota
 from sentry.types.group import PriorityLevel
+from sentry.uptime.endpoints.validators import UptimeDomainCheckFailureValidator
 from sentry.uptime.models import UptimeStatus, UptimeSubscription
+from sentry.uptime.subscriptions.subscriptions import build_fingerprint
 from sentry.uptime.types import GROUP_TYPE_UPTIME_DOMAIN_CHECK_FAILURE, UptimeMonitorMode
 from sentry.utils import metrics
 from sentry.workflow_engine.handlers.detector.base import DetectorOccurrence, EventData
@@ -36,23 +36,6 @@ from sentry.workflow_engine.types import (
 logger = logging.getLogger(__name__)
 
 
-def resolve_uptime_issue(detector: Detector) -> None:
-    """
-    Sends an update to the issue platform to resolve the uptime issue for this
-    monitor.
-    """
-    status_change = StatusChangeMessage(
-        fingerprint=build_fingerprint(detector),
-        project_id=detector.project_id,
-        new_status=GroupStatus.RESOLVED,
-        new_substatus=None,
-    )
-    produce_occurrence_to_kafka(
-        payload_type=PayloadType.STATUS_CHANGE,
-        status_change=status_change,
-    )
-
-
 @dataclass(frozen=True)
 class UptimePacketValue:
     """
@@ -64,12 +47,20 @@ class UptimePacketValue:
     metric_tags: dict[str, str]
 
 
-def build_detector_fingerprint_component(detector: Detector) -> str:
-    return f"uptime-detector:{detector.id}"
+def get_active_failure_threshold() -> int:
+    """
+    When in active monitoring mode, overrides how many failures in a row we
+    need to see to mark the monitor as down
+    """
+    return options.get("uptime.active-failure-threshold")
 
 
-def build_fingerprint(detector: Detector) -> list[str]:
-    return [build_detector_fingerprint_component(detector)]
+def get_active_recovery_threshold() -> int:
+    """
+    When in active monitoring mode, how many successes in a row do we need to
+    mark it as up
+    """
+    return options.get("uptime.active-recovery-threshold")
 
 
 def build_evidence_display(result: CheckResult) -> list[IssueEvidence]:
@@ -284,6 +275,7 @@ class UptimeDomainCheckFailure(GroupType):
     enable_escalation_detection = False
     detector_settings = DetectorSettings(
         handler=UptimeDetectorHandler,
+        validator=UptimeDomainCheckFailureValidator,
         config_schema={
             "$schema": "https://json-schema.org/draft/2020-12/schema",
             "description": "A representation of an uptime alert",

--- a/src/sentry/uptime/grouptype.py
+++ b/src/sentry/uptime/grouptype.py
@@ -47,22 +47,6 @@ class UptimePacketValue:
     metric_tags: dict[str, str]
 
 
-def get_active_failure_threshold() -> int:
-    """
-    When in active monitoring mode, overrides how many failures in a row we
-    need to see to mark the monitor as down
-    """
-    return options.get("uptime.active-failure-threshold")
-
-
-def get_active_recovery_threshold() -> int:
-    """
-    When in active monitoring mode, how many successes in a row do we need to
-    mark it as up
-    """
-    return options.get("uptime.active-recovery-threshold")
-
-
 def build_evidence_display(result: CheckResult) -> list[IssueEvidence]:
     evidence_display: list[IssueEvidence] = []
 

--- a/src/sentry/uptime/subscriptions/subscriptions.py
+++ b/src/sentry/uptime/subscriptions/subscriptions.py
@@ -10,12 +10,14 @@ from sentry_kafka_schemas.schema_types.uptime_results_v1 import (
 from sentry import quotas
 from sentry.constants import DataCategory, ObjectStatus
 from sentry.deletions.models.scheduleddeletion import RegionScheduledDeletion
+from sentry.issues.producer import PayloadType, produce_occurrence_to_kafka
+from sentry.issues.status_change_message import StatusChangeMessage
 from sentry.models.environment import Environment
+from sentry.models.group import GroupStatus
 from sentry.models.project import Project
 from sentry.quotas.base import SeatAssignmentResult
 from sentry.types.actor import Actor
 from sentry.uptime.detectors.url_extraction import extract_domain_parts
-from sentry.uptime.grouptype import UptimeDomainCheckFailure, resolve_uptime_issue
 from sentry.uptime.models import (
     UptimeStatus,
     UptimeSubscription,
@@ -53,6 +55,31 @@ UPTIME_SUBSCRIPTION_TYPE = "uptime_monitor"
 MAX_AUTO_SUBSCRIPTIONS_PER_ORG = 1
 MAX_MANUAL_SUBSCRIPTIONS_PER_ORG = 100
 MAX_MONITORS_PER_DOMAIN = 100
+
+
+def build_detector_fingerprint_component(detector: Detector) -> str:
+    return f"uptime-detector:{detector.id}"
+
+
+def build_fingerprint(detector: Detector) -> list[str]:
+    return [build_detector_fingerprint_component(detector)]
+
+
+def resolve_uptime_issue(detector: Detector) -> None:
+    """
+    Sends an update to the issue platform to resolve the uptime issue for this
+    monitor.
+    """
+    status_change = StatusChangeMessage(
+        fingerprint=build_fingerprint(detector),
+        project_id=detector.project_id,
+        new_status=GroupStatus.RESOLVED,
+        new_substatus=None,
+    )
+    produce_occurrence_to_kafka(
+        payload_type=PayloadType.STATUS_CHANGE,
+        status_change=status_change,
+    )
 
 
 class MaxManualUptimeSubscriptionsReached(ValueError):
@@ -209,7 +236,7 @@ def create_uptime_detector(
     if mode == UptimeMonitorMode.MANUAL:
         manual_subscription_count = Detector.objects.filter(
             status=ObjectStatus.ACTIVE,
-            type=UptimeDomainCheckFailure.slug,
+            type=GROUP_TYPE_UPTIME_DOMAIN_CHECK_FAILURE,
             project__organization=project.organization,
             config__mode=UptimeMonitorMode.MANUAL,
         ).count()
@@ -521,7 +548,7 @@ def is_url_auto_monitored_for_project(project: Project, url: str) -> bool:
     auto_detected_subscription_ids = list(
         Detector.objects.filter(
             status=ObjectStatus.ACTIVE,
-            type=UptimeDomainCheckFailure.slug,
+            type=GROUP_TYPE_UPTIME_DOMAIN_CHECK_FAILURE,
             project=project,
             config__mode__in=(
                 UptimeMonitorMode.AUTO_DETECTED_ONBOARDING.value,
@@ -549,7 +576,7 @@ def get_auto_monitored_detectors_for_project(
         ]
     return list(
         Detector.objects.filter(
-            type=UptimeDomainCheckFailure.slug, project=project, config__mode__in=modes
+            type=GROUP_TYPE_UPTIME_DOMAIN_CHECK_FAILURE, project=project, config__mode__in=modes
         )
     )
 

--- a/tests/sentry/uptime/consumers/test_results_consumer.py
+++ b/tests/sentry/uptime/consumers/test_results_consumer.py
@@ -43,9 +43,12 @@ from sentry.uptime.detectors.result_handler import (
     build_onboarding_failure_key,
 )
 from sentry.uptime.detectors.tasks import is_failed_url
-from sentry.uptime.grouptype import UptimeDomainCheckFailure, build_detector_fingerprint_component
+from sentry.uptime.grouptype import UptimeDomainCheckFailure
 from sentry.uptime.models import UptimeStatus, UptimeSubscription, UptimeSubscriptionRegion
-from sentry.uptime.subscriptions.subscriptions import UptimeMonitorNoSeatAvailable
+from sentry.uptime.subscriptions.subscriptions import (
+    UptimeMonitorNoSeatAvailable,
+    build_detector_fingerprint_component,
+)
 from sentry.uptime.types import IncidentStatus, UptimeMonitorMode
 from sentry.utils import json
 from tests.sentry.uptime.subscriptions.test_tasks import ConfigPusherTestMixin

--- a/tests/sentry/uptime/endpoints/test_detector.py
+++ b/tests/sentry/uptime/endpoints/test_detector.py
@@ -1,18 +1,11 @@
 from django.utils import timezone
 from rest_framework import status
-from sentry_kafka_schemas.schema_types.uptime_results_v1 import (
-    CHECKSTATUS_FAILURE,
-    CHECKSTATUS_SUCCESS,
-)
 
 from sentry.testutils.cases import APITestCase
 from sentry.uptime.grouptype import UptimeDomainCheckFailure
 from sentry.uptime.models import UptimeStatus, UptimeSubscription, get_uptime_subscription
-from sentry.uptime.subscriptions.subscriptions import create_uptime_subscription
 from sentry.uptime.types import UptimeMonitorMode
-from sentry.workflow_engine.models import DataCondition, DataConditionGroup, Detector
-from sentry.workflow_engine.models.data_condition import Condition
-from sentry.workflow_engine.types import DetectorPriorityLevel
+from sentry.workflow_engine.models import Detector
 
 
 def _get_valid_data(project_id, environment_name, **overrides):
@@ -52,54 +45,24 @@ class UptimeDetectorBaseTest(APITestCase):
             organization_id=self.organization.id, name="production"
         )
         self.project = self.create_project()
-        with self.tasks():
-            self.uptime_subscription = create_uptime_subscription(
-                url="https://www.google.com",
-                interval_seconds=UptimeSubscription.IntervalSeconds.ONE_MINUTE,
-                timeout_ms=30000,
-                method=UptimeSubscription.SupportedHTTPMethods.GET,
-                headers=[],
-                body=None,
-                trace_sampling=False,
-                uptime_status=UptimeStatus.OK,
-            )
 
-        self.data_source = self.create_data_source(
-            organization=self.organization, source_id=self.uptime_subscription.id
+        self.uptime_subscription = self.create_uptime_subscription(
+            url="https://www.google.com",
+            interval_seconds=UptimeSubscription.IntervalSeconds.ONE_MINUTE,
+            timeout_ms=30000,
+            method=UptimeSubscription.SupportedHTTPMethods.GET,
+            headers=[],
+            body=None,
+            trace_sampling=False,
+            uptime_status=UptimeStatus.OK,
         )
 
-        self.data_condition_group: DataConditionGroup = DataConditionGroup.objects.create(
-            organization=self.organization,
-        )
-        DataCondition.objects.create(
-            comparison=CHECKSTATUS_FAILURE,
-            type=Condition.EQUAL,
-            condition_result=DetectorPriorityLevel.HIGH,
-            condition_group=self.data_condition_group,
-        )
-        DataCondition.objects.create(
-            comparison=CHECKSTATUS_SUCCESS,
-            type=Condition.EQUAL,
-            condition_result=DetectorPriorityLevel.OK,
-            condition_group=self.data_condition_group,
-        )
-
-        self.detector = self.create_detector(
-            project_id=self.project.id,
+        self.detector = self.create_uptime_detector(
+            project=self.project,
+            env=self.environment,
+            uptime_subscription=self.uptime_subscription,
             name="Test Detector",
-            type=UptimeDomainCheckFailure.slug,
-            config={
-                "environment": self.environment.name,
-                "mode": UptimeMonitorMode.MANUAL.value,
-                "recovery_threshold": 1,
-                "downtime_threshold": 1,
-            },
-            workflow_condition_group=self.data_condition_group,
         )
-        self.data_source_detector = self.create_data_source_detector(
-            data_source=self.data_source, detector=self.detector
-        )
-        assert self.detector.data_sources is not None
 
 
 class OrganizationDetectorDetailsPutTest(UptimeDetectorBaseTest):
@@ -126,25 +89,24 @@ class OrganizationDetectorDetailsPutTest(UptimeDetectorBaseTest):
                 "timeout_ms": 15000,
             },
             "conditionGroup": {
-                "id": self.data_condition_group.id,
+                "id": self.detector.workflow_condition_group.id,
                 "organizationId": self.organization.id,
             },
             "config": self.detector.config,
         }
 
-        with self.tasks():
-            self.get_success_response(
-                self.organization.slug,
-                self.detector.id,
-                **valid_data,
-                status_code=status.HTTP_200_OK,
-                method="PUT",
-            )
+        self.get_success_response(
+            self.organization.slug,
+            self.detector.id,
+            **valid_data,
+            status_code=status.HTTP_200_OK,
+            method="PUT",
+        )
 
-            updated_sub: UptimeSubscription = UptimeSubscription.objects.get(
-                id=self.uptime_subscription.id
-            )
-            assert updated_sub.timeout_ms == 15000
+        updated_sub: UptimeSubscription = UptimeSubscription.objects.get(
+            id=self.uptime_subscription.id
+        )
+        assert updated_sub.timeout_ms == 15000
 
     def test_update_invalid(self) -> None:
         valid_data = {
@@ -158,25 +120,24 @@ class OrganizationDetectorDetailsPutTest(UptimeDetectorBaseTest):
                 "timeout_ms": 80000,
             },
             "conditionGroup": {
-                "id": self.data_condition_group.id,
+                "id": self.detector.workflow_condition_group.id,
                 "organizationId": self.organization.id,
             },
             "config": self.detector.config,
         }
 
-        with self.tasks():
-            response = self.get_error_response(
-                self.organization.slug,
-                self.detector.id,
-                **valid_data,
-                status_code=status.HTTP_400_BAD_REQUEST,
-                method="PUT",
-            )
+        response = self.get_error_response(
+            self.organization.slug,
+            self.detector.id,
+            **valid_data,
+            status_code=status.HTTP_400_BAD_REQUEST,
+            method="PUT",
+        )
 
-            assert "dataSource" in response.data
-            assert "Ensure this value is less than or equal to 60000." in str(
-                response.data["dataSource"]
-            )
+        assert "dataSource" in response.data
+        assert "Ensure this value is less than or equal to 60000." in str(
+            response.data["dataSource"]
+        )
 
 
 class OrganizationDetectorIndexPostTest(APITestCase):
@@ -191,40 +152,40 @@ class OrganizationDetectorIndexPostTest(APITestCase):
         invalid_data = _get_valid_data(
             self.project.id, self.environment.name, dataSource={"timeout_ms": 80000}
         )
-        with self.tasks():
-            response = self.get_error_response(
-                self.organization.slug,
-                **invalid_data,
-                status_code=status.HTTP_400_BAD_REQUEST,
-            )
 
-            assert "dataSource" in response.data
-            assert "Ensure this value is less than or equal to 60000" in str(
-                response.data["dataSource"]
-            )
+        response = self.get_error_response(
+            self.organization.slug,
+            **invalid_data,
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+
+        assert "dataSource" in response.data
+        assert "Ensure this value is less than or equal to 60000" in str(
+            response.data["dataSource"]
+        )
 
     def test_create_detector(self):
         valid_data = _get_valid_data(
             self.project.id,
             self.environment.name,
         )
-        with self.tasks():
-            response = self.get_success_response(
-                self.organization.slug,
-                **valid_data,
-                status_code=status.HTTP_201_CREATED,
-            )
 
-            detector: Detector = Detector.objects.get(id=response.data["id"])
-            created_sub: UptimeSubscription = get_uptime_subscription(detector)
+        response = self.get_success_response(
+            self.organization.slug,
+            **valid_data,
+            status_code=status.HTTP_201_CREATED,
+        )
 
-            assert detector.name == "Test Uptime Detector"
-            assert detector.type == UptimeDomainCheckFailure.slug
-            assert detector.project_id == self.project.id
+        detector: Detector = Detector.objects.get(id=response.data["id"])
+        created_sub: UptimeSubscription = get_uptime_subscription(detector)
 
-            assert created_sub.timeout_ms == 30000
-            assert created_sub.url == "https://www.google.com"
-            assert created_sub.interval_seconds == UptimeSubscription.IntervalSeconds.ONE_MINUTE
+        assert detector.name == "Test Uptime Detector"
+        assert detector.type == UptimeDomainCheckFailure.slug
+        assert detector.project_id == self.project.id
+
+        assert created_sub.timeout_ms == 30000
+        assert created_sub.url == "https://www.google.com"
+        assert created_sub.interval_seconds == UptimeSubscription.IntervalSeconds.ONE_MINUTE
 
     def test_create_detector_optional_fields(self):
         valid_data = _get_valid_data(
@@ -241,23 +202,23 @@ class OrganizationDetectorIndexPostTest(APITestCase):
                 "trace_sampling": True,
             },
         )
-        with self.tasks():
-            response = self.get_success_response(
-                self.organization.slug,
-                **valid_data,
-                status_code=status.HTTP_201_CREATED,
-            )
-            detector: Detector = Detector.objects.get(id=response.data["id"])
-            created_sub: UptimeSubscription = get_uptime_subscription(detector)
 
-            assert detector.name == "Test Uptime Detector"
-            assert detector.type == UptimeDomainCheckFailure.slug
-            assert detector.project_id == self.project.id
+        response = self.get_success_response(
+            self.organization.slug,
+            **valid_data,
+            status_code=status.HTTP_201_CREATED,
+        )
+        detector: Detector = Detector.objects.get(id=response.data["id"])
+        created_sub: UptimeSubscription = get_uptime_subscription(detector)
 
-            assert created_sub.timeout_ms == 30000
-            assert created_sub.url == "https://www.google.com"
-            assert created_sub.interval_seconds == UptimeSubscription.IntervalSeconds.ONE_MINUTE
-            assert created_sub.method == "PUT"
-            assert created_sub.headers == [["key", "value"]]
-            assert created_sub.body == "<html/>"
-            assert created_sub.trace_sampling is True
+        assert detector.name == "Test Uptime Detector"
+        assert detector.type == UptimeDomainCheckFailure.slug
+        assert detector.project_id == self.project.id
+
+        assert created_sub.timeout_ms == 30000
+        assert created_sub.url == "https://www.google.com"
+        assert created_sub.interval_seconds == UptimeSubscription.IntervalSeconds.ONE_MINUTE
+        assert created_sub.method == "PUT"
+        assert created_sub.headers == [["key", "value"]]
+        assert created_sub.body == "<html/>"
+        assert created_sub.trace_sampling is True

--- a/tests/sentry/uptime/endpoints/test_detector.py
+++ b/tests/sentry/uptime/endpoints/test_detector.py
@@ -78,6 +78,7 @@ class OrganizationDetectorDetailsPutTest(UptimeDetectorBaseTest):
         }
 
     def test_update(self) -> None:
+        assert self.detector.workflow_condition_group
         valid_data = {
             "id": self.detector.id,
             "projectId": self.project.id,
@@ -109,6 +110,8 @@ class OrganizationDetectorDetailsPutTest(UptimeDetectorBaseTest):
         assert updated_sub.timeout_ms == 15000
 
     def test_update_invalid(self) -> None:
+        assert self.detector.workflow_condition_group
+
         valid_data = {
             "id": self.detector.id,
             "projectId": self.project.id,

--- a/tests/sentry/uptime/endpoints/test_detector.py
+++ b/tests/sentry/uptime/endpoints/test_detector.py
@@ -1,0 +1,263 @@
+from django.utils import timezone
+from rest_framework import status
+from sentry_kafka_schemas.schema_types.uptime_results_v1 import (
+    CHECKSTATUS_FAILURE,
+    CHECKSTATUS_SUCCESS,
+)
+
+from sentry.testutils.cases import APITestCase
+from sentry.uptime.grouptype import UptimeDomainCheckFailure
+from sentry.uptime.models import UptimeStatus, UptimeSubscription, get_uptime_subscription
+from sentry.uptime.subscriptions.subscriptions import create_uptime_subscription
+from sentry.uptime.types import UptimeMonitorMode
+from sentry.workflow_engine.models import DataCondition, DataConditionGroup, Detector
+from sentry.workflow_engine.models.data_condition import Condition
+from sentry.workflow_engine.types import DetectorPriorityLevel
+
+
+def _get_valid_data(project_id, environment_name, **overrides):
+    data = {
+        "projectId": project_id,
+        "name": "Test Uptime Detector",
+        "type": UptimeDomainCheckFailure.slug,
+        "dataSource": {
+            "timeout_ms": 30000,
+            "name": "Test Uptime Detector",
+            "url": "https://www.google.com",
+            "interval_seconds": UptimeSubscription.IntervalSeconds.ONE_MINUTE,
+        },
+        "conditionGroup": {
+            "logicType": "any",
+            "conditions": [
+                {"comparison": 1, "type": "eq", "condition_result": "high"},
+                {"comparison": 0, "type": "eq", "condition_result": "ok"},
+            ],
+        },
+        "config": {
+            "environment": environment_name,
+            "mode": UptimeMonitorMode.MANUAL.value,
+            "recovery_threshold": 1,
+            "downtime_threshold": 1,
+        },
+    }
+    data.update(overrides)
+    return data
+
+
+class UptimeDetectorBaseTest(APITestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_as(user=self.user)
+        self.environment = self.create_environment(
+            organization_id=self.organization.id, name="production"
+        )
+        self.project = self.create_project()
+        with self.tasks():
+            self.uptime_subscription = create_uptime_subscription(
+                url="https://www.google.com",
+                interval_seconds=UptimeSubscription.IntervalSeconds.ONE_MINUTE,
+                timeout_ms=30000,
+                method=UptimeSubscription.SupportedHTTPMethods.GET,
+                headers=[],
+                body=None,
+                trace_sampling=False,
+                uptime_status=UptimeStatus.OK,
+            )
+
+        self.data_source = self.create_data_source(
+            organization=self.organization, source_id=self.uptime_subscription.id
+        )
+
+        self.data_condition_group: DataConditionGroup = DataConditionGroup.objects.create(
+            organization=self.organization,
+        )
+        DataCondition.objects.create(
+            comparison=CHECKSTATUS_FAILURE,
+            type=Condition.EQUAL,
+            condition_result=DetectorPriorityLevel.HIGH,
+            condition_group=self.data_condition_group,
+        )
+        DataCondition.objects.create(
+            comparison=CHECKSTATUS_SUCCESS,
+            type=Condition.EQUAL,
+            condition_result=DetectorPriorityLevel.OK,
+            condition_group=self.data_condition_group,
+        )
+
+        self.detector = self.create_detector(
+            project_id=self.project.id,
+            name="Test Detector",
+            type=UptimeDomainCheckFailure.slug,
+            config={
+                "environment": self.environment.name,
+                "mode": UptimeMonitorMode.MANUAL.value,
+                "recovery_threshold": 1,
+                "downtime_threshold": 1,
+            },
+            workflow_condition_group=self.data_condition_group,
+        )
+        self.data_source_detector = self.create_data_source_detector(
+            data_source=self.data_source, detector=self.detector
+        )
+        assert self.detector.data_sources is not None
+
+
+class OrganizationDetectorDetailsPutTest(UptimeDetectorBaseTest):
+    endpoint = "sentry-api-0-organization-detector-details"
+
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.context = {
+            "organization": self.project.organization,
+            "project": self.project,
+            "request": self.make_request(),
+        }
+
+    def test_update(self) -> None:
+        valid_data = {
+            "id": self.detector.id,
+            "projectId": self.project.id,
+            "name": "Test Uptime Detector",
+            "type": UptimeDomainCheckFailure.slug,
+            "dateCreated": self.detector.date_added,
+            "dateUpdated": timezone.now(),
+            "dataSource": {
+                "timeout_ms": 15000,
+            },
+            "conditionGroup": {
+                "id": self.data_condition_group.id,
+                "organizationId": self.organization.id,
+            },
+            "config": self.detector.config,
+        }
+
+        with self.tasks():
+            self.get_success_response(
+                self.organization.slug,
+                self.detector.id,
+                **valid_data,
+                status_code=status.HTTP_200_OK,
+                method="PUT",
+            )
+
+            updated_sub: UptimeSubscription = UptimeSubscription.objects.get(
+                id=self.uptime_subscription.id
+            )
+            assert updated_sub.timeout_ms == 15000
+
+    def test_update_invalid(self) -> None:
+        valid_data = {
+            "id": self.detector.id,
+            "projectId": self.project.id,
+            "name": "Test Uptime Detector",
+            "type": UptimeDomainCheckFailure.slug,
+            "dateCreated": self.detector.date_added,
+            "dateUpdated": timezone.now(),
+            "dataSource": {
+                "timeout_ms": 80000,
+            },
+            "conditionGroup": {
+                "id": self.data_condition_group.id,
+                "organizationId": self.organization.id,
+            },
+            "config": self.detector.config,
+        }
+
+        with self.tasks():
+            response = self.get_error_response(
+                self.organization.slug,
+                self.detector.id,
+                **valid_data,
+                status_code=status.HTTP_400_BAD_REQUEST,
+                method="PUT",
+            )
+
+            assert "dataSource" in response.data
+            assert "Ensure this value is less than or equal to 60000." in str(
+                response.data["dataSource"]
+            )
+
+
+class OrganizationDetectorIndexPostTest(APITestCase):
+    endpoint = "sentry-api-0-organization-detector-index"
+    method = "post"
+
+    def setUp(self):
+        super().setUp()
+        self.login_as(user=self.user)
+
+    def test_create_detector_validation_error(self):
+        invalid_data = _get_valid_data(
+            self.project.id, self.environment.name, dataSource={"timeout_ms": 80000}
+        )
+        with self.tasks():
+            response = self.get_error_response(
+                self.organization.slug,
+                **invalid_data,
+                status_code=status.HTTP_400_BAD_REQUEST,
+            )
+
+            assert "dataSource" in response.data
+            assert "Ensure this value is less than or equal to 60000" in str(
+                response.data["dataSource"]
+            )
+
+    def test_create_detector(self):
+        valid_data = _get_valid_data(
+            self.project.id,
+            self.environment.name,
+        )
+        with self.tasks():
+            response = self.get_success_response(
+                self.organization.slug,
+                **valid_data,
+                status_code=status.HTTP_201_CREATED,
+            )
+
+            detector: Detector = Detector.objects.get(id=response.data["id"])
+            created_sub: UptimeSubscription = get_uptime_subscription(detector)
+
+            assert detector.name == "Test Uptime Detector"
+            assert detector.type == UptimeDomainCheckFailure.slug
+            assert detector.project_id == self.project.id
+
+            assert created_sub.timeout_ms == 30000
+            assert created_sub.url == "https://www.google.com"
+            assert created_sub.interval_seconds == UptimeSubscription.IntervalSeconds.ONE_MINUTE
+
+    def test_create_detector_optional_fields(self):
+        valid_data = _get_valid_data(
+            self.project.id,
+            self.environment.name,
+            dataSource={
+                "timeout_ms": 30000,
+                "name": "Test Uptime Detector",
+                "url": "https://www.google.com",
+                "interval_seconds": UptimeSubscription.IntervalSeconds.ONE_MINUTE,
+                "method": "PUT",
+                "headers": [["key", "value"]],
+                "body": "<html/>",
+                "trace_sampling": True,
+            },
+        )
+        with self.tasks():
+            response = self.get_success_response(
+                self.organization.slug,
+                **valid_data,
+                status_code=status.HTTP_201_CREATED,
+            )
+            detector: Detector = Detector.objects.get(id=response.data["id"])
+            created_sub: UptimeSubscription = get_uptime_subscription(detector)
+
+            assert detector.name == "Test Uptime Detector"
+            assert detector.type == UptimeDomainCheckFailure.slug
+            assert detector.project_id == self.project.id
+
+            assert created_sub.timeout_ms == 30000
+            assert created_sub.url == "https://www.google.com"
+            assert created_sub.interval_seconds == UptimeSubscription.IntervalSeconds.ONE_MINUTE
+            assert created_sub.method == "PUT"
+            assert created_sub.headers == [["key", "value"]]
+            assert created_sub.body == "<html/>"
+            assert created_sub.trace_sampling is True

--- a/tests/sentry/uptime/endpoints/test_validators.py
+++ b/tests/sentry/uptime/endpoints/test_validators.py
@@ -76,12 +76,6 @@ class UptimeMonitorDataSourceValidatorTest(TestCase):
         validator = UptimeMonitorDataSourceValidator(data=data, context=self.context)
         assert not validator.is_valid()
 
-    def test_bad_status(self):
-        data = self.get_valid_data()
-        data["status"] = ["ready to work!"]
-        validator = UptimeMonitorDataSourceValidator(data=data, context=self.context)
-        assert not validator.is_valid()
-
     def test_too_many_urls(self):
         for _ in range(0, 100):
             UptimeSubscription.objects.create(

--- a/tests/sentry/uptime/endpoints/test_validators.py
+++ b/tests/sentry/uptime/endpoints/test_validators.py
@@ -1,5 +1,11 @@
-from sentry.testutils.cases import UptimeTestCase
-from sentry.uptime.endpoints.validators import compute_http_request_size
+from sentry.constants import ObjectStatus
+from sentry.monitors.validators import MONITOR_STATUSES_REVERSE
+from sentry.testutils.cases import TestCase, UptimeTestCase
+from sentry.uptime.endpoints.validators import (
+    UptimeMonitorDataSourceValidator,
+    compute_http_request_size,
+)
+from sentry.uptime.models import UptimeSubscription
 
 
 class ComputeHttpRequestSizeTest(UptimeTestCase):
@@ -33,3 +39,76 @@ class ComputeHttpRequestSizeTest(UptimeTestCase):
             )
             == 70
         )
+
+
+class UptimeMonitorDataSourceValidatorTest(TestCase):
+    def get_valid_data(self):
+        return {
+            "name": "Name",
+            "status": MONITOR_STATUSES_REVERSE[ObjectStatus.ACTIVE],
+            "owner": self.user.name,
+            "environment": self.environment.name,
+            "url": "https://www.google.com",
+            "interval_seconds": UptimeSubscription.IntervalSeconds.ONE_MINUTE,
+            "timeout_ms": 30000,
+            "method": UptimeSubscription.SupportedHTTPMethods.GET,
+            "headers": [],
+            "trace_sampling": False,
+            "body": None,
+        }
+
+    def setUp(self):
+        self.context = {
+            "organization": self.project.organization,
+            "project": self.project,
+            "request": self.make_request(),
+        }
+
+    def test_simple(self):
+        validator = UptimeMonitorDataSourceValidator(
+            data=self.get_valid_data(), context=self.context
+        )
+        assert validator.is_valid()
+
+    def test_bad_interval(self):
+        data = self.get_valid_data()
+        data["interval_seconds"] = 3700
+        validator = UptimeMonitorDataSourceValidator(data=data, context=self.context)
+        assert not validator.is_valid()
+
+    def test_bad_method(self):
+        data = self.get_valid_data()
+        data["method"] = "GOT"
+        validator = UptimeMonitorDataSourceValidator(data=data, context=self.context)
+        assert not validator.is_valid()
+
+    def test_bad_status(self):
+        data = self.get_valid_data()
+        data["status"] = ["ready to work!"]
+        validator = UptimeMonitorDataSourceValidator(data=data, context=self.context)
+        assert not validator.is_valid()
+
+    def test_too_many_urls(self):
+        for _ in range(0, 100):
+            UptimeSubscription.objects.create(
+                url="https://www.google.com",
+                interval_seconds=3600,
+                timeout_ms=30000,
+                status=UptimeSubscription.Status.CREATING.value,
+                url_domain="google",
+                url_domain_suffix="com",
+            )
+
+        data = self.get_valid_data()
+        data["url"] = "https://www.google.com"
+        validator = UptimeMonitorDataSourceValidator(data=data, context=self.context)
+        assert not validator.is_valid()
+        assert "You cannot create any additional alerts for this domain" in str(
+            validator.errors["url"]
+        )
+
+    def test_too_big_request(self):
+        data = self.get_valid_data()
+        data["body"] = "0" * 1000
+        validator = UptimeMonitorDataSourceValidator(data=data, context=self.context)
+        assert not validator.is_valid()

--- a/tests/sentry/uptime/endpoints/test_validators.py
+++ b/tests/sentry/uptime/endpoints/test_validators.py
@@ -1,5 +1,3 @@
-from sentry.constants import ObjectStatus
-from sentry.monitors.validators import MONITOR_STATUSES_REVERSE
 from sentry.testutils.cases import TestCase, UptimeTestCase
 from sentry.uptime.endpoints.validators import (
     UptimeMonitorDataSourceValidator,
@@ -44,10 +42,6 @@ class ComputeHttpRequestSizeTest(UptimeTestCase):
 class UptimeMonitorDataSourceValidatorTest(TestCase):
     def get_valid_data(self):
         return {
-            "name": "Name",
-            "status": MONITOR_STATUSES_REVERSE[ObjectStatus.ACTIVE],
-            "owner": self.user.name,
-            "environment": self.environment.name,
             "url": "https://www.google.com",
             "interval_seconds": UptimeSubscription.IntervalSeconds.ONE_MINUTE,
             "timeout_ms": 30000,

--- a/tests/sentry/uptime/test_grouptype.py
+++ b/tests/sentry/uptime/test_grouptype.py
@@ -22,13 +22,15 @@ from sentry.uptime.grouptype import (
     UptimeDetectorHandler,
     UptimeDomainCheckFailure,
     UptimePacketValue,
-    build_detector_fingerprint_component,
     build_event_data,
     build_evidence_display,
+)
+from sentry.uptime.models import UptimeStatus, UptimeSubscription, get_uptime_subscription
+from sentry.uptime.subscriptions.subscriptions import (
+    build_detector_fingerprint_component,
     build_fingerprint,
     resolve_uptime_issue,
 )
-from sentry.uptime.models import UptimeStatus, UptimeSubscription, get_uptime_subscription
 from sentry.uptime.types import UptimeMonitorMode
 from sentry.workflow_engine.models.data_source import DataPacket
 from sentry.workflow_engine.models.detector import Detector


### PR DESCRIPTION
I think this is broadly correct--not sure about things around seat allocation or audit trails.  The tests are obviously bare-bones, but once there's no major problems with implementation, I'll go ahead and flesh them out.

I tried to extract the common bits of functionality from the UptimeMonitorValidator, and the new grouptype validator.

There were some bits of code I had to move from uptime/grouptype due to some circular dependency issues; they wound up in subscriptions.py

