### PR TITLE
chore(ACI): Don't incr metric/logs for snoozed rule, add tests

### DIFF
--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -336,6 +336,9 @@ class SubscriptionProcessor:
         alert_operator, resolve_operator = self.THRESHOLD_TYPE_OPERATORS[
             AlertRuleThresholdType(self.alert_rule.threshold_type)
         ]
+        snooze_queryset = RuleSnooze.objects.filter(
+            alert_rule_id=self.alert_rule.id, user_id__isnull=True
+        )
         if alert_operator(
             aggregation_value, trigger.alert_threshold
         ) and not self.check_trigger_matches_status(trigger, TriggerStatus.ACTIVE):
@@ -346,9 +349,7 @@ class SubscriptionProcessor:
                 tags={"detection_type": self.alert_rule.detection_type},
             )
             if has_dual_processing_flag:
-                is_rule_globally_snoozed = RuleSnooze.objects.filter(
-                    alert_rule_id=self.alert_rule.id, user_id__isnull=True
-                ).exists()
+                is_rule_globally_snoozed = snooze_queryset.exists()
                 if detector is not None and not is_rule_globally_snoozed:
                     logger.info(
                         "subscription_processor.alert_triggered",
@@ -381,9 +382,7 @@ class SubscriptionProcessor:
                 tags={"detection_type": self.alert_rule.detection_type},
             )
             if has_dual_processing_flag:
-                is_rule_globally_snoozed = RuleSnooze.objects.filter(
-                    alert_rule_id=self.alert_rule.id, user_id__isnull=True
-                ).exists()
+                is_rule_globally_snoozed = snooze_queryset.exists()
                 if detector is not None and not is_rule_globally_snoozed:
                     logger.info(
                         "subscription_processor.alert_triggered",

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -341,7 +341,6 @@ class SubscriptionProcessor:
         )
         logger_extra = {
             "rule_id": self.alert_rule.id,
-            "detector_id": detector.id,
             "organization_id": self.subscription.project.organization.id,
             "project_id": self.subscription.project.id,
             "aggregation_value": aggregation_value,
@@ -359,6 +358,7 @@ class SubscriptionProcessor:
             if has_dual_processing_flag:
                 is_rule_globally_snoozed = snooze_queryset.exists()
                 if detector is not None and not is_rule_globally_snoozed:
+                    logger_extra["detector_id"] = detector.id
                     logger.info(
                         "subscription_processor.alert_triggered",
                         extra=logger_extra,
@@ -385,6 +385,7 @@ class SubscriptionProcessor:
             if has_dual_processing_flag:
                 is_rule_globally_snoozed = snooze_queryset.exists()
                 if detector is not None and not is_rule_globally_snoozed:
+                    logger_extra["detector_id"] = detector.id
                     logger.info(
                         "subscription_processor.alert_triggered",
                         extra=logger_extra,

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -361,7 +361,7 @@ class SubscriptionProcessor:
                             "trigger_id": trigger.id,
                         },
                     )
-                if not metrics_incremented:
+                if not metrics_incremented and not is_rule_globally_snoozed:
                     metrics.incr("dual_processing.alert_rules.fire")
                     metrics_incremented = True
             # triggering a threshold will create an incident and set the status to active

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -339,6 +339,14 @@ class SubscriptionProcessor:
         snooze_queryset = RuleSnooze.objects.filter(
             alert_rule_id=self.alert_rule.id, user_id__isnull=True
         )
+        logger_extra = {
+            "rule_id": self.alert_rule.id,
+            "detector_id": detector.id,
+            "organization_id": self.subscription.project.organization.id,
+            "project_id": self.subscription.project.id,
+            "aggregation_value": aggregation_value,
+            "trigger_id": trigger.id,
+        }
         if alert_operator(
             aggregation_value, trigger.alert_threshold
         ) and not self.check_trigger_matches_status(trigger, TriggerStatus.ACTIVE):
@@ -353,14 +361,7 @@ class SubscriptionProcessor:
                 if detector is not None and not is_rule_globally_snoozed:
                     logger.info(
                         "subscription_processor.alert_triggered",
-                        extra={
-                            "rule_id": self.alert_rule.id,
-                            "detector_id": detector.id,
-                            "organization_id": self.subscription.project.organization.id,
-                            "project_id": self.subscription.project.id,
-                            "aggregation_value": aggregation_value,
-                            "trigger_id": trigger.id,
-                        },
+                        extra=logger_extra,
                     )
                 if not metrics_incremented and not is_rule_globally_snoozed:
                     metrics.incr("dual_processing.alert_rules.fire")
@@ -386,14 +387,7 @@ class SubscriptionProcessor:
                 if detector is not None and not is_rule_globally_snoozed:
                     logger.info(
                         "subscription_processor.alert_triggered",
-                        extra={
-                            "rule_id": self.alert_rule.id,
-                            "detector_id": detector.id,
-                            "organization_id": self.subscription.project.organization.id,
-                            "project_id": self.subscription.project.id,
-                            "aggregation_value": aggregation_value,
-                            "trigger_id": trigger.id,
-                        },
+                        extra=logger_extra,
                     )
                 if not is_rule_globally_snoozed:
                     metrics.incr("dual_processing.alert_rules.resolve")

--- a/tests/sentry/incidents/subscription_processor/test_subscription_processor_workflow_engine.py
+++ b/tests/sentry/incidents/subscription_processor/test_subscription_processor_workflow_engine.py
@@ -108,6 +108,52 @@ class ProcessUpdateWorkflowEngineTest(ProcessUpdateComparisonAlertTest):
         )
 
     @with_feature("organizations:workflow-engine-metric-alert-dual-processing-logs")
