### PR TITLE
feat(aci): Add cron detector search alias

### DIFF
--- a/src/sentry/workflow_engine/endpoints/organization_detector_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_index.py
@@ -39,6 +39,7 @@ from sentry.models.group import GroupStatus
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.team import Team
+from sentry.monitors.grouptype import MonitorIncidentType
 from sentry.uptime.grouptype import UptimeDomainCheckFailure
 from sentry.users.models.user import User
 from sentry.users.services.user import RpcUser
@@ -106,6 +107,7 @@ SORT_MAP = {
 DETECTOR_TYPE_ALIASES = {
     "metric": MetricIssue.slug,
     "uptime": UptimeDomainCheckFailure.slug,
+    "cron": MonitorIncidentType.slug,
 }
 
 

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
@@ -13,6 +13,7 @@ from sentry.grouping.grouptype import ErrorGroupType
 from sentry.incidents.grouptype import MetricIssue
 from sentry.incidents.models.alert_rule import AlertRuleDetectionType
 from sentry.models.environment import Environment
+from sentry.monitors.grouptype import MonitorIncidentType
 from sentry.search.utils import _HACKY_INVALID_USER
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import (
@@ -403,6 +404,12 @@ class OrganizationDetectorIndexGetTest(OrganizationDetectorIndexBaseTest):
                 "environment": "production",
             },
         )
+        cron_detector = self.create_detector(
+            project_id=self.project.id,
+            name="Cron Detector",
+            type=MonitorIncidentType.slug,
+        )
+
         response = self.get_success_response(
             self.organization.slug, qs_params={"project": self.project.id, "query": "type:metric"}
         )
@@ -412,6 +419,11 @@ class OrganizationDetectorIndexGetTest(OrganizationDetectorIndexBaseTest):
             self.organization.slug, qs_params={"project": self.project.id, "query": "type:uptime"}
         )
         assert {d["name"] for d in response.data} == {uptime_detector.name}
+
+        response = self.get_success_response(
+            self.organization.slug, qs_params={"project": self.project.id, "query": "type:cron"}
+        )
+        assert {d["name"] for d in response.data} == {cron_detector.name}
 
     def test_general_query(self) -> None:
         detector = self.create_detector(


### PR DESCRIPTION
Allows searching `type:cron` so it's more user friendly