### PR TITLE
fix(autofix-state): Check org-id in autofix get function

### DIFF
--- a/src/sentry/seer/autofix/autofix.py
+++ b/src/sentry/seer/autofix/autofix.py
@@ -601,7 +601,9 @@ def trigger_autofix(
             500,
         )
 
-    check_autofix_status.apply_async(args=[run_id], countdown=timedelta(minutes=15).seconds)
+    check_autofix_status.apply_async(
+        args=[run_id, group.organization.id], countdown=timedelta(minutes=15).seconds
+    )
 
     group.update(seer_autofix_last_triggered=timezone.now())
 

--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -352,7 +352,7 @@ def _run_automation(
     if not has_budget:
         return
 
-    autofix_state = get_autofix_state(group_id=group.id)
+    autofix_state = get_autofix_state(group_id=group.id, organization_id=group.organization.id)
     if autofix_state:
         return  # already have an autofix on this issue
 

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -148,7 +148,7 @@ def get_autofix_state(
         ):
             state = AutofixState.validate(result["state"])
 
-            if result["state"]["request"]["organization_id"] != organization_id:
+            if state.request["organization_id"] != organization_id:
                 raise SeerPermissionError("Different organization ID found in autofix state")
 
             return state

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -15,6 +15,7 @@ from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.repository import Repository
 from sentry.seer.autofix.constants import AutofixAutomationTuningSettings, AutofixStatus
+from sentry.seer.models import SeerPermissionError
 from sentry.seer.signed_seer_api import sign_with_seer_secret
 from sentry.utils import json
 from sentry.utils.outcomes import Outcome, track_outcome
@@ -27,6 +28,7 @@ class AutofixIssue(TypedDict):
 
 
 class AutofixRequest(TypedDict):
+    organization_id: int
     project_id: int
     issue: AutofixIssue
 
@@ -112,6 +114,7 @@ def get_autofix_state(
     run_id: int | None = None,
     check_repo_access: bool = False,
     is_user_fetching: bool = False,
+    organization_id: int,
 ) -> AutofixState | None:
     path = "/v1/automation/autofix/state"
     body = orjson.dumps(
@@ -143,7 +146,12 @@ def get_autofix_state(
             or run_id is not None
             and result["run_id"] == run_id
         ):
-            return AutofixState.validate(result["state"])
+            state = AutofixState.validate(result["state"])
+
+            if result["state"]["request"]["organization_id"] != organization_id:
+                raise SeerPermissionError("Different organization ID found in autofix state")
+
+            return state
 
     return None
 

--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -4,6 +4,7 @@ import logging
 from typing import Any
 
 import orjson
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.response import Response
 
 from sentry.api.api_owners import ApiOwner
@@ -16,6 +17,7 @@ from sentry.models.group import Group
 from sentry.models.repository import Repository
 from sentry.seer.autofix.autofix import trigger_autofix
 from sentry.seer.autofix.utils import get_autofix_state
+from sentry.seer.models import SeerPermissionError
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.users.services.user.service import user_service
 from sentry.utils.cache import cache
@@ -68,12 +70,20 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
 
         is_user_watching = request.GET.get("isUserWatching", False)
 
-        autofix_state = get_autofix_state(
-            group_id=group.id,
-            organization_id=group.organization.id,
-            check_repo_access=check_repo_access,
-            is_user_fetching=bool(is_user_watching),
-        )
+        try:
+            autofix_state = get_autofix_state(
+                group_id=group.id,
+                organization_id=group.organization.id,
+                check_repo_access=check_repo_access,
+                is_user_fetching=bool(is_user_watching),
+            )
+        except SeerPermissionError:
+            logger.exception(
+                "group_ai_autofix.get.seer_permission_error",
+                extra={"group_id": group.id, "organization_id": group.organization.id},
+            )
+
+            raise PermissionDenied("You are not authorized to access this autofix state")
 
         if check_repo_access:
             cache.set(access_check_cache_key, True, timeout=60)  # 1 minute timeout

--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -70,6 +70,7 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
 
         autofix_state = get_autofix_state(
             group_id=group.id,
+            organization_id=group.organization.id,
             check_repo_access=check_repo_access,
             is_user_fetching=bool(is_user_watching),
         )

--- a/src/sentry/seer/models.py
+++ b/src/sentry/seer/models.py
@@ -51,3 +51,11 @@ class SummarizeTraceResponse(BaseModel):
     key_observations: str
     performance_characteristics: str
     suggested_investigations: list[SpanInsight]
+
+
+class SeerPermissionError(Exception):
+    def __init__(self, message: str):
+        self.message = message
+
+    def __str__(self):
+        return f"Seer permission error: {self.message}"

--- a/src/sentry/tasks/autofix.py
+++ b/src/sentry/tasks/autofix.py
@@ -22,8 +22,8 @@ logger = logging.getLogger(__name__)
         ),
     ),
 )
