### PR TITLE
fix(preprod): build info can be missing for processing builds

### DIFF
--- a/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarAppInfo.tsx
+++ b/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarAppInfo.tsx
@@ -89,7 +89,7 @@ export function BuildDetailsSidebarAppInfo(props: BuildDetailsSidebarAppInfoProp
           <InfoIcon>
             <IconFile />
           </InfoIcon>
-          <Text>{getReadableArtifactTypeLabel(props.appInfo.artifact_type)}</Text>
+          <Text>{getReadableArtifactTypeLabel(props.appInfo.artifact_type || null)}</Text>
         </Flex>
         <Flex gap="2xs" align="center">
           <InfoIcon>

--- a/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarAppInfo.tsx
+++ b/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarAppInfo.tsx
@@ -40,7 +40,7 @@ export function BuildDetailsSidebarAppInfo(props: BuildDetailsSidebarAppInfoProp
         <AppIcon>
           <AppIconPlaceholder>{props.appInfo.name?.charAt(0) || ''}</AppIconPlaceholder>
         </AppIcon>
-        <Heading as="h3">{props.appInfo.name}</Heading>
+        {props.appInfo.name && <Heading as="h3">{props.appInfo.name}</Heading>}
       </Flex>
 
       {props.sizeInfo && (
@@ -71,12 +71,14 @@ export function BuildDetailsSidebarAppInfo(props: BuildDetailsSidebarAppInfoProp
               : ''}
           </Text>
         </Flex>
-        <Flex gap="2xs" align="center">
-          <InfoIcon>
-            <IconJson />
-          </InfoIcon>
-          <Text>{props.appInfo.app_id}</Text>
-        </Flex>
+        {props.appInfo.app_id && (
+          <Flex gap="2xs" align="center">
+            <InfoIcon>
+              <IconJson />
+            </InfoIcon>
+            <Text>{props.appInfo.app_id}</Text>
+          </Flex>
+        )}
         {props.appInfo.date_added && (
           <Flex gap="2xs" align="center">
             <InfoIcon>

--- a/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarAppInfo.tsx
+++ b/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarAppInfo.tsx
@@ -77,19 +77,21 @@ export function BuildDetailsSidebarAppInfo(props: BuildDetailsSidebarAppInfoProp
           </InfoIcon>
           <Text>{props.appInfo.app_id}</Text>
         </Flex>
-        <Flex gap="2xs" align="center">
-          <InfoIcon>
-            <IconClock />
-          </InfoIcon>
-          <Text>
-            {getFormattedDate(props.appInfo.date_added, 'MM/DD/YYYY [at] hh:mm A')}
-          </Text>
-        </Flex>
+        {props.appInfo.date_added && (
+          <Flex gap="2xs" align="center">
+            <InfoIcon>
+              <IconClock />
+            </InfoIcon>
+            <Text>
+              {getFormattedDate(props.appInfo.date_added, 'MM/DD/YYYY [at] hh:mm A')}
+            </Text>
+          </Flex>
+        )}
         <Flex gap="2xs" align="center">
           <InfoIcon>
             <IconFile />
           </InfoIcon>
-          <Text>{getReadableArtifactTypeLabel(props.appInfo.artifact_type || null)}</Text>
+          <Text>{getReadableArtifactTypeLabel(props.appInfo.artifact_type ?? null)}</Text>
         </Flex>
         <Flex gap="2xs" align="center">
           <InfoIcon>

--- a/static/app/views/preprod/types/buildDetailsTypes.ts
+++ b/static/app/views/preprod/types/buildDetailsTypes.ts
@@ -9,15 +9,15 @@ export interface BuildDetailsApiResponse {
 }
 
 export interface BuildDetailsAppInfo {
-  app_id: string;
-  artifact_type: BuildDetailsArtifactType;
-  build_number: string;
-  date_added: string;
-  date_built: string;
-  is_installable: boolean;
-  name: string;
-  platform: Platform | null;
-  version: string;
+  app_id?: string;
+  artifact_type?: BuildDetailsArtifactType;
+  build_number?: string;
+  date_added?: string;
+  date_built?: string;
+  is_installable?: boolean;
+  name?: string;
+  platform?: Platform;
+  version?: string;
   // build_configuration?: string; // Uncomment when available
   // icon?: string | null; // Uncomment when available
 }

--- a/static/app/views/preprod/utils/labelUtils.tsx
+++ b/static/app/views/preprod/utils/labelUtils.tsx
@@ -16,8 +16,12 @@ export function getPlatformIconFromPlatform(platform: Platform): 'apple' | 'andr
 }
 
 export function getReadableArtifactTypeLabel(
-  artifactType: BuildDetailsArtifactType
+  artifactType: BuildDetailsArtifactType | null
 ): string {
+  if (artifactType === null) {
+    return 'Unknown';
+  }
+
   switch (artifactType) {
     case BuildDetailsArtifactType.XCARCHIVE:
       return 'XCArchive';


### PR DESCRIPTION
These fields can be missing when a build hasn't processed yet so they shouldn't be required.
