### PR TITLE
feat(performance): Updates Web Vital issue endpoint to accept a timestamp for event creation

### DIFF
--- a/src/sentry/issues/endpoints/project_user_issue.py
+++ b/src/sentry/issues/endpoints/project_user_issue.py
@@ -157,6 +157,7 @@ class ProjectUserIssueRequestSerializer(serializers.Serializer):
     transaction = serializers.CharField(required=True)
     issueType = serializers.ChoiceField(required=True, choices=ISSUE_TYPE_CHOICES)
     traceId = serializers.CharField(required=False)
+    timestamp = serializers.DateTimeField(required=False)
 
 
 class WebVitalsIssueDataSerializer(ProjectUserIssueRequestSerializer):
@@ -249,6 +250,9 @@ class ProjectUserIssueEndpoint(ProjectEndpoint):
             "received": now.isoformat(),
             "tags": formatter.get_tags(),
         }
+
+        if validated_data.get("timestamp"):
+            event_data["timestamp"] = validated_data["timestamp"].isoformat()
 
         if validated_data.get("traceId"):
             event_data["contexts"] = {

--- a/tests/sentry/issues/endpoints/test_project_user_issue.py
+++ b/tests/sentry/issues/endpoints/test_project_user_issue.py
@@ -40,6 +40,7 @@ class ProjectUserIssueEndpointTest(APITestCase):
             "score": 75,
             "vital": "lcp",
             "traceId": "1234567890",
+            "timestamp": "2025-01-01T00:00:00Z",
         }
 
         with patch(
@@ -77,8 +78,8 @@ class ProjectUserIssueEndpointTest(APITestCase):
         # Verify event data
         assert event_data["project_id"] == self.project.id
         assert event_data["platform"] == self.project.platform
+        assert event_data["timestamp"] == "2025-01-01T00:00:00+00:00"
         assert "event_id" in event_data
-        assert "timestamp" in event_data
         assert "received" in event_data
         assert event_data["tags"] == {
             "transaction": "/test-transaction",


### PR DESCRIPTION
Update endpoint to accept `timestamp` for issue event creation