### PR TITLE
fix(prevent) attempt to fix redirection in prevent route

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -2433,6 +2433,9 @@ function buildRoutes(): RouteObject[] {
           children: [
             {
               index: true,
+              redirectTo: 'new/',
+            },
+            {
               path: 'new/',
               component: make(() => import('sentry/views/prevent/preventAI/onboarding')),
             },

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -2372,6 +2372,10 @@ function buildRoutes(): RouteObject[] {
 
   const codecovChildren: SentryRouteObject[] = [
     {
+      index: true,
+      redirectTo: '/prevent/prevent-ai/new/',
+    },
+    {
       path: 'coverage/',
       children: [
         // This is a layout route that will render a header for coverage
@@ -2409,40 +2413,26 @@ function buildRoutes(): RouteObject[] {
     },
     {
       path: 'tests/',
+      component: make(() => import('sentry/views/prevent/tests/testsWrapper')),
       children: [
-        // Render tests page with layout wrapper
         {
-          component: make(() => import('sentry/views/prevent/tests/testsWrapper')),
-          children: [
-            {
-              index: true,
-              component: make(() => import('sentry/views/prevent/tests/tests')),
-            },
-          ],
+          index: true,
+          component: make(() => import('sentry/views/prevent/tests/tests')),
         },
-        // Render tests onboarding with layout wrapper
         {
           path: 'new/',
-          component: make(() => import('sentry/views/prevent/tests/testsWrapper')),
-          children: [
-            {
-              index: true,
-              component: make(() => import('sentry/views/prevent/tests/onboarding')),
-            },
-          ],
+          component: make(() => import('sentry/views/prevent/tests/onboarding')),
         },
       ],
     },
     {
       path: 'prevent-ai/',
       children: [
-        // Render prevent AI onboarding with layout wrapper
         {
-          path: 'new/',
           component: make(() => import('sentry/views/prevent/preventAI/wrapper')),
           children: [
             {
-              index: true,
+              path: 'new/',
               component: make(() => import('sentry/views/prevent/preventAI/onboarding')),
             },
           ],
@@ -2451,15 +2441,11 @@ function buildRoutes(): RouteObject[] {
     },
     {
       path: 'tokens/',
+      component: make(() => import('sentry/views/prevent/tokens/tokensWrapper')),
       children: [
         {
-          component: make(() => import('sentry/views/prevent/tokens/tokensWrapper')),
-          children: [
-            {
-              index: true,
-              component: make(() => import('sentry/views/prevent/tokens/tokens')),
-            },
-          ],
+          index: true,
+          component: make(() => import('sentry/views/prevent/tokens/tokens')),
         },
       ],
     },

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -2432,6 +2432,7 @@ function buildRoutes(): RouteObject[] {
           component: make(() => import('sentry/views/prevent/preventAI/wrapper')),
           children: [
             {
+              index: true,
               path: 'new/',
               component: make(() => import('sentry/views/prevent/preventAI/onboarding')),
             },

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -2373,7 +2373,7 @@ function buildRoutes(): RouteObject[] {
   const codecovChildren: SentryRouteObject[] = [
     {
       index: true,
-      redirectTo: '/prevent/prevent-ai/new/',
+      redirectTo: 'prevent-ai/new/',
     },
     {
       path: 'coverage/',

--- a/static/app/views/prevent/index.tsx
+++ b/static/app/views/prevent/index.tsx
@@ -1,22 +1,14 @@
 import Feature from 'sentry/components/acl/feature';
 import {NoAccess} from 'sentry/components/noAccess';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
-import Redirect from 'sentry/components/redirect';
-import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
-import {PREVENT_BASE_URL} from 'sentry/views/prevent/settings';
 
 interface Props {
   children: React.ReactNode;
 }
 
 export default function PreventPage({children}: Props) {
-  const location = useLocation();
   const organization = useOrganization();
-
-  if (location.pathname === `/${PREVENT_BASE_URL}/`) {
-    return <Redirect to={`/${PREVENT_BASE_URL}/prevent-ai/new/`} />;
-  }
 
   return (
     <Feature


### PR DESCRIPTION
This PR intends to address redirection issues w/ the /prevent/ route.

Currently, `.../prevent/`, `.../prevent/tests/` and `.../prevent/tokens/` redirect to `.../codecov/`, breaking the UI. This PR intends to amend this

Closes https://linear.app/getsentry/issue/CCMRG-1508/fix-routing-when-explicitly-route-to-prevent-routes