### PR TITLE
Fix seer api auth header for delete by hash

### DIFF
--- a/src/sentry/seer/similarity/grouping_records.py
+++ b/src/sentry/seer/similarity/grouping_records.py
@@ -130,11 +130,10 @@ def call_seer_to_delete_these_hashes(project_id: int, hashes: Sequence[str]) -> 
     extra = {"project_id": project_id, "hashes": hashes}
     try:
         body = {"project_id": project_id, "hash_list": hashes}
-        response = seer_grouping_connection_pool.urlopen(
-            "POST",
+        response = make_signed_seer_api_request(
+            seer_grouping_connection_pool,
             SEER_HASH_GROUPING_RECORDS_DELETE_URL,
-            body=json.dumps(body),
-            headers={"Content-Type": "application/json;charset=utf-8"},
+            body=json.dumps(body).encode("utf-8"),
             timeout=POST_BULK_GROUPING_RECORDS_TIMEOUT,
         )
     except ReadTimeoutError:

--- a/tests/sentry/seer/similarity/test_grouping_records.py
+++ b/tests/sentry/seer/similarity/test_grouping_records.py
@@ -175,7 +175,7 @@ def test_post_bulk_grouping_records_use_reranking(
 
 @django_db_all
 @mock.patch("sentry.seer.similarity.grouping_records.logger")
-@mock.patch("sentry.seer.similarity.grouping_records.seer_grouping_connection_pool.urlopen")
+@mock.patch("sentry.seer.similarity.grouping_records.make_signed_seer_api_request")
 def test_delete_grouping_records_by_hash_success(
     mock_seer_request: MagicMock, mock_logger: MagicMock
 ):
@@ -197,7 +197,7 @@ def test_delete_grouping_records_by_hash_success(
 
 @django_db_all
 @mock.patch("sentry.seer.similarity.grouping_records.logger")
-@mock.patch("sentry.seer.similarity.grouping_records.seer_grouping_connection_pool.urlopen")
+@mock.patch("sentry.seer.similarity.grouping_records.make_signed_seer_api_request")
 def test_delete_grouping_records_by_hash_timeout(
     mock_seer_request: MagicMock, mock_logger: MagicMock
 ):
@@ -220,7 +220,7 @@ def test_delete_grouping_records_by_hash_timeout(
 
 @django_db_all
 @mock.patch("sentry.seer.similarity.grouping_records.logger")
-@mock.patch("sentry.seer.similarity.grouping_records.seer_grouping_connection_pool.urlopen")
+@mock.patch("sentry.seer.similarity.grouping_records.make_signed_seer_api_request")
 def test_delete_grouping_records_by_hash_failure(
     mock_seer_request: MagicMock, mock_logger: MagicMock
 ):


### PR DESCRIPTION
<!-- Describe your PR here. -->
Fixes "No auth header found" error for Seer grouping record deletion.

Previously, the `call_seer_to_delete_these_hashes` function used a direct `urlopen` call, omitting necessary authentication headers for the Seer API. This PR updates the function to use `make_signed_seer_api_request`, ensuring all requests to Seer for deleting grouping records are properly authenticated with an HMAC signature. Corresponding tests have been updated to mock the authenticated request.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
<a href="https://cursor.com/background-agent?bcId=bc-446c25ff-aa55-4f58-92b4-72c93abb993f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-446c25ff-aa55-4f58-92b4-72c93abb993f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

