### PR TITLE
feat(aci): Add check-ins table to cron monitor details page

### DIFF
--- a/static/app/views/alerts/rules/crons/details.tsx
+++ b/static/app/views/alerts/rules/crons/details.tsx
@@ -6,6 +6,7 @@ import {
   deleteMonitorProcessingErrorByType,
   updateMonitor,
 } from 'sentry/actionCreators/monitors';
+import {SectionHeading} from 'sentry/components/charts/styles';
 import {Alert} from 'sentry/components/core/alert';
 import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingError from 'sentry/components/loadingError';
@@ -195,10 +196,15 @@ function MonitorDetails({params, location}: Props) {
                 <DetailsTimeline monitor={monitor} onStatsLoaded={checkHasUnknown} />
                 <MonitorStats monitor={monitor} monitorEnvs={monitor.environments} />
                 <MonitorIssues monitor={monitor} monitorEnvs={monitor.environments} />
-                <MonitorCheckIns monitor={monitor} monitorEnvs={monitor.environments} />
+                <SectionHeading>{t('Recent Check-Ins')}</SectionHeading>
+                <MonitorCheckIns
+                  monitorSlug={monitor.slug}
+                  monitorEnvs={monitor.environments}
+                  project={monitor.project}
+                />
               </Fragment>
             ) : (
-              <MonitorOnboarding monitor={monitor} />
+              <MonitorOnboarding monitorSlug={monitor.slug} project={monitor.project} />
             )}
           </Layout.Main>
           <Layout.Side>

