### PR TITLE
feat(suspect commits): Add group_owner_id to committers endpoint response

### DIFF
--- a/src/sentry/api/endpoints/event_file_committers.py
+++ b/src/sentry/api/endpoints/event_file_committers.py
@@ -19,10 +19,10 @@ class EventFileCommittersEndpoint(ProjectEndpoint):
 
     def get(self, request: Request, project, event_id) -> Response:
         """
-        Retrieve Committer information for an event
+        Retrieve Suspect Commit information for an event
         ```````````````````````````````````````````
 
-        Return committers on an individual event, plus a per-frame breakdown.
+        Return suspect commits on an individual event.
 
         :pparam string project_id_or_slug: the id or slug of the project the event
                                      belongs to.

--- a/src/sentry/utils/committers.py
+++ b/src/sentry/utils/committers.py
@@ -129,6 +129,7 @@ class AuthorCommits(TypedDict):
 
 
 class AuthorCommitsSerialized(TypedDict):
+    group_owner_id: int
     author: Author | None
     commits: Sequence[MutableMapping[str, Any]]
 
@@ -197,6 +198,7 @@ def _get_serialized_committers_from_group_owners(
 
     return [
         {
+            "group_owner_id": owner.id,
             "author": author,
             "commits": [
                 serialize(

--- a/tests/sentry/api/endpoints/test_event_committers.py
+++ b/tests/sentry/api/endpoints/test_event_committers.py
@@ -64,6 +64,12 @@ class EventCommittersTest(APITestCase):
         assert commits[0]["message"] == commit.message
         assert commits[0]["suspectCommitType"] == "via commit in release"
 
+        group_owner = GroupOwner.objects.get(
+            group=event.group, type=GroupOwnerType.SUSPECT_COMMIT.value
+        )
+        assert "group_owner_id" in response.data["committers"][0]
+        assert response.data["committers"][0]["group_owner_id"] == group_owner.id
+
     def test_no_group(self) -> None:
         self.login_as(user=self.user)
 
@@ -162,6 +168,12 @@ class EventCommittersTest(APITestCase):
         assert len(commits) == 1
         assert commits[0]["message"] == "placeholder commit message"
         assert commits[0]["suspectCommitType"] == "via SCM integration"
+
+        group_owner = GroupOwner.objects.get(
+            group=event.group, type=GroupOwnerType.SUSPECT_COMMIT.value
+        )
+        assert "group_owner_id" in response.data["committers"][0]
+        assert response.data["committers"][0]["group_owner_id"] == group_owner.id
 
     def test_with_commit_context_pull_request(self) -> None:
         self.login_as(user=self.user)
@@ -273,3 +285,9 @@ class EventCommittersTest(APITestCase):
         assert author["name"] == "External Dev"
         assert "username" not in author  # No Sentry user fields
         assert "id" not in author  # No Sentry user fields
+
+        group_owner = GroupOwner.objects.get(
+            group_id=event.group.id, type=GroupOwnerType.SUSPECT_COMMIT.value
+        )
+        assert "group_owner_id" in response.data["committers"][0]
+        assert response.data["committers"][0]["group_owner_id"] == group_owner.id

--- a/tests/sentry/utils/test_committers.py
+++ b/tests/sentry/utils/test_committers.py
@@ -268,6 +268,11 @@ class GetSerializedEventFileCommitters(CommitTestCase):
         assert result[0]["commits"][0]["id"] == commit.key
         assert result[0]["commits"][0]["suspectCommitType"] == "via SCM integration"
 
+        group_owner = GroupOwner.objects.get(
+            group_id=event.group.id, type=GroupOwnerType.SUSPECT_COMMIT.value
+        )
+        assert result[0]["group_owner_id"] == group_owner.id
+
     def test_with_release_based_groupowner(self) -> None:
         """Test that release-based GroupOwner returns expected commit data."""
         event = self.store_event(
@@ -296,6 +301,11 @@ class GetSerializedEventFileCommitters(CommitTestCase):
         assert len(result[0]["commits"]) == 1
         assert result[0]["commits"][0]["id"] == commit.key
         assert result[0]["commits"][0]["suspectCommitType"] == "via commit in release"
+
+        group_owner = GroupOwner.objects.get(
+            group_id=event.group.id, type=GroupOwnerType.SUSPECT_COMMIT.value
+        )
+        assert result[0]["group_owner_id"] == group_owner.id
 
     def test_with_multiple_groupowners(self) -> None:
         """Test that multiple GroupOwners return the most recent one only."""
@@ -336,6 +346,17 @@ class GetSerializedEventFileCommitters(CommitTestCase):
         # Should return the most recent one only
         assert len(result) == 1
         assert result[0]["commits"][0]["id"] == commit2.key
+
+        # Check group_owner_id matches the most recent GroupOwner
+        most_recent_group_owner = (
+            GroupOwner.objects.filter(
+                group_id=event.group.id, type=GroupOwnerType.SUSPECT_COMMIT.value
+            )
+            .order_by("-date_added")
+            .first()
+        )
+        assert most_recent_group_owner is not None
+        assert result[0]["group_owner_id"] == most_recent_group_owner.id
 
     def test_no_groupowners(self) -> None:
         """Test that no GroupOwners returns empty list."""
@@ -469,6 +490,11 @@ class GetSerializedEventFileCommitters(CommitTestCase):
         assert "id" not in author  # No Sentry user data
         assert result[0]["commits"][0]["id"] == commit.key
         assert result[0]["commits"][0]["suspectCommitType"] == "via SCM integration"
+
+        group_owner = GroupOwner.objects.get(
+            group_id=group.id, type=GroupOwnerType.SUSPECT_COMMIT.value
+        )
+        assert result[0]["group_owner_id"] == group_owner.id
 
 
 class DedupeCommits(CommitTestCase):


### PR DESCRIPTION
All suspect commits are now GroupOwners, so every object returned from this response will have a `group_owner_id`.

Having the `group_owner_id` for each suspect commit on the frontend side allows us to add feedback analytics (in draft [here](https://github.com/getsentry/sentry/pull/99056))