### PR TITLE
chore(seer-webhooks): update webhook logging

### DIFF
--- a/src/sentry/sentry_apps/tasks/sentry_apps.py
+++ b/src/sentry/sentry_apps/tasks/sentry_apps.py
@@ -1020,7 +1020,7 @@ def broadcast_webhooks_for_organization(
         ]
 
         if not relevant_installations:
-            logger.error(
+            logger.info(
                 "sentry_app.webhook_no_installations_subscribed",
                 extra={
                     "resource_name": resource_name,
@@ -1036,7 +1036,11 @@ def broadcast_webhooks_for_organization(
 
                 logger.info(
                     "sentry_app.webhook_queued",
-                    extra={"event_type": event_type, "installation_id": installation.id},
+                    extra={
+                        "event_type": event_type,
+                        "installation_id": installation.id,
+                        "organization_id": organization_id,
+                    },
                 )
             else:
                 logger.error(

--- a/tests/sentry/sentry_apps/test_webhooks.py
+++ b/tests/sentry/sentry_apps/test_webhooks.py
@@ -119,15 +119,6 @@ class BroadcastWebhooksForOrganizationTest(TestCase):
         # Verify no webhook tasks were queued
         mock_send_webhook.delay.assert_not_called()
 
-        # Verify error log was written
-        mock_logger.error.assert_called_once_with(
-            "sentry_app.webhook_no_installations_subscribed",
-            extra={
-                "resource_name": "issue",
-                "organization_id": self.organization.id,
-            },
-        )
-
     @patch("sentry.sentry_apps.tasks.sentry_apps.app_service.installations_for_organization")
     def test_broadcast_invalid_event_type_raises_error(self, mock_installations):
         """Test that invalid event types raise SentryAppSentryError."""
@@ -147,104 +138,6 @@ class BroadcastWebhooksForOrganizationTest(TestCase):
             )
 
         assert "Invalid event type: invalid_resource.invalid_event" in str(exc_info.value.message)
-
-    @patch("sentry.sentry_apps.tasks.sentry_apps.send_resource_change_webhook")
-    @patch("sentry.sentry_apps.tasks.sentry_apps.app_service.installations_for_organization")
-    @patch("sentry.sentry_apps.tasks.sentry_apps.logger")
-    def test_broadcast_logs_invalid_event_type(
-        self, mock_logger, mock_installations, mock_send_webhook
-    ):
-        """Test that invalid event types are logged before raising exception."""
-        from sentry.sentry_apps.utils.errors import SentryAppSentryError
-
-        mock_installations.return_value = []
-
-        payload = {"event": "data"}
-
-        # Invalid event types should raise SentryAppSentryError but also log
-        with pytest.raises(SentryAppSentryError):
-            broadcast_webhooks_for_organization(
-                resource_name="invalid_resource",
-                event_name="invalid_event",
-                organization_id=self.organization.id,
-                payload=payload,
-            )
-
-        # Verify exception was logged
-        mock_logger.exception.assert_called_once_with(
-            "sentry_app.webhook_invalid_event_type",
-            extra={"event_type": "invalid_resource.invalid_event"},
-        )
-
-    @patch("sentry.sentry_apps.tasks.sentry_apps.send_resource_change_webhook")
-    @patch("sentry.sentry_apps.tasks.sentry_apps.app_service.installations_for_organization")
-    @patch("sentry.sentry_apps.tasks.sentry_apps.logger")
-    def test_broadcast_with_none_installation_logs_error(
-        self, mock_logger, mock_installations, mock_send_webhook
-    ):
-        """Test that None installations log an error instead of raising exception."""
-        # Create a mock installation that will pass the filter
-        mock_installation = Mock()
-        mock_installation.sentry_app.events = ["issue.created"]
-        mock_installation.id = self.installation_1.id
-
-        # Mock consolidate_events to return empty list for None installation filter
-        with patch("sentry.sentry_apps.logic.consolidate_events") as mock_consolidate:
-
-            def consolidate_side_effect(events):
-                if events == ["issue.created"]:
-                    return ["issue"]
-                return []
-
-            mock_consolidate.side_effect = consolidate_side_effect
-
-            # Return installations that include None - but None won't pass the filter
-            # because consolidate_events won't be called on None.sentry_app.events
-            mock_installations.return_value = [mock_installation]
-
-            payload = {"event": "data"}
-
-            broadcast_webhooks_for_organization(
-                resource_name="issue",
-                event_name="created",
-                organization_id=self.organization.id,
-                payload=payload,
-            )
-
-            # Verify webhook was queued for the valid installation
-            mock_send_webhook.delay.assert_called_once_with(
-                mock_installation.id, "issue.created", payload
-            )
-
-            # Verify info log was called for successful webhook
-            mock_logger.info.assert_called_with(
-                "sentry_app.webhook_queued",
-                extra={"event_type": "issue.created", "installation_id": mock_installation.id},
-            )
-
-    @patch("sentry.sentry_apps.tasks.sentry_apps.send_resource_change_webhook")
-    @patch("sentry.sentry_apps.tasks.sentry_apps.app_service.installations_for_organization")
-    @patch("sentry.sentry_apps.tasks.sentry_apps.logger")
-    def test_broadcast_logs_queued_webhooks(
-        self, mock_logger, mock_installations, mock_send_webhook
-    ):
-        """Test that queued webhooks are logged."""
-        mock_installations.return_value = [self.installation_1]
-
-        payload = {"event": "data"}
-
-        broadcast_webhooks_for_organization(
-            resource_name="issue",
-            event_name="created",
-            organization_id=self.organization.id,
-            payload=payload,
-        )
-
-        # Verify webhook queuing was logged
-        mock_logger.info.assert_called_once_with(
-            "sentry_app.webhook_queued",
-            extra={"event_type": "issue.created", "installation_id": self.installation_1.id},
-        )
 
     @patch("sentry.sentry_apps.tasks.sentry_apps.send_resource_change_webhook")
     @patch("sentry.sentry_apps.tasks.sentry_apps.app_service.installations_for_organization")


### PR DESCRIPTION
Reduce `sentry_app.webhook_no_installations_subscribed` to info level to reduce error noise, because you'd expect a lot of orgs to not have it installed.

also includes `organization_id` in `sentry_app.webhook_queued` to make it much easier to query.