### PR TITLE
fix(ecosystem): Don't report exceptions in LifecycleMetric.__exit__

### DIFF
--- a/src/sentry/integrations/utils/metrics.py
+++ b/src/sentry/integrations/utils/metrics.py
@@ -316,8 +316,8 @@ class EventLifecycle:
 
         if exc_value is not None:
             # We were forced to exit the context by a raised exception.
-            # Default to creating a Sentry issue for unhandled exceptions
-            self.record_failure(exc_value, create_issue=True)
+            # Don't create a Sentry issue; whoever is catching this should handle it.
+            self.record_failure(exc_value, create_issue=False)
         else:
             # We exited the context without record_success or record_failure being
             # called. Assume success if we were told to do so. Else, log a halt

--- a/tests/sentry/integrations/utils/test_lifecycle_metrics.py
+++ b/tests/sentry/integrations/utils/test_lifecycle_metrics.py
@@ -143,8 +143,6 @@ class IntegrationEventLifecycleMetricTest(TestCase):
         mock_logger: mock.MagicMock,
         mock_sentry_sdk: mock.MagicMock,
     ) -> None:
-        mock_sentry_sdk.capture_exception.return_value = "test-event-id"
-
         metric_obj = self.TestLifecycleMetric()
         with pytest.raises(ExampleException):
             with metric_obj.capture() as lifecycle:
@@ -152,7 +150,7 @@ class IntegrationEventLifecycleMetricTest(TestCase):
                 raise ExampleException()
 
         self._check_metrics_call_args(mock_metrics, "failure")
-        mock_sentry_sdk.capture_exception.assert_called_once()
+        mock_sentry_sdk.capture_exception.assert_not_called()
         mock_logger.warning.assert_called_once_with(
             "integrations.slo.failure",
             extra={
@@ -161,7 +159,6 @@ class IntegrationEventLifecycleMetricTest(TestCase):
                 "integration_name": "my_integration",
                 "interaction_type": "my_interaction",
                 "exception_summary": repr(ExampleException()),
-                "slo_event_id": "test-event-id",
             },
         )
 

--- a/tests/sentry/integrations/utils/test_sync.py
+++ b/tests/sentry/integrations/utils/test_sync.py
@@ -210,7 +210,7 @@ class TestSyncAssigneeInbound(TestCase):
         updated_assignee = self.group.get_assignee()
         assert updated_assignee is None
 
-        mock_record_failure.assert_called_once_with(mock.ANY, create_issue=True)
+        mock_record_failure.assert_called_once_with(mock.ANY, create_issue=False)
 
         exception_param = mock_record_failure.call_args_list[0].args[0]
 


### PR DESCRIPTION
Exceptions that are escaping will be caught up the call stack, where they may be discarded or reported with custom fingerprinting.
By reporting them, LIfecycleMetric removes the ability for callers to make choices regarding exception noise management, and since it can successfully track the outcome of its specific event without reporting the exception, it's simplest to choose not to report to Sentry in this case.

This _is_ expected to reduce exception reporting in some cases, but in all of those cases we should have existing SLO tracking and can easily request reporting if desired. It's somewhat impractical to ensure no change in reporting behavior, because there is a pattern of relying on context, filtering decorators, and retry decorator flags to tune reporting, and that's hard to sort out.