### PR TITLE
core: visually balance buttons that contain icons

### DIFF
--- a/static/app/components/core/button/index.mdx
+++ b/static/app/components/core/button/index.mdx
@@ -90,9 +90,21 @@ Buttons support an optional leading icon.
   <Button icon={<IconAdd />} priority="primary">
     Add
   </Button>
+  <Button icon={<IconAdd />} priority="primary" size="sm">
+    Add
+  </Button>
+  <Button icon={<IconAdd />} priority="primary" size="xs">
+    Add
+  </Button>
 </Storybook.Demo>
 ```jsx
 <Button icon={<IconAdd />} priority="primary">
+  Add
+</Button>
+<Button icon={<IconAdd />} priority="primary" size="sm">
+  Add
+</Button>
+<Button icon={<IconAdd />} priority="primary" size="xs">
   Add
 </Button>
 ```
@@ -137,9 +149,13 @@ In scenarios where high information density is critical, buttons may be displaye
 
 <Storybook.Demo>
   <Button icon={<IconAdd />} aria-label="Add" />
+  <Button icon={<IconAdd />} aria-label="Add" size="sm" />
+  <Button icon={<IconAdd />} aria-label="Add" size="xs" />
 </Storybook.Demo>
 ```jsx
 <Button icon={<IconAdd />} aria-label="Add" />
+<Button icon={<IconAdd />} aria-label="Add" size="sm" />
+<Button icon={<IconAdd />} aria-label="Add" size="xs" />
 ```
 
 ## Accessibility

