### PR TITLE
ref(replay): update summary endpoint blueprint and 404 for missing replays

### DIFF
--- a/src/sentry/replays/blueprints/api.md
+++ b/src/sentry/replays/blueprints/api.md
@@ -587,7 +587,7 @@ A POST request is issued with no body. The URL and authorization context is used
   - start (optional, string) - ISO 8601 format (`YYYY-MM-DDTHH:mm:ss.sssZ`).
   - end (optional, string) - ISO 8601 format. Required if `start` is set.
 
-`start` and `end` default to the last 90 days. If the replay is not found in the specified time range this endpoint will 404.
+`start` and `end` default to the last 90 days. If the replay is not found in the specified time range, this endpoint will 404.
 
 ### Fetch Replay Summary Task State [GET]
 

--- a/src/sentry/replays/blueprints/api.md
+++ b/src/sentry/replays/blueprints/api.md
@@ -581,23 +581,38 @@ A POST request is issued with no body. The URL and authorization context is used
 
 - Response 204
 
-## Replay Summarize Breadcrumb [/projects/<organization_id_or_slug>/<project_id_or_slug>/replays/<replay_id>/summarize/breadcrumbs/]
+## Replay Summarize [/projects/<organization_id_or_slug>/<project_id_or_slug>/replays/<replay_id>/summarize/]
 
-### Fetch Replay Breadcrumb Summary [GET]
+- Parameters
+  - start (optional, string) - ISO 8601 format (`YYYY-MM-DDTHH:mm:ss.sssZ`).
+  - end (optional, string) - ISO 8601 format. Required if `start` is set.
 
-| Column                   | Type            | Description                                                                                   |
-| ------------------------ | --------------- | --------------------------------------------------------------------------------------------- |
-| title                    | str             | The main title of the user journey summary.                                                   |
-| summary                  | str             | A concise summary featuring the highlights of the user's journey while using the application. |
-| time_ranges              | list[TimeRange] | A list of TimeRange objects.                                                                  |
-| time_ranges.period_start | number          | The start time (UNIX timestamp) of the analysis window.                                       |
-| time_ranges.period_end   | number          | The end time (UNIX timestamp) of the analysis window.                                         |
-| time_ranges.period_title | str             | A concise summary utilizing 6 words or fewer describing what happened during the time range.  |
+`start` and `end` default to the last 90 days. If the replay is not found in the specified time range this endpoint will 404.
+
+### Fetch Replay Summary Task State [GET]
+
+Retrieve the last status of a replay summary task. If the status is "completed", summary results are returned in `data`.
+
+| Column                        | Type             | Description                                                                                                            |
+| ----------------------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| status                        | str              | One of "processing", "not_started", "error", or "completed".                                                           |
+| created_at                    | optional[str]    | Time this status was last updated. ISO 8601 format. Null if not started.                                               |
+| num_segments                  | optional[number] | The number of replay segments used for this summary. E.g. 8 means the first 8 segments were used. Null if not started. |
+| data                          | optional[object] | The summary results. Null if not completed.                                                                            |
+| data.title                    | str              | The main title of the user journey summary.                                                                            |
+| data.summary                  | str              | A concise summary featuring the highlights of the user's journey while using the application.                          |
+| data.time_ranges              | list[TimeRange]  | A list of TimeRange objects.                                                                                           |
+| data.time_ranges.period_start | number           | The start time (UNIX timestamp) of the analysis window.                                                                |
+| data.time_ranges.period_end   | number           | The end time (UNIX timestamp) of the analysis window.                                                                  |
+| data.time_ranges.period_title | str              | A concise summary utilizing 6 words or fewer describing what happened during the time range.                           |
 
 - Response 200
 
   ```json
   {
+    "status": "completed",
+    "created_at": "2025-06-06T14:05:57.909921",
+    "num_segments": 5,
     "data": {
       "title": "Something Happened",
       "summary": "The application broke",
@@ -610,6 +625,46 @@ A POST request is issued with no body. The URL and authorization context is used
       ]
     }
   }
+  ```
+
+  ```json
+  {
+    "status": "error",
+    "created_at": "2025-06-06T14:05:11.909921",
+    "num_segments": 5,
+    "data": null
+  }
+  ```
+
+  ```json
+  {
+    "status": "not_started",
+    "created_at": null,
+    "num_segments": null,
+    "data": null
+  }
+  ```
+
+### Submit a Replay Summary Task [POST]
+
+Submit a task to generate a replay summary. If an older task is processing the same replay and `num_segments`, the new request will be dropped. If `num_segments` has increased or the other task is too old, the new one will overwrite it.
+
+- Request
+
+  ```json
+  {
+    "num_segments": 5,
+    "temperature": 0.3
+  }
+  ```
+
+  To summarize the whole replay, submit an up-to-date segment count in `num_segments`. `temperature` must be a number between 0 and 1 (inclusive).
+  Higher `temperature` causes more randomness in the results. Submitting it is optional - defaults to 0.2.
+
+- Response 200 (Empty Response)
+
+  ```json
+  {}
   ```
 
 ## Replay Deletion Jobs [/projects/<organization_id_or_slug>/<project_id_or_slug>/replays/jobs/delete/]

