### PR TITLE
feat(insights): add full screen button to time spent widgets

### DIFF
--- a/static/app/components/modals/insightChartModal.tsx
+++ b/static/app/components/modals/insightChartModal.tsx
@@ -10,10 +10,17 @@ import {ChartRenderingContext} from 'sentry/views/insights/common/components/cha
 export type InsightChartModalOptions = {
   children: React.ReactNode;
   title: React.ReactNode;
+  footer?: React.ReactNode;
 };
 type Props = ModalRenderProps & InsightChartModalOptions;
 
-export default function InsightChartModal({Header, title, children}: Props) {
+export default function InsightChartModal({
+  Header,
+  title,
+  children,
+  Footer,
+  footer,
+}: Props) {
   return (
     <Fragment>
       <Container>
@@ -24,6 +31,8 @@ export default function InsightChartModal({Header, title, children}: Props) {
         <ChartRenderingContext value={{height: 300, isFullscreen: true}}>
           {children}
         </ChartRenderingContext>
+
+        {footer && <Footer>{footer}</Footer>}
       </Container>
     </Fragment>
   );

--- a/static/app/views/insights/common/components/widgets/overviewSlowAssetsWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/overviewSlowAssetsWidget.tsx
@@ -1,6 +1,9 @@
 import {Fragment} from 'react';
 import {useTheme} from '@emotion/react';
 
+import {openInsightChartModal} from 'sentry/actionCreators/modal';
+import {Button} from 'sentry/components/core/button';
+import {IconExpand} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -27,6 +30,7 @@ import {Referrer} from 'sentry/views/insights/pages/frontend/referrers';
 import {WidgetVisualizationStates} from 'sentry/views/insights/pages/platform/laravel/widgetVisualizationStates';
 import {useReleaseBubbleProps} from 'sentry/views/insights/pages/platform/shared/getReleaseBubbleProps';
 import {
+  ModalChartContainer,
   SeriesColorIndicator,
   WidgetFooterTable,
 } from 'sentry/views/insights/pages/platform/shared/styles';
@@ -48,6 +52,7 @@ export default function OverviewAssetsByTimeSpentWidget(props: LoadableChartWidg
   const groupBy = SpanFields.NORMALIZED_DESCRIPTION;
   const yAxes = 'p75(span.duration)';
   const totalTimeField = 'sum(span.duration)';
+  const title = t('Assets by Time Spent');
 
   const {
     data: assetListData,
@@ -161,39 +166,56 @@ export default function OverviewAssetsByTimeSpentWidget(props: LoadableChartWidg
       },
     ],
     mode: Mode.AGGREGATE,
-    title: t('Assets by Time Spent'),
+    title,
     query: search?.formatString(),
     sort: undefined,
     groupBy: [groupBy],
     referrer,
   });
 
-  const chartActions = (
-    <BaseChartActionDropdown
-      key="slow assets widget"
-      exploreUrl={exploreUrl}
-      referrer={referrer}
-      alertMenuOptions={assetSeriesData.map(series => ({
-        key: series.seriesName,
-        label: series.seriesName,
-        to: getAlertsUrl({
-          project,
-          aggregate: yAxes,
-          organization,
-          pageFilters: selection,
-          dataset: Dataset.EVENTS_ANALYTICS_PLATFORM,
-          query: `${SpanFields.NORMALIZED_DESCRIPTION}:${series.seriesName}`,
-          referrer,
-        }),
-      }))}
-    />
-  );
-
   return (
     <Widget
-      Title={<Widget.WidgetTitle title={t('Assets by Time Spent')} />}
+      Title={<Widget.WidgetTitle title={title} />}
       Visualization={visualization}
-      Actions={hasData && <Widget.WidgetToolbar>{chartActions}</Widget.WidgetToolbar>}
+      Actions={
+        hasData && (
+          <Widget.WidgetToolbar>
+            <Fragment>
+              <BaseChartActionDropdown
+                key="slow assets widget"
+                exploreUrl={exploreUrl}
+                referrer={referrer}
+                alertMenuOptions={assetSeriesData.map(series => ({
+                  key: series.seriesName,
+                  label: series.seriesName,
+                  to: getAlertsUrl({
+                    project,
+                    aggregate: yAxes,
+                    organization,
+                    pageFilters: selection,
+                    dataset: Dataset.EVENTS_ANALYTICS_PLATFORM,
+                    query: `${SpanFields.NORMALIZED_DESCRIPTION}:${series.seriesName}`,
+                    referrer,
+                  }),
+                }))}
+              />
+              <Button
+                size="xs"
+                aria-label={t('Open Full-Screen View')}
+                borderless
+                icon={<IconExpand />}
+                onClick={() => {
+                  openInsightChartModal({
+                    title,
+                    footer,
+                    children: <ModalChartContainer>{visualization}</ModalChartContainer>,
+                  });
+                }}
+              />
+            </Fragment>
+          </Widget.WidgetToolbar>
+        )
+      }
       noFooterPadding
       Footer={props.loaderSource === 'releases-drawer' ? undefined : footer}
     />

--- a/static/app/views/insights/common/components/widgets/overviewTimeConsumingRequestsWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/overviewTimeConsumingRequestsWidget.tsx
@@ -1,6 +1,9 @@
 import {Fragment} from 'react';
 import {useTheme} from '@emotion/react';
 
+import {openInsightChartModal} from 'sentry/actionCreators/modal';
+import {Button} from 'sentry/components/core/button';
+import {IconExpand} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -13,6 +16,7 @@ import {Mode} from 'sentry/views/explore/queryParams/mode';
 import {getExploreUrl} from 'sentry/views/explore/utils';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
 import {BaseChartActionDropdown} from 'sentry/views/insights/common/components/chartActionDropdown';
+import {ModalChartContainer} from 'sentry/views/insights/common/components/insightsChartContainer';
 import {TimeSpentCell} from 'sentry/views/insights/common/components/tableCells/timeSpentCell';
 import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/components/widgets/types';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
@@ -163,32 +167,49 @@ export default function OverviewTimeConsumingRequestsWidget(
     referrer,
   });
 
-  const chartActions = (
-    <BaseChartActionDropdown
-      key="time consuming requests widget"
-      exploreUrl={exploreUrl}
-      referrer={referrer}
-      alertMenuOptions={requestSeriesData.map(series => ({
-        key: series.seriesName,
-        label: aliases[series.seriesName],
-        to: getAlertsUrl({
-          project,
-          aggregate: yAxes,
-          organization,
-          pageFilters: selection,
-          dataset: Dataset.EVENTS_ANALYTICS_PLATFORM,
-          query: `${SpanFields.SPAN_DOMAIN}:${series.seriesName}`,
-          referrer,
-        }),
-      }))}
-    />
-  );
-
   return (
     <Widget
       Title={<Widget.WidgetTitle title={title} />}
       Visualization={visualization}
-      Actions={hasData && <Widget.WidgetToolbar>{chartActions}</Widget.WidgetToolbar>}
+      Actions={
+        hasData && (
+          <Widget.WidgetToolbar>
+            <Fragment>
+              <BaseChartActionDropdown
+                key="time consuming requests widget"
+                exploreUrl={exploreUrl}
+                referrer={referrer}
+                alertMenuOptions={requestSeriesData.map(series => ({
+                  key: series.seriesName,
+                  label: aliases[series.seriesName],
+                  to: getAlertsUrl({
+                    project,
+                    aggregate: yAxes,
+                    organization,
+                    pageFilters: selection,
+                    dataset: Dataset.EVENTS_ANALYTICS_PLATFORM,
+                    query: `${SpanFields.SPAN_DOMAIN}:${series.seriesName}`,
+                    referrer,
+                  }),
+                }))}
+              />
+              <Button
+                size="xs"
+                aria-label={t('Open Full-Screen View')}
+                borderless
+                icon={<IconExpand />}
+                onClick={() => {
+                  openInsightChartModal({
+                    title,
+                    footer,
+                    children: <ModalChartContainer>{visualization}</ModalChartContainer>,
+                  });
+                }}
+              />
+            </Fragment>
+          </Widget.WidgetToolbar>
+        )
+      }
       noFooterPadding
       Footer={props.loaderSource === 'releases-drawer' ? undefined : footer}
     />

--- a/static/app/views/insights/pages/platform/shared/styles.tsx
+++ b/static/app/views/insights/pages/platform/shared/styles.tsx
@@ -19,6 +19,7 @@ export const WidgetFooterTable = styled('div')<{columns?: number}>`
   display: grid;
   grid-template-columns: max-content 1fr repeat(${p => getColumns(p) - 2}, max-content);
   font-size: ${p => p.theme.fontSize.sm};
+  width: 100%;
 
   & > * {
     padding: ${space(1)} ${space(0.5)};


### PR DESCRIPTION
Adds a full screen button to both the "assets by time spent" and "network requests by time spent" widgets
![Uploading image.png…]()

<img width="1261" height="661" alt="image" src="https://github.com/user-attachments/assets/0b95a9b2-49bf-481c-94aa-f3d60731b83d" />
