### PR TITLE
fix(logs btn): remove extra margin

### DIFF
--- a/static/app/views/explore/logs/styles.tsx
+++ b/static/app/views/explore/logs/styles.tsx
@@ -404,7 +404,6 @@ export const LogsSidebarCollapseButton = withChonk(
     border-left-color: ${p => p.theme.background};
     border-top-left-radius: 0px;
     border-bottom-left-radius: 0px;
-    margin-bottom: ${space(1)};
     margin-left: -31px;
     display: none;
 
@@ -413,7 +412,6 @@ export const LogsSidebarCollapseButton = withChonk(
     }
   `,
   chonkStyled(Button)<{sidebarOpen: boolean}>`
-    margin-bottom: ${space(1)};
     display: none;
     margin-left: -31px;
 


### PR DESCRIPTION
**Before:**
<img width="154" height="92" alt="Screenshot 2025-09-04 at 1 38 47 PM" src="https://github.com/user-attachments/assets/24a6fe5a-ad83-460d-b9fd-9bcee32db8d8" />

**After:**
<img width="166" height="107" alt="Screenshot 2025-09-04 at 1 38 51 PM" src="https://github.com/user-attachments/assets/8adea54e-724e-4c9f-a9f7-5b4cd46c046f" />