### PR TITLE
fix(typing): Remove sentry.db.postgres.base from problem list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -306,7 +306,6 @@ module = [
     "sentry.api.endpoints.organization_events_meta",
     "sentry.api.endpoints.organization_releases",
     "sentry.api.paginator",
-    "sentry.db.postgres.base",
     "sentry.integrations.slack.message_builder.notifications.issues",
     "sentry.middleware.auth",
     "sentry.middleware.ratelimit",

--- a/src/sentry/db/postgres/schema.py
+++ b/src/sentry/db/postgres/schema.py
@@ -1,4 +1,5 @@
 from django.contrib.postgres.constraints import ExclusionConstraint
+from django.db.backends.base.schema import BaseDatabaseSchemaEditor
 from django.db.backends.postgresql.schema import (
     DatabaseSchemaEditor as PostgresDatabaseSchemaEditor,
 )
@@ -114,7 +115,7 @@ class SafePostgresDatabaseSchemaEditor(DatabaseSchemaEditorMixin, PostgresDataba
         super(DatabaseSchemaEditorMixin, self).remove_field(model, field)
 
 
-class DatabaseSchemaEditorProxy:
+class DatabaseSchemaEditorProxy(BaseDatabaseSchemaEditor):
     """
     Wrapper that allows us to use either the `SafePostgresDatabaseSchemaEditor` or
     `PostgresDatabaseSchemaEditor`. Can be configured by setting the `safe` property


### PR DESCRIPTION
Made minimal changes to allow mypy to pass with the file removed from the problem list.

This mostly consistent of adding a workaround to allow us to access Django internals.

Test plan: `mypy` no errors