### PR TITLE
fix(aci): Use correct time period in metric details chart

### DIFF
--- a/static/app/views/detectors/components/details/metric/chart.tsx
+++ b/static/app/views/detectors/components/details/metric/chart.tsx
@@ -12,7 +12,7 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {MetricDetector, SnubaQuery} from 'sentry/types/workflowEngine/detectors';
 import {useLocation} from 'sentry/utils/useLocation';
-import {TimePeriod} from 'sentry/views/alerts/rules/metric/types';
+import {useDetectorDateParams} from 'sentry/views/detectors/components/details/metric/utils/useDetectorTimePeriods';
 import {getDetectorDataset} from 'sentry/views/detectors/datasetConfig/getDetectorDataset';
 import {useIncidentMarkers} from 'sentry/views/detectors/hooks/useIncidentMarkers';
 import {useMetricDetectorSeries} from 'sentry/views/detectors/hooks/useMetricDetectorSeries';
@@ -21,6 +21,8 @@ import {useOpenPeriods} from 'sentry/views/detectors/hooks/useOpenPeriods';
 
 interface MetricDetectorDetailsChartProps {
   detector: MetricDetector;
+  // Passing snubaQuery separately to avoid checking null in all places
+  snubaQuery: SnubaQuery;
 }
 const CHART_HEIGHT = 180;
 
@@ -201,24 +203,22 @@ function MetricDetectorChart({
   );
 }
 
