### PR TITLE
chore(integratoins): add tracing & SLOs to integration proxy

### DIFF
--- a/src/sentry/integrations/api/endpoints/integration_proxy.py
+++ b/src/sentry/integrations/api/endpoints/integration_proxy.py
@@ -21,6 +21,7 @@ from sentry.api.base import Endpoint, control_silo_endpoint
 from sentry.auth.exceptions import IdentityNotValid
 from sentry.constants import ObjectStatus
 from sentry.integrations.models.organization_integration import OrganizationIntegration
+from sentry.integrations.utils.metrics import IntegrationProxyEvent, IntegrationProxyEventType
 from sentry.metrics.base import Tags
 from sentry.shared_integrations.exceptions import ApiHostError, ApiTimeoutError
 from sentry.silo.base import SiloMode
@@ -254,25 +255,45 @@ class InternalIntegrationProxyEndpoint(Endpoint):
         """
         Catch-all workaround instead of explicitly setting handlers for each method (GET, POST, etc.)
         """
-        # Removes leading slashes as it can result in incorrect urls being generated
-        self.proxy_path = trim_leading_slashes(request.headers.get(PROXY_PATH, ""))
-        self.log_extra["method"] = request.method
-        self.log_extra["path"] = self.proxy_path
-        self.log_extra["host"] = request.headers.get("Host")
+        with IntegrationProxyEvent(
+            interaction_type=IntegrationProxyEventType.SHOULD_PROXY
+        ).capture():
+            # Removes leading slashes as it can result in incorrect urls being generated
+            self.proxy_path = trim_leading_slashes(request.headers.get(PROXY_PATH, ""))
+            self.log_extra["method"] = request.method
+            self.log_extra["path"] = self.proxy_path
+            self.log_extra["host"] = request.headers.get("Host")
 
-        if not self._should_operate(request):
-            return HttpResponseBadRequest()
+            if not self._should_operate(request):
+                return HttpResponseBadRequest()
 
-        self._add_metric(metric_name=IntegrationProxySuccessMetricType.INITIALIZE, sample_rate=1.0)
+            self._add_metric(
+                metric_name=IntegrationProxySuccessMetricType.INITIALIZE, sample_rate=1.0
+            )
 
-        base_url = request.headers.get(PROXY_BASE_URL_HEADER)
-        base_url = base_url.rstrip("/")
+            base_url = request.headers.get(PROXY_BASE_URL_HEADER)
+            base_url = base_url.rstrip("/")
 
-        full_url = urljoin(f"{base_url}/", self.proxy_path)
-        self.log_extra["full_url"] = full_url
-        headers = clean_outbound_headers(request.headers)
+            full_url = urljoin(f"{base_url}/", self.proxy_path)
+            self.log_extra["full_url"] = full_url
+            headers = clean_outbound_headers(request.headers)
 
-        response = self._call_third_party_api(request=request, full_url=full_url, headers=headers)
+        with IntegrationProxyEvent(
+            interaction_type=IntegrationProxyEventType.PROXY_REQUEST
+        ).capture() as lifecycle:
+            if self.org_integration is not None:
+                lifecycle.add_extras(
+                    {
+                        "integration_id": self.org_integration.integration_id,
+                        "organization_id": self.org_integration.organization_id,
+                    }
+                )
+            if self.integration is not None:
+                lifecycle.add_extras({"provider": self.integration.provider})
+
+            response = self._call_third_party_api(
+                request=request, full_url=full_url, headers=headers
+            )
 
         self._add_metric(
             metric_name=IntegrationProxySuccessMetricType.COMPLETE_RESPONSE_CODE,

--- a/src/sentry/integrations/api/endpoints/integration_proxy.py
+++ b/src/sentry/integrations/api/endpoints/integration_proxy.py
@@ -7,6 +7,7 @@ from enum import StrEnum
 from typing import Any
 from urllib.parse import urljoin
 
+import sentry_sdk
 from django.conf import settings
 from django.http import HttpRequest, HttpResponse, HttpResponseBadRequest
 from requests import Request, Response
@@ -248,6 +249,7 @@ class InternalIntegrationProxyEndpoint(Endpoint):
             headers=clean_headers,
         )
 
+    @sentry_sdk.trace(op="integration_proxy.http_method_not_allowed")
     def http_method_not_allowed(self, request):
         """
         Catch-all workaround instead of explicitly setting handlers for each method (GET, POST, etc.)

--- a/src/sentry/integrations/utils/metrics.py
+++ b/src/sentry/integrations/utils/metrics.py
@@ -423,3 +423,37 @@ class IntegrationWebhookEvent(IntegrationEventLifecycleMetric):
 
     def get_interaction_type(self) -> str:
         return str(self.interaction_type)
+
+
+class IntegrationProxyEventType(StrEnum):
+    """An instance to be recorded of a integration proxy event."""
+
+    SHOULD_PROXY = "should_proxy"
+    PROXY_REQUEST = "proxy_request"
+
+
+@dataclass
+class IntegrationProxyEvent(EventLifecycleMetric):
+    """An instance to be recorded of a integration proxy event."""
+
+    interaction_type: IntegrationProxyEventType
+
+    def get_metrics_domain(self) -> str:
+        return "integration_proxy"
+
+    def get_interaction_type(self) -> str:
+        return str(self.interaction_type)
+
+    def get_metric_key(self, outcome: EventLifecycleOutcome) -> str:
+        tokens = (self.get_metrics_domain(), self.interaction_type, str(outcome))
+        return ".".join(tokens)
+
+    def get_metric_tags(self) -> Mapping[str, str]:
+        return {
+            "interaction_type": self.interaction_type,
+        }
+
+    def get_extras(self) -> Mapping[str, Any]:
+        return {
+            "interaction_type": self.interaction_type,
+        }


### PR DESCRIPTION
Part of debugging [SENTRY-YP5](https://sentry.sentry.io/issues/3919710734/?query=is%3Aunresolved%20timesSeen%3A%3E10k%20assigned_or_suggested%3Amy_teams&referrer=issue-stream&sort=freq) where we keep timing out while trying to reach the integration proxy. A hypothesis is we're missing instrumentation on the proxy side so maybe there's some error happening on that side. But there also may not be if we can't even reach the proxy (which would complicate things further ;-;)