### PR TITLE
feat(preprod): support multiple apps in the status check

### DIFF
--- a/bin/preprod/trigger_size_status_check
+++ b/bin/preprod/trigger_size_status_check
@@ -200,8 +200,9 @@ def main() -> None:
 
         # Clean up existing artifacts for this commit to make script idempotent
         logger.info("\n🧹 Cleaning up existing artifacts for commit %s...", COMMIT_SHA[:8])
-        existing_artifacts = PreprodArtifact.get_sibling_artifacts_for_commit(
-            commit_comparison, project=project
+        existing_artifacts = PreprodArtifact.objects.filter(
+            commit_comparison=commit_comparison,
+            project__organization_id=project.organization_id,
         )
         if existing_artifacts.exists():
             # Delete size metrics first (foreign key constraint)

--- a/bin/preprod/trigger_size_status_check
+++ b/bin/preprod/trigger_size_status_check
@@ -18,7 +18,7 @@ from sentry.preprod.vcs.status_checks.tasks import create_preprod_status_check_t
 # Configuration #
 #################
 ORG_SLUG = "sentry"
-PROJECT_SLUG = "hackernews"
+PROJECT_SLUG = "internal"
 REPO_NAME = "EmergeTools/hackernews"
 COMMIT_SHA = "db2b4ae626b458b4be651019f1a7c112406c003e"
 
@@ -38,7 +38,7 @@ APPS = [
     },
 ]
 
-CURRENT_TEST = "mixed_states"
+CURRENT_TEST = "multiple_metrics"
 
 
 TEST_CASES = {
@@ -73,32 +73,77 @@ TEST_CASES = {
         "description": "Testing mixed states: some analyzed, some processing",
         "mixed": True,  # Special flag for mixed state logic
     },
+    "multiple_metrics": {
+        "state": PreprodArtifact.ArtifactState.PROCESSED,
+        "description": "Testing multiple metric types per artifact (main app + watch/dynamic features)",
+        "create_metrics": True,
+        "create_multiple_metrics": True,  # Special flag for creating multiple metrics per artifact
+    },
 }
 
 
-def create_size_metrics(preprod_artifact: PreprodArtifact, app_config: dict) -> None:
+def create_size_metrics(
+    preprod_artifact: PreprodArtifact, app_config: dict, create_multiple: bool = False
+) -> None:
     """Create size analysis metrics for testing."""
     logger.info("📊 Creating size analysis metrics for %s...", app_config["app_id"])
 
     # Different sizes based on platform for variety
     if "android" in app_config["app_id"].lower():
-        download_size = 4 * 1024 * 1024  # 4.0 MB for Android
-        install_size = int(8.2 * 1024 * 1024)  # 8.2 MB for Android
+        main_download_size = 4 * 1024 * 1024  # 4.0 MB for Android
+        main_install_size = int(8.2 * 1024 * 1024)  # 8.2 MB for Android
     else:
-        download_size = 3 * 1024 * 1024  # 3.0 MB for iOS
-        install_size = int(6.8 * 1024 * 1024)  # 6.8 MB for iOS
+        main_download_size = 3 * 1024 * 1024  # 3.0 MB for iOS
+        main_install_size = int(6.8 * 1024 * 1024)  # 6.8 MB for iOS
 
-    current_size_metrics = PreprodArtifactSizeMetrics.objects.create(
+    # Create main artifact metrics
+    main_metrics = PreprodArtifactSizeMetrics.objects.create(
         preprod_artifact=preprod_artifact,
         metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
         state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
-        min_download_size=download_size,
-        max_download_size=download_size,
-        min_install_size=install_size,
-        max_install_size=install_size,
+        min_download_size=main_download_size,
+        max_download_size=main_download_size,
+        min_install_size=main_install_size,
+        max_install_size=main_install_size,
         processing_version="1.0",
     )
-    logger.info("  ✓ Created current size metrics: %s", current_size_metrics.id)
+    logger.info("  ✓ Created main artifact metrics: %s", main_metrics.id)
+
+    if create_multiple:
+        # Create additional metrics based on platform
+        if "android" in app_config["app_id"].lower():
+            # Android Dynamic Feature
+            feature_download_size = 1024 * 1024  # 1.0 MB
+            feature_install_size = int(1.5 * 1024 * 1024)  # 1.5 MB
+
+            feature_metrics = PreprodArtifactSizeMetrics.objects.create(
+                preprod_artifact=preprod_artifact,
+                metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.ANDROID_DYNAMIC_FEATURE,
+                state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+                min_download_size=feature_download_size,
+                max_download_size=feature_download_size,
+                min_install_size=feature_install_size,
+                max_install_size=feature_install_size,
+                processing_version="1.0",
+                identifier="premium_features",
+            )
+            logger.info("  ✓ Created dynamic feature metrics: %s", feature_metrics.id)
+        else:
+            # iOS Watch App
+            watch_download_size = 512 * 1024  # 512 KB
+            watch_install_size = 1024 * 1024  # 1.0 MB
+
+            watch_metrics = PreprodArtifactSizeMetrics.objects.create(
+                preprod_artifact=preprod_artifact,
+                metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.WATCH_ARTIFACT,
+                state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+                min_download_size=watch_download_size,
+                max_download_size=watch_download_size,
+                min_install_size=watch_install_size,
+                max_install_size=watch_install_size,
+                processing_version="1.0",
+            )
+            logger.info("  ✓ Created watch app metrics: %s", watch_metrics.id)
 
     # Note: Not creating previous artifacts for comparison in this test script
     # In production, size comparison would be calculated against historical data
@@ -151,6 +196,40 @@ def print_expected_output(test_case: str, artifacts: list[PreprodArtifact]) -> N
                 download_size,
                 install_size,
             )
+    elif test_case == "multiple_metrics":
+        logger.info("   ✅ Builds processed successfully with multiple metrics per artifact")
+        for artifact in artifacts:
+            # Show different sizes based on platform for demo
+            if "android" in artifact.app_id.lower():
+                # Main Android app
+                logger.info(
+                    "   | %s | %s (%s) | 4.0 MB | 🔺 2.0 KB | 8.2 MB | 🔺 28.0 KB | N/A |",
+                    artifact.app_id,
+                    artifact.build_version,
+                    artifact.build_number,
+                )
+                # Android dynamic feature
+                logger.info(
+                    "   | %s (Dynamic Feature) | %s (%s) | 1.0 MB | 🔺 0.5 KB | 1.5 MB | 🔺 1.0 KB | N/A |",
+                    artifact.app_id,
+                    artifact.build_version,
+                    artifact.build_number,
+                )
+            else:
+                # Main iOS app
+                logger.info(
+                    "   | %s | %s (%s) | 3.0 MB | 🔺 2.0 KB | 6.8 MB | 🔺 28.0 KB | N/A |",
+                    artifact.app_id,
+                    artifact.build_version,
+                    artifact.build_number,
+                )
+                # iOS watch app
+                logger.info(
+                    "   | %s (Watch) | %s (%s) | 512.0 KB | 🔺 1.0 KB | 1.0 MB | 🔺 2.0 KB | N/A |",
+                    artifact.app_id,
+                    artifact.build_version,
+                    artifact.build_number,
+                )
     elif test_case == "mixed_states":
         logger.info("   🔄 Mixed state: 1 build analyzed, 1 build processing")
         for artifact in artifacts:
@@ -287,7 +366,8 @@ def main() -> None:
 
             # Create size metrics if requested
             if create_metrics:
-                create_size_metrics(preprod_artifact, app_config)
+                create_multiple = test_config.get("create_multiple_metrics", False)
+                create_size_metrics(preprod_artifact, app_config, create_multiple)
             else:
                 logger.info("  📊 Skipping size metrics creation for %s", app_config["app_id"])
 

