### PR TITLE
feat(ourlogs): Re-add setup logs

### DIFF
--- a/static/app/utils/analytics/logsAnalyticsEvent.tsx
+++ b/static/app/utils/analytics/logsAnalyticsEvent.tsx
@@ -18,9 +18,6 @@ export type LogsAnalyticsEventParameters = {
     page_source: LogsAnalyticsPageSource;
     toggleState: 'enabled' | 'disabled';
   };
-  'logs.doc_link.clicked': {
-    organization: Organization;
-  };
   'logs.explorer.metadata': {
     columns: readonly string[];
     columns_count: number;
@@ -39,6 +36,11 @@ export type LogsAnalyticsEventParameters = {
     table_result_sort: string[];
     user_queries: string;
     user_queries_count: number;
+  };
+  'logs.explorer.setup_button_clicked': {
+    organization: Organization;
+    platform: PlatformKey | 'unknown';
+    supports_onboarding_checklist: boolean;
   };
   'logs.issue_details.drawer_opened': {
     organization: Organization;
@@ -95,7 +97,7 @@ type LogsAnalyticsEventKey = keyof LogsAnalyticsEventParameters;
 export const logsAnalyticsEventMap: Record<LogsAnalyticsEventKey, string | null> = {
   'logs.auto_refresh.timeout': 'Log Auto-refresh Timeout',
   'logs.auto_refresh.toggled': 'Log Auto-refresh Toggled',
-  'logs.doc_link.clicked': 'Logs documentation link clicked',
+  'logs.explorer.setup_button_clicked': 'Logs Setup Button Clicked',
   'logs.explorer.metadata': 'Log Explorer Pageload Metadata',
   'logs.onboarding': 'Logs Explore Empty State (Onboarding)',
   'logs.issue_details.drawer_opened': 'Issues Page Logs Drawer Opened',

--- a/static/app/views/explore/logs/content.tsx
+++ b/static/app/views/explore/logs/content.tsx
@@ -1,15 +1,21 @@
 import {FeatureBadge} from 'sentry/components/core/badge/featureBadge';
 import {Button} from 'sentry/components/core/button';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
+import {LinkButton} from 'sentry/components/core/button/linkButton';
 import * as Layout from 'sentry/components/layouts/thirds';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
-import {IconMegaphone} from 'sentry/icons';
+import {withoutLoggingSupport} from 'sentry/data/platformCategories';
+import {platforms} from 'sentry/data/platforms';
+import {IconMegaphone, IconOpen} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {defined} from 'sentry/utils';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
 import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
 import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import useProjects from 'sentry/utils/useProjects';
 import ExploreBreadcrumb from 'sentry/views/explore/components/breadcrumb';
 import {LogsPageDataProvider} from 'sentry/views/explore/contexts/logs/logsPageData';
 import {
@@ -124,8 +130,53 @@ function LogsHeader() {
       <Layout.HeaderActions>
         <ButtonBar>
           <FeedbackButton />
+          <SetupLogsButton />
         </ButtonBar>
       </Layout.HeaderActions>
     </Layout.Header>
+  );
+}
+
+function SetupLogsButton() {
+  const organization = useOrganization();
+  const projects = useProjects();
+  const pageFilters = usePageFilters();
+  let project = projects.projects?.[0];
+
+  const filtered = projects.projects?.filter(p =>
+    pageFilters.selection.projects.includes(parseInt(p.id, 10))
+  );
+  if (filtered) {
+    project = filtered[0];
+  }
+
+  const currentPlatform = project?.platform
+    ? platforms.find(p => p.id === project.platform)
+    : undefined;
+
+  let href = 'https://docs.sentry.io/product/explore/logs/getting-started/';
+  const doesNotSupportLogging = currentPlatform
+    ? withoutLoggingSupport.has(currentPlatform.id)
+    : false;
+  if (project && currentPlatform) {
+    href = 'https://docs.sentry.io/platforms/' + currentPlatform.id + '/logs/';
+  }
+  return (
+    <LinkButton
+      icon={<IconOpen />}
+      priority="default"
+      href={href}
+      external
+      size="xs"
+      onClick={() => {
+        trackAnalytics('logs.explorer.setup_button_clicked', {
+          organization,
+          platform: currentPlatform?.id ?? 'unknown',
+          supports_onboarding_checklist: !doesNotSupportLogging,
+        });
+      }}
+    >
+      {t('Set Up Logs')}
+    </LinkButton>
   );
 }


### PR DESCRIPTION
### Summary
This adds a setup button to take people to the logs docs directly more or less based on their first selected project. This will be helpful in environments such as ST and SH where we forego 'has_logs' and the onboarding flow.

<img width="288" height="206" alt="Screenshot 2025-09-03 at 1 54 32 PM" src="https://github.com/user-attachments/assets/e94d7835-5d4a-4588-b18a-0c80ddde8f55" />