-def check_autofix_status(run_id: int) -> None:
-    state = get_autofix_state(run_id=run_id)
+def check_autofix_status(run_id: int, organization_id: int) -> None:
+    state = get_autofix_state(run_id=run_id, organization_id=organization_id)
 
     if (
         state

--- a/tests/sentry/autofix/test_utils.py
+++ b/tests/sentry/autofix/test_utils.py
@@ -50,7 +50,12 @@ class TestGetAutofixStateFromPrId(TestCase):
         mock_response.json.return_value = {
             "state": {
                 "run_id": 123,
-                "request": {"project_id": 456, "issue": {"id": 789}},
+                "request": {
+                    "project_id": 456,
+                    "organization_id": 999,
+                    "issue": {"id": 789, "title": "Test Issue"},
+                    "repos": [],
+                },
                 "updated_at": "2023-07-18T12:00:00Z",
                 "status": "PROCESSING",
             }
@@ -62,7 +67,12 @@ class TestGetAutofixStateFromPrId(TestCase):
         # Assertions
         assert result is not None
         assert result.run_id == 123
-        assert result.request == {"project_id": 456, "issue": {"id": 789}}
+        assert result.request == {
+            "project_id": 456,
+            "organization_id": 999,
+            "issue": {"id": 789, "title": "Test Issue"},
+            "repos": [],
+        }
         assert result.updated_at == datetime(2023, 7, 18, 12, 0, tzinfo=timezone.utc)
         assert result.status == AutofixStatus.PROCESSING
 
@@ -109,19 +119,29 @@ class TestGetAutofixState(TestCase):
             "group_id": 123,
             "state": {
                 "run_id": 456,
-                "request": {"project_id": 789, "issue": {"id": 123}},
+                "request": {
+                    "project_id": 789,
+                    "organization_id": 999,
+                    "issue": {"id": 123, "title": "Test Issue"},
+                    "repos": [],
+                },
                 "updated_at": "2023-07-18T12:00:00Z",
                 "status": "PROCESSING",
             },
         }
 
         # Call the function
-        result = get_autofix_state(group_id=123)
+        result = get_autofix_state(group_id=123, organization_id=999)
 
         # Assertions
         assert isinstance(result, AutofixState)
         assert result.run_id == 456
-        assert result.request == {"project_id": 789, "issue": {"id": 123}}
+        assert result.request == {
+            "project_id": 789,
+            "organization_id": 999,
+            "issue": {"id": 123, "title": "Test Issue"},
+            "repos": [],
+        }
         assert result.updated_at == datetime(2023, 7, 18, 12, 0, tzinfo=timezone.utc)
         assert result.status == AutofixStatus.PROCESSING
 
@@ -140,19 +160,29 @@ class TestGetAutofixState(TestCase):
             "run_id": 456,
             "state": {
                 "run_id": 456,
-                "request": {"project_id": 789, "issue": {"id": 123}},
+                "request": {
+                    "project_id": 789,
+                    "organization_id": 999,
+                    "issue": {"id": 123, "title": "Test Issue"},
+                    "repos": [],
+                },
                 "updated_at": "2023-07-18T12:00:00Z",
                 "status": "COMPLETED",
             },
         }
 
         # Call the function
