### PR TITLE
feat(preprod): Add basic size comparison task and comparison logic

### DIFF
--- a/src/sentry/preprod/api/models/project_preprod_size_analysis_models.py
+++ b/src/sentry/preprod/api/models/project_preprod_size_analysis_models.py
@@ -1,7 +1,0 @@
-from pydantic import BaseModel, Field
-
-
-# Keep in sync with https://github.com/getsentry/launchpad/blob/ff2d2956d062b202206353747af3bdb5bf6062a5/src/launchpad/size/models/common.py#L92
-class SizeAnalysisResults(BaseModel):
-    download_size: int = Field(..., description="Estimated download size in bytes")
-    install_size: int = Field(..., description="Estimated install size in bytes")

--- a/src/sentry/preprod/models.py
+++ b/src/sentry/preprod/models.py
@@ -149,7 +149,9 @@ class PreprodArtifact(DefaultFieldsModel):
             project__organization_id=self.project.organization_id,
         ).order_by("app_id")
 
-    def get_base_artifact_for_commit(self) -> models.QuerySet["PreprodArtifact"]:
+    def get_base_artifact_for_commit(
+        self, artifact_type: ArtifactType | None = None
+    ) -> models.QuerySet["PreprodArtifact"]:
         """
         Get the base artifact for the same commit comparison (monorepo scenario).
         There can only be one base artifact for a commit comparison, as we only create one
@@ -170,9 +172,12 @@ class PreprodArtifact(DefaultFieldsModel):
             commit_comparison=base_commit_comparison,
             project__organization_id=self.project.organization_id,
             app_id=self.app_id,
-        ).first()
+            artifact_type=artifact_type if artifact_type is not None else self.artifact_type,
+        )
 
-    def get_head_artifacts_for_commit(self) -> models.QuerySet["PreprodArtifact"]:
+    def get_head_artifacts_for_commit(
+        self, artifact_type: ArtifactType | None = None
+    ) -> models.QuerySet["PreprodArtifact"]:
         """
         Get all head artifacts for the same commit comparison (monorepo scenario).
         There can be multiple head artifacts for a commit comparison, as multiple
@@ -193,6 +198,7 @@ class PreprodArtifact(DefaultFieldsModel):
             commit_comparison__in=head_commit_comparisons,
             project__organization_id=self.project.organization_id,
             app_id=self.app_id,
+            artifact_type=artifact_type if artifact_type is not None else self.artifact_type,
         )
 
     class Meta:

--- a/src/sentry/preprod/models.py
+++ b/src/sentry/preprod/models.py
@@ -10,6 +10,7 @@ from sentry.db.models.fields.bounded import (
     BoundedPositiveIntegerField,
 )
 from sentry.db.models.fields.foreignkey import FlexibleForeignKey
+from sentry.models.commitcomparison import CommitComparison
 
 
 @region_silo_model
@@ -147,6 +148,52 @@ class PreprodArtifact(DefaultFieldsModel):
             commit_comparison=self.commit_comparison,
             project__organization_id=self.project.organization_id,
         ).order_by("app_id")
+
+    def get_base_artifact_for_commit(self) -> models.QuerySet["PreprodArtifact"]:
+        """
+        Get the base artifact for the same commit comparison (monorepo scenario).
+        There can only be one base artifact for a commit comparison, as we only create one
+        CommitComparison for a given build and head SHA.
+        """
+        if not self.commit_comparison:
+            return PreprodArtifact.objects.none()
+
+        try:
+            base_commit_comparison = CommitComparison.objects.get(
+                head_sha=self.commit_comparison.base_sha,
+                organization_id=self.project.organization_id,
+            )
+        except CommitComparison.DoesNotExist:
+            return PreprodArtifact.objects.none()
+
+        return PreprodArtifact.objects.filter(
+            commit_comparison=base_commit_comparison,
+            project__organization_id=self.project.organization_id,
+            app_id=self.app_id,
+        ).first()
+
+    def get_head_artifacts_for_commit(self) -> models.QuerySet["PreprodArtifact"]:
+        """
+        Get all head artifacts for the same commit comparison (monorepo scenario).
+        There can be multiple head artifacts for a commit comparison, as multiple
+        CommitComparisons can have the same base SHA.
+        """
+        if not self.commit_comparison:
+            return PreprodArtifact.objects.none()
+
+        try:
+            head_commit_comparisons = CommitComparison.objects.filter(
+                base_sha=self.commit_comparison.head_sha,
+                organization_id=self.project.organization_id,
+            )
+        except CommitComparison.DoesNotExist:
+            return PreprodArtifact.objects.none()
+
+        return PreprodArtifact.objects.filter(
+            commit_comparison__in=head_commit_comparisons,
+            project__organization_id=self.project.organization_id,
+            app_id=self.app_id,
+        )
 
     class Meta:
         app_label = "preprod"

--- a/src/sentry/preprod/models.py
+++ b/src/sentry/preprod/models.py
@@ -186,13 +186,10 @@ class PreprodArtifact(DefaultFieldsModel):
         if not self.commit_comparison:
             return PreprodArtifact.objects.none()
 
