### PR TITLE
test(performance): Increase timeout of spans group by test

### DIFF
--- a/static/app/views/explore/spans/spansTab.spec.tsx
+++ b/static/app/views/explore/spans/spansTab.spec.tsx
@@ -214,7 +214,7 @@ describe('SpansTabContent', () => {
       'timestamp',
       'project',
     ]);
-  });
+  }, 20_000);
 
   it('opens toolbar when switching to aggregates tab', async () => {
     render(


### PR DESCRIPTION
Seems to be right around that 5 second timeout so it flakes a lot. https://sentry.sentry.io/explore/traces/?aggregateField=%7B%22groupBy%22%3A%22branch%22%7D&aggregateField=%7B%22yAxes%22%3A%5B%22avg%28span.duration%29%22%5D%7D&environment=ci%3Apull_request&environment=ci%3Amaster&mode=aggregate&project=4857230&query=span.op%3A%22jest%20test%22%20span.description%3A%22SpansTabContent%20%3E%20inserts%20group%20bys%20from%20aggregate%20mode%20as%20fields%20in%20samples%20mode%22&statsPeriod=30d
