### PR TITLE
feat(thread-leaks): Add SENTRY_THREAD_LEAK_STRICT environment variable

### DIFF
--- a/src/sentry/testutils/thread_leaks/pytest.py
+++ b/src/sentry/testutils/thread_leaks/pytest.py
@@ -1,6 +1,7 @@
 """Pytest plugin for thread leak detection."""
 
 from collections.abc import Generator
+from os import environ
 from typing import Any
 
 import pytest
@@ -15,8 +16,10 @@ def thread_leak_allowlist(reason: str | None = None, *, issue: int) -> pytest.Ma
     return decorator
 
 
-# TODO(DI-1067): strict mode
-STRICT = False
+# TODO(DI-1067): strict mode by default
+STRICT = environ.get("SENTRY_THREAD_LEAK_STRICT", "") == "1"
+
+del environ  # hygiene
 
 
 @pytest.hookimpl(wrapper=True)


### PR DESCRIPTION
Allow overriding thread leak strict mode via environment variable
instead of requiring code changes. This simplifies reproduction
instructions in GitHub issues.

Usage: SENTRY_THREAD_LEAK_STRICT=1 pytest ...
