### PR TITLE
Fix seer api auth header missing

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -761,7 +761,7 @@ RPC_TIMEOUT = 5.0
 # Shared secret used to sign cross-region RPC requests from the seer microservice.
 SEER_RPC_SHARED_SECRET: list[str] | None = None
 # Shared secret used to sign cross-region RPC requests to the seer microservice.
-SEER_API_SHARED_SECRET: str = ""
+SEER_API_SHARED_SECRET: str = os.environ.get("SEER_API_SHARED_SECRET", "")
 
 # Shared secret used to sign cross-region RPC requests from the launchpad microservice.
 LAUNCHPAD_RPC_SHARED_SECRET: list[str] | None = None
@@ -4086,6 +4086,9 @@ if ngrok_host:
 
 if SILO_DEVSERVER or IS_DEV:
     LAUNCHPAD_RPC_SHARED_SECRET = ["launchpad-also-very-long-value-haha"]
+    # Set default SEER_API_SHARED_SECRET for development if not already set
+    if not SEER_API_SHARED_SECRET:
+        SEER_API_SHARED_SECRET = "seer-api-shared-secret-for-dev"
 
 if SILO_DEVSERVER:
     # Add connections for the region & control silo databases.
@@ -4117,6 +4120,7 @@ if SILO_DEVSERVER:
     ]
     RPC_TIMEOUT = 15.0
     SEER_RPC_SHARED_SECRET = ["seers-also-very-long-value-haha"]
+    SEER_API_SHARED_SECRET = "seer-api-shared-secret-for-dev"
 
     # Key for signing integration proxy requests.
     SENTRY_SUBNET_SECRET = "secret-subnet-signature"


### PR DESCRIPTION
<!-- Describe your PR here. -->
Fixes Seer API authentication by ensuring `SEER_API_SHARED_SECRET` is properly loaded. Previously, it was hardcoded to an empty string, causing "No auth header found" errors even when shared secret authentication was enabled. This PR updates `SEER_API_SHARED_SECRET` to load from an environment variable and provides default values for development environments, allowing correct HMAC signature generation for Seer API requests.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
<a href="https://cursor.com/background-agent?bcId=bc-71ba85f9-50ad-4f8a-b83d-605b8a2be6f1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-71ba85f9-50ad-4f8a-b83d-605b8a2be6f1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

