### PR TITLE
fix(aci milestone 3): correctly update incident activity if group status doesn't change on new open period

### DIFF
--- a/src/sentry/issues/priority.py
+++ b/src/sentry/issues/priority.py
@@ -62,12 +62,13 @@ def update_priority(
             "reason": reason,
         },
     )
+
+    record_group_history(group, status=PRIORITY_TO_GROUP_HISTORY_STATUS[priority], actor=actor)
+
     # TODO (aci cleanup): if the group corresponds to a metric issue, then update its incident activity
     # we will remove this once we've fully deprecated the Incident model
     if group.type == MetricIssue.type_id:
         update_incident_activity_based_on_group_activity(group, priority)
-
-    record_group_history(group, status=PRIORITY_TO_GROUP_HISTORY_STATUS[priority], actor=actor)
 
     issue_update_priority.send_robust(
         group=group,


### PR DESCRIPTION
Each incident needs to open with a priority change in the IncidentActivity model. However, if a new open period opens on a group with the same priority as the latest on its last open period, no priority change will be recorded on the group. To handle these cases, always manually update the incident activity on open period creation.