### PR TITLE
fix(typing): Remove sentry.notifications.notifications.activity.base from problem list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -311,7 +311,6 @@ module = [
     "sentry.middleware.auth",
     "sentry.middleware.ratelimit",
     "sentry.net.http",
-    "sentry.notifications.notifications.activity.base",
     "sentry.plugins.config",
     "sentry.release_health.metrics_sessions_v2",
     "sentry.search.events.builder.errors",

--- a/src/sentry/notifications/notifications/activity/base.py
+++ b/src/sentry/notifications/notifications/activity/base.py
@@ -80,6 +80,7 @@ class GroupActivityNotification(ActivityNotification, abc.ABC):
 
     def __init__(self, activity: Activity) -> None:
         super().__init__(activity)
+        assert activity.group is not None
         self.group = activity.group
 
     def get_description(self) -> tuple[str, str | None, Mapping[str, Any]]:

--- a/src/sentry/notifications/utils/avatar.py
+++ b/src/sentry/notifications/utils/avatar.py
@@ -36,7 +36,7 @@ def get_sentry_avatar_url() -> str:
     return str(absolute_uri(get_asset_url("sentry", url)))
 
 
-def avatar_as_html(user: User | RpcUser, size: int = 20) -> SafeString:
+def avatar_as_html(user: User | RpcUser | None, size: int = 20) -> SafeString:
     if not user:
         return format_html(
             '<img class="avatar" src="{}" width="{}px" height="{}px" />',


### PR DESCRIPTION
Made minimal changes to allow mypy to pass with the file removed from the problem list.

The only scary part here is adding the `assert activity.group is not None`... but the structure of the class means that it'd pretty-much immediately throw if a `None` group got passed in anyways. (And tests show no errors!) I feel fairly confident this will be a no-op.

Test plan: `mypy` no errors; `pytest tests/sentry/notifications/**` no durable failures (three flaky failures that immediately passed on retry).