### PR TITLE
fix(ai-insights): fallback to gen_ai span count

### DIFF
--- a/static/app/views/insights/agents/views/overview.tsx
+++ b/static/app/views/insights/agents/views/overview.tsx
@@ -158,7 +158,7 @@ function AgentsOverviewPage() {
 
   const hasAgentRuns = agentRunsRequest.isLoading
     ? undefined
-    : agentRunsRequest.data.length > 0;
+    : agentRunsRequest.data?.length > 0;
 
   return (
     <SearchQueryBuilderProvider {...eapSpanSearchQueryProviderProps}>

--- a/static/app/views/insights/agents/views/overview.tsx
+++ b/static/app/views/insights/agents/views/overview.tsx
@@ -1,8 +1,10 @@
 import {Fragment, useCallback, useEffect, useMemo} from 'react';
 import styled from '@emotion/styled';
 
+import TransparentLoadingMask from 'sentry/components/charts/transparentLoadingMask';
 import {SegmentedControl} from 'sentry/components/core/segmentedControl';
 import * as Layout from 'sentry/components/layouts/thirds';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
 import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
@@ -12,6 +14,7 @@ import {
 } from 'sentry/components/performance/spanSearchQueryBuilder';
 import {SearchQueryBuilderProvider} from 'sentry/components/searchQueryBuilder/context';
 import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {getSelectedProjectList} from 'sentry/utils/project/useSelectedProjectsHaveField';
 import {decodeScalar} from 'sentry/utils/queryString';
@@ -38,6 +41,7 @@ import {
 } from 'sentry/views/insights/agents/hooks/useActiveTable';
 import {useLocationSyncedState} from 'sentry/views/insights/agents/hooks/useLocationSyncedState';
 import {AIInsightsFeature} from 'sentry/views/insights/agents/utils/features';
+import {Referrer} from 'sentry/views/insights/agents/utils/referrers';
 import {Onboarding} from 'sentry/views/insights/agents/views/onboarding';
 import {TwoColumnWidgetGrid, WidgetGrid} from 'sentry/views/insights/agents/views/styles';
 import {ModuleFeature} from 'sentry/views/insights/common/components/moduleFeature';
@@ -47,6 +51,7 @@ import {InsightsProjectSelector} from 'sentry/views/insights/common/components/p
 import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
 import OverviewAgentsDurationChartWidget from 'sentry/views/insights/common/components/widgets/overviewAgentsDurationChartWidget';
 import OverviewAgentsRunsChartWidget from 'sentry/views/insights/common/components/widgets/overviewAgentsRunsChartWidget';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {AgentsPageHeader} from 'sentry/views/insights/pages/agents/agentsPageHeader';
 import {getAIModuleTitle} from 'sentry/views/insights/pages/agents/settings';
 import {ModuleName} from 'sentry/views/insights/types';
@@ -139,6 +144,22 @@ function AgentsOverviewPage() {
     eapSpanSearchQueryBuilderProps
   );
 
+  // Fire a request to check if there are any agent runs
+  // If there are, we show the count/duration of agent runs
+  // If there are not, we show the count/duration of all AI spans
+  const agentRunsRequest = useSpans(
+    {
+      search: 'span.op:"gen_ai.invoke_agent"',
+      fields: ['id'],
+      limit: 1,
+    },
+    Referrer.AGENT_RUNS_WIDGET
+  );
+
+  const hasAgentRuns = agentRunsRequest.isLoading
+    ? undefined
+    : agentRunsRequest.data.length > 0;
+
   return (
     <SearchQueryBuilderProvider {...eapSpanSearchQueryProviderProps}>
       <AgentsPageHeader
@@ -171,10 +192,20 @@ function AgentsOverviewPage() {
                   <Fragment>
                     <WidgetGrid rowHeight={210} paddingBottom={0}>
                       <WidgetGrid.Position1>
-                        <OverviewAgentsRunsChartWidget />
+                        {hasAgentRuns === undefined ? (
+                          <LoadingPanel />
+                        ) : (
+                          <OverviewAgentsRunsChartWidget hasAgentRuns={hasAgentRuns} />
+                        )}
                       </WidgetGrid.Position1>
                       <WidgetGrid.Position2>
-                        <OverviewAgentsDurationChartWidget />
+                        {hasAgentRuns === undefined ? (
+                          <LoadingPanel />
+                        ) : (
+                          <OverviewAgentsDurationChartWidget
+                            hasAgentRuns={hasAgentRuns}
+                          />
+                        )}
                       </WidgetGrid.Position2>
                       <WidgetGrid.Position3>
                         <IssuesWidget />
@@ -280,6 +311,33 @@ function PageWithProviders() {
     </AIInsightsFeature>
   );
 }
+
+function LoadingPanel() {
+  return (
+    <LoadingPlaceholder>
+      <LoadingMask visible />
+      <LoadingIndicator size={24} />
+    </LoadingPlaceholder>
+  );
+}
+
+const LoadingPlaceholder = styled('div')`
+  border: 1px solid ${p => p.theme.border};
+  border-radius: ${p => p.theme.borderRadius};
+  height: 100%;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  gap: ${space(1)};
+
+  padding-top: 32px;
+`;
+
+const LoadingMask = styled(TransparentLoadingMask)`
+  background: ${p => p.theme.background};
+`;
 
 const QueryBuilderWrapper = styled('div')`
   flex: 2;

--- a/static/app/views/insights/common/components/widgets/overviewAgentsDurationChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/overviewAgentsDurationChartWidget.tsx
@@ -24,7 +24,7 @@ import {useReleaseBubbleProps} from 'sentry/views/insights/pages/platform/shared
 import {Toolbar} from 'sentry/views/insights/pages/platform/shared/toolbar';
 
 export default function OverviewAgentsDurationChartWidget(
-  props: LoadableChartWidgetProps & {hasAgentRuns: boolean}
+  props: LoadableChartWidgetProps & {hasAgentRuns?: boolean}
 ) {
   const organization = useOrganization();
   const pageFilterChartParams = usePageFilterChartParams({

--- a/static/app/views/insights/common/components/widgets/overviewAgentsDurationChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/overviewAgentsDurationChartWidget.tsx
@@ -8,7 +8,10 @@ import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/tim
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {useCombinedQuery} from 'sentry/views/insights/agents/hooks/useCombinedQuery';
-import {getAgentRunsFilter} from 'sentry/views/insights/agents/utils/query';
+import {
+  getAgentRunsFilter,
+  getAITracesFilter,
+} from 'sentry/views/insights/agents/utils/query';
 import {Referrer} from 'sentry/views/insights/agents/utils/referrers';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
 import {ModalChartContainer} from 'sentry/views/insights/common/components/insightsChartContainer';
@@ -21,7 +24,7 @@ import {useReleaseBubbleProps} from 'sentry/views/insights/pages/platform/shared
 import {Toolbar} from 'sentry/views/insights/pages/platform/shared/toolbar';
 
 export default function OverviewAgentsDurationChartWidget(
-  props: LoadableChartWidgetProps
+  props: LoadableChartWidgetProps & {hasAgentRuns: boolean}
 ) {
   const organization = useOrganization();
   const pageFilterChartParams = usePageFilterChartParams({
@@ -29,7 +32,9 @@ export default function OverviewAgentsDurationChartWidget(
   });
   const releaseBubbleProps = useReleaseBubbleProps(props);
 
-  const fullQuery = useCombinedQuery(getAgentRunsFilter());
+  const fullQuery = useCombinedQuery(
+    props.hasAgentRuns ? getAgentRunsFilter() : getAITracesFilter()
+  );
 
   const {data, isLoading, error} = useSpanSeries(
     {

--- a/static/app/views/insights/common/components/widgets/overviewAgentsRunsChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/overviewAgentsRunsChartWidget.tsx
@@ -1,12 +1,20 @@
 import {t} from 'sentry/locale';
 import {useCombinedQuery} from 'sentry/views/insights/agents/hooks/useCombinedQuery';
-import {getAgentRunsFilter} from 'sentry/views/insights/agents/utils/query';
+import {
+  getAgentRunsFilter,
+  getAITracesFilter,
+} from 'sentry/views/insights/agents/utils/query';
 import {Referrer} from 'sentry/views/insights/agents/utils/referrers';
 import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/components/widgets/types';
 import {BaseTrafficWidget} from 'sentry/views/insights/pages/platform/shared/baseTrafficWidget';
 
-export default function OverviewAgentsRunsChartWidget(props: LoadableChartWidgetProps) {
-  const query = useCombinedQuery(getAgentRunsFilter());
+export default function OverviewAgentsRunsChartWidget(
+  props: LoadableChartWidgetProps & {hasAgentRuns: boolean}
+) {
+  const query = useCombinedQuery(
+    props.hasAgentRuns ? getAgentRunsFilter() : getAITracesFilter()
+  );
+
   return (
     <BaseTrafficWidget
       id="overviewAgentsRunsChartWidget"

--- a/static/app/views/insights/common/components/widgets/overviewAgentsRunsChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/overviewAgentsRunsChartWidget.tsx
@@ -9,7 +9,7 @@ import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/compon
 import {BaseTrafficWidget} from 'sentry/views/insights/pages/platform/shared/baseTrafficWidget';
 
 export default function OverviewAgentsRunsChartWidget(
-  props: LoadableChartWidgetProps & {hasAgentRuns: boolean}
+  props: LoadableChartWidgetProps & {hasAgentRuns?: boolean}
 ) {
   const query = useCombinedQuery(
     props.hasAgentRuns ? getAgentRunsFilter() : getAITracesFilter()


### PR DESCRIPTION
Closes [TET-989: Traffic and Duration widgets rely on invoke_agent spans](https://linear.app/getsentry/issue/TET-989/traffic-and-duration-widgets-rely-on-invoke-agent-spans)