### PR TITLE
chore(releases): Trigger commit backfill task when we update last_seen for releases

### DIFF
--- a/src/sentry/models/releaseenvironment.py
+++ b/src/sentry/models/releaseenvironment.py
@@ -12,7 +12,7 @@ from sentry.db.models import (
     sane_repr,
 )
 from sentry.releases.commits import get_dual_write_start_date
-from sentry.releases.tasks import backfill_commits_for_release_async
+from sentry.releases.tasks import backfill_commits_for_release
 from sentry.utils import metrics
 from sentry.utils.cache import cache
 
@@ -81,7 +81,7 @@ class ReleaseEnvironment(Model):
             # Only fire the task if this release just crossed the dual-write start date
             dual_write_start = get_dual_write_start_date()
             if dual_write_start and old_last_seen < dual_write_start <= datetime:
-                backfill_commits_for_release_async.delay(
+                backfill_commits_for_release.delay(
                     organization_id=project.organization_id,
                     release_id=instance.release_id,
                 )

--- a/src/sentry/models/releaseenvironment.py
+++ b/src/sentry/models/releaseenvironment.py
@@ -11,6 +11,8 @@ from sentry.db.models import (
     region_silo_model,
     sane_repr,
 )
+from sentry.releases.commits import get_dual_write_start_date
+from sentry.releases.tasks import backfill_commits_for_release_async
 from sentry.utils import metrics
 from sentry.utils.cache import cache
 
@@ -68,11 +70,21 @@ class ReleaseEnvironment(Model):
         # it even if we can't
         if not created and instance.last_seen < datetime - timedelta(seconds=60):
             metric_tags["bumped"] = "true"
+            old_last_seen = instance.last_seen
             cls.objects.filter(
                 id=instance.id, last_seen__lt=datetime - timedelta(seconds=60)
             ).update(last_seen=datetime)
             instance.last_seen = datetime
             cache.set(cache_key, instance, 3600)
+
+            # Check if we need to backfill commits for this release
+            # Only fire the task if this release just crossed the dual-write start date
+            dual_write_start = get_dual_write_start_date()
+            if dual_write_start and old_last_seen < dual_write_start <= datetime:
+                backfill_commits_for_release_async.delay(
+                    organization_id=project.organization_id,
+                    release_id=instance.release_id,
+                )
         else:
             metric_tags["bumped"] = "false"
 

--- a/src/sentry/models/releaseprojectenvironment.py
+++ b/src/sentry/models/releaseprojectenvironment.py
@@ -14,6 +14,8 @@ from sentry.db.models import (
     region_silo_model,
     sane_repr,
 )
+from sentry.releases.commits import get_dual_write_start_date
+from sentry.releases.tasks import backfill_commits_for_release_async
 from sentry.utils import metrics
 from sentry.utils.cache import cache
 
@@ -83,12 +85,20 @@ class ReleaseProjectEnvironment(Model):
 
         # Same as releaseenvironment model. Minimizes last_seen updates to once a minute
         if not created and instance.last_seen < datetime - timedelta(seconds=60):
+            old_last_seen = instance.last_seen
             cls.objects.filter(
                 id=instance.id, last_seen__lt=datetime - timedelta(seconds=60)
             ).update(last_seen=datetime)
             instance.last_seen = datetime
             cache.set(cache_key, instance, 3600)
             metrics_tags["bumped"] = "true"
+
+            dual_write_start = get_dual_write_start_date()
+            if dual_write_start and old_last_seen < dual_write_start <= datetime:
+                backfill_commits_for_release_async.delay(
+                    organization_id=project.organization_id,
+                    release_id=release.id,
+                )
         else:
             metrics_tags["bumped"] = "false"
 

--- a/src/sentry/models/releaseprojectenvironment.py
+++ b/src/sentry/models/releaseprojectenvironment.py
@@ -15,7 +15,7 @@ from sentry.db.models import (
     sane_repr,
 )
 from sentry.releases.commits import get_dual_write_start_date
-from sentry.releases.tasks import backfill_commits_for_release_async
+from sentry.releases.tasks import backfill_commits_for_release
 from sentry.utils import metrics
 from sentry.utils.cache import cache
 
@@ -95,7 +95,7 @@ class ReleaseProjectEnvironment(Model):
 
             dual_write_start = get_dual_write_start_date()
             if dual_write_start and old_last_seen < dual_write_start <= datetime:
-                backfill_commits_for_release_async.delay(
+                backfill_commits_for_release.delay(
                     organization_id=project.organization_id,
                     release_id=release.id,
                 )

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3467,3 +3467,9 @@ register(
     default=True,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "commit.dual-write-start-date",
+    type=String,
+    default=None,
+    flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK,
+)

--- a/src/sentry/releases/commits.py
+++ b/src/sentry/releases/commits.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 from django.db import router
 
-from sentry import features
+from sentry import features, options
 from sentry.models.commit import Commit as OldCommit
 from sentry.models.commitauthor import CommitAuthor
 from sentry.models.commitfilechange import CommitFileChange as OldCommitFileChange
@@ -12,6 +12,25 @@ from sentry.releases.models import Commit, CommitFileChange
 from sentry.utils.db import atomic_transaction
 
 logger = logging.getLogger(__name__)
+
+
+def get_dual_write_start_date() -> datetime | None:
+    """
+    Get the dual-write start date from options.
+    Returns None if not set or invalid.
+    """
+    start_date_str = options.get("commit.dual-write-start-date")
+    if not start_date_str:
+        return None
+
+    try:
+        return datetime.fromisoformat(start_date_str)
+    except (ValueError, TypeError):
+        logger.exception(
+            "get_dual_write_start_date.invalid_date",
+            extra={"start_date_str": start_date_str},
+        )
+        return None
 
 
 def _dual_write_commit(

--- a/src/sentry/releases/commits.py
+++ b/src/sentry/releases/commits.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime
+from datetime import UTC, datetime
 
 from django.db import router
 
@@ -18,13 +18,17 @@ def get_dual_write_start_date() -> datetime | None:
     """
     Get the dual-write start date from options.
     Returns None if not set or invalid.
+    Always returns a timezone-aware datetime in UTC.
     """
     start_date_str = options.get("commit.dual-write-start-date")
     if not start_date_str:
         return None
 
     try:
-        return datetime.fromisoformat(start_date_str)
+        dt = datetime.fromisoformat(start_date_str)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=UTC)
+        return dt
     except (ValueError, TypeError):
         logger.exception(
             "get_dual_write_start_date.invalid_date",

--- a/tests/sentry/models/test_releaseenvironment.py
+++ b/tests/sentry/models/test_releaseenvironment.py
@@ -2,10 +2,16 @@ from datetime import timedelta
 
 from django.utils import timezone
 
+from sentry.models.commit import Commit as OldCommit
+from sentry.models.commitauthor import CommitAuthor
 from sentry.models.environment import Environment
 from sentry.models.release import Release
+from sentry.models.releasecommit import ReleaseCommit
 from sentry.models.releaseenvironment import ReleaseEnvironment
+from sentry.models.repository import Repository
+from sentry.releases.models import Commit
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.options import override_options
 
 
 class GetOrCreateTest(TestCase):
@@ -52,3 +58,133 @@ class GetOrCreateTest(TestCase):
         )
         assert relenv.id == relenv2.id
         assert ReleaseEnvironment.objects.get(id=relenv.id).last_seen == relenv2.last_seen
+
+
+class BackfillTriggerTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.project = self.create_project()
+        self.release = self.create_release(project=self.project, version="1.0.0")
+        self.environment = Environment.objects.create(
+            organization_id=self.project.organization_id, name="production"
+        )
+
+        self.repo = Repository.objects.create(
+            name="test-repo",
+            organization_id=self.project.organization_id,
+        )
+        self.author = CommitAuthor.objects.create(
+            organization_id=self.project.organization_id,
+            email="test@example.com",
+            name="Test Author",
+        )
+        self.old_commit = OldCommit.objects.create(
+            organization_id=self.project.organization_id,
+            repository_id=self.repo.id,
+            key="abc123",
+            message="Test commit",
+            author=self.author,
+        )
+        ReleaseCommit.objects.create(
+            organization_id=self.project.organization_id,
+            release=self.release,
+            commit=self.old_commit,
+            order=1,
+        )
+
+    def test_triggers_backfill_when_crossing_dual_write_start_date(self):
+        dual_write_start = timezone.now() - timedelta(hours=1)
+        with self.feature({"organizations:commit-retention-dual-writing": True}):
+            with override_options({"commit.dual-write-start-date": dual_write_start.isoformat()}):
+                old_last_seen = dual_write_start - timedelta(days=1)
+                ReleaseEnvironment.objects.create(
+                    organization_id=self.project.organization_id,
+                    project_id=self.project.id,
+                    release_id=self.release.id,
+                    environment_id=self.environment.id,
+                    first_seen=old_last_seen,
+                    last_seen=old_last_seen,
+                )
+                assert not Commit.objects.filter(id=self.old_commit.id).exists()
+
+                new_last_seen = timezone.now()
+                with self.tasks():
+                    ReleaseEnvironment.get_or_create(
+                        project=self.project,
+                        release=self.release,
+                        environment=self.environment,
+                        datetime=new_last_seen,
+                    )
+                assert Commit.objects.filter(id=self.old_commit.id).exists()
+                new_commit = Commit.objects.get(id=self.old_commit.id)
+                assert new_commit.key == "abc123"
+                assert new_commit.message == "Test commit"
+
+    def test_no_trigger_when_already_after_dual_write_start(self):
+        dual_write_start = timezone.now() - timedelta(hours=2)
+        with self.feature({"organizations:commit-retention-dual-writing": True}):
+            with override_options({"commit.dual-write-start-date": dual_write_start.isoformat()}):
+                old_last_seen = dual_write_start + timedelta(hours=1)
+                ReleaseEnvironment.objects.create(
+                    organization_id=self.project.organization_id,
+                    project_id=self.project.id,
+                    release_id=self.release.id,
+                    environment_id=self.environment.id,
+                    first_seen=old_last_seen,
+                    last_seen=old_last_seen,
+                )
+                new_last_seen = timezone.now()
+                with self.tasks():
+                    ReleaseEnvironment.get_or_create(
+                        project=self.project,
+                        release=self.release,
+                        environment=self.environment,
+                        datetime=new_last_seen,
+                    )
+                assert not Commit.objects.filter(id=self.old_commit.id).exists()
+
+    def test_no_trigger_when_dual_write_not_configured(self):
+        old_last_seen = timezone.now() - timedelta(days=1)
+        ReleaseEnvironment.objects.create(
+            organization_id=self.project.organization_id,
+            project_id=self.project.id,
+            release_id=self.release.id,
+            environment_id=self.environment.id,
+            first_seen=old_last_seen,
+            last_seen=old_last_seen,
+        )
+        with self.tasks():
+            ReleaseEnvironment.get_or_create(
+                project=self.project,
+                release=self.release,
+                environment=self.environment,
+                datetime=timezone.now(),
+            )
+
+        assert not Commit.objects.filter(id=self.old_commit.id).exists()
+
+    def test_no_trigger_when_last_seen_not_bumped(self):
+        dual_write_start = timezone.now() - timedelta(hours=1)
+
+        with self.feature({"organizations:commit-retention-dual-writing": True}):
+            with override_options({"commit.dual-write-start-date": dual_write_start.isoformat()}):
+                old_last_seen = dual_write_start - timedelta(days=1)
+                ReleaseEnvironment.objects.create(
+                    organization_id=self.project.organization_id,
+                    project_id=self.project.id,
+                    release_id=self.release.id,
+                    environment_id=self.environment.id,
+                    first_seen=old_last_seen,
+                    last_seen=old_last_seen,
+                )
+
+                new_last_seen = old_last_seen + timedelta(seconds=30)
+                with self.tasks():
+                    ReleaseEnvironment.get_or_create(
+                        project=self.project,
+                        release=self.release,
+                        environment=self.environment,
+                        datetime=new_last_seen,
+                    )
+
+                assert not Commit.objects.filter(id=self.old_commit.id).exists()

--- a/tests/sentry/models/test_releaseprojectenvironment.py
+++ b/tests/sentry/models/test_releaseprojectenvironment.py
@@ -2,10 +2,16 @@ from datetime import timedelta
 
 from django.utils import timezone
 
+from sentry.models.commit import Commit as OldCommit
+from sentry.models.commitauthor import CommitAuthor
 from sentry.models.environment import Environment
 from sentry.models.release import Release
+from sentry.models.releasecommit import ReleaseCommit
 from sentry.models.releaseprojectenvironment import ReleaseProjectEnvironment
+from sentry.models.repository import Repository
+from sentry.releases.models import Commit
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.options import override_options
 
 
 class GetOrCreateTest(TestCase):
@@ -83,3 +89,124 @@ class GetOrCreateTest(TestCase):
         )
         assert release_project_env.first_seen == self.datetime_now
         assert release_project_env.last_seen == self.datetime_now
+
+
+class BackfillTriggerTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.project = self.create_project()
+        self.release = self.create_release(project=self.project, version="1.0.0")
+        self.environment = Environment.objects.create(
+            organization_id=self.project.organization_id, name="production"
+        )
+        self.repo = Repository.objects.create(
+            name="test-repo",
+            organization_id=self.project.organization_id,
+        )
+        self.author = CommitAuthor.objects.create(
+            organization_id=self.project.organization_id,
+            email="test@example.com",
+            name="Test Author",
+        )
+        self.old_commit = OldCommit.objects.create(
+            organization_id=self.project.organization_id,
+            repository_id=self.repo.id,
+            key="abc123",
+            message="Test commit",
+            author=self.author,
+        )
+        ReleaseCommit.objects.create(
+            organization_id=self.project.organization_id,
+            release=self.release,
+            commit=self.old_commit,
+            order=1,
+        )
+
+    def test_triggers_backfill_when_crossing_dual_write_start_date(self):
+        dual_write_start = timezone.now() - timedelta(hours=1)
+        with self.feature({"organizations:commit-retention-dual-writing": True}):
+            with override_options({"commit.dual-write-start-date": dual_write_start.isoformat()}):
+                old_last_seen = dual_write_start - timedelta(days=1)
+                ReleaseProjectEnvironment.objects.create(
+                    project_id=self.project.id,
+                    release_id=self.release.id,
+                    environment_id=self.environment.id,
+                    first_seen=old_last_seen,
+                    last_seen=old_last_seen,
+                )
+                assert not Commit.objects.filter(id=self.old_commit.id).exists()
+                new_last_seen = timezone.now()
+                with self.tasks():
+                    ReleaseProjectEnvironment.get_or_create(
+                        project=self.project,
+                        release=self.release,
+                        environment=self.environment,
+                        datetime=new_last_seen,
+                    )
+                assert Commit.objects.filter(id=self.old_commit.id).exists()
+                new_commit = Commit.objects.get(id=self.old_commit.id)
+                assert new_commit.key == "abc123"
+                assert new_commit.message == "Test commit"
+
+    def test_no_trigger_when_already_after_dual_write_start(self):
+        dual_write_start = timezone.now() - timedelta(hours=2)
+        with self.feature({"organizations:commit-retention-dual-writing": True}):
+            with override_options({"commit.dual-write-start-date": dual_write_start.isoformat()}):
+                old_last_seen = dual_write_start + timedelta(hours=1)
+                ReleaseProjectEnvironment.objects.create(
+                    project_id=self.project.id,
+                    release_id=self.release.id,
+                    environment_id=self.environment.id,
+                    first_seen=old_last_seen,
+                    last_seen=old_last_seen,
+                )
+                new_last_seen = timezone.now()
+                with self.tasks():
+                    ReleaseProjectEnvironment.get_or_create(
+                        project=self.project,
+                        release=self.release,
+                        environment=self.environment,
+                        datetime=new_last_seen,
+                    )
+                assert not Commit.objects.filter(id=self.old_commit.id).exists()
+
+    def test_no_trigger_when_dual_write_not_configured(self):
+        old_last_seen = timezone.now() - timedelta(days=1)
+        ReleaseProjectEnvironment.objects.create(
+            project_id=self.project.id,
+            release_id=self.release.id,
+            environment_id=self.environment.id,
+            first_seen=old_last_seen,
+            last_seen=old_last_seen,
+        )
+        new_last_seen = timezone.now()
+        with self.tasks():
+            ReleaseProjectEnvironment.get_or_create(
+                project=self.project,
+                release=self.release,
+                environment=self.environment,
+                datetime=new_last_seen,
+            )
+        assert not Commit.objects.filter(id=self.old_commit.id).exists()
+
+    def test_no_trigger_when_last_seen_not_bumped(self):
+        dual_write_start = timezone.now() - timedelta(hours=1)
+        with self.feature({"organizations:commit-retention-dual-writing": True}):
+            with override_options({"commit.dual-write-start-date": dual_write_start.isoformat()}):
+                old_last_seen = dual_write_start - timedelta(days=1)
+                ReleaseProjectEnvironment.objects.create(
+                    project_id=self.project.id,
+                    release_id=self.release.id,
+                    environment_id=self.environment.id,
+                    first_seen=old_last_seen,
+                    last_seen=old_last_seen,
+                )
+                new_last_seen = old_last_seen + timedelta(seconds=30)
+                with self.tasks():
+                    ReleaseProjectEnvironment.get_or_create(
+                        project=self.project,
+                        release=self.release,
+                        environment=self.environment,
+                        datetime=new_last_seen,
+                    )
+                assert not Commit.objects.filter(id=self.old_commit.id).exists()

--- a/tests/sentry/releases/test_commits.py
+++ b/tests/sentry/releases/test_commits.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 from unittest.mock import patch
 
 import pytest
@@ -625,9 +625,23 @@ class GetDualWriteStartDateTest(TestCase):
     def test_get_dual_write_start_date_not_set(self):
         assert get_dual_write_start_date() is None
 
-    def test_get_dual_write_start_date_valid(self):
+    def test_get_dual_write_start_date_valid_naive(self):
+        """Test that naive datetime is converted to UTC"""
         with override_options({"commit.dual-write-start-date": "2024-01-15T10:30:00"}):
-            assert get_dual_write_start_date() == datetime(2024, 1, 15, 10, 30)
+            result = get_dual_write_start_date()
+            assert result is not None
+            assert result.tzinfo is not None
+            assert result == datetime(2024, 1, 15, 10, 30, tzinfo=UTC)
+
+    def test_get_dual_write_start_date_valid_with_timezone(self):
+        """Test that timezone-aware datetime is preserved"""
+        with override_options({"commit.dual-write-start-date": "2024-01-15T10:30:00+05:00"}):
+            result = get_dual_write_start_date()
+            assert result is not None
+            assert result.tzinfo is not None
+            # The datetime should be the same moment in time
+            expected = datetime(2024, 1, 15, 5, 30, tzinfo=UTC)
+            assert result == expected
 
     def test_get_dual_write_start_date_invalid(self):
         with override_options({"commit.dual-write-start-date": "not-a-date"}):
@@ -636,3 +650,14 @@ class GetDualWriteStartDateTest(TestCase):
     def test_get_dual_write_start_date_empty_string(self):
         with override_options({"commit.dual-write-start-date": ""}):
             assert get_dual_write_start_date() is None
+
+    def test_get_dual_write_start_date_comparison_with_django_models(self):
+        """Test that the returned datetime can be compared with Django model datetimes"""
+        with override_options({"commit.dual-write-start-date": "2024-01-15T10:30:00"}):
+            dual_write_start = get_dual_write_start_date()
+            assert dual_write_start is not None
+
+            # Django's timezone.now() returns timezone-aware datetime
+            now = timezone.now()
+            # This comparison should not raise TypeError
+            assert now > dual_write_start


### PR DESCRIPTION
This triggers the commit backfill task whenever we update `last_seen` on `ReleaseProject` and `ReleaseProjectEnvironment`.
