### PR TITLE
ref(feedback): show seer setup link in feedback summary if not enabled

### DIFF
--- a/static/app/components/feedback/summaryCategories/feedbackSummary.tsx
+++ b/static/app/components/feedback/summaryCategories/feedbackSummary.tsx
@@ -1,14 +1,35 @@
 import styled from '@emotion/styled';
 
+import {Link} from 'sentry/components/core/link';
+import {useOrganizationSeerSetup} from 'sentry/components/events/autofix/useOrganizationSeerSetup';
 import useFeedbackSummary from 'sentry/components/feedback/list/useFeedbackSummary';
 import Placeholder from 'sentry/components/placeholder';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
+import useOrganization from 'sentry/utils/useOrganization';
 
 export default function FeedbackSummary() {
   const {isError, isPending, summary, tooFewFeedbacks} = useFeedbackSummary();
 
-  if (isPending) {
+  // if we are showing this component, gen-ai-features must be true
+  // and org.hideAiFeatures must be false,
+  // but we still need to check that their seer acknowledgement exists
+  const {setupAcknowledgement, isPending: isOrgSeerSetupPending} =
+    useOrganizationSeerSetup();
+  const organization = useOrganization();
+
+  if (isPending || isOrgSeerSetupPending) {
     return <LoadingPlaceholder />;
+  }
+
+  if (!setupAcknowledgement.orgHasAcknowledged) {
+    return (
+      <SummaryContent>
+        {tct(
+          'Seer access is required to see feedback summaries. Please view the [link:Seer settings page] for more information.',
+          {link: <Link to={`/settings/${organization.slug}/seer/`} />}
+        )}
+      </SummaryContent>
+    );
   }
 
   if (isError) {
@@ -17,7 +38,7 @@ export default function FeedbackSummary() {
 
   if (tooFewFeedbacks) {
     return (
-      <SummaryContent>{t('Not enough feedback to generate AI summary')}</SummaryContent>
+      <SummaryContent>{t('Not enough feedback to generate AI summary.')}</SummaryContent>
     );
   }
 

--- a/static/app/components/feedback/summaryCategories/feedbackSummaryCategories.tsx
+++ b/static/app/components/feedback/summaryCategories/feedbackSummaryCategories.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import {FeatureBadge} from 'sentry/components/core/badge/featureBadge';
 import {Button} from 'sentry/components/core/button';
 import {Flex} from 'sentry/components/core/layout';
+import {useOrganizationSeerSetup} from 'sentry/components/events/autofix/useOrganizationSeerSetup';
 import FeedbackCategories from 'sentry/components/feedback/summaryCategories/feedbackCategories';
 import FeedbackSummary from 'sentry/components/feedback/summaryCategories/feedbackSummary';
 import {IconThumb} from 'sentry/icons';
@@ -16,10 +17,12 @@ export default function FeedbackSummaryCategories() {
 
   const openForm = useFeedbackForm();
 
+  const {areAiFeaturesAllowed} = useOrganizationSeerSetup();
+
   const showSummaryCategories =
-    organization.features.includes('gen-ai-features') &&
     (organization.features.includes('user-feedback-ai-summaries') ||
-      organization.features.includes('user-feedback-ai-categorization-features'));
+      organization.features.includes('user-feedback-ai-categorization-features')) &&
+    areAiFeaturesAllowed;
 
   if (!showSummaryCategories) {
     return null;


### PR DESCRIPTION
closes https://linear.app/getsentry/issue/REPLAY-678/user-feedback-error-summarizing-feedback-without-explanation

previously, if an org didn't have the seer acknowledgement set up, we would show an error message with no other information. it wasn't that the endpoint errored; it was that the user didn't have the proper permissions:

<img width="409" height="104" alt="SCR-20250908-knju" src="https://github.com/user-attachments/assets/27e3cfa0-4e0c-40f4-a24a-2e0f1d588b25" />

this pr adds a clarifying message to set up seer in settings if that's the issue:

<img width="428" height="138" alt="SCR-20250908-kmvz" src="https://github.com/user-attachments/assets/20b26f6a-5f28-489e-b16d-580e7d8eb67b" />
