### PR TITLE
ref(api): clean up `global-views` from organization_group_index

### DIFF
--- a/tests/acceptance/test_organization_group_index.py
+++ b/tests/acceptance/test_organization_group_index.py
@@ -95,26 +95,6 @@ class OrganizationGroupIndexTest(AcceptanceTestCase, SnubaTestCase):
         assert len(groups) == 1
 
     @patch("django.utils.timezone.now")
-    def test_resolve_issues_removal_multi_projects(self, mock_now: MagicMock) -> None:
-        mock_now.return_value = datetime.now(timezone.utc)
-        self.create_issues()
-
-        group1 = self.event_a.group
-
-        self.page.visit_issue_list(self.org.slug)
-        self.page.wait_for_stream()
-
-        self.page.select_issue(1)
-        self.page.resolve_issues()
-
-        group1.update(status=GroupStatus.RESOLVED, substatus=None)
-
-        self.page.wait_for_issue_removal()
-        groups = self.browser.elements('[data-test-id="event-issue-header"]')
-
-        assert len(groups) == 1
-
-    @patch("django.utils.timezone.now")
     def test_archive_issues(self, mock_now: MagicMock) -> None:
         mock_now.return_value = datetime.now(timezone.utc)
         self.create_issues()
@@ -135,47 +115,7 @@ class OrganizationGroupIndexTest(AcceptanceTestCase, SnubaTestCase):
         assert len(groups) == 1
 
     @patch("django.utils.timezone.now")
-    def test_archive_issues_multi_projects(self, mock_now: MagicMock) -> None:
-        mock_now.return_value = datetime.now(timezone.utc)
-        self.create_issues()
-
-        group1 = self.event_a.group
-
-        self.page.visit_issue_list(self.org.slug)
-        self.page.wait_for_stream()
-
-        self.page.select_issue(1)
-        self.page.archive_issues()
-
-        group1.update(status=GroupStatus.IGNORED, substatus=None)
-
-        self.page.wait_for_issue_removal()
-        groups = self.browser.elements('[data-test-id="event-issue-header"]')
-
-        assert len(groups) == 1
-
-    @patch("django.utils.timezone.now")
     def test_delete_issues(self, mock_now: MagicMock) -> None:
-        mock_now.return_value = datetime.now(timezone.utc)
-        self.create_issues()
-
-        group1 = self.event_a.group
-
-        self.page.visit_issue_list(self.org.slug)
-        self.page.wait_for_stream()
-
-        self.page.select_issue(1)
-        self.page.delete_issues()
-
-        group1.update(status=GroupStatus.PENDING_DELETION, substatus=None)
-
-        self.page.wait_for_issue_removal()
-        groups = self.browser.elements('[data-test-id="event-issue-header"]')
-
-        assert len(groups) == 1
-
-    @patch("django.utils.timezone.now")
-    def test_delete_issues_multi_projects(self, mock_now: MagicMock) -> None:
         mock_now.return_value = datetime.now(timezone.utc)
         self.create_issues()
 

--- a/tests/acceptance/test_organization_group_index.py
+++ b/tests/acceptance/test_organization_group_index.py
@@ -99,21 +99,20 @@ class OrganizationGroupIndexTest(AcceptanceTestCase, SnubaTestCase):
         mock_now.return_value = datetime.now(timezone.utc)
         self.create_issues()
 
-        with self.feature(["organizations:global-views"]):
-            group1 = self.event_a.group
+        group1 = self.event_a.group
 
-            self.page.visit_issue_list(self.org.slug)
-            self.page.wait_for_stream()
+        self.page.visit_issue_list(self.org.slug)
+        self.page.wait_for_stream()
 
-            self.page.select_issue(1)
-            self.page.resolve_issues()
+        self.page.select_issue(1)
+        self.page.resolve_issues()
 
-            group1.update(status=GroupStatus.RESOLVED, substatus=None)
+        group1.update(status=GroupStatus.RESOLVED, substatus=None)
 
