### PR TITLE
feat(performance): updates user issue endpoint to accept a trace id 

### DIFF
--- a/src/sentry/issues/endpoints/project_user_issue.py
+++ b/src/sentry/issues/endpoints/project_user_issue.py
@@ -200,6 +200,8 @@ class ProjectUserIssueEndpoint(ProjectEndpoint):
             "organizations:performance-web-vitals-seer-suggestions",
             organization,
             actor=request.user,
+        ) and features.has(
+            "organizations:issue-web-vitals-ingest", organization, actor=request.user
         )
 
     @extend_schema(

--- a/src/sentry/issues/endpoints/project_user_issue.py
+++ b/src/sentry/issues/endpoints/project_user_issue.py
@@ -102,13 +102,14 @@ class WebVitalsUserIssueFormatter(BaseUserIssueFormatter):
         return {
             "transaction": transaction,
             "web_vital": vital,
-            "score": self.data.get("score"),
+            "score": str(self.data.get("score")),
         }
 
     def get_evidence(self) -> tuple[dict, list[IssueEvidence]]:
         vital = self.data.get("vital", "")
         score = self.data.get("score")
         transaction = self.data.get("transaction", "")
+        trace_id = self.data.get("traceId")
 
         evidence_data = {
             "transaction": transaction,
@@ -134,6 +135,16 @@ class WebVitalsUserIssueFormatter(BaseUserIssueFormatter):
             ),
         ]
 
+        if trace_id:
+            evidence_data["trace_id"] = trace_id
+            evidence_display.append(
+                IssueEvidence(
+                    name="Trace ID",
+                    value=trace_id,
+                    important=False,
+                )
+            )
+
         return (evidence_data, evidence_display)
 
 
@@ -145,6 +156,7 @@ ISSUE_TYPE_CHOICES = [
 class ProjectUserIssueRequestSerializer(serializers.Serializer):
     transaction = serializers.CharField(required=True)
     issueType = serializers.ChoiceField(required=True, choices=ISSUE_TYPE_CHOICES)
+    traceId = serializers.CharField(required=False)
 
 
 class WebVitalsIssueDataSerializer(ProjectUserIssueRequestSerializer):
@@ -188,8 +200,6 @@ class ProjectUserIssueEndpoint(ProjectEndpoint):
             "organizations:performance-web-vitals-seer-suggestions",
             organization,
             actor=request.user,
-        ) and features.has(
-            "organizations:issue-web-vitals-ingest", organization, actor=request.user
         )
 
     @extend_schema(
@@ -237,6 +247,14 @@ class ProjectUserIssueEndpoint(ProjectEndpoint):
             "received": now.isoformat(),
             "tags": formatter.get_tags(),
         }
+
+        if validated_data.get("traceId"):
+            event_data["contexts"] = {
+                "trace": {
+                    "trace_id": validated_data["traceId"],
+                    "type": "trace",
+                }
+            }
 
         (evidence_data, evidence_display) = formatter.get_evidence()
 

--- a/tests/sentry/issues/endpoints/test_project_user_issue.py
+++ b/tests/sentry/issues/endpoints/test_project_user_issue.py
@@ -39,6 +39,7 @@ class ProjectUserIssueEndpointTest(APITestCase):
             "issueType": WebVitalsGroup.slug,
             "score": 75,
             "vital": "lcp",
+            "traceId": "1234567890",
         }
 
         with patch(
@@ -66,6 +67,12 @@ class ProjectUserIssueEndpointTest(APITestCase):
         assert occurrence.subtitle == "/test-transaction has an LCP score of 75"
         assert occurrence.culprit == "/test-transaction"
         assert occurrence.level == "info"
+        assert occurrence.evidence_data == {
+            "transaction": "/test-transaction",
+            "vital": "lcp",
+            "score": 75,
+            "trace_id": "1234567890",
+        }
 
         # Verify event data
         assert event_data["project_id"] == self.project.id
@@ -76,7 +83,13 @@ class ProjectUserIssueEndpointTest(APITestCase):
         assert event_data["tags"] == {
             "transaction": "/test-transaction",
             "web_vital": "lcp",
-            "score": 75,
+            "score": "75",
+        }
+        assert event_data["contexts"] == {
+            "trace": {
+                "trace_id": "1234567890",
+                "type": "trace",
+            }
         }
 
     def test_no_access(self) -> None:


### PR DESCRIPTION
- Updates the `user-issue` endpoint to accept a `traceId` that attaches a trace to the event context and issue occurrence evidence. This is so seer autofix can leverage traces when investigating web vital issues.
- Also fixes issue score using a numeric value instead of str in event tags.