### PR TITLE
fix(aci): Display 404 monitor message

### DIFF
--- a/static/app/views/detectors/detail.tsx
+++ b/static/app/views/detectors/detail.tsx
@@ -17,6 +17,7 @@ export default function DetectorDetails() {
     data: detector,
     isPending,
     isError,
+    error,
     refetch,
   } = useDetectorQuery(params.detectorId);
 
@@ -27,7 +28,12 @@ export default function DetectorDetails() {
   }
 
   if (isError) {
-    return <LoadingError onRetry={refetch} />;
+    return (
+      <LoadingError
+        message={error.status === 404 ? t('The monitor could not be found.') : undefined}
+        onRetry={refetch}
+      />
+    );
   }
 
   if (!project) {

--- a/static/app/views/detectors/edit.tsx
+++ b/static/app/views/detectors/edit.tsx
@@ -16,6 +16,7 @@ export default function DetectorEdit() {
     data: detector,
     isPending,
     isError,
+    error,
     refetch,
   } = useDetectorQuery(params.detectorId);
 
@@ -27,7 +28,12 @@ export default function DetectorEdit() {
   }
 
   if (isError) {
-    return <LoadingError onRetry={refetch} />;
+    return (
+      <LoadingError
+        message={error.status === 404 ? t('The monitor could not be found.') : undefined}
+        onRetry={refetch}
+      />
+    );
   }
 
   if (!project) {


### PR DESCRIPTION
Instead of the generic error message, inform that the monitor could not be found.