--- a/bin/preprod/trigger_size_status_check
+++ b/bin/preprod/trigger_size_status_check
@@ -1,0 +1,339 @@
+#!/usr/bin/env python
+
+from sentry.runner import configure
+
+configure()
+
+import logging
+import sys
+
+logger = logging.getLogger(__name__)
+
+from sentry.models.commitcomparison import CommitComparison
+from sentry.models.project import Project
+from sentry.preprod.models import PreprodArtifact, PreprodArtifactSizeMetrics
+from sentry.preprod.vcs.status_checks.tasks import create_preprod_status_check_task
+
+#################
+# Configuration #
+#################
+ORG_SLUG = "sentry"
+PROJECT_SLUG = "hackernews"
+REPO_NAME = "EmergeTools/hackernews"
+COMMIT_SHA = "db2b4ae626b458b4be651019f1a7c112406c003e"
+
+# Multiple apps for monorepo scenario - sorted by app ID for stable ordering
+APPS = [
+    {
+        "app_id": "com.emerge.hackernews.android",
+        "platform": "Android",
+        "build_version": "1.0.3",
+        "build_number": 14,
+    },
+    {
+        "app_id": "com.emerge.hackernews.ios",
+        "platform": "iOS",
+        "build_version": "1.0.3",
+        "build_number": 42,
+    },
+]
+
+CURRENT_TEST = "mixed_states"
+
+
+TEST_CASES = {
+    "uploading": {
+        "state": PreprodArtifact.ArtifactState.UPLOADING,
+        "description": "Testing uploading/processing state",
+        "create_metrics": False,
+    },
+    "uploaded": {
+        "state": PreprodArtifact.ArtifactState.UPLOADED,
+        "description": "Testing uploaded state (still processing)",
+        "create_metrics": False,
+    },
+    "failed": {
+        "state": PreprodArtifact.ArtifactState.FAILED,
+        "description": "Testing failed state with error message",
+        "create_metrics": False,
+        "error_code": PreprodArtifact.ErrorCode.ARTIFACT_PROCESSING_TIMEOUT,
+        "error_message": "Processing timeout - artifact too large",
+    },
+    "processed_no_metrics": {
+        "state": PreprodArtifact.ArtifactState.PROCESSED,
+        "description": "Testing processed state without size analysis",
+        "create_metrics": False,
+    },
+    "processed_with_metrics": {
+        "state": PreprodArtifact.ArtifactState.PROCESSED,
+        "description": "Testing processed state with full size analysis table",
+        "create_metrics": True,
+    },
+    "mixed_states": {
+        "description": "Testing mixed states: some analyzed, some processing",
+        "mixed": True,  # Special flag for mixed state logic
+    },
+}
+
+
+def create_size_metrics(preprod_artifact: PreprodArtifact, app_config: dict) -> None:
+    """Create size analysis metrics for testing."""
+    logger.info("📊 Creating size analysis metrics for %s...", app_config["app_id"])
+
+    # Different sizes based on platform for variety
+    if "android" in app_config["app_id"].lower():
+        download_size = 4 * 1024 * 1024  # 4.0 MB for Android
+        install_size = int(8.2 * 1024 * 1024)  # 8.2 MB for Android
+    else:
+        download_size = 3 * 1024 * 1024  # 3.0 MB for iOS
+        install_size = int(6.8 * 1024 * 1024)  # 6.8 MB for iOS
+
+    current_size_metrics = PreprodArtifactSizeMetrics.objects.create(
+        preprod_artifact=preprod_artifact,
+        metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+        state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+        min_download_size=download_size,
+        max_download_size=download_size,
+        min_install_size=install_size,
+        max_install_size=install_size,
+        processing_version="1.0",
+    )
+    logger.info("  ✓ Created current size metrics: %s", current_size_metrics.id)
+
+    # Note: Not creating previous artifacts for comparison in this test script
+    # In production, size comparison would be calculated against historical data
+
+
+def print_expected_output(test_case: str, artifacts: list[PreprodArtifact]) -> None:
+    """Print expected status check output for the test case."""
+    logger.info("\n📋 Expected status check output for '%s' (%s apps):", test_case, len(artifacts))
+    logger.info("   📊 **Bundle Analysis:**")
+    logger.info("   | Name | Version | Download | Change | Install | Change | Approval |")
+
+    if test_case in ["uploading", "uploaded"]:
+        logger.info("   ⏳ Builds processing...")
+        for artifact in artifacts:
+            logger.info(
+                "   | %s | %s (%s) | Processing... | - | Processing... | - | N/A |",
+                artifact.app_id,
+                artifact.build_version,
+                artifact.build_number,
+            )
+    elif test_case == "failed":
+        logger.info("   ❌ Builds failed.")
+        logger.info("   | Name | Version | Error |")
+        logger.info("   |------|---------|-------|")  # noqa
+        for artifact in artifacts:
+            logger.info(
+                "   | %s | %s (%s) | %s |",
+                artifact.app_id,
+                artifact.build_version,
+                artifact.build_number,
+                artifact.error_message,
+            )
+    elif test_case == "processed_no_metrics":
+        logger.info("   ✅ Builds processed successfully.")
+    elif test_case == "processed_with_metrics":
+        logger.info("   ✅ Builds processed successfully")
+        for artifact in artifacts:
+            # Show different sizes based on platform for demo
+            if "android" in artifact.app_id.lower():
+                download_size = "4.0 MB"
+                install_size = "8.2 MB"
+            else:
+                download_size = "3.0 MB"
+                install_size = "6.8 MB"
+            logger.info(
+                "   | %s | %s (%s) | %s | 🔺 2.0 KB | %s | 🔺 28.0 KB | N/A |",
+                artifact.app_id,
+                artifact.build_version,
+                artifact.build_number,
+                download_size,
+                install_size,
+            )
+    elif test_case == "mixed_states":
+        logger.info("   🔄 Mixed state: 1 build analyzed, 1 build processing")
+        for artifact in artifacts:
+            if artifact.state == PreprodArtifact.ArtifactState.PROCESSED:
+                # Show completed analysis
+                if "android" in artifact.app_id.lower():
+                    download_size = "4.0 MB"
+                    install_size = "8.2 MB"
+                else:
+                    download_size = "3.0 MB"
+                    install_size = "6.8 MB"
+                logger.info(
+                    "   | %s | %s (%s) | %s | 🔺 2.0 KB | %s | 🔺 28.0 KB | N/A |",
+                    artifact.app_id,
+                    artifact.build_version,
+                    artifact.build_number,
+                    download_size,
+                    install_size,
+                )
+            else:
+                # Show processing state
+                logger.info(
+                    "   | %s | %s (%s) | Processing... | - | Processing... | - | N/A |",
+                    artifact.app_id,
+                    artifact.build_version,
+                    artifact.build_number,
+                )
+
+
+def main() -> None:
+    """Main function to test size analysis status checks."""
+    try:
+        # Get project
+        project = Project.objects.get(slug=PROJECT_SLUG, organization__slug=ORG_SLUG)
+        logger.info("Found project: %s (ID: %s)", project.name, project.id)
+
+        # Get or create commit comparison
+        commit_comparison, created = CommitComparison.objects.get_or_create(
+            head_repo_name=REPO_NAME,
+            head_sha=COMMIT_SHA,
+            provider="github",
+            organization_id=project.organization.id,
+        )
+        logger.info(
+            "%s commit comparison: %s", "Created" if created else "Found", commit_comparison.id
+        )
+
+        # Clean up existing artifacts for this commit to make script idempotent
+        logger.info("\n🧹 Cleaning up existing artifacts for commit %s...", COMMIT_SHA[:8])
+        existing_artifacts = PreprodArtifact.get_sibling_artifacts_for_commit(
+            commit_comparison, project=project
+        )
+        if existing_artifacts.exists():
+            # Delete size metrics first (foreign key constraint)
+            from sentry.preprod.models import PreprodArtifactSizeMetrics
+
+            size_metrics_count = PreprodArtifactSizeMetrics.objects.filter(
+                preprod_artifact__in=existing_artifacts
+            ).count()
+            PreprodArtifactSizeMetrics.objects.filter(
+                preprod_artifact__in=existing_artifacts
+            ).delete()
+
+            # Delete the artifacts
+            artifact_count = existing_artifacts.count()
+            existing_artifacts.delete()
+            logger.info(
+                "  ✓ Deleted %s existing artifacts and %s size metrics",
+                artifact_count,
+                size_metrics_count,
+            )
+        else:
+            logger.info("  ✓ No existing artifacts found (clean slate)")
+
+        # Validate test case
+        if CURRENT_TEST not in TEST_CASES:
+            raise ValueError(
+                f"Invalid test case: {CURRENT_TEST}. Available: {list(TEST_CASES.keys())}"
+            )
+
+        test_config = TEST_CASES[CURRENT_TEST]
+        logger.info("🧪 Running test case: %s", CURRENT_TEST)
+        logger.info("📝 Description: %s", test_config["description"])
+        logger.info("📱 Creating %s apps for monorepo scenario", len(APPS))
+
+        created_artifacts = []
+
+        # Create artifacts for each app (sorted by app_id for consistent ordering)
+        for i, app_config in enumerate(sorted(APPS, key=lambda x: x["app_id"])):
+            logger.info(
+                "\n📦 Creating artifact for %s (%s)...",
+                app_config["app_id"],
+                app_config["platform"],
+            )
+
+            # Handle mixed states case - alternate between processed and uploading
+            if test_config.get("mixed"):
+                if i == 0:  # First app: completed with metrics
+                    state = PreprodArtifact.ArtifactState.PROCESSED
+                    create_metrics = True
+                    logger.info("  🎯 Mixed state: This app will be PROCESSED with metrics")
+                else:  # Second app: still uploading
+                    state = PreprodArtifact.ArtifactState.UPLOADING
+                    create_metrics = False
+                    logger.info("  🎯 Mixed state: This app will be UPLOADING")
+            else:
+                state = test_config["state"]
+                create_metrics = test_config["create_metrics"]
+
+            # Create artifact data based on test case and app config
+            artifact_data = {
+                "project": project,
+                "app_id": app_config["app_id"],
+                "commit_comparison": commit_comparison,
+                "state": state,
+                "build_version": app_config["build_version"],
+                "build_number": app_config["build_number"],
+            }
+
+            # Add error code and message for failed state
+            if state == PreprodArtifact.ArtifactState.FAILED:
+                artifact_data["error_code"] = test_config.get("error_code")
+                artifact_data["error_message"] = test_config.get("error_message", "Unknown error")
+
+            # Create the preprod artifact
+            preprod_artifact = PreprodArtifact.objects.create(**artifact_data)
+            created_artifacts.append(preprod_artifact)
+            logger.info(
+                "  ✓ Created artifact: %s (state: %s)",
+                preprod_artifact.id,
+                preprod_artifact.get_state_display(),
+            )
+
+            # Create size metrics if requested
+            if create_metrics:
+                create_size_metrics(preprod_artifact, app_config)
+            else:
+                logger.info("  📊 Skipping size metrics creation for %s", app_config["app_id"])
+
+        # Call the status check task for the first artifact (it will find all artifacts for the commit)
+        logger.info(
+            "\n🚀 Calling create_preprod_status_check_task with artifact %s...",
+            created_artifacts[0].id,
+        )
+        result = create_preprod_status_check_task(preprod_artifact_id=created_artifacts[0].id)
+        logger.info("Task result: %s", result)
+        logger.info("✅ Status check function called successfully!")
+
+        # Show GitHub link
+        logger.info("\n🔍 Check your GitHub status check at:")
+        logger.info("   https://github.com/%s/commit/%s", REPO_NAME, COMMIT_SHA)
+
+        # Show expected output
+        print_expected_output(CURRENT_TEST, created_artifacts)
+
+        # Show other test cases
+        logger.info("\n💡 To test other cases, change CURRENT_TEST to:")
+        for case, config in TEST_CASES.items():
+            marker = "👉" if case == CURRENT_TEST else "  "
+            logger.info("   %s '%s' - %s", marker, case, config["description"])
+
+        logger.info("\n🔧 Debug: Created %s artifacts:", len(created_artifacts))
+        for artifact in created_artifacts:
+            logger.info(
+                "  - %s: ID %s, State: %s",
+                artifact.app_id,
+                artifact.id,
+                artifact.get_state_display(),
+            )
+
+    except Project.DoesNotExist:
+        logger.exception("❌ Project not found: %s/%s", ORG_SLUG, PROJECT_SLUG)
+        logger.info("Available projects:")
+        for p in Project.objects.select_related("organization").all()[:10]:
+            logger.info("  - %s/%s", p.organization.slug, p.slug)
+        sys.exit(1)
+    except Exception as e:
+        logger.exception("❌ Error: %s", e)
+        import traceback
+
+        traceback.print_exc()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/sentry/preprod/models.py
+++ b/src/sentry/preprod/models.py
@@ -130,23 +130,23 @@ class PreprodArtifact(DefaultFieldsModel):
     # An identifier for the main binary
     main_binary_identifier = models.CharField(max_length=255, db_index=True, null=True)
 
