### PR TITLE
Add size comparison API for triggering and getting status of comparisons

### DIFF
--- a/src/sentry/preprod/analytics.py
+++ b/src/sentry/preprod/analytics.py
@@ -75,6 +75,24 @@ class PreprodArtifactApiDeleteEvent(analytics.Event):
     artifact_id: str
 
 
+@analytics.eventclass("preprod_artifact.api.size_analysis_compare.get")
+class PreprodArtifactApiSizeAnalysisCompareGetEvent(analytics.Event):
+    organization_id: int
+    project_id: int
+    user_id: int | None = None
+    head_artifact_id: str
+    base_artifact_id: str
+
+
+@analytics.eventclass("preprod_artifact.api.size_analysis_compare.post")
+class PreprodArtifactApiSizeAnalysisComparePostEvent(analytics.Event):
+    organization_id: int
+    project_id: int
+    user_id: int | None = None
+    head_artifact_id: str
+    base_artifact_id: str
+
+
 class PreprodArtifactApiInstallDetailsEvent(analytics.Event):
     type = "preprod_artifact.api.install_details"
 
@@ -97,3 +115,5 @@ analytics.register(PreprodArtifactApiRerunAnalysisEvent)
 analytics.register(PreprodArtifactApiAdminGetInfoEvent)
 analytics.register(PreprodArtifactApiAdminBatchDeleteEvent)
 analytics.register(PreprodArtifactApiDeleteEvent)
+analytics.register(PreprodArtifactApiSizeAnalysisCompareGetEvent)
+analytics.register(PreprodArtifactApiSizeAnalysisComparePostEvent)

--- a/src/sentry/preprod/api/endpoints/size_analysis/project_preprod_size_analysis_compare.py
+++ b/src/sentry/preprod/api/endpoints/size_analysis/project_preprod_size_analysis_compare.py
@@ -402,7 +402,7 @@ class ProjectPreprodArtifactSizeAnalysisCompareEndpoint(ProjectEndpoint):
             if not base_metric:
                 logger.info(
                     "preprod.size_analysis.compare.api.no_matching_base_metric",
-                    extra={"head_metric_id": head_metric.id, "base_metric_id": base_metric.id},
+                    extra={"head_metric_id": head_metric.id},
                 )
                 continue
 

--- a/src/sentry/preprod/api/endpoints/size_analysis/project_preprod_size_analysis_compare.py
+++ b/src/sentry/preprod/api/endpoints/size_analysis/project_preprod_size_analysis_compare.py
@@ -1,0 +1,188 @@
+import logging
+
+from django.http.response import HttpResponseBase
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases.project import ProjectEndpoint
+from sentry.preprod.api.models.size_analysis.project_preprod_size_analysis_compare_models import (
+    SizeAnalysisCompareResponse,
+    SizeAnalysisComparison,
+)
+from sentry.preprod.models import (
+    PreprodArtifact,
+    PreprodArtifactSizeComparison,
+    PreprodArtifactSizeMetrics,
+)
+from sentry.preprod.size_analysis.tasks import manual_size_analysis_comparison
+
+logger = logging.getLogger(__name__)
+
+
+@region_silo_endpoint
+class ProjectPreprodArtifactSizeAnalysisCompareEndpoint(ProjectEndpoint):
+    owner = ApiOwner.EMERGE_TOOLS
+    publish_status = {
+        "GET": ApiPublishStatus.EXPERIMENTAL,
+    }
+
+    def get(
+        self, request: Request, project, head_artifact_id, base_artifact_id
+    ) -> HttpResponseBase:
+        """
+        Download size analysis results for a preprod artifact
+        ````````````````````````````````````````````````````
+
+        Download the size analysis comparison results for a preprod artifact.
+
+        :pparam string organization_id_or_slug: the id or slug of the organization the
+                                          artifact belongs to.
+        :pparam string project_id_or_slug: the id or slug of the project to retrieve the
+                                     artifact from.
+        :pparam string artifact_id: the ID of the preprod artifact to download size analysis for.
+        :auth: required
+        """
+
+        # Query all size metrics for the head and base artifacts
+        try:
+            head_preprod_artifact = PreprodArtifact.objects.get(id=head_artifact_id)
+        except PreprodArtifact.DoesNotExist:
+            return Response(
+                {"detail": f"Head PreprodArtifact with id {head_artifact_id} does not exist."},
+                status=404,
+            )
+        try:
+            base_preprod_artifact = PreprodArtifact.objects.get(id=base_artifact_id)
+        except PreprodArtifact.DoesNotExist:
+            return Response(
+                {"detail": f"Base PreprodArtifact with id {base_artifact_id} does not exist."},
+                status=404,
+            )
+
+        head_metrics_map = _build_metrics_map(head_preprod_artifact.size_metrics.all())
+        base_metrics_map = _build_metrics_map(base_preprod_artifact.size_metrics.all())
+
+        # For each head metric, try to find a matching base metric (by metrics_artifact_type and identifier)
+        comparisons: list[SizeAnalysisComparison] = []
+        for key, head_metric in head_metrics_map.items():
+            base_metric = base_metrics_map.get(key)
+            if not base_metric:
+                # No matching base metric, so we can't compare
+                comparisons.append(
+                    SizeAnalysisComparison(
+                        metrics_artifact_type=head_metric.metrics_artifact_type,
+                        identifier=head_metric.identifier,
+                        state=PreprodArtifactSizeComparison.State.FAILED,
+                        comparison_id=None,
+                        error_code="NO_BASE_METRIC",
+                        error_message="No matching base artifact size metric found.",
+                    )
+                )
+                continue
+
+            # Try to find a comparison object
+            comparison_obj = PreprodArtifactSizeComparison.objects.filter(
+                head_size_analysis=head_metric,
+                base_size_analysis=base_metric,
+            ).first()
+
+            if comparison_obj is None:
+                # No comparison has been run yet
+                logger.info(
+                    "preprod.size_analysis.compare.api.no_comparison_found",
+                    extra={"head_metric_id": head_metric.id, "base_metric_id": base_metric.id},
+                )
+                continue
+
+            if comparison_obj.state == PreprodArtifactSizeComparison.State.SUCCESS:
+                comparisons.append(
+                    SizeAnalysisComparison(
+                        metrics_artifact_type=head_metric.metrics_artifact_type,
+                        identifier=head_metric.identifier,
+                        state=PreprodArtifactSizeComparison.State.SUCCESS,
+                        comparison_id=comparison_obj.id,
+                        error_code=None,
+                        error_message=None,
+                    )
+                )
+            elif comparison_obj.state == PreprodArtifactSizeComparison.State.FAILED:
+                comparisons.append(
+                    SizeAnalysisComparison(
+                        metrics_artifact_type=head_metric.metrics_artifact_type,
+                        identifier=head_metric.identifier,
+                        state=PreprodArtifactSizeComparison.State.FAILED,
+                        comparison_id=comparison_obj.id,
+                        error_code=(
+                            str(comparison_obj.error_code)
+                            if comparison_obj.error_code is not None
+                            else None
+                        ),
+                        error_message=comparison_obj.error_message,
+                    )
+                )
+            else:
+                # Still processing or pending
+                comparisons.append(
+                    SizeAnalysisComparison(
+                        metrics_artifact_type=head_metric.metrics_artifact_type,
+                        identifier=head_metric.identifier,
+                        state=PreprodArtifactSizeComparison.State.PROCESSING,
+                        comparison_id=comparison_obj.id,
+                        error_code=None,
+                        error_message=None,
+                    )
+                )
+
+        response = SizeAnalysisCompareResponse(
+            head_artifact_id=int(head_artifact_id),
+            base_artifact_id=int(base_artifact_id),
+            comparisons=comparisons,
+        )
+        return Response(response.model_dump())
+
+    def post(
+        self, request: Request, project, head_artifact_id, base_artifact_id
+    ) -> HttpResponseBase:
+        """
+        Compare size analysis results for a preprod artifact
+        ````````````````````````````````````````````````````
+
+        Compare the size analysis results for a preprod artifact.
+        """
+
+        try:
+            head_preprod_artifact = PreprodArtifact.objects.get(id=head_artifact_id)
+        except PreprodArtifact.DoesNotExist:
+            return Response(
+                {"detail": f"Head PreprodArtifact with id {head_artifact_id} does not exist."},
+                status=404,
+            )
+        try:
+            base_preprod_artifact = PreprodArtifact.objects.get(id=base_artifact_id)
+        except PreprodArtifact.DoesNotExist:
+            return Response(
+                {"detail": f"Base PreprodArtifact with id {base_artifact_id} does not exist."},
+                status=404,
+            )
+
+        head_metrics_map = _build_metrics_map(head_preprod_artifact.size_metrics.all())
+        base_metrics_map = _build_metrics_map(base_preprod_artifact.size_metrics.all())
+
+        for key, head_metric in head_metrics_map.items():
+            base_metric = base_metrics_map.get(key)
+            if not base_metric:
+                logger.info(
+                    "preprod.size_analysis.compare.api.no_matching_base_metric",
+                    extra={"head_metric_id": head_metric.id, "base_metric_id": base_metric.id},
+                )
+                continue
+
+            manual_size_analysis_comparison(head_metric, base_metric)
+
+
+# Build a mapping of (metrics_artifact_type, identifier) -> size metric for quick lookup of matching metrics from head or base size metrics
+def _build_metrics_map(metrics: list[PreprodArtifactSizeMetrics]):
+    return {(metric.metrics_artifact_type, metric.identifier): metric for metric in metrics}

