### PR TITLE
fix(typing): Remove sentry.api.paginator from problem list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -305,7 +305,6 @@ ignore_missing_imports = true
 module = [
     "sentry.api.endpoints.organization_events_meta",
     "sentry.api.endpoints.organization_releases",
-    "sentry.api.paginator",
     "sentry.db.postgres.base",
     "sentry.middleware.auth",
     "sentry.middleware.ratelimit",

--- a/src/sentry/utils/cursors.py
+++ b/src/sentry/utils/cursors.py
@@ -7,7 +7,7 @@ T = TypeVar("T")
 CursorValue = Union[float, int, str]
 
 
-class KeyCallable(Protocol):
+class KeyCallable[T](Protocol):
     def __call__(self, value: T, for_prev: bool = ...) -> CursorValue: ...
 
 
@@ -108,7 +108,7 @@ class CursorResult(Sequence[T]):
 
 
 def _build_next_values(
-    cursor: Cursor, results: Sequence[T], key: KeyCallable, limit: int, is_desc: bool
+    cursor: Cursor, results: Sequence[T], key: KeyCallable[T], limit: int, is_desc: bool
 ) -> tuple[CursorValue, int, bool]:
     value = cursor.value
     offset = cursor.offset
@@ -241,7 +241,7 @@ def _build_prev_values(
 
 def build_cursor(
     results: Sequence[T],
-    key: KeyCallable,
+    key: KeyCallable[T],
     limit: int = 100,
     is_desc: bool = False,
     cursor: Cursor | None = None,


### PR DESCRIPTION
Made minimal changes to allow mypy to pass with the file removed from the problem list.

Only potentially-risky change is enforcing the cursor's `int` value type... but IIUC it needs to be int to work, so I don't think this should ever actually be causing problems. Would be better if we could type for this (rather than asserting on it), but I don't feel comfortable genericizing the whole Cursor stack.

Test plan: `mypy` no errors.
