### PR TITLE
feat(explore): Use query params for spans group bys

### DIFF
--- a/static/app/views/explore/contexts/pageParamsContext/index.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/index.tsx
@@ -254,11 +254,6 @@ export function useExploreFields(): string[] {
   return pageParams.fields;
 }
 
-export function useExploreGroupBys(): string[] {
-  const pageParams = useExplorePageParams();
-  return pageParams.groupBys;
-}
-
 export function useExploreQuery(): string {
   const pageParams = useExplorePageParams();
   return pageParams.query;

--- a/static/app/views/explore/hooks/useAddToDashboard.tsx
+++ b/static/app/views/explore/hooks/useAddToDashboard.tsx
@@ -16,14 +16,16 @@ import {
 import {handleAddQueryToDashboard} from 'sentry/views/discover/utils';
 import {
   useExploreDataset,
-  useExploreGroupBys,
   useExploreQuery,
   useExploreSortBys,
   useExploreVisualizes,
 } from 'sentry/views/explore/contexts/pageParamsContext';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {formatSort} from 'sentry/views/explore/contexts/pageParamsContext/sortBys';
-import {useQueryParamsMode} from 'sentry/views/explore/queryParams/context';
+import {
+  useQueryParamsGroupBys,
+  useQueryParamsMode,
+} from 'sentry/views/explore/queryParams/context';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
 
 export const CHART_TYPE_TO_DISPLAY_TYPE = {
@@ -40,7 +42,7 @@ export function useAddToDashboard() {
 
   const mode = useQueryParamsMode();
   const dataset = useExploreDataset();
-  const groupBys = useExploreGroupBys();
+  const groupBys = useQueryParamsGroupBys();
   const sortBys = useExploreSortBys();
   const visualizes = useExploreVisualizes();
   const query = useExploreQuery();

--- a/static/app/views/explore/hooks/useExploreTimeseries.spec.tsx
+++ b/static/app/views/explore/hooks/useExploreTimeseries.spec.tsx
@@ -9,8 +9,10 @@ import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
 import type {Organization} from 'sentry/types/organization';
 import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
+import {PageParamsProvider} from 'sentry/views/explore/contexts/pageParamsContext';
 import {useExploreTimeseries} from 'sentry/views/explore/hooks/useExploreTimeseries';
 import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
+import {SpansQueryParamsProvider} from 'sentry/views/explore/spans/spansQueryParamsProvider';
 import {OrganizationContext} from 'sentry/views/organizationContext';
 
 jest.mock('sentry/utils/useLocation');
@@ -22,7 +24,11 @@ function createWrapper(org: Organization) {
     const queryClient = makeTestQueryClient();
     return (
       <QueryClientProvider client={queryClient}>
-        <OrganizationContext value={org}>{children}</OrganizationContext>
+        <OrganizationContext value={org}>
+          <SpansQueryParamsProvider>
+            <PageParamsProvider>{children}</PageParamsProvider>
+          </SpansQueryParamsProvider>
+        </OrganizationContext>
       </QueryClientProvider>
     );
   };

--- a/static/app/views/explore/hooks/useExploreTimeseries.tsx
+++ b/static/app/views/explore/hooks/useExploreTimeseries.tsx
@@ -7,7 +7,6 @@ import {determineSeriesSampleCountAndIsSampled} from 'sentry/views/alerts/rules/
 import {
   useExploreAggregateSortBys,
   useExploreDataset,
-  useExploreGroupBys,
   useExploreVisualizes,
 } from 'sentry/views/explore/contexts/pageParamsContext';
 import {formatSort} from 'sentry/views/explore/contexts/pageParamsContext/sortBys';
@@ -19,6 +18,7 @@ import {
   type SpansRPCQueryExtras,
 } from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {useTopEvents} from 'sentry/views/explore/hooks/useTopEvents';
+import {useQueryParamsGroupBys} from 'sentry/views/explore/queryParams/context';
 import {computeVisualizeSampleTotals} from 'sentry/views/explore/utils';
 import {useSortedTimeSeries} from 'sentry/views/insights/common/queries/useSortedTimeSeries';
 
@@ -65,7 +65,7 @@ function useExploreTimeseriesImpl({
   queryExtras,
 }: UseExploreTimeseriesOptions): UseExploreTimeseriesResults {
   const dataset = useExploreDataset();
-  const groupBys = useExploreGroupBys();
+  const groupBys = useQueryParamsGroupBys();
   const sortBys = useExploreAggregateSortBys();
   const visualizes = useExploreVisualizes({validate: true});
   const [interval] = useChartInterval();

--- a/static/app/views/explore/hooks/useGroupByFields.tsx
+++ b/static/app/views/explore/hooks/useGroupByFields.tsx
@@ -15,7 +15,7 @@ interface UseGroupByFieldsProps {
    * All the group bys that are in use. They will be injected if
    * they dont exist already.
    */
-  groupBys: string[];
+  groupBys: readonly string[];
   numberTags: TagCollection;
   stringTags: TagCollection;
   traceItemType: TraceItemDataset;

--- a/static/app/views/explore/hooks/useSortByFields.tsx
+++ b/static/app/views/explore/hooks/useSortByFields.tsx
@@ -7,7 +7,7 @@ import {TypeBadge} from 'sentry/views/explore/components/typeBadge';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {useTraceItemTags} from 'sentry/views/explore/contexts/spanTagsContext';
 
-type Props = {fields: string[]; groupBys: string[]; mode: Mode; yAxes: string[]};
+type Props = {fields: string[]; groupBys: readonly string[]; mode: Mode; yAxes: string[]};
 
 export function useSortByFields({fields, yAxes, groupBys, mode}: Props) {
   const {tags: numberTags} = useTraceItemTags('number');

--- a/static/app/views/explore/hooks/useTopEvents.tsx
+++ b/static/app/views/explore/hooks/useTopEvents.tsx
@@ -1,6 +1,6 @@
 import {useMemo} from 'react';
 
-import {useExploreGroupBys} from 'sentry/views/explore/contexts/pageParamsContext';
+import {useQueryParamsGroupBys} from 'sentry/views/explore/queryParams/context';
 
 export const TOP_EVENTS_LIMIT = 5;
 
@@ -8,7 +8,7 @@ export const TOP_EVENTS_LIMIT = 5;
 // This hook always returns 5, which can be misleading, but there's no simple way
 // to get the series count without adding more complexity to this hook.
 export function useTopEvents(): number | undefined {
-  const groupBys = useExploreGroupBys();
+  const groupBys = useQueryParamsGroupBys();
 
   const topEvents: number | undefined = useMemo(() => {
     if (groupBys.every(groupBy => groupBy === '')) {

--- a/static/app/views/explore/logs/logsToolbar.spec.tsx
+++ b/static/app/views/explore/logs/logsToolbar.spec.tsx
@@ -218,7 +218,7 @@ describe('LogsToolbar', () => {
 
       await userEvent.click(screen.getByRole('button', {name: 'Add Group'}));
       expect(router.location.query.aggregateField).toEqual(
-        [{groupBy: 'message'}, {yAxes: ['count(message)']}, {groupBy: ''}].map(
+        [{groupBy: 'message'}, {groupBy: ''}, {yAxes: ['count(message)']}].map(
           aggregateField => JSON.stringify(aggregateField)
         )
       );

--- a/static/app/views/explore/multiQueryMode/locationUtils.tsx
+++ b/static/app/views/explore/multiQueryMode/locationUtils.tsx
@@ -138,7 +138,7 @@ export function useReadQueriesFromLocation(): ReadableExploreQueryParts[] {
 type WritableExploreQueryParts = {
   chartType?: ChartType;
   fields?: string[];
-  groupBys?: string[];
+  groupBys?: readonly string[];
   query?: string;
   sortBys?: Sort[];
   yAxes?: string[];
@@ -185,8 +185,7 @@ export function useUpdateQueryAtIndex(index: number) {
 
       const newQuery = {...queryToUpdate, ...updates};
       newQuery.fields = getFieldsForConstructedQuery(newQuery.yAxes);
-      const newQueries = [...queries];
-      newQueries[index] = newQuery;
+      const newQueries = queries.map((query, i) => (i === index ? newQuery : query));
 
       const target = getUpdatedLocationWithQueries(location, newQueries);
       navigate(target);

--- a/static/app/views/explore/spans/spansQueryParams.tsx
+++ b/static/app/views/explore/spans/spansQueryParams.tsx
@@ -79,6 +79,7 @@ export function getTargetWithReadableQueryParams(
 ): Location {
   const target: Location = {...location, query: {...location.query}};
 
+  updateNullableLocation(target, SPANS_MODE_KEY, writableQueryParams.mode);
   updateNullableLocation(
     target,
     SPANS_AGGREGATE_FIELD_KEY,

--- a/static/app/views/explore/spans/spansTab.spec.tsx
+++ b/static/app/views/explore/spans/spansTab.spec.tsx
@@ -17,10 +17,10 @@ import {FieldKind} from 'sentry/utils/fields';
 import {
   PageParamsProvider,
   useExploreFields,
-  useExploreGroupBys,
 } from 'sentry/views/explore/contexts/pageParamsContext';
 import * as spanTagsModule from 'sentry/views/explore/contexts/spanTagsContext';
 import {TraceItemAttributeProvider} from 'sentry/views/explore/contexts/traceItemAttributeContext';
+import {useQueryParamsGroupBys} from 'sentry/views/explore/queryParams/context';
 import {SpansQueryParamsProvider} from 'sentry/views/explore/spans/spansQueryParamsProvider';
 import {SpansTabContent} from 'sentry/views/explore/spans/spansTab';
 import {TraceItemDataset} from 'sentry/views/explore/types';
@@ -167,10 +167,10 @@ describe('SpansTabContent', () => {
 
   it('inserts group bys from aggregate mode as fields in samples mode', async () => {
     let fields: string[] = [];
-    let groupBys: string[] = [];
+    let groupBys: readonly string[] = [];
     function Component() {
       fields = useExploreFields();
-      groupBys = useExploreGroupBys();
+      groupBys = useQueryParamsGroupBys();
       return <SpansTabContent datePageFilterProps={datePageFilterProps} />;
     }
 

--- a/static/app/views/explore/tables/aggregatesTable.tsx
+++ b/static/app/views/explore/tables/aggregatesTable.tsx
@@ -32,7 +32,6 @@ import {
 } from 'sentry/views/explore/components/table';
 import {
   useExploreFields,
-  useExploreGroupBys,
   useExploreQuery,
   useExploreSortBys,
   useExploreVisualizes,
@@ -46,6 +45,7 @@ import {TOP_EVENTS_LIMIT, useTopEvents} from 'sentry/views/explore/hooks/useTopE
 import {
   useQueryParamsAggregateCursor,
   useQueryParamsAggregateFields,
+  useQueryParamsGroupBys,
 } from 'sentry/views/explore/queryParams/context';
 import {prettifyAggregation, viewSamplesTarget} from 'sentry/views/explore/utils';
 
@@ -65,7 +65,7 @@ export function AggregatesTable({aggregatesTableResult}: AggregatesTableProps) {
   const topEvents = useTopEvents();
   const aggregateFields = useQueryParamsAggregateFields();
   const fields = useExploreFields();
-  const groupBys = useExploreGroupBys();
+  const groupBys = useQueryParamsGroupBys();
   const visualizes = useExploreVisualizes();
   const sorts = useExploreSortBys();
   const setSorts = useSetExploreSortBys();

--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -17,7 +17,6 @@ import ProjectsStore from 'sentry/stores/projectsStore';
 import {
   PageParamsProvider,
   useExploreFields,
-  useExploreGroupBys,
   useExploreSortBys,
   useExploreVisualizes,
   useSetExploreMode,
@@ -25,7 +24,12 @@ import {
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {Visualize} from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
 import {TraceItemAttributeProvider} from 'sentry/views/explore/contexts/traceItemAttributeContext';
-import {useQueryParamsMode} from 'sentry/views/explore/queryParams/context';
+import {
+  useQueryParamsAggregateFields,
+  useQueryParamsGroupBys,
+  useQueryParamsMode,
+} from 'sentry/views/explore/queryParams/context';
+import {VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
 import {SpansQueryParamsProvider} from 'sentry/views/explore/spans/spansQueryParamsProvider';
 import {ExploreToolbar} from 'sentry/views/explore/toolbar';
 import {TraceItemDataset} from 'sentry/views/explore/types';
@@ -294,7 +298,7 @@ describe('ExploreToolbar', () => {
     let groupBys: any;
 
     function Component() {
-      groupBys = useExploreGroupBys();
+      groupBys = useQueryParamsGroupBys();
       return <ExploreToolbar />;
     }
     render(
@@ -343,7 +347,7 @@ describe('ExploreToolbar', () => {
     let mode: any;
 
     function Component() {
-      groupBys = useExploreGroupBys();
+      groupBys = useQueryParamsGroupBys();
       mode = useQueryParamsMode();
       return <ExploreToolbar />;
     }
@@ -370,7 +374,7 @@ describe('ExploreToolbar', () => {
     let mode: any;
 
     function Component() {
-      groupBys = useExploreGroupBys();
+      groupBys = useQueryParamsGroupBys();
       mode = useQueryParamsMode();
       return <ExploreToolbar />;
     }
@@ -389,6 +393,35 @@ describe('ExploreToolbar', () => {
 
     expect(mode).toEqual(Mode.AGGREGATE);
     expect(groupBys).toEqual(['', '']);
+  });
+
+  it('adds group bys before visualizes when reasonable', async () => {
+    let aggregateFields: any;
+
+    function Component() {
+      aggregateFields = useQueryParamsAggregateFields();
+      return <ExploreToolbar />;
+    }
+    render(
+      <Wrapper>
+        <Component />
+      </Wrapper>
+    );
+
+    expect(aggregateFields).toEqual([
+      {groupBy: ''},
+      new VisualizeFunction('count(span.duration)'),
+    ]);
+
+    const section = screen.getByTestId('section-group-by');
+
+    await userEvent.click(within(section).getByRole('button', {name: 'Add Group'}));
+
+    expect(aggregateFields).toEqual([
+      {groupBy: ''},
+      {groupBy: ''},
+      new VisualizeFunction('count(span.duration)'),
+    ]);
   });
 
   it('allows changing sort by in samples mode', async () => {

--- a/static/app/views/explore/toolbar/index.tsx
+++ b/static/app/views/explore/toolbar/index.tsx
@@ -2,11 +2,13 @@ import styled from '@emotion/styled';
 
 import {defined} from 'sentry/utils';
 import {
-  useExploreGroupBys,
   useExploreVisualizes,
-  useSetExploreGroupBys,
   useSetExploreVisualizes,
 } from 'sentry/views/explore/contexts/pageParamsContext';
+import {
+  useQueryParamsGroupBys,
+  useSetQueryParamsGroupBys,
+} from 'sentry/views/explore/queryParams/context';
 import {ToolbarGroupBy} from 'sentry/views/explore/toolbar/toolbarGroupBy';
 import {ToolbarSaveAs} from 'sentry/views/explore/toolbar/toolbarSaveAs';
 import {ToolbarSortBy} from 'sentry/views/explore/toolbar/toolbarSortBy';
@@ -23,8 +25,8 @@ export function ExploreToolbar({extras, width}: ExploreToolbarProps) {
   const visualizes = useExploreVisualizes();
   const setVisualizes = useSetExploreVisualizes();
 
-  const groupBys = useExploreGroupBys();
-  const setGroupBys = useSetExploreGroupBys();
+  const groupBys = useQueryParamsGroupBys();
+  const setGroupBys = useSetQueryParamsGroupBys();
 
   return (
     <Container data-test-id="explore-span-toolbar" width={width}>

--- a/static/app/views/explore/toolbar/toolbarGroupBy.tsx
+++ b/static/app/views/explore/toolbar/toolbarGroupBy.tsx
@@ -17,7 +17,7 @@ import {useGroupByFields} from 'sentry/views/explore/hooks/useGroupByFields';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 
 interface ToolbarGroupByProps {
-  groupBys: string[];
+  groupBys: readonly string[];
   setGroupBys: (groupBys: string[], mode?: Mode) => void;
 }
 
@@ -45,7 +45,7 @@ export function ToolbarGroupBy({groupBys, setGroupBys}: ToolbarGroupByProps) {
   );
 
   return (
-    <DragNDropContext columns={groupBys} setColumns={setGroupBysWithOp}>
+    <DragNDropContext columns={groupBys.slice()} setColumns={setGroupBysWithOp}>
       {({editableColumns, insertColumn, updateColumnAtIndex, deleteColumnAtIndex}) => (
         <ToolbarSection data-test-id="section-group-by">
           <ToolbarGroupByHeader />

--- a/static/app/views/explore/toolbar/toolbarSaveAs.tsx
+++ b/static/app/views/explore/toolbar/toolbarSaveAs.tsx
@@ -29,7 +29,6 @@ import {Dataset} from 'sentry/views/alerts/rules/metric/types';
 import {ToolbarSection} from 'sentry/views/explore/components/toolbar/styles';
 import {
   useExploreFields,
-  useExploreGroupBys,
   useExploreId,
   useExploreQuery,
   useExploreSortBys,
@@ -40,7 +39,10 @@ import {useChartInterval} from 'sentry/views/explore/hooks/useChartInterval';
 import {useGetSavedQuery} from 'sentry/views/explore/hooks/useGetSavedQueries';
 import {useSpansSaveQuery} from 'sentry/views/explore/hooks/useSaveQuery';
 import {generateExploreCompareRoute} from 'sentry/views/explore/multiQueryMode/locationUtils';
-import {useQueryParamsMode} from 'sentry/views/explore/queryParams/context';
+import {
+  useQueryParamsGroupBys,
+  useQueryParamsMode,
+} from 'sentry/views/explore/queryParams/context';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 import {getAlertsUrl} from 'sentry/views/insights/common/utils/getAlertsUrl';
 
@@ -54,7 +56,7 @@ export function ToolbarSaveAs() {
   const pageFilters = usePageFilters();
 
   const query = useExploreQuery();
-  const groupBys = useExploreGroupBys();
+  const groupBys = useQueryParamsGroupBys();
   const visualizes = useExploreVisualizes();
   const fields = useExploreFields();
   const sortBys = useExploreSortBys();

--- a/static/app/views/explore/toolbar/toolbarSortBy.tsx
+++ b/static/app/views/explore/toolbar/toolbarSortBy.tsx
@@ -14,7 +14,6 @@ import {
 } from 'sentry/views/explore/components/toolbar/styles';
 import {
   useExploreFields,
-  useExploreGroupBys,
   useExploreSortBys,
   useExploreVisualizes,
   useSetExploreSortBys,
@@ -22,12 +21,15 @@ import {
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {useSortByFields} from 'sentry/views/explore/hooks/useSortByFields';
 import {Tab, useTab} from 'sentry/views/explore/hooks/useTab';
-import {useQueryParamsMode} from 'sentry/views/explore/queryParams/context';
+import {
+  useQueryParamsGroupBys,
+  useQueryParamsMode,
+} from 'sentry/views/explore/queryParams/context';
 
 export function ToolbarSortBy() {
   const mode = useQueryParamsMode();
   const fields = useExploreFields();
-  const groupBys = useExploreGroupBys();
+  const groupBys = useQueryParamsGroupBys();
   const visualizes = useExploreVisualizes();
 
   const sorts = useExploreSortBys();

--- a/static/app/views/explore/utils.tsx
+++ b/static/app/views/explore/utils.tsx
@@ -270,7 +270,7 @@ export function generateTargetQuery({
   yAxes,
 }: {
   fields: string[];
-  groupBys: string[];
+  groupBys: readonly string[];
   location: Location;
   // needed to generate targets when `project` is in the group by
   projects: Project[];
@@ -368,7 +368,7 @@ export function viewSamplesTarget({
   projects,
 }: {
   fields: string[];
-  groupBys: string[];
+  groupBys: readonly string[];
   location: Location;
   // needed to generate targets when `project` is in the group by
   projects: Project[];


### PR DESCRIPTION
This migrates explore traces to use query params for the group bys.