--- a/src/sentry/preprod/api/endpoints/size_analysis/project_preprod_size_analysis_compare.py
+++ b/src/sentry/preprod/api/endpoints/size_analysis/project_preprod_size_analysis_compare.py
@@ -40,16 +40,17 @@ class ProjectPreprodArtifactSizeAnalysisCompareEndpoint(ProjectEndpoint):
         self, request: Request, project, head_artifact_id, base_artifact_id
     ) -> HttpResponseBase:
         """
-        Download size analysis results for a preprod artifact
+        Get size analysis comparison results for a preprod artifact
         ````````````````````````````````````````````````````
 
-        Download the size analysis comparison results for a preprod artifact.
+        Get size analysis comparison results for a preprod artifact.
 
         :pparam string organization_id_or_slug: the id or slug of the organization the
                                           artifact belongs to.
         :pparam string project_id_or_slug: the id or slug of the project to retrieve the
                                      artifact from.
-        :pparam string artifact_id: the ID of the preprod artifact to download size analysis for.
+        :pparam string head_artifact_id: the ID of the head preprod artifact to get size analysis comparison for.
+        :pparam string base_artifact_id: the ID of the base preprod artifact to get size analysis comparison for.
         :auth: required
         """
 
@@ -172,10 +173,6 @@ class ProjectPreprodArtifactSizeAnalysisCompareEndpoint(ProjectEndpoint):
             )
 
             if comparison_obj.state == PreprodArtifactSizeComparison.State.SUCCESS:
-                logger.info(
-                    "preprod.size_analysis.compare.api.get.success",
-                    extra={"comparison_id": comparison_obj.id},
-                )
                 comparisons.append(
                     SizeAnalysisComparison(
                         head_size_metric_id=head_metric.id,
@@ -220,6 +217,14 @@ class ProjectPreprodArtifactSizeAnalysisCompareEndpoint(ProjectEndpoint):
                     )
                 )
 