-        result = get_autofix_state(run_id=456)
+        result = get_autofix_state(run_id=456, organization_id=999)
 
         # Assertions
         assert isinstance(result, AutofixState)
         assert result.run_id == 456
-        assert result.request == {"project_id": 789, "issue": {"id": 123}}
+        assert result.request == {
+            "project_id": 789,
+            "organization_id": 999,
+            "issue": {"id": 123, "title": "Test Issue"},
+            "repos": [],
+        }
         assert result.updated_at == datetime(2023, 7, 18, 12, 0, tzinfo=timezone.utc)
         assert result.status == AutofixStatus.COMPLETED
 
@@ -170,7 +200,7 @@ class TestGetAutofixState(TestCase):
         mock_response.json.return_value = {}
 
         # Call the function
-        result = get_autofix_state(group_id=123)
+        result = get_autofix_state(group_id=123, organization_id=999)
 
         # Assertions
         assert result is None
@@ -183,7 +213,7 @@ class TestGetAutofixState(TestCase):
 
         # Call the function and expect an exception
         with pytest.raises(Exception) as context:
-            get_autofix_state(group_id=123)
+            get_autofix_state(group_id=123, organization_id=999)
 
         # Assertions
         assert "HTTP Error" in str(context.value)

--- a/tests/sentry/autofix/test_webhooks.py
+++ b/tests/sentry/autofix/test_webhooks.py
@@ -16,7 +16,14 @@ class AutofixPrWebhookTest(APITestCase):
         "sentry.seer.autofix.webhooks.get_autofix_state_from_pr_id",
         return_value=AutofixState(
             run_id=1,
-            request={"project_id": 2, "issue": {"id": 3}},
+            request={
+                "project_id": 2,
+                "organization_id": 4,
+                "issue": {"id": 3, "title": "Test issue"},
+                "repos": [
+                    {"provider": "github", "owner": "test", "name": "test", "external_id": "123"}
+                ],
+            },
             updated_at=datetime.now(timezone.utc),
             status=AutofixStatus.PROCESSING,
         ),
@@ -48,7 +55,14 @@ class AutofixPrWebhookTest(APITestCase):
         "sentry.seer.autofix.webhooks.get_autofix_state_from_pr_id",
         return_value=AutofixState(
             run_id=1,
-            request={"project_id": 2, "issue": {"id": 3}},
+            request={
+                "project_id": 2,
+                "organization_id": 4,
+                "issue": {"id": 3, "title": "Test issue"},
+                "repos": [
+                    {"provider": "github", "owner": "test", "name": "test", "external_id": "123"}
+                ],
+            },
             updated_at=datetime.now(timezone.utc),
             status=AutofixStatus.PROCESSING,
         ),
@@ -80,7 +94,14 @@ class AutofixPrWebhookTest(APITestCase):
         "sentry.seer.autofix.webhooks.get_autofix_state_from_pr_id",
         return_value=AutofixState(
             run_id=1,
-            request={"project_id": 2, "issue": {"id": 3}},
+            request={
+                "project_id": 2,
+                "organization_id": 4,
+                "issue": {"id": 3, "title": "Test issue"},
+                "repos": [
+                    {"provider": "github", "owner": "test", "name": "test", "external_id": "123"}
+                ],
+            },
             updated_at=datetime.now(timezone.utc),
             status=AutofixStatus.PROCESSING,
         ),

--- a/tests/sentry/seer/autofix/test_autofix.py
+++ b/tests/sentry/seer/autofix/test_autofix.py
@@ -756,7 +756,7 @@ class TestTriggerAutofix(APITestCase, SnubaTestCase):
         group = event.group
 
         # Setup the mock return value for _call_autofix
-        mock_call.return_value = "test-run-id"
+        mock_call.return_value = 123
 
         # Set test user
         test_user = self.create_user()
