### PR TITLE
fix(deletions): When deleting events, do not report project is missing

### DIFF
--- a/tests/sentry/deletions/tasks/test_nodestore.py
+++ b/tests/sentry/deletions/tasks/test_nodestore.py
@@ -1,5 +1,7 @@
 from uuid import uuid4
 
+import pytest
+
 from sentry.deletions.tasks.nodestore import (
     delete_events_for_groups_from_nodestore_and_eventstore,
     fetch_events_from_eventstore,
@@ -8,6 +10,7 @@ from sentry.services.eventstore.models import Event
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.referrer import Referrer
 from sentry.testutils.cases import TestCase
+from sentry.utils.snuba import UnqualifiedQueryError
 
 
 class NodestoreDeletionTaskTest(TestCase):
@@ -58,3 +61,33 @@ class NodestoreDeletionTaskTest(TestCase):
         # Events should be deleted from eventstore after nodestore deletion
         events_after = self.fetch_events_from_eventstore(group_ids, dataset=Dataset.Events)
         assert len(events_after) == 0
+
+    def test_deletion_with_project_deleted(self) -> None:
+        """Test nodestore deletion when project is deleted."""
+        events = self.create_n_events_with_group(n_events=5)
+        group_ids = [event.group_id for event in events if event.group_id is not None]
+
+        # Verify events exist in both eventstore and nodestore before deletion
+        events = self.fetch_events_from_eventstore(group_ids, dataset=Dataset.Events)
+        assert len(events) == 5
+
+        # Deleting the project will cause Snuba to raise an error when fetching the event IDs.
+        self.project.delete()
+
+        with self.tasks():
+            # To delete events from the nodestore we fetch the event IDs from the eventstore (Snuba),
+            # however, when we delete the project, Snuba will raise an error.
+            delete_events_for_groups_from_nodestore_and_eventstore.apply_async(
+                kwargs={
+                    "organization_id": self.project.organization_id,
+                    "project_id": self.project.id,
+                    "group_ids": group_ids,
+                    "times_seen": [1] * len(group_ids),
+                    "transaction_id": uuid4().hex,
+                    "dataset_str": Dataset.Events.value,
+                    "referrer": "deletions.groups",
+                },
+            )
+
+        with pytest.raises(UnqualifiedQueryError):
+            self.fetch_events_from_eventstore(group_ids, dataset=Dataset.Events)


### PR DESCRIPTION
When deleting events from the nodestore, we fetch the event ids from the eventstore (Snuba). This requires querying by the project, however, if the project is deleted from PostgreSQL, then Snuba deems the query as invalid.

This change removes reporting the issue to Sentry but allows us to track it via Datadog.

Contributes [SENTRY-4B05](https://sentry.sentry.io/issues/6792120685/)