### PR TITLE
fix(aci): Precise redis project ID clean-up via Lua script

### DIFF
--- a/src/sentry/buffer/base.py
+++ b/src/sentry/buffer/base.py
@@ -38,6 +38,8 @@ class Buffer(Service):
         "get_hash_length",
         "delete_hash",
         "delete_key",
+        "conditional_delete_from_sorted_sets",
+        "conditional_delete_from_sorted_set",
     )
 
     def get(
@@ -98,6 +100,24 @@ class Buffer(Service):
 
     def delete_keys(self, keys: list[str], min: float, max: float) -> None:
         return None
+
+    def conditional_delete_from_sorted_sets(
+        self, keys: list[str], project_ids_and_timestamps: list[tuple[int, float]]
+    ) -> dict[str, list[int]]:
+        """
+        Remove project IDs from multiple sorted sets only if their current score is <= the provided timestamp.
+        Default implementation returns empty dict (no operations performed).
+        """
+        return {}
+
+    def conditional_delete_from_sorted_set(
+        self, key: str, project_ids_and_timestamps: list[tuple[int, float]]
+    ) -> list[int]:
+        """
+        Remove project IDs from a single sorted set only if their current score is <= the provided timestamp.
+        Default implementation returns empty list (no operations performed).
+        """
+        return []
 
     def incr(
         self,

--- a/src/sentry/buffer/base.py
+++ b/src/sentry/buffer/base.py
@@ -39,7 +39,6 @@ class Buffer(Service):
         "delete_hash",
         "delete_key",
         "conditional_delete_from_sorted_sets",
-        "conditional_delete_from_sorted_set",
     )
 
     def get(
@@ -104,20 +103,7 @@ class Buffer(Service):
     def conditional_delete_from_sorted_sets(
         self, keys: list[str], project_ids_and_timestamps: list[tuple[int, float]]
     ) -> dict[str, list[int]]:
-        """
-        Remove project IDs from multiple sorted sets only if their current score is <= the provided timestamp.
-        Default implementation returns empty dict (no operations performed).
-        """
         return {}
-
-    def conditional_delete_from_sorted_set(
-        self, key: str, project_ids_and_timestamps: list[tuple[int, float]]
-    ) -> list[int]:
-        """
-        Remove project IDs from a single sorted set only if their current score is <= the provided timestamp.
-        Default implementation returns empty list (no operations performed).
-        """
-        return []
 
     def incr(
         self,

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3165,6 +3165,12 @@ register(
     default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "buffer.conditional_delete_enabled",
+    type=Bool,
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # Restrict uptime issue creation for specific host provider identifiers. Items
 # in this list map to the `host_provider_id` column in the UptimeSubscription

--- a/src/sentry/scripts/alerts/conditional_zrem.lua
+++ b/src/sentry/scripts/alerts/conditional_zrem.lua
@@ -1,0 +1,28 @@
+-- Conditional sorted set member removal for a single key
+-- Removes members from a sorted set only if their current score is <= the provided max_score
+--
+-- KEYS[1]: The sorted set key
+-- ARGV: Pairs of member and max_score values
+--       Format: [member1, max_score1, member2, max_score2, ...]
+--
+-- Returns: List of members that were actually removed
+
+local key = KEYS[1]
+local removed = {}
+
+-- Process pairs of member and max_score
+for i = 1, #ARGV, 2 do
+    local member = ARGV[i]
+    local max_score = tonumber(ARGV[i + 1])
+
+    -- Get the current score of the member
+    local current_score = redis.call('ZSCORE', key, member)
+
+    -- If member exists and score is <= max_score, remove it
+    if current_score and tonumber(current_score) <= max_score then
+        redis.call('ZREM', key, member)
+        table.insert(removed, member)
+    end
+end
+
+return removed

--- a/tests/sentry/buffer/test_redis.py
+++ b/tests/sentry/buffer/test_redis.py
@@ -714,28 +714,6 @@ class TestRedisBuffer:
         remaining: list[tuple[str, float]] = client.zrange(key, 0, -1, withscores=True)
         assert remaining == [("2", 100.1)]
 
-    def test_conditional_delete_from_sorted_set_single_key_convenience(self) -> None:
-        """Test the single-key convenience method"""
-        if not self.buf.is_redis_cluster:
-            pytest.skip("conditional_delete_from_sorted_sets requires Redis Cluster mode")
-
-        key = "single_key_test"
-        client = get_cluster_routing_client(self.buf.cluster, self.buf.is_redis_cluster)
-
-        # Add test data
-        client.zadd(key, {"1": 50, "2": 150})
-
-        # Use single-key method
-        project_ids_and_timestamps = [(1, 100.0), (2, 100.0)]
-        result = self.buf.conditional_delete_from_sorted_set(key, project_ids_and_timestamps)
-
-        # Should remove only project_id=1
-        assert result == [1]
-
-        # Verify remaining data
-        remaining: list[tuple[str, float]] = client.zrange(key, 0, -1, withscores=True)
-        assert remaining == [("2", 150.0)]
-
     def test_conditional_delete_requires_redis_cluster(self) -> None:
         """Test that method requires Redis Cluster mode"""
         if self.buf.is_redis_cluster:


### PR DESCRIPTION
The time-range based approach is mostly ok, but risks removing unobserved projects in some theoreticallypossible race cases. 
Mostly, this opens the door to processing some projects rather than all, allowing us to move toward sharding our project batch scheduling to smooth out load.
