### PR TITLE
feat(uptime): Add feature flag for detector IDs by default

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -475,6 +475,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Enable processing uptime results via the detector handler
     manager.add("organizations:uptime-detector-handler", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     manager.add("organizations:uptime-detector-create-issues", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Enable using detector IDs by default in uptime endpoints (instead of requiring useDetectorId query parameter)
+    manager.add("organizations:uptime-detector-ids-by-default", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable sending uptime results to EAP (Events Analytics Platform)
     manager.add("organizations:uptime-eap-results", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable querying uptime data from EAP uptime_results instead of uptime_checks

--- a/tests/sentry/uptime/endpoints/test_project_uptime_alert_details.py
+++ b/tests/sentry/uptime/endpoints/test_project_uptime_alert_details.py
@@ -43,6 +43,20 @@ class ProjectUptimeAlertDetailsGetEndpointTest(ProjectUptimeAlertDetailsBaseEndp
         # Should return the same data as the subscription ID test
         assert resp.data == serialize(uptime_subscription, self.user)
 
+    def test_detector_ids_by_default_feature_flag_enabled(self) -> None:
+        """Test that detector IDs are used by default when feature flag is enabled."""
+        uptime_subscription = self.create_project_uptime_subscription()
+        detector = get_detector(uptime_subscription.uptime_subscription)
+
+        # Test with feature flag enabled - detector ID should work without query parameter
+        with self.feature("organizations:uptime-detector-ids-by-default"):
+            resp = self.get_success_response(
+                self.organization.slug,
+                uptime_subscription.project.slug,
+                detector.id,
+            )
+            assert resp.data == serialize(uptime_subscription, self.user)
+
 
 class ProjectUptimeAlertDetailsPutEndpointTest(ProjectUptimeAlertDetailsBaseEndpointTest):
     method = "put"


### PR DESCRIPTION
Adds organizations:uptime-detector-ids-by-default feature flag to
control whether uptime endpoints treat IDs as detector IDs by default,
instead of requiring the useDetectorId=1 query parameter.

When the feature flag is enabled, endpoints will use detector IDs by
default but still respect the useDetectorId query parameter for backward
compatibility. When disabled, endpoints preserve the legacy behavior of
treating IDs as ProjectUptimeSubscription IDs unless useDetectorId=1 is
explicitly provided.

This allows for gradual rollout of the detector ID change and quick
rollback if customer issues arise.