### PR TITLE
feat(coding-agents): Take repos from root cause when triggered from rca

### DIFF
--- a/src/sentry/integrations/api/endpoints/organization_coding_agents.py
+++ b/src/sentry/integrations/api/endpoints/organization_coding_agents.py
@@ -258,6 +258,22 @@ class OrganizationCodingAgentsEndpoint(OrganizationEndpoint):
 
         return autofix_state
 
+    def _extract_repos_from_root_cause(self, autofix_state: AutofixState) -> list[str]:
+        """Extract repository names from autofix state root cause."""
+        root_cause_step = next(
+            (step for step in autofix_state.steps if step["key"] == "root_cause_analysis"), None
+        )
+
+        if not root_cause_step or not root_cause_step["causes"]:
+            return []
+
+        cause = root_cause_step["causes"][0]
+
+        if "relevant_repos" not in cause:
+            return []
+
+        return list(set(cause["relevant_repos"])) or []
+
     def _extract_repos_from_solution(self, autofix_state: AutofixState) -> list[str]:
         """Extract repository names from autofix state solution."""
         repos = set()
@@ -287,23 +303,29 @@ class OrganizationCodingAgentsEndpoint(OrganizationEndpoint):
         trigger_source: AutofixTriggerSource,
     ) -> list[dict]:
         """Launch coding agents for all repositories in the solution."""
-        solution_repos = set(self._extract_repos_from_solution(autofix_state))
+
+        repos = set(
+            self._extract_repos_from_root_cause(autofix_state)
+            if trigger_source == AutofixTriggerSource.ROOT_CAUSE
+            else self._extract_repos_from_solution(autofix_state)
+        )
+
         autofix_state_repos = {f"{repo.owner}/{repo.name}" for repo in autofix_state.request.repos}
 
-        # Repos that were in the solution but not in the autofix state
-        solution_repos_not_found = solution_repos - autofix_state_repos
+        # Repos that were in the repos but not in the autofix state
+        repos_not_found = repos - autofix_state_repos
         logger.warning(
-            "coding_agent.post.solution_repos_not_found",
+            "coding_agent.post.repos_not_found",
             extra={
                 "organization_id": organization.id,
                 "run_id": run_id,
-                "solution_repos_not_found": solution_repos_not_found,
+                "repos_not_found": repos_not_found,
             },
         )
 
-        validated_solution_repos = solution_repos - solution_repos_not_found
+        validated_repos = repos - repos_not_found
 
-        repos_to_launch = validated_solution_repos or autofix_state_repos
+        repos_to_launch = validated_repos or autofix_state_repos
 
         if not repos_to_launch:
             raise NotFound("No repos to run agents")


### PR DESCRIPTION
2nd PR in the stack after #99075 

Support taking repo names from the root cause as well in the coding agent trigger endpoint