@@ -772,7 +772,7 @@ class TestTriggerAutofix(APITestCase, SnubaTestCase):
 
         # Verify the response
         assert response.status_code == 202
-        assert response.data["run_id"] == "test-run-id"
+        assert response.data["run_id"] == 123
 
         # Verify the field is updated in the database
         group.refresh_from_db()
@@ -795,7 +795,7 @@ class TestTriggerAutofix(APITestCase, SnubaTestCase):
 
         # Verify check_autofix_status was scheduled
         mock_check_autofix_status.assert_called_once_with(
-            args=["test-run-id"], countdown=timedelta(minutes=15).seconds
+            args=[123, group.organization.id], countdown=timedelta(minutes=15).seconds
         )
 
     @patch("sentry.models.Group.get_recommended_event_for_environments")

--- a/tests/sentry/seer/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/seer/endpoints/test_group_ai_autofix.py
@@ -35,7 +35,12 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         group = self.create_group()
         mock_get_autofix_state.return_value = AutofixState(
             run_id=123,
-            request={"project_id": 456, "issue": {"id": 789}},
+            request={
+                "project_id": 456,
+                "organization_id": group.organization.id,
+                "issue": {"id": 789, "title": "Test Issue"},
+                "repos": [],
+            },
             updated_at=datetime.fromisoformat("2023-07-18T12:00:00Z"),
             status=AutofixStatus.PROCESSING,
         )
@@ -52,7 +57,10 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         assert "issue_summary" not in response.data["autofix"]["request"]
 
         mock_get_autofix_state.assert_called_once_with(
-            group_id=group.id, check_repo_access=True, is_user_fetching=False
+            group_id=group.id,
+            check_repo_access=True,
+            is_user_fetching=False,
+            organization_id=group.organization.id,
         )
 
     @patch("sentry.seer.endpoints.group_ai_autofix.get_autofix_state")
@@ -69,7 +77,10 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         assert response.data["autofix"] is None
 
         mock_get_autofix_state.assert_called_once_with(
-            group_id=group.id, check_repo_access=True, is_user_fetching=False
+            group_id=group.id,
+            check_repo_access=True,
+            is_user_fetching=False,
+            organization_id=group.organization.id,
         )
 
     @patch("sentry.seer.endpoints.group_ai_autofix.get_autofix_state")
