### PR TITLE
feat(crons): Indicate when we may have had an upstream problem

### DIFF
--- a/static/app/views/insights/crons/components/checkInCell.tsx
+++ b/static/app/views/insights/crons/components/checkInCell.tsx
@@ -7,6 +7,7 @@ import {Tooltip} from 'sentry/components/core/tooltip';
 import {DateTime} from 'sentry/components/dateTime';
 import Duration from 'sentry/components/duration';
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
+import QuestionTooltip from 'sentry/components/questionTooltip';
 import ShortId from 'sentry/components/shortId';
 import {
   StatusIndicator,
@@ -24,6 +25,13 @@ import {CheckInStatus} from 'sentry/views/insights/crons/types';
 import {statusToText} from 'sentry/views/insights/crons/utils';
 
 import {DEFAULT_CHECKIN_MARGIN, DEFAULT_MAX_RUNTIME} from './monitorForm';
+
+/**
+ * How many seconds can a check-in have been stuck in Relay before being
+ * considered to have "high latency", at which point we'll show an indicator on
+ * the check-in row.
+ */
+const HIGH_LATENCY_CUTOFF = 60;
 
 interface CheckInRowProps {
   cellKey: CheckInCellKey;
@@ -123,6 +131,7 @@ export function CheckInCell({cellKey, project, checkIn}: CheckInRowProps) {
     <TimestampContainer>
       <ExpectedDateTime date={expectedTime} timeZone seconds />
       <OffScheduleIndicator checkIn={checkIn} />
+      <ProcessingLatencyIndicator checkIn={checkIn} />
     </TimestampContainer>
   ) : (
     emptyCell
@@ -300,30 +309,59 @@ interface TimeoutLateByProps {
 }
 
 /**
- * Renders a tag indicating how late the completing check-in was when a
- * check-in timed out but still has a duration (indicating we have a closing
- * check-in)
+ * Computes the timeout check-ins lateBySeconds, this is how much longer the
+ * check-in ran past it's max runtime. Also returns the maxRuntimeSeconds. This
+ * is computed from the monitor config at the time of the check-inAlso returns
+ * the maxRuntimeSeconds. This is computed from the monitor config at the time
+ * of the check-in
  */
-function CompletedLateIndicator({checkIn}: TimeoutLateByProps) {
-  const {duration, monitorConfig} = checkIn;
+function computeTimeoutMetrics({status, duration, monitorConfig}: CheckIn) {
+  // metrics are only valid for check-ins that timed out
+  if (status !== CheckInStatus.TIMEOUT) {
+    return null;
+  }
 
+  // metrics are only valid for timed out check-ins with a duraiton
   if (duration === null) {
     return null;
   }
 
   const maxRuntimeSeconds = (monitorConfig.max_runtime ?? DEFAULT_MAX_RUNTIME) * 60;
-  const lateBySecond = duration / 1000 - maxRuntimeSeconds;
+  const lateBySeconds = duration / 1000 - maxRuntimeSeconds;
 
-  // In cases where a check-in was processed late due to being stuck in relay
-  // we may compute a negative lateBySecond. In those cases do not render the
-  // indicator.
-  //
-  // This happens because the check-in is marked as timedout, later we receive
-  // a completing check-in that updates the duration. Typically this would
-  // imply the check-in ran too long. But if the duration is less than the
-  // max-runtine, it implies the check-in was produced to kafka much later than
-  // it should have, and the job actually ran like normal
-  if (lateBySecond < 0) {
+  return {maxRuntimeSeconds, lateBySeconds};
+}
+
+/**
+ * In cases where a check-in was processed late due to being stuck in relay we
+ * may compute a negative lateBySeconds.
+ *
+ * This happens because the check-in is marked as timed out, later we receive a
+ * completing check-in that updates the duration. Typically this would imply
+ * the check-in ran too long. But if the duration is less than the max-runtine,
+ * it implies the check-in was produced to kafka much later than it should
+ * have, and the job actually ran like normal
+ */
+function isAbnormalLate(lateBySeconds: number) {
+  return lateBySeconds < 0;
+}
+
+/**
+ * Renders a tag indicating how late the completing check-in was when a
+ * check-in timed out but still has a duration (indicating we have a closing
+ * check-in)
+ */
+function CompletedLateIndicator({checkIn}: TimeoutLateByProps) {
+  const metrics = computeTimeoutMetrics(checkIn);
+
+  if (metrics === null) {
+    return null;
+  }
+
+  const {maxRuntimeSeconds, lateBySeconds} = metrics;
+
+  // See comment on isAbnormalLate for this case
+  if (isAbnormalLate(lateBySeconds)) {
     return null;
   }
 
@@ -335,7 +373,7 @@ function CompletedLateIndicator({checkIn}: TimeoutLateByProps) {
 
   const lateBy = (
     <strong>
-      <Duration seconds={lateBySecond} />
+      <Duration seconds={lateBySeconds} />
     </strong>
   );
 
@@ -347,7 +385,7 @@ function CompletedLateIndicator({checkIn}: TimeoutLateByProps) {
   return (
     <Tooltip skipWrapper title={title}>
       <Tag type="error">
-        {t('%s late', <Duration abbreviation seconds={lateBySecond} />)}
+        {t('%s late', <Duration abbreviation seconds={lateBySeconds} />)}
       </Tag>
     </Tooltip>
   );
@@ -382,6 +420,50 @@ function NotSentIndicator() {
       <Tag type="warning">{t('Not Sent')}</Tag>
     </Tooltip>
   );
+}
+
+interface ProcessingLatencyProps {
+  checkIn: CheckIn;
+}
+
+/**
+ * Renders a slow processing indicator to inform the user that we took a long
+ * time to process this check-in.
+ */
+function ProcessingLatencyIndicator({checkIn}: ProcessingLatencyProps) {
+  const {dateClock, dateAdded, status} = checkIn;
+
+  // Check-ins that have a high latency, the time between the dateAdded (the
+  // time the opening check-in was received by relay) and the dateClock (the
+  // reference time at the point the check-in was placed in kafka), indicates
+  // that the check-in spent a long time in relay.
+  //
+  // Right now there's little we can do to correct for this, so as a best
+  // effort to help the user understand that there was a problem.
+  const processingLatency = moment(dateClock).diff(dateAdded, 'seconds');
+  const hasProcessingLatency =
+    status !== CheckInStatus.MISSED && processingLatency >= HIGH_LATENCY_CUTOFF;
+
+  // Timned out check-ins that have abnormal "lateBySeconds" metrics indicate
+  // the completing check-in was stuck in relay.
+  const timeoutMetrics = computeTimeoutMetrics(checkIn);
+  const abnormalLateCheckIn =
+    timeoutMetrics && isAbnormalLate(timeoutMetrics.lateBySeconds);
+
+  if (!hasProcessingLatency && !abnormalLateCheckIn) {
+    return null;
+  }
+
+  // Different tooltips for different scenarios
+  const tooltipMessage = hasProcessingLatency
+    ? t(
+        'This check-in was processed late due to abnormal system latency in Sentry. The status of this check-in may be inaccurate.'
+      )
+    : t(
+        'This check-in was incorrectly marked as timed-out. The check-in was processed late due to abnormal system latency in Sentry.'
+      );
+
+  return <QuestionTooltip icon="info" size="sm" title={tooltipMessage} />;
 }
 
 const Status = styled('div')`

--- a/static/app/views/insights/crons/components/monitorCheckInsGrid.spec.tsx
+++ b/static/app/views/insights/crons/components/monitorCheckInsGrid.spec.tsx
@@ -189,4 +189,64 @@ describe('CheckInRow', () => {
     expect(screen.getByText('Timed Out')).toBeInTheDocument();
     expect(screen.queryByText(/late/)).not.toBeInTheDocument();
   });
+
+  it('shows processing latency indicator when check-in has high processing latency', async () => {
+    const checkIn = CheckInFixture({
+      status: CheckInStatus.OK,
+      dateAdded: '2025-01-01T00:00:00Z', // When check-in was received by relay
+      dateClock: '2025-01-01T00:02:00Z', // When check-in was placed in kafka (2 minutes later - high latency)
+      dateUpdated: '2025-01-01T00:02:10Z',
+      dateInProgress: '2025-01-01T00:00:01Z',
+      duration: 9000,
+    });
+
+    render(<MonitorCheckInsGrid project={project} checkIns={[checkIn]} />);
+
+    // Should show the processing latency info icon
+    const infoIcon = screen.getByTestId('more-information');
+    expect(infoIcon).toBeInTheDocument();
+
+    await userEvent.hover(infoIcon);
+
+    const expectedTooltip =
+      'This check-in was processed late due to abnormal system latency in Sentry. The status of this check-in may be inaccurate.';
+    expect(await screen.findByText(expectedTooltip)).toBeInTheDocument();
+  });
+
+  it('shows processing latency indicator for abnormally late check-in', async () => {
+    const checkIn = CheckInFixture({
+      status: CheckInStatus.TIMEOUT,
+      dateAdded: '2025-01-01T00:00:01Z',
+      dateClock: '2025-01-01T00:00:01Z', // No processing latency
+      dateUpdated: '2025-01-01T00:05:00Z',
+      dateInProgress: '2025-01-01T00:00:01Z',
+      duration: 5 * 60 * 1000, // 5 minutes - less than max_runtime of 10 minutes (abnormally late)
+    });
+
+    render(<MonitorCheckInsGrid project={project} checkIns={[checkIn]} />);
+
+    // Should show the processing latency info icon for abnormally late timing
+    const infoIcon = screen.getByTestId('more-information');
+    expect(infoIcon).toBeInTheDocument();
+
+    await userEvent.hover(infoIcon);
+
+    const expectedTooltip =
+      'This check-in was incorrectly marked as timed-out. The check-in was processed late due to abnormal system latency in Sentry.';
+    expect(await screen.findByText(expectedTooltip)).toBeInTheDocument();
+  });
+
+  it('does not show processing latency indicator for normal check-ins', () => {
+    const checkIn = CheckInFixture({
+      status: CheckInStatus.OK,
+      dateAdded: '2025-01-01T00:00:01Z',
+      dateClock: '2025-01-01T00:00:02Z', // Only 1 second processing latency
+      dateUpdated: '2025-01-01T00:00:10Z',
+      dateInProgress: '2025-01-01T00:00:01Z',
+      duration: null, // No duration to avoid abnormal late condition
+    });
+
+    render(<MonitorCheckInsGrid project={project} checkIns={[checkIn]} />);
+    expect(screen.queryByTestId('more-information')).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
Looks like this

<img width="1487" height="361" alt="image" src="https://github.com/user-attachments/assets/1c4529a7-d945-4d61-8548-bef749e31b21" />

and

<img width="1500" height="352" alt="image" src="https://github.com/user-attachments/assets/9abb93d7-8566-40d0-b974-df605a8c0226" />

Relates to [NEW-503: Investigate -30min late check-in issue](https://linear.app/getsentry/issue/NEW-503/investigate-30min-late-check-in-issue)