### PR TITLE
fix(replay): pass in start/end params to selector endpoint

### DIFF
--- a/static/app/utils/replays/hooks/useDeadRageSelectors.tsx
+++ b/static/app/utils/replays/hooks/useDeadRageSelectors.tsx
@@ -1,4 +1,5 @@
 import {useApiQuery} from 'sentry/utils/queryClient';
+import {decodeList, decodeScalar} from 'sentry/utils/queryString';
 import hydratedSelectorData from 'sentry/utils/replays/hydrateSelectorData';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -20,9 +21,11 @@ export default function useDeadRageSelectors(params: DeadRageSelectorQueryParams
           query: {
             query: '!count_dead_clicks:0',
             cursor: params.cursor,
-            environment: query.environment,
+            environment: decodeList(query.environment),
             project: query.project,
             statsPeriod: query.statsPeriod,
+            start: decodeScalar(query.start),
+            end: decodeScalar(query.end),
             per_page: params.per_page,
             sort: query[params.prefix + 'sort'] ?? params.sort,
           },


### PR DESCRIPTION
we weren't passing in start/end params. this means that currently, when a user filters on the replay index by start/end time, the rage & dead click widgets do not update. closes https://linear.app/getsentry/issue/REPLAY-681/add-startend-params-to-selector-query-on-frontend

before:


https://github.com/user-attachments/assets/b125f77b-1325-4084-b7b8-6d9bbb9d8eaa


after:

https://github.com/user-attachments/assets/34f7baea-dbc1-45fb-a3a5-e5fe88f53ae9

