### PR TITLE
ref(codeowners): clean up `validate_codeowner_associations`

### DIFF
--- a/src/sentry/api/serializers/models/projectcodeowners.py
+++ b/src/sentry/api/serializers/models/projectcodeowners.py
@@ -75,7 +75,7 @@ class ProjectCodeOwnersSerializer(Serializer):
                     rule_owner["name"] = rule_owner.pop("identifier")
 
     def serialize(self, obj, attrs, user, **kwargs):
-        from sentry.api.validators.project_codeowners import validate_codeowners_associations
+        from sentry.api.validators.project_codeowners import build_codeowners_associations
 
         data = {
             "id": str(obj.id),
@@ -96,7 +96,7 @@ class ProjectCodeOwnersSerializer(Serializer):
             data["ownershipSyntax"] = convert_schema_to_rules_text(obj.schema)
 
         if "errors" in self.expand:
-            _, errors = validate_codeowners_associations(obj.raw, obj.project)
+            _, errors = build_codeowners_associations(obj.raw, obj.project)
             data["errors"] = errors
 
         if "renameIdentifier" in self.expand and hasattr(obj, "schema") and obj.schema:

--- a/src/sentry/issues/endpoints/organization_codeowners_associations.py
+++ b/src/sentry/issues/endpoints/organization_codeowners_associations.py
@@ -9,7 +9,7 @@ from sentry.api.bases.organization import (
     OrganizationEndpoint,
     OrganizationIntegrationsLoosePermission,
 )
-from sentry.api.validators.project_codeowners import validate_codeowners_associations
+from sentry.api.validators.project_codeowners import build_codeowners_associations
 from sentry.constants import ObjectStatus
 from sentry.integrations.services.integration import integration_service
 from sentry.models.organization import Organization
@@ -48,6 +48,6 @@ class OrganizationCodeOwnersAssociationsEndpoint(OrganizationEndpoint):
             )
         result = {}
         for pco in project_code_owners:
-            associations, errors = validate_codeowners_associations(pco.raw, pco.project)
+            associations, errors = build_codeowners_associations(pco.raw, pco.project)
             result[pco.project.slug] = {"associations": associations, "errors": errors}
         return self.respond(result, status=status.HTTP_200_OK)

--- a/src/sentry/issues/endpoints/project_codeowners_index.py
+++ b/src/sentry/issues/endpoints/project_codeowners_index.py
@@ -11,7 +11,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models import projectcodeowners as projectcodeowners_serializers
-from sentry.api.validators.project_codeowners import validate_codeowners_associations
+from sentry.api.validators.project_codeowners import build_codeowners_associations
 from sentry.issues.endpoints.bases.codeowners import ProjectCodeOwnersBase
 from sentry.issues.endpoints.serializers import ProjectCodeOwnerSerializer
 from sentry.issues.ownership.grammar import (
@@ -38,7 +38,7 @@ class ProjectCodeOwnersEndpoint(ProjectCodeOwnersBase):
 
         # Convert raw to issue owners syntax so that the schema can be created
         raw = codeowner.raw
-        associations, _ = validate_codeowners_associations(codeowner.raw, project)
+        associations, _ = build_codeowners_associations(codeowner.raw, project)
         codeowner.raw = convert_codeowners_syntax(
             codeowner.raw,
             associations,

--- a/src/sentry/issues/endpoints/serializers.py
+++ b/src/sentry/issues/endpoints/serializers.py
@@ -10,7 +10,7 @@ from rest_framework.exceptions import ValidationError
 from sentry import analytics
 from sentry.analytics.events.codeowners_max_length_exceeded import CodeOwnersMaxLengthExceeded
 from sentry.api.serializers.rest_framework.base import CamelSnakeModelSerializer
-from sentry.api.validators.project_codeowners import validate_codeowners_associations
+from sentry.api.validators.project_codeowners import build_codeowners_associations
 from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
 from sentry.issues.ownership.grammar import (
     convert_codeowners_syntax,
@@ -66,7 +66,7 @@ class ProjectCodeOwnerSerializer(CamelSnakeModelSerializer[ProjectCodeOwners]):
 
         # Ignore association errors and continue parsing CODEOWNERS for valid lines.
         # Allow users to incrementally fix association errors; for CODEOWNERS with many external mappings.
-        associations, _ = validate_codeowners_associations(attrs["raw"], self.context["project"])
+        associations, _ = build_codeowners_associations(attrs["raw"], self.context["project"])
 
         issue_owner_rules = convert_codeowners_syntax(
             attrs["raw"], associations, attrs["code_mapping_id"]

--- a/src/sentry/models/projectcodeowners.py
+++ b/src/sentry/models/projectcodeowners.py
@@ -97,7 +97,7 @@ class ProjectCodeOwners(Model):
         2. convert the codeowner file to the ownership syntax
         3. convert the ownership syntax to the schema
         """
-        from sentry.api.validators.project_codeowners import validate_codeowners_associations
+        from sentry.api.validators.project_codeowners import build_codeowners_associations
         from sentry.utils.codeowners import MAX_RAW_LENGTH
 
         if raw and self.raw != raw:
@@ -118,7 +118,7 @@ class ProjectCodeOwners(Model):
             logger.warning({"raw": f"Raw needs to be <= {MAX_RAW_LENGTH} characters in length"})
             return
 
-        associations, _ = validate_codeowners_associations(self.raw, self.project)
+        associations, _ = build_codeowners_associations(self.raw, self.project)
 
         issue_owner_rules = convert_codeowners_syntax(
             codeowners=self.raw,

--- a/tests/sentry/issues/endpoints/test_organization_codeowners_associations.py
+++ b/tests/sentry/issues/endpoints/test_organization_codeowners_associations.py
@@ -1,6 +1,6 @@
 from rest_framework import status
 
-from sentry.api.validators.project_codeowners import validate_codeowners_associations
+from sentry.api.validators.project_codeowners import build_codeowners_associations
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import assume_test_silo_mode
@@ -65,9 +65,7 @@ class OrganizationCodeOwnersAssociationsEndpointTest(APITestCase):
         response = self.get_success_response(self.organization.slug, status=status.HTTP_200_OK)
         for code_owner in [code_owner_1, code_owner_2]:
             assert code_owner.project.slug in response.data.keys()
-            associations, errors = validate_codeowners_associations(
-                code_owner.raw, code_owner.project
-            )
+            associations, errors = build_codeowners_associations(code_owner.raw, code_owner.project)
             assert "associations" in response.data[code_owner.project.slug].keys()
             assert response.data[code_owner.project.slug]["associations"] == associations
             assert "errors" in response.data[code_owner.project.slug].keys()


### PR DESCRIPTION
Touch up `validate_codeowners_associations` since it was a bit confusing to me when working on #98668.