### PR TITLE
fix(replay): fix tooltip flashing on replay timeline

### DIFF
--- a/static/app/components/replays/breadcrumbs/replayTimelineTooltip.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimelineTooltip.tsx
@@ -57,8 +57,8 @@ export default function TimelineTooltip({container}: Props) {
       ref={labelRef}
       style={{
         display: lastHoverTime ? 'block' : 'none',
-        top: 0,
         left: toPercent(divide(lastHoverTime ?? 0, durationMs)),
+        transform: 'translateX(10px)',
       }}
     >
       <Text size="sm" tabular style={{fontWeight: 'normal'}}>
@@ -81,6 +81,8 @@ export default function TimelineTooltip({container}: Props) {
 
 const CursorLabel = styled(Overlay)`
   position: absolute;
-  translate: 10px -10px;
   padding: ${space(0.75)} ${space(1)};
+  pointer-events: none;
+  white-space: nowrap;
+  z-index: 1000;
 `;


### PR DESCRIPTION
closes https://linear.app/getsentry/issue/REPLAY-666/tooltip-flashing-on-replay-details-timeline

something weird was happening w/ the current time tooltip in the timeline's zoom state, where mouse hovering over the tooltip (?) would cause it to flash/flicker rapidly. to alleviate this, i moved the tooltip slightly so that there was less potential for overlap.

before:

https://github.com/user-attachments/assets/4838f045-461f-4d73-aa31-0883893c2f31


after:




https://github.com/user-attachments/assets/c643e652-0ab5-4d13-a939-5a681e7bfa14
