### PR TITLE
fix(insights): Update trace view to not use event timestamp on Web Vital issue events

### DIFF
--- a/static/app/components/events/interfaces/performance/eventTraceView.tsx
+++ b/static/app/components/events/interfaces/performance/eventTraceView.tsx
@@ -7,7 +7,7 @@ import {TRACE_WATERFALL_PREFERENCES_KEY} from 'sentry/components/events/interfac
 import {getEventTimestampInSeconds} from 'sentry/components/events/interfaces/utils';
 import {generateTraceTarget} from 'sentry/components/quickTrace/utils';
 import {t} from 'sentry/locale';
-import type {Event} from 'sentry/types/event';
+import {type Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
@@ -60,7 +60,9 @@ interface EventTraceViewInnerProps {
 }
 
 function EventTraceViewInner({event, organization, traceId}: EventTraceViewInnerProps) {
-  const timestamp = getEventTimestampInSeconds(event);
+  const timestamp = isWebVitalsEvent(event)
+    ? undefined
+    : getEventTimestampInSeconds(event);
 
   const trace = useTrace({
     timestamp,
@@ -128,6 +130,11 @@ function OneOtherIssueEvent({event}: {event: Event}) {
 const IssuesTraceContainer = styled('div')`
   position: relative;
 `;
+
+// TODO: We just check for the existence of a web_vital tag for now, improve with a more rigid check
+const isWebVitalsEvent = (event: Event) => {
+  return event.tags.some((tag: {key: string}) => tag?.key === 'web_vital');
+};
 
 interface EventTraceViewProps {
   event: Event;


### PR DESCRIPTION
Update trace view to not use event timestamp on Web Vital issue events. This is because Web Vital issues are synthetic and have a separate occurrence from the connect trace sample