-            self.page.wait_for_issue_removal()
-            groups = self.browser.elements('[data-test-id="event-issue-header"]')
+        self.page.wait_for_issue_removal()
+        groups = self.browser.elements('[data-test-id="event-issue-header"]')
 
-            assert len(groups) == 1
+        assert len(groups) == 1
 
     @patch("django.utils.timezone.now")
     def test_archive_issues(self, mock_now: MagicMock) -> None:
@@ -142,19 +141,18 @@ class OrganizationGroupIndexTest(AcceptanceTestCase, SnubaTestCase):
 
         group1 = self.event_a.group
 
-        with self.feature("organizations:global-views"):
-            self.page.visit_issue_list(self.org.slug)
-            self.page.wait_for_stream()
+        self.page.visit_issue_list(self.org.slug)
+        self.page.wait_for_stream()
 
-            self.page.select_issue(1)
-            self.page.archive_issues()
+        self.page.select_issue(1)
+        self.page.archive_issues()
 
-            group1.update(status=GroupStatus.IGNORED, substatus=None)
+        group1.update(status=GroupStatus.IGNORED, substatus=None)
 
-            self.page.wait_for_issue_removal()
-            groups = self.browser.elements('[data-test-id="event-issue-header"]')
+        self.page.wait_for_issue_removal()
+        groups = self.browser.elements('[data-test-id="event-issue-header"]')
 
-            assert len(groups) == 1
+        assert len(groups) == 1
 
     @patch("django.utils.timezone.now")
     def test_delete_issues(self, mock_now: MagicMock) -> None:
@@ -183,19 +181,18 @@ class OrganizationGroupIndexTest(AcceptanceTestCase, SnubaTestCase):
 
         group1 = self.event_a.group
 
-        with self.feature("organizations:global-views"):
-            self.page.visit_issue_list(self.org.slug)
-            self.page.wait_for_stream()
+        self.page.visit_issue_list(self.org.slug)
+        self.page.wait_for_stream()
 
-            self.page.select_issue(1)
-            self.page.delete_issues()
+        self.page.select_issue(1)
+        self.page.delete_issues()
 
-            group1.update(status=GroupStatus.PENDING_DELETION, substatus=None)
+        group1.update(status=GroupStatus.PENDING_DELETION, substatus=None)
 
-            self.page.wait_for_issue_removal()
-            groups = self.browser.elements('[data-test-id="event-issue-header"]')
+        self.page.wait_for_issue_removal()
+        groups = self.browser.elements('[data-test-id="event-issue-header"]')
 
-            assert len(groups) == 1
+        assert len(groups) == 1
 
     @patch("django.utils.timezone.now")
     def test_merge_issues(self, mock_now: MagicMock) -> None:

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -4249,22 +4249,6 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
             group=group2, type=ActivityType.SET_PRIORITY.value, user_id=self.user.id
         ).exists()
 
-    def test_resolved_in_upcoming_release_multiple_projects(self) -> None:
-        project_2 = self.create_project(slug="foo")
-        group1 = self.create_group(status=GroupStatus.UNRESOLVED)
-        group2 = self.create_group(status=GroupStatus.UNRESOLVED, project=project_2)
-
-        self.login_as(user=self.user)
-        response = self.get_response(
-            qs_params={
-                "id": [group1.id, group2.id],
-                "statd": "resolved",
-                "statusDetails": {"inUpcomingRelease": True},
-            }
-        )
-
-        assert response.status_code == 400
-
 
 class GroupDeleteTest(APITestCase, SnubaTestCase):
     endpoint = "sentry-api-0-organization-group-index"

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -340,33 +340,13 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
         assert len(response.data) == 1
         assert response.data[0]["id"] == str(event.group.id)
 
