### PR TITLE
feat(explore): Use query params for spans visualizes

### DIFF
--- a/static/app/views/explore/components/toolbar/toolbarVisualize/visualizeEquation.tsx
+++ b/static/app/views/explore/components/toolbar/toolbarVisualize/visualizeEquation.tsx
@@ -13,9 +13,9 @@ import {
   getFieldDefinition,
 } from 'sentry/utils/fields';
 import {ToolbarRow} from 'sentry/views/explore/components/toolbar/styles';
-import {Visualize} from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
 import {useTraceItemTags} from 'sentry/views/explore/contexts/spanTagsContext';
 import {useExploreSuggestedAttribute} from 'sentry/views/explore/hooks/useExploreSuggestedAttribute';
+import {Visualize} from 'sentry/views/explore/queryParams/visualize';
 
 interface VisualizeEquationProps {
   onDelete: () => void;

--- a/static/app/views/explore/contexts/pageParamsContext/index.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/index.tsx
@@ -281,22 +281,6 @@ export function useExploreId(): string | undefined {
   return pageParams.id;
 }
 
-interface UseExploreVisualizesOptions {
-  validate: boolean;
-}
-
-export function useExploreVisualizes(options?: UseExploreVisualizesOptions): Visualize[] {
-  const {validate = false} = options || {};
-  const pageParams = useExplorePageParams();
-
-  return useMemo(() => {
-    if (validate) {
-      return pageParams.visualizes.filter(visualize => visualize.isValid());
-    }
-    return pageParams.visualizes;
-  }, [pageParams.visualizes, validate]);
-}
-
 export function newExploreTarget(
   location: Location,
   pageParams: WritablePageParams

--- a/static/app/views/explore/hooks/useAddToDashboard.tsx
+++ b/static/app/views/explore/hooks/useAddToDashboard.tsx
@@ -18,13 +18,13 @@ import {
   useExploreDataset,
   useExploreQuery,
   useExploreSortBys,
-  useExploreVisualizes,
 } from 'sentry/views/explore/contexts/pageParamsContext';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {formatSort} from 'sentry/views/explore/contexts/pageParamsContext/sortBys';
 import {
   useQueryParamsGroupBys,
   useQueryParamsMode,
+  useQueryParamsVisualizes,
 } from 'sentry/views/explore/queryParams/context';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
 
@@ -44,7 +44,7 @@ export function useAddToDashboard() {
   const dataset = useExploreDataset();
   const groupBys = useQueryParamsGroupBys();
   const sortBys = useExploreSortBys();
-  const visualizes = useExploreVisualizes();
+  const visualizes = useQueryParamsVisualizes();
   const query = useExploreQuery();
 
   const getEventView = useCallback(

--- a/static/app/views/explore/hooks/useExploreTimeseries.tsx
+++ b/static/app/views/explore/hooks/useExploreTimeseries.tsx
@@ -7,10 +7,8 @@ import {determineSeriesSampleCountAndIsSampled} from 'sentry/views/alerts/rules/
 import {
   useExploreAggregateSortBys,
   useExploreDataset,
-  useExploreVisualizes,
 } from 'sentry/views/explore/contexts/pageParamsContext';
 import {formatSort} from 'sentry/views/explore/contexts/pageParamsContext/sortBys';
-import type {Visualize} from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
 import {DEFAULT_VISUALIZATION} from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
 import {useChartInterval} from 'sentry/views/explore/hooks/useChartInterval';
 import {
@@ -18,7 +16,11 @@ import {
   type SpansRPCQueryExtras,
 } from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {useTopEvents} from 'sentry/views/explore/hooks/useTopEvents';
-import {useQueryParamsGroupBys} from 'sentry/views/explore/queryParams/context';
+import {
+  useQueryParamsGroupBys,
+  useQueryParamsVisualizes,
+} from 'sentry/views/explore/queryParams/context';
+import type {Visualize} from 'sentry/views/explore/queryParams/visualize';
 import {computeVisualizeSampleTotals} from 'sentry/views/explore/utils';
 import {useSortedTimeSeries} from 'sentry/views/insights/common/queries/useSortedTimeSeries';
 
@@ -39,7 +41,7 @@ export const useExploreTimeseries = ({
   enabled: boolean;
   query: string;
 }) => {
-  const visualizes = useExploreVisualizes();
+  const visualizes = useQueryParamsVisualizes();
   const topEvents = useTopEvents();
   const isTopN = topEvents ? topEvents > 0 : false;
 
@@ -67,7 +69,7 @@ function useExploreTimeseriesImpl({
   const dataset = useExploreDataset();
   const groupBys = useQueryParamsGroupBys();
   const sortBys = useExploreAggregateSortBys();
-  const visualizes = useExploreVisualizes({validate: true});
+  const visualizes = useQueryParamsVisualizes({validate: true});
   const [interval] = useChartInterval();
   const topEvents = useTopEvents();
 
@@ -121,7 +123,7 @@ function useExploreTimeseriesImpl({
 
 function shouldTriggerHighAccuracy(
   data: ReturnType<typeof useSortedTimeSeries>['data'],
-  visualizes: Visualize[],
+  visualizes: readonly Visualize[],
   isTopN: boolean
 ) {
   const hasData = computeVisualizeSampleTotals(
@@ -134,7 +136,7 @@ function shouldTriggerHighAccuracy(
 
 function _checkCanQueryForMoreData(
   data: ReturnType<typeof useSortedTimeSeries>['data'],
-  visualizes: Visualize[],
+  visualizes: readonly Visualize[],
   isTopN: boolean
 ) {
   return visualizes.some(visualize => {

--- a/static/app/views/explore/logs/logsToolbar.tsx
+++ b/static/app/views/explore/logs/logsToolbar.tsx
@@ -120,12 +120,7 @@ function ToolbarVisualize({numberTags, stringTags}: LogsToolbarProps) {
 
   const addChart = useCallback(() => {
     const newVisualizes = [...visualizes, new VisualizeFunction('count(message)')].map(
-      visualize => {
-        return {
-          yAxes: [visualize.yAxis],
-          chartType: visualize.selectedChartType,
-        };
-      }
+      visualize => visualize.serialize()
     );
     setVisualizes(newVisualizes);
   }, [setVisualizes, visualizes]);
@@ -134,15 +129,9 @@ function ToolbarVisualize({numberTags, stringTags}: LogsToolbarProps) {
     (group: number, newVisualize: Visualize) => {
       const newVisualizes = visualizes.map((visualize, i) => {
         if (i === group) {
-          return {
-            yAxes: [newVisualize.yAxis],
-            chartType: newVisualize.selectedChartType,
-          };
+          return newVisualize.serialize();
         }
-        return {
-          yAxes: [visualize.yAxis],
-          chartType: visualize.selectedChartType,
-        };
+        return visualize.serialize();
       });
       setVisualizes(newVisualizes);
     },
@@ -152,10 +141,7 @@ function ToolbarVisualize({numberTags, stringTags}: LogsToolbarProps) {
   const onDelete = useCallback(
     (group: number) => {
       const newVisualizes = visualizes.toSpliced(group, 1).map(visualize => {
-        return {
-          yAxes: [visualize.yAxis],
-          chartType: visualize.selectedChartType,
-        };
+        return visualize.serialize();
       });
       setVisualizes(newVisualizes);
     },

--- a/static/app/views/explore/queryParams/context.tsx
+++ b/static/app/views/explore/queryParams/context.tsx
@@ -183,9 +183,26 @@ export function useSetQueryParamsAggregateFields() {
   );
 }
 
-export function useQueryParamsVisualizes(): readonly Visualize[] {
+interface UseQueryParamsVisualizesOptions {
+  validate: boolean;
+}
+
+export function useQueryParamsVisualizes(
+  options?: UseQueryParamsVisualizesOptions
+): readonly Visualize[] {
+  const {validate = false} = options || {};
   const queryParams = useQueryParams();
-  return queryParams.visualizes;
+  return useMemo(() => {
+    if (validate) {
+      return queryParams.visualizes.filter(visualize => {
+        if (isVisualizeEquation(visualize)) {
+          return visualize.expression.isValid;
+        }
+        return true;
+      });
+    }
+    return queryParams.visualizes;
+  }, [queryParams.visualizes, validate]);
 }
 
 export function useSetQueryParamsVisualizes() {
@@ -257,10 +274,7 @@ export function useSetQueryParamsGroupBys() {
               aggregateFields.push({groupBy});
             }
           }
-          aggregateFields.push({
-            yAxes: [aggregateField.yAxis],
-            chartType: aggregateField.selectedChartType,
-          });
+          aggregateFields.push(aggregateField.serialize());
         } else if (isGroupBy(aggregateField)) {
           const {value: groupBy, done} = iter.next();
           if (!done) {

--- a/static/app/views/explore/queryParams/visualize.ts
+++ b/static/app/views/explore/queryParams/visualize.ts
@@ -21,7 +21,7 @@ interface VisualizeOptions {
 export abstract class Visualize {
   readonly yAxis: string;
   readonly chartType: ChartType;
-  readonly selectedChartType?: ChartType;
+  protected readonly selectedChartType?: ChartType;
   abstract readonly kind: 'function' | 'equation';
 
   constructor(yAxis: string, options?: VisualizeOptions) {
@@ -38,6 +38,18 @@ export abstract class Visualize {
     chartType?: ChartType;
     yAxis?: string;
   }): Visualize;
+
+  serialize(): BaseVisualize {
+    const json: BaseVisualize = {
+      yAxes: [this.yAxis],
+    };
+
+    if (defined(this.selectedChartType)) {
+      json.chartType = this.selectedChartType;
+    }
+
+    return json;
+  }
 
   static fromJSON(json: BaseVisualize): Visualize[] {
     return json.yAxes.map(yAxis => {

--- a/static/app/views/explore/spans/charts/index.spec.tsx
+++ b/static/app/views/explore/spans/charts/index.spec.tsx
@@ -3,9 +3,9 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {PageParamsProvider} from 'sentry/views/explore/contexts/pageParamsContext';
-import {defaultVisualizes} from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
 import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {ExploreCharts} from 'sentry/views/explore/spans/charts';
+import {defaultVisualizes} from 'sentry/views/explore/spans/spansQueryParams';
 import {SpansQueryParamsProvider} from 'sentry/views/explore/spans/spansQueryParamsProvider';
 
 describe('ExploreCharts', () => {

--- a/static/app/views/explore/spans/charts/index.tsx
+++ b/static/app/views/explore/spans/charts/index.tsx
@@ -16,15 +16,13 @@ import {ChartVisualization} from 'sentry/views/explore/components/chart/chartVis
 import type {ChartInfo} from 'sentry/views/explore/components/chart/types';
 import ChartContextMenu from 'sentry/views/explore/components/chartContextMenu';
 import {FloatingTrigger} from 'sentry/views/explore/components/suspectTags/floatingTrigger';
-import type {
-  BaseVisualize,
-  Visualize,
-} from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
+import type {BaseVisualize} from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
 import {DEFAULT_VISUALIZATION} from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
 import {useChartBoxSelect} from 'sentry/views/explore/hooks/useChartBoxSelect';
 import {useChartInterval} from 'sentry/views/explore/hooks/useChartInterval';
 import {type SamplingMode} from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {useTopEvents} from 'sentry/views/explore/hooks/useTopEvents';
+import type {Visualize} from 'sentry/views/explore/queryParams/visualize';
 import {CHART_HEIGHT} from 'sentry/views/explore/settings';
 import {ConfidenceFooter} from 'sentry/views/explore/spans/charts/confidenceFooter';
 import {
@@ -42,7 +40,7 @@ interface ExploreChartsProps {
   query: string;
   setVisualizes: (visualizes: BaseVisualize[]) => void;
   timeseriesResult: ReturnType<typeof useSortedTimeSeries>;
-  visualizes: Visualize[];
+  visualizes: readonly Visualize[];
   samplingMode?: SamplingMode;
 }
 
@@ -77,7 +75,7 @@ export function ExploreCharts({
       if (i === index) {
         visualize = visualize.replace({chartType});
       }
-      return visualize.toJSON();
+      return visualize.serialize();
     });
     setVisualizes(newVisualizes);
   }

--- a/static/app/views/explore/spans/spansQueryParams.tsx
+++ b/static/app/views/explore/spans/spansQueryParams.tsx
@@ -144,7 +144,7 @@ function defaultGroupBys(): [GroupBy] {
   return [{groupBy: ''}];
 }
 
-function defaultVisualizes(): [Visualize] {
+export function defaultVisualizes(): [Visualize] {
   return [new VisualizeFunction(DEFAULT_VISUALIZATION)];
 }
 

--- a/static/app/views/explore/spans/spansQueryParams.tsx
+++ b/static/app/views/explore/spans/spansQueryParams.tsx
@@ -84,6 +84,9 @@ export function getTargetWithReadableQueryParams(
   const target: Location = {...location, query: {...location.query}};
 
   updateNullableLocation(target, SPANS_MODE_KEY, writableQueryParams.mode);
+
+  updateNullableLocation(target, SPANS_FIELD_KEY, writableQueryParams.fields);
+
   updateNullableLocation(
     target,
     SPANS_AGGREGATE_FIELD_KEY,

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -51,9 +51,7 @@ import {
   useExploreFields,
   useExploreId,
   useExploreQuery,
-  useExploreVisualizes,
   useSetExplorePageParams,
-  useSetExploreVisualizes,
 } from 'sentry/views/explore/contexts/pageParamsContext';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {useTraceItemTags} from 'sentry/views/explore/contexts/spanTagsContext';
@@ -65,7 +63,11 @@ import {useExploreTimeseries} from 'sentry/views/explore/hooks/useExploreTimeser
 import {useExploreTracesTable} from 'sentry/views/explore/hooks/useExploreTracesTable';
 import {Tab, useTab} from 'sentry/views/explore/hooks/useTab';
 import {useVisitQuery} from 'sentry/views/explore/hooks/useVisitQuery';
-import {useQueryParamsMode} from 'sentry/views/explore/queryParams/context';
+import {
+  useQueryParamsMode,
+  useQueryParamsVisualizes,
+  useSetQueryParamsVisualizes,
+} from 'sentry/views/explore/queryParams/context';
 import {ExploreCharts} from 'sentry/views/explore/spans/charts';
 import {ExploreSpansTour, ExploreSpansTourContext} from 'sentry/views/explore/spans/tour';
 import {ExploreTables} from 'sentry/views/explore/tables';
@@ -399,8 +401,8 @@ function SpanTabContentSection({
   setControlSectionExpanded,
 }: SpanTabContentSectionProps) {
   const {selection} = usePageFilters();
-  const visualizes = useExploreVisualizes();
-  const setVisualizes = useSetExploreVisualizes();
+  const visualizes = useQueryParamsVisualizes();
+  const setVisualizes = useSetQueryParamsVisualizes();
   const [tab, setTab] = useTab();
 
   const query = useExploreQuery();

--- a/static/app/views/explore/tables/aggregateColumnEditorModal.tsx
+++ b/static/app/views/explore/tables/aggregateColumnEditorModal.tsx
@@ -22,7 +22,6 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {TagCollection} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
-import {defined} from 'sentry/utils';
 import {
   EQUATION_PREFIX,
   parseFunction,
@@ -94,11 +93,7 @@ export function AggregateColumnEditorModal({
       if (isGroupBy(col)) {
         newColumns.push(col);
       } else if (isVisualize(col)) {
-        if (defined(col.selectedChartType)) {
-          newColumns.push({yAxes: [col.yAxis], chartType: col.selectedChartType});
-        } else {
-          newColumns.push({yAxes: [col.yAxis]});
-        }
+        newColumns.push(col.serialize());
       }
     }
 

--- a/static/app/views/explore/tables/aggregatesTable.tsx
+++ b/static/app/views/explore/tables/aggregatesTable.tsx
@@ -34,7 +34,6 @@ import {
   useExploreFields,
   useExploreQuery,
   useExploreSortBys,
-  useExploreVisualizes,
   useSetExploreSortBys,
 } from 'sentry/views/explore/contexts/pageParamsContext';
 import {isGroupBy} from 'sentry/views/explore/contexts/pageParamsContext/aggregateFields';
@@ -46,6 +45,7 @@ import {
   useQueryParamsAggregateCursor,
   useQueryParamsAggregateFields,
   useQueryParamsGroupBys,
+  useQueryParamsVisualizes,
 } from 'sentry/views/explore/queryParams/context';
 import {prettifyAggregation, viewSamplesTarget} from 'sentry/views/explore/utils';
 
@@ -66,7 +66,7 @@ export function AggregatesTable({aggregatesTableResult}: AggregatesTableProps) {
   const aggregateFields = useQueryParamsAggregateFields();
   const fields = useExploreFields();
   const groupBys = useQueryParamsGroupBys();
-  const visualizes = useExploreVisualizes();
+  const visualizes = useQueryParamsVisualizes();
   const sorts = useExploreSortBys();
   const setSorts = useSetExploreSortBys();
   const query = useExploreQuery();

--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -18,16 +18,15 @@ import {
   PageParamsProvider,
   useExploreFields,
   useExploreSortBys,
-  useExploreVisualizes,
   useSetExploreMode,
 } from 'sentry/views/explore/contexts/pageParamsContext';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
-import {Visualize} from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
 import {TraceItemAttributeProvider} from 'sentry/views/explore/contexts/traceItemAttributeContext';
 import {
   useQueryParamsAggregateFields,
   useQueryParamsGroupBys,
   useQueryParamsMode,
+  useQueryParamsVisualizes,
 } from 'sentry/views/explore/queryParams/context';
 import {VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
 import {SpansQueryParamsProvider} from 'sentry/views/explore/spans/spansQueryParamsProvider';
@@ -72,7 +71,7 @@ describe('ExploreToolbar', () => {
   it('disables changing visualize fields for count', async () => {
     let visualizes: any;
     function Component() {
-      visualizes = useExploreVisualizes();
+      visualizes = useQueryParamsVisualizes();
       return <ExploreToolbar />;
     }
 
@@ -85,7 +84,7 @@ describe('ExploreToolbar', () => {
     const section = screen.getByTestId('section-visualizes');
 
     // this is the default
-    expect(visualizes).toEqual([new Visualize('count(span.duration)')]);
+    expect(visualizes).toEqual([new VisualizeFunction('count(span.duration)')]);
 
     expect(await within(section).findByRole('button', {name: 'spans'})).toBeDisabled();
   });
@@ -93,7 +92,7 @@ describe('ExploreToolbar', () => {
   it('changes to count(span.duration) when using count', async () => {
     let visualizes: any;
     function Component() {
-      visualizes = useExploreVisualizes();
+      visualizes = useQueryParamsVisualizes();
       return <ExploreToolbar />;
     }
 
@@ -106,7 +105,7 @@ describe('ExploreToolbar', () => {
     const section = screen.getByTestId('section-visualizes');
 
     // this is the default
-    expect(visualizes).toEqual([new Visualize('count(span.duration)')]);
+    expect(visualizes).toEqual([new VisualizeFunction('count(span.duration)')]);
 
     // try changing the aggregate
     await userEvent.click(within(section).getByRole('button', {name: 'count'}));
@@ -116,18 +115,18 @@ describe('ExploreToolbar', () => {
     await userEvent.click(within(section).getByRole('button', {name: 'span.duration'}));
     await userEvent.click(within(section).getByRole('option', {name: 'span.self_time'}));
 
-    expect(visualizes).toEqual([new Visualize('avg(span.self_time)')]);
+    expect(visualizes).toEqual([new VisualizeFunction('avg(span.self_time)')]);
 
     await userEvent.click(within(section).getByRole('button', {name: 'avg'}));
     await userEvent.click(within(section).getByRole('option', {name: 'count'}));
 
-    expect(visualizes).toEqual([new Visualize('count(span.duration)')]);
+    expect(visualizes).toEqual([new VisualizeFunction('count(span.duration)')]);
   });
 
   it('disables changing visualize fields for epm', async () => {
     let visualizes: any;
     function Component() {
-      visualizes = useExploreVisualizes();
+      visualizes = useQueryParamsVisualizes();
       return <ExploreToolbar />;
     }
 
@@ -140,7 +139,7 @@ describe('ExploreToolbar', () => {
     const section = screen.getByTestId('section-visualizes');
 
     // this is the default
-    expect(visualizes).toEqual([new Visualize('count(span.duration)')]);
+    expect(visualizes).toEqual([new VisualizeFunction('count(span.duration)')]);
 
     // change aggregate to epm
     await userEvent.click(within(section).getByRole('button', {name: 'count'}));
@@ -152,7 +151,7 @@ describe('ExploreToolbar', () => {
   it('changes to epm() when using epm', async () => {
     let visualizes: any;
     function Component() {
-      visualizes = useExploreVisualizes();
+      visualizes = useQueryParamsVisualizes();
       return <ExploreToolbar />;
     }
 
@@ -165,7 +164,7 @@ describe('ExploreToolbar', () => {
     const section = screen.getByTestId('section-visualizes');
 
     // this is the default
-    expect(visualizes).toEqual([new Visualize('count(span.duration)')]);
+    expect(visualizes).toEqual([new VisualizeFunction('count(span.duration)')]);
 
     // try changing the aggregate
     await userEvent.click(within(section).getByRole('button', {name: 'count'}));
@@ -175,24 +174,24 @@ describe('ExploreToolbar', () => {
     await userEvent.click(within(section).getByRole('button', {name: 'span.duration'}));
     await userEvent.click(within(section).getByRole('option', {name: 'span.self_time'}));
 
-    expect(visualizes).toEqual([new Visualize('avg(span.self_time)')]);
+    expect(visualizes).toEqual([new VisualizeFunction('avg(span.self_time)')]);
 
     await userEvent.click(within(section).getByRole('button', {name: 'avg'}));
     await userEvent.click(within(section).getByRole('option', {name: 'epm'}));
 
-    expect(visualizes).toEqual([new Visualize('epm()')]);
+    expect(visualizes).toEqual([new VisualizeFunction('epm()')]);
 
     // try changing the aggregate
     await userEvent.click(within(section).getByRole('button', {name: 'epm'}));
     await userEvent.click(within(section).getByRole('option', {name: 'avg'}));
 
-    expect(visualizes).toEqual([new Visualize('avg(span.duration)')]);
+    expect(visualizes).toEqual([new VisualizeFunction('avg(span.duration)')]);
   });
 
   it('defaults count_unique argument to span.op', async () => {
     let visualizes: any;
     function Component() {
-      visualizes = useExploreVisualizes();
+      visualizes = useQueryParamsVisualizes();
       return <ExploreToolbar />;
     }
 
@@ -205,13 +204,13 @@ describe('ExploreToolbar', () => {
     const section = screen.getByTestId('section-visualizes');
 
     // this is the default
-    expect(visualizes).toEqual([new Visualize('count(span.duration)')]);
+    expect(visualizes).toEqual([new VisualizeFunction('count(span.duration)')]);
 
     // try changing the aggregate
     await userEvent.click(within(section).getByRole('button', {name: 'count'}));
     await userEvent.click(within(section).getByRole('option', {name: 'count_unique'}));
 
-    expect(visualizes).toEqual([new Visualize('count_unique(span.op)')]);
+    expect(visualizes).toEqual([new VisualizeFunction('count_unique(span.op)')]);
 
     // try changing the aggregate + field
     await userEvent.click(within(section).getByRole('button', {name: 'count_unique'}));
@@ -221,13 +220,13 @@ describe('ExploreToolbar', () => {
     await userEvent.click(within(section).getByRole('button', {name: 'span.duration'}));
     await userEvent.click(within(section).getByRole('option', {name: 'span.self_time'}));
 
-    expect(visualizes).toEqual([new Visualize('avg(span.self_time)')]);
+    expect(visualizes).toEqual([new VisualizeFunction('avg(span.self_time)')]);
     //
     // try changing the aggregate back to count_unique
     await userEvent.click(within(section).getByRole('button', {name: 'avg'}));
     await userEvent.click(within(section).getByRole('option', {name: 'count_unique'}));
 
-    expect(visualizes).toEqual([new Visualize('count_unique(span.op)')]);
+    expect(visualizes).toEqual([new VisualizeFunction('count_unique(span.op)')]);
   });
 
   it('allows changing visualizes', async () => {
@@ -235,7 +234,7 @@ describe('ExploreToolbar', () => {
     let visualizes: any;
     function Component() {
       fields = useExploreFields();
-      visualizes = useExploreVisualizes();
+      visualizes = useQueryParamsVisualizes();
       return <ExploreToolbar />;
     }
 
@@ -248,7 +247,7 @@ describe('ExploreToolbar', () => {
     const section = screen.getByTestId('section-visualizes');
 
     // this is the default
-    expect(visualizes).toEqual([new Visualize('count(span.duration)')]);
+    expect(visualizes).toEqual([new VisualizeFunction('count(span.duration)')]);
 
     expect(fields).toEqual([
       'id',
@@ -262,12 +261,12 @@ describe('ExploreToolbar', () => {
     // try changing the aggregate
     await userEvent.click(within(section).getByRole('button', {name: 'count'}));
     await userEvent.click(within(section).getByRole('option', {name: 'avg'}));
-    expect(visualizes).toEqual([new Visualize('avg(span.duration)')]);
+    expect(visualizes).toEqual([new VisualizeFunction('avg(span.duration)')]);
 
     // try changing the field
     await userEvent.click(within(section).getByRole('button', {name: 'span.duration'}));
     await userEvent.click(within(section).getByRole('option', {name: 'span.self_time'}));
-    expect(visualizes).toEqual([new Visualize('avg(span.self_time)')]);
+    expect(visualizes).toEqual([new VisualizeFunction('avg(span.self_time)')]);
 
     expect(fields).toEqual([
       'id',
@@ -282,13 +281,13 @@ describe('ExploreToolbar', () => {
     // try adding a new chart
     await userEvent.click(within(section).getByRole('button', {name: 'Add Chart'}));
     expect(visualizes).toEqual([
-      new Visualize('avg(span.self_time)'),
-      new Visualize('count(span.duration)'),
+      new VisualizeFunction('avg(span.self_time)'),
+      new VisualizeFunction('count(span.duration)'),
     ]);
 
     // delete second chart
     await userEvent.click(within(section).getAllByLabelText('Remove Overlay')[1]!);
-    expect(visualizes).toEqual([new Visualize('avg(span.self_time)')]);
+    expect(visualizes).toEqual([new VisualizeFunction('avg(span.self_time)')]);
 
     // only one left so we hide the delete button
     expect(within(section).queryByLabelText('Remove Overlay')).not.toBeInTheDocument();

--- a/static/app/views/explore/toolbar/index.tsx
+++ b/static/app/views/explore/toolbar/index.tsx
@@ -2,12 +2,10 @@ import styled from '@emotion/styled';
 
 import {defined} from 'sentry/utils';
 import {
-  useExploreVisualizes,
-  useSetExploreVisualizes,
-} from 'sentry/views/explore/contexts/pageParamsContext';
-import {
   useQueryParamsGroupBys,
+  useQueryParamsVisualizes,
   useSetQueryParamsGroupBys,
+  useSetQueryParamsVisualizes,
 } from 'sentry/views/explore/queryParams/context';
 import {ToolbarGroupBy} from 'sentry/views/explore/toolbar/toolbarGroupBy';
 import {ToolbarSaveAs} from 'sentry/views/explore/toolbar/toolbarSaveAs';
@@ -22,8 +20,8 @@ interface ExploreToolbarProps {
 }
 
 export function ExploreToolbar({extras, width}: ExploreToolbarProps) {
-  const visualizes = useExploreVisualizes();
-  const setVisualizes = useSetExploreVisualizes();
+  const visualizes = useQueryParamsVisualizes();
+  const setVisualizes = useSetQueryParamsVisualizes();
 
   const groupBys = useQueryParamsGroupBys();
   const setGroupBys = useSetQueryParamsGroupBys();

--- a/static/app/views/explore/toolbar/toolbarSaveAs.tsx
+++ b/static/app/views/explore/toolbar/toolbarSaveAs.tsx
@@ -32,7 +32,6 @@ import {
   useExploreId,
   useExploreQuery,
   useExploreSortBys,
-  useExploreVisualizes,
 } from 'sentry/views/explore/contexts/pageParamsContext';
 import {useAddToDashboard} from 'sentry/views/explore/hooks/useAddToDashboard';
 import {useChartInterval} from 'sentry/views/explore/hooks/useChartInterval';
@@ -42,7 +41,9 @@ import {generateExploreCompareRoute} from 'sentry/views/explore/multiQueryMode/l
 import {
   useQueryParamsGroupBys,
   useQueryParamsMode,
+  useQueryParamsVisualizes,
 } from 'sentry/views/explore/queryParams/context';
+import {isVisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 import {getAlertsUrl} from 'sentry/views/insights/common/utils/getAlertsUrl';
 
@@ -57,16 +58,13 @@ export function ToolbarSaveAs() {
 
   const query = useExploreQuery();
   const groupBys = useQueryParamsGroupBys();
-  const visualizes = useExploreVisualizes();
+  const visualizes = useQueryParamsVisualizes();
   const fields = useExploreFields();
   const sortBys = useExploreSortBys();
   const mode = useQueryParamsMode();
   const id = useExploreId();
   const visualizeYAxes = useMemo(
-    () =>
-      dedupeArray(
-        visualizes.filter(visualize => !visualize.isEquation).map(v => v.yAxis)
-      ),
+    () => dedupeArray(visualizes.filter(isVisualizeFunction).map(v => v.yAxis)),
     [visualizes]
   );
 
@@ -234,7 +232,7 @@ export function ToolbarSaveAs() {
       !valueIsEqual(locationSortByString, singleQuery?.orderby),
       !valueIsEqual(fields, singleQuery?.fields),
       !valueIsEqual(
-        visualizes.map(visualize => visualize.toJSON()),
+        visualizes.map(visualize => visualize.serialize()),
         singleQuery?.visualize,
         true
       ),

--- a/static/app/views/explore/toolbar/toolbarSortBy.tsx
+++ b/static/app/views/explore/toolbar/toolbarSortBy.tsx
@@ -15,7 +15,6 @@ import {
 import {
   useExploreFields,
   useExploreSortBys,
-  useExploreVisualizes,
   useSetExploreSortBys,
 } from 'sentry/views/explore/contexts/pageParamsContext';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
@@ -24,13 +23,14 @@ import {Tab, useTab} from 'sentry/views/explore/hooks/useTab';
 import {
   useQueryParamsGroupBys,
   useQueryParamsMode,
+  useQueryParamsVisualizes,
 } from 'sentry/views/explore/queryParams/context';
 
 export function ToolbarSortBy() {
   const mode = useQueryParamsMode();
   const fields = useExploreFields();
   const groupBys = useQueryParamsGroupBys();
-  const visualizes = useExploreVisualizes();
+  const visualizes = useQueryParamsVisualizes();
 
   const sorts = useExploreSortBys();
   const setSorts = useSetExploreSortBys();

--- a/static/app/views/explore/utils.spec.tsx
+++ b/static/app/views/explore/utils.spec.tsx
@@ -2,13 +2,13 @@ import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
-import {Visualize} from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
+import {VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
 import {findSuggestedColumns, viewSamplesTarget} from 'sentry/views/explore/utils';
 
 describe('viewSamplesTarget', () => {
   const project = ProjectFixture();
   const projects = [project];
-  const visualize = new Visualize('count(span.duration)');
+  const visualize = new VisualizeFunction('count(span.duration)');
   const sort = {
     field: 'count(span.duration)',
     kind: 'desc' as const,

--- a/static/app/views/explore/utils.tsx
+++ b/static/app/views/explore/utils.tsx
@@ -34,10 +34,7 @@ import {newExploreTarget} from 'sentry/views/explore/contexts/pageParamsContext'
 import type {GroupBy} from 'sentry/views/explore/contexts/pageParamsContext/aggregateFields';
 import {isGroupBy} from 'sentry/views/explore/contexts/pageParamsContext/aggregateFields';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
-import type {
-  BaseVisualize,
-  Visualize,
-} from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
+import type {BaseVisualize} from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
 import type {
   RawGroupBy,
   RawVisualize,
@@ -53,6 +50,7 @@ import type {
 } from 'sentry/views/explore/hooks/useTraceItemDetails';
 import {getLogsUrlFromSavedQueryUrl} from 'sentry/views/explore/logs/utils';
 import type {ReadableExploreQueryParts} from 'sentry/views/explore/multiQueryMode/locationUtils';
+import type {Visualize} from 'sentry/views/explore/queryParams/visualize';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 import type {ChartType} from 'sentry/views/insights/common/components/chart';
 import {isChartType} from 'sentry/views/insights/common/components/chart';
@@ -375,7 +373,7 @@ export function viewSamplesTarget({
   query: string;
   row: Record<string, any>;
   sorts: Sort[];
-  visualizes: Visualize[];
+  visualizes: readonly Visualize[];
 }) {
   const search = new MutableSearch(query);
 


### PR DESCRIPTION
This migrates spans to use query params to read/write visualizes.