### PR TITLE
Revert "fix(preprod): Enable downloads for uploaded APK artifacts (#98812)"

### DIFF
--- a/src/sentry/preprod/api/endpoints/project_preprod_artifact_update.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_artifact_update.py
@@ -213,16 +213,6 @@ class ProjectPreprodArtifactUpdateEndpoint(ProjectEndpoint):
                 preprod_artifact.state = PreprodArtifact.ArtifactState.PROCESSED
                 updated_fields.append("state")
 
-                # For APK artifacts, set installable_app_file_id to file_id if not already set
-                # APK files are already installable and don't need conversion like AAB files
-                if (
-                    preprod_artifact.artifact_type == PreprodArtifact.ArtifactType.APK
-                    and preprod_artifact.installable_app_file_id is None
-                    and preprod_artifact.file_id is not None
-                ):
-                    preprod_artifact.installable_app_file_id = preprod_artifact.file_id
-                    updated_fields.append("installable_app_file_id")
-
             preprod_artifact.save(update_fields=updated_fields + ["date_updated"])
 
             create_preprod_status_check_task.apply_async(

--- a/tests/sentry/preprod/api/endpoints/test_project_preprod_artifact_update.py
+++ b/tests/sentry/preprod/api/endpoints/test_project_preprod_artifact_update.py
@@ -232,27 +232,3 @@ class ProjectPreprodArtifactUpdateEndpointTest(TestCase):
         assert stored_extras["is_simulator"] is False
         assert stored_extras["codesigning_type"] == "distribution"
         assert stored_extras["profile_name"] == "Production Profile"
-
-    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=["test-secret-key"])
-    def test_update_apk_artifact_sets_installable_app_file_id(self) -> None:
-        """Test that APK artifacts get installable_app_file_id set when marked as PROCESSED"""
-        # Ensure the artifact starts without installable_app_file_id
-        assert self.preprod_artifact.installable_app_file_id is None
-        assert self.preprod_artifact.file_id is not None
-
-        # Update with APK artifact type to trigger PROCESSED state
-        data = {
-            "artifact_type": PreprodArtifact.ArtifactType.APK,
-            "build_version": "1.0.0",
-            "build_number": 1,
-        }
-        response = self._make_request(data)
-
-        assert response.status_code == 200
-        resp_data = response.json()
-        assert resp_data["success"] is True
-        assert "installable_app_file_id" in resp_data["updated_fields"]
-
-        self.preprod_artifact.refresh_from_db()
-        assert self.preprod_artifact.state == PreprodArtifact.ArtifactState.PROCESSED
-        assert self.preprod_artifact.installable_app_file_id == self.preprod_artifact.file_id


### PR DESCRIPTION
This would short-circuit the logic in launchpad which is not what we
want if we want to resign the APK.

This reverts commit 376ac6bb15bb2a719708a17300606c64705753f3.

<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
