### PR TITLE
feat(widget-builder): Do not trigger URL updates for every keystroke

### DIFF
--- a/static/app/utils/url/useQueryParamState.tsx
+++ b/static/app/utils/url/useQueryParamState.tsx
@@ -32,6 +32,10 @@ type UseQueryParamStateProps<T> =
   | UseQueryParamStateWithListDecoder<T>
   | UseQueryParamStateWithSortsDecoder<T>;
 
+type UseQueryParamStateOptions = {
+  updateUrl?: boolean;
+};
+
 /**
  * Hook to manage a state that is synced with a query param in the URL
  *
@@ -44,7 +48,10 @@ export function useQueryParamState<T = string>({
   decoder,
   deserializer,
   serializer,
-}: UseQueryParamStateProps<T>): [T | undefined, (newField: T | undefined) => void] {
+}: UseQueryParamStateProps<T>): [
+  T | undefined,
+  (newField: T | undefined, options?: UseQueryParamStateOptions) => void,
+] {
   const {batchUrlParamUpdates} = useUrlBatchContext();
 
   // The URL query params give us our initial state
@@ -69,8 +76,12 @@ export function useQueryParamState<T = string>({
   });
 
   const updateField = useCallback(
-    (newField: T | undefined) => {
+    (newField: T | undefined, options: UseQueryParamStateOptions = {updateUrl: true}) => {
       setLocalState(newField);
+
+      if (!options?.updateUrl) {
+        return;
+      }
 
       if (!defined(newField)) {
         batchUrlParamUpdates({[fieldName]: undefined});

--- a/static/app/views/dashboards/widgetBuilder/components/nameAndDescFields.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/nameAndDescFields.spec.tsx
@@ -43,6 +43,9 @@ describe('WidgetBuilder', () => {
     );
 
     await userEvent.type(await screen.findByPlaceholderText('Name'), 'some name');
+
+    // trigger blur
+    await userEvent.tab();
     expect(mockNavigate).toHaveBeenLastCalledWith(
       expect.objectContaining({
         ...router.location,
@@ -57,6 +60,9 @@ describe('WidgetBuilder', () => {
       await screen.findByPlaceholderText('Description'),
       'some description'
     );
+
+    // trigger blur
+    await userEvent.tab();
     expect(mockNavigate).toHaveBeenLastCalledWith(
       expect.objectContaining({
         ...router.location,

--- a/static/app/views/dashboards/widgetBuilder/components/nameAndDescFields.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/nameAndDescFields.tsx
@@ -46,10 +46,19 @@ function WidgetBuilderNameAndDescription({
         value={state.title}
         onChange={(newTitle: any) => {
           // clear error once user starts typing
-          setError?.({...error, title: undefined});
-          dispatch({type: BuilderStateAction.SET_TITLE, payload: newTitle});
+          if (error?.title) {
+            setError?.({...error, title: undefined});
+          }
+          dispatch(
+            {type: BuilderStateAction.SET_TITLE, payload: newTitle},
+            {updateUrl: false}
+          );
         }}
         onBlur={() => {
+          dispatch(
+            {type: BuilderStateAction.SET_TITLE, payload: state.title ?? ''},
+            {updateUrl: true}
+          );
           trackAnalytics('dashboards_views.widget_builder.change', {
             from: source,
             widget_type: state.dataset ?? '',
@@ -85,9 +94,19 @@ function WidgetBuilderNameAndDescription({
           rows={4}
           value={state.description}
           onChange={e => {
-            dispatch({type: BuilderStateAction.SET_DESCRIPTION, payload: e.target.value});
+            dispatch(
+              {type: BuilderStateAction.SET_DESCRIPTION, payload: e.target.value},
+              {updateUrl: false}
+            );
           }}
           onBlur={() => {
+            dispatch(
+              {
+                type: BuilderStateAction.SET_DESCRIPTION,
+                payload: state.description ?? '',
+              },
+              {updateUrl: true}
+            );
             trackAnalytics('dashboards_views.widget_builder.change', {
               from: source,
               widget_type: state.dataset ?? '',

--- a/static/app/views/dashboards/widgetBuilder/components/nameAndDescFields.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/nameAndDescFields.tsx
@@ -54,9 +54,9 @@ function WidgetBuilderNameAndDescription({
             {updateUrl: false}
           );
         }}
-        onBlur={() => {
+        onBlur={value => {
           dispatch(
-            {type: BuilderStateAction.SET_TITLE, payload: state.title ?? ''},
+            {type: BuilderStateAction.SET_TITLE, payload: value},
             {updateUrl: true}
           );
           trackAnalytics('dashboards_views.widget_builder.change', {
@@ -99,11 +99,11 @@ function WidgetBuilderNameAndDescription({
               {updateUrl: false}
             );
           }}
-          onBlur={() => {
+          onBlur={e => {
             dispatch(
               {
                 type: BuilderStateAction.SET_DESCRIPTION,
-                payload: state.description ?? '',
+                payload: e.target.value,
               },
               {updateUrl: true}
             );

--- a/static/app/views/dashboards/widgetBuilder/components/queryFilterBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/queryFilterBuilder.tsx
@@ -219,11 +219,15 @@ function WidgetBuilderQueryFilterBuilder({
                   {updateUrl: false}
                 );
               }}
-              onBlur={() => {
+              onBlur={e => {
                 dispatch(
                   {
                     type: BuilderStateAction.SET_LEGEND_ALIAS,
-                    payload: state.legendAlias?.length ? state.legendAlias : [],
+                    payload: state.legendAlias?.length
+                      ? state.legendAlias?.map((q, i) =>
+                          i === index ? e.target.value : q
+                        )
+                      : [e.target.value],
                   },
                   {updateUrl: true}
                 );

--- a/static/app/views/dashboards/widgetBuilder/components/queryFilterBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/queryFilterBuilder.tsx
@@ -203,18 +203,30 @@ function WidgetBuilderQueryFilterBuilder({
           {canHaveAlias && (
             <LegendAliasInput
               type="text"
-              name="name"
+              name="alias"
               placeholder={t('Legend Alias')}
               value={state.legendAlias?.[index] || ''}
               onChange={e => {
-                dispatch({
-                  type: BuilderStateAction.SET_LEGEND_ALIAS,
-                  payload: state.legendAlias?.length
-                    ? state.legendAlias?.map((q, i) => (i === index ? e.target.value : q))
-                    : [e.target.value],
-                });
+                dispatch(
+                  {
+                    type: BuilderStateAction.SET_LEGEND_ALIAS,
+                    payload: state.legendAlias?.length
+                      ? state.legendAlias?.map((q, i) =>
+                          i === index ? e.target.value : q
+                        )
+                      : [e.target.value],
+                  },
+                  {updateUrl: false}
+                );
               }}
               onBlur={() => {
+                dispatch(
+                  {
+                    type: BuilderStateAction.SET_LEGEND_ALIAS,
+                    payload: state.legendAlias?.length ? state.legendAlias : [],
+                  },
+                  {updateUrl: true}
+                );
                 trackAnalytics('dashboards_views.widget_builder.change', {
                   builder_version: WidgetBuilderVersion.SLIDEOUT,
                   field: 'filter.alias',

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
@@ -712,9 +712,11 @@ function Visualize({error, setError}: VisualizeProps) {
                                   {updateUrl: false}
                                 );
                               }}
-                              onBlur={() => {
+                              onBlur={e => {
+                                const newFields = cloneDeep(fields);
+                                newFields[index]!.alias = e.target.value;
                                 dispatch(
-                                  {type: updateAction, payload: fields},
+                                  {type: updateAction, payload: newFields},
                                   {updateUrl: true}
                                 );
                                 trackAnalytics('dashboards_views.widget_builder.change', {

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
@@ -700,17 +700,23 @@ function Visualize({error, setError}: VisualizeProps) {
                         <FieldExtras isChartWidget={isChartWidget || isBigNumberWidget}>
                           {!isChartWidget && !isBigNumberWidget && (
                             <LegendAliasInput
-                              type="text"
-                              name="name"
+                              name="alias"
                               placeholder={t('Add Alias')}
                               value={field.alias ?? ''}
                               disabled={disableTransactionWidget}
                               onChange={e => {
                                 const newFields = cloneDeep(fields);
                                 newFields[index]!.alias = e.target.value;
-                                dispatch({type: updateAction, payload: newFields});
+                                dispatch(
+                                  {type: updateAction, payload: newFields},
+                                  {updateUrl: false}
+                                );
                               }}
                               onBlur={() => {
+                                dispatch(
+                                  {type: updateAction, payload: fields},
+                                  {updateUrl: true}
+                                );
                                 trackAnalytics('dashboards_views.widget_builder.change', {
                                   builder_version: WidgetBuilderVersion.SLIDEOUT,
                                   field: 'visualize.legendAlias',

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
@@ -84,6 +84,24 @@ describe('useWidgetBuilderState', () => {
     );
   });
 
+  it('does not update the url when the updateUrl option is false', () => {
+    const {result} = renderHook(() => useWidgetBuilderState(), {
+      wrapper: WidgetBuilderProvider,
+    });
+
+    act(() => {
+      result.current.dispatch(
+        {
+          type: BuilderStateAction.SET_TITLE,
+          payload: 'new title',
+        },
+        {updateUrl: false}
+      );
+    });
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
   describe('display type', () => {
     it('returns the display type from the query params', () => {
       mockedUsedLocation.mockReturnValue(

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -346,10 +346,10 @@ function useWidgetBuilderState(): {
           } else {
             setFields([], options);
             setYAxis(
-              config.defaultWidgetQuery.aggregates?.map(
-                aggregate => explodeField({field: aggregate}),
-                options
-              )
+              config.defaultWidgetQuery.aggregates?.map(aggregate =>
+                explodeField({field: aggregate})
+              ),
+              options
             );
             setSort(decodeSorts(config.defaultWidgetQuery.orderby), options);
           }

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -85,6 +85,10 @@ type WidgetAction =
       type: typeof BuilderStateAction.SET_THRESHOLDS;
     };
 
+type WidgetBuilderStateActionOptions = {
+  updateUrl?: boolean;
+};
+
 export interface WidgetBuilderState {
   dataset?: WidgetType;
   description?: string;
@@ -101,7 +105,7 @@ export interface WidgetBuilderState {
 }
 
 function useWidgetBuilderState(): {
-  dispatch: (action: WidgetAction) => void;
+  dispatch: (action: WidgetAction, options?: WidgetBuilderStateActionOptions) => void;
   state: WidgetBuilderState;
 } {
   const [title, setTitle] = useQueryParamState<string>({fieldName: 'title'});
@@ -198,17 +202,17 @@ function useWidgetBuilderState(): {
   );
 
   const dispatch = useCallback(
-    (action: WidgetAction) => {
+    (action: WidgetAction, options?: WidgetBuilderStateActionOptions) => {
       const currentDatasetConfig = getDatasetConfig(dataset);
       switch (action.type) {
         case BuilderStateAction.SET_TITLE:
-          setTitle(action.payload);
+          setTitle(action.payload, options);
           break;
         case BuilderStateAction.SET_DESCRIPTION:
-          setDescription(action.payload);
+          setDescription(action.payload, options);
           break;
         case BuilderStateAction.SET_DISPLAY_TYPE: {
-          setDisplayType(action.payload);
+          setDisplayType(action.payload, options);
           const [aggregates, columns] = partition(fields, field => {
             const fieldString = generateFieldAsString(field);
             return isAggregateFieldOrEquation(fieldString);
@@ -223,15 +227,15 @@ function useWidgetBuilderState(): {
             return {...axis, alias: undefined};
           });
           if (action.payload === DisplayType.TABLE) {
-            setLimit(undefined);
-            setYAxis([]);
-            setLegendAlias([]);
+            setLimit(undefined, options);
+            setYAxis([], options);
+            setLegendAlias([], options);
             const newFields = [
               ...columnsWithoutAlias,
               ...aggregatesWithoutAlias,
               ...(yAxisWithoutAlias ?? []),
             ];
-            setFields(newFields);
+            setFields(newFields, options);
 
             // Keep the sort if it's already contained in the new fields
             // Otherwise, reset sorting to the first field
@@ -264,20 +268,21 @@ function useWidgetBuilderState(): {
                         kind: 'desc',
                         field: generateFieldAsString(newFields[0] as QueryFieldValue),
                       },
-                    ]
+                    ],
+                options
               );
             }
           } else if (action.payload === DisplayType.BIG_NUMBER) {
             // TODO: Reset the selected aggregate here for widgets with equations
-            setLimit(undefined);
-            setSort([]);
-            setYAxis([]);
-            setLegendAlias([]);
+            setLimit(undefined, options);
+            setSort([], options);
+            setYAxis([], options);
+            setLegendAlias([], options);
             // Columns are ignored for big number widgets because there is no grouping
-            setFields([...aggregatesWithoutAlias, ...(yAxisWithoutAlias ?? [])]);
-            setQuery(query?.slice(0, 1));
+            setFields([...aggregatesWithoutAlias, ...(yAxisWithoutAlias ?? [])], options);
+            setQuery(query?.slice(0, 1), options);
           } else {
-            setFields(columnsWithoutAlias);
+            setFields(columnsWithoutAlias, options);
             const nextAggregates = [
               ...aggregatesWithoutAlias.slice(0, MAX_NUM_Y_AXES),
               ...(yAxisWithoutAlias?.slice(0, MAX_NUM_Y_AXES) ?? []),
@@ -288,71 +293,76 @@ function useWidgetBuilderState(): {
                 alias: undefined,
               });
             }
-            setYAxis(nextAggregates);
+            setYAxis(nextAggregates, options);
 
             // Reset the limit to a valid value, bias towards the current limit or
             // default if possible
             const maxLimit = getResultsLimit(query?.length ?? 1, nextAggregates.length);
-            setLimit(Math.min(limit ?? DEFAULT_RESULTS_LIMIT, maxLimit));
+            setLimit(Math.min(limit ?? DEFAULT_RESULTS_LIMIT, maxLimit), options);
 
             if (dataset === WidgetType.RELEASE && sort?.length === 0) {
               setSort(
                 decodeSorts(
                   getDatasetConfig(WidgetType.RELEASE).defaultWidgetQuery.orderby
-                )
+                ),
+                options
               );
             }
           }
-          setThresholds(undefined);
-          setSelectedAggregate(undefined);
+          setThresholds(undefined, options);
+          setSelectedAggregate(undefined, options);
           break;
         }
         case BuilderStateAction.SET_DATASET: {
-          setDataset(action.payload);
+          setDataset(action.payload, options);
 
           let nextDisplayType = displayType;
           if (action.payload === WidgetType.ISSUE) {
             // Issues only support table display type
-            setDisplayType(DisplayType.TABLE);
+            setDisplayType(DisplayType.TABLE, options);
             nextDisplayType = DisplayType.TABLE;
           }
 
           const config = getDatasetConfig(action.payload);
           setFields(
-            config.defaultWidgetQuery.fields?.map(field => explodeField({field}))
+            config.defaultWidgetQuery.fields?.map(field => explodeField({field})),
+            options
           );
           if (
             nextDisplayType === DisplayType.TABLE ||
             nextDisplayType === DisplayType.BIG_NUMBER
           ) {
-            setYAxis([]);
+            setYAxis([], options);
             setFields(
-              config.defaultWidgetQuery.fields?.map(field => explodeField({field}))
+              config.defaultWidgetQuery.fields?.map(field => explodeField({field})),
+              options
             );
             setSort(
               nextDisplayType === DisplayType.BIG_NUMBER
                 ? []
-                : decodeSorts(config.defaultWidgetQuery.orderby)
+                : decodeSorts(config.defaultWidgetQuery.orderby),
+              options
             );
           } else {
-            setFields([]);
+            setFields([], options);
             setYAxis(
-              config.defaultWidgetQuery.aggregates?.map(aggregate =>
-                explodeField({field: aggregate})
+              config.defaultWidgetQuery.aggregates?.map(
+                aggregate => explodeField({field: aggregate}),
+                options
               )
             );
-            setSort(decodeSorts(config.defaultWidgetQuery.orderby));
+            setSort(decodeSorts(config.defaultWidgetQuery.orderby), options);
           }
 
-          setThresholds(undefined);
-          setQuery([config.defaultWidgetQuery.conditions]);
-          setLegendAlias([]);
-          setSelectedAggregate(undefined);
-          setLimit(undefined);
+          setThresholds(undefined, options);
+          setQuery([config.defaultWidgetQuery.conditions], options);
+          setLegendAlias([], options);
+          setSelectedAggregate(undefined, options);
+          setLimit(undefined, options);
           break;
         }
         case BuilderStateAction.SET_FIELDS: {
-          setFields(action.payload);
+          setFields(action.payload, options);
 
           const isRemoved = action.payload.length < (fields?.length ?? 0);
           if (
@@ -397,7 +407,8 @@ function useWidgetBuilderState(): {
                         ),
                       },
                     ]
-                  : []
+                  : [],
+                options
               );
             } else {
               // Find the index of the first field that doesn't match the old fields, is not an equation, and is not a disabled release sort option.
@@ -424,19 +435,23 @@ function useWidgetBuilderState(): {
                           ),
                         },
                       ]
-                    : []
+                    : [],
+                  options
                 );
               } else {
                 // At this point, we can assume the fields are the same length so
                 // using the changedFieldIndex in action.payload is safe.
-                setSort([
-                  {
-                    kind: sort?.[0]?.kind ?? 'desc',
-                    field: generateFieldAsString(
-                      action.payload[changedFieldIndex] as QueryFieldValue
-                    ),
-                  },
-                ]);
+                setSort(
+                  [
+                    {
+                      kind: sort?.[0]?.kind ?? 'desc',
+                      field: generateFieldAsString(
+                        action.payload[changedFieldIndex] as QueryFieldValue
+                      ),
+                    },
+                  ],
+                  options
+                );
               }
             }
           }
@@ -453,15 +468,18 @@ function useWidgetBuilderState(): {
               field => field.kind !== FieldValueKind.EQUATION
             );
             // Adding a grouping, so default the sort to the first aggregate if possible
-            setSort([
-              {
-                kind: 'desc',
-                field: generateFieldAsString(
-                  (firstYAxisNotEquation as QueryFieldValue) ??
-                    (firstActionPayloadNotEquation as QueryFieldValue)
-                ),
-              },
-            ]);
+            setSort(
+              [
+                {
+                  kind: 'desc',
+                  field: generateFieldAsString(
+                    (firstYAxisNotEquation as QueryFieldValue) ??
+                      (firstActionPayloadNotEquation as QueryFieldValue)
+                  ),
+                },
+              ],
+              options
+            );
           }
 
           if (action.payload.length > 0 && (yAxis?.length ?? 0) > 0 && !defined(limit)) {
@@ -469,20 +487,21 @@ function useWidgetBuilderState(): {
               Math.min(
                 DEFAULT_RESULTS_LIMIT,
                 getResultsLimit(query?.length ?? 1, yAxis?.length ?? 0)
-              )
+              ),
+              options
             );
           }
           break;
         }
         case BuilderStateAction.SET_Y_AXIS:
-          setYAxis(action.payload);
+          setYAxis(action.payload, options);
           if (action.payload.length > 0 && fields?.length === 0) {
             // Clear the sort if there is no grouping
-            setSort([]);
+            setSort([], options);
           }
           break;
         case BuilderStateAction.SET_QUERY:
-          setQuery(action.payload);
+          setQuery(action.payload, options);
           break;
         case BuilderStateAction.SET_SORT: {
           if (dataset === WidgetType.ISSUE) {
@@ -492,41 +511,42 @@ function useWidgetBuilderState(): {
                   field,
                   kind: REVERSED_ORDER_FIELD_SORT_LIST.includes(field) ? 'desc' : 'asc',
                 })
-              )
+              ),
+              options
             );
           } else {
-            setSort(action.payload);
+            setSort(action.payload, options);
           }
           break;
         }
         case BuilderStateAction.SET_LIMIT:
-          setLimit(action.payload);
+          setLimit(action.payload, options);
           break;
         case BuilderStateAction.SET_LEGEND_ALIAS:
-          setLegendAlias(action.payload);
+          setLegendAlias(action.payload, options);
           break;
         case BuilderStateAction.SET_SELECTED_AGGREGATE:
-          setSelectedAggregate(action.payload);
+          setSelectedAggregate(action.payload, options);
           break;
         case BuilderStateAction.SET_STATE:
-          setDataset(action.payload.dataset);
-          setDescription(action.payload.description);
-          setDisplayType(action.payload.displayType);
+          setDataset(action.payload.dataset, options);
+          setDescription(action.payload.description, options);
+          setDisplayType(action.payload.displayType, options);
           if (action.payload.field) {
-            setFields(deserializeFields(action.payload.field));
+            setFields(deserializeFields(action.payload.field), options);
           }
-          setLegendAlias(action.payload.legendAlias);
-          setLimit(action.payload.limit);
-          setQuery(action.payload.query);
-          setSelectedAggregate(action.payload.selectedAggregate);
-          setSort(decodeSorts(action.payload.sort));
-          setTitle(action.payload.title);
+          setLegendAlias(action.payload.legendAlias, options);
+          setLimit(action.payload.limit, options);
+          setQuery(action.payload.query, options);
+          setSelectedAggregate(action.payload.selectedAggregate, options);
+          setSort(decodeSorts(action.payload.sort), options);
+          setTitle(action.payload.title, options);
           if (action.payload.yAxis) {
-            setYAxis(deserializeFields(action.payload.yAxis));
+            setYAxis(deserializeFields(action.payload.yAxis), options);
           }
           break;
         case BuilderStateAction.SET_THRESHOLDS:
-          setThresholds(action.payload);
+          setThresholds(action.payload, options);
           break;
         default:
           break;


### PR DESCRIPTION
This is one of a series of improvements I'm trying to make to the widget builder state management. The goal of this PR is to prevent keystrokes in fields such as the title, description, or the alias input fields from immediately trigging a re-render as a result from updating the URL params. Those changes should only be pushed to the URL during the `onBlur` when a user clicks out of a field.

My next steps (which will be accomplished in future PRs) include:
- Get rid of the batch queueing mechanism and just flush updates to the URL immediately (now that we're using the `onBlur`, we don't need to batch stuff)
- Rethink how we're handling the state object and whether it's contributing to re-render issues
- Add additional memoization where possible to limit heavy component re-rendering (e.g. title changes should not trigger re-rendering in the visualize component)