### PR TITLE
feat(deletions): Add IssuePlatform batching back

### DIFF
--- a/src/sentry/deletions/tasks/nodestore.py
+++ b/src/sentry/deletions/tasks/nodestore.py
@@ -208,15 +208,12 @@ def delete_events_from_eventstore(
 
 
 def delete_events_from_eventstore_issue_platform(
-   """
-   When this task executes, the groups will have been deleted from the DB, thus, we won't have access
-   to the times_seen field via the Group model.
-   """
-
-# to the times_seen field via the Group model.
-def delete_events_from_eventstore_issue_platform(
     organization_id: int, project_id: int, group_ids: Sequence[int], times_seen_list: Sequence[int]
 ) -> None:
+    """
+    When this task executes, the groups will have been deleted from the DB, thus, we won't have access
+    to the times_seen field via the Group model.
+    """
     requests = []
     # Split group_ids into batches where the sum of times_seen is less than ISSUE_PLATFORM_MAX_ROWS_TO_DELETE
     current_batch: list[int] = []

--- a/src/sentry/deletions/tasks/nodestore.py
+++ b/src/sentry/deletions/tasks/nodestore.py
@@ -207,7 +207,12 @@ def delete_events_from_eventstore(
         eventstream.backend.end_delete_groups(eventstream_state)
 
 
-# When this task executes, the groups will have been deleted from the DB, thus, we won't have access
+def delete_events_from_eventstore_issue_platform(
+   """
+   When this task executes, the groups will have been deleted from the DB, thus, we won't have access
+   to the times_seen field via the Group model.
+   """
+
 # to the times_seen field via the Group model.
 def delete_events_from_eventstore_issue_platform(
     organization_id: int, project_id: int, group_ids: Sequence[int], times_seen_list: Sequence[int]

--- a/src/sentry/deletions/tasks/nodestore.py
+++ b/src/sentry/deletions/tasks/nodestore.py
@@ -210,14 +210,14 @@ def delete_events_from_eventstore(
 # When this task executes, the groups will have been deleted from the DB, thus, we won't have access
 # to the times_seen field via the Group model.
 def delete_events_from_eventstore_issue_platform(
-    organization_id: int, project_id: int, group_ids: Sequence[int], times_seen: Sequence[int]
+    organization_id: int, project_id: int, group_ids: Sequence[int], times_seen_list: Sequence[int]
 ) -> None:
     requests = []
     # Split group_ids into batches where the sum of times_seen is less than ISSUE_PLATFORM_MAX_ROWS_TO_DELETE
     current_batch: list[int] = []
     current_batch_rows = 0
 
-    for group_id, times_seen in zip(group_ids, times_seen):
+    for group_id, times_seen in zip(group_ids, times_seen_list):
         # If adding this group would exceed the limit, create a request with the current batch
         if current_batch_rows + times_seen > ISSUE_PLATFORM_MAX_ROWS_TO_DELETE:
             requests.append(delete_request(organization_id, project_id, current_batch))

--- a/src/sentry/deletions/tasks/nodestore.py
+++ b/src/sentry/deletions/tasks/nodestore.py
@@ -55,6 +55,7 @@ def delete_events_for_groups_from_nodestore_and_eventstore(
     organization_id: int,
     project_id: int,
     group_ids: Sequence[int],
+    times_seen: Sequence[int],
     transaction_id: str,
     dataset_str: str,
     referrer: str,
@@ -71,7 +72,8 @@ def delete_events_for_groups_from_nodestore_and_eventstore(
     Args:
         organization_id:        Organization ID for tenant context
         project_id:             Project ID that all groups belong to
-        group_ids:              List of group IDs to delete events for
+        group_ids:              List of group IDs to delete events for (sorted by times_seen & id)
+        times_seen:             List of times_seen for the groups (the caller has to ensure it matches to the group_ids)
         transaction_id:         Unique identifier to help debug deletion tasks
         dataset_str:            Dataset string to delete events from
         referrer:               Referrer for the task
@@ -86,6 +88,7 @@ def delete_events_for_groups_from_nodestore_and_eventstore(
         "organization_id": organization_id,
         "project_id": project_id,
         "group_ids": group_ids,
+        "times_seen": times_seen,
         "transaction_id": transaction_id,
         "dataset_str": dataset_str,
         "referrer": referrer,
@@ -125,7 +128,7 @@ def delete_events_for_groups_from_nodestore_and_eventstore(
             # from the nodestore. This is why we only delete from the eventstore once we've deleted
             # from the nodestore.
             delete_events_from_eventstore(
-                organization_id, project_id, group_ids, Dataset(dataset_str)
+                organization_id, project_id, group_ids, times_seen, Dataset(dataset_str)
             )
 
     # TODO: Add specific error handling for retryable errors and raise RetryTask when appropriate
@@ -189,26 +192,45 @@ def delete_events_from_nodestore(events: Sequence[Event], dataset: Dataset) -> N
 
 
 def delete_events_from_eventstore(
-    organization_id: int, project_id: int, group_ids: Sequence[int], dataset: Dataset
+    organization_id: int,
+    project_id: int,
+    group_ids: Sequence[int],
+    times_seen: Sequence[int],
+    dataset: Dataset,
 ) -> None:
     if dataset == Dataset.IssuePlatform:
-        delete_events_from_eventstore_issue_platform(organization_id, project_id, group_ids)
+        delete_events_from_eventstore_issue_platform(
+            organization_id, project_id, group_ids, times_seen
+        )
     else:
         eventstream_state = eventstream.backend.start_delete_groups(project_id, group_ids)
         eventstream.backend.end_delete_groups(eventstream_state)
 
 
-# Since we now schedule a task to delete events from the eventstore, we are likely
-# to end up with the groups being deleted from the DB, thus, we won't have access
-# to the times_seen field.
-#
-# For now, we will drop the ability to delete groups in batches based on the times_seen field.
-#
-# In the future, we can schedule multiple event deletion tasks taking into account the times_seen field.
+# When this task executes, the groups will have been deleted from the DB, thus, we won't have access
+# to the times_seen field via the Group model.
 def delete_events_from_eventstore_issue_platform(
-    organization_id: int, project_id: int, group_ids: Sequence[int]
+    organization_id: int, project_id: int, group_ids: Sequence[int], times_seen: Sequence[int]
 ) -> None:
-    requests = [delete_request(organization_id, project_id, group_ids)]
+    requests = []
+    # Split group_ids into batches where the sum of times_seen is less than ISSUE_PLATFORM_MAX_ROWS_TO_DELETE
+    current_batch: list[int] = []
+    current_batch_rows = 0
+
+    for group_id, times_seen in zip(group_ids, times_seen):
+        # If adding this group would exceed the limit, create a request with the current batch
+        if current_batch_rows + times_seen > ISSUE_PLATFORM_MAX_ROWS_TO_DELETE:
+            requests.append(delete_request(organization_id, project_id, current_batch))
+            # We now start a new batch
+            current_batch = [group_id]
+            current_batch_rows = times_seen
+        else:
+            current_batch.append(group_id)
+            current_batch_rows += times_seen
+
+    # Add the final batch if it's not empty
+    if current_batch:
+        requests.append(delete_request(organization_id, project_id, current_batch))
     bulk_snuba_queries(requests)
 
 

--- a/tests/sentry/deletions/tasks/test_nodestore.py
+++ b/tests/sentry/deletions/tasks/test_nodestore.py
@@ -48,6 +48,7 @@ class NodestoreDeletionTaskTest(TestCase):
                     "organization_id": self.project.organization_id,
                     "project_id": self.project.id,
                     "group_ids": group_ids,
+                    "times_seen": [1] * len(group_ids),
                     "transaction_id": uuid4().hex,
                     "dataset_str": Dataset.Events.value,
                     "referrer": "deletions.groups",


### PR DESCRIPTION
In #96795 we added a new task for deleting nodestore events separate from the group deletion task due to its slowness.

Once it went live, we noticed that it would fail when retrieving the Group from the group_ids passed. This was due to the parent task having deleted the groups before the new task would be executed.

In order to prevent the problem, we temporarily removed the batching support for Issue Platform in #96958 since there would not be customer impact and TTL would eventually delete the data.

This change does the following:
* Calls the new task with the `group_ids` sorted
* Add a new parameter containing the associated `times_seen` for those group ids

All of this batching is to ensure we don't call Snuba light deletions for more than [ISSUE_PLATFORM_MAX_ROWS_TO_DELETE](https://github.com/getsentry/snuba/blob/54feb15b7575142d4b3af7f50d2c2c865329f2db/snuba/datasets/configuration/issues/storages/search_issues.yaml#L139) rows.

Fixes [ID-840: Add issue platform batching logic back](https://linear.app/getsentry/issue/ID-840/add-issue-platform-batching-logic-back)