### PR TITLE
fix(aci): keep workflow enabled state when updating rule

### DIFF
--- a/src/sentry/workflow_engine/migration_helpers/issue_alert_dual_write.py
+++ b/src/sentry/workflow_engine/migration_helpers/issue_alert_dual_write.py
@@ -153,8 +153,6 @@ def update_migrated_issue_alert(rule: Rule) -> Workflow | None:
     workflow.owner_team_id = rule.owner_team_id
 
     workflow.name = rule.label
-
-    workflow.enabled = True
     workflow.save()
 
     return workflow

--- a/tests/sentry/workflow_engine/migration_helpers/test_issue_alert_dual_write.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_issue_alert_dual_write.py
@@ -335,6 +335,19 @@ class IssueAlertDualWriteUpdateTest(RuleMigrationHelpersTestBase):
         with pytest.raises(ValidationError):
             update_migrated_issue_alert(self.issue_alert)
 
+    def test_keeps_snooze_status(self) -> None:
+        RuleSnooze.objects.create(rule=self.issue_alert)
+        workflow = IssueAlertMigrator(self.issue_alert, self.user.id).run()
+        assert workflow.enabled is False
+
+        self.issue_alert.data["frequency"] = 5
+        self.issue_alert.save()
+
+        update_migrated_issue_alert(self.issue_alert)
+
+        workflow.refresh_from_db()
+        assert workflow.enabled is False
+
 
 class IssueAlertDualWriteDeleteTest(RuleMigrationHelpersTestBase):
     def setUp(self) -> None:


### PR DESCRIPTION
Issue alerts can be updated even if they're muted. We don't unmute them when updating so we shouldn't re-enable the workflow either.