### PR TITLE
Fix seer api auth header missing

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -761,7 +761,7 @@ RPC_TIMEOUT = 5.0
 # Shared secret used to sign cross-region RPC requests from the seer microservice.
 SEER_RPC_SHARED_SECRET: list[str] | None = None
 # Shared secret used to sign cross-region RPC requests to the seer microservice.
-SEER_API_SHARED_SECRET: str = ""
+SEER_API_SHARED_SECRET: str = os.environ.get("SEER_API_SHARED_SECRET", "")
 
 # Shared secret used to sign cross-region RPC requests from the launchpad microservice.
 LAUNCHPAD_RPC_SHARED_SECRET: list[str] | None = None
@@ -4117,6 +4117,7 @@ if SILO_DEVSERVER:
     ]
     RPC_TIMEOUT = 15.0
     SEER_RPC_SHARED_SECRET = ["seers-also-very-long-value-haha"]
+    SEER_API_SHARED_SECRET = "seer-api-also-very-long-value-haha"
 
     # Key for signing integration proxy requests.
     SENTRY_SUBNET_SECRET = "secret-subnet-signature"


### PR DESCRIPTION
Fixes an issue where Seer API requests failed with "No auth header found" when `seer.api.use-shared-secret` was enabled.

**Why:**
The `SEER_API_SHARED_SECRET` was hardcoded as an empty string, preventing the generation of necessary authentication headers. This PR updates `SEER_API_SHARED_SECRET` to be configurable via an environment variable and provides a default value for `SILO_DEVSERVER` mode. This ensures proper authentication for Seer API requests in both production and development environments.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
<a href="https://cursor.com/background-agent?bcId=bc-bdc50860-ac14-4e1b-9c2c-18489337803a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bdc50860-ac14-4e1b-9c2c-18489337803a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

