### PR TITLE
chore(deletions): Remove sequential approach to deleting events

### DIFF
--- a/src/sentry/deletions/defaults/group.py
+++ b/src/sentry/deletions/defaults/group.py
@@ -7,9 +7,8 @@ from collections.abc import Mapping, Sequence
 from typing import Any
 
 from sentry_sdk import set_tag
-from snuba_sdk import DeleteQuery, Request
 
-from sentry import eventstore, eventstream, models, nodestore, options
+from sentry import models
 from sentry.deletions.tasks.nodestore import delete_events_for_groups_from_nodestore_and_eventstore
 from sentry.issues.grouptype import GroupCategory, InvalidGroupTypeError
 from sentry.models.group import Group, GroupStatus
@@ -18,7 +17,6 @@ from sentry.notifications.models.notificationmessage import NotificationMessage
 from sentry.services.eventstore.models import Event
 from sentry.snuba.dataset import Dataset
 from sentry.tasks.delete_seer_grouping_records import may_schedule_task_to_delete_hashes_from_seer
-from sentry.utils.snuba import bulk_snuba_queries
 
 from ..base import BaseDeletionTask, BaseRelation, ModelDeletionTask, ModelRelation
 from ..manager import DeletionTaskManager
@@ -27,9 +25,6 @@ logger = logging.getLogger(__name__)
 
 GROUP_CHUNK_SIZE = 100
 EVENT_CHUNK_SIZE = 10000
-# XXX: To be removed
-# https://github.com/getsentry/snuba/blob/54feb15b7575142d4b3af7f50d2c2c865329f2db/snuba/datasets/configuration/issues/storages/search_issues.yaml#L139
-ISSUE_PLATFORM_MAX_ROWS_TO_DELETE = 2000000
 
 # Group models that relate only to groups and not to events. We assume those to
 # be safe to delete/mutate within a single transaction for user-triggered
@@ -95,33 +90,6 @@ class EventsBaseDeletionTask(BaseDeletionTask[Group]):
         self.group_ids = group_ids
         self.project_ids = list(self.project_groups.keys())
 
-    # XXX: To be removed
-    def get_unfetched_events(self) -> list[Event]:
-        conditions = []
-        if self.last_event is not None:
-            conditions.extend(
-                [
-                    ["timestamp", "<=", self.last_event.timestamp],
-                    [
-                        ["timestamp", "<", self.last_event.timestamp],
-                        ["event_id", "<", self.last_event.event_id],
-                    ],
-                ]
-            )
-
-        logger.info("Fetching %s events for deletion.", self.DEFAULT_CHUNK_SIZE)
-        events = eventstore.backend.get_unfetched_events(
-            filter=eventstore.Filter(
-                conditions=conditions, project_ids=self.project_ids, group_ids=self.group_ids
-            ),
-            limit=self.DEFAULT_CHUNK_SIZE,
-            referrer=self.referrer,
-            orderby=["-timestamp", "-event_id"],
-            tenant_ids=self.tenant_ids,
-            dataset=self.dataset,
-        )
-        return events
-
     @property
     def tenant_ids(self) -> Mapping[str, Any]:
         result = {"referrer": self.referrer}
@@ -132,48 +100,8 @@ class EventsBaseDeletionTask(BaseDeletionTask[Group]):
     def chunk(self, apply_filter: bool = False) -> bool:
         """This method is called to delete chunks of data. It returns a boolean to say
         if the deletion has completed and if it needs to be called again."""
