### PR TITLE
feat(ai): Allow disabling model cost fetching task

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3480,3 +3480,12 @@ register(
     default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+# Controls whether the async task fetches AI model prices from
+# external sources and stores them in cache.
+register(
+    "ai.model-costs.enable-external-price-fetch",
+    type=Bool,
+    default=True,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)

--- a/src/sentry/relay/config/ai_model_costs.py
+++ b/src/sentry/relay/config/ai_model_costs.py
@@ -3,6 +3,7 @@ from typing import Required, TypedDict
 
 from django.conf import settings
 
+from sentry import options
 from sentry.utils.cache import cache
 
 logger = logging.getLogger(__name__)
@@ -38,6 +39,9 @@ def ai_model_costs_config() -> AIModelCosts | None:
     Returns:
         AIModelCosts object containing cost information for AI models
     """
+    if not options.get("ai.model-costs.enable-external-price-fetch"):
+        return None
+
     cached_costs = cache.get(AI_MODEL_COSTS_CACHE_KEY)
     if cached_costs is not None:
         return cached_costs

--- a/src/sentry/tasks/ai_agent_monitoring.py
+++ b/src/sentry/tasks/ai_agent_monitoring.py
@@ -119,6 +119,10 @@ def fetch_ai_model_costs() -> None:
     OpenRouter prices take precedence over models.dev prices.
     """
 
+    if not options.get("ai.model-costs.enable-external-price-fetch"):
+        # if this feature is disabled, we don't need to fetch model costs
+        return
+
     models_dict: dict[ModelId, AIModelCostV2] = {}
 
     # Fetch from OpenRouter API (takes precedence)

--- a/tests/sentry/api/endpoints/test_relay_globalconfig_v3.py
+++ b/tests/sentry/api/endpoints/test_relay_globalconfig_v3.py
@@ -119,6 +119,7 @@ def test_return_global_config_on_right_version(
     },
 )
 @patch("sentry.relay.globalconfig.RELAY_OPTIONS", [])
+@django_db_all
 def test_global_config_valid_with_generic_filters() -> None:
     config = get_global_config()
     assert config == normalize_global_config(config)


### PR DESCRIPTION
When running sentry as self hosted in air gapped environment, or with strict egress firewall rules, model cost fetching will fail and cause a lot of noise in the logs. Introducing this options gives users ability to turn this feature off in those scenarios.

This should help with https://github.com/getsentry/sentry/issues/98338

closes [TET-1051: issue on self hosting sentry when fetching current model prices from openrouter](https://linear.app/getsentry/issue/TET-1051/issue-on-self-hosting-sentry-when-fetching-current-model-prices-from)