### PR TITLE
fix(typing): Remove sentry.integrations.slack.message_builder.notifications.issues from problem list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -307,7 +307,6 @@ module = [
     "sentry.api.endpoints.organization_releases",
     "sentry.api.paginator",
     "sentry.db.postgres.base",
-    "sentry.integrations.slack.message_builder.notifications.issues",
     "sentry.middleware.auth",
     "sentry.middleware.ratelimit",
     "sentry.net.http",

--- a/src/sentry/integrations/slack/message_builder/notifications/issues.py
+++ b/src/sentry/integrations/slack/message_builder/notifications/issues.py
@@ -22,9 +22,8 @@ class IssueNotificationMessageBuilder(SlackNotificationsMessageBuilder):
         self.notification: ProjectNotification = notification
 
     def build(self) -> SlackBlock:
-        group = getattr(self.notification, "group", None)
         return SlackIssuesMessageBuilder(
-            group=group,
+            group=self.notification.group,
             event=getattr(self.notification, "event", None),
             tags=self.context.get("tags", None),
             rules=getattr(self.notification, "rules", None),


### PR DESCRIPTION
Made minimal changes to allow mypy to pass with the file removed from the problem list.

Normally, `ProjectNotification`s aren't guaranteed to have a `group` property set. Hence the current in-code tendency towards accessing it through `getattr` with a `None` default.

... but, in this case in particular, we're immediately passing it into `SlackIssuesMessageBuilder::build`. That immediately accesses `group.issue_category`, `group.organization`, etc — so it would already throw if `group` was `None`.

Since we need `group` to be non-`None`, let's just take it directly. (Which has the benefit of better typing!)

Test plan: `mypy` no errors; `pytest tests/sentry/integrations/slack/**` no durable failures (one flaky failure that passed on first retry)