### PR TITLE
fix(uptime): Only query summary when the timeWindowConfig resolves

### DIFF
--- a/static/app/views/insights/uptime/components/overviewTimeline/index.tsx
+++ b/static/app/views/insights/uptime/components/overviewTimeline/index.tsx
@@ -31,9 +31,8 @@ export function OverviewTimeline({uptimeRules}: Props) {
   const dateNavigation = useDateNavigation();
 
   const {data: summaries} = useUptimeMonitorSummaries({
-    start: timeWindowConfig.start,
-    end: timeWindowConfig.end,
     detectorIds: uptimeRules.map(rule => String(rule.detectorId)),
+    timeWindowConfig,
   });
 
   return (

--- a/static/app/views/insights/uptime/utils/useUptimeMonitorSummary.tsx
+++ b/static/app/views/insights/uptime/utils/useUptimeMonitorSummary.tsx
@@ -1,3 +1,4 @@
+import type {TimeWindowConfig} from 'sentry/components/checkInTimeline/types';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import type {UptimeSummary} from 'sentry/views/alerts/rules/uptime/types';
@@ -9,26 +10,21 @@ interface Options {
    */
   detectorIds: string[];
   /**
-   * Optional end time for calculating the summary
+   * The window configuration object, if supplied the `start` and `end` will be
+   * calculated using the timewindow start end time.
    */
-  end?: Date;
-  /**
-   * Optional start time for calculating the summary
-   */
-  start?: Date;
+  timeWindowConfig?: TimeWindowConfig;
 }
 
 /**
  * Fetches Uptime Monitor summaries
  */
-export function useUptimeMonitorSummaries({detectorIds, start, end}: Options) {
+export function useUptimeMonitorSummaries({detectorIds, timeWindowConfig}: Options) {
   const selectionQuery: Record<string, any> = {};
 
-  if (start) {
-    selectionQuery.start = Math.floor(start.getTime() / 1000);
-  }
-  if (end) {
-    selectionQuery.end = Math.floor(end.getTime() / 1000);
+  if (timeWindowConfig) {
+    selectionQuery.start = Math.floor(timeWindowConfig.start.getTime() / 1000);
+    selectionQuery.end = Math.floor(timeWindowConfig.end.getTime() / 1000);
   }
 
   const organization = useOrganization();
@@ -44,6 +40,9 @@ export function useUptimeMonitorSummaries({detectorIds, start, end}: Options) {
         },
       },
     ],
-    {staleTime: 0}
+    {
+      staleTime: 0,
+      enabled: !timeWindowConfig || timeWindowConfig.rollupConfig.totalBuckets > 0,
+    }
   );
 }


### PR DESCRIPTION
Prior to this change the start / end time would change as the
timeWindowConfig finished computing (since we have to wait to know the
size of the timeline container)