-    def test_feature_gate(self) -> None:
-        # ensure there are two or more projects
-        self.create_project(organization=self.project.organization)
-        self.login_as(user=self.user)
-
-        response = self.get_response()
-        assert response.status_code == 400
-        assert response.data["detail"] == "You do not have the multi project stream feature enabled"
-
-        with self.feature("organizations:global-views"):
-            response = self.get_response()
-            assert response.status_code == 200
-
-    def test_replay_feature_gate(self) -> None:
-        # allow replays to query for backend
-        self.create_project(organization=self.project.organization)
-        self.login_as(user=self.user)
-        self.get_success_response(extra_headers={"HTTP_X-Sentry-Replay-Request": "1"})
-
     def test_with_all_projects(self) -> None:
         # ensure there are two or more projects
         self.create_project(organization=self.project.organization)
         self.login_as(user=self.user)
 
-        with self.feature("organizations:global-views"):
-            response = self.get_success_response(project_id=[-1])
-            assert response.status_code == 200
+        response = self.get_success_response(project_id=[-1])
+        assert response.status_code == 200
 
     def test_boolean_search_feature_flag(self) -> None:
         self.login_as(user=self.user)
@@ -564,8 +544,7 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
         self.create_member(organization=self.organization, teams=[self.team], user=user)
         self.login_as(user=user)
 
-        with self.feature("organizations:global-views"):
-            response = self.get_success_response(query=event_id, project=[other_project.id])
+        response = self.get_success_response(query=event_id, project=[other_project.id])
         assert response["X-Sentry-Direct-Hit"] == "1"
         assert len(response.data) == 1
         assert response.data[0]["id"] == str(event.group.id)
@@ -631,19 +610,17 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
             data={"timestamp": before_now(seconds=1).isoformat()},
             project_id=project2.id,
         )
-        with self.feature("organizations:global-views"):
-            response = self.get_success_response(
-                query=f"issue:[{event.group.qualified_short_id},{event2.group.qualified_short_id}]",
-                shortIdLookup=1,
-            )
+        response = self.get_success_response(
+            query=f"issue:[{event.group.qualified_short_id},{event2.group.qualified_short_id}]",
+            shortIdLookup=1,
+        )
         assert len(response.data) == 2
         assert response.get("X-Sentry-Direct-Hit") != "1"
 
-        with self.feature("organizations:global-views"):
-            response = self.get_success_response(
-                query=f"issue:[{event.group.qualified_short_id},{event2.group.qualified_short_id}]",
-                shortIdLookup=1,
-            )
+        response = self.get_success_response(
+            query=f"issue:[{event.group.qualified_short_id},{event2.group.qualified_short_id}]",
+            shortIdLookup=1,
+        )
         assert len(response.data) == 2
         assert response.get("X-Sentry-Direct-Hit") != "1"
 
@@ -715,19 +692,13 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
             project_id=project2.id,
         )
 
-        with self.feature("organizations:global-views"):
-            response = self.get_success_response(
-                **{"query": 'first-release:"%s"' % release.version}
-            )
+        response = self.get_success_response(**{"query": 'first-release:"%s"' % release.version})
         issues = json.loads(response.content)
         assert len(issues) == 2
         assert int(issues[0]["id"]) == event2.group.id
         assert int(issues[1]["id"]) == event.group.id
 
-        with self.feature("organizations:global-views"):
-            response = self.get_success_response(
-                **{"query": 'first-release:"%s"' % release.version}
-            )
+        response = self.get_success_response(**{"query": 'first-release:"%s"' % release.version})
         issues = json.loads(response.content)
         assert len(issues) == 2
         assert int(issues[0]["id"]) == event2.group.id
@@ -786,8 +757,7 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
             project_id=project.id,
         )
 
-        with self.feature("organizations:global-views"):
-            response = self.get_success_response(**{"query": 'release.package:["foo", "bar"]'})
+        response = self.get_success_response(**{"query": 'release.package:["foo", "bar"]'})
         issues = json.loads(response.content)
         assert len(issues) == 2
         assert int(issues[0]["id"]) == event2.group.id
@@ -3343,10 +3313,9 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         )
 
         self.login_as(user=self.user)
-        with self.feature("organizations:global-views"):
-            response = self.get_success_response(
-                qs_params={"id": [group1.id, group2.id], "group4": group4.id}, status="resolved"
-            )
+        response = self.get_success_response(
+            qs_params={"id": [group1.id, group2.id], "group4": group4.id}, status="resolved"
+        )
         assert response.data == {"status": "resolved", "statusDetails": {}, "inbox": None}
 
         new_group1 = Group.objects.get(id=group1.id)
