### PR TITLE
ref(ui): Remove iconSize from CopyToClipboardButton

### DIFF
--- a/static/app/components/copyToClipboardButton.stories.tsx
+++ b/static/app/components/copyToClipboardButton.stories.tsx
@@ -1,4 +1,3 @@
-import type {ComponentProps} from 'react';
 import {Fragment} from 'react';
 
 import {CopyToClipboardButton} from 'sentry/components/copyToClipboardButton';
@@ -42,23 +41,4 @@ export default Storybook.story('CopyToClipboardButton', story => {
       </Fragment>
     );
   });
-
-  const propMatrix: Storybook.PropMatrix<ComponentProps<typeof CopyToClipboardButton>> = {
-    size: [undefined, 'md', 'sm', 'xs', 'zero'],
-    iconSize: [undefined, 'xs', 'sm', 'md', 'lg', 'xl', '2xl'],
-  };
-  story('Size Props', () => (
-    <Fragment>
-      <p>
-        Try to keep the <Storybook.JSXProperty name="size" value="" /> and{' '}
-        <Storybook.JSXProperty name="iconSize" value="" /> props set to the same value.
-        Here's a grid of all the possible combinations.
-      </p>
-      <Storybook.PropMatrix
-        render={CopyToClipboardButton}
-        propMatrix={propMatrix}
-        selectedProps={['size', 'iconSize']}
-      />
-    </Fragment>
-  ));
 });

--- a/static/app/components/copyToClipboardButton.tsx
+++ b/static/app/components/copyToClipboardButton.tsx
@@ -1,5 +1,3 @@
-import styled from '@emotion/styled';
-
 import {Button, type ButtonProps} from 'sentry/components/core/button';
 import {IconCopy} from 'sentry/icons';
 import useCopyToClipboard from 'sentry/utils/useCopyToClipboard';
@@ -8,7 +6,6 @@ type Overwrite<T, U> = Pick<T, Exclude<keyof T, keyof U>> & U;
 
 type Props = {
   text: string;
-  iconSize?: React.ComponentProps<typeof IconCopy>['size'];
   onError?: undefined | ((error: Error) => void);
 } & Overwrite<
   Omit<ButtonProps, 'children'>,
