### PR TITLE
feat(aci): add check-ins table to uptime monitor details page

### DIFF
--- a/static/app/views/alerts/rules/uptime/details.tsx
+++ b/static/app/views/alerts/rules/uptime/details.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import {updateUptimeRule} from 'sentry/actionCreators/uptime';
 import {hasEveryAccess} from 'sentry/components/acl/access';
 import Breadcrumbs from 'sentry/components/breadcrumbs';
+import {SectionHeading} from 'sentry/components/charts/styles';
 import {Alert} from 'sentry/components/core/alert';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
@@ -191,7 +192,12 @@ export default function UptimeAlertDetails({params}: UptimeAlertDetailsProps) {
           )}
           <DetailsTimeline uptimeRule={uptimeRule} onStatsLoaded={checkHasUnknown} />
           <UptimeIssues project={project} uptimeRule={uptimeRule} />
-          <UptimeChecksTable uptimeRule={uptimeRule} />
+          <SectionHeading>{t('Checks List')}</SectionHeading>
+          <UptimeChecksTable
+            detectorId={String(uptimeRule.detectorId)}
+            projectSlug={uptimeRule.projectSlug}
+            traceSampling={uptimeRule.traceSampling}
+          />
         </Layout.Main>
         <Layout.Side>
           <UptimeDetailsSidebar

