### PR TITLE
feat(ui): Capture `tctCode` translations

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -357,6 +357,7 @@ pnpm-lock.yaml                                           @getsentry/owners-js-de
 /static/app/components/analyticsArea.tsx       @getsentry/app-frontend
 /static/app/components/events/interfaces/      @getsentry/app-frontend
 /static/app/components/forms/                  @getsentry/app-frontend
+/static/app/locale.tsx                         @getsentry/app-frontend
 ## End of Frontend
 
 # Workflow engine

--- a/build-utils/ts-extract-gettext.ts
+++ b/build-utils/ts-extract-gettext.ts
@@ -21,6 +21,7 @@ const FUNCTION_NAMES: Record<string, string[]> = {
   t: ['msgid'],
   tn: ['msgid', 'msgid_plural', 'count'],
   tct: ['msgid'],
+  tctCode: ['msgid'],
 };
 
 function getTsScriptKind(filePath: string): ts.ScriptKind {


### PR DESCRIPTION
In #81464 a `tctCode` helper was added. The names of these functions are important because it is largely how translations are extracted. It is also worth avoiding calling other functions t, tct, tn etc.
