### PR TITLE
feat(performance): Updates Web Vital issue creation to send also trace timestamp

### DIFF
--- a/static/app/views/insights/browser/webVitals/components/pageOverviewSidebar.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/components/pageOverviewSidebar.spec.tsx
@@ -43,7 +43,7 @@ describe('PageOverviewSidebar', () => {
     eventsMock = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/`,
       body: {
-        data: [{trace: '123'}],
+        data: [{trace: '123', timestamp: '2025-01-01T00:00:00Z'}],
       },
     });
 
@@ -188,6 +188,7 @@ describe('PageOverviewSidebar', () => {
             score: 80,
             transaction: TRANSACTION_NAME,
             traceId: '123',
+            timestamp: '2025-01-01T00:00:00Z',
           }),
         })
       );
@@ -203,6 +204,7 @@ describe('PageOverviewSidebar', () => {
           score: 100,
           transaction: TRANSACTION_NAME,
           traceId: '123',
+          timestamp: '2025-01-01T00:00:00Z',
         }),
       })
     );

--- a/static/app/views/insights/browser/webVitals/queries/useSampleWebVitalTrace.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/useSampleWebVitalTrace.tsx
@@ -67,7 +67,7 @@ function useSampleWebVitalTrace({
     {
       search,
       sorts: [{field: `measurements.${webVital}`, kind: 'asc'}],
-      fields: [SpanFields.TRACE, field],
+      fields: [SpanFields.TRACE, SpanFields.TIMESTAMP, field],
       enabled: defined(p75Value) && enabled,
       limit: 1, // We only need one sample to attach to the issue
     },
@@ -114,12 +114,13 @@ export function useSampleWebVitalTraceParallel({
   });
   const isLoading =
     isLcpLoading || isClsLoading || isFcpLoading || isTtfbLoading || isInpLoading;
+
   return {
-    lcp: lcp?.[0]?.[SpanFields.TRACE],
-    cls: cls?.[0]?.[SpanFields.TRACE],
-    fcp: fcp?.[0]?.[SpanFields.TRACE],
-    ttfb: ttfb?.[0]?.[SpanFields.TRACE],
-    inp: inp?.[0]?.[SpanFields.TRACE],
+    lcp: lcp?.[0],
+    cls: cls?.[0],
+    fcp: fcp?.[0],
+    ttfb: ttfb?.[0],
+    inp: inp?.[0],
     isLoading,
   };
 }

--- a/static/app/views/insights/browser/webVitals/utils/useRunSeerAnalysis.tsx
+++ b/static/app/views/insights/browser/webVitals/utils/useRunSeerAnalysis.tsx
@@ -6,12 +6,17 @@ import {useInvalidateWebVitalsIssuesQuery} from 'sentry/views/insights/browser/w
 import type {ProjectScore} from 'sentry/views/insights/browser/webVitals/types';
 import {useCreateIssue} from 'sentry/views/insights/browser/webVitals/utils/useCreateIssue';
 
+type WebVitalTraceSample = {
+  timestamp: string;
+  trace: string;
+};
+
 type WebVitalTraceSamples = {
-  cls?: string;
-  fcp?: string;
-  inp?: string;
-  lcp?: string;
-  ttfb?: string;
+  cls?: WebVitalTraceSample;
+  fcp?: WebVitalTraceSample;
+  inp?: WebVitalTraceSample;
+  lcp?: WebVitalTraceSample;
+  ttfb?: WebVitalTraceSample;
 };
 
 // Creates a new issue for each web vital that has a score under 90 and runs seer autofix for each of them
@@ -45,7 +50,8 @@ export function useRunSeerAnalysis({
           vital: webVital,
           score: projectScore[`${webVital}Score`],
           transaction,
-          traceId: webVitalTraceSamples[webVital],
+          traceId: webVitalTraceSamples[webVital]?.trace,
+          timestamp: webVitalTraceSamples[webVital]?.timestamp,
         });
         return result.event_id;
       } catch (error) {

--- a/static/app/views/insights/browser/webVitals/utils/useRunSeerAnalysis.tsx
+++ b/static/app/views/insights/browser/webVitals/utils/useRunSeerAnalysis.tsx
@@ -5,6 +5,7 @@ import {ORDER} from 'sentry/views/insights/browser/webVitals/components/charts/p
 import {useInvalidateWebVitalsIssuesQuery} from 'sentry/views/insights/browser/webVitals/queries/useWebVitalsIssuesQuery';
 import type {ProjectScore} from 'sentry/views/insights/browser/webVitals/types';
 import {useCreateIssue} from 'sentry/views/insights/browser/webVitals/utils/useCreateIssue';
+import type {SpanFields, SpanResponse} from 'sentry/views/insights/types';
 
 type WebVitalTraceSample = Pick<SpanResponse, SpanFields.Timestamp | SpanFields.Trace>;
 

--- a/static/app/views/insights/browser/webVitals/utils/useRunSeerAnalysis.tsx
+++ b/static/app/views/insights/browser/webVitals/utils/useRunSeerAnalysis.tsx
@@ -7,7 +7,7 @@ import type {ProjectScore} from 'sentry/views/insights/browser/webVitals/types';
 import {useCreateIssue} from 'sentry/views/insights/browser/webVitals/utils/useCreateIssue';
 import type {SpanFields, SpanResponse} from 'sentry/views/insights/types';
 
-type WebVitalTraceSample = Pick<SpanResponse, SpanFields.Timestamp | SpanFields.Trace>;
+type WebVitalTraceSample = Pick<SpanResponse, SpanFields.TIMESTAMP | SpanFields.TRACE>;
 
 type WebVitalTraceSamples = {
   cls?: WebVitalTraceSample;

--- a/static/app/views/insights/browser/webVitals/utils/useRunSeerAnalysis.tsx
+++ b/static/app/views/insights/browser/webVitals/utils/useRunSeerAnalysis.tsx
@@ -6,10 +6,7 @@ import {useInvalidateWebVitalsIssuesQuery} from 'sentry/views/insights/browser/w
 import type {ProjectScore} from 'sentry/views/insights/browser/webVitals/types';
 import {useCreateIssue} from 'sentry/views/insights/browser/webVitals/utils/useCreateIssue';
 
-type WebVitalTraceSample = {
-  timestamp: string;
-  trace: string;
-};
+type WebVitalTraceSample = Pick<SpanResponse, SpanFields.Timestamp | SpanFields.Trace>;
 
 type WebVitalTraceSamples = {
   cls?: WebVitalTraceSample;


### PR DESCRIPTION
Updates Web Vital issue creation to send also trace timestamp when calling post `/user-issue`.