### PR TITLE
Update pr to include import removal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,8 +54,6 @@ junit.xml
 .webpack.meta
 pip-wheel-metadata/
 Brewfile.lock.json
-import-graph.txt
-import-graph.dot
 bin/rrweb-output
 model-manifest.json
 .mypy_cache

--- a/src/sentry/__init__.py
+++ b/src/sentry/__init__.py
@@ -1,5 +1,4 @@
 # this must import first
-import sentry._importchecker  # NOQA isort:skip
 
 import importlib.metadata
 import os

--- a/tests/sentry/conf/types/test_imports.py
+++ b/tests/sentry/conf/types/test_imports.py
@@ -15,7 +15,6 @@ ALLOWLIST = frozenset(
         "sentry.conf.types",
         "sentry.conf.types.kafka_definition",
         # these come from sentry.__init__ -- please don't make this longer!
-        "sentry._importchecker",
         "sentry.monkey",
         "sentry.monkey.pickle",
     )


### PR DESCRIPTION
This PR completes the removal of the `_importchecker.py` development tool by cleaning up all remaining references and its generated output files. The `_importchecker.py` file was used to track imports and generate dependency graphs, and is no longer needed.

Specifically, this PR:
- Removes the import statement for `sentry._importchecker` from `src/sentry/__init__.py`.
- Removes `sentry._importchecker` from the import `ALLOWLIST` in `tests/sentry/conf/types/test_imports.py`.
- Removes `import-graph.txt` and `import-graph.dot` (output files of the checker) from `.gitignore`.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
[Slack Thread](https://sentry.slack.com/archives/C07T7SFG7DH/p1757087523995849?thread_ts=1757087523.995849&cid=C07T7SFG7DH)

<a href="https://cursor.com/background-agent?bcId=bc-3bab08d8-a11b-48c2-9d8d-755cbf39a7d7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3bab08d8-a11b-48c2-9d8d-755cbf39a7d7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

