### PR TITLE
ref(ACI): Clean up logging and metrics for dual processing, add to dynamic rules

### DIFF
--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -280,7 +280,6 @@ class SubscriptionProcessor:
                 tags={"detection_type": self.alert_rule.detection_type},
             )
             metrics_incremented = self.handle_logging_metrics_dual_processing(
-                organization=self.subscription.project.organization,
                 trigger=trigger,
                 aggregation_value=aggregation_value,
                 metrics_incremented=metrics_incremented,
@@ -299,7 +298,6 @@ class SubscriptionProcessor:
                 tags={"detection_type": self.alert_rule.detection_type},
             )
             metrics_incremented = self.handle_logging_metrics_dual_processing(
-                organization=self.subscription.project.organization,
                 trigger=trigger,
                 aggregation_value=aggregation_value,
                 metrics_incremented=metrics_incremented,
@@ -340,7 +338,6 @@ class SubscriptionProcessor:
 
     def handle_logging_metrics_dual_processing(
         self,
-        organization: Organization,
         trigger: AlertRuleTrigger,
         aggregation_value: float,
         metrics_incremented: bool,
@@ -401,7 +398,6 @@ class SubscriptionProcessor:
                 tags={"detection_type": self.alert_rule.detection_type},
             )
             metrics_incremented = self.handle_logging_metrics_dual_processing(
-                organization=self.subscription.project.organization,
                 trigger=trigger,
                 aggregation_value=aggregation_value,
                 metrics_incremented=metrics_incremented,
@@ -425,7 +421,6 @@ class SubscriptionProcessor:
                 tags={"detection_type": self.alert_rule.detection_type},
             )
             metrics_incremented = self.handle_logging_metrics_dual_processing(
-                organization=self.subscription.project.organization,
                 trigger=trigger,
                 aggregation_value=aggregation_value,
                 metrics_incremented=metrics_incremented,

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -281,10 +281,10 @@ class SubscriptionProcessor:
                 tags={"detection_type": self.alert_rule.detection_type},
             )
             incremented = self.handle_logging_metrics_dual_processing(
-                trigger_id=trigger.id,
+                trigger=trigger,
                 aggregation_value=aggregation_value,
                 metrics_incremented=metrics_incremented,
-                detector_id=detector.id if detector else None,
+                detector=detector,
                 is_resolved=False,
             )
             incremented = metrics_incremented or incremented
@@ -300,10 +300,10 @@ class SubscriptionProcessor:
                 tags={"detection_type": self.alert_rule.detection_type},
             )
             incremented = self.handle_logging_metrics_dual_processing(
-                trigger_id=trigger.id,
+                trigger=trigger,
                 aggregation_value=aggregation_value,
                 metrics_incremented=metrics_incremented,
-                detector_id=detector.id if detector else None,
+                detector=detector,
                 is_resolved=True,
             )
             incremented = metrics_incremented or incremented
@@ -340,10 +340,10 @@ class SubscriptionProcessor:
 
     def handle_logging_metrics_dual_processing(
         self,
-        trigger_id: int,
+        trigger: AlertRuleTrigger,
         aggregation_value: float,
         metrics_incremented: bool,
-        detector_id: int | None,
+        detector: Detector | None,
         is_resolved: bool = False,
     ) -> bool:
         if features.has(
@@ -356,16 +356,16 @@ class SubscriptionProcessor:
                 ).exists()
                 and not metrics_incremented
             ):
-                if detector_id is not None:
+                if detector is not None:
                     logger.info(
                         "subscription_processor.alert_triggered",
                         extra={
                             "rule_id": self.alert_rule.id,
-                            "detector_id": detector_id,
+                            "detector_id": detector.id,
                             "organization_id": self.subscription.project.organization.id,
                             "project_id": self.subscription.project.id,
                             "aggregation_value": aggregation_value,
-                            "trigger_id": trigger_id,
+                            "trigger_id": trigger.id,
                         },
                     )
                 if is_resolved:
