### PR TITLE
chore(timeseries): Improve `/events-timeseries/` spot-check

### DIFF
--- a/static/app/views/insights/common/queries/useDiscoverSeries.ts
+++ b/static/app/views/insights/common/queries/useDiscoverSeries.ts
@@ -139,6 +139,7 @@ const useDiscoverSeries = <T extends string[]>(
       yAxis: yAxis as SpanProperty[],
       interval,
       enabled: isTimeSeriesEndpointComparisonEnabled,
+      sampling: samplingMode,
     },
     `${referrer}-time-series`
   );

--- a/static/app/views/insights/common/queries/useDiscoverSeries.ts
+++ b/static/app/views/insights/common/queries/useDiscoverSeries.ts
@@ -231,7 +231,7 @@ function comparator(
 ) {
   // Compare numbers by near equality, which makes the comparison less sensitive to small natural variations in value caused by request sequencing
   if (key === 'value' && typeof valueA === 'number' && typeof valueB === 'number') {
-    return areNumbersAlmostEqual(valueA, valueB);
+    return areNumbersAlmostEqual(valueA, valueB, 3);
   }
 
   // Otherwise use default deep comparison

--- a/static/app/views/insights/common/queries/useDiscoverSeries.ts
+++ b/static/app/views/insights/common/queries/useDiscoverSeries.ts
@@ -205,6 +205,7 @@ const useDiscoverSeries = <T extends string[]>(
                 ? search
                 : search.formatString()
               : undefined,
+            referrer,
           });
           return;
         }


### PR DESCRIPTION
- Log referrer (easier to track)
- Obey sampling mode (this was an oversight)
- Increase comparison threhold (our tolerance is higher than 0.5 in practice)

The biggest thing here is the increase in toletance. I got some logs that we're seeing data differences, and it's true! Some datapoints in some payloads are different but up to ~2.5% in production! Mysterious, but I think we can chalk it up to natural differences while scanning the data. Regardless, let's elimitate that as a source of logs.
