### PR TITLE
Resolve complex union type error

### DIFF
--- a/static/app/views/insights/mobile/screenload/components/tables/screenLoadSpansTable.tsx
+++ b/static/app/views/insights/mobile/screenload/components/tables/screenLoadSpansTable.tsx
@@ -114,7 +114,7 @@ export function ScreenLoadSpansTable({
         'ttfd_contribution_rate()',
         'count()',
         `sum(${SPAN_SELF_TIME})`,
-      ],
+      ] as string[],
     },
     'api.insights.mobile-span-table'
   );


### PR DESCRIPTION
Resolves a TypeScript error `Expression produces a union type that is too complex to represent` by explicitly typing the `fields` array as `string[]`. This prevents TypeScript from inferring an overly complex union type from the mixed string literals and template strings.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
<a href="https://cursor.com/background-agent?bcId=bc-4e43679e-51b3-4731-9b33-2a2004bc3609">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4e43679e-51b3-4731-9b33-2a2004bc3609">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

