### PR TITLE
feat(preprod): add links for VCS items

### DIFF
--- a/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarContent.tsx
+++ b/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarContent.tsx
@@ -1,5 +1,6 @@
 import {Alert} from 'sentry/components/core/alert';
 import {Flex} from 'sentry/components/core/layout';
+import {ExternalLink} from 'sentry/components/core/link';
 import {
   KeyValueData,
   type KeyValueDataContentProps,
@@ -9,6 +10,12 @@ import type {UseApiQueryResult} from 'sentry/utils/queryClient';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import {BuildDetailsSidebarAppInfo} from 'sentry/views/preprod/buildDetails/sidebar/buildDetailsSidebarAppInfo';
 import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
+import {
+  getBranchUrl,
+  getPrUrl,
+  getRepoUrl,
+  getShaUrl,
+} from 'sentry/views/preprod/utils/vcsLinkUtils';
 
 interface BuildDetailsSidebarContentProps {
   artifactId: string;
@@ -36,59 +43,90 @@ export function BuildDetailsSidebarContent(props: BuildDetailsSidebarContentProp
     return <Alert type="error">No build details found</Alert>;
   }
 
-  // TODO: Linkify
+  const vcsInfo = buildDetailsData.vcs_info;
+
+  const createLinkableValue = (
+    value: string | number | undefined,
+    url: string | null
+  ) => {
+    const displayValue = value ?? '-';
+    if (url && displayValue !== '-') {
+      return <ExternalLink href={url}>{displayValue}</ExternalLink>;
+    }
+    return displayValue;
+  };
+
   const vcsInfoContentItems: KeyValueDataContentProps[] = [
     {
       item: {
         key: 'SHA',
         subject: 'SHA',
-        value: buildDetailsData.vcs_info.head_sha ?? '-',
+        value: createLinkableValue(
+          vcsInfo.head_sha,
+          getShaUrl(vcsInfo, vcsInfo.head_sha || '')
+        ),
       },
     },
     {
       item: {
         key: 'Base SHA',
         subject: 'Base SHA',
-        value: buildDetailsData.vcs_info.base_sha ?? '-',
+        value: createLinkableValue(
+          vcsInfo.base_sha,
+          getShaUrl(vcsInfo, vcsInfo.base_sha || '', true)
+        ),
       },
     },
     {
       item: {
         key: 'PR Number',
         subject: 'PR Number',
-        value: buildDetailsData.vcs_info.pr_number ?? '-',
+        value: createLinkableValue(vcsInfo.pr_number, getPrUrl(vcsInfo)),
       },
     },
     {
       item: {
         key: 'Branch',
         subject: 'Branch',
-        value: buildDetailsData.vcs_info.head_ref ?? '-',
+        value: createLinkableValue(
+          vcsInfo.head_ref,
+          getBranchUrl(vcsInfo, vcsInfo.head_ref || '')
+        ),
       },
     },
     {
       item: {
         key: 'Base Branch',
         subject: 'Base Branch',
-        value: buildDetailsData.vcs_info.base_ref ?? '-',
+        value: createLinkableValue(
+          vcsInfo.base_ref,
+          getBranchUrl(vcsInfo, vcsInfo.base_ref || '', true)
+        ),
       },
     },
     {
       item: {
         key: 'Repo Name',
         subject: 'Repo Name',
-        value: buildDetailsData.vcs_info.head_repo_name ?? '-',
+        value: createLinkableValue(
+          vcsInfo.head_repo_name,
+          getRepoUrl(vcsInfo, vcsInfo.head_repo_name || '')
+        ),
       },
     },
   ];
 
   // Base repo name is only available for forks, so we shouldn't show it if it's not present
-  if (buildDetailsData.vcs_info.base_repo_name) {
+  // Also hide it if it's the same as the head repo name
+  if (vcsInfo.base_repo_name && vcsInfo.base_repo_name !== vcsInfo.head_repo_name) {
     vcsInfoContentItems.push({
       item: {
         key: 'Base Repo Name',
         subject: 'Base Repo Name',
-        value: buildDetailsData.vcs_info.base_repo_name,
+        value: createLinkableValue(
+          vcsInfo.base_repo_name,
+          getRepoUrl(vcsInfo, vcsInfo.base_repo_name)
+        ),
       },
     });
   }

--- a/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarContent.tsx
+++ b/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarContent.tsx
@@ -45,15 +45,17 @@ export function BuildDetailsSidebarContent(props: BuildDetailsSidebarContentProp
 
   const vcsInfo = buildDetailsData.vcs_info;
 
-  const createLinkableValue = (
+  const makeLinkableValue = (
     value: string | number | undefined,
     url: string | null
-  ) => {
-    const displayValue = value ?? '-';
-    if (url && displayValue !== '-') {
-      return <ExternalLink href={url}>{displayValue}</ExternalLink>;
+  ): React.ReactNode => {
+    if (value === undefined || value === null) {
+      return '-';
     }
-    return displayValue;
+    if (url === null || url === undefined) {
+      return value;
+    }
+    return <ExternalLink href={url}>{value}</ExternalLink>;
   };
 
   const vcsInfoContentItems: KeyValueDataContentProps[] = [
@@ -61,19 +63,16 @@ export function BuildDetailsSidebarContent(props: BuildDetailsSidebarContentProp
       item: {
         key: 'SHA',
         subject: 'SHA',
-        value: createLinkableValue(
-          vcsInfo.head_sha,
-          getShaUrl(vcsInfo, vcsInfo.head_sha || '')
-        ),
+        value: makeLinkableValue(vcsInfo.head_sha, getShaUrl(vcsInfo, vcsInfo.head_sha)),
       },
     },
     {
       item: {
         key: 'Base SHA',
         subject: 'Base SHA',
-        value: createLinkableValue(
+        value: makeLinkableValue(
           vcsInfo.base_sha,
-          getShaUrl(vcsInfo, vcsInfo.base_sha || '', true)
+          getShaUrl(vcsInfo, vcsInfo.base_sha, true)
         ),
       },
     },
@@ -81,16 +80,16 @@ export function BuildDetailsSidebarContent(props: BuildDetailsSidebarContentProp
       item: {
         key: 'PR Number',
         subject: 'PR Number',
-        value: createLinkableValue(vcsInfo.pr_number, getPrUrl(vcsInfo)),
+        value: makeLinkableValue(vcsInfo.pr_number, getPrUrl(vcsInfo)),
       },
     },
     {
       item: {
         key: 'Branch',
         subject: 'Branch',
-        value: createLinkableValue(
+        value: makeLinkableValue(
           vcsInfo.head_ref,
-          getBranchUrl(vcsInfo, vcsInfo.head_ref || '')
+          getBranchUrl(vcsInfo, vcsInfo.head_ref)
         ),
       },
     },
@@ -98,9 +97,9 @@ export function BuildDetailsSidebarContent(props: BuildDetailsSidebarContentProp
       item: {
         key: 'Base Branch',
         subject: 'Base Branch',
-        value: createLinkableValue(
+        value: makeLinkableValue(
           vcsInfo.base_ref,
-          getBranchUrl(vcsInfo, vcsInfo.base_ref || '', true)
+          getBranchUrl(vcsInfo, vcsInfo.base_ref, true)
         ),
       },
     },
@@ -108,9 +107,9 @@ export function BuildDetailsSidebarContent(props: BuildDetailsSidebarContentProp
       item: {
         key: 'Repo Name',
         subject: 'Repo Name',
-        value: createLinkableValue(
+        value: makeLinkableValue(
           vcsInfo.head_repo_name,
-          getRepoUrl(vcsInfo, vcsInfo.head_repo_name || '')
+          getRepoUrl(vcsInfo, vcsInfo.head_repo_name)
         ),
       },
     },
@@ -123,7 +122,7 @@ export function BuildDetailsSidebarContent(props: BuildDetailsSidebarContentProp
       item: {
         key: 'Base Repo Name',
         subject: 'Base Repo Name',
-        value: createLinkableValue(
+        value: makeLinkableValue(
           vcsInfo.base_repo_name,
           getRepoUrl(vcsInfo, vcsInfo.base_repo_name)
         ),

--- a/static/app/views/preprod/types/buildDetailsTypes.ts
+++ b/static/app/views/preprod/types/buildDetailsTypes.ts
@@ -30,7 +30,7 @@ interface BuildDetailsVcsInfo {
   head_repo_name?: string;
   head_sha?: string;
   pr_number?: number;
-  provider?: 'github' | 'github_enterprise' | 'gitlab' | 'bitbucket' | 'bitbucket_server';
+  provider?: 'github';
 }
 
 export interface BuildDetailsSizeInfo {

--- a/static/app/views/preprod/utils/vcsLinkUtils.spec.ts
+++ b/static/app/views/preprod/utils/vcsLinkUtils.spec.ts
@@ -23,18 +23,6 @@ describe('VCS Link Utils', () => {
       expect(url).toBe('https://github.com/upstream/repo/commit/def456');
     });
 
-    it('returns correct GitLab URL', () => {
-      const gitlabVcsInfo = {...mockVcsInfo, provider: 'gitlab' as const};
-      const url = getShaUrl(gitlabVcsInfo, mockVcsInfo.head_sha);
-      expect(url).toBe('https://gitlab.com/owner/repo/-/commit/abc123');
-    });
-
-    it('returns correct Bitbucket URL', () => {
-      const bitbucketVcsInfo = {...mockVcsInfo, provider: 'bitbucket' as const};
-      const url = getShaUrl(bitbucketVcsInfo, mockVcsInfo.head_sha);
-      expect(url).toBe('https://bitbucket.org/owner/repo/commits/abc123');
-    });
-
     it('returns null for invalid SHA', () => {
       const url = getShaUrl(mockVcsInfo, '');
       expect(url).toBeNull();
@@ -53,18 +41,6 @@ describe('VCS Link Utils', () => {
       expect(url).toBe('https://github.com/owner/repo/pull/42');
     });
 
-    it('returns correct GitLab MR URL', () => {
-      const gitlabVcsInfo = {...mockVcsInfo, provider: 'gitlab' as const};
-      const url = getPrUrl(gitlabVcsInfo);
-      expect(url).toBe('https://gitlab.com/owner/repo/-/merge_requests/42');
-    });
-
-    it('returns correct Bitbucket PR URL', () => {
-      const bitbucketVcsInfo = {...mockVcsInfo, provider: 'bitbucket' as const};
-      const url = getPrUrl(bitbucketVcsInfo);
-      expect(url).toBe('https://bitbucket.org/owner/repo/pull-requests/42');
-    });
-
     it('returns null for missing PR number', () => {
       const vcsInfoNoPr = {...mockVcsInfo, pr_number: undefined};
       const url = getPrUrl(vcsInfoNoPr);
@@ -78,18 +54,6 @@ describe('VCS Link Utils', () => {
       expect(url).toBe('https://github.com/owner/repo/tree/feature-branch');
     });
 
-    it('returns correct GitLab branch URL', () => {
-      const gitlabVcsInfo = {...mockVcsInfo, provider: 'gitlab' as const};
-      const url = getBranchUrl(gitlabVcsInfo, mockVcsInfo.head_ref);
-      expect(url).toBe('https://gitlab.com/owner/repo/-/tree/feature-branch');
-    });
-
-    it('returns correct Bitbucket branch URL', () => {
-      const bitbucketVcsInfo = {...mockVcsInfo, provider: 'bitbucket' as const};
-      const url = getBranchUrl(bitbucketVcsInfo, mockVcsInfo.head_ref);
-      expect(url).toBe('https://bitbucket.org/owner/repo/src/feature-branch');
-    });
-
     it('returns null for empty branch', () => {
       const url = getBranchUrl(mockVcsInfo, '');
       expect(url).toBeNull();
@@ -100,18 +64,6 @@ describe('VCS Link Utils', () => {
     it('returns correct GitHub repo URL', () => {
       const url = getRepoUrl(mockVcsInfo, mockVcsInfo.head_repo_name);
       expect(url).toBe('https://github.com/owner/repo');
-    });
-
-    it('returns correct GitLab repo URL', () => {
-      const gitlabVcsInfo = {...mockVcsInfo, provider: 'gitlab' as const};
-      const url = getRepoUrl(gitlabVcsInfo, mockVcsInfo.head_repo_name);
-      expect(url).toBe('https://gitlab.com/owner/repo');
-    });
-
-    it('returns correct Bitbucket repo URL', () => {
-      const bitbucketVcsInfo = {...mockVcsInfo, provider: 'bitbucket' as const};
-      const url = getRepoUrl(bitbucketVcsInfo, mockVcsInfo.head_repo_name);
-      expect(url).toBe('https://bitbucket.org/owner/repo');
     });
 
     it('returns null for empty repo name', () => {

--- a/static/app/views/preprod/utils/vcsLinkUtils.spec.ts
+++ b/static/app/views/preprod/utils/vcsLinkUtils.spec.ts
@@ -14,24 +14,24 @@ describe('VCS Link Utils', () => {
 
   describe('getShaUrl', () => {
     it('returns correct GitHub URL for head SHA', () => {
-      const url = getShaUrl(mockVcsInfo, mockVcsInfo.head_sha!);
+      const url = getShaUrl(mockVcsInfo, mockVcsInfo.head_sha);
       expect(url).toBe('https://github.com/owner/repo/commit/abc123');
     });
 
     it('returns correct GitHub URL for base SHA', () => {
-      const url = getShaUrl(mockVcsInfo, mockVcsInfo.base_sha!, true);
+      const url = getShaUrl(mockVcsInfo, mockVcsInfo.base_sha, true);
       expect(url).toBe('https://github.com/upstream/repo/commit/def456');
     });
 
     it('returns correct GitLab URL', () => {
       const gitlabVcsInfo = {...mockVcsInfo, provider: 'gitlab' as const};
-      const url = getShaUrl(gitlabVcsInfo, mockVcsInfo.head_sha!);
+      const url = getShaUrl(gitlabVcsInfo, mockVcsInfo.head_sha);
       expect(url).toBe('https://gitlab.com/owner/repo/-/commit/abc123');
     });
 
     it('returns correct Bitbucket URL', () => {
       const bitbucketVcsInfo = {...mockVcsInfo, provider: 'bitbucket' as const};
-      const url = getShaUrl(bitbucketVcsInfo, mockVcsInfo.head_sha!);
+      const url = getShaUrl(bitbucketVcsInfo, mockVcsInfo.head_sha);
       expect(url).toBe('https://bitbucket.org/owner/repo/commits/abc123');
     });
 
@@ -42,7 +42,7 @@ describe('VCS Link Utils', () => {
 
     it('returns null for missing provider', () => {
       const vcsInfoNoProvider = {...mockVcsInfo, provider: undefined};
-      const url = getShaUrl(vcsInfoNoProvider, mockVcsInfo.head_sha!);
+      const url = getShaUrl(vcsInfoNoProvider, mockVcsInfo.head_sha);
       expect(url).toBeNull();
     });
   });
@@ -74,19 +74,19 @@ describe('VCS Link Utils', () => {
 
   describe('getBranchUrl', () => {
     it('returns correct GitHub branch URL', () => {
-      const url = getBranchUrl(mockVcsInfo, mockVcsInfo.head_ref!);
+      const url = getBranchUrl(mockVcsInfo, mockVcsInfo.head_ref);
       expect(url).toBe('https://github.com/owner/repo/tree/feature-branch');
     });
 
     it('returns correct GitLab branch URL', () => {
       const gitlabVcsInfo = {...mockVcsInfo, provider: 'gitlab' as const};
-      const url = getBranchUrl(gitlabVcsInfo, mockVcsInfo.head_ref!);
+      const url = getBranchUrl(gitlabVcsInfo, mockVcsInfo.head_ref);
       expect(url).toBe('https://gitlab.com/owner/repo/-/tree/feature-branch');
     });
 
     it('returns correct Bitbucket branch URL', () => {
       const bitbucketVcsInfo = {...mockVcsInfo, provider: 'bitbucket' as const};
-      const url = getBranchUrl(bitbucketVcsInfo, mockVcsInfo.head_ref!);
+      const url = getBranchUrl(bitbucketVcsInfo, mockVcsInfo.head_ref);
       expect(url).toBe('https://bitbucket.org/owner/repo/src/feature-branch');
     });
 
@@ -98,19 +98,19 @@ describe('VCS Link Utils', () => {
 
   describe('getRepoUrl', () => {
     it('returns correct GitHub repo URL', () => {
-      const url = getRepoUrl(mockVcsInfo, mockVcsInfo.head_repo_name!);
+      const url = getRepoUrl(mockVcsInfo, mockVcsInfo.head_repo_name);
       expect(url).toBe('https://github.com/owner/repo');
     });
 
     it('returns correct GitLab repo URL', () => {
       const gitlabVcsInfo = {...mockVcsInfo, provider: 'gitlab' as const};
-      const url = getRepoUrl(gitlabVcsInfo, mockVcsInfo.head_repo_name!);
+      const url = getRepoUrl(gitlabVcsInfo, mockVcsInfo.head_repo_name);
       expect(url).toBe('https://gitlab.com/owner/repo');
     });
 
     it('returns correct Bitbucket repo URL', () => {
       const bitbucketVcsInfo = {...mockVcsInfo, provider: 'bitbucket' as const};
-      const url = getRepoUrl(bitbucketVcsInfo, mockVcsInfo.head_repo_name!);
+      const url = getRepoUrl(bitbucketVcsInfo, mockVcsInfo.head_repo_name);
       expect(url).toBe('https://bitbucket.org/owner/repo');
     });
 

--- a/static/app/views/preprod/utils/vcsLinkUtils.spec.ts
+++ b/static/app/views/preprod/utils/vcsLinkUtils.spec.ts
@@ -1,0 +1,122 @@
+import {getBranchUrl, getPrUrl, getRepoUrl, getShaUrl} from './vcsLinkUtils';
+
+describe('VCS Link Utils', () => {
+  const mockVcsInfo = {
+    head_sha: 'abc123',
+    base_sha: 'def456',
+    head_ref: 'feature-branch',
+    base_ref: 'main',
+    head_repo_name: 'owner/repo',
+    base_repo_name: 'upstream/repo',
+    pr_number: 42,
+    provider: 'github' as const,
+  };
+
+  describe('getShaUrl', () => {
+    it('returns correct GitHub URL for head SHA', () => {
+      const url = getShaUrl(mockVcsInfo, mockVcsInfo.head_sha!);
+      expect(url).toBe('https://github.com/owner/repo/commit/abc123');
+    });
+
+    it('returns correct GitHub URL for base SHA', () => {
+      const url = getShaUrl(mockVcsInfo, mockVcsInfo.base_sha!, true);
+      expect(url).toBe('https://github.com/upstream/repo/commit/def456');
+    });
+
+    it('returns correct GitLab URL', () => {
+      const gitlabVcsInfo = {...mockVcsInfo, provider: 'gitlab' as const};
+      const url = getShaUrl(gitlabVcsInfo, mockVcsInfo.head_sha!);
+      expect(url).toBe('https://gitlab.com/owner/repo/-/commit/abc123');
+    });
+
+    it('returns correct Bitbucket URL', () => {
+      const bitbucketVcsInfo = {...mockVcsInfo, provider: 'bitbucket' as const};
+      const url = getShaUrl(bitbucketVcsInfo, mockVcsInfo.head_sha!);
+      expect(url).toBe('https://bitbucket.org/owner/repo/commits/abc123');
+    });
+
+    it('returns null for invalid SHA', () => {
+      const url = getShaUrl(mockVcsInfo, '');
+      expect(url).toBeNull();
+    });
+
+    it('returns null for missing provider', () => {
+      const vcsInfoNoProvider = {...mockVcsInfo, provider: undefined};
+      const url = getShaUrl(vcsInfoNoProvider, mockVcsInfo.head_sha!);
+      expect(url).toBeNull();
+    });
+  });
+
+  describe('getPrUrl', () => {
+    it('returns correct GitHub PR URL', () => {
+      const url = getPrUrl(mockVcsInfo);
+      expect(url).toBe('https://github.com/owner/repo/pull/42');
+    });
+
+    it('returns correct GitLab MR URL', () => {
+      const gitlabVcsInfo = {...mockVcsInfo, provider: 'gitlab' as const};
+      const url = getPrUrl(gitlabVcsInfo);
+      expect(url).toBe('https://gitlab.com/owner/repo/-/merge_requests/42');
+    });
+
+    it('returns correct Bitbucket PR URL', () => {
+      const bitbucketVcsInfo = {...mockVcsInfo, provider: 'bitbucket' as const};
+      const url = getPrUrl(bitbucketVcsInfo);
+      expect(url).toBe('https://bitbucket.org/owner/repo/pull-requests/42');
+    });
+
+    it('returns null for missing PR number', () => {
+      const vcsInfoNoPr = {...mockVcsInfo, pr_number: undefined};
+      const url = getPrUrl(vcsInfoNoPr);
+      expect(url).toBeNull();
+    });
+  });
+
+  describe('getBranchUrl', () => {
+    it('returns correct GitHub branch URL', () => {
+      const url = getBranchUrl(mockVcsInfo, mockVcsInfo.head_ref!);
+      expect(url).toBe('https://github.com/owner/repo/tree/feature-branch');
+    });
+
+    it('returns correct GitLab branch URL', () => {
+      const gitlabVcsInfo = {...mockVcsInfo, provider: 'gitlab' as const};
+      const url = getBranchUrl(gitlabVcsInfo, mockVcsInfo.head_ref!);
+      expect(url).toBe('https://gitlab.com/owner/repo/-/tree/feature-branch');
+    });
+
+    it('returns correct Bitbucket branch URL', () => {
+      const bitbucketVcsInfo = {...mockVcsInfo, provider: 'bitbucket' as const};
+      const url = getBranchUrl(bitbucketVcsInfo, mockVcsInfo.head_ref!);
+      expect(url).toBe('https://bitbucket.org/owner/repo/src/feature-branch');
+    });
+
+    it('returns null for empty branch', () => {
+      const url = getBranchUrl(mockVcsInfo, '');
+      expect(url).toBeNull();
+    });
+  });
+
+  describe('getRepoUrl', () => {
+    it('returns correct GitHub repo URL', () => {
+      const url = getRepoUrl(mockVcsInfo, mockVcsInfo.head_repo_name!);
+      expect(url).toBe('https://github.com/owner/repo');
+    });
+
+    it('returns correct GitLab repo URL', () => {
+      const gitlabVcsInfo = {...mockVcsInfo, provider: 'gitlab' as const};
+      const url = getRepoUrl(gitlabVcsInfo, mockVcsInfo.head_repo_name!);
+      expect(url).toBe('https://gitlab.com/owner/repo');
+    });
+
+    it('returns correct Bitbucket repo URL', () => {
+      const bitbucketVcsInfo = {...mockVcsInfo, provider: 'bitbucket' as const};
+      const url = getRepoUrl(bitbucketVcsInfo, mockVcsInfo.head_repo_name!);
+      expect(url).toBe('https://bitbucket.org/owner/repo');
+    });
+
+    it('returns null for empty repo name', () => {
+      const url = getRepoUrl(mockVcsInfo, '');
+      expect(url).toBeNull();
+    });
+  });
+});

--- a/static/app/views/preprod/utils/vcsLinkUtils.ts
+++ b/static/app/views/preprod/utils/vcsLinkUtils.ts
@@ -1,0 +1,134 @@
+interface VcsInfo {
+  base_ref?: string;
+  base_repo_name?: string;
+  base_sha?: string;
+  head_ref?: string;
+  head_repo_name?: string;
+  head_sha?: string;
+  pr_number?: number;
+  provider?: 'github' | 'github_enterprise' | 'gitlab' | 'bitbucket' | 'bitbucket_server';
+}
+
+function getBaseUrl(provider: string, repoName: string): string {
+  switch (provider) {
+    case 'github':
+      return `https://github.com/${repoName}`;
+    case 'github_enterprise':
+      // For enterprise, we'd need the custom domain which isn't available in the data
+      // Fall back to generic GitHub for now
+      return `https://github.com/${repoName}`;
+    case 'gitlab':
+      return `https://gitlab.com/${repoName}`;
+    case 'bitbucket':
+      return `https://bitbucket.org/${repoName}`;
+    case 'bitbucket_server':
+      // For Bitbucket Server, we'd need the custom domain which isn't available
+      // Fall back to generic Bitbucket for now
+      return `https://bitbucket.org/${repoName}`;
+    default:
+      return '';
+  }
+}
+
+export function getShaUrl(
+  vcsInfo: VcsInfo,
+  sha: string,
+  isBaseSha = false
+): string | null {
+  if (!vcsInfo.provider || !sha || sha === '-') {
+    return null;
+  }
+
+  const repoName = isBaseSha
+    ? vcsInfo.base_repo_name || vcsInfo.head_repo_name
+    : vcsInfo.head_repo_name;
+  if (!repoName) {
+    return null;
+  }
+
+  const baseUrl = getBaseUrl(vcsInfo.provider, repoName);
+  if (!baseUrl) {
+    return null;
+  }
+
+  switch (vcsInfo.provider) {
+    case 'github':
+    case 'github_enterprise':
+      return `${baseUrl}/commit/${sha}`;
+    case 'gitlab':
+      return `${baseUrl}/-/commit/${sha}`;
+    case 'bitbucket':
+    case 'bitbucket_server':
+      return `${baseUrl}/commits/${sha}`;
+    default:
+      return null;
+  }
+}
+
+export function getPrUrl(vcsInfo: VcsInfo): string | null {
+  if (!vcsInfo.provider || !vcsInfo.pr_number || !vcsInfo.head_repo_name) {
+    return null;
+  }
+
+  const baseUrl = getBaseUrl(vcsInfo.provider, vcsInfo.head_repo_name);
+  if (!baseUrl) {
+    return null;
+  }
+
+  switch (vcsInfo.provider) {
+    case 'github':
+    case 'github_enterprise':
+      return `${baseUrl}/pull/${vcsInfo.pr_number}`;
+    case 'gitlab':
+      return `${baseUrl}/-/merge_requests/${vcsInfo.pr_number}`;
+    case 'bitbucket':
+    case 'bitbucket_server':
+      return `${baseUrl}/pull-requests/${vcsInfo.pr_number}`;
+    default:
+      return null;
+  }
+}
+
+export function getBranchUrl(
+  vcsInfo: VcsInfo,
+  branch: string,
+  isBaseBranch = false
+): string | null {
+  if (!vcsInfo.provider || !branch || branch === '-') {
+    return null;
+  }
+
+  const repoName = isBaseBranch
+    ? vcsInfo.base_repo_name || vcsInfo.head_repo_name
+    : vcsInfo.head_repo_name;
+  if (!repoName) {
+    return null;
+  }
+
+  const baseUrl = getBaseUrl(vcsInfo.provider, repoName);
+  if (!baseUrl) {
+    return null;
+  }
+
+  switch (vcsInfo.provider) {
+    case 'github':
+    case 'github_enterprise':
+      return `${baseUrl}/tree/${branch}`;
+    case 'gitlab':
+      return `${baseUrl}/-/tree/${branch}`;
+    case 'bitbucket':
+    case 'bitbucket_server':
+      return `${baseUrl}/src/${branch}`;
+    default:
+      return null;
+  }
+}
+
+export function getRepoUrl(vcsInfo: VcsInfo, repoName: string): string | null {
+  if (!vcsInfo.provider || !repoName || repoName === '-') {
+    return null;
+  }
+
+  const baseUrl = getBaseUrl(vcsInfo.provider, repoName);
+  return baseUrl || null;
+}

--- a/static/app/views/preprod/utils/vcsLinkUtils.ts
+++ b/static/app/views/preprod/utils/vcsLinkUtils.ts
@@ -6,33 +6,21 @@ interface VcsInfo {
   head_repo_name?: string;
   head_sha?: string;
   pr_number?: number;
-  provider?: 'github' | 'github_enterprise' | 'gitlab' | 'bitbucket' | 'bitbucket_server';
+  provider?: 'github';
 }
 
-function getBaseUrl(provider: string, repoName: string): string {
+function getBaseUrl(provider: string, repoName: string): string | null {
   switch (provider) {
     case 'github':
       return `https://github.com/${repoName}`;
-    case 'github_enterprise':
-      // For enterprise, we'd need the custom domain which isn't available in the data
-      // Fall back to generic GitHub for now
-      return `https://github.com/${repoName}`;
-    case 'gitlab':
-      return `https://gitlab.com/${repoName}`;
-    case 'bitbucket':
-      return `https://bitbucket.org/${repoName}`;
-    case 'bitbucket_server':
-      // For Bitbucket Server, we'd need the custom domain which isn't available
-      // Fall back to generic Bitbucket for now
-      return `https://bitbucket.org/${repoName}`;
     default:
-      return '';
+      return null;
   }
 }
 
 export function getShaUrl(
   vcsInfo: VcsInfo,
-  sha: string,
+  sha: string | undefined,
   isBaseSha = false
 ): string | null {
   if (!vcsInfo.provider || !sha || sha === '-') {
@@ -53,13 +41,7 @@ export function getShaUrl(
 
   switch (vcsInfo.provider) {
     case 'github':
-    case 'github_enterprise':
       return `${baseUrl}/commit/${sha}`;
-    case 'gitlab':
-      return `${baseUrl}/-/commit/${sha}`;
-    case 'bitbucket':
-    case 'bitbucket_server':
-      return `${baseUrl}/commits/${sha}`;
     default:
       return null;
   }
@@ -77,13 +59,7 @@ export function getPrUrl(vcsInfo: VcsInfo): string | null {
 
   switch (vcsInfo.provider) {
     case 'github':
-    case 'github_enterprise':
       return `${baseUrl}/pull/${vcsInfo.pr_number}`;
-    case 'gitlab':
-      return `${baseUrl}/-/merge_requests/${vcsInfo.pr_number}`;
-    case 'bitbucket':
-    case 'bitbucket_server':
-      return `${baseUrl}/pull-requests/${vcsInfo.pr_number}`;
     default:
       return null;
   }
@@ -91,7 +67,7 @@ export function getPrUrl(vcsInfo: VcsInfo): string | null {
 
 export function getBranchUrl(
   vcsInfo: VcsInfo,
-  branch: string,
+  branch: string | undefined,
   isBaseBranch = false
 ): string | null {
   if (!vcsInfo.provider || !branch || branch === '-') {
@@ -112,19 +88,16 @@ export function getBranchUrl(
 
   switch (vcsInfo.provider) {
     case 'github':
-    case 'github_enterprise':
       return `${baseUrl}/tree/${branch}`;
-    case 'gitlab':
-      return `${baseUrl}/-/tree/${branch}`;
-    case 'bitbucket':
-    case 'bitbucket_server':
-      return `${baseUrl}/src/${branch}`;
     default:
       return null;
   }
 }
 
-export function getRepoUrl(vcsInfo: VcsInfo, repoName: string): string | null {
+export function getRepoUrl(
+  vcsInfo: VcsInfo,
+  repoName: string | undefined
+): string | null {
   if (!vcsInfo.provider || !repoName || repoName === '-') {
     return null;
   }


### PR DESCRIPTION
Makes our VCS items links to the user's repo. For now I'm only adding Github support.

Resolves https://linear.app/getsentry/issue/EME-194/vcs-info-items-should-link-to-provider-if-possible

<img width="357" height="232" alt="Screenshot 2025-09-08 at 10 39 09 AM" src="https://github.com/user-attachments/assets/359a1de7-9d37-445d-9466-e91fe8f3aff1" />

I also hid the base repo name if it's the same as the head, since for 99.9% of builds that will be the case.
