### PR TITLE
test(buffer): Enable cluster mode in tests

### DIFF
--- a/tests/sentry/buffer/test_redis.py
+++ b/tests/sentry/buffer/test_redis.py
@@ -34,8 +34,8 @@ class TestRedisBuffer:
     def buffer(self, set_sentry_option, request):
         value = copy.deepcopy(options.get("redis.clusters"))
         value["default"]["is_redis_cluster"] = request.param == "cluster"
-        set_sentry_option("redis.clusters", value)
-        return RedisBuffer()
+        with set_sentry_option("redis.clusters", value):
+            yield RedisBuffer()
 
     @pytest.fixture(autouse=True)
     def setup_buffer(self, buffer):


### PR DESCRIPTION
Previous, 'is_cluster' was false in all tests because 'set_sentry_option' was being called in the setup fixture, but not being actually used as a context manager.
Due to this, "is_redis_cluster" was False in all tests, and we were effectively running the same tests twice.

NB: This still doesn't result in RedisCluster being used; the cached entry for the cluster is still a FailoverRedis from the fixture setup flushdb, but it's a step in the right direction that doesn't require users to run a full/backend-ci devservices.
