### PR TITLE
Fix missing seer api auth header

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -760,7 +760,7 @@ RPC_TIMEOUT = 5.0
 # Shared secret used to sign cross-region RPC requests from the seer microservice.
 SEER_RPC_SHARED_SECRET: list[str] | None = None
 # Shared secret used to sign cross-region RPC requests to the seer microservice.
-SEER_API_SHARED_SECRET: str = ""
+SEER_API_SHARED_SECRET: str = os.environ.get("SEER_API_SHARED_SECRET", "")
 
 # Shared secret used to sign cross-region RPC requests from the launchpad microservice.
 LAUNCHPAD_RPC_SHARED_SECRET: list[str] | None = None
@@ -4085,6 +4085,9 @@ if ngrok_host:
 
 if SILO_DEVSERVER or IS_DEV:
     LAUNCHPAD_RPC_SHARED_SECRET = ["launchpad-also-very-long-value-haha"]
+    # Set a development secret for Seer API authentication if not already set
+    if not SEER_API_SHARED_SECRET:
+        SEER_API_SHARED_SECRET = "seer-api-development-shared-secret"
 
 if SILO_DEVSERVER:
     # Add connections for the region & control silo databases.


### PR DESCRIPTION
<!-- Describe your PR here. -->
Fixes an issue where `SEER_API_SHARED_SECRET` was hardcoded to an empty string, preventing the generation of `Rpcsignature` authentication headers for Seer API requests.

This PR:
- Configures `SEER_API_SHARED_SECRET` to load its value from the `SEER_API_SHARED_SECRET` environment variable.
- Provides a default development secret for `SEER_API_SHARED_SECRET` when running in development mode (`SILO_DEVSERVER` or `IS_DEV`) if the environment variable is not set.

This ensures that requests to the Seer API are properly signed, resolving "No auth header found" errors in both production and development environments.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
<a href="https://cursor.com/background-agent?bcId=bc-6c494832-0817-470d-a81c-b6c21f2a1b45">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6c494832-0817-470d-a81c-b6c21f2a1b45">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

