### PR TITLE
ref(autofix): Make autofix request a pydantic model

### DIFF
--- a/src/sentry/integrations/api/endpoints/organization_coding_agents.py
+++ b/src/sentry/integrations/api/endpoints/organization_coding_agents.py
@@ -288,9 +288,7 @@ class OrganizationCodingAgentsEndpoint(OrganizationEndpoint):
     ) -> list[dict]:
         """Launch coding agents for all repositories in the solution."""
         solution_repos = set(self._extract_repos_from_solution(autofix_state))
-        autofix_state_repos = {
-            f"{repo.owner}/{repo.name}" for repo in autofix_state.request["repos"]
-        }
+        autofix_state_repos = {f"{repo.owner}/{repo.name}" for repo in autofix_state.request.repos}
 
         # Repos that were in the solution but not in the autofix state
         solution_repos_not_found = solution_repos - autofix_state_repos
@@ -321,7 +319,7 @@ class OrganizationCodingAgentsEndpoint(OrganizationEndpoint):
             repo = next(
                 (
                     repo
-                    for repo in autofix_state.request["repos"]
+                    for repo in autofix_state.request.repos
                     if f"{repo.owner}/{repo.name}" == repo_name
                 ),
                 None,
@@ -341,7 +339,7 @@ class OrganizationCodingAgentsEndpoint(OrganizationEndpoint):
             launch_request = CodingAgentLaunchRequest(
                 prompt=prompt,
                 repository=repo,
-                branch_name=sanitize_branch_name(autofix_state.request["issue"]["title"]),
+                branch_name=sanitize_branch_name(autofix_state.request.issue["title"]),
             )
 
             try:

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -35,6 +35,9 @@ class AutofixRequest(BaseModel):
     issue: AutofixIssue
     repos: list[SeerRepoDefinition]
 
+    class Config:
+        extra = "allow"
+
 
 class FileChange(BaseModel):
     path: str

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -29,7 +29,7 @@ class AutofixIssue(TypedDict):
     title: str
 
 
-class AutofixRequest(TypedDict):
+class AutofixRequest(BaseModel):
     organization_id: int
     project_id: int
     issue: AutofixIssue
@@ -163,7 +163,7 @@ def get_autofix_state(
         ):
             state = AutofixState.validate(result["state"])
 
-            if state.request["organization_id"] != organization_id:
+            if state.request.organization_id != organization_id:
                 raise SeerPermissionError("Different organization ID found in autofix state")
 
             return state

--- a/src/sentry/seer/autofix/webhooks.py
+++ b/src/sentry/seer/autofix/webhooks.py
@@ -10,18 +10,11 @@ from sentry.utils import metrics
 
 
 def get_webhook_analytics_fields(autofix_state: AutofixState) -> dict[str, Any]:
-    webhook_analytics_fields = {}
-
-    autofix_request = autofix_state.request
-
-    webhook_analytics_fields["project_id"] = autofix_request.project_id
-
-    issue = autofix_request.issue
-    webhook_analytics_fields["group_id"] = issue.get("id", None) if issue else None
-
-    webhook_analytics_fields["run_id"] = autofix_state.run_id
-
-    return webhook_analytics_fields
+    return {
+        "project_id": autofix_state.request.project_id,
+        "group_id": autofix_state.request.issue["id"],
+        "run_id": autofix_state.run_id,
+    }
 
 
 def handle_github_pr_webhook_for_autofix(

--- a/src/sentry/seer/autofix/webhooks.py
+++ b/src/sentry/seer/autofix/webhooks.py
@@ -14,9 +14,9 @@ def get_webhook_analytics_fields(autofix_state: AutofixState) -> dict[str, Any]:
 
     autofix_request = autofix_state.request
 
-    webhook_analytics_fields["project_id"] = autofix_request.get("project_id", None)
+    webhook_analytics_fields["project_id"] = autofix_request.project_id
 
-    issue = autofix_request.get("issue", None)
+    issue = autofix_request.issue
     webhook_analytics_fields["group_id"] = issue.get("id", None) if issue else None
 
     webhook_analytics_fields["run_id"] = autofix_state.run_id

--- a/tests/sentry/integrations/api/endpoints/test_organization_coding_agents.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_coding_agents.py
@@ -12,7 +12,8 @@ from sentry.integrations.coding_agent.integration import (
 )
 from sentry.integrations.coding_agent.models import CodingAgentLaunchRequest
 from sentry.integrations.services.integration.serial import serialize_integration
-from sentry.seer.autofix.utils import CodingAgentState, CodingAgentStatus
+from sentry.seer.autofix.constants import AutofixStatus
+from sentry.seer.autofix.utils import AutofixState, CodingAgentState, CodingAgentStatus
 from sentry.seer.models import SeerRepoDefinition
 from sentry.testutils.cases import APITestCase
 
@@ -134,15 +135,28 @@ class BaseOrganizationCodingAgentsTest(APITestCase):
                 )
             ]
 
-        mock_autofix_state = MagicMock()
-        mock_autofix_state.steps = [
-            {"key": "solution", "solution": [{"relevant_code_file": {"repo_name": "test/repo"}}]}
-        ]
-        mock_autofix_state.request = {
-            "repos": repos,
-            "issue": {"title": "Test Issue"},
-        }
-        return mock_autofix_state
+        return AutofixState.validate(
+            {
+                "run_id": 123,
+                "updated_at": datetime.now(UTC),
+                "status": AutofixStatus.PROCESSING,
+                "request": {
+                    "organization_id": self.organization.id,
+                    "project_id": self.project.id,
+                    "repos": repos,
+                    "issue": {"id": 123, "title": "Test Issue"},
+                },
+                "steps": [
+                    {
+                        "key": "solution",
+                        "solution": [
+                            {"relevant_code_file": {"repo_name": "owner1/repo1"}},
+                            {"relevant_code_file": {"repo_name": "owner2/repo2"}},
+                        ],
+                    }
+                ],
+            }
+        )
 
     def mock_integration_service_calls(self, integrations=None):
         """Helper to mock integration service calls for GET endpoint."""


### PR DESCRIPTION
Because `AutofixRequest` was a typed dict, we weren't correctly converting its fields into pydantic models when parsing.

Change needed for Coding/Cursor agent integration
