### PR TITLE
feat(aci): Spans dataset special case on `count()`

### DIFF
--- a/static/app/views/detectors/components/forms/metric/visualize.tsx
+++ b/static/app/views/detectors/components/forms/metric/visualize.tsx
@@ -12,7 +12,11 @@ import {space} from 'sentry/styles/space';
 import type {SelectValue} from 'sentry/types/core';
 import type {AggregateParameter} from 'sentry/utils/discover/fields';
 import {parseFunction} from 'sentry/utils/discover/fields';
-import {ALLOWED_EXPLORE_VISUALIZE_AGGREGATES, prettifyTagKey} from 'sentry/utils/fields';
+import {
+  AggregationKey,
+  ALLOWED_EXPLORE_VISUALIZE_AGGREGATES,
+  prettifyTagKey,
+} from 'sentry/utils/fields';
 import {unreachable} from 'sentry/utils/unreachable';
 import useOrganization from 'sentry/utils/useOrganization';
 import useTags from 'sentry/utils/useTags';
@@ -31,7 +35,13 @@ import {
 } from 'sentry/views/detectors/datasetConfig/useTraceItemAttributes';
 import type {FieldValue} from 'sentry/views/discover/table/types';
 import {FieldValueKind} from 'sentry/views/discover/table/types';
+import {DEFAULT_VISUALIZATION_FIELD} from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
 import {TraceItemDataset} from 'sentry/views/explore/types';
+
+const LOCKED_SPAN_COUNT_OPTION = {
+  value: DEFAULT_VISUALIZATION_FIELD,
+  label: t('spans'),
+};
 
 /**
  * Render a tag badge for field types, similar to dashboard widget builder
@@ -289,6 +299,9 @@ export function Visualize() {
     updateAggregateFunction(aggregate, newParameters);
   };
 
+  const lockSpanOptions =
+    dataset === DetectorDataset.SPANS && aggregate === AggregationKey.COUNT;
+
   const hasVisibleParameters =
     Boolean(aggregateMetadata?.parameters?.length) &&
     dataset !== DetectorDataset.SPANS &&
@@ -325,13 +338,22 @@ export function Visualize() {
                 <StyledVisualizeSelect
                   searchable
                   triggerLabel={
-                    parameters[index] || param.defaultValue || t('Select metric')
+                    lockSpanOptions
+                      ? LOCKED_SPAN_COUNT_OPTION.label
+                      : parameters[index] || param.defaultValue || t('Select metric')
                   }
-                  options={fieldOptionsDropdown}
-                  value={parameters[index] || param.defaultValue || ''}
+                  options={
+                    lockSpanOptions ? [LOCKED_SPAN_COUNT_OPTION] : fieldOptionsDropdown
+                  }
+                  value={
+                    lockSpanOptions
+                      ? DEFAULT_VISUALIZATION_FIELD
+                      : parameters[index] || param.defaultValue || ''
+                  }
                   onChange={option => {
                     handleParameterChange(index, String(option.value));
                   }}
+                  disabled={lockSpanOptions}
                 />
               ) : param.kind === 'dropdown' && param.options ? (
                 <StyledVisualizeSelect


### PR DESCRIPTION
Disables the argument dropdown for spans when using the count function. Similar to dashboards and trace query builder.

<img width="570" height="260" alt="image" src="https://github.com/user-attachments/assets/03db82f0-e5b2-4059-af04-4a8e692eb20b" />
