### PR TITLE
Add `other` category to CATEGORY_LIST

### DIFF
--- a/src/sentry/utils/platform_categories.py
+++ b/src/sentry/utils/platform_categories.py
@@ -180,6 +180,7 @@ CATEGORY_LIST = [
     {id: "desktop", "name": _("Desktop"), "platforms": DESKTOP},
     {id: "serverless", "name": _("Serverless"), "platforms": SERVERLESS},
     {id: "gaming", "name": _("Gaming"), "platforms": GAMING},
+    {id: "other", "name": _("Other"), "platforms": {"other"}},
 ]
 
 # Mirrors `const sourceMaps` in sentry/static/app/data/platformCategories.tsx


### PR DESCRIPTION
Allow to provision projects with `other`. `CATEGORY_LIST` is only used in [getsentry](https://github.com/getsentry/getsentry/blob/44e64f1d08b876fa06b7870ebaa1b7638fc7c8d7/getsentry/web/channel_provisioning/endpoint.py#L38).