### PR TITLE
Fix probabilistic auth header omission for seer api

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3023,12 +3023,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Controls the rate of using the sentry api shared secret for communicating to sentry.
-register(
-    "seer.api.use-shared-secret",
-    default=0.0,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 register(
     "similarity.backfill_nodestore_use_multithread",

--- a/src/sentry/seer/signed_seer_api.py
+++ b/src/sentry/seer/signed_seer_api.py
@@ -1,7 +1,6 @@
 import hashlib
 import hmac
 import logging
-from random import random
 from typing import Any
 from urllib.parse import urlparse
 
@@ -55,16 +54,15 @@ def make_signed_seer_api_request(
 
 def sign_with_seer_secret(body: bytes) -> dict[str, str]:
     auth_headers: dict[str, str] = {}
-    if random() < options.get("seer.api.use-shared-secret"):
-        if settings.SEER_API_SHARED_SECRET:
-            signature = hmac.new(
-                settings.SEER_API_SHARED_SECRET.encode("utf-8"),
-                body,
-                hashlib.sha256,
-            ).hexdigest()
-            auth_headers["Authorization"] = f"Rpcsignature rpc0:{signature}"
-        else:
-            logger.warning(
-                "Seer.api.use-shared-secret is set but secret is not set. Unable to add auth headers for call to Seer."
-            )
+    if settings.SEER_API_SHARED_SECRET:
+        signature = hmac.new(
+            settings.SEER_API_SHARED_SECRET.encode("utf-8"),
+            body,
+            hashlib.sha256,
+        ).hexdigest()
+        auth_headers["Authorization"] = f"Rpcsignature rpc0:{signature}"
+    else:
+        logger.warning(
+            "SEER_API_SHARED_SECRET is not set. Unable to add auth headers for call to Seer."
+        )
     return auth_headers

--- a/tests/sentry/event_manager/test_severity.py
+++ b/tests/sentry/event_manager/test_severity.py
@@ -78,10 +78,7 @@ class TestGetEventSeverity(TestCase):
         assert reason == "ml"
         assert cache.get(SEER_ERROR_COUNT_KEY) == 0
 
-        with (
-            override_options({"seer.api.use-shared-secret": 1.0}),
-            override_settings(SEER_API_SHARED_SECRET="some-secret"),
-        ):
+        with override_settings(SEER_API_SHARED_SECRET="some-secret"):
             _get_severity_score(event)
             mock_urlopen.assert_called_with(
                 "POST",

--- a/tests/sentry/seer/test_signed_seer_api.py
+++ b/tests/sentry/seer/test_signed_seer_api.py
@@ -42,7 +42,10 @@ def test_simple() -> None:
         "POST",
         PATH,
         body=REQUEST_BODY,
-        headers={"content-type": "application/json;charset=utf-8"},
+        headers={
+            "content-type": "application/json;charset=utf-8",
+            "Authorization": "Rpcsignature rpc0:d2e6070dfab955db6fc9f3bc0518f75f27ca93ae2e393072929e5f6cba26ff07",
+        },
     )
 
 
@@ -53,7 +56,10 @@ def test_uses_given_timeout() -> None:
         "POST",
         PATH,
         body=REQUEST_BODY,
-        headers={"content-type": "application/json;charset=utf-8"},
+        headers={
+            "content-type": "application/json;charset=utf-8",
+            "Authorization": "Rpcsignature rpc0:d2e6070dfab955db6fc9f3bc0518f75f27ca93ae2e393072929e5f6cba26ff07",
+        },
         timeout=5,
     )
 
@@ -65,37 +71,24 @@ def test_uses_given_retries() -> None:
         "POST",
         PATH,
         body=REQUEST_BODY,
-        headers={"content-type": "application/json;charset=utf-8"},
+        headers={
+            "content-type": "application/json;charset=utf-8",
+            "Authorization": "Rpcsignature rpc0:d2e6070dfab955db6fc9f3bc0518f75f27ca93ae2e393072929e5f6cba26ff07",
+        },
         retries=5,
     )
 
 
 @pytest.mark.django_db
-def test_uses_shared_secret() -> None:
-    with override_options({"seer.api.use-shared-secret": 1.0}):
-        mock_url_open = run_test_case()
-        mock_url_open.assert_called_once_with(
-            "POST",
-            PATH,
-            body=REQUEST_BODY,
-            headers={
-                "content-type": "application/json;charset=utf-8",
-                "Authorization": "Rpcsignature rpc0:d2e6070dfab955db6fc9f3bc0518f75f27ca93ae2e393072929e5f6cba26ff07",
-            },
-        )
+def test_missing_shared_secret() -> None:
+    mock_url_open = run_test_case(shared_secret="")
 
-
-@pytest.mark.django_db
-def test_uses_shared_secret_missing_secret() -> None:
-    with override_options({"seer.api.use-shared-secret": 1.0}):
-        mock_url_open = run_test_case(shared_secret="")
-
-        mock_url_open.assert_called_once_with(
-            "POST",
-            PATH,
-            body=REQUEST_BODY,
-            headers={"content-type": "application/json;charset=utf-8"},
-        )
+    mock_url_open.assert_called_once_with(
+        "POST",
+        PATH,
+        body=REQUEST_BODY,
+        headers={"content-type": "application/json;charset=utf-8"},
+    )
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
<!-- Describe your PR here. -->
Fixes an issue where Sentry's Seer API requests would probabilistically omit authentication headers, leading to "No auth header found" errors.

The `sign_with_seer_secret` function no longer uses a probabilistic check (`random() < options.get("seer.api.use-shared-secret")`) to decide whether to include the `Authorization` header. Instead, it now **always** includes the header when `settings.SEER_API_SHARED_SECRET` is configured.

This change ensures consistent authentication for all Seer API calls, preventing intermittent failures.

**Key changes:**
*   Removed probabilistic logic from `sign_with_seer_secret`.
*   Ensured authentication headers are always added when `SEER_API_SHARED_SECRET` is set.
*   Updated relevant tests to reflect the non-probabilistic behavior.
*   Removed the deprecated `seer.api.use-shared-secret` option from defaults.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
<a href="https://cursor.com/background-agent?bcId=bc-f2f4a2bc-2a70-4415-8a11-f1b0471b0e26">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f2f4a2bc-2a70-4415-8a11-f1b0471b0e26">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

