### PR TITLE
chore(ACI): Filter alert trigger logs to rules w/o a global snooze

### DIFF
--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -53,6 +53,7 @@ from sentry.incidents.utils.types import (
 )
 from sentry.models.organization import Organization
 from sentry.models.project import Project
+from sentry.models.rulesnooze import RuleSnooze
 from sentry.seer.anomaly_detection.get_anomaly_data import get_anomaly_data_from_seer_legacy
 from sentry.seer.anomaly_detection.utils import (
     anomaly_has_confidence,
@@ -345,7 +346,10 @@ class SubscriptionProcessor:
                 tags={"detection_type": self.alert_rule.detection_type},
             )
             if has_dual_processing_flag:
-                if detector is not None:
+                is_rule_globally_snoozed = RuleSnooze.objects.filter(
+                    alert_rule_id=self.alert_rule.id, user_id__isnull=True
+                ).exists()
+                if detector is not None and not is_rule_globally_snoozed:
                     logger.info(
                         "subscription_processor.alert_triggered",
                         extra={


### PR DESCRIPTION
While trying to compare the rule/detector triggers in the existing metric alert rule system versus the new one in workflow engine I forgot to account for the fact that we evaluate `RuleSnooze` objects further in the pipeline for metric alerts as they are today, but in workflow engine we evaluate this as a part of the workflow evaluation. This led to uneven logs where globally muted alert rules were logging that they were triggered but the same could not be said for workflow engine. This PR filters the alert rule logs to those that do not have a global snooze on them.