+    @with_feature("organizations:workflow-engine-metric-alert-processing")
+    @patch("sentry.incidents.subscription_processor.metrics")
+    @patch("sentry.incidents.subscription_processor.logger")
+    def test_snoozed_alert_metrics_logging(
+        self, mock_logger: MagicMock, mock_metrics: MagicMock
+    ) -> None:
+        """
+        Test that we are logging when we enter workflow engine at the same rate as we store a metric for firing a snoozed alert
+        """
+        rule = self.rule
+        trigger = self.trigger
+        detector = self.create_detector(name="hojicha", type=MetricIssue.slug)
+        data_source = self.create_data_source(source_id=str(self.sub.id))
+        data_source.detectors.set([detector])
+        self.create_alert_rule_detector(alert_rule_id=rule.id, detector=detector)
+        # create a warning trigger
+        create_alert_rule_trigger(self.rule, WARNING_TRIGGER_LABEL, trigger.alert_threshold - 1)
+        self.snooze_rule(owner_id=self.user.id, alert_rule=rule)
+        self.send_update(rule, trigger.alert_threshold + 1)
+        assert mock_logger.info.call_count == 1
+        logger_extra = {
+            "results": [],
+            "num_results": 0,
+            "value": trigger.alert_threshold + 1,
+            "rule_id": rule.id,
+        }
+        mock_logger.info.assert_any_call(
+            "dual processing results for alert rule",
+            extra=logger_extra,
+        )
+        mock_metrics.incr.assert_has_calls(
+            [
+                call(
+                    "incidents.alert_rules.threshold.alert",
+                    tags={"detection_type": "static"},
+                ),
+                call("incidents.alert_rules.trigger", tags={"type": "fire"}),
+                call(
+                    "incidents.alert_rules.threshold.alert",
+                    tags={"detection_type": "static"},
+                ),
+                call("incidents.alert_rules.trigger", tags={"type": "fire"}),
+            ],
+        )
+
+    @with_feature("organizations:workflow-engine-metric-alert-dual-processing-logs")
     @patch("sentry.incidents.subscription_processor.metrics")
     def test_resolve_metrics(self, mock_metrics: MagicMock) -> None:
         rule = self.rule

