### PR TITLE
fix(replay): use IN condition for trace queries to avoid recursion depth

### DIFF
--- a/src/sentry/replays/usecases/summarize.py
+++ b/src/sentry/replays/usecases/summarize.py
@@ -97,7 +97,7 @@ def fetch_trace_connected_errors(
             organization=project.organization,
         )
 
-        trace_ids_query = " OR ".join([f"trace:{trace_id}" for trace_id in trace_ids])
+        trace_ids_query = f"trace:[{','.join(trace_ids)}]"
 
         # Query for errors dataset
         error_query_results = query_trace_connected_events(


### PR DESCRIPTION
Fixes [SENTRY-4F08](https://sentry.sentry.io/issues/6856703798/events/21489a34b746431d84762b16f0e02d85/)
Closes [REPLAY-671: Recursion depth exceeded for trace queries](https://linear.app/getsentry/issue/REPLAY-671/recursion-depth-exceeded-for-trace-queries)