### PR TITLE
ref(groupingInfo): remove redundant by

### DIFF
--- a/static/app/components/events/groupingInfo/groupingVariant.tsx
+++ b/static/app/components/events/groupingInfo/groupingVariant.tsx
@@ -175,7 +175,6 @@ function GroupingVariant({event, variant, showNonContributing}: GroupingVariantP
       <Tooltip title={title}>
         <VariantTitle>
           <ContributionIcon isContributing={isContributing} />
-          {t('By')}{' '}
           {variant.description
             ?.split(' ')
             .map(i => capitalize(i))


### PR DESCRIPTION
For #97310.

At the top of the grouping info section it says the event was grouped by X, Y, and Z. We then also say "By" in the headings for X, Y, and Z. Removes the second "by".

<img width="398" height="59" alt="image" src="https://github.com/user-attachments/assets/ad5f0902-92b8-4270-8a9c-6620add1a5ba" />

