### PR TITLE
Fix seer api auth header for delete by hash

### DIFF
--- a/src/sentry/seer/similarity/grouping_records.py
+++ b/src/sentry/seer/similarity/grouping_records.py
@@ -14,7 +14,7 @@ from sentry.conf.server import (
     SEER_PROJECT_GROUPING_RECORDS_DELETE_URL,
 )
 from sentry.net.http import connection_from_url
-from sentry.seer.signed_seer_api import make_signed_seer_api_request
+from sentry.seer.signed_seer_api import make_signed_seer_api_request, sign_with_seer_secret
 from sentry.seer.similarity.types import RawSeerSimilarIssueData
 from sentry.utils import json, metrics
 
@@ -90,10 +90,13 @@ def call_seer_to_delete_project_grouping_records(
 ) -> bool:
     try:
         # TODO: Move this over to POST json_api implementation
+        # For GET requests, we need to sign an empty body for authentication
+        body = b""
+        auth_headers = sign_with_seer_secret(body)
         response = seer_grouping_connection_pool.urlopen(
             "GET",
             f"{SEER_PROJECT_GROUPING_RECORDS_DELETE_URL}/{project_id}",
-            headers={"Content-Type": "application/json;charset=utf-8"},
+            headers={"Content-Type": "application/json;charset=utf-8", **auth_headers},
             timeout=POST_BULK_GROUPING_RECORDS_TIMEOUT,
         )
     except ReadTimeoutError:
@@ -130,11 +133,10 @@ def call_seer_to_delete_these_hashes(project_id: int, hashes: Sequence[str]) -> 
     extra = {"project_id": project_id, "hashes": hashes}
     try:
         body = {"project_id": project_id, "hash_list": hashes}
-        response = seer_grouping_connection_pool.urlopen(
-            "POST",
+        response = make_signed_seer_api_request(
+            seer_grouping_connection_pool,
             SEER_HASH_GROUPING_RECORDS_DELETE_URL,
-            body=json.dumps(body),
-            headers={"Content-Type": "application/json;charset=utf-8"},
+            body=json.dumps(body).encode("utf-8"),
             timeout=POST_BULK_GROUPING_RECORDS_TIMEOUT,
         )
     except ReadTimeoutError:


### PR DESCRIPTION
<!-- Fixes Seer API calls for deleting grouping records that were failing due to missing authentication headers. -->

This PR addresses the "No auth header found" error for Seer API calls related to deleting grouping records.

The `call_seer_to_delete_these_hashes` function (POST request) now correctly utilizes `make_signed_seer_api_request` for authentication. Additionally, the `call_seer_to_delete_project_grouping_records` function (GET request) now manually signs its requests using `sign_with_seer_secret`.

This ensures all deletion requests to Seer are properly authenticated.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
<a href="https://cursor.com/background-agent?bcId=bc-fc6b34ff-6eed-4c63-9589-e513b54d81db">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fc6b34ff-6eed-4c63-9589-e513b54d81db">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

