### PR TITLE
Better monitor type and add check-ins timeline to detector details page

### DIFF
--- a/static/app/types/workflowEngine/detectors.tsx
+++ b/static/app/types/workflowEngine/detectors.tsx
@@ -1,4 +1,3 @@
-import type {ObjectStatus} from 'sentry/types/core';
 import type {SimpleGroup} from 'sentry/types/group';
 import type {
   DataCondition,
@@ -10,7 +9,7 @@ import type {
   Dataset,
   EventTypes,
 } from 'sentry/views/alerts/rules/metric/types';
-import type {MonitorConfig, MonitorEnvironment} from 'sentry/views/insights/crons/types';
+import type {Monitor, MonitorConfig} from 'sentry/views/insights/crons/types';
 
 /**
  * See SnubaQuerySerializer
@@ -68,14 +67,7 @@ export interface UptimeSubscriptionDataSource extends BaseDataSource {
 }
 
 export interface CronMonitorDataSource extends BaseDataSource {
-  queryObj: {
-    config: MonitorConfig;
-    environments: MonitorEnvironment[];
-    isMuted: boolean;
-    isUpserting: boolean;
-    slug: string;
-    status: ObjectStatus;
-  };
+  queryObj: Omit<Monitor, 'alertRule'>;
   type: 'cron_monitor';
 }
 

--- a/static/app/views/detectors/components/details/cron/index.tsx
+++ b/static/app/views/detectors/components/details/cron/index.tsx
@@ -16,6 +16,7 @@ import {DetectorDetailsAutomations} from 'sentry/views/detectors/components/deta
 import {DetectorExtraDetails} from 'sentry/views/detectors/components/details/common/extraDetails';
 import {DetectorDetailsHeader} from 'sentry/views/detectors/components/details/common/header';
 import {DetectorDetailsOngoingIssues} from 'sentry/views/detectors/components/details/common/ongoingIssues';
+import {DetailsTimeline} from 'sentry/views/insights/crons/components/detailsTimeline';
 import {MonitorCheckIns} from 'sentry/views/insights/crons/components/monitorCheckIns';
 import {MonitorOnboarding} from 'sentry/views/insights/crons/components/onboarding';
 import type {MonitorEnvironment} from 'sentry/views/insights/crons/types';
@@ -54,7 +55,7 @@ export function CronDetectorDetails({detector, project}: CronDetectorDetailsProp
           {hasCheckedIn ? (
             <Fragment>
               <DatePageFilter />
-              {/* TODO: Add check-in chart */}
+              <DetailsTimeline monitor={dataSource.queryObj} />
               <DetectorDetailsOngoingIssues detectorId={detector.id} />
               <Section title={t('Recent Check-Ins')}>
                 <div>

--- a/static/app/views/insights/crons/components/detailsTimeline.tsx
+++ b/static/app/views/insights/crons/components/detailsTimeline.tsx
@@ -32,7 +32,7 @@ interface Props {
   /**
    * Called when monitor stats have been loaded for this timeline.
    */
-  onStatsLoaded: (stats: MonitorBucket[]) => void;
+  onStatsLoaded?: (stats: MonitorBucket[]) => void;
 }
 
 export function DetailsTimeline({monitor, onStatsLoaded}: Props) {

--- a/tests/js/fixtures/detectors.ts
+++ b/tests/js/fixtures/detectors.ts
@@ -1,5 +1,7 @@
+import {ActorFixture} from 'sentry-fixture/actor';
 import {DataConditionGroupFixture} from 'sentry-fixture/dataConditions';
 import {SimpleGroupFixture} from 'sentry-fixture/group';
+import {ProjectFixture} from 'sentry-fixture/project';
 import {UserFixture} from 'sentry-fixture/user';
 
 import type {
@@ -159,6 +161,11 @@ export function CronMonitorDataSourceFixture(
     sourceId: '1',
     type: 'cron_monitor',
     queryObj: {
+      id: 'uuid-foo',
+      name: 'Test Monitor',
+      dateCreated: '2023-01-01T00:00:00Z',
+      owner: ActorFixture(),
+      project: ProjectFixture(),
       config: {
         checkin_margin: null,
         failure_issue_threshold: 1,


### PR DESCRIPTION
The `queryObj` is nearly the same as the existing cron `Monitor` type, which make reusing this chart very simple

<img width="852" height="389" alt="CleanShot 2025-09-05 at 15 15 55" src="https://github.com/user-attachments/assets/e9207cf7-b291-4f04-941b-dfe9c82d274f" />