@@ -18,7 +15,6 @@ type Props = {
 >;
 
 export function CopyToClipboardButton({
-  iconSize,
   onCopy,
   onError,
   text,
@@ -32,7 +28,7 @@ export function CopyToClipboardButton({
   });
 
   return (
-    <CopyButton
+    <Button
       aria-label={label}
       title={label}
       tooltipProps={{delay: 0}}
@@ -41,13 +37,8 @@ export function CopyToClipboardButton({
         onClick();
         passedOnClick?.(e);
       }}
+      icon={<IconCopy color="subText" />}
       {...props}
-    >
-      <IconCopy size={iconSize} />
-    </CopyButton>
+    />
   );
 }
-
-const CopyButton = styled(Button)`
-  color: ${p => p.theme.subText};
-`;

--- a/static/app/components/events/interfaces/frame/stacktraceLinkModal.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLinkModal.tsx
@@ -240,12 +240,7 @@ function StacktraceLinkModal({
                       return (
                         <div key={i} style={{display: 'flex', alignItems: 'center'}}>
                           <SuggestionOverflow>{suggestion}</SuggestionOverflow>
-                          <CopyToClipboardButton
-                            borderless
-                            text={suggestion}
-                            size="xs"
-                            iconSize="xs"
-                          />
+                          <CopyToClipboardButton borderless text={suggestion} size="xs" />
                         </div>
                       );
                     })}

--- a/static/app/components/replays/diff/replayTextDiff.tsx
+++ b/static/app/components/replays/diff/replayTextDiff.tsx
@@ -36,7 +36,6 @@ export function ReplayTextDiff() {
           <CopyToClipboardButton
             text={leftBody ?? ''}
             size="xs"
-            iconSize="xs"
             borderless
             aria-label={t('Copy Before')}
           />
@@ -45,7 +44,6 @@ export function ReplayTextDiff() {
           <CopyToClipboardButton
             text={rightBody ?? ''}
             size="xs"
-            iconSize="xs"
             borderless
             aria-label={t('Copy After')}
           />

--- a/static/app/components/structuredEventData/index.tsx
+++ b/static/app/components/structuredEventData/index.tsx
@@ -169,7 +169,6 @@ export default function StructuredEventData({
       {showCopyButton && (
         <StyledCopyButton
           borderless
-          iconSize="xs"
           onCopy={onCopy}
           size="xs"
           text={JSON.stringify(data, null, '\t')}

--- a/static/app/components/textCopyInput.tsx
+++ b/static/app/components/textCopyInput.tsx
@@ -74,7 +74,7 @@ function TextCopyInput({
       <InputGroup.TrailingItems>
         <StyledCopyButton
           borderless
-          iconSize={size === 'xs' ? 'xs' : 'sm'}
+          size={size === 'xs' ? 'xs' : 'sm'}
           onCopy={onCopy}
           text={children}
         />

--- a/static/app/components/version.tsx
+++ b/static/app/components/version.tsx
@@ -126,7 +126,7 @@ function Version({
       }}
     >
       <TooltipVersionWrapper>{version}</TooltipVersionWrapper>
-      <CopyToClipboardButton borderless text={version} size="zero" iconSize="xs" />
+      <CopyToClipboardButton borderless text={version} size="zero" />
     </TooltipContent>
   );
 

--- a/static/app/components/versionHoverCard.tsx
+++ b/static/app/components/versionHoverCard.tsx
@@ -207,12 +207,7 @@ function VersionHoverHeader({releaseVersion}: VersionHoverHeaderProps) {
       {t('Release:')}
       <VersionWrapper>
         <StyledVersion version={releaseVersion} truncate anchor={false} />
-        <CopyToClipboardButton
-          borderless
-          iconSize="xs"
-          size="zero"
-          text={releaseVersion}
-        />
+        <CopyToClipboardButton borderless size="zero" text={releaseVersion} />
       </VersionWrapper>
     </Flex>
   );

--- a/static/app/views/discover/table/quickContext/quickContextHovercard.tsx
+++ b/static/app/views/discover/table/quickContext/quickContextHovercard.tsx
@@ -117,7 +117,6 @@ function HoverHeader({
           <CopyToClipboardButton
             borderless
             data-test-id="quick-context-hover-header-copy-button"
-            iconSize="xs"
             onCopy={() => {
               trackAnalytics('discover_v2.quick_context_header_copy', {
                 organization,

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/description.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/description.tsx
@@ -198,7 +198,6 @@ export function SpanDescription({
         <CopyToClipboardButton
           borderless
           size="zero"
-          iconSize="xs"
           text={span.name}
           tooltipProps={{disabled: true}}
         />
@@ -214,7 +213,6 @@ export function SpanDescription({
             <CopyToClipboardButton
               borderless
               size="zero"
-              iconSize="xs"
               text={formattedDescription}
               tooltipProps={{disabled: true}}
             />
@@ -318,7 +316,6 @@ function ResourceImage(props: {
         <CopyToClipboardButton
           borderless
           size="zero"
-          iconSize="xs"
           text={fileName}
           title={t('Copy file name')}
         />

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/description.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/description.tsx
@@ -202,7 +202,6 @@ export function SpanDescription({
             <CopyToClipboardButton
               borderless
               size="zero"
-              iconSize="xs"
               text={formattedDescription}
               tooltipProps={{disabled: true}}
             />
@@ -304,7 +303,6 @@ function ResourceImage(props: {
         <CopyToClipboardButton
           borderless
           size="zero"
-          iconSize="xs"
           text={fileName}
           title={t('Copy file name')}
         />

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -149,7 +149,6 @@ function SubtitleWithCopyButton({
         <CopyToClipboardButton
           borderless
           size="zero"
-          iconSize="xs"
           text={clipboardText}
           tooltipProps={{disabled: true}}
         />
@@ -176,7 +175,6 @@ function TitleOp({text}: {text: string}) {
           <CopyToClipboardButton
             borderless
             size="zero"
-            iconSize="xs"
             text={text}
             tooltipProps={{disabled: true}}
           />
@@ -1219,12 +1217,7 @@ function CopyableCardValueWithLink({
       <CardValueText>
         {value}
         {typeof value === 'string' ? (
-          <StyledCopyToClipboardButton
-            borderless
-            size="zero"
-            iconSize="xs"
-            text={value}
-          />
+          <StyledCopyToClipboardButton borderless size="zero" text={value} />
         ) : null}
       </CardValueText>
       {linkTarget && linkTarget ? (

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/highlights.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/highlights.tsx
@@ -53,7 +53,6 @@ export function TransactionHighlights(props: HighlightProps) {
       <CopyToClipboardButton
         borderless
         size="zero"
-        iconSize="xs"
         text={props.node.value.transaction}
         tooltipProps={{disabled: true}}
       />

--- a/static/app/views/performance/newTraceDetails/traceHeader/breadcrumbs.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/breadcrumbs.tsx
@@ -435,7 +435,6 @@ function LeafBreadCrumbLabel({
         text={traceSlug}
         size="zero"
         borderless
-        iconSize="xs"
         style={{
           transform: 'translateY(-1px) translateX(-3px)',
         }}

--- a/static/app/views/settings/project/projectToolbar.tsx
+++ b/static/app/views/settings/project/projectToolbar.tsx
@@ -95,7 +95,7 @@ export default function ProjectToolbarSettings({project}: Props) {
                 'To enable the Dev Toolbar, copy and paste your domain into the Allowed Origins text box below: [domain] ',
                 {domain: <strong>{domain}</strong>}
               )}
-              <CopyToClipboardButton borderless iconSize="xs" size="zero" text={domain} />
+              <CopyToClipboardButton borderless size="zero" text={domain} />
             </Alert>
           </Alert.Container>
         )}

--- a/static/app/views/settings/projectProguard/associations.tsx
+++ b/static/app/views/settings/projectProguard/associations.tsx
@@ -45,12 +45,7 @@ function ProguardAssociationsBody({
               >
                 <TextOverflow>{release}</TextOverflow>
               </ReleaseLink>
-              <CopyToClipboardButton
-                text={release}
-                borderless
-                size="zero"
-                iconSize="sm"
-              />
+              <CopyToClipboardButton text={release} borderless size="zero" />
             </ReleaseContent>
           </ListItem>
         ))}


### PR DESCRIPTION
We already have logic built into the button to size icons according to
the size of the button.