### PR TITLE
fix(groupingInfo): Fix feedback button loading outside container.

### DIFF
--- a/static/app/components/events/groupingInfo/groupingInfo.tsx
+++ b/static/app/components/events/groupingInfo/groupingInfo.tsx
@@ -66,7 +66,7 @@ export default function GroupingInfo({
   );
 
   return (
-    <Fragment>
+    <GroupingInfoContainer>
       <ConfigHeader>
         {hasStreamlinedUI && (
           <GroupInfoSummary
@@ -113,9 +113,16 @@ export default function GroupingInfo({
               </Fragment>
             ))
         : null}
-    </Fragment>
+    </GroupingInfoContainer>
   );
 }
+
+const GroupingInfoContainer = styled('div')`
+  width: 100%;
+  max-width: 100%;
+  overflow: hidden;
+  box-sizing: border-box;
+`;
 
 const ConfigHeader = styled('div')`
   display: flex;


### PR DESCRIPTION
Fix for the feedback button loads outside the groupingInfo section when the page is refreshed. (https://github.com/getsentry/sentry/pull/97718#discussion_r2271401003)

<img width="2424" height="178" alt="image" src="https://github.com/user-attachments/assets/d66e7f9d-e828-4fca-a0c2-329a3fdb56ac" />