-    @classmethod
-    def get_sibling_artifacts_for_commit(cls, commit_comparison, project=None, include_self=True):
+    def get_sibling_artifacts_for_commit(self):
         """
         Get all artifacts for the same commit comparison (monorepo scenario).
 
-        Args:
-            commit_comparison: The CommitComparison to find artifacts for
-            project: Optional project filter (if None, finds across all projects)
-            include_self: Whether to include all artifacts or just siblings
+        Note: Always includes the calling artifact itself along with any siblings.
+        Results are filtered by the current artifact's organization for security.
 
         Returns:
             QuerySet of PreprodArtifact objects, ordered by app_id for stable results
         """
-        queryset = cls.objects.filter(commit_comparison=commit_comparison)
-        if project:
-            queryset = queryset.filter(project=project)
-        return queryset.order_by("app_id")
+        if not self.commit_comparison:
+            return PreprodArtifact.objects.none()
+
+        return PreprodArtifact.objects.filter(
+            commit_comparison=self.commit_comparison,
+            project__organization_id=self.project.organization_id,
+        ).order_by("app_id")
 
     class Meta:
         app_label = "preprod"

--- a/src/sentry/preprod/models.py
+++ b/src/sentry/preprod/models.py
@@ -130,7 +130,7 @@ class PreprodArtifact(DefaultFieldsModel):
     # An identifier for the main binary
     main_binary_identifier = models.CharField(max_length=255, db_index=True, null=True)
 
