### PR TITLE
fix(replay): add polling timeout for summary endpoint

### DIFF
--- a/static/app/views/replays/detail/ai/ai.tsx
+++ b/static/app/views/replays/detail/ai/ai.tsx
@@ -45,15 +45,19 @@ export default function Ai() {
     summaryData,
     isPending: isSummaryPending,
     isError,
+    isTimedOut,
     startSummaryRequest,
   } = useReplaySummaryContext();
 
-  function ErrorState({area}: {area: string}) {
+  function ErrorState({area, extraMessage}: {area: string; extraMessage?: string}) {
     return (
       <Wrapper data-test-id="replay-details-ai-summary-tab">
         <EndStateContainer>
           <img src={aiBanner} alt="" />
-          <div>{t('Failed to load replay summary.')}</div>
+          <div>
+            {t('Failed to load replay summary') +
+              (extraMessage ? ` - ${extraMessage}` : '.')}
+          </div>
           <div>
             <Button
               priority="default"
@@ -61,7 +65,7 @@ export default function Ai() {
               size="xs"
               onClick={() => {
                 startSummaryRequest();
-                trackAnalytics('replay.ai-summary.regenerate-requested', {
+                trackAnalytics('replay.ai-summary.regenerate-requested.', {
                   organization,
                   area: analyticsArea + area,
                 });
@@ -145,7 +149,11 @@ export default function Ai() {
   }
 
   if (isError) {
-    return <ErrorState area=".error" />;
+    return <ErrorState area="error" />;
+  }
+
+  if (isTimedOut) {
+    return <ErrorState area="timeout" extraMessage={t('Processing timed out')} />;
   }
 
   // checking this prevents initial flicker

--- a/static/app/views/replays/detail/ai/ai.tsx
+++ b/static/app/views/replays/detail/ai/ai.tsx
@@ -47,7 +47,6 @@ export default function Ai() {
     isPolling,
     isError,
     startSummaryRequest,
-    didTimeout,
   } = useReplaySummaryContext();
 
   function ErrorState({area}: {area: string}) {
@@ -144,10 +143,6 @@ export default function Ai() {
         </EndStateContainer>
       </Wrapper>
     );
-  }
-
-  if (didTimeout) {
-    return <ErrorState area=".timeout" />;
   }
 
   if (isError) {

--- a/static/app/views/replays/detail/ai/ai.tsx
+++ b/static/app/views/replays/detail/ai/ai.tsx
@@ -44,7 +44,6 @@ export default function Ai() {
   const {
     summaryData,
     isPending: isSummaryPending,
-    isPolling,
     isError,
     startSummaryRequest,
   } = useReplaySummaryContext();
@@ -156,7 +155,7 @@ export default function Ai() {
       summaryData?.status
     );
 
-  if (isSummaryPending || isPolling || summaryNotComplete) {
+  if (isSummaryPending || summaryNotComplete) {
     return (
       <Wrapper data-test-id="replay-details-ai-summary-tab">
         <LoadingContainer>

--- a/static/app/views/replays/detail/ai/ai.tsx
+++ b/static/app/views/replays/detail/ai/ai.tsx
@@ -47,6 +47,7 @@ export default function Ai() {
     isPolling,
     isError,
     startSummaryRequest,
+    didTimeout,
   } = useReplaySummaryContext();
 
   if (replayRecord?.project_id && !project) {
@@ -111,6 +112,34 @@ export default function Ai() {
             >
               {t('View Seer Settings')}
             </LinkButton>
+          </div>
+        </EndStateContainer>
+      </Wrapper>
+    );
+  }
+
+  if (didTimeout) {
+    return (
+      <Wrapper data-test-id="replay-details-ai-summary-tab">
+        <EndStateContainer>
+          <img src={aiBanner} alt="" />
+          <div>{t('Failed to load replay summary.')}</div>
+          <div>
+            <Button
+              priority="default"
+              type="button"
+              size="xs"
+              onClick={() => {
+                startSummaryRequest();
+                trackAnalytics('replay.ai-summary.regenerate-requested', {
+                  organization,
+                  area: analyticsArea + '.timeout',
+                });
+              }}
+              icon={<IconSync size="xs" />}
+            >
+              {t('Retry')}
+            </Button>
           </div>
         </EndStateContainer>
       </Wrapper>

--- a/static/app/views/replays/detail/ai/ai.tsx
+++ b/static/app/views/replays/detail/ai/ai.tsx
@@ -65,7 +65,7 @@ export default function Ai() {
               size="xs"
               onClick={() => {
                 startSummaryRequest();
-                trackAnalytics('replay.ai-summary.regenerate-requested.', {
+                trackAnalytics('replay.ai-summary.regenerate-requested', {
                   organization,
                   area: analyticsArea + area,
                 });
@@ -149,11 +149,11 @@ export default function Ai() {
   }
 
   if (isError) {
-    return <ErrorState area="error" />;
+    return <ErrorState area=".error" />;
   }
 
   if (isTimedOut) {
-    return <ErrorState area="timeout" extraMessage={t('Processing timed out')} />;
+    return <ErrorState area=".timeout" extraMessage={t('Processing timed out.')} />;
   }
 
   // checking this prevents initial flicker

--- a/static/app/views/replays/detail/ai/ai.tsx
+++ b/static/app/views/replays/detail/ai/ai.tsx
@@ -50,6 +50,34 @@ export default function Ai() {
     didTimeout,
   } = useReplaySummaryContext();
 
+  function ErrorState({area}: {area: string}) {
+    return (
+      <Wrapper data-test-id="replay-details-ai-summary-tab">
+        <EndStateContainer>
+          <img src={aiBanner} alt="" />
+          <div>{t('Failed to load replay summary.')}</div>
+          <div>
+            <Button
+              priority="default"
+              type="button"
+              size="xs"
+              onClick={() => {
+                startSummaryRequest();
+                trackAnalytics('replay.ai-summary.regenerate-requested', {
+                  organization,
+                  area: analyticsArea + area,
+                });
+              }}
+              icon={<IconSync size="xs" />}
+            >
+              {t('Retry')}
+            </Button>
+          </div>
+        </EndStateContainer>
+      </Wrapper>
+    );
+  }
+
   if (replayRecord?.project_id && !project) {
     return (
       <Wrapper data-test-id="replay-details-ai-summary-tab">
@@ -119,59 +147,11 @@ export default function Ai() {
   }
 
   if (didTimeout) {
-    return (
-      <Wrapper data-test-id="replay-details-ai-summary-tab">
-        <EndStateContainer>
-          <img src={aiBanner} alt="" />
-          <div>{t('Failed to load replay summary.')}</div>
-          <div>
-            <Button
-              priority="default"
-              type="button"
-              size="xs"
-              onClick={() => {
-                startSummaryRequest();
-                trackAnalytics('replay.ai-summary.regenerate-requested', {
-                  organization,
-                  area: analyticsArea + '.timeout',
-                });
-              }}
-              icon={<IconSync size="xs" />}
-            >
-              {t('Retry')}
-            </Button>
-          </div>
-        </EndStateContainer>
-      </Wrapper>
-    );
+    return <ErrorState area=".timeout" />;
   }
 
   if (isError) {
-    return (
-      <Wrapper data-test-id="replay-details-ai-summary-tab">
-        <EndStateContainer>
-          <img src={aiBanner} alt="" />
-          <div>{t('Failed to load replay summary.')}</div>
-          <div>
-            <Button
-              priority="default"
-              type="button"
-              size="xs"
-              onClick={() => {
-                startSummaryRequest();
-                trackAnalytics('replay.ai-summary.regenerate-requested', {
-                  organization,
-                  area: analyticsArea + '.error',
-                });
-              }}
-              icon={<IconSync size="xs" />}
-            >
-              {t('Retry')}
-            </Button>
-          </div>
-        </EndStateContainer>
-      </Wrapper>
-    );
+    return <ErrorState area=".error" />;
   }
 
   // checking this prevents initial flicker

--- a/static/app/views/replays/detail/ai/ai.tsx
+++ b/static/app/views/replays/detail/ai/ai.tsx
@@ -243,7 +243,7 @@ export default function Ai() {
           {segmentCount > 100 && (
             <Subtext>
               {t(
-                'Note: this replay is too long, so we currently only summarize part of it.'
+                `Note: this replay is too long, so we're currently only summarizing part of it.`
               )}
             </Subtext>
           )}

--- a/static/app/views/replays/detail/ai/replaySummaryContext.tsx
+++ b/static/app/views/replays/detail/ai/replaySummaryContext.tsx
@@ -16,7 +16,6 @@ const ReplaySummaryContext = createContext<UseFetchReplaySummaryResult>({
   isPolling: false,
   startSummaryRequest: () => {},
   isStartSummaryRequestPending: false,
-  didTimeout: false,
 });
 
 export function useReplaySummaryContext() {

--- a/static/app/views/replays/detail/ai/replaySummaryContext.tsx
+++ b/static/app/views/replays/detail/ai/replaySummaryContext.tsx
@@ -13,7 +13,7 @@ const ReplaySummaryContext = createContext<UseFetchReplaySummaryResult>({
   summaryData: undefined,
   isError: false,
   isPending: false,
-  isPolling: false,
+  isTimedOut: false,
   startSummaryRequest: () => {},
   isStartSummaryRequestPending: false,
 });

--- a/static/app/views/replays/detail/ai/replaySummaryContext.tsx
+++ b/static/app/views/replays/detail/ai/replaySummaryContext.tsx
@@ -16,6 +16,7 @@ const ReplaySummaryContext = createContext<UseFetchReplaySummaryResult>({
   isPolling: false,
   startSummaryRequest: () => {},
   isStartSummaryRequestPending: false,
+  didTimeout: false,
 });
 
 export function useReplaySummaryContext() {

--- a/static/app/views/replays/detail/ai/useFetchReplaySummary.spec.tsx
+++ b/static/app/views/replays/detail/ai/useFetchReplaySummary.spec.tsx
@@ -77,7 +77,6 @@ describe('useFetchReplaySummary', () => {
       await waitFor(() => {
         expect(result.current.summaryData).toEqual(mockSummaryData);
       });
-      expect(result.current.isPolling).toBe(false);
       expect(result.current.isPending).toBe(false);
       expect(result.current.isError).toBe(false);
       expect(mockRequest).toHaveBeenCalledTimes(1);
@@ -97,7 +96,6 @@ describe('useFetchReplaySummary', () => {
       await waitFor(() => {
         expect(result.current.isError).toBe(true);
       });
-      expect(result.current.isPolling).toBe(false);
       expect(result.current.isPending).toBe(false);
     });
   });
@@ -121,7 +119,6 @@ describe('useFetchReplaySummary', () => {
 
       // The hook should not make API calls when disabled
       expect(result.current.summaryData).toBeUndefined();
-      expect(result.current.isPolling).toBe(false);
       expect(result.current.isError).toBe(false);
       expect(mockRequest).not.toHaveBeenCalled();
     });
@@ -145,12 +142,11 @@ describe('useFetchReplaySummary', () => {
       await waitFor(() => {
         expect(result.current.summaryData).toBeDefined();
       });
-      expect(result.current.isPolling).toBe(false);
       expect(result.current.isPending).toBe(false);
       expect(result.current.isError).toBe(false);
     });
 
-    it('should poll when summary data is undefined and startSummaryRequest is pending', async () => {
+    it('should be pending when summary data is undefined and startSummaryRequest is pending', async () => {
       // Mock the initial query to return undefined data
       const initialQuery = MockApiClient.addMockResponse({
         url: `/projects/${mockOrganization.slug}/${mockProject.slug}/replays/replay-123/summarize/`,
@@ -182,7 +178,7 @@ describe('useFetchReplaySummary', () => {
       });
 
       expect(result.current.summaryData).toBeUndefined();
-      expect(result.current.isPolling).toBe(true);
+      expect(result.current.isPending).toBe(true);
       expect(initialQuery).toHaveBeenCalledTimes(1);
       expect(startSummaryRequest).toHaveBeenCalledTimes(1);
 
@@ -191,8 +187,8 @@ describe('useFetchReplaySummary', () => {
     });
   });
 
-  describe('polling behavior', () => {
-    it('should poll when status is PROCESSING', async () => {
+  describe('pending behavior', () => {
+    it('should be pending when status is PROCESSING', async () => {
       MockApiClient.addMockResponse({
         url: `/projects/${mockOrganization.slug}/${mockProject.slug}/replays/replay-123/summarize/`,
         body: {status: ReplaySummaryStatus.PROCESSING, data: undefined},
@@ -203,13 +199,12 @@ describe('useFetchReplaySummary', () => {
       });
 
       await waitFor(() => {
-        expect(result.current.isPolling).toBe(true);
+        expect(result.current.isPending).toBe(true);
       });
-      expect(result.current.isPending).toBe(true);
       expect(result.current.isError).toBe(false);
     });
 
-    it('should stop polling when status is COMPLETED', async () => {
+    it('should not be pending when status is COMPLETED', async () => {
       MockApiClient.addMockResponse({
         url: `/projects/${mockOrganization.slug}/${mockProject.slug}/replays/replay-123/summarize/`,
         body: {
@@ -223,13 +218,12 @@ describe('useFetchReplaySummary', () => {
       });
 
       await waitFor(() => {
-        expect(result.current.isPolling).toBe(false);
+        expect(result.current.isPending).toBe(false);
       });
-      expect(result.current.isPending).toBe(false);
       expect(result.current.isError).toBe(false);
     });
 
-    it('should stop polling when status is ERROR', async () => {
+    it('should not be pending when status is ERROR', async () => {
       MockApiClient.addMockResponse({
         url: `/projects/${mockOrganization.slug}/${mockProject.slug}/replays/replay-123/summarize/`,
         body: {status: ReplaySummaryStatus.ERROR, data: undefined},
@@ -240,9 +234,8 @@ describe('useFetchReplaySummary', () => {
       });
 
       await waitFor(() => {
-        expect(result.current.isPolling).toBe(false);
+        expect(result.current.isPending).toBe(false);
       });
-      expect(result.current.isPending).toBe(false);
       expect(result.current.isError).toBe(true);
     });
   });
@@ -268,9 +261,8 @@ describe('useFetchReplaySummary', () => {
       });
 
       await waitFor(() => {
-        expect(result.current.isPolling).toBe(false);
+        expect(result.current.isPending).toBe(false);
       });
-      expect(result.current.isPending).toBe(false);
       expect(result.current.isError).toBe(false);
       expect(mockPostRequest).toHaveBeenCalledTimes(0);
 

--- a/static/app/views/replays/detail/ai/useFetchReplaySummary.tsx
+++ b/static/app/views/replays/detail/ai/useFetchReplaySummary.tsx
@@ -172,6 +172,8 @@ export function useFetchReplaySummary(
       return;
     }
 
+    // Reset timeout state when manually starting a new summary request
+    setDidTimeout(false);
     startSummaryRequestMutate();
   }, [options?.enabled, startSummaryRequestMutate]);
 

--- a/static/app/views/replays/detail/ai/useFetchReplaySummary.tsx
+++ b/static/app/views/replays/detail/ai/useFetchReplaySummary.tsx
@@ -13,8 +13,6 @@ import {
 } from 'sentry/views/replays/detail/ai/utils';
 
 export interface UseFetchReplaySummaryResult {
-  /** Whether the summary generation POST request timed out. */
-  didTimeout: boolean;
   /**
    * Whether there was an error with the initial query or summary generation,
    * or the summary data status is errored.
@@ -43,7 +41,7 @@ export interface UseFetchReplaySummaryResult {
 }
 
 const POLL_INTERVAL_MS = 500;
-const GLOBAL_TIMEOUT_MS = 45 * 1000; // Timeout is 45 seconds total across all POST requests
+const GLOBAL_TIMEOUT_MS = 30 * 1000; // Timeout is 30 seconds total for polling
 
 const isPolling = (
   summaryData: SummaryResponse | undefined,
@@ -203,7 +201,8 @@ export function useFetchReplaySummary(
   const isErrorRet =
     isError ||
     summaryData?.status === ReplaySummaryStatus.ERROR ||
-    isStartSummaryRequestError;
+    isStartSummaryRequestError ||
+    didTimeout;
 
   // Auto-start logic.
   // TODO: remove the condition segmentCount <= 100
@@ -249,6 +248,5 @@ export function useFetchReplaySummary(
     isError: isErrorRet,
     startSummaryRequest,
     isStartSummaryRequestPending,
-    didTimeout,
   };
 }

--- a/static/app/views/replays/detail/ai/useFetchReplaySummary.tsx
+++ b/static/app/views/replays/detail/ai/useFetchReplaySummary.tsx
@@ -41,7 +41,7 @@ export interface UseFetchReplaySummaryResult {
 }
 
 const POLL_INTERVAL_MS = 500;
-const GLOBAL_TIMEOUT_MS = 30 * 1000; // Timeout is 30 seconds total for polling
+const GLOBAL_TIMEOUT_MS = 30 * 1000;
 
 const isPolling = (
   summaryData: SummaryResponse | undefined,
@@ -64,7 +64,7 @@ const isPolling = (
       return isStartSummaryRequestPending;
 
     case ReplaySummaryStatus.PROCESSING:
-      // Currently processing - always poll (unless timeout occurred)
+      // Currently processing - poll
       return true;
 
     case ReplaySummaryStatus.COMPLETED:
@@ -104,7 +104,7 @@ export function useFetchReplaySummary(
   // component will briefly show a completed state before the summary data query updates.
   const startSummaryRequestTime = useRef<number>(0);
 
-  // The global timeout prevents against infinite polling.
+  // The global timeout to prevent against infinite polling
   const pollingTimeoutRef = useRef<number | null>(null);
   const [didTimeout, setDidTimeout] = useState(false);
 
@@ -189,7 +189,6 @@ export function useFetchReplaySummary(
     isStartSummaryRequestError ||
     didTimeout;
 
-  // Manage polling timeout - start timeout when polling begins, clear when it stops
   useEffect(() => {
     if (isPollingRet && !pollingTimeoutRef.current) {
       setDidTimeout(false);

--- a/static/app/views/replays/detail/ai/useFetchReplaySummary.tsx
+++ b/static/app/views/replays/detail/ai/useFetchReplaySummary.tsx
@@ -158,7 +158,7 @@ export function useFetchReplaySummary(
     }
     startSummaryRequestMutate();
 
-    // Start new polling timeout.
+    // Clear timeout, if any, and start a new one.
     setDidTimeout(false);
     clearPollingTimeout();
     pollingTimeoutRef.current = window.setTimeout(() => {

--- a/static/app/views/replays/detail/ai/useFetchReplaySummary.tsx
+++ b/static/app/views/replays/detail/ai/useFetchReplaySummary.tsx
@@ -114,7 +114,6 @@ export function useFetchReplaySummary(
     };
   }, []);
 
-  // Start summary logic.
   const {
     mutate: startSummaryRequestMutate,
     isError: isStartSummaryRequestError,
@@ -146,7 +145,6 @@ export function useFetchReplaySummary(
         ),
       });
       startSummaryRequestTime.current = Date.now();
-      clearPollingTimeout(); // Clear since this request succeeded.
     },
   });
 
@@ -165,7 +163,6 @@ export function useFetchReplaySummary(
     }, POLL_TIMEOUT_MS);
   }, [options?.enabled, startSummaryRequestMutate]);
 
-  // Polling logic.
   const {
     data: summaryData,
     isPending,
@@ -186,6 +183,13 @@ export function useFetchReplaySummary(
       ...options,
     }
   );
+
+  useEffect(() => {
+    // Clear the polling timeout when we get new summary results.
+    if (!isPending) {
+      clearPollingTimeout();
+    }
+  }, [isPending]);
 
   const isPendingRet =
     dataUpdatedAt < startSummaryRequestTime.current ||

--- a/static/app/views/replays/detail/ai/useFetchReplaySummary.tsx
+++ b/static/app/views/replays/detail/ai/useFetchReplaySummary.tsx
@@ -13,7 +13,7 @@ import {
 } from 'sentry/views/replays/detail/ai/utils';
 
 const POLL_INTERVAL_MS = 500;
-const POLL_TIMEOUT_MS = 30 * 1000;
+const POLL_TIMEOUT_MS = 5 * 1000;
 
 export interface UseFetchReplaySummaryResult {
   /**
@@ -30,6 +30,10 @@ export interface UseFetchReplaySummaryResult {
    * The summary could still be processing even if this is false.
    */
   isStartSummaryRequestPending: boolean;
+  /**
+   * Whether the summary processing timed out. Not the same as isError.
+   */
+  isTimedOut: boolean;
   /** Function to trigger a new summary generation request. */
   startSummaryRequest: () => void;
   /** The summary data response from the API. */
@@ -199,8 +203,7 @@ export function useFetchReplaySummary(
   const isErrorRet =
     isStartSummaryRequestError ||
     isError ||
-    summaryData?.status === ReplaySummaryStatus.ERROR ||
-    didTimeout;
+    summaryData?.status === ReplaySummaryStatus.ERROR;
 
   // Auto-start logic.
   // TODO: remove the condition segmentCount <= 100
@@ -228,6 +231,7 @@ export function useFetchReplaySummary(
     summaryData,
     isPending: isPendingRet,
     isError: isErrorRet,
+    isTimedOut: didTimeout,
     startSummaryRequest,
     isStartSummaryRequestPending,
   };

--- a/static/app/views/replays/detail/ai/useFetchReplaySummary.tsx
+++ b/static/app/views/replays/detail/ai/useFetchReplaySummary.tsx
@@ -13,7 +13,7 @@ import {
 } from 'sentry/views/replays/detail/ai/utils';
 
 const POLL_INTERVAL_MS = 500;
-const POLL_TIMEOUT_MS = 5 * 1000;
+const POLL_TIMEOUT_MS = 30 * 1000; // Based on task timeout in Seer.
 
 export interface UseFetchReplaySummaryResult {
   /**
@@ -188,13 +188,6 @@ export function useFetchReplaySummary(
     }
   );
 
-  useEffect(() => {
-    // Clear the polling timeout when we get new summary results.
-    if (!isPending) {
-      clearPollingTimeout();
-    }
-  }, [isPending]);
-
   const isPendingRet =
     dataUpdatedAt < startSummaryRequestTime.current ||
     isStartSummaryRequestPending ||
@@ -204,6 +197,13 @@ export function useFetchReplaySummary(
     isStartSummaryRequestError ||
     isError ||
     summaryData?.status === ReplaySummaryStatus.ERROR;
+
+  useEffect(() => {
+    // Clears the polling timeout when we get valid summary results.
+    if (!isPendingRet) {
+      clearPollingTimeout();
+    }
+  }, [isPendingRet]);
 
   // Auto-start logic.
   // TODO: remove the condition segmentCount <= 100

--- a/static/app/views/replays/detail/ai/useFetchReplaySummary.tsx
+++ b/static/app/views/replays/detail/ai/useFetchReplaySummary.tsx
@@ -212,17 +212,12 @@ export function useFetchReplaySummary(
     segmentCount > summaryData.num_segments;
   const needsInitialGeneration = summaryData?.status === ReplaySummaryStatus.NOT_STARTED;
 
-  const isGlobalTimeoutReached =
-    startSummaryRequestTime.current > 0 &&
-    Date.now() - startSummaryRequestTime.current > GLOBAL_TIMEOUT_MS;
-
   useEffect(() => {
     if (
       (segmentsIncreased || needsInitialGeneration) &&
       !isPendingRet &&
       !isPollingRet &&
-      !isErrorRet &&
-      !isGlobalTimeoutReached
+      !isErrorRet
     ) {
       startSummaryRequest();
     }
@@ -233,7 +228,6 @@ export function useFetchReplaySummary(
     isPollingRet,
     startSummaryRequest,
     isErrorRet,
-    isGlobalTimeoutReached,
   ]);
 
   // Cleanup global timeout on unmount

--- a/static/app/views/replays/detail/ai/useFetchReplaySummary.tsx
+++ b/static/app/views/replays/detail/ai/useFetchReplaySummary.tsx
@@ -12,6 +12,9 @@ import {
   type SummaryResponse,
 } from 'sentry/views/replays/detail/ai/utils';
 
+const POLL_INTERVAL_MS = 500;
+const POLL_TIMEOUT_MS = 30 * 1000;
+
 export interface UseFetchReplaySummaryResult {
   /**
    * Whether there was an error with the initial query or summary generation,
@@ -32,9 +35,6 @@ export interface UseFetchReplaySummaryResult {
   /** The summary data response from the API. */
   summaryData: SummaryResponse | undefined;
 }
-
-const POLL_INTERVAL_MS = 500;
-const POLL_TIMEOUT_MS = 5 * 1000;
 
 const shouldPoll = (
   summaryData: SummaryResponse | undefined,

--- a/static/app/views/replays/detail/ai/useFetchReplaySummary.tsx
+++ b/static/app/views/replays/detail/ai/useFetchReplaySummary.tsx
@@ -113,10 +113,13 @@ export function useFetchReplaySummary(
   } = useMutation({
     mutationFn: () => {
       if (!timeoutRef.current) {
+        setDidTimeout(false);
+
         timeoutRef.current = window.setTimeout(() => {
           // after GLOBAL_TIMEOUT_MS passes, set the timeout state as true,
           // causing a re-render, so we can show an error message
           setDidTimeout(true);
+          timeoutRef.current = null;
         }, GLOBAL_TIMEOUT_MS);
       }
       return api.requestPromise(


### PR DESCRIPTION
relates to https://linear.app/getsentry/issue/REPLAY-670/frontend-should-prevent-infinite-post-requests

will implement the rest of the ticket ("only 1 request for the 'needs initial generation' case") in a followup

timeout state (same as error state):

<img width="670" height="564" alt="SCR-20250904-nrpi" src="https://github.com/user-attachments/assets/3d810797-daea-49ba-b024-cd16170b9693" />
