### PR TITLE
feat(trace-eap-waterfall): Updating occurence id from /trace/ endpoint

### DIFF
--- a/src/sentry/snuba/trace.py
+++ b/src/sentry/snuba/trace.py
@@ -111,7 +111,7 @@ def _serialize_rpc_issue(event: dict[str, Any], group_cache: dict[int, Group]) -
             issue = Group.objects.get(id=issue_id, project__id=occurrence.project_id)
             group_cache[issue_id] = issue
         return SerializedIssue(
-            event_id=occurrence.id,
+            event_id=occurrence.event_id,
             project_id=occurrence.project_id,
             project_slug=span["project.slug"],
             start_timestamp=span["precise.start_ts"],

--- a/tests/snuba/api/endpoints/test_organization_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_trace.py
@@ -372,6 +372,7 @@ class OrganizationEventsTraceEndpointTest(
         assert len(child["occurrences"]) == 1
         error_event = child["occurrences"][0]
         assert error_event is not None
+        assert error_event["event_id"] == self.root_event.event_id
         assert error_event["description"] == "File IO on Main Thread"
         assert error_event["project_slug"] == self.project.slug
         assert error_event["level"] == "info"


### PR DESCRIPTION
`occurence.id` does not map to the the id needed by Issues to load the event's details. This is a regression from the /events-trace/ to /trace/ migration. 
<img width="748" height="205" alt="Screenshot 2025-09-04 at 3 26 51 PM" src="https://github.com/user-attachments/assets/852fc3e9-9fc2-4a70-aa17-b871d2adb43d" />

<img width="1091" height="618" alt="Screenshot 2025-09-04 at 3 25 28 PM" src="https://github.com/user-attachments/assets/a5c56d33-7b0a-4184-8756-fc0293d50722" />


