### PR TITLE
chore(aci): Make workflow_engine.buffer.use_new_buffer permanently True

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -100,5 +100,6 @@
   "python.testing.pytestArgs": ["tests"],
   "python.analysis.autoImportCompletions": true,
   "prettier.configPath": "prettier.config.mjs",
-  "biome.enabled": false
+  "biome.enabled": false,
+  "cursorpyright.analysis.autoImportCompletions": true
 }

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3140,7 +3140,7 @@ register(
 register(
     "workflow_engine.buffer.use_new_buffer",
     type=Bool,
-    default=False,
+    default=True,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 

--- a/src/sentry/workflow_engine/buffer/__init__.py
+++ b/src/sentry/workflow_engine/buffer/__init__.py
@@ -1,7 +1,5 @@
 from django.conf import settings
 
-import sentry.buffer as old_buffer
-from sentry import options
 from sentry.buffer.base import Buffer
 from sentry.utils.services import LazyServiceWrapper
 
@@ -15,7 +13,4 @@ def get_backend() -> LazyServiceWrapper[Buffer]:
     """
     Retrieve the appropriate Buffer to use for the workflow engine.
     """
-    if options.get("workflow_engine.buffer.use_new_buffer"):
-        return _backend
-    else:
-        return old_buffer.backend
+    return _backend

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -4,6 +4,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 from django.utils import timezone
 
+from sentry.buffer.base import Buffer
+from sentry.buffer.redis import RedisBuffer
 from sentry.eventstream.base import GroupState
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.models.activity import Activity
@@ -12,8 +14,6 @@ from sentry.services.eventstore.models import GroupEvent
 from sentry.testutils.factories import Factories
 from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.testutils.helpers.features import with_feature
-from sentry.testutils.helpers.options import override_options
-from sentry.testutils.helpers.redis import mock_redis_buffer
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.types.activity import ActivityType
 from sentry.utils import json
@@ -315,7 +315,11 @@ class TestProcessWorkflows(BaseWorkflowTest):
         assert triggered_workflows == {self.error_workflow}
 
 
-@mock_redis_buffer()
+def mock_workflows_buffer():
+    return patch("sentry.workflow_engine.buffer.get_backend", new=lambda: RedisBuffer())
+
+
+@mock_workflows_buffer()
 class TestEvaluateWorkflowTriggers(BaseWorkflowTest):
     def setUp(self) -> None:
         (
@@ -485,7 +489,7 @@ class TestWorkflowEnqueuing(BaseWorkflowTest):
         self.action_group, _ = self.create_workflow_action(self.workflow)
 
         self.buffer_keys = DelayedWorkflow.get_buffer_keys()
-        self.mock_redis_buffer = mock_redis_buffer()
+        self.mock_redis_buffer = mock_workflows_buffer()
         self.mock_redis_buffer.__enter__()
 
     def tearDown(self) -> None:
@@ -677,7 +681,7 @@ class TestWorkflowEnqueuing(BaseWorkflowTest):
 
 
 @freeze_time(FROZEN_TIME)
-@mock_redis_buffer()
+@mock_workflows_buffer()
 class TestEvaluateWorkflowActionFilters(BaseWorkflowTest):
     def setUp(self) -> None:
         (
@@ -860,13 +864,13 @@ class TestEnqueueWorkflows(BaseWorkflowTest):
             group=self.group_event.group,
         )
 
-    @patch("sentry.buffer.backend.push_to_sorted_set")
-    @patch("sentry.buffer.backend.push_to_hash_bulk")
+    @patch("sentry.workflow_engine.buffer.get_backend")
     @patch("random.choice")
-    @override_options({"workflow_engine.buffer.use_new_buffer": False})
     def test_enqueue_workflows__adds_to_workflow_engine_buffer(
-        self, mock_randchoice, mock_push_to_hash_bulk, mock_push_to_sorted_set
+        self, mock_randchoice, mock_get_backend
     ) -> None:
+        mock_buffer = MagicMock(spec=Buffer)
+        mock_get_backend.return_value = mock_buffer
         mock_randchoice.return_value = f"{DelayedWorkflow.buffer_key}:{5}"
         enqueue_workflows(
             {
@@ -881,44 +885,17 @@ class TestEnqueueWorkflows(BaseWorkflowTest):
             }
         )
 
-        mock_push_to_sorted_set.assert_called_once_with(
+        mock_buffer.push_to_sorted_set.assert_called_once_with(
             key=f"{DelayedWorkflow.buffer_key}:{5}",
             value=[self.group_event.project_id],
         )
 
-    @patch("sentry.workflow_engine.buffer._backend.push_to_sorted_set")
-    @patch("sentry.workflow_engine.buffer._backend.push_to_hash_bulk")
-    @patch("random.choice")
-    @override_options({"workflow_engine.buffer.use_new_buffer": True})
-    def test_enqueue_workflows__adds_to_workflow_engine_buffer_new_buffer(
-        self, mock_randchoice, mock_push_to_hash_bulk, mock_push_to_sorted_set
-    ) -> None:
-        key_choice = f"{DelayedWorkflow.buffer_key}:{5}"
-        mock_randchoice.return_value = key_choice
-        enqueue_workflows(
-            {
-                self.workflow: DelayedWorkflowItem(
-                    self.workflow,
-                    self.group_event,
-                    self.workflow.when_condition_group_id,
-                    [self.slow_workflow_filter_group.id],
-                    [self.workflow_filter_group.id],
-                    timestamp=timezone.now(),
-                )
-            }
-        )
-
-        mock_push_to_sorted_set.assert_called_once_with(
-            key=key_choice,
-            value=[self.group_event.project_id],
-        )
-
-    @patch("sentry.buffer.backend.push_to_sorted_set")
-    @patch("sentry.buffer.backend.push_to_hash_bulk")
-    @override_options({"workflow_engine.buffer.use_new_buffer": False})
+    @patch("sentry.workflow_engine.buffer.get_backend")
     def test_enqueue_workflow__adds_to_workflow_engine_set(
-        self, mock_push_to_hash_bulk, mock_push_to_sorted_set
+        self, mock_get_backend: MagicMock
     ) -> None:
+        mock_buffer = MagicMock(spec=Buffer)
+        mock_get_backend.return_value = mock_buffer
         current_time = timezone.now()
         workflow_filter_group_2 = self.create_data_condition_group()
         self.create_workflow_data_condition_group(
@@ -955,7 +932,7 @@ class TestEnqueueWorkflows(BaseWorkflowTest):
         passing_condition_group_ids = ",".join(
             str(id) for id in [self.workflow_filter_group.id, workflow_filter_group_2.id]
         )
-        mock_push_to_hash_bulk.assert_called_once_with(
+        mock_buffer.push_to_hash_bulk.assert_called_once_with(
             model=Workflow,
             filters={"project_id": self.group_event.project_id},
             data={


### PR DESCRIPTION
It's been true in prod for some time, and it's not going back.

Option to be removed once nothing deployed cares about the value.
