### PR TITLE
ref(discover): Remove router props from container routes

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -2284,48 +2284,40 @@ function buildRoutes(): RouteObject[] {
     {
       index: true,
       component: make(() => import('sentry/views/explore/indexRedirect')),
-      deprecatedRouteProps: true,
     },
     {
       path: 'profiling/',
       component: make(() => import('sentry/views/profiling')),
       children: profilingChildren,
-      deprecatedRouteProps: true,
     },
     {
       path: 'traces/',
       component: make(() => import('sentry/views/traces')),
       children: tracesChildren,
-      deprecatedRouteProps: true,
     },
     {
       path: 'replays/',
       component: make(() => import('sentry/views/replays/index')),
       children: replayChildren,
-      deprecatedRouteProps: true,
     },
     {
       path: 'discover/',
       component: make(() => import('sentry/views/discover')),
       children: discoverChildren,
-      deprecatedRouteProps: true,
     },
     {
       path: 'releases/',
       component: make(() => import('sentry/views/releases/index')),
       children: releaseChildren,
-      deprecatedRouteProps: true,
     },
     {
       path: 'logs/',
       component: make(() => import('sentry/views/explore/logs')),
       children: logsChildren,
-      deprecatedRouteProps: true,
     },
     {
       path: 'saved-queries/',
       component: make(() => import('sentry/views/explore/savedQueries')),
-      deprecatedRouteProps: true,
     },
   ];
   const exploreRoutes: SentryRouteObject = {

--- a/static/app/views/discover/index.tsx
+++ b/static/app/views/discover/index.tsx
@@ -1,19 +1,16 @@
+import {Outlet} from 'react-router-dom';
+
 import Feature from 'sentry/components/acl/feature';
 import {Alert} from 'sentry/components/core/alert';
 import * as Layout from 'sentry/components/layouts/thirds';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
 import Redirect from 'sentry/components/redirect';
 import {t} from 'sentry/locale';
-import type {Organization} from 'sentry/types/organization';
-import withOrganization from 'sentry/utils/withOrganization';
+import useOrganization from 'sentry/utils/useOrganization';
 import {useRedirectNavV2Routes} from 'sentry/views/nav/useRedirectNavV2Routes';
 
-type Props = {
-  children: React.ReactNode;
-  organization: Organization;
-};
-
-function DiscoverContainer({organization, children}: Props) {
+function DiscoverContainer() {
+  const organization = useOrganization();
   const redirectPath = useRedirectNavV2Routes({
     oldPathPrefix: '/discover/',
     newPathPrefix: '/explore/discover/',
@@ -42,9 +39,11 @@ function DiscoverContainer({organization, children}: Props) {
       hookName="feature-disabled:discover2-page"
       renderDisabled={renderNoAccess}
     >
-      <NoProjectMessage organization={organization}>{children}</NoProjectMessage>
+      <NoProjectMessage organization={organization}>
+        <Outlet />
+      </NoProjectMessage>
     </Feature>
   );
 }
 
-export default withOrganization(DiscoverContainer);
+export default DiscoverContainer;

--- a/static/app/views/explore/logs/index.tsx
+++ b/static/app/views/explore/logs/index.tsx
@@ -1,13 +1,11 @@
+import {Outlet} from 'react-router-dom';
+
 import Feature from 'sentry/components/acl/feature';
 import {NoAccess} from 'sentry/components/noAccess';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
 import useOrganization from 'sentry/utils/useOrganization';
 
-interface Props {
-  children: React.ReactNode;
-}
-
-export default function LogsPage({children}: Props) {
+export default function LogsPage() {
   const organization = useOrganization();
 
   return (
@@ -16,7 +14,9 @@ export default function LogsPage({children}: Props) {
       organization={organization}
       renderDisabled={NoAccess}
     >
-      <NoProjectMessage organization={organization}>{children}</NoProjectMessage>
+      <NoProjectMessage organization={organization}>
+        <Outlet />
+      </NoProjectMessage>
     </Feature>
   );
 }

--- a/static/app/views/profiling/index.tsx
+++ b/static/app/views/profiling/index.tsx
@@ -1,3 +1,5 @@
+import {Outlet} from 'react-router-dom';
+
 import Feature from 'sentry/components/acl/feature';
 import {Alert} from 'sentry/components/core/alert';
 import * as Layout from 'sentry/components/layouts/thirds';
@@ -9,11 +11,7 @@ import {useRedirectNavV2Routes} from 'sentry/views/nav/useRedirectNavV2Routes';
 
 const profilingFeature = ['profiling'];
 
-type Props = {
-  children: React.ReactNode;
-};
-
-function ProfilingContainer({children}: Props) {
+function ProfilingContainer() {
   const organization = useOrganization();
 
   const redirectPath = useRedirectNavV2Routes({
@@ -40,7 +38,9 @@ function ProfilingContainer({children}: Props) {
         </Layout.Page>
       )}
     >
-      <NoProjectMessage organization={organization}>{children}</NoProjectMessage>
+      <NoProjectMessage organization={organization}>
+        <Outlet />
+      </NoProjectMessage>
     </Feature>
   );
 }

--- a/static/app/views/releases/index.tsx
+++ b/static/app/views/releases/index.tsx
@@ -1,12 +1,9 @@
+import {Outlet} from 'react-router-dom';
+
 import Redirect from 'sentry/components/redirect';
-import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import {useRedirectNavV2Routes} from 'sentry/views/nav/useRedirectNavV2Routes';
 
-type Props = RouteComponentProps & {
-  children: React.ReactNode;
-};
-
-export default function ReleasesContainer({children}: Props) {
+export default function ReleasesContainer() {
   const redirectPath = useRedirectNavV2Routes({
     oldPathPrefix: '/releases/',
     newPathPrefix: '/explore/releases/',
@@ -16,5 +13,5 @@ export default function ReleasesContainer({children}: Props) {
     return <Redirect to={redirectPath} />;
   }
 
-  return children;
+  return <Outlet />;
 }

--- a/static/app/views/traces/index.tsx
+++ b/static/app/views/traces/index.tsx
@@ -1,3 +1,5 @@
+import {Outlet} from 'react-router-dom';
+
 import Feature from 'sentry/components/acl/feature';
 import {NoAccess} from 'sentry/components/noAccess';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
@@ -5,11 +7,7 @@ import Redirect from 'sentry/components/redirect';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useRedirectNavV2Routes} from 'sentry/views/nav/useRedirectNavV2Routes';
 
-interface Props {
-  children: React.ReactNode;
-}
-
-export default function TracesPage({children}: Props) {
+export default function TracesPage() {
   const organization = useOrganization();
 
   const redirectPath = useRedirectNavV2Routes({
@@ -28,7 +26,9 @@ export default function TracesPage({children}: Props) {
       organization={organization}
       renderDisabled={NoAccess}
     >
-      <NoProjectMessage organization={organization}>{children}</NoProjectMessage>
+      <NoProjectMessage organization={organization}>
+        <Outlet />
+      </NoProjectMessage>
     </Feature>
   );
 }


### PR DESCRIPTION
Few easy ones that mostly render the no project message and children.
