### PR TITLE
Fix seer api auth header for delete by hash

### DIFF
--- a/src/sentry/seer/similarity/grouping_records.py
+++ b/src/sentry/seer/similarity/grouping_records.py
@@ -89,11 +89,11 @@ def call_seer_to_delete_project_grouping_records(
     project_id: int,
 ) -> bool:
     try:
-        # TODO: Move this over to POST json_api implementation
-        response = seer_grouping_connection_pool.urlopen(
-            "GET",
-            f"{SEER_PROJECT_GROUPING_RECORDS_DELETE_URL}/{project_id}",
-            headers={"Content-Type": "application/json;charset=utf-8"},
+        body = {"project_id": project_id}
+        response = make_signed_seer_api_request(
+            seer_grouping_connection_pool,
+            SEER_PROJECT_GROUPING_RECORDS_DELETE_URL,
+            body=json.dumps(body).encode("utf-8"),
             timeout=POST_BULK_GROUPING_RECORDS_TIMEOUT,
         )
     except ReadTimeoutError:
@@ -130,11 +130,10 @@ def call_seer_to_delete_these_hashes(project_id: int, hashes: Sequence[str]) -> 
     extra = {"project_id": project_id, "hashes": hashes}
     try:
         body = {"project_id": project_id, "hash_list": hashes}
-        response = seer_grouping_connection_pool.urlopen(
-            "POST",
+        response = make_signed_seer_api_request(
+            seer_grouping_connection_pool,
             SEER_HASH_GROUPING_RECORDS_DELETE_URL,
-            body=json.dumps(body),
-            headers={"Content-Type": "application/json;charset=utf-8"},
+            body=json.dumps(body).encode("utf-8"),
             timeout=POST_BULK_GROUPING_RECORDS_TIMEOUT,
         )
     except ReadTimeoutError:


### PR DESCRIPTION
<!-- Describe your PR here. -->
Fixes "No auth header found" errors for Seer grouping record deletion by ensuring all Seer API calls are properly authenticated.

**Why these changes?**

Previously, `call_seer_to_delete_these_hashes` and `call_seer_to_delete_project_grouping_records` were making direct `urlopen` calls to Seer without the required authentication headers, leading to 401 errors.

**What was changed?**

*   **`call_seer_to_delete_these_hashes`**: Switched from direct `urlopen` to `make_signed_seer_api_request` for authenticated POST requests.
*   **`call_seer_to_delete_project_grouping_records`**: Converted the unauthenticated GET request to an authenticated POST request, aligning with other Seer API patterns and addressing a previous TODO.
*   **Tests**: Updated existing mocks to target `make_signed_seer_api_request` and added new comprehensive tests for `call_seer_to_delete_project_grouping_records`.

This ensures all Seer deletion requests are signed and properly authenticated.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
<a href="https://cursor.com/background-agent?bcId=bc-edb81c9d-18c1-4230-9a14-3293b17f03fb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-edb81c9d-18c1-4230-9a14-3293b17f03fb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

