### PR TITLE
chore(ACI): Move fire/resolve logs

### DIFF
--- a/tests/sentry/incidents/subscription_processor/test_subscription_processor.py
+++ b/tests/sentry/incidents/subscription_processor/test_subscription_processor.py
@@ -503,11 +503,6 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
             [
                 call(
                     "incidents.alert_rules.hit_rate_limit",
-                    tags={
-                        "last_incident_id": original_incident.id,
-                        "project_id": self.sub.project.id,
-                        "trigger_id": trigger.id,
-                    },
                 ),
             ],
             any_order=True,

--- a/tests/sentry/incidents/subscription_processor/test_subscription_processor_workflow_engine.py
+++ b/tests/sentry/incidents/subscription_processor/test_subscription_processor_workflow_engine.py
@@ -95,10 +95,10 @@ class ProcessUpdateWorkflowEngineTest(ProcessUpdateComparisonAlertTest):
                     "incidents.alert_rules.threshold.alert",
                     tags={"detection_type": "static"},
                 ),
+                call("incidents.alert_rules.trigger", tags={"type": "fire"}),
                 call(
                     "dual_processing.alert_rules.fire",
                 ),
-                call("incidents.alert_rules.trigger", tags={"type": "fire"}),
                 call(
                     "incidents.alert_rules.threshold.alert",
                     tags={"detection_type": "static"},
@@ -120,18 +120,18 @@ class ProcessUpdateWorkflowEngineTest(ProcessUpdateComparisonAlertTest):
                     "incidents.alert_rules.threshold.alert",
                     tags={"detection_type": "static"},
                 ),
+                call("incidents.alert_rules.trigger", tags={"type": "fire"}),
                 call(
                     "dual_processing.alert_rules.fire",
                 ),
-                call("incidents.alert_rules.trigger", tags={"type": "fire"}),
                 call(
                     "incidents.alert_rules.threshold.resolve",
                     tags={"detection_type": "static"},
                 ),
+                call("incidents.alert_rules.trigger", tags={"type": "resolve"}),
                 call(
                     "dual_processing.alert_rules.resolve",
                 ),
-                call("incidents.alert_rules.trigger", tags={"type": "resolve"}),
             ]
         )
 


### PR DESCRIPTION
Move the logs and metrics for when we fire and resolve a metric alert to below the code that checks for an incident trigger. This ensures that we are only logging when we haven't hit any of the early returns for instances like when we're still in the 10 minute cooldown period or we haven't hit the number of trigger counts (an unused in reality feature). 

Draft because as I write this description I'm not sure if we actually want to do this since workflow engine doesn't have the cooldown this might actually be a better comparison as it is currently.