--- a/src/sentry/replays/blueprints/api.md
+++ b/src/sentry/replays/blueprints/api.md
@@ -647,7 +647,7 @@ Retrieve the last status of a replay summary task. If the status is "completed",
 
 ### Submit a Replay Summary Task [POST]
 
-Submit a task to generate a replay summary. If an older task is processing the same replay and `num_segments`, the new request will be dropped. If `num_segments` has increased or the other task is too old, the new one will overwrite it.
+Submit a task to generate a replay summary. This will overwrite any previous task state. If an older task is processing the same replay and `num_segments`, the new task will be dropped. If `num_segments` has increased or the other task is too old, the new one will overwrite it.
 
 - Request
 

--- a/src/sentry/replays/blueprints/api.md
+++ b/src/sentry/replays/blueprints/api.md
@@ -647,7 +647,7 @@ Retrieve the last status of a replay summary task. If the status is "completed",
 
 ### Submit a Replay Summary Task [POST]
 
-Submit a task to generate a replay summary. This will overwrite any previous task state. If an older task is processing the same replay and `num_segments`, the new task will be dropped. If `num_segments` has increased or the other task is too old, the new one will overwrite it.
+Submit a task to generate a replay summary for the first `num_segments` segments of the replay recording. This will overwrite any previous task state. If an older task is processing the same replay and `num_segments`, the new task will be dropped. If `num_segments` has increased or the other task is too old, the new one will overwrite it.
 
 - Request
 

--- a/src/sentry/replays/blueprints/api.md
+++ b/src/sentry/replays/blueprints/api.md
@@ -604,7 +604,7 @@ Retrieve the last status of a replay summary task. If the status is "completed",
 | data.time_ranges              | list[TimeRange]  | A list of TimeRange objects.                                                                                           |
 | data.time_ranges.period_start | number           | The start time (UNIX timestamp) of the analysis window.                                                                |
 | data.time_ranges.period_end   | number           | The end time (UNIX timestamp) of the analysis window.                                                                  |
-| data.time_ranges.period_title | str              | A concise summary utilizing 6 words or fewer describing what happened during the time range.                           |
+| data.time_ranges.period_title | str              | A concise summary utilizing 9 words or fewer describing what happened during the time range.                           |
 
 - Response 200
 

--- a/src/sentry/replays/endpoints/project_replay_summary.py
+++ b/src/sentry/replays/endpoints/project_replay_summary.py
@@ -207,10 +207,17 @@ class ProjectReplaySummaryEndpoint(ProjectEndpoint):
             )
             processed_response = process_raw_response(
                 snuba_response,
-                fields=request.query_params.getlist("field"),
+                fields=[],  # Defaults to all fields.
             )
-            error_ids = processed_response[0].get("error_ids", []) if processed_response else []
-            trace_ids = processed_response[0].get("trace_ids", []) if processed_response else []
+
+            if not processed_response:
+                return self.respond(
+                    {"detail": "Replay not found."},
+                    status=404,
+                )
+
+            error_ids = processed_response[0].get("error_ids", [])
+            trace_ids = processed_response[0].get("trace_ids", [])
 
             # Fetch same-trace errors.
             trace_connected_errors = fetch_trace_connected_errors(


### PR DESCRIPTION
Closes [REPLAY-668: Update Sentry API blueprint](https://linear.app/getsentry/issue/REPLAY-668/update-sentry-api-blueprint)
Closes [REPLAY-669: 404 if replay is missing from the date range](https://linear.app/getsentry/issue/REPLAY-669/404-if-replay-is-missing-from-the-date-range)