### PR TITLE
fix(feedback): dont show missing spam evidence

### DIFF
--- a/static/app/components/feedback/feedbackItem/feedbackItem.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItem.tsx
@@ -165,10 +165,8 @@ function FeedbackItemContexts({
   eventData.contexts = eventData.contexts ?? {};
   eventData.contexts.feedback = eventData.contexts.feedback ?? {};
 
-  if ('spam_detection_enabled' in evidenceObject) {
-    eventData.contexts.feedback['auto_spam.detection_enabled'] =
-      evidenceObject.spam_detection_enabled;
-  }
+  eventData.contexts.feedback['auto_spam.detection_enabled'] =
+    evidenceObject.spam_detection_enabled;
   if (evidenceObject.spam_detection_enabled) {
     eventData.contexts.feedback['auto_spam.is_spam'] = evidenceObject.is_spam;
   }

--- a/static/app/components/feedback/feedbackItem/feedbackItem.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItem.tsx
@@ -164,9 +164,14 @@ function FeedbackItemContexts({
   );
   eventData.contexts = eventData.contexts ?? {};
   eventData.contexts.feedback = eventData.contexts.feedback ?? {};
-  eventData.contexts.feedback['auto_spam.detection_enabled'] =
-    evidenceObject.spam_detection_enabled;
-  eventData.contexts.feedback['auto_spam.is_spam'] = evidenceObject.is_spam;
+
+  if ('spam_detection_enabled' in evidenceObject) {
+    eventData.contexts.feedback['auto_spam.detection_enabled'] =
+      evidenceObject.spam_detection_enabled;
+  }
+  if (evidenceObject.is_spam) {
+    eventData.contexts.feedback['auto_spam.is_spam'] = evidenceObject.is_spam;
+  }
 
   const cards = getOrderedContextItems(eventData).map(
     ({alias, type, value: contextValue}) => (

--- a/static/app/components/feedback/feedbackItem/feedbackItem.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItem.tsx
@@ -164,7 +164,6 @@ function FeedbackItemContexts({
   );
   eventData.contexts = eventData.contexts ?? {};
   eventData.contexts.feedback = eventData.contexts.feedback ?? {};
-
   eventData.contexts.feedback['auto_spam.detection_enabled'] =
     evidenceObject.spam_detection_enabled;
   if (evidenceObject.spam_detection_enabled) {

--- a/static/app/components/feedback/feedbackItem/feedbackItem.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItem.tsx
@@ -169,7 +169,7 @@ function FeedbackItemContexts({
     eventData.contexts.feedback['auto_spam.detection_enabled'] =
       evidenceObject.spam_detection_enabled;
   }
-  if (evidenceObject.is_spam) {
+  if ('is_spam' in evidenceObject) {
     eventData.contexts.feedback['auto_spam.is_spam'] = evidenceObject.is_spam;
   }
 

--- a/static/app/components/feedback/feedbackItem/feedbackItem.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItem.tsx
@@ -169,7 +169,7 @@ function FeedbackItemContexts({
     eventData.contexts.feedback['auto_spam.detection_enabled'] =
       evidenceObject.spam_detection_enabled;
   }
-  if ('is_spam' in evidenceObject) {
+  if (evidenceObject.spam_detection_enabled) {
     eventData.contexts.feedback['auto_spam.is_spam'] = evidenceObject.is_spam;
   }
 


### PR DESCRIPTION
Prevents showing `null` for these:
<img width="384" height="134" alt="Screenshot 2025-09-04 at 6 15 23 PM" src="https://github.com/user-attachments/assets/1d5f0dd4-a8c7-4ddc-a2a6-bad092f8e745" />

`is_spam` will be missing whenever it's not spam.
`spam_detection_enabled` will be missing for feedback before the recent backend changes