### PR TITLE
chore(ACI): Remove tags from metric, move to logs

### DIFF
--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -691,9 +691,11 @@ class SubscriptionProcessor:
             and self.subscription.project.id in last_incident_projects
             and ((timezone.now() - last_incident.date_added).seconds / 60) <= 10
         ):
-            metrics.incr(
-                "incidents.alert_rules.hit_rate_limit",
-                tags={
+            rate_limit_string = "incidents.alert_rules.hit_rate_limit"
+            metrics.incr(rate_limit_string)
+            logger.info(
+                rate_limit_string,
+                extra={
                     "last_incident_id": last_incident.id,
                     "project_id": self.subscription.project.id,
                     "trigger_id": trigger.id,


### PR DESCRIPTION
We have some automatic high cardinality tag nuking in Datadog so these aren't showing up - remove them from the metric and move to logs instead so we can actually look it up.