### PR TITLE
:mag: nit: rename `IntegrationInstallationConfigurationError` to `IntegrationInstallationError`

### DIFF
--- a/src/sentry/integrations/bitbucket/issues.py
+++ b/src/sentry/integrations/bitbucket/issues.py
@@ -10,8 +10,8 @@ from sentry.models.group import Group
 from sentry.organizations.services.organization.service import organization_service
 from sentry.shared_integrations.exceptions import (
     ApiError,
+    IntegrationConfigurationError,
     IntegrationFormError,
-    IntegrationInstallationConfigurationError,
 )
 from sentry.silo.base import all_silo_function
 from sentry.users.models.identity import Identity
@@ -152,7 +152,7 @@ class BitbucketIssuesSpec(SourceCodeIssueIntegration):
     def raise_error(self, exc: Exception, identity: Identity | None = None) -> NoReturn:
         if isinstance(exc, ApiError) and exc.json:
             if (message := exc.json.get("error", {}).get("message")) in BITBUCKET_HALT_ERROR_CODES:
-                raise IntegrationInstallationConfigurationError(message)
+                raise IntegrationConfigurationError(message)
         super().raise_error(exc, identity)
 
     def create_issue(self, data, **kwargs):

--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -18,9 +18,9 @@ from sentry.organizations.services.organization.service import organization_serv
 from sentry.services.eventstore.models import Event, GroupEvent
 from sentry.shared_integrations.exceptions import (
     ApiError,
+    IntegrationConfigurationError,
     IntegrationError,
     IntegrationFormError,
-    IntegrationInstallationConfigurationError,
     IntegrationResourceNotFoundError,
 )
 from sentry.silo.base import all_silo_function
@@ -48,7 +48,7 @@ class GitHubIssuesSpec(SourceCodeIssueIntegration):
                         {"detail": "Some given field was misconfigured"}
                     ) from exc
             elif exc.code == 410:
-                raise IntegrationInstallationConfigurationError(
+                raise IntegrationConfigurationError(
                     "Issues are disabled for this repository, please check your repository permissions"
                 ) from exc
             elif exc.code == 404:
@@ -57,9 +57,9 @@ class GitHubIssuesSpec(SourceCodeIssueIntegration):
                 if exc.json is not None:
                     detail = exc.json.get("message")
                     if detail:
-                        raise IntegrationInstallationConfigurationError(detail) from exc
+                        raise IntegrationConfigurationError(detail) from exc
 
-                raise IntegrationInstallationConfigurationError(
+                raise IntegrationConfigurationError(
                     "You are not authorized to create issues in this repository. Please check your repository permissions."
                 ) from exc
 

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -46,9 +46,9 @@ from sentry.shared_integrations.exceptions import (
     ApiInvalidRequestError,
     ApiRateLimitedError,
     ApiUnauthorized,
+    IntegrationConfigurationError,
     IntegrationError,
     IntegrationFormError,
-    IntegrationInstallationConfigurationError,
 )
 from sentry.silo.base import all_silo_function
 from sentry.users.models.user import User
@@ -949,7 +949,7 @@ class JiraIntegration(IssueSyncIntegration):
 
         meta = client.get_create_meta_for_project(jira_project)
         if not meta:
-            raise IntegrationInstallationConfigurationError(
+            raise IntegrationConfigurationError(
                 "Could not fetch issue create configuration from Jira."
             )
 
@@ -1022,7 +1022,7 @@ class JiraIntegration(IssueSyncIntegration):
             id_field = client.user_id_field()
             client.assign_issue(external_issue.key, jira_user and jira_user.get(id_field))
         except ApiUnauthorized as e:
-            raise IntegrationInstallationConfigurationError(
+            raise IntegrationConfigurationError(
                 "Insufficient permissions to assign user to the Jira issue."
             ) from e
         except ApiError as e:

--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -43,9 +43,9 @@ from sentry.shared_integrations.exceptions import (
     ApiError,
     ApiHostError,
     ApiUnauthorized,
+    IntegrationConfigurationError,
     IntegrationError,
     IntegrationFormError,
-    IntegrationInstallationConfigurationError,
 )
 from sentry.silo.base import all_silo_function
 from sentry.users.models.identity import Identity
@@ -995,7 +995,7 @@ class JiraServerIntegration(IssueSyncIntegration):
 
         issue_type_meta = client.get_issue_fields(jira_project, issue_type)
         if not issue_type_meta:
-            raise IntegrationInstallationConfigurationError(
+            raise IntegrationConfigurationError(
                 "Could not fetch issue create configuration from Jira."
             )
 
@@ -1287,7 +1287,7 @@ class JiraServerIntegration(IssueSyncIntegration):
                     **logging_context,
                 },
             )
-            raise IntegrationInstallationConfigurationError(
+            raise IntegrationConfigurationError(
                 "Insufficient permissions to assign user to Jira Server issue"
             ) from e
         except ApiError as e:

--- a/src/sentry/integrations/tasks/sync_assignee_outbound.py
+++ b/src/sentry/integrations/tasks/sync_assignee_outbound.py
@@ -15,8 +15,8 @@ from sentry.integrations.services.integration import integration_service
 from sentry.models.organization import Organization
 from sentry.shared_integrations.exceptions import (
     ApiUnauthorized,
+    IntegrationConfigurationError,
     IntegrationError,
-    IntegrationInstallationConfigurationError,
 )
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task, retry
@@ -109,6 +109,6 @@ def sync_assignee_outbound(
             OrganizationIntegrationNotFound,
             ApiUnauthorized,
             IntegrationSyncTargetNotFound,
-            IntegrationInstallationConfigurationError,
+            IntegrationConfigurationError,
         ) as e:
             lifecycle.record_halt(halt_reason=e)

--- a/src/sentry/integrations/vsts/issues.py
+++ b/src/sentry/integrations/vsts/issues.py
@@ -19,9 +19,9 @@ from sentry.models.activity import Activity
 from sentry.shared_integrations.exceptions import (
     ApiError,
     ApiUnauthorized,
+    IntegrationConfigurationError,
     IntegrationError,
     IntegrationFormError,
-    IntegrationInstallationConfigurationError,
 )
 from sentry.silo.base import all_silo_function
 from sentry.users.models.identity import Identity
@@ -310,7 +310,7 @@ class VstsIssuesSpec(IssueSyncIntegration, SourceCodeIssueIntegration, ABC):
                 },
             )
             if isinstance(e, ApiUnauthorized):
-                raise IntegrationInstallationConfigurationError(
+                raise IntegrationConfigurationError(
                     "Insufficient permissions to assign user to the VSTS issue."
                 ) from e
             raise IntegrationError("There was an error assigning the issue.") from e

--- a/src/sentry/issues/endpoints/group_integration_details.py
+++ b/src/sentry/issues/endpoints/group_integration_details.py
@@ -28,9 +28,9 @@ from sentry.models.activity import Activity
 from sentry.models.group import Group
 from sentry.models.grouplink import GroupLink
 from sentry.shared_integrations.exceptions import (
+    IntegrationConfigurationError,
     IntegrationError,
     IntegrationFormError,
-    IntegrationInstallationConfigurationError,
 )
 from sentry.signals import integration_issue_created, integration_issue_linked
 from sentry.types.activity import ActivityType
@@ -310,7 +310,7 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
 
             try:
                 data = installation.create_issue(request.data)
-            except IntegrationInstallationConfigurationError as exc:
+            except IntegrationConfigurationError as exc:
                 lifecycle.record_halt(exc)
                 return Response({"non_field_errors": [str(exc)]}, status=400)
             except IntegrationFormError as exc:

--- a/src/sentry/rules/actions/integrations/create_ticket/utils.py
+++ b/src/sentry/rules/actions/integrations/create_ticket/utils.py
@@ -23,8 +23,8 @@ from sentry.notifications.utils.links import create_link_to_workflow
 from sentry.services.eventstore.models import GroupEvent
 from sentry.shared_integrations.exceptions import (
     ApiUnauthorized,
+    IntegrationConfigurationError,
     IntegrationFormError,
-    IntegrationInstallationConfigurationError,
 )
 from sentry.silo.base import region_silo_function
 from sentry.types.rules import RuleFuture
@@ -180,7 +180,7 @@ def create_issue(event: GroupEvent, futures: Sequence[RuleFuture]) -> None:
             try:
                 response = installation.create_issue(data)
             except (
-                IntegrationInstallationConfigurationError,
+                IntegrationConfigurationError,
                 IntegrationFormError,
                 InvalidIdentity,
                 ApiUnauthorized,

--- a/src/sentry/shared_integrations/exceptions/__init__.py
+++ b/src/sentry/shared_integrations/exceptions/__init__.py
@@ -169,7 +169,7 @@ class IntegrationError(Exception):
     pass
 
 
-class IntegrationInstallationConfigurationError(IntegrationError):
+class IntegrationConfigurationError(IntegrationError):
     """
     Error when external API access is blocked due to configuration issues
     like permissions, visibility changes, or invalid project settings.

--- a/tests/sentry/integrations/github/test_issues.py
+++ b/tests/sentry/integrations/github/test_issues.py
@@ -18,9 +18,9 @@ from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.integrations.services.integration import integration_service
 from sentry.issues.grouptype import FeedbackGroup
 from sentry.shared_integrations.exceptions import (
+    IntegrationConfigurationError,
     IntegrationError,
     IntegrationFormError,
-    IntegrationInstallationConfigurationError,
 )
 from sentry.silo.util import PROXY_BASE_URL_HEADER, PROXY_OI_HEADER, PROXY_SIGNATURE_HEADER
 from sentry.testutils.cases import IntegratedApiTestCase, PerformanceIssueTestCase, TestCase
@@ -319,7 +319,7 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
             "description": "This is the description",
         }
 
-        with pytest.raises(IntegrationInstallationConfigurationError) as e:
+        with pytest.raises(IntegrationConfigurationError) as e:
             self.install.create_issue(form_data)
 
         assert (
@@ -346,7 +346,7 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
             "description": "This is the description",
         }
 
-        with pytest.raises(IntegrationInstallationConfigurationError) as e:
+        with pytest.raises(IntegrationConfigurationError) as e:
             self.install.create_issue(form_data)
 
         assert e.value.args[0] == "Repository was archived so is read-only."

--- a/tests/sentry/integrations/jira/test_integration.py
+++ b/tests/sentry/integrations/jira/test_integration.py
@@ -19,10 +19,7 @@ from sentry.integrations.models.organization_integration import OrganizationInte
 from sentry.integrations.services.integration import integration_service
 from sentry.models.grouplink import GroupLink
 from sentry.models.groupmeta import GroupMeta
-from sentry.shared_integrations.exceptions import (
-    IntegrationError,
-    IntegrationInstallationConfigurationError,
-)
+from sentry.shared_integrations.exceptions import IntegrationConfigurationError, IntegrationError
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase, IntegrationTestCase
 from sentry.testutils.factories import EventType
@@ -888,7 +885,7 @@ class RegionJiraIntegrationTest(APITestCase):
 
         responses.add(responses.PUT, assign_issue_url, status=401, json={})
 
-        with pytest.raises(IntegrationInstallationConfigurationError) as excinfo:
+        with pytest.raises(IntegrationConfigurationError) as excinfo:
             installation.sync_assignee_outbound(external_issue, user)
 
         assert str(excinfo.value) == "Insufficient permissions to assign user to the Jira issue."

--- a/tests/sentry/integrations/jira/test_ticket_action.py
+++ b/tests/sentry/integrations/jira/test_ticket_action.py
@@ -12,9 +12,9 @@ from sentry.models.rule import Rule
 from sentry.services.eventstore.models import GroupEvent
 from sentry.shared_integrations.exceptions import (
     ApiInvalidRequestError,
+    IntegrationConfigurationError,
     IntegrationError,
     IntegrationFormError,
-    IntegrationInstallationConfigurationError,
 )
 from sentry.testutils.asserts import assert_failure_metric, assert_halt_metric
 from sentry.testutils.cases import RuleTestCase
@@ -240,7 +240,7 @@ class JiraTicketRulesTestCase(RuleTestCase, BaseAPITestCase):
             assert start.args == (EventLifecycleOutcome.STARTED,)
             assert_halt_metric(
                 mock_record_event,
-                IntegrationInstallationConfigurationError(
+                IntegrationConfigurationError(
                     "Could not fetch issue create configuration from Jira."
                 ),
             )

--- a/tests/sentry/integrations/jira_server/test_integration.py
+++ b/tests/sentry/integrations/jira_server/test_integration.py
@@ -23,8 +23,8 @@ from sentry.models.groupmeta import GroupMeta
 from sentry.shared_integrations.exceptions import (
     ApiError,
     ApiUnauthorized,
+    IntegrationConfigurationError,
     IntegrationError,
-    IntegrationInstallationConfigurationError,
 )
 from sentry.silo.base import SiloMode
 from sentry.silo.safety import unguarded_write
@@ -885,7 +885,7 @@ class JiraServerRegionIntegrationTest(JiraServerIntegrationBaseTest):
                 }
             ],
         )
-        with pytest.raises(IntegrationInstallationConfigurationError) as exc_info:
+        with pytest.raises(IntegrationConfigurationError) as exc_info:
             self.installation.sync_assignee_outbound(
                 external_issue=external_issue, user=user, assign=True
             )

--- a/tests/sentry/integrations/tasks/test_sync_assignee_outbound.py
+++ b/tests/sentry/integrations/tasks/test_sync_assignee_outbound.py
@@ -9,7 +9,7 @@ from sentry.integrations.models import ExternalIssue, Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.tasks import sync_assignee_outbound
 from sentry.integrations.types import EventLifecycleOutcome
-from sentry.shared_integrations.exceptions import IntegrationInstallationConfigurationError
+from sentry.shared_integrations.exceptions import IntegrationConfigurationError
 from sentry.testutils.asserts import assert_halt_metric, assert_success_metric
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import assume_test_silo_mode_of
@@ -165,7 +165,7 @@ class TestSyncAssigneeOutbound(TestCase):
     def test_integration_installation_configuration_error(
         self, mock_sync_assignee, mock_record_event
     ):
-        mock_sync_assignee.side_effect = IntegrationInstallationConfigurationError(
+        mock_sync_assignee.side_effect = IntegrationConfigurationError(
             "Insufficient permissions to assign user"
         )
 
@@ -175,5 +175,5 @@ class TestSyncAssigneeOutbound(TestCase):
         assert mock_record_event.call_count == 2
         assert_halt_metric(
             mock_record_event,
-            IntegrationInstallationConfigurationError("Insufficient permissions to assign user"),
+            IntegrationConfigurationError("Insufficient permissions to assign user"),
         )

--- a/tests/sentry/issues/endpoints/test_group_integration_details.py
+++ b/tests/sentry/issues/endpoints/test_group_integration_details.py
@@ -12,9 +12,9 @@ from sentry.models.group import Group
 from sentry.models.grouplink import GroupLink
 from sentry.models.organization import Organization
 from sentry.shared_integrations.exceptions import (
+    IntegrationConfigurationError,
     IntegrationError,
     IntegrationFormError,
-    IntegrationInstallationConfigurationError,
 )
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.factories import EventType
@@ -36,7 +36,7 @@ def raise_integration_error(*args: Any, **kwargs: Any) -> None:
 
 
 def raise_integration_installation_configuration_error(*args: Any, **kwargs: Any) -> None:
-    raise IntegrationInstallationConfigurationError("Repository has no issue tracker.")
+    raise IntegrationConfigurationError("Repository has no issue tracker.")
 
 
 class GroupIntegrationDetailsTest(APITestCase):
@@ -480,7 +480,7 @@ class GroupIntegrationDetailsTest(APITestCase):
 
             self.assert_metric_recorded(
                 mock_record_halt,
-                IntegrationInstallationConfigurationError,
+                IntegrationConfigurationError,
                 "Repository has no issue tracker.",
             )
 


### PR DESCRIPTION
renamed error for better clarity and conciseness

The "Installation" part was redundant these errors occur when integrations are misconfigured and require user intervention, not specifically during installation