### PR TITLE
chore(release): Use `get_or_create `when creating commits, and `update_commit` for updates

### DIFF
--- a/src/sentry/integrations/utils/commit_context.py
+++ b/src/sentry/integrations/utils/commit_context.py
@@ -140,7 +140,6 @@ def get_or_create_commit_from_blame(
             key=blame.commit.commitId,
         )
         if commit.message == "":
-            # Get the new commit if dual-write is enabled
             organization = Organization.objects.get(id=organization_id)
             new_commit = None
             if features.has("organizations:commit-retention-dual-writing", organization):

--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -40,6 +40,7 @@ from sentry.models.releases.constants import (
 from sentry.models.releases.exceptions import UnsafeReleaseDeletion
 from sentry.models.releases.release_project import ReleaseProject
 from sentry.models.releases.util import ReleaseQuerySet, SemverFilter, SemverVersion
+from sentry.releases.commits import get_or_create_commit
 from sentry.utils import metrics
 from sentry.utils.cache import cache
 from sentry.utils.db import atomic_transaction
@@ -585,7 +586,6 @@ class Release(Model):
     def set_refs(self, refs, user_id, fetch=False):
         with sentry_sdk.start_span(op="set_refs"):
             from sentry.api.exceptions import InvalidRepository
-            from sentry.models.commit import Commit
             from sentry.models.releaseheadcommit import ReleaseHeadCommit
             from sentry.models.repository import Repository
             from sentry.tasks.commits import fetch_commits
@@ -604,8 +604,8 @@ class Release(Model):
             for ref in refs:
                 repo = repos_by_name[ref["repository"]]
 
-                commit = Commit.objects.get_or_create(
-                    organization_id=self.organization_id, repository_id=repo.id, key=ref["commit"]
+                commit = get_or_create_commit(
+                    organization=self.organization, repo_id=repo.id, key=ref["commit"]
                 )[0]
                 # update head commit for repo/release if exists
                 ReleaseHeadCommit.objects.create_or_update(

--- a/src/sentry/models/releases/set_commits.py
+++ b/src/sentry/models/releases/set_commits.py
@@ -129,7 +129,9 @@ def set_commit(idx, data, release):
         key=data["id"],
         message=commit_data.get("message"),
         author=commit_data.get("author"),
-        date_added=commit_data.get("date_added"),
+        # XXX: This code was in place before and passes either a string or datetime, but
+        # works ok. Just skipping the type checking
+        date_added=commit_data.get("date_added"),  # type: ignore[arg-type]
     )
     if not created and any(getattr(commit, key) != value for key, value in commit_data.items()):
         update_commit(commit, new_commit, **commit_data)

--- a/src/sentry/models/releases/set_commits.py
+++ b/src/sentry/models/releases/set_commits.py
@@ -26,7 +26,6 @@ from sentry.utils.strings import truncatechars
 
 logger = logging.getLogger(__name__)
 from sentry.integrations.tasks.kick_off_status_syncs import kick_off_status_syncs
-from sentry.models.commit import Commit
 from sentry.models.group import Group, GroupStatus
 from sentry.models.grouplink import GroupLink
 from sentry.models.groupresolution import GroupResolution
@@ -35,6 +34,7 @@ from sentry.models.releasecommit import ReleaseCommit
 from sentry.models.releaseheadcommit import ReleaseHeadCommit
 from sentry.models.repository import Repository
 from sentry.plugins.providers.repository import RepositoryProvider
+from sentry.releases.commits import get_or_create_commit, update_commit
 
 
 class _CommitDataKwargs(TypedDict, total=False):
@@ -123,14 +123,16 @@ def set_commit(idx, data, release):
     if "timestamp" in data:
         commit_data["date_added"] = data["timestamp"]
 
-    commit, created = Commit.objects.get_or_create(
-        organization_id=release.organization_id,
-        repository_id=repo.id,
+    commit, new_commit, created = get_or_create_commit(
+        organization=release.organization,
+        repo_id=repo.id,
         key=data["id"],
-        defaults=commit_data,
+        message=commit_data.get("message"),
+        author=commit_data.get("author"),
+        date_added=commit_data.get("date_added"),
     )
     if not created and any(getattr(commit, key) != value for key, value in commit_data.items()):
-        commit.update(**commit_data)
+        update_commit(commit, new_commit, **commit_data)
 
     if author is None:
         author = commit.author


### PR DESCRIPTION
Context: https://www.notion.so/sentry/Release-Retention-2028b10e4b5d802ea421c193303becaf

This updates the last paths for creating `Commit` rows to use our dual write path, and adds an update function to guarantee dual writes there as well.

<!-- Describe your PR here. -->