-        if not options.get("deletions.nodestore.parallelization-task-enabled"):
-            events = self.get_unfetched_events()
-            if events:
-                # Adding this variable to see the values in stack traces
-                last_event = events[-1]
-                self.delete_events_from_nodestore_sequential(events)
-                # This value will be used in the next call to chunk
-                self.last_event = last_event
-                # As long as it returns True the task will keep iterating
-                return True
-            else:
-                # Now that all events have been deleted from the eventstore, we can delete the events from snuba
-                self.delete_events_from_snuba()
-                return False
-        else:
-            self.delete_events_from_nodestore_and_eventstore()
-            return False
-
-    # XXX: To be removed
-    def delete_events_from_nodestore_sequential(self, events: Sequence[Event]) -> None:
-        # We delete by the occurrence_id instead of the event_id
-        node_ids = [
-            Event.generate_node_id(
-                event.project_id,
-                (
-                    event._snuba_data["occurrence_id"]
-                    if self.dataset == Dataset.IssuePlatform
-                    else event.event_id
-                ),
-            )
-            for event in events
-        ]
-        nodestore.backend.delete_multi(node_ids)
-        self.post_delete_events_from_nodestore(events)
-
-    # XXX: To be removed
-    def post_delete_events_from_nodestore(self, events: Sequence[Event]) -> None:
-        pass
-
-    # XXX: To be removed
-    def delete_events_from_snuba(self) -> None:
-        raise NotImplementedError
+        self.delete_events_from_nodestore_and_eventstore()
+        return False
 
     def delete_events_from_nodestore_and_eventstore(self) -> None:
         """Schedule asynchronous deletion of events from the nodestore and eventstore for all groups."""
@@ -212,31 +140,6 @@ class ErrorEventsDeletionTask(EventsBaseDeletionTask):
 
     dataset = Dataset.Events
 
-    # XXX: To be removed
-    def post_delete_events_from_nodestore(self, events: Sequence[Event]) -> None:
-        self.delete_dangling_attachments_and_user_reports(events)
-
-    # XXX: To be removed
-    def delete_dangling_attachments_and_user_reports(self, events: Sequence[Event]) -> None:
-        # Remove EventAttachment and UserReport *again* as those may not have a
-        # group ID, therefore there may be dangling ones after "regular" model
-        # deletion.
-        event_ids = [event.event_id for event in events]
-        models.EventAttachment.objects.filter(
-            event_id__in=event_ids, project_id__in=self.project_ids
-        ).delete()
-        models.UserReport.objects.filter(
-            event_id__in=event_ids, project_id__in=self.project_ids
-        ).delete()
-
-    # XXX: To be removed
-    def delete_events_from_snuba(self) -> None:
-        # Remove all group events now that their node data has been removed.
-        for project_id, groups in self.project_groups.items():
-            group_ids = [group.id for group in groups]
-            eventstream_state = eventstream.backend.start_delete_groups(project_id, group_ids)
-            eventstream.backend.end_delete_groups(eventstream_state)
-
 
 class IssuePlatformEventsDeletionTask(EventsBaseDeletionTask):
     """
@@ -244,50 +147,6 @@ class IssuePlatformEventsDeletionTask(EventsBaseDeletionTask):
     """
 
     dataset = Dataset.IssuePlatform
