### PR TITLE
feat(preprod): improve treemap searching

### DIFF
--- a/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
+++ b/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
@@ -73,22 +73,38 @@ export function BuildDetailsMainContent(props: BuildDetailsMainContentProps) {
     Object.keys(appSizeData.treemap.category_breakdown).length > 0;
 
   // Filter data based on search query
-  const filteredTreemapData = {
-    ...appSizeData.treemap,
-    root: filterTreemapElement(appSizeData.treemap.root, searchQuery || '', ''),
-  };
+  const filteredRoot = filterTreemapElement(
+    appSizeData.treemap.root,
+    searchQuery || '',
+    ''
+  );
+  const filteredTreemapData = filteredRoot
+    ? {
+        ...appSizeData.treemap,
+        root: filteredRoot,
+      }
+    : null;
 
   let visualizationContent: React.ReactNode;
   if (categoriesEnabled) {
     visualizationContent =
       selectedContent === 'treemap' ? (
-        <AppSizeTreemap root={filteredTreemapData.root} searchQuery={searchQuery || ''} />
+        filteredTreemapData ? (
+          <AppSizeTreemap
+            root={filteredTreemapData.root}
+            searchQuery={searchQuery || ''}
+          />
+        ) : (
+          <Alert type="info">No files found matching "{searchQuery}"</Alert>
+        )
       ) : (
         <AppSizeCategories treemapData={appSizeData.treemap} />
       );
   } else {
-    visualizationContent = (
+    visualizationContent = filteredTreemapData ? (
       <AppSizeTreemap root={filteredTreemapData.root} searchQuery={searchQuery || ''} />
+    ) : (
+      <Alert type="info">No files found matching "{searchQuery}"</Alert>
     );
   }
 

--- a/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
+++ b/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
@@ -75,7 +75,7 @@ export function BuildDetailsMainContent(props: BuildDetailsMainContentProps) {
   // Filter data based on search query
   const filteredTreemapData = {
     ...appSizeData.treemap,
-    root: filterTreemapElement(appSizeData.treemap.root, searchQuery || ''),
+    root: filterTreemapElement(appSizeData.treemap.root, searchQuery || '', ''),
   };
 
   let visualizationContent: React.ReactNode;

--- a/static/app/views/preprod/utils/treemapFiltering.spec.tsx
+++ b/static/app/views/preprod/utils/treemapFiltering.spec.tsx
@@ -1,73 +1,7 @@
 import type {TreemapElement} from 'sentry/views/preprod/types/appSizeTypes';
 import {TreemapType} from 'sentry/views/preprod/types/appSizeTypes';
 
-import {filterTreemapElement, nodeNameMatchesSearchTerm} from './treemapFiltering';
-
-describe('nodeNameMatchesSearchTerm', () => {
-  it('returns true when no search term is provided', () => {
-    expect(nodeNameMatchesSearchTerm('file.js', '/src', '')).toBe(true);
-    expect(nodeNameMatchesSearchTerm('file.js', '/src', null)).toBe(true);
-    expect(nodeNameMatchesSearchTerm('file.js', '/src', undefined)).toBe(true);
-  });
-
-  it('performs simple name matching', () => {
-    expect(nodeNameMatchesSearchTerm('myFile.js', '/src', 'file')).toBe(true);
-    expect(nodeNameMatchesSearchTerm('myFile.js', '/src', 'File')).toBe(true);
-    expect(nodeNameMatchesSearchTerm('myFile.js', '/src', 'xyz')).toBe(false);
-  });
-
-  it('handles backtick escaping (removes backticks but still partial matching)', () => {
-    expect(nodeNameMatchesSearchTerm('file.js', '/src', '`file.js`')).toBe(true);
-    expect(nodeNameMatchesSearchTerm('file.js', '/src', '`file`')).toBe(true);
-    expect(nodeNameMatchesSearchTerm('myfile.js', '/src', '`file.js`')).toBe(true); // backticks still allow partial matching
-    expect(nodeNameMatchesSearchTerm('file.js', '/src', '`file')).toBe(true);
-    expect(nodeNameMatchesSearchTerm('myfile.js', '/src', '`file`')).toBe(true); // backtick still allows partial matching
-  });
-
-  it('performs path-based searching', () => {
-    expect(nodeNameMatchesSearchTerm('file.js', '/src/components', 'src/file')).toBe(
-      true
-    );
-    expect(
-      nodeNameMatchesSearchTerm('file.js', '/src/components', 'components/file')
-    ).toBe(true);
-    expect(
-      nodeNameMatchesSearchTerm('file.js', '/src/components', 'src/components/file')
-    ).toBe(true);
-    expect(nodeNameMatchesSearchTerm('file.js', '/src/components', 'utils/file')).toBe(
-      false
-    );
-  });
-
-  it('handles path search with backticks', () => {
-    expect(
-      nodeNameMatchesSearchTerm('file.js', '/src/components', '`src/components/file`')
-    ).toBe(true);
-    expect(
-      nodeNameMatchesSearchTerm('file.js', '/src/components', '`components/file`')
-    ).toBe(true);
-    expect(
-      nodeNameMatchesSearchTerm('otherfile.js', '/src/components', '`components/file`')
-    ).toBe(true); // backticks still allow partial matching - otherfile.js contains "file"
-  });
-
-  it('matches partial path segments in order', () => {
-    expect(
-      nodeNameMatchesSearchTerm(
-        'index.js',
-        '/app/src/components/button',
-        'src/comp/index'
-      )
-    ).toBe(true);
-    expect(
-      nodeNameMatchesSearchTerm(
-        'index.js',
-        '/app/src/components/button',
-        'comp/src/index'
-      )
-    ).toBe(false);
-  });
-});
+import {filterTreemapElement} from './treemapFiltering';
 
 describe('filterTreemapElement', () => {
   const createMockElement = (

--- a/static/app/views/preprod/utils/treemapFiltering.spec.tsx
+++ b/static/app/views/preprod/utils/treemapFiltering.spec.tsx
@@ -1,61 +1,351 @@
-import {TreemapElementFixture} from 'sentry-fixture/preProdAppSize';
+import type {TreemapElement} from 'sentry/views/preprod/types/appSizeTypes';
+import {TreemapType} from 'sentry/views/preprod/types/appSizeTypes';
 
-import {filterTreemapElement} from './treemapFiltering';
+import {filterTreemapElement, nodeNameMatchesSearchTerm} from './treemapFiltering';
 
-describe('treemapFiltering', () => {
-  describe('filterTreemapElement', () => {
-    it('returns original element when search query is empty', () => {
-      const treemapElement = TreemapElementFixture();
-      const result = filterTreemapElement(treemapElement, '');
-      expect(result).toEqual(treemapElement);
-    });
+describe('nodeNameMatchesSearchTerm', () => {
+  it('returns true when no search term is provided', () => {
+    expect(nodeNameMatchesSearchTerm('file.js', '/src', '')).toBe(true);
+    expect(nodeNameMatchesSearchTerm('file.js', '/src', null)).toBe(true);
+    expect(nodeNameMatchesSearchTerm('file.js', '/src', undefined)).toBe(true);
+  });
 
-    it('returns original element when search query is only whitespace', () => {
-      const treemapElement = TreemapElementFixture();
-      const result = filterTreemapElement(treemapElement, '   ');
-      expect(result).toEqual(treemapElement);
-    });
+  it('performs simple name matching', () => {
+    expect(nodeNameMatchesSearchTerm('myFile.js', '/src', 'file')).toBe(true);
+    expect(nodeNameMatchesSearchTerm('myFile.js', '/src', 'File')).toBe(true);
+    expect(nodeNameMatchesSearchTerm('myFile.js', '/src', 'xyz')).toBe(false);
+  });
 
-    it('filters by file name', () => {
-      const treemapElement = TreemapElementFixture();
-      const result = filterTreemapElement(treemapElement, 'main');
-      expect(result).toBeTruthy();
-      expect(result?.children).toHaveLength(1);
-      expect(result?.children[0]!.name).toBe('src');
-      expect(result?.children[0]!.children).toHaveLength(1);
-      expect(result?.children[0]!.children[0]!.name).toBe('main.js');
-    });
+  it('handles backtick escaping (removes backticks but still partial matching)', () => {
+    expect(nodeNameMatchesSearchTerm('file.js', '/src', '`file.js`')).toBe(true);
+    expect(nodeNameMatchesSearchTerm('file.js', '/src', '`file`')).toBe(true);
+    expect(nodeNameMatchesSearchTerm('myfile.js', '/src', '`file.js`')).toBe(true); // backticks still allow partial matching
+    expect(nodeNameMatchesSearchTerm('file.js', '/src', '`file')).toBe(true);
+    expect(nodeNameMatchesSearchTerm('myfile.js', '/src', '`file`')).toBe(true); // backtick still allows partial matching
+  });
 
-    it('filters by path', () => {
-      const treemapElement = TreemapElementFixture();
-      const result = filterTreemapElement(treemapElement, 'utils.js');
-      expect(result).toBeTruthy();
-      expect(result?.children).toHaveLength(1);
-      expect(result?.children[0]!.name).toBe('src');
-      expect(result?.children[0]!.children).toHaveLength(1);
-      expect(result?.children[0]!.children[0]!.name).toBe('utils.js');
-    });
+  it('performs path-based searching', () => {
+    expect(nodeNameMatchesSearchTerm('file.js', '/src/components', 'src/file')).toBe(
+      true
+    );
+    expect(
+      nodeNameMatchesSearchTerm('file.js', '/src/components', 'components/file')
+    ).toBe(true);
+    expect(
+      nodeNameMatchesSearchTerm('file.js', '/src/components', 'src/components/file')
+    ).toBe(true);
+    expect(nodeNameMatchesSearchTerm('file.js', '/src/components', 'utils/file')).toBe(
+      false
+    );
+  });
 
-    it('filters case-insensitively', () => {
-      const treemapElement = TreemapElementFixture();
-      const result = filterTreemapElement(treemapElement, 'MAIN');
-      expect(result).toBeTruthy();
-      expect(result?.children).toHaveLength(1);
-      expect(result?.children[0]!.children[0]!.name).toBe('main.js');
-    });
+  it('handles path search with backticks', () => {
+    expect(
+      nodeNameMatchesSearchTerm('file.js', '/src/components', '`src/components/file`')
+    ).toBe(true);
+    expect(
+      nodeNameMatchesSearchTerm('file.js', '/src/components', '`components/file`')
+    ).toBe(true);
+    expect(
+      nodeNameMatchesSearchTerm('otherfile.js', '/src/components', '`components/file`')
+    ).toBe(true); // backticks still allow partial matching - otherfile.js contains "file"
+  });
 
-    it('returns null when no matches found', () => {
-      const treemapElement = TreemapElementFixture();
-      const result = filterTreemapElement(treemapElement, 'nonexistent');
-      expect(result).toBeNull();
-    });
+  it('matches partial path segments in order', () => {
+    expect(
+      nodeNameMatchesSearchTerm(
+        'index.js',
+        '/app/src/components/button',
+        'src/comp/index'
+      )
+    ).toBe(true);
+    expect(
+      nodeNameMatchesSearchTerm(
+        'index.js',
+        '/app/src/components/button',
+        'comp/src/index'
+      )
+    ).toBe(false);
+  });
+});
 
-    it('includes parent directories when children match', () => {
-      const treemapElement = TreemapElementFixture();
-      const result = filterTreemapElement(treemapElement, 'main.js');
-      expect(result).toBeTruthy();
-      expect(result?.name).toBe('root');
-      expect(result?.children[0]!.name).toBe('src');
-    });
+describe('filterTreemapElement', () => {
+  const createMockElement = (
+    name: string,
+    children: TreemapElement[] = []
+  ): TreemapElement => ({
+    name,
+    size: 100,
+    is_dir: children.length > 0,
+    type: TreemapType.FILES,
+    children,
+    path: name,
+  });
+
+  it('returns original element when no search query', () => {
+    const element = createMockElement('root', [
+      createMockElement('child1'),
+      createMockElement('child2'),
+    ]);
+
+    const result = filterTreemapElement(element, '');
+    expect(result).toBe(element);
+  });
+
+  it('filters elements by name', () => {
+    const element = createMockElement('root', [
+      createMockElement('match.js'),
+      createMockElement('different.css'),
+    ]);
+
+    const result = filterTreemapElement(element, 'match');
+    expect(result?.children).toHaveLength(1);
+    expect(result?.children[0]?.name).toBe('match.js');
+  });
+
+  it('includes parent when child matches', () => {
+    const element = createMockElement('root', [
+      createMockElement('parent', [
+        createMockElement('match.js'),
+        createMockElement('different.css'),
+      ]),
+    ]);
+
+    const result = filterTreemapElement(element, 'match');
+    expect(result?.children).toHaveLength(1);
+    expect(result?.children[0]?.name).toBe('parent');
+    expect(result?.children[0]?.children).toHaveLength(1);
+    expect(result?.children[0]?.children[0]?.name).toBe('match.js');
+  });
+
+  it('includes all children when parent matches (regular search)', () => {
+    const element = createMockElement('root', [
+      createMockElement('sentry', [
+        createMockElement('component1.js'),
+        createMockElement('component2.js'),
+        createMockElement('utils.js'),
+      ]),
+      createMockElement('other', [createMockElement('file.js')]),
+    ]);
+
+    const result = filterTreemapElement(element, 'sentry');
+    expect(result?.children).toHaveLength(1);
+    expect(result?.children[0]?.name).toBe('sentry');
+    // Should include ALL children of the matching parent
+    expect(result?.children[0]?.children).toHaveLength(3);
+    expect(result?.children[0]?.children.map(c => c.name)).toEqual([
+      'component1.js',
+      'component2.js',
+      'utils.js',
+    ]);
+  });
+
+  it('filters children when using exact search with double backticks', () => {
+    const element = createMockElement('root', [
+      createMockElement('sentry', [
+        createMockElement('component1.js'),
+        createMockElement('component2.js'),
+        createMockElement('utils.js'),
+      ]),
+      createMockElement('other', [createMockElement('file.js')]),
+    ]);
+
+    const result = filterTreemapElement(element, '`sentry`');
+    expect(result?.children).toHaveLength(1);
+    expect(result?.children[0]?.name).toBe('sentry');
+    // With exact search, should filter children recursively (none match 'sentry')
+    expect(result?.children[0]?.children).toHaveLength(0);
+  });
+
+  it('handles path-based searching in nested structure', () => {
+    const element = createMockElement('root', [
+      createMockElement('src', [
+        createMockElement('components', [createMockElement('button.js')]),
+        createMockElement('utils', [createMockElement('helper.js')]),
+      ]),
+    ]);
+
+    const result = filterTreemapElement(element, 'src/comp/button');
+    expect(result?.children).toHaveLength(1);
+    expect(result?.children[0]?.name).toBe('src');
+    expect(result?.children[0]?.children).toHaveLength(1);
+    expect(result?.children[0]?.children[0]?.name).toBe('components');
+    expect(result?.children[0]?.children[0]?.children).toHaveLength(1);
+    expect(result?.children[0]?.children[0]?.children[0]?.name).toBe('button.js');
+  });
+
+  it('returns null when no matches found', () => {
+    const element = createMockElement('root', [
+      createMockElement('nomatch1.js'),
+      createMockElement('nomatch2.css'),
+    ]);
+
+    const result = filterTreemapElement(element, 'nonexistent');
+    expect(result).toBeNull();
+  });
+
+  it('regular search - should only return matching children', () => {
+    const element = createMockElement('root', [
+      createMockElement('match.js'),
+      createMockElement('different.css'),
+      createMockElement('another-match.ts'),
+    ]);
+
+    const result = filterTreemapElement(element, 'match');
+    expect(result?.children).toHaveLength(2);
+    expect(result?.children.map(c => c.name)).toEqual(['match.js', 'another-match.ts']);
+  });
+
+  it('regular search - should include all children when parent directory matches', () => {
+    const element = createMockElement('root', [
+      createMockElement('sentry-folder', [
+        createMockElement('component1.js'),
+        createMockElement('component2.js'),
+        createMockElement('utils.js'),
+      ]),
+      createMockElement('other-folder', [createMockElement('file.js')]),
+    ]);
+
+    const result = filterTreemapElement(element, 'sentry');
+    expect(result?.children).toHaveLength(1);
+    expect(result?.children[0]?.name).toBe('sentry-folder');
+    // When parent matches, should include ALL its children
+    expect(result?.children[0]?.children).toHaveLength(3);
+    expect(result?.children[0]?.children.map(c => c.name)).toEqual([
+      'component1.js',
+      'component2.js',
+      'utils.js',
+    ]);
+  });
+
+  it('searching HackerNews should only return HackerNews related nodes', () => {
+    const element = createMockElement('root', [
+      createMockElement('App', [
+        createMockElement('HackerNews.framework', [
+          createMockElement('HackerNews'),
+          createMockElement('Info.plist'),
+        ]),
+        createMockElement('SomeOtherFramework', [createMockElement('OtherFile')]),
+      ]),
+      createMockElement('Libraries', [
+        createMockElement('libHackerNews.a'),
+        createMockElement('libOther.a'),
+      ]),
+      createMockElement('Resources', [
+        createMockElement('image.png'),
+        createMockElement('HackerNewsIcon.png'),
+      ]),
+    ]);
+
+    const result = filterTreemapElement(element, 'HackerNews');
+
+    // Should only include nodes that match or contain matching children
+    expect(result?.children).toHaveLength(3); // App, Libraries, Resources
+
+    // App folder should only contain HackerNews.framework
+    expect(result?.children[0]?.name).toBe('App');
+    expect(result?.children[0]?.children).toHaveLength(1);
+    expect(result?.children[0]?.children[0]?.name).toBe('HackerNews.framework');
+
+    // Libraries folder should only contain libHackerNews.a
+    expect(result?.children[1]?.name).toBe('Libraries');
+    expect(result?.children[1]?.children).toHaveLength(1);
+    expect(result?.children[1]?.children[0]?.name).toBe('libHackerNews.a');
+
+    // Resources folder should only contain HackerNewsIcon.png
+    expect(result?.children[2]?.name).toBe('Resources');
+    expect(result?.children[2]?.children).toHaveLength(1);
+    expect(result?.children[2]?.children[0]?.name).toBe('HackerNewsIcon.png');
+  });
+
+  it('filters to matching nodes only', () => {
+    const element = createMockElement('root', [
+      createMockElement('Payload', [
+        createMockElement('Applications', [
+          createMockElement('HackerNews.app', [createMockElement('Contents')]),
+        ]),
+      ]),
+      createMockElement('Frameworks', [
+        createMockElement('SomeFramework.framework', [createMockElement('SomeFile')]),
+      ]),
+    ]);
+
+    const result = filterTreemapElement(element, 'HackerNews');
+
+    expect(result?.children).toHaveLength(1);
+    expect(result?.children[0]?.name).toBe('Payload');
+    expect(result?.children[0]?.children).toHaveLength(1);
+    expect(result?.children[0]?.children[0]?.name).toBe('Applications');
+    expect(result?.children[0]?.children[0]?.children).toHaveLength(1);
+    expect(result?.children[0]?.children[0]?.children[0]?.name).toBe('HackerNews.app');
+  });
+
+  it('excludes unrelated top-level nodes', () => {
+    const element = createMockElement('root', [
+      createMockElement('Assets.car'),
+      createMockElement('HackerNews', [
+        createMockElement('__TEXT'),
+        createMockElement('__cstring'),
+        createMockElement('SwiftSoup'),
+      ]),
+      createMockElement('SwiftSoup', [
+        createMockElement('Element'),
+        createMockElement('Html'),
+      ]),
+      createMockElement('Swift'),
+      createMockElement('Plugins', [
+        createMockElement('HackerNewsHomeWidgetExtension.appex'),
+      ]),
+      createMockElement('Frameworks', [createMockElement('Common.framework')]),
+    ]);
+
+    const result = filterTreemapElement(element, 'HackerNews');
+
+    expect(result?.children?.length).toBe(2);
+    expect(result?.children?.map(c => c.name)).toEqual(['HackerNews', 'Plugins']);
+    expect(result?.children?.find(c => c.name === 'SwiftSoup')).toBeUndefined();
+    expect(result?.children?.find(c => c.name === 'Assets.car')).toBeUndefined();
+  });
+
+  it('filters children of app containers when app name matches search', () => {
+    const result = filterTreemapElement(
+      createMockElement('HackerNews.app', [
+        createMockElement('Contents', [
+          createMockElement('Frameworks', [
+            createMockElement('SomeUnrelatedFramework.framework'),
+          ]),
+          createMockElement('Resources', [createMockElement('unrelated-icon.png')]),
+        ]),
+      ]),
+      'HackerNews',
+      '/Applications'
+    );
+
+    expect(result).not.toBeNull();
+    expect(result?.name).toBe('HackerNews.app');
+    expect(result?.children).toHaveLength(0);
+  });
+
+  it('filters app container children when using root filtering', () => {
+    const element = createMockElement('root', [
+      createMockElement('Applications', [
+        createMockElement('HackerNews.app', [
+          createMockElement('Contents', [
+            createMockElement('Frameworks', [
+              createMockElement('SomeUnrelatedFramework.framework'),
+            ]),
+            createMockElement('Resources', [createMockElement('unrelated-icon.png')]),
+          ]),
+        ]),
+      ]),
+    ]);
+
+    const result = filterTreemapElement(element, 'HackerNews', '', true);
+
+    expect(result?.children).toHaveLength(1);
+    expect(result?.children[0]?.name).toBe('Applications');
+    expect(result?.children[0]?.children).toHaveLength(1);
+    expect(result?.children[0]?.children[0]?.name).toBe('HackerNews.app');
+    expect(result?.children[0]?.children[0]?.children).toHaveLength(0);
   });
 });

--- a/static/app/views/preprod/utils/treemapFiltering.spec.tsx
+++ b/static/app/views/preprod/utils/treemapFiltering.spec.tsx
@@ -340,12 +340,26 @@ describe('filterTreemapElement', () => {
       ]),
     ]);
 
-    const result = filterTreemapElement(element, 'HackerNews', '', true);
+    const result = filterTreemapElement(element, 'HackerNews', '');
 
     expect(result?.children).toHaveLength(1);
     expect(result?.children[0]?.name).toBe('Applications');
     expect(result?.children[0]?.children).toHaveLength(1);
     expect(result?.children[0]?.children[0]?.name).toBe('HackerNews.app');
     expect(result?.children[0]?.children[0]?.children).toHaveLength(0);
+  });
+
+  it('returns null when searching for completely non-existent terms', () => {
+    const element = createMockElement('root', [
+      createMockElement('App', [
+        createMockElement('HackerNews.app', [
+          createMockElement('Contents', [createMockElement('Frameworks')]),
+        ]),
+      ]),
+      createMockElement('Libraries', [createMockElement('libSomething.a')]),
+    ]);
+
+    const result = filterTreemapElement(element, 'asdfghijklskdjfgjsdjfgjsdjfgjkslkfgj');
+    expect(result).toBeNull();
   });
 });

--- a/static/app/views/preprod/utils/treemapFiltering.ts
+++ b/static/app/views/preprod/utils/treemapFiltering.ts
@@ -2,29 +2,91 @@ import type {TreemapElement} from 'sentry/views/preprod/types/appSizeTypes';
 
 export function filterTreemapElement(
   element: TreemapElement,
-  searchQuery: string
+  searchQuery: string,
+  parentPath = '',
+  isRoot = false
 ): TreemapElement | null {
   if (!searchQuery.trim()) {
     return element;
   }
 
-  const query = searchQuery.toLowerCase();
-  const matchesQuery = (name: string, path?: string) => {
-    const nameMatch = name.toLowerCase().includes(query);
-    const pathMatch = path?.toLowerCase().includes(query);
-    return nameMatch || pathMatch;
-  };
+  const currentPath = parentPath ? `${parentPath}/${element.name}` : element.name;
 
-  // Check if current element matches
-  const currentMatches = matchesQuery(element.name, element.path);
+  // Check if current element matches using enhanced search
+  // For root nodes, we don't check if the element itself matches - we always filter children
+  const currentMatches = isRoot
+    ? false
+    : nodeNameMatchesSearchTerm(element.name, parentPath, searchQuery);
 
-  // Filter children recursively
+  // Check if current element directly matches (not just path match)
+  const currentDirectlyMatches = isRoot
+    ? false
+    : nodeNameDirectlyMatches(element.name, searchQuery);
+
+  // Check if this is an exact match search (double backticks)
+  const isExactSearch = searchQuery.startsWith('`') && searchQuery.endsWith('`');
+
+  if (currentMatches) {
+    if (isExactSearch) {
+      // For exact searches, only include matching children
+      const filteredChildren = element.children
+        .map(child => filterTreemapElement(child, searchQuery, currentPath, false))
+        .filter((child): child is TreemapElement => child !== null);
+
+      return {
+        ...element,
+        children: filteredChildren,
+      };
+    }
+
+    if (currentDirectlyMatches) {
+      // For regular searches where the node name directly matches, we have special logic:
+      // App containers (like .app, .framework, .bundle) should filter their children
+      // to avoid showing unrelated content when the app name matches the search term.
+      // Regular folders should include all children as before.
+      const nodeName = element.name.toLowerCase();
+      const isAppContainer =
+        nodeName.endsWith('.app') ||
+        nodeName.endsWith('.framework') ||
+        nodeName.endsWith('.bundle') ||
+        nodeName.endsWith('.plugin');
+
+      if (isAppContainer) {
+        // App containers: filter children recursively to avoid showing unrelated content
+        const filteredChildren = element.children
+          .map(child => filterTreemapElement(child, searchQuery, currentPath, false))
+          .filter((child): child is TreemapElement => child !== null);
+
+        return {
+          ...element,
+          children: filteredChildren,
+        };
+      }
+      // Regular folders: include all children (traditional behavior)
+      return {
+        ...element,
+        children: [...element.children],
+      };
+    }
+
+    // For intermediate path matches, filter children recursively
+    const filteredChildren = element.children
+      .map(child => filterTreemapElement(child, searchQuery, currentPath))
+      .filter((child): child is TreemapElement => child !== null);
+
+    return {
+      ...element,
+      children: filteredChildren,
+    };
+  }
+
+  // If current element doesn't match, filter children recursively
   const filteredChildren = element.children
-    .map(child => filterTreemapElement(child, searchQuery))
+    .map(child => filterTreemapElement(child, searchQuery, currentPath))
     .filter((child): child is TreemapElement => child !== null);
 
-  // If current element matches or has matching children, include it
-  if (currentMatches || filteredChildren.length > 0) {
+  // Include element if it has matching children
+  if (filteredChildren.length > 0) {
     return {
       ...element,
       children: filteredChildren,
@@ -32,4 +94,75 @@ export function filterTreemapElement(
   }
 
   return null;
+}
+
+/**
+ * Checks if a node name matches the search term with enhanced features like
+ * backtick escaping and path-based searching.
+ */
+export function nodeNameMatchesSearchTerm(
+  nodeName: string,
+  parentPath: string,
+  searchTerm: string | null | undefined
+): boolean {
+  if (!searchTerm) {
+    return true;
+  }
+
+  let actualSearchTerm = searchTerm;
+
+  // Handle backtick escaping - just removes backticks like the original code
+  if (searchTerm.startsWith('`') && searchTerm.endsWith('`')) {
+    actualSearchTerm = searchTerm.substring(1, searchTerm.length - 1);
+  } else if (searchTerm.startsWith('`')) {
+    actualSearchTerm = searchTerm.substring(1);
+  }
+
+  if (!actualSearchTerm.includes('/')) {
+    // Non-path search - only match if the node name itself contains the search term
+    return nodeName.toLowerCase().includes(actualSearchTerm.toLowerCase());
+  }
+
+  // Path search - search across the full path
+  const searchTermParts = actualSearchTerm.split('/');
+  const fullPath = `${parentPath}/${nodeName}`.toLowerCase();
+  const pathItems = fullPath.split('/');
+
+  let pathStart = 0;
+  let matchCount = 0;
+
+  for (const searchPart of searchTermParts) {
+    for (let j = pathStart; j < pathItems.length; j++) {
+      if (pathItems[j].includes(searchPart.toLowerCase())) {
+        pathStart = j + 1;
+        matchCount += 1;
+        break;
+      }
+    }
+  }
+
+  return matchCount === searchTermParts.length;
+}
+
+/**
+ * Checks if a node name directly matches the search term (not just in its path).
+ * Used to distinguish between direct matches vs intermediate path matches.
+ */
+export function nodeNameDirectlyMatches(nodeName: string, searchTerm: string): boolean {
+  let actualSearchTerm = searchTerm;
+
+  // Handle backtick escaping
+  if (searchTerm.startsWith('`') && searchTerm.endsWith('`')) {
+    actualSearchTerm = searchTerm.substring(1, searchTerm.length - 1);
+  } else if (searchTerm.startsWith('`')) {
+    actualSearchTerm = searchTerm.substring(1);
+  }
+
+  // For direct matching, ignore path parts and just check the node name
+  if (actualSearchTerm.includes('/')) {
+    const lastPart = actualSearchTerm.split('/').pop() || '';
+    return nodeName.toLowerCase().includes(lastPart.toLowerCase());
+  }
+
+  return nodeName.toLowerCase().includes(actualSearchTerm.toLowerCase());
 }

--- a/tests/js/fixtures/preProdAppSize.ts
+++ b/tests/js/fixtures/preProdAppSize.ts
@@ -1,7 +1,6 @@
 import type {
   AppleInsightResults,
   OptimizableImageFile,
-  TreemapElement,
 } from 'sentry/views/preprod/types/appSizeTypes';
 import type {ProcessedInsight} from 'sentry/views/preprod/utils/insightProcessing';
 
@@ -102,62 +101,6 @@ export function AppleInsightResultsFixture(
         },
       ],
     },
-    ...params,
-  };
-}
-
-export function TreemapElementFixture(
-  params: Partial<TreemapElement> = {}
-): TreemapElement {
-  return {
-    name: 'root',
-    size: 1000,
-    type: 'files' as any,
-    is_dir: true,
-    children: [
-      {
-        name: 'src',
-        size: 500,
-        type: 'files' as any,
-        is_dir: true,
-        path: '/app/src',
-        children: [
-          {
-            name: 'main.js',
-            size: 200,
-            type: 'files' as any,
-            is_dir: false,
-            path: '/app/src/main.js',
-            children: [],
-          },
-          {
-            name: 'utils.js',
-            size: 300,
-            type: 'files' as any,
-            is_dir: false,
-            path: '/app/src/utils.js',
-            children: [],
-          },
-        ],
-      },
-      {
-        name: 'assets',
-        size: 500,
-        type: 'assets' as any,
-        is_dir: true,
-        path: '/app/assets',
-        children: [
-          {
-            name: 'image.png',
-            size: 500,
-            type: 'assets' as any,
-            is_dir: false,
-            path: '/app/assets/image.png',
-            children: [],
-          },
-        ],
-      },
-    ],
     ...params,
   };
 }


### PR DESCRIPTION
Resolves https://linear.app/getsentry/issue/EME-181/backtick-search-directory-search

Adds backtick (exact match) and directory searching. 

<img width="1039" height="590" alt="Screenshot 2025-09-08 at 10 22 59 AM" src="https://github.com/user-attachments/assets/fe2d6aaf-2249-4702-9e86-850028f28353" />

Also adds an empty state:

<img width="374" height="135" alt="Screenshot 2025-09-08 at 10 23 06 AM" src="https://github.com/user-attachments/assets/990b1d3b-31ae-4499-8ce2-9fd56afa5a48" />
