### PR TITLE
chore(scm): add halts to get_stacktrace_link/check_file

### DIFF
--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -473,9 +473,9 @@ def process_api_error(e: ApiError) -> list[dict[str, Any]] | None:
         message = e.json.get("message", "")
         if RATE_LIMITED_MESSAGE in message:
             return []
-        elif "403 Forbidden" in message or e.code == 403:
+        elif "403 Forbidden" in message:
             return []
-    elif e.code == 404:
+    elif e.code == 404 or e.code == 403:
         return []
     elif isinstance(e, ApiInvalidRequestError):
         return []

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -479,8 +479,7 @@ def process_api_error(e: ApiError) -> list[dict[str, Any]] | None:
         return []
     elif isinstance(e, ApiInvalidRequestError):
         return []
-    else:
-        return None
+    return None
 
 
 class GitHubOpenPRCommentWorkflow(OpenPRCommentWorkflow):

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -64,7 +64,7 @@ from sentry.organizations.services.organization import organization_service
 from sentry.organizations.services.organization.model import RpcOrganization
 from sentry.pipeline.views.base import PipelineView, render_react_view
 from sentry.shared_integrations.constants import ERR_INTERNAL, ERR_UNAUTHORIZED
-from sentry.shared_integrations.exceptions import ApiError, IntegrationError
+from sentry.shared_integrations.exceptions import ApiError, ApiInvalidRequestError, IntegrationError
 from sentry.snuba.referrer import Referrer
 from sentry.templatetags.sentry_helpers import small_count
 from sentry.users.models.user import User
@@ -468,6 +468,21 @@ OPEN_PR_ISSUE_TABLE_TOGGLE_TEMPLATE = """\
 OPEN_PR_ISSUE_DESCRIPTION_LENGTH = 52
 
 
+def process_api_error(e: ApiError) -> list[dict[str, Any]] | None:
+    if e.json:
+        message = e.json.get("message", "")
+        if RATE_LIMITED_MESSAGE in message:
+            return []
+        elif "403 Forbidden" in message or e.code == 403:
+            return []
+    elif e.code == 404:
+        return []
+    elif isinstance(e, ApiInvalidRequestError):
+        return []
+    else:
+        return None
+
+
 class GitHubOpenPRCommentWorkflow(OpenPRCommentWorkflow):
     integration: GitHubIntegration
     organization_option_key = "sentry:github_open_pr_bot"
@@ -479,8 +494,9 @@ class GitHubOpenPRCommentWorkflow(OpenPRCommentWorkflow):
         try:
             pr_files = client.get_pullrequest_files(repo=repo.name, pull_number=pr.key)
         except ApiError as e:
-            if (e.json and RATE_LIMITED_MESSAGE in e.json.get("message", "")) or e.code == 404:
-                return []
+            api_error_resp = process_api_error(e)
+            if api_error_resp is not None:
+                return api_error_resp
             else:
                 raise
 

--- a/src/sentry/shared_integrations/exceptions/__init__.py
+++ b/src/sentry/shared_integrations/exceptions/__init__.py
@@ -89,6 +89,8 @@ class ApiError(Exception):
             return ApiConflictError(response.text, url=url)
         elif response.status_code == 400:
             return ApiInvalidRequestError(response.text, url=url)
+        elif response.status_code == 403:
+            return ApiForbiddenError(response.text, url=url)
 
         return cls(response.text, response.status_code, url=url)
 
@@ -157,6 +159,10 @@ class ApiConnectionResetError(ApiError):
 
 class ApiInvalidRequestError(ApiError):
     code = 400
+
+
+class ApiForbiddenError(ApiError):
+    code = 403
 
 
 class UnsupportedResponseType(ApiError):

--- a/tests/sentry/integrations/github/tasks/test_open_pr_comment.py
+++ b/tests/sentry/integrations/github/tasks/test_open_pr_comment.py
@@ -217,7 +217,7 @@ class TestSafeForComment(GithubCommentTestCase):
     @responses.activate
     def test_error__api_error(self) -> None:
         responses.add(
-            responses.GET, self.gh_path.format(pull_number=self.pr.key), status=400, json={}
+            responses.GET, self.gh_path.format(pull_number=self.pr.key), status=500, json={}
         )
 
         with pytest.raises(ApiError):


### PR DESCRIPTION
For check_file, these errors were flagging our SLOs and oncall alerts. Turned out to be 403 errors with no message body so record them as halt but still raise since the caller function returns the error back to the user.

Other halts/swallowing of errors are for get_pr_diffs which were also flapping the SLOs