### PR TITLE
feat(thread-leaks): Silences Django dev server thread leaks

### DIFF
--- a/src/sentry/testutils/thread_leaks/pytest.py
+++ b/src/sentry/testutils/thread_leaks/pytest.py
@@ -35,15 +35,17 @@ def pytest_runtest_call(item: pytest.Item) -> Generator[dict[str, Any]]:
 
         # TODO(DI-1282): ignoring all leaks involving this thread, issue is too widespread to use allowlist marks.
         # actual fix must be implemented. see issue #98988
-        is_dev_server_thread_leak = any(
-            get_thread_function_name(thread)
-            == "django.core.servers.basehttp.ThreadedWSGIServer.process_request_thread"
+        filtered_thread_leaks = {
+            thread
             for thread in error.thread_leaks
-        )
-        if is_dev_server_thread_leak:
-            return result
+            if get_thread_function_name(thread)
+            != "django.core.servers.basehttp.ThreadedWSGIServer.process_request_thread"
+        }
 
-        result["events"] = sentry.capture_event(error.thread_leaks, STRICT, allowlisted, item)
+        if filtered_thread_leaks:
+            result["events"] = sentry.capture_event(
+                filtered_thread_leaks, STRICT, allowlisted, item
+            )
 
-        if STRICT and not allowlisted:
+        if STRICT and not allowlisted and filtered_thread_leaks:
             raise

--- a/src/sentry/testutils/thread_leaks/pytest.py
+++ b/src/sentry/testutils/thread_leaks/pytest.py
@@ -7,6 +7,7 @@ from typing import Any
 import pytest
 
 from . import sentry
+from ._threading import get_thread_function_name
 from .assertion import ThreadLeakAssertionError, assert_none
 
 
@@ -31,6 +32,17 @@ def pytest_runtest_call(item: pytest.Item) -> Generator[dict[str, Any]]:
             yield result
     except ThreadLeakAssertionError as error:
         allowlisted = item.get_closest_marker("thread_leak_allowlist")
+
+        # TODO(DI-1282): ignoring all leaks involving this thread, issue is too widespread to use allowlist marks.
+        # actual fix must be implemented. see issue #98988
+        is_dev_server_thread_leak = any(
+            get_thread_function_name(thread)
+            == "django.core.servers.basehttp.ThreadedWSGIServer.process_request_thread"
+            for thread in error.thread_leaks
+        )
+        if is_dev_server_thread_leak:
+            return result
+
         result["events"] = sentry.capture_event(error.thread_leaks, STRICT, allowlisted, item)
 
         if STRICT and not allowlisted:


### PR DESCRIPTION
Ignore my mistake in the branch name 😓 

Silences Sentry errors and test failures for thread leaks regarding Django dev server.

This problem is too widespread to be solved with marks, so we temporarily silence these leaks while we work on a permanent fix.

Related: #98988 and https://linear.app/getsentry/issue/DI-1282/thread-leak-in-test-django-dev-server