### PR TITLE
fix(integrations): Fix too many values to unpack error

### DIFF
--- a/src/sentry/integrations/utils/codecov.py
+++ b/src/sentry/integrations/utils/codecov.py
@@ -93,7 +93,7 @@ def get_codecov_data(repo: str, service: str, path: str) -> tuple[LineCoverage |
     if not codecov_token:
         return None, None
 
-    owner_username, repo_name = repo.split("/")
+    owner_username, repo_name, rest = repo.split("/", 2)
     service = "gh" if service == IntegrationProviderSlug.GITHUB.value else service
 
     path = path.lstrip("/")

--- a/src/sentry/integrations/utils/codecov.py
+++ b/src/sentry/integrations/utils/codecov.py
@@ -93,7 +93,8 @@ def get_codecov_data(repo: str, service: str, path: str) -> tuple[LineCoverage |
     if not codecov_token:
         return None, None
 
-    owner_username, repo_name, rest = repo.split("/", 2)
+    params = repo.split("/")
+    owner_username, repo_name = params[:2]
     service = "gh" if service == IntegrationProviderSlug.GITHUB.value else service
 
     path = path.lstrip("/")


### PR DESCRIPTION
fixes [ECO#1046](https://linear.app/getsentry/issue/ECO-1046/valueerror-too-many-values-to-unpack-expected-2) & [SENTRY-3Z4Q](https://sentry.sentry.io/issues/6656597786/?project=1&query=integration_name%3Agitlab%20interaction_type%3Aget_stacktrace_link&referrer=issue-stream) I think this was what was paging me for `get_stacktrace_link`