### PR TITLE
perf: Remove unnecessary JOIN for querying foreign groups

### DIFF
--- a/src/sentry/api/helpers/group_index/delete.py
+++ b/src/sentry/api/helpers/group_index/delete.py
@@ -93,11 +93,11 @@ def delete_group_list(
 
     # Removing GroupHash rows prevents new events from associating to the groups
     # we just deleted.
-    GroupHash.objects.filter(project_id=project.id, group__id__in=group_ids).delete()
+    GroupHash.objects.filter(project_id=project.id, group_id__in=group_ids).delete()
 
     # We remove `GroupInbox` rows here so that they don't end up influencing queries for
     # `Group` instances that are pending deletion
-    GroupInbox.objects.filter(project_id=project.id, group__id__in=group_ids).delete()
+    GroupInbox.objects.filter(project_id=project.id, group_id__in=group_ids).delete()
 
     # Schedule a task per GROUP_CHUNK_SIZE batch of groups
     for i in range(0, len(group_ids), GROUP_CHUNK_SIZE):

--- a/src/sentry/integrations/repository/issue_alert.py
+++ b/src/sentry/integrations/repository/issue_alert.py
@@ -179,7 +179,7 @@ class IssueAlertNotificationMessageRepository:
         control the usage of memory in the application.
         It is up to the caller to iterate over all the data, or store in memory if they need all objects concurrently.
         """
-        group_id_filter = Q(rule_fire_history__group__id__in=group_ids) if group_ids else Q()
+        group_id_filter = Q(rule_fire_history__group_id__in=group_ids) if group_ids else Q()
         project_id_filter = Q(rule_fire_history__project_id__in=project_ids) if project_ids else Q()
         open_period_start_filter = (
             Q(open_period_start=open_period_start) if open_period_start else Q()

--- a/src/sentry/integrations/repository/notification_action.py
+++ b/src/sentry/integrations/repository/notification_action.py
@@ -174,7 +174,7 @@ class NotificationActionNotificationMessageRepository:
         It is up to the caller to iterate over all the data, or store in memory if they need all objects concurrently.
         """
         action_id_filter = Q(action__id__in=action_ids) if action_ids else Q()
-        group_id_filter = Q(group__id__in=group_ids) if group_ids else Q()
+        group_id_filter = Q(group_id__in=group_ids) if group_ids else Q()
         open_period_start_filter = (
             Q(open_period_start=open_period_start) if open_period_start else Q()
         )

--- a/src/sentry/tasks/delete_seer_grouping_records.py
+++ b/src/sentry/tasks/delete_seer_grouping_records.py
@@ -86,7 +86,7 @@ def may_schedule_task_to_delete_hashes_from_seer(
         batch_size = options.get("embeddings-grouping.seer.delete-record-batch-size") or 100
 
         for group_hash in RangeQuerySetWrapper(
-            GroupHash.objects.filter(project_id=project.id, group__id__in=group_ids),
+            GroupHash.objects.filter(project_id=project.id, group_id__in=group_ids),
             step=batch_size,
         ):
             group_hashes.append(group_hash.hash)


### PR DESCRIPTION
Removing foreign key traversals (`group__id__in`) in favor of direct field lookups (`group_id__in`) eliminates unnecessary SQL JOINs.