-    def get_sibling_artifacts_for_commit(self):
+    def get_sibling_artifacts_for_commit(self) -> models.QuerySet["PreprodArtifact"]:
         """
         Get all artifacts for the same commit comparison (monorepo scenario).
 

--- a/src/sentry/preprod/models.py
+++ b/src/sentry/preprod/models.py
@@ -130,6 +130,24 @@ class PreprodArtifact(DefaultFieldsModel):
     # An identifier for the main binary
     main_binary_identifier = models.CharField(max_length=255, db_index=True, null=True)
 
+    @classmethod
+    def get_sibling_artifacts_for_commit(cls, commit_comparison, project=None, include_self=True):
+        """
+        Get all artifacts for the same commit comparison (monorepo scenario).
+
+        Args:
+            commit_comparison: The CommitComparison to find artifacts for
+            project: Optional project filter (if None, finds across all projects)
+            include_self: Whether to include all artifacts or just siblings
+
+        Returns:
+            QuerySet of PreprodArtifact objects, ordered by app_id for stable results
+        """
+        queryset = cls.objects.filter(commit_comparison=commit_comparison)
+        if project:
+            queryset = queryset.filter(project=project)
+        return queryset.order_by("app_id")
+
     class Meta:
         app_label = "preprod"
         db_table = "sentry_preprodartifact"

--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -338,7 +338,7 @@ def _assemble_preprod_artifact_file(
 
 
 def _assemble_preprod_artifact_size_analysis(
-    assemble_result: AssembleResult, project, artifact_id, org_id
+    assemble_result: AssembleResult, project, artifact_id: int, org_id: int
 ):
     preprod_artifact = None
     try:
@@ -372,7 +372,6 @@ def _assemble_preprod_artifact_size_analysis(
             assemble_result.bundle_temp_file.read()
         )
 
-        # Update size metrics in its own transaction
         with transaction.atomic(router.db_for_write(PreprodArtifactSizeMetrics)):
             # TODO(preprod): parse this from the treemap json and handle other artifact types
             size_metrics, created = PreprodArtifactSizeMetrics.objects.update_or_create(
@@ -401,7 +400,6 @@ def _assemble_preprod_artifact_size_analysis(
         )
 
     except Exception as e:
-        # Handle size analysis processing failures
         logger.exception(
             "Failed to process size analysis results",
             extra={
@@ -412,7 +410,6 @@ def _assemble_preprod_artifact_size_analysis(
             },
         )
 
-        # Update size metrics to failed state
         with transaction.atomic(router.db_for_write(PreprodArtifactSizeMetrics)):
             PreprodArtifactSizeMetrics.objects.update_or_create(
                 preprod_artifact=preprod_artifact,

--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -244,8 +244,8 @@ def create_preprod_artifact(
             # TODO(preprod): add gating to only create if has quota
             PreprodArtifactSizeMetrics.objects.get_or_create(
                 preprod_artifact=preprod_artifact,
+                metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
                 defaults={
-                    "metrics_artifact_type": PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
                     "state": PreprodArtifactSizeMetrics.SizeAnalysisState.PENDING,
                 },
             )

--- a/src/sentry/preprod/vcs/status_checks/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/tasks.py
@@ -99,7 +99,7 @@ def create_preprod_status_check_task(preprod_artifact_id: int) -> None:
         )
         return
 
-    size_metrics_map = {}
+    size_metrics_map: dict[int, list[PreprodArtifactSizeMetrics]] = {}
     if all_artifacts:
         artifact_ids = [artifact.id for artifact in all_artifacts]
         size_metrics_qs = PreprodArtifactSizeMetrics.objects.filter(

--- a/src/sentry/preprod/vcs/status_checks/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/tasks.py
@@ -58,16 +58,6 @@ def create_preprod_status_check_task(preprod_artifact_id: int) -> None:
         extra={"artifact_id": preprod_artifact.id},
     )
 
-    # Get all artifacts for this commit (will be single item if no siblings)
-    if preprod_artifact.commit_comparison:
-        all_artifacts = list(
-            PreprodArtifact.get_sibling_artifacts_for_commit(
-                preprod_artifact.commit_comparison, project=preprod_artifact.project
-            )
-        )
-    else:
-        all_artifacts = [preprod_artifact]
-
     if not preprod_artifact.commit_comparison:
         logger.info(
             "preprod.status_checks.create.no_commit_comparison",
@@ -86,6 +76,9 @@ def create_preprod_status_check_task(preprod_artifact_id: int) -> None:
             },
         )
         return
+
+    # Get all artifacts for this commit across all projects in the organization
+    all_artifacts = list(preprod_artifact.get_sibling_artifacts_for_commit())
 
     client, repository = _get_status_check_client(preprod_artifact.project, commit_comparison)
     if not client or not repository:

--- a/src/sentry/preprod/vcs/status_checks/templates.py
+++ b/src/sentry/preprod/vcs/status_checks/templates.py
@@ -226,7 +226,7 @@ def _create_sorted_artifact_metric_rows(
     Returns one row per metric type per artifact, sorted so that all metrics for each
     artifact appear together, with MAIN_ARTIFACT first, then WATCH_ARTIFACT, etc.
     """
-    rows = []
+    rows: list[tuple[PreprodArtifact, PreprodArtifactSizeMetrics | None]] = []
 
     for artifact in artifacts:
         size_metrics_list = size_metrics_map.get(artifact.id, [])

--- a/src/sentry/preprod/vcs/status_checks/templates.py
+++ b/src/sentry/preprod/vcs/status_checks/templates.py
@@ -1,138 +1,209 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from enum import Enum
 
 from django.utils.translation import gettext_lazy as _
+from django.utils.translation import ngettext
 
-from sentry.preprod.models import PreprodArtifact
-
-
-@dataclass(frozen=True)
-class _StatusCheckData:
-    """Data for formatting status check messages."""
-
-    build_id: int
-    app_id: str
-    version: str
+from sentry.preprod.models import PreprodArtifact, PreprodArtifactSizeMetrics
 
 
-@dataclass(frozen=True)
-class _SuccessStatusCheckData(_StatusCheckData):
-    """Extended data for successful status checks with size metrics."""
-
-    download_size: str
-    download_change: str
-    install_size: str
-    install_change: str
+class _OverallStatus(Enum):
+    PROCESSING = "processing"
+    FAILED = "failed"
+    SUCCESS = "success"
 
 
-@dataclass(frozen=True)
-class _FailureStatusCheckData(_StatusCheckData):
-    """Extended data for failed status checks with error information."""
-
-    error_message: str
+_SIZE_ANALYZER_TITLE_BASE = _("Size Analysis")
 
 
 def format_status_check_messages(
-    preprod_artifact: PreprodArtifact,
+    artifacts: list[PreprodArtifact],
+    size_metrics_map: dict[int, PreprodArtifactSizeMetrics],
 ) -> tuple[str, str, str]:
     """
-    Format status check messages based on artifact state.
+    Args:
+        artifacts: List of PreprodArtifact objects
+        size_metrics_map: Dict mapping artifact_id to PreprodArtifactSizeMetrics
 
     Returns:
         tuple: (title, subtitle, summary)
     """
-    version_parts = []
-    if preprod_artifact.build_version:
-        version_parts.append(preprod_artifact.build_version)
-    if preprod_artifact.build_number:
-        version_parts.append(f"({preprod_artifact.build_number})")
-    version_string = " ".join(version_parts) if version_parts else "Unknown"
+    if not artifacts:
+        raise ValueError("Cannot format messages for empty artifact list")
 
-    base_data = _StatusCheckData(
-        build_id=preprod_artifact.id,
-        app_id=preprod_artifact.app_id or "--",
-        version=version_string,
-    )
+    title = _SIZE_ANALYZER_TITLE_BASE
 
-    title = str(_SIZE_ANALYZER_TITLE_BASE)
+    analyzed_count = 0
+    processing_count = 0
+    errored_count = 0
 
