### PR TITLE
chore(releases): Use `bulk_create_commit_file_changes` when creating `CommitFileChange` rows

### DIFF
--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -44,7 +44,7 @@ from sentry.plugins.providers.integration_repository import (
     RepoExistsError,
     get_integration_repository_provider,
 )
-from sentry.releases.commits import create_commit
+from sentry.releases.commits import bulk_create_commit_file_changes, create_commit
 from sentry.seer.autofix.webhooks import handle_github_pr_webhook_for_autofix
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.users.services.user.service import user_service
@@ -470,7 +470,7 @@ class PushEventWebhook(GitHubWebhook):
                         )
 
                     if file_changes:
-                        CommitFileChange.objects.bulk_create(file_changes)
+                        bulk_create_commit_file_changes(organization, file_changes)
                         post_bulk_create(file_changes)
 
             except IntegrityError:

--- a/src/sentry/models/releases/set_commits.py
+++ b/src/sentry/models/releases/set_commits.py
@@ -34,7 +34,11 @@ from sentry.models.releasecommit import ReleaseCommit
 from sentry.models.releaseheadcommit import ReleaseHeadCommit
 from sentry.models.repository import Repository
 from sentry.plugins.providers.repository import RepositoryProvider
-from sentry.releases.commits import get_or_create_commit, update_commit
+from sentry.releases.commits import (
+    bulk_create_commit_file_changes,
+    get_or_create_commit,
+    update_commit,
+)
 
 
 class _CommitDataKwargs(TypedDict, total=False):
@@ -142,19 +146,16 @@ def set_commit(idx, data, release):
     # Guard against patch_set being None
     patch_set = data.get("patch_set") or []
     if patch_set:
-        CommitFileChange.objects.bulk_create(
-            [
-                CommitFileChange(
-                    organization_id=release.organization.id,
-                    commit=commit,
-                    filename=patched_file["path"],
-                    type=patched_file["type"],
-                )
-                for patched_file in patch_set
-            ],
-            ignore_conflicts=True,
-            batch_size=100,
-        )
+        file_changes = [
+            CommitFileChange(
+                organization_id=release.organization.id,
+                commit=commit,
+                filename=patched_file["path"],
+                type=patched_file["type"],
+            )
+            for patched_file in patch_set
+        ]
+        bulk_create_commit_file_changes(release.organization, file_changes)
 
     try:
         with atomic_transaction(using=router.db_for_write(ReleaseCommit)):

--- a/src/sentry/releases/commits.py
+++ b/src/sentry/releases/commits.py
@@ -157,6 +157,10 @@ def bulk_create_commit_file_changes(
                 )
                 for old_fc in old_file_changes
             ]
-            new_file_changes = CommitFileChange.objects.bulk_create(new_file_change_objects)
+            new_file_changes = CommitFileChange.objects.bulk_create(
+                new_file_change_objects,
+                ignore_conflicts=True,
+                batch_size=100,
+            )
 
     return old_file_changes, new_file_changes

--- a/src/sentry/releases/commits.py
+++ b/src/sentry/releases/commits.py
@@ -151,20 +151,38 @@ def bulk_create_commit_file_changes(
         )
         new_file_changes = None
         if features.has("organizations:commit-retention-dual-writing", organization):
-            new_file_change_objects = [
-                CommitFileChange(
-                    id=old_fc.id,
-                    organization_id=old_fc.organization_id,
-                    commit_id=old_fc.commit_id,
-                    filename=old_fc.filename,
-                    type=old_fc.type,
-                )
-                for old_fc in old_file_changes
-            ]
-            new_file_changes = CommitFileChange.objects.bulk_create(
-                new_file_change_objects,
-                ignore_conflicts=True,
-                batch_size=100,
+            # Since ignore_conflicts doesn't return IDs, fetch all file changes for the commits
+            # and match them up by filename and type
+            commit_ids = {fc.commit_id for fc in file_changes}
+
+            existing_old_fcs = OldCommitFileChange.objects.filter(
+                commit_id__in=commit_ids,
             )
+            existing_lookup = {
+                (old_fc.commit_id, old_fc.filename, old_fc.type): old_fc
+                for old_fc in existing_old_fcs
+            }
+
+            new_file_change_objects = []
+            for fc in file_changes:
+                key = (fc.commit_id, fc.filename, fc.type)
+                if key in existing_lookup:
+                    old_fc = existing_lookup[key]
+                    new_file_change_objects.append(
+                        CommitFileChange(
+                            id=old_fc.id,
+                            organization_id=old_fc.organization_id,
+                            commit_id=old_fc.commit_id,
+                            filename=old_fc.filename,
+                            type=old_fc.type,
+                        )
+                    )
+
+            if new_file_change_objects:
+                new_file_changes = CommitFileChange.objects.bulk_create(
+                    new_file_change_objects,
+                    ignore_conflicts=True,
+                    batch_size=100,
+                )
 
     return old_file_changes, new_file_changes

--- a/src/sentry/releases/commits.py
+++ b/src/sentry/releases/commits.py
@@ -144,7 +144,11 @@ def bulk_create_commit_file_changes(
             router.db_for_write(CommitFileChange),
         )
     ):
