### PR TITLE
ref(uptime): Remove usage of ProjectUptimeSubscription from endpoints

### DIFF
--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -654,7 +654,7 @@ class UptimeParams:
         location="path",
         required=True,
         type=int,
-        description="The ID of the uptime alert rule you'd like to query. Can be either a project uptime subscription ID (default) or a detector ID (when useDetectorId=1 query parameter is provided).",
+        description="The ID of the uptime alert rule you'd like to query.",
     )
     OWNER = OpenApiParameter(
         name="owner",

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -476,8 +476,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:uptime-create-issues", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enables detailed logging for uptime results
     manager.add("organizations:uptime-detailed-logging", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Enable using detector IDs by default in uptime endpoints (instead of requiring useDetectorId query parameter)
-    manager.add("organizations:uptime-detector-ids-by-default", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable sending uptime results to EAP (Events Analytics Platform)
     manager.add("organizations:uptime-eap-results", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable querying uptime data from EAP uptime_results instead of uptime_checks

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -72,10 +72,14 @@ from sentry.relay.config.metric_extraction import (
 from sentry.sentry_apps.services.app import app_service
 from sentry.sentry_apps.utils.errors import SentryAppBaseError
 from sentry.snuba.dataset import Dataset
-from sentry.uptime.models import ProjectUptimeSubscription, UptimeStatus
-from sentry.uptime.types import UptimeMonitorMode
+from sentry.uptime.types import (
+    DATA_SOURCE_UPTIME_SUBSCRIPTION,
+    GROUP_TYPE_UPTIME_DOMAIN_CHECK_FAILURE,
+    UptimeMonitorMode,
+)
 from sentry.utils.cursors import Cursor, StringCursor
-from sentry.workflow_engine.models import Detector
+from sentry.workflow_engine.models import Detector, DetectorState
+from sentry.workflow_engine.types import DetectorPriorityLevel
 
 logger = logging.getLogger(__name__)
 
@@ -274,12 +278,18 @@ class OrganizationCombinedRuleIndexEndpoint(OrganizationEndpoint):
             project__in=projects,
         )
 
-        uptime_rules = ProjectUptimeSubscription.objects.filter(
-            project__in=projects,
-            mode__in=(
-                UptimeMonitorMode.MANUAL,
-                UptimeMonitorMode.AUTO_DETECTED_ACTIVE,
-            ),
+        uptime_rules = (
+            Detector.objects.filter(
+                type=GROUP_TYPE_UPTIME_DOMAIN_CHECK_FAILURE,
+                project__in=projects,
+                config__mode__in=(
+                    UptimeMonitorMode.MANUAL.value,
+                    UptimeMonitorMode.AUTO_DETECTED_ACTIVE.value,
+                ),
+                data_sources__type=DATA_SOURCE_UPTIME_SUBSCRIPTION,
+            )
+            .select_related("project")
+            .prefetch_related("data_sources")
         )
         crons_rules = (
             Monitor.objects.filter(project_id__in=[p.id for p in projects])
@@ -367,15 +377,18 @@ class OrganizationCombinedRuleIndexEndpoint(OrganizationEndpoint):
                 incident_status=Value(-2, output_field=IntegerField())
             )
             uptime_rules = uptime_rules.annotate(
+                detector_priority=Subquery(
+                    DetectorState.objects.filter(detector=OuterRef("pk")).values("state")[:1]
+                ),
                 incident_status=Case(
-                    # If an uptime monitor is failing we want to treat it the same as if an alert is failing, so sort
-                    # by the critical status
+                    # If an uptime detector is in HIGH priority (failing)
+                    # state, treat it like a critical incident
                     When(
-                        uptime_subscription__uptime_status=UptimeStatus.FAILED,
+                        detector_priority=DetectorPriorityLevel.HIGH,
                         then=IncidentStatus.CRITICAL.value,
                     ),
                     default=-2,
-                )
+                ),
             )
             crons_rules = crons_rules.annotate(
                 incident_status=Case(

--- a/src/sentry/uptime/endpoints/bases.py
+++ b/src/sentry/uptime/endpoints/bases.py
@@ -1,19 +1,13 @@
-import logging
-
 from rest_framework.request import Request
 
-from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.bases.project import ProjectAlertRulePermission, ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
-from sentry.uptime.models import ProjectUptimeSubscription, get_detector
 from sentry.uptime.types import (
     DATA_SOURCE_UPTIME_SUBSCRIPTION,
     GROUP_TYPE_UPTIME_DOMAIN_CHECK_FAILURE,
 )
 from sentry.workflow_engine.models import Detector
-
-logger = logging.getLogger(__name__)
 
 
 class ProjectUptimeAlertEndpoint(ProjectEndpoint):
@@ -23,9 +17,10 @@ class ProjectUptimeAlertEndpoint(ProjectEndpoint):
     def convert_args(
         self,
         request: Request,
-        # XXX(epurkhiser): There's a getsentry test that depends on this
-        # argument name, when we change this over to purely detector_id we
-        # should make the effort to fix the parameter name then
+        # XXX(epurkhiser): THIS IS A DETECTOR
+        #
+        # This name is completely wrong, but there's a test in getsentry that's
+        # using this parameter name that we'll have to fix first to change it.
         uptime_project_subscription_id: str,
         *args,
         **kwargs,
@@ -33,52 +28,14 @@ class ProjectUptimeAlertEndpoint(ProjectEndpoint):
         args, kwargs = super().convert_args(request, *args, **kwargs)
         project = kwargs["project"]
 
-        # Check feature flag and query parameter to determine if ID should be treated as detector ID
-        detector_ids_by_default = features.has(
-            "organizations:uptime-detector-ids-by-default", project.organization, actor=request.user
-        )
-        use_detector_id = detector_ids_by_default or request.GET.get("useDetectorId") == "1"
-
-        # XXX(epurkhiser): We can remove this dual reading logic once all
-        # endpoints are using the Detector IDs over ProjectUptimeSubscription
-        # IDs.
-        if use_detector_id:
-            # Treat ID as detector ID - find detector and its associated subscription
-            try:
-                detector = Detector.objects.get(
-                    project=project,
-                    id=uptime_project_subscription_id,
-                    type=GROUP_TYPE_UPTIME_DOMAIN_CHECK_FAILURE,
-                    data_sources__type=DATA_SOURCE_UPTIME_SUBSCRIPTION,
-                )
-                # Get the uptime subscription from the detector's data source
-                data_source = detector.data_sources.get(type=DATA_SOURCE_UPTIME_SUBSCRIPTION)
-                uptime_subscription_id = data_source.source_id
-                uptime_monitor = ProjectUptimeSubscription.objects.get(
-                    project=project, uptime_subscription__id=uptime_subscription_id
-                )
-                kwargs["uptime_detector"] = detector
-                kwargs["uptime_monitor"] = uptime_monitor
-            except (Detector.DoesNotExist, ProjectUptimeSubscription.DoesNotExist, AttributeError):
-                raise ResourceDoesNotExist
-        else:
-            # Treat ID as project uptime subscription ID (legacy behavior)
-            logger.warning(
-                "uptime.endpoint.using_project_subscription_id",
-                extra={
-                    "organization_id": project.organization.id,
-                    "project_id": project.id,
-                    "uptime_project_subscription_id": uptime_project_subscription_id,
-                },
+        try:
+            kwargs["uptime_detector"] = Detector.objects.get(
+                project=project,
+                id=uptime_project_subscription_id,
+                type=GROUP_TYPE_UPTIME_DOMAIN_CHECK_FAILURE,
+                data_sources__type=DATA_SOURCE_UPTIME_SUBSCRIPTION,
             )
-            try:
-                uptime_monitor = ProjectUptimeSubscription.objects.get(
-                    project=project, id=uptime_project_subscription_id
-                )
-                detector = get_detector(uptime_monitor.uptime_subscription)
-                kwargs["uptime_detector"] = detector
-                kwargs["uptime_monitor"] = uptime_monitor
-            except ProjectUptimeSubscription.DoesNotExist:
-                raise ResourceDoesNotExist
+        except Detector.DoesNotExist:
+            raise ResourceDoesNotExist
 
         return args, kwargs

--- a/src/sentry/uptime/endpoints/organiation_uptime_alert_index.py
+++ b/src/sentry/uptime/endpoints/organiation_uptime_alert_index.py
@@ -1,4 +1,6 @@
 from django.db.models import Q
+from django.db.models.fields import BigIntegerField, CharField
+from django.db.models.functions import Cast
 from drf_spectacular.utils import extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -19,10 +21,15 @@ from sentry.models.organization import Organization
 from sentry.search.utils import tokenize_query
 from sentry.types.actor import Actor
 from sentry.uptime.endpoints.serializers import (
-    ProjectUptimeSubscriptionSerializer,
-    ProjectUptimeSubscriptionSerializerResponse,
+    UptimeDetectorSerializer,
+    UptimeDetectorSerializerResponse,
 )
-from sentry.uptime.models import ProjectUptimeSubscription
+from sentry.uptime.models import UptimeSubscription
+from sentry.uptime.types import (
+    DATA_SOURCE_UPTIME_SUBSCRIPTION,
+    GROUP_TYPE_UPTIME_DOMAIN_CHECK_FAILURE,
+)
+from sentry.workflow_engine.models import Detector
 
 
 @region_silo_endpoint
@@ -44,7 +51,7 @@ class OrganizationUptimeAlertIndexEndpoint(OrganizationEndpoint):
         ],
         responses={
             200: inline_sentry_response_serializer(
-                "UptimeAlertList", list[ProjectUptimeSubscriptionSerializerResponse]
+                "UptimeAlertList", list[UptimeDetectorSerializerResponse]
             ),
             401: RESPONSE_UNAUTHORIZED,
             403: RESPONSE_FORBIDDEN,
@@ -60,14 +67,17 @@ class OrganizationUptimeAlertIndexEndpoint(OrganizationEndpoint):
         except NoProjects:
             return self.respond([])
 
-        queryset = ProjectUptimeSubscription.objects.filter(
-            project__organization_id=organization.id, project_id__in=filter_params["project_id"]
+        queryset = Detector.objects.filter(
+            type=GROUP_TYPE_UPTIME_DOMAIN_CHECK_FAILURE,
+            project__organization_id=organization.id,
+            project_id__in=filter_params["project_id"],
         )
         query = request.GET.get("query")
         owners = request.GET.getlist("owner")
 
         if "environment" in filter_params:
-            queryset = queryset.filter(environment__in=filter_params["environment_objects"])
+            environment_names = [env.name for env in filter_params["environment_objects"]]
+            queryset = queryset.filter(config__environment__in=environment_names)
 
         if owners:
             owners_set = set(owners)
@@ -103,10 +113,20 @@ class OrganizationUptimeAlertIndexEndpoint(OrganizationEndpoint):
             for key, value in tokens.items():
                 if key == "query":
                     query_value = " ".join(value)
-                    queryset = queryset.filter(
-                        Q(name__icontains=query_value)
-                        | Q(uptime_subscription__url__icontains=query_value)
+
+                    linked_subscription_ids = queryset.values_list(
+                        Cast("data_sources__source_id", BigIntegerField()), flat=True
                     )
+                    matching_subscription_ids = UptimeSubscription.objects.filter(
+                        id__in=linked_subscription_ids, url__icontains=query_value
+                    ).values_list(Cast("id", CharField()), flat=True)
+
+                    url_filter = Q(
+                        data_sources__type=DATA_SOURCE_UPTIME_SUBSCRIPTION,
+                        data_sources__source_id__in=matching_subscription_ids,
+                    )
+
+                    queryset = queryset.filter(Q(name__icontains=query_value) | url_filter)
                 elif key == "name":
                     queryset = queryset.filter(in_iexact("name", value))
                 else:
@@ -115,6 +135,6 @@ class OrganizationUptimeAlertIndexEndpoint(OrganizationEndpoint):
         return self.paginate(
             request=request,
             queryset=queryset,
-            on_results=lambda x: serialize(x, request.user, ProjectUptimeSubscriptionSerializer()),
+            on_results=lambda x: serialize(x, request.user, UptimeDetectorSerializer()),
             paginator_cls=OffsetPaginator,
         )

--- a/src/sentry/uptime/endpoints/project_uptime_alert_checks_index.py
+++ b/src/sentry/uptime/endpoints/project_uptime_alert_checks_index.py
@@ -35,11 +35,7 @@ from sentry.models.project import Project
 from sentry.uptime.eap_utils import get_columns_for_uptime_trace_item_type
 from sentry.uptime.endpoints.bases import ProjectUptimeAlertEndpoint
 from sentry.uptime.endpoints.serializers import EapCheckEntrySerializerResponse
-from sentry.uptime.models import (
-    ProjectUptimeSubscription,
-    UptimeSubscription,
-    get_uptime_subscription,
-)
+from sentry.uptime.models import UptimeSubscription, get_uptime_subscription
 from sentry.uptime.types import EapCheckEntry, IncidentStatus
 from sentry.utils import snuba_rpc
 from sentry.workflow_engine.models import Detector
@@ -60,7 +56,6 @@ class ProjectUptimeAlertCheckIndexEndpoint(ProjectUptimeAlertEndpoint):
         request: Request,
         project: Project,
         uptime_detector: Detector,
-        uptime_monitor: ProjectUptimeSubscription,
     ) -> Response:
         uptime_subscription = get_uptime_subscription(uptime_detector)
 

--- a/src/sentry/uptime/endpoints/project_uptime_alert_details.py
+++ b/src/sentry/uptime/endpoints/project_uptime_alert_details.py
@@ -17,12 +17,9 @@ from sentry.apidocs.constants import (
 from sentry.apidocs.parameters import GlobalParams, UptimeParams
 from sentry.models.project import Project
 from sentry.uptime.endpoints.bases import ProjectUptimeAlertEndpoint
-from sentry.uptime.endpoints.serializers import (
-    ProjectUptimeSubscriptionSerializer,
-    ProjectUptimeSubscriptionSerializerResponse,
-)
+from sentry.uptime.endpoints.serializers import UptimeDetectorSerializer
 from sentry.uptime.endpoints.validators import UptimeMonitorValidator
-from sentry.uptime.models import ProjectUptimeSubscription
+from sentry.uptime.models import get_audit_log_data
 from sentry.uptime.subscriptions.subscriptions import delete_uptime_detector
 from sentry.utils.audit import create_audit_entry
 from sentry.workflow_engine.models import Detector
@@ -47,7 +44,7 @@ class ProjectUptimeAlertDetailsEndpoint(ProjectUptimeAlertEndpoint):
             UptimeParams.UPTIME_ALERT_ID,
         ],
         responses={
-            200: ProjectUptimeSubscriptionSerializer,
+            200: UptimeDetectorSerializer,
             401: RESPONSE_UNAUTHORIZED,
             403: RESPONSE_FORBIDDEN,
             404: RESPONSE_NOT_FOUND,
@@ -57,14 +54,11 @@ class ProjectUptimeAlertDetailsEndpoint(ProjectUptimeAlertEndpoint):
         self,
         request: Request,
         project: Project,
-        uptime_monitor: ProjectUptimeSubscription,
         uptime_detector: Detector,
     ) -> Response:
-        serialized_uptime_alert: ProjectUptimeSubscriptionSerializerResponse = serialize(
-            uptime_monitor,
-            request.user,
+        return self.respond(
+            serialize(uptime_detector, request.user, serializer=UptimeDetectorSerializer())
         )
-        return self.respond(serialized_uptime_alert)
 
     @extend_schema(
         operation_id="Update an Uptime Monitor for a Project",
@@ -75,7 +69,7 @@ class ProjectUptimeAlertDetailsEndpoint(ProjectUptimeAlertEndpoint):
         ],
         request=UptimeMonitorValidator,
         responses={
-            200: ProjectUptimeSubscriptionSerializer,
+            200: UptimeDetectorSerializer,
             400: RESPONSE_BAD_REQUEST,
             401: RESPONSE_UNAUTHORIZED,
             403: RESPONSE_FORBIDDEN,
@@ -86,7 +80,6 @@ class ProjectUptimeAlertDetailsEndpoint(ProjectUptimeAlertEndpoint):
         self,
         request: Request,
         project: Project,
-        uptime_monitor: ProjectUptimeSubscription,
         uptime_detector: Detector,
     ) -> Response:
         """
@@ -95,7 +88,7 @@ class ProjectUptimeAlertDetailsEndpoint(ProjectUptimeAlertEndpoint):
         validator = UptimeMonitorValidator(
             data=request.data,
             partial=True,
-            instance=uptime_monitor,
+            instance=uptime_detector,
             context={
                 "organization": project.organization,
                 "project": project,
@@ -106,7 +99,9 @@ class ProjectUptimeAlertDetailsEndpoint(ProjectUptimeAlertEndpoint):
         if not validator.is_valid():
             return self.respond(validator.errors, status=400)
 
-        return self.respond(serialize(validator.save(), request.user))
+        return self.respond(
+            serialize(validator.save(), request.user, serializer=UptimeDetectorSerializer())
+        )
 
     @extend_schema(
         operation_id="Delete an Uptime Monitor for a Project",
@@ -126,18 +121,17 @@ class ProjectUptimeAlertDetailsEndpoint(ProjectUptimeAlertEndpoint):
         self,
         request: Request,
         project: Project,
-        uptime_monitor: ProjectUptimeSubscription,
         uptime_detector: Detector,
     ) -> Response:
         """
         Delete an uptime monitor.
         """
-        audit_log_data = uptime_monitor.get_audit_log_data()
+        audit_log_data = get_audit_log_data(uptime_detector)
         delete_uptime_detector(uptime_detector)
         create_audit_entry(
             request=request,
             organization=project.organization,
-            target_object=uptime_monitor.id,
+            target_object=uptime_detector.id,
             event=audit_log.get_event_id("UPTIME_MONITOR_REMOVE"),
             data=audit_log_data,
         )

--- a/src/sentry/uptime/endpoints/project_uptime_alert_index.py
+++ b/src/sentry/uptime/endpoints/project_uptime_alert_index.py
@@ -16,7 +16,7 @@ from sentry.apidocs.constants import (
 )
 from sentry.apidocs.parameters import GlobalParams
 from sentry.models.project import Project
-from sentry.uptime.endpoints.serializers import ProjectUptimeSubscriptionSerializer
+from sentry.uptime.endpoints.serializers import UptimeDetectorSerializer
 from sentry.uptime.endpoints.validators import UptimeMonitorValidator
 
 
@@ -34,7 +34,7 @@ class ProjectUptimeAlertIndexEndpoint(ProjectEndpoint):
         parameters=[GlobalParams.ORG_ID_OR_SLUG],
         request=UptimeMonitorValidator,
         responses={
-            201: ProjectUptimeSubscriptionSerializer,
+            201: UptimeDetectorSerializer,
             400: RESPONSE_BAD_REQUEST,
             401: RESPONSE_UNAUTHORIZED,
             403: RESPONSE_FORBIDDEN,
@@ -57,4 +57,6 @@ class ProjectUptimeAlertIndexEndpoint(ProjectEndpoint):
         if not validator.is_valid():
             return self.respond(validator.errors, status=400)
 
-        return self.respond(serialize(validator.save(), request.user))
+        return self.respond(
+            serialize(validator.save(), request.user, serializer=UptimeDetectorSerializer())
+        )

--- a/src/sentry/uptime/endpoints/serializers.py
+++ b/src/sentry/uptime/endpoints/serializers.py
@@ -1,7 +1,6 @@
 from collections.abc import MutableMapping, Sequence
 from typing import Any, Literal, TypedDict, cast, override
 
-from django.db.models import prefetch_related_objects
 from sentry_kafka_schemas.schema_types.snuba_uptime_results_v1 import (
     CheckStatus,
     CheckStatusReasonType,
@@ -10,7 +9,7 @@ from sentry_kafka_schemas.schema_types.snuba_uptime_results_v1 import (
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.models.actor import ActorSerializer, ActorSerializerResponse
 from sentry.types.actor import Actor
-from sentry.uptime.models import ProjectUptimeSubscription, UptimeSubscription
+from sentry.uptime.models import UptimeStatus, UptimeSubscription
 from sentry.uptime.subscriptions.regions import get_region_config
 from sentry.uptime.types import (
     DATA_SOURCE_UPTIME_SUBSCRIPTION,
@@ -18,7 +17,14 @@ from sentry.uptime.types import (
     IncidentStatus,
     UptimeSummary,
 )
-from sentry.workflow_engine.models import DataSourceDetector
+from sentry.workflow_engine.models import DataSourceDetector, DetectorState
+from sentry.workflow_engine.models.detector import Detector
+from sentry.workflow_engine.types import DetectorPriorityLevel
+
+DETECTOR_PRIORITY_TO_UPTIME_STATUS = {
+    DetectorPriorityLevel.OK: UptimeStatus.OK,
+    DetectorPriorityLevel.HIGH: UptimeStatus.FAILED,
+}
 
 
 class UptimeSubscriptionSerializerResponse(TypedDict):
@@ -47,8 +53,10 @@ class UptimeSubscriptionSerializer(Serializer):
         }
 
 
-class ProjectUptimeSubscriptionSerializerResponse(UptimeSubscriptionSerializerResponse):
+class UptimeDetectorSerializerResponse(UptimeSubscriptionSerializerResponse):
     id: str
+    # TODO(epurkhiser): Should be removed once the frontend is using `id`
+    # instead of `detectorId`
     detectorId: int
     projectSlug: str
     environment: str | None
@@ -59,55 +67,76 @@ class ProjectUptimeSubscriptionSerializerResponse(UptimeSubscriptionSerializerRe
     owner: ActorSerializerResponse
 
 
-@register(ProjectUptimeSubscription)
-class ProjectUptimeSubscriptionSerializer(Serializer):
-    def __init__(self, expand=None):
-        self.expand = expand
-
+class UptimeDetectorSerializer(Serializer):
     def get_attrs(
-        self, item_list: Sequence[ProjectUptimeSubscription], user: Any, **kwargs: Any
+        self, item_list: Sequence[Detector], user: Any, **kwargs: Any
     ) -> MutableMapping[Any, Any]:
-        prefetch_related_objects(item_list, "uptime_subscription", "project", "environment")
-        owners = list(filter(None, [item.owner for item in item_list]))
+        detector_state_lookup = {
+            ds.detector_id: ds for ds in DetectorState.objects.filter(detector__in=item_list)
+        }
+
+        # Get uptime subscriptions through data source detectors
+        data_source_detectors = DataSourceDetector.objects.filter(
+            detector__in=item_list,
+            data_source__type=DATA_SOURCE_UPTIME_SUBSCRIPTION,
+        ).select_related("data_source")
+
+        subscription_by_id = {
+            str(sub.id): sub
+            for sub in UptimeSubscription.objects.filter(
+                id__in=[dsd.data_source.source_id for dsd in data_source_detectors]
+            )
+        }
+
+        detector_to_subscription = {
+            dsd.detector_id: subscription_by_id.get(dsd.data_source.source_id)
+            for dsd in data_source_detectors
+        }
+
+        # Serialize owners
+        owners = [detector.owner for detector in item_list if detector.owner]
         owners_serialized = serialize(
             Actor.resolve_many(owners, filter_none=False), user, ActorSerializer()
         )
-        serialized_owner_lookup = {
-            owner: serialized_owner for owner, serialized_owner in zip(owners, owners_serialized)
-        }
-
-        detector_id_lookup = {
-            int(source_id): detector_id
-            for source_id, detector_id in DataSourceDetector.objects.filter(
-                data_source__type=DATA_SOURCE_UPTIME_SUBSCRIPTION,
-                data_source__source_id__in=[str(item.uptime_subscription.id) for item in item_list],
-            ).values_list("data_source__source_id", "detector_id")
-        }
+        owner_lookup = {owner: serialized for owner, serialized in zip(owners, owners_serialized)}
 
         return {
-            item: {
-                "owner": serialized_owner_lookup.get(item.owner) if item.owner else None,
-                "detector_id": detector_id_lookup.get(item.uptime_subscription.id),
+            detector: {
+                "uptime_subscription": detector_to_subscription.get(detector.id),
+                "detector_state": detector_state_lookup.get(detector.id),
+                "owner": detector.owner and owner_lookup.get(detector.owner) or None,
             }
-            for item in item_list
+            for detector in item_list
         }
 
-    def serialize(
-        self, obj: ProjectUptimeSubscription, attrs, user, **kwargs
-    ) -> ProjectUptimeSubscriptionSerializerResponse:
+    def serialize(self, obj: Detector, attrs, user, **kwargs) -> UptimeDetectorSerializerResponse:
+        uptime_subscription = attrs["uptime_subscription"]
+        detector_state = attrs["detector_state"]
+
+        if not uptime_subscription:
+            # Handle case where we can't find the associated uptime subscription
+            raise ValueError(f"Could not find UptimeSubscription for detector {obj.id}")
+
         serialized_subscription: UptimeSubscriptionSerializerResponse = serialize(
-            obj.uptime_subscription
+            uptime_subscription
         )
+
+        if detector_state and detector_state.state in DETECTOR_PRIORITY_TO_UPTIME_STATUS:
+            uptime_status = DETECTOR_PRIORITY_TO_UPTIME_STATUS[detector_state.state]
+        else:
+            uptime_status = UptimeStatus.OK
 
         return {
             "id": str(obj.id),
-            "detectorId": attrs["detector_id"],
+            # TODO(epurkhiser): Should be removed once the frontend is using `id`
+            # instead of `detectorId`
+            "detectorId": obj.id,
             "projectSlug": obj.project.slug,
-            "environment": obj.environment.name if obj.environment else None,
-            "name": obj.name or f"Uptime Monitoring for {obj.uptime_subscription.url}",
-            "status": obj.get_status_display(),
-            "uptimeStatus": obj.uptime_subscription.uptime_status,
-            "mode": obj.mode,
+            "environment": obj.config.get("environment"),
+            "name": obj.name or f"Uptime Monitoring for {uptime_subscription.url}",
+            "status": "active" if obj.enabled else "disabled",
+            "uptimeStatus": uptime_status,
+            "mode": obj.config.get("mode", 1),  # Default to MANUAL mode
             "owner": attrs["owner"],
             **serialized_subscription,
         }

--- a/src/sentry/uptime/models.py
+++ b/src/sentry/uptime/models.py
@@ -40,6 +40,7 @@ from sentry.workflow_engine.models import (
     DataSource,
     DataSourceDetector,
     Detector,
+    DetectorState,
 )
 from sentry.workflow_engine.registry import data_source_type_registry
 from sentry.workflow_engine.types import DataSourceTypeHandler, DetectorPriorityLevel
@@ -378,6 +379,32 @@ def get_project_subscription(detector: Detector) -> ProjectUptimeSubscription:
     return ProjectUptimeSubscription.objects.get(uptime_subscription_id=int(data_source.source_id))
 
 
+def get_audit_log_data(detector: Detector):
+    """Get audit log data from a detector instead of a ProjectUptimeSubscription instance."""
+    uptime_subscription = get_uptime_subscription(detector)
+
+    owner_user_id = None
+    owner_team_id = None
+    if detector.owner:
+        if detector.owner.is_user:
+            owner_user_id = detector.owner.id
+        elif detector.owner.is_team:
+            owner_team_id = detector.owner.id
+
+    return {
+        "project": detector.project_id,
+        "name": detector.name,
+        "owner_user_id": owner_user_id,
+        "owner_team_id": owner_team_id,
+        "url": uptime_subscription.url,
+        "interval_seconds": uptime_subscription.interval_seconds,
+        "timeout": uptime_subscription.timeout_ms,
+        "method": uptime_subscription.method,
+        "headers": uptime_subscription.headers,
+        "body": uptime_subscription.body,
+    }
+
+
 def create_detector_from_project_subscription(project_sub: ProjectUptimeSubscription) -> Detector:
     """
     Creates a uptime detector and associated data-source given a
@@ -417,5 +444,19 @@ def create_detector_from_project_subscription(project_sub: ProjectUptimeSubscrip
         workflow_condition_group=condition_group,
     )
     DataSourceDetector.objects.create(data_source=data_source, detector=detector)
+
+    # Create DetectorState based on the uptime_status from the uptime_subscription
+    if project_sub.uptime_subscription.uptime_status == UptimeStatus.FAILED:
+        DetectorState.objects.create(
+            detector=detector,
+            state=DetectorPriorityLevel.HIGH,
+            is_triggered=True,
+        )
+    else:
+        DetectorState.objects.create(
+            detector=detector,
+            state=DetectorPriorityLevel.OK,
+            is_triggered=False,
+        )
 
     return detector

--- a/tests/sentry/uptime/endpoints/test_organization_uptime_alert_index.py
+++ b/tests/sentry/uptime/endpoints/test_organization_uptime_alert_index.py
@@ -1,4 +1,6 @@
 from sentry.api.serializers import serialize
+from sentry.uptime.endpoints.serializers import UptimeDetectorSerializer
+from sentry.uptime.models import get_detector
 from tests.sentry.uptime.endpoints import UptimeAlertBaseEndpointTest
 
 
@@ -9,14 +11,23 @@ class OrganizationUptimeAlertIndexBaseEndpointTest(UptimeAlertBaseEndpointTest):
 class OrganizationUptimeAlertIndexEndpointTest(OrganizationUptimeAlertIndexBaseEndpointTest):
     method = "get"
 
-    def check_valid_response(self, response, expected_alerts):
-        assert [serialize(uptime_alert) for uptime_alert in expected_alerts] == response.data
+    def check_valid_response(self, response, expected_detectors):
+        assert [
+            serialize(uptime_alert, serializer=UptimeDetectorSerializer())
+            for uptime_alert in expected_detectors
+        ] == response.data
 
     def test(self) -> None:
         alert_1 = self.create_project_uptime_subscription(name="test1")
         alert_2 = self.create_project_uptime_subscription(name="test2")
         resp = self.get_success_response(self.organization.slug)
-        self.check_valid_response(resp, [alert_1, alert_2])
+        self.check_valid_response(
+            resp,
+            [
+                get_detector(alert_1.uptime_subscription),
+                get_detector(alert_2.uptime_subscription),
+            ],
+        )
 
     def test_search_by_url(self) -> None:
         self.create_project_uptime_subscription()
@@ -25,7 +36,12 @@ class OrganizationUptimeAlertIndexEndpointTest(OrganizationUptimeAlertIndexBaseE
         )
 
         response = self.get_success_response(self.organization.slug, query="santry")
-        self.check_valid_response(response, [santry_monitor])
+        self.check_valid_response(
+            response,
+            [
+                get_detector(santry_monitor.uptime_subscription),
+            ],
+        )
 
     def test_environment_filter(self) -> None:
         env = self.create_environment()
@@ -33,7 +49,12 @@ class OrganizationUptimeAlertIndexEndpointTest(OrganizationUptimeAlertIndexBaseE
         env_monitor = self.create_project_uptime_subscription(env=env)
 
         response = self.get_success_response(self.organization.slug, environment=[env.name])
-        self.check_valid_response(response, [env_monitor])
+        self.check_valid_response(
+            response,
+            [
+                get_detector(env_monitor.uptime_subscription),
+            ],
+        )
 
     def test_owner_filter(self) -> None:
         user_1 = self.create_user()
@@ -50,28 +71,51 @@ class OrganizationUptimeAlertIndexEndpointTest(OrganizationUptimeAlertIndexBaseE
 
         # Monitor by user
         response = self.get_success_response(self.organization.slug, owner=[f"user:{user_1.id}"])
-        self.check_valid_response(response, [uptime_a])
+        self.check_valid_response(
+            response,
+            [
+                get_detector(uptime_a.uptime_subscription),
+            ],
+        )
 
         # Monitors by users and teams
         response = self.get_success_response(
             self.organization.slug,
             owner=[f"user:{user_1.id}", f"user:{user_2.id}", f"team:{team_1.id}"],
         )
-        self.check_valid_response(response, [uptime_a, uptime_b, uptime_c])
+        self.check_valid_response(
+            response,
+            [
+                get_detector(uptime_a.uptime_subscription),
+                get_detector(uptime_b.uptime_subscription),
+                get_detector(uptime_c.uptime_subscription),
+            ],
+        )
 
         # myteams
         response = self.get_success_response(
             self.organization.slug,
             owner=["myteams"],
         )
-        self.check_valid_response(response, [uptime_d])
+        self.check_valid_response(
+            response,
+            [
+                get_detector(uptime_d.uptime_subscription),
+            ],
+        )
 
         # unassigned monitors
         response = self.get_success_response(
             self.organization.slug,
             owner=["unassigned", f"user:{user_1.id}"],
         )
-        self.check_valid_response(response, [uptime_a, uptime_e])
+        self.check_valid_response(
+            response,
+            [
+                get_detector(uptime_a.uptime_subscription),
+                get_detector(uptime_e.uptime_subscription),
+            ],
+        )
 
         # Invalid user ID
         response = self.get_success_response(

--- a/tests/sentry/uptime/endpoints/test_project_uptime_alert_index.py
+++ b/tests/sentry/uptime/endpoints/test_project_uptime_alert_index.py
@@ -6,8 +6,9 @@ from sentry.constants import ObjectStatus
 from sentry.models.environment import Environment
 from sentry.quotas.base import SeatAssignmentResult
 from sentry.uptime.endpoints.validators import MAX_REQUEST_SIZE_BYTES
-from sentry.uptime.models import ProjectUptimeSubscription
+from sentry.uptime.models import get_project_subscription
 from sentry.uptime.types import UptimeMonitorMode
+from sentry.workflow_engine.models import Detector
 from tests.sentry.uptime.endpoints import UptimeAlertBaseEndpointTest
 
 
@@ -30,7 +31,8 @@ class ProjectUptimeAlertIndexPostEndpointTest(ProjectUptimeAlertIndexBaseEndpoin
             timeout_ms=1500,
             body=None,
         )
-        uptime_monitor = ProjectUptimeSubscription.objects.get(id=resp.data["id"])
+        detector = Detector.objects.get(id=resp.data["detectorId"])
+        uptime_monitor = get_project_subscription(detector)
         uptime_subscription = uptime_monitor.uptime_subscription
         assert uptime_monitor.name == "test"
         assert uptime_monitor.environment == Environment.get_or_create(
@@ -58,7 +60,8 @@ class ProjectUptimeAlertIndexPostEndpointTest(ProjectUptimeAlertIndexBaseEndpoin
             body=None,
             trace_sampling=True,
         )
-        uptime_monitor = ProjectUptimeSubscription.objects.get(id=resp.data["id"])
+        detector = Detector.objects.get(id=resp.data["detectorId"])
+        uptime_monitor = get_project_subscription(detector)
         uptime_subscription = uptime_monitor.uptime_subscription
         assert uptime_subscription.trace_sampling is True
 
@@ -73,7 +76,8 @@ class ProjectUptimeAlertIndexPostEndpointTest(ProjectUptimeAlertIndexBaseEndpoin
             timeout_ms=1000,
             body=None,
         )
-        uptime_monitor = ProjectUptimeSubscription.objects.get(id=resp.data["id"])
+        detector = Detector.objects.get(id=resp.data["detectorId"])
+        uptime_monitor = get_project_subscription(detector)
         assert uptime_monitor.environment is None
 
     def test_no_owner(self) -> None:
@@ -87,7 +91,8 @@ class ProjectUptimeAlertIndexPostEndpointTest(ProjectUptimeAlertIndexBaseEndpoin
             interval_seconds=60,
             timeout_ms=1000,
         )
-        uptime_monitor = ProjectUptimeSubscription.objects.get(id=resp.data["id"])
+        detector = Detector.objects.get(id=resp.data["detectorId"])
+        uptime_monitor = get_project_subscription(detector)
         assert uptime_monitor.owner_user_id is None
         assert uptime_monitor.owner_team_id is None
 
@@ -101,7 +106,8 @@ class ProjectUptimeAlertIndexPostEndpointTest(ProjectUptimeAlertIndexBaseEndpoin
             interval_seconds=60,
             timeout_ms=1000,
         )
-        uptime_monitor = ProjectUptimeSubscription.objects.get(id=resp.data["id"])
+        detector = Detector.objects.get(id=resp.data["detectorId"])
+        uptime_monitor = get_project_subscription(detector)
         assert uptime_monitor.owner_user_id is None
         assert uptime_monitor.owner_team_id is None
 
@@ -135,7 +141,8 @@ class ProjectUptimeAlertIndexPostEndpointTest(ProjectUptimeAlertIndexBaseEndpoin
             timeout_ms=1000,
             mode=UptimeMonitorMode.AUTO_DETECTED_ACTIVE,
         )
-        uptime_monitor = ProjectUptimeSubscription.objects.get(id=resp.data["id"])
+        detector = Detector.objects.get(id=resp.data["detectorId"])
+        uptime_monitor = get_project_subscription(detector)
         uptime_subscription = uptime_monitor.uptime_subscription
         assert uptime_monitor.name == "test"
         assert uptime_monitor.owner_user_id == self.user.id
@@ -159,7 +166,8 @@ class ProjectUptimeAlertIndexPostEndpointTest(ProjectUptimeAlertIndexBaseEndpoin
             body='{"key": "value"}',
             headers=[["header", "value"]],
         )
-        uptime_monitor = ProjectUptimeSubscription.objects.get(id=resp.data["id"])
+        detector = Detector.objects.get(id=resp.data["detectorId"])
+        uptime_monitor = get_project_subscription(detector)
         uptime_subscription = uptime_monitor.uptime_subscription
         assert uptime_subscription.body == '{"key": "value"}'
         assert uptime_subscription.headers == [["header", "value"]]
@@ -178,7 +186,8 @@ class ProjectUptimeAlertIndexPostEndpointTest(ProjectUptimeAlertIndexBaseEndpoin
             body='{"key": "value"}',
             headers=[["header", "value"]],
         )
-        uptime_monitor = ProjectUptimeSubscription.objects.get(id=resp.data["id"])
+        detector = Detector.objects.get(id=resp.data["detectorId"])
+        uptime_monitor = get_project_subscription(detector)
         new_proj = self.create_project()
         resp = self.get_success_response(
             self.organization.slug,
@@ -193,7 +202,8 @@ class ProjectUptimeAlertIndexPostEndpointTest(ProjectUptimeAlertIndexBaseEndpoin
             body='{"key": "value"}',
             headers=[["header", "value"]],
         )
-        new_uptime_monitor = ProjectUptimeSubscription.objects.get(id=resp.data["id"])
+        new_detector = Detector.objects.get(id=resp.data["detectorId"])
+        new_uptime_monitor = get_project_subscription(new_detector)
         assert uptime_monitor.uptime_subscription_id != new_uptime_monitor.uptime_subscription_id
         assert new_uptime_monitor.project_id != uptime_monitor.project_id
         resp = self.get_success_response(
@@ -209,7 +219,8 @@ class ProjectUptimeAlertIndexPostEndpointTest(ProjectUptimeAlertIndexBaseEndpoin
             body='{"key": "value"}',
             headers=[["header", "different value"]],
         )
-        newer_uptime_monitor = ProjectUptimeSubscription.objects.get(id=resp.data["id"])
+        newer_detector = Detector.objects.get(id=resp.data["detectorId"])
+        newer_uptime_monitor = get_project_subscription(newer_detector)
         assert (
             newer_uptime_monitor.uptime_subscription_id != new_uptime_monitor.uptime_subscription_id
         )
@@ -296,7 +307,8 @@ class ProjectUptimeAlertIndexPostEndpointTest(ProjectUptimeAlertIndexBaseEndpoin
             timeout_ms=1000,
             owner=f"user:{self.user.id}",
         )
-        uptime_monitor = ProjectUptimeSubscription.objects.get(id=resp.data["id"])
+        detector = Detector.objects.get(id=resp.data["detectorId"])
+        uptime_monitor = get_project_subscription(detector)
         assert uptime_monitor.status == ObjectStatus.DISABLED
 
     def test_timeout_too_large(self) -> None:

--- a/tests/sentry/uptime/subscriptions/test_subscriptions.py
+++ b/tests/sentry/uptime/subscriptions/test_subscriptions.py
@@ -37,7 +37,7 @@ from sentry.uptime.subscriptions.subscriptions import (
     get_auto_monitored_detectors_for_project,
     is_url_auto_monitored_for_project,
     remove_uptime_subscription_if_unused,
-    update_project_uptime_subscription,
+    update_uptime_detector,
     update_uptime_subscription,
 )
 from sentry.uptime.types import UptimeMonitorMode
@@ -472,8 +472,8 @@ class UpdateProjectUptimeSubscriptionTest(UptimeTestCase):
             prev_uptime_subscription = proj_sub.uptime_subscription
             prev_uptime_subscription.refresh_from_db()
             prev_subscription_id = prev_uptime_subscription.subscription_id
-            update_project_uptime_subscription(
-                proj_sub,
+            update_uptime_detector(
+                detector,
                 environment=self.environment,
                 url="https://santry.io",
                 interval_seconds=60,
@@ -525,8 +525,8 @@ class UpdateProjectUptimeSubscriptionTest(UptimeTestCase):
             )
             other_proj_sub = get_project_subscription(other_detector)
 
-            update_project_uptime_subscription(
-                proj_sub,
+            update_uptime_detector(
+                detector,
                 environment=self.environment,
                 url=proj_sub.uptime_subscription.url,
                 interval_seconds=other_proj_sub.uptime_subscription.interval_seconds,
@@ -571,9 +571,8 @@ class UpdateProjectUptimeSubscriptionTest(UptimeTestCase):
                 timeout_ms=1000,
                 mode=UptimeMonitorMode.AUTO_DETECTED_ACTIVE,
             )
-            proj_sub = get_project_subscription(detector)
-            update_project_uptime_subscription(
-                proj_sub,
+            update_uptime_detector(
+                detector,
                 environment=self.environment,
                 url="https://santry.io",
                 interval_seconds=60,
@@ -600,9 +599,8 @@ class UpdateProjectUptimeSubscriptionTest(UptimeTestCase):
                 mode=UptimeMonitorMode.AUTO_DETECTED_ACTIVE,
                 status=ObjectStatus.DISABLED,
             )
-            proj_sub = get_project_subscription(detector)
-            update_project_uptime_subscription(
-                proj_sub,
+            update_uptime_detector(
+                detector,
                 environment=self.environment,
                 url="https://santry.io",
                 interval_seconds=60,


### PR DESCRIPTION
This systemically removes ProjectUptimeSubscription usages from uptime endpoints.

- Remove legacy dual ID handling logic and query parameter dependencies. The useDetectorId query parameter no longer has any affect, all IDs are treated as detector Ids.

- Update all endpoints to use Detector model instead of ProjectUptimeSubscription.

- Refactor serializers to work with Detector objects and associated UptimeSubscription data.

- Update validators to create and update Detector instances directly

- Update audit logging to use detector IDs and consolidated audit log data functions. Previously the get_audit_log_data method was part of the ProjectUptimeSubscription, which is no longer used.

- Remove unused ProjectUptimeSubscription references throughout codebase

IMPORTANTLY the tests have very little changes to them, this is because this change does NOT change how data is returned.

Requires #98527

Fixes: [NEW-513: Remove `ProjectUptimeSubscription` from endpoints](https://linear.app/getsentry/issue/NEW-513/remove-projectuptimesubscription-from-endpoints)