### PR TITLE
chore(releases): Use `create_commit` when creating commits

### DIFF
--- a/src/sentry/integrations/bitbucket/webhook.py
+++ b/src/sentry/integrations/bitbucket/webhook.py
@@ -29,6 +29,7 @@ from sentry.models.commitauthor import CommitAuthor
 from sentry.models.organization import Organization
 from sentry.models.repository import Repository
 from sentry.plugins.providers import IntegrationRepositoryProvider
+from sentry.releases.commits import create_commit
 from sentry.utils.email import parse_email
 
 logger = logging.getLogger("sentry.webhooks")
@@ -144,9 +145,9 @@ class PushEventWebhook(BitbucketWebhook):
                     author = authors[author_email]
                 try:
                     with transaction.atomic(router.db_for_write(Commit)):
-                        Commit.objects.create(
-                            repository_id=repo.id,
-                            organization_id=organization.id,
+                        create_commit(
+                            organization=organization,
+                            repo_id=repo.id,
                             key=commit["hash"],
                             message=commit["message"],
                             author=author,

--- a/src/sentry/integrations/bitbucket_server/webhook.py
+++ b/src/sentry/integrations/bitbucket_server/webhook.py
@@ -26,6 +26,7 @@ from sentry.models.commitauthor import CommitAuthor
 from sentry.models.organization import Organization
 from sentry.models.repository import Repository
 from sentry.plugins.providers import IntegrationRepositoryProvider
+from sentry.releases.commits import create_commit
 from sentry.shared_integrations.exceptions import ApiHostError, ApiUnauthorized, IntegrationError
 from sentry.web.frontend.base import region_silo_view
 
@@ -131,9 +132,9 @@ class PushEventWebhook(BitbucketServerWebhook):
                         author = authors[author_email]
                     try:
                         with transaction.atomic(router.db_for_write(Commit)):
-                            Commit.objects.create(
-                                repository_id=repo.id,
-                                organization_id=organization.id,
+                            create_commit(
+                                organization=organization,
+                                repo_id=repo.id,
                                 key=commit["id"],
                                 message=commit["message"],
                                 author=author,

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -44,6 +44,7 @@ from sentry.plugins.providers.integration_repository import (
     RepoExistsError,
     get_integration_repository_provider,
 )
+from sentry.releases.commits import create_commit
 from sentry.seer.autofix.webhooks import handle_github_pr_webhook_for_autofix
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.users.services.user.service import user_service
@@ -424,9 +425,9 @@ class PushEventWebhook(GitHubWebhook):
                 author.preload_users()
             try:
                 with transaction.atomic(router.db_for_write(Commit)):
-                    c = Commit.objects.create(
-                        repository_id=repo.id,
-                        organization_id=organization.id,
+                    c, _ = create_commit(
+                        organization=organization,
+                        repo_id=repo.id,
                         key=commit["id"],
                         message=commit["message"],
                         author=author,

--- a/src/sentry/integrations/gitlab/webhooks.py
+++ b/src/sentry/integrations/gitlab/webhooks.py
@@ -33,6 +33,7 @@ from sentry.models.repository import Repository
 from sentry.organizations.services.organization import organization_service
 from sentry.organizations.services.organization.model import RpcOrganization
 from sentry.plugins.providers import IntegrationRepositoryProvider
+from sentry.releases.commits import create_commit
 
 logger = logging.getLogger("sentry.webhooks")
 
@@ -251,9 +252,9 @@ class PushEventWebhook(GitlabWebhook):
                 if author is not None:
                     author.preload_users()
                 with transaction.atomic(router.db_for_write(Commit)):
-                    Commit.objects.create(
-                        repository_id=repo.id,
-                        organization_id=organization.id,
+                    create_commit(
+                        organization=organization,
+                        repo_id=repo.id,
                         key=commit["id"],
                         message=commit["message"],
                         author=author,

--- a/src/sentry/integrations/utils/commit_context.py
+++ b/src/sentry/integrations/utils/commit_context.py
@@ -28,6 +28,7 @@ from sentry.issues.auto_source_code_config.code_mapping import (
 from sentry.models.commit import Commit
 from sentry.models.commitauthor import CommitAuthor
 from sentry.models.organization import Organization
+from sentry.releases.commits import create_commit
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.utils import metrics
 from sentry.utils.committers import get_stacktrace_path_from_event_frame
@@ -160,9 +161,9 @@ def get_or_create_commit_from_blame(
             email=blame.commit.commitAuthorEmail,
             defaults={"name": blame.commit.commitAuthorName},
         )
-        commit = Commit.objects.create(
-            organization_id=organization_id,
-            repository_id=blame.repo.id,
+        commit, _ = create_commit(
+            organization=Organization.objects.get(id=organization_id),
+            repo_id=blame.repo.id,
             key=blame.commit.commitId,
             date_added=blame.commit.committedDate,
             author=commit_author,

--- a/src/sentry_plugins/bitbucket/endpoints/webhook.py
+++ b/src/sentry_plugins/bitbucket/endpoints/webhook.py
@@ -17,6 +17,7 @@ from sentry.models.commitauthor import CommitAuthor
 from sentry.models.repository import Repository
 from sentry.organizations.services.organization.service import organization_service
 from sentry.plugins.providers import RepositoryProvider
+from sentry.releases.commits import create_commit
 from sentry.utils import json
 from sentry.utils.email import parse_email
 
@@ -67,9 +68,10 @@ class PushEventWebhook(Webhook):
                     author = authors[author_email]
                 try:
                     with transaction.atomic(router.db_for_write(Commit)):
-                        Commit.objects.create(
-                            repository_id=repo.id,
-                            organization_id=organization_id,
+                        organization = organization_service.get(id=organization_id)
+                        create_commit(
+                            organization=organization,
+                            repo_id=repo.id,
                             key=commit["hash"],
                             message=commit["message"],
                             author=author,

--- a/src/sentry_plugins/bitbucket/endpoints/webhook.py
+++ b/src/sentry_plugins/bitbucket/endpoints/webhook.py
@@ -14,6 +14,7 @@ from rest_framework.request import Request
 from sentry.integrations.bitbucket.constants import BITBUCKET_IP_RANGES, BITBUCKET_IPS
 from sentry.models.commit import Commit
 from sentry.models.commitauthor import CommitAuthor
+from sentry.models.organization import Organization
 from sentry.models.repository import Repository
 from sentry.organizations.services.organization.service import organization_service
 from sentry.plugins.providers import RepositoryProvider
@@ -68,7 +69,7 @@ class PushEventWebhook(Webhook):
                     author = authors[author_email]
                 try:
                     with transaction.atomic(router.db_for_write(Commit)):
-                        organization = organization_service.get(id=organization_id)
+                        organization = Organization.objects.get(id=organization_id)
                         create_commit(
                             organization=organization,
                             repo_id=repo.id,

--- a/src/sentry_plugins/github/webhooks/events/push.py
+++ b/src/sentry_plugins/github/webhooks/events/push.py
@@ -15,6 +15,7 @@ from sentry.models.commitfilechange import CommitFileChange
 from sentry.models.organization import Organization
 from sentry.models.repository import Repository
 from sentry.plugins.providers import RepositoryProvider
+from sentry.releases.commits import create_commit
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.users.services.user.service import user_service
 from sentry_plugins.github.client import GithubPluginClient
@@ -141,9 +142,9 @@ class PushEventWebhook(Webhook):
 
             try:
                 with transaction.atomic(router.db_for_write(Commit)):
-                    c = Commit.objects.create(
-                        repository_id=repo.id,
-                        organization_id=organization_id,
+                    c, _ = create_commit(
+                        organization=Organization.objects.get(id=organization_id),
+                        repo_id=repo.id,
                         key=commit["id"],
                         message=commit["message"],
                         author=author,

--- a/src/sentry_plugins/github/webhooks/events/push.py
+++ b/src/sentry_plugins/github/webhooks/events/push.py
@@ -40,6 +40,11 @@ class PushEventWebhook(Webhook):
         except Repository.DoesNotExist:
             raise Http404()
 
+        try:
+            organization = Organization.objects.get(id=organization_id)
+        except Organization.DoesNotExist:
+            raise Http404()
+
         # We need to track GitHub's "full_name" which is the repository slug.
         # This is needed to access the API since `external_id` isn't sufficient.
         if repo.config.get("name") != event["repository"]["full_name"]:
@@ -143,7 +148,7 @@ class PushEventWebhook(Webhook):
             try:
                 with transaction.atomic(router.db_for_write(Commit)):
                     c, _ = create_commit(
-                        organization=Organization.objects.get(id=organization_id),
+                        organization=organization,
                         repo_id=repo.id,
                         key=commit["id"],
                         message=commit["message"],


### PR DESCRIPTION
Context: https://www.notion.so/sentry/Release-Retention-2028b10e4b5d802ea421c193303becaf

Use our new dual writing function for creating commits so that we can dual write when we enable the feature flag. This excludes uses of `get_or_create_commit` for now.

<!-- Describe your PR here. -->