### PR TITLE
fix(insights): double slahes when navigating from insights overview to transaction summary

### DIFF
--- a/static/app/views/insights/pages/transactionCell.tsx
+++ b/static/app/views/insights/pages/transactionCell.tsx
@@ -47,7 +47,7 @@ export function TransactionCell({project, transaction, transactionMethod}: Props
 
   return (
     <OverflowEllipsisTextContainer>
-      <Link to={`${pathname}/?${qs.stringify(query)}`}>{transaction}</Link>
+      <Link to={`${pathname}?${qs.stringify(query)}`}>{transaction}</Link>
     </OverflowEllipsisTextContainer>
   );
 }


### PR DESCRIPTION
`pathname` (which is generated via the `generateTransactionSummaryRoute` function) already includes a trailing slash