### PR TITLE
fix(crons): Do not show CompletedLateIndicator when not actually late

### DIFF
--- a/static/app/views/insights/crons/components/checkInCell.tsx
+++ b/static/app/views/insights/crons/components/checkInCell.tsx
@@ -314,6 +314,19 @@ function CompletedLateIndicator({checkIn}: TimeoutLateByProps) {
   const maxRuntimeSeconds = (monitorConfig.max_runtime ?? DEFAULT_MAX_RUNTIME) * 60;
   const lateBySecond = duration / 1000 - maxRuntimeSeconds;
 
+  // In cases where a check-in was processed late due to being stuck in relay
+  // we may compute a negative lateBySecond. In those cases do not render the
+  // indicator.
+  //
+  // This happens because the check-in is marked as timedout, later we receive
+  // a completing check-in that updates the duration. Typically this would
+  // imply the check-in ran too long. But if the duration is less than the
+  // max-runtine, it implies the check-in was produced to kafka much later than
+  // it should have, and the job actually ran like normal
+  if (lateBySecond < 0) {
+    return null;
+  }
+
   const maxRuntime = (
     <strong>
       <Duration seconds={maxRuntimeSeconds} />

--- a/static/app/views/insights/crons/components/monitorCheckInsGrid.spec.tsx
+++ b/static/app/views/insights/crons/components/monitorCheckInsGrid.spec.tsx
@@ -170,4 +170,23 @@ describe('CheckInRow', () => {
 
     expect(await screen.findByText(expectedTooltip)).toBeInTheDocument();
   });
+
+  it('handles timeout check-in with duration less than max_runtime without showing late indicator', () => {
+    // When a check-in's closing check-in is processed very late (due to being
+    // stuck in relay) we should not show a CompletedLateIndicator, even though
+    // it's `COMPLETE_TIMEOUT`.
+    const checkIn = CheckInFixture({
+      status: CheckInStatus.TIMEOUT,
+      dateAdded: '2025-01-01T00:00:01Z',
+      dateUpdated: '2025-01-01T00:05:00Z',
+      dateInProgress: '2025-01-01T00:00:01Z',
+      duration: 5 * 60 * 1000,
+    });
+
+    render(<MonitorCheckInsGrid project={project} checkIns={[checkIn]} />);
+
+    // Should show timeout status but no late indicator since lateBySecond < 0
+    expect(screen.getByText('Timed Out')).toBeInTheDocument();
+    expect(screen.queryByText(/late/)).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
This can happen when a check-in becomes stuck in relay and is incorrectly marked as timed-out, and later has it's OK check-in processed.

Relates to [NEW-503: Investigate -30min late check-in issue](https://linear.app/getsentry/issue/NEW-503/investigate-30min-late-check-in-issue)