@@ -83,7 +94,12 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         group = self.create_group()
         autofix_state = AutofixState(
             run_id=123,
-            request={"project_id": 456, "issue": {"id": 789}},
+            request={
+                "project_id": 456,
+                "organization_id": group.organization.id,
+                "issue": {"id": 789, "title": "Test Issue"},
+                "repos": [],
+            },
             updated_at=datetime.fromisoformat("2023-07-18T12:00:00Z"),
             status=AutofixStatus.PROCESSING,
             codebases={
@@ -135,7 +151,12 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         group = self.create_group()
         autofix_state = AutofixState(
             run_id=123,
-            request={"project_id": 456, "issue": {"id": 789}},
+            request={
+                "project_id": 456,
+                "organization_id": group.organization.id,
+                "issue": {"id": 789, "title": "Test Issue"},
+                "repos": [],
+            },
             updated_at=datetime.fromisoformat("2023-07-18T12:00:00Z"),
             status=AutofixStatus.PROCESSING,
             codebases={
@@ -213,7 +234,12 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         group = self.create_group()
         autofix_state = AutofixState(
             run_id=123,
-            request={"project_id": 456, "issue": {"id": 789}},
+            request={
+                "project_id": 456,
+                "organization_id": group.organization.id,
+                "issue": {"id": 789, "title": "Test Issue"},
+                "repos": [],
+            },
             updated_at=datetime.fromisoformat("2023-07-18T12:00:00Z"),
             status=AutofixStatus.PROCESSING,
             codebases={
@@ -258,7 +284,12 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         group = self.create_group()
         autofix_state = AutofixState(
             run_id=123,
-            request={"project_id": 456, "issue": {"id": 789}},
+            request={
+                "project_id": 456,
+                "organization_id": group.organization.id,
+                "issue": {"id": 789, "title": "Test Issue"},
+                "repos": [],
+            },
             updated_at=datetime.fromisoformat("2023-07-18T12:00:00Z"),
             status=AutofixStatus.PROCESSING,
             # Empty codebases dictionary
@@ -366,7 +397,9 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 202
 
-        mock_check_autofix_status.assert_called_once_with(args=[123], countdown=900)
+        mock_check_autofix_status.assert_called_once_with(
+            args=[123, group.organization.id], countdown=900
+        )
 
     @patch("sentry.seer.explorer.utils.get_from_profiling_service")
     @patch("sentry.seer.autofix.autofix._get_profile_from_trace_tree")
@@ -434,7 +467,9 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 202
 
-        mock_check_autofix_status.assert_called_once_with(args=[123], countdown=900)
+        mock_check_autofix_status.assert_called_once_with(
+            args=[123, group.organization.id], countdown=900
+        )
 
     @patch("sentry.seer.explorer.utils.get_from_profiling_service")
     @patch("sentry.seer.autofix.autofix._get_profile_from_trace_tree")
@@ -514,7 +549,9 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 202
 
-        mock_check_autofix_status.assert_called_once_with(args=[123], countdown=900)
+        mock_check_autofix_status.assert_called_once_with(
+            args=[123, group.organization.id], countdown=900
+        )
 
     @patch("sentry.models.Group.get_recommended_event_for_environments", return_value=None)
     @patch("sentry.seer.explorer.utils.get_from_profiling_service")
@@ -594,7 +631,9 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 202
 
-        mock_check_autofix_status.assert_called_once_with(args=[123], countdown=900)
+        mock_check_autofix_status.assert_called_once_with(
+            args=[123, group.organization.id], countdown=900
+        )
 
     @patch("sentry.models.Group.get_recommended_event_for_environments", return_value=None)
     @patch("sentry.models.Group.get_latest_event", return_value=None)
@@ -655,7 +694,10 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         # Verify cache behavior - cache miss should trigger repo access check
         mock_cache.get.assert_called_once_with(f"autofix_access_check:{self.group.id}")
         mock_get_autofix_state.assert_called_once_with(
-            group_id=self.group.id, check_repo_access=True, is_user_fetching=False
+            group_id=self.group.id,
+            check_repo_access=True,
+            is_user_fetching=False,
+            organization_id=self.group.organization.id,
         )
 
         # Verify the cache was set with a 60-second timeout
@@ -686,7 +728,10 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         # Verify cache behavior - cache hit should skip repo access check
         mock_cache.get.assert_called_once_with(f"autofix_access_check:{self.group.id}")
         mock_get_autofix_state.assert_called_once_with(
-            group_id=self.group.id, check_repo_access=False, is_user_fetching=False
+            group_id=self.group.id,
+            check_repo_access=False,
+            is_user_fetching=False,
+            organization_id=self.group.organization.id,
         )
 
         # Verify the cache was not set again
@@ -705,7 +750,12 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         # Mock the autofix state
         mock_get_autofix_state.return_value = AutofixState(
             run_id=123,
-            request={"project_id": 456, "issue": {"id": 789}},
+            request={
+                "project_id": 456,
+                "organization_id": group.organization.id,
+                "issue": {"id": 789, "title": "Test Issue"},
+                "repos": [],
+            },
             updated_at=datetime.fromisoformat("2023-07-18T12:00:00Z"),
             status=AutofixStatus.PROCESSING,
         )
@@ -719,7 +769,10 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         # Verify first request behavior
         mock_cache.get.assert_called_once_with(f"autofix_access_check:{group.id}")
         mock_get_autofix_state.assert_called_once_with(
-            group_id=group.id, check_repo_access=True, is_user_fetching=False
+            group_id=group.id,
+            check_repo_access=True,
+            is_user_fetching=False,
+            organization_id=group.organization.id,
         )
         mock_cache.set.assert_called_once_with(f"autofix_access_check:{group.id}", True, timeout=60)
 
@@ -736,7 +789,10 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         # Verify second request behavior
         mock_cache.get.assert_called_once_with(f"autofix_access_check:{group.id}")
         mock_get_autofix_state.assert_called_once_with(
-            group_id=group.id, check_repo_access=False, is_user_fetching=False
+            group_id=group.id,
+            check_repo_access=False,
+            is_user_fetching=False,
+            organization_id=group.organization.id,
         )
         mock_cache.set.assert_not_called()
 
@@ -753,6 +809,9 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         # Verify third request behavior - should be like the first request
         mock_cache.get.assert_called_once_with(f"autofix_access_check:{group.id}")
         mock_get_autofix_state.assert_called_once_with(
-            group_id=group.id, check_repo_access=True, is_user_fetching=False
+            group_id=group.id,
+            check_repo_access=True,
+            is_user_fetching=False,
+            organization_id=group.organization.id,
         )
         mock_cache.set.assert_called_once_with(f"autofix_access_check:{group.id}", True, timeout=60)

--- a/tests/sentry/tasks/test_autofix.py
+++ b/tests/sentry/tasks/test_autofix.py
@@ -17,13 +17,18 @@ class TestCheckAutofixStatus(TestCase):
         # Mock the get_autofix_state function to return a state that's been processing for too long
         mock_get_autofix_state.return_value = AutofixState(
             run_id=123,
-            request={"project_id": 456, "issue": {"id": 789}},
+            request={
+                "project_id": 456,
+                "organization_id": 789,
+                "issue": {"id": 789, "title": "Test Issue"},
+                "repos": [],
+            },
             updated_at=datetime.now() - timedelta(minutes=10),  # Naive datetime
             status=AutofixStatus.PROCESSING,
         )
 
         # Call the task
-        check_autofix_status(123)
+        check_autofix_status(123, 789)
 
         # Check that the logger.error was called
         mock_logger.assert_called_once_with(
@@ -38,13 +43,18 @@ class TestCheckAutofixStatus(TestCase):
         # Mock the get_autofix_state function to return a state that's still within the time limit
         mock_get_autofix_state.return_value = AutofixState(
             run_id=123,
-            request={"project_id": 456, "issue": {"id": 789}},
+            request={
+                "project_id": 456,
+                "organization_id": 789,
+                "issue": {"id": 789, "title": "Test Issue"},
+                "repos": [],
+            },
             updated_at=datetime.now() - timedelta(minutes=3),  # Naive datetime
             status=AutofixStatus.PROCESSING,
         )
 
         # Call the task
-        check_autofix_status(123)
+        check_autofix_status(123, 789)
 
         # Check that the logger.error was not called
         mock_logger.assert_not_called()
@@ -57,13 +67,18 @@ class TestCheckAutofixStatus(TestCase):
         # Mock the get_autofix_state function to return a completed state
         mock_get_autofix_state.return_value = AutofixState(
             run_id=123,
-            request={"project_id": 456, "issue": {"id": 789}},
+            request={
+                "project_id": 456,
+                "organization_id": 789,
+                "issue": {"id": 789, "title": "Test Issue"},
+                "repos": [],
+            },
             updated_at=datetime.now() - timedelta(minutes=10),  # Naive datetime
             status=AutofixStatus.COMPLETED,
         )
 
         # Call the task
-        check_autofix_status(123)
+        check_autofix_status(123, 789)
 
         # Check that the logger.error was not called
         mock_logger.assert_not_called()
@@ -77,7 +92,7 @@ class TestCheckAutofixStatus(TestCase):
         mock_get_autofix_state.return_value = None
 
         # Call the task
-        check_autofix_status(123)
+        check_autofix_status(123, 789)
 
         # Check that the logger.error was not called
         mock_logger.assert_not_called()


### PR DESCRIPTION
We didn't actually check whether the caller has access to that autofix state.

This adds a check within `get_autofix_state` and makes sure callers pass an `organization_id`
