### PR TITLE
chore(ACI): Log aggregation value and trigger id

### DIFF
--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -357,6 +357,8 @@ class SubscriptionProcessor:
                             "detector_id": detector.id,
                             "organization_id": self.subscription.project.organization.id,
                             "project_id": self.subscription.project.id,
+                            "aggregation_value": aggregation_value,
+                            "trigger_id": trigger.id,
                         },
                     )
                 if not metrics_incremented:
@@ -387,6 +389,8 @@ class SubscriptionProcessor:
                             "detector_id": detector.id,
                             "organization_id": self.subscription.project.organization.id,
                             "project_id": self.subscription.project.id,
+                            "aggregation_value": aggregation_value,
+                            "trigger_id": trigger.id,
                         },
                     )
                 metrics.incr("dual_processing.alert_rules.resolve")

--- a/tests/sentry/incidents/subscription_processor/test_subscription_processor_workflow_engine.py
+++ b/tests/sentry/incidents/subscription_processor/test_subscription_processor_workflow_engine.py
@@ -71,6 +71,8 @@ class ProcessUpdateWorkflowEngineTest(ProcessUpdateComparisonAlertTest):
             "detector_id": detector.id,
             "organization_id": rule.organization_id,
             "project_id": self.project.id,
+            "aggregation_value": trigger.alert_threshold + 1,
+            "trigger_id": trigger.id,
         }
         mock_logger.info.assert_any_call(
             "subscription_processor.alert_triggered",


### PR DESCRIPTION
We ran into an inconsistency where we are seemingly falling into the code block that writes a log when we trigger an alert when we already have an active trigger. This PR adds additional fields to the logs to help investigate further - I want to know if the aggregation value is in fact continuing to be above the trigger threshold. 