### PR TITLE
fix(preprod): Enable downloads for uploaded APK artifacts

### DIFF
--- a/src/sentry/preprod/api/endpoints/project_preprod_artifact_update.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_artifact_update.py
@@ -213,6 +213,16 @@ class ProjectPreprodArtifactUpdateEndpoint(ProjectEndpoint):
                 preprod_artifact.state = PreprodArtifact.ArtifactState.PROCESSED
                 updated_fields.append("state")
 
+                # For APK artifacts, set installable_app_file_id to file_id if not already set
+                # APK files are already installable and don't need conversion like AAB files
+                if (
+                    preprod_artifact.artifact_type == PreprodArtifact.ArtifactType.APK
+                    and preprod_artifact.installable_app_file_id is None
+                    and preprod_artifact.file_id is not None
+                ):
+                    preprod_artifact.installable_app_file_id = preprod_artifact.file_id
+                    updated_fields.append("installable_app_file_id")
+
             preprod_artifact.save(update_fields=updated_fields + ["date_updated"])
 
             create_preprod_status_check_task.apply_async(


### PR DESCRIPTION
## Summary

- Fix APK artifact downloads that were previously blocked due to missing `installable_app_file_id`

## Changes

Previously, uploaded APK files couldn't be downloaded because:
- AAB files get converted to APK format during processing and populate `installable_app_file_id`
- APK files are uploaded directly but `installable_app_file_id` remained null
- Download logic requires non-null `installable_app_file_id`

This change automatically sets `installable_app_file_id = file_id` for APK artifacts when they transition to PROCESSED state, since APK files are already in installable format and don't need conversion like AAB files.