### PR TITLE
feat(ai): Generate fuzzy matching model names in pricing dict

### DIFF
--- a/src/sentry/tasks/ai_agent_monitoring.py
+++ b/src/sentry/tasks/ai_agent_monitoring.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from typing import Any
 
 from sentry import options
@@ -22,6 +23,77 @@ logger = logging.getLogger(__name__)
 # API endpoints
 OPENROUTER_MODELS_API_URL = "https://openrouter.ai/api/v1/models"
 MODELS_DEV_API_URL = "https://models.dev/api.json"
+
+
+def _create_glob_model_name(model_id: str) -> str:
+    """
+    Create a glob version of a model name by stripping dates and versions.
+
+    Examples:
+    - "claude-4-sonnet-20250522" -> "claude-4-sonnet-*"
+    - "o3-pro-2025-06-10" -> "o3-pro-*"
+    - "claude-3-5-haiku@20241022" -> "claude-3-5-haiku@*"
+    - "claude-opus-4-1-20250805-v1:0" -> "claude-opus-4-1-*"
+
+    Args:
+        model_id: The original model ID
+
+    Returns:
+        The glob version of the model name
+    """
+    # Pattern to match various date and version formats
+    # Matches:
+    # - YYYYMMDD (e.g., 20250522)
+    # - YYYY-MM-DD (e.g., 2025-06-10)
+    # - YYYY/MM/DD (e.g., 2025/06/10)
+    # - YYYY.MM.DD (e.g., 2025.06.10)
+    # - v followed by version numbers (e.g., v1:0, v2.1, v3)
+    # - @ followed by dates (e.g., @20241022)
+    # - -v followed by version numbers (e.g., -v1.0)
+    # - _v followed by version numbers (e.g., _v1.0)
+
+    # Use a single comprehensive regex that handles all patterns
+    # This regex matches:
+    # 1. Date patterns: -YYYYMMDD, -YYYY-MM-DD, -YYYY/MM/DD, -YYYY.MM.DD
+    # 2. Version patterns: -v1.0, -v1:0, _v1.0, _v1:0
+    # 3. @date patterns: @YYYYMMDD, @YYYY-MM-DD, @YYYY/MM/DD, @YYYY.MM.DD
+    # 4. Combined patterns: -YYYYMMDD-v1:0, @YYYYMMDD-v1:0
+
+    # First, handle @date patterns (they have special handling)
+    glob_name = re.sub(
+        r"@(?:19|20)\d{2}(?:[-_/.]?\d{2}){2}(?:[-_]v\d+(?:[.:]\d+)*)?", "@*", model_id
+    )
+
+    # Then handle regular date and version patterns
+    glob_name = re.sub(
+        r"([-_])(?:19|20)\d{2}(?:[-_/.]?\d{2}){2}(?:[-_]v\d+(?:[.:]\d+)*)?", r"\1*", glob_name
+    )
+
+    # Handle standalone version patterns (without dates)
+    glob_name = re.sub(r"([-_])v\d+(?:[.:]\d+)*", r"\1*", glob_name)
+
+    return glob_name
+
+
+def _add_glob_model_names(models_dict: dict[ModelId, AIModelCostV2]) -> None:
+    """
+    Add glob versions of model names to the models dictionary.
+
+    For each model, creates a glob version by stripping dates and versions,
+    and adds it to the dictionary if it doesn't already exist.
+
+    Args:
+        models_dict: The dictionary of models to add glob versions to
+    """
+
+    # needed to avoid modifying the dictionary during iteration
+    model_ids = list(models_dict.keys())
+
+    for model_id in model_ids:
+        glob_name = _create_glob_model_name(model_id)
+
+        if glob_name != model_id and glob_name not in models_dict:
+            models_dict[glob_name] = models_dict[model_id]
 
 
 @instrumented_task(
@@ -85,6 +157,9 @@ def fetch_ai_model_costs() -> None:
             continue
 
         models_dict[alternative_model_id] = models_dict[existing_model_id]
+
+    # Add glob versions of model names for flexible matching
+    _add_glob_model_names(models_dict)
 
     ai_model_costs: AIModelCosts = {"version": 2, "models": models_dict}
     cache.set(AI_MODEL_COSTS_CACHE_KEY, ai_model_costs, AI_MODEL_COSTS_CACHE_TTL)

--- a/tests/sentry/tasks/test_ai_agent_monitoring.py
+++ b/tests/sentry/tasks/test_ai_agent_monitoring.py
@@ -486,3 +486,135 @@ class FetchAIModelCostsTest(TestCase):
 
         # Non-existent mapping should not create a new model
         assert "nonexistent-mapping" not in models
+
+    @responses.activate
+    def test_fetch_ai_model_costs_with_glob_model_names(self) -> None:
+        """Test that glob versions of model names are added correctly"""
+        # Mock responses with models that should generate glob patterns
+        mock_openrouter_response = {
+            "data": [
+                {
+                    "id": "openai/gpt-4o-mini-20250522",
+                    "pricing": {
+                        "prompt": "0.0000003",
+                        "completion": "0.00000165",
+                    },
+                },
+                {
+                    "id": "openai/claude-3-5-sonnet-20241022",
+                    "pricing": {
+                        "prompt": "0.00000015",
+                        "completion": "0.00000075",
+                    },
+                },
+                {
+                    "id": "openai/gpt-4",  # No date/version, should not generate glob
+                    "pricing": {
+                        "prompt": "0.0000003",
+                        "completion": "0.00000165",
+                    },
+                },
+            ]
+        }
+
+        mock_models_dev_response = {
+            "anthropic": {
+                "models": {
+                    "claude-3-5-haiku@20241022": {
+                        "cost": {
+                            "input": 0.25 * 1000000,
+                            "output": 1.25 * 1000000,
+                        }
+                    },
+                    "o3-pro-2025-06-10": {
+                        "cost": {
+                            "input": 0.5 * 1000000,
+                            "output": 2.5 * 1000000,
+                        }
+                    },
+                }
+            }
+        }
+
+        self._mock_openrouter_api_response(mock_openrouter_response)
+        self._mock_models_dev_api_response(mock_models_dev_response)
+
+        fetch_ai_model_costs()
+
+        # Verify the data was cached correctly
+        cached_data = _get_ai_model_costs_from_cache()
+        assert cached_data is not None
+        models = cached_data.get("models")
+        assert models is not None
+
+        # Should have original models + glob versions
+        # 3 from OpenRouter + 2 from models.dev + 4 glob versions = 9 total
+        assert len(models) == 9
+
+        # Check original models exist
+        assert "gpt-4o-mini-20250522" in models
+        assert "claude-3-5-sonnet-20241022" in models
+        assert "gpt-4" in models
+        assert "claude-3-5-haiku@20241022" in models
+        assert "o3-pro-2025-06-10" in models
+
+        # Check glob versions were added
+        assert "gpt-4o-mini-*" in models
+        assert "claude-3-5-sonnet-*" in models
+        assert "claude-3-5-haiku@*" in models
+        assert "o3-pro-*" in models
+
+        # Verify glob versions have same pricing as original models
+        gpt4o_mini_original = models["gpt-4o-mini-20250522"]
+        gpt4o_mini_glob = models["gpt-4o-mini-*"]
+        assert gpt4o_mini_original.get("inputPerToken") == gpt4o_mini_glob.get("inputPerToken")
+        assert gpt4o_mini_original.get("outputPerToken") == gpt4o_mini_glob.get("outputPerToken")
+
+        claude_sonnet_original = models["claude-3-5-sonnet-20241022"]
+        claude_sonnet_glob = models["claude-3-5-sonnet-*"]
+        assert claude_sonnet_original.get("inputPerToken") == claude_sonnet_glob.get(
+            "inputPerToken"
+        )
+        assert claude_sonnet_original.get("outputPerToken") == claude_sonnet_glob.get(
+            "outputPerToken"
+        )
+
+        claude_haiku_original = models["claude-3-5-haiku@20241022"]
+        claude_haiku_glob = models["claude-3-5-haiku@*"]
+        assert claude_haiku_original.get("inputPerToken") == claude_haiku_glob.get("inputPerToken")
+        assert claude_haiku_original.get("outputPerToken") == claude_haiku_glob.get(
+            "outputPerToken"
+        )
+
+        o3_pro_original = models["o3-pro-2025-06-10"]
+        o3_pro_glob = models["o3-pro-*"]
+        assert o3_pro_original.get("inputPerToken") == o3_pro_glob.get("inputPerToken")
+        assert o3_pro_original.get("outputPerToken") == o3_pro_glob.get("outputPerToken")
+
+        # Verify gpt-4 (no date/version) doesn't have a glob version
+        assert "gpt-4*" not in models
+
+    @responses.activate
+    def test_create_glob_model_name_various_formats(self) -> None:
+        """Test glob generation with various date and version formats"""
+        from sentry.tasks.ai_agent_monitoring import _create_glob_model_name
+
+        # Test cases with expected outputs
+        test_cases = [
+            ("model-20250522", "model-*"),  # YYYYMMDD -> *
+            ("model-2025-06-10", "model-*"),  # YYYY-MM-DD -> *
+            ("model-2025/06/10", "model-*"),  # YYYY/MM/DD -> *
+            ("model-2025.06.10", "model-*"),  # YYYY.MM.DD -> *
+            ("model-v1.0", "model-*"),  # v1.0 -> *
+            ("model-v2.1.0", "model-*"),  # v2.1.0 -> *
+            ("model@20241022", "model@*"),  # @YYYYMMDD -> @*
+            ("model-v1:0", "model-*"),  # v1:0 -> *
+            ("model-20250610-v1:0", "model-*"),  # YYYYMMDD-v1:0 -> *
+            ("model@20250610-v1:0", "model@*"),  # @YYYYMMDD-v1:0 -> @*
+        ]
+
+        for model_id, expected_glob in test_cases:
+            actual_glob = _create_glob_model_name(model_id)
+            assert (
+                actual_glob == expected_glob
+            ), f"Expected {expected_glob} for {model_id}, got {actual_glob}"


### PR DESCRIPTION
After https://github.com/getsentry/relay/pull/5106 was merged, relay now supports fuzzy matching models names. This is useful when we don't have all the prices for the latest snapshots, but the pricing remains the same, just the exact model name changed.

To avoid these problems, we can generate fuzzy names of all of the models and just strip the date or the version from the name using regexes.

We will still first try to match by exact name, and use fuzzy matching only as a fallback in case we fail to find the exact name.


closes [TET-1054: Strip model snapshot when calculating price](https://linear.app/getsentry/issue/TET-1054/strip-model-snapshot-when-calculating-price)