### PR TITLE
feat(snuba): Do not fetch for projects just to get the organization ID

### DIFF
--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -4,7 +4,7 @@ import functools
 import os
 import re
 from collections import defaultdict
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from datetime import datetime, timedelta, timezone
 from typing import Any, Never, Protocol, TypedDict
 
@@ -46,7 +46,7 @@ from sentry.utils import metrics, snuba
 from sentry.utils.hashlib import md5_text
 from sentry.utils.snuba import (
     _prepare_start_end,
-    get_organization_id_from_project_ids,
+    get_organization_id,
     get_snuba_translators,
     nest_groups,
     raw_snql_query,
@@ -419,7 +419,7 @@ class SnubaTagStorage(TagStorage):
 
         optimize_kwargs: _OptimizeKwargs = {}
 
-        organization_id = get_organization_id_from_project_ids(get_project_list(project_id))
+        organization_id = get_organization_id(get_project_list(project_id))
         organization = Organization.objects.get_from_cache(id=organization_id)
         if features.has("organizations:tag-key-sample-n", organization):
             # Add static sample amount to the query. Turbo will sample at 10% by
@@ -454,7 +454,7 @@ class SnubaTagStorage(TagStorage):
         # We want to disable FINAL in the snuba query to reduce load.
         optimize_kwargs: _OptimizeKwargs = {"turbo": True}
 
-        organization_id = get_organization_id_from_project_ids(projects)
+        organization_id = get_organization_id(projects)
         organization = Organization.objects.get_from_cache(id=organization_id)
         if features.has("organizations:tag-key-sample-n", organization):
             # Add static sample amount to the query. Turbo will sample at 10% by
@@ -594,7 +594,7 @@ class SnubaTagStorage(TagStorage):
         self, project_ids, group_id_list, environment_ids, key: str, value, tenant_ids=None
     ):
         translated_params = _translate_filter_keys(project_ids, group_id_list, environment_ids)
-        organization_id = get_organization_id_from_project_ids(project_ids)
+        organization_id = get_organization_id(project_ids)
         start, end = _prepare_start_end(
             None,
             None,
@@ -837,7 +837,7 @@ class SnubaTagStorage(TagStorage):
         environment_ids: Sequence[int] | None,
         start: datetime | None = None,
         end: datetime | None = None,
-        tenant_ids: dict[str, str | int] | None = None,
+        tenant_ids: Mapping[str, str | int] | None = None,
         referrer: str = "tagstore.get_groups_user_counts",
     ) -> dict[int, int]:
         return self.__get_groups_user_counts(
@@ -859,11 +859,11 @@ class SnubaTagStorage(TagStorage):
         environment_ids: Sequence[int] | None,
         start: datetime | None = None,
         end: datetime | None = None,
-        tenant_ids: dict[str, str | int] | None = None,
+        tenant_ids: Mapping[str, str | int] | None = None,
         referrer: str = "tagstore.get_generic_groups_user_counts",
     ) -> dict[int, int]:
         translated_params = _translate_filter_keys(project_ids, group_ids, environment_ids)
-        organization_id = get_organization_id_from_project_ids(project_ids)
+        organization_id = get_organization_id(project_ids)
         start, end = _prepare_start_end(
             start,
             end,

--- a/tests/sentry/deletions/tasks/test_nodestore.py
+++ b/tests/sentry/deletions/tasks/test_nodestore.py
@@ -58,3 +58,31 @@ class NodestoreDeletionTaskTest(TestCase):
         # Events should be deleted from eventstore after nodestore deletion
         events_after = self.fetch_events_from_eventstore(group_ids, dataset=Dataset.Events)
         assert len(events_after) == 0
+
+    def test_simple_deletion_with_project_deleted(self) -> None:
+        """Test nodestore deletion when events are found."""
+        events = self.create_n_events_with_group(n_events=5)
+        group_ids = [event.group_id for event in events if event.group_id is not None]
+
+        # Verify events exist in both eventstore and nodestore before deletion
+        events = self.fetch_events_from_eventstore(group_ids, dataset=Dataset.Events)
+        assert len(events) == 5
+
+        self.project.delete()
+
+        with self.tasks():
+            delete_events_for_groups_from_nodestore_and_eventstore.apply_async(
+                kwargs={
+                    "organization_id": self.project.organization_id,
+                    "project_id": self.project.id,
+                    "group_ids": group_ids,
+                    "times_seen": [1] * len(group_ids),
+                    "transaction_id": uuid4().hex,
+                    "dataset_str": Dataset.Events.value,
+                    "referrer": "deletions.groups",
+                },
+            )
+
+        # Events should be deleted from eventstore after nodestore deletion
+        events_after = self.fetch_events_from_eventstore(group_ids, dataset=Dataset.Events)
+        assert len(events_after) == 0

--- a/tests/sentry/utils/test_snuba.py
+++ b/tests/sentry/utils/test_snuba.py
@@ -25,7 +25,6 @@ from sentry.utils.snuba import (
     _bulk_snuba_query,
     _prepare_query_params,
     get_json_type,
-    get_query_params_to_update_for_projects,
     get_snuba_column_name,
     get_snuba_translators,
     quantize_time,
@@ -248,7 +247,7 @@ class PrepareQueryParamsTest(TestCase):
 
         self.project.delete()
         with pytest.raises(UnqualifiedQueryError):
-            get_query_params_to_update_for_projects(query_params)
+            _prepare_query_params(query_params)
 
     @mock.patch("sentry.models.Project.objects.get_from_cache", side_effect=Project.DoesNotExist)
     def test_with_some_deleted_projects(self, mock_project: mock.MagicMock) -> None:
@@ -258,7 +257,7 @@ class PrepareQueryParamsTest(TestCase):
         )
 
         other_project.delete()
-        organization_id, _ = get_query_params_to_update_for_projects(query_params)
+        organization_id, _ = _prepare_query_params(query_params)
         assert organization_id == self.organization.id
 
     def test_outcomes_dataset_with_org_id(self) -> None:

--- a/tests/sentry/utils/test_snuba.py
+++ b/tests/sentry/utils/test_snuba.py
@@ -257,8 +257,7 @@ class PrepareQueryParamsTest(TestCase):
         )
 
         other_project.delete()
-        organization_id, _ = _prepare_query_params(query_params)
-        assert organization_id == self.organization.id
+        _prepare_query_params(query_params)
 
     def test_outcomes_dataset_with_org_id(self) -> None:
         query_params = SnubaQueryParams(


### PR DESCRIPTION
The task to delete events from the nodestore (PR #96795) does not have the guarantee that the project will exist in the DB.

This change prioritizes extracting the project ids and organization id from the Snuba filter keys.

Fixes [SENTRY-4B05](https://sentry.sentry.io/issues/6792120685/).