-    match preprod_artifact.state:
-        case PreprodArtifact.ArtifactState.UPLOADING | PreprodArtifact.ArtifactState.UPLOADED:
-            summary = _SIZE_ANALYZER_PROCESSING_SUMMARY_TEMPLATE % base_data.__dict__
-            subtitle = str(_SIZE_ANALYZER_SUBTITLE_PROCESSING)
-        case PreprodArtifact.ArtifactState.FAILED:
-            failure_data = _FailureStatusCheckData(
-                build_id=preprod_artifact.id,
-                app_id=preprod_artifact.app_id or "--",
-                version=version_string,
-                error_message=preprod_artifact.error_message or "Unknown error",
-            )
-            summary = _SIZE_ANALYZER_FAILURE_SUMMARY_TEMPLATE % failure_data.__dict__
-            subtitle = str(_SIZE_ANALYZER_SUBTITLE_ERROR)
-        case PreprodArtifact.ArtifactState.PROCESSED:
-            from sentry.preprod.models import PreprodArtifactSizeMetrics
-
-            current_metrics = PreprodArtifactSizeMetrics.objects.filter(
-                preprod_artifact=preprod_artifact,
-                metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
-                state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
-            ).first()
-
-            if current_metrics:
-                success_data = _SuccessStatusCheckData(
-                    build_id=preprod_artifact.id,
-                    app_id=preprod_artifact.app_id or "--",
-                    version=version_string,
-                    download_size=_format_file_size(current_metrics.min_download_size),
-                    download_change="N/A",
-                    install_size=_format_file_size(current_metrics.min_install_size),
-                    install_change="N/A",
-                )
-                summary = _SIZE_ANALYZER_SUCCESS_SUMMARY_TEMPLATE % success_data.__dict__
+    for artifact in artifacts:
+        if artifact.state == PreprodArtifact.ArtifactState.FAILED:
+            errored_count += 1
+        elif artifact.state == PreprodArtifact.ArtifactState.PROCESSED:
+            # Check if size analysis is completed using preloaded metrics
+            size_metrics = size_metrics_map.get(artifact.id)
+            if (
+                size_metrics
+                and size_metrics.state == PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED
+            ):
+                analyzed_count += 1
             else:
-                # TODO(telkins): what to do in this case?
-                summary = (
-                    _("Build %(build_id)s for `%(app_id)s` processed successfully.")
-                    % base_data.__dict__
-                )
-            subtitle = _generate_success_subtitle(preprod_artifact)
-        case _:
-            raise ValueError(f"Invalid artifact state: {preprod_artifact.state}")
+                # Artifact is processed but analysis is still pending -> count as processing
+                processing_count += 1
+        else:
+            # UPLOADING or UPLOADED states
+            processing_count += 1
 
-    # Convert lazy translation strings to regular strings for JSON serialization
+    # Build subtitle with counts
+    parts = []
+    if analyzed_count > 0:
+        parts.append(
+            ngettext("1 build analyzed", "{} builds analyzed", analyzed_count).format(
+                analyzed_count
+            )
+        )
+    if processing_count > 0:
+        parts.append(
+            ngettext("1 build processing", "{} builds processing", processing_count).format(
+                processing_count
+            )
+        )
+    if errored_count > 0:
+        parts.append(
+            ngettext("1 build errored", "{} builds errored", errored_count).format(errored_count)
+        )
+
+    subtitle = ", ".join(parts)
+
+    # Determine overall status
+    if errored_count > 0:
+        overall_status = _OverallStatus.FAILED
+    elif processing_count > 0:
+        overall_status = _OverallStatus.PROCESSING
+    else:
+        overall_status = _OverallStatus.SUCCESS
+
+    # Generate summary table
+    match overall_status:
+        case _OverallStatus.PROCESSING:
+            summary = _format_processing_summary(artifacts, size_metrics_map)
+        case _OverallStatus.FAILED:
+            summary = _format_failure_summary(artifacts)
+        case _OverallStatus.SUCCESS:
+            summary = _format_success_summary(artifacts, size_metrics_map)
+
     return str(title), str(subtitle), str(summary)
 
 
-_SIZE_ANALYZER_TITLE_BASE = _("Size Analysis")
-_SIZE_ANALYZER_SUBTITLE_PROCESSING = _("Processing...")
-_SIZE_ANALYZER_SUBTITLE_SUCCESS = _("Complete")
-_SIZE_ANALYZER_SUBTITLE_ERROR = _("Error processing")
-_SIZE_ANALYZER_SUBTITLE_COMPLETE_FIRST_BUILD = _("1 build analyzed")
-# TODO: Re-add these when size comparison is implemented
-# _SIZE_ANALYZER_SUBTITLE_SIZE_INCREASED = _("1 build increased in size")
-# _SIZE_ANALYZER_SUBTITLE_SIZE_DECREASED = _("1 build decreased in size")
-# _SIZE_ANALYZER_SUBTITLE_NO_CHANGE = _("1 build, no size change")
+def _format_processing_summary(
+    artifacts: list[PreprodArtifact], size_metrics_map: dict[int, PreprodArtifactSizeMetrics]
+) -> str:
+    """Format summary for artifacts in mixed processing/analyzed state."""
+    table_rows = []
+    for artifact in artifacts:
+        version_parts = []
+        if artifact.build_version:
+            version_parts.append(artifact.build_version)
+        if artifact.build_number:
+            version_parts.append(f"({artifact.build_number})")
+        version_string = " ".join(version_parts) if version_parts else _("Unknown")
 
-_SIZE_ANALYZER_PROCESSING_SUMMARY_TEMPLATE = _(
-    """| Name | Version | Download | Change | Install | Change | Approval |
-|------|---------|----------|--------|---------|--------|----------|
-| `%(app_id)s` | %(version)s | Processing... | - | Processing... | - | N/A |
+        # Check if this specific artifact is analyzed or still processing
+        if artifact.state == PreprodArtifact.ArtifactState.PROCESSED:
+            size_metrics = size_metrics_map.get(artifact.id)
+            if (
+                size_metrics
+                and size_metrics.state == PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED
+            ):
+                # This artifact is analyzed - show actual sizes
+                download_size = _format_file_size(size_metrics.max_download_size)
+                install_size = _format_file_size(size_metrics.max_install_size)
+                download_change = _("N/A")
+                install_change = _("N/A")
+                table_rows.append(
+                    f"| `{artifact.app_id or '--'}` | {version_string} | {download_size} | {download_change} | {install_size} | {install_change} | {_('N/A')} |"
+                )
+                continue
 
-Analysis will be updated when processing completes."""
-)
-_SIZE_ANALYZER_FAILURE_SUMMARY_TEMPLATE = _(
-    """| Name | Version | Error |
-|------|---------|-------|
-| `%(app_id)s` | %(version)s | %(error_message)s |
-"""
-)
-_SIZE_ANALYZER_SUCCESS_SUMMARY_TEMPLATE = _(
-    """| Name | Version | Download | Change | Install | Change | Approval |
-|------|---------|----------|--------|---------|--------|----------|
-| `%(app_id)s` | %(version)s | %(download_size)s | %(download_change)s | %(install_size)s | %(install_change)s | N/A |
-"""
-)
+        # This artifact is still processing
+        table_rows.append(
+            f"| `{artifact.app_id or '--'}` | {version_string} | {_('Processing...')} | - | {_('Processing...')} | - | {_('N/A')} |"
+        )
+
+    return _(
+        "| Name | Version | Download | Change | Install | Change | Approval |\n"
+        "|------|---------|----------|--------|---------|--------|----------|\n"
+        "{table_rows}"
+    ).format(table_rows="\n".join(table_rows))
+
+
+def _format_failure_summary(artifacts: list[PreprodArtifact]) -> str:
+    """Format summary for multiple artifacts with failures."""
+    table_rows = []
+    for artifact in artifacts:
+        version_parts = []
+        if artifact.build_version:
+            version_parts.append(artifact.build_version)
+        if artifact.build_number:
+            version_parts.append(f"({artifact.build_number})")
+        version_string = " ".join(version_parts) if version_parts else _("Unknown")
+
+        if artifact.state == PreprodArtifact.ArtifactState.FAILED:
+            error_msg = artifact.error_message or _("Unknown error")
+            table_rows.append(f"| `{artifact.app_id or '--'}` | {version_string} | {error_msg} |")
+        else:
+            # Show successful/processing ones too in mixed state
+            table_rows.append(
+                f"| `{artifact.app_id or '--'}` | {version_string} | {_('Processing...')} |"
+            )
+
+    return _("| Name | Version | Error |\n" "|------|---------|-------|\n" "{table_rows}").format(
+        table_rows="\n".join(table_rows)
+    )
+
+
+def _format_success_summary(
+    artifacts: list[PreprodArtifact], size_metrics_map: dict[int, PreprodArtifactSizeMetrics]
+) -> str:
+    """Format summary for multiple successful artifacts with size data."""
+    table_rows = []
+    for artifact in artifacts:
+        version_parts = []
+        if artifact.build_version:
+            version_parts.append(artifact.build_version)
+        if artifact.build_number:
+            version_parts.append(f"({artifact.build_number})")
+        version_string = " ".join(version_parts) if version_parts else _("Unknown")
+
+        # Get size metrics from preloaded map
+        size_metrics = size_metrics_map.get(artifact.id)
+
+        if (
+            size_metrics
+            and size_metrics.state == PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED
+        ):
+            download_size = _format_file_size(size_metrics.max_download_size)
+            install_size = _format_file_size(size_metrics.max_install_size)
+            # TODO: Calculate actual size changes
+            download_change = _("N/A")
+            install_change = _("N/A")
+        else:
+            download_size = _("Unknown")
+            install_size = _("Unknown")
+            download_change = "-"
+            install_change = "-"
+
+        table_rows.append(
+            f"| `{artifact.app_id or '--'}` | {version_string} | {download_size} | {download_change} | {install_size} | {install_change} | {_('N/A')} |"
+        )
+
+    return _(
+        "| Name | Version | Download | Change | Install | Change | Approval |\n"
+        "|------|---------|----------|--------|---------|--------|----------|\n"
+        "{table_rows}"
+    ).format(table_rows="\n".join(table_rows))
 
 
 def _format_file_size(size_bytes: int | None) -> str:
