### PR TITLE
chore(ACI): Add logs for triggers to compare both systems

### DIFF
--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -371,14 +371,15 @@ class SubscriptionProcessor:
                 "incidents.alert_rules.threshold.resolve",
                 tags={"detection_type": self.alert_rule.detection_type},
             )
-            if has_dual_processing_flag and detector is not None:
-                logger.info(
-                    "subscription_processor.alert_triggered",
-                    extra={
-                        "rule_id": self.alert_rule.id,
-                        "detector_id": detector.id,
-                    },
-                )
+            if has_dual_processing_flag:
+                if detector is not None:
+                    logger.info(
+                        "subscription_processor.alert_triggered",
+                        extra={
+                            "rule_id": self.alert_rule.id,
+                            "detector_id": detector.id,
+                        },
+                    )
                 metrics.incr("dual_processing.alert_rules.resolve")
             incident_trigger = self.trigger_resolve_threshold(trigger, aggregation_value)
 

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -350,6 +350,8 @@ class SubscriptionProcessor:
                         extra={
                             "rule_id": self.alert_rule.id,
                             "detector_id": detector.id,
+                            "organization_id": self.subscription.project.organization.id,
+                            "project_id": self.subscription.project.id,
                         },
                     )
                 if not metrics_incremented:
@@ -378,6 +380,8 @@ class SubscriptionProcessor:
                         extra={
                             "rule_id": self.alert_rule.id,
                             "detector_id": detector.id,
+                            "organization_id": self.subscription.project.organization.id,
+                            "project_id": self.subscription.project.id,
                         },
                     )
                 metrics.incr("dual_processing.alert_rules.resolve")

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -344,13 +344,14 @@ class SubscriptionProcessor:
                 tags={"detection_type": self.alert_rule.detection_type},
             )
             if has_dual_processing_flag:
-                logger.info(
-                    "subscription_processor.alert_triggered",
-                    extra={
-                        "rule_id": self.alert_rule.id,
-                        "detector_id": detector.id,
-                    },
-                )
+                if detector is not None:
+                    logger.info(
+                        "subscription_processor.alert_triggered",
+                        extra={
+                            "rule_id": self.alert_rule.id,
+                            "detector_id": detector.id,
+                        },
+                    )
                 if not metrics_incremented:
                     metrics.incr("dual_processing.alert_rules.fire")
                     metrics_incremented = True
@@ -370,7 +371,7 @@ class SubscriptionProcessor:
                 "incidents.alert_rules.threshold.resolve",
                 tags={"detection_type": self.alert_rule.detection_type},
             )
-            if has_dual_processing_flag:
+            if has_dual_processing_flag and detector is not None:
                 logger.info(
                     "subscription_processor.alert_triggered",
                     extra={

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -324,7 +324,7 @@ class SubscriptionProcessor:
         aggregation_value: float,
         fired_incident_triggers: list[IncidentTrigger],
         metrics_incremented: bool,
-        detector: Detector,
+        detector: Detector | None,
     ) -> tuple[list[IncidentTrigger], bool]:
         # OVER/UNDER value trigger
         has_dual_processing_flag = features.has(

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -14,7 +14,13 @@ from sentry.models.environment import Environment
 from sentry.services.eventstore.models import GroupEvent
 from sentry.utils import json
 from sentry.workflow_engine import buffer
-from sentry.workflow_engine.models import Action, DataConditionGroup, Detector, Workflow
+from sentry.workflow_engine.models import (
+    Action,
+    DataConditionGroup,
+    Detector,
+    DetectorWorkflow,
+    Workflow,
+)
 from sentry.workflow_engine.models.workflow_data_condition_group import WorkflowDataConditionGroup
 from sentry.workflow_engine.processors.contexts.workflow_event_context import (
     WorkflowEventContext,
@@ -183,6 +189,21 @@ def evaluate_workflow_triggers(
         else:
             if evaluation:
                 triggered_workflows.add(workflow)
+                if features.has(
+                    "organizations:workflow-engine-metric-alert-dual-processing-logs",
+                    workflow.organization,
+                ):
+                    try:
+                        detector_workflow = DetectorWorkflow.objects.get(workflow_id=workflow.id)
+                        logger.info(
+                            "workflow_engine.process_workflows.workflow_triggered",
+                            extra={
+                                "workflow_id": workflow.id,
+                                "detector_id": detector_workflow.detector_id,
+                            },
+                        )
+                    except DetectorWorkflow.DoesNotExist:
+                        continue
 
     metrics_incr(
         "process_workflows.triggered_workflows",

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -200,6 +200,8 @@ def evaluate_workflow_triggers(
                             extra={
                                 "workflow_id": workflow.id,
                                 "detector_id": detector_workflow.detector_id,
+                                "organization_id": workflow.organization.id,
+                                "project_id": event_data.group.project.id,
                             },
                         )
                     except DetectorWorkflow.DoesNotExist:

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -347,6 +347,8 @@ class TestEvaluateWorkflowTriggers(BaseWorkflowTest):
             extra={
                 "workflow_id": self.workflow.id,
                 "detector_id": self.detector.id,
+                "organization_id": self.workflow.organization.id,
+                "project_id": self.event_data.group.project.id,
             },
         )
 

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -11,6 +11,7 @@ from sentry.models.environment import Environment
 from sentry.services.eventstore.models import GroupEvent
 from sentry.testutils.factories import Factories
 from sentry.testutils.helpers.datetime import before_now, freeze_time
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.helpers.redis import mock_redis_buffer
 from sentry.testutils.pytest.fixtures import django_db_all
@@ -336,6 +337,18 @@ class TestEvaluateWorkflowTriggers(BaseWorkflowTest):
             {self.workflow}, self.event_data, self.event_start_time
         )
         assert triggered_workflows == {self.workflow}
+
+    @with_feature("organizations:workflow-engine-metric-alert-dual-processing-logs")
+    @patch("sentry.workflow_engine.processors.workflow.logger")
+    def test_logs_triggered_workflows(self, mock_logger: MagicMock) -> None:
+        evaluate_workflow_triggers({self.workflow}, self.event_data, self.event_start_time)
+        mock_logger.info.assert_called_once_with(
+            "workflow_engine.process_workflows.workflow_triggered",
+            extra={
+                "workflow_id": self.workflow.id,
+                "detector_id": self.detector.id,
+            },
+        )
 
     def test_workflow_trigger__no_conditions(self) -> None:
         assert self.workflow.when_condition_group


### PR DESCRIPTION
Add logs on both the subscription processor when a trigger's threshold is met or resolved and in workflow engine when the workflow's trigger conditions are met so that we can compare the two systems. Both logs have the detector ID so we can match them up and are behind a flag with a small subset of organizations flagged in so it won't be too much data.