### PR TITLE
Add auth header to delete grouping records request

### DIFF
--- a/tests/sentry/seer/similarity/test_grouping_records.py
+++ b/tests/sentry/seer/similarity/test_grouping_records.py
@@ -175,7 +175,7 @@ def test_post_bulk_grouping_records_use_reranking(
 
 @django_db_all
 @mock.patch("sentry.seer.similarity.grouping_records.logger")
-@mock.patch("sentry.seer.similarity.grouping_records.seer_grouping_connection_pool.urlopen")
+@mock.patch("sentry.seer.similarity.grouping_records.make_signed_seer_api_request")
 def test_delete_grouping_records_by_hash_success(
     mock_seer_request: MagicMock, mock_logger: MagicMock
 ):
@@ -197,7 +197,7 @@ def test_delete_grouping_records_by_hash_success(
 
 @django_db_all
 @mock.patch("sentry.seer.similarity.grouping_records.logger")
-@mock.patch("sentry.seer.similarity.grouping_records.seer_grouping_connection_pool.urlopen")
+@mock.patch("sentry.seer.similarity.grouping_records.make_signed_seer_api_request")
 def test_delete_grouping_records_by_hash_timeout(
     mock_seer_request: MagicMock, mock_logger: MagicMock
 ):
@@ -220,7 +220,7 @@ def test_delete_grouping_records_by_hash_timeout(
 
 @django_db_all
 @mock.patch("sentry.seer.similarity.grouping_records.logger")
-@mock.patch("sentry.seer.similarity.grouping_records.seer_grouping_connection_pool.urlopen")
+@mock.patch("sentry.seer.similarity.grouping_records.make_signed_seer_api_request")
 def test_delete_grouping_records_by_hash_failure(
     mock_seer_request: MagicMock, mock_logger: MagicMock
 ):


### PR DESCRIPTION
<!-- Describe your PR here. -->
Fixes unauthenticated requests to Seer for deleting grouping records.

**Why:**
Sentry's `call_seer_to_delete_these_hashes` and `call_seer_to_delete_project_grouping_records` functions were making direct HTTP requests to Seer without the required `Authorization` header, leading to "No auth header found" errors in Seer logs.

**What changed:**
1.  `call_seer_to_delete_these_hashes` (POST request) now uses `make_signed_seer_api_request` to ensure proper authentication headers are included.
2.  `call_seer_to_delete_project_grouping_records` (GET request) now explicitly adds authentication headers using `sign_with_seer_secret` as `make_signed_seer_api_request` is POST-specific.
3.  Corresponding test mocks were updated to reflect the change from `seer_grouping_connection_pool.urlopen` to `make_signed_seer_api_request`.

This resolves the authentication issue and prevents "No auth header found" errors for these endpoints.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
<a href="https://cursor.com/background-agent?bcId=bc-f7d88016-6ca4-4d7c-993e-4ed6490df60f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f7d88016-6ca4-4d7c-993e-4ed6490df60f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