@@ -146,20 +217,3 @@ def _format_file_size(size_bytes: int | None) -> str:
         return f"{size_bytes / 1024:.1f} KB"
     else:  # B
         return f"{size_bytes} B"
-
-
-def _generate_success_subtitle(preprod_artifact: PreprodArtifact) -> str:
-    """Generate a dynamic subtitle based on size changes for successful builds."""
-    from sentry.preprod.models import PreprodArtifactSizeMetrics
-
-    current_metrics = PreprodArtifactSizeMetrics.objects.filter(
-        preprod_artifact=preprod_artifact,
-        metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
-        state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
-    ).first()
-
-    if not current_metrics:
-        return str(_SIZE_ANALYZER_SUBTITLE_SUCCESS)
-
-    # For now, just show "1 build analyzed" since we're not doing diffing yet
-    return str(_SIZE_ANALYZER_SUBTITLE_COMPLETE_FIRST_BUILD)

--- a/src/sentry/preprod/vcs/status_checks/templates.py
+++ b/src/sentry/preprod/vcs/status_checks/templates.py
@@ -187,11 +187,11 @@ def _format_success_summary(
             download_size = _format_file_size(size_metrics.max_download_size)
             install_size = _format_file_size(size_metrics.max_install_size)
             # TODO: Calculate actual size changes
-            download_change = _("N/A")
-            install_change = _("N/A")
+            download_change = str(_("N/A"))
+            install_change = str(_("N/A"))
         else:
-            download_size = _("Unknown")
-            install_size = _("Unknown")
+            download_size = str(_("Unknown"))
+            install_size = str(_("Unknown"))
             download_change = "-"
             install_change = "-"
 

--- a/tests/sentry/preprod/test_models.py
+++ b/tests/sentry/preprod/test_models.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+from sentry.models.commitcomparison import CommitComparison
+from sentry.preprod.models import PreprodArtifact
+from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import region_silo_test
+
+
+@region_silo_test
+class PreprodArtifactModelTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.organization = self.create_organization(owner=self.user)
+        self.team = self.create_team(organization=self.organization)
+        self.project = self.create_project(
+            teams=[self.team], organization=self.organization, name="test_project"
+        )
+
+    def test_get_sibling_artifacts_for_commit_single_artifact(self):
+        """Test getting artifacts when there's only one artifact for the commit."""
+        commit_comparison = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="a" * 40,
+            base_sha="b" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+            head_ref="feature/test",
+            base_ref="main",
+        )
+
+        artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            app_id="com.example.app",
+            commit_comparison=commit_comparison,
+        )
+
+        artifacts = list(artifact.get_sibling_artifacts_for_commit())
+
+        assert len(artifacts) == 1
+        assert artifacts[0] == artifact
+
+    def test_get_sibling_artifacts_for_commit_multiple_artifacts_same_commit(self):
+        """Test getting artifacts when multiple artifacts exist for the same commit (monorepo)."""
+        commit_comparison = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="a" * 40,
+            base_sha="b" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+            head_ref="feature/test",
+            base_ref="main",
+        )
+
+        artifacts = []
+        app_ids = ["com.example.android", "com.example.ios", "com.example.web"]
+        for app_id in app_ids:
+            artifact = PreprodArtifact.objects.create(
+                project=self.project,
+                state=PreprodArtifact.ArtifactState.PROCESSED,
+                app_id=app_id,
+                commit_comparison=commit_comparison,
+            )
+            artifacts.append(artifact)
+
+        sibling_artifacts = list(artifacts[0].get_sibling_artifacts_for_commit())
+
+        assert len(sibling_artifacts) == 3
+        assert set(sibling_artifacts) == set(artifacts)
+
+    def test_get_sibling_artifacts_for_commit_different_commits_excluded(self):
+        """Test that artifacts from different commits are excluded."""
+        commit_comparison_1 = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="a" * 40,
+            base_sha="b" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+            head_ref="feature/test1",
+            base_ref="main",
+        )
+
+        commit_comparison_2 = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="c" * 40,
+            base_sha="d" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+            head_ref="feature/test2",
+            base_ref="main",
+        )
+
+        artifact_1 = PreprodArtifact.objects.create(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            app_id="com.example.app1",
+            commit_comparison=commit_comparison_1,
+        )
+
+        artifact_2 = PreprodArtifact.objects.create(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            app_id="com.example.app2",
+            commit_comparison=commit_comparison_2,
+        )
+
+        artifacts_1 = list(artifact_1.get_sibling_artifacts_for_commit())
+        assert len(artifacts_1) == 1
+        assert artifacts_1[0] == artifact_1
+
+        artifacts_2 = list(artifact_2.get_sibling_artifacts_for_commit())
+        assert len(artifacts_2) == 1
+        assert artifacts_2[0] == artifact_2
+
+    def test_get_sibling_artifacts_for_commit_cross_org_security(self):
+        """Test that artifacts from different organizations are excluded for security."""
+        # Create second organization
+        other_org = self.create_organization(name="other_org")
+        other_project = self.create_project(organization=other_org, name="other_project")
+
+        # Create commit comparison for first org
+        commit_comparison_org1 = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="a" * 40,
+            base_sha="b" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+            head_ref="feature/test",
+            base_ref="main",
+        )
+
+        # Create commit comparison for second org with same commit SHA
+        commit_comparison_org2 = CommitComparison.objects.create(
+            organization_id=other_org.id,
+            head_sha="a" * 40,  # Same SHA as org1
+            base_sha="b" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+            head_ref="feature/test",
+            base_ref="main",
+        )
+
+        # Create artifacts in each org
+        artifact_org1 = PreprodArtifact.objects.create(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            app_id="com.example.app1",
+            commit_comparison=commit_comparison_org1,
+        )
+
+        artifact_org2 = PreprodArtifact.objects.create(
+            project=other_project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            app_id="com.example.app2",
+            commit_comparison=commit_comparison_org2,
+        )
+
+        # Query for org1 artifacts should only return org1 artifacts
+        artifacts_org1 = list(artifact_org1.get_sibling_artifacts_for_commit())
+        assert len(artifacts_org1) == 1
+        assert artifacts_org1[0] == artifact_org1
+
+        # Query for org2 artifacts should only return org2 artifacts
+        artifacts_org2 = list(artifact_org2.get_sibling_artifacts_for_commit())
+        assert len(artifacts_org2) == 1
+        assert artifacts_org2[0] == artifact_org2
+
+    def test_get_sibling_artifacts_for_commit_no_commit_comparison(self):
+        """Test that method returns empty queryset when artifact has no commit_comparison."""
+        artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            app_id="com.example.app",
+            commit_comparison=None,
+        )
+
+        artifacts = list(artifact.get_sibling_artifacts_for_commit())
+        assert len(artifacts) == 0