--- a/static/app/components/core/button/index.tsx
+++ b/static/app/components/core/button/index.tsx
@@ -38,6 +38,7 @@ export function Button({
   return (
     <Tooltip skipWrapper {...tooltipProps} title={title} disabled={!title}>
       <StyledButton
+        hasChildren={hasChildren}
         aria-label={accessibleLabel}
         aria-disabled={disabled}
         aria-busy={busy}
@@ -71,7 +72,12 @@ export function Button({
   );
 }
 
-export const StyledButton = styled('button')<ButtonProps>`
+/**
+ * Only use this component if for some reason you need to override
+ * the styles of a button that is not accessible directly.
+ * @deprecated
+ */
+export const StyledButton = styled('button')<ButtonProps & {hasChildren: boolean}>`
   ${p => (p.theme.isChonk ? getChonkButtonStyles(p as any) : getButtonStyles(p as any))}
 `;
 

--- a/static/app/components/core/button/styles.chonk.tsx
+++ b/static/app/components/core/button/styles.chonk.tsx
@@ -44,6 +44,8 @@ const chonkHoverElevation = '1px';
 
 export function DO_NOT_USE_getChonkButtonStyles(
   p: Pick<ButtonProps, 'priority' | 'busy' | 'disabled' | 'borderless'> & {
+    hasChildren: boolean;
+    icon: ButtonProps['icon'];
     size: NonNullable<ButtonProps['size']>;
     theme: DO_NOT_USE_ChonkTheme;
   }
@@ -78,8 +80,9 @@ export function DO_NOT_USE_getChonkButtonStyles(
       cursor: 'not-allowed',
     },
 
-    padding: getChonkButtonSizeTheme(p.size, p.theme).padding,
-    borderRadius: getChonkButtonSizeTheme(p.size, p.theme).borderRadius,
+    padding: getChonkButtonSizeTheme(p.size, p.icon, p.hasChildren, p.theme).padding,
+    borderRadius: getChonkButtonSizeTheme(p.size, p.icon, p.hasChildren, p.theme)
+      .borderRadius,
     border: 'none',
     color: chonkButtonTheme.color,
 
@@ -290,30 +293,60 @@ function getChonkButtonTheme(type: ChonkButtonType, theme: DO_NOT_USE_ChonkTheme
   }
 }
 
-function getChonkButtonSizeTheme(
+function getChonkIconPaddingLeft(
   size: ButtonProps['size'],
   theme: DO_NOT_USE_ChonkTheme
+) {
+  switch (size) {
+    case 'md':
+      return theme.space.lg;
+    case 'sm':
+      return theme.space.md;
+    case 'xs':
+      return theme.space.sm;
+    case 'zero':
+      return theme.space.xs;
+    default:
+      return undefined;
+  }
+}
+
+function getChonkButtonSizeTheme(
+  size: ButtonProps['size'],
+  icon: ButtonProps['icon'],
+  hasChildren: boolean,
+  theme: DO_NOT_USE_ChonkTheme
 ): StrictCSSObject {
+  const visuallyBalanceIcon = icon && hasChildren;
+
   switch (size) {
     case 'md':
       return {
         borderRadius: theme.radius.lg,
-        padding: `${theme.space.md} ${theme.space.xl}`,
+        padding: visuallyBalanceIcon
+          ? `${theme.space.md} ${theme.space.xl} ${theme.space.md} ${getChonkIconPaddingLeft(size, theme)}`
+          : `${theme.space.md} ${theme.space.xl}`,
       };
     case 'sm':
       return {
         borderRadius: theme.radius.md,
-        padding: `${theme.space.md} ${theme.space.lg}`,
+        padding: visuallyBalanceIcon
+          ? `${theme.space.md} ${theme.space.lg} ${theme.space.md} ${getChonkIconPaddingLeft(size, theme)}`
+          : `${theme.space.md} ${theme.space.lg}`,
       };
     case 'xs':
       return {
         borderRadius: theme.radius.sm,
-        padding: `${theme.space.sm} ${theme.space.md}`,
+        padding: visuallyBalanceIcon
+          ? `${theme.space.sm} ${theme.space.md} ${theme.space.sm} ${getChonkIconPaddingLeft(size, theme)}`
+          : `${theme.space.sm} ${theme.space.md}`,
       };
     case 'zero':
       return {
         borderRadius: theme.radius.xs,
-        padding: `${theme.space.xs} ${theme.space.sm}`,
+        padding: visuallyBalanceIcon
+          ? `${theme.space.xs} ${theme.space.sm} ${theme.space.xs} ${getChonkIconPaddingLeft(size, theme)}`
+          : `${theme.space.xs} ${theme.space.sm}`,
       };
     default:
       return {};

--- a/static/app/components/core/button/styles.tsx
+++ b/static/app/components/core/button/styles.tsx
@@ -147,11 +147,44 @@ const buttonPadding: ButtonPaddingSizes = {
   },
 };
 
+// We offset the icon padding to make the button feel visually balanced.
+const iconPaddingLeft = {
+  md: buttonPadding.md.paddingLeft - 6,
+  sm: buttonPadding.sm.paddingLeft - 4,
+  xs: buttonPadding.xs.paddingLeft - 2,
+};
+
+function getButtonPadding(
+  size: ButtonSize,
+  icon: ButtonProps['icon'],
+  hasChildren: boolean
+): {
+  paddingBottom: number;
+  paddingLeft: number;
+  paddingRight: number;
+  paddingTop: number;
+} {
+  if (icon && hasChildren) {
+    return {
+      ...buttonPadding[size],
+      paddingLeft: iconPaddingLeft[size],
+    };
+  }
+  return {
+    ...buttonPadding[size],
+  };
+}
+
 const getSizeStyles = ({
   size = 'md',
+  icon,
+  hasChildren,
   translucentBorder,
   theme,
-}: (ButtonProps | LinkButtonProps) & {theme: Theme}): SerializedStyles => {
+}: (ButtonProps | LinkButtonProps) & {
+  hasChildren: boolean;
+  theme: Theme;
+}): SerializedStyles => {
   const buttonSize = size === 'zero' ? 'md' : size;
   const formStyles = theme.form[buttonSize];
 
@@ -161,15 +194,15 @@ const getSizeStyles = ({
     ? {
         height: `calc(${formStyles.height} - 2px)`,
         minHeight: `calc(${formStyles.minHeight} - 2px)`,
-        paddingTop: buttonPadding[buttonSize].paddingTop - 1,
-        paddingBottom: buttonPadding[buttonSize].paddingBottom - 1,
+        paddingTop: getButtonPadding(buttonSize, icon, hasChildren).paddingTop - 1,
+        paddingBottom: getButtonPadding(buttonSize, icon, hasChildren).paddingBottom - 1,
         margin: 1,
       }
     : {};
 
   return css`
     ${formStyles}
-    ${buttonPadding[buttonSize]}
+    ${getButtonPadding(buttonSize, icon, hasChildren)}
     ${borderStyles}
   `;
 };
@@ -177,7 +210,7 @@ const getSizeStyles = ({
 // This should only be used by the different underlying button implementations
 // and not directly by consumers of the button component.
 export function DO_NOT_USE_getButtonStyles(
-  p: (ButtonProps | LinkButtonProps) & {theme: Theme}
+  p: (ButtonProps | LinkButtonProps) & {hasChildren: boolean; theme: Theme}
 ): SerializedStyles {
   return css`
     position: relative;

--- a/static/app/components/core/segmentedControl/index.chonk.tsx
+++ b/static/app/components/core/segmentedControl/index.chonk.tsx
@@ -72,7 +72,7 @@ export const ChonkStyledSegmentWrap = chonkStyled('label')<{
   padding: ${p => segmentedWrapPadding[p.size]};
   font-weight: ${p => p.theme.fontWeight.normal};
 
-  ${p => ({...DO_NOT_USE_getChonkButtonStyles({...p, disabled: p.isDisabled, priority: p.isSelected && p.priority === 'primary' ? 'primary' : 'default'})})}
+  ${p => ({...DO_NOT_USE_getChonkButtonStyles({...p, disabled: p.isDisabled, priority: p.isSelected && p.priority === 'primary' ? 'primary' : 'default', hasChildren: true, icon: undefined})})}
 
   &:has(input:focus-visible) {
     ${p => p.theme.focusRing()};


### PR DESCRIPTION
Visually balances buttons that contain icons (icon only buttons are not affected)


https://github.com/user-attachments/assets/6a623726-bc04-49d7-9f4c-3b8b4600951c

