### PR TITLE
fix(uptime): log when we drop a check

### DIFF
--- a/src/sentry/uptime/consumers/results_consumer.py
+++ b/src/sentry/uptime/consumers/results_consumer.py
@@ -371,6 +371,14 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
                 tags={"mode": mode_name, **metric_tags},
                 sample_rate=1.0,
             )
+            logger.info(
+                "uptime.result_processor.skipping_already_processed_update",
+                extra={
+                    "guid": result["guid"],
+                    "region": result["region"],
+                    "subscription_id": result["subscription_id"],
+                },
+            )
             return
 
         subscription_interval_ms = 1000 * subscription.interval_seconds


### PR DESCRIPTION
Let's get some logging in to confirm we're getting out-of-order arrivals from kafka (and therefore vector)