-    # XXX: To be removed
-    max_rows_to_delete = ISSUE_PLATFORM_MAX_ROWS_TO_DELETE
-
-    def delete_events_from_snuba(self) -> None:
-        requests = []
-        for project_id, groups in self.project_groups.items():
-            # Split group_ids into batches where the sum of times_seen is less than max_rows_to_delete
-            current_batch: list[int] = []
-            current_batch_rows = 0
-
-            # Deterministic sort for sanity, and for very large deletions we'll
-            # delete the "smaller" groups first
-            groups.sort(key=lambda g: (g.times_seen, g.id))
-
-            for group in groups:
-                times_seen = group.times_seen
-
-                # If adding this group would exceed the limit, create a request with the current batch
-                if current_batch_rows + times_seen > self.max_rows_to_delete:
-                    requests.append(self.delete_request(project_id, current_batch))
-                    # We now start a new batch
-                    current_batch = [group.id]
-                    current_batch_rows = times_seen
-                else:
-                    current_batch.append(group.id)
-                    current_batch_rows += times_seen
-
-            # Add the final batch if it's not empty
-            if current_batch:
-                requests.append(self.delete_request(project_id, current_batch))
-
-        bulk_snuba_queries(requests)
-
-    def delete_request(self, project_id: int, group_ids: Sequence[int]) -> Request:
-        query = DeleteQuery(
-            self.dataset.value,
-            column_conditions={"project_id": [project_id], "group_id": list(group_ids)},
-        )
-        return Request(
-            dataset=self.dataset.value,
-            app_id=self.referrer,
-            query=query,
-            tenant_ids=self.tenant_ids,
-        )
 
 
 class GroupDeletionTask(ModelDeletionTask[Group]):

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -886,14 +886,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Enable sequential deletion of events from nodestore
-register(
-    "deletions.nodestore.parallelization-task-enabled",
-    default=False,
-    type=Bool,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-
 register(
     "issues.severity.first-event-severity-calculation-projects-allowlist",
     type=Sequence,

--- a/tests/sentry/deletions/test_group.py
+++ b/tests/sentry/deletions/test_group.py
@@ -8,7 +8,7 @@ from uuid import uuid4
 from snuba_sdk import Column, Condition, Entity, Function, Op, Query, Request
 
 from sentry import nodestore
-from sentry.deletions.defaults.group import ErrorEventsDeletionTask, IssuePlatformEventsDeletionTask
+from sentry.deletions.defaults.group import ErrorEventsDeletionTask
 from sentry.deletions.tasks.groups import delete_groups_for_project
 from sentry.issues.grouptype import FeedbackGroup, GroupCategory
 from sentry.issues.issue_occurrence import IssueOccurrence
@@ -91,10 +91,6 @@ class DeleteGroupTest(TestCase, SnubaTestCase):
         assert nodestore.backend.get(self.keep_node_id), "Does not remove from second group"
         assert Group.objects.filter(id=self.keep_event.group_id).exists()
 
-    def test_simple_with_new_task(self) -> None:
-        with self.options({"deletions.nodestore.parallelization-task-enabled": True}):
-            self.test_simple()
-
     def test_simple_multiple_groups(self) -> None:
         other_event = self.store_event(
             data={"timestamp": before_now(minutes=1).isoformat(), "fingerprint": ["group3"]},
@@ -117,10 +113,6 @@ class DeleteGroupTest(TestCase, SnubaTestCase):
 
         assert Group.objects.filter(id=self.keep_event.group_id).exists()
         assert nodestore.backend.get(self.keep_node_id)
-
-    def test_simple_multiple_groups_with_new_task(self) -> None:
-        with self.options({"deletions.nodestore.parallelization-task-enabled": True}):
-            self.test_simple_multiple_groups()
 
     def test_grouphistory_relation(self) -> None:
         other_event = self.store_event(
@@ -155,10 +147,6 @@ class DeleteGroupTest(TestCase, SnubaTestCase):
         assert GroupHistory.objects.filter(id=other_history_one.id).exists() is False
         assert GroupHistory.objects.filter(id=other_history_two.id).exists() is False
 
-    def test_grouphistory_relation_with_new_task(self) -> None:
-        with self.options({"deletions.nodestore.parallelization-task-enabled": True}):
-            self.test_grouphistory_relation()
-
     @mock.patch("sentry.services.nodestore.delete_multi")
     def test_cleanup(self, nodestore_delete_multi: mock.Mock) -> None:
         os.environ["_SENTRY_CLEANUP"] = "1"
@@ -175,10 +163,6 @@ class DeleteGroupTest(TestCase, SnubaTestCase):
             assert nodestore_delete_multi.call_count == 0
         finally:
             del os.environ["_SENTRY_CLEANUP"]
-
-    def test_cleanup_with_new_task(self) -> None:
-        with self.options({"deletions.nodestore.parallelization-task-enabled": True}):
-            self.test_cleanup()
 
     @mock.patch(
         "sentry.tasks.delete_seer_grouping_records.delete_seer_grouping_records_by_hash.apply_async"
@@ -221,10 +205,6 @@ class DeleteGroupTest(TestCase, SnubaTestCase):
         assert mock_delete_seer_grouping_records_by_hash_apply_async.call_args[1] == {
             "args": [group.project.id, hashes, 0]
         }
-
-    def test_delete_groups_delete_grouping_records_by_hash_with_new_task(self) -> None:
-        with self.options({"deletions.nodestore.parallelization-task-enabled": True}):
-            self.test_delete_groups_delete_grouping_records_by_hash()
 
     @mock.patch(
         "sentry.tasks.delete_seer_grouping_records.delete_seer_grouping_records_by_hash.apply_async"
@@ -273,10 +253,6 @@ class DeleteGroupTest(TestCase, SnubaTestCase):
             assert mock_delete_seer_grouping_records_by_hash_apply_async.call_args[1] == {
                 "args": [self.project.id, error_group_hashes, 0]
             }
-
-    def test_invalid_group_type_handling_with_new_task(self) -> None:
-        with self.options({"deletions.nodestore.parallelization-task-enabled": True}):
-            self.test_invalid_group_type_handling()
 
 
 class DeleteIssuePlatformTest(TestCase, SnubaTestCase, OccurrenceTestMixin):
@@ -385,57 +361,10 @@ class DeleteIssuePlatformTest(TestCase, SnubaTestCase, OccurrenceTestMixin):
         # assert not nodestore.backend.get(occurrence_node_id)
         assert self.select_issue_platform_events(self.project.id) is None
 
-    def test_simple_issue_platform_with_new_task(self) -> None:
-        with self.options({"deletions.nodestore.parallelization-task-enabled": True}):
-            self.test_simple_issue_platform()
-
-    @mock.patch("sentry.deletions.defaults.group.bulk_snuba_queries")
+    @mock.patch("sentry.deletions.tasks.nodestore.bulk_snuba_queries")
     def test_issue_platform_batching(self, mock_bulk_snuba_queries: mock.Mock) -> None:
         # Patch max_rows_to_delete to a small value for testing
-        with mock.patch.object(IssuePlatformEventsDeletionTask, "max_rows_to_delete", 6):
-            # Create three groups with times_seen such that batching is required
-            group1 = self.create_group(project=self.project)
-            group2 = self.create_group(project=self.project)
-            group3 = self.create_group(project=self.project)
-            group4 = self.create_group(project=self.project)
-
-            # Set times_seen for each group
-            Group.objects.filter(id=group1.id).update(times_seen=3, type=GroupCategory.FEEDBACK)
-            Group.objects.filter(id=group2.id).update(times_seen=1, type=GroupCategory.FEEDBACK)
-            Group.objects.filter(id=group3.id).update(times_seen=3, type=GroupCategory.FEEDBACK)
-            Group.objects.filter(id=group4.id).update(times_seen=3, type=GroupCategory.FEEDBACK)
-
-            # This will delete the group and the events from the node store and Snuba
-            with self.tasks():
-                delete_groups_for_project(
-                    object_ids=[group1.id, group2.id, group3.id, group4.id],
-                    transaction_id=uuid4().hex,
-                    project_id=self.project.id,
-                )
-
-            # There should be two batches with max_rows_to_delete=6
-            # First batch: [group2, group1] (1+3=4 events, under limit)
-            # Second batch: [group3, group4] (3+3=6 events, at limit)
-            assert mock_bulk_snuba_queries.call_count == 1
-            requests = mock_bulk_snuba_queries.call_args[0][0]
-            assert len(requests) == 2
-
-            first_batch = requests[0].query.column_conditions["group_id"]
-            second_batch = requests[1].query.column_conditions["group_id"]
-
-            # Since we sort by times_seen, the first batch will be [group2, group1]
-            # and the second batch will be [group3, group4]
-            assert first_batch == [group2.id, group1.id]  # group2 has less times_seen than group1
-            # group3 and group4 have the same times_seen, thus sorted by id
-            assert second_batch == [group3.id, group4.id]
-
-    @mock.patch("sentry.deletions.tasks.nodestore.bulk_snuba_queries")
-    def test_issue_platform_batching_with_new_task(
-        self, mock_bulk_snuba_queries: mock.Mock
-    ) -> None:
-        # Patch max_rows_to_delete to a small value for testing
         with (
-            self.options({"deletions.nodestore.parallelization-task-enabled": True}),
             self.tasks(),
             mock.patch("sentry.deletions.tasks.nodestore.ISSUE_PLATFORM_MAX_ROWS_TO_DELETE", 6),
         ):


### PR DESCRIPTION
Now that we delete events inside of the new task from #96795, we don't need the old code anymore.

The original PR got reviewed in #98791

Fixes [ID-921](https://linear.app/getsentry/issue/ID-921/remove-sequential-approach-to-deleting-events).