### PR TITLE
feat(billing): Add Philippines TIN (Tax Identification Number)

### DIFF
--- a/static/gsApp/utils/salesTax.tsx
+++ b/static/gsApp/utils/salesTax.tsx
@@ -101,6 +101,7 @@ const SALES_TAX_COUNTRY_INFO = {
   MT: taxInfo.VAT,
   NL: taxInfo.VAT,
   NO: taxInfo.VAT,
+  PH: taxInfo.TIN,
   PL: taxInfo.VAT,
   PT: taxInfo.VAT,
   RO: taxInfo.VAT,

--- a/static/gsApp/views/subscriptionPage/billingDetails.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/billingDetails.spec.tsx
@@ -413,4 +413,34 @@ describe('Billing details form', () => {
       })
     );
   });
+
+  it('displays TIN field for Philippines', async () => {
+    const billingDetailsWithPhilippines = BillingDetailsFixture({
+      countryCode: 'PH',
+      taxNumber: '123456789000',
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/customers/${organization.slug}/billing-details/`,
+      method: 'GET',
+      body: billingDetailsWithPhilippines,
+    });
+
+    render(
+      <BillingDetailsView
+        organization={organization}
+        subscription={subscription}
+        location={router.location}
+      />
+    );
+
+    await screen.findByRole('textbox', {name: /street address 1/i});
+
+    // Philippines should display TIN field
+    expect(screen.getByRole('textbox', {name: 'TIN'})).toBeInTheDocument();
+    expect(screen.getByDisplayValue('123456789000')).toBeInTheDocument();
+
+    // Help text should mention Tax Identification Number
+    expect(screen.getByText(/Tax Identification Number/)).toBeInTheDocument();
+  });
 });

--- a/static/gsApp/views/subscriptionPage/billingDetails.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/billingDetails.spec.tsx
@@ -440,7 +440,7 @@ describe('Billing details form', () => {
     expect(screen.getByRole('textbox', {name: 'TIN'})).toBeInTheDocument();
     expect(screen.getByDisplayValue('123456789000')).toBeInTheDocument();
 
-    // Help text should mention Tax Identification Number
-    expect(screen.getByText(/Tax Identification Number/)).toBeInTheDocument();
+    // Help text should mention Taxpayer Identification Number
+    expect(screen.getByText(/Taxpayer Identification Number/)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Let customers input Philippines TIN (Tax Identification Number)

related to: https://github.com/getsentry/getsentry/pull/18293