### PR TITLE
fix(billing): Disable log byte abbreviation on subscription overview page

### DIFF
--- a/static/gsApp/utils/billing.spec.tsx
+++ b/static/gsApp/utils/billing.spec.tsx
@@ -215,12 +215,12 @@ describe('formatReservedWithUnits', () => {
       formatReservedWithUnits(0.1234, DataCategory.LOG_BYTE, {
         isAbbreviated: true,
       })
-    ).toBe('0 GB');
+    ).toBe('0.1 GB');
     expect(
       formatReservedWithUnits(1.234, DataCategory.LOG_BYTE, {
         isAbbreviated: true,
       })
-    ).toBe('1 GB');
+    ).toBe('1.2 GB');
     expect(
       formatReservedWithUnits(0.1, DataCategory.LOG_BYTE, {
         useUnitScaling: true,
@@ -251,6 +251,32 @@ describe('formatReservedWithUnits', () => {
         useUnitScaling: true,
       })
     ).toBe(UNLIMITED);
+
+    expect(
+      formatReservedWithUnits(1234, DataCategory.LOG_BYTE, {
+        isAbbreviated: true,
+      })
+    ).toBe('1,234 GB');
+    expect(
+      formatReservedWithUnits(MILLION, DataCategory.LOG_BYTE, {
+        isAbbreviated: true,
+      })
+    ).toBe('1,000,000 GB');
+    expect(
+      formatReservedWithUnits(1.234 * MILLION, DataCategory.LOG_BYTE, {
+        isAbbreviated: true,
+      })
+    ).toBe('1,234,000 GB');
+    expect(
+      formatReservedWithUnits(BILLION, DataCategory.LOG_BYTE, {
+        isAbbreviated: true,
+      })
+    ).toBe('1,000,000,000 GB');
+    expect(
+      formatReservedWithUnits(1.234 * BILLION, DataCategory.LOG_BYTE, {
+        isAbbreviated: true,
+      })
+    ).toBe('1,234,000,000 GB');
   });
 });
 

--- a/static/gsApp/utils/billing.tsx
+++ b/static/gsApp/utils/billing.tsx
@@ -150,7 +150,11 @@ export function formatReservedWithUnits(
     return options.isGifted ? '0 GB' : UNLIMITED;
   }
   if (!options.useUnitScaling) {
-    const formatted = formatReservedNumberToString(reservedQuantity, options);
+    const byteOptions =
+      dataCategory === DataCategory.LOG_BYTE
+        ? {...options, isAbbreviated: false}
+        : options;
+    const formatted = formatReservedNumberToString(reservedQuantity, byteOptions);
     return `${formatted} GB`;
   }
 


### PR DESCRIPTION

Closes https://linear.app/getsentry/issue/BIL-1520/subscription-page-showing-multiple-measurement-units-for-logs-5k-gb