### PR TITLE
chore(releases): Capture IndexError when no commits in target repo for previous release

### DIFF
--- a/src/sentry/tasks/commits.py
+++ b/src/sentry/tasks/commits.py
@@ -153,7 +153,8 @@ def fetch_commits(release_id: int, user_id: int, refs, prev_release_id=None, **k
                     release=prev_release,
                     repository_id=repo.id,
                 ).values_list("commit__key", flat=True)[0]
-            except IndexError:
+            except IndexError as e:
+                sentry_sdk.capture_exception(e)
                 pass
 
         end_sha = ref["commit"]


### PR DESCRIPTION
relates to REPLAY-188

The goal is to investigate why we sometimes cannot derive a start SHA when getting release commits. No start SHA can become a problem because it triggers fallback behaviors in the integration providers and returns a large range of commits, some of which may extend beyond the unknown exact range of the commits included in the release.

If we don't have a `previousCommit` in our release ref to use as the start SHA, we look in the previous release for the head commit and use that. But if the previous release doesn't contain any commits in the target repo, we get an `IndexError` and the start SHA remains None. Here we capture that exception so we can investigate further.