### PR TITLE
fix(aci): only assert that alert_threshold is non-null for alert fires

### DIFF
--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -689,7 +689,8 @@ def email_users(
         user = users[index]
         # TODO(iamrajjoshi): Temporarily assert that alert_threshold is not None
         # This should be removed when we update the typing and fetch the trigger_threshold in the new system
-        assert alert_context.alert_threshold is not None
+        if trigger_status == TriggerStatus.ACTIVE:
+            assert alert_context.alert_threshold is not None
 
         email_context = generate_incident_trigger_email_context(
             project=project,

--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -506,7 +506,7 @@ def generate_incident_trigger_email_context(
     alert_context: AlertContext,
     open_period_context: OpenPeriodContext,
     trigger_status: TriggerStatus,
-    trigger_threshold: float,
+    trigger_threshold: float | None,
     user: User | RpcUser | None = None,
     notification_uuid: str | None = None,
 ) -> dict[str, Any]:

--- a/src/sentry/incidents/typings/metric_detector.py
+++ b/src/sentry/incidents/typings/metric_detector.py
@@ -86,7 +86,11 @@ class AlertContext:
     def from_alert_rule_incident(
         cls, alert_rule: AlertRule, alert_rule_threshold: float | None = None
     ) -> AlertContext:
-        resolve_threshold = alert_rule.resolve_threshold
+        resolve_threshold = (
+            alert_rule.resolve_threshold
+            if alert_rule.resolve_threshold is not None
+            else alert_rule_threshold
+        )
 
         if alert_rule.detection_type == AlertRuleDetectionType.DYNAMIC:
             alert_rule_threshold = 0


### PR DESCRIPTION
For alert resolutions, we pass `resolve_threshold` instead.