--- a/tests/sentry/preprod/test_tasks.py
+++ b/tests/sentry/preprod/test_tasks.py
@@ -503,6 +503,7 @@ class AssemblePreprodArtifactSizeAnalysisTest(BaseAssembleTest):
         # Create an existing size metrics record
         existing_size_metrics = PreprodArtifactSizeMetrics.objects.create(
             preprod_artifact=self.preprod_artifact,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
             state=PreprodArtifactSizeMetrics.SizeAnalysisState.PENDING,
         )
 

--- a/tests/sentry/preprod/vcs/status_checks/test_status_checks_tasks.py
+++ b/tests/sentry/preprod/vcs/status_checks/test_status_checks_tasks.py
@@ -269,11 +269,19 @@ class CreatePreprodStatusCheckTaskTest(TestCase):
                 assert call_kwargs["repo"] == "owner/repo"
                 assert call_kwargs["sha"] == preprod_artifact.commit_comparison.head_sha
                 assert call_kwargs["status"] == expected_status
-                assert call_kwargs["title"]  # Just check it exists
-                assert call_kwargs["subtitle"]  # Just check it exists
+                assert call_kwargs["title"] == "Size Analysis"
+
+                # Note: PROCESSED without size metrics = still processing
+                if expected_status == StatusCheckStatus.SUCCESS:
+                    # SUCCESS only when processed AND has completed size metrics
+                    assert "1 build" in call_kwargs["subtitle"]
+                elif expected_status == StatusCheckStatus.IN_PROGRESS:
+                    assert "1 build processing" in call_kwargs["subtitle"]
+                elif expected_status == StatusCheckStatus.FAILURE:
+                    assert "1 build errored" in call_kwargs["subtitle"]
+
                 assert call_kwargs["summary"]  # Just check it exists
                 assert call_kwargs["external_id"] == str(preprod_artifact.id)
-                # target_url can be None or a string depending on state
 
     def test_create_preprod_status_check_task_api_failure_handling(self):
         """Test task handles status check API failures gracefully."""
@@ -294,3 +302,119 @@ class CreatePreprodStatusCheckTaskTest(TestCase):
 
         # Verify API was called but task completed without exception
         mock_provider.create_status_check.assert_called_once()
+
+    def test_create_preprod_status_check_task_multiple_artifacts_same_commit(self):
+        """Test task handles multiple artifacts for the same commit (monorepo scenario)."""
+        commit_comparison = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="a" * 40,
+            base_sha="b" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+            head_ref="feature/test",
+            base_ref="main",
+        )
+
+        # Create multiple artifacts for the same commit (monorepo scenario)
+        artifacts = []
+        for i in range(3):
+            artifact = PreprodArtifact.objects.create(
+                project=self.project,
+                state=PreprodArtifact.ArtifactState.PROCESSED,
+                app_id=f"com.example.app{i}",
+                build_version="1.0.0",
+                build_number=i + 1,
+                commit_comparison=commit_comparison,
+            )
+            artifacts.append(artifact)
+
+        _, mock_provider, client_patch, provider_patch = self._create_working_status_check_setup(
+            artifacts[0]
+        )
+
+        with client_patch, provider_patch:
+            with self.tasks():
+                # Call with just one artifact ID - it should find all sibling artifacts
+                create_preprod_status_check_task(artifacts[0].id)
+
+        mock_provider.create_status_check.assert_called_once()
+        call_kwargs = mock_provider.create_status_check.call_args.kwargs
+
+        assert call_kwargs["title"] == "Size Analysis"
+        assert (
+            call_kwargs["subtitle"] == "3 builds processing"
+        )  # All processed but no metrics = processing
+
+        summary = call_kwargs["summary"]
+        assert "com.example.app0" in summary
+        assert "com.example.app1" in summary
+        assert "com.example.app2" in summary
+
+    def test_create_preprod_status_check_task_mixed_states_monorepo(self):
+        """Test task handles mixed artifact states in monorepo scenario."""
+        from sentry.preprod.models import PreprodArtifactSizeMetrics
+
+        commit_comparison = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="a" * 40,
+            base_sha="b" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+            head_ref="feature/test",
+            base_ref="main",
+        )
+
+        processed_artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            app_id="com.example.processed",
+            commit_comparison=commit_comparison,
+        )
+
+        PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=processed_artifact,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            min_download_size=1024 * 1024,
+            max_download_size=1024 * 1024,
+            min_install_size=2 * 1024 * 1024,
+            max_install_size=2 * 1024 * 1024,
+        )
+
+        _ = PreprodArtifact.objects.create(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.UPLOADING,
+            app_id="com.example.uploading",
+            commit_comparison=commit_comparison,
+        )
+
+        _ = PreprodArtifact.objects.create(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.FAILED,
+            app_id="com.example.failed",
+            error_message="Upload timeout",
+            commit_comparison=commit_comparison,
+        )
+
+        _, mock_provider, client_patch, provider_patch = self._create_working_status_check_setup(
+            processed_artifact
+        )
+
+        with client_patch, provider_patch:
+            with self.tasks():
+                create_preprod_status_check_task(processed_artifact.id)
+
+        mock_provider.create_status_check.assert_called_once()
+        call_kwargs = mock_provider.create_status_check.call_args.kwargs
+
+        assert call_kwargs["title"] == "Size Analysis"
+        assert call_kwargs["subtitle"] == "1 build analyzed, 1 build processing, 1 build errored"
+        assert call_kwargs["status"] == StatusCheckStatus.FAILURE  # Failed takes priority
+
+        summary = call_kwargs["summary"]
+        assert "com.example.processed" in summary
+        assert "com.example.uploading" in summary
+        assert "com.example.failed" in summary
+        assert "Upload timeout" in summary

--- a/tests/sentry/preprod/vcs/status_checks/test_templates.py
+++ b/tests/sentry/preprod/vcs/status_checks/test_templates.py
@@ -31,17 +31,13 @@ class FormatStatusMessagesTest(TestCase):
                     build_number=1,
                 )
 
-                title, subtitle, summary = format_status_check_messages(artifact)
+                title, subtitle, summary = format_status_check_messages([artifact], {})
 
-                # Check title and subtitle
                 assert title == "Size Analysis"
-                assert subtitle == "Processing..."
-
-                # Check summary contains processing indicators
+                assert subtitle == "1 build processing"
                 assert "Processing..." in summary
                 assert "com.example.app" in summary
                 assert "1.0.0 (1)" in summary