@@ -3893,10 +3862,9 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         )
 
         self.login_as(user=self.user)
-        with self.feature("organizations:global-views"):
-            response = self.get_success_response(
-                qs_params={"id": [group1.id, group2.id], "group4": group4.id}, isBookmarked="true"
-            )
+        response = self.get_success_response(
+            qs_params={"id": [group1.id, group2.id], "group4": group4.id}, isBookmarked="true"
+        )
         assert response.data == {"isBookmarked": True}
 
         bookmark1 = GroupBookmark.objects.filter(group=group1, user_id=self.user.id)
@@ -3926,10 +3894,9 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         group4 = self.create_group(project=self.create_project(slug="foo"))
 
         self.login_as(user=self.user)
-        with self.feature("organizations:global-views"):
-            response = self.get_success_response(
-                qs_params={"id": [group1.id, group2.id], "group4": group4.id}, isSubscribed="true"
-            )
+        response = self.get_success_response(
+            qs_params={"id": [group1.id, group2.id], "group4": group4.id}, isSubscribed="true"
+        )
         assert response.data == {"isSubscribed": True, "subscriptionDetails": {"reason": "unknown"}}
 
         assert GroupSubscription.objects.filter(
@@ -3992,10 +3959,9 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         )
 
         self.login_as(user=self.user)
-        with self.feature("organizations:global-views"):
-            response = self.get_success_response(
-                qs_params={"id": [group1.id, group2.id], "group4": group4.id}, hasSeen="true"
-            )
+        response = self.get_success_response(
+            qs_params={"id": [group1.id, group2.id], "group4": group4.id}, hasSeen="true"
+        )
         assert response.data == {"hasSeen": True}
 
         r1 = GroupSeen.objects.filter(group=group1, user_id=self.user.id)
@@ -4331,7 +4297,7 @@ class GroupDeleteTest(APITestCase, SnubaTestCase):
         group_ids = [group.id for group in groups]
 
         self.login_as(user=self.user)
-        with self.tasks(), self.feature("organizations:global-views"):
+        with self.tasks():
             response = self.get_response(qs_params={"id": group_ids})
             assert response.status_code == 204
 
@@ -4390,7 +4356,7 @@ class GroupDeleteTest(APITestCase, SnubaTestCase):
             GroupHash.objects.create(project=g.project, hash=hash, group=g)
 
         self.login_as(user=self.user)
-        with self.feature("organizations:global-views"), self.tasks():
+        with self.tasks():
             response = self.get_response(qs_params={"id": [group1.id, group2.id]})
 
         assert response.status_code == 204
@@ -4399,71 +4365,70 @@ class GroupDeleteTest(APITestCase, SnubaTestCase):
 
     def test_bulk_delete_for_many_projects_without_option(self) -> None:
         NEW_CHUNK_SIZE = 2
-        with self.feature("organizations:global-views"):
-            project_2 = self.create_project(slug="baz", organization=self.organization)
-            groups_1 = self.create_n_groups_with_hashes(2, project=self.project)
-            groups_2 = self.create_n_groups_with_hashes(5, project=project_2)
+        project_2 = self.create_project(slug="baz", organization=self.organization)
+        groups_1 = self.create_n_groups_with_hashes(2, project=self.project)
+        groups_2 = self.create_n_groups_with_hashes(5, project=project_2)
 
