### PR TITLE
ref(feedback): add tooltip to summary experimental badge

### DIFF
--- a/static/app/components/feedback/summaryCategories/feedbackSummaryCategories.tsx
+++ b/static/app/components/feedback/summaryCategories/feedbackSummaryCategories.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import {Badge} from 'sentry/components/core/badge';
 import {Button} from 'sentry/components/core/button';
 import {Flex} from 'sentry/components/core/layout';
+import {Tooltip} from 'sentry/components/core/tooltip';
 import FeedbackCategories from 'sentry/components/feedback/summaryCategories/feedbackCategories';
 import FeedbackSummary from 'sentry/components/feedback/summaryCategories/feedbackSummary';
 import {IconThumb} from 'sentry/icons';
@@ -55,7 +56,14 @@ export default function FeedbackSummaryCategories() {
       <SummaryContainer>
         <Flex justify="between" align="center">
           <SummaryHeader>
-            {t('Summary')} <Badge type="experimental">{t('Experimental')}</Badge>
+            {t('Summary')}
+            <Tooltip
+              title={t(
+                'This feature is experimental! Try it out and let us know what you think. No promises!'
+              )}
+            >
+              <Badge type="experimental">{t('Experimental')}</Badge>
+            </Tooltip>
           </SummaryHeader>
           <Flex gap="xs">
             {feedbackButton({type: 'positive'})}

--- a/static/app/components/feedback/summaryCategories/feedbackSummaryCategories.tsx
+++ b/static/app/components/feedback/summaryCategories/feedbackSummaryCategories.tsx
@@ -1,9 +1,8 @@
 import styled from '@emotion/styled';
 
-import {Badge} from 'sentry/components/core/badge';
+import {FeatureBadge} from 'sentry/components/core/badge/featureBadge';
 import {Button} from 'sentry/components/core/button';
 import {Flex} from 'sentry/components/core/layout';
-import {Tooltip} from 'sentry/components/core/tooltip';
 import FeedbackCategories from 'sentry/components/feedback/summaryCategories/feedbackCategories';
 import FeedbackSummary from 'sentry/components/feedback/summaryCategories/feedbackSummary';
 import {IconThumb} from 'sentry/icons';
@@ -56,14 +55,7 @@ export default function FeedbackSummaryCategories() {
       <SummaryContainer>
         <Flex justify="between" align="center">
           <SummaryHeader>
-            {t('Summary')}
-            <Tooltip
-              title={t(
-                'This feature is experimental! Try it out and let us know what you think. No promises!'
-              )}
-            >
-              <Badge type="experimental">{t('Experimental')}</Badge>
-            </Tooltip>
+            {t('Summary')} <FeatureBadge type="experimental" />
           </SummaryHeader>
           <Flex gap="xs">
             {feedbackButton({type: 'positive'})}


### PR DESCRIPTION
Add a tooltip according to dev doc guidelines and consistent with replay summaries. We plan to eventually open beta w/this badge

<img width="436" height="164" alt="Screenshot 2025-09-04 at 6 23 18 PM" src="https://github.com/user-attachments/assets/5c1721dd-f3f3-4ea9-9b37-829e2e73fbd8" />
