### PR TITLE
chore(aci): remove individual user muting option on rule creation

### DIFF
--- a/static/app/components/alerts/snoozeAlert.tsx
+++ b/static/app/components/alerts/snoozeAlert.tsx
@@ -4,11 +4,8 @@ import styled from '@emotion/styled';
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {Button} from 'sentry/components/core/button';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
-import type {MenuItemProps} from 'sentry/components/dropdownMenu';
-import {DropdownMenu} from 'sentry/components/dropdownMenu';
-import {IconChevron, IconMute, IconSound} from 'sentry/icons';
+import {IconMute, IconSound} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {RuleActionsCategories} from 'sentry/types/alerts';
 import useApi from 'sentry/utils/useApi';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
@@ -23,7 +20,6 @@ type Props = {
     snoozeForEveryone?: boolean;
   }) => void;
   projectSlug: string;
-  ruleActionCategory: RuleActionsCategories;
   type: 'issue' | 'metric';
   disabled?: boolean;
   ruleId?: string;
@@ -34,7 +30,6 @@ function SnoozeAlert({
   onSnooze,
   projectSlug,
   ruleId,
-  ruleActionCategory,
   hasAccess,
   type,
   disabled: alwaysDisabled,
@@ -126,33 +121,13 @@ function SnoozeAlert({
     }
   }
 
-  const primaryMuteAction =
-    ruleActionCategory === RuleActionsCategories.ALL_DEFAULT ? 'me' : 'everyone';
+  const primaryMuteAction = 'everyone';
 
   useEffect(() => {
     if (location.query.mute === '1' && !isSnoozed) {
       handleMute(primaryMuteAction, true);
     }
   }, [location.query, isSnoozed, handleMute, primaryMuteAction]);
-
-  const dropdownItems: MenuItemProps[] = [
-    {
-      key: 'me',
-      label: t('Mute for me'),
-      onAction: () => handleMute('me'),
-      // Hidden if all default actions because it will be the primary button and no default actions since it shouldn't be an option
-      hidden: ruleActionCategory !== RuleActionsCategories.SOME_DEFAULT,
-    },
-    {
-      key: 'everyone',
-      label: t('Mute for everyone'),
-      onAction: () => handleMute('everyone'),
-      // Hidden if some default or no default actions since it will be the primary button, not in dropdown
-      hidden: ruleActionCategory !== RuleActionsCategories.ALL_DEFAULT,
-    },
-  ];
-
-  const hasDropdown = dropdownItems.some(item => !item.hidden);
 
   if (isSnoozed) {
     return (
@@ -172,39 +147,18 @@ function SnoozeAlert({
         size="sm"
         icon={<IconSound />}
         disabled={alwaysDisabled || disabled || !hasAccess}
-        hasDropdown={hasDropdown}
+        hasDropdown={false}
         onClick={() => {
           handleMute(primaryMuteAction);
         }}
       >
-        {primaryMuteAction === 'me' ? t('Mute for me') : t('Mute for everyone')}
+        {t('Mute for everyone')}
       </MuteButton>
-      {ruleActionCategory !== RuleActionsCategories.NO_DEFAULT && (
-        <DropdownMenu
-          size="sm"
-          trigger={triggerProps => (
-            <DropdownTrigger
-              {...triggerProps}
-              size="sm"
-              aria-label={t('Mute alert options')}
-              icon={<IconChevron direction="down" />}
-            />
-          )}
-          items={dropdownItems}
-          isDisabled={alwaysDisabled || disabled || !hasAccess}
-        />
-      )}
     </ButtonBar>
   );
 }
 
 export default SnoozeAlert;
-
-const DropdownTrigger = styled(Button)`
-  box-shadow: none;
-  border-radius: 0 ${p => p.theme.borderRadius} ${p => p.theme.borderRadius} 0;
-  border-left: none;
-`;
 
 const MuteButton = styled(Button)<{hasDropdown: boolean}>`
   box-shadow: none;

--- a/static/app/views/alerts/rules/issue/details/ruleDetails.spec.tsx
+++ b/static/app/views/alerts/rules/issue/details/ruleDetails.spec.tsx
@@ -213,7 +213,7 @@ describe('AlertRuleDetails', () => {
       'aria-disabled',
       'true'
     );
-    expect(screen.getByRole('button', {name: 'Mute for me'})).toHaveAttribute(
+    expect(screen.getByRole('button', {name: 'Mute for everyone'})).toHaveAttribute(
       'aria-disabled',
       'true'
     );

--- a/static/app/views/alerts/rules/issue/details/ruleDetails.tsx
+++ b/static/app/views/alerts/rules/issue/details/ruleDetails.tsx
@@ -425,7 +425,6 @@ function AlertRuleDetails({params, location, router}: AlertRuleDetailsProps) {
                   onSnooze={onSnooze}
                   ruleId={rule.id}
                   projectSlug={projectSlug}
-                  ruleActionCategory={ruleActionCategory}
                   hasAccess={hasAccess}
                   type="issue"
                   disabled={rule.status === 'disabled'}

--- a/static/app/views/alerts/rules/metric/details/header.tsx
+++ b/static/app/views/alerts/rules/metric/details/header.tsx
@@ -14,7 +14,6 @@ import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {makeAlertsPathname} from 'sentry/views/alerts/pathnames';
 import type {MetricRule} from 'sentry/views/alerts/rules/metric/types';
-import {getAlertRuleActionCategory} from 'sentry/views/alerts/rules/utils';
 import {
   AlertWizardAlertNames,
   DEPRECATED_TRANSACTION_ALERTS,
@@ -123,7 +122,6 @@ function DetailsHeader({
                   onSnooze={onSnooze}
                   ruleId={rule.id}
                   projectSlug={project.slug}
-                  ruleActionCategory={getAlertRuleActionCategory(rule)}
                   hasAccess={hasAccess}
                   type="metric"
                 />

--- a/static/app/views/alerts/rules/metric/details/index.spec.tsx
+++ b/static/app/views/alerts/rules/metric/details/index.spec.tsx
@@ -191,9 +191,9 @@ describe('MetricAlertDetails', () => {
       }
     );
 
-    expect(await screen.findByText('Mute for me')).toBeInTheDocument();
+    expect(await screen.findByText('Mute for everyone')).toBeInTheDocument();
 
-    await userEvent.click(screen.getByRole('button', {name: 'Mute for me'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Mute for everyone'}));
     expect(postRequest).toHaveBeenCalledTimes(1);
 
     expect(await screen.findByText('Unmute')).toBeInTheDocument();


### PR DESCRIPTION
we are no longer supporting individual user snoozing for alerts in aci world, so we should remove this option in the rules UI to limit confusion

there will no longer be a dropdown option to "mute for me"

<img width="190" height="53" alt="Screenshot 2025-09-08 at 1 56 54 PM" src="https://github.com/user-attachments/assets/58e5ed05-3dfe-489c-ad0f-6fcb35ede0ec" />
