### PR TITLE
chore(nav): Remove opt-out option from help menu

### DIFF
--- a/static/app/views/nav/primary/help.tsx
+++ b/static/app/views/nav/primary/help.tsx
@@ -131,19 +131,6 @@ export function PrimaryNavigationHelp() {
                   startTour();
                 },
               },
-              {
-                key: 'new-ui',
-                label: t('Switch to old navigation'),
-                onAction() {
-                  mutateUserOptions({prefersStackedNavigation: false});
-                  trackAnalytics(
-                    'navigation.help_menu_opt_out_stacked_navigation_clicked',
-                    {
-                      organization,
-                    }
-                  );
-                },
-              },
               organization?.features?.includes('chonk-ui')
                 ? user.options.prefersChonkUI
                   ? {

--- a/static/app/views/nav/tour/tour.tsx
+++ b/static/app/views/nav/tour/tour.tsx
@@ -230,7 +230,7 @@ export function StackedNavigationTourReminder({children}: {children: React.React
     <TourGuide
       title={t('Come back anytime')}
       description={t(
-        'You can always use the help menu to take this tour again, switch to the old experience, or share feedback with the team.'
+        'You can always use the help menu to take this tour again or share feedback with the team.'
       )}
       actions={
         <TourAction


### PR DESCRIPTION
Step 1 of removing the old navigation: No more opting out.

Next step will be to force everyone on to the new navigation, then to remove the old code entirely.