-        old_file_changes = OldCommitFileChange.objects.bulk_create(file_changes)
+        old_file_changes = OldCommitFileChange.objects.bulk_create(
+            file_changes,
+            ignore_conflicts=True,
+            batch_size=100,
+        )
         new_file_changes = None
         if features.has("organizations:commit-retention-dual-writing", organization):
             new_file_change_objects = [

--- a/src/sentry_plugins/github/webhooks/events/push.py
+++ b/src/sentry_plugins/github/webhooks/events/push.py
@@ -15,7 +15,7 @@ from sentry.models.commitfilechange import CommitFileChange
 from sentry.models.organization import Organization
 from sentry.models.repository import Repository
 from sentry.plugins.providers import RepositoryProvider
-from sentry.releases.commits import create_commit
+from sentry.releases.commits import bulk_create_commit_file_changes, create_commit
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.users.services.user.service import user_service
 from sentry_plugins.github.client import GithubPluginClient
@@ -146,6 +146,7 @@ class PushEventWebhook(Webhook):
                 author = authors[author_email]
 
             try:
+                organization = Organization.objects.get(id=organization_id)
                 with transaction.atomic(router.db_for_write(Commit)):
                     c, _ = create_commit(
                         organization=organization,
@@ -179,7 +180,7 @@ class PushEventWebhook(Webhook):
                         )
 
                     if file_changes:
-                        CommitFileChange.objects.bulk_create(file_changes)
+                        bulk_create_commit_file_changes(organization, file_changes)
 
             except IntegrityError:
                 pass

--- a/src/sentry_plugins/github/webhooks/events/push.py
+++ b/src/sentry_plugins/github/webhooks/events/push.py
@@ -146,7 +146,6 @@ class PushEventWebhook(Webhook):
                 author = authors[author_email]
 
             try:
-                organization = Organization.objects.get(id=organization_id)
                 with transaction.atomic(router.db_for_write(Commit)):
                     c, _ = create_commit(
                         organization=organization,

--- a/tests/sentry/releases/test_commits.py
+++ b/tests/sentry/releases/test_commits.py
@@ -499,41 +499,55 @@ class CreateCommitFileChangeDualWriteTest(TestCase):
             assert len(old_file_changes) == 1
             assert new_file_changes is not None
             assert len(new_file_changes) == 1
-            assert new_file_changes[0].id == old_file_changes[0].id
+            # With ignore_conflicts, returned objects don't have IDs, so fetch from DB
+            fetched_old = OldCommitFileChange.objects.get(
+                commit_id=self.commit.id, filename="test_pk.py", type="M"
+            )
+            fetched_new = CommitFileChange.objects.get(
+                commit_id=self.commit.id, filename="test_pk.py", type="M"
+            )
+            assert fetched_new.id == fetched_old.id
             # The IDs should NOT be sequential with the manual file change we created
-            assert new_file_changes[0].id != manual_new_fc.id + 1
-            assert old_file_changes[0].id > dummy_fc2.id
-            fetched_new = CommitFileChange.objects.get(id=old_file_changes[0].id)
+            assert fetched_new.id != manual_new_fc.id + 1
+            assert fetched_old.id > dummy_fc2.id
             assert fetched_new.filename == "test_pk.py"
             assert fetched_new.organization_id == self.organization.id
 
-    def test_create_file_change_transaction_atomicity(self):
-        """Test that the operation is atomic when dual write fails"""
+    def test_create_file_change_idempotent(self):
+        """Test that the operation is idempotent with ignore_conflicts"""
         with self.feature({"organizations:commit-retention-dual-writing": True}):
-            # Create a file change that will conflict on the unique constraint
+            # Create a file change first
             existing_old = OldCommitFileChange.objects.create(
                 organization_id=self.organization.id,
                 commit_id=self.commit.id,
                 filename="unique_file.py",
                 type="A",
             )
-            with pytest.raises(Exception):
-                file_changes = [
-                    OldCommitFileChange(
-                        organization_id=self.organization.id,
-                        commit_id=self.commit.id,
-                        filename="unique_file.py",
-                        type="M",
-                    ),
-                ]
-                bulk_create_commit_file_changes(
-                    organization=self.organization,
-                    file_changes=file_changes,
-                )
+            # Try to create the same file change again (should be ignored, not error)
+            file_changes = [
+                OldCommitFileChange(
+                    organization_id=self.organization.id,
+                    commit_id=self.commit.id,
+                    filename="unique_file.py",
+                    type="A",  # Same type - exact duplicate
+                ),
+            ]
+            # Should not raise due to ignore_conflicts
+            bulk_create_commit_file_changes(
+                organization=self.organization,
+                file_changes=file_changes,
+            )
 
             existing_old.refresh_from_db()
             assert existing_old.type == "A"
-            assert not CommitFileChange.objects.filter(filename="unique_file.py").exists()
+            # Should have dual written the existing one
+            assert CommitFileChange.objects.filter(
+                commit_id=self.commit.id, filename="unique_file.py"
+            ).exists()
+            new_fc = CommitFileChange.objects.get(
+                commit_id=self.commit.id, filename="unique_file.py"
+            )
+            assert new_fc.id == existing_old.id
 
     def test_bulk_create_multiple_file_changes(self):
         """Test that bulk creation works with multiple file changes"""
@@ -580,7 +594,14 @@ class CreateCommitFileChangeDualWriteTest(TestCase):
             assert new_file_changes[2].filename == "file3.py"
             assert new_file_changes[2].type == "D"
 
-            for old_fc, new_fc in zip(old_file_changes, new_file_changes):
+            # With ignore_conflicts, returned objects don't have IDs, so fetch from DB
+            for filename, ftype in [("file1.py", "A"), ("file2.py", "M"), ("file3.py", "D")]:
+                old_fc = OldCommitFileChange.objects.get(
+                    commit_id=self.commit.id, filename=filename, type=ftype
+                )
+                new_fc = CommitFileChange.objects.get(
+                    commit_id=self.commit.id, filename=filename, type=ftype
+                )
                 assert old_fc.id == new_fc.id
 
             assert (


### PR DESCRIPTION
Context: https://www.notion.so/sentry/Release-Retention-2028b10e4b5d802ea421c193303becaf

This updates all creations of `CommitFileChange` to use our dual writing function.

<!-- Describe your PR here. -->