--- a/tests/sentry/incidents/subscription_processor/test_subscription_processor_workflow_engine.py
+++ b/tests/sentry/incidents/subscription_processor/test_subscription_processor_workflow_engine.py
@@ -154,9 +154,15 @@ class ProcessUpdateWorkflowEngineTest(ProcessUpdateComparisonAlertTest):
         )
 
     @with_feature("organizations:workflow-engine-metric-alert-dual-processing-logs")
+    @with_feature("organizations:workflow-engine-metric-alert-processing")
     @patch("sentry.incidents.subscription_processor.metrics")
-    def test_resolve_metrics(self, mock_metrics: MagicMock) -> None:
+    @patch("sentry.incidents.subscription_processor.logger")
+    def test_resolve_metrics_logging(self, mock_logger: MagicMock, mock_metrics: MagicMock) -> None:
         rule = self.rule
+        detector = self.create_detector(name="hojicha", type=MetricIssue.slug)
+        data_source = self.create_data_source(source_id=str(self.sub.id))
+        data_source.detectors.set([detector])
+        self.create_alert_rule_detector(alert_rule_id=rule.id, detector=detector)
         trigger = self.trigger
         self.send_update(rule, trigger.alert_threshold + 1, timedelta(minutes=-2))
         self.send_update(rule, rule.resolve_threshold - 1, timedelta(minutes=-1))
@@ -180,6 +186,51 @@ class ProcessUpdateWorkflowEngineTest(ProcessUpdateComparisonAlertTest):
                 call("incidents.alert_rules.trigger", tags={"type": "resolve"}),
             ]
         )
+        assert mock_logger.info.call_count == 4
+        other_extra = {
+            "rule_id": rule.id,
+            "detector_id": detector.id,
+            "organization_id": rule.organization_id,
+            "project_id": self.project.id,
+            "aggregation_value": trigger.alert_threshold + 1,
+            "trigger_id": trigger.id,
+        }
+        mock_logger.info.assert_any_call(
+            "subscription_processor.alert_triggered",
+            extra=other_extra,
+        )
+
+    @with_feature("organizations:workflow-engine-metric-alert-dual-processing-logs")
+    @with_feature("organizations:workflow-engine-metric-alert-processing")
+    @patch("sentry.incidents.subscription_processor.metrics")
+    @patch("sentry.incidents.subscription_processor.logger")
+    def test_snoozed_resolve_metrics_logging(
+        self, mock_logger: MagicMock, mock_metrics: MagicMock
+    ) -> None:
+        rule = self.rule
+        self.snooze_rule(owner_id=self.user.id, alert_rule=rule)
+        detector = self.create_detector(name="hojicha", type=MetricIssue.slug)
+        data_source = self.create_data_source(source_id=str(self.sub.id))
+        data_source.detectors.set([detector])
+        self.create_alert_rule_detector(alert_rule_id=rule.id, detector=detector)
+        trigger = self.trigger
+        self.send_update(rule, trigger.alert_threshold + 1, timedelta(minutes=-2))
+        self.send_update(rule, rule.resolve_threshold - 1, timedelta(minutes=-1))
+        mock_metrics.incr.assert_has_calls(
+            [
+                call(
+                    "incidents.alert_rules.threshold.alert",
+                    tags={"detection_type": "static"},
+                ),
+                call("incidents.alert_rules.trigger", tags={"type": "fire"}),
+                call(
+                    "incidents.alert_rules.threshold.resolve",
+                    tags={"detection_type": "static"},
+                ),
+                call("incidents.alert_rules.trigger", tags={"type": "resolve"}),
+            ]
+        )
+        assert mock_logger.info.call_count == 2
 
     @patch("sentry.incidents.subscription_processor.metrics")
     def test_alert(self, mock_metrics: MagicMock) -> None:


### PR DESCRIPTION
I am seeing instances of globally snoozed rules still logging that the rule is firing/resolving (these are reported the same) and I realized that I missed the check on resolve, so this PR adds that and test coverage around it. I also was incrementing the metric even if the rule was globally snoozed so that is fixed as well.

TODO: We are not yet tracking the same data for anomaly detection alerts, there will be a follow up PR to do that