### PR TITLE
chore(timeseries): Increase sampling of `/events-timeseries/` spot-check

### DIFF
--- a/static/app/views/insights/common/queries/useDiscoverSeries.ts
+++ b/static/app/views/insights/common/queries/useDiscoverSeries.ts
@@ -129,7 +129,7 @@ const useDiscoverSeries = <T extends string[]>(
   // Add a 10% sampled fetch of equivalent `/events-timeseries/` response so we
   // can compare the result and spot-check that there aren't any differences.
   const isTimeSeriesEndpointComparisonEnabled =
-    useIsSampled(0.1) &&
+    useIsSampled(0.5) &&
     organization.features.includes('insights-events-time-series-spot-check');
 
   const eventsTimeSeriesResult = useFetchEventsTimeSeries(


### PR DESCRIPTION
The current amount of sampling results in [pathetic total volume](https://sentry.sentry.io/dashboard/149406/?project=1&statsPeriod=1h), not really enough to be confidence. Increasing the sampling! The current sampling is roughly 10% of the traffic to `/events-stats/` that originates in Insights, which is not a lot in the grand scheme of things.