-export function MetricDetectorDetailsChart({detector}: MetricDetectorDetailsChartProps) {
-  const dataSource = detector.dataSources[0];
-  const snubaQuery = dataSource.queryObj?.snubaQuery;
+export function MetricDetectorDetailsChart({
+  detector,
+  snubaQuery,
+}: MetricDetectorDetailsChartProps) {
   const location = useLocation();
   const statsPeriod = location.query?.statsPeriod as string | undefined;
   const start = location.query?.start as string | undefined;
   const end = location.query?.end as string | undefined;
-  const dateParams =
-    start && end
-      ? {start, end}
-      : statsPeriod
-        ? {statsPeriod}
-        : {statsPeriod: TimePeriod.SEVEN_DAYS};
-
-  if (!snubaQuery) {
-    // Unlikely, helps narrow types
-    return null;
-  }
+  const detectorDataset = getDetectorDataset(snubaQuery.dataset, snubaQuery.eventTypes);
+  const dateParams = useDetectorDateParams({
+    dataset: detectorDataset,
+    intervalSeconds: snubaQuery.timeWindow,
+    start,
+    end,
+    urlStatsPeriod: statsPeriod,
+  });
 
   return (
     <ChartContainer>

--- a/static/app/views/detectors/components/details/metric/index.tsx
+++ b/static/app/views/detectors/components/details/metric/index.tsx
@@ -35,7 +35,9 @@ export function MetricDetectorDetails({detector, project}: MetricDetectorDetails
             <TransactionsDatasetWarning />
           )}
           <MetricTimePeriodSelect dataset={detectorDataset} interval={interval} />
-          <MetricDetectorDetailsChart detector={detector} />
+          {snubaQuery && (
+            <MetricDetectorDetailsChart detector={detector} snubaQuery={snubaQuery} />
+          )}
           <DetectorDetailsOngoingIssues detectorId={detector.id} />
           <DetectorDetailsAutomations detector={detector} />
         </DetailLayout.Main>

--- a/static/app/views/detectors/components/details/metric/timePeriodSelect.spec.tsx
+++ b/static/app/views/detectors/components/details/metric/timePeriodSelect.spec.tsx
@@ -11,14 +11,14 @@ describe('MetricTimePeriodSelect', () => {
 
     // Opens the select and chooses a different period
     await userEvent.click(
-      // Default selected should be Last 7 days for this interval/dataset
-      screen.getByRole('button', {name: /last 7 days/i})
+      // Default currently selected
+      screen.getByRole('button', {name: /last 14 days/i})
     );
 
-    await userEvent.click(screen.getByText(/last 14 days/i));
+    await userEvent.click(screen.getByText(/last 7 days/i));
 
     await waitFor(() => {
-      expect(router.location.query.statsPeriod).toBe('14d');
+      expect(router.location.query.statsPeriod).toBe('7d');
     });
 
     // Ensure absolute range is cleared

--- a/static/app/views/detectors/components/details/metric/utils/useDetectorTimePeriods.tsx
+++ b/static/app/views/detectors/components/details/metric/utils/useDetectorTimePeriods.tsx
@@ -1,0 +1,124 @@
+import {useMemo} from 'react';
+
+import {getDatasetConfig} from 'sentry/views/detectors/datasetConfig/getDatasetConfig';
+import type {DetectorDataset} from 'sentry/views/detectors/datasetConfig/types';
+import {
+  getTimePeriodLabel,
+  MetricDetectorInterval,
+  MetricDetectorTimePeriod,
+} from 'sentry/views/detectors/datasetConfig/utils/timePeriods';
+
+export type DetectorTimePeriodOption = {
+  label: React.ReactNode;
+  value: MetricDetectorTimePeriod;
+};
+
+/** Map a detector interval in seconds to a MetricDetectorInterval (minutes). */
+function mapIntervalSecondsToMetricInterval(
+  intervalSeconds: number
+): MetricDetectorInterval | undefined {
+  const intervalMinutes = Math.floor(intervalSeconds / 60);
+  const validIntervals = Object.values(MetricDetectorInterval)
+    .filter(value => typeof value === 'number')
+    .sort((a, b) => a - b);
+  if (validIntervals.includes(intervalMinutes)) {
+    return intervalMinutes;
+  }
+  return undefined;
+}
+
+/** Resolve a valid statsPeriod for a detector based on dataset and interval. */
+function resolveStatsPeriodForDetector({
+  dataset,
+  intervalSeconds,
+  urlStatsPeriod,
+}: {
+  dataset: DetectorDataset;
+  intervalSeconds: number | undefined;
+  urlStatsPeriod?: string;
+}): MetricDetectorTimePeriod {
+  if (!intervalSeconds) {
+    return MetricDetectorTimePeriod.SEVEN_DAYS;
+  }
+
+  const metricInterval = mapIntervalSecondsToMetricInterval(intervalSeconds);
+  if (!metricInterval) {
+    return (
+      (urlStatsPeriod as MetricDetectorTimePeriod) ?? MetricDetectorTimePeriod.SEVEN_DAYS
+    );
+  }
+  const datasetConfig = getDatasetConfig(dataset);
+  const allowed = datasetConfig.getTimePeriods(metricInterval);
+  if (urlStatsPeriod && allowed.includes(urlStatsPeriod as MetricDetectorTimePeriod)) {
+    return urlStatsPeriod as MetricDetectorTimePeriod;
+  }
+  const largest = allowed[allowed.length - 1];
+  return largest ?? MetricDetectorTimePeriod.SEVEN_DAYS;
+}
+
+export function useDetectorTimePeriodOptions(params: {
+  dataset: DetectorDataset | undefined;
+  intervalSeconds: number | undefined;
+}): DetectorTimePeriodOption[] {
+  const {dataset, intervalSeconds} = params;
+
+  return useMemo(() => {
+    if (!dataset || !intervalSeconds) {
+      return [];
+    }
+    const metricInterval = mapIntervalSecondsToMetricInterval(intervalSeconds);
+    if (!metricInterval) {
+      return [];
+    }
+    const datasetConfig = getDatasetConfig(dataset);
+    const timePeriods = datasetConfig.getTimePeriods(metricInterval);
+    return timePeriods.map(period => ({
+      value: period,
+      label: getTimePeriodLabel(period),
+    }));
+  }, [dataset, intervalSeconds]);
+}
+
+export function useDetectorResolvedStatsPeriod(params: {
+  dataset: DetectorDataset | undefined;
+  intervalSeconds: number | undefined;
+  urlStatsPeriod?: string;
+}): MetricDetectorTimePeriod {
+  const {dataset, intervalSeconds, urlStatsPeriod} = params;
+
+  return useMemo(() => {
+    if (!dataset) {
+      return MetricDetectorTimePeriod.SEVEN_DAYS;
+    }
+    return resolveStatsPeriodForDetector({
+      dataset,
+      intervalSeconds,
+      urlStatsPeriod,
+    });
+  }, [dataset, intervalSeconds, urlStatsPeriod]);
+}
+
+export function useDetectorDateParams(params: {
+  dataset: DetectorDataset | undefined;
+  intervalSeconds: number | undefined;
+  end?: string;
+  start?: string;
+  urlStatsPeriod?: string;
+}): {end?: string; start?: string; statsPeriod?: MetricDetectorTimePeriod} {
+  const {dataset, intervalSeconds, start, end, urlStatsPeriod} = params;
+
+  return useMemo(() => {
+    if (start && end) {
+      return {start, end};
+    }
+    if (!dataset) {
+      return {};
+    }
+    const resolved = resolveStatsPeriodForDetector({
+      dataset,
+      intervalSeconds,
+      urlStatsPeriod,
+    });
+    return {statsPeriod: resolved};
+  }, [dataset, intervalSeconds, start, end, urlStatsPeriod]);
+}

--- a/static/app/views/detectors/components/details/metric/utils/useDetectorTimePeriods.tsx
+++ b/static/app/views/detectors/components/details/metric/utils/useDetectorTimePeriods.tsx
@@ -8,11 +8,6 @@ import {
   MetricDetectorTimePeriod,
 } from 'sentry/views/detectors/datasetConfig/utils/timePeriods';
 
-export type DetectorTimePeriodOption = {
-  label: React.ReactNode;
-  value: MetricDetectorTimePeriod;
-};
-
 /** Map a detector interval in seconds to a MetricDetectorInterval (minutes). */
 function mapIntervalSecondsToMetricInterval(
   intervalSeconds: number
@@ -55,6 +50,11 @@ function resolveStatsPeriodForDetector({
   const largest = allowed[allowed.length - 1];
   return largest ?? MetricDetectorTimePeriod.SEVEN_DAYS;
 }
+
+type DetectorTimePeriodOption = {
+  label: React.ReactNode;
+  value: MetricDetectorTimePeriod;
+};
 
 export function useDetectorTimePeriodOptions(params: {
   dataset: DetectorDataset | undefined;

--- a/static/app/views/detectors/datasetConfig/utils/discoverSeries.tsx
+++ b/static/app/views/detectors/datasetConfig/utils/discoverSeries.tsx
@@ -117,6 +117,7 @@ export function getDiscoverSeriesQueryOptions({
         dataset,
         includePrevious: false,
         includeAllArgs: true,
+        partial: '1',
         statsPeriod,
         start,
         end,

--- a/static/app/views/detectors/datasetConfig/utils/timePeriods.tsx
+++ b/static/app/views/detectors/datasetConfig/utils/timePeriods.tsx
@@ -7,6 +7,7 @@ export enum MetricDetectorTimePeriod {
   THREE_DAYS = '3d',
   SEVEN_DAYS = '7d',
   FOURTEEN_DAYS = '14d',
+  TWENTY_EIGHT_DAYS = '28d',
 }
 
 export enum MetricDetectorInterval {
@@ -66,31 +67,39 @@ const STANDARD_TIME_PERIODS_MAP: Record<
     MetricDetectorTimePeriod.THREE_DAYS,
     MetricDetectorTimePeriod.SEVEN_DAYS,
     MetricDetectorTimePeriod.FOURTEEN_DAYS,
+    MetricDetectorTimePeriod.TWENTY_EIGHT_DAYS,
   ],
   [MetricDetectorInterval.THIRTY_MINUTES]: [
     MetricDetectorTimePeriod.ONE_DAY,
     MetricDetectorTimePeriod.THREE_DAYS,
     MetricDetectorTimePeriod.SEVEN_DAYS,
     MetricDetectorTimePeriod.FOURTEEN_DAYS,
+    MetricDetectorTimePeriod.TWENTY_EIGHT_DAYS,
   ],
   [MetricDetectorInterval.ONE_HOUR]: [
     MetricDetectorTimePeriod.ONE_DAY,
     MetricDetectorTimePeriod.THREE_DAYS,
     MetricDetectorTimePeriod.SEVEN_DAYS,
     MetricDetectorTimePeriod.FOURTEEN_DAYS,
+    MetricDetectorTimePeriod.TWENTY_EIGHT_DAYS,
   ],
   [MetricDetectorInterval.TWO_HOURS]: [
     MetricDetectorTimePeriod.ONE_DAY,
     MetricDetectorTimePeriod.THREE_DAYS,
     MetricDetectorTimePeriod.SEVEN_DAYS,
     MetricDetectorTimePeriod.FOURTEEN_DAYS,
+    MetricDetectorTimePeriod.TWENTY_EIGHT_DAYS,
   ],
   [MetricDetectorInterval.FOUR_HOURS]: [
     MetricDetectorTimePeriod.THREE_DAYS,
     MetricDetectorTimePeriod.SEVEN_DAYS,
     MetricDetectorTimePeriod.FOURTEEN_DAYS,
+    MetricDetectorTimePeriod.TWENTY_EIGHT_DAYS,
   ],
-  [MetricDetectorInterval.ONE_DAY]: [MetricDetectorTimePeriod.FOURTEEN_DAYS],
+  [MetricDetectorInterval.ONE_DAY]: [
+    MetricDetectorTimePeriod.FOURTEEN_DAYS,
+    MetricDetectorTimePeriod.TWENTY_EIGHT_DAYS,
+  ],
 };
 
 const EAP_TIME_PERIODS_MAP: Record<MetricDetectorInterval, MetricDetectorTimePeriod[]> = {


### PR DESCRIPTION
Use the same hook in both the dropdown with the options and the chart.

Make 28 day time periods available on monitor details.

Pass partial = "1" to get buckets that are still partial, metric alerts gets around this by selecting an exact time period. We might want this enabled only for really large time periods. On shorter intervals like 1 minute, partial buckets are not as interesting. 1 day partial buckets are much more interesting especially if the alert is already firing.

The overall goal was to get this metric detector to look like the original metric alert https://sentry.sentry.io/issues/monitors/2809059/