### PR TITLE
fix(replay): fix feedback replay context not resetting

### DIFF
--- a/static/app/components/feedback/feedbackItem/replaySection.tsx
+++ b/static/app/components/feedback/feedbackItem/replaySection.tsx
@@ -37,6 +37,7 @@ export default function ReplaySection({eventTimestampMs, organization, replayId}
 
   return (
     <LazyLoad
+      key={replayId}
       {...props}
       LazyComponent={LazyReplayClipPreviewComponent}
       clipOffsets={CLIP_OFFSETS}


### PR DESCRIPTION
closes https://linear.app/getsentry/issue/REPLAY-129/replay-previewer-buggy-when-viewing-a-played-video

Fixes the issue where the `currentTime` was getting mutated when navigating between different feedback replay previews.

This change will force the entire lazy-loaded component tree (including the `ReplayContextProvider`) to completely re-mount whenever the `replayId` changes. This includes resetting the `ReplayContextProvider` state, which contains the `currentTime` that was getting corrupted.

before:


https://github.com/user-attachments/assets/f78e39ce-5554-4933-9932-87f7652c5d69



after:

https://github.com/user-attachments/assets/86b03077-1855-430a-b379-39ef25535d6c


