### PR TITLE
fix(codeowners): handle multiple external actor to same sentry team

### DIFF
--- a/src/sentry/api/validators/project_codeowners.py
+++ b/src/sentry/api/validators/project_codeowners.py
@@ -82,8 +82,8 @@ def validate_codeowners_associations(
     users_without_access = []
     users_without_access_external_names = []
 
-    team_ids_to_external_names: Mapping[int, list[str]] = {}
-    user_ids_to_external_names: Mapping[int, list[str]] = {}
+    team_ids_to_external_names: dict[int, list[str]] = {}
+    user_ids_to_external_names: dict[int, list[str]] = {}
 
     for xa in external_actors:
         if xa.team_id is not None:

--- a/src/sentry/api/validators/project_codeowners.py
+++ b/src/sentry/api/validators/project_codeowners.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections import defaultdict
 from collections.abc import Collection, Mapping, Sequence
 from functools import reduce
 from operator import or_
@@ -82,8 +83,8 @@ def validate_codeowners_associations(
     users_without_access = []
     users_without_access_external_names = []
 
-    team_ids_to_external_names: dict[int, list[str]] = {team_id: [] for team_id in team_names}
-    user_ids_to_external_names: dict[int, list[str]] = {user_id: [] for user_id in usernames}
+    team_ids_to_external_names: dict[int, list[str]] = defaultdict(list)
+    user_ids_to_external_names: dict[int, list[str]] = defaultdict(list)
 
     for xa in external_actors:
         if xa.team_id is not None:

--- a/src/sentry/api/validators/project_codeowners.py
+++ b/src/sentry/api/validators/project_codeowners.py
@@ -82,20 +82,22 @@ def validate_codeowners_associations(
     users_without_access = []
     users_without_access_external_names = []
 
-    team_ids_to_external_names: Mapping[int, list[str]] = {
-        xa.team_id: list(
-            filter(lambda team_name: team_name.lower() == xa.external_name.lower(), team_names)
-        )
-        for xa in external_actors
-        if xa.team_id is not None
-    }
-    user_ids_to_external_names: Mapping[int, list[str]] = {
-        xa.user_id: list(
-            filter(lambda username: username.lower() == xa.external_name.lower(), usernames)
-        )
-        for xa in external_actors
-        if xa.user_id is not None
-    }
+    team_ids_to_external_names: Mapping[int, list[str]] = {}
+    user_ids_to_external_names: Mapping[int, list[str]] = {}
+
+    for xa in external_actors:
+        if xa.team_id is not None:
+            if xa.team_id not in team_ids_to_external_names:
+                team_ids_to_external_names[xa.team_id] = []
+            team_ids_to_external_names[xa.team_id].extend(
+                filter(lambda team_name: team_name.lower() == xa.external_name.lower(), team_names)
+            )
+        if xa.user_id is not None:
+            if xa.user_id not in user_ids_to_external_names:
+                user_ids_to_external_names[xa.user_id] = []
+            user_ids_to_external_names[xa.user_id].extend(
+                filter(lambda username: username.lower() == xa.external_name.lower(), usernames)
+            )
 
     for user in user_service.get_many(
         filter=dict(user_ids=list(user_ids_to_external_names.keys()))

--- a/src/sentry/api/validators/project_codeowners.py
+++ b/src/sentry/api/validators/project_codeowners.py
@@ -82,19 +82,15 @@ def validate_codeowners_associations(
     users_without_access = []
     users_without_access_external_names = []
 
-    team_ids_to_external_names: dict[int, list[str]] = {}
-    user_ids_to_external_names: dict[int, list[str]] = {}
+    team_ids_to_external_names: dict[int, list[str]] = {team_id: [] for team_id in team_names}
+    user_ids_to_external_names: dict[int, list[str]] = {user_id: [] for user_id in usernames}
 
     for xa in external_actors:
         if xa.team_id is not None:
-            if xa.team_id not in team_ids_to_external_names:
-                team_ids_to_external_names[xa.team_id] = []
             team_ids_to_external_names[xa.team_id].extend(
                 filter(lambda team_name: team_name.lower() == xa.external_name.lower(), team_names)
             )
         if xa.user_id is not None:
-            if xa.user_id not in user_ids_to_external_names:
-                user_ids_to_external_names[xa.user_id] = []
             user_ids_to_external_names[xa.user_id].extend(
                 filter(lambda username: username.lower() == xa.external_name.lower(), usernames)
             )


### PR DESCRIPTION
Old codeowner association logic before https://github.com/getsentry/sentry/pull/98668 assumed that for each team, we had a 1-1 mapping between teams and external teams. This wasn't correct, since we can have multiple external team names map to the same sentry team — for example https://github.com/getsentry/sentry/pull/98668 fixed the case with case-sensitivity, where `@getsentry/issue-detection-backend` and `@getsentry/ISSUE-DETECTION-BACKEND` can both be mapped to a single sentry team with 1 ExternalActor record. 

However, this wasn't fixed for a case in which you have multiple ExternalActor records that map to the same sentry team:
<img width="1191" height="125" alt="Screenshot 2025-09-05 at 3 59 11 PM" src="https://github.com/user-attachments/assets/d582a34d-3db0-42f3-83c6-4c7727c244a5" />
In this case, we would randomly pick one record to honor — so any codeowner rules that mention `@charlieluo/test` would be ignored while `@charlieluo/Test1` would work. This fixes the issue by compiling **all** associations between a sentry team_id and external names
