### PR TITLE
chore: Hide Prevent coverage feature from TA release

### DIFF
--- a/static/app/views/nav/secondary/sections/prevent/preventSecondaryNav.spec.tsx
+++ b/static/app/views/nav/secondary/sections/prevent/preventSecondaryNav.spec.tsx
@@ -9,7 +9,7 @@ jest.mock('sentry/utils/analytics', () => ({
   trackAnalytics: jest.fn(),
 }));
 
-const ALL_AVAILABLE_FEATURES = ['codecov-ui'];
+const ALL_AVAILABLE_FEATURES = ['codecov-ui', 'prevent-test-analytics'];
 
 describe('PreventSecondaryNav', () => {
   beforeEach(() => {

--- a/static/app/views/nav/secondary/sections/prevent/preventSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/prevent/preventSecondaryNav.tsx
@@ -48,7 +48,7 @@ function PreventSecondaryNav() {
               {t('Coverage')}
             </SecondaryNav.Item>
           </Feature>
-          <Feature features={['codecov-ui']}>
+          <Feature features={['prevent-test-analytics']}>
             <SecondaryNav.Item to={testsPathname} activeTo={testsPathname}>
               {t('Tests')}
             </SecondaryNav.Item>
@@ -60,7 +60,7 @@ function PreventSecondaryNav() {
             {t('Prevent AI')}
           </SecondaryNav.Item>
         </SecondaryNav.Section>
-        <Feature features={['codecov-ui']}>
+        <Feature features={['prevent-test-analytics']}>
           <SecondaryNav.Section id="prevent-configure" title={t('Configure')}>
             <SecondaryNav.Item to={`${tokensPathName}`} activeTo={tokensPathName}>
               {t('Tokens')}

--- a/static/app/views/prevent/preventAI/wrapper.spec.tsx
+++ b/static/app/views/prevent/preventAI/wrapper.spec.tsx
@@ -5,7 +5,7 @@ import {render, screen} from 'sentry-test/reactTestingLibrary';
 import PreventAIPageWrapper from 'sentry/views/prevent/preventAI/wrapper';
 import {PREVENT_AI_PAGE_TITLE} from 'sentry/views/prevent/settings';
 
-const COVERAGE_FEATURE = 'codecov-ui';
+const COVERAGE_FEATURE = 'prevent-test-analytics';
 
 describe('PreventAIPageWrapper', () => {
   describe('when the wrapper is used', () => {

--- a/static/app/views/prevent/tests/testsWrapper.spec.tsx
+++ b/static/app/views/prevent/tests/testsWrapper.spec.tsx
@@ -5,7 +5,7 @@ import {render, screen} from 'sentry-test/reactTestingLibrary';
 import {TESTS_PAGE_TITLE} from 'sentry/views/prevent/settings';
 import TestAnalyticsPageWrapper from 'sentry/views/prevent/tests/testsWrapper';
 
-const COVERAGE_FEATURE = 'codecov-ui';
+const COVERAGE_FEATURE = 'prevent-test-analytics';
 
 describe('TestAnalyticsPageWrapper', () => {
   describe('when the wrapper is used', () => {

--- a/static/app/views/prevent/tokens/tokensWrapper.spec.tsx
+++ b/static/app/views/prevent/tokens/tokensWrapper.spec.tsx
@@ -5,7 +5,7 @@ import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {TOKENS_PAGE_TITLE} from 'sentry/views/prevent/settings';
 import TokensPageWrapper from 'sentry/views/prevent/tokens/tokensWrapper';
 
-const COVERAGE_FEATURE = 'codecov-ui';
+const COVERAGE_FEATURE = 'prevent-test-analytics';
 
 describe('TokensPageWrapper', () => {
   describe('when the wrapper is used', () => {


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/CCMRG-1489/hide-coverage-for-ta-rollout

Note for consideration: Currently /Users/calvinyau/sentry/static/app/views/prevent/index.tsx is wrapped in a `<Feature />` component that is gated on `['prevent-ai']` which means all of Prevent will not show if the prevent-ai flag isn't turned on. We should consider changing this if we want prevent-ai and TA to be decoupled where either being turned on will show Prevent in the sidebar