### PR TITLE
fix(typing): Remove sentry.plugins.config from problem list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -310,7 +310,6 @@ module = [
     "sentry.middleware.auth",
     "sentry.middleware.ratelimit",
     "sentry.net.http",
-    "sentry.plugins.config",
     "sentry.release_health.metrics_sessions_v2",
     "sentry.search.events.builder.errors",
     "sentry.search.events.builder.metrics",

--- a/src/sentry/plugins/base/v1.py
+++ b/src/sentry/plugins/base/v1.py
@@ -5,6 +5,7 @@ from collections.abc import Sequence
 from threading import local
 from typing import TYPE_CHECKING, Any
 
+from django import forms
 from django.http import HttpResponseRedirect
 from django.urls import reverse
 
@@ -68,7 +69,7 @@ class IPlugin(local, PluggableViewMixin, PluginConfigMixin):
     conf_key: str | None = None
     conf_title: str | _StrPromise | None = None
 
-    project_conf_form: Any = None
+    project_conf_form: type[forms.Form] | None = None
 
     # Global enabled state
     enabled = True

--- a/src/sentry/plugins/base/v2.py
+++ b/src/sentry/plugins/base/v2.py
@@ -5,6 +5,7 @@ from collections.abc import Mapping, MutableMapping, Sequence
 from threading import local
 from typing import TYPE_CHECKING, Any, Protocol
 
+from django import forms
 from django.http import HttpResponseRedirect
 
 from sentry.plugins import HIDDEN_PLUGINS
@@ -66,7 +67,7 @@ class IPlugin2(local, PluginConfigMixin):
     conf_key: str | None = None
     conf_title: str | _StrPromise | None = None
 
-    project_conf_form: Any = None
+    project_conf_form: type[forms.Form] | None = None
 
     # Global enabled state
     enabled = True

--- a/src/sentry/plugins/config.py
+++ b/src/sentry/plugins/config.py
@@ -2,7 +2,6 @@ __all__ = ["PluginConfigMixin"]
 
 
 from collections.abc import Callable
-from typing import Any
 
 from django import forms
 from rest_framework import serializers
@@ -84,7 +83,7 @@ class ConfigValidator:
 
 
 class PluginConfigMixin(ProviderMixin):
-    project_conf_form: Any
+    project_conf_form: type[forms.Form] | None
     get_option: Callable
 
     def get_config(self, project, user=None, initial=None, add_additional_fields: bool = False):

--- a/src/sentry/plugins/config.py
+++ b/src/sentry/plugins/config.py
@@ -1,6 +1,9 @@
 __all__ = ["PluginConfigMixin"]
 
 
+from collections.abc import Callable
+from typing import Any
+
 from django import forms
 from rest_framework import serializers
 
@@ -81,6 +84,9 @@ class ConfigValidator:
 
 
 class PluginConfigMixin(ProviderMixin):
+    project_conf_form: Any
+    get_option: Callable
+
     def get_config(self, project, user=None, initial=None, add_additional_fields: bool = False):
         form = self.project_conf_form
         if not form:

--- a/src/sentry/utils/forms.py
+++ b/src/sentry/utils/forms.py
@@ -51,7 +51,7 @@ def field_to_config(name: str, field: forms.Field) -> _FieldConfig:
     return config
 
 
-def form_to_config(form: forms.Form) -> list[_FieldConfig]:
+def form_to_config(form: forms.Form | type[forms.Form]) -> list[_FieldConfig]:
     return [field_to_config(name, field) for name, field in form.base_fields.items()]
 
 

--- a/tests/sentry/plugins/test_config.py
+++ b/tests/sentry/plugins/test_config.py
@@ -15,7 +15,7 @@ class DummyForm(forms.Form):
 
 
 class DummyPlugin(Plugin2):
-    project_conf_form = DummyForm()
+    project_conf_form = DummyForm
 
 
 class ConfigTest(TestCase):


### PR DESCRIPTION
Made minimal changes to allow mypy to pass with the file removed from the problem list.

Declaring property types is fine and does not clobber assignments (so this is safe):
```
>>> class Decl:
...     x: int
...
>>> class Assign:
...     x: int = 5
...
>>> class DA(Decl, Assign):
...     pass
...
>>> DA().x
5
>>> class AD(Assign, Decl):
...     pass
...
>>> AD().x
5
```

Test plan: `mypy` no errors.
