### PR TITLE
fix(aci): Spans with transaction event types

### DIFF
--- a/static/app/views/detectors/datasetConfig/getDetectorDataset.tsx
+++ b/static/app/views/detectors/datasetConfig/getDetectorDataset.tsx
@@ -22,17 +22,10 @@ export const getDetectorDataset = (
       return DetectorDataset.TRANSACTIONS;
     }
     case Dataset.EVENTS_ANALYTICS_PLATFORM: {
-      // Spans and logs use the same dataset
-      if (eventTypes.includes(EventTypes.TRACE_ITEM_SPAN)) {
-        return DetectorDataset.SPANS;
-      }
       if (eventTypes.includes(EventTypes.TRACE_ITEM_LOG)) {
         return DetectorDataset.LOGS;
       }
-      if (eventTypes.includes(EventTypes.TRANSACTION)) {
-        return DetectorDataset.TRANSACTIONS;
-      }
-      throw new Error(`Unsupported event types`);
+      return DetectorDataset.SPANS;
     }
     case Dataset.METRICS:
     case Dataset.SESSIONS:

--- a/static/app/views/detectors/datasetConfig/logs.tsx
+++ b/static/app/views/detectors/datasetConfig/logs.tsx
@@ -16,7 +16,6 @@ import {
 } from 'sentry/views/detectors/datasetConfig/utils/timePeriods';
 
 import type {DetectorDatasetConfig} from './base';
-import {parseEventTypesFromQuery} from './eventTypes';
 
 type LogsSeriesRepsonse = EventsStats;
 
@@ -40,8 +39,9 @@ export const DetectorLogsConfig: DetectorDatasetConfig<LogsSeriesRepsonse> = {
     return intervals.filter(interval => interval > MetricDetectorInterval.ONE_MINUTE);
   },
   getTimePeriods: interval => getEapTimePeriodsForInterval(interval),
-  separateEventTypesFromQuery: query =>
-    parseEventTypesFromQuery(query, DEFAULT_EVENT_TYPES),
+  separateEventTypesFromQuery: query => {
+    return {eventTypes: [EventTypes.TRACE_ITEM_LOG], query};
+  },
   toSnubaQueryString: snubaQuery => snubaQuery?.query ?? '',
   transformSeriesQueryData: (data, aggregate) => {
     return [transformEventsStatsToSeries(data, aggregate)];

--- a/static/app/views/detectors/datasetConfig/spans.spec.tsx
+++ b/static/app/views/detectors/datasetConfig/spans.spec.tsx
@@ -1,0 +1,20 @@
+import {EventTypes} from 'sentry/views/alerts/rules/metric/types';
+import {DetectorSpansConfig} from 'sentry/views/detectors/datasetConfig/spans';
+
+describe('spans.separateEventTypesFromQuery', () => {
+  it('returns transaction type and preserves query when is_transaction:true', () => {
+    const input = 'is_transaction:true';
+    const {eventTypes, query} = DetectorSpansConfig.separateEventTypesFromQuery(input);
+
+    expect(eventTypes).toEqual([EventTypes.TRANSACTION]);
+    expect(query).toBe(input);
+  });
+
+  it('returns span type and preserves query when not present', () => {
+    const input = 'op:http.client status_code:200';
+    const {eventTypes, query} = DetectorSpansConfig.separateEventTypesFromQuery(input);
+
+    expect(eventTypes).toEqual([EventTypes.TRACE_ITEM_SPAN]);
+    expect(query).toBe(input);
+  });
+});


### PR DESCRIPTION
Correctly set eventType to transaction when saving span queries that are filtered down to just transactions. Also fixes determining the detector dataset when loading.
