### PR TITLE
fix(replays): Move message processing logic into the thread-pool task

### DIFF
--- a/src/sentry/replays/consumers/recording.py
+++ b/src/sentry/replays/consumers/recording.py
@@ -91,6 +91,7 @@ def process_and_commit_message(message: Message[KafkaPayload]) -> None:
 # Processing Task
 
 
+@sentry_sdk.trace
 def process_message(message: bytes) -> ProcessedEvent | None:
     try:
         recording_event = parse_recording_event(message)
@@ -186,6 +187,7 @@ def parse_headers(recording: bytes, replay_id: str) -> tuple[int, bytes]:
 # I/O Task
 
 
+@sentry_sdk.trace
 def commit_message(message: ProcessedEvent) -> None:
     try:
         commit_recording_message(message)

--- a/src/sentry/replays/consumers/recording.py
+++ b/src/sentry/replays/consumers/recording.py
@@ -3,13 +3,12 @@ import zlib
 from collections.abc import Mapping
 from typing import cast
 
-import sentry_sdk.profiler
-import sentry_sdk.scope
+import sentry_sdk
 from arroyo.backends.kafka.consumer import KafkaPayload
-from arroyo.processing.strategies import RunTask, RunTaskInThreads
+from arroyo.processing.strategies import RunTaskInThreads
 from arroyo.processing.strategies.abstract import ProcessingStrategy, ProcessingStrategyFactory
 from arroyo.processing.strategies.commit import CommitOffsets
-from arroyo.types import Commit, FilteredPayload, Message, Partition
+from arroyo.types import Commit, Message, Partition
 from django.conf import settings
 from sentry_kafka_schemas.codecs import Codec, ValidationError
 from sentry_kafka_schemas.schema_types.ingest_replay_recordings_v1 import ReplayRecording
