### PR TITLE
fix(ourlogs): Only allow non-tag attributes for AttributeField

### DIFF
--- a/static/app/views/explore/hooks/useTraceItemAttributeKeys.spec.tsx
+++ b/static/app/views/explore/hooks/useTraceItemAttributeKeys.spec.tsx
@@ -1,11 +1,12 @@
 import {LocationFixture} from 'sentry-fixture/locationFixture';
-import {OrganizationFixture} from 'sentry-fixture/organization';
+import {mockTraceItemAttributeKeysApi} from 'sentry-fixture/traceItemAttributeKeys';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {makeTestQueryClient} from 'sentry-test/queryClient';
 import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
+import type {Tag} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
 import {FieldKind} from 'sentry/utils/fields';
 import {QueryClientProvider} from 'sentry/utils/queryClient';
@@ -28,8 +29,8 @@ function createWrapper(organization: Organization) {
 }
 
 describe('useTraceItemAttributeKeys', () => {
-  const organization = OrganizationFixture({slug: 'org-slug'});
-  const mockAttributeKeys = [
+  const {organization} = initializeOrg();
+  const mockAttributeKeys: Tag[] = [
     {
       key: 'test.attribute1',
       name: 'Test Attribute 1',
@@ -58,7 +59,6 @@ describe('useTraceItemAttributeKeys', () => {
     mockedUsedLocation.mockReturnValue(LocationFixture());
 
     // Setup the PageFilters store with default values
-    const {organization: _initOrg} = initializeOrg();
     PageFiltersStore.init();
     PageFiltersStore.onInitializeUrlState(
       {
@@ -76,18 +76,10 @@ describe('useTraceItemAttributeKeys', () => {
   });
 
   it('fetches attribute keys correctly for string type', async () => {
-    const mockResponse = MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/trace-items/attributes/`,
-      body: mockAttributeKeys,
-      match: [
-        (_url: string, options: {query?: Record<string, any>}) => {
-          const query = options?.query || {};
-          return (
-            query.itemType === TraceItemDataset.LOGS && query.attributeType === 'string'
-          );
-        },
-      ],
-    });
+    const mockResponse = mockTraceItemAttributeKeysApi(
+      organization.slug,
+      mockAttributeKeys
+    );
 
     const {result} = renderHook(
       () =>
@@ -103,7 +95,6 @@ describe('useTraceItemAttributeKeys', () => {
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     expect(mockResponse).toHaveBeenCalled();
 
-    // Verify expected attributes (excluding sentry. prefixed ones)
     const expectedAttributes = {
       'test.attribute1': {
         key: 'test.attribute1',
@@ -142,18 +133,12 @@ describe('useTraceItemAttributeKeys', () => {
       },
     ];
 
-    const mockResponse = MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/trace-items/attributes/`,
-      body: numberAttributeKeys,
-      match: [
-        (_url: string, options: {query?: Record<string, any>}) => {
-          const query = options?.query || {};
-          return (
-            query.itemType === TraceItemDataset.LOGS && query.attributeType === 'number'
-          );
-        },
-      ],
-    });
+    const mockResponse = mockTraceItemAttributeKeysApi(
+      organization.slug,
+      numberAttributeKeys,
+      TraceItemDataset.LOGS,
+      'number'
+    );
 
     const {result} = renderHook(
       () =>
@@ -211,10 +196,7 @@ describe('useTraceItemAttributeKeys', () => {
       },
     ];
 
-    MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/trace-items/attributes/`,
-      body: attributesWithInvalidChars,
-    });
+    mockTraceItemAttributeKeysApi(organization.slug, attributesWithInvalidChars);
 
     const {result} = renderHook(
       () =>
@@ -229,7 +211,6 @@ describe('useTraceItemAttributeKeys', () => {
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    // Should only contain valid attributes
     const expectedAttributes = {
       'valid.attribute': {
         key: 'valid.attribute',
@@ -270,18 +251,10 @@ describe('useTraceItemAttributeKeys', () => {
       },
     ];
 
-    const mockResponse = MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/trace-items/attributes/`,
-      body: testAttributeKeys,
-      match: [
-        (_url: string, options: {query?: Record<string, any>}) => {
-          const query = options?.query || {};
-          return (
-            query.itemType === TraceItemDataset.LOGS && query.attributeType === 'string'
-          );
-        },
-      ],
-    });
+    const mockResponse = mockTraceItemAttributeKeysApi(
+      organization.slug,
+      testAttributeKeys
+    );
 
     const {result} = renderHook(
       () =>

--- a/static/app/views/explore/hooks/useTraceItemAttributeKeys.tsx
+++ b/static/app/views/explore/hooks/useTraceItemAttributeKeys.tsx
@@ -61,3 +61,13 @@ export function useTraceItemAttributeKeys({
     isLoading: isFetching,
   };
 }
+
+/**
+ * We want to remove attributes that have tag wrapper in some cases (eg. datascrubbing attribute field)
+ * As they are not valid in some contexts (eg. relay event selectors).
+ */
+export function elideTagBasedAttributes(attributes: TagCollection) {
+  return Object.fromEntries(
+    Object.entries(attributes).filter(([key]) => !key.startsWith('tags['))
+  );
+}

--- a/static/app/views/settings/components/dataScrubbing/modals/form/attributeField.spec.tsx
+++ b/static/app/views/settings/components/dataScrubbing/modals/form/attributeField.spec.tsx
@@ -1,53 +1,110 @@
-import {createMockAttributeResults} from 'sentry-fixture/log';
+import {LocationFixture} from 'sentry-fixture/locationFixture';
+import {mockTraceItemAttributeKeysApi} from 'sentry-fixture/traceItemAttributeKeys';
 
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import {useTraceItemAttributeKeys} from 'sentry/views/explore/hooks/useTraceItemAttributeKeys';
+import PageFiltersStore from 'sentry/stores/pageFiltersStore';
+import type {Tag} from 'sentry/types/group';
+import {FieldKind} from 'sentry/utils/fields';
+import {useLocation} from 'sentry/utils/useLocation';
 import AttributeField from 'sentry/views/settings/components/dataScrubbing/modals/form/attributeField';
 import {AllowedDataScrubbingDatasets} from 'sentry/views/settings/components/dataScrubbing/types';
 
-jest.mock('sentry/views/explore/hooks/useTraceItemAttributeKeys');
-
-const mockUseTraceItemAttributeKeys = jest.mocked(useTraceItemAttributeKeys);
+jest.mock('sentry/utils/useLocation');
+const mockedUseLocation = jest.mocked(useLocation);
 
 describe('AttributeField', () => {
-  const mockAttributeResults = createMockAttributeResults();
+  const {organization} = initializeOrg();
+  const mockAttributeKeys: Tag[] = [
+    {
+      key: 'user.email',
+      name: 'user.email',
+      kind: FieldKind.TAG,
+    },
+    {
+      key: 'user.id',
+      name: 'user.id',
+      kind: FieldKind.TAG,
+    },
+    {
+      key: 'custom.field',
+      name: 'custom.field',
+      kind: FieldKind.TAG,
+    },
+    {
+      key: 'request.method',
+      name: 'request.method',
+      kind: FieldKind.TAG,
+    },
+    {
+      key: 'response.status',
+      name: 'response.status',
+      kind: FieldKind.TAG,
+    },
+  ];
 
   beforeEach(() => {
-    const logsResult = mockAttributeResults[AllowedDataScrubbingDatasets.LOGS];
-    if (logsResult) {
-      mockUseTraceItemAttributeKeys.mockReturnValue(logsResult);
-    }
-  });
-
-  afterEach(() => {
+    MockApiClient.clearMockResponses();
     jest.clearAllMocks();
+    mockedUseLocation.mockReturnValue(LocationFixture());
+
+    // Setup the PageFilters store with default values
+    PageFiltersStore.init();
+    PageFiltersStore.onInitializeUrlState(
+      {
+        projects: [1],
+        environments: [],
+        datetime: {
+          period: '14d',
+          start: null,
+          end: null,
+          utc: false,
+        },
+      },
+      new Set()
+    );
   });
 
-  it('default render', () => {
+  it('default render', async () => {
+    mockTraceItemAttributeKeysApi(organization.slug, mockAttributeKeys);
+
+    const value = 'user.email';
     render(
       <AttributeField
         dataset={AllowedDataScrubbingDatasets.LOGS}
         onChange={jest.fn()}
-        value="user.email"
-      />
+        value={value}
+      />,
+      {organization}
     );
 
-    expect(screen.getByPlaceholderText('Select or type attribute')).toHaveValue(
-      'user.email'
-    );
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('Select or type attribute')).toHaveValue(value);
+    });
   });
 
   it('displays suggestions when input is focused', async () => {
+    mockTraceItemAttributeKeysApi(organization.slug, mockAttributeKeys);
+
+    const value = '';
     render(
       <AttributeField
         dataset={AllowedDataScrubbingDatasets.LOGS}
         onChange={jest.fn()}
-        value=""
-      />
+        value={value}
+      />,
+      {organization}
     );
 
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('Select or type attribute')).toHaveValue(value);
+    });
+
     await userEvent.click(screen.getByPlaceholderText('Select or type attribute'));
+
+    // Wait for suggestions to load
+    await screen.findByText('message');
 
     const suggestions = screen.getAllByRole('listitem');
     expect(suggestions.length).toBeGreaterThan(0);
@@ -56,15 +113,26 @@ describe('AttributeField', () => {
   });
 
   it('filters suggestions based on input value', async () => {
+    mockTraceItemAttributeKeysApi(organization.slug, mockAttributeKeys);
+
+    const value = 'user';
     render(
       <AttributeField
         dataset={AllowedDataScrubbingDatasets.LOGS}
         onChange={jest.fn()}
-        value="user"
-      />
+        value={value}
+      />,
+      {organization}
     );
 
     await userEvent.click(screen.getByPlaceholderText('Select or type attribute'));
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('Select or type attribute')).toHaveValue(value);
+    });
+
+    // Wait for suggestions to load
+    await screen.findByText('user.email');
 
     const suggestions = screen.getAllByRole('listitem');
     expect(suggestions).toHaveLength(2);
@@ -76,15 +144,26 @@ describe('AttributeField', () => {
   it('calls onChange when suggestion is clicked', async () => {
     const handleOnChange = jest.fn();
 
+    mockTraceItemAttributeKeysApi(organization.slug, mockAttributeKeys);
+
+    const value = '';
     render(
       <AttributeField
         dataset={AllowedDataScrubbingDatasets.LOGS}
         onChange={handleOnChange}
-        value=""
-      />
+        value={value}
+      />,
+      {organization}
     );
 
     await userEvent.click(screen.getByPlaceholderText('Select or type attribute'));
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('Select or type attribute')).toHaveValue(value);
+    });
+
+    // Wait for suggestions to load
+    await screen.findByText('message');
 
     const suggestions = screen.getAllByRole('listitem');
     await userEvent.click(suggestions[1]!);
@@ -94,17 +173,28 @@ describe('AttributeField', () => {
 
   it('handles keyboard navigation', async () => {
     const handleOnChange = jest.fn();
+    const value = '';
+
+    mockTraceItemAttributeKeysApi(organization.slug, mockAttributeKeys);
 
     render(
       <AttributeField
         dataset={AllowedDataScrubbingDatasets.LOGS}
         onChange={handleOnChange}
-        value=""
-      />
+        value={value}
+      />,
+      {organization}
     );
 
     const input = screen.getByPlaceholderText('Select or type attribute');
     await userEvent.click(input);
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('Select or type attribute')).toHaveValue(value);
+    });
+
+    // Wait for suggestions to load
+    await screen.findByText('message');
 
     await userEvent.keyboard('{ArrowDown}{ArrowDown}{Enter}');
 
@@ -113,17 +203,27 @@ describe('AttributeField', () => {
 
   it('handles keyboard navigation with arrow up', async () => {
     const handleOnChange = jest.fn();
+    const value = '';
+    mockTraceItemAttributeKeysApi(organization.slug, mockAttributeKeys);
 
     render(
       <AttributeField
         dataset={AllowedDataScrubbingDatasets.LOGS}
         onChange={handleOnChange}
-        value=""
-      />
+        value={value}
+      />,
+      {organization}
     );
 
     const input = screen.getByPlaceholderText('Select or type attribute');
     await userEvent.click(input);
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('Select or type attribute')).toHaveValue(value);
+    });
+
+    // Wait for suggestions to load
+    await screen.findByText('message');
 
     await userEvent.keyboard('{ArrowDown}{ArrowDown}{ArrowUp}{Enter}');
 
@@ -131,17 +231,26 @@ describe('AttributeField', () => {
   });
 
   it('closes suggestions on escape key', async () => {
+    mockTraceItemAttributeKeysApi(organization.slug, mockAttributeKeys);
+    const value = '';
     render(
       <AttributeField
         dataset={AllowedDataScrubbingDatasets.LOGS}
         onChange={jest.fn()}
-        value=""
-      />
+        value={value}
+      />,
+      {organization}
     );
 
     const input = screen.getByPlaceholderText('Select or type attribute');
     await userEvent.click(input);
 
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('Select or type attribute')).toHaveValue(value);
+    });
+
+    // Wait for suggestions to load
+    await screen.findByText('message');
     expect(screen.getAllByRole('listitem').length).toBeGreaterThan(0);
 
     await userEvent.keyboard('{Escape}');
@@ -151,16 +260,22 @@ describe('AttributeField', () => {
 
   it('calls onBlur when input loses focus', async () => {
     const handleOnBlur = jest.fn();
+    const value = 'test';
+    mockTraceItemAttributeKeysApi(organization.slug, mockAttributeKeys);
 
     render(
       <AttributeField
         dataset={AllowedDataScrubbingDatasets.LOGS}
         onChange={jest.fn()}
         onBlur={handleOnBlur}
-        value="test"
-      />
+        value={value}
+      />,
+      {organization}
     );
 
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('Select or type attribute')).toHaveValue(value);
+    });
     const input = screen.getByPlaceholderText('Select or type attribute');
     await userEvent.click(input);
     await userEvent.tab();
@@ -170,15 +285,21 @@ describe('AttributeField', () => {
 
   it('handles typing in input field', async () => {
     const handleOnChange = jest.fn();
+    const value = '';
+    mockTraceItemAttributeKeysApi(organization.slug, mockAttributeKeys);
 
     render(
       <AttributeField
         dataset={AllowedDataScrubbingDatasets.LOGS}
         onChange={handleOnChange}
-        value=""
-      />
+        value={value}
+      />,
+      {organization}
     );
 
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('Select or type attribute')).toHaveValue(value);
+    });
     const input = screen.getByPlaceholderText('Select or type attribute');
     await userEvent.type(input, 'custom');
 
@@ -191,32 +312,101 @@ describe('AttributeField', () => {
   });
 
   it('limits suggestions to 50 items', async () => {
-    const manyAttributes: Record<string, any> = {};
+    // Create many mock attributes
+    const value = '';
+    const manyAttributes: Tag[] = [];
     for (let i = 0; i < 100; i++) {
-      manyAttributes[`attr${i}`] = {
+      manyAttributes.push({
         key: `attr${i}`,
         name: `attr${i}`,
-        kind: 'TAG',
-      };
+        kind: FieldKind.TAG,
+      });
     }
 
-    mockUseTraceItemAttributeKeys.mockReturnValue({
-      attributes: manyAttributes,
-      isLoading: false,
-      error: null,
-    });
+    mockTraceItemAttributeKeysApi(organization.slug, manyAttributes);
 
     render(
       <AttributeField
         dataset={AllowedDataScrubbingDatasets.LOGS}
         onChange={jest.fn()}
-        value=""
-      />
+        value={value}
+      />,
+      {organization}
     );
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('Select or type attribute')).toHaveValue(value);
+    });
 
     await userEvent.click(screen.getByPlaceholderText('Select or type attribute'));
 
+    await screen.findByText('message');
+
     const suggestions = screen.getAllByRole('listitem');
     expect(suggestions).toHaveLength(50);
+  });
+
+  it('filters out tag-based attributes using elideTagBasedAttributes', async () => {
+    const value = '';
+    const attributesWithTags: Tag[] = [
+      {
+        key: 'user.email',
+        name: 'user.email',
+        kind: FieldKind.TAG,
+      },
+      {
+        key: 'tags[environment,string]',
+        name: 'tags[environment,string]',
+        kind: FieldKind.TAG,
+      },
+      {
+        key: 'tags[id,string]',
+        name: 'tags[id,string]',
+        kind: FieldKind.TAG,
+      },
+      {
+        key: 'tags[message,string]',
+        name: 'tags[message,string]',
+        kind: FieldKind.TAG,
+      },
+      {
+        key: 'tags[project_id,string]',
+        name: 'tags[project_id,string]',
+        kind: FieldKind.TAG,
+      },
+      {
+        key: 'custom.field',
+        name: 'custom.field',
+        kind: FieldKind.TAG,
+      },
+    ];
+
+    MockApiClient.clearMockResponses();
+    mockTraceItemAttributeKeysApi(organization.slug, attributesWithTags);
+
+    render(
+      <AttributeField
+        dataset={AllowedDataScrubbingDatasets.LOGS}
+        onChange={jest.fn()}
+        value={value}
+      />,
+      {organization}
+    );
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('Select or type attribute')).toHaveValue(value);
+    });
+
+    await screen.findByPlaceholderText('Select or type attribute');
+
+    await userEvent.click(screen.getByPlaceholderText('Select or type attribute'));
+
+    await screen.findByText('message');
+
+    const suggestions = screen.getAllByRole('listitem');
+    const suggestionTexts = suggestions.map(item => item.textContent);
+
+    // Should not contain any tags
+    expect(suggestionTexts).toEqual(['message', 'user.email', 'custom.field']);
   });
 });

--- a/static/app/views/settings/components/dataScrubbing/modals/form/attributeField.tsx
+++ b/static/app/views/settings/components/dataScrubbing/modals/form/attributeField.tsx
@@ -64,6 +64,8 @@ export default function AttributeField({
       !traceItemAttributeStringsResult.isLoading &&
       !traceItemAttributeStringsResult.error
     ) {
+      // This limits the attributes you can see when selecting for pii scrubbing, but we have to currently as tags[] syntax is strictly invalid.
+      // We should address this ultimately via fixing the trace item keys endpoint to emit the stored/relay-esque syntax at some point, instead of frontend hacks.
       setSuggestedAttributeValues(
         elideTagBasedAttributes(traceItemAttributeStringsResult.attributes)
       );

--- a/static/app/views/settings/components/dataScrubbing/modals/form/attributeField.tsx
+++ b/static/app/views/settings/components/dataScrubbing/modals/form/attributeField.tsx
@@ -11,7 +11,10 @@ import type {TagCollection} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import useProjects from 'sentry/utils/useProjects';
-import {useTraceItemAttributeKeys} from 'sentry/views/explore/hooks/useTraceItemAttributeKeys';
+import {
+  elideTagBasedAttributes,
+  useTraceItemAttributeKeys,
+} from 'sentry/views/explore/hooks/useTraceItemAttributeKeys';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 import {
   AllowedDataScrubbingDatasets,
@@ -48,7 +51,7 @@ export default function AttributeField({
     projects: project ? [project] : undefined,
   });
   const [suggestedAttributeValues, setSuggestedAttributeValues] = useLocalStorageState(
-    `advanced-data-scrubbing.suggested-attribute-values:${projectId ? projectId : 'all'}`,
+    `advanced-data-scrubbing.suggested-attribute-values:v2:${projectId ? projectId : 'all'}`,
     {} as TagCollection
   );
 
@@ -61,7 +64,9 @@ export default function AttributeField({
       !traceItemAttributeStringsResult.isLoading &&
       !traceItemAttributeStringsResult.error
     ) {
-      setSuggestedAttributeValues(traceItemAttributeStringsResult.attributes);
+      setSuggestedAttributeValues(
+        elideTagBasedAttributes(traceItemAttributeStringsResult.attributes)
+      );
     }
   }, [
     onChange,

--- a/tests/js/fixtures/traceItemAttributeKeys.ts
+++ b/tests/js/fixtures/traceItemAttributeKeys.ts
@@ -1,0 +1,20 @@
+import type {Tag} from 'sentry/types/group';
+import {TraceItemDataset} from 'sentry/views/explore/types';
+
+export function mockTraceItemAttributeKeysApi(
+  orgSlug: string,
+  attributeKeys: Tag[],
+  itemType: TraceItemDataset = TraceItemDataset.LOGS,
+  attributeType: 'string' | 'number' = 'string'
+) {
+  return MockApiClient.addMockResponse({
+    url: `/organizations/${orgSlug}/trace-items/attributes/`,
+    body: attributeKeys,
+    match: [
+      (_url: string, options: {query?: Record<string, any>}) => {
+        const query = options?.query || {};
+        return query.itemType === itemType && query.attributeType === attributeType;
+      },
+    ],
+  });
+}


### PR DESCRIPTION
### Summary
The tag internal syntax only works for the discover resolver, it is not valid as a selector in Relay.

Other in this PR:
- Added a mock for trace item keys for re-use.