--- a/static/app/views/alerts/rules/uptime/uptimeChecksGrid.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeChecksGrid.tsx
@@ -13,7 +13,7 @@ import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {getShortEventId} from 'sentry/utils/events';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
-import type {UptimeCheck, UptimeRule} from 'sentry/views/alerts/rules/uptime/types';
+import type {UptimeCheck} from 'sentry/views/alerts/rules/uptime/types';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {
   reasonToText,
@@ -22,8 +22,8 @@ import {
 } from 'sentry/views/insights/uptime/timelineConfig';
 
 type Props = {
+  traceSampling: boolean;
   uptimeChecks: UptimeCheck[];
-  uptimeRule: UptimeRule;
 };
 
 /**
@@ -32,7 +32,7 @@ type Props = {
  */
 const EMPTY_TRACE = '00000000000000000000000000000000';
 
-export function UptimeChecksGrid({uptimeRule, uptimeChecks}: Props) {
+export function UptimeChecksGrid({traceSampling, uptimeChecks}: Props) {
   const traceIds = uptimeChecks?.map(check => check.traceId) ?? [];
 
   const {data: spanCounts, isPending: spanCountLoading} = useSpans(
@@ -72,7 +72,7 @@ export function UptimeChecksGrid({uptimeRule, uptimeChecks}: Props) {
         renderBodyCell: (column, dataRow) => (
           <CheckInBodyCell
             column={column as GridColumnOrder<keyof UptimeCheck>}
-            uptimeRule={uptimeRule}
+            traceSampling={traceSampling}
             check={dataRow}
             spanCount={traceSpanCounts?.[dataRow.traceId]}
           />
@@ -86,12 +86,12 @@ function CheckInBodyCell({
   check,
   column,
   spanCount,
-  uptimeRule,
+  traceSampling,
 }: {
   check: UptimeCheck;
   column: GridColumnOrder<keyof UptimeCheck>;
   spanCount: number | undefined;
-  uptimeRule: UptimeRule;
+  traceSampling: boolean;
 }) {
   const theme = useTheme();
 
@@ -163,7 +163,7 @@ function CheckInBodyCell({
           <Tooltip
             isHoverable
             title={
-              uptimeRule.traceSampling
+              traceSampling
                 ? tct(
                     'No spans found in this trace. Configure your SDKs to see correlated spans across services. [learnMore:Learn more].',
                     {learnMore}

--- a/static/app/views/alerts/rules/uptime/uptimeChecksTable.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeChecksTable.tsx
@@ -1,6 +1,5 @@
 import {Fragment} from 'react';
 
-import {SectionHeading} from 'sentry/components/charts/styles';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Pagination from 'sentry/components/pagination';
@@ -10,14 +9,19 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useUptimeChecks} from 'sentry/views/insights/uptime/utils/useUptimeChecks';
 
-import type {UptimeRule} from './types';
 import {UptimeChecksGrid} from './uptimeChecksGrid';
 
 interface UptimeChecksTableProps {
-  uptimeRule: UptimeRule;
+  detectorId: string;
+  projectSlug: string;
+  traceSampling: boolean;
 }
 
-export function UptimeChecksTable({uptimeRule}: UptimeChecksTableProps) {
+export function UptimeChecksTable({
+  detectorId,
+  projectSlug,
+  traceSampling,
+}: UptimeChecksTableProps) {
   const location = useLocation();
   const organization = useOrganization();
 
@@ -35,8 +39,8 @@ export function UptimeChecksTable({uptimeRule}: UptimeChecksTableProps) {
     refetch,
   } = useUptimeChecks({
     orgSlug: organization.slug,
-    projectSlug: uptimeRule.projectSlug,
-    detectorId: String(uptimeRule.detectorId),
+    projectSlug,
+    detectorId,
     cursor: decodeScalar(location.query.cursor),
     ...timeRange,
     limit: 10,
@@ -48,11 +52,10 @@ export function UptimeChecksTable({uptimeRule}: UptimeChecksTableProps) {
 
   return (
     <Fragment>
-      <SectionHeading>{t('Checks List')}</SectionHeading>
       {isPending ? (
         <LoadingIndicator />
       ) : (
-        <UptimeChecksGrid uptimeRule={uptimeRule} uptimeChecks={uptimeChecks} />
+        <UptimeChecksGrid traceSampling={traceSampling} uptimeChecks={uptimeChecks} />
       )}
       <Pagination pageLinks={getResponseHeader?.('Link')} />
     </Fragment>

--- a/static/app/views/detectors/components/details/uptime/index.tsx
+++ b/static/app/views/detectors/components/details/uptime/index.tsx
@@ -6,11 +6,11 @@ import {t} from 'sentry/locale';
 import type {Project} from 'sentry/types/project';
 import type {UptimeDetector} from 'sentry/types/workflowEngine/detectors';
 import getDuration from 'sentry/utils/duration/getDuration';
+import {UptimeChecksTable} from 'sentry/views/alerts/rules/uptime/uptimeChecksTable';
 import {DetectorDetailsAssignee} from 'sentry/views/detectors/components/details/common/assignee';
 import {DetectorDetailsAutomations} from 'sentry/views/detectors/components/details/common/automations';
 import {DetectorExtraDetails} from 'sentry/views/detectors/components/details/common/extraDetails';
 import {DetectorDetailsHeader} from 'sentry/views/detectors/components/details/common/header';
-import {DetectorDetailsOngoingIssues} from 'sentry/views/detectors/components/details/common/ongoingIssues';
 
 type UptimeDetectorDetailsProps = {
   detector: UptimeDetector;
@@ -26,7 +26,15 @@ export function UptimeDetectorDetails({detector, project}: UptimeDetectorDetails
       <DetailLayout.Body>
         <DetailLayout.Main>
           <DatePageFilter />
-          <DetectorDetailsOngoingIssues detectorId={detector.id} />
+          <Section title={t('Recent Check-Ins')}>
+            <div>
+              <UptimeChecksTable
+                detectorId={detector.id}
+                projectSlug={project.slug}
+                traceSampling={detector.dataSources[0].queryObj.traceSampling}
+              />
+            </div>
+          </Section>
           <DetectorDetailsAutomations detector={detector} />
         </DetailLayout.Main>
         <DetailLayout.Sidebar>

--- a/static/app/views/detectors/detail.spec.tsx
+++ b/static/app/views/detectors/detail.spec.tsx
@@ -11,12 +11,14 @@ import {GroupFixture} from 'sentry-fixture/group';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 import {TeamFixture} from 'sentry-fixture/team';
+import {UptimeCheckFixture} from 'sentry-fixture/uptimeCheck';
 import {UserFixture} from 'sentry-fixture/user';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import ProjectsStore from 'sentry/stores/projectsStore';
 import TeamStore from 'sentry/stores/teamStore';
+import {CheckStatus} from 'sentry/views/alerts/rules/uptime/types';
 import DetectorDetails from 'sentry/views/detectors/detail';
 
 describe('DetectorDetails', () => {
@@ -223,6 +225,33 @@ describe('DetectorDetails', () => {
         url: `/organizations/${organization.slug}/detectors/${uptimeDetector.id}/`,
         body: uptimeDetector,
       });
+
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/events/',
+        method: 'GET',
+        body: [],
+      });
+
+      // Mock uptime checks endpoint
+      MockApiClient.addMockResponse({
+        url: `/projects/${organization.slug}/${project.slug}/uptime/${uptimeDetector.id}/checks/`,
+        body: [
+          UptimeCheckFixture({
+            checkStatus: CheckStatus.SUCCESS,
+            scheduledCheckTime: '2025-01-01T00:00:00Z',
+            httpStatusCode: 200,
+            durationMs: 150,
+            regionName: 'US East',
+          }),
+          UptimeCheckFixture({
+            checkStatus: CheckStatus.FAILURE,
+            scheduledCheckTime: '2025-01-01T00:01:00Z',
+            httpStatusCode: 500,
+            durationMs: 5000,
+            regionName: 'US West',
+          }),
+        ],
+      });
     });
 
     it('displays correct detector details', async () => {
@@ -257,6 +286,23 @@ describe('DetectorDetails', () => {
         'href',
         '/organizations/org-slug/issues/monitors/1/edit/'
       );
+    });
+
+    it('displays the check-in table with correct data', async () => {
+      render(<DetectorDetails />, {
+        organization,
+        initialRouterConfig,
+      });
+
+      expect(await screen.findByText('Recent Check-Ins')).toBeInTheDocument();
+
+      // Verify check-in data is displayed
+      expect(screen.getByText('Uptime')).toBeInTheDocument();
+      expect(screen.getByText('200')).toBeInTheDocument();
+      expect(screen.getByText('US East')).toBeInTheDocument();
+      expect(screen.getByText('Failure')).toBeInTheDocument();
+      expect(screen.getByText('500')).toBeInTheDocument();
+      expect(screen.getByText('US West')).toBeInTheDocument();
     });
   });
 

--- a/static/app/views/issueDetails/groupUptimeChecks.tsx
+++ b/static/app/views/issueDetails/groupUptimeChecks.tsx
@@ -76,7 +76,10 @@ export default function GroupUptimeChecks() {
         previousDisabled,
       }}
     >
-      <UptimeChecksGrid uptimeRule={uptimeRule} uptimeChecks={uptimeChecks} />
+      <UptimeChecksGrid
+        traceSampling={uptimeRule.traceSampling}
+        uptimeChecks={uptimeChecks}
+      />
     </EventListTable>
   );
 }


### PR DESCRIPTION
pretty much the same as https://github.com/getsentry/sentry/pull/98834

takes the recent check-ins table from the uptime page and adds it to the detector details. needed to make a couple small changes to the component props so that it can be used in both places.

<img width="991" height="410" alt="Screenshot 2025-09-08 at 4 00 37 PM" src="https://github.com/user-attachments/assets/26af2139-75e5-4809-8b9d-656af6ecad2f" />
