### PR TITLE
ref(preprod): Remove router props from preprod routes

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -2476,26 +2476,22 @@ function buildRoutes(): RouteObject[] {
     {
       path: 'builds/',
       component: make(() => import('sentry/views/preprod/buildList/buildList')),
-      deprecatedRouteProps: true,
     },
     {
       path: ':artifactId/',
       component: make(() => import('sentry/views/preprod/buildDetails/buildDetails')),
-      deprecatedRouteProps: true,
     },
     {
       path: 'compare/:headArtifactId/',
       component: make(
         () => import('sentry/views/preprod/buildComparison/buildComparison')
       ),
-      deprecatedRouteProps: true,
     },
     {
       path: 'compare/:headArtifactId/:baseArtifactId/',
       component: make(
         () => import('sentry/views/preprod/buildComparison/buildComparison')
       ),
-      deprecatedRouteProps: true,
     },
   ];
   const preprodRoutes: SentryRouteObject = {
@@ -2503,7 +2499,6 @@ function buildRoutes(): RouteObject[] {
     component: make(() => import('sentry/views/preprod/index')),
     withOrgPath: true,
     children: preprodChildren,
-    deprecatedRouteProps: true,
   };
 
   const feedbackV2Children: SentryRouteObject[] = [

--- a/static/app/views/preprod/index.tsx
+++ b/static/app/views/preprod/index.tsx
@@ -1,3 +1,5 @@
+import {Outlet} from 'react-router-dom';
+
 import Feature from 'sentry/components/acl/feature';
 import {Alert} from 'sentry/components/core/alert';
 import * as Layout from 'sentry/components/layouts/thirds';
@@ -5,11 +7,7 @@ import NoProjectMessage from 'sentry/components/noProjectMessage';
 import {t} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
 
-type Props = {
-  children: NonNullable<React.ReactNode>;
-};
-
-function PreprodContainer({children}: Props) {
+function PreprodContainer() {
   const organization = useOrganization();
 
   return (
@@ -26,7 +24,9 @@ function PreprodContainer({children}: Props) {
         </Layout.Page>
       )}
     >
-      <NoProjectMessage organization={organization}>{children}</NoProjectMessage>
+      <NoProjectMessage organization={organization}>
+        <Outlet />
+      </NoProjectMessage>
     </Feature>
   );
 }


### PR DESCRIPTION
Only one component was using the injected children, other components seem too new to be using them.
