### PR TITLE
fix(explore): Persist visibility and chart type

### DIFF
--- a/static/app/views/explore/logs/logsGraph.tsx
+++ b/static/app/views/explore/logs/logsGraph.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useMemo, useState} from 'react';
+import {Fragment, useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import Feature from 'sentry/components/acl/feature';
@@ -42,6 +42,7 @@ import {
   useQueryParamsMode,
   useQueryParamsTopEventsLimit,
   useQueryParamsVisualizes,
+  useSetQueryParamsVisualizes,
 } from 'sentry/views/explore/queryParams/context';
 import {isGroupBy} from 'sentry/views/explore/queryParams/groupBy';
 import {Mode} from 'sentry/views/explore/queryParams/mode';
@@ -61,12 +62,41 @@ interface LogsGraphProps {
 
 export function LogsGraph({timeseriesResult}: LogsGraphProps) {
   const visualizes = useQueryParamsVisualizes();
+  const setVisualizes = useSetQueryParamsVisualizes();
+
+  function handleChartTypeChange(index: number, chartType: ChartType) {
+    const newVisualizes = visualizes.map((visualize, i) => {
+      if (i === index) {
+        visualize = visualize.replace({chartType});
+      }
+      return visualize.serialize();
+    });
+    setVisualizes(newVisualizes);
+  }
+
+  function handleChartVisibilityChange(index: number, visible: boolean) {
+    const newVisualizes = visualizes.map((visualize, i) => {
+      if (i === index) {
+        visualize = visualize.replace({visible});
+      }
+      return visualize.serialize();
+    });
+    setVisualizes(newVisualizes);
+  }
 
   return (
     <Fragment>
       {visualizes.map((visualize, index) => {
         return (
-          <Graph key={index} visualize={visualize} timeseriesResult={timeseriesResult} />
+          <Graph
+            key={index}
+            visualize={visualize}
+            timeseriesResult={timeseriesResult}
+            onChartTypeChange={chartType => handleChartTypeChange(index, chartType)}
+            onChartVisibilityChange={visible =>
+              handleChartVisibilityChange(index, visible)
+            }
+          />
         );
       })}
     </Fragment>
@@ -74,15 +104,20 @@ export function LogsGraph({timeseriesResult}: LogsGraphProps) {
 }
 
 interface GraphProps extends LogsGraphProps {
+  onChartTypeChange: (chartType: ChartType) => void;
+  onChartVisibilityChange: (visible: boolean) => void;
   visualize: Visualize;
 }
 
-function Graph({timeseriesResult, visualize}: GraphProps) {
+function Graph({
+  onChartTypeChange,
+  onChartVisibilityChange,
+  timeseriesResult,
+  visualize,
+}: GraphProps) {
   const aggregate = visualize.yAxis;
   const topEventsLimit = useQueryParamsTopEventsLimit();
 
-  const [visible, setVisible] = useState(true);
-  const [chartType, setChartType] = useState<ChartType>(ChartType.BAR);
   const [interval, setInterval, intervalOptions] = useChartInterval({
     unspecifiedStrategy: ChartIntervalUnspecifiedStrategy.USE_SMALLEST,
   });
@@ -92,7 +127,7 @@ function Graph({timeseriesResult, visualize}: GraphProps) {
     const isTopEvents = defined(topEventsLimit);
     const samplingMeta = determineSeriesSampleCountAndIsSampled(series, isTopEvents);
     return {
-      chartType,
+      chartType: visualize.chartType,
       series,
       timeseriesResult,
       yAxis: aggregate,
@@ -103,14 +138,18 @@ function Graph({timeseriesResult, visualize}: GraphProps) {
       samplingMode: undefined,
       topEvents: isTopEvents ? TOP_EVENTS_LIMIT : undefined,
     };
-  }, [chartType, timeseriesResult, aggregate, topEventsLimit]);
+  }, [visualize.chartType, timeseriesResult, aggregate, topEventsLimit]);
 
   const Title = (
     <Widget.WidgetTitle title={prettifyAggregation(aggregate) ?? aggregate} />
   );
 
   const chartIcon =
-    chartType === ChartType.LINE ? 'line' : chartType === ChartType.AREA ? 'area' : 'bar';
+    visualize.chartType === ChartType.LINE
+      ? 'line'
+      : visualize.chartType === ChartType.AREA
+        ? 'area'
+        : 'bar';
 
   const Actions = (
     <Fragment>
@@ -122,10 +161,10 @@ function Graph({timeseriesResult, visualize}: GraphProps) {
             showChevron: false,
             size: 'xs',
           }}
-          value={chartType}
+          value={visualize.chartType}
           menuTitle="Type"
           options={EXPLORE_CHART_TYPE_OPTIONS}
-          onChange={option => setChartType(option.value)}
+          onChange={option => onChartTypeChange(option.value)}
         />
       </Tooltip>
       <Tooltip title={t('Time interval displayed in this visualization (ex. 5m)')}>
@@ -145,8 +184,8 @@ function Graph({timeseriesResult, visualize}: GraphProps) {
       <ContextMenu
         interval={interval}
         visualize={visualize}
-        visible={visible}
-        setVisible={setVisible}
+        visible={visualize.visible}
+        setVisible={onChartVisibilityChange}
       />
     </Fragment>
   );
@@ -155,16 +194,16 @@ function Graph({timeseriesResult, visualize}: GraphProps) {
     <Widget
       Title={Title}
       Actions={Actions}
-      Visualization={visible && <ChartVisualization chartInfo={chartInfo} />}
+      Visualization={visualize.visible && <ChartVisualization chartInfo={chartInfo} />}
       Footer={
-        visible && (
+        visualize.visible && (
           <ConfidenceFooter
             chartInfo={chartInfo}
             isLoading={timeseriesResult.isLoading}
           />
         )
       }
-      height={visible ? 200 : 50}
+      height={visualize.visible ? 200 : 50}
       revealActions="always"
     />
   );

--- a/static/app/views/explore/queryParams/visualize.spec.ts
+++ b/static/app/views/explore/queryParams/visualize.spec.ts
@@ -35,6 +35,7 @@ describe('VisualizeFunction', () => {
   it('clones', () => {
     const vis1 = new VisualizeFunction('count(span.duration)', {
       chartType: ChartType.AREA,
+      visible: false,
     });
     const vis2 = vis1.clone();
     expect(vis1).toEqual(vis2);
@@ -60,16 +61,29 @@ describe('VisualizeFunction', () => {
     );
   });
 
+  it('replaces visible', () => {
+    const vis1 = new VisualizeFunction('count(span.duration)', {
+      visible: false,
+    });
+    const vis2 = vis1.replace({visible: true});
+    expect(vis2).toEqual(new VisualizeFunction('count(span.duration)', {visible: true}));
+  });
+
   it('replaces yAxes and chart type', () => {
     const vis1 = new VisualizeFunction('count(span.duration)', {
       chartType: ChartType.AREA,
+      visible: true,
     });
     const vis2 = vis1.replace({
       yAxis: 'avg(span.duration)',
       chartType: ChartType.LINE,
+      visible: false,
     });
     expect(vis2).toEqual(
-      new VisualizeFunction('avg(span.duration)', {chartType: ChartType.LINE})
+      new VisualizeFunction('avg(span.duration)', {
+        chartType: ChartType.LINE,
+        visible: false,
+      })
     );
   });
 


### PR DESCRIPTION
This does a few things
1. ensure the chart visibility is persisted for spans and logs
	- this fixes a long standing bug where if you have 2 charts, collapse the first one, and delete the first one, the remaining chart is still collapsed 
3. ensure the chart type is persisted for logs
4. ensure the default chart type is auto decided for logs