-                assert "Analysis will be updated when processing completes" in summary
 
     def test_failed_state_formatting(self):
         """Test formatting for failed state."""
@@ -54,13 +50,10 @@ class FormatStatusMessagesTest(TestCase):
             error_message="Build timeout",
         )
 
-        title, subtitle, summary = format_status_check_messages(artifact)
+        title, subtitle, summary = format_status_check_messages([artifact], {})
 
-        # Check title and subtitle
         assert title == "Size Analysis"
-        assert subtitle == "Error processing"
-
-        # Check summary contains error information
+        assert subtitle == "1 build errored"
         assert "Build timeout" in summary
         assert "com.example.app" in summary
         assert "1.0.0 (1)" in summary
@@ -76,14 +69,11 @@ class FormatStatusMessagesTest(TestCase):
             build_number=1,
         )
 
-        title, subtitle, summary = format_status_check_messages(artifact)
+        title, subtitle, summary = format_status_check_messages([artifact], {})
 
-        # Check title and subtitle (fallback)
         assert title == "Size Analysis"
-        assert subtitle == "Complete"  # Falls back to basic success message
-
-        # Should be a simple success message
-        assert "processed successfully" in summary
+        assert subtitle == "1 build processing"  # Processed but no metrics = still processing
+        assert "Processing..." in summary
 
     def test_processed_state_with_metrics_no_previous(self):
         """Test formatting for processed state with metrics but no previous build."""
@@ -95,8 +85,7 @@ class FormatStatusMessagesTest(TestCase):
             build_number=1,
         )
 
-        # Create size metrics
-        PreprodArtifactSizeMetrics.objects.create(
+        size_metrics = PreprodArtifactSizeMetrics.objects.create(
             preprod_artifact=artifact,
             metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
             state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
@@ -106,20 +95,16 @@ class FormatStatusMessagesTest(TestCase):
             max_install_size=2 * 1024 * 1024,
         )
 
-        title, subtitle, summary = format_status_check_messages(artifact)
+        size_metrics_map = {artifact.id: size_metrics}
 
-        # Check title and subtitle
+        title, subtitle, summary = format_status_check_messages([artifact], size_metrics_map)
+
         assert title == "Size Analysis"
-        assert subtitle == "1 build analyzed"  # Simplified subtitle
-
-        # Check summary contains size table
-        assert "1.0 MB" in summary  # Download size
-        assert "2.0 MB" in summary  # Install size
-        assert "N/A" in summary  # No diffing yet
+        assert subtitle == "1 build analyzed"
+        assert "1.0 MB" in summary
+        assert "2.0 MB" in summary
+        assert "N/A" in summary
         assert "com.example.app" in summary
-
-    # TODO: Add back diffing tests when size comparison is implemented
-    # For now, all processed states with metrics will show "1 build analyzed"
 
     def test_version_string_formatting(self):
         """Test version string formatting with different combinations."""
@@ -140,7 +125,7 @@ class FormatStatusMessagesTest(TestCase):
                     build_number=build_number,
                 )
 
-                title, subtitle, summary = format_status_check_messages(artifact)
+                title, subtitle, summary = format_status_check_messages([artifact], {})
 
                 assert expected in summary
 
@@ -161,6 +146,122 @@ class FormatStatusMessagesTest(TestCase):
                     error_message=input_error,
                 )
 
-                title, subtitle, summary = format_status_check_messages(artifact)
+                title, subtitle, summary = format_status_check_messages([artifact], {})
 
                 assert expected_error in summary
+
+    def test_multiple_artifacts_all_processing(self):
+        """Test formatting for multiple artifacts all in processing states."""
+        artifacts = []
+        for i, state in enumerate(
+            [
+                PreprodArtifact.ArtifactState.UPLOADING,
+                PreprodArtifact.ArtifactState.UPLOADED,
+            ]
+        ):
+            artifacts.append(
+                PreprodArtifact.objects.create(
+                    project=self.project,
+                    state=state,
+                    app_id=f"com.example.app{i}",
+                    build_version="1.0.0",
+                    build_number=i + 1,
+                )
+            )
+
+        title, subtitle, summary = format_status_check_messages(artifacts, {})
+
+        assert title == "Size Analysis"
+        assert subtitle == "2 builds processing"
+        assert "Processing..." in summary
+        assert "com.example.app0" in summary
+        assert "com.example.app1" in summary
+
+    def test_multiple_artifacts_all_analyzed(self):
+        """Test formatting for multiple artifacts all analyzed."""
+        artifacts = []
+        size_metrics_map = {}
+
+        for i in range(2):
+            artifact = PreprodArtifact.objects.create(
+                project=self.project,
+                state=PreprodArtifact.ArtifactState.PROCESSED,
+                app_id=f"com.example.app{i}",
+                build_version="1.0.0",
+                build_number=i + 1,
+            )
+            artifacts.append(artifact)
+
+            size_metrics = PreprodArtifactSizeMetrics.objects.create(
+                preprod_artifact=artifact,
+                metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+                state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+                min_download_size=(i + 1) * 1024 * 1024,  # Different sizes
+                max_download_size=(i + 1) * 1024 * 1024,
+                min_install_size=(i + 2) * 1024 * 1024,
+                max_install_size=(i + 2) * 1024 * 1024,
+            )
+            size_metrics_map[artifact.id] = size_metrics
+
+        title, subtitle, summary = format_status_check_messages(artifacts, size_metrics_map)
+
+        assert title == "Size Analysis"
+        assert subtitle == "2 builds analyzed"
+        assert "1.0 MB" in summary  # First artifact download size
+        assert "2.0 MB" in summary  # Second artifact download size
+        assert "com.example.app0" in summary
+        assert "com.example.app1" in summary
+
+    def test_multiple_artifacts_mixed_states(self):
+        """Test formatting for mixed states (some analyzed, some processing, some failed)."""
+        artifacts = []
+        size_metrics_map = {}
+
+        processed_artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            app_id="com.example.processed",
+            build_version="1.0.0",
+            build_number=1,
+        )
+        artifacts.append(processed_artifact)
+
+        size_metrics = PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=processed_artifact,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            min_download_size=1024 * 1024,
+            max_download_size=1024 * 1024,
+            min_install_size=2 * 1024 * 1024,
+            max_install_size=2 * 1024 * 1024,
+        )
+        size_metrics_map[processed_artifact.id] = size_metrics
+
+        uploading_artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.UPLOADING,
+            app_id="com.example.uploading",
+            build_version="1.0.0",
+            build_number=2,
+        )
+        artifacts.append(uploading_artifact)
+
+        failed_artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.FAILED,
+            app_id="com.example.failed",
+            build_version="1.0.0",
+            build_number=3,
+            error_message="Upload timeout",
+        )
+        artifacts.append(failed_artifact)
+
+        title, subtitle, summary = format_status_check_messages(artifacts, size_metrics_map)
+
+        assert title == "Size Analysis"
+        assert subtitle == "1 build analyzed, 1 build processing, 1 build errored"
+        assert "Processing..." in summary  # Non-failed artifacts show as processing
+        assert "Upload timeout" in summary  # Failed artifact error
+        assert "com.example.processed" in summary
+        assert "com.example.uploading" in summary
+        assert "com.example.failed" in summary


### PR DESCRIPTION
Updates our status check logic to support multiple apps for the same commit, say if the user is uploading from a monorepo or producing multiple apps like an iOS and macOS variant.

<img width="855" height="327" alt="Screenshot 2025-09-04 at 5 09 51 PM" src="https://github.com/user-attachments/assets/d17dfa85-1e92-4594-84c3-4ed6e50136dc" />
