### PR TITLE
fix(bug-prediction): Check org when getting event

### DIFF
--- a/src/sentry/seer/fetch_issues/fetch_issues_given_exception_type.py
+++ b/src/sentry/seer/fetch_issues/fetch_issues_given_exception_type.py
@@ -23,7 +23,7 @@ This number is global so that fetching issues and events is consistent.
 logger = logging.getLogger(__name__)
 
 
-def get_latest_issue_event(group_id: int) -> dict[str, Any]:
+def get_latest_issue_event(group_id: int, organization_id: int | None = None) -> dict[str, Any]:
     """
     Get the latest event for a group.
     """
@@ -32,6 +32,17 @@ def get_latest_issue_event(group_id: int) -> dict[str, Any]:
         logger.warning(
             "Group not found",
             extra={"group_id": group_id},
+        )
+        return {}
+
+    if organization_id is not None and group.organization.id != organization_id:
+        logger.warning(
+            "Group does not belong to expected organization",
+            extra={
+                "group_id": group_id,
+                "organization_id": organization_id,
+                "actual_organization_id": group.organization.id,
+            },
         )
         return {}
 

--- a/src/sentry/seer/fetch_issues/fetch_issues_given_exception_type.py
+++ b/src/sentry/seer/fetch_issues/fetch_issues_given_exception_type.py
@@ -35,7 +35,7 @@ def get_latest_issue_event(group_id: int, organization_id: int | None = None) ->
         )
         return {}
 
-    if organization_id is not None and group.organization.id != organization_id:
+    if group.organization.id != organization_id:
         logger.warning(
             "Group does not belong to expected organization",
             extra={

--- a/tests/sentry/seer/fetch_issues/test_fetch_issues_given_exception_type.py
+++ b/tests/sentry/seer/fetch_issues/test_fetch_issues_given_exception_type.py
@@ -339,3 +339,13 @@ class TestGetIssuesGivenExceptionTypes(APITestCase, SnubaTestCase):
             group_id=1,
         )
         assert group_ids == {}
+
+    def test_get_latest_issue_event_wrong_organization(self) -> None:
+        event = self.store_event(data={}, project_id=self.project.id)
+        group = event.group
+        assert group is not None
+
+        # Test with wrong organization_id - should return empty dict
+        wrong_org_id = group.organization.id + 1
+        results = get_latest_issue_event(group.id, organization_id=wrong_org_id)
+        assert results == {}

--- a/tests/sentry/seer/fetch_issues/test_fetch_issues_given_exception_type.py
+++ b/tests/sentry/seer/fetch_issues/test_fetch_issues_given_exception_type.py
@@ -71,7 +71,7 @@ class TestGetIssuesGivenExceptionTypes(APITestCase, SnubaTestCase):
         assert group_ids == {"issues": [], "issues_full": []}
 
         # Assert latest event is returned
-        results = get_latest_issue_event(group.id)
+        results = get_latest_issue_event(group.id, organization_id=self.organization.id)
         assert results["id"] == group.id
         assert results["title"] == "KeyError: This a bad error"
         assert len(results["events"]) == 1
@@ -165,7 +165,7 @@ class TestGetIssuesGivenExceptionTypes(APITestCase, SnubaTestCase):
         assert group_3.id not in [int(issue["id"]) for issue in group_ids["issues_full"]]
 
         # Assert latest event is returned
-        results = get_latest_issue_event(group_1.id)
+        results = get_latest_issue_event(group_1.id, organization_id=self.organization.id)
         assert results["id"] == group_1.id
         assert results["title"] == "KeyError: This a bad error"
         assert len(results["events"]) == 1
@@ -225,7 +225,7 @@ class TestGetIssuesGivenExceptionTypes(APITestCase, SnubaTestCase):
         assert group_ids == {"issues": [], "issues_full": []}
 
         # Assert latest event is returned
-        results = get_latest_issue_event(group.id)
+        results = get_latest_issue_event(group.id, organization_id=self.organization.id)
         assert results["id"] == group.id
         assert results["title"] == "KeyError: This a bad error"
         assert len(results["events"]) == 1
@@ -303,7 +303,7 @@ class TestGetIssuesGivenExceptionTypes(APITestCase, SnubaTestCase):
         assert group_ids["issues_full"][0]["title"] == "ValueError: This a bad error"
 
         # Assert latest event is returned
-        results = get_latest_issue_event(group_2.id)
+        results = get_latest_issue_event(group_2.id, organization_id=self.organization.id)
         assert results["id"] == group_2.id
         assert results["title"] == "ValueError: This a bad error"
         assert len(results["events"]) == 1
@@ -345,7 +345,5 @@ class TestGetIssuesGivenExceptionTypes(APITestCase, SnubaTestCase):
         group = event.group
         assert group is not None
 
-        # Test with wrong organization_id - should return empty dict
-        wrong_org_id = group.organization.id + 1
-        results = get_latest_issue_event(group.id, organization_id=wrong_org_id)
+        results = get_latest_issue_event(group.id)
         assert results == {}


### PR DESCRIPTION
defaulting to `None` disables this fetch until [the seer PR](https://github.com/getsentry/seer/pull/3297) is deployed