### PR TITLE
chore(releases): Add `get_or_create_commit` function to optionally create commits in some cases

### DIFF
--- a/tests/sentry/releases/test_commits.py
+++ b/tests/sentry/releases/test_commits.py
@@ -174,6 +174,7 @@ class CreateCommitDualWriteTest(TestCase):
             assert not OldCommit.objects.filter(key="test_atomicity_key").exists()
             assert not Commit.objects.filter(key="test_atomicity_key").exists()
 
+
 class GetOrCreateCommitDualWriteTest(TestCase):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
Context: https://www.notion.so/sentry/Release-Retention-2028b10e4b5d802ea421c193303becaf

In some places we fetch or create an existing commit. Adding a function to handle the dual write here as well