### PR TITLE
fix(typing): Remove sentry_plugins.jira.plugin from problem list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -324,7 +324,6 @@ module = [
     "sentry.services.eventstore.models",
     "sentry.snuba.metrics.query_builder",
     "sentry.testutils.cases",
-    "sentry_plugins.jira.plugin",
     "tests.sentry.api.helpers.test_group_index",
     "tests.sentry.issues.test_utils",
 ]

--- a/src/sentry/plugins/bases/issue2.py
+++ b/src/sentry/plugins/bases/issue2.py
@@ -170,6 +170,9 @@ class IssueTrackingPlugin2(Plugin):
         """
         If overriding, supported properties include 'readonly': true
         """
+        return self._get_new_issue_fields_impl(group, event)
+
+    def _get_new_issue_fields_impl(self, group, event):
         return [
             {
                 "name": "title",

--- a/src/sentry_plugins/jira/plugin.py
+++ b/src/sentry_plugins/jira/plugin.py
@@ -134,8 +134,8 @@ class JiraPlugin(CorePluginMixin, IssuePlugin2):
 
         return issue_type_meta
 
-    def get_new_issue_fields(self, request: Request, group, event, **kwargs):
-        fields = super().get_new_issue_fields(request, group, event, **kwargs)
+    def get_new_issue_fields(self, request: Request | None, group, event, **kwargs):
+        fields = super()._get_new_issue_fields_impl(group, event)
 
         jira_project_key = self.get_option("default_project", group.project)
 
@@ -414,7 +414,7 @@ class JiraPlugin(CorePluginMixin, IssuePlugin2):
             message += " ".join(f"{k}: {v}" for k, v in data.get("errors").items())
         return message
 
-    def create_issue(self, request: Request, group, form_data):
+    def create_issue(self, request: Request | None, group, form_data):
         cleaned_data = {}
 
         # protect against mis-configured plugin submitting a form without an
@@ -678,7 +678,7 @@ class JiraPlugin(CorePluginMixin, IssuePlugin2):
             )
 
         try:
-            issue_id = self.create_issue(request={}, group=group, form_data=post_data)
+            issue_id = self.create_issue(request=None, group=group, form_data=post_data)
         except PluginError as e:
             logger.info("post_process.fail", extra={"error": str(e)})
         else:


### PR DESCRIPTION
Made minimal changes to allow mypy to pass with the file removed from the problem list.

Notably, the base class method doesn't actually require the `Request`, so I split it out into an `_impl` method so that the child class could call in without one (while maintaining the existing function type signature through the hierarchy).

Test plan: `mypy` no errors
