### PR TITLE
fix(typing): Remove sentry.integrations.slack.webhooks.event from problem list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -308,7 +308,6 @@ module = [
     "sentry.api.paginator",
     "sentry.db.postgres.base",
     "sentry.integrations.slack.message_builder.notifications.issues",
-    "sentry.integrations.slack.webhooks.event",
     "sentry.middleware.auth",
     "sentry.middleware.ratelimit",
     "sentry.net.http",

--- a/src/sentry/incidents/charts.py
+++ b/src/sentry/incidents/charts.py
@@ -1,7 +1,7 @@
 from collections.abc import Mapping
 from datetime import datetime, timedelta
 from functools import reduce
-from typing import Any, Optional
+from typing import Any
 
 from django.utils import timezone
 
@@ -23,6 +23,7 @@ from sentry.snuba.models import QuerySubscription, SnubaQuery, SnubaQueryEventTy
 from sentry.snuba.referrer import Referrer
 from sentry.snuba.utils import build_query_strings
 from sentry.users.models.user import User
+from sentry.users.services.user import RpcUser
 
 CRASH_FREE_SESSIONS = "percentage(sessions_crashed, sessions) AS _crash_rate_alert_aggregate"
 CRASH_FREE_USERS = "percentage(users_crashed, users) AS _crash_rate_alert_aggregate"
@@ -66,7 +67,7 @@ def fetch_metric_alert_sessions_data(
     organization: Organization,
     rule_aggregate: str,
     query_params: Mapping[str, str],
-    user: Optional["User"] = None,
+    user: User | RpcUser | None = None,
 ) -> Any:
     try:
         resp = client.get(
@@ -92,7 +93,7 @@ def fetch_metric_alert_events_timeseries(
     organization: Organization,
     rule_aggregate: str,
     query_params: Mapping[str, str],
-    user: Optional["User"] = None,
+    user: User | RpcUser | None = None,
 ) -> list[Any]:
     try:
         resp = client.get(
@@ -130,7 +131,7 @@ def fetch_metric_issue_open_periods(
     organization: Organization,
     open_period_identifier: int,
     time_period: Mapping[str, str],
-    user: Optional["User"] = None,
+    user: User | RpcUser | None = None,
 ) -> list[Any]:
     try:
         resp = client.get(
@@ -166,7 +167,7 @@ def build_metric_alert_chart(
     period: str | None = None,
     start: str | None = None,
     end: str | None = None,
-    user: Optional["User"] = None,
+    user: User | RpcUser | None = None,
     size: ChartSize | None = None,
     subscription: QuerySubscription | None = None,
 ) -> str | None:

--- a/src/sentry/integrations/slack/unfurl/discover.py
+++ b/src/sentry/integrations/slack/unfurl/discover.py
@@ -20,7 +20,7 @@ from sentry.integrations.messaging.metrics import (
     MessagingInteractionType,
 )
 from sentry.integrations.models.integration import Integration
-from sentry.integrations.services.integration import integration_service
+from sentry.integrations.services.integration import RpcIntegration, integration_service
 from sentry.integrations.slack.message_builder.discover import SlackDiscoverMessageBuilder
 from sentry.integrations.slack.spec import SlackMessagingSpec
 from sentry.integrations.slack.unfurl.types import Handler, UnfurlableUrl, UnfurledUrl
@@ -29,6 +29,7 @@ from sentry.models.organization import Organization
 from sentry.search.events.filter import to_list
 from sentry.snuba.referrer import Referrer
 from sentry.users.models.user import User
+from sentry.users.services.user import RpcUser
 from sentry.utils.dates import (
     get_interval_from_range,
     parse_stats_period,
@@ -117,9 +118,9 @@ def is_aggregate(field: str) -> bool:
 
 def unfurl_discover(
     request: HttpRequest,
-    integration: Integration,
+    integration: Integration | RpcIntegration,
     links: list[UnfurlableUrl],
-    user: User | None = None,
+    user: User | RpcUser | None = None,
 ) -> UnfurledUrl:
     event = MessagingInteractionEvent(
         MessagingInteractionType.UNFURL_DISCOVER, SlackMessagingSpec(), user=user
@@ -129,9 +130,9 @@ def unfurl_discover(
 
 
 def _unfurl_discover(
-    integration: Integration,
+    integration: Integration | RpcIntegration,
     links: list[UnfurlableUrl],
-    user: User | None = None,
+    user: User | RpcUser | None = None,
 ) -> UnfurledUrl:
     org_integrations = integration_service.get_organization_integrations(
         integration_id=integration.id

--- a/src/sentry/integrations/slack/unfurl/issues.py
+++ b/src/sentry/integrations/slack/unfurl/issues.py
@@ -9,7 +9,7 @@ from sentry.integrations.messaging.metrics import (
     MessagingInteractionType,
 )
 from sentry.integrations.models.integration import Integration
-from sentry.integrations.services.integration import integration_service
+from sentry.integrations.services.integration import RpcIntegration, integration_service
 from sentry.integrations.slack.message_builder.issues import SlackIssuesMessageBuilder
 from sentry.integrations.slack.spec import SlackMessagingSpec
 from sentry.integrations.slack.unfurl.types import (
@@ -22,6 +22,7 @@ from sentry.models.group import Group
 from sentry.models.project import Project
 from sentry.services import eventstore
 from sentry.users.models.user import User
+from sentry.users.services.user import RpcUser
 
 map_issue_args = make_type_coercer(
     {
@@ -33,9 +34,9 @@ map_issue_args = make_type_coercer(
 
 def unfurl_issues(
     request: HttpRequest,
-    integration: Integration,
+    integration: Integration | RpcIntegration,
     links: list[UnfurlableUrl],
-    user: User | None = None,
+    user: User | RpcUser | None = None,
 ) -> UnfurledUrl:
     """
     Returns a map of the attachments used in the response we send to Slack
@@ -49,7 +50,9 @@ def unfurl_issues(
         return _unfurl_issues(integration, links)
 
 
-def _unfurl_issues(integration: Integration, links: list[UnfurlableUrl]) -> UnfurledUrl:
+def _unfurl_issues(
+    integration: Integration | RpcIntegration, links: list[UnfurlableUrl]
+) -> UnfurledUrl:
     org_integrations = integration_service.get_organization_integrations(
         integration_id=integration.id
     )

--- a/src/sentry/integrations/slack/unfurl/metric_alerts.py
+++ b/src/sentry/integrations/slack/unfurl/metric_alerts.py
@@ -26,7 +26,7 @@ from sentry.integrations.messaging.metrics import (
     MessagingInteractionType,
 )
 from sentry.integrations.models.integration import Integration
-from sentry.integrations.services.integration import integration_service
+from sentry.integrations.services.integration import RpcIntegration, integration_service
 from sentry.integrations.slack.message_builder.metric_alerts import SlackMetricAlertMessageBuilder
 from sentry.integrations.slack.spec import SlackMessagingSpec
 from sentry.integrations.slack.unfurl.types import (
@@ -37,6 +37,7 @@ from sentry.integrations.slack.unfurl.types import (
 )
 from sentry.models.organization import Organization
 from sentry.users.models.user import User
+from sentry.users.services.user import RpcUser
 
 map_incident_args = make_type_coercer(
     {
@@ -52,9 +53,9 @@ map_incident_args = make_type_coercer(
 
 def unfurl_metric_alerts(
     request: HttpRequest,
-    integration: Integration,
+    integration: Integration | RpcIntegration,
     links: list[UnfurlableUrl],
-    user: User | None = None,
+    user: User | RpcUser | None = None,
 ) -> UnfurledUrl:
     event = MessagingInteractionEvent(
         MessagingInteractionType.UNFURL_METRIC_ALERTS, SlackMessagingSpec(), user=user
@@ -64,9 +65,9 @@ def unfurl_metric_alerts(
 
 
 def _unfurl_metric_alerts(
-    integration: Integration,
+    integration: Integration | RpcIntegration,
     links: list[UnfurlableUrl],
-    user: User | None = None,
+    user: User | RpcUser | None = None,
 ) -> UnfurledUrl:
     alert_filter_query = Q()
     incident_filter_query = Q()

--- a/src/sentry/integrations/slack/unfurl/types.py
+++ b/src/sentry/integrations/slack/unfurl/types.py
@@ -8,7 +8,9 @@ from typing import Any, NamedTuple, Optional, Protocol
 from django.http.request import HttpRequest
 
 from sentry.integrations.models.integration import Integration
+from sentry.integrations.services.integration import RpcIntegration
 from sentry.users.models.user import User
+from sentry.users.services.user import RpcUser
 
 UnfurledUrl = Mapping[Any, Any]
 ArgsMapper = Callable[[str, Mapping[str, Optional[str]]], Mapping[str, Any]]
@@ -29,9 +31,9 @@ class HandlerCallable(Protocol):
     def __call__(
         self,
         request: HttpRequest,
-        integration: Integration,
+        integration: Integration | RpcIntegration,
         links: list[UnfurlableUrl],
-        user: User | None = None,
+        user: User | RpcUser | None = None,
     ) -> UnfurledUrl: ...
 
 

--- a/src/sentry/integrations/slack/views/link_identity.py
+++ b/src/sentry/integrations/slack/views/link_identity.py
@@ -19,7 +19,10 @@ SUCCESS_LINKED_MESSAGE = (
 
 
 def build_linking_url(
-    integration: RpcIntegration, slack_id: str, channel_id: str, response_url: str
+    integration: RpcIntegration,
+    slack_id: str | None,
+    channel_id: str | None,
+    response_url: str | None,
 ) -> str:
     return base_build_linking_url(
         "sentry-integration-slack-link-identity",


### PR DESCRIPTION
Made minimal changes to allow mypy to pass with the file removed from the problem list.

This mostly consisted of (1) propagating RPC types a bit into the integrations stack and (2) having `is None` checks log errors early, rather than trying to ping slack (and failing, excepting, and logging).

Test plan: `mypy` no errors