@@ -401,10 +401,10 @@ class SubscriptionProcessor:
                 tags={"detection_type": self.alert_rule.detection_type},
             )
             incremented = self.handle_logging_metrics_dual_processing(
-                trigger_id=trigger.id,
+                trigger=trigger,
                 aggregation_value=aggregation_value,
                 metrics_incremented=metrics_incremented,
-                detector_id=detector.id if detector else None,
+                detector=detector,
                 is_resolved=False,
             )
             incremented = metrics_incremented or incremented
@@ -425,10 +425,10 @@ class SubscriptionProcessor:
                 tags={"detection_type": self.alert_rule.detection_type},
             )
             incremented = self.handle_logging_metrics_dual_processing(
-                trigger_id=trigger.id,
+                trigger=trigger,
                 aggregation_value=aggregation_value,
                 metrics_incremented=metrics_incremented,
-                detector_id=detector.id if detector else None,
+                detector=detector,
                 is_resolved=True,
             )
             incremented = metrics_incremented or incremented

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -281,10 +281,10 @@ class SubscriptionProcessor:
                 tags={"detection_type": self.alert_rule.detection_type},
             )
             incremented = self.handle_logging_metrics_dual_processing(
-                trigger=trigger,
+                trigger_id=trigger.id,
                 aggregation_value=aggregation_value,
                 metrics_incremented=metrics_incremented,
-                detector=detector,
+                detector_id=detector.id if detector else None,
                 is_resolved=False,
             )
             incremented = metrics_incremented or incremented
@@ -300,10 +300,10 @@ class SubscriptionProcessor:
                 tags={"detection_type": self.alert_rule.detection_type},
             )
             incremented = self.handle_logging_metrics_dual_processing(
-                trigger=trigger,
+                trigger_id=trigger.id,
                 aggregation_value=aggregation_value,
                 metrics_incremented=metrics_incremented,
-                detector=detector,
+                detector_id=detector.id if detector else None,
                 is_resolved=True,
             )
             incremented = metrics_incremented or incremented
@@ -340,10 +340,10 @@ class SubscriptionProcessor:
 
     def handle_logging_metrics_dual_processing(
         self,
-        trigger: AlertRuleTrigger,
+        trigger_id: int,
         aggregation_value: float,
         metrics_incremented: bool,
-        detector: Detector | None,
+        detector_id: int | None,
         is_resolved: bool = False,
     ) -> bool:
         if features.has(
@@ -356,16 +356,16 @@ class SubscriptionProcessor:
                 ).exists()
                 and not metrics_incremented
             ):
-                if detector is not None:
+                if detector_id is not None:
                     logger.info(
                         "subscription_processor.alert_triggered",
                         extra={
                             "rule_id": self.alert_rule.id,
-                            "detector_id": detector.id,
+                            "detector_id": detector_id,
                             "organization_id": self.subscription.project.organization.id,
                             "project_id": self.subscription.project.id,
                             "aggregation_value": aggregation_value,
-                            "trigger_id": trigger.id,
+                            "trigger_id": trigger_id,
                         },
                     )
                 if is_resolved:
@@ -401,10 +401,10 @@ class SubscriptionProcessor:
                 tags={"detection_type": self.alert_rule.detection_type},
             )
             incremented = self.handle_logging_metrics_dual_processing(
-                trigger=trigger,
+                trigger_id=trigger.id,
                 aggregation_value=aggregation_value,
                 metrics_incremented=metrics_incremented,
-                detector=detector,
+                detector_id=detector.id if detector else None,
                 is_resolved=False,
             )
             incremented = metrics_incremented or incremented
@@ -425,10 +425,10 @@ class SubscriptionProcessor:
                 tags={"detection_type": self.alert_rule.detection_type},
             )
             incremented = self.handle_logging_metrics_dual_processing(
-                trigger=trigger,
+                trigger_id=trigger.id,
                 aggregation_value=aggregation_value,
                 metrics_incremented=metrics_incremented,
-                detector=detector,
+                detector_id=detector.id if detector else None,
                 is_resolved=True,
             )
             incremented = metrics_incremented or incremented