+        logger.info(
+            "preprod.size_analysis.compare.api.get.success",
+            extra={
+                "head_artifact_id": head_artifact_id,
+                "base_artifact_id": base_artifact_id,
+                "comparisons": comparisons.count(),
+            },
+        )
         response = SizeAnalysisCompareGETResponse(
             head_artifact_id=int(head_artifact_id),
             base_artifact_id=int(base_artifact_id),
@@ -231,10 +236,18 @@ class ProjectPreprodArtifactSizeAnalysisCompareEndpoint(ProjectEndpoint):
         self, request: Request, project, head_artifact_id, base_artifact_id
     ) -> HttpResponseBase:
         """
-        Compare size analysis results for a preprod artifact
+        Trigger size analysis comparison for a preprod artifact
         ````````````````````````````````````````````````````
 
-        Compare the size analysis results for a preprod artifact.
+        Trigger size analysis comparison for a preprod artifact. Will run comparisons async for all size metrics.
+
+        :pparam string organization_id_or_slug: the id or slug of the organization the
+                                          artifact belongs to.
+        :pparam string project_id_or_slug: the id or slug of the project to retrieve the
+                                     artifact from.
+        :pparam string head_artifact_id: the ID of the head preprod artifact to trigger size analysis comparison for.
+        :pparam string base_artifact_id: the ID of the base preprod artifact to trigger size analysis comparison for.
+        :auth: required
         """
 
         analytics.record(

--- a/src/sentry/preprod/api/endpoints/size_analysis/project_preprod_size_analysis_compare.py
+++ b/src/sentry/preprod/api/endpoints/size_analysis/project_preprod_size_analysis_compare.py
@@ -120,6 +120,8 @@ class ProjectPreprodArtifactSizeAnalysisCompareEndpoint(ProjectEndpoint):
                 # No matching base metric, so we can't compare
                 comparisons.append(
                     SizeAnalysisComparison(
+                        head_size_metric_id=head_metric.id,
+                        base_size_metric_id=base_metric.id,
                         metrics_artifact_type=head_metric.metrics_artifact_type,
                         identifier=head_metric.identifier,
                         state=PreprodArtifactSizeComparison.State.FAILED,
@@ -152,6 +154,8 @@ class ProjectPreprodArtifactSizeAnalysisCompareEndpoint(ProjectEndpoint):
                 )
                 comparisons.append(
                     SizeAnalysisComparison(
+                        head_size_metric_id=head_metric.id,
+                        base_size_metric_id=base_metric.id,
                         metrics_artifact_type=head_metric.metrics_artifact_type,
                         identifier=head_metric.identifier,
                         state=PreprodArtifactSizeComparison.State.PENDING,
@@ -174,6 +178,8 @@ class ProjectPreprodArtifactSizeAnalysisCompareEndpoint(ProjectEndpoint):
                 )
                 comparisons.append(
                     SizeAnalysisComparison(
+                        head_size_metric_id=head_metric.id,
+                        base_size_metric_id=base_metric.id,
                         metrics_artifact_type=head_metric.metrics_artifact_type,
                         identifier=head_metric.identifier,
                         state=PreprodArtifactSizeComparison.State.SUCCESS,
@@ -185,6 +191,8 @@ class ProjectPreprodArtifactSizeAnalysisCompareEndpoint(ProjectEndpoint):
             elif comparison_obj.state == PreprodArtifactSizeComparison.State.FAILED:
                 comparisons.append(
                     SizeAnalysisComparison(
+                        head_size_metric_id=head_metric.id,
+                        base_size_metric_id=base_metric.id,
                         metrics_artifact_type=head_metric.metrics_artifact_type,
                         identifier=head_metric.identifier,
                         state=PreprodArtifactSizeComparison.State.FAILED,
@@ -201,6 +209,8 @@ class ProjectPreprodArtifactSizeAnalysisCompareEndpoint(ProjectEndpoint):
                 # Still processing or pending
                 comparisons.append(
                     SizeAnalysisComparison(
+                        head_size_metric_id=head_metric.id,
+                        base_size_metric_id=base_metric.id,
                         metrics_artifact_type=head_metric.metrics_artifact_type,
                         identifier=head_metric.identifier,
                         state=PreprodArtifactSizeComparison.State.PROCESSING,

--- a/src/sentry/preprod/api/endpoints/size_analysis/project_preprod_size_analysis_compare.py
+++ b/src/sentry/preprod/api/endpoints/size_analysis/project_preprod_size_analysis_compare.py
@@ -90,7 +90,7 @@ class ProjectPreprodArtifactSizeAnalysisCompareEndpoint(ProjectEndpoint):
             return Response({"error": "Project not found"}, status=404)
 
         head_size_metrics_qs = PreprodArtifactSizeMetrics.objects.filter(
-            preprod_artifact_id__in=[head_artifact_id],
+            preprod_artifact_id__in=[head_preprod_artifact.id],
             preprod_artifact__project=project,
         ).select_related("preprod_artifact")
         head_size_metrics = list(head_size_metrics_qs)
@@ -116,7 +116,7 @@ class ProjectPreprodArtifactSizeAnalysisCompareEndpoint(ProjectEndpoint):
             return Response({"error": "Project not found"}, status=404)
 
         base_size_metrics_qs = PreprodArtifactSizeMetrics.objects.filter(
-            preprod_artifact_id__in=[base_artifact_id],
+            preprod_artifact_id__in=[base_preprod_artifact.id],
             preprod_artifact__project=project,
         ).select_related("preprod_artifact")
         base_size_metrics = list(base_size_metrics_qs)
@@ -297,10 +297,6 @@ class ProjectPreprodArtifactSizeAnalysisCompareEndpoint(ProjectEndpoint):
                 {"detail": f"Head PreprodArtifact with id {head_artifact_id} does not exist."},
                 status=404,
             )
-
-        if head_preprod_artifact.project.id != project.id:
-            return Response({"error": "Project not found"}, status=404)
-
         try:
             base_preprod_artifact = PreprodArtifact.objects.get(
                 id=base_artifact_id,
@@ -312,11 +308,8 @@ class ProjectPreprodArtifactSizeAnalysisCompareEndpoint(ProjectEndpoint):
                 status=404,
             )
 
-        if base_preprod_artifact.project.id != project.id:
-            return Response({"error": "Project not found"}, status=404)
-
         head_size_metrics_qs = PreprodArtifactSizeMetrics.objects.filter(
-            preprod_artifact_id__in=[head_artifact_id],
+            preprod_artifact_id__in=[head_preprod_artifact.id],
             preprod_artifact__project=project,
         ).select_related("preprod_artifact")
 
@@ -343,7 +336,7 @@ class ProjectPreprodArtifactSizeAnalysisCompareEndpoint(ProjectEndpoint):
             )
 
         base_size_metrics_qs = PreprodArtifactSizeMetrics.objects.filter(
-            preprod_artifact_id__in=[base_artifact_id],
+            preprod_artifact_id__in=[base_preprod_artifact.id],
             preprod_artifact__project=project,
         ).select_related("preprod_artifact")
         if base_size_metrics_qs.count() == 0:

--- a/src/sentry/preprod/api/endpoints/urls.py
+++ b/src/sentry/preprod/api/endpoints/urls.py
@@ -1,5 +1,9 @@
 from django.urls import re_path
 
+from sentry.preprod.api.endpoints.size_analysis.project_preprod_size_analysis_compare import (
+    ProjectPreprodArtifactSizeAnalysisCompareEndpoint,
+)
+
 from .organization_preprod_artifact_assemble import ProjectPreprodArtifactAssembleEndpoint
 from .preprod_artifact_admin_batch_delete import PreprodArtifactAdminBatchDeleteEndpoint
 from .preprod_artifact_admin_info import PreprodArtifactAdminInfoEndpoint
@@ -59,6 +63,12 @@ preprod_urlpatterns = [
         r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/files/installablepreprodartifact/(?P<url_path>[^/]+)/$",
         ProjectInstallablePreprodArtifactDownloadEndpoint.as_view(),
         name="sentry-api-0-installable-preprod-artifact-download",
+    ),
+    # Size analysis
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/preprodartifacts/size-analysis/compare/(?P<head_artifact_id>[^/]+)/(?P<base_artifact_id>[^/]+)/$",
+        ProjectPreprodArtifactSizeAnalysisCompareEndpoint.as_view(),
+        name="sentry-api-0-project-preprod-artifact-size-analysis-compare",
     ),
 ]
 

--- a/src/sentry/preprod/api/endpoints/urls.py
+++ b/src/sentry/preprod/api/endpoints/urls.py
@@ -66,7 +66,7 @@ preprod_urlpatterns = [
     ),
     # Size analysis
     re_path(
-        r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/preprodartifacts/size-analysis/compare/(?P<base_artifact_id>[^/]+)/(?P<head_artifact_id>[^/]+)/$",
+        r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/preprodartifacts/size-analysis/compare/(?P<head_artifact_id>[^/]+)/(?P<base_artifact_id>[^/]+)/$",
         ProjectPreprodArtifactSizeAnalysisCompareEndpoint.as_view(),
         name="sentry-api-0-project-preprod-artifact-size-analysis-compare",
     ),

--- a/src/sentry/preprod/api/endpoints/urls.py
+++ b/src/sentry/preprod/api/endpoints/urls.py
@@ -66,7 +66,7 @@ preprod_urlpatterns = [
     ),
     # Size analysis
     re_path(
-        r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/preprodartifacts/size-analysis/compare/(?P<head_artifact_id>[^/]+)/(?P<base_artifact_id>[^/]+)/$",
+        r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/preprodartifacts/size-analysis/compare/(?P<base_artifact_id>[^/]+)/(?P<head_artifact_id>[^/]+)/$",
         ProjectPreprodArtifactSizeAnalysisCompareEndpoint.as_view(),
         name="sentry-api-0-project-preprod-artifact-size-analysis-compare",
     ),

--- a/src/sentry/preprod/api/models/size_analysis/project_preprod_size_analysis_compare_models.py
+++ b/src/sentry/preprod/api/models/size_analysis/project_preprod_size_analysis_compare_models.py
@@ -5,7 +5,7 @@ from sentry.preprod.models import PreprodArtifactSizeComparison, PreprodArtifact
 
 class SizeAnalysisComparison(BaseModel):
     head_size_metric_id: int
-    base_size_metric_id: int
+    base_size_metric_id: int | None
 
     metrics_artifact_type: PreprodArtifactSizeMetrics.MetricsArtifactType
     identifier: str | None

--- a/src/sentry/preprod/api/models/size_analysis/project_preprod_size_analysis_compare_models.py
+++ b/src/sentry/preprod/api/models/size_analysis/project_preprod_size_analysis_compare_models.py
@@ -4,6 +4,9 @@ from sentry.preprod.models import PreprodArtifactSizeComparison, PreprodArtifact
 
 
 class SizeAnalysisComparison(BaseModel):
+    head_size_metric_id: int
+    base_size_metric_id: int
+
     metrics_artifact_type: PreprodArtifactSizeMetrics.MetricsArtifactType
     identifier: str | None
     state: PreprodArtifactSizeComparison.State

--- a/src/sentry/preprod/api/models/size_analysis/project_preprod_size_analysis_compare_models.py
+++ b/src/sentry/preprod/api/models/size_analysis/project_preprod_size_analysis_compare_models.py
@@ -25,3 +25,4 @@ class SizeAnalysisCompareGETResponse(BaseModel):
 class SizeAnalysisComparePOSTResponse(BaseModel):
     status: str
     message: str
+    existing_comparisons: list[SizeAnalysisComparison] | None

--- a/src/sentry/preprod/api/models/size_analysis/project_preprod_size_analysis_compare_models.py
+++ b/src/sentry/preprod/api/models/size_analysis/project_preprod_size_analysis_compare_models.py
@@ -16,7 +16,12 @@ class SizeAnalysisComparison(BaseModel):
     error_message: str | None
 
 
-class SizeAnalysisCompareResponse(BaseModel):
+class SizeAnalysisCompareGETResponse(BaseModel):
     head_artifact_id: int
     base_artifact_id: int
     comparisons: list[SizeAnalysisComparison]
+
+
+class SizeAnalysisComparePOSTResponse(BaseModel):
+    status: str
+    message: str

--- a/src/sentry/preprod/api/models/size_analysis/project_preprod_size_analysis_compare_models.py
+++ b/src/sentry/preprod/api/models/size_analysis/project_preprod_size_analysis_compare_models.py
@@ -1,0 +1,22 @@
+from pydantic import BaseModel
+
+from sentry.preprod.models import PreprodArtifactSizeComparison, PreprodArtifactSizeMetrics
+
+
+class SizeAnalysisComparison(BaseModel):
+    metrics_artifact_type: PreprodArtifactSizeMetrics.MetricsArtifactType
+    identifier: str | None
+    state: PreprodArtifactSizeComparison.State
+
+    # Only present when state is SUCCESS
+    comparison_id: int | None
+
+    # Only present when state is FAILED
+    error_code: str | None
+    error_message: str | None
+
+
+class SizeAnalysisCompareResponse(BaseModel):
+    head_artifact_id: int
+    base_artifact_id: int
+    comparisons: list[SizeAnalysisComparison]

--- a/tests/sentry/preprod/api/endpoints/size_analysis/test_project_preprod_size_analysis_compare.py
+++ b/tests/sentry/preprod/api/endpoints/size_analysis/test_project_preprod_size_analysis_compare.py
@@ -1,0 +1,652 @@
+from unittest.mock import patch
+
+from django.test import override_settings
+from django.urls import reverse
+
+from sentry.models.files.file import File
+from sentry.preprod.models import (
+    PreprodArtifact,
+    PreprodArtifactSizeComparison,
+    PreprodArtifactSizeMetrics,
+)
+from sentry.testutils.cases import APITestCase
+
+
+class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
+    endpoint = "sentry-api-0-project-preprod-artifact-size-analysis-compare"
+    method = "get"
+
+    def setUp(self):
+        self.user = self.create_user()
+        self.organization = self.create_organization(owner=self.user)
+        self.project = self.create_project(organization=self.organization)
+        self.login_as(user=self.user)
+
+        # Create test files
+        self.head_file = File.objects.create(
+            name="head_artifact.apk", type="application/octet-stream"
+        )
+        self.base_file = File.objects.create(
+            name="base_artifact.apk", type="application/octet-stream"
+        )
+        self.head_analysis_file = File.objects.create(
+            name="head_analysis.json", type="application/json"
+        )
+        self.base_analysis_file = File.objects.create(
+            name="base_analysis.json", type="application/json"
+        )
+
+        # Create head artifact
+        self.head_artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            file_id=self.head_file.id,
+            app_name="TestApp",
+            app_id="com.test.app",
+            build_version="2.0.0",
+            build_number=2,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+        )
+
+        # Create base artifact
+        self.base_artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            file_id=self.base_file.id,
+            app_name="TestApp",
+            app_id="com.test.app",
+            build_version="1.0.0",
+            build_number=1,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+        )
+
+        # Create size metrics for head artifact
+        self.head_size_metric = PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=self.head_artifact,
+            analysis_file_id=self.head_analysis_file.id,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            identifier="main",
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+        )
+
+        # Create size metrics for base artifact
+        self.base_size_metric = PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=self.base_artifact,
+            analysis_file_id=self.base_analysis_file.id,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            identifier="main",
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+        )
+
+    def _get_url(self, head_artifact_id=None, base_artifact_id=None):
+        head_artifact_id = head_artifact_id or self.head_artifact.id
+        base_artifact_id = base_artifact_id or self.base_artifact.id
+        return reverse(
+            "sentry-api-0-project-preprod-artifact-size-analysis-compare",
+            args=[self.organization.slug, self.project.slug, head_artifact_id, base_artifact_id],
+        )
+
+    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
+    def test_get_comparison_success_with_completed_comparison(self):
+        """Test GET endpoint returns successful comparison when comparison exists and is completed"""
+        # Create a successful comparison
+        comparison = PreprodArtifactSizeComparison.objects.create(
+            head_size_analysis=self.head_size_metric,
+            base_size_analysis=self.base_size_metric,
+            organization_id=self.organization.id,
+            state=PreprodArtifactSizeComparison.State.SUCCESS,
+            file_id=12345,
+        )
+
+        response = self.get_success_response(
+            self.organization.slug,
+            self.project.slug,
+            self.head_artifact.id,
+            self.base_artifact.id,
+        )
+
+        data = response.data
+        assert data["head_artifact_id"] == self.head_artifact.id
+        assert data["base_artifact_id"] == self.base_artifact.id
+        assert len(data["comparisons"]) == 1
+
+        comparison_data = data["comparisons"][0]
+        assert comparison_data["head_size_metric_id"] == self.head_size_metric.id
+        assert comparison_data["base_size_metric_id"] == self.base_size_metric.id
+        assert (
+            comparison_data["metrics_artifact_type"]
+            == PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT
+        )
+        assert comparison_data["identifier"] == "main"
+        assert comparison_data["state"] == PreprodArtifactSizeComparison.State.SUCCESS
+        assert comparison_data["comparison_id"] == comparison.id
+        assert comparison_data["error_code"] is None
+        assert comparison_data["error_message"] is None
+
+    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
+    def test_get_comparison_success_with_failed_comparison(self):
+        """Test GET endpoint returns failed comparison when comparison exists and failed"""
+        # Create a failed comparison
+        comparison = PreprodArtifactSizeComparison.objects.create(
+            head_size_analysis=self.head_size_metric,
+            base_size_analysis=self.base_size_metric,
+            organization_id=self.organization.id,
+            state=PreprodArtifactSizeComparison.State.FAILED,
+            error_code=PreprodArtifactSizeComparison.ErrorCode.UNKNOWN,
+            error_message="Comparison failed due to processing error",
+        )
+
+        response = self.get_success_response(
+            self.organization.slug,
+            self.project.slug,
+            self.head_artifact.id,
+            self.base_artifact.id,
+        )
+        data = response.data
+        comparison_data = data["comparisons"][0]
+        assert comparison_data["state"] == PreprodArtifactSizeComparison.State.FAILED
+        assert comparison_data["comparison_id"] == comparison.id
+        assert comparison_data["error_code"] == str(PreprodArtifactSizeComparison.ErrorCode.UNKNOWN)
+        assert comparison_data["error_message"] == "Comparison failed due to processing error"
+
+    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
+    def test_get_comparison_success_with_processing_comparison(self):
+        """Test GET endpoint returns processing comparison when comparison is in progress"""
+        # Create a processing comparison
+        comparison = PreprodArtifactSizeComparison.objects.create(
+            head_size_analysis=self.head_size_metric,
+            base_size_analysis=self.base_size_metric,
+            organization_id=self.organization.id,
+            state=PreprodArtifactSizeComparison.State.PROCESSING,
+        )
+
+        response = self.get_success_response(
+            self.organization.slug,
+            self.project.slug,
+            self.head_artifact.id,
+            self.base_artifact.id,
+        )
+        data = response.data
+        comparison_data = data["comparisons"][0]
+        assert comparison_data["state"] == PreprodArtifactSizeComparison.State.PROCESSING
+        assert comparison_data["comparison_id"] == comparison.id
+        assert comparison_data["error_code"] is None
+        assert comparison_data["error_message"] is None
+
+    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
+    def test_get_comparison_success_with_pending_comparison(self):
+        """Test GET endpoint returns pending comparison when no comparison exists yet"""
+        response = self.get_success_response(
+            self.organization.slug,
+            self.project.slug,
+            self.head_artifact.id,
+            self.base_artifact.id,
+        )
+        data = response.data
+        comparison_data = data["comparisons"][0]
+        assert comparison_data["state"] == PreprodArtifactSizeComparison.State.PENDING
+        assert comparison_data["comparison_id"] is None
+        assert comparison_data["error_code"] is None
+        assert comparison_data["error_message"] is None
+
+    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
+    def test_get_comparison_success_with_no_matching_base_metric(self):
+        """Test GET endpoint handles case where no matching base metric exists"""
+        # Create a head metric with different identifier
+        PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=self.head_artifact,
+            analysis_file_id=self.head_analysis_file.id,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.WATCH_ARTIFACT,
+            identifier="watch",
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+        )
+
+        response = self.get_success_response(
+            self.organization.slug,
+            self.project.slug,
+            self.head_artifact.id,
+            self.base_artifact.id,
+        )
+        data = response.data
+        assert len(data["comparisons"]) == 2  # main + watch
+
+        # Find the watch comparison
+        watch_comparison = next(
+            (c for c in data["comparisons"] if c["identifier"] == "watch"), None
+        )
+        assert watch_comparison is not None
+        assert watch_comparison["state"] == PreprodArtifactSizeComparison.State.FAILED
+        assert watch_comparison["error_code"] == "NO_BASE_METRIC"
+        assert watch_comparison["error_message"] == "No matching base artifact size metric found."
+
+    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
+    def test_get_comparison_head_artifact_not_found(self):
+        """Test GET endpoint returns 404 when head artifact doesn't exist"""
+        response = self.get_error_response(
+            self.organization.slug,
+            self.project.slug,
+            999999,
+            self.base_artifact.id,
+            status_code=404,
+        )
+        assert "Head PreprodArtifact with id 999999 does not exist" in response.data["detail"]
+
+    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
+    def test_get_comparison_base_artifact_not_found(self):
+        """Test GET endpoint returns 404 when base artifact doesn't exist"""
+        response = self.get_error_response(
+            self.organization.slug,
+            self.project.slug,
+            self.head_artifact.id,
+            999999,
+            status_code=404,
+        )
+        assert "Base PreprodArtifact with id 999999 does not exist" in response.data["detail"]
+
+    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
+    def test_get_comparison_head_artifact_wrong_project(self):
+        """Test GET endpoint returns 404 when head artifact belongs to different project"""
+        other_project = self.create_project(organization=self.organization)
+        other_artifact = PreprodArtifact.objects.create(
+            project=other_project,
+            app_name="OtherApp",
+            app_id="com.other.app",
+            build_version="1.0.0",
+            build_number=1,
+        )
+
+        response = self.get_error_response(
+            self.organization.slug,
+            self.project.slug,
+            other_artifact.id,
+            self.base_artifact.id,
+            status_code=404,
+        )
+        assert response.data["error"] == "Project not found"
+
+    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
+    def test_get_comparison_base_artifact_wrong_project(self):
+        """Test GET endpoint returns 404 when base artifact belongs to different project"""
+        other_project = self.create_project(organization=self.organization)
+        other_artifact = PreprodArtifact.objects.create(
+            project=other_project,
+            app_name="OtherApp",
+            app_id="com.other.app",
+            build_version="1.0.0",
+            build_number=1,
+        )
+
+        response = self.get_error_response(
+            self.organization.slug,
+            self.project.slug,
+            self.head_artifact.id,
+            other_artifact.id,
+            status_code=404,
+        )
+        assert response.data["error"] == "Project not found"
+
+    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
+    def test_get_comparison_head_artifact_no_size_metrics(self):
+        """Test GET endpoint returns 404 when head artifact has no size metrics"""
+        # Create artifact without size metrics
+        artifact_no_metrics = PreprodArtifact.objects.create(
+            project=self.project,
+            app_name="NoMetricsApp",
+            app_id="com.nometrics.app",
+            build_version="1.0.0",
+            build_number=1,
+        )
+
+        response = self.get_error_response(
+            self.organization.slug,
+            self.project.slug,
+            artifact_no_metrics.id,
+            self.base_artifact.id,
+            status_code=404,
+        )
+        assert (
+            f"Head PreprodArtifact with id {artifact_no_metrics.id} has no size metrics"
+            in response.data["detail"]
+        )
+
+    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
+    def test_get_comparison_base_artifact_no_size_metrics(self):
+        """Test GET endpoint returns 404 when base artifact has no size metrics"""
+        # Create artifact without size metrics
+        artifact_no_metrics = PreprodArtifact.objects.create(
+            project=self.project,
+            app_name="NoMetricsApp",
+            app_id="com.nometrics.app",
+            build_version="1.0.0",
+            build_number=1,
+        )
+
+        response = self.get_error_response(
+            self.organization.slug,
+            self.project.slug,
+            self.head_artifact.id,
+            artifact_no_metrics.id,
+            status_code=404,
+        )
+        assert (
+            f"Base PreprodArtifact with id {artifact_no_metrics.id} has no size metrics"
+            in response.data["detail"]
+        )
+
+    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": False})
+    def test_get_comparison_feature_disabled(self):
+        """Test GET endpoint returns 403 when feature flag is disabled"""
+        response = self.get_error_response(
+            self.organization.slug,
+            self.project.slug,
+            self.head_artifact.id,
+            self.base_artifact.id,
+            status_code=403,
+        )
+        assert response.data["error"] == "Feature not enabled"
+
+    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
+    @patch("sentry.preprod.size_analysis.tasks.manual_size_analysis_comparison.apply_async")
+    def test_post_comparison_success(self, mock_apply_async):
+        """Test POST endpoint successfully triggers comparison"""
+        self.get_success_response(
+            self.organization.slug,
+            self.project.slug,
+            self.head_artifact.id,
+            self.base_artifact.id,
+            method="post",
+        )
+        mock_apply_async.assert_called_once_with(
+            kwargs={
+                "head_size_metric_id": self.head_size_metric.id,
+                "base_size_metric_id": self.base_size_metric.id,
+            }
+        )
+
+    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
+    def test_post_comparison_head_artifact_not_found(self):
+        """Test POST endpoint returns 404 when head artifact doesn't exist"""
+        response = self.get_error_response(
+            self.organization.slug,
+            self.project.slug,
+            999999,
+            self.base_artifact.id,
+            method="post",
+            status_code=404,
+        )
+        assert "Head PreprodArtifact with id 999999 does not exist" in response.data["detail"]
+
+    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
+    def test_post_comparison_base_artifact_not_found(self):
+        """Test POST endpoint returns 404 when base artifact doesn't exist"""
+        response = self.get_error_response(
+            self.organization.slug,
+            self.project.slug,
+            self.head_artifact.id,
+            999999,
+            method="post",
+            status_code=404,
+        )
+        assert "Base PreprodArtifact with id 999999 does not exist" in response.data["detail"]
+
+    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
+    def test_post_comparison_head_artifact_no_size_metrics(self):
+        """Test POST endpoint returns 404 when head artifact has no size metrics"""
+        artifact_no_metrics = PreprodArtifact.objects.create(
+            project=self.project,
+            app_name="NoMetricsApp",
+            app_id="com.nometrics.app",
+            build_version="1.0.0",
+            build_number=1,
+        )
+
+        response = self.client.post(self._get_url(head_artifact_id=artifact_no_metrics.id))
+
+        assert response.status_code == 404
+        assert (
+            f"Head PreprodArtifact with id {artifact_no_metrics.id} has no size metrics"
+            in response.json()["detail"]
+        )
+
+    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
+    def test_post_comparison_base_artifact_no_size_metrics(self):
+        """Test POST endpoint returns 404 when base artifact has no size metrics"""
+        artifact_no_metrics = PreprodArtifact.objects.create(
+            project=self.project,
+            app_name="NoMetricsApp",
+            app_id="com.nometrics.app",
+            build_version="1.0.0",
+            build_number=1,
+        )
+
+        response = self.client.post(self._get_url(base_artifact_id=artifact_no_metrics.id))
+
+        assert response.status_code == 404
+        assert (
+            f"Base PreprodArtifact with id {artifact_no_metrics.id} has no size metrics"
+            in response.json()["detail"]
+        )
+
+    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
+    def test_post_comparison_head_artifact_processing(self):
+        """Test POST endpoint returns 202 when head artifact size metrics are still processing"""
+        # Set head size metric to processing state
+        self.head_size_metric.state = PreprodArtifactSizeMetrics.SizeAnalysisState.PROCESSING
+        self.head_size_metric.save()
+
+        response = self.client.post(self._get_url())
+
+        assert response.status_code == 202
+        data = response.json()
+        assert data["status"] == "processing"
+        assert (
+            f"Head PreprodArtifact with id {self.head_artifact.id} has no completed size metrics yet"
+            in data["message"]
+        )
+
+    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
+    def test_post_comparison_base_artifact_processing(self):
+        """Test POST endpoint returns 202 when base artifact size metrics are still processing"""
+        # Set base size metric to processing state
+        self.base_size_metric.state = PreprodArtifactSizeMetrics.SizeAnalysisState.PROCESSING
+        self.base_size_metric.save()
+
+        response = self.client.post(self._get_url())
+
+        assert response.status_code == 202
+        data = response.json()
+        assert data["status"] == "processing"
+        assert (
+            f"Base PreprodArtifact with id {self.base_artifact.id} has no completed size metrics yet"
+            in data["message"]
+        )
+
+    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
+    def test_post_comparison_existing_comparison(self):
+        """Test POST endpoint returns existing comparison when comparison already exists"""
+        # Create an existing comparison
+        comparison = PreprodArtifactSizeComparison.objects.create(
+            head_size_analysis=self.head_size_metric,
+            base_size_analysis=self.base_size_metric,
+            organization_id=self.organization.id,
+            state=PreprodArtifactSizeComparison.State.SUCCESS,
+            file_id=12345,
+        )
+
+        response = self.client.post(self._get_url())
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "exists"
+        assert "A comparison already exists for the head and base size metrics" in data["message"]
+        assert len(data["existing_comparisons"]) == 1
+        assert data["existing_comparisons"][0]["comparison_id"] == comparison.id
+
+    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
+    def test_post_comparison_existing_failed_comparison(self):
+        """Test POST endpoint returns existing failed comparison when comparison exists and failed"""
+        # Create a failed comparison
+        comparison = PreprodArtifactSizeComparison.objects.create(
+            head_size_analysis=self.head_size_metric,
+            base_size_analysis=self.base_size_metric,
+            organization_id=self.organization.id,
+            state=PreprodArtifactSizeComparison.State.FAILED,
+            error_code=PreprodArtifactSizeComparison.ErrorCode.UNKNOWN,
+            error_message="Processing failed",
+        )
+
+        response = self.client.post(self._get_url())
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "exists"
+        assert len(data["existing_comparisons"]) == 1
+        comparison_data = data["existing_comparisons"][0]
+        assert comparison_data["state"] == comparison.state
+        assert comparison_data["error_code"] == str(comparison.error_code)
+        assert comparison_data["error_message"] == comparison.error_message
+
+    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
+    @patch("sentry.preprod.size_analysis.utils.can_compare_size_metrics")
+    def test_post_comparison_cannot_compare_size_metrics(self, mock_can_compare):
+        """Test POST endpoint returns 400 when size metrics cannot be compared"""
+        mock_can_compare.return_value = False
+
+        response = self.client.post(self._get_url())
+
+        assert response.status_code == 400
+        assert "Head and base size metrics cannot be compared" in response.json()["detail"]
+
+    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
+    @patch("sentry.preprod.size_analysis.tasks.manual_size_analysis_comparison.apply_async")
+    def test_post_comparison_multiple_metrics(self, mock_apply_async):
+        """Test POST endpoint handles multiple size metrics correctly"""
+        # Create additional size metrics
+        head_watch_metric = PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=self.head_artifact,
+            analysis_file_id=self.head_analysis_file.id,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.WATCH_ARTIFACT,
+            identifier="watch",
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+        )
+
+        base_watch_metric = PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=self.base_artifact,
+            analysis_file_id=self.base_analysis_file.id,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.WATCH_ARTIFACT,
+            identifier="watch",
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+        )
+
+        response = self.client.post(self._get_url())
+
+        assert response.status_code == 200
+        # Should be called twice - once for main artifact, once for watch artifact
+        assert mock_apply_async.call_count == 2
+
+        # Check the calls
+        calls = mock_apply_async.call_args_list
+        call_kwargs = [call[1]["kwargs"] for call in calls]
+
+        # Should have calls for both main and watch metrics
+        main_call = next(
+            (
+                call
+                for call in call_kwargs
+                if call["head_size_metric_id"] == self.head_size_metric.id
+            ),
+            None,
+        )
+        watch_call = next(
+            (call for call in call_kwargs if call["head_size_metric_id"] == head_watch_metric.id),
+            None,
+        )
+
+        assert main_call is not None
+        assert watch_call is not None
+        assert main_call["base_size_metric_id"] == self.base_size_metric.id
+        assert watch_call["base_size_metric_id"] == base_watch_metric.id
+
+    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": False})
+    def test_post_comparison_feature_disabled(self):
+        """Test POST endpoint returns 403 when feature flag is disabled"""
+        response = self.client.post(self._get_url())
+
+        assert response.status_code == 403
+        assert response.json()["error"] == "Feature not enabled"
+
+    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
+    def test_post_comparison_no_matching_base_metric(self):
+        """Test POST endpoint skips metrics with no matching base metric"""
+        # Create head metric with different identifier that won't match base
+        PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=self.head_artifact,
+            analysis_file_id=self.head_analysis_file.id,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.WATCH_ARTIFACT,
+            identifier="watch",
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+        )
+
+        with patch(
+            "sentry.preprod.size_analysis.tasks.manual_size_analysis_comparison.apply_async"
+        ) as mock_apply_async:
+            response = self.client.post(self._get_url())
+
+            assert response.status_code == 200
+            # Should only be called once for the main artifact, not for the watch artifact
+            mock_apply_async.assert_called_once_with(
+                kwargs={
+                    "head_size_metric_id": self.head_size_metric.id,
+                    "base_size_metric_id": self.base_size_metric.id,
+                }
+            )
+
+    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
+    def test_get_comparison_multiple_metrics(self):
+        """Test GET endpoint handles multiple size metrics correctly"""
+        # Create additional size metrics
+        head_watch_metric = PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=self.head_artifact,
+            analysis_file_id=self.head_analysis_file.id,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.WATCH_ARTIFACT,
+            identifier="watch",
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+        )
+
+        base_watch_metric = PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=self.base_artifact,
+            analysis_file_id=self.base_analysis_file.id,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.WATCH_ARTIFACT,
+            identifier="watch",
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+        )
+
+        # Create comparison for watch metrics
+        watch_comparison = PreprodArtifactSizeComparison.objects.create(
+            head_size_analysis=head_watch_metric,
+            base_size_analysis=base_watch_metric,
+            organization_id=self.organization.id,
+            state=PreprodArtifactSizeComparison.State.SUCCESS,
+        )
+
+        response = self.get_success_response(
+            self.organization.slug,
+            self.project.slug,
+            self.head_artifact.id,
+            self.base_artifact.id,
+        )
+        data = response.data
+        assert len(data["comparisons"]) == 2
+
+        # Check main artifact comparison
+        main_comparison = next((c for c in data["comparisons"] if c["identifier"] == "main"), None)
+        assert main_comparison is not None
+        assert main_comparison["head_size_metric_id"] == self.head_size_metric.id
+        assert main_comparison["base_size_metric_id"] == self.base_size_metric.id
+
+        # Check watch artifact comparison
+        watch_comparison_data = next(
+            (c for c in data["comparisons"] if c["identifier"] == "watch"), None
+        )
+        assert watch_comparison_data is not None
+        assert watch_comparison_data["head_size_metric_id"] == head_watch_metric.id
+        assert watch_comparison_data["base_size_metric_id"] == base_watch_metric.id
+        assert watch_comparison_data["comparison_id"] == watch_comparison.id


### PR DESCRIPTION
Add size comparison GET and POST API endpoints:

GET returns a list of all comparisons for a given head and base artifact ID.
POST will manually run a comparison for all size metrics in the provided head and base artifact IDs