### PR TITLE
feat(explore): Support managed fields to query params

### DIFF
--- a/static/app/views/explore/logs/logsLocationQueryParamsProvider.tsx
+++ b/static/app/views/explore/logs/logsLocationQueryParamsProvider.tsx
@@ -6,6 +6,7 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import {
   getReadableQueryParamsFromLocation,
   getTargetWithReadableQueryParams,
+  isDefaultFields,
 } from 'sentry/views/explore/logs/logsQueryParams';
 import {QueryParamsContextProvider} from 'sentry/views/explore/queryParams/context';
 import type {WritableQueryParams} from 'sentry/views/explore/queryParams/writableQueryParams';
@@ -33,10 +34,14 @@ export function LogsLocationQueryParamsProvider({
     [location, navigate]
   );
 
+  const isUsingDefaultFields = isDefaultFields(location);
+
   return (
     <QueryParamsContextProvider
+      isUsingDefaultFields={isUsingDefaultFields}
       queryParams={readableQueryParams}
       setQueryParams={setWritableQueryParams}
+      shouldManageFields
     >
       {children}
     </QueryParamsContextProvider>

--- a/static/app/views/explore/logs/logsQueryParams.tsx
+++ b/static/app/views/explore/logs/logsQueryParams.tsx
@@ -41,6 +41,10 @@ import type {WritableQueryParams} from 'sentry/views/explore/queryParams/writabl
 const LOGS_MODE_KEY = 'mode';
 export const LOGS_AGGREGATE_FIELD_KEY = 'aggregateField';
 
+export function isDefaultFields(location: Location): boolean {
+  return getFieldsFromLocation(location, LOGS_FIELDS_KEY) ? false : true;
+}
+
 export function getReadableQueryParamsFromLocation(
   location: Location
 ): ReadableQueryParams {

--- a/static/app/views/explore/logs/logsStateQueryParamsProvider.tsx
+++ b/static/app/views/explore/logs/logsStateQueryParamsProvider.tsx
@@ -70,6 +70,8 @@ export function LogsStateQueryParamsProvider({
     <QueryParamsContextProvider
       queryParams={readableQueryParams}
       setQueryParams={setWritableQueryParams}
+      isUsingDefaultFields
+      shouldManageFields={false}
     >
       {children}
     </QueryParamsContextProvider>

--- a/static/app/views/explore/queryParams/context.tsx
+++ b/static/app/views/explore/queryParams/context.tsx
@@ -1,5 +1,5 @@
 import type {ReactNode} from 'react';
-import {useCallback, useMemo} from 'react';
+import {useCallback, useEffect, useMemo, useState} from 'react';
 
 import {defined} from 'sentry/utils';
 import type {Sort} from 'sentry/utils/discover/fields';
@@ -10,6 +10,7 @@ import type {
   WritableAggregateField,
 } from 'sentry/views/explore/queryParams/aggregateField';
 import {isGroupBy} from 'sentry/views/explore/queryParams/groupBy';
+import {deriveUpdatedManagedFields} from 'sentry/views/explore/queryParams/managedFields';
 import type {Mode} from 'sentry/views/explore/queryParams/mode';
 import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
 import {
@@ -21,7 +22,9 @@ import {
 import type {WritableQueryParams} from 'sentry/views/explore/queryParams/writableQueryParams';
 
 interface QueryParamsContextValue {
+  managedFields: Set<string>;
   queryParams: ReadableQueryParams;
+  setManagedFields: (managedFields: Set<string>) => void;
   setQueryParams: (queryParams: WritableQueryParams) => void;
 }
 
@@ -30,21 +33,44 @@ const [_QueryParamsContextProvider, useQueryParamsContext, QueryParamsContext] =
     name: 'QueryParamsContext',
   });
 
-interface QueryParamsContextProps extends QueryParamsContextValue {
+interface QueryParamsContextProps {
   children: ReactNode;
+  isUsingDefaultFields: boolean;
+  queryParams: ReadableQueryParams;
+  setQueryParams: (queryParams: WritableQueryParams) => void;
+  shouldManageFields: boolean;
 }
+
+function setManagedFieldsStub() {}
 
 export function QueryParamsContextProvider({
   children,
+  isUsingDefaultFields,
   queryParams,
   setQueryParams,
+  shouldManageFields,
 }: QueryParamsContextProps) {
+  const [managedFields, setManagedFields] = useState(new Set<string>());
+
+  // Whenever the fields is reset to the defaults, we should wipe the state of the
+  // managed fields. This can happen when
+  // 1. user clicks on the side bar when already on the page
+  // 2. some code intentionally wipes the fields
+  useEffect(() => {
+    if (isUsingDefaultFields) {
+      setManagedFields(new Set());
+    }
+  }, [isUsingDefaultFields]);
+
   const value = useMemo(() => {
     return {
+      managedFields,
+      setManagedFields: shouldManageFields ? setManagedFields : setManagedFieldsStub,
       queryParams,
       setQueryParams,
     };
-  }, [queryParams, setQueryParams]);
+  }, [managedFields, setManagedFields, queryParams, setQueryParams, shouldManageFields]);
+
   return <QueryParamsContext value={value}>{children}</QueryParamsContext>;
 }
 
@@ -54,10 +80,29 @@ export function useQueryParams() {
 }
 
 function useSetQueryParams() {
-  const {setQueryParams} = useQueryParamsContext();
+  const {
+    managedFields,
+    setManagedFields,
+    queryParams: readableQueryParams,
+    setQueryParams,
+  } = useQueryParamsContext();
 
   return useCallback(
     (writableQueryParams: WritableQueryParams) => {
+      const {updatedFields, updatedManagedFields} = deriveUpdatedManagedFields(
+        managedFields,
+        readableQueryParams,
+        writableQueryParams
+      );
+
+      if (defined(updatedManagedFields)) {
+        setManagedFields(updatedManagedFields);
+      }
+
+      if (defined(updatedFields)) {
+        writableQueryParams.fields = updatedFields;
+      }
+
       if (shouldResetCursors(writableQueryParams)) {
         // setting it to null tells the implementer that it should be reset
         writableQueryParams.cursor = null;
@@ -65,7 +110,7 @@ function useSetQueryParams() {
       }
       setQueryParams(writableQueryParams);
     },
-    [setQueryParams]
+    [managedFields, setManagedFields, readableQueryParams, setQueryParams]
   );
 }
 

--- a/static/app/views/explore/queryParams/managedFields.spec.tsx
+++ b/static/app/views/explore/queryParams/managedFields.spec.tsx
@@ -1,0 +1,160 @@
+import {deriveUpdatedManagedFields} from 'sentry/views/explore/queryParams/managedFields';
+import {Mode} from 'sentry/views/explore/queryParams/mode';
+import {
+  ReadableQueryParams,
+  type ReadableQueryParamsOptions,
+} from 'sentry/views/explore/queryParams/readableQueryParams';
+import {VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
+import type {WritableQueryParams} from 'sentry/views/explore/queryParams/writableQueryParams';
+
+const defaultReadableQueryParamsOptions: ReadableQueryParamsOptions = {
+  aggregateCursor: '',
+  aggregateFields: [{groupBy: ''}, new VisualizeFunction('avg(foo)')],
+  aggregateSortBys: [],
+  cursor: '',
+  fields: ['foo', 'bar'],
+  mode: Mode.SAMPLES,
+  query: '',
+  sortBys: [],
+};
+
+describe('deriveUpdatedManagedFields', () => {
+  it('should clear managed fields when clearing fields', () => {
+    const managedFields = new Set<string>();
+    const readableQueryParams = new ReadableQueryParams({
+      ...defaultReadableQueryParamsOptions,
+    });
+    const writableQueryParams: WritableQueryParams = {fields: null};
+    const {updatedManagedFields} = deriveUpdatedManagedFields(
+      managedFields,
+      readableQueryParams,
+      writableQueryParams
+    );
+    expect(updatedManagedFields).toEqual(new Set());
+  });
+
+  it('should not change managed fields when nothing changes', () => {
+    const managedFields = new Set<string>();
+    const readableQueryParams = new ReadableQueryParams({
+      ...defaultReadableQueryParamsOptions,
+    });
+    const writableQueryParams: WritableQueryParams = {};
+    const {updatedManagedFields} = deriveUpdatedManagedFields(
+      managedFields,
+      readableQueryParams,
+      writableQueryParams
+    );
+    expect(updatedManagedFields).toEqual(new Set());
+  });
+
+  it('should manage new visualized field', () => {
+    const managedFields = new Set<string>();
+    const readableQueryParams = new ReadableQueryParams({
+      ...defaultReadableQueryParamsOptions,
+    });
+    const writableQueryParams: WritableQueryParams = {
+      aggregateFields: [{groupBy: ''}, {yAxes: ['avg(foo)']}, {yAxes: ['avg(baz)']}],
+    };
+    const {updatedManagedFields} = deriveUpdatedManagedFields(
+      managedFields,
+      readableQueryParams,
+      writableQueryParams
+    );
+    expect(updatedManagedFields).toEqual(new Set(['baz']));
+  });
+
+  it('should keep managing unchanged visualized field', () => {
+    const managedFields = new Set<string>(['baz']);
+    const readableQueryParams = new ReadableQueryParams({
+      ...defaultReadableQueryParamsOptions,
+      aggregateFields: [
+        {groupBy: ''},
+        new VisualizeFunction('avg(foo)'),
+        new VisualizeFunction('avg(baz)'),
+      ],
+    });
+    const writableQueryParams: WritableQueryParams = {
+      aggregateFields: [{groupBy: ''}, {yAxes: ['avg(foo)']}, {yAxes: ['p50(baz)']}],
+    };
+    const {updatedManagedFields} = deriveUpdatedManagedFields(
+      managedFields,
+      readableQueryParams,
+      writableQueryParams
+    );
+    expect(updatedManagedFields).toEqual(new Set(['baz']));
+  });
+
+  it('should stop managing removed visualized field', () => {
+    const managedFields = new Set<string>(['baz']);
+    const readableQueryParams = new ReadableQueryParams({
+      ...defaultReadableQueryParamsOptions,
+      aggregateFields: [
+        {groupBy: ''},
+        new VisualizeFunction('avg(foo)'),
+        new VisualizeFunction('avg(baz)'),
+      ],
+    });
+    const writableQueryParams: WritableQueryParams = {
+      aggregateFields: [{groupBy: ''}, {yAxes: ['avg(foo)']}],
+    };
+    const {updatedManagedFields} = deriveUpdatedManagedFields(
+      managedFields,
+      readableQueryParams,
+      writableQueryParams
+    );
+    expect(updatedManagedFields).toEqual(new Set());
+  });
+
+  it('should stop managing removed field', () => {
+    const managedFields = new Set<string>(['foo']);
+    const readableQueryParams = new ReadableQueryParams({
+      ...defaultReadableQueryParamsOptions,
+    });
+    const writableQueryParams: WritableQueryParams = {
+      aggregateFields: [{groupBy: ''}, {yAxes: ['avg(bar)']}],
+    };
+    const {updatedManagedFields} = deriveUpdatedManagedFields(
+      managedFields,
+      readableQueryParams,
+      writableQueryParams
+    );
+    expect(updatedManagedFields).toEqual(new Set());
+  });
+
+  it('should keep managing when there is still a visualized field', () => {
+    const managedFields = new Set<string>(['foo']);
+    const readableQueryParams = new ReadableQueryParams({
+      ...defaultReadableQueryParamsOptions,
+      aggregateFields: [
+        {groupBy: ''},
+        new VisualizeFunction('avg(foo)'),
+        new VisualizeFunction('p50(foo)'),
+      ],
+    });
+    const writableQueryParams: WritableQueryParams = {
+      aggregateFields: [{groupBy: ''}, {yAxes: ['avg(foo)']}],
+    };
+    const {updatedManagedFields} = deriveUpdatedManagedFields(
+      managedFields,
+      readableQueryParams,
+      writableQueryParams
+    );
+    expect(updatedManagedFields).toEqual(new Set(['foo']));
+  });
+
+  it('should not managed field already in fields', () => {
+    const managedFields = new Set<string>();
+    const readableQueryParams = new ReadableQueryParams({
+      ...defaultReadableQueryParamsOptions,
+    });
+    const writableQueryParams: WritableQueryParams = {
+      aggregateFields: [{groupBy: ''}, {yAxes: ['avg(foo)']}, {yAxes: ['avg(bar)']}],
+    };
+    const {updatedManagedFields} = deriveUpdatedManagedFields(
+      managedFields,
+      readableQueryParams,
+      writableQueryParams
+    );
+    expect(updatedManagedFields).toEqual(new Set());
+  });
+});

--- a/static/app/views/explore/queryParams/managedFields.tsx
+++ b/static/app/views/explore/queryParams/managedFields.tsx
@@ -1,0 +1,198 @@
+import {defined} from 'sentry/utils';
+import {parseFunction} from 'sentry/utils/discover/fields';
+import type {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
+import {
+  isBaseVisualize,
+  isVisualizeFunction,
+  Visualize,
+  type BaseVisualize,
+} from 'sentry/views/explore/queryParams/visualize';
+import type {WritableQueryParams} from 'sentry/views/explore/queryParams/writableQueryParams';
+
+type DerivedUpdatedManagedFields = {
+  updatedFields?: string[];
+  updatedManagedFields?: Set<string>;
+};
+
+export function deriveUpdatedManagedFields(
+  managedFields: Set<string>,
+  readableQueryParams: ReadableQueryParams,
+  writableQueryParams: WritableQueryParams
+): DerivedUpdatedManagedFields {
+  // null means to clear it, when this happens we should stop managing all fields
+  if (writableQueryParams.fields === null) {
+    return {
+      updatedManagedFields: new Set(),
+    };
+  }
+
+  const {readableRefs, writableRefs} = findAllFieldRefs(
+    readableQueryParams,
+    writableQueryParams
+  );
+
+  const allFields = new Set<string>([...readableRefs.keys(), ...writableRefs.keys()]);
+
+  // if the writable fields is undefined, it means we're not changing it
+  // so we should infer it from the readable fields
+  const fields = writableQueryParams.fields ?? readableQueryParams.fields;
+
+  const fieldsToAdd = new Set<string>();
+  const fieldsToDelete = new Set<string>();
+  const updatedManagedFields = new Set(managedFields);
+
+  allFields.forEach(field => {
+    const readableCount = readableRefs.get(field) || 0;
+    const writableCount = writableRefs.get(field) || 0;
+
+    if (
+      writableCount > readableCount &&
+      !updatedManagedFields.has(field) &&
+      !fields.includes(field)
+    ) {
+      // found a field that
+      // 1. isn't in the list of fields
+      // 2. isn't being managed
+      // 3. a writable reference was found
+      // this means we should start managing the field
+      updatedManagedFields.add(field);
+      fieldsToAdd.add(field);
+    } else if (
+      readableCount > 0 &&
+      writableCount <= 0 &&
+      updatedManagedFields.has(field)
+    ) {
+      // found a field that
+      // 1. all references have been removed
+      // 2. is being managed
+      updatedManagedFields.delete(field);
+      fieldsToDelete.add(field);
+    }
+  });
+
+  const {removedFields} = findChangedFields(readableQueryParams, writableQueryParams);
+
+  // when a field is intentionally removed, it should no longer be managed
+  removedFields.forEach(field => {
+    updatedManagedFields.delete(field);
+    fieldsToDelete.delete(field);
+  });
+
+  let updatedFields: string[] | undefined = undefined;
+
+  if (fieldsToAdd.size || fieldsToDelete.size) {
+    updatedFields = fields.filter(field => {
+      const keep = !fieldsToDelete.has(field);
+      if (!keep) {
+        // it's possible the user manually added a duplicate of the field,
+        // but we want to only delete 1 instance of the field
+        fieldsToDelete.delete(field);
+      }
+      return keep;
+    });
+    updatedFields.push(...fieldsToAdd);
+  }
+
+  return {updatedFields, updatedManagedFields};
+}
+
+type Counter = Map<string, number>;
+
+/**
+ * Finds all references to fields that we should consider managing. This looks after
+ * 1. visualized functions
+ */
+function findAllFieldRefs(
+  readableQueryParams: ReadableQueryParams,
+  writableQueryParams: WritableQueryParams
+): {
+  readableRefs: Counter;
+  writableRefs: Counter;
+} {
+  const readableRefs = new Map();
+  const writableRefs = new Map();
+
+  const readableVisualizeFields: string[] =
+    readableQueryParams.visualizes.flatMap(getVisualizeFields);
+
+  readableVisualizeFields.forEach(field => {
+    const count = readableRefs.get(field) || 0;
+    readableRefs.set(field, count + 1);
+  });
+
+  const writableVisualizeFields: string[] =
+    writableQueryParams.aggregateFields === null
+      ? // null means to clear it so make sure to handle it correctly
+        []
+      : defined(writableQueryParams.aggregateFields)
+        ? writableQueryParams.aggregateFields
+            .filter<BaseVisualize>(isBaseVisualize)
+            .flatMap(visualize => {
+              const visualizes = Visualize.fromJSON(visualize);
+              return visualizes.flatMap(getVisualizeFields);
+            })
+        : // undefined means it's unchanged so use the results from the readableQueryParams
+          readableVisualizeFields;
+
+  writableVisualizeFields.forEach(field => {
+    const count = writableRefs.get(field) || 0;
+    writableRefs.set(field, count + 1);
+  });
+
+  return {readableRefs, writableRefs};
+}
+
+function getVisualizeFields(visualize: Visualize): string[] {
+  if (isVisualizeFunction(visualize)) {
+    const field = parseFunction(visualize.yAxis)?.arguments?.[0];
+    return defined(field) ? [field] : [];
+  }
+
+  return []; // TODO: unsupported
+}
+
+function findChangedFields(
+  readableQueryParams: ReadableQueryParams,
+  writableQueryParams: WritableQueryParams
+): {
+  addedFields: Set<string>;
+  removedFields: Set<string>;
+} {
+  const addedFields = new Set<string>();
+  const removedFields = new Set<string>();
+
+  // TODO: check if we need to distinguish between null and undefined here
+  if (defined(writableQueryParams.fields)) {
+    function countFields(counter: Counter, field: string) {
+      const count = counter.get(field) || 0;
+      counter.set(field, count + 1);
+      return counter;
+    }
+
+    const readableFields: Counter = readableQueryParams.fields.reduce(
+      countFields,
+      new Map()
+    );
+
+    const writableFields: Counter = writableQueryParams.fields.reduce(
+      countFields,
+      new Map()
+    );
+
+    const fields = new Set([...readableFields.keys(), ...writableFields.keys()]);
+    fields.forEach(field => {
+      const readableCount = readableFields.get(field) || 0;
+      const writableCount = writableFields.get(field) || 0;
+      if (readableCount > writableCount) {
+        removedFields.add(field);
+      } else {
+        addedFields.add(field);
+      }
+    });
+  }
+
+  return {
+    addedFields,
+    removedFields,
+  };
+}

--- a/static/app/views/explore/queryParams/visualize.ts
+++ b/static/app/views/explore/queryParams/visualize.ts
@@ -144,7 +144,7 @@ export interface BaseVisualize {
   chartType?: ChartType;
 }
 
-function isBaseVisualize(value: any): value is BaseVisualize {
+export function isBaseVisualize(value: any): value is BaseVisualize {
   const hasYAxes =
     defined(value) &&
     typeof value === 'object' &&

--- a/static/app/views/explore/spans/spansQueryParams.tsx
+++ b/static/app/views/explore/spans/spansQueryParams.tsx
@@ -37,6 +37,10 @@ const SPANS_GROUP_BY_KEY = 'groupBy';
 const SPANS_VISUALIZATION_KEY = 'visualize';
 const SPANS_AGGREGATE_SORT_KEY = 'aggregateSort';
 
+export function isDefaultFields(location: Location): boolean {
+  return getFieldsFromLocation(location, SPANS_FIELD_KEY) ? false : true;
+}
+
 export function getReadableQueryParamsFromLocation(
   location: Location,
   organization: Organization

--- a/static/app/views/explore/spans/spansQueryParamsProvider.tsx
+++ b/static/app/views/explore/spans/spansQueryParamsProvider.tsx
@@ -9,6 +9,7 @@ import type {WritableQueryParams} from 'sentry/views/explore/queryParams/writabl
 import {
   getReadableQueryParamsFromLocation,
   getTargetWithReadableQueryParams,
+  isDefaultFields,
 } from 'sentry/views/explore/spans/spansQueryParams';
 
 interface SpansQueryParamsProviderProps {
@@ -33,10 +34,14 @@ export function SpansQueryParamsProvider({children}: SpansQueryParamsProviderPro
     [location, navigate]
   );
 
+  const isUsingDefaultFields = isDefaultFields(location);
+
   return (
     <QueryParamsContextProvider
+      isUsingDefaultFields={isUsingDefaultFields}
       queryParams={readableQueryParams}
       setQueryParams={setWritableQueryParams}
+      shouldManageFields
     >
       {children}
     </QueryParamsContextProvider>


### PR DESCRIPTION
This adds support for managed fields to query params. It doesn't write the fields just yet.