### PR TITLE
Improve Unreal Engine default stack trace rules

### DIFF
--- a/src/sentry/grouping/enhancer/enhancement-configs/all-platforms@2023-01-11.txt
+++ b/src/sentry/grouping/enhancer/enhancement-configs/all-platforms@2023-01-11.txt
@@ -14,10 +14,25 @@ family:native package:/Users/**                                      +app
 
 # Unreal Engine
 
+## UE internal fatal log message handling
+
+family:native stack.function:UE::Logging::Private::BasicFatalLog     v+app -app ^-app
+
 ## UE internal assertion handling
-family:native stack.function:FDebug::CheckVerifyFailedImpl*                v+app -app ^-app
+family:native stack.function:FDebug::CheckVerifyFailedImpl*                                             v+app -app ^-app
+stack.function:*::Impl::ExecCheckImplInternal | [ stack.function:FDebug::CheckVerifyFailedImpl ]        -app
+stack.function:FDebug::CheckVerifyFailedImpl2 | [ stack.function:FDebug::CheckVerifyFailedImpl2V ]      -app
 
 ## UE internal ensure handling
+
+### UE 5.2 and older
+family:native stack.function:FDebug::OptionallyLogFormattedEnsureMessageReturningFalse                  v+app -app ^-app
+category:indirection | [ stack.function:FDebug::OptionallyLogFormattedEnsureMessageReturningFalse ]     -app
+
+### UE 5.3
+family:native stack.function:DispatchCheckVerify*                          v+app -app ^-app
+
+### UE 5.4 and newer
 family:native stack.function:UE::Assert::Private::ExecCheckImplInternal*   v+app -app ^-app
 
 ## UE SDK USentrySubsystem event capturing


### PR DESCRIPTION
This PR expands the list of default stack trace rules for Unreal Engine to improve grouping of assertions, ensures and fatal log message events. Since Unreal SDK supports multiple engine versions (4.27-5.6) we need to handle version-specific differences accordingly.

Similar changes were introduced earlier in scope of:
- https://github.com/getsentry/sentry/pull/85475

Related issues:
- https://github.com/getsentry/sentry-unreal/issues/829
- https://github.com/getsentry/sentry/issues/26418

## Key changes

### Ensures (non-fatal errors)

The existing rule for ensure events is only working properly for projects built with UE 5.4 and newer. For older engine versions, these events were getting grouped together under the same issue with the generic top-level stacktrace info as the entry point for the internal engine's ensure handling is different there.

#### UE 5.2 and older

Suggested rules:

```
family:native stack.function:FDebug::OptionallyLogFormattedEnsureMessageReturningFalse  v+app -app ^-app
category:indirection | [ stack.function:FDebug::OptionallyLogFormattedEnsureMessageReturningFalse ] -app
```

Expected stacktrace:

<img width="1946" height="1282" alt="image" src="https://github.com/user-attachments/assets/2d23b722-edc6-4c0d-ad28-0b81c1b63c7a" />

Example events:

| Engine version | 4.27 | 5.0 | 5.1 | 5.2 |
|----------------|------|-----|-----|-----|
| Ensure example |  [Link](https://ivan-tustanivskyi.sentry.io/issues/6857397348/events/58d02fbe67e5480884f178b4168ccda3/)     |  [Link](https://ivan-tustanivskyi.sentry.io/issues/6859249866/events/57ecc359edce4a8d07ebb6229f645537/)  |  [Link](https://ivan-tustanivskyi.sentry.io/issues/6859200125/events/a32c4cdc1c86416ef4712291912119e8/)   |   [Link](https://ivan-tustanivskyi.sentry.io/issues/6859200125/events/089aea3c075c47bbe59700952e6e77c7/)  |

#### UE 5.3

Suggested rule:

```
family:native stack.function:DispatchCheckVerify*   v+app -app ^-app
```

Expected stacktrace:

<img width="1935" height="1324" alt="image" src="https://github.com/user-attachments/assets/230ad35c-c493-4a79-bfe8-4cee1aa194df" />

Example events:

| Engine version | 5.3 |
|----------------|-----|
| Ensure example |  [Link](https://ivan-tustanivskyi.sentry.io/issues/6859249866/events/116156ee787c4f5033d9bfd034804aa2/)   |

### Asserts

While the existing rule for asserts works well for UE 5.3-5.5 other supported engine versions need some fine-tuning to properly cut off the generic topmost stacktrace frames

#### UE 5.0-5.2

Suggested rule:

```
stack.function:*::Impl::ExecCheckImplInternal | [ stack.function:FDebug::CheckVerifyFailedImpl ]    -app
```

Expected stacktrace:

<img width="1932" height="936" alt="image" src="https://github.com/user-attachments/assets/51e655f7-17ce-45a7-b6ab-bcfcdcb1c894" />


Example events:

| Engine version | 5.0 | 5.1 | 5.2 |
|----------------|-----|-----|-----|
| Assert example |   [Link](https://ivan-tustanivskyi.sentry.io/issues/6859249984/events/97d14d248f3a4ea9b7c49c65a5861a7b/)  |  [Link](https://ivan-tustanivskyi.sentry.io/issues/6859229171/events/7a54b210d9c14f3ca68f2e8808ac60c7/)   |   [Link](https://ivan-tustanivskyi.sentry.io/issues/6859229171/events/b18617bdf6314cee782a04b103279a7f/)  |

#### UE 5.6

Suggested rule:

```
stack.function:FDebug::CheckVerifyFailedImpl2 | [ stack.function:FDebug::CheckVerifyFailedImpl2V ]  -app
```

Expected stacktrace:

<img width="1940" height="936" alt="image" src="https://github.com/user-attachments/assets/20bc9e68-fc54-42f5-9a04-5dd3d50daba5" />

Example events:

| Engine version | 5.6 |
|----------------|-----|
| Ensure example |  [Link](https://ivan-tustanivskyi.sentry.io/issues/6864112296/events/3ba2b97ebbc8445f164af390bba3b4ba/)   |


### Fatal log

Starting from UE 5.2 there's a reliable way to distinguish frames that represent engine's internal fatal log mesaage handling.

### UE 5.2 and newer

Suggested rule:

```
family:native stack.function:UE::Logging::Private::BasicFatalLog    v+app -app ^-app
```

Expected stacktrace:

<img width="1932" height="829" alt="image" src="https://github.com/user-attachments/assets/67b831fc-b198-4594-b651-f8fbd8038a2b" />

Example events:

| Engine version | 5.2 | 5.3 | 5.4 | 5.5 | 5.6 |
|----------------|-----|-----|-----|-----|-----|
| Assert example |   [Link](https://ivan-tustanivskyi.sentry.io/issues/6859229509/events/99cb43bd5c68413c996d8efee434c219/)  |     [Link](https://ivan-tustanivskyi.sentry.io/issues/6859250021/events/3055446bdda04ff5210393226d6ad05e/)    |   [Link](https://ivan-tustanivskyi.sentry.io/issues/6859273039/events/8681f2c1e2644cde089cb79422baa66b/)  |   [Link](https://ivan-tustanivskyi.sentry.io/issues/6859249984/events/9c3abcaf53a142cf8f6f722b0ca42a78/)  |  [Link](https://ivan-tustanivskyi.sentry.io/issues/6864112296/events/94a715bf9d834eb0bf3b38fa1e01c07c/)  |