### PR TITLE
feat(insights): Update Web Vitals issue creation with p75 trace sample

### DIFF
--- a/static/app/views/insights/browser/webVitals/components/pageOverviewSidebar.tsx
+++ b/static/app/views/insights/browser/webVitals/components/pageOverviewSidebar.tsx
@@ -45,7 +45,6 @@ import type {ProjectScore} from 'sentry/views/insights/browser/webVitals/types';
 import type {BrowserType} from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
 import {useHasSeerWebVitalsSuggestions} from 'sentry/views/insights/browser/webVitals/utils/useHasSeerWebVitalsSuggestions';
 import {useRunSeerAnalysis} from 'sentry/views/insights/browser/webVitals/utils/useRunSeerAnalysis';
-import {SpanFields} from 'sentry/views/insights/types';
 import type {SubregionCode} from 'sentry/views/insights/types';
 import {SidebarSpacer} from 'sentry/views/performance/transactionSummary/utils';
 
@@ -151,26 +150,12 @@ export function PageOverviewSidebar({
     eventIds: newlyCreatedIssueEventIds,
   });
 
-  const {
-    lcp,
-    cls,
-    fcp,
-    ttfb,
-    inp,
-    isLoading: isLoadingWebVitalTraceSamples,
-  } = useSampleWebVitalTraceParallel({
-    transaction,
-    projectData,
-    enabled: hasSeerWebVitalsSuggestions,
-  });
-
-  const webVitalTraceSamples = {
-    lcp: lcp?.[0]?.[SpanFields.TRACE],
-    cls: cls?.[0]?.[SpanFields.TRACE],
-    fcp: fcp?.[0]?.[SpanFields.TRACE],
-    ttfb: ttfb?.[0]?.[SpanFields.TRACE],
-    inp: inp?.[0]?.[SpanFields.TRACE],
-  };
+  const {isLoading: isLoadingWebVitalTraceSamples, ...webVitalTraceSamples} =
+    useSampleWebVitalTraceParallel({
+      transaction,
+      projectData,
+      enabled: hasSeerWebVitalsSuggestions,
+    });
 
   const runSeerAnalysis = useRunSeerAnalysis({
     projectScore,

--- a/static/app/views/insights/browser/webVitals/queries/useSampleWebVitalTrace.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/useSampleWebVitalTrace.tsx
@@ -16,7 +16,7 @@ type Props = {
   projectData?: ProjectData[];
 };
 
-export function useSampleWebVitalTrace({
+function useSampleWebVitalTrace({
   transaction,
   projectData,
   webVital,

--- a/static/app/views/insights/browser/webVitals/queries/useSampleWebVitalTrace.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/useSampleWebVitalTrace.tsx
@@ -1,0 +1,116 @@
+import {decodeList} from 'sentry/utils/queryString';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {useLocation} from 'sentry/utils/useLocation';
+import type {ProjectData} from 'sentry/views/insights/browser/webVitals/components/webVitalMeters';
+import {SPANS_FILTER} from 'sentry/views/insights/browser/webVitals/queries/useSpanSamplesWebVitalsQuery';
+import {Referrer} from 'sentry/views/insights/browser/webVitals/referrers';
+import type {WebVitals} from 'sentry/views/insights/browser/webVitals/types';
+import decodeBrowserTypes from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import {SpanFields, type SubregionCode} from 'sentry/views/insights/types';
+
+type Props = {
+  transaction: string;
+  webVital: WebVitals;
+  enabled?: boolean;
+  projectData?: ProjectData[];
+};
+
+export function useSampleWebVitalTrace({
+  transaction,
+  projectData,
+  webVital,
+  enabled = true,
+}: Props) {
+  const location = useLocation();
+
+  let field: SpanFields | undefined;
+  switch (webVital) {
+    case 'cls':
+      field = SpanFields.CLS;
+      break;
+    case 'fcp':
+      field = SpanFields.FCP;
+      break;
+    case 'ttfb':
+      field = SpanFields.TTFB;
+      break;
+    case 'inp':
+      field = SpanFields.INP;
+      break;
+    case 'lcp':
+    default:
+      field = SpanFields.LCP;
+      break;
+  }
+
+  const browserTypes = decodeBrowserTypes(location.query[SpanFields.BROWSER_NAME]);
+  const subregions = decodeList(
+    location.query[SpanFields.USER_GEO_SUBREGION]
+  ) as SubregionCode[];
+  const p75Value = projectData?.[0]?.[`p75(measurements.${webVital})`];
+  const webVitalFilter = p75Value ? `measurements.${webVital}:>=${p75Value}` : '';
+
+  const search = new MutableSearch(SPANS_FILTER);
+  search.addFilterValue(SpanFields.TRANSACTION, transaction);
+  search.addStringFilter(webVitalFilter);
+  if (browserTypes) {
+    search.addDisjunctionFilterValues(SpanFields.BROWSER_NAME, browserTypes);
+  }
+  if (subregions) {
+    search.addDisjunctionFilterValues(SpanFields.USER_GEO_SUBREGION, subregions);
+  }
+
+  return useSpans(
+    {
+      search,
+      sorts: [{field: `measurements.${webVital}`, kind: 'asc'}],
+      fields: [SpanFields.TRACE, field],
+      enabled: Boolean(p75Value) && enabled,
+      limit: 1, // We only need one sample to attach to the issue
+    },
+    Referrer.WEB_VITAL_SPANS
+  );
+}
+
+// Unfortunately, we need to run separate queries for each web vital since we need a sample trace for each
+// Theres no way to get 5 samples for 5 separate web vital conditions in a single query at the moment
+export function useSampleWebVitalTraceParallel({
+  transaction,
+  projectData,
+  enabled = true,
+}: Omit<Props, 'webVital'>) {
+  const {data: lcp, isLoading: isLcpLoading} = useSampleWebVitalTrace({
+    transaction,
+    projectData,
+    webVital: 'lcp',
+    enabled,
+  });
+  const {data: cls, isLoading: isClsLoading} = useSampleWebVitalTrace({
+    transaction,
+    projectData,
+    webVital: 'cls',
+    enabled,
+  });
+  const {data: fcp, isLoading: isFcpLoading} = useSampleWebVitalTrace({
+    transaction,
+    projectData,
+    webVital: 'fcp',
+    enabled,
+  });
+  const {data: ttfb, isLoading: isTtfbLoading} = useSampleWebVitalTrace({
+    transaction,
+    projectData,
+    webVital: 'ttfb',
+    enabled,
+  });
+  const {data: inp, isLoading: isInpLoading} = useSampleWebVitalTrace({
+    transaction,
+    projectData,
+    webVital: 'inp',
+    enabled,
+  });
+  const isLoading =
+    isLcpLoading || isClsLoading || isFcpLoading || isTtfbLoading || isInpLoading;
+  return {lcp, cls, fcp, ttfb, inp, isLoading};
+}

--- a/static/app/views/insights/browser/webVitals/views/pageOverview.tsx
+++ b/static/app/views/insights/browser/webVitals/views/pageOverview.tsx
@@ -193,6 +193,7 @@ function PageOverview() {
               projectScoreIsLoading={isPending}
               browserTypes={browserTypes}
               subregions={subregions}
+              projectData={pageData}
             />
           </Layout.Side>
         </Layout.Body>


### PR DESCRIPTION
- Updates the call to `user-issue` to also include a p75 trace sample
- p75 trace samples are obtained for each web vital by doing a separate span query for each vital