### PR TITLE
chore(aci): add action triggering to ecosystem codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -386,6 +386,7 @@ pnpm-lock.yaml                                           @getsentry/owners-js-de
 /src/sentry/pipeline/                                                @getsentry/ecosystem
 /src/sentry/plugins/                                                 @getsentry/ecosystem
 /src/sentry/shared_integrations/                                     @getsentry/ecosystem
+/src/sentry/workflow_engine/tasks/actions.py                         @getsentry/ecosystem
 
 /src/sentry/users/models/identity.py                                 @getsentry/enterprise
 


### PR DESCRIPTION
Hopefully this will help auto-assign action triggering issues to Ecosystem team.