### PR TITLE
feat(coding-agents): Add provider & update repo fields

### DIFF
--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -59,15 +59,21 @@ class AutofixTriggerSource(StrEnum):
 
 class CodingAgentResult(BaseModel):
     description: str
-    repo_external_id: str
+    repo_provider: str
+    repo_full_name: str
     branch_name: str | None = None
     pr_url: str | None = None
+
+
+class CodingAgentProviderType(StrEnum):
+    CURSOR_BACKGROUND_AGENT = "cursor_background_agent"
 
 
 class CodingAgentState(BaseModel):
     id: str
     status: CodingAgentStatus = CodingAgentStatus.PENDING
     agent_url: str | None = None
+    provider: CodingAgentProviderType
     name: str
     started_at: datetime
     results: list[CodingAgentResult] = []
@@ -92,6 +98,17 @@ class AutofixState(BaseModel):
 
     class Config:
         extra = "allow"
+
+
+class CodingAgentStateUpdate(BaseModel):
+    status: CodingAgentStatus | None = None
+    agent_url: str | None = None
+    results: list[CodingAgentResult] | None = None
+
+
+class CodingAgentStateUpdateRequest(BaseModel):
+    agent_id: str
+    updates: CodingAgentStateUpdate
 
 
 autofix_connection_pool = connection_from_url(

--- a/tests/sentry/integrations/api/endpoints/test_organization_coding_agents.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_coding_agents.py
@@ -13,7 +13,12 @@ from sentry.integrations.coding_agent.integration import (
 from sentry.integrations.coding_agent.models import CodingAgentLaunchRequest
 from sentry.integrations.services.integration.serial import serialize_integration
 from sentry.seer.autofix.constants import AutofixStatus
-from sentry.seer.autofix.utils import AutofixState, CodingAgentState, CodingAgentStatus
+from sentry.seer.autofix.utils import (
+    AutofixState,
+    CodingAgentProviderType,
+    CodingAgentState,
+    CodingAgentStatus,
+)
 from sentry.seer.models import SeerRepoDefinition
 from sentry.testutils.cases import APITestCase
 
@@ -51,6 +56,7 @@ class MockCodingAgentInstallation(CodingAgentIntegration):
         return CodingAgentState(
             id="mock-123",
             status=CodingAgentStatus.PENDING,
+            provider=CodingAgentProviderType.CURSOR_BACKGROUND_AGENT,
             name="Mock Agent",
             started_at=datetime.now(UTC),
         )
@@ -705,6 +711,7 @@ class OrganizationCodingAgentsPostLaunchTest(BaseOrganizationCodingAgentsTest):
             CodingAgentState(  # Second call succeeds
                 id="success-123",
                 status=CodingAgentStatus.PENDING,
+                provider=CodingAgentProviderType.CURSOR_BACKGROUND_AGENT,
                 name="Success Agent",
                 started_at=datetime.now(UTC),
             ),

--- a/tests/sentry/integrations/api/endpoints/test_organization_coding_agents.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_coding_agents.py
@@ -72,6 +72,7 @@ class MockCodingAgentClient(CodingAgentClient):
         return CodingAgentState(
             id="mock-123",
             status=CodingAgentStatus.PENDING,
+            provider=CodingAgentProviderType.CURSOR_BACKGROUND_AGENT,
             name="Mock Agent",
             started_at=datetime.now(UTC),
         )

--- a/tests/sentry/integrations/coding_agent/test_base.py
+++ b/tests/sentry/integrations/coding_agent/test_base.py
@@ -7,7 +7,7 @@ from sentry.integrations.coding_agent.integration import (
     CodingAgentIntegrationProvider,
 )
 from sentry.integrations.coding_agent.models import CodingAgentLaunchRequest
-from sentry.seer.autofix.utils import CodingAgentState, CodingAgentStatus
+from sentry.seer.autofix.utils import CodingAgentProviderType, CodingAgentState, CodingAgentStatus
 from sentry.seer.models import SeerRepoDefinition
 from sentry.testutils.cases import TestCase
 
@@ -55,6 +55,7 @@ class MockCodingAgentClient(CodingAgentClient):
         return CodingAgentState(
             id="test-123",
             status=CodingAgentStatus.PENDING,
+            provider=CodingAgentProviderType.CURSOR_BACKGROUND_AGENT,
             name="Test Agent",
             started_at=datetime.now(UTC),
         )
@@ -74,6 +75,7 @@ class CodingAgentBaseTest(TestCase):
         mock_state = CodingAgentState(
             id="test-123",
             status=CodingAgentStatus.PENDING,
+            provider=CodingAgentProviderType.CURSOR_BACKGROUND_AGENT,
             name="Test Agent",
             started_at=datetime.now(UTC),
         )

--- a/tests/sentry/seer/autofix/test_autofix_utils.py
+++ b/tests/sentry/seer/autofix/test_autofix_utils.py
@@ -171,6 +171,7 @@ class TestAutofixStateParsing(TestCase):
                     "id": "agent-1",
                     "status": "completed",
                     "name": "Autofixer",
+                    "provider": "cursor_background_agent",
                     "started_at": "2025-08-25T12:00:00.000Z",
                     "results": [],
                 }


### PR DESCRIPTION
Adds a provider field to the coding agent state, adjusts the repo fields, and the request/update models for the seer coding agent state update endpoint
