### PR TITLE
fix(releases): Optimize release project lookup

### DIFF
--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -189,13 +189,31 @@ def debounce_update_release_health_data(organization, project_ids: list[int]):
         should_update.keys()
     )
 
-    # Check which we already have rows for.
-    existing = set(
+    # Pre-flight query which was broken out of the release-project query below. By running this
+    # in a separate query we can utilize the index on (organization, version) and remove a join.
+    # The total cost of the two queries is significantly less than a single query.
+    release_ids_and_versions = dict(
+        Release.objects.filter(
+            organization_id=organization.id,
+            version__in=[x[1] for x in project_releases],
+        ).values_list("id", "version")
+    )
+
+    release_ids_and_project_ids = dict(
         ReleaseProject.objects.filter(
             project_id__in=[x[0] for x in project_releases],
-            release__version__in=[x[1] for x in project_releases],
-        ).values_list("project_id", "release__version")
+            release_id__in=release_ids_and_versions.values(),
+        ).values_list("release_id", "project_id")
     )
+
+    # I'm zipping the results of the two queries above to emulate the results of the old query
+    # which was removed. I'm not changing the existing semantics of the code. I'm only performance
+    # optimizing database access. Feel free to change.
+    existing = {
+        (project_id, release_ids_and_versions[release_id])
+        for release_id, project_id in release_ids_and_project_ids.items()
+    }
+
     to_upsert = []
     for key in project_releases:
         if key not in existing:

--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -199,10 +199,10 @@ def debounce_update_release_health_data(organization, project_ids: list[int]):
         ).values_list("id", "version")
     )
 
-    release_ids_and_project_ids = dict(
+    release_ids_and_project_ids = list(
         ReleaseProject.objects.filter(
             project_id__in=[x[0] for x in project_releases],
-            release_id__in=release_ids_and_versions.values(),
+            release_id__in=release_ids_and_versions.keys(),
         ).values_list("release_id", "project_id")
     )
 
@@ -211,7 +211,7 @@ def debounce_update_release_health_data(organization, project_ids: list[int]):
     # optimizing database access. Feel free to change.
     existing = {
         (project_id, release_ids_and_versions[release_id])
-        for release_id, project_id in release_ids_and_project_ids.items()
+        for release_id, project_id in release_ids_and_project_ids
     }
 
     to_upsert = []


### PR DESCRIPTION
Takes this query plan (which in reality executed as a nested loop):

```
Hash Join  (cost=15.66..26.15 rows=3 width=524)
  Hash Cond: (sentry_release_project.release_id = sentry_release.id)
  ->  Bitmap Heap Scan on sentry_release_project  (cost=4.94..15.37 rows=26 width=16)
        Recheck Cond: (project_id = ANY ('{1,2,3,4,5}'::bigint[]))
        ->  Bitmap Index Scan on sentry_rele_project_3143eb_idx  (cost=0.00..4.94 rows=26 width=0)
              Index Cond: (project_id = ANY ('{1,2,3,4,5}'::bigint[]))
  ->  Hash  (cost=10.65..10.65 rows=5 width=524)
        ->  Seq Scan on sentry_release  (cost=0.00..10.65 rows=5 width=524)
              Filter: ((version)::text = ANY ('{version,hello,world,and,all}'::text[]))
```

And turns it into two queries:

```
-- First
Index Scan using sentry_rele_organiz_6975e7_idx on sentry_release  (cost=0.14..8.16 rows=1 width=524)
  Index Cond: (organization_id = 1)
  Filter: ((version)::text = ANY ('{a,b,c}'::text[]))

-- Second
Index Only Scan using sentry_release_project_project_id_release_id_44ff55de_uniq on sentry_release_project  (cost=0.15..12.01 rows=1 width=8)
  Index Cond: ((project_id = ANY ('{1,2,3,4,5}'::bigint[])) AND (release_id = ANY ('{1,2,3,4,5}'::bigint[])))
```

Worst case cost is estimated to be ~20% better than present but best case cost is 15x better. IMO we won't see worst case performance for the two new queries here but we definitely saw it for the previous query.

Fixes: https://sentry.sentry.io/issues/6605286276/?project=1&query=is%3Aunresolved%20issue.category%3Adb_query&referrer=issue-stream
Closes: https://linear.app/getsentry/issue/REPLAY-675/fix-slow-db-query-release-project-debounce-lookup
DataDog: https://app.datadoghq.com/databases/queries?query=SELECT%20sentry_release_project.project_id&dbPanels=%5B%7B%22t%22%3A%22dbQueryPanel%22%2C%22qs%22%3A%22372d8c8d6eaf6e1e%22%2C%22dbType%22%3A%22PostgreSQL%22%7D%5D&dbPlanSignature=a6502149d94f0522&dbType=PostgreSQL&fromUser=false&qListSort=avgDuration%3Adesc&start=1757066166914&end=1757100635000&paused=true