-            with (
-                self.tasks(),
-                patch("sentry.api.helpers.group_index.delete.GROUP_CHUNK_SIZE", NEW_CHUNK_SIZE),
-                patch("sentry.deletions.tasks.groups.logger") as mock_logger,
-                patch(
-                    "sentry.api.helpers.group_index.delete.uuid4",
-                    side_effect=[self.get_mock_uuid("foo"), self.get_mock_uuid("bar")],
+        with (
+            self.tasks(),
+            patch("sentry.api.helpers.group_index.delete.GROUP_CHUNK_SIZE", NEW_CHUNK_SIZE),
+            patch("sentry.deletions.tasks.groups.logger") as mock_logger,
+            patch(
+                "sentry.api.helpers.group_index.delete.uuid4",
+                side_effect=[self.get_mock_uuid("foo"), self.get_mock_uuid("bar")],
+            ),
+        ):
+            self.login_as(user=self.user)
+            response = self.get_success_response(qs_params={"query": ""})
+            assert response.status_code == 204
+            batch_1 = [g.id for g in groups_2[0:2]]
+            batch_2 = [g.id for g in groups_2[2:4]]
+            batch_3 = [g.id for g in groups_2[4:]]
+            assert batch_1 + batch_2 + batch_3 == [g.id for g in groups_2]
+
+            calls_by_project: dict[int, list[tuple[str, dict[str, Any]]]] = defaultdict(list)
+            for log_call in mock_logger.info.call_args_list:
+                calls_by_project[log_call[1]["extra"]["project_id"]].append(log_call)
+
+            assert len(calls_by_project) == 2
+            assert calls_by_project[self.project.id] == [
+                call(
+                    "delete_groups.started",
+                    extra={
+                        "object_ids": [g.id for g in groups_1],
+                        "project_id": self.project.id,
+                        "transaction_id": "bar",
+                    },
                 ),
-            ):
-                self.login_as(user=self.user)
-                response = self.get_success_response(qs_params={"query": ""})
-                assert response.status_code == 204
-                batch_1 = [g.id for g in groups_2[0:2]]
-                batch_2 = [g.id for g in groups_2[2:4]]
-                batch_3 = [g.id for g in groups_2[4:]]
-                assert batch_1 + batch_2 + batch_3 == [g.id for g in groups_2]
+            ]
+            assert calls_by_project[project_2.id] == [
+                call(
+                    "delete_groups.started",
+                    extra={
+                        "object_ids": batch_1,
+                        "project_id": project_2.id,
+                        "transaction_id": "foo",
+                    },
+                ),
+                call(
+                    "delete_groups.started",
+                    extra={
+                        "object_ids": batch_2,
+                        "project_id": project_2.id,
+                        "transaction_id": "foo",
+                    },
+                ),
+                call(
+                    "delete_groups.started",
+                    extra={
+                        "object_ids": batch_3,
+                        "project_id": project_2.id,
+                        "transaction_id": "foo",
+                    },
+                ),
+            ]
 
-                calls_by_project: dict[int, list[tuple[str, dict[str, Any]]]] = defaultdict(list)
-                for log_call in mock_logger.info.call_args_list:
-                    calls_by_project[log_call[1]["extra"]["project_id"]].append(log_call)
-
-                assert len(calls_by_project) == 2
-                assert calls_by_project[self.project.id] == [
-                    call(
-                        "delete_groups.started",
-                        extra={
-                            "object_ids": [g.id for g in groups_1],
-                            "project_id": self.project.id,
-                            "transaction_id": "bar",
-                        },
-                    ),
-                ]
-                assert calls_by_project[project_2.id] == [
-                    call(
-                        "delete_groups.started",
-                        extra={
-                            "object_ids": batch_1,
-                            "project_id": project_2.id,
-                            "transaction_id": "foo",
-                        },
-                    ),
-                    call(
-                        "delete_groups.started",
-                        extra={
-                            "object_ids": batch_2,
-                            "project_id": project_2.id,
-                            "transaction_id": "foo",
-                        },
-                    ),
-                    call(
-                        "delete_groups.started",
-                        extra={
-                            "object_ids": batch_3,
-                            "project_id": project_2.id,
-                            "transaction_id": "foo",
-                        },
-                    ),
-                ]
-
-            self.assert_deleted_groups(groups_1 + groups_2)
+        self.assert_deleted_groups(groups_1 + groups_2)
 
     def test_bulk_delete_performance_issues(self) -> None:
         groups = self.create_n_groups_with_hashes(


### PR DESCRIPTION
Refs https://linear.app/getsentry/issue/ID-927/deprecate-global-views-flag

