### PR TITLE
feat(ai): Change type of cost attributes to currency

### DIFF
--- a/src/sentry/search/eap/constants.py
+++ b/src/sentry/search/eap/constants.py
@@ -49,7 +49,9 @@ AGGREGATION_OPERATOR_MAP = {
 SearchType = (
     SizeUnit
     | DurationUnit
-    | Literal["duration", "integer", "number", "percentage", "string", "boolean", "rate"]
+    | Literal[
+        "duration", "integer", "number", "percentage", "string", "boolean", "rate", "currency"
+    ]
 )
 
 SIZE_TYPE: set[SearchType] = set(SIZE_UNITS.keys())
@@ -98,6 +100,7 @@ TYPE_MAP: dict[SearchType, AttributeKey.Type.ValueType] = {
     "percentage": DOUBLE,
     "string": STRING,
     "boolean": BOOLEAN,
+    "currency": DOUBLE,
 }
 
 # https://github.com/getsentry/snuba/blob/master/snuba/web/rpc/v1/endpoint_time_series.py

--- a/src/sentry/search/eap/spans/attributes.py
+++ b/src/sentry/search/eap/spans/attributes.py
@@ -201,7 +201,7 @@ SPAN_ATTRIBUTE_DEFINITIONS = {
         ResolvedAttribute(
             public_alias="ai.total_cost",
             internal_name="ai.total_cost",
-            search_type="number",
+            search_type="currency",
         ),
         ResolvedAttribute(
             public_alias="gen_ai.usage.input_tokens",
@@ -229,9 +229,24 @@ SPAN_ATTRIBUTE_DEFINITIONS = {
             search_type="integer",
         ),
         ResolvedAttribute(
+            public_alias="gen_ai.cost.input_tokens",
+            internal_name="gen_ai.cost.input_tokens",
+            search_type="currency",
+        ),
+        ResolvedAttribute(
+            public_alias="gen_ai.cost.output_tokens",
+            internal_name="gen_ai.cost.output_tokens",
+            search_type="currency",
+        ),
+        ResolvedAttribute(
+            public_alias="gen_ai.cost.total_tokens",
+            internal_name="gen_ai.cost.total_tokens",
+            search_type="currency",
+        ),
+        ResolvedAttribute(
             public_alias="gen_ai.usage.total_cost",
             internal_name="gen_ai.usage.total_cost",
-            search_type="number",
+            search_type="currency",
         ),
         ResolvedAttribute(
             public_alias="http.decoded_response_content_length",


### PR DESCRIPTION
On frontend we support `currency` as an attribute type, and format it differently than a number attribute.

This PR introduces currency type as a new `search_type`, and sets existing attributes search type to `currency`.

Closes [TET-1105: Token cost should have type 'currency'](https://linear.app/getsentry/issue/TET-1105/token-cost-should-have-type-currency)
