### PR TITLE
pre-commit: add missing hooks from the spec

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -165,6 +165,8 @@ repos:
       - id: debug-statements
       - id: name-tests-test
         args: [--pytest-test-first]
+      - id: check-added-large-files
+        args: ['--maxkb=1024']
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: v0.10.0.1


### PR DESCRIPTION
this brings sentry up to date with https://www.notion.so/sentry/Standard-Spec-pre-commit-2238b10e4b5d8019aa1fe1158e39c38e 
