### PR TITLE
feat(agent-monitoring): add onboarding for langchain and langgraph integrations

### DIFF
--- a/static/app/gettingStartedDocs/python/python.tsx
+++ b/static/app/gettingStartedDocs/python/python.tsx
@@ -322,20 +322,20 @@ export const performanceOnboarding: OnboardingConfig = {
       type: StepType.CONFIGURE,
       content: [
         {
-          type: 'text' as const,
+          type: 'text',
           text: t(
             "Configuration should happen as early as possible in your application's lifecycle."
           ),
         },
         {
-          type: 'text' as const,
+          type: 'text',
           text: tct(
             "Once this is done, Sentry's Python SDK captures all unhandled exceptions and transactions. To enable tracing, use [code:traces_sample_rate=1.0] in the sentry_sdk.init() call.",
             {code: <code />}
           ),
         },
         {
-          type: 'code' as const,
+          type: 'code',
           language: 'python',
           code: `
 import sentry_sdk
@@ -348,7 +348,7 @@ sentry_sdk.init(
 )`,
         },
         {
-          type: 'text' as const,
+          type: 'text',
           text: tct(
             'Learn more about tracing [linkTracingOptions:options], how to use the [linkTracesSampler:traces_sampler] function, or how to [linkSampleTransactions:sample transactions].',
             {
@@ -372,7 +372,7 @@ sentry_sdk.init(
       type: StepType.VERIFY,
       content: [
         {
-          type: 'text' as const,
+          type: 'text',
           text: tct(
             'Verify that performance monitoring is working correctly with our [link:automatic instrumentation] by simply using your Python application.',
             {
@@ -383,7 +383,7 @@ sentry_sdk.init(
           ),
         },
         {
-          type: 'text' as const,
+          type: 'text',
           text: tct(
             'You have the option to manually construct a transaction using [link:custom instrumentation].',
             {
@@ -475,7 +475,7 @@ export const agentMonitoringOnboarding: OnboardingConfig = {
       type: StepType.CONFIGURE,
       content: [
         {
-          type: 'text' as const,
+          type: 'text',
           text: tct(
             'Import and initialize the Sentry SDK with the [openai:OpenAI Agents] integration:',
             {
@@ -486,7 +486,7 @@ export const agentMonitoringOnboarding: OnboardingConfig = {
           ),
         },
         {
-          type: 'code' as const,
+          type: 'code',
           language: 'python',
           code: `
 import sentry_sdk
@@ -504,7 +504,7 @@ sentry_sdk.init(
 )`,
         },
         {
-          type: 'text' as const,
+          type: 'text',
           text: t(
             'The OpenAI Agents integration will automatically collect information about agents, tools, prompts, tokens, and models.'
           ),
@@ -516,14 +516,14 @@ sentry_sdk.init(
       type: StepType.CONFIGURE,
       content: [
         {
-          type: 'text' as const,
+          type: 'text',
           text: tct(
             'Import and initialize the Sentry SDK - the OpenAIIntegration will be enabled automatically:',
             {code: <code />}
           ),
         },
         {
-          type: 'code' as const,
+          type: 'code',
           language: 'python',
           code: `
 import sentry_sdk
@@ -543,14 +543,14 @@ sentry_sdk.init(
       type: StepType.CONFIGURE,
       content: [
         {
-          type: 'text' as const,
+          type: 'text',
           text: tct(
             'Import and initialize the Sentry SDK - the Anthropic Integration will be enabled automatically:',
             {code: <code />}
           ),
         },
         {
-          type: 'code' as const,
+          type: 'code',
           language: 'python',
           code: `
 import sentry_sdk
@@ -570,7 +570,7 @@ sentry_sdk.init(
       type: StepType.CONFIGURE,
       content: [
         {
-          type: 'text' as const,
+          type: 'text',
           text: tct(
             'If you are not using a supported SDK integration, you can instrument your AI calls manually. See [link:manual instrumentation docs] for details.',
             {
@@ -581,7 +581,7 @@ sentry_sdk.init(
           ),
         },
         {
-          type: 'code' as const,
+          type: 'code',
           language: 'python',
           code: `
 import sentry_sdk
@@ -596,7 +596,7 @@ sentry_sdk.init(dsn="${params.dsn.public}", traces_sample_rate=1.0)
       type: StepType.CONFIGURE,
       content: [
         {
-          type: 'text' as const,
+          type: 'text',
           text: tct(
             'Import and initialize the Sentry SDK for [langchain:LangChain] monitoring:',
             {
@@ -607,7 +607,7 @@ sentry_sdk.init(dsn="${params.dsn.public}", traces_sample_rate=1.0)
           ),
         },
         {
-          type: 'code' as const,
+          type: 'code',
           language: 'python',
           code: `
 import sentry_sdk
@@ -625,7 +625,7 @@ sentry_sdk.init(
 )`,
         },
         {
-          type: 'text' as const,
+          type: 'text',
           text: t(
             'The LangChain integration will automatically collect information about agents, tools, prompts, tokens, and models.'
           ),
@@ -637,7 +637,7 @@ sentry_sdk.init(
       type: StepType.CONFIGURE,
       content: [
         {
-          type: 'text' as const,
+          type: 'text',
           text: tct(
             'Import and initialize the Sentry SDK for [langgraph:LangGraph] monitoring:',
             {
@@ -648,7 +648,7 @@ sentry_sdk.init(
           ),
         },
         {
-          type: 'code' as const,
+          type: 'code',
           language: 'python',
           code: `
 import sentry_sdk
@@ -666,7 +666,7 @@ sentry_sdk.init(
 )`,
         },
         {
-          type: 'text' as const,
+          type: 'text',
           text: t(
             'The LangGraph integration will automatically collect information about agents, tools, prompts, tokens, and models.'
           ),
@@ -697,13 +697,13 @@ sentry_sdk.init(
       type: StepType.VERIFY,
       content: [
         {
-          type: 'text' as const,
+          type: 'text',
           text: t(
             'Verify that agent monitoring is working correctly by creating and running a simple agent:'
           ),
         },
         {
-          type: 'code' as const,
+          type: 'code',
           language: 'python',
           code: `
 # Example Agents SDK usage (replace with your actual calls)
@@ -734,13 +734,13 @@ print(result)
       type: StepType.VERIFY,
       content: [
         {
-          type: 'text' as const,
+          type: 'text',
           text: t(
             'Verify that agent monitoring is working correctly by making a simple OpenAI API call:'
           ),
         },
         {
-          type: 'code' as const,
+          type: 'code',
           language: 'python',
           code: `
 from openai import OpenAI
@@ -760,13 +760,13 @@ print(response.choices[0].message.content)
       type: StepType.VERIFY,
       content: [
         {
-          type: 'text' as const,
+          type: 'text',
           text: t(
             'Verify that agent monitoring is working correctly by making a simple Anthropic API call:'
           ),
         },
         {
-          type: 'code' as const,
+          type: 'code',
           language: 'python',
           code: `
 import anthropic
@@ -789,13 +789,13 @@ print(message.content)
       type: StepType.VERIFY,
       content: [
         {
-          type: 'text' as const,
+          type: 'text',
           text: t(
             'Verify that agent monitoring is working correctly by creating a LangChain agent:'
           ),
         },
         {
-          type: 'code' as const,
+          type: 'code',
           language: 'python',
           code: `
 import random
@@ -840,13 +840,13 @@ with sentry_sdk.start_transaction(name="langchain-openai"):
       type: StepType.VERIFY,
       content: [
         {
-          type: 'text' as const,
+          type: 'text',
           text: t(
             'Verify that agent monitoring is working correctly by creating a LangGraph workflow:'
           ),
         },
         {
-          type: 'code' as const,
+          type: 'code',
           language: 'python',
           code: `
 import random
@@ -899,13 +899,13 @@ with sentry_sdk.start_transaction(name="langgraph-openai"):
       type: StepType.VERIFY,
       content: [
         {
-          type: 'text' as const,
+          type: 'text',
           text: t(
             'Verify that agent monitoring is working correctly by running your manually instrumented code:'
           ),
         },
         {
-          type: 'code' as const,
+          type: 'code',
           language: 'python',
           code: `
 import json

--- a/static/app/gettingStartedDocs/python/python.tsx
+++ b/static/app/gettingStartedDocs/python/python.tsx
@@ -474,7 +474,7 @@ export const agentMonitoringOnboarding: OnboardingConfig = {
     const openaiAgentsStep = {
       type: StepType.CONFIGURE,
       description: tct(
-        'Import and initialize the Sentry SDK with the [openai:OpenAIAgents] integration:',
+        'Import and initialize the Sentry SDK with the [openai:OpenAI Agents] integration:',
         {
           openai: (
             <ExternalLink href="https://docs.sentry.io/product/insights/agents/getting-started/#quick-start-with-openai-agents" />
@@ -543,7 +543,7 @@ sentry_sdk.init(
     const anthropicSdkStep = {
       type: StepType.CONFIGURE,
       description: tct(
-        'Import and initialize the Sentry SDK - the AnthropicIntegration will be enabled automatically:',
+        'Import and initialize the Sentry SDK - the Anthropic Integration will be enabled automatically:',
         {code: <code />}
       ),
       configurations: [

--- a/static/app/gettingStartedDocs/python/python.tsx
+++ b/static/app/gettingStartedDocs/python/python.tsx
@@ -474,7 +474,7 @@ export const agentMonitoringOnboarding: OnboardingConfig = {
     const openaiAgentsStep = {
       type: StepType.CONFIGURE,
       description: tct(
-        'Import and initialize the Sentry SDK with the [openai:OpenAI Agents] integration:',
+        'Import and initialize the Sentry SDK with the [openai:OpenAIAgents] integration:',
         {
           openai: (
             <ExternalLink href="https://docs.sentry.io/product/insights/agents/getting-started/#quick-start-with-openai-agents" />
@@ -514,7 +514,7 @@ sentry_sdk.init(
     const openaiSdkStep = {
       type: StepType.CONFIGURE,
       description: tct(
-        'Import and initialize the Sentry SDK with the [code:OpenAIIntegration] to instrument the OpenAI SDK:',
+        'Import and initialize the Sentry SDK - the OpenAIIntegration will be enabled automatically:',
         {code: <code />}
       ),
       configurations: [
@@ -526,7 +526,6 @@ sentry_sdk.init(
               language: 'python',
               code: `
 import sentry_sdk
-from sentry_sdk.integrations.openai import OpenAIIntegration
 
 sentry_sdk.init(
     dsn="${params.dsn.public}",
@@ -544,7 +543,7 @@ sentry_sdk.init(
     const anthropicSdkStep = {
       type: StepType.CONFIGURE,
       description: tct(
-        'Import and initialize the Sentry SDK with the [code:AnthropicIntegration] to instrument the Anthropic SDK:',
+        'Import and initialize the Sentry SDK - the AnthropicIntegration will be enabled automatically:',
         {code: <code />}
       ),
       configurations: [
@@ -601,7 +600,7 @@ sentry_sdk.init(dsn="${params.dsn.public}", traces_sample_rate=1.0)
     const langchainStep = {
       type: StepType.CONFIGURE,
       description: tct(
-        'Import and initialize the Sentry SDK with the [langchain:LangChain] integration:',
+        'Import and initialize the Sentry SDK for [langchain:LangChain] monitoring:',
         {
           langchain: (
             <ExternalLink href="https://docs.sentry.io/platforms/python/integrations/langchain/" />
@@ -641,7 +640,7 @@ sentry_sdk.init(
     const langgraphStep = {
       type: StepType.CONFIGURE,
       description: tct(
-        'Import and initialize the Sentry SDK with the [langgraph:LangGraph] integration:',
+        'Import and initialize the Sentry SDK for [langgraph:LangGraph] monitoring:',
         {
           langgraph: (
             <ExternalLink href="https://docs.sentry.io/platforms/python/integrations/langgraph/" />

--- a/static/app/gettingStartedDocs/python/python.tsx
+++ b/static/app/gettingStartedDocs/python/python.tsx
@@ -322,20 +322,20 @@ export const performanceOnboarding: OnboardingConfig = {
       type: StepType.CONFIGURE,
       content: [
         {
-          type: 'text',
+          type: 'text' as const,
           text: t(
             "Configuration should happen as early as possible in your application's lifecycle."
           ),
         },
         {
-          type: 'text',
+          type: 'text' as const,
           text: tct(
             "Once this is done, Sentry's Python SDK captures all unhandled exceptions and transactions. To enable tracing, use [code:traces_sample_rate=1.0] in the sentry_sdk.init() call.",
             {code: <code />}
           ),
         },
         {
-          type: 'code',
+          type: 'code' as const,
           language: 'python',
           code: `
 import sentry_sdk
@@ -348,7 +348,7 @@ sentry_sdk.init(
 )`,
         },
         {
-          type: 'text',
+          type: 'text' as const,
           text: tct(
             'Learn more about tracing [linkTracingOptions:options], how to use the [linkTracesSampler:traces_sampler] function, or how to [linkSampleTransactions:sample transactions].',
             {
@@ -372,7 +372,7 @@ sentry_sdk.init(
       type: StepType.VERIFY,
       content: [
         {
-          type: 'text',
+          type: 'text' as const,
           text: tct(
             'Verify that performance monitoring is working correctly with our [link:automatic instrumentation] by simply using your Python application.',
             {
@@ -383,7 +383,7 @@ sentry_sdk.init(
           ),
         },
         {
-          type: 'text',
+          type: 'text' as const,
           text: tct(
             'You have the option to manually construct a transaction using [link:custom instrumentation].',
             {
@@ -473,22 +473,22 @@ export const agentMonitoringOnboarding: OnboardingConfig = {
   configure: (params: Params) => {
     const openaiAgentsStep = {
       type: StepType.CONFIGURE,
-      description: tct(
-        'Import and initialize the Sentry SDK with the [openai:OpenAI Agents] integration:',
+      content: [
         {
-          openai: (
-            <ExternalLink href="https://docs.sentry.io/product/insights/agents/getting-started/#quick-start-with-openai-agents" />
-          ),
-        }
-      ),
-      configurations: [
-        {
-          code: [
+          type: 'text' as const,
+          text: tct(
+            'Import and initialize the Sentry SDK with the [openai:OpenAI Agents] integration:',
             {
-              label: 'Python',
-              value: 'python',
-              language: 'python',
-              code: `
+              openai: (
+                <ExternalLink href="https://docs.sentry.io/product/insights/agents/getting-started/#quick-start-with-openai-agents" />
+              ),
+            }
+          ),
+        },
+        {
+          type: 'code' as const,
+          language: 'python',
+          code: `
 import sentry_sdk
 from sentry_sdk.integrations.openai_agents import OpenAIAgentsIntegration
 
@@ -502,29 +502,30 @@ sentry_sdk.init(
         OpenAIAgentsIntegration(),
     ],
 )`,
-            },
-          ],
+        },
+        {
+          type: 'text' as const,
+          text: t(
+            'The OpenAI Agents integration will automatically collect information about agents, tools, prompts, tokens, and models.'
+          ),
         },
       ],
-      additionalInfo: t(
-        'The OpenAI Agents integration will automatically collect information about agents, tools, prompts, tokens, and models.'
-      ),
     };
 
     const openaiSdkStep = {
       type: StepType.CONFIGURE,
-      description: tct(
-        'Import and initialize the Sentry SDK - the OpenAIIntegration will be enabled automatically:',
-        {code: <code />}
-      ),
-      configurations: [
+      content: [
         {
-          code: [
-            {
-              label: 'Python',
-              value: 'python',
-              language: 'python',
-              code: `
+          type: 'text' as const,
+          text: tct(
+            'Import and initialize the Sentry SDK - the OpenAIIntegration will be enabled automatically:',
+            {code: <code />}
+          ),
+        },
+        {
+          type: 'code' as const,
+          language: 'python',
+          code: `
 import sentry_sdk
 
 sentry_sdk.init(
@@ -534,26 +535,24 @@ sentry_sdk.init(
     # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
     send_default_pii=True,
 )`,
-            },
-          ],
         },
       ],
     };
 
     const anthropicSdkStep = {
       type: StepType.CONFIGURE,
-      description: tct(
-        'Import and initialize the Sentry SDK - the Anthropic Integration will be enabled automatically:',
-        {code: <code />}
-      ),
-      configurations: [
+      content: [
         {
-          code: [
-            {
-              label: 'Python',
-              value: 'python',
-              language: 'python',
-              code: `
+          type: 'text' as const,
+          text: tct(
+            'Import and initialize the Sentry SDK - the Anthropic Integration will be enabled automatically:',
+            {code: <code />}
+          ),
+        },
+        {
+          type: 'code' as const,
+          language: 'python',
+          code: `
 import sentry_sdk
 
 sentry_sdk.init(
@@ -563,58 +562,54 @@ sentry_sdk.init(
     # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
     send_default_pii=True,
 )`,
-            },
-          ],
         },
       ],
     };
 
     const manualStep = {
       type: StepType.CONFIGURE,
-      description: tct(
-        'If you are not using a supported SDK integration, you can instrument your AI calls manually. See [link:manual instrumentation docs] for details.',
+      content: [
         {
-          link: (
-            <ExternalLink href="https://docs.sentry.io/platforms/python/tracing/instrumentation/custom-instrumentation/ai-agents-module/" />
-          ),
-        }
-      ),
-      configurations: [
-        {
-          code: [
+          type: 'text' as const,
+          text: tct(
+            'If you are not using a supported SDK integration, you can instrument your AI calls manually. See [link:manual instrumentation docs] for details.',
             {
-              label: 'Python',
-              value: 'python',
-              language: 'python',
-              code: `
+              link: (
+                <ExternalLink href="https://docs.sentry.io/platforms/python/tracing/instrumentation/custom-instrumentation/ai-agents-module/" />
+              ),
+            }
+          ),
+        },
+        {
+          type: 'code' as const,
+          language: 'python',
+          code: `
 import sentry_sdk
 
 sentry_sdk.init(dsn="${params.dsn.public}", traces_sample_rate=1.0)
 `,
-            },
-          ],
         },
       ],
     };
 
     const langchainStep = {
       type: StepType.CONFIGURE,
-      description: tct(
-        'Import and initialize the Sentry SDK for [langchain:LangChain] monitoring:',
+      content: [
         {
-          langchain: (
-            <ExternalLink href="https://docs.sentry.io/platforms/python/integrations/langchain/" />
-          ),
-        }
-      ),
-      configurations: [
-        {
-          code: [
+          type: 'text' as const,
+          text: tct(
+            'Import and initialize the Sentry SDK for [langchain:LangChain] monitoring:',
             {
-              label: 'Python',
-              value: 'python',
-              language: 'python',
-              code: `
+              langchain: (
+                <ExternalLink href="https://docs.sentry.io/platforms/python/integrations/langchain/" />
+              ),
+            }
+          ),
+        },
+        {
+          type: 'code' as const,
+          language: 'python',
+          code: `
 import sentry_sdk
 from sentry_sdk.integrations.openai import OpenAIIntegration
 
@@ -628,33 +623,34 @@ sentry_sdk.init(
     # Disable OpenAI integration for correct token accounting
     disabled_integrations=[OpenAIIntegration()],
 )`,
-            },
-          ],
+        },
+        {
+          type: 'text' as const,
+          text: t(
+            'The LangChain integration will automatically collect information about agents, tools, prompts, tokens, and models.'
+          ),
         },
       ],
-      additionalInfo: t(
-        'The LangChain integration will automatically collect information about agents, tools, prompts, tokens, and models.'
-      ),
     };
 
     const langgraphStep = {
       type: StepType.CONFIGURE,
-      description: tct(
-        'Import and initialize the Sentry SDK for [langgraph:LangGraph] monitoring:',
+      content: [
         {
-          langgraph: (
-            <ExternalLink href="https://docs.sentry.io/platforms/python/integrations/langgraph/" />
-          ),
-        }
-      ),
-      configurations: [
-        {
-          code: [
+          type: 'text' as const,
+          text: tct(
+            'Import and initialize the Sentry SDK for [langgraph:LangGraph] monitoring:',
             {
-              label: 'Python',
-              value: 'python',
-              language: 'python',
-              code: `
+              langgraph: (
+                <ExternalLink href="https://docs.sentry.io/platforms/python/integrations/langgraph/" />
+              ),
+            }
+          ),
+        },
+        {
+          type: 'code' as const,
+          language: 'python',
+          code: `
 import sentry_sdk
 from sentry_sdk.integrations.openai import OpenAIIntegration
 
@@ -668,13 +664,14 @@ sentry_sdk.init(
     # Disable OpenAI integration for correct token accounting
     disabled_integrations=[OpenAIIntegration()],
 )`,
-            },
-          ],
+        },
+        {
+          type: 'text' as const,
+          text: t(
+            'The LangGraph integration will automatically collect information about agents, tools, prompts, tokens, and models.'
+          ),
         },
       ],
-      additionalInfo: t(
-        'The LangGraph integration will automatically collect information about agents, tools, prompts, tokens, and models.'
-      ),
     };
 
     const selected = (params.platformOptions as any)?.integration ?? 'openai_agents';
@@ -698,17 +695,17 @@ sentry_sdk.init(
   verify: (params: Params) => {
     const openaiAgentsVerifyStep = {
       type: StepType.VERIFY,
-      description: t(
-        'Verify that agent monitoring is working correctly by creating and running a simple agent:'
-      ),
-      configurations: [
+      content: [
         {
-          code: [
-            {
-              label: 'Python',
-              value: 'python',
-              language: 'python',
-              code: `
+          type: 'text' as const,
+          text: t(
+            'Verify that agent monitoring is working correctly by creating and running a simple agent:'
+          ),
+        },
+        {
+          type: 'code' as const,
+          language: 'python',
+          code: `
 # Example Agents SDK usage (replace with your actual calls)
 class MyAgent:
     def __init__(self, name: str, model_provider: str, model: str):
@@ -729,25 +726,23 @@ my_agent = MyAgent(
 result = my_agent.run()
 print(result)
 `,
-            },
-          ],
         },
       ],
     };
 
     const openaiSdkVerifyStep = {
       type: StepType.VERIFY,
-      description: t(
-        'Verify that agent monitoring is working correctly by making a simple OpenAI API call:'
-      ),
-      configurations: [
+      content: [
         {
-          code: [
-            {
-              label: 'Python',
-              value: 'python',
-              language: 'python',
-              code: `
+          type: 'text' as const,
+          text: t(
+            'Verify that agent monitoring is working correctly by making a simple OpenAI API call:'
+          ),
+        },
+        {
+          type: 'code' as const,
+          language: 'python',
+          code: `
 from openai import OpenAI
 
 client = OpenAI()
@@ -757,25 +752,23 @@ response = client.chat.completions.create(
 )
 print(response.choices[0].message.content)
 `,
-            },
-          ],
         },
       ],
     };
 
     const anthropicSdkVerifyStep = {
       type: StepType.VERIFY,
-      description: t(
-        'Verify that agent monitoring is working correctly by making a simple Anthropic API call:'
-      ),
-      configurations: [
+      content: [
         {
-          code: [
-            {
-              label: 'Python',
-              value: 'python',
-              language: 'python',
-              code: `
+          type: 'text' as const,
+          text: t(
+            'Verify that agent monitoring is working correctly by making a simple Anthropic API call:'
+          ),
+        },
+        {
+          type: 'code' as const,
+          language: 'python',
+          code: `
 import anthropic
 
 client = anthropic.Anthropic()
@@ -788,25 +781,23 @@ message = client.messages.create(
 )
 print(message.content)
 `,
-            },
-          ],
         },
       ],
     };
 
     const langchainVerifyStep = {
       type: StepType.VERIFY,
-      description: t(
-        'Verify that agent monitoring is working correctly by creating a LangChain agent:'
-      ),
-      configurations: [
+      content: [
         {
-          code: [
-            {
-              label: 'Python',
-              value: 'python',
-              language: 'python',
-              code: `
+          type: 'text' as const,
+          text: t(
+            'Verify that agent monitoring is working correctly by creating a LangChain agent:'
+          ),
+        },
+        {
+          type: 'code' as const,
+          language: 'python',
+          code: `
 import random
 from langchain.agents import AgentExecutor, create_openai_functions_agent
 from langchain.chat_models import init_chat_model
@@ -841,25 +832,23 @@ with sentry_sdk.start_transaction(name="langchain-openai"):
     })
     print(result)
 `,
-            },
-          ],
         },
       ],
     };
 
     const langgraphVerifyStep = {
       type: StepType.VERIFY,
-      description: t(
-        'Verify that agent monitoring is working correctly by creating a LangGraph workflow:'
-      ),
-      configurations: [
+      content: [
         {
-          code: [
-            {
-              label: 'Python',
-              value: 'python',
-              language: 'python',
-              code: `
+          type: 'text' as const,
+          text: t(
+            'Verify that agent monitoring is working correctly by creating a LangGraph workflow:'
+          ),
+        },
+        {
+          type: 'code' as const,
+          language: 'python',
+          code: `
 import random
 from typing import Annotated, Literal, TypedDict
 
@@ -902,25 +891,23 @@ with sentry_sdk.start_transaction(name="langgraph-openai"):
     })
     print(result)
 `,
-            },
-          ],
         },
       ],
     };
 
     const manualVerifyStep = {
       type: StepType.VERIFY,
-      description: t(
-        'Verify that agent monitoring is working correctly by running your manually instrumented code:'
-      ),
-      configurations: [
+      content: [
         {
-          code: [
-            {
-              label: 'Python',
-              value: 'python',
-              language: 'python',
-              code: `
+          type: 'text' as const,
+          text: t(
+            'Verify that agent monitoring is working correctly by running your manually instrumented code:'
+          ),
+        },
+        {
+          type: 'code' as const,
+          language: 'python',
+          code: `
 import json
 import sentry_sdk
 
@@ -940,8 +927,6 @@ with sentry_sdk.start_span(op="gen_ai.chat", name="chat o3-mini") as span:
     span.set_data("gen_ai.request.message", json.dumps([{"role": "user", "content": "Tell me a joke"}]))
     span.set_data("gen_ai.response.text", json.dumps(["joke..."]))
 `,
-            },
-          ],
         },
       ],
     };

--- a/static/app/gettingStartedDocs/python/python.tsx
+++ b/static/app/gettingStartedDocs/python/python.tsx
@@ -5,6 +5,7 @@ import {
   type Docs,
   type DocsParams,
   type OnboardingConfig,
+  type OnboardingStep,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {
   getCrashReportBackendInstallStep,
@@ -471,7 +472,7 @@ export const agentMonitoringOnboarding: OnboardingConfig = {
     ];
   },
   configure: (params: Params) => {
-    const openaiAgentsStep = {
+    const openaiAgentsStep: OnboardingStep = {
       type: StepType.CONFIGURE,
       content: [
         {
@@ -512,7 +513,7 @@ sentry_sdk.init(
       ],
     };
 
-    const openaiSdkStep = {
+    const openaiSdkStep: OnboardingStep = {
       type: StepType.CONFIGURE,
       content: [
         {
@@ -539,7 +540,7 @@ sentry_sdk.init(
       ],
     };
 
-    const anthropicSdkStep = {
+    const anthropicSdkStep: OnboardingStep = {
       type: StepType.CONFIGURE,
       content: [
         {
@@ -566,7 +567,7 @@ sentry_sdk.init(
       ],
     };
 
-    const manualStep = {
+    const manualStep: OnboardingStep = {
       type: StepType.CONFIGURE,
       content: [
         {
@@ -592,7 +593,7 @@ sentry_sdk.init(dsn="${params.dsn.public}", traces_sample_rate=1.0)
       ],
     };
 
-    const langchainStep = {
+    const langchainStep: OnboardingStep = {
       type: StepType.CONFIGURE,
       content: [
         {
@@ -633,7 +634,7 @@ sentry_sdk.init(
       ],
     };
 
-    const langgraphStep = {
+    const langgraphStep: OnboardingStep = {
       type: StepType.CONFIGURE,
       content: [
         {
@@ -693,7 +694,7 @@ sentry_sdk.init(
     return [openaiAgentsStep];
   },
   verify: (params: Params) => {
-    const openaiAgentsVerifyStep = {
+    const openaiAgentsVerifyStep: OnboardingStep = {
       type: StepType.VERIFY,
       content: [
         {
@@ -730,7 +731,7 @@ print(result)
       ],
     };
 
-    const openaiSdkVerifyStep = {
+    const openaiSdkVerifyStep: OnboardingStep = {
       type: StepType.VERIFY,
       content: [
         {
@@ -756,7 +757,7 @@ print(response.choices[0].message.content)
       ],
     };
 
-    const anthropicSdkVerifyStep = {
+    const anthropicSdkVerifyStep: OnboardingStep = {
       type: StepType.VERIFY,
       content: [
         {
@@ -785,7 +786,7 @@ print(message.content)
       ],
     };
 
-    const langchainVerifyStep = {
+    const langchainVerifyStep: OnboardingStep = {
       type: StepType.VERIFY,
       content: [
         {
@@ -836,7 +837,7 @@ with sentry_sdk.start_transaction(name="langchain-openai"):
       ],
     };
 
-    const langgraphVerifyStep = {
+    const langgraphVerifyStep: OnboardingStep = {
       type: StepType.VERIFY,
       content: [
         {
@@ -895,7 +896,7 @@ with sentry_sdk.start_transaction(name="langgraph-openai"):
       ],
     };
 
-    const manualVerifyStep = {
+    const manualVerifyStep: OnboardingStep = {
       type: StepType.VERIFY,
       content: [
         {

--- a/static/app/views/insights/agents/views/onboarding.tsx
+++ b/static/app/views/insights/agents/views/onboarding.tsx
@@ -19,10 +19,7 @@ import type {
   DocsParams,
   OnboardingStep,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
-import {
-  DocsPageLocation,
-  StepType,
-} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {DocsPageLocation} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {useSourcePackageRegistries} from 'sentry/components/onboarding/gettingStartedDoc/useSourcePackageRegistries';
 import {useLoadGettingStarted} from 'sentry/components/onboarding/gettingStartedDoc/utils/useLoadGettingStarted';
 import {PlatformOptionDropdown} from 'sentry/components/onboarding/platformOptionDropdown';
@@ -259,6 +256,8 @@ export function Onboarding() {
             {label: 'OpenAI SDK', value: 'openai'},
             {label: 'OpenAI Agents SDK', value: 'openai_agents'},
             {label: 'Anthropic SDK', value: 'anthropic'},
+            {label: 'LangChain', value: 'langchain'},
+            {label: 'LangGraph', value: 'langgraph'},
             {label: 'Manual', value: 'manual'},
           ]
         : [
@@ -348,12 +347,7 @@ export function Onboarding() {
   const steps = [
     ...(agentMonitoringDocs.install?.(docParams) || []),
     ...(agentMonitoringDocs.configure?.(docParams) || []),
-    {
-      type: StepType.VERIFY,
-      description: t(
-        'Verify that agent monitoring is working correctly by triggering some AI agent interactions in your application.'
-      ),
-    },
+    ...(agentMonitoringDocs.verify?.(docParams) || []),
   ];
 
   return (


### PR DESCRIPTION
- Add in-product onboarding for LangChain and LangGraph integrations
- Move verify code snippets to separate verify steps for all frameworks 
- Move onboarding to content blocks

| Before | After |
|--------|-------|
| <img width="668" height="811" alt="image" src="https://github.com/user-attachments/assets/f81ff313-ba97-46db-a15c-b6fb2a55e8db" /> | <img width="674" height="673" alt="image" src="https://github.com/user-attachments/assets/ed672257-79e6-465b-8dab-70b2caea1da6" /> |


Closes TET-1117