### PR TITLE
fix(logs): Don't navigate to specific platforms for set up

### DIFF
--- a/static/app/views/explore/logs/content.tsx
+++ b/static/app/views/explore/logs/content.tsx
@@ -154,18 +154,15 @@ function SetupLogsButton() {
     ? platforms.find(p => p.id === project.platform)
     : undefined;
 
-  let href = 'https://docs.sentry.io/product/explore/logs/getting-started/';
   const doesNotSupportLogging = currentPlatform
     ? withoutLoggingSupport.has(currentPlatform.id)
     : false;
-  if (project && currentPlatform) {
-    href = 'https://docs.sentry.io/platforms/' + currentPlatform.id + '/logs/';
-  }
+
   return (
     <LinkButton
       icon={<IconOpen />}
       priority="primary"
-      href={href}
+      href="https://docs.sentry.io/product/explore/logs/getting-started/"
       external
       size="xs"
       onClick={() => {


### PR DESCRIPTION
resolves https://linear.app/getsentry/issue/LOGS-336/404-error-on-set-up-logs-cta-in-dashboard

Navigating to platforms is a recipe for 404s, so let's just only link to getting started. This also means we don't need to duplicate content that much.