### PR TITLE
ref(groupingInfo): move groupingComponentListItem to groupingComponentFrames.tsx

### DIFF
--- a/static/app/components/events/groupingInfo/groupingComponent.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponent.tsx
@@ -48,19 +48,6 @@ const GroupingComponentList = styled('ul')<{isInline: boolean}>`
   }
 `;
 
-export const GroupingComponentListItem = styled('li')<{isCollapsible?: boolean}>`
-  padding: 0;
-  margin: ${space(0.25)} 0 ${space(0.25)} ${space(1.5)};
-
-  ${p =>
-    p.isCollapsible &&
-    css`
-      border-left: 1px solid ${p.theme.innerBorder};
-      margin: 0 0 -${space(0.25)} ${space(1)};
-      padding-left: ${space(0.5)};
-    `}
-`;
-
 export const GroupingValue = styled('code')<{
   valueType: string;
   contributes?: boolean;

--- a/static/app/components/events/groupingInfo/groupingComponent.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponent.tsx
@@ -1,7 +1,5 @@
-import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import {space} from 'sentry/styles/space';
 import type {EventGroupComponent} from 'sentry/types/event';
 
 import GroupingComponentChildren from './groupingComponentChildren';
@@ -48,31 +46,8 @@ const GroupingComponentList = styled('ul')<{isInline: boolean}>`
   }
 `;
 
-export const GroupingValue = styled('code')<{
-  valueType: string;
-  contributes?: boolean;
-}>`
-  display: inline-block;
-  margin: ${space(0.25)} ${space(0.5)} ${space(0.25)} 0;
-  font-size: ${p => p.theme.fontSize.sm};
-  padding: 0 ${space(0.25)};
-  background: ${p => (p.contributes ? 'rgba(112, 163, 214, 0.1)' : 'transparent')};
-  color: ${p => (p.contributes ? p.theme.textColor : p.theme.subText)};
-
-  ${({valueType, theme, contributes}) =>
-    (valueType === 'function' || valueType === 'symbol') &&
-    css`
-      font-weight: ${contributes ? theme.fontWeight.bold : 'normal'};
-      color: ${contributes ? theme.textColor : theme.subText};
-    `}
-`;
-
 const GroupingComponentWrapper = styled('div')<{isContributing: boolean}>`
   color: ${p => (p.isContributing ? p.theme.textColor : p.theme.subText)};
-
-  ${GroupingValue}, button {
-    opacity: 1;
-  }
 `;
 
 export const GroupingHint = styled('small')`

--- a/static/app/components/events/groupingInfo/groupingComponentChildren.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponentChildren.tsx
@@ -2,10 +2,8 @@ import {Fragment} from 'react';
 
 import type {EventGroupComponent} from 'sentry/types/event';
 
-import GroupingComponent, {
-  GroupingComponentListItem,
-  GroupingValue,
-} from './groupingComponent';
+import GroupingComponent, {GroupingValue} from './groupingComponent';
+import {GroupingComponentListItem} from './groupingComponentFrames';
 import {groupingComponentFilter} from './utils';
 
 type Props = {

--- a/static/app/components/events/groupingInfo/groupingComponentChildren.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponentChildren.tsx
@@ -1,8 +1,11 @@
 import {Fragment} from 'react';
+import {css} from '@emotion/react';
+import styled from '@emotion/styled';
 
+import {space} from 'sentry/styles/space';
 import type {EventGroupComponent} from 'sentry/types/event';
 
-import GroupingComponent, {GroupingValue} from './groupingComponent';
+import GroupingComponent from './groupingComponent';
 import {GroupingComponentListItem} from './groupingComponentFrames';
 import {groupingComponentFilter} from './utils';
 
@@ -38,5 +41,24 @@ function GroupingComponentChildren({component, showNonContributing}: Props) {
     </Fragment>
   );
 }
+
+const GroupingValue = styled('code')<{
+  valueType: string;
+  contributes?: boolean;
+}>`
+  display: inline-block;
+  margin: ${space(0.25)} ${space(0.5)} ${space(0.25)} 0;
+  font-size: ${p => p.theme.fontSize.sm};
+  padding: 0 ${space(0.25)};
+  background: ${p => (p.contributes ? 'rgba(112, 163, 214, 0.1)' : 'transparent')};
+  color: ${p => (p.contributes ? p.theme.textColor : p.theme.subText)};
+
+  ${({valueType, theme, contributes}) =>
+    (valueType === 'function' || valueType === 'symbol') &&
+    css`
+      font-weight: ${contributes ? theme.fontWeight.bold : 'normal'};
+      color: ${contributes ? theme.textColor : theme.subText};
+    `}
+`;
 
 export default GroupingComponentChildren;

--- a/static/app/components/events/groupingInfo/groupingComponentFrames.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponentFrames.tsx
@@ -1,12 +1,11 @@
 import {Fragment, useEffect, useState} from 'react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/core/button';
 import {IconAdd, IconSubtract} from 'sentry/icons';
 import {tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-
-import {GroupingComponentListItem} from './groupingComponent';
 
 interface GroupingComponentFramesProps {
   initialCollapsed: boolean;
@@ -78,6 +77,19 @@ function GroupingComponentFrames({
 const ToggleCollapse = styled(Button)`
   margin: ${space(0.5)} 0;
   color: ${p => p.theme.linkColor};
+`;
+
+export const GroupingComponentListItem = styled('li')<{isCollapsible?: boolean}>`
+  padding: 0;
+  margin: ${space(0.25)} 0 ${space(0.25)} ${space(1.5)};
+
+  ${p =>
+    p.isCollapsible &&
+    css`
+      border-left: 1px solid ${p.theme.innerBorder};
+      margin: 0 0 -${space(0.25)} ${space(1)};
+      padding-left: ${space(0.5)};
+    `}
 `;
 
 export default GroupingComponentFrames;


### PR DESCRIPTION
- Move `GroupingComponentListItem` from `groupingComponent.tsx` to `groupingComponentFrames.tsx` because it is not used in `groupingComponent.tsx`. 
- Remove `opacity: 1` because it is not needed anymore and moved `groupingValue` to `groupingComponentChildren.tsx` 
