### PR TITLE
feat(on-demand): Add feature flag check before cardinality check

### DIFF
--- a/src/sentry/tasks/on_demand_metrics.py
+++ b/src/sentry/tasks/on_demand_metrics.py
@@ -8,7 +8,7 @@ import sentry_sdk
 from celery.exceptions import SoftTimeLimitExceeded
 from django.utils import timezone
 
-from sentry import options
+from sentry import features, options
 from sentry.models.dashboard_widget import (
     DashboardWidgetQuery,
     DashboardWidgetQueryOnDemand,
@@ -423,6 +423,9 @@ def check_field_cardinality(
     is_task: bool = False,
     widget_query: DashboardWidgetQuery | None = None,
 ) -> dict[str, str]:
+    if not features.has("organizations:on-demand-metrics-extraction-widgets", organization):
+        return {}
+
     if not query_columns:
         return {}
     if is_task:

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
@@ -3132,7 +3132,9 @@ class OrganizationDashboardDetailsOnDemandTest(OrganizationDashboardDetailsTestC
             assert current_version.extraction_state == "enabled:creation"
 
     @mock.patch("sentry.tasks.on_demand_metrics._query_cardinality")
-    def test_cardinality_precedence_over_feature_checks(self, mock_query: mock.MagicMock) -> None:
+    def test_feature_check_takes_precedence_over_cardinality(
+        self, mock_query: mock.MagicMock
+    ) -> None:
         mock_query.return_value = {"data": [{"count_unique(sometag)": 1_000_000}]}, [
             "sometag",
         ]
@@ -3169,7 +3171,7 @@ class OrganizationDashboardDetailsOnDemandTest(OrganizationDashboardDetailsTestC
         for version in OnDemandMetricSpecVersioning.get_spec_versions():
             current_version = ondemand_objects.filter(spec_version=version.version).first()
             assert current_version is not None
-            assert current_version.extraction_state == "disabled:high-cardinality"
+            assert current_version.extraction_state == "disabled:pre-rollout"
 
     @mock.patch("sentry.api.serializers.rest_framework.dashboard.get_current_widget_specs")
     def test_cardinality_skips_non_discover_widget_types(

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
@@ -3132,6 +3132,48 @@ class OrganizationDashboardDetailsOnDemandTest(OrganizationDashboardDetailsTestC
             assert current_version.extraction_state == "enabled:creation"
 
     @mock.patch("sentry.tasks.on_demand_metrics._query_cardinality")
+    def test_cardinality_check_with_feature_flag(self, mock_query: mock.MagicMock) -> None:
+        mock_query.return_value = {"data": [{"count_unique(sometag)": 1_000_000}]}, [
+            "sometag",
+        ]
+        data: dict[str, Any] = {
+            "title": "first dashboard",
+            "widgets": [
+                {
+                    "title": "errors per project",
+                    "displayType": "table",
+                    "interval": "5m",
+                    "widgetType": DashboardWidgetTypes.get_type_name(self.widget_type),
+                    "queries": [
+                        {
+                            "name": "errors",
+                            "fields": ["count()", "sometag"],
+                            "columns": ["sometag"],
+                            "aggregates": ["count()"],
+                            "conditions": "event.type:transaction",
+                        }
+                    ],
+                },
+            ],
+        }
+
+        with self.feature(["organizations:on-demand-metrics-extraction-widgets"]):
+            response = self.do_request("put", self.url(self.dashboard.id), data=data)
+        assert response.status_code == 200, response.data
+        widgets = self.get_widgets(self.dashboard.id)
+        assert len(widgets) == 1
+        last = list(widgets).pop()
+        queries = last.dashboardwidgetquery_set.all()
+
+        ondemand_objects = DashboardWidgetQueryOnDemand.objects.filter(
+            dashboard_widget_query=queries[0]
+        )
+        for version in OnDemandMetricSpecVersioning.get_spec_versions():
+            current_version = ondemand_objects.filter(spec_version=version.version).first()
+            assert current_version is not None
+            assert current_version.extraction_state == "disabled:high-cardinality"
+
+    @mock.patch("sentry.tasks.on_demand_metrics._query_cardinality")
     def test_feature_check_takes_precedence_over_cardinality(
         self, mock_query: mock.MagicMock
     ) -> None:


### PR DESCRIPTION
Some users are experiencing high latency due to this cardinality check. Since metrics extraction for widgets has paused and we're in the process of migrating users to spans/EAP, I figured we could avoid running this check for users that do not have the feature flag if we're not planning to continue rolling it out.

e.g. [this trace](https://sentry.sentry.io/explore/traces/trace/0cb58686696d43dc941cfc85063a6c20/?aggregateField=%7B%22groupBy%22%3A%22%22%7D&aggregateField=%7B%22yAxes%22%3A%5B%22p99%28span.duration%29%22%5D%7D&field=id&field=span.op&field=span.description&field=span.duration&field=transaction&field=timestamp&field=transaction.method&fov=0%2C19733.5478515625&node=span-be1da64ea1567f2a&project=1&query=is_transaction%3ATrue%20transaction%3A%5B%2Fapi%2F0%2Forganizations%2F%7Borganization_id_or_slug%7D%2Fdashboards%2F%7Bdashboard_id%7D%2F%2C%2Fapi%2F0%2Forganizations%2F%7Borganization_id_or_slug%7D%2Fdashboards%2F%5D%20transaction.method%3A%5BPUT%2CPOST%5D&sort=-span.duration&source=traces&statsPeriod=7d&targetId=be1da64ea1567f2a&timestamp=1756909738) shows 15s waiting for the cardinality check for an org that doesn't have access