### PR TITLE
chore(releases) - Update ReleaseProjectEnvironment last_seen on health data arrival

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1229,6 +1229,13 @@ register(
     flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+register(
+    "release-health.enable-release-last-seen-update",
+    type=Bool,
+    default=False,
+    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # Run an experimental grouping config in background for performance analysis
 register("store.background-grouping-config-id", default=None, flags=FLAG_AUTOMATOR_MODIFIABLE)
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1232,7 +1232,7 @@ register(
 register(
     "release-health.disable-release-last-seen-update",
     type=Bool,
-    default=True,
+    default=False,
     flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
 )
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1230,9 +1230,9 @@ register(
 )
 
 register(
-    "release-health.enable-release-last-seen-update",
+    "release-health.disable-release-last-seen-update",
     type=Bool,
-    default=False,
+    default=True,
     flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
 )
 

--- a/src/sentry/release_health/tasks.py
+++ b/src/sentry/release_health/tasks.py
@@ -124,8 +124,8 @@ def adopt_releases(org_id: int, totals: Totals) -> Sequence[int]:
 def _update_last_seen(
     org_id, current_time, cutoff_time, project_id, environment_name, release_version
 ):
-    # Add a feature flag to allow disabling last_seen updates if needed
-    if options.get("release_health.enable_release_last_seen_update", False):
+    # Skip last_seen updates when the disable option is set (default True)
+    if options.get("release-health.disable-release-last-seen-update", True):
         logger.info(
             "Release last_seen update skipped due to feature flag",
             extra={

--- a/src/sentry/release_health/tasks.py
+++ b/src/sentry/release_health/tasks.py
@@ -1,5 +1,6 @@
 import logging
 from collections.abc import Iterator, Sequence
+from datetime import datetime, timedelta
 from typing import Any, TypedDict
 
 from django.core.exceptions import ValidationError
@@ -81,89 +82,155 @@ def process_projects_with_sessions(org_id, project_ids) -> None:
 
 
 def adopt_releases(org_id: int, totals: Totals) -> Sequence[int]:
-    # Using the totals calculated in sum_sessions_and_releases, mark any releases as adopted if they reach a threshold.
+    # Process all releases with sessions: update last_seen, and if they meet the 10% threshold, handle adoption logic.
     adopted_ids = []
+    current_time = timezone.now()
+    cutoff_time = current_time - timedelta(seconds=60)
+
     with metrics.timer(
         "sentry.tasks.monitor_release_adoption.process_projects_with_sessions.updates"
     ):
-        for adopted_release in iter_adopted_releases(totals):
-            rpe = None
-            try:
-                rpe = ReleaseProjectEnvironment.objects.get(
-                    project_id=adopted_release["project_id"],
-                    release_id=Release.objects.get(
-                        organization=org_id, version=adopted_release["version"]
-                    ).id,
-                    environment__name=adopted_release["environment"],
-                    environment__organization_id=org_id,
-                )
+        # Single loop: process all releases with sessions
+        for project_id, project_totals in totals.items():
+            for environment_name, env_totals in project_totals.items():
+                total_sessions = env_totals["total_sessions"]
 
-                updates: dict[str, Any] = {}
-                if rpe.adopted is None:
-                    updates["adopted"] = timezone.now()
-
-                if rpe.unadopted is not None:
-                    updates["unadopted"] = None
-
-                if updates:
-                    rpe.update(**updates)
-
-                # Emit metric indicating updated. Not interested in the actual row being
-                # updated. More that this step completed successfully.
-                metrics.incr("sentry.tasks.process_projects_with_sessions.updated_rpe")
-            except (Release.DoesNotExist, ReleaseProjectEnvironment.DoesNotExist):
-                metrics.incr("sentry.tasks.process_projects_with_sessions.creating_rpe")
-                try:
-                    env = Environment.objects.get_or_create(
-                        name=adopted_release["environment"], organization_id=org_id
-                    )[0]
-                    try:
-                        release = Release.objects.get_or_create(
-                            organization_id=org_id,
-                            version=adopted_release["version"],
-                            defaults={
-                                "status": ReleaseStatus.OPEN,
-                            },
-                        )[0]
-                    except IntegrityError:
-                        release = Release.objects.get(
-                            organization_id=org_id, version=adopted_release["version"]
+                for release_version, session_count in env_totals["releases"].items():
+                    # If this release meets the adoption threshold, handle adoption logic
+                    if valid_environment(
+                        environment_name, total_sessions
+                    ) and valid_and_adopted_release(release_version, session_count, total_sessions):
+                        rpe = _handle_release_adoption(
+                            org_id, project_id, environment_name, release_version, current_time
                         )
-                    except ValidationError:
-                        release = None
-                        logger.exception(
-                            "sentry.tasks.process_projects_with_sessions.creating_rpe.ValidationError",
-                            extra={
-                                "org_id": org_id,
-                                "release_version": adopted_release["version"],
-                            },
-                        )
+                        if rpe:
+                            adopted_ids.append(rpe.id)
 
-                    if release:
-                        release.add_project(Project.objects.get(id=adopted_release["project_id"]))
-
-                        ReleaseEnvironment.objects.get_or_create(
-                            environment=env, organization_id=org_id, release=release
+                    if session_count > 0:  # Has session activity
+                        # Always update last_seen for any release with sessions
+                        _update_last_seen(
+                            org_id,
+                            current_time,
+                            cutoff_time,
+                            project_id,
+                            environment_name,
+                            release_version,
                         )
-
-                        rpe = ReleaseProjectEnvironment.objects.create(
-                            project_id=adopted_release["project_id"],
-                            release_id=release.id,
-                            environment=env,
-                            adopted=timezone.now(),
-                        )
-                except (
-                    Project.DoesNotExist,
-                    Environment.DoesNotExist,
-                    Release.DoesNotExist,
-                    ReleaseEnvironment.DoesNotExist,
-                ) as exc:
-                    metrics.incr("sentry.tasks.process_projects_with_sessions.skipped_update")
-                    capture_exception(exc)
-            if rpe:
-                adopted_ids.append(rpe.id)
 
     return adopted_ids
+
+
+def _update_last_seen(
+    org_id, current_time, cutoff_time, project_id, environment_name, release_version
+):
+    try:
+        ReleaseProjectEnvironment.objects.filter(
+            project_id=project_id,
+            release__organization_id=org_id,
+            release__version=release_version,
+            environment__name=environment_name,
+            environment__organization_id=org_id,
+            last_seen__lt=cutoff_time,  # Only update if >60 seconds old
+        ).update(last_seen=current_time)
+    except Exception as e:
+        logger.warning(
+            "Failed to update last_seen for release",
+            extra={
+                "org_id": org_id,
+                "project_id": project_id,
+                "release_version": release_version,
+                "environment": environment_name,
+                "error": str(e),
+            },
+        )
+
+
+def _handle_release_adoption(
+    org_id: int,
+    project_id: int,
+    environment_name: str,
+    release_version: str,
+    current_time: datetime,
+) -> ReleaseProjectEnvironment | None:
+    """
+    Handle adoption logic for a single release that meets the adoption threshold.
+    Returns the ReleaseProjectEnvironment instance if successful, None otherwise.
+    """
+    rpe = None
+    try:
+        rpe = ReleaseProjectEnvironment.objects.get(
+            project_id=project_id,
+            release_id=Release.objects.get(organization=org_id, version=release_version).id,
+            environment__name=environment_name,
+            environment__organization_id=org_id,
+        )
+
+        updates: dict[str, Any] = {}
+
+        if rpe.adopted is None:
+            updates["adopted"] = current_time
+
+        if rpe.unadopted is not None:
+            updates["unadopted"] = None
+
+        # Note: last_seen already updated in main loop
+
+        if updates:
+            rpe.update(**updates)
+
+        # Emit metric indicating updated
+        metrics.incr("sentry.tasks.process_projects_with_sessions.updated_rpe")
+
+    except (Release.DoesNotExist, ReleaseProjectEnvironment.DoesNotExist):
+        metrics.incr("sentry.tasks.process_projects_with_sessions.creating_rpe")
+        try:
+            env = Environment.objects.get_or_create(name=environment_name, organization_id=org_id)[
+                0
+            ]
+            try:
+                release = Release.objects.get_or_create(
+                    organization_id=org_id,
+                    version=release_version,
+                    defaults={
+                        "status": ReleaseStatus.OPEN,
+                    },
+                )[0]
+            except IntegrityError:
+                release = Release.objects.get(organization_id=org_id, version=release_version)
+            except ValidationError:
+                release = None
+                logger.exception(
+                    "sentry.tasks.process_projects_with_sessions.creating_rpe.ValidationError",
+                    extra={
+                        "org_id": org_id,
+                        "release_version": release_version,
+                    },
+                )
+
+            if release:
+                release.add_project(Project.objects.get(id=project_id))
+
+                ReleaseEnvironment.objects.get_or_create(
+                    environment=env, organization_id=org_id, release=release
+                )
+
+                rpe = ReleaseProjectEnvironment.objects.create(
+                    project_id=project_id,
+                    release_id=release.id,
+                    environment=env,
+                    adopted=current_time,
+                    last_seen=current_time,
+                )
+        except (
+            Project.DoesNotExist,
+            Environment.DoesNotExist,
+            Release.DoesNotExist,
+            ReleaseEnvironment.DoesNotExist,
+        ) as exc:
+            metrics.incr("sentry.tasks.process_projects_with_sessions.skipped_update")
+            capture_exception(exc)
+
+    return rpe
 
 
 def cleanup_adopted_releases(project_ids: Sequence[int], adopted_ids: Sequence[int]) -> None:

--- a/static/app/components/group/releaseStats.tsx
+++ b/static/app/components/group/releaseStats.tsx
@@ -111,7 +111,9 @@ function GroupReleaseStats({
                   {t('Last Seen')}
                 </GuideAnchor>
                 <QuestionTooltip
-                  title={t('When the most recent event in this issue was captured.')}
+                  title={t(
+                    'When the most recent event or session activity in this issue was captured.'
+                  )}
                   size="xs"
                 />
               </SidebarSection.Title>
@@ -131,7 +133,9 @@ function GroupReleaseStats({
               <SidebarSection.Title>
                 {t('First Seen')}
                 <QuestionTooltip
-                  title={t('When the first event in this issue was captured.')}
+                  title={t(
+                    'When the first event or session activity in this issue was captured.'
+                  )}
                   size="xs"
                 />
               </SidebarSection.Title>

--- a/static/app/views/releases/detail/overview/sidebar/projectReleaseDetails.tsx
+++ b/static/app/views/releases/detail/overview/sidebar/projectReleaseDetails.tsx
@@ -149,11 +149,11 @@ function ProjectReleaseDetails({release, releaseMeta, project}: Props) {
             }
           />
           <KeyValueTableRow
-            keyName={t('First Event')}
+            keyName={t('First Activity')}
             value={firstEvent ? <TimeSince date={firstEvent} /> : '\u2014'}
           />
           <KeyValueTableRow
-            keyName={t('Last Event')}
+            keyName={t('Last Activity')}
             value={lastEvent ? <TimeSince date={lastEvent} /> : '\u2014'}
           />
           <KeyValueTableRow

--- a/tests/sentry/release_health/test_tasks.py
+++ b/tests/sentry/release_health/test_tasks.py
@@ -15,8 +15,8 @@ from sentry.models.repository import Repository
 from sentry.release_health.release_monitor.base import BaseReleaseMonitorBackend
 from sentry.release_health.release_monitor.metrics import MetricReleaseMonitorBackend
 from sentry.release_health.tasks import (
+    adopt_releases,
     has_been_adopted,
-    iter_adopted_releases,
     monitor_release_adoption,
     process_projects_with_sessions,
     valid_and_adopted_release,
@@ -39,6 +39,7 @@ class BaseTestReleaseMonitor(TestCase, BaseMetricsTestCase):
         backend = self.backend_class()
         self.backend = mock.patch("sentry.release_health.tasks.release_monitor", backend)
         self.backend.__enter__()
+        # no global option mocking needed
         self.project = self.create_project()
         self.project1 = self.create_project()
         self.project2 = self.create_project()
@@ -566,7 +567,9 @@ class BaseTestReleaseMonitor(TestCase, BaseMetricsTestCase):
         )
 
         before_call = timezone.now()
-        process_projects_with_sessions(self.organization.id, [self.project1.id])
+        # Disable flag must be False to allow updates in this test
+        with self.options({"release-health.disable-release-last-seen-update": False}):
+            process_projects_with_sessions(self.organization.id, [self.project1.id])
 
         updated = ReleaseProjectEnvironment.objects.get(id=self.rpe.id)
         assert updated.last_seen >= before_call
@@ -576,30 +579,69 @@ class TestMetricReleaseMonitor(BaseTestReleaseMonitor, BaseMetricsTestCase):
     backend_class = MetricReleaseMonitorBackend
 
 
-def test_iter_adopted_releases() -> None:
-    """Test the totals object is flattened into a list of tuple of values."""
-    assert (
-        list(iter_adopted_releases({1: {"": {"releases": {"0.1": 1}, "total_sessions": 1}}})) == []
-    )
-
-    assert list(
-        iter_adopted_releases(
-            {
-                1: {"prod": {"releases": {"0.1": 1, "0.3": 9}, "total_sessions": 10}},
-                2: {"prod": {"releases": {"0.1": 1, "0.2": 4}, "total_sessions": 5}},
-            }
+class TestAdoptReleasesPath(TestMetricReleaseMonitor):
+    def test_adopt_releases_respects_environment_and_threshold(self) -> None:
+        # Empty environment should be ignored
+        adopt_releases(
+            self.organization.id,
+            {self.project1.id: {"": {"releases": {"0.1": 1}, "total_sessions": 1}}},
         )
-    ) == [
-        {"project_id": 1, "environment": "prod", "version": "0.1"},
-        {"project_id": 1, "environment": "prod", "version": "0.3"},
-        {"project_id": 2, "environment": "prod", "version": "0.1"},
-        {"project_id": 2, "environment": "prod", "version": "0.2"},
-    ]
 
-    assert (
-        list(iter_adopted_releases({1: {"prod": {"releases": {"0.1": 1}, "total_sessions": 100}}}))
-        == []
-    )
+        assert not ReleaseProjectEnvironment.objects.filter(
+            project_id=self.project1.id, environment__name=""
+        ).exists()
+
+        # Valid env with releases meeting 10% threshold should be adopted
+        adopt_releases(
+            self.organization.id,
+            {
+                self.project1.id: {
+                    "prod": {"releases": {"0.1": 1, "0.3": 9}, "total_sessions": 10}
+                },
+                self.project2.id: {"prod": {"releases": {"0.1": 1, "0.2": 4}, "total_sessions": 5}},
+            },
+        )
+
+        assert ReleaseProjectEnvironment.objects.filter(
+            project_id=self.project1.id,
+            release__version="0.1",
+            environment__name="prod",
+            adopted__isnull=False,
+        ).exists()
+
+        assert ReleaseProjectEnvironment.objects.filter(
+            project_id=self.project1.id,
+            release__version="0.3",
+            environment__name="prod",
+            adopted__isnull=False,
+        ).exists()
+
+        assert ReleaseProjectEnvironment.objects.filter(
+            project_id=self.project2.id,
+            release__version="0.1",
+            environment__name="prod",
+            adopted__isnull=False,
+        ).exists()
+
+        assert ReleaseProjectEnvironment.objects.filter(
+            project_id=self.project2.id,
+            release__version="0.2",
+            environment__name="prod",
+            adopted__isnull=False,
+        ).exists()
+
+        # Below threshold should not adopt
+        adopt_releases(
+            self.organization.id,
+            {self.project1.id: {"prod": {"releases": {"0.1": 1}, "total_sessions": 100}}},
+        )
+
+        assert not ReleaseProjectEnvironment.objects.filter(
+            project_id=self.project1.id,
+            release__version="0.1",
+            environment__name="prod",
+            adopted__gt=timezone.now(),
+        ).exists()
 
 
 def test_valid_environment() -> None:


### PR DESCRIPTION
We want to use the last_seen field to be able to tell if a Release has health data in Snuba. This also aligns with the purpose of this field, which doesnt really mean last event seen as it seems today since spans will also set last_seen. It will now mean last activity which is more accurate.