--- a/static/app/views/detectors/components/details/cron/index.spec.tsx
+++ b/static/app/views/detectors/components/details/cron/index.spec.tsx
@@ -1,0 +1,128 @@
+import {CheckInFixture} from 'sentry-fixture/checkIn';
+import {
+  CronDetectorFixture,
+  CronMonitorDataSourceFixture,
+  CronMonitorEnvironmentFixture,
+} from 'sentry-fixture/detectors';
+import {ProjectFixture} from 'sentry-fixture/project';
+import {ProjectKeysFixture} from 'sentry-fixture/projectKeys';
+import {UserFixture} from 'sentry-fixture/user';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {CronDetectorDetails} from 'sentry/views/detectors/components/details/cron';
+
+describe('CronDetectorDetails - check-ins', () => {
+  const project = ProjectFixture();
+  const cronDataSource = CronMonitorDataSourceFixture({
+    queryObj: {
+      ...CronMonitorDataSourceFixture().queryObj,
+      // Ensure we have a lastCheckIn so the check-ins section is shown
+      environments: [
+        CronMonitorEnvironmentFixture({
+          lastCheckIn: '2025-01-01T00:00:00Z',
+        }),
+      ],
+    },
+  });
+  const detector = CronDetectorFixture({
+    id: '1',
+    projectId: project.id,
+    workflowIds: [],
+    dataSources: [cronDataSource],
+  });
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/open-periods/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/issues/?limit=5&query=is%3Aunresolved%20detector%3A1&statsPeriod=14d`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/users/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/users/1/`,
+      body: UserFixture(),
+    });
+    MockApiClient.addMockResponse({
+      url: `/projects/org-slug/${project.slug}/monitors/${cronDataSource.queryObj.slug}/checkins/`,
+      body: [],
+    });
+  });
+
+  it('should show onboarding when the monitor has never checked in', async () => {
+    MockApiClient.addMockResponse({
+      url: `/projects/org-slug/${project.slug}/keys/`,
+      body: ProjectKeysFixture(),
+    });
+
+    const noCheckInDataSource = CronMonitorDataSourceFixture({
+      queryObj: {
+        ...CronMonitorDataSourceFixture().queryObj,
+        environments: [
+          CronMonitorEnvironmentFixture({
+            lastCheckIn: null,
+            nextCheckIn: null,
+          }),
+        ],
+      },
+    });
+
+    const noCheckInDetector = CronDetectorFixture({
+      id: '2',
+      projectId: project.id,
+      dataSources: [noCheckInDataSource],
+    });
+
+    render(<CronDetectorDetails detector={noCheckInDetector} project={project} />);
+
+    expect(
+      await screen.findByRole('heading', {name: 'Instrument your monitor'})
+    ).toBeInTheDocument();
+    expect(screen.getByText('Waiting for first Check-in')).toBeInTheDocument();
+    expect(screen.queryByText('Recent Check-Ins')).not.toBeInTheDocument();
+  });
+
+  describe('check-ins', () => {
+    it('shows recent check-ins with an empty table', async () => {
+      render(<CronDetectorDetails detector={detector} project={project} />);
+
+      expect(await screen.findByText('Recent Check-Ins')).toBeInTheDocument();
+      expect(
+        screen.getByText('No check-ins have been recorded for this time period.')
+      ).toBeInTheDocument();
+    });
+
+    it('shows recent check-ins with a table when they exist', async () => {
+      MockApiClient.addMockResponse({
+        url: `/projects/org-slug/${project.slug}/monitors/${cronDataSource.queryObj.slug}/checkins/`,
+        body: [CheckInFixture()],
+      });
+
+      render(<CronDetectorDetails detector={detector} project={project} />);
+
+      // Wait for data to load and a row to render
+      expect(await screen.findByText('Failed')).toBeInTheDocument();
+
+      // Should render table headers
+      expect(screen.getByRole('columnheader', {name: 'Status'})).toBeInTheDocument();
+      expect(screen.getByRole('columnheader', {name: 'Started'})).toBeInTheDocument();
+      expect(screen.getByRole('columnheader', {name: 'Completed'})).toBeInTheDocument();
+      expect(screen.getByRole('columnheader', {name: 'Duration'})).toBeInTheDocument();
+      expect(screen.getByRole('columnheader', {name: 'Issues'})).toBeInTheDocument();
+      expect(screen.getByRole('columnheader', {name: 'Expected At'})).toBeInTheDocument();
+
+      // Empty-state should not be visible when data exists
+      expect(
+        screen.queryByText('No check-ins have been recorded for this time period.')
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/static/app/views/detectors/components/details/cron/index.tsx
+++ b/static/app/views/detectors/components/details/cron/index.tsx
@@ -1,3 +1,4 @@
+import {Fragment} from 'react';
 import sortBy from 'lodash/sortBy';
 
 import {Alert} from 'sentry/components/core/alert';
@@ -15,6 +16,9 @@ import {DetectorDetailsAutomations} from 'sentry/views/detectors/components/deta
 import {DetectorExtraDetails} from 'sentry/views/detectors/components/details/common/extraDetails';
 import {DetectorDetailsHeader} from 'sentry/views/detectors/components/details/common/header';
 import {DetectorDetailsOngoingIssues} from 'sentry/views/detectors/components/details/common/ongoingIssues';
+import {MonitorCheckIns} from 'sentry/views/insights/crons/components/monitorCheckIns';
+import {MonitorOnboarding} from 'sentry/views/insights/crons/components/onboarding';
+import type {MonitorEnvironment} from 'sentry/views/insights/crons/types';
 
 type CronDetectorDetailsProps = {
   detector: CronDetector;
@@ -30,23 +34,40 @@ function getLatestCronMonitorEnv(detector: CronDetector) {
   return envsSortedByLastCheck[envsSortedByLastCheck.length - 1];
 }
 
+function hasLastCheckIn(envs: MonitorEnvironment[]) {
+  return envs.some(e => e.lastCheckIn);
+}
+
 export function CronDetectorDetails({detector, project}: CronDetectorDetailsProps) {
   const dataSource = detector.dataSources[0];
 
   const {failure_issue_threshold, recovery_threshold} = dataSource.queryObj.config;
 
   const monitorEnv = getLatestCronMonitorEnv(detector);
+  const hasCheckedIn = hasLastCheckIn(dataSource.queryObj.environments);
 
   return (
     <DetailLayout>
       <DetectorDetailsHeader detector={detector} project={project} />
       <DetailLayout.Body>
         <DetailLayout.Main>
-          <DatePageFilter />
-          {/* TODO: Add check-in chart */}
-          <DetectorDetailsOngoingIssues detectorId={detector.id} />
-          <DetectorDetailsAutomations detector={detector} />
-          {/* TODO: Add recent check-ins table */}
+          {hasCheckedIn ? (
+            <Fragment>
+              <DatePageFilter />
+              {/* TODO: Add check-in chart */}
+              <DetectorDetailsOngoingIssues detectorId={detector.id} />
+              <Section title={t('Recent Check-Ins')}>
+                <MonitorCheckIns
+                  monitorSlug={dataSource.queryObj.slug}
+                  monitorEnvs={dataSource.queryObj.environments}
+                  project={project}
+                />
+              </Section>
+              <DetectorDetailsAutomations detector={detector} />
+            </Fragment>
+          ) : (
+            <MonitorOnboarding monitorSlug={dataSource.queryObj.slug} project={project} />
+          )}
         </DetailLayout.Main>
         <DetailLayout.Sidebar>
           <Section title={t('Detect')}>

--- a/static/app/views/detectors/components/details/cron/index.tsx
+++ b/static/app/views/detectors/components/details/cron/index.tsx
@@ -57,11 +57,13 @@ export function CronDetectorDetails({detector, project}: CronDetectorDetailsProp
               {/* TODO: Add check-in chart */}
               <DetectorDetailsOngoingIssues detectorId={detector.id} />
               <Section title={t('Recent Check-Ins')}>
-                <MonitorCheckIns
-                  monitorSlug={dataSource.queryObj.slug}
-                  monitorEnvs={dataSource.queryObj.environments}
-                  project={project}
-                />
+                <div>
+                  <MonitorCheckIns
+                    monitorSlug={dataSource.queryObj.slug}
+                    monitorEnvs={dataSource.queryObj.environments}
+                    project={project}
+                  />
+                </div>
               </Section>
               <DetectorDetailsAutomations detector={detector} />
             </Fragment>

--- a/static/app/views/detectors/detail.spec.tsx
+++ b/static/app/views/detectors/detail.spec.tsx
@@ -261,6 +261,17 @@ describe('DetectorDetails', () => {
   });
 
   describe('cron detectors', () => {
+    beforeEach(() => {
+      MockApiClient.addMockResponse({
+        url: '/projects/org-slug/project-slug/monitors/test-monitor/checkins/',
+        body: [],
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/detectors/${cronDetector.id}/`,
+        body: cronDetector,
+      });
+    });
+
     const cronMonitorDataSource = CronMonitorDataSourceFixture({
       queryObj: {
         ...CronMonitorDataSourceFixture().queryObj,
@@ -278,13 +289,6 @@ describe('DetectorDetails', () => {
       owner: `team:${ownerTeam.id}`,
       workflowIds: ['1', '2'],
       dataSources: [cronMonitorDataSource],
-    });
-
-    beforeEach(() => {
-      MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/detectors/${cronDetector.id}/`,
-        body: cronDetector,
-      });
     });
 
     it('displays correct detector details', async () => {

--- a/static/app/views/insights/crons/components/monitorCheckIns.tsx
+++ b/static/app/views/insights/crons/components/monitorCheckIns.tsx
@@ -1,3 +1,5 @@
+import {Fragment} from 'react';
+
 import LoadingError from 'sentry/components/loadingError';
 import Pagination from 'sentry/components/pagination';
 import type {Project} from 'sentry/types/project';
@@ -42,7 +44,7 @@ export function MonitorCheckIns({monitorSlug, monitorEnvs, project}: Props) {
   const hasMultiEnv = monitorEnvs.length > 1;
 
   return (
-    <div>
+    <Fragment>
       <MonitorCheckInsGrid
         checkIns={checkInList ?? []}
         isLoading={isPending}
@@ -50,6 +52,6 @@ export function MonitorCheckIns({monitorSlug, monitorEnvs, project}: Props) {
         project={project}
       />
       <Pagination pageLinks={getResponseHeader?.('Link')} />
-    </div>
+    </Fragment>
   );
 }

--- a/static/app/views/insights/crons/components/monitorCheckIns.tsx
+++ b/static/app/views/insights/crons/components/monitorCheckIns.tsx
@@ -1,24 +1,22 @@
-import {Fragment} from 'react';
-
-import {SectionHeading} from 'sentry/components/charts/styles';
 import LoadingError from 'sentry/components/loadingError';
 import Pagination from 'sentry/components/pagination';
-import {t} from 'sentry/locale';
+import type {Project} from 'sentry/types/project';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
-import type {Monitor, MonitorEnvironment} from 'sentry/views/insights/crons/types';
+import type {MonitorEnvironment} from 'sentry/views/insights/crons/types';
 import {useMonitorCheckIns} from 'sentry/views/insights/crons/utils/useMonitorCheckIns';
 
 import {MonitorCheckInsGrid} from './monitorCheckInsGrid';
 
 type Props = {
-  monitor: Monitor;
   monitorEnvs: MonitorEnvironment[];
+  monitorSlug: string;
+  project: Project;
 };
 
 const PER_PAGE = 10;
 
-export function MonitorCheckIns({monitor, monitorEnvs}: Props) {
+export function MonitorCheckIns({monitorSlug, monitorEnvs, project}: Props) {
   const location = useLocation();
   const organization = useOrganization();
 
@@ -29,8 +27,8 @@ export function MonitorCheckIns({monitor, monitorEnvs}: Props) {
     isError,
   } = useMonitorCheckIns({
     orgSlug: organization.slug,
-    projectSlug: monitor.project.slug,
-    monitorIdOrSlug: monitor.slug,
+    projectSlug: project.slug,
+    monitorIdOrSlug: monitorSlug,
     limit: PER_PAGE,
     expand: 'groups',
     environment: monitorEnvs.map(e => e.name),
@@ -44,15 +42,14 @@ export function MonitorCheckIns({monitor, monitorEnvs}: Props) {
   const hasMultiEnv = monitorEnvs.length > 1;
 
   return (
-    <Fragment>
-      <SectionHeading>{t('Recent Check-Ins')}</SectionHeading>
+    <div>
       <MonitorCheckInsGrid
         checkIns={checkInList ?? []}
         isLoading={isPending}
         hasMultiEnv={hasMultiEnv}
-        project={monitor.project}
+        project={project}
       />
       <Pagination pageLinks={getResponseHeader?.('Link')} />
-    </Fragment>
+    </div>
   );
 }

--- a/static/app/views/insights/crons/components/monitorQuickStartGuide.tsx
+++ b/static/app/views/insights/crons/components/monitorQuickStartGuide.tsx
@@ -5,7 +5,7 @@ import partition from 'lodash/partition';
 import {CompactSelect} from 'sentry/components/core/compactSelect';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {PlatformKey, ProjectKey} from 'sentry/types/project';
+import type {PlatformKey, Project, ProjectKey} from 'sentry/types/project';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import type {QuickStartProps} from 'sentry/views/insights/crons/components/quickStartEntries';
@@ -25,10 +25,10 @@ import {
   RubyRailsCronQuickStart,
   RubySidekiqCronQuickStart,
 } from 'sentry/views/insights/crons/components/quickStartEntries';
-import type {Monitor} from 'sentry/views/insights/crons/types';
 
 interface Props {
-  monitor: Monitor;
+  monitorSlug: string;
+  project: Project;
 }
 
 interface OnboardingGuide {
@@ -138,11 +138,11 @@ export const platformsWithGuides = Array.from(
 
 const guideToSelectOption = ({key, label}: any) => ({label, value: key});
 
-export default function MonitorQuickStartGuide({monitor}: Props) {
+export default function MonitorQuickStartGuide({monitorSlug, project}: Props) {
   const org = useOrganization();
 
   const {data: projectKeys} = useApiQuery<ProjectKey[]>(
-    [`/projects/${org.slug}/${monitor.project.slug}/keys/`],
+    [`/projects/${org.slug}/${project.slug}/keys/`],
     {staleTime: Infinity}
   );
 
@@ -162,7 +162,7 @@ export default function MonitorQuickStartGuide({monitor}: Props) {
   ];
 
   const platformSpecific = platformGuides.filter(guide =>
-    guide.platforms?.has(monitor.project.platform ?? 'other')
+    guide.platforms?.has(project.platform ?? 'other')
   );
 
   const defaultExample = platformSpecific.length > 0 ? platformSpecific[0]!.key : 'cli';
@@ -178,10 +178,10 @@ export default function MonitorQuickStartGuide({monitor}: Props) {
         onChange={({value}) => setSelectedGuide(value)}
       />
       <Guide
-        slug={monitor.slug}
+        slug={monitorSlug}
         orgSlug={org.slug}
         orgId={org.id}
-        projectId={monitor.project.id}
+        projectId={project.id}
         cronsUrl={projectKeys?.[0]!.dsn.crons}
         dsnKey={projectKeys?.[0]!.dsn.public}
       />

--- a/static/app/views/insights/crons/components/onboarding.tsx
+++ b/static/app/views/insights/crons/components/onboarding.tsx
@@ -5,15 +5,16 @@ import OnboardingPanel from 'sentry/components/onboardingPanel';
 import {t, tct} from 'sentry/locale';
 import pulsingIndicatorStyles from 'sentry/styles/pulsingIndicator';
 import {space} from 'sentry/styles/space';
-import type {Monitor} from 'sentry/views/insights/crons/types';
+import type {Project} from 'sentry/types/project';
 
 import MonitorQuickStartGuide from './monitorQuickStartGuide';
 
 interface Props {
-  monitor: Monitor;
+  monitorSlug: string;
+  project: Project;
 }
 
-export function MonitorOnboarding({monitor}: Props) {
+export function MonitorOnboarding({monitorSlug, project}: Props) {
   return (
     <OnboardingPanel noCenter>
       <h3>{t('Instrument your monitor')}</h3>
@@ -27,7 +28,7 @@ export function MonitorOnboarding({monitor}: Props) {
           }
         )}
       </p>
-      <MonitorQuickStartGuide monitor={monitor} />
+      <MonitorQuickStartGuide monitorSlug={monitorSlug} project={project} />
       <WaitingNotice>
         <WaitingIndicator />
         {t('Waiting for first Check-in')}


### PR DESCRIPTION
Takes the recent check-ins table from the crons page and adds it to the detector details. 

Needed to make a couple small changes to the component props so that it can be used in both places

<img width="1118" height="578" alt="CleanShot 2025-09-04 at 11 30 54" src="https://github.com/user-attachments/assets/cb042bb8-b4dc-4d36-9261-e82bee8c3db9" />