-        try:
-            head_commit_comparisons = CommitComparison.objects.filter(
-                base_sha=self.commit_comparison.head_sha,
-                organization_id=self.project.organization_id,
-            )
-        except CommitComparison.DoesNotExist:
-            return PreprodArtifact.objects.none()
+        head_commit_comparisons = CommitComparison.objects.filter(
+            base_sha=self.commit_comparison.head_sha,
+            organization_id=self.project.organization_id,
+        )
 
         return PreprodArtifact.objects.filter(
             commit_comparison__in=head_commit_comparisons,

--- a/src/sentry/preprod/size_analysis/compare.py
+++ b/src/sentry/preprod/size_analysis/compare.py
@@ -47,16 +47,20 @@ def compare_size_analysis(
         if head_size is not None and base_size is not None:
             size_diff = head_size - base_size
             if size_diff == 0:
-                diff_type = DiffType.UNCHANGED
+                continue  # Skip diff_items with size_diff of 0
             elif size_diff > 0:
                 diff_type = DiffType.INCREASED
             else:
                 diff_type = DiffType.DECREASED
         elif head_size is not None:
             size_diff = head_size
+            if size_diff == 0:
+                continue  # Skip diff_items with size_diff of 0
             diff_type = DiffType.ADDED
         else:
             size_diff = -base_size
+            if size_diff == 0:
+                continue  # Skip diff_items with size_diff of 0
             diff_type = DiffType.REMOVED
 
         diff_items.append(

--- a/src/sentry/preprod/size_analysis/compare.py
+++ b/src/sentry/preprod/size_analysis/compare.py
@@ -1,0 +1,88 @@
+import logging
+
+from sentry.preprod.models import PreprodArtifactSizeMetrics
+from sentry.preprod.size_analysis.models import (
+    ComparisonResults,
+    DiffItem,
+    DiffType,
+    SizeAnalysisResults,
+    SizeMetricDiffItem,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# TODO: Tests
+def compare_size_analysis(
+    head_size_analysis: PreprodArtifactSizeMetrics,
+    head_size_analysis_results: SizeAnalysisResults,
+    base_size_analysis: PreprodArtifactSizeMetrics,
+    base_size_analysis_results: SizeAnalysisResults,
+) -> ComparisonResults:
+    diff_items = []
+
+    def flatten_treemap(element, parent_path=""):
+        items = {}
+        path = element.path or (parent_path + "/" + element.name if parent_path else element.name)
+        items[path] = element.size
+        for child in getattr(element, "children", []):
+            items.update(flatten_treemap(child, path))
+        return items
+
+    head_treemap = (
+        head_size_analysis_results.treemap.root if head_size_analysis_results.treemap else None
+    )
+    base_treemap = (
+        base_size_analysis_results.treemap.root if base_size_analysis_results.treemap else None
+    )
+
+    head_files = flatten_treemap(head_treemap) if head_treemap else {}
+    base_files = flatten_treemap(base_treemap) if base_treemap else {}
+
+    all_paths = set(head_files.keys()) | set(base_files.keys())
+
+    for path in sorted(all_paths):
+        head_size = head_files.get(path)
+        base_size = base_files.get(path)
+        if head_size is not None and base_size is not None:
+            size_diff = head_size - base_size
+            if size_diff == 0:
+                diff_type = DiffType.UNCHANGED
+            elif size_diff > 0:
+                diff_type = DiffType.INCREASED
+            else:
+                diff_type = DiffType.DECREASED
+        elif head_size is not None:
+            size_diff = head_size
+            diff_type = DiffType.ADDED
+        else:
+            size_diff = -base_size
+            diff_type = DiffType.REMOVED
+
+        diff_items.append(
+            DiffItem(
+                size_diff=size_diff,
+                head_size=head_size,
+                base_size=base_size,
+                path=path,
+                type=diff_type,
+            )
+        )
+
+    size_metric_diff_item = SizeMetricDiffItem(
+        metrics_artifact_type=getattr(
+            head_size_analysis,
+            "metrics_artifact_type",
+            PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+        ),
+        identifier=head_size_analysis.identifier,
+        head_install_size=head_size_analysis.max_install_size,
+        head_download_size=head_size_analysis.max_download_size,
+        base_install_size=base_size_analysis.max_install_size,
+        base_download_size=base_size_analysis.max_download_size,
+    )
+
+    return ComparisonResults(
+        diff_items=diff_items,
+        size_metric_diff_item=size_metric_diff_item,
+    )

--- a/src/sentry/preprod/size_analysis/compare.py
+++ b/src/sentry/preprod/size_analysis/compare.py
@@ -7,15 +7,14 @@ from sentry.preprod.size_analysis.models import (
     DiffType,
     SizeAnalysisResults,
     SizeMetricDiffItem,
+    TreemapElement,
 )
 
 logger = logging.getLogger(__name__)
 
 
-def _flatten_leaf_nodes(element, parent_path=""):
+def _flatten_leaf_nodes(element: TreemapElement, parent_path: str = "") -> dict[str, int]:
     items = {}
-    if element is None:
-        return items
 
     path = element.path or (parent_path + "/" + element.name if parent_path else element.name)
     children = getattr(element, "children", [])
@@ -66,8 +65,8 @@ def compare_size_analysis(
             if size_diff == 0:
                 continue  # Skip diff_items with size_diff of 0
             diff_type = DiffType.ADDED
-        else:
-            size_diff = -base_size
+        elif base_size is not None:
+            size_diff = 0 - base_size
             if size_diff == 0:
                 continue  # Skip diff_items with size_diff of 0
             diff_type = DiffType.REMOVED

--- a/src/sentry/preprod/size_analysis/compare.py
+++ b/src/sentry/preprod/size_analysis/compare.py
@@ -21,12 +21,18 @@ def compare_size_analysis(
 ) -> ComparisonResults:
     diff_items = []
 
-    def flatten_treemap(element, parent_path=""):
+    def flatten_leaf_nodes(element, parent_path=""):
         items = {}
+        if element is None:
+            return items
         path = element.path or (parent_path + "/" + element.name if parent_path else element.name)
-        items[path] = element.size
-        for child in getattr(element, "children", []):
-            items.update(flatten_treemap(child, path))
+        children = getattr(element, "children", [])
+        if not children:
+            # Only add leaf nodes
+            items[path] = element.size
+        else:
+            for child in children:
+                items.update(flatten_leaf_nodes(child, path))
         return items
 
     head_treemap = (
@@ -36,8 +42,8 @@ def compare_size_analysis(
         base_size_analysis_results.treemap.root if base_size_analysis_results.treemap else None
     )
 
-    head_files = flatten_treemap(head_treemap) if head_treemap else {}
-    base_files = flatten_treemap(base_treemap) if base_treemap else {}
+    head_files = flatten_leaf_nodes(head_treemap) if head_treemap else {}
+    base_files = flatten_leaf_nodes(base_treemap) if base_treemap else {}
 
     all_paths = set(head_files.keys()) | set(base_files.keys())
 

--- a/src/sentry/preprod/size_analysis/models.py
+++ b/src/sentry/preprod/size_analysis/models.py
@@ -1,9 +1,8 @@
 from dataclasses import Field
 from enum import Enum
 
-from pydantic import ConfigDict
+from pydantic import BaseModel, ConfigDict
 
-from sentry.db.models.base import BaseModel
 from sentry.preprod.models import PreprodArtifactSizeMetrics
 
 ###

--- a/src/sentry/preprod/size_analysis/models.py
+++ b/src/sentry/preprod/size_analysis/models.py
@@ -1,4 +1,3 @@
-from dataclasses import Field
 from enum import Enum
 
 from pydantic import BaseModel, ConfigDict
@@ -13,30 +12,28 @@ from sentry.preprod.models import PreprodArtifactSizeMetrics
 class TreemapElement(BaseModel):
     model_config = ConfigDict(frozen=True)
 
-    name: str = Field(..., description="Display name of the element")
-    size: int = Field(..., ge=0, description="Install size in bytes")
-    path: str | None = Field(None, description="Relative file or directory path")
-    is_dir: bool = Field(False, description="Whether this element represents a directory")
+    name: str
+    size: int
+    path: str | None
+    is_dir: bool
     """ Some files (like zip files) are not directories but have children. """
-    children: list["TreemapElement"] = Field(default_factory=list, description="Child elements")
+    children: list["TreemapElement"]
 
 
 class TreemapResults(BaseModel):
     """Complete treemap analysis results."""
 
-    root: TreemapElement = Field(..., description="Root element of the treemap")
-    file_count: int = Field(..., ge=0, description="Total number of files analyzed")
-    category_breakdown: dict[str, dict[str, int]] = Field(
-        default_factory=dict, description="Size breakdown by category"
-    )
-    platform: str = Field(default="unknown", description="Platform (ios, android, etc.)")
+    root: TreemapElement
+    file_count: int
+    category_breakdown: dict[str, dict[str, int]]
+    platform: str
 
 
 # Keep in sync with https://github.com/getsentry/launchpad/blob/main/src/launchpad/size/models/common.py#L92
 class SizeAnalysisResults(BaseModel):
-    download_size: int = Field(..., description="Estimated download size in bytes")
-    install_size: int = Field(..., description="Estimated install size in bytes")
-    treemap: TreemapResults | None = Field(..., description="Hierarchical size analysis treemap")
+    download_size: int
+    install_size: int
+    treemap: TreemapResults | None
 
 
 ###
@@ -53,27 +50,22 @@ class DiffType(str, Enum):
 
 
 class DiffItem(BaseModel):
-    size_diff: int = Field(..., description="Size diff")
-    head_size: int | None = Field(None, description="Head node size if node is present in head")
-    base_size: int | None = Field(None, description="Base node size if node is present in base")
-    path: str = Field(..., description="Item path")
-    type: DiffType = Field(..., description="Type of change")
+    size_diff: int
+    head_size: int | None
+    base_size: int | None
+    path: str
+    type: DiffType
 
 
 class SizeMetricDiffItem(BaseModel):
-    metrics_artifact_type: PreprodArtifactSizeMetrics.MetricsArtifactType = Field(
-        ..., description=r"Artifact type \(main, watch, android dynamic feat\)"
-    )
-    identifier: str | None = Field(
-        ...,
-        description=r"Optional identifier used to discriminate between duplicate MetricsArtifactType \(e.g. Android dynamic feat\)",
-    )
-    head_install_size: int = Field(..., description="Overall install size of head artifact")
-    head_download_size: int = Field(..., description="Overall download size of head artifact")
-    base_install_size: int = Field(..., description="Overall install size of base artifact")
-    base_download_size: int = Field(..., description="Overall download size of base artifact")
+    metrics_artifact_type: PreprodArtifactSizeMetrics.MetricsArtifactType
+    identifier: str | None
+    head_install_size: int
+    head_download_size: int
+    base_install_size: int
+    base_download_size: int
 
 
 class ComparisonResults(BaseModel):
-    diff_items: list[DiffItem] = Field(..., description="List of diff items")
-    size_metric_diff_item: SizeMetricDiffItem = Field(..., description="Size metrics diff item")
+    diff_items: list[DiffItem]
+    size_metric_diff_item: SizeMetricDiffItem

--- a/src/sentry/preprod/size_analysis/models.py
+++ b/src/sentry/preprod/size_analysis/models.py
@@ -1,0 +1,80 @@
+from dataclasses import Field
+from enum import Enum
+
+from pydantic import ConfigDict
+
+from sentry.db.models.base import BaseModel
+from sentry.preprod.models import PreprodArtifactSizeMetrics
+
+###
+# Size analysis results (non-comparison)
+###
+
+
+class TreemapElement(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    name: str = Field(..., description="Display name of the element")
+    size: int = Field(..., ge=0, description="Install size in bytes")
+    path: str | None = Field(None, description="Relative file or directory path")
+    is_dir: bool = Field(False, description="Whether this element represents a directory")
+    """ Some files (like zip files) are not directories but have children. """
+    children: list["TreemapElement"] = Field(default_factory=list, description="Child elements")
+
+
+class TreemapResults(BaseModel):
+    """Complete treemap analysis results."""
+
+    root: TreemapElement = Field(..., description="Root element of the treemap")
+    file_count: int = Field(..., ge=0, description="Total number of files analyzed")
+    category_breakdown: dict[str, dict[str, int]] = Field(
+        default_factory=dict, description="Size breakdown by category"
+    )
+    platform: str = Field(default="unknown", description="Platform (ios, android, etc.)")
+
+
+# Keep in sync with https://github.com/getsentry/launchpad/blob/main/src/launchpad/size/models/common.py#L92
+class SizeAnalysisResults(BaseModel):
+    download_size: int = Field(..., description="Estimated download size in bytes")
+    install_size: int = Field(..., description="Estimated install size in bytes")
+    treemap: TreemapResults | None = Field(..., description="Hierarchical size analysis treemap")
+
+
+###
+# Comparison results
+###
+
+
+class DiffType(str, Enum):
+    ADDED = "added"
+    REMOVED = "removed"
+    INCREASED = "increased"
+    DECREASED = "decreased"
+    UNCHANGED = "unchanged"
+
+
+class DiffItem(BaseModel):
+    size_diff: int = Field(..., description="Size diff")
+    head_size: int | None = Field(None, description="Head node size if node is present in head")
+    base_size: int | None = Field(None, description="Base node size if node is present in base")
+    path: str = Field(..., description="Item path")
+    type: DiffType = Field(..., description="Type of change")
+
+
+class SizeMetricDiffItem(BaseModel):
+    metrics_artifact_type: PreprodArtifactSizeMetrics.MetricsArtifactType = Field(
+        ..., description=r"Artifact type \(main, watch, android dynamic feat\)"
+    )
+    identifier: str | None = Field(
+        ...,
+        description=r"Optional identifier used to discriminate between duplicate MetricsArtifactType \(e.g. Android dynamic feat\)",
+    )
+    head_install_size: int = Field(..., description="Overall install size of head artifact")
+    head_download_size: int = Field(..., description="Overall download size of head artifact")
+    base_install_size: int = Field(..., description="Overall install size of base artifact")
+    base_download_size: int = Field(..., description="Overall download size of base artifact")
+
+
+class ComparisonResults(BaseModel):
+    diff_items: list[DiffItem] = Field(..., description="List of diff items")
+    size_metric_diff_item: SizeMetricDiffItem = Field(..., description="Size metrics diff item")

--- a/src/sentry/preprod/size_analysis/tasks.py
+++ b/src/sentry/preprod/size_analysis/tasks.py
@@ -52,7 +52,7 @@ def compare_preprod_artifact_size_analysis(
 
     # Run all comparisons with artifact as head
     base_commit_comparisons = CommitComparison.objects.filter(
-        sha=artifact.commit_comparison.base_sha,
+        head_sha=artifact.commit_comparison.base_sha,
     )
     for base_commit_comparison in base_commit_comparisons:
         try:
@@ -64,7 +64,7 @@ def compare_preprod_artifact_size_analysis(
         except PreprodArtifact.DoesNotExist:
             logger.exception(
                 "preprod.size_analysis.compare.base_artifact_not_found",
-                extra={"base_artifact_id": base_artifact.id},
+                extra={"commit_comparison_id": base_commit_comparison.id},
             )
             continue
 
@@ -103,7 +103,7 @@ def compare_preprod_artifact_size_analysis(
         except PreprodArtifact.DoesNotExist:
             logger.exception(
                 "preprod.size_analysis.compare.head_artifact_not_found",
-                extra={"head_artifact_id": head_artifact.id},
+                extra={"commit_comparison_id": head_commit_comparison.id},
             )
             continue
 
@@ -221,7 +221,9 @@ def _run_size_analysis_comparison(
         )
         return
 
-    head_size_analysis_results = SizeAnalysisResults.parse_raw(head_analysis_file.getfile())
+    head_size_analysis_results = SizeAnalysisResults.model_validate_json(
+        head_analysis_file.getfile()
+    )
     base_size_analysis_results = SizeAnalysisResults.parse_raw(base_analysis_file.getfile())
 
     logger.info(

--- a/src/sentry/preprod/size_analysis/tasks.py
+++ b/src/sentry/preprod/size_analysis/tasks.py
@@ -224,7 +224,9 @@ def _run_size_analysis_comparison(
     head_size_analysis_results = SizeAnalysisResults.model_validate_json(
         head_analysis_file.getfile()
     )
-    base_size_analysis_results = SizeAnalysisResults.parse_raw(base_analysis_file.getfile())
+    base_size_analysis_results = SizeAnalysisResults.model_validate_json(
+        base_analysis_file.getfile()
+    )
 
     logger.info(
         "preprod.size_analysis.compare.start",

--- a/src/sentry/preprod/size_analysis/tasks.py
+++ b/src/sentry/preprod/size_analysis/tasks.py
@@ -85,8 +85,8 @@ def compare_preprod_artifact_size_analysis(
             )
             continue
 
-        base_metrics_map = build_size_metrics_map(base_artifact.size_metrics.all())
-        head_metrics_map = build_size_metrics_map(artifact.size_metrics.all())
+        base_metrics_map = build_size_metrics_map(base_size_metrics)
+        head_metrics_map = build_size_metrics_map(head_size_metrics)
 
         for key, base_metric in base_metrics_map.items():
             matching_head_size_metric = head_metrics_map.get(key)
@@ -176,7 +176,7 @@ def manual_size_analysis_comparison(
 ):
     try:
         head_size_metric = PreprodArtifactSizeMetrics.objects.get(id=head_size_metric_id)
-    except PreprodArtifact.DoesNotExist:
+    except PreprodArtifactSizeMetrics.DoesNotExist:
         logger.exception(
             "preprod.size_analysis.compare.head_artifact_not_found",
             extra={"head_size_metric_id": head_size_metric_id},
@@ -185,7 +185,7 @@ def manual_size_analysis_comparison(
 
     try:
         base_size_metric = PreprodArtifactSizeMetrics.objects.get(id=base_size_metric_id)
-    except PreprodArtifact.DoesNotExist:
+    except PreprodArtifactSizeMetrics.DoesNotExist:
         logger.exception(
             "preprod.size_analysis.compare.base_artifact_not_found",
             extra={"base_size_metric_id": base_size_metric_id},

--- a/src/sentry/preprod/size_analysis/tasks.py
+++ b/src/sentry/preprod/size_analysis/tasks.py
@@ -1,0 +1,220 @@
+import logging
+from io import BytesIO
+
+from sentry.models.commitcomparison import CommitComparison
+from sentry.models.files.file import File
+from sentry.preprod.models import (
+    PreprodArtifact,
+    PreprodArtifactSizeComparison,
+    PreprodArtifactSizeMetrics,
+)
+from sentry.preprod.size_analysis.compare import compare_size_analysis
+from sentry.preprod.size_analysis.models import SizeAnalysisResults
+from sentry.silo.base import SiloMode
+from sentry.tasks.base import instrumented_task
+from sentry.taskworker.config import TaskworkerConfig
+from sentry.taskworker.namespaces import attachments_tasks
+from sentry.utils import json
+
+logger = logging.getLogger(__name__)
+
+
+@instrumented_task(
+    name="sentry.preprod.tasks.compare_preprod_artifact_size_analysis",
+    queue="compare",
+    silo_mode=SiloMode.REGION,
+    taskworker_config=TaskworkerConfig(
+        namespace=attachments_tasks,
+        processing_deadline_duration=30,
+    ),
+)
+def compare_preprod_artifact_size_analysis(
+    artifact_id: int,
+):
+    try:
+        artifact = PreprodArtifact.objects.get(
+            id=artifact_id,
+        )
+    except PreprodArtifact.DoesNotExist:
+        logger.exception(
+            "preprod.size_analysis.compare.artifact_not_found",
+            extra={
+                "artifact_id": artifact_id,
+            },
+        )
+        return
+
+    if not artifact.commit_comparison:
+        logger.info(
+            "preprod.size_analysis.compare.artifact_no_commit_comparison",
+            extra={"artifact_id": artifact_id},
+        )
+        return
+
+    # Run all comparisons with artifact as head
+    base_commit_comparisons = CommitComparison.objects.filter(
+        sha=artifact.commit_comparison.base_sha,
+    )
+    for base_commit_comparison in base_commit_comparisons:
+        base_artifact = PreprodArtifact.objects.get(
+            project=artifact.project,
+            app_id=artifact.app_id,
+            commit_comparison=base_commit_comparison,
+        )
+        for size_metric in base_artifact.size_metrics.all():
+            matching_head_size_metric = artifact.size_metrics.filter(
+                metrics_artifact_type=size_metric.metrics_artifact_type,
+                identifier=size_metric.identifier,
+            ).first()
+            if matching_head_size_metric:
+                logger.info(
+                    "preprod.size_analysis.compare.running_comparison",
+                    extra={
+                        "head_artifact_id": artifact_id,
+                        "base_artifact_id": base_artifact.id,
+                        "size_metric_id": size_metric.id if size_metric.identifier else None,
+                    },
+                )
+                _run_size_analysis_comparison(matching_head_size_metric, size_metric)
+            else:
+                logger.info(
+                    "preprod.size_analysis.compare.no_matching_base_size_metric",
+                    extra={"head_artifact_id": artifact_id, "size_metric_id": size_metric.id},
+                )
+
+    # Also run comparisons with artifact as base
+    head_commit_comparisons = CommitComparison.objects.get(
+        base_sha=artifact.commit_comparison.head_sha,
+    )
+    for head_commit_comparison in head_commit_comparisons:
+        head_artifact = PreprodArtifact.objects.get(
+            project=artifact.project,
+            app_id=artifact.app_id,
+            commit_comparison=head_commit_comparison,
+        )
+        for size_metric in head_artifact.size_metrics.all():
+            matching_base_size_metric = artifact.size_metrics.filter(
+                metrics_artifact_type=size_metric.metrics_artifact_type,
+                identifier=size_metric.identifier,
+            ).first()
+            if matching_base_size_metric:
+                logger.info(
+                    "preprod.size_analysis.compare.running_comparison",
+                    extra={"base_artifact_id": artifact_id, "head_artifact_id": head_artifact.id},
+                )
+                _run_size_analysis_comparison(size_metric, matching_base_size_metric)
+            else:
+                logger.info(
+                    "preprod.size_analysis.compare.no_matching_base_size_metric",
+                    extra={"head_artifact_id": head_artifact.id, "size_metric_id": size_metric.id},
+                )
+
+
+@instrumented_task(
+    name="sentry.preprod.tasks.manual_size_analysis_comparison",
+    queue="compare",
+    silo_mode=SiloMode.REGION,
+    taskworker_config=TaskworkerConfig(
+        namespace=attachments_tasks,
+        processing_deadline_duration=30,
+    ),
+)
+def manual_size_analysis_comparison(
+    head_artifact_id: int,
+    base_artifact_id: int,
+):
+    try:
+        head_artifact = PreprodArtifact.objects.get(id=head_artifact_id)
+    except PreprodArtifact.DoesNotExist:
+        logger.exception(
+            "preprod.size_analysis.compare.head_artifact_not_found",
+            extra={"head_artifact_id": head_artifact_id},
+        )
+        return
+    try:
+        base_artifact = PreprodArtifact.objects.get(id=base_artifact_id)
+    except PreprodArtifact.DoesNotExist:
+        logger.exception(
+            "preprod.size_analysis.compare.base_artifact_not_found",
+            extra={"base_artifact_id": base_artifact_id},
+        )
+        return
+
+    for size_metric in head_artifact.size_metrics.all():
+        matching_base_size_metric = base_artifact.size_metrics.filter(
+            metrics_artifact_type=size_metric.metrics_artifact_type,
+            identifier=size_metric.identifier,
+        ).first()
+        if matching_base_size_metric:
+            _run_size_analysis_comparison(size_metric, matching_base_size_metric)
+        else:
+            logger.info(
+                "preprod.size_analysis.compare.no_matching_base_size_metric",
+                extra={"head_artifact_id": head_artifact_id, "size_metric_id": size_metric.id},
+            )
+
+
+def _run_size_analysis_comparison(
+    head_size_analysis: PreprodArtifactSizeMetrics,
+    base_size_analysis: PreprodArtifactSizeMetrics,
+):
+    comparison = PreprodArtifactSizeComparison.objects.get(
+        head_size_analysis=head_size_analysis,
+        base_size_analysis=base_size_analysis,
+    )
+
+    if comparison:
+        logger.info(
+            "preprod.size_analysis.compare.existing_comparison",
+            extra={
+                "head_artifact_size_analysis_id": head_size_analysis.id,
+                "base_artifact_size_analysis_id": base_size_analysis.id,
+            },
+        )
+        return
+
+    head_size_analysis_results = SizeAnalysisResults.parse_raw(head_size_analysis.analysis_file_id)
+    base_size_analysis_results = SizeAnalysisResults.parse_raw(base_size_analysis.analysis_file_id)
+
+    logger.info(
+        "preprod.size_analysis.compare.start",
+        extra={
+            "head_artifact_size_analysis_id": head_size_analysis.id,
+            "base_artifact_size_analysis_id": base_size_analysis.id,
+        },
+    )
+
+    comparison = PreprodArtifactSizeComparison.objects.create(
+        head_size_analysis=head_size_analysis,
+        base_size_analysis=base_size_analysis,
+        organization_id=head_size_analysis.preprod_artifact.project.organization.id,
+    )
+
+    comparison_results = compare_size_analysis(
+        head_size_analysis,
+        head_size_analysis_results,
+        base_size_analysis,
+        base_size_analysis_results,
+    )
+
+    logger.info(
+        "preprod.size_analysis.compare.create_file",
+        extra={"comparison_id": comparison.id},
+    )
+    file = File.objects.create(
+        name=comparison.id,
+        type="size_analysis_comparison.json",
+        headers={"Content-Type": "application/json"},
+    )
+    file.putfile(file.putfile(BytesIO(json.dumps(comparison_results.to_json()).encode())))
+
+    comparison.file_id = file.id
+    comparison.state = PreprodArtifactSizeComparison.State.SUCCESS
+    comparison.save()
+
+    logger.info(
+        "preprod.size_analysis.compare.success",
+        extra={"comparison_id": comparison.id},
+    )
+
+    # TODO: Status check/webhook/alerts

--- a/src/sentry/preprod/size_analysis/tasks.py
+++ b/src/sentry/preprod/size_analysis/tasks.py
@@ -222,10 +222,10 @@ def _run_size_analysis_comparison(
         return
 
     head_size_analysis_results = SizeAnalysisResults.model_validate_json(
-        head_analysis_file.getfile()
+        head_analysis_file.getfile().read()
     )
     base_size_analysis_results = SizeAnalysisResults.model_validate_json(
-        base_analysis_file.getfile()
+        base_analysis_file.getfile().read()
     )
 
     logger.info(

--- a/src/sentry/preprod/size_analysis/tasks.py
+++ b/src/sentry/preprod/size_analysis/tasks.py
@@ -196,13 +196,13 @@ def manual_size_analysis_comparison(
 
 
 def _run_size_analysis_comparison(
-    base_size_metric: PreprodArtifactSizeMetrics,
     head_size_metric: PreprodArtifactSizeMetrics,
+    base_size_metric: PreprodArtifactSizeMetrics,
 ):
     try:
         comparison = PreprodArtifactSizeComparison.objects.get(
-            head_size_analysis=base_size_metric,
-            base_size_analysis=head_size_metric,
+            head_size_analysis=head_size_metric,
+            base_size_analysis=base_size_metric,
         )
 
         # Existing comparison exists or is already running,
@@ -273,10 +273,10 @@ def _run_size_analysis_comparison(
     )
 
     comparison_results = compare_size_analysis(
-        head_size_metric,
-        head_size_analysis_results,
-        base_size_metric,
-        base_size_analysis_results,
+        head_size_analysis=head_size_metric,
+        head_size_analysis_results=head_size_analysis_results,
+        base_size_analysis=base_size_metric,
+        base_size_analysis_results=base_size_analysis_results,
     )
 
     logger.info(

--- a/src/sentry/preprod/size_analysis/tasks.py
+++ b/src/sentry/preprod/size_analysis/tasks.py
@@ -245,6 +245,7 @@ def _run_size_analysis_comparison(
         head_size_analysis=head_size_analysis,
         base_size_analysis=base_size_analysis,
         organization_id=head_size_analysis.preprod_artifact.project.organization.id,
+        state=PreprodArtifactSizeComparison.State.PROCESSING,
     )
 
     comparison_results = compare_size_analysis(

--- a/src/sentry/preprod/size_analysis/tasks.py
+++ b/src/sentry/preprod/size_analysis/tasks.py
@@ -71,12 +71,14 @@ def compare_preprod_artifact_size_analysis(
             )
             continue
 
-        base_size_metrics = PreprodArtifactSizeMetrics.objects.filter(
+        base_size_metrics_qs = PreprodArtifactSizeMetrics.objects.filter(
             preprod_artifact_id__in=[base_artifact.id],
         ).select_related("preprod_artifact")
-        head_size_metrics = PreprodArtifactSizeMetrics.objects.filter(
+        base_size_metrics = list(base_size_metrics_qs)
+        head_size_metrics_qs = PreprodArtifactSizeMetrics.objects.filter(
             preprod_artifact_id__in=[artifact_id],
         ).select_related("preprod_artifact")
+        head_size_metrics = list(head_size_metrics_qs)
 
         if not can_compare_size_metrics(head_size_metrics, base_size_metrics):
             logger.info(
@@ -128,12 +130,14 @@ def compare_preprod_artifact_size_analysis(
             )
             continue
 
-        head_size_metrics = PreprodArtifactSizeMetrics.objects.filter(
+        head_size_metrics_qs = PreprodArtifactSizeMetrics.objects.filter(
             preprod_artifact_id__in=[head_artifact.id],
         ).select_related("preprod_artifact")
-        base_size_metrics = PreprodArtifactSizeMetrics.objects.filter(
+        head_size_metrics = list(head_size_metrics_qs)
+        base_size_metrics_qs = PreprodArtifactSizeMetrics.objects.filter(
             preprod_artifact_id__in=[artifact_id],
         ).select_related("preprod_artifact")
+        base_size_metrics = list(base_size_metrics_qs)
 
         if not can_compare_size_metrics(head_size_metrics, base_size_metrics):
             logger.info(
@@ -284,7 +288,7 @@ def _run_size_analysis_comparison(
         extra={"comparison_id": comparison.id},
     )
     file = File.objects.create(
-        name=comparison.id,
+        name=str(comparison.id),
         type="size_analysis_comparison.json",
         headers={"Content-Type": "application/json"},
     )

--- a/src/sentry/preprod/size_analysis/utils.py
+++ b/src/sentry/preprod/size_analysis/utils.py
@@ -1,0 +1,6 @@
+from sentry.preprod.models import PreprodArtifactSizeMetrics
+
+
+# Build a mapping of (metrics_artifact_type, identifier) -> size metric for quick lookup of matching metrics from head or base size metrics
+def build_size_metrics_map(metrics: list[PreprodArtifactSizeMetrics]):
+    return {(metric.metrics_artifact_type, metric.identifier): metric for metric in metrics}

--- a/src/sentry/preprod/size_analysis/utils.py
+++ b/src/sentry/preprod/size_analysis/utils.py
@@ -1,6 +1,40 @@
+import logging
+
 from sentry.preprod.models import PreprodArtifactSizeMetrics
+
+logger = logging.getLogger(__name__)
 
 
 # Build a mapping of (metrics_artifact_type, identifier) -> size metric for quick lookup of matching metrics from head or base size metrics
 def build_size_metrics_map(metrics: list[PreprodArtifactSizeMetrics]):
     return {(metric.metrics_artifact_type, metric.identifier): metric for metric in metrics}
+
+
+def can_compare_size_metrics(
+    head_metrics: list[PreprodArtifactSizeMetrics], base_metric: list[PreprodArtifactSizeMetrics]
+):
+    # Check that both lists have the same length
+    if len(head_metrics) != len(base_metric):
+        # TODO: Add ability to compare size metrics with different lengths
+        logger.info(
+            "preprod.size_analysis.compare.cannot_compare_size_metrics.different_length",
+            extra={
+                "head_metrics_length": len(head_metrics),
+                "base_metric_length": len(base_metric),
+            },
+        )
+        return False
+
+    # Build sets of (metrics_artifact_type, identifier) for both lists
+    head_set = {(m.metrics_artifact_type, m.identifier) for m in head_metrics}
+    base_set = {(m.metrics_artifact_type, m.identifier) for m in base_metric}
+
+    # Return True if the sets are equal (all metrics match on both dimensions)
+    if head_set == base_set:
+        return True
+
+    logger.info(
+        "preprod.size_analysis.compare.cannot_compare_size_metrics.sets_not_equal",
+        extra={"head_set": head_set, "base_set": base_set},
+    )
+    return False

--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -388,18 +388,19 @@ def _assemble_preprod_artifact_size_analysis(
             )
 
         # Trigger size analysis comparison if eligible
+        logger.info(
+            "Created or updated preprod artifact size metrics with analysis file",
+            extra={
+                "preprod_artifact_id": preprod_artifact.id,
+                "size_metrics_id": size_metrics.id,
+                "analysis_file_id": assemble_result.bundle.id,
+                "was_created": created,
+                "project_id": project.id,
+                "organization_id": org_id,
+            },
+        )
 
-    logger.info(
-        "Created or updated preprod artifact size metrics with analysis file",
-        extra={
-            "preprod_artifact_id": preprod_artifact.id,
-            "size_metrics_id": size_metrics.id,
-            "analysis_file_id": assemble_result.bundle.id,
-            "was_created": created,
-            "project_id": project.id,
-            "organization_id": org_id,
-        },
-    )except Exception as e:
+    except Exception as e:
         logger.exception(
             "Failed to process size analysis results",
             extra={

--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -12,13 +12,13 @@ from django.db import router, transaction
 from sentry.models.commitcomparison import CommitComparison
 from sentry.models.organization import Organization
 from sentry.models.project import Project
-from sentry.preprod.api.models.project_preprod_size_analysis_models import SizeAnalysisResults
 from sentry.preprod.models import (
     PreprodArtifact,
     PreprodArtifactSizeMetrics,
     PreprodBuildConfiguration,
 )
 from sentry.preprod.producer import produce_preprod_artifact_to_kafka
+from sentry.preprod.size_analysis.models import SizeAnalysisResults
 from sentry.preprod.vcs.status_checks.size.tasks import create_preprod_status_check_task
 from sentry.silo.base import SiloMode
 from sentry.tasks.assemble import (
@@ -387,19 +387,19 @@ def _assemble_preprod_artifact_size_analysis(
                 },
             )
 
-        logger.info(
-            "Created or updated preprod artifact size metrics with analysis file",
-            extra={
-                "preprod_artifact_id": preprod_artifact.id,
-                "size_metrics_id": size_metrics.id,
-                "analysis_file_id": assemble_result.bundle.id,
-                "was_created": created,
-                "project_id": project.id,
-                "organization_id": org_id,
-            },
-        )
+        # Trigger size analysis comparison if eligible
 
-    except Exception as e:
+    logger.info(
+        "Created or updated preprod artifact size metrics with analysis file",
+        extra={
+            "preprod_artifact_id": preprod_artifact.id,
+            "size_metrics_id": size_metrics.id,
+            "analysis_file_id": assemble_result.bundle.id,
+            "was_created": created,
+            "project_id": project.id,
+            "organization_id": org_id,
+        },
+    )except Exception as e:
         logger.exception(
             "Failed to process size analysis results",
             extra={

--- a/tests/sentry/preprod/size_analysis/test_compare.py
+++ b/tests/sentry/preprod/size_analysis/test_compare.py
@@ -9,10 +9,8 @@ from sentry.preprod.size_analysis.models import (
     TreemapResults,
 )
 from sentry.testutils.cases import TestCase
-from sentry.testutils.silo import region_silo_test
 
 
-@region_silo_test
 class CompareSizeAnalysisTest(TestCase):
     def setUp(self):
         super().setUp()

--- a/tests/sentry/preprod/size_analysis/test_compare.py
+++ b/tests/sentry/preprod/size_analysis/test_compare.py
@@ -1,0 +1,438 @@
+from sentry.preprod.models import PreprodArtifactSizeMetrics
+from sentry.preprod.size_analysis.compare import compare_size_analysis
+from sentry.preprod.size_analysis.models import (
+    ComparisonResults,
+    DiffType,
+    SizeAnalysisResults,
+    SizeMetricDiffItem,
+    TreemapElement,
+    TreemapResults,
+)
+from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import region_silo_test
+
+
+@region_silo_test
+class CompareSizeAnalysisTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.organization = self.create_organization(owner=self.user)
+        self.project = self.create_project(organization=self.organization)
+
+    def _create_treemap_element(self, name, size, path=None, children=None):
+        """Helper to create TreemapElement."""
+        return TreemapElement(
+            name=name,
+            size=size,
+            path=path,
+            is_dir=children is not None,
+            children=children or [],
+        )
+
+    def _create_size_analysis_results(
+        self, download_size=500, install_size=1000, treemap_root=None
+    ):
+        """Helper to create SizeAnalysisResults."""
+        treemap = None
+        if treemap_root:
+            treemap = TreemapResults(
+                root=treemap_root,
+                file_count=1,  # Required field
+                category_breakdown={},
+                platform="test",
+            )
+
+        return SizeAnalysisResults(
+            download_size=download_size,
+            install_size=install_size,
+            treemap=treemap,
+        )
+
+    def test_compare_size_analysis_no_treemaps(self):
+        """Test compare_size_analysis with no treemap data."""
+        head_metrics = PreprodArtifactSizeMetrics(
+            preprod_artifact_id=1,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            identifier="test",
+            max_install_size=2000,
+            max_download_size=1000,
+        )
+        base_metrics = PreprodArtifactSizeMetrics(
+            preprod_artifact_id=1,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            identifier="test",
+            max_install_size=1500,
+            max_download_size=800,
+        )
+
+        head_results = self._create_size_analysis_results(download_size=1000, install_size=2000)
+        base_results = self._create_size_analysis_results(download_size=800, install_size=1500)
+
+        result = compare_size_analysis(head_metrics, head_results, base_metrics, base_results)
+
+        assert isinstance(result, ComparisonResults)
+        assert result.diff_items == []
+        assert isinstance(result.size_metric_diff_item, SizeMetricDiffItem)
+        assert result.size_metric_diff_item.head_install_size == 2000
+        assert result.size_metric_diff_item.head_download_size == 1000
+        assert result.size_metric_diff_item.base_install_size == 1500
+        assert result.size_metric_diff_item.base_download_size == 800
+
+    def test_compare_size_analysis_file_added(self):
+        """Test compare_size_analysis with a file added."""
+        head_metrics = PreprodArtifactSizeMetrics(
+            preprod_artifact_id=1,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            identifier="test",
+            max_install_size=1500,
+            max_download_size=800,
+        )
+        base_metrics = PreprodArtifactSizeMetrics(
+            preprod_artifact_id=1,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            identifier="test",
+            max_install_size=1500,
+            max_download_size=800,
+        )
+
+        # Head has one file, base has none
+        head_treemap = self._create_treemap_element("file.txt", 100)
+        head_results = self._create_size_analysis_results(treemap_root=head_treemap)
+        base_results = self._create_size_analysis_results()
+
+        result = compare_size_analysis(head_metrics, head_results, base_metrics, base_results)
+
+        assert len(result.diff_items) == 1
+        diff_item = result.diff_items[0]
+        assert diff_item.path == "file.txt"
+        assert diff_item.size_diff == 100
+        assert diff_item.head_size == 100
+        assert diff_item.base_size is None
+        assert diff_item.type == DiffType.ADDED
+
+    def test_compare_size_analysis_file_removed(self):
+        """Test compare_size_analysis with a file removed."""
+        head_metrics = PreprodArtifactSizeMetrics(
+            preprod_artifact_id=1,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            identifier="test",
+            max_install_size=1500,
+            max_download_size=800,
+        )
+        base_metrics = PreprodArtifactSizeMetrics(
+            preprod_artifact_id=1,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            identifier="test",
+            max_install_size=1500,
+            max_download_size=800,
+        )
+
+        # Base has one file, head has none
+        base_treemap = self._create_treemap_element("file.txt", 100)
+        head_results = self._create_size_analysis_results()
+        base_results = self._create_size_analysis_results(treemap_root=base_treemap)
+
+        result = compare_size_analysis(head_metrics, head_results, base_metrics, base_results)
+
+        assert len(result.diff_items) == 1
+        diff_item = result.diff_items[0]
+        assert diff_item.path == "file.txt"
+        assert diff_item.size_diff == -100
+        assert diff_item.head_size is None
+        assert diff_item.base_size == 100
+        assert diff_item.type == DiffType.REMOVED
+
+    def test_compare_size_analysis_file_increased(self):
+        """Test compare_size_analysis with a file size increased."""
+        head_metrics = PreprodArtifactSizeMetrics(
+            preprod_artifact_id=1,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            identifier="test",
+            max_install_size=1500,
+            max_download_size=800,
+        )
+        base_metrics = PreprodArtifactSizeMetrics(
+            preprod_artifact_id=1,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            identifier="test",
+            max_install_size=1500,
+            max_download_size=800,
+        )
+
+        # Same file, different sizes
+        head_treemap = self._create_treemap_element("file.txt", 150)
+        base_treemap = self._create_treemap_element("file.txt", 100)
+        head_results = self._create_size_analysis_results(treemap_root=head_treemap)
+        base_results = self._create_size_analysis_results(treemap_root=base_treemap)
+
+        result = compare_size_analysis(head_metrics, head_results, base_metrics, base_results)
+
+        assert len(result.diff_items) == 1
+        diff_item = result.diff_items[0]
+        assert diff_item.path == "file.txt"
+        assert diff_item.size_diff == 50
+        assert diff_item.head_size == 150
+        assert diff_item.base_size == 100
+        assert diff_item.type == DiffType.INCREASED
+
+    def test_compare_size_analysis_file_decreased(self):
+        """Test compare_size_analysis with a file size decreased."""
+        head_metrics = PreprodArtifactSizeMetrics(
+            preprod_artifact_id=1,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            identifier="test",
+            max_install_size=1500,
+            max_download_size=800,
+        )
+        base_metrics = PreprodArtifactSizeMetrics(
+            preprod_artifact_id=1,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            identifier="test",
+            max_install_size=1500,
+            max_download_size=800,
+        )
+
+        # Same file, different sizes
+        head_treemap = self._create_treemap_element("file.txt", 50)
+        base_treemap = self._create_treemap_element("file.txt", 100)
+        head_results = self._create_size_analysis_results(treemap_root=head_treemap)
+        base_results = self._create_size_analysis_results(treemap_root=base_treemap)
+
+        result = compare_size_analysis(head_metrics, head_results, base_metrics, base_results)
+
+        assert len(result.diff_items) == 1
+        diff_item = result.diff_items[0]
+        assert diff_item.path == "file.txt"
+        assert diff_item.size_diff == -50
+        assert diff_item.head_size == 50
+        assert diff_item.base_size == 100
+        assert diff_item.type == DiffType.DECREASED
+
+    def test_compare_size_analysis_file_unchanged(self):
+        """Test compare_size_analysis with a file size unchanged (should be skipped)."""
+        head_metrics = PreprodArtifactSizeMetrics(
+            preprod_artifact_id=1,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            identifier="test",
+            max_install_size=1500,
+            max_download_size=800,
+        )
+        base_metrics = PreprodArtifactSizeMetrics(
+            preprod_artifact_id=1,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            identifier="test",
+            max_install_size=1500,
+            max_download_size=800,
+        )
+
+        # Same file, same size
+        head_treemap = self._create_treemap_element("file.txt", 100)
+        base_treemap = self._create_treemap_element("file.txt", 100)
+        head_results = self._create_size_analysis_results(treemap_root=head_treemap)
+        base_results = self._create_size_analysis_results(treemap_root=base_treemap)
+
+        result = compare_size_analysis(head_metrics, head_results, base_metrics, base_results)
+
+        # Should skip files with no size difference
+        assert len(result.diff_items) == 0
+
+    def test_compare_size_analysis_multiple_files(self):
+        """Test compare_size_analysis with multiple files."""
+        head_metrics = PreprodArtifactSizeMetrics(
+            preprod_artifact_id=1,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            identifier="test",
+            max_install_size=1500,
+            max_download_size=800,
+        )
+        base_metrics = PreprodArtifactSizeMetrics(
+            preprod_artifact_id=1,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            identifier="test",
+            max_install_size=1500,
+            max_download_size=800,
+        )
+
+        # Head has file1 (increased), file2 (new), file3 (removed from base)
+        # Base has file1 (original), file3 (removed from head)
+        head_treemap = self._create_treemap_element(
+            "dir",
+            0,
+            children=[
+                self._create_treemap_element("file1.txt", 150),  # increased from 100
+                self._create_treemap_element("file2.txt", 200),  # new file
+            ],
+        )
+        base_treemap = self._create_treemap_element(
+            "dir",
+            0,
+            children=[
+                self._create_treemap_element("file1.txt", 100),  # original size
+                self._create_treemap_element("file3.txt", 300),  # removed file
+            ],
+        )
+        head_results = self._create_size_analysis_results(treemap_root=head_treemap)
+        base_results = self._create_size_analysis_results(treemap_root=base_treemap)
+
+        result = compare_size_analysis(head_metrics, head_results, base_metrics, base_results)
+
+        assert len(result.diff_items) == 3
+
+        # Sort by path for consistent testing
+        diff_items = sorted(result.diff_items, key=lambda x: x.path)
+
+        # file1.txt - increased
+        assert diff_items[0].path == "dir/file1.txt"
+        assert diff_items[0].size_diff == 50
+        assert diff_items[0].type == DiffType.INCREASED
+
+        # file2.txt - added
+        assert diff_items[1].path == "dir/file2.txt"
+        assert diff_items[1].size_diff == 200
+        assert diff_items[1].type == DiffType.ADDED
+
+        # file3.txt - removed
+        assert diff_items[2].path == "dir/file3.txt"
+        assert diff_items[2].size_diff == -300
+        assert diff_items[2].type == DiffType.REMOVED
+
+    def test_compare_size_analysis_zero_size_diffs_skipped(self):
+        """Test that zero size diffs are skipped for all diff types."""
+        head_metrics = PreprodArtifactSizeMetrics(
+            preprod_artifact_id=1,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            identifier="test",
+            max_install_size=1500,
+            max_download_size=800,
+        )
+        base_metrics = PreprodArtifactSizeMetrics(
+            preprod_artifact_id=1,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            identifier="test",
+            max_install_size=1500,
+            max_download_size=800,
+        )
+
+        # Test added file with zero size
+        head_treemap = self._create_treemap_element("file1.txt", 0)
+        head_results = self._create_size_analysis_results(treemap_root=head_treemap)
+        base_results = self._create_size_analysis_results()
+
+        result = compare_size_analysis(head_metrics, head_results, base_metrics, base_results)
+        assert len(result.diff_items) == 0
+
+        # Test removed file with zero size
+        base_treemap = self._create_treemap_element("file2.txt", 0)
+        head_results = self._create_size_analysis_results()
+        base_results = self._create_size_analysis_results(treemap_root=base_treemap)
+
+        result = compare_size_analysis(head_metrics, head_results, base_metrics, base_results)
+        assert len(result.diff_items) == 0
+
+    def test_compare_size_analysis_different_artifact_types(self):
+        """Test compare_size_analysis with different artifact types."""
+        head_metrics = PreprodArtifactSizeMetrics(
+            preprod_artifact_id=1,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.WATCH_ARTIFACT,
+            identifier="watch",
+            max_install_size=1500,
+            max_download_size=800,
+        )
+        base_metrics = PreprodArtifactSizeMetrics(
+            preprod_artifact_id=1,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            identifier="main",
+            max_install_size=1500,
+            max_download_size=800,
+        )
+
+        head_results = self._create_size_analysis_results()
+        base_results = self._create_size_analysis_results()
+
+        result = compare_size_analysis(head_metrics, head_results, base_metrics, base_results)
+
+        assert (
+            result.size_metric_diff_item.metrics_artifact_type
+            == PreprodArtifactSizeMetrics.MetricsArtifactType.WATCH_ARTIFACT
+        )
+        assert result.size_metric_diff_item.identifier == "watch"
+
+    def test_compare_size_analysis_complex_nested_structure(self):
+        """Test compare_size_analysis with complex nested directory structure."""
+        head_metrics = PreprodArtifactSizeMetrics(
+            preprod_artifact_id=1,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.WATCH_ARTIFACT,
+            identifier="watch",
+            max_install_size=1500,
+            max_download_size=800,
+        )
+        base_metrics = PreprodArtifactSizeMetrics(
+            preprod_artifact_id=1,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            identifier="main",
+            max_install_size=1500,
+            max_download_size=800,
+        )
+
+        # Complex nested structure
+        head_treemap = self._create_treemap_element(
+            "app",
+            0,
+            children=[
+                self._create_treemap_element(
+                    "src",
+                    0,
+                    children=[
+                        self._create_treemap_element("main.js", 500),
+                        self._create_treemap_element("utils.js", 200),
+                    ],
+                ),
+                self._create_treemap_element(
+                    "assets",
+                    0,
+                    children=[
+                        self._create_treemap_element("logo.png", 100),
+                    ],
+                ),
+            ],
+        )
+        base_treemap = self._create_treemap_element(
+            "app",
+            0,
+            children=[
+                self._create_treemap_element(
+                    "src",
+                    0,
+                    children=[
+                        self._create_treemap_element("main.js", 400),  # increased
+                        # utils.js removed
+                    ],
+                ),
+                # assets directory removed
+            ],
+        )
+
+        head_results = self._create_size_analysis_results(treemap_root=head_treemap)
+        base_results = self._create_size_analysis_results(treemap_root=base_treemap)
+
+        result = compare_size_analysis(head_metrics, head_results, base_metrics, base_results)
+
+        assert len(result.diff_items) == 3
+
+        # Sort by path for consistent testing
+        diff_items = sorted(result.diff_items, key=lambda x: x.path)
+
+        # app/assets/logo.png - added
+        assert diff_items[0].path == "app/assets/logo.png"
+        assert diff_items[0].size_diff == 100
+        assert diff_items[0].type == DiffType.ADDED
+
+        # app/src/main.js - increased
+        assert diff_items[1].path == "app/src/main.js"
+        assert diff_items[1].size_diff == 100
+        assert diff_items[1].type == DiffType.INCREASED
+
+        # app/src/utils.js - added
+        assert diff_items[2].path == "app/src/utils.js"
+        assert diff_items[2].size_diff == 200
+        assert diff_items[2].type == DiffType.ADDED

--- a/tests/sentry/preprod/size_analysis/test_size_analysis_tasks.py
+++ b/tests/sentry/preprod/size_analysis/test_size_analysis_tasks.py
@@ -16,11 +16,9 @@ from sentry.preprod.size_analysis.tasks import (
     manual_size_analysis_comparison,
 )
 from sentry.testutils.cases import TestCase
-from sentry.testutils.silo import region_silo_test
 from sentry.utils import json
 
 
-@region_silo_test
 class ComparePreprodArtifactSizeAnalysisTest(TestCase):
     def setUp(self):
         super().setUp()
@@ -346,7 +344,6 @@ class ComparePreprodArtifactSizeAnalysisTest(TestCase):
             mock_run_comparison.assert_not_called()
 
 
-@region_silo_test
 class ManualSizeAnalysisComparisonTest(TestCase):
     def setUp(self):
         super().setUp()
@@ -413,7 +410,6 @@ class ManualSizeAnalysisComparisonTest(TestCase):
             assert call_args[1]["extra"]["base_size_metric_id"] == 99999
 
 
-@region_silo_test
 class RunSizeAnalysisComparisonTest(TestCase):
     def setUp(self):
         super().setUp()

--- a/tests/sentry/preprod/size_analysis/test_tasks.py
+++ b/tests/sentry/preprod/size_analysis/test_tasks.py
@@ -1,0 +1,714 @@
+from io import BytesIO
+from unittest.mock import patch
+
+import pytest
+
+from sentry.models.commitcomparison import CommitComparison
+from sentry.models.files.file import File
+from sentry.preprod.models import (
+    PreprodArtifact,
+    PreprodArtifactSizeComparison,
+    PreprodArtifactSizeMetrics,
+)
+from sentry.preprod.size_analysis.tasks import (
+    _run_size_analysis_comparison,
+    compare_preprod_artifact_size_analysis,
+    manual_size_analysis_comparison,
+)
+from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import region_silo_test
+from sentry.utils import json
+
+
+@region_silo_test
+class ComparePreprodArtifactSizeAnalysisTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.organization = self.create_organization(owner=self.user)
+        self.project = self.create_project(organization=self.organization)
+
+    def _create_size_metrics_with_analysis_file(self, artifact, analysis_data):
+        """Helper to create PreprodArtifactSizeMetrics with analysis file."""
+        # Create analysis file
+        analysis_file = File.objects.create(
+            name=f"size-analysis-{artifact.id}",
+            type="preprod.file",
+            headers={"Content-Type": "application/json"},
+        )
+        analysis_file.putfile(BytesIO(json.dumps(analysis_data).encode()))
+
+        # Create size metrics
+        return PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=artifact,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            analysis_file_id=analysis_file.id,
+            max_install_size=analysis_data.get("install_size", 1000),
+            max_download_size=analysis_data.get("download_size", 500),
+        )
+
+    def test_compare_preprod_artifact_size_analysis_nonexistent_artifact(self):
+        """Test compare_preprod_artifact_size_analysis with nonexistent artifact."""
+        with patch("sentry.preprod.size_analysis.tasks.logger") as mock_logger:
+            compare_preprod_artifact_size_analysis(artifact_id=99999)
+
+            mock_logger.exception.assert_called_once()
+            call_args = mock_logger.exception.call_args
+            assert "preprod.size_analysis.compare.artifact_not_found" in call_args[0]
+            assert call_args[1]["extra"]["artifact_id"] == 99999
+
+    def test_compare_preprod_artifact_size_analysis_no_commit_comparison(self):
+        """Test compare_preprod_artifact_size_analysis with artifact having no commit comparison."""
+        artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            app_id="com.example.app",
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+        )
+
+        with patch("sentry.preprod.size_analysis.tasks.logger") as mock_logger:
+            compare_preprod_artifact_size_analysis(artifact_id=artifact.id)
+
+            mock_logger.info.assert_called_once()
+            call_args = mock_logger.info.call_args
+            assert "preprod.size_analysis.compare.artifact_no_commit_comparison" in call_args[0]
+            assert call_args[1]["extra"]["artifact_id"] == artifact.id
+
+    def test_compare_preprod_artifact_size_analysis_success_as_head(self):
+        """Test compare_preprod_artifact_size_analysis with artifact as head."""
+        # Create commit comparisons
+        head_commit = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="a" * 40,
+            base_sha="b" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+        )
+        base_commit = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="b" * 40,
+            base_sha="c" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+        )
+
+        # Create artifacts
+        head_artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            commit_comparison=head_commit,
+            app_id="com.example.app",
+            build_version="1.0.0",
+            build_number=1,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+        )
+        base_artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            commit_comparison=base_commit,
+            app_id="com.example.app",
+            build_version="1.0.0",
+            build_number=1,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+        )
+
+        # Create size analysis data
+        head_analysis_data = {
+            "download_size": 1000,
+            "install_size": 2000,
+            "treemap": {
+                "root": {
+                    "name": "app",
+                    "size": 0,
+                    "path": None,
+                    "is_dir": True,
+                    "children": [
+                        {
+                            "name": "main.js",
+                            "size": 1000,
+                            "path": None,
+                            "is_dir": False,
+                            "children": [],
+                        }
+                    ],
+                },
+                "file_count": 1,
+                "category_breakdown": {},
+                "platform": "test",
+            },
+        }
+        base_analysis_data = {
+            "download_size": 800,
+            "install_size": 1500,
+            "treemap": {
+                "root": {
+                    "name": "app",
+                    "size": 0,
+                    "path": None,
+                    "is_dir": True,
+                    "children": [
+                        {
+                            "name": "main.js",
+                            "size": 800,
+                            "path": None,
+                            "is_dir": False,
+                            "children": [],
+                        }
+                    ],
+                },
+                "file_count": 1,
+                "category_breakdown": {},
+                "platform": "test",
+            },
+        }
+
+        # Create size metrics
+        self._create_size_metrics_with_analysis_file(head_artifact, head_analysis_data)
+        self._create_size_metrics_with_analysis_file(base_artifact, base_analysis_data)
+
+        with patch(
+            "sentry.preprod.size_analysis.tasks._run_size_analysis_comparison"
+        ) as mock_run_comparison:
+            compare_preprod_artifact_size_analysis(artifact_id=head_artifact.id)
+
+            # Should call _run_size_analysis_comparison with head and base metrics
+            mock_run_comparison.assert_called_once()
+            call_args = mock_run_comparison.call_args[0]
+            # Verify that the call was made with the correct metrics
+            assert call_args[0].preprod_artifact.id == head_artifact.id
+            assert call_args[1].preprod_artifact.id == base_artifact.id
+
+    def test_compare_preprod_artifact_size_analysis_success_as_base(self):
+        """Test compare_preprod_artifact_size_analysis with artifact as base."""
+        # Create commit comparisons
+        base_commit = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="a" * 40,
+            base_sha="b" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+        )
+        head_commit = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="c" * 40,
+            base_sha="a" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+        )
+
+        # Create artifacts
+        base_artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            commit_comparison=base_commit,
+            app_id="com.example.app",
+            build_version="1.0.0",
+            build_number=1,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+        )
+        head_artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            commit_comparison=head_commit,
+            app_id="com.example.app",
+            build_version="1.0.0",
+            build_number=1,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+        )
+
+        # Create size analysis data
+        analysis_data = {
+            "download_size": 1000,
+            "install_size": 2000,
+            "treemap": {
+                "root": {
+                    "name": "app",
+                    "size": 0,
+                    "path": None,
+                    "is_dir": True,
+                    "children": [
+                        {
+                            "name": "main.js",
+                            "size": 1000,
+                            "path": None,
+                            "is_dir": False,
+                            "children": [],
+                        }
+                    ],
+                },
+                "file_count": 1,
+                "category_breakdown": {},
+                "platform": "test",
+            },
+        }
+
+        # Create size metrics
+        self._create_size_metrics_with_analysis_file(base_artifact, analysis_data)
+        self._create_size_metrics_with_analysis_file(head_artifact, analysis_data)
+
+        with patch(
+            "sentry.preprod.size_analysis.tasks._run_size_analysis_comparison"
+        ) as mock_run_comparison:
+            compare_preprod_artifact_size_analysis(artifact_id=base_artifact.id)
+
+            # Should call _run_size_analysis_comparison with head and base metrics
+            mock_run_comparison.assert_called_once()
+            call_args = mock_run_comparison.call_args[0]
+            # Verify that the call was made with the correct metrics
+            assert call_args[0].preprod_artifact.id == head_artifact.id
+            assert call_args[1].preprod_artifact.id == base_artifact.id
+
+    def test_compare_preprod_artifact_size_analysis_no_matching_artifacts(self):
+        """Test compare_preprod_artifact_size_analysis with no matching artifacts."""
+        # Create commit comparison
+        commit = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="a" * 40,
+            base_sha="b" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+        )
+
+        # Create artifact
+        artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            commit_comparison=commit,
+            app_id="com.example.app",
+            build_version="1.0.0",
+            build_number=1,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+        )
+
+        with patch(
+            "sentry.preprod.size_analysis.tasks._run_size_analysis_comparison"
+        ) as mock_run_comparison:
+            compare_preprod_artifact_size_analysis(artifact_id=artifact.id)
+
+            # Should not call _run_size_analysis_comparison
+            mock_run_comparison.assert_not_called()
+
+    def test_compare_preprod_artifact_size_analysis_cannot_compare_metrics(self):
+        """Test compare_preprod_artifact_size_analysis when metrics cannot be compared."""
+        # Create commit comparisons
+        head_commit = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="a" * 40,
+            base_sha="b" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+        )
+        base_commit = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="b" * 40,
+            base_sha="c" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+        )
+
+        # Create artifacts
+        head_artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            commit_comparison=head_commit,
+            app_id="com.example.app",
+            build_version="1.0.0",
+            build_number=1,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+        )
+        base_artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            commit_comparison=base_commit,
+            app_id="com.example.app",
+            build_version="1.0.0",
+            build_number=1,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+        )
+
+        # Create size metrics with different artifact types (should not be comparable)
+        PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=head_artifact,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+        )
+        PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=base_artifact,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.WATCH_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+        )
+
+        with patch(
+            "sentry.preprod.size_analysis.tasks._run_size_analysis_comparison"
+        ) as mock_run_comparison:
+            compare_preprod_artifact_size_analysis(artifact_id=head_artifact.id)
+
+            # Should not call _run_size_analysis_comparison due to incompatible metrics
+            mock_run_comparison.assert_not_called()
+
+
+@region_silo_test
+class ManualSizeAnalysisComparisonTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.organization = self.create_organization(owner=self.user)
+        self.project = self.create_project(organization=self.organization)
+
+    def _create_size_metrics(self, **kwargs):
+        """Helper to create PreprodArtifactSizeMetrics."""
+        artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            app_id="com.example.app",
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+        )
+        return PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=artifact,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            **kwargs,
+        )
+
+    def test_manual_size_analysis_comparison_success(self):
+        """Test manual_size_analysis_comparison with valid metrics."""
+        head_size_metrics = self._create_size_metrics()
+        base_size_metrics = self._create_size_metrics()
+
+        with patch(
+            "sentry.preprod.size_analysis.tasks._run_size_analysis_comparison"
+        ) as mock_run_comparison:
+            manual_size_analysis_comparison(
+                head_size_metric_id=head_size_metrics.id,
+                base_size_metric_id=base_size_metrics.id,
+            )
+
+            mock_run_comparison.assert_called_once_with(head_size_metrics, base_size_metrics)
+
+    def test_manual_size_analysis_comparison_nonexistent_head_metric(self):
+        """Test manual_size_analysis_comparison with nonexistent head metric."""
+        base_size_metrics = self._create_size_metrics()
+
+        with patch("sentry.preprod.size_analysis.tasks.logger") as mock_logger:
+            manual_size_analysis_comparison(
+                head_size_metric_id=99999,
+                base_size_metric_id=base_size_metrics.id,
+            )
+
+            mock_logger.exception.assert_called_once()
+            call_args = mock_logger.exception.call_args
+            assert "preprod.size_analysis.compare.head_artifact_not_found" in call_args[0]
+            assert call_args[1]["extra"]["head_size_metric_id"] == 99999
+
+    def test_manual_size_analysis_comparison_nonexistent_base_metric(self):
+        """Test manual_size_analysis_comparison with nonexistent base metric."""
+        head_size_metrics = self._create_size_metrics()
+
+        with patch("sentry.preprod.size_analysis.tasks.logger") as mock_logger:
+            manual_size_analysis_comparison(
+                head_size_metric_id=head_size_metrics.id,
+                base_size_metric_id=99999,
+            )
+
+            mock_logger.exception.assert_called_once()
+            call_args = mock_logger.exception.call_args
+            assert "preprod.size_analysis.compare.base_artifact_not_found" in call_args[0]
+            assert call_args[1]["extra"]["base_size_metric_id"] == 99999
+
+
+@region_silo_test
+class RunSizeAnalysisComparisonTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.organization = self.create_organization(owner=self.user)
+        self.project = self.create_project(organization=self.organization)
+
+    def _create_size_metrics_with_analysis_file(self, analysis_data):
+        """Helper to create PreprodArtifactSizeMetrics with analysis file."""
+        artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            app_id="com.example.app",
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+        )
+
+        # Create analysis file
+        analysis_file = File.objects.create(
+            name=f"size-analysis-{artifact.id}",
+            type="preprod.file",
+            headers={"Content-Type": "application/json"},
+        )
+        analysis_file.putfile(BytesIO(json.dumps(analysis_data).encode()))
+
+        # Create size metrics
+        return PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=artifact,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            analysis_file_id=analysis_file.id,
+            max_install_size=analysis_data.get("install_size", 1000),
+            max_download_size=analysis_data.get("download_size", 500),
+        )
+
+    def test_run_size_analysis_comparison_success(self):
+        """Test _run_size_analysis_comparison with successful comparison."""
+        # Create analysis data
+        head_analysis_data = {
+            "download_size": 1000,
+            "install_size": 2000,
+            "treemap": {
+                "root": {
+                    "name": "app",
+                    "size": 0,
+                    "path": None,
+                    "is_dir": True,
+                    "children": [
+                        {
+                            "name": "main.js",
+                            "size": 1000,
+                            "path": None,
+                            "is_dir": False,
+                            "children": [],
+                        }
+                    ],
+                },
+                "file_count": 1,
+                "category_breakdown": {},
+                "platform": "test",
+            },
+        }
+        base_analysis_data = {
+            "download_size": 800,
+            "install_size": 1500,
+            "treemap": {
+                "root": {
+                    "name": "app",
+                    "size": 0,
+                    "path": None,
+                    "is_dir": True,
+                    "children": [
+                        {
+                            "name": "main.js",
+                            "size": 800,
+                            "path": None,
+                            "is_dir": False,
+                            "children": [],
+                        }
+                    ],
+                },
+                "file_count": 1,
+                "category_breakdown": {},
+                "platform": "test",
+            },
+        }
+
+        # Create size metrics
+        head_size_metrics = self._create_size_metrics_with_analysis_file(head_analysis_data)
+        base_size_metrics = self._create_size_metrics_with_analysis_file(base_analysis_data)
+
+        # Run comparison
+        _run_size_analysis_comparison(head_size_metrics, base_size_metrics)
+
+        # Verify comparison was created
+        comparisons = PreprodArtifactSizeComparison.objects.filter(
+            head_size_analysis=head_size_metrics,
+            base_size_analysis=base_size_metrics,
+        )
+        assert len(comparisons) == 1
+        comparison = comparisons[0]
+        assert comparison.state == PreprodArtifactSizeComparison.State.SUCCESS
+        assert comparison.organization_id == self.organization.id
+        assert comparison.file_id is not None
+
+        # Verify comparison file was created
+        comparison_file = File.objects.get(id=comparison.file_id)
+        assert comparison_file.type == "size_analysis_comparison.json"
+        assert comparison_file.name == str(comparison.id)
+
+        # Verify file content
+        file_content = json.loads(comparison_file.getfile().read().decode())
+        assert "diff_items" in file_content
+        assert "size_metric_diff_item" in file_content
+
+    def test_run_size_analysis_comparison_existing_comparison_processing(self):
+        """Test _run_size_analysis_comparison with existing processing comparison."""
+        # Create size metrics
+        head_size_metrics = self._create_size_metrics_with_analysis_file(
+            {"download_size": 1000, "install_size": 2000}
+        )
+        base_size_metrics = self._create_size_metrics_with_analysis_file(
+            {"download_size": 800, "install_size": 1500}
+        )
+
+        # Create existing comparison in processing state
+        existing_comparison = PreprodArtifactSizeComparison.objects.create(
+            head_size_analysis=head_size_metrics,
+            base_size_analysis=base_size_metrics,
+            organization_id=self.organization.id,
+            state=PreprodArtifactSizeComparison.State.PROCESSING,
+        )
+
+        with patch("sentry.preprod.size_analysis.tasks.logger") as mock_logger:
+            _run_size_analysis_comparison(head_size_metrics, base_size_metrics)
+
+            # Should log that existing comparison exists
+            mock_logger.info.assert_called()
+            call_args = mock_logger.info.call_args
+            assert "preprod.size_analysis.compare.existing_comparison" in call_args[0]
+
+        # Verify no new comparison was created
+        comparisons = PreprodArtifactSizeComparison.objects.filter(
+            head_size_analysis=head_size_metrics,
+            base_size_analysis=base_size_metrics,
+        )
+        assert len(comparisons) == 1
+        assert comparisons[0].id == existing_comparison.id
+
+    def test_run_size_analysis_comparison_existing_comparison_success(self):
+        """Test _run_size_analysis_comparison with existing successful comparison."""
+        # Create size metrics
+        head_size_metrics = self._create_size_metrics_with_analysis_file(
+            {"download_size": 1000, "install_size": 2000}
+        )
+        base_size_metrics = self._create_size_metrics_with_analysis_file(
+            {"download_size": 800, "install_size": 1500}
+        )
+
+        # Create existing comparison in success state
+        existing_comparison = PreprodArtifactSizeComparison.objects.create(
+            head_size_analysis=head_size_metrics,
+            base_size_analysis=base_size_metrics,
+            organization_id=self.organization.id,
+            state=PreprodArtifactSizeComparison.State.SUCCESS,
+        )
+
+        with patch("sentry.preprod.size_analysis.tasks.logger") as mock_logger:
+            _run_size_analysis_comparison(head_size_metrics, base_size_metrics)
+
+            # Should log that existing comparison exists
+            mock_logger.info.assert_called()
+            call_args = mock_logger.info.call_args
+            assert "preprod.size_analysis.compare.existing_comparison" in call_args[0]
+
+        # Verify no new comparison was created
+        comparisons = PreprodArtifactSizeComparison.objects.filter(
+            head_size_analysis=head_size_metrics,
+            base_size_analysis=base_size_metrics,
+        )
+        assert len(comparisons) == 1
+        assert comparisons[0].id == existing_comparison.id
+
+    def test_run_size_analysis_comparison_missing_head_analysis_file(self):
+        """Test _run_size_analysis_comparison with missing head analysis file."""
+        # Create size metrics without analysis file
+        head_artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            app_id="com.example.app",
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+        )
+        head_size_metrics = PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=head_artifact,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            analysis_file_id=99999,  # Nonexistent file
+        )
+
+        base_size_metrics = self._create_size_metrics_with_analysis_file(
+            {"download_size": 800, "install_size": 1500}
+        )
+
+        with patch("sentry.preprod.size_analysis.tasks.logger") as mock_logger:
+            _run_size_analysis_comparison(head_size_metrics, base_size_metrics)
+
+            mock_logger.exception.assert_called_once()
+            call_args = mock_logger.exception.call_args
+            assert "preprod.size_analysis.compare.head_analysis_file_not_found" in call_args[0]
+
+        # Verify no comparison was created
+        comparisons = PreprodArtifactSizeComparison.objects.filter(
+            head_size_analysis=head_size_metrics,
+            base_size_analysis=base_size_metrics,
+        )
+        assert len(comparisons) == 0
+
+    def test_run_size_analysis_comparison_missing_base_analysis_file(self):
+        """Test _run_size_analysis_comparison with missing base analysis file."""
+        head_size_metrics = self._create_size_metrics_with_analysis_file(
+            {"download_size": 1000, "install_size": 2000}
+        )
+
+        # Create size metrics without analysis file
+        base_artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            app_id="com.example.app",
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+        )
+        base_size_metrics = PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=base_artifact,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            analysis_file_id=99999,  # Nonexistent file
+        )
+
+        with patch("sentry.preprod.size_analysis.tasks.logger") as mock_logger:
+            _run_size_analysis_comparison(head_size_metrics, base_size_metrics)
+
+            mock_logger.exception.assert_called_once()
+            call_args = mock_logger.exception.call_args
+            assert "preprod.size_analysis.compare.base_analysis_file_not_found" in call_args[0]
+
+        # Verify no comparison was created
+        comparisons = PreprodArtifactSizeComparison.objects.filter(
+            head_size_analysis=head_size_metrics,
+            base_size_analysis=base_size_metrics,
+        )
+        assert len(comparisons) == 0
+
+    def test_run_size_analysis_comparison_invalid_json(self):
+        """Test _run_size_analysis_comparison with invalid JSON in analysis files."""
+        head_artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            app_id="com.example.app",
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+        )
+        base_artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            app_id="com.example.app",
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+        )
+
+        # Create analysis files with invalid JSON
+        head_analysis_file = File.objects.create(
+            name=f"size-analysis-{head_artifact.id}",
+            type="preprod.file",
+            headers={"Content-Type": "application/json"},
+        )
+        head_analysis_file.putfile(BytesIO(b"invalid json"))
+
+        base_analysis_file = File.objects.create(
+            name=f"size-analysis-{base_artifact.id}",
+            type="preprod.file",
+            headers={"Content-Type": "application/json"},
+        )
+        base_analysis_file.putfile(BytesIO(b"invalid json"))
+
+        # Create size metrics
+        head_size_metrics = PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=head_artifact,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            analysis_file_id=head_analysis_file.id,
+        )
+        base_size_metrics = PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=base_artifact,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            analysis_file_id=base_analysis_file.id,
+        )
+
+        # Should raise an exception due to invalid JSON
+        with pytest.raises(Exception):
+            _run_size_analysis_comparison(head_size_metrics, base_size_metrics)
+
+        # Verify no comparison was created
+        comparisons = PreprodArtifactSizeComparison.objects.filter(
+            head_size_analysis=head_size_metrics,
+            base_size_analysis=base_size_metrics,
+        )
+        assert len(comparisons) == 0

--- a/tests/sentry/preprod/test_models.py
+++ b/tests/sentry/preprod/test_models.py
@@ -182,3 +182,543 @@ class PreprodArtifactModelTest(TestCase):
 
         artifacts = list(artifact.get_sibling_artifacts_for_commit())
         assert len(artifacts) == 0
+
+    def test_get_base_artifact_for_commit_single_artifact(self):
+        """Test getting base artifact when there's only one base artifact."""
+        base_commit_comparison = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="b" * 40,
+            base_sha="c" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+            head_ref="main",
+            base_ref="develop",
+        )
+
+        base_artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            app_id="com.example.app",
+            commit_comparison=base_commit_comparison,
+        )
+
+        head_commit_comparison = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="a" * 40,
+            base_sha="b" * 40,  # This matches the head_sha of base_commit_comparison
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+            head_ref="feature/test",
+            base_ref="main",
+        )
+
+        # Create head artifact
+        head_artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            app_id="com.example.app",
+            commit_comparison=head_commit_comparison,
+        )
+
+        # Get base artifact from head artifact
+        result = head_artifact.get_base_artifact_for_commit()
+        assert result == base_artifact
+
+    def test_get_base_artifact_for_commit_multiple_artifacts_same_commit(self):
+        """Test getting base artifact when multiple artifacts exist for the same base commit (monorepo)."""
+        # Create base commit comparison
+        base_commit_comparison = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="b" * 40,
+            base_sha="c" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+            head_ref="main",
+            base_ref="develop",
+        )
+
+        # Create head commit comparison
+        head_commit_comparison = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="a" * 40,
+            base_sha="b" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+            head_ref="feature/test",
+            base_ref="main",
+        )
+
+        # Create multiple base artifacts (monorepo scenario)
+        base_artifacts = []
+        app_ids = ["com.example.android", "com.example.ios", "com.example.web"]
+        for app_id in app_ids:
+            artifact = PreprodArtifact.objects.create(
+                project=self.project,
+                state=PreprodArtifact.ArtifactState.PROCESSED,
+                app_id=app_id,
+                commit_comparison=base_commit_comparison,
+            )
+            base_artifacts.append(artifact)
+
+        # Create head artifact with matching app_id
+        head_artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            app_id="com.example.android",  # This should match one of the base artifacts
+            commit_comparison=head_commit_comparison,
+        )
+
+        # Get base artifact from head artifact (should return the one with matching app_id)
+        result = head_artifact.get_base_artifact_for_commit()
+        assert result is not None
+        assert result.app_id == head_artifact.app_id
+        assert result.app_id == "com.example.android"
+
+    def test_get_base_artifact_for_commit_no_matching_app_id(self):
+        """Test that method returns None when no base artifact has matching app_id."""
+        # Create base commit comparison
+        base_commit_comparison = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="b" * 40,
+            base_sha="c" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+            head_ref="main",
+            base_ref="develop",
+        )
+
+        # Create head commit comparison
+        head_commit_comparison = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="a" * 40,
+            base_sha="b" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+            head_ref="feature/test",
+            base_ref="main",
+        )
+
+        # Create base artifacts with different app_ids
+        base_artifacts = []
+        app_ids = ["com.example.android", "com.example.ios", "com.example.web"]
+        for app_id in app_ids:
+            artifact = PreprodArtifact.objects.create(
+                project=self.project,
+                state=PreprodArtifact.ArtifactState.PROCESSED,
+                app_id=app_id,
+                commit_comparison=base_commit_comparison,
+            )
+            base_artifacts.append(artifact)
+
+        # Create head artifact with app_id that doesn't match any base artifacts
+        head_artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            app_id="com.example.different",  # This doesn't match any base artifacts
+            commit_comparison=head_commit_comparison,
+        )
+
+        # Get base artifact from head artifact (should return None due to no matching app_id)
+        result = head_artifact.get_base_artifact_for_commit()
+        assert result is None
+
+    def test_get_base_artifact_for_commit_no_base_commit(self):
+        """Test that method returns None when no base commit comparison exists."""
+        # Create head commit comparison with a base_sha that doesn't exist
+        head_commit_comparison = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="a" * 40,
+            base_sha="x" * 40,  # Use a valid SHA format that doesn't exist
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+            head_ref="feature/test",
+            base_ref="main",
+        )
+
+        # Create head artifact
+        head_artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            app_id="com.example.app",
+            commit_comparison=head_commit_comparison,
+        )
+
+        # Get base artifact from head artifact (should return None)
+        artifacts = list(head_artifact.get_base_artifact_for_commit())
+        assert len(artifacts) == 0
+
+    def test_get_base_artifact_for_commit_cross_org_security(self):
+        """Test that base artifacts from different organizations are excluded for security."""
+        # Create second organization
+        other_org = self.create_organization(name="other_org")
+        other_project = self.create_project(organization=other_org, name="other_project")
+
+        # Create base commit comparison for first org
+        base_commit_comparison_org1 = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="b" * 40,
+            base_sha="c" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+            head_ref="main",
+            base_ref="develop",
+        )
+
+        # Create base commit comparison for second org with same head SHA
+        base_commit_comparison_org2 = CommitComparison.objects.create(
+            organization_id=other_org.id,
+            head_sha="b" * 40,  # Same SHA as org1
+            base_sha="c" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+            head_ref="main",
+            base_ref="develop",
+        )
+
+        # Create head commit comparison for first org
+        head_commit_comparison_org1 = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="a" * 40,
+            base_sha="b" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+            head_ref="feature/test",
+            base_ref="main",
+        )
+
+        base_artifact_org1 = PreprodArtifact.objects.create(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            app_id="com.example.app",
+            commit_comparison=base_commit_comparison_org1,
+        )
+
+        base_artifact_org2 = PreprodArtifact.objects.create(
+            project=other_project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            app_id="com.example.app",  # Same app_id but different org
+            commit_comparison=base_commit_comparison_org2,
+        )
+
+        # Create head artifact in first org with matching app_id
+        head_artifact_org1 = PreprodArtifact.objects.create(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            app_id="com.example.app",  # Matches base_artifact_org1
+            commit_comparison=head_commit_comparison_org1,
+        )
+
+        # Query for base artifact from org1 should only return org1 base artifact
+        result = head_artifact_org1.get_base_artifact_for_commit()
+        assert result == base_artifact_org1
+        assert result != base_artifact_org2
+
+    def test_get_base_artifact_for_commit_no_commit_comparison(self):
+        """Test that method returns None when artifact has no commit_comparison."""
+        artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            app_id="com.example.app",
+            commit_comparison=None,
+        )
+
+        artifacts = list(artifact.get_base_artifact_for_commit())
+        assert len(artifacts) == 0
+
+    def test_get_head_artifacts_for_commit_single_artifact(self):
+        """Test getting head artifacts when there's only one head artifact."""
+        # Create base commit comparison
+        base_commit_comparison = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="b" * 40,
+            base_sha="c" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+            head_ref="main",
+            base_ref="develop",
+        )
+
+        # Create head commit comparison that references the base
+        head_commit_comparison = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="a" * 40,
+            base_sha="b" * 40,  # This matches the head_sha of base_commit_comparison
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+            head_ref="feature/test",
+            base_ref="main",
+        )
+
+        # Create base artifact
+        base_artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            app_id="com.example.app",
+            commit_comparison=base_commit_comparison,
+        )
+
+        # Create head artifact
+        head_artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            app_id="com.example.app",
+            commit_comparison=head_commit_comparison,
+        )
+
+        # Get head artifacts from base artifact
+        head_artifacts = list(base_artifact.get_head_artifacts_for_commit())
+        assert len(head_artifacts) == 1
+        assert head_artifacts[0] == head_artifact
+
+    def test_get_head_artifacts_for_commit_multiple_artifacts_same_commit(self):
+        """Test getting head artifacts when multiple head artifacts exist for the same base commit (monorepo)."""
+        # Create base commit comparison
+        base_commit_comparison = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="b" * 40,
+            base_sha="c" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+            head_ref="main",
+            base_ref="develop",
+        )
+
+        # Create multiple head commit comparisons that reference the same base
+        head_commit_comparisons = []
+        for i in range(3):
+            head_commit_comparison = CommitComparison.objects.create(
+                organization_id=self.organization.id,
+                head_sha=f"{chr(ord('a') + i)}" * 40,
+                base_sha="b" * 40,  # All reference the same base
+                provider="github",
+                head_repo_name="owner/repo",
+                base_repo_name="owner/repo",
+                head_ref=f"feature/test{i}",
+                base_ref="main",
+            )
+            head_commit_comparisons.append(head_commit_comparison)
+
+        # Create base artifact
+        base_artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            app_id="com.example.app",
+            commit_comparison=base_commit_comparison,
+        )
+
+        # Create multiple head artifacts with matching app_id (monorepo scenario)
+        head_artifacts = []
+        app_ids = [
+            "com.example.app",
+            "com.example.app",
+            "com.example.app",
+        ]  # All match base artifact
+        for i, app_id in enumerate(app_ids):
+            artifact = PreprodArtifact.objects.create(
+                project=self.project,
+                state=PreprodArtifact.ArtifactState.PROCESSED,
+                app_id=app_id,
+                commit_comparison=head_commit_comparisons[i],
+            )
+            head_artifacts.append(artifact)
+
+        # Get head artifacts from base artifact
+        result_artifacts = list(base_artifact.get_head_artifacts_for_commit())
+        assert len(result_artifacts) == 3
+        assert set(result_artifacts) == set(head_artifacts)
+        # Verify all returned artifacts have matching app_id
+        for artifact in result_artifacts:
+            assert artifact.app_id == base_artifact.app_id
+
+    def test_get_head_artifacts_for_commit_no_matching_app_id(self):
+        """Test that method returns empty queryset when no head artifacts have matching app_id."""
+        # Create base commit comparison
+        base_commit_comparison = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="b" * 40,
+            base_sha="c" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+            head_ref="main",
+            base_ref="develop",
+        )
+
+        # Create head commit comparison that references the base
+        head_commit_comparison = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="a" * 40,
+            base_sha="b" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+            head_ref="feature/test",
+            base_ref="main",
+        )
+
+        # Create base artifact
+        base_artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            app_id="com.example.app",
+            commit_comparison=base_commit_comparison,
+        )
+
+        # Create head artifact with different app_id
+        PreprodArtifact.objects.create(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            app_id="com.example.different",  # Different app_id from base
+            commit_comparison=head_commit_comparison,
+        )
+
+        # Get head artifacts from base artifact (should return empty due to no matching app_id)
+        head_artifacts = list(base_artifact.get_head_artifacts_for_commit())
+        assert len(head_artifacts) == 0
+
+    def test_get_head_artifacts_for_commit_no_head_commits(self):
+        """Test that method returns empty queryset when no head commit comparisons exist."""
+        # Create base commit comparison
+        base_commit_comparison = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="b" * 40,
+            base_sha="c" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+            head_ref="main",
+            base_ref="develop",
+        )
+
+        # Create base artifact
+        base_artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            app_id="com.example.app",
+            commit_comparison=base_commit_comparison,
+        )
+
+        # Get head artifacts from base artifact (should return empty)
+        head_artifacts = list(base_artifact.get_head_artifacts_for_commit())
+        assert len(head_artifacts) == 0
+
+    def test_get_head_artifacts_for_commit_cross_org_security(self):
+        """Test that head artifacts from different organizations are excluded for security."""
+        # Create second organization
+        other_org = self.create_organization(name="other_org")
+        other_project = self.create_project(organization=other_org, name="other_project")
+
+        # Create base commit comparison for first org
+        base_commit_comparison_org1 = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="b" * 40,
+            base_sha="c" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+            head_ref="main",
+            base_ref="develop",
+        )
+
+        # Create base commit comparison for second org with same head SHA
+        base_commit_comparison_org2 = CommitComparison.objects.create(
+            organization_id=other_org.id,
+            head_sha="b" * 40,  # Same SHA as org1
+            base_sha="c" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+            head_ref="main",
+            base_ref="develop",
+        )
+
+        # Create head commit comparison for first org
+        head_commit_comparison_org1 = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="a" * 40,
+            base_sha="b" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+            head_ref="feature/test",
+            base_ref="main",
+        )
+
+        # Create head commit comparison for second org
+        head_commit_comparison_org2 = CommitComparison.objects.create(
+            organization_id=other_org.id,
+            head_sha="d" * 40,
+            base_sha="b" * 40,  # Same base SHA as org1
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+            head_ref="feature/test",
+            base_ref="main",
+        )
+
+        # Create base artifacts in each org with matching app_ids
+        base_artifact_org1 = PreprodArtifact.objects.create(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            app_id="com.example.app",
+            commit_comparison=base_commit_comparison_org1,
+        )
+
+        base_artifact_org2 = PreprodArtifact.objects.create(
+            project=other_project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            app_id="com.example.app",  # Same app_id but different org
+            commit_comparison=base_commit_comparison_org2,
+        )
+
+        # Create head artifacts in each org with matching app_ids
+        head_artifact_org1 = PreprodArtifact.objects.create(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            app_id="com.example.app",  # Matches base_artifact_org1
+            commit_comparison=head_commit_comparison_org1,
+        )
+
+        head_artifact_org2 = PreprodArtifact.objects.create(
+            project=other_project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            app_id="com.example.app",  # Matches base_artifact_org2
+            commit_comparison=head_commit_comparison_org2,
+        )
+
+        # Query for head artifacts from org1 base should only return org1 head artifacts
+        head_artifacts_org1 = list(base_artifact_org1.get_head_artifacts_for_commit())
+        assert len(head_artifacts_org1) == 1
+        assert head_artifacts_org1[0] == head_artifact_org1
+        assert head_artifact_org2 not in head_artifacts_org1
+
+        # Query for head artifacts from org2 base should only return org2 head artifacts
+        head_artifacts_org2 = list(base_artifact_org2.get_head_artifacts_for_commit())
+        assert len(head_artifacts_org2) == 1
+        assert head_artifacts_org2[0] == head_artifact_org2
+        assert head_artifact_org1 not in head_artifacts_org2
+
+    def test_get_head_artifacts_for_commit_no_commit_comparison(self):
+        """Test that method returns empty queryset when artifact has no commit_comparison."""
+        artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            app_id="com.example.app",
+            commit_comparison=None,
+        )
+
+        head_artifacts = list(artifact.get_head_artifacts_for_commit())
+        assert len(head_artifacts) == 0


### PR DESCRIPTION
Adds size_analysis results comparison code to diff treemaps and also adds a task to invoke both automatic (CI upload) and manual (user-triggered) size analyses for upcoming preprod code

Remaining TODO (might do in follow up): Add build_configuration checking to be sure comparsion can run