### PR TITLE
feat(explore): Use query params for spans aggregate fields

### DIFF
--- a/static/app/views/explore/contexts/pageParamsContext/aggregateFields.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/aggregateFields.tsx
@@ -41,7 +41,6 @@ export function isVisualize(value: any): value is Visualize {
   );
 }
 
-export type BaseAggregateField = GroupBy | BaseVisualize;
 export type AggregateField = GroupBy | Visualize;
 
 export function defaultAggregateFields(): AggregateField[] {

--- a/static/app/views/explore/contexts/pageParamsContext/index.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/index.tsx
@@ -22,7 +22,7 @@ import {
   updateLocationWithId,
 } from 'sentry/views/explore/contexts/pageParamsContext/id';
 
-import type {AggregateField, BaseAggregateField, GroupBy} from './aggregateFields';
+import type {AggregateField, GroupBy} from './aggregateFields';
 import {
   defaultAggregateFields,
   getAggregateFieldsFromLocation,
@@ -247,28 +247,6 @@ export function useExplorePageParams(): ReadablePageParams {
 
 export function useExploreDataset(): DiscoverDatasets {
   return DiscoverDatasets.SPANS;
-}
-
-interface UseExploreAggregateFieldsOptions {
-  validate?: boolean;
-}
-
-export function useExploreAggregateFields(
-  options?: UseExploreAggregateFieldsOptions
-): AggregateField[] {
-  const {validate = false} = options || {};
-  const pageParams = useExplorePageParams();
-  return useMemo(() => {
-    if (validate) {
-      return pageParams.aggregateFields.filter(aggregateField => {
-        if (isVisualize(aggregateField)) {
-          return aggregateField.isValid();
-        }
-        return true;
-      });
-    }
-    return pageParams.aggregateFields;
-  }, [pageParams.aggregateFields, validate]);
 }
 
 export function useExploreFields(): string[] {
@@ -548,16 +526,6 @@ export function useSetExplorePageParams(): (
       navigate(target);
     },
     [location, navigate, readablePageParams, managedFields, setManagedFields]
-  );
-}
-
-export function useSetExploreAggregateFields() {
-  const setPageParams = useSetExplorePageParams();
-  return useCallback(
-    (aggregateFields: BaseAggregateField[]) => {
-      setPageParams({aggregateFields});
-    },
-    [setPageParams]
   );
 }
 

--- a/static/app/views/explore/hooks/useExploreAggregatesTable.tsx
+++ b/static/app/views/explore/hooks/useExploreAggregatesTable.tsx
@@ -5,7 +5,6 @@ import {defined} from 'sentry/utils';
 import EventView from 'sentry/utils/discover/eventView';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {
-  useExploreAggregateFields,
   useExploreDataset,
   useExploreSortBys,
 } from 'sentry/views/explore/contexts/pageParamsContext';
@@ -13,6 +12,7 @@ import {isGroupBy} from 'sentry/views/explore/contexts/pageParamsContext/aggrega
 import {formatSort} from 'sentry/views/explore/contexts/pageParamsContext/sortBys';
 import type {SpansRPCQueryExtras} from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {useProgressiveQuery} from 'sentry/views/explore/hooks/useProgressiveQuery';
+import {useQueryParamsAggregateFields} from 'sentry/views/explore/queryParams/context';
 import {useSpansQuery} from 'sentry/views/insights/common/queries/useSpansQuery';
 
 interface UseExploreAggregatesTableOptions {
@@ -59,7 +59,7 @@ function useExploreAggregatesTableImp({
   const {selection} = usePageFilters();
 
   const dataset = useExploreDataset();
-  const aggregateFields = useExploreAggregateFields({validate: true});
+  const aggregateFields = useQueryParamsAggregateFields({validate: true});
   const sorts = useExploreSortBys();
 
   const fields = useMemo(() => {

--- a/static/app/views/explore/queryParams/visualize.ts
+++ b/static/app/views/explore/queryParams/visualize.ts
@@ -71,7 +71,7 @@ export class VisualizeFunction extends Visualize {
   }
 }
 
-class VisualizeEquation extends Visualize {
+export class VisualizeEquation extends Visualize {
   readonly kind = 'equation';
   readonly expression: Expression;
 
@@ -131,6 +131,12 @@ export function isVisualizeFunction(
   visualize: Visualize
 ): visualize is VisualizeFunction {
   return visualize.kind === 'function';
+}
+
+export function isVisualizeEquation(
+  visualize: Visualize
+): visualize is VisualizeEquation {
+  return visualize.kind === 'equation';
 }
 
 export interface BaseVisualize {

--- a/static/app/views/explore/spans/spansQueryParams.tsx
+++ b/static/app/views/explore/spans/spansQueryParams.tsx
@@ -13,6 +13,7 @@ import {
   getGroupBysFromLocation,
   isGroupBy,
 } from 'sentry/views/explore/queryParams/groupBy';
+import {updateNullableLocation} from 'sentry/views/explore/queryParams/location';
 import {getModeFromLocation} from 'sentry/views/explore/queryParams/mode';
 import {getQueryFromLocation} from 'sentry/views/explore/queryParams/query';
 import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
@@ -23,6 +24,7 @@ import {
   isVisualize,
   VisualizeFunction,
 } from 'sentry/views/explore/queryParams/visualize';
+import type {WritableQueryParams} from 'sentry/views/explore/queryParams/writableQueryParams';
 import {SpanFields} from 'sentry/views/insights/types';
 
 const SPANS_MODE_KEY = 'mode';
@@ -69,6 +71,23 @@ export function getReadableQueryParamsFromLocation(
     aggregateFields,
     aggregateSortBys,
   });
+}
+
+export function getTargetWithReadableQueryParams(
+  location: Location,
+  writableQueryParams: WritableQueryParams
+): Location {
+  const target: Location = {...location, query: {...location.query}};
+
+  updateNullableLocation(
+    target,
+    SPANS_AGGREGATE_FIELD_KEY,
+    writableQueryParams.aggregateFields?.map(aggregateField =>
+      JSON.stringify(aggregateField)
+    )
+  );
+
+  return target;
 }
 
 function defaultFields(organization: Organization): string[] {

--- a/static/app/views/explore/spans/spansQueryParamsProvider.tsx
+++ b/static/app/views/explore/spans/spansQueryParamsProvider.tsx
@@ -2,10 +2,14 @@ import type {ReactNode} from 'react';
 import {useCallback, useMemo} from 'react';
 
 import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {QueryParamsContextProvider} from 'sentry/views/explore/queryParams/context';
 import type {WritableQueryParams} from 'sentry/views/explore/queryParams/writableQueryParams';
-import {getReadableQueryParamsFromLocation} from 'sentry/views/explore/spans/spansQueryParams';
+import {
+  getReadableQueryParamsFromLocation,
+  getTargetWithReadableQueryParams,
+} from 'sentry/views/explore/spans/spansQueryParams';
 
 interface SpansQueryParamsProviderProps {
   children: ReactNode;
@@ -13,6 +17,7 @@ interface SpansQueryParamsProviderProps {
 
 export function SpansQueryParamsProvider({children}: SpansQueryParamsProviderProps) {
   const location = useLocation();
+  const navigate = useNavigate();
   const organization = useOrganization();
 
   const readableQueryParams = useMemo(
@@ -21,10 +26,11 @@ export function SpansQueryParamsProvider({children}: SpansQueryParamsProviderPro
   );
 
   const setWritableQueryParams = useCallback(
-    (_writableQueryParams: WritableQueryParams) => {
-      // TODO
+    (writableQueryParams: WritableQueryParams) => {
+      const target = getTargetWithReadableQueryParams(location, writableQueryParams);
+      navigate(target);
     },
-    []
+    [location, navigate]
   );
 
   return (

--- a/static/app/views/explore/tables/aggregateColumnEditorModal.spec.tsx
+++ b/static/app/views/explore/tables/aggregateColumnEditorModal.spec.tsx
@@ -11,12 +11,10 @@ import {openModal} from 'sentry/actionCreators/modal';
 import type {TagCollection} from 'sentry/types/group';
 import {parseFunction} from 'sentry/utils/discover/fields';
 import {FieldKind} from 'sentry/utils/fields';
-import type {AggregateField} from 'sentry/views/explore/contexts/pageParamsContext/aggregateFields';
 import {isGroupBy} from 'sentry/views/explore/contexts/pageParamsContext/aggregateFields';
-import {
-  DEFAULT_VISUALIZATION,
-  Visualize,
-} from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
+import {DEFAULT_VISUALIZATION} from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
+import type {AggregateField} from 'sentry/views/explore/queryParams/aggregateField';
+import {VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
 import {AggregateColumnEditorModal} from 'sentry/views/explore/tables/aggregateColumnEditorModal';
 
 const stringTags: TagCollection = {
@@ -76,7 +74,7 @@ describe('AggregateColumnEditorModal', () => {
         modalProps => (
           <AggregateColumnEditorModal
             {...modalProps}
-            columns={[{groupBy: ''}, new Visualize(DEFAULT_VISUALIZATION)]}
+            columns={[{groupBy: ''}, new VisualizeFunction(DEFAULT_VISUALIZATION)]}
             onColumnsChange={() => {}}
             stringTags={stringTags}
             numberTags={numberTags}
@@ -104,8 +102,8 @@ describe('AggregateColumnEditorModal', () => {
             columns={[
               {groupBy: 'geo.country'},
               {groupBy: 'geo.region'},
-              new Visualize('count(span.duration)'),
-              new Visualize('avg(span.self_time)'),
+              new VisualizeFunction('count(span.duration)'),
+              new VisualizeFunction('avg(span.self_time)'),
             ]}
             onColumnsChange={onColumnsChange}
             stringTags={stringTags}
@@ -122,8 +120,8 @@ describe('AggregateColumnEditorModal', () => {
     expectRows(rows).toHaveAggregateFields([
       {groupBy: 'geo.country'},
       {groupBy: 'geo.region'},
-      new Visualize('count(span.duration)'),
-      new Visualize('avg(span.self_time)'),
+      new VisualizeFunction('count(span.duration)'),
+      new VisualizeFunction('avg(span.self_time)'),
     ]);
 
     await userEvent.click(screen.getAllByLabelText('Remove Column')[0]!);
@@ -131,8 +129,8 @@ describe('AggregateColumnEditorModal', () => {
     rows = await screen.findAllByTestId('editor-row');
     expectRows(rows).toHaveAggregateFields([
       {groupBy: 'geo.region'},
-      new Visualize('count(span.duration)'),
-      new Visualize('avg(span.self_time)'),
+      new VisualizeFunction('count(span.duration)'),
+      new VisualizeFunction('avg(span.self_time)'),
     ]);
 
     // only 1 group by remaining, disable the delete option
@@ -143,7 +141,7 @@ describe('AggregateColumnEditorModal', () => {
     rows = await screen.findAllByTestId('editor-row');
     expectRows(rows).toHaveAggregateFields([
       {groupBy: 'geo.region'},
-      new Visualize('avg(span.self_time)'),
+      new VisualizeFunction('avg(span.self_time)'),
     ]);
 
     // 1 group by and visualize remaining so both should be disabled
@@ -168,7 +166,10 @@ describe('AggregateColumnEditorModal', () => {
         modalProps => (
           <AggregateColumnEditorModal
             {...modalProps}
-            columns={[{groupBy: 'geo.country'}, new Visualize(DEFAULT_VISUALIZATION)]}
+            columns={[
+              {groupBy: 'geo.country'},
+              new VisualizeFunction(DEFAULT_VISUALIZATION),
+            ]}
             onColumnsChange={onColumnsChange}
             stringTags={stringTags}
             numberTags={numberTags}
@@ -183,7 +184,7 @@ describe('AggregateColumnEditorModal', () => {
     rows = await screen.findAllByTestId('editor-row');
     expectRows(rows).toHaveAggregateFields([
       {groupBy: 'geo.country'},
-      new Visualize('count(span.duration)'),
+      new VisualizeFunction('count(span.duration)'),
     ]);
 
     await userEvent.click(screen.getByRole('button', {name: 'Add a Column'}));
@@ -194,7 +195,7 @@ describe('AggregateColumnEditorModal', () => {
     rows = await screen.findAllByTestId('editor-row');
     expectRows(rows).toHaveAggregateFields([
       {groupBy: 'geo.country'},
-      new Visualize('count(span.duration)'),
+      new VisualizeFunction('count(span.duration)'),
       {groupBy: ''},
     ]);
 
@@ -206,9 +207,9 @@ describe('AggregateColumnEditorModal', () => {
     rows = await screen.findAllByTestId('editor-row');
     expectRows(rows).toHaveAggregateFields([
       {groupBy: 'geo.country'},
-      new Visualize('count(span.duration)'),
+      new VisualizeFunction('count(span.duration)'),
       {groupBy: ''},
-      new Visualize('count(span.duration)'),
+      new VisualizeFunction('count(span.duration)'),
     ]);
 
     await userEvent.click(screen.getByRole('button', {name: 'Apply'}));
@@ -231,7 +232,10 @@ describe('AggregateColumnEditorModal', () => {
         modalProps => (
           <AggregateColumnEditorModal
             {...modalProps}
-            columns={[{groupBy: 'geo.country'}, new Visualize(DEFAULT_VISUALIZATION)]}
+            columns={[
+              {groupBy: 'geo.country'},
+              new VisualizeFunction(DEFAULT_VISUALIZATION),
+            ]}
             onColumnsChange={onColumnsChange}
             stringTags={stringTags}
             numberTags={numberTags}
@@ -246,7 +250,7 @@ describe('AggregateColumnEditorModal', () => {
     rows = await screen.findAllByTestId('editor-row');
     expectRows(rows).toHaveAggregateFields([
       {groupBy: 'geo.country'},
-      new Visualize('count(span.duration)'),
+      new VisualizeFunction('count(span.duration)'),
     ]);
 
     const options: string[] = [
@@ -269,7 +273,7 @@ describe('AggregateColumnEditorModal', () => {
     rows = await screen.findAllByTestId('editor-row');
     expectRows(rows).toHaveAggregateFields([
       {groupBy: 'geo.city'},
-      new Visualize('count(span.duration)'),
+      new VisualizeFunction('count(span.duration)'),
     ]);
 
     await userEvent.click(screen.getByRole('button', {name: 'Apply'}));
@@ -295,7 +299,10 @@ describe('AggregateColumnEditorModal', () => {
         modalProps => (
           <AggregateColumnEditorModal
             {...modalProps}
-            columns={[{groupBy: 'geo.country'}, new Visualize(DEFAULT_VISUALIZATION)]}
+            columns={[
+              {groupBy: 'geo.country'},
+              new VisualizeFunction(DEFAULT_VISUALIZATION),
+            ]}
             onColumnsChange={onColumnsChange}
             stringTags={stringTags}
             numberTags={numberTags}

--- a/static/app/views/explore/tables/aggregatesTable.tsx
+++ b/static/app/views/explore/tables/aggregatesTable.tsx
@@ -31,7 +31,6 @@ import {
   useTableStyles,
 } from 'sentry/views/explore/components/table';
 import {
-  useExploreAggregateFields,
   useExploreFields,
   useExploreGroupBys,
   useExploreQuery,
@@ -44,7 +43,10 @@ import {useTraceItemTags} from 'sentry/views/explore/contexts/spanTagsContext';
 import type {AggregatesTableResult} from 'sentry/views/explore/hooks/useExploreAggregatesTable';
 import {usePaginationAnalytics} from 'sentry/views/explore/hooks/usePaginationAnalytics';
 import {TOP_EVENTS_LIMIT, useTopEvents} from 'sentry/views/explore/hooks/useTopEvents';
-import {useQueryParamsAggregateCursor} from 'sentry/views/explore/queryParams/context';
+import {
+  useQueryParamsAggregateCursor,
+  useQueryParamsAggregateFields,
+} from 'sentry/views/explore/queryParams/context';
 import {prettifyAggregation, viewSamplesTarget} from 'sentry/views/explore/utils';
 
 import {FieldRenderer} from './fieldRenderer';
@@ -61,7 +63,7 @@ export function AggregatesTable({aggregatesTableResult}: AggregatesTableProps) {
   const {result, eventView} = aggregatesTableResult;
 
   const topEvents = useTopEvents();
-  const aggregateFields = useExploreAggregateFields();
+  const aggregateFields = useQueryParamsAggregateFields();
   const fields = useExploreFields();
   const groupBys = useExploreGroupBys();
   const visualizes = useExploreVisualizes();

--- a/static/app/views/explore/tables/index.tsx
+++ b/static/app/views/explore/tables/index.tsx
@@ -11,9 +11,7 @@ import {space} from 'sentry/styles/space';
 import type {Confidence} from 'sentry/types/organization';
 import useOrganization from 'sentry/utils/useOrganization';
 import {
-  useExploreAggregateFields,
   useExploreFields,
-  useSetExploreAggregateFields,
   useSetExploreFields,
 } from 'sentry/views/explore/contexts/pageParamsContext';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
@@ -22,6 +20,10 @@ import type {AggregatesTableResult} from 'sentry/views/explore/hooks/useExploreA
 import type {SpansTableResult} from 'sentry/views/explore/hooks/useExploreSpansTable';
 import type {TracesTableResult} from 'sentry/views/explore/hooks/useExploreTracesTable';
 import {Tab} from 'sentry/views/explore/hooks/useTab';
+import {
+  useQueryParamsAggregateFields,
+  useSetQueryParamsAggregateFields,
+} from 'sentry/views/explore/queryParams/context';
 import {AggregateColumnEditorModal} from 'sentry/views/explore/tables/aggregateColumnEditorModal';
 import {AggregatesTable} from 'sentry/views/explore/tables/aggregatesTable';
 import {ColumnEditorModal} from 'sentry/views/explore/tables/columnEditorModal';
@@ -43,8 +45,8 @@ interface ExploreTablesProps extends BaseExploreTablesProps {
 export function ExploreTables(props: ExploreTablesProps) {
   const organization = useOrganization();
 
-  const aggregateFields = useExploreAggregateFields();
-  const setAggregateFields = useSetExploreAggregateFields();
+  const aggregateFields = useQueryParamsAggregateFields();
+  const setAggregateFields = useSetQueryParamsAggregateFields();
 
   const fields = useExploreFields();
   const setFields = useSetExploreFields();
@@ -72,7 +74,7 @@ export function ExploreTables(props: ExploreTablesProps) {
       modalProps => (
         <AggregateColumnEditorModal
           {...modalProps}
-          columns={aggregateFields}
+          columns={aggregateFields.slice()}
           onColumnsChange={setAggregateFields}
           stringTags={stringTags}
           numberTags={numberTags}


### PR DESCRIPTION
This migrates explore traces to use query params for the aggregate fields.