@@ -64,38 +63,45 @@ class ProcessReplayRecordingStrategyFactory(ProcessingStrategyFactory[KafkaPaylo
         commit: Commit,
         partitions: Mapping[Partition, int],
     ) -> ProcessingStrategy[KafkaPayload]:
-        return RunTask(
-            function=process_message,
-            next_step=RunTaskInThreads(
-                processing_function=commit_message,
-                concurrency=self.num_threads,
-                max_pending_futures=self.max_pending_futures,
-                next_step=CommitOffsets(commit),
-            ),
+        return RunTaskInThreads(
+            processing_function=process_and_commit_message,
+            concurrency=self.num_threads,
+            max_pending_futures=self.max_pending_futures,
+            next_step=CommitOffsets(commit),
         )
+
+
+def process_and_commit_message(message: Message[KafkaPayload]) -> None:
+    isolation_scope = sentry_sdk.get_isolation_scope().fork()
+    with sentry_sdk.scope.use_isolation_scope(isolation_scope):
+        with sentry_sdk.start_transaction(
+            name="replays.consumer.recording.process_and_commit_message",
+            op="replays.consumer.recording.process_and_commit_message",
+            custom_sampling_context={
+                "sample_rate": getattr(
+                    settings, "SENTRY_REPLAY_RECORDINGS_CONSUMER_APM_SAMPLING", 0
+                )
+            },
+        ):
+            processed_message = process_message(message.payload.value)
+            if processed_message:
+                commit_message(processed_message)
 
 
 # Processing Task
 
 
-def process_message(message: Message[KafkaPayload]) -> ProcessedEvent | FilteredPayload:
-    with sentry_sdk.start_transaction(
-        name="replays.consumer.recording_buffered.process_message",
-        op="replays.consumer.recording_buffered.process_message",
-        custom_sampling_context={
-            "sample_rate": getattr(settings, "SENTRY_REPLAY_RECORDINGS_CONSUMER_APM_SAMPLING", 0)
-        },
-    ):
-        try:
-            recording_event = parse_recording_event(message.payload.value)
-            set_tag("org_id", recording_event["context"]["org_id"])
-            set_tag("project_id", recording_event["context"]["project_id"])
-            return process_recording_event(recording_event)
-        except DropSilently:
-            return FilteredPayload()
-        except Exception:
-            logger.exception("Failed to process replay recording message.")
-            return FilteredPayload()
+def process_message(message: bytes) -> ProcessedEvent | None:
+    try:
+        recording_event = parse_recording_event(message)
+        set_tag("org_id", recording_event["context"]["org_id"])
+        set_tag("project_id", recording_event["context"]["project_id"])
+        return process_recording_event(recording_event)
+    except DropSilently:
+        return None
+    except Exception:
+        logger.exception("Failed to process replay recording message.")
+        return None
 
 
 @sentry_sdk.trace
@@ -180,26 +186,15 @@ def parse_headers(recording: bytes, replay_id: str) -> tuple[int, bytes]:
 # I/O Task
 
 
-def commit_message(message: Message[ProcessedEvent]) -> None:
-    isolation_scope = sentry_sdk.get_isolation_scope().fork()
-    with sentry_sdk.scope.use_isolation_scope(isolation_scope):
-        with sentry_sdk.start_transaction(
-            name="replays.consumer.recording_buffered.commit_message",
-            op="replays.consumer.recording_buffered.commit_message",
-            custom_sampling_context={
-                "sample_rate": getattr(
-                    settings, "SENTRY_REPLAY_RECORDINGS_CONSUMER_APM_SAMPLING", 0
-                )
-            },
-        ):
-            try:
-                commit_recording_message(message.payload)
-                track_recording_metadata(message.payload)
-                return None
-            except GCS_RETRYABLE_ERRORS:
-                raise
-            except DropEvent:
-                return None
-            except Exception:
-                logger.exception("Failed to commit replay recording message.")
-                return None
+def commit_message(message: ProcessedEvent) -> None:
+    try:
+        commit_recording_message(message)
+        track_recording_metadata(message)
+        return None
+    except GCS_RETRYABLE_ERRORS:
+        raise
+    except DropEvent:
+        return None
+    except Exception:
+        logger.exception("Failed to commit replay recording message.")
+        return None

--- a/tests/sentry/replays/unit/consumers/test_recording.py
+++ b/tests/sentry/replays/unit/consumers/test_recording.py
@@ -2,8 +2,6 @@ import zlib
 
 import msgpack
 import pytest
-from arroyo.backends.kafka.consumer import KafkaPayload
-from arroyo.types import FilteredPayload, Message, Value
 
 from sentry.replays.consumers.recording import (
     DropSilently,
@@ -420,7 +418,7 @@ def test_process_message_compressed_with_video() -> None:
 
 def test_process_message_invalid_message() -> None:
     """Test "process_message" function with invalid message."""
-    assert process_message(make_kafka_message(b"")) == FilteredPayload()
+    assert process_message(make_kafka_message(b"")) is None
 
 
 def test_process_message_invalid_recording_json() -> None:
@@ -440,7 +438,7 @@ def test_process_message_invalid_recording_json() -> None:
     }
 
     kafka_message = make_kafka_message(message)
-    assert process_message(kafka_message) == FilteredPayload()
+    assert process_message(kafka_message) is None
 
 
 def test_process_message_invalid_headers() -> None:
@@ -460,7 +458,7 @@ def test_process_message_invalid_headers() -> None:
     }
 
     kafka_message = make_kafka_message(message)
-    assert process_message(kafka_message) == FilteredPayload()
+    assert process_message(kafka_message) is None
 
 
 def test_process_message_malformed_headers() -> None:
@@ -480,7 +478,7 @@ def test_process_message_malformed_headers() -> None:
     }
 
     kafka_message = make_kafka_message(message)
-    assert process_message(kafka_message) == FilteredPayload()
+    assert process_message(kafka_message) is None
 
 
 def test_process_message_malformed_headers_invalid_unicode_codepoint() -> None:
@@ -500,7 +498,7 @@ def test_process_message_malformed_headers_invalid_unicode_codepoint() -> None:
     }
 
     kafka_message = make_kafka_message(message)
-    assert process_message(kafka_message) == FilteredPayload()
+    assert process_message(kafka_message) is None
 
 
 def test_process_message_no_headers() -> None:
@@ -520,12 +518,8 @@ def test_process_message_no_headers() -> None:
     }
 
     kafka_message = make_kafka_message(message)
-    assert process_message(kafka_message) == FilteredPayload()
+    assert process_message(kafka_message) is None
 
 
-def make_kafka_message(message) -> Message[KafkaPayload]:
-    return Message(Value(KafkaPayload(key=None, value=msgpack.packb(message), headers=[]), {}))
-
-
-def make_processed_event_message(processed_event: ProcessedEvent) -> Message[ProcessedEvent]:
-    return Message(Value(processed_event, {}))
+def make_kafka_message(message) -> bytes:
+    return msgpack.packb(message)


### PR DESCRIPTION
Under the previous system, when back-pressure was emitted by the queue the processed message that triggered the message rejection would be dropped and retried. This meant when production out ran consumption we would make the problem worse by continually processing the same message in a loop. This would consume resources and potentially starve the pool.

By moving the processing logic into the pool we'll never process a message unless there's room in the queue.