### PR TITLE
ref(insights): remove query date range logic

### DIFF
--- a/static/app/views/insights/common/components/insightsModuleDatePageFilter.tsx
+++ b/static/app/views/insights/common/components/insightsModuleDatePageFilter.tsx
@@ -8,13 +8,9 @@ import {
 import {IconBusiness} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
-import {
-  OLD_QUERY_DATE_RANGE_LIMIT,
-  QUERY_DATE_RANGE_LIMIT,
-} from 'sentry/views/insights/settings';
+import {QUERY_DATE_RANGE_LIMIT} from 'sentry/views/insights/settings';
 
 const DISABLED_OPTIONS = ['90d'];
-const OLD_DISABLED_OPTIONS = ['14d', '30d', '90d'];
 
 export function InsightsModuleDatePageFilter() {
   const organization = useOrganization();
@@ -22,16 +18,6 @@ export function InsightsModuleDatePageFilter() {
   const hasDateRangeQueryLimit = organization.features.includes(
     'insights-query-date-range-limit'
   );
-  const shouldIncreaseDefaultDateRange = organization.features.includes(
-    'dashboards-plan-limits'
-  );
-  const defaultPickableDays = shouldIncreaseDefaultDateRange
-    ? QUERY_DATE_RANGE_LIMIT
-    : OLD_QUERY_DATE_RANGE_LIMIT;
-
-  const disabledOptions = shouldIncreaseDefaultDateRange
-    ? DISABLED_OPTIONS
-    : OLD_DISABLED_OPTIONS;
 
   const dateFilterProps: DatePageFilterProps = {};
   if (hasDateRangeQueryLimit) {
@@ -41,22 +27,15 @@ export function InsightsModuleDatePageFilter() {
         '1h': t('Last 1 hour'),
         '24h': t('Last 24 hours'),
         '7d': t('Last 7 days'),
-        ...(shouldIncreaseDefaultDateRange
-          ? {
-              '14d': t('Last 14 days'),
-              '30d': t('Last 30 days'),
-            }
-          : {
-              '14d': <DisabledDateOption value={t('Last 14 days')} />,
-              '30d': <DisabledDateOption value={t('Last 30 days')} />,
-            }),
+        '14d': t('Last 14 days'),
+        '30d': t('Last 30 days'),
         '90d': <DisabledDateOption value={t('Last 90 days')} />,
       };
     };
 
-    dateFilterProps.maxPickableDays = defaultPickableDays;
+    dateFilterProps.maxPickableDays = QUERY_DATE_RANGE_LIMIT;
     dateFilterProps.isOptionDisabled = ({value}) => {
-      if (!disabledOptions.includes(value)) {
+      if (!DISABLED_OPTIONS.includes(value)) {
         return false;
       }
       return true;

--- a/static/app/views/insights/common/components/modulePageProviders.tsx
+++ b/static/app/views/insights/common/components/modulePageProviders.tsx
@@ -8,11 +8,7 @@ import {WidgetSyncContextProvider} from 'sentry/views/dashboards/contexts/widget
 import {useHasDataTrackAnalytics} from 'sentry/views/insights/common/utils/useHasDataTrackAnalytics';
 import {useModuleTitles} from 'sentry/views/insights/common/utils/useModuleTitle';
 import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
-import {
-  INSIGHTS_TITLE,
-  OLD_QUERY_DATE_RANGE_LIMIT,
-  QUERY_DATE_RANGE_LIMIT,
-} from 'sentry/views/insights/settings';
+import {INSIGHTS_TITLE, QUERY_DATE_RANGE_LIMIT} from 'sentry/views/insights/settings';
 import type {ModuleName} from 'sentry/views/insights/types';
 
 type ModuleNameStrings = `${ModuleName}`;
@@ -38,12 +34,7 @@ export function ModulePageProviders({
   const hasDateRangeQueryLimit = organization.features.includes(
     'insights-query-date-range-limit'
   );
-  const shouldIncreaseDefaultDateRange = organization.features.includes(
-    'dashboards-plan-limits'
-  );
-  const defaultPickableDays = shouldIncreaseDefaultDateRange
-    ? QUERY_DATE_RANGE_LIMIT
-    : OLD_QUERY_DATE_RANGE_LIMIT;
+  const defaultPickableDays = QUERY_DATE_RANGE_LIMIT;
 
   useHasDataTrackAnalytics(moduleName as ModuleName, analyticEventName);
 

--- a/static/app/views/insights/common/components/modulePageProviders.tsx
+++ b/static/app/views/insights/common/components/modulePageProviders.tsx
@@ -34,7 +34,6 @@ export function ModulePageProviders({
   const hasDateRangeQueryLimit = organization.features.includes(
     'insights-query-date-range-limit'
   );
-  const defaultPickableDays = QUERY_DATE_RANGE_LIMIT;
 
   useHasDataTrackAnalytics(moduleName as ModuleName, analyticEventName);
 
@@ -46,7 +45,7 @@ export function ModulePageProviders({
 
   return (
     <PageFiltersContainer
-      maxPickableDays={hasDateRangeQueryLimit ? defaultPickableDays : undefined}
+      maxPickableDays={hasDateRangeQueryLimit ? QUERY_DATE_RANGE_LIMIT : undefined}
       storageNamespace={view}
     >
       <SentryDocumentTitle title={fullPageTitle} orgSlug={organization.slug}>

--- a/static/app/views/insights/settings.ts
+++ b/static/app/views/insights/settings.ts
@@ -110,7 +110,6 @@ export const INSIGHTS_BASE_URL = 'insights';
 export const DEFAULT_INTERVAL = '10m';
 
 export const QUERY_DATE_RANGE_LIMIT = 30; // Maximum number of days that can be queried for, enabled by the `insights-query-date-range-limit` feature flag
-export const OLD_QUERY_DATE_RANGE_LIMIT = 7;
 
 export const MODULE_TITLES: Record<ModuleName, string> = {
   [ModuleName.DB]: DB_MODULE_TITLE,


### PR DESCRIPTION
Removes the logic that conditionally increases the default query date range limit if a flag is on. This is no longer needed because we fully GAd the flag