### PR TITLE
Fix probabilistic auth header omission for seer api

### DIFF
--- a/tests/sentry/seer/test_signed_seer_api.py
+++ b/tests/sentry/seer/test_signed_seer_api.py
@@ -42,7 +42,10 @@ def test_simple() -> None:
         "POST",
         PATH,
         body=REQUEST_BODY,
-        headers={"content-type": "application/json;charset=utf-8"},
+        headers={
+            "content-type": "application/json;charset=utf-8",
+            "Authorization": "Rpcsignature rpc0:d2e6070dfab955db6fc9f3bc0518f75f27ca93ae2e393072929e5f6cba26ff07",
+        },
     )
 
 
@@ -53,7 +56,10 @@ def test_uses_given_timeout() -> None:
         "POST",
         PATH,
         body=REQUEST_BODY,
-        headers={"content-type": "application/json;charset=utf-8"},
+        headers={
+            "content-type": "application/json;charset=utf-8",
+            "Authorization": "Rpcsignature rpc0:d2e6070dfab955db6fc9f3bc0518f75f27ca93ae2e393072929e5f6cba26ff07",
+        },
         timeout=5,
     )
 
@@ -65,7 +71,10 @@ def test_uses_given_retries() -> None:
         "POST",
         PATH,
         body=REQUEST_BODY,
-        headers={"content-type": "application/json;charset=utf-8"},
+        headers={
+            "content-type": "application/json;charset=utf-8",
+            "Authorization": "Rpcsignature rpc0:d2e6070dfab955db6fc9f3bc0518f75f27ca93ae2e393072929e5f6cba26ff07",
+        },
         retries=5,
     )
 
@@ -73,6 +82,34 @@ def test_uses_given_retries() -> None:
 @pytest.mark.django_db
 def test_uses_shared_secret() -> None:
     with override_options({"seer.api.use-shared-secret": 1.0}):
+        mock_url_open = run_test_case()
+        mock_url_open.assert_called_once_with(
+            "POST",
+            PATH,
+            body=REQUEST_BODY,
+            headers={
+                "content-type": "application/json;charset=utf-8",
+                "Authorization": "Rpcsignature rpc0:d2e6070dfab955db6fc9f3bc0518f75f27ca93ae2e393072929e5f6cba26ff07",
+            },
+        )
+
+
+@pytest.mark.django_db
+def test_no_auth_when_secret_missing() -> None:
+    mock_url_open = run_test_case(shared_secret="")
+    mock_url_open.assert_called_once_with(
+        "POST",
+        PATH,
+        body=REQUEST_BODY,
+        headers={"content-type": "application/json;charset=utf-8"},
+    )
+
+
+@pytest.mark.django_db
+def test_always_uses_auth_when_secret_available() -> None:
+    """Test that auth headers are always included when secret is available, regardless of probabilistic setting."""
+    # Test with probabilistic setting at 0.0 (should still include auth)
+    with override_options({"seer.api.use-shared-secret": 0.0}):
         mock_url_open = run_test_case()
         mock_url_open.assert_called_once_with(
             "POST",


### PR DESCRIPTION
<!-- Describe your PR here. -->
Fixes an issue where requests to the Seer API for similar issues would sometimes fail due to missing authentication headers.

The `sign_with_seer_secret` function previously used a probabilistic check (`random() < options.get("seer.api.use-shared-secret")`) to determine if an `Authorization` header should be added. This meant that if `seer.api.use-shared-secret` was less than 1.0, some requests would be sent without the required header, leading to "No auth header found" errors from Seer.

This PR changes the logic to always include the `Authorization` header if `settings.SEER_API_SHARED_SECRET` is configured. The `seer.api.use-shared-secret` option now primarily controls logging/warning behavior when the secret is missing, rather than the presence of the header itself.

Updated existing tests and added new ones to reflect this deterministic authentication behavior.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
<a href="https://cursor.com/background-agent?bcId=bc-9ffa853a-b22f-4ca4-90e0-5fa2f49b3710">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9ffa853a-b22f-4ca4-90e0-5fa2f49b3710">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