--- a/tests/sentry/incidents/subscription_processor/test_subscription_processor_workflow_engine.py
+++ b/tests/sentry/incidents/subscription_processor/test_subscription_processor_workflow_engine.py
@@ -38,6 +38,7 @@ from sentry.seer.anomaly_detection.utils import translate_direction
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.helpers.features import with_feature
 from sentry.utils import json
+from sentry.workflow_engine.models import Detector
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.types import DetectorPriorityLevel
 from tests.sentry.incidents.subscription_processor.test_subscription_processor import (
@@ -588,4 +589,67 @@ class ProcessUpdateAnomalyDetectionWorkflowEngineTest(ProcessUpdateAnomalyDetect
                     "notification_uuid": mock.ANY,
                 },
             ],
+        )
+
+    @with_feature("organizations:incidents")
+    @with_feature("organizations:anomaly-detection-alerts")
+    @with_feature("organizations:workflow-engine-metric-alert-processing")
+    @with_feature("organizations:workflow-engine-metric-alert-dual-processing-logs")
+    @patch(
+        "sentry.seer.anomaly_detection.get_anomaly_data.SEER_ANOMALY_DETECTION_CONNECTION_POOL.urlopen"
+    )
+    @patch("sentry.incidents.subscription_processor.metrics")
+    @patch("sentry.incidents.subscription_processor.logger")
+    def test_anomaly_detection_metrics_logging(
+        self, mock_logger: MagicMock, mock_metrics: MagicMock, mock_seer_request: MagicMock
+    ) -> None:
+        rule = self.dynamic_rule
+        trigger = self.trigger
+        warning_trigger = create_alert_rule_trigger(rule, WARNING_TRIGGER_LABEL, 0)
+        create_alert_rule_trigger_action(
+            warning_trigger,
+            AlertRuleTriggerAction.Type.EMAIL,
+            AlertRuleTriggerAction.TargetType.USER,
+            str(self.user.id),
+        )
+        self.create_workflow_engine_models(rule)
+        detector = Detector.objects.get(name="hojicha")
+        value = 10
+
+        seer_return_value = self.get_seer_return_value(
+            anomaly_score=0.9, value=value, anomaly_type=AnomalyType.HIGH_CONFIDENCE
+        )
+        mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
+        self.send_update(rule, value, timedelta(minutes=-2))
+
+        # assert that we only create a metric for `dual_processing.alert_rules.fire` once despite having 2 triggers
+        mock_metrics.incr.assert_has_calls(
+            [
+                call(
+                    "incidents.alert_rules.threshold.alert",
+                    tags={"detection_type": "dynamic"},
+                ),
+                call(
+                    "dual_processing.alert_rules.fire",
+                ),
+                call("incidents.alert_rules.trigger", tags={"type": "fire"}),
+                call(
+                    "incidents.alert_rules.threshold.alert",
+                    tags={"detection_type": "dynamic"},
+                ),
+                call("incidents.alert_rules.trigger", tags={"type": "fire"}),
+            ],
+        )
+        assert mock_logger.info.call_count == 4
+        other_extra = {
+            "rule_id": rule.id,
+            "detector_id": detector.id,
+            "organization_id": rule.organization_id,
+            "project_id": self.project.id,
+            "aggregation_value": value,
+            "trigger_id": trigger.id,
+        }
+        mock_logger.info.assert_any_call(
+            "subscription_processor.alert_triggered",
+            extra=other_extra,
         )


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/99059 to refactor the code to add logging and metrics for dual processing tracking by pulling it into it's own method `handle_logging_metrics_dual_processing` and apply the same treatment to anomaly detection rules. This PR also cleans up the tests and adds more test coverage for anomaly detection rules to ensure we are logging and incrementing metrics as we expect in all scenarios.