### PR TITLE
fix(profiling): Flamegraph search index

### DIFF
--- a/static/app/components/profiling/flamegraph/flamegraphToolbar/flamegraphSearch.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphToolbar/flamegraphSearch.tsx
@@ -225,7 +225,7 @@ function sortFrameResults(
   // If frames have the same start times, move frames with lower stack depth first.
   // This results in top down and left to right iteration
   let sid = -1;
-  const spans: Array<SpanChartNode | FlamegraphFrame> = new Array(results.frames.size);
+  const spans: Array<SpanChartNode | FlamegraphFrame> = new Array(results.spans.size);
   for (const n of results.spans.values()) {
     spans[++sid] = n.span;
   }

--- a/static/app/utils/profiling/flamegraph/flamegraphStateProvider/reducers/flamegraphSearch.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphStateProvider/reducers/flamegraphSearch.tsx
@@ -76,7 +76,7 @@ export function flamegraphSearchReducer(
       };
     }
     case 'set search results': {
-      return {...state, highlightFrames: null, ...action.payload};
+      return {...state, index: null, highlightFrames: null, ...action.payload};
     }
     case 'set search index position': {
       return {...state, index: action.payload};


### PR DESCRIPTION
This fixes 2 things like the flamegraph search index:
1. when updating the search results, we reset the search index
2. when sorting the flame results, make sure the arrays are the right size