### PR TITLE
ref(groupingInfo): Add collapse button next to stack-trace

### DIFF
--- a/static/app/components/events/groupingInfo/groupingComponent.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponent.tsx
@@ -1,5 +1,4 @@
 import {useEffect, useRef, useState} from 'react';
-import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/core/button';
@@ -107,11 +106,11 @@ export const GroupingHint = styled('small')`
 
 const CaretButton = styled(Button)`
   display: inline-block;
-  padding: ${space(0.25)};
+  padding: ${p => p.theme.space.xs};
   min-height: auto;
   border: none;
   background: transparent;
-  margin-left: ${space(0.5)};
+  margin-left: ${p => p.theme.space.sm};
   vertical-align: middle;
 
   &:hover {

--- a/static/app/components/events/groupingInfo/groupingComponent.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponent.tsx
@@ -1,4 +1,5 @@
-import {useState} from 'react';
+import {useEffect, useRef, useState} from 'react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/core/button';
@@ -39,8 +40,24 @@ function GroupingComponent({
   const hasHiddenItems = isStacktraceComponent && totalItems > maxItems;
 
   const [isCollapsed, setIsCollapsed] = useState(!showNonContributing);
+  const hasUserInteracted = useRef(false);
+
+  // Automatically uncollapse stack traces when switching to 'all values'
+  // but only if the user hasn't manually interacted with the collapse state
+  useEffect(() => {
+    if (
+      isStacktraceComponent &&
+      showNonContributing &&
+      isCollapsed &&
+      !hasUserInteracted.current
+    ) {
+      setIsCollapsed(false);
+      onCollapsedChange?.(false);
+    }
+  }, [showNonContributing, isStacktraceComponent, isCollapsed, onCollapsedChange]);
 
   const handleCollapsedChange = (collapsed: boolean) => {
+    hasUserInteracted.current = true;
     setIsCollapsed(collapsed);
     onCollapsedChange?.(collapsed);
   };

--- a/static/app/components/events/groupingInfo/groupingComponent.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponent.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import {Button} from 'sentry/components/core/button';
 import {IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import type {EventGroupComponent} from 'sentry/types/event';
 
 import GroupingComponentChildren from './groupingComponentChildren';
@@ -44,15 +45,14 @@ function GroupingComponent({
     }
   }, [showNonContributing, component.id, onCollapsedChange]);
 
-  const toggleCollapsed = () => {
-    const newCollapsed = !isCollapsed;
-    setIsCollapsed(newCollapsed);
-    onCollapsedChange?.(newCollapsed);
+  const handleCollapsedChange = (collapsed: boolean) => {
+    setIsCollapsed(collapsed);
+    onCollapsedChange?.(collapsed);
   };
 
   const stacktraceProps =
     component.id === 'stacktrace'
-      ? {collapsed: isCollapsed, onCollapsedChange: toggleCollapsed}
+      ? {collapsed: isCollapsed, onCollapsedChange: handleCollapsedChange}
       : {};
 
   return (
@@ -61,13 +61,13 @@ function GroupingComponent({
         {component.name || component.id}
         {component.hint && <GroupingHint>{` (${component.hint})`}</GroupingHint>}
         {component.id === 'stacktrace' && stacktraceValues.length > maxVisibleItems && (
-          <CaretButton
+          <CollapseButton
             size="xs"
             priority="link"
             icon={
               <IconChevron direction={isCollapsed ? 'down' : 'up'} legacySize="12px" />
             }
-            onClick={toggleCollapsed}
+            onClick={() => handleCollapsedChange(!isCollapsed)}
             aria-label={isCollapsed ? t('expand stacktrace') : t('collapse stacktrace')}
           />
         )}
@@ -102,12 +102,11 @@ export const GroupingHint = styled('small')`
   font-size: 0.8em;
 `;
 
-const CaretButton = styled(Button)`
+const CollapseButton = styled(Button)`
   display: inline-block;
   padding: ${p => p.theme.space.xs};
   min-height: auto;
   border: none;
-  background: transparent;
   margin-left: ${p => p.theme.space.sm};
   vertical-align: middle;
 

--- a/static/app/components/events/groupingInfo/groupingComponent.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponent.tsx
@@ -24,6 +24,7 @@ function GroupingComponent({
   maxVisibleItems = 2,
   onCollapsedChange,
 }: Props) {
+  const shouldInlineValue = shouldInlineComponentValue(component);
   const isStacktrace = component.id === 'stacktrace';
   const stacktraceValues = isStacktrace
     ? (component.values as EventGroupComponent[])
@@ -48,7 +49,7 @@ function GroupingComponent({
     onCollapsedChange?.(newCollapsed);
   };
 
-  const ListComponent = isStacktrace
+  const GroupingComponentListItems = isStacktrace
     ? GroupingComponentStacktrace
     : GroupingComponentChildren;
   const stacktraceProps = isStacktrace
@@ -73,8 +74,8 @@ function GroupingComponent({
         )}
       </span>
 
-      <GroupingComponentList isInline={shouldInlineComponentValue(component)}>
-        <ListComponent
+      <GroupingComponentList isInline={shouldInlineValue}>
+        <GroupingComponentListItems
           component={component}
           showNonContributing={showNonContributing}
           {...stacktraceProps}

--- a/static/app/components/events/groupingInfo/groupingComponent.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponent.tsx
@@ -4,7 +4,6 @@ import styled from '@emotion/styled';
 import {Button} from 'sentry/components/core/button';
 import {IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import type {EventGroupComponent} from 'sentry/types/event';
 
 import GroupingComponentChildren from './groupingComponentChildren';

--- a/static/app/components/events/groupingInfo/groupingComponent.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponent.tsx
@@ -25,6 +25,10 @@ function GroupingComponent({
   onCollapsedChange,
 }: Props) {
   const shouldInlineValue = shouldInlineComponentValue(component);
+  const GroupingComponentListItems =
+    component.id === 'stacktrace'
+      ? GroupingComponentStacktrace
+      : GroupingComponentChildren;
   const isStacktrace = component.id === 'stacktrace';
   const stacktraceValues = isStacktrace
     ? (component.values as EventGroupComponent[])
@@ -49,9 +53,6 @@ function GroupingComponent({
     onCollapsedChange?.(newCollapsed);
   };
 
-  const GroupingComponentListItems = isStacktrace
-    ? GroupingComponentStacktrace
-    : GroupingComponentChildren;
   const stacktraceProps = isStacktrace
     ? {collapsed: isCollapsed, onCollapsedChange: toggleCollapsed}
     : {};

--- a/static/app/components/events/groupingInfo/groupingComponent.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponent.tsx
@@ -1,4 +1,3 @@
-import {useCallback, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/core/button';
@@ -26,16 +25,6 @@ function GroupingComponent({component, showNonContributing, maxVisibleItems}: Pr
 
   // For stacktrace components, use frame-level collapse; otherwise use full collapse
   const isStacktraceComponent = component.id === 'stacktrace';
-  const [isCollapsed, setIsCollapsed] = useState(isStacktraceComponent);
-
-  const toggleCollapsed = useCallback(() => {
-    setIsCollapsed(prev => !prev);
-  }, []);
-
-  // Handle collapse state changes from child components (e.g., when frames are expanded via "+ show x similar")
-  const handleCollapseChange = useCallback((collapsed: boolean) => {
-    setIsCollapsed(collapsed);
-  }, []);
 
   // Calculate total items for stacktrace components
   const totalItems = isStacktraceComponent
@@ -44,6 +33,8 @@ function GroupingComponent({component, showNonContributing, maxVisibleItems}: Pr
   const maxItems = maxVisibleItems || 2;
   const hasHiddenItems = isStacktraceComponent && totalItems > maxItems;
 
+  const isCollapsed = showNonContributing;
+
   return (
     <GroupingComponentWrapper isContributing={component.contributes}>
       {component.name === 'stack-trace' && hasHiddenItems && (
@@ -51,16 +42,7 @@ function GroupingComponent({component, showNonContributing, maxVisibleItems}: Pr
           size="xs"
           priority="link"
           icon={<IconChevron direction={isCollapsed ? 'down' : 'up'} legacySize="12px" />}
-          onClick={toggleCollapsed}
-          aria-label={isCollapsed ? t('expand stacktrace') : t('collapse stacktrace')}
-        />
-      )}
-      {component.name === 'stack-trace' && !hasHiddenItems && (
-        <CaretButton
-          size="xs"
-          priority="link"
-          icon={<IconChevron direction={isCollapsed ? 'down' : 'up'} legacySize="12px" />}
-          onClick={toggleCollapsed}
+          onClick={() => {}}
           aria-label={isCollapsed ? t('expand stacktrace') : t('collapse stacktrace')}
         />
       )}
@@ -73,9 +55,6 @@ function GroupingComponent({component, showNonContributing, maxVisibleItems}: Pr
         <GroupingComponentListItems
           component={component}
           showNonContributing={showNonContributing}
-          isCollapsed={isCollapsed}
-          maxVisibleItems={maxItems}
-          onCollapseChange={isStacktraceComponent ? handleCollapseChange : undefined}
         />
       </GroupingComponentList>
     </GroupingComponentWrapper>

--- a/static/app/components/events/groupingInfo/groupingComponent.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponent.tsx
@@ -41,20 +41,25 @@ function GroupingComponent({
 
   const [isCollapsed, setIsCollapsed] = useState(!showNonContributing);
   const hasUserInteracted = useRef(false);
+  const prevShowNonContributing = useRef(showNonContributing);
 
-  // Automatically uncollapse stack traces when switching to 'all values'
-  // but only if the user hasn't manually interacted with the collapse state
   useEffect(() => {
     if (
       isStacktraceComponent &&
-      showNonContributing &&
-      isCollapsed &&
-      !hasUserInteracted.current
+      prevShowNonContributing.current !== showNonContributing
     ) {
-      setIsCollapsed(false);
-      onCollapsedChange?.(false);
+      if (showNonContributing) {
+        setIsCollapsed(false);
+        onCollapsedChange?.(false);
+        hasUserInteracted.current = false;
+      } else {
+        setIsCollapsed(true);
+        onCollapsedChange?.(true);
+        hasUserInteracted.current = false;
+      }
+      prevShowNonContributing.current = showNonContributing;
     }
-  }, [showNonContributing, isStacktraceComponent, isCollapsed, onCollapsedChange]);
+  }, [showNonContributing, isStacktraceComponent, onCollapsedChange]);
 
   const handleCollapsedChange = (collapsed: boolean) => {
     hasUserInteracted.current = true;

--- a/static/app/components/events/groupingInfo/groupingComponent.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponent.tsx
@@ -64,18 +64,20 @@ function GroupingComponent({
 
   return (
     <GroupingComponentWrapper isContributing={component.contributes}>
-      {component.name === 'stack-trace' && hasHiddenItems && (
-        <CaretButton
-          size="xs"
-          priority="link"
-          icon={<IconChevron direction={isCollapsed ? 'down' : 'up'} legacySize="12px" />}
-          onClick={() => handleCollapsedChange(!isCollapsed)}
-          aria-label={isCollapsed ? t('expand stacktrace') : t('collapse stacktrace')}
-        />
-      )}
       <span>
         {component.name || component.id}
         {component.hint && <GroupingHint>{` (${component.hint})`}</GroupingHint>}
+        {component.name === 'stack-trace' && hasHiddenItems && (
+          <CaretButton
+            size="xs"
+            priority="link"
+            icon={
+              <IconChevron direction={isCollapsed ? 'down' : 'up'} legacySize="12px" />
+            }
+            onClick={() => handleCollapsedChange(!isCollapsed)}
+            aria-label={isCollapsed ? t('expand stacktrace') : t('collapse stacktrace')}
+          />
+        )}
       </span>
 
       <GroupingComponentList isInline={shouldInlineValue}>
@@ -110,10 +112,13 @@ export const GroupingHint = styled('small')`
 `;
 
 const CaretButton = styled(Button)`
+  display: inline-block;
   padding: ${space(0.25)};
   min-height: auto;
   border: none;
   background: transparent;
+  margin-left: ${space(0.5)};
+  vertical-align: middle;
 
   &:hover {
     background: ${p => p.theme.background};

--- a/static/app/components/events/groupingInfo/groupingComponent.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponent.tsx
@@ -13,10 +13,9 @@ import {getFrameGroups, shouldInlineComponentValue} from './utils';
 type Props = {
   component: EventGroupComponent;
   showNonContributing: boolean;
-  onCollapsedChange?: (collapsed: boolean) => void;
 };
 
-function GroupingComponent({component, showNonContributing, onCollapsedChange}: Props) {
+function GroupingComponent({component, showNonContributing}: Props) {
   const maxVisibleItems = 2;
   const shouldInlineValue = shouldInlineComponentValue(component);
 
@@ -40,18 +39,13 @@ function GroupingComponent({component, showNonContributing, onCollapsedChange}: 
     if (component.id === 'stacktrace' && prevTabState.current !== showNonContributing) {
       const shouldCollapse = !showNonContributing;
       setIsCollapsed(shouldCollapse);
-      onCollapsedChange?.(shouldCollapse);
       prevTabState.current = showNonContributing;
     }
-  }, [showNonContributing, component.id, onCollapsedChange]);
+  }, [showNonContributing, component.id]);
 
-  const handleCollapsedChange = useCallback(
-    (collapsed: boolean) => {
-      setIsCollapsed(collapsed);
-      onCollapsedChange?.(collapsed);
-    },
-    [onCollapsedChange]
-  );
+  const handleCollapsedChange = useCallback((collapsed: boolean) => {
+    setIsCollapsed(collapsed);
+  }, []);
 
   const stacktraceProps =
     component.id === 'stacktrace'

--- a/static/app/components/events/groupingInfo/groupingComponent.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponent.tsx
@@ -1,3 +1,4 @@
+import {useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/core/button';
@@ -13,9 +14,15 @@ type Props = {
   component: EventGroupComponent;
   showNonContributing: boolean;
   maxVisibleItems?: number;
+  onCollapsedChange?: (collapsed: boolean) => void;
 };
 
-function GroupingComponent({component, showNonContributing, maxVisibleItems}: Props) {
+function GroupingComponent({
+  component,
+  showNonContributing,
+  maxVisibleItems,
+  onCollapsedChange,
+}: Props) {
   const shouldInlineValue = shouldInlineComponentValue(component);
 
   const GroupingComponentListItems =
@@ -23,17 +30,20 @@ function GroupingComponent({component, showNonContributing, maxVisibleItems}: Pr
       ? GroupingComponentStacktrace
       : GroupingComponentChildren;
 
-  // For stacktrace components, use frame-level collapse; otherwise use full collapse
   const isStacktraceComponent = component.id === 'stacktrace';
 
-  // Calculate total items for stacktrace components
   const totalItems = isStacktraceComponent
     ? (component.values as EventGroupComponent[])?.length || 0
     : 0;
   const maxItems = maxVisibleItems || 2;
   const hasHiddenItems = isStacktraceComponent && totalItems > maxItems;
 
-  const isCollapsed = showNonContributing;
+  const [isCollapsed, setIsCollapsed] = useState(!showNonContributing);
+
+  const handleCollapsedChange = (collapsed: boolean) => {
+    setIsCollapsed(collapsed);
+    onCollapsedChange?.(collapsed);
+  };
 
   return (
     <GroupingComponentWrapper isContributing={component.contributes}>
@@ -42,7 +52,6 @@ function GroupingComponent({component, showNonContributing, maxVisibleItems}: Pr
           size="xs"
           priority="link"
           icon={<IconChevron direction={isCollapsed ? 'down' : 'up'} legacySize="12px" />}
-          onClick={() => {}}
           aria-label={isCollapsed ? t('expand stacktrace') : t('collapse stacktrace')}
         />
       )}
@@ -55,6 +64,7 @@ function GroupingComponent({component, showNonContributing, maxVisibleItems}: Pr
         <GroupingComponentListItems
           component={component}
           showNonContributing={showNonContributing}
+          {...(isStacktraceComponent ? {onCollapsedChange: handleCollapsedChange} : {})}
         />
       </GroupingComponentList>
     </GroupingComponentWrapper>

--- a/static/app/components/events/groupingInfo/groupingComponent.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponent.tsx
@@ -52,7 +52,6 @@ function GroupingComponent({component, showNonContributing}: Props) {
       ? {
           collapsed: isCollapsed,
           onCollapsedChange: handleCollapsedChange,
-          maxVisibleItems,
         }
       : {};
 

--- a/static/app/components/events/groupingInfo/groupingComponent.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponent.tsx
@@ -21,7 +21,7 @@ type Props = {
 function GroupingComponent({
   component,
   showNonContributing,
-  maxVisibleItems,
+  maxVisibleItems = 2,
   onCollapsedChange,
 }: Props) {
   const shouldInlineValue = shouldInlineComponentValue(component);
@@ -36,8 +36,7 @@ function GroupingComponent({
   const totalItems = isStacktraceComponent
     ? (component.values as EventGroupComponent[])?.length || 0
     : 0;
-  const maxItems = maxVisibleItems || 2;
-  const hasHiddenItems = isStacktraceComponent && totalItems > maxItems;
+  const hasHiddenItems = isStacktraceComponent && totalItems > maxVisibleItems;
 
   const [isCollapsed, setIsCollapsed] = useState(!showNonContributing);
   const hasUserInteracted = useRef(false);

--- a/static/app/components/events/groupingInfo/groupingComponent.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponent.tsx
@@ -29,23 +29,20 @@ function GroupingComponent({
     component.id === 'stacktrace'
       ? GroupingComponentStacktrace
       : GroupingComponentChildren;
-  const isStacktrace = component.id === 'stacktrace';
-  const stacktraceValues = isStacktrace
-    ? (component.values as EventGroupComponent[])
-    : [];
-  const hasCollapsibleItems = isStacktrace && stacktraceValues.length > maxVisibleItems;
+  const stacktraceValues =
+    component.id === 'stacktrace' ? (component.values as EventGroupComponent[]) : [];
 
   const [isCollapsed, setIsCollapsed] = useState(!showNonContributing);
   const prevTabState = useRef(showNonContributing);
 
   useEffect(() => {
-    if (isStacktrace && prevTabState.current !== showNonContributing) {
+    if (component.id === 'stacktrace' && prevTabState.current !== showNonContributing) {
       const shouldCollapse = !showNonContributing;
       setIsCollapsed(shouldCollapse);
       onCollapsedChange?.(shouldCollapse);
       prevTabState.current = showNonContributing;
     }
-  }, [showNonContributing, isStacktrace, onCollapsedChange]);
+  }, [showNonContributing, component.id, onCollapsedChange]);
 
   const toggleCollapsed = () => {
     const newCollapsed = !isCollapsed;
@@ -53,16 +50,17 @@ function GroupingComponent({
     onCollapsedChange?.(newCollapsed);
   };
 
-  const stacktraceProps = isStacktrace
-    ? {collapsed: isCollapsed, onCollapsedChange: toggleCollapsed}
-    : {};
+  const stacktraceProps =
+    component.id === 'stacktrace'
+      ? {collapsed: isCollapsed, onCollapsedChange: toggleCollapsed}
+      : {};
 
   return (
     <GroupingComponentWrapper isContributing={component.contributes}>
       <span>
         {component.name || component.id}
         {component.hint && <GroupingHint>{` (${component.hint})`}</GroupingHint>}
-        {component.name === 'stack-trace' && hasCollapsibleItems && (
+        {component.id === 'stacktrace' && stacktraceValues.length > maxVisibleItems && (
           <CaretButton
             size="xs"
             priority="link"

--- a/static/app/components/events/groupingInfo/groupingComponent.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponent.tsx
@@ -8,7 +8,7 @@ import type {EventGroupComponent} from 'sentry/types/event';
 
 import GroupingComponentChildren from './groupingComponentChildren';
 import GroupingComponentStacktrace from './groupingComponentStacktrace';
-import {shouldInlineComponentValue} from './utils';
+import {getFrameGroups, shouldInlineComponentValue} from './utils';
 
 type Props = {
   component: EventGroupComponent;
@@ -29,8 +29,11 @@ function GroupingComponent({
     component.id === 'stacktrace'
       ? GroupingComponentStacktrace
       : GroupingComponentChildren;
-  const stacktraceValues =
-    component.id === 'stacktrace' ? (component.values as EventGroupComponent[]) : [];
+  const isStacktraceCollapsible =
+    component.id === 'stacktrace' &&
+    getFrameGroups(component, showNonContributing).some(
+      group => group.data.length > maxVisibleItems
+    );
 
   const [isCollapsed, setIsCollapsed] = useState(!showNonContributing);
   const prevTabState = useRef(showNonContributing);
@@ -59,7 +62,7 @@ function GroupingComponent({
       <span>
         {component.name || component.id}
         {component.hint && <GroupingHint>{` (${component.hint})`}</GroupingHint>}
-        {component.id === 'stacktrace' && stacktraceValues.length > maxVisibleItems && (
+        {component.id === 'stacktrace' && isStacktraceCollapsible && (
           <CollapseButton
             size="xs"
             priority="link"

--- a/static/app/components/events/groupingInfo/groupingComponent.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponent.tsx
@@ -52,6 +52,7 @@ function GroupingComponent({
           size="xs"
           priority="link"
           icon={<IconChevron direction={isCollapsed ? 'down' : 'up'} legacySize="12px" />}
+          onClick={() => handleCollapsedChange(!isCollapsed)}
           aria-label={isCollapsed ? t('expand stacktrace') : t('collapse stacktrace')}
         />
       )}
@@ -64,7 +65,9 @@ function GroupingComponent({
         <GroupingComponentListItems
           component={component}
           showNonContributing={showNonContributing}
-          {...(isStacktraceComponent ? {onCollapsedChange: handleCollapsedChange} : {})}
+          {...(isStacktraceComponent
+            ? {collapsed: isCollapsed, onCollapsedChange: handleCollapsedChange}
+            : {})}
         />
       </GroupingComponentList>
     </GroupingComponentWrapper>

--- a/static/app/components/events/groupingInfo/groupingComponent.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponent.tsx
@@ -25,6 +25,7 @@ function GroupingComponent({
   onCollapsedChange,
 }: Props) {
   const shouldInlineValue = shouldInlineComponentValue(component);
+
   const GroupingComponentListItems =
     component.id === 'stacktrace'
       ? GroupingComponentStacktrace

--- a/static/app/components/events/groupingInfo/groupingComponentChildren.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponentChildren.tsx
@@ -12,32 +12,44 @@ import {groupingComponentFilter} from './utils';
 type Props = {
   component: EventGroupComponent;
   showNonContributing: boolean;
+  isCollapsed?: boolean;
+  maxVisibleItems?: number;
+  onCollapseChange?: (collapsed: boolean) => void;
 };
 
-function GroupingComponentChildren({component, showNonContributing}: Props) {
+function GroupingComponentChildren({
+  component,
+  showNonContributing,
+  isCollapsed: _isCollapsed,
+  maxVisibleItems,
+  onCollapseChange: _onCollapseChange,
+}: Props) {
   return (
     <Fragment>
       {component.values
         .filter((value: any) => groupingComponentFilter(value, showNonContributing))
-        .map((value: any) => (
-          <GroupingComponentListItem key={typeof value === 'object' ? value.id : value}>
-            {typeof value === 'object' ? (
-              <GroupingComponent
-                component={value}
-                showNonContributing={showNonContributing}
-              />
-            ) : (
-              <GroupingValue
-                valueType={component.name || component.id}
-                contributes={component.contributes}
-              >
-                {typeof value === 'string' || typeof value === 'number'
-                  ? value
-                  : JSON.stringify(value, null, 2)}
-              </GroupingValue>
-            )}
-          </GroupingComponentListItem>
-        ))}
+        .map((value: any) => {
+          return (
+            <GroupingComponentListItem key={typeof value === 'object' ? value.id : value}>
+              {typeof value === 'object' ? (
+                <GroupingComponent
+                  component={value}
+                  showNonContributing={showNonContributing}
+                  maxVisibleItems={maxVisibleItems}
+                />
+              ) : (
+                <GroupingValue
+                  valueType={component.name || component.id}
+                  contributes={component.contributes}
+                >
+                  {typeof value === 'string' || typeof value === 'number'
+                    ? value
+                    : JSON.stringify(value, null, 2)}
+                </GroupingValue>
+              )}
+            </GroupingComponentListItem>
+          );
+        })}
     </Fragment>
   );
 }

--- a/static/app/components/events/groupingInfo/groupingComponentChildren.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponentChildren.tsx
@@ -12,44 +12,32 @@ import {groupingComponentFilter} from './utils';
 type Props = {
   component: EventGroupComponent;
   showNonContributing: boolean;
-  isCollapsed?: boolean;
-  maxVisibleItems?: number;
-  onCollapseChange?: (collapsed: boolean) => void;
 };
 
-function GroupingComponentChildren({
-  component,
-  showNonContributing,
-  isCollapsed: _isCollapsed,
-  maxVisibleItems,
-  onCollapseChange: _onCollapseChange,
-}: Props) {
+function GroupingComponentChildren({component, showNonContributing}: Props) {
   return (
     <Fragment>
       {component.values
         .filter((value: any) => groupingComponentFilter(value, showNonContributing))
-        .map((value: any) => {
-          return (
-            <GroupingComponentListItem key={typeof value === 'object' ? value.id : value}>
-              {typeof value === 'object' ? (
-                <GroupingComponent
-                  component={value}
-                  showNonContributing={showNonContributing}
-                  maxVisibleItems={maxVisibleItems}
-                />
-              ) : (
-                <GroupingValue
-                  valueType={component.name || component.id}
-                  contributes={component.contributes}
-                >
-                  {typeof value === 'string' || typeof value === 'number'
-                    ? value
-                    : JSON.stringify(value, null, 2)}
-                </GroupingValue>
-              )}
-            </GroupingComponentListItem>
-          );
-        })}
+        .map((value: any) => (
+          <GroupingComponentListItem key={typeof value === 'object' ? value.id : value}>
+            {typeof value === 'object' ? (
+              <GroupingComponent
+                component={value}
+                showNonContributing={showNonContributing}
+              />
+            ) : (
+              <GroupingValue
+                valueType={component.name || component.id}
+                contributes={component.contributes}
+              >
+                {typeof value === 'string' || typeof value === 'number'
+                  ? value
+                  : JSON.stringify(value, null, 2)}
+              </GroupingValue>
+            )}
+          </GroupingComponentListItem>
+        ))}
     </Fragment>
   );
 }

--- a/static/app/components/events/groupingInfo/groupingComponentFrames.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponentFrames.tsx
@@ -12,7 +12,7 @@ interface GroupingComponentFramesProps {
   items: React.ReactNode[];
   collapsed?: boolean;
   maxVisibleItems?: number;
-  onCollapsedChange?: (collapsed: boolean) => void; // NEW: controlled mode
+  onCollapsedChange?: (collapsed: boolean) => void;
 }
 
 function GroupingComponentFrames({
@@ -20,11 +20,10 @@ function GroupingComponentFrames({
   maxVisibleItems = 2,
   initialCollapsed,
   onCollapsedChange,
-  collapsed, // NEW
+  collapsed,
 }: GroupingComponentFramesProps) {
   const [internalCollapsed, setInternalCollapsed] = useState(initialCollapsed);
 
-  // keep internal in sync with initialCollapsed if uncontrolled
   useEffect(() => {
     if (collapsed === undefined) {
       setInternalCollapsed(initialCollapsed);

--- a/static/app/components/events/groupingInfo/groupingComponentFrames.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponentFrames.tsx
@@ -11,12 +11,14 @@ interface GroupingComponentFramesProps {
   initialCollapsed: boolean;
   items: React.ReactNode[];
   maxVisibleItems?: number;
+  onCollapseChange?: (collapsed: boolean) => void;
 }
 
 function GroupingComponentFrames({
   items,
   maxVisibleItems = 2,
   initialCollapsed,
+  onCollapseChange,
 }: GroupingComponentFramesProps) {
   const [collapsed, setCollapsed] = useState(initialCollapsed);
   const isCollapsible = items.length > maxVisibleItems;
@@ -24,6 +26,11 @@ function GroupingComponentFrames({
   useEffect(() => {
     setCollapsed(initialCollapsed);
   }, [initialCollapsed]);
+
+  const handleCollapseChange = (newCollapsed: boolean) => {
+    setCollapsed(newCollapsed);
+    onCollapseChange?.(newCollapsed);
+  };
 
   return (
     <Fragment>
@@ -43,7 +50,7 @@ function GroupingComponentFrames({
                 size="sm"
                 priority="link"
                 icon={<IconAdd legacySize="8px" />}
-                onClick={() => setCollapsed(false)}
+                onClick={() => handleCollapseChange(false)}
               >
                 {tct('show [numberOfFrames] similar', {
                   numberOfFrames: items.length - maxVisibleItems,
@@ -62,7 +69,7 @@ function GroupingComponentFrames({
             size="sm"
             priority="link"
             icon={<IconSubtract legacySize="8px" />}
-            onClick={() => setCollapsed(true)}
+            onClick={() => handleCollapseChange(true)}
           >
             {tct('collapse [numberOfFrames] similar', {
               numberOfFrames: items.length - maxVisibleItems,

--- a/static/app/components/events/groupingInfo/groupingComponentFrames.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponentFrames.tsx
@@ -11,12 +11,14 @@ interface GroupingComponentFramesProps {
   initialCollapsed: boolean;
   items: React.ReactNode[];
   maxVisibleItems?: number;
+  onCollapsedChange?: (collapsed: boolean) => void;
 }
 
 function GroupingComponentFrames({
   items,
   maxVisibleItems = 2,
   initialCollapsed,
+  onCollapsedChange,
 }: GroupingComponentFramesProps) {
   const [collapsed, setCollapsed] = useState(initialCollapsed);
   const isCollapsible = items.length > maxVisibleItems;
@@ -24,6 +26,10 @@ function GroupingComponentFrames({
   useEffect(() => {
     setCollapsed(initialCollapsed);
   }, [initialCollapsed]);
+
+  useEffect(() => {
+    onCollapsedChange?.(collapsed);
+  }, [collapsed, onCollapsedChange]);
 
   return (
     <Fragment>

--- a/static/app/components/events/groupingInfo/groupingComponentFrames.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponentFrames.tsx
@@ -33,7 +33,7 @@ function GroupingComponentFrames({
   const isControlled = collapsed !== undefined;
   const value = isControlled ? collapsed : internalCollapsed;
 
-  const setValue = (next: boolean) => {
+  const setCollapsed = (next: boolean) => {
     if (!isControlled) setInternalCollapsed(next);
     onCollapsedChange?.(next);
   };
@@ -58,7 +58,7 @@ function GroupingComponentFrames({
                 size="sm"
                 priority="link"
                 icon={<IconAdd legacySize="8px" />}
-                onClick={() => setValue(false)}
+                onClick={() => setCollapsed(false)}
               >
                 {tct('show [numberOfFrames] similar', {
                   numberOfFrames: items.length - maxVisibleItems,
@@ -77,7 +77,7 @@ function GroupingComponentFrames({
             size="sm"
             priority="link"
             icon={<IconSubtract legacySize="8px" />}
-            onClick={() => setValue(true)}
+            onClick={() => setCollapsed(true)}
           >
             {tct('collapse [numberOfFrames] similar', {
               numberOfFrames: items.length - maxVisibleItems,

--- a/static/app/components/events/groupingInfo/groupingComponentFrames.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponentFrames.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useEffect, useState} from 'react';
+import {Fragment} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -8,9 +8,8 @@ import {tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 
 interface GroupingComponentFramesProps {
-  initialCollapsed: boolean;
+  collapsed: boolean;
   items: React.ReactNode[];
-  collapsed?: boolean;
   maxVisibleItems?: number;
   onCollapsedChange?: (collapsed: boolean) => void;
 }
@@ -18,32 +17,19 @@ interface GroupingComponentFramesProps {
 function GroupingComponentFrames({
   items,
   maxVisibleItems = 2,
-  initialCollapsed,
   onCollapsedChange,
   collapsed,
 }: GroupingComponentFramesProps) {
-  const [internalCollapsed, setInternalCollapsed] = useState(initialCollapsed);
-
   const isCollapsible = items.length > maxVisibleItems;
 
-  useEffect(() => {
-    if (collapsed === undefined) {
-      setInternalCollapsed(initialCollapsed);
-    }
-  }, [initialCollapsed, collapsed]);
-
-  const isControlled = collapsed !== undefined;
-  const value = isControlled ? collapsed : internalCollapsed;
-
   const setCollapsed = (next: boolean) => {
-    if (!isControlled) setInternalCollapsed(next);
     onCollapsedChange?.(next);
   };
 
   return (
     <Fragment>
       {items.map((item, index) => {
-        if (!value || index < maxVisibleItems) {
+        if (!collapsed || index < maxVisibleItems) {
           return (
             <GroupingComponentListItem isCollapsible={isCollapsible} key={index}>
               {item}
@@ -71,7 +57,7 @@ function GroupingComponentFrames({
         return null;
       })}
 
-      {!value && items.length > maxVisibleItems && (
+      {!collapsed && items.length > maxVisibleItems && (
         <GroupingComponentListItem>
           <ToggleCollapse
             size="sm"

--- a/static/app/components/events/groupingInfo/groupingComponentFrames.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponentFrames.tsx
@@ -24,6 +24,8 @@ function GroupingComponentFrames({
 }: GroupingComponentFramesProps) {
   const [internalCollapsed, setInternalCollapsed] = useState(initialCollapsed);
 
+  const isCollapsible = items.length > maxVisibleItems;
+
   useEffect(() => {
     if (collapsed === undefined) {
       setInternalCollapsed(initialCollapsed);
@@ -37,8 +39,6 @@ function GroupingComponentFrames({
     if (!isControlled) setInternalCollapsed(next);
     onCollapsedChange?.(next);
   };
-
-  const isCollapsible = items.length > maxVisibleItems;
 
   return (
     <Fragment>

--- a/static/app/components/events/groupingInfo/groupingComponentFrames.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponentFrames.tsx
@@ -11,14 +11,12 @@ interface GroupingComponentFramesProps {
   initialCollapsed: boolean;
   items: React.ReactNode[];
   maxVisibleItems?: number;
-  onCollapseChange?: (collapsed: boolean) => void;
 }
 
 function GroupingComponentFrames({
   items,
   maxVisibleItems = 2,
   initialCollapsed,
-  onCollapseChange,
 }: GroupingComponentFramesProps) {
   const [collapsed, setCollapsed] = useState(initialCollapsed);
   const isCollapsible = items.length > maxVisibleItems;
@@ -26,11 +24,6 @@ function GroupingComponentFrames({
   useEffect(() => {
     setCollapsed(initialCollapsed);
   }, [initialCollapsed]);
-
-  const handleCollapseChange = (newCollapsed: boolean) => {
-    setCollapsed(newCollapsed);
-    onCollapseChange?.(newCollapsed);
-  };
 
   return (
     <Fragment>
@@ -50,7 +43,7 @@ function GroupingComponentFrames({
                 size="sm"
                 priority="link"
                 icon={<IconAdd legacySize="8px" />}
-                onClick={() => handleCollapseChange(false)}
+                onClick={() => setCollapsed(false)}
               >
                 {tct('show [numberOfFrames] similar', {
                   numberOfFrames: items.length - maxVisibleItems,
@@ -69,7 +62,7 @@ function GroupingComponentFrames({
             size="sm"
             priority="link"
             icon={<IconSubtract legacySize="8px" />}
-            onClick={() => handleCollapseChange(true)}
+            onClick={() => setCollapsed(true)}
           >
             {tct('collapse [numberOfFrames] similar', {
               numberOfFrames: items.length - maxVisibleItems,

--- a/static/app/components/events/groupingInfo/groupingComponentStacktrace.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponentStacktrace.tsx
@@ -61,7 +61,6 @@ function GroupingComponentStacktrace({
             />
           ))}
           collapsed={collapsed}
-          initialCollapsed={!showNonContributing}
           onCollapsedChange={onCollapsedChange}
         />
       ))}

--- a/static/app/components/events/groupingInfo/groupingComponentStacktrace.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponentStacktrace.tsx
@@ -1,7 +1,5 @@
-import {Fragment, useCallback, useEffect, useMemo, useState} from 'react';
-import styled from '@emotion/styled';
+import {Fragment} from 'react';
 
-import {space} from 'sentry/styles/space';
 import type {EventGroupComponent} from 'sentry/types/event';
 
 import GroupingComponent from './groupingComponent';
@@ -16,22 +14,11 @@ type FrameGroup = {
 type Props = {
   component: EventGroupComponent;
   showNonContributing: boolean;
-  isCollapsed?: boolean;
-  maxVisibleItems?: number;
-  onCollapseChange?: (collapsed: boolean) => void;
 };
 
-function GroupingComponentStacktrace({
-  component,
-  showNonContributing,
-  isCollapsed = false,
-  maxVisibleItems = 2,
-  onCollapseChange,
-}: Props) {
-  const [frameGroupStates, setFrameGroupStates] = useState<boolean[]>([]);
-
-  const frameGroups = useMemo(() => {
-    const groups: FrameGroup[] = [];
+function GroupingComponentStacktrace({component, showNonContributing}: Props) {
+  const getFrameGroups = () => {
+    const frameGroups: FrameGroup[] = [];
 
     (component.values as EventGroupComponent[])
       .filter(value => groupingComponentFilter(value, showNonContributing))
@@ -42,82 +29,35 @@ function GroupingComponentStacktrace({
           .sort((a, b) => a.localeCompare(b))
           .join('');
 
-        const lastGroup = groups[groups.length - 1];
+        const lastGroup = frameGroups[frameGroups.length - 1];
 
         if (lastGroup?.key === key) {
           lastGroup.data.push(value);
         } else {
-          groups.push({key, data: [value]});
+          frameGroups.push({key, data: [value]});
         }
       });
 
-    return groups;
-  }, [component.values, showNonContributing]);
-
-  useEffect(() => {
-    const initialStates = frameGroups.map(() => isCollapsed);
-    setFrameGroupStates(initialStates);
-  }, [frameGroups, isCollapsed]);
-
-  const handleFrameGroupCollapseChange = useCallback(
-    (index: number, collapsed: boolean) => {
-      setFrameGroupStates(prev => {
-        const newStates = [...prev];
-        newStates[index] = collapsed;
-        return newStates;
-      });
-    },
-    []
-  );
-
-  // Track when all frame groups change their collapse state to sync with parent
-  useEffect(() => {
-    if (onCollapseChange && frameGroups.length > 0) {
-      // Determine if the overall stacktrace should be considered collapsed
-      // If any frame group is expanded (not collapsed), the stacktrace is expanded
-      const anyFrameGroupExpanded = frameGroupStates.some(state => !state);
-      onCollapseChange(!anyFrameGroupExpanded);
-    }
-  }, [frameGroupStates, frameGroups.length, onCollapseChange]);
+    return frameGroups;
+  };
 
   return (
     <Fragment>
-      {frameGroups.map((group, index) => {
-        // When parent is collapsed, only show up to maxVisibleItems frame groups
-        if (isCollapsed && index >= maxVisibleItems) {
-          return null;
-        }
-
-        const groupIsCollapsed = frameGroupStates[index] ?? isCollapsed;
-        const hasMultipleFrames = group.data.length > 2;
-
-        return (
-          <FrameGroupContainer key={index}>
-            <GroupingComponentFrames
-              items={group.data.map((v, idx) => (
-                <GroupingComponent
-                  key={idx}
-                  component={v}
-                  showNonContributing={showNonContributing}
-                  maxVisibleItems={maxVisibleItems}
-                />
-              ))}
-              initialCollapsed={groupIsCollapsed}
-              onCollapseChange={collapsed =>
-                handleFrameGroupCollapseChange(index, collapsed)
-              }
-              maxVisibleItems={hasMultipleFrames ? 2 : undefined}
+      {getFrameGroups().map((group, index) => (
+        <GroupingComponentFrames
+          key={index}
+          items={group.data.map((v, idx) => (
+            <GroupingComponent
+              key={idx}
+              component={v}
+              showNonContributing={showNonContributing}
             />
-          </FrameGroupContainer>
-        );
-      })}
+          ))}
+          initialCollapsed={!showNonContributing}
+        />
+      ))}
     </Fragment>
   );
 }
-
-const FrameGroupContainer = styled('div')`
-  margin-bottom: ${space(2)};
-  position: relative;
-`;
 
 export default GroupingComponentStacktrace;

--- a/static/app/components/events/groupingInfo/groupingComponentStacktrace.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponentStacktrace.tsx
@@ -4,12 +4,7 @@ import type {EventGroupComponent} from 'sentry/types/event';
 
 import GroupingComponent from './groupingComponent';
 import GroupingComponentFrames from './groupingComponentFrames';
-import {groupingComponentFilter} from './utils';
-
-type FrameGroup = {
-  data: EventGroupComponent[];
-  key: string;
-};
+import {getFrameGroups} from './utils';
 
 type Props = {
   component: EventGroupComponent;
@@ -24,33 +19,9 @@ function GroupingComponentStacktrace({
   onCollapsedChange,
   collapsed = false,
 }: Props) {
-  const getFrameGroups = () => {
-    const frameGroups: FrameGroup[] = [];
-
-    (component.values as EventGroupComponent[])
-      .filter(value => groupingComponentFilter(value, showNonContributing))
-      .forEach(value => {
-        const key = (value.values as EventGroupComponent[])
-          .filter(v => groupingComponentFilter(v, showNonContributing))
-          .map(v => v.id)
-          .sort((a, b) => a.localeCompare(b))
-          .join('');
-
-        const lastGroup = frameGroups[frameGroups.length - 1];
-
-        if (lastGroup?.key === key) {
-          lastGroup.data.push(value);
-        } else {
-          frameGroups.push({key, data: [value]});
-        }
-      });
-
-    return frameGroups;
-  };
-
   return (
     <Fragment>
-      {getFrameGroups().map((group, index) => (
+      {getFrameGroups(component, showNonContributing).map((group, index) => (
         <GroupingComponentFrames
           key={index}
           items={group.data.map((v, idx) => (

--- a/static/app/components/events/groupingInfo/groupingComponentStacktrace.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponentStacktrace.tsx
@@ -14,9 +14,14 @@ type FrameGroup = {
 type Props = {
   component: EventGroupComponent;
   showNonContributing: boolean;
+  onCollapsedChange?: (collapsed: boolean) => void;
 };
 
-function GroupingComponentStacktrace({component, showNonContributing}: Props) {
+function GroupingComponentStacktrace({
+  component,
+  showNonContributing,
+  onCollapsedChange,
+}: Props) {
   const getFrameGroups = () => {
     const frameGroups: FrameGroup[] = [];
 
@@ -54,6 +59,7 @@ function GroupingComponentStacktrace({component, showNonContributing}: Props) {
             />
           ))}
           initialCollapsed={!showNonContributing}
+          onCollapsedChange={onCollapsedChange}
         />
       ))}
     </Fragment>

--- a/static/app/components/events/groupingInfo/groupingComponentStacktrace.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponentStacktrace.tsx
@@ -1,5 +1,10 @@
-import {Fragment} from 'react';
+import {Fragment, useState} from 'react';
+import styled from '@emotion/styled';
 
+import {Button} from 'sentry/components/core/button';
+import {IconSubtract} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import type {EventGroupComponent} from 'sentry/types/event';
 
 import GroupingComponent from './groupingComponent';
@@ -17,6 +22,8 @@ type Props = {
 };
 
 function GroupingComponentStacktrace({component, showNonContributing}: Props) {
+  const [allCollapsed, setAllCollapsed] = useState(false);
+
   const getFrameGroups = () => {
     const frameGroups: FrameGroup[] = [];
 
@@ -41,9 +48,24 @@ function GroupingComponentStacktrace({component, showNonContributing}: Props) {
     return frameGroups;
   };
 
+  const frameGroups = getFrameGroups();
+  const hasCollapsibleGroups = frameGroups.some(group => group.data.length > 2);
+
   return (
     <Fragment>
-      {getFrameGroups().map((group, index) => (
+      {hasCollapsibleGroups && (
+        <CollapseAllContainer>
+          <Button
+            size="sm"
+            priority="link"
+            icon={<IconSubtract legacySize="8px" />}
+            onClick={() => setAllCollapsed(!allCollapsed)}
+          >
+            {allCollapsed ? t('expand all') : t('collapse all')}
+          </Button>
+        </CollapseAllContainer>
+      )}
+      {frameGroups.map((group, index) => (
         <GroupingComponentFrames
           key={index}
           items={group.data.map((v, idx) => (
@@ -53,11 +75,17 @@ function GroupingComponentStacktrace({component, showNonContributing}: Props) {
               showNonContributing={showNonContributing}
             />
           ))}
-          initialCollapsed={!showNonContributing}
+          initialCollapsed={!showNonContributing || allCollapsed}
         />
       ))}
     </Fragment>
   );
 }
+
+const CollapseAllContainer = styled('div')`
+  display: flex;
+  justify-content: flex-start;
+  margin-bottom: ${space(1)};
+`;
 
 export default GroupingComponentStacktrace;

--- a/static/app/components/events/groupingInfo/groupingComponentStacktrace.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponentStacktrace.tsx
@@ -14,6 +14,7 @@ type FrameGroup = {
 type Props = {
   component: EventGroupComponent;
   showNonContributing: boolean;
+  collapsed?: boolean;
   onCollapsedChange?: (collapsed: boolean) => void;
 };
 
@@ -21,6 +22,7 @@ function GroupingComponentStacktrace({
   component,
   showNonContributing,
   onCollapsedChange,
+  collapsed = false,
 }: Props) {
   const getFrameGroups = () => {
     const frameGroups: FrameGroup[] = [];
@@ -58,6 +60,7 @@ function GroupingComponentStacktrace({
               showNonContributing={showNonContributing}
             />
           ))}
+          collapsed={collapsed}
           initialCollapsed={!showNonContributing}
           onCollapsedChange={onCollapsedChange}
         />

--- a/static/app/components/events/groupingInfo/utils.tsx
+++ b/static/app/components/events/groupingInfo/utils.tsx
@@ -35,10 +35,26 @@ export function getFrameGroups(
 ): FrameGroup[] {
   const frameGroups: FrameGroup[] = [];
 
-  (component.values as EventGroupComponent[])
+  if (!Array.isArray(component.values)) {
+    return frameGroups;
+  }
+
+  component.values
+    .filter(
+      (value): value is EventGroupComponent =>
+        typeof value === 'object' && value !== null && 'id' in value
+    )
     .filter(value => groupingComponentFilter(value, showNonContributing))
     .forEach(value => {
-      const key = (value.values as EventGroupComponent[])
+      if (!Array.isArray(value.values)) {
+        return;
+      }
+
+      const key = value.values
+        .filter(
+          (v): v is EventGroupComponent =>
+            typeof v === 'object' && v !== null && 'id' in v
+        )
         .filter(v => groupingComponentFilter(v, showNonContributing))
         .map(v => v.id)
         .sort((a, b) => a.localeCompare(b))

--- a/static/app/components/events/groupingInfo/utils.tsx
+++ b/static/app/components/events/groupingInfo/utils.tsx
@@ -23,3 +23,35 @@ export function groupingComponentFilter(
 
   return true;
 }
+
+type FrameGroup = {
+  data: EventGroupComponent[];
+  key: string;
+};
+
+export function getFrameGroups(
+  component: EventGroupComponent,
+  showNonContributing: boolean
+): FrameGroup[] {
+  const frameGroups: FrameGroup[] = [];
+
+  (component.values as EventGroupComponent[])
+    .filter(value => groupingComponentFilter(value, showNonContributing))
+    .forEach(value => {
+      const key = (value.values as EventGroupComponent[])
+        .filter(v => groupingComponentFilter(v, showNonContributing))
+        .map(v => v.id)
+        .sort((a, b) => a.localeCompare(b))
+        .join('');
+
+      const lastGroup = frameGroups[frameGroups.length - 1];
+
+      if (lastGroup?.key === key) {
+        lastGroup.data.push(value);
+      } else {
+        frameGroups.push({key, data: [value]});
+      }
+    });
+
+  return frameGroups;
+}


### PR DESCRIPTION
As of #98255, the grouping stacktrace is auto expanded when set to see all values. If the stacktrace is long, this can hide the `- collapse x values` button at the bottom so you have to scroll to collapse the values. Added a button next to `stack-trace` so it is easier to collapse stacktraces with a lot of frames. 

<img width="840" height="180" alt="image" src="https://github.com/user-attachments/assets/ce04e18b-ad58